### PR TITLE
feat(appearance): app chrome can match terminal theme; configurable status-bar usage format

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -159,6 +159,23 @@ const UiUpdateFields = z
     statusBarVisible: z.boolean().optional(),
     usagePercentageDisplay: z.enum(['used', 'remaining']).optional(),
     statusBarUsageMode: z.enum(['verbose', 'compact']).optional(),
+    statusBarUsageFormat: z
+      .object({
+        template: z.string(),
+        byProvider: z
+          .object({
+            claude: z.string().optional(),
+            codex: z.string().optional(),
+            gemini: z.string().optional(),
+            'opencode-go': z.string().optional(),
+            kimi: z.string().optional(),
+            minimax: z.string().optional(),
+            grok: z.string().optional(),
+            antigravity: z.string().optional()
+          })
+          .optional()
+      })
+      .optional(),
     dismissedUpdateVersion: NullableString.optional(),
     lastUpdateCheckAt: z.number().finite().nullable().optional(),
     pendingUpdateNudgeId: NullableString.optional(),

--- a/src/renderer/src/app-shell/use-app-chrome-layout.ts
+++ b/src/renderer/src/app-shell/use-app-chrome-layout.ts
@@ -3,6 +3,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
 import { canShowRightSidebarForView } from '@/lib/right-sidebar-visibility'
 import { resolveLeftSidebarStyleVariables } from '@/lib/left-sidebar-appearance'
+import { useWorkspaceChromeDocumentStyle } from '@/lib/use-workspace-chrome-document-style'
 import { resolveLeftTitlebarChromeLayout } from '@/lib/titlebar-left-chrome'
 import { shouldShowWorktreeCreationSurface } from '@/lib/worktree-creation-surface'
 import { useAppStore } from '../store'
@@ -48,6 +49,7 @@ export function useAppChromeLayout() {
   )
 
   const systemPrefersDark = useSystemPrefersDark()
+  useWorkspaceChromeDocumentStyle()
   const leftSidebarStyle = useMemo(
     () => resolveLeftSidebarStyleVariables(settings, systemPrefersDark),
     [settings, systemPrefersDark]

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -607,11 +607,11 @@
 }
 
 .markdown-light .markdown-body a {
-  color: #0969da;
+  color: var(--syntax-link, #0969da);
 }
 
 .markdown-dark .markdown-body a {
-  color: #58a6ff;
+  color: var(--syntax-link, #58a6ff);
 }
 
 .markdown-light .markdown-body .markdown-doc-link-broken,
@@ -648,7 +648,7 @@
 }
 
 .markdown-light .markdown-body pre {
-  background: #f6f8fa;
+  background: color-mix(in srgb, var(--foreground) 4%, var(--editor-surface));
   border: 1px solid rgba(0, 0, 0, 0.08);
 }
 
@@ -873,74 +873,74 @@
 /* ── Syntax Highlighting (GitHub-inspired) ────────── */
 
 .markdown-light .hljs {
-  color: #24292f;
+  color: var(--foreground, #24292f);
 }
 
 .markdown-light .hljs-comment,
 .markdown-light .hljs-quote {
-  color: #6e7781;
+  color: var(--syntax-comment, #6e7781);
   font-style: italic;
 }
 
 .markdown-light .hljs-keyword,
 .markdown-light .hljs-selector-tag,
 .markdown-light .hljs-template-tag {
-  color: #cf222e;
+  color: var(--syntax-keyword, #cf222e);
 }
 
 .markdown-light .hljs-string,
 .markdown-light .hljs-doctag,
 .markdown-light .hljs-regexp {
-  color: #0a3069;
+  color: var(--syntax-string, #0a3069);
 }
 
 .markdown-light .hljs-number,
 .markdown-light .hljs-literal {
-  color: #0550ae;
+  color: var(--syntax-number, #0550ae);
 }
 
 .markdown-light .hljs-title,
 .markdown-light .hljs-section {
-  color: #8250df;
+  color: var(--syntax-function, #8250df);
 }
 
 .markdown-light .hljs-type,
 .markdown-light .hljs-built_in {
-  color: #0550ae;
+  color: var(--syntax-type, #0550ae);
 }
 
 .markdown-light .hljs-attr,
 .markdown-light .hljs-attribute {
-  color: #0550ae;
+  color: var(--syntax-type, #0550ae);
 }
 
 .markdown-light .hljs-variable,
 .markdown-light .hljs-template-variable {
-  color: #953800;
+  color: var(--syntax-variable, #953800);
 }
 
 .markdown-light .hljs-tag,
 .markdown-light .hljs-name {
-  color: #116329;
+  color: var(--syntax-tag, #116329);
 }
 
 .markdown-light .hljs-symbol,
 .markdown-light .hljs-bullet,
 .markdown-light .hljs-selector-class,
 .markdown-light .hljs-selector-id {
-  color: #0550ae;
+  color: var(--syntax-function, #0550ae);
 }
 
 .markdown-light .hljs-meta {
-  color: #1f7f34;
+  color: var(--syntax-meta, #1f7f34);
 }
 
 .markdown-light .hljs-addition {
-  color: #116329;
+  color: var(--syntax-addition, #116329);
   background: rgba(46, 160, 67, 0.1);
 }
 .markdown-light .hljs-deletion {
-  color: #82071e;
+  color: var(--syntax-deletion, #82071e);
   background: rgba(248, 81, 73, 0.1);
 }
 
@@ -952,74 +952,74 @@
 }
 
 .markdown-dark .hljs {
-  color: #e6edf3;
+  color: var(--foreground, #e6edf3);
 }
 
 .markdown-dark .hljs-comment,
 .markdown-dark .hljs-quote {
-  color: #8b949e;
+  color: var(--syntax-comment, #8b949e);
   font-style: italic;
 }
 
 .markdown-dark .hljs-keyword,
 .markdown-dark .hljs-selector-tag,
 .markdown-dark .hljs-template-tag {
-  color: #ff7b72;
+  color: var(--syntax-keyword, #ff7b72);
 }
 
 .markdown-dark .hljs-string,
 .markdown-dark .hljs-doctag,
 .markdown-dark .hljs-regexp {
-  color: #a5d6ff;
+  color: var(--syntax-string, #a5d6ff);
 }
 
 .markdown-dark .hljs-number,
 .markdown-dark .hljs-literal {
-  color: #79c0ff;
+  color: var(--syntax-number, #79c0ff);
 }
 
 .markdown-dark .hljs-title,
 .markdown-dark .hljs-section {
-  color: #d2a8ff;
+  color: var(--syntax-function, #d2a8ff);
 }
 
 .markdown-dark .hljs-type,
 .markdown-dark .hljs-built_in {
-  color: #ffa657;
+  color: var(--syntax-type, #ffa657);
 }
 
 .markdown-dark .hljs-attr,
 .markdown-dark .hljs-attribute {
-  color: #79c0ff;
+  color: var(--syntax-type, #79c0ff);
 }
 
 .markdown-dark .hljs-variable,
 .markdown-dark .hljs-template-variable {
-  color: #ffa657;
+  color: var(--syntax-variable, #ffa657);
 }
 
 .markdown-dark .hljs-tag,
 .markdown-dark .hljs-name {
-  color: #7ee787;
+  color: var(--syntax-tag, #7ee787);
 }
 
 .markdown-dark .hljs-symbol,
 .markdown-dark .hljs-bullet,
 .markdown-dark .hljs-selector-class,
 .markdown-dark .hljs-selector-id {
-  color: #d2a8ff;
+  color: var(--syntax-function, #d2a8ff);
 }
 
 .markdown-dark .hljs-meta {
-  color: #79c0ff;
+  color: var(--syntax-meta, #79c0ff);
 }
 
 .markdown-dark .hljs-addition {
-  color: #aff5b4;
+  color: var(--syntax-addition, #aff5b4);
   background: rgba(46, 160, 67, 0.15);
 }
 .markdown-dark .hljs-deletion {
-  color: #ffdcd7;
+  color: var(--syntax-deletion, #ffdcd7);
   background: rgba(248, 81, 73, 0.15);
 }
 

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -1016,121 +1016,121 @@
    inside the <pre> contentDOM — there is no <code> wrapper when using a
    React NodeView, so selectors must target pre > .hljs-* directly. */
 .rich-markdown-code-block-wrapper .hljs-keyword {
-  color: #cf222e;
+  color: var(--syntax-keyword, #cf222e);
 }
 .rich-markdown-code-block-wrapper .hljs-string {
-  color: #0a3069;
+  color: var(--syntax-string, #0a3069);
 }
 .rich-markdown-code-block-wrapper .hljs-number {
-  color: #0550ae;
+  color: var(--syntax-number, #0550ae);
 }
 .rich-markdown-code-block-wrapper .hljs-comment {
-  color: #6e7781;
+  color: var(--syntax-comment, #6e7781);
   font-style: italic;
 }
 .rich-markdown-code-block-wrapper .hljs-function {
-  color: #8250df;
+  color: var(--syntax-function, #8250df);
 }
 .rich-markdown-code-block-wrapper .hljs-title {
-  color: #8250df;
+  color: var(--syntax-function, #8250df);
 }
 .rich-markdown-code-block-wrapper .hljs-built_in {
-  color: #0550ae;
+  color: var(--syntax-type, #0550ae);
 }
 .rich-markdown-code-block-wrapper .hljs-type {
-  color: #0550ae;
+  color: var(--syntax-type, #0550ae);
 }
 .rich-markdown-code-block-wrapper .hljs-attr {
-  color: #0550ae;
+  color: var(--syntax-type, #0550ae);
 }
 .rich-markdown-code-block-wrapper .hljs-selector-class {
-  color: #0550ae;
+  color: var(--syntax-type, #0550ae);
 }
 .rich-markdown-code-block-wrapper .hljs-variable {
-  color: #953800;
+  color: var(--syntax-variable, #953800);
 }
 .rich-markdown-code-block-wrapper .hljs-meta {
-  color: #6e7781;
+  color: var(--syntax-meta, #6e7781);
 }
 .rich-markdown-code-block-wrapper .hljs-tag {
-  color: #116329;
+  color: var(--syntax-tag, #116329);
 }
 .rich-markdown-code-block-wrapper .hljs-name {
-  color: #116329;
+  color: var(--syntax-tag, #116329);
 }
 .rich-markdown-code-block-wrapper .hljs-params {
-  color: #953800;
+  color: var(--syntax-variable, #953800);
 }
 .rich-markdown-code-block-wrapper .hljs-literal {
-  color: #0550ae;
+  color: var(--syntax-number, #0550ae);
 }
 .rich-markdown-code-block-wrapper .hljs-regexp {
-  color: #0a3069;
+  color: var(--syntax-number, #0a3069);
 }
 .rich-markdown-code-block-wrapper .hljs-operator {
-  color: #cf222e;
+  color: var(--syntax-keyword, #cf222e);
 }
 .rich-markdown-code-block-wrapper .hljs-property {
-  color: #0550ae;
+  color: var(--syntax-type, #0550ae);
 }
 
 .dark .rich-markdown-code-block-wrapper .hljs-keyword {
-  color: #ff7b72;
+  color: var(--syntax-keyword, #ff7b72);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-string {
-  color: #a5d6ff;
+  color: var(--syntax-string, #a5d6ff);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-number {
-  color: #79c0ff;
+  color: var(--syntax-number, #79c0ff);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-comment {
-  color: #8b949e;
+  color: var(--syntax-comment, #8b949e);
   font-style: italic;
 }
 .dark .rich-markdown-code-block-wrapper .hljs-function {
-  color: #d2a8ff;
+  color: var(--syntax-function, #d2a8ff);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-title {
-  color: #d2a8ff;
+  color: var(--syntax-function, #d2a8ff);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-built_in {
-  color: #79c0ff;
+  color: var(--syntax-type, #79c0ff);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-type {
-  color: #79c0ff;
+  color: var(--syntax-type, #79c0ff);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-attr {
-  color: #79c0ff;
+  color: var(--syntax-type, #79c0ff);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-selector-class {
-  color: #79c0ff;
+  color: var(--syntax-type, #79c0ff);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-variable {
-  color: #ffa657;
+  color: var(--syntax-variable, #ffa657);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-meta {
-  color: #8b949e;
+  color: var(--syntax-meta, #8b949e);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-tag {
-  color: #7ee787;
+  color: var(--syntax-tag, #7ee787);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-name {
-  color: #7ee787;
+  color: var(--syntax-tag, #7ee787);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-params {
-  color: #ffa657;
+  color: var(--syntax-variable, #ffa657);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-literal {
-  color: #79c0ff;
+  color: var(--syntax-number, #79c0ff);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-regexp {
-  color: #a5d6ff;
+  color: var(--syntax-number, #a5d6ff);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-operator {
-  color: #ff7b72;
+  color: var(--syntax-keyword, #ff7b72);
 }
 .dark .rich-markdown-code-block-wrapper .hljs-property {
-  color: #79c0ff;
+  color: var(--syntax-type, #79c0ff);
 }
 
 .rich-markdown-editor hr {

--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -45,6 +45,7 @@ type DiffSectionBodyProps = {
   onMount: DiffOnMount
 }
 
+/** Body of one combined-diff section: Monaco diff, image compare, or placeholder for unloaded content. */
 export function DiffSectionBody({
   section,
   index,

--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -31,7 +31,7 @@ type DiffSectionBodyProps = {
   addLineCommentLabel?: string
   isBranchMode: boolean
   sideBySide: boolean
-  isDark: boolean
+  monacoTheme: string
   language: string
   modelPathBase: string
   isEditable: boolean
@@ -56,7 +56,7 @@ export function DiffSectionBody({
   addLineCommentLabel,
   isBranchMode,
   sideBySide,
-  isDark,
+  monacoTheme,
   language,
   modelPathBase,
   isEditable,
@@ -177,7 +177,7 @@ export function DiffSectionBody({
           language={language}
           original={section.originalContent}
           modified={section.modifiedContent}
-          theme={isDark ? 'vs-dark' : 'vs'}
+          theme={monacoTheme}
           onMount={onMount}
           // Why: @monaco-editor/react can dispose models before widget teardown.
           // Keep them through unmount and dispose unattached models next tick.

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -29,7 +29,7 @@ export function DiffSectionItem({
   index,
   isBranchMode,
   sideBySide,
-  isDark,
+  monacoTheme,
   settings,
   sectionHeight,
   worktreeId,
@@ -366,7 +366,7 @@ export function DiffSectionItem({
           addLineCommentLabel={addLineCommentLabel}
           isBranchMode={isBranchMode}
           sideBySide={sideBySide}
-          isDark={isDark}
+          monacoTheme={monacoTheme}
           language={language}
           modelPathBase={modelPathBase}
           isEditable={isEditable}

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -24,6 +24,7 @@ import { submitDiffSectionComment } from './diff-section-comment-submit'
 import type { DiffSectionItemProps } from './diff-section-item-props'
 import { useDiffSectionModelLifecycle } from './use-diff-section-model-lifecycle'
 
+/** One file entry in the combined diff: header, Monaco model lifecycle and the section body. */
 export function DiffSectionItem({
   section,
   index,

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -29,6 +29,7 @@ import { useDiffEditorRegistration } from './diff-navigation-context'
 import { preserveDiffViewStateAcrossModelSwaps } from './diff-model-swap-view-state'
 import { monacoFindOptions } from './monaco-find-options'
 
+/** Monaco diff editor for a single file, keeping view state across model swaps. */
 export default function DiffViewer({
   modelKey,
   originalModelKey,

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSta
 import { DiffEditor, type DiffOnMount } from '@monaco-editor/react'
 import type { editor } from 'monaco-editor'
 import { useAppStore } from '@/store'
+import { useMonacoEditorTheme } from './use-monaco-editor-theme'
 import { diffViewStateCache, setWithLRU } from '@/lib/scroll-cache'
 import { monaco } from '@/lib/monaco-setup'
 import { computeDiffEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
@@ -66,9 +67,7 @@ export default function DiffViewer({
   )
   const terminalFontSize = settings?.terminalFontSize ?? 13
   const diffEditorFontSize = computeDiffEditorFontSize(terminalFontSize, editorFontZoomLevel)
-  const isDark =
-    settings?.theme === 'dark' ||
-    (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const { theme: monacoTheme } = useMonacoEditorTheme()
 
   const diffEditorRef = useRef<editor.IStandaloneDiffEditor | null>(null)
   const { registerDiffEditor, unregisterDiffEditor } = useDiffEditorRegistration()
@@ -408,7 +407,7 @@ export default function DiffViewer({
             language={language}
             original={originalContent}
             modified={modifiedContent}
-            theme={isDark ? 'vs-dark' : 'vs'}
+            theme={monacoTheme}
             onMount={handleMount}
             // Why: a file can have multiple live diff tabs, so key models off tab identity (not file path) to avoid cross-tab reuse.
             // Why: Changes mode rotates only the original-side model after HEAD moves, preserving the modified side's undo stack.

--- a/src/renderer/src/components/editor/IpynbCellEditor.tsx
+++ b/src/renderer/src/components/editor/IpynbCellEditor.tsx
@@ -38,6 +38,7 @@ export function IpynbEditableTextCell({
   )
 }
 
+/** Monaco-backed editor for one notebook code cell; mounts only while the cell is active. */
 function IpynbCodeCellEditor({
   cell,
   source,

--- a/src/renderer/src/components/editor/IpynbCellEditor.tsx
+++ b/src/renderer/src/components/editor/IpynbCellEditor.tsx
@@ -1,12 +1,11 @@
-import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
+import { memo, useCallback, useLayoutEffect, useMemo, useRef } from 'react'
 import Editor, { type OnMount } from '@monaco-editor/react'
 import Markdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize from 'rehype-sanitize'
 import remarkGfm from 'remark-gfm'
-import { monaco } from '@/lib/monaco-setup'
 import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
-import { resolveDocumentTheme } from '@/lib/document-theme'
+import { useMonacoEditorTheme } from './use-monaco-editor-theme'
 import { useAppStore } from '@/store'
 import { installEditorSaveShortcut, installMonacoEditorFindShortcut } from './editor-shortcuts'
 import { getIpynbCodeCellEditorHeight, getIpynbCodeCellPreviewLines } from './ipynb-code-cell-lines'
@@ -66,7 +65,7 @@ function IpynbCodeCellEditor({
   }, [onDeactivate, onSaveRequest])
   const fontSize = computeEditorFontSize(settings?.terminalFontSize ?? 13, editorFontZoomLevel)
   const editorHeight = getIpynbCodeCellEditorHeight(source, fontSize)
-  const isDark = resolveDocumentTheme(settings?.theme ?? 'system')
+  const { theme: monacoTheme } = useMonacoEditorTheme()
   const lines = useMemo(() => getIpynbCodeCellPreviewLines(source), [source])
   const handleMount: OnMount = useCallback((editorInstance, monacoInstance) => {
     editorInstance.focus()
@@ -89,10 +88,6 @@ function IpynbCodeCellEditor({
       onDeactivateRef.current()
     })
   }, [])
-
-  useEffect(() => {
-    monaco.editor.setTheme(isDark ? 'vs-dark' : 'vs')
-  }, [isDark])
 
   if (!active) {
     return (
@@ -124,7 +119,7 @@ function IpynbCodeCellEditor({
         height={editorHeight}
         defaultLanguage={cell.language}
         language={cell.language}
-        theme={isDark ? 'vs-dark' : 'vs'}
+        theme={monacoTheme}
         value={source}
         onMount={handleMount}
         onChange={(value) => onChange(value ?? '')}

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -510,6 +510,7 @@ export function getMarkdownPreviewSourceRelativePath(
   return relativePathInsideRoot(sourceWorktreePath, filePath)
 }
 
+/** Rendered markdown view with Mermaid, task-list, link and image handling relative to the source file. */
 export default function MarkdownPreview({
   content,
   filePath,

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -35,6 +35,7 @@ import type { Components, Options as ReactMarkdownOptions } from 'react-markdown
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useAppStore } from '@/store'
+import { useEditorSurfaceAppearance } from './use-editor-surface-appearance'
 import { toast } from 'sonner'
 import { computeEditorFontSize } from '@/lib/editor-font-zoom'
 import { getConnectionIdForFile } from '@/lib/connection-context'
@@ -640,9 +641,7 @@ export default function MarkdownPreview({
   )
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const editorFontSize = computeEditorFontSize(14, editorFontZoomLevel)
-  const isDark =
-    settings?.theme === 'dark' ||
-    (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const { isDark } = useEditorSurfaceAppearance()
 
   const renderedContent = usePreserveSectionDuringExternalEdit(content, bodyRef)
 

--- a/src/renderer/src/components/editor/MermaidViewer.tsx
+++ b/src/renderer/src/components/editor/MermaidViewer.tsx
@@ -8,10 +8,10 @@ type MermaidViewerProps = {
   filePath: string
 }
 
-// Why: MermaidViewer is the full-file counterpart to MermaidBlock (which
-// renders fenced mermaid blocks inside markdown). When a user opens a .mmd
-// or .mermaid file in diagram mode, the entire file content is the diagram
-// source — no markdown wrapper, no frontmatter, just mermaid syntax.
+/**
+ * Full-file Mermaid diagram view, the counterpart to MermaidBlock (fenced blocks inside markdown).
+ * Why: a .mmd / .mermaid file in diagram mode is pure diagram source — no markdown wrapper, no frontmatter.
+ */
 export default function MermaidViewer({
   content,
   filePath

--- a/src/renderer/src/components/editor/MermaidViewer.tsx
+++ b/src/renderer/src/components/editor/MermaidViewer.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useRef } from 'react'
-import { useAppStore } from '@/store'
+import { useEditorSurfaceAppearance } from './use-editor-surface-appearance'
 import { scrollTopCache, setWithLRU } from '@/lib/scroll-cache'
 import MermaidBlock from './MermaidBlock'
 
@@ -17,10 +17,7 @@ export default function MermaidViewer({
   filePath
 }: MermaidViewerProps): React.JSX.Element {
   const rootRef = useRef<HTMLDivElement>(null)
-  const settings = useAppStore((s) => s.settings)
-  const isDark =
-    settings?.theme === 'dark' ||
-    (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const { isDark } = useEditorSurfaceAppearance()
 
   // Why: Each viewing mode (source vs diagram) produces different DOM heights.
   // Mode-scoped keys prevent restoring a source-mode scroll position in diagram

--- a/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
+++ b/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
@@ -38,6 +38,7 @@ type MonacoCodeExcerptProps = {
   language: string
 }
 
+/** Read-only Monaco snippet showing a few lines of a file with a highlighted range. */
 export default function MonacoCodeExcerpt({
   lines,
   firstLineNumber,

--- a/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
+++ b/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { monaco } from '@/lib/monaco-setup'
 import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
-import { resolveDocumentTheme } from '@/lib/document-theme'
+import { useMonacoEditorTheme } from './use-monaco-editor-theme'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 
@@ -52,13 +52,9 @@ export default function MonacoCodeExcerpt({
     editorFontZoomLevel
   )
   const fontFamily = resolveEditorFontFamily(settings)
-  const isDark = resolveDocumentTheme(settings?.theme ?? 'system')
+  useMonacoEditorTheme()
   const code = useMemo(() => lines.join('\n'), [lines])
   const [htmlLines, setHtmlLines] = useState<string[]>(() => lines.map(() => ''))
-
-  useEffect(() => {
-    monaco.editor.setTheme(isDark ? 'vs-dark' : 'vs')
-  }, [isDark])
 
   useEffect(() => {
     if (lines.length === 0) {

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -4,6 +4,7 @@ import Editor from '@monaco-editor/react'
 import type { editor } from 'monaco-editor'
 import type { MarkdownDocument } from '../../../../shared/filesystem-entry-types'
 import { useAppStore } from '@/store'
+import { useMonacoEditorTheme } from './use-monaco-editor-theme'
 import '@/lib/monaco-setup'
 import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 
@@ -114,9 +115,7 @@ export default function MonacoEditor({
   const [gutterMenuOpen, setGutterMenuOpen] = useState(false)
   const [gutterMenuPoint, setGutterMenuPoint] = useState({ x: 0, y: 0 })
   const [gutterMenuLine, setGutterMenuLine] = useState(1)
-  const isDark =
-    settings?.theme === 'dark' ||
-    (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const { theme: monacoTheme } = useMonacoEditorTheme()
 
   const { queueReveal, cancelScheduledReveal, clearTransientRevealHighlight } =
     useMonacoRevealScheduler()
@@ -231,7 +230,7 @@ export default function MonacoEditor({
         language={language}
         // Why: defaultValue, not controlled value — Orca owns post-mount content sync; a controlled path would double setValue.
         defaultValue={content}
-        theme={isDark ? 'vs-dark' : 'vs'}
+        theme={monacoTheme}
         onChange={contentSync.handleChange}
         onMount={handleMount}
         options={{

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -46,6 +46,7 @@ type MonacoEditorProps = {
   autoHeight?: boolean
 }
 
+/** Main Monaco file editor: wires models, view state, find, autosave and the surface theme. */
 export default function MonacoEditor({
   fileId,
   filePath,

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import type { NodeViewProps } from '@tiptap/react'
 import { Copy, Check } from 'lucide-react'
-import { useAppStore } from '@/store'
+import { useEditorSurfaceAppearance } from './use-editor-surface-appearance'
 import MermaidBlock from './MermaidBlock'
 import { translate } from '@/i18n/i18n'
 import {
@@ -28,10 +28,7 @@ export function RichMarkdownCodeBlock({
   // Why: clipboard IPC can resolve after the node view unmounts; avoid
   // starting a reset timer that will outlive the component.
   const isMountedRef = useRef(false)
-  const settings = useAppStore((s) => s.settings)
-  const isDark =
-    settings?.theme === 'dark' ||
-    (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const { isDark } = useEditorSurfaceAppearance()
 
   const isMermaid = language === 'mermaid'
 

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -13,6 +13,7 @@ import {
   isKnownCodeBlockLanguage
 } from './rich-markdown-code-block-languages'
 
+/** Tiptap node view for a fenced code block with a language picker and copy action. */
 export function RichMarkdownCodeBlock({
   node,
   updateAttributes

--- a/src/renderer/src/components/editor/combined-diff/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/combined-diff/CombinedDiffViewer.tsx
@@ -38,6 +38,7 @@ import { useCombinedDiffNotesActions } from './review-controls/use-combined-diff
 import { useCombinedDiffSectionActions } from './review-controls/use-combined-diff-section-actions'
 import { useCombinedDiffViewPreferences } from './review-controls/use-combined-diff-view-preferences'
 
+/** All changed files of a worktree in one scrolling diff with a collapsible file tree. */
 export default function CombinedDiffViewer({
   file,
   viewStateKey

--- a/src/renderer/src/components/editor/combined-diff/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/combined-diff/CombinedDiffViewer.tsx
@@ -6,6 +6,7 @@ import { selectWorktreeDiffCommentsOrEmpty } from '@/store/worktree-diff-comment
 import type { OpenFile } from '@/store/slices/editor'
 import '@/lib/monaco-setup'
 import type { DiffSection } from '../diff-section-types'
+import { useMonacoEditorTheme } from '../use-monaco-editor-theme'
 import {
   EMPTY_GIT_BRANCH_ENTRIES,
   EMPTY_GIT_STATUS_ENTRIES,
@@ -62,9 +63,7 @@ export default function CombinedDiffViewer({
   )
   const activeGroupId = useAppStore((s) => s.activeGroupIdByWorktree[file.worktreeId])
   const canOpenWorkspaceFileBrowserForPath = useWorkspaceFileBrowserActionPredicate(file.worktreeId)
-  const isDark =
-    settings?.theme === 'dark' ||
-    (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const { theme: monacoTheme } = useMonacoEditorTheme()
 
   const [sections, setSections] = useState<DiffSection[]>([])
   const [sectionHeights, setSectionHeights] = useState<Record<number, number>>({})
@@ -349,7 +348,7 @@ export default function CombinedDiffViewer({
             isAllMode={entrySet.isAllMode}
             isBranchMode={entrySet.isBranchMode}
             isCommitMode={entrySet.isCommitMode}
-            isDark={isDark}
+            monacoTheme={monacoTheme}
             loadSection={loadSection}
             markDirectScrollInput={markDirectScrollInput}
             modifiedEditorsRef={modifiedEditorsRef}

--- a/src/renderer/src/components/editor/combined-diff/scroll-viewport/combined-diff-section-list.tsx
+++ b/src/renderer/src/components/editor/combined-diff/scroll-viewport/combined-diff-section-list.tsx
@@ -19,7 +19,7 @@ export function CombinedDiffSectionList({
   isAllMode,
   isBranchMode,
   isCommitMode,
-  isDark,
+  monacoTheme,
   loadSection,
   markDirectScrollInput,
   modifiedEditorsRef,
@@ -47,7 +47,7 @@ export function CombinedDiffSectionList({
   isAllMode: boolean
   isBranchMode: boolean
   isCommitMode: boolean
-  isDark: boolean
+  monacoTheme: string
   loadSection: (index: number) => void
   markDirectScrollInput: () => void
   modifiedEditorsRef: DiffSectionItemProps['modifiedEditorsRef']
@@ -99,7 +99,7 @@ export function CombinedDiffSectionList({
                   index={virtualItem.index}
                   isBranchMode={isBranchMode}
                   sideBySide={sideBySide}
-                  isDark={isDark}
+                  monacoTheme={monacoTheme}
                   settings={settings}
                   sectionHeight={sectionHeights[virtualItem.index]}
                   worktreeId={file.worktreeId}

--- a/src/renderer/src/components/editor/diff-section-item-props.ts
+++ b/src/renderer/src/components/editor/diff-section-item-props.ts
@@ -8,7 +8,8 @@ export type DiffSectionItemProps = {
   index: number
   isBranchMode: boolean
   sideBySide: boolean
-  isDark: boolean
+  /** Monaco theme name resolved by the owning viewer; Monaco's theme is global. */
+  monacoTheme: string
   settings: {
     terminalFontSize?: number
     terminalFontFamily?: string

--- a/src/renderer/src/components/editor/monaco-terminal-theme-registry.ts
+++ b/src/renderer/src/components/editor/monaco-terminal-theme-registry.ts
@@ -1,0 +1,22 @@
+import { monaco } from '@/lib/monaco-setup'
+import {
+  buildMonacoThemeData,
+  TERMINAL_MONACO_THEME_NAME,
+  type TerminalEditorPalette
+} from '@/lib/terminal-editor-palette'
+
+let definedThemeSignature: string | null = null
+
+/**
+ * Registers the terminal-derived Monaco theme for `palette` and returns its name. Monaco themes are
+ * global, so the signature guard keeps repeated calls from every editor instance idempotent.
+ */
+export function ensureTerminalMonacoTheme(palette: TerminalEditorPalette): string {
+  const themeData = buildMonacoThemeData(palette)
+  const signature = JSON.stringify(themeData)
+  if (signature !== definedThemeSignature) {
+    monaco.editor.defineTheme(TERMINAL_MONACO_THEME_NAME, themeData)
+    definedThemeSignature = signature
+  }
+  return TERMINAL_MONACO_THEME_NAME
+}

--- a/src/renderer/src/components/editor/use-editor-surface-appearance.ts
+++ b/src/renderer/src/components/editor/use-editor-surface-appearance.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+import { useAppStore } from '@/store'
+import {
+  resolveEditorSurfaceAppearance,
+  type EditorSurfaceAppearance
+} from '@/lib/terminal-editor-palette'
+import { useSystemPrefersDark } from '../terminal-pane/use-system-prefers-dark'
+
+/** Light/dark flag (and terminal palette, when the chrome follows it) for markdown, mermaid, and viewer panes. */
+export function useEditorSurfaceAppearance(): EditorSurfaceAppearance {
+  const settings = useAppStore((s) => s.settings)
+  const systemPrefersDark = useSystemPrefersDark()
+  return useMemo(
+    () => resolveEditorSurfaceAppearance(settings, systemPrefersDark),
+    [settings, systemPrefersDark]
+  )
+}

--- a/src/renderer/src/components/editor/use-monaco-editor-theme.ts
+++ b/src/renderer/src/components/editor/use-monaco-editor-theme.ts
@@ -1,0 +1,31 @@
+import { useLayoutEffect, useMemo } from 'react'
+import { monaco } from '@/lib/monaco-setup'
+import { buildMonacoThemeData, TERMINAL_MONACO_THEME_NAME } from '@/lib/terminal-editor-palette'
+import { useEditorSurfaceAppearance } from './use-editor-surface-appearance'
+
+let definedThemeSignature: string | null = null
+
+/** Monaco theme name for the current appearance; defines/re-applies the terminal-derived theme as it changes. */
+export function useMonacoEditorTheme(): { isDark: boolean; theme: string } {
+  const { isDark, palette } = useEditorSurfaceAppearance()
+  const theme = useMemo(() => {
+    if (!palette) {
+      return isDark ? 'vs-dark' : 'vs'
+    }
+    // Why: define during render so a child <Editor> mounting before this hook's effects already finds
+    // the theme registered; the signature guard keeps the global redefinition idempotent across instances.
+    const themeData = buildMonacoThemeData(palette)
+    const signature = JSON.stringify(themeData)
+    if (signature !== definedThemeSignature) {
+      monaco.editor.defineTheme(TERMINAL_MONACO_THEME_NAME, themeData)
+      definedThemeSignature = signature
+    }
+    return TERMINAL_MONACO_THEME_NAME
+  }, [isDark, palette])
+  useLayoutEffect(() => {
+    // Why: Monaco's theme is global and @monaco-editor/react only re-applies on a name change, so a
+    // redefined orca-terminal (terminal theme switched) needs an explicit setTheme; same-theme calls are no-ops.
+    monaco.editor.setTheme(theme)
+  }, [theme, palette])
+  return { isDark, theme }
+}

--- a/src/renderer/src/components/editor/use-monaco-editor-theme.ts
+++ b/src/renderer/src/components/editor/use-monaco-editor-theme.ts
@@ -1,9 +1,7 @@
 import { useLayoutEffect, useMemo } from 'react'
 import { monaco } from '@/lib/monaco-setup'
-import { buildMonacoThemeData, TERMINAL_MONACO_THEME_NAME } from '@/lib/terminal-editor-palette'
+import { ensureTerminalMonacoTheme } from './monaco-terminal-theme-registry'
 import { useEditorSurfaceAppearance } from './use-editor-surface-appearance'
-
-let definedThemeSignature: string | null = null
 
 /** Monaco theme name for the current appearance; defines/re-applies the terminal-derived theme as it changes. */
 export function useMonacoEditorTheme(): { isDark: boolean; theme: string } {
@@ -13,14 +11,8 @@ export function useMonacoEditorTheme(): { isDark: boolean; theme: string } {
       return isDark ? 'vs-dark' : 'vs'
     }
     // Why: define during render so a child <Editor> mounting before this hook's effects already finds
-    // the theme registered; the signature guard keeps the global redefinition idempotent across instances.
-    const themeData = buildMonacoThemeData(palette)
-    const signature = JSON.stringify(themeData)
-    if (signature !== definedThemeSignature) {
-      monaco.editor.defineTheme(TERMINAL_MONACO_THEME_NAME, themeData)
-      definedThemeSignature = signature
-    }
-    return TERMINAL_MONACO_THEME_NAME
+    // the theme registered.
+    return ensureTerminalMonacoTheme(palette)
   }, [isDark, palette])
   useLayoutEffect(() => {
     // Why: Monaco's theme is global and @monaco-editor/react only re-applies on a name change, so a

--- a/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-body.tsx
+++ b/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-body.tsx
@@ -31,7 +31,7 @@ export function PRFilesCombinedDiffBody({
   scrollContainerRef,
   virtualizer,
   sections,
-  isDark,
+  monacoTheme,
   settings,
   sectionHeights,
   inlineReviewComments,
@@ -65,7 +65,7 @@ export function PRFilesCombinedDiffBody({
   scrollContainerRef: React.RefObject<HTMLDivElement | null>
   virtualizer: Virtualizer<HTMLDivElement, Element>
   sections: DiffSection[]
-  isDark: boolean
+  monacoTheme: string
   settings: DiffSectionItemProps['settings']
   sectionHeights: Record<number, number>
   inlineReviewComments: DecoratedDiffComment[]
@@ -127,7 +127,7 @@ export function PRFilesCombinedDiffBody({
                     index={virtualItem.index}
                     isBranchMode={false}
                     sideBySide={sideBySide}
-                    isDark={isDark}
+                    monacoTheme={monacoTheme}
                     settings={settings}
                     sectionHeight={sectionHeights[virtualItem.index]}
                     worktreeId={`github-pr:${repoId}:${prNumber}`}

--- a/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-body.tsx
+++ b/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-body.tsx
@@ -12,6 +12,7 @@ import type { GitBranchChangeEntry } from '../../../../../shared/git-diff-compar
 import type { DiffSectionItemProps } from '@/components/editor/diff-section-item-props'
 import { PRFilesCombinedDiffToolbar } from './pr-files-combined-diff-toolbar'
 
+/** Toolbar plus combined diff sections for a pull request’s files inside the inspect dialog. */
 export function PRFilesCombinedDiffBody({
   files,
   repoPath,

--- a/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-viewer.tsx
+++ b/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-viewer.tsx
@@ -73,6 +73,7 @@ export function PRFilesCombinedDiffViewer(
   )
 }
 
+/** Scrollable list of per-file diff sections for the inspected pull request. */
 function PRFilesCombinedDiffSections({
   files,
   comments,

--- a/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-viewer.tsx
+++ b/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-viewer.tsx
@@ -12,6 +12,7 @@ import type { DiffSection } from '@/components/editor/diff-section-types'
 import { getCombinedDiffBranchEntriesInTreeOrder } from '../../editor/combined-diff/browse-files/combined-diff-file-tree-filter'
 import type { CombinedDiffFileTreeEntry } from '../../editor/combined-diff/resolve-changes/combined-diff-section-identity'
 import { useAppStore } from '@/store'
+import { useMonacoEditorTheme } from '@/components/editor/use-monaco-editor-theme'
 import type { GitBranchChangeEntry } from '../../../../../shared/git-diff-compare-types'
 import { isPRFileViewed } from '@/components/github/pr-file-content-size'
 import {
@@ -92,9 +93,7 @@ function PRFilesCombinedDiffSections({
   setFileTreeCollapsed
 }: PRFilesCombinedDiffSectionsProps): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
-  const isDark =
-    settings?.theme === 'dark' ||
-    (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const { theme: monacoTheme } = useMonacoEditorTheme()
   // Why: this subtree is keyed by the diff signature, so its file set is fixed for the
   // mount. Freezing it in state keeps a stable identity without caching through a ref.
   const [entries] = useState<GitBranchChangeEntry[]>(() =>
@@ -358,7 +357,7 @@ function PRFilesCombinedDiffSections({
       scrollContainerRef={scrollContainerRef}
       virtualizer={virtualizer}
       sections={sections}
-      isDark={isDark}
+      monacoTheme={monacoTheme}
       settings={settings}
       sectionHeights={sectionHeights}
       inlineReviewComments={inlineReviewComments}

--- a/src/renderer/src/components/pull-request-page/files/combined-diff-viewer.tsx
+++ b/src/renderer/src/components/pull-request-page/files/combined-diff-viewer.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSta
 import { useVirtualizer } from '@tanstack/react-virtual'
 import type { editor as monacoEditor } from 'monaco-editor'
 import { useAppStore } from '@/store'
+import { useMonacoEditorTheme } from '@/components/editor/use-monaco-editor-theme'
 import { DiffSectionItem } from '@/components/editor/DiffSectionItem'
 import { CombinedDiffFileTree } from '../../editor/combined-diff/browse-files/combined-diff-file-tree'
 import { createCombinedDiffSectionIndexMap } from '../../editor/combined-diff/resolve-changes/combined-diff-section-identity'
@@ -48,9 +49,7 @@ export function PRFilesCombinedDiffViewer({
   onViewedChange
 }: PRFilesCombinedDiffViewerProps): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
-  const isDark =
-    settings?.theme === 'dark' ||
-    (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const { theme: monacoTheme } = useMonacoEditorTheme()
   const diffEntrySignature = useMemo(
     () =>
       JSON.stringify(
@@ -359,7 +358,7 @@ export function PRFilesCombinedDiffViewer({
                     index={virtualItem.index}
                     isBranchMode={false}
                     sideBySide={sideBySide}
-                    isDark={isDark}
+                    monacoTheme={monacoTheme}
                     settings={settings}
                     sectionHeight={sectionHeights[virtualItem.index]}
                     worktreeId={`github-pr:${repoId}:${prNumber}`}

--- a/src/renderer/src/components/pull-request-page/files/combined-diff-viewer.tsx
+++ b/src/renderer/src/components/pull-request-page/files/combined-diff-viewer.tsx
@@ -33,6 +33,7 @@ import { buildInlineReviewComments } from './inline-comments'
 import { usePRFileSectionHeights } from './section-heights'
 import { usePRFileActiveSection } from './active-section'
 
+/** Combined diff of a pull request’s files with file tree, section heights and active-section tracking. */
 export function PRFilesCombinedDiffViewer({
   files,
   comments,

--- a/src/renderer/src/components/settings/AppearancePane.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.test.tsx
@@ -24,6 +24,8 @@ const mocks = vi.hoisted(() => ({
     toggleStatusBarItem: vi.fn(),
     usagePercentageDisplay: 'used' as 'used' | 'remaining',
     setUsagePercentageDisplay: vi.fn(),
+    statusBarUsageFormat: { template: '' },
+    setStatusBarUsageFormat: vi.fn(),
     recordFeatureInteraction: vi.fn(),
     setWorktreeCardMode: vi.fn(),
     appearanceAccordionDeepLink: null as 'interface' | 'terminal' | 'window' | null,

--- a/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
@@ -21,10 +21,12 @@ import {
 } from './appearance-search'
 import { USAGE_PERCENTAGE_DISPLAY_SETTING_ID } from './appearance-usage-percentage-search'
 import { LeftSidebarAppearanceSetting } from './LeftSidebarAppearanceSetting'
+import { WorkspaceChromeAppearanceSetting } from './WorkspaceChromeAppearanceSetting'
 import {
   getLeftSidebarAppearanceEntry,
   getShowPinnedWorktreesInGroupsEntry,
-  getWorkspaceCardLayoutEntry
+  getWorkspaceCardLayoutEntry,
+  getWorkspaceChromeAppearanceEntry
 } from './appearance-sidebar-search'
 import { translate } from '@/i18n/i18n'
 import { matchesSettingsSearch, normalizeSettingsSearchQuery } from './settings-search'
@@ -75,6 +77,7 @@ export function AppearanceWindowSidebarSection({
   const visibleStatusBarToggles = useAvailableStatusBarToggles(getStatusBarToggles())
   const usagePercentageDisplayEntry = getUsagePercentageDisplayEntry()
   const leftSidebarAppearanceEntry = getLeftSidebarAppearanceEntry()
+  const workspaceChromeAppearanceEntry = getWorkspaceChromeAppearanceEntry()
   const sidebarEntries = getSidebarEntries()
   const workspaceCardLayoutEntry = getWorkspaceCardLayoutEntry()
   const layoutEntries = getLayoutEntries()
@@ -122,6 +125,15 @@ export function AppearanceWindowSidebarSection({
           forceVisible={forceVisiblePrimary}
         >
           <LeftSidebarAppearanceSetting settings={settings} updateSettings={updateSettings} />
+        </SearchableSetting>
+
+        <SearchableSetting
+          title={workspaceChromeAppearanceEntry.title}
+          description={workspaceChromeAppearanceEntry.description}
+          keywords={workspaceChromeAppearanceEntry.keywords}
+          forceVisible={forceVisiblePrimary}
+        >
+          <WorkspaceChromeAppearanceSetting settings={settings} updateSettings={updateSettings} />
         </SearchableSetting>
 
         <SearchableSetting

--- a/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
@@ -63,6 +63,7 @@ function recordStatusBarToggleInteraction(
   }
 }
 
+/** Window & Sidebar appearance section: sidebar/chrome appearance, status bar controls, and layout advanced settings. */
 export function AppearanceWindowSidebarSection({
   settings,
   updateSettings,
@@ -102,6 +103,7 @@ export function AppearanceWindowSidebarSection({
   })
   const statusBarControlMatches =
     matchesSettingsSearch(searchQuery, usagePercentageDisplayEntry) ||
+    matchesSettingsSearch(searchQuery, statusBarUsageFormatEntry) ||
     visibleStatusBarToggles.some((toggle) =>
       matchesSettingsSearch(searchQuery, {
         title: toggle.title,

--- a/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
@@ -20,6 +20,8 @@ import {
   getUsagePercentageDisplayEntry
 } from './appearance-search'
 import { USAGE_PERCENTAGE_DISPLAY_SETTING_ID } from './appearance-usage-percentage-search'
+import { getStatusBarUsageFormatEntry } from './appearance-status-bar-usage-format-search'
+import { StatusBarUsageFormatSetting } from './StatusBarUsageFormatSetting'
 import { LeftSidebarAppearanceSetting } from './LeftSidebarAppearanceSetting'
 import { WorkspaceChromeAppearanceSetting } from './WorkspaceChromeAppearanceSetting'
 import {
@@ -76,6 +78,9 @@ export function AppearanceWindowSidebarSection({
   const setWorktreeCardMode = useAppStore((state) => state.setWorktreeCardMode)
   const visibleStatusBarToggles = useAvailableStatusBarToggles(getStatusBarToggles())
   const usagePercentageDisplayEntry = getUsagePercentageDisplayEntry()
+  const statusBarUsageFormatEntry = getStatusBarUsageFormatEntry()
+  const statusBarUsageFormat = useAppStore((state) => state.statusBarUsageFormat)
+  const setStatusBarUsageFormat = useAppStore((state) => state.setStatusBarUsageFormat)
   const leftSidebarAppearanceEntry = getLeftSidebarAppearanceEntry()
   const workspaceChromeAppearanceEntry = getWorkspaceChromeAppearanceEntry()
   const sidebarEntries = getSidebarEntries()
@@ -176,6 +181,18 @@ export function AppearanceWindowSidebarSection({
                       ]}
                     />
                   }
+                />
+              </SearchableSetting>
+
+              <SearchableSetting
+                title={statusBarUsageFormatEntry.title}
+                description={statusBarUsageFormatEntry.description}
+                keywords={statusBarUsageFormatEntry.keywords}
+                className="space-y-2"
+              >
+                <StatusBarUsageFormatSetting
+                  format={statusBarUsageFormat}
+                  onChange={setStatusBarUsageFormat}
                 />
               </SearchableSetting>
 

--- a/src/renderer/src/components/settings/StatusBarUsageFormatSetting.test.tsx
+++ b/src/renderer/src/components/settings/StatusBarUsageFormatSetting.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { StatusBarUsageFormatSetting } from './StatusBarUsageFormatSetting'
+import { getStatusBarEntries } from './appearance-search'
+import { getStatusBarUsageFormatEntry } from './appearance-status-bar-usage-format-search'
+import { matchesSettingsSearch } from './settings-search'
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: { usagePercentageDisplay: 'used' | 'remaining' }) => unknown) =>
+    selector({ usagePercentageDisplay: 'used' })
+}))
+
+describe('StatusBarUsageFormatSetting', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows the current template and a preview rendered from sample data', () => {
+    render(
+      <StatusBarUsageFormatSetting
+        format={{ template: '{provider} | 5h: {5h}[ | Fable: {fable}]' }}
+        onChange={vi.fn()}
+      />
+    )
+    const input = screen.getByRole('textbox', { name: 'Usage format' }) as HTMLInputElement
+    expect(input.value).toBe('{provider} | 5h: {5h}[ | Fable: {fable}]')
+    expect(screen.getByText('Claude | 5h: 14% | Fable: 37%')).toBeTruthy()
+  })
+
+  it('writes template edits while keeping provider overrides', () => {
+    const onChange = vi.fn()
+    render(
+      <StatusBarUsageFormatSetting
+        format={{ template: 'old', byProvider: { codex: '{plan}' } }}
+        onChange={onChange}
+      />
+    )
+    fireEvent.change(screen.getByRole('textbox', { name: 'Usage format' }), {
+      target: { value: '{7d}' }
+    })
+    expect(onChange).toHaveBeenLastCalledWith({ template: '{7d}', byProvider: { codex: '{plan}' } })
+  })
+
+  it('explains that an empty template keeps the built-in format and offers no reset', () => {
+    render(<StatusBarUsageFormatSetting format={{ template: '' }} onChange={vi.fn()} />)
+    expect(screen.getByText(/built-in format/i)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Reset' })).toBeNull()
+  })
+
+  it('resets to the built-in format', () => {
+    const onChange = vi.fn()
+    render(<StatusBarUsageFormatSetting format={{ template: '{5h}' }} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }))
+    expect(onChange).toHaveBeenLastCalledWith({ template: '' })
+  })
+
+  it('is indexed for Appearance search under the status bar entries', () => {
+    const entry = getStatusBarUsageFormatEntry()
+    expect(getStatusBarEntries()).toContainEqual(entry)
+    for (const query of ['format', 'template', 'status bar', 'usage']) {
+      expect(matchesSettingsSearch(query, entry)).toBe(true)
+    }
+  })
+})

--- a/src/renderer/src/components/settings/StatusBarUsageFormatSetting.tsx
+++ b/src/renderer/src/components/settings/StatusBarUsageFormatSetting.tsx
@@ -32,7 +32,7 @@ const PLACEHOLDERS: readonly [token: string, fallback: string, key: string][] = 
   ['[ … ]', 'dropped when a placeholder inside is empty', 'optional']
 ]
 
-// Why: a fixed sample keeps the preview meaningful before any provider has reported usage.
+/** Fixed sample so the preview reads meaningfully before any provider has reported usage. */
 function sampleLimits(now: number): ProviderRateLimits {
   const hours = 60 * 60 * 1000
   return {
@@ -61,6 +61,7 @@ function sampleLimits(now: number): ProviderRateLimits {
   }
 }
 
+/** Template editor for the footer usage text, with a live preview rendered against sample limits. */
 export function StatusBarUsageFormatSetting({
   format,
   onChange

--- a/src/renderer/src/components/settings/StatusBarUsageFormatSetting.tsx
+++ b/src/renderer/src/components/settings/StatusBarUsageFormatSetting.tsx
@@ -1,0 +1,144 @@
+import type React from 'react'
+import { useMemo } from 'react'
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import type { StatusBarUsageFormat } from '../../../../shared/status-bar-usage-format'
+import { normalizeUsagePercentageDisplay } from '../../../../shared/usage-percentage-display'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '../../store'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import {
+  buildUsageFormatValues,
+  renderUsageFormatTemplate
+} from '../status-bar/usage-format-template'
+import { getStatusBarUsageFormatEntry } from './appearance-status-bar-usage-format-search'
+import { SettingsRow } from './SettingsFormControls'
+
+type StatusBarUsageFormatSettingProps = {
+  format: StatusBarUsageFormat
+  onChange: (format: StatusBarUsageFormat) => void
+}
+
+const EXAMPLE_TEMPLATE =
+  '{provider}[ | 5h: {5h} ({5h.reset})][ | 7d: {7d}][ | Fable: {fable}][ | 30d: {30d}]'
+
+const PLACEHOLDERS: readonly [token: string, fallback: string, key: string][] = [
+  ['{provider}', 'provider name', 'provider'],
+  ['{plan}', 'plan (Codex)', 'plan'],
+  ['{5h} {7d} {fable} {30d}', 'window percentage', 'windows'],
+  ['{5h.reset}', 'time until reset, e.g. 3h 15m', 'reset'],
+  ['{5h.resetAt}', 'reset clock time, e.g. 20:50', 'resetAt'],
+  ['{buckets}', 'Gemini model buckets', 'buckets'],
+  ['[ … ]', 'dropped when a placeholder inside is empty', 'optional']
+]
+
+// Why: a fixed sample keeps the preview meaningful before any provider has reported usage.
+function sampleLimits(now: number): ProviderRateLimits {
+  const hours = 60 * 60 * 1000
+  return {
+    provider: 'claude',
+    session: {
+      usedPercent: 14,
+      windowMinutes: 300,
+      resetsAt: now + 3.25 * hours,
+      resetDescription: null
+    },
+    weekly: {
+      usedPercent: 20,
+      windowMinutes: 10080,
+      resetsAt: now + 63 * hours,
+      resetDescription: null
+    },
+    fableWeekly: {
+      usedPercent: 37,
+      windowMinutes: 10080,
+      resetsAt: now + 63 * hours,
+      resetDescription: null
+    },
+    updatedAt: now,
+    error: null,
+    status: 'ok'
+  }
+}
+
+export function StatusBarUsageFormatSetting({
+  format,
+  onChange
+}: StatusBarUsageFormatSettingProps): React.JSX.Element {
+  const display = normalizeUsagePercentageDisplay(useAppStore((s) => s.usagePercentageDisplay))
+  const entry = getStatusBarUsageFormatEntry()
+  const template = format.template
+  const hasTemplate = template.trim().length > 0
+  const preview = useMemo(() => {
+    if (!hasTemplate) {
+      return null
+    }
+    const now = Date.now()
+    return renderUsageFormatTemplate(
+      template,
+      buildUsageFormatValues(sampleLimits(now), { display, now })
+    )
+  }, [display, hasTemplate, template])
+
+  return (
+    <div className="space-y-2">
+      <SettingsRow
+        alignTop
+        label={entry.title}
+        description={entry.description}
+        control={
+          hasTemplate ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onChange({ ...format, template: '' })}
+            >
+              {translate('auto.components.settings.StatusBarUsageFormatSetting.reset', 'Reset')}
+            </Button>
+          ) : null
+        }
+      />
+      {/* Why full-width: templates run long, and the row's control slot would truncate them. */}
+      <Input
+        aria-label={entry.title}
+        value={template}
+        placeholder={EXAMPLE_TEMPLATE}
+        spellCheck={false}
+        className="h-8 font-mono text-[12px]"
+        onChange={(event) => onChange({ ...format, template: event.target.value })}
+      />
+      <div className="space-y-1 text-[11px] text-muted-foreground">
+        <div>
+          <span className="text-foreground/80">
+            {translate(
+              'auto.components.settings.StatusBarUsageFormatSetting.previewLabel',
+              'Preview'
+            )}
+            {': '}
+          </span>
+          {preview !== null ? (
+            <span className="whitespace-pre font-mono tabular-nums text-foreground">{preview}</span>
+          ) : (
+            translate(
+              'auto.components.settings.StatusBarUsageFormatSetting.previewBuiltin',
+              'Leave empty to use Orca’s built-in format.'
+            )
+          )}
+        </div>
+        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5">
+          {PLACEHOLDERS.map(([token, fallback, key]) => (
+            <div key={key} className="contents">
+              <dt className="font-mono">{token}</dt>
+              <dd>
+                {translate(
+                  `auto.components.settings.StatusBarUsageFormatSetting.placeholder.${key}`,
+                  fallback
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/StatusBarUsageFormatSetting.tsx
+++ b/src/renderer/src/components/settings/StatusBarUsageFormatSetting.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
 import type { StatusBarUsageFormat } from '../../../../shared/status-bar-usage-format'
 import { normalizeUsagePercentageDisplay } from '../../../../shared/usage-percentage-display'
@@ -70,16 +70,17 @@ export function StatusBarUsageFormatSetting({
   const entry = getStatusBarUsageFormatEntry()
   const template = format.template
   const hasTemplate = template.trim().length > 0
+  // Why: the sample's reset times are relative to `now`, so a mount-time clock keeps the preview stable.
+  const [now] = useState(() => Date.now())
   const preview = useMemo(() => {
     if (!hasTemplate) {
       return null
     }
-    const now = Date.now()
     return renderUsageFormatTemplate(
       template,
       buildUsageFormatValues(sampleLimits(now), { display, now })
     )
-  }, [display, hasTemplate, template])
+  }, [display, hasTemplate, now, template])
 
   return (
     <div className="space-y-2">

--- a/src/renderer/src/components/settings/WorkspaceChromeAppearanceSetting.tsx
+++ b/src/renderer/src/components/settings/WorkspaceChromeAppearanceSetting.tsx
@@ -1,0 +1,56 @@
+import type React from 'react'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { WorkspaceChromeAppearanceMode } from '../../../../shared/ui-chrome-types'
+import { translate } from '@/i18n/i18n'
+import { SettingsRow, SettingsSegmentedControl } from './SettingsFormControls'
+
+type WorkspaceChromeAppearanceSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function WorkspaceChromeAppearanceSetting({
+  settings,
+  updateSettings
+}: WorkspaceChromeAppearanceSettingProps): React.JSX.Element {
+  const title = translate(
+    'auto.components.settings.AppearancePane.workspaceChromeAppearance.title',
+    'App Chrome Appearance'
+  )
+  return (
+    <SettingsRow
+      alignTop
+      label={title}
+      description={translate(
+        'auto.components.settings.AppearancePane.workspaceChromeAppearance.rowDescription',
+        'Make the tab bar, status bar, side panels, and full-page views match your terminal theme, or keep the app theme.'
+      )}
+      control={
+        <SettingsSegmentedControl<WorkspaceChromeAppearanceMode>
+          size="sm"
+          value={settings.workspaceChromeAppearanceMode ?? 'default'}
+          onChange={(workspaceChromeAppearanceMode) =>
+            updateSettings({ workspaceChromeAppearanceMode })
+          }
+          ariaLabel={title}
+          options={[
+            {
+              value: 'default',
+              label: translate(
+                'auto.components.settings.AppearancePane.workspaceChromeAppearance.default',
+                'Default'
+              )
+            },
+            {
+              value: 'match-terminal',
+              label: translate(
+                'auto.components.settings.AppearancePane.workspaceChromeAppearance.matchTerminal',
+                'Match Terminal'
+              )
+            }
+          ]}
+        />
+      }
+    />
+  )
+}

--- a/src/renderer/src/components/settings/WorkspaceChromeAppearanceSetting.tsx
+++ b/src/renderer/src/components/settings/WorkspaceChromeAppearanceSetting.tsx
@@ -9,6 +9,7 @@ type WorkspaceChromeAppearanceSettingProps = {
   updateSettings: (updates: Partial<GlobalSettings>) => void
 }
 
+/** Default / Match Terminal toggle for the app chrome surfaces. */
 export function WorkspaceChromeAppearanceSetting({
   settings,
   updateSettings
@@ -23,7 +24,7 @@ export function WorkspaceChromeAppearanceSetting({
       label={title}
       description={translate(
         'auto.components.settings.AppearancePane.workspaceChromeAppearance.rowDescription',
-        'Make the tab bar, status bar, side panels, and full-page views match your terminal theme, or keep the app theme.'
+        'Make the tab bar, status bar, side panels, full-page views, and popovers match your terminal theme, or keep the app theme.'
       )}
       control={
         <SettingsSegmentedControl<WorkspaceChromeAppearanceMode>

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -163,6 +163,7 @@ export const getTitlebarEntries = createLocalizedCatalog((): SettingsSearchEntry
   }
 ])
 
+/** Search entries for every Status Bar control, including the per-provider toggles. */
 export const getStatusBarEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   getUsagePercentageDisplayEntry(),
   getStatusBarUsageFormatEntry(),

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -7,6 +7,7 @@ import { translateSearchKeyword } from './settings-search-keywords'
 import { SHOW_UI_LANGUAGE_SETTING } from '@/i18n/supported-languages'
 import { getStatusBarToggles } from './appearance-status-bar-search'
 import { getUsagePercentageDisplayEntry } from './appearance-usage-percentage-search'
+import { getStatusBarUsageFormatEntry } from './appearance-status-bar-usage-format-search'
 import { getMenuBarIconEntries, getSystemTrayEntries } from './appearance-system-presence-search'
 
 export {
@@ -164,6 +165,7 @@ export const getTitlebarEntries = createLocalizedCatalog((): SettingsSearchEntry
 
 export const getStatusBarEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   getUsagePercentageDisplayEntry(),
+  getStatusBarUsageFormatEntry(),
   ...getStatusBarToggles().map(({ title, description, keywords }) => ({
     title,
     description,

--- a/src/renderer/src/components/settings/appearance-sidebar-search.ts
+++ b/src/renderer/src/components/settings/appearance-sidebar-search.ts
@@ -35,6 +35,7 @@ export const getLeftSidebarAppearanceEntry = createLocalizedCatalog(
   })
 )
 
+/** Settings-search entry for the App Chrome Appearance row. */
 export const getWorkspaceChromeAppearanceEntry = createLocalizedCatalog(
   (): SettingsSearchEntry => ({
     title: translate(
@@ -43,7 +44,7 @@ export const getWorkspaceChromeAppearanceEntry = createLocalizedCatalog(
     ),
     description: translate(
       'auto.components.settings.appearance.search.workspaceChromeAppearance.description',
-      'Make the tab bar, status bar, side panels, and full-page views match your terminal theme, or keep the app theme.'
+      'Make the tab bar, status bar, side panels, full-page views, and popovers match your terminal theme, or keep the app theme.'
     ),
     keywords: [
       ...translateSearchKeyword(
@@ -167,6 +168,7 @@ export const getShowPinnedWorktreesInGroupsEntry = createLocalizedCatalog(
   })
 )
 
+/** Search entries for the sidebar-related appearance controls. */
 export const getSidebarEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   {
     title: translate('auto.components.settings.appearance.search.155a1e7438', 'Show Tasks Button'),

--- a/src/renderer/src/components/settings/appearance-sidebar-search.ts
+++ b/src/renderer/src/components/settings/appearance-sidebar-search.ts
@@ -3,77 +3,121 @@ import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 
-export const getLeftSidebarAppearanceEntry = createLocalizedCatalog((): SettingsSearchEntry => ({
-  title: translate(
-    'auto.components.settings.appearance.search.leftSidebarAppearance.title',
-    'Left Sidebar Appearance'
-  ),
-  description: translate(
-    'auto.components.settings.appearance.search.leftSidebarAppearance.description',
-    'Make the left sidebar match your terminal, stay default, or use a tint.'
-  ),
-  keywords: [
-    ...translateSearchKeyword('auto.components.settings.appearance.search.5bff6a2ef0', 'sidebar'),
-    ...translateSearchKeyword(
-      'auto.components.settings.appearance.search.leftSidebarAppearance.project',
-      'project'
+export const getLeftSidebarAppearanceEntry = createLocalizedCatalog(
+  (): SettingsSearchEntry => ({
+    title: translate(
+      'auto.components.settings.appearance.search.leftSidebarAppearance.title',
+      'Left Sidebar Appearance'
     ),
-    ...translateSearchKeyword(
-      'auto.components.settings.appearance.search.leftSidebarAppearance.terminal',
-      'terminal'
+    description: translate(
+      'auto.components.settings.appearance.search.leftSidebarAppearance.description',
+      'Make the left sidebar match your terminal, stay default, or use a tint.'
     ),
-    ...translateSearchKeyword(
-      'auto.components.settings.appearance.search.leftSidebarAppearance.background',
-      'background'
-    ),
-    ...translateSearchKeyword(
-      'auto.components.settings.appearance.search.leftSidebarAppearance.tint',
-      'tint'
-    )
-  ]
-}))
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.appearance.search.5bff6a2ef0', 'sidebar'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.leftSidebarAppearance.project',
+        'project'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.leftSidebarAppearance.terminal',
+        'terminal'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.leftSidebarAppearance.background',
+        'background'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.leftSidebarAppearance.tint',
+        'tint'
+      )
+    ]
+  })
+)
 
-export const getWorkspaceCardLayoutEntry = createLocalizedCatalog((): SettingsSearchEntry => ({
-  title: translate(
-    'auto.components.settings.appearance.search.workspaceCardLayout.title',
-    'Workspace Card Layout'
-  ),
-  description: translate(
-    'auto.components.settings.appearance.search.workspaceCardLayout.description',
-    'Workspace cards can use compact or detailed layouts.'
-  ),
-  keywords: [
-    ...translateSearchKeyword(
-      'auto.components.settings.appearance.search.workspaceCardLayout.compact',
-      'compact'
+export const getWorkspaceChromeAppearanceEntry = createLocalizedCatalog(
+  (): SettingsSearchEntry => ({
+    title: translate(
+      'auto.components.settings.appearance.search.workspaceChromeAppearance.title',
+      'App Chrome Appearance'
     ),
-    ...translateSearchKeyword(
-      'auto.components.settings.appearance.search.workspaceCardLayout.compactDisplay',
-      'compact display'
+    description: translate(
+      'auto.components.settings.appearance.search.workspaceChromeAppearance.description',
+      'Make the tab bar, status bar, side panels, and full-page views match your terminal theme, or keep the app theme.'
     ),
-    ...translateSearchKeyword(
-      'auto.components.settings.appearance.search.workspaceCardLayout.workspaceCards',
-      'workspace cards'
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceChromeAppearance.tabBar',
+        'tab bar'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceChromeAppearance.statusBar',
+        'status bar'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.leftSidebarAppearance.terminal',
+        'terminal'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceChromeAppearance.theme',
+        'theme'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceChromeAppearance.chrome',
+        'chrome'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.5bff6a2ef0', 'sidebar'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.leftSidebarAppearance.background',
+        'background'
+      )
+    ]
+  })
+)
+
+export const getWorkspaceCardLayoutEntry = createLocalizedCatalog(
+  (): SettingsSearchEntry => ({
+    title: translate(
+      'auto.components.settings.appearance.search.workspaceCardLayout.title',
+      'Workspace Card Layout'
     ),
-    ...translateSearchKeyword(
-      'auto.components.settings.appearance.search.workspaceCardLayout.worktreeCards',
-      'worktree cards'
+    description: translate(
+      'auto.components.settings.appearance.search.workspaceCardLayout.description',
+      'Workspace cards can use compact or detailed layouts.'
     ),
-    ...translateSearchKeyword('auto.components.settings.appearance.search.5bff6a2ef0', 'sidebar'),
-    ...translateSearchKeyword(
-      'auto.components.settings.appearance.search.workspaceCardLayout.cardLayout',
-      'card layout'
-    ),
-    ...translateSearchKeyword(
-      'auto.components.settings.appearance.search.workspaceCardLayout.workspaceOptions',
-      'workspace options'
-    ),
-    ...translateSearchKeyword(
-      'auto.components.settings.appearance.search.workspaceCardLayout.detailed',
-      'detailed'
-    )
-  ]
-}))
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.compact',
+        'compact'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.compactDisplay',
+        'compact display'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.workspaceCards',
+        'workspace cards'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.worktreeCards',
+        'worktree cards'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.5bff6a2ef0', 'sidebar'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.cardLayout',
+        'card layout'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.workspaceOptions',
+        'workspace options'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.detailed',
+        'detailed'
+      )
+    ]
+  })
+)
 
 export const getShowPinnedWorktreesInGroupsEntry = createLocalizedCatalog(
   (): SettingsSearchEntry => ({
@@ -189,5 +233,6 @@ export const getSidebarEntries = createLocalizedCatalog((): SettingsSearchEntry[
   },
   getWorkspaceCardLayoutEntry(),
   getLeftSidebarAppearanceEntry(),
+  getWorkspaceChromeAppearanceEntry(),
   getShowPinnedWorktreesInGroupsEntry()
 ])

--- a/src/renderer/src/components/settings/appearance-status-bar-usage-format-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-usage-format-search.ts
@@ -3,6 +3,7 @@ import { translate } from '@/i18n/i18n'
 import type { SettingsSearchEntry } from './settings-search'
 import { translateSearchKeyword } from './settings-search-keywords'
 
+/** Settings-search entry for the status bar usage format template. */
 export const getStatusBarUsageFormatEntry = createLocalizedCatalog(
   (): SettingsSearchEntry => ({
     title: translate(

--- a/src/renderer/src/components/settings/appearance-status-bar-usage-format-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-usage-format-search.ts
@@ -1,0 +1,36 @@
+import { createLocalizedCatalog } from '@/i18n/localized-catalog'
+import { translate } from '@/i18n/i18n'
+import type { SettingsSearchEntry } from './settings-search'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export const getStatusBarUsageFormatEntry = createLocalizedCatalog(
+  (): SettingsSearchEntry => ({
+    title: translate(
+      'auto.components.settings.appearance.search.statusBarUsageFormat.title',
+      'Usage format'
+    ),
+    description: translate(
+      'auto.components.settings.appearance.search.statusBarUsageFormat.description',
+      'Customize how each provider’s usage is written in the status bar with placeholders.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.appearance.search.00a028f25f', 'usage'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.896eb53fd4',
+        'status bar'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.statusBarUsageFormat.format',
+        'format'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.statusBarUsageFormat.template',
+        'template'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.statusBarUsageFormat.placeholder',
+        'placeholder'
+      )
+    ]
+  })
+)

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -3,7 +3,8 @@ import { getTerminalPaneSearchEntries } from './terminal-search'
 import { getAppearancePaneSearchEntries, getSidebarEntries } from './appearance-search'
 import {
   getShowPinnedWorktreesInGroupsEntry,
-  getWorkspaceCardLayoutEntry
+  getWorkspaceCardLayoutEntry,
+  getWorkspaceChromeAppearanceEntry
 } from './appearance-sidebar-search'
 import { matchesSettingsSearch } from './settings-search'
 
@@ -239,5 +240,15 @@ describe('getTerminalPaneSearchEntries', () => {
     expect(getSidebarEntries()).toContainEqual(entry)
     expect(getAppearancePaneSearchEntries()).toContainEqual(entry)
     expect(matchesSettingsSearch('duplicate', entry)).toBe(true)
+  })
+
+  it('indexes the app chrome appearance setting for Appearance search', () => {
+    const entry = getWorkspaceChromeAppearanceEntry()
+
+    expect(getSidebarEntries()).toContainEqual(entry)
+    expect(getAppearancePaneSearchEntries()).toContainEqual(entry)
+    for (const query of ['tab bar', 'status bar', 'terminal', 'theme', 'chrome', 'sidebar']) {
+      expect(matchesSettingsSearch(query, entry)).toBe(true)
+    }
   })
 })

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1174,6 +1174,7 @@ function getProviderLetter(provider: ProviderRateLimits['provider']): string {
 // Why: Gemini exposes extra experimental buckets that made the pre-existing verbose footer noisy.
 const STATUS_BAR_BUCKET_NAMES = new Set(['Flash', 'Pro', '1.5 Pro'])
 
+/** Full per-window usage text for one provider; a user template, when set, replaces the built-in layout. */
 function VerboseProviderUsage({
   p,
   display

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1267,6 +1267,7 @@ function VerboseProviderUsage({
   )
 }
 
+/** Status-bar usage readout for one provider; a user template overrides the built-in text in both usage modes. */
 export function ProviderSegment({
   p,
   compact,

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -65,6 +65,8 @@ import { UsageRosterPanel, getTightestUsageSection } from './UsageRosterPanel'
 import { getUsageProviderAccountsSectionId } from './usage-provider-settings-target'
 import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
 import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
+import { resolveStatusBarUsageTemplate } from '../../../../shared/status-bar-usage-format'
+import { buildUsageFormatValues, renderUsageFormatTemplate } from './usage-format-template'
 import {
   markLiveCodexSessionsForRestart,
   resolveCodexRestartPromptAccountLabel
@@ -1179,6 +1181,22 @@ function VerboseProviderUsage({
   p: ProviderRateLimits
   display: UsagePercentageDisplay
 }): React.JSX.Element {
+  const usageFormat = useAppStore((s) => s.statusBarUsageFormat)
+  const template = resolveStatusBarUsageTemplate(usageFormat, p.provider)
+  // Why: the template can show reset countdowns, so tick with them like the account switcher does.
+  const now = useResetCountdownClock([
+    p.session?.resetsAt,
+    p.weekly?.resetsAt,
+    p.fableWeekly?.resetsAt,
+    p.monthly?.resetsAt
+  ])
+  if (template !== null) {
+    return (
+      <span className="whitespace-pre tabular-nums">
+        {renderUsageFormatTemplate(template, buildUsageFormatValues(p, { display, now }))}
+      </span>
+    )
+  }
   if (p.buckets && p.buckets.length > 0) {
     const visibleBuckets = p.buckets.filter((bucket) => STATUS_BAR_BUCKET_NAMES.has(bucket.name))
     return (

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1280,6 +1280,9 @@ export function ProviderSegment({
 }): React.JSX.Element {
   const provider = p?.provider ?? 'claude'
   const statusLabel = p ? getProviderUsageStatusLabel(p) : ''
+  const usageFormat = useAppStore((s) => s.statusBarUsageFormat)
+  // Why: a user template replaces the built-in text in both usage modes, so compact mode can't silently drop it.
+  const hasTemplate = resolveStatusBarUsageTemplate(usageFormat, provider) !== null
 
   // Idle / initial load
   if (!p || p.status === 'idle') {
@@ -1329,9 +1332,9 @@ export function ProviderSegment({
   return (
     <span className="inline-flex items-center gap-1.5">
       <ProviderIcon provider={provider} />
-      {mode === 'verbose' ? (
+      {mode === 'verbose' || hasTemplate ? (
         <>
-          {tightest && !compact ? (
+          {mode === 'verbose' && tightest && !compact ? (
             <MiniBar usedPct={clampUsedPercent(tightest.window.usedPercent)} display={display} />
           ) : null}
           <VerboseProviderUsage p={p} display={display} />

--- a/src/renderer/src/components/status-bar/provider-segment-usage-format.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-usage-format.test.tsx
@@ -1,0 +1,67 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rate-limit-types'
+import type { StatusBarUsageFormat } from '../../../../shared/status-bar-usage-format'
+
+let statusBarUsageFormat: StatusBarUsageFormat = { template: '' }
+
+vi.mock('@/i18n/i18n', () => ({
+  i18n: { language: 'en' },
+  translate: (_key: string, fallback: string, values?: Record<string, string>) => {
+    let result = fallback
+    for (const [key, value] of Object.entries(values ?? {})) {
+      result = result.replace(`{{${key}}}`, value)
+    }
+    return result
+  }
+}))
+vi.mock('@/lib/agent-catalog', () => ({
+  AgentIcon: () => null
+}))
+vi.mock('../../store', () => ({
+  useAppStore: (
+    selector: (state: {
+      usagePercentageDisplay: 'used' | 'remaining'
+      statusBarUsageFormat: StatusBarUsageFormat
+    }) => unknown
+  ) => selector({ usagePercentageDisplay: 'used', statusBarUsageFormat })
+}))
+
+function windowOf(usedPercent: number, windowMinutes: number): RateLimitWindow {
+  return { usedPercent, windowMinutes, resetsAt: null, resetDescription: null }
+}
+
+function claudeLimits(): ProviderRateLimits {
+  return {
+    provider: 'claude',
+    session: windowOf(14, 300),
+    weekly: windowOf(20, 10080),
+    fableWeekly: windowOf(37, 10080),
+    updatedAt: Date.now(),
+    error: null,
+    status: 'ok'
+  }
+}
+
+describe('ProviderSegment usage format template', () => {
+  it('renders the user template instead of the built-in window labels', async () => {
+    statusBarUsageFormat = { template: '{provider} | 5h: {5h} | 7d: {7d}[ | Fable: {fable}]' }
+    const { ProviderSegment } = await import('./StatusBar')
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={claudeLimits()} compact={false} display="used" mode="verbose" />
+    )
+    expect(markup).toContain('Claude | 5h: 14% | 7d: 20% | Fable: 37%')
+    expect(markup).not.toContain('14% used')
+    // Why: multiple spaces in the template must survive HTML whitespace collapsing.
+    expect(markup).toMatch(/<span class="[^"]*whitespace-pre[^"]*">Claude \| 5h/)
+  })
+
+  it('falls back to the built-in rendering when the template is empty', async () => {
+    statusBarUsageFormat = { template: '   ' }
+    const { ProviderSegment } = await import('./StatusBar')
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={claudeLimits()} compact={false} display="used" mode="verbose" />
+    )
+    expect(markup).toContain('14% used')
+  })
+})

--- a/src/renderer/src/components/status-bar/provider-segment-usage-format.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-usage-format.test.tsx
@@ -58,6 +58,16 @@ describe('ProviderSegment usage format template', () => {
     expect(markup).toMatch(/<span class="[^"]*whitespace-pre[^"]*">Claude \| 5h/)
   })
 
+  it('honors the template in compact usage mode instead of the tightest-window label', async () => {
+    statusBarUsageFormat = { template: '{provider} {5h}/{7d}' }
+    const { ProviderSegment } = await import('./StatusBar')
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={claudeLimits()} compact={false} display="used" mode="compact" />
+    )
+    expect(markup).toContain('Claude 14%/20%')
+    expect(markup).not.toContain('37% used Fable')
+  })
+
   it('falls back to the built-in rendering when the template is empty', async () => {
     statusBarUsageFormat = { template: '   ' }
     const { ProviderSegment } = await import('./StatusBar')

--- a/src/renderer/src/components/status-bar/provider-segment-usage-format.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-usage-format.test.tsx
@@ -27,10 +27,12 @@ vi.mock('../../store', () => ({
   ) => selector({ usagePercentageDisplay: 'used', statusBarUsageFormat })
 }))
 
+/** Rate-limit window fixture with only the fields the template reads. */
 function windowOf(usedPercent: number, windowMinutes: number): RateLimitWindow {
   return { usedPercent, windowMinutes, resetsAt: null, resetDescription: null }
 }
 
+/** Claude limits fixture covering the 5h and 7d windows. */
 function claudeLimits(): ProviderRateLimits {
   return {
     provider: 'claude',

--- a/src/renderer/src/components/status-bar/usage-format-template.test.ts
+++ b/src/renderer/src/components/status-bar/usage-format-template.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rate-limit-types'
+import { buildUsageFormatValues, renderUsageFormatTemplate } from './usage-format-template'
+
+const NOW = Date.UTC(2026, 7, 27, 12, 0, 0)
+
+function win(
+  usedPercent: number,
+  windowMinutes: number,
+  resetInMs: number | null
+): RateLimitWindow {
+  return {
+    usedPercent,
+    windowMinutes,
+    resetsAt: resetInMs === null ? null : NOW + resetInMs,
+    resetDescription: null
+  }
+}
+
+function provider(overrides: Partial<ProviderRateLimits>): ProviderRateLimits {
+  return {
+    provider: 'claude',
+    session: null,
+    weekly: null,
+    updatedAt: NOW,
+    error: null,
+    status: 'ok',
+    ...overrides
+  }
+}
+
+describe('renderUsageFormatTemplate', () => {
+  it('substitutes known placeholders and leaves unknown ones verbatim', () => {
+    expect(
+      renderUsageFormatTemplate('{provider}: {5h} {nope}', { provider: 'Claude', '5h': '14%' })
+    ).toBe('Claude: 14% {nope}')
+  })
+
+  it('drops an optional group when any placeholder inside is empty', () => {
+    const values = { provider: 'Grok', '5h': '', '7d': '19%' }
+    expect(renderUsageFormatTemplate('{provider}[ | 5h: {5h}][ | 7d: {7d}]', values)).toBe(
+      'Grok | 7d: 19%'
+    )
+  })
+
+  it('keeps an optional group whose placeholders all resolve', () => {
+    expect(
+      renderUsageFormatTemplate('[{5h} ({5h.reset})]', { '5h': '14%', '5h.reset': '3h 15m' })
+    ).toBe('14% (3h 15m)')
+  })
+
+  it('keeps bracket text that contains no placeholders as literal', () => {
+    expect(renderUsageFormatTemplate('[x] {5h}', { '5h': '14%' })).toBe('[x] 14%')
+  })
+
+  it("preserves the author's spacing and removes only the dropped group text", () => {
+    expect(
+      renderUsageFormatTemplate('{provider}   [{5h}] [{7d}] end  ', {
+        provider: 'A',
+        '5h': '',
+        '7d': ''
+      })
+    ).toBe('A     end  ')
+  })
+})
+
+describe('buildUsageFormatValues', () => {
+  it('exposes provider, window percentages, reset countdowns and clock times', () => {
+    const values = buildUsageFormatValues(
+      provider({
+        session: win(14, 300, 3 * 60 * 60 * 1000 + 15 * 60 * 1000),
+        weekly: win(20, 10080, (2 * 24 + 15) * 60 * 60 * 1000),
+        fableWeekly: win(37, 10080, 24 * 60 * 60 * 1000)
+      }),
+      { display: 'used', now: NOW, timeZone: 'UTC' }
+    )
+
+    expect(values).toMatchObject({
+      provider: 'Claude',
+      plan: '',
+      '5h': '14%',
+      '5h.reset': '3h 15m',
+      '5h.resetAt': '15:15',
+      '7d': '20%',
+      '7d.reset': '2d 15h',
+      fable: '37%',
+      'fable.reset': '1d',
+      '30d': '',
+      '30d.reset': '',
+      '30d.resetAt': '',
+      buckets: ''
+    })
+  })
+
+  it('shows remaining percentages when the display setting says so', () => {
+    const values = buildUsageFormatValues(provider({ session: win(14, 300, null) }), {
+      display: 'remaining',
+      now: NOW,
+      timeZone: 'UTC'
+    })
+    expect(values['5h']).toBe('86%')
+    expect(values['5h.reset']).toBe('')
+    expect(values['5h.resetAt']).toBe('')
+  })
+
+  it('exposes the Codex plan and the monthly window', () => {
+    const values = buildUsageFormatValues(
+      provider({ provider: 'codex', planType: 'plus', monthly: win(4, 43200, null) }),
+      { display: 'used', now: NOW, timeZone: 'UTC' }
+    )
+    expect(values.provider).toBe('Codex')
+    expect(values.plan).toBe('Plus')
+    expect(values['30d']).toBe('4%')
+  })
+
+  it('joins Gemini buckets in the status bar order', () => {
+    const values = buildUsageFormatValues(
+      provider({
+        provider: 'gemini',
+        buckets: [
+          { ...win(40, 300, null), name: 'Pro' },
+          { ...win(12, 300, null), name: 'Flash' },
+          { ...win(1, 300, null), name: 'Other' }
+        ]
+      }),
+      { display: 'used', now: NOW, timeZone: 'UTC' }
+    )
+    expect(values.buckets).toBe('Flash 12% · Pro 40%')
+  })
+})

--- a/src/renderer/src/components/status-bar/usage-format-template.test.ts
+++ b/src/renderer/src/components/status-bar/usage-format-template.test.ts
@@ -4,6 +4,7 @@ import { buildUsageFormatValues, renderUsageFormatTemplate } from './usage-forma
 
 const NOW = Date.UTC(2026, 7, 27, 12, 0, 0)
 
+/** Rate-limit window fixture. */
 function win(
   usedPercent: number,
   windowMinutes: number,
@@ -17,6 +18,7 @@ function win(
   }
 }
 
+/** Provider limits fixture with overridable fields. */
 function provider(overrides: Partial<ProviderRateLimits>): ProviderRateLimits {
   return {
     provider: 'claude',

--- a/src/renderer/src/components/status-bar/usage-format-template.ts
+++ b/src/renderer/src/components/status-bar/usage-format-template.ts
@@ -1,0 +1,93 @@
+import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rate-limit-types'
+import { formatResetDuration } from '../../../../shared/rate-limit-reset-format'
+import {
+  getDisplayedUsagePercentage,
+  type UsagePercentageDisplay
+} from '../../../../shared/usage-percentage-display'
+import { getProviderDisplayName } from './usage-error-copy'
+import { formatPlanLabel } from './usage-roster-formatting'
+
+export type UsageFormatValues = Record<string, string>
+
+const PLACEHOLDER_RE = /\{([a-zA-Z0-9_.]+)\}/g
+// Why: one level of brackets only — nested optional groups aren't worth the parsing cost for a footer string.
+const OPTIONAL_GROUP_RE = /\[([^[\]]*)\]/g
+
+function substitute(text: string, values: UsageFormatValues): string {
+  return text.replace(PLACEHOLDER_RE, (match, key: string) =>
+    Object.hasOwn(values, key) ? values[key] : match
+  )
+}
+
+/** Renders `{key}` placeholders; `[...]` groups vanish when any known placeholder inside is empty.
+ *  Whitespace is the author's: nothing is collapsed or trimmed, so render it with `whitespace-pre`. */
+export function renderUsageFormatTemplate(template: string, values: UsageFormatValues): string {
+  const withGroups = template.replace(OPTIONAL_GROUP_RE, (match, inner: string) => {
+    const keys = [...inner.matchAll(PLACEHOLDER_RE)].map((m) => m[1])
+    if (keys.length === 0) {
+      return match
+    }
+    const missing = keys.some((key) => Object.hasOwn(values, key) && values[key] === '')
+    return missing ? '' : substitute(inner, values)
+  })
+  return substitute(withGroups, values)
+}
+
+export type UsageFormatValueOptions = {
+  display: UsagePercentageDisplay
+  now: number
+  /** Test hook; production uses the viewer's zone. */
+  timeZone?: string
+  locale?: string
+}
+
+const WINDOW_KEYS: readonly [
+  key: string,
+  pick: (p: ProviderRateLimits) => RateLimitWindow | null | undefined
+][] = [
+  ['5h', (p) => p.session],
+  ['7d', (p) => p.weekly],
+  ['fable', (p) => p.fableWeekly],
+  ['30d', (p) => p.monthly]
+]
+
+// Same subset and order the built-in Gemini rendering shows.
+const BUCKET_ORDER = ['Flash', 'Pro', '1.5 Pro']
+
+function percent(window: RateLimitWindow, display: UsagePercentageDisplay): string {
+  return `${getDisplayedUsagePercentage(window.usedPercent, display)}%`
+}
+
+function resetClock(resetsAt: number, options: UsageFormatValueOptions): string {
+  return new Intl.DateTimeFormat(options.locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+    timeZone: options.timeZone
+  }).format(resetsAt)
+}
+
+/** Every placeholder the footer template can reference, empty string when the provider lacks it. */
+export function buildUsageFormatValues(
+  p: ProviderRateLimits,
+  options: UsageFormatValueOptions
+): UsageFormatValues {
+  const values: UsageFormatValues = {
+    provider: getProviderDisplayName(p.provider),
+    plan: formatPlanLabel(p.planType) ?? ''
+  }
+  for (const [key, pick] of WINDOW_KEYS) {
+    const window = pick(p)
+    values[key] = window ? percent(window, options.display) : ''
+    values[`${key}.reset`] =
+      window?.resetsAt != null ? formatResetDuration(window.resetsAt - options.now) : ''
+    values[`${key}.resetAt`] = window?.resetsAt != null ? resetClock(window.resetsAt, options) : ''
+  }
+  const buckets = (p.buckets ?? [])
+    .filter((bucket) => BUCKET_ORDER.includes(bucket.name))
+    .sort((a, b) => BUCKET_ORDER.indexOf(a.name) - BUCKET_ORDER.indexOf(b.name))
+  values.buckets = buckets
+    .map((bucket) => `${bucket.name} ${percent(bucket, options.display)}`)
+    .join(' · ')
+  return values
+}

--- a/src/renderer/src/components/status-bar/usage-format-template.ts
+++ b/src/renderer/src/components/status-bar/usage-format-template.ts
@@ -13,6 +13,7 @@ const PLACEHOLDER_RE = /\{([a-zA-Z0-9_.]+)\}/g
 // Why: one level of brackets only — nested optional groups aren't worth the parsing cost for a footer string.
 const OPTIONAL_GROUP_RE = /\[([^[\]]*)\]/g
 
+/** Replaces known `{key}` placeholders; unknown ones are left verbatim. */
 function substitute(text: string, values: UsageFormatValues): string {
   return text.replace(PLACEHOLDER_RE, (match, key: string) =>
     Object.hasOwn(values, key) ? values[key] : match
@@ -54,10 +55,12 @@ const WINDOW_KEYS: readonly [
 // Same subset and order the built-in Gemini rendering shows.
 const BUCKET_ORDER = ['Flash', 'Pro', '1.5 Pro']
 
+/** Window percentage in the user's Used/Remaining preference. */
 function percent(window: RateLimitWindow, display: UsagePercentageDisplay): string {
   return `${getDisplayedUsagePercentage(window.usedPercent, display)}%`
 }
 
+/** Reset time as a 24h clock string in the viewer's zone. */
 function resetClock(resetsAt: number, options: UsageFormatValueOptions): string {
   return new Intl.DateTimeFormat(options.locale, {
     hour: '2-digit',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6538,6 +6538,12 @@
           "showPinnedWorktreesInGroups": {
             "title": "Also show pinned worktrees in their original lists",
             "description": "Pinned worktrees stay in Pinned and also appear in All, Project, Status, and PR."
+          },
+          "workspaceChromeAppearance": {
+            "title": "App Chrome Appearance",
+            "rowDescription": "Make the tab bar, status bar, side panels, and full-page views match your terminal theme, or keep the app theme.",
+            "default": "Default",
+            "matchTerminal": "Match Terminal"
           }
         },
         "AutoRenameBranchFromWorkSetting": {
@@ -8963,7 +8969,11 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Usage percentages",
-            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining."
+            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining.",
+            "workspaceChromeAppearance": {
+              "title": "App Chrome Appearance",
+              "description": "Make the tab bar, status bar, side panels, and full-page views match your terminal theme, or keep the app theme."
+            }
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6541,7 +6541,7 @@
           },
           "workspaceChromeAppearance": {
             "title": "App Chrome Appearance",
-            "rowDescription": "Make the tab bar, status bar, side panels, and full-page views match your terminal theme, or keep the app theme.",
+            "rowDescription": "Make the tab bar, status bar, side panels, full-page views, and popovers match your terminal theme, or keep the app theme.",
             "default": "Default",
             "matchTerminal": "Match Terminal"
           }
@@ -8972,7 +8972,7 @@
             "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining.",
             "workspaceChromeAppearance": {
               "title": "App Chrome Appearance",
-              "description": "Make the tab bar, status bar, side panels, and full-page views match your terminal theme, or keep the app theme."
+              "description": "Make the tab bar, status bar, side panels, full-page views, and popovers match your terminal theme, or keep the app theme."
             },
             "statusBarUsageFormat": {
               "title": "Usage format",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6541,7 +6541,7 @@
           },
           "workspaceChromeAppearance": {
             "title": "App Chrome Appearance",
-            "rowDescription": "Make the tab bar, status bar, side panels, full-page views, and popovers match your terminal theme, or keep the app theme.",
+            "rowDescription": "Make the tab bar, status bar, side panels, full-page views, popovers, and file editors match your terminal theme, or keep the app theme.",
             "default": "Default",
             "matchTerminal": "Match Terminal"
           }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8973,6 +8973,10 @@
             "workspaceChromeAppearance": {
               "title": "App Chrome Appearance",
               "description": "Make the tab bar, status bar, side panels, and full-page views match your terminal theme, or keep the app theme."
+            },
+            "statusBarUsageFormat": {
+              "title": "Usage format",
+              "description": "Customize how each provider’s usage is written in the status bar with placeholders."
             }
           }
         },
@@ -11532,6 +11536,11 @@
         },
         "NativeChatSupportedAgents": {
           "label": "Supported agents:"
+        },
+        "StatusBarUsageFormatSetting": {
+          "reset": "Reset",
+          "previewLabel": "Preview",
+          "previewBuiltin": "Leave empty to use Orca’s built-in format."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5587,6 +5587,12 @@
             "tintOpacity": "色合いの強さ",
             "tintOpacityDescription": "サイドバーに色合いをどの程度強く混ぜるかを調整します。"
           },
+          "workspaceChromeAppearance": {
+            "title": "アプリ UI の外観",
+            "rowDescription": "タブバー、ステータスバー、サイドパネル、全画面ビュー、ポップオーバー、ファイルエディタをターミナルのテーマに合わせるか、アプリのテーマのままにします。",
+            "default": "デフォルト",
+            "matchTerminal": "ターミナルに合わせる"
+          },
           "workspaceCardLayoutGuidance": "ワークスペースサイドバーで管理されます。",
           "872af9556e": "システムトレイ",
           "2edf606c46": "閉じるときにトレイへ最小化",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5622,6 +5622,12 @@
             "tintOpacity": "色调强度",
             "tintOpacityDescription": "控制色调混入边栏的强度。"
           },
+          "workspaceChromeAppearance": {
+            "title": "应用界面外观",
+            "rowDescription": "让标签栏、状态栏、侧边面板、全页视图、弹出层和文件编辑器匹配终端主题，或保持应用主题。",
+            "default": "默认",
+            "matchTerminal": "匹配终端"
+          },
           "workspaceCardLayoutGuidance": "从工作区侧边栏管理。",
           "872af9556e": "系统托盘",
           "2edf606c46": "关闭时最小化到托盘",

--- a/src/renderer/src/lib/left-sidebar-appearance.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.ts
@@ -18,6 +18,7 @@ type LeftSidebarAppearanceSettings = TerminalSurfaceSettings &
 
 export type LeftSidebarStyleVariables = Record<string, string>
 
+/** Sidebar token variables for one color pair, optionally re-deriving the text/surface tokens too. */
 function buildSurfaceVariables(args: {
   background: string
   foreground: string
@@ -30,6 +31,7 @@ function buildSurfaceVariables(args: {
   }
 }
 
+/** Match-terminal mode: sidebar variables derived from the active terminal theme. */
 function resolveTerminalSurfaceVariables(
   settings: LeftSidebarAppearanceSettings,
   systemPrefersDark: boolean

--- a/src/renderer/src/lib/left-sidebar-appearance.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.ts
@@ -1,50 +1,22 @@
 import type { GlobalSettings } from '../../../shared/global-settings-types'
-import { HEX_COLOR_RE } from '../../../shared/color-validation'
 import {
   normalizeLeftSidebarTintColor,
   normalizeLeftSidebarTintOpacity
 } from '../../../shared/left-sidebar-appearance'
-import { resolveEffectiveTerminalAppearance } from './terminal-theme'
+import {
+  buildSidebarTokenVariables,
+  buildSurfaceTextTokenVariables,
+  resolveTerminalSurfaceColors,
+  type TerminalSurfaceSettings
+} from './terminal-surface-colors'
 
-type LeftSidebarAppearanceSettings = Pick<
-  GlobalSettings,
-  | 'leftSidebarAppearanceMode'
-  | 'leftSidebarTintColor'
-  | 'leftSidebarTintOpacity'
-  | 'theme'
-  | 'terminalThemeDark'
-  | 'terminalDividerColorDark'
-  | 'terminalUseSeparateLightTheme'
-  | 'terminalThemeLight'
-  | 'terminalCustomThemes'
-  | 'terminalDividerColorLight'
-  | 'terminalColorOverrides'
-  | 'terminalBackgroundOpacity'
->
+type LeftSidebarAppearanceSettings = TerminalSurfaceSettings &
+  Pick<
+    GlobalSettings,
+    'leftSidebarAppearanceMode' | 'leftSidebarTintColor' | 'leftSidebarTintOpacity'
+  >
 
 export type LeftSidebarStyleVariables = Record<string, string>
-
-function hexToRgba(hex: string, alpha: number): string {
-  const normalized = normalizeLeftSidebarTintColor(hex)
-  let clean = normalized.replace('#', '')
-  if (clean.length === 3) {
-    clean = clean
-      .split('')
-      .map((part) => part + part)
-      .join('')
-  }
-  const r = Number.parseInt(clean.slice(0, 2), 16)
-  const g = Number.parseInt(clean.slice(2, 4), 16)
-  const b = Number.parseInt(clean.slice(4, 6), 16)
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`
-}
-
-function applyAlpha(color: string, alpha: number | undefined): string {
-  if (alpha === undefined || alpha >= 1 || !HEX_COLOR_RE.test(color.trim())) {
-    return color
-  }
-  return hexToRgba(color, Math.min(1, Math.max(0, alpha)))
-}
 
 function buildSurfaceVariables(args: {
   background: string
@@ -52,54 +24,17 @@ function buildSurfaceVariables(args: {
   overrideTextTokens?: boolean
 }): LeftSidebarStyleVariables {
   const { background, foreground, overrideTextTokens = false } = args
-  const accent = `color-mix(in srgb, ${foreground} 9%, ${background})`
-  // 7% keeps the sidebar divider at the same prominence as the global --border
-  // (7% in dark mode) so it reads like the rest of the UI; 14% rendered brighter (#5906).
-  const border = `color-mix(in srgb, ${foreground} 7%, ${background})`
-  const ring = `color-mix(in srgb, ${foreground} 44%, ${background})`
-  const vars: LeftSidebarStyleVariables = {
-    '--worktree-sidebar': background,
-    '--worktree-sidebar-foreground': foreground,
-    '--worktree-sidebar-accent': accent,
-    '--worktree-sidebar-accent-foreground': foreground,
-    '--worktree-sidebar-border': border,
-    '--worktree-sidebar-ring': ring,
-    // Why: older worktree-sidebar descendants still consume the shadcn sidebar
-    // token family; mirror it inside this scoped root so every left-sidebar
-    // surface follows the selected appearance.
-    '--sidebar': background,
-    '--sidebar-foreground': foreground,
-    '--sidebar-accent': accent,
-    '--sidebar-accent-foreground': foreground,
-    '--sidebar-border': border,
-    '--sidebar-ring': ring
+  return {
+    ...buildSidebarTokenVariables({ background, foreground }),
+    ...(overrideTextTokens ? buildSurfaceTextTokenVariables({ background, foreground }) : {})
   }
-  if (overrideTextTokens) {
-    vars['--background'] = background
-    vars['--foreground'] = foreground
-    vars['--card'] = `color-mix(in srgb, ${foreground} 4%, ${background})`
-    vars['--card-foreground'] = foreground
-    vars['--accent'] = `color-mix(in srgb, ${foreground} 9%, ${background})`
-    vars['--accent-foreground'] = foreground
-    vars['--muted'] = `color-mix(in srgb, ${foreground} 7%, ${background})`
-    vars['--muted-foreground'] = `color-mix(in srgb, ${foreground} 62%, ${background})`
-    // Match the global --border (7%) so sidebar-scoped dividers aren't brighter (#5906).
-    vars['--border'] = `color-mix(in srgb, ${foreground} 7%, ${background})`
-  }
-  return vars
 }
 
 function resolveTerminalSurfaceVariables(
   settings: LeftSidebarAppearanceSettings,
   systemPrefersDark: boolean
 ): LeftSidebarStyleVariables {
-  const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
-  const background = applyAlpha(
-    settings.terminalColorOverrides?.background ?? appearance.theme?.background ?? '#000000',
-    settings.terminalBackgroundOpacity
-  )
-  const foreground =
-    settings.terminalColorOverrides?.foreground ?? appearance.theme?.foreground ?? '#fafafa'
+  const { background, foreground } = resolveTerminalSurfaceColors(settings, systemPrefersDark)
   return buildSurfaceVariables({ background, foreground, overrideTextTokens: true })
 }
 

--- a/src/renderer/src/lib/terminal-editor-palette.test.ts
+++ b/src/renderer/src/lib/terminal-editor-palette.test.ts
@@ -1,0 +1,199 @@
+import { tmpdir } from 'node:os'
+import { describe, expect, it } from 'vitest'
+import { getDefaultSettings } from '../../../shared/constants'
+import {
+  buildMonacoThemeData,
+  buildSyntaxTokenVariables,
+  mixHexColors,
+  resolveTerminalEditorPalette,
+  TERMINAL_MONACO_THEME_NAME,
+  toHexColor
+} from './terminal-editor-palette'
+
+/** Solarized Light as a Warp-imported custom theme, selected as the (single) terminal theme. */
+const SOLARIZED_LIGHT = {
+  id: 'warp:solarized-light',
+  name: 'Solarized Light',
+  source: 'warp' as const,
+  mode: 'light' as const,
+  importedAt: '2026-01-01T00:00:00.000Z',
+  terminal: {
+    background: '#fdf6e3',
+    foreground: '#657b83',
+    cursor: '#586e75',
+    selectionBackground: '#eee8d5',
+    black: '#073642',
+    red: '#dc322f',
+    green: '#859900',
+    yellow: '#b58900',
+    blue: '#268bd2',
+    magenta: '#d33682',
+    cyan: '#2aa198',
+    white: '#eee8d5',
+    brightBlack: '#002b36',
+    brightRed: '#cb4b16',
+    brightGreen: '#586e75',
+    brightYellow: '#657b83',
+    brightBlue: '#839496',
+    brightMagenta: '#6c71c4',
+    brightCyan: '#93a1a1',
+    brightWhite: '#fdf6e3'
+  }
+}
+
+function matchTerminalSettings(overrides = {}) {
+  return {
+    ...getDefaultSettings(tmpdir()),
+    workspaceChromeAppearanceMode: 'match-terminal' as const,
+    terminalCustomThemes: [SOLARIZED_LIGHT],
+    terminalThemeDark: 'custom:warp:solarized-light',
+    terminalUseSeparateLightTheme: false,
+    ...overrides
+  }
+}
+
+describe('resolveTerminalEditorPalette', () => {
+  it('keeps the app editor theme unless the chrome follows the terminal', () => {
+    expect(
+      resolveTerminalEditorPalette(
+        matchTerminalSettings({ workspaceChromeAppearanceMode: 'default' }),
+        true
+      )
+    ).toBeNull()
+    expect(
+      resolveTerminalEditorPalette(
+        matchTerminalSettings({ workspaceChromeAppearanceMode: undefined }),
+        true
+      )
+    ).toBeNull()
+    expect(resolveTerminalEditorPalette(null, true)).toBeNull()
+  })
+
+  it('rates light/dark by the terminal background, not the OS scheme', () => {
+    const palette = resolveTerminalEditorPalette(matchTerminalSettings(), true)
+    expect(palette).not.toBeNull()
+    expect(palette?.isDark).toBe(false)
+    expect(palette?.background).toBe('#fdf6e3')
+    expect(palette?.foreground).toBe('#657b83')
+    expect(palette?.cursor).toBe('#586e75')
+    expect(palette?.selection).toBe('#eee8d5')
+  })
+
+  it('maps syntax roles onto the ANSI palette and mutes comments toward the background', () => {
+    const palette = resolveTerminalEditorPalette(matchTerminalSettings(), true)
+    expect(palette?.syntax).toMatchObject({
+      keyword: '#d33682',
+      string: '#859900',
+      number: '#2aa198',
+      function: '#268bd2',
+      type: '#b58900',
+      variable: '#dc322f',
+      tag: '#268bd2',
+      link: '#268bd2',
+      addition: '#859900',
+      deletion: '#dc322f'
+    })
+    expect(palette?.syntax.comment).toBe(mixHexColors('#657b83', '#fdf6e3', 62))
+  })
+
+  it('mutes comments toward the background on a high-contrast theme', () => {
+    const palette = resolveTerminalEditorPalette(
+      matchTerminalSettings({
+        terminalColorOverrides: { background: '#000000', foreground: '#ffffff' }
+      }),
+      true
+    )
+    expect(palette?.syntax.comment).toBe('#9e9e9e')
+  })
+
+  it('lets color overrides win over the selected theme', () => {
+    const palette = resolveTerminalEditorPalette(
+      matchTerminalSettings({
+        terminalColorOverrides: { background: '#101820', magenta: '#ff00ff' }
+      }),
+      false
+    )
+    expect(palette?.background).toBe('#101820')
+    expect(palette?.isDark).toBe(true)
+    expect(palette?.syntax.keyword).toBe('#ff00ff')
+  })
+
+  it('keeps the Monaco surface opaque when the terminal background is translucent', () => {
+    const palette = resolveTerminalEditorPalette(
+      matchTerminalSettings({ terminalBackgroundOpacity: 0.5 }),
+      true
+    )
+    expect(palette?.background).toBe('#fdf6e3')
+  })
+})
+
+describe('buildSyntaxTokenVariables', () => {
+  it('exposes every syntax role as a --syntax-* variable', () => {
+    const palette = resolveTerminalEditorPalette(matchTerminalSettings(), true)!
+    const vars = buildSyntaxTokenVariables(palette)
+    expect(vars['--syntax-keyword']).toBe('#d33682')
+    expect(vars['--syntax-comment']).toBe(palette.syntax.comment)
+    expect(Object.keys(vars).sort()).toEqual(
+      Object.keys(palette.syntax)
+        .map((role) => `--syntax-${role}`)
+        .sort()
+    )
+  })
+})
+
+describe('buildMonacoThemeData', () => {
+  it('picks the vs base for a light terminal theme and paints the editor with its colors', () => {
+    const palette = resolveTerminalEditorPalette(matchTerminalSettings(), true)!
+    const theme = buildMonacoThemeData(palette)
+    expect(TERMINAL_MONACO_THEME_NAME).toBe('orca-terminal')
+    expect(theme.base).toBe('vs')
+    expect(theme.colors['editor.background']).toBe('#fdf6e3')
+    expect(theme.colors['editor.foreground']).toBe('#657b83')
+    expect(theme.colors['editorCursor.foreground']).toBe('#586e75')
+    expect(theme.colors['editor.selectionBackground']).toBe('#eee8d5')
+    expect(theme.rules).toContainEqual({ token: 'keyword', foreground: 'd33682' })
+    expect(theme.rules).toContainEqual({ token: 'string', foreground: '859900' })
+    expect(theme.rules).toContainEqual({
+      token: 'comment',
+      foreground: palette.syntax.comment.slice(1),
+      fontStyle: 'italic'
+    })
+  })
+
+  it('picks the vs-dark base for a dark terminal theme', () => {
+    const palette = resolveTerminalEditorPalette(
+      matchTerminalSettings({
+        terminalColorOverrides: { background: '#101820', foreground: '#f0f4f8' }
+      }),
+      true
+    )!
+    expect(buildMonacoThemeData(palette).base).toBe('vs-dark')
+  })
+
+  it('only emits hex colors, which is all Monaco accepts', () => {
+    const palette = resolveTerminalEditorPalette(matchTerminalSettings(), true)!
+    const theme = buildMonacoThemeData(palette)
+    for (const value of Object.values(theme.colors)) {
+      expect(value).toMatch(/^#[0-9a-f]{6}([0-9a-f]{2})?$/)
+    }
+    for (const rule of theme.rules) {
+      expect(rule.foreground).toMatch(/^[0-9a-f]{6}$/)
+    }
+  })
+})
+
+describe('color helpers', () => {
+  it('normalizes css colors to hex and preserves alpha only when translucent', () => {
+    expect(toHexColor('#abc')).toBe('#aabbcc')
+    expect(toHexColor('rgb(16, 24, 32)')).toBe('#101820')
+    expect(toHexColor('rgba(16, 24, 32, 0.5)')).toBe('#10182080')
+    expect(toHexColor('not-a-color')).toBeNull()
+  })
+
+  it('mixes foreground into background by weight', () => {
+    expect(mixHexColors('#ffffff', '#000000', 50)).toBe('#808080')
+    expect(mixHexColors('#ffffff', '#000000', 0)).toBe('#000000')
+    expect(mixHexColors('#ffffff', '#000000', 100)).toBe('#ffffff')
+    expect(mixHexColors('bogus', '#000000', 50)).toBe('bogus')
+  })
+})

--- a/src/renderer/src/lib/terminal-editor-palette.test.ts
+++ b/src/renderer/src/lib/terminal-editor-palette.test.ts
@@ -41,6 +41,7 @@ const SOLARIZED_LIGHT = {
   }
 }
 
+/** Settings fixture in match-terminal mode with a light custom terminal theme. */
 function matchTerminalSettings(overrides = {}) {
   return {
     ...getDefaultSettings(tmpdir()),

--- a/src/renderer/src/lib/terminal-editor-palette.ts
+++ b/src/renderer/src/lib/terminal-editor-palette.ts
@@ -1,0 +1,235 @@
+import type { ITheme } from '@xterm/xterm'
+import type { editor as monacoEditor } from 'monaco-editor'
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import { isTerminalBackgroundLight, parseCssRgbColor } from './terminal-title-contrast'
+import { resolveEffectiveTerminalAppearance } from './terminal-theme'
+import type { SurfaceStyleVariables, TerminalSurfaceSettings } from './terminal-surface-colors'
+
+export type TerminalEditorPaletteSettings = TerminalSurfaceSettings &
+  Pick<GlobalSettings, 'workspaceChromeAppearanceMode'>
+
+/** Syntax roles shared by Monaco token rules and the hljs `--syntax-*` CSS hooks. */
+export type TerminalSyntaxColors = {
+  comment: string
+  keyword: string
+  string: string
+  number: string
+  function: string
+  type: string
+  variable: string
+  tag: string
+  meta: string
+  addition: string
+  deletion: string
+  link: string
+}
+
+export type TerminalEditorPalette = {
+  isDark: boolean
+  /** Opaque `#rrggbb`; Monaco cannot paint a translucent editor surface. */
+  background: string
+  foreground: string
+  cursor: string
+  selection: string
+  syntax: TerminalSyntaxColors
+}
+
+export const TERMINAL_MONACO_THEME_NAME = 'orca-terminal'
+
+/** Matches the --muted-foreground mix in terminal-surface-colors.ts. */
+const MUTED_FOREGROUND_MIX_PERCENT = 62
+const FALLBACK_BACKGROUND = '#000000'
+const FALLBACK_FOREGROUND = '#fafafa'
+
+function channelToHex(channel: number): string {
+  return Math.round(Math.min(255, Math.max(0, channel)))
+    .toString(16)
+    .padStart(2, '0')
+}
+
+/** Any parseable CSS color to `#rrggbb` (`#rrggbbaa` when translucent); null when it fails to parse. */
+export function toHexColor(color: string | undefined): string | null {
+  const rgba = parseCssRgbColor(color)
+  if (!rgba) {
+    return null
+  }
+  const rgb = `#${channelToHex(rgba.r)}${channelToHex(rgba.g)}${channelToHex(rgba.b)}`
+  return rgba.a >= 1 ? rgb : `${rgb}${channelToHex(rgba.a * 255)}`
+}
+
+/** Opaque `#rrggbb` of `color-mix(in srgb, fg P%, bg)`; falls back to `fg` when either fails to parse. */
+export function mixHexColors(foreground: string, background: string, percent: number): string {
+  const fg = parseCssRgbColor(foreground)
+  const bg = parseCssRgbColor(background)
+  if (!fg || !bg) {
+    return foreground
+  }
+  const weight = Math.min(1, Math.max(0, percent / 100))
+  const mix = (a: number, b: number): number => a * weight + b * (1 - weight)
+  return `#${channelToHex(mix(fg.r, bg.r))}${channelToHex(mix(fg.g, bg.g))}${channelToHex(mix(fg.b, bg.b))}`
+}
+
+function pickColor(candidates: (string | undefined)[], fallback: string): string {
+  for (const candidate of candidates) {
+    const hex = toHexColor(candidate)
+    if (hex) {
+      return hex
+    }
+  }
+  return fallback
+}
+
+/** Editor colors derived from the active terminal theme; null unless the chrome follows the terminal. */
+export function resolveTerminalEditorPalette(
+  settings: TerminalEditorPaletteSettings | null | undefined,
+  systemPrefersDark: boolean
+): TerminalEditorPalette | null {
+  if (!settings || (settings.workspaceChromeAppearanceMode ?? 'default') !== 'match-terminal') {
+    return null
+  }
+  const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
+  const theme: ITheme = { ...appearance.theme, ...settings.terminalColorOverrides }
+  const rawBackground = theme.background ?? FALLBACK_BACKGROUND
+  const background = pickColor([rawBackground], FALLBACK_BACKGROUND).slice(0, 7)
+  const foreground = pickColor([theme.foreground], FALLBACK_FOREGROUND).slice(0, 7)
+  // Why: the terminal theme's own brightness decides light/dark styling — a light terminal theme under a
+  // dark OS setting must still get light syntax and Monaco's `vs` base, not `vs-dark`.
+  const isDark = !isTerminalBackgroundLight(rawBackground, {
+    backgroundOpacity: settings.terminalBackgroundOpacity ?? undefined,
+    appSurface: appearance.mode
+  })
+  const ansi = (key: 'red' | 'green' | 'yellow' | 'blue' | 'magenta' | 'cyan'): string =>
+    pickColor([theme[key]], foreground)
+  return {
+    isDark,
+    background,
+    foreground,
+    cursor: pickColor([theme.cursor], foreground),
+    selection: pickColor([theme.selectionBackground], mixHexColors(foreground, background, 22)),
+    syntax: {
+      // Why: ANSI palettes have no dedicated muted color; mix like --muted-foreground (62%) so comments recede.
+      comment: mixHexColors(foreground, background, MUTED_FOREGROUND_MIX_PERCENT),
+      keyword: ansi('magenta'),
+      string: ansi('green'),
+      number: ansi('cyan'),
+      function: ansi('blue'),
+      type: ansi('yellow'),
+      variable: ansi('red'),
+      tag: ansi('blue'),
+      meta: ansi('cyan'),
+      addition: ansi('green'),
+      deletion: ansi('red'),
+      link: ansi('blue')
+    }
+  }
+}
+
+/** `--syntax-*` hooks the hljs stylesheets read ahead of their GitHub defaults. */
+export function buildSyntaxTokenVariables(palette: TerminalEditorPalette): SurfaceStyleVariables {
+  const variables: SurfaceStyleVariables = {}
+  for (const [role, color] of Object.entries(palette.syntax)) {
+    variables[`--syntax-${role}`] = color
+  }
+  return variables
+}
+
+function alphaHex(color: string, alpha: number): string {
+  return `${color.slice(0, 7)}${channelToHex(alpha * 255)}`
+}
+
+/** Monaco theme data painting the editor with the terminal palette. */
+export function buildMonacoThemeData(
+  palette: TerminalEditorPalette
+): monacoEditor.IStandaloneThemeData {
+  const { background, foreground, syntax } = palette
+  const mix = (percent: number): string => mixHexColors(foreground, background, percent)
+  const rule = (token: string, color: string, fontStyle?: string) => ({
+    token,
+    foreground: color.slice(1, 7),
+    ...(fontStyle ? { fontStyle } : {})
+  })
+  return {
+    base: palette.isDark ? 'vs-dark' : 'vs',
+    inherit: true,
+    rules: [
+      rule('', foreground),
+      rule('comment', syntax.comment, 'italic'),
+      rule('keyword', syntax.keyword),
+      rule('operator', syntax.keyword),
+      rule('string', syntax.string),
+      rule('string.value.json', syntax.string),
+      rule('attribute.value', syntax.string),
+      rule('number', syntax.number),
+      rule('constant', syntax.number),
+      rule('regexp', syntax.number),
+      rule('type', syntax.type),
+      rule('predefined', syntax.type),
+      rule('attribute.name', syntax.type),
+      rule('key', syntax.type),
+      rule('string.key.json', syntax.type),
+      rule('tag', syntax.tag),
+      rule('meta.tag', syntax.tag),
+      rule('metatag', syntax.tag),
+      rule('variable', syntax.variable),
+      rule('annotation', syntax.meta),
+      rule('meta', syntax.meta),
+      rule('invalid', syntax.deletion),
+      rule('emphasis', foreground, 'italic'),
+      rule('strong', foreground, 'bold')
+    ],
+    colors: {
+      'editor.background': background,
+      'editor.foreground': foreground,
+      'editorGutter.background': background,
+      'editorLineNumber.foreground': mix(40),
+      'editorLineNumber.activeForeground': mix(80),
+      'editor.lineHighlightBackground': mix(5),
+      'editor.lineHighlightBorder': mix(5),
+      'editor.selectionBackground': palette.selection,
+      'editor.inactiveSelectionBackground': mix(12),
+      'editor.selectionHighlightBackground': mix(14),
+      'editor.wordHighlightBackground': mix(12),
+      'editor.wordHighlightStrongBackground': mix(18),
+      'editor.findMatchBackground': alphaHex(syntax.type, 0.45),
+      'editor.findMatchHighlightBackground': alphaHex(syntax.type, 0.25),
+      'editorCursor.foreground': palette.cursor,
+      'editorWhitespace.foreground': mix(18),
+      'editorIndentGuide.background1': mix(10),
+      'editorIndentGuide.activeBackground1': mix(25),
+      'editorBracketMatch.background': mix(15),
+      'editorBracketMatch.border': mix(30),
+      'editorWidget.background': mix(5),
+      'editorWidget.border': mix(12),
+      'editorSuggestWidget.background': mix(5),
+      'editorHoverWidget.background': mix(5),
+      'input.background': mix(8),
+      'input.foreground': foreground,
+      'minimap.background': background,
+      'scrollbarSlider.background': alphaHex(mix(40), 0.4),
+      'scrollbarSlider.hoverBackground': alphaHex(mix(50), 0.5),
+      'diffEditor.insertedTextBackground': alphaHex(syntax.addition, 0.2),
+      'diffEditor.insertedLineBackground': alphaHex(syntax.addition, 0.1),
+      'diffEditor.removedTextBackground': alphaHex(syntax.deletion, 0.2),
+      'diffEditor.removedLineBackground': alphaHex(syntax.deletion, 0.1)
+    }
+  }
+}
+
+export type EditorSurfaceAppearance = {
+  isDark: boolean
+  /** Null when editor panes keep the app theme. */
+  palette: TerminalEditorPalette | null
+}
+
+/** Light/dark styling for editor panes: the terminal palette when the chrome follows it, else the app theme. */
+export function resolveEditorSurfaceAppearance(
+  settings: TerminalEditorPaletteSettings | null | undefined,
+  systemPrefersDark: boolean
+): EditorSurfaceAppearance {
+  const palette = resolveTerminalEditorPalette(settings, systemPrefersDark)
+  if (palette) {
+    return { isDark: palette.isDark, palette }
+  }
+  const theme = settings?.theme ?? 'system'
+  return { isDark: theme === 'dark' || (theme === 'system' && systemPrefersDark), palette: null }
+}

--- a/src/renderer/src/lib/terminal-editor-palette.ts
+++ b/src/renderer/src/lib/terminal-editor-palette.ts
@@ -41,6 +41,7 @@ const MUTED_FOREGROUND_MIX_PERCENT = 62
 const FALLBACK_BACKGROUND = '#000000'
 const FALLBACK_FOREGROUND = '#fafafa'
 
+/** One 0–255 channel as two lowercase hex digits, clamped. */
 function channelToHex(channel: number): string {
   return Math.round(Math.min(255, Math.max(0, channel)))
     .toString(16)
@@ -65,10 +66,12 @@ export function mixHexColors(foreground: string, background: string, percent: nu
     return foreground
   }
   const weight = Math.min(1, Math.max(0, percent / 100))
+  /** Weighted blend of one channel. */
   const mix = (a: number, b: number): number => a * weight + b * (1 - weight)
   return `#${channelToHex(mix(fg.r, bg.r))}${channelToHex(mix(fg.g, bg.g))}${channelToHex(mix(fg.b, bg.b))}`
 }
 
+/** First candidate that parses as a color, as hex; otherwise the fallback. */
 function pickColor(candidates: (string | undefined)[], fallback: string): string {
   for (const candidate of candidates) {
     const hex = toHexColor(candidate)
@@ -98,6 +101,7 @@ export function resolveTerminalEditorPalette(
     backgroundOpacity: settings.terminalBackgroundOpacity ?? undefined,
     appSurface: appearance.mode
   })
+  /** ANSI slot color, falling back to the foreground when the theme lacks it. */
   const ansi = (key: 'red' | 'green' | 'yellow' | 'blue' | 'magenta' | 'cyan'): string =>
     pickColor([theme[key]], foreground)
   return {
@@ -133,6 +137,7 @@ export function buildSyntaxTokenVariables(palette: TerminalEditorPalette): Surfa
   return variables
 }
 
+/** `#rrggbb` with the given 0–1 alpha appended as `aa`. */
 function alphaHex(color: string, alpha: number): string {
   return `${color.slice(0, 7)}${channelToHex(alpha * 255)}`
 }
@@ -142,7 +147,9 @@ export function buildMonacoThemeData(
   palette: TerminalEditorPalette
 ): monacoEditor.IStandaloneThemeData {
   const { background, foreground, syntax } = palette
+  /** Foreground mixed into the background at the given percent. */
   const mix = (percent: number): string => mixHexColors(foreground, background, percent)
+  /** Monaco token rule; Monaco wants the color without the leading `#`. */
   const rule = (token: string, color: string, fontStyle?: string) => ({
     token,
     foreground: color.slice(1, 7),

--- a/src/renderer/src/lib/terminal-surface-colors.ts
+++ b/src/renderer/src/lib/terminal-surface-colors.ts
@@ -1,0 +1,111 @@
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import { HEX_COLOR_RE } from '../../../shared/color-validation'
+import { resolveEffectiveTerminalAppearance } from './terminal-theme'
+
+export type TerminalSurfaceSettings = Pick<
+  GlobalSettings,
+  | 'theme'
+  | 'terminalThemeDark'
+  | 'terminalDividerColorDark'
+  | 'terminalUseSeparateLightTheme'
+  | 'terminalThemeLight'
+  | 'terminalCustomThemes'
+  | 'terminalDividerColorLight'
+  | 'terminalColorOverrides'
+  | 'terminalBackgroundOpacity'
+>
+
+export type TerminalSurfaceColors = {
+  background: string
+  foreground: string
+}
+
+export type SurfaceStyleVariables = Record<string, string>
+
+export function hexToRgba(hex: string, alpha: number): string {
+  let clean = hex.trim().replace('#', '')
+  if (clean.length === 3) {
+    clean = clean
+      .split('')
+      .map((part) => part + part)
+      .join('')
+  }
+  const r = Number.parseInt(clean.slice(0, 2), 16)
+  const g = Number.parseInt(clean.slice(2, 4), 16)
+  const b = Number.parseInt(clean.slice(4, 6), 16)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+function applyAlpha(color: string, alpha: number | undefined): string {
+  if (alpha === undefined || alpha >= 1 || !HEX_COLOR_RE.test(color.trim())) {
+    return color
+  }
+  return hexToRgba(color, Math.min(1, Math.max(0, alpha)))
+}
+
+/** Background/foreground of the active terminal theme, with color overrides and background opacity applied. */
+export function resolveTerminalSurfaceColors(
+  settings: TerminalSurfaceSettings,
+  systemPrefersDark: boolean
+): TerminalSurfaceColors {
+  const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
+  const background = applyAlpha(
+    settings.terminalColorOverrides?.background ?? appearance.theme?.background ?? '#000000',
+    settings.terminalBackgroundOpacity
+  )
+  const foreground =
+    settings.terminalColorOverrides?.foreground ?? appearance.theme?.foreground ?? '#fafafa'
+  return { background, foreground }
+}
+
+/** Re-derives the shadcn text/surface token family from a terminal color pair so chrome scoped
+ *  under it keeps readable contrast regardless of the app theme. Mix ratios match the global
+ *  tokens (7% border, #5906). */
+export function buildSurfaceTextTokenVariables({
+  background,
+  foreground
+}: TerminalSurfaceColors): SurfaceStyleVariables {
+  return {
+    '--background': background,
+    '--foreground': foreground,
+    '--card': `color-mix(in srgb, ${foreground} 4%, ${background})`,
+    '--card-foreground': foreground,
+    '--accent': `color-mix(in srgb, ${foreground} 9%, ${background})`,
+    '--accent-foreground': foreground,
+    '--muted': `color-mix(in srgb, ${foreground} 7%, ${background})`,
+    '--muted-foreground': `color-mix(in srgb, ${foreground} 62%, ${background})`,
+    '--border': `color-mix(in srgb, ${foreground} 7%, ${background})`,
+    '--popover': `color-mix(in srgb, ${foreground} 4%, ${background})`,
+    '--popover-foreground': foreground,
+    '--secondary': `color-mix(in srgb, ${foreground} 7%, ${background})`,
+    '--secondary-foreground': foreground,
+    '--input': `color-mix(in srgb, ${foreground} 12%, ${background})`,
+    '--ring': `color-mix(in srgb, ${foreground} 44%, ${background})`
+  }
+}
+
+/** The shadcn sidebar token family plus Orca's worktree-sidebar mirror, derived from one color pair. */
+export function buildSidebarTokenVariables({
+  background,
+  foreground
+}: TerminalSurfaceColors): SurfaceStyleVariables {
+  const accent = `color-mix(in srgb, ${foreground} 9%, ${background})`
+  // 7% keeps the sidebar divider at the same prominence as the global --border (#5906).
+  const border = `color-mix(in srgb, ${foreground} 7%, ${background})`
+  const ring = `color-mix(in srgb, ${foreground} 44%, ${background})`
+  return {
+    '--worktree-sidebar': background,
+    '--worktree-sidebar-foreground': foreground,
+    '--worktree-sidebar-accent': accent,
+    '--worktree-sidebar-accent-foreground': foreground,
+    '--worktree-sidebar-border': border,
+    '--worktree-sidebar-ring': ring,
+    // Why: older worktree-sidebar descendants still consume the shadcn sidebar token family.
+    '--sidebar': background,
+    '--sidebar-foreground': foreground,
+    '--sidebar-accent': accent,
+    '--sidebar-accent-foreground': foreground,
+    '--sidebar-border': border,
+    '--sidebar-ring': ring
+  }
+}

--- a/src/renderer/src/lib/terminal-surface-colors.ts
+++ b/src/renderer/src/lib/terminal-surface-colors.ts
@@ -22,6 +22,7 @@ export type TerminalSurfaceColors = {
 
 export type SurfaceStyleVariables = Record<string, string>
 
+/** `#rgb` / `#rrggbb` to `rgba()` with the given alpha. */
 export function hexToRgba(hex: string, alpha: number): string {
   let clean = hex.trim().replace('#', '')
   if (clean.length === 3) {
@@ -36,6 +37,7 @@ export function hexToRgba(hex: string, alpha: number): string {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`
 }
 
+/** Applies the terminal background opacity to a hex color; other formats pass through unchanged. */
 function applyAlpha(color: string, alpha: number | undefined): string {
   if (alpha === undefined || alpha >= 1 || !HEX_COLOR_RE.test(color.trim())) {
     return color

--- a/src/renderer/src/lib/terminal-title-contrast.ts
+++ b/src/renderer/src/lib/terminal-title-contrast.ts
@@ -53,7 +53,7 @@ function compositeTerminalBackground(
   return alpha < 1 ? compositeRgb(color, appSurface, alpha) : { ...color, a: 1 }
 }
 
-function parseCssRgbColor(color: string | undefined): RgbaColor | null {
+export function parseCssRgbColor(color: string | undefined): RgbaColor | null {
   const value = color?.trim().toLowerCase()
   if (!value) {
     return null

--- a/src/renderer/src/lib/terminal-title-contrast.ts
+++ b/src/renderer/src/lib/terminal-title-contrast.ts
@@ -53,6 +53,7 @@ function compositeTerminalBackground(
   return alpha < 1 ? compositeRgb(color, appSurface, alpha) : { ...color, a: 1 }
 }
 
+/** Parses `#rgb[a]`, `#rrggbb[aa]`, `rgb()` / `rgba()` into channels; null for anything else. */
 export function parseCssRgbColor(color: string | undefined): RgbaColor | null {
   const value = color?.trim().toLowerCase()
   if (!value) {

--- a/src/renderer/src/lib/use-workspace-chrome-document-style.ts
+++ b/src/renderer/src/lib/use-workspace-chrome-document-style.ts
@@ -1,0 +1,33 @@
+import { useLayoutEffect, useMemo, useRef } from 'react'
+import { useAppStore } from '../store'
+import { useSystemPrefersDark } from '../components/terminal-pane/use-system-prefers-dark'
+import {
+  applyWorkspaceChromeStyleVariables,
+  resolveWorkspaceChromeStyleVariables
+} from './workspace-chrome-appearance'
+
+/** Keeps the document root's chrome variables in sync with the workspace chrome appearance setting. */
+export function useWorkspaceChromeDocumentStyle(): void {
+  const settings = useAppStore((s) => s.settings)
+  const systemPrefersDark = useSystemPrefersDark()
+  const variables = useMemo(
+    () => resolveWorkspaceChromeStyleVariables(settings, systemPrefersDark),
+    [settings, systemPrefersDark]
+  )
+  const appliedKeysRef = useRef<string[]>([])
+  useLayoutEffect(() => {
+    const style = document.documentElement.style
+    appliedKeysRef.current = applyWorkspaceChromeStyleVariables(
+      style,
+      variables,
+      appliedKeysRef.current
+    )
+    return () => {
+      appliedKeysRef.current = applyWorkspaceChromeStyleVariables(
+        style,
+        undefined,
+        appliedKeysRef.current
+      )
+    }
+  }, [variables])
+}

--- a/src/renderer/src/lib/workspace-chrome-appearance.test.ts
+++ b/src/renderer/src/lib/workspace-chrome-appearance.test.ts
@@ -91,6 +91,25 @@ describe('resolveWorkspaceChromeStyleVariables', () => {
     expect(dark?.['--bg-titlebar']).not.toBe(light?.['--bg-titlebar'])
   })
 
+  it('paints editor panes with the terminal background and exposes its syntax palette', () => {
+    const vars = resolveWorkspaceChromeStyleVariables(
+      settings({
+        workspaceChromeAppearanceMode: 'match-terminal',
+        terminalColorOverrides: {
+          background: '#101820',
+          foreground: '#f0f4f8',
+          magenta: '#ff00ff',
+          green: '#00ff00'
+        }
+      }),
+      true
+    )
+
+    expect(vars?.['--editor-surface']).toBe('#101820')
+    expect(vars?.['--syntax-keyword']).toBe('#ff00ff')
+    expect(vars?.['--syntax-string']).toBe('#00ff00')
+  })
+
   it('honors terminal background opacity', () => {
     const vars = resolveWorkspaceChromeStyleVariables(
       settings({

--- a/src/renderer/src/lib/workspace-chrome-appearance.test.ts
+++ b/src/renderer/src/lib/workspace-chrome-appearance.test.ts
@@ -1,0 +1,147 @@
+import { tmpdir } from 'node:os'
+import { describe, expect, it } from 'vitest'
+import { getDefaultSettings } from '../../../shared/constants'
+import {
+  applyWorkspaceChromeStyleVariables,
+  resolveWorkspaceChromeStyleVariables
+} from './workspace-chrome-appearance'
+
+function settings(overrides = {}) {
+  return {
+    ...getDefaultSettings(tmpdir()),
+    ...overrides
+  }
+}
+
+describe('resolveWorkspaceChromeStyleVariables', () => {
+  it('keeps the app-theme chrome surface by default', () => {
+    expect(resolveWorkspaceChromeStyleVariables(settings(), true)).toBeUndefined()
+    expect(resolveWorkspaceChromeStyleVariables(null, true)).toBeUndefined()
+  })
+
+  it('treats a missing mode from older persisted settings as default', () => {
+    expect(
+      resolveWorkspaceChromeStyleVariables(
+        settings({ workspaceChromeAppearanceMode: undefined }),
+        true
+      )
+    ).toBeUndefined()
+  })
+
+  it('paints the titlebar hook and card with the terminal background and re-derives text tokens', () => {
+    const vars = resolveWorkspaceChromeStyleVariables(
+      settings({
+        workspaceChromeAppearanceMode: 'match-terminal',
+        terminalColorOverrides: {
+          background: '#101820',
+          foreground: '#f0f4f8'
+        }
+      }),
+      true
+    )
+
+    expect(vars).toMatchObject({
+      '--bg-titlebar': '#101820',
+      '--card': '#101820',
+      '--background': '#101820',
+      '--foreground': '#f0f4f8',
+      '--card-foreground': '#f0f4f8'
+    })
+    expect(vars?.['--muted-foreground']).toBe('color-mix(in srgb, #f0f4f8 62%, #101820)')
+    expect(vars?.['--border']).toBe('color-mix(in srgb, #f0f4f8 7%, #101820)')
+    expect(vars?.['--accent']).toBe('color-mix(in srgb, #f0f4f8 9%, #101820)')
+    expect(vars?.['--popover']).toBe('color-mix(in srgb, #f0f4f8 4%, #101820)')
+  })
+
+  it('re-derives both sidebar token families so side panels follow too', () => {
+    const vars = resolveWorkspaceChromeStyleVariables(
+      settings({
+        workspaceChromeAppearanceMode: 'match-terminal',
+        terminalColorOverrides: { background: '#101820', foreground: '#f0f4f8' }
+      }),
+      true
+    )
+
+    expect(vars).toMatchObject({
+      '--sidebar': '#101820',
+      '--sidebar-foreground': '#f0f4f8',
+      '--worktree-sidebar': '#101820',
+      '--worktree-sidebar-foreground': '#f0f4f8'
+    })
+    expect(vars?.['--sidebar-accent']).toBe(vars?.['--worktree-sidebar-accent'])
+  })
+
+  it('falls back to the selected builtin terminal theme when no overrides are set', () => {
+    const dark = resolveWorkspaceChromeStyleVariables(
+      settings({ workspaceChromeAppearanceMode: 'match-terminal' }),
+      true
+    )
+    const light = resolveWorkspaceChromeStyleVariables(
+      settings({
+        workspaceChromeAppearanceMode: 'match-terminal',
+        terminalUseSeparateLightTheme: true,
+        theme: 'light'
+      }),
+      false
+    )
+
+    expect(dark?.['--bg-titlebar']).toMatch(/^#[0-9a-f]{6}$/i)
+    expect(light?.['--bg-titlebar']).toMatch(/^#[0-9a-f]{6}$/i)
+    expect(dark?.['--bg-titlebar']).not.toBe(light?.['--bg-titlebar'])
+  })
+
+  it('honors terminal background opacity', () => {
+    const vars = resolveWorkspaceChromeStyleVariables(
+      settings({
+        workspaceChromeAppearanceMode: 'match-terminal',
+        terminalColorOverrides: { background: '#123456' },
+        terminalBackgroundOpacity: 0.5
+      }),
+      true
+    )
+
+    expect(vars?.['--bg-titlebar']).toBe('rgba(18, 52, 86, 0.5)')
+    expect(vars?.['--card']).toBe('rgba(18, 52, 86, 0.5)')
+  })
+})
+
+describe('applyWorkspaceChromeStyleVariables', () => {
+  function fakeStyle() {
+    const props = new Map<string, string>()
+    return {
+      props,
+      setProperty: (key: string, value: string) => void props.set(key, value),
+      removeProperty: (key: string) => {
+        props.delete(key)
+        return ''
+      }
+    }
+  }
+
+  it('sets every variable and reports the applied keys', () => {
+    const style = fakeStyle()
+    const keys = applyWorkspaceChromeStyleVariables(
+      style,
+      { '--card': '#111', '--ring': '#222' },
+      []
+    )
+
+    expect(keys).toEqual(['--card', '--ring'])
+    expect([...style.props]).toEqual([
+      ['--card', '#111'],
+      ['--ring', '#222']
+    ])
+  })
+
+  it('removes previously applied keys that the next set no longer contains', () => {
+    const style = fakeStyle()
+    let keys = applyWorkspaceChromeStyleVariables(style, { '--card': '#111', '--ring': '#222' }, [])
+    keys = applyWorkspaceChromeStyleVariables(style, { '--card': '#333' }, keys)
+
+    expect(keys).toEqual(['--card'])
+    expect([...style.props]).toEqual([['--card', '#333']])
+
+    expect(applyWorkspaceChromeStyleVariables(style, undefined, keys)).toEqual([])
+    expect(style.props.size).toBe(0)
+  })
+})

--- a/src/renderer/src/lib/workspace-chrome-appearance.test.ts
+++ b/src/renderer/src/lib/workspace-chrome-appearance.test.ts
@@ -6,6 +6,7 @@ import {
   resolveWorkspaceChromeStyleVariables
 } from './workspace-chrome-appearance'
 
+/** Settings fixture in match-terminal mode unless overridden. */
 function settings(overrides = {}) {
   return {
     ...getDefaultSettings(tmpdir()),
@@ -106,6 +107,7 @@ describe('resolveWorkspaceChromeStyleVariables', () => {
 })
 
 describe('applyWorkspaceChromeStyleVariables', () => {
+  /** Minimal CSSStyleDeclaration stand-in recording set/removed properties. */
   function fakeStyle() {
     const props = new Map<string, string>()
     return {

--- a/src/renderer/src/lib/workspace-chrome-appearance.ts
+++ b/src/renderer/src/lib/workspace-chrome-appearance.ts
@@ -1,0 +1,56 @@
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import {
+  buildSidebarTokenVariables,
+  buildSurfaceTextTokenVariables,
+  resolveTerminalSurfaceColors,
+  type SurfaceStyleVariables,
+  type TerminalSurfaceSettings
+} from './terminal-surface-colors'
+
+export type WorkspaceChromeAppearanceSettings = TerminalSurfaceSettings &
+  Pick<GlobalSettings, 'workspaceChromeAppearanceMode'>
+
+export type WorkspaceChromeStyleVariables = SurfaceStyleVariables
+
+/** Document-root CSS variables that make every app chrome surface (tab strip, status bar, side
+ *  panels, full-page views, popovers) follow the terminal theme; undefined keeps the app theme.
+ *  Left-sidebar appearance modes still win because they scope their own vars below the root. */
+export function resolveWorkspaceChromeStyleVariables(
+  settings: WorkspaceChromeAppearanceSettings | null | undefined,
+  systemPrefersDark: boolean
+): WorkspaceChromeStyleVariables | undefined {
+  if (!settings || (settings.workspaceChromeAppearanceMode ?? 'default') !== 'match-terminal') {
+    return undefined
+  }
+  const colors = resolveTerminalSurfaceColors(settings, systemPrefersDark)
+  return {
+    // Status bar and titlebars paint this hook ahead of --card.
+    '--bg-titlebar': colors.background,
+    ...buildSurfaceTextTokenVariables(colors),
+    ...buildSidebarTokenVariables(colors),
+    // Why: tab surfaces are bg-card; pin it to the terminal background so they don't read as a lighter strip.
+    '--card': colors.background
+  }
+}
+
+type StyleDeclarationLike = Pick<CSSStyleDeclaration, 'setProperty' | 'removeProperty'>
+
+/** Writes `next` onto a root style, clearing whatever the previous call set; returns the keys now applied. */
+export function applyWorkspaceChromeStyleVariables(
+  style: StyleDeclarationLike,
+  next: WorkspaceChromeStyleVariables | undefined,
+  previousKeys: readonly string[]
+): string[] {
+  const nextKeys = next ? Object.keys(next) : []
+  for (const key of previousKeys) {
+    if (!next || !(key in next)) {
+      style.removeProperty(key)
+    }
+  }
+  if (next) {
+    for (const key of nextKeys) {
+      style.setProperty(key, next[key])
+    }
+  }
+  return nextKeys
+}

--- a/src/renderer/src/lib/workspace-chrome-appearance.ts
+++ b/src/renderer/src/lib/workspace-chrome-appearance.ts
@@ -1,4 +1,5 @@
 import type { GlobalSettings } from '../../../shared/global-settings-types'
+import { buildSyntaxTokenVariables, resolveTerminalEditorPalette } from './terminal-editor-palette'
 import {
   buildSidebarTokenVariables,
   buildSurfaceTextTokenVariables,
@@ -13,7 +14,7 @@ export type WorkspaceChromeAppearanceSettings = TerminalSurfaceSettings &
 export type WorkspaceChromeStyleVariables = SurfaceStyleVariables
 
 /** Document-root CSS variables that make every app chrome surface (tab strip, status bar, side
- *  panels, full-page views, popovers) follow the terminal theme; undefined keeps the app theme.
+ *  panels, full-page views, popovers, editor panes) follow the terminal theme; undefined keeps the app theme.
  *  Left-sidebar appearance modes still win because they scope their own vars below the root. */
 export function resolveWorkspaceChromeStyleVariables(
   settings: WorkspaceChromeAppearanceSettings | null | undefined,
@@ -23,13 +24,17 @@ export function resolveWorkspaceChromeStyleVariables(
     return undefined
   }
   const colors = resolveTerminalSurfaceColors(settings, systemPrefersDark)
+  const editorPalette = resolveTerminalEditorPalette(settings, systemPrefersDark)
   return {
     // Status bar and titlebars paint this hook ahead of --card.
     '--bg-titlebar': colors.background,
     ...buildSurfaceTextTokenVariables(colors),
     ...buildSidebarTokenVariables(colors),
     // Why: tab surfaces are bg-card; pin it to the terminal background so they don't read as a lighter strip.
-    '--card': colors.background
+    '--card': colors.background,
+    // Markdown preview, rich editor, notebooks, and viewers paint --editor-surface; Monaco follows via its own theme.
+    '--editor-surface': colors.background,
+    ...(editorPalette ? buildSyntaxTokenVariables(editorPalette) : {})
   }
 }
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -47,6 +47,11 @@ import {
   normalizeStatusBarUsageMode,
   type StatusBarUsageMode
 } from '../../../../shared/status-bar-usage-mode'
+import {
+  DEFAULT_STATUS_BAR_USAGE_FORMAT,
+  normalizeStatusBarUsageFormat,
+  type StatusBarUsageFormat
+} from '../../../../shared/status-bar-usage-format'
 import type { GitLabWorkItem } from '../../../../shared/gitlab-types'
 import type { LaunchSource } from '../../../../shared/telemetry-events'
 import type { TaskSourceContext } from '../../../../shared/task-source-context'
@@ -973,6 +978,8 @@ export type UISlice = {
   setUsagePercentageDisplay: (display: UsagePercentageDisplay) => void
   statusBarUsageMode: StatusBarUsageMode
   setStatusBarUsageMode: (mode: StatusBarUsageMode) => void
+  statusBarUsageFormat: StatusBarUsageFormat
+  setStatusBarUsageFormat: (format: StatusBarUsageFormat) => void
   workspacePortScan: { key: string; result: WorkspacePortScanResult } | null
   workspacePortScansByKey: Record<string, WorkspacePortScanResult>
   workspacePortScanRefreshing: boolean
@@ -2343,6 +2350,12 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     window.api.ui.set({ statusBarUsageMode: normalized }).catch(console.error)
     set({ statusBarUsageMode: normalized })
   },
+  statusBarUsageFormat: { ...DEFAULT_STATUS_BAR_USAGE_FORMAT },
+  setStatusBarUsageFormat: (format) => {
+    const normalized = normalizeStatusBarUsageFormat(format)
+    window.api.ui.set({ statusBarUsageFormat: normalized }).catch(console.error)
+    set({ statusBarUsageFormat: normalized })
+  },
   workspacePortScan: null,
   workspacePortScansByKey: {},
   workspacePortScanRefreshing: false,
@@ -2668,6 +2681,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         statusBarVisible: ui.statusBarVisible ?? true,
         usagePercentageDisplay: normalizeUsagePercentageDisplay(ui.usagePercentageDisplay),
         statusBarUsageMode: normalizeStatusBarUsageMode(ui.statusBarUsageMode),
+        statusBarUsageFormat: normalizeStatusBarUsageFormat(ui.statusBarUsageFormat),
         // Why: default true so existing users see the pet on first enabling the flag; only an explicit Hide persists false.
         petVisible: ui.petVisible ?? ui.sidekickVisible ?? true,
         petSize: clampPetSize(ui.petSize ?? ui.sidekickSize ?? PET_SIZE_DEFAULT),

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -2351,6 +2351,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     set({ statusBarUsageMode: normalized })
   },
   statusBarUsageFormat: { ...DEFAULT_STATUS_BAR_USAGE_FORMAT },
+  /** Persists the footer usage template and mirrors it into the store. */
   setStatusBarUsageFormat: (format) => {
     const normalized = normalizeStatusBarUsageFormat(format)
     window.api.ui.set({ statusBarUsageFormat: normalized }).catch(console.error)

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -1081,6 +1081,7 @@ export type UISlice = {
   setBrowserKagiSessionLink: (link: string | null) => void
 }
 
+/** Renderer UI state slice: layout, appearance, status bar and persisted UI preferences. */
 export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get) => ({
   sidebarOpen: true,
   sidebarWidth: 280,
@@ -2553,6 +2554,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   editorFontZoomLevel: 0,
   setEditorFontZoomLevel: (level) => set({ editorFontZoomLevel: level }),
 
+  /** Applies a persisted UI snapshot, normalizing every field against current repos and defaults. */
   hydratePersistedUI: (ui, source = 'sync') =>
     set((s) => {
       const manualRepoOrder = normalizeManualRepoOrder(ui.manualRepoOrder)

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -13,6 +13,7 @@ import { cloneDefaultWorkspaceStatuses } from './workspace-statuses'
 import { DEFAULT_WORKTREE_CARD_PROPERTIES } from './worktree/card-properties'
 import { DEFAULT_USAGE_PERCENTAGE_DISPLAY } from './usage-percentage-display'
 import { DEFAULT_STATUS_BAR_USAGE_MODE } from './status-bar-usage-mode'
+import { DEFAULT_STATUS_BAR_USAGE_FORMAT } from './status-bar-usage-format'
 import { buildDefaultSettings } from './default-global-settings'
 import { DEFAULT_SETUP_AGENT_STARTUP_POLICY } from './setup-agent-startup-policy'
 import { DEFAULT_BROWSER_PAGE_ZOOM_LEVEL } from './browser-page-zoom'
@@ -287,6 +288,7 @@ export function getDefaultUIState(): PersistedUIState {
     statusBarVisible: true,
     usagePercentageDisplay: DEFAULT_USAGE_PERCENTAGE_DISPLAY,
     statusBarUsageMode: DEFAULT_STATUS_BAR_USAGE_MODE,
+    statusBarUsageFormat: { ...DEFAULT_STATUS_BAR_USAGE_FORMAT },
     dismissedUpdateVersion: null,
     lastUpdateCheckAt: null,
     trustedOrcaHooks: {},

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -239,6 +239,7 @@ export function getDefaultPersistedState(homedir: string): PersistedState {
   }
 }
 
+/** Fresh persisted UI state for a first launch. */
 export function getDefaultUIState(): PersistedUIState {
   return {
     lastActiveRepoId: null,

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -17,6 +17,7 @@ import {
 import { DEFAULT_SOURCE_CONTROL_GROUP_ORDER } from './source-control-group-order'
 import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from './terminal-scrollback-policy'
 
+/** Assembles the stock global settings from the few platform-derived inputs. */
 export function buildDefaultSettings(args: {
   workspaceDir: string
   appFontFamily: string

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -44,6 +44,7 @@ export function buildDefaultSettings(args: {
     leftSidebarAppearanceMode: 'default',
     leftSidebarTintColor: DEFAULT_LEFT_SIDEBAR_TINT_COLOR,
     leftSidebarTintOpacity: DEFAULT_LEFT_SIDEBAR_TINT_OPACITY,
+    workspaceChromeAppearanceMode: 'default',
     uiLanguage: UI_LANGUAGE_SYSTEM,
     appIcon: DEFAULT_APP_ICON_ID,
     appFontFamily: args.appFontFamily,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -30,6 +30,7 @@ import type {
   BranchPrefixStrategy,
   FloatingTerminalTriggerLocation,
   LeftSidebarAppearanceMode,
+  WorkspaceChromeAppearanceMode,
   OpenInApplication,
   SourceControlGroupOrder,
   SourceControlViewMode,
@@ -78,6 +79,8 @@ export type GlobalSettings = {
   leftSidebarAppearanceMode: LeftSidebarAppearanceMode
   leftSidebarTintColor?: string
   leftSidebarTintOpacity?: number
+  /** Lets the tab strip and status bar follow the terminal theme instead of the app theme. */
+  workspaceChromeAppearanceMode?: WorkspaceChromeAppearanceMode
   uiLanguage: UiLanguage
   appIcon: AppIconId
   appFontFamily: string

--- a/src/shared/persisted-ui-state-types.ts
+++ b/src/shared/persisted-ui-state-types.ts
@@ -5,6 +5,7 @@ import type { ContextualTourId } from './contextual-tours'
 import type { FeatureInteractionState } from './feature-interactions'
 import type { UsagePercentageDisplay } from './usage-percentage-display'
 import type { StatusBarUsageMode } from './status-bar-usage-mode'
+import type { StatusBarUsageFormat } from './status-bar-usage-format'
 import type { PersistedTrustedOrcaHooks } from './orca-yaml-hook-types'
 import type { CustomPet } from './pet-types'
 import type {
@@ -108,6 +109,8 @@ export type PersistedUIState = {
   usagePercentageDisplay?: UsagePercentageDisplay
   /** Client-side footer presentation; verbose preserves the pre-roster all-window default. */
   statusBarUsageMode?: StatusBarUsageMode
+  /** User template for footer usage text; empty template keeps the built-in rendering. */
+  statusBarUsageFormat?: StatusBarUsageFormat
   dismissedUpdateVersion: string | null
   lastUpdateCheckAt: number | null
   /** Dev-only update channel override; absent means the build's own channel. */

--- a/src/shared/status-bar-usage-format.test.ts
+++ b/src/shared/status-bar-usage-format.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeStatusBarUsageFormat,
+  resolveStatusBarUsageTemplate
+} from './status-bar-usage-format'
+
+describe('normalizeStatusBarUsageFormat', () => {
+  it('returns an empty template for missing or malformed values', () => {
+    expect(normalizeStatusBarUsageFormat(undefined)).toEqual({ template: '' })
+    expect(normalizeStatusBarUsageFormat('not-an-object')).toEqual({ template: '' })
+    expect(normalizeStatusBarUsageFormat({ template: 42 })).toEqual({ template: '' })
+  })
+
+  it('keeps a shared template and only known provider overrides', () => {
+    expect(
+      normalizeStatusBarUsageFormat({
+        template: '{provider} {5h}',
+        byProvider: { codex: '{plan} {5h}', bogus: 'x', claude: 7 }
+      })
+    ).toEqual({ template: '{provider} {5h}', byProvider: { codex: '{plan} {5h}' } })
+  })
+
+  it('drops an empty byProvider map', () => {
+    expect(normalizeStatusBarUsageFormat({ template: 'a', byProvider: {} })).toEqual({
+      template: 'a'
+    })
+  })
+})
+
+describe('resolveStatusBarUsageTemplate', () => {
+  it('prefers a provider override, then the shared template, then null', () => {
+    const format = { template: 'shared', byProvider: { codex: 'codex-only' } }
+    expect(resolveStatusBarUsageTemplate(format, 'codex')).toBe('codex-only')
+    expect(resolveStatusBarUsageTemplate(format, 'claude')).toBe('shared')
+    expect(resolveStatusBarUsageTemplate({ template: '   ' }, 'claude')).toBeNull()
+    expect(resolveStatusBarUsageTemplate(undefined, 'claude')).toBeNull()
+  })
+})

--- a/src/shared/status-bar-usage-format.ts
+++ b/src/shared/status-bar-usage-format.ts
@@ -1,0 +1,58 @@
+import type { ProviderRateLimits } from './rate-limit-types'
+
+export type StatusBarUsageProvider = ProviderRateLimits['provider']
+
+const STATUS_BAR_USAGE_PROVIDERS: ReadonlySet<string> = new Set<StatusBarUsageProvider>([
+  'claude',
+  'codex',
+  'gemini',
+  'opencode-go',
+  'kimi',
+  'minimax',
+  'grok',
+  'antigravity'
+])
+
+/** User-defined footer usage text. Empty `template` means Orca's built-in rendering. */
+export type StatusBarUsageFormat = {
+  template: string
+  /** Per-provider templates that win over `template`; absent providers fall back to it. */
+  byProvider?: Partial<Record<StatusBarUsageProvider, string>>
+}
+
+export const DEFAULT_STATUS_BAR_USAGE_FORMAT: StatusBarUsageFormat = { template: '' }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function normalizeStatusBarUsageFormat(value: unknown): StatusBarUsageFormat {
+  if (!isRecord(value)) {
+    return { ...DEFAULT_STATUS_BAR_USAGE_FORMAT }
+  }
+  const template = typeof value.template === 'string' ? value.template : ''
+  const byProvider: Partial<Record<StatusBarUsageProvider, string>> = {}
+  if (isRecord(value.byProvider)) {
+    for (const [provider, override] of Object.entries(value.byProvider)) {
+      if (STATUS_BAR_USAGE_PROVIDERS.has(provider) && typeof override === 'string') {
+        byProvider[provider as StatusBarUsageProvider] = override
+      }
+    }
+  }
+  return Object.keys(byProvider).length > 0 ? { template, byProvider } : { template }
+}
+
+/** The template to render for `provider`, or null when the built-in rendering should be used. */
+export function resolveStatusBarUsageTemplate(
+  format: StatusBarUsageFormat | null | undefined,
+  provider: StatusBarUsageProvider
+): string | null {
+  if (!format) {
+    return null
+  }
+  const override = format.byProvider?.[provider]
+  if (override && override.trim()) {
+    return override
+  }
+  return format.template.trim() ? format.template : null
+}

--- a/src/shared/status-bar-usage-format.ts
+++ b/src/shared/status-bar-usage-format.ts
@@ -22,10 +22,12 @@ export type StatusBarUsageFormat = {
 
 export const DEFAULT_STATUS_BAR_USAGE_FORMAT: StatusBarUsageFormat = { template: '' }
 
+/** Plain-object guard for persisted JSON. */
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+/** Coerces persisted/RPC input into a valid format, dropping unknown providers and non-string overrides. */
 export function normalizeStatusBarUsageFormat(value: unknown): StatusBarUsageFormat {
   if (!isRecord(value)) {
     return { ...DEFAULT_STATUS_BAR_USAGE_FORMAT }

--- a/src/shared/ui-chrome-types.ts
+++ b/src/shared/ui-chrome-types.ts
@@ -14,6 +14,9 @@ export type SourceControlGroupOrder = 'changes-first' | 'staged-first' | 'untrac
 
 export type LeftSidebarAppearanceMode = 'default' | 'match-terminal' | 'tinted'
 
+/** Surface for the workspace tab strip and status bar: app theme, or the active terminal theme. */
+export type WorkspaceChromeAppearanceMode = 'default' | 'match-terminal'
+
 /** Strategy for the prefix prepended to worktree branch names. */
 export type BranchPrefixStrategy = 'git-username' | 'custom' | 'none'
 


### PR DESCRIPTION
## ELI5

Two appearance settings: (1) the whole app frame (tab strip, status bar, side panels, popovers) can adopt the terminal theme's colors instead of the app theme, and (2) the status bar's usage text can be formatted with a user-defined template.

## What Changed

**feat(appearance): let file editors follow the terminal theme in match-terminal mode** (closes #17199)

- Monaco surfaces (file editor, plain text, diffs, combined diffs, notebooks, markdown source, code excerpts) were hard-wired to `vs` / `vs-dark`, and the Markdown preview / rich editor painted the fixed `--editor-surface` with GitHub-colored hljs tokens — so in match-terminal mode the editor pane was the one surface still on the app theme.
- `terminal-editor-palette.ts` derives an editor palette from the active terminal theme (background / foreground / cursor / selection + syntax roles mapped onto the ANSI slots) and builds a Monaco theme (`orca-terminal`) from it; light/dark is rated by the terminal background's luminance, so a light terminal theme under a dark OS setting still gets light styling.
- Match-terminal chrome variables now also carry `--editor-surface` and a `--syntax-*` set that the hljs stylesheets read ahead of their defaults (non-match-terminal look unchanged).
- `useEditorSurfaceAppearance` / `useMonacoEditorTheme` replace the per-component `isDark ? 'vs-dark' : 'vs'`; the diff-section chain passes the Monaco theme name instead of a dark flag.

**feat(appearance): let app chrome follow the terminal theme**

- New Settings → Appearance → "App Chrome Appearance" (Default / Match Terminal), next to Left Sidebar Appearance.
- In match-terminal mode the terminal theme's background/foreground are written as document-root CSS variables (`--bg-titlebar`, `--background` / `--card` / `--popover` / …, both sidebar token families), so the tab strip, status bar, side panels, full-page views and popovers follow the terminal. Left-sidebar modes still win because they scope their own variables below the root.
- Terminal color pair + token derivation moved into `terminal-surface-colors.ts` and shared with the sidebar resolver.
- Persisted as `workspaceChromeAppearance` in global settings.

**feat(status-bar): configurable usage format template**

- New Settings → Appearance → Status Bar → "Usage format": a template that replaces the built-in per-provider usage text when non-empty.
- Placeholders: `{provider}`, `{plan}`, the 5h / 7d / fable / 30d windows as percentages (following Used/Remaining), `{x.reset}` countdowns, `{x.resetAt}` clock times, Gemini `{buckets}`. `[...]` groups drop out when a placeholder inside is empty so one template works across providers with different windows. Whitespace is rendered as authored.
- Persisted as `PersistedUIState.statusBarUsageFormat` (with a `byProvider` override map reserved for later); the RPC UI-update schema gains the optional field.

## Why

Users who pick a terminal theme often want the surrounding chrome to match instead of clashing with the app theme, and the built-in usage text is fixed per provider — a template lets people show exactly the windows/format they care about in the limited status-bar space. Both are opt-in and default to existing behavior.

## Linked Issue

Fixes #16936 (app chrome should be able to match the terminal theme)
Fixes #16937 (configurable status bar usage format)

## Visual Proof

Terminal theme in these shots: **Everforest Light** (Settings → Appearance → Terminal Themes):

![terminal theme: Everforest Light](https://github.com/user-attachments/assets/904ddcd9-7e08-4e72-9675-1978bf1450f5)

New settings — **App Chrome Appearance = Match Terminal** and **Usage format** with live preview:

![App Chrome Appearance + Usage format settings](https://github.com/user-attachments/assets/31e1c655-fb71-4f9f-9345-bb020e3ae7fc)

**After** — with Match Terminal on, the sidebar, tab strip, panes and status bar all take the Everforest Light surface colors; the status bar shows the custom `{provider}[ | 5h: {5h} ( resets {5h.reset} ) ][ | 7d: {7d}]` template:

![After: app chrome matches terminal theme](https://github.com/user-attachments/assets/17e25f74-7f93-422a-9ddd-2c74ad8918c0)

**Before** — with App Chrome Appearance = Default (the current behavior), the same window renders with the stock app-theme chrome; both settings default to the existing behavior, so this PR changes nothing unless opted in.

## Testing

- Unit tests added: `workspace-chrome-appearance.test.ts`, `usage-format-template.test.ts`, `provider-segment-usage-format.test.tsx`, `StatusBarUsageFormatSetting.test.tsx`, `status-bar-usage-format.test.ts`; existing appearance/search tests updated.
- Rebased onto current `main` (conflicts in `constants.ts` / `en.json` resolved; the appearance default now lives in `default-global-settings.ts`); `pnpm tc`, affected test files (126 tests), `oxlint` and `oxfmt --check` on changed files all pass locally.
- Manually tested on macOS (local workspaces). Settings are renderer-only presentation state; no execution-host / SSH behavior is touched.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude (Claude Code, Claude Fable 5); reviewed and tested by the author.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



