### PR TITLE
fix(remote-workspace): host silence must not delete a local row it was never told about

### DIFF
--- a/src/renderer/src/hooks/remote-workspace-session-merge-closed-terminal-tombstone.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-session-merge-closed-terminal-tombstone.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { mergeDirectSshRemoteWorkspaceSession } from './remote-workspace-session-merge'
+import { getDefaultWorkspaceSession } from '../../../shared/constants'
+import { buildWorkspaceSessionPayload } from '@/lib/workspace-session'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { ensureWorktreeHasInitialTerminal } from '@/lib/worktree-initial-terminal-seeding'
+import {
+  makeCreatedAgentWorktree as makeWorktree,
+  seedEmptyActivatableWorktree
+} from '@/lib/worktree-activation-created-agent-test-state'
+import { useAppStore } from '@/store'
+
+/**
+ * The closed-last-terminal tombstone across a direct-SSH reconnect, end to end.
+ *
+ * The unit-level rule lives in remote-workspace-session-merge-local-survival.test.ts; this asserts
+ * what that rule is FOR. `Object.hasOwn(tabsByWorktree, worktreeId)` has to keep meaning one thing
+ * — the merge dropping the key turned "the user closed the last terminal" into "never
+ * initialized", and the seeding pass then handed the terminal back on every reconnect.
+ */
+const initialAppStoreState = useAppStore.getState()
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+/** The state a workspace lands in once its last terminal is closed: an explicit empty row. */
+function seedClosedLastTerminal(worktreeId: string): void {
+  useAppStore.setState({ tabsByWorktree: { [worktreeId]: [] } })
+  expect(useAppStore.getState().reconcileWorktreeTabModel(worktreeId).renderableTabCount).toBe(0)
+}
+
+/** The real merge against a host that has no row for this worktree, hydrated the way
+ *  remote-workspace-snapshot-apply does it. */
+function applyHostSnapshotOmitting(worktreeId: string): void {
+  const state = useAppStore.getState()
+  const merged = mergeDirectSshRemoteWorkspaceSession(
+    buildWorkspaceSessionPayload(state),
+    getDefaultWorkspaceSession(),
+    new Set([worktreeId]),
+    state.tabsByWorktree,
+    new Set()
+  )
+  const replaceWorkspaceKeys = [worktreeId]
+  useAppStore.getState().hydrateWorkspaceSession(merged, { replaceWorkspaceKeys })
+  useAppStore.getState().hydrateTabsSession(merged, { replaceWorkspaceKeys })
+}
+
+describe('a closed-last-terminal row that a direct-SSH snapshot says nothing about', () => {
+  it('survives the reconnect, so startup hydration adds no terminal', () => {
+    const worktree = makeWorktree()
+    seedEmptyActivatableWorktree(worktree)
+    seedClosedLastTerminal(worktree.id)
+
+    applyHostSnapshotOmitting(worktree.id)
+
+    expect(Object.hasOwn(useAppStore.getState().tabsByWorktree, worktree.id)).toBe(true)
+    expect(useAppStore.getState().tabsByWorktree[worktree.id]).toEqual([])
+    expect(ensureWorktreeHasInitialTerminal(useAppStore.getState(), worktree.id)).toBeNull()
+    expect(useAppStore.getState().tabsByWorktree[worktree.id]).toEqual([])
+  })
+
+  it('still re-seeds when the user explicitly opens the workspace', () => {
+    // The mirror risk of preserving the row rather than dropping it: the tombstone must suppress
+    // seeding on startup hydration ONLY. An explicit activation opts into reseedEmptiedWorkspace,
+    // and a preserved row that swallowed it would trade a duplicate terminal for a dead workspace.
+    // Passes before the merge fix too — it is the guard on it, not evidence of it.
+    const worktree = makeWorktree()
+    seedEmptyActivatableWorktree(worktree)
+    seedClosedLastTerminal(worktree.id)
+
+    applyHostSnapshotOmitting(worktree.id)
+    const result = activateAndRevealWorktree(worktree.id, { notifyHostRuntime: false })
+
+    expect(result).not.toBe(false)
+    expect(useAppStore.getState().tabsByWorktree[worktree.id]).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/hooks/remote-workspace-session-merge-local-survival.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-session-merge-local-survival.test.ts
@@ -338,3 +338,45 @@ describe('a tab id local state already holds under two worktrees', () => {
     expect(merged.tabsByWorktree[OTHER_WORKTREE]?.map((tab) => tab.id)).toEqual(['build'])
   })
 })
+
+describe('local rows the snapshot carries no answer for', () => {
+  it('keeps the explicit empty row that records a closed last terminal', () => {
+    // initial-terminal.ts: a missing row means never initialized, an explicit empty row means the
+    // user closed the last terminal. Dropping the key downgrades the second into the first, so the
+    // seeding pass re-creates the terminal the user just closed on every reconnect.
+    const current = sessionState({ tabsByWorktree: { [WORKTREE]: [] } })
+    const remote = sessionState({ activeWorktreeId: null, tabsByWorktree: {} })
+
+    const merged = merge(current, remote, { [WORKTREE]: [] })
+
+    expect(Object.hasOwn(merged.tabsByWorktree, WORKTREE), 'tombstone erased').toBe(true)
+    expect(merged.tabsByWorktree[WORKTREE]).toEqual([])
+  })
+
+  it('invents no row for a worktree neither side has one for', () => {
+    // The counterweight: presence has to come from a real local row, not from membership in the
+    // replace set, or a never-initialized workspace gets a tombstone it never earned.
+    const current = sessionState({ tabsByWorktree: {} })
+    const remote = sessionState({ activeWorktreeId: null, tabsByWorktree: {} })
+
+    const merged = merge(current, remote, {})
+
+    expect(Object.hasOwn(merged.tabsByWorktree, WORKTREE)).toBe(false)
+  })
+
+  it('keeps the default-terminal-tabs marker the snapshot does not carry', () => {
+    // The marker is write-once and is the only guard on applyDefaultTerminalTabs. A snapshot that
+    // omits it is a host that was never told, not a host reporting the tabs were never applied —
+    // and taking it literally re-applies the whole template on top of the user's tabs.
+    const agent = terminalTab('agent')
+    const current = sessionState({
+      tabsByWorktree: { [WORKTREE]: [agent] },
+      defaultTerminalTabsAppliedByWorktreeId: { [WORKTREE]: true }
+    })
+    const remote = sessionState({ tabsByWorktree: { [WORKTREE]: [agent] } })
+
+    const merged = merge(current, remote, { [WORKTREE]: [agent] })
+
+    expect(merged.defaultTerminalTabsAppliedByWorktreeId?.[WORKTREE]).toBe(true)
+  })
+})

--- a/src/renderer/src/hooks/remote-workspace-session-merge.ts
+++ b/src/renderer/src/hooks/remote-workspace-session-merge.ts
@@ -36,12 +36,19 @@ export function mergeDirectSshRemoteWorkspaceSession(
   const locallyPreservedTabIds = new Set<string>()
   const localTabsFor = (worktreeId: string): TerminalTab[] =>
     liveTabsByWorktree[worktreeId] ?? current.tabsByWorktree[worktreeId] ?? []
+  // Why presence and not length: an explicit empty row is the record that the user closed the last
+  // terminal (initial-terminal.ts), and localTabsFor cannot tell it from an absent one. Admitting
+  // only non-empty rows dropped the key, which reads downstream as "never initialized" and seeds a
+  // fresh terminal on every reconnect.
+  const hasLocalTabsRow = (worktreeId: string): boolean =>
+    Object.hasOwn(liveTabsByWorktree, worktreeId) ||
+    Object.hasOwn(current.tabsByWorktree, worktreeId)
   // Why the union and not just the remote keys: a host snapshot that has never been told about this
   // worktree carries no entry for it at all, and iterating only its keys would drop every local tab
   // through the omit below.
   const mergedWorktreeIds = new Set([
     ...Object.keys(remote.tabsByWorktree),
-    ...[...replaceWorktreeIds].filter((worktreeId) => localTabsFor(worktreeId).length > 0)
+    ...[...replaceWorktreeIds].filter(hasLocalTabsRow)
   ])
   // The active worktree is walked FIRST so that when one tab id is held locally under two of them,
   // the copy that survives below is the one the user is looking at. That matches what
@@ -255,7 +262,11 @@ export function mergeDirectSshRemoteWorkspaceSession(
       ...remote.lastVisitedAtByWorktreeId
     },
     defaultTerminalTabsAppliedByWorktreeId: {
-      ...omitTargetWorktrees(current.defaultTerminalTabsAppliedByWorktreeId),
+      // Why no omit here: the marker is write-once and is the only guard on applyDefaultTerminalTabs,
+      // so a snapshot that omits it is a host that was never told rather than one reporting the tabs
+      // were never applied — omitting the local entry re-applies the whole template over the user's
+      // tabs. Removal is the worktree-teardown path's job, not a reconnect's.
+      ...current.defaultTerminalTabsAppliedByWorktreeId,
       ...remote.defaultTerminalTabsAppliedByWorktreeId
     }
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​122 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​122 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

**Stack: 3 of 6 — based on #16747.**

## ELI5

When you reconnect to an SSH machine, Orca merges what the remote machine remembers with what your laptop remembers.

The rule is *"the remote is the boss for things it knows about."* The bug is that Orca also treated **silence** as an instruction. If the remote said nothing about a workspace, Orca deleted your local record of it.

Two records were being lost that way:
- **"you closed your last terminal here"** — an empty list, which *means something*. Lose it and Orca thinks you never had terminals and opens a fresh one.
- **"default tabs already applied here"** — lose it and the template gets laid down again.

**The fix:** silence is not a delete. Keep a record the remote simply hasn't heard about yet.

**Safety:** this only ever *keeps* things. It cannot cause a tab to disappear.

---

Two fields in `mergeDirectSshRemoteWorkspaceSession` treated an absent remote entry as an authoritative delete. Both are records whose **absence is itself meaningful**, so deleting them on silence destroys information the host never had.

## Symptom 1 — the user closes their last terminal on an SSH workspace, and it comes back on reconnect

`src/renderer/src/components/terminal/initial-terminal.ts:5` states the contract verbatim:

> "a missing row means never initialized; an explicit empty row records that the user closed the last terminal."

`mergeDirectSshRemoteWorkspaceSession` violated it. `mergedWorktreeIds` was

```
keys(remote.tabsByWorktree) ∪ { replaced worktrees whose local tab list is NON-EMPTY }
```

(`src/renderer/src/hooks/remote-workspace-session-merge.ts:41-45`), so a worktree holding an explicit `[]` and absent from the host snapshot was excluded. `omitTargetWorktrees(current.tabsByWorktree)` then stripped the key and nothing re-added it. Proven by direct execution of the real function:

```
Object.hasOwn(merged.tabsByWorktree, WORKTREE) → false
```

Downstream, `worktree-initial-terminal-seeding.ts:125` computes

```
shouldHonourClosedTerminalTombstone = Object.hasOwn(store.tabsByWorktree, worktreeId) && …   → false
shouldAutoCreateInitialTerminal(0, false)   (initial-terminal.ts:6)                          → true
```

…and a terminal is created.

**The projection is innocent.** `remote-workspace-session-projection.ts:47-59` and `:161-168` both round-trip an empty array faithfully. The row is lost only when the host snapshot has no entry for that worktree path *at all* — a first sync, a snapshot predating the close, or `resolveWorktreeId(path)` returning null during startup.

## Symptom 2 — a reconnect re-applies the default-tab template over the user's tabs

`:257-260` deleted the local `defaultTerminalTabsAppliedByWorktreeId` entry for every replaced worktree and trusted the remote snapshot to carry it. This was **the only field in that function with no preservation branch.** The marker is write-once and is the sole guard on `applyDefaultTerminalTabs` (`worktree-default-terminal-tabs.ts:34`).

Combined with PR #16747 of this stack: the marker's wire counterpart was *also* being stripped on every read, so the remote snapshot could never carry it back. Either half alone leaves the marker lossy — this is the client-side half.

## The fix, and why this shape

1. `hasLocalTabsRow(worktreeId)` admits a replaced worktree whose local row **EXISTS** (`Object.hasOwn`) rather than whose local row is non-empty. `localTabsFor` cannot tell an explicit `[]` from an absent one, which is exactly the distinction that matters.
2. `defaultTerminalTabsAppliedByWorktreeId` drops the `omitTargetWorktrees(…)` wrapper. Removal is the worktree-teardown path's job, not a reconnect's.

Both are the same rule the rest of that function already applies to tabs: **the host is authoritative for what it knows, not for what it has never been told.** Both are statements about what absence *means*, local to one function, so they survive the SSH-v3 consolidation unchanged. Neither adds a per-tab identity or generation field — the redesign's Phase 3 deletes the eleven the codebase already carries (784 refs).

## Evidence

Before (production hunks reverted to `main`, tests present):

```
 FAIL  remote-workspace-session-merge-closed-terminal-tombstone.test.ts
       > a closed-last-terminal row that a direct-SSH snapshot says nothing about
       > survives the reconnect, so startup hydration adds no terminal
 FAIL  remote-workspace-session-merge-local-survival.test.ts
       > keeps the explicit empty row that records a closed last terminal
 FAIL  remote-workspace-session-merge-local-survival.test.ts
       > keeps the default-terminal-tabs marker the snapshot does not carry

 Test Files  2 failed (2)
      Tests  3 failed | 18 passed (21)
```

After:

```
 Test Files  2 passed (2)          # the two merge suites
      Tests  21 passed (21)

 Test Files  7 passed (7)          # + worktree-default-terminal-tabs, initial-terminal, remote-workspace
      Tests  45 passed (45)

$ pnpm tc → clean
$ pnpm run check:code-quality:changed → 0 new findings across 13 changed files
```

The closed-terminal-tombstone suite also covers the mirror risk directly: preserving the row must not resurrect tabs, and a never-initialized workspace must not acquire a tombstone it never earned.

## Deliberately NOT done

- **The `hostUnknown` preserve branch is untouched.** It already never deletes a local tab the host has not heard of, deliberately, to avoid killing live panes.
- **No close-suppression here.** A keep-biased merge with no way to say "the user closed this" is precisely the SSH-v3 failure mode — *"The merge now keeps a local tab the host has never been told about"* — and unbounded growth on a daily reconnect cycle is the reported bug one level up. That is the durable close tombstone, and it belongs on top of this (PR 6) rather than mixed into it. This PR is strictly the "absence is not a delete" half.
- **No revision counter here.** Ack-based retirement needs the tombstone map to exist first; adding a revision to these two fields alone would be over-engineering with nothing to retire.

## Relationship to open PR #16571

#16571 implements tombstones **keyed by tab id** in this same function. It structurally cannot cover the case here: a worktree holding an explicit `[]` has no tab ids left to tombstone, and the *key itself* goes missing. Complementary in behaviour, **conflicting in text** — its unchanged context includes the exact `defaultTerminalTabsAppliedByWorktreeId` lines this rewrites. Whoever lands second resolves.

#15912 is the only other open PR touching `worktree-initial-terminal-seeding.ts`; it changes the downstream consumer of the signal this repairs. The two must agree on what "empty worktree" means.

## One deliberate consequence, previously unmentioned

Preserving the write-once marker means a worktree **deleted and recreated on the host at the same
path** keeps its marker and never re-applies its default-tab template. That is narrow and
deliberate: the marker is keyed by worktree, removal belongs to the worktree-teardown path, and the
alternative — letting a reconnect clear it — is the bug this fixes. Naming it so a reviewer does not
have to find it.

## Risk / blast radius

Renderer-side, one function, no wire change. The change is strictly *preserving* — it can only add keys to the merged result, never remove them. The failure mode of getting it wrong is a stale local row surviving a reconnect; the failure mode of `main` is a tab the user closed coming back and a template re-applied over their tabs.

## How to verify

```
pnpm test src/renderer/src/hooks/remote-workspace-session-merge
```

To see it fail: `git checkout main -- src/renderer/src/hooks/remote-workspace-session-merge.ts` and re-run.

---

# End-to-end verification

## Specs this PR routes to

```
$ git diff --name-only nwparker/ssh-02-normalizer-field..nwparker/ssh-03-merge-preserves-local \
    | node config/scripts/pr-e2e-source-routing.mjs
["tests/e2e/ssh-cold-activation-restore.spec.ts",
 "tests/e2e/ssh-reconnect-tab-destruction.spec.ts"]

$ … | node config/scripts/pr-e2e-source-routing.mjs --ssh-source
true
```

**Under `main`'s router these three files route to `[]`.** `remote-workspace-session-merge.ts` is the single most load-bearing file in the direct-SSH restore path and it reached no e2e spec — the gap #16746 closes. `ssh-reconnect-tab-destruction.spec.ts`, the spec guarding this exact regression class, previously ran only if you edited that spec file.

## Lane result

Covered by the full Docker-SSH lane at the stack tip (below). The routed subset for this level can also be run directly:

```
pnpm test:e2e:ssh-docker -- tests/e2e/ssh-cold-activation-restore.spec.ts \
                            tests/e2e/ssh-reconnect-tab-destruction.spec.ts
```

```
$ pnpm test:e2e:ssh-docker
BUILD_SHA=49bb96e0b4c135ce305a2f4dfe2d4b52e0b19cde   DIRTY=0
14 specs / 20 tests → 17 passed, 2 failed, 1 skipped (10.7m)
```

**The two lane failures, resolved — and one is now exempted:**

| Spec | `main` | tip (isolated) | tip (full lane) | Outcome |
|---|---|---|---|---|
| `ssh-docker-bulk-open-freeze-repro` | FAILED — harness `TypeError: … reading 'workerIndex'` at `docker-ssh-relay-target.ts:226` | — | FAILED | **Not a flake — a 100% failure**, and three further arity bugs behind it. Now **exempted** from the lane; repair tracked in stablyai/orca#16764 |
| `ssh-port-forward-lifecycle` | PASSED | **PASSED** (59.6s) | FAILED at `ssh-port-forward-lifecycle-evidence.ts:159` waiting on `getByText('Ports')` | **Flaky in-lane**, not a regression |

Port-forward was re-run at the same commit and build and passed in 59.6s. It is green on `main`, green at the tip in isolation, and red only inside the full lane — it is the set's one `@headful` spec and runs last. **Called flaky in-lane rather than "unrelated": a real lane-ordering problem, pre-existing, and worth tracking.**

> **Note on the recorded run:** the 14-spec result above predates the bulk-open exemption. The lane now runs **13** specs; bulk-open is not among them. The other 13 results are unaffected — nothing about that spec's failure changes another's outcome, since the runner passes them all to one Playwright invocation with `--workers=1` and each spec owns its own fixture container.

## Build provenance

`hasLocalTabsRow` is a new identifier — **0 occurrences in `main`'s source**, so any nonzero count proves the bundle carries this change. It survives the renderer build unmangled:

```
$ cat out/renderer/assets/*.js | grep -c hasLocalTabsRow
2
```

Measured on the lane build:

```
BUILD_SHA=49bb96e0b4c135ce305a2f4dfe2d4b52e0b19cde   DIRTY=0
tombstone=13   hasLocalTabsRow=2   hostAuthority=4   mayCreate=3
```

`hasLocalTabsRow=2` is this level's symbol; the other three prove the rest of the stack is in the same build.

> **Provenance trap, reproduced on this tree.** Do not grep a single renderer chunk. `grep -c <sym> out/renderer/assets/store-*.js | head -1` matched `store-DtDSfs7_.js` and reported **0** for a symbol present **13** times across `store-uJWnDUOY.js`, `App-CZkf3Bu7.js` and `quick-commands-menu-events-SBDd6cXN.js`. Always use `cat out/renderer/assets/*.js | grep -c <sym>`.
>
> Also: renderer `console.warn` never reaches the app log. Only main-process stdio is forwarded by `ORCA_E2E_FORWARD_APP_LOGS=1`.

## What is NOT covered

- **Neither routed spec drives the exact failing scenario.** The tombstone is lost only when the host snapshot has no entry for that worktree path *at all* — a first sync, a snapshot predating the close, or `resolveWorktreeId(path)` returning null during startup. The routed specs do not construct that state; the direct proof is the two unit suites, which are genuine failing-first tests. The e2e run demonstrates no regression, not positive coverage of the failing path.
- **This does not fix the daily tab growth.** It is bounded: one tab, and only for a user who closed their last terminal, or a re-applied default-tab template. The accumulation fix is #16752.
- **No close-suppression here.** A keep-biased merge with no way to say "the user closed this" is the SSH-v3 failure mode in the other direction. That is #16752 and it stacks on top of this deliberately.
- **No revision counter here.** Ack-based retirement needs the tombstone map to exist first.
- **Known text conflict with open PR #16571**, which rewrites the same `defaultTerminalTabsAppliedByWorktreeId` lines. Complementary in behaviour, conflicting in text; whoever lands second resolves.

## Failing-first test

Yes.

```
 FAIL  …-closed-terminal-tombstone.test.ts > survives the reconnect, so startup hydration adds no terminal
 FAIL  …-local-survival.test.ts > keeps the explicit empty row that records a closed last terminal
 FAIL  …-local-survival.test.ts > keeps the default-terminal-tabs marker the snapshot does not carry
      Tests  3 failed | 18 passed (21)
```

with the production hunks reverted to `main`; 21 passed restored. The suites also cover the mirror risk directly: preserving the row must not resurrect tabs, and a never-initialized workspace must not acquire a tombstone it never earned.

