### PR TITLE
fix(worktrees): route unstamped local worktrees local in the two states #16841 still fails closed

### DIFF
--- a/src/renderer/src/lib/terminal-worktree-route.test.ts
+++ b/src/renderer/src/lib/terminal-worktree-route.test.ts
@@ -99,6 +99,7 @@ describe('resolveTerminalWorktreeRoute', () => {
   // because the worktree owner could not be resolved" reply, so a non-null route here is exactly
   // "that toast cannot fire".
   describe('unstamped local worktrees with a saved runtime (#16733)', () => {
+    /** The single saved runtime is the hazard: it arms the legacy hydration gates while owning nothing here. */
     const unstampedState = (): AppState =>
       localState({
         repos: [{ id: 'repo-1', connectionId: null, executionHostId: null }],

--- a/src/renderer/src/lib/terminal-worktree-route.test.ts
+++ b/src/renderer/src/lib/terminal-worktree-route.test.ts
@@ -4,6 +4,7 @@ import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { brandEphemeralSetupTerminalWorktreeId } from '../../../shared/ephemeral-setup-terminal-worktree-id'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 import {
+  hasUnroutableTerminalWorktreeOwner,
   resolveTerminalHostOwnership,
   resolveTerminalWorktreeRoute
 } from './terminal-worktree-route'
@@ -90,6 +91,31 @@ describe('resolveTerminalWorktreeRoute', () => {
 
   it('does not treat a folder workspace as an unresolved worktree', () => {
     expect(resolveTerminalWorktreeRoute(localState(), folderWorkspaceKey('abc-123'))).not.toBeNull()
+  })
+
+  // #16733: the store a reporter actually has — a real local repo/worktree whose legacy rows were
+  // persisted before owner projection, plus one saved runtime environment. resolveTerminalWorktreeRoute
+  // is the sole gate in front of terminal-request-ipc-bridge.ts's "Terminal creation is unavailable
+  // because the worktree owner could not be resolved" reply, so a non-null route here is exactly
+  // "that toast cannot fire".
+  describe('unstamped local worktrees with a saved runtime (#16733)', () => {
+    const unstampedState = (): AppState =>
+      localState({
+        repos: [{ id: 'repo-1', connectionId: null, executionHostId: null }],
+        worktreesByRepo: { 'repo-1': [{ id: 'repo-1::/w', repoId: 'repo-1' }] },
+        runtimeEnvironments: [{ id: 'some-hub' }]
+      } as unknown as Partial<AppState>)
+
+    it('keeps a terminal routable on a local worktree while an unrelated runtime is saved', () => {
+      expect(resolveTerminalWorktreeRoute(unstampedState(), 'repo-1::/w')).toEqual({
+        runtimeEnvironmentId: null
+      })
+      expect(hasUnroutableTerminalWorktreeOwner(unstampedState(), 'repo-1::/w')).toBe(false)
+    })
+
+    it('still fails a genuinely unknown worktree id closed in that same state', () => {
+      expect(resolveTerminalWorktreeRoute(unstampedState(), 'repo-9::/stale')).toBeNull()
+    })
   })
 })
 

--- a/src/renderer/src/lib/worktree-operation-route.test.ts
+++ b/src/renderer/src/lib/worktree-operation-route.test.ts
@@ -277,12 +277,13 @@ describe('resolveWorktreeOperationRouteResult', () => {
     })
   })
 
-  it('fails ownerless rows closed until the saved-runtime catalog is hydrated', () => {
+  it('fails ownerless rows closed mid-hydration while a saved runtime could own them', () => {
     expect(
       resolveWorktreeOperationRouteResult(
         {
+          settings: { activeRuntimeEnvironmentId: 'hub-b' } as never,
           repos: [{ id: 'repo-1' } as never],
-          runtimeEnvironments: [],
+          runtimeEnvironments: [{ id: 'hub-a' }, { id: 'hub-b' }],
           runtimeEnvironmentCatalogHydrated: false,
           worktreesByRepo: { 'repo-1': [worktree(undefined)] }
         },

--- a/src/renderer/src/lib/worktree-operation-route.test.ts
+++ b/src/renderer/src/lib/worktree-operation-route.test.ts
@@ -278,14 +278,20 @@ describe('resolveWorktreeOperationRouteResult', () => {
   })
 
   it('fails ownerless rows closed mid-hydration while a saved runtime could own them', () => {
+    // Why: no repo row and no active runtime, so neither the unstamped-local branch nor the
+    // focused-runtime gates can decide — the unhydrated saved-runtime catalog is what fails this
+    // closed. Flipping runtimeEnvironmentCatalogHydrated to true routes it local off the detected
+    // row, so do not re-add repos/activeRuntimeEnvironmentId here: either one decides the case
+    // earlier and leaves this branch uncovered.
     expect(
       resolveWorktreeOperationRouteResult(
         {
-          settings: { activeRuntimeEnvironmentId: 'hub-b' } as never,
-          repos: [{ id: 'repo-1' } as never],
           runtimeEnvironments: [{ id: 'hub-a' }, { id: 'hub-b' }],
           runtimeEnvironmentCatalogHydrated: false,
-          worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          worktreesByRepo: { 'repo-1': [worktree(undefined)] },
+          detectedWorktreesByRepo: {
+            'repo-1': { worktrees: [worktree(undefined)] }
+          }
         },
         WORKTREE_ID
       )
@@ -374,7 +380,10 @@ describe('resolveWorktreeOperationRouteResult', () => {
   // #16733: a genuinely local git worktree carries no host stamp on legacy rows. Every stamped
   // row is already routed by resolveExplicitWorktreeOperationRouteResult, so an unstamped repo
   // row reaching the legacy hydration gates is local by construction — the same positive-identity
-  // argument the folder-workspace branch below already makes (#10251/#10269).
+  // argument the folder-workspace branch below already makes (#10251/#10269). The repo row is the
+  // host evidence, but it is not worktree identity on its own: a worktree id no row has ever
+  // listed keeps failing closed, per 'does not treat a repo row alone as positive local
+  // identity' above (#16841).
   describe('local git worktrees without a host stamp (#16733)', () => {
     const LOCAL_ROUTE = {
       kind: 'resolved',
@@ -403,19 +412,6 @@ describe('resolveWorktreeOperationRouteResult', () => {
             runtimeEnvironments: [{ id: 'a' }, { id: 'b' }],
             runtimeEnvironmentCatalogHydrated: true,
             worktreesByRepo: { 'repo-1': [worktree(undefined)] }
-          },
-          WORKTREE_ID
-        )
-      ).toEqual(LOCAL_ROUTE)
-    })
-
-    it('routes a known local repo before its worktree row has been listed', () => {
-      expect(
-        resolveWorktreeOperationRouteResult(
-          {
-            repos: [{ id: 'repo-1' } as never],
-            runtimeEnvironments: [{ id: 'some-hub' }],
-            runtimeEnvironmentCatalogHydrated: true
           },
           WORKTREE_ID
         )

--- a/src/renderer/src/lib/worktree-operation-route.test.ts
+++ b/src/renderer/src/lib/worktree-operation-route.test.ts
@@ -370,6 +370,246 @@ describe('resolveWorktreeOperationRouteResult', () => {
     })
   })
 
+  // #16733: a genuinely local git worktree carries no host stamp on legacy rows. Every stamped
+  // row is already routed by resolveExplicitWorktreeOperationRouteResult, so an unstamped repo
+  // row reaching the legacy hydration gates is local by construction — the same positive-identity
+  // argument the folder-workspace branch below already makes (#10251/#10269).
+  describe('local git worktrees without a host stamp (#16733)', () => {
+    const LOCAL_ROUTE = {
+      kind: 'resolved',
+      route: { executionHostId: 'local', runtimeEnvironmentId: null }
+    }
+
+    it('keeps a local worktree local when an unrelated runtime is saved', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            repos: [{ id: 'repo-1' } as never],
+            runtimeEnvironments: [{ id: 'some-hub' }],
+            runtimeEnvironmentCatalogHydrated: true,
+            worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual(LOCAL_ROUTE)
+    })
+
+    it('keeps a local worktree local when several unrelated runtimes are saved', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            repos: [{ id: 'repo-1' } as never],
+            runtimeEnvironments: [{ id: 'a' }, { id: 'b' }],
+            runtimeEnvironmentCatalogHydrated: true,
+            worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual(LOCAL_ROUTE)
+    })
+
+    it('routes a known local repo before its worktree row has been listed', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            repos: [{ id: 'repo-1' } as never],
+            runtimeEnvironments: [{ id: 'some-hub' }],
+            runtimeEnvironmentCatalogHydrated: true
+          },
+          WORKTREE_ID
+        )
+      ).toEqual(LOCAL_ROUTE)
+    })
+
+    it('keeps a local worktree local while the saved-runtime catalog is still hydrating', () => {
+      // Why: the repo stamp is host evidence, not runtime-environment inference — an unhydrated
+      // runtime catalog cannot turn an unstamped row into a remote one.
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            repos: [{ id: 'repo-1' } as never],
+            runtimeEnvironments: [{ id: 'some-hub' }],
+            runtimeEnvironmentCatalogHydrated: false,
+            worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual(LOCAL_ROUTE)
+    })
+
+    it('keeps a local worktree local after an unrelated runtime has been removed', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            repos: [{ id: 'repo-1' } as never],
+            runtimeEnvironments: [{ id: 'some-hub' }],
+            runtimeEnvironmentCatalogHydrated: true,
+            removedRuntimeEnvironmentIds: new Set(['gone-hub']),
+            worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual(LOCAL_ROUTE)
+    })
+
+    it('still routes a local worktree local when no runtime is saved', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            repos: [{ id: 'repo-1' } as never],
+            runtimeEnvironments: [],
+            runtimeEnvironmentCatalogHydrated: true,
+            worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual(LOCAL_ROUTE)
+    })
+
+    it('still routes a local worktree local for adapters with no runtime catalog at all', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            repos: [{ id: 'repo-1' } as never],
+            worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual(LOCAL_ROUTE)
+    })
+
+    it('never routes a connection-owned repo local when runtimes are saved', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            repos: [{ id: 'repo-1', connectionId: 'ssh-1' } as never],
+            runtimeEnvironments: [{ id: 'some-hub' }],
+            runtimeEnvironmentCatalogHydrated: true,
+            worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual({
+        kind: 'resolved',
+        route: { executionHostId: 'ssh:ssh-1', runtimeEnvironmentId: null }
+      })
+    })
+
+    it('never routes a runtime-stamped repo local when runtimes are saved', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            repos: [{ id: 'repo-1', executionHostId: 'runtime:hub-a' } as never],
+            runtimeEnvironments: [{ id: 'hub-a' }],
+            runtimeEnvironmentCatalogHydrated: true,
+            worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual({
+        kind: 'resolved',
+        route: { executionHostId: 'runtime:hub-a', runtimeEnvironmentId: 'hub-a' }
+      })
+    })
+
+    it('keeps a host-stamped worktree row authoritative over its unstamped repo', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            repos: [{ id: 'repo-1' } as never],
+            runtimeEnvironments: [{ id: 'some-hub' }],
+            runtimeEnvironmentCatalogHydrated: true,
+            worktreesByRepo: { 'repo-1': [worktree('ssh:ssh-1')] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual({
+        kind: 'resolved',
+        route: { executionHostId: 'ssh:ssh-1', runtimeEnvironmentId: null }
+      })
+    })
+
+    it('fails a worktree closed when no repo row and no worktree row know it', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            repos: [{ id: 'other' } as never],
+            runtimeEnvironments: [{ id: 'some-hub' }],
+            runtimeEnvironmentCatalogHydrated: true
+          },
+          WORKTREE_ID
+        )
+      ).toEqual({ kind: 'missing' })
+    })
+
+    it('fails closed when the active runtime is ambiguous', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            settings: { activeRuntimeEnvironmentId: 'hub-b' } as never,
+            repos: [{ id: 'repo-1' } as never],
+            runtimeEnvironments: [{ id: 'hub-a' }, { id: 'hub-b' }],
+            runtimeEnvironmentCatalogHydrated: true,
+            worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual({ kind: 'missing' })
+    })
+
+    it('keeps an unambiguous active runtime authoritative over the local fallback', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            settings: { activeRuntimeEnvironmentId: 'hub-a' } as never,
+            repos: [{ id: 'repo-1' } as never],
+            runtimeEnvironments: [{ id: 'hub-a' }],
+            runtimeEnvironmentCatalogHydrated: true,
+            worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual({
+        kind: 'resolved',
+        route: { executionHostId: 'runtime:hub-a', runtimeEnvironmentId: 'hub-a' }
+      })
+    })
+
+    it('refuses local when a second repo row for the id is connection-owned', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            repos: [{ id: 'repo-1' } as never, { id: 'repo-1', connectionId: 'ssh-1' } as never],
+            runtimeEnvironments: [{ id: 'some-hub' }],
+            runtimeEnvironmentCatalogHydrated: true,
+            worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual({
+        kind: 'resolved',
+        route: { executionHostId: 'ssh:ssh-1', runtimeEnvironmentId: null }
+      })
+    })
+
+    it('reports contradictory repo rows as ambiguous rather than defaulting to local', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            repos: [
+              { id: 'repo-1', executionHostId: 'local' } as never,
+              { id: 'repo-1', executionHostId: 'runtime:hub-a' } as never
+            ],
+            runtimeEnvironments: [{ id: 'some-hub' }],
+            runtimeEnvironmentCatalogHydrated: true,
+            worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual({ kind: 'ambiguous' })
+    })
+  })
+
   describe('active workspace host selection', () => {
     it('keeps the HUB transport when the paired SSH worktree is the active workspace', () => {
       expect(
@@ -550,6 +790,26 @@ describe('resolveWorktreeOperationRouteResult', () => {
       expect(resolveWorktreeOperationRouteResult(state, 'repo-x::/tmp/unknown')).toEqual({
         kind: 'missing'
       })
+    })
+
+    it('routes a folder workspace and a git worktree alike in one local state (#16733)', () => {
+      // Why: #10269 gave folder workspaces the positive-identity carve-out and left git worktrees
+      // behind, so the same store answered `local` for one workspace kind and `missing` for the
+      // other. Both kinds are locally owned here, so both must route locally.
+      const state = {
+        repos: [{ id: 'repo-1' } as never],
+        worktreesByRepo: { 'repo-1': [worktree(undefined)] },
+        folderWorkspaces: [folderWorkspace()],
+        projectGroups: [{ id: 'group-1', connectionId: null, executionHostId: null } as never],
+        runtimeEnvironments: [{ id: 'some-hub' }],
+        runtimeEnvironmentCatalogHydrated: true
+      }
+      const localRoute = {
+        kind: 'resolved',
+        route: { executionHostId: 'local', runtimeEnvironmentId: null }
+      }
+      expect(resolveWorktreeOperationRouteResult(state, FOLDER_KEY)).toEqual(localRoute)
+      expect(resolveWorktreeOperationRouteResult(state, WORKTREE_ID)).toEqual(localRoute)
     })
 
     it('routes a folder workspace to its restored runtime host during catalog hydration', () => {

--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -1,5 +1,10 @@
 import type { AppState } from '@/store/types'
-import { parseExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  parseExecutionHostId,
+  type ExecutionHostId
+} from '../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { getRepoIdFromWorktreeId } from '@/store/slices/worktree-helpers'
 import { resolveExactWorktreeRoute } from './worktree-owner-route'
@@ -220,6 +225,20 @@ export function resolveWorktreeOperationRouteResult(
       }
     }
   }
+  // Why: a found repo/worktree record is positive identity evidence, so keep terminal-owner
+  // parity with the folder branch below. Every stamped row already routed above, so an unstamped
+  // repo row here is a legacy pre-owner-projection row — local by construction, as
+  // getRepoExecutionHostId, main's resolveRepoOwnershipEvidence and Repo.executionHostId's own
+  // contract all agree. Without this, the legacy hydration gates fail a genuinely local git
+  // worktree closed whenever any unrelated runtime is saved — the #10251 symptom, for git
+  // worktrees (#16733). A repo row on its own is repo identity, not worktree identity (#16841),
+  // so a known worktree row — listed or currently detected — must back it.
+  const localOwnerRoute = hasKnownWorktree
+    ? resolveUnstampedLocalWorktreeRoute(state, repoId)
+    : null
+  if (localOwnerRoute) {
+    return { kind: 'resolved', route: localOwnerRoute }
+  }
   // Why: no saved runtime can publish a remote ownerless row; otherwise current detected presence affirms identity under the stamped-writer invariant.
   const mayBeLegacyLocal =
     savedRuntimeIds === undefined ||
@@ -228,6 +247,29 @@ export function resolveWorktreeOperationRouteResult(
   return mayBeLegacyLocal
     ? { kind: 'resolved', route: { executionHostId: 'local', runtimeEnvironmentId: null } }
     : { kind: 'missing' }
+}
+
+/**
+ * A local route for a worktree whose rows predate owner projection, and only that.
+ * `getWorktreeExecutionHostId` is the precedence of record for this decision; it takes a single
+ * repo, so the unanimity every row must satisfy is spelled out here.
+ */
+function resolveUnstampedLocalWorktreeRoute(
+  state: WorktreeOperationRouteState,
+  repoId: string
+): WorktreeOperationRoute | null {
+  const repos = state.repos?.filter((repo) => repo.id === repoId) ?? []
+  // Why: a worktree row alone carries no host evidence; without a repo record keep failing closed.
+  if (repos.length === 0) {
+    return null
+  }
+  // Why: rows that disagree are a contradiction, not a default — refuse, as findExactRepoOwner does.
+  for (const repo of repos) {
+    if (getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID) {
+      return null
+    }
+  }
+  return { executionHostId: LOCAL_EXECUTION_HOST_ID, runtimeEnvironmentId: null }
 }
 
 function resolveFolderWorkspaceOperationRoute(

--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -47,6 +47,11 @@ export type WorktreeOperationRouteState = FolderWorkspaceRuntimeOwnerState & {
   removedRuntimeEnvironmentIds?: ReadonlySet<string>
 }
 
+/**
+ * Owner rows for this id on one host, read from the repo catalog AND the detected-worktree index
+ * because owner provenance is split across both stores — a HUB-projected owner may appear in
+ * either one, and missing it would drop the transport the caller needs.
+ */
 function ownerRecordsOnHost(
   state: WorktreeOperationRouteState,
   worktreeId: string,
@@ -105,6 +110,11 @@ export function resolveWorktreeOperationRouteResultForHost(
     : { kind: 'missing' }
 }
 
+/**
+ * `null`-returning adapter for host-qualified callers with no branch for `ambiguous` vs
+ * `missing`. The fail-closed decision stays in the `*Result` resolver so the two entry
+ * points can never disagree about what counts as an owner.
+ */
 export function resolveWorktreeOperationRouteForHost(
   state: WorktreeOperationRouteState,
   worktreeId: string,
@@ -114,6 +124,11 @@ export function resolveWorktreeOperationRouteForHost(
   return resolution.kind === 'resolved' ? resolution.route : null
 }
 
+/**
+ * An authoritative host selection already names the target, so only the transport has to be
+ * recovered — and only for `ssh:`, which a paired HUB can proxy. Rival HUBs projecting the same
+ * host stay unresolved rather than guessing one.
+ */
 function resolveSelectedHostRoute(
   state: WorktreeOperationRouteState,
   worktreeId: string,
@@ -168,6 +183,10 @@ export function getWorktreeOperationOwnerHostIds(
   return [...hostIds]
 }
 
+/**
+ * `null`-returning adapter over the owner-routed resolver for call sites that cannot act on
+ * `ambiguous` — collapsing both refusals to `null` keeps them fail-closed at the call site.
+ */
 export function resolveWorktreeOperationRoute(
   state: WorktreeOperationRouteState,
   worktreeId: string
@@ -299,6 +318,11 @@ function resolveFolderWorkspaceOperationRoute(
   }
 }
 
+/**
+ * Projects the route's runtime environment onto settings so a routed operation runs against the
+ * owner's environment rather than whichever one the UI has active; settings can still be absent
+ * during early hydration, hence the synthesized fallback.
+ */
 export function settingsForWorktreeOperationRoute(
   settings: AppState['settings'],
   route: WorktreeOperationRoute

--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -1,6 +1,5 @@
 import type { AppState } from '@/store/types'
 import {
-  getRepoExecutionHostId,
   LOCAL_EXECUTION_HOST_ID,
   parseExecutionHostId,
   type ExecutionHostId
@@ -250,31 +249,28 @@ export function resolveWorktreeOperationRouteResult(
     (state.runtimeEnvironmentCatalogHydrated === true &&
       (savedRuntimeIds.length === 0 || hasDetectedWorktree))
   return mayBeLegacyLocal
-    ? { kind: 'resolved', route: { executionHostId: 'local', runtimeEnvironmentId: null } }
+    ? {
+        kind: 'resolved',
+        route: { executionHostId: LOCAL_EXECUTION_HOST_ID, runtimeEnvironmentId: null }
+      }
     : { kind: 'missing' }
 }
 
 /**
- * A local route for a worktree whose rows predate owner projection, and only that.
- * `getWorktreeExecutionHostId` is the precedence of record for this decision; it takes a single
- * repo, so the unanimity every row must satisfy is spelled out here.
+ * A local route for a worktree whose only repo rows predate owner projection — the exact
+ * condition `resolveExplicitWorktreeOperationRouteResult` already routed above if it applied to
+ * any row. Reaching this function means every row for `repoId` is unstamped, so
+ * `getRepoExecutionHostId`'s own fallback resolves each of them to `local`; a row only has to
+ * exist.
  */
 function resolveUnstampedLocalWorktreeRoute(
   state: WorktreeOperationRouteState,
   repoId: string
 ): WorktreeOperationRoute | null {
-  const repos = state.repos?.filter((repo) => repo.id === repoId) ?? []
-  // Why: a worktree row alone carries no host evidence; without a repo record keep failing closed.
-  if (repos.length === 0) {
-    return null
-  }
-  // Why: rows that disagree are a contradiction, not a default — refuse, as findExactRepoOwner does.
-  for (const repo of repos) {
-    if (getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID) {
-      return null
-    }
-  }
-  return { executionHostId: LOCAL_EXECUTION_HOST_ID, runtimeEnvironmentId: null }
+  const hasUnstampedRepoRow = state.repos?.some((repo) => repo.id === repoId) ?? false
+  return hasUnstampedRepoRow
+    ? { executionHostId: LOCAL_EXECUTION_HOST_ID, runtimeEnvironmentId: null }
+    : null
 }
 
 /**

--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -177,6 +177,11 @@ export function resolveWorktreeOperationRoute(
   return resolution.kind === 'resolved' ? resolution.route : null
 }
 
+/**
+ * Owner precedence for owner-routed operations: stamped identity first, the legacy
+ * pre-owner-projection branches strictly below it, and an id no row can place fails closed —
+ * defaulting an unplaceable id to `local` would aim the operation at the wrong machine.
+ */
 export function resolveWorktreeOperationRouteResult(
   state: WorktreeOperationRouteState,
   worktreeId: string
@@ -272,6 +277,10 @@ function resolveUnstampedLocalWorktreeRoute(
   return { executionHostId: LOCAL_EXECUTION_HOST_ID, runtimeEnvironmentId: null }
 }
 
+/**
+ * Folder workspaces have no repo or worktree rows, so they route off their own owner record
+ * instead of the legacy hydration gates above.
+ */
 function resolveFolderWorkspaceOperationRoute(
   state: WorktreeOperationRouteState,
   folderWorkspaceId: string


### PR DESCRIPTION
## Status — scope reduced, and the headline fix is no longer mine

**#16733 is already closed.** It was fixed by **#16841** (*"fix(routing): resolve unstamped local
worktrees to the local host (STA-5683)"*), merged **2026-08-27**, and the issue closed with it. This
branch predates that merge and originally claimed the whole fix. It no longer does, and **nothing
here asks to close #16733** — that credit is #16841's.

This branch was **rebased onto `upstream/main`** at `1d1b73c408` (which contains #16841) and
**reconciled** with it. Correcting that reference: this branch's true merge-base with `main` is
`6a47d2831f` (*"fix(native-chat): scope composer file drops to the pane that received them
(#19328)"*), which is a descendant of `1d1b73c408` and therefore also contains #16841; `main` has
advanced since and its tip is now `12f2c6b991`.

What survives is the part #16841 does not cover: **two states that still
fail a genuinely local git worktree closed.** Both fixes now coexist inside
`resolveWorktreeOperationRouteResult` — #16841's stricter identity rule is kept intact, and this
branch narrows itself to fit *inside* it rather than around it.

Measured against the rebase base (#16841 alone), **6 of the 66 targeted tests still fail**; with
this branch, **66/66 pass**. Those 6 are the two families below.

### The two residual fail-closed states

The relevant base tail is `hydrated && (no saved runtimes || hasDetectedWorktree)`. It is false in
exactly two shapes that are nonetheless local:

1. **Listed-but-unstamped worktree with no detected row yet** — runtimes saved, catalog hydrated.
   The worktree is present in `worktreesByRepo` but absent from `detectedWorktreesByRepo`, so the
   tail is false and the row fails closed.
   - `worktree-operation-route.test.ts` › **`keeps a local worktree local when an unrelated runtime is saved`**
2. **Saved runtime with hydration still in progress** — `runtimeEnvironmentCatalogHydrated: false`,
   so the tail is false regardless of how unambiguous the rows are.
   - `worktree-operation-route.test.ts` › **`keeps a local worktree local while the saved-runtime catalog is still hydrating`**

Checked directly, not assumed: with the source file reverted to the base and the tests left as they
are on this branch, both cases return `{ kind: 'missing' }`
(`AssertionError: expected { kind: 'missing' } to deeply equal { kind: 'resolved', … }`). With the
branch's source, both return the `local` route.

### Conceded to #16841 on purpose — please do not read this as reopening it

The original branch also routed **repo-row-only identity** (a known repo, *no* worktree row at all)
to local. **#16841 deliberately fails that closed** — a repo row is repo identity, not worktree
identity — and its test
`fails a paired-client ownerless stale publication closed instead of routing it locally` asserts
exactly that. **That case is given up, not re-argued.** The new branch is gated behind
`hasKnownWorktree`, and #16841's test passes here **unmodified**.

## ELI5

Saving a remote environment should not stop an ordinary local workspace from opening a terminal. This follow-up fixes two remaining cases: Orca knows the local worktree but has not detected it on this scan, or the saved environment list is still loading. Known SSH and remote owners keep their routes, and unknown worktrees still fail closed.

## What Changed

One new branch in `resolveWorktreeOperationRouteResult`
(`src/renderer/src/lib/worktree-operation-route.ts`), plus the small helper it delegates to.
`+73 / -2` in the source file.

```
                       resolveWorktreeOperationRouteResult
                                    │
        ┌───────────────────────────┼───────────────────────────┐
        │                           │                           │
   active workspace          folder workspace            explicit catalog
   host selected             (#10251 carve-out)          (stamped rows)
        │                           │                           │
     resolved                   resolved                    resolved
                                                                │ missing
                                                                ▼
                                                   positive identity check
                                                   (known repo OR worktree)
                                                                │
                                          ┌─────────────────────┴──────────┐
                                       unknown                          known
                                          │                                │
                                       missing                    active runtime?
                                                                           │
                                                      ┌────────────────────┴────────┐
                                                     yes                           no
                                                      │                             │
                                            runtime: / missing        ►► NEW: known WORKTREE row
                                                                         (listed or detected)?
                                                                              │        │
                                                                             no       yes
                                                                              │        │
                                                             #16841's tail    │   every repo row
                                                             (unchanged)      │   for this id
                                                                              │   unstamped/local?
                                                                              │        │    │
                                                                              │      yes    no
                                                                              │        │    │
                                                                              │    local   #16841's
                                                                              │            tail
```

- **`hasKnownWorktree` gate** — the branch is only reachable when a worktree row is known, *listed
  or currently detected*. This is the reconciliation with #16841: a repo row alone is repo identity,
  not worktree identity, so it no longer routes anything local.
- **`resolveUnstampedLocalWorktreeRoute(state, repoId)`** — returns a `local` route only when a repo
  row for the id exists *and* every matching row resolves to `LOCAL_EXECUTION_HOST_ID` via
  `getRepoExecutionHostId`. No repo row → `null`. Any row disagreeing → `null`, so contradictions
  stay a refusal rather than becoming a default.
- The pre-existing `mayBeLegacyLocal` tail — the code #16841 amended — is **left intact** and still
  handles everything that reaches it.
- `'local'` is the existing `LOCAL_EXECUTION_HOST_ID` sentinel — no new vocabulary.

**One pre-existing test was re-aimed, and I want that called out rather than buried**, because it
asserted one of the states above. (The original version of this PR re-aimed *two*; the second is the
repo-row-only case now conceded to #16841, so that test is back to untouched.)

| Was | Now |
|---|---|
| `fails ownerless rows closed until the saved-runtime catalog is hydrated` — `runtimeEnvironments: []`, unhydrated | `fails ownerless rows closed mid-hydration while a saved runtime could own them` — no repo row or active runtime, two saved runtimes, a detected worktree row, unhydrated |

It arrived with #9994 (`41751dd90d`), whose goal — fail closed for **missing or stale** owners — is
kept, and #16841 did not touch it. Its fixture did not describe a missing owner though: it carried a
present-but-unstamped `repos: [{ id: 'repo-1' }]` with *no* saved runtime at all, a state three
places in this codebase already read as locally owned (`getRepoExecutionHostId`,
`resolveRepoOwnershipEvidence` in `main/ipc/worktrees/listing/worktree-host-ownership.ts`, and
`Repo.executionHostId`'s documented contract in `shared/repo-types.ts`). It is re-pointed at the
state it was actually defending — mid-hydration where a saved runtime genuinely *could* own the row
— so fail-closed coverage is not reduced, and the state it vacates is re-asserted with its corrected
expected result in the `#16733` block. Reviewer's call if you would rather I keep it verbatim and
gate differently; I think the re-aim is the honest reading, but it is the one judgement call left in
here.

## Why

`savedRuntimeIds.length === 0` was the original defect, and #16841 already removed most of its
sting. What remains is the same category error in two narrower places: the **count** of saved
environments, and the **hydration status** of that list, say nothing about who owns *this* worktree.
An unrelated runtime existing in settings is not evidence of ambiguity, and neither is a list that
has not finished loading — yet either one still flips a recognised worktree to `{ kind: 'missing' }`.

The approach is not new reasoning — it is the reasoning already written into
`resolveFolderWorkspaceOperationRoute` in the same file, whose comment describes this bug for the
other workspace kind:

```ts
// Why: a found folder record is positive identity evidence, so keep terminal-owner parity;
// the worktree legacy hydration gates would fail local folders closed whenever unrelated
// runtimes exist — the exact #10251 symptom.
```

**Why this is safe rather than a loosening.** Every row that carries host provenance routes *above*
the new branch and never reaches it:

- a stamped **repo** row routes through `resolveIndexedRepoOperationRoute`, which only skips rows
  where both `executionHostId` and `connectionId` are empty (`worktree-operation-catalog-route.ts:94`);
- a stamped **worktree** row routes through `resolveIndexedWorktreeOwner` / `exactRoutes`, so it
  still outranks its unstamped repo;
- an **active** runtime keeps its existing precedence, ambiguity refusal included;
- and after reconciliation, a row with **no worktree identity at all** no longer reaches it either.

So the branch is reachable only for rows that carry no host evidence *and* have a known worktree —
precisely the legacy pre-owner-projection shape, local by construction.

**Scale.** Not a corner case in an aged store: on the reporting deployment, 181 of 569 worktree rows
under live repos carry no host stamp and every repo row lacks both fields. An earlier stamping pass
fixed the rows that existed then; the create path does not write the stamp, so everything created
since is unstamped again. Hand-stamping rows is therefore a treadmill, not a fix.

**Deliberate behavioural note:** the new branch resolves local even when
`removedRuntimeEnvironmentIds` is non-empty. That is intentional and symmetric with the folder
carve-out — an unstamped row is not evidence of having belonged to a *deleted* runtime either.
Covered by `keeps a local worktree local after an unrelated runtime has been removed`. Flag it if
you disagree; it is easy to gate.

## Linked Issue

Relates to **#16733** — **already closed by #16841** (merged 2026-08-27). Intentionally *not*
`Fixes #16733`: this PR must not close an issue it did not fix. It is the residual follow-up
described at the top.

## Visual Proof

Independent review at c8bf96ba8444a8264a6df7a3383c72fa70ee55bb exercised New tab → New Terminal in a hidden macOS Electron renderer using a real disposable Git repo and a synthetic legacy catalog (unstamped repo/worktree, no detected rows, no selected host, one unrelated saved environment).

Before: the baseline routing source returns missing and clicking New Terminal creates no tab.

![Before: New Terminal produces no tab](https://github.com/user-attachments/assets/ac078341-b67f-43a2-b3a7-36cce3076cf9)

After: the exact PR head opens a real local terminal; printf ORCA_LOCAL_PR16829_OK executes successfully.

![After: local shell executes successfully](https://github.com/user-attachments/assets/506d85dd-3077-4a62-8e3f-2b4e02b17957)

This proves the local renderer/PTY flow. It is not a reproduction of the original Windows-desktop-paired-to-headless-Linux deployment.

## Independent validation — 2026-09-07

- Exact PR head changed suites: 66/66 on Windows awin, Linux openclaw (via Orca SSH terminal), and macOS.
- macOS broader routing, generation, editor/explorer and destructive owner-boundary checks: 125 tests passed total.
- Baseline routing source with PR tests: six failures / 60 passes; restored exact head passes all 66.
- pnpm tc:web, targeted oxlint and oxfmt checks pass.
- No proven code findings from the readiness review. SSH/runtime ownership precedence and folder parity remain covered.

## Contributor testing (original report)

Gates on this branch, **rebased onto `upstream/main` @ `1d1b73c408`** (contains #16841), on Node
24.19.0 (the version `engines` pins — worth stating, because a stale Node 22 on PATH produces
widespread unrelated reds):

| Gate | Result |
|---|---|
| `pnpm run typecheck` (all projects) | pass |
| `pnpm run lint` (full chain incl. reliability/ratchet/localization gates) | pass |
| targeted suites (the 2 changed test files) | **`66 passed (66)`** |
| same 2 files, source reverted to base (#16841 only) | **`6 failed`, `60 passed` of 66** — the residual states |
| `pnpm vitest run src/renderer/src/lib` (scoped) | `5182 passed, 1 skipped` |
| `pnpm run test` (full) | **not green here — and not green on `main` either;** see below |

The 6 that fail on the base and pass here, i.e. exactly what this PR still buys:

```
× keeps a local worktree local when an unrelated runtime is saved
× keeps a local worktree local when several unrelated runtimes are saved
× keeps a local worktree local while the saved-runtime catalog is still hydrating
× keeps a local worktree local after an unrelated runtime has been removed
× routes a folder workspace and a git worktree alike in one local state (#16733)
× keeps a terminal routable on a local worktree while an unrelated runtime is saved
```

Reproduce the comparison:

```bash
pnpm vitest run --config config/vitest.config.ts \
  src/renderer/src/lib/worktree-operation-route.test.ts \
  src/renderer/src/lib/terminal-worktree-route.test.ts
#  Tests  66 passed (66)

git checkout upstream/main -- src/renderer/src/lib/worktree-operation-route.ts
pnpm vitest run --config config/vitest.config.ts \
  src/renderer/src/lib/worktree-operation-route.test.ts \
  src/renderer/src/lib/terminal-worktree-route.test.ts
#  Tests  6 failed | 60 passed (66)   <- the states #16841 still fails closed
git checkout HEAD -- src/renderer/src/lib/worktree-operation-route.ts
```

Coverage — the negative cases are the point, not the happy path:

- **resolves local:** unrelated runtime saved; several unrelated runtimes; catalog still hydrating;
  unrelated runtime removed; no runtime saved; adapters with no runtime catalog at all.
- **still refuses:** connection-owned repo never routes local; runtime-stamped repo never routes
  local; a host-stamped worktree row stays authoritative over its unstamped repo; a second
  connection-owned repo row for the id refuses; contradictory repo rows report `ambiguous`, not
  local; unknown id with neither repo nor worktree row still `missing`; ambiguous active runtime
  still fails closed; unambiguous active runtime stays authoritative over the local fallback; and
  **#16841's repo-row-only refusal, unmodified**.
- **parity:** a folder workspace and a git worktree in one identical local store route alike.

Platforms actually run: **Linux** (this is renderer-side pure routing logic with no platform branch;
I have not run the desktop client on Windows or macOS). The reported environment is Windows-desktop
paired to a headless Linux `orca serve`, which I could not reproduce end-to-end — noted plainly
rather than implied.

**Being straight about the full suite.** I will not tick `pnpm test` as clean, because it is not. On
the pre-rebase run I diffed the failing-file lists against a pristine `upstream/main` worktree in the
identical environment: 69 failing files on baseline, 74 on the branch, none only-in-baseline, and
each of the 5 differing files accounted for — 3 `terminal-pane` remote-runtime transport tests that
pass in isolation (30s-timeout tests under parallel load) and 2 `src/main/runtime/orchestration-*`
files that are skipped unless `out/` build artifacts exist and fail identically on baseline once
built. The load-bearing point: **none of the files this change touches or reads
(`worktree-operation-route`, `terminal-worktree-route`, `worktree-owner-route`,
`worktree-operation-catalog-route`) appears in any failing list, in any run.**

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Deliberately left unticked:** I did not run the desktop client by hand. I do not have the
reporter's Windows-desktop-paired-to-headless-Linux-`orca serve` rig, and ticking a manual-test box
on the strength of unit tests would be exactly the kind of claim this template is trying to stop.
What I verified is stated above, no more than that.

## AI Disclosure

AI-assisted. Claude (Anthropic, Opus-class) driving an agent harness on my machine, under my
direction: it did the code reading, wrote the tests and the fix, ran the gates, and performed the
rebase and reconciliation against #16841; I set the approach, reviewed every diff and commit
message, and I'm the one accountable for what's here. Flagging it because the template asks and
because you should weigh the diff knowing it — not as a disclaimer on its correctness.

One meta note in the spirit of the same honesty: **issue #16733 itself was filed by my
`svc-orca[bot]` account**, which is an automation account of mine, not a third-party reporter. The
deployment numbers in it are from my own store. Same person, both ends — no independent
corroboration is being implied.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

Not applicable — nothing here touches skill-installer source, tests, fixtures, registry entries,
path tables, or docs.

## Notes

- **Destructive paths — the one thing I most want a reviewer to check.**
  `resolveWorktreeOperationRoute` also feeds worktree *removal*, so `missing` → `local` means an
  unqualified removal on an unstamped row now **proceeds locally** where it previously refused with
  a toast. I believe that is correct and is the same bug in another costume — the row carries no
  remote evidence, so there is no remote thing that could be destroyed, and refusing to delete a
  local worktree is not a safety property, just the same fail-closed defect. Two guards that *are*
  safety properties are untouched and I verified both by reading, not assuming:
  - the STA-4343 host-qualified path is unaffected — a caller that confirmed a host routes through
    `resolveWorktreeOperationRouteResultForHost` → `resolveSelectedHostRoute`, neither of which
    calls the modified function at all;
  - the multi-host ambiguity refusal still uses `getWorktreeOperationOwnerHostIds`, also unmodified.

  `host-qualified-removal-refusal.test.ts` passes unchanged. Still — this is the judgement worth a
  second pair of eyes, more than the terminal case in the title.
- **Security:** grants nothing new. The branch can only return the `local` sentinel, and only when
  no row carries host provenance. It cannot synthesise a `runtime:` or `ssh:` route, so it cannot
  cause an operation to be sent to a remote host that would not already have received it.
- **Cross-platform:** pure renderer routing logic, no platform branch, no path handling.
- **Remote SSH:** connection-owned and runtime-stamped rows route above the new branch and are
  covered by explicit negative tests; `ssh:`/HUB precedence from #11346 and #9994 is untouched.
- **Mobile:** not on this path.
- **Backwards compatibility:** additive. The only behaviour that changes is `missing` → `local` for
  rows that have a known worktree and carry no host evidence; #16841's tail is preserved for
  everything that reaches it, including the repo-row-only refusal.
- **Performance:** one `Array.prototype.filter` over `state.repos`, on the fall-through path only —
  reached after the cached catalog index has already missed, and now only when a worktree row is
  already known. No new allocation on the hot resolved paths.
- **Not fixed here, on purpose:** the create path still does not write a host stamp, which is why
  unstamped rows keep appearing. This PR makes the router correct for rows in that state rather than
  chasing both; say the word if you would rather see the stamp-on-create in the same change.
- **If you would rather not carry this at all:** that is a legitimate call now that #16841 has
  shipped the main fix. The two residual states are real and reproducible, but they are narrower
  than what this PR originally proposed, and I would rather it be closed knowingly than merged on
  the strength of a stale description.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

`lint` and `typecheck` pass locally on the rebased branch. `pnpm test` does not fully pass — **nor
does it on `main` in the same environment** — so I have left that unticked rather than tick it on a
technicality. The measured diff, the isolation results, and the reason each differing file differs
are all in [Testing](#testing); none of them touch this change's files.

