### PR TITLE
feat(dashboard): stop an agent from the board without opening its worktree

### DIFF
--- a/src/main/ipc/dashboard-payload-validation.ts
+++ b/src/main/ipc/dashboard-payload-validation.ts
@@ -20,6 +20,7 @@ import {
 } from './dashboard-workspace-payload-validation'
 import { isDashboardFilterOptions } from './dashboard-filter-payload-validation'
 export { isDashboardSpawnAgentArgs } from './dashboard-agent-launch-validation'
+export { isDashboardStopAgentArgs } from './dashboard-stop-agent-validation'
 
 const MAX_DASHBOARD_CARDS = 1_000
 const MAX_DASHBOARD_SUBAGENTS = 100

--- a/src/main/ipc/dashboard-popout.test.ts
+++ b/src/main/ipc/dashboard-popout.test.ts
@@ -282,6 +282,41 @@ describe('registerDashboardPopoutHandlers', () => {
     expect(sendToTrustedMock).toHaveBeenCalledWith('ui:sleepDashboardWorkspace', args)
   })
 
+  it('relays valid stop requests from only the popout, without raising the main window', () => {
+    const args = {
+      paneKey: 'tab1:leaf1',
+      worktreeId: 'w1',
+      tabId: 't1',
+      leafId: 'l1',
+      ptyId: 'pty1'
+    }
+
+    handlers.get('dashboardPopout:stopAgent')!({ sender: untrustedSender } as never, args)
+    handlers.get('dashboardPopout:stopAgent')!({ sender: popoutSender } as never, {
+      ...args,
+      paneKey: ''
+    })
+    expect(sendToTrustedMock).not.toHaveBeenCalled()
+
+    handlers.get('dashboardPopout:stopAgent')!({ sender: popoutSender } as never, args)
+    expect(sendToTrustedMock).toHaveBeenCalledWith('ui:stopDashboardAgent', args)
+    // Stopping must not pull the user off the board.
+    expect(safelyRevealMock).not.toHaveBeenCalled()
+    expect(appMock.focus).not.toHaveBeenCalled()
+  })
+
+  it('accepts a stop request for a retained card with no live pane', () => {
+    const args = {
+      paneKey: 'tab1:leaf1',
+      worktreeId: 'w1',
+      tabId: 't1',
+      leafId: null,
+      ptyId: null
+    }
+
+    handlers.get('dashboardPopout:stopAgent')!({ sender: popoutSender } as never, args)
+    expect(sendToTrustedMock).toHaveBeenCalledWith('ui:stopDashboardAgent', args)
+  })
   it('reveals an agent in only the trusted main window', () => {
     const main = makeWindow(mainSender)
     getTrustedWindowMock.mockReturnValue(main)

--- a/src/main/ipc/dashboard-popout.ts
+++ b/src/main/ipc/dashboard-popout.ts
@@ -17,7 +17,8 @@ import {
   isDashboardPaneKey,
   isDashboardRevealAgentArgs,
   isDashboardSleepWorkspaceArgs,
-  isDashboardSpawnAgentArgs
+  isDashboardSpawnAgentArgs,
+  isDashboardStopAgentArgs
 } from './dashboard-payload-validation'
 
 // The most recent snapshot the main renderer published, replayed to the popout
@@ -41,6 +42,7 @@ export function registerDashboardPopoutHandlers(
   ipcMain.removeHandler('dashboardPopout:ackAgent')
   ipcMain.removeHandler('dashboardPopout:spawnAgent')
   ipcMain.removeHandler('dashboardPopout:sleepWorkspace')
+  ipcMain.removeHandler('dashboardPopout:stopAgent')
 
   onDashboardPopoutOpenChanged((open) => {
     if (!open) {
@@ -126,6 +128,20 @@ export function registerDashboardPopoutHandlers(
       return
     }
     sendToTrustedUIRenderer('ui:ackDashboardAgent', (args as { paneKey: string }).paneKey)
+  })
+
+  // Stop-from-board: the main renderer owns the terminal/pty teardown, so relay
+  // the request to it. Deliberately does NOT raise the main window — the whole
+  // point is clearing an agent without leaving the board.
+  ipcMain.handle('dashboardPopout:stopAgent', (event, args: unknown): void => {
+    if (
+      !isDashboardPopoutRenderer(event.sender) ||
+      !isDashboardEnabled(store) ||
+      !isDashboardStopAgentArgs(args)
+    ) {
+      return
+    }
+    sendToTrustedUIRenderer('ui:stopDashboardAgent', args)
   })
 
   // Click-to-focus: raise the main window and route it to the agent's pane.

--- a/src/main/ipc/dashboard-stop-agent-validation.ts
+++ b/src/main/ipc/dashboard-stop-agent-validation.ts
@@ -1,0 +1,21 @@
+import type { DashboardStopAgentArgs } from '../../shared/dashboard-snapshot'
+
+const MAX_ID_LENGTH = 4_096
+
+function isBoundedId(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= MAX_ID_LENGTH
+}
+
+export function isDashboardStopAgentArgs(value: unknown): value is DashboardStopAgentArgs {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const args = value as Record<string, unknown>
+  return (
+    isBoundedId(args.paneKey) &&
+    isBoundedId(args.worktreeId) &&
+    isBoundedId(args.tabId) &&
+    (args.leafId === null || isBoundedId(args.leafId)) &&
+    (args.ptyId === null || isBoundedId(args.ptyId))
+  )
+}

--- a/src/preload/api/dashboard-api.ts
+++ b/src/preload/api/dashboard-api.ts
@@ -2,7 +2,8 @@ import type {
   DashboardRevealAgentArgs,
   DashboardSleepWorkspaceArgs,
   DashboardSnapshot,
-  DashboardSpawnAgentArgs
+  DashboardSpawnAgentArgs,
+  DashboardStopAgentArgs
 } from '../../shared/dashboard-snapshot'
 import type {
   TerminalPreviewConnectResult,
@@ -17,6 +18,7 @@ export type DashboardApi = {
   onSnapshotRequested: (callback: () => void) => () => void
   onRevealAgent: (callback: (args: DashboardRevealAgentArgs) => void) => () => void
   onAckAgent: (callback: (paneKey: string) => void) => () => void
+  onStopAgent: (callback: (args: DashboardStopAgentArgs) => void) => () => void
   onSpawnAgent: (callback: (args: DashboardSpawnAgentArgs) => void) => () => void
   onSleepWorkspace: (callback: (args: DashboardSleepWorkspaceArgs) => void) => () => void
   requestSnapshot: () => Promise<void>
@@ -24,6 +26,7 @@ export type DashboardApi = {
   onViewRequested: (callback: (view: 'board' | 'map') => void) => () => void
   revealAgent: (args: DashboardRevealAgentArgs) => Promise<void>
   ackAgent: (paneKey: string) => Promise<void>
+  stopAgent: (args: DashboardStopAgentArgs) => Promise<void>
   spawnAgent: (args: DashboardSpawnAgentArgs) => Promise<void>
   sleepWorkspace: (args: DashboardSleepWorkspaceArgs) => Promise<void>
 }

--- a/src/preload/api/dashboard-bridge.ts
+++ b/src/preload/api/dashboard-bridge.ts
@@ -3,7 +3,8 @@ import type {
   DashboardRevealAgentArgs,
   DashboardSleepWorkspaceArgs,
   DashboardSnapshot,
-  DashboardSpawnAgentArgs
+  DashboardSpawnAgentArgs,
+  DashboardStopAgentArgs
 } from '../../shared/dashboard-snapshot'
 import type { PreloadApi } from '../api-types'
 
@@ -37,6 +38,12 @@ export const dashboardApi = {
     ipcRenderer.on('ui:ackDashboardAgent', listener)
     return () => ipcRenderer.removeListener('ui:ackDashboardAgent', listener)
   },
+  onStopAgent: (callback: (args: DashboardStopAgentArgs) => void): (() => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, args: DashboardStopAgentArgs): void =>
+      callback(args)
+    ipcRenderer.on('ui:stopDashboardAgent', listener)
+    return () => ipcRenderer.removeListener('ui:stopDashboardAgent', listener)
+  },
   onSpawnAgent: (callback: (args: DashboardSpawnAgentArgs) => void): (() => void) => {
     const listener = (_event: Electron.IpcRendererEvent, args: DashboardSpawnAgentArgs): void =>
       callback(args)
@@ -68,6 +75,8 @@ export const dashboardApi = {
     ipcRenderer.invoke('dashboardPopout:revealAgent', args),
   ackAgent: (paneKey: string): Promise<void> =>
     ipcRenderer.invoke('dashboardPopout:ackAgent', { paneKey }),
+  stopAgent: (args: DashboardStopAgentArgs): Promise<void> =>
+    ipcRenderer.invoke('dashboardPopout:stopAgent', args),
   spawnAgent: (args: DashboardSpawnAgentArgs): Promise<void> =>
     ipcRenderer.invoke('dashboardPopout:spawnAgent', args),
   sleepWorkspace: (args: DashboardSleepWorkspaceArgs): Promise<void> =>

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.test.tsx
@@ -19,23 +19,28 @@ vi.mock('./AgentKanbanCard', () => ({
     card,
     repoIcon,
     now,
-    onOpenTerminal
+    onOpenTerminal,
+    onStop
   }: {
     card: DashboardCard
     repoIcon?: RepoIcon | null
     now: number
     onOpenTerminal: (card: DashboardCard) => void
+    onStop: (card: DashboardCard) => void
   }) => (
-    <div
-      data-testid="card"
-      data-bucket={card.bucket}
-      data-unseen={card.unseen}
-      data-now={now}
-      data-repo-icon={repoIcon === null ? 'none' : JSON.stringify(repoIcon)}
-      onClick={() => onOpenTerminal(card)}
-    >
-      {card.worktreeName}
-    </div>
+    <>
+      <div
+        data-testid="card"
+        data-bucket={card.bucket}
+        data-unseen={card.unseen}
+        data-now={now}
+        data-repo-icon={repoIcon === null ? 'none' : JSON.stringify(repoIcon)}
+        onClick={() => onOpenTerminal(card)}
+      >
+        {card.worktreeName}
+      </div>
+      <button data-testid="stop-card" onClick={() => onStop(card)} />
+    </>
   )
 }))
 vi.mock('./AgentTerminalDialog', () => ({
@@ -55,6 +60,20 @@ vi.mock('./AgentTerminalDialog', () => ({
       <button data-testid="terminal-dialog-close" onClick={() => onOpenChange(false)} />
     </div>
   )
+}))
+vi.mock('./AgentStopConfirmDialog', () => ({
+  AgentStopConfirmDialog: ({
+    card,
+    onConfirm
+  }: {
+    card: DashboardCard | null
+    onConfirm: () => void
+  }) =>
+    card ? (
+      <div data-testid="stop-dialog" data-pty-id={card.ptyId ?? undefined}>
+        <button data-testid="stop-confirm" onClick={onConfirm} />
+      </div>
+    ) : null
 }))
 
 function card(overrides: Partial<DashboardCard>): DashboardCard {
@@ -92,6 +111,7 @@ function renderBoard(
 }
 
 const ackAgent = vi.fn(async () => {})
+const stopAgent = vi.fn(async () => {})
 
 describe('AgentKanbanBoard', () => {
   beforeEach(async () => {
@@ -102,7 +122,7 @@ describe('AgentKanbanBoard', () => {
       vi.fn(() => ({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() }))
     )
     // The board relays seen-acks through the dashboard preload API.
-    ;(window as unknown as { api: unknown }).api = { dashboard: { ackAgent } }
+    ;(window as unknown as { api: unknown }).api = { dashboard: { ackAgent, stopAgent } }
   })
   afterEach(() => {
     cleanup()
@@ -310,6 +330,39 @@ describe('AgentKanbanBoard', () => {
     rerender(<AgentKanbanBoard snapshot={{ generatedAt: 3, cards: [] }} />)
     expect(screen.getByTestId('terminal-dialog').dataset.open).toBe('true')
     expect(screen.getByTestId('terminal-dialog').dataset.ptyId).toBeUndefined()
+  })
+
+  it('re-resolves a pending stop against the live card before confirming', () => {
+    const agent = card({ paneKey: 'pk-stop', ptyId: 'pty-old', dotState: 'working' })
+    const { rerender } = render(<AgentKanbanBoard snapshot={{ generatedAt: 1, cards: [agent] }} />)
+
+    fireEvent.click(screen.getByTestId('stop-card'))
+    expect(screen.getByTestId('stop-dialog').dataset.ptyId).toBe('pty-old')
+
+    const moved = { ...agent, ptyId: 'pty-new', leafId: 'leaf-new' }
+    rerender(<AgentKanbanBoard snapshot={{ generatedAt: 2, cards: [moved] }} />)
+    expect(screen.getByTestId('stop-dialog').dataset.ptyId).toBe('pty-new')
+
+    fireEvent.click(screen.getByTestId('stop-confirm'))
+    expect(stopAgent).toHaveBeenCalledWith({
+      paneKey: 'pk-stop',
+      worktreeId: 'w1',
+      tabId: 'tab1',
+      leafId: 'leaf-new',
+      ptyId: 'pty-new'
+    })
+  })
+
+  it('closes a pending stop when its card disappears', () => {
+    const agent = card({ paneKey: 'pk-gone', ptyId: 'pty-gone', dotState: 'working' })
+    const { rerender } = render(<AgentKanbanBoard snapshot={{ generatedAt: 1, cards: [agent] }} />)
+
+    fireEvent.click(screen.getByTestId('stop-card'))
+    expect(screen.getByTestId('stop-dialog')).toBeInTheDocument()
+
+    rerender(<AgentKanbanBoard snapshot={{ generatedAt: 2, cards: [] }} />)
+    expect(screen.queryByTestId('stop-dialog')).not.toBeInTheDocument()
+    expect(stopAgent).not.toHaveBeenCalled()
   })
 
   it('relays a seen-ack when a dialog opens and when the open agent changes state', () => {

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.tsx
@@ -6,12 +6,13 @@ import {
   type DashboardCard,
   type DashboardSnapshot
 } from '../../../../shared/dashboard-snapshot'
-import type { RepoIcon } from '../../../../shared/repo-icon'
 import { cn } from '@/lib/utils'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
-import { AgentKanbanCard } from './AgentKanbanCard'
+import { AgentKanbanColumn } from './AgentKanbanColumn'
 import { AgentDashboardToolbar } from './AgentDashboardToolbar'
+import { stopNeedsDialog } from './AgentKanbanCardStopControl'
+import { AgentStopConfirmDialog } from './AgentStopConfirmDialog'
 import { AgentTerminalDialog, type AgentRevealArgs } from './AgentTerminalDialog'
 import {
   EMPTY_DASHBOARD_FILTERS,
@@ -35,19 +36,6 @@ function revealAgentViaPopoutRelay(args: AgentRevealArgs): void {
   void window.api.dashboard.revealAgent?.(args)
 }
 
-function bucketLabel(bucket: DashboardBucket): string {
-  switch (bucket) {
-    case 'attention':
-      return translate('dashboardPopout.bucket.attention', 'Needs You')
-    case 'working':
-      return translate('dashboardPopout.bucket.working', 'Working')
-    case 'done':
-      return translate('dashboardPopout.bucket.done', 'Done')
-    case 'idle':
-      return translate('dashboardPopout.bucket.idle', 'Idle')
-  }
-}
-
 function groupByBucket(cards: DashboardCard[]): Record<DashboardBucket, DashboardCard[]> {
   const grouped: Record<DashboardBucket, DashboardCard[]> = {
     attention: [],
@@ -64,52 +52,6 @@ function groupByBucket(cards: DashboardCard[]): Record<DashboardBucket, Dashboar
     grouped[bucket].sort((a, b) => b.stateChangedAt - a.stateChangedAt)
   }
   return grouped
-}
-
-function KanbanColumn({
-  bucket,
-  cards,
-  repoIconsByRepoId,
-  now,
-  onOpenTerminal
-}: {
-  bucket: DashboardBucket
-  cards: DashboardCard[]
-  repoIconsByRepoId: Record<string, RepoIcon | null> | undefined
-  now: number
-  onOpenTerminal: (card: DashboardCard) => void
-}): React.JSX.Element {
-  return (
-    // Why: attention no longer tints the whole column — the cards inside carry
-    // their own state color, so a column border would double-signal it.
-    <section className="flex min-w-[264px] flex-1 flex-col rounded-xl border border-border/60 bg-muted/30">
-      <header className="flex items-center gap-2 px-3 py-2">
-        <span className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
-          {bucketLabel(bucket)}
-        </span>
-        <span className="ml-auto rounded-full bg-background px-1.5 text-[11px] tabular-nums text-muted-foreground">
-          {cards.length}
-        </span>
-      </header>
-      <div className="scrollbar-sleek flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 pb-2">
-        {cards.length === 0 ? (
-          <p className="px-1 py-2 text-[11px] text-muted-foreground">
-            {translate('dashboardPopout.bucket.empty', 'None')}
-          </p>
-        ) : (
-          cards.map((card) => (
-            <AgentKanbanCard
-              key={card.paneKey}
-              card={card}
-              repoIcon={repoIconsByRepoId?.[card.repoId] ?? null}
-              now={now}
-              onOpenTerminal={onOpenTerminal}
-            />
-          ))
-        )}
-      </div>
-    </section>
-  )
 }
 
 type AgentKanbanBoardProps = {
@@ -229,6 +171,45 @@ export function AgentKanbanBoard({
     },
     [onAckAgent]
   )
+
+  // Stopping kills the agent's process in the main renderer, which owns the
+  // store and the terminal teardown. Still-running agents confirm through a
+  // dialog first; idle/done ones already confirmed inline on their card.
+  const [pendingStopPaneKey, setPendingStopPaneKey] = useState<string | null>(null)
+  const resolvedPendingStopCard = useMemo(() => {
+    if (!pendingStopPaneKey) {
+      return null
+    }
+    return snapshot.cards.find((card) => card.paneKey === pendingStopPaneKey) ?? null
+  }, [pendingStopPaneKey, snapshot.cards])
+  // ?. shields this from dev-HMR preload skew, same as the ack relay above.
+  const emitStop = useCallback((card: DashboardCard) => {
+    void window.api.dashboard.stopAgent?.({
+      paneKey: card.paneKey,
+      worktreeId: card.worktreeId,
+      tabId: card.tabId,
+      leafId: card.leafId,
+      ptyId: card.ptyId
+    })
+  }, [])
+  const handleStop = useCallback(
+    (card: DashboardCard) => {
+      if (stopNeedsDialog(card)) {
+        setPendingStopPaneKey(card.paneKey)
+        return
+      }
+      emitStop(card)
+    },
+    [emitStop]
+  )
+  const handleConfirmStop = useCallback(() => {
+    setPendingStopPaneKey(null)
+    if (resolvedPendingStopCard) {
+      emitStop(resolvedPendingStopCard)
+    }
+  }, [emitStop, resolvedPendingStopCard])
+  const handleCancelStop = useCallback(() => setPendingStopPaneKey(null), [])
+
   // Watching the open dialog counts as seeing state changes as they happen —
   // without this, an agent finishing while you watch would re-flag its card.
   useEffect(() => {
@@ -284,13 +265,14 @@ export function AgentKanbanBoard({
           {/* Auto margins center the capped board and collapse during horizontal overflow. */}
           <div className="mx-auto flex w-full max-w-[1280px] gap-3">
             {visibleBuckets.map((bucket) => (
-              <KanbanColumn
+              <AgentKanbanColumn
                 key={bucket}
                 bucket={bucket}
                 cards={grouped[bucket]}
                 repoIconsByRepoId={snapshot.repoIconsByRepoId}
                 now={now}
                 onOpenTerminal={handleOpenTerminal}
+                onStop={handleStop}
               />
             ))}
           </div>
@@ -299,6 +281,11 @@ export function AgentKanbanBoard({
           card={dialogCard}
           onOpenChange={handleDialogOpenChange}
           onReveal={onRevealAgent}
+        />
+        <AgentStopConfirmDialog
+          card={resolvedPendingStopCard}
+          onCancel={handleCancelStop}
+          onConfirm={handleConfirmStop}
         />
       </div>
     </TooltipProvider>

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
@@ -2,6 +2,7 @@
 
 import '@testing-library/jest-dom/vitest'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DashboardCard } from '../../../../shared/dashboard-snapshot'
 import type { RepoIcon } from '../../../../shared/repo-icon'
@@ -53,6 +54,7 @@ function renderCard(props: {
   now: number
   repoIcon?: RepoIcon | null
   onOpenTerminal?: () => void
+  onStop?: () => void
 }): ReturnType<typeof render> {
   return render(
     <TooltipProvider>
@@ -61,6 +63,7 @@ function renderCard(props: {
         repoIcon={props.repoIcon}
         now={props.now}
         onOpenTerminal={props.onOpenTerminal ?? vi.fn()}
+        onStop={props.onStop ?? vi.fn()}
       />
     </TooltipProvider>
   )
@@ -99,6 +102,7 @@ describe('AgentKanbanCard', () => {
           card={{ ...attentionCard, askSummary: undefined }}
           now={2_000}
           onOpenTerminal={vi.fn()}
+          onStop={vi.fn()}
         />
       </TooltipProvider>
     )
@@ -213,7 +217,7 @@ describe('AgentKanbanCard', () => {
 
     const cardElement = container.firstElementChild!
     const header = cardElement.querySelector('button')!.firstElementChild!
-    const footer = cardElement.lastElementChild!
+    const footer = cardElement.querySelectorAll('button')[1]
     expect(header).toHaveTextContent('Sparse-checkout parser')
     expect(header).not.toHaveTextContent('dashboard-review')
     expect(footer).toHaveTextContent('dashboard-review')
@@ -243,6 +247,7 @@ describe('AgentKanbanCard', () => {
 
   it('skips structured-clone rerenders until visible card data or its age changes', () => {
     const onOpenTerminal = vi.fn()
+    const onStop = vi.fn()
     const initial = card({
       startedAt: 1_000,
       subagents: [{ id: 'child-1', name: 'Review loop', dotState: 'working' }]
@@ -255,6 +260,7 @@ describe('AgentKanbanCard', () => {
           repoIcon={repoIcon}
           now={61_500}
           onOpenTerminal={onOpenTerminal}
+          onStop={onStop}
         />
       </TooltipProvider>
     )
@@ -269,6 +275,7 @@ describe('AgentKanbanCard', () => {
           repoIcon={{ ...repoIcon }}
           now={62_000}
           onOpenTerminal={onOpenTerminal}
+          onStop={onStop}
         />
       </TooltipProvider>
     )
@@ -281,6 +288,7 @@ describe('AgentKanbanCard', () => {
           repoIcon={{ ...repoIcon }}
           now={121_500}
           onOpenTerminal={onOpenTerminal}
+          onStop={onStop}
         />
       </TooltipProvider>
     )
@@ -299,6 +307,7 @@ describe('AgentKanbanCard', () => {
           card={{ ...initial, workingMode: 'monitoring' }}
           now={2_000}
           onOpenTerminal={vi.fn()}
+          onStop={vi.fn()}
         />
       </TooltipProvider>
     )
@@ -308,6 +317,7 @@ describe('AgentKanbanCard', () => {
 
   it('rerenders when the repo icon changes', () => {
     const onOpenTerminal = vi.fn()
+    const onStop = vi.fn()
     const initial = card({ startedAt: 1_000 })
     const { rerender } = render(
       <TooltipProvider>
@@ -316,6 +326,7 @@ describe('AgentKanbanCard', () => {
           repoIcon={{ type: 'lucide', name: 'Rocket' }}
           now={61_500}
           onOpenTerminal={onOpenTerminal}
+          onStop={onStop}
         />
       </TooltipProvider>
     )
@@ -328,10 +339,63 @@ describe('AgentKanbanCard', () => {
           repoIcon={{ type: 'lucide', name: 'Database' }}
           now={61_500}
           onOpenTerminal={onOpenTerminal}
+          onStop={onStop}
         />
       </TooltipProvider>
     )
     expect(agentIconRender).toHaveBeenCalledTimes(2)
+  })
+
+  it('arms an inline confirmation before stopping an idle agent', async () => {
+    const user = userEvent.setup()
+    const onStop = vi.fn()
+    const onOpenTerminal = vi.fn()
+    renderCard({
+      card: card({ bucket: 'idle', dotState: 'idle' }),
+      now: 2_000,
+      onOpenTerminal,
+      onStop
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Stop agent' }))
+    expect(onStop).not.toHaveBeenCalled()
+    // Opening the terminal is the card's own click target — stopping must not trip it.
+    expect(onOpenTerminal).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'Stop agent?' }))
+    expect(onStop).toHaveBeenCalledTimes(1)
+    expect(onOpenTerminal).not.toHaveBeenCalled()
+  })
+
+  it('disarms the inline confirmation when the pointer leaves the card', async () => {
+    const user = userEvent.setup()
+    const onStop = vi.fn()
+    const { container } = renderCard({
+      card: card({ bucket: 'idle', dotState: 'done' }),
+      now: 2_000,
+      onStop
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Stop agent' }))
+    fireEvent.mouseLeave(container.firstElementChild as HTMLElement)
+
+    expect(screen.queryByRole('button', { name: 'Stop agent?' })).not.toBeInTheDocument()
+    expect(onStop).not.toHaveBeenCalled()
+  })
+
+  it('hands a still-running agent straight to the board so it can confirm in a dialog', async () => {
+    const user = userEvent.setup()
+    const onStop = vi.fn()
+    renderCard({
+      card: card({ bucket: 'working', dotState: 'working' }),
+      now: 2_000,
+      onStop
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Stop agent' }))
+
+    expect(onStop).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('button', { name: 'Stop agent?' })).not.toBeInTheDocument()
   })
 
   it('updates the relative age when the UI language changes', async () => {

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react'
+import { memo, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   ChevronRight,
@@ -13,6 +13,7 @@ import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
 import { AgentStateDot } from '@/components/AgentStateDot'
 import { RepoIconGlyph } from '@/components/repo/repo-icon'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { AgentKanbanCardStopControl } from './AgentKanbanCardStopControl'
 import { cn } from '@/lib/utils'
 import {
   dashboardCardDisplayState,
@@ -192,6 +193,8 @@ type AgentKanbanCardProps = {
    *  card: bucket moves remount the card, and an embedded dialog would close
    *  the chat mid-conversation. */
   onOpenTerminal: (card: DashboardCard) => void
+  /** Stops the agent (kills its process). Board-owned for the same reason. */
+  onStop: (card: DashboardCard) => void
 }
 
 /** One agent on the kanban board. Clicking opens the board's live terminal dialog. */
@@ -200,7 +203,8 @@ export const AgentKanbanCard = memo(
     card,
     repoIcon = null,
     now,
-    onOpenTerminal
+    onOpenTerminal,
+    onStop
   }: AgentKanbanCardProps): React.JSX.Element {
     useTranslation()
     const [subagentsOpen, setSubagentsOpen] = useState(false)
@@ -215,21 +219,30 @@ export const AgentKanbanCard = memo(
     // twice.
     const heading = card.conversationName ?? card.worktreeName
     const worktreeInFooter = card.conversationName !== undefined
+    const [confirmingStop, setConfirmingStop] = useState(false)
+    const armStop = useCallback(() => setConfirmingStop(true), [])
+    const disarmStop = useCallback(() => setConfirmingStop(false), [])
 
     return (
+      // Why: the stop control overlays the card rather than nesting inside its
+      // button (nested buttons are invalid HTML), which keeps the whole card
+      // clickable for open-terminal.
       <div
         // Why: a stable per-agent view-transition-name lets the browser morph
         // the card from its old column to its new one when its bucket changes.
         // paneKey has ':'/'/' which aren't valid in a custom-ident, so slugify.
         style={{ viewTransitionName: `agentcard-${card.paneKey.replace(/[^a-zA-Z0-9]/g, '-')}` }}
         className={cn(
-          'group flex w-full flex-col gap-1.5 rounded-lg border p-2.5 text-left transition-colors',
+          'group group/card relative flex w-full flex-col gap-1.5 rounded-lg border p-2.5 text-left transition-colors',
           needsYou
             ? 'border-agent-question/40 bg-agent-question/[0.06] hover:border-agent-question/60 hover:bg-agent-question/10'
             : isDone
               ? 'border-emerald-500/40 bg-emerald-500/[0.06] hover:border-emerald-500/60 hover:bg-emerald-500/10'
               : 'border-border/60 bg-card hover:border-border hover:bg-accent/40'
         )}
+        // Why: leaving the card is the cheapest possible "never mind" — an armed
+        // stop confirmation must not survive the pointer moving to another card.
+        onMouseLeave={disarmStop}
       >
         <button
           type="button"
@@ -346,11 +359,19 @@ export const AgentKanbanCard = memo(
             </span>
           ) : null}
         </button>
+        <AgentKanbanCardStopControl
+          card={card}
+          confirming={confirmingStop}
+          onArm={armStop}
+          onDisarm={disarmStop}
+          onStop={onStop}
+        />
       </div>
     )
   },
   (previous, next) =>
     previous.onOpenTerminal === next.onOpenTerminal &&
+    previous.onStop === next.onStop &&
     sameCard(previous.card, next.card) &&
     sameRepoIcon(previous.repoIcon, next.repoIcon) &&
     (displayTimestamp(previous.card) <= 0 ||

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCardStopControl.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCardStopControl.tsx
@@ -1,0 +1,111 @@
+import { useCallback, useEffect } from 'react'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { DashboardCard } from '../../../../shared/dashboard-snapshot'
+
+/** How long the inline "Stop agent?" confirmation stays armed before reverting. */
+const CONFIRM_TIMEOUT_MS = 3_000
+
+/** Idle and done agents confirm inline; anything still running routes through
+ *  the board's modal, mirroring Cmd+W in the main window (idle panes close
+ *  outright, running ones prompt). */
+export function stopNeedsDialog(card: DashboardCard): boolean {
+  return card.dotState !== 'idle' && card.dotState !== 'done'
+}
+
+type AgentKanbanCardStopControlProps = {
+  card: DashboardCard
+  /** Armed state lives on the card so moving the pointer anywhere off the card
+   *  — not merely off this small control — cancels a pending confirmation. */
+  confirming: boolean
+  onArm: () => void
+  onDisarm: () => void
+  /** Fires once the stop is committed — the board decides whether that means
+   *  stopping now or opening the confirmation dialog. */
+  onStop: (card: DashboardCard) => void
+}
+
+/**
+ * Stop affordance for one card, overlaid on the top-right corner where the
+ * state dot sits (the dot fades out on hover so they never collide). It is a
+ * SIBLING of the card's button — nesting a button inside one is invalid HTML —
+ * so clicking it can never also open the terminal.
+ */
+export function AgentKanbanCardStopControl({
+  card,
+  confirming,
+  onArm,
+  onDisarm,
+  onStop
+}: AgentKanbanCardStopControlProps): React.JSX.Element {
+  // Why: an armed confirmation the user walked away from must not stay armed
+  // for the next visit to this card.
+  useEffect(() => {
+    if (!confirming) {
+      return
+    }
+    const timer = setTimeout(onDisarm, CONFIRM_TIMEOUT_MS)
+    return () => clearTimeout(timer)
+  }, [confirming, onDisarm])
+
+  const handleStopClick = useCallback(() => {
+    if (confirming || stopNeedsDialog(card)) {
+      onDisarm()
+      onStop(card)
+      return
+    }
+    onArm()
+  }, [card, confirming, onArm, onDisarm, onStop])
+
+  // Matches the card's p-2.5 padding so the control lands exactly on the dot.
+  const anchor = 'absolute right-2.5 top-2.5 z-10 flex items-center'
+
+  if (confirming) {
+    return (
+      <span className={anchor}>
+        <button
+          type="button"
+          autoFocus
+          onClick={handleStopClick}
+          onBlur={onDisarm}
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') {
+              onDisarm()
+            }
+          }}
+          className={cn(
+            'inline-flex items-center rounded-md border border-destructive/30 bg-destructive/10 px-1.5 py-0.5',
+            'text-[10px] font-medium leading-none text-destructive',
+            'transition-colors hover:bg-destructive/20',
+            'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-destructive'
+          )}
+        >
+          {translate('dashboardPopout.card.stop.confirm', 'Stop agent?')}
+        </button>
+      </span>
+    )
+  }
+
+  return (
+    <span className={anchor}>
+      <button
+        type="button"
+        onClick={handleStopClick}
+        aria-label={translate('dashboardPopout.card.stop.action', 'Stop agent')}
+        title={translate(
+          'dashboardPopout.card.stop.tooltip',
+          'Stop agent — kills the process and closes its terminal'
+        )}
+        className={cn(
+          'inline-flex items-center justify-center rounded-sm text-muted-foreground/70 hover:text-destructive',
+          'transition-opacity duration-150',
+          'can-hover:opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100',
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+        )}
+      >
+        <X className="size-3.5" />
+      </button>
+    </span>
+  )
+}

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanColumn.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanColumn.tsx
@@ -1,0 +1,66 @@
+import type { DashboardBucket, DashboardCard } from '../../../../shared/dashboard-snapshot'
+import type { RepoIcon } from '../../../../shared/repo-icon'
+import { translate } from '@/i18n/i18n'
+import { AgentKanbanCard } from './AgentKanbanCard'
+
+function bucketLabel(bucket: DashboardBucket): string {
+  switch (bucket) {
+    case 'attention':
+      return translate('dashboardPopout.bucket.attention', 'Needs You')
+    case 'working':
+      return translate('dashboardPopout.bucket.working', 'Working')
+    case 'done':
+      return translate('dashboardPopout.bucket.done', 'Done')
+    case 'idle':
+      return translate('dashboardPopout.bucket.idle', 'Idle')
+  }
+}
+
+export function AgentKanbanColumn({
+  bucket,
+  cards,
+  repoIconsByRepoId,
+  now,
+  onOpenTerminal,
+  onStop
+}: {
+  bucket: DashboardBucket
+  cards: DashboardCard[]
+  repoIconsByRepoId: Record<string, RepoIcon | null> | undefined
+  now: number
+  onOpenTerminal: (card: DashboardCard) => void
+  onStop: (card: DashboardCard) => void
+}): React.JSX.Element {
+  return (
+    // Why: attention no longer tints the whole column — the cards inside carry
+    // their own state color, so a column border would double-signal it.
+    <section className="flex min-w-[264px] flex-1 flex-col rounded-xl border border-border/60 bg-muted/30">
+      <header className="flex items-center gap-2 px-3 py-2">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+          {bucketLabel(bucket)}
+        </span>
+        <span className="ml-auto rounded-full bg-background px-1.5 text-[11px] tabular-nums text-muted-foreground">
+          {cards.length}
+        </span>
+      </header>
+      <div className="scrollbar-sleek flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 pb-2">
+        {cards.length === 0 ? (
+          <p className="px-1 py-2 text-[11px] text-muted-foreground">
+            {translate('dashboardPopout.bucket.empty', 'None')}
+          </p>
+        ) : (
+          cards.map((card) => (
+            <AgentKanbanCard
+              key={card.paneKey}
+              card={card}
+              repoIcon={repoIconsByRepoId?.[card.repoId] ?? null}
+              now={now}
+              onOpenTerminal={onOpenTerminal}
+              onStop={onStop}
+            />
+          ))
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/components/dashboard-popout/AgentStopConfirmDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentStopConfirmDialog.tsx
@@ -1,0 +1,69 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+import type { DashboardCard } from '../../../../shared/dashboard-snapshot'
+
+type AgentStopConfirmDialogProps = {
+  /** The agent awaiting confirmation; null renders the dialog closed. */
+  card: DashboardCard | null
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+/**
+ * Confirms stopping an agent that is still running. Reuses CloseTerminalDialog's
+ * copy keys verbatim so the board and Cmd+W say the same thing about the same
+ * action. The "don't ask again" opt-out is deliberately omitted: it belongs to
+ * the terminal's own close flow, not to a board that stops agents by the card.
+ */
+export function AgentStopConfirmDialog({
+  card,
+  onCancel,
+  onConfirm
+}: AgentStopConfirmDialogProps): React.JSX.Element {
+  return (
+    <Dialog
+      open={card !== null}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          onCancel()
+        }
+      }}
+    >
+      <DialogContent className="max-w-sm" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle className="text-sm">
+            {translate(
+              'auto.components.terminal.pane.CloseTerminalDialog.stop_agent_title',
+              'Stop this agent?'
+            )}
+          </DialogTitle>
+          <DialogDescription className="text-xs">
+            {translate(
+              'auto.components.terminal.pane.CloseTerminalDialog.stop_agent_description',
+              "Closing this terminal will stop the agent's current work."
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={onCancel}>
+            {translate('auto.components.terminal.pane.CloseTerminalDialog.1d1a7a9c1f', 'Cancel')}
+          </Button>
+          <Button type="button" variant="destructive" size="sm" autoFocus onClick={onConfirm}>
+            {translate(
+              'auto.components.terminal.pane.CloseTerminalDialog.stop_agent_confirm',
+              'Stop Agent'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/dashboard/useDashboardPopoutBridge.ts
+++ b/src/renderer/src/components/dashboard/useDashboardPopoutBridge.ts
@@ -3,6 +3,7 @@ import { useAppStore, type AppState } from '@/store'
 import { revealDashboardAgent } from './reveal-dashboard-agent'
 import { runSleepWorktree } from '../sidebar/sleep-worktree-flow'
 import type { RepoIcon } from '../../../../shared/repo-icon'
+import { stopDashboardAgent } from '@/lib/stop-dashboard-agent'
 import { buildDashboardSnapshot, type DashboardSnapshotState } from './build-dashboard-snapshot'
 import { createWorktreeAgentRowsCache } from './worktree-agent-rows-cache'
 import { launchDashboardAgent } from './launch-dashboard-agent'
@@ -147,6 +148,17 @@ export function useDashboardPopoutBridge(enabled: boolean): void {
     }
     return window.api.dashboard.onAckAgent?.((paneKey) => {
       useAppStore.getState().acknowledgeAgents([paneKey])
+    })
+  }, [enabled])
+
+  // Stopping an agent from the board runs its terminal teardown here, where the
+  // store lives. Same ?. shield as the ack listener above.
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+    return window.api.dashboard.onStopAgent?.((args) => {
+      stopDashboardAgent(args)
     })
   }, [enabled])
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17703,6 +17703,11 @@
     "settingsTooltip": "Board settings",
     "card": {
       "you": "You",
+      "stop": {
+        "action": "Stop agent",
+        "confirm": "Stop agent?",
+        "tooltip": "Stop agent — kills the process and closes its terminal"
+      },
       "time": {
         "justNow": "just now",
         "minutes": "{{count}}m",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14807,6 +14807,11 @@
     "total": "{{count}} total",
     "card": {
       "you": "You",
+      "stop": {
+        "action": "Detener agente",
+        "confirm": "¿Detener agente?",
+        "tooltip": "Detener agente: termina el proceso y cierra su terminal"
+      },
       "time": {
         "justNow": "ahora mismo",
         "minutes": "{{count}} min",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14842,6 +14842,11 @@
     "total": "合計 {{count}} 件",
     "card": {
       "you": "あなた",
+      "stop": {
+        "action": "Agent を停止",
+        "confirm": "Agent を停止しますか?",
+        "tooltip": "Agent を停止 — プロセスを終了してターミナルを閉じます"
+      },
       "time": {
         "justNow": "たった今",
         "minutes": "{{count}}分",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14981,6 +14981,11 @@
     "total": "총 {{count}}개",
     "card": {
       "you": "나",
+      "stop": {
+        "action": "에이전트 중지",
+        "confirm": "에이전트를 중지할까요?",
+        "tooltip": "에이전트 중지 — 프로세스를 종료하고 터미널을 닫습니다"
+      },
       "time": {
         "justNow": "방금",
         "minutes": "{{count}}분",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14946,6 +14946,11 @@
     "total": "共 {{count}} 个",
     "card": {
       "you": "你",
+      "stop": {
+        "action": "停止 Agent",
+        "confirm": "停止 Agent?",
+        "tooltip": "停止 Agent — 结束进程并关闭其终端"
+      },
       "time": {
         "justNow": "刚刚",
         "minutes": "{{count}} 分钟",

--- a/src/renderer/src/lib/stop-dashboard-agent.test.ts
+++ b/src/renderer/src/lib/stop-dashboard-agent.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { stopDashboardAgent } from './stop-dashboard-agent'
+
+const dropAgentStatus = vi.fn()
+const dismissRetainedAgent = vi.fn()
+const closeTerminalTab = vi.fn()
+const closeWebRuntimeTerminal = vi.fn((_ptyId: string | null | undefined) => false)
+const ptyKill = vi.fn()
+
+let terminalLayoutsByTabId: Record<string, { ptyIdsByLeafId?: Record<string, string> }> = {}
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({
+      dropAgentStatus,
+      dismissRetainedAgent,
+      terminalLayoutsByTabId
+    })
+  }
+}))
+
+vi.mock('@/components/terminal/terminal-tab-actions', () => ({
+  closeTerminalTab: (...args: unknown[]) => closeTerminalTab(...args)
+}))
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  closeWebRuntimeTerminal: (ptyId: string | null | undefined) => closeWebRuntimeTerminal(ptyId)
+}))
+
+function args(
+  overrides: Partial<Parameters<typeof stopDashboardAgent>[0]> = {}
+): Parameters<typeof stopDashboardAgent>[0] {
+  return {
+    paneKey: 'tab-1:leaf-1',
+    worktreeId: 'worktree-1',
+    tabId: 'tab-1',
+    leafId: 'leaf-1',
+    ptyId: 'pty-1',
+    ...overrides
+  }
+}
+
+describe('stopDashboardAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    closeWebRuntimeTerminal.mockReturnValue(false)
+    terminalLayoutsByTabId = {
+      'tab-1': { ptyIdsByLeafId: { 'leaf-1': 'pty-1' } }
+    }
+    vi.stubGlobal('window', { api: { pty: { kill: ptyKill } } })
+  })
+
+  it('drops the row before tearing the pane down so retention cannot resurrect the card', () => {
+    const order: string[] = []
+    dropAgentStatus.mockImplementation(() => order.push('drop'))
+    dismissRetainedAgent.mockImplementation(() => order.push('dismiss'))
+    closeTerminalTab.mockImplementation(() => order.push('close'))
+
+    stopDashboardAgent(args())
+
+    expect(order).toEqual(['drop', 'dismiss', 'close'])
+    expect(dropAgentStatus).toHaveBeenCalledWith('tab-1:leaf-1')
+    expect(dismissRetainedAgent).toHaveBeenCalledWith('tab-1:leaf-1')
+  })
+
+  it('closes the whole tab when the agent is its only pane', () => {
+    stopDashboardAgent(args())
+
+    expect(closeTerminalTab).toHaveBeenCalledWith(
+      'tab-1',
+      expect.objectContaining({
+        reason: 'user',
+        rejectPinned: true
+      })
+    )
+    expect(ptyKill).not.toHaveBeenCalled()
+  })
+
+  it('kills only the agent pane when the tab is split', () => {
+    terminalLayoutsByTabId = {
+      'tab-1': { ptyIdsByLeafId: { 'leaf-1': 'pty-1', 'leaf-2': 'pty-2' } }
+    }
+
+    stopDashboardAgent(args())
+
+    expect(ptyKill).toHaveBeenCalledWith('pty-1')
+    expect(closeTerminalTab).not.toHaveBeenCalled()
+  })
+
+  it('routes a host-owned runtime pane through the runtime close instead of pty.kill', () => {
+    terminalLayoutsByTabId = {
+      'tab-1': {
+        ptyIdsByLeafId: { 'leaf-1': 'remote:env/1', 'leaf-2': 'pty-2' }
+      }
+    }
+    closeWebRuntimeTerminal.mockReturnValue(true)
+
+    stopDashboardAgent(args({ ptyId: 'remote:env/1' }))
+
+    expect(closeWebRuntimeTerminal).toHaveBeenCalledWith('remote:env/1')
+    expect(ptyKill).not.toHaveBeenCalled()
+  })
+
+  it('stops the agent anyway when a pinned tab refuses to close', () => {
+    closeTerminalTab.mockImplementation((_tabId: string, options: { onCancel?: () => void }) =>
+      options.onCancel?.()
+    )
+
+    stopDashboardAgent(args())
+
+    expect(ptyKill).toHaveBeenCalledWith('pty-1')
+  })
+
+  it('only drops the row for a retained card whose pane is already gone', () => {
+    stopDashboardAgent(args({ ptyId: null }))
+
+    expect(dropAgentStatus).toHaveBeenCalledWith('tab-1:leaf-1')
+    expect(dismissRetainedAgent).toHaveBeenCalledWith('tab-1:leaf-1')
+    expect(closeTerminalTab).not.toHaveBeenCalled()
+    expect(ptyKill).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/stop-dashboard-agent.ts
+++ b/src/renderer/src/lib/stop-dashboard-agent.ts
@@ -1,0 +1,56 @@
+import { useAppStore } from '@/store'
+import { closeTerminalTab } from '@/components/terminal/terminal-tab-actions'
+import { closeWebRuntimeTerminal } from '@/runtime/web-runtime-session'
+import type { DashboardStopAgentArgs } from '../../../shared/dashboard-snapshot'
+
+/** Kills the PTY behind one agent pane, matching TerminalPane's own split-pane
+ *  teardown order: host-owned runtime terminals first, local/SSH otherwise. */
+function killAgentPane(ptyId: string): void {
+  if (closeWebRuntimeTerminal(ptyId)) {
+    return
+  }
+  void window.api.pty.kill(ptyId)
+}
+
+function paneCountForTab(tabId: string): number {
+  const layout = useAppStore.getState().terminalLayoutsByTabId[tabId]
+  return Object.keys(layout?.ptyIdsByLeafId ?? {}).length
+}
+
+/**
+ * Stops one agent from the pop-out board: kills its process and takes its row
+ * off the board. Runs in the MAIN renderer — the pop-out has no store of its
+ * own — and never activates the worktree, so the board stays put.
+ */
+export function stopDashboardAgent(args: DashboardStopAgentArgs): void {
+  const state = useAppStore.getState()
+  // Why: drop the live row BEFORE the pane dies so dropAgentStatus plants its
+  // retention suppressor while a live entry still exists; otherwise the
+  // retention sync re-adds the agent as a retained "done" row and the card
+  // never actually leaves the board.
+  state.dropAgentStatus(args.paneKey)
+  state.dismissRetainedAgent(args.paneKey)
+
+  if (!args.ptyId) {
+    // Retained card whose pane is already gone — the row was the only thing left.
+    return
+  }
+
+  // A split tab hosts other panes the user didn't ask to close, so kill just
+  // this agent's PTY and leave the tab standing.
+  if (paneCountForTab(args.tabId) > 1) {
+    killAgentPane(args.ptyId)
+    return
+  }
+
+  const ptyId = args.ptyId
+  closeTerminalTab(args.tabId, {
+    reason: 'user',
+    // Why: the pinned-close confirmation would open a modal in the main window,
+    // which is behind the board and may be unattended. Stop the agent anyway
+    // and leave the pinned tab itself alone — silently doing nothing would read
+    // as a broken button.
+    rejectPinned: true,
+    onCancel: () => killAgentPane(ptyId)
+  })
+}

--- a/src/shared/dashboard-snapshot.ts
+++ b/src/shared/dashboard-snapshot.ts
@@ -223,7 +223,6 @@ export type DashboardRevealAgentArgs = {
   tabId: string
   leafId: string | null
 }
-
 export type DashboardSpawnAgentArgs = {
   worktreeId: string
   agent: TuiAgent
@@ -233,4 +232,15 @@ export type DashboardSpawnAgentArgs = {
  *  teardown sequence, so the pop-out only names the target. */
 export type DashboardSleepWorkspaceArgs = {
   worktreeId: string
+}
+
+/** Payload for stopping an agent from the board: kills its process and drops
+ *  its row. ptyId is null for a retained card whose pane is already gone —
+ *  there is nothing left to kill, so the stop degrades to dropping the row. */
+export type DashboardStopAgentArgs = {
+  paneKey: string
+  worktreeId: string
+  tabId: string
+  leafId: string | null
+  ptyId: string | null
 }


### PR DESCRIPTION
Split out of #12095, which bundled this dashboard feature with an unrelated Antigravity quota rewrite. This PR is the dashboard half only — no `src/main/rate-limits/` changes. Rebased onto current `main`.

## Why

Clearing a finished agent off the kanban board required opening its worktree, finding the tab, and closing it there — the card only disappeared once the pane died. For idle agents, which is most of what accumulates on the board, that is three navigations to dismiss one card.

## What

A per-card stop control in the top-right corner, where the state dot sits (the dot fades on hover so they never collide).

- **Idle and done cards** confirm inline: the X becomes a red "Stop agent?" pill that commits on a second click and reverts on mouse-leave, blur, Escape, or a 3s timeout.
- **Anything still running** routes through a modal reusing `CloseTerminalDialog`'s strings verbatim, so the board and Cmd+W say the same thing.
- **No bulk "clear idle" action**: idle means the agent is not working right now, not that its work is finished, so each dismissal stays deliberate.

## Ordering and teardown

The row must be dropped **before** the pane is torn down. `dropAgentStatus` only plants its one-shot retention suppressor when a live entry still exists; reversed, the retention sync re-adds the agent as a retained "done" row and the card never leaves the board.

Two teardown cases the naive "kill the pty" would get wrong:

- A **split tab** hosts panes the user did not ask to close, so kill only this agent's pty and leave the tab standing. Single-pane tabs go through `closeTerminalTab` for full Cmd+W semantics.
- A **pinned tab**'s close confirmation would open a modal in the main window, which is behind the board and may be unattended. Stop the agent anyway via the `onCancel` path and leave the pinned tab alone — a button that silently does nothing reads as broken.

The IPC deliberately does not raise the main window: the point is clearing an agent without leaving the board.

## Structural notes

Two extractions the 300-line ceiling forced, both following existing patterns:

- The kanban column moves out of `AgentKanbanBoard` into its own `AgentKanbanColumn`.
- The stop-args validator lives in `dashboard-stop-agent-validation.ts`; `dashboard-payload-validation.ts` is at the ceiling, so it only re-exports — the same wiring `dashboard-agent-launch-validation` already uses.

`ja.json` uses `Agent` rather than `エージェント`, matching every other Agent string in that catalog and satisfying `verify:localization-catalog`.

## Validation

`pnpm typecheck`, `oxlint`, the three `verify:localization-*` gates, `check:reliability-gates`, `check:max-lines-ratchet`, `check:runtime-electron-ratchet`, and `audit:code-quality:native` all pass. Scoped vitest run: 45 files, 409 tests passing.

https://claude.ai/code/session_01MZJuvDFhjHtuky5z9BF43a
