### PR TITLE
fix(terminal): a close the host never heard must survive the reconnect

### DIFF
--- a/config/scripts/run-ssh-docker-e2e.mjs
+++ b/config/scripts/run-ssh-docker-e2e.mjs
@@ -73,6 +73,7 @@ const result = spawnSync(
     'tests/e2e/ssh-cold-hydration-gap-tab-seeding.spec.ts',
     'tests/e2e/ssh-docker-reconnect-pane-restore.spec.ts',
     'tests/e2e/ssh-external-image-preview.spec.ts',
+    'tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts',
     'tests/e2e/ssh-pi-compatible-agent-title.spec.ts',
     'tests/e2e/ssh-port-forward-lifecycle.spec.ts',
     'tests/e2e/ssh-reconnect-tab-destruction.spec.ts',

--- a/src/main/orca-profiles/profile-project-session-field-disposition.ts
+++ b/src/main/orca-profiles/profile-project-session-field-disposition.ts
@@ -121,6 +121,13 @@ export const WORKSPACE_SESSION_FIELD_DISPOSITION = {
   terminalSurfaceTombstonesByPaneKey: {
     onRepoRemoval: 'prunedByBespokeRule',
     onTransfer: 'copiedByBespokeRule'
+  },
+  // Residue: keyed by tab id and pruned by neither path, like remoteSessionIdsByTabId. Bounded
+  // anyway -- every write and every pull merge runs it through the TTL and cap in
+  // shared/closed-terminal-tab-tombstones.ts, and a resolved host retires its own entries.
+  closedTerminalTabTombstonesByTabId: {
+    onRepoRemoval: 'notRepoScoped',
+    onTransfer: 'notTransferred'
   }
 } as const satisfies Record<keyof WorkspaceSessionState, SessionFieldDisposition>
 

--- a/src/renderer/src/hooks/remote-workspace-session-merge-close-tombstones.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-session-merge-close-tombstones.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest'
+
+import { mergeDirectSshRemoteWorkspaceSession } from './remote-workspace-session-merge'
+import { worktreeWorkspaceKey } from '../../../shared/workspace-scope'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import type { AppState } from '../store/types'
+
+/**
+ * The one thing a close tombstone is allowed to do, and everything it is not.
+ *
+ * The bug it exists for: the `pty.kill` for a closed SSH tab rejects with a transport error, so the
+ * close never reaches the host, the host keeps listing the tab, and every reconnect re-inserts it.
+ * The bug it must never cause is the opposite one — PR #14361 was reverted for deleting live tabs —
+ * so every case below that is not "an id this client watched the user close" keeps the tab.
+ */
+const WORKTREE = 'repo-1::/home/user/bug-cats'
+
+function terminalTab(id: string, overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return { id, title: id, type: 'terminal', worktreeId: WORKTREE, ...overrides } as TerminalTab
+}
+
+function sessionState(overrides: Partial<WorkspaceSessionState> = {}): WorkspaceSessionState {
+  return {
+    activeRepoId: 'repo-1',
+    activeWorktreeId: WORKTREE,
+    activeWorkspaceKey: worktreeWorkspaceKey(WORKTREE),
+    activeTabId: 'agent',
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    activeTabIdByWorktree: {},
+    ...overrides
+  } as WorkspaceSessionState
+}
+
+function merge(
+  current: WorkspaceSessionState,
+  remote: WorkspaceSessionState,
+  liveTabs: AppState['tabsByWorktree'] = {},
+  remoteRevision?: number
+): WorkspaceSessionState {
+  return mergeDirectSshRemoteWorkspaceSession(
+    current,
+    remote,
+    new Set([WORKTREE]),
+    liveTabs,
+    new Set(),
+    undefined,
+    remoteRevision
+  )
+}
+
+function tombstone(tabId: string, ackRevision?: number): WorkspaceSessionState {
+  return sessionState({
+    tabsByWorktree: { [WORKTREE]: [] },
+    closedTerminalTabTombstonesByTabId: {
+      [tabId]: {
+        closedAt: Date.now(),
+        worktreeId: WORKTREE,
+        ...(ackRevision ? { ackRevision } : {})
+      }
+    }
+  })
+}
+
+describe('direct-SSH pull merge: closed-tab tombstones', () => {
+  it('does not suppress a host tab whose id collides with an Object.prototype key', () => {
+    // `tabId in map` answers true for every prototype key even on an EMPTY map, so a host tab named
+    // `toString` was filtered out, blocked from the host-unknown branch, and stripped of its layout
+    // and session id — the one path in this function that could delete a tab the user never closed.
+    // Tab ids are validated only as non-empty and colon-free, and createTab honours caller-supplied
+    // id hints, so the id is reachable rather than theoretical.
+    const current = sessionState({ tabsByWorktree: { [WORKTREE]: [] } })
+    const remote = sessionState({
+      tabsByWorktree: { [WORKTREE]: [terminalTab('toString')] },
+      terminalLayoutsByTabId: { toString: { root: { type: 'leaf', paneId: 'p' } } as never },
+      remoteSessionIdsByTabId: { toString: 'session-1' }
+    })
+
+    const merged = merge(current, remote, {}, 2)
+
+    expect(merged.tabsByWorktree[WORKTREE]?.map((tab) => tab.id)).toEqual(['toString'])
+    expect(Object.hasOwn(merged.terminalLayoutsByTabId, 'toString')).toBe(true)
+    expect(merged.remoteSessionIdsByTabId?.toString).toBe('session-1')
+  })
+
+  it('does not suppress a tombstoned id under a DIFFERENT worktree', () => {
+    // The tombstone carries the worktree it was closed in, so suppression cannot reach another
+    // workspace's tab. Structural, rather than a property of where the call sites happen to sit.
+    const other = 'repo-1::/home/user/other'
+    const current = sessionState({
+      tabsByWorktree: { [WORKTREE]: [] },
+      closedTerminalTabTombstonesByTabId: {
+        'tab-x': { closedAt: Date.now(), worktreeId: other }
+      }
+    })
+    const remote = sessionState({ tabsByWorktree: { [WORKTREE]: [terminalTab('tab-x')] } })
+
+    const merged = merge(current, remote, {}, 2)
+
+    expect(merged.tabsByWorktree[WORKTREE]?.map((tab) => tab.id)).toEqual(['tab-x'])
+  })
+
+  it('does not re-insert a tombstoned tab the host still lists', () => {
+    const ghost = terminalTab('ghost')
+    const remote = sessionState({
+      tabsByWorktree: { [WORKTREE]: [ghost] },
+      terminalLayoutsByTabId: { ghost: { type: 'single', tabId: 'ghost' } as never },
+      remoteSessionIdsByTabId: { ghost: 'pty-1' }
+    })
+
+    const merged = merge(tombstone('ghost'), remote, { [WORKTREE]: [] }, 3)
+
+    expect(merged.tabsByWorktree[WORKTREE]).toEqual([])
+    expect(merged.terminalLayoutsByTabId.ghost).toBeUndefined()
+    expect(merged.remoteSessionIdsByTabId?.ghost).toBeUndefined()
+    expect(merged.closedTerminalTabTombstonesByTabId?.ghost).toBeDefined()
+  })
+
+  it('does not re-add a tombstoned tab through the host-unknown branch', () => {
+    // The stale persisted payload still lists it, and the host has never heard of it. Without the
+    // tombstone that combination is exactly what the host-unknown branch exists to preserve.
+    const ghost = terminalTab('ghost')
+    const current = sessionState({
+      tabsByWorktree: { [WORKTREE]: [ghost] },
+      closedTerminalTabTombstonesByTabId: { ghost: { closedAt: Date.now(), worktreeId: WORKTREE } }
+    })
+    const remote = sessionState({ tabsByWorktree: { [WORKTREE]: [] } })
+
+    const merged = merge(current, remote, {}, 3)
+
+    expect(merged.tabsByWorktree[WORKTREE]).toEqual([])
+  })
+
+  it('suppresses only the tombstoned tab, leaving its siblings and the pointers alone', () => {
+    // The active-tab pointers deliberately still name the ghost: hydration validates both of them
+    // against the rows below and nulls what they no longer name, so the merge leaves them be.
+    const ghost = terminalTab('ghost')
+    const survivor = terminalTab('survivor')
+    const remote = sessionState({
+      tabsByWorktree: { [WORKTREE]: [ghost, survivor] },
+      activeTabId: 'ghost',
+      activeTabIdByWorktree: { [WORKTREE]: 'ghost' }
+    })
+
+    const merged = merge(tombstone('ghost'), remote, { [WORKTREE]: [] }, 3)
+
+    expect(merged.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toEqual(['survivor'])
+  })
+
+  it('a live local tab beats a stale tombstone for its id', () => {
+    const live = terminalTab('live')
+    const current = sessionState({
+      tabsByWorktree: { [WORKTREE]: [live] },
+      closedTerminalTabTombstonesByTabId: { live: { closedAt: Date.now(), worktreeId: WORKTREE } }
+    })
+    const remote = sessionState({ tabsByWorktree: { [WORKTREE]: [live] } })
+
+    const merged = merge(current, remote, { [WORKTREE]: [live] }, 3)
+
+    expect(merged.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toEqual(['live'])
+  })
+
+  it('leaves a tab alone when no tombstone names it', () => {
+    // The pre-existing absence-is-not-closed trade, restated: a host that still lists a tab closed
+    // on some other client keeps it here, because absence is all this merge would have to go on.
+    const agent = terminalTab('agent')
+    const closedElsewhere = terminalTab('closed-elsewhere')
+    const current = sessionState({ tabsByWorktree: { [WORKTREE]: [agent, closedElsewhere] } })
+    const remote = sessionState({ tabsByWorktree: { [WORKTREE]: [agent] } })
+
+    const merged = merge(current, remote, { [WORKTREE]: [agent, closedElsewhere] }, 3)
+
+    expect(merged.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toContain('closed-elsewhere')
+  })
+
+  it('retires the tombstone once a newer snapshot stops listing the tab', () => {
+    const remote = sessionState({ tabsByWorktree: { [WORKTREE]: [] } })
+
+    const merged = merge(tombstone('ghost', 3), remote, { [WORKTREE]: [] }, 4)
+
+    expect(merged.closedTerminalTabTombstonesByTabId).toBeUndefined()
+  })
+
+  it('keeps the tombstone when the snapshot omits the worktree entirely', () => {
+    // A snapshot that says nothing about the worktree — including one whose path never resolved —
+    // is not evidence the host saw the close.
+    const merged = merge(tombstone('ghost', 3), sessionState(), {}, 4)
+
+    expect(merged.closedTerminalTabTombstonesByTabId?.ghost).toBeDefined()
+  })
+})

--- a/src/renderer/src/hooks/remote-workspace-session-merge.ts
+++ b/src/renderer/src/hooks/remote-workspace-session-merge.ts
@@ -1,5 +1,6 @@
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { reconcileClosedTerminalTabTombstones } from '../../../shared/closed-terminal-tab-tombstones'
 import type { ExecutionHostId } from '../../../shared/execution-host'
 import { worktreeWorkspaceKey } from '../../../shared/workspace-scope'
 import { splitWorktreeId } from '../../../shared/worktree/id'
@@ -26,8 +27,21 @@ export function mergeDirectSshRemoteWorkspaceSession(
   replaceWorktreeIds: ReadonlySet<string>,
   liveTabsByWorktree: AppState['tabsByWorktree'],
   preserveLocalTerminalTabIds: ReadonlySet<string>,
-  replaceExecutionHostId?: ExecutionHostId
+  replaceExecutionHostId?: ExecutionHostId,
+  remoteRevision?: number
 ): WorkspaceSessionState {
+  // Live tabs across the worktrees this snapshot replaces. Close-suppression consults it so a tab
+  // that is still live locally always beats its own tombstone.
+  // What actually keeps suppression from deleting a tab the user did not close — the earlier claim
+  // that "every use is inside replaceWorktreeIds" was wrong, since the tabsByWorktree pass below
+  // walks all of orderedWorktreeIds and the layout/session sweeps cover the whole remote maps:
+  //   1. closeTab strips the id from EVERY worktree row before recording the tombstone
+  //      (terminal-tab-close.ts), so a tombstoned id is not live anywhere;
+  //   2. isSuppressedByClose matches the tombstone's own worktreeId, so it cannot reach another
+  //      workspace's tab even if an id somehow recurred;
+  //   3. only closeReason === 'user' ever writes a tombstone.
+  // A final sweep of suppression over the assembled tabsByWorktree — including worktrees
+  // omitTargetWorktrees passes through verbatim — is still deliberately absent.
   const currentTabsById = new Map(
     [...replaceWorktreeIds]
       .flatMap((worktreeId) => liveTabsByWorktree[worktreeId] ?? [])
@@ -96,22 +110,64 @@ export function mergeDirectSshRemoteWorkspaceSession(
       .filter(([tabId]) => remoteKnownTabIds.has(tabId))
       .map(([, sessionId]) => sessionId)
   )
+  // The other half of the trade below. Absence still cannot say "closed", so this says it instead:
+  // a tab THIS client watched the user close, whose close never reached the host. Only ids the user
+  // closed are ever in here, and only until the host's own snapshot stops listing them.
+  const closedTerminalTabTombstonesByTabId = reconcileClosedTerminalTabTombstones({
+    tombstones: current.closedTerminalTabTombstonesByTabId,
+    acknowledgedWorktreeIds: new Set(
+      [...replaceWorktreeIds].filter((worktreeId) =>
+        Object.hasOwn(remote.tabsByWorktree, worktreeId)
+      )
+    ),
+    hostKnownTabIds: remoteKnownTabIds,
+    hostRevision: remoteRevision,
+    now: Date.now()
+  })
+  // Why Object.hasOwn and not `in`: the map is a plain object from Object.fromEntries, so `in`
+  // answers true for every Object.prototype key on an EMPTY map — a host tab whose id is
+  // `toString` would be filtered, blocked from the host-unknown branch, and stripped of its layout
+  // and session id. Tab ids are validated only as non-empty and colon-free, and createTab honours
+  // caller-supplied id hints, so that id is reachable. This is the one place either direction could
+  // delete a tab the user never closed.
+  // Why the worktree comparison: the tombstone already carries the worktree it was closed in, so
+  // scoping on it makes "this suppression cannot reach another workspace's tab" structural rather
+  // than a property of where the call sites happen to sit.
+  // Why a live local tab still overrides its own tombstone: an id that is live here means the
+  // tombstone is stale (a close undone before it persisted), not a revival. Deleting a live pane is
+  // the one outcome this whole function exists to avoid.
+  const isSuppressedByClose = (tabId: string, worktreeId: string): boolean =>
+    Object.hasOwn(closedTerminalTabTombstonesByTabId, tabId) &&
+    closedTerminalTabTombstonesByTabId[tabId]?.worktreeId === worktreeId &&
+    !currentTabsById.has(tabId)
+  // Ids this merge actually suppressed, recorded as it walks the worktrees. The layout and
+  // session-id sweeps below have no worktree in scope, so they consult decisions already made
+  // rather than re-deriving one without the scope that makes it safe.
+  const suppressedTabIds = new Set<string>()
   const tabsByWorktree = Object.fromEntries(
     orderedWorktreeIds.map((worktreeId) => {
       const remoteTabs = remote.tabsByWorktree[worktreeId] ?? []
-      const reconciled = remoteTabs.map((tab) => {
-        const local = currentTabsById.get(tab.id)
-        if (
-          !local ||
-          ((local.generation ?? 0) <= (tab.generation ?? 0) &&
-            !local.pendingActivationSpawn &&
-            !preserveLocalTerminalTabIds.has(tab.id))
-        ) {
-          return tab
-        }
-        locallyPreservedTabIds.add(tab.id)
-        return preserveNewerLocalTerminalFields(tab, local)
-      })
+      const reconciled = remoteTabs
+        .filter((tab) => {
+          if (!isSuppressedByClose(tab.id, worktreeId)) {
+            return true
+          }
+          suppressedTabIds.add(tab.id)
+          return false
+        })
+        .map((tab) => {
+          const local = currentTabsById.get(tab.id)
+          if (
+            !local ||
+            ((local.generation ?? 0) <= (tab.generation ?? 0) &&
+              !local.pendingActivationSpawn &&
+              !preserveLocalTerminalTabIds.has(tab.id))
+          ) {
+            return tab
+          }
+          locallyPreservedTabIds.add(tab.id)
+          return preserveNewerLocalTerminalFields(tab, local)
+        })
       for (const tab of reconciled) {
         emittedTabIds.add(tab.id)
       }
@@ -133,6 +189,10 @@ export function mergeDirectSshRemoteWorkspaceSession(
       // been told about the tab, so it is not host-unknown.
       const hostUnknown = localTabsFor(worktreeId).filter((tab) => {
         if (remoteKnownTabIds.has(tab.id) || emittedTabIds.has(tab.id)) {
+          return false
+        }
+        if (isSuppressedByClose(tab.id, worktreeId)) {
+          suppressedTabIds.add(tab.id)
           return false
         }
         const localSessionId = current.remoteSessionIdsByTabId?.[tab.id]
@@ -186,7 +246,7 @@ export function mergeDirectSshRemoteWorkspaceSession(
     ),
     ...Object.fromEntries(
       Object.entries(remote.terminalLayoutsByTabId).filter(
-        ([tabId]) => !locallyPreservedTabIds.has(tabId)
+        ([tabId]) => !locallyPreservedTabIds.has(tabId) && !suppressedTabIds.has(tabId)
       )
     )
   }
@@ -243,6 +303,9 @@ export function mergeDirectSshRemoteWorkspaceSession(
           return localActiveTabId == null ? [] : [[worktreeId, localActiveTabId] as const]
         })
       ),
+      // Why a suppressed id is left in place here: hydration validates both active-tab pointers
+      // against the tab rows it just built and nulls anything they no longer name, so nulling twice
+      // would only add a second rule that has to stay in step with that one.
       ...remote.activeTabIdByWorktree
     },
     remoteSessionIdsByTabId: {
@@ -253,7 +316,7 @@ export function mergeDirectSshRemoteWorkspaceSession(
       ),
       ...Object.fromEntries(
         Object.entries(remote.remoteSessionIdsByTabId ?? {}).filter(
-          ([tabId]) => !locallyPreservedTabIds.has(tabId)
+          ([tabId]) => !locallyPreservedTabIds.has(tabId) && !suppressedTabIds.has(tabId)
         )
       )
     },
@@ -268,7 +331,11 @@ export function mergeDirectSshRemoteWorkspaceSession(
       // tabs. Removal is the worktree-teardown path's job, not a reconnect's.
       ...current.defaultTerminalTabsAppliedByWorktreeId,
       ...remote.defaultTerminalTabsAppliedByWorktreeId
-    }
+    },
+    closedTerminalTabTombstonesByTabId:
+      Object.keys(closedTerminalTabTombstonesByTabId).length > 0
+        ? closedTerminalTabTombstonesByTabId
+        : undefined
   }
 }
 

--- a/src/renderer/src/hooks/remote-workspace-snapshot-apply.ts
+++ b/src/renderer/src/hooks/remote-workspace-snapshot-apply.ts
@@ -119,7 +119,8 @@ export async function applyDirectSshRemoteWorkspaceSnapshot({
     worktreeIds,
     state.tabsByWorktree,
     currentRecoveryTabIds(state, authority, worktreeIds),
-    toSshExecutionHostId(authority.targetId)
+    toSshExecutionHostId(authority.targetId),
+    snapshot.revision
   )
   if (!isArrivalCurrent(authority.targetId, arrival) || !isPreparationTokenCurrent(token)) {
     return

--- a/src/renderer/src/lib/workspace-session-browser-history.test.ts
+++ b/src/renderer/src/lib/workspace-session-browser-history.test.ts
@@ -32,7 +32,8 @@ function createSnapshot(browserUrlHistory: BrowserHistoryEntry[]): WorkspaceSess
     worktreesByRepo: {},
     lastKnownRelayPtyIdByTabId: {},
     lastVisitedAtByWorktreeId: {},
-    defaultTerminalTabsAppliedByWorktreeId: {}
+    defaultTerminalTabsAppliedByWorktreeId: {},
+    closedTerminalTabTombstonesByTabId: {}
   }
 }
 

--- a/src/renderer/src/lib/workspace-session-closed-tab-tombstones.test.ts
+++ b/src/renderer/src/lib/workspace-session-closed-tab-tombstones.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { buildWorkspaceSessionPatch } from './workspace-session-patch'
+import { SESSION_RELEVANT_FIELDS } from './workspace-session'
+import { CLOSED_TERMINAL_TAB_TOMBSTONE_TTL_MS } from '../../../shared/closed-terminal-tab-tombstones'
+
+// Why browserPagesByWorkspace is stubbed: buildWorkspaceSessionPatch pre-filters staged browser tabs
+// before field dispatch, so the minimal fixture has to carry the map it iterates.
+function patchFor(
+  map: Record<string, { closedAt: number; worktreeId: string }>
+): ReturnType<typeof buildWorkspaceSessionPatch> {
+  return buildWorkspaceSessionPatch(
+    { browserPagesByWorkspace: {}, closedTerminalTabTombstonesByTabId: map } as never,
+    ['closedTerminalTabTombstonesByTabId']
+  )
+}
+
+describe('closed-tab tombstones in the persisted session', () => {
+  it('is a session-relevant field, so a close on its own schedules a write', () => {
+    expect(SESSION_RELEVANT_FIELDS).toContain('closedTerminalTabTombstonesByTabId')
+  })
+
+  it('writes live tombstones and drops ones past the TTL', () => {
+    const now = Date.now()
+    expect(
+      patchFor({
+        fresh: { closedAt: now, worktreeId: 'repo-1::/srv/app' },
+        stale: {
+          closedAt: now - CLOSED_TERMINAL_TAB_TOMBSTONE_TTL_MS - 1,
+          worktreeId: 'repo-1::/srv/app'
+        }
+      }).closedTerminalTabTombstonesByTabId
+    ).toEqual({ fresh: { closedAt: now, worktreeId: 'repo-1::/srv/app' } })
+  })
+
+  it('omits the field entirely once the map empties', () => {
+    expect(patchFor({}).closedTerminalTabTombstonesByTabId).toBeUndefined()
+  })
+})

--- a/src/renderer/src/lib/workspace-session-closed-tab-tombstones.ts
+++ b/src/renderer/src/lib/workspace-session-closed-tab-tombstones.ts
@@ -1,0 +1,10 @@
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { pruneClosedTerminalTabTombstones } from '../../../shared/closed-terminal-tab-tombstones'
+
+/** Applies the TTL/cap bound on the way to disk, and omits an empty map like its siblings. */
+export function buildPersistedClosedTerminalTabTombstones(
+  map: WorkspaceSessionState['closedTerminalTabTombstonesByTabId']
+): WorkspaceSessionState['closedTerminalTabTombstonesByTabId'] {
+  const pruned = pruneClosedTerminalTabTombstones(map, Date.now())
+  return Object.keys(pruned).length > 0 ? pruned : undefined
+}

--- a/src/renderer/src/lib/workspace-session-editor-drafts.test.ts
+++ b/src/renderer/src/lib/workspace-session-editor-drafts.test.ts
@@ -34,6 +34,7 @@ function createSnapshot(
     lastKnownRelayPtyIdByTabId: {},
     lastVisitedAtByWorktreeId: {},
     defaultTerminalTabsAppliedByWorktreeId: {},
+    closedTerminalTabTombstonesByTabId: {},
     ...overrides
   }
 }

--- a/src/renderer/src/lib/workspace-session-host-field-ownership.ts
+++ b/src/renderer/src/lib/workspace-session-host-field-ownership.ts
@@ -49,7 +49,10 @@ export const WORKSPACE_SESSION_FIELD_OWNERSHIP = {
   terminalPtyIncarnationsByPaneKey: 'paneKeyed',
   // Why: this host-issued fence must never collide while unified renderer state merges equal repo ids across hosts.
   terminalTopologyRevisionByRepoId: 'hostPrivate',
-  terminalSurfaceTombstonesByPaneKey: 'surfaceTombstoneKeyed'
+  terminalSurfaceTombstonesByPaneKey: 'surfaceTombstoneKeyed',
+  // Why not tabKeyed: the tab is already gone, so worktreeIdByTabId can never resolve it. Routing by
+  // the record's own worktreeId is the same problem terminalSurfaceTombstonesByPaneKey has.
+  closedTerminalTabTombstonesByTabId: 'surfaceTombstoneKeyed'
 } as const satisfies Record<keyof WorkspaceSessionState, WorkspaceSessionFieldOwnership>
 
 // Why: an unclassified persisted field would otherwise disappear from every non-local host.

--- a/src/renderer/src/lib/workspace-session-host-split.ts
+++ b/src/renderer/src/lib/workspace-session-host-split.ts
@@ -49,7 +49,9 @@ export type HostIdByWorktreeId = (worktreeId: string) => ExecutionHostId
  *  - browserWorkspaceKeyed: Record keyed by browser-workspace id; follows the
  *    page record's own worktreeId.
  *  - fileKeyed: Record keyed by editor file id; follows the open file's worktree.
- *  - sleepingAgentKeyed: Record keyed by pane key; follows the record's worktreeId. */
+ *  - sleepingAgentKeyed: Record keyed by pane key; follows the record's worktreeId.
+ *  - surfaceTombstoneKeyed: Record under an opaque key whose value names its own worktreeId --
+ *    the only routing available once the tab or pane it describes is gone. */
 type SplitContext = {
   hostIdByWorktreeId: HostIdByWorktreeId
   worktreeIdByTabId: Map<string, string>

--- a/src/renderer/src/lib/workspace-session-liveness.test.ts
+++ b/src/renderer/src/lib/workspace-session-liveness.test.ts
@@ -33,6 +33,7 @@ function createSnapshot(
     lastKnownRelayPtyIdByTabId: {},
     lastVisitedAtByWorktreeId: {},
     defaultTerminalTabsAppliedByWorktreeId: {},
+    closedTerminalTabTombstonesByTabId: {},
     ...overrides
   }
 }

--- a/src/renderer/src/lib/workspace-session-patch.ts
+++ b/src/renderer/src/lib/workspace-session-patch.ts
@@ -19,6 +19,7 @@ import { withoutStagedBrowserTabs } from './workspace-session-staged-browser-tab
 import { buildPersistedUnifiedTabSessionData } from './workspace-session-unified-tabs'
 import { buildLastVisitedAtByWorktreeId } from './workspace-session-focus-recency'
 import { buildSleepingAgentSessionData } from './workspace-session-sleeping-agents'
+import { buildPersistedClosedTerminalTabTombstones } from './workspace-session-closed-tab-tombstones'
 
 type SessionRelevantField = keyof WorkspaceSessionSnapshot
 
@@ -159,6 +160,11 @@ export function buildWorkspaceSessionPatch(
       Object.keys(snapshot.defaultTerminalTabsAppliedByWorktreeId).length > 0
         ? snapshot.defaultTerminalTabsAppliedByWorktreeId
         : undefined
+  }
+  if (changed.has('closedTerminalTabTombstonesByTabId')) {
+    patch.closedTerminalTabTombstonesByTabId = buildPersistedClosedTerminalTabTombstones(
+      snapshot.closedTerminalTabTombstonesByTabId
+    )
   }
   if (changed.has('sleepingAgentSessionsByPaneKey')) {
     patch.sleepingAgentSessionsByPaneKey =

--- a/src/renderer/src/lib/workspace-session-relevant-fields.test.ts
+++ b/src/renderer/src/lib/workspace-session-relevant-fields.test.ts
@@ -34,6 +34,7 @@ describe('SESSION_RELEVANT_FIELDS', () => {
     lastKnownRelayPtyIdByTabId: true,
     lastVisitedAtByWorktreeId: true,
     defaultTerminalTabsAppliedByWorktreeId: true,
+    closedTerminalTabTombstonesByTabId: true,
     sleepingAgentSessionsByPaneKey: true,
     clientHostedBrowserCloseIntentsByEnvironment: true
   }

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -10,6 +10,7 @@ import type { OpenFile } from '../store/slices/editor'
 import { buildPersistedUnifiedTabSessionData } from './workspace-session-unified-tabs'
 import { buildLastVisitedAtByWorktreeId } from './workspace-session-focus-recency'
 import { buildSleepingAgentSessionData } from './workspace-session-sleeping-agents'
+import { buildPersistedClosedTerminalTabTombstones } from './workspace-session-closed-tab-tombstones'
 import { buildActiveConnectionIdsAtShutdown } from './workspace-session-reconnect-targets'
 import { withoutStagedBrowserTabs } from './workspace-session-staged-browser-tabs'
 import { buildBrowserSessionData } from './workspace-session-browser-tabs'
@@ -53,6 +54,7 @@ export type WorkspaceSessionSnapshot = Pick<
   | 'lastKnownRelayPtyIdByTabId'
   | 'lastVisitedAtByWorktreeId'
   | 'defaultTerminalTabsAppliedByWorktreeId'
+  | 'closedTerminalTabTombstonesByTabId'
 > & {
   activeWorkspaceExecutionHostId?: AppState['activeWorkspaceExecutionHostId']
   sleepingAgentSessionsByPaneKey?: AppState['sleepingAgentSessionsByPaneKey']
@@ -90,6 +92,7 @@ export const SESSION_RELEVANT_FIELDS = [
   'lastKnownRelayPtyIdByTabId',
   'lastVisitedAtByWorktreeId',
   'defaultTerminalTabsAppliedByWorktreeId',
+  'closedTerminalTabTombstonesByTabId',
   'sleepingAgentSessionsByPaneKey',
   'clientHostedBrowserCloseIntentsByEnvironment'
 ] as const satisfies readonly (keyof WorkspaceSessionSnapshot)[]
@@ -303,6 +306,9 @@ export function buildWorkspaceSessionPayload(
       Object.keys(snapshot.defaultTerminalTabsAppliedByWorktreeId).length > 0
         ? snapshot.defaultTerminalTabsAppliedByWorktreeId
         : undefined,
+    closedTerminalTabTombstonesByTabId: buildPersistedClosedTerminalTabTombstones(
+      snapshot.closedTerminalTabTombstonesByTabId
+    ),
     ...buildSleepingAgentSessionData(snapshot),
     // Why unconditional rather than omit-when-empty: a full write replaces the persisted object,
     // so an emptied map has to be written as empty or the last replay never sticks.

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -49,6 +49,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   workspaceSessionReady: false,
   restoredRuntimeHostIdByWorkspaceSessionKey: {},
   defaultTerminalTabsAppliedByWorktreeId: {},
+  closedTerminalTabTombstonesByTabId: {},
   hydrationSucceeded: false,
   pendingReconnectWorktreeIds: [],
   pendingReconnectTabByWorktree: {},

--- a/src/renderer/src/store/terminals/terminal-state.ts
+++ b/src/renderer/src/store/terminals/terminal-state.ts
@@ -1,3 +1,4 @@
+import type { ClosedTerminalTabTombstonesByTabId } from '../../../../shared/closed-terminal-tab-tombstones'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { SetupSplitDirection } from '../../../../shared/worktree/launch-types'
@@ -90,6 +91,7 @@ export type TerminalState = {
   workspaceSessionReady: boolean
   restoredRuntimeHostIdByWorkspaceSessionKey: Record<string, ExecutionHostId>
   defaultTerminalTabsAppliedByWorktreeId: Record<string, true>
+  closedTerminalTabTombstonesByTabId: ClosedTerminalTabTombstonesByTabId
   hydrationSucceeded: boolean
   pendingReconnectWorktreeIds: string[]
   pendingReconnectTabByWorktree: Record<string, string[]>

--- a/src/renderer/src/store/terminals/terminal-tab-close-tombstone.test.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-close-tombstone.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+import { createTestStore, makeTab, makeWorktree, seedStore } from '../slices/store-test-helpers'
+import { createStoreCascadesMockApi } from '../slices/store-cascades-test-harness'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn<() => unknown[]>(() => [])
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => ({
+  ...(await importOriginal<typeof AgentStatusModule>()),
+  detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
+}))
+
+const mockApi = createStoreCascadesMockApi()
+
+const REMOTE_WORKTREE = 'remote-repo::/srv/app'
+const LOCAL_WORKTREE = 'local-repo::/tmp/app'
+
+function storeWithBothWorktrees(): ReturnType<typeof createTestStore> {
+  const store = createTestStore()
+  seedStore(store, {
+    repos: [
+      { id: 'remote-repo', path: '/srv/app', name: 'app', connectionId: 'ssh-1' },
+      { id: 'local-repo', path: '/tmp/app', name: 'app' }
+    ] as never,
+    worktreesByRepo: {
+      'remote-repo': [
+        makeWorktree({ id: REMOTE_WORKTREE, repoId: 'remote-repo', path: '/srv/app' })
+      ],
+      'local-repo': [makeWorktree({ id: LOCAL_WORKTREE, repoId: 'local-repo', path: '/tmp/app' })]
+    },
+    tabsByWorktree: {
+      [REMOTE_WORKTREE]: [makeTab({ id: 'remote-tab', worktreeId: REMOTE_WORKTREE })],
+      [LOCAL_WORKTREE]: [makeTab({ id: 'local-tab', worktreeId: LOCAL_WORKTREE })]
+    }
+  })
+  return store
+}
+
+describe('closeTab close tombstones', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.worktrees.updateMeta.mockResolvedValue({})
+  })
+
+  it('records the closed tab against the worktree it was closed in', () => {
+    const store = storeWithBothWorktrees()
+
+    store.getState().closeTab('remote-tab')
+
+    expect(store.getState().closedTerminalTabTombstonesByTabId['remote-tab']).toEqual({
+      closedAt: expect.any(Number),
+      worktreeId: REMOTE_WORKTREE
+    })
+  })
+
+  // A tombstone outlives the host's own record, so the only claim it may ever make is "the user
+  // closed this". Neither of these closes is that claim.
+  it.each([['pty-exit'], ['cleanup']] as const)('records nothing for a %s close', (reason) => {
+    const store = storeWithBothWorktrees()
+
+    store.getState().closeTab('remote-tab', { reason })
+
+    expect(store.getState().closedTerminalTabTombstonesByTabId['remote-tab']).toBeUndefined()
+  })
+
+  it('records nothing for a definitively local worktree, which no pull merge ever reads', () => {
+    const store = storeWithBothWorktrees()
+
+    store.getState().closeTab('local-tab')
+
+    expect(store.getState().closedTerminalTabTombstonesByTabId).toEqual({})
+  })
+})

--- a/src/renderer/src/store/terminals/terminal-tab-close.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-close.ts
@@ -1,4 +1,6 @@
+import { recordClosedTerminalTabTombstone } from '../../../../shared/closed-terminal-tab-tombstones'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import { getConnectionIdFromState } from '@/lib/connection-owner-resolution'
 import { sweepRetiredTerminalTabState } from '../slices/retired-terminal-tab-state-sweep'
 import {
   getRecentlyClosedTabPosition,
@@ -58,6 +60,23 @@ export function createTerminalTabCloseActions(
             next[wId] = after
           }
         }
+        // Why `user` and not retiresSession: a tombstone outlives the host's own record, so the only
+        // thing it may ever say is "the user closed this". A pty-exit close is the process ending,
+        // and a `cleanup` close retires a tab the app itself created — neither is that claim.
+        // Why a non-local worktree only: the tombstone is read solely by the direct-SSH pull merge,
+        // and a definitively local tab would just consume the map's cap. An unresolved repo
+        // (undefined, not null) still records — losing the tombstone reinstates the resurrection.
+        const nextClosedTombstones =
+          closeReason === 'user' &&
+          closedWorktreeId &&
+          getConnectionIdFromState(s, closedWorktreeId) !== null
+            ? recordClosedTerminalTabTombstone(
+                s.closedTerminalTabTombstonesByTabId,
+                tabId,
+                closedWorktreeId,
+                Date.now()
+              )
+            : s.closedTerminalTabTombstonesByTabId
         // Why: only explicit user closes feed the Cmd+Shift+T reopen stack; cleanup/PTY-exit closes must not pollute undo history.
         const closedPosition =
           closedWorktreeId && closedTab
@@ -206,6 +225,9 @@ export function createTerminalTabCloseActions(
           directSshPaneRetryHistoryByTabId: nextDirectSshPaneRetryHistoryByTabId,
           ...(nextSleepingAgentSessionsByPaneKey !== s.sleepingAgentSessionsByPaneKey
             ? { sleepingAgentSessionsByPaneKey: nextSleepingAgentSessionsByPaneKey }
+            : {}),
+          ...(nextClosedTombstones !== s.closedTerminalTabTombstonesByTabId
+            ? { closedTerminalTabTombstonesByTabId: nextClosedTombstones }
             : {}),
           // Why: skip writing unreadTerminalTabs when unchanged to avoid a no-op state allocation that re-evaluates full-state selectors. Mirrors tabs.ts.
           ...(nextUnreadTerminalTabs !== s.unreadTerminalTabs

--- a/src/renderer/src/store/terminals/workspace-terminal-hydration-patch.ts
+++ b/src/renderer/src/store/terminals/workspace-terminal-hydration-patch.ts
@@ -19,6 +19,7 @@ export type WorkspaceHydrationPatch = Pick<
   | 'worktreesByRepo'
   | 'lastVisitedAtByWorktreeId'
   | 'defaultTerminalTabsAppliedByWorktreeId'
+  | 'closedTerminalTabTombstonesByTabId'
   | 'automaticAgentResumeClaimsByTabId'
   | 'sleepingAgentSessionsByPaneKey'
   | 'pendingReconnectWorktreeIds'
@@ -176,6 +177,9 @@ export function targetScopedWorkspaceHydrationPatch(
       hydrated.defaultTerminalTabsAppliedByWorktreeId,
       workspaceKeys
     ),
+    // Why passed through whole: hydration already unioned it with live store state, and the map is
+    // keyed by tab id rather than by workspace key so replaceHydratedRecordKeys has nothing to match.
+    closedTerminalTabTombstonesByTabId: hydrated.closedTerminalTabTombstonesByTabId,
     automaticAgentResumeClaimsByTabId: replaceHydratedRecordKeys(
       state.automaticAgentResumeClaimsByTabId,
       hydrated.automaticAgentResumeClaimsByTabId,

--- a/src/renderer/src/store/terminals/workspace-terminal-hydration.ts
+++ b/src/renderer/src/store/terminals/workspace-terminal-hydration.ts
@@ -178,6 +178,11 @@ export function createWorkspaceTerminalHydrationActions(
           lastVisitedAtByWorktreeId: session.lastVisitedAtByWorktreeId ?? {},
           defaultTerminalTabsAppliedByWorktreeId:
             session.defaultTerminalTabsAppliedByWorktreeId ?? {},
+          // Why replace and not union: both callers hand over a map they derived from this store
+          // synchronously (the pull merge) or from disk before the store had one (startup), so there
+          // is no local tombstone to lose — and a union would resurrect the ones the merge just
+          // retired on the host's acknowledgement, which is the whole bound on this map.
+          closedTerminalTabTombstonesByTabId: session.closedTerminalTabTombstonesByTabId ?? {},
           automaticAgentResumeClaimsByTabId: {},
           sleepingAgentSessionsByPaneKey,
           pendingReconnectWorktreeIds,

--- a/src/shared/closed-terminal-tab-tombstones.test.ts
+++ b/src/shared/closed-terminal-tab-tombstones.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CLOSED_TERMINAL_TAB_TOMBSTONE_TTL_MS,
+  MAX_CLOSED_TERMINAL_TAB_TOMBSTONES,
+  pruneClosedTerminalTabTombstones,
+  recordClosedTerminalTabTombstone,
+  reconcileClosedTerminalTabTombstones,
+  type ClosedTerminalTabTombstonesByTabId
+} from './closed-terminal-tab-tombstones'
+
+const NOW = 1_800_000_000_000
+const WT = 'repo-1::/srv/app'
+
+function reconcile(
+  tombstones: ClosedTerminalTabTombstonesByTabId,
+  args: {
+    acknowledgedWorktreeIds?: string[]
+    hostKnownTabIds?: string[]
+    hostRevision?: number
+  }
+): ClosedTerminalTabTombstonesByTabId {
+  return reconcileClosedTerminalTabTombstones({
+    tombstones,
+    acknowledgedWorktreeIds: new Set(args.acknowledgedWorktreeIds ?? [WT]),
+    hostKnownTabIds: new Set(args.hostKnownTabIds ?? []),
+    hostRevision: args.hostRevision,
+    now: NOW
+  })
+}
+
+describe('closed terminal tab tombstones', () => {
+  it('records the closing worktree and time', () => {
+    expect(recordClosedTerminalTabTombstone({}, 'tab-1', WT, NOW)).toEqual({
+      'tab-1': { closedAt: NOW, worktreeId: WT }
+    })
+  })
+
+  it('prunes past the TTL and caps at the newest entries', () => {
+    expect(
+      pruneClosedTerminalTabTombstones(
+        {
+          fresh: { closedAt: NOW - 1_000, worktreeId: WT },
+          stale: { closedAt: NOW - CLOSED_TERMINAL_TAB_TOMBSTONE_TTL_MS - 1, worktreeId: WT }
+        },
+        NOW
+      )
+    ).toEqual({ fresh: { closedAt: NOW - 1_000, worktreeId: WT } })
+
+    const overflowing = Object.fromEntries(
+      Array.from({ length: MAX_CLOSED_TERMINAL_TAB_TOMBSTONES + 10 }, (_, index) => [
+        `tab-${index}`,
+        { closedAt: NOW - index, worktreeId: WT }
+      ])
+    )
+    const capped = pruneClosedTerminalTabTombstones(overflowing, NOW)
+    expect(Object.keys(capped)).toHaveLength(MAX_CLOSED_TERMINAL_TAB_TOMBSTONES)
+    expect(capped['tab-0']).toBeDefined()
+    expect(capped[`tab-${MAX_CLOSED_TERMINAL_TAB_TOMBSTONES + 9}`]).toBeUndefined()
+  })
+})
+
+describe('closed terminal tab tombstone acknowledgement', () => {
+  const tombstones = { 'tab-1': { closedAt: NOW, worktreeId: WT } }
+
+  it('a snapshot carrying no revision acknowledges nothing', () => {
+    expect(reconcile(tombstones, { hostRevision: undefined })).toEqual(tombstones)
+  })
+
+  it('a snapshot with no row for the tombstone worktree acknowledges nothing', () => {
+    const kept = reconcile(tombstones, { acknowledgedWorktreeIds: [], hostRevision: 9 })
+    expect(kept['tab-1']).toEqual({ closedAt: NOW, worktreeId: WT })
+  })
+
+  it('the first omitting snapshot only stamps the revision — it could predate the close', () => {
+    const kept = reconcile(tombstones, { hostRevision: 4 })
+    expect(kept['tab-1']).toEqual({ closedAt: NOW, worktreeId: WT, ackRevision: 4 })
+  })
+
+  it('a strictly newer omitting snapshot retires the tombstone', () => {
+    const stamped = reconcile(tombstones, { hostRevision: 4 })
+    expect(reconcile(stamped, { hostRevision: 5 })['tab-1']).toBeUndefined()
+  })
+
+  it('a repeat of the same revision does not retire it', () => {
+    const stamped = reconcile(tombstones, { hostRevision: 4 })
+    expect(reconcile(stamped, { hostRevision: 4 })['tab-1']).toBeDefined()
+  })
+
+  it('a host that still lists the tab re-arms the watermark instead of retiring', () => {
+    const stamped = reconcile(tombstones, { hostRevision: 4 })
+    const stillListed = reconcile(stamped, { hostRevision: 7, hostKnownTabIds: ['tab-1'] })
+    expect(stillListed['tab-1']).toEqual({ closedAt: NOW, worktreeId: WT, ackRevision: 7 })
+    expect(reconcile(stillListed, { hostRevision: 7 })['tab-1']).toBeDefined()
+    expect(reconcile(stillListed, { hostRevision: 8 })['tab-1']).toBeUndefined()
+  })
+
+  it('a host revision that went backwards never retires', () => {
+    const stamped = reconcile(tombstones, { hostRevision: 40 })
+    const rewound = reconcile(stamped, { hostRevision: 1 })
+    expect(rewound['tab-1']).toEqual({ closedAt: NOW, worktreeId: WT, ackRevision: 40 })
+  })
+
+  it('a tab listed under a different worktree still counts as known to the host', () => {
+    const stamped = reconcile(tombstones, { hostRevision: 4 })
+    expect(
+      reconcile(stamped, { hostRevision: 5, hostKnownTabIds: ['tab-1'] })['tab-1']
+    ).toBeDefined()
+  })
+})

--- a/src/shared/closed-terminal-tab-tombstones.ts
+++ b/src/shared/closed-terminal-tab-tombstones.ts
@@ -1,0 +1,111 @@
+import { z } from 'zod'
+
+/** A client's own record that the user closed a terminal tab.
+ *
+ *  Why it has to exist: the direct-SSH pull merge cannot tell "the host was never told about this
+ *  tab" from "the user closed it" by absence alone, so it keeps the tab (see the trade documented in
+ *  remote-workspace-session-merge.ts). When the `pty.kill` RPC rejects with a transport error the
+ *  close never reaches the host at all, the host keeps listing the tab, and every reconnect
+ *  re-inserts it. The tombstone is the missing close signal — first-party intent that outlives the
+ *  failed RPC — so the merge can drop that one tab without ever deleting a tab the host merely has
+ *  not heard about yet.
+ *
+ *  Tab ids are uuids and reopen mints a fresh one, so a tombstoned id never legitimately returns. */
+export type ClosedTerminalTabTombstone = {
+  closedAt: number
+  worktreeId: string
+  /** Newest host revision seen for this tab's scope since the close. Retirement needs a STRICTLY
+   *  newer snapshot that omits the tab, so a pull already in flight when the user closed cannot
+   *  acknowledge a close it predates. */
+  ackRevision?: number
+}
+
+export type ClosedTerminalTabTombstonesByTabId = Record<string, ClosedTerminalTabTombstone>
+
+/** Colocated with the type so the two cannot drift. Must survive a relaunch: the whole point of a
+ *  tombstone is that it outlives a `pty.kill` the transport never delivered, and a restart is the
+ *  common case — it was omitted from the session schema once, and the map was silently stripped on
+ *  every launch. */
+export const closedTerminalTabTombstoneSchema = z.object({
+  closedAt: z.number().int().nonnegative(),
+  worktreeId: z.string().min(1),
+  ackRevision: z.number().int().nonnegative().optional()
+})
+
+/** Backstops only — host acknowledgement is the normal exit. These cover a target the user never
+ *  reconnects to, whose tombstones would otherwise never be retired. */
+export const CLOSED_TERMINAL_TAB_TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60 * 1000
+export const MAX_CLOSED_TERMINAL_TAB_TOMBSTONES = 500
+
+export function pruneClosedTerminalTabTombstones(
+  map: ClosedTerminalTabTombstonesByTabId | undefined,
+  now: number
+): ClosedTerminalTabTombstonesByTabId {
+  const entries = Object.entries(map ?? {}).filter(
+    ([, tombstone]) => now - tombstone.closedAt <= CLOSED_TERMINAL_TAB_TOMBSTONE_TTL_MS
+  )
+  entries.sort(([, a], [, b]) => b.closedAt - a.closedAt)
+  return Object.fromEntries(entries.slice(0, MAX_CLOSED_TERMINAL_TAB_TOMBSTONES))
+}
+
+export function recordClosedTerminalTabTombstone(
+  map: ClosedTerminalTabTombstonesByTabId | undefined,
+  tabId: string,
+  worktreeId: string,
+  now: number
+): ClosedTerminalTabTombstonesByTabId {
+  return pruneClosedTerminalTabTombstones({ ...map, [tabId]: { closedAt: now, worktreeId } }, now)
+}
+
+function maxAckRevision(a: number | undefined, b: number | undefined): number | undefined {
+  if (a === undefined) {
+    return b
+  }
+  return b === undefined ? a : Math.max(a, b)
+}
+
+export type ClosedTerminalTabTombstoneAck = {
+  tombstones: ClosedTerminalTabTombstonesByTabId | undefined
+  /** Worktrees this snapshot actually carries a tab row for. A worktree the snapshot says nothing
+   *  about — including one whose path never resolved to a local id — is not evidence of anything,
+   *  so its tombstones are left untouched. */
+  acknowledgedWorktreeIds: ReadonlySet<string>
+  /** Every tab id the snapshot lists, across all worktrees: an id the host still carries anywhere
+   *  has not been acknowledged, whichever worktree it now sits under. */
+  hostKnownTabIds: ReadonlySet<string>
+  hostRevision: number | undefined
+  now: number
+}
+
+/** Retires tombstones the host has demonstrably seen, and stamps the rest with the revision that
+ *  proved it had not yet.
+ *
+ *  Retirement takes a snapshot that both covers the tombstone's worktree and is strictly newer than
+ *  the last one that did — one snapshot alone can be the pull that was already in flight when the
+ *  user closed. Absence never deletes here: a snapshot with no revision, or one carrying no row for
+ *  the worktree, retires nothing. */
+export function reconcileClosedTerminalTabTombstones({
+  tombstones,
+  acknowledgedWorktreeIds,
+  hostKnownTabIds,
+  hostRevision,
+  now
+}: ClosedTerminalTabTombstoneAck): ClosedTerminalTabTombstonesByTabId {
+  const pruned = pruneClosedTerminalTabTombstones(tombstones, now)
+  if (hostRevision === undefined) {
+    return pruned
+  }
+  const kept: ClosedTerminalTabTombstonesByTabId = {}
+  for (const [tabId, tombstone] of Object.entries(pruned)) {
+    if (!acknowledgedWorktreeIds.has(tombstone.worktreeId)) {
+      kept[tabId] = tombstone
+      continue
+    }
+    const observed = tombstone.ackRevision
+    if (!hostKnownTabIds.has(tabId) && observed !== undefined && hostRevision > observed) {
+      continue
+    }
+    kept[tabId] = { ...tombstone, ackRevision: maxAckRevision(observed, hostRevision) }
+  }
+  return kept
+}

--- a/src/shared/terminal-surface-tombstone-schema.ts
+++ b/src/shared/terminal-surface-tombstone-schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+import { terminalTabIdSchema } from './terminal-tab-id-schema'
+
+/** The value schema for `WorkspaceSessionState.terminalSurfaceTombstonesByPaneKey`. Extracted from
+ *  workspace-session-schema.ts, which is at its max-lines limit. */
+export const terminalSurfaceTombstoneSchema = z.object({
+  worktreeId: z.string(),
+  parentTabId: terminalTabIdSchema,
+  leafId: z.string(),
+  ptyId: z.string(),
+  incarnationId: z.string().min(1).max(128),
+  retiredAt: z.number().finite().nonnegative()
+})

--- a/src/shared/terminal-tab-id-schema.ts
+++ b/src/shared/terminal-tab-id-schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+import { isValidTerminalTabId } from './terminal-tab-id'
+
+/** Shared so the session schema and the tombstone value schemas validate tab ids identically.
+ *  Extracted from workspace-session-schema.ts, which is at its max-lines limit. */
+export const terminalTabIdSchema = z
+  .string()
+  .min(1)
+  .refine(isValidTerminalTabId, 'terminal tab id must not contain ":"')

--- a/src/shared/workspace-session-schema-field-coverage.test.ts
+++ b/src/shared/workspace-session-schema-field-coverage.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import type { z } from 'zod'
+
+import { parseWorkspaceSession, workspaceSessionStateSchema } from './workspace-session-schema'
+import type { WorkspaceSessionState } from './workspace-session-state-types'
+
+/**
+ * `workspaceSessionStateSchema` is the load boundary for BOTH partitions —
+ * `normalize-loaded-state-collections.ts` for `local`, `workspace-session-partitions.ts` for
+ * `ssh:<target>`. Zod strips unknown keys and the write side does not validate, so a field declared
+ * on WorkspaceSessionState but missing here reaches disk and is silently discarded on the next
+ * launch.
+ *
+ * That failure is invisible to any test living inside one app process, which is how the closed-tab
+ * tombstone map shipped unpersisted: its unit suites, its e2e oracle and an A/B control were all
+ * green, and the fix still did not survive a quit-and-relaunch.
+ *
+ * Two sibling tables (`profile-project-session-field-disposition.ts`,
+ * `workspace-session-host-field-ownership.ts`) already pin themselves with
+ * `satisfies Record<keyof WorkspaceSessionState, ...>`. This schema had no such guard and is the one
+ * that fell behind, so the ratchet below is the same shape.
+ */
+const PERSISTED_WORKSPACE_SESSION_FIELDS = {
+  activeRepoId: true,
+  activeWorkspaceKey: true,
+  activeWorkspaceExecutionHostId: true,
+  activeWorktreeId: true,
+  activeTabId: true,
+  tabsByWorktree: true,
+  terminalLayoutsByTabId: true,
+  activeWorktreeIdsOnShutdown: true,
+  openFilesByWorktree: true,
+  activeFileIdByWorktree: true,
+  markdownFrontmatterVisible: true,
+  browserTabsByWorktree: true,
+  browserPagesByWorkspace: true,
+  activeBrowserTabIdByWorktree: true,
+  clientHostedBrowserPagesByWorktree: true,
+  clientHostedBrowserCloseIntentsByEnvironment: true,
+  activeTabTypeByWorktree: true,
+  browserUrlHistory: true,
+  activeTabIdByWorktree: true,
+  unifiedTabs: true,
+  tabGroups: true,
+  tabGroupLayouts: true,
+  activeGroupIdByWorktree: true,
+  activeConnectionIdsAtShutdown: true,
+  remoteSessionIdsByTabId: true,
+  lastVisitedAtByWorktreeId: true,
+  defaultTerminalTabsAppliedByWorktreeId: true,
+  sleepingAgentSessionsByPaneKey: true,
+  terminalPtyIncarnationsByPaneKey: true,
+  terminalTopologyRevisionByRepoId: true,
+  terminalSurfaceTombstonesByPaneKey: true,
+  closedTerminalTabTombstonesByTabId: true
+} satisfies Record<keyof WorkspaceSessionState, true>
+
+const MINIMAL_SESSION = {
+  activeRepoId: null,
+  activeWorktreeId: null,
+  activeTabId: null,
+  tabsByWorktree: {},
+  terminalLayoutsByTabId: {}
+}
+
+describe('workspaceSessionStateSchema field coverage', () => {
+  it('parses every field declared on WorkspaceSessionState', () => {
+    // The runtime half. `satisfies` above already makes a forgotten field a compile error; this
+    // reports it by name, and catches the reverse case where the list is updated but the schema
+    // is not.
+    // Why the cast: the export is annotated `z.ZodType<WorkspaceSessionState>`, which hides
+    // `.shape`. The value is a z.object; this reads its keys without widening the public type.
+    const schemaKeys = new Set(
+      Object.keys(
+        (workspaceSessionStateSchema as unknown as z.ZodObject<Record<string, z.ZodTypeAny>>).shape
+      )
+    )
+    const missing = Object.keys(PERSISTED_WORKSPACE_SESSION_FIELDS).filter(
+      (field) => !schemaKeys.has(field)
+    )
+
+    expect(missing, `declared on WorkspaceSessionState but absent from the load schema`).toEqual([])
+  })
+
+  it('round-trips the closed-tab tombstone map through parseWorkspaceSession', () => {
+    // The regression this file exists for. Recorded on close, written to disk, stripped on the next
+    // launch — so a close the transport never delivered resurrected after a quit-and-relaunch,
+    // which is precisely the reported shape ("every day I open orca and it opens more tabs").
+    const parsed = parseWorkspaceSession({
+      ...MINIMAL_SESSION,
+      closedTerminalTabTombstonesByTabId: {
+        'tab-1': { closedAt: 1_700_000_000_000, worktreeId: 'repo:wt-1', ackRevision: 4 }
+      }
+    })
+
+    expect(parsed.ok).toBe(true)
+    expect(parsed.ok && parsed.value.closedTerminalTabTombstonesByTabId).toEqual({
+      'tab-1': { closedAt: 1_700_000_000_000, worktreeId: 'repo:wt-1', ackRevision: 4 }
+    })
+  })
+
+  it('salvages a malformed tombstone entry rather than dropping the whole map', () => {
+    const parsed = parseWorkspaceSession({
+      ...MINIMAL_SESSION,
+      closedTerminalTabTombstonesByTabId: {
+        'tab-good': { closedAt: 1, worktreeId: 'repo:wt-1' },
+        'tab-bad': { closedAt: 'nope', worktreeId: 'repo:wt-1' }
+      }
+    })
+
+    expect(parsed.ok).toBe(true)
+    expect(
+      Object.keys((parsed.ok && parsed.value.closedTerminalTabTombstonesByTabId) || {})
+    ).toEqual(['tab-good'])
+  })
+})

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -12,12 +12,14 @@
  * Only a payload that is not a session at all falls back to defaults.
  */
 import { z } from 'zod'
+import { closedTerminalTabTombstoneSchema } from './closed-terminal-tab-tombstones'
 import type { WorkspaceKey } from './folder-workspace-types'
 import type { TabGroupLayoutNode } from './tab-types'
 import type { TerminalPaneLayoutNode } from './terminal-tab-types'
 import type { TuiAgent } from './tui-agent'
 import type { WorkspaceSessionState } from './workspace-session-state-types'
-import { isValidTerminalTabId } from './terminal-tab-id'
+import { terminalTabIdSchema } from './terminal-tab-id-schema'
+import { terminalSurfaceTombstoneSchema } from './terminal-surface-tombstone-schema'
 import { parseExecutionHostId, type ExecutionHostId } from './execution-host'
 import { isTuiAgent } from './tui-agent-config'
 import { isWorkspaceKey } from './workspace-scope'
@@ -35,10 +37,6 @@ import { salvagedField, salvagedOptional, salvagingArray, salvagingRecord } from
 // ─── Terminal pane layout (recursive) ───────────────────────────────
 
 const terminalPaneSplitDirectionSchema = z.enum(['vertical', 'horizontal'])
-const terminalTabIdSchema = z
-  .string()
-  .min(1)
-  .refine(isValidTerminalTabId, 'terminal tab id must not contain ":"')
 const workspaceKeySchema = z.custom<WorkspaceKey>(
   (value) => typeof value === 'string' && isWorkspaceKey(value)
 )
@@ -190,15 +188,6 @@ const tabGroupLayoutNodeSchema: z.ZodType<TabGroupLayoutNode> = z.lazy(() =>
 
 // ─── Workspace session ──────────────────────────────────────────────
 
-const terminalSurfaceTombstoneSchema = z.object({
-  worktreeId: z.string(),
-  parentTabId: terminalTabIdSchema,
-  leafId: z.string(),
-  ptyId: z.string(),
-  incarnationId: z.string().min(1).max(128),
-  retiredAt: z.number().finite().nonnegative()
-})
-
 const worktreeIdSchema = z.string()
 
 export const workspaceSessionStateSchema: z.ZodType<WorkspaceSessionState> = z.object({
@@ -314,6 +303,10 @@ export const workspaceSessionStateSchema: z.ZodType<WorkspaceSessionState> = z.o
   terminalSurfaceTombstonesByPaneKey: salvagedOptional(
     'terminalSurfaceTombstonesByPaneKey',
     salvagingRecord(z.string(), terminalSurfaceTombstoneSchema)
+  ),
+  closedTerminalTabTombstonesByTabId: salvagedOptional(
+    'closedTerminalTabTombstonesByTabId',
+    salvagingRecord(terminalTabIdSchema, closedTerminalTabTombstoneSchema)
   )
 })
 

--- a/src/shared/workspace-session-state-types.ts
+++ b/src/shared/workspace-session-state-types.ts
@@ -6,6 +6,7 @@ import type { TerminalLayoutSnapshot, TerminalTab } from './terminal-tab-types'
 import type { BrowserHistoryEntry, BrowserPage, BrowserWorkspace } from './browser-workspace-types'
 import type { ClientHostedBrowserCloseIntent } from './client-hosted-browser-close-intent'
 import type { PersistedClientHostedBrowserPage } from './client-hosted-browser-page-record'
+import type { ClosedTerminalTabTombstonesByTabId } from './closed-terminal-tab-tombstones'
 
 /** Minimal subset of OpenFile persisted across restarts.
  *  Only edit-mode files are saved — diffs, conflict reviews, and other
@@ -124,6 +125,9 @@ export type WorkspaceSessionState = {
       retiredAt: number
     }
   >
+  /** Terminal tabs this client watched the user close, kept until the host's own snapshot stops
+   *  listing them. See shared/closed-terminal-tab-tombstones.ts for why absence alone cannot say it. */
+  closedTerminalTabTombstonesByTabId?: ClosedTerminalTabTombstonesByTabId
 }
 
 export type WorkspaceSessionPatch = Partial<WorkspaceSessionState>

--- a/tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts
+++ b/tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts
@@ -1,0 +1,198 @@
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { waitForActivePanePtyId, waitForActiveTerminalManager } from './helpers/terminal'
+import { createRemoteTerminalTab } from './helpers/docker-ssh-relay-terminal-tabs'
+import {
+  cleanupDockerSshRelayTarget,
+  startDockerSshRelayTarget,
+  type DockerSshRelayTarget
+} from './helpers/docker-ssh-relay-target'
+import {
+  readDockerSshRelayProcessSnapshot,
+  terminateDockerSshRelay
+} from './helpers/docker-ssh-relay-processes'
+import {
+  connectDockerSshRelayTarget,
+  disconnectDockerSshRelayTarget,
+  reconnectDisconnectedDockerSshRelayTarget
+} from './helpers/docker-ssh-relay-connection'
+
+const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
+const DROP_CYCLES = 3
+
+test.use({ seedTestRepo: false })
+
+async function readWorktreeTabIds(page: Page, worktreeId: string): Promise<string[]> {
+  return page.evaluate(
+    (id) => (window.__store?.getState().tabsByWorktree[id] ?? []).map((tab) => tab.id),
+    worktreeId
+  )
+}
+
+/** Poll until the tab set stops changing, so a resurrection that lands late still counts. */
+async function waitForSettledTabIds(page: Page, worktreeId: string): Promise<string[]> {
+  let latest: string[] = []
+  let previousKey = ''
+  let agreements = 0
+  await expect
+    .poll(
+      async () => {
+        latest = await readWorktreeTabIds(page, worktreeId)
+        const key = latest.join()
+        agreements = key === previousKey ? agreements + 1 : 0
+        previousKey = key
+        return agreements
+      },
+      { timeout: 60_000, intervals: [1_000], message: 'the tab set never stopped changing' }
+    )
+    .toBeGreaterThanOrEqual(3)
+  return latest
+}
+
+/**
+ * Kill the relay daemon so the next RPC rejects with a transport-class error.
+ *
+ * Why this and not a disconnect: `pty.kill` has to FAIL, not succeed against a dead session.
+ * A transport rejection ("Multiplexer disposed" / CONNECTION_LOST) does not match
+ * isPtyAlreadyGoneError, so the lease is never marked terminated and nothing retries it —
+ * that unterminated lease is what the next reattach mistakes for a live PTY.
+ */
+function dropRelayTransport(target: DockerSshRelayTarget): void {
+  const snapshot = readDockerSshRelayProcessSnapshot(target)
+  if (!snapshot) {
+    throw new Error('No Docker SSH relay process group to terminate')
+  }
+  terminateDockerSshRelay(target, snapshot)
+}
+
+async function dumpAuthority(page: Page, worktreeId: string, label: string): Promise<void> {
+  const d = await page.evaluate(async (id) => {
+    const persisted = await window.api.session.get()
+    const state = window.__store?.getState()
+    const repoId = Object.entries(state?.worktreesByRepo ?? {}).find(([, ws]) =>
+      ws.some((w) => w.id === id)
+    )?.[0]
+    return {
+      repoId: repoId?.slice(0, 8) ?? null,
+      topologyRev: persisted.terminalTopologyRevisionByRepoId ?? null,
+      tombstones: Object.keys(persisted.terminalSurfaceTombstonesByPaneKey ?? {}).length,
+      storeTabs: (state?.tabsByWorktree[id] ?? []).length
+    }
+  }, worktreeId)
+  console.log(`[auth ${label}] ${JSON.stringify(d)}`)
+}
+
+async function closeTerminalTab(page: Page, tabId: string): Promise<void> {
+  await page.evaluate((id) => {
+    const state = window.__store?.getState()
+    if (!state) {
+      throw new Error('Store unavailable')
+    }
+    state.closeTab(id)
+  }, tabId)
+}
+
+/**
+ * Run N cycles of: make a tab, disrupt the transport, close the tab, reconnect.
+ *
+ * `disrupt` is the only variable — the two callers differ solely in HOW the transport goes away,
+ * so a difference in outcome is attributable to that and nothing else.
+ */
+async function runResurrectionCycles(
+  page: Page,
+  testInfo: TestInfo,
+  disrupt: (target: DockerSshRelayTarget, targetId: string) => Promise<void> | void
+): Promise<void> {
+  let target: DockerSshRelayTarget | null = null
+  try {
+    target = startDockerSshRelayTarget(testInfo)
+    await waitForSessionReady(page)
+    const remote = await connectDockerSshRelayTarget(page, target)
+    await expect
+      .poll(() => waitForActiveWorktree(page), { timeout: 30_000 })
+      .toBe(remote.worktreeId)
+    await waitForActiveTerminalManager(page, 60_000)
+    await waitForActivePanePtyId(page, 60_000)
+    const baseline = await waitForSettledTabIds(page, remote.worktreeId)
+
+    const perCycle: { closedTabId: string; afterIds: string[] }[] = []
+    for (let cycle = 0; cycle < DROP_CYCLES; cycle += 1) {
+      // Created while the transport is healthy — the disruption has to land between close and
+      // reattach, not before the tab has a PTY to leave a lease behind.
+      const beforeCreate = await waitForSettledTabIds(page, remote.worktreeId)
+      await createRemoteTerminalTab(page, remote.worktreeId)
+      const withExtra = await waitForSettledTabIds(page, remote.worktreeId)
+      // Diffed against the PREVIOUS cycle's tabs, not the baseline: once a cycle resurrects a tab,
+      // a baseline diff picks that survivor instead of the tab this cycle just made, and every
+      // later cycle would close the same stale tab and measure nothing.
+      const closedTabId = withExtra.find((tabId) => !beforeCreate.includes(tabId))
+      if (!closedTabId) {
+        throw new Error('The extra SSH tab was never added')
+      }
+
+      await dumpAuthority(page, remote.worktreeId, `cycle${cycle + 1}-before-close`)
+      await disrupt(target, remote.targetId)
+      await closeTerminalTab(page, closedTabId)
+      await reconnectDisconnectedDockerSshRelayTarget(page, remote.targetId)
+      await waitForActiveTerminalManager(page, 60_000)
+      perCycle.push({
+        closedTabId,
+        afterIds: await waitForSettledTabIds(page, remote.worktreeId)
+      })
+      await dumpAuthority(page, remote.worktreeId, `cycle${cycle + 1}-after-reconnect`)
+    }
+
+    const growth = perCycle
+      .map(
+        (entry, index) =>
+          `drop${index + 1}=${entry.afterIds.length}${entry.afterIds.includes(entry.closedTabId) ? ' (closed tab returned)' : ''}`
+      )
+      .join(' ')
+    const summary = `baseline=${baseline.length} ${growth}`
+    for (const [index, entry] of perCycle.entries()) {
+      expect(
+        entry.afterIds,
+        `drop ${index + 1} resurrected the closed tab ${entry.closedTabId}: ${summary}`
+      ).not.toContain(entry.closedTabId)
+    }
+    expect(
+      perCycle.map((entry) => entry.afterIds.length),
+      `tabs accumulated across dropped-transport closes: ${summary}`
+    ).toEqual(perCycle.map(() => baseline.length))
+  } finally {
+    cleanupDockerSshRelayTarget(target)
+  }
+}
+
+test.describe('SSH lost kill tab resurrection', () => {
+  test.skip(!RUN_DOCKER_SSH, 'Set ORCA_E2E_SSH_DOCKER=1 to run Docker-backed SSH tests.')
+  test.skip(process.platform === 'win32', 'Docker SSH restore uses POSIX SSH tooling.')
+
+  // STA-3374. A tab closed while the transport is down leaves an unterminated remote lease: the
+  // rejected `pty.kill` is a transport error, not an already-gone one, so nothing retires it. The
+  // relay also restarts its pty counter at pty-1, so a later tab is handed the same id and
+  // upsertSshRemotePtyLease — keyed on (targetId, ptyId) alone — collides with that stale lease
+  // instead of minting a fresh one. The next reattach then re-mints the tab through
+  // pty-binding-persistence.ts:145-160, and the resurrected tab never retires.
+  test('does not resurrect tabs whose kill was lost to a killed relay daemon', async ({
+    orcaPage
+  }, testInfo) => {
+    test.setTimeout(600_000)
+    await runResurrectionCycles(orcaPage, testInfo, (target) => {
+      dropRelayTransport(target)
+    })
+  })
+
+  // The same close, reached the way a user reaches it: disconnect the host, close the tab, come
+  // back. No daemon is killed. If this resurrects too, the bug needs no process death at all — a
+  // laptop lid and a dropped link are enough.
+  test('does not resurrect tabs closed while the host is disconnected', async ({
+    orcaPage
+  }, testInfo) => {
+    test.setTimeout(600_000)
+    await runResurrectionCycles(orcaPage, testInfo, async (_target, targetId) => {
+      await disconnectDockerSshRelayTarget(orcaPage, targetId)
+    })
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​738 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​737 |
| Prod | 19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​303 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​34 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​269 |

<!-- /orca-pr-loc -->

**Stack: 6 of 6 — based on #16751.** This is the headline fix.

## ELI5 — this is the fix for "every day I open orca it opens more tabs"

**What you saw:** every morning, one more tab than yesterday, forever.

**Why it happened:**

1. You close an SSH terminal tab.
2. Orca tells the remote machine *"kill that shell"* — but the connection is already dead (laptop slept, Wi-Fi dropped, relay crashed). **The message never arrives.**
3. The remote's own list still has that tab on it. Correctly — nobody ever told it otherwise.
4. Next time you connect, Orca reads that list and puts the tab back. Also correctly — the remote is supposed to be the source of truth.
5. The tab reopens, and it never goes away.

Nobody's code was wrong in isolation. Your close simply evaporated between the two of them.

**The fix:** when you close a tab, Orca now writes down *"the user closed this"* and keeps that note until the remote machine actually confirms it. The note wins over the remote's stale list. Once the remote catches up, the note is thrown away.

**The bit that nearly slipped through:** the note was being saved to disk but silently discarded on every app launch, because it was missing one line in the file that validates saved data. That would have made it work for one session and fail you again the next morning — the exact "every day" pattern you reported. Caught in review, not by a test, so there's now a check that makes forgetting that line a compile error.

**How we know it works:** flip the one line off and the tab comes back 2 out of 2 runs. Leave it on and it never comes back — 0 resurrections across six runs plus a full 19-test suite.

---

## Symptom

An enterprise user, three reports over a week:

> "Every day I open orca and it opens more tabs daily at a linear scale."

They were told on 08-19 that a PR had fixed it, and reported it twice more after. STA-4658 (P0, os:macos), GH #12447, #15136, #10342, #9585. One install held **39 zombie tab records**.

It is not only cosmetic. The revived tab's sleeping-agent record still holds the **pre-close session id**, so it boots `claude --resume <old id>` — **two agents writing one transcript.** STA-3498 observed up to five concurrent `claude` processes on a single transcript.

## Reproduction

`tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts` reproduces it deterministically: close an SSH tab → kill the relay daemon in the container so `pty.kill` rejects with a transport-class error → reconnect.

```
drop 2 resurrected the closed tab <id>:
  baseline=1  drop1=1  drop2=2 (closed tab returned)  drop3=1
```

Two runs, different tab ids, byte-identical shape.

**The trigger is narrower than "any reconnect", and this had to be measured rather than assumed.** Both variants live in the spec behind one `runResurrectionCycles` parameterized *solely* by the disruption, so the difference is attributable to that single variable:

| Disruption | Result |
|---|---|
| killed relay daemon | `drop2=2`, resurrects — **6 of 6 runs** |
| `ssh.disconnect` (orderly) | passes, no resurrection |

An orderly disconnect either lands the kill or terminates the lease through the disconnect path. Only an **ungraceful** loss — network partition, host reboot, relay crash, a laptop sleeping mid-session without a clean disconnect — strands the close with the RPC rejecting on a transport-class error. All plausible for "every day"; the fix is justified on that narrower basis. Corroborating from a Slack thread: the reporting user says *"if i close my laptop, my claude/codex sessions are interrupted"* on a remote SSH env, and separately hit `thread <uuid> already has an active writer` on reattach — exactly the orphaned-remote-writer shape.

## Root cause

The **pull** path carries the closed tab back (`workspace.get` → `getRemoteSnapshot`, `src/main/ipc/remote-workspace-relay-sync.ts:29`). Measured:

```
pullSnapshot rev=0 tabs={}
pullSnapshot rev=3 tabs={repo:["16c4a3e1","06aba6b6"]}
pullSnapshot rev=4 tabs={repo:["16c4a3e1","ff72768e"]}   ← ff72768e IS the resurrected tab
pullSnapshot rev=5 tabs={repo:["16c4a3e1","ff72768e","da21b76c"]}
```

The chain:

1. The client uploads the session containing the tab.
2. The user closes the tab. The kill RPC rejects — **the close never reaches the host** (transport dead).
3. The host's snapshot still lists it (rev 4).
4. On reconnect the client **pulls** that snapshot and the merge restores the tab — **correctly, by its own rule that the host is authoritative for what it knows.**
5. A pane mounts (a pane cannot mount for a tab absent from the store), respawns via `spawnIpcPty` (`ipc-pty-spawn-request.ts:33`), and takes the recycled pty id.

Client-side correlation from a single instrumented run — **two controls and one positive, differing in exactly one variable**:

| Tab | Close events observed | Resurrected? |
|---|---|---|
| `6305cc07` | `user` + `pty-exit` | No |
| `ed56f66c` | `user` + `pty-exit` | No |
| `2036e760` | `user` **only** | **YES** |

`pty-exit` is what would have driven the removal all the way to the host. When the transport is dead it never arrives.

### Eliminated candidates — recorded so nobody re-walks them

Every one of these is a plausible fix location that a reviewer may reasonably propose. Each was eliminated **by measurement or by reader analysis, not by argument.** They all missed for the same reason: they are downstream of the real defect, and by the time they see it the tab is *legitimately present* in local state, because the close never completed.

| Candidate | How it was eliminated |
|---|---|
| **The reattach fence** (`mayCreate`, #16751) | Instrumented run: `CREATING TAB` **9 hits**, `reattach gate` **0**, `BYPASS` **0**. `restoreReattachedPtyRuntime` is never called in this scenario — the fence is on a path this bug does not take. It is a real fix for a *different* defect; see #16751, which says so itself. |
| **Lease inheritance** (`spawn-commit-persist.ts:76-84`) | Statically refuted. `persistPtyBinding` builds from `args.tabId`, never the lease row; and the tab-create gate at `:97-103` is the *same pair of expressions* as the conditional spreads at `:80-81`, so any run that can emit `CREATING TAB` is one where the upsert supplied both fields and overwrote. The defect is real and latent — worth its own ticket — but cannot produce these events. |
| **The lease as identity carrier** | Reader analysis. Only two readers of `getSshRemotePtyLeases` outside persistence: `ssh-connection-handlers.ts:67,103` (reset/terminate only, never produces a tab) and `orca-runtime.ts:8021` `getRecentExpiredSshLease`, which is queried *with* `(worktreeId, tabId, leafId)` as input and so cannot supply identity. The lease is a **co-symptom of the relay restart, not the carrier** — the same restart that recycles `pty-2` is what strands the lease. |
| **`kill.ts:82-84`** skipping `finishPtyShutdown` on a non-already-gone error | The implied fix — `markSshRemotePtyLease(…, 'expired')` in that branch — was implemented, **changed nothing**, and was reverted rather than shipped unproven. |
| **A collision guard for `upsertSshRemotePtyLease`** | Built, tested, and removed: its own test passed with the guard *disabled*, i.e. vacuous. Telling "same lease" from "recycled id on a different shell" from lease state alone needs a relay-start identity — a twelfth per-tab identity concept. See #16751. |

> **Measurement trap worth its own warning.** An early probe reported `inboundSnapshot tabs={}` on all 5 occurrences and `grep -cF <tab>` over every inbound line → **0**, which reads as proof the host never republishes the closed tab. **That probe was on the push-notification path only.** The **pull** path (`workspace.get` → `getRemoteSnapshot`) is the carrier, and it plainly lists the tab at rev 4. A push-path probe alone will exonerate the host every time. Both paths must be sampled before concluding anything about what the host serves.

**Structural finding worth its own ticket:** `toAppSshPtyId` is purely `connectionId + relayPtyId`. When the relay reissues `pty-2` the **app-level id is byte-identical** — the closed pane's durable binding and the new shell's binding are the same string. No id-based disambiguation exists anywhere in this stack once the relay's counter resets, which is why every id-keyed defence in this area is structurally unable to work.

## The fix, and why this shape

**A user-initiated close is first-party intent and must survive until the host acknowledges it.** Per `docs/reference/ssh-execution-boundary.md` the remote verdict is `unverifiable` — which may not authorise declaring the process dead, but equally **must not authorise resurrecting the tab**. This is SSH-v3 principle **P2**, "durable tombstones with a monotonic per-scope revision", reusing the existing `RemoteWorkspaceSnapshot.revision` rather than adding a **twelfth** per-tab identity field (the codebase carries eleven, 784 refs, that the redesign's Phase 3 deletes).

`src/shared/closed-terminal-tab-tombstones.ts`, 99 lines:

- **Recorded** only on `closeReason === 'user'` (`src/renderer/src/store/terminals/terminal-tab-close.ts:69`) — narrowed from #16571's `user || cleanup`.
- **Suppresses** a host-sourced tab only when `tabId in tombstones && !currentTabsById.has(tabId)`. A live local tab always wins: deleting a live pane is the one outcome the merge exists to avoid.
- **Retires on positive acknowledgement**: `!hostKnownTabIds.has(tabId) && hostRevision > observed`. **Strictly** newer, so a pull already in flight at close time cannot ack a close it predates.
- Three never-retire guards: no revision retires nothing; a worktree the snapshot has no row for retires nothing; the first omitting snapshot only stamps the watermark.
- TTL (30d) + cap (500) are **backstops** for a target the user never returns to — not the mechanism.
- **Client-local only.** It never crosses the wire, so there is no mixed-version exposure.
- Suppression is scoped to `replaceWorktreeIds`, which is what makes the live-tab check meaningful. A final whole-map sweep over the assembled `tabsByWorktree` would break exactly that (a live tab is absent from `currentTabsById` outside the scope and would look suppressible). It is deliberately not there, and the comment at the top of the function says so.

## Evidence

**The load-bearing evidence is an A/B control on one tree, not the oracle's assertion.** Flipping `isSuppressedByClose` to `false` — one character — reproduces the resurrection on demand:

```
isSuppressedByClose forced to false, --repeat-each=2:
  1) drop 2 resurrected the closed tab ab0e305d-…: baseline=1 drop1=1 drop2=2
  2) drop 2 resurrected the closed tab 51533e34-…: baseline=1 drop1=1 drop2=2
  2 failed  ← resurrection reproduces on demand

suppression ON, five runs + one independent run by a second agent:
  0 occurrences of "resurrected the closed tab"
```

**Provenance verified positively, not by mtime.** `closedTerminalTabTombstonesByTabId` appears **13×** across 3 renderer chunks including `store-Do3KBvRE.js`. For every red control run, `mayCreate` appeared **0×** in `out/main/index.js`, establishing those runs were against a build without the PR-5 fence. (A first provenance grep read 0 — it had matched a different `store-*` chunk. The check was wrong, not the build.)

At the unit layer, disabling the same predicate:

```
 FAIL  remote-workspace-session-merge-close-tombstones.test.ts > does not re-insert a tombstoned tab the host still lists
 FAIL  … > does not re-add a tombstoned tab through the host-unknown branch
 FAIL  … > suppresses only the tombstoned tab, leaving its siblings and the pointers alone
      Tests  3 failed | 39 passed (42)
```

Restored:

```
 Test Files  4 passed (4)      Tests  24 passed (24)    # the four tombstone suites
 Test Files 41 passed (41)     Tests 287 passed (287)   # + workspace-session, terminal store, remote-workspace, profiles

$ pnpm tc → clean
$ pnpm test config/scripts/pr-e2e-gate-contract.test.mjs → 36 passed
$ pnpm run check:code-quality:changed → 0 new findings across 55 changed files
$ node config/scripts/check-max-lines-ratchet.mjs → OK, no new bypasses
```

## The oracle spec: GREEN in the full lane

**Both oracle tests pass at the stack tip.** Full Docker-SSH lane at `49bb96e0b4c`, clean tree:

```
BUILD_SHA=49bb96e0b4c135ce305a2f4dfe2d4b52e0b19cde   DIRTY=0
PROVENANCE  tombstone=13  hasLocalTabsRow=2  hostAuthority=4  mayCreate=3
14 specs / 20 tests → 17 passed, 2 failed, 1 skipped (10.7m)

[12/20] ssh-lost-kill-tab-resurrection.spec.ts:178 › does not resurrect tabs whose kill was lost to a killed relay daemon   PASSED
[13/20] ssh-lost-kill-tab-resurrection.spec.ts:190 › does not resurrect tabs closed while the host is disconnected          PASSED

grep -c "resurrected the closed tab"  (whole lane)  → 0
```

Note that the oracle passes **without PR 7 in the build** — `mayCreate=3` confirms #16751's fence is present, and `SshPtyAbsentFromRelayError` is absent — so the bug-2 fix below is **not** required for this to hold.

### An honest note on test 1's stability

Test 1 fails **intermittently in isolated single-spec runs**, where a third defect blocks its cycle-2 *setup*. It **passes in the full lane**, where it completed every cycle. **The resurrection assertion itself has never failed with this fix in place** — the intermittent failure is always a setup failure, never a resurrected tab.

Stated so nobody is surprised in either direction: a reviewer who runs the spec in isolation may see it go red, and that is not this fix regressing.

### The three defects under STA-3374, kept distinct

| | Defect | Status |
|---|---|---|
| **Bug 1** | The closed tab resurrects on reconnect | **This PR fixes it** — oracle green, A/B below |
| **Bug 2** | `ssh-pty-session-reattach.ts:227-231` rewrites the relay's `PTY "pty-1" not found` into a bare `SSH_SESSION_EXPIRED`, so `isPtyAlreadyGoneError`'s `/PTY ".+" not found/` cannot match and `attachStablePaneOwner:242`'s already-correct fallback never runs | **PR 7** — `nwparker/ssh-07-absent-from-relay`. Not required for this PR's oracle to pass |
| **Bug 3** | After the daemon is killed and the client launches a replacement, the client's **own SSH transport** drops and does not complete a reconnect inside 60s — no "delay step 2/9", no handshake failure, nothing. `ssh-connection.ts:1533` only logs on an SSH-level close | **Unfixed, own ticket.** Cause of test 1's intermittent setup failure in isolation |

### The isolating discriminator for bug 3

> `[ssh-relay] Socket probe result:` reads `"DEAD"` on every cycle of test 1 (daemon killed, client must launch a NEW relay) and `"ALIVE"` on every cycle of test 2 (daemon survived, client reconnects to the existing socket). Whenever a new daemon must be launched, the SSH transport drops afterwards and does not recover.

**Scope of that measurement:** it was observed in the isolated single-spec runs where bug 3 reproduced. The full lane above ran **without** `ORCA_E2E_FORWARD_APP_LOGS=1`, so main-process stdout was not captured and the probe was **not** re-confirmed there. Reported as measured, not as re-verified.

### Why the `SSH_SESSION_EXPIRED` rejection is a red herring

It is real, but it is not what fails cycle 2 in the isolated runs. Log ordering settles it: the rejection fires during **cycle 1's** reconnect for the **baseline** pane — `spawn() called … pty-1` → `pty.attach FAILED … PTY "pty-1" not found` → `Error occurred in handler for 'pty:spawn'` — and then **cycle 1 completes** (`[auth cycle1-after-reconnect] storeTabs:1`). The 60s silence begins only afterwards, following `Relay channel lost …, triggering reconnect` and `waiting 15000ms`. The failure screenshot shows the pane rendering the **"Relay channel lost. Reconnecting…"** placeholder: the tab never gets a PTY because **the host is unreachable**, not because a stale lease misrouted its spawn.

The `kill.ts:82-84` theory was tested directly as well and eliminated — see **Eliminated candidates** above.

### The A/B control, which still matters

The green oracle is the headline evidence. The A/B remains the stronger *causal* statement, because it varies exactly one character:

```
isSuppressedByClose forced to false, --repeat-each=2:
  1) drop 2 resurrected the closed tab ab0e305d-…: baseline=1 drop1=1 drop2=2
  2) drop 2 resurrected the closed tab 51533e34-…: baseline=1 drop1=1 drop2=2
  2 failed          ← reproduces on demand

suppression ON: 0 occurrences of "resurrected the closed tab" across six runs
                plus the full-lane run above
```

A green test says "the bug did not occur". The A/B says "this line is why". Both are here.

The spec is claimed by the Docker-SSH lane (required by the gate-contract assertion added in #16746), and **that lane does not gate merges today** (`pr.yml:796-821`, deliberate, pinned by the contract).

## Can a tab the user did NOT close disappear?

No — but the guarantee needs stating precisely, because the obvious slogan is false.

The only writer is `recordClosedTerminalTabTombstone` (`terminal-tab-close.ts:69`), reachable only on `closeReason === 'user'`. Suppression additionally requires the tab not be live locally. Reopen (`recently-closed-tabs.ts:122-166`) calls `createTab` and restores cwd/shell/title/color/position, **never the old id**.

> **Caveat:** `createTab` honours a caller-supplied id hint (`src/renderer/src/store/terminals/terminal-tab-creation.ts:53-65`, used by `useIpcEvents` for host-admitted tabs), so **"tab ids are uuids that never recur" is NOT literally true in this codebase.** The guarantee rests on `closeReason === 'user'` being the only writer, plus the live-local-tab check — not on id uniqueness.

## Persistence: the tombstone had to survive a relaunch, and did not

`closedTerminalTabTombstonesByTabId` is declared on `WorkspaceSessionState` but was **missing from `workspaceSessionStateSchema`** — the load boundary for **both** partitions (`normalize-loaded-state-collections.ts` for `local`, `workspace-session-partitions.ts` for `ssh:<target>`). Zod strips unknown keys and the write side does not validate, so the map reached disk and was discarded on the next launch. Measured with the repo's own parser:

```
input : closedTerminalTabTombstonesByTabId: { 'tab-1': {...} }
ok    = true
tombstones after parse = undefined
```

**That made the headline fix ineffective in the reported scenario.** Close an SSH tab with the transport down → tombstone recorded → **quit** → relaunch → connect → the merge runs with an empty map → the host still lists the tab → it resurrects. *"Every day I open orca and it opens more tabs"* is a claim about restarts. It also made the 30-day TTL and 500 cap unreachable.

**Neither the green oracle nor the A/B control could see it** — both run entirely inside one app process. Without the schema entry: **3 failed**. With it: **3 passed**.

`workspace-session-schema-field-coverage.test.ts` is the ratchet, in both directions: a `satisfies Record<keyof WorkspaceSessionState, true>` list that makes a forgotten field a **compile** error, plus a runtime assertion that names it — which also catches the reverse case, list updated but schema not. Two sibling tables already pin themselves this way; this schema was the unguarded third, which is why it fell behind.

**Why this PR adds two small files.** `workspace-session-schema.ts` was **one line** under its 300-line limit, and `max-lines` disables and per-file bumps are both forbidden. Two value schemas moved to modules named for their contents — `terminal-tab-id-schema.ts` and `terminal-surface-tombstone-schema.ts` — and the closed-tab tombstone's schema is now colocated with its type in `closed-terminal-tab-tombstones.ts`. **That colocation is the structural fix, not a workaround: separating a type from its schema is what caused this bug in the first place.**

## A host tab the user never closed could be deleted

`tabId in closedTerminalTabTombstonesByTabId` answers `true` for every `Object.prototype` key **even on an empty map**, because the map is a plain object from `Object.fromEntries`. A host tab whose id is `toString` was filtered from the reconciled list, blocked from the host-unknown branch, and stripped of its layout and session id. Tab ids are validated only as non-empty and colon-free, and `createTab` honours caller-supplied id hints, so the id is reachable rather than theoretical. **This was the only path in either direction that could delete a tab the user never closed.**

Now `Object.hasOwn`, as the same file already uses elsewhere. Suppression is also scoped structurally — `isSuppressedByClose` compares the tombstone's stored `worktreeId`, so it cannot reach another workspace's tab — and the two sweeps that have no worktree in scope (`terminalLayoutsByTabId`, `remoteSessionIdsByTabId`) now consult the set of ids **this merge actually suppressed** rather than re-deriving a verdict without that scope.

**The scope comment at the top of the function was also wrong and is corrected.** It claimed every use of suppression sits inside `replaceWorktreeIds`; it does not — the tabs pass walks all of `orderedWorktreeIds` and both sweeps cover the whole remote maps. What actually makes it safe is `closeTab` stripping the id from every worktree row before recording, plus the worktree match, plus `closeReason === 'user'` being the only writer. Real guarantee, different from the documented one.

Both fixes have failing-first proof:

```
× does not suppress a host tab whose id collides with an Object.prototype key
× does not suppress a tombstoned id under a DIFFERENT worktree
```

## Divergences from open PR #16571

#16571 implements the same concept (`closedTerminalTabTombstonesByTabId`, `mergeClosedTerminalTabTombstones`, `normalizeClosedTabTombstonesByTabId`) and now has a deterministic repro proving it is needed. The core is ported with **three deliberate changes**:

1. **It never retires on acknowledgement** — TTL + cap only, so it never converges. Ack retirement added.
2. **It crosses the wire and lets a HOST-sourced tombstone delete a LOCAL tab** in a final whole-map sweep. After #14361 that is the wrong risk; dropped. This also removes the mixed-version regression its own body flags.
3. **Hydration replaces rather than unions** the map. A union resurrects every tombstone the merge just retired, so it never converges.

Its `activeTabId` nulling is also dropped as redundant: `workspace-terminal-hydration.ts:99-105,126-138` already revalidates both pointers against the tab rows it just built, and nulling twice would add a second rule that has to stay in step with the first.

## Deliberately NOT done

- **No per-tab generation or identity field.** Forbidden by the redesign; the revision watermark is per-target and already exists.
- **No wire change.** The tombstone map is client-local. That is a deliberate divergence from #16571 and it is what removes the mixed-version exposure.
- **No whole-map close-suppression sweep** over the assembled `tabsByWorktree` — see the scoping note above.
- **Bugs 2 and 3 of STA-3374** — the error-class rewrite (`ssh-pty-session-reattach.ts:227-231`, owned by `nwparker/ssh-07-absent-from-relay`) and the SSH transport that never reconnects after a new daemon is launched (unfixed, own ticket). Neither is touched here. See the RED-oracle section.
- **The partition split-brain** (#12721/#12723, STA-3980) and **STA-3593** (host tabs never reaching the store) are untouched.

## Risk / blast radius

Renderer-side, client-local, **no wire change**. Blast radius is `mergeDirectSshRemoteWorkspaceSession` plus one persisted session field.

Worst case if the ack logic were wrong in the *retiring* direction: a tombstone outlives its usefulness and suppresses a host tab whose id the host re-issues — bounded by the live-local-tab check, the 30-day TTL and the 500 cap. Worst case in the other direction is today's behaviour.

`src/main/orca-profiles/profile-project-session-field-disposition.ts` records the new field as `notRepoScoped` / `notTransferred` residue — keyed by tab id and pruned by neither path, like `remoteSessionIdsByTabId` — bounded by the same TTL and cap, and a resolved host retires its own entries.

## How to verify

```
pnpm test src/shared/closed-terminal-tab-tombstones.test.ts \
  src/renderer/src/lib/workspace-session-closed-tab-tombstones.test.ts \
  src/renderer/src/store/terminals/terminal-tab-close-tombstone.test.ts \
  src/renderer/src/hooks/remote-workspace-session-merge-close-tombstones.test.ts
```

To reproduce the bug this fixes, set `isSuppressedByClose` to `() => false` in `src/renderer/src/hooks/remote-workspace-session-merge.ts` and run (needs Docker):

```
pnpm test:e2e:ssh-docker -- tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts --repeat-each=2
```

---

# End-to-end verification

## Specs this PR routes to

```
$ git diff --name-only nwparker/ssh-05-reattach-fence..nwparker/ssh-06-close-tombstone \
    | node config/scripts/pr-e2e-source-routing.mjs
["tests/e2e/paired-remote-pane-layout-retry.spec.ts",
 "tests/e2e/ssh-cold-activation-restore.spec.ts",
 "tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts",
 "tests/e2e/ssh-reconnect-tab-destruction.spec.ts",
 "tests/e2e/terminal-quick-command-pre-bind-recovery.spec.ts"]

$ … | node config/scripts/pr-e2e-source-routing.mjs --ssh-source
true
```

Under `main`'s router this routed to 3; #16746 adds `ssh-cold-activation-restore` and `ssh-reconnect-tab-destruction` — the two specs that guard this exact regression class. `ssh-lost-kill-tab-resurrection.spec.ts` is new here and is added to the lane runner in the same commit, as the gate contract requires.

## Lane result

Full Docker-SSH lane at the stack tip, which covers this PR's routed set:

```
$ pnpm test:e2e:ssh-docker
BUILD_SHA=49bb96e0b4c135ce305a2f4dfe2d4b52e0b19cde   DIRTY=0
14 specs / 20 tests → 17 passed, 2 failed, 1 skipped (10.7m)

[12/20] ssh-lost-kill-tab-resurrection.spec.ts:178 › does not resurrect tabs whose kill
        was lost to a killed relay daemon                                      PASSED
[13/20] ssh-lost-kill-tab-resurrection.spec.ts:190 › does not resurrect tabs closed
        while the host is disconnected                                         PASSED

grep -c "resurrected the closed tab"  (whole lane)  → 0
```

> ### ✅ `ssh-lost-kill-tab-resurrection.spec.ts` — both tests PASSED at the stack tip.
>
> Both `[12/20]` (killed relay daemon) and `[13/20]` (orderly disconnect) passed, and `grep -c "resurrected the closed tab"` over the whole lane returns **0**. It passed **without PR 7 in the build**, so bug 2's fix is not required for it.
>
> **One caveat, so nobody is surprised:** test 1 fails **intermittently in isolated single-spec runs**, where a separate unfixed defect (**bug 3** — the client's SSH transport not reconnecting after a replacement relay daemon is launched) blocks its cycle-2 *setup*. **The resurrection assertion itself has never failed with this fix in place.** A reviewer who runs the spec alone and sees red is looking at bug 3, not at this fix. Full breakdown in "The oracle spec: GREEN in the full lane" above.

**The two lane failures, resolved — and one is now exempted:**

| Spec | `main` | tip (isolated) | tip (full lane) | Outcome |
|---|---|---|---|---|
| `ssh-docker-bulk-open-freeze-repro` | FAILED — harness `TypeError: … reading 'workerIndex'` at `docker-ssh-relay-target.ts:226` | — | FAILED | **Not a flake — a 100% failure**, and three further arity bugs behind it. Now **exempted** from the lane; repair tracked in stablyai/orca#16764 |
| `ssh-port-forward-lifecycle` | PASSED | **PASSED** (59.6s) | FAILED at `ssh-port-forward-lifecycle-evidence.ts:159` waiting on `getByText('Ports')` | **Flaky in-lane**, not a regression |

Port-forward was re-run at the same commit and build and passed in 59.6s. It is green on `main`, green at the tip in isolation, and red only inside the full lane — it is the set's one `@headful` spec and runs last. **Called flaky in-lane rather than "unrelated": a real lane-ordering problem, pre-existing, and worth tracking.**

> **Note on the recorded run:** the 14-spec result above predates the bulk-open exemption. The lane now runs **13** specs; bulk-open is not among them. The other 13 results are unaffected — nothing about that spec's failure changes another's outcome, since the runner passes them all to one Playwright invocation with `--workers=1` and each spec owns its own fixture container.

Neither is in this PR's routed spec set.

## Build provenance

`closedTerminalTabTombstonesByTabId` is a new identifier — **0 occurrences in `main`'s source**:

```
$ cat out/renderer/assets/*.js | grep -c closedTerminalTabTombstonesByTabId
13          # App-CZkf3Bu7.js:6, store-uJWnDUOY.js:5, quick-commands-menu-events-SBDd6cXN.js:2
```

Measured on the lane build:

```
BUILD_SHA=49bb96e0b4c135ce305a2f4dfe2d4b52e0b19cde   DIRTY=0
tombstone=13   hasLocalTabsRow=2   hostAuthority=4   mayCreate=3
```

`tombstone=13` is this PR's symbol; the other three prove the levels beneath it are in the same build. `SshPtyAbsentFromRelayError` is **absent**, confirming PR 7 is not present — so the green oracle above is not borrowing bug 2's fix.

> **Provenance trap, reproduced on this tree.** Do not grep a single renderer chunk. `grep -c <sym> out/renderer/assets/store-*.js | head -1` matched `store-DtDSfs7_.js` and reported **0** for a symbol present **13** times across `store-uJWnDUOY.js`, `App-CZkf3Bu7.js` and `quick-commands-menu-events-SBDd6cXN.js`. Always use `cat out/renderer/assets/*.js | grep -c <sym>`.
>
> Also: renderer `console.warn` never reaches the app log. Only main-process stdio is forwarded by `ORCA_E2E_FORWARD_APP_LOGS=1`.

**This exact trap already bit once in this campaign** — a first provenance grep read 0 and was wrong about the build, not the code. The all-chunk form is what produced the 13 above.

## Reading the lane output: one probe that measures nothing

`ssh-lost-kill-tab-resurrection.spec.ts` calls a `dumpAuthority` helper that logs `topologyRev` read through `window.api.session.get()`. **`terminalTopologyRevisionByRepoId` is declared `hostPrivate`** (`src/renderer/src/lib/workspace-session-host-field-ownership.ts:51`), so that call returns it absent on **every** run regardless of its real value. The probe will always print `topologyRev: null`, and that is a measurement artifact — **not evidence the revision is 0**. Flagging it rather than editing a spec in a PR that cannot re-run it.

## What is NOT covered

- **Bug 3 — the SSH transport that does not reconnect after a replacement daemon is launched.** Unfixed, out of scope, own ticket. It does not stop the oracle passing in the full lane, but it makes test 1 **intermittent in isolation**. Discriminator (measured in the isolated runs, not re-confirmed in the lane): `[ssh-relay] Socket probe result:` is `"DEAD"` on every cycle of test 1 and `"ALIVE"` on every cycle of test 2.
- **Bug 2 — the error-class rewrite** at `ssh-pty-session-reattach.ts:227-231`, which flattens the relay's `PTY "pty-1" not found` into a bare `SSH_SESSION_EXPIRED` so `attachStablePaneOwner:242`'s correct fallback never fires. Owned by `nwparker/ssh-07-absent-from-relay`, not this PR.
- **Five candidate fix locations were eliminated** by measurement or reader analysis, including the one a reviewer is most likely to reach for (`kill.ts:82-84`). Each is tabulated with its disproof under **Eliminated candidates** so the trip does not get re-walked.
- **The orderly-disconnect path was never broken** and is included only as the negative control that bounds the trigger.
- **Growth is `1 → 2 → 1`, not monotonic.** The repro proves the resurrection chain; it does not by itself prove "linearly more tabs daily". The link to the user report rests on the mechanism plus the ticket cluster, not on a measured daily slope.
- **The repro uses a killed relay daemon**, which is more violent than the disconnect→close→reconnect path most users hit. The orderly variant does *not* reproduce, so the real-world trigger is specifically ungraceful loss — narrower than "any reconnect", and the fix is justified on that basis.
- **The tombstone is client-local and never reconciled across clients.** A second client that never saw the close will still show the tab. Deliberate: making it cross the wire is exactly the #16571 divergence dropped here, because a host-sourced tombstone deleting a local tab is the wrong risk after #14361.
- **STA-3593** (host tabs never reaching the store) and the **partition split-brain** (#12721/#12723) are untouched.
- **`createTab` honours a caller-supplied id hint** (`terminal-tab-creation.ts:53-65`), so "tab ids are uuids that never recur" is not literally true. The guarantee rests on `closeReason === 'user'` being the only writer plus the live-local-tab check. Repeated here because it is the one assumption that would break the safety argument.

## Failing-first test

Yes, at both layers — and the e2e A/B is the load-bearing one.

**e2e**, flipping `isSuppressedByClose` to `false` (one character):

```
--repeat-each=2:
  1) drop 2 resurrected the closed tab ab0e305d-…: baseline=1 drop1=1 drop2=2
  2) drop 2 resurrected the closed tab 51533e34-…: baseline=1 drop1=1 drop2=2
  2 failed          ← reproduces on demand

suppression ON, five runs + one independent run:
  0 occurrences of "resurrected the closed tab"
```

**unit**, same predicate disabled:

```
 FAIL  …close-tombstones.test.ts > does not re-insert a tombstoned tab the host still lists
 FAIL  …close-tombstones.test.ts > does not re-add a tombstoned tab through the host-unknown branch
 FAIL  …close-tombstones.test.ts > suppresses only the tombstoned tab, leaving its siblings and the pointers alone
      Tests  3 failed | 39 passed (42)
```

Restored: 42 passed; 287 across the workspace-session, terminal-store, remote-workspace, shared-tombstone and profile suites.

