### PR TITLE
feat(editor): Add command palette shortcut keybinding

### DIFF
--- a/src/renderer/src/components/automations/AutomationEditorPromptEditor.test.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorPromptEditor.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const editorProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }))
 const installFindShortcut = vi.hoisted(() => vi.fn(() => vi.fn()))
+const cleanupCommandPaletteShortcut = vi.hoisted(() => vi.fn())
+const installCommandPaletteShortcut = vi.hoisted(() => vi.fn(() => cleanupCommandPaletteShortcut))
 const syncContentOnMount = vi.hoisted(() => vi.fn(() => false))
 const syncContentUpdate = vi.hoisted(() => vi.fn())
 
@@ -23,6 +25,7 @@ vi.mock('@/store', () => ({
     })
 }))
 vi.mock('@/components/editor/editor-shortcuts', () => ({
+  installMonacoEditorCommandPaletteShortcut: installCommandPaletteShortcut,
   installMonacoEditorFindShortcut: installFindShortcut
 }))
 vi.mock('@/components/editor/monaco-content-sync', () => ({
@@ -41,6 +44,8 @@ afterEach(() => {
   cleanup()
   editorProps.current = null
   installFindShortcut.mockClear()
+  installCommandPaletteShortcut.mockClear()
+  cleanupCommandPaletteShortcut.mockClear()
   syncContentOnMount.mockClear()
   syncContentUpdate.mockClear()
 })
@@ -64,7 +69,7 @@ describe('AutomationEditorPromptEditor', () => {
     ).toBe('Prompt placeholder')
   })
 
-  it('installs find and syncs an external rewrite after mount', () => {
+  it('installs editor shortcuts and syncs an external rewrite after mount', () => {
     const editorInstance = {
       getContainerDomNode: () => document.createElement('div'),
       onDidDispose: vi.fn()
@@ -82,6 +87,7 @@ describe('AutomationEditorPromptEditor', () => {
     onMount(editorInstance)
 
     expect(installFindShortcut).toHaveBeenCalledWith(editorInstance)
+    expect(installCommandPaletteShortcut).toHaveBeenCalledWith(editorInstance)
     expect(syncContentOnMount).toHaveBeenCalledWith(editorInstance, 'original')
 
     rerender(
@@ -94,6 +100,10 @@ describe('AutomationEditorPromptEditor', () => {
     )
 
     expect(syncContentUpdate).toHaveBeenCalledWith(editorInstance, 'from template')
+
+    const disposeEditor = editorInstance.onDidDispose.mock.calls[0]?.[0] as () => void
+    disposeEditor()
+    expect(cleanupCommandPaletteShortcut).toHaveBeenCalledTimes(1)
   })
 
   it('dismisses on Escape only when find is closed', () => {

--- a/src/renderer/src/components/automations/AutomationEditorPromptEditor.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorPromptEditor.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback, useLayoutEffect, useMemo, useRef } from 'react'
 import Editor, { type OnMount } from '@monaco-editor/react'
 import type { editor } from 'monaco-editor'
-import { installMonacoEditorFindShortcut } from '@/components/editor/editor-shortcuts'
+import {
+  installMonacoEditorCommandPaletteShortcut,
+  installMonacoEditorFindShortcut
+} from '@/components/editor/editor-shortcuts'
 import { syncContentOnMount, syncContentUpdate } from '@/components/editor/monaco-content-sync'
 import { isMonacoFindWidgetOpen } from '@/components/editor/monaco-find-widget'
 import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
@@ -102,6 +105,7 @@ export function AutomationEditorPromptEditor({
     editorRef.current = editorInstance
     const editorDomNode = editorInstance.getContainerDomNode()
     const cleanupFindShortcut = installMonacoEditorFindShortcut(editorInstance)
+    const cleanupCommandPaletteShortcut = installMonacoEditorCommandPaletteShortcut(editorInstance)
     const cleanupEscapeDismiss = installPromptEditorEscapeDismiss(editorDomNode, onDismissRef)
     isApplyingProgrammaticContentRef.current = true
     try {
@@ -113,6 +117,7 @@ export function AutomationEditorPromptEditor({
     }
     editorInstance.onDidDispose(() => {
       cleanupFindShortcut()
+      cleanupCommandPaletteShortcut()
       cleanupEscapeDismiss()
       if (editorRef.current === editorInstance) {
         editorRef.current = null

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -16,6 +16,7 @@ import { DiffSectionHeader } from './DiffSectionHeader'
 import type { DiffComment } from '../../../../shared/diff-comment-types'
 import { isDiffComment } from '@/lib/diff-comment-compat'
 import { installEditorSaveShortcut, installMonacoEditorFindShortcut } from './editor-shortcuts'
+import { installMonacoDiffCommandPaletteShortcuts } from './monaco-diff-command-palette-shortcuts'
 import { DiffSectionBody } from './DiffSectionBody'
 import { useDiffSectionLayoutMetrics } from './useDiffSectionLayoutMetrics'
 import { getLiveDiffSectionRenderLimit } from './diff-section-live-render-limit'
@@ -213,6 +214,8 @@ export function DiffSectionItem({
     lineNumberOptionsSubRef.current?.dispose()
     lineNumberOptionsSubRef.current = applyDiffEditorLineNumberOptions(editor, sideBySide)
     const modified = editor.getModifiedEditor()
+    const cleanupCommandPaletteShortcuts = installMonacoDiffCommandPaletteShortcuts(editor)
+    modified.onDidDispose(cleanupCommandPaletteShortcuts)
 
     // Why: measuring before Monaco computes hidden unchanged regions records
     // full-file height, making virtualized combined diffs jump as rows remount.

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -17,6 +17,7 @@ import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-opti
 import type { DiffComment } from '../../../../shared/diff-comment-types'
 import { isDiffComment } from '@/lib/diff-comment-compat'
 import { installEditorSaveShortcut, installMonacoEditorFindShortcut } from './editor-shortcuts'
+import { installMonacoDiffCommandPaletteShortcuts } from './monaco-diff-command-palette-shortcuts'
 import { diffEditorScrollbarOptions } from './diff-editor-scrollbar-options'
 import { LargeDiffFallback } from './LargeDiffFallback'
 import { getLargeDiffRenderLimit } from './large-diff-render-limit'
@@ -294,6 +295,8 @@ export default function DiffViewer({
 
       const originalEditor = diffEditor.getOriginalEditor()
       const modifiedEditor = diffEditor.getModifiedEditor()
+      const cleanupCommandPaletteShortcuts = installMonacoDiffCommandPaletteShortcuts(diffEditor)
+      diffEditor.onDidDispose(cleanupCommandPaletteShortcuts)
       diffEditor.onDidDispose(preserveDiffViewStateAcrossModelSwaps(diffEditor).dispose)
 
       setupCopy(originalEditor, monaco, filePath, propsRef)

--- a/src/renderer/src/components/editor/IpynbCellEditor.tsx
+++ b/src/renderer/src/components/editor/IpynbCellEditor.tsx
@@ -8,7 +8,11 @@ import { monaco } from '@/lib/monaco-setup'
 import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 import { resolveDocumentTheme } from '@/lib/document-theme'
 import { useAppStore } from '@/store'
-import { installEditorSaveShortcut, installMonacoEditorFindShortcut } from './editor-shortcuts'
+import {
+  installEditorSaveShortcut,
+  installMonacoEditorFindShortcut,
+  installMonacoEditorCommandPaletteShortcut
+} from './editor-shortcuts'
 import { getIpynbCodeCellEditorHeight, getIpynbCodeCellPreviewLines } from './ipynb-code-cell-lines'
 import type { IpynbCell } from './ipynb-parse'
 import MonacoCodeExcerpt from './MonacoCodeExcerpt'
@@ -77,12 +81,14 @@ function IpynbCodeCellEditor({
       }
     )
     const cleanupFindShortcut = installMonacoEditorFindShortcut(editorInstance)
+    const cleanupCommandPaletteShortcut = installMonacoEditorCommandPaletteShortcut(editorInstance)
     const blurSub = editorInstance.onDidBlurEditorWidget(() => {
       onDeactivateRef.current()
     })
     editorInstance.onDidDispose(() => {
       cleanupSaveShortcut()
       cleanupFindShortcut()
+      cleanupCommandPaletteShortcut()
       blurSub.dispose()
     })
     editorInstance.addCommand(monacoInstance.KeyCode.Escape, () => {

--- a/src/renderer/src/components/editor/editor-shortcuts.test.ts
+++ b/src/renderer/src/components/editor/editor-shortcuts.test.ts
@@ -19,11 +19,14 @@ vi.mock('@/store', () => ({
 
 import {
   installEditorAddReviewNoteShortcut,
+  installEditorCommandPaletteShortcut,
   installEditorFindShortcut,
   installMonacoDiffChangeNavigationShortcut,
+  installMonacoEditorCommandPaletteShortcut,
   installMonacoEditorFindShortcut,
   installOpenDraftAddReviewNoteGuard
 } from './editor-shortcuts'
+import { installMonacoDiffCommandPaletteShortcuts } from './monaco-diff-command-palette-shortcuts'
 
 type ShortcutFixture = {
   container: HTMLDivElement
@@ -394,5 +397,158 @@ describe('installMonacoDiffChangeNavigationShortcut', () => {
     expect(disposedEvent.defaultPrevented).toBe(false)
     expect(fixture.goToDiff).toHaveBeenCalledTimes(1)
     expect(fixture.goToDiff).toHaveBeenCalledWith('next')
+  })
+})
+
+describe('installEditorCommandPaletteShortcut', () => {
+  function createCommandPaletteFixture(): {
+    container: HTMLDivElement
+    dispose: () => void
+    input: HTMLTextAreaElement
+    onCommandPalette: ReturnType<typeof vi.fn>
+    onDownstreamKeyDown: ReturnType<typeof vi.fn>
+  } {
+    const container = document.createElement('div')
+    const input = document.createElement('textarea')
+    const onCommandPalette = vi.fn()
+    const onDownstreamKeyDown = vi.fn()
+    container.appendChild(input)
+    document.body.appendChild(container)
+    input.addEventListener('keydown', onDownstreamKeyDown)
+
+    return {
+      container,
+      dispose: installEditorCommandPaletteShortcut(container, onCommandPalette),
+      input,
+      onCommandPalette,
+      onDownstreamKeyDown
+    }
+  }
+
+  it('triggers on default F1 keydown', () => {
+    const fixture = createCommandPaletteFixture()
+
+    const event = dispatchKeyDown(fixture.input, { key: 'F1', code: 'F1' })
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(fixture.onCommandPalette).toHaveBeenCalledTimes(1)
+    expect(fixture.onDownstreamKeyDown).not.toHaveBeenCalled()
+    fixture.dispose()
+  })
+
+  it('consumes matched repeats without invoking command palette again', () => {
+    const fixture = createCommandPaletteFixture()
+
+    const initialEvent = dispatchKeyDown(fixture.input, { key: 'F1', code: 'F1' })
+    const repeatEvent = dispatchKeyDown(fixture.input, { key: 'F1', code: 'F1', repeat: true })
+
+    expect(initialEvent.defaultPrevented).toBe(true)
+    expect(repeatEvent.defaultPrevented).toBe(true)
+    expect(fixture.onCommandPalette).toHaveBeenCalledTimes(1)
+    expect(fixture.onDownstreamKeyDown).not.toHaveBeenCalled()
+    fixture.dispose()
+  })
+
+  it('honors a custom binding and consumes the old Monaco default', () => {
+    shortcutState.keybindings = { 'editor.commandPalette': ['Mod+Shift+P'] }
+    const fixture = createCommandPaletteFixture()
+
+    const defaultEvent = dispatchKeyDown(fixture.input, { key: 'F1', code: 'F1' })
+    const customEvent = dispatchKeyDown(fixture.input, {
+      key: 'p',
+      code: 'KeyP',
+      metaKey: true,
+      shiftKey: true
+    })
+
+    expect(defaultEvent.defaultPrevented).toBe(true)
+    expect(customEvent.defaultPrevented).toBe(true)
+    expect(fixture.onCommandPalette).toHaveBeenCalledTimes(1)
+    expect(fixture.onDownstreamKeyDown).not.toHaveBeenCalled()
+    fixture.dispose()
+  })
+
+  it('consumes F1 without opening the palette when the action is disabled', () => {
+    shortcutState.keybindings = { 'editor.commandPalette': [] }
+    const fixture = createCommandPaletteFixture()
+
+    const event = dispatchKeyDown(fixture.input, { key: 'F1', code: 'F1' })
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(fixture.onCommandPalette).not.toHaveBeenCalled()
+    expect(fixture.onDownstreamKeyDown).not.toHaveBeenCalled()
+    fixture.dispose()
+  })
+
+  it('removes the listener when disposed', () => {
+    const fixture = createCommandPaletteFixture()
+    fixture.dispose()
+
+    const event = dispatchKeyDown(fixture.input, { key: 'F1', code: 'F1' })
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(fixture.onCommandPalette).not.toHaveBeenCalled()
+    expect(fixture.onDownstreamKeyDown).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs Monaco existing quickCommand action through the shared bridge', () => {
+    const container = document.createElement('div')
+    const input = document.createElement('textarea')
+    const run = vi.fn()
+    const getAction = vi.fn((_id: string) => ({ run }))
+    container.appendChild(input)
+    document.body.appendChild(container)
+    const dispose = installMonacoEditorCommandPaletteShortcut({
+      getAction,
+      getContainerDomNode: () => container
+    })
+
+    dispatchKeyDown(input, { key: 'F1', code: 'F1' })
+
+    expect(getAction).toHaveBeenCalledWith('editor.action.quickCommand')
+    expect(run).toHaveBeenCalledTimes(1)
+    dispose()
+  })
+})
+
+describe('installMonacoDiffCommandPaletteShortcuts', () => {
+  it('installs and disposes the command palette bridge on both panes', () => {
+    const createEditor = () => {
+      const container = document.createElement('div')
+      const input = document.createElement('textarea')
+      const run = vi.fn()
+      container.appendChild(input)
+      document.body.appendChild(container)
+      return {
+        editor: {
+          getAction: vi.fn((_id: string) => ({ run })),
+          getContainerDomNode: () => container
+        },
+        input,
+        run
+      }
+    }
+    const original = createEditor()
+    const modified = createEditor()
+    const dispose = installMonacoDiffCommandPaletteShortcuts({
+      getOriginalEditor: () => original.editor,
+      getModifiedEditor: () => modified.editor
+    })
+
+    dispatchKeyDown(original.input, { key: 'F1', code: 'F1' })
+    dispatchKeyDown(modified.input, { key: 'F1', code: 'F1' })
+
+    expect(original.editor.getAction).toHaveBeenCalledWith('editor.action.quickCommand')
+    expect(modified.editor.getAction).toHaveBeenCalledWith('editor.action.quickCommand')
+    expect(original.run).toHaveBeenCalledTimes(1)
+    expect(modified.run).toHaveBeenCalledTimes(1)
+
+    dispose()
+    const disposedEvent = dispatchKeyDown(original.input, { key: 'F1', code: 'F1' })
+    const modifiedDisposedEvent = dispatchKeyDown(modified.input, { key: 'F1', code: 'F1' })
+    expect(disposedEvent.defaultPrevented).toBe(false)
+    expect(modifiedDisposedEvent.defaultPrevented).toBe(false)
+    expect(original.run).toHaveBeenCalledTimes(1)
+    expect(modified.run).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/editor/editor-shortcuts.ts
+++ b/src/renderer/src/components/editor/editor-shortcuts.ts
@@ -127,13 +127,47 @@ export function installOpenDraftAddReviewNoteGuard(target: HTMLElement): () => v
   return () => target.removeEventListener('keydown', handleKeyDown, true)
 }
 
-type MonacoFindShortcutEditor = {
+type MonacoActionShortcutEditor = {
   getAction: (id: string) => { run: () => void | Promise<void> } | null
   getContainerDomNode: () => HTMLElement
 }
 
-export function installMonacoEditorFindShortcut(editor: MonacoFindShortcutEditor): () => void {
+export function installMonacoEditorFindShortcut(editor: MonacoActionShortcutEditor): () => void {
   return installEditorFindShortcut(editor.getContainerDomNode(), () => {
     void editor.getAction('actions.find')?.run()
+  })
+}
+
+export function installEditorCommandPaletteShortcut(
+  target: HTMLElement,
+  onCommandPalette: () => void
+): () => void {
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    const matchesShortcut = editorShortcutMatches('editor.commandPalette', event)
+    // Why: consume Monaco's F1 after the Orca binding is remapped or disabled.
+    const matchesDefaultShortcut = keybindingMatchesAction(
+      'editor.commandPalette',
+      event,
+      getShortcutPlatform()
+    )
+    if (!matchesShortcut && !matchesDefaultShortcut) {
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+    if (matchesShortcut && !event.repeat) {
+      onCommandPalette()
+    }
+  }
+
+  target.addEventListener('keydown', handleKeyDown, true)
+  return () => target.removeEventListener('keydown', handleKeyDown, true)
+}
+
+export function installMonacoEditorCommandPaletteShortcut(
+  editor: MonacoActionShortcutEditor
+): () => void {
+  return installEditorCommandPaletteShortcut(editor.getContainerDomNode(), () => {
+    void editor.getAction('editor.action.quickCommand')?.run()
   })
 }

--- a/src/renderer/src/components/editor/monaco-diff-command-palette-shortcuts.ts
+++ b/src/renderer/src/components/editor/monaco-diff-command-palette-shortcuts.ts
@@ -1,0 +1,20 @@
+import { installMonacoEditorCommandPaletteShortcut } from './editor-shortcuts'
+
+type MonacoCommandPaletteEditor = Parameters<typeof installMonacoEditorCommandPaletteShortcut>[0]
+
+type MonacoDiffCommandPaletteEditor = {
+  getOriginalEditor: () => MonacoCommandPaletteEditor
+  getModifiedEditor: () => MonacoCommandPaletteEditor
+}
+
+export function installMonacoDiffCommandPaletteShortcuts(
+  editor: MonacoDiffCommandPaletteEditor
+): () => void {
+  const cleanupOriginal = installMonacoEditorCommandPaletteShortcut(editor.getOriginalEditor())
+  const cleanupModified = installMonacoEditorCommandPaletteShortcut(editor.getModifiedEditor())
+
+  return () => {
+    cleanupOriginal()
+    cleanupModified()
+  }
+}

--- a/src/renderer/src/components/editor/monaco-editor-input-bindings.ts
+++ b/src/renderer/src/components/editor/monaco-editor-input-bindings.ts
@@ -8,6 +8,7 @@ import { getDiffCommentPopoverLeft } from '../diff-comments/diff-comment-popover
 import {
   installEditorAddReviewNoteShortcut,
   installEditorSaveShortcut,
+  installMonacoEditorCommandPaletteShortcut,
   installMonacoEditorFindShortcut
 } from './editor-shortcuts'
 import {
@@ -58,6 +59,7 @@ export function installMonacoEditorInputBindings(params: MonacoEditorInputBindin
     propsRef.current.onSave(value)
   })
   const cleanupFindShortcut = installMonacoEditorFindShortcut(editorInstance)
+  const cleanupCommandPaletteShortcut = installMonacoEditorCommandPaletteShortcut(editorInstance)
   // Opens the same composer as the selection "+" button.
   const cleanupAddReviewNoteShortcut = installEditorAddReviewNoteShortcut(editorDomNode, () => {
     // Why: keep an open draft instead of remounting, to avoid same-tick chord races before the composer guard runs.
@@ -132,6 +134,7 @@ export function installMonacoEditorInputBindings(params: MonacoEditorInputBindin
     disposeInputBindings: () => {
       cleanupSaveShortcut()
       cleanupFindShortcut()
+      cleanupCommandPaletteShortcut()
       cleanupAddReviewNoteShortcut()
       editorDomNode.removeEventListener('paste', onLargeTextPaste, { capture: true })
       searchInFilesAction.dispose()

--- a/src/shared/keybindings-default-bindings.test.ts
+++ b/src/shared/keybindings-default-bindings.test.ts
@@ -20,6 +20,28 @@ describe('keybindings', () => {
   })
 
   it.each(['darwin', 'linux', 'win32'] as const)(
+    'binds editor command palette to F1 on %s',
+    (platform) => {
+      expect(getEffectiveKeybindingsForAction('editor.commandPalette', platform)).toEqual(['F1'])
+      expect(formatKeybindingList(['F1'], platform)).toBe('F1')
+      expect(
+        keybindingMatchesAction(
+          'editor.commandPalette',
+          {
+            key: 'F1',
+            code: 'F1',
+            meta: false,
+            control: false,
+            alt: false,
+            shift: false
+          },
+          platform
+        )
+      ).toBe(true)
+    }
+  )
+
+  it.each(['darwin', 'linux', 'win32'] as const)(
     'binds editor word wrap to Alt+Z on %s',
     (platform) => {
       expect(getEffectiveKeybindingsForAction('editor.toggleWordWrap', platform)).toEqual(['Alt+Z'])

--- a/src/shared/keybindings/definitions-core-3.ts
+++ b/src/shared/keybindings/definitions-core-3.ts
@@ -35,6 +35,15 @@ export const KEYBINDING_DEFINITION_CORE_3: readonly KeybindingDefinition[] = [
     defaultBindings: platformBindings(['Mod+C'])
   },
   {
+    id: 'editor.commandPalette',
+    title: 'Command Palette',
+    group: 'Editors',
+    scope: 'editor',
+    searchKeywords: ['shortcut', 'editor', 'command', 'palette', 'f1', 'action'],
+    defaultBindings: platformBindings(['F1']),
+    allowBareKeybindings: true
+  },
+  {
     id: 'editor.find',
     title: 'Find in editor',
     group: 'Editors',

--- a/src/shared/keybindings/types.ts
+++ b/src/shared/keybindings/types.ts
@@ -83,6 +83,7 @@ export type KeybindingActionId =
   | 'browser.hardReload'
   | 'browser.focusAddressBar'
   | 'browser.grabElement'
+  | 'editor.commandPalette'
   | 'editor.find'
   | 'editor.replace'
   | 'editor.save'


### PR DESCRIPTION
## ELI5

When working inside code editors, diff viewers, or notebook cells, you can now press `F1` (or your custom configured shortcut such as `Cmd+Shift+P` / `Ctrl+Shift+P`) to open the editor command palette and quickly run Monaco editor actions.

## What Changed

1. **Keybinding Registry**:
   - Added `editor.commandPalette` action ID to `KeybindingActionId` in `src/shared/keybindings.ts`.
   - Defined default binding to `F1` under the `Editors` group with `editor` scope and `allowBareKeybindings: true`.
   - Added default keybinding tests across darwin, linux, and win32 in `src/shared/keybindings-default-bindings.test.ts`.

2. **Editor Shortcuts Bridge**:
   - Implemented `installEditorCommandPaletteShortcut` and `installMonacoEditorCommandPaletteShortcut` in `src/renderer/src/components/editor/editor-shortcuts.ts`.
   - Consumes matched key-repeats (`event.repeat`) during key-hold to prevent repeated invocation or event leaking to Monaco's built-in handlers while triggering `editor.action.quickCommand` on initial keydown.

3. **Editor Surface Integrations**:
   - Integrated into standard Monaco editor bindings via `src/renderer/src/components/editor/monaco-editor-input-bindings.ts`.
   - Integrated into both original and modified diff panes in `src/renderer/src/components/editor/DiffViewer.tsx` and `src/renderer/src/components/editor/DiffSectionItem.tsx`.
   - Integrated into Jupyter notebook code cells in `src/renderer/src/components/editor/IpynbCellEditor.tsx`.

4. **Unit Tests**:
   - Added unit tests in `src/renderer/src/components/editor/editor-shortcuts.test.ts` verifying default `F1` trigger, repeat key consumption, custom keybinding remapping (e.g., `Mod+Shift+P`), clean disposal, and Monaco action bridging.

## Why

In VS Code and Monaco-based editors, `F1` (or `Cmd+Shift+P` / `Ctrl+Shift+P`) is the standard shortcut to open the command palette for editor actions. Previously in Orca, there was no managed `editor.commandPalette` action in the keybinding system, preventing users from invoking or customizing this shortcut consistently across standard editors, diff panes, and notebook cells.

## Linked Issue

Fixes #16790


## Visual Proof

<img width="1189" height="1045" alt="image" src="https://github.com/user-attachments/assets/cb29884f-d0f3-48ce-b15d-01707b8501f8" />


## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Developed and validated with Gemini 3.7 Flash via Antigravity pair-programming agent.

## Review
- **Cross-platform**: Keybinding registered for all platforms (`darwin`, `linux`, `win32`). Tested across OS targets.
- **SSH / Remote / Local**: Pure client-side renderer keybinding and editor bridge; operates identically across local and remote sessions.
- **Performance**: Zero overhead; event listeners are attached in capture phase and cleanly disposed on unmount/teardown.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes
- **Security**: No security impact. Only triggers Monaco's existing in-memory editor actions.
- **Repeat Key Handling**: Follows the established pattern in `installEditorFindShortcut`, consuming hold repeats to prevent Monaco UI jitter.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
