### PR TITLE
fix(ssh): a relay that reports a PTY absent must authorise a fresh spawn

### DIFF
--- a/src/main/ipc/pty/pane/stable-pane-relay-absence-respawn.test.ts
+++ b/src/main/ipc/pty/pane/stable-pane-relay-absence-respawn.test.ts
@@ -1,25 +1,34 @@
 import { describe, expect, it, vi } from 'vitest'
+import type { WorkspaceSessionState } from '../../../../shared/workspace-session-state-types'
 import {
   SSH_SESSION_EXPIRED_ERROR,
   SshPtyAbsentFromRelayError
 } from '../../../providers/ssh-pty-errors'
+import type { Store } from '../../../persistence'
 import type { IPtyProvider } from '../../../providers/types'
 import { spawnForStablePane, type StablePaneOwner } from './stable-owner'
 
+const LEAF = '1b3f2c4d-5e6a-4b7c-8d9e-0f1a2b3c4d5e'
+const SIBLING_LEAF = '2c4d3e5f-6a7b-4c8d-9e0f-1a2b3c4d5e6f'
+const WORKTREE = 'worktree-1'
 const OWNER: StablePaneOwner = {
   tabId: 'tab-1',
-  leafId: '1b3f2c4d-5e6a-4b7c-8d9e-0f1a2b3c4d5e',
-  ptyId: 'ssh:conn-1@@pty-1'
+  leafId: LEAF,
+  ptyId: 'ssh:conn-1@@pty-1',
+  hasPersistedBinding: true
 }
 
-function spawnAfterAttachRejection(error: unknown): {
+function spawnAfterAttachRejection(
+  error: unknown,
+  persistence?: { store: Store; worktreeId: string }
+): {
   run: () => ReturnType<typeof spawnForStablePane>
   spawn: ReturnType<typeof vi.fn>
 } {
   const spawn = vi
     .fn()
     .mockRejectedValueOnce(error)
-    .mockResolvedValueOnce({ id: 'ssh:conn-1@@pty-1', isReattach: false })
+    .mockResolvedValueOnce({ id: 'ssh:conn-1@@pty-2', isReattach: false })
   return {
     spawn,
     run: () =>
@@ -29,8 +38,44 @@ function spawnAfterAttachRejection(error: unknown): {
         spawnOptions: { cols: 80, rows: 24 },
         owner: OWNER,
         connectionId: 'conn-1',
-        resolveOwner: () => null
+        resolveOwner: () => null,
+        ...(persistence ? { store: persistence.store, worktreeId: persistence.worktreeId } : {})
       })
+  }
+}
+
+/** Real retirement against an in-memory session, so `retireTerminalSurfaceFromPersistence` runs. */
+function sessionStore(leaves: string[]): { store: Store; read: () => WorkspaceSessionState } {
+  let session = {
+    tabsByWorktree: {
+      [WORKTREE]: [{ id: 'tab-1', worktreeId: WORKTREE, ptyId: 'ssh:conn-1@@pty-1' }]
+    },
+    terminalLayoutsByTabId: {
+      'tab-1': {
+        root: leaves.reduce<Record<string, unknown>>(
+          (node, leafId) =>
+            Object.keys(node).length === 0
+              ? { type: 'leaf', leafId }
+              : { type: 'split', direction: 'row', first: node, second: { type: 'leaf', leafId } },
+          {}
+        ),
+        activeLeafId: leaves[0],
+        ptyIdsByLeafId: Object.fromEntries(
+          leaves.map((leafId, index) => [leafId, `ssh:conn-1@@pty-${index + 1}`])
+        )
+      }
+    },
+    terminalPtyIncarnationsByPaneKey: {}
+  } as unknown as WorkspaceSessionState
+  return {
+    read: () => session,
+    store: {
+      getWorkspaceSession: () => session,
+      setWorkspaceSession: (next: WorkspaceSessionState) => {
+        session = next
+      },
+      flushOrThrow: () => {}
+    } as unknown as Store
   }
 }
 
@@ -59,5 +104,62 @@ describe('stable pane adoption after the relay reports the PTY absent', () => {
 
     await expect(run()).rejects.toThrow(message)
     expect(spawn).toHaveBeenCalledTimes(1)
+  })
+
+  // Why a real store: without one the `args.worktreeId` guard short-circuits and the retirement —
+  // which can delete the parent tab and its layout — never runs. "Reconnect lost every tab" is the
+  // regression this subsystem was reverted for twice, so the composition needs its own coverage.
+  describe('with persistence actually reached', () => {
+    it('retires only the absent leaf and leaves the tab and its sibling bound', async () => {
+      const { store, read } = sessionStore([LEAF, SIBLING_LEAF])
+      const { run, spawn } = spawnAfterAttachRejection(
+        new SshPtyAbsentFromRelayError(`${SSH_SESSION_EXPIRED_ERROR}: pty-1`),
+        { store, worktreeId: WORKTREE }
+      )
+
+      const result = await run()
+
+      expect(spawn).toHaveBeenCalledTimes(2)
+      expect(result.owner).toBeNull()
+      const session = read()
+      expect(session.tabsByWorktree[WORKTREE]?.map((tab) => tab.id)).toEqual(['tab-1'])
+      const layout = session.terminalLayoutsByTabId['tab-1']
+      expect(layout).toBeDefined()
+      expect(layout?.ptyIdsByLeafId?.[SIBLING_LEAF]).toBe('ssh:conn-1@@pty-2')
+      expect(layout?.ptyIdsByLeafId?.[LEAF]).toBeUndefined()
+    })
+
+    // Pins current behaviour rather than blessing it: retiring the LAST leaf drops the tab from
+    // persistence, and the fallback returns owner=null so main does not re-persist a binding — tab
+    // survival then rests entirely on the renderer. If that ever regresses, this is the tripwire.
+    it('drops the tab when the absent leaf was the only one, leaving re-persistence to the renderer', async () => {
+      const { store, read } = sessionStore([LEAF])
+      const { run, spawn } = spawnAfterAttachRejection(
+        new SshPtyAbsentFromRelayError(`${SSH_SESSION_EXPIRED_ERROR}: pty-1`),
+        { store, worktreeId: WORKTREE }
+      )
+
+      const result = await run()
+
+      expect(spawn).toHaveBeenCalledTimes(2)
+      expect(result.owner).toBeNull()
+      const session = read()
+      expect(session.tabsByWorktree[WORKTREE]).toEqual([])
+      expect(session.terminalLayoutsByTabId['tab-1']).toBeUndefined()
+    })
+
+    it('leaves persistence untouched when the failure is not positive absence', async () => {
+      const { store, read } = sessionStore([LEAF, SIBLING_LEAF])
+      const before = JSON.stringify(read())
+      const { run, spawn } = spawnAfterAttachRejection(
+        new Error('SSH connection lost, reconnecting...'),
+        { store, worktreeId: WORKTREE }
+      )
+
+      await expect(run()).rejects.toThrow('SSH connection lost')
+
+      expect(spawn).toHaveBeenCalledTimes(1)
+      expect(JSON.stringify(read())).toBe(before)
+    })
   })
 })

--- a/src/main/ipc/pty/pane/stable-pane-relay-absence-respawn.test.ts
+++ b/src/main/ipc/pty/pane/stable-pane-relay-absence-respawn.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  SSH_SESSION_EXPIRED_ERROR,
+  SshPtyAbsentFromRelayError
+} from '../../../providers/ssh-pty-errors'
+import type { IPtyProvider } from '../../../providers/types'
+import { spawnForStablePane, type StablePaneOwner } from './stable-owner'
+
+const OWNER: StablePaneOwner = {
+  tabId: 'tab-1',
+  leafId: '1b3f2c4d-5e6a-4b7c-8d9e-0f1a2b3c4d5e',
+  ptyId: 'ssh:conn-1@@pty-1'
+}
+
+function spawnAfterAttachRejection(error: unknown): {
+  run: () => ReturnType<typeof spawnForStablePane>
+  spawn: ReturnType<typeof vi.fn>
+} {
+  const spawn = vi
+    .fn()
+    .mockRejectedValueOnce(error)
+    .mockResolvedValueOnce({ id: 'ssh:conn-1@@pty-1', isReattach: false })
+  return {
+    spawn,
+    run: () =>
+      spawnForStablePane({
+        runtime: undefined,
+        provider: { spawn } as unknown as IPtyProvider,
+        spawnOptions: { cols: 80, rows: 24 },
+        owner: OWNER,
+        connectionId: 'conn-1',
+        resolveOwner: () => null
+      })
+  }
+}
+
+describe('stable pane adoption after the relay reports the PTY absent', () => {
+  it('spawns fresh once the relay has positively answered for that id', async () => {
+    const { run, spawn } = spawnAfterAttachRejection(
+      new SshPtyAbsentFromRelayError(`${SSH_SESSION_EXPIRED_ERROR}: pty-1`)
+    )
+
+    const result = await run()
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(spawn.mock.calls[0]?.[0]).toMatchObject({ attachOnly: true })
+    expect(spawn.mock.calls[1]?.[0]).not.toHaveProperty('sessionId')
+    expect(result.owner).toBeNull()
+  })
+
+  // A restarted relay renumbers from pty-1, so the message alone cannot distinguish absence from a
+  // lost link — only the class may authorise abandoning the binding.
+  it.each([
+    ['an expired session with no relay evidence', `${SSH_SESSION_EXPIRED_ERROR}: pty-1`],
+    ['a lost link', 'SSH connection lost, reconnecting...'],
+    ['a request timeout', 'Request "pty.attach" timed out after 10000ms']
+  ])('keeps the binding and refuses to respawn after %s', async (_label, message) => {
+    const { run, spawn } = spawnAfterAttachRejection(new Error(message))
+
+    await expect(run()).rejects.toThrow(message)
+    expect(spawn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ipc/pty/provider/liveness.ts
+++ b/src/main/ipc/pty/provider/liveness.ts
@@ -3,7 +3,10 @@ import type { AgentSessionOwnerBinding } from '../../../../shared/agent-session-
 import { agentSessionOwnerBindingsEqual } from '../../../../shared/claimed-agent-pty-owner'
 import { addNodePtyRecoveryHint } from '../../../daemon/node-pty-error-hints'
 import type { Store } from '../../../persistence'
-import { isSshPtyNotFoundError } from '../../../providers/ssh-pty-errors'
+import {
+  isSshPtyAbsentFromRelayError,
+  isSshPtyNotFoundError
+} from '../../../providers/ssh-pty-errors'
 import type { IPtyProvider } from '../../../providers/types'
 import { markClaudePtyExited } from '../../../claude-accounts/live-pty-gate'
 import { ptyIncarnationById, ptyOwnership } from './ownership-state'
@@ -54,7 +57,13 @@ export function normalizeNodePtySpawnError(err: unknown): Error {
 
 export function isPtyAlreadyGoneError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err)
-  return isSshPtyNotFoundError(err) || /Session not found/i.test(message)
+  return (
+    isSshPtyNotFoundError(err) ||
+    // Why: the reattach path rewrites the relay's wording to SSH_SESSION_EXPIRED and only this
+    // class preserves that the relay itself answered "absent" rather than the link dropping.
+    isSshPtyAbsentFromRelayError(err) ||
+    /Session not found/i.test(message)
+  )
 }
 
 export function delay(ms: number): Promise<void> {

--- a/src/main/providers/ssh-pty-errors.ts
+++ b/src/main/providers/ssh-pty-errors.ts
@@ -10,3 +10,25 @@ export function isSshPtyIdentityMismatchError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error)
   return message.includes(SSH_PTY_IDENTITY_MISMATCH_ERROR) || /identity mismatch/i.test(message)
 }
+
+/**
+ * A reachable relay answered for this exact PTY id and reported it absent — positive evidence of
+ * absence from the execution host, so `exited` rather than `unverifiable`
+ * (docs/reference/ssh-execution-boundary.md). Deliberately NOT raised for a transport failure, a
+ * request timeout, a disposed multiplexer, an identity mismatch (the id names a live PTY belonging
+ * to another pane), or `restoreRequired` (the PTY is live, only its source stream is not) — none of
+ * those observe the process, and treating them as absence orphans live remote work.
+ *
+ * Carries the same `SSH_SESSION_EXPIRED` message so message-based consumers are unaffected; only
+ * callers that can act on the stronger verdict test the class.
+ */
+export class SshPtyAbsentFromRelayError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SshPtyAbsentFromRelayError'
+  }
+}
+
+export function isSshPtyAbsentFromRelayError(error: unknown): boolean {
+  return error instanceof SshPtyAbsentFromRelayError
+}

--- a/src/main/providers/ssh-pty-relay-absence-verdict.test.ts
+++ b/src/main/providers/ssh-pty-relay-absence-verdict.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  SSH_PTY_IDENTITY_MISMATCH_ERROR,
+  SSH_SESSION_EXPIRED_ERROR,
+  isSshPtyAbsentFromRelayError
+} from './ssh-pty-errors'
+import { SshPtyProvider } from './ssh-pty-provider'
+
+function providerRejectingAttachWith(error: unknown): SshPtyProvider {
+  const mux = {
+    request: vi.fn().mockRejectedValue(error),
+    notify: vi.fn(),
+    onNotification: vi.fn().mockReturnValue(vi.fn())
+  }
+  return new SshPtyProvider('conn-1', mux as never)
+}
+
+async function reattachRejection(error: unknown): Promise<unknown> {
+  const provider = providerRejectingAttachWith(error)
+  return await provider.spawn({ cols: 80, rows: 24, sessionId: 'pty-1' }).then(
+    () => undefined,
+    (rejection: unknown) => rejection
+  )
+}
+
+describe('SSH PTY relay absence verdict', () => {
+  it('reports a relay-delivered not-found as positive absence', async () => {
+    const rejection = await reattachRejection(new Error('PTY "pty-1" not found'))
+
+    expect(isSshPtyAbsentFromRelayError(rejection)).toBe(true)
+    expect((rejection as Error).message).toBe(`${SSH_SESSION_EXPIRED_ERROR}: pty-1`)
+  })
+
+  it('does not report absence when the id names a live PTY owned by another pane', async () => {
+    const rejection = await reattachRejection(
+      new Error('PTY "pty-1" not found (identity mismatch)')
+    )
+
+    expect(isSshPtyAbsentFromRelayError(rejection)).toBe(false)
+    // Byte-identical to the pre-change message: only the class is new, so the toast humanizer,
+    // both spawn-execute lease paths, and the renderer's substring checks are untouched.
+    expect((rejection as Error).message).toBe(
+      `${SSH_SESSION_EXPIRED_ERROR}: pty-1 ${SSH_PTY_IDENTITY_MISMATCH_ERROR}`
+    )
+  })
+
+  // Loss of contact never observes the process: each of these must stay `unverifiable`.
+  it.each([
+    ['a lost link', 'SSH connection lost, reconnecting...'],
+    ['a disposed multiplexer', 'Multiplexer disposed'],
+    ['a request timeout', 'Request "pty.attach" timed out after 10000ms']
+  ])('does not report absence for %s', async (_label, message) => {
+    const rejection = await reattachRejection(new Error(message))
+
+    expect(isSshPtyAbsentFromRelayError(rejection)).toBe(false)
+    expect((rejection as Error).message).toBe(message)
+  })
+
+  it('does not report absence when the PTY is live but its source needs restoring', async () => {
+    const mux = {
+      request: vi.fn().mockResolvedValue({
+        incarnationId: 'incarnation-1',
+        sourceRecovery: { status: 'restoreRequired', reason: 'checkpointUnavailable' }
+      }),
+      notify: vi.fn(),
+      onNotification: vi.fn().mockReturnValue(vi.fn())
+    }
+    const provider = new SshPtyProvider('conn-1', mux as never)
+
+    const rejection = await provider.spawn({ cols: 80, rows: 24, sessionId: 'pty-1' }).then(
+      () => undefined,
+      (error: unknown) => error
+    )
+
+    expect(isSshPtyAbsentFromRelayError(rejection)).toBe(false)
+    expect((rejection as Error).message).toContain(SSH_SESSION_EXPIRED_ERROR)
+  })
+})

--- a/src/main/providers/ssh-pty-session-reattach.ts
+++ b/src/main/providers/ssh-pty-session-reattach.ts
@@ -3,6 +3,7 @@ import { isPtyIncarnationId, type PtyIncarnationId } from '../../shared/pty-inca
 import {
   SSH_PTY_IDENTITY_MISMATCH_ERROR,
   SSH_SESSION_EXPIRED_ERROR,
+  SshPtyAbsentFromRelayError,
   isSshPtyIdentityMismatchError,
   isSshPtyNotFoundError
 } from './ssh-pty-errors'
@@ -225,10 +226,16 @@ export async function reattachSshPtySession(args: {
     // Why: an expired relay lease must be surfaced distinctly so the renderer clears its binding.
     console.warn(`[ssh-pty] pty.attach FAILED for ${args.sessionId}:`, error)
     if (isSshPtyNotFoundError(error)) {
-      const mismatchMarker = isSshPtyIdentityMismatchError(error)
-        ? ` ${SSH_PTY_IDENTITY_MISMATCH_ERROR}`
-        : ''
-      throw new Error(`${SSH_SESSION_EXPIRED_ERROR}: ${relaySessionId}${mismatchMarker}`)
+      if (isSshPtyIdentityMismatchError(error)) {
+        // The id names a LIVE PTY owned by another pane, so this is not evidence of absence.
+        throw new Error(
+          `${SSH_SESSION_EXPIRED_ERROR}: ${relaySessionId} ${SSH_PTY_IDENTITY_MISMATCH_ERROR}`
+        )
+      }
+      // Why the class: the relay answered for this exact id, so callers holding a pane binding may
+      // retire it and spawn fresh. Plain `SSH_SESSION_EXPIRED` cannot say that — a restarted relay
+      // renumbers from pty-1, so the message alone is indistinguishable from a lost link.
+      throw new SshPtyAbsentFromRelayError(`${SSH_SESSION_EXPIRED_ERROR}: ${relaySessionId}`)
     }
     throw error
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​243 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​243 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |

<!-- /orca-pr-loc -->

7 of 7 in the SSH stack, on top of #16752 (#16746 -> #16747 -> #16748 -> #16750 -> #16751 -> #16752 -> this). The diff below is only this change.

## ELI5

If the relay program on the remote machine dies and restarts, it forgets its shells and numbers new ones from 1 again.

So Orca asks for "pty-1", and the fresh relay honestly answers *"I don't have a pty-1."*

Orca **already knows how to handle that** — throw away the stale link and start a new shell. But the message got flattened into a generic "session expired" error on the way, so the code that checks for *"gone"* couldn't recognise it, and the recovery never ran. You got a terminal that refused to open.

**The fix:** keep the specific answer instead of flattening it, so the recovery that already exists can fire.

**Why this is safe:** the app only treats a shell as gone when the relay is *reachable and says so* — and in one case only after the relay has checked the operating system and confirmed the process is dead. A dropped connection or a timeout never counts, because "I couldn't reach it" is not "it's gone." That distinction was tested by running the real check against every error the connection layer can produce.

**It can never kill anything** — worst case is a shell left running unattached, which was already possible before this change through a different route.

---

## The bug

A relay renumbers its PTYs from `pty-1` on every start. After the relay daemon dies and restarts, a pane still bound to `pty-1` takes the *attach* path against a PTY that no longer exists, and `pty:spawn` rejects outright:

```
[ssh-pty] spawn() called with sessionId=ssh:…@@pty-1, attempting pty.attach
[ssh-pty] pty.attach FAILED for ssh:…@@pty-1: Error: PTY "pty-1" not found
Error occurred in handler for 'pty:spawn': Error: SSH_SESSION_EXPIRED: pty-1
```

**The recovery machinery already existed and was already correct.** `attachStablePaneOwner` (`src/main/ipc/pty/pane/stable-owner.ts:242`) has exactly the right fallback — retire the pane binding, `runtime.onPtyExit`, then let `spawnForStablePane` spawn fresh — and it is gated on `isPtyAlreadyGoneError`.

The defect is one layer up. `reattachSshPtySession` (`src/main/providers/ssh-pty-session-reattach.ts:227-231`) flattened the relay's `PTY "pty-1" not found` into a bare `Error("SSH_SESSION_EXPIRED: pty-1")`, **discarding the evidence**. `isPtyAlreadyGoneError` classifies on that message via `/PTY ".+" not found/`, so it could never match, and the error propagated to the renderer instead of falling back. Observed call path:

```
reattachSshPtySession → reattachSshPtySessionForSpawn → SshPtyProvider.spawn
 → attachStablePaneOwner → adoptStablePane → preparePtyIpcSpawnPreflight → runPtyIpcSpawn
```

This also explains why an earlier attempt in `kill.ts` changed nothing: wrong path entirely.

## The fix

`SshPtyAbsentFromRelayError` carries the verdict the message cannot — *a reachable relay answered for this exact id and reported it absent*. Per `docs/reference/ssh-execution-boundary.md` that is `exited`, not `unverifiable`. `isPtyAlreadyGoneError` also accepts the class.

## Why this is narrow, not just plausible

**Negative space.** `pty.attach` is `src/relay/pty-handler.ts:1763`, and only three throws are inside it:

| site | meaning | classified absent? |
|---|---|---|
| `:1776` | no record, or already disposed | yes |
| `:1789` | relay called `isProcessAlive(pid)`, found it **dead**, marked the physical exit, notified its exit listener, disposed the managed PTY and removed it from its table — *then* threw | yes |
| `:1801` | identity mismatch: the id names a **live** PTY owned by another pane | **no** |

`:1789` is the strongest form of the argument: the relay is not reporting ignorance, it has *verified death and acted on it*. "Not found" reads weaker than it is. The other four `not found` throws (`:958`, `:1942`, `:2042`, `:2051`) are in different methods and unreachable from this path.

Loss of contact cannot be mistaken for absence. Every string `ssh-channel-multiplexer.ts` can synthesise, run against the real `/PTY ".+" not found/i` predicate:

| synthesised at | string | matches? |
| -- | -- | -- |
| `:53` | `SSH connection lost, reconnecting...` | no |
| `:53` | `Multiplexer disposed` | no |
| `:72` | `Request "<m>" timed out after <n>ms` | no |
| `:486` | `Method not found: <m>` | no |
| `:229`, `:261` | `Request "<m>" was cancelled` | no |
| `:607` | `Connection timed out (no ack received)` | no |

The sole place an Error is built from a relay-supplied payload is `handleResponse` (`:520`), so only the two genuine relay strings can ever reach the predicate. `restoreRequired` (the PTY is live, only its source stream is not) keeps its plain Error and is never classified absent.

**Blast radius is one call site.** `isPtyAlreadyGoneError`'s other consumers — `kill.ts:66`, `kill.ts:266`, `inspect.ts:91` — all handle `pty.shutdown` / `pty.inspectProcess` errors. The new class is thrown only from `reattachSshPtySession`, so none of them can ever see it. `stable-owner.ts:242` is the only behaviour that changes.

**Both thrown `error.message` values are byte-identical to the previous ones.** The old code built ``SSH_SESSION_EXPIRED: <id>${mismatchMarker}`` where the marker was `' SSH_PTY_IDENTITY_MISMATCH'` or `''`; the two branches produce exactly those strings.

**The string that crosses IPC does change, and that is the more important half.** Electron serializes the stack, whose first line is `${name}: ${message}`, so the renderer now sees `SshPtyAbsentFromRelayError: SSH_SESSION_EXPIRED: pty-1` where it previously saw `Error: SSH_SESSION_EXPIRED: pty-1`. That is visible in this PR's own e2e observable below. Every consumer was therefore checked against the **changed** string, and none anchors on `Error:` or on a line start — all six match on substring or on a regex with no start anchor. That is *why* it is safe, not an incidental detail:

- `src/main/ipc/pty/ipc/spawn-execute.ts:145-146`
- `src/main/ipc/pty/runtime/spawn-execute.ts:225-226` (the paired-runtime path — easy to miss, there are two)
- `TerminalErrorToast.tsx:32`, the fussiest consumer: `SSH_SESSION_EXPIRED:[ \t]*\S*(?:[ \t]+SSH_PTY_IDENTITY_MISMATCH)?`
- `ipc-pty-connect.ts:124`, `remote-runtime-pty-transport.ts:1526`, `pty-connection/ssh-session-connect.ts:15`

**This is parity with shipped local behaviour, not a new policy.** The local daemon already reaches this exact fallback: `SessionNotFoundError` carries the message `Session not found: <id>` (`daemon-errors.ts:59`), which `isPtyAlreadyGoneError` already matches via `/Session not found/i` (`liveness.ts:65`). Local panes have been retiring their binding and respawning on positive absence for as long as that predicate has existed. This PR gives SSH the same treatment for the same class of evidence.

## Can this abandon or duplicate a LIVE remote session?

It can never **kill** one — the fallback issues no shutdown or kill, only client-side bookkeeping plus a spawn. The failure mode is orphaning, never termination.

**The one real risk, stated plainly:** the relay is authoritative only over *its own id space*. If a daemon is abnormally replaced while the old daemon's PTYs survive, the new daemon truthfully answers "pty-1 not found" while a live shell exists under the old one, and we retire the binding and spawn fresh — orphaning it. This is **pre-existing**: the renderer already did exactly this on `SSH_SESSION_EXPIRED` (`deferred-session-reattach-connect.ts:144-150`); this PR moves the same decision into main for the stable-pane path. Bounded to one extra shell per pane per relay restart.

I previously called this unavoidable. **It is not, and the PR should not claim it is.** Abnormal replacement is one line away: `src/relay/relay-daemon.ts:23-27` handles `uncaughtException` with `relayLogLine` + `socketOwnership.cleanup()` + `process.exit(1)` and **no PTY disposal**, so any uncaught throw in the relay orphans every PTY it owned. And the client is not actually blind here — `relay.status` already returns `pid` and `uptimeMs` (`relay-daemon.ts:130-131`), so a daemon demonstrably younger than the binding is detectable. Two non-blocking follow-ups are filed: dispose PTYs in that handler, and decline to re-run `launchAgent` / `resumeProviderSession` when the answering daemon is younger than the binding.

The fresh spawn uses the *original* request's options, so a request carrying `command` / `launchAgent` / `resumeProviderSession` will run it — pre-existing cold-restore behaviour, not introduced here.

Concurrency: `attachStablePaneOwner` re-resolves the owner **before and after** retiring and aborts with `terminal_pane_owner_changed` if anything moved; `retirePersistedStablePaneOwner` is fenced on the exact ptyId + incarnation. It cannot clobber a pane that re-bound underneath it, and it cannot loop.

## Evidence

**The e2e oracle cannot discriminate this change in either direction** — `ssh-lost-kill-tab-resurrection.spec.ts` passes at the stack tip with `SshPtyAbsentFromRelayError` absent from the build. Don't go looking for oracle evidence that cannot exist. The real evidence is below.

Two grep counts, identical across both runs on this branch, carry the e2e evidence. The pass/fail is incidental.

| count | both runs | what it proves |
|---|---|---|
| `grep -c "Error occurred in handler for 'pty:spawn'"` | **0** | the observable this change controls is gone |
| `grep -c "resurrected the closed tab"` | **0** | any red is a setup timeout, never a correctness failure |

**Primary e2e observable** (deterministic, where the test outcome is not): the presence or absence of

```
Error occurred in handler for 'pty:spawn': SshPtyAbsentFromRelayError: SSH_SESSION_EXPIRED: pty-1
```

Disable the new clause and that line returns; enable it and it is gone, with the run otherwise byte-identical. A/B'd on one tree, one build pipeline.

**Unit A/B:** with the clause disabled, `stable-pane-relay-absence-respawn.test.ts` fails on exactly one case ("spawns fresh once the relay has positively answered for that id") and the others pass. The clause is load-bearing.

**Persistence coverage (added after review).** The first cut of that suite passed no `store`/`worktreeId`, so `attachStablePaneOwner`'s guard (`stable-owner.ts:258-261`) short-circuited and the retirement never ran — which matters, because `retireTerminalSurfaceFromPersistence` deletes the parent tab and its layout when the retired leaf is the last one. `retirePersistedStablePaneOwner` and `attachStablePaneOwner` had **zero** coverage repo-wide. Three tests now drive the fallback against a real in-memory session: a two-leaf tab keeps the tab and the sibling's binding; a one-leaf tab drops from persistence (pinning current behaviour, since the fallback returns `owner: null` so tab survival then rests on the renderer); and a non-absence failure leaves persistence byte-for-byte untouched. A/B'd by removing `worktreeId` — the two persistence tests fail, the rest pass, confirming they exercise the path rather than the guard.

**Two full oracle runs on this branch**, provenance `SshPtyAbsentFromRelayError`=6 in `out/main/index.js` and tombstones=13 in the renderer each time. Both runs: test 2 passed all three cycles; test 1 failed at the cycle-2 `createRemoteTerminalTab` **setup** timeout. `grep -c "resurrected the closed tab"` = **0** in both — any red here is a setup timeout, never a correctness failure.

Test 1's red is a **separate, pre-existing transport defect** that this PR does not touch and did not introduce (own ticket). Its discriminator, in one line:

> At every **reconnect**, `[ssh-relay] Socket probe result:` reads `"DEAD"` in test 1 and `"ALIVE"` in test 2. Whenever the client must launch a **new** relay daemon, the SSH transport drops afterwards and does not recover within 60s. (The initial-connect probe is DEAD in both tests and carries no signal.)

It is intermittent, not deterministic: red 5 of 5 in isolated single-spec runs, green in the full 14-spec lane.

**Gates:** `pnpm tc` clean · **314 files / 3849 tests passed, 0 failed** (providers, ipc/pty, persistence, ssh, tombstones, toast humanizer) · `check:code-quality:changed` 0 findings across 55 files · oxlint + oxfmt clean · no `max-lines` disables.

