### PR TITLE
Add quick command duplication with a list cap

### DIFF
--- a/mobile/src/session/QuickCommandRow.tsx
+++ b/mobile/src/session/QuickCommandRow.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { View, Text, Pressable, StyleSheet } from 'react-native'
 import * as Clipboard from 'expo-clipboard'
-import { Check, Copy, Pencil, Play, Trash2 } from 'lucide-react-native'
+import { Check, Copy, CopyPlus, Pencil, Play, Trash2 } from 'lucide-react-native'
 import { colors, spacing, typography } from '../theme/mobile-theme'
 import { MobileAgentIcon } from '../components/MobileAgentIcon'
 import type { TerminalQuickCommand } from '../../../src/shared/terminal-quick-command-types'
@@ -16,7 +16,9 @@ type QuickCommandRowProps = {
   first: boolean
   onLaunch: (command: TerminalQuickCommand) => void
   onEdit: (command: TerminalQuickCommand) => void
+  onDuplicate: (command: TerminalQuickCommand) => void
   onDelete: (command: TerminalQuickCommand) => void
+  canDuplicate: boolean
   disabled: boolean
 }
 
@@ -30,7 +32,9 @@ export function QuickCommandRow({
   first,
   onLaunch,
   onEdit,
+  onDuplicate,
   onDelete,
+  canDuplicate,
   disabled
 }: QuickCommandRowProps) {
   const isAgent = isAgentQuickCommand(command)
@@ -90,6 +94,7 @@ export function QuickCommandRow({
   }
 
   const copyDisabled = disabled || !canCopy
+  const duplicateDisabled = disabled || !canDuplicate
   const copyLabel =
     copyStatus === 'copied'
       ? 'Copied'
@@ -148,6 +153,22 @@ export function QuickCommandRow({
         ) : (
           <Copy size={15} color={copyIconColor} />
         )}
+      </Pressable>
+      <Pressable
+        style={({ pressed }) => [
+          styles.rowAction,
+          !canDuplicate && styles.disabled,
+          pressed && !duplicateDisabled && styles.pressed
+        ]}
+        disabled={duplicateDisabled}
+        onPress={() => onDuplicate(command)}
+        accessibilityRole="button"
+        accessibilityLabel={
+          canDuplicate ? `Duplicate ${command.label}` : 'Quick command limit reached'
+        }
+        accessibilityState={{ disabled: duplicateDisabled }}
+      >
+        <CopyPlus size={15} color={colors.textSecondary} />
       </Pressable>
       <Pressable
         style={({ pressed }) => [styles.rowAction, pressed && !disabled && styles.pressed]}

--- a/mobile/src/session/QuickCommandsList.tsx
+++ b/mobile/src/session/QuickCommandsList.tsx
@@ -26,6 +26,7 @@ type ListProps = {
   onQueryChange: (value: string) => void
   onLaunch: (command: TerminalQuickCommand) => void
   onEdit: (command: TerminalQuickCommand) => void
+  onDuplicate: (command: TerminalQuickCommand) => void
   onDelete: (command: TerminalQuickCommand) => void
   onAdd: () => void
 }
@@ -42,6 +43,7 @@ export function QuickCommandsList({
   onQueryChange,
   onLaunch,
   onEdit,
+  onDuplicate,
   onDelete,
   onAdd
 }: ListProps) {
@@ -90,7 +92,9 @@ export function QuickCommandsList({
           commands={repoCommands}
           onLaunch={onLaunch}
           onEdit={onEdit}
+          onDuplicate={onDuplicate}
           onDelete={onDelete}
+          canDuplicate={canAdd}
           disabled={disabled}
         />
       ) : null}
@@ -101,7 +105,9 @@ export function QuickCommandsList({
           commands={globalCommands}
           onLaunch={onLaunch}
           onEdit={onEdit}
+          onDuplicate={onDuplicate}
           onDelete={onDelete}
+          canDuplicate={canAdd}
           disabled={disabled}
         />
       ) : null}
@@ -130,14 +136,18 @@ function QuickCommandGroup({
   commands,
   onLaunch,
   onEdit,
+  onDuplicate,
   onDelete,
+  canDuplicate,
   disabled
 }: {
   label: string
   commands: TerminalQuickCommand[]
   onLaunch: (command: TerminalQuickCommand) => void
   onEdit: (command: TerminalQuickCommand) => void
+  onDuplicate: (command: TerminalQuickCommand) => void
   onDelete: (command: TerminalQuickCommand) => void
+  canDuplicate: boolean
   disabled: boolean
 }) {
   return (
@@ -151,7 +161,9 @@ function QuickCommandGroup({
             first={index === 0}
             onLaunch={onLaunch}
             onEdit={onEdit}
+            onDuplicate={onDuplicate}
             onDelete={onDelete}
+            canDuplicate={canDuplicate}
             disabled={disabled}
           />
         ))}

--- a/mobile/src/session/QuickCommandsSheet.tsx
+++ b/mobile/src/session/QuickCommandsSheet.tsx
@@ -6,6 +6,7 @@ import { BottomDrawer } from '../components/BottomDrawer'
 import type { RpcClient } from '../transport/rpc-client'
 import type { TerminalQuickCommand } from '../../../src/shared/terminal-quick-command-types'
 import {
+  duplicateTerminalQuickCommand,
   getQuickCommandPreview,
   MAX_QUICK_COMMANDS,
   quickCommandMatchesRepo
@@ -91,6 +92,17 @@ export function QuickCommandsSheet({
         ? quickCommandToDraft(command)
         : createEmptyQuickCommandDraft(repoId ? { type: 'repo', repoId } : { type: 'global' })
     )
+    setView('editor')
+  }
+
+  const openDuplicateEditor = (command: TerminalQuickCommand) => {
+    if (commands.length >= MAX_QUICK_COMMANDS) {
+      return
+    }
+    // Why: only the derived label is kept — the draft id stays null so the save
+    // path mints a fresh one instead of overwriting the source command.
+    const { label } = duplicateTerminalQuickCommand(command, command.id, commands)
+    setDraft({ ...quickCommandToDraft(command), id: null, label })
     setView('editor')
   }
 
@@ -190,6 +202,7 @@ export function QuickCommandsSheet({
           onQueryChange={setQuery}
           onLaunch={handleLaunch}
           onEdit={openEditor}
+          onDuplicate={openDuplicateEditor}
           onDelete={handleDelete}
           onAdd={() => openEditor()}
         />

--- a/mobile/src/terminal/quick-commands.ts
+++ b/mobile/src/terminal/quick-commands.ts
@@ -2,6 +2,7 @@ import type { TerminalQuickCommand } from '../../../src/shared/terminal-quick-co
 import type { TuiAgent } from '../../../src/shared/tui-agent'
 import {
   applyTerminalQuickCommandMutation,
+  duplicateTerminalQuickCommand,
   flattenTerminalQuickCommand,
   getTerminalQuickCommandBody,
   isTerminalAgentQuickCommand,
@@ -31,6 +32,7 @@ export {
   MAX_QUICK_COMMAND_TERMINAL_TEXT_LENGTH,
   parseNormalizedTerminalQuickCommands,
   applyTerminalQuickCommandMutation,
+  duplicateTerminalQuickCommand,
   type TerminalQuickCommandMutation
 }
 

--- a/src/renderer/src/components/settings/QuickCommandsList.tsx
+++ b/src/renderer/src/components/settings/QuickCommandsList.tsx
@@ -1,10 +1,11 @@
-import { Check, Copy, Pencil, TerminalSquare, Trash2 } from 'lucide-react'
+import { Check, Copy, CopyPlus, Pencil, TerminalSquare, Trash2 } from 'lucide-react'
 import type { Repo } from '../../../../shared/repo-types'
 import type {
   TerminalQuickCommand,
   TerminalQuickCommandScope
 } from '../../../../shared/terminal-quick-command-types'
 import {
+  canAddTerminalQuickCommand,
   getTerminalQuickCommandBody,
   getTerminalQuickCommandScope,
   isTerminalAgentQuickCommand
@@ -41,12 +42,16 @@ function getRunModeLabel(command: TerminalQuickCommand): string {
 function QuickCommandRow({
   command,
   repoById,
+  canDuplicate,
   onEdit,
+  onDuplicate,
   onRemove
 }: {
   command: TerminalQuickCommand
   repoById: Map<string, Pick<Repo, 'displayName' | 'path' | 'badgeColor'>>
+  canDuplicate: boolean
   onEdit: (command: TerminalQuickCommand) => void
+  onDuplicate: (command: TerminalQuickCommand) => void
   onRemove: (command: TerminalQuickCommand) => void
 }): React.JSX.Element {
   const scope = getTerminalQuickCommandScope(command)
@@ -69,6 +74,14 @@ function QuickCommandRow({
     'Edit {{value0}}',
     { value0: commandName }
   )
+  const duplicateLabel = canDuplicate
+    ? translate('auto.components.settings.QuickCommandsPane.4f2a1c8b3d', 'Duplicate {{value0}}', {
+        value0: commandName
+      })
+    : translate(
+        'auto.components.settings.QuickCommandsPane.7c6d5e4f2a',
+        'Quick command limit reached'
+      )
 
   return (
     <div className="group/qc flex items-center gap-3 rounded-md px-2 py-2.5 transition-colors hover:bg-accent/60 focus-within:bg-accent/60">
@@ -140,6 +153,17 @@ function QuickCommandRow({
           type="button"
           variant="ghost"
           size="icon-sm"
+          disabled={!canDuplicate}
+          aria-label={duplicateLabel}
+          title={duplicateLabel}
+          onClick={() => onDuplicate(command)}
+        >
+          <CopyPlus />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
           aria-label={translate(
             'auto.components.settings.QuickCommandsPane.8764c6e9e4',
             'Remove {{value0}}',
@@ -205,6 +229,7 @@ export function QuickCommandsList({
   hasQuery,
   repoById,
   onEdit,
+  onDuplicate,
   onRemove
 }: {
   commands: TerminalQuickCommand[]
@@ -212,11 +237,13 @@ export function QuickCommandsList({
   hasQuery: boolean
   repoById: Map<string, Pick<Repo, 'displayName' | 'path' | 'badgeColor'>>
   onEdit: (command: TerminalQuickCommand) => void
+  onDuplicate: (command: TerminalQuickCommand) => void
   onRemove: (command: TerminalQuickCommand) => void
 }): React.JSX.Element {
   if (visibleCommands.length === 0) {
     return <QuickCommandsEmptyState hasCommands={commands.length > 0} hasQuery={hasQuery} />
   }
+  const canDuplicate = canAddTerminalQuickCommand(commands)
   return (
     <div className="-mx-2 divide-y divide-border/50">
       {visibleCommands.map((command) => (
@@ -224,7 +251,9 @@ export function QuickCommandsList({
           key={command.id}
           command={command}
           repoById={repoById}
+          canDuplicate={canDuplicate}
           onEdit={onEdit}
+          onDuplicate={onDuplicate}
           onRemove={onRemove}
         />
       ))}

--- a/src/renderer/src/components/settings/QuickCommandsPane.tsx
+++ b/src/renderer/src/components/settings/QuickCommandsPane.tsx
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { TerminalQuickCommand } from '../../../../shared/terminal-quick-command-types'
-import { getTerminalQuickCommandScope } from '../../../../shared/terminal-quick-commands'
+import {
+  canAddTerminalQuickCommand,
+  duplicateTerminalQuickCommand,
+  getTerminalQuickCommandScope
+} from '../../../../shared/terminal-quick-commands'
 import {
   createTerminalQuickCommandDraft,
   TerminalQuickCommandDialog
 } from '@/components/terminal-quick-commands/TerminalQuickCommandDialog'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 import { searchTerminalQuickCommands } from '@/lib/terminal-quick-command-search'
 import { useAppStore } from '../../store'
 import { Button } from '../ui/button'
@@ -204,13 +209,17 @@ export function QuickCommandsPane({
   ) {
     // Why: Settings deep-links use this one-shot signal to open the add dialog;
     // consume it before paint so the pane never flashes without the editor.
+    // Consume it even at the cap, or the signal stays armed and reopens the
+    // dialog later when a command is deleted.
     consumedAddIntentSignalRef.current = intentSignal
-    setEditor({
-      mode: 'add',
-      command: createDraftForCurrentFilter(),
-      connectionGeneration: selectedRuntimeConnectionGeneration,
-      hostId: selectedHostId
-    })
+    if (canAddTerminalQuickCommand(commands)) {
+      setEditor({
+        mode: 'add',
+        command: createDraftForCurrentFilter(),
+        connectionGeneration: selectedRuntimeConnectionGeneration,
+        hostId: selectedHostId
+      })
+    }
   }
 
   const toggleScope = (key: string): void => {
@@ -275,13 +284,35 @@ export function QuickCommandsPane({
     void useAppStore.getState().deleteTerminalQuickCommand(selectedHostId, command.id)
   }
 
-  const openAddDialog = (): void =>
+  const openAddDialog = (): void => {
+    // Why: the host rejects a new-id upsert above the cap; blocking here keeps
+    // the failure out of the save path where the draft would already be typed.
+    if (!canAddTerminalQuickCommand(commands)) {
+      return
+    }
     setEditor({
       mode: 'add',
       command: createDraftForCurrentFilter(),
       connectionGeneration: selectedRuntimeConnectionGeneration,
       hostId: selectedHostId
     })
+  }
+
+  const duplicateCommand = (command: TerminalQuickCommand): void => {
+    if (!canAddTerminalQuickCommand(commands)) {
+      return
+    }
+    setEditor({
+      mode: 'add',
+      command: duplicateTerminalQuickCommand(
+        command,
+        `quick-command-${createBrowserUuid()}`,
+        commands
+      ),
+      connectionGeneration: selectedRuntimeConnectionGeneration,
+      hostId: selectedHostId
+    })
+  }
 
   return (
     <div className="space-y-4">
@@ -300,6 +331,7 @@ export function QuickCommandsPane({
           setScopeSelection(null)
         }}
         canAdd={canManageSelectedHost}
+        atCommandLimit={!canAddTerminalQuickCommand(commands)}
         onAdd={openAddDialog}
         repos={hostRepos}
         effectiveSelection={effectiveSelection}
@@ -384,6 +416,7 @@ export function QuickCommandsPane({
                 hostId: selectedHostId
               })
             }
+            onDuplicate={duplicateCommand}
             onRemove={(command) => void removeCommand(command)}
           />
         </>

--- a/src/renderer/src/components/settings/QuickCommandsToolbar.tsx
+++ b/src/renderer/src/components/settings/QuickCommandsToolbar.tsx
@@ -16,6 +16,7 @@ type QuickCommandsToolbarProps = {
   selectedHostId: ExecutionHostId
   onHostChange: (hostId: ExecutionHostId) => void
   canAdd: boolean
+  atCommandLimit: boolean
   onAdd: () => void
   repos: readonly Repo[]
   effectiveSelection: ReadonlySet<string>
@@ -34,6 +35,7 @@ export function QuickCommandsToolbar({
   selectedHostId,
   onHostChange,
   canAdd,
+  atCommandLimit,
   onAdd,
   repos,
   effectiveSelection,
@@ -104,7 +106,16 @@ export function QuickCommandsToolbar({
         type="button"
         variant="outline"
         size="sm"
-        disabled={!canAdd}
+        disabled={!canAdd || atCommandLimit}
+        // Why: a disabled button with no reason reads as a bug; name the cap.
+        title={
+          atCommandLimit
+            ? translate(
+                'auto.components.settings.QuickCommandsPane.7c6d5e4f2a',
+                'Quick command limit reached'
+              )
+            : undefined
+        }
         onClick={onAdd}
         className="ml-auto"
       >

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandItem.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandItem.test.tsx
@@ -58,13 +58,18 @@ afterEach(() => {
   container.remove()
 })
 
-function renderItem(item: HostedTerminalQuickCommand = entry): {
+function renderItem(
+  item: HostedTerminalQuickCommand = entry,
+  canDuplicate = true
+): {
   onRun: ReturnType<typeof vi.fn>
   onEdit: ReturnType<typeof vi.fn>
+  onDuplicate: ReturnType<typeof vi.fn>
   onDelete: ReturnType<typeof vi.fn>
 } {
   const onRun = vi.fn()
   const onEdit = vi.fn()
+  const onDuplicate = vi.fn()
   const onDelete = vi.fn()
   act(() => {
     root.render(
@@ -74,14 +79,16 @@ function renderItem(item: HostedTerminalQuickCommand = entry): {
         createElement(TabBarQuickCommandItem, {
           entry: item,
           showHostLabel: false,
+          canDuplicate,
           onRun,
           onEdit,
+          onDuplicate,
           onDelete
         })
       )
     )
   })
-  return { onRun, onEdit, onDelete }
+  return { onRun, onEdit, onDuplicate, onDelete }
 }
 
 describe('TabBarQuickCommandItem', () => {
@@ -172,6 +179,42 @@ describe('TabBarQuickCommandItem', () => {
 
     expect(container.querySelector('button[aria-label="Couldn\'t copy"]')).not.toBeNull()
     expect(container.querySelector('button[aria-label="Copied"]')).toBeNull()
+  })
+
+  it('duplicates without running, editing, or copying the command', () => {
+    const { onRun, onEdit, onDuplicate, onDelete } = renderItem()
+
+    const duplicateButton = container.querySelector('button[aria-label="Duplicate Git status"]')
+    if (!(duplicateButton instanceof HTMLButtonElement)) {
+      throw new Error('duplicate button not found')
+    }
+
+    act(() => {
+      duplicateButton.click()
+    })
+
+    expect(onDuplicate).toHaveBeenCalledTimes(1)
+    expect(onRun).not.toHaveBeenCalled()
+    expect(onEdit).not.toHaveBeenCalled()
+    expect(onDelete).not.toHaveBeenCalled()
+    expect(writeClipboardText).not.toHaveBeenCalled()
+  })
+
+  it('disables duplication once the quick command limit is reached', () => {
+    const { onDuplicate } = renderItem(entry, false)
+
+    const duplicateButton = container.querySelector(
+      'button[aria-label="Quick command limit reached"]'
+    )
+    if (!(duplicateButton instanceof HTMLButtonElement)) {
+      throw new Error('duplicate button not found')
+    }
+
+    expect(duplicateButton.disabled).toBe(true)
+    act(() => {
+      duplicateButton.click()
+    })
+    expect(onDuplicate).not.toHaveBeenCalled()
   })
 
   it('prevents nested action pointerdown from selecting the command row', () => {

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandItem.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandItem.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent, PointerEvent } from 'react'
-import { Check, Copy, Pencil, Play, Trash2 } from 'lucide-react'
+import { Check, Copy, CopyPlus, Pencil, Play, Trash2 } from 'lucide-react'
 import { CommandItem } from '@/components/ui/command'
 import {
   getTerminalQuickCommandBody,
@@ -14,15 +14,18 @@ import { cn } from '@/lib/utils'
 type TabBarQuickCommandItemProps = {
   entry: HostedTerminalQuickCommand
   showHostLabel: boolean
+  canDuplicate: boolean
   onRun: () => void
   onEdit: () => void
+  onDuplicate: () => void
   onDelete: () => void
 }
 
 function stopRowSelect(event: MouseEvent | PointerEvent): void {
   // Why: cmdk selects the parent CommandItem on click; nested actions must not
   // also run the quick command. preventDefault keeps focus in the search input
-  // so arrow/Enter navigation still works after Copy (Edit/Delete close the menu).
+  // so arrow/Enter navigation still works after Copy (the dialog and Delete
+  // actions close the menu themselves).
   event.preventDefault()
   event.stopPropagation()
 }
@@ -30,8 +33,10 @@ function stopRowSelect(event: MouseEvent | PointerEvent): void {
 export function TabBarQuickCommandItem({
   entry,
   showHostLabel,
+  canDuplicate,
   onRun,
   onEdit,
+  onDuplicate,
   onDelete
 }: TabBarQuickCommandItemProps): React.JSX.Element {
   const { command } = entry
@@ -53,6 +58,17 @@ export function TabBarQuickCommandItem({
               'auto.components.tab.bar.TabBarQuickCommandsButton.69a1441a21',
               'Nothing to copy'
             )
+
+  const duplicateLabel = canDuplicate
+    ? translate(
+        'auto.components.tab.bar.TabBarQuickCommandsButton.4f2a1c8b3d',
+        'Duplicate {{value0}}',
+        { value0: command.label }
+      )
+    : translate(
+        'auto.components.tab.bar.TabBarQuickCommandsButton.7c6d5e4f2a',
+        'Quick command limit reached'
+      )
 
   return (
     <CommandItem
@@ -111,6 +127,20 @@ export function TabBarQuickCommandItem({
           title={copyLabel}
         >
           {status === 'copied' ? <Check className="size-3" /> : <Copy className="size-3" />}
+        </button>
+        <button
+          type="button"
+          disabled={!canDuplicate}
+          onPointerDown={stopRowSelect}
+          onClick={(event) => {
+            stopRowSelect(event)
+            onDuplicate()
+          }}
+          className="cursor-pointer rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+          aria-label={duplicateLabel}
+          title={duplicateLabel}
+        >
+          <CopyPlus className="size-3" />
         </button>
         <button
           type="button"

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
@@ -7,9 +7,12 @@ import {
   TerminalQuickCommandDialog
 } from '@/components/terminal-quick-commands/TerminalQuickCommandDialog'
 import {
+  canAddTerminalQuickCommand,
+  duplicateTerminalQuickCommand,
   getTerminalQuickCommandScope,
   isTerminalQuickCommandComplete
 } from '../../../../shared/terminal-quick-commands'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree/id'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { runQuickCommandInNewTab } from '@/lib/run-quick-command-in-new-tab'
@@ -124,6 +127,27 @@ export function TabBarQuickCommandsButton({
     }
   }
 
+  // Why: the cap is per host, so count the owning host's full list rather than
+  // the scope-filtered commands rendered in the menu.
+  const getHostCommands = (hostId: ExecutionHostId): readonly TerminalQuickCommand[] =>
+    hosts.find((host) => host.hostId === hostId)?.commands ?? []
+
+  const handleDuplicateCommand = (entry: HostedTerminalQuickCommand): void => {
+    const hostCommands = getHostCommands(entry.hostId)
+    if (!canAddTerminalQuickCommand(hostCommands)) {
+      return
+    }
+    setEditor({
+      mode: 'add',
+      hostId: entry.hostId,
+      command: duplicateTerminalQuickCommand(
+        entry.command,
+        `quick-command-${createBrowserUuid()}`,
+        hostCommands
+      )
+    })
+  }
+
   const handleDeleteCommand = async (entry: HostedTerminalQuickCommand): Promise<void> => {
     const { command } = entry
     const confirmed = await confirm({
@@ -222,9 +246,11 @@ export function TabBarQuickCommandsButton({
         hostOwnershipPending={remoteHostPending}
         onMenuOpen={refreshRemoteHost}
         onAddCommand={addRepoCommand}
+        canDuplicateCommand={(entry) => canAddTerminalQuickCommand(getHostCommands(entry.hostId))}
         onEditCommand={(entry) =>
           setEditor({ mode: 'edit', command: entry.command, hostId: entry.hostId })
         }
+        onDuplicateCommand={handleDuplicateCommand}
         onDeleteCommand={(entry) => void handleDeleteCommand(entry)}
         onRunCommand={handleRun}
       />

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.keyboard.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.keyboard.test.ts
@@ -131,8 +131,10 @@ function makeProps() {
     addHosts: [],
     hostLoadFailed: false,
     hostOwnershipPending: false,
+    canDuplicateCommand: () => true,
     onAddCommand: vi.fn(),
     onDeleteCommand: vi.fn(),
+    onDuplicateCommand: vi.fn(),
     onEditCommand: vi.fn(),
     onMenuOpen: vi.fn(),
     onRunCommand: vi.fn()

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.tsx
@@ -40,8 +40,10 @@ type TabBarQuickCommandsMenuProps = {
   addHosts: readonly TerminalQuickCommandHost[]
   hostLoadFailed: boolean
   hostOwnershipPending: boolean
+  canDuplicateCommand: (entry: HostedTerminalQuickCommand) => boolean
   onAddCommand: (hostId: TerminalQuickCommandHost['hostId']) => void
   onDeleteCommand: (entry: HostedTerminalQuickCommand) => void
+  onDuplicateCommand: (entry: HostedTerminalQuickCommand) => void
   onEditCommand: (entry: HostedTerminalQuickCommand) => void
   onMenuOpen: () => void
   onRunCommand: (entry: HostedTerminalQuickCommand) => void
@@ -54,8 +56,10 @@ export function TabBarQuickCommandsMenu({
   addHosts,
   hostLoadFailed,
   hostOwnershipPending,
+  canDuplicateCommand,
   onAddCommand,
   onDeleteCommand,
+  onDuplicateCommand,
   onEditCommand,
   onMenuOpen,
   onRunCommand
@@ -170,6 +174,30 @@ export function TabBarQuickCommandsMenu({
     },
     [closeMenu, onRunCommand]
   )
+  const renderCommandItems = (
+    entries: readonly HostedTerminalQuickCommand[]
+  ): React.JSX.Element[] =>
+    entries.map((entry) => (
+      <TabBarQuickCommandItem
+        key={entry.key}
+        entry={entry}
+        showHostLabel={addHosts.length > 1}
+        canDuplicate={canDuplicateCommand(entry)}
+        onRun={() => runAndClose(entry)}
+        onEdit={() => {
+          closeMenu()
+          onEditCommand(entry)
+        }}
+        onDuplicate={() => {
+          closeMenu()
+          onDuplicateCommand(entry)
+        }}
+        onDelete={() => {
+          closeMenu()
+          onDeleteCommand(entry)
+        }}
+      />
+    ))
   const searchInput = useTabBarQuickCommandSearchInput({
     commandListRef,
     commandValue,
@@ -350,41 +378,11 @@ export function TabBarQuickCommandsMenu({
                       )}
                 </CommandEmpty>
               ) : null}
-              {filteredRepoCommands.map((entry) => (
-                <TabBarQuickCommandItem
-                  key={entry.key}
-                  entry={entry}
-                  showHostLabel={addHosts.length > 1}
-                  onRun={() => runAndClose(entry)}
-                  onEdit={() => {
-                    closeMenu()
-                    onEditCommand(entry)
-                  }}
-                  onDelete={() => {
-                    closeMenu()
-                    onDeleteCommand(entry)
-                  }}
-                />
-              ))}
+              {renderCommandItems(filteredRepoCommands)}
               {filteredRepoCommands.length > 0 && filteredGlobalCommands.length > 0 ? (
                 <CommandSeparator className="my-1" />
               ) : null}
-              {filteredGlobalCommands.map((entry) => (
-                <TabBarQuickCommandItem
-                  key={entry.key}
-                  entry={entry}
-                  showHostLabel={addHosts.length > 1}
-                  onRun={() => runAndClose(entry)}
-                  onEdit={() => {
-                    closeMenu()
-                    onEditCommand(entry)
-                  }}
-                  onDelete={() => {
-                    closeMenu()
-                    onDeleteCommand(entry)
-                  }}
-                />
-              ))}
+              {renderCommandItems(filteredGlobalCommands)}
             </CommandList>
             {hostOwnershipPending ? (
               <TabBarQuickCommandHostLoadStatus failed={hostLoadFailed} />

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3365,7 +3365,9 @@
             "53b17a4b1b": "Couldn't copy",
             "a9a564b7e7": "Copy {{value0}}",
             "69a1441a21": "Nothing to copy",
-            "192a4616a5": "Quick command actions"
+            "192a4616a5": "Quick command actions",
+            "4f2a1c8b3d": "Duplicate {{value0}}",
+            "7c6d5e4f2a": "Quick command limit reached"
           },
           "shell": {
             "icons": {
@@ -7556,7 +7558,9 @@
           "8d525e5f15": "Copied",
           "53b17a4b1b": "Couldn't copy",
           "a9a564b7e7": "Copy {{value0}}",
-          "69a1441a21": "Nothing to copy"
+          "69a1441a21": "Nothing to copy",
+          "4f2a1c8b3d": "Duplicate {{value0}}",
+          "7c6d5e4f2a": "Quick command limit reached"
         },
         "RecentTabOrderControl": {
           "3b17c81ede": "Tab strip order",

--- a/src/shared/terminal-quick-commands.test.ts
+++ b/src/shared/terminal-quick-commands.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from 'vitest'
+import type { TerminalQuickCommand } from './terminal-quick-command-types'
 import {
   applyTerminalQuickCommandMutation,
   buildTerminalQuickCommandInput,
+  canAddTerminalQuickCommand,
+  duplicateTerminalQuickCommand,
   flattenTerminalQuickCommand,
   getTerminalQuickCommandAction,
   getTerminalQuickCommandBody,
   getDefaultTerminalQuickCommands,
   isTerminalQuickCommandComplete,
+  MAX_QUICK_COMMAND_LABEL_LENGTH,
+  MAX_QUICK_COMMANDS,
   normalizeTerminalQuickCommands,
   parseNormalizedTerminalQuickCommands,
   supportsTerminalAgentQuickCommand,
@@ -384,5 +389,126 @@ describe('flattenTerminalQuickCommand', () => {
       appendEnter: true
     })
     expect(result.command).toBe('echo one; echo two')
+  })
+})
+
+describe('duplicateTerminalQuickCommand', () => {
+  const base = {
+    id: 'original',
+    label: 'Start Claude Max',
+    command: 'claude --effort max',
+    appendEnter: true,
+    scope: { type: 'repo' as const, repoId: 'repo-1' }
+  }
+
+  it('copies every field except the id and label', () => {
+    const copy = duplicateTerminalQuickCommand(base, 'new-id')
+    expect(copy).toEqual({
+      ...base,
+      id: 'new-id',
+      label: 'Start Claude Max (copy)'
+    })
+  })
+
+  it('preserves agent action fields', () => {
+    const agentCommand = {
+      id: 'original',
+      label: 'Review',
+      action: 'agent-prompt' as const,
+      agent: 'claude' as const,
+      prompt: 'review this diff',
+      scope: { type: 'global' as const }
+    }
+    expect(duplicateTerminalQuickCommand(agentCommand, 'new-id')).toEqual({
+      ...agentCommand,
+      id: 'new-id',
+      label: 'Review (copy)'
+    })
+  })
+
+  it('numbers repeated copies instead of chaining the suffix', () => {
+    const first = duplicateTerminalQuickCommand(base, 'id-2', [base])
+    const second = duplicateTerminalQuickCommand(first, 'id-3', [base, first])
+    expect(first.label).toBe('Start Claude Max (copy)')
+    expect(second.label).toBe('Start Claude Max (copy 2)')
+  })
+
+  it('skips labels already taken', () => {
+    const taken = { ...base, id: 'other', label: 'Start Claude Max (copy)' }
+    expect(duplicateTerminalQuickCommand(base, 'id-3', [base, taken]).label).toBe(
+      'Start Claude Max (copy 2)'
+    )
+  })
+
+  it('keeps the suffix intact when the label hits the length cap', () => {
+    const longLabel = 'a'.repeat(MAX_QUICK_COMMAND_LABEL_LENGTH)
+    const copy = duplicateTerminalQuickCommand({ ...base, label: longLabel }, 'id-2')
+    expect(copy.label.length).toBeLessThanOrEqual(MAX_QUICK_COMMAND_LABEL_LENGTH)
+    expect(copy.label.endsWith(' (copy)')).toBe(true)
+  })
+
+  it('produces a command that is already in canonical form', () => {
+    const [canonical] = normalizeTerminalQuickCommands([base])
+    const copy = duplicateTerminalQuickCommand(canonical!, 'new-id')
+    // Why: the duplicate is persisted as-is, so it must survive the wire parser
+    // without normalization rewriting it.
+    expect(parseNormalizedTerminalQuickCommands([canonical!, copy])).not.toBeNull()
+  })
+
+  it('renumbers a label that is only the copy suffix instead of chaining it', () => {
+    expect(duplicateTerminalQuickCommand({ ...base, label: '(copy)' }, 'id-2').label).toBe(
+      '(copy 2)'
+    )
+  })
+
+  it('never returns a label with surrounding whitespace', () => {
+    // Why: the save path trims, so an untrimmed copy would not match its own
+    // persisted form and the wire parser would reject the host echo.
+    for (const label of ['', '   ', '(copy)']) {
+      const copy = duplicateTerminalQuickCommand({ ...base, label }, 'id-2')
+      expect(copy.label).toBe(copy.label.trim())
+      expect(copy.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('terminates when the counter exceeds the safe integer range', () => {
+    // Why: Number(n) + 1 === n past 2^53, which spun the uniqueness loop forever
+    // — and the source command's own label is always in the existing set.
+    const label = 'Deploy (copy 9007199254740992)'
+    const source = { ...base, label }
+    const copy = duplicateTerminalQuickCommand(source, 'id-2', [source])
+    expect(copy.label).not.toBe(label)
+    expect(copy.label.length).toBeLessThanOrEqual(MAX_QUICK_COMMAND_LABEL_LENGTH)
+  })
+
+  it('does not grow a suffix chain across repeated duplication', () => {
+    let current: TerminalQuickCommand = { ...base, label: 'Deploy' }
+    const seen: TerminalQuickCommand[] = [current]
+    for (let round = 0; round < 5; round += 1) {
+      current = duplicateTerminalQuickCommand(current, `id-${round}`, seen)
+      seen.push(current)
+    }
+    expect(seen.map((entry) => entry.label)).toEqual([
+      'Deploy',
+      'Deploy (copy)',
+      'Deploy (copy 2)',
+      'Deploy (copy 3)',
+      'Deploy (copy 4)',
+      'Deploy (copy 5)'
+    ])
+  })
+})
+
+describe('canAddTerminalQuickCommand', () => {
+  it('blocks once the list is at the cap', () => {
+    const commands = Array.from({ length: MAX_QUICK_COMMANDS }, (_, index) => ({
+      id: `id-${index}`,
+      label: `Command ${index}`,
+      command: 'echo hi',
+      appendEnter: true
+    }))
+    expect(canAddTerminalQuickCommand(commands)).toBe(false)
+    expect(canAddTerminalQuickCommand(commands.slice(1))).toBe(true)
+    expect(canAddTerminalQuickCommand([])).toBe(true)
   })
 })

--- a/src/shared/terminal-quick-commands.ts
+++ b/src/shared/terminal-quick-commands.ts
@@ -251,6 +251,61 @@ export function buildTerminalQuickCommandInput(command: TerminalCommandQuickComm
   return command.appendEnter ? `${command.command}\r` : command.command
 }
 
+// Why: the space before "(copy)" is optional so a label that is exactly "(copy)"
+// renumbers instead of chaining; the digit run is bounded because anything longer
+// is user text, not a copy index, and would overflow past Number's safe range.
+const COPY_LABEL_SUFFIX_RE = /^(.*?)\s*\(copy(?: ([1-9]\d{0,5}))?\)$/
+
+// Why: duplicating "Deploy (copy)" must yield "(copy 2)", not "(copy) (copy)",
+// so repeated duplication stays readable instead of growing a suffix chain.
+function buildDuplicateTerminalQuickCommandLabel(
+  label: string,
+  existingLabels: ReadonlySet<string>
+): string {
+  const trimmed = label.trim()
+  const match = COPY_LABEL_SUFFIX_RE.exec(trimmed)
+  const base = match ? match[1] : trimmed
+  // Why: a non-advancing counter would spin the uniqueness loop forever.
+  const parsed = match ? Number(match[2] ?? 1) : 0
+  let counter = Number.isSafeInteger(parsed) ? parsed + 1 : 1
+
+  // Why: truncate the base, not the suffix — a clipped "(cop" reads as corruption
+  // — then trim, since the save path trims and the copy must match what persists.
+  const buildLabel = (index: number): string => {
+    const suffix = index <= 1 ? ' (copy)' : ` (copy ${index})`
+    const room = MAX_QUICK_COMMAND_LABEL_LENGTH - suffix.length
+    return `${base.slice(0, Math.max(0, room)).trimEnd()}${suffix}`.trim()
+  }
+
+  let candidate = buildLabel(counter)
+  while (existingLabels.has(candidate)) {
+    counter += 1
+    candidate = buildLabel(counter)
+  }
+  return candidate
+}
+
+// Why: duplicating carries every field except identity, so new fields on the
+// command type are copied automatically instead of being silently dropped.
+export function duplicateTerminalQuickCommand(
+  command: TerminalQuickCommand,
+  id: string,
+  existingCommands: readonly TerminalQuickCommand[] = []
+): TerminalQuickCommand {
+  const existingLabels = new Set(existingCommands.map((entry) => entry.label))
+  return {
+    ...command,
+    id,
+    label: buildDuplicateTerminalQuickCommandLabel(command.label, existingLabels)
+  }
+}
+
+export function canAddTerminalQuickCommand(
+  commands: readonly TerminalQuickCommand[] = []
+): boolean {
+  return commands.length < MAX_QUICK_COMMANDS
+}
+
 const LINE_BREAK_RE = /\r\n|\r|\n/
 
 // Why: quick-command lines are independent shell commands; one shell command


### PR DESCRIPTION
## Summary

Duplicating a quick command copies every field except the id and derives a unique `(copy)` / `(copy N)` label, bounded by the label length cap. Adding and duplicating are both blocked once the list reaches `MAX_QUICK_COMMANDS`, on desktop and mobile alike; the host already rejects over-cap upserts, so the UI checks keep that failure out of the save path.

Shared logic lives in `src/shared/terminal-quick-commands.ts` and is re-exported by mobile rather than reimplemented.

## Label derivation

Two edge cases are worth calling out, both reachable because the label field accepts arbitrary user text:

- **The copy index is limited to six digits.** A longer digit run is treated as text rather than parsed past `Number`'s safe range. Without this, a label like `Deploy (copy 9007199254740992)` made `counter + 1 === counter` in IEEE-754, so the uniqueness loop never advanced and froze the UI. The source command's own label is always in the existing set, so this was reachable in production, not just in theory.
- **The space before `(copy)` is optional**, so a label that is exactly `(copy)` renumbers instead of chaining. The result is trimmed, since the save path trims and the local copy must match what persists.

## Testing

- `src/shared/terminal-quick-commands.test.ts` — 29 tests, including regressions for the non-advancing counter, the suffix-only label, whitespace-only labels, and repeated duplication not growing a chain.
- Typecheck, `oxfmt --check`, and the changed-code quality gate all pass.
- Localization catalog synced via `pnpm run sync:localization-catalog` (4 keys added to `en.json`).

**Not verified:** the rendered UI. The automated tests cover label logic and the cap predicate, but the disabled add button, its tooltip, and the prefilled duplicate dialog have not been exercised in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)