### PR TITLE
fix(sidebar): put pinned folder workspaces in the Pinned section

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.folder-workspace-rows.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.folder-workspace-rows.test.ts
@@ -165,7 +165,7 @@ describe('WorktreeList lineage child card renderer', () => {
     const markup = await renderWorktreeListMarkup()
 
     expect(markup).toContain(
-      'aria-activedescendant="worktree-list-option-folder%3Afolder-workspace-1"'
+      'aria-activedescendant="worktree-list-option-project-group%3Afolder-group-1%3Afolder-workspace%3Afolder-workspace-1"'
     )
   })
 

--- a/src/renderer/src/components/sidebar/host-section-folder-workspace-counts.test.ts
+++ b/src/renderer/src/components/sidebar/host-section-folder-workspace-counts.test.ts
@@ -125,4 +125,20 @@ describe('folder workspace host counts', () => {
       { hostId: 'ssh:builder', count: 1 }
     ])
   })
+
+  it('counts a pinned folder workspace once when it renders in two sections', () => {
+    // Why: under showPinnedWorktreesInGroups the same workspace emits a Pinned
+    // row and a project-group row. The host badge counts workspaces, not rows.
+    const pinnedCopy: Extract<Row, { type: 'folder-workspace' }> = {
+      ...FOLDER_ROW,
+      key: 'pinned:folder-workspace:folder-1',
+      sectionKey: 'pinned',
+      folderWorkspace: { ...FOLDER_ROW.folderWorkspace, isPinned: true }
+    }
+
+    expect(hostCounts([LOCAL_ROW, pinnedCopy, FOLDER_ROW])).toEqual([
+      { hostId: 'local', count: 1 },
+      { hostId: 'ssh:builder', count: 1 }
+    ])
+  })
 })

--- a/src/renderer/src/components/sidebar/host-section-folder-workspace-counts.test.ts
+++ b/src/renderer/src/components/sidebar/host-section-folder-workspace-counts.test.ts
@@ -67,7 +67,8 @@ const PROJECT_GROUP: ProjectGroup = {
 
 const FOLDER_ROW: Extract<Row, { type: 'folder-workspace' }> = {
   type: 'folder-workspace',
-  key: 'folder-workspace:folder-1',
+  key: 'project-group:group-1:folder-workspace:folder-1',
+  sectionKey: 'project-group:group-1',
   folderWorkspace: {
     id: 'folder-1',
     projectGroupId: PROJECT_GROUP.id,

--- a/src/renderer/src/components/sidebar/host-section-rows.test.ts
+++ b/src/renderer/src/components/sidebar/host-section-rows.test.ts
@@ -128,7 +128,8 @@ function folderWorkspaceRow(
   }
   return {
     type: 'folder-workspace',
-    key: 'folder-workspace:folder-1',
+    key: 'project-group:group-1:folder-workspace:folder-1',
+    sectionKey: 'project-group:group-1',
     folderWorkspace,
     projectGroup,
     depth: 0,
@@ -601,7 +602,7 @@ describe('addHostSectionRows', () => {
       'repo:local',
       'local-wt',
       'host:ssh:ssh-1',
-      'folder-workspace:folder-1'
+      'project-group:group-1:folder-workspace:folder-1'
     ])
   })
 

--- a/src/renderer/src/components/sidebar/host-section-rows.ts
+++ b/src/renderer/src/components/sidebar/host-section-rows.ts
@@ -87,6 +87,7 @@ function countWorkspaceRows(rows: readonly Row[]): number {
   // while a visibly populated project sits right under it.
   let count = 0
   const seenWorktreeIds = new Set<string>()
+  const seenFolderWorkspaceIds = new Set<string>()
   let pendingHeader: Extract<Row, { type: 'header' }> | null = null
   let pendingHeaderHadWorkspaces = false
   const flushHeader = (): void => {
@@ -123,7 +124,12 @@ function countWorkspaceRows(rows: readonly Row[]): number {
       continue
     }
     if (row.type === 'folder-workspace') {
-      count += 1
+      // Why dedupe: a pinned folder workspace renders in Pinned and in its group
+      // under duplicate-in-groups, but it is still one workspace to the badge.
+      if (!seenFolderWorkspaceIds.has(row.folderWorkspace.id)) {
+        count += 1
+        seenFolderWorkspaceIds.add(row.folderWorkspace.id)
+      }
       pendingHeaderHadWorkspaces = pendingHeader !== null
     }
   }

--- a/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
@@ -118,7 +118,8 @@ describe('getCyclableWorktreeIds', () => {
     const rows: HostSectionRow[] = [
       {
         type: 'folder-workspace',
-        key: 'folder-workspace:folder-1',
+        key: 'project-group:group-1:folder-workspace:folder-1',
+        sectionKey: 'project-group:group-1',
         folderWorkspace: { id: 'folder-1', projectGroupId: 'group-1' } as never,
         projectGroup: { id: 'group-1' } as never,
         depth: 0,

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.folder-workspace-lanes.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.folder-workspace-lanes.test.ts
@@ -94,7 +94,7 @@ describe('folder workspaces render under every Group by mode', () => {
 
   it('does not duplicate the row under repo grouping', () => {
     const rows = buildSidebarRows({ groupBy: 'repo' })
-    expect(folderRows(rows).map((row) => row.key)).toEqual(['folder-workspace:fw-1'])
+    expect(folderRows(rows).map((row) => row.sectionKey)).toEqual([`project-group:${GROUP.id}`])
   })
 })
 

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.pinned-folder-workspaces.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.pinned-folder-workspaces.test.ts
@@ -109,7 +109,8 @@ describe('pinned folder workspaces land in the Pinned section', () => {
       })
       expect(rows[pinnedHeaderIndex + 1]).toMatchObject({
         type: 'folder-workspace',
-        key: 'folder-workspace:fw-1',
+        key: `${PINNED_GROUP_KEY}:folder-workspace:fw-1`,
+        sectionKey: PINNED_GROUP_KEY,
         folderWorkspace: { id: 'fw-1', isPinned: true }
       })
     })
@@ -164,7 +165,9 @@ describe('pinned folder workspaces follow the display policy', () => {
       sectionKey: PINNED_GROUP_KEY,
       folderWorkspace: { id: 'fw-1' }
     })
-    expect(folderRows(rows.slice(2)).map((row) => row.key)).toEqual(['folder-workspace:fw-1'])
+    expect(folderRows(rows.slice(2)).map((row) => row.sectionKey)).toEqual([
+      `project-group:${GROUP.id}`
+    ])
   })
 
   it('sits beside a pinned git worktree in Pinned', () => {

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.pinned-folder-workspaces.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.pinned-folder-workspaces.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest'
+import { buildRows } from './build-rows'
+import { PINNED_GROUP_KEY } from './group-keys'
+import type { Row, WorktreeGroupBy } from './row-types'
+import { repo, worktree } from '../../worktree-list-groups-test-fixtures'
+import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import type { Repo } from '../../../../../../shared/repo-types'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+
+const GROUP: ProjectGroup = {
+  id: 'group-1',
+  name: 'Folder Project',
+  parentPath: '/tmp/parent',
+  parentGroupId: null,
+  createdFrom: 'folder-scan',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'fw-1',
+    projectGroupId: GROUP.id,
+    name: 'Folder workspace',
+    folderPath: '/tmp/parent',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 1,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    workspaceStatus: 'in-progress',
+    ...overrides
+  }
+}
+
+const GROUPED_REPO: Repo = { ...repo, projectGroupId: GROUP.id }
+
+function buildSidebarRows(options: {
+  groupBy: WorktreeGroupBy
+  folderWorkspaces?: readonly FolderWorkspace[]
+  projectGroups?: readonly ProjectGroup[]
+  worktrees?: (typeof worktree)[]
+  collapsedGroups?: Set<string>
+  showPinnedWorktreesInGroups?: boolean
+}): Row[] {
+  const worktrees = options.worktrees ?? [worktree]
+  return buildRows(
+    options.groupBy,
+    worktrees,
+    new Map([[GROUPED_REPO.id, GROUPED_REPO]]),
+    null,
+    options.collapsedGroups ?? new Set<string>(),
+    undefined,
+    undefined,
+    'manual',
+    {},
+    new Map(worktrees.map((entry) => [entry.id, entry])),
+    false,
+    options.showPinnedWorktreesInGroups === true
+      ? ({ showPinnedWorktreesInGroups: true } as never)
+      : undefined,
+    options.projectGroups ?? [GROUP],
+    new Set(),
+    new Map(),
+    new Map(),
+    [],
+    undefined,
+    options.folderWorkspaces ?? [makeFolderWorkspace()]
+  )
+}
+
+function folderRows(rows: Row[]): Extract<Row, { type: 'folder-workspace' }>[] {
+  return rows.filter(
+    (row): row is Extract<Row, { type: 'folder-workspace' }> => row.type === 'folder-workspace'
+  )
+}
+
+function headerKeys(rows: Row[]): string[] {
+  return rows.filter((row) => row.type === 'header').map((row) => row.key)
+}
+
+const ALL_GROUP_BY: WorktreeGroupBy[] = ['repo', 'workspace-status', 'pr-status', 'none']
+
+describe('pinned folder workspaces land in the Pinned section', () => {
+  // The screenshot case: Pin on a folder workspace flips isPinned, but the card
+  // stayed under its project group instead of moving to the left Pinned list.
+  for (const groupBy of ALL_GROUP_BY) {
+    it(`emits the pinned folder workspace under Pinned when groupBy is ${groupBy}`, () => {
+      const rows = buildSidebarRows({
+        groupBy,
+        folderWorkspaces: [makeFolderWorkspace({ isPinned: true })]
+      })
+      const pinnedHeaderIndex = rows.findIndex(
+        (row) => row.type === 'header' && row.key === PINNED_GROUP_KEY
+      )
+      expect(pinnedHeaderIndex).toBeGreaterThanOrEqual(0)
+      expect(rows[pinnedHeaderIndex]).toMatchObject({
+        type: 'header',
+        key: PINNED_GROUP_KEY,
+        count: 1
+      })
+      expect(rows[pinnedHeaderIndex + 1]).toMatchObject({
+        type: 'folder-workspace',
+        key: 'folder-workspace:fw-1',
+        folderWorkspace: { id: 'fw-1', isPinned: true }
+      })
+    })
+  }
+
+  it('creates Pinned when the only pinned member is a folder workspace', () => {
+    const rows = buildSidebarRows({
+      groupBy: 'repo',
+      worktrees: [worktree],
+      folderWorkspaces: [makeFolderWorkspace({ isPinned: true })]
+    })
+    expect(headerKeys(rows)[0]).toBe(PINNED_GROUP_KEY)
+    expect(folderRows(rows)).toHaveLength(1)
+  })
+
+  it('keeps an unpinned folder workspace out of Pinned', () => {
+    const rows = buildSidebarRows({
+      groupBy: 'repo',
+      folderWorkspaces: [makeFolderWorkspace({ isPinned: false })]
+    })
+    expect(headerKeys(rows)).not.toContain(PINNED_GROUP_KEY)
+    expect(folderRows(rows)).toHaveLength(1)
+  })
+})
+
+describe('pinned folder workspaces follow the display policy', () => {
+  it('leaves the project group in single-location mode', () => {
+    const rows = buildSidebarRows({
+      groupBy: 'repo',
+      folderWorkspaces: [makeFolderWorkspace({ isPinned: true })]
+    })
+    expect(folderRows(rows)).toHaveLength(1)
+    const projectHeaderIndex = rows.findIndex(
+      (row) => row.type === 'header' && row.key.startsWith('project-group:')
+    )
+    expect(projectHeaderIndex).toBeGreaterThan(0)
+    const afterProject = rows.slice(projectHeaderIndex + 1)
+    expect(folderRows(afterProject)).toHaveLength(0)
+  })
+
+  it('duplicates into the project group when the policy allows it', () => {
+    const rows = buildSidebarRows({
+      groupBy: 'repo',
+      folderWorkspaces: [makeFolderWorkspace({ isPinned: true })],
+      showPinnedWorktreesInGroups: true
+    })
+    expect(folderRows(rows)).toHaveLength(2)
+    expect(rows[0]).toMatchObject({ type: 'header', key: PINNED_GROUP_KEY })
+    expect(rows[1]).toMatchObject({
+      type: 'folder-workspace',
+      key: `${PINNED_GROUP_KEY}:folder-workspace:fw-1`,
+      sectionKey: PINNED_GROUP_KEY,
+      folderWorkspace: { id: 'fw-1' }
+    })
+    expect(folderRows(rows.slice(2)).map((row) => row.key)).toEqual(['folder-workspace:fw-1'])
+  })
+
+  it('sits beside a pinned git worktree in Pinned', () => {
+    const pinnedWorktree = { ...worktree, id: 'wt-pinned', isPinned: true }
+    const rows = buildSidebarRows({
+      groupBy: 'none',
+      worktrees: [pinnedWorktree],
+      folderWorkspaces: [makeFolderWorkspace({ isPinned: true })]
+    })
+    expect(rows[0]).toMatchObject({ type: 'header', key: PINNED_GROUP_KEY, count: 2 })
+    expect(rows[1]).toMatchObject({ type: 'item', worktree: { id: 'wt-pinned' } })
+    expect(rows[2]).toMatchObject({ type: 'folder-workspace', folderWorkspace: { id: 'fw-1' } })
+  })
+})
+
+describe('pinned folder workspace host bookkeeping', () => {
+  const SSH_HOST = 'ssh:target-1' as ExecutionHostId
+
+  it('scopes a folder-only Pinned header to its host', () => {
+    const sshGroup: ProjectGroup = { ...GROUP, connectionId: 'target-1' }
+    const rows = buildRows(
+      'repo',
+      [],
+      new Map(),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      'manual',
+      {},
+      new Map(),
+      false,
+      undefined,
+      [sshGroup],
+      new Set(),
+      new Map(),
+      new Map(),
+      [],
+      undefined,
+      [makeFolderWorkspace({ isPinned: true })]
+    )
+    const header = rows.find((row) => row.type === 'header' && row.key === PINNED_GROUP_KEY)
+    expect(header).toBeDefined()
+    const counts = header && 'hostWorktreeCounts' in header ? header.hostWorktreeCounts : undefined
+    expect(counts?.get(SSH_HOST)).toBe(1)
+    const ids = header && 'hostWorktreeIds' in header ? header.hostWorktreeIds : undefined
+    expect(ids?.has(SSH_HOST)).toBe(true)
+    expect(ids?.get(SSH_HOST)).toEqual([])
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
@@ -31,7 +31,8 @@ import {
 } from './row-builders'
 import {
   compareFolderWorkspacesForDisplay,
-  getRenderableFolderWorkspaces
+  getRenderableFolderWorkspaces,
+  partitionFolderWorkspacesForPinnedDisplay
 } from './folder-workspace-lanes'
 import { getPinnedWorktreeDisplayPolicy } from './row-types'
 import type {
@@ -76,7 +77,10 @@ export function buildRows(
   const projectIndex = buildProjectGroupingIndex(projectGrouping)
   // Membership is decided once, above the groupBy switch: every mode renders the
   // same set of folder workspaces and only chooses where they land (#15362).
+  // Pin is a later placement choice on that same set, matching git worktrees.
   const renderableFolderWorkspaces = getRenderableFolderWorkspaces(folderWorkspaces, projectGroups)
+  const { pinned: pinnedFolderWorkspaces, natural: naturalFolderWorkspaces } =
+    partitionFolderWorkspacesForPinnedDisplay(renderableFolderWorkspaces, pinnedDisplayPolicy)
   const cyclicLineageIds = nestLineage
     ? getCyclicProjectedWorktreeLineageIds(lineageById, worktreeMap)
     : new Set<string>()
@@ -134,6 +138,7 @@ export function buildRows(
   })
   emitPinnedGroup(
     pinnedSectionWorktrees,
+    pinnedFolderWorkspaces,
     repoMap,
     defaultHostId,
     collapsedGroups,
@@ -145,28 +150,29 @@ export function buildRows(
     worktreeMap,
     nestLineage,
     cyclicLineageIds,
-    noticeHostContextLabelByRepoId
+    noticeHostContextLabelByRepoId,
+    pinnedDisplayPolicy === 'duplicate-in-groups'
   )
   if (groupBy === 'none') {
     // Why folder workspaces gate this too: an account with only folder
     // workspaces rendered nothing at all in flat mode before (#15362).
-    if (naturalWorktrees.length > 0 || renderableFolderWorkspaces.length > 0) {
+    if (naturalWorktrees.length > 0 || naturalFolderWorkspaces.length > 0) {
       result.push({
         type: 'header',
         key: ALL_GROUP_KEY,
         label: ALL_GROUP_META.label,
-        count: naturalWorktrees.length + renderableFolderWorkspaces.length,
+        count: naturalWorktrees.length + naturalFolderWorkspaces.length,
         tone: ALL_GROUP_META.tone,
         icon: ALL_GROUP_META.icon,
         hostWorktreeCounts: getLaneHostWorktreeCounts(
           naturalWorktrees,
-          renderableFolderWorkspaces,
+          naturalFolderWorkspaces,
           repoMap,
           defaultHostId
         ),
         hostWorktreeIds: getLaneHostWorktreeIds(
           naturalWorktrees,
-          renderableFolderWorkspaces,
+          naturalFolderWorkspaces,
           repoMap,
           defaultHostId
         ),
@@ -181,7 +187,7 @@ export function buildRows(
           hostContextLabelByWorktreeIdentity: mixedWorktreeHostContextLabels,
           cyclicLineageIds
         })
-        for (const pair of [...renderableFolderWorkspaces].sort((left, right) =>
+        for (const pair of [...naturalFolderWorkspaces].sort((left, right) =>
           compareFolderWorkspacesForDisplay(left.folderWorkspace, right.folderWorkspace)
         )) {
           result.push(buildFolderWorkspaceRow(pair, 0))
@@ -205,7 +211,7 @@ export function buildRows(
     pendingByRepo,
     repoOrder,
     projectOrderBy,
-    folderWorkspaces: renderableFolderWorkspaces
+    folderWorkspaces: naturalFolderWorkspaces
   })
 
   const sectionContext: SectionAppendContext = {
@@ -239,7 +245,7 @@ export function buildRows(
   appendProjectGroupSections(sectionContext, {
     orderedGroups,
     projectGroups,
-    folderWorkspaces: renderableFolderWorkspaces,
+    folderWorkspaces: naturalFolderWorkspaces,
     projectOrderBy,
     repoOrder
   })

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
@@ -31,8 +31,7 @@ import {
 } from './row-builders'
 import {
   compareFolderWorkspacesForDisplay,
-  getRenderableFolderWorkspaces,
-  partitionFolderWorkspacesForPinnedDisplay
+  getRenderableFolderWorkspaces
 } from './folder-workspace-lanes'
 import { getPinnedWorktreeDisplayPolicy } from './row-types'
 import type {
@@ -77,10 +76,7 @@ export function buildRows(
   const projectIndex = buildProjectGroupingIndex(projectGrouping)
   // Membership is decided once, above the groupBy switch: every mode renders the
   // same set of folder workspaces and only chooses where they land (#15362).
-  // Pin is a later placement choice on that same set, matching git worktrees.
   const renderableFolderWorkspaces = getRenderableFolderWorkspaces(folderWorkspaces, projectGroups)
-  const { pinned: pinnedFolderWorkspaces, natural: naturalFolderWorkspaces } =
-    partitionFolderWorkspacesForPinnedDisplay(renderableFolderWorkspaces, pinnedDisplayPolicy)
   const cyclicLineageIds = nestLineage
     ? getCyclicProjectedWorktreeLineageIds(lineageById, worktreeMap)
     : new Set<string>()
@@ -109,6 +105,16 @@ export function buildRows(
     pinnedDisplayPolicy === 'duplicate-in-groups'
       ? worktrees
       : worktrees.filter((worktree) => !pinnedSectionIds.has(getWorktreeHostIdentity(worktree)))
+  // Pin is placement, not membership, for folder workspaces too: the pinned ones
+  // always render under Pinned and only the policy decides whether their group
+  // keeps a second copy. Mirrors the worktree partition directly above.
+  const pinnedFolderWorkspaces = renderableFolderWorkspaces.filter(
+    (pair) => pair.folderWorkspace.isPinned
+  )
+  const naturalFolderWorkspaces =
+    pinnedDisplayPolicy === 'duplicate-in-groups'
+      ? renderableFolderWorkspaces
+      : renderableFolderWorkspaces.filter((pair) => !pair.folderWorkspace.isPinned)
   const mixedWorktreeHostContextLabels = getMixedWorktreeHostContextLabels(
     naturalWorktrees,
     repoMap,
@@ -136,23 +142,22 @@ export function buildRows(
     settings,
     projectGrouping
   })
-  emitPinnedGroup(
-    pinnedSectionWorktrees,
-    pinnedFolderWorkspaces,
+  emitPinnedGroup({
+    result,
+    worktrees: pinnedSectionWorktrees,
+    folderWorkspaces: pinnedFolderWorkspaces,
     repoMap,
     defaultHostId,
     collapsedGroups,
     renderedNaturalAnchorRepoIds,
     importedWorktreesByRepo,
-    groupBy !== 'repo',
-    result,
+    allowImportedFallback: groupBy !== 'repo',
     lineageById,
     worktreeMap,
     nestLineage,
     cyclicLineageIds,
-    noticeHostContextLabelByRepoId,
-    pinnedDisplayPolicy === 'duplicate-in-groups'
-  )
+    noticeHostContextLabelByRepoId
+  })
   if (groupBy === 'none') {
     // Why folder workspaces gate this too: an account with only folder
     // workspaces rendered nothing at all in flat mode before (#15362).
@@ -190,7 +195,7 @@ export function buildRows(
         for (const pair of [...naturalFolderWorkspaces].sort((left, right) =>
           compareFolderWorkspacesForDisplay(left.folderWorkspace, right.folderWorkspace)
         )) {
-          result.push(buildFolderWorkspaceRow(pair, 0))
+          result.push(buildFolderWorkspaceRow(pair, ALL_GROUP_KEY, 0))
         }
       }
     }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-lanes.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-lanes.ts
@@ -6,7 +6,7 @@ import {
   getWorkspaceStatusGroupKey
 } from '../../../../../../shared/workspace-statuses'
 import { ALL_GROUP_KEY, getPRLaneKey } from './group-keys'
-import type { PinnedWorktreeDisplayPolicy, WorktreeGroupBy } from './row-types'
+import type { WorktreeGroupBy } from './row-types'
 
 /** A folder workspace paired with the project group that owns it. The pair is
  *  carried through grouping because FolderWorkspaceRow needs a non-optional
@@ -74,23 +74,4 @@ export function compareFolderWorkspacesForDisplay(
   const leftOrder = left.manualOrder ?? left.sortOrder
   const rightOrder = right.manualOrder ?? right.sortOrder
   return rightOrder - leftOrder || left.name.localeCompare(right.name)
-}
-
-/** Pin is placement, not membership: every renderable folder workspace still
- *  renders, but a pinned one belongs in Pinned the same way a git worktree does. */
-export function partitionFolderWorkspacesForPinnedDisplay(
-  folderWorkspaces: readonly RenderableFolderWorkspace[],
-  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
-): {
-  pinned: RenderableFolderWorkspace[]
-  natural: RenderableFolderWorkspace[]
-} {
-  const pinned = folderWorkspaces.filter((pair) => pair.folderWorkspace.isPinned)
-  if (pinnedDisplayPolicy === 'duplicate-in-groups') {
-    return { pinned, natural: [...folderWorkspaces] }
-  }
-  return {
-    pinned,
-    natural: folderWorkspaces.filter((pair) => !pair.folderWorkspace.isPinned)
-  }
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-lanes.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-lanes.ts
@@ -6,7 +6,7 @@ import {
   getWorkspaceStatusGroupKey
 } from '../../../../../../shared/workspace-statuses'
 import { ALL_GROUP_KEY, getPRLaneKey } from './group-keys'
-import type { WorktreeGroupBy } from './row-types'
+import type { PinnedWorktreeDisplayPolicy, WorktreeGroupBy } from './row-types'
 
 /** A folder workspace paired with the project group that owns it. The pair is
  *  carried through grouping because FolderWorkspaceRow needs a non-optional
@@ -74,4 +74,23 @@ export function compareFolderWorkspacesForDisplay(
   const leftOrder = left.manualOrder ?? left.sortOrder
   const rightOrder = right.manualOrder ?? right.sortOrder
   return rightOrder - leftOrder || left.name.localeCompare(right.name)
+}
+
+/** Pin is placement, not membership: every renderable folder workspace still
+ *  renders, but a pinned one belongs in Pinned the same way a git worktree does. */
+export function partitionFolderWorkspacesForPinnedDisplay(
+  folderWorkspaces: readonly RenderableFolderWorkspace[],
+  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
+): {
+  pinned: RenderableFolderWorkspace[]
+  natural: RenderableFolderWorkspace[]
+} {
+  const pinned = folderWorkspaces.filter((pair) => pair.folderWorkspace.isPinned)
+  if (pinnedDisplayPolicy === 'duplicate-in-groups') {
+    return { pinned, natural: [...folderWorkspaces] }
+  }
+  return {
+    pinned,
+    natural: folderWorkspaces.filter((pair) => !pair.folderWorkspace.isPinned)
+  }
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/group-sections.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/group-sections.ts
@@ -211,7 +211,7 @@ export function appendOrderedGroups(
         cyclicLineageIds
       })
       for (const pair of folderPairs) {
-        result.push(buildFolderWorkspaceRow(pair, projectGroupDepth))
+        result.push(buildFolderWorkspaceRow(pair, key, projectGroupDepth))
       }
     }
   }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/pinned-group-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/pinned-group-rows.ts
@@ -1,11 +1,22 @@
 import type { Repo } from '../../../../../../shared/repo-types'
 import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../../../shared/worktree/types'
-import { getWorktreeExecutionHostId } from '../../../../../../shared/execution-host'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import { PINNED_GROUP_KEY, PINNED_GROUP_META } from './group-keys'
-import { appendWorktreeRows, buildImportedWorktreesCardRow } from './row-builders'
-import type { NoticeHostContext } from './host-labels'
+import {
+  compareFolderWorkspacesForDisplay,
+  type RenderableFolderWorkspace
+} from './folder-workspace-lanes'
+import {
+  getLaneHostWorktreeCounts,
+  getLaneHostWorktreeIds,
+  type NoticeHostContext
+} from './host-labels'
+import {
+  appendWorktreeRows,
+  buildFolderWorkspaceRow,
+  buildImportedWorktreesCardRow
+} from './row-builders'
 import type { ImportedWorktreesCardCandidate, Row } from './row-types'
 
 /**
@@ -16,6 +27,7 @@ import type { ImportedWorktreesCardCandidate, Row } from './row-types'
  */
 export function emitPinnedGroup(
   pinnedSectionWorktrees: Worktree[],
+  pinnedFolderWorkspaces: readonly RenderableFolderWorkspace[],
   repoMap: Map<string, Repo>,
   defaultHostId: ExecutionHostId,
   collapsedGroups: Set<string>,
@@ -27,21 +39,15 @@ export function emitPinnedGroup(
   worktreeMap: Map<string, Worktree>,
   nestLineage: boolean,
   cyclicLineageIds: ReadonlySet<string>,
-  noticeHostContextLabelByRepoId?: ReadonlyMap<string, NoticeHostContext>
+  noticeHostContextLabelByRepoId?: ReadonlyMap<string, NoticeHostContext>,
+  duplicatePinnedFolderKeys = false
 ): void {
-  if (pinnedSectionWorktrees.length === 0) {
+  if (pinnedSectionWorktrees.length === 0 && pinnedFolderWorkspaces.length === 0) {
     return
   }
-  const hostWorktreeCounts = new Map<ExecutionHostId, number>()
-  const hostWorktreeIds = new Map<ExecutionHostId, string[]>()
   const pinnedRepoOrder: string[] = []
   const seenPinnedRepoIds = new Set<string>()
   for (const worktree of pinnedSectionWorktrees) {
-    const hostId = getWorktreeExecutionHostId(worktree, repoMap.get(worktree.repoId), defaultHostId)
-    hostWorktreeCounts.set(hostId, (hostWorktreeCounts.get(hostId) ?? 0) + 1)
-    const hostIds = hostWorktreeIds.get(hostId) ?? []
-    hostIds.push(worktree.id)
-    hostWorktreeIds.set(hostId, hostIds)
     if (!seenPinnedRepoIds.has(worktree.repoId)) {
       pinnedRepoOrder.push(worktree.repoId)
       seenPinnedRepoIds.add(worktree.repoId)
@@ -52,11 +58,21 @@ export function emitPinnedGroup(
     type: 'header',
     key: PINNED_GROUP_KEY,
     label: PINNED_GROUP_META.label,
-    count: pinnedSectionWorktrees.length,
+    count: pinnedSectionWorktrees.length + pinnedFolderWorkspaces.length,
     tone: PINNED_GROUP_META.tone,
     icon: PINNED_GROUP_META.icon,
-    hostWorktreeCounts,
-    hostWorktreeIds,
+    hostWorktreeCounts: getLaneHostWorktreeCounts(
+      pinnedSectionWorktrees,
+      pinnedFolderWorkspaces,
+      repoMap,
+      defaultHostId
+    ),
+    hostWorktreeIds: getLaneHostWorktreeIds(
+      pinnedSectionWorktrees,
+      pinnedFolderWorkspaces,
+      repoMap,
+      defaultHostId
+    ),
     worktreeIds: pinnedSectionWorktrees.map((worktree) => worktree.id)
   })
   if (collapsedGroups.has(PINNED_GROUP_KEY)) {
@@ -83,31 +99,37 @@ export function emitPinnedGroup(
     sectionKey: PINNED_GROUP_KEY,
     cyclicLineageIds
   })
-  if (!allowImportedFallback) {
-    return
-  }
-  // Why: imported fallback sits after the last row of that repo; splice from the
-  // end so earlier inserts do not shift later targets.
-  const lastResultIndexByRepoId = new Map<string, number>()
-  for (let index = firstItemIndex; index < result.length; index++) {
-    const row = result[index]
-    if (row?.type === 'item') {
-      lastResultIndexByRepoId.set(row.worktree.repoId, index)
+  if (allowImportedFallback) {
+    // Why: imported fallback sits after the last row of that repo; splice from the
+    // end so earlier inserts do not shift later targets.
+    const lastResultIndexByRepoId = new Map<string, number>()
+    for (let index = firstItemIndex; index < result.length; index++) {
+      const row = result[index]
+      if (row?.type === 'item') {
+        lastResultIndexByRepoId.set(row.worktree.repoId, index)
+      }
     }
-  }
-  const inserts = [...lastResultIndexByRepoId.entries()].sort((left, right) => right[1] - left[1])
-  for (const [repoId, index] of inserts) {
-    const candidate = importedWorktreesByRepo.get(repoId)
-    if (candidate && !renderedNaturalAnchorRepoIds.has(repoId)) {
-      result.splice(
-        index + 1,
-        0,
-        buildImportedWorktreesCardRow(
-          candidate,
-          'pinned-fallback',
-          noticeHostContextLabelByRepoId?.get(repoId)
+    const inserts = [...lastResultIndexByRepoId.entries()].sort((left, right) => right[1] - left[1])
+    for (const [repoId, index] of inserts) {
+      const candidate = importedWorktreesByRepo.get(repoId)
+      if (candidate && !renderedNaturalAnchorRepoIds.has(repoId)) {
+        result.splice(
+          index + 1,
+          0,
+          buildImportedWorktreesCardRow(
+            candidate,
+            'pinned-fallback',
+            noticeHostContextLabelByRepoId?.get(repoId)
+          )
         )
-      )
+      }
     }
+  }
+  for (const pair of [...pinnedFolderWorkspaces].sort((left, right) =>
+    compareFolderWorkspacesForDisplay(left.folderWorkspace, right.folderWorkspace)
+  )) {
+    result.push(
+      buildFolderWorkspaceRow(pair, 0, duplicatePinnedFolderKeys ? PINNED_GROUP_KEY : undefined)
+    )
   }
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/pinned-group-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/pinned-group-rows.ts
@@ -19,35 +19,55 @@ import {
 } from './row-builders'
 import type { ImportedWorktreesCardCandidate, Row } from './row-types'
 
+export type PinnedGroupEmitOptions = {
+  result: Row[]
+  /** Pinned git worktrees, already resolved to whole lineage subtrees when nesting. */
+  worktrees: Worktree[]
+  /** Pinned folder workspaces. They carry no repo, so they take no part in the
+   *  repo-anchored imported-worktrees fallback below. */
+  folderWorkspaces: readonly RenderableFolderWorkspace[]
+  repoMap: Map<string, Repo>
+  defaultHostId: ExecutionHostId
+  collapsedGroups: Set<string>
+  renderedNaturalAnchorRepoIds: ReadonlySet<string>
+  importedWorktreesByRepo: ReadonlyMap<string, ImportedWorktreesCardCandidate>
+  allowImportedFallback: boolean
+  lineageById: Record<string, WorktreeLineage>
+  worktreeMap: Map<string, Worktree>
+  nestLineage: boolean
+  cyclicLineageIds: ReadonlySet<string>
+  noticeHostContextLabelByRepoId?: ReadonlyMap<string, NoticeHostContext>
+}
+
 /**
  * The Pinned section's rows.
  *
  * Split out of row-builders to keep that file under the line cap; pinned
  * emission has its own ordering and imported-fallback placement rules.
  */
-export function emitPinnedGroup(
-  pinnedSectionWorktrees: Worktree[],
-  pinnedFolderWorkspaces: readonly RenderableFolderWorkspace[],
-  repoMap: Map<string, Repo>,
-  defaultHostId: ExecutionHostId,
-  collapsedGroups: Set<string>,
-  renderedNaturalAnchorRepoIds: ReadonlySet<string>,
-  importedWorktreesByRepo: ReadonlyMap<string, ImportedWorktreesCardCandidate>,
-  allowImportedFallback: boolean,
-  result: Row[],
-  lineageById: Record<string, WorktreeLineage>,
-  worktreeMap: Map<string, Worktree>,
-  nestLineage: boolean,
-  cyclicLineageIds: ReadonlySet<string>,
-  noticeHostContextLabelByRepoId?: ReadonlyMap<string, NoticeHostContext>,
-  duplicatePinnedFolderKeys = false
-): void {
-  if (pinnedSectionWorktrees.length === 0 && pinnedFolderWorkspaces.length === 0) {
+export function emitPinnedGroup(options: PinnedGroupEmitOptions): void {
+  const {
+    result,
+    worktrees,
+    folderWorkspaces,
+    repoMap,
+    defaultHostId,
+    collapsedGroups,
+    renderedNaturalAnchorRepoIds,
+    importedWorktreesByRepo,
+    allowImportedFallback,
+    lineageById,
+    worktreeMap,
+    nestLineage,
+    cyclicLineageIds,
+    noticeHostContextLabelByRepoId
+  } = options
+  if (worktrees.length === 0 && folderWorkspaces.length === 0) {
     return
   }
   const pinnedRepoOrder: string[] = []
   const seenPinnedRepoIds = new Set<string>()
-  for (const worktree of pinnedSectionWorktrees) {
+  for (const worktree of worktrees) {
     if (!seenPinnedRepoIds.has(worktree.repoId)) {
       pinnedRepoOrder.push(worktree.repoId)
       seenPinnedRepoIds.add(worktree.repoId)
@@ -58,22 +78,20 @@ export function emitPinnedGroup(
     type: 'header',
     key: PINNED_GROUP_KEY,
     label: PINNED_GROUP_META.label,
-    count: pinnedSectionWorktrees.length + pinnedFolderWorkspaces.length,
+    count: worktrees.length + folderWorkspaces.length,
     tone: PINNED_GROUP_META.tone,
     icon: PINNED_GROUP_META.icon,
+    // Why the lane helpers and not a local tally: a Pinned section holding only
+    // folder workspaces still needs a defined host map, or the host sections
+    // read the missing key as unscoped and leak the global worktrees in (#15362).
     hostWorktreeCounts: getLaneHostWorktreeCounts(
-      pinnedSectionWorktrees,
-      pinnedFolderWorkspaces,
+      worktrees,
+      folderWorkspaces,
       repoMap,
       defaultHostId
     ),
-    hostWorktreeIds: getLaneHostWorktreeIds(
-      pinnedSectionWorktrees,
-      pinnedFolderWorkspaces,
-      repoMap,
-      defaultHostId
-    ),
-    worktreeIds: pinnedSectionWorktrees.map((worktree) => worktree.id)
+    hostWorktreeIds: getLaneHostWorktreeIds(worktrees, folderWorkspaces, repoMap, defaultHostId),
+    worktreeIds: worktrees.map((worktree) => worktree.id)
   })
   if (collapsedGroups.has(PINNED_GROUP_KEY)) {
     for (const repoId of pinnedRepoOrder) {
@@ -92,44 +110,43 @@ export function emitPinnedGroup(
   }
 
   const firstItemIndex = result.length
-  appendWorktreeRows(result, pinnedSectionWorktrees, repoMap, lineageById, worktreeMap, {
+  appendWorktreeRows(result, worktrees, repoMap, lineageById, worktreeMap, {
     nestLineage,
     collapsedGroups,
     groupDepth: 0,
     sectionKey: PINNED_GROUP_KEY,
     cyclicLineageIds
   })
-  if (allowImportedFallback) {
-    // Why: imported fallback sits after the last row of that repo; splice from the
-    // end so earlier inserts do not shift later targets.
-    const lastResultIndexByRepoId = new Map<string, number>()
-    for (let index = firstItemIndex; index < result.length; index++) {
-      const row = result[index]
-      if (row?.type === 'item') {
-        lastResultIndexByRepoId.set(row.worktree.repoId, index)
-      }
-    }
-    const inserts = [...lastResultIndexByRepoId.entries()].sort((left, right) => right[1] - left[1])
-    for (const [repoId, index] of inserts) {
-      const candidate = importedWorktreesByRepo.get(repoId)
-      if (candidate && !renderedNaturalAnchorRepoIds.has(repoId)) {
-        result.splice(
-          index + 1,
-          0,
-          buildImportedWorktreesCardRow(
-            candidate,
-            'pinned-fallback',
-            noticeHostContextLabelByRepoId?.get(repoId)
-          )
-        )
-      }
-    }
-  }
-  for (const pair of [...pinnedFolderWorkspaces].sort((left, right) =>
+  for (const pair of [...folderWorkspaces].sort((left, right) =>
     compareFolderWorkspacesForDisplay(left.folderWorkspace, right.folderWorkspace)
   )) {
-    result.push(
-      buildFolderWorkspaceRow(pair, 0, duplicatePinnedFolderKeys ? PINNED_GROUP_KEY : undefined)
-    )
+    result.push(buildFolderWorkspaceRow(pair, PINNED_GROUP_KEY, 0))
+  }
+  if (!allowImportedFallback) {
+    return
+  }
+  // Why: imported fallback sits after the last row of that repo; splice from the
+  // end so earlier inserts do not shift later targets.
+  const lastResultIndexByRepoId = new Map<string, number>()
+  for (let index = firstItemIndex; index < result.length; index++) {
+    const row = result[index]
+    if (row?.type === 'item') {
+      lastResultIndexByRepoId.set(row.worktree.repoId, index)
+    }
+  }
+  const inserts = [...lastResultIndexByRepoId.entries()].sort((left, right) => right[1] - left[1])
+  for (const [repoId, index] of inserts) {
+    const candidate = importedWorktreesByRepo.get(repoId)
+    if (candidate && !renderedNaturalAnchorRepoIds.has(repoId)) {
+      result.splice(
+        index + 1,
+        0,
+        buildImportedWorktreesCardRow(
+          candidate,
+          'pinned-fallback',
+          noticeHostContextLabelByRepoId?.get(repoId)
+        )
+      )
+    }
   }
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/project-group-sections.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/project-group-sections.ts
@@ -109,7 +109,7 @@ export function appendProjectGroupSections(
     })
     if (!collapsedGroups.has(key)) {
       for (const pair of folderWorkspacesByProjectGroupId.get(projectGroup.id) ?? []) {
-        result.push(buildFolderWorkspaceRow(pair, depth + 1))
+        result.push(buildFolderWorkspaceRow(pair, key, depth + 1))
       }
       appendOrderedGroups(ctx, withRepoSectionDisplayLabels(repoEntries), depth + 1)
       for (const childGroup of childGroups) {

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/row-builders.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/row-builders.ts
@@ -253,20 +253,21 @@ export function appendWorktreeRows(
 }
 
 /** The one folder-workspace row constructor, shared by the project-group,
- *  grouped-lane and flat emitters so their rows cannot diverge. */
+ *  grouped-lane, pinned and flat emitters so their rows cannot diverge.
+ *  Section-qualified like WorktreeRow.rowKey, so a pinned workspace's two copies
+ *  get distinct virtualizer keys and distinct option ids. */
 export function buildFolderWorkspaceRow(
   pair: RenderableFolderWorkspace,
-  groupDepth: number,
-  sectionKey?: string
+  sectionKey: string,
+  groupDepth: number
 ): FolderWorkspaceRow {
-  const id = pair.folderWorkspace.id
   return {
     type: 'folder-workspace',
-    key: sectionKey ? `${sectionKey}:folder-workspace:${id}` : `folder-workspace:${id}`,
+    key: `${sectionKey}:folder-workspace:${pair.folderWorkspace.id}`,
+    sectionKey,
     folderWorkspace: pair.folderWorkspace,
     projectGroup: pair.projectGroup,
     depth: 0,
-    groupDepth,
-    ...(sectionKey ? { sectionKey } : {})
+    groupDepth
   }
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/row-builders.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/row-builders.ts
@@ -256,14 +256,17 @@ export function appendWorktreeRows(
  *  grouped-lane and flat emitters so their rows cannot diverge. */
 export function buildFolderWorkspaceRow(
   pair: RenderableFolderWorkspace,
-  groupDepth: number
+  groupDepth: number,
+  sectionKey?: string
 ): FolderWorkspaceRow {
+  const id = pair.folderWorkspace.id
   return {
     type: 'folder-workspace',
-    key: `folder-workspace:${pair.folderWorkspace.id}`,
+    key: sectionKey ? `${sectionKey}:folder-workspace:${id}` : `folder-workspace:${id}`,
     folderWorkspace: pair.folderWorkspace,
     projectGroup: pair.projectGroup,
     depth: 0,
-    groupDepth
+    groupDepth,
+    ...(sectionKey ? { sectionKey } : {})
   }
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/row-types.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/row-types.ts
@@ -91,6 +91,7 @@ export type FolderWorkspaceRow = {
   projectGroup: ProjectGroup
   depth: number
   groupDepth: number
+  sectionKey?: string
 }
 
 /** Minimal shape buildRows needs for an in-flight create. Deliberately not the

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/row-types.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/row-types.ts
@@ -91,7 +91,9 @@ export type FolderWorkspaceRow = {
   projectGroup: ProjectGroup
   depth: number
   groupDepth: number
-  sectionKey?: string
+  /** The emitting section, as on WorktreeRow: a pinned workspace can render in
+   *  Pinned and in its group at once, and only this tells the two copies apart. */
+  sectionKey: string
 }
 
 /** Minimal shape buildRows needs for an in-flight create. Deliberately not the

--- a/src/renderer/src/components/sidebar/worktree-list/listing/render-row.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/render-row.ts
@@ -25,7 +25,7 @@ export function getRenderRowKey(row: RenderRow): string {
     return `pending:${row.creationId}`
   }
   if (row.type === 'folder-workspace') {
-    return `folder-workspace:${row.folderWorkspace.id}`
+    return row.key
   }
   return `wt:${row.rowKey}`
 }

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-collapsed-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-collapsed-groups.ts
@@ -61,7 +61,7 @@ export function useEffectiveCollapsedGroups(args: {
         agentSendTargetWorktreeId,
         folderWorkspaces,
         projectGroups,
-        { groupBy, workspaceStatuses, defaultHostId }
+        { groupBy, workspaceStatuses, defaultHostId, pinnedDisplayPolicy }
       )
       if (folderKeys.length === 0) {
         return collapsedGroups

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
@@ -9,7 +9,6 @@ import type { Repo } from '../../../../../../shared/repo-types'
 import type { WorkspaceStatusDefinition, Worktree } from '../../../../../../shared/worktree/types'
 import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-types'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
-import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import { getHostDisplayLabelOverrides } from '../../../../../../shared/host-setting-overrides'
 import { buildRows } from '../grouping/build-rows'
 import type { ProjectGroupingModel } from '../grouping/project-grouping'
@@ -53,7 +52,7 @@ function collectRenderedSidebarRowKeys(sectionRows: ReturnType<typeof addHostSec
     } else if (row.type === 'item') {
       keys.add(row.rowKey)
     } else if (row.type === 'folder-workspace') {
-      keys.add(folderWorkspaceKey(row.folderWorkspace.id))
+      keys.add(row.key)
     } else if (row.type === 'pending-creation') {
       keys.add(`pending:${row.creationId}`)
     } else if (row.type === 'imported-worktrees-card') {

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/active-descendant-option.folder-workspace.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/active-descendant-option.folder-workspace.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import { PINNED_GROUP_KEY, getProjectGroupHeaderKey } from '../grouping/group-keys'
+import { buildFolderWorkspaceRow } from '../grouping/row-builders'
+import type { RenderRow } from '../listing/render-row'
+import { getWorktreeOptionId } from '../rows/option-dom'
+import { getActiveDescendantOptionId, getRenderRowOptionId } from './active-descendant-option'
+
+const FOLDER_WORKSPACE: FolderWorkspace = {
+  id: 'fw-1',
+  projectGroupId: 'group-1',
+  name: 'Folder workspace',
+  folderPath: '/tmp/parent',
+  linkedTask: null,
+  comment: '',
+  isArchived: false,
+  isUnread: false,
+  isPinned: true,
+  sortOrder: 1,
+  lastActivityAt: 1,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const PROJECT_GROUP: ProjectGroup = {
+  id: 'group-1',
+  name: 'Group',
+  parentPath: '/tmp/parent',
+  parentGroupId: null,
+  createdFrom: 'folder-scan',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const GROUP_SECTION_KEY = getProjectGroupHeaderKey(PROJECT_GROUP.id)
+const WORKSPACE_ID = folderWorkspaceKey(FOLDER_WORKSPACE.id)
+
+function folderRow(sectionKey: string): RenderRow {
+  return buildFolderWorkspaceRow(
+    { folderWorkspace: FOLDER_WORKSPACE, projectGroup: PROJECT_GROUP },
+    sectionKey,
+    0
+  )
+}
+
+describe('folder workspace active-descendant ids', () => {
+  it('names the row that rendered, not the workspace', () => {
+    // Why this matters: folder-row.tsx puts row.key in the DOM id. An option id
+    // derived from the workspace id instead would dangle on the pinned copy,
+    // and aria-activedescendant would point at no element at all.
+    const pinnedRow = folderRow(PINNED_GROUP_KEY)
+    expect(getRenderRowOptionId(pinnedRow)).toBe(
+      getWorktreeOptionId(`${PINNED_GROUP_KEY}:folder-workspace:fw-1`)
+    )
+    expect(getRenderRowOptionId(folderRow(GROUP_SECTION_KEY))).not.toBe(
+      getRenderRowOptionId(pinnedRow)
+    )
+  })
+
+  it('points at the natural copy when the pinned duplicate is also mounted', () => {
+    const renderRows = [folderRow(PINNED_GROUP_KEY), folderRow(GROUP_SECTION_KEY)]
+
+    expect(
+      getActiveDescendantOptionId({
+        activeWorktreeId: WORKSPACE_ID,
+        pinnedDisplayPolicy: 'duplicate-in-groups',
+        renderRows,
+        virtualItems: [{ index: 0 }, { index: 1 }]
+      })
+    ).toBe(getRenderRowOptionId(renderRows[1]))
+  })
+
+  it('falls back to the pinned copy when it is the only one mounted', () => {
+    const renderRows = [folderRow(PINNED_GROUP_KEY)]
+
+    expect(
+      getActiveDescendantOptionId({
+        activeWorktreeId: WORKSPACE_ID,
+        pinnedDisplayPolicy: 'duplicate-in-groups',
+        renderRows,
+        virtualItems: [{ index: 0 }]
+      })
+    ).toBe(getRenderRowOptionId(renderRows[0]))
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/active-descendant-option.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/active-descendant-option.ts
@@ -1,12 +1,10 @@
-import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import type { RenderRow } from '../listing/render-row'
 import {
   getWorktreeExecutionHostId,
   type ExecutionHostId
 } from '../../../../../../shared/execution-host'
 import type { PinnedWorktreeDisplayPolicy } from '../grouping/row-types'
-import { isPinnedWorktreeRow } from '../listing/renderable-rows'
-import { getRenderRowWorktreeItem, renderRowContainsWorktree } from './render-row-lookup'
+import { isPinnedSectionRenderRow, renderRowContainsWorktree } from './render-row-lookup'
 import { getWorktreeOptionId } from '../rows/option-dom'
 
 export function getRenderRowOptionId(
@@ -33,7 +31,7 @@ export function getRenderRowOptionId(
     return getWorktreeOptionId(row.rowKey)
   }
   if (row.type === 'folder-workspace') {
-    return getWorktreeOptionId(folderWorkspaceKey(row.folderWorkspace.id))
+    return getWorktreeOptionId(row.key)
   }
   return undefined
 }
@@ -84,15 +82,13 @@ export function getActiveDescendantOptionId(args: {
       if (!optionId) {
         continue
       }
-      const itemRow = getRenderRowWorktreeItem(
-        row,
-        args.activeWorktreeId,
-        args.activeWorkspaceExecutionHostId ?? undefined
-      )
       if (
         args.pinnedDisplayPolicy === 'duplicate-in-groups' &&
-        itemRow &&
-        !isPinnedWorktreeRow(itemRow)
+        !isPinnedSectionRenderRow(
+          row,
+          args.activeWorktreeId,
+          args.activeWorkspaceExecutionHostId ?? undefined
+        )
       ) {
         return optionId
       }

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.test.ts
@@ -154,4 +154,16 @@ describe('reveal keys under non-repo grouping', () => {
     expect(keys).toContain(getProjectGroupHeaderKey(group.id))
     expect(keys.some((key) => key.startsWith('workspace-status:'))).toBe(false)
   })
+
+  it('includes Pinned so a collapsed Pinned section can be expanded', () => {
+    const pinned = makeFolderWorkspace({ isPinned: true })
+    const keys = getFolderWorkspaceRevealGroupKeys(
+      folderWorkspaceKey(pinned.id),
+      [pinned],
+      [group],
+      { groupBy: 'repo', workspaceStatuses: [], defaultHostId: 'local' }
+    )
+    expect(keys).toContain('pinned')
+    expect(keys[0]).toBe('pinned')
+  })
 })

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.test.ts
@@ -155,7 +155,10 @@ describe('reveal keys under non-repo grouping', () => {
     expect(keys.some((key) => key.startsWith('workspace-status:'))).toBe(false)
   })
 
-  it('includes Pinned so a collapsed Pinned section can be expanded', () => {
+  it('expands Pinned and nothing else when the card only renders there', () => {
+    // Why "nothing else": expandGroupsForWorktreeReveal persists every toggle it
+    // makes, so returning the project group would permanently un-collapse a
+    // section the user collapsed and the card is not in.
     const pinned = makeFolderWorkspace({ isPinned: true })
     const keys = getFolderWorkspaceRevealGroupKeys(
       folderWorkspaceKey(pinned.id),
@@ -163,7 +166,35 @@ describe('reveal keys under non-repo grouping', () => {
       [group],
       { groupBy: 'repo', workspaceStatuses: [], defaultHostId: 'local' }
     )
-    expect(keys).toContain('pinned')
     expect(keys[0]).toBe('pinned')
+    expect(keys).not.toContain(getProjectGroupHeaderKey(group.id))
+    // The host section wraps Pinned too, so it must still be expanded.
+    expect(keys).toContain('host:ssh:target-1')
+  })
+
+  it('expands the project group instead when the pinned card is duplicated there', () => {
+    const pinned = makeFolderWorkspace({ isPinned: true })
+    const keys = getFolderWorkspaceRevealGroupKeys(
+      folderWorkspaceKey(pinned.id),
+      [pinned],
+      [group],
+      {
+        groupBy: 'repo',
+        workspaceStatuses: [],
+        defaultHostId: 'local',
+        pinnedDisplayPolicy: 'duplicate-in-groups'
+      }
+    )
+    expect(keys).toContain(getProjectGroupHeaderKey(group.id))
+  })
+
+  it('leaves an unpinned workspace reveal untouched', () => {
+    const keys = getFolderWorkspaceRevealGroupKeys(workspaceKey, [folderWorkspace], [group], {
+      groupBy: 'repo',
+      workspaceStatuses: [],
+      defaultHostId: 'local'
+    })
+    expect(keys).not.toContain('pinned')
+    expect(keys).toContain(getProjectGroupHeaderKey(group.id))
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.ts
@@ -6,7 +6,7 @@ import { parseWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import { PINNED_GROUP_KEY, getProjectGroupHeaderKey } from '../grouping/group-keys'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import { getFolderWorkspaceLaneKey } from '../grouping/folder-workspace-lanes'
-import type { WorktreeGroupBy } from '../grouping/row-types'
+import type { PinnedWorktreeDisplayPolicy, WorktreeGroupBy } from '../grouping/row-types'
 import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
 
 function findFolderWorkspaceByKey(
@@ -65,6 +65,7 @@ export function getFolderWorkspaceRevealGroupKeys(
     groupBy?: WorktreeGroupBy
     workspaceStatuses?: readonly WorkspaceStatusDefinition[]
     defaultHostId?: ExecutionHostId
+    pinnedDisplayPolicy?: PinnedWorktreeDisplayPolicy
   }
 ): string[] {
   const folderWorkspace = findFolderWorkspaceByKey(worktreeId, folderWorkspaces)
@@ -73,6 +74,18 @@ export function getFolderWorkspaceRevealGroupKeys(
   }
 
   const groupsById = new Map(projectGroups.map((group) => [group.id, group]))
+  const owningGroup = groupsById.get(folderWorkspace.projectGroupId)
+  // The host section wraps every lane, so it is expanded either way.
+  const hostKeys =
+    owningGroup && options?.defaultHostId
+      ? [`host:${getFolderWorkspaceHostId(folderWorkspace, owningGroup, options.defaultHostId)}`]
+      : []
+  // Why the either/or: under the default policy a pinned workspace renders ONLY
+  // in Pinned, so expanding its project group would persist an un-collapse of a
+  // section the row is not in. Mirrors getPinnedWorktreeRevealCollapsedGroupKeys.
+  if (folderWorkspace.isPinned && options?.pinnedDisplayPolicy !== 'duplicate-in-groups') {
+    return [PINNED_GROUP_KEY, ...hostKeys]
+  }
   const keys: string[] = []
   const seen = new Set<string>()
   let groupId: string | null = folderWorkspace.projectGroupId
@@ -85,14 +98,10 @@ export function getFolderWorkspaceRevealGroupKeys(
     keys.unshift(getProjectGroupHeaderKey(group.id))
     groupId = group.parentGroupId
   }
-  if (folderWorkspace.isPinned) {
-    keys.unshift(PINNED_GROUP_KEY)
-  }
 
   // Under non-repo grouping the project-group headers above do not exist, so the
   // lane and host headers are the ones actually hiding the row (#15362). Lane
   // keys come from the same function grouping uses, so the two cannot disagree.
-  const owningGroup = groupsById.get(folderWorkspace.projectGroupId)
   if (options?.groupBy && options.groupBy !== 'repo' && owningGroup) {
     keys.push(
       getFolderWorkspaceLaneKey(
@@ -102,10 +111,6 @@ export function getFolderWorkspaceRevealGroupKeys(
       )
     )
   }
-  if (owningGroup && options?.defaultHostId) {
-    keys.push(
-      `host:${getFolderWorkspaceHostId(folderWorkspace, owningGroup, options.defaultHostId)}`
-    )
-  }
+  keys.push(...hostKeys)
   return keys
 }

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.ts
@@ -3,7 +3,7 @@ import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { WorkspaceStatusDefinition, Worktree } from '../../../../../../shared/worktree/types'
 import { folderWorkspaceToWorktree } from '../../../../../../shared/folder-workspace-worktree'
 import { parseWorkspaceKey } from '../../../../../../shared/workspace-scope'
-import { getProjectGroupHeaderKey } from '../grouping/group-keys'
+import { PINNED_GROUP_KEY, getProjectGroupHeaderKey } from '../grouping/group-keys'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import { getFolderWorkspaceLaneKey } from '../grouping/folder-workspace-lanes'
 import type { WorktreeGroupBy } from '../grouping/row-types'
@@ -84,6 +84,9 @@ export function getFolderWorkspaceRevealGroupKeys(
     }
     keys.unshift(getProjectGroupHeaderKey(group.id))
     groupId = group.parentGroupId
+  }
+  if (folderWorkspace.isPinned) {
+    keys.unshift(PINNED_GROUP_KEY)
   }
 
   // Under non-repo grouping the project-group headers above do not exist, so the

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/pending-reveal-inputs.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/pending-reveal-inputs.ts
@@ -64,7 +64,8 @@ export function expandGroupsForWorktreeReveal(
     {
       groupBy: args.groupBy,
       workspaceStatuses: args.workspaceStatuses,
-      defaultHostId: args.defaultHostId
+      defaultHostId: args.defaultHostId,
+      pinnedDisplayPolicy: args.pinnedDisplayPolicy
     }
   )
   if (folderGroupKeys.length > 0) {

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.folder-workspace.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.folder-workspace.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it } from 'vitest'
 import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import { PINNED_GROUP_KEY, getProjectGroupHeaderKey } from '../grouping/group-keys'
+import { buildFolderWorkspaceRow } from '../grouping/row-builders'
 import type { RenderRow } from '../listing/render-row'
-import { findPreferredRenderRowIndexForWorktreeIdentity } from './render-row-lookup'
+import {
+  findPreferredRenderRowIndexForWorktree,
+  findPreferredRenderRowIndexForWorktreeIdentity
+} from './render-row-lookup'
 
 const FOLDER_WORKSPACE: FolderWorkspace = {
   id: 'fw-1',
@@ -34,25 +39,23 @@ const PROJECT_GROUP: ProjectGroup = {
   updatedAt: 1
 }
 
+const GROUP_SECTION_KEY = getProjectGroupHeaderKey(PROJECT_GROUP.id)
+const WORKSPACE_ID = folderWorkspaceKey(FOLDER_WORKSPACE.id)
+
+// Built through the real emitter's constructor so these fixtures cannot drift
+// from the section-qualified keys buildRows actually produces.
+function folderRow(sectionKey: string, folderWorkspace = FOLDER_WORKSPACE): RenderRow {
+  return buildFolderWorkspaceRow({ folderWorkspace, projectGroup: PROJECT_GROUP }, sectionKey, 0)
+}
+
 describe('host-qualified reveal lookup finds folder workspaces', () => {
   it('returns the folder row index instead of -1', () => {
     // Reveal requests for the current workspace carry executionHostId, which
     // routes here. A walker that only knows item rows returned -1 and the
     // reveal silently never completed (#15362).
-    const rows: RenderRow[] = [
-      {
-        type: 'folder-workspace',
-        key: `folder-workspace:${FOLDER_WORKSPACE.id}`,
-        folderWorkspace: FOLDER_WORKSPACE,
-        projectGroup: PROJECT_GROUP,
-        depth: 0,
-        groupDepth: 0
-      } as RenderRow
-    ]
-
     const index = findPreferredRenderRowIndexForWorktreeIdentity(
-      rows,
-      { id: folderWorkspaceKey(FOLDER_WORKSPACE.id), hostId: undefined },
+      [folderRow(GROUP_SECTION_KEY)],
+      { id: WORKSPACE_ID, hostId: undefined },
       'single-location'
     )
 
@@ -60,53 +63,59 @@ describe('host-qualified reveal lookup finds folder workspaces', () => {
   })
 
   it('does not match a different folder workspace', () => {
-    const rows: RenderRow[] = [
-      {
-        type: 'folder-workspace',
-        key: 'folder-workspace:other',
-        folderWorkspace: { ...FOLDER_WORKSPACE, id: 'other' },
-        projectGroup: PROJECT_GROUP,
-        depth: 0,
-        groupDepth: 0
-      } as RenderRow
-    ]
+    const rows = [folderRow(GROUP_SECTION_KEY, { ...FOLDER_WORKSPACE, id: 'other' })]
 
     expect(
       findPreferredRenderRowIndexForWorktreeIdentity(
         rows,
-        { id: folderWorkspaceKey(FOLDER_WORKSPACE.id), hostId: undefined },
+        { id: WORKSPACE_ID, hostId: undefined },
         'single-location'
       )
     ).toBe(-1)
   })
 
-  it('prefers the natural copy over the pinned duplicate', () => {
-    const rows: RenderRow[] = [
-      {
-        type: 'folder-workspace',
-        key: `pinned:folder-workspace:${FOLDER_WORKSPACE.id}`,
-        folderWorkspace: { ...FOLDER_WORKSPACE, isPinned: true },
-        projectGroup: PROJECT_GROUP,
-        depth: 0,
-        groupDepth: 0,
-        sectionKey: 'pinned'
-      } as RenderRow,
-      {
-        type: 'folder-workspace',
-        key: `folder-workspace:${FOLDER_WORKSPACE.id}`,
-        folderWorkspace: { ...FOLDER_WORKSPACE, isPinned: true },
-        projectGroup: PROJECT_GROUP,
-        depth: 0,
-        groupDepth: 0
-      } as RenderRow
-    ]
-
+  it('still lands on the Pinned copy when it is the only one rendered', () => {
+    // single-location moves the card into Pinned, so Pinned is not a duplicate
+    // there and must remain revealable.
     expect(
       findPreferredRenderRowIndexForWorktreeIdentity(
-        rows,
-        { id: folderWorkspaceKey(FOLDER_WORKSPACE.id), hostId: undefined },
+        [folderRow(PINNED_GROUP_KEY, { ...FOLDER_WORKSPACE, isPinned: true })],
+        { id: WORKSPACE_ID, hostId: undefined },
+        'single-location'
+      )
+    ).toBe(0)
+  })
+})
+
+describe('pinned folder workspace duplicates resolve to one preferred row', () => {
+  const pinned: FolderWorkspace = { ...FOLDER_WORKSPACE, isPinned: true }
+  const duplicatedRows = [folderRow(PINNED_GROUP_KEY, pinned), folderRow(GROUP_SECTION_KEY, pinned)]
+
+  it('prefers the natural copy over the pinned duplicate by identity', () => {
+    expect(
+      findPreferredRenderRowIndexForWorktreeIdentity(
+        duplicatedRows,
+        { id: WORKSPACE_ID, hostId: undefined },
         'duplicate-in-groups'
       )
     ).toBe(1)
+  })
+
+  it('prefers the natural copy over the pinned duplicate by id', () => {
+    // Why both walkers: hostless reveals route through the by-id one, and it
+    // knew nothing about folder rows having two copies.
+    expect(
+      findPreferredRenderRowIndexForWorktree(duplicatedRows, WORKSPACE_ID, 'duplicate-in-groups')
+    ).toBe(1)
+  })
+
+  it('falls back to the pinned copy when the natural copy is collapsed away', () => {
+    expect(
+      findPreferredRenderRowIndexForWorktree(
+        [folderRow(PINNED_GROUP_KEY, pinned)],
+        WORKSPACE_ID,
+        'duplicate-in-groups'
+      )
+    ).toBe(0)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.folder-workspace.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.folder-workspace.test.ts
@@ -79,4 +79,34 @@ describe('host-qualified reveal lookup finds folder workspaces', () => {
       )
     ).toBe(-1)
   })
+
+  it('prefers the natural copy over the pinned duplicate', () => {
+    const rows: RenderRow[] = [
+      {
+        type: 'folder-workspace',
+        key: `pinned:folder-workspace:${FOLDER_WORKSPACE.id}`,
+        folderWorkspace: { ...FOLDER_WORKSPACE, isPinned: true },
+        projectGroup: PROJECT_GROUP,
+        depth: 0,
+        groupDepth: 0,
+        sectionKey: 'pinned'
+      } as RenderRow,
+      {
+        type: 'folder-workspace',
+        key: `folder-workspace:${FOLDER_WORKSPACE.id}`,
+        folderWorkspace: { ...FOLDER_WORKSPACE, isPinned: true },
+        projectGroup: PROJECT_GROUP,
+        depth: 0,
+        groupDepth: 0
+      } as RenderRow
+    ]
+
+    expect(
+      findPreferredRenderRowIndexForWorktreeIdentity(
+        rows,
+        { id: folderWorkspaceKey(FOLDER_WORKSPACE.id), hostId: undefined },
+        'duplicate-in-groups'
+      )
+    ).toBe(1)
+  })
 })

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.ts
@@ -16,7 +16,7 @@ export function getRenderRowSidebarKey(row: RenderRow): string | null {
     return row.rowKey
   }
   if (row.type === 'folder-workspace') {
-    return folderWorkspaceKey(row.folderWorkspace.id)
+    return row.key
   }
   if (row.type === 'pending-creation') {
     return `pending:${row.creationId}`
@@ -78,7 +78,22 @@ export function getRenderRowWorktreeItem(
   return row.type === 'item' && itemMatchesWorktree(row, worktreeId, executionHostId) ? row : null
 }
 
-// Prefer the worktree's natural group row over its pinned duplicate when both are rendered.
+/** Whether this row is the Pinned-section copy of the workspace it renders.
+ *  Rows that do not render the workspace at all count as pinned so they are
+ *  never preferred over a real natural-group copy. */
+export function isPinnedSectionRenderRow(
+  row: RenderRow,
+  worktreeId: string,
+  executionHostId?: ExecutionHostId
+): boolean {
+  if (row.type === 'folder-workspace') {
+    return row.sectionKey === PINNED_GROUP_KEY
+  }
+  const itemRow = getRenderRowWorktreeItem(row, worktreeId, executionHostId)
+  return itemRow === null || isPinnedWorktreeRow(itemRow)
+}
+
+// Prefer the workspace's natural group row over its pinned duplicate when both are rendered.
 export function findPreferredRenderRowIndexForWorktree(
   renderRows: readonly RenderRow[],
   worktreeId: string,
@@ -93,14 +108,9 @@ export function findPreferredRenderRowIndexForWorktree(
     if (fallbackIndex === -1) {
       fallbackIndex = index
     }
-    const itemRow = getRenderRowWorktreeItem(row, worktreeId)
-    if (pinnedDisplayPolicy === 'duplicate-in-groups' && itemRow && !isPinnedWorktreeRow(itemRow)) {
-      return index
-    }
     if (
       pinnedDisplayPolicy === 'duplicate-in-groups' &&
-      row.type === 'folder-workspace' &&
-      row.sectionKey !== PINNED_GROUP_KEY
+      !isPinnedSectionRenderRow(row, worktreeId)
     ) {
       return index
     }
@@ -126,7 +136,7 @@ export function findPreferredRenderRowIndexForWorktreeIdentity(
       if (fallbackIndex === -1) {
         fallbackIndex = index
       }
-      if (pinnedDisplayPolicy !== 'duplicate-in-groups' || row.sectionKey !== PINNED_GROUP_KEY) {
+      if (!isPinnedSectionRenderRow(row, worktree.id)) {
         return index
       }
       continue

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.ts
@@ -4,6 +4,7 @@ import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import type { Worktree } from '../../../../../../shared/worktree/types'
 import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import type { RenderRow } from '../listing/render-row'
+import { PINNED_GROUP_KEY } from '../grouping/group-keys'
 import type { PinnedWorktreeDisplayPolicy } from '../grouping/row-types'
 import { isPinnedWorktreeRow, type WorktreeItemRow } from '../listing/renderable-rows'
 
@@ -96,6 +97,13 @@ export function findPreferredRenderRowIndexForWorktree(
     if (pinnedDisplayPolicy === 'duplicate-in-groups' && itemRow && !isPinnedWorktreeRow(itemRow)) {
       return index
     }
+    if (
+      pinnedDisplayPolicy === 'duplicate-in-groups' &&
+      row.type === 'folder-workspace' &&
+      row.sectionKey !== PINNED_GROUP_KEY
+    ) {
+      return index
+    }
   }
   return fallbackIndex
 }
@@ -112,7 +120,13 @@ export function findPreferredRenderRowIndexForWorktreeIdentity(
     // Why: host-qualified reveals are emitted for folder workspaces too, and a
     // walker that only knows item rows returns -1 so the reveal never lands.
     if (row.type === 'folder-workspace') {
-      if (folderWorkspaceKey(row.folderWorkspace.id) === worktree.id) {
+      if (folderWorkspaceKey(row.folderWorkspace.id) !== worktree.id) {
+        continue
+      }
+      if (fallbackIndex === -1) {
+        fallbackIndex = index
+      }
+      if (pinnedDisplayPolicy !== 'duplicate-in-groups' || row.sectionKey !== PINNED_GROUP_KEY) {
         return index
       }
       continue

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-active-row.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-active-row.ts
@@ -4,7 +4,33 @@ import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import { composeWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import type { HostSectionRow } from '../../host-section-rows'
 import type { PinnedWorktreeDisplayPolicy } from '../grouping/row-types'
-import { isPinnedWorktreeRow, type WorktreeItemRow } from '../listing/renderable-rows'
+import { folderWorkspaceToWorktree } from '../../../../../../shared/folder-workspace-worktree'
+import { PINNED_GROUP_KEY } from '../grouping/group-keys'
+
+/** The identity a row contributes to the active surface. Folder workspaces
+ *  duplicate into Pinned exactly like worktrees, so both kinds resolve here. */
+function getActiveSurfaceRowRef(
+  row: HostSectionRow
+): { rowKey: string; sectionKey: string; worktreeId: string; worktreeIdentity: string } | null {
+  if (row.type === 'item') {
+    return {
+      rowKey: row.rowKey,
+      sectionKey: row.sectionKey,
+      worktreeId: row.worktree.id,
+      worktreeIdentity: composeWorktreeHostIdentity(row.worktree.hostId, row.worktree.id)
+    }
+  }
+  if (row.type === 'folder-workspace') {
+    const worktree = folderWorkspaceToWorktree(row.folderWorkspace)
+    return {
+      rowKey: row.key,
+      sectionKey: row.sectionKey,
+      worktreeId: worktree.id,
+      worktreeIdentity: composeWorktreeHostIdentity(worktree.hostId, worktree.id)
+    }
+  }
+  return null
+}
 
 // A worktree can render in more than one section; the row the user actually clicked owns
 // the primary active surface so its duplicates stay visually secondary.
@@ -43,27 +69,27 @@ export function usePrimaryActiveWorktreeRow(args: {
       if (current === null || current.worktreeIdentity !== activeIdentity) {
         return null
       }
-      const rowStillVisible = rows.some(
-        (row) =>
-          row.type === 'item' &&
-          composeWorktreeHostIdentity(row.worktree.hostId, row.worktree.id) ===
-            current.worktreeIdentity &&
-          row.rowKey === current.rowKey
-      )
+      const rowStillVisible = rows.some((row) => {
+        const ref = getActiveSurfaceRowRef(row)
+        return ref?.worktreeIdentity === current.worktreeIdentity && ref.rowKey === current.rowKey
+      })
       return rowStillVisible ? current : null
     })
   }, [activeIdentity, activeWorktreeId, rows])
 
   const getActiveSurfaceVariant = useCallback(
-    (row: WorktreeItemRow): ActiveSurfaceVariant => {
-      const rowIdentity = composeWorktreeHostIdentity(row.worktree.hostId, row.worktree.id)
-      if (primaryActiveWorktreeRow?.worktreeIdentity === rowIdentity) {
-        return primaryActiveWorktreeRow.rowKey === row.rowKey ? 'primary' : 'secondary'
+    (row: HostSectionRow): ActiveSurfaceVariant => {
+      const ref = getActiveSurfaceRowRef(row)
+      if (!ref) {
+        return 'primary'
+      }
+      if (primaryActiveWorktreeRow?.worktreeIdentity === ref.worktreeIdentity) {
+        return primaryActiveWorktreeRow.rowKey === ref.rowKey ? 'primary' : 'secondary'
       }
       if (
         pinnedDisplayPolicy === 'duplicate-in-groups' &&
-        activeWorktreeId === row.worktree.id &&
-        isPinnedWorktreeRow(row)
+        activeWorktreeId === ref.worktreeId &&
+        ref.sectionKey === PINNED_GROUP_KEY
       ) {
         return 'secondary'
       }
@@ -74,19 +100,11 @@ export function usePrimaryActiveWorktreeRow(args: {
 
   const handleImmediateWorktreeRowActivate = useCallback(
     (worktreeId: string, rowKey: string | undefined): void => {
-      const row = rowsRef.current.find(
-        (candidate) =>
-          candidate.type === 'item' &&
-          candidate.worktree.id === worktreeId &&
-          candidate.rowKey === rowKey
-      )
+      const ref = rowsRef.current
+        .map(getActiveSurfaceRowRef)
+        .find((candidate) => candidate?.worktreeId === worktreeId && candidate.rowKey === rowKey)
       setPrimaryActiveWorktreeRow(
-        rowKey && row?.type === 'item'
-          ? {
-              worktreeIdentity: composeWorktreeHostIdentity(row.worktree.hostId, worktreeId),
-              rowKey
-            }
-          : null
+        rowKey && ref ? { worktreeIdentity: ref.worktreeIdentity, rowKey } : null
       )
       onImmediateWorktreeActivate(worktreeId, rowKey)
     },

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-active-row.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-active-row.ts
@@ -100,9 +100,18 @@ export function usePrimaryActiveWorktreeRow(args: {
 
   const handleImmediateWorktreeRowActivate = useCallback(
     (worktreeId: string, rowKey: string | undefined): void => {
-      const ref = rowsRef.current
-        .map(getActiveSurfaceRowRef)
-        .find((candidate) => candidate?.worktreeId === worktreeId && candidate.rowKey === rowKey)
+      // Why the loop and not map().find(): this runs on every sidebar card
+      // click, where the codebase already hand-optimizes to keep the pointer
+      // path free of avoidable work. Short-circuit instead of resolving a ref
+      // for every row.
+      let ref: ReturnType<typeof getActiveSurfaceRowRef> = null
+      for (const row of rowsRef.current) {
+        const candidate = getActiveSurfaceRowRef(row)
+        if (candidate?.worktreeId === worktreeId && candidate.rowKey === rowKey) {
+          ref = candidate
+          break
+        }
+      }
       setPrimaryActiveWorktreeRow(
         rowKey && ref ? { worktreeIdentity: ref.worktreeIdentity, rowKey } : null
       )

--- a/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
@@ -60,7 +60,6 @@ export function renderFolderWorkspaceVirtualRow(args: {
   const { ctx, row, vItem } = args
   const folderWorktree = folderWorkspaceToWorktree(row.folderWorkspace)
   const folderWorktreeIdentity = getWorktreeHostIdentity(folderWorktree)
-  const optionRowKey = row.sectionKey ? row.key : folderWorktree.id
   const pathStatus = ctx.getCachedFolderWorkspacePathStatus({
     scope: 'folder-workspace',
     folderWorkspaceId: row.folderWorkspace.id
@@ -89,13 +88,13 @@ export function renderFolderWorkspaceVirtualRow(args: {
   return (
     <div
       key={vItem.key}
-      id={getWorktreeOptionId(optionRowKey)}
+      id={getWorktreeOptionId(row.key)}
       role="option"
       aria-selected={ctx.selectedWorktreeIds.has(folderWorktreeIdentity)}
       aria-current={ctx.activeWorktreeId === folderWorktree.id ? 'page' : undefined}
       data-worktree-id={folderWorktree.id}
       data-worktree-host-identity={folderWorktreeIdentity}
-      data-worktree-row-key={optionRowKey}
+      data-worktree-row-key={row.key}
       data-worktree-virtual-row
       data-worktree-virtual-row-key={String(vItem.key)}
       data-worktree-virtual-row-start={vItem.start}
@@ -104,7 +103,7 @@ export function renderFolderWorkspaceVirtualRow(args: {
       className="absolute left-0 right-0 top-0"
       style={{ transform: getVirtualRowTransform(vItem.start) }}
       onClickCapture={ctx.onRowClickCapture}
-      onPointerDown={(event) => ctx.onRowPointerDown(event, folderWorktree, optionRowKey)}
+      onPointerDown={(event) => ctx.onRowPointerDown(event, folderWorktree, row.key)}
     >
       <div
         className="relative"
@@ -119,7 +118,7 @@ export function renderFolderWorkspaceVirtualRow(args: {
           flushSurface
           nativeDragEnabled={false}
           onImmediateActivate={activationDisabled ? undefined : ctx.onImmediateActivate}
-          activationRowKey={optionRowKey}
+          activationRowKey={row.key}
           onSelectionGesture={(event) => ctx.onSelectionGesture(event, folderWorktree)}
           onContextMenuSelect={ctx.onContextMenuSelect}
           statusPrDisplay={folderPrDisplay}

--- a/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
@@ -60,6 +60,7 @@ export function renderFolderWorkspaceVirtualRow(args: {
   const { ctx, row, vItem } = args
   const folderWorktree = folderWorkspaceToWorktree(row.folderWorkspace)
   const folderWorktreeIdentity = getWorktreeHostIdentity(folderWorktree)
+  const optionRowKey = row.sectionKey ? row.key : folderWorktree.id
   const pathStatus = ctx.getCachedFolderWorkspacePathStatus({
     scope: 'folder-workspace',
     folderWorkspaceId: row.folderWorkspace.id
@@ -88,13 +89,13 @@ export function renderFolderWorkspaceVirtualRow(args: {
   return (
     <div
       key={vItem.key}
-      id={getWorktreeOptionId(folderWorktree.id)}
+      id={getWorktreeOptionId(optionRowKey)}
       role="option"
       aria-selected={ctx.selectedWorktreeIds.has(folderWorktreeIdentity)}
       aria-current={ctx.activeWorktreeId === folderWorktree.id ? 'page' : undefined}
       data-worktree-id={folderWorktree.id}
       data-worktree-host-identity={folderWorktreeIdentity}
-      data-worktree-row-key={folderWorktree.id}
+      data-worktree-row-key={optionRowKey}
       data-worktree-virtual-row
       data-worktree-virtual-row-key={String(vItem.key)}
       data-worktree-virtual-row-start={vItem.start}
@@ -103,7 +104,7 @@ export function renderFolderWorkspaceVirtualRow(args: {
       className="absolute left-0 right-0 top-0"
       style={{ transform: getVirtualRowTransform(vItem.start) }}
       onClickCapture={ctx.onRowClickCapture}
-      onPointerDown={(event) => ctx.onRowPointerDown(event, folderWorktree, folderWorktree.id)}
+      onPointerDown={(event) => ctx.onRowPointerDown(event, folderWorktree, optionRowKey)}
     >
       <div
         className="relative"
@@ -118,7 +119,7 @@ export function renderFolderWorkspaceVirtualRow(args: {
           flushSurface
           nativeDragEnabled={false}
           onImmediateActivate={activationDisabled ? undefined : ctx.onImmediateActivate}
-          activationRowKey={folderWorktree.id}
+          activationRowKey={optionRowKey}
           onSelectionGesture={(event) => ctx.onSelectionGesture(event, folderWorktree)}
           onContextMenuSelect={ctx.onContextMenuSelect}
           statusPrDisplay={folderPrDisplay}

--- a/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
@@ -17,6 +17,8 @@ import { getVirtualRowTransform } from '../viewport/virtual-rows'
 import { getFolderWorkspaceRowGeometry } from './indentation'
 import { getFolderWorkspaceCardPrDisplay } from '../../folder-workspace-card-pr-display'
 import { FolderPathStatusIndicator } from './FolderPathStatusIndicator'
+import type { ActiveSurfaceVariant } from '../../WorktreeCard'
+import type { HostSectionRow } from '../../host-section-rows'
 import type { FolderWorkspaceItemRow } from '../listing/renderable-rows'
 import { getWorktreeOptionId } from './option-dom'
 
@@ -37,6 +39,7 @@ export type FolderWorkspaceRowContext = {
     scope: 'folder-workspace'
     folderWorkspaceId: string
   }) => FolderWorkspacePathStatus | null
+  getActiveSurfaceVariant: (row: HostSectionRow) => ActiveSurfaceVariant
   onSelectionGesture: (event: React.MouseEvent<HTMLElement>, worktree: Worktree) => boolean
   onContextMenuSelect: (
     event: React.MouseEvent<HTMLElement>,
@@ -60,6 +63,7 @@ export function renderFolderWorkspaceVirtualRow(args: {
   const { ctx, row, vItem } = args
   const folderWorktree = folderWorkspaceToWorktree(row.folderWorkspace)
   const folderWorktreeIdentity = getWorktreeHostIdentity(folderWorktree)
+  const isActive = ctx.activeWorktreeId === folderWorktree.id
   const pathStatus = ctx.getCachedFolderWorkspacePathStatus({
     scope: 'folder-workspace',
     folderWorkspaceId: row.folderWorkspace.id
@@ -91,7 +95,7 @@ export function renderFolderWorkspaceVirtualRow(args: {
       id={getWorktreeOptionId(row.key)}
       role="option"
       aria-selected={ctx.selectedWorktreeIds.has(folderWorktreeIdentity)}
-      aria-current={ctx.activeWorktreeId === folderWorktree.id ? 'page' : undefined}
+      aria-current={isActive ? 'page' : undefined}
       data-worktree-id={folderWorktree.id}
       data-worktree-host-identity={folderWorktreeIdentity}
       data-worktree-row-key={row.key}
@@ -112,8 +116,11 @@ export function renderFolderWorkspaceVirtualRow(args: {
         <WorktreeCard
           worktree={folderWorktree}
           repo={undefined}
-          isActive={ctx.activeWorktreeId === folderWorktree.id}
+          isActive={isActive}
           isCurrentWorktree={ctx.currentWorktreeId === folderWorktree.id}
+          // Why: the Pinned copy and the group copy are both "active"; only the
+          // one the user activated should draw the primary surface.
+          activeSurfaceVariant={isActive ? ctx.getActiveSurfaceVariant(row) : 'primary'}
           contentIndent={cardContentIndent}
           flushSurface
           nativeDragEnabled={false}

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
@@ -149,6 +149,7 @@ export function buildWorktreeVirtualRowContext(args: BuildArgs): WorktreeVirtual
       prCache: props.prCache,
       hostedReviewCache: props.hostedReviewCache,
       getCachedFolderWorkspacePathStatus: args.getCachedFolderWorkspacePathStatus,
+      getActiveSurfaceVariant: primaryActive.getActiveSurfaceVariant,
       onSelectionGesture: props.onSelectionGesture,
       onContextMenuSelect: props.onContextMenuSelect,
       onImmediateActivate: primaryActive.handleImmediateWorktreeRowActivate,

--- a/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.test.ts
@@ -4,6 +4,8 @@ import type { ProjectGroup } from '../../../../shared/project-group-types'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import type { HostSectionRow } from './host-section-rows'
+import { PINNED_GROUP_KEY, getProjectGroupHeaderKey } from './worktree-list/grouping/group-keys'
+import { buildFolderWorkspaceRow } from './worktree-list/grouping/row-builders'
 import { getRenderedWorktreesInSidebarOrder } from './worktree-sidebar-row-preference'
 
 const repo: Repo = {
@@ -80,20 +82,17 @@ const folderWorkspace: FolderWorkspace = {
   updatedAt: 1
 }
 
+function folderRow(sectionKey: string, workspace = folderWorkspace): HostSectionRow {
+  return buildFolderWorkspaceRow({ folderWorkspace: workspace, projectGroup }, sectionKey, 0)
+}
+
 describe('getRenderedWorktreesInSidebarOrder', () => {
   it('keeps folder workspaces in visual order while preferring natural pinned rows', () => {
     const pinned = worktree('pinned', true)
     const afterFolder = worktree('after-folder')
     const rows: HostSectionRow[] = [
       item(pinned, 'pinned'),
-      {
-        type: 'folder-workspace',
-        key: 'folder-workspace:folder-1',
-        folderWorkspace,
-        projectGroup,
-        depth: 0,
-        groupDepth: 0
-      },
+      folderRow(getProjectGroupHeaderKey(projectGroup.id)),
       item(pinned, 'repo:repo-1'),
       item(afterFolder, 'repo:repo-1')
     ]
@@ -101,5 +100,30 @@ describe('getRenderedWorktreesInSidebarOrder', () => {
     expect(
       getRenderedWorktreesInSidebarOrder(rows, 'duplicate-in-groups').map(({ id }) => id)
     ).toEqual(['folder:folder-1', 'pinned', 'after-folder'])
+  })
+
+  it('counts a duplicated pinned folder workspace once, at its natural position', () => {
+    // Why: the Pinned copy and the group copy are one workspace to selection and
+    // Cmd+Shift+Arrow. Counting both would put the same card in the order twice.
+    const pinnedFolder = { ...folderWorkspace, isPinned: true }
+    const rows: HostSectionRow[] = [
+      folderRow(PINNED_GROUP_KEY, pinnedFolder),
+      item(worktree('after-pinned'), 'repo:repo-1'),
+      folderRow(getProjectGroupHeaderKey(projectGroup.id), pinnedFolder)
+    ]
+
+    expect(
+      getRenderedWorktreesInSidebarOrder(rows, 'duplicate-in-groups').map(({ id }) => id)
+    ).toEqual(['after-pinned', 'folder:folder-1'])
+  })
+
+  it('keeps the pinned folder workspace when it is its only rendered copy', () => {
+    const rows: HostSectionRow[] = [
+      folderRow(PINNED_GROUP_KEY, { ...folderWorkspace, isPinned: true })
+    ]
+
+    expect(getRenderedWorktreesInSidebarOrder(rows, 'single-location').map(({ id }) => id)).toEqual(
+      ['folder:folder-1']
+    )
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.ts
@@ -3,82 +3,72 @@ import type { Worktree } from '../../../../shared/worktree/types'
 import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
 import type { HostSectionRow } from './host-section-rows'
 import { PINNED_GROUP_KEY } from './worktree-list/grouping/group-keys'
+import type { FolderWorkspaceItemRow } from './worktree-list/listing/renderable-rows'
 import type { PinnedWorktreeDisplayPolicy, WorktreeRow } from './worktree-list/grouping/row-types'
+
+/**
+ * One row per workspace, out of the copies the sidebar rendered.
+ *
+ * Why: a duplicated pinned row is the same workspace to navigation and
+ * selection. Prefer its natural-group copy, falling back to the Pinned copy
+ * when that is the only one rendered.
+ */
+function getPreferredRows<Row>(
+  rows: readonly Row[],
+  getIdentity: (row: Row) => string,
+  isPinnedSectionRow: (row: Row) => boolean
+): Row[] {
+  const preferredRows: Row[] = []
+  const seen = new Set<string>()
+  const take = (row: Row): void => {
+    preferredRows.push(row)
+    seen.add(getIdentity(row))
+  }
+  for (const row of rows) {
+    if (!isPinnedSectionRow(row) && !seen.has(getIdentity(row))) {
+      take(row)
+    }
+  }
+  for (const row of rows) {
+    if (!seen.has(getIdentity(row))) {
+      take(row)
+    }
+  }
+  return preferredRows
+}
 
 export function getPreferredWorktreeRows(
   rows: readonly WorktreeRow[],
   pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
 ): WorktreeRow[] {
-  // Why: duplicated pinned rows represent one workspace to navigation and selection.
-  // Prefer its natural-group copy, falling back to Pinned when that copy is hidden.
-  if (pinnedDisplayPolicy === 'single-location') {
-    const seen = new Set<string>()
-    return rows.filter((row) => {
-      const identity = getWorktreeHostIdentity(row.worktree)
-      if (seen.has(identity)) {
-        return false
-      }
-      seen.add(identity)
-      return true
-    })
-  }
-
-  const preferredRows: WorktreeRow[] = []
-  const seen = new Set<string>()
-  for (const row of rows) {
-    const identity = getWorktreeHostIdentity(row.worktree)
-    if (row.sectionKey === PINNED_GROUP_KEY || seen.has(identity)) {
-      continue
-    }
-    preferredRows.push(row)
-    seen.add(identity)
-  }
-  for (const row of rows) {
-    const identity = getWorktreeHostIdentity(row.worktree)
-    if (seen.has(identity)) {
-      continue
-    }
-    preferredRows.push(row)
-    seen.add(identity)
-  }
-  return preferredRows
+  return getPreferredRows(
+    rows,
+    (row) => getWorktreeHostIdentity(row.worktree),
+    (row) => pinnedDisplayPolicy === 'duplicate-in-groups' && row.sectionKey === PINNED_GROUP_KEY
+  )
 }
 
 export function getRenderedWorktreesInSidebarOrder(
   rows: readonly HostSectionRow[],
   pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
 ): Worktree[] {
-  const itemRows = rows.filter((row): row is WorktreeRow => row.type === 'item')
-  const preferredRowKeys = new Set(
-    getPreferredWorktreeRows(itemRows, pinnedDisplayPolicy).map((row) => row.rowKey)
-  )
-  const renderedWorktrees: Worktree[] = []
-  const seenFolderIds = new Set<string>()
-  const naturalFolderIds = new Set(
-    rows
-      .filter(
-        (row): row is Extract<HostSectionRow, { type: 'folder-workspace' }> =>
-          row.type === 'folder-workspace' && row.sectionKey !== PINNED_GROUP_KEY
-      )
-      .map((row) => row.folderWorkspace.id)
-  )
+  const preferredRowKeys = new Set([
+    ...getPreferredWorktreeRows(
+      rows.filter((row): row is WorktreeRow => row.type === 'item'),
+      pinnedDisplayPolicy
+    ).map((row) => row.rowKey),
+    ...getPreferredRows(
+      rows.filter((row): row is FolderWorkspaceItemRow => row.type === 'folder-workspace'),
+      (row) => row.folderWorkspace.id,
+      (row) => pinnedDisplayPolicy === 'duplicate-in-groups' && row.sectionKey === PINNED_GROUP_KEY
+    ).map((row) => row.key)
+  ])
 
+  const renderedWorktrees: Worktree[] = []
   for (const row of rows) {
     if (row.type === 'item' && preferredRowKeys.has(row.rowKey)) {
       renderedWorktrees.push(row.worktree)
-    } else if (row.type === 'folder-workspace') {
-      const folderId = row.folderWorkspace.id
-      if (seenFolderIds.has(folderId)) {
-        continue
-      }
-      if (
-        pinnedDisplayPolicy === 'duplicate-in-groups' &&
-        row.sectionKey === PINNED_GROUP_KEY &&
-        naturalFolderIds.has(folderId)
-      ) {
-        continue
-      }
-      seenFolderIds.add(folderId)
+    } else if (row.type === 'folder-workspace' && preferredRowKeys.has(row.key)) {
       renderedWorktrees.push(folderWorkspaceToWorktree(row.folderWorkspace))
     }
   }

--- a/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.ts
@@ -53,11 +53,32 @@ export function getRenderedWorktreesInSidebarOrder(
     getPreferredWorktreeRows(itemRows, pinnedDisplayPolicy).map((row) => row.rowKey)
   )
   const renderedWorktrees: Worktree[] = []
+  const seenFolderIds = new Set<string>()
+  const naturalFolderIds = new Set(
+    rows
+      .filter(
+        (row): row is Extract<HostSectionRow, { type: 'folder-workspace' }> =>
+          row.type === 'folder-workspace' && row.sectionKey !== PINNED_GROUP_KEY
+      )
+      .map((row) => row.folderWorkspace.id)
+  )
 
   for (const row of rows) {
     if (row.type === 'item' && preferredRowKeys.has(row.rowKey)) {
       renderedWorktrees.push(row.worktree)
     } else if (row.type === 'folder-workspace') {
+      const folderId = row.folderWorkspace.id
+      if (seenFolderIds.has(folderId)) {
+        continue
+      }
+      if (
+        pinnedDisplayPolicy === 'duplicate-in-groups' &&
+        row.sectionKey === PINNED_GROUP_KEY &&
+        naturalFolderIds.has(folderId)
+      ) {
+        continue
+      }
+      seenFolderIds.add(folderId)
       renderedWorktrees.push(folderWorkspaceToWorktree(row.folderWorkspace))
     }
   }

--- a/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.ts
@@ -13,14 +13,14 @@ import type { PinnedWorktreeDisplayPolicy, WorktreeRow } from './worktree-list/g
  * selection. Prefer its natural-group copy, falling back to the Pinned copy
  * when that is the only one rendered.
  */
-function getPreferredRows<Row>(
-  rows: readonly Row[],
-  getIdentity: (row: Row) => string,
-  isPinnedSectionRow: (row: Row) => boolean
-): Row[] {
-  const preferredRows: Row[] = []
+function getPreferredRows<TRow>(
+  rows: readonly TRow[],
+  getIdentity: (row: TRow) => string,
+  isPinnedSectionRow: (row: TRow) => boolean
+): TRow[] {
+  const preferredRows: TRow[] = []
   const seen = new Set<string>()
-  const take = (row: Row): void => {
+  const take = (row: TRow): void => {
     preferredRows.push(row)
     seen.add(getIdentity(row))
   }
@@ -52,23 +52,25 @@ export function getRenderedWorktreesInSidebarOrder(
   rows: readonly HostSectionRow[],
   pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
 ): Worktree[] {
-  const preferredRowKeys = new Set([
-    ...getPreferredWorktreeRows(
+  const preferredWorktreeRowKeys = new Set(
+    getPreferredWorktreeRows(
       rows.filter((row): row is WorktreeRow => row.type === 'item'),
       pinnedDisplayPolicy
-    ).map((row) => row.rowKey),
-    ...getPreferredRows(
+    ).map((row) => row.rowKey)
+  )
+  const preferredFolderRowKeys = new Set(
+    getPreferredRows(
       rows.filter((row): row is FolderWorkspaceItemRow => row.type === 'folder-workspace'),
       (row) => row.folderWorkspace.id,
       (row) => pinnedDisplayPolicy === 'duplicate-in-groups' && row.sectionKey === PINNED_GROUP_KEY
     ).map((row) => row.key)
-  ])
+  )
 
   const renderedWorktrees: Worktree[] = []
   for (const row of rows) {
-    if (row.type === 'item' && preferredRowKeys.has(row.rowKey)) {
+    if (row.type === 'item' && preferredWorktreeRowKeys.has(row.rowKey)) {
       renderedWorktrees.push(row.worktree)
-    } else if (row.type === 'folder-workspace' && preferredRowKeys.has(row.key)) {
+    } else if (row.type === 'folder-workspace' && preferredFolderRowKeys.has(row.key)) {
       renderedWorktrees.push(folderWorkspaceToWorktree(row.folderWorkspace))
     }
   }


### PR DESCRIPTION
## ELI5

Pinning a folder workspace now puts it in the left **Pinned** list, the same way pinning a git worktree already does.

## Visual Proof

Captured from the running Electron app over CDP. Same persisted `isPinned: true` state on both sides — only the code differs, so this is the fix and not a setup difference.

![pinned-folder-workspace-before-after.png](https://github.com/user-attachments/assets/a9bbd874-dbb2-44ef-b134-df3751616f40)

Also verified live, through the real UI rather than the store:

- **Pin** from the row's context menu moves the card into Pinned and out of its project group.
- `showPinnedWorktreesInGroups` renders both copies, with distinct DOM ids, and exactly **one** primary active surface; clicking the Pinned copy promotes it and demotes the group copy.
- Revealing from a fully collapsed sidebar expands Pinned and lands on the card.
- Shift-click range selection spans Pinned → project group and selects each workspace once.

## What Changed

`buildRows` already treated pin as *placement* for git worktrees. Folder workspaces had an `isPinned` flag, a Pin/Unpin menu item and persistence, but the Pinned emitter only accepted `Worktree[]`, so a pinned folder workspace stayed under its project group. Pin is now a placement choice on the same renderable folder-workspace set (#15362), partitioned right beside the existing worktree partition:

```ts
const pinnedFolderWorkspaces = renderableFolderWorkspaces.filter((pair) => pair.folderWorkspace.isPinned)
const naturalFolderWorkspaces =
  pinnedDisplayPolicy === 'duplicate-in-groups'
    ? renderableFolderWorkspaces
    : renderableFolderWorkspaces.filter((pair) => !pair.folderWorkspace.isPinned)
```

**`FolderWorkspaceRow` now carries a required `sectionKey`,** and derives `key` from it — exactly as `WorktreeRow` derives `rowKey`. Rendering the same workspace twice is only safe if the two copies are distinguishable everywhere, and previously they were not: the virtualizer key, the DOM option id, the reveal walkers and the sidebar-order preference each answered "which row is this?" differently. One key now flows through all of them, and the type makes a section-less folder row unrepresentable.

Falling out of that:

- Pinned header host counts use the same lane helper as the status/PR lanes, so a folder-only Pinned section still scopes to its SSH/runtime host.
- `emitPinnedGroup` took 15 positional parameters; it now takes one options object.
- The duplicate-preference rule (`prefer the natural copy, fall back to Pinned`) is written once and shared by worktree and folder rows.

### Review follow-ups

Reviewed against `/readiness-checklist`; each of these is a consequence of a folder workspace newly being able to render twice, found in review and fixed here:

- **Reveal over-expanded.** `expandGroupsForWorktreeReveal` persists every toggle it makes. Adding Pinned *on top of* the project-group chain permanently un-collapsed a section the card is not in. Now an either/or, mirroring `getPinnedWorktreeRevealCollapsedGroupKeys`.
- **Host badge double-counted** a duplicated folder workspace; item rows already deduped for this exact reason.
- **Both copies drew the primary active surface**, because the active-surface rule only understood item rows. Generalized to any row that can duplicate — which also gives folder rows the click-promotion worktrees already had.
- **`collectRenderedSidebarRowKeys`** still emitted the pre-change folder key, disagreeing with `getRenderRowSidebarKey`.
- `useEffectiveCollapsedGroups` held the pinned display policy but did not pass it down; the active-surface lookup resolved a ref for every row on the click path.

## Why

The menu already said Unpin, so the pin write was working — the card just never moved. Same class of gap as #15362: Pinned was another lane the git-worktree path owned and the folder-workspace path never joined.

## Testing

- [x] Manually tested in the running app (see Visual Proof)
- [x] Automated tests added

`build-rows.pinned-folder-workspaces.test.ts` was run against `main` first: 9 of 10 failed, with no Pinned header for a pinned folder workspace. New coverage for the review follow-ups: reveal either/or per policy, host-badge dedup, and option-id/aria-activedescendant identity for the duplicated row. Navigation fixtures build rows through `buildFolderWorkspaceRow` so they cannot drift from the real key shape.

`pnpm tc` clean; `pnpm test src/renderer` 26,506 passing; `pnpm run check:code-quality:changed` 0 new findings.

- macOS unit tests + live app. Linux/Windows: grouping is host-id keyed, no path or shortcut changes.
- SSH: host counts go through `getFolderWorkspaceHostId`, the same resolver the status/PR lanes use, so a pinned SSH folder workspace cannot leak into the local host section. The Pinned header's host map was verified identical to the previous local tally for the git-worktree-only case.

## Review

- **Cross-platform:** no path, shortcut or menu-accelerator changes.
- **Backward compatibility:** the row key changed shape, so I traced every persisted UI field. `collapsedGroups` stores *header* keys only; folder-workspace rows are never headers, so no saved state references the old key. No mobile or paired-web surface imports these modules — no wire impact.
- **Performance:** two extra O(F) partitions per `buildRows` (memoized, unchanged deps). Folder rows re-key once on upgrade, then only on grouping changes — the same behavior item rows have always had.
- **Security:** no IPC, filesystem or auth changes. The one new sink is a DOM id, already `encodeURIComponent`-wrapped and only ever read by `getElementById`.

## Known gaps (pre-existing, not introduced here)

Folder rows pass neither `renameRowKey` nor `revealHighlight`, so rename-on-reveal and the reveal glow do not fire for folder workspaces — identical on `main`. Folder workspaces still do not join Cmd+Shift+Arrow cycling (that walker is item-row-only). Both are out of scope.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm typecheck`, `pnpm test`, lint pass locally

## Authorship

Original fix and problem diagnosis by @lafraia (commit 1). Commits 2-4 are a takeover pass: the section-key rework, the readiness-checklist review, and its follow-up fixes.
