### PR TITLE
Add terminal unavailability exports to parity test

### DIFF
--- a/src/shared/runtime-client-export-parity.test.ts
+++ b/src/shared/runtime-client-export-parity.test.ts
@@ -158,6 +158,7 @@ type RuntimeTypeInventory = [
   Runtime.RuntimeTerminalSplit,
   Runtime.RuntimeTerminalState,
   Runtime.RuntimeTerminalSummary,
+  Runtime.RuntimeTerminalUnavailableReason,
   Runtime.RuntimeTerminalVisualGroupNode,
   Runtime.RuntimeTerminalVisualLayout,
   Runtime.RuntimeTerminalVisualLayoutNode,
@@ -225,8 +226,11 @@ describe('runtime client public export parity', () => {
       'BROWSER_UNAVAILABLE_ERROR_CODE',
       'COMPUTER_ERROR_CODES',
       'HEADLESS_RUNTIME_WINDOW_ID',
+      'TERMINAL_PTY_DEGRADATION_CAPABILITY',
+      'TERMINAL_UNAVAILABLE_ERROR_CODE',
       'UNPUBLISHED_WORKTREE_PUBLICATION_EPOCH',
-      'browserUnavailableMessage'
+      'browserUnavailableMessage',
+      'terminalUnavailableMessage'
     ])
     expect(Object.keys(RemoteClient).sort()).toEqual([
       'RemoteRuntimeClientError',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Problem

The runtime client export parity test was missing terminal unavailability-related exports, which should be validated for consistency between runtime and client interfaces.

## Solution

Added terminal unavailability exports to the parity test inventory:
- `RuntimeTerminalUnavailableReason` type
- `TERMINAL_PTY_DEGRADATION_CAPABILITY` constant
- `TERMINAL_UNAVAILABLE_ERROR_CODE` constant
- `terminalUnavailableMessage` export

## Testing

- [x] Parity test updated to cover all terminal unavailability exports
- [x] Test-only change, no behavioral impact

## Checklist

- [x] This PR is small and focused
- [x] Export parity validation for terminal unavailability
- [x] N/A: No UI/behavior/platform/security changes