### PR TITLE
fix(settings): show tooltip for truncated shortcut titles in shortcut…

### DIFF
--- a/src/renderer/src/components/settings/ShortcutCommandBlock.test.tsx
+++ b/src/renderer/src/components/settings/ShortcutCommandBlock.test.tsx
@@ -42,4 +42,36 @@ describe('ShortcutCommandBlock', () => {
     expect(helper.classList.contains('whitespace-normal')).toBe(true)
     expect(helper.classList.contains('truncate')).toBe(false)
   })
+
+  it('renders title with tooltip trigger for truncated names', () => {
+    const item = getKeybindingDefinition('worktree.history.back')
+    expect(item).not.toBeNull()
+
+    render(
+      <TooltipProvider>
+        <ShortcutCommandBlock
+          item={item!}
+          groupTitle="Navigation"
+          platform="darwin"
+          effective={['Ctrl+Alt+Left']}
+          modified={false}
+          warnings={[]}
+          previousBindings={[]}
+          recordingBindingIndex={null}
+          onStartRecordingAt={vi.fn()}
+          onAppendBinding={vi.fn()}
+          onCancelRecording={vi.fn()}
+          onCapture={vi.fn()}
+          onClearError={vi.fn()}
+          onRemoveBindingAt={vi.fn()}
+          onResetAction={vi.fn()}
+          onDisableAction={vi.fn()}
+          onEnableAction={vi.fn()}
+        />
+      </TooltipProvider>
+    )
+
+    const titleElement = screen.getByText(item!.title)
+    expect(titleElement.getAttribute('data-slot')).toBe('tooltip-trigger')
+  })
 })

--- a/src/renderer/src/components/settings/ShortcutCommandBlock.tsx
+++ b/src/renderer/src/components/settings/ShortcutCommandBlock.tsx
@@ -122,14 +122,21 @@ export function ShortcutCommandBlock({
     >
       <div className="flex min-h-9 items-center gap-3 rounded-md px-2 py-1 transition-colors hover:bg-accent/40 focus-within:bg-accent/40">
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          <span
-            className={cn(
-              'truncate text-sm',
-              isDisabled ? 'text-muted-foreground' : 'text-foreground'
-            )}
-          >
-            {item.title}
-          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className={cn(
+                  'truncate text-sm',
+                  isDisabled ? 'text-muted-foreground' : 'text-foreground'
+                )}
+              >
+                {item.title}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={4}>
+              {item.title}
+            </TooltipContent>
+          </Tooltip>
           {modified ? (
             <Badge variant="outline" className="shrink-0 text-[11px]">
               {translate('auto.components.settings.ShortcutCommandBlock.287e07ddde', 'Modified')}


### PR DESCRIPTION
## ELI5

In **Settings → Shortcuts**, long shortcut titles like `Worktree History Back` get truncated with `...`, but hovering over them didn't reveal the full name. This PR wraps the title in Orca's standard Tooltip so you can see the complete action title on hover.

## What Changed

- **`src/renderer/src/components/settings/ShortcutCommandBlock.tsx`**: Wrapped the action title `<span>` with existing `<Tooltip>`, `<TooltipTrigger asChild>`, and `<TooltipContent side="top" sideOffset={4}>` components.
- **`src/renderer/src/components/settings/ShortcutCommandBlock.test.tsx`**: Added a unit test verifying that the shortcut action title renders with the `data-slot="tooltip-trigger"` attribute.

Kept the change strictly minimal (~7 lines in the component), reusing existing Radix UI tooltip components without introducing new dependencies, layout changes, or style regressions.

## Why

In `ShortcutCommandBlock.tsx`, the shortcut title uses `truncate text-sm` to fit nicely within list rows. When titles are long, the end of the action name is cut off. Wrapping it in `<Tooltip>` allows users to inspect the full action name effortlessly while preserving the clean and compact list layout.

## Linked Issue

Fixes #16805

## Visual Proof

| Before | After |
|---|---|
| <img width="848" height="528" alt="image" src="https://github.com/user-attachments/assets/7e9ea026-9d17-4a98-b81a-7545f3fccee7" />|<img width="851" height="681" alt="image" src="https://github.com/user-attachments/assets/c3cdcaf8-5d3a-4de9-a15b-d5bb991b63ae" />|

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Verification Details:**
- `pnpm test src/renderer/src/components/settings/ShortcutCommandBlock.test.tsx` — 2/2 tests passed
- `pnpm test src/renderer/src/components/settings` — 161 test files (1,073 tests) passed
- `pnpm tc` — Typecheck passed cleanly
- `npx oxlint src/renderer/src/components/settings/ShortcutCommandBlock.tsx src/renderer/src/components/settings/ShortcutCommandBlock.test.tsx` — 0 warnings, 0 errors

## AI Disclosure

Developed and validated with Gemini 3.7 Flash via Antigravity pair-programming agent. Design conventions and tooltip placement were aligned with `docs/STYLEGUIDE.md`.