### PR TITLE
fix(tabs): enable isolated floating tab reordering

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -3,6 +3,7 @@
  * handling in one surface so the floating worktree does not drift from the
  * main tab model while still keeping the DOM-mounted panes local. */
 import { Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { DndContext, DragOverlay } from '@dnd-kit/core'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import { FileText, Globe, Minus, TerminalSquare } from 'lucide-react'
 import { toast } from 'sonner'
@@ -10,7 +11,10 @@ import EmulatorPane from '@/components/emulator-pane/EmulatorPane'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { useContextualTour } from '@/components/contextual-tours/use-contextual-tour'
 import TabBar from '@/components/tab-bar/TabBar'
+import TabDragPreview from '@/components/tab-bar/TabDragPreview'
+import { TabDragProvider } from '@/components/tab-group/tab-drag-context'
 import { resolveGroupTabFromVisibleId } from '@/components/tab-group/tab-group-visible-id'
+import { useTabDragSplit } from '@/components/tab-group/useTabDragSplit'
 import TerminalPane, { type TerminalPaneHandle } from '@/components/terminal-pane/TerminalPane'
 import { shouldDeferParkedPtyExitTabClose } from '@/components/terminal-pane/terminal-parked-tab-watchers'
 import { useTerminalTabColdParking } from '@/components/terminal-pane/use-terminal-tab-cold-parking'
@@ -154,7 +158,7 @@ type FloatingPanelShortcutResolution =
   | { kind: 'chrome'; action: KeybindingActionId }
 
 const FLOATING_TERMINAL_NO_DRAG_SELECTOR =
-  'button,input,textarea,select,[role="menuitem"],[data-testid="sortable-tab"],[data-floating-terminal-no-drag]'
+  'button,input,textarea,select,[role="menuitem"],.terminal-tab-strip,[data-floating-terminal-no-drag]'
 const FLOATING_TERMINAL_SHORTCUT_SURFACE_SELECTOR = '[data-floating-terminal-shortcut-surface]'
 
 type FloatingTerminalPanelBoundsState = {
@@ -341,6 +345,10 @@ export function FloatingTerminalPanel({
     bounds: FloatingTerminalPanelBounds
     moved: boolean
   } | null>(null)
+  const tabDrag = useTabDragSplit({
+    worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+    enabled: open
+  })
 
   const activeGroup = useMemo(
     () =>
@@ -1825,56 +1833,78 @@ export function FloatingTerminalPanel({
           onPointerCancel={handleDragEnd}
           onDoubleClick={handleTitlebarDoubleClick}
         >
-          <div className="flex h-full min-w-0 flex-1">
-            <TabBar
-              tabs={terminalItems}
-              activeTabId={activeTerminalId}
-              worktreeId={FLOATING_TERMINAL_WORKTREE_ID}
-              expandedPaneByTabId={expandedPaneByTabId}
-              onActivate={activateFloatingItem}
-              onClose={closeFloatingItemConfirmed}
-              onCloseOthers={closeOthers}
-              onCloseToRight={closeToRight}
-              onCloseToLeft={closeToLeft}
-              onNewTerminalTab={() => createFloatingTerminalTab()}
-              onNewTerminalWithShell={createFloatingTerminalTab}
-              onNewBrowserTab={createFloatingBrowserTab}
-              onNewFileTab={createFloatingMarkdownTab}
-              onOpenFileTab={openFloatingMarkdownTab}
-              newTabMenuOrder="markdown-first"
-              onSetCustomTitle={setTabCustomTitle}
-              onSetTabColor={setTabColor}
-              onTogglePaneExpand={(tabId) =>
-                setTabPaneExpanded(tabId, expandedPaneByTabId[tabId] !== true)
-              }
-              editorFiles={editorItems}
-              browserTabs={browserItems}
-              activeFileId={activeEditorUnifiedId}
-              activeBrowserTabId={activeBrowserId}
-              activeSimulatorTabId={activeTab?.contentType === 'simulator' ? activeTab.id : null}
-              activeTabType={activeTabType}
-              onActivateFile={activateFloatingItem}
-              onCloseFile={closeFloatingItemConfirmed}
-              onActivateBrowserTab={activateFloatingItem}
-              onCloseBrowserTab={closeFloatingItemConfirmed}
-              onDuplicateBrowserTab={(browserTabId) => {
-                const source = browserTabs.find((tab) => tab.id === browserTabId)
-                if (!source) {
-                  return
-                }
-                createBrowserTab(FLOATING_TERMINAL_WORKTREE_ID, source.url, {
-                  ...buildDuplicatedBrowserTabOptions(source),
-                  targetGroupId: activeGroup?.id,
-                  browserRuntimeEnvironmentId: null
-                })
-              }}
-              onCloseAllFiles={closeAllFiles}
-              onMakePreviewFilePermanent={makePreviewFilePermanent}
-              onPinFile={pinFile}
-              tabBarOrder={tabBarOrder}
-              tabStripChrome="floating-panel"
-            />
-          </div>
+          <TabDragProvider
+            isTabDragActive={tabDrag.activeDrag !== null}
+            isTabDragActiveRef={tabDrag.isTabDragActiveRef}
+          >
+            <DndContext
+              sensors={tabDrag.sensors}
+              collisionDetection={tabDrag.collisionDetection}
+              onDragStart={tabDrag.onDragStart}
+              onDragMove={tabDrag.onDragMove}
+              onDragOver={tabDrag.onDragOver}
+              onDragEnd={tabDrag.onDragEnd}
+              onDragCancel={tabDrag.onDragCancel}
+              autoScroll={false}
+            >
+              <div ref={tabDrag.setDragRootNode} className="flex h-full min-w-0 flex-1">
+                <TabBar
+                  tabs={terminalItems}
+                  activeTabId={activeTerminalId}
+                  worktreeId={FLOATING_TERMINAL_WORKTREE_ID}
+                  expandedPaneByTabId={expandedPaneByTabId}
+                  onActivate={activateFloatingItem}
+                  onClose={closeFloatingItemConfirmed}
+                  onCloseOthers={closeOthers}
+                  onCloseToRight={closeToRight}
+                  onCloseToLeft={closeToLeft}
+                  onNewTerminalTab={() => createFloatingTerminalTab()}
+                  onNewTerminalWithShell={createFloatingTerminalTab}
+                  onNewBrowserTab={createFloatingBrowserTab}
+                  onNewFileTab={createFloatingMarkdownTab}
+                  onOpenFileTab={openFloatingMarkdownTab}
+                  newTabMenuOrder="markdown-first"
+                  onSetCustomTitle={setTabCustomTitle}
+                  onSetTabColor={setTabColor}
+                  onTogglePaneExpand={(tabId) =>
+                    setTabPaneExpanded(tabId, expandedPaneByTabId[tabId] !== true)
+                  }
+                  editorFiles={editorItems}
+                  browserTabs={browserItems}
+                  activeFileId={activeEditorUnifiedId}
+                  activeBrowserTabId={activeBrowserId}
+                  activeSimulatorTabId={
+                    activeTab?.contentType === 'simulator' ? activeTab.id : null
+                  }
+                  activeTabType={activeTabType}
+                  onActivateFile={activateFloatingItem}
+                  onCloseFile={closeFloatingItemConfirmed}
+                  onActivateBrowserTab={activateFloatingItem}
+                  onCloseBrowserTab={closeFloatingItemConfirmed}
+                  onDuplicateBrowserTab={(browserTabId) => {
+                    const source = browserTabs.find((tab) => tab.id === browserTabId)
+                    if (!source) {
+                      return
+                    }
+                    createBrowserTab(FLOATING_TERMINAL_WORKTREE_ID, source.url, {
+                      ...buildDuplicatedBrowserTabOptions(source),
+                      targetGroupId: activeGroup?.id,
+                      browserRuntimeEnvironmentId: null
+                    })
+                  }}
+                  onCloseAllFiles={closeAllFiles}
+                  onMakePreviewFilePermanent={makePreviewFilePermanent}
+                  onPinFile={pinFile}
+                  tabBarOrder={tabBarOrder}
+                  tabStripChrome="floating-panel"
+                  hoveredTabInsertion={tabDrag.hoveredTabInsertion}
+                />
+              </div>
+              <DragOverlay dropAnimation={null}>
+                {tabDrag.activeDrag ? <TabDragPreview drag={tabDrag.activeDrag} /> : null}
+              </DragOverlay>
+            </DndContext>
+          </TabDragProvider>
           <FloatingTerminalWindowControls
             maximized={maximized}
             onToggleMaximized={toggleMaximized}

--- a/src/renderer/src/components/floating-terminal/floating-terminal-panel-render-probe.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-panel-render-probe.ts
@@ -2,6 +2,23 @@ import { vi } from 'vitest'
 import { hookRuntime } from './floating-terminal-panel-test-harness'
 import type { FloatingTerminalPanelBounds } from './floating-terminal-panel-bounds'
 
+vi.mock('@/components/tab-group/useTabDragSplit', () => ({
+  useTabDragSplit: () => ({
+    activeDrag: null,
+    collisionDetection: () => [],
+    hoveredDropTarget: null,
+    hoveredTabInsertion: null,
+    isTabDragActiveRef: { current: false },
+    onDragCancel: () => undefined,
+    onDragEnd: () => undefined,
+    onDragMove: () => undefined,
+    onDragOver: () => undefined,
+    onDragStart: () => undefined,
+    sensors: [],
+    setDragRootNode: () => undefined
+  })
+}))
+
 export type ReactElementLike = {
   type: unknown
   props: Record<string, unknown>

--- a/tests/e2e/floating-mobile-emulator-tab.spec.ts
+++ b/tests/e2e/floating-mobile-emulator-tab.spec.ts
@@ -1,5 +1,6 @@
 import type { Page, TestInfo } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
 // Why: mirrors FLOATING_TERMINAL_WORKTREE_ID in src/shared/constants.ts.
 // E2E specs avoid importing renderer/shared modules into the Playwright runner.
@@ -7,6 +8,7 @@ const FLOATING_WORKTREE_ID = 'global-floating-terminal'
 const PANEL_SELECTOR = '[data-floating-terminal-panel]'
 const OPEN_PANEL_SELECTOR = `${PANEL_SELECTOR}[aria-hidden="false"]`
 const TOGGLE_EVENT = 'orca-toggle-floating-terminal'
+const TAB_SELECTOR = '.terminal-tab-strip [data-tab-id]'
 
 type SeededSimulatorTab = {
   id: string
@@ -122,4 +124,81 @@ test('floating Mobile Emulator tab renders content and closes from the tab strip
 
   await expect(tabLocator).toHaveCount(0)
   await expect(openPanel.locator('[data-emulator-pane]')).toHaveCount(0)
+})
+
+test('floating tab drag reorders only the floating tab context', async ({ orcaPage }) => {
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+
+  const firstTab = await seedFloatingSimulatorTab(orcaPage)
+  const secondTab = await orcaPage.evaluate((worktreeId) => {
+    const store = (window as E2EWindow).__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    return store.getState().createUnifiedTab(worktreeId, 'simulator', {
+      label: 'Mobile Emulator 2',
+      recordInteraction: false
+    })
+  }, FLOATING_WORKTREE_ID)
+  await openFloatingPanelIfNeeded(orcaPage)
+
+  const openPanel = orcaPage.locator(OPEN_PANEL_SELECTOR).first()
+  const mainOrderBefore = await orcaPage
+    .locator(TAB_SELECTOR)
+    .evaluateAll(
+      (nodes, panelSelector) =>
+        nodes
+          .filter((node) => !node.closest(panelSelector))
+          .map((node) => (node as HTMLElement).dataset.tabId ?? ''),
+      PANEL_SELECTOR
+    )
+  const floatingOrderBefore = await openPanel
+    .locator(TAB_SELECTOR)
+    .evaluateAll((nodes) => nodes.map((node) => (node as HTMLElement).dataset.tabId ?? ''))
+  expect(floatingOrderBefore).toEqual([firstTab.id, secondTab.id])
+
+  const firstBox = await openPanel
+    .locator(`${TAB_SELECTOR}[data-tab-id="${firstTab.id}"]`)
+    .boundingBox()
+  const secondBox = await openPanel
+    .locator(`${TAB_SELECTOR}[data-tab-id="${secondTab.id}"]`)
+    .boundingBox()
+  expect(firstBox).not.toBeNull()
+  expect(secondBox).not.toBeNull()
+
+  await orcaPage.mouse.move(firstBox!.x + firstBox!.width / 2, firstBox!.y + firstBox!.height / 2)
+  await orcaPage.mouse.down()
+  await orcaPage.mouse.move(
+    secondBox!.x + secondBox!.width * 0.75,
+    secondBox!.y + secondBox!.height / 2,
+    {
+      steps: 8
+    }
+  )
+  await orcaPage.mouse.up()
+
+  await expect
+    .poll(
+      () =>
+        openPanel
+          .locator(TAB_SELECTOR)
+          .evaluateAll((nodes) => nodes.map((node) => (node as HTMLElement).dataset.tabId ?? '')),
+      { timeout: 5_000, message: 'Floating tab drag did not reorder the floating tab strip' }
+    )
+    .toEqual([secondTab.id, firstTab.id])
+  await expect
+    .poll(() =>
+      orcaPage
+        .locator(TAB_SELECTOR)
+        .evaluateAll(
+          (nodes, panelSelector) =>
+            nodes
+              .filter((node) => !node.closest(panelSelector))
+              .map((node) => (node as HTMLElement).dataset.tabId ?? ''),
+          PANEL_SELECTOR
+        )
+    )
+    .toEqual(mainOrderBefore)
 })


### PR DESCRIPTION
## ELI5

The floating terminal window now has its own drag-and-drop context, so its tabs can be reordered without affecting tabs in the main workspace.

## What Changed

- Mounted the existing tab drag context inside the floating terminal panel
- Scoped floating tab reordering to the floating workspace ID
- Kept the main and floating drag contexts independent
- Prevented window dragging from intercepting drags inside the floating tab strip
- Added unit and Electron E2E coverage for isolated tab reordering

## Why

Only the main workspace previously mounted a drag-and-drop context. Tabs rendered inside the floating terminal window therefore had no active drag context, while the floating titlebar could intercept their pointer movement.

Reusing the existing tab drag implementation with a floating-workspace scope keeps both contexts independent without introducing another drag system.

## Linked Issue

N/A — Reported and reproduced directly without a linked issue.

## Visual Proof

N/A — This change does not alter the visual styling or layout. It only enables the existing tab-reordering behavior inside the floating window, and the interaction is covered by Electron E2E tests.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Tested on macOS:

- `pnpm lint` passed
- `pnpm typecheck` passed
- FloatingTerminalPanel unit tests: 68 passed
- Electron E2E: 2 passed
- Desktop build passed
- macOS native component compiled, but the full build stopped during local app signing with `errSecInternalComponent`
- Full test suite: 62,967 passed; 5 tests outside this diff failed, and one cross-version suite could not resolve the local `v1.4.184` tag

Reviewer verification:

1. Open the floating terminal window
2. Create at least two tabs in the floating workspace
3. Drag one floating tab past the other
4. Confirm the floating tab order changes
5. Confirm the main workspace tab order remains unchanged

## AI Disclosure

OpenAI Codex (GPT-5) was used to diagnose, implement, and test this change.

## Review

- Security: no data or permission boundaries changed
- Cross-platform: reuses the existing pointer sensor implementation without platform-specific input handling
- Remote SSH and folder workspaces: no path, Git, or execution-host behavior changed
- Mobile: no mobile runtime behavior changed
- Backwards compatibility: existing main-workspace tab dragging is unchanged
- Performance: no polling or new global listeners were added

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The change is limited to floating terminal tab interaction and its regression coverage.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)