### PR TITLE
feat(agent-session-continuation): continue a session in a new worktree

### DIFF
--- a/src/renderer/src/components/agent-session-continuation/AgentSessionContinuationDialog.test.tsx
+++ b/src/renderer/src/components/agent-session-continuation/AgentSessionContinuationDialog.test.tsx
@@ -8,15 +8,21 @@ import type { AgentSessionContinuationRequest } from '@/lib/agent-session-contin
 const mocks = vi.hoisted(() => ({
   detectAgents: vi.fn(),
   launchContinuation: vi.fn(),
-  settings: { defaultTuiAgent: 'codex', disabledTuiAgents: [] }
+  launchContinuationInNewWorktree: vi.fn(),
+  settings: { defaultTuiAgent: 'codex', disabledTuiAgents: [] },
+  repos: [{ id: 'repo-1', kind: 'git' }] as { id: string; kind: string }[]
 }))
 
 vi.mock('@/store', () => ({
-  useAppStore: (selector: (state: unknown) => unknown) => selector({ settings: mocks.settings })
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({ settings: mocks.settings, repos: mocks.repos })
 }))
 vi.mock('@/lib/launch-agent-session-continuation', () => ({
   detectAgentSessionContinuationAgents: mocks.detectAgents,
   launchAgentSessionContinuation: mocks.launchContinuation
+}))
+vi.mock('@/lib/launch-agent-session-continuation-worktree', () => ({
+  launchAgentSessionContinuationInNewWorktree: mocks.launchContinuationInNewWorktree
 }))
 vi.mock('@/lib/agent-catalog', () => ({
   getAgentCatalog: () => [{ id: 'codex', label: 'Codex' }],
@@ -40,21 +46,39 @@ vi.mock('@/components/ui/dialog', () => ({
   DialogTitle: ({ children }: { children?: ReactNode }) => React.createElement('h2', null, children)
 }))
 vi.mock('@/components/ui/select', () => ({
-  Select: ({ children }: { children?: ReactNode }) => React.createElement('div', null, children),
-  SelectContent: ({ children }: { children?: ReactNode }) =>
-    React.createElement('div', null, children),
-  SelectItem: ({ children }: { children?: ReactNode }) =>
-    React.createElement('div', null, children),
-  SelectTrigger: ({ children }: { children?: ReactNode }) =>
-    React.createElement('button', null, children),
-  SelectValue: () => React.createElement('span')
+  Select: ({
+    value,
+    onValueChange,
+    children
+  }: {
+    value?: string
+    onValueChange?: (next: string) => void
+    children?: ReactNode
+  }) =>
+    React.createElement(
+      'select',
+      {
+        value,
+        onChange: (event: { target: { value: string } }) => onValueChange?.(event.target.value)
+      },
+      children
+    ),
+  SelectContent: ({ children }: { children?: ReactNode }) => children,
+  SelectItem: ({ value, children }: { value?: string; children?: ReactNode }) =>
+    React.createElement('option', { value }, children),
+  SelectTrigger: () => null,
+  SelectValue: () => null
 }))
 
 import { AgentSessionContinuationDialog } from './AgentSessionContinuationDialog'
 
-function request(worktreeId: string): AgentSessionContinuationRequest {
+function request(worktreeId: string, sourceTitle?: string): AgentSessionContinuationRequest {
   return {
-    source: { capturedText: 'previous session', sourceAgent: 'codex' },
+    source: {
+      capturedText: 'previous session',
+      sourceAgent: 'codex',
+      ...(sourceTitle ? { sourceTitle } : {})
+    },
     worktreeId,
     workspacePath: '/repo',
     launchSource: 'sidebar'
@@ -105,5 +129,82 @@ describe('AgentSessionContinuationDialog', () => {
 
     await act(async () => resolveSecond(['codex']))
     await vi.waitFor(() => expect(container.querySelector('[data-agent="codex"]')).not.toBeNull())
+  })
+
+  it('offers a new worktree for a git workspace and seeds the branch from the tab title', async () => {
+    mocks.detectAgents.mockResolvedValue(['codex'])
+
+    await act(async () => {
+      root.render(
+        <AgentSessionContinuationDialog
+          open
+          request={request('repo-1::/repo/wt', '\u2733 RW-20595 nested components')}
+          onOpenChange={vi.fn()}
+        />
+      )
+    })
+
+    expect(container.textContent).toContain('Destination')
+    const destination = container.querySelectorAll('select')[1]
+    expect(destination).toBeDefined()
+
+    await act(async () => {
+      destination.value = 'new-worktree'
+      destination.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+
+    const branchInput = container.querySelector('input')
+    expect(branchInput?.value).toBe('RW-20595')
+  })
+
+  it('hides the destination picker for a folder workspace', async () => {
+    mocks.detectAgents.mockResolvedValue(['codex'])
+    mocks.repos = [{ id: 'repo-1', kind: 'folder' }]
+
+    await act(async () => {
+      root.render(
+        <AgentSessionContinuationDialog
+          open
+          request={request('repo-1::/repo/wt', 'RW-20595')}
+          onOpenChange={vi.fn()}
+        />
+      )
+    })
+
+    expect(container.textContent).not.toContain('Destination')
+    mocks.repos = [{ id: 'repo-1', kind: 'git' }]
+  })
+
+  it('creates the worktree instead of a tab when the destination is a new worktree', async () => {
+    mocks.detectAgents.mockResolvedValue(['codex'])
+    mocks.launchContinuationInNewWorktree.mockReturnValue(true)
+
+    await act(async () => {
+      root.render(
+        <AgentSessionContinuationDialog
+          open
+          request={request('repo-1::/repo/wt', 'RW-20595')}
+          onOpenChange={vi.fn()}
+        />
+      )
+    })
+
+    await act(async () => {
+      const destination = container.querySelectorAll('select')[1]
+      destination.value = 'new-worktree'
+      destination.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+
+    const startButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Start New Session')
+    )
+    await act(async () => {
+      startButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(mocks.launchContinuation).not.toHaveBeenCalled()
+    expect(mocks.launchContinuationInNewWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({ repoId: 'repo-1', branchName: 'RW-20595', agent: 'codex' })
+    )
   })
 })

--- a/src/renderer/src/components/agent-session-continuation/AgentSessionContinuationDialog.test.tsx
+++ b/src/renderer/src/components/agent-session-continuation/AgentSessionContinuationDialog.test.tsx
@@ -207,4 +207,40 @@ describe('AgentSessionContinuationDialog', () => {
       expect.objectContaining({ repoId: 'repo-1', branchName: 'RW-20595', agent: 'codex' })
     )
   })
+
+  it('falls back to this workspace when the repo stops offering worktrees after selection', async () => {
+    mocks.detectAgents.mockResolvedValue(['codex'])
+    mocks.launchContinuation.mockResolvedValue(true)
+    const pending = request('repo-1::/repo/wt', 'RW-20595')
+
+    await act(async () => {
+      root.render(<AgentSessionContinuationDialog open request={pending} onOpenChange={vi.fn()} />)
+    })
+
+    await act(async () => {
+      const destination = container.querySelectorAll('select')[1]
+      destination.value = 'new-worktree'
+      destination.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+
+    // Why: the picker vanishes, but the 'new-worktree' selection it left behind must not launch.
+    mocks.repos = [{ id: 'repo-1', kind: 'folder' }]
+    await act(async () => {
+      root.render(<AgentSessionContinuationDialog open request={pending} onOpenChange={vi.fn()} />)
+    })
+    expect(container.textContent).not.toContain('Destination')
+
+    const startButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Start New Session')
+    )
+    await act(async () => {
+      startButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(mocks.launchContinuationInNewWorktree).not.toHaveBeenCalled()
+    expect(mocks.launchContinuation).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: 'repo-1::/repo/wt', agent: 'codex' })
+    )
+    mocks.repos = [{ id: 'repo-1', kind: 'git' }]
+  })
 })

--- a/src/renderer/src/components/agent-session-continuation/AgentSessionContinuationDialog.tsx
+++ b/src/renderer/src/components/agent-session-continuation/AgentSessionContinuationDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Loader2, MessageSquarePlus } from 'lucide-react'
 import AgentCombobox from '@/components/agent/AgentCombobox'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import {
   Dialog,
   DialogContent,
@@ -29,8 +30,11 @@ import {
   detectAgentSessionContinuationAgents,
   launchAgentSessionContinuation
 } from '@/lib/launch-agent-session-continuation'
+import { launchAgentSessionContinuationInNewWorktree } from '@/lib/launch-agent-session-continuation-worktree'
 import { useAppStore } from '@/store'
 import { isTuiAgentEnabled } from '../../../../shared/tui-agent-selection'
+import { isGitRepoKind } from '../../../../shared/repo-kind'
+import { splitWorktreeIdForFilesystem } from '../../../../shared/worktree/id'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import { chooseInitialContinuationAgent } from './agent-session-continuation-selection'
 
@@ -41,6 +45,22 @@ type AgentSessionContinuationDialogProps = {
 }
 
 const EMPTY_DISABLED_AGENTS: TuiAgent[] = []
+
+type ContinuationDestination = 'current' | 'new-worktree'
+
+// Why: the source tab title usually already carries the ticket id, so the branch
+// name is a confirmation rather than a fresh decision.
+function suggestBranchName(sourceTitle: string | null | undefined): string {
+  const title = sourceTitle?.trim() ?? ''
+  const ticket = /[A-Z]{2,}[-/]\d+/.exec(title)?.[0]
+  if (ticket) {
+    return ticket.replace('/', '-')
+  }
+  return title
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40)
+}
 
 export function AgentSessionContinuationDialog({
   open,
@@ -55,7 +75,19 @@ export function AgentSessionContinuationDialog({
   const [detectionFailed, setDetectionFailed] = useState(false)
   const [starting, setStarting] = useState(false)
   const [showStarting, setShowStarting] = useState(false)
+  const [destination, setDestination] = useState<ContinuationDestination>('current')
+  const [branchName, setBranchName] = useState('')
+  const [baseRef, setBaseRef] = useState('')
+  const repos = useAppStore((state) => state.repos)
   const disabledAgents = settings?.disabledTuiAgents ?? EMPTY_DISABLED_AGENTS
+  const sourceRepoId = request
+    ? (splitWorktreeIdForFilesystem(request.worktreeId)?.repoId ?? null)
+    : null
+  // Why: folder workspaces have no branches, so a new worktree is not a destination there.
+  const canCreateWorktree = useMemo(() => {
+    const repo = sourceRepoId ? repos.find((entry) => entry.id === sourceRepoId) : null
+    return Boolean(repo && isGitRepoKind(repo))
+  }, [repos, sourceRepoId])
 
   const agents = useMemo(
     () =>
@@ -76,6 +108,9 @@ export function AgentSessionContinuationDialog({
     setDetectedAgents([])
     setSelectedAgent(null)
     setContextMode('focused')
+    setDestination('current')
+    setBranchName(suggestBranchName(request.source.sourceTitle))
+    setBaseRef('')
     void detectAgentSessionContinuationAgents(request.worktreeId)
       .then((detected) => {
         if (cancelled) {
@@ -129,15 +164,27 @@ export function AgentSessionContinuationDialog({
       return
     }
     setStarting(true)
-    const launched = await launchAgentSessionContinuation({
-      agent: selectedAgent,
-      prompt,
-      worktreeId: request.worktreeId,
-      groupId: request.groupId,
-      workspacePath: request.workspacePath,
-      initialCwd: request.initialCwd,
-      launchSource: request.launchSource
-    })
+    const launched =
+      destination === 'new-worktree' && sourceRepoId
+        ? launchAgentSessionContinuationInNewWorktree({
+            agent: selectedAgent,
+            prompt,
+            repoId: sourceRepoId,
+            branchName: branchName.trim(),
+            baseBranch: baseRef.trim() || null,
+            sourceTitle: request.source.sourceTitle,
+            telemetrySource:
+              request.launchSource === 'sidebar' ? 'sidebar' : 'terminal_context_menu'
+          })
+        : await launchAgentSessionContinuation({
+            agent: selectedAgent,
+            prompt,
+            worktreeId: request.worktreeId,
+            groupId: request.groupId,
+            workspacePath: request.workspacePath,
+            initialCwd: request.initialCwd,
+            launchSource: request.launchSource
+          })
     setStarting(false)
     if (launched) {
       onOpenChange(false)
@@ -148,7 +195,13 @@ export function AgentSessionContinuationDialog({
   const sourceAgentLabel = request?.source.sourceAgent
     ? getAgentLabel(request.source.sourceAgent)
     : null
-  const startDisabled = detecting || starting || agents.length === 0 || !selectedAgent
+  const creatingWorktree = destination === 'new-worktree'
+  const startDisabled =
+    detecting ||
+    starting ||
+    agents.length === 0 ||
+    !selectedAgent ||
+    (creatingWorktree && !branchName.trim())
 
   return (
     <Dialog
@@ -274,7 +327,65 @@ export function AgentSessionContinuationDialog({
             </p>
           </div>
 
-          {request?.initialCwd ? (
+          {canCreateWorktree ? (
+            <div className="min-w-0 space-y-1.5">
+              <label className="text-xs font-medium">
+                {translate('components.agentSessionContinuation.destination', 'Destination')}
+              </label>
+              <Select
+                value={destination}
+                onValueChange={(value) => setDestination(value as ContinuationDestination)}
+              >
+                <SelectTrigger className="min-w-0 w-full" size="sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="current">
+                    {translate(
+                      'components.agentSessionContinuation.destinationCurrent',
+                      'This workspace'
+                    )}
+                  </SelectItem>
+                  <SelectItem value="new-worktree">
+                    {translate(
+                      'components.agentSessionContinuation.destinationNewWorktree',
+                      'New worktree'
+                    )}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              {creatingWorktree ? (
+                <div className="min-w-0 space-y-1.5 pt-1">
+                  <Input
+                    value={branchName}
+                    onChange={(event) => setBranchName(event.target.value)}
+                    placeholder={translate(
+                      'components.agentSessionContinuation.branchNamePlaceholder',
+                      'Branch name'
+                    )}
+                    className="min-w-0 w-full"
+                  />
+                  <Input
+                    value={baseRef}
+                    onChange={(event) => setBaseRef(event.target.value)}
+                    placeholder={translate(
+                      'components.agentSessionContinuation.baseRefPlaceholder',
+                      'Base ref (defaults to the project base)'
+                    )}
+                    className="min-w-0 w-full"
+                  />
+                  <p className="text-[11px] leading-4 text-muted-foreground">
+                    {translate(
+                      'components.agentSessionContinuation.destinationNewWorktreeDescription',
+                      'Creates the worktree, then starts the Agent there with this context. Uncommitted changes stay in the source workspace.'
+                    )}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {!creatingWorktree && request?.initialCwd ? (
             <div className="text-[11px] text-muted-foreground">
               {translate('components.agentSessionContinuation.startsIn', 'Starts in:')}{' '}
               <span className="break-all font-mono text-foreground/80">{request.initialCwd}</span>

--- a/src/renderer/src/components/agent-session-continuation/AgentSessionContinuationDialog.tsx
+++ b/src/renderer/src/components/agent-session-continuation/AgentSessionContinuationDialog.tsx
@@ -88,6 +88,9 @@ export function AgentSessionContinuationDialog({
     const repo = sourceRepoId ? repos.find((entry) => entry.id === sourceRepoId) : null
     return Boolean(repo && isGitRepoKind(repo))
   }, [repos, sourceRepoId])
+  // Why: the picker disappears when Git becomes unavailable, but the selection it left behind
+  // would still launch the worktree path.
+  const creatingWorktree = destination === 'new-worktree' && canCreateWorktree
 
   const agents = useMemo(
     () =>
@@ -165,7 +168,7 @@ export function AgentSessionContinuationDialog({
     }
     setStarting(true)
     const launched =
-      destination === 'new-worktree' && sourceRepoId
+      creatingWorktree && sourceRepoId
         ? launchAgentSessionContinuationInNewWorktree({
             agent: selectedAgent,
             prompt,
@@ -195,7 +198,6 @@ export function AgentSessionContinuationDialog({
   const sourceAgentLabel = request?.source.sourceAgent
     ? getAgentLabel(request.source.sourceAgent)
     : null
-  const creatingWorktree = destination === 'new-worktree'
   const startDisabled =
     detecting ||
     starting ||

--- a/src/renderer/src/components/terminal-pane/terminal-agent-session-continuation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-session-continuation.test.ts
@@ -14,7 +14,11 @@ const store = {
       providerSession?: { transcriptPath?: string }
     }
   >,
-  tabsByWorktree: {} as Record<string, { id: string; launchAgent?: string | null }[]>
+  tabsByWorktree: {} as Record<
+    string,
+    { id: string; launchAgent?: string | null; title?: string; customTitle?: string | null }[]
+  >,
+  settings: undefined as { tabAutoGenerateTitle?: boolean } | undefined
 }
 
 vi.mock('@/store', () => ({ useAppStore: { getState: () => store } }))
@@ -78,6 +82,7 @@ describe('prepareAgentSessionContinuationFromPane', () => {
       }
     }
     store.tabsByWorktree = { 'wt-1': [{ id: 'tab-1', launchAgent: 'claude' }] }
+    store.settings = undefined
   })
 
   it('prepares a generic request without serializing when a transcript exists', () => {
@@ -122,5 +127,31 @@ describe('prepareAgentSessionContinuationFromPane', () => {
       capturedText: 'latest terminal context',
       transcriptPath: null
     })
+  })
+
+  it('carries the resolved tab label so the dialog can seed a branch name', () => {
+    // Why: the destination picker seeds the branch from this title; without it
+    // the terminal entry point hands the dialog nothing to seed from.
+    store.tabsByWorktree = {
+      'wt-1': [
+        {
+          id: 'tab-1',
+          launchAgent: 'claude',
+          title: 'claude working',
+          customTitle: '\u2733 RW-20595 nested components'
+        }
+      ]
+    }
+
+    const request = prepareAgentSessionContinuationFromPane({
+      pane: makePane('unused scrollback'),
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      groupId: null,
+      workspacePath: '/repo/worktree',
+      initialCwd: '/repo/worktree'
+    })
+
+    expect(request?.source.sourceTitle).toBe('\u2733 RW-20595 nested components')
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-agent-session-continuation.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-session-continuation.ts
@@ -7,6 +7,7 @@ import {
 import { useAppStore } from '@/store'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
+import { resolveTerminalTabTitle } from '../../../../shared/tab-title-resolution'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import { translate } from '@/i18n/i18n'
 
@@ -53,6 +54,12 @@ export function prepareAgentSessionContinuationFromPane({
   const paneKey = makePaneKey(tabId, pane.leafId)
   const status = state.agentStatusByPaneKey[paneKey]
   const sourceAgent = resolveSourceAgent({ pane, tabId, worktreeId })
+  // Why: the tab label is what the user named this work, so the continuation
+  // dialog can seed a branch name from it instead of asking twice.
+  const tab = state.tabsByWorktree[worktreeId]?.find((entry) => entry.id === tabId)
+  const sourceTitle = tab
+    ? resolveTerminalTabTitle(tab, state.settings?.tabAutoGenerateTitle === true, tab.title)
+    : null
   const transcriptPath = status?.providerSession?.transcriptPath?.trim() || null
   const capturedText = transcriptPath ? '' : pane.serializeAddon.serialize({ scrollback: 800 })
   const source = {
@@ -63,7 +70,8 @@ export function prepareAgentSessionContinuationFromPane({
     sourceWorkingDirectory: initialCwd || workspacePath,
     transcriptPath,
     lastPrompt: status?.prompt,
-    lastAssistantMessage: status?.lastAssistantMessage
+    lastAssistantMessage: status?.lastAssistantMessage,
+    sourceTitle
   }
   if (!buildAgentSessionContinuationPrompt(source, 'focused')) {
     toast.error(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16756,7 +16756,15 @@
       "agentUnavailable": "{{agent}} was not detected on this workspace host.",
       "sent": "Session context sent to {{agent}} in a new session.",
       "deliveryFailed": "The new {{agent}} session started, but its context could not be sent.",
-      "launchFailed": "Could not start a new {{agent}} session."
+      "launchFailed": "Could not start a new {{agent}} session.",
+      "destination": "Destination",
+      "destinationCurrent": "This workspace",
+      "destinationNewWorktree": "New worktree",
+      "branchNamePlaceholder": "Branch name",
+      "baseRefPlaceholder": "Base ref (defaults to the project base)",
+      "destinationNewWorktreeDescription": "Creates the worktree, then starts the Agent there with this context. Uncommitted changes stay in the source workspace.",
+      "worktreeRepoMissing": "Could not find the project this session belongs to.",
+      "creatingWorktree": "Creating {{branch}} and starting {{agent}} there."
     },
     "status": {
       "bar": {

--- a/src/renderer/src/lib/launch-agent-session-continuation-worktree.ts
+++ b/src/renderer/src/lib/launch-agent-session-continuation-worktree.ts
@@ -1,0 +1,113 @@
+import { toast } from 'sonner'
+import { getAgentLabel } from '@/lib/agent-catalog'
+import { getAgentLaunchPlatformForRepo } from '@/lib/agent-launch-platform'
+import { getLocalRepoProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
+import { CLIENT_PLATFORM } from '@/lib/new-workspace'
+import { runBackgroundWorktreeCreation } from '@/lib/worktree-creation-flow'
+import { buildQuickComposerStartup } from '@/hooks/composer-state/quick-startup-plan'
+import { useAppStore } from '@/store'
+import { repoIsRemote } from '../../../shared/agent-launch-remote'
+import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
+import { translate } from '@/i18n/i18n'
+import type { TuiAgent } from '../../../shared/tui-agent'
+import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
+
+type LaunchContinuationInNewWorktreeArgs = {
+  agent: TuiAgent
+  prompt: string
+  repoId: string
+  branchName: string
+  baseBranch?: string | null
+  sourceTitle?: string | null
+  telemetrySource: WorktreeCreationRequest['telemetrySource']
+}
+
+/**
+ * Continue a session in a checkout that does not exist yet: create the worktree
+ * and hand the continuation prompt to the agent Orca starts inside it.
+ *
+ * Why a separate entry point: `launchAgentSessionContinuation` opens a tab in a
+ * live worktree, so it can detect agents and preflight trust against a real
+ * path. Here the worktree is created first and the launch is owned by the
+ * creation flow, which already knows how to seed an agent from a startup plan.
+ */
+export function launchAgentSessionContinuationInNewWorktree({
+  agent,
+  prompt,
+  repoId,
+  branchName,
+  baseBranch,
+  sourceTitle,
+  telemetrySource
+}: LaunchContinuationInNewWorktreeArgs): boolean {
+  const state = useAppStore.getState()
+  const repo = state.repos.find((entry) => entry.id === repoId)
+  if (!repo) {
+    toast.error(
+      translate(
+        'components.agentSessionContinuation.worktreeRepoMissing',
+        'Could not find the project this session belongs to.'
+      )
+    )
+    return false
+  }
+
+  const projectRuntime = repo.connectionId
+    ? undefined
+    : getLocalRepoProjectExecutionRuntimeContext(
+        {
+          activeRepoId: repoId,
+          activeWorktreeId: null,
+          projects: state.projects,
+          repos: state.repos,
+          settings: state.settings,
+          worktreesByRepo: state.worktreesByRepo
+        },
+        repoId,
+        CLIENT_PLATFORM
+      )
+  const platform = getAgentLaunchPlatformForRepo(repo, projectRuntime)
+  const isRemote = repoIsRemote(repo)
+
+  // Why: `prompt` and not `draftPrompt` — the continuation is already reviewed
+  // in the dialog, so the new agent should start on it rather than wait on a
+  // draft the user has to submit again.
+  const { startupPlan, backendStartup, telemetry } = buildQuickComposerStartup({
+    agent,
+    prompt,
+    draftPrompt: null,
+    settings: state.settings,
+    repoConnectionId: repo.connectionId,
+    platform,
+    shell: resolveLocalWindowsAgentStartupShell({
+      platform,
+      isRemote,
+      terminalWindowsShell: state.settings?.terminalWindowsShell
+    }),
+    isRemote,
+    telemetrySource
+  })
+
+  const creationId = runBackgroundWorktreeCreation({
+    repoId,
+    name: branchName,
+    ...(baseBranch ? { baseBranch } : {}),
+    setupDecision: 'inherit',
+    agent,
+    startup: backendStartup,
+    startupPlan,
+    quickPrompt: prompt,
+    quickTelemetry: telemetry,
+    pendingFirstAgentMessageRename: false,
+    note: sourceTitle?.trim() ? `Continued from: ${sourceTitle.trim()}` : ''
+  })
+
+  toast.success(
+    translate(
+      'components.agentSessionContinuation.creatingWorktree',
+      'Creating {{branch}} and starting {{agent}} there.',
+      { branch: branchName, agent: getAgentLabel(agent) }
+    )
+  )
+  return Boolean(creationId)
+}


### PR DESCRIPTION
## ELI5

Research starts in the primary workspace, then turns into a change that needs
its own branch. **Continue in New Session…** could not take you there: it
always reopened in the workspace you were already in. This adds a
**Destination** picker to that dialog — stay here, or create a new worktree and
let the agent start there with the same handed-off context.

## What Changed

`AgentSessionContinuationDialog` gains a **Destination** picker:

- **This workspace** — today's behavior, unchanged and still the default.
- **New worktree** — branch name plus base ref; an empty base falls back to the
  project default. `Starts in:` is hidden for this destination because that
  path does not exist yet.

The new launch lives in `launch-agent-session-continuation-worktree.ts` and
reuses what is already there rather than adding a parallel launch path:
`buildQuickComposerStartup` for the startup plan, `runBackgroundWorktreeCreation`
for the create. The prompt is passed as `prompt`, not `draftPrompt`, so the
agent starts on the continuation instead of waiting on a draft the user has to
submit again — it was already reviewed in the dialog.

Two details worth calling out:

- the branch name is seeded from the source tab title, which usually already
  carries the ticket id (`✳ RW-20595 nested components` → `RW-20595`), and
  stays editable;
- folder workspaces have no branches, so the picker is hidden when the source
  workspace is not a git repo (`isGitRepoKind`), and the effective destination
  falls back to this workspace with it.

The terminal entry point now also fills `sourceTitle` on the request, resolved
through the same `resolveTerminalTabTitle` the tab bar uses. Without it only the
AI Vault path set a title, so from the terminal pane the dialog had nothing to
seed the branch name from and the field opened empty.

Also in this PR: the eight new `translate()` keys are registered in `en.json`
via `pnpm run sync:localization-catalog` — without it `verify:localization-catalog`
and `verify:localization-extraction` fail and `pnpm lint` is red. No other
locale is touched, so the rest fall back to English until translated.

## Why

The continuation dialog inherits `worktreeId` from the source session, so every
continuation lands in the same workspace. Research often begins in the primary
workspace and becomes a code change, and that change needs its own branch and
checkout — otherwise several sessions write to one git index and "what exactly
am I committing for this task" stops being answerable. The only way to a fresh
worktree today is to drop the session context and start over, which is exactly
the work this flow exists to avoid.

The approach stays inside existing machinery: no new IPC surface, no second
worktree-creation path, no per-agent branching. The picker is a destination
choice in front of a launch that Orca already performs from the composer.

## Linked Issue

Fixes #19293

## Visual Proof

Captured from a live Electron build driven by the repo's own E2E harness
(`_electron` + an isolated userData dir + the seeded fixture repo), so every
path and title on screen belongs to a throwaway test workspace.

**Before** — the dialog `main` ships today: Agent, Context, `Starts in:`, and no
way to leave the source workspace.

![Before: no destination picker](https://raw.githubusercontent.com/dmitrygil1/orca/pr-16794-screenshots/01-before-no-destination.png)

**After, default** — a **Destination** row appears between Context and
`Starts in:`, preselected to **This workspace**. Everything else, including
`Starts in:`, is unchanged.

![After: destination set to this workspace](https://raw.githubusercontent.com/dmitrygil1/orca/pr-16794-screenshots/02-after-this-workspace.png)

**After, new worktree** — branch name and base ref appear, the branch is seeded
from the tab label (`✳ ORCA-1234 rate limit banner` → `ORCA-1234`), the
explanation names what happens to uncommitted changes, and `Starts in:`
disappears because that path does not exist yet.

![After: destination set to a new worktree](https://raw.githubusercontent.com/dmitrygil1/orca/pr-16794-screenshots/03-after-new-worktree.png)

**After, branch cleared** — `Start New Session` is disabled while the branch
name is empty, so the worktree path cannot be started without one.

![After: start disabled without a branch name](https://raw.githubusercontent.com/dmitrygil1/orca/pr-16794-screenshots/04-after-branch-required.png)

## Testing

Verified against a live dev build on macOS: the destination picker renders
between Context and `Starts in:`, switching to **New worktree** reveals the
branch and base-ref fields, `Start New Session` stays disabled until a branch
name is present, `Starts in:` hides for that destination, and the worktree is
created with the agent starting on the continuation prompt.

Automated, on this branch:

- `pnpm lint` — green (includes `verify:localization-catalog`,
  `verify:localization-extraction`, `verify:localization-coverage`)
- `pnpm typecheck` — green
- `pnpm build` — green (`build:desktop` + `build:native`, macOS)
- `pnpm test src/renderer/src/components/agent-session-continuation src/renderer/src/lib/launch-agent-session-continuation.test.ts src/renderer/src/i18n`
  — 21 files, 157 tests passing. The full suite is left to CI.

`AgentSessionContinuationDialog.test.tsx` covers: the branch seed from a tab
title, the picker staying hidden for a folder workspace, the new-worktree
destination calling the create path instead of `launchAgentSessionContinuation`,
and a regression case where the repo stops offering worktrees after selection —
the launch must fall back to this workspace. That last test fails if the
`canCreateWorktree` guard in `handleStart` is reverted, so it catches the actual
defect rather than the happy path.

Platforms actually exercised by hand: macOS. Linux, Windows and SSH are covered
by reuse rather than manual runs — see Review.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Opus 5 (1M context) through Claude Code: the implementation,
the tests, and the `canCreateWorktree` fix below. Every command quoted under
Testing was run locally and its output read, not assumed.

## Review

AI code review summary, dimensions the contributor guide asks for:

- **Cross-platform.** No new path building and no platform branch of my own.
  The launch platform comes from `getAgentLaunchPlatformForRepo`, and the
  Windows startup shell from `resolveLocalWindowsAgentStartupShell` — the same
  helpers the composer quick-start uses. Shortcut labels and accelerators are
  untouched.
- **Remote / SSH.** `repo.connectionId` short-circuits the local runtime probe,
  and `repoIsRemote(repo)` feeds the startup plan, so a remote repo does not
  get local preflight context. Worktree creation goes through
  `runBackgroundWorktreeCreation`, the same remote-aware flow used elsewhere;
  no process, credential, shell, or filesystem path is assumed local. Not
  exercised by hand over SSH — flagging that honestly.
- **Agents and integrations.** Agent-neutral: `TuiAgent` in, `getAgentLabel`
  for display, no per-agent or per-provider branching. Nothing git-provider
  specific.
- **Performance.** No hot-path work. The dialog adds two derived constants and
  one memo dependency; the launch is a single background creation, already the
  existing mechanism.
- **UI quality.** Existing shadcn `Select` and `Input` primitives and current
  tokens, per `docs/STYLEGUIDE.md`. The picker is hidden rather than disabled
  where it cannot apply, and its selection cannot outlive its visibility (that
  is the regression test above).
- **Security.** No new IPC surface, no new persisted state, no credential
  handling. The prompt text follows the same route as a composer quick start.
- **Backwards compatibility.** The default destination is unchanged, so an
  untouched dialog behaves exactly as before.

Known limitation, stated rather than hidden: only `en.json` is populated; other
catalogs fall back to English until translated.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

CodeRabbit's one actionable comment (a hidden stale destination could still
launch the worktree path when `canCreateWorktree` flipped after selection) is
fixed in `17abe7f9`: `creatingWorktree` now folds in `canCreateWorktree` and
`handleStart` starts from that effective value. A regression test comes with it.

Capturing the screenshots is what surfaced the empty branch-name field, fixed in
`a73da8f2`: the described seeding only worked from the AI Vault path. The
regression is covered by a unit test on `prepareAgentSessionContinuationFromPane`.

No conflicts with `main` (`mergeable: MERGEABLE`), and every module this branch
imports still exists upstream under the same path after the `shared/types`
barrel removal.

CI on this PR has never run — a maintainer's approval is needed to start
workflows for a fork PR, so the checks are empty rather than failing.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck` and `pnpm build` pass locally; targeted test suites pass, full `pnpm test` left to CI
