### PR TITLE
Always enable Tasks button and provider shortcuts

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarNav.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.test.tsx
@@ -464,15 +464,21 @@ describe('SidebarNav', () => {
     expect(searchButton?.querySelector('kbd')).toBeNull()
   })
 
-  it('hides task source shortcuts until the Tasks row is hovered or focused', async () => {
+  it('keeps task source shortcuts keyboard-reachable and revealed on Tasks row hover or focus', async () => {
     const container = await renderSidebarNav()
 
     const tasksButton = getButtonByText(container, 'Tasks')
-    const shortcuts = tasksButton.querySelector('[aria-label="Open GitHub tasks"]')?.parentElement
+    const githubShortcut = tasksButton.parentElement?.querySelector<HTMLButtonElement>(
+      'button[aria-label="Open GitHub tasks"]'
+    )
+    expect(githubShortcut).not.toBeNull()
+    expect(githubShortcut?.tabIndex).toBe(0)
+    expect(tasksButton.contains(githubShortcut ?? null)).toBe(false)
 
-    expect(shortcuts?.className).toContain('hidden')
-    expect(shortcuts?.className).toContain('group-hover:flex')
-    expect(shortcuts?.className).toContain('group-focus-within:flex')
+    const shortcuts = githubShortcut?.parentElement
+    expect(shortcuts?.className).toContain('can-hover:opacity-0')
+    expect(shortcuts?.className).toContain('can-hover:group-hover:opacity-100')
+    expect(shortcuts?.className).toContain('can-hover:group-focus-within:opacity-100')
   })
 
   it('hides available Tasks from its sidebar context menu', async () => {
@@ -495,7 +501,9 @@ describe('SidebarNav', () => {
     expect(tasksButton.getAttribute('aria-disabled')).toBeNull()
     expect(tasksButton.disabled).toBe(false)
     expect(tasksButton.className).not.toContain('opacity-50')
-    expect(tasksButton.querySelector('[aria-label="Open GitHub tasks"]')).not.toBeNull()
+    expect(
+      tasksButton.parentElement?.querySelector('button[aria-label="Open GitHub tasks"]')
+    ).not.toBeNull()
 
     await clickButton(tasksButton)
     expect(mocks.openTaskPage).toHaveBeenCalled()

--- a/src/renderer/src/components/sidebar/SidebarNav.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.test.tsx
@@ -479,7 +479,6 @@ describe('SidebarNav', () => {
     const container = await renderSidebarNav()
 
     const tasksButton = getButtonByText(container, 'Tasks')
-    expect(tasksButton.getAttribute('aria-disabled')).toBe('false')
 
     const tasksMenu = tasksButton.closest('[data-testid="context-menu"]')
     expect(tasksMenu).not.toBeNull()
@@ -488,18 +487,18 @@ describe('SidebarNav', () => {
     expect(mocks.updateSettings).toHaveBeenCalledWith({ showTasksButton: false })
   })
 
-  it('keeps unavailable Tasks context-menu-capable while left click remains inert', async () => {
+  it('keeps Tasks enabled with no git repos so the page can explain the empty state', async () => {
     setSidebarState({ repos: [folderRepo()] })
     const container = await renderSidebarNav()
 
     const tasksButton = getButtonByText(container, 'Tasks')
-    expect(tasksButton.getAttribute('aria-disabled')).toBe('true')
+    expect(tasksButton.getAttribute('aria-disabled')).toBeNull()
     expect(tasksButton.disabled).toBe(false)
-    expect(tasksButton.querySelectorAll('[role="button"]')).toHaveLength(0)
-    expect(tasksButton.querySelector('[aria-label="Open GitHub tasks"]')).toBeNull()
+    expect(tasksButton.className).not.toContain('opacity-50')
+    expect(tasksButton.querySelector('[aria-label="Open GitHub tasks"]')).not.toBeNull()
 
     await clickButton(tasksButton)
-    expect(mocks.openTaskPage).not.toHaveBeenCalled()
+    expect(mocks.openTaskPage).toHaveBeenCalled()
 
     const tasksMenu = tasksButton.closest('[data-testid="context-menu"]')
     expect(tasksMenu).not.toBeNull()

--- a/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
+++ b/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
@@ -34,33 +34,24 @@ function HideTaskSidebarMenu({ onHide }: { onHide: () => void }): React.JSX.Elem
 }
 
 function TaskProviderShortcut({
-  canBrowseTasks,
   label,
   onOpen,
   children
 }: {
-  canBrowseTasks: boolean
   label: string
   onOpen: () => void
   children: React.ReactNode
 }): React.JSX.Element {
   return (
     <span
-      role={canBrowseTasks ? 'button' : undefined}
+      role="button"
       tabIndex={-1}
       onClick={(e) => {
         e.stopPropagation()
-        if (!canBrowseTasks) {
-          return
-        }
         onOpen()
       }}
-      className={cn(
-        'rounded p-0.5 text-muted-foreground/70',
-        canBrowseTasks ? 'transition-colors hover:text-foreground' : 'cursor-default'
-      )}
-      aria-label={canBrowseTasks ? label : undefined}
-      aria-hidden={canBrowseTasks ? undefined : true}
+      className="rounded p-0.5 text-muted-foreground/70 transition-colors hover:text-foreground"
+      aria-label={label}
     >
       {children}
     </span>
@@ -73,7 +64,6 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
   const activeView = useAppStore((s) => s.activeView)
   const repos = useAppStore((s) => s.repos)
   const repoMap = useRepoMap()
-  const canBrowseTasks = repos.some((repo) => isGitRepoKind(repo))
   const showTasksButton = useAppStore((s) => s.settings?.showTasksButton !== false)
   const rawVisibleTaskProviders = useAppStore((s) => s.settings?.visibleTaskProviders)
   const defaultTaskSource = useAppStore((s) => s.settings?.defaultTaskSource ?? 'github')
@@ -134,7 +124,7 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
   ])
 
   const handlePrefetch = React.useCallback(() => {
-    if (!canBrowseTasks || resolvedDefaultTaskSource !== 'github') {
+    if (resolvedDefaultTaskSource !== 'github') {
       return
     }
     const activeRepo = activeRepoId ? (repoMap.get(activeRepoId) ?? null) : null
@@ -150,7 +140,6 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
     }
   }, [
     activeRepoId,
-    canBrowseTasks,
     defaultTaskViewPreset,
     prefetchWorkItems,
     repoMap,
@@ -173,23 +162,16 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
       <ContextMenuTrigger asChild>
         <button
           type="button"
-          onClick={() => {
-            if (!canBrowseTasks) {
-              return
-            }
-            openTaskPage()
-          }}
+          onClick={() => openTaskPage()}
           onPointerEnter={handlePrefetch}
           onFocus={handlePrefetch}
-          aria-disabled={!canBrowseTasks}
           aria-current={tasksActive ? 'page' : undefined}
           data-contextual-tour-target="sidebar-tasks"
           className={cn(
             'group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
             tasksActive
               ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
-              : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8',
-            !canBrowseTasks && 'cursor-not-allowed opacity-50 hover:bg-transparent'
+              : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'
           )}
         >
           <List
@@ -202,7 +184,6 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
           <span className="hidden items-center gap-1 group-hover:flex group-focus-within:flex">
             {visibleTaskProviders.includes('github') ? (
               <TaskProviderShortcut
-                canBrowseTasks={canBrowseTasks}
                 label={translate(
                   'auto.components.sidebar.SidebarNav.0ccba862b8',
                   'Open GitHub tasks'
@@ -214,7 +195,6 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
             ) : null}
             {visibleTaskProviders.includes('gitlab') ? (
               <TaskProviderShortcut
-                canBrowseTasks={canBrowseTasks}
                 label={translate(
                   'auto.components.sidebar.SidebarNav.196c1b5362',
                   'Open GitLab tasks'
@@ -226,7 +206,6 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
             ) : null}
             {visibleTaskProviders.includes('linear') ? (
               <TaskProviderShortcut
-                canBrowseTasks={canBrowseTasks}
                 label={translate(
                   'auto.components.sidebar.SidebarNav.c39ab10000',
                   'Open Linear tasks'
@@ -238,7 +217,6 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
             ) : null}
             {visibleTaskProviders.includes('jira') ? (
               <TaskProviderShortcut
-                canBrowseTasks={canBrowseTasks}
                 label={translate(
                   'auto.components.sidebar.SidebarNav.e7ad3c540d',
                   'Open Jira tasks'

--- a/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
+++ b/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
@@ -43,18 +43,14 @@ function TaskProviderShortcut({
   children: React.ReactNode
 }): React.JSX.Element {
   return (
-    <span
-      role="button"
-      tabIndex={-1}
-      onClick={(e) => {
-        e.stopPropagation()
-        onOpen()
-      }}
-      className="rounded p-0.5 text-muted-foreground/70 transition-colors hover:text-foreground"
+    <button
+      type="button"
+      onClick={onOpen}
+      className="rounded p-0.5 text-muted-foreground/70 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-worktree-sidebar-ring"
       aria-label={label}
     >
       {children}
-    </span>
+    </button>
   )
 }
 
@@ -160,28 +156,34 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <button
-          type="button"
-          onClick={() => openTaskPage()}
-          onPointerEnter={handlePrefetch}
-          onFocus={handlePrefetch}
-          aria-current={tasksActive ? 'page' : undefined}
-          data-contextual-tour-target="sidebar-tasks"
-          className={cn(
-            'group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
-            tasksActive
-              ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
-              : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'
-          )}
-        >
-          <List
-            className={cn('size-4 shrink-0', !tasksActive && 'text-worktree-sidebar-foreground/30')}
-            strokeWidth={tasksActive ? 2.25 : 1.75}
-          />
-          <span className="flex-1">
-            {translate('auto.components.sidebar.SidebarNav.fee535205b', 'Tasks')}
-          </span>
-          <span className="hidden items-center gap-1 group-hover:flex group-focus-within:flex">
+        {/* Why: shortcuts sit beside the Tasks button, not inside it, so each stays keyboard-reachable. */}
+        <div className="group relative">
+          <button
+            type="button"
+            onClick={() => openTaskPage()}
+            onPointerEnter={handlePrefetch}
+            onFocus={handlePrefetch}
+            aria-current={tasksActive ? 'page' : undefined}
+            data-contextual-tour-target="sidebar-tasks"
+            className={cn(
+              'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
+              tasksActive
+                ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
+                : 'text-worktree-sidebar-foreground/60 group-hover:bg-worktree-sidebar-foreground/8'
+            )}
+          >
+            <List
+              className={cn(
+                'size-4 shrink-0',
+                !tasksActive && 'text-worktree-sidebar-foreground/30'
+              )}
+              strokeWidth={tasksActive ? 2.25 : 1.75}
+            />
+            <span className="flex-1">
+              {translate('auto.components.sidebar.SidebarNav.fee535205b', 'Tasks')}
+            </span>
+          </button>
+          <span className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1 can-hover:pointer-events-none can-hover:opacity-0 can-hover:group-hover:pointer-events-auto can-hover:group-hover:opacity-100 can-hover:group-focus-within:pointer-events-auto can-hover:group-focus-within:opacity-100">
             {visibleTaskProviders.includes('github') ? (
               <TaskProviderShortcut
                 label={translate(
@@ -227,7 +229,7 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
               </TaskProviderShortcut>
             ) : null}
           </span>
-        </button>
+        </div>
       </ContextMenuTrigger>
       <HideTaskSidebarMenu onHide={hideTasksButton} />
     </ContextMenu>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​56 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 |

<!-- /orca-pr-loc -->

## Problem

The Tasks button was disabled when no git repositories were present, preventing users from accessing the Tasks page even to see an empty-state explanation during onboarding.

## Solution

Remove the `canBrowseTasks` condition that gated the Tasks button and make it always enabled. This allows the Tasks page itself to handle the empty state for workspaces without git repos.

## What Changed

- Removed `canBrowseTasks` variable from `SidebarTaskNavButton` and all related conditionals
- Removed `aria-disabled` attribute from the Tasks button
- Removed opacity-50 and cursor-not-allowed styling
- Made `TaskProviderShortcut` components always interactive
- Updated tests to expect the button enabled in all states

## Why

This improves onboarding by letting users discover Tasks in any workspace, including empty or folder-only ones, instead of blocking with a disabled button. The Tasks page can explain the empty state.

## Testing

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

Tests updated in `SidebarNav.test.tsx` verify the Tasks button remains enabled with folder repos.