### PR TITLE
fix(ssh): a reattach may bind a pane but never create one

### DIFF
--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
@@ -1,14 +1,92 @@
+import { toSshExecutionHostId } from '../../../shared/execution-host'
 import type { PersistedState } from '../../../shared/persisted-state-types'
 import type { SshRemotePtyLease } from '../../../shared/ssh-types'
 import { isTerminalLeafId } from '../../../shared/stable-pane-id'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
 
 export type SshPtyLeaseOperations = {
   state: PersistedState
   toStoredPtyId: (targetId: string, ptyId: string) => string
+  toComparablePtyId: (targetId: string, ptyId: string) => string
   clearBindingsForTarget: (targetId: string) => void
   clearBindingsForLeases: (targetId: string, leases: SshRemotePtyLease[]) => boolean
   flush: () => void
   flushDurableStateOrThrowAsync: () => Promise<void>
+}
+
+/**
+ * The PTY a pane is durably bound to, keyed on the leaf alone — the only remint-stable half of a
+ * pane key, since `detachTerminalPaneToTab` moves a live pane and leaves its lease naming the tab
+ * it left.
+ *
+ * Reads both partitions deliberately. Main writes some SSH pane bindings to `ssh:<target>` and
+ * some to `local`, so a reader that consulted one would see "unbound" for a live pane and expire
+ * its lease. Reading both makes this fence correct whichever partition the binding landed in.
+ */
+function durablyBoundPtyIdForPane(
+  operations: SshPtyLeaseOperations,
+  targetId: string,
+  leafId: string
+): string | undefined {
+  const findLeafBinding = (session: WorkspaceSessionState | undefined): string | undefined =>
+    Object.values(session?.terminalLayoutsByTabId ?? {}).find(
+      (layout) => layout?.ptyIdsByLeafId?.[leafId]
+    )?.ptyIdsByLeafId?.[leafId]
+  const boundPtyId =
+    findLeafBinding(operations.state.workspaceSession) ??
+    findLeafBinding(operations.state.workspaceSessionsByHostId?.[toSshExecutionHostId(targetId)])
+  return boundPtyId ? operations.toComparablePtyId(targetId, boundPtyId) : undefined
+}
+
+/**
+ * One pane owns at most one live remote PTY. Lease identity is `(targetId, ptyId)` alone, so a
+ * pane re-leasing under a new relay id leaves its predecessor live with nothing to retire it and
+ * the next reattach fans out over both — the reported 2 -> 19 -> 20 across three reconnects.
+ *
+ * Superseded leases are marked `expired`, never `terminated`: losing a lease is not evidence the
+ * shell died, so the remote process is deliberately left running.
+ */
+function supersedeSiblingLeasesForPane(
+  operations: SshPtyLeaseOperations,
+  winner: SshRemotePtyLease,
+  now: number
+): void {
+  if (!winner.worktreeId || !winner.leafId) {
+    return
+  }
+  if (winner.state === 'terminated' || winner.state === 'expired') {
+    return
+  }
+  // At upsert time the arriving lease may not be the one the pane is bound to yet. Expiring the
+  // bound predecessor would detach a live pane, so leave both live and let reattach arbitrate
+  // with the binding in hand.
+  const boundPtyId = durablyBoundPtyIdForPane(operations, winner.targetId, winner.leafId)
+  if (boundPtyId && boundPtyId !== winner.ptyId) {
+    return
+  }
+  const superseded: SshRemotePtyLease[] = []
+  for (const lease of operations.state.sshRemotePtyLeases ?? []) {
+    if (
+      lease.ptyId === winner.ptyId ||
+      lease.targetId !== winner.targetId ||
+      lease.worktreeId !== winner.worktreeId ||
+      // Leaf only: a lease freezes its tabId, so a pane broken out into a new tab would otherwise
+      // never compete with its own predecessor — which is the reported cardinality growth.
+      lease.leafId !== winner.leafId ||
+      lease.state === 'terminated' ||
+      lease.state === 'expired'
+    ) {
+      continue
+    }
+    lease.state = 'expired'
+    lease.updatedAt = now
+    superseded.push(lease)
+  }
+  if (superseded.length > 0) {
+    // Why: matching on lease ptyId first means this scrubs only the predecessor's stale binding —
+    // the winner's own binding cannot match and is left intact.
+    operations.clearBindingsForLeases(winner.targetId, superseded)
+  }
 }
 
 export function getSshRemotePtyLeases(
@@ -37,6 +115,11 @@ export function upsertSshRemotePtyLease(
   )
   const existing =
     existingIndex !== -1 ? operations.state.sshRemotePtyLeases[existingIndex] : undefined
+  // NOTE: a relay numbers its PTYs from `pty-1` on every start, so after a relay restart this
+  // match can be an id RECYCLED onto a different shell rather than the same lease. When the
+  // caller names its own pane the merge below overwrites the stale identity; when it omits those
+  // fields (both spawn callers do, conditionally) the stale pane survives. Distinguishing the two
+  // needs a relay-start identity the lease does not carry — see STA-3077 notes before adding one.
   // Why: callers pass optional fields as explicit `undefined`, which would blank the stored tabId/leafId
   // (and friends) when re-upserting an existing lease.
   const definedLease = Object.fromEntries(
@@ -53,6 +136,7 @@ export function upsertSshRemotePtyLease(
   } else {
     operations.state.sshRemotePtyLeases.push(next)
   }
+  supersedeSiblingLeasesForPane(operations, next, now)
   operations.flush()
 }
 

--- a/src/main/persistence/loading-store/pty-binding-persistence.ts
+++ b/src/main/persistence/loading-store/pty-binding-persistence.ts
@@ -46,6 +46,13 @@ export class PtyBindingPersistenceOperations {
       expectedSourceBinding?: PtyBindingSourceExpectation
       /** Set by host-initiated creates, which have no renderer session writer behind them. */
       hostAdmittedMembership?: boolean
+      /**
+       * Defaults true, which is what `pty:spawn` needs — it can beat the debounced layout writer
+       * and must be able to mint the surface it is binding. A reattach is the opposite: the pane
+       * either still exists or the user closed it, so creating one grafts back a tab they closed.
+       * Callers pass false only once absence is meaningful; see the relay's reattach bind.
+       */
+      mayCreate?: boolean
     },
     hostId?: string | null
   ): boolean {
@@ -84,6 +91,24 @@ export class PtyBindingPersistenceOperations {
         boundPtyId !== args.expectedBinding.ptyId ||
         session.terminalPtyIncarnationsByPaneKey?.[paneKey] !== args.expectedBinding.incarnationId
       ) {
+        return false
+      }
+    }
+    // Decided before any mutation so a refusal leaves nothing half-written. Mirrors the four
+    // creating branches below — mint a tab, mint a root leaf, split the root and graft a leaf,
+    // mint a layout — each of which sets `terminalMembershipChanged`.
+    if (args.mayCreate === false) {
+      const existingTab = session.tabsByWorktree?.[bindingWorktreeId]?.find(
+        (candidate) => candidate.id === args.tabId
+      )
+      const existingLayout = session.terminalLayoutsByTabId?.[args.tabId]
+      const wouldCreateTopology =
+        !existingTab ||
+        (isTerminalLeafId(args.leafId) &&
+          (!existingLayout ||
+            !existingLayout.root ||
+            !layoutContainsLeafId(existingLayout.root, args.leafId)))
+      if (wouldCreateTopology) {
         return false
       }
     }

--- a/src/main/persistence/loading-store/ssh-lease-recovery-operations.ts
+++ b/src/main/persistence/loading-store/ssh-lease-recovery-operations.ts
@@ -155,6 +155,11 @@ export function getSshPtyLeaseOperations(owner: SshLeaseRecoveryOperations): Ssh
         targetId,
         ptyId
       ),
+    toComparablePtyId: (targetId, ptyId) =>
+      owner[sshLeaseRecoveryOperationsContext].bindingRecovery.getRelayPtyIdForSshLeaseComparison(
+        targetId,
+        ptyId
+      ),
     clearBindingsForTarget: (targetId) =>
       clearSshRemotePtyBindingsForTargetOperation(
         getSshPtyBindingCleanupOperations(owner),

--- a/src/main/runtime/workspace-session-terminal-membership-authority.ts
+++ b/src/main/runtime/workspace-session-terminal-membership-authority.ts
@@ -160,6 +160,25 @@ export function advanceTerminalTopologyRevision(
   }
 }
 
+/**
+ * The tab whose live layout holds this leaf. Only the leaf half of a pane key is remint-stable —
+ * `detachTerminalPaneToTab` moves a live pane into a new tab, so a stored tabId names the tab the
+ * pane left. Callers fencing on location must resolve it here rather than trust a frozen tabId.
+ */
+export function findTerminalTabIdForLeaf(
+  session: WorkspaceSessionState | undefined,
+  leafId: string
+): string | undefined {
+  for (const [tabId, layout] of Object.entries(session?.terminalLayoutsByTabId ?? {})) {
+    const leafIds = new Set<string>()
+    collectLeafIds(layout.root, leafIds)
+    if (leafIds.has(leafId)) {
+      return tabId
+    }
+  }
+  return undefined
+}
+
 export function hasHostAuthoritativeTerminalMembership(
   session: WorkspaceSessionState | undefined,
   worktreeId: string

--- a/src/main/ssh-reattach-pane-cardinality.test.ts
+++ b/src/main/ssh-reattach-pane-cardinality.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { rmSync, mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { testState, createStore, makeTerminalTab } from './persistence-test-harness'
+import { TEST_LEAF_1, TEST_LEAF_2 } from './persistence-session-fixtures'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: { isEncryptionAvailable: () => false }
+}))
+
+const TARGET = 'ssh-1'
+const WORKTREE = 'repo1::/worktree'
+const TAB = 'tab-1'
+const OTHER_TAB = 'tab-moved-to'
+
+/**
+ * The renderer's published session for one SSH pane. `terminalTopologyRevisionByRepoId` is what
+ * makes persisted membership authoritative — without it the host cannot tell "the user closed
+ * this tab" from "the renderer has not published its layout yet".
+ */
+function sessionWithPane(args: {
+  tabId: string
+  leafId: string
+  ptyId: string
+  authoritative?: boolean
+}) {
+  return {
+    activeRepoId: 'repo1',
+    activeWorktreeId: WORKTREE,
+    activeTabId: args.tabId,
+    tabsByWorktree: {
+      [WORKTREE]: [makeTerminalTab({ id: args.tabId, ptyId: args.ptyId, worktreeId: WORKTREE })]
+    },
+    terminalLayoutsByTabId: {
+      [args.tabId]: {
+        root: { type: 'leaf' as const, leafId: args.leafId },
+        activeLeafId: args.leafId,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [args.leafId]: args.ptyId }
+      }
+    },
+    ...(args.authoritative === false ? {} : { terminalTopologyRevisionByRepoId: { repo1: 1 } })
+  }
+}
+
+/** The session after the user closes the tab: membership stays authoritative, the tab is gone. */
+function sessionAfterClose() {
+  return {
+    activeRepoId: 'repo1',
+    activeWorktreeId: WORKTREE,
+    activeTabId: null,
+    tabsByWorktree: { [WORKTREE]: [] },
+    terminalLayoutsByTabId: {},
+    terminalTopologyRevisionByRepoId: { repo1: 2 }
+  }
+}
+
+/** What the relay's reattach bind does per PTY — see `restoreReattachedPtyRuntime`. */
+function relayReattachBinds(
+  store: ReturnType<typeof createStore>,
+  args: { tabId: string; leafId: string; ptyId: string; incarnationId?: string }
+): boolean | null {
+  return store.persistPtyBinding({
+    worktreeId: WORKTREE,
+    tabId: args.tabId,
+    leafId: args.leafId,
+    ptyId: args.ptyId,
+    ...(args.incarnationId ? { incarnationId: args.incarnationId } : {}),
+    mayCreate: false
+  })
+}
+
+/**
+ * Both binding writers land before the lease upsert — spawn asserts that ordering directly, and
+ * the relay's reattach binds the pane before `markSshRemotePtyLeasesAttachedAsync`. Supersession
+ * therefore sees a session already naming the arriving shell.
+ *
+ * Goes through `persistPtyBinding` rather than `setWorkspaceSession` because that is the writer
+ * production uses; a raw session write is reconciled back to the attached lease's PTY by binding
+ * recovery, which would make the fixture disagree with the real flow.
+ */
+function paneBindsTo(
+  store: ReturnType<typeof createStore>,
+  args: { tabId: string; leafId: string; ptyId: string }
+): void {
+  store.persistPtyBinding({
+    worktreeId: WORKTREE,
+    tabId: args.tabId,
+    leafId: args.leafId,
+    ptyId: args.ptyId
+  })
+}
+
+function liveLeasePtyIds(store: ReturnType<typeof createStore>): string[] {
+  return store
+    .getSshRemotePtyLeases(TARGET)
+    .filter((lease) => lease.state !== 'terminated' && lease.state !== 'expired')
+    .map((lease) => lease.ptyId)
+}
+
+function tabIds(store: ReturnType<typeof createStore>): string[] {
+  return (store.getWorkspaceSession().tabsByWorktree?.[WORKTREE] ?? []).map((tab) => tab.id)
+}
+
+describe('STA-3077: an SSH reattach binds panes without grafting them back', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+  })
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  // The reported user-visible bug in one assertion. `closeTab` fires pty.kill in the background
+  // and only COUNTS rejections, so a transport-class failure leaves the lease non-terminated —
+  // and `reattachKnownPtys` treats every non-terminated lease as live.
+  it('does not resurrect a tab whose closing pty.kill failed with a transport error', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithPane({ tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-1' }))
+    store.upsertSshRemotePtyLease({
+      targetId: TARGET,
+      ptyId: 'pty-1',
+      worktreeId: WORKTREE,
+      tabId: TAB,
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+    // The user closes the tab; the remote kill never lands, so the lease survives untouched.
+    store.setWorkspaceSession(sessionAfterClose())
+
+    const bound = relayReattachBinds(store, {
+      tabId: TAB,
+      leafId: TEST_LEAF_1,
+      ptyId: 'pty-1',
+      incarnationId: 'inc-1'
+    })
+
+    expect(bound).toBe(false)
+    expect(tabIds(store)).toEqual([])
+  })
+
+  // Tripwire: a refusal must not depend on the pane sitting where its lease says it does.
+  // `detachTerminalPaneToTab` moves a live pane, and the lease keeps naming the tab it left.
+  it('binds a pane that moved to another tab rather than refusing it', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(
+      sessionWithPane({ tabId: OTHER_TAB, leafId: TEST_LEAF_1, ptyId: 'pty-1' })
+    )
+
+    const { findTerminalTabIdForLeaf } =
+      await import('./runtime/workspace-session-terminal-membership-authority')
+    // The relay resolves the tab from the live layout before binding, exactly as the production
+    // path does; forwarding the lease's frozen `TAB` here is what would strand the pane.
+    const resolvedTabId = findTerminalTabIdForLeaf(store.getWorkspaceSession(), TEST_LEAF_1)
+    expect(resolvedTabId).toBe(OTHER_TAB)
+
+    const bound = relayReattachBinds(store, {
+      tabId: resolvedTabId!,
+      leafId: TEST_LEAF_1,
+      ptyId: 'pty-2',
+      incarnationId: 'inc-2'
+    })
+
+    expect(bound).toBe(true)
+    expect(
+      store.getWorkspaceSession().terminalLayoutsByTabId?.[OTHER_TAB]?.ptyIdsByLeafId?.[TEST_LEAF_1]
+    ).toBe('pty-2')
+  })
+
+  // Losing a tab is worse than keeping a duplicate. Before the renderer publishes a layout the
+  // host cannot read absence as a close, so the creating write must still be allowed — this is
+  // the disconnect/reconnect tab loss that reverted this fix twice.
+  it('still binds when the session is not yet authoritative for the worktree', async () => {
+    const store = await createStore()
+
+    const bound = store.persistPtyBinding({
+      worktreeId: WORKTREE,
+      tabId: TAB,
+      leafId: TEST_LEAF_1,
+      ptyId: 'pty-1',
+      incarnationId: 'inc-1',
+      // The relay passes mayCreate:false only once membership is authoritative; an unauthoritative
+      // session takes the creating write instead.
+      ...(store.getWorkspaceSession().terminalTopologyRevisionByRepoId?.repo1
+        ? { mayCreate: false }
+        : {})
+    })
+
+    expect(bound).toBe(true)
+    expect(tabIds(store)).toEqual([TAB])
+  })
+
+  it('refuses to graft a second leaf into a tab the reattach does not already own', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithPane({ tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-1' }))
+
+    const bound = relayReattachBinds(store, {
+      tabId: TAB,
+      leafId: TEST_LEAF_2,
+      ptyId: 'pty-2',
+      incarnationId: 'inc-2'
+    })
+
+    expect(bound).toBe(false)
+    const layout = store.getWorkspaceSession().terminalLayoutsByTabId?.[TAB]
+    expect(layout?.ptyIdsByLeafId?.[TEST_LEAF_2]).toBeUndefined()
+    expect(layout?.root).toEqual({ type: 'leaf', leafId: TEST_LEAF_1 })
+  })
+
+  // A close raises the repo's topology revision, and that is what the fence reads. Pinned as
+  // behavior because `terminalSurfaceTombstonesByPaneKey` — the older per-surface fence — is
+  // consumed and cleared by `sanitizeWorkspaceSessionTerminalRetirements` on every session write,
+  // so it is never present by the time a binding write could consult it.
+  it('treats a raised topology revision as the authority that makes absence a close', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithPane({ tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-1' }))
+    store.setWorkspaceSession(sessionAfterClose())
+
+    const session = store.getWorkspaceSession()
+    expect(session.terminalTopologyRevisionByRepoId?.repo1).toBeGreaterThan(0)
+    expect(session.terminalSurfaceTombstonesByPaneKey ?? {}).toEqual({})
+    expect(relayReattachBinds(store, { tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-1' })).toBe(
+      false
+    )
+  })
+})
+
+describe('STA-3077: one pane keeps at most one live remote lease', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+  })
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  // The 2 -> 19 -> 20 mechanism: lease identity was `(targetId, ptyId)` alone, so a reconnect
+  // minting a new relay id left its predecessor live with nothing to retire it.
+  it('retires the predecessor when a pane re-leases under a new relay pty id', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithPane({ tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-1' }))
+    const lease = { targetId: TARGET, worktreeId: WORKTREE, tabId: TAB, leafId: TEST_LEAF_1 }
+    store.upsertSshRemotePtyLease({ ...lease, ptyId: 'pty-1', state: 'attached' })
+
+    paneBindsTo(store, { tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-2' })
+    store.upsertSshRemotePtyLease({ ...lease, ptyId: 'pty-2', state: 'attached' })
+
+    expect(liveLeasePtyIds(store)).toEqual(['pty-2'])
+  })
+
+  // Superseding must not assert a death nobody observed — the remote shell is deliberately left
+  // running, so the predecessor is `expired`, never `terminated`.
+  it('marks the superseded lease expired rather than terminated', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithPane({ tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-1' }))
+    const lease = { targetId: TARGET, worktreeId: WORKTREE, tabId: TAB, leafId: TEST_LEAF_1 }
+    store.upsertSshRemotePtyLease({ ...lease, ptyId: 'pty-1', state: 'attached' })
+
+    paneBindsTo(store, { tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-2' })
+    store.upsertSshRemotePtyLease({ ...lease, ptyId: 'pty-2', state: 'attached' })
+
+    const predecessor = store.getSshRemotePtyLeases(TARGET).find((entry) => entry.ptyId === 'pty-1')
+    expect(predecessor?.state).toBe('expired')
+  })
+
+  // The reported growth: live claims must not scale with reconnect count.
+  it('holds the live lease count flat across ten reconnects of one pane', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithPane({ tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-0' }))
+    const lease = { targetId: TARGET, worktreeId: WORKTREE, tabId: TAB, leafId: TEST_LEAF_1 }
+
+    for (let reconnect = 0; reconnect < 10; reconnect++) {
+      paneBindsTo(store, { tabId: TAB, leafId: TEST_LEAF_1, ptyId: `pty-${reconnect}` })
+      store.upsertSshRemotePtyLease({ ...lease, ptyId: `pty-${reconnect}`, state: 'attached' })
+    }
+
+    expect(liveLeasePtyIds(store)).toEqual(['pty-9'])
+  })
+
+  // A pane broken out into its own tab keeps its leaf but not its tabId. Keying supersession on
+  // the tab would stop it competing with its own predecessor — the cardinality growth again.
+  it('supersedes across a tab change, because the leaf is the pane identity', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithPane({ tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-1' }))
+    store.upsertSshRemotePtyLease({
+      targetId: TARGET,
+      ptyId: 'pty-1',
+      worktreeId: WORKTREE,
+      tabId: TAB,
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+
+    paneBindsTo(store, { tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-2' })
+    // The successor's lease names the tab the pane sits in NOW; the predecessor's still names the
+    // one it was written in. Only the leaf is common, so keying on the tab would stop the two
+    // competing and leave both live — the cardinality growth.
+    store.upsertSshRemotePtyLease({
+      targetId: TARGET,
+      ptyId: 'pty-2',
+      worktreeId: WORKTREE,
+      tabId: OTHER_TAB,
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+
+    expect(liveLeasePtyIds(store)).toEqual(['pty-2'])
+  })
+
+  // Expiring the lease the pane is actually bound to would detach a live pane. When the arriving
+  // lease is not yet the bound one, both stay live and reattach arbitrates with the binding.
+  it('leaves both live when the pane is still bound to the predecessor', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithPane({ tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-1' }))
+    const lease = { targetId: TARGET, worktreeId: WORKTREE, tabId: TAB, leafId: TEST_LEAF_1 }
+    store.upsertSshRemotePtyLease({ ...lease, ptyId: 'pty-1', state: 'attached' })
+
+    // A lease arrives for a shell the pane has NOT bound; the binding still names pty-1.
+    store.upsertSshRemotePtyLease({ ...lease, ptyId: 'pty-9', state: 'detached' })
+
+    expect(liveLeasePtyIds(store).sort()).toEqual(['pty-1', 'pty-9'])
+  })
+
+  // Panes are independent: superseding one must not touch a sibling's lease.
+  it('does not supersede a different pane in the same worktree', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithPane({ tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-1' }))
+    store.upsertSshRemotePtyLease({
+      targetId: TARGET,
+      ptyId: 'sibling-pty',
+      worktreeId: WORKTREE,
+      tabId: TAB,
+      leafId: TEST_LEAF_2,
+      state: 'attached'
+    })
+    const lease = { targetId: TARGET, worktreeId: WORKTREE, tabId: TAB, leafId: TEST_LEAF_1 }
+    store.upsertSshRemotePtyLease({ ...lease, ptyId: 'pty-1', state: 'attached' })
+
+    paneBindsTo(store, { tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-2' })
+    store.upsertSshRemotePtyLease({ ...lease, ptyId: 'pty-2', state: 'attached' })
+
+    expect(liveLeasePtyIds(store).sort()).toEqual(['pty-2', 'sibling-pty'])
+  })
+
+  // Characterises the merge that makes relay pty-id RECYCLING dangerous: a lease upserted without
+  // pane fields inherits whatever pane the matched record named. Correct for a same-shell
+  // re-upsert, which is why it exists; unsafe when the relay restarted and handed this id to a
+  // different shell. Pinned so a future change to the merge is a deliberate one.
+  it('inherits stored pane fields when a lease re-upserts without them', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: TARGET,
+      ptyId: 'pty-1',
+      worktreeId: WORKTREE,
+      tabId: TAB,
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+
+    store.upsertSshRemotePtyLease({
+      targetId: TARGET,
+      ptyId: 'pty-1',
+      worktreeId: undefined,
+      tabId: undefined,
+      leafId: undefined,
+      state: 'detached'
+    } as never)
+
+    expect(store.getSshRemotePtyLeases(TARGET)[0]).toMatchObject({
+      ptyId: 'pty-1',
+      tabId: TAB,
+      leafId: TEST_LEAF_1,
+      state: 'detached'
+    })
+  })
+})

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -79,6 +79,10 @@ import {
 import { normalizeRemoteArtifactInput } from '../../shared/artifact-cli-bridge'
 import type { Store } from '../persistence'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
+import {
+  findTerminalTabIdForLeaf,
+  hasHostAuthoritativeTerminalMembership
+} from '../runtime/workspace-session-terminal-membership-authority'
 import { DEFAULT_PTY_SOURCE_WINDOW_SU } from '../../shared/pty-source-credit-contract'
 import { PTY_CONSUMER_STALE_OWNER_RECOVERY_ERROR } from '../../shared/pty-consumer-session'
 import {
@@ -2551,19 +2555,50 @@ export class SshRelaySession {
     lease: SshPtyLease | undefined
   ): void {
     if (lease?.worktreeId && lease.tabId && lease.leafId) {
+      const session = this.store.getWorkspaceSession?.()
+      // The lease froze its tabId at write time; `detachTerminalPaneToTab` moves a live pane, so
+      // trusting it would fence this reattach to the tab the pane LEFT and refuse a pane that
+      // merely moved. Leaf is the identity, the tab is only where it currently sits.
+      // SSH spawns bind panes into `ssh:<target>` while this reattach binds into `local`, so a
+      // fence that consulted only one partition would read "no pane" for a pane the other holds.
+      const hostSession = this.store.getWorkspaceSession?.(toSshExecutionHostId(this.targetId))
+      const tabId =
+        findTerminalTabIdForLeaf(session, lease.leafId) ??
+        findTerminalTabIdForLeaf(hostSession, lease.leafId) ??
+        lease.tabId
       this.runtime?.registerPty(appPtyId, lease.worktreeId, this.targetId, {
-        tabId: lease.tabId,
+        tabId,
         leafId: lease.leafId,
         incarnationId
       })
       try {
-        this.store.persistPtyBinding({
+        // Absence of the pane only means "the user closed it" once the persisted membership
+        // speaks for this worktree. Before that it means the renderer has not published its
+        // layout yet, and refusing there drops a tab the user still has — the regression that
+        // reverted this fix twice. Losing a tab is worse than keeping a duplicate, so an
+        // unauthoritative session still gets the creating write.
+        // Authority is read from `local` because that is the partition this write lands in — it
+        // is local's absence we would be interpreting. But a pane the other partition still holds
+        // is not gone, so it keeps its creating write: refusing there would strand a live pane
+        // behind a binding reattach can no longer reach.
+        const mayCreate =
+          !hasHostAuthoritativeTerminalMembership(session, lease.worktreeId) ||
+          findTerminalTabIdForLeaf(hostSession, lease.leafId) !== undefined
+        const bound = this.store.persistPtyBinding({
           worktreeId: lease.worktreeId,
-          tabId: lease.tabId,
+          tabId,
           leafId: lease.leafId,
           ptyId: appPtyId,
-          incarnationId
+          incarnationId,
+          ...(mayCreate ? {} : { mayCreate: false })
         })
+        if (bound === false) {
+          // The pane is gone for good, so this shell has no surface to reach it through. Expire
+          // the lease so later reconnects stop fanning out over it — deliberately not
+          // `terminated`, which would assert an exit nothing here observed, and deliberately
+          // without killing the remote process.
+          this.store.markSshRemotePtyLease(this.targetId, appPtyId, 'expired')
+        }
       } catch (error) {
         console.error('[ssh-relay-session] Failed to persist reconnect incarnation:', error)
       }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​376 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​376 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​172 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​168 |

<!-- /orca-pr-loc -->

**Stack: 5 of 6 — based on #16750.**



> **Read this first:** this restores a mechanism that landed and was reverted **twice**. The revert chain is summarised below, and the one thing both prior attempts lacked is the second bullet of the fix.

## Symptom

An SSH reconnect rewrites deleted pane state from stale leases: tabs the user closed are grafted back, close tombstones are erased, and duplicate pane leases accumulate. Canceled ticket STA-4268 (P0) states the mechanism exactly:

> "Leases have no pane incarnation and upsert only by target/PTY. Every nonterminal lease is reattached; frozen coordinates are passed to `persistPtyBinding`, which creates and flushes missing tabs and layout leaves."

## Root cause

`reattachKnownPtys` treats every non-terminated lease as live and calls `persistPtyBinding`, which had **no way to say "bind only"**. Two of its branches then rebuild UI nobody asked for:

- `src/main/persistence/loading-store/pty-binding-persistence.ts:133-143` — `if (args.incarnationId)` unconditionally deletes the pane's close tombstone.
- `:145-160` — on a tab-not-found it mints one via `createMinimalPersistedTerminalTab`. The in-code comment names its **only intended caller**: *"pty:spawn can beat the debounced writer."* Spawn. There was no guard, so reattach took the same branch.

Separately, `upsertSshRemotePtyLease` matched `(targetId, ptyId)` alone (`src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts:34-36`), so a **new relay pty id on the second reattach minted a SECOND lease** instead of updating the first, leaving the predecessor non-terminated with nothing to retire it.

**Revert history — please read before reviewing.** #13326 landed this; #14361 reverted it (−23,088, 165 files); #14384 re-applied it (+23,281); **#14395 reverted again — opened and merged nine seconds apart, empty commit body.** Five readiness tickets filed against that revert (STA-4268, STA-4272, STA-4357, STA-4446, STA-4661) were all **canceled** while automated counsel re-proved the defect on three consecutive dailies; STA-4661 went through 4-seat counsel and was classified *"release-blocking, revert-class."* `grep -rn "mayCreate" src/` returns nothing on `main` — the mechanism is genuinely out of the tree. #13324/#13325 are attempt three, untouched since 08-09.

## The fix, and why this shape

**+160 production lines across 5 files.**

1. **`mayCreate`, default true.** When false, one pre-mutation check mirrors all four creating branches (mint a tab, mint a root leaf, split the root and graft a leaf, mint a layout) and returns `false` **without mutating**, so a refusal leaves nothing half-written.

2. **The authority gate — the part both prior attempts lacked, and probably why both were reverted.** `mayCreate: false` *alone* refuses in two situations: "the user closed it" **and** "the renderer has not published its layout yet". The second is routine on disconnect→reconnect and is almost certainly the #14361 tab-loss mechanism. **The fence was not wrong; it was UNCONDITIONED.** It is now passed only when `hasHostAuthoritativeTerminalMembership()` says the persisted membership speaks for this worktree — reusing the function already guarding the same question at `orca-runtime.ts:8608`. **Losing a tab is worse than keeping a duplicate**, so an unauthoritative session still gets the creating write.

   Authority is read from the `local` partition because that is the partition this write lands in — it is *local's* absence being interpreted. But a pane the `ssh:<target>` partition still holds is not gone, so it keeps its creating write; refusing there would strand a live pane behind a binding reattach can no longer reach. (This is the GH #12721/#12723 / STA-3980 partition split-brain. This PR does **not** fix it; it refuses to judge from one side of it.)

3. **`findTerminalTabIdForLeaf`** — bind resolves the tab from the *live layout* instead of the lease's frozen `tabId`. Only the leaf half of a pane key is remint-stable: `detachTerminalPaneToTab` moves a live pane into a new tab, so a stored `tabId` names the tab the pane *left*. **Identity vs location.**

4. **Pane-keyed supersession** — retires siblings on `(targetId, worktreeId, leafId)` to `expired`, guarded by the durable binding, which reads `local` then `ssh:<target>` so it is correct whichever partition the binding landed in.

**On refusal the lease goes `expired`, never `terminated`, and the remote shell is left running.** `expired` records that this shell has no surface to reach it through; `terminated` would assert an exit nothing here observed, which `docs/reference/ssh-execution-boundary.md` forbids.

## Evidence

A/B on this tree: disable the authority gate (`mayCreate = true`) and the supersession call by hand.

```
 × does not resurrect a tab whose closing pty.kill failed with a transport error
 × refuses to graft a second leaf into a tab the reattach does not already own
 × treats a raised topology revision as the authority that makes absence a close
 × retires the predecessor when a pane re-leases under a new relay pty id
 × marks the superseded lease expired rather than terminated
 × holds the live lease count flat across ten reconnects of one pane
     AssertionError: expected [ 'pty-0', 'pty-1', 'pty-2', …(7) ] to deeply equal [ 'pty-9' ]
 × supersedes across a tab change, because the leaf is the pane identity
 × does not supersede a different pane in the same worktree

 Test Files  1 failed (1)
      Tests  8 failed | 4 passed (12)
```

That `[ 'pty-0' … 7 more ]` vs `[ 'pty-9' ]` is the lease-accumulation mechanism in miniature. The **4 that pass both ways are the over-refusal tripwires**, which is the point of having them.

Restored:

```
 Test Files  1 passed (1)      Tests  12 passed (12)
 Test Files 178 passed | 2 skipped (180)
      Tests  2439 passed | 14 skipped (2453)   # src/main/ssh, src/main/persistence, src/main/runtime/workspace-session

$ pnpm tc → clean
$ pnpm run check:code-quality:changed → 0 new findings across 30 changed files
```

## Honesty about scope — this is NOT the fix for the daily tab growth

The deterministic e2e repro (`ssh-lost-kill-tab-resurrection.spec.ts`, PR 6 of this stack) is **byte-identical before and after this change** — not a partial improvement, no change at all. Instrumentation shows why: in that scenario `restoreReattachedPtyRuntime` is **never called** (`CREATING TAB` 9 hits, `reattach gate` **0**, `BYPASS` **0**). The fence is on a path that bug does not take. Build provenance was verified positively, not by mtime: `mayCreate` appears 3× in `out/main/index.js` for the fenced build and 0× for every control run.

This is a real, separately-provable defect with an A/B control behind it. **It must not be claimed as the fix for the user report**, and this PR does not claim it. PR 6 is the one that closes that.

## Deliberately NOT done

- **A collision guard for `upsertSshRemotePtyLease`.** Built, tested, and **removed** — its own test passed with the guard disabled, i.e. vacuous. Distinguishing "same lease" from "recycled id on a different shell" from lease state alone needs a relay-start identity, which would be a **twelfth** per-tab identity concept; the codebase already carries eleven (784 refs) that SSH-v3 Phase 3 deletes. Left as an in-code NOTE and a follow-up. **This handles lease DIVERGENCE, not COLLISION.**
- **A port of #13324.** Its own authors deleted its load fold and reverted its local-only reader in #13326 (*"a headless-owned pane still gets a vote before its lease is retired"*). Porting it ships a state-destroying migration they removed.
- **`bindPaneShell` from #13325.** Its purpose is making `isSupersededPtyId` live, and that fence does not exist in `main`. It would have been a refactor plus a **silently-ignored `mayCreate`** — TS drops excess props through spreads (verified), which is why `mayCreate` is passed here as a conditional spread rather than a plain property.
- **The partition split-brain itself** (#12721/#12723, STA-3980, STA-5068). Specified but not started; it needs a decision on whether the desktop and headless planes share one home for SSH pane bindings, and a poisoned-partition test harness. Out of scope.
- **The tombstone half of the guard.** `sanitizeWorkspaceSessionTerminalRetirements` applies every tombstone then clears the map on **every** session write, so `terminalSurfaceTombstonesByPaneKey` is structurally always empty at `pty-binding-persistence.ts:163`. Guarding it would have been inert. Correction recorded here rather than shipped as dead code.

## Still unfixed, carried forward

`attachIdentityMismatches` (`src/relay/pty-handler.ts:399`) still compares `tabId`, and `expectedIdentityForLease` (`ssh-relay-session.ts:197`) composes its paneKey from the frozen `tabId`. That refusal maps to `SSH_SESSION_EXPIRED`, which authorises a respawn onto a shell just proved alive. #14384 fixed it; `eb22e49` reverted it; it never came back. It needs its own PR.

## The revert-class risk changes shape rather than disappearing

Both prior reverts (#14361, #14395) were for **tab loss**. The authority gate is what stops that
recurrence, and four of the twelve tests are over-refusal tripwires.

But a *wrong* refusal here has a different signature, and a reviewer should weigh it deliberately
rather than assume the old one is the only one: refusing to bind leaves the lease `expired` and the
**remote shell still running with no surface to reach it through** — an orphaned remote writer, the
`thread <uuid> already has an active writer` shape #16752's own body cites from a user report. The
user does not lose a tab; they lose the ability to reattach to work that is still alive, and a later
reattach can collide with the orphan.

That is why refusal is gated on `hasHostAuthoritativeTerminalMembership` *and* on the pane being
absent from both partitions, and why the lease goes `expired` rather than `terminated` — the remote
process is deliberately left running so it remains recoverable.

## Risk / blast radius

Main-process, SSH reattach path only. `mayCreate` defaults true, so every genuine-create caller (`pty:spawn`, stable-pane adoption, runtime spawn-commit) is unchanged by construction — enumerated below. Given the revert history, the specific risk to weigh is **over-refusal losing a user's tab**, which is what the authority gate exists to prevent and what four of the twelve tests assert directly.

| Path | Entry | Fenced? |
|---|---|---|
| Relay bulk reattach | `reattachKnownPtys` → `restoreReattachedPtyRuntime` (`:2247`/`:2548`) | yes, now |
| Targeted single-PTY recovery | `reattachRejectedPty` (`:1960`) | yes — same function |
| Renderer pane-retry / cold spawn | `pty:spawn` → `reattachSshPtySession` → `pty.attach` | genuine create, default true |
| Stable-pane adoption | `attachStablePaneOwner` | genuine create, default true |
| Runtime/headless spawn-commit | `runtime/spawn-commit.ts:163` | genuine create, default true |

There is no separate wake-sweep binder; sleep/wake re-enters via `reattachKnownPtys`.

## How to verify

```
pnpm test src/main/ssh-reattach-pane-cardinality.test.ts
```

To reproduce the defect: set `mayCreate` to `true` in `ssh-relay-session.ts` and comment out the `supersedeSiblingLeasesForPane(operations, next, now)` call in `ssh-pty-lease-operations.ts:139`, then re-run — 8 of 12 fail.

---

# End-to-end verification

## Specs this PR routes to

```
$ git diff --name-only nwparker/ssh-04-host-authority-seeding..nwparker/ssh-05-reattach-fence \
    | node config/scripts/pr-e2e-source-routing.mjs
["tests/e2e/pty-input-write-queue-ssh.spec.ts",
 "tests/e2e/ssh-cold-activation-restore.spec.ts",
 "tests/e2e/ssh-docker-reconnect-pane-restore.spec.ts",
 "tests/e2e/ssh-port-forward-lifecycle.spec.ts",
 "tests/e2e/ssh-reconnect-tab-destruction.spec.ts",
 "tests/e2e/ssh-startup-exec-readiness.spec.ts",
 "tests/e2e/ssh-terminal-window-wake-stale-grid-repro.spec.ts"]

$ … | node config/scripts/pr-e2e-source-routing.mjs --ssh-source
true
```

Seven specs — the widest of the stack, because this is the only level touching `src/main/ssh/`. Under `main`'s router it routed to 5; #16746 adds `ssh-port-forward-lifecycle` and `ssh-reconnect-tab-destruction`.

`ssh-port-forward-lifecycle` failed in the full lane and was **cleared** — it passes on `main` and passes at this stack tip in isolation (59.6s, same build); it is flaky only inside the full lane. See the verdict table below. Note the routing change is what put it in front of this PR at all: under `main`'s router this level would never have run it.

**Given this PR restores a twice-reverted mechanism, breadth here matters more than anywhere else in the stack.** The reverts were both for tab *loss*, so the specs that matter most are the reconnect/restore ones — `ssh-docker-reconnect-pane-restore`, `ssh-reconnect-tab-destruction`, `ssh-cold-activation-restore`.

## Lane result

Covered by the full Docker-SSH lane at the stack tip (below). The routed subset for this level can also be run directly:

```
pnpm test:e2e:ssh-docker -- tests/e2e/pty-input-write-queue-ssh.spec.ts \
                            tests/e2e/ssh-cold-activation-restore.spec.ts \
                            tests/e2e/ssh-docker-reconnect-pane-restore.spec.ts \
                            tests/e2e/ssh-port-forward-lifecycle.spec.ts \
                            tests/e2e/ssh-reconnect-tab-destruction.spec.ts \
                            tests/e2e/ssh-startup-exec-readiness.spec.ts \
                            tests/e2e/ssh-terminal-window-wake-stale-grid-repro.spec.ts
```

```
$ pnpm test:e2e:ssh-docker
BUILD_SHA=49bb96e0b4c135ce305a2f4dfe2d4b52e0b19cde   DIRTY=0
14 specs / 20 tests → 17 passed, 2 failed, 1 skipped (10.7m)
```

**The two lane failures, resolved — and one is now exempted:**

| Spec | `main` | tip (isolated) | tip (full lane) | Outcome |
|---|---|---|---|---|
| `ssh-docker-bulk-open-freeze-repro` | FAILED — harness `TypeError: … reading 'workerIndex'` at `docker-ssh-relay-target.ts:226` | — | FAILED | **Not a flake — a 100% failure**, and three further arity bugs behind it. Now **exempted** from the lane; repair tracked in stablyai/orca#16764 |
| `ssh-port-forward-lifecycle` | PASSED | **PASSED** (59.6s) | FAILED at `ssh-port-forward-lifecycle-evidence.ts:159` waiting on `getByText('Ports')` | **Flaky in-lane**, not a regression |

Port-forward was re-run at the same commit and build and passed in 59.6s. It is green on `main`, green at the tip in isolation, and red only inside the full lane — it is the set's one `@headful` spec and runs last. **Called flaky in-lane rather than "unrelated": a real lane-ordering problem, pre-existing, and worth tracking.**

> **Note on the recorded run:** the 14-spec result above predates the bulk-open exemption. The lane now runs **13** specs; bulk-open is not among them. The other 13 results are unaffected — nothing about that spec's failure changes another's outcome, since the runner passes them all to one Playwright invocation with `--workers=1` and each spec owns its own fixture container.

## Build provenance

`mayCreate` is a new identifier — **0 occurrences in `main`'s source**, which is the positive check that the fence is in the build. It lands in the main bundle:

```
$ grep -c mayCreate out/main/index.js
3
```

This count is load-bearing for the honesty section below: **every red run cited in this campaign was verified at `mayCreate` = 0**, establishing those runs were against a build without this fence. A green claim made against a bundle showing 0 would be meaningless.

Measured on the lane build:

```
BUILD_SHA=49bb96e0b4c135ce305a2f4dfe2d4b52e0b19cde   DIRTY=0
tombstone=13   hasLocalTabsRow=2   hostAuthority=4   mayCreate=3
```

`mayCreate=3` is this level's symbol; the other three prove the rest of the stack is in the same build.

> **Provenance trap, reproduced on this tree.** Do not grep a single renderer chunk. `grep -c <sym> out/renderer/assets/store-*.js | head -1` matched `store-DtDSfs7_.js` and reported **0** for a symbol present **13** times across `store-uJWnDUOY.js`, `App-CZkf3Bu7.js` and `quick-commands-menu-events-SBDd6cXN.js`. Always use `cat out/renderer/assets/*.js | grep -c <sym>`.
>
> Also: renderer `console.warn` never reaches the app log. Only main-process stdio is forwarded by `ORCA_E2E_FORWARD_APP_LOGS=1`.

## What is NOT covered — read this before approving

- **This does NOT close the daily tab growth, and the e2e proves it.** `ssh-lost-kill-tab-resurrection.spec.ts` (in #16752) is **byte-identical before and after this change** — not a partial improvement, no change at all. Instrumentation shows why: in that scenario `restoreReattachedPtyRuntime` is never called (`CREATING TAB` 9 hits, `reattach gate` **0**, `BYPASS` **0**). The fence is on a path that bug does not take. This PR does not claim otherwise; #16752 is the fix for the user report.
- **No e2e spec drives the fenced path.** The seven routed specs exercise SSH reconnect and pane restore broadly, so they are the right regression guard for the *over-refusal* risk that caused both previous reverts — but none constructs a stale lease pointing at a closed pane. The direct proof is the 12-test A/B unit suite.
- **Lease COLLISION is not handled**, only divergence. A collision guard for `upsertSshRemotePtyLease` was built, tested, and removed — its own test passed with the guard disabled, i.e. vacuous. Distinguishing "same lease" from "recycled id on a different shell" needs a relay-start identity, which would be a twelfth per-tab identity concept. Left as an in-code NOTE.
- **The partition split-brain is not fixed** (#12721/#12723, STA-3980, STA-5068). This PR refuses to *judge* from one side of it — reading both `local` and `ssh:<target>` before deciding a pane is gone — but the two owner maps still disagree.
- **`attachIdentityMismatches` still compares `tabId`** (`src/relay/pty-handler.ts:399`), and `expectedIdentityForLease` still composes its paneKey from the frozen tabId (`ssh-relay-session.ts:197`). That refusal maps to `SSH_SESSION_EXPIRED`, which authorises a respawn onto a shell just proved alive. #14384 fixed it; `eb22e49` reverted it; it never came back. Needs its own PR.
- **The `SSH_SESSION_EXPIRED` error class is lossy one layer up**, and that is a separate defect from the one above: `ssh-pty-session-reattach.ts:227-231` rewrites the relay's `PTY "pty-1" not found` into a bare `SSH_SESSION_EXPIRED`, so `isPtyAlreadyGoneError`'s `/PTY ".+" not found/` cannot match and `attachStablePaneOwner:242`'s already-correct fallback never runs. Owned by `nwparker/ssh-07-absent-from-relay`, stacked after this one. Not fixed here.
- **The tombstone half of the guard is unreachable, not merely unexercised.** `sanitizeWorkspaceSessionTerminalRetirements` applies every tombstone then clears the map on every session write, so `terminalSurfaceTombstonesByPaneKey` is structurally always empty at `pty-binding-persistence.ts:163`. Guarding it would have been inert; recorded rather than shipped as dead code.

## Failing-first test

Yes — an A/B control on this tree rather than a revert, because the two halves interact.

```
 × does not resurrect a tab whose closing pty.kill failed with a transport error
 × refuses to graft a second leaf into a tab the reattach does not already own
 × treats a raised topology revision as the authority that makes absence a close
 × retires the predecessor when a pane re-leases under a new relay pty id
 × marks the superseded lease expired rather than terminated
 × holds the live lease count flat across ten reconnects of one pane
     AssertionError: expected [ 'pty-0', 'pty-1', 'pty-2', …(7) ] to deeply equal [ 'pty-9' ]
 × supersedes across a tab change, because the leaf is the pane identity
 × does not supersede a different pane in the same worktree
      Tests  8 failed | 4 passed (12)
```

Reproduce: set `mayCreate` to `true` in `ssh-relay-session.ts` and comment out `supersedeSiblingLeasesForPane(operations, next, now)` at `ssh-pty-lease-operations.ts:139`. Restored: 12 passed. The 4 that pass both ways are the over-refusal tripwires.

