### PR TITLE
Split onboarding flow controller

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -51,7 +51,6 @@ inline src/renderer/src/components/editor/CombinedDiffViewer.tsx
 inline src/renderer/src/components/editor/MarkdownPreview.tsx
 inline src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
 inline src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
-inline src/renderer/src/components/onboarding/use-onboarding-flow.ts
 inline src/renderer/src/components/right-sidebar/PortsPanel.tsx
 inline src/renderer/src/components/settings/AccountsPane.tsx
 inline src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx

--- a/src/renderer/src/components/onboarding/onboarding-flow-state.ts
+++ b/src/renderer/src/components/onboarding/onboarding-flow-state.ts
@@ -1,0 +1,169 @@
+import { toast } from 'sonner'
+import type { AppState } from '@/store/types'
+import { translate } from '@/i18n/i18n'
+import { ONBOARDING_FINAL_STEP, ONBOARDING_FLOW_VERSION } from '../../../../shared/constants'
+import type { EventProps } from '../../../../shared/telemetry-events'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { OnboardingState } from '../../../../shared/onboarding-state-types'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import { STEPS } from './use-onboarding-flow-types'
+
+type TaskSourcesSnapshotProps = EventProps<'onboarding_task_sources_snapshot'>
+type TaskSourcesGithubStatus = TaskSourcesSnapshotProps['github_status']
+type TaskSourcesLinearStatus = TaskSourcesSnapshotProps['linear_status']
+export type TaskSourcesExitAction = TaskSourcesSnapshotProps['exit_action']
+
+export function shouldSkipIntegrationsStep(status: AppState['preflightStatus']): boolean {
+  return status?.gh.installed === true
+}
+
+export function shouldSkipWindowsTerminalStep(isWindows: boolean): boolean {
+  return !isWindows
+}
+
+export type OnboardingStepSkipOptions = {
+  skipIntegrations: boolean
+  skipWindowsTerminal: boolean
+}
+
+export function isSkippedStepIndex(index: number, options: OnboardingStepSkipOptions): boolean {
+  const step = STEPS[index]
+  return (
+    (options.skipIntegrations && step?.id === 'integrations') ||
+    (options.skipWindowsTerminal && step?.id === 'windows_terminal')
+  )
+}
+
+export function resolveStepIndex(
+  index: number,
+  skipOptions: OnboardingStepSkipOptions,
+  direction: 'forward' | 'backward'
+): number {
+  const lastIndex = STEPS.length - 1
+  let nextIndex = Math.min(Math.max(index, 0), lastIndex)
+  while (isSkippedStepIndex(nextIndex, skipOptions)) {
+    const candidate = nextIndex + (direction === 'forward' ? 1 : -1)
+    if (candidate < 0 || candidate > lastIndex) {
+      return direction === 'forward' ? lastIndex : 0
+    }
+    nextIndex = candidate
+  }
+  return nextIndex
+}
+
+export function getGitHubTaskSourceStatus(
+  status: AppState['preflightStatus'],
+  loading: boolean
+): TaskSourcesGithubStatus {
+  if (loading || !status) {
+    return 'checking'
+  }
+  if (!status.gh.installed) {
+    return 'not_installed'
+  }
+  return status.gh.authenticated ? 'connected' : 'not_authenticated'
+}
+
+export function getLinearTaskSourceStatus(
+  status: AppState['linearStatus'],
+  checked: boolean
+): TaskSourcesLinearStatus {
+  if (status.connected) {
+    return 'connected'
+  }
+  return checked ? 'not_connected' : 'checking'
+}
+
+type OnboardingStepId = (typeof STEPS)[number]['id']
+
+type OnboardingProgressSnapshot = Pick<
+  OnboardingState,
+  'flowVersion' | 'lastCompletedStep' | 'outcome'
+>
+
+export function remapOpenOnboardingLastCompletedStep({
+  flowVersion,
+  lastCompletedStep,
+  outcome
+}: OnboardingProgressSnapshot): number {
+  if (flowVersion === ONBOARDING_FLOW_VERSION) {
+    return lastCompletedStep
+  }
+  if (outcome === 'completed' && lastCompletedStep >= 4) {
+    return ONBOARDING_FINAL_STEP
+  }
+  // Why: in v3 (four-step, pre-Windows-terminal) step 4 already meant notifications, so resume there.
+  if (flowVersion === 3) {
+    return Math.min(4, lastCompletedStep)
+  }
+  // Why: v2 (five-step) and older seven-step data used step 4 for removed agent setup, not integrations.
+  if (flowVersion === 2) {
+    if (lastCompletedStep === 3) {
+      return 2
+    }
+    if (lastCompletedStep >= 4) {
+      return 3
+    }
+    return lastCompletedStep
+  }
+  if (lastCompletedStep === 3) {
+    return 2
+  }
+  if (lastCompletedStep === 4) {
+    return 2
+  }
+  if (lastCompletedStep >= 5) {
+    return 3
+  }
+  return lastCompletedStep
+}
+
+type SkippedOnboardingPreferenceOptions = {
+  currentStepId: OnboardingStepId
+  themeBeforePreview: GlobalSettings['theme'] | null
+  settingsTheme: GlobalSettings['theme'] | undefined
+  selectedAgent: TuiAgent | null
+  setTheme: (theme: GlobalSettings['theme']) => void
+  applyTheme: (theme: GlobalSettings['theme']) => void
+  updateSettings: (updates: Partial<GlobalSettings>) => Promise<void> | void
+  setError: (message: string | null) => void
+}
+
+export async function prepareSkippedOnboardingPreferences({
+  currentStepId,
+  themeBeforePreview,
+  settingsTheme,
+  selectedAgent,
+  setTheme,
+  applyTheme,
+  updateSettings,
+  setError
+}: SkippedOnboardingPreferenceOptions): Promise<boolean> {
+  try {
+    // Why: theme tiles save immediately for a stable preview, but skip must not keep this step's choice.
+    if (currentStepId === 'theme') {
+      const themeToRestore = themeBeforePreview ?? settingsTheme
+      if (themeToRestore) {
+        setTheme(themeToRestore)
+        applyTheme(themeToRestore)
+        await updateSettings({ theme: themeToRestore })
+      }
+    }
+    // Why: skipping bypasses step persistence, so save the visible agent choice before closing.
+    if (currentStepId === 'agent' && selectedAgent) {
+      await updateSettings({ defaultTuiAgent: selectedAgent })
+    }
+    return true
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    setError(message)
+    toast.error(
+      translate(
+        'auto.components.onboarding.use.onboarding.flow.52acfbef51',
+        'Could not save progress'
+      ),
+      { description: message }
+    )
+    return false
+  }
+}

--- a/src/renderer/src/components/onboarding/use-onboarding-flow-actions.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow-actions.ts
@@ -1,0 +1,268 @@
+import { useCallback, useRef, type Dispatch, type SetStateAction } from 'react'
+import { toast } from 'sonner'
+import { applyDocumentTheme } from '@/lib/document-theme'
+import { track } from '@/lib/telemetry'
+import { translate } from '@/i18n/i18n'
+import { ONBOARDING_FINAL_STEP } from '../../../../shared/constants'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { OnboardingState } from '../../../../shared/onboarding-state-types'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import { buildWindowsTerminalSnapshotPayload } from './windows-terminal-onboarding-telemetry'
+import { persistStep, type PersistCurrentStepResult } from './use-onboarding-flow-persistence'
+import { STEPS, type StepNumber } from './use-onboarding-flow-types'
+import {
+  prepareSkippedOnboardingPreferences,
+  resolveStepIndex,
+  type OnboardingStepSkipOptions,
+  type TaskSourcesExitAction
+} from './onboarding-flow-state'
+
+type CloseWith = (
+  outcome: 'completed' | 'dismissed',
+  lastStepReached: StepNumber,
+  completedPath?: 'add_project_modal',
+  dismissedExtras?: { advancedVia: 'button' | 'keyboard'; durationMs: number }
+) => Promise<boolean>
+
+type OnboardingFlowActionsArgs = {
+  busyLabel: string | null
+  setBusyLabel: Dispatch<SetStateAction<string | null>>
+  setError: Dispatch<SetStateAction<string | null>>
+  currentStep: (typeof STEPS)[number]
+  consumeStepDurationMs: () => number
+  trackTaskSourcesSnapshot: (
+    exitAction: TaskSourcesExitAction,
+    durationMs: number,
+    advancedVia: 'button' | 'keyboard'
+  ) => void
+  settings: GlobalSettings | null
+  persistCurrentStep: () => Promise<PersistCurrentStepResult>
+  closeWith: CloseWith
+  openModal: (modal: 'add-repo') => void
+  getNextStepIndex: (index: number) => number
+  onOnboardingChange: (state: OnboardingState) => void
+  stepIndex: number
+  setStepIndex: Dispatch<SetStateAction<number>>
+  selectedAgent: TuiAgent | null
+  themeStepEntryThemeRef: { current: GlobalSettings['theme'] | null }
+  setTheme: Dispatch<SetStateAction<GlobalSettings['theme']>>
+  updateSettings: (updates: Partial<GlobalSettings>) => Promise<void> | void
+  skipOptions: OnboardingStepSkipOptions
+}
+
+export function useOnboardingFlowActions({
+  busyLabel,
+  setBusyLabel,
+  setError,
+  currentStep,
+  consumeStepDurationMs,
+  trackTaskSourcesSnapshot,
+  settings,
+  persistCurrentStep,
+  closeWith,
+  openModal,
+  getNextStepIndex,
+  onOnboardingChange,
+  stepIndex,
+  setStepIndex,
+  selectedAgent,
+  themeStepEntryThemeRef,
+  setTheme,
+  updateSettings,
+  skipOptions
+}: OnboardingFlowActionsArgs) {
+  // Why: sync latch; busyLabel state commits too late to stop a ~30ms Cmd+Enter auto-repeat from re-entering next() and skipping a step.
+  const nextInFlightRef = useRef(false)
+  const trackCurrentStepCompleted = useCallback(
+    (advancedVia: 'button' | 'keyboard'): void => {
+      const durationMs = consumeStepDurationMs()
+      track('onboarding_step_completed', {
+        step: currentStep.stepNumber,
+        value_kind: currentStep.valueKind,
+        duration_ms: durationMs,
+        advanced_via: advancedVia
+      })
+      if (currentStep.id === 'integrations') {
+        trackTaskSourcesSnapshot('continue', durationMs, advancedVia)
+      }
+      if (currentStep.id === 'windows_terminal') {
+        track(
+          'onboarding_windows_terminal_snapshot',
+          buildWindowsTerminalSnapshotPayload({
+            settings,
+            exitAction: 'continue',
+            durationMs,
+            advancedVia
+          })
+        )
+      }
+    },
+    [
+      consumeStepDurationMs,
+      currentStep.id,
+      currentStep.stepNumber,
+      currentStep.valueKind,
+      settings,
+      trackTaskSourcesSnapshot
+    ]
+  )
+  const next = useCallback(
+    async (advancedVia: 'button' | 'keyboard' = 'button') => {
+      if (nextInFlightRef.current || busyLabel) {
+        return
+      }
+      nextInFlightRef.current = true
+      try {
+        const result = await persistCurrentStep()
+        if (result.ok) {
+          trackCurrentStepCompleted(advancedVia)
+          if (currentStep.id === 'notifications') {
+            setBusyLabel('Opening Add Project...')
+            const closed = await closeWith('completed', ONBOARDING_FINAL_STEP, 'add_project_modal')
+            if (closed) {
+              openModal('add-repo')
+            }
+            return
+          }
+          const nextIndex = getNextStepIndex(stepIndex)
+          const skippedThroughStepNumber = STEPS[nextIndex].stepNumber - 1
+          if (skippedThroughStepNumber > currentStep.stepNumber) {
+            // Why: skipped optional pages must still persist progress at the next visible page.
+            try {
+              onOnboardingChange(await persistStep(skippedThroughStepNumber))
+            } catch (err) {
+              toast.error(
+                translate(
+                  'auto.components.onboarding.use.onboarding.flow.52acfbef51',
+                  'Could not save progress'
+                ),
+                {
+                  description: err instanceof Error ? err.message : String(err)
+                }
+              )
+            }
+          }
+          setStepIndex(nextIndex)
+        }
+      } finally {
+        setBusyLabel(null)
+        nextInFlightRef.current = false
+      }
+    },
+    [
+      busyLabel,
+      closeWith,
+      currentStep.id,
+      currentStep.stepNumber,
+      getNextStepIndex,
+      onOnboardingChange,
+      openModal,
+      persistCurrentStep,
+      stepIndex,
+      trackCurrentStepCompleted,
+      setBusyLabel,
+      setStepIndex
+    ]
+  )
+
+  const skipToRepo = useCallback(async () => {
+    if (busyLabel) {
+      return
+    }
+    setError(null)
+    if (currentStep.id === 'notifications') {
+      return
+    }
+    const durationMs = consumeStepDurationMs()
+    const preferencesSaved = await prepareSkippedOnboardingPreferences({
+      currentStepId: currentStep.id,
+      themeBeforePreview: themeStepEntryThemeRef.current,
+      settingsTheme: settings?.theme,
+      selectedAgent,
+      setTheme,
+      applyTheme: applyDocumentTheme,
+      updateSettings,
+      setError
+    })
+    if (!preferencesSaved) {
+      return
+    }
+    const stepId = currentStep.id
+    const stepNumber = currentStep.stepNumber
+    const valueKind = currentStep.valueKind
+    setBusyLabel('Opening Add Project...')
+    try {
+      const closed = await closeWith('completed', ONBOARDING_FINAL_STEP, 'add_project_modal')
+      if (!closed) {
+        return
+      }
+      // Why: repo picker now lives in the Add Project dialog, so skipping optional setup closes onboarding and hands off to it.
+      track('onboarding_step_skipped', {
+        step: stepNumber,
+        value_kind: valueKind,
+        duration_ms: durationMs,
+        advanced_via: 'button'
+      })
+      if (stepId === 'integrations') {
+        trackTaskSourcesSnapshot('skip_to_project_setup', durationMs, 'button')
+      }
+      if (stepId === 'windows_terminal') {
+        track(
+          'onboarding_windows_terminal_snapshot',
+          buildWindowsTerminalSnapshotPayload({
+            settings,
+            exitAction: 'skip_to_project_setup',
+            durationMs,
+            advancedVia: 'button'
+          })
+        )
+      }
+      openModal('add-repo')
+    } finally {
+      setBusyLabel(null)
+    }
+  }, [
+    busyLabel,
+    closeWith,
+    consumeStepDurationMs,
+    currentStep.id,
+    currentStep.stepNumber,
+    currentStep.valueKind,
+    openModal,
+    selectedAgent,
+    settings,
+    trackTaskSourcesSnapshot,
+    updateSettings,
+    setBusyLabel,
+    setError,
+    setTheme,
+    themeStepEntryThemeRef
+  ])
+
+  const dismissOnboarding = useCallback(
+    async (advancedVia: 'button' | 'keyboard' = 'button'): Promise<boolean> => {
+      if (busyLabel) {
+        return false
+      }
+      setError(null)
+      return closeWith('dismissed', currentStep.stepNumber, undefined, {
+        durationMs: consumeStepDurationMs(),
+        advancedVia
+      })
+    },
+    [busyLabel, closeWith, consumeStepDurationMs, currentStep.stepNumber, setError]
+  )
+
+  const back = useCallback(() => {
+    setStepIndex((index) => resolveStepIndex(index - 1, skipOptions, 'backward'))
+  }, [setStepIndex, skipOptions])
+
+  const jumpToStep = useCallback(
+    (idx: number) => {
+      setStepIndex(resolveStepIndex(idx, skipOptions, idx < stepIndex ? 'backward' : 'forward'))
+    },
+    [setStepIndex, skipOptions, stepIndex]
+  )
+
+  return { next, skipToRepo, dismissOnboarding, back, jumpToStep }
+}

--- a/src/renderer/src/components/onboarding/use-onboarding-flow-telemetry.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow-telemetry.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { applyDocumentTheme } from '@/lib/document-theme'
+import { track } from '@/lib/telemetry'
+import { ONBOARDING_FINAL_STEP } from '../../../../shared/constants'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { EventProps } from '../../../../shared/telemetry-events'
+import type { AppState } from '@/store/types'
+import {
+  getGitHubTaskSourceStatus,
+  getLinearTaskSourceStatus,
+  type TaskSourcesExitAction
+} from './onboarding-flow-state'
+import type { StepNumber, STEPS } from './use-onboarding-flow-types'
+type OnboardingTelemetryArgs = {
+  remappedLastCompletedStep: number
+  currentStep: (typeof STEPS)[number]
+  persistedThemeRef: { current: GlobalSettings['theme'] }
+  preflightStatus: AppState['preflightStatus']
+  preflightStatusLoading: boolean
+  linearStatus: AppState['linearStatus']
+  linearStatusChecked: boolean
+}
+
+export function useOnboardingFlowTelemetry({
+  remappedLastCompletedStep,
+  currentStep,
+  persistedThemeRef,
+  preflightStatus,
+  preflightStatusLoading,
+  linearStatus,
+  linearStatusChecked
+}: OnboardingTelemetryArgs) {
+  const startedTrackedRef = useRef(false)
+  useEffect(() => {
+    if (startedTrackedRef.current) {
+      return
+    }
+    startedTrackedRef.current = true
+    const lastCompleted = remappedLastCompletedStep
+    track(
+      'onboarding_started',
+      lastCompleted >= 1 && lastCompleted < ONBOARDING_FINAL_STEP
+        ? { resumed_from_step: lastCompleted as StepNumber }
+        : {}
+    )
+  }, [remappedLastCompletedStep])
+
+  const stepStartedAtRef = useRef<number>(Date.now())
+  useEffect(() => {
+    stepStartedAtRef.current = Date.now()
+    track('onboarding_step_viewed', {
+      step: currentStep.stepNumber,
+      value_kind: currentStep.valueKind
+    })
+  }, [currentStep.id, currentStep.stepNumber, currentStep.valueKind])
+
+  const consumeStepDurationMs = useCallback((): number => {
+    return Math.max(0, Date.now() - stepStartedAtRef.current)
+  }, [])
+
+  const setLifecycleRootRef = useCallback(
+    (node: HTMLElement | null): void => {
+      if (node === null) {
+        applyDocumentTheme(persistedThemeRef.current)
+      }
+    },
+    [persistedThemeRef]
+  )
+
+  const trackTaskSourcesSnapshot = useCallback(
+    (
+      exitAction: TaskSourcesExitAction,
+      durationMs: number,
+      advancedVia: 'button' | 'keyboard'
+    ): void => {
+      const payload: EventProps<'onboarding_task_sources_snapshot'> = {
+        github_status: getGitHubTaskSourceStatus(preflightStatus, preflightStatusLoading),
+        linear_status: getLinearTaskSourceStatus(linearStatus, linearStatusChecked),
+        exit_action: exitAction,
+        duration_ms: durationMs,
+        advanced_via: advancedVia
+      }
+      track('onboarding_task_sources_snapshot', payload)
+    },
+    [linearStatus, linearStatusChecked, preflightStatus, preflightStatusLoading]
+  )
+
+  return { consumeStepDurationMs, setLifecycleRootRef, trackTaskSourcesSnapshot }
+}

--- a/src/renderer/src/components/onboarding/use-onboarding-flow.test.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow.test.ts
@@ -3,7 +3,7 @@ import { toast } from 'sonner'
 import {
   prepareSkippedOnboardingPreferences,
   remapOpenOnboardingLastCompletedStep
-} from './use-onboarding-flow'
+} from './onboarding-flow-state'
 import { getDefaultOnboardingState } from '../../../../shared/constants'
 
 vi.mock('sonner', () => ({

--- a/src/renderer/src/components/onboarding/use-onboarding-flow.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: single orchestrator for every onboarding-step transition; splitting would scatter ordering across hooks and lose the controller-shape contract OnboardingFlow.tsx consumes. */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { getAgentCatalog } from '@/lib/agent-catalog'
@@ -6,183 +5,27 @@ import { useAppStore } from '@/store'
 import { applyDocumentTheme } from '@/lib/document-theme'
 import { track } from '@/lib/telemetry'
 import { buildAgentPickedPayload } from './agent-picked-payload'
-import { ONBOARDING_FINAL_STEP, ONBOARDING_FLOW_VERSION } from '../../../../shared/constants'
-import type { EventProps } from '../../../../shared/telemetry-events'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { OnboardingState } from '../../../../shared/onboarding-state-types'
 import type { TuiAgent } from '../../../../shared/tui-agent'
-import { STEPS, type StepNumber } from './use-onboarding-flow-types'
+import { STEPS } from './use-onboarding-flow-types'
 import { persistStep, useCloseWith, usePersistCurrentStep } from './use-onboarding-flow-persistence'
 import { resolveOnboardingSettingsHydration } from './onboarding-settings-hydration'
 import { translate } from '@/i18n/i18n'
 import { resolveAgentPermissionModeSummary } from '../../../../shared/tui-agent-permissions'
 import { isWindowsUserAgent } from '@/components/terminal-pane/pane-helpers'
-import { buildWindowsTerminalSnapshotPayload } from './windows-terminal-onboarding-telemetry'
+import {
+  isSkippedStepIndex,
+  remapOpenOnboardingLastCompletedStep,
+  resolveStepIndex,
+  shouldSkipIntegrationsStep,
+  shouldSkipWindowsTerminalStep
+} from './onboarding-flow-state'
 
+import { useOnboardingFlowActions } from './use-onboarding-flow-actions'
+import { useOnboardingFlowTelemetry } from './use-onboarding-flow-telemetry'
 export { STEPS } from './use-onboarding-flow-types'
 export type { StepId, StepNumber } from './use-onboarding-flow-types'
-
-type TaskSourcesSnapshotProps = EventProps<'onboarding_task_sources_snapshot'>
-type TaskSourcesGithubStatus = TaskSourcesSnapshotProps['github_status']
-type TaskSourcesLinearStatus = TaskSourcesSnapshotProps['linear_status']
-type TaskSourcesExitAction = TaskSourcesSnapshotProps['exit_action']
-
-function shouldSkipIntegrationsStep(
-  status: ReturnType<typeof useAppStore.getState>['preflightStatus']
-): boolean {
-  return status?.gh.installed === true
-}
-
-function shouldSkipWindowsTerminalStep(isWindows: boolean): boolean {
-  return !isWindows
-}
-
-type OnboardingStepSkipOptions = {
-  skipIntegrations: boolean
-  skipWindowsTerminal: boolean
-}
-
-function isSkippedStepIndex(index: number, options: OnboardingStepSkipOptions): boolean {
-  const step = STEPS[index]
-  return (
-    (options.skipIntegrations && step?.id === 'integrations') ||
-    (options.skipWindowsTerminal && step?.id === 'windows_terminal')
-  )
-}
-
-function resolveStepIndex(
-  index: number,
-  skipOptions: OnboardingStepSkipOptions,
-  direction: 'forward' | 'backward'
-): number {
-  const lastIndex = STEPS.length - 1
-  let nextIndex = Math.min(Math.max(index, 0), lastIndex)
-  while (isSkippedStepIndex(nextIndex, skipOptions)) {
-    const candidate = nextIndex + (direction === 'forward' ? 1 : -1)
-    if (candidate < 0 || candidate > lastIndex) {
-      return direction === 'forward' ? lastIndex : 0
-    }
-    nextIndex = candidate
-  }
-  return nextIndex
-}
-
-function getGitHubTaskSourceStatus(
-  status: ReturnType<typeof useAppStore.getState>['preflightStatus'],
-  loading: boolean
-): TaskSourcesGithubStatus {
-  if (loading || !status) {
-    return 'checking'
-  }
-  if (!status.gh.installed) {
-    return 'not_installed'
-  }
-  return status.gh.authenticated ? 'connected' : 'not_authenticated'
-}
-
-function getLinearTaskSourceStatus(
-  status: ReturnType<typeof useAppStore.getState>['linearStatus'],
-  checked: boolean
-): TaskSourcesLinearStatus {
-  if (status.connected) {
-    return 'connected'
-  }
-  return checked ? 'not_connected' : 'checking'
-}
-
-type OnboardingStepId = (typeof STEPS)[number]['id']
-
-type OnboardingProgressSnapshot = Pick<
-  OnboardingState,
-  'flowVersion' | 'lastCompletedStep' | 'outcome'
->
-
-export function remapOpenOnboardingLastCompletedStep({
-  flowVersion,
-  lastCompletedStep,
-  outcome
-}: OnboardingProgressSnapshot): number {
-  if (flowVersion === ONBOARDING_FLOW_VERSION) {
-    return lastCompletedStep
-  }
-  if (outcome === 'completed' && lastCompletedStep >= 4) {
-    return ONBOARDING_FINAL_STEP
-  }
-  // Why: in v3 (four-step, pre-Windows-terminal) step 4 already meant notifications, so resume there.
-  if (flowVersion === 3) {
-    return Math.min(4, lastCompletedStep)
-  }
-  // Why: v2 (five-step) and older seven-step data used step 4 for removed agent setup, not integrations.
-  if (flowVersion === 2) {
-    if (lastCompletedStep === 3) {
-      return 2
-    }
-    if (lastCompletedStep >= 4) {
-      return 3
-    }
-    return lastCompletedStep
-  }
-  if (lastCompletedStep === 3) {
-    return 2
-  }
-  if (lastCompletedStep === 4) {
-    return 2
-  }
-  if (lastCompletedStep >= 5) {
-    return 3
-  }
-  return lastCompletedStep
-}
-
-type SkippedOnboardingPreferenceOptions = {
-  currentStepId: OnboardingStepId
-  themeBeforePreview: GlobalSettings['theme'] | null
-  settingsTheme: GlobalSettings['theme'] | undefined
-  selectedAgent: TuiAgent | null
-  setTheme: (theme: GlobalSettings['theme']) => void
-  applyTheme: (theme: GlobalSettings['theme']) => void
-  updateSettings: (updates: Partial<GlobalSettings>) => Promise<void> | void
-  setError: (message: string | null) => void
-}
-
-export async function prepareSkippedOnboardingPreferences({
-  currentStepId,
-  themeBeforePreview,
-  settingsTheme,
-  selectedAgent,
-  setTheme,
-  applyTheme,
-  updateSettings,
-  setError
-}: SkippedOnboardingPreferenceOptions): Promise<boolean> {
-  try {
-    // Why: theme tiles save immediately for a stable preview, but skip must not keep this step's choice.
-    if (currentStepId === 'theme') {
-      const themeToRestore = themeBeforePreview ?? settingsTheme
-      if (themeToRestore) {
-        setTheme(themeToRestore)
-        applyTheme(themeToRestore)
-        await updateSettings({ theme: themeToRestore })
-      }
-    }
-    // Why: skipping bypasses step persistence, so save the visible agent choice before closing.
-    if (currentStepId === 'agent' && selectedAgent) {
-      await updateSettings({ defaultTuiAgent: selectedAgent })
-    }
-    return true
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    setError(message)
-    toast.error(
-      translate(
-        'auto.components.onboarding.use.onboarding.flow.52acfbef51',
-        'Could not save progress'
-      ),
-      { description: message }
-    )
-    return false
-  }
-}
 
 export function useOnboardingFlow(
   onboarding: OnboardingState,
@@ -365,11 +208,6 @@ export function useOnboardingFlow(
     [skipOptions]
   )
 
-  const getPreviousStepIndex = useCallback(
-    (idx: number): number => resolveStepIndex(idx - 1, skipOptions, 'backward'),
-    [skipOptions]
-  )
-
   useEffect(() => {
     if (currentStep.id !== 'integrations' || !preflightStatusChecked || !skipIntegrations) {
       return
@@ -402,63 +240,16 @@ export function useOnboardingFlow(
     stepIndex
   ])
 
-  // Why: ref guard stops StrictMode's double-invoke from emitting onboarding_started twice.
-  const startedTrackedRef = useRef(false)
-  useEffect(() => {
-    if (startedTrackedRef.current) {
-      return
-    }
-    startedTrackedRef.current = true
-    // Why: resumed_from_step is the step the user finished, not the one we resume into.
-    const lastCompleted = remappedLastCompletedStep
-    track(
-      'onboarding_started',
-      lastCompleted >= 1 && lastCompleted < ONBOARDING_FINAL_STEP
-        ? { resumed_from_step: lastCompleted as StepNumber }
-        : {}
-    )
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  // Why: re-pinned per step view so duration_ms measures only post-resume time; optional so a missing baseline drops the field, not the event. See docs/onboarding-telemetry-extensions.md.
-  const stepStartedAtRef = useRef<number>(Date.now())
-  useEffect(() => {
-    stepStartedAtRef.current = Date.now()
-    track('onboarding_step_viewed', {
-      step: currentStep.stepNumber,
-      value_kind: currentStep.valueKind
+  const { consumeStepDurationMs, setLifecycleRootRef, trackTaskSourcesSnapshot } =
+    useOnboardingFlowTelemetry({
+      remappedLastCompletedStep,
+      currentStep,
+      persistedThemeRef,
+      preflightStatus,
+      preflightStatusLoading,
+      linearStatus,
+      linearStatusChecked
     })
-  }, [currentStep.id, currentStep.stepNumber, currentStep.valueKind])
-
-  const consumeStepDurationMs = useCallback((): number => {
-    return Math.max(0, Date.now() - stepStartedAtRef.current)
-  }, [])
-
-  const setLifecycleRootRef = useCallback((node: HTMLElement | null): void => {
-    if (node !== null) {
-      return
-    }
-    // Why: theme preview mutates state outside this component, so revert on modal-root detach rather than a passive Effect.
-    applyDocumentTheme(persistedThemeRef.current)
-  }, [])
-
-  const trackTaskSourcesSnapshot = useCallback(
-    (
-      exitAction: TaskSourcesExitAction,
-      durationMs: number,
-      advancedVia: 'button' | 'keyboard'
-    ): void => {
-      // Why: one low-cardinality snapshot captures task-source usability at step exit without per-button telemetry.
-      track('onboarding_task_sources_snapshot', {
-        github_status: getGitHubTaskSourceStatus(preflightStatus, preflightStatusLoading),
-        linear_status: getLinearTaskSourceStatus(linearStatus, linearStatusChecked),
-        exit_action: exitAction,
-        duration_ms: durationMs,
-        advanced_via: advancedVia
-      })
-    },
-    [linearStatus, linearStatusChecked, preflightStatus, preflightStatusLoading]
-  )
 
   // Why: auto-pick only on first mount; otherwise re-running would clobber/race the user's own agent selection.
   const didAutoSelectRef = useRef(false)
@@ -495,192 +286,27 @@ export function useOnboardingFlow(
     setError
   })
 
-  // Why: sync latch; busyLabel state commits too late to stop a ~30ms Cmd+Enter auto-repeat from re-entering next() and skipping a step.
-  const nextInFlightRef = useRef(false)
-  const trackCurrentStepCompleted = useCallback(
-    (advancedVia: 'button' | 'keyboard'): void => {
-      const durationMs = consumeStepDurationMs()
-      track('onboarding_step_completed', {
-        step: currentStep.stepNumber,
-        value_kind: currentStep.valueKind,
-        duration_ms: durationMs,
-        advanced_via: advancedVia
-      })
-      if (currentStep.id === 'integrations') {
-        trackTaskSourcesSnapshot('continue', durationMs, advancedVia)
-      }
-      if (currentStep.id === 'windows_terminal') {
-        track(
-          'onboarding_windows_terminal_snapshot',
-          buildWindowsTerminalSnapshotPayload({
-            settings,
-            exitAction: 'continue',
-            durationMs,
-            advancedVia
-          })
-        )
-      }
-    },
-    [
-      consumeStepDurationMs,
-      currentStep.id,
-      currentStep.stepNumber,
-      currentStep.valueKind,
-      settings,
-      trackTaskSourcesSnapshot
-    ]
-  )
-  const next = useCallback(
-    async (advancedVia: 'button' | 'keyboard' = 'button') => {
-      if (nextInFlightRef.current || busyLabel) {
-        return
-      }
-      nextInFlightRef.current = true
-      try {
-        const result = await persistCurrentStep()
-        if (result.ok) {
-          trackCurrentStepCompleted(advancedVia)
-          if (currentStep.id === 'notifications') {
-            setBusyLabel('Opening Add Project...')
-            const closed = await closeWith('completed', ONBOARDING_FINAL_STEP, 'add_project_modal')
-            if (closed) {
-              openModal('add-repo')
-            }
-            return
-          }
-          const nextIndex = getNextStepIndex(stepIndex)
-          const skippedThroughStepNumber = STEPS[nextIndex].stepNumber - 1
-          if (skippedThroughStepNumber > currentStep.stepNumber) {
-            // Why: skipped optional pages must still persist progress at the next visible page.
-            try {
-              onOnboardingChange(await persistStep(skippedThroughStepNumber))
-            } catch (err) {
-              toast.error(
-                translate(
-                  'auto.components.onboarding.use.onboarding.flow.52acfbef51',
-                  'Could not save progress'
-                ),
-                {
-                  description: err instanceof Error ? err.message : String(err)
-                }
-              )
-            }
-          }
-          setStepIndex(nextIndex)
-        }
-      } finally {
-        setBusyLabel(null)
-        nextInFlightRef.current = false
-      }
-    },
-    [
-      busyLabel,
-      closeWith,
-      currentStep.id,
-      currentStep.stepNumber,
-      getNextStepIndex,
-      onOnboardingChange,
-      openModal,
-      persistCurrentStep,
-      stepIndex,
-      trackCurrentStepCompleted
-    ]
-  )
-
-  const skipToRepo = useCallback(async () => {
-    if (busyLabel) {
-      return
-    }
-    setError(null)
-    if (currentStep.id === 'notifications') {
-      return
-    }
-    const durationMs = consumeStepDurationMs()
-    const preferencesSaved = await prepareSkippedOnboardingPreferences({
-      currentStepId: currentStep.id,
-      themeBeforePreview: themeStepEntryThemeRef.current,
-      settingsTheme: settings?.theme,
-      selectedAgent,
-      setTheme,
-      applyTheme: applyDocumentTheme,
-      updateSettings,
-      setError
-    })
-    if (!preferencesSaved) {
-      return
-    }
-    const stepId = currentStep.id
-    const stepNumber = currentStep.stepNumber
-    const valueKind = currentStep.valueKind
-    setBusyLabel('Opening Add Project...')
-    try {
-      const closed = await closeWith('completed', ONBOARDING_FINAL_STEP, 'add_project_modal')
-      if (!closed) {
-        return
-      }
-      // Why: repo picker now lives in the Add Project dialog, so skipping optional setup closes onboarding and hands off to it.
-      track('onboarding_step_skipped', {
-        step: stepNumber,
-        value_kind: valueKind,
-        duration_ms: durationMs,
-        advanced_via: 'button'
-      })
-      if (stepId === 'integrations') {
-        trackTaskSourcesSnapshot('skip_to_project_setup', durationMs, 'button')
-      }
-      if (stepId === 'windows_terminal') {
-        track(
-          'onboarding_windows_terminal_snapshot',
-          buildWindowsTerminalSnapshotPayload({
-            settings,
-            exitAction: 'skip_to_project_setup',
-            durationMs,
-            advancedVia: 'button'
-          })
-        )
-      }
-      openModal('add-repo')
-    } finally {
-      setBusyLabel(null)
-    }
-  }, [
+  const { next, skipToRepo, dismissOnboarding, back, jumpToStep } = useOnboardingFlowActions({
     busyLabel,
-    closeWith,
+    setBusyLabel,
+    setError,
+    currentStep,
     consumeStepDurationMs,
-    currentStep.id,
-    currentStep.stepNumber,
-    currentStep.valueKind,
-    openModal,
-    selectedAgent,
-    settings,
     trackTaskSourcesSnapshot,
-    updateSettings
-  ])
-
-  const dismissOnboarding = useCallback(
-    async (advancedVia: 'button' | 'keyboard' = 'button'): Promise<boolean> => {
-      if (busyLabel) {
-        return false
-      }
-      setError(null)
-      return closeWith('dismissed', currentStep.stepNumber, undefined, {
-        durationMs: consumeStepDurationMs(),
-        advancedVia
-      })
-    },
-    [busyLabel, closeWith, consumeStepDurationMs, currentStep.stepNumber]
-  )
-
-  const back = useCallback(() => {
-    setStepIndex(getPreviousStepIndex)
-  }, [getPreviousStepIndex])
-
-  const jumpToStep = useCallback(
-    (idx: number) => {
-      setStepIndex(resolveStepIndex(idx, skipOptions, idx < stepIndex ? 'backward' : 'forward'))
-    },
-    [skipOptions, stepIndex]
-  )
+    settings,
+    persistCurrentStep,
+    closeWith,
+    openModal,
+    getNextStepIndex,
+    onOnboardingChange,
+    stepIndex,
+    setStepIndex,
+    selectedAgent,
+    themeStepEntryThemeRef,
+    setTheme,
+    updateSettings,
+    skipOptions
+  })
 
   return {
     settings,


### PR DESCRIPTION
## Summary
- separate onboarding progression rules and persistence preparation from the React controller
- isolate telemetry timing/snapshots and navigation actions into focused hooks
- preserve the controller shape consumed by `OnboardingFlow`
- remove the onboarding flow max-lines bypass

Stacked on #16770.

## Verification
- `pnpm tc`
- targeted Oxlint across all onboarding modules
- 29 onboarding controller, persistence, and rendered-flow tests
- `pnpm check:max-lines-ratchet`