### PR TITLE
Extract daemon launch path helpers

### DIFF
--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -1,11 +1,9 @@
 /* eslint-disable max-lines -- Why: owns the full daemon lifecycle (init, launch, adapter wiring,
 restart, teardown); the "swap the provider atomically" invariant keeps restart + singletons co-located. */
-import { join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { getAppEnvironment } from '../../shared/app-environment'
-import { mkdirSync, existsSync, readFileSync, unlinkSync } from 'node:fs'
+import { readFileSync, unlinkSync } from 'node:fs'
 import { fork, type ChildProcess } from 'node:child_process'
-import { connect } from 'node:net'
 import {
   DaemonSpawner,
   getDaemonPidPath,
@@ -52,13 +50,21 @@ import {
   rebindLocalProviderListeners
 } from '../ipc/pty'
 import { isStartupDiagnosticsEnabled, logStartupDiagnostic } from '../startup/startup-diagnostics'
-import { getDaemonLogFilePath } from '../observability/logs-directory'
 import {
   confirmSeededClaudeLivePtys,
   hasSeededUnconfirmedClaudePtys
 } from '../claude-accounts/live-pty-gate'
 import { parseDaemonReadyIdentity, readDaemonProcessIncarnation } from './daemon-ready-identity'
 import type { DaemonEndpointIdentity } from './daemon-hello-protocol'
+import {
+  daemonLogArgs,
+  getAliveDaemonSessionCount,
+  getDaemonEntryPath,
+  getDaemonHistoryDir as getHistoryDir,
+  getDaemonRuntimeDir as getRuntimeDir,
+  probeDaemonSocket as probeSocket,
+  resolvePackagedDarwinAppVersion
+} from './daemon-launch-paths'
 
 // Why: daemon init runs concurrent with window load, so an in-process t timestamp (not harness stderr timing) measures cold-start.
 function logDaemonMilestone(event: string, details: Record<string, unknown> = {}): void {
@@ -100,105 +106,6 @@ type DaemonProvider = DaemonPtyRouter | DaemonPtyAdapter | DegradedDaemonPtyProv
 let adapter: DaemonProvider | null = null
 // Why: coalesce concurrent restartDaemon() calls so two entries can't race the 7-step sequence against a half-spawned replacement.
 let restartInFlight: Promise<RestartDaemonResult> | null = null
-
-function getRuntimeDir(): string {
-  const dir = join(getAppEnvironment().getPath('userData'), 'daemon')
-  mkdirSync(dir, { recursive: true })
-  return dir
-}
-
-function getHistoryDir(): string {
-  const dir = join(getAppEnvironment().getPath('userData'), 'terminal-history')
-  mkdirSync(dir, { recursive: true })
-  return dir
-}
-
-function getDaemonEntryPath(): string {
-  const appPath = getAppEnvironment().getAppPath()
-  // Why: packaged getAppPath() points at app.asar, so redirect to app.asar.unpacked where daemon-entry.js is fork-executable.
-  // Why asar and not isPackaged: orcad is a packaged non-Electron host whose bundle root holds
-  // orcad.js and daemon-entry.js side by side with no asar to redirect (see parcel-watcher-entry-path.ts).
-  const basePath = appPath.includes('app.asar')
-    ? appPath.replace('app.asar', 'app.asar.unpacked')
-    : appPath
-  const directEntryPath = join(basePath, 'daemon-entry.js')
-  if (existsSync(directEntryPath)) {
-    return directEntryPath
-  }
-  return join(basePath, 'out', 'main', 'daemon-entry.js')
-}
-
-// macOS TCC attribution pins the daemon to a packaged app bundle; there is none on a Node host.
-function resolvePackagedDarwinAppVersion(): string | null {
-  const environment = getAppEnvironment()
-  return process.platform === 'darwin' && environment.isPackaged() ? environment.getVersion() : null
-}
-
-// Why: pass a log-file arg so field failures are diagnosable, but honor the ORCA_DIAGNOSTICS_DISABLED privacy switch.
-function daemonLogArgs(): string[] {
-  const disabled = (process.env.ORCA_DIAGNOSTICS_DISABLED ?? '').trim().toLowerCase()
-  if (disabled === '1' || disabled === 'true') {
-    return []
-  }
-  return ['--log-file', getDaemonLogFilePath()]
-}
-
-// Why: a socket that accepts a connection proves a daemon survived a previous app session and can be reused.
-function probeSocket(socketPath: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    if (process.platform !== 'win32' && !existsSync(socketPath)) {
-      resolve(false)
-      return
-    }
-    const sock = connect({ path: socketPath })
-    let settled = false
-    let timer: ReturnType<typeof setTimeout>
-    function finish(alive: boolean, options?: { destroy?: boolean }): void {
-      if (settled) {
-        return
-      }
-      settled = true
-      clearTimeout(timer)
-      sock.removeListener('connect', onConnect)
-      sock.removeListener('error', onError)
-      if (options?.destroy) {
-        sock.destroy()
-      }
-      resolve(alive)
-    }
-
-    function onConnect(): void {
-      finish(true, { destroy: true })
-    }
-
-    function onError(): void {
-      finish(false)
-    }
-
-    timer = setTimeout(() => {
-      finish(false, { destroy: true })
-    }, 1000)
-    sock.on('connect', onConnect)
-    sock.on('error', onError)
-  })
-}
-
-async function getAliveDaemonSessionCount(
-  socketPath: string,
-  tokenPath: string,
-  protocolVersion = PROTOCOL_VERSION
-): Promise<number | null> {
-  const client = new DaemonClient({ socketPath, tokenPath, protocolVersion })
-  try {
-    await client.ensureConnected()
-    const result = await client.request<ListSessionsResult>('listSessions', undefined)
-    return result.sessions.filter((session) => session.isAlive).length
-  } catch {
-    return null
-  } finally {
-    client.disconnect()
-  }
-}
 
 function createPreservedDaemonHandle(
   runtimeDir: string,

--- a/src/main/daemon/daemon-launch-paths.ts
+++ b/src/main/daemon/daemon-launch-paths.ts
@@ -1,0 +1,93 @@
+import { existsSync, mkdirSync } from 'node:fs'
+import { connect } from 'node:net'
+import { join } from 'node:path'
+import { getAppEnvironment } from '../../shared/app-environment'
+import { getDaemonLogFilePath } from '../observability/logs-directory'
+import { DaemonClient } from './client'
+import { PROTOCOL_VERSION, type ListSessionsResult } from './types'
+
+export function getDaemonRuntimeDir(): string {
+  const dir = join(getAppEnvironment().getPath('userData'), 'daemon')
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+export function getDaemonHistoryDir(): string {
+  const dir = join(getAppEnvironment().getPath('userData'), 'terminal-history')
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+export function getDaemonEntryPath(): string {
+  const appPath = getAppEnvironment().getAppPath()
+  // Why: packaged getAppPath() points at app.asar, so redirect to app.asar.unpacked where daemon-entry.js is fork-executable.
+  // Why asar and not isPackaged: orcad is a packaged non-Electron host whose bundle root holds
+  // orcad.js and daemon-entry.js side by side with no asar to redirect (see parcel-watcher-entry-path.ts).
+  const basePath = appPath.includes('app.asar')
+    ? appPath.replace('app.asar', 'app.asar.unpacked')
+    : appPath
+  const directEntryPath = join(basePath, 'daemon-entry.js')
+  return existsSync(directEntryPath)
+    ? directEntryPath
+    : join(basePath, 'out', 'main', 'daemon-entry.js')
+}
+
+// macOS TCC attribution pins the daemon to a packaged app bundle; there is none on a Node host.
+export function resolvePackagedDarwinAppVersion(): string | null {
+  const environment = getAppEnvironment()
+  return process.platform === 'darwin' && environment.isPackaged() ? environment.getVersion() : null
+}
+
+// Why: pass a log-file arg so field failures are diagnosable, but honor the ORCA_DIAGNOSTICS_DISABLED privacy switch.
+export function daemonLogArgs(): string[] {
+  const disabled = (process.env.ORCA_DIAGNOSTICS_DISABLED ?? '').trim().toLowerCase()
+  return disabled === '1' || disabled === 'true' ? [] : ['--log-file', getDaemonLogFilePath()]
+}
+
+// Why: a socket that accepts a connection proves a daemon survived a previous app session and can be reused.
+export function probeDaemonSocket(socketPath: string): Promise<boolean> {
+  const { promise, resolve } = Promise.withResolvers<boolean>()
+  if (process.platform !== 'win32' && !existsSync(socketPath)) {
+    resolve(false)
+    return promise
+  }
+  const socket = connect({ path: socketPath })
+  let settled = false
+  let timer: ReturnType<typeof setTimeout>
+  const finish = (alive: boolean, destroy = false): void => {
+    if (settled) {
+      return
+    }
+    settled = true
+    clearTimeout(timer)
+    socket.removeListener('connect', onConnect)
+    socket.removeListener('error', onError)
+    if (destroy) {
+      socket.destroy()
+    }
+    resolve(alive)
+  }
+  const onConnect = (): void => finish(true, true)
+  const onError = (): void => finish(false)
+  timer = setTimeout(() => finish(false, true), 1000)
+  socket.on('connect', onConnect)
+  socket.on('error', onError)
+  return promise
+}
+
+export async function getAliveDaemonSessionCount(
+  socketPath: string,
+  tokenPath: string,
+  protocolVersion = PROTOCOL_VERSION
+): Promise<number | null> {
+  const client = new DaemonClient({ socketPath, tokenPath, protocolVersion })
+  try {
+    await client.ensureConnected()
+    const result = await client.request<ListSessionsResult>('listSessions', undefined)
+    return result.sessions.filter((session) => session.isAlive).length
+  } catch {
+    return null
+  } finally {
+    client.disconnect()
+  }
+}


### PR DESCRIPTION
## Summary
- isolate daemon runtime/history paths, entry resolution, diagnostics args, socket probing, and live-session counting
- keep launcher/adoption/restart state in the existing daemon lifecycle owner
- reduce daemon-init without changing provider swap semantics

Stacked on #16775.

## Verification
- `pnpm tc`
- targeted Oxlint on both daemon modules
- 80 daemon entry-path, initialization, replacement, adoption, readiness, and failure tests