### PR TITLE
Extract terminal output scheduler subsystems

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-cursor-sequencing.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-cursor-sequencing.ts
@@ -1,0 +1,168 @@
+type CursorQueueEntry = {
+  chunks: { data: string }[]
+  chunkIndex: number
+}
+
+export const SYNC_FOREGROUND_FLUSH_CHARS = 256 * 1024
+const CURSOR_SHOW_SEQUENCE = '\x1b[?25h'
+const CURSOR_HIDE_SEQUENCE = '\x1b[?25l'
+const SYNCHRONIZED_OUTPUT_END_SEQUENCE = '\x1b[?2026l'
+
+function findCursorPositionSequenceEnd(
+  data: string,
+  fromIndex: number,
+  toIndex = data.length
+): number {
+  let offset = data.indexOf('\x1b[', fromIndex)
+  while (offset !== -1 && offset < toIndex) {
+    let index = offset + 2
+    while (index < toIndex) {
+      const char = data[index]
+      if (char === 'G' || char === 'H' || char === 'f') {
+        return index + 1
+      }
+      if ((char < '0' || char > '9') && char !== ';') {
+        break
+      }
+      index += 1
+    }
+    offset = data.indexOf('\x1b[', offset + 2)
+  }
+  return -1
+}
+
+export function removeTransientCursorShowSequences(data: string): string {
+  let result = ''
+  let offset = 0
+  let showIndex = data.indexOf(CURSOR_SHOW_SEQUENCE)
+  while (showIndex !== -1) {
+    const nextHideIndex = data.indexOf(
+      CURSOR_HIDE_SEQUENCE,
+      showIndex + CURSOR_SHOW_SEQUENCE.length
+    )
+    const nextPositionEnd = findCursorPositionSequenceEnd(
+      data,
+      showIndex + CURSOR_SHOW_SEQUENCE.length,
+      nextHideIndex === -1 ? data.length : nextHideIndex
+    )
+    if (nextHideIndex === -1) {
+      if (nextPositionEnd === -1) {
+        const synchronizedEndIndex = data.indexOf(
+          SYNCHRONIZED_OUTPUT_END_SEQUENCE,
+          showIndex + CURSOR_SHOW_SEQUENCE.length
+        )
+        if (synchronizedEndIndex === -1) {
+          break
+        }
+        // Why: keep the cursor hidden through the synchronized repaint, restoring it after the frame ends so Windows never paints it in the transient draw position.
+        result += data.slice(offset, showIndex)
+        result += data.slice(
+          showIndex + CURSOR_SHOW_SEQUENCE.length,
+          synchronizedEndIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length
+        )
+        result += CURSOR_SHOW_SEQUENCE
+        offset = synchronizedEndIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length
+        showIndex = data.indexOf(CURSOR_SHOW_SEQUENCE, offset)
+        continue
+      }
+      // Why: Codex can show the cursor before its final synchronized-frame placement. Place first so xterm cannot rasterize the stale cell.
+      result += data.slice(offset, showIndex)
+      result += data.slice(showIndex + CURSOR_SHOW_SEQUENCE.length, nextPositionEnd)
+      result += CURSOR_SHOW_SEQUENCE
+      offset = nextPositionEnd
+      showIndex = data.indexOf(CURSOR_SHOW_SEQUENCE, offset)
+      continue
+    }
+    result += data.slice(offset, showIndex)
+    offset = showIndex + CURSOR_SHOW_SEQUENCE.length
+    showIndex = data.indexOf(CURSOR_SHOW_SEQUENCE, offset)
+  }
+  return offset === 0 ? data : result + data.slice(offset)
+}
+
+function containsCursorPositionSequence(data: string): boolean {
+  let offset = data.indexOf('\x1b[')
+  while (offset !== -1) {
+    let index = offset + 2
+    while (index < data.length) {
+      const char = data[index]
+      if (char === 'G' || char === 'H' || char === 'f') {
+        return true
+      }
+      if ((char < '0' || char > '9') && char !== ';') {
+        break
+      }
+      index += 1
+    }
+    offset = data.indexOf('\x1b[', offset + 2)
+  }
+  return false
+}
+
+function containsCursorRestore(data: string): boolean {
+  const hideIndex = data.indexOf(CURSOR_HIDE_SEQUENCE)
+  const showIndex = data.lastIndexOf(CURSOR_SHOW_SEQUENCE)
+  return hideIndex !== -1 && showIndex > hideIndex && containsCursorPositionSequence(data)
+}
+
+export function containsDrainableCursorRestore(data: string): boolean {
+  const synchronizedEndIndex = data.lastIndexOf(SYNCHRONIZED_OUTPUT_END_SEQUENCE)
+  if (synchronizedEndIndex === -1) {
+    return containsCursorRestore(data)
+  }
+  return containsCursorRestore(
+    data.slice(synchronizedEndIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length)
+  )
+}
+
+export function containsFinalCursorPlacementBeforeSynchronizedEnd(data: string): boolean {
+  const synchronizedEndIndex = data.lastIndexOf(SYNCHRONIZED_OUTPUT_END_SEQUENCE)
+  if (synchronizedEndIndex === -1) {
+    return false
+  }
+  const lastShowIndex = data.lastIndexOf(CURSOR_SHOW_SEQUENCE, synchronizedEndIndex)
+  if (lastShowIndex === -1) {
+    return false
+  }
+  const lastHideIndex = data.lastIndexOf(CURSOR_HIDE_SEQUENCE, synchronizedEndIndex)
+  if (lastHideIndex > lastShowIndex) {
+    return false
+  }
+  return (
+    findCursorPositionSequenceEnd(
+      data,
+      lastShowIndex + CURSOR_SHOW_SEQUENCE.length,
+      synchronizedEndIndex
+    ) !== -1
+  )
+}
+
+function previewQueuedData(entry: CursorQueueEntry, limit: number): string {
+  let data = ''
+  for (let index = entry.chunkIndex; index < entry.chunks.length; index += 1) {
+    const chunk = entry.chunks[index]
+    const remaining = limit - data.length
+    if (remaining <= 0) {
+      break
+    }
+    data += chunk.data.slice(0, remaining)
+  }
+  return data
+}
+
+export function coalescedQueuedDataNeedsCursorRestore(entry: CursorQueueEntry): boolean {
+  const data = previewQueuedData(entry, SYNC_FOREGROUND_FLUSH_CHARS)
+  const synchronizedEndIndex = data.lastIndexOf(SYNCHRONIZED_OUTPUT_END_SEQUENCE)
+  if (synchronizedEndIndex === -1) {
+    return false
+  }
+  const synchronizedFrame = data.slice(
+    0,
+    synchronizedEndIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length
+  )
+  return (
+    containsCursorRestore(synchronizedFrame) &&
+    !containsFinalCursorPlacementBeforeSynchronizedEnd(synchronizedFrame) &&
+    !containsDrainableCursorRestore(data)
+  )
+}

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-queue-chunks.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-queue-chunks.ts
@@ -1,0 +1,181 @@
+import { flattenRetainedSlice } from '@/lib/flatten-retained-slice'
+import type {
+  QueueEntry,
+  QueuedWrite,
+  TerminalOutputBeforeWrite,
+  TerminalOutputParsedCallback
+} from './pane-terminal-output-scheduler'
+import { recordTerminalOutputQueueDebugPressure as recordQueueDebugPressure } from './pane-terminal-output-scheduler-debug'
+
+type ForegroundRefreshSyncResolver = () => boolean
+const ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY = (): boolean => true
+
+export function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
+  let remaining = limit
+  let data = ''
+  let foreground: boolean | null = null
+  let forceForegroundRefresh = false
+  let followupForegroundRefresh = false
+  let shouldRefreshForegroundSynchronously: ForegroundRefreshSyncResolver | null = null
+  let additionalRefreshSyncResolvers: ForegroundRefreshSyncResolver[] | null = null
+  let stripTransientCursorShows = false
+  let beforeWrite: TerminalOutputBeforeWrite | undefined
+  let additionalBeforeWriteCallbacks: TerminalOutputBeforeWrite[] | null = null
+  const parsedCallbacks: TerminalOutputParsedCallback[] = []
+  const ackCredits: (() => void)[] = []
+
+  while (remaining > 0 && entry.chunkIndex < entry.chunks.length) {
+    const chunk = entry.chunks[entry.chunkIndex]
+    if (foreground !== null && chunk.foreground !== foreground) {
+      break
+    }
+    foreground ??= chunk.foreground
+    forceForegroundRefresh ||= chunk.forceForegroundRefresh
+    followupForegroundRefresh ||= chunk.followupForegroundRefresh
+    // Why: one drained write can combine chunks from different renderer states or producers; preserve every forced policy and prep hook.
+    if (chunk.forceForegroundRefresh) {
+      if (shouldRefreshForegroundSynchronously === null) {
+        shouldRefreshForegroundSynchronously = chunk.shouldRefreshForegroundSynchronously
+      } else if (
+        chunk.shouldRefreshForegroundSynchronously !== shouldRefreshForegroundSynchronously &&
+        !additionalRefreshSyncResolvers?.includes(chunk.shouldRefreshForegroundSynchronously)
+      ) {
+        additionalRefreshSyncResolvers ??= []
+        additionalRefreshSyncResolvers.push(chunk.shouldRefreshForegroundSynchronously)
+      }
+    }
+    stripTransientCursorShows ||= chunk.stripTransientCursorShows
+    if (!beforeWrite) {
+      beforeWrite = chunk.beforeWrite
+    } else if (
+      chunk.beforeWrite &&
+      chunk.beforeWrite !== beforeWrite &&
+      !additionalBeforeWriteCallbacks?.includes(chunk.beforeWrite)
+    ) {
+      additionalBeforeWriteCallbacks ??= []
+      additionalBeforeWriteCallbacks.push(chunk.beforeWrite)
+    }
+    if (chunk.data.length <= remaining) {
+      data += chunk.data
+      remaining -= chunk.data.length
+      entry.queuedChars -= chunk.data.length
+      // Clear drained slots before the 64-chunk compaction can release them.
+      entry.chunks[entry.chunkIndex] = {
+        data: '',
+        retainedChars: 0,
+        foreground: chunk.foreground,
+        forceForegroundRefresh: false,
+        followupForegroundRefresh: false,
+        shouldRefreshForegroundSynchronously: ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY,
+        stripTransientCursorShows: false
+      }
+      entry.chunkIndex += 1
+      if (chunk.onParsed) {
+        parsedCallbacks.push(chunk.onParsed)
+      }
+      if (chunk.ackCredit) {
+        ackCredits.push(chunk.ackCredit)
+      }
+      continue
+    }
+
+    data += chunk.data.slice(0, remaining)
+    const residual = chunk.data.slice(remaining)
+    // Geometric flattening bounds retained parents while keeping total copy work linear.
+    const flatten = residual.length * 2 <= chunk.retainedChars
+    entry.chunks[entry.chunkIndex] = {
+      ...chunk,
+      data: flatten ? flattenRetainedSlice(residual) : residual,
+      retainedChars: flatten ? residual.length : chunk.retainedChars
+    }
+    entry.queuedChars -= remaining
+    remaining = 0
+  }
+
+  compactConsumedChunks(entry)
+  if (entry.queuedChars < 0) {
+    entry.queuedChars = 0
+  }
+  recordQueueDebugPressure()
+  return data
+    ? {
+        data,
+        foreground: foreground === true,
+        forceForegroundRefresh,
+        followupForegroundRefresh,
+        shouldRefreshForegroundSynchronously:
+          additionalRefreshSyncResolvers && shouldRefreshForegroundSynchronously
+            ? () =>
+                shouldRefreshForegroundSynchronously() ||
+                additionalRefreshSyncResolvers.some((resolve) => resolve())
+            : (shouldRefreshForegroundSynchronously ?? ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY),
+        stripTransientCursorShows,
+        beforeWrite:
+          additionalBeforeWriteCallbacks && beforeWrite
+            ? (queuedData) => {
+                beforeWrite(queuedData)
+                for (const callback of additionalBeforeWriteCallbacks) {
+                  callback(queuedData)
+                }
+              }
+            : beforeWrite,
+        onParsed:
+          parsedCallbacks.length > 0
+            ? () => {
+                for (const callback of parsedCallbacks) {
+                  callback()
+                }
+              }
+            : undefined,
+        ackCredits
+      }
+    : null
+}
+
+export function compactConsumedChunks(entry: QueueEntry): void {
+  if (entry.chunkIndex === 0) {
+    return
+  }
+  if (entry.chunkIndex === entry.chunks.length) {
+    entry.chunks.length = 0
+    entry.chunkIndex = 0
+    return
+  }
+  if (entry.chunkIndex >= 64) {
+    entry.chunks.splice(0, entry.chunkIndex)
+    entry.chunkIndex = 0
+  }
+}
+
+export function enqueueChunk(
+  entry: QueueEntry,
+  data: string,
+  options?: {
+    foreground?: boolean
+    forceForegroundRefresh?: boolean
+    followupForegroundRefresh?: boolean
+    shouldRefreshForegroundSynchronously?: ForegroundRefreshSyncResolver
+    stripTransientCursorShows?: boolean
+    beforeWrite?: TerminalOutputBeforeWrite
+    onParsed?: TerminalOutputParsedCallback
+    ackCredit?: () => void
+  }
+): void {
+  // Own queued data so producer slices cannot pin larger PTY or restore buffers.
+  const owned = flattenRetainedSlice(data)
+  entry.chunks.push({
+    data: owned,
+    retainedChars: owned.length,
+    foreground: options?.foreground === true,
+    forceForegroundRefresh: options?.forceForegroundRefresh === true,
+    followupForegroundRefresh: options?.followupForegroundRefresh === true,
+    shouldRefreshForegroundSynchronously:
+      options?.shouldRefreshForegroundSynchronously ?? ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY,
+    stripTransientCursorShows: options?.stripTransientCursorShows === true,
+    beforeWrite: options?.beforeWrite,
+    onParsed: options?.onParsed,
+    ackCredit: options?.ackCredit
+  })
+  entry.queuedChars += data.length
+  recordQueueDebugPressure()
+}

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-debug.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-debug.ts
@@ -1,0 +1,110 @@
+import { e2eConfig } from '@/lib/e2e-config'
+
+type QueueDebugEntry = { queuedChars: number }
+
+// Why the cap is lossy: a backgrounded Chromium document throttles timers while PTYs keep writing, so unbounded hidden scrollback would grow renderer memory until the app crashes.
+type TerminalOutputSchedulerDebugSnapshot = {
+  backgroundEnqueueCount: number
+  deferredForegroundEnqueueCount: number
+  foregroundWriteCount: number
+  backgroundWriteCount: number
+  deferredForegroundWriteCount: number
+  flushWriteCount: number
+  scheduledDrainCount: number
+  queuedTerminalCount: number
+  queuedChars: number
+  peakQueuedTerminalCount: number
+  peakQueuedChars: number
+  peakQueuedCharsByTerminal: number
+  droppedBacklogCount: number
+  drainWrites: number[]
+  drainHighPriority: boolean[]
+}
+
+export const terminalOutputSchedulerDebugEnabled = e2eConfig.exposeStore
+export const terminalOutputSchedulerDebugState: TerminalOutputSchedulerDebugSnapshot = {
+  backgroundEnqueueCount: 0,
+  deferredForegroundEnqueueCount: 0,
+  foregroundWriteCount: 0,
+  backgroundWriteCount: 0,
+  deferredForegroundWriteCount: 0,
+  flushWriteCount: 0,
+  scheduledDrainCount: 0,
+  queuedTerminalCount: 0,
+  queuedChars: 0,
+  peakQueuedTerminalCount: 0,
+  peakQueuedChars: 0,
+  peakQueuedCharsByTerminal: 0,
+  droppedBacklogCount: 0,
+  drainWrites: [],
+  drainHighPriority: []
+}
+
+let readQueueEntries: () => Iterable<QueueDebugEntry> = () => []
+
+export function setTerminalOutputDebugQueueReader(reader: () => Iterable<QueueDebugEntry>): void {
+  readQueueEntries = reader
+}
+
+function resetDebugState(): void {
+  const state = terminalOutputSchedulerDebugState
+  state.backgroundEnqueueCount = 0
+  state.deferredForegroundEnqueueCount = 0
+  state.foregroundWriteCount = 0
+  state.backgroundWriteCount = 0
+  state.deferredForegroundWriteCount = 0
+  state.flushWriteCount = 0
+  state.scheduledDrainCount = 0
+  state.queuedTerminalCount = 0
+  state.queuedChars = 0
+  state.peakQueuedTerminalCount = 0
+  state.peakQueuedChars = 0
+  state.peakQueuedCharsByTerminal = 0
+  state.droppedBacklogCount = 0
+  state.drainWrites = []
+  state.drainHighPriority = []
+}
+
+export function recordTerminalOutputQueueDebugPressure(): void {
+  if (!terminalOutputSchedulerDebugEnabled) {
+    return
+  }
+  let queuedTerminalCount = 0
+  let queuedChars = 0
+  let queuedCharsByTerminal = 0
+  for (const entry of readQueueEntries()) {
+    queuedTerminalCount++
+    queuedChars += entry.queuedChars
+    queuedCharsByTerminal = Math.max(queuedCharsByTerminal, entry.queuedChars)
+  }
+  const state = terminalOutputSchedulerDebugState
+  state.queuedTerminalCount = queuedTerminalCount
+  state.queuedChars = queuedChars
+  state.peakQueuedTerminalCount = Math.max(state.peakQueuedTerminalCount, queuedTerminalCount)
+  state.peakQueuedChars = Math.max(state.peakQueuedChars, queuedChars)
+  state.peakQueuedCharsByTerminal = Math.max(state.peakQueuedCharsByTerminal, queuedCharsByTerminal)
+}
+
+export function exposeTerminalOutputSchedulerDebugApi(): void {
+  if (!terminalOutputSchedulerDebugEnabled || typeof window === 'undefined') {
+    return
+  }
+  // Why: the e2e repro must prove background output used the shared drain, but production must not accumulate diagnostic counters indefinitely.
+  const target = window as unknown as {
+    __terminalOutputSchedulerDebug?: {
+      reset: () => void
+      snapshot: () => TerminalOutputSchedulerDebugSnapshot
+    }
+  }
+  target.__terminalOutputSchedulerDebug ??= {
+    reset: resetDebugState,
+    snapshot: () => {
+      recordTerminalOutputQueueDebugPressure()
+      return {
+        ...terminalOutputSchedulerDebugState,
+        drainWrites: [...terminalOutputSchedulerDebugState.drainWrites],
+        drainHighPriority: [...terminalOutputSchedulerDebugState.drainHighPriority]
+      }
+    }
+  }
+}

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -1,5 +1,4 @@
 /* oxlint-disable max-lines -- Why: output ordering, foreground settle, queue state, and e2e diagnostics form one state machine; splitting it would make backlog/resume guarantees harder to audit. */
-import { e2eConfig } from '@/lib/e2e-config'
 import {
   discardForegroundRenderSettle,
   writeForegroundTerminalChunk,
@@ -7,7 +6,6 @@ import {
 } from './pane-terminal-foreground-render-settle'
 import { runGuardedWriteCompletionStep } from './xterm-write-callback-guard'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
-import { flattenRetainedSlice } from '@/lib/flatten-retained-slice'
 import {
   discardInFlightTerminalOutputAckCredits,
   registerTerminalOutputAckCredits
@@ -24,12 +22,26 @@ import {
   TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS,
   terminalOutputBacklogCapChars
 } from '../../../../shared/terminal-scrollback-policy'
+import {
+  coalescedQueuedDataNeedsCursorRestore,
+  containsDrainableCursorRestore,
+  removeTransientCursorShowSequences,
+  SYNC_FOREGROUND_FLUSH_CHARS
+} from './pane-terminal-cursor-sequencing'
+import {
+  exposeTerminalOutputSchedulerDebugApi as exposeDebugApi,
+  recordTerminalOutputQueueDebugPressure as recordQueueDebugPressure,
+  setTerminalOutputDebugQueueReader,
+  terminalOutputSchedulerDebugEnabled as debugEnabled,
+  terminalOutputSchedulerDebugState as debugState
+} from './pane-terminal-output-scheduler-debug'
+import { enqueueChunk, takeQueuedChunk } from './pane-terminal-output-queue-chunks'
 
 type TerminalOutputTarget = ForegroundTerminalOutputTarget
 
-type TerminalOutputBeforeWrite = (data: string) => void
+export type TerminalOutputBeforeWrite = (data: string) => void
 type TerminalBacklogRecoveryRequest = () => boolean
-type TerminalOutputParsedCallback = () => void
+export type TerminalOutputParsedCallback = () => void
 type ForegroundRefreshSyncResolver = () => boolean
 
 type WriteTerminalOutputOptions = {
@@ -62,7 +74,7 @@ type QueueChunk = {
   ackCredit?: () => void
 }
 
-type QueuedWrite = {
+export type QueuedWrite = {
   data: string
   foreground: boolean
   forceForegroundRefresh: boolean
@@ -74,7 +86,7 @@ type QueuedWrite = {
   ackCredits: (() => void)[]
 }
 
-type QueueEntry = {
+export type QueueEntry = {
   terminal: TerminalOutputTarget
   chunks: QueueChunk[]
   chunkIndex: number
@@ -103,7 +115,6 @@ const MAX_WRITES_PER_DRAIN = 2
 const HIGH_PRIORITY_MAX_WRITES_PER_DRAIN = 8
 const DRAIN_TIME_BUDGET_MS = 8
 const LARGE_BACKLOG_CHARS = 512 * 1024
-const SYNC_FOREGROUND_FLUSH_CHARS = 256 * 1024
 // Why mutable: the cap scales with the user's scrollback setting (terminalOutputBacklogCapChars), configured when settings apply; the chunk-count cap stays fixed.
 let maxQueueChars = TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS
 const MAX_BACKGROUND_QUEUE_CHUNKS = 4096
@@ -117,9 +128,6 @@ const FOREGROUND_HOLD_SAFETY_DELAY_MS = 250
 // Why: key repeat can tick every 30-50ms; one frame catches split restores without batching multiple typed-character redraws behind the fallback.
 const LATENCY_SENSITIVE_FOREGROUND_COALESCE_DELAY_MS = 16
 const LATENCY_SENSITIVE_FOREGROUND_HOLD_SAFETY_DELAY_MS = 32
-const CURSOR_SHOW_SEQUENCE = '\x1b[?25h'
-const CURSOR_HIDE_SEQUENCE = '\x1b[?25l'
-const SYNCHRONIZED_OUTPUT_END_SEQUENCE = '\x1b[?2026l'
 // Why: leading CAN aborts any partial escape sequence before the style reset so the backlog warning renders cleanly.
 const BACKGROUND_BACKLOG_WARNING =
   '\x18\x1b[0m\r\n[Orca skipped hidden terminal output because the backlog grew too large.]\r\n'
@@ -129,6 +137,7 @@ const FOREGROUND_BACKLOG_WARNING =
 const ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY = (): boolean => true
 
 const queuedByTerminal = new Map<TerminalOutputTarget, QueueEntry>()
+setTerminalOutputDebugQueueReader(() => queuedByTerminal.values())
 const backlogRecoveryByTerminal = new WeakMap<
   TerminalOutputTarget,
   TerminalBacklogRecoveryRequest
@@ -168,125 +177,6 @@ function cancelImmediateDrain(): void {
 export function setUseMessageChannelDrainForTesting(value: boolean | null): void {
   cancelImmediateDrain()
   useMessageChannelDrain = value ?? (typeof MessageChannel !== 'undefined' && !isVitestEnv())
-}
-const debugEnabled = e2eConfig.exposeStore
-
-// Why the cap is lossy: a backgrounded Chromium document throttles timers while PTYs keep writing, so unbounded hidden scrollback would grow renderer memory until the app crashes.
-
-type TerminalOutputSchedulerDebugSnapshot = {
-  backgroundEnqueueCount: number
-  deferredForegroundEnqueueCount: number
-  foregroundWriteCount: number
-  backgroundWriteCount: number
-  deferredForegroundWriteCount: number
-  flushWriteCount: number
-  scheduledDrainCount: number
-  queuedTerminalCount: number
-  queuedChars: number
-  peakQueuedTerminalCount: number
-  peakQueuedChars: number
-  peakQueuedCharsByTerminal: number
-  droppedBacklogCount: number
-  drainWrites: number[]
-  drainHighPriority: boolean[]
-}
-
-type TerminalOutputSchedulerDebugApi = {
-  reset: () => void
-  snapshot: () => TerminalOutputSchedulerDebugSnapshot
-}
-
-const debugState: TerminalOutputSchedulerDebugSnapshot = {
-  backgroundEnqueueCount: 0,
-  deferredForegroundEnqueueCount: 0,
-  foregroundWriteCount: 0,
-  backgroundWriteCount: 0,
-  deferredForegroundWriteCount: 0,
-  flushWriteCount: 0,
-  scheduledDrainCount: 0,
-  queuedTerminalCount: 0,
-  queuedChars: 0,
-  peakQueuedTerminalCount: 0,
-  peakQueuedChars: 0,
-  peakQueuedCharsByTerminal: 0,
-  droppedBacklogCount: 0,
-  drainWrites: [],
-  drainHighPriority: []
-}
-
-function resetDebugState(): void {
-  debugState.backgroundEnqueueCount = 0
-  debugState.deferredForegroundEnqueueCount = 0
-  debugState.foregroundWriteCount = 0
-  debugState.backgroundWriteCount = 0
-  debugState.deferredForegroundWriteCount = 0
-  debugState.flushWriteCount = 0
-  debugState.scheduledDrainCount = 0
-  debugState.queuedTerminalCount = 0
-  debugState.queuedChars = 0
-  debugState.peakQueuedTerminalCount = 0
-  debugState.peakQueuedChars = 0
-  debugState.peakQueuedCharsByTerminal = 0
-  debugState.droppedBacklogCount = 0
-  debugState.drainWrites = []
-  debugState.drainHighPriority = []
-}
-
-function readQueueDebugSnapshot(): {
-  queuedTerminalCount: number
-  queuedChars: number
-  queuedCharsByTerminal: number
-} {
-  let queuedChars = 0
-  let queuedCharsByTerminal = 0
-  for (const entry of queuedByTerminal.values()) {
-    queuedChars += entry.queuedChars
-    queuedCharsByTerminal = Math.max(queuedCharsByTerminal, entry.queuedChars)
-  }
-  return {
-    queuedTerminalCount: queuedByTerminal.size,
-    queuedChars,
-    queuedCharsByTerminal
-  }
-}
-
-function recordQueueDebugPressure(): void {
-  if (!debugEnabled) {
-    return
-  }
-  const current = readQueueDebugSnapshot()
-  debugState.queuedTerminalCount = current.queuedTerminalCount
-  debugState.queuedChars = current.queuedChars
-  debugState.peakQueuedTerminalCount = Math.max(
-    debugState.peakQueuedTerminalCount,
-    current.queuedTerminalCount
-  )
-  debugState.peakQueuedChars = Math.max(debugState.peakQueuedChars, current.queuedChars)
-  debugState.peakQueuedCharsByTerminal = Math.max(
-    debugState.peakQueuedCharsByTerminal,
-    current.queuedCharsByTerminal
-  )
-}
-
-function exposeDebugApi(): void {
-  if (!debugEnabled || typeof window === 'undefined') {
-    return
-  }
-  // Why: the e2e repro must prove background output used the shared drain, but production must not accumulate diagnostic counters indefinitely.
-  const target = window as unknown as {
-    __terminalOutputSchedulerDebug?: TerminalOutputSchedulerDebugApi
-  }
-  target.__terminalOutputSchedulerDebug ??= {
-    reset: resetDebugState,
-    snapshot: () => {
-      recordQueueDebugPressure()
-      return {
-        ...debugState,
-        drainWrites: [...debugState.drainWrites],
-        drainHighPriority: [...debugState.drainHighPriority]
-      }
-    }
-  }
 }
 
 function scheduleDrain(delayMs: number): void {
@@ -428,335 +318,6 @@ function scheduleForegroundCoalesceRelease(
 
 function isEntryDrainable(entry: QueueEntry): boolean {
   return !entry.foregroundHold && !entry.foregroundCoalesce
-}
-
-function findCursorPositionSequenceEnd(
-  data: string,
-  fromIndex: number,
-  toIndex = data.length
-): number {
-  let offset = data.indexOf('\x1b[', fromIndex)
-  while (offset !== -1 && offset < toIndex) {
-    let index = offset + 2
-    while (index < toIndex) {
-      const char = data[index]
-      if (char === 'G' || char === 'H' || char === 'f') {
-        return index + 1
-      }
-      if ((char < '0' || char > '9') && char !== ';') {
-        break
-      }
-      index += 1
-    }
-    offset = data.indexOf('\x1b[', offset + 2)
-  }
-  return -1
-}
-
-function removeTransientCursorShowSequences(data: string): string {
-  let result = ''
-  let offset = 0
-  let showIndex = data.indexOf(CURSOR_SHOW_SEQUENCE)
-  while (showIndex !== -1) {
-    const nextHideIndex = data.indexOf(
-      CURSOR_HIDE_SEQUENCE,
-      showIndex + CURSOR_SHOW_SEQUENCE.length
-    )
-    const nextPositionEnd = findCursorPositionSequenceEnd(
-      data,
-      showIndex + CURSOR_SHOW_SEQUENCE.length,
-      nextHideIndex === -1 ? data.length : nextHideIndex
-    )
-    if (nextHideIndex === -1) {
-      if (nextPositionEnd === -1) {
-        const synchronizedEndIndex = data.indexOf(
-          SYNCHRONIZED_OUTPUT_END_SEQUENCE,
-          showIndex + CURSOR_SHOW_SEQUENCE.length
-        )
-        if (synchronizedEndIndex === -1) {
-          break
-        }
-        // Why: keep the cursor hidden through the synchronized repaint, restoring it after the frame ends so Windows never paints it in the transient draw position.
-        result += data.slice(offset, showIndex)
-        result += data.slice(
-          showIndex + CURSOR_SHOW_SEQUENCE.length,
-          synchronizedEndIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length
-        )
-        result += CURSOR_SHOW_SEQUENCE
-        offset = synchronizedEndIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length
-        showIndex = data.indexOf(CURSOR_SHOW_SEQUENCE, offset)
-        continue
-      }
-      // Why: Codex can show the cursor before its final synchronized-frame placement. Place first so xterm cannot rasterize the stale cell.
-      result += data.slice(offset, showIndex)
-      result += data.slice(showIndex + CURSOR_SHOW_SEQUENCE.length, nextPositionEnd)
-      result += CURSOR_SHOW_SEQUENCE
-      offset = nextPositionEnd
-      showIndex = data.indexOf(CURSOR_SHOW_SEQUENCE, offset)
-      continue
-    }
-    result += data.slice(offset, showIndex)
-    offset = showIndex + CURSOR_SHOW_SEQUENCE.length
-    showIndex = data.indexOf(CURSOR_SHOW_SEQUENCE, offset)
-  }
-  return offset === 0 ? data : result + data.slice(offset)
-}
-
-function containsCursorPositionSequence(data: string): boolean {
-  let offset = data.indexOf('\x1b[')
-  while (offset !== -1) {
-    let index = offset + 2
-    while (index < data.length) {
-      const char = data[index]
-      if (char === 'G' || char === 'H' || char === 'f') {
-        return true
-      }
-      if ((char < '0' || char > '9') && char !== ';') {
-        break
-      }
-      index += 1
-    }
-    offset = data.indexOf('\x1b[', offset + 2)
-  }
-  return false
-}
-
-function containsCursorRestore(data: string): boolean {
-  const hideIndex = data.indexOf(CURSOR_HIDE_SEQUENCE)
-  const showIndex = data.lastIndexOf(CURSOR_SHOW_SEQUENCE)
-  return hideIndex !== -1 && showIndex > hideIndex && containsCursorPositionSequence(data)
-}
-
-function containsDrainableCursorRestore(data: string): boolean {
-  const synchronizedEndIndex = data.lastIndexOf(SYNCHRONIZED_OUTPUT_END_SEQUENCE)
-  if (synchronizedEndIndex === -1) {
-    return containsCursorRestore(data)
-  }
-  return containsCursorRestore(
-    data.slice(synchronizedEndIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length)
-  )
-}
-
-function containsFinalCursorPlacementBeforeSynchronizedEnd(data: string): boolean {
-  const synchronizedEndIndex = data.lastIndexOf(SYNCHRONIZED_OUTPUT_END_SEQUENCE)
-  if (synchronizedEndIndex === -1) {
-    return false
-  }
-  const lastShowIndex = data.lastIndexOf(CURSOR_SHOW_SEQUENCE, synchronizedEndIndex)
-  if (lastShowIndex === -1) {
-    return false
-  }
-  const lastHideIndex = data.lastIndexOf(CURSOR_HIDE_SEQUENCE, synchronizedEndIndex)
-  if (lastHideIndex > lastShowIndex) {
-    return false
-  }
-  return (
-    findCursorPositionSequenceEnd(
-      data,
-      lastShowIndex + CURSOR_SHOW_SEQUENCE.length,
-      synchronizedEndIndex
-    ) !== -1
-  )
-}
-
-function previewQueuedData(entry: QueueEntry, limit: number): string {
-  let data = ''
-  for (let index = entry.chunkIndex; index < entry.chunks.length; index += 1) {
-    const chunk = entry.chunks[index]
-    const remaining = limit - data.length
-    if (remaining <= 0) {
-      break
-    }
-    data += chunk.data.slice(0, remaining)
-  }
-  return data
-}
-
-function coalescedQueuedDataNeedsCursorRestore(entry: QueueEntry): boolean {
-  const data = previewQueuedData(entry, SYNC_FOREGROUND_FLUSH_CHARS)
-  const synchronizedEndIndex = data.lastIndexOf(SYNCHRONIZED_OUTPUT_END_SEQUENCE)
-  if (synchronizedEndIndex === -1) {
-    return false
-  }
-  const synchronizedFrame = data.slice(
-    0,
-    synchronizedEndIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length
-  )
-  return (
-    containsCursorRestore(synchronizedFrame) &&
-    !containsFinalCursorPlacementBeforeSynchronizedEnd(synchronizedFrame) &&
-    !containsDrainableCursorRestore(data)
-  )
-}
-
-function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
-  let remaining = limit
-  let data = ''
-  let foreground: boolean | null = null
-  let forceForegroundRefresh = false
-  let followupForegroundRefresh = false
-  let shouldRefreshForegroundSynchronously: ForegroundRefreshSyncResolver | null = null
-  let additionalRefreshSyncResolvers: ForegroundRefreshSyncResolver[] | null = null
-  let stripTransientCursorShows = false
-  let beforeWrite: TerminalOutputBeforeWrite | undefined
-  let additionalBeforeWriteCallbacks: TerminalOutputBeforeWrite[] | null = null
-  const parsedCallbacks: TerminalOutputParsedCallback[] = []
-  const ackCredits: (() => void)[] = []
-
-  while (remaining > 0 && entry.chunkIndex < entry.chunks.length) {
-    const chunk = entry.chunks[entry.chunkIndex]
-    if (foreground !== null && chunk.foreground !== foreground) {
-      break
-    }
-    foreground ??= chunk.foreground
-    forceForegroundRefresh ||= chunk.forceForegroundRefresh
-    followupForegroundRefresh ||= chunk.followupForegroundRefresh
-    // Why: one drained write can combine chunks from different renderer states or producers; preserve every forced policy and prep hook.
-    if (chunk.forceForegroundRefresh) {
-      if (shouldRefreshForegroundSynchronously === null) {
-        shouldRefreshForegroundSynchronously = chunk.shouldRefreshForegroundSynchronously
-      } else if (
-        chunk.shouldRefreshForegroundSynchronously !== shouldRefreshForegroundSynchronously &&
-        !additionalRefreshSyncResolvers?.includes(chunk.shouldRefreshForegroundSynchronously)
-      ) {
-        additionalRefreshSyncResolvers ??= []
-        additionalRefreshSyncResolvers.push(chunk.shouldRefreshForegroundSynchronously)
-      }
-    }
-    stripTransientCursorShows ||= chunk.stripTransientCursorShows
-    if (!beforeWrite) {
-      beforeWrite = chunk.beforeWrite
-    } else if (
-      chunk.beforeWrite &&
-      chunk.beforeWrite !== beforeWrite &&
-      !additionalBeforeWriteCallbacks?.includes(chunk.beforeWrite)
-    ) {
-      additionalBeforeWriteCallbacks ??= []
-      additionalBeforeWriteCallbacks.push(chunk.beforeWrite)
-    }
-    if (chunk.data.length <= remaining) {
-      data += chunk.data
-      remaining -= chunk.data.length
-      entry.queuedChars -= chunk.data.length
-      // Clear drained slots before the 64-chunk compaction can release them.
-      entry.chunks[entry.chunkIndex] = {
-        data: '',
-        retainedChars: 0,
-        foreground: chunk.foreground,
-        forceForegroundRefresh: false,
-        followupForegroundRefresh: false,
-        shouldRefreshForegroundSynchronously: ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY,
-        stripTransientCursorShows: false
-      }
-      entry.chunkIndex += 1
-      if (chunk.onParsed) {
-        parsedCallbacks.push(chunk.onParsed)
-      }
-      if (chunk.ackCredit) {
-        ackCredits.push(chunk.ackCredit)
-      }
-      continue
-    }
-
-    data += chunk.data.slice(0, remaining)
-    const residual = chunk.data.slice(remaining)
-    // Geometric flattening bounds retained parents while keeping total copy work linear.
-    const flatten = residual.length * 2 <= chunk.retainedChars
-    entry.chunks[entry.chunkIndex] = {
-      ...chunk,
-      data: flatten ? flattenRetainedSlice(residual) : residual,
-      retainedChars: flatten ? residual.length : chunk.retainedChars
-    }
-    entry.queuedChars -= remaining
-    remaining = 0
-  }
-
-  compactConsumedChunks(entry)
-  if (entry.queuedChars < 0) {
-    entry.queuedChars = 0
-  }
-  recordQueueDebugPressure()
-  return data
-    ? {
-        data,
-        foreground: foreground === true,
-        forceForegroundRefresh,
-        followupForegroundRefresh,
-        shouldRefreshForegroundSynchronously:
-          additionalRefreshSyncResolvers && shouldRefreshForegroundSynchronously
-            ? () =>
-                shouldRefreshForegroundSynchronously() ||
-                additionalRefreshSyncResolvers.some((resolve) => resolve())
-            : (shouldRefreshForegroundSynchronously ?? ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY),
-        stripTransientCursorShows,
-        beforeWrite:
-          additionalBeforeWriteCallbacks && beforeWrite
-            ? (queuedData) => {
-                beforeWrite(queuedData)
-                for (const callback of additionalBeforeWriteCallbacks) {
-                  callback(queuedData)
-                }
-              }
-            : beforeWrite,
-        onParsed:
-          parsedCallbacks.length > 0
-            ? () => {
-                for (const callback of parsedCallbacks) {
-                  callback()
-                }
-              }
-            : undefined,
-        ackCredits
-      }
-    : null
-}
-
-function compactConsumedChunks(entry: QueueEntry): void {
-  if (entry.chunkIndex === 0) {
-    return
-  }
-  if (entry.chunkIndex === entry.chunks.length) {
-    entry.chunks.length = 0
-    entry.chunkIndex = 0
-    return
-  }
-  if (entry.chunkIndex >= 64) {
-    entry.chunks.splice(0, entry.chunkIndex)
-    entry.chunkIndex = 0
-  }
-}
-
-function enqueueChunk(
-  entry: QueueEntry,
-  data: string,
-  options?: {
-    foreground?: boolean
-    forceForegroundRefresh?: boolean
-    followupForegroundRefresh?: boolean
-    shouldRefreshForegroundSynchronously?: ForegroundRefreshSyncResolver
-    stripTransientCursorShows?: boolean
-    beforeWrite?: TerminalOutputBeforeWrite
-    onParsed?: TerminalOutputParsedCallback
-    ackCredit?: () => void
-  }
-): void {
-  // Own queued data so producer slices cannot pin larger PTY or restore buffers.
-  const owned = flattenRetainedSlice(data)
-  entry.chunks.push({
-    data: owned,
-    retainedChars: owned.length,
-    foreground: options?.foreground === true,
-    forceForegroundRefresh: options?.forceForegroundRefresh === true,
-    followupForegroundRefresh: options?.followupForegroundRefresh === true,
-    shouldRefreshForegroundSynchronously:
-      options?.shouldRefreshForegroundSynchronously ?? ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY,
-    stripTransientCursorShows: options?.stripTransientCursorShows === true,
-    beforeWrite: options?.beforeWrite,
-    onParsed: options?.onParsed,
-    ackCredit: options?.ackCredit
-  })
-  entry.queuedChars += data.length
-  recordQueueDebugPressure()
 }
 
 // Why: every discard path MUST fire these before clearing/replacing the queue — a dropped chunk still counts as consumed, or main's in-flight window shrinks permanently and the PTY wedges.


### PR DESCRIPTION
## Summary
- extract synchronized cursor sequencing from the terminal output scheduler
- isolate queue chunk retention/compaction and E2E scheduler diagnostics
- keep queue ownership and drain orchestration in the existing scheduler API

Stacked on #16774.

## Verification
- `pnpm tc`
- targeted Oxlint on all four scheduler modules
- 74 scheduler ordering, ACK-credit, backlog, disposal, refresh, retention, and synchronized-frame tests