### PR TITLE
feat(native-chat): support Cursor Agent conversations

### DIFF
--- a/src/main/agent-hooks/server-cursor-normalization.test.ts
+++ b/src/main/agent-hooks/server-cursor-normalization.test.ts
@@ -30,12 +30,20 @@ describe('Cursor hook normalization', () => {
   it('beforeSubmitPrompt maps to working and captures the prompt', () => {
     const result = _internals.normalizeHookPayload(
       'cursor',
-      buildBody({ hook_event_name: 'beforeSubmitPrompt', prompt: 'add a README' }),
+      buildBody({
+        hook_event_name: 'beforeSubmitPrompt',
+        conversation_id: 'cursor-conversation',
+        prompt: 'add a README'
+      }),
       'production'
     )
     expect(result?.payload.state).toBe('working')
     expect(result?.payload.agentType).toBe('cursor')
     expect(result?.payload.prompt).toBe('add a README')
+    expect(result?.providerSession).toEqual({
+      key: 'conversation_id',
+      id: 'cursor-conversation'
+    })
   })
 
   it('stop maps to done', () => {

--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -20,6 +28,7 @@ vi.mock('os', async () => {
 import { CursorHookService } from './hook-service'
 import { POSIX_HOOK_STDIN_READER } from '../agent-hooks/hook-stdin-contract'
 import { CURSOR_EVENTS, type CursorEvent } from './hook-events'
+import { extractAgentProviderSession } from '../../shared/agent-session-resume'
 
 const CURSOR_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'cursor-hook.cmd' : 'cursor-hook.sh'
 const WINDOWS_POWERSHELL_LAUNCHER =
@@ -225,6 +234,44 @@ describe('CursorHookService', () => {
       }
     }
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'carries the real managed-script conversation_id into providerSession',
+    () => {
+      expect(new CursorHookService().install().state).toBe('installed')
+      const command = requireRegisteredCommand(
+        readInstalledCursorHooks(homeDir),
+        'beforeSubmitPrompt'
+      )
+      const binDir = join(homeDir, 'bin')
+      const capturePath = join(homeDir, 'captured-payload.json')
+      const curlStub = join(binDir, 'curl')
+      mkdirSync(binDir)
+      writeFileSync(curlStub, '#!/bin/sh\ncommand -p cat > "$ORCA_CURSOR_CAPTURE_FILE"\nexit 0\n')
+      chmodSync(curlStub, 0o755)
+      const payload = {
+        hook_event_name: 'beforeSubmitPrompt',
+        conversation_id: 'cursor-conversation',
+        prompt: 'add a README'
+      }
+
+      const result = runRegisteredCursorHook(command, JSON.stringify(payload), {
+        ORCA_AGENT_HOOK_PORT: '12345',
+        ORCA_AGENT_HOOK_TOKEN: 'token',
+        ORCA_PANE_KEY: 'tab:leaf',
+        ORCA_CURSOR_CAPTURE_FILE: capturePath,
+        PATH: `${binDir}:${process.env.PATH ?? ''}`
+      })
+
+      expect(result.status).toBe(0)
+      const captured = JSON.parse(readFileSync(capturePath, 'utf8')) as Record<string, unknown>
+      expect(captured).toEqual(payload)
+      expect(extractAgentProviderSession('cursor', captured)).toEqual({
+        key: 'conversation_id',
+        id: 'cursor-conversation'
+      })
+    }
+  )
 
   it('emits protocol-valid JSON when the managed Cursor script is missing (#15462)', () => {
     expect(new CursorHookService().install().state).toBe('installed')

--- a/src/main/native-chat/host-readable-transcript-path.test.ts
+++ b/src/main/native-chat/host-readable-transcript-path.test.ts
@@ -6,7 +6,8 @@ import {
   needsWslHostTranslation,
   resetHostReadableTranscriptPathCacheForTests,
   toHostReadableTranscriptPath,
-  wslCodexSessionsDirs
+  wslCodexSessionsDirs,
+  wslCursorProjectsDirs
 } from './host-readable-transcript-path'
 import { WslTranscriptFsError } from './wsl-transcript-fs-gate'
 
@@ -227,5 +228,18 @@ describe('wslCodexSessionsDirs', () => {
     await expect(
       wslCodexSessionsDirs({ platform: 'win32', listWslHomeDirs: async () => [UBUNTU_HOME] })
     ).resolves.toContain(`${accountHome}\\sessions`)
+  })
+})
+
+describe('wslCursorProjectsDirs', () => {
+  it('reuses cached WSL homes across resolve-poll ticks', async () => {
+    const listWslHomeDirs = vi.fn(async () => [UBUNTU_HOME])
+
+    await expect(wslCursorProjectsDirs({ platform: 'win32', listWslHomeDirs })).resolves.toEqual([
+      `${UBUNTU_HOME}\\.cursor\\projects`
+    ])
+    await wslCursorProjectsDirs({ platform: 'win32', listWslHomeDirs })
+
+    expect(listWslHomeDirs).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/native-chat/host-readable-transcript-path.ts
+++ b/src/main/native-chat/host-readable-transcript-path.ts
@@ -209,6 +209,17 @@ export async function wslCodexSessionsDirs(
   return dirs.filter((dir, index) => dirs.indexOf(dir) === index)
 }
 
+/** Cursor transcripts use the same cached WSL home discovery as Codex. */
+export async function wslCursorProjectsDirs(
+  deps: Pick<HostReadableTranscriptPathDeps, 'platform' | 'listWslHomeDirs'> = {}
+): Promise<string[]> {
+  if ((deps.platform ?? process.platform) !== 'win32') {
+    return []
+  }
+  const homeDirs = await wslHomeDirs(deps.listWslHomeDirs ?? defaultListWslHomeDirs)
+  return homeDirs.map((home) => joinUnderWslHome(home, '.cursor', 'projects'))
+}
+
 // Why: node:path.join is posix-flavoured off Windows and would mangle the
 // `\\wsl.localhost\` share prefix these roots must keep.
 function joinUnderWslHome(home: string, ...segments: string[]): string {

--- a/src/main/native-chat/session-file-resolver-cursor-wsl.test.ts
+++ b/src/main/native-chat/session-file-resolver-cursor-wsl.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const UBUNTU_ROOT = '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.cursor\\projects'
+const DEBIAN_ROOT = '\\\\wsl.localhost\\Debian\\home\\ada\\.cursor\\projects'
+
+const mocks = vi.hoisted(() => ({
+  homes: vi.fn(async () => [UBUNTU_ROOT, DEBIAN_ROOT]),
+  gate: vi.fn(async (_options: { path: string }) => []),
+  hostHit: null as string | null,
+  guestHitRoot: null as string | null,
+  walk: vi.fn(
+    async (
+      dir: string,
+      _agent: string,
+      _issues: unknown[],
+      options: { readDirectory?: (dirPath: string) => Promise<unknown[]> }
+    ) => {
+      await options.readDirectory?.(dir)
+      if (!dir.startsWith('\\\\wsl.localhost\\')) {
+        return mocks.hostHit ? [mocks.hostHit] : []
+      }
+      return dir === mocks.guestHitRoot
+        ? [`${dir}\\project\\agent-transcripts\\cursor-session.jsonl`]
+        : []
+    }
+  )
+}))
+
+vi.mock('./host-readable-transcript-path', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  wslCursorProjectsDirs: mocks.homes
+}))
+vi.mock('./wsl-transcript-fs-gate', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  runWslTranscriptFsTask: mocks.gate
+}))
+vi.mock('../ai-vault/session-scanner-discovery', () => ({
+  walkSessionFiles: mocks.walk
+}))
+
+import { resolveSessionFilePath } from './session-file-resolver'
+import { WslTranscriptFsError } from './wsl-transcript-fs-gate'
+
+beforeEach(() => {
+  mocks.homes.mockClear()
+  mocks.gate.mockClear()
+  mocks.walk.mockClear()
+  mocks.hostHit = null
+  mocks.guestHitRoot = null
+})
+
+describe('Cursor WSL session resolver', () => {
+  it('does not enumerate WSL homes when the host root has the transcript', async () => {
+    mocks.hostHit = 'C:\\Users\\ada\\.cursor\\projects\\p\\agent-transcripts\\cursor-session.jsonl'
+
+    await expect(resolveSessionFilePath('cursor', 'cursor-session')).resolves.toBe(mocks.hostHit)
+    expect(mocks.homes).not.toHaveBeenCalled()
+    expect(mocks.gate).not.toHaveBeenCalled()
+  })
+
+  it('finds a transcript under a guest Cursor projects root', async () => {
+    mocks.guestHitRoot = UBUNTU_ROOT
+
+    await expect(resolveSessionFilePath('cursor', 'cursor-session')).resolves.toBe(
+      `${UBUNTU_ROOT}\\project\\agent-transcripts\\cursor-session.jsonl`
+    )
+    expect(mocks.gate).toHaveBeenCalledWith(
+      expect.objectContaining({ operation: 'readdir', priority: 'scan' }),
+      expect.any(Function)
+    )
+  })
+
+  it("keeps scanning after one guest root is refused and returns another root's hit", async () => {
+    const refusal = new WslTranscriptFsError('timeout', 'slow Ubuntu share')
+    mocks.gate.mockImplementation(async (options: { path: string }) => {
+      if (options.path.includes('Ubuntu')) {
+        throw refusal
+      }
+      return []
+    })
+    mocks.guestHitRoot = DEBIAN_ROOT
+
+    await expect(resolveSessionFilePath('cursor', 'cursor-session')).resolves.toBe(
+      `${DEBIAN_ROOT}\\project\\agent-transcripts\\cursor-session.jsonl`
+    )
+  })
+
+  it('reports unavailability when every guest root is refused', async () => {
+    const refusal = new WslTranscriptFsError('unavailable', 'stuck permits')
+    mocks.gate.mockRejectedValue(refusal)
+
+    await expect(resolveSessionFilePath('cursor', 'cursor-session')).rejects.toBe(refusal)
+  })
+
+  it('keeps a caller abort authoritative over a guest root refusal', async () => {
+    const controller = new AbortController()
+    const abortReason = new Error('caller went away')
+    mocks.gate.mockImplementation(async () => {
+      controller.abort(abortReason)
+      throw new WslTranscriptFsError('timeout', 'slow share')
+    })
+
+    await expect(
+      resolveSessionFilePath('cursor', 'cursor-session', {}, controller.signal)
+    ).rejects.toBe(abortReason)
+  })
+})

--- a/src/main/native-chat/session-file-resolver.test.ts
+++ b/src/main/native-chat/session-file-resolver.test.ts
@@ -52,6 +52,21 @@ describe('resolveSessionFilePath', () => {
     ).resolves.toBe(target)
   })
 
+  it('resolves Cursor sessions only from the AI Vault agent-transcripts layout', async () => {
+    const root = await makeRoot('orca-native-chat-resolve-cursor-')
+    const cursorProjectsDir = join(root, 'cursor-projects')
+    const projectDir = join(cursorProjectsDir, 'project')
+    const targetDir = join(projectDir, 'agent-transcripts')
+    await mkdir(targetDir, { recursive: true })
+    await writeFile(join(projectDir, 'cursor-session.jsonl'), '{}\n')
+    const target = join(targetDir, 'cursor-session.jsonl')
+    await writeFile(target, '{}\n')
+
+    await expect(
+      resolveSessionFilePath('cursor', 'cursor-session', { cursorProjectsDir })
+    ).resolves.toBe(target)
+  })
+
   it('resolves Grok chat_history.jsonl under encodeURIComponent(cwd)/sessionId', async () => {
     const root = await makeRoot('orca-native-chat-resolve-grok-')
     const grokSessionsDir = join(root, 'grok-sessions')

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -7,6 +7,7 @@ import {
 } from '../../shared/native-chat-agent-support'
 import { isWslUncPath } from '../../shared/wsl-paths'
 import { walkSessionFiles } from '../ai-vault/session-scanner-discovery'
+import { AI_VAULT_AGENT_SOURCES } from '../ai-vault/session-scanner-agent-sources'
 import { OMP_SESSION_ARTIFACT_DIR_PATTERN } from '../ai-vault/session-scanner-omp-subagent-transcripts'
 import { normalizeAgentSessionsDir } from '../ai-vault/session-scanner-values'
 import { resolveOrcaManagedCodexHomePath } from '../codex/codex-home-paths'
@@ -14,8 +15,13 @@ import {
   findGrokChatHistoryBySessionId,
   resolveGrokSessionsDir
 } from '../../shared/grok-session-paths'
-import { toHostReadableTranscriptPath, wslCodexSessionsDirs } from './host-readable-transcript-path'
+import {
+  toHostReadableTranscriptPath,
+  wslCodexSessionsDirs,
+  wslCursorProjectsDirs
+} from './host-readable-transcript-path'
 import { findWslCodexSessionPath } from './wsl-codex-session-path-scan'
+import { wslGatedReaddir } from './wsl-transcript-fs-access'
 import { wslTranscriptFsRefusal, type WslTranscriptFsError } from './wsl-transcript-fs-gate'
 
 // Why: these mirror the path constants in ai-vault/session-scanner.ts. Reads
@@ -65,6 +71,8 @@ export type ResolveSessionFileOptions = {
   codexSessionsDirs?: string[]
   /** Override the Grok sessions root (`~/.grok/sessions`). */
   grokSessionsDir?: string
+  /** Override the Cursor projects root (`~/.cursor/projects`). */
+  cursorProjectsDir?: string
   /** Override the omp sessions root (`~/.omp/agent/sessions`). */
   ompSessionsDir?: string
   /** Authoritative transcript path reported by the agent hook
@@ -149,6 +157,17 @@ async function resolveSessionFileById(
       // Why: enumerating WSL homes spawns wsl.exe per distro, which boots ones the
       // user left stopped. Only pay that after this host's own Codex roots miss.
       overrideDirs ? undefined : wslCodexSessionsDirs,
+      signal
+    )
+  }
+  if (transcriptAgent === 'cursor') {
+    const overrideDir = options.cursorProjectsDir
+    return resolveCursorSessionFile(
+      trimmedId,
+      [AI_VAULT_AGENT_SOURCES.cursor.rootDirs({ cursorProjectsDir: overrideDir }, [])[0]].filter(
+        (dir): dir is string => Boolean(dir)
+      ),
+      overrideDir ? undefined : wslCursorProjectsDirs,
       signal
     )
   }
@@ -258,6 +277,57 @@ async function resolveGrokSessionFile(
   const history = await findGrokChatHistoryBySessionId(sessionsDir, sessionId)
   signal?.throwIfAborted()
   return history
+}
+
+async function resolveCursorSessionFile(
+  sessionId: string,
+  projectsDirs: string[],
+  loadFallbackDirs?: () => Promise<string[]>,
+  signal?: AbortSignal
+): Promise<string | null> {
+  const hit = await findCursorTranscriptInDirs(sessionId, projectsDirs, signal)
+  if (hit || !loadFallbackDirs) {
+    return hit
+  }
+  signal?.throwIfAborted()
+  const fallbackDirs = (await loadFallbackDirs()).filter((dir) => !projectsDirs.includes(dir))
+  signal?.throwIfAborted()
+  return findCursorTranscriptInDirs(sessionId, fallbackDirs, signal)
+}
+
+async function findCursorTranscriptInDirs(
+  sessionId: string,
+  projectsDirs: string[],
+  signal?: AbortSignal
+): Promise<string | null> {
+  const source = AI_VAULT_AGENT_SOURCES.cursor
+  const targetName = `${sessionId}.jsonl`
+  let unavailable: WslTranscriptFsError | undefined
+  for (const rootDir of projectsDirs) {
+    const isWslRoot = isWslUncPath(rootDir)
+    try {
+      const files = await walkSessionFiles(rootDir, 'cursor', [], {
+        extensions: new Set(source.extensions),
+        directoryPredicate: source.directoryPredicate,
+        filePredicate: (path) =>
+          basename(path) === targetName && (source.filePredicate?.(path) ?? true),
+        ...(isWslRoot
+          ? { readDirectory: (dirPath: string) => wslGatedReaddir(dirPath, 'scan', signal) }
+          : {}),
+        signal
+      })
+      if (files[0]) {
+        return files[0]
+      }
+    } catch (error) {
+      signal?.throwIfAborted()
+      unavailable = wslTranscriptFsRefusal(error)
+    }
+  }
+  if (unavailable) {
+    throw unavailable
+  }
+  return null
 }
 
 // omp keeps one directory per working directory (`-Documents-dog-app`) with the

--- a/src/main/native-chat/transcript-line-decoders-cursor.ts
+++ b/src/main/native-chat/transcript-line-decoders-cursor.ts
@@ -1,0 +1,19 @@
+import type { NativeChatMessage } from '../../shared/native-chat-types'
+import { asRecord, extractString, parseJsonObject } from '../ai-vault/session-scanner-values'
+import { claudeContentBlocks } from './transcript-record-blocks'
+
+/** Cursor Agent message rows carry Claude-shaped content blocks without ids or timestamps. */
+export function decodeCursorTranscriptLine(
+  line: string,
+  fallbackId: string
+): NativeChatMessage | null {
+  const record = parseJsonObject(line)
+  const role = extractString(record?.role)
+  if (role !== 'user' && role !== 'assistant') {
+    return null
+  }
+  const blocks = claudeContentBlocks(asRecord(record?.message)?.content)
+  return blocks.length > 0
+    ? { id: fallbackId, role, blocks, timestamp: null, source: 'transcript' }
+    : null
+}

--- a/src/main/native-chat/transcript-line-decoders.cursor.test.ts
+++ b/src/main/native-chat/transcript-line-decoders.cursor.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { decodeCursorTranscriptLine } from './transcript-line-decoders-cursor'
+
+describe('decodeCursorTranscriptLine', () => {
+  it('decodes user and assistant text without inventing metadata', () => {
+    expect(
+      decodeCursorTranscriptLine(
+        JSON.stringify({ role: 'user', message: { content: [{ type: 'text', text: 'Fix it' }] } }),
+        'cursor:0'
+      )
+    ).toEqual({
+      id: 'cursor:0',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'Fix it' }],
+      timestamp: null,
+      source: 'transcript'
+    })
+  })
+
+  it('keeps assistant text and tool_use blocks in transcript order', () => {
+    expect(
+      decodeCursorTranscriptLine(
+        JSON.stringify({
+          role: 'assistant',
+          message: {
+            content: [
+              { type: 'text', text: 'Checking' },
+              { type: 'tool_use', name: 'Read', input: { path: 'README.md' } }
+            ]
+          }
+        }),
+        'cursor:1'
+      )
+    ).toMatchObject({
+      role: 'assistant',
+      blocks: [
+        { type: 'text', text: 'Checking' },
+        { type: 'tool-call', name: 'Read', input: { path: 'README.md' } }
+      ],
+      timestamp: null
+    })
+  })
+
+  it('skips lifecycle, malformed and empty message rows', () => {
+    expect(
+      decodeCursorTranscriptLine(JSON.stringify({ type: 'turn_ended', status: 'success' }), 'a')
+    ).toBeNull()
+    expect(decodeCursorTranscriptLine('{', 'b')).toBeNull()
+    expect(
+      decodeCursorTranscriptLine(
+        JSON.stringify({ role: 'assistant', message: { content: [] } }),
+        'c'
+      )
+    ).toBeNull()
+  })
+})

--- a/src/main/native-chat/transcript-line-decoders.ts
+++ b/src/main/native-chat/transcript-line-decoders.ts
@@ -11,5 +11,6 @@
 
 export { decodeClaudeTranscriptLine } from './transcript-line-decoders-claude'
 export { decodeCodexTranscriptLine } from './transcript-line-decoders-codex'
+export { decodeCursorTranscriptLine } from './transcript-line-decoders-cursor'
 export { decodeGrokTranscriptLine } from './transcript-line-decoders-grok'
 export { decodeOmpTranscriptLine } from './transcript-line-decoders-omp'

--- a/src/main/native-chat/transcript-reader.test.ts
+++ b/src/main/native-chat/transcript-reader.test.ts
@@ -191,6 +191,29 @@ describe('readNativeChatTranscript (claude)', () => {
   })
 })
 
+describe('readNativeChatTranscript (cursor)', () => {
+  it('routes Cursor text and tool_use rows through the dedicated decoder', async () => {
+    const filePath = await writeFixture('orca-native-chat-cursor-', [
+      { role: 'user', message: { content: [{ type: 'text', text: 'Inspect README' }] } },
+      {
+        role: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'Read', input: { path: 'README.md' } }] }
+      },
+      { type: 'turn_ended', status: 'success' }
+    ])
+
+    const result = await readNativeChatTranscript('cursor', 'cursor-session', { filePath })
+    expect('messages' in result && result.messages).toMatchObject([
+      { role: 'user', blocks: [{ type: 'text', text: 'Inspect README' }], timestamp: null },
+      {
+        role: 'assistant',
+        blocks: [{ type: 'tool-call', name: 'Read', input: { path: 'README.md' } }],
+        timestamp: null
+      }
+    ])
+  })
+})
+
 describe('readNativeChatTranscript (codex)', () => {
   it('maps tool calls and results to tool-call/tool-result blocks', async () => {
     const filePath = await writeFixture('orca-native-chat-codex-', [

--- a/src/main/native-chat/transcript-reader.ts
+++ b/src/main/native-chat/transcript-reader.ts
@@ -11,6 +11,7 @@ import { wslTranscriptFsRefusal } from './wsl-transcript-fs-gate'
 import {
   decodeClaudeTranscriptLine,
   decodeCodexTranscriptLine,
+  decodeCursorTranscriptLine,
   decodeGrokTranscriptLine,
   decodeOmpTranscriptLine
 } from './transcript-line-decoders'
@@ -60,6 +61,9 @@ export async function readNativeChatTranscript(
     }
     if (transcriptAgent === 'codex') {
       return { messages: await readTranscript(filePath, decodeCodexTranscriptLine) }
+    }
+    if (transcriptAgent === 'cursor') {
+      return { messages: await readTranscript(filePath, decodeCursorTranscriptLine) }
     }
     if (transcriptAgent === 'grok') {
       return { messages: await readTranscript(filePath, decodeGrokTranscriptLine) }

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -8,6 +8,7 @@ import { resolveSessionFilePath, type ResolveSessionFileOptions } from './sessio
 import {
   decodeClaudeTranscriptLine,
   decodeCodexTranscriptLine,
+  decodeCursorTranscriptLine,
   decodeGrokTranscriptLine,
   decodeOmpTranscriptLine
 } from './transcript-line-decoders'
@@ -40,6 +41,9 @@ export function nativeChatLineDecoderForAgent(agent: AgentType): NativeChatLineD
   }
   if (transcriptAgent === 'codex') {
     return decodeCodexTranscriptLine
+  }
+  if (transcriptAgent === 'cursor') {
+    return decodeCursorTranscriptLine
   }
   if (transcriptAgent === 'grok') {
     return decodeGrokTranscriptLine

--- a/src/main/native-chat/transcript-turn-lifecycle.test.ts
+++ b/src/main/native-chat/transcript-turn-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   decodeClaudeTurnLifecycle,
   decodeCodexTurnLifecycle,
+  decodeCursorTurnLifecycle,
   nativeChatTurnLifecycleDecoderForAgent
 } from './transcript-turn-lifecycle'
 
@@ -10,7 +11,35 @@ describe('native chat transcript turn lifecycle', () => {
     expect(nativeChatTurnLifecycleDecoderForAgent('claude')).not.toBeNull()
     expect(nativeChatTurnLifecycleDecoderForAgent('openclaude')).not.toBeNull()
     expect(nativeChatTurnLifecycleDecoderForAgent('codex')).not.toBeNull()
+    expect(nativeChatTurnLifecycleDecoderForAgent('cursor')).not.toBeNull()
     expect(nativeChatTurnLifecycleDecoderForAgent('grok')).toBeNull()
+  })
+
+  it('decodes Cursor turn_ended without inventing ids, timestamps or failure messages', () => {
+    expect(
+      decodeCursorTurnLifecycle(
+        JSON.stringify({ type: 'turn_ended', status: 'success' }),
+        'cursor:success'
+      )
+    ).toEqual({ state: 'completed', turnId: 'cursor:success', timestamp: null })
+    expect(
+      decodeCursorTurnLifecycle(
+        JSON.stringify({ type: 'turn_ended', status: 'error', error: 'request failed' }),
+        'cursor:error'
+      )
+    ).toEqual({ state: 'completed', turnId: 'cursor:error', timestamp: null })
+    expect(
+      decodeCursorTurnLifecycle(
+        JSON.stringify({ type: 'turn_ended', status: 'aborted', error: 'cancelled' }),
+        'cursor:aborted'
+      )
+    ).toEqual({ state: 'interrupted', turnId: 'cursor:aborted', timestamp: null })
+    expect(
+      decodeCursorTurnLifecycle(
+        JSON.stringify({ type: 'turn_ended', status: 'unknown' }),
+        'cursor:unknown'
+      )
+    ).toBeNull()
   })
 
   it('decodes Codex task boundaries with the provider turn id', () => {

--- a/src/main/native-chat/transcript-turn-lifecycle.ts
+++ b/src/main/native-chat/transcript-turn-lifecycle.ts
@@ -27,10 +27,31 @@ export function nativeChatTurnLifecycleDecoderForAgent(
   if (transcriptAgent === 'codex') {
     return decodeCodexTurnLifecycle
   }
+  if (transcriptAgent === 'cursor') {
+    return decodeCursorTurnLifecycle
+  }
   if (transcriptAgent === 'claude') {
     return decodeClaudeTurnLifecycle
   }
   return null
+}
+
+export function decodeCursorTurnLifecycle(
+  line: string,
+  fallbackId: string
+): NativeChatTurnLifecycle | null {
+  const record = parseJsonObject(line)
+  if (record?.type !== 'turn_ended') {
+    return null
+  }
+  if (record.status !== 'success' && record.status !== 'error' && record.status !== 'aborted') {
+    return null
+  }
+  return {
+    state: record.status === 'aborted' ? 'interrupted' : 'completed',
+    turnId: fallbackId,
+    timestamp: null
+  }
 }
 
 export function decodeCodexTurnLifecycle(

--- a/src/main/native-chat/transcript-watch.test.ts
+++ b/src/main/native-chat/transcript-watch.test.ts
@@ -69,6 +69,10 @@ function codexLifecycleLine(
   })}\n`
 }
 
+function cursorLine(role: 'user' | 'assistant', text: string): string {
+  return `${JSON.stringify({ role, message: { content: [{ type: 'text', text }] } })}\n`
+}
+
 async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
   const start = Date.now()
   while (!predicate()) {
@@ -104,6 +108,42 @@ describe('subscribeNativeChatTranscript', () => {
 
     expect(snapshots).toHaveLength(1)
     expect(appends.flat().map((message) => message.id)).toEqual(['a-1'])
+  })
+
+  it('tails Cursor messages and turn lifecycle through the shared watcher', async () => {
+    const filePath = await tempFile(cursorLine('user', 'first'))
+    const snapshots: NativeChatMessage[][] = []
+    const appends: NativeChatMessage[][] = []
+    const lifecycles: NativeChatTurnLifecycle[] = []
+    const sub = await subscribeNativeChatTranscript({
+      agent: 'cursor',
+      sessionId: 'ignored',
+      filePath,
+      onInitialSnapshot: (messages) => snapshots.push(messages),
+      onAppend: (messages, lifecycle) => {
+        appends.push(messages)
+        if (lifecycle) {
+          lifecycles.push(lifecycle)
+        }
+      },
+      debounceMs: 5
+    })
+
+    await waitFor(() => snapshots.length === 1)
+    await appendFile(
+      filePath,
+      `${cursorLine('assistant', 'done')}${JSON.stringify({
+        type: 'turn_ended',
+        status: 'success'
+      })}\n`
+    )
+    await waitFor(() => appends.flat().some((message) => message.role === 'assistant'))
+    await waitFor(() => lifecycles.length === 1)
+    sub.unsubscribe()
+
+    expect(snapshots[0]?.[0]).toMatchObject({ role: 'user', timestamp: null })
+    expect(appends.flat().at(-1)).toMatchObject({ role: 'assistant', timestamp: null })
+    expect(lifecycles[0]).toMatchObject({ state: 'completed', timestamp: null })
   })
 
   it('delivers an empty initial snapshot so clients do not remain loading', async () => {

--- a/src/renderer/src/components/native-chat/native-chat-availability.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-availability.test.ts
@@ -67,6 +67,19 @@ describe('canToggleNativeChat', () => {
     ).toBe(true)
   })
 
+  it('accepts local Cursor but rejects Model-A SSH Cursor transcripts', () => {
+    const forConnection = (connectionId: string | null): boolean =>
+      canToggleNativeChat({
+        experimentalNativeChatEnabled: true,
+        contentType: 'terminal',
+        launchAgent: 'cursor',
+        nativeChatTranscriptIsLocalReadable: isNativeChatTranscriptLocalReadable(connectionId)
+      })
+    expect(forConnection(null)).toBe(true)
+    expect(forConnection('runtime-ssh-env-1')).toBe(true)
+    expect(forConnection('ssh-target-1')).toBe(false)
+  })
+
   it('accepts runtime-owned Grok because Model B reads the transcript locally', () => {
     expect(
       canToggleNativeChat({

--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -37,6 +37,11 @@ describe('agent session resume metadata', () => {
       { conversationId: 'agy-conversation' },
       { key: 'conversation_id', id: 'agy-conversation' }
     ],
+    [
+      'cursor',
+      { conversation_id: 'cursor-conversation' },
+      { key: 'conversation_id', id: 'cursor-conversation' }
+    ],
     ['opencode', { sessionID: 'opencode-session' }, { key: 'session_id', id: 'opencode-session' }],
     [
       'pi',
@@ -101,6 +106,7 @@ describe('agent session resume metadata', () => {
 
   it('rejects unsupported sources and unsafe ids', () => {
     expect(extractAgentProviderSession('cursor', { session_id: 'cursor-session' })).toBeNull()
+    expect(extractAgentProviderSession('cursor', { conversation_id: '--last' })).toBeNull()
     expect(normalizeAgentProviderSession({ key: 'session_id', id: 'bad\nid' })).toBeNull()
     expect(normalizeAgentProviderSession({ key: 'session_id', id: '--last' })).toBeNull()
     expect(extractAgentProviderSession('codex', { session_id: '--last' })).toBeNull()

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -206,6 +206,10 @@ export function extractAgentProviderSession(
       const id = readSessionId(payload, ['conversationId'])
       return id ? { key: 'conversation_id', id } : null
     }
+    case 'cursor': {
+      const id = readSessionId(payload, ['conversation_id'])
+      return id ? { key: 'conversation_id', id } : null
+    }
     case 'opencode':
     case 'mimo-code': {
       const id = readSessionId(payload, ['sessionID'])
@@ -239,7 +243,6 @@ export function extractAgentProviderSession(
       return id ? { key: 'session_id', id } : null
     }
     case 'amp':
-    case 'cursor':
     case 'command-code':
     case 'hermes':
       return null

--- a/src/shared/native-chat-agent-support.test.ts
+++ b/src/shared/native-chat-agent-support.test.ts
@@ -12,11 +12,11 @@ describe('resolveNativeChatTranscriptAgent', () => {
     expect(resolveNativeChatTranscriptAgent('claude')).toBe('claude')
   })
 
-  it('passes codex, grok and omp through and rejects everything else', () => {
+  it('passes codex, cursor, grok and omp through and rejects everything else', () => {
     expect(resolveNativeChatTranscriptAgent('codex')).toBe('codex')
     expect(resolveNativeChatTranscriptAgent('grok')).toBe('grok')
     expect(resolveNativeChatTranscriptAgent('omp')).toBe('omp')
-    expect(resolveNativeChatTranscriptAgent('cursor')).toBeNull()
+    expect(resolveNativeChatTranscriptAgent('cursor')).toBe('cursor')
     expect(resolveNativeChatTranscriptAgent(null)).toBeNull()
     expect(resolveNativeChatTranscriptAgent(undefined)).toBeNull()
   })
@@ -27,7 +27,7 @@ describe('isNativeChatSupportedAgent', () => {
     expect(isNativeChatSupportedAgent('claude')).toBe(true)
     expect(isNativeChatSupportedAgent('openclaude')).toBe(true)
     expect(isNativeChatSupportedAgent('omp')).toBe(true)
-    expect(isNativeChatSupportedAgent('cursor')).toBe(false)
+    expect(isNativeChatSupportedAgent('cursor')).toBe(true)
     expect(isNativeChatSupportedAgent(null)).toBe(false)
     expect(isNativeChatSupportedAgent(undefined)).toBe(false)
   })
@@ -35,14 +35,14 @@ describe('isNativeChatSupportedAgent', () => {
 
 describe('nativeChatRequiresLocalTranscript', () => {
   it('covers the agents whose hook discloses no transcript path', () => {
-    // Claude/Codex report `transcript_path`; Grok and omp report only an id, so
+    // Claude/Codex report `transcript_path`; Cursor/Grok/omp report only an id, so
     // native chat has to find their file on a disk this process can read.
     expect(nativeChatRequiresLocalTranscript('grok')).toBe(true)
     expect(nativeChatRequiresLocalTranscript('omp')).toBe(true)
+    expect(nativeChatRequiresLocalTranscript('cursor')).toBe(true)
     expect(nativeChatRequiresLocalTranscript('claude')).toBe(false)
     expect(nativeChatRequiresLocalTranscript('openclaude')).toBe(false)
     expect(nativeChatRequiresLocalTranscript('codex')).toBe(false)
-    expect(nativeChatRequiresLocalTranscript('cursor')).toBe(false)
     expect(nativeChatRequiresLocalTranscript(null)).toBe(false)
     expect(nativeChatRequiresLocalTranscript(undefined)).toBe(false)
   })

--- a/src/shared/native-chat-agent-support.ts
+++ b/src/shared/native-chat-agent-support.ts
@@ -1,10 +1,11 @@
-export type NativeChatTranscriptAgent = 'claude' | 'codex' | 'grok' | 'omp'
+export type NativeChatTranscriptAgent = 'claude' | 'codex' | 'cursor' | 'grok' | 'omp'
 
 /** Agents whose transcripts the native chat view can parse and render. */
 export const NATIVE_CHAT_SUPPORTED_AGENTS: ReadonlySet<string> = new Set([
   'claude',
   'openclaude',
   'codex',
+  'cursor',
   'grok',
   'omp'
 ])
@@ -19,7 +20,7 @@ export function isNativeChatSupportedAgent(agent: string | null | undefined): bo
  *  so the chat view must stay closed instead of loading forever. */
 export function nativeChatRequiresLocalTranscript(agent: string | null | undefined): boolean {
   const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
-  return transcriptAgent === 'grok' || transcriptAgent === 'omp'
+  return transcriptAgent === 'cursor' || transcriptAgent === 'grok' || transcriptAgent === 'omp'
 }
 
 /** True when the agent renders a digit-commit question selector that ignores
@@ -40,7 +41,7 @@ export function resolveNativeChatTranscriptAgent(
   if (agent === 'claude' || agent === 'openclaude') {
     return 'claude'
   }
-  if (agent === 'codex' || agent === 'grok' || agent === 'omp') {
+  if (agent === 'codex' || agent === 'cursor' || agent === 'grok' || agent === 'omp') {
     return agent
   }
   return null

--- a/tests/e2e/native-chat-cursor.spec.ts
+++ b/tests/e2e/native-chat-cursor.spec.ts
@@ -1,0 +1,216 @@
+import { randomUUID } from 'node:crypto'
+import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import type { GlobalSettings } from '../../src/shared/global-settings-types'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  waitForActivePaneHookDescriptor,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import {
+  clearTerminalPtyWriteLog,
+  installTerminalPtyWriteSpy,
+  readTerminalPtyWriteEntries
+} from './helpers/terminal-pty-write-spy'
+
+async function enableCursorNativeChat(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const nextSettings = await window.api.settings.set({
+      experimentalNativeChat: true,
+      uiLanguage: 'en',
+      nativeChatSessionOptions: {
+        cursor: {
+          model: 'gpt-5.3-codex',
+          valuesByModel: {
+            'gpt-5.3-codex': { effort: 'high', fastMode: false }
+          }
+        }
+      }
+    })
+    window.__store?.setState({ settings: nextSettings as GlobalSettings })
+  })
+}
+
+async function seedCursorSession(
+  page: Page,
+  args: { paneKey: string; worktreeId: string; sessionId: string }
+): Promise<void> {
+  await page.evaluate(({ paneKey, worktreeId, sessionId }) => {
+    window.__store
+      ?.getState()
+      .setAgentStatus(
+        paneKey,
+        { state: 'working', prompt: 'Cursor Native Chat E2E', agentType: 'cursor' },
+        'Cursor',
+        undefined,
+        { worktreeId },
+        { providerSession: { key: 'conversation_id', id: sessionId } }
+      )
+  }, args)
+}
+
+async function toggleTerminalTabView(
+  page: Page,
+  args: { tabId: string; worktreeId: string }
+): Promise<void> {
+  await page.evaluate(({ tabId, worktreeId }) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    const state = store.getState()
+    const unifiedTab = (state.unifiedTabsByWorktree[worktreeId] ?? []).find(
+      (tab) => tab.contentType === 'terminal' && tab.entityId === tabId
+    )
+    if (!unifiedTab) {
+      throw new Error('Unified terminal tab not found')
+    }
+    state.toggleTabViewMode(unifiedTab.id)
+  }, args)
+}
+
+function line(record: unknown): string {
+  return `${JSON.stringify(record)}\n`
+}
+
+test.describe('Cursor Native Chat', () => {
+  test('renders, tails, controls and preserves a Cursor conversation', async ({
+    electronApp,
+    orcaPage
+  }, testInfo) => {
+    const consoleErrors: string[] = []
+    const pageErrors: string[] = []
+    orcaPage.on('console', (message) => {
+      if (message.type() === 'error') {
+        consoleErrors.push(message.text())
+      }
+    })
+    orcaPage.on('pageerror', (error) => pageErrors.push(error.message))
+
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    await installTerminalPtyWriteSpy(electronApp)
+
+    const descriptor = await waitForActivePaneHookDescriptor(orcaPage)
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    const [tabId] = descriptor.paneKey.split(':')
+    const sessionId = `e2e-cursor-native-chat-${randomUUID()}`
+    const isolatedHome = await electronApp.evaluate(({ app }) => app.getPath('home'))
+    const transcriptDir = path.join(
+      isolatedHome,
+      '.cursor',
+      'projects',
+      'e2e-project',
+      'agent-transcripts',
+      sessionId
+    )
+    const transcriptPath = path.join(transcriptDir, `${sessionId}.jsonl`)
+    mkdirSync(transcriptDir, { recursive: true })
+
+    const userText = 'Review the Cursor Native Chat contract'
+    const assistantText = 'I will inspect the resolver before changing anything.'
+    writeFileSync(
+      transcriptPath,
+      [
+        line({ role: 'user', message: { content: [{ type: 'text', text: userText }] } }),
+        line({
+          role: 'assistant',
+          message: {
+            content: [
+              { type: 'text', text: assistantText },
+              { type: 'tool_use', name: 'Read', input: { path: 'README.md' } }
+            ]
+          }
+        })
+      ].join('')
+    )
+
+    const screenshotDir = path.join(
+      process.cwd(),
+      'validation-screenshots',
+      `native-chat-cursor-${Date.now()}`
+    )
+    mkdirSync(screenshotDir, { recursive: true })
+    await testInfo.attach('validation-screenshot-dir', {
+      body: screenshotDir,
+      contentType: 'text/plain'
+    })
+
+    await enableCursorNativeChat(orcaPage)
+    await seedCursorSession(orcaPage, {
+      paneKey: descriptor.paneKey,
+      worktreeId: descriptor.worktreeId,
+      sessionId
+    })
+    await toggleTerminalTabView(orcaPage, { tabId, worktreeId: descriptor.worktreeId })
+
+    const chatRoot = orcaPage.locator('[data-native-chat-root="true"]')
+    await expect(chatRoot).toBeVisible({ timeout: 15_000 })
+    await expect(chatRoot.getByText(userText)).toBeVisible({ timeout: 30_000 })
+    await expect(chatRoot.getByText(assistantText)).toBeVisible()
+    await expect(chatRoot.getByRole('button', { name: /Read README\.md/ })).toBeVisible()
+    await expect(chatRoot.getByRole('button', { name: 'Stop the agent' })).toBeEnabled()
+    await orcaPage.screenshot({ path: path.join(screenshotDir, '01-cursor-history.png') })
+
+    await clearTerminalPtyWriteLog(electronApp)
+    await chatRoot.getByRole('button', { name: 'Stop the agent' }).click()
+    await expect
+      .poll(async () => readTerminalPtyWriteEntries(electronApp), { timeout: 10_000 })
+      .toEqual(expect.arrayContaining([expect.objectContaining({ id: ptyId, data: '\u001b' })]))
+
+    const liveText = 'Cursor live tail is connected.'
+    appendFileSync(
+      transcriptPath,
+      `${line({
+        role: 'assistant',
+        message: { content: [{ type: 'text', text: liveText }] }
+      })}${line({ type: 'turn_ended', status: 'success' })}`
+    )
+    await expect(chatRoot.getByText(liveText)).toBeVisible({ timeout: 20_000 })
+
+    await orcaPage.getByRole('button', { name: 'Show terminal' }).click()
+    await expect(chatRoot).toHaveCount(0)
+    await expect(orcaPage.getByRole('textbox', { name: 'Terminal input' })).toBeVisible()
+    await orcaPage.getByRole('button', { name: 'Show chat view' }).click()
+    await expect(chatRoot).toBeVisible()
+    await expect(chatRoot.getByText(liveText)).toBeVisible()
+    await orcaPage.screenshot({ path: path.join(screenshotDir, '02-cursor-live-restored.png') })
+
+    const modelButton = chatRoot.getByRole('button', { name: 'Model' })
+    await expect(modelButton).toBeVisible()
+    await modelButton.click()
+    await orcaPage.getByRole('menuitemradio', { name: 'GPT-5.3 Codex' }).click()
+    const modeButton = chatRoot.getByRole('button', { name: 'Effort' })
+    await expect(modeButton).toBeEnabled()
+    await modeButton.click()
+    await expect(orcaPage.getByText('Fast mode', { exact: true })).toBeVisible()
+    await orcaPage.keyboard.press('Escape')
+
+    await clearTerminalPtyWriteLog(electronApp)
+    const prompt = 'Cursor composer routed to the active PTY'
+    await chatRoot.getByPlaceholder('Send a message…').fill(prompt)
+    await chatRoot.getByRole('button', { name: 'Send' }).click()
+    await expect
+      .poll(
+        async () => {
+          const entries = await readTerminalPtyWriteEntries(electronApp)
+          return (
+            entries.length > 0 &&
+            entries.every((entry) => entry.id === ptyId) &&
+            entries.some((entry) => entry.data.includes(prompt)) &&
+            entries.some((entry) => entry.data.includes('\r'))
+          )
+        },
+        { timeout: 10_000 }
+      )
+      .toBe(true)
+
+    expect(consoleErrors).toEqual([])
+    expect(pageErrors).toEqual([])
+  })
+})


### PR DESCRIPTION
## ELI5

Cursor Agent sessions can now use Orca's existing Native Chat view instead of being limited to the terminal. Orca reads the transcript produced by the `cursor-agent` CLI and keeps input and Stop routed to the same terminal session.

## What Changed

- Capture the Cursor managed-hook `conversation_id` as the existing provider session identity.
- Add Cursor to the Native Chat support matrix without making it a sleeping/resumable agent.
- Resolve Cursor transcripts from the real `.cursor/projects/**/agent-transcripts/<id>/<id>.jsonl` layout, including Windows-hosted WSL homes.
- Decode Cursor user/assistant text, assistant tool calls, and `turn_ended` lifecycle rows without inventing IDs, timestamps, or tool results.
- Route full reads, tail reads, live watching, paired runtime access, composer input, and Stop through the existing Native Chat paths.
- Keep direct SSH fail-closed because the desktop process cannot read a remote Cursor transcript there.

## Why

Orca already detects and launches Cursor Agent, but Native Chat did not recognize its session identity or transcript format. Extending the shared support, resolver, decoder, and watcher paths keeps Cursor aligned with the existing Chat UI without adding a provider-specific UI or changing the remote wire schema.

## Linked Issue

Fixes #15718

The issue was closed as a duplicate of the broader #7766; this PR implements only its Cursor CLI Native Chat scope and intentionally does not claim to close the remaining sidebar work in #7766.

## Visual Proof

N/A - no new visual design or components. This enables Cursor in the existing Native Chat UI unchanged; the Electron E2E verifies rendered history, tool calls, live append, terminal round-trip restoration, model/mode controls, composer routing, and Stop.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- Real `cursor-agent` `2026.08.25-3e8eec8` smoke: verified the current transcript schema and resolved the generated session by `conversation_id`.
- Focused Vitest suite: 13 files, 213 passed, 2 platform skips.
- Electron E2E: `native-chat-cursor.spec.ts`, 1 passed on macOS headless Electron.
- `pnpm tc`: passed.
- `pnpm run check:code-quality:changed`: 0 findings.
- `electron-vite build --mode e2e`: passed.
- `git diff --check`: passed.
- The repository `pnpm test` wrapper is blocked on this machine by the patched `node-pty` source-build preflight; the same Vitest config was run directly for the focused suite. Full lint/test/build matrices are left to PR CI.
- Windows/WSL behavior is covered by resolver and filesystem-gate tests; it was not manually tested on Windows.
- Paired runtime and direct SSH fail-closed behavior are covered by integration/availability tests; no live SSH host was used.

## AI Disclosure

Implemented and reviewed with OpenAI Codex.

## Review

- Cross-platform: path construction uses existing source definitions and Node path APIs; WSL UNC scans use the existing bounded filesystem gate and preserve refusal/abort semantics.
- Local/remote: local and paired-runtime owners can read Cursor transcripts; Model-A direct SSH remains fail-closed rather than loading forever.
- Agent compatibility: Claude, Codex, Grok, and OMP dispatch paths are unchanged; Cursor is intentionally not added to sleeping-session resume contracts.
- Backwards compatibility: no remote RPC or stream schema changes.
- Performance: WSL home discovery is lazy after a host miss and reuses the existing cache; transcript search reuses the AI Vault Cursor predicates.
- UI quality: the existing Native Chat UI, model/mode catalog, composer, and Stop controls are reused without new components or styles.
- Security: no credentials or transcript contents are persisted outside existing paths; direct SSH does not fall back to reading a local lookalike.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No dependencies, version bumps, release metadata, sidebar title changes, or remote wire changes are included.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
