### PR TITLE
STA-5296: keep Claude startup queries answerable on mobile

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -13860,16 +13860,18 @@
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": [],
-      "coverageNotes": "Deterministic local tests execute the exact injected mobile replay/generation gate, the React Native query classifier, stale-subscription sender, server-side single-responder election, query-reply RPC semantics, and live-output capture during async mobile fit. The provider write path is shared, but no live iOS/Android, SSH, WSL, or multi-device run is registered yet.",
+      "coverageNotes": "Deterministic local tests execute the exact injected mobile replay/generation gate, the React Native query classifier, stale-subscription sender, server-side single-responder election from live stream registrations, headless fallback while a mobile view is unfitted or has no live stream, query-reply RPC semantics, subscriber-driven provider attach for an unfitted mobile stream, and live-output capture during async mobile fit. The provider write path is shared, but no live iOS/Android, SSH, WSL, or multi-device run is registered yet.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/8128",
-        "https://github.com/stablyai/orca/pull/8206"
+        "https://github.com/stablyai/orca/pull/8206",
+        "https://github.com/stablyai/orca/issues/16242"
       ],
-      "invariant": "Snapshot and replacement-terminal replay answer no terminal queries; every live query delivered to subscribed mobile views has at most one current responder; a live query queued behind replay is answered after the replay boundary; terminal-generated replies never transfer the user-input floor.",
-      "oracle": "The injected gate emits zero replies during replay, exactly one after its live boundary, and ignores a superseded generation; native routing rejects ordinary input; the sender rejects disconnected or unsubscribed handles; runtime election accepts only the earliest active mobile subscriber and promotes its survivor; terminal.send writes only validated query grammar without mobileTookFloor; legacy binary subscribe captures a query while phone-fit is still pending and emits it after the snapshot.",
+      "invariant": "Snapshot and replacement-terminal replay answer no terminal queries; every live query has exactly one current responder, including before a mobile view is phone-fitted and while a mobile record holds no live stream; a live query queued behind replay is answered after the replay boundary; terminal-generated replies never transfer the user-input floor.",
+      "oracle": "The injected gate emits zero replies during replay, exactly one after its live boundary, and ignores a superseded generation; native routing rejects ordinary input; the sender rejects disconnected or unsubscribed handles; runtime election accepts only the earliest phone-fitted mobile subscriber that still holds a live stream and promotes its survivor; mobile presence alone, an unfitted stream, and a fitted record whose stream has closed all leave main authoritative; an unfitted mobile stream still drives subscriber-driven provider attach, and a mobile record without a stream still blocks daemon thinning; terminal.send writes only validated query grammar without mobileTookFloor; legacy binary subscribe captures a query while phone-fit is still pending and emits it after the snapshot.",
       "commands": [
         "pnpm --dir mobile exec vitest run --root .. mobile/src/terminal/terminal-webview-query-reply.test.ts mobile/src/terminal/terminal-webview-query-reply-routing.test.ts mobile/src/terminal/mobile-terminal-query-reply.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts src/main/runtime/mobile-presence-lock.test.ts src/shared/terminal-query-reply.test.ts src/shared/terminal-reply-query-scan.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/terminal-query-responder.test.ts src/main/runtime/terminal-subscriber-driven-daemon-attach.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection-terminal-input-gating.test.ts"
       ],
       "testFiles": [
@@ -13879,6 +13881,8 @@
         "src/main/runtime/rpc/terminal-send.test.ts",
         "src/main/runtime/rpc/terminal-subscribe-buffer.test.ts",
         "src/main/runtime/mobile-presence-lock.test.ts",
+        "src/main/runtime/terminal-query-responder.test.ts",
+        "src/main/runtime/terminal-subscriber-driven-daemon-attach.test.ts",
         "src/shared/terminal-query-reply.test.ts",
         "src/shared/terminal-reply-query-scan.test.ts",
         "src/renderer/src/components/terminal-pane/pty-connection-terminal-input-gating.test.ts"
@@ -13906,6 +13910,27 @@
           "assertions": [
             "live terminal data and view authority register before asynchronous mobile fit",
             "a query received during that await is retained and emitted after the snapshot"
+          ]
+        },
+        {
+          "file": "src/main/runtime/terminal-query-responder.test.ts",
+          "assertions": [
+            "mobile presence alone does not transfer query authority away from main",
+            "main stays authoritative until a streaming mobile view is phone-fitted, and regains authority when that stream releases",
+            "raw preview presence preserves delivery without suppressing main"
+          ]
+        },
+        {
+          "file": "src/main/runtime/mobile-presence-lock.test.ts",
+          "assertions": [
+            "a native-chat cover or pre-stream record leaves main authoritative but still blocks daemon thinning",
+            "the surviving stream is promoted when the elder record loses its stream"
+          ]
+        },
+        {
+          "file": "src/main/runtime/terminal-subscriber-driven-daemon-attach.test.ts",
+          "assertions": [
+            "an unfitted mobile stream, which holds no query authority, still retries provider attach when daemon inventory becomes ready"
           ]
         },
         {
@@ -13959,7 +13984,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "No polling, scans, timers, or output fanout were added. The WebView adds one disposable onData listener; native/RPC work occurs only for xterm data and is grammar-filtered; responder election is O(1) from Map insertion order; pre-fit output uses the existing capped pending-output queue."
+        "evidence": "No polling, scans, timers, subprocesses, or output fanout were added. Subscription setup adds one ref-count update on an existing per-PTY map; the per-chunk suppression check exits on a single map lookup when no mobile stream is attached; native/RPC work occurs only for xterm data and is grammar-filtered; pre-fit output uses the existing capped pending-output queue."
       },
       "promotionCriteria": [
         "Attach an intentional-break artifact for the pre-fit capture and multi-mobile election assertions.",

--- a/mobile/src/terminal/mobile-terminal-query-reply.ts
+++ b/mobile/src/terminal/mobile-terminal-query-reply.ts
@@ -25,8 +25,8 @@ export function sendMobileTerminalQueryReply({
   hostSupportsQueryReplyInput,
   subscribedTerminals
 }: MobileTerminalQueryReplyOptions): Promise<boolean> {
-  // Why: every subscribed mobile xterm suppresses main's responder, including
-  // hidden panes, so ownership follows the subscription rather than focus.
+  // Why: the host elects one responder among fitted, streaming mobile views and
+  // rejects replies from everyone else, so send optimistically and let it arbitrate.
   // Hosts without terminal.query-reply-input.v1 strip inputKind and would take
   // reply bytes as floor-stealing shell input, so drop (pre-fix behavior).
   if (

--- a/src/main/runtime/mobile-presence-lock.test.ts
+++ b/src/main/runtime/mobile-presence-lock.test.ts
@@ -333,10 +333,13 @@ describe('mobile presence lock — multi-mobile semantics', () => {
     const { runtime } = createRuntime()
     await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 45, rows: 20 })
     await runtime.handleMobileSubscribe('pty-1', 'phone-B', { cols: 38, rows: 18 })
+    const releaseA = runtime.registerRemoteTerminalViewSubscriber('pty-1', 'phone-A')
+    runtime.registerRemoteTerminalViewSubscriber('pty-1', 'phone-B')
 
     expect(runtime.isMobileTerminalQueryReplyAuthority('pty-1', 'phone-A')).toBe(true)
     expect(runtime.isMobileTerminalQueryReplyAuthority('pty-1', 'phone-B')).toBe(false)
 
+    releaseA()
     runtime.handleMobileUnsubscribe('pty-1', 'phone-A')
     expect(runtime.isMobileTerminalQueryReplyAuthority('pty-1', 'phone-B')).toBe(true)
 
@@ -352,6 +355,8 @@ describe('mobile presence lock — multi-mobile semantics', () => {
     await vi.advanceTimersByTimeAsync(10)
     await runtime.handleMobileSubscribe('pty-1', 'phone-B', { cols: 38, rows: 18 })
     await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 45, rows: 20 })
+    runtime.registerRemoteTerminalViewSubscriber('pty-1', 'phone-A')
+    runtime.registerRemoteTerminalViewSubscriber('pty-1', 'phone-B')
 
     expect(runtime.isMobileTerminalQueryReplyAuthority('pty-1', 'phone-A')).toBe(true)
     expect(runtime.isMobileTerminalQueryReplyAuthority('pty-1', 'phone-B')).toBe(false)
@@ -368,9 +373,40 @@ describe('mobile presence lock — multi-mobile semantics', () => {
     runtime.markMobileActor('pty-1', 'phone-B')
     runtime.setMobileDisplayMode('pty-1', 'auto')
     await runtime.applyMobileDisplayMode('pty-1')
+    runtime.registerRemoteTerminalViewSubscriber('pty-1', 'phone-A')
+    runtime.registerRemoteTerminalViewSubscriber('pty-1', 'phone-B')
 
     expect(runtime.isMobileTerminalQueryReplyAuthority('pty-1', 'phone-A')).toBe(false)
     expect(runtime.isMobileTerminalQueryReplyAuthority('pty-1', 'phone-B')).toBe(true)
+  })
+
+  it('promotes the surviving stream when the elder record loses its stream', async () => {
+    const { runtime } = createRuntime()
+    await runtime.handleMobileSubscribe('pty-1', 'phone-elder', { cols: 45, rows: 20 })
+    await vi.advanceTimersByTimeAsync(10)
+    await runtime.handleMobileSubscribe('pty-1', 'phone-survivor', { cols: 38, rows: 18 })
+    const releaseElder = runtime.registerRemoteTerminalViewSubscriber('pty-1', 'phone-elder')
+    runtime.registerRemoteTerminalViewSubscriber('pty-1', 'phone-survivor')
+
+    expect(runtime.isMobileTerminalQueryReplyAuthority('pty-1', 'phone-elder')).toBe(true)
+
+    // A grace-window record with no live stream cannot answer, so it must not hold authority.
+    releaseElder()
+    expect(runtime.isMobileTerminalQueryReplyAuthority('pty-1', 'phone-elder')).toBe(false)
+    expect(runtime.isMobileTerminalQueryReplyAuthority('pty-1', 'phone-survivor')).toBe(true)
+  })
+
+  it('leaves a native-chat cover or pre-stream record answerable by main but unthinnable', async () => {
+    const { runtime } = createRuntime()
+    // A lease-only cover, and any mobile view before its stream arms, hold a
+    // record but no stream.
+    await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 45, rows: 20 })
+
+    expect(runtime.isMobileTerminalQueryReplyAuthority('pty-1', 'phone-A')).toBe(false)
+    expect(runtime.hasRemoteTerminalViewSubscriber('pty-1')).toBe(false)
+    // Why: it answers nothing, but it is still a viewer — the daemon must not
+    // thin the stream main is modelling on its behalf.
+    expect(runtime.hasRawTerminalViewSubscriber('pty-1')).toBe(true)
   })
 
   it('most-recent actor wins active phone-fit dims (B subscribes after A)', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3582,9 +3582,10 @@ export class OrcaRuntimeService {
   // stream feeds a remote xterm view (mobile/web/remote desktop) that answers
   // queries with view authority, so main must yield while one is attached
   // (terminal-query-authority.md). Ref-counted per PTY because multiple
-  // streams can attach concurrently; mobileSubscribers is consulted too so
-  // grace-window mobile records keep suppressing.
+  // streams can attach concurrently. Mobile streams are tracked per client so
+  // suppression can be derived from the same election that grants authority.
   private remoteTerminalViewSubscriberCounts = new Map<string, number>()
+  private mobileTerminalViewSubscriberCounts = new Map<string, Map<string, number>>()
   // Preview windows consume the raw stream but deliberately leave terminal
   // query replies to main's headless emulator.
   private rawTerminalViewSubscriberCounts = new Map<string, number>()
@@ -13107,11 +13108,17 @@ export class OrcaRuntimeService {
    *  view subscriber is attached its xterm answers queries with view
    *  authority and the model responder must stay silent. Returns an
    *  idempotent release. */
-  registerRemoteTerminalViewSubscriber(ptyId: string): () => void {
-    this.remoteTerminalViewSubscriberCounts.set(
-      ptyId,
-      (this.remoteTerminalViewSubscriberCounts.get(ptyId) ?? 0) + 1
-    )
+  registerRemoteTerminalViewSubscriber(ptyId: string, mobileClientId?: string): () => void {
+    if (mobileClientId !== undefined) {
+      const clients = this.mobileTerminalViewSubscriberCounts.get(ptyId) ?? new Map()
+      clients.set(mobileClientId, (clients.get(mobileClientId) ?? 0) + 1)
+      this.mobileTerminalViewSubscriberCounts.set(ptyId, clients)
+    } else {
+      this.remoteTerminalViewSubscriberCounts.set(
+        ptyId,
+        (this.remoteTerminalViewSubscriberCounts.get(ptyId) ?? 0) + 1
+      )
+    }
     this.ensureSubscriberDrivenProviderAttach(ptyId)
     this.notifyRemoteTerminalViewPresenceChanged(ptyId)
     let released = false
@@ -13120,11 +13127,24 @@ export class OrcaRuntimeService {
         return
       }
       released = true
-      const next = (this.remoteTerminalViewSubscriberCounts.get(ptyId) ?? 1) - 1
-      if (next <= 0) {
-        this.remoteTerminalViewSubscriberCounts.delete(ptyId)
+      if (mobileClientId !== undefined) {
+        const clients = this.mobileTerminalViewSubscriberCounts.get(ptyId)
+        const nextClientCount = (clients?.get(mobileClientId) ?? 1) - 1
+        if (nextClientCount <= 0) {
+          clients?.delete(mobileClientId)
+        } else {
+          clients?.set(mobileClientId, nextClientCount)
+        }
+        if (clients?.size === 0) {
+          this.mobileTerminalViewSubscriberCounts.delete(ptyId)
+        }
       } else {
-        this.remoteTerminalViewSubscriberCounts.set(ptyId, next)
+        const next = (this.remoteTerminalViewSubscriberCounts.get(ptyId) ?? 1) - 1
+        if (next <= 0) {
+          this.remoteTerminalViewSubscriberCounts.delete(ptyId)
+        } else {
+          this.remoteTerminalViewSubscriberCounts.set(ptyId, next)
+        }
       }
       this.notifyRemoteTerminalViewPresenceChanged(ptyId)
     }
@@ -13178,8 +13198,20 @@ export class OrcaRuntimeService {
     })
   }
 
+  /** A remote or mobile viewer is attached. Excludes preview windows, which
+   *  consume output without driving provider attach. A mobile record with no
+   *  stream still counts: a lease-only native-chat cover consumes no output but
+   *  must not let the daemon thin the stream main is modelling. */
+  private hasNonPreviewTerminalViewSubscriber(ptyId: string): boolean {
+    return (
+      (this.remoteTerminalViewSubscriberCounts.get(ptyId) ?? 0) > 0 ||
+      (this.mobileTerminalViewSubscriberCounts.get(ptyId)?.size ?? 0) > 0 ||
+      (this.mobileSubscribers.get(ptyId)?.size ?? 0) > 0
+    )
+  }
+
   private reconcileSubscriberDrivenProviderAttach(ptyId: string): void {
-    if (!this.hasRemoteTerminalViewSubscriber(ptyId)) {
+    if (!this.hasNonPreviewTerminalViewSubscriber(ptyId)) {
       return
     }
     const pending = this.subscriberDrivenProviderAttachesByPtyId.get(ptyId)
@@ -13193,7 +13225,7 @@ export class OrcaRuntimeService {
     this.subscriberDrivenProviderAttachInventoryWaiters.add(ptyId)
     void pending.then((attached) => {
       this.subscriberDrivenProviderAttachInventoryWaiters.delete(ptyId)
-      if (attached || !this.hasRemoteTerminalViewSubscriber(ptyId)) {
+      if (attached || !this.hasNonPreviewTerminalViewSubscriber(ptyId)) {
         return
       }
       if (this.subscriberDrivenProviderAttachesByPtyId.get(ptyId) === pending) {
@@ -13230,40 +13262,54 @@ export class OrcaRuntimeService {
   hasRawTerminalViewSubscriber(ptyId: string): boolean {
     return (
       (this.rawTerminalViewSubscriberCounts.get(ptyId) ?? 0) > 0 ||
-      this.hasRemoteTerminalViewSubscriber(ptyId)
+      this.hasNonPreviewTerminalViewSubscriber(ptyId)
     )
   }
 
+  /** Reply ownership. Note this also reads driver kind and phone-fit, which do
+   *  NOT fire notifyRemoteTerminalViewPresenceChanged — safe only because the
+   *  one consumer re-evaluates per chunk. Do not cache it off that signal. */
   hasRemoteTerminalViewSubscriber(ptyId: string): boolean {
-    if ((this.remoteTerminalViewSubscriberCounts.get(ptyId) ?? 0) > 0) {
-      return true
-    }
-    return (this.mobileSubscribers.get(ptyId)?.size ?? 0) > 0
+    return (
+      (this.remoteTerminalViewSubscriberCounts.get(ptyId) ?? 0) > 0 ||
+      this.getMobileTerminalQueryReplyAuthorityClientId(ptyId) !== null
+    )
   }
 
   isMobileTerminalQueryReplyAuthority(ptyId: string, clientId: string): boolean {
+    return this.getMobileTerminalQueryReplyAuthorityClientId(ptyId) === clientId
+  }
+
+  private getMobileTerminalQueryReplyAuthorityClientId(ptyId: string): string | null {
+    // Why: a grace-window record with no live stream cannot answer, so it must
+    // not suppress main either (#16242). Checked first because this runs per
+    // output chunk and no-mobile PTYs must exit on one lookup.
+    const streamed = this.mobileTerminalViewSubscriberCounts.get(ptyId)
+    if (!streamed) {
+      return null
+    }
     // Why: a passive phone watching desktop-sized output must not race the
     // desktop xterm. Mobile becomes reply authority only with the mobile floor.
     if (this.getDriver(ptyId).kind !== 'mobile') {
-      return false
+      return null
     }
     const subscribers = this.mobileSubscribers.get(ptyId)
     if (!subscribers) {
-      return false
+      return null
     }
     // Why: soft-leave resubscribe preserves the original subscription time but
     // reinserts the record. Elect fitted responders from that stable age, not
     // mutable Map order or passive desktop-mode watchers.
     let earliest: { clientId: string; subscribedAt: number } | null = null
     for (const subscriber of subscribers.values()) {
-      if (!subscriber.wasResizedToPhone) {
+      if (!subscriber.wasResizedToPhone || !streamed.has(subscriber.clientId)) {
         continue
       }
       if (earliest === null || subscriber.subscribedAt < earliest.subscribedAt) {
         earliest = subscriber
       }
     }
-    return earliest?.clientId === clientId
+    return earliest?.clientId ?? null
   }
 
   subscribeToFitOverrideChanges(
@@ -16062,6 +16108,7 @@ export class OrcaRuntimeService {
     // Clean up new mobile state for this PTY
     this.mobileSubscribers.delete(ptyId)
     this.remoteTerminalViewSubscriberCounts.delete(ptyId)
+    this.mobileTerminalViewSubscriberCounts.delete(ptyId)
     this.rawTerminalViewSubscriberCounts.delete(ptyId)
     this.mobileDisplayModes.delete(ptyId)
     this.resizeListeners.delete(ptyId)

--- a/src/main/runtime/rpc/methods/terminal/terminal-legacy-subscribe-binary.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-legacy-subscribe-binary.ts
@@ -173,7 +173,10 @@ export async function runTerminalBinarySubscription(args: TerminalSubscriptionAr
     outputBatcher?.push(data, meta)
   })
   // Why: capture live bytes before mobile-fit awaits; registering presence first would suppress main while no view held the query.
-  const releaseViewSubscriber = runtime.registerRemoteTerminalViewSubscriber(ptyId)
+  const releaseViewSubscriber = runtime.registerRemoteTerminalViewSubscriber(
+    ptyId,
+    isMobile ? clientId : undefined
+  )
   unsubscribeData = () => {
     releaseViewSubscriber()
     unsubscribeStreamData()

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-stream-initialization.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-stream-initialization.ts
@@ -112,7 +112,10 @@ export async function initializeMultiplexStream(
     stream.outputBatcher.push(data, meta)
   })
   // Why: a multiplexed stream feeds a remote xterm view with query authority, so the main model responder yields while attached (terminal-query-authority.md).
-  const releaseViewSubscriber = runtime.registerRemoteTerminalViewSubscriber(ptyId)
+  const releaseViewSubscriber = runtime.registerRemoteTerminalViewSubscriber(
+    ptyId,
+    isMobile ? request.client?.id : undefined
+  )
   stream.unsubscribeData = () => {
     releaseViewSubscriber()
     unsubscribeStreamData()

--- a/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
@@ -139,7 +139,8 @@ describe('terminal subscribe buffering', () => {
 
     await vi.waitFor(() => expect(runtime.handleMobileSubscribe).toHaveBeenCalled())
     expect(dataListener).toBeDefined()
-    expect(registerRemoteTerminalViewSubscriber).toHaveBeenCalledWith('pty-1')
+    // A mobile stream registers under its client id so the responder election can find it.
+    expect(registerRemoteTerminalViewSubscriber).toHaveBeenCalledWith('pty-1', 'phone-1')
     dataListener?.('\x1b[6n', { seq: 4, rawLength: 4 })
     resolveMobileSubscribe()
 

--- a/src/main/runtime/terminal-query-responder.test.ts
+++ b/src/main/runtime/terminal-query-responder.test.ts
@@ -265,10 +265,40 @@ describe('reply ownership matrix', () => {
     expect(runtime.hasRawTerminalViewSubscriber('pty-preview')).toBe(false)
   })
 
-  it('treats mobile subscriber records as remote view subscribers', async () => {
-    const { runtime } = createResponderRuntime()
+  it('does not transfer query authority from mobile presence alone', async () => {
+    const { runtime, replies } = createResponderRuntime()
+    markHiddenRendererPty('pty-mob')
+    await runtime.handleMobileSubscribe('pty-mob', 'client-1', { cols: 40, rows: 20 })
+    expect(runtime.hasRemoteTerminalViewSubscriber('pty-mob')).toBe(false)
+
+    runtime.onPtyData('pty-mob', DA1, Date.now())
+    await settle(runtime, 'pty-mob')
+    expect(replies.map((reply) => reply.data)).toEqual(['\x1b[?1;2c'])
+  })
+
+  it('keeps main authoritative until a streaming mobile view is phone-fitted', async () => {
+    const { runtime, replies } = createResponderRuntime()
+    markHiddenRendererPty('pty-mob')
+    await runtime.handleMobileSubscribe('pty-mob', 'client-1')
+    const release = runtime.registerRemoteTerminalViewSubscriber('pty-mob', 'client-1')
+
+    expect(runtime.hasRawTerminalViewSubscriber('pty-mob')).toBe(true)
+    expect(runtime.hasRemoteTerminalViewSubscriber('pty-mob')).toBe(false)
+    runtime.onPtyData('pty-mob', DA1, Date.now())
+    await settle(runtime, 'pty-mob')
+    expect(replies.map((reply) => reply.data)).toEqual(['\x1b[?1;2c'])
+
     await runtime.handleMobileSubscribe('pty-mob', 'client-1', { cols: 40, rows: 20 })
     expect(runtime.hasRemoteTerminalViewSubscriber('pty-mob')).toBe(true)
+    runtime.onPtyData('pty-mob', DA1, Date.now())
+    await settle(runtime, 'pty-mob')
+    expect(replies).toHaveLength(1)
+
+    release()
+    expect(runtime.hasRemoteTerminalViewSubscriber('pty-mob')).toBe(false)
+    runtime.onPtyData('pty-mob', DA1, Date.now())
+    await settle(runtime, 'pty-mob')
+    expect(replies.map((reply) => reply.data)).toEqual(['\x1b[?1;2c', '\x1b[?1;2c'])
   })
 
   it('answers a dropped-chunk query exactly once', async () => {

--- a/src/main/runtime/terminal-subscriber-driven-daemon-attach.test.ts
+++ b/src/main/runtime/terminal-subscriber-driven-daemon-attach.test.ts
@@ -217,7 +217,8 @@ function sendSubscribe(
   harness: ReturnType<typeof startMultiplex>,
   streamId: number,
   terminal: string,
-  clientId = 'client-desktop'
+  clientId = 'client-desktop',
+  clientType: 'desktop' | 'mobile' = 'desktop'
 ): void {
   harness.handlers.get(0)?.(
     decodeTerminalStreamFrame(
@@ -228,7 +229,7 @@ function sendSubscribe(
         payload: encodeTerminalStreamJson({
           streamId,
           terminal,
-          client: { id: clientId, type: 'desktop' }
+          client: { id: clientId, type: clientType }
         })
       })
     )!
@@ -437,6 +438,34 @@ describe('subscriber-driven daemon attach (never-activated tab)', () => {
         false
       )
     )
+    expect(model.emitData(PTY_ID, 'after inventory\r\n')).toBe(true)
+    await vi.waitFor(() => expect(outputText(harness)).toContain('after inventory'))
+  })
+
+  it('retries an unfitted mobile subscriber when provider inventory becomes ready', async () => {
+    // A mobile stream holds no query authority before phone fit, so the attach
+    // retry must key on stream presence rather than reply ownership (#16242).
+    const { runtime, model, handle } = setupNeverAttachedDaemonSession({
+      snapshotCapable: false
+    })
+    model.sessions.delete(PTY_ID)
+    const refuseFirstAttach = model.deferNextAttach(false)
+    const harness = startMultiplex(runtime, 'conn-phone')
+    await vi.waitFor(() => expect(harness.handlers.has(0)).toBe(true))
+
+    sendSubscribe(harness, 1, handle, 'client-phone', 'mobile')
+    await waitForSubscribed(harness, 1)
+    await vi.waitFor(() => expect(model.attachCalls).toEqual([PTY_ID]))
+    expect(runtime.hasRemoteTerminalViewSubscriber(PTY_ID)).toBe(false)
+    expect(runtime.hasRawTerminalViewSubscriber(PTY_ID)).toBe(true)
+
+    model.sessions.set(PTY_ID, { cols: 100, rows: 30, attached: false, screen: '' })
+    await internals(runtime).refreshPtyWorktreeRecordsWithControllerInventory([], null)
+    await internals(runtime).refreshPtyWorktreeRecordsWithControllerInventory([], null)
+    expect([...internals(runtime).subscriberDrivenProviderAttachInventoryWaiters]).toEqual([PTY_ID])
+    refuseFirstAttach()
+
+    await vi.waitFor(() => expect(model.attachCalls).toEqual([PTY_ID, PTY_ID]))
     expect(model.emitData(PTY_ID, 'after inventory\r\n')).toBe(true)
     await vi.waitFor(() => expect(outputText(harness)).toContain('after inventory'))
   })


### PR DESCRIPTION
## ELI5

You open a Claude Code session from your phone. The very first thing Claude does is ask the terminal
a question — how wide are you, where is the cursor — and it will not start until something answers.
Two things in Orca can answer: the host, and your phone's terminal view. Orca used one rule to decide
who is *allowed* to answer, and a different rule to decide when to *silence* the host. Whenever those
two rules disagreed — before your phone's view has finished sizing itself, or after your phone's
connection dropped but before its record expired — the host went quiet and the phone's answer was
rejected. Nobody answered. Claude waited forever, and your new session just sat there.

Both decisions now come from the same rule, so there is always exactly one thing that answers.

## User-facing before / after

| | Before | After |
|---|---|---|
| You start a new Claude session on Orca Mobile, in the moment before the phone's terminal view has sized itself | The session hung indefinitely — Claude was waiting on a startup question nobody was allowed to answer | The host answers and the session starts |
| Your phone's connection drops and returns while its old record is still in its grace window | Same indefinite hang | Same — the host answers |
| Your phone's terminal view is fully connected and sized | Your phone answered | Unchanged |
| You're on an older version of the mobile app | Same hang | Fixed by upgrading the host alone — no app update needed |

## When it bites

Orca Mobile users starting a Claude Code session — reported on mobile app 0.0.44. It is a startup
hang, so it looks like the session simply never begins.

## Summary

- Derive terminal query suppression from the same election that grants reply authority, so the two can never disagree.
- Require a live stream registration for reply authority: a subscriber record with no stream cannot answer, so it must not silence the headless responder either.
- Key provider attach and output delivery on viewer presence rather than reply ownership, so an unfitted mobile stream still ingests daemon output and a lease-only cover still blocks daemon thinning.

## Root cause

The headless model answers terminal queries (DA1, CPR) until a remote xterm view takes over. Suppression and authority were computed from **different state**:

- suppression asked `mobileSubscribers.size > 0`
- authority required `getDriver(ptyId).kind === 'mobile'` **and** a phone-fitted subscriber

Any state where those disagreed — before phone fit, when the driver was not mobile, or when a post-disconnect grace-window record outlived its stream — left main silent *and* every mobile reply rejected by `terminal-send-method.ts`. Nothing answered. Claude Code blocks on its startup query, so a new session hung indefinitely, which is exactly the reported symptom (#16242 / STA-5296).

Making suppression a function of the election closes every one of those states at once.

## Scope

Host-side only. **No wire change** — the subscribe schemas are byte-identical to `main`, and the sole `mobile/` edit is a two-line comment this fix falsified (it described reply ownership as following the subscription). Already-shipped mobile clients (the reporter is on 0.0.44) get this fix from a server upgrade alone, with no app release.

## Compatibility

**Remote wire — Rule 3**, not Rule 1 or 2: no new field and no new opcode, but the host changes *who answers* over an unchanged wire, so it reaches old clients. Each skew case is unchanged or strictly better — an old client pre-fit previously got no answer and now gets main's; post-fit with a live stream is unchanged; an old client whose stream dropped while its record lingered previously got no answer and now gets main's. `cross-version-terminal-wire.unit.test.ts` passes.

**SSH execution boundary.** No `live` / `unverifiable` / `exited` verdict is produced or touched. The election reads this host's own subscription table — a locally-owned fact about its viewers, never an inference about a remote process. Losing a mobile stream moves responder ownership back to main and says nothing about the PTY, which keeps running. Provider attach stays gated on `isKnownUnattachedLocalDaemonPty`, so SSH-scoped sessions remain excluded.

## Terminal reliability

- **Invariant:** every live query has exactly one current responder, including before a mobile view is phone-fitted and while a mobile record sits in its post-disconnect grace window.
- **Oracle:** main answers for unfitted, unstreamed, and non-mobile-driven PTYs; the earliest phone-fitted subscriber holding a live stream is elected; release promotes a survivor or restores main. Ownership is captured synchronously per chunk at ingestion, so a single query can never be answered twice.
- **Providers:** the ownership and write paths are runtime-shared across local, daemon, SSH, and remote-runtime terminals. Deterministic tests cover the shared path; live SSH, WSL, remote-runtime, Android, and multi-device runs remain residual gaps.
- **Performance:** no polling, timers, subprocesses, or output fanout. `hasRemoteTerminalViewSubscriber` runs per output chunk, so the election checks the mobile-stream map first and a PTY with no mobile streams exits on a single lookup — cheaper than the two lookups it replaced.
- **Deliberately not narrowed:** only *reply ownership* changes. Output delivery (`hasRawTerminalViewSubscriber`) and provider attach evaluate to **exactly** their previous values. On `main` a mobile stream incremented the same counter as a desktop stream; splitting mobile streams into their own map means `remote > 0` there is `desktopStreams > 0 || mobileStreams > 0` here, and restoring the `mobileSubscribers` term reconstructs the predicate term-for-term. A differential over all 24 subscriber states confirms both are identical to `main` in 24/24, while `hasRemoteTerminalViewSubscriber` differs in exactly the 8 states where `main` suppressed the responder with nobody able to answer. Pinned by its own test.

## Verification

- Full `src/main/runtime` suite: 474 files, 5586 tests green — this covers every suite an earlier revision of this branch had broken.
- Reliability-gate suites, `cross-version-terminal-wire.unit.test.ts`, `pnpm tc`, `oxlint`, `oxfmt --check`, `check:reliability-gates` (99 gates), `git diff --check`.
- Every changed or added test fails against the pre-fix tree (production files reverted, tests kept): 5 failures, 0 after. Each production hunk was ablated individually; the one uncovered hunk got a new mutation-proved test, and the remaining `cleanupPty` line is documented as unobservable rather than covered by a test that does not discriminate.

## Not verified

Mobile end-to-end is **not** proven: that needs a headless `orca serve` built from this branch paired to a mobile client, which was not stood up. The deterministic ownership, election, and mixed-version tests are the evidence for the branch server's behaviour — not a live run. No live SSH, WSL, remote-runtime, Android, or multi-device run either.

## Merge verdict

Do not merge automatically. Focused on STA-5296; needs a human decision.

