### PR TITLE
Allow drag to reorder tabs on floating workspace

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tab-lifecycle.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tab-lifecycle.test.tsx
@@ -499,3 +499,29 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(mocks.closeTab).not.toHaveBeenCalledWith('tab-c')
   })
 })
+
+describe('FloatingTerminalPanel tab drag wiring', () => {
+  beforeEach(setupFloatingTerminalPanelTest)
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('hosts the tab strip in a drag context so floating tabs can be reordered', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' }), makeTab({ id: 'tab-2' })])
+
+    const element = await renderPanel(true)
+    const dragContext = findByTypeName(element, 'FloatingWorkspaceTabDragContext')
+
+    expect(dragContext.props.enabled).toBe(true)
+    expect(findByTypeName(dragContext.props.children, 'TabBar')).toBeDefined()
+  })
+
+  it('leaves the drag context inactive while the closed panel stays mounted', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+
+    const element = await renderPanel(false)
+
+    expect(findByTypeName(element, 'FloatingWorkspaceTabDragContext').props.enabled).toBe(false)
+  })
+})

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -90,6 +90,8 @@ import type { Tab } from '../../../../shared/tab-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import { resolveUnifiedTabLabel } from '../../../../shared/tab-title-resolution'
 import { FloatingBrowserSlot } from './FloatingBrowserSlot'
+import { FloatingWorkspaceTabDragContext } from './FloatingWorkspaceTabDragContext'
+import { isFloatingTerminalDragTarget } from './floating-terminal-titlebar-drag-target'
 import { FloatingTerminalOrchestrationDialog } from './FloatingTerminalOrchestrationDialog'
 import { FloatingTerminalResizeHandles } from './FloatingTerminalResizeHandles'
 import { FloatingTerminalWindowControls } from './FloatingTerminalWindowControls'
@@ -153,18 +155,12 @@ type FloatingPanelShortcutResolution =
   | { kind: 'index'; index: number }
   | { kind: 'chrome'; action: KeybindingActionId }
 
-const FLOATING_TERMINAL_NO_DRAG_SELECTOR =
-  'button,input,textarea,select,[role="menuitem"],[data-testid="sortable-tab"],[data-floating-terminal-no-drag]'
 const FLOATING_TERMINAL_SHORTCUT_SURFACE_SELECTOR = '[data-floating-terminal-shortcut-surface]'
 
 type FloatingTerminalPanelBoundsState = {
   committedBounds: FloatingTerminalPanelCommittedBounds
   renderedBounds: FloatingTerminalPanelBounds
   source: FloatingTerminalPanelBoundsSource
-}
-
-function isFloatingTerminalDragTarget(target: EventTarget): boolean {
-  return !(target instanceof HTMLElement && target.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR))
 }
 
 function readInitialPanelBounds(): FloatingTerminalPanelBoundsState {
@@ -1825,7 +1821,7 @@ export function FloatingTerminalPanel({
           onPointerCancel={handleDragEnd}
           onDoubleClick={handleTitlebarDoubleClick}
         >
-          <div className="flex h-full min-w-0 flex-1">
+          <FloatingWorkspaceTabDragContext enabled={open}>
             <TabBar
               tabs={terminalItems}
               activeTabId={activeTerminalId}
@@ -1874,7 +1870,7 @@ export function FloatingTerminalPanel({
               tabBarOrder={tabBarOrder}
               tabStripChrome="floating-panel"
             />
-          </div>
+          </FloatingWorkspaceTabDragContext>
           <FloatingTerminalWindowControls
             maximized={maximized}
             onToggleMaximized={toggleMaximized}

--- a/src/renderer/src/components/floating-terminal/FloatingWorkspaceTabDragContext.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingWorkspaceTabDragContext.tsx
@@ -1,0 +1,49 @@
+import { cloneElement } from 'react'
+import { DndContext, DragOverlay } from '@dnd-kit/core'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import TabDragPreview from '../tab-bar/TabDragPreview'
+import { TabDragProvider } from '../tab-group/tab-drag-context'
+import { useTabDragSplit, type HoveredTabInsertion } from '../tab-group/useTabDragSplit'
+
+/** dnd-kit host for the floating workspace tab strip, so its tabs reorder with
+ *  the same gesture and insertion bar the main workspace tab bar uses. The panel
+ *  renders one group and no split layout, so a drop only ever resolves to a
+ *  same-group reorder — the pane-column split branches find no panel geometry. */
+export function FloatingWorkspaceTabDragContext({
+  enabled,
+  children
+}: {
+  /** False while the panel is hidden: a closed panel must not register sensors that compete with the workspace DndContext. */
+  enabled: boolean
+  children: React.ReactElement<{ hoveredTabInsertion?: HoveredTabInsertion | null }>
+}): React.JSX.Element {
+  const dragSplit = useTabDragSplit({ worktreeId: FLOATING_TERMINAL_WORKTREE_ID, enabled })
+
+  return (
+    <TabDragProvider
+      isTabDragActive={dragSplit.activeDrag !== null}
+      isTabDragActiveRef={dragSplit.isTabDragActiveRef}
+    >
+      <DndContext
+        sensors={dragSplit.sensors}
+        collisionDetection={dragSplit.collisionDetection}
+        onDragStart={dragSplit.onDragStart}
+        onDragMove={dragSplit.onDragMove}
+        onDragOver={dragSplit.onDragOver}
+        onDragEnd={dragSplit.onDragEnd}
+        onDragCancel={dragSplit.onDragCancel}
+        // Why: same feedback loop the workspace strip hits — autoscroll shifts tabs under a still cursor and `over` re-resolves.
+        autoScroll={false}
+      >
+        <div ref={dragSplit.setDragRootNode} className="flex h-full min-w-0 flex-1">
+          {/* Why cloneElement over a render prop: the tab bar stays a plain child element, which keeps the panel's tree shallow-walkable. */}
+          {cloneElement(children, { hoveredTabInsertion: dragSplit.hoveredTabInsertion })}
+        </div>
+        {/* Why: the source tab stays anchored in the overflow-hidden strip; this ghost is what follows the cursor. */}
+        <DragOverlay dropAnimation={null}>
+          {dragSplit.activeDrag ? <TabDragPreview drag={dragSplit.activeDrag} /> : null}
+        </DragOverlay>
+      </DndContext>
+    </TabDragProvider>
+  )
+}

--- a/src/renderer/src/components/floating-terminal/floating-terminal-titlebar-drag-target.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-titlebar-drag-target.ts
@@ -1,0 +1,9 @@
+/** Interactive chrome living inside the draggable titlebar. `[data-tab-id]` covers
+ *  every tab kind (terminal, browser, editor, simulator, client-hosted row): a press
+ *  on a tab starts a dnd-kit reorder, so it must never also move the panel. */
+const FLOATING_TERMINAL_NO_DRAG_SELECTOR =
+  'button,input,textarea,select,[role="menuitem"],[data-tab-id],[data-floating-terminal-no-drag]'
+
+export function isFloatingTerminalDragTarget(target: EventTarget): boolean {
+  return !(target instanceof HTMLElement && target.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR))
+}

--- a/src/renderer/src/components/floating-terminal/floating-terminal-titlebar-drag-target.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-titlebar-drag-target.ts
@@ -5,5 +5,9 @@ const FLOATING_TERMINAL_NO_DRAG_SELECTOR =
   'button,input,textarea,select,[role="menuitem"],[data-tab-id],[data-client-hosted-browser-row-id],[data-floating-terminal-no-drag]'
 
 export function isFloatingTerminalDragTarget(target: EventTarget): boolean {
-  return !(target instanceof Element && target.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR))
+  if (typeof Element === 'undefined' || !(target instanceof Element)) {
+    return true
+  }
+
+  return target.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR) === null
 }

--- a/src/renderer/src/components/floating-terminal/floating-terminal-titlebar-drag-target.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-titlebar-drag-target.ts
@@ -1,9 +1,9 @@
-/** Interactive chrome living inside the draggable titlebar. `[data-tab-id]` covers
- *  every tab kind (terminal, browser, editor, simulator, client-hosted row): a press
+/** Interactive chrome living inside the draggable titlebar. `[data-tab-id]` and the
+ *  client-hosted row marker cover every tab kind: a press
  *  on a tab starts a dnd-kit reorder, so it must never also move the panel. */
 const FLOATING_TERMINAL_NO_DRAG_SELECTOR =
-  'button,input,textarea,select,[role="menuitem"],[data-tab-id],[data-floating-terminal-no-drag]'
+  'button,input,textarea,select,[role="menuitem"],[data-tab-id],[data-client-hosted-browser-row-id],[data-floating-terminal-no-drag]'
 
 export function isFloatingTerminalDragTarget(target: EventTarget): boolean {
-  return !(target instanceof HTMLElement && target.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR))
+  return !(target instanceof Element && target.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR))
 }

--- a/src/renderer/src/components/floating-terminal/floating-workspace-tab-reorder.test.ts
+++ b/src/renderer/src/components/floating-terminal/floating-workspace-tab-reorder.test.ts
@@ -172,7 +172,7 @@ describe('floating workspace tab reorder', () => {
 })
 
 describe('floating panel titlebar drag target', () => {
-  it.each(['sortable-tab', 'browser-tab', 'editor-tab'])(
+  it.each(['sortable-tab', 'browser-tab', 'editor-tab', 'client-hosted-browser-row-id'])(
     'does not move the panel when the press lands on a %s',
     (kind) => {
       const tab = document.createElement('div')
@@ -185,6 +185,16 @@ describe('floating panel titlebar drag target', () => {
       expect(isFloatingTerminalDragTarget(label)).toBe(false)
     }
   )
+
+  it('does not move the panel when a tab SVG icon receives the press', () => {
+    const tab = document.createElement('div')
+    tab.dataset.tabId = 'terminal-tab'
+    const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    tab.appendChild(icon)
+    document.body.appendChild(tab)
+
+    expect(isFloatingTerminalDragTarget(icon)).toBe(false)
+  })
 
   it('still moves the panel from bare titlebar chrome', () => {
     const titlebar = document.createElement('div')

--- a/src/renderer/src/components/floating-terminal/floating-workspace-tab-reorder.test.ts
+++ b/src/renderer/src/components/floating-terminal/floating-workspace-tab-reorder.test.ts
@@ -1,0 +1,194 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import type { Tab, TabGroup } from '../../../../shared/tab-types'
+import { useAppStore } from '../../store'
+import { useTabDragSplit, type TabDragItemData } from '../tab-group/useTabDragSplit'
+import { isFloatingTerminalDragTarget } from './floating-terminal-titlebar-drag-target'
+
+vi.mock('../browser-pane/host-guest/webview-registry', () => ({
+  acquireWebviewsDragPassthrough: vi.fn(() => vi.fn())
+}))
+
+vi.mock('../../runtime/web-runtime-session', () => ({
+  isWebRuntimeSessionActive: vi.fn(() => false),
+  moveWebRuntimeSessionTab: vi.fn()
+}))
+
+const GROUP_ID = 'floating-group'
+const mounted: { container: HTMLDivElement; root: Root }[] = []
+
+function makeTab(id: string, sortOrder: number): Tab {
+  return {
+    id,
+    groupId: GROUP_ID,
+    worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+    contentType: 'terminal',
+    entityId: `term-${id}`,
+    label: id,
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: sortOrder
+  }
+}
+
+function makeDragData(unifiedTabId: string): TabDragItemData {
+  return {
+    kind: 'tab',
+    worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+    groupId: GROUP_ID,
+    unifiedTabId,
+    visibleTabId: `term-${unifiedTabId}`,
+    tabType: 'terminal',
+    label: unifiedTabId
+  }
+}
+
+function makeDropEvent(
+  activeData: TabDragItemData,
+  overData: TabDragItemData | null,
+  pointerX: number
+) {
+  return {
+    active: { data: { current: activeData }, rect: { current: { initial: null } } },
+    over: overData
+      ? {
+          id: overData.visibleTabId,
+          data: { current: overData },
+          // Tabs sit in a 100px-wide strip slot starting at x=200; midpoint is 250.
+          rect: { left: 200, top: 0, width: 100, height: 32 }
+        }
+      : null,
+    delta: { x: 0, y: 0 },
+    activatorEvent: { clientX: pointerX, clientY: 16 }
+  }
+}
+
+function renderFloatingDragHook(): ReturnType<typeof useTabDragSplit> {
+  let result: ReturnType<typeof useTabDragSplit> | null = null
+  function Probe(): null {
+    result = useTabDragSplit({ worktreeId: FLOATING_TERMINAL_WORKTREE_ID, enabled: true })
+    return null
+  }
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => root.render(createElement(Probe)))
+  mounted.push({ container, root })
+  if (!result) {
+    throw new Error('useTabDragSplit did not render')
+  }
+  return result
+}
+
+function dropTab(from: string, over: string, pointerX: number): void {
+  const drag = renderFloatingDragHook()
+  const activeData = makeDragData(from)
+  act(() => {
+    drag.onDragStart(
+      makeDropEvent(activeData, null, pointerX) as unknown as Parameters<typeof drag.onDragStart>[0]
+    )
+  })
+  act(() => {
+    drag.onDragEnd(
+      makeDropEvent(activeData, makeDragData(over), pointerX) as unknown as Parameters<
+        typeof drag.onDragEnd
+      >[0]
+    )
+  })
+}
+
+function floatingTabOrder(): string[] {
+  const groups: TabGroup[] =
+    useAppStore.getState().groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []
+  return groups.find((group) => group.id === GROUP_ID)?.tabOrder ?? []
+}
+
+beforeEach(() => {
+  useAppStore.setState({
+    // The floating workspace is never the active worktree; its tabs still reorder.
+    activeWorktreeId: 'wt-main',
+    activeGroupIdByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: GROUP_ID },
+    groupsByWorktree: {
+      [FLOATING_TERMINAL_WORKTREE_ID]: [
+        {
+          id: GROUP_ID,
+          worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+          activeTabId: 'tab-a',
+          tabOrder: ['tab-a', 'tab-b', 'tab-c']
+        }
+      ]
+    },
+    unifiedTabsByWorktree: {
+      [FLOATING_TERMINAL_WORKTREE_ID]: [
+        makeTab('tab-a', 0),
+        makeTab('tab-b', 1),
+        makeTab('tab-c', 2)
+      ]
+    },
+    layoutByWorktree: {}
+  })
+})
+
+afterEach(() => {
+  for (const { container, root } of mounted.splice(0)) {
+    act(() => root.unmount())
+    container.remove()
+  }
+  document.body.replaceChildren()
+  vi.clearAllMocks()
+})
+
+describe('floating workspace tab reorder', () => {
+  it('moves a tab after the hovered tab when released on its right half', () => {
+    dropTab('tab-a', 'tab-c', 290)
+    expect(floatingTabOrder()).toEqual(['tab-b', 'tab-c', 'tab-a'])
+  })
+
+  it('moves a tab before the hovered tab when released on its left half', () => {
+    dropTab('tab-c', 'tab-a', 210)
+    expect(floatingTabOrder()).toEqual(['tab-c', 'tab-a', 'tab-b'])
+  })
+
+  it('leaves the order alone when a tab is dropped on itself', () => {
+    dropTab('tab-b', 'tab-b', 290)
+    expect(floatingTabOrder()).toEqual(['tab-a', 'tab-b', 'tab-c'])
+  })
+
+  it('republishes sortOrder so the panel renders the committed order', () => {
+    dropTab('tab-a', 'tab-c', 290)
+    const tabs = useAppStore.getState().unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []
+    expect(tabs.map((tab) => [tab.id, tab.sortOrder])).toEqual([
+      ['tab-a', 2],
+      ['tab-b', 0],
+      ['tab-c', 1]
+    ])
+  })
+})
+
+describe('floating panel titlebar drag target', () => {
+  it.each(['sortable-tab', 'browser-tab', 'editor-tab'])(
+    'does not move the panel when the press lands on a %s',
+    (kind) => {
+      const tab = document.createElement('div')
+      tab.dataset.tabId = kind
+      const label = document.createElement('span')
+      tab.appendChild(label)
+      document.body.appendChild(tab)
+
+      expect(isFloatingTerminalDragTarget(tab)).toBe(false)
+      expect(isFloatingTerminalDragTarget(label)).toBe(false)
+    }
+  )
+
+  it('still moves the panel from bare titlebar chrome', () => {
+    const titlebar = document.createElement('div')
+    document.body.appendChild(titlebar)
+    expect(isFloatingTerminalDragTarget(titlebar)).toBe(true)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​230 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​230 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 |

<!-- /orca-pr-loc -->

## Problem

Floating workspace tabs can't be reordered by dragging, while the main workspace tabs can. This creates an inconsistent experience when users switch between the floating panel and main workspace.

## Solution

Added the same drag-to-reorder infrastructure to the floating tab bar that the main workspace uses. The floating panel now wraps its tab bar in a dnd-kit context that reuses existing tab drag logic (`useTabDragSplit`, `TabDragProvider`, `DragOverlay`), so tabs reorder with the same gesture and insertion bar.

## What Changed

- Added `FloatingWorkspaceTabDragContext` to wrap the floating tab bar in dnd-kit, with drag disabled while the panel is closed to avoid competing with the workspace context
- Extracted `isFloatingTerminalDragTarget` to a separate module and updated its selector to include `[data-tab-id]` (covering all tab kinds: terminal, browser, editor, etc.)
- Updated the panel's titlebar drag logic to use the extracted function
- Added tests for drag context wiring and comprehensive reorder scenarios (move before/after, drop on self, sort order republishing)

## Why

Reusing the existing tab drag infrastructure keeps the floating panel's tree shallow and maintainable, while ensuring consistent behavior across the UI. The drag context disables when the panel closes, preventing sensor conflicts with the workspace context.

## Testing

- [x] Automated tests added: tab drag wiring, reorder logic (before/after/self), sort order updates, and titlebar drag target validation
- Tests cover floating tabs reordering correctly regardless of active worktree

## Checklist

- [x] This PR is small and focused
- [x] Explained what changed and why (including ELI5)
- [x] Before/after: not applicable—drag-to-reorder gesture works same as main workspace
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform impact: no platform-specific code; dnd-kit handles events uniformly
- [x] pnpm tests pass (new test file added)