### PR TITLE
Fix concurrent daemon spawn recovery after disconnect

### DIFF
--- a/src/main/daemon/daemon-endpoint-errors.ts
+++ b/src/main/daemon/daemon-endpoint-errors.ts
@@ -1,4 +1,5 @@
 import { DAEMON_ENDPOINT_LOST_MESSAGE } from './daemon-endpoint-ownership'
+import { DaemonConnectionLostError } from './daemon-errors'
 import { DAEMON_UNAVAILABLE_RECONNECT_MESSAGE } from './types'
 
 /**
@@ -16,6 +17,9 @@ export function isUnknownRequestTypeError(err: unknown): boolean {
 export function isDaemonGoneError(err: unknown): boolean {
   if (!(err instanceof Error)) {
     return false
+  }
+  if (err instanceof DaemonConnectionLostError) {
+    return true
   }
   const errno = err as NodeJS.ErrnoException
   if ((errno.code === 'ENOENT' || errno.code === 'ECONNREFUSED') && errno.syscall === 'connect') {

--- a/src/main/daemon/daemon-pty-adapter-concurrent-recovery.test.ts
+++ b/src/main/daemon/daemon-pty-adapter-concurrent-recovery.test.ts
@@ -1,0 +1,78 @@
+import { expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { DaemonServer } from './daemon-server'
+import { createMockSubprocess } from './daemon-pty-adapter-test-harness'
+import { getDaemonSocketPath } from './daemon-spawner'
+
+it('recovers concurrent spawns rejected by an adapter-initiated disconnect', async () => {
+  const concurrentSpawnCount = 70
+  const dir = mkdtempSync(join(tmpdir(), 'daemon-concurrent-recovery-test-'))
+  const socketPath = getDaemonSocketPath(dir)
+  const tokenPath = join(dir, 'test.token')
+  const allPreparationsEntered = Promise.withResolvers<void>()
+  const releaseHeldPreparations = Promise.withResolvers<void>()
+  const spawnedSessionIds: string[] = []
+  let preparationCount = 0
+
+  const spawnSubprocess: ConstructorParameters<typeof DaemonServer>[0]['spawnSubprocess'] = (
+    options
+  ) => {
+    spawnedSessionIds.push(options.sessionId)
+    return createMockSubprocess()
+  }
+  let server = new DaemonServer({
+    socketPath,
+    tokenPath,
+    spawnSubprocess,
+    // Hold siblings until one retriable reply makes the adapter disconnect their shared socket.
+    preparePtySpawn: async () => {
+      const preparationNumber = ++preparationCount
+      if (preparationCount === concurrentSpawnCount) {
+        allPreparationsEntered.resolve()
+      }
+      await allPreparationsEntered.promise
+      if (preparationNumber === 1) {
+        throw new Error('Connection lost')
+      }
+      await releaseHeldPreparations.promise
+    }
+  })
+  await server.start()
+
+  const respawn = vi.fn(async () => {
+    await server.shutdown()
+    releaseHeldPreparations.resolve()
+    server = new DaemonServer({ socketPath, tokenPath, spawnSubprocess })
+    await server.start()
+  })
+  const adapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn })
+
+  try {
+    const sessionIds = Array.from(
+      { length: concurrentSpawnCount },
+      (_, index) => `high-volume-${index}`
+    )
+    const results = await Promise.all(
+      sessionIds.map((sessionId) => adapter.spawn({ sessionId, cols: 80, rows: 24 }))
+    )
+
+    expect(preparationCount).toBe(concurrentSpawnCount)
+    expect(respawn).toHaveBeenCalledTimes(1)
+    expect(respawn).toHaveBeenCalledWith('daemon_died')
+    expect(new Set(results.map(({ id }) => id))).toEqual(new Set(sessionIds))
+    expect(new Set(spawnedSessionIds)).toEqual(new Set(sessionIds))
+
+    const later = await adapter.spawn({ sessionId: 'after-recovery', cols: 80, rows: 24 })
+    expect(later.id).toBe('after-recovery')
+    expect(respawn).toHaveBeenCalledTimes(1)
+    expect(spawnedSessionIds).toHaveLength(concurrentSpawnCount + 1)
+  } finally {
+    adapter.dispose()
+    releaseHeldPreparations.resolve()
+    await server.shutdown()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​78 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​78 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5

When one daemon request triggers recovery, the adapter closes its shared control connection. Other terminal launches that were already using that connection now join the same recovery and retry instead of showing `DaemonConnectionLostError: Disconnected`.

## What Changed

- Classify typed `DaemonConnectionLostError` failures as proven daemon endpoint loss.
- Route concurrent callers through the existing single respawn promise and one bounded retry.
- Add a deterministic 70-spawn regression that holds sibling RPCs in flight, triggers adapter-owned disconnect, and verifies one respawn, unique PTYs, and a healthy later spawn.

## Why

High-volume agent execution can have many PTY creations in flight on one daemon connection. The first reconnectable failure starts recovery and intentionally disconnects that socket; previously, sibling requests escaped recovery because their typed `Disconnected` error did not match the message-only daemon-gone classifier.

## Linked Issue

[STA-5353](https://linear.app/stably/issue/STA-5353/resolve-daemonconnectionlosterror-during-high-volume-codex-agent)

## Visual Proof

N/A — daemon lifecycle behavior has no direct UI change.

## Testing

- [x] Automated regression verified to fail on unmodified main and pass with this fix.
- [x] `pnpm test` for six focused daemon suites: 80 tests passed.
- [x] `pnpm tc:node`.
- [x] `pnpm run check:code-quality:changed` with zero findings.
- [x] Stress regression passed repeatedly on macOS; CI covers other supported platforms.

## Review

The change preserves the existing respawn owner, adoption/disposal guards, one-retry bound, and session identity checks. It changes no wire payloads or SSH process-liveness semantics.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or mechanically translates no upstream skill-installer material.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Visual proof is not applicable
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and backwards-compatibility impact considered
- [x] Focused tests, node typecheck, formatting, and changed-code quality checks pass

<!-- sta-5353-reliability-contract -->

## Reliability Contract

- **Invariant (`terminal-session.daemon-connection-loss-recovery`):** concurrent create/attach calls whose shared daemon control socket is intentionally disconnected by one proven endpoint-loss recovery all join one adapter-owned respawn, retry at most once, preserve unique requested session IDs, and leave the replacement endpoint healthy.
- **Failure source:** STA-5353 reported `DaemonConnectionLostError: Disconnected` while roughly 70 agent terminals launched concurrently.
- **Oracle:** the deterministic 70-spawn socket-server regression holds sibling RPCs in flight, forces one server reply to initiate disconnect, and requires all 70 results, one respawn, unique spawned sessions, and a successful later spawn. Reverting the typed classifier makes this oracle fail with the reported exception.
- **Gate:** accepted manifest gap for this classifier-only fix; the regression is part of the normal unit suite and exact-head CI, but has no dedicated `config/reliability-gates.jsonc` entry.
- **Provider/platform coverage:** local-daemon behavior is covered on macOS locally and by Node 24/26 CI plus native/package jobs across macOS, Linux, and Windows. SSH, WSL, paired-runtime, mobile/relay, folder-workspace, and remote-wire contracts are unaffected because no RPC payload, opcode, path, process-verdict, or provider-selection behavior changes.
- **Performance budget:** one constant-time typed error check is added only on an error path; no polling, timers, scans, listeners, startup awaits, or subprocess fanout are added. The oracle requires exactly one respawn under 70 callers.
- **Diagnostics:** the typed `DaemonConnectionLostError` and existing daemon-respawn warning retain the failure and recovery signals without adding customer-content telemetry.
- **Residual gaps:** no live 70-process Electron journey or destructive real-daemon crash was run; the socket-level concurrency oracle proves the changed lifecycle contract directly, and there is no renderable UI change for visual proof.

<!-- /sta-5353-reliability-contract -->