### PR TITLE
fix(terminal): preserve host PTY binding over stale renderer replay

### DIFF
--- a/src/main/persistence-pty-binding-reconciliation.test.ts
+++ b/src/main/persistence-pty-binding-reconciliation.test.ts
@@ -221,6 +221,56 @@ describe('Store', () => {
     })
   })
 
+  it('advances topology when a host-admitted PTY fills an existing renderer tab', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {
+        wt1: [makeTerminalTab({ id: 'tab1', worktreeId: 'wt1', ptyId: null })]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: TEST_LEAF_1 },
+          activeLeafId: TEST_LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      }
+    })
+
+    expect(
+      store.persistPtyBinding({
+        worktreeId: 'wt1',
+        tabId: 'tab1',
+        leafId: TEST_LEAF_1,
+        ptyId: 'host-pty',
+        hostAdmittedMembership: true
+      })
+    ).toBe(true)
+
+    expect(store.getWorkspaceSession().terminalTopologyRevisionByRepoId?.wt1).toBe(1)
+
+    // The renderer's pre-spawn snapshot must not erase the host's binding.
+    store.setWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {
+        wt1: [makeTerminalTab({ id: 'tab1', worktreeId: 'wt1', ptyId: null })]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: TEST_LEAF_1 },
+          activeLeafId: TEST_LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      }
+    })
+    expect(store.getWorkspaceSession().tabsByWorktree.wt1[0].ptyId).toBe('host-pty')
+    expect(
+      store.getWorkspaceSession().terminalLayoutsByTabId.tab1?.ptyIdsByLeafId?.[TEST_LEAF_1]
+    ).toBe('host-pty')
+  })
+
   it('admits a fresh host spawn after retirement while rejecting an older renderer topology', async () => {
     const store = await createStore()
     store.setWorkspaceSession({

--- a/src/main/persistence-pty-binding-reconciliation.test.ts
+++ b/src/main/persistence-pty-binding-reconciliation.test.ts
@@ -381,6 +381,83 @@ describe('Store', () => {
     ).toBe('host-pty')
   })
 
+  // The host-partitioned path is separate code: a non-local binding reads and writes
+  // `workspaceSessionsByHostId[hostId]`, and its rollback restores that partition rather
+  // than `workspaceSession`. Fence a remote binding and pin that the local partition is
+  // left alone, so an SSH host can never correct a pane by writing over local state.
+  it('fences a remote host binding without touching the local session', async () => {
+    const store = await createStore()
+    const HOST_ID = 'ssh:remote-1'
+    const rendererReplay = (): void => {
+      store.setWorkspaceSession(
+        {
+          ...getDefaultWorkspaceSession(),
+          tabsByWorktree: {
+            wt1: [makeTerminalTab({ id: 'tab1', worktreeId: 'wt1', ptyId: 'stale-pty' })]
+          },
+          terminalLayoutsByTabId: {
+            tab1: {
+              root: { type: 'leaf', leafId: TEST_LEAF_1 },
+              activeLeafId: TEST_LEAF_1,
+              expandedLeafId: null,
+              ptyIdsByLeafId: { [TEST_LEAF_1]: 'stale-pty' }
+            }
+          }
+        },
+        HOST_ID
+      )
+    }
+    rendererReplay()
+
+    expect(
+      store.persistPtyBinding(
+        {
+          worktreeId: 'wt1',
+          tabId: 'tab1',
+          leafId: TEST_LEAF_1,
+          ptyId: 'host-pty',
+          hostAdmittedMembership: true
+        },
+        HOST_ID
+      )
+    ).toBe(true)
+
+    rendererReplay()
+
+    const remote = store.getWorkspaceSession(HOST_ID)
+    expect(remote.terminalLayoutsByTabId.tab1?.ptyIdsByLeafId?.[TEST_LEAF_1]).toBe('host-pty')
+    expect(remote.tabsByWorktree.wt1[0].ptyId).toBe('host-pty')
+    // Host isolation: the remote binding must not have leaked into the local partition.
+    expect(store.getWorkspaceSession().tabsByWorktree.wt1).toBeUndefined()
+  })
+
+  // The first binding on a host has no partition to mutate: `getWorkspaceSession` hands back
+  // a fresh default that is stored nowhere, so the binding only survives because the non-local
+  // branch writes the session into `workspaceSessionsByHostId`. Without that write the whole
+  // binding is silently dropped, and the remote pane comes back unbound.
+  it('creates the host partition when a remote host binds its first pane', async () => {
+    const store = await createStore()
+    const HOST_ID = 'ssh:remote-2'
+
+    expect(
+      store.persistPtyBinding(
+        {
+          worktreeId: 'wt1',
+          tabId: 'tab1',
+          leafId: TEST_LEAF_1,
+          ptyId: 'remote-pty',
+          hostAdmittedMembership: true
+        },
+        HOST_ID
+      )
+    ).toBe(true)
+
+    const remote = store.getWorkspaceSession(HOST_ID)
+    expect(remote.terminalLayoutsByTabId.tab1?.ptyIdsByLeafId?.[TEST_LEAF_1]).toBe('remote-pty')
+    expect(remote.tabsByWorktree.wt1?.[0]?.ptyId).toBe('remote-pty')
+    expect(store.getWorkspaceSession().tabsByWorktree.wt1).toBeUndefined()
+  })
+
   it('admits a fresh host spawn after retirement while rejecting an older renderer topology', async () => {
     const store = await createStore()
     store.setWorkspaceSession({

--- a/src/main/persistence-pty-binding-reconciliation.test.ts
+++ b/src/main/persistence-pty-binding-reconciliation.test.ts
@@ -271,6 +271,116 @@ describe('Store', () => {
     ).toBe('host-pty')
   })
 
+  // Why a second, non-empty replay: the empty-binding case above is already carried by the
+  // Issue #217 merge in setLocalWorkspaceSession, so only the fence pins this one.
+  it('rejects a stale renderer replay that renames a host-bound PTY', async () => {
+    const store = await createStore()
+    const rendererReplay = (): void => {
+      store.setWorkspaceSession({
+        ...getDefaultWorkspaceSession(),
+        tabsByWorktree: {
+          wt1: [makeTerminalTab({ id: 'tab1', worktreeId: 'wt1', ptyId: 'stale-pty' })]
+        },
+        terminalLayoutsByTabId: {
+          tab1: {
+            root: { type: 'leaf', leafId: TEST_LEAF_1 },
+            activeLeafId: TEST_LEAF_1,
+            expandedLeafId: null,
+            ptyIdsByLeafId: { [TEST_LEAF_1]: 'stale-pty' }
+          }
+        }
+      })
+    }
+    rendererReplay()
+
+    expect(
+      store.persistPtyBinding({
+        worktreeId: 'wt1',
+        tabId: 'tab1',
+        leafId: TEST_LEAF_1,
+        ptyId: 'host-pty',
+        hostAdmittedMembership: true
+      })
+    ).toBe(true)
+
+    rendererReplay()
+
+    expect(
+      store.getWorkspaceSession().terminalLayoutsByTabId.tab1?.ptyIdsByLeafId?.[TEST_LEAF_1]
+    ).toBe('host-pty')
+    expect(store.getWorkspaceSession().tabsByWorktree.wt1[0].ptyId).toBe('host-pty')
+  })
+
+  // The tab record and the layout leaf are two separate persisted spellings of the same
+  // binding, and the renderer can desync either one alone — each must raise the fence.
+  it('fences a host binding that only corrects the tab record', async () => {
+    const store = await createStore()
+    const rendererReplay = (): void => {
+      store.setWorkspaceSession({
+        ...getDefaultWorkspaceSession(),
+        tabsByWorktree: {
+          wt1: [makeTerminalTab({ id: 'tab1', worktreeId: 'wt1', ptyId: 'stale-pty' })]
+        },
+        terminalLayoutsByTabId: {
+          tab1: {
+            root: { type: 'leaf', leafId: TEST_LEAF_1 },
+            activeLeafId: TEST_LEAF_1,
+            expandedLeafId: null,
+            ptyIdsByLeafId: { [TEST_LEAF_1]: 'host-pty' }
+          }
+        }
+      })
+    }
+    rendererReplay()
+
+    store.persistPtyBinding({
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_1,
+      ptyId: 'host-pty',
+      hostAdmittedMembership: true
+    })
+
+    rendererReplay()
+
+    expect(store.getWorkspaceSession().tabsByWorktree.wt1[0].ptyId).toBe('host-pty')
+  })
+
+  it('fences a host binding that only corrects the layout leaf', async () => {
+    const store = await createStore()
+    const rendererReplay = (): void => {
+      store.setWorkspaceSession({
+        ...getDefaultWorkspaceSession(),
+        tabsByWorktree: {
+          wt1: [makeTerminalTab({ id: 'tab1', worktreeId: 'wt1', ptyId: 'host-pty' })]
+        },
+        terminalLayoutsByTabId: {
+          tab1: {
+            root: { type: 'leaf', leafId: TEST_LEAF_1 },
+            activeLeafId: TEST_LEAF_1,
+            expandedLeafId: null,
+            ptyIdsByLeafId: { [TEST_LEAF_1]: 'stale-pty' }
+          }
+        }
+      })
+    }
+    rendererReplay()
+
+    store.persistPtyBinding({
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_1,
+      ptyId: 'host-pty',
+      hostAdmittedMembership: true
+    })
+
+    rendererReplay()
+
+    expect(
+      store.getWorkspaceSession().terminalLayoutsByTabId.tab1?.ptyIdsByLeafId?.[TEST_LEAF_1]
+    ).toBe('host-pty')
+  })
+
   it('admits a fresh host spawn after retirement while rejecting an older renderer topology', async () => {
     const store = await createStore()
     store.setWorkspaceSession({

--- a/src/main/persistence/loading-store/pty-binding-persistence.ts
+++ b/src/main/persistence/loading-store/pty-binding-persistence.ts
@@ -123,7 +123,6 @@ export class PtyBindingPersistenceOperations {
       args.expectedBinding !== undefined &&
       args.incarnationId !== args.expectedBinding.incarnationId
     let terminalMembershipChanged = false
-    let hostAdmittedTabCreated = false
     const advanceTopologyFence = (): void => {
       const repoId = getRepoIdFromWorktreeId(bindingWorktreeId)
       const currentRevision = session.terminalTopologyRevisionByRepoId?.[repoId] ?? 0
@@ -131,7 +130,7 @@ export class PtyBindingPersistenceOperations {
       // the authority — with no fence the renderer's pre-create tab list replays
       // over it and the tab is lost even on the repo's first such change.
       const establishesMembershipAuthority =
-        args.expectedSourceBinding !== undefined || hostAdmittedTabCreated
+        args.expectedSourceBinding !== undefined || args.hostAdmittedMembership === true
       if (
         !reconciledIncarnation &&
         (!terminalMembershipChanged || (currentRevision <= 0 && !establishesMembershipAuthority))
@@ -170,10 +169,10 @@ export class PtyBindingPersistenceOperations {
     const tabs = session.tabsByWorktree?.[bindingWorktreeId]
     const tab = tabs?.find((t) => t.id === args.tabId)
     if (tab) {
+      terminalMembershipChanged = tab.ptyId !== args.ptyId
       tab.ptyId = args.ptyId
     } else {
       terminalMembershipChanged = true
-      hostAdmittedTabCreated = args.hostAdmittedMembership === true
       // Why: pty:spawn can beat the debounced writer; persist a minimal tab so hydration won't prune the binding as orphaned.
       const nextTabs = [
         ...(tabs ?? []),
@@ -207,6 +206,9 @@ export class PtyBindingPersistenceOperations {
     }
     const layout = session.terminalLayoutsByTabId?.[args.tabId]
     if (layout) {
+      if (layout.ptyIdsByLeafId?.[args.leafId] !== args.ptyId) {
+        terminalMembershipChanged = true
+      }
       if (!layout.root) {
         terminalMembershipChanged = true
         // Why: createTab can persist an empty layout before TerminalPane mounts; the sync binding still needs a durable root.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​237 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​237 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5
Sometimes Orca creates a terminal in the background before its tab is drawn. A slightly older save from the app could then forget which running terminal belongs in that tab, so opening it showed a blank pane with `terminal_pane_owner_changed` even though the command or agent was still running. This change keeps that link intact so the tab opens onto the correct live terminal.

## Before / After

**Before:** If a terminal was created in the background at the unlucky moment an older UI save landed, opening its tab could show a blank pane and `terminal_pane_owner_changed`. The shell or agent was still running and could still be read through the CLI, but it was no longer usable in Orca's terminal view.

**After:** The tab keeps its link to the newly created terminal when that late save arrives. Opening the tab shows the correct live shell or agent instead of the ownership error.

## When you would hit this

This is a narrow timing race in background/headless terminal creation—most directly `orca terminal create --worktree active` without `--focus`, including the same pattern used by orchestration workers. It occurs when Orca's UI already knows about the tab but still has an older pending save from before the terminal was attached; it is not a general reload, sleep/wake, or SSH reconnect fix.

## Summary
- Advance the terminal topology fence when a host-admitted PTY fills an existing renderer tab or leaf.
- Prevent stale renderer snapshots from erasing the persisted PTY owner and causing `terminal_pane_owner_changed` on reattach.
- Add regression coverage for existing-tab binding and stale replay preservation.

Fixes STA-4139.

## Verification
- Focused persistence/runtime/IPC tests: 83 passed.
- `oxlint` on changed files: passed.
- `pnpm tc`: passed.
- `pnpm run check:code-quality:changed`: blocked by the repository script parsing pnpm's engine warning as JSON (environment/tooling warning contamination).
- Manual Electron/mobile visual QA: N/A. This is a timing-dependent persistence race, not a stable visual change; a screenshot would only show the generic blank/error state after the race and would not prove the tab-to-terminal link survived. The observable before/after behavior is documented above and the actual state transition is covered by the regression test.
