### PR TITLE
Fix terminal paste cancellation after xterm focus replacement

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -227,8 +227,10 @@ import { formatTerminalPasteExecutionError } from './terminal-paste-errors'
 import { resolveTerminalPasteRuntime } from './terminal-paste-runtime'
 import { getTerminalPasteSshRemotePlatform } from './terminal-paste-ssh-platform'
 import {
+  captureTerminalPanePasteFocusSnapshot,
   isTerminalPanePasteFocusCurrent,
-  isTerminalPanePasteTargetCurrent
+  isTerminalPanePasteTargetCurrent,
+  type TerminalPanePasteFocusSnapshot
 } from './terminal-paste-target-state'
 import { writeTerminalPastePtyInput } from './terminal-pty-paste-writer'
 import {
@@ -1952,7 +1954,7 @@ function TerminalPane(
     const executePanePasteText = async (
       pane: ManagedPane,
       source: TerminalPasteSource,
-      activeElementAtDispatch: Element | null,
+      focusAtDispatch: TerminalPanePasteFocusSnapshot,
       text: string,
       options?: TerminalPasteTextOptions
     ): Promise<void> => {
@@ -1993,7 +1995,7 @@ function TerminalPane(
           }
           return isTerminalPanePasteFocusCurrent({
             requireSameFocusedElement: keyboardOwnedPaste,
-            activeElementAtDispatch,
+            focusAtDispatch,
             paneContainer: pane.container
           })
         },
@@ -2044,7 +2046,7 @@ function TerminalPane(
         useAppStore.getState(),
         worktreeId
       )
-      const activeElementAtDispatch = document.activeElement
+      const focusAtDispatch = captureTerminalPanePasteFocusSnapshot(pane.container)
       void pasteTerminalClipboard({
         readClipboardText,
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
@@ -2052,7 +2054,7 @@ function TerminalPane(
         runtimeEnvironmentId,
         protectedMultilineTextPasteOptions: resolvePaneProtectedMultilinePasteOptions(pane),
         pasteText: (text, options) =>
-          executePanePasteText(pane, source, activeElementAtDispatch, text, options),
+          executePanePasteText(pane, source, focusAtDispatch, text, options),
         onTextPasteError: () =>
           setTerminalError('Paste failed: clipboard text is too large for a safe terminal paste.'),
         onImagePasteError: (error) => setTerminalError(formatClipboardImagePasteError(error))
@@ -2187,6 +2189,10 @@ function TerminalPane(
       if (!pane) {
         return
       }
+      const focusAtDispatch = captureTerminalPanePasteFocusSnapshot(
+        pane.container,
+        activeElementAtDispatch
+      )
       const connectionId = getConnectionId(worktreeId) ?? null
       const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(
         useAppStore.getState(),
@@ -2199,7 +2205,7 @@ function TerminalPane(
         runtimeEnvironmentId,
         protectedMultilineTextPasteOptions: resolvePaneProtectedMultilinePasteOptions(pane),
         pasteText: (text, options) =>
-          executePanePasteText(pane, 'app-menu', activeElementAtDispatch, text, options),
+          executePanePasteText(pane, 'app-menu', focusAtDispatch, text, options),
         onTextPasteError: () =>
           setTerminalError('Paste failed: clipboard text is too large for a safe terminal paste.'),
         onImagePasteError: (error) => setTerminalError(formatClipboardImagePasteError(error))

--- a/src/renderer/src/components/terminal-pane/terminal-paste-target-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-target-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  captureTerminalPanePasteFocusSnapshot,
   isTerminalPanePasteFocusCurrent,
   isTerminalPanePasteTargetCurrent
 } from './terminal-paste-target-state'
@@ -121,7 +122,7 @@ describe('terminal paste target state', () => {
     expect(
       isTerminalPanePasteFocusCurrent({
         requireSameFocusedElement: true,
-        activeElementAtDispatch: terminalInput,
+        focusAtDispatch: { element: terminalInput, ownedByPane: true },
         paneContainer,
         activeElement: terminalInput
       })
@@ -136,7 +137,7 @@ describe('terminal paste target state', () => {
     expect(
       isTerminalPanePasteFocusCurrent({
         requireSameFocusedElement: true,
-        activeElementAtDispatch: terminalInput,
+        focusAtDispatch: { element: terminalInput, ownedByPane: true },
         paneContainer,
         activeElement: renameInput
       })
@@ -151,7 +152,7 @@ describe('terminal paste target state', () => {
     expect(
       isTerminalPanePasteFocusCurrent({
         requireSameFocusedElement: true,
-        activeElementAtDispatch: terminalInput,
+        focusAtDispatch: { element: terminalInput, ownedByPane: true },
         paneContainer,
         activeElement: body
       })
@@ -161,16 +162,40 @@ describe('terminal paste target state', () => {
   it('keeps keyboard-owned paste current when xterm replaces its helper textarea', () => {
     const originalTerminalInput = makeElement('textarea', ['xterm-helper-textarea'])
     const replacementTerminalInput = makeElement('textarea', ['xterm-helper-textarea'])
-    const paneContainer = makePaneContainerFor([originalTerminalInput, replacementTerminalInput])
+    let acceptedElements: readonly Element[] = [originalTerminalInput]
+    const paneContainer = {
+      contains: vi.fn((element: Element | null) => acceptedElements.includes(element as Element))
+    } as unknown as Element
+    const focusAtDispatch = captureTerminalPanePasteFocusSnapshot(
+      paneContainer,
+      originalTerminalInput
+    )
+    acceptedElements = [replacementTerminalInput]
 
+    expect(focusAtDispatch.ownedByPane).toBe(true)
     expect(
       isTerminalPanePasteFocusCurrent({
         requireSameFocusedElement: true,
-        activeElementAtDispatch: originalTerminalInput,
+        focusAtDispatch,
         paneContainer,
         activeElement: replacementTerminalInput
       })
     ).toBe(true)
+  })
+
+  it('rejects a replacement helper when the dispatch focus was never owned by the pane', () => {
+    const outsideInput = makeElement('input')
+    const replacementTerminalInput = makeElement('textarea', ['xterm-helper-textarea'])
+    const paneContainer = makePaneContainerFor([replacementTerminalInput])
+
+    expect(
+      isTerminalPanePasteFocusCurrent({
+        requireSameFocusedElement: true,
+        focusAtDispatch: { element: outsideInput, ownedByPane: false },
+        paneContainer,
+        activeElement: replacementTerminalInput
+      })
+    ).toBe(false)
   })
 
   it('rejects keyboard-owned paste when focus moves to another control in the pane', () => {
@@ -181,7 +206,7 @@ describe('terminal paste target state', () => {
     expect(
       isTerminalPanePasteFocusCurrent({
         requireSameFocusedElement: true,
-        activeElementAtDispatch: terminalInput,
+        focusAtDispatch: { element: terminalInput, ownedByPane: true },
         paneContainer,
         activeElement: searchInput
       })
@@ -196,7 +221,7 @@ describe('terminal paste target state', () => {
     expect(
       isTerminalPanePasteFocusCurrent({
         requireSameFocusedElement: false,
-        activeElementAtDispatch: terminalInput,
+        focusAtDispatch: { element: terminalInput, ownedByPane: true },
         paneContainer,
         activeElement: otherInput
       })

--- a/src/renderer/src/components/terminal-pane/terminal-paste-target-state.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-target-state.ts
@@ -38,23 +38,39 @@ export function isTerminalPanePasteTargetCurrent({
   )
 }
 
+export type TerminalPanePasteFocusSnapshot = {
+  element: Element | null
+  ownedByPane: boolean
+}
+
+export function captureTerminalPanePasteFocusSnapshot(
+  paneContainer: Element,
+  element: Element | null = typeof document === 'undefined' ? null : document.activeElement
+): TerminalPanePasteFocusSnapshot {
+  return {
+    element,
+    ownedByPane: element === null || paneContainer.contains(element)
+  }
+}
+
 export type TerminalPanePasteFocusState = {
   requireSameFocusedElement: boolean
-  activeElementAtDispatch: Element | null
+  focusAtDispatch: TerminalPanePasteFocusSnapshot
   paneContainer: Element
   activeElement?: Element | null
 }
 
 export function isTerminalPanePasteFocusCurrent({
   requireSameFocusedElement,
-  activeElementAtDispatch,
+  focusAtDispatch,
   paneContainer,
   activeElement = typeof document === 'undefined' ? null : document.activeElement
 }: TerminalPanePasteFocusState): boolean {
+  const activeElementAtDispatch = focusAtDispatch.element
   if (!requireSameFocusedElement || activeElementAtDispatch === null) {
     return true
   }
-  if (!paneContainer.contains(activeElementAtDispatch)) {
+  if (!focusAtDispatch.ownedByPane) {
     return false
   }
   if (activeElement === activeElementAtDispatch) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 |

<!-- /orca-pr-loc -->

## ELI5

A paste could begin in the right terminal, wait for the clipboard, and then be cancelled because xterm replaced its hidden input element during that wait. Orca now remembers that the original input belonged to the pane, then accepts xterm's valid replacement only while the same pane and PTY still own focus.

In plainer words: you click into a terminal pane and press paste. Orca has to go and fetch the
clipboard, which takes a moment. During that moment the terminal widget sometimes quietly swaps out
the invisible box that receives your keystrokes — normal behaviour on its part. Orca was checking
"is the exact box I started with still on screen?", found a different one, decided the paste must be
aimed somewhere else, and **cancelled it**. Your text never arrived, even though the pane was right
there still accepting typing. Orca now checks the thing that actually matters — that the same pane
and the same running terminal still hold focus.

## User-facing before / after

| | Before | After |
|---|---|---|
| You paste into a terminal and the terminal widget replaces its hidden input while the clipboard is being read | The paste was cancelled. Nothing arrived, and the pane still took typing normally, so there was no clue why | The paste lands in the pane you aimed it at |
| Focus genuinely moves to a **different** pane mid-paste | Cancelled | Still cancelled — that is the case the guard exists for |
| Focus moves to something that isn't a terminal | Cancelled | Still cancelled |
| The pane's terminal is replaced by a different one mid-paste | — | Refused, so text can't land in the wrong process |

## When it bites

Reported on Linux, where the hidden-input replacement is most frequent, but the code path is the same
on every platform. It hits anyone pasting into a terminal pane, and it looks like the paste silently
did nothing.


## What Changed

- Capture terminal-pane focus ownership synchronously when paste dispatch begins.
- Validate the current helper plus the existing pane, leaf, transport, and PTY identities before execution.
- Keep rejecting focus that moves to another pane or a non-terminal control.
- Add a red/green regression contract for xterm helper replacement and a wrong-owner safety case.

## Why

STA-3834 / #13623 reports Linux pastes being cancelled even though input to the same pane remains available. The stale guard rechecked whether the original xterm helper was still contained after asynchronous clipboard reading; when xterm detached and replaced that helper, Orca rejected the valid current target.

## Linked Issue

Fixes #13623

Linear: https://linear.app/stably/issue/STA-3834/bug-paste-cancelled

## Visual Proof

The focused Electron journey delays clipboard delivery, replaces the xterm helper during the wait, and proves the marker reaches the terminal. It passed three consecutive recorded runs.

https://github.com/user-attachments/assets/6a37620e-db56-48f3-b397-a782f43dd6a8

Baseline proof is deterministic rather than visual: the new helper-replacement unit contract failed before the fix (`expected true, received false`) and passes with this commit.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `pnpm test` across 8 focused terminal clipboard/paste suites: 96 passed.
- `pnpm tc:web`: passed.
- Explicit `oxlint` and `oxfmt --check` on all 3 changed files: passed.
- Electron Playwright clipboard-blur journey: passed once in the focused validation and 3/3 in the recorded visual-proof run.
- E2E-mode Electron bundle: passed.
- `pnpm run check:code-quality:changed`: blocked before lint by a pre-existing Node 26 engine-warning JSON parse failure; direct changed-file lint passed.

Actual Linux desktop + Wispr Flow reproduction remains unverified; validation used the shared renderer path in Electron on macOS.

## Review

Two adversarial review-until-clean rounds found no remaining in-scope issues. The scope excludes STA-5272's broader deferred-paste feature and cancellation-presentation changes.

### Terminal reliability contract

- **Invariant (`terminal-input.paste-focus-ownership`):** a paste started in a terminal pane may survive xterm helper replacement only while current focus remains in that pane and pane/leaf/transport/PTY identity is unchanged.
- **Failure source:** STA-3834 / #13623.
- **Oracle:** the red/green helper-replacement unit contract plus the Electron delayed-clipboard journey that proves terminal delivery.
- **Gate:** accepted gap—`config/reliability-gates.jsonc` has no dedicated paste-focus gate; the focused unit and Electron tests are not yet a manifest gate.
- **Coverage:** the shared renderer check is platform-neutral and preserves existing local/daemon/SSH/remote/WSL PTY routing structurally. Electron macOS was exercised; Linux/Wispr, Windows/ConPTY, physical SSH, paired web, and mobile/relay were not exercised. Mobile paste interaction is unaffected.
- **Performance budget:** one bounded focus snapshot and DOM containment check per paste; no polling, timers, subprocesses, collection scans, render subscriptions, or retained growth added.
- **Diagnostics:** existing paste execution reasons remain visible through the terminal error path; the unit failure and Electron recording distinguish stale helper ownership from wrong-pane focus.
- **Residual gap:** real Linux/Wispr behavior and cross-provider live runs remain unproved.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No wire, persisted-state, Git, filesystem, path, shell, provider, or subprocess contract changes. Folder workspaces and Git providers are unaffected.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

