### PR TITLE
feat(dashboard): open files and links from the agent preview terminal

### DIFF
--- a/src/main/ipc/dashboard-file-link-payload-validation.ts
+++ b/src/main/ipc/dashboard-file-link-payload-validation.ts
@@ -1,0 +1,33 @@
+import {
+  DASHBOARD_MAX_FILE_LINK_PATH_LENGTH,
+  type DashboardOpenFileArgs
+} from '../../shared/dashboard-snapshot'
+import { normalizeExecutionHostId } from '../../shared/execution-host'
+
+const MAX_ID_LENGTH = 4_096
+
+function isBoundedString(value: unknown, maxLength: number, allowEmpty = false): value is string {
+  return typeof value === 'string' && value.length <= maxLength && (allowEmpty || value.length > 0)
+}
+
+function isOptionalPositiveInteger(value: unknown): boolean {
+  return value === null || (typeof value === 'number' && Number.isInteger(value) && value > 0)
+}
+
+export function isDashboardOpenFileArgs(value: unknown): value is DashboardOpenFileArgs {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const args = value as Record<string, unknown>
+  return (
+    // A folder-workspace card can carry no worktree id; the path still routes.
+    isBoundedString(args.worktreeId, MAX_ID_LENGTH, true) &&
+    (args.executionHostId === undefined ||
+      (isBoundedString(args.executionHostId, MAX_ID_LENGTH) &&
+        normalizeExecutionHostId(args.executionHostId) !== null)) &&
+    isBoundedString(args.path, DASHBOARD_MAX_FILE_LINK_PATH_LENGTH) &&
+    isOptionalPositiveInteger(args.line) &&
+    isOptionalPositiveInteger(args.column) &&
+    (args.openWithSystemDefault === undefined || typeof args.openWithSystemDefault === 'boolean')
+  )
+}

--- a/src/main/ipc/dashboard-payload-validation.test.ts
+++ b/src/main/ipc/dashboard-payload-validation.test.ts
@@ -18,6 +18,7 @@ vi.mock('../../shared/repo-icon', async (importOriginal) => {
 
 import {
   admitDashboardSnapshot,
+  isDashboardOpenFileArgs,
   isDashboardRevealAgentArgs,
   isDashboardSpawnAgentArgs,
   isDashboardSnapshot
@@ -577,5 +578,34 @@ describe('dashboard payload validation', () => {
     expect(
       isDashboardRevealAgentArgs({ repoId: 'repo-1', worktreeId: 'worktree-1', tabId: '' })
     ).toBe(false)
+  })
+})
+
+describe('isDashboardOpenFileArgs', () => {
+  const args = { worktreeId: 'worktree-1', path: 'src/app.ts', line: 12, column: 3 }
+
+  it('admits a printed path with optional position and host', () => {
+    expect(isDashboardOpenFileArgs(args)).toBe(true)
+    expect(isDashboardOpenFileArgs({ ...args, line: null, column: null })).toBe(true)
+    expect(
+      isDashboardOpenFileArgs({
+        ...args,
+        executionHostId: 'ssh:target-1',
+        openWithSystemDefault: true
+      })
+    ).toBe(true)
+    // A folder workspace card can carry no worktree id; the path still routes.
+    expect(isDashboardOpenFileArgs({ ...args, worktreeId: '' })).toBe(true)
+  })
+
+  it('rejects an empty path, a bad position, or an unparseable host', () => {
+    expect(isDashboardOpenFileArgs({ ...args, path: '' })).toBe(false)
+    expect(isDashboardOpenFileArgs({ ...args, path: 'a'.repeat(4_097) })).toBe(false)
+    expect(isDashboardOpenFileArgs({ ...args, line: 0 })).toBe(false)
+    expect(isDashboardOpenFileArgs({ ...args, column: 1.5 })).toBe(false)
+    expect(isDashboardOpenFileArgs({ ...args, executionHostId: 'runtime:' })).toBe(false)
+    expect(isDashboardOpenFileArgs({ ...args, openWithSystemDefault: 'yes' })).toBe(false)
+    expect(isDashboardOpenFileArgs(null)).toBe(false)
+    expect(isDashboardOpenFileArgs([args])).toBe(false)
   })
 })

--- a/src/main/ipc/dashboard-payload-validation.ts
+++ b/src/main/ipc/dashboard-payload-validation.ts
@@ -20,6 +20,7 @@ import {
 } from './dashboard-workspace-payload-validation'
 import { isDashboardFilterOptions } from './dashboard-filter-payload-validation'
 export { isDashboardSpawnAgentArgs } from './dashboard-agent-launch-validation'
+export { isDashboardOpenFileArgs } from './dashboard-file-link-payload-validation'
 
 const MAX_DASHBOARD_CARDS = 1_000
 const MAX_DASHBOARD_SUBAGENTS = 100

--- a/src/main/ipc/dashboard-popout.test.ts
+++ b/src/main/ipc/dashboard-popout.test.ts
@@ -274,6 +274,27 @@ describe('registerDashboardPopoutHandlers', () => {
     expect(sendToTrustedMock).toHaveBeenCalledWith('ui:sleepDashboardWorkspace', args)
   })
 
+  it('opens a preview file link in only the trusted main window', () => {
+    const main = makeWindow(mainSender)
+    getTrustedWindowMock.mockReturnValue(main)
+    const args = { worktreeId: 'w1', path: 'src/app.ts', line: 12, column: 3 }
+
+    handlers.get('dashboardPopout:openFile')!({ sender: untrustedSender } as never, args)
+    handlers.get('dashboardPopout:openFile')!({ sender: popoutSender } as never, {
+      ...args,
+      path: ''
+    })
+    handlers.get('dashboardPopout:openFile')!({ sender: popoutSender } as never, {
+      ...args,
+      line: 0
+    })
+    expect(safelyRevealMock).not.toHaveBeenCalled()
+
+    handlers.get('dashboardPopout:openFile')!({ sender: popoutSender } as never, args)
+    expect(safelyRevealMock).toHaveBeenCalledWith(main)
+    expect(mainSender.send).toHaveBeenCalledWith('ui:openDashboardFile', args)
+  })
+
   it('reveals an agent in only the trusted main window', () => {
     const main = makeWindow(mainSender)
     getTrustedWindowMock.mockReturnValue(main)

--- a/src/main/ipc/dashboard-popout.ts
+++ b/src/main/ipc/dashboard-popout.ts
@@ -13,6 +13,7 @@ import { safelyRevealWindow } from '../window/focus-existing-window'
 import { getTrustedUIRendererWindow, isTrustedUIRenderer, sendToTrustedUIRenderer } from './ui'
 import {
   admitDashboardSnapshot,
+  isDashboardOpenFileArgs,
   isDashboardPaneKey,
   isDashboardRevealAgentArgs,
   isDashboardSleepWorkspaceArgs,
@@ -40,6 +41,7 @@ export function registerDashboardPopoutHandlers(
   ipcMain.removeHandler('dashboardPopout:ackAgent')
   ipcMain.removeHandler('dashboardPopout:spawnAgent')
   ipcMain.removeHandler('dashboardPopout:sleepWorkspace')
+  ipcMain.removeHandler('dashboardPopout:openFile')
 
   onDashboardPopoutOpenChanged((open) => {
     if (!open) {
@@ -142,6 +144,29 @@ export function registerDashboardPopoutHandlers(
     }
     safelyRevealWindow(mainWindow)
     mainWindow.webContents.send('ui:revealDashboardAgent', args)
+    try {
+      app.focus({ steal: true })
+    } catch {
+      // Best-effort; the per-window focus above may still bring it forward.
+    }
+  })
+
+  // Following a file link in a preview terminal lands in the main window's
+  // editor, so it raises that window exactly as click-to-focus does.
+  ipcMain.handle('dashboardPopout:openFile', (event, args: unknown): void => {
+    if (
+      !isDashboardPopoutRenderer(event.sender) ||
+      !isDashboardEnabled(store) ||
+      !isDashboardOpenFileArgs(args)
+    ) {
+      return
+    }
+    const mainWindow = getTrustedUIRendererWindow()
+    if (!mainWindow) {
+      return
+    }
+    safelyRevealWindow(mainWindow)
+    mainWindow.webContents.send('ui:openDashboardFile', args)
     try {
       app.focus({ steal: true })
     } catch {

--- a/src/preload/api/dashboard-api.ts
+++ b/src/preload/api/dashboard-api.ts
@@ -1,4 +1,5 @@
 import type {
+  DashboardOpenFileArgs,
   DashboardRevealAgentArgs,
   DashboardSleepWorkspaceArgs,
   DashboardSnapshot,
@@ -19,6 +20,7 @@ export type DashboardApi = {
   onAckAgent: (callback: (paneKey: string) => void) => () => void
   onSpawnAgent: (callback: (args: DashboardSpawnAgentArgs) => void) => () => void
   onSleepWorkspace: (callback: (args: DashboardSleepWorkspaceArgs) => void) => () => void
+  onOpenFile: (callback: (args: DashboardOpenFileArgs) => void) => () => void
   requestSnapshot: () => Promise<void>
   onSnapshot: (callback: (snapshot: DashboardSnapshot) => void) => () => void
   onViewRequested: (callback: (view: 'board' | 'map') => void) => () => void
@@ -26,6 +28,7 @@ export type DashboardApi = {
   ackAgent: (paneKey: string) => Promise<void>
   spawnAgent: (args: DashboardSpawnAgentArgs) => Promise<void>
   sleepWorkspace: (args: DashboardSleepWorkspaceArgs) => Promise<void>
+  openFile: (args: DashboardOpenFileArgs) => Promise<void>
 }
 
 export type TerminalPreviewApi = {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -12,6 +12,7 @@ import type { AppIdentity } from '../shared/app-identity'
 import type { MacCapturedDigitRowChord } from '../shared/macos-symbolic-hotkeys'
 import type { ComputerAwakeStatus } from '../shared/computer-awake-mode'
 import type {
+  DashboardOpenFileArgs,
   DashboardRevealAgentArgs,
   DashboardSleepWorkspaceArgs,
   DashboardSnapshot,
@@ -2479,6 +2480,12 @@ const api = {
       ipcRenderer.on('ui:sleepDashboardWorkspace', listener)
       return () => ipcRenderer.removeListener('ui:sleepDashboardWorkspace', listener)
     },
+    onOpenFile: (callback: (args: DashboardOpenFileArgs) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, args: DashboardOpenFileArgs): void =>
+        callback(args)
+      ipcRenderer.on('ui:openDashboardFile', listener)
+      return () => ipcRenderer.removeListener('ui:openDashboardFile', listener)
+    },
 
     // ── Consumer side (pop-out window) ───────────────────────────────────
     requestSnapshot: (): Promise<void> => ipcRenderer.invoke('dashboard:requestSnapshot'),
@@ -2501,7 +2508,9 @@ const api = {
     spawnAgent: (args: DashboardSpawnAgentArgs): Promise<void> =>
       ipcRenderer.invoke('dashboardPopout:spawnAgent', args),
     sleepWorkspace: (args: DashboardSleepWorkspaceArgs): Promise<void> =>
-      ipcRenderer.invoke('dashboardPopout:sleepWorkspace', args)
+      ipcRenderer.invoke('dashboardPopout:sleepWorkspace', args),
+    openFile: (args: DashboardOpenFileArgs): Promise<void> =>
+      ipcRenderer.invoke('dashboardPopout:openFile', args)
   },
 
   terminalPreview: {

--- a/src/renderer/src/components/dashboard-popout/AgentDashboardMapView.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentDashboardMapView.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useMemo, useState, type RefObject } from 'react'
 import type {
   DashboardCard,
+  DashboardOpenFileArgs,
   DashboardSleepWorkspaceArgs,
   DashboardSnapshot,
   DashboardSpawnAgentArgs
@@ -37,6 +38,7 @@ type AgentDashboardMapViewProps = {
   dialogCard: DashboardCard | null
   onDialogOpenChange: (open: boolean) => void
   onRevealAgent: (args: AgentRevealArgs) => void
+  onOpenFile: (args: DashboardOpenFileArgs) => void
   onOpenTerminal: (card: DashboardCard) => void
   onSpawnAgent?: (args: DashboardSpawnAgentArgs) => void
   onSleepWorkspace?: (args: DashboardSleepWorkspaceArgs) => void
@@ -57,6 +59,7 @@ export function AgentDashboardMapView({
   dialogCard,
   onDialogOpenChange,
   onRevealAgent,
+  onOpenFile,
   onOpenTerminal,
   onSpawnAgent,
   onSleepWorkspace,
@@ -179,6 +182,7 @@ export function AgentDashboardMapView({
             card={dialogCard}
             onOpenChange={onDialogOpenChange}
             onReveal={onRevealAgent}
+            onOpenFile={onOpenFile}
             className="mr-0 animate-in fade-in-0 slide-in-from-left-2 duration-200 motion-reduce:animate-none"
           />
         ) : null}

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.tsx
@@ -4,6 +4,7 @@ import {
   DASHBOARD_BUCKET_ORDER,
   type DashboardBucket,
   type DashboardCard,
+  type DashboardOpenFileArgs,
   type DashboardSnapshot
 } from '../../../../shared/dashboard-snapshot'
 import type { RepoIcon } from '../../../../shared/repo-icon'
@@ -33,6 +34,12 @@ function ackAgentViaPopoutRelay(paneKey: string): void {
  *  both channels ship together, so a stale preload lacks both. */
 function revealAgentViaPopoutRelay(args: AgentRevealArgs): void {
   void window.api.dashboard.revealAgent?.(args)
+}
+
+/** Follow a preview file link from the pop-out window: the main renderer owns
+ *  the workspace paths and the editor. Same `?.` HMR-skew guard as above. */
+function openFileViaPopoutRelay(args: DashboardOpenFileArgs): void {
+  void window.api.dashboard.openFile?.(args)
 }
 
 function bucketLabel(bucket: DashboardBucket): string {
@@ -123,6 +130,9 @@ type AgentKanbanBoardProps = {
   /** Focuses the agent's pane. Defaults to the pop-out IPC relay; the in-window
    *  host activates the worktree/pane locally and closes the overlay. */
   onRevealAgent?: (args: AgentRevealArgs) => void
+  /** Follows a file link in a card's preview terminal. Defaults to the pop-out
+   *  IPC relay; the in-window host opens the file locally. */
+  onOpenFile?: (args: DashboardOpenFileArgs) => void
   /** When provided, renders a close control in the header (in-window mode). The
    *  pop-out relies on its native window controls, so it omits this. */
   onClose?: () => void
@@ -139,6 +149,7 @@ export function AgentKanbanBoard({
   containerClassName = 'h-screen w-screen',
   onAckAgent = ackAgentViaPopoutRelay,
   onRevealAgent = revealAgentViaPopoutRelay,
+  onOpenFile = openFileViaPopoutRelay,
   onClose,
   headerActions
 }: AgentKanbanBoardProps): React.JSX.Element {
@@ -299,6 +310,7 @@ export function AgentKanbanBoard({
           card={dialogCard}
           onOpenChange={handleDialogOpenChange}
           onReveal={onRevealAgent}
+          onOpenFile={onOpenFile}
         />
       </div>
     </TooltipProvider>

--- a/src/renderer/src/components/dashboard-popout/AgentMapTimeRangeField.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapTimeRangeField.test.tsx
@@ -128,6 +128,7 @@ function renderMapView(): ReturnType<typeof render> {
       onQueryChange={vi.fn()}
       filters={{ projects: [], workspaceStatuses: [], reviewStates: [] }}
       onFiltersChange={vi.fn()}
+      onOpenFile={vi.fn()}
       searchInputRef={{ current: null }}
       now={NOW}
       dialogCard={null}

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
@@ -76,6 +76,7 @@ describe('AgentTerminalDialog', () => {
         card={card({ terminalInput: TERMINAL_INPUT })}
         onOpenChange={() => {}}
         onReveal={() => {}}
+        onOpenFile={() => {}}
       />
     )
 
@@ -86,7 +87,14 @@ describe('AgentTerminalDialog', () => {
   })
 
   it('passes null when the card carries no profile, so the preview routes by client OS', () => {
-    render(<AgentTerminalDialog card={card()} onOpenChange={() => {}} onReveal={() => {}} />)
+    render(
+      <AgentTerminalDialog
+        card={card()}
+        onOpenChange={() => {}}
+        onReveal={() => {}}
+        onOpenFile={() => {}}
+      />
+    )
 
     expect(screen.getByTestId('preview')).toHaveAttribute('data-terminal-input', 'null')
   })
@@ -97,6 +105,7 @@ describe('AgentTerminalDialog', () => {
         card={card({ bucket: 'idle', dotState: 'done', finishedAt: 100, unseen: false })}
         onOpenChange={() => {}}
         onReveal={() => {}}
+        onOpenFile={() => {}}
       />
     )
 
@@ -112,6 +121,7 @@ describe('AgentTerminalDialog', () => {
         card={card({ bucket: 'done', dotState: 'done', finishedAt: 100, unseen: true })}
         onOpenChange={() => {}}
         onReveal={() => {}}
+        onOpenFile={() => {}}
       />
     )
 
@@ -125,6 +135,7 @@ describe('AgentTerminalDialog', () => {
         card={card({ executionHostId: 'runtime:env-1' })}
         onOpenChange={() => {}}
         onReveal={onReveal}
+        onOpenFile={() => {}}
       />
     )
 
@@ -139,7 +150,14 @@ describe('AgentTerminalDialog', () => {
   })
 
   it('reuses the terminal surface as a non-modal adjacent panel', () => {
-    render(<AgentTerminalPanel card={card()} onOpenChange={() => {}} onReveal={() => {}} />)
+    render(
+      <AgentTerminalPanel
+        card={card()}
+        onOpenChange={() => {}}
+        onReveal={() => {}}
+        onOpenFile={() => {}}
+      />
+    )
 
     expect(screen.getByRole('dialog', { name: 'wt' })).toHaveAttribute('data-state', 'open')
     expect(screen.getByTestId('preview')).toHaveClass('min-h-0', 'flex-1')
@@ -151,7 +169,12 @@ describe('AgentTerminalDialog', () => {
     const onOpenChange = vi.fn()
     render(
       <>
-        <AgentTerminalPanel card={card()} onOpenChange={onOpenChange} onReveal={() => {}} />
+        <AgentTerminalPanel
+          card={card()}
+          onOpenChange={onOpenChange}
+          onReveal={() => {}}
+          onOpenFile={() => {}}
+        />
         <Popover defaultOpen>
           <PopoverTrigger>Details</PopoverTrigger>
           <PopoverContent>Worktree details</PopoverContent>

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -8,9 +8,11 @@ import { Button } from '@/components/ui/button'
 import {
   dashboardCardDisplayState,
   type DashboardCard,
+  type DashboardOpenFileArgs,
   type DashboardRevealAgentArgs
 } from '../../../../shared/dashboard-snapshot'
 import { AgentTerminalPreview } from './AgentTerminalPreview'
+import type { PreviewFileLinkActivation } from './preview-terminal-file-links'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 
@@ -24,6 +26,8 @@ type AgentTerminalDialogProps = {
   /** Focus the agent's pane. The pop-out relays over IPC; the in-window host
    *  activates the worktree/pane locally. */
   onReveal: (args: AgentRevealArgs) => void
+  /** Follow a file link in the preview, routed the same two ways as onReveal. */
+  onOpenFile: (args: DashboardOpenFileArgs) => void
 }
 
 type AgentTerminalFrameProps = Omit<AgentTerminalDialogProps, 'card'> & {
@@ -37,8 +41,19 @@ function AgentTerminalFrame({
   title,
   previewClassName,
   onOpenChange,
-  onReveal
+  onReveal,
+  onOpenFile
 }: AgentTerminalFrameProps): React.JSX.Element {
+  const openFileLink = (activation: PreviewFileLinkActivation): void => {
+    onOpenFile({
+      worktreeId: card.worktreeId,
+      executionHostId: card.executionHostId,
+      path: activation.path,
+      line: activation.line,
+      column: activation.column,
+      openWithSystemDefault: activation.openWithSystemDefault
+    })
+  }
   const reveal = (): void => {
     onReveal({
       repoId: card.repoId,
@@ -76,6 +91,7 @@ function AgentTerminalFrame({
         <AgentTerminalPreview
           ptyId={card.ptyId}
           terminalInput={card.terminalInput ?? null}
+          onOpenFileLink={openFileLink}
           className={previewClassName}
         />
       ) : (
@@ -106,7 +122,8 @@ function AgentTerminalFrame({
 export function AgentTerminalDialog({
   card,
   onOpenChange,
-  onReveal
+  onReveal,
+  onOpenFile
 }: AgentTerminalDialogProps): React.JSX.Element {
   return (
     <Dialog open={card !== null} onOpenChange={onOpenChange}>
@@ -145,6 +162,7 @@ export function AgentTerminalDialog({
             }
             onOpenChange={onOpenChange}
             onReveal={onReveal}
+            onOpenFile={onOpenFile}
           />
         </DialogContent>
       ) : null}
@@ -156,6 +174,7 @@ export function AgentTerminalPanel({
   card,
   onOpenChange,
   onReveal,
+  onOpenFile,
   className
 }: Omit<AgentTerminalDialogProps, 'card'> & {
   card: DashboardCard
@@ -197,6 +216,7 @@ export function AgentTerminalPanel({
         previewClassName="h-auto min-h-0 flex-1"
         onOpenChange={onOpenChange}
         onReveal={onReveal}
+        onOpenFile={onOpenFile}
       />
     </section>
   )

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
@@ -3,27 +3,26 @@ import { Terminal } from '@xterm/xterm'
 import '@xterm/xterm/css/xterm.css'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import { subscribeToTerminalUserInput } from '@/components/terminal-pane/terminal-user-input-signal'
-import { composeActiveTerminalTheme } from '@/components/terminal-pane/terminal-appearance'
 import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
 import { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-kitty-keyboard-mode-tracker'
 import { replayPreviewConnectionSnapshot } from './preview-terminal-snapshot-replay'
 import { useEffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/use-effective-mac-option-as-alt'
-import {
-  buildPreviewAppearanceOptions,
-  buildPreviewTerminalOptions
-} from './preview-terminal-options'
-import { syncPreviewTerminalLigatures } from './preview-terminal-ligatures'
+import { buildPreviewTerminalOptions } from './preview-terminal-options'
 import { installPreviewTerminalCompatibility } from './preview-terminal-compatibility'
+import {
+  applyPreviewTerminalAppearance,
+  resolvePreviewTerminalAppearance
+} from './preview-terminal-appearance'
 import { createPreviewClipboardPaster } from './preview-terminal-paste'
 import { installPreviewImeBridge, type PreviewImeBridge } from './preview-terminal-ime-bridge'
 import type { DashboardCardTerminalInput } from '../../../../shared/dashboard-snapshot'
 import { translate } from '@/i18n/i18n'
-import { getBuiltinTheme, resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { installPreviewTerminalKeyHandler } from './preview-terminal-key-handler'
 import { createPreviewGridClaim } from './preview-grid-claim'
 import { installPreviewTerminalAppMenuClipboard } from './preview-terminal-app-menu-clipboard'
+import type { PreviewFileLinkActivation } from './preview-terminal-file-links'
 import type { TerminalPreviewDataPayload } from '../../../../shared/terminal-preview'
 
 const PREVIEW_SCROLLBACK_ROWS = 24
@@ -52,11 +51,15 @@ function clamp(value: number, min: number, max: number): number {
 export function AgentTerminalPreview({
   ptyId,
   terminalInput = null,
+  onOpenFileLink,
   className
 }: {
   ptyId: string
   /** Host-input facts relayed with the card; null routes bytes by client OS. */
   terminalInput?: DashboardCardTerminalInput | null
+  /** Follows a file path the terminal printed. Omitted leaves paths unlinked —
+   *  the preview itself can neither resolve nor open one. */
+  onOpenFileLink?: (activation: PreviewFileLinkActivation) => void
   className?: string
 }): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -69,17 +72,17 @@ export function AgentTerminalPreview({
   const settingsRef = useRef(settings)
   const macOptionAsAltRef = useRef(macOptionAsAlt)
   const terminalInputRef = useRef(terminalInput)
-  const { terminalTheme, terminalMode } = useMemo(() => {
-    if (!settings) {
-      return { terminalTheme: null, terminalMode: 'dark' as const }
-    }
-    const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
-    const theme = composeActiveTerminalTheme(
-      appearance.theme ?? getBuiltinTheme(appearance.themeName),
-      settings
-    )
-    return { terminalTheme: theme, terminalMode: appearance.mode }
-  }, [settings, systemPrefersDark])
+  const onOpenFileLinkRef = useRef(onOpenFileLink)
+  // Whether the host can open a file at all decides whether paths linkify, so
+  // only gaining or losing that capability rebuilds the terminal; which callback
+  // runs is read live through the ref.
+  const fileLinksEnabled = onOpenFileLink !== undefined
+  // Hover hint for the link under the cursor, mirroring a pane's corner tooltip.
+  const [linkHint, setLinkHint] = useState<string | null>(null)
+  const { terminalTheme, terminalMode } = useMemo(
+    () => resolvePreviewTerminalAppearance(settings, systemPrefersDark),
+    [settings, systemPrefersDark]
+  )
   // A null snapshot means no serializer knows this pty (it died or was never
   // spawned this session) — say so instead of painting a silent blank terminal.
   const [ptyGone, setPtyGone] = useState(false)
@@ -92,7 +95,8 @@ export function AgentTerminalPreview({
     settingsRef.current = settings
     macOptionAsAltRef.current = macOptionAsAlt
     terminalInputRef.current = terminalInput
-  }, [settings, macOptionAsAlt, terminalInput])
+    onOpenFileLinkRef.current = onOpenFileLink
+  }, [settings, macOptionAsAlt, terminalInput, onOpenFileLink])
 
   useEffect(() => {
     setPtyGone(false)
@@ -247,7 +251,12 @@ export function AgentTerminalPreview({
         return
       }
       disposeTerminalCompatibility = installPreviewTerminalCompatibility(terminal, {
-        getSettings: () => settingsRef.current
+        getSettings: () => settingsRef.current,
+        openFileLink: fileLinksEnabled
+          ? (activation) => onOpenFileLinkRef.current?.(activation)
+          : undefined,
+        onLinkHover: setLinkHint,
+        onLinkLeave: () => setLinkHint(null)
       })
     }
 
@@ -402,6 +411,7 @@ export function AgentTerminalPreview({
 
     return () => {
       disposed = true
+      setLinkHint(null)
       if (retryTimer) {
         clearTimeout(retryTimer)
       }
@@ -417,21 +427,16 @@ export function AgentTerminalPreview({
       terminal?.dispose()
       terminalRef.current = null
     }
-  }, [ptyId, terminalTheme, terminalMode])
+  }, [ptyId, terminalTheme, terminalMode, fileLinksEnabled])
 
   // Why: appearance settings must land on the open terminal, and the OS input
   // source can flip Option-as-Alt with no settings change at all. A remount
   // would reconnect the pty and repaint the agent's screen from a new snapshot.
   useEffect(() => {
     const terminal = terminalRef.current
-    if (!terminal) {
-      return
+    if (terminal) {
+      applyPreviewTerminalAppearance(terminal, settings, macOptionAsAlt === 'true')
     }
-    Object.assign(
-      terminal.options,
-      buildPreviewAppearanceOptions(settings, macOptionAsAlt === 'true')
-    )
-    syncPreviewTerminalLigatures(terminal, settings)
   }, [settings, macOptionAsAlt])
 
   return (
@@ -460,6 +465,8 @@ export function AgentTerminalPreview({
       >
         <div ref={containerRef} className="origin-bottom-left" />
       </div>
+      {/* Same corner hint a pane shows on link hover (.pane-link-tooltip). */}
+      {linkHint ? <div className="pane-link-tooltip xterm-hover">{linkHint}</div> : null}
     </div>
   )
 }

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-appearance.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-appearance.ts
@@ -1,0 +1,42 @@
+import { composeActiveTerminalTheme } from '@/components/terminal-pane/terminal-appearance'
+import { getBuiltinTheme, resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
+import { buildPreviewAppearanceOptions } from './preview-terminal-options'
+import { syncPreviewTerminalLigatures } from './preview-terminal-ligatures'
+import type { ITheme, Terminal } from '@xterm/xterm'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+
+export type PreviewTerminalAppearance = {
+  terminalTheme: ITheme | null
+  terminalMode: 'dark' | 'light'
+}
+
+/** The pane appearance a preview terminal opens with. Recreating the terminal
+ *  reconnects the pty, so this must resolve to the same value across renders
+ *  that change nothing about the theme. */
+export function resolvePreviewTerminalAppearance(
+  settings: GlobalSettings | null,
+  systemPrefersDark: boolean
+): PreviewTerminalAppearance {
+  if (!settings) {
+    return { terminalTheme: null, terminalMode: 'dark' }
+  }
+  const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
+  return {
+    terminalTheme: composeActiveTerminalTheme(
+      appearance.theme ?? getBuiltinTheme(appearance.themeName),
+      settings
+    ),
+    terminalMode: appearance.mode
+  }
+}
+
+/** Lands changed appearance settings on an already-open preview terminal — a
+ *  remount would reconnect the pty and repaint from a new snapshot. */
+export function applyPreviewTerminalAppearance(
+  terminal: Terminal,
+  settings: GlobalSettings | null,
+  macOptionAsAlt: boolean
+): void {
+  Object.assign(terminal.options, buildPreviewAppearanceOptions(settings, macOptionAsAlt))
+  syncPreviewTerminalLigatures(terminal, settings)
+}

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-compatibility.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-compatibility.ts
@@ -41,8 +41,8 @@ export function installPreviewTerminalCompatibility(
   activateOrcaTerminalUnicodeProvider(terminal)
   installWindowsCtrlAltChordRepair(terminal)
   const linkHover = { hover: deps.onLinkHover, leave: deps.onLinkLeave }
-  installPreviewTerminalLinks(terminal, linkHover)
   const openFileLink = deps.openFileLink
+  installPreviewTerminalLinks(terminal, { ...linkHover, ...(openFileLink ? { openFileLink } : {}) })
   const fileLinks = openFileLink
     ? installPreviewTerminalFileLinks(terminal, { ...linkHover, activate: openFileLink })
     : null

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-compatibility.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-compatibility.ts
@@ -8,19 +8,30 @@ import { configureLazyArabicShapingJoiner } from '@/lib/pane-manager/terminal-ar
 import { installTerminalImeCandidateAnchor } from '@/lib/pane-manager/terminal-ime-candidate-anchor'
 import { normalizeTerminalTuiMouseWheelMultiplier } from '@/lib/pane-manager/pane-terminal-tui-wheel-reports'
 import { installPreviewTerminalLinks } from './preview-terminal-links'
+import {
+  installPreviewTerminalFileLinks,
+  type PreviewFileLinkActivation
+} from './preview-terminal-file-links'
 import { syncPreviewTerminalLigatures } from './preview-terminal-ligatures'
 
 /**
  * Brings the preview's emulator up to a pane's: Orca's Unicode 11 width shim,
- * Windows Ctrl+Alt chord classification, clickable links, ligatures, the TUI
- * wheel multiplier, lazy Arabic shaping, and the IME candidate anchor.
+ * Windows Ctrl+Alt chord classification, clickable URL and file links,
+ * ligatures, the TUI wheel multiplier, lazy Arabic shaping, and the IME
+ * candidate anchor.
  *
  * Returns a disposer for everything bound to the terminal's DOM element, which
  * must run before that terminal is disposed or replaced.
  */
 export function installPreviewTerminalCompatibility(
   terminal: Terminal,
-  deps: { getSettings: () => GlobalSettings | null }
+  deps: {
+    getSettings: () => GlobalSettings | null
+    /** Omitted when the host has no workspace routing to open a file with. */
+    openFileLink?: (activation: PreviewFileLinkActivation) => void
+    onLinkHover?: (text: string) => void
+    onLinkLeave?: () => void
+  }
 ): () => void {
   // Why: the width shim wraps xterm's v11 provider, so the addon that registers
   // it has to load first — and both must precede any replay write, or wide
@@ -29,7 +40,12 @@ export function installPreviewTerminalCompatibility(
   terminal.loadAddon(new Unicode11Addon())
   activateOrcaTerminalUnicodeProvider(terminal)
   installWindowsCtrlAltChordRepair(terminal)
-  installPreviewTerminalLinks(terminal)
+  const linkHover = { hover: deps.onLinkHover, leave: deps.onLinkLeave }
+  installPreviewTerminalLinks(terminal, linkHover)
+  const openFileLink = deps.openFileLink
+  const fileLinks = openFileLink
+    ? installPreviewTerminalFileLinks(terminal, { ...linkHover, activate: openFileLink })
+    : null
   syncPreviewTerminalLigatures(terminal, deps.getSettings())
   attachTerminalMouseWheelMultiplier(terminal, {
     getTuiMouseWheelMultiplier: () =>
@@ -42,6 +58,7 @@ export function installPreviewTerminalCompatibility(
   const imeAnchorHandler = installTerminalImeCandidateAnchor(terminal)
 
   return () => {
+    fileLinks?.dispose()
     if (imeAnchorHandler && terminal.element) {
       terminal.element.removeEventListener('compositionstart', imeAnchorHandler)
       terminal.element.removeEventListener('compositionupdate', imeAnchorHandler)

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-file-links.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-file-links.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ILink, ILinkProvider, Terminal } from '@xterm/xterm'
+import {
+  makeBufferLine,
+  type TestBufferLine
+} from '@/components/terminal-pane/terminal-link-provider-buffer-fixtures'
+import {
+  installPreviewTerminalFileLinks,
+  type PreviewFileLinkActivation
+} from './preview-terminal-file-links'
+
+function installOn(rows: TestBufferLine[]): {
+  links: (bufferLineNumber?: number) => ILink[] | undefined
+  activations: PreviewFileLinkActivation[]
+  hints: string[]
+  clearSelection: ReturnType<typeof vi.fn>
+} {
+  let provider: ILinkProvider | null = null
+  const clearSelection = vi.fn()
+  const terminal = {
+    buffer: { active: { getLine: (y: number) => rows[y] } },
+    registerLinkProvider: (next: ILinkProvider) => {
+      provider = next
+      return { dispose: vi.fn() }
+    },
+    clearSelection
+  } as unknown as Terminal
+  const activations: PreviewFileLinkActivation[] = []
+  const hints: string[] = []
+  installPreviewTerminalFileLinks(terminal, {
+    activate: (activation) => activations.push(activation),
+    hover: (text) => hints.push(text)
+  })
+  return {
+    links: (bufferLineNumber = 1) => {
+      let resolved: ILink[] | undefined
+      provider?.provideLinks(bufferLineNumber, (links) => {
+        resolved = links
+      })
+      return resolved
+    },
+    activations,
+    hints,
+    clearSelection
+  }
+}
+
+function modifierClick(overrides: Partial<MouseEvent> = {}): MouseEvent {
+  // Both modifiers so the assertion holds on every client platform.
+  return {
+    button: 0,
+    ctrlKey: true,
+    metaKey: true,
+    altKey: false,
+    shiftKey: false,
+    preventDefault: vi.fn(),
+    ...overrides
+  } as unknown as MouseEvent
+}
+
+describe('preview terminal file links', () => {
+  it('follows a separator path with its line and column', () => {
+    const preview = installOn([makeBufferLine('  at src/renderer/app.ts:42:7 failed')])
+
+    const links = preview.links()
+    expect(links).toHaveLength(1)
+    links?.[0].activate(modifierClick(), links[0].text)
+
+    expect(preview.activations).toEqual([
+      { path: 'src/renderer/app.ts', line: 42, column: 7, openWithSystemDefault: false }
+    ])
+    expect(preview.clearSelection).toHaveBeenCalled()
+  })
+
+  it('hands the file to the OS default app on Shift+Mod-click, as a pane does', () => {
+    const preview = installOn([makeBufferLine('open ./notes/report.pdf')])
+
+    const links = preview.links()
+    links?.[0].activate(modifierClick({ shiftKey: true }), links[0].text)
+
+    expect(preview.activations[0]?.openWithSystemDefault).toBe(true)
+  })
+
+  it('ignores a plain click so selection and TUI mouse input keep working', () => {
+    const preview = installOn([makeBufferLine('see src/main/index.ts')])
+
+    const links = preview.links()
+    links?.[0].activate(modifierClick({ ctrlKey: false, metaKey: false }), links?.[0].text ?? '')
+
+    expect(preview.activations).toEqual([])
+  })
+
+  it('leaves a bare filename unlinked — the preview cannot resolve it', () => {
+    // A pane promotes `package.json` only once it resolves against the pane cwd.
+    expect(
+      installOn([makeBufferLine('edited package.json and tsconfig.json')]).links()
+    ).toBeUndefined()
+  })
+
+  it('names the gesture on hover so the link is not a dead end', () => {
+    const preview = installOn([makeBufferLine('see src/main/index.ts')])
+
+    const links = preview.links()
+    links?.[0].hover?.(modifierClick(), links[0].text)
+
+    expect(preview.hints[0]).toContain('src/main/index.ts')
+    expect(preview.hints[0]).toContain('click to open')
+  })
+
+  it('spans a soft-wrapped path across rows', () => {
+    const preview = installOn([
+      makeBufferLine('src/renderer/src/components/dashboard-popout/'),
+      makeBufferLine('AgentTerminalPreview.tsx:12', { isWrapped: true })
+    ])
+
+    const links = preview.links(2)
+    expect(links?.[0].text).toContain('AgentTerminalPreview.tsx')
+    expect(links?.[0].range.start.y).toBe(1)
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-file-links.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-file-links.test.ts
@@ -64,7 +64,8 @@ describe('preview terminal file links', () => {
 
     const links = preview.links()
     expect(links).toHaveLength(1)
-    links?.[0].activate(modifierClick(), links[0].text)
+    if (!links || links.length === 0) throw new Error('expected a link')
+    links[0].activate(modifierClick(), links[0].text)
 
     expect(preview.activations).toEqual([
       { path: 'src/renderer/app.ts', line: 42, column: 7, openWithSystemDefault: false }
@@ -76,7 +77,8 @@ describe('preview terminal file links', () => {
     const preview = installOn([makeBufferLine('open ./notes/report.pdf')])
 
     const links = preview.links()
-    links?.[0].activate(modifierClick({ shiftKey: true }), links[0].text)
+    if (!links || links.length === 0) throw new Error('expected a link')
+    links[0].activate(modifierClick({ shiftKey: true }), links[0].text)
 
     expect(preview.activations[0]?.openWithSystemDefault).toBe(true)
   })
@@ -101,7 +103,8 @@ describe('preview terminal file links', () => {
     const preview = installOn([makeBufferLine('see src/main/index.ts')])
 
     const links = preview.links()
-    links?.[0].hover?.(modifierClick(), links[0].text)
+    if (!links || links.length === 0) throw new Error('expected a link')
+    links[0].hover?.(modifierClick(), links[0].text)
 
     expect(preview.hints[0]).toContain('src/main/index.ts')
     expect(preview.hints[0]).toContain('click to open')

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-file-links.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-file-links.ts
@@ -1,0 +1,83 @@
+import type { IDisposable, Terminal } from '@xterm/xterm'
+import { extractTerminalFileLinks, type ParsedTerminalFileLink } from '@/lib/terminal-links'
+import {
+  buildWrappedLogicalLine,
+  rangeForParsedFileLink
+} from '@/components/terminal-pane/wrapped-terminal-link-ranges'
+import { isTerminalLinkDirectActivation } from '@/components/terminal-pane/terminal-link-activation'
+import { getTerminalFileOpenHint } from '@/components/terminal-pane/terminal-link-open-hints'
+
+/** A followed file link, as the agent's terminal printed it. */
+export type PreviewFileLinkActivation = {
+  path: string
+  line: number | null
+  column: number | null
+  /** Shift+Mod-click: hand the file to the OS default app, as a pane does. */
+  openWithSystemDefault: boolean
+}
+
+export type PreviewTerminalFileLinkDeps = {
+  activate: (activation: PreviewFileLinkActivation) => void
+  hover?: (text: string) => void
+  leave?: () => void
+}
+
+// Why: a pane promotes a bare filename to a link only once it resolves against
+// that pane's cwd, which the preview cannot probe — it has neither the pane cwd
+// nor filesystem access to the agent's host. Claiming separator paths only keeps
+// `README` plain text instead of a link that opens nothing.
+function carriesPathSeparator(link: ParsedTerminalFileLink): boolean {
+  return link.pathText.includes('/') || link.pathText.includes('\\')
+}
+
+/**
+ * Makes file paths in the preview clickable under the same Mod+click gesture a
+ * pane uses. Resolving the path against its workspace and opening the editor
+ * both belong to the main renderer, so activation only reports what was
+ * printed — see the `activate` dep.
+ */
+export function installPreviewTerminalFileLinks(
+  terminal: Terminal,
+  deps: PreviewTerminalFileLinkDeps
+): IDisposable {
+  return terminal.registerLinkProvider({
+    provideLinks: (bufferLineNumber, callback) => {
+      const logicalLine = buildWrappedLogicalLine(terminal.buffer.active, bufferLineNumber)
+      if (!logicalLine?.text) {
+        callback(undefined)
+        return
+      }
+      const links = extractTerminalFileLinks(logicalLine.text)
+        .filter(carriesPathSeparator)
+        .flatMap((parsed) => {
+          const range = rangeForParsedFileLink(logicalLine, parsed.startIndex, parsed.endIndex)
+          if (!range) {
+            return []
+          }
+          return [
+            {
+              range,
+              text: parsed.displayText,
+              activate: (event: MouseEvent) => {
+                if (!isTerminalLinkDirectActivation(event)) {
+                  return
+                }
+                event.preventDefault()
+                deps.activate({
+                  path: parsed.pathText,
+                  line: parsed.line,
+                  column: parsed.column,
+                  openWithSystemDefault: event.shiftKey === true
+                })
+                terminal.clearSelection()
+              },
+              hover: () =>
+                deps.hover?.(`${parsed.displayText} (${getTerminalFileOpenHint(false)})`),
+              leave: () => deps.leave?.()
+            }
+          ]
+        })
+      callback(links.length > 0 ? links : undefined)
+    }
+  })
+}

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-links.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-links.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Terminal } from '@xterm/xterm'
+import { installPreviewTerminalLinks } from './preview-terminal-links'
+import type { PreviewFileLinkActivation } from './preview-terminal-file-links'
+
+const openUrl = vi.fn(() => Promise.resolve(true))
+
+vi.mock('@xterm/addon-web-links', () => ({
+  // The addon's regex scan is xterm's business; these tests cover the OSC 8
+  // route, which reaches xterm through options.linkHandler instead.
+  WebLinksAddon: class {
+    dispose(): void {}
+  }
+}))
+vi.mock('@/lib/pane-manager/terminal-link-provider-guard', () => ({
+  installGuardedLinkProviderRegistration: vi.fn()
+}))
+
+function installOn(): {
+  terminal: Terminal
+  fileLinks: PreviewFileLinkActivation[]
+  hints: string[]
+} {
+  const terminal = {
+    options: {} as Terminal['options'],
+    loadAddon: vi.fn(),
+    clearSelection: vi.fn()
+  } as unknown as Terminal
+  const fileLinks: PreviewFileLinkActivation[] = []
+  const hints: string[] = []
+  installPreviewTerminalLinks(terminal, {
+    hover: (text) => hints.push(text),
+    openFileLink: (activation) => fileLinks.push(activation)
+  })
+  return { terminal, fileLinks, hints }
+}
+
+function modifierClick(overrides: Partial<MouseEvent> = {}): MouseEvent {
+  return {
+    button: 0,
+    ctrlKey: true,
+    metaKey: true,
+    altKey: false,
+    shiftKey: false,
+    preventDefault: vi.fn(),
+    ...overrides
+  } as unknown as MouseEvent
+}
+
+describe('preview terminal OSC 8 links', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('window', { api: { shell: { openUrl } } })
+  })
+
+  it('claims OSC 8 links so xterm cannot fall back to its blocked window.open', () => {
+    // Regression: with no linkHandler xterm confirms "this link could
+    // potentially be dangerous" and then opens nothing at all.
+    expect(installOn().terminal.options.linkHandler).toBeTruthy()
+  })
+
+  it('opens an OSC 8 URL in the system browser on Mod+click', () => {
+    const preview = installOn()
+    preview.terminal.options.linkHandler?.activate(
+      modifierClick(),
+      'https://www.figma.com/design/abc',
+      {} as never
+    )
+
+    expect(openUrl).toHaveBeenCalledWith('https://www.figma.com/design/abc')
+  })
+
+  it('ignores a plain click so selection still works', () => {
+    const preview = installOn()
+    preview.terminal.options.linkHandler?.activate(
+      modifierClick({ ctrlKey: false, metaKey: false }),
+      'https://example.com',
+      {} as never
+    )
+
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it('routes a file:// OSC 8 target through the workspace file opener', () => {
+    const preview = installOn()
+    preview.terminal.options.linkHandler?.activate(
+      modifierClick(),
+      'file:///Users/dev/work/src/app%20one.ts',
+      {} as never
+    )
+
+    expect(openUrl).not.toHaveBeenCalled()
+    expect(preview.fileLinks).toEqual([
+      {
+        path: '/Users/dev/work/src/app one.ts',
+        line: null,
+        column: null,
+        openWithSystemDefault: false
+      }
+    ])
+  })
+
+  it('leaves an unknown protocol alone rather than handing it to the OS', () => {
+    const preview = installOn()
+    preview.terminal.options.linkHandler?.activate(
+      modifierClick(),
+      'javascript:alert(1)',
+      {} as never
+    )
+
+    expect(openUrl).not.toHaveBeenCalled()
+    expect(preview.fileLinks).toEqual([])
+  })
+
+  it('names the gesture when hovering an OSC 8 link', () => {
+    const preview = installOn()
+    preview.terminal.options.linkHandler?.hover?.(
+      modifierClick(),
+      'https://example.com',
+      {} as never
+    )
+
+    expect(preview.hints[0]).toContain('https://example.com')
+    expect(preview.hints[0]).toContain('click to open')
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-links.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-links.test.ts
@@ -100,6 +100,24 @@ describe('preview terminal OSC 8 links', () => {
     ])
   })
 
+  it('preserves the host of a UNC file:// target', () => {
+    const preview = installOn()
+    preview.terminal.options.linkHandler?.activate(
+      modifierClick(),
+      'file://server/share/file.ts',
+      {} as never
+    )
+
+    expect(preview.fileLinks).toEqual([
+      {
+        path: '//server/share/file.ts',
+        line: null,
+        column: null,
+        openWithSystemDefault: false
+      }
+    ])
+  })
+
   it('leaves an unknown protocol alone rather than handing it to the OS', () => {
     const preview = installOn()
     preview.terminal.options.linkHandler?.activate(
@@ -122,5 +140,17 @@ describe('preview terminal OSC 8 links', () => {
 
     expect(preview.hints[0]).toContain('https://example.com')
     expect(preview.hints[0]).toContain('click to open')
+  })
+
+  it('describes opening the file, not the browser, when hovering a file:// OSC 8 link', () => {
+    const preview = installOn()
+    preview.terminal.options.linkHandler?.hover?.(
+      modifierClick(),
+      'file:///Users/dev/work/src/app.ts',
+      {} as never
+    )
+
+    expect(preview.hints[0]).toContain('file:///Users/dev/work/src/app.ts')
+    expect(preview.hints[0]).not.toContain('browser')
   })
 })

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-links.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-links.ts
@@ -3,20 +3,57 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import { installGuardedLinkProviderRegistration } from '@/lib/pane-manager/terminal-link-provider-guard'
 import { isTerminalHttpLinkActivation } from '@/components/terminal-pane/terminal-http-link-activation'
 import { getTerminalPreviewUrlOpenHint } from '@/components/terminal-pane/terminal-link-open-hints'
+import type { PreviewFileLinkActivation } from './preview-terminal-file-links'
 
-export type PreviewTerminalLinkHoverDeps = {
+export type PreviewTerminalLinkDeps = {
   hover?: (text: string) => void
   leave?: () => void
+  /** Same opener the file-path provider uses, for `file://` OSC 8 targets. */
+  openFileLink?: (activation: PreviewFileLinkActivation) => void
+}
+
+function openUrlInSystemBrowser(terminal: Terminal, uri: string): void {
+  void window.api.shell.openUrl(uri).catch(() => undefined)
+  terminal.clearSelection()
+}
+
+/** An OSC 8 target Orca is willing to act on. Anything else is left alone
+ *  rather than handed to the OS. */
+function routeOscLinkTarget(text: string): { kind: 'url' } | { kind: 'file'; path: string } | null {
+  let url: URL
+  try {
+    url = new URL(text)
+  } catch {
+    return null
+  }
+  if (url.protocol === 'http:' || url.protocol === 'https:') {
+    return { kind: 'url' }
+  }
+  if (url.protocol === 'file:') {
+    try {
+      return { kind: 'file', path: decodeURIComponent(url.pathname) }
+    } catch {
+      return null
+    }
+  }
+  return null
 }
 
 /**
- * Makes URLs in the preview clickable under the same Mod+click gesture a pane
- * uses. Links always open in the system browser: Orca's in-app browser routing
+ * Makes links in the preview clickable under the same Mod+click gesture a pane
+ * uses. URLs always open in the system browser: Orca's in-app browser routing
  * is workspace-scoped, and the pop-out window hosts no browser pane.
+ *
+ * Covers both link shapes, because they reach xterm by different routes:
+ * plain-text URLs through the web-links addon's regex scan, and OSC 8
+ * hyperlinks (what the agent CLIs actually emit) through `options.linkHandler`.
+ * Leaving the latter unset is not neutral — xterm's built-in fallback confirms
+ * "this link could potentially be dangerous" and then calls `window.open()`,
+ * which Electron blocks, so the click dead-ends on a scary dialog.
  */
 export function installPreviewTerminalLinks(
   terminal: Terminal,
-  deps: PreviewTerminalLinkHoverDeps = {}
+  deps: PreviewTerminalLinkDeps = {}
 ): void {
   // Why: a link provider throwing inside provideLinks (xterm's LinkComputer
   // raises RangeError on pathological wrapped lines) escapes to window.onerror
@@ -29,8 +66,7 @@ export function installPreviewTerminalLinks(
           return
         }
         event.preventDefault()
-        void window.api.shell.openUrl(uri).catch(() => undefined)
-        terminal.clearSelection()
+        openUrlInSystemBrowser(terminal, uri)
       },
       {
         hover: (_event, uri) => {
@@ -42,4 +78,38 @@ export function installPreviewTerminalLinks(
       }
     )
   )
+
+  // Why the guard: `options` is absent on a Terminal stub, and preview setup
+  // runs inside an async boot — a throw here strands the whole terminal.
+  if (!terminal.options) {
+    return
+  }
+  terminal.options.linkHandler = {
+    // Why: `file://` targets are Orca's to route, so the handler must be offered
+    // them rather than only http(s).
+    allowNonHttpProtocols: true,
+    activate: (event, text) => {
+      if (!isTerminalHttpLinkActivation(event as MouseEvent | undefined)) {
+        return
+      }
+      const target = routeOscLinkTarget(text)
+      if (!target) {
+        return
+      }
+      ;(event as MouseEvent | undefined)?.preventDefault?.()
+      if (target.kind === 'url') {
+        openUrlInSystemBrowser(terminal, text)
+        return
+      }
+      deps.openFileLink?.({
+        path: target.path,
+        line: null,
+        column: null,
+        openWithSystemDefault: (event as MouseEvent | undefined)?.shiftKey === true
+      })
+      terminal.clearSelection()
+    },
+    hover: (_event, text) => deps.hover?.(`${text} (${getTerminalPreviewUrlOpenHint()})`),
+    leave: () => deps.leave?.()
+  }
 }

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-links.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-links.ts
@@ -2,25 +2,44 @@ import type { Terminal } from '@xterm/xterm'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { installGuardedLinkProviderRegistration } from '@/lib/pane-manager/terminal-link-provider-guard'
 import { isTerminalHttpLinkActivation } from '@/components/terminal-pane/terminal-http-link-activation'
+import { getTerminalPreviewUrlOpenHint } from '@/components/terminal-pane/terminal-link-open-hints'
+
+export type PreviewTerminalLinkHoverDeps = {
+  hover?: (text: string) => void
+  leave?: () => void
+}
 
 /**
  * Makes URLs in the preview clickable under the same Mod+click gesture a pane
  * uses. Links always open in the system browser: Orca's in-app browser routing
  * is workspace-scoped, and the pop-out window hosts no browser pane.
  */
-export function installPreviewTerminalLinks(terminal: Terminal): void {
+export function installPreviewTerminalLinks(
+  terminal: Terminal,
+  deps: PreviewTerminalLinkHoverDeps = {}
+): void {
   // Why: a link provider throwing inside provideLinks (xterm's LinkComputer
   // raises RangeError on pathological wrapped lines) escapes to window.onerror
   // and kills the renderer — guard before any provider registers.
   installGuardedLinkProviderRegistration(terminal)
   terminal.loadAddon(
-    new WebLinksAddon((event, uri) => {
-      if (!isTerminalHttpLinkActivation(event)) {
-        return
+    new WebLinksAddon(
+      (event, uri) => {
+        if (!isTerminalHttpLinkActivation(event)) {
+          return
+        }
+        event.preventDefault()
+        void window.api.shell.openUrl(uri).catch(() => undefined)
+        terminal.clearSelection()
+      },
+      {
+        hover: (_event, uri) => {
+          if (uri) {
+            deps.hover?.(`${uri} (${getTerminalPreviewUrlOpenHint()})`)
+          }
+        },
+        leave: () => deps.leave?.()
       }
-      event.preventDefault()
-      void window.api.shell.openUrl(uri).catch(() => undefined)
-      terminal.clearSelection()
-    })
+    )
   )
 }

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-links.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-links.ts
@@ -2,7 +2,11 @@ import type { Terminal } from '@xterm/xterm'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { installGuardedLinkProviderRegistration } from '@/lib/pane-manager/terminal-link-provider-guard'
 import { isTerminalHttpLinkActivation } from '@/components/terminal-pane/terminal-http-link-activation'
-import { getTerminalPreviewUrlOpenHint } from '@/components/terminal-pane/terminal-link-open-hints'
+import {
+  getTerminalFileOpenHint,
+  getTerminalPreviewUrlOpenHint
+} from '@/components/terminal-pane/terminal-link-open-hints'
+import { fileUriToFilesystemPath } from '../../../../shared/file-uri-path'
 import type { PreviewFileLinkActivation } from './preview-terminal-file-links'
 
 export type PreviewTerminalLinkDeps = {
@@ -30,11 +34,8 @@ function routeOscLinkTarget(text: string): { kind: 'url' } | { kind: 'file'; pat
     return { kind: 'url' }
   }
   if (url.protocol === 'file:') {
-    try {
-      return { kind: 'file', path: decodeURIComponent(url.pathname) }
-    } catch {
-      return null
-    }
+    const path = fileUriToFilesystemPath(url)
+    return path ? { kind: 'file', path } : null
   }
   return null
 }
@@ -109,7 +110,13 @@ export function installPreviewTerminalLinks(
       })
       terminal.clearSelection()
     },
-    hover: (_event, text) => deps.hover?.(`${text} (${getTerminalPreviewUrlOpenHint()})`),
+    hover: (_event, text) => {
+      const hint =
+        routeOscLinkTarget(text)?.kind === 'file'
+          ? getTerminalFileOpenHint(false)
+          : getTerminalPreviewUrlOpenHint()
+      deps.hover?.(`${text} (${hint})`)
+    },
     leave: () => deps.leave?.()
   }
 }

--- a/src/renderer/src/components/dashboard/AgentDashboardDrawer.tsx
+++ b/src/renderer/src/components/dashboard/AgentDashboardDrawer.tsx
@@ -13,6 +13,7 @@ import {
   WORKSPACE_TOP_CHROME_HEIGHT
 } from '../sidebar/workspace-chrome-metrics'
 import { AgentDashboardSettingsMenu } from './AgentDashboardSettingsMenu'
+import { openDashboardFileLink } from './open-dashboard-file-link'
 import { useLiveDashboardSnapshot } from './useLiveDashboardSnapshot'
 import { translate } from '@/i18n/i18n'
 
@@ -54,6 +55,10 @@ function AgentDashboardDrawerBody({
     [onClose]
   )
 
+  // A preview file link opens right here: this window already owns the
+  // workspace paths and the editor the pop-out has to relay for.
+  const handleOpenFile = useCallback(openDashboardFileLink, [])
+
   // Switching to pop-out from the board hands the surface over rather than
   // leaving an in-window board that the setting says should be a window.
   const handleSwitchToPopout = useCallback(() => {
@@ -69,6 +74,7 @@ function AgentDashboardDrawerBody({
       containerClassName="h-full w-full bg-transparent"
       onAckAgent={handleAckAgent}
       onRevealAgent={handleRevealAgent}
+      onOpenFile={handleOpenFile}
       onClose={onClose}
       headerActions={
         <AgentDashboardSettingsMenu

--- a/src/renderer/src/components/dashboard/open-dashboard-file-link.test.ts
+++ b/src/renderer/src/components/dashboard/open-dashboard-file-link.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { openDetectedFilePath, getKnownWorktreeById, resolvePaneWslDistro, getConnectionId } =
+  vi.hoisted(() => ({
+    openDetectedFilePath: vi.fn(),
+    getKnownWorktreeById: vi.fn((): { id: string; path: string } | undefined => ({
+      id: 'wt-1',
+      path: '/Users/dev/work/feature'
+    })),
+    resolvePaneWslDistro: vi.fn((): string | null => null),
+    getConnectionId: vi.fn((): string | null => null)
+  }))
+
+vi.mock('@/components/terminal-pane/terminal-link-handlers', () => ({ openDetectedFilePath }))
+vi.mock('@/components/terminal-pane/terminal-pane-wsl-distro', () => ({ resolvePaneWslDistro }))
+vi.mock('@/lib/connection-context', () => ({ getConnectionId }))
+vi.mock('@/store', () => ({
+  useAppStore: { getState: () => ({ getKnownWorktreeById }) }
+}))
+
+import { openDashboardFileLink } from './open-dashboard-file-link'
+
+describe('openDashboardFileLink', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getKnownWorktreeById.mockReturnValue({ id: 'wt-1', path: '/Users/dev/work/feature' })
+    resolvePaneWslDistro.mockReturnValue(null)
+    getConnectionId.mockReturnValue(null)
+  })
+
+  it('resolves a printed relative path against the card workspace', () => {
+    openDashboardFileLink({
+      worktreeId: 'wt-1',
+      path: 'src/app.ts',
+      line: 12,
+      column: 3
+    })
+
+    expect(getKnownWorktreeById).toHaveBeenCalledWith('wt-1', undefined)
+    expect(openDetectedFilePath).toHaveBeenCalledWith(
+      '/Users/dev/work/feature/src/app.ts',
+      12,
+      3,
+      expect.objectContaining({
+        worktreeId: 'wt-1',
+        worktreePath: '/Users/dev/work/feature',
+        runtimeEnvironmentId: null,
+        openWithSystemDefault: false
+      })
+    )
+  })
+
+  it('keeps an absolute path as the terminal printed it', () => {
+    openDashboardFileLink({
+      worktreeId: 'wt-1',
+      path: '/etc/hosts',
+      line: null,
+      column: null,
+      openWithSystemDefault: true
+    })
+
+    expect(openDetectedFilePath).toHaveBeenCalledWith(
+      '/etc/hosts',
+      null,
+      null,
+      expect.objectContaining({ openWithSystemDefault: true })
+    )
+  })
+
+  it('routes a runtime-hosted card to its runtime environment', () => {
+    openDashboardFileLink({
+      worktreeId: 'wt-1',
+      executionHostId: 'runtime:box-7',
+      path: 'src/app.ts',
+      line: null,
+      column: null
+    })
+
+    expect(getKnownWorktreeById).toHaveBeenCalledWith('wt-1', 'runtime:box-7')
+    expect(openDetectedFilePath).toHaveBeenCalledWith(
+      '/Users/dev/work/feature/src/app.ts',
+      null,
+      null,
+      expect.objectContaining({ runtimeEnvironmentId: 'box-7' })
+    )
+  })
+
+  it('never lets a local WSL distro rewrite an SSH workspace path', () => {
+    getConnectionId.mockReturnValue('ssh-target-2')
+
+    openDashboardFileLink({
+      worktreeId: 'wt-1',
+      executionHostId: 'ssh:ssh-target-2',
+      path: 'src/app.ts',
+      line: null,
+      column: null
+    })
+
+    expect(resolvePaneWslDistro).not.toHaveBeenCalled()
+    expect(openDetectedFilePath).toHaveBeenCalledWith(
+      expect.any(String),
+      null,
+      null,
+      expect.objectContaining({ wslDistro: null })
+    )
+  })
+
+  it('still opens an absolute path when the workspace is no longer known', () => {
+    getKnownWorktreeById.mockReturnValue(undefined)
+
+    openDashboardFileLink({
+      worktreeId: 'gone',
+      path: '/Users/dev/work/feature/src/app.ts',
+      line: null,
+      column: null
+    })
+
+    expect(openDetectedFilePath).toHaveBeenCalledWith(
+      '/Users/dev/work/feature/src/app.ts',
+      null,
+      null,
+      expect.objectContaining({ worktreePath: '' })
+    )
+  })
+})

--- a/src/renderer/src/components/dashboard/open-dashboard-file-link.ts
+++ b/src/renderer/src/components/dashboard/open-dashboard-file-link.ts
@@ -1,0 +1,37 @@
+import type { DashboardOpenFileArgs } from '../../../../shared/dashboard-snapshot'
+import { parseExecutionHostId } from '../../../../shared/execution-host'
+import { openDetectedFilePath } from '@/components/terminal-pane/terminal-link-handlers'
+import { resolvePaneWslDistro } from '@/components/terminal-pane/terminal-pane-wsl-distro'
+import { getConnectionId } from '@/lib/connection-context'
+import { resolveExplicitFileLinkTargetPath } from '@/lib/explicit-file-link-target'
+import { useAppStore } from '@/store'
+
+/**
+ * Follows a file path a dashboard preview terminal linkified. Runs in the MAIN
+ * window for both hosts — the in-window drawer calls it directly, the pop-out
+ * relays over IPC — because only this window owns the workspace paths and the
+ * editor. Resolution and host routing are the pane link's own, so a dashboard
+ * link and a pane link land in the same place.
+ */
+export function openDashboardFileLink(args: DashboardOpenFileArgs): void {
+  const state = useAppStore.getState()
+  // Host-qualified: the same worktree id can exist on several hosts, and a
+  // folder workspace is not in worktreesByRepo at all.
+  const worktreePath = state.getKnownWorktreeById(args.worktreeId, args.executionHostId)?.path ?? ''
+  const absolutePath = worktreePath
+    ? resolveExplicitFileLinkTargetPath(args.path, worktreePath)
+    : args.path
+  if (!absolutePath) {
+    return
+  }
+  const host = parseExecutionHostId(args.executionHostId)
+  openDetectedFilePath(absolutePath, args.line, args.column, {
+    worktreeId: args.worktreeId,
+    worktreePath,
+    runtimeEnvironmentId: host?.kind === 'runtime' ? host.environmentId : null,
+    wslDistro: getConnectionId(args.worktreeId)
+      ? null
+      : resolvePaneWslDistro(state, args.worktreeId, worktreePath),
+    openWithSystemDefault: args.openWithSystemDefault === true
+  })
+}

--- a/src/renderer/src/components/dashboard/useDashboardPopoutBridge.ts
+++ b/src/renderer/src/components/dashboard/useDashboardPopoutBridge.ts
@@ -5,6 +5,7 @@ import { runSleepWorktree } from '../sidebar/sleep-worktree-flow'
 import type { RepoIcon } from '../../../../shared/repo-icon'
 import { buildDashboardSnapshot, type DashboardSnapshotState } from './build-dashboard-snapshot'
 import { launchDashboardAgent } from './launch-dashboard-agent'
+import { openDashboardFileLink } from './open-dashboard-file-link'
 
 // Why: cap snapshot rebuilds during bursts of agent-status pings. The board is a
 // glanceable surface, so ~4 updates/sec is plenty and keeps the cross-worktree
@@ -105,7 +106,8 @@ function watchSnapshotInputs(onChanged: () => void): () => void {
  *     store and publish it to the main process (which relays it to the popout).
  *     Does nothing while the popout is closed, so it's free in the common case.
  *  2. Handle click-to-focus reveal requests forwarded from the popout: activate
- *     the agent's worktree and focus its pane in this (main) window.
+ *     the agent's worktree and focus its pane in this (main) window, and open
+ *     files its preview terminals linkified.
  */
 export function useDashboardPopoutBridge(enabled: boolean): void {
   useEffect(() => {
@@ -134,6 +136,15 @@ export function useDashboardPopoutBridge(enabled: boolean): void {
       useAppStore.getState().setActiveWorktree(args.worktreeId, args.executionHostId)
       activateTabAndFocusPane(args.tabId, args.leafId, { flashFocusedPane: true })
     })
+  }, [enabled])
+
+  // Following a file link in a pop-out preview opens the file here, where the
+  // workspace paths and the editor live.
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+    return window.api.dashboard.onOpenFile?.(openDashboardFileLink)
   }, [enabled])
 
   // Opening a card's terminal dialog in the popout acks the agent here — the

--- a/src/renderer/src/components/terminal-pane/terminal-link-open-hints.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-open-hints.ts
@@ -89,6 +89,12 @@ export function getTerminalUrlOpenHint(options: TerminalUrlOpenHintOptions = {})
     : `${prefix}Ctrl+click to open, or Shift+Ctrl+click for system browser`
 }
 
+// Why: the dashboard's preview terminal has no in-app browser to route to, so
+// its hint names only the gesture that works there.
+export function getTerminalPreviewUrlOpenHint(): string {
+  return isMacPlatform() ? '⌘+click to open in browser' : 'Ctrl+click to open in browser'
+}
+
 export function getTerminalUrlSystemBrowserHint(): string {
   return isMacPlatform() ? '⇧⌘+click for system browser' : 'Shift+Ctrl+click for system browser'
 }

--- a/src/shared/dashboard-snapshot.ts
+++ b/src/shared/dashboard-snapshot.ts
@@ -234,3 +234,21 @@ export type DashboardSpawnAgentArgs = {
 export type DashboardSleepWorkspaceArgs = {
   worktreeId: string
 }
+
+/** Longest printed path the file-link bridge accepts; the main-process
+ *  validator enforces it so a pathological TUI line cannot cross the bridge. */
+export const DASHBOARD_MAX_FILE_LINK_PATH_LENGTH = 4_096
+
+/** Opens a file path a preview terminal linkified. Resolution against the
+ *  workspace, host routing and the editor all live in the main renderer, so the
+ *  pop-out only names the workspace and the path exactly as the agent printed
+ *  it — the pop-out has no worktree paths and no editor of its own. */
+export type DashboardOpenFileArgs = {
+  worktreeId: string
+  executionHostId?: ExecutionHostId
+  path: string
+  line: number | null
+  column: number | null
+  /** Shift+Mod-click hands the file to the OS default app, as a pane does. */
+  openWithSystemDefault?: boolean
+}


### PR DESCRIPTION
## Problem

The agent dashboard's preview terminal linkifies URLs but nothing else. Mod+clicking a file path an agent just printed — the single most common thing you want to follow from a dashboard card — does nothing at all, in both the in-window drawer and the pop-out window.

## What this does

Adds a file-path link provider to the preview terminal under the same `Mod+click` / `Shift+Mod+click` gesture its URL links already use, and routes activation to the main window, which owns the workspace paths and the editor:

- **in-window drawer** → calls `openDashboardFileLink` directly
- **pop-out window** → relays `dashboardPopout:openFile` over IPC, gated on the pop-out renderer and validated like every other pop-out channel, then raises the main window exactly as click-to-focus does

Resolution and host routing are the pane link's own code (`openDetectedFilePath`), so a dashboard link and a pane link land in the same place — including SSH, runtime and WSL workspaces, folder workspaces, and host-qualified worktree ids.

Links now also show the pane's corner hover hint (`.pane-link-tooltip`) naming the gesture, for URLs as well as files, so the affordance is no longer silent.

## Deliberate limits

- **Bare filenames stay plain text.** A pane promotes `package.json` to a link only once it resolves against that pane's cwd; the preview has neither the pane cwd nor filesystem access to the agent's host, so it claims separator paths only rather than offering links that open nothing.
- **No action popover.** The plain-click popover is pane-bound (pane id, pty-mouse claim, settings store), and the pop-out renderer has no settings surface to route its gear to. The modifier gestures are covered.

## Test plan

- `preview-terminal-file-links.test.ts` — separator paths linkify with line/column, bare filenames do not, plain click is ignored so selection and TUI mouse input keep working, Shift+Mod sets the OS-default flag, soft-wrapped paths span rows, hover names the gesture
- `open-dashboard-file-link.test.ts` — relative paths resolve against the card's workspace, absolute paths pass through, runtime hosts route to their environment, a local WSL distro never rewrites an SSH path, an unknown workspace still opens an absolute path
- `dashboard-file-link-payload-validation` + `dashboard-popout` IPC tests — payload bounds and the trusted-sender gate
- `pnpm tc` clean; 3723 tests pass across `src/main/ipc`, `src/renderer/src/components/dashboard`, `src/renderer/src/components/dashboard-popout`

Manual: Mod+click a path in a card's preview in both the drawer and the pop-out — the file opens in the main window's editor at the reported line; Shift+Mod hands it to the OS default app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPufeXGY5CUNNeDfRpjRPu