### PR TITLE
test(runtime): keep export parity current

### DIFF
--- a/src/shared/runtime-client-export-parity.test.ts
+++ b/src/shared/runtime-client-export-parity.test.ts
@@ -225,8 +225,11 @@ describe('runtime client public export parity', () => {
       'BROWSER_UNAVAILABLE_ERROR_CODE',
       'COMPUTER_ERROR_CODES',
       'HEADLESS_RUNTIME_WINDOW_ID',
+      'TERMINAL_PTY_DEGRADATION_CAPABILITY',
+      'TERMINAL_UNAVAILABLE_ERROR_CODE',
       'UNPUBLISHED_WORKTREE_PUBLICATION_EPOCH',
-      'browserUnavailableMessage'
+      'browserUnavailableMessage',
+      'terminalUnavailableMessage'
     ])
     expect(Object.keys(RemoteClient).sort()).toEqual([
       'RemoteRuntimeClientError',

--- a/src/shared/runtime-client-export-parity.test.ts
+++ b/src/shared/runtime-client-export-parity.test.ts
@@ -158,6 +158,7 @@ type RuntimeTypeInventory = [
   Runtime.RuntimeTerminalSplit,
   Runtime.RuntimeTerminalState,
   Runtime.RuntimeTerminalSummary,
+  Runtime.RuntimeTerminalUnavailableReason,
   Runtime.RuntimeTerminalVisualGroupNode,
   Runtime.RuntimeTerminalVisualLayout,
   Runtime.RuntimeTerminalVisualLayoutNode,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Summary
- update the runtime export-parity inventory for the terminal degradation exports now published by `runtime-types`
- unblock unrelated PR merge refs that fail shard 10 under Node 24 and Node 26

## Verification
- reproduced the failure on `origin/main`, PR #16128 merge ref, and PR #16711 merge ref under Node 24 and Node 26
- focused parity test passes on current Node 26 and Node 24
- focused parity test passes on both PR merge refs under Node 24 and Node 26
- `pnpm tc` passes
- changed-code quality passes with Node 24
