### PR TITLE
Fix Jira connector routing in Web UI

### DIFF
--- a/src/renderer/src/web/web-preload-api-jira.test.ts
+++ b/src/renderer/src/web/web-preload-api-jira.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import {
+  installBrowserGlobals,
+  writeStoredRuntimeEnvironment
+} from './web-preload-api-test-harness'
+
+describe('web Jira preload API', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.doUnmock('./web-runtime-client')
+  })
+
+  it('routes Jira connector calls through the paired runtime', async () => {
+    const runtimeCalls: { method: string; params: unknown }[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params })
+          return Promise.resolve({
+            id: `call-${runtimeCalls.length}`,
+            ok: true,
+            result:
+              method === 'jira.connect'
+                ? { ok: true, viewer: { accountId: 'viewer-1', displayName: 'Test User' } }
+                : { connected: false, viewer: null },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const credentials = {
+      siteUrl: 'https://jira.example.com',
+      email: 'user@example.com',
+      apiToken: 'token'
+    }
+    await expect(globals.window.api.jira.connect(credentials)).resolves.toMatchObject({ ok: true })
+    await expect(globals.window.api.jira.status()).resolves.toEqual({
+      connected: false,
+      viewer: null
+    })
+
+    expect(runtimeCalls).toEqual([
+      { method: 'jira.connect', params: credentials },
+      { method: 'jira.status', params: undefined }
+    ])
+  })
+})

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -88,6 +88,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
     gl: createGitLabApi(),
     hostedReview: createRuntimeNamespaceApi('hostedReview'),
     linear: createRuntimeNamespaceApi('linear'),
+    jira: createRuntimeNamespaceApi('jira'),
     hooks: createHooksApi(),
     stats: {
       getSummary: async () =>


### PR DESCRIPTION
### Summary

- expose the Jira runtime namespace from the Web preload API
- route Web UI Jira connector calls through runtime RPC, matching Linear and hosted review connectors
- add a regression test for `jira.connect` and `jira.status` routing

### Root cause

The Web preload omitted the Jira namespace, so its fallback returned `undefined` for `window.api.jira.connect()`. The Jira store then crashed while reading `result.ok`, and no request reached the runtime.

### Test plan

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/web/web-preload-api-jira.test.ts src/renderer/src/runtime/runtime-jira-client.test.ts src/renderer/src/store/slices/jira.test.ts src/main/runtime/rpc/methods/jira.test.ts src/main/jira/client.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/web/web-preload-api.ts src/renderer/src/web/web-preload-api-jira.test.ts --deny-warnings`
- manually verified Jira connection from a headless `orca serve` Web UI

Fixes #16802