### PR TITLE
fix(serve): install supervisor disconnect quit after app environment init

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -972,10 +972,12 @@ if (hasSingleInstanceLock) {
   installDevParentSignalQuit(shouldCoupleToDevParent)
   // Why: run after configureDevUserDataPath but before app.setName('Orca') (whenReady), which changes the resolved path on case-sensitive filesystems.
   initDataPath()
-  // Why here rather than at module scope: this validates the supervisor handoff env
-  // against getCanonicalUserDataPath(), so it needs setAppEnvironment() installed above
-  // and the canonical path captured just now. At module scope it threw
-  // 'AppEnvironment not initialized' and killed every macOS `orca serve` at startup.
+  // Why not at module scope with the other lifetime couplings (#16761): this resolves the handoff
+  // path, so it throws until setAppEnvironment() above installs the accessor — which killed every
+  // `orca serve` process before it could listen. After initDataPath() specifically, so the
+  // path-equality check against the CLI's env var uses the dir captured before app.setName().
+  // Safe to defer, and must stay synchronous: no 'disconnect' can be delivered until this module
+  // finishes evaluating, so moving this behind an await would open a real orphan window.
   installServeSupervisorDisconnectQuit(isServeMode)
   // Why here: initDataPath above gives the canonical userData path for the record file; the write
   // itself lands for the next launch (see macos-press-and-hold-default.ts).

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -758,7 +758,6 @@ if (app.isPackaged && process.platform !== 'win32') {
 }
 configureDevUserDataPath(is.dev)
 configureOrcaUserDataPathEnv()
-installServeSupervisorDisconnectQuit(isServeMode)
 
 // Why: just past createMainWindow's 10s ready-to-show fallback, so a window revealed that way still gets its tray icon.
 const TRAY_CREATE_FALLBACK_MS = 12_000
@@ -973,6 +972,11 @@ if (hasSingleInstanceLock) {
   installDevParentSignalQuit(shouldCoupleToDevParent)
   // Why: run after configureDevUserDataPath but before app.setName('Orca') (whenReady), which changes the resolved path on case-sensitive filesystems.
   initDataPath()
+  // Why here rather than at module scope: this validates the supervisor handoff env
+  // against getCanonicalUserDataPath(), so it needs setAppEnvironment() installed above
+  // and the canonical path captured just now. At module scope it threw
+  // 'AppEnvironment not initialized' and killed every macOS `orca serve` at startup.
+  installServeSupervisorDisconnectQuit(isServeMode)
   // Why here: initDataPath above gives the canonical userData path for the record file; the write
   // itself lands for the next launch (see macos-press-and-hold-default.ts).
   applyMacPressAndHoldDefaultAtStartup(getCanonicalUserDataPath())

--- a/src/main/serve-update-handoff.app-environment.test.ts
+++ b/src/main/serve-update-handoff.app-environment.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installFakeAppEnvironment } from '../../config/scripts/vitest-host-ports-setup'
+import {
+  SERVE_UPDATE_HANDOFF_PATH_ENV,
+  getServeUpdateHandoffPath
+} from '../shared/serve-update-handoff'
+
+/**
+ * Runtime companion to the source-level ordering guard in
+ * startup/desktop-startup-ordering.test.ts (issue #16761).
+ *
+ * The sibling serve-update-handoff.test.ts mocks `./persistence`, so under it
+ * getCanonicalUserDataPath() can never throw — which is exactly why a module-scope call to
+ * installServeSupervisorDisconnectQuit() shipped and killed every `orca serve` process on
+ * macOS. This file keeps the real path resolver so that dependency stays visible.
+ */
+vi.mock('electron', () => ({ app: { getVersion: () => '1.0.51', quit: vi.fn() } }))
+
+// Why reach for the slot directly: there is no uninstall API, and vitest-host-ports-setup installs
+// a fake before every test — so the uninstalled state this guards can only be reproduced this way.
+const APP_ENVIRONMENT_SLOT = Symbol.for('orca.host.appEnvironment')
+
+describe('serve supervisor disconnect quit', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+  let installedEnvironment: unknown
+  let installedHandoffPath: string | undefined
+  let userDataDir: string
+
+  beforeEach(() => {
+    userDataDir = mkdtempSync(join(tmpdir(), 'orca-serve-handoff-env-'))
+    installedHandoffPath = process.env[SERVE_UPDATE_HANDOFF_PATH_ENV]
+    const slot = globalThis as Record<symbol, unknown>
+    installedEnvironment = slot[APP_ENVIRONMENT_SLOT]
+    delete slot[APP_ENVIRONMENT_SLOT]
+    // Why pin darwin: hasServeUpdateSupervisor() short-circuits off-macOS, so the guard would
+    // silently cover nothing on Linux/Windows CI — where this suite actually runs.
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    process.env[SERVE_UPDATE_HANDOFF_PATH_ENV] = getServeUpdateHandoffPath(userDataDir)
+  })
+
+  afterEach(() => {
+    const slot = globalThis as Record<symbol, unknown>
+    if (installedEnvironment === undefined) {
+      delete slot[APP_ENVIRONMENT_SLOT]
+    } else {
+      slot[APP_ENVIRONMENT_SLOT] = installedEnvironment
+    }
+    Object.defineProperty(process, 'platform', originalPlatform)
+    // Why restore rather than delete: this suite can run inside a serve process that set it.
+    if (installedHandoffPath === undefined) {
+      delete process.env[SERVE_UPDATE_HANDOFF_PATH_ENV]
+    } else {
+      process.env[SERVE_UPDATE_HANDOFF_PATH_ENV] = installedHandoffPath
+    }
+    rmSync(userDataDir, { recursive: true, force: true })
+    vi.resetModules()
+  })
+
+  it('resolves a real user data path, so it cannot run before the app environment is installed', async () => {
+    const { installServeSupervisorDisconnectQuit } = await import('./serve-update-handoff')
+
+    expect(() => installServeSupervisorDisconnectQuit(true)).toThrow(
+      /AppEnvironment not initialized/
+    )
+  })
+
+  it('installs the disconnect quit once the app environment is available', async () => {
+    installFakeAppEnvironment({ getPath: () => userDataDir })
+    const { installServeSupervisorDisconnectQuit } = await import('./serve-update-handoff')
+    const listeners: (() => void)[] = []
+    const parent = {
+      once: (_event: 'disconnect', listener: () => void) => listeners.push(listener),
+      off: (_event: 'disconnect', listener: () => void) =>
+        listeners.splice(listeners.indexOf(listener), 1)
+    }
+
+    const dispose = installServeSupervisorDisconnectQuit(true, parent)
+
+    expect(listeners).toHaveLength(1)
+    dispose()
+    expect(listeners).toHaveLength(0)
+  })
+})

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -340,20 +340,33 @@ describe('startup ordering', () => {
     expect(desktopAutomationStart).toBeGreaterThan(desktopSetWebContents)
   })
 
-  it('installs the serve supervisor disconnect quit after the app environment and data path exist', () => {
+  it('installs the serve supervisor disconnect quit after the app environment and data path', () => {
+    // Why (#16761): the call resolves the handoff path through getCanonicalUserDataPath(). At module
+    // scope that accessor throws by design, so every `orca serve` process on macOS died at startup
+    // before it could listen. serve-update-handoff.test.ts mocks the resolver, so only ordering
+    // catches this; serve-update-handoff.app-environment.test.ts pins the throw it depends on.
     const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
-    const setEnvironment = source.indexOf('setAppEnvironment(new ElectronAppEnvironment())')
-    const initData = source.indexOf('initDataPath()')
-    const installSupervisorQuit = source.indexOf(
-      'installServeSupervisorDisconnectQuit(isServeMode)'
-    )
+    const install = 'installServeSupervisorDisconnectQuit(isServeMode)'
+    const appEnvironmentIndex = source.indexOf('setAppEnvironment(new ElectronAppEnvironment())')
+    const dataPathIndex = source.indexOf('initDataPath()')
+    const installIndex = source.indexOf(install)
 
-    expect(setEnvironment).toBeGreaterThanOrEqual(0)
-    expect(initData).toBeGreaterThan(setEnvironment)
-    // Why: the call validates the supervisor handoff env against getCanonicalUserDataPath(),
-    // so it needs both the installed app environment and the captured canonical path. At
-    // module scope it resolved neither and threw 'AppEnvironment not initialized', killing
-    // every macOS `orca serve` process at startup.
-    expect(installSupervisorQuit).toBeGreaterThan(initData)
+    expect(source.split(install).length - 1, `${install} should appear exactly once`).toBe(1)
+    expect(appEnvironmentIndex).toBeGreaterThanOrEqual(0)
+    expect(dataPathIndex).toBeGreaterThan(appEnvironmentIndex)
+    expect(installIndex).toBeGreaterThan(dataPathIndex)
+
+    // Why also pin it synchronous: 'disconnect' cannot be delivered while this module is still
+    // evaluating, which is the whole reason deferring it is free. Parked behind an await — say
+    // inside app.whenReady() — the ordering above still holds but a parent that dies in the gap
+    // leaves the serve process orphaned on its port, which is the failure this handler prevents.
+    expect(installIndex).toBeLessThan(source.indexOf('void app.whenReady().then('))
+    expect(installIndex).toBeGreaterThan(source.indexOf('if (hasSingleInstanceLock) {'))
+    const betweenCode = source
+      .slice(dataPathIndex, installIndex)
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('//'))
+      .join('\n')
+    expect(betweenCode).not.toContain('await')
   })
 })

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -339,4 +339,21 @@ describe('startup ordering', () => {
     expect(desktopSetWebContents).toBeGreaterThanOrEqual(0)
     expect(desktopAutomationStart).toBeGreaterThan(desktopSetWebContents)
   })
+
+  it('installs the serve supervisor disconnect quit after the app environment and data path exist', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const setEnvironment = source.indexOf('setAppEnvironment(new ElectronAppEnvironment())')
+    const initData = source.indexOf('initDataPath()')
+    const installSupervisorQuit = source.indexOf(
+      'installServeSupervisorDisconnectQuit(isServeMode)'
+    )
+
+    expect(setEnvironment).toBeGreaterThanOrEqual(0)
+    expect(initData).toBeGreaterThan(setEnvironment)
+    // Why: the call validates the supervisor handoff env against getCanonicalUserDataPath(),
+    // so it needs both the installed app environment and the captured canonical path. At
+    // module scope it resolved neither and threw 'AppEnvironment not initialized', killing
+    // every macOS `orca serve` process at startup.
+    expect(installSupervisorQuit).toBeGreaterThan(initData)
+  })
 })


### PR DESCRIPTION
## ELI5

On macOS, `orca serve` asked "am I supervised?" before the app had figured out where its data directory is. Asking that question resolves a path, and resolving a path that early throws on purpose — so the serve process died instantly, every time. This moves the question a few lines later, to where its two prerequisites already exist.

## What Changed

Moved `installServeSupervisorDisconnectQuit(isServeMode)` out of module scope in `src/main/index.ts` and next to the sibling `installDevParent*` handlers, after `initDataPath()`.

Added an ordering invariant to `src/main/startup/desktop-startup-ordering.test.ts` so the call cannot drift back above `setAppEnvironment()` / `initDataPath()`.

No change to `src/main/serve-update-handoff.ts` — its logic was already correct, it was just called too early.

## Why

`installServeSupervisorDisconnectQuit()` → `hasServeUpdateSupervisor()` → `getConfiguredHandoffPath()` resolves `getCanonicalUserDataPath()` in order to validate `ORCA_SERVE_UPDATE_HANDOFF_PATH`. At module scope, `_userDataDir` is still unset, so that takes its "should not be hit in normal startup" fallback into `getAppEnvironment()` — which throws until `setAppEnvironment()` runs inside the `if (hasSingleInstanceLock)` block, ~180 lines later.

The early return in `getConfiguredHandoffPath()` only covers the case where the env var is unset, and **the CLI supervisor sets it by default on macOS**, so the throw was on the default path, not an exotic configuration. Result: every `orca serve` process on 1.4.190 exited at startup with an uncaught `AppEnvironment not initialized`, and the supervising service manager restarted it into the same crash.

The invariant is already documented at the place this violated — the comment above `setAppEnvironment()`:

> Why first: both accessors throw until installed, and everything below this line may resolve a path or read a credential.

`src/shared/app-environment.ts` is new in 1.4.190; before it this fallback read Electron's `app.getPath('userData')`, which works pre-`ready`. That is why 1.4.188 is unaffected even though `serve-update-handoff.ts` is byte-identical between the two.

Placing it after `initDataPath()` rather than merely after `setAppEnvironment()` is deliberate: the comparison should use the canonical path captured before `app.setName()` can change how `userData` resolves, which is the same reason the surrounding init calls sit there.

## Linked Issue

Fixes #16761

## Visual Proof

`N/A` — no UI or interaction surface; this is main-process startup ordering. The observable difference is in the serve process lifecycle:

**Before** (1.4.190, on every restart):

```
[main_uncaught_exception] Error: AppEnvironment not initialized — call setAppEnvironment() during startup before resolving app paths
    at getAppEnvironment (…/out/main/index.js:4929:24)
    at getCanonicalUserDataPath (…/out/main/index.js:19422:36)
    at getConfiguredHandoffPath (…/out/main/index.js:197446:49)
    at hasServeUpdateSupervisor (…/out/main/index.js:197450:42)
    at installServeSupervisorDisconnectQuit (…/out/main/index.js:197488:25)
    at Module.<anonymous> (…/out/main/index.js:266555:1)
```

**After**: serve reaches its listening state and holds its port; no `main_uncaught_exception`.

## Testing

The new ordering test fails on `main` and passes with the fix:

```
# before the one-line move
FAIL  src/main/startup/desktop-startup-ordering.test.ts > startup ordering >
      installs the serve supervisor disconnect quit after the app environment and data path exist
AssertionError: expected 35635 to be greater than 45105

# after
Test Files  3 passed (3)
     Tests  27 passed (27)
```

Ran locally on macOS (arm64):

- `pnpm vitest run src/main/startup/desktop-startup-ordering.test.ts src/main/serve-update-handoff.test.ts src/main/updater.headless-serve-install.test.ts` — 27 passed
- `pnpm run typecheck:node` — clean
- `oxlint` on both changed files — clean
- Full `pnpm test` / `pnpm build` left to CI.

Platforms: the crash and the fix are macOS-specific in effect (`hasServeUpdateSupervisor()` is `darwin`-gated), but the change is a plain statement move with no platform branch, so Linux/Windows behavior is unchanged. Not applicable to SSH/remote or mobile beyond the fact that a working `orca serve` is what remote clients pair against.

Note on why the existing unit tests could not have caught this: `serve-update-handoff.test.ts` mocks `./persistence`, so `getCanonicalUserDataPath()` never throws under test. A behavior test in that file would only assert the mock. Hence the guard lives in the startup-ordering file, alongside the other invariants of this kind.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Investigation, patch, and tests written with Claude Code (Claude Opus 5). The crash was found on a real machine running `orca serve` under a LaunchAgent; the root cause was traced by reading the shipped `app.asar` of 1.4.188 vs 1.4.190 and then the corresponding `main` sources. All claims in this PR were verified against the running process and the test suite rather than inferred.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: none — no credential or path is newly exposed; the handoff path is validated exactly as before, just later.
- Cross-platform: statement move only, no platform branch added or removed.
- Remote SSH / mobile: unaffected except that `orca serve` starts again.
- Backwards compatibility: the disconnect listener is registered slightly later in startup. A parent disconnect in that window no longer triggers `app.quit()` — but in that window the process has not yet taken the single-instance lock or initialized its data path, so it is not yet a runtime any client could be using.
- Performance: no change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
