### PR TITLE
Split Jira issue workspace presentation

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -42,7 +42,6 @@ inline src/relay/git-handler.ts
 inline src/relay/pty-handler.ts
 inline src/relay/workspace-space-scan.ts
 inline src/renderer/src/components/GitLabItemDialog.tsx
-inline src/renderer/src/components/JiraIssueWorkspace.tsx
 inline src/renderer/src/components/LinearItemDrawer.tsx
 inline src/renderer/src/components/TaskPage.tsx
 inline src/renderer/src/components/Terminal.tsx

--- a/src/renderer/src/components/JiraIssueWorkspace.tsx
+++ b/src/renderer/src/components/JiraIssueWorkspace.tsx
@@ -1,33 +1,13 @@
-/* eslint-disable max-lines -- Why: the Jira drawer co-locates preview,
-   metadata edits, and comments so the task page has one full issue surface. */
 /* oxlint-disable react-doctor/no-adjust-state-on-prop-change -- Why: Jira issue hydration, comments, transitions, priorities, and user options are loaded from provider IPC for the selected issue. */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import {
-  ArrowRight,
-  Clipboard,
-  ExternalLink,
-  GitBranch,
-  LoaderCircle,
-  RefreshCw,
-  Save,
-  Send,
-  X
-} from 'lucide-react'
 import { toast } from 'sonner'
 import { VisuallyHidden } from 'radix-ui'
-
-import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
-import { JiraIcon } from '@/components/icons/JiraIcon'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/ui/sheet'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { cn } from '@/lib/utils'
 import {
   getCommentBodySubmitState,
   hasBoundedCommentBodyText
 } from '@/lib/comment-body-submit-state'
+
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { useAppStore } from '@/store'
 import {
@@ -48,57 +28,15 @@ import type {
 } from '../../../shared/jira-types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { translate } from '@/i18n/i18n'
-import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
+import { JiraIssueMetadataBar, JiraIssueWorkspaceHeader } from './jira-issue-workspace-chrome'
+import { JiraIssueCommentComposer, JiraIssueWorkspaceContent } from './jira-issue-workspace-content'
+import { getJiraIssueWorkspaceActions } from './jira-issue-workspace-actions'
 
 type JiraIssueWorkspaceProps = {
   issue: JiraIssue | null
   onUse: (issue: JiraIssue) => void
   onClose: () => void
   sourceContext?: TaskSourceContext | null
-}
-
-function formatRelativeTime(input: string): string {
-  return formatUiRelativeTimeFromDate(input)
-}
-
-function buildJiraBranchName(issue: JiraIssue): string {
-  const slug = issue.title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 52)
-  return `${issue.key.toLowerCase()}${slug ? `-${slug}` : ''}`
-}
-
-function buildJiraPrompt(issue: JiraIssue): string {
-  return `Complete Jira issue ${issue.key}: ${issue.title}\n\n${issue.url}`
-}
-
-function jiraStatusClass(categoryKey: string): string {
-  if (categoryKey === 'done') {
-    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
-  }
-  if (categoryKey === 'indeterminate') {
-    return 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-200'
-  }
-  return 'border-border/50 bg-muted/40 text-muted-foreground'
-}
-
-async function copyTextToClipboard(text: string, label: string): Promise<void> {
-  try {
-    await window.api.ui.writeClipboardText(text)
-    toast.success(
-      translate('auto.components.JiraIssueWorkspace.2ff69a3545', '{{value0}} copied', {
-        value0: label
-      })
-    )
-  } catch {
-    toast.error(
-      translate('auto.components.JiraIssueWorkspace.6c41a9bcea', 'Failed to copy {{value0}}', {
-        value0: label.toLowerCase()
-      })
-    )
-  }
 }
 
 export default function JiraIssueWorkspace({
@@ -343,41 +281,10 @@ export default function JiraIssueWorkspace({
   }, [commentDraft, commentSubmitting, displayed, providerSettings])
   const canSubmitComment = hasBoundedCommentBodyText(commentDraft)
 
-  const actionItems = useMemo(() => {
-    if (!displayed) {
-      return []
-    }
-    return [
-      {
-        label: translate('auto.components.JiraIssueWorkspace.69da9a208c', 'Open in Jira'),
-        icon: ExternalLink,
-        action: () => window.api.shell.openUrl(displayed.url)
-      },
-      {
-        label: translate('auto.components.JiraIssueWorkspace.779bb91ee0', 'Copy URL'),
-        icon: Clipboard,
-        action: () => void copyTextToClipboard(displayed.url, 'URL')
-      },
-      {
-        label: translate('auto.components.JiraIssueWorkspace.38839801e8', 'Copy key'),
-        icon: Clipboard,
-        action: () => void copyTextToClipboard(displayed.key, 'Key')
-      },
-      {
-        label: translate(
-          'auto.components.JiraIssueWorkspace.80efa101c5',
-          'Copy suggested branch name'
-        ),
-        icon: GitBranch,
-        action: () => void copyTextToClipboard(buildJiraBranchName(displayed), 'Branch name')
-      },
-      {
-        label: translate('auto.components.JiraIssueWorkspace.0cc62bd690', 'Copy prompt'),
-        icon: Clipboard,
-        action: () => void copyTextToClipboard(buildJiraPrompt(displayed), 'Prompt')
-      }
-    ]
-  }, [displayed])
+  const actionItems = useMemo(
+    () => (displayed ? getJiraIssueWorkspaceActions(displayed) : []),
+    [displayed]
+  )
 
   return (
     <Sheet open={issue !== null} onOpenChange={(open) => !open && onClose()}>
@@ -404,419 +311,46 @@ export default function JiraIssueWorkspace({
 
         {displayed ? (
           <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background">
-            <div className="flex-none border-b border-border/50 bg-muted/30 px-4 py-3">
-              <div className="flex items-start gap-3">
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
-                    <span className="font-mono">{displayed.key}</span>
-                    {displayed.siteName ? <span>{displayed.siteName}</span> : null}
-                    <span>{displayed.project.key}</span>
-                    <span>{formatRelativeTime(displayed.updatedAt)}</span>
-                    {issueLoading ? <LoaderCircle className="size-3 animate-spin" /> : null}
-                  </div>
-                  <h2 className="mt-1 text-[20px] font-semibold leading-tight text-foreground">
-                    {displayed.title}
-                  </h2>
-                </div>
-                <Button
-                  onClick={() => onUse(displayed)}
-                  className="hidden shrink-0 gap-2 sm:inline-flex"
-                  size="sm"
-                >
-                  {translate('auto.components.JiraIssueWorkspace.2441be6f9f', 'Start workspace')}
-                  <ArrowRight className="size-4" />
-                </Button>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      className="shrink-0"
-                      onClick={onClose}
-                      aria-label={translate(
-                        'auto.components.JiraIssueWorkspace.76513c7898',
-                        'Close Jira issue preview'
-                      )}
-                    >
-                      <X className="size-4" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" sideOffset={6}>
-                    {translate('auto.components.JiraIssueWorkspace.7a96985ca0', 'Close')}
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-            </div>
+            <JiraIssueWorkspaceHeader
+              displayed={displayed}
+              issueLoading={issueLoading}
+              onUse={onUse}
+              onClose={onClose}
+            />
 
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-border/60 px-4 py-2.5">
-              <Popover>
-                <PopoverTrigger asChild>
-                  <button
-                    type="button"
-                    disabled={pendingField === 'transition' || transitions.length === 0}
-                    className={cn(
-                      'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium transition hover:opacity-80 disabled:opacity-50',
-                      jiraStatusClass(displayed.status.categoryKey)
-                    )}
-                  >
-                    {displayed.status.name}
-                    {pendingField === 'transition' ? (
-                      <LoaderCircle className="size-3 animate-spin" />
-                    ) : null}
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent
-                  className="popover-scroll-content scrollbar-sleek w-52 p-1"
-                  align="start"
-                >
-                  {transitions.map((transition) => (
-                    <button
-                      key={transition.id}
-                      type="button"
-                      onClick={() =>
-                        void mutateIssue(
-                          'transition',
-                          { transitionId: transition.id },
-                          { status: transition.to }
-                        )
-                      }
-                      className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
-                    >
-                      {transition.name}
-                    </button>
-                  ))}
-                </PopoverContent>
-              </Popover>
+            <JiraIssueMetadataBar
+              displayed={displayed}
+              pendingField={pendingField}
+              transitions={transitions}
+              priorities={priorities}
+              users={users}
+              mutateIssue={mutateIssue}
+            />
 
-              <Popover>
-                <PopoverTrigger asChild>
-                  <button
-                    type="button"
-                    disabled={pendingField === 'priority'}
-                    className="rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground transition hover:bg-muted/40 disabled:opacity-50"
-                  >
-                    {displayed.priority?.name ??
-                      translate('auto.components.JiraIssueWorkspace.51bed73f88', 'No priority')}
-                    {pendingField === 'priority' ? (
-                      <LoaderCircle className="ml-1 inline size-3 animate-spin" />
-                    ) : null}
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent
-                  className="popover-scroll-content scrollbar-sleek w-48 p-1"
-                  align="start"
-                >
-                  <button
-                    type="button"
-                    onClick={() =>
-                      void mutateIssue('priority', { priorityId: null }, { priority: undefined })
-                    }
-                    className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
-                  >
-                    {translate('auto.components.JiraIssueWorkspace.51bed73f88', 'No priority')}
-                  </button>
-                  {priorities.map((priority) => (
-                    <button
-                      key={priority.id}
-                      type="button"
-                      onClick={() =>
-                        void mutateIssue('priority', { priorityId: priority.id }, { priority })
-                      }
-                      className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
-                    >
-                      {priority.name}
-                    </button>
-                  ))}
-                </PopoverContent>
-              </Popover>
+            <JiraIssueWorkspaceContent
+              displayed={displayed}
+              titleDraft={titleDraft}
+              setTitleDraft={setTitleDraft}
+              labelsDraft={labelsDraft}
+              setLabelsDraft={setLabelsDraft}
+              handleSaveTitle={handleSaveTitle}
+              handleSaveLabels={handleSaveLabels}
+              pendingField={pendingField}
+              comments={comments}
+              commentsError={commentsError}
+              commentsLoading={commentsLoading}
+              retryComments={() => void loadComments(displayed, requestIdRef.current)}
+              onUse={onUse}
+              actionItems={actionItems}
+            />
 
-              <Popover>
-                <PopoverTrigger asChild>
-                  <button
-                    type="button"
-                    disabled={pendingField === 'assignee'}
-                    className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground transition hover:bg-muted/40 disabled:opacity-50"
-                  >
-                    {displayed.assignee?.displayName ??
-                      translate('auto.components.JiraIssueWorkspace.54649eaeab', '+ Assignee')}
-                    {pendingField === 'assignee' ? (
-                      <LoaderCircle className="size-3 animate-spin" />
-                    ) : null}
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent
-                  className="popover-scroll-content scrollbar-sleek w-56 p-1"
-                  align="start"
-                >
-                  <button
-                    type="button"
-                    onClick={() =>
-                      void mutateIssue(
-                        'assignee',
-                        { assigneeAccountId: null },
-                        { assignee: undefined }
-                      )
-                    }
-                    className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
-                  >
-                    {translate('auto.components.JiraIssueWorkspace.0b6b5646ed', 'Unassigned')}
-                  </button>
-                  {users.map((user) => (
-                    <button
-                      key={user.accountId}
-                      type="button"
-                      onClick={() =>
-                        void mutateIssue(
-                          'assignee',
-                          { assigneeAccountId: user.accountId },
-                          { assignee: user }
-                        )
-                      }
-                      className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
-                    >
-                      {user.avatarUrl ? (
-                        <img src={user.avatarUrl} alt="" className="size-5 rounded-full" />
-                      ) : null}
-                      <span className="truncate">{user.displayName}</span>
-                    </button>
-                  ))}
-                </PopoverContent>
-              </Popover>
-            </div>
-
-            <div className="grid min-h-0 flex-1 grid-cols-1 xl:grid-cols-[minmax(0,1fr)_228px]">
-              <div className="min-h-0 overflow-y-auto scrollbar-sleek">
-                <section className="border-b border-border/40 px-4 py-4">
-                  <div className="grid gap-2">
-                    <label className="text-[11px] font-medium text-muted-foreground">
-                      {translate('auto.components.JiraIssueWorkspace.444865b4a8', 'Title')}
-                    </label>
-                    <div className="flex gap-2">
-                      <Input
-                        value={titleDraft}
-                        onChange={(event) => setTitleDraft(event.target.value)}
-                        onKeyDown={(event) => {
-                          if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
-                            event.preventDefault()
-                            handleSaveTitle()
-                          }
-                        }}
-                        className="h-8 text-xs"
-                      />
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={handleSaveTitle}
-                        disabled={pendingField === 'title'}
-                      >
-                        {pendingField === 'title' ? (
-                          <LoaderCircle className="size-4 animate-spin" />
-                        ) : (
-                          <Save className="size-4" />
-                        )}
-                      </Button>
-                    </div>
-                    <label className="mt-2 text-[11px] font-medium text-muted-foreground">
-                      {translate('auto.components.JiraIssueWorkspace.aee97b6913', 'Labels')}
-                    </label>
-                    <div className="flex gap-2">
-                      <Input
-                        value={labelsDraft}
-                        onChange={(event) => setLabelsDraft(event.target.value)}
-                        placeholder={translate(
-                          'auto.components.JiraIssueWorkspace.0f3c07a901',
-                          'backend, bug'
-                        )}
-                        className="h-8 text-xs"
-                      />
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={handleSaveLabels}
-                        disabled={pendingField === 'labels'}
-                      >
-                        {pendingField === 'labels' ? (
-                          <LoaderCircle className="size-4 animate-spin" />
-                        ) : (
-                          <Save className="size-4" />
-                        )}
-                      </Button>
-                    </div>
-                  </div>
-                </section>
-
-                <section className="border-b border-border/40 px-4 py-4">
-                  <div className="mb-2 flex items-center gap-2">
-                    <JiraIcon className="size-3 text-muted-foreground" />
-                    <span className="text-xs font-medium text-foreground">
-                      {displayed.issueType.name}
-                    </span>
-                    <span className="text-xs text-muted-foreground">
-                      {displayed.project.key} ·{' '}
-                      {displayed.assignee?.displayName ??
-                        translate('auto.components.JiraIssueWorkspace.0b6b5646ed', 'Unassigned')}
-                    </span>
-                  </div>
-                  {displayed.description?.trim() ? (
-                    <CommentMarkdown
-                      content={displayed.description}
-                      variant="document"
-                      className="text-[14px] leading-relaxed"
-                    />
-                  ) : (
-                    <p className="text-sm italic text-muted-foreground">
-                      {translate(
-                        'auto.components.JiraIssueWorkspace.c4889a47e4',
-                        'No description provided.'
-                      )}
-                    </p>
-                  )}
-                </section>
-
-                <section className="px-4 py-4">
-                  <div className="mb-3 flex items-center justify-between gap-3">
-                    <div className="flex items-center gap-2">
-                      <span className="text-[13px] font-medium text-foreground">
-                        {translate('auto.components.JiraIssueWorkspace.9a980b06b9', 'Comments')}
-                      </span>
-                      {comments.length > 0 ? (
-                        <span className="text-[12px] text-muted-foreground">{comments.length}</span>
-                      ) : null}
-                    </div>
-                    {commentsError ? (
-                      <Button
-                        variant="outline"
-                        size="xs"
-                        onClick={() => void loadComments(displayed, requestIdRef.current)}
-                        disabled={commentsLoading}
-                        className="gap-1"
-                      >
-                        {commentsLoading ? (
-                          <LoaderCircle className="size-3 animate-spin" />
-                        ) : (
-                          <RefreshCw className="size-3" />
-                        )}
-                        {translate('auto.components.JiraIssueWorkspace.5cd09beaf9', 'Retry')}
-                      </Button>
-                    ) : null}
-                  </div>
-                  {commentsError ? (
-                    <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                      {commentsError}
-                    </div>
-                  ) : commentsLoading && comments.length === 0 ? (
-                    <div className="flex items-center justify-center py-8">
-                      <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
-                    </div>
-                  ) : comments.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                      {translate(
-                        'auto.components.JiraIssueWorkspace.9178090e26',
-                        'No comments yet.'
-                      )}
-                    </p>
-                  ) : (
-                    <div className="flex flex-col gap-3">
-                      {comments.map((comment) => (
-                        <div
-                          key={comment.id}
-                          className="rounded-md border border-border/50 bg-muted/20"
-                        >
-                          <div className="flex min-w-0 items-center gap-2 border-b border-border/40 px-3 py-2">
-                            {comment.user?.avatarUrl ? (
-                              <img
-                                src={comment.user.avatarUrl}
-                                alt=""
-                                className="size-5 shrink-0 rounded-full"
-                              />
-                            ) : null}
-                            <span className="truncate text-[13px] font-semibold text-foreground">
-                              {comment.user?.displayName ??
-                                translate(
-                                  'auto.components.JiraIssueWorkspace.666cfdd835',
-                                  'Unknown'
-                                )}
-                            </span>
-                            <span className="shrink-0 text-[12px] text-muted-foreground">
-                              {formatRelativeTime(comment.createdAt)}
-                            </span>
-                          </div>
-                          <div className="px-3 py-2">
-                            {/* Why: Jira comment screenshots need the same preview
-                                affordance without changing compact comment typography. */}
-                            <CommentMarkdown
-                              content={comment.body}
-                              expandImages
-                              className="text-[13px] leading-relaxed"
-                            />
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </section>
-              </div>
-
-              <aside className="border-t border-border/50 bg-muted/20 px-3 py-3 xl:border-l xl:border-t-0">
-                <Button
-                  onClick={() => onUse(displayed)}
-                  className="mb-3 w-full justify-center gap-2 sm:hidden"
-                >
-                  {translate('auto.components.JiraIssueWorkspace.2441be6f9f', 'Start workspace')}
-                  <ArrowRight className="size-4" />
-                </Button>
-                <div className="grid gap-1">
-                  {actionItems.map((item) => {
-                    const Icon = item.icon
-                    return (
-                      <Tooltip key={item.label}>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            onClick={item.action}
-                            className="flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
-                          >
-                            <Icon className="size-3.5 shrink-0" />
-                            <span className="truncate">{item.label}</span>
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent side="left" sideOffset={6}>
-                          {item.label}
-                        </TooltipContent>
-                      </Tooltip>
-                    )
-                  })}
-                </div>
-              </aside>
-            </div>
-
-            <div className="flex-none border-t border-border/50 bg-background px-3 py-3">
-              <div className="flex gap-2">
-                <textarea
-                  value={commentDraft}
-                  onChange={(event) => setCommentDraft(event.target.value)}
-                  placeholder={translate(
-                    'auto.components.JiraIssueWorkspace.a585fd204e',
-                    'Add a Jira comment...'
-                  )}
-                  rows={2}
-                  disabled={commentSubmitting}
-                  className="min-h-10 flex-1 resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-                />
-                <Button
-                  onClick={() => void handleSubmitComment()}
-                  disabled={!canSubmitComment || commentSubmitting}
-                  className="self-end gap-2"
-                >
-                  {commentSubmitting ? (
-                    <LoaderCircle className="size-4 animate-spin" />
-                  ) : (
-                    <Send className="size-4" />
-                  )}
-                  {translate('auto.components.JiraIssueWorkspace.b0b92666c9', 'Comment')}
-                </Button>
-              </div>
-            </div>
+            <JiraIssueCommentComposer
+              commentDraft={commentDraft}
+              setCommentDraft={setCommentDraft}
+              commentSubmitting={commentSubmitting}
+              canSubmitComment={canSubmitComment}
+              handleSubmitComment={() => void handleSubmitComment()}
+            />
           </div>
         ) : null}
       </SheetContent>

--- a/src/renderer/src/components/jira-issue-workspace-actions.ts
+++ b/src/renderer/src/components/jira-issue-workspace-actions.ts
@@ -1,0 +1,68 @@
+import { Clipboard, ExternalLink, GitBranch } from 'lucide-react'
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import type { JiraIssue } from '../../../shared/jira-types'
+import type { JiraIssueWorkspaceAction } from './jira-issue-workspace-content'
+
+function buildJiraBranchName(issue: JiraIssue): string {
+  const slug = issue.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 52)
+  return `${issue.key.toLowerCase()}${slug ? `-${slug}` : ''}`
+}
+
+async function copyTextToClipboard(text: string, label: string): Promise<void> {
+  try {
+    await window.api.ui.writeClipboardText(text)
+    toast.success(
+      translate('auto.components.JiraIssueWorkspace.2ff69a3545', '{{value0}} copied', {
+        value0: label
+      })
+    )
+  } catch {
+    toast.error(
+      translate('auto.components.JiraIssueWorkspace.6c41a9bcea', 'Failed to copy {{value0}}', {
+        value0: label.toLowerCase()
+      })
+    )
+  }
+}
+
+export function getJiraIssueWorkspaceActions(issue: JiraIssue): JiraIssueWorkspaceAction[] {
+  return [
+    {
+      label: translate('auto.components.JiraIssueWorkspace.69da9a208c', 'Open in Jira'),
+      icon: ExternalLink,
+      action: () => window.api.shell.openUrl(issue.url)
+    },
+    {
+      label: translate('auto.components.JiraIssueWorkspace.779bb91ee0', 'Copy URL'),
+      icon: Clipboard,
+      action: () => void copyTextToClipboard(issue.url, 'URL')
+    },
+    {
+      label: translate('auto.components.JiraIssueWorkspace.38839801e8', 'Copy key'),
+      icon: Clipboard,
+      action: () => void copyTextToClipboard(issue.key, 'Key')
+    },
+    {
+      label: translate(
+        'auto.components.JiraIssueWorkspace.80efa101c5',
+        'Copy suggested branch name'
+      ),
+      icon: GitBranch,
+      action: () => void copyTextToClipboard(buildJiraBranchName(issue), 'Branch name')
+    },
+    {
+      label: translate('auto.components.JiraIssueWorkspace.0cc62bd690', 'Copy prompt'),
+      icon: Clipboard,
+      action: () =>
+        void copyTextToClipboard(
+          `Complete Jira issue ${issue.key}: ${issue.title}\n\n${issue.url}`,
+          'Prompt'
+        )
+    }
+  ]
+}

--- a/src/renderer/src/components/jira-issue-workspace-chrome.tsx
+++ b/src/renderer/src/components/jira-issue-workspace-chrome.tsx
@@ -1,0 +1,225 @@
+import { ArrowRight, LoaderCircle, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
+import type {
+  JiraIssue,
+  JiraIssueUpdate,
+  JiraPriority,
+  JiraTransition,
+  JiraUser
+} from '../../../shared/jira-types'
+
+function jiraStatusClass(categoryKey: string): string {
+  if (categoryKey === 'done') {
+    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
+  }
+  if (categoryKey === 'indeterminate') {
+    return 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-200'
+  }
+  return 'border-border/50 bg-muted/40 text-muted-foreground'
+}
+
+export function JiraIssueWorkspaceHeader({
+  displayed,
+  issueLoading,
+  onUse,
+  onClose
+}: {
+  displayed: JiraIssue
+  issueLoading: boolean
+  onUse: (issue: JiraIssue) => void
+  onClose: () => void
+}): React.JSX.Element {
+  return (
+    <div className="flex-none border-b border-border/50 bg-muted/30 px-4 py-3">
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
+            <span className="font-mono">{displayed.key}</span>
+            {displayed.siteName ? <span>{displayed.siteName}</span> : null}
+            <span>{displayed.project.key}</span>
+            <span>{formatUiRelativeTimeFromDate(displayed.updatedAt)}</span>
+            {issueLoading ? <LoaderCircle className="size-3 animate-spin" /> : null}
+          </div>
+          <h2 className="mt-1 text-[20px] font-semibold leading-tight text-foreground">
+            {displayed.title}
+          </h2>
+        </div>
+        <Button
+          onClick={() => onUse(displayed)}
+          className="hidden shrink-0 gap-2 sm:inline-flex"
+          size="sm"
+        >
+          {translate('auto.components.JiraIssueWorkspace.2441be6f9f', 'Start workspace')}
+          <ArrowRight className="size-4" />
+        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="shrink-0"
+              onClick={onClose}
+              aria-label={translate(
+                'auto.components.JiraIssueWorkspace.76513c7898',
+                'Close Jira issue preview'
+              )}
+            >
+              <X className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            {translate('auto.components.JiraIssueWorkspace.7a96985ca0', 'Close')}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  )
+}
+
+export function JiraIssueMetadataBar({
+  displayed,
+  pendingField,
+  transitions,
+  priorities,
+  users,
+  mutateIssue
+}: {
+  displayed: JiraIssue
+  pendingField: string | null
+  transitions: JiraTransition[]
+  priorities: JiraPriority[]
+  users: JiraUser[]
+  mutateIssue: (
+    field: string,
+    updates: JiraIssueUpdate,
+    optimistic?: Partial<JiraIssue>
+  ) => Promise<void>
+}): React.JSX.Element {
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-border/60 px-4 py-2.5">
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            disabled={pendingField === 'transition' || transitions.length === 0}
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium transition hover:opacity-80 disabled:opacity-50',
+              jiraStatusClass(displayed.status.categoryKey)
+            )}
+          >
+            {displayed.status.name}
+            {pendingField === 'transition' ? (
+              <LoaderCircle className="size-3 animate-spin" />
+            ) : null}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="popover-scroll-content scrollbar-sleek w-52 p-1" align="start">
+          {transitions.map((transition) => (
+            <button
+              key={transition.id}
+              type="button"
+              onClick={() =>
+                void mutateIssue(
+                  'transition',
+                  { transitionId: transition.id },
+                  { status: transition.to }
+                )
+              }
+              className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
+            >
+              {transition.name}
+            </button>
+          ))}
+        </PopoverContent>
+      </Popover>
+
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            disabled={pendingField === 'priority'}
+            className="rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground transition hover:bg-muted/40 disabled:opacity-50"
+          >
+            {displayed.priority?.name ??
+              translate('auto.components.JiraIssueWorkspace.51bed73f88', 'No priority')}
+            {pendingField === 'priority' ? (
+              <LoaderCircle className="ml-1 inline size-3 animate-spin" />
+            ) : null}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="popover-scroll-content scrollbar-sleek w-48 p-1" align="start">
+          <button
+            type="button"
+            onClick={() =>
+              void mutateIssue('priority', { priorityId: null }, { priority: undefined })
+            }
+            className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
+          >
+            {translate('auto.components.JiraIssueWorkspace.51bed73f88', 'No priority')}
+          </button>
+          {priorities.map((priority) => (
+            <button
+              key={priority.id}
+              type="button"
+              onClick={() =>
+                void mutateIssue('priority', { priorityId: priority.id }, { priority })
+              }
+              className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
+            >
+              {priority.name}
+            </button>
+          ))}
+        </PopoverContent>
+      </Popover>
+
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            disabled={pendingField === 'assignee'}
+            className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground transition hover:bg-muted/40 disabled:opacity-50"
+          >
+            {displayed.assignee?.displayName ??
+              translate('auto.components.JiraIssueWorkspace.54649eaeab', '+ Assignee')}
+            {pendingField === 'assignee' ? <LoaderCircle className="size-3 animate-spin" /> : null}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="popover-scroll-content scrollbar-sleek w-56 p-1" align="start">
+          <button
+            type="button"
+            onClick={() =>
+              void mutateIssue('assignee', { assigneeAccountId: null }, { assignee: undefined })
+            }
+            className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
+          >
+            {translate('auto.components.JiraIssueWorkspace.0b6b5646ed', 'Unassigned')}
+          </button>
+          {users.map((user) => (
+            <button
+              key={user.accountId}
+              type="button"
+              onClick={() =>
+                void mutateIssue(
+                  'assignee',
+                  { assigneeAccountId: user.accountId },
+                  { assignee: user }
+                )
+              }
+              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
+            >
+              {user.avatarUrl ? (
+                <img src={user.avatarUrl} alt="" className="size-5 rounded-full" />
+              ) : null}
+              <span className="truncate">{user.displayName}</span>
+            </button>
+          ))}
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/src/renderer/src/components/jira-issue-workspace-content.tsx
+++ b/src/renderer/src/components/jira-issue-workspace-content.tsx
@@ -1,0 +1,289 @@
+import type { LucideIcon } from 'lucide-react'
+import { ArrowRight, LoaderCircle, RefreshCw, Save, Send } from 'lucide-react'
+import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
+import { JiraIcon } from '@/components/icons/JiraIcon'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
+import type { JiraComment, JiraIssue } from '../../../shared/jira-types'
+
+export type JiraIssueWorkspaceAction = {
+  label: string
+  icon: LucideIcon
+  action: () => void
+}
+
+export function JiraIssueWorkspaceContent({
+  displayed,
+  titleDraft,
+  setTitleDraft,
+  labelsDraft,
+  setLabelsDraft,
+  handleSaveTitle,
+  handleSaveLabels,
+  pendingField,
+  comments,
+  commentsError,
+  commentsLoading,
+  retryComments,
+  onUse,
+  actionItems
+}: {
+  displayed: JiraIssue
+  titleDraft: string
+  setTitleDraft: (value: string) => void
+  labelsDraft: string
+  setLabelsDraft: (value: string) => void
+  handleSaveTitle: () => void
+  handleSaveLabels: () => void
+  pendingField: string | null
+  comments: JiraComment[]
+  commentsError: string | null
+  commentsLoading: boolean
+  retryComments: () => void
+  onUse: (issue: JiraIssue) => void
+  actionItems: JiraIssueWorkspaceAction[]
+}): React.JSX.Element {
+  return (
+    <div className="grid min-h-0 flex-1 grid-cols-1 xl:grid-cols-[minmax(0,1fr)_228px]">
+      <div className="min-h-0 overflow-y-auto scrollbar-sleek">
+        <section className="border-b border-border/40 px-4 py-4">
+          <div className="grid gap-2">
+            <label className="text-[11px] font-medium text-muted-foreground">
+              {translate('auto.components.JiraIssueWorkspace.444865b4a8', 'Title')}
+            </label>
+            <div className="flex gap-2">
+              <Input
+                value={titleDraft}
+                onChange={(event) => setTitleDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
+                    event.preventDefault()
+                    handleSaveTitle()
+                  }
+                }}
+                className="h-8 text-xs"
+              />
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleSaveTitle}
+                disabled={pendingField === 'title'}
+              >
+                {pendingField === 'title' ? (
+                  <LoaderCircle className="size-4 animate-spin" />
+                ) : (
+                  <Save className="size-4" />
+                )}
+              </Button>
+            </div>
+            <label className="mt-2 text-[11px] font-medium text-muted-foreground">
+              {translate('auto.components.JiraIssueWorkspace.aee97b6913', 'Labels')}
+            </label>
+            <div className="flex gap-2">
+              <Input
+                value={labelsDraft}
+                onChange={(event) => setLabelsDraft(event.target.value)}
+                placeholder={translate(
+                  'auto.components.JiraIssueWorkspace.0f3c07a901',
+                  'backend, bug'
+                )}
+                className="h-8 text-xs"
+              />
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleSaveLabels}
+                disabled={pendingField === 'labels'}
+              >
+                {pendingField === 'labels' ? (
+                  <LoaderCircle className="size-4 animate-spin" />
+                ) : (
+                  <Save className="size-4" />
+                )}
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b border-border/40 px-4 py-4">
+          <div className="mb-2 flex items-center gap-2">
+            <JiraIcon className="size-3 text-muted-foreground" />
+            <span className="text-xs font-medium text-foreground">{displayed.issueType.name}</span>
+            <span className="text-xs text-muted-foreground">
+              {displayed.project.key} ·{' '}
+              {displayed.assignee?.displayName ??
+                translate('auto.components.JiraIssueWorkspace.0b6b5646ed', 'Unassigned')}
+            </span>
+          </div>
+          {displayed.description?.trim() ? (
+            <CommentMarkdown
+              content={displayed.description}
+              variant="document"
+              className="text-[14px] leading-relaxed"
+            />
+          ) : (
+            <p className="text-sm italic text-muted-foreground">
+              {translate(
+                'auto.components.JiraIssueWorkspace.c4889a47e4',
+                'No description provided.'
+              )}
+            </p>
+          )}
+        </section>
+
+        <section className="px-4 py-4">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <span className="text-[13px] font-medium text-foreground">
+                {translate('auto.components.JiraIssueWorkspace.9a980b06b9', 'Comments')}
+              </span>
+              {comments.length > 0 ? (
+                <span className="text-[12px] text-muted-foreground">{comments.length}</span>
+              ) : null}
+            </div>
+            {commentsError ? (
+              <Button
+                variant="outline"
+                size="xs"
+                onClick={retryComments}
+                disabled={commentsLoading}
+                className="gap-1"
+              >
+                {commentsLoading ? (
+                  <LoaderCircle className="size-3 animate-spin" />
+                ) : (
+                  <RefreshCw className="size-3" />
+                )}
+                {translate('auto.components.JiraIssueWorkspace.5cd09beaf9', 'Retry')}
+              </Button>
+            ) : null}
+          </div>
+          {commentsError ? (
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {commentsError}
+            </div>
+          ) : commentsLoading && comments.length === 0 ? (
+            <div className="flex items-center justify-center py-8">
+              <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
+            </div>
+          ) : comments.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {translate('auto.components.JiraIssueWorkspace.9178090e26', 'No comments yet.')}
+            </p>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {comments.map((comment) => (
+                <div key={comment.id} className="rounded-md border border-border/50 bg-muted/20">
+                  <div className="flex min-w-0 items-center gap-2 border-b border-border/40 px-3 py-2">
+                    {comment.user?.avatarUrl ? (
+                      <img
+                        src={comment.user.avatarUrl}
+                        alt=""
+                        className="size-5 shrink-0 rounded-full"
+                      />
+                    ) : null}
+                    <span className="truncate text-[13px] font-semibold text-foreground">
+                      {comment.user?.displayName ??
+                        translate('auto.components.JiraIssueWorkspace.666cfdd835', 'Unknown')}
+                    </span>
+                    <span className="shrink-0 text-[12px] text-muted-foreground">
+                      {formatUiRelativeTimeFromDate(comment.createdAt)}
+                    </span>
+                  </div>
+                  <div className="px-3 py-2">
+                    {/* Why: Jira comment screenshots need the same preview
+                                affordance without changing compact comment typography. */}
+                    <CommentMarkdown
+                      content={comment.body}
+                      expandImages
+                      className="text-[13px] leading-relaxed"
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+
+      <aside className="border-t border-border/50 bg-muted/20 px-3 py-3 xl:border-l xl:border-t-0">
+        <Button
+          onClick={() => onUse(displayed)}
+          className="mb-3 w-full justify-center gap-2 sm:hidden"
+        >
+          {translate('auto.components.JiraIssueWorkspace.2441be6f9f', 'Start workspace')}
+          <ArrowRight className="size-4" />
+        </Button>
+        <div className="grid gap-1">
+          {actionItems.map((item) => {
+            const Icon = item.icon
+            return (
+              <Tooltip key={item.label}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={item.action}
+                    className="flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
+                  >
+                    <Icon className="size-3.5 shrink-0" />
+                    <span className="truncate">{item.label}</span>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="left" sideOffset={6}>
+                  {item.label}
+                </TooltipContent>
+              </Tooltip>
+            )
+          })}
+        </div>
+      </aside>
+    </div>
+  )
+}
+
+export function JiraIssueCommentComposer({
+  commentDraft,
+  setCommentDraft,
+  commentSubmitting,
+  canSubmitComment,
+  handleSubmitComment
+}: {
+  commentDraft: string
+  setCommentDraft: (value: string) => void
+  commentSubmitting: boolean
+  canSubmitComment: boolean
+  handleSubmitComment: () => void
+}): React.JSX.Element {
+  return (
+    <div className="flex-none border-t border-border/50 bg-background px-3 py-3">
+      <div className="flex gap-2">
+        <textarea
+          value={commentDraft}
+          onChange={(event) => setCommentDraft(event.target.value)}
+          placeholder={translate(
+            'auto.components.JiraIssueWorkspace.a585fd204e',
+            'Add a Jira comment...'
+          )}
+          rows={2}
+          disabled={commentSubmitting}
+          className="min-h-10 flex-1 resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        />
+        <Button
+          onClick={handleSubmitComment}
+          disabled={!canSubmitComment || commentSubmitting}
+          className="self-end gap-2"
+        >
+          {commentSubmitting ? (
+            <LoaderCircle className="size-4 animate-spin" />
+          ) : (
+            <Send className="size-4" />
+          )}
+          {translate('auto.components.JiraIssueWorkspace.b0b92666c9', 'Comment')}
+        </Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- split Jira drawer chrome, metadata controls, content, comment composer, and action construction into focused modules
- preserve the existing state/hydration/mutation owner in `JiraIssueWorkspace`
- remove the Jira workspace max-lines bypass without barrel exports

Stacked on #16767.

## Verification
- `pnpm tc`
- targeted Oxlint across all Jira workspace modules
- `pnpm check:max-lines-ratchet`