### PR TITLE
feat(mobile): add causal network diagnostics

### DIFF
--- a/mobile/app/connection-log.tsx
+++ b/mobile/app/connection-log.tsx
@@ -18,6 +18,8 @@ import {
 import { buildConnectionDiagnosticsReport } from '../src/diagnostics/connection-diagnostics-report'
 import { diagnoseConnection } from '../src/diagnostics/connection-diagnostics-analysis'
 import { submitConnectionDiagnostics } from '../src/diagnostics/connection-diagnostics-submission'
+import { useHostStatusGates } from '../src/transport/host-status-gates'
+import { loadHostAppVersion } from '../src/transport/host-app-version-store'
 import type { ConnectionLogEntry, HostProfile } from '../src/transport/types'
 
 // Why: getSnapshot must be referentially stable when there's no data —
@@ -53,7 +55,12 @@ export default function ConnectionLogScreen() {
   }, [params.hostId])
 
   const selected = hosts.find((h) => h.id === selectedId) ?? null
-  const { state } = useHostClient(selected?.id)
+  const { client, state } = useHostClient(selected?.id)
+  const { desktopAppVersion: liveDesktopAppVersion } = useHostStatusGates({
+    hostId: selected?.id,
+    client,
+    connState: state
+  })
   const reconnectAttempts = useReconnectAttempt(selected?.id)
   const lastConnectedAt = useLastConnectedAt(selected?.id)
   const { activePath, pendingPath } = useConnectionPathStatus(selected?.id)
@@ -82,6 +89,7 @@ export default function ConnectionLogScreen() {
     if (!selected) {
       return
     }
+    const desktopAppVersion = liveDesktopAppVersion ?? (await loadHostAppVersion(selected.id))
     const report = buildConnectionDiagnosticsReport({
       hostName: selected.name,
       endpoint: selected.endpoint,
@@ -90,6 +98,7 @@ export default function ConnectionLogScreen() {
       lastConnectedAt,
       platform: `${Platform.OS} ${Platform.Version ?? ''}`.trim(),
       appVersion: Constants.expoConfig?.version ?? 'unknown',
+      desktopAppVersion,
       entries,
       activePath,
       pendingPath
@@ -97,7 +106,16 @@ export default function ConnectionLogScreen() {
     await Clipboard.setStringAsync(report)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
-  }, [selected, state, reconnectAttempts, lastConnectedAt, entries, activePath, pendingPath])
+  }, [
+    selected,
+    state,
+    reconnectAttempts,
+    lastConnectedAt,
+    entries,
+    activePath,
+    pendingPath,
+    liveDesktopAppVersion
+  ])
 
   const sendDiagnostics = useCallback(async () => {
     if (!selected || submissionState === 'sending') {
@@ -106,6 +124,7 @@ export default function ConnectionLogScreen() {
     setSubmissionState('sending')
     const appVersion = Constants.expoConfig?.version ?? 'unknown'
     const platform = `${Platform.OS} ${Platform.Version ?? ''}`.trim()
+    const desktopAppVersion = liveDesktopAppVersion ?? (await loadHostAppVersion(selected.id))
     const report = buildConnectionDiagnosticsReport({
       hostName: selected.name,
       endpoint: selected.endpoint,
@@ -114,6 +133,7 @@ export default function ConnectionLogScreen() {
       lastConnectedAt,
       platform,
       appVersion,
+      desktopAppVersion,
       entries,
       activePath,
       pendingPath
@@ -128,7 +148,8 @@ export default function ConnectionLogScreen() {
     lastConnectedAt,
     entries,
     activePath,
-    pendingPath
+    pendingPath,
+    liveDesktopAppVersion
   ])
 
   return (

--- a/mobile/app/connection-log.tsx
+++ b/mobile/app/connection-log.tsx
@@ -8,13 +8,15 @@ import { ChevronLeft, Copy, Check } from 'lucide-react-native'
 import { colors, spacing, typography } from '../src/theme/mobile-theme'
 import { ConnectionLog } from '../src/components/ConnectionLog'
 import { loadHosts } from '../src/transport/host-store'
-import { connectionLogStore } from '../src/transport/connection-log-buffer'
+import { connectionLogStore } from '../src/transport/persisted-connection-log-store'
 import { useHostClient } from '../src/transport/client-context'
 import {
+  useConnectionPathStatus,
   useLastConnectedAt,
   useReconnectAttempt
 } from '../src/transport/client-context-connection-metrics'
 import { buildConnectionDiagnosticsReport } from '../src/diagnostics/connection-diagnostics-report'
+import { diagnoseConnection } from '../src/diagnostics/connection-diagnostics-analysis'
 import type { ConnectionLogEntry, HostProfile } from '../src/transport/types'
 
 // Why: getSnapshot must be referentially stable when there's no data —
@@ -49,6 +51,13 @@ export default function ConnectionLogScreen() {
   const { state } = useHostClient(selected?.id)
   const reconnectAttempts = useReconnectAttempt(selected?.id)
   const lastConnectedAt = useLastConnectedAt(selected?.id)
+  const { activePath, pendingPath } = useConnectionPathStatus(selected?.id)
+
+  useEffect(() => {
+    if (selectedId) {
+      void connectionLogStore.hydrate(selectedId)
+    }
+  }, [selectedId])
 
   const subscribe = useCallback(
     (listener: () => void) =>
@@ -60,6 +69,9 @@ export default function ConnectionLogScreen() {
     [selectedId]
   )
   const entries = useSyncExternalStore(subscribe, getSnapshot)
+  const diagnosis = selected
+    ? diagnoseConnection({ endpoint: selected.endpoint, state, activePath, pendingPath, entries })
+    : null
 
   const copyDiagnostics = useCallback(async () => {
     if (!selected) {
@@ -73,12 +85,14 @@ export default function ConnectionLogScreen() {
       lastConnectedAt,
       platform: `${Platform.OS} ${Platform.Version ?? ''}`.trim(),
       appVersion: Constants.expoConfig?.version ?? 'unknown',
-      entries
+      entries,
+      activePath,
+      pendingPath
     })
     await Clipboard.setStringAsync(report)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
-  }, [selected, state, reconnectAttempts, lastConnectedAt, entries])
+  }, [selected, state, reconnectAttempts, lastConnectedAt, entries, activePath, pendingPath])
 
   return (
     <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
@@ -86,7 +100,7 @@ export default function ConnectionLogScreen() {
         <Pressable style={styles.backButton} onPress={() => router.back()}>
           <ChevronLeft size={22} color={colors.textSecondary} />
         </Pressable>
-        <Text style={styles.heading}>Connection log</Text>
+        <Text style={styles.heading}>Network diagnostics</Text>
       </View>
 
       {hosts.length > 1 && (
@@ -121,14 +135,21 @@ export default function ConnectionLogScreen() {
               ) : (
                 <Copy size={14} color={colors.textSecondary} />
               )}
-              <Text style={styles.copyButtonText}>{copied ? 'Copied' : 'Copy diagnostics'}</Text>
+              <Text style={styles.copyButtonText}>{copied ? 'Copied' : 'Copy report'}</Text>
             </Pressable>
           </View>
+          {diagnosis && (
+            <View style={styles.diagnosisCard}>
+              <Text style={styles.diagnosisHeading}>What this suggests</Text>
+              <Text style={styles.diagnosisText}>{diagnosis.likelyCause}</Text>
+              <Text style={styles.diagnosisNext}>{diagnosis.nextStep}</Text>
+            </View>
+          )}
           {entries.length > 0 ? (
             <ConnectionLog entries={[...entries]} title={selected.name} />
           ) : (
             <Text style={styles.emptyText}>
-              No connection events yet this session. Events appear as the app dials this host.
+              No connection events yet. Events appear as the app dials this host.
             </Text>
           )}
         </>
@@ -198,6 +219,31 @@ const styles = StyleSheet.create({
   statusText: {
     fontSize: typography.metaSize,
     color: colors.textSecondary
+  },
+  diagnosisCard: {
+    backgroundColor: colors.bgPanel,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.borderSubtle,
+    borderRadius: 10,
+    padding: spacing.md,
+    marginBottom: spacing.md
+  },
+  diagnosisHeading: {
+    fontSize: typography.metaSize,
+    fontWeight: '600',
+    color: colors.textPrimary,
+    marginBottom: spacing.xs
+  },
+  diagnosisText: {
+    fontSize: typography.metaSize,
+    color: colors.textPrimary,
+    lineHeight: 18
+  },
+  diagnosisNext: {
+    fontSize: typography.metaSize,
+    color: colors.textSecondary,
+    lineHeight: 18,
+    marginTop: spacing.xs
   },
   copyButton: {
     flexDirection: 'row',

--- a/mobile/app/connection-log.tsx
+++ b/mobile/app/connection-log.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
 import { View, Text, StyleSheet, Pressable, Platform } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useRouter } from 'expo-router'
+import { useLocalSearchParams, useRouter } from 'expo-router'
 import * as Clipboard from 'expo-clipboard'
 import Constants from 'expo-constants'
-import { ChevronLeft, Copy, Check } from 'lucide-react-native'
+import { ChevronLeft, Copy, Check, Send } from 'lucide-react-native'
 import { colors, spacing, typography } from '../src/theme/mobile-theme'
 import { ConnectionLog } from '../src/components/ConnectionLog'
 import { loadHosts } from '../src/transport/host-store'
@@ -17,6 +17,7 @@ import {
 } from '../src/transport/client-context-connection-metrics'
 import { buildConnectionDiagnosticsReport } from '../src/diagnostics/connection-diagnostics-report'
 import { diagnoseConnection } from '../src/diagnostics/connection-diagnostics-analysis'
+import { submitConnectionDiagnostics } from '../src/diagnostics/connection-diagnostics-submission'
 import type { ConnectionLogEntry, HostProfile } from '../src/transport/types'
 
 // Why: getSnapshot must be referentially stable when there's no data —
@@ -28,10 +29,14 @@ const EMPTY_ENTRIES: readonly ConnectionLogEntry[] = []
 // log fills live instead of showing a stale tail.
 export default function ConnectionLogScreen() {
   const router = useRouter()
+  const params = useLocalSearchParams<{ hostId?: string }>()
   const insets = useSafeAreaInsets()
   const [hosts, setHosts] = useState<HostProfile[]>([])
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+  const [submissionState, setSubmissionState] = useState<'idle' | 'sending' | 'sent' | 'failed'>(
+    'idle'
+  )
 
   useEffect(() => {
     let stale = false
@@ -40,12 +45,12 @@ export default function ConnectionLogScreen() {
         return
       }
       setHosts(loaded)
-      setSelectedId((prev) => prev ?? loaded[0]?.id ?? null)
+      setSelectedId((prev) => prev ?? params.hostId ?? loaded[0]?.id ?? null)
     })
     return () => {
       stale = true
     }
-  }, [])
+  }, [params.hostId])
 
   const selected = hosts.find((h) => h.id === selectedId) ?? null
   const { state } = useHostClient(selected?.id)
@@ -93,6 +98,38 @@ export default function ConnectionLogScreen() {
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }, [selected, state, reconnectAttempts, lastConnectedAt, entries, activePath, pendingPath])
+
+  const sendDiagnostics = useCallback(async () => {
+    if (!selected || submissionState === 'sending') {
+      return
+    }
+    setSubmissionState('sending')
+    const appVersion = Constants.expoConfig?.version ?? 'unknown'
+    const platform = `${Platform.OS} ${Platform.Version ?? ''}`.trim()
+    const report = buildConnectionDiagnosticsReport({
+      hostName: selected.name,
+      endpoint: selected.endpoint,
+      state,
+      reconnectAttempts,
+      lastConnectedAt,
+      platform,
+      appVersion,
+      entries,
+      activePath,
+      pendingPath
+    })
+    const result = await submitConnectionDiagnostics({ report, appVersion, platform })
+    setSubmissionState(result.ok ? 'sent' : 'failed')
+  }, [
+    selected,
+    submissionState,
+    state,
+    reconnectAttempts,
+    lastConnectedAt,
+    entries,
+    activePath,
+    pendingPath
+  ])
 
   return (
     <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
@@ -143,6 +180,29 @@ export default function ConnectionLogScreen() {
               <Text style={styles.diagnosisHeading}>What this suggests</Text>
               <Text style={styles.diagnosisText}>{diagnosis.likelyCause}</Text>
               <Text style={styles.diagnosisNext}>{diagnosis.nextStep}</Text>
+              <Text style={styles.privacyHint}>
+                Sends redacted connection events only—never terminal contents or credentials.
+              </Text>
+              <Pressable
+                style={styles.sendButton}
+                onPress={() => void sendDiagnostics()}
+                disabled={submissionState === 'sending'}
+              >
+                {submissionState === 'sent' ? (
+                  <Check size={14} color={colors.statusGreen} />
+                ) : (
+                  <Send size={14} color={colors.textPrimary} />
+                )}
+                <Text style={styles.sendButtonText}>
+                  {submissionState === 'sending'
+                    ? 'Sending…'
+                    : submissionState === 'sent'
+                      ? 'Diagnostics sent'
+                      : submissionState === 'failed'
+                        ? 'Retry sending'
+                        : 'Send diagnostics to Orca'}
+                </Text>
+              </Pressable>
             </View>
           )}
           {entries.length > 0 ? (
@@ -244,6 +304,28 @@ const styles = StyleSheet.create({
     color: colors.textSecondary,
     lineHeight: 18,
     marginTop: spacing.xs
+  },
+  privacyHint: {
+    marginTop: spacing.sm,
+    fontSize: 11,
+    lineHeight: 15,
+    color: colors.textMuted
+  },
+  sendButton: {
+    marginTop: spacing.md,
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: 8,
+    backgroundColor: colors.bgRaised
+  },
+  sendButtonText: {
+    fontSize: typography.metaSize,
+    fontWeight: '600',
+    color: colors.textPrimary
   },
   copyButton: {
     flexDirection: 'row',

--- a/mobile/app/connection-log.tsx
+++ b/mobile/app/connection-log.tsx
@@ -146,7 +146,7 @@ export default function ConnectionLogScreen() {
             </View>
           )}
           {entries.length > 0 ? (
-            <ConnectionLog entries={[...entries]} title={selected.name} />
+            <ConnectionLog entries={[...entries]} title={selected.name} fillAvailableHeight />
           ) : (
             <Text style={styles.emptyText}>
               No connection events yet. Events appear as the app dials this host.

--- a/mobile/app/connection-log.tsx
+++ b/mobile/app/connection-log.tsx
@@ -118,7 +118,7 @@ export default function ConnectionLogScreen() {
   ])
 
   const sendDiagnostics = useCallback(async () => {
-    if (!selected || submissionState === 'sending') {
+    if (!selected || submissionState === 'sending' || diagnosis?.reportability !== 'orca-relay') {
       return
     }
     setSubmissionState('sending')
@@ -149,7 +149,8 @@ export default function ConnectionLogScreen() {
     entries,
     activePath,
     pendingPath,
-    liveDesktopAppVersion
+    liveDesktopAppVersion,
+    diagnosis
   ])
 
   return (
@@ -201,29 +202,33 @@ export default function ConnectionLogScreen() {
               <Text style={styles.diagnosisHeading}>What this suggests</Text>
               <Text style={styles.diagnosisText}>{diagnosis.likelyCause}</Text>
               <Text style={styles.diagnosisNext}>{diagnosis.nextStep}</Text>
-              <Text style={styles.privacyHint}>
-                Sends redacted connection events only—never terminal contents or credentials.
-              </Text>
-              <Pressable
-                style={styles.sendButton}
-                onPress={() => void sendDiagnostics()}
-                disabled={submissionState === 'sending'}
-              >
-                {submissionState === 'sent' ? (
-                  <Check size={14} color={colors.statusGreen} />
-                ) : (
-                  <Send size={14} color={colors.textPrimary} />
-                )}
-                <Text style={styles.sendButtonText}>
-                  {submissionState === 'sending'
-                    ? 'Sending…'
-                    : submissionState === 'sent'
-                      ? 'Diagnostics sent'
-                      : submissionState === 'failed'
-                        ? 'Retry sending'
-                        : 'Send diagnostics to Orca'}
-                </Text>
-              </Pressable>
+              {diagnosis.reportability === 'orca-relay' && (
+                <>
+                  <Text style={styles.privacyHint}>
+                    Sends redacted connection events only—never terminal contents or credentials.
+                  </Text>
+                  <Pressable
+                    style={styles.sendButton}
+                    onPress={() => void sendDiagnostics()}
+                    disabled={submissionState === 'sending'}
+                  >
+                    {submissionState === 'sent' ? (
+                      <Check size={14} color={colors.statusGreen} />
+                    ) : (
+                      <Send size={14} color={colors.textPrimary} />
+                    )}
+                    <Text style={styles.sendButtonText}>
+                      {submissionState === 'sending'
+                        ? 'Sending…'
+                        : submissionState === 'sent'
+                          ? 'Diagnostics sent'
+                          : submissionState === 'failed'
+                            ? 'Retry sending'
+                            : 'Send diagnostics to Orca'}
+                    </Text>
+                  </Pressable>
+                </>
+              )}
             </View>
           )}
           {entries.length > 0 ? (

--- a/mobile/app/connection-log.tsx
+++ b/mobile/app/connection-log.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 import { View, Text, StyleSheet, Pressable, Platform } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
@@ -9,18 +9,24 @@ import { colors, spacing, typography } from '../src/theme/mobile-theme'
 import { ConnectionLog } from '../src/components/ConnectionLog'
 import { loadHosts } from '../src/transport/host-store'
 import { connectionLogStore } from '../src/transport/persisted-connection-log-store'
-import { useHostClient } from '../src/transport/client-context'
+import { useHostClient, useRpcClientContext } from '../src/transport/client-context'
 import {
   useConnectionPathStatus,
-  useLastConnectedAt,
   useReconnectAttempt
 } from '../src/transport/client-context-connection-metrics'
 import { buildConnectionDiagnosticsReport } from '../src/diagnostics/connection-diagnostics-report'
-import { diagnoseConnection } from '../src/diagnostics/connection-diagnostics-analysis'
+import {
+  diagnoseConnection,
+  getReportableConnectionIncidentId
+} from '../src/diagnostics/connection-diagnostics-analysis'
 import { submitConnectionDiagnostics } from '../src/diagnostics/connection-diagnostics-submission'
 import {
   readHydratedConnectionLog,
-  selectDiagnosticsHostId
+  readConnectionDiagnosticsSnapshot,
+  resolveDiagnosticsHostId,
+  getDiagnosticsSubmissionState,
+  updateDiagnosticsSubmissionState,
+  type DiagnosticsSubmissionStates
 } from '../src/diagnostics/connection-diagnostics-screen-data'
 import { useHostStatusGates } from '../src/transport/host-status-gates'
 import { loadHostAppVersion } from '../src/transport/host-app-version-store'
@@ -34,15 +40,19 @@ const EMPTY_ENTRIES: readonly ConnectionLogEntry[] = []
 // screen also *acquires* the host client — opening it kicks a dial and the
 // log fills live instead of showing a stale tail.
 export default function ConnectionLogScreen() {
+  const clientContext = useRpcClientContext()
   const router = useRouter()
   const params = useLocalSearchParams<{ hostId?: string }>()
   const insets = useSafeAreaInsets()
+  const routeKey = useMemo(() => ({}), [params.hostId])
   const [hosts, setHosts] = useState<HostProfile[]>([])
-  const [selectedId, setSelectedId] = useState<string | null>(null)
-  const [copied, setCopied] = useState(false)
-  const [submissionState, setSubmissionState] = useState<'idle' | 'sending' | 'sent' | 'failed'>(
-    'idle'
-  )
+  const [manualSelection, setManualSelection] = useState<{
+    hostId: string
+    requestedHostId: string | undefined
+    routeKey: object
+  } | null>(null)
+  const [copiedHostId, setCopiedHostId] = useState<string | null>(null)
+  const [submissionStates, setSubmissionStates] = useState<DiagnosticsSubmissionStates>({})
 
   useEffect(() => {
     let stale = false
@@ -51,13 +61,13 @@ export default function ConnectionLogScreen() {
         return
       }
       setHosts(loaded)
-      setSelectedId((prev) => selectDiagnosticsHostId(loaded, params.hostId, prev))
     })
     return () => {
       stale = true
     }
-  }, [params.hostId])
+  }, [])
 
+  const selectedId = resolveDiagnosticsHostId(hosts, params.hostId, manualSelection, routeKey)
   const selected = hosts.find((h) => h.id === selectedId) ?? null
   const { client, state } = useHostClient(selected?.id)
   const { desktopAppVersion: liveDesktopAppVersion } = useHostStatusGates({
@@ -66,12 +76,11 @@ export default function ConnectionLogScreen() {
     connState: state
   })
   const reconnectAttempts = useReconnectAttempt(selected?.id)
-  const lastConnectedAt = useLastConnectedAt(selected?.id)
   const { activePath, pendingPath } = useConnectionPathStatus(selected?.id)
 
   useEffect(() => {
     if (selectedId) {
-      void connectionLogStore.hydrate(selectedId).catch(() => {})
+      void readHydratedConnectionLog(connectionLogStore, selectedId)
     }
   }, [selectedId])
 
@@ -88,74 +97,90 @@ export default function ConnectionLogScreen() {
   const diagnosis = selected
     ? diagnoseConnection({ endpoint: selected.endpoint, state, activePath, pendingPath, entries })
     : null
+  const incidentId = selected
+    ? getReportableConnectionIncidentId({
+        endpoint: selected.endpoint,
+        state,
+        activePath,
+        pendingPath,
+        entries
+      })
+    : null
+  const submissionKey = selected && incidentId ? `${selected.id}:${incidentId}` : null
+  const submissionState = getDiagnosticsSubmissionState(submissionStates, submissionKey)
+  const copied = copiedHostId === selectedId
 
   const copyDiagnostics = useCallback(async () => {
     if (!selected) {
       return
     }
     const desktopAppVersion = liveDesktopAppVersion ?? (await loadHostAppVersion(selected.id))
-    const hydratedEntries = await readHydratedConnectionLog(connectionLogStore, selected.id)
+    const snapshot = await readConnectionDiagnosticsSnapshot(
+      clientContext,
+      connectionLogStore,
+      selected.id
+    )
     const report = buildConnectionDiagnosticsReport({
       hostName: selected.name,
       endpoint: selected.endpoint,
-      state,
-      reconnectAttempts,
-      lastConnectedAt,
+      state: snapshot.state,
+      reconnectAttempts: snapshot.reconnectAttempts,
+      lastConnectedAt: snapshot.lastConnectedAt,
       platform: `${Platform.OS} ${Platform.Version ?? ''}`.trim(),
       appVersion: Constants.expoConfig?.version ?? 'unknown',
       desktopAppVersion,
-      entries: hydratedEntries,
-      activePath,
-      pendingPath
+      entries: snapshot.entries,
+      activePath: snapshot.activePath,
+      pendingPath: snapshot.pendingPath
     })
     await Clipboard.setStringAsync(report)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }, [
-    selected,
-    state,
-    reconnectAttempts,
-    lastConnectedAt,
-    activePath,
-    pendingPath,
-    liveDesktopAppVersion
-  ])
+    setCopiedHostId(selected.id)
+    setTimeout(() => setCopiedHostId((hostId) => (hostId === selected.id ? null : hostId)), 2000)
+  }, [selected, liveDesktopAppVersion, clientContext])
 
   const sendDiagnostics = useCallback(async () => {
-    if (!selected || submissionState === 'sending' || diagnosis?.reportability !== 'orca-relay') {
+    if (!selected || !submissionKey || submissionState === 'sending') {
       return
     }
-    setSubmissionState('sending')
+    const startedKey = submissionKey
+    setSubmissionStates((states) => updateDiagnosticsSubmissionState(states, startedKey, 'sending'))
     const appVersion = Constants.expoConfig?.version ?? 'unknown'
     const platform = `${Platform.OS} ${Platform.Version ?? ''}`.trim()
     const desktopAppVersion = liveDesktopAppVersion ?? (await loadHostAppVersion(selected.id))
-    const hydratedEntries = await readHydratedConnectionLog(connectionLogStore, selected.id)
+    const snapshot = await readConnectionDiagnosticsSnapshot(
+      clientContext,
+      connectionLogStore,
+      selected.id
+    )
+    const currentIncidentId = getReportableConnectionIncidentId({
+      endpoint: selected.endpoint,
+      state: snapshot.state,
+      activePath: snapshot.activePath,
+      pendingPath: snapshot.pendingPath,
+      entries: snapshot.entries
+    })
+    if (`${selected.id}:${currentIncidentId ?? ''}` !== startedKey) {
+      setSubmissionStates((states) => updateDiagnosticsSubmissionState(states, startedKey, null))
+      return
+    }
     const report = buildConnectionDiagnosticsReport({
       hostName: selected.name,
       endpoint: selected.endpoint,
-      state,
-      reconnectAttempts,
-      lastConnectedAt,
+      state: snapshot.state,
+      reconnectAttempts: snapshot.reconnectAttempts,
+      lastConnectedAt: snapshot.lastConnectedAt,
       platform,
       appVersion,
       desktopAppVersion,
-      entries: hydratedEntries,
-      activePath,
-      pendingPath
+      entries: snapshot.entries,
+      activePath: snapshot.activePath,
+      pendingPath: snapshot.pendingPath
     })
     const result = await submitConnectionDiagnostics({ report, appVersion, platform })
-    setSubmissionState(result.ok ? 'sent' : 'failed')
-  }, [
-    selected,
-    submissionState,
-    state,
-    reconnectAttempts,
-    lastConnectedAt,
-    activePath,
-    pendingPath,
-    liveDesktopAppVersion,
-    diagnosis
-  ])
+    setSubmissionStates((states) =>
+      updateDiagnosticsSubmissionState(states, startedKey, result.ok ? 'sent' : 'failed')
+    )
+  }, [selected, submissionKey, submissionState, liveDesktopAppVersion, clientContext])
 
   return (
     <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
@@ -172,7 +197,9 @@ export default function ConnectionLogScreen() {
             <Pressable
               key={host.id}
               style={[styles.hostChip, host.id === selectedId && styles.hostChipActive]}
-              onPress={() => setSelectedId(host.id)}
+              onPress={() =>
+                setManualSelection({ hostId: host.id, requestedHostId: params.hostId, routeKey })
+              }
             >
               <Text
                 style={[styles.hostChipText, host.id === selectedId && styles.hostChipTextActive]}

--- a/mobile/app/connection-log.tsx
+++ b/mobile/app/connection-log.tsx
@@ -18,6 +18,10 @@ import {
 import { buildConnectionDiagnosticsReport } from '../src/diagnostics/connection-diagnostics-report'
 import { diagnoseConnection } from '../src/diagnostics/connection-diagnostics-analysis'
 import { submitConnectionDiagnostics } from '../src/diagnostics/connection-diagnostics-submission'
+import {
+  readHydratedConnectionLog,
+  selectDiagnosticsHostId
+} from '../src/diagnostics/connection-diagnostics-screen-data'
 import { useHostStatusGates } from '../src/transport/host-status-gates'
 import { loadHostAppVersion } from '../src/transport/host-app-version-store'
 import type { ConnectionLogEntry, HostProfile } from '../src/transport/types'
@@ -47,7 +51,7 @@ export default function ConnectionLogScreen() {
         return
       }
       setHosts(loaded)
-      setSelectedId((prev) => prev ?? params.hostId ?? loaded[0]?.id ?? null)
+      setSelectedId((prev) => selectDiagnosticsHostId(loaded, params.hostId, prev))
     })
     return () => {
       stale = true
@@ -67,7 +71,7 @@ export default function ConnectionLogScreen() {
 
   useEffect(() => {
     if (selectedId) {
-      void connectionLogStore.hydrate(selectedId)
+      void connectionLogStore.hydrate(selectedId).catch(() => {})
     }
   }, [selectedId])
 
@@ -90,6 +94,7 @@ export default function ConnectionLogScreen() {
       return
     }
     const desktopAppVersion = liveDesktopAppVersion ?? (await loadHostAppVersion(selected.id))
+    const hydratedEntries = await readHydratedConnectionLog(connectionLogStore, selected.id)
     const report = buildConnectionDiagnosticsReport({
       hostName: selected.name,
       endpoint: selected.endpoint,
@@ -99,7 +104,7 @@ export default function ConnectionLogScreen() {
       platform: `${Platform.OS} ${Platform.Version ?? ''}`.trim(),
       appVersion: Constants.expoConfig?.version ?? 'unknown',
       desktopAppVersion,
-      entries,
+      entries: hydratedEntries,
       activePath,
       pendingPath
     })
@@ -111,7 +116,6 @@ export default function ConnectionLogScreen() {
     state,
     reconnectAttempts,
     lastConnectedAt,
-    entries,
     activePath,
     pendingPath,
     liveDesktopAppVersion
@@ -125,6 +129,7 @@ export default function ConnectionLogScreen() {
     const appVersion = Constants.expoConfig?.version ?? 'unknown'
     const platform = `${Platform.OS} ${Platform.Version ?? ''}`.trim()
     const desktopAppVersion = liveDesktopAppVersion ?? (await loadHostAppVersion(selected.id))
+    const hydratedEntries = await readHydratedConnectionLog(connectionLogStore, selected.id)
     const report = buildConnectionDiagnosticsReport({
       hostName: selected.name,
       endpoint: selected.endpoint,
@@ -134,7 +139,7 @@ export default function ConnectionLogScreen() {
       platform,
       appVersion,
       desktopAppVersion,
-      entries,
+      entries: hydratedEntries,
       activePath,
       pendingPath
     })
@@ -146,7 +151,6 @@ export default function ConnectionLogScreen() {
     state,
     reconnectAttempts,
     lastConnectedAt,
-    entries,
     activePath,
     pendingPath,
     liveDesktopAppVersion,
@@ -205,7 +209,8 @@ export default function ConnectionLogScreen() {
               {diagnosis.reportability === 'orca-relay' && (
                 <>
                   <Text style={styles.privacyHint}>
-                    Sends redacted connection events only—never terminal contents or credentials.
+                    Sends a size-limited redacted report including host name, endpoint, versions,
+                    connection state, and events—never terminal contents or credentials.
                   </Text>
                   <Pressable
                     style={styles.sendButton}

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -63,6 +63,7 @@ import { ConfirmModal } from '../../../src/components/ConfirmModal'
 import { BottomDrawer } from '../../../src/components/BottomDrawer'
 import { useHostProtocolGates } from '../../../src/components/HostProtocolGate'
 import { AuthFailedBanner } from '../../../src/components/AuthFailedBanner'
+import { HostDiagnosticsLink } from '../../../src/components/HostDiagnosticsLink'
 import { HostRouteNoticeBanner } from '../../../src/components/HostRouteNoticeBanner'
 import { visibleHostRouteNotice } from '../../../src/host-route-notice'
 import { MobileSearchField } from '../../../src/components/MobileSearchField'
@@ -1089,6 +1090,17 @@ export function HostScreen({
           onRemove={() => setConfirmRemoveHost(true)}
         />
       )}
+
+      {connState !== 'connected' &&
+      !relayRecovery.pairingRejected &&
+      reconnectAttempts >= 3 &&
+      hostId ? (
+        <HostDiagnosticsLink
+          onPress={() =>
+            router.push({ pathname: '/connection-log', params: { hostId: String(hostId) } })
+          }
+        />
+      ) : null}
 
       {/* Why a bounced route landed here (e.g. the workspace was deleted on the desktop). */}
       {routeNotice && (

--- a/mobile/app/troubleshoot.tsx
+++ b/mobile/app/troubleshoot.tsx
@@ -222,7 +222,7 @@ export default function TroubleshootScreen() {
           onPress={() => router.push('/connection-log')}
         >
           <ScrollText size={16} color={colors.textPrimary} />
-          <Text style={styles.diagnosticButtonLabel}>View connection log</Text>
+          <Text style={styles.diagnosticButtonLabel}>View network diagnostics</Text>
         </Pressable>
 
         {checks.length > 0 && (

--- a/mobile/src/components/ConnectionLog.test.tsx
+++ b/mobile/src/components/ConnectionLog.test.tsx
@@ -1,0 +1,48 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ConnectionLogEntry } from '../transport/types'
+import { ConnectionLog } from './ConnectionLog'
+
+vi.mock('react-native', () => ({
+  ScrollView: 'ScrollView',
+  StyleSheet: { create: <T,>(styles: T) => styles, hairlineWidth: 1 },
+  Text: 'Text',
+  View: 'View'
+}))
+
+const entries: ConnectionLogEntry[] = [
+  { id: 'event-1', ts: 1, level: 'info', message: 'Opening WebSocket' }
+]
+
+describe('ConnectionLog', () => {
+  let renderer: ReactTestRenderer | null = null
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+  })
+
+  function renderLog(fillAvailableHeight = false): ReactTestRenderer {
+    act(() => {
+      renderer = create(createElement(ConnectionLog, { entries, fillAvailableHeight }))
+    })
+    return renderer as unknown as ReactTestRenderer
+  }
+
+  it('keeps the compact height in pairing flows', () => {
+    const instance = renderLog()
+    const containerStyles = instance.root.findAllByType('View')[0]!.props.style
+
+    expect(containerStyles).toContainEqual({ maxHeight: 240 })
+  })
+
+  it('fills the available diagnostics viewport', () => {
+    const instance = renderLog(true)
+    const containerStyles = instance.root.findAllByType('View')[0]!.props.style
+    const scroll = instance.root.findByType('ScrollView')
+
+    expect(containerStyles).toContainEqual({ flex: 1 })
+    expect(scroll.props.style).toEqual({ flex: 1 })
+  })
+})

--- a/mobile/src/components/ConnectionLog.test.tsx
+++ b/mobile/src/components/ConnectionLog.test.tsx
@@ -1,5 +1,5 @@
 import { createElement } from 'react'
-import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { act, create } from 'react-test-renderer'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ConnectionLogEntry } from '../transport/types'
 import { ConnectionLog } from './ConnectionLog'
@@ -16,18 +16,29 @@ const entries: ConnectionLogEntry[] = [
 ]
 
 describe('ConnectionLog', () => {
-  let renderer: ReactTestRenderer | null = null
+  type RenderedNode = { props: { style?: unknown } }
+  type Renderer = {
+    root: {
+      findAllByType: (type: unknown) => RenderedNode[]
+      findByType: (type: unknown) => RenderedNode
+    }
+    unmount: () => void
+  }
+
+  let renderer: Renderer | null = null
 
   afterEach(() => {
     act(() => renderer?.unmount())
     renderer = null
   })
 
-  function renderLog(fillAvailableHeight = false): ReactTestRenderer {
+  function renderLog(fillAvailableHeight = false): Renderer {
     act(() => {
-      renderer = create(createElement(ConnectionLog, { entries, fillAvailableHeight }))
+      renderer = create(
+        createElement(ConnectionLog, { entries, fillAvailableHeight })
+      ) as unknown as Renderer
     })
-    return renderer as unknown as ReactTestRenderer
+    return renderer as Renderer
   }
 
   it('keeps the compact height in pairing flows', () => {

--- a/mobile/src/components/ConnectionLog.test.tsx
+++ b/mobile/src/components/ConnectionLog.test.tsx
@@ -15,6 +15,11 @@ const entries: ConnectionLogEntry[] = [
   { id: 'event-1', ts: 1, level: 'info', message: 'Opening WebSocket' }
 ]
 
+const duplicateEntries: ConnectionLogEntry[] = [
+  { id: 'relay-1', ts: 1, level: 'info', message: 'Relay recovery started' },
+  { id: 'relay-1', ts: 2, level: 'warn', message: 'Relay retry scheduled' }
+]
+
 describe('ConnectionLog', () => {
   type RenderedNode = { props: { style?: unknown } }
   type Renderer = {
@@ -55,5 +60,22 @@ describe('ConnectionLog', () => {
 
     expect(containerStyles).toContainEqual({ flex: 1 })
     expect(scroll.props.style).toEqual({ flex: 1 })
+  })
+
+  it('does not emit duplicate-key warnings for repeated persisted event IDs', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    act(() => {
+      renderer = create(
+        createElement(ConnectionLog, { entries: duplicateEntries })
+      ) as unknown as Renderer
+    })
+
+    expect(
+      consoleError.mock.calls.some(([message]) =>
+        String(message).includes('Encountered two children with the same key')
+      )
+    ).toBe(false)
+
+    consoleError.mockRestore()
   })
 })

--- a/mobile/src/components/ConnectionLog.tsx
+++ b/mobile/src/components/ConnectionLog.tsx
@@ -8,6 +8,7 @@ type Props = {
   // Tag printed before the first entry so it's clear what's being logged
   // (e.g. 'Pairing' vs 'Reconnect').
   title?: string
+  fillAvailableHeight?: boolean
 }
 
 const LEVEL_COLOR: Record<ConnectionLogEntry['level'], string> = {
@@ -37,7 +38,7 @@ function formatTime(ts: number, baseTs: number): string {
   return `+${Math.round(elapsed)}s`
 }
 
-export function ConnectionLog({ entries, title }: Props) {
+export function ConnectionLog({ entries, title, fillAvailableHeight = false }: Props) {
   const scrollRef = useRef<ScrollView | null>(null)
 
   if (entries.length === 0) {
@@ -46,11 +47,16 @@ export function ConnectionLog({ entries, title }: Props) {
   const baseTs = entries[0]!.ts
 
   return (
-    <View style={styles.container}>
+    <View
+      style={[
+        styles.container,
+        fillAvailableHeight ? styles.fillContainer : styles.boundedContainer
+      ]}
+    >
       {title && <Text style={styles.title}>{title}</Text>}
       <ScrollView
         ref={scrollRef}
-        style={styles.scroll}
+        style={fillAvailableHeight ? styles.fillScroll : styles.boundedScroll}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
         onContentSizeChange={() => scrollRef.current?.scrollToEnd({ animated: true })}
@@ -81,13 +87,18 @@ export function ConnectionLog({ entries, title }: Props) {
 const styles = StyleSheet.create({
   container: {
     width: '100%',
-    maxHeight: 240,
     backgroundColor: colors.bgPanel,
     borderRadius: radii.card,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: colors.borderSubtle,
     paddingVertical: spacing.sm,
     paddingHorizontal: spacing.md
+  },
+  boundedContainer: {
+    maxHeight: 240
+  },
+  fillContainer: {
+    flex: 1
   },
   title: {
     fontSize: typography.metaSize,
@@ -97,8 +108,11 @@ const styles = StyleSheet.create({
     letterSpacing: 1,
     marginBottom: spacing.xs
   },
-  scroll: {
+  boundedScroll: {
     maxHeight: 200
+  },
+  fillScroll: {
+    flex: 1
   },
   scrollContent: {
     gap: 6

--- a/mobile/src/components/ConnectionLog.tsx
+++ b/mobile/src/components/ConnectionLog.tsx
@@ -45,6 +45,7 @@ export function ConnectionLog({ entries, title, fillAvailableHeight = false }: P
     return null
   }
   const baseTs = entries[0]!.ts
+  const keyOccurrences = new Map<string, number>()
 
   return (
     <View
@@ -61,24 +62,29 @@ export function ConnectionLog({ entries, title, fillAvailableHeight = false }: P
         showsVerticalScrollIndicator={false}
         onContentSizeChange={() => scrollRef.current?.scrollToEnd({ animated: true })}
       >
-        {entries.map((entry) => (
-          <View key={entry.id} style={styles.row}>
-            <Text style={styles.timestamp}>{formatTime(entry.ts, baseTs)}</Text>
-            <Text style={[styles.glyph, { color: LEVEL_COLOR[entry.level] }]}>
-              {LEVEL_GLYPH[entry.level]}
-            </Text>
-            <View style={styles.rowText}>
-              <Text style={[styles.message, { color: LEVEL_COLOR[entry.level] }]}>
-                {entry.message}
+        {entries.map((entry) => {
+          const occurrence = keyOccurrences.get(entry.id) ?? 0
+          keyOccurrences.set(entry.id, occurrence + 1)
+          const renderKey = occurrence === 0 ? entry.id : `${entry.id}:${occurrence}`
+          return (
+            <View key={renderKey} style={styles.row}>
+              <Text style={styles.timestamp}>{formatTime(entry.ts, baseTs)}</Text>
+              <Text style={[styles.glyph, { color: LEVEL_COLOR[entry.level] }]}>
+                {LEVEL_GLYPH[entry.level]}
               </Text>
-              {entry.detail && (
-                <Text style={styles.detail} numberOfLines={2}>
-                  {entry.detail}
+              <View style={styles.rowText}>
+                <Text style={[styles.message, { color: LEVEL_COLOR[entry.level] }]}>
+                  {entry.message}
                 </Text>
-              )}
+                {entry.detail && (
+                  <Text style={styles.detail} numberOfLines={2}>
+                    {entry.detail}
+                  </Text>
+                )}
+              </View>
             </View>
-          </View>
-        ))}
+          )
+        })}
       </ScrollView>
     </View>
   )

--- a/mobile/src/components/HostDiagnosticsLink.tsx
+++ b/mobile/src/components/HostDiagnosticsLink.tsx
@@ -1,0 +1,38 @@
+import { ChevronRight } from 'lucide-react-native'
+import { Pressable, StyleSheet, Text } from 'react-native'
+import { colors, radii, spacing, typography } from '../theme/mobile-theme'
+
+export function HostDiagnosticsLink({ onPress }: { onPress: () => void }): React.JSX.Element {
+  return (
+    <Pressable
+      style={styles.link}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel="View network diagnostics"
+    >
+      <Text style={styles.text}>View network diagnostics</Text>
+      <ChevronRight size={16} color={colors.textSecondary} />
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  link: {
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.sm,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgPanel,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between'
+  },
+  text: {
+    color: colors.textSecondary,
+    fontSize: typography.metaSize,
+    fontWeight: '600'
+  }
+})

--- a/mobile/src/diagnostics/connection-diagnostics-analysis.test.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-analysis.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { diagnoseConnection } from './connection-diagnostics-analysis'
+import type { ConnectionLogEntry } from '../transport/types'
+
+function event(message: string, detail?: string): ConnectionLogEntry {
+  return { id: message, ts: 1, level: 'error', message, detail }
+}
+
+describe('diagnoseConnection', () => {
+  it('reports the current healthy path instead of a historical failure', () => {
+    expect(
+      diagnoseConnection({
+        endpoint: 'ws://100.88.90.25:6768',
+        state: 'connected',
+        activePath: 'relay',
+        entries: [event('WebSocket connect timeout')]
+      })
+    ).toEqual({
+      likelyCause: 'Connection is healthy via Relay.',
+      nextStep: 'No action needed.'
+    })
+  })
+
+  it('distinguishes an invalid Relay credential from a transient outage', () => {
+    expect(
+      diagnoseConnection({
+        endpoint: 'ws://100.88.90.25:6768',
+        state: 'reconnecting',
+        pendingPath: 'relay',
+        entries: [event('Relay: relay dial failed', 'relay director resolve failed (401)')]
+      })
+    ).toEqual({
+      likelyCause: 'Relay rejected the saved resume credential.',
+      nextStep: 'Try a direct connection; if Relay keeps returning 401, pair this device again.'
+    })
+  })
+
+  it('identifies the direct Tailscale timeout while Relay recovery is pending', () => {
+    expect(
+      diagnoseConnection({
+        endpoint: 'ws://100.88.90.25:6768',
+        state: 'reconnecting',
+        activePath: 'tailscale',
+        pendingPath: 'relay',
+        entries: [event('WebSocket connect timeout')]
+      })
+    ).toEqual({
+      likelyCause: 'The saved Tailscale endpoint did not answer before the connection timeout.',
+      nextStep: 'Relay recovery is in progress; keep Orca open while it retries.'
+    })
+  })
+
+  it('identifies an authenticated Relay liveness failure', () => {
+    expect(
+      diagnoseConnection({
+        endpoint: 'ws://192.168.1.2:6768',
+        state: 'reconnecting',
+        activePath: 'relay',
+        entries: [
+          {
+            ...event('Relay health check failed'),
+            code: 'liveness-timeout',
+            path: 'relay'
+          }
+        ]
+      })
+    ).toEqual({
+      likelyCause: 'Relay stopped answering authenticated health checks.',
+      nextStep: 'Orca closed the stale session and started recovery.'
+    })
+  })
+
+  it('separates an active Relay close from a failed Relay dial', () => {
+    expect(
+      diagnoseConnection({
+        endpoint: 'ws://192.168.1.2:6768',
+        state: 'reconnecting',
+        activePath: 'relay',
+        entries: [
+          {
+            ...event('Relay: active relay session failed', 'RelayOuterError: close code 4408'),
+            code: 'relay-session-failed',
+            path: 'relay'
+          }
+        ]
+      })
+    ).toEqual({
+      likelyCause: 'The active Relay session closed unexpectedly.',
+      nextStep: 'Orca started Relay recovery; the event history includes the cell close reason.'
+    })
+  })
+})

--- a/mobile/src/diagnostics/connection-diagnostics-analysis.test.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-analysis.test.ts
@@ -17,7 +17,8 @@ describe('diagnoseConnection', () => {
       })
     ).toEqual({
       likelyCause: 'Connection is healthy via Relay.',
-      nextStep: 'No action needed.'
+      nextStep: 'No action needed.',
+      reportability: 'none'
     })
   })
 
@@ -31,7 +32,8 @@ describe('diagnoseConnection', () => {
       })
     ).toEqual({
       likelyCause: 'Relay rejected the saved resume credential.',
-      nextStep: 'Try a direct connection; if Relay keeps returning 401, pair this device again.'
+      nextStep: 'Try a direct connection; if Relay keeps returning 401, pair this device again.',
+      reportability: 'none'
     })
   })
 
@@ -46,7 +48,8 @@ describe('diagnoseConnection', () => {
       })
     ).toEqual({
       likelyCause: 'The saved Tailscale endpoint did not answer before the connection timeout.',
-      nextStep: 'Relay recovery is in progress; keep Orca open while it retries.'
+      nextStep: 'Relay recovery is in progress; keep Orca open while it retries.',
+      reportability: 'none'
     })
   })
 
@@ -66,7 +69,8 @@ describe('diagnoseConnection', () => {
       })
     ).toEqual({
       likelyCause: 'Relay stopped answering authenticated health checks.',
-      nextStep: 'Orca closed the stale session and started recovery.'
+      nextStep: 'Orca closed the stale session and started recovery.',
+      reportability: 'orca-relay'
     })
   })
 
@@ -86,7 +90,52 @@ describe('diagnoseConnection', () => {
       })
     ).toEqual({
       likelyCause: 'The active Relay session closed unexpectedly.',
-      nextStep: 'Orca started Relay recovery; the event history includes the cell close reason.'
+      nextStep: 'Orca started Relay recovery; the event history includes the cell close reason.',
+      reportability: 'orca-relay'
     })
+  })
+
+  it('marks authenticated Relay liveness failures as safe to send', () => {
+    expect(
+      diagnoseConnection({
+        endpoint: 'ws://192.168.1.2:6768',
+        state: 'reconnecting',
+        activePath: 'relay',
+        entries: [
+          {
+            ...event('Relay health check failed'),
+            code: 'liveness-timeout',
+            path: 'relay'
+          }
+        ]
+      }).reportability
+    ).toBe('orca-relay')
+  })
+
+  it.each([
+    ['direct timeout', 'connect-timeout', 'tailscale'],
+    ['handshake timeout', 'handshake-timeout', 'relay'],
+    ['invalid credential', 'relay director resolve failed (401)', 'relay'],
+    ['ambiguous recovery', 'retry scheduled', 'relay']
+  ] as const)('does not offer submission for %s', (_name, message, path) => {
+    expect(
+      diagnoseConnection({
+        endpoint: 'ws://100.88.90.25:6768',
+        state: 'reconnecting',
+        pendingPath: 'relay',
+        entries: [{ ...event(message), path }]
+      }).reportability
+    ).toBe('none')
+  })
+
+  it('does not offer submission for a bounded Relay director outage', () => {
+    expect(
+      diagnoseConnection({
+        endpoint: 'ws://100.88.90.25:6768',
+        state: 'reconnecting',
+        pendingPath: 'relay',
+        entries: [event('Relay: relay dial failed', 'relay director resolve failed (503)')]
+      }).reportability
+    ).toBe('none')
   })
 })

--- a/mobile/src/diagnostics/connection-diagnostics-analysis.test.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-analysis.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { diagnoseConnection } from './connection-diagnostics-analysis'
+import {
+  diagnoseConnection,
+  getReportableConnectionIncidentId
+} from './connection-diagnostics-analysis'
 import type { ConnectionLogEntry } from '../transport/types'
 
 function event(message: string, detail?: string): ConnectionLogEntry {
@@ -162,5 +165,76 @@ describe('diagnoseConnection', () => {
         entries: [event('active relay session failed')]
       }).reportability
     ).toBe('none')
+  })
+
+  it('ignores failures from before the current app resume boundary', () => {
+    expect(
+      diagnoseConnection({
+        endpoint: 'ws://192.168.1.2:6768',
+        state: 'connecting',
+        activePath: 'lan',
+        entries: [
+          {
+            ...event('Relay health check failed'),
+            code: 'liveness-timeout',
+            path: 'relay'
+          },
+          {
+            ...event('App returned to foreground'),
+            id: 'resume',
+            ts: 2,
+            code: 'app-resumed'
+          },
+          { ...event('WebSocket closed'), id: 'closed', ts: 3, code: 'socket-closed' }
+        ]
+      }).reportability
+    ).toBe('none')
+  })
+
+  it('uses a structured direct liveness path ahead of the current active path', () => {
+    expect(
+      diagnoseConnection({
+        endpoint: 'ws://192.168.1.2:6768',
+        state: 'reconnecting',
+        activePath: 'relay',
+        entries: [
+          {
+            ...event('Connection health check failed'),
+            code: 'liveness-timeout',
+            path: 'lan'
+          }
+        ]
+      })
+    ).toEqual({
+      likelyCause: 'The connected host stopped answering authenticated health checks.',
+      nextStep: 'Orca closed the stale session and started recovery.',
+      reportability: 'none'
+    })
+  })
+
+  it('keys reportability to the current structured incident', () => {
+    const args = {
+      endpoint: 'ws://192.168.1.2:6768',
+      state: 'reconnecting' as const,
+      activePath: 'relay' as const,
+      entries: [
+        { ...event('Authenticated'), code: 'direct-connected' as const, path: 'lan' as const },
+        {
+          ...event('Relay health check failed'),
+          id: 'current-relay-failure',
+          ts: 2,
+          code: 'liveness-timeout' as const,
+          path: 'relay' as const
+        }
+      ]
+    }
+
+    expect(getReportableConnectionIncidentId(args)).toBe('current-relay-failure')
+    expect(
+      getReportableConnectionIncidentId({
+        ...args,
+        entries: [...args.entries, { ...event('Network changed'), ts: 3, code: 'network-changed' }]
+      })
+    ).toBeNull()
   })
 })

--- a/mobile/src/diagnostics/connection-diagnostics-analysis.test.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-analysis.test.ts
@@ -138,4 +138,29 @@ describe('diagnoseConnection', () => {
       }).reportability
     ).toBe('none')
   })
+
+  it('classifies the newest failure instead of an older persisted 401', () => {
+    expect(
+      diagnoseConnection({
+        endpoint: 'ws://100.88.90.25:6768',
+        state: 'reconnecting',
+        pendingPath: 'relay',
+        entries: [
+          event('Relay: relay dial failed', 'relay director resolve failed (401)'),
+          { ...event('WebSocket connect timeout'), id: 'newer', ts: 2, code: 'connect-timeout' }
+        ]
+      }).likelyCause
+    ).toBe('The saved Tailscale endpoint did not answer before the connection timeout.')
+  })
+
+  it('requires structured Relay evidence before offering submission', () => {
+    expect(
+      diagnoseConnection({
+        endpoint: 'ws://192.168.1.2:6768',
+        state: 'reconnecting',
+        activePath: 'relay',
+        entries: [event('active relay session failed')]
+      }).reportability
+    ).toBe('none')
+  })
 })

--- a/mobile/src/diagnostics/connection-diagnostics-analysis.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-analysis.ts
@@ -1,0 +1,113 @@
+import { isTailscaleEndpoint } from '../../../src/shared/remote-runtime-tailscale-hint'
+import type {
+  ConnectionLogEntry,
+  ConnectionState,
+  MobileConnectionDiagnosticPath
+} from '../transport/types'
+
+export type ConnectionDiagnosis = {
+  likelyCause: string
+  nextStep: string
+}
+
+export function diagnoseConnection(args: {
+  endpoint: string
+  state: ConnectionState
+  activePath?: MobileConnectionDiagnosticPath
+  pendingPath?: MobileConnectionDiagnosticPath | null
+  entries: readonly ConnectionLogEntry[]
+}): ConnectionDiagnosis {
+  if (args.state === 'connected') {
+    return {
+      likelyCause: `Connection is healthy${args.activePath ? ` via ${formatPath(args.activePath)}` : ''}.`,
+      nextStep: 'No action needed.'
+    }
+  }
+  const evidence = args.entries
+    .map((entry) => `${entry.code ?? ''} ${entry.message} ${entry.detail ?? ''}`)
+    .join('\n')
+
+  if (/relay director resolve failed \(401\)/i.test(evidence)) {
+    return {
+      likelyCause: 'Relay rejected the saved resume credential.',
+      nextStep: 'Try a direct connection; if Relay keeps returning 401, pair this device again.'
+    }
+  }
+
+  if (/relay director resolve failed \(503\)/i.test(evidence)) {
+    const retryMs = parseRetryDelayMs(evidence)
+    return {
+      likelyCause: `Relay service was temporarily unavailable${retryMs == null ? '.' : ` and asked Orca to retry in ${formatDelay(retryMs)}.`}`,
+      nextStep: 'Keep Orca open; recovery should retry automatically.'
+    }
+  }
+
+  if (/liveness-timeout|liveness timeout|connection health check failed/i.test(evidence)) {
+    const path = args.activePath === 'relay' ? 'Relay' : 'The connected host'
+    return {
+      likelyCause: `${path} stopped answering authenticated health checks.`,
+      nextStep: 'Orca closed the stale session and started recovery.'
+    }
+  }
+
+  if (/relay-session-failed|active relay session failed/i.test(evidence)) {
+    return {
+      likelyCause: 'The active Relay session closed unexpectedly.',
+      nextStep: 'Orca started Relay recovery; the event history includes the cell close reason.'
+    }
+  }
+
+  if (/authentication-rejected|unauthorized|pairing may be revoked/i.test(evidence)) {
+    return {
+      likelyCause: 'The desktop rejected this device during authentication.',
+      nextStep: 'Confirm the device is still paired; pair it again if the rejection repeats.'
+    }
+  }
+
+  if (/connect-timeout|websocket connect timeout/i.test(evidence)) {
+    return {
+      likelyCause: isTailscaleEndpoint(args.endpoint)
+        ? 'The saved Tailscale endpoint did not answer before the connection timeout.'
+        : 'The saved direct endpoint did not answer before the connection timeout.',
+      nextStep:
+        args.pendingPath === 'relay'
+          ? 'Relay recovery is in progress; keep Orca open while it retries.'
+          : 'Check the local/VPN network and confirm the desktop is awake.'
+    }
+  }
+
+  if (/handshake-timeout|handshake timeout/i.test(evidence)) {
+    return {
+      likelyCause: 'The endpoint opened, but the encrypted Orca handshake did not finish.',
+      nextStep: 'Confirm the desktop is running a compatible Orca version and retry.'
+    }
+  }
+
+  if (args.pendingPath === 'relay') {
+    return {
+      likelyCause: 'Relay recovery is selected, but no more specific failure is recorded yet.',
+      nextStep: 'Keep this page open while the next recovery event is recorded.'
+    }
+  }
+
+  return {
+    likelyCause: 'No single failure cause can be determined from the recorded events.',
+    nextStep: 'Run diagnostics and copy the report again after the next connection attempt.'
+  }
+}
+
+function parseRetryDelayMs(evidence: string): number | null {
+  const match = /retry(?:-|\s)?after(?:=|\s)(\d+)ms/i.exec(evidence)
+  return match ? Number(match[1]) : null
+}
+
+function formatDelay(ms: number): string {
+  return ms < 60_000 ? `${Math.round(ms / 1000)}s` : `${Math.round(ms / 60_000)}m`
+}
+
+function formatPath(path: MobileConnectionDiagnosticPath): string {
+  if (path === 'relay') {
+    return 'Relay'
+  }
+  return path === 'tailscale' ? 'Tailscale/direct' : 'LAN/direct'
+}

--- a/mobile/src/diagnostics/connection-diagnostics-analysis.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-analysis.ts
@@ -8,6 +8,7 @@ import type {
 export type ConnectionDiagnosis = {
   likelyCause: string
   nextStep: string
+  reportability: 'none' | 'orca-relay'
 }
 
 export function diagnoseConnection(args: {
@@ -20,7 +21,8 @@ export function diagnoseConnection(args: {
   if (args.state === 'connected') {
     return {
       likelyCause: `Connection is healthy${args.activePath ? ` via ${formatPath(args.activePath)}` : ''}.`,
-      nextStep: 'No action needed.'
+      nextStep: 'No action needed.',
+      reportability: 'none'
     }
   }
   const evidence = args.entries
@@ -30,7 +32,8 @@ export function diagnoseConnection(args: {
   if (/relay director resolve failed \(401\)/i.test(evidence)) {
     return {
       likelyCause: 'Relay rejected the saved resume credential.',
-      nextStep: 'Try a direct connection; if Relay keeps returning 401, pair this device again.'
+      nextStep: 'Try a direct connection; if Relay keeps returning 401, pair this device again.',
+      reportability: 'none'
     }
   }
 
@@ -38,29 +41,41 @@ export function diagnoseConnection(args: {
     const retryMs = parseRetryDelayMs(evidence)
     return {
       likelyCause: `Relay service was temporarily unavailable${retryMs == null ? '.' : ` and asked Orca to retry in ${formatDelay(retryMs)}.`}`,
-      nextStep: 'Keep Orca open; recovery should retry automatically.'
+      nextStep: 'Keep Orca open; recovery should retry automatically.',
+      reportability: 'none'
     }
   }
 
   if (/liveness-timeout|liveness timeout|connection health check failed/i.test(evidence)) {
     const path = args.activePath === 'relay' ? 'Relay' : 'The connected host'
+    const relayLiveness =
+      args.activePath === 'relay' ||
+      args.entries.some(
+        (entry) =>
+          entry.path === 'relay' &&
+          (entry.code === 'liveness-timeout' ||
+            /liveness timeout|health check failed/i.test(entry.message))
+      )
     return {
       likelyCause: `${path} stopped answering authenticated health checks.`,
-      nextStep: 'Orca closed the stale session and started recovery.'
+      nextStep: 'Orca closed the stale session and started recovery.',
+      reportability: relayLiveness ? 'orca-relay' : 'none'
     }
   }
 
   if (/relay-session-failed|active relay session failed/i.test(evidence)) {
     return {
       likelyCause: 'The active Relay session closed unexpectedly.',
-      nextStep: 'Orca started Relay recovery; the event history includes the cell close reason.'
+      nextStep: 'Orca started Relay recovery; the event history includes the cell close reason.',
+      reportability: 'orca-relay'
     }
   }
 
   if (/authentication-rejected|unauthorized|pairing may be revoked/i.test(evidence)) {
     return {
       likelyCause: 'The desktop rejected this device during authentication.',
-      nextStep: 'Confirm the device is still paired; pair it again if the rejection repeats.'
+      nextStep: 'Confirm the device is still paired; pair it again if the rejection repeats.',
+      reportability: 'none'
     }
   }
 
@@ -72,27 +87,31 @@ export function diagnoseConnection(args: {
       nextStep:
         args.pendingPath === 'relay'
           ? 'Relay recovery is in progress; keep Orca open while it retries.'
-          : 'Check the local/VPN network and confirm the desktop is awake.'
+          : 'Check the local/VPN network and confirm the desktop is awake.',
+      reportability: 'none'
     }
   }
 
   if (/handshake-timeout|handshake timeout/i.test(evidence)) {
     return {
       likelyCause: 'The endpoint opened, but the encrypted Orca handshake did not finish.',
-      nextStep: 'Confirm the desktop is running a compatible Orca version and retry.'
+      nextStep: 'Confirm the desktop is running a compatible Orca version and retry.',
+      reportability: 'none'
     }
   }
 
   if (args.pendingPath === 'relay') {
     return {
       likelyCause: 'Relay recovery is selected, but no more specific failure is recorded yet.',
-      nextStep: 'Keep this page open while the next recovery event is recorded.'
+      nextStep: 'Keep this page open while the next recovery event is recorded.',
+      reportability: 'none'
     }
   }
 
   return {
     likelyCause: 'No single failure cause can be determined from the recorded events.',
-    nextStep: 'Run diagnostics and copy the report again after the next connection attempt.'
+    nextStep: 'Run diagnostics and copy the report again after the next connection attempt.',
+    reportability: 'none'
   }
 }
 

--- a/mobile/src/diagnostics/connection-diagnostics-analysis.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-analysis.ts
@@ -11,13 +11,15 @@ export type ConnectionDiagnosis = {
   reportability: 'none' | 'orca-relay'
 }
 
-export function diagnoseConnection(args: {
+type DiagnoseConnectionArgs = {
   endpoint: string
   state: ConnectionState
   activePath?: MobileConnectionDiagnosticPath
   pendingPath?: MobileConnectionDiagnosticPath | null
   entries: readonly ConnectionLogEntry[]
-}): ConnectionDiagnosis {
+}
+
+export function diagnoseConnection(args: DiagnoseConnectionArgs): ConnectionDiagnosis {
   if (args.state === 'connected') {
     return {
       likelyCause: `Connection is healthy${args.activePath ? ` via ${formatPath(args.activePath)}` : ''}.`,
@@ -25,7 +27,7 @@ export function diagnoseConnection(args: {
       reportability: 'none'
     }
   }
-  const failure = args.entries.toReversed().find(isDiagnosticFailure)
+  const failure = findCurrentDiagnosticFailure(args.entries)
   const evidence = failure ? `${failure.code ?? ''} ${failure.message} ${failure.detail ?? ''}` : ''
 
   if (/relay director resolve failed \(401\)/i.test(evidence)) {
@@ -47,7 +49,13 @@ export function diagnoseConnection(args: {
 
   if (/liveness-timeout|liveness timeout|connection health check failed/i.test(evidence)) {
     const relayLiveness = failure?.code === 'liveness-timeout' && failure.path === 'relay'
-    const path = relayLiveness || args.activePath === 'relay' ? 'Relay' : 'The connected host'
+    const structuredDirectLiveness =
+      failure?.code === 'liveness-timeout' &&
+      (failure.path === 'lan' || failure.path === 'tailscale')
+    const path =
+      relayLiveness || (!structuredDirectLiveness && args.activePath === 'relay')
+        ? 'Relay'
+        : 'The connected host'
     return {
       likelyCause: `${path} stopped answering authenticated health checks.`,
       nextStep: 'Orca closed the stale session and started recovery.',
@@ -106,6 +114,34 @@ export function diagnoseConnection(args: {
     nextStep: 'Run diagnostics and copy the report again after the next connection attempt.',
     reportability: 'none'
   }
+}
+
+export function getReportableConnectionIncidentId(args: DiagnoseConnectionArgs): string | null {
+  if (diagnoseConnection(args).reportability !== 'orca-relay') {
+    return null
+  }
+  return findCurrentDiagnosticFailure(args.entries)?.id ?? null
+}
+
+function findCurrentDiagnosticFailure(
+  entries: readonly ConnectionLogEntry[]
+): ConnectionLogEntry | undefined {
+  const boundaryIndex = entries.findLastIndex(isDiagnosticBoundary)
+  return entries
+    .slice(boundaryIndex + 1)
+    .toReversed()
+    .find(isDiagnosticFailure)
+}
+
+function isDiagnosticBoundary(entry: ConnectionLogEntry): boolean {
+  return (
+    entry.code === 'client-session-started' ||
+    entry.code === 'app-resumed' ||
+    entry.code === 'network-changed' ||
+    entry.code === 'relay-connected' ||
+    entry.code === 'direct-connected' ||
+    entry.message === 'Authenticated'
+  )
 }
 
 function isDiagnosticFailure(entry: ConnectionLogEntry): boolean {

--- a/mobile/src/diagnostics/connection-diagnostics-analysis.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-analysis.ts
@@ -25,9 +25,8 @@ export function diagnoseConnection(args: {
       reportability: 'none'
     }
   }
-  const evidence = args.entries
-    .map((entry) => `${entry.code ?? ''} ${entry.message} ${entry.detail ?? ''}`)
-    .join('\n')
+  const failure = args.entries.toReversed().find(isDiagnosticFailure)
+  const evidence = failure ? `${failure.code ?? ''} ${failure.message} ${failure.detail ?? ''}` : ''
 
   if (/relay director resolve failed \(401\)/i.test(evidence)) {
     return {
@@ -47,15 +46,8 @@ export function diagnoseConnection(args: {
   }
 
   if (/liveness-timeout|liveness timeout|connection health check failed/i.test(evidence)) {
-    const path = args.activePath === 'relay' ? 'Relay' : 'The connected host'
-    const relayLiveness =
-      args.activePath === 'relay' ||
-      args.entries.some(
-        (entry) =>
-          entry.path === 'relay' &&
-          (entry.code === 'liveness-timeout' ||
-            /liveness timeout|health check failed/i.test(entry.message))
-      )
+    const relayLiveness = failure?.code === 'liveness-timeout' && failure.path === 'relay'
+    const path = relayLiveness || args.activePath === 'relay' ? 'Relay' : 'The connected host'
     return {
       likelyCause: `${path} stopped answering authenticated health checks.`,
       nextStep: 'Orca closed the stale session and started recovery.',
@@ -67,7 +59,8 @@ export function diagnoseConnection(args: {
     return {
       likelyCause: 'The active Relay session closed unexpectedly.',
       nextStep: 'Orca started Relay recovery; the event history includes the cell close reason.',
-      reportability: 'orca-relay'
+      reportability:
+        failure?.code === 'relay-session-failed' && failure.path === 'relay' ? 'orca-relay' : 'none'
     }
   }
 
@@ -113,6 +106,13 @@ export function diagnoseConnection(args: {
     nextStep: 'Run diagnostics and copy the report again after the next connection attempt.',
     reportability: 'none'
   }
+}
+
+function isDiagnosticFailure(entry: ConnectionLogEntry): boolean {
+  const evidence = `${entry.code ?? ''} ${entry.message} ${entry.detail ?? ''}`
+  return /relay director resolve failed \((?:401|503)\)|liveness-timeout|liveness timeout|connection health check failed|relay-session-failed|active relay session failed|authentication-rejected|unauthorized|pairing may be revoked|connect-timeout|websocket connect timeout|handshake-timeout|handshake timeout/i.test(
+    evidence
+  )
 }
 
 function parseRetryDelayMs(evidence: string): number | null {

--- a/mobile/src/diagnostics/connection-diagnostics-report.test.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-report.test.ts
@@ -13,6 +13,7 @@ describe('buildConnectionDiagnosticsReport', () => {
       lastConnectedAt: NOW - 5 * 60_000,
       platform: 'ios 26.5.1',
       appVersion: '0.0.29',
+      desktopAppVersion: '1.4.191',
       entries: [
         {
           id: 'log-1',
@@ -26,6 +27,7 @@ describe('buildConnectionDiagnosticsReport', () => {
     })
 
     expect(report).toContain('App: Orca Mobile 0.0.29 · ios 26.5.1')
+    expect(report).toContain('Host Orca version: 1.4.191')
     expect(report).toContain('Endpoint: 100.65.9.106:6768 (Tailscale)')
     expect(report).toContain('State: reconnecting (reconnect attempts: 12)')
     expect(report).toContain('(5m 0s ago)')
@@ -48,6 +50,7 @@ describe('buildConnectionDiagnosticsReport', () => {
     })
 
     expect(report).toContain('Endpoint: 192.168.1.50:6768')
+    expect(report).toContain('Host Orca version: unknown')
     expect(report).not.toContain('(Tailscale)')
     expect(report).toContain('Last connected: never this session')
     expect(report).toContain('No connection events recorded.')

--- a/mobile/src/diagnostics/connection-diagnostics-report.test.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-report.test.ts
@@ -50,6 +50,39 @@ describe('buildConnectionDiagnosticsReport', () => {
     expect(report).toContain('Endpoint: 192.168.1.50:6768')
     expect(report).not.toContain('(Tailscale)')
     expect(report).toContain('Last connected: never this session')
-    expect(report).toContain('No connection events recorded this session.')
+    expect(report).toContain('No connection events recorded.')
+  })
+
+  it('explains the most likely cause and redacts credentials before copying', () => {
+    const report = buildConnectionDiagnosticsReport({
+      hostName: 'Host 3',
+      endpoint: 'ws://100.88.90.25:6768',
+      state: 'reconnecting',
+      reconnectAttempts: 4,
+      lastConnectedAt: null,
+      platform: 'android 36',
+      appVersion: '0.0.46',
+      activePath: 'tailscale',
+      pendingPath: 'relay',
+      entries: [
+        {
+          id: 'relay-failure',
+          ts: NOW - 5_000,
+          level: 'error',
+          message: 'Relay: relay dial failed',
+          detail:
+            'RelayDirectorHttpError: relay director resolve failed (503); retry after 30000ms; resumeToken=secret-resume-token'
+        }
+      ],
+      nowMs: NOW
+    })
+
+    expect(report).toContain(
+      'Likely cause: Relay service was temporarily unavailable and asked Orca to retry in 30s.'
+    )
+    expect(report).toContain('Path: active=tailscale; recovery=relay')
+    expect(report).toContain('Next step: Keep Orca open; recovery should retry automatically.')
+    expect(report).toContain('resumeToken=[redacted]')
+    expect(report).not.toContain('secret-resume-token')
   })
 })

--- a/mobile/src/diagnostics/connection-diagnostics-report.test.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-report.test.ts
@@ -88,4 +88,58 @@ describe('buildConnectionDiagnosticsReport', () => {
     expect(report).toContain('resumeToken=[redacted]')
     expect(report).not.toContain('secret-resume-token')
   })
+
+  it('redacts quoted JSON credentials and never echoes an invalid endpoint', () => {
+    const report = buildConnectionDiagnosticsReport({
+      hostName: 'Host 4',
+      endpoint: 'not-a-url?token=endpoint-secret',
+      state: 'reconnecting',
+      reconnectAttempts: 1,
+      lastConnectedAt: null,
+      platform: 'android 36',
+      appVersion: '0.0.47',
+      entries: [
+        {
+          id: 'json-secret',
+          ts: NOW,
+          level: 'error',
+          message: 'Relay failed',
+          detail: '{"resumeToken":"json-secret","authorization":"Bearer bearer-secret"}'
+        }
+      ],
+      nowMs: NOW
+    })
+
+    expect(report).toContain('Endpoint: invalid endpoint')
+    expect(report).not.toContain('endpoint-secret')
+    expect(report).not.toContain('json-secret')
+    expect(report).not.toContain('bearer-secret')
+  })
+
+  it('bounds a single event line before submission while preserving its identity', () => {
+    const report = buildConnectionDiagnosticsReport({
+      hostName: 'Host 5',
+      endpoint: 'ws://192.168.1.2:6768',
+      state: 'reconnecting',
+      reconnectAttempts: 1,
+      lastConnectedAt: null,
+      platform: 'android 36',
+      appVersion: '0.0.47',
+      entries: [
+        {
+          id: 'oversized',
+          ts: NOW,
+          level: 'error',
+          message: `newest oversized ${'😀'.repeat(2_000)}`
+        }
+      ],
+      nowMs: NOW
+    })
+
+    expect(report).toContain('newest oversized')
+    expect(report).toContain('[truncated]')
+    expect(new TextEncoder().encode(report.split('\n').at(-1)!).byteLength).toBeLessThanOrEqual(
+      2048
+    )
+  })
 })

--- a/mobile/src/diagnostics/connection-diagnostics-report.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-report.ts
@@ -4,6 +4,7 @@ import type {
   ConnectionState,
   MobileConnectionDiagnosticPath
 } from '../transport/types'
+import { normalizeHostAppVersion } from '../transport/host-app-version-store'
 import { formatEndpoint } from './host-reachability'
 import { diagnoseConnection } from './connection-diagnostics-analysis'
 import { redactConnectionLogEntry, redactConnectionLogText } from './connection-log-redaction'
@@ -19,6 +20,7 @@ export function buildConnectionDiagnosticsReport(args: {
   lastConnectedAt: number | null
   platform: string
   appVersion: string
+  desktopAppVersion?: string | null
   entries: readonly ConnectionLogEntry[]
   activePath?: MobileConnectionDiagnosticPath
   pendingPath?: MobileConnectionDiagnosticPath | null
@@ -37,6 +39,8 @@ export function buildConnectionDiagnosticsReport(args: {
   lines.push('Orca Mobile connection diagnostics')
   lines.push(`Generated: ${new Date(now).toISOString()}`)
   lines.push(`App: Orca Mobile ${args.appVersion} · ${args.platform}`)
+  const desktopAppVersion = normalizeHostAppVersion(args.desktopAppVersion)
+  lines.push(`Host Orca version: ${desktopAppVersion ?? 'unknown'}`)
   lines.push(`Host: ${redactConnectionLogText(args.hostName)}`)
   lines.push(
     `Endpoint: ${formatEndpoint(args.endpoint)}${isTailscaleEndpoint(args.endpoint) ? ' (Tailscale)' : ''}`

--- a/mobile/src/diagnostics/connection-diagnostics-report.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-report.ts
@@ -1,6 +1,12 @@
 import { isTailscaleEndpoint } from '../../../src/shared/remote-runtime-tailscale-hint'
-import type { ConnectionLogEntry, ConnectionState } from '../transport/types'
+import type {
+  ConnectionLogEntry,
+  ConnectionState,
+  MobileConnectionDiagnosticPath
+} from '../transport/types'
 import { formatEndpoint } from './host-reachability'
+import { diagnoseConnection } from './connection-diagnostics-analysis'
+import { redactConnectionLogEntry, redactConnectionLogText } from './connection-log-redaction'
 
 // Why: one shareable text blob answering everything we historically had to
 // ask reporters one message at a time (endpoint type, state, attempt count,
@@ -14,31 +20,52 @@ export function buildConnectionDiagnosticsReport(args: {
   platform: string
   appVersion: string
   entries: readonly ConnectionLogEntry[]
+  activePath?: MobileConnectionDiagnosticPath
+  pendingPath?: MobileConnectionDiagnosticPath | null
   nowMs?: number
 }): string {
   const now = args.nowMs ?? Date.now()
+  const entries = args.entries.map(redactConnectionLogEntry)
+  const diagnosis = diagnoseConnection({
+    endpoint: args.endpoint,
+    state: args.state,
+    activePath: args.activePath,
+    pendingPath: args.pendingPath,
+    entries
+  })
   const lines: string[] = []
   lines.push('Orca Mobile connection diagnostics')
   lines.push(`Generated: ${new Date(now).toISOString()}`)
   lines.push(`App: Orca Mobile ${args.appVersion} · ${args.platform}`)
-  lines.push(`Host: ${args.hostName}`)
+  lines.push(`Host: ${redactConnectionLogText(args.hostName)}`)
   lines.push(
     `Endpoint: ${formatEndpoint(args.endpoint)}${isTailscaleEndpoint(args.endpoint) ? ' (Tailscale)' : ''}`
   )
   lines.push(`State: ${args.state} (reconnect attempts: ${args.reconnectAttempts})`)
+  if (args.activePath) {
+    lines.push(
+      `Path: active=${args.activePath}${args.pendingPath ? `; recovery=${args.pendingPath}` : ''}`
+    )
+  }
   lines.push(
     args.lastConnectedAt == null
       ? 'Last connected: never this session'
       : `Last connected: ${new Date(args.lastConnectedAt).toISOString()} (${formatAgo(now - args.lastConnectedAt)} ago)`
   )
   lines.push('')
-  if (args.entries.length === 0) {
-    lines.push('No connection events recorded this session.')
+  lines.push(`Likely cause: ${diagnosis.likelyCause}`)
+  lines.push(`Next step: ${diagnosis.nextStep}`)
+  lines.push('')
+  if (entries.length === 0) {
+    lines.push('No connection events recorded.')
   } else {
-    lines.push(`Connection log (${args.entries.length} events, oldest first):`)
-    for (const entry of args.entries) {
+    lines.push(`Recent connection history (${entries.length} events, oldest first):`)
+    for (const entry of entries) {
       const detail = entry.detail ? ` — ${entry.detail}` : ''
-      lines.push(`${new Date(entry.ts).toISOString()} [${entry.level}] ${entry.message}${detail}`)
+      const evidence = [entry.code, entry.path].filter(Boolean).join(' · ')
+      lines.push(
+        `${new Date(entry.ts).toISOString()} [${entry.level}]${evidence ? ` [${evidence}]` : ''} ${entry.message}${detail}`
+      )
     }
   }
   return lines.join('\n')

--- a/mobile/src/diagnostics/connection-diagnostics-report.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-report.ts
@@ -9,6 +9,9 @@ import { formatEndpoint } from './host-reachability'
 import { diagnoseConnection } from './connection-diagnostics-analysis'
 import { redactConnectionLogEntry, redactConnectionLogText } from './connection-log-redaction'
 
+const MAX_EVENT_LINE_BYTES = 2 * 1024
+const EVENT_TRUNCATION_MARKER = ' … [truncated]'
+
 // Why: one shareable text blob answering everything we historically had to
 // ask reporters one message at a time (endpoint type, state, attempt count,
 // last-connected, versions, and the reconnect lifecycle log).
@@ -68,11 +71,33 @@ export function buildConnectionDiagnosticsReport(args: {
       const detail = entry.detail ? ` — ${entry.detail}` : ''
       const evidence = [entry.code, entry.path].filter(Boolean).join(' · ')
       lines.push(
-        `${new Date(entry.ts).toISOString()} [${entry.level}]${evidence ? ` [${evidence}]` : ''} ${entry.message}${detail}`
+        truncateUtf8WithMarker(
+          `${new Date(entry.ts).toISOString()} [${entry.level}]${evidence ? ` [${evidence}]` : ''} ${entry.message}${detail}`,
+          MAX_EVENT_LINE_BYTES,
+          EVENT_TRUNCATION_MARKER
+        )
       )
     }
   }
   return lines.join('\n')
+}
+
+function truncateUtf8WithMarker(value: string, maxBytes: number, marker: string): string {
+  if (new TextEncoder().encode(value).byteLength <= maxBytes) {
+    return value
+  }
+  const markerBytes = new TextEncoder().encode(marker).byteLength
+  const characters: string[] = []
+  let bytes = 0
+  for (const character of value) {
+    const characterBytes = new TextEncoder().encode(character).byteLength
+    if (bytes + characterBytes + markerBytes > maxBytes) {
+      break
+    }
+    characters.push(character)
+    bytes += characterBytes
+  }
+  return `${characters.join('')}${marker}`
 }
 
 function formatAgo(ms: number): string {

--- a/mobile/src/diagnostics/connection-diagnostics-screen-data.test.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-screen-data.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  readHydratedConnectionLog,
+  selectDiagnosticsHostId
+} from './connection-diagnostics-screen-data'
+import type { ConnectionLogEntry, HostProfile } from '../transport/types'
+
+const host = (id: string): HostProfile => ({
+  id,
+  name: id,
+  endpoint: 'ws://192.168.1.2:6768',
+  deviceToken: 'token',
+  publicKeyB64: 'key',
+  lastConnected: 0
+})
+
+describe('connection diagnostics screen data', () => {
+  it('prefers a valid route host when navigation changes', () => {
+    expect(selectDiagnosticsHostId([host('a'), host('b')], 'b', 'a')).toBe('b')
+    expect(selectDiagnosticsHostId([host('a')], 'missing', 'missing')).toBe('a')
+  })
+
+  it('waits for hydration and then reads the refreshed log', async () => {
+    const entries: ConnectionLogEntry[] = []
+    const store = {
+      hydrate: vi.fn(async () => {
+        entries.push({ id: 'stored', ts: 1, level: 'info', message: 'stored event' })
+      }),
+      get: vi.fn(() => entries)
+    }
+
+    await expect(readHydratedConnectionLog(store, 'host-a')).resolves.toEqual(entries)
+    expect(store.get).toHaveBeenCalledAfter(store.hydrate)
+  })
+})

--- a/mobile/src/diagnostics/connection-diagnostics-screen-data.test.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-screen-data.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  getDiagnosticsSubmissionState,
+  readConnectionDiagnosticsSnapshot,
   readHydratedConnectionLog,
-  selectDiagnosticsHostId
+  resolveDiagnosticsHostId,
+  selectDiagnosticsHostId,
+  updateDiagnosticsSubmissionState
 } from './connection-diagnostics-screen-data'
 import type { ConnectionLogEntry, HostProfile } from '../transport/types'
 
@@ -20,6 +24,33 @@ describe('connection diagnostics screen data', () => {
     expect(selectDiagnosticsHostId([host('a')], 'missing', 'missing')).toBe('a')
   })
 
+  it('applies route changes synchronously without discarding a chip choice for the same route', () => {
+    const hosts = [host('a'), host('b')]
+    expect(resolveDiagnosticsHostId(hosts, undefined, null)).toBe('a')
+    expect(resolveDiagnosticsHostId(hosts, 'b', { hostId: 'a', requestedHostId: 'a' })).toBe('b')
+    expect(resolveDiagnosticsHostId(hosts, 'b', { hostId: 'a', requestedHostId: 'b' })).toBe('a')
+  })
+
+  it('does not revive a stale manual choice when routing away and back', () => {
+    const hosts = [host('a'), host('b'), host('c')]
+    const firstRouteA = {}
+    const routeC = {}
+    const secondRouteA = {}
+    const manualSelection = { hostId: 'b', requestedHostId: 'a', routeKey: firstRouteA }
+
+    expect(resolveDiagnosticsHostId(hosts, 'c', manualSelection, routeC)).toBe('c')
+    expect(resolveDiagnosticsHostId(hosts, 'a', manualSelection, secondRouteA)).toBe('a')
+  })
+
+  it('keeps async submission completion scoped to its host incident', () => {
+    let states = updateDiagnosticsSubmissionState({}, 'host-a:incident-1', 'sending')
+    states = updateDiagnosticsSubmissionState(states, 'host-b:incident-2', 'sending')
+    states = updateDiagnosticsSubmissionState(states, 'host-a:incident-1', 'sent')
+
+    expect(getDiagnosticsSubmissionState(states, 'host-a:incident-1')).toBe('sent')
+    expect(getDiagnosticsSubmissionState(states, 'host-b:incident-2')).toBe('sending')
+  })
+
   it('waits for hydration and then reads the refreshed log', async () => {
     const entries: ConnectionLogEntry[] = []
     const store = {
@@ -31,5 +62,46 @@ describe('connection diagnostics screen data', () => {
 
     await expect(readHydratedConnectionLog(store, 'host-a')).resolves.toEqual(entries)
     expect(store.get).toHaveBeenCalledAfter(store.hydrate)
+  })
+
+  it('retries one transient hydration failure before reading', async () => {
+    const entries = [{ id: 'stored', ts: 1, level: 'info' as const, message: 'stored event' }]
+    const store = {
+      hydrate: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('storage unavailable'))
+        .mockResolvedValueOnce(undefined),
+      get: vi.fn(() => entries)
+    }
+
+    await expect(readHydratedConnectionLog(store, 'host-a')).resolves.toEqual(entries)
+    expect(store.hydrate).toHaveBeenCalledTimes(2)
+  })
+
+  it('reads connection metadata after hydration completes', async () => {
+    let state: 'connecting' | 'reconnecting' = 'connecting'
+    const store = {
+      hydrate: vi.fn(async () => {
+        state = 'reconnecting'
+      }),
+      get: vi.fn(() => [{ id: 'new', ts: 2, level: 'warn' as const, message: 'new event' }])
+    }
+    const context = {
+      getState: vi.fn(() => state),
+      getReconnectAttempt: vi.fn(() => 2),
+      getLastConnectedAt: vi.fn(() => 1),
+      getActivePath: vi.fn(() => 'relay' as const),
+      getPendingPath: vi.fn(() => null)
+    }
+
+    await expect(readConnectionDiagnosticsSnapshot(context, store, 'host-a')).resolves.toEqual({
+      state: 'reconnecting',
+      reconnectAttempts: 2,
+      lastConnectedAt: 1,
+      activePath: 'relay',
+      pendingPath: null,
+      entries: [{ id: 'new', ts: 2, level: 'warn', message: 'new event' }]
+    })
+    expect(context.getState).toHaveBeenCalledAfter(store.hydrate)
   })
 })

--- a/mobile/src/diagnostics/connection-diagnostics-screen-data.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-screen-data.ts
@@ -1,5 +1,15 @@
 import type { ConnectionLogStore } from '../transport/connection-log-buffer'
 import type { ConnectionLogEntry, HostProfile } from '../transport/types'
+import type { RpcClientContextValue } from '../transport/rpc-client-context-contract'
+
+export type DiagnosticsHostSelection = {
+  hostId: string
+  requestedHostId: string | undefined
+  routeKey?: object
+}
+
+export type DiagnosticsSubmissionState = 'sending' | 'sent' | 'failed'
+export type DiagnosticsSubmissionStates = Readonly<Record<string, DiagnosticsSubmissionState>>
 
 export function selectDiagnosticsHostId(
   hosts: readonly HostProfile[],
@@ -15,10 +25,70 @@ export function selectDiagnosticsHostId(
   return hosts[0]?.id ?? null
 }
 
+export function resolveDiagnosticsHostId(
+  hosts: readonly HostProfile[],
+  requestedHostId: string | undefined,
+  manualSelection: DiagnosticsHostSelection | null,
+  routeKey?: object
+): string | null {
+  const selected = manualSelection
+  if (selected && selected.requestedHostId === requestedHostId && selected.routeKey === routeKey) {
+    const manualHostId = selected.hostId
+    if (hosts.some((host) => host.id === manualHostId)) {
+      return manualHostId
+    }
+  }
+  return selectDiagnosticsHostId(hosts, requestedHostId, null)
+}
+
+export function getDiagnosticsSubmissionState(
+  states: DiagnosticsSubmissionStates,
+  key: string | null
+): DiagnosticsSubmissionState | 'idle' {
+  return key ? (states[key] ?? 'idle') : 'idle'
+}
+
+export function updateDiagnosticsSubmissionState(
+  states: DiagnosticsSubmissionStates,
+  key: string,
+  state: DiagnosticsSubmissionState | null
+): DiagnosticsSubmissionStates {
+  const next = { ...states }
+  if (state) {
+    next[key] = state
+  } else {
+    delete next[key]
+  }
+  return next
+}
+
 export async function readHydratedConnectionLog(
   store: Pick<ConnectionLogStore, 'hydrate' | 'get'>,
   hostId: string
 ): Promise<readonly ConnectionLogEntry[]> {
-  await store.hydrate(hostId).catch(() => {})
+  try {
+    await store.hydrate(hostId)
+  } catch {
+    await store.hydrate(hostId).catch(() => {})
+  }
   return store.get(hostId)
+}
+
+export async function readConnectionDiagnosticsSnapshot(
+  context: Pick<
+    RpcClientContextValue,
+    'getState' | 'getReconnectAttempt' | 'getLastConnectedAt' | 'getActivePath' | 'getPendingPath'
+  >,
+  store: Pick<ConnectionLogStore, 'hydrate' | 'get'>,
+  hostId: string
+) {
+  const entries = await readHydratedConnectionLog(store, hostId)
+  return {
+    state: context.getState(hostId),
+    reconnectAttempts: context.getReconnectAttempt(hostId),
+    lastConnectedAt: context.getLastConnectedAt(hostId),
+    activePath: context.getActivePath(hostId),
+    pendingPath: context.getPendingPath(hostId),
+    entries
+  }
 }

--- a/mobile/src/diagnostics/connection-diagnostics-screen-data.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-screen-data.ts
@@ -1,0 +1,24 @@
+import type { ConnectionLogStore } from '../transport/connection-log-buffer'
+import type { ConnectionLogEntry, HostProfile } from '../transport/types'
+
+export function selectDiagnosticsHostId(
+  hosts: readonly HostProfile[],
+  requestedHostId: string | undefined,
+  previousHostId: string | null
+): string | null {
+  if (requestedHostId && hosts.some((host) => host.id === requestedHostId)) {
+    return requestedHostId
+  }
+  if (previousHostId && hosts.some((host) => host.id === previousHostId)) {
+    return previousHostId
+  }
+  return hosts[0]?.id ?? null
+}
+
+export async function readHydratedConnectionLog(
+  store: Pick<ConnectionLogStore, 'hydrate' | 'get'>,
+  hostId: string
+): Promise<readonly ConnectionLogEntry[]> {
+  await store.hydrate(hostId).catch(() => {})
+  return store.get(hostId)
+}

--- a/mobile/src/diagnostics/connection-diagnostics-submission.test.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-submission.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+import { submitConnectionDiagnostics } from './connection-diagnostics-submission'
+
+describe('submitConnectionDiagnostics', () => {
+  it('sends a bounded report only through the feedback lane', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 204 }))
+    const result = await submitConnectionDiagnostics(
+      { report: 'x'.repeat(100_000), appVersion: '0.0.47', platform: 'android 36' },
+      fetchImpl
+    )
+
+    expect(result).toEqual({ ok: true })
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://www.onorca.dev/v1/feedback',
+      expect.objectContaining({ method: 'POST' })
+    )
+    const request = fetchImpl.mock.calls[0]?.[1]
+    const body = JSON.parse(String(request?.body)) as { feedback: string; submissionType: string }
+    expect(body.submissionType).toBe('feedback')
+    expect(body.feedback.length).toBeLessThanOrEqual(64 * 1024)
+  })
+
+  it('returns a safe failure for a rejected response', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 503 }))
+    await expect(
+      submitConnectionDiagnostics(
+        { report: 'report', appVersion: '0.0.47', platform: 'android' },
+        fetchImpl
+      )
+    ).resolves.toEqual({ ok: false, error: 'status 503' })
+  })
+})

--- a/mobile/src/diagnostics/connection-diagnostics-submission.test.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-submission.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { submitConnectionDiagnostics } from './connection-diagnostics-submission'
 
 describe('submitConnectionDiagnostics', () => {
-  it('sends a bounded report only through the feedback lane', async () => {
+  it('sends a bounded report through the diagnostics lane', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 204 }))
     const result = await submitConnectionDiagnostics(
       { report: 'x'.repeat(100_000), appVersion: '0.0.47', platform: 'android 36' },
@@ -16,7 +16,7 @@ describe('submitConnectionDiagnostics', () => {
     )
     const request = fetchImpl.mock.calls[0]?.[1]
     const body = JSON.parse(String(request?.body)) as { feedback: string; submissionType: string }
-    expect(body.submissionType).toBe('feedback')
+    expect(body.submissionType).toBe('connection_diagnostics')
     expect(body.feedback.length).toBeLessThanOrEqual(64 * 1024)
   })
 

--- a/mobile/src/diagnostics/connection-diagnostics-submission.test.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-submission.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
-import { submitConnectionDiagnostics } from './connection-diagnostics-submission'
+import {
+  boundConnectionDiagnosticsReport,
+  submitConnectionDiagnostics
+} from './connection-diagnostics-submission'
 
 describe('submitConnectionDiagnostics', () => {
   it('sends a bounded report through the diagnostics lane', async () => {
@@ -17,7 +20,7 @@ describe('submitConnectionDiagnostics', () => {
     const request = fetchImpl.mock.calls[0]?.[1]
     const body = JSON.parse(String(request?.body)) as { feedback: string; submissionType: string }
     expect(body.submissionType).toBe('connection_diagnostics')
-    expect(body.feedback.length).toBeLessThanOrEqual(64 * 1024)
+    expect(new TextEncoder().encode(body.feedback).byteLength).toBeLessThanOrEqual(64 * 1024)
   })
 
   it('returns a safe failure for a rejected response', async () => {
@@ -28,5 +31,24 @@ describe('submitConnectionDiagnostics', () => {
         fetchImpl
       )
     ).resolves.toEqual({ ok: false, error: 'status 503' })
+  })
+
+  it('preserves the newest complete events when bounding a UTF-8 report', () => {
+    const report = [
+      'Orca Mobile connection diagnostics',
+      'State: reconnecting',
+      '',
+      'Recent connection history (3 events, oldest first):',
+      `oldest ${'😀'.repeat(20)}`,
+      `middle ${'😀'.repeat(20)}`,
+      `newest ${'😀'.repeat(20)}`
+    ].join('\n')
+
+    const bounded = boundConnectionDiagnosticsReport(report, 180)
+
+    expect(new TextEncoder().encode(bounded).byteLength).toBeLessThanOrEqual(180)
+    expect(bounded).toContain('newest')
+    expect(bounded).not.toContain('oldest')
+    expect(bounded).toMatch(/older omitted/)
   })
 })

--- a/mobile/src/diagnostics/connection-diagnostics-submission.test.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-submission.test.ts
@@ -51,4 +51,21 @@ describe('submitConnectionDiagnostics', () => {
     expect(bounded).not.toContain('oldest')
     expect(bounded).toMatch(/older omitted/)
   })
+
+  it('retains a bounded form of the newest event when that event exceeds the budget', () => {
+    const report = [
+      'Orca Mobile connection diagnostics',
+      'State: reconnecting',
+      '',
+      'Recent connection history (2 events, oldest first):',
+      'old event',
+      `newest oversized ${'😀'.repeat(1_000)}`
+    ].join('\n')
+
+    const bounded = boundConnectionDiagnosticsReport(report, 220)
+
+    expect(new TextEncoder().encode(bounded).byteLength).toBeLessThanOrEqual(220)
+    expect(bounded).toContain('newest oversized')
+    expect(bounded).toContain('[truncated]')
+  })
 })

--- a/mobile/src/diagnostics/connection-diagnostics-submission.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-submission.ts
@@ -24,7 +24,7 @@ export async function submitConnectionDiagnostics(
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         feedback: report,
-        submissionType: 'feedback',
+        submissionType: 'connection_diagnostics',
         githubLogin: null,
         githubEmail: null,
         appVersion: submission.appVersion,

--- a/mobile/src/diagnostics/connection-diagnostics-submission.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-submission.ts
@@ -1,0 +1,50 @@
+const CONNECTION_DIAGNOSTICS_ENDPOINT = 'https://www.onorca.dev/v1/feedback'
+const SUBMISSION_TIMEOUT_MS = 10_000
+const MAX_SUBMISSION_BYTES = 64 * 1024
+
+export type ConnectionDiagnosticsSubmission = {
+  report: string
+  appVersion: string
+  platform: string
+}
+
+export type ConnectionDiagnosticsSubmissionResult = { ok: true } | { ok: false; error: string }
+
+/** Sends only the already-redacted, bounded report after an explicit user tap. */
+export async function submitConnectionDiagnostics(
+  submission: ConnectionDiagnosticsSubmission,
+  fetchImpl: typeof fetch = fetch
+): Promise<ConnectionDiagnosticsSubmissionResult> {
+  const report = submission.report.slice(0, MAX_SUBMISSION_BYTES)
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), SUBMISSION_TIMEOUT_MS)
+  try {
+    const response = await fetchImpl(CONNECTION_DIAGNOSTICS_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        feedback: report,
+        submissionType: 'feedback',
+        githubLogin: null,
+        githubEmail: null,
+        appVersion: submission.appVersion,
+        platform: `mobile-${submission.platform}`,
+        osRelease: 'unknown',
+        arch: 'unknown'
+      }),
+      signal: controller.signal
+    })
+    return response.ok ? { ok: true } : { ok: false, error: `status ${response.status}` }
+  } catch (error) {
+    return {
+      ok: false,
+      error: controller.signal.aborted
+        ? 'request timed out'
+        : error instanceof Error
+          ? error.message
+          : 'request failed'
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/mobile/src/diagnostics/connection-diagnostics-submission.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-submission.ts
@@ -15,7 +15,7 @@ export async function submitConnectionDiagnostics(
   submission: ConnectionDiagnosticsSubmission,
   fetchImpl: typeof fetch = fetch
 ): Promise<ConnectionDiagnosticsSubmissionResult> {
-  const report = submission.report.slice(0, MAX_SUBMISSION_BYTES)
+  const report = boundConnectionDiagnosticsReport(submission.report)
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), SUBMISSION_TIMEOUT_MS)
   try {
@@ -47,4 +47,57 @@ export async function submitConnectionDiagnostics(
   } finally {
     clearTimeout(timeout)
   }
+}
+
+export function boundConnectionDiagnosticsReport(
+  report: string,
+  maxBytes: number = MAX_SUBMISSION_BYTES
+): string {
+  if (utf8Bytes(report) <= maxBytes) {
+    return report
+  }
+  const lines = report.split('\n')
+  const historyIndex = lines.findIndex((line) => line.startsWith('Recent connection history ('))
+  if (historyIndex === -1) {
+    return truncateUtf8(report, maxBytes)
+  }
+  const header = lines.slice(0, historyIndex)
+  const events = lines.slice(historyIndex + 1)
+  let kept: string[] = []
+  for (let index = events.length - 1; index >= 0; index--) {
+    const candidateEvents = [events[index]!, ...kept]
+    const candidate = formatBoundedReport(header, candidateEvents, events.length)
+    if (utf8Bytes(candidate) > maxBytes) {
+      break
+    }
+    kept = candidateEvents
+  }
+  return truncateUtf8(formatBoundedReport(header, kept, events.length), maxBytes)
+}
+
+function formatBoundedReport(header: string[], events: string[], totalEvents: number): string {
+  const omitted = totalEvents - events.length
+  return [
+    ...header,
+    `Recent connection history (${events.length} newest events; ${omitted} older omitted):`,
+    ...events
+  ].join('\n')
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  const characters: string[] = []
+  let bytes = 0
+  for (const character of value) {
+    const characterBytes = utf8Bytes(character)
+    if (bytes + characterBytes > maxBytes) {
+      break
+    }
+    characters.push(character)
+    bytes += characterBytes
+  }
+  return characters.join('')
+}
+
+function utf8Bytes(value: string): number {
+  return new TextEncoder().encode(value).byteLength
 }

--- a/mobile/src/diagnostics/connection-diagnostics-submission.ts
+++ b/mobile/src/diagnostics/connection-diagnostics-submission.ts
@@ -72,7 +72,29 @@ export function boundConnectionDiagnosticsReport(
     }
     kept = candidateEvents
   }
+  if (kept.length === 0 && events.length > 0) {
+    return formatReportWithTruncatedNewestEvent(header, events, maxBytes)
+  }
   return truncateUtf8(formatBoundedReport(header, kept, events.length), maxBytes)
+}
+
+function formatReportWithTruncatedNewestEvent(
+  header: string[],
+  events: string[],
+  maxBytes: number
+): string {
+  const history = `Recent connection history (1 newest event; ${events.length - 1} older omitted):`
+  const prefix = [...header, history].join('\n') + '\n'
+  const availableBytes = maxBytes - utf8Bytes(prefix)
+  if (availableBytes <= 0) {
+    return truncateUtf8(prefix, maxBytes)
+  }
+  const marker = ' … [truncated]'
+  const markerBytes = utf8Bytes(marker)
+  if (availableBytes <= markerBytes) {
+    return truncateUtf8(prefix, maxBytes)
+  }
+  return `${prefix}${truncateUtf8(events.at(-1)!, availableBytes - markerBytes)}${marker}`
 }
 
 function formatBoundedReport(header: string[], events: string[], totalEvents: number): string {

--- a/mobile/src/diagnostics/connection-log-redaction.ts
+++ b/mobile/src/diagnostics/connection-log-redaction.ts
@@ -1,0 +1,23 @@
+import type { ConnectionLogEntry } from '../transport/types'
+
+const SECRET_ASSIGNMENT =
+  /\b(resumeToken|deviceToken|authorization|credential|token|publicKeyB64)(\s*[:=]\s*)(?:Bearer\s+)?([^\s;,]+)/gi
+const SECRET_QUERY = /([?&](?:token|credential|resumeToken|deviceToken)=)[^&#\s]+/gi
+const URL_USERINFO = /(wss?:\/\/)[^/@\s]+@/gi
+
+export function redactConnectionLogText(value: string): string {
+  return value
+    .replace(SECRET_ASSIGNMENT, (_match, label: string, separator: string) => {
+      return `${label}${separator}[redacted]`
+    })
+    .replace(SECRET_QUERY, '$1[redacted]')
+    .replace(URL_USERINFO, '$1[redacted]@')
+}
+
+export function redactConnectionLogEntry(entry: ConnectionLogEntry): ConnectionLogEntry {
+  return {
+    ...entry,
+    message: redactConnectionLogText(entry.message),
+    ...(entry.detail ? { detail: redactConnectionLogText(entry.detail) } : {})
+  }
+}

--- a/mobile/src/diagnostics/connection-log-redaction.ts
+++ b/mobile/src/diagnostics/connection-log-redaction.ts
@@ -1,12 +1,40 @@
 import type { ConnectionLogEntry } from '../transport/types'
 
+const SECRET_JSON_ASSIGNMENT =
+  /(["'])(resumeToken|deviceToken|authorization|credential|token|publicKeyB64)\1(\s*:\s*)(["'])(?:Bearer\s+)?(?:\\.|(?!\4)[^\\\r\n])*\4/gi
+const SECRET_QUOTED_VALUE_ASSIGNMENT =
+  /\b(resumeToken|deviceToken|authorization|credential|token|publicKeyB64)(\s*[:=]\s*)(["'])(?:Bearer\s+)?(?:\\.|(?!\3)[^\\\r\n])*\3/gi
+const SECRET_UNTERMINATED_JSON_ASSIGNMENT =
+  /(["'])(resumeToken|deviceToken|authorization|credential|token|publicKeyB64)\1(\s*:\s*)(["'])(?:Bearer\s+)?(?:\\.|(?!\4)[^\\\r\n])*(?=\r?\n|$)/gi
+const SECRET_UNTERMINATED_QUOTED_VALUE_ASSIGNMENT =
+  /\b(resumeToken|deviceToken|authorization|credential|token|publicKeyB64)(\s*[:=]\s*)(["'])(?:Bearer\s+)?(?:\\.|(?!\3)[^\\\r\n])*(?=\r?\n|$)/gi
 const SECRET_ASSIGNMENT =
-  /\b(resumeToken|deviceToken|authorization|credential|token|publicKeyB64)(\s*[:=]\s*)(?:Bearer\s+)?([^\s;,]+)/gi
+  /\b(resumeToken|deviceToken|authorization|credential|token|publicKeyB64)(\s*[:=]\s*)(?:Bearer\s+)?([^\s;,}"']+)/gi
 const SECRET_QUERY = /([?&](?:token|credential|resumeToken|deviceToken)=)[^&#\s]+/gi
-const URL_USERINFO = /(wss?:\/\/)[^/@\s]+@/gi
+const URL_USERINFO = /((?:wss?|https?):\/\/)[^\s/?#]*@/gi
 
 export function redactConnectionLogText(value: string): string {
   return value
+    .replace(
+      SECRET_JSON_ASSIGNMENT,
+      (_match, keyQuote: string, label: string, separator: string, valueQuote: string) =>
+        `${keyQuote}${label}${keyQuote}${separator}${valueQuote}[redacted]${valueQuote}`
+    )
+    .replace(
+      SECRET_QUOTED_VALUE_ASSIGNMENT,
+      (_match, label: string, separator: string, valueQuote: string) =>
+        `${label}${separator}${valueQuote}[redacted]${valueQuote}`
+    )
+    .replace(
+      SECRET_UNTERMINATED_JSON_ASSIGNMENT,
+      (_match, keyQuote: string, label: string, separator: string, valueQuote: string) =>
+        `${keyQuote}${label}${keyQuote}${separator}${valueQuote}[redacted]`
+    )
+    .replace(
+      SECRET_UNTERMINATED_QUOTED_VALUE_ASSIGNMENT,
+      (_match, label: string, separator: string, valueQuote: string) =>
+        `${label}${separator}${valueQuote}[redacted]`
+    )
     .replace(SECRET_ASSIGNMENT, (_match, label: string, separator: string) => {
       return `${label}${separator}[redacted]`
     })

--- a/mobile/src/diagnostics/host-reachability.test.ts
+++ b/mobile/src/diagnostics/host-reachability.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { testHostReachability, unreachableHostDetail } from './host-reachability'
+import { formatEndpoint, testHostReachability, unreachableHostDetail } from './host-reachability'
 
 describe('unreachableHostDetail', () => {
   it('points at Tailscale for tailnet CGNAT endpoints', () => {
@@ -20,6 +20,10 @@ describe('unreachableHostDetail', () => {
 
   it('does not treat non-CGNAT 100.x addresses as Tailscale', () => {
     expect(unreachableHostDetail('ws://100.20.1.5:6768')).toBe('Cannot reach 100.20.1.5:6768')
+  })
+
+  it('does not echo malformed endpoints that may contain credentials', () => {
+    expect(formatEndpoint('not-a-url?token=secret')).toBe('invalid endpoint')
   })
 })
 

--- a/mobile/src/diagnostics/host-reachability.ts
+++ b/mobile/src/diagnostics/host-reachability.ts
@@ -55,7 +55,7 @@ export function formatEndpoint(endpoint: string): string {
     const url = new URL(endpoint)
     return url.host
   } catch {
-    return endpoint
+    return 'invalid endpoint'
   }
 }
 

--- a/mobile/src/home/MobileHomeScreen.tsx
+++ b/mobile/src/home/MobileHomeScreen.tsx
@@ -177,6 +177,8 @@ export function MobileHomeScreen() {
           onDismiss: () => setActionTarget(null),
           onReconnect: (hostId) => void forceReconnectHost(hostId),
           onDisconnect: disconnectHostClient,
+          onDiagnostics: (hostId) =>
+            data.router.push({ pathname: '/connection-log', params: { hostId } }),
           onEdit: openMobileHostEdit,
           onRemove: (host) => setConfirmRemove(host)
         })}

--- a/mobile/src/host-list-action-sheet-actions.test.ts
+++ b/mobile/src/host-list-action-sheet-actions.test.ts
@@ -3,6 +3,7 @@ import { getHostListActionSheetActions } from './host-list-action-sheet-actions'
 import type { ConnectionState, HostProfile } from './transport/types'
 
 vi.mock('lucide-react-native', () => ({
+  Activity: vi.fn(),
   Edit3: vi.fn(),
   PowerOff: vi.fn(),
   RefreshCw: vi.fn()
@@ -22,6 +23,7 @@ function build(overrides: { state?: ConnectionState; hasEverConnected?: boolean 
     onDismiss: vi.fn(),
     onReconnect: vi.fn(),
     onDisconnect: vi.fn(),
+    onDiagnostics: vi.fn(),
     onEdit: vi.fn(),
     onRemove: vi.fn()
   }
@@ -35,14 +37,17 @@ function build(overrides: { state?: ConnectionState; hasEverConnected?: boolean 
 }
 
 describe('getHostListActionSheetActions', () => {
-  // Why: both open a second drawer. Presenting one while this sheet's native
+  // Why: these navigate or open a second drawer. Presenting while this sheet's native
   // Modal is still up freezes the whole screen on iOS — issue #8791.
-  it.each(['Edit host', 'Remove'])('defers %s until the action sheet has closed', (label) => {
-    const { actions } = build()
-    expect(actions.find((action) => action.label === label)).toMatchObject({
-      closeBeforePress: true
-    })
-  })
+  it.each(['Network diagnostics', 'Edit host', 'Remove'])(
+    'defers %s until the action sheet has closed',
+    (label) => {
+      const { actions } = build()
+      expect(actions.find((action) => action.label === label)).toMatchObject({
+        closeBeforePress: true
+      })
+    }
+  )
 
   it('leaves the in-place actions undeferred so they fire on tap', () => {
     const { actions, spies } = build()
@@ -65,15 +70,23 @@ describe('getHostListActionSheetActions', () => {
     expect(spies.onEdit).toHaveBeenCalledWith(HOST.id)
   })
 
+  it('routes Network diagnostics with the selected host', () => {
+    const { actions, spies } = build()
+    actions.find((action) => action.label === 'Network diagnostics')?.onPress()
+    expect(spies.onDiagnostics).toHaveBeenCalledWith(HOST.id)
+  })
+
   it('offers Disconnect only while the socket is live', () => {
     expect(build({ state: 'reconnecting' }).actions.map((action) => action.label)).toEqual([
       'Reconnect',
       'Disconnect',
+      'Network diagnostics',
       'Edit host',
       'Remove'
     ])
     expect(build({ state: 'disconnected' }).actions.map((action) => action.label)).toEqual([
       'Connect',
+      'Network diagnostics',
       'Edit host',
       'Remove'
     ])
@@ -93,6 +106,7 @@ describe('getHostListActionSheetActions', () => {
         onDismiss: vi.fn(),
         onReconnect: vi.fn(),
         onDisconnect: vi.fn(),
+        onDiagnostics: vi.fn(),
         onEdit: vi.fn(),
         onRemove: vi.fn()
       })

--- a/mobile/src/host-list-action-sheet-actions.ts
+++ b/mobile/src/host-list-action-sheet-actions.ts
@@ -1,9 +1,9 @@
-import { Edit3, PowerOff, RefreshCw } from 'lucide-react-native'
+import { Activity, Edit3, PowerOff, RefreshCw } from 'lucide-react-native'
 import type { ActionSheetAction } from './components/ActionSheetModal'
 import type { ConnectionState, HostProfile } from './transport/types'
 
-/** Builds the home-screen host long-press menu. Edit and Remove open a second
- *  drawer, so both must defer until this sheet's native Modal has unmounted —
+/** Builds the home-screen host long-press menu. Navigation and second drawers
+ *  defer until this sheet's native Modal has unmounted —
  *  presenting into a live one freezes the whole screen on iOS (issue #8791). */
 export function getHostListActionSheetActions(args: {
   host: HostProfile | null
@@ -13,6 +13,7 @@ export function getHostListActionSheetActions(args: {
   onDismiss: () => void
   onReconnect: (hostId: string) => void
   onDisconnect: (hostId: string) => void
+  onDiagnostics: (hostId: string) => void
   onEdit: (hostId: string) => void
   onRemove: (host: HostProfile) => void
 }): ActionSheetAction[] {
@@ -47,6 +48,14 @@ export function getHostListActionSheetActions(args: {
           }
         ]
       : []),
+    {
+      label: 'Network diagnostics',
+      icon: Activity,
+      closeBeforePress: true,
+      onPress: () => {
+        args.onDiagnostics(host.id)
+      }
+    },
     {
       label: 'Edit host',
       icon: Edit3,

--- a/mobile/src/transport/client-context-connection-metrics.ts
+++ b/mobile/src/transport/client-context-connection-metrics.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { useRpcClientContext, type RpcClientContextValue } from './client-context'
+import { useRpcClientContext } from './client-context'
+import type { RpcClientContextValue } from './rpc-client-context-contract'
 import type { MobileConnectionPath } from './stable-logical-rpc-client'
 
 export function useReconnectAttempt(hostId: string | undefined): number {
@@ -8,6 +9,20 @@ export function useReconnectAttempt(hostId: string | undefined): number {
 
 export function useLastConnectedAt(hostId: string | undefined): number | null {
   return useHostMetric(hostId, (context, id) => context.getLastConnectedAt(id), null)
+}
+
+export function useConnectionPathStatus(hostId: string | undefined): {
+  activePath: MobileConnectionPath
+  pendingPath: MobileConnectionPath | null
+} {
+  return useHostMetric(
+    hostId,
+    (context, id) => ({
+      activePath: context.getActivePath(id),
+      pendingPath: context.getPendingPath(id)
+    }),
+    { activePath: 'lan', pendingPath: null }
+  )
 }
 
 // Both inputs classifyConnection needs about a relay recovery, read from one

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -21,6 +21,7 @@ import {
 import { HostOpenRetryScheduler } from './host-open-retry-scheduler'
 import { openHostClientEntry, type HostClientStoreEntry } from './host-entry-opener'
 import { shouldPreserveActiveRelay } from './relay-reconnect-preservation'
+import { recordConnectionRevival } from './persisted-connection-log-store'
 import {
   createHostClientSelectors,
   listHostClients,
@@ -35,8 +36,6 @@ import type { ConnectionState, HostProfile } from './types'
 import type { RpcClientContextValue } from './rpc-client-context-contract'
 
 type StoreEntry = HostClientStoreEntry
-export type { HostClientAcquisition } from './host-client-acquisition-registry'
-export type { RpcClientContextValue } from './rpc-client-context-contract'
 
 const Ctx = createContext<RpcClientContextValue | null>(null)
 
@@ -311,7 +310,8 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       for (const hostId of pendingAcquisitionsRef.current.keys()) {
         retrySchedulerRef.current?.expedite(hostId)
       }
-      for (const entry of storeRef.current.values()) {
+      for (const [hostId, entry] of storeRef.current) {
+        recordConnectionRevival(hostId, reason)
         try {
           entry.client.notifyForeground(reason)
         } catch {

--- a/mobile/src/transport/connection-log-buffer.test.ts
+++ b/mobile/src/transport/connection-log-buffer.test.ts
@@ -53,4 +53,40 @@ describe('connection log buffer', () => {
     store.append('host-a', entry(2))
     expect(onA).toHaveBeenCalledTimes(1)
   })
+
+  it('hydrates persisted history without dropping events recorded during app startup', async () => {
+    let finishLoad: (entries: readonly ConnectionLogEntry[]) => void = () => {}
+    const load = vi.fn(
+      () =>
+        new Promise<readonly ConnectionLogEntry[]>((resolve) => {
+          finishLoad = resolve
+        })
+    )
+    const save = vi.fn(async () => {})
+    const store = createConnectionLogStore(3, { load, save })
+
+    store.append('host-a', entry(3))
+    finishLoad([entry(1), entry(2)])
+    await store.hydrate('host-a')
+
+    expect(store.get('host-a').map((e) => e.id)).toEqual(['log-1', 'log-2', 'log-3'])
+    await vi.waitFor(() => expect(save).toHaveBeenCalled())
+    expect(save).toHaveBeenLastCalledWith('host-a', [entry(1), entry(2), entry(3)])
+  })
+
+  it('redacts credentials before retaining or persisting an event', async () => {
+    const save = vi.fn(async () => {})
+    const store = createConnectionLogStore(3, { load: async () => [], save })
+
+    store.append('host-a', {
+      ...entry(1),
+      detail: 'resumeToken=do-not-copy deviceToken:also-secret'
+    })
+    await store.hydrate('host-a')
+
+    expect(store.get('host-a')[0]?.detail).toBe('resumeToken=[redacted] deviceToken:[redacted]')
+    await vi.waitFor(() => expect(save).toHaveBeenCalled())
+    expect(JSON.stringify(save.mock.calls)).not.toContain('do-not-copy')
+    expect(JSON.stringify(save.mock.calls)).not.toContain('also-secret')
+  })
 })

--- a/mobile/src/transport/connection-log-buffer.test.ts
+++ b/mobile/src/transport/connection-log-buffer.test.ts
@@ -89,4 +89,31 @@ describe('connection log buffer', () => {
     expect(JSON.stringify(save.mock.calls)).not.toContain('do-not-copy')
     expect(JSON.stringify(save.mock.calls)).not.toContain('also-secret')
   })
+
+  it('does not overwrite persisted history when hydration fails and retries later', async () => {
+    const load = vi
+      .fn<() => Promise<readonly ConnectionLogEntry[]>>()
+      .mockRejectedValueOnce(new Error('storage unavailable'))
+      .mockResolvedValueOnce([entry(1)])
+    const save = vi.fn(async () => {})
+    const store = createConnectionLogStore(3, { load, save })
+
+    store.append('host-a', entry(2))
+    await expect(store.hydrate('host-a')).rejects.toThrow('storage unavailable')
+    expect(save).not.toHaveBeenCalled()
+
+    await store.hydrate('host-a')
+    expect(store.get('host-a').map((value) => value.id)).toEqual(['log-1', 'log-2'])
+  })
+
+  it('preserves legacy entries that reused the same event id', async () => {
+    const store = createConnectionLogStore(3, {
+      load: async () => [entry(1), { ...entry(2), id: 'log-1' }],
+      save: async () => {}
+    })
+
+    await store.hydrate('host-a')
+
+    expect(store.get('host-a').map((value) => value.message)).toEqual(['event 1', 'event 2'])
+  })
 })

--- a/mobile/src/transport/connection-log-buffer.test.ts
+++ b/mobile/src/transport/connection-log-buffer.test.ts
@@ -90,6 +90,64 @@ describe('connection log buffer', () => {
     expect(JSON.stringify(save.mock.calls)).not.toContain('also-secret')
   })
 
+  it('redacts quoted credential values when the object key is unquoted', async () => {
+    const store = createConnectionLogStore(3, { load: async () => [], save: async () => {} })
+
+    store.append('host-a', {
+      ...entry(1),
+      detail: `resumeToken: 'secret-one' deviceToken="secret-two"`
+    })
+    await store.hydrate('host-a')
+
+    expect(store.get('host-a')[0]?.detail).toBe(
+      `resumeToken: '[redacted]' deviceToken="[redacted]"`
+    )
+  })
+
+  it('redacts the full quoted credential when its value contains an escaped quote', async () => {
+    const store = createConnectionLogStore(3, { load: async () => [], save: async () => {} })
+
+    store.append('host-a', {
+      ...entry(1),
+      detail: String.raw`{"token":"secret\"tail"} token: 'secret\'tail'`
+    })
+    await store.hydrate('host-a')
+
+    expect(store.get('host-a')[0]?.detail).toBe(`{"token":"[redacted]"} token: '[redacted]'`)
+  })
+
+  it('redacts unterminated quoted credentials', async () => {
+    const store = createConnectionLogStore(3, { load: async () => [], save: async () => {} })
+
+    store.append('host-a', {
+      ...entry(1),
+      message: 'token="secret',
+      detail: '{"authorization":"Bearer also-secret'
+    })
+    await store.hydrate('host-a')
+
+    expect(store.get('host-a')[0]).toMatchObject({
+      message: 'token="[redacted]',
+      detail: '{"authorization":"[redacted]'
+    })
+  })
+
+  it('redacts URL userinfo through the last authority separator', async () => {
+    const store = createConnectionLogStore(3, { load: async () => [], save: async () => {} })
+
+    store.append('host-a', {
+      ...entry(1),
+      message: 'wss://user:p@ss@example.com/x',
+      detail: 'https://user:pass@example.com/x'
+    })
+    await store.hydrate('host-a')
+
+    expect(store.get('host-a')[0]).toMatchObject({
+      message: 'wss://[redacted]@example.com/x',
+      detail: 'https://[redacted]@example.com/x'
+    })
+  })
+
   it('does not overwrite persisted history when hydration fails and retries later', async () => {
     const load = vi
       .fn<() => Promise<readonly ConnectionLogEntry[]>>()
@@ -115,5 +173,34 @@ describe('connection log buffer', () => {
     await store.hydrate('host-a')
 
     expect(store.get('host-a').map((value) => value.message)).toEqual(['event 1', 'event 2'])
+  })
+
+  it('retries one transient persistence failure without requiring another append', async () => {
+    const save = vi.fn().mockResolvedValue(undefined)
+    const store = createConnectionLogStore(3, { load: async () => [], save })
+
+    await store.hydrate('host-a')
+    await vi.waitFor(() => expect(save).toHaveBeenCalled())
+    save.mockReset()
+    save.mockRejectedValueOnce(new Error('storage unavailable')).mockResolvedValueOnce(undefined)
+    store.append('host-a', entry(1))
+
+    await vi.waitFor(() => expect(save).toHaveBeenCalledTimes(2))
+    expect(save).toHaveBeenLastCalledWith('host-a', [entry(1)])
+  })
+
+  it('does not retry failed automatic hydration for every appended event', async () => {
+    const load = vi.fn().mockRejectedValue(new Error('storage unavailable'))
+    const store = createConnectionLogStore(3, { load, save: async () => {} })
+
+    store.append('host-a', entry(1))
+    await expect(store.hydrate('host-a')).rejects.toThrow('storage unavailable')
+    store.append('host-a', entry(2))
+    store.append('host-a', entry(3))
+    await Promise.resolve()
+
+    expect(load).toHaveBeenCalledTimes(1)
+    await expect(store.hydrate('host-a')).rejects.toThrow('storage unavailable')
+    expect(load).toHaveBeenCalledTimes(2)
   })
 })

--- a/mobile/src/transport/connection-log-buffer.ts
+++ b/mobile/src/transport/connection-log-buffer.ts
@@ -1,4 +1,5 @@
 import type { ConnectionLogEntry } from './types'
+import { redactConnectionLogEntry } from '../diagnostics/connection-log-redaction'
 
 // Why: the rpc-client's onLog entries were only wired during pairing; for
 // long-lived host connections everything went to console.log, invisible to
@@ -12,19 +13,89 @@ const MAX_ENTRIES_PER_HOST = 200
 export type ConnectionLogStore = {
   append: (hostId: string, entry: ConnectionLogEntry) => void
   get: (hostId: string) => readonly ConnectionLogEntry[]
+  hydrate: (hostId: string) => Promise<void>
   subscribe: (hostId: string, listener: () => void) => () => void
 }
 
+export type ConnectionLogPersistence = {
+  load: (hostId: string) => Promise<readonly ConnectionLogEntry[]>
+  save: (hostId: string, entries: readonly ConnectionLogEntry[]) => Promise<void>
+}
+
 export function createConnectionLogStore(
-  maxEntriesPerHost: number = MAX_ENTRIES_PER_HOST
+  maxEntriesPerHost: number = MAX_ENTRIES_PER_HOST,
+  persistence?: ConnectionLogPersistence
 ): ConnectionLogStore {
   const entriesByHost = new Map<string, ConnectionLogEntry[]>()
   const listenersByHost = new Map<string, Set<() => void>>()
+  const hydratedHosts = new Set<string>()
+  const hydrationByHost = new Map<string, Promise<void>>()
+  const saveByHost = new Map<string, Promise<void>>()
   // Why: useSyncExternalStore compares snapshots by reference — getSnapshot
   // must return the SAME array until the data actually changes, or React
   // loops re-rendering. Cache per host; invalidate on append.
   const snapshotByHost = new Map<string, readonly ConnectionLogEntry[]>()
   const EMPTY: readonly ConnectionLogEntry[] = []
+
+  const trim = (entries: ConnectionLogEntry[]): void => {
+    if (entries.length > maxEntriesPerHost) {
+      entries.splice(0, entries.length - maxEntriesPerHost)
+    }
+  }
+
+  const notify = (hostId: string): void => {
+    snapshotByHost.delete(hostId)
+    const listeners = listenersByHost.get(hostId)
+    if (listeners) {
+      for (const listener of listeners) {
+        listener()
+      }
+    }
+  }
+
+  const persist = (hostId: string): void => {
+    if (!persistence || !hydratedHosts.has(hostId)) {
+      return
+    }
+    const snapshot = [...(entriesByHost.get(hostId) ?? [])]
+    const previous = saveByHost.get(hostId) ?? Promise.resolve()
+    const pending = previous
+      .catch(() => {})
+      .then(() => persistence.save(hostId, snapshot))
+      .catch(() => {})
+    saveByHost.set(hostId, pending)
+  }
+
+  const hydrate = async (hostId: string): Promise<void> => {
+    if (!persistence || hydratedHosts.has(hostId)) {
+      return
+    }
+    const existing = hydrationByHost.get(hostId)
+    if (existing) {
+      return existing
+    }
+    const pending = persistence
+      .load(hostId)
+      .then((stored) => {
+        const live = entriesByHost.get(hostId) ?? []
+        const byId = new Map<string, ConnectionLogEntry>()
+        for (const entry of [...stored, ...live]) {
+          byId.set(entry.id, redactConnectionLogEntry(entry))
+        }
+        const merged = [...byId.values()].sort((a, b) => a.ts - b.ts)
+        trim(merged)
+        entriesByHost.set(hostId, merged)
+        hydratedHosts.add(hostId)
+        notify(hostId)
+        persist(hostId)
+      })
+      .catch(() => {
+        hydratedHosts.add(hostId)
+      })
+      .finally(() => hydrationByHost.delete(hostId))
+    hydrationByHost.set(hostId, pending)
+    return pending
+  }
 
   return {
     append(hostId, entry) {
@@ -33,17 +104,10 @@ export function createConnectionLogStore(
         entries = []
         entriesByHost.set(hostId, entries)
       }
-      entries.push(entry)
-      if (entries.length > maxEntriesPerHost) {
-        entries.splice(0, entries.length - maxEntriesPerHost)
-      }
-      snapshotByHost.delete(hostId)
-      const listeners = listenersByHost.get(hostId)
-      if (listeners) {
-        for (const listener of listeners) {
-          listener()
-        }
-      }
+      entries.push(redactConnectionLogEntry(entry))
+      trim(entries)
+      notify(hostId)
+      void hydrate(hostId).then(() => persist(hostId))
     },
 
     get(hostId) {
@@ -59,6 +123,8 @@ export function createConnectionLogStore(
       snapshotByHost.set(hostId, snapshot)
       return snapshot
     },
+
+    hydrate,
 
     subscribe(hostId, listener) {
       let listeners = listenersByHost.get(hostId)
@@ -80,5 +146,3 @@ export function createConnectionLogStore(
     }
   }
 }
-
-export const connectionLogStore = createConnectionLogStore()

--- a/mobile/src/transport/connection-log-buffer.ts
+++ b/mobile/src/transport/connection-log-buffer.ts
@@ -29,6 +29,7 @@ export function createConnectionLogStore(
   const entriesByHost = new Map<string, ConnectionLogEntry[]>()
   const listenersByHost = new Map<string, Set<() => void>>()
   const hydratedHosts = new Set<string>()
+  const hydrationFailedHosts = new Set<string>()
   const hydrationByHost = new Map<string, Promise<void>>()
   const saveByHost = new Map<string, Promise<void>>()
   // Why: useSyncExternalStore compares snapshots by reference — getSnapshot
@@ -61,18 +62,27 @@ export function createConnectionLogStore(
     const previous = saveByHost.get(hostId) ?? Promise.resolve()
     const pending = previous
       .catch(() => {})
-      .then(() => persistence.save(hostId, snapshot))
+      .then(async () => {
+        try {
+          await persistence.save(hostId, snapshot)
+        } catch {
+          await persistence.save(hostId, snapshot)
+        }
+      })
       .catch(() => {})
     saveByHost.set(hostId, pending)
   }
 
-  const hydrate = async (hostId: string): Promise<void> => {
+  const hydrateHost = async (hostId: string, retryAfterFailure: boolean): Promise<void> => {
     if (!persistence || hydratedHosts.has(hostId)) {
       return
     }
     const existing = hydrationByHost.get(hostId)
     if (existing) {
       return existing
+    }
+    if (!retryAfterFailure && hydrationFailedHosts.has(hostId)) {
+      return
     }
     const pending = persistence
       .load(hostId)
@@ -92,8 +102,13 @@ export function createConnectionLogStore(
         trim(merged)
         entriesByHost.set(hostId, merged)
         hydratedHosts.add(hostId)
+        hydrationFailedHosts.delete(hostId)
         notify(hostId)
         persist(hostId)
+      })
+      .catch((error: unknown) => {
+        hydrationFailedHosts.add(hostId)
+        throw error
       })
       .finally(() => hydrationByHost.delete(hostId))
     hydrationByHost.set(hostId, pending)
@@ -110,7 +125,7 @@ export function createConnectionLogStore(
       entries.push(redactConnectionLogEntry(entry))
       trim(entries)
       notify(hostId)
-      void hydrate(hostId)
+      void hydrateHost(hostId, false)
         .then(() => persist(hostId))
         .catch(() => {})
     },
@@ -129,7 +144,7 @@ export function createConnectionLogStore(
       return snapshot
     },
 
-    hydrate,
+    hydrate: (hostId) => hydrateHost(hostId, true),
 
     subscribe(hostId, listener) {
       let listeners = listenersByHost.get(hostId)

--- a/mobile/src/transport/connection-log-buffer.ts
+++ b/mobile/src/transport/connection-log-buffer.ts
@@ -78,19 +78,22 @@ export function createConnectionLogStore(
       .load(hostId)
       .then((stored) => {
         const live = entriesByHost.get(hostId) ?? []
-        const byId = new Map<string, ConnectionLogEntry>()
+        const seen = new Set<string>()
+        const merged: ConnectionLogEntry[] = []
         for (const entry of [...stored, ...live]) {
-          byId.set(entry.id, redactConnectionLogEntry(entry))
+          const redacted = redactConnectionLogEntry(entry)
+          const fingerprint = JSON.stringify(redacted)
+          if (!seen.has(fingerprint)) {
+            seen.add(fingerprint)
+            merged.push(redacted)
+          }
         }
-        const merged = [...byId.values()].sort((a, b) => a.ts - b.ts)
+        merged.sort((a, b) => a.ts - b.ts)
         trim(merged)
         entriesByHost.set(hostId, merged)
         hydratedHosts.add(hostId)
         notify(hostId)
         persist(hostId)
-      })
-      .catch(() => {
-        hydratedHosts.add(hostId)
       })
       .finally(() => hydrationByHost.delete(hostId))
     hydrationByHost.set(hostId, pending)
@@ -107,7 +110,9 @@ export function createConnectionLogStore(
       entries.push(redactConnectionLogEntry(entry))
       trim(entries)
       notify(hostId)
-      void hydrate(hostId).then(() => persist(hostId))
+      void hydrate(hostId)
+        .then(() => persist(hostId))
+        .catch(() => {})
     },
 
     get(hostId) {

--- a/mobile/src/transport/direct-connection-log.ts
+++ b/mobile/src/transport/direct-connection-log.ts
@@ -1,0 +1,46 @@
+import { isTailscaleEndpoint } from '../../../src/shared/remote-runtime-tailscale-hint'
+import type { LivenessTimeoutEvidence } from './rpc-session-liveness-watchdog'
+import type {
+  ConnectionLogEntry,
+  ConnectionLogLevel,
+  ConnectionLogSink,
+  MobileConnectionDiagnosticPath
+} from './types'
+
+export class DirectConnectionLog {
+  private sequence = 0
+  private readonly path: MobileConnectionDiagnosticPath
+
+  constructor(
+    endpoint: string,
+    private readonly sink?: ConnectionLogSink
+  ) {
+    this.path = isTailscaleEndpoint(endpoint) ? 'tailscale' : 'lan'
+  }
+
+  emit = (
+    level: ConnectionLogLevel,
+    message: string,
+    detail?: string,
+    evidence?: Pick<ConnectionLogEntry, 'code' | 'path'>
+  ): void => {
+    this.sink?.({
+      id: `log-${++this.sequence}-${Date.now()}`,
+      ts: Date.now(),
+      level,
+      message,
+      detail,
+      ...evidence,
+      path: evidence?.path ?? this.path
+    })
+  }
+
+  livenessTimeout = (evidence: LivenessTimeoutEvidence): void => {
+    this.emit(
+      'error',
+      'Connection health check failed',
+      `${evidence.reason}; ${evidence.missedProbes}/${evidence.missedProbeLimit} probes missed; last authenticated activity ${evidence.lastInboundAgeMs}ms ago`,
+      { code: 'liveness-timeout' }
+    )
+  }
+}

--- a/mobile/src/transport/direct-rpc-client.ts
+++ b/mobile/src/transport/direct-rpc-client.ts
@@ -1,4 +1,5 @@
 import type { ConnectOptions, RpcClient, SendRequestOptions } from './rpc-client'
+import { DirectConnectionLog } from './direct-connection-log'
 import { RpcClientAuthenticationRetry } from './rpc-client-authentication-retry'
 import { RpcClientConnectionState } from './rpc-client-connection-state'
 import {
@@ -16,12 +17,7 @@ import {
 } from './rpc-client-stream-registry'
 import { RpcSessionLivenessWatchdog } from './rpc-session-liveness-watchdog'
 import { isStaleForegroundDial } from './rpc-stale-dial'
-import type {
-  ConnectionLogLevel,
-  ConnectionState,
-  ForegroundNudgeReason,
-  RpcResponse
-} from './types'
+import type { ConnectionState, ForegroundNudgeReason, RpcResponse } from './types'
 
 const LIVENESS_REQUEST_ID_PREFIX = 'mobile-liveness-'
 
@@ -36,7 +32,7 @@ export class DirectRpcClient implements RpcClient {
   private readonly authenticationRetry: RpcClientAuthenticationRetry
   private readonly socketClose: RpcClientSocketCloseController
   private requestCounter = 0
-  private logCounter = 0
+  private readonly connectionLog: DirectConnectionLog
   private intentionallyClosed = false
   private authenticationGeneration = 0
   private livenessSession: RpcClientSocketSession | null = null
@@ -47,10 +43,12 @@ export class DirectRpcClient implements RpcClient {
     serverPublicKeyB64: string,
     private readonly options: ConnectOptions
   ) {
+    this.connectionLog = new DirectConnectionLog(endpoint, options.onLog)
     this.reconnect = new RpcClientReconnectSchedule({
       openConnection: () => this.openConnection(),
       rejectConnectWaiters: (reason) => this.connectionState.rejectWaiters(reason),
-      emitLog: (message, detail) => this.emitLog('info', message, detail)
+      emitLog: (message, detail) =>
+        this.connectionLog.emit('info', message, detail, { code: 'retry-scheduled' })
     })
     this.connectionState = new RpcClientConnectionState({
       endpoint,
@@ -78,7 +76,8 @@ export class DirectRpcClient implements RpcClient {
         if (identity === this.livenessSession && this.socketSession === this.livenessSession) {
           this.socketClose.forceClose(this.livenessSession)
         }
-      }
+      },
+      onTimeout: this.connectionLog.livenessTimeout
     })
     this.socketFactory = new RpcClientSocketFactory({
       endpoint,
@@ -89,7 +88,7 @@ export class DirectRpcClient implements RpcClient {
       getReconnectAttempt: () => this.getReconnectAttempt(),
       getLastConnectedAt: () => this.getLastConnectedAt(),
       isIntentionallyClosed: () => this.intentionallyClosed,
-      emitLog: (level, message, detail) => this.emitLog(level, message, detail),
+      emitLog: this.connectionLog.emit,
       onHandshakeStarted: () => this.connectionState.publish('handshaking'),
       onAuthenticated: (session) => this.handleAuthenticated(session),
       onAuthRejected: (reason) => this.authenticationRetry.reject(reason),
@@ -102,7 +101,8 @@ export class DirectRpcClient implements RpcClient {
     this.authenticationRetry = new RpcClientAuthenticationRetry({
       endpoint,
       stopLiveness: () => this.stopLiveness(),
-      emitWarning: (message, detail) => this.emitLog('warn', message, detail),
+      emitWarning: (message, detail) =>
+        this.connectionLog.emit('warn', message, detail, { code: 'authentication-rejected' }),
       retry: (reason) => this.retryAuthentication(reason),
       latchFailure: (reason) => this.latchAuthenticationFailure(reason)
     })
@@ -122,7 +122,8 @@ export class DirectRpcClient implements RpcClient {
           this.stopLiveness()
         }
       },
-      emitWarning: (message, detail) => this.emitLog('warn', message, detail)
+      emitWarning: (message, detail, evidence) =>
+        this.connectionLog.emit('warn', message, detail, evidence)
     })
     this.openConnection()
   }
@@ -232,7 +233,7 @@ export class DirectRpcClient implements RpcClient {
     this.reconnect.authenticated()
     this.authenticationRetry.accepted()
     this.connectionState.publish('connected')
-    this.emitLog('success', 'Authenticated', 'Channel ready for RPC')
+    this.connectionLog.emit('success', 'Authenticated', 'Channel ready for RPC')
     this.streams.replayAfterAuthentication()
   }
 
@@ -310,15 +311,5 @@ export class DirectRpcClient implements RpcClient {
 
   private nextId(): string {
     return `rpc-${++this.requestCounter}-${Date.now()}`
-  }
-
-  private emitLog(level: ConnectionLogLevel, message: string, detail?: string): void {
-    this.options.onLog?.({
-      id: `log-${++this.logCounter}-${Date.now()}`,
-      ts: Date.now(),
-      level,
-      message,
-      detail
-    })
   }
 }

--- a/mobile/src/transport/direct-rpc-client.ts
+++ b/mobile/src/transport/direct-rpc-client.ts
@@ -233,7 +233,9 @@ export class DirectRpcClient implements RpcClient {
     this.reconnect.authenticated()
     this.authenticationRetry.accepted()
     this.connectionState.publish('connected')
-    this.connectionLog.emit('success', 'Authenticated', 'Channel ready for RPC')
+    this.connectionLog.emit('success', 'Authenticated', 'Channel ready for RPC', {
+      code: 'direct-connected'
+    })
     this.streams.replayAfterAuthentication()
   }
 

--- a/mobile/src/transport/host-app-version-store.test.ts
+++ b/mobile/src/transport/host-app-version-store.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const asyncStorageMock = vi.hoisted(() => ({
+  getItem: vi.fn(),
+  setItem: vi.fn()
+}))
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: asyncStorageMock
+}))
+
+import {
+  loadHostAppVersion,
+  normalizeHostAppVersion,
+  recordHostAppVersion
+} from './host-app-version-store'
+
+describe('host app version store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    asyncStorageMock.getItem.mockResolvedValue(null)
+    asyncStorageMock.setItem.mockResolvedValue(undefined)
+  })
+
+  it('persists a bounded version once per host', async () => {
+    asyncStorageMock.getItem.mockResolvedValueOnce(null).mockResolvedValueOnce('1.4.191')
+
+    await recordHostAppVersion('host-1', ' 1.4.191 ')
+    await recordHostAppVersion('host-1', '1.4.191')
+
+    expect(asyncStorageMock.setItem).toHaveBeenCalledOnce()
+    expect(asyncStorageMock.setItem).toHaveBeenCalledWith(
+      'orca:host-app-version:v1:host-1',
+      '1.4.191'
+    )
+  })
+
+  it('loads a previously observed version without requiring a live host', async () => {
+    asyncStorageMock.getItem.mockResolvedValue('1.4.188')
+
+    await expect(loadHostAppVersion('host-1')).resolves.toBe('1.4.188')
+  })
+
+  it('rejects multiline, empty, and oversized host-provided values', async () => {
+    expect(normalizeHostAppVersion('1.4.191\nInjected: value')).toBeNull()
+    expect(normalizeHostAppVersion('   ')).toBeNull()
+    expect(normalizeHostAppVersion('x'.repeat(65))).toBeNull()
+
+    await recordHostAppVersion('host-1', '1.4.191\nInjected: value')
+    expect(asyncStorageMock.setItem).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/transport/host-app-version-store.ts
+++ b/mobile/src/transport/host-app-version-store.ts
@@ -1,0 +1,47 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+const STORAGE_KEY_PREFIX = 'orca:host-app-version:v1:'
+const MAX_VERSION_LENGTH = 64
+
+export function normalizeHostAppVersion(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const normalized = value.trim()
+  if (
+    normalized.length === 0 ||
+    normalized.length > MAX_VERSION_LENGTH ||
+    normalized.includes('\n') ||
+    normalized.includes('\r')
+  ) {
+    return null
+  }
+  return normalized
+}
+
+export async function loadHostAppVersion(hostId: string): Promise<string | null> {
+  try {
+    return normalizeHostAppVersion(await AsyncStorage.getItem(storageKey(hostId)))
+  } catch {
+    return null
+  }
+}
+
+export async function recordHostAppVersion(hostId: string, value: unknown): Promise<void> {
+  const appVersion = normalizeHostAppVersion(value)
+  if (!appVersion) {
+    return
+  }
+  try {
+    const key = storageKey(hostId)
+    if (normalizeHostAppVersion(await AsyncStorage.getItem(key)) !== appVersion) {
+      await AsyncStorage.setItem(key, appVersion)
+    }
+  } catch {
+    // Best-effort diagnostic metadata must never affect host connectivity.
+  }
+}
+
+function storageKey(hostId: string): string {
+  return `${STORAGE_KEY_PREFIX}${hostId}`
+}

--- a/mobile/src/transport/host-entry-opener.ts
+++ b/mobile/src/transport/host-entry-opener.ts
@@ -1,4 +1,4 @@
-import { connectionLogStore } from './connection-log-buffer'
+import { connectionLogStore } from './persisted-connection-log-store'
 import { loadHosts } from './host-store'
 import { openHostLogicalClient } from './host-logical-client'
 import type { HostClientOpenRegistry } from './host-client-open-registry'
@@ -65,6 +65,7 @@ export async function openHostClientEntry(
       id: `host-open-${ticket.generation}-${Date.now()}`,
       ts: Date.now(),
       level: 'error',
+      code: 'host-open-failed',
       message: 'Host client open failed',
       detail: `${category}; retry ${retry.nextDelayMs}ms (failure ${retry.failureCount})`
     })

--- a/mobile/src/transport/host-entry-opener.ts
+++ b/mobile/src/transport/host-entry-opener.ts
@@ -1,4 +1,7 @@
-import { connectionLogStore } from './persisted-connection-log-store'
+import {
+  connectionLogStore,
+  recordConnectionClientSessionStart
+} from './persisted-connection-log-store'
 import { loadHosts } from './host-store'
 import { openHostLogicalClient } from './host-logical-client'
 import type { HostClientOpenRegistry } from './host-client-open-registry'
@@ -99,6 +102,7 @@ export async function openHostClientEntry(
 
     let client: RpcClient
     try {
+      recordConnectionClientSessionStart(hostId)
       client = openHostLogicalClient(host, (entry) => connectionLogStore.append(hostId, entry))
     } catch {
       failCurrentOpen('client-construction')

--- a/mobile/src/transport/host-status-gates.test.ts
+++ b/mobile/src/transport/host-status-gates.test.ts
@@ -4,6 +4,13 @@ import { describe, expect, it, vi } from 'vitest'
 import type { RpcClient } from './rpc-client'
 import { useHostStatusGates, type HostStatusGates } from './host-status-gates'
 
+const recordHostAppVersionMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+
+vi.mock('./host-app-version-store', () => ({
+  normalizeHostAppVersion: (value: unknown) => (typeof value === 'string' ? value : null),
+  recordHostAppVersion: (...args: unknown[]) => recordHostAppVersionMock(...args)
+}))
+
 describe('useHostStatusGates', () => {
   it('clears every prior-host gate and ignores its late response while the client is replaced', async () => {
     let resolveOldStatus: ((response: unknown) => void) | null = null
@@ -76,6 +83,7 @@ describe('useHostStatusGates', () => {
     const sendRequest = vi.fn().mockResolvedValue({
       ok: true,
       result: {
+        appVersion: '1.4.191',
         capabilities: ['browser.screencast.v1'],
         floatingWorkspaceEnabled: true
       }
@@ -95,11 +103,13 @@ describe('useHostStatusGates', () => {
         await Promise.resolve()
       })
       expect(gates).toMatchObject({
+        desktopAppVersion: '1.4.191',
         hostCapabilities: ['browser.screencast.v1'],
         floatingWorkspaceEnabled: true
       })
 
       expect(sendRequest).toHaveBeenCalledOnce()
+      expect(recordHostAppVersionMock).toHaveBeenCalledWith('host-1', '1.4.191')
     } finally {
       renderer?.unmount()
     }

--- a/mobile/src/transport/host-status-gates.ts
+++ b/mobile/src/transport/host-status-gates.ts
@@ -3,10 +3,12 @@ import type { RpcClient } from './rpc-client'
 import type { ConnectionState, RpcSuccess } from './types'
 import { evaluateCompat, type CompatVerdict } from './protocol-compat'
 import type { DesktopStatus } from '../worktree/host-worktree-rpc-types'
+import { normalizeHostAppVersion, recordHostAppVersion } from './host-app-version-store'
 
 export type HostStatusGates = {
   hostCapabilities: string[]
   floatingWorkspaceEnabled: boolean
+  desktopAppVersion: string | null
   compatVerdict: CompatVerdict
   statusPending: boolean
 }
@@ -53,6 +55,7 @@ export function useHostStatusGates(args: {
           settle({
             hostCapabilities: [],
             floatingWorkspaceEnabled: false,
+            desktopAppVersion: null,
             compatVerdict: { kind: 'ok' }
           })
           return
@@ -64,9 +67,14 @@ export function useHostStatusGates(args: {
           desktopProtocolVersion: status.protocolVersion,
           desktopMinCompatibleMobileVersion: status.minCompatibleMobileVersion
         })
+        const desktopAppVersion = normalizeHostAppVersion(status.appVersion)
+        if (hostId && desktopAppVersion) {
+          void recordHostAppVersion(hostId, desktopAppVersion)
+        }
         settle({
           hostCapabilities: status.capabilities ?? [],
           floatingWorkspaceEnabled: status.floatingWorkspaceEnabled === true,
+          desktopAppVersion,
           compatVerdict: verdict
         })
         if (verdict.kind === 'blocked') {
@@ -84,6 +92,7 @@ export function useHostStatusGates(args: {
           settle({
             hostCapabilities: [],
             floatingWorkspaceEnabled: false,
+            desktopAppVersion: null,
             compatVerdict: { kind: 'ok' }
           })
         }
@@ -100,6 +109,7 @@ export function useHostStatusGates(args: {
     return {
       hostCapabilities: EMPTY_HOST_CAPABILITIES,
       floatingWorkspaceEnabled: false,
+      desktopAppVersion: null,
       compatVerdict: { kind: 'ok' },
       statusPending: connState === 'connected' && client !== null
     }
@@ -107,6 +117,7 @@ export function useHostStatusGates(args: {
   return {
     hostCapabilities: proven.hostCapabilities,
     floatingWorkspaceEnabled: proven.floatingWorkspaceEnabled,
+    desktopAppVersion: proven.desktopAppVersion,
     compatVerdict: proven.compatVerdict,
     // Why (F10): unchanged pending timing — the reconnect refetch is still "unknown", it just no
     // longer blanks the capabilities this same host already proved.

--- a/mobile/src/transport/mobile-endpoint-lifecycle.ts
+++ b/mobile/src/transport/mobile-endpoint-lifecycle.ts
@@ -93,7 +93,8 @@ function createSupervisor(
         resumeCredentialVersion: credential.version,
         resumeConfirmReqId: confirmReqId,
         deviceToken: host.deviceToken,
-        desktopPublicKeyB64: host.publicKeyB64
+        desktopPublicKeyB64: host.publicKeyB64,
+        onLog
       }),
     resolveRelay: resolveMobileRelayEndpoint,
     readBundle: readMobileRelayCredentialBundle,

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -234,8 +234,10 @@ describe('mobile endpoint supervisor', () => {
       .fn()
       .mockReturnValueOnce(new FakeRelaySession('connected', new RelayOuterError(4429)))
       .mockImplementation(() => new FakeRelaySession('connected'))
+    const onLog = vi.fn()
     const deps = dependencies({
       openRelay,
+      onLog,
       randomBytes: () => new Uint8Array([128, 0])
     })
     const supervisor = new MobileEndpointSupervisor(logical, host, deps)
@@ -245,6 +247,13 @@ describe('mobile endpoint supervisor', () => {
 
     expect(openRelay).toHaveBeenCalledOnce()
     expect(logical.getPendingPath()).toBe('relay')
+    expect(onLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'relay-session-failed',
+        path: 'relay',
+        message: 'Relay: active relay session failed'
+      })
+    )
     await vi.advanceTimersByTimeAsync(249)
     expect(openRelay).toHaveBeenCalledOnce()
     await vi.advanceTimersByTimeAsync(1)

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -22,6 +22,11 @@ import * as recoveryPresentation from './mobile-relay-recovery-presentation'
 import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { ForegroundNudgeReason, HostProfile } from './types'
 import { MobileRelayBackgroundGrace } from './mobile-relay-background-grace'
+import {
+  logRelayConnected,
+  logRelayCredentialUnavailable,
+  logRelayDialFailure
+} from './mobile-relay-diagnostic-log'
 
 export type { MobileEndpointSupervisorDependencies } from './mobile-endpoint-supervisor-contract'
 
@@ -98,7 +103,7 @@ export class MobileEndpointSupervisor {
       recordMigration: () => {
         this.relayRotationPending = false
         this.hysteresis.recordMigration(dependencies.now())
-        this.logRelay('runtime channel migrated to relay')
+        logRelayConnected(this.logRelay)
       },
       scheduleLease: (expiry) =>
         this.leaseRotation.scheduleFromLease(
@@ -107,8 +112,7 @@ export class MobileEndpointSupervisor {
       scheduleDirectProbe: () => this.directProbe.schedule(),
       onBookkeepingError: (error) =>
         this.logRelay('relay bookkeeping failed after migration', error.message.slice(0, 80)),
-      onDialFailure: (error) =>
-        this.logRelay('relay dial failed', `${error.name}: ${String(error.message).slice(0, 80)}`)
+      onDialFailure: (error) => logRelayDialFailure(this.logRelay, error)
     })
     this.directProbe = new DirectReturnProbe(dependencies, {
       hysteresis: this.hysteresis,
@@ -166,7 +170,8 @@ export class MobileEndpointSupervisor {
         // Why: the direct client enters reconnecting after its first failed
         // dial and may never publish disconnected while its retry loop lives.
         recoveryPresentation.onActiveFailure(this.logical, this.relayReconnect, state, this.bundle)
-        this.relayReconnect.handleStateFailure(this.logical, state)
+        const relayFailure = this.relayReconnect.handleStateFailure(this.logical, state)
+        logRelayDialFailure(this.logRelay, relayFailure, 'active-session')
       }
     })
     if (this.relayReconnect.needsRecovery(this.logical.getState())) {
@@ -249,11 +254,7 @@ export class MobileEndpointSupervisor {
         this.logical.setRecoveryPath(null)
         // Why: "expired" vs "missing" separates a sleep-past-expiry phone
         // (needs re-pair or LAN) from a Keychain failure in field reports.
-        this.logRelay(
-          selection.bundle
-            ? 'relay credential expired or rejected; slow reprobe armed'
-            : 'no relay credential bundle; slow reprobe armed'
-        )
+        logRelayCredentialUnavailable(this.logRelay, selection.bundle !== null)
         this.relayReconnect.armCredentialReprobe()
         if (ownsRecovery) {
           // Why: no dial happened — keep the session and the intent; the reprobe

--- a/mobile/src/transport/mobile-relay-diagnostic-log.ts
+++ b/mobile/src/transport/mobile-relay-diagnostic-log.ts
@@ -1,0 +1,38 @@
+import type { RelayRecoveryLog } from './mobile-relay-recovery-log'
+import { RelayDirectorHttpError } from './mobile-relay-resume-director'
+
+export function logRelayConnected(log: RelayRecoveryLog): void {
+  log('runtime channel migrated to relay', undefined, {
+    level: 'success',
+    code: 'relay-connected'
+  })
+}
+
+export function logRelayDialFailure(
+  log: RelayRecoveryLog,
+  error: Error | null,
+  source: 'dial' | 'active-session' = 'dial'
+): void {
+  if (!error) {
+    return
+  }
+  const base = `${error.name}: ${String(error.message).slice(0, 80)}`
+  const detail =
+    error instanceof RelayDirectorHttpError && error.retryAfterMs != null
+      ? `${base}; retry-after=${error.retryAfterMs}ms`
+      : base
+  log(source === 'dial' ? 'relay dial failed' : 'active relay session failed', detail, {
+    level: 'error',
+    code: source === 'dial' ? 'relay-dial-failed' : 'relay-session-failed'
+  })
+}
+
+export function logRelayCredentialUnavailable(log: RelayRecoveryLog, hasBundle: boolean): void {
+  log(
+    hasBundle
+      ? 'relay credential expired or rejected; slow reprobe armed'
+      : 'no relay credential bundle; slow reprobe armed',
+    undefined,
+    { level: 'warn', code: 'relay-credential-unavailable' }
+  )
+}

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -46,9 +46,7 @@ export class RelayReconnectController {
     this.credentials = new RelayCredentialEligibility(dependencies.now)
   }
 
-  getFailureCount(): number {
-    return this.failureCount.current()
-  }
+  getFailureCount = (): number => this.failureCount.current()
 
   reportRecoveryTo(logical: StableLogicalRpcClient): void {
     this.failureCount.reportTo(logical.setRecoveryAttempt)
@@ -97,17 +95,17 @@ export class RelayReconnectController {
     return 'recover'
   }
 
-  handleStateFailure(logical: StableLogicalRpcClient, state: ConnectionState): void {
+  handleStateFailure(logical: StableLogicalRpcClient, state: ConnectionState): Error | null {
     if (!this.needsRecovery(state)) {
-      return
+      return null
     }
-    this.registerActiveFailure(logical)
+    const failure = this.registerActiveFailure(logical)
     this.onRetry()
+    return failure
   }
 
-  needsRecovery(state: ConnectionState): boolean {
-    return state !== 'connected' && state !== 'connecting' && state !== 'handshaking'
-  }
+  needsRecovery = (state: ConnectionState): boolean =>
+    state !== 'connected' && state !== 'connecting' && state !== 'handshaking'
 
   suspendActiveRelay(logical: StableLogicalRpcClient): void {
     if (logical.getActivePath() !== 'relay') {
@@ -207,9 +205,9 @@ export class RelayReconnectController {
 
   recordRejectedCredential = (version: number): void => this.credentials.recordRejected(version)
 
-  registerActiveFailure(logical: StableLogicalRpcClient): void {
+  registerActiveFailure(logical: StableLogicalRpcClient): Error | null {
     if (logical.getActivePath() !== 'relay') {
-      return
+      return null
     }
     const failure = this.activeSession?.getFailure()
     this.activeSession = null
@@ -219,6 +217,7 @@ export class RelayReconnectController {
     } else {
       this.activeRelayConnectedAt = null
     }
+    return failure ?? null
   }
 
   // True when the caller is still inside the cooldown window and must not

--- a/mobile/src/transport/mobile-relay-recovery-log.test.ts
+++ b/mobile/src/transport/mobile-relay-recovery-log.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createRelayRecoveryLog } from './mobile-relay-recovery-log'
+import type { ConnectionLogEntry } from './types'
+
+describe('createRelayRecoveryLog', () => {
+  it('uses distinct ids across logger instances', () => {
+    const entries: ConnectionLogEntry[] = []
+    const sink = vi.fn((entry: ConnectionLogEntry) => entries.push(entry))
+    createRelayRecoveryLog(() => 1, sink)('first')
+    createRelayRecoveryLog(() => 1, sink)('second')
+
+    expect(entries[0]?.id).not.toBe(entries[1]?.id)
+  })
+})

--- a/mobile/src/transport/mobile-relay-recovery-log.ts
+++ b/mobile/src/transport/mobile-relay-recovery-log.ts
@@ -1,6 +1,10 @@
-import type { ConnectionLogSink } from './types'
+import type { ConnectionDiagnosticCode, ConnectionLogLevel, ConnectionLogSink } from './types'
 
-export type RelayRecoveryLog = (message: string, detail?: string) => void
+export type RelayRecoveryLog = (
+  message: string,
+  detail?: string,
+  evidence?: { level?: ConnectionLogLevel; code?: ConnectionDiagnosticCode }
+) => void
 
 // Why: relay recovery failed silently in production for weeks; every decision
 // must reach logcat and the in-app connection log.
@@ -9,12 +13,14 @@ export function createRelayRecoveryLog(
   onLog?: ConnectionLogSink
 ): RelayRecoveryLog {
   let sequence = 0
-  return (message, detail) => {
+  return (message, detail, evidence) => {
     console.log(`[relay] ${message}`, detail ?? '')
     onLog?.({
       id: `relay-${++sequence}`,
       ts: now(),
-      level: 'info',
+      level: evidence?.level ?? 'info',
+      path: 'relay',
+      ...(evidence?.code ? { code: evidence.code } : {}),
       message: `Relay: ${message}`,
       ...(detail ? { detail } : {})
     })

--- a/mobile/src/transport/mobile-relay-recovery-log.ts
+++ b/mobile/src/transport/mobile-relay-recovery-log.ts
@@ -6,6 +6,8 @@ export type RelayRecoveryLog = (
   evidence?: { level?: ConnectionLogLevel; code?: ConnectionDiagnosticCode }
 ) => void
 
+let relayLoggerInstanceSequence = 0
+
 // Why: relay recovery failed silently in production for weeks; every decision
 // must reach logcat and the in-app connection log.
 export function createRelayRecoveryLog(
@@ -13,10 +15,11 @@ export function createRelayRecoveryLog(
   onLog?: ConnectionLogSink
 ): RelayRecoveryLog {
   let sequence = 0
+  const instanceId = `${Date.now().toString(36)}-${(++relayLoggerInstanceSequence).toString(36)}`
   return (message, detail, evidence) => {
     console.log(`[relay] ${message}`, detail ?? '')
     onLog?.({
-      id: `relay-${++sequence}`,
+      id: `relay-${instanceId}-${++sequence}`,
       ts: now(),
       level: evidence?.level ?? 'info',
       path: 'relay',

--- a/mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts
@@ -21,6 +21,7 @@ vi.mock('./mobile-relay-e2ee-link', () => ({
 }))
 
 import { connectMobileRelayRpcSession } from './mobile-relay-rpc-session'
+import type { ConnectionLogSink } from './types'
 
 const relay = {
   v: 1 as const,
@@ -31,7 +32,7 @@ const relay = {
   e2eeFraming: 2 as const
 }
 
-async function authenticateSession() {
+async function authenticateSession(onLog?: ConnectionLogSink) {
   const session = connectMobileRelayRpcSession({
     relay,
     resumeToken: 'resume-secret',
@@ -39,7 +40,8 @@ async function authenticateSession() {
     resumeConfirmReqId: 'confirm-1',
     deviceToken: 'device-token',
     desktopPublicKeyB64: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
-    requestTimeoutMs: 30_000
+    requestTimeoutMs: 30_000,
+    onLog
   })
   fakes.linkOptions!.onHello({
     type: 'relay-hello',
@@ -103,7 +105,8 @@ describe('mobile relay RPC session liveness', () => {
   })
 
   it('disconnects after two fair foreground misses', async () => {
-    const session = await authenticateSession()
+    const onLog = vi.fn<ConnectionLogSink>()
+    const session = await authenticateSession(onLog)
 
     session.notifyForeground('focus')
     expect(sentRequests().map(({ method }) => method)).toEqual(['status.get'])
@@ -114,6 +117,16 @@ describe('mobile relay RPC session liveness', () => {
 
     expect(session.getState()).toBe('disconnected')
     expect(fakes.close).toHaveBeenCalledOnce()
+    expect(onLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'liveness-timeout',
+        path: 'relay',
+        message: 'Relay health check failed',
+        detail: expect.stringMatching(
+          /^probe-timeout; 2\/2 probes missed; last authenticated activity \d+ms ago$/
+        )
+      })
+    )
   })
 
   it('rate-limits foreground sequences without suppressing a retry', async () => {

--- a/mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts
@@ -129,6 +129,28 @@ describe('mobile relay RPC session liveness', () => {
     )
   })
 
+  it('uses distinct liveness evidence IDs for sessions created in the same millisecond', async () => {
+    vi.setSystemTime(1_000)
+    const firstLog = vi.fn<ConnectionLogSink>()
+    const first = await authenticateSession(firstLog)
+    first.notifyForeground('focus')
+    await vi.advanceTimersByTimeAsync(8_000)
+    const firstId = firstLog.mock.calls[0]?.[0].id
+
+    vi.clearAllMocks()
+    fakes.sendText.mockReturnValue(true)
+    vi.setSystemTime(1_000)
+    const secondLog = vi.fn<ConnectionLogSink>()
+    const second = await authenticateSession(secondLog)
+    second.notifyForeground('focus')
+    await vi.advanceTimersByTimeAsync(8_000)
+    const secondId = secondLog.mock.calls[0]?.[0].id
+
+    expect(firstId).toBeTruthy()
+    expect(secondId).toBeTruthy()
+    expect(secondId).not.toBe(firstId)
+  })
+
   it('rate-limits foreground sequences without suppressing a retry', async () => {
     const session = await authenticateSession()
     session.notifyForeground('focus')

--- a/mobile/src/transport/mobile-relay-rpc-session.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session.ts
@@ -11,7 +11,7 @@ import { openRpcRequestBudget, resolvePostConnectRequestTimeout } from './rpc-re
 import { isRpcResponse } from './rpc-response-shape'
 import { RpcSessionLivenessWatchdog } from './rpc-session-liveness-watchdog'
 import type { RpcClient } from './rpc-client'
-import type { ConnectionState, RpcResponse } from './types'
+import type { ConnectionLogSink, ConnectionState, RpcResponse } from './types'
 
 const RELAY_PROBE_TIMEOUT_MS = 4_000
 const RELAY_MISSED_PROBE_LIMIT = 2
@@ -41,6 +41,7 @@ export function connectMobileRelayRpcSession(args: {
   desktopPublicKeyB64: string
   requestTimeoutMs?: number
   createSocket?: (url: string) => WebSocket
+  onLog?: ConnectionLogSink
 }): MobileRelayRpcSession {
   const requestTimeoutMs = args.requestTimeoutMs ?? 30_000
   const pending = new Map<string, PendingRequest>()
@@ -53,6 +54,7 @@ export function connectMobileRelayRpcSession(args: {
   let resumeConfirmation: DeviceResumeConfirmed | null = null
   let failure: Error | null = null
   let closed = false
+  let logSequence = 0
   const livenessIdentity = {}
   const streams = new MobileRelayRpcStreams({
     nextId,
@@ -145,6 +147,17 @@ export function connectMobileRelayRpcSession(args: {
     voluntaryProbeMinIntervalMs: RELAY_FOREGROUND_PROBE_MIN_INTERVAL_MS,
     sendProbe: () =>
       state === 'connected' && sendFrame({ id: nextId(), method: 'status.get', params: undefined }),
+    onTimeout: (evidence) => {
+      args.onLog?.({
+        id: `relay-liveness-${++logSequence}-${Date.now()}`,
+        ts: Date.now(),
+        level: 'error',
+        code: 'liveness-timeout',
+        path: 'relay',
+        message: 'Relay health check failed',
+        detail: `${evidence.reason}; ${evidence.missedProbes}/${evidence.missedProbeLimit} probes missed; last authenticated activity ${evidence.lastInboundAgeMs}ms ago`
+      })
+    },
     terminate: () => fail(new Error('relay session liveness timeout'))
   })
   return client

--- a/mobile/src/transport/mobile-relay-rpc-session.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session.ts
@@ -16,6 +16,7 @@ import type { ConnectionLogSink, ConnectionState, RpcResponse } from './types'
 const RELAY_PROBE_TIMEOUT_MS = 4_000
 const RELAY_MISSED_PROBE_LIMIT = 2
 const RELAY_FOREGROUND_PROBE_MIN_INTERVAL_MS = 10_000
+let relayRpcSessionSequence = 0
 
 type PendingRequest = {
   resolve: (response: RpcResponse) => void
@@ -55,6 +56,7 @@ export function connectMobileRelayRpcSession(args: {
   let failure: Error | null = null
   let closed = false
   let logSequence = 0
+  const logSessionId = `${Date.now().toString(36)}-${(++relayRpcSessionSequence).toString(36)}`
   const livenessIdentity = {}
   const streams = new MobileRelayRpcStreams({
     nextId,
@@ -149,7 +151,7 @@ export function connectMobileRelayRpcSession(args: {
       state === 'connected' && sendFrame({ id: nextId(), method: 'status.get', params: undefined }),
     onTimeout: (evidence) => {
       args.onLog?.({
-        id: `relay-liveness-${++logSequence}-${Date.now()}`,
+        id: `relay-liveness-${logSessionId}-${++logSequence}`,
         ts: Date.now(),
         level: 'error',
         code: 'liveness-timeout',

--- a/mobile/src/transport/persisted-connection-log-store.test.ts
+++ b/mobile/src/transport/persisted-connection-log-store.test.ts
@@ -1,0 +1,57 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ConnectionLogEntry } from './types'
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: vi.fn(),
+    setItem: vi.fn()
+  }
+}))
+
+describe('persisted connection log store', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.mocked(AsyncStorage.getItem).mockReset()
+    vi.mocked(AsyncStorage.setItem).mockReset()
+    vi.mocked(AsyncStorage.setItem).mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+  })
+
+  it('keeps a new client-session boundary when a restart shares the prior timestamp', async () => {
+    const stored: ConnectionLogEntry[] = [
+      {
+        id: 'client-session-1000',
+        ts: 1_000,
+        level: 'info',
+        code: 'client-session-started',
+        message: 'Mobile client session started'
+      },
+      {
+        id: 'relay-failure',
+        ts: 1_000,
+        level: 'error',
+        code: 'relay-session-failed',
+        message: 'Relay: active relay session failed'
+      }
+    ]
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify(stored))
+    vi.resetModules()
+    const { connectionLogStore, recordConnectionClientSessionStart } =
+      await import('./persisted-connection-log-store')
+
+    recordConnectionClientSessionStart('host-a')
+    await connectionLogStore.hydrate('host-a')
+
+    expect(connectionLogStore.get('host-a').map((entry) => entry.code)).toEqual([
+      'client-session-started',
+      'relay-session-failed',
+      'client-session-started'
+    ])
+  })
+})

--- a/mobile/src/transport/persisted-connection-log-store.ts
+++ b/mobile/src/transport/persisted-connection-log-store.ts
@@ -1,0 +1,60 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { createConnectionLogStore } from './connection-log-buffer'
+import type { ConnectionLogEntry } from './types'
+
+const STORAGE_PREFIX = 'orca.mobile.connection-log.v1.'
+
+export const connectionLogStore = createConnectionLogStore(200, {
+  async load(hostId) {
+    const raw = await AsyncStorage.getItem(storageKey(hostId))
+    if (!raw) {
+      return []
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      return Array.isArray(parsed) ? parsed.filter(isConnectionLogEntry) : []
+    } catch {
+      return []
+    }
+  },
+  save(hostId, entries) {
+    return AsyncStorage.setItem(storageKey(hostId), JSON.stringify(entries))
+  }
+})
+
+export function recordConnectionRevival(
+  hostId: string,
+  reason: 'app-resume' | 'network-change'
+): void {
+  const now = Date.now()
+  connectionLogStore.append(hostId, {
+    id: `revival-${reason}-${now}`,
+    ts: now,
+    level: 'info',
+    code: reason === 'app-resume' ? 'app-resumed' : 'network-changed',
+    message: reason === 'app-resume' ? 'App returned to foreground' : 'Network changed',
+    detail: 'Connection recovery notified'
+  })
+}
+
+function storageKey(hostId: string): string {
+  return `${STORAGE_PREFIX}${encodeURIComponent(hostId)}`
+}
+
+function isConnectionLogEntry(value: unknown): value is ConnectionLogEntry {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const entry = value as Partial<ConnectionLogEntry>
+  return (
+    typeof entry.id === 'string' &&
+    typeof entry.ts === 'number' &&
+    Number.isFinite(entry.ts) &&
+    (entry.level === 'info' ||
+      entry.level === 'success' ||
+      entry.level === 'warn' ||
+      entry.level === 'error') &&
+    typeof entry.message === 'string' &&
+    (entry.detail === undefined || typeof entry.detail === 'string')
+  )
+}

--- a/mobile/src/transport/persisted-connection-log-store.ts
+++ b/mobile/src/transport/persisted-connection-log-store.ts
@@ -3,6 +3,8 @@ import { createConnectionLogStore } from './connection-log-buffer'
 import type { ConnectionLogEntry } from './types'
 
 const STORAGE_PREFIX = 'orca.mobile.connection-log.v1.'
+const clientSessionId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+const sessionStartedHosts = new Set<string>()
 
 export const connectionLogStore = createConnectionLogStore(200, {
   async load(hostId) {
@@ -34,6 +36,21 @@ export function recordConnectionRevival(
     code: reason === 'app-resume' ? 'app-resumed' : 'network-changed',
     message: reason === 'app-resume' ? 'App returned to foreground' : 'Network changed',
     detail: 'Connection recovery notified'
+  })
+}
+
+export function recordConnectionClientSessionStart(hostId: string): void {
+  if (sessionStartedHosts.has(hostId)) {
+    return
+  }
+  sessionStartedHosts.add(hostId)
+  const now = Date.now()
+  connectionLogStore.append(hostId, {
+    id: `client-session-${clientSessionId}-${now}`,
+    ts: now,
+    level: 'info',
+    code: 'client-session-started',
+    message: 'Mobile client session started'
   })
 }
 

--- a/mobile/src/transport/rpc-client-socket-close-controller.ts
+++ b/mobile/src/transport/rpc-client-socket-close-controller.ts
@@ -6,6 +6,7 @@ import type { RpcClientSocketFactory } from './rpc-client-socket-factory'
 import type { RpcClientSocketSession } from './rpc-client-socket-session'
 import type { RpcClientStreamRegistry } from './rpc-client-stream-registry'
 import { RpcSynthesizedCloseIndex } from './rpc-socket-close-evidence'
+import type { ConnectionLogEntry } from './types'
 
 const UNAUTHORIZED_CLOSE_CODE = 4001
 
@@ -21,7 +22,11 @@ type SocketCloseControllerOptions = {
   getAuthenticationGeneration: () => number
   isIntentionallyClosed: () => boolean
   stopLiveness: (session: RpcClientSocketSession) => void
-  emitWarning: (message: string, detail: string) => void
+  emitWarning: (
+    message: string,
+    detail: string,
+    evidence?: Pick<ConnectionLogEntry, 'code' | 'path'>
+  ) => void
 }
 
 export class RpcClientSocketCloseController {
@@ -80,7 +85,11 @@ export class RpcClientSocketCloseController {
       streamCount: this.options.streams.size(),
       attempt: this.options.reconnect.getAttempt()
     })
-    this.options.emitWarning('WebSocket closed', 'Will attempt to reconnect')
+    this.options.emitWarning(
+      'WebSocket closed',
+      `${closeCode == null ? 'Close code unavailable' : `Close code ${closeCode}`}; reconnect scheduled`,
+      { code: 'socket-closed' }
+    )
     this.options.requests.rejectAll('Connection interrupted', { deliveryUnknown: true })
     this.options.connectionState.publish('reconnecting')
     this.options.reconnect.schedule()

--- a/mobile/src/transport/rpc-client-socket-factory.ts
+++ b/mobile/src/transport/rpc-client-socket-factory.ts
@@ -1,7 +1,7 @@
 import { publicKeyFromBase64 } from './e2ee'
 import { RpcClientSocketSession } from './rpc-client-socket-session'
 import { redactSocketEndpoint } from './socket-event-debug'
-import type { ConnectionLogLevel, ConnectionState, RpcResponse } from './types'
+import type { ConnectionLogEmitter, ConnectionState, RpcResponse } from './types'
 
 type SocketFactoryOptions = {
   endpoint: string
@@ -12,7 +12,7 @@ type SocketFactoryOptions = {
   getReconnectAttempt: () => number
   getLastConnectedAt: () => number | null
   isIntentionallyClosed: () => boolean
-  emitLog: (level: ConnectionLogLevel, message: string, detail?: string) => void
+  emitLog: ConnectionLogEmitter
   onHandshakeStarted: () => void
   onAuthenticated: (session: RpcClientSocketSession) => void
   onAuthRejected: (reason: string) => void

--- a/mobile/src/transport/rpc-client-socket-session.ts
+++ b/mobile/src/transport/rpc-client-socket-session.ts
@@ -9,7 +9,7 @@ import {
 import { isRpcResponse } from './rpc-response-shape'
 import { isStaleRpcSocketEvent, logRpcSocketClose } from './rpc-socket-close-evidence'
 import { describeSocketEvent, redactSocketEndpoint } from './socket-event-debug'
-import type { ConnectionLogLevel, ConnectionState, RpcResponse } from './types'
+import type { ConnectionLogEmitter, ConnectionState, RpcResponse } from './types'
 import { websocketPayloadToUint8 } from './websocket-payload-bytes'
 
 const CONNECT_TIMEOUT_MS = 12_000
@@ -24,7 +24,7 @@ type SocketSessionOptions = {
   getState: () => ConnectionState
   getReconnectAttempt: () => number
   isIntentionallyClosed: () => boolean
-  emitLog: (level: ConnectionLogLevel, message: string, detail?: string) => void
+  emitLog: ConnectionLogEmitter
   onHandshakeStarted: () => void
   onAuthenticated: (session: RpcClientSocketSession) => void
   onAuthRejected: (reason: string) => void
@@ -261,7 +261,8 @@ export class RpcClientSocketSession {
         this.options.emitLog(
           'error',
           'WebSocket connect timeout',
-          `No TCP/WS handshake within ${CONNECT_TIMEOUT_MS / 1000}s — endpoint unreachable?`
+          `No TCP/WS handshake within ${CONNECT_TIMEOUT_MS / 1000}s — endpoint unreachable?`,
+          { code: 'connect-timeout' }
         )
         this.options.onForcedClose(this)
       }
@@ -280,7 +281,8 @@ export class RpcClientSocketSession {
       this.options.emitLog(
         'error',
         'Handshake timeout',
-        `No e2ee_ready/e2ee_authenticated within ${HANDSHAKE_TIMEOUT_MS / 1000}s`
+        `No e2ee_ready/e2ee_authenticated within ${HANDSHAKE_TIMEOUT_MS / 1000}s`,
+        { code: 'handshake-timeout' }
       )
       this.options.onForcedClose(this)
     }, HANDSHAKE_TIMEOUT_MS)

--- a/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
@@ -46,6 +46,37 @@ describe('RpcSessionLivenessWatchdog', () => {
     expect(terminate).toHaveBeenCalledWith(identity)
   })
 
+  it('reports causal evidence before terminating a stale session', async () => {
+    const onTimeout = vi.fn()
+    const terminate = vi.fn()
+    const identity = {}
+    const watchdog = new RpcSessionLivenessWatchdog({
+      transport: 'relay',
+      idleProbeMs: null,
+      probeTimeoutMs: 4_000,
+      missedProbeLimit: 2,
+      sendProbe: () => true,
+      terminate,
+      onTimeout,
+      now: Date.now
+    })
+    watchdog.start(identity)
+    watchdog.probeNow(identity)
+
+    await vi.advanceTimersByTimeAsync(8_000)
+
+    expect(onTimeout).toHaveBeenCalledWith({
+      transport: 'relay',
+      reason: 'probe-timeout',
+      missedProbes: 2,
+      missedProbeLimit: 2,
+      lastInboundAgeMs: 8_000
+    })
+    expect(onTimeout.mock.invocationCallOrder[0]).toBeLessThan(
+      terminate.mock.invocationCallOrder[0]!
+    )
+  })
+
   it('authenticated activity resets suspicion', async () => {
     const { identity, terminate, watchdog } = fixture()
     watchdog.probeNow(identity)

--- a/mobile/src/transport/rpc-session-liveness-watchdog.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.ts
@@ -8,6 +8,7 @@ type WatchdogOptions = {
   transport: 'direct' | 'relay'
   sendProbe: (identity: RpcSessionIdentity) => boolean
   terminate: (identity: RpcSessionIdentity) => void
+  onTimeout?: (evidence: LivenessTimeoutEvidence) => void
   idleProbeMs?: number | null
   probeTimeoutMs?: number
   missedProbeLimit?: number
@@ -15,6 +16,14 @@ type WatchdogOptions = {
   now?: () => number
   setTimer?: typeof setTimeout
   clearTimer?: typeof clearTimeout
+}
+
+export type LivenessTimeoutEvidence = {
+  transport: 'direct' | 'relay'
+  reason: 'probe-send-failed' | 'probe-timeout'
+  missedProbes: number
+  missedProbeLimit: number
+  lastInboundAgeMs: number
 }
 
 export class RpcSessionLivenessWatchdog {
@@ -138,7 +147,7 @@ export class RpcSessionLivenessWatchdog {
       sent = false
     }
     if (!sent) {
-      this.terminateCurrent(identity)
+      this.terminateCurrent(identity, 'probe-send-failed')
       return
     }
     this.timer = this.setTimer(() => this.handleProbeTimeout(identity, sentAt), this.probeTimeoutMs)
@@ -161,7 +170,7 @@ export class RpcSessionLivenessWatchdog {
     }
     this.missedProbes += 1
     if (this.missedProbes >= this.missedProbeLimit) {
-      this.terminateCurrent(identity)
+      this.terminateCurrent(identity, 'probe-timeout')
       return
     }
     console.log('[net] activity-probe timeout tolerated', {
@@ -172,7 +181,10 @@ export class RpcSessionLivenessWatchdog {
     this.startProbe(identity)
   }
 
-  private terminateCurrent(identity: RpcSessionIdentity): void {
+  private terminateCurrent(
+    identity: RpcSessionIdentity,
+    reason: LivenessTimeoutEvidence['reason']
+  ): void {
     if (this.identity !== identity) {
       return
     }
@@ -183,6 +195,13 @@ export class RpcSessionLivenessWatchdog {
       transport: this.options.transport,
       missedProbes: this.missedProbes,
       missedProbeLimit: this.missedProbeLimit
+    })
+    this.options.onTimeout?.({
+      transport: this.options.transport,
+      reason,
+      missedProbes: this.missedProbes,
+      missedProbeLimit: this.missedProbeLimit,
+      lastInboundAgeMs: Math.max(0, this.now() - this.lastInboundAt)
     })
     this.options.terminate(identity)
   }

--- a/mobile/src/transport/types.ts
+++ b/mobile/src/transport/types.ts
@@ -39,6 +39,23 @@ export type RpcResponse = RpcSuccess | RpcFailure
 
 export type ConnectionLogLevel = 'info' | 'success' | 'warn' | 'error'
 
+export type MobileConnectionDiagnosticPath = 'lan' | 'tailscale' | 'relay'
+
+export type ConnectionDiagnosticCode =
+  | 'app-resumed'
+  | 'network-changed'
+  | 'connect-timeout'
+  | 'handshake-timeout'
+  | 'authentication-rejected'
+  | 'socket-closed'
+  | 'liveness-timeout'
+  | 'retry-scheduled'
+  | 'relay-dial-failed'
+  | 'relay-session-failed'
+  | 'relay-connected'
+  | 'relay-credential-unavailable'
+  | 'host-open-failed'
+
 export type ConnectionLogEntry = {
   id: string
   ts: number
@@ -47,9 +64,18 @@ export type ConnectionLogEntry = {
   message: string
   // Optional second line for endpoint/error/elapsed detail.
   detail?: string
+  code?: ConnectionDiagnosticCode
+  path?: MobileConnectionDiagnosticPath
 }
 
 export type ConnectionLogSink = (entry: ConnectionLogEntry) => void
+
+export type ConnectionLogEmitter = (
+  level: ConnectionLogLevel,
+  message: string,
+  detail?: string,
+  evidence?: Pick<ConnectionLogEntry, 'code' | 'path'>
+) => void
 
 export type ConnectionState =
   | 'connecting'

--- a/mobile/src/transport/types.ts
+++ b/mobile/src/transport/types.ts
@@ -42,6 +42,7 @@ export type ConnectionLogLevel = 'info' | 'success' | 'warn' | 'error'
 export type MobileConnectionDiagnosticPath = 'lan' | 'tailscale' | 'relay'
 
 export type ConnectionDiagnosticCode =
+  | 'client-session-started'
   | 'app-resumed'
   | 'network-changed'
   | 'connect-timeout'
@@ -53,6 +54,7 @@ export type ConnectionDiagnosticCode =
   | 'relay-dial-failed'
   | 'relay-session-failed'
   | 'relay-connected'
+  | 'direct-connected'
   | 'relay-credential-unavailable'
   | 'host-open-failed'
 

--- a/mobile/src/transport/use-all-host-clients.ts
+++ b/mobile/src/transport/use-all-host-clients.ts
@@ -3,7 +3,7 @@ import type { RpcClient } from './rpc-client'
 import type { MobileConnectionPath } from './stable-logical-rpc-client'
 import type { ConnectionState } from './types'
 import { useRpcClientContext } from './client-context'
-import type { HostClientAcquisition } from './client-context'
+import type { HostClientAcquisition } from './host-client-acquisition-registry'
 
 type UseAllHostClientsOptions = {
   autoConnectHostIds?: readonly string[]

--- a/mobile/src/worktree/host-worktree-rpc-types.ts
+++ b/mobile/src/worktree/host-worktree-rpc-types.ts
@@ -3,6 +3,7 @@ import type { ExecutionHostId } from '../../../src/shared/execution-host'
 
 // Locally-typed subset of the desktop status payload read from status.get.
 export type DesktopStatus = {
+  appVersion?: string
   protocolVersion?: number
   minCompatibleMobileVersion?: number
   // Why: absent on hosts that predate the mobile Floating Workspace entry;


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​977 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​965 |
| Prod | 35 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1297 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​136 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1161 |

<!-- /orca-pr-loc -->

## Summary

- revamp Settings → Troubleshooting → Network diagnostics with a plain-language likely cause and next step
- persist a bounded 200-event per-host diagnostic tail across app force-kills
- redact credentials before events enter memory, AsyncStorage, or copied reports
- record direct/Tailscale/Relay path, retry scheduling, socket close codes, app/network transitions, liveness evidence, Relay director status and Retry-After, migrations, and active Relay-session failures
- keep transport selection and reconnect behavior unchanged; no upload endpoint or automatic Slack reporting

## Deterministic baseline

Existing focused baseline was green: 4 files, 19/19 tests.

The new pre-fix oracle failed at mobile/src/diagnostics/connection-diagnostics-report.test.ts:78 because the copied report did not contain:

> Likely cause: Relay service was temporarily unavailable and asked Orca to retry in 30s.

The received report exposed only the raw Relay error and included an unredacted resume token.

## Validation

- focused diagnostics/transport gate: 8 files, 121/121 passed
- full mobile Vitest suite: 469 files, 3773 passed, 3 skipped
- pnpm typecheck
- pnpm lint
- pnpm format:check

## Privacy and scope

Reports retain the host name and endpoint because they are necessary connection evidence and copying is an explicit user action. Credentials, authorization values, public keys, URL userinfo, and sensitive query values are redacted locally. The persisted history is bounded and never leaves the device automatically.