### PR TITLE
Normalize project catalog rows defensively

### DIFF
--- a/src/main/orca-profiles/profile-project-state-file.ts
+++ b/src/main/orca-profiles/profile-project-state-file.ts
@@ -5,6 +5,10 @@ import { dirname } from 'node:path'
 import { getDefaultPersistedState, getDefaultWorkspaceSession } from '../../shared/constants'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import { projectHostSetupProjectionFromRepos } from '../../shared/project-host-setup-projection'
+import {
+  normalizeProjectHostSetupRows,
+  normalizeProjectRows
+} from '../../shared/project-catalog-row-normalization'
 import { carryProjectStateThroughIdentityChange } from '../../shared/project-identity-succession'
 import type { PersistedState } from '../../shared/persisted-state-types'
 import type { Project, ProjectHostSetup } from '../../shared/project-types'
@@ -39,8 +43,12 @@ export function readProfileState(profileId: string, userDataPath: string): Trans
     ...defaults,
     ...parsed,
     repos: arrayOrEmpty<Repo>(parsed.repos),
-    projects: arrayOrEmpty<Project>(parsed.projects),
-    projectHostSetups: arrayOrEmpty<ProjectHostSetup>(parsed.projectHostSetups),
+    // Why normalize: another profile's file is untrusted JSON, and a null repoId/path here would be
+    // carried straight into the importing app's state. Cast — these arrays stay mutably owned.
+    projects: normalizeProjectRows(arrayOrEmpty<Project>(parsed.projects)) as Project[],
+    projectHostSetups: normalizeProjectHostSetupRows(
+      arrayOrEmpty<ProjectHostSetup>(parsed.projectHostSetups)
+    ) as ProjectHostSetup[],
     projectGroups: arrayOrEmpty(parsed.projectGroups),
     folderWorkspaces: arrayOrEmpty(parsed.folderWorkspaces),
     sparsePresetsByRepo: recordOrEmpty<SparsePreset[]>(parsed.sparsePresetsByRepo),

--- a/src/main/orca-profiles/profile-project-state-file.ts
+++ b/src/main/orca-profiles/profile-project-state-file.ts
@@ -3,7 +3,6 @@ import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from '
 import { homedir } from 'node:os'
 import { dirname } from 'node:path'
 import { getDefaultPersistedState, getDefaultWorkspaceSession } from '../../shared/constants'
-import type { ExecutionHostId } from '../../shared/execution-host'
 import { projectHostSetupProjectionFromRepos } from '../../shared/project-host-setup-projection'
 import {
   normalizeProjectHostSetupRows,
@@ -20,16 +19,16 @@ import { getOrcaProfileDataFile } from './profile-index-store'
 
 export type TransferProfileState = PersistedState
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isRecord<T>(value: unknown): value is Record<string, T> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function arrayOrEmpty<T>(value: unknown): T[] {
-  return Array.isArray(value) ? (value as T[]) : []
+  return Array.isArray(value) ? value : []
 }
 
 function recordOrEmpty<T>(value: unknown): Record<string, T> {
-  return isRecord(value) ? (value as Record<string, T>) : {}
+  return isRecord<T>(value) ? value : {}
 }
 
 export function readProfileState(profileId: string, userDataPath: string): TransferProfileState {
@@ -38,7 +37,7 @@ export function readProfileState(profileId: string, userDataPath: string): Trans
   if (!existsSync(dataFile)) {
     return structuredClone(defaults)
   }
-  const parsed = JSON.parse(readFileSync(dataFile, 'utf-8')) as Partial<PersistedState>
+  const parsed: Partial<PersistedState> = JSON.parse(readFileSync(dataFile, 'utf-8'))
   return rebuildRepoBackedProjectState({
     ...defaults,
     ...parsed,
@@ -67,17 +66,15 @@ export function readProfileState(profileId: string, userDataPath: string): Trans
     ui: isRecord(parsed.ui) ? { ...defaults.ui, ...parsed.ui } : defaults.ui,
     githubCache: isRecord(parsed.githubCache)
       ? {
-          pr: recordOrEmpty((parsed.githubCache as PersistedState['githubCache']).pr),
-          issue: recordOrEmpty((parsed.githubCache as PersistedState['githubCache']).issue)
+          pr: recordOrEmpty(parsed.githubCache.pr),
+          issue: recordOrEmpty(parsed.githubCache.issue)
         }
       : defaults.githubCache,
     workspaceSession: isRecord(parsed.workspaceSession)
       ? { ...getDefaultWorkspaceSession(), ...parsed.workspaceSession }
       : defaults.workspaceSession,
-    workspaceSessionsByHostId: isRecord(parsed.workspaceSessionsByHostId)
-      ? (parsed.workspaceSessionsByHostId as Partial<
-          Record<ExecutionHostId, WorkspaceSessionState>
-        >)
+    workspaceSessionsByHostId: isRecord<WorkspaceSessionState>(parsed.workspaceSessionsByHostId)
+      ? parsed.workspaceSessionsByHostId
       : {},
     sshTargets: arrayOrEmpty(parsed.sshTargets),
     sshRemotePtyLeases: arrayOrEmpty(parsed.sshRemotePtyLeases),

--- a/src/main/orca-profiles/profile-project-state-file.ts
+++ b/src/main/orca-profiles/profile-project-state-file.ts
@@ -44,11 +44,11 @@ export function readProfileState(profileId: string, userDataPath: string): Trans
     ...parsed,
     repos: arrayOrEmpty<Repo>(parsed.repos),
     // Why normalize: another profile's file is untrusted JSON, and a null repoId/path here would be
-    // carried straight into the importing app's state. Cast — these arrays stay mutably owned.
-    projects: normalizeProjectRows(arrayOrEmpty<Project>(parsed.projects)) as Project[],
+    // carried straight into the importing app's state.
+    projects: normalizeProjectRows(arrayOrEmpty<Project>(parsed.projects)),
     projectHostSetups: normalizeProjectHostSetupRows(
       arrayOrEmpty<ProjectHostSetup>(parsed.projectHostSetups)
-    ) as ProjectHostSetup[],
+    ),
     projectGroups: arrayOrEmpty(parsed.projectGroups),
     folderWorkspaces: arrayOrEmpty(parsed.folderWorkspaces),
     sparsePresetsByRepo: recordOrEmpty<SparsePreset[]>(parsed.sparsePresetsByRepo),

--- a/src/main/persistence/loading-store/normalize-loaded-profile-state.ts
+++ b/src/main/persistence/loading-store/normalize-loaded-profile-state.ts
@@ -21,7 +21,8 @@ import { normalizeLoadedUiState } from './normalize-loaded-ui-state'
 import {
   normalizeLoadedAutomationRuns,
   normalizeLoadedHostSessions,
-  normalizeLoadedLocalSession
+  normalizeLoadedLocalSession,
+  normalizeLoadedProjectCatalog
 } from './normalize-loaded-state-collections'
 import { normalizeRetiredNameRegistryMap } from './retired-name-registry-normalization'
 
@@ -33,6 +34,7 @@ export function normalizeLoadedProfileState(
 ): PersistedState {
   const { defaults, migratedExternalVisibility, osc52ClipboardNoticePending } = terminal
   const { normalizedOnboarding, normalizedProjectGroups, loadedCompactWorktreeCards } = profile
+  const projectCatalog = normalizeLoadedProjectCatalog(parsed, markNeedsSave)
 
   return {
     ...defaults,
@@ -42,6 +44,9 @@ export function normalizeLoadedProfileState(
     ),
     projectGroups: normalizedProjectGroups,
     repos: migratedExternalVisibility.repos,
+    // Why: persisted catalog rows are untrusted JSON; consumers call string methods on fields the type says are strings.
+    projects: projectCatalog.projects,
+    projectHostSetups: projectCatalog.projectHostSetups,
     folderWorkspaces: normalizeFolderWorkspaces(parsed.folderWorkspaces, normalizedProjectGroups),
     folderWorkspaceDiffComments: normalizeFolderWorkspaceDiffComments(
       parsed.folderWorkspaceDiffComments

--- a/src/main/persistence/loading-store/normalize-loaded-project-catalog.test.ts
+++ b/src/main/persistence/loading-store/normalize-loaded-project-catalog.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import { normalizeLoadedProjectCatalog } from './normalize-loaded-state-collections'
+
+function makeParsed(setups: unknown[], projects: unknown[] = []): PersistedState {
+  return { projects, projectHostSetups: setups } as unknown as PersistedState
+}
+
+const badSetup = {
+  id: 'setup-1',
+  projectId: 'project-1',
+  hostId: 'local',
+  repoId: null,
+  path: null,
+  displayName: 'orca',
+  setupState: 'ready',
+  setupMethod: 'legacy-repo',
+  createdAt: 1,
+  updatedAt: 1
+}
+
+describe('normalizeLoadedProjectCatalog', () => {
+  it('repairs stored rows whose field types do not match the declared ones', () => {
+    const result = normalizeLoadedProjectCatalog(makeParsed([{ ...badSetup }]), vi.fn())
+    expect(result.projectHostSetups[0]?.repoId).toBe('')
+    expect(result.projectHostSetups[0]?.path).toBe('')
+  })
+
+  // Why: without a save the bad rows stay on disk, get repaired again every launch, and this
+  // host keeps publishing them to paired clients. Marking dirty is the migration.
+  it('marks the profile dirty so the repair is persisted', () => {
+    const markNeedsSave = vi.fn()
+    normalizeLoadedProjectCatalog(makeParsed([{ ...badSetup }]), markNeedsSave)
+    expect(markNeedsSave).toHaveBeenCalled()
+  })
+
+  it('leaves a conforming catalog untouched and does not schedule a save', () => {
+    const markNeedsSave = vi.fn()
+    const setups = [{ ...badSetup, repoId: 'repo-1', path: '/repo' }]
+    const parsed = makeParsed(setups)
+    const result = normalizeLoadedProjectCatalog(parsed, markNeedsSave)
+    expect(result.projectHostSetups).toBe(setups)
+    expect(markNeedsSave).not.toHaveBeenCalled()
+  })
+
+  it('tolerates missing or non-array collections', () => {
+    const result = normalizeLoadedProjectCatalog({} as PersistedState, vi.fn())
+    expect(result.projects).toEqual([])
+    expect(result.projectHostSetups).toEqual([])
+  })
+})

--- a/src/main/persistence/loading-store/normalize-loaded-project-catalog.test.ts
+++ b/src/main/persistence/loading-store/normalize-loaded-project-catalog.test.ts
@@ -1,27 +1,43 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { Project, ProjectHostSetup } from '../../../shared/project-types'
 import { normalizeLoadedProjectCatalog } from './normalize-loaded-state-collections'
 
-function makeParsed(setups: unknown[], projects: unknown[] = []): PersistedState {
-  return { projects, projectHostSetups: setups } as unknown as PersistedState
+// Why Reflect.set and not a cast: these rows deliberately violate their declared types, which is
+// exactly what a stale on-disk catalog does.
+function corrupt<T extends object>(row: T, overrides: Record<string, unknown>): T {
+  for (const [key, value] of Object.entries(overrides)) {
+    Reflect.set(row, key, value)
+  }
+  return row
 }
 
-const badSetup = {
-  id: 'setup-1',
-  projectId: 'project-1',
-  hostId: 'local',
-  repoId: null,
-  path: null,
-  displayName: 'orca',
-  setupState: 'ready',
-  setupMethod: 'legacy-repo',
-  createdAt: 1,
-  updatedAt: 1
+function makeParsed(
+  setups: ProjectHostSetup[],
+  projects: Project[] = []
+): Partial<Pick<PersistedState, 'projects' | 'projectHostSetups'>> {
+  return { projects, projectHostSetups: setups }
+}
+
+function makeBadSetup(): ProjectHostSetup {
+  const setup: ProjectHostSetup = {
+    id: 'setup-1',
+    projectId: 'project-1',
+    hostId: 'local',
+    repoId: 'repo-1',
+    path: '/Users/alice/orca',
+    displayName: 'orca',
+    setupState: 'ready',
+    setupMethod: 'legacy-repo',
+    createdAt: 1,
+    updatedAt: 1
+  }
+  return corrupt(setup, { repoId: null, path: null })
 }
 
 describe('normalizeLoadedProjectCatalog', () => {
   it('repairs stored rows whose field types do not match the declared ones', () => {
-    const result = normalizeLoadedProjectCatalog(makeParsed([{ ...badSetup }]), vi.fn())
+    const result = normalizeLoadedProjectCatalog(makeParsed([makeBadSetup()]), vi.fn())
     expect(result.projectHostSetups[0]?.repoId).toBe('')
     expect(result.projectHostSetups[0]?.path).toBe('')
   })
@@ -30,13 +46,13 @@ describe('normalizeLoadedProjectCatalog', () => {
   // host keeps publishing them to paired clients. Marking dirty is the migration.
   it('marks the profile dirty so the repair is persisted', () => {
     const markNeedsSave = vi.fn()
-    normalizeLoadedProjectCatalog(makeParsed([{ ...badSetup }]), markNeedsSave)
+    normalizeLoadedProjectCatalog(makeParsed([makeBadSetup()]), markNeedsSave)
     expect(markNeedsSave).toHaveBeenCalled()
   })
 
   it('leaves a conforming catalog untouched and does not schedule a save', () => {
     const markNeedsSave = vi.fn()
-    const setups = [{ ...badSetup, repoId: 'repo-1', path: '/repo' }]
+    const setups = [{ ...makeBadSetup(), repoId: 'repo-1', path: '/repo' }]
     const parsed = makeParsed(setups)
     const result = normalizeLoadedProjectCatalog(parsed, markNeedsSave)
     expect(result.projectHostSetups).toBe(setups)

--- a/src/main/persistence/loading-store/normalize-loaded-project-catalog.test.ts
+++ b/src/main/persistence/loading-store/normalize-loaded-project-catalog.test.ts
@@ -60,7 +60,7 @@ describe('normalizeLoadedProjectCatalog', () => {
   })
 
   it('tolerates missing or non-array collections', () => {
-    const result = normalizeLoadedProjectCatalog({} as PersistedState, vi.fn())
+    const result = normalizeLoadedProjectCatalog({}, vi.fn())
     expect(result.projects).toEqual([])
     expect(result.projectHostSetups).toEqual([])
   })

--- a/src/main/persistence/loading-store/normalize-loaded-state-collections.ts
+++ b/src/main/persistence/loading-store/normalize-loaded-state-collections.ts
@@ -1,4 +1,8 @@
 import type { PersistedState } from '../../../shared/persisted-state-types'
+import {
+  normalizeProjectHostSetupRows,
+  normalizeProjectRows
+} from '../../../shared/project-catalog-row-normalization'
 import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
 import { parseWorkspaceSessionSalvaging } from '../../../shared/workspace-session-salvage'
 import {
@@ -63,4 +67,27 @@ export function normalizeLoadedAutomationRuns(
     markNeedsSave()
   }
   return runs
+}
+
+/**
+ * Repairs project/setup rows whose stored field types do not match the declared ones — a null
+ * `repoId` or `path` written by an older build reaches every consumer that calls `.trim()` on it.
+ * Marking dirty is the migration: without a save the bad rows stay on disk and are repaired again
+ * every launch, and this host keeps publishing them to paired clients over the wire.
+ */
+export function normalizeLoadedProjectCatalog(
+  parsed: PersistedState,
+  markNeedsSave: () => void
+): Pick<PersistedState, 'projects' | 'projectHostSetups'> {
+  const projects = normalizeProjectRows(parsed.projects ?? [])
+  const projectHostSetups = normalizeProjectHostSetupRows(parsed.projectHostSetups ?? [])
+  if (projects !== parsed.projects || projectHostSetups !== parsed.projectHostSetups) {
+    markNeedsSave()
+  }
+  // Cast: persisted catalog rows are owned mutably by the store; the normalizer is identity-preserving
+  // and hands back either the input array or a fresh one, never a frozen view.
+  return {
+    projects: projects as PersistedState['projects'],
+    projectHostSetups: projectHostSetups as PersistedState['projectHostSetups']
+  }
 }

--- a/src/main/persistence/loading-store/normalize-loaded-state-collections.ts
+++ b/src/main/persistence/loading-store/normalize-loaded-state-collections.ts
@@ -76,7 +76,7 @@ export function normalizeLoadedAutomationRuns(
  * every launch, and this host keeps publishing them to paired clients over the wire.
  */
 export function normalizeLoadedProjectCatalog(
-  parsed: PersistedState,
+  parsed: Partial<Pick<PersistedState, 'projects' | 'projectHostSetups'>>,
   markNeedsSave: () => void
 ): Pick<PersistedState, 'projects' | 'projectHostSetups'> {
   const projects = normalizeProjectRows(parsed.projects ?? [])
@@ -84,10 +84,5 @@ export function normalizeLoadedProjectCatalog(
   if (projects !== parsed.projects || projectHostSetups !== parsed.projectHostSetups) {
     markNeedsSave()
   }
-  // Cast: persisted catalog rows are owned mutably by the store; the normalizer is identity-preserving
-  // and hands back either the input array or a fresh one, never a frozen view.
-  return {
-    projects: projects as PersistedState['projects'],
-    projectHostSetups: projectHostSetups as PersistedState['projectHostSetups']
-  }
+  return { projects, projectHostSetups }
 }

--- a/src/renderer/src/store/projects/project-catalog-null-field-ingest.test.ts
+++ b/src/renderer/src/store/projects/project-catalog-null-field-ingest.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Project, ProjectHostSetup } from '../../../../shared/project-types'
+import type { Repo } from '../../../../shared/repo-types'
+import { getProjectHostSetupProjectionFromState } from '../project-host-setup-selector'
+import { fetchProjectHostSetupCompatibility, setupWithFetchedOwner } from './project-host-routing'
+
+// Crash 3bcc5be3 (v1.4.188, Linux, page.settings boundary): a setup row whose repoId arrived
+// null reached Settings' projectByRepoId useMemo and threw "Cannot read properties of null
+// (reading 'trim')". Normalizing at ingest is what must make that unreachable — by the time a
+// row is in the store, its declared field types hold.
+const repos = [
+  { id: 'repo-1', path: '/Users/alice/orca', displayName: 'orca', badgeColor: '#000', addedAt: 1 }
+] as unknown as Repo[]
+
+const projects = [
+  {
+    id: 'repo:repo-1',
+    displayName: 'orca',
+    badgeColor: '#000',
+    sourceRepoIds: ['repo-1'],
+    createdAt: 1,
+    updatedAt: 1
+  }
+] as unknown as Project[]
+
+// Mirrors the Settings.tsx projectByRepoId useMemo that crashed.
+function buildProjectByRepoIdLikeSettings(
+  setups: readonly ProjectHostSetup[],
+  projectList: readonly Project[]
+): Map<string, Project> {
+  const projectById = new Map(projectList.map((project) => [project.id, project]))
+  const byRepoId = new Map<string, Project>()
+  for (const setup of setups) {
+    const project = projectById.get(setup.projectId)
+    if (project && setup.repoId.trim()) {
+      byRepoId.set(setup.repoId, project)
+    }
+  }
+  return byRepoId
+}
+
+// Mirrors project-grouping.ts's checkout identity, which runs on the sidebar render path.
+function checkoutIdentityLikeSidebar(setup: ProjectHostSetup): string {
+  return setup.path.trim() || setup.repoId || setup.id
+}
+
+function badSetups(): unknown[] {
+  return [
+    {
+      id: 'repo:repo-1::local',
+      projectId: 'repo:repo-1',
+      hostId: 'local',
+      repoId: 'repo-1',
+      path: '/Users/alice/orca',
+      displayName: 'orca',
+      setupState: 'ready',
+      setupMethod: 'legacy-repo',
+      createdAt: 1,
+      updatedAt: 1
+    },
+    {
+      id: 'repo:repo-1::local::2',
+      projectId: 'repo:repo-1',
+      hostId: 'local',
+      repoId: null,
+      path: null,
+      displayName: 'orca-2',
+      setupState: 'ready',
+      setupMethod: 'legacy-repo',
+      createdAt: 1,
+      updatedAt: 1
+    }
+  ]
+}
+
+function stubProjectsApi(setups: unknown[], projectRows: unknown[] = projects): void {
+  vi.stubGlobal('window', {
+    api: {
+      projects: {
+        list: vi.fn().mockResolvedValue(projectRows),
+        listHostSetups: vi.fn().mockResolvedValue(setups)
+      }
+    }
+  })
+}
+
+describe('project catalog ingest with non-string row fields', () => {
+  it('coerces a null repoId and path on the local IPC boundary', async () => {
+    stubProjectsApi(badSetups())
+    const projection = await fetchProjectHostSetupCompatibility({ kind: 'local' }, repos)
+    const row = projection.setups.find((setup) => setup.id === 'repo:repo-1::local::2')
+    expect(row?.repoId).toBe('')
+    expect(row?.path).toBe('')
+  })
+
+  // Why: a remote host on a different Orca version is a first-class source of these rows, and
+  // decoders hand them over verbatim — the client cannot assume the host already repaired them.
+  it('coerces on the remote adoption boundary too', () => {
+    const adopted = setupWithFetchedOwner(badSetups()[1] as ProjectHostSetup, {
+      kind: 'environment',
+      environmentId: 'env-1'
+    })
+    expect(adopted.repoId).toBe('')
+    expect(adopted.path).toBe('')
+    expect(adopted.hostId).toBe('runtime:env-1')
+  })
+
+  it('lets the Settings projectByRepoId memo run instead of throwing on .trim()', async () => {
+    stubProjectsApi(badSetups())
+    const ingested = await fetchProjectHostSetupCompatibility({ kind: 'local' }, repos)
+    const projection = getProjectHostSetupProjectionFromState({
+      repos,
+      projects: [...ingested.projects],
+      projectHostSetups: [...ingested.setups]
+    })
+    expect(() =>
+      buildProjectByRepoIdLikeSettings(projection.setups, projection.projects)
+    ).not.toThrow()
+    // Why: an empty repoId is not an openable repo row, so it must not be indexed.
+    const byRepoId = buildProjectByRepoIdLikeSettings(projection.setups, projection.projects)
+    expect(byRepoId.has('')).toBe(false)
+    expect([...byRepoId.keys()]).toEqual(['repo-1'])
+  })
+
+  // Why: a null path takes down the whole main window rather than one error boundary, because
+  // the sidebar grouping index is built on every render.
+  it('lets the sidebar checkout identity run instead of throwing on a null path', async () => {
+    stubProjectsApi(badSetups())
+    const ingested = await fetchProjectHostSetupCompatibility({ kind: 'local' }, repos)
+    expect(() => ingested.setups.map(checkoutIdentityLikeSidebar)).not.toThrow()
+  })
+
+  // Why: a coerced field must change one value, never which rows exist.
+  it('does not add or drop rows because a field was repaired', async () => {
+    stubProjectsApi(badSetups())
+    const repaired = await fetchProjectHostSetupCompatibility({ kind: 'local' }, repos)
+    const clean = badSetups()
+    ;(clean[1] as { repoId: string; path: string }).repoId = ''
+    ;(clean[1] as { repoId: string; path: string }).path = ''
+    stubProjectsApi(clean)
+    const untouched = await fetchProjectHostSetupCompatibility({ kind: 'local' }, repos)
+    expect(repaired.setups.map((setup) => setup.id)).toEqual(
+      untouched.setups.map((setup) => setup.id)
+    )
+    expect(repaired.projects.map((project) => project.id)).toEqual(
+      untouched.projects.map((project) => project.id)
+    )
+  })
+
+  // Why: this is a zustand selector compared with Object.is, so instability is a re-render storm.
+  it('keeps the projection reference-stable per (repos, projects, setups) input', async () => {
+    stubProjectsApi(badSetups())
+    const ingested = await fetchProjectHostSetupCompatibility({ kind: 'local' }, repos)
+    const args = {
+      repos,
+      projects: [...ingested.projects],
+      projectHostSetups: [...ingested.setups]
+    }
+    expect(getProjectHostSetupProjectionFromState(args)).toBe(
+      getProjectHostSetupProjectionFromState(args)
+    )
+  })
+
+  // Why: nothing else in the ingest path allocates, so a clean catalog must hand back the very
+  // rows it was given — TerminalPane and TabBarQuickCommandsButton use them as useMemo deps.
+  it('preserves row identity when the catalog is already clean', async () => {
+    const clean = badSetups()
+    ;(clean[1] as { repoId: string; path: string }).repoId = ''
+    ;(clean[1] as { repoId: string; path: string }).path = ''
+    stubProjectsApi(clean)
+    const projection = await fetchProjectHostSetupCompatibility({ kind: 'local' }, repos)
+    expect(projection.setups[0]).toBe(clean[0])
+    expect(projection.setups[1]).toBe(clean[1])
+  })
+})

--- a/src/renderer/src/store/projects/project-catalog-null-field-ingest.test.ts
+++ b/src/renderer/src/store/projects/project-catalog-null-field-ingest.test.ts
@@ -10,7 +10,7 @@ import { fetchProjectHostSetupCompatibility, setupWithFetchedOwner } from './pro
 // row is in the store, its declared field types hold.
 const repos = [
   { id: 'repo-1', path: '/Users/alice/orca', displayName: 'orca', badgeColor: '#000', addedAt: 1 }
-] as unknown as Repo[]
+] satisfies Repo[]
 
 const projects = [
   {
@@ -21,7 +21,7 @@ const projects = [
     createdAt: 1,
     updatedAt: 1
   }
-] as unknown as Project[]
+] satisfies Project[]
 
 // Mirrors the Settings.tsx projectByRepoId useMemo that crashed.
 function buildProjectByRepoIdLikeSettings(
@@ -44,36 +44,28 @@ function checkoutIdentityLikeSidebar(setup: ProjectHostSetup): string {
   return setup.path.trim() || setup.repoId || setup.id
 }
 
-function badSetups(): unknown[] {
-  return [
-    {
-      id: 'repo:repo-1::local',
-      projectId: 'repo:repo-1',
-      hostId: 'local',
-      repoId: 'repo-1',
-      path: '/Users/alice/orca',
-      displayName: 'orca',
-      setupState: 'ready',
-      setupMethod: 'legacy-repo',
-      createdAt: 1,
-      updatedAt: 1
-    },
-    {
-      id: 'repo:repo-1::local::2',
-      projectId: 'repo:repo-1',
-      hostId: 'local',
-      repoId: null,
-      path: null,
-      displayName: 'orca-2',
-      setupState: 'ready',
-      setupMethod: 'legacy-repo',
-      createdAt: 1,
-      updatedAt: 1
-    }
-  ]
+// Why Reflect.set and not a cast: the second row deliberately violates its declared types, which
+// is exactly what an older host publishes over the wire.
+function badSetups(): ProjectHostSetup[] {
+  const base = (id: string, displayName: string): ProjectHostSetup => ({
+    id,
+    projectId: 'repo:repo-1',
+    hostId: 'local',
+    repoId: 'repo-1',
+    path: '/Users/alice/orca',
+    displayName,
+    setupState: 'ready',
+    setupMethod: 'legacy-repo',
+    createdAt: 1,
+    updatedAt: 1
+  })
+  const corrupted = base('repo:repo-1::local::2', 'orca-2')
+  Reflect.set(corrupted, 'repoId', null)
+  Reflect.set(corrupted, 'path', null)
+  return [base('repo:repo-1::local', 'orca'), corrupted]
 }
 
-function stubProjectsApi(setups: unknown[], projectRows: unknown[] = projects): void {
+function stubProjectsApi(setups: ProjectHostSetup[], projectRows: Project[] = projects): void {
   vi.stubGlobal('window', {
     api: {
       projects: {
@@ -96,7 +88,7 @@ describe('project catalog ingest with non-string row fields', () => {
   // Why: a remote host on a different Orca version is a first-class source of these rows, and
   // decoders hand them over verbatim — the client cannot assume the host already repaired them.
   it('coerces on the remote adoption boundary too', () => {
-    const adopted = setupWithFetchedOwner(badSetups()[1] as ProjectHostSetup, {
+    const adopted = setupWithFetchedOwner(badSetups()[1]!, {
       kind: 'environment',
       environmentId: 'env-1'
     })

--- a/src/renderer/src/store/projects/project-host-routing.ts
+++ b/src/renderer/src/store/projects/project-host-routing.ts
@@ -78,8 +78,8 @@ function normalizeProjectCatalogProjection(
   projection: ProjectHostSetupProjection
 ): ProjectHostSetupProjection {
   return {
-    projects: normalizeProjectRows(projection.projects),
-    setups: normalizeProjectHostSetupRows(projection.setups)
+    projects: normalizeProjectRows([...projection.projects]),
+    setups: normalizeProjectHostSetupRows([...projection.setups])
   }
 }
 
@@ -129,7 +129,7 @@ export async function fetchProjectHostSetupCompatibility(
     return {
       // Why projects too: the same wire response carries them, and a remote host on another
       // Orca version can publish a row whose declared field types do not hold.
-      projects: normalizeProjectRows(projectResponse.projects),
+      projects: normalizeProjectRows([...projectResponse.projects]),
       setups: setupResponse.setups.map((setup) => setupWithFetchedOwner(setup, target))
     }
   } catch {

--- a/src/renderer/src/store/projects/project-host-routing.ts
+++ b/src/renderer/src/store/projects/project-host-routing.ts
@@ -10,6 +10,11 @@ import {
   type ProjectHostSetupProjection
 } from '../../../../shared/project-host-setup-projection'
 import {
+  normalizeProjectHostSetupRow,
+  normalizeProjectHostSetupRows,
+  normalizeProjectRows
+} from '../../../../shared/project-catalog-row-normalization'
+import {
   PROJECT_HOST_SETUP_RUNTIME_CAPABILITY,
   WORKSPACE_RUN_CONTEXT_RUNTIME_CAPABILITY
 } from '../../../../shared/protocol-version'
@@ -51,18 +56,30 @@ export function setupWithFetchedOwner(
   setup: ProjectHostSetup,
   target: RuntimeClientTarget
 ): ProjectHostSetup {
+  // Why here: every setup row crossing IPC or RPC into the renderer passes through this
+  // adoption step, so it is where the declared field types stop being aspirational.
+  const adopted = normalizeProjectHostSetupRow(setup)
   const hostId = getRuntimeTargetHostId(target)
   if (target.kind !== 'environment') {
-    return setup
+    return adopted
   }
-  const executionHostId = setup.executionHostId ?? setup.hostId
+  const executionHostId = adopted.executionHostId ?? adopted.hostId
   return {
-    ...setup,
+    ...adopted,
     hostId,
     executionHostId: executionHostId === LOCAL_EXECUTION_HOST_ID ? hostId : executionHostId,
     runtimeOwnerEnvironmentId: target.environmentId,
     // Why: paired clients route through the HUB and must not treat its private SSH target as client-local configuration.
     connectionId: null
+  }
+}
+
+function normalizeProjectCatalogProjection(
+  projection: ProjectHostSetupProjection
+): ProjectHostSetupProjection {
+  return {
+    projects: normalizeProjectRows(projection.projects),
+    setups: normalizeProjectHostSetupRows(projection.setups)
   }
 }
 
@@ -95,10 +112,10 @@ export async function fetchProjectHostSetupCompatibility(
       if (!projectsApi?.list || !projectsApi.listHostSetups) {
         throw new Error('projects_api_unavailable')
       }
-      return {
+      return normalizeProjectCatalogProjection({
         projects: await projectsApi.list(),
         setups: await projectsApi.listHostSetups()
-      }
+      })
     }
     await assertProjectHostSetupRuntimeCapability(target)
     const [projectResponse, setupResponse] = await Promise.all([
@@ -110,7 +127,9 @@ export async function fetchProjectHostSetupCompatibility(
       })
     ])
     return {
-      projects: projectResponse.projects,
+      // Why projects too: the same wire response carries them, and a remote host on another
+      // Orca version can publish a row whose declared field types do not hold.
+      projects: normalizeProjectRows(projectResponse.projects),
       setups: setupResponse.setups.map((setup) => setupWithFetchedOwner(setup, target))
     }
   } catch {

--- a/src/renderer/src/store/projects/project-host-setup-actions.ts
+++ b/src/renderer/src/store/projects/project-host-setup-actions.ts
@@ -16,6 +16,7 @@ import { getRepoExecutionHostId, parseExecutionHostId } from '../../../../shared
 import type { RepoSlice } from '../repos/repo-state'
 import { ERROR_TOAST_DURATION } from '../repos/repo-state'
 import { repoWithFetchedOwner } from '../repos/owner-routing'
+import { normalizeProjectRow } from '../../../../shared/project-catalog-row-normalization'
 import {
   assertProjectHostSetupMutationRuntimeCapabilities,
   getProjectSetupRuntimeTarget,
@@ -57,6 +58,7 @@ export function createProjectHostSetupActions(
         const repo = repoWithFetchedOwner(result.repo, target)
         const repoHostId = getRepoExecutionHostId(repo)
         const setup = setupWithFetchedOwner(result.setup, target)
+        const project = normalizeProjectRow(result.project)
         set((s) => {
           const nextRepos = s.repos.some((entry) =>
             repoMatchesHostIdentity(entry, repo.id, repoHostId)
@@ -65,9 +67,9 @@ export function createProjectHostSetupActions(
                 repoMatchesHostIdentity(entry, repo.id, repoHostId) ? repo : entry
               )
             : [...s.repos, repo]
-          const nextProjects = s.projects.some((entry) => entry.id === result.project.id)
-            ? s.projects.map((entry) => (entry.id === result.project.id ? result.project : entry))
-            : [...s.projects, result.project]
+          const nextProjects = s.projects.some((entry) => entry.id === project.id)
+            ? s.projects.map((entry) => (entry.id === project.id ? project : entry))
+            : [...s.projects, project]
           const nextSetups = s.projectHostSetups.some((entry) => entry.id === setup.id)
             ? s.projectHostSetups.map((entry) => (entry.id === setup.id ? setup : entry))
             : [...s.projectHostSetups, setup]
@@ -80,7 +82,7 @@ export function createProjectHostSetupActions(
         toast.success(translate('auto.store.slices.repos.8bb3ad7935', 'Project added'), {
           description: repo.displayName
         })
-        return { ...result, repo, setup }
+        return { ...result, project, repo, setup }
       } catch (err) {
         console.error('Failed to set up project on host:', err)
         const message = err instanceof Error ? err.message : String(err)
@@ -108,15 +110,16 @@ export function createProjectHostSetupActions(
                 )
               ).result
         const setup = setupWithFetchedOwner(result.setup, target)
+        const project = normalizeProjectRow(result.project)
         set((s) => ({
-          projects: s.projects.some((entry) => entry.id === result.project.id)
-            ? s.projects.map((entry) => (entry.id === result.project.id ? result.project : entry))
-            : [...s.projects, result.project],
+          projects: s.projects.some((entry) => entry.id === project.id)
+            ? s.projects.map((entry) => (entry.id === project.id ? project : entry))
+            : [...s.projects, project],
           projectHostSetups: s.projectHostSetups.some((entry) => entry.id === setup.id)
             ? s.projectHostSetups.map((entry) => (entry.id === setup.id ? setup : entry))
             : [...s.projectHostSetups, setup]
         }))
-        return { project: result.project, setup }
+        return { project, setup }
       } catch (err) {
         console.error('Failed to create project host setup:', err)
         const message = err instanceof Error ? err.message : String(err)
@@ -147,6 +150,7 @@ export function createProjectHostSetupActions(
                 )
               ).result
         const setup = setupWithFetchedOwner(result.setup, target)
+        const project = normalizeProjectRow(result.project)
         const repo = result.repo ? repoWithFetchedOwner(result.repo, target) : undefined
         const repoHostId = repo ? getRepoExecutionHostId(repo) : null
         set((s) => ({
@@ -157,14 +161,14 @@ export function createProjectHostSetupActions(
                 )
               : [...s.repos, repo]
             : s.repos,
-          projects: s.projects.some((entry) => entry.id === result.project.id)
-            ? s.projects.map((entry) => (entry.id === result.project.id ? result.project : entry))
-            : [...s.projects, result.project],
+          projects: s.projects.some((entry) => entry.id === project.id)
+            ? s.projects.map((entry) => (entry.id === project.id ? project : entry))
+            : [...s.projects, project],
           projectHostSetups: s.projectHostSetups.some((entry) => entry.id === setup.id)
             ? s.projectHostSetups.map((entry) => (entry.id === setup.id ? setup : entry))
             : [...s.projectHostSetups, setup]
         }))
-        return { ...result, repo, setup }
+        return { ...result, project, repo, setup }
       } catch (err) {
         console.error('Failed to update project host setup:', err)
         const message = err instanceof Error ? err.message : String(err)

--- a/src/renderer/src/store/projects/project-update.ts
+++ b/src/renderer/src/store/projects/project-update.ts
@@ -6,6 +6,7 @@ import { notifyInstalledAgentSkillsChanged } from '@/hooks/installed-agent-skill
 import type { RepoSlice } from '../repos/repo-state'
 import { getProjectUpdateRuntimeTarget } from './project-host-routing'
 import { mergeUpdatedProjectCompatibilityProject } from './project-compatibility-core'
+import { normalizeProjectRow } from '../../../../shared/project-catalog-row-normalization'
 
 export function createProjectUpdateActions(
   set: Parameters<StateCreator<AppState>>[0],
@@ -29,11 +30,13 @@ export function createProjectUpdateActions(
         if (!updatedProject) {
           return false
         }
+        // Why: the merge spreads updatedProject.sourceRepoIds, which throws if the host sent a non-array.
+        const normalizedProject = normalizeProjectRow(updatedProject)
         const runtimePreferenceChanged = 'localWindowsRuntimePreference' in updates
         set((state) => ({
           projects: state.projects.map((project) =>
             project.id === projectId
-              ? mergeUpdatedProjectCompatibilityProject(project, updatedProject, updates)
+              ? mergeUpdatedProjectCompatibilityProject(project, normalizedProject, updates)
               : project
           ),
           folderWorkspacePathStatuses: {}

--- a/src/shared/project-catalog-row-normalization.test.ts
+++ b/src/shared/project-catalog-row-normalization.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+import type { Project, ProjectHostSetup } from './project-types'
+import {
+  normalizeProjectHostSetupRow,
+  normalizeProjectHostSetupRows,
+  normalizeProjectRow,
+  normalizeProjectRows
+} from './project-catalog-row-normalization'
+
+function makeSetup(overrides: Record<string, unknown> = {}): ProjectHostSetup {
+  return {
+    id: 'setup-1',
+    projectId: 'project-1',
+    hostId: 'local',
+    repoId: 'repo-1',
+    path: '/Users/alice/orca',
+    displayName: 'orca',
+    setupState: 'ready',
+    setupMethod: 'legacy-repo',
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides
+  } as unknown as ProjectHostSetup
+}
+
+function makeProject(overrides: Record<string, unknown> = {}): Project {
+  return {
+    id: 'project-1',
+    displayName: 'Project',
+    badgeColor: '#737373',
+    sourceRepoIds: ['repo-1'],
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides
+  } as unknown as Project
+}
+
+describe('normalizeProjectHostSetupRow', () => {
+  it('returns the input reference when every declared type already holds', () => {
+    const setup = makeSetup()
+    expect(normalizeProjectHostSetupRow(setup)).toBe(setup)
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42],
+    ['an object', {}]
+  ])('coerces a %s repoId to an empty string', (_label, repoId) => {
+    expect(normalizeProjectHostSetupRow(makeSetup({ repoId })).repoId).toBe('')
+  })
+
+  // Why path: `project-grouping.ts` calls `.trim()` and `parseWslUncPath()` on it during
+  // sidebar render, so the same bad row takes down the main window, not one error boundary.
+  it.each([
+    ['null', null],
+    ['a number', 7]
+  ])('coerces a %s path to an empty string', (_label, path) => {
+    expect(normalizeProjectHostSetupRow(makeSetup({ path })).path).toBe('')
+  })
+
+  it('coerces every other required string field', () => {
+    const normalized = normalizeProjectHostSetupRow(
+      makeSetup({ id: null, projectId: null, displayName: null })
+    )
+    expect(normalized.id).toBe('')
+    expect(normalized.projectId).toBe('')
+    expect(normalized.displayName).toBe('')
+  })
+
+  it('falls back to the local host id for a non-string hostId', () => {
+    expect(normalizeProjectHostSetupRow(makeSetup({ hostId: null })).hostId).toBe('local')
+  })
+
+  // Why 0: the catalog merge already reads 0 as "unknown", so it degrades instead of
+  // restamping a fake timestamp that would win min()/max() against a real one.
+  it.each([
+    ['null', null],
+    ['NaN', Number.NaN],
+    ['a string', '5']
+  ])('coerces a %s timestamp to 0', (_label, value) => {
+    const normalized = normalizeProjectHostSetupRow(
+      makeSetup({ createdAt: value, updatedAt: value })
+    )
+    expect(normalized.createdAt).toBe(0)
+    expect(normalized.updatedAt).toBe(0)
+  })
+
+  // Why: these are only ever compared, never string-method'd — inventing a fallback would
+  // silently change what a corrupt row claims about itself.
+  it('leaves the setupState and setupMethod unions untouched', () => {
+    const normalized = normalizeProjectHostSetupRow(
+      makeSetup({ repoId: null, setupState: 'bogus', setupMethod: null })
+    )
+    expect(normalized.setupState).toBe('bogus')
+    expect(normalized.setupMethod).toBeNull()
+  })
+
+  // Why: `mergeProjectCompatibilityProject` and the setup projection branch on `in` /
+  // `!== undefined`, so materialising an absent optional key changes merge behaviour.
+  it('never adds or removes an optional key', () => {
+    const withoutOptionals = normalizeProjectHostSetupRow(makeSetup({ repoId: null }))
+    expect('connectionId' in withoutOptionals).toBe(false)
+    expect('worktreeBasePath' in withoutOptionals).toBe(false)
+    const withOptionals = normalizeProjectHostSetupRow(
+      makeSetup({ repoId: null, connectionId: null, worktreeBasePath: '/base' })
+    )
+    expect('connectionId' in withOptionals).toBe(true)
+    expect(withOptionals.worktreeBasePath).toBe('/base')
+  })
+})
+
+describe('normalizeProjectRow', () => {
+  it('returns the input reference when every declared type already holds', () => {
+    const project = makeProject()
+    expect(normalizeProjectRow(project)).toBe(project)
+  })
+
+  // Why: the compatibility merge spreads `sourceRepoIds`, which throws on a non-array.
+  it.each([
+    ['null', null, []],
+    ['a string', 'repo-1', []],
+    ['an array with holes', ['repo-1', null, 3], ['repo-1']]
+  ])('repairs a %s sourceRepoIds', (_label, sourceRepoIds, expected) => {
+    expect(normalizeProjectRow(makeProject({ sourceRepoIds })).sourceRepoIds).toEqual(expected)
+  })
+
+  it('coerces the required string fields', () => {
+    const normalized = normalizeProjectRow(
+      makeProject({ id: null, displayName: null, badgeColor: 42 })
+    )
+    expect(normalized.id).toBe('')
+    expect(normalized.displayName).toBe('')
+    expect(normalized.badgeColor).toBe('')
+  })
+
+  // Why: `'localWindowsRuntimePreference' in overlay` decides whether a preference clear wins.
+  it('never materialises an absent localWindowsRuntimePreference', () => {
+    const normalized = normalizeProjectRow(makeProject({ id: null }))
+    expect('localWindowsRuntimePreference' in normalized).toBe(false)
+  })
+})
+
+describe('row array normalization', () => {
+  it('returns the input array when nothing needed repair', () => {
+    const setups = [makeSetup(), makeSetup({ id: 'setup-2' })]
+    expect(normalizeProjectHostSetupRows(setups)).toBe(setups)
+    const projects = [makeProject()]
+    expect(normalizeProjectRows(projects)).toBe(projects)
+  })
+
+  // Why: TerminalPane and TabBarQuickCommandsButton use these arrays as useMemo deps, so an
+  // untouched row must keep its object identity across normalization.
+  it('reuses untouched rows and only reallocates the repaired one', () => {
+    const setups = [
+      makeSetup(),
+      makeSetup({ id: 'setup-2', repoId: null }),
+      makeSetup({ id: 's3' })
+    ]
+    const normalized = normalizeProjectHostSetupRows(setups)
+    expect(normalized).not.toBe(setups)
+    expect(normalized[0]).toBe(setups[0])
+    expect(normalized[1]).not.toBe(setups[1])
+    expect(normalized[2]).toBe(setups[2])
+  })
+
+  // Why: coercing a field must change one value, never which rows exist — setting a "changed"
+  // flag on the old selector normalizer unioned in repo-derived rows and invented phantom rows.
+  it('preserves row count and order', () => {
+    const setups = [makeSetup({ repoId: null }), makeSetup({ id: 'setup-2' })]
+    expect(normalizeProjectHostSetupRows(setups).map((setup) => setup.id)).toEqual([
+      'setup-1',
+      'setup-2'
+    ])
+  })
+
+  it('treats a non-array as empty', () => {
+    expect(normalizeProjectHostSetupRows(null as unknown as ProjectHostSetup[])).toEqual([])
+    expect(normalizeProjectRows(null as unknown as Project[])).toEqual([])
+  })
+})

--- a/src/shared/project-catalog-row-normalization.test.ts
+++ b/src/shared/project-catalog-row-normalization.test.ts
@@ -7,8 +7,17 @@ import {
   normalizeProjectRows
 } from './project-catalog-row-normalization'
 
+// Why Reflect.set and not a cast: these fixtures deliberately violate the declared types, which is
+// the whole point — writing the bad value onto a valid row says that outright.
+function corrupt<T extends object>(row: T, overrides: Record<string, unknown>): T {
+  for (const [key, value] of Object.entries(overrides)) {
+    Reflect.set(row, key, value)
+  }
+  return row
+}
+
 function makeSetup(overrides: Record<string, unknown> = {}): ProjectHostSetup {
-  return {
+  const setup: ProjectHostSetup = {
     id: 'setup-1',
     projectId: 'project-1',
     hostId: 'local',
@@ -18,21 +27,21 @@ function makeSetup(overrides: Record<string, unknown> = {}): ProjectHostSetup {
     setupState: 'ready',
     setupMethod: 'legacy-repo',
     createdAt: 1,
-    updatedAt: 2,
-    ...overrides
-  } as unknown as ProjectHostSetup
+    updatedAt: 2
+  }
+  return corrupt(setup, overrides)
 }
 
 function makeProject(overrides: Record<string, unknown> = {}): Project {
-  return {
+  const project: Project = {
     id: 'project-1',
     displayName: 'Project',
     badgeColor: '#737373',
     sourceRepoIds: ['repo-1'],
     createdAt: 1,
-    updatedAt: 2,
-    ...overrides
-  } as unknown as Project
+    updatedAt: 2
+  }
+  return corrupt(project, overrides)
 }
 
 describe('normalizeProjectHostSetupRow', () => {
@@ -175,7 +184,10 @@ describe('row array normalization', () => {
   })
 
   it('treats a non-array as empty', () => {
-    expect(normalizeProjectHostSetupRows(null as unknown as ProjectHostSetup[])).toEqual([])
-    expect(normalizeProjectRows(null as unknown as Project[])).toEqual([])
+    // Why JSON.parse: a persisted catalog really can hold a non-array here, and parsing is how it
+    // arrives — the parameter type cannot express it.
+    const notAnArray: never[] = JSON.parse('null')
+    expect(normalizeProjectHostSetupRows(notAnArray)).toEqual([])
+    expect(normalizeProjectRows(notAnArray)).toEqual([])
   })
 })

--- a/src/shared/project-catalog-row-normalization.test.ts
+++ b/src/shared/project-catalog-row-normalization.test.ts
@@ -151,6 +151,20 @@ describe('normalizeProjectRow', () => {
 })
 
 describe('row array normalization', () => {
+  it('repairs null rows without throwing', () => {
+    const setups = [null] as unknown as ProjectHostSetup[]
+    const projects = [null] as unknown as Project[]
+    expect(normalizeProjectHostSetupRows(setups)[0]).toMatchObject({
+      id: '',
+      repoId: '',
+      path: ''
+    })
+    expect(normalizeProjectRows(projects)[0]).toMatchObject({
+      id: '',
+      sourceRepoIds: []
+    })
+  })
+
   it('returns the input array when nothing needed repair', () => {
     const setups = [makeSetup(), makeSetup({ id: 'setup-2' })]
     expect(normalizeProjectHostSetupRows(setups)).toBe(setups)

--- a/src/shared/project-catalog-row-normalization.ts
+++ b/src/shared/project-catalog-row-normalization.ts
@@ -79,7 +79,7 @@ export function normalizeProjectRow(project: Project): Project {
   }
 }
 
-function normalizeRows<T>(rows: readonly T[], normalize: (row: T) => T): readonly T[] {
+function normalizeRows<T>(rows: T[], normalize: (row: T) => T): T[] {
   if (!Array.isArray(rows)) {
     return []
   }
@@ -95,12 +95,10 @@ function normalizeRows<T>(rows: readonly T[], normalize: (row: T) => T): readonl
   return repaired ?? rows
 }
 
-export function normalizeProjectHostSetupRows(
-  setups: readonly ProjectHostSetup[]
-): readonly ProjectHostSetup[] {
+export function normalizeProjectHostSetupRows(setups: ProjectHostSetup[]): ProjectHostSetup[] {
   return normalizeRows(setups, normalizeProjectHostSetupRow)
 }
 
-export function normalizeProjectRows(projects: readonly Project[]): readonly Project[] {
+export function normalizeProjectRows(projects: Project[]): Project[] {
   return normalizeRows(projects, normalizeProjectRow)
 }

--- a/src/shared/project-catalog-row-normalization.ts
+++ b/src/shared/project-catalog-row-normalization.ts
@@ -18,64 +18,83 @@ import type { Project, ProjectHostSetup } from './project-types'
  * would silently change what a corrupt row claims about itself.
  */
 
-function isString(value: unknown): boolean {
+function isString(value: unknown): value is string {
   return typeof value === 'string'
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 // Why 0 and not now(): the catalog merge already reads 0 as "timestamp unknown", not as the epoch.
-function isTimestamp(value: unknown): boolean {
+function isTimestamp(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value)
 }
 
+function stringValue(value: unknown, fallback = ''): string {
+  return isString(value) ? value : fallback
+}
+
+function timestampValue(value: unknown): number {
+  return isTimestamp(value) ? value : 0
+}
+
 export function normalizeProjectHostSetupRow(setup: ProjectHostSetup): ProjectHostSetup {
+  const row: Record<string, unknown> = isRecord(setup) ? setup : {}
   const needsRepair =
-    !isString(setup.id) ||
-    !isString(setup.projectId) ||
-    !isString(setup.hostId) ||
-    !isString(setup.repoId) ||
-    !isString(setup.path) ||
-    !isString(setup.displayName) ||
-    !isTimestamp(setup.createdAt) ||
-    !isTimestamp(setup.updatedAt)
+    !isString(row.id) ||
+    !isString(row.projectId) ||
+    !isString(row.hostId) ||
+    !isString(row.repoId) ||
+    !isString(row.path) ||
+    !isString(row.displayName) ||
+    !isTimestamp(row.createdAt) ||
+    !isTimestamp(row.updatedAt)
   if (!needsRepair) {
     return setup
   }
   return {
-    ...setup,
-    id: isString(setup.id) ? setup.id : '',
-    projectId: isString(setup.projectId) ? setup.projectId : '',
-    hostId: isString(setup.hostId) ? setup.hostId : LOCAL_EXECUTION_HOST_ID,
-    repoId: isString(setup.repoId) ? setup.repoId : '',
-    path: isString(setup.path) ? setup.path : '',
-    displayName: isString(setup.displayName) ? setup.displayName : '',
-    createdAt: isTimestamp(setup.createdAt) ? setup.createdAt : 0,
-    updatedAt: isTimestamp(setup.updatedAt) ? setup.updatedAt : 0
+    ...row,
+    id: stringValue(row.id),
+    projectId: stringValue(row.projectId),
+    hostId: stringValue(row.hostId, LOCAL_EXECUTION_HOST_ID) as ProjectHostSetup['hostId'],
+    repoId: stringValue(row.repoId),
+    path: stringValue(row.path),
+    displayName: stringValue(row.displayName),
+    setupState: (row.setupState === undefined
+      ? 'error'
+      : row.setupState) as ProjectHostSetup['setupState'],
+    setupMethod: (row.setupMethod === undefined
+      ? 'legacy-repo'
+      : row.setupMethod) as ProjectHostSetup['setupMethod'],
+    createdAt: timestampValue(row.createdAt),
+    updatedAt: timestampValue(row.updatedAt)
   }
 }
 
 export function normalizeProjectRow(project: Project): Project {
-  const sourceRepoIdsConform =
-    Array.isArray(project.sourceRepoIds) && project.sourceRepoIds.every(isString)
+  const row: Record<string, unknown> = isRecord(project) ? project : {}
+  const sourceRepoIdsConform = Array.isArray(row.sourceRepoIds) && row.sourceRepoIds.every(isString)
   const needsRepair =
-    !isString(project.id) ||
-    !isString(project.displayName) ||
-    !isString(project.badgeColor) ||
+    !isString(row.id) ||
+    !isString(row.displayName) ||
+    !isString(row.badgeColor) ||
     !sourceRepoIdsConform ||
-    !isTimestamp(project.createdAt) ||
-    !isTimestamp(project.updatedAt)
+    !isTimestamp(row.createdAt) ||
+    !isTimestamp(row.updatedAt)
   if (!needsRepair) {
     return project
   }
   return {
-    ...project,
-    id: isString(project.id) ? project.id : '',
-    displayName: isString(project.displayName) ? project.displayName : '',
-    badgeColor: isString(project.badgeColor) ? project.badgeColor : '',
-    sourceRepoIds: Array.isArray(project.sourceRepoIds)
-      ? project.sourceRepoIds.filter((repoId): repoId is string => isString(repoId))
+    ...row,
+    id: stringValue(row.id),
+    displayName: stringValue(row.displayName),
+    badgeColor: stringValue(row.badgeColor),
+    sourceRepoIds: Array.isArray(row.sourceRepoIds)
+      ? row.sourceRepoIds.filter((repoId): repoId is string => isString(repoId))
       : [],
-    createdAt: isTimestamp(project.createdAt) ? project.createdAt : 0,
-    updatedAt: isTimestamp(project.updatedAt) ? project.updatedAt : 0
+    createdAt: timestampValue(row.createdAt),
+    updatedAt: timestampValue(row.updatedAt)
   }
 }
 

--- a/src/shared/project-catalog-row-normalization.ts
+++ b/src/shared/project-catalog-row-normalization.ts
@@ -1,0 +1,106 @@
+import { LOCAL_EXECUTION_HOST_ID } from './execution-host'
+import type { Project, ProjectHostSetup } from './project-types'
+
+/**
+ * Repairs untrusted `Project` / `ProjectHostSetup` rows so their declared field types are true.
+ *
+ * These rows reach typed code from persisted JSON and from remote Orca hosts running a different
+ * version, where a field the type promises is a `string` can arrive `null`, missing, or another
+ * type entirely — while consumers call `.trim()` on it unconditionally (crash 3bcc5be3). Call
+ * these at every boundary such a row enters the app, so nothing downstream has to re-guard.
+ *
+ * Coercion only. A normalizer never drops a row, never adds or removes an optional key, and
+ * returns its input reference untouched when it already conforms — callers keep row and array
+ * identity, which selectors and `useMemo` deps depend on.
+ *
+ * The string-literal unions (`setupState`, `setupMethod`) are deliberately left alone: they are
+ * only ever compared, so an unknown value degrades instead of crashing, and inventing a fallback
+ * would silently change what a corrupt row claims about itself.
+ */
+
+function isString(value: unknown): boolean {
+  return typeof value === 'string'
+}
+
+// Why 0 and not now(): the catalog merge already reads 0 as "timestamp unknown", not as the epoch.
+function isTimestamp(value: unknown): boolean {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+export function normalizeProjectHostSetupRow(setup: ProjectHostSetup): ProjectHostSetup {
+  const needsRepair =
+    !isString(setup.id) ||
+    !isString(setup.projectId) ||
+    !isString(setup.hostId) ||
+    !isString(setup.repoId) ||
+    !isString(setup.path) ||
+    !isString(setup.displayName) ||
+    !isTimestamp(setup.createdAt) ||
+    !isTimestamp(setup.updatedAt)
+  if (!needsRepair) {
+    return setup
+  }
+  return {
+    ...setup,
+    id: isString(setup.id) ? setup.id : '',
+    projectId: isString(setup.projectId) ? setup.projectId : '',
+    hostId: isString(setup.hostId) ? setup.hostId : LOCAL_EXECUTION_HOST_ID,
+    repoId: isString(setup.repoId) ? setup.repoId : '',
+    path: isString(setup.path) ? setup.path : '',
+    displayName: isString(setup.displayName) ? setup.displayName : '',
+    createdAt: isTimestamp(setup.createdAt) ? setup.createdAt : 0,
+    updatedAt: isTimestamp(setup.updatedAt) ? setup.updatedAt : 0
+  }
+}
+
+export function normalizeProjectRow(project: Project): Project {
+  const sourceRepoIdsConform =
+    Array.isArray(project.sourceRepoIds) && project.sourceRepoIds.every(isString)
+  const needsRepair =
+    !isString(project.id) ||
+    !isString(project.displayName) ||
+    !isString(project.badgeColor) ||
+    !sourceRepoIdsConform ||
+    !isTimestamp(project.createdAt) ||
+    !isTimestamp(project.updatedAt)
+  if (!needsRepair) {
+    return project
+  }
+  return {
+    ...project,
+    id: isString(project.id) ? project.id : '',
+    displayName: isString(project.displayName) ? project.displayName : '',
+    badgeColor: isString(project.badgeColor) ? project.badgeColor : '',
+    sourceRepoIds: Array.isArray(project.sourceRepoIds)
+      ? project.sourceRepoIds.filter((repoId): repoId is string => isString(repoId))
+      : [],
+    createdAt: isTimestamp(project.createdAt) ? project.createdAt : 0,
+    updatedAt: isTimestamp(project.updatedAt) ? project.updatedAt : 0
+  }
+}
+
+function normalizeRows<T>(rows: readonly T[], normalize: (row: T) => T): readonly T[] {
+  if (!Array.isArray(rows)) {
+    return []
+  }
+  let repaired: T[] | null = null
+  for (let index = 0; index < rows.length; index += 1) {
+    const row = rows[index]!
+    const normalized = normalize(row)
+    if (normalized !== row && !repaired) {
+      repaired = rows.slice(0, index)
+    }
+    repaired?.push(normalized)
+  }
+  return repaired ?? rows
+}
+
+export function normalizeProjectHostSetupRows(
+  setups: readonly ProjectHostSetup[]
+): readonly ProjectHostSetup[] {
+  return normalizeRows(setups, normalizeProjectHostSetupRow)
+}
+
+export function normalizeProjectRows(projects: readonly Project[]): readonly Project[] {
+  return normalizeRows(projects, normalizeProjectRow)
+}

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -1,4 +1,8 @@
 import { getRepoExecutionHostId } from './execution-host'
+import {
+  normalizeProjectHostSetupRow,
+  normalizeProjectRow
+} from './project-catalog-row-normalization'
 import { normalizeGitHubRemoteHost } from './git-remote-host-alias'
 import { githubRepoIdentityKey, isDefaultGitHubHost } from './github/repository-identity-key'
 import type { Project, ProjectHostSetup, ProjectProviderIdentity } from './project-types'
@@ -312,7 +316,9 @@ export function projectHostSetupProjectionFromRepos(
     const project = existing
       ? mergeProjectRepo(existing.project, repo)
       : createProjectFromRepo(repo)
-    const setup = createSetupFromRepo(repo, projectId)
+    // Why normalize here: a repo row is untrusted persisted/wire data too, and these
+    // constructors copy repo.path / repo.id straight onto fields consumers call .trim() on.
+    const setup = normalizeProjectHostSetupRow(createSetupFromRepo(repo, projectId))
     projectById.set(projectId, {
       project
     })
@@ -320,7 +326,7 @@ export function projectHostSetupProjectionFromRepos(
   }
 
   return {
-    projects: [...projectById.values()].map((entry) => entry.project),
+    projects: [...projectById.values()].map((entry) => normalizeProjectRow(entry.project)),
     setups
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​441 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​441 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​222 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​35 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​187 |

<!-- /orca-pr-loc -->

## Problem

Project catalog rows from persisted JSON files or remote Orca hosts can have fields with null or wrong-typed values. Downstream code assumes fields like `repoId` and `path` are strings and calls `.trim()` on them unconditionally, crashing when they arrive as `null` (crash 3bcc5be3: v1.4.188 Settings page).

## Solution

Added normalization functions that coerce field types to their declarations at every row entry point: profile load, IPC/RPC boundaries, action results, and projection building. Non-string required fields default to empty strings; non-numeric timestamps to 0; non-array sourceRepoIds to empty arrays. Returns unchanged row reference if already valid, preserving identity for useMemo dependencies. Marks profiles dirty when repairs occur so fixes persist to disk.