### PR TITLE
fix(worktrees): stop remote deletes from reappearing after path-spelling misses

### DIFF
--- a/src/main/ipc/worktree-path-comparison.ts
+++ b/src/main/ipc/worktree-path-comparison.ts
@@ -1,5 +1,8 @@
 import { posix, win32 } from 'node:path'
-import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
+import {
+  foldMacOSFirmlinkPrefix,
+  isWindowsAbsolutePathLike
+} from '../../shared/cross-platform-path'
 
 export function areWorktreePathsEqual(
   leftPath: string,
@@ -108,11 +111,5 @@ function normalizePosixWorktreePathForComparison(
   platform: NodeJS.Platform
 ): string {
   const normalized = posix.normalize(posix.resolve(pathValue))
-  if (platform !== 'darwin') {
-    return normalized
-  }
-  if (normalized === '/private/tmp') {
-    return '/tmp'
-  }
-  return normalized.startsWith('/private/tmp/') ? normalized.slice('/private'.length) : normalized
+  return platform === 'darwin' ? foldMacOSFirmlinkPrefix(normalized) : normalized
 }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -616,7 +616,8 @@ import { recordManagedHookInstallFailure } from '../agent-hooks/install-telemetr
 import {
   isWindowsAbsolutePathLike,
   isPathInsideOrEqual,
-  normalizeRuntimePathForComparison
+  normalizeRuntimePathForComparison,
+  normalizeWorktreeSelectorPathForComparison
 } from '../../shared/cross-platform-path'
 import { findRuntimeWorkspaceFileOwner } from '../../shared/runtime-workspace-file-owner'
 import { resolveTerminalStartupCwd } from '../../shared/terminal-startup-cwd'
@@ -41436,7 +41437,10 @@ function branchSelectorMatches(branch: string, selector: string): boolean {
 }
 
 function runtimePathsEqual(left: string, right: string): boolean {
-  return normalizeRuntimePathForComparison(left) === normalizeRuntimePathForComparison(right)
+  return (
+    normalizeWorktreeSelectorPathForComparison(left) ===
+    normalizeWorktreeSelectorPathForComparison(right)
+  )
 }
 
 /**
@@ -41455,7 +41459,7 @@ function runtimeWorktreeIdentityKey(worktreeId: string): string {
   // Same suffix rule: this keys PTY refresh, sleep, and mutation-queue state per session.
   const parsed = splitWorktreeId(worktreeId)
   return parsed
-    ? `${parsed.repoId}\0${normalizeRuntimePathForComparison(parsed.worktreePath)}`
+    ? `${parsed.repoId}\0${normalizeWorktreeSelectorPathForComparison(parsed.worktreePath)}`
     : worktreeId
 }
 
@@ -41463,7 +41467,7 @@ function runtimeWorktreeLookupKey(worktreeId: string): string {
   const parsed = splitWorktreeId(worktreeId)
   return JSON.stringify(
     parsed
-      ? ['parsed', parsed.repoId, normalizeRuntimePathForComparison(parsed.worktreePath)]
+      ? ['parsed', parsed.repoId, normalizeWorktreeSelectorPathForComparison(parsed.worktreePath)]
       : ['raw', worktreeId]
   )
 }

--- a/src/main/runtime/worktree-rm-id-selector-path-spelling.test.ts
+++ b/src/main/runtime/worktree-rm-id-selector-path-spelling.test.ts
@@ -143,6 +143,28 @@ describe('worktree id selectors vs. the path spelling git reports (#16243)', () 
     }
   )
 
+  it('resolves /tmp against a scan that reports /private/tmp (#16753)', async () => {
+    const gitPath = '/private/tmp/orca/workspaces/plugin-host'
+    const gitRepo = '/private/tmp/orca/repo'
+    scanReports(gitPath, gitRepo)
+    const runtime = new OrcaRuntimeService(makeStore(gitRepo) as never)
+
+    await expect(
+      runtime.showManagedWorktree(`id:${REPO_ID}::/tmp/orca/workspaces/plugin-host`)
+    ).resolves.toMatchObject({ path: gitPath })
+    await expect(
+      runtime.showManagedWorktree('path:/tmp/orca/workspaces/plugin-host')
+    ).resolves.toMatchObject({ path: gitPath })
+
+    const internals = runtime as unknown as RemovalInternals
+    await expect(
+      internals.resolveWorktreeRemovalTarget(
+        `id:${REPO_ID}::/tmp/orca/workspaces/plugin-host`,
+        LOCAL_EXECUTION_HOST_ID
+      )
+    ).resolves.toMatchObject({ repoId: REPO_ID, path: gitPath })
+  })
+
   it('still refuses an id whose path names a different workspace', async () => {
     scanReports(WORKTREE_PATH)
     const runtime = new OrcaRuntimeService(makeStore() as never)

--- a/src/renderer/src/store/slices/worktrees-remote-runtime-removal.test.ts
+++ b/src/renderer/src/store/slices/worktrees-remote-runtime-removal.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AppState } from '../types'
 import type { RuntimeEnvironmentCallRequest } from '../../runtime/runtime-compatibility-test-fixture'
 import { makeWorktree } from './worktrees-slice-test-fixtures'
+import { getAuthoritativelyRemovedWorktreeIds } from './worktrees/listing/authoritative-worktree-removal-memory'
 import {
   createTestStore,
   mockApi,
@@ -36,7 +37,12 @@ describe('worktree remote runtime mutations', () => {
 
   it('removes worktrees through the active remote runtime environment', async () => {
     const store = createTestStore()
-    const wt = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      hostId: 'runtime:env-1'
+    })
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'rpc-rm',
       ok: true,
@@ -50,7 +56,7 @@ describe('worktree remote runtime mutations', () => {
 
     const result = await store
       .getState()
-      .removeWorktree({ id: wt.id, executionHostId: null }, false, {
+      .removeWorktree({ id: wt.id, executionHostId: 'runtime:env-1' }, false, {
         snapshotPruneBatchId: 'batch-1'
       })
 
@@ -79,6 +85,7 @@ describe('worktree remote runtime mutations', () => {
       backendOwnsPtyTeardown: true
     })
     expect(store.getState().worktreesByRepo.repo1).toEqual([])
+    expect([...(getAuthoritativelyRemovedWorktreeIds('runtime:env-1') ?? [])]).toEqual([wt.id])
   })
 
   it('cleans up a preserved branch through the same host qualifier the removal used', async () => {
@@ -411,37 +418,60 @@ describe('worktree remote runtime mutations', () => {
     expect(mockApi.worktrees.remove).not.toHaveBeenCalled()
   })
 
-  it.each(['repo_not_found', 'selector_not_found'])(
-    'forgets a mirrored row when the remote returns %s',
-    async (errorCode) => {
-      const store = createTestStore()
-      const wt = makeWorktree({
-        id: 'repo-gone::/path/stale',
-        repoId: 'repo-gone',
-        path: '/path/stale',
-        hostId: 'runtime:env-1'
-      })
-      runtimeEnvironmentCall.mockResolvedValue({
-        id: 'rpc-rm',
-        ok: false,
-        error: { code: errorCode, message: errorCode },
-        _meta: { runtimeId: 'runtime-remote' }
-      })
-      store.setState({
-        settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
-        worktreesByRepo: { 'repo-gone': [wt] }
-      } as Partial<AppState>)
+  it('forgets a mirrored row when the remote returns repo_not_found', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo-gone::/path/stale',
+      repoId: 'repo-gone',
+      path: '/path/stale',
+      hostId: 'runtime:env-1'
+    })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-rm',
+      ok: false,
+      error: { code: 'repo_not_found', message: 'repo_not_found' },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: { 'repo-gone': [wt] }
+    } as Partial<AppState>)
 
-      const result = await store.getState().removeWorktree({ id: wt.id, executionHostId: null })
+    const result = await store.getState().removeWorktree({ id: wt.id, executionHostId: null })
 
-      expect(result).toEqual({ ok: true })
-      expect(mockApi.worktrees.forgetLocal).toHaveBeenCalledWith({
-        worktreeId: wt.id,
-        hostId: 'runtime:env-1'
-      })
-      expect(store.getState().worktreesByRepo['repo-gone']).toEqual([])
-    }
-  )
+    expect(result).toEqual({ ok: true })
+    expect(mockApi.worktrees.forgetLocal).toHaveBeenCalledWith({
+      worktreeId: wt.id,
+      hostId: 'runtime:env-1'
+    })
+    expect(store.getState().worktreesByRepo['repo-gone']).toEqual([])
+  })
+
+  it('does not forget a live remote row when the host returns selector_not_found (#16753)', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      hostId: 'runtime:env-1'
+    })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-rm',
+      ok: false,
+      error: { code: 'selector_not_found', message: 'selector_not_found' },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    const result = await store.getState().removeWorktree({ id: wt.id, executionHostId: null })
+
+    expect(result).toEqual({ ok: false, error: 'selector_not_found' })
+    expect(mockApi.worktrees.forgetLocal).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo.repo1).toEqual([wt])
+  })
 
   it('does not forget a row that becomes ambiguous while remote removal is in flight', async () => {
     const store = createTestStore()

--- a/src/renderer/src/store/slices/worktrees/listing/authoritative-worktree-removal-memory.ts
+++ b/src/renderer/src/store/slices/worktrees/listing/authoritative-worktree-removal-memory.ts
@@ -1,6 +1,14 @@
 import { parseExecutionHostId, type ExecutionHostId } from '../../../../../../shared/execution-host'
 import { AUTHORITATIVE_REMOVAL_MEMORY_LIMIT } from './worktree-slice-constants'
 
+/** SSH fallback reads and paired-runtime catalog refreshes can both resurrect a row mid-delete. */
+export function shouldRememberAuthoritativeWorktreeRemoval(
+  hostId: ExecutionHostId | undefined
+): hostId is ExecutionHostId {
+  const kind = hostId ? parseExecutionHostId(hostId)?.kind : undefined
+  return kind === 'ssh' || kind === 'runtime'
+}
+
 // Why: main retires the persisted SSH metadata a scan proved gone, but that IPC is async and the next fallback
 // read can already be in flight, so this session memory covers the window until the delete lands. It is not the
 // durable half: reloads start empty and rely on the metadata itself being gone.

--- a/src/renderer/src/store/slices/worktrees/teardown/host-qualified-worktree-row-removal.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/host-qualified-worktree-row-removal.ts
@@ -1,8 +1,11 @@
 import { requestVirtualizedScrollAnchorRecord } from '@/hooks/requestVirtualizedScrollAnchorRecord'
 import { getWorktreeOperationOwnerHostIds } from '@/lib/worktree-operation-route'
-import { parseExecutionHostId, type ExecutionHostId } from '../../../../../../shared/execution-host'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import { resolveWorkspaceCleanupRemovalHostId } from '../../../../../../shared/workspace-cleanup-host-identity'
-import { rememberAuthoritativelyRemovedWorktrees } from '../listing/authoritative-worktree-removal-memory'
+import {
+  rememberAuthoritativelyRemovedWorktrees,
+  shouldRememberAuthoritativeWorktreeRemoval
+} from '../listing/authoritative-worktree-removal-memory'
 import { worktreeHostMatchOptions, worktreeMatchesHost } from '../listing/worktree-host-ownership'
 import { composeWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import type { WorktreeSliceGet, WorktreeSliceSet } from '../listing/worktree-slice-types'
@@ -134,7 +137,7 @@ export function dropConfirmedHostRow(
       sortEpoch: state.sortEpoch + 1
     }
   })
-  if (parseExecutionHostId(requiredExecutionHostId)?.kind === 'ssh') {
+  if (shouldRememberAuthoritativeWorktreeRemoval(requiredExecutionHostId)) {
     rememberAuthoritativelyRemovedWorktrees(requiredExecutionHostId, [worktreeId])
   }
   return sameIdSurvives

--- a/src/renderer/src/store/slices/worktrees/teardown/remove-worktree.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/remove-worktree.ts
@@ -2,7 +2,6 @@ import type { WorktreeSlice } from '../../worktree-helpers'
 import type { WorktreeSliceGet, WorktreeSliceSet } from '../listing/worktree-slice-types'
 import type { RemoveWorktreeResult } from '../../../../../../shared/worktree/create-types'
 import { getRepoIdFromWorktreeId } from '../../worktree-helpers'
-import { parseExecutionHostId } from '../../../../../../shared/execution-host'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { getActiveRuntimeTarget } from '../../../../runtime/runtime-rpc-client'
 import { forgetHugeRepoWarningDismissalsForWorktrees } from '@/lib/source-control-huge-repo-warning-dismissals'
@@ -28,7 +27,10 @@ import {
 import { preservedBranchCleanupKey } from '../../../../../../shared/preserved-branch-cleanup'
 import { composeWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import { pruneHostedReviewLinkMutationGenerations } from '../metadata/hosted-review-link-mutation'
-import { rememberAuthoritativelyRemovedWorktrees } from '../listing/authoritative-worktree-removal-memory'
+import {
+  rememberAuthoritativelyRemovedWorktrees,
+  shouldRememberAuthoritativeWorktreeRemoval
+} from '../listing/authoritative-worktree-removal-memory'
 import { preservedBranchRuntimeTargetByCleanupKey } from './preserved-branch-cleanup-target'
 import {
   isRuntimeRepoNotFoundError,
@@ -153,6 +155,10 @@ export function createRemoveWorktree(
           if (currentResolution.kind === 'resolved') {
             removalGenerationGuard?.assertCurrent()
           }
+          // Why (#16753): selector_not_found is often a path-spelling miss; forgetting the row lets the next scan resurrect it.
+          if (isRuntimeSelectorNotFoundError(error) && !isRuntimeRepoNotFoundError(error)) {
+            throw error
+          }
           try {
             removalResult = await window.api.worktrees.forgetLocal({
               worktreeId,
@@ -224,7 +230,7 @@ export function createRemoveWorktree(
       forgetHugeRepoWarningDismissalsForWorktrees([worktreeId])
       // Why: forget-local is legal while the host is unreachable, so record the removal here too — otherwise an
       // in-flight metadata read that snapshotted this row re-appends it, and disconnected polls never drop it.
-      if (hostId && parseExecutionHostId(hostId)?.kind === 'ssh') {
+      if (shouldRememberAuthoritativeWorktreeRemoval(hostId)) {
         rememberAuthoritativelyRemovedWorktrees(hostId, [worktreeId])
       }
 

--- a/src/shared/cross-platform-path.test.ts
+++ b/src/shared/cross-platform-path.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
   areLocalWindowsWslPathAliases,
+  foldMacOSFirmlinkPrefix,
   isCaseInsensitiveRuntimeRoot,
   isPathInsideOrEqual,
   isRuntimePathAbsolute,
   normalizeRuntimePathForComparison,
+  normalizeWorktreeSelectorPathForComparison,
   relativePathInsideRoot,
   resolveRuntimePath
 } from './cross-platform-path'
@@ -111,6 +113,22 @@ describe('cross-platform path containment', () => {
         '\\\\wsl.localhost\\ubuntu\\home\\Alice\\repo\\line\nbreak'
       )
     ).toBe('line\nbreak')
+  })
+
+  it('folds macOS firmlink spellings for worktree selectors without touching /private/Users', () => {
+    expect(foldMacOSFirmlinkPrefix('/private/tmp/orca/wt')).toBe('/tmp/orca/wt')
+    expect(foldMacOSFirmlinkPrefix('/tmp/orca/wt')).toBe('/tmp/orca/wt')
+    expect(foldMacOSFirmlinkPrefix('/private/var/folders/xx')).toBe('/var/folders/xx')
+    expect(foldMacOSFirmlinkPrefix('/private/tmpdir/x')).toBe('/private/tmpdir/x')
+    expect(foldMacOSFirmlinkPrefix('/private/Users/ada')).toBe('/private/Users/ada')
+    expect(normalizeWorktreeSelectorPathForComparison('/private/tmp/orca/wt/')).toBe(
+      normalizeWorktreeSelectorPathForComparison('/tmp/orca/wt')
+    )
+    expect(normalizeWorktreeSelectorPathForComparison('/private/var/folders/xx')).toBe(
+      normalizeWorktreeSelectorPathForComparison('/var/folders/xx')
+    )
+    // General path comparison stays unfolded so relativePathInsideRoot segment counts stay aligned.
+    expect(normalizeRuntimePathForComparison('/private/tmp/orca/wt')).toBe('/private/tmp/orca/wt')
   })
 
   it('matches macOS NFD paths against agent-recorded NFC paths', () => {

--- a/src/shared/cross-platform-path.ts
+++ b/src/shared/cross-platform-path.ts
@@ -56,6 +56,27 @@ export function normalizeRuntimePathForComparison(rawValue: string): string {
   return isWindowsPath ? normalized.toLowerCase() : normalized
 }
 
+/**
+ * Comparison only. macOS firmlinks `/tmp`→`/private/tmp` and `/var`→`/private/var`,
+ * and Git reports the private spelling while callers often keep the public one.
+ * Kept out of `normalizeRuntimePathForComparison` because that function's
+ * relative-path slicer counts raw segments and a prefix fold would desync them.
+ */
+export function foldMacOSFirmlinkPrefix(pathname: string): string {
+  if (pathname === '/private/tmp' || pathname.startsWith('/private/tmp/')) {
+    return `/tmp${pathname.slice('/private/tmp'.length)}`
+  }
+  if (pathname === '/private/var' || pathname.startsWith('/private/var/')) {
+    return `/var${pathname.slice('/private/var'.length)}`
+  }
+  return pathname
+}
+
+/** Worktree `id:` / `path:` selector comparison. Never persist or return this as a real path. */
+export function normalizeWorktreeSelectorPathForComparison(rawValue: string): string {
+  return foldMacOSFirmlinkPrefix(normalizeRuntimePathForComparison(rawValue))
+}
+
 export function areLocalWindowsWslPathAliases(left: string, right: string): boolean {
   const leftIdentity = getLocalWindowsWslPathIdentity(left)
   const rightIdentity = getLocalWindowsWslPathIdentity(right)

--- a/src/shared/worktree/id.test.ts
+++ b/src/shared/worktree/id.test.ts
@@ -145,6 +145,13 @@ describe('worktreeIdComparisonKey path-spelling parity for id: selectors (#16243
   })
 
   // #15598/#15616: the same Windows checkout is recorded with both separators.
+  it('folds macOS /tmp and /var firmlink spellings Git reports as /private/... (#16753)', () => {
+    expect(key('repo-123::/private/tmp/orca/wt')).toBe(key('repo-123::/tmp/orca/wt'))
+    expect(key('repo-123::/private/var/folders/xx/wt')).toBe(key('repo-123::/var/folders/xx/wt'))
+    expect(key('repo-123::/private/tmpdir/wt')).not.toBe(key('repo-123::/tmpdir/wt'))
+    expect(key('repo-123::/private/Users/ada/wt')).not.toBe(key('repo-123::/Users/ada/wt'))
+  })
+
   it('folds Windows separator and drive-letter case, as `path:` already does', () => {
     const windows = 'repo-123::D:/Agentic/game2'
     expect(key('repo-123::D:\\Agentic\\game2')).toBe(key(windows))

--- a/src/shared/worktree/id.ts
+++ b/src/shared/worktree/id.ts
@@ -1,4 +1,4 @@
-import { normalizeRuntimePathForComparison } from '../cross-platform-path'
+import { normalizeWorktreeSelectorPathForComparison } from '../cross-platform-path'
 import { WORKTREE_ID_SEPARATOR } from '../pty-session-id-format'
 
 export { WORKTREE_ID_SEPARATOR } from '../pty-session-id-format'
@@ -20,16 +20,16 @@ export function getRepoIdFromWorktreeId(worktreeId: string): string {
 
 /**
  * Canonical comparison form of a worktree id: the repoId is compared EXACT and only the path folds,
- * through the same `normalizeRuntimePathForComparison` a `path:` selector has always applied and
- * byte-exact id matching denied the renderer (#16243). Null for a malformed id, so callers keep
- * exact matching for it. Comparison only — never persist or return this key.
+ * through the same `normalizeWorktreeSelectorPathForComparison` a `path:` selector applies
+ * (#16243, #16753). Null for a malformed id, so callers keep exact matching for it.
+ * Comparison only — never persist or return this key.
  */
 export function worktreeIdComparisonKey(worktreeId: string): string | null {
   const parsed = splitWorktreeId(worktreeId)
   if (!parsed || !parsed.repoId || !parsed.worktreePath) {
     return null
   }
-  return `${parsed.repoId}${WORKTREE_ID_SEPARATOR}${normalizeRuntimePathForComparison(
+  return `${parsed.repoId}${WORKTREE_ID_SEPARATOR}${normalizeWorktreeSelectorPathForComparison(
     parsed.worktreePath
   )}`
 }


### PR DESCRIPTION
Deleting a worktree on a remote Mac from a local Orca client could look like it worked, then the worktree came back because it was never actually removed. The client asked the host to delete one path spelling while Git on the Mac listed another (`/tmp` vs `/private/tmp`). The host said it could not find the worktree. The client treated that as "already gone," hid the row, and the next catalog refresh put the still-on-disk worktree back.

## What Changed

- Worktree `id:` and `path:` selectors fold macOS firmlink spellings (`/tmp` with `/private/tmp`, `/var` with `/private/var`) the same way Git lists them.
- `selector_not_found` from a live paired host is an error again. The row stays. `repo_not_found` still forgets a dead mirror.
- Successful deletes on paired runtimes are remembered the same way SSH deletes already were, so an in-flight catalog refresh cannot resurrect the row.

## Why

#16753: local client, remote Mac, both 1.4.190. Delete shows "Deleting…", the row vanishes, then it reappears and the directory is still on the remote disk. Local deletes work.

#16494 already folded Windows path spellings for `id:` selectors. It used `normalizeRuntimePathForComparison`, which does not fold macOS firmlinks. I reproduced the leftover miss on 1.4.190: `id:…::/tmp/…` and `path:/tmp/…` both returned `selector_not_found` against a Git listing at `/private/tmp/…`. Exact `/private/tmp` ids deleted and stayed gone.

The renderer then called `forgetLocal` on `selector_not_found`, which is the blink. Paired-runtime removals were also missing the SSH-only scan-resurrection memory, so even a completed delete could come back if a refresh was already in flight.

## Linked Issue

Fixes #16753

## Visual Proof

N/A. No layout or chrome change. The user-visible change is delete either removes the worktree or keeps the row with an error, instead of hiding it and letting the next scan restore it.

## Testing

- Isolated 1.4.190 `orca serve` pair under `/tmp/orca-repro-16753`, dummy repo, dummy workspace dir. Production Orca was not used. Exact `id:` delete succeeded and stayed gone. `/tmp` vs `/private/tmp` `id:` and `path:` selectors returned `selector_not_found` and left the Git worktree on disk. `name:` delete succeeded.
- Focused tests: 75 passed.
- Neutralization, same as #16494: strip the firmlink fold and keep the new tests, 2 fail (`id.test.ts` firmlink key, `worktree-rm-id-selector-path-spelling.test.ts` `/tmp` vs `/private/tmp` resolve). Strip the `selector_not_found` throw and keep the new test, 1 fail (`does not forget a live remote row…`). Restore, 75 pass again.
- `pnpm tc` exit 0.
- `pnpm run check:code-quality:changed` 0 findings.
- Did not click Delete in a two-Mac desktop window (would have opened another Orca on a machine already in use). The isolated serve repro is the same `worktree.rm` RPC the UI sends.
- Did not run full `pnpm lint`, `pnpm test`, or `pnpm build` locally. CI should cover those.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Investigation, the isolated 1.4.190 repro, the tests, and the patch were written with xAI Grok 4.6 inside Orca.

## Review

- **Security:** delete still requires an exact repo id. Firmlink folding is comparison-only and does not widen host or repo. Ambiguous folded ids still refuse (`selector_ambiguous`). `selector_not_found` no longer deletes local metadata for a live host.
- **Cross-platform:** `/private/tmp` and `/private/var` folds are path-shape based so a non-Mac client talking to a Mac host matches. `/private/tmpdir` and `/private/Users` stay distinct. Windows and POSIX case/separator rules from #16494 are unchanged. `normalizeRuntimePathForComparison` is unchanged so relative-path slicing is not affected.
- **Remote / SSH / paired runtime:** this is the paired-runtime delete path. SSH already remembered removals; paired runtimes now do too. Mixed-version: older hosts still miss `/tmp` vs `/private/tmp`; the client no longer pretends that miss was a successful delete, so the row does not blink. Newer hosts resolve the miss and delete.
- **Agents / git providers:** no agent, provider, or Git command surface change. Selector comparison only.
- **UI:** no layout change. Failed remote deletes can now show the existing failure toast instead of a silent blink.
- **Performance:** one prefix check on selector comparison. No extra Git or RPC on the success path.
- **Backwards compatibility:** persisted ids are unchanged. Only comparison keys fold.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Author

No X account on file.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)