### PR TITLE
fix(ssh): suppress resume after relay replacement

### DIFF
--- a/src/main/ipc/pty-pane-reservation-settlement.test.ts
+++ b/src/main/ipc/pty-pane-reservation-settlement.test.ts
@@ -117,6 +117,7 @@ describe('registerPtyHandlers', () => {
       }),
       flushOrThrow: vi.fn(),
       persistPtyBinding: vi.fn(),
+      getSshRemotePtyLeases: vi.fn(() => []),
       upsertSshRemotePtyLease: vi.fn(),
       removeSshRemotePtyLease: vi.fn(),
       markSshRemotePtyLease: vi.fn()
@@ -136,6 +137,7 @@ describe('registerPtyHandlers', () => {
       seedHeadlessTerminal: vi.fn(),
       getDriver: vi.fn(() => ({ kind: 'host' })),
       onPtySpawned: vi.fn(),
+      markPtyLivenessUnverifiable: vi.fn(),
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()
     }
@@ -172,9 +174,12 @@ describe('registerPtyHandlers', () => {
         sessionId: deadPtyId,
         command: undefined
       })
-      expect(remoteSpawn.mock.calls[1]?.[0]).toMatchObject({
-        command: 'codex resume exact-dead-ssh-provider-session'
-      })
+      expect(remoteSpawn.mock.calls[1]?.[0]).toMatchObject({ command: undefined })
+      expect(runtime.markPtyLivenessUnverifiable).toHaveBeenCalledWith(
+        deadPtyId,
+        expect.stringContaining('cannot be proven')
+      )
+      expect(runtime.onPtyExit).toHaveBeenCalledWith(deadPtyId, -1, 'inc-dead-ssh-owner')
       expect(store.setWorkspaceSession).toHaveBeenCalledWith(expect.anything(), hostId)
       expect(store.persistPtyBinding).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/main/ipc/pty-relay-age-fallback.test.ts
+++ b/src/main/ipc/pty-relay-age-fallback.test.ts
@@ -49,7 +49,7 @@ vi.mock('../codex/codex-state-db-backfill-recovery', () =>
   import('./pty-ipc-mock-registry').then((m) => m.codexBackfillRecoveryModuleMock())
 )
 
-describe('relay-age-aware pane fallback', () => {
+describe('relay-process-aware pane fallback', () => {
   const { handlers, mainWindow } = setupPtyIpcSuite()
 
   it('starts a plain shell and reports an unverifiable resume after relay replacement', async () => {
@@ -66,11 +66,18 @@ describe('relay-age-aware pane fallback', () => {
       if (options.attachOnly) {
         throw new SshPtyAbsentFromRelayError('SSH_SESSION_EXPIRED: old-pty')
       }
-      return { id: newPtyId, incarnationId: 'new-incarnation' }
+      return {
+        id: newPtyId,
+        incarnationId: 'new-incarnation',
+        relayProcessId: 'replacement-relay-process'
+      }
     })
     registerSshPtyProvider(connectionId, {
       spawn: providerSpawn,
-      requestHostRpc: vi.fn(async () => ({ pid: 42, uptimeMs: 8_999 })),
+      requestHostRpc: vi.fn(async () => ({
+        relayProcessId: 'replacement-relay-process',
+        uptimeMs: Number.MAX_SAFE_INTEGER
+      })),
       write: vi.fn(),
       resize: vi.fn(),
       kill: vi.fn(),
@@ -108,7 +115,8 @@ describe('relay-age-aware pane fallback', () => {
           leafId,
           state: 'detached',
           createdAt: 1_000,
-          updatedAt: 1_000
+          updatedAt: 1_000,
+          relayProcessId: 'original-relay-process'
         }
       ]),
       upsertSshRemotePtyLease: vi.fn(),
@@ -132,6 +140,7 @@ describe('relay-age-aware pane fallback', () => {
       noteTerminalSpawnCommand: vi.fn(),
       seedHeadlessTerminal: vi.fn(),
       onPtySpawned: vi.fn(),
+      markPtyLivenessUnverifiable: vi.fn(),
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()
     }
@@ -177,11 +186,26 @@ describe('relay-age-aware pane fallback', () => {
     expect(providerSpawn).toHaveBeenCalledTimes(2)
     expect(providerSpawn.mock.calls[1]?.[0]).toMatchObject({
       command: undefined,
+      commandDelivery: undefined,
+      startupCommandDelivery: undefined,
       launchAgent: undefined,
+      agentSessionEnsure: undefined,
+      agentSessionCreateOperationId: undefined,
       env: expect.not.objectContaining({ ORCA_AGENT_LAUNCH_TOKEN: expect.anything() })
     })
+    expect(runtime.markPtyLivenessUnverifiable).toHaveBeenCalledWith(
+      oldPtyId,
+      expect.stringContaining('cannot be proven')
+    )
+    expect(runtime.onPtyExit).toHaveBeenCalledWith(oldPtyId, -1, 'old-incarnation')
     expect(runtime.noteTerminalSpawnCommand).toHaveBeenCalledWith(newPtyId, null)
     expect(runtime.registerPty.mock.calls.at(-1)?.[3]).not.toHaveProperty('agentLaunchAuthority')
+    expect(store.upsertSshRemotePtyLease).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ptyId: 'new-pty',
+        relayProcessId: 'replacement-relay-process'
+      })
+    )
     expect(trackMock).not.toHaveBeenCalledWith('agent_started', expect.anything())
   })
 })

--- a/src/main/ipc/pty-relay-age-fallback.test.ts
+++ b/src/main/ipc/pty-relay-age-fallback.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from 'vitest'
+import { makePaneKey } from '../../shared/stable-pane-id'
+import { setupPtyIpcSuite } from './pty-ipc-test-harness'
+import { trackMock } from './pty-ipc-mock-registry'
+import { registerPtyHandlers, registerSshPtyProvider } from './pty'
+import { SshPtyAbsentFromRelayError } from '../providers/ssh-pty-errors'
+
+vi.mock('electron', () => import('./pty-ipc-mock-registry').then((m) => m.electronModuleMock()))
+vi.mock('fs', () => import('./pty-ipc-mock-registry').then((m) => m.fsModuleMock()))
+vi.mock('node-pty', () => import('./pty-ipc-mock-registry').then((m) => m.nodePtyModuleMock()))
+vi.mock('node:child_process', async (importOriginal) =>
+  (await import('./pty-ipc-mock-registry')).childProcessModuleMock(await importOriginal())
+)
+vi.mock('../opencode/hook-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.openCodeHookServiceModuleMock())
+)
+vi.mock('../mimo/hook-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.mimoHookServiceModuleMock())
+)
+vi.mock('../agent-hooks/server', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.agentHookServerModuleMock())
+)
+vi.mock('../pi/titlebar-extension-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.piTitlebarExtensionModuleMock())
+)
+vi.mock('../pwsh', () => import('./pty-ipc-mock-registry').then((m) => m.pwshModuleMock()))
+vi.mock('../wsl', async (importOriginal) =>
+  (await import('./pty-ipc-mock-registry')).wslModuleMock(await importOriginal())
+)
+vi.mock('../telemetry/client', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.telemetryClientModuleMock())
+)
+vi.mock('../telemetry/classify-error', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.classifyErrorModuleMock())
+)
+vi.mock('../cli/linux-terminal-orca-cli-shim', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.linuxCliShimModuleMock())
+)
+vi.mock('../memory/pty-registry', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.ptyRegistryModuleMock())
+)
+vi.mock('../agent-hooks/migration-unsupported-pty-state', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.migrationUnsupportedPtyModuleMock())
+)
+vi.mock('../codex/codex-pane-account-registry', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.codexPaneAccountRegistryModuleMock())
+)
+vi.mock('../codex/codex-state-db-backfill-recovery', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.codexBackfillRecoveryModuleMock())
+)
+
+describe('relay-age-aware pane fallback', () => {
+  const { handlers, mainWindow } = setupPtyIpcSuite()
+
+  it('starts a plain shell and reports an unverifiable resume after relay replacement', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(10_000)
+    const connectionId = 'ssh-1'
+    const worktreeId = 'repo-1::/remote/worktree'
+    const tabId = 'tab-relay-replacement'
+    const leafId = '56565656-5656-4656-8656-565656565656'
+    const paneKey = makePaneKey(tabId, leafId)
+    const oldPtyId = `ssh:${connectionId}@@old-pty`
+    const newPtyId = `ssh:${connectionId}@@new-pty`
+    const providerSpawn = vi.fn(async (options: { attachOnly?: boolean }) => {
+      if (options.attachOnly) {
+        throw new SshPtyAbsentFromRelayError('SSH_SESSION_EXPIRED: old-pty')
+      }
+      return { id: newPtyId, incarnationId: 'new-incarnation' }
+    })
+    registerSshPtyProvider(connectionId, {
+      spawn: providerSpawn,
+      requestHostRpc: vi.fn(async () => ({ pid: 42, uptimeMs: 8_999 })),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => []),
+      getForegroundProcess: vi.fn(async () => null)
+    } as never)
+    let session = {
+      tabsByWorktree: { [worktreeId]: [{ id: tabId, worktreeId, ptyId: oldPtyId }] },
+      terminalLayoutsByTabId: {
+        [tabId]: {
+          root: { type: 'leaf' as const, leafId },
+          activeLeafId: leafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [leafId]: oldPtyId }
+        }
+      },
+      terminalPtyIncarnationsByPaneKey: { [paneKey]: 'old-incarnation' }
+    }
+    const store = {
+      getWorkspaceSession: vi.fn(() => session),
+      setWorkspaceSession: vi.fn((next) => {
+        session = next
+      }),
+      flushOrThrow: vi.fn(),
+      persistPtyBinding: vi.fn(),
+      getSshRemotePtyLeases: vi.fn(() => [
+        {
+          targetId: connectionId,
+          ptyId: 'old-pty',
+          worktreeId,
+          tabId,
+          leafId,
+          state: 'detached',
+          createdAt: 1_000,
+          updatedAt: 1_000
+        }
+      ]),
+      upsertSshRemotePtyLease: vi.fn(),
+      getFolderWorkspace: vi.fn(() => undefined),
+      getFolderWorkspaces: vi.fn(() => []),
+      getProjectGroups: vi.fn(() => []),
+      getRepos: vi.fn(() => [])
+    }
+    const runtime = {
+      setPtyController: vi.fn(),
+      resolveTerminalPane: vi.fn(() => {
+        throw new Error('terminal_not_found')
+      }),
+      createPreAllocatedTerminalHandle: vi.fn(() => 'term-relay-replacement'),
+      preAllocateHandleForPty: vi.fn(() => 'term-relay-replacement'),
+      registerPreAllocatedHandleForPty: vi.fn(),
+      beginPtyRegistration: vi.fn(),
+      cancelPendingPtyRegistration: vi.fn(),
+      assertPtyRegistrationAllowed: vi.fn(),
+      registerPty: vi.fn(),
+      noteTerminalSpawnCommand: vi.fn(),
+      seedHeadlessTerminal: vi.fn(),
+      onPtySpawned: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn()
+    }
+    registerPtyHandlers(
+      mainWindow as never,
+      runtime as never,
+      undefined,
+      undefined,
+      undefined,
+      store as never
+    )
+
+    const mounted = await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      cwd: '/remote/worktree',
+      command: 'codex resume old-session',
+      commandDelivery: 'provider',
+      startupCommandDelivery: 'shell-ready',
+      launchAgent: 'codex',
+      launchConfig: { agent: 'codex', agentCommand: 'codex resume old-session' },
+      launchToken: 'launch-token',
+      connectionId,
+      worktreeId,
+      tabId,
+      leafId,
+      terminalColorQueryReplies: { foreground: 'rgb:ffff/ffff/ffff' },
+      env: {
+        ORCA_PANE_KEY: paneKey,
+        ORCA_TAB_ID: tabId,
+        ORCA_WORKTREE_ID: worktreeId,
+        ORCA_AGENT_LAUNCH_TOKEN: 'launch-token'
+      },
+      telemetry: {
+        agent_kind: 'codex',
+        launch_source: 'new_workspace_composer',
+        request_kind: 'resume'
+      }
+    })
+
+    expect(mounted).toMatchObject({ id: newPtyId, agentResumeUnavailable: true })
+    expect(mounted).not.toHaveProperty('launchConfig')
+    expect(providerSpawn).toHaveBeenCalledTimes(2)
+    expect(providerSpawn.mock.calls[1]?.[0]).toMatchObject({
+      command: undefined,
+      launchAgent: undefined,
+      env: expect.not.objectContaining({ ORCA_AGENT_LAUNCH_TOKEN: expect.anything() })
+    })
+    expect(runtime.noteTerminalSpawnCommand).toHaveBeenCalledWith(newPtyId, null)
+    expect(runtime.registerPty.mock.calls.at(-1)?.[3]).not.toHaveProperty('agentLaunchAuthority')
+    expect(trackMock).not.toHaveBeenCalledWith('agent_started', expect.anything())
+  })
+})

--- a/src/main/ipc/pty/ipc/spawn-commit-persist.ts
+++ b/src/main/ipc/pty/ipc/spawn-commit-persist.ts
@@ -80,6 +80,7 @@ export async function persistPtyIpcSpawnCommit(ctx: PtyIpcSpawnState): Promise<{
       ...(typeof args.tabId === 'string' ? { tabId: args.tabId } : {}),
       ...(ctx.validatedLeafId ? { leafId: ctx.validatedLeafId } : {}),
       state: 'attached',
+      ...(ctx.result.relayProcessId ? { relayProcessId: ctx.result.relayProcessId } : {}),
       lastAttachedAt: Date.now()
     })
   }

--- a/src/main/ipc/pty/ipc/spawn-commit.ts
+++ b/src/main/ipc/pty/ipc/spawn-commit.ts
@@ -24,6 +24,10 @@ import { persistPtyIpcSpawnCommit } from './spawn-commit-persist'
 
 export async function commitPtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<PtySpawnResult> {
   const args = ctx.args
+  const agentStartupSuppressed = ctx.stablePaneAbsenceVerdict?.status === 'unverifiable'
+  const suppressedAgentStartupWasRequested =
+    agentStartupSuppressed &&
+    Boolean(args.launchAgent || args.launchConfig || args.resumeProviderSession)
   const { rendererPreSignaled, rendererAlreadyRegistered } = await persistPtyIpcSpawnCommit(ctx)
 
   // Why: seed the headless emulator before registerPty so concurrent live PTY data lands on top of the seed, not replacing it (mobile keeps the daemon-restored scrollback).
@@ -76,8 +80,8 @@ export async function commitPtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<PtySpawn
     const agentLaunchAuthority = admitRendererAgentLaunchAuthority({
       launchToken: args.launchToken,
       spawnEnv: ctx.spawnEnv,
-      launchAgent: args.launchAgent,
-      launchConfig: ctx.effectiveLaunchConfig,
+      launchAgent: agentStartupSuppressed ? undefined : args.launchAgent,
+      launchConfig: agentStartupSuppressed ? undefined : ctx.effectiveLaunchConfig,
       isReattach: ctx.result.isReattach === true,
       hasStablePaneOwner: ctx.stablePaneOwner !== null,
       incarnationId: ctx.result.incarnationId
@@ -118,10 +122,10 @@ export async function commitPtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<PtySpawn
   if (!ctx.stablePaneOwner) {
     ctx.deps.runtime?.noteTerminalSpawnCommand?.(
       ctx.result.id,
-      typeof ctx.launchCommand === 'string' ? ctx.launchCommand : null
+      !agentStartupSuppressed && typeof ctx.launchCommand === 'string' ? ctx.launchCommand : null
     )
   }
-  if (ctx.isClaudeLaunch && !ctx.stablePaneOwner) {
+  if (!agentStartupSuppressed && ctx.isClaudeLaunch && !ctx.stablePaneOwner) {
     markClaudePtySpawned(ctx.result.id)
   }
   // Why: record the paneKey mapping so clearProviderPtyState can clear the agent-hooks server's per-paneKey caches on exit.
@@ -170,7 +174,7 @@ export async function commitPtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<PtySpawn
     })
   }
   // Why: telemetry-plan.md§Agent launch semantics — fire agent_started only after spawn resolved; safeParse each field so a spoofed IPC payload can't poison the event (missing required field skips it).
-  if (args.telemetry && !ctx.stablePaneOwner) {
+  if (!agentStartupSuppressed && args.telemetry && !ctx.stablePaneOwner) {
     const agentKindParse = agentKindSchema.safeParse(args.telemetry.agent_kind)
     const launchSourceParse = launchSourceSchema.safeParse(args.telemetry.launch_source)
     const requestKindParse = requestKindSchema.safeParse(args.telemetry.request_kind)
@@ -192,7 +196,7 @@ export async function commitPtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<PtySpawn
     ctx.snapshotKittyFlagsCoverReconciledSeq
       ? { snapshotSeq: ctx.reconciledSnapshotSeq }
       : { snapshotKittyKeyboardFlags: undefined }),
-    ...(!ctx.result.isReattach && ctx.effectiveLaunchConfig
+    ...(!agentStartupSuppressed && !ctx.result.isReattach && ctx.effectiveLaunchConfig
       ? { launchConfig: ctx.effectiveLaunchConfig }
       : {}),
     // Why: a daemon-retry race can surface isReattach even for a minted session id, and a reattach must never claim its cwd was remapped.
@@ -201,7 +205,8 @@ export async function commitPtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<PtySpawn
       : {}),
     // Why: the pane asked to resume and got a fresh session instead; only the
     // renderer can say so, and a reattach never ran this launch command.
-    ...(ctx.codexResumeLaunch.notifyResumeUnavailable && !ctx.result.isReattach
+    ...((ctx.codexResumeLaunch.notifyResumeUnavailable || suppressedAgentStartupWasRequested) &&
+    !ctx.result.isReattach
       ? { agentResumeUnavailable: true as const }
       : {})
   }

--- a/src/main/ipc/pty/ipc/spawn-execute.ts
+++ b/src/main/ipc/pty/ipc/spawn-execute.ts
@@ -55,6 +55,7 @@ export async function executePtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<void> {
           owner: stablePaneOwnerCandidate,
           worktreeId: args.worktreeId,
           connectionId: args.connectionId,
+          absenceVerdict: ctx.stablePaneAbsenceVerdict,
           resolveOwner: () =>
             resolveStablePaneOwner(
               ctx.deps.runtime,
@@ -66,6 +67,10 @@ export async function executePtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<void> {
         })
     ctx.result = stablePaneSpawn.result
     ctx.stablePaneOwner = stablePaneSpawn.owner
+    ctx.stablePaneAbsenceVerdict =
+      'absenceVerdict' in stablePaneSpawn
+        ? stablePaneSpawn.absenceVerdict
+        : ctx.stablePaneAbsenceVerdict
     if (
       ctx.stablePaneOwner &&
       ctx.isMintedSessionId &&

--- a/src/main/ipc/pty/ipc/spawn-preflight.ts
+++ b/src/main/ipc/pty/ipc/spawn-preflight.ts
@@ -52,7 +52,7 @@ export async function preparePtyIpcSpawnPreflight(ctx: PtyIpcSpawnState): Promis
     }
   }
   ctx.spawnTiming.mark('stable_adoption_setup')
-  ctx.preAdoptedStablePane =
+  const stablePaneAdoption =
     ctx.earlyStablePaneOwner && ctx.earlyWorktreeId
       ? await ctx.deps.adoptStablePane({
           cols: args.cols,
@@ -65,6 +65,9 @@ export async function preparePtyIpcSpawnPreflight(ctx: PtyIpcSpawnState): Promis
           ownsPaneSpawnReservation: true
         })
       : null
+  ctx.preAdoptedStablePane = stablePaneAdoption?.result ? stablePaneAdoption : null
+  ctx.stablePaneAbsenceVerdict =
+    stablePaneAdoption?.result === null ? stablePaneAdoption.absenceVerdict : undefined
   ctx.spawnTiming.mark('stable_adoption')
   if (ctx.earlyStablePaneOwner && !ctx.preAdoptedStablePane) {
     const pathUsable = ctx.deps.assertFolderWorkspacePtyPathUsable(args.worktreeId)

--- a/src/main/ipc/pty/ipc/spawn-state.ts
+++ b/src/main/ipc/pty/ipc/spawn-state.ts
@@ -2,6 +2,7 @@ import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../../../pro
 import type { CodexPaneHomeRoute } from '../../../codex/codex-pane-account-registry'
 import type { CodexAccountSelectionTarget } from '../../../codex-accounts/runtime-selection'
 import type { SleepingAgentLaunchConfig } from '../../../../shared/agent-session-resume'
+import type { PtyLivenessVerdict } from '../../../../shared/pty-liveness-verdict'
 import type { ClaudeRuntimeAuthPreparation } from '../../../claude-accounts/runtime-auth-service'
 import type { PtySpawnTiming } from '../../pty-spawn-timing'
 import { createPtySpawnTiming } from '../../pty-spawn-timing'
@@ -28,6 +29,7 @@ export type PtyIpcSpawnState = {
   finishTerminalInstall: () => void
   result: PtySpawnResult
   stablePaneOwner: StablePaneOwner | null
+  stablePaneAbsenceVerdict: PtyLivenessVerdict | undefined
   stablePaneBindingPersisted: boolean
   rejectedRegistrationCandidate: PtySpawnResult | null
   pendingRegistrationPtyId: string | null
@@ -105,6 +107,7 @@ export function createPtyIpcSpawnState(
     finishTerminalInstall: () => {},
     result: { id: '' },
     stablePaneOwner: null,
+    stablePaneAbsenceVerdict: undefined,
     stablePaneBindingPersisted: false,
     rejectedRegistrationCandidate: null,
     pendingRegistrationPtyId: null,

--- a/src/main/ipc/pty/ipc/spawn-types.ts
+++ b/src/main/ipc/pty/ipc/spawn-types.ts
@@ -4,6 +4,7 @@ import type {
   SleepingAgentLaunchConfig
 } from '../../../../shared/agent-session-resume'
 import type { ProjectExecutionRuntimeResolution } from '../../../../shared/project-execution-runtime'
+import type { PtyLivenessVerdict } from '../../../../shared/pty-liveness-verdict'
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { TerminalStartupCwdMissingDirFallback } from '../../../../shared/terminal-startup-cwd'
@@ -76,6 +77,10 @@ export type AdoptStablePaneResult = {
   materialized?: true
 }
 
+export type AdoptStablePaneOutcome =
+  | AdoptStablePaneResult
+  | { result: null; owner: null; absenceVerdict: PtyLivenessVerdict }
+
 export type PtySpawnIpcDeps = {
   runtime?: OrcaRuntimeService
   store?: Store
@@ -87,7 +92,7 @@ export type PtySpawnIpcDeps = {
     onCodexHomePtySpawned?: (args: CodexHomePtySpawnedLifecycleArgs) => void
   }
   getLocalPtyStartupPromise: (connectionId?: string | null) => Promise<void> | undefined
-  adoptStablePane: (args: AdoptStablePaneArgs) => Promise<AdoptStablePaneResult | null>
+  adoptStablePane: (args: AdoptStablePaneArgs) => Promise<AdoptStablePaneOutcome | null>
   assertFolderWorkspacePtyPathUsable: (worktreeId: string | undefined) => Promise<void> | void
   resolvePtySpawnStartupCwd: (
     worktreeId: string | undefined,

--- a/src/main/ipc/pty/pane/adopt-stable.ts
+++ b/src/main/ipc/pty/pane/adopt-stable.ts
@@ -8,13 +8,13 @@ import {
   resolveStablePaneOwner,
   stablePaneAdoptionsByOwnerKey
 } from './stable-owner'
-import type { AdoptStablePaneArgs, AdoptStablePaneResult } from '../ipc/spawn-types'
+import type { AdoptStablePaneArgs, AdoptStablePaneOutcome } from '../ipc/spawn-types'
 
 export async function adoptStablePane(
   runtime: OrcaRuntimeService | undefined,
   store: Store | undefined,
   args: AdoptStablePaneArgs
-): Promise<AdoptStablePaneResult | null> {
+): Promise<AdoptStablePaneOutcome | null> {
   const paneKey = makePaneKey(args.tabId, args.leafId)
   const ownerKey = makePaneSpawnReservationKey(args.worktreeId, args.connectionId, paneKey)
   const pendingAdoption = ownerKey ? stablePaneAdoptionsByOwnerKey.get(ownerKey) : undefined

--- a/src/main/ipc/pty/pane/ssh-relay-absence-verdict.ts
+++ b/src/main/ipc/pty/pane/ssh-relay-absence-verdict.ts
@@ -2,21 +2,17 @@ import type { PtyLivenessVerdict } from '../../../../shared/pty-liveness-verdict
 import type { IPtyProvider } from '../../../providers/types'
 
 const RELAY_STATUS_TIMEOUT_MS = 5_000
-const REPLACEMENT_RELAY_REASON = 'the answering SSH relay is younger than the persisted PTY binding'
+export const UNPROVEN_RELAY_OWNER_REASON =
+  'the answering SSH relay cannot be proven to own the persisted PTY binding'
 
-type RelayStatus = { uptimeMs?: unknown }
+type RelayStatus = { relayProcessId?: unknown }
 
 export async function resolveSshRelayAbsenceVerdict(args: {
   provider: IPtyProvider
-  bindingCreatedAt?: number
-  now?: () => number
+  bindingRelayProcessId?: string
 }): Promise<PtyLivenessVerdict> {
-  if (!args.provider.requestHostRpc || !Number.isFinite(args.bindingCreatedAt)) {
-    return { status: 'exited' }
-  }
-  const bindingAgeAtRequest = (args.now ?? Date.now)() - Number(args.bindingCreatedAt)
-  if (bindingAgeAtRequest < 0) {
-    return { status: 'exited' }
+  if (!args.provider.requestHostRpc || !args.bindingRelayProcessId) {
+    return { status: 'unverifiable', reason: UNPROVEN_RELAY_OWNER_REASON }
   }
   try {
     const status = (await args.provider.requestHostRpc(
@@ -26,14 +22,10 @@ export async function resolveSshRelayAbsenceVerdict(args: {
         timeoutMs: RELAY_STATUS_TIMEOUT_MS
       }
     )) as RelayStatus
-    const uptimeMs = status?.uptimeMs
-    return typeof uptimeMs === 'number' && Number.isFinite(uptimeMs) && uptimeMs >= 0
-      ? uptimeMs < bindingAgeAtRequest
-        ? { status: 'unverifiable', reason: REPLACEMENT_RELAY_REASON }
-        : { status: 'exited' }
-      : { status: 'exited' }
+    return status?.relayProcessId === args.bindingRelayProcessId
+      ? { status: 'exited' }
+      : { status: 'unverifiable', reason: UNPROVEN_RELAY_OWNER_REASON }
   } catch {
-    // The attach response already proved absence; a failed age refinement does not revoke it.
-    return { status: 'exited' }
+    return { status: 'unverifiable', reason: UNPROVEN_RELAY_OWNER_REASON }
   }
 }

--- a/src/main/ipc/pty/pane/ssh-relay-absence-verdict.ts
+++ b/src/main/ipc/pty/pane/ssh-relay-absence-verdict.ts
@@ -1,0 +1,39 @@
+import type { PtyLivenessVerdict } from '../../../../shared/pty-liveness-verdict'
+import type { IPtyProvider } from '../../../providers/types'
+
+const RELAY_STATUS_TIMEOUT_MS = 5_000
+const REPLACEMENT_RELAY_REASON = 'the answering SSH relay is younger than the persisted PTY binding'
+
+type RelayStatus = { uptimeMs?: unknown }
+
+export async function resolveSshRelayAbsenceVerdict(args: {
+  provider: IPtyProvider
+  bindingCreatedAt?: number
+  now?: () => number
+}): Promise<PtyLivenessVerdict> {
+  if (!args.provider.requestHostRpc || !Number.isFinite(args.bindingCreatedAt)) {
+    return { status: 'exited' }
+  }
+  const bindingAgeAtRequest = (args.now ?? Date.now)() - Number(args.bindingCreatedAt)
+  if (bindingAgeAtRequest < 0) {
+    return { status: 'exited' }
+  }
+  try {
+    const status = (await args.provider.requestHostRpc(
+      'relay.status',
+      {},
+      {
+        timeoutMs: RELAY_STATUS_TIMEOUT_MS
+      }
+    )) as RelayStatus
+    const uptimeMs = status?.uptimeMs
+    return typeof uptimeMs === 'number' && Number.isFinite(uptimeMs) && uptimeMs >= 0
+      ? uptimeMs < bindingAgeAtRequest
+        ? { status: 'unverifiable', reason: REPLACEMENT_RELAY_REASON }
+        : { status: 'exited' }
+      : { status: 'exited' }
+  } catch {
+    // The attach response already proved absence; a failed age refinement does not revoke it.
+    return { status: 'exited' }
+  }
+}

--- a/src/main/ipc/pty/pane/stable-owner.ts
+++ b/src/main/ipc/pty/pane/stable-owner.ts
@@ -1,9 +1,10 @@
 import { toSshExecutionHostId } from '../../../../shared/execution-host'
+import type { PtyLivenessVerdict } from '../../../../shared/pty-liveness-verdict'
 import { makePaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
 import type { Store } from '../../../persistence'
 import { retireTerminalSurfaceFromPersistence } from '../../../runtime/mobile-session-terminal-persistence-retirement'
 import type { OrcaRuntimeService } from '../../../runtime/orca-runtime'
-import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../../../providers/types'
+import type { PtySpawnResult } from '../../../providers/types'
 import { parseAppSshPtyId } from '../../../providers/ssh-pty-id'
 import {
   isDaemonEndpointGoneError,
@@ -13,22 +14,14 @@ import {
 import { ptyIncarnationById, ptyOwnership } from '../provider/ownership-state'
 import { isPtyAlreadyGoneError } from '../provider/liveness'
 import { clearProviderPtyState } from '../provider/state-cleanup'
+import { resolveSshRelayAbsenceVerdict } from './ssh-relay-absence-verdict'
+import {
+  withoutAgentStartupIntent,
+  type StablePaneSpawnContext
+} from './stable-pane-spawn-fallback'
+import type { StablePaneAdoption, StablePaneOwner } from './stable-pane-types'
 
-export type StablePaneOwner = {
-  handle?: string
-  tabId: string
-  leafId: string
-  ptyId: string
-  incarnationId?: string
-  hasPersistedBinding?: true
-  persistedIncarnationId?: string
-  runtimeIncarnationId?: string
-}
-export type StablePaneAdoption = {
-  result: PtySpawnResult
-  owner: StablePaneOwner
-  materialized?: true
-} | null
+export type { StablePaneOwner } from './stable-pane-types'
 export const stablePaneAdoptionsByOwnerKey = new Map<string, Promise<StablePaneAdoption>>()
 
 export function resolvePersistedStablePaneOwner(
@@ -36,7 +29,10 @@ export function resolvePersistedStablePaneOwner(
   paneKey: string,
   worktreeId: string,
   connectionId: string | null | undefined
-): Pick<StablePaneOwner, 'tabId' | 'leafId' | 'ptyId' | 'incarnationId'> | null {
+): Pick<
+  StablePaneOwner,
+  'tabId' | 'leafId' | 'ptyId' | 'incarnationId' | 'bindingCreatedAt'
+> | null {
   if (!store || typeof store.getWorkspaceSession !== 'function') {
     return null
   }
@@ -55,11 +51,18 @@ export function resolvePersistedStablePaneOwner(
     return null
   }
   const incarnationId = session.terminalPtyIncarnationsByPaneKey?.[paneKey]
+  const relayPtyId = parseAppSshPtyId(ptyId)?.relayPtyId
+  const bindingCreatedAt =
+    connectionId && relayPtyId
+      ? store.getSshRemotePtyLeases(connectionId).find((lease) => lease.ptyId === relayPtyId)
+          ?.createdAt
+      : undefined
   return {
     tabId: parsed.tabId,
     leafId: parsed.leafId,
     ptyId,
-    ...(incarnationId ? { incarnationId } : {})
+    ...(incarnationId ? { incarnationId } : {}),
+    ...(Number.isFinite(bindingCreatedAt) ? { bindingCreatedAt } : {})
   }
 }
 
@@ -114,6 +117,9 @@ export function resolveStablePaneOwner(
       ? { incarnationId: runtimeIncarnationId ?? persisted?.incarnationId }
       : {}),
     ...(persisted ? { hasPersistedBinding: true as const } : {}),
+    ...(Number.isFinite(persisted?.bindingCreatedAt)
+      ? { bindingCreatedAt: persisted?.bindingCreatedAt }
+      : {}),
     ...(persisted?.incarnationId ? { persistedIncarnationId: persisted.incarnationId } : {}),
     ...(runtimeIncarnationId ? { runtimeIncarnationId } : {})
   }
@@ -154,18 +160,6 @@ export function retirePersistedStablePaneOwner(
   store.setWorkspaceSession(retired, hostId)
   store.flushOrThrow()
   return true
-}
-
-export type StablePaneSpawnContext = {
-  runtime: OrcaRuntimeService | undefined
-  store?: Store
-  provider: IPtyProvider
-  spawnOptions: PtySpawnOptions
-  owner: StablePaneOwner | null
-  worktreeId?: string
-  connectionId?: string | null
-  resolveOwner?: () => StablePaneOwner | null
-  onFreshSpawn?: (result: PtySpawnResult) => void
 }
 
 export function stablePanePersistenceFence(
@@ -211,7 +205,10 @@ export function persistAdmittedStablePaneBinding(args: {
 
 export async function attachStablePaneOwner(
   args: StablePaneSpawnContext & { owner: StablePaneOwner }
-): Promise<{ result: PtySpawnResult; owner: StablePaneOwner } | null> {
+): Promise<
+  | { result: PtySpawnResult; owner: StablePaneOwner }
+  | { result: null; owner: null; absenceVerdict: PtyLivenessVerdict }
+> {
   const { owner, provider, runtime, spawnOptions } = args
   let result: PtySpawnResult
   try {
@@ -242,6 +239,10 @@ export async function attachStablePaneOwner(
     if (!isPtyAlreadyGoneError(error)) {
       throw error
     }
+    const absenceVerdict = await resolveSshRelayAbsenceVerdict({
+      provider,
+      bindingCreatedAt: owner.bindingCreatedAt
+    })
     const ownerBeforeRetire = args.resolveOwner?.()
     if (
       ownerBeforeRetire &&
@@ -264,7 +265,7 @@ export async function attachStablePaneOwner(
     if (args.resolveOwner?.()) {
       throw new Error('terminal_pane_owner_changed')
     }
-    return null
+    return { result: null, owner: null, absenceVerdict }
   }
   if (
     result.id !== owner.ptyId ||
@@ -278,16 +279,24 @@ export async function attachStablePaneOwner(
   return { result, owner }
 }
 
-export async function spawnForStablePane(
-  args: StablePaneSpawnContext
-): Promise<{ result: PtySpawnResult; owner: StablePaneOwner | null }> {
+export async function spawnForStablePane(args: StablePaneSpawnContext): Promise<{
+  result: PtySpawnResult
+  owner: StablePaneOwner | null
+  absenceVerdict?: PtyLivenessVerdict
+}> {
+  let absenceVerdict = args.absenceVerdict
   if (args.owner) {
     const attached = await attachStablePaneOwner({ ...args, owner: args.owner })
-    if (attached) {
+    if (attached.result) {
       return attached
     }
+    absenceVerdict = attached.absenceVerdict
   }
-  const result = await args.provider.spawn(args.spawnOptions)
+  const result = await args.provider.spawn(
+    absenceVerdict?.status === 'unverifiable'
+      ? withoutAgentStartupIntent(args.spawnOptions)
+      : args.spawnOptions
+  )
   args.onFreshSpawn?.(result)
-  return { result, owner: null }
+  return { result, owner: null, ...(absenceVerdict ? { absenceVerdict } : {}) }
 }

--- a/src/main/ipc/pty/pane/stable-owner.ts
+++ b/src/main/ipc/pty/pane/stable-owner.ts
@@ -31,7 +31,7 @@ export function resolvePersistedStablePaneOwner(
   connectionId: string | null | undefined
 ): Pick<
   StablePaneOwner,
-  'tabId' | 'leafId' | 'ptyId' | 'incarnationId' | 'bindingCreatedAt'
+  'tabId' | 'leafId' | 'ptyId' | 'incarnationId' | 'bindingRelayProcessId'
 > | null {
   if (!store || typeof store.getWorkspaceSession !== 'function') {
     return null
@@ -52,17 +52,17 @@ export function resolvePersistedStablePaneOwner(
   }
   const incarnationId = session.terminalPtyIncarnationsByPaneKey?.[paneKey]
   const relayPtyId = parseAppSshPtyId(ptyId)?.relayPtyId
-  const bindingCreatedAt =
+  const bindingRelayProcessId =
     connectionId && relayPtyId
       ? store.getSshRemotePtyLeases(connectionId).find((lease) => lease.ptyId === relayPtyId)
-          ?.createdAt
+          ?.relayProcessId
       : undefined
   return {
     tabId: parsed.tabId,
     leafId: parsed.leafId,
     ptyId,
     ...(incarnationId ? { incarnationId } : {}),
-    ...(Number.isFinite(bindingCreatedAt) ? { bindingCreatedAt } : {})
+    ...(bindingRelayProcessId ? { bindingRelayProcessId } : {})
   }
 }
 
@@ -117,8 +117,8 @@ export function resolveStablePaneOwner(
       ? { incarnationId: runtimeIncarnationId ?? persisted?.incarnationId }
       : {}),
     ...(persisted ? { hasPersistedBinding: true as const } : {}),
-    ...(Number.isFinite(persisted?.bindingCreatedAt)
-      ? { bindingCreatedAt: persisted?.bindingCreatedAt }
+    ...(persisted?.bindingRelayProcessId
+      ? { bindingRelayProcessId: persisted.bindingRelayProcessId }
       : {}),
     ...(persisted?.incarnationId ? { persistedIncarnationId: persisted.incarnationId } : {}),
     ...(runtimeIncarnationId ? { runtimeIncarnationId } : {})
@@ -239,22 +239,32 @@ export async function attachStablePaneOwner(
     if (!isPtyAlreadyGoneError(error)) {
       throw error
     }
-    const absenceVerdict = await resolveSshRelayAbsenceVerdict({
-      provider,
-      bindingCreatedAt: owner.bindingCreatedAt
-    })
+    const absenceVerdict = args.connectionId
+      ? await resolveSshRelayAbsenceVerdict({
+          provider,
+          bindingRelayProcessId: owner.bindingRelayProcessId
+        })
+      : ({ status: 'exited' } as const)
     const ownerBeforeRetire = args.resolveOwner?.()
     if (
       ownerBeforeRetire &&
       (ownerBeforeRetire.ptyId !== owner.ptyId ||
         ownerBeforeRetire.runtimeIncarnationId !== owner.runtimeIncarnationId ||
         ownerBeforeRetire.hasPersistedBinding !== owner.hasPersistedBinding ||
+        ownerBeforeRetire.bindingRelayProcessId !== owner.bindingRelayProcessId ||
         ownerBeforeRetire.persistedIncarnationId !== owner.persistedIncarnationId)
     ) {
       throw new Error('terminal_pane_owner_changed')
     }
-    runtime?.onPtyExit(owner.ptyId, 0, owner.incarnationId)
-    clearProviderPtyState(owner.ptyId)
+    if (absenceVerdict.status === 'unverifiable') {
+      runtime?.markPtyLivenessUnverifiable(owner.ptyId, absenceVerdict.reason)
+      runtime?.onPtyExit(owner.ptyId, -1, owner.incarnationId)
+    } else {
+      runtime?.onPtyExit(owner.ptyId, 0, owner.incarnationId)
+    }
+    clearProviderPtyState(owner.ptyId, {
+      preserveAgentSessionOwners: absenceVerdict.status === 'unverifiable'
+    })
     ptyOwnership.delete(owner.ptyId)
     if (
       args.worktreeId &&

--- a/src/main/ipc/pty/pane/stable-pane-relay-age-fallback.test.ts
+++ b/src/main/ipc/pty/pane/stable-pane-relay-age-fallback.test.ts
@@ -6,23 +6,41 @@ import { noCodexResumeLaunch } from '../host-env/codex-resume'
 import { registerSshPtyProvider, unregisterSshPtyProvider } from '../provider/registry'
 import { spawnPtyFromRuntimeController } from '../runtime/spawn'
 import { adoptStablePane } from './adopt-stable'
+import { agentSessionOwners } from './agent-session-owners'
 import { resolveStablePaneOwner, spawnForStablePane } from './stable-owner'
 
-const NOW = 10_000
 const BINDING_CREATED_AT = 1_000
-const BINDING_AGE = NOW - BINDING_CREATED_AT
+const RELAY_PROCESS_ID = 'relay-process-1'
 const WORKTREE_ID = 'worktree-1'
 const TAB_ID = 'tab-1'
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 const PANE_KEY = `${TAB_ID}:${LEAF_ID}`
 const CONNECTION_ID = 'ssh-1'
 const APP_PTY_ID = `ssh:${CONNECTION_ID}@@pty-1`
+const CLAIMED_OWNER = {
+  claim: {
+    digestVersion: 1 as const,
+    keyId: 'key',
+    identityDigest: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    worktreeScopeDigest: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    agent: 'codex' as const
+  },
+  generation: 'generation-1',
+  phase: 'live' as const,
+  ptyId: APP_PTY_ID,
+  surface: {
+    worktreeId: WORKTREE_ID,
+    tabId: TAB_ID,
+    leafId: LEAF_ID,
+    terminalHandle: 'term-1'
+  }
+}
 
 type AbsenceFallbackResult = Awaited<ReturnType<typeof spawnForStablePane>> & {
   absenceVerdict: { status: 'live' | 'unverifiable' | 'exited' }
 }
 
-function createStore(): Store {
+function createStore(relayProcessId: string | null | undefined = RELAY_PROCESS_ID): Store {
   let session = {
     tabsByWorktree: {
       [WORKTREE_ID]: [
@@ -58,7 +76,8 @@ function createStore(): Store {
         leafId: LEAF_ID,
         state: 'detached',
         createdAt: BINDING_CREATED_AT,
-        updatedAt: BINDING_CREATED_AT
+        updatedAt: BINDING_CREATED_AT,
+        ...(relayProcessId ? { relayProcessId } : {})
       }
     ]
   } as unknown as Store
@@ -73,7 +92,10 @@ function createProvider(relayStatus: unknown): {
     .fn()
     .mockRejectedValueOnce(new Error('PTY "pty-1" not found'))
     .mockResolvedValueOnce({ id: `ssh:${CONNECTION_ID}@@pty-2`, isReattach: false })
-  const requestHostRpc = vi.fn().mockResolvedValue(relayStatus)
+  const requestHostRpc =
+    relayStatus instanceof Error
+      ? vi.fn().mockRejectedValue(relayStatus)
+      : vi.fn().mockResolvedValue(relayStatus)
   return {
     provider: { spawn, requestHostRpc } as unknown as IPtyProvider,
     requestHostRpc,
@@ -94,17 +116,28 @@ const STARTUP_INTENT: PtySpawnOptions = {
   agentSessionCreateOperationId: 'create-1'
 }
 
-async function runFallback(relayStatus: unknown): Promise<{
+async function runFallback(
+  relayStatus: unknown,
+  bindingRelayProcessId: string | null | undefined = RELAY_PROCESS_ID
+): Promise<{
   result: AbsenceFallbackResult
   requestHostRpc: ReturnType<typeof vi.fn>
   spawn: ReturnType<typeof vi.fn>
+  runtime: {
+    markPtyLivenessUnverifiable: ReturnType<typeof vi.fn>
+    onPtyExit: ReturnType<typeof vi.fn>
+  }
 }> {
-  const store = createStore()
+  const store = createStore(bindingRelayProcessId)
   const owner = resolveStablePaneOwner(undefined, store, PANE_KEY, WORKTREE_ID, CONNECTION_ID)
   expect(owner).not.toBeNull()
   const { provider, requestHostRpc, spawn } = createProvider(relayStatus)
+  const runtime = {
+    markPtyLivenessUnverifiable: vi.fn(),
+    onPtyExit: vi.fn()
+  }
   const result = (await spawnForStablePane({
-    runtime: undefined,
+    runtime: runtime as never,
     store,
     provider,
     spawnOptions: STARTUP_INTENT,
@@ -112,24 +145,20 @@ async function runFallback(relayStatus: unknown): Promise<{
     connectionId: CONNECTION_ID,
     resolveOwner: () => null
   })) as AbsenceFallbackResult
-  return { result, requestHostRpc, spawn }
+  return { result, requestHostRpc, spawn, runtime }
 }
 
-describe('stable pane relay-age-aware absence fallback', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-    vi.setSystemTime(NOW)
-  })
-
+describe('stable pane relay-process-aware absence fallback', () => {
+  beforeEach(() => vi.useFakeTimers())
   afterEach(() => {
     unregisterSshPtyProvider(CONNECTION_ID)
     vi.useRealTimers()
   })
 
-  it('degrades a stale binding answered by a younger live relay to unverifiable', async () => {
-    const { result, requestHostRpc, spawn } = await runFallback({
-      pid: 42,
-      uptimeMs: BINDING_AGE - 1
+  it('degrades a binding answered by a replacement relay to unverifiable', async () => {
+    const { result, requestHostRpc, spawn, runtime } = await runFallback({
+      relayProcessId: 'relay-process-2',
+      uptimeMs: Number.MAX_SAFE_INTEGER
     })
 
     expect(result.absenceVerdict.status).toBe('unverifiable')
@@ -143,36 +172,93 @@ describe('stable pane relay-age-aware absence fallback', () => {
       startupIngress: STARTUP_INTENT.startupIngress,
       env: { KEEP_ME: 'yes' },
       onPtySpawnCommitted: STARTUP_INTENT.onPtySpawnCommitted,
+      agentSessionEnsure: undefined,
       agentSessionCreateOperationId: undefined
     })
+    expect(runtime.markPtyLivenessUnverifiable).toHaveBeenCalledWith(
+      APP_PTY_ID,
+      expect.stringContaining('cannot be proven')
+    )
+    expect(runtime.onPtyExit).toHaveBeenCalledWith(APP_PTY_ID, -1, undefined)
   })
 
   it.each([
-    ['exactly as old as the binding', BINDING_AGE],
-    ['one millisecond older than the binding', BINDING_AGE + 1]
-  ])('keeps genuine positive absence exited when the relay is %s', async (_label, uptimeMs) => {
-    const { result, spawn } = await runFallback({ pid: 42, uptimeMs })
+    ['missing', undefined],
+    ['zero', 0],
+    ['equal to the old binding age', 9_000],
+    ['sub-second newer', 9_000.5],
+    ['negative', -1],
+    ['non-finite', Number.POSITIVE_INFINITY]
+  ])(
+    'ignores %s uptime when exact relay-process authority is present',
+    async (_label, uptimeMs) => {
+      const { result, spawn, runtime } = await runFallback({
+        relayProcessId: RELAY_PROCESS_ID,
+        ...(uptimeMs === undefined ? {} : { uptimeMs })
+      })
 
-    expect(result.absenceVerdict.status).toBe('exited')
+      expect(result.absenceVerdict.status).toBe('exited')
+      expect(spawn.mock.calls[1]?.[0]).toMatchObject({
+        command: STARTUP_INTENT.command,
+        launchAgent: STARTUP_INTENT.launchAgent
+      })
+      expect(runtime.markPtyLivenessUnverifiable).not.toHaveBeenCalled()
+      expect(runtime.onPtyExit).toHaveBeenCalledWith(APP_PTY_ID, 0, undefined)
+    }
+  )
+
+  it.each([
+    ['persisted lease identity is missing', { relayProcessId: RELAY_PROCESS_ID }, null],
+    ['old relay omits process identity', { pid: 42, uptimeMs: 9_000 }, RELAY_PROCESS_ID],
+    ['relay identity is malformed', { relayProcessId: 42 }, RELAY_PROCESS_ID],
+    ['status request fails', new Error('relay status unavailable'), RELAY_PROCESS_ID],
+    [
+      'relay restarted while reporting preserved uptime',
+      { relayProcessId: 'relay-process-2', uptimeMs: 9_000 },
+      RELAY_PROCESS_ID
+    ],
+    [
+      'older relay never owned the process',
+      { relayProcessId: 'relay-process-2', uptimeMs: 99_000 },
+      RELAY_PROCESS_ID
+    ]
+  ])('keeps absence unverifiable when %s', async (_label, relayStatus, bindingIdentity) => {
+    const { result, spawn, runtime } = await runFallback(relayStatus, bindingIdentity)
+
+    expect(result.absenceVerdict.status).toBe('unverifiable')
     expect(spawn.mock.calls[1]?.[0]).toMatchObject({
-      command: STARTUP_INTENT.command,
-      launchAgent: STARTUP_INTENT.launchAgent
+      command: undefined,
+      launchAgent: undefined
     })
+    expect(runtime.markPtyLivenessUnverifiable).toHaveBeenCalledOnce()
+    expect(runtime.onPtyExit).toHaveBeenCalledWith(APP_PTY_ID, -1, undefined)
   })
 
-  it('keeps an older host without relay age compatible with the prior fallback', async () => {
-    const { result, spawn } = await runFallback({ pid: 42 })
+  it('preserves the old agent ownership fence when absence is unverifiable', async () => {
+    agentSessionOwners.register(CLAIMED_OWNER)
+    try {
+      await runFallback({ relayProcessId: 'relay-process-2' })
 
-    expect(result.absenceVerdict.status).toBe('exited')
-    expect(spawn.mock.calls[1]?.[0]).toMatchObject({
-      command: STARTUP_INTENT.command,
-      launchAgent: STARTUP_INTENT.launchAgent
-    })
+      expect(agentSessionOwners.listForPty(APP_PTY_ID)).toEqual([CLAIMED_OWNER])
+    } finally {
+      agentSessionOwners.release(APP_PTY_ID)
+    }
+  })
+
+  it('releases the old agent ownership fence after authoritative exit', async () => {
+    agentSessionOwners.register(CLAIMED_OWNER)
+    try {
+      await runFallback({ relayProcessId: RELAY_PROCESS_ID })
+
+      expect(agentSessionOwners.listForPty(APP_PTY_ID)).toEqual([])
+    } finally {
+      agentSessionOwners.release(APP_PTY_ID)
+    }
   })
 
   it('carries an early adoption verdict into the later full spawn', async () => {
     const store = createStore()
-    const { provider, spawn } = createProvider({ pid: 42, uptimeMs: BINDING_AGE - 1 })
+    const { provider, spawn } = createProvider({ relayProcessId: 'relay-process-2' })
     registerSshPtyProvider(CONNECTION_ID, provider)
 
     const adoption = await adoptStablePane(undefined, store, {
@@ -259,7 +345,7 @@ describe('stable pane relay-age-aware absence fallback', () => {
         },
         stablePaneAbsenceVerdict: {
           status: 'unverifiable',
-          reason: 'the answering SSH relay is younger than the persisted PTY binding'
+          reason: 'the answering SSH relay cannot be proven to own the persisted PTY binding'
         }
       } as never
     )

--- a/src/main/ipc/pty/pane/stable-pane-relay-age-fallback.test.ts
+++ b/src/main/ipc/pty/pane/stable-pane-relay-age-fallback.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkspaceSessionState } from '../../../../shared/workspace-session-state-types'
+import type { Store } from '../../../persistence'
+import type { IPtyProvider, PtySpawnOptions } from '../../../providers/types'
+import { noCodexResumeLaunch } from '../host-env/codex-resume'
+import { registerSshPtyProvider, unregisterSshPtyProvider } from '../provider/registry'
+import { spawnPtyFromRuntimeController } from '../runtime/spawn'
+import { adoptStablePane } from './adopt-stable'
+import { resolveStablePaneOwner, spawnForStablePane } from './stable-owner'
+
+const NOW = 10_000
+const BINDING_CREATED_AT = 1_000
+const BINDING_AGE = NOW - BINDING_CREATED_AT
+const WORKTREE_ID = 'worktree-1'
+const TAB_ID = 'tab-1'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const PANE_KEY = `${TAB_ID}:${LEAF_ID}`
+const CONNECTION_ID = 'ssh-1'
+const APP_PTY_ID = `ssh:${CONNECTION_ID}@@pty-1`
+
+type AbsenceFallbackResult = Awaited<ReturnType<typeof spawnForStablePane>> & {
+  absenceVerdict: { status: 'live' | 'unverifiable' | 'exited' }
+}
+
+function createStore(): Store {
+  let session = {
+    tabsByWorktree: {
+      [WORKTREE_ID]: [
+        {
+          id: TAB_ID,
+          worktreeId: WORKTREE_ID,
+          ptyId: APP_PTY_ID,
+          createdAt: BINDING_CREATED_AT
+        }
+      ]
+    },
+    terminalLayoutsByTabId: {
+      [TAB_ID]: {
+        root: { type: 'leaf', leafId: LEAF_ID },
+        activeLeafId: LEAF_ID,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF_ID]: APP_PTY_ID }
+      }
+    }
+  } as unknown as WorkspaceSessionState
+  return {
+    getWorkspaceSession: () => session,
+    setWorkspaceSession: (nextSession: WorkspaceSessionState) => {
+      session = nextSession as typeof session
+    },
+    flushOrThrow: vi.fn(),
+    getSshRemotePtyLeases: () => [
+      {
+        targetId: CONNECTION_ID,
+        ptyId: 'pty-1',
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        leafId: LEAF_ID,
+        state: 'detached',
+        createdAt: BINDING_CREATED_AT,
+        updatedAt: BINDING_CREATED_AT
+      }
+    ]
+  } as unknown as Store
+}
+
+function createProvider(relayStatus: unknown): {
+  provider: IPtyProvider
+  requestHostRpc: ReturnType<typeof vi.fn>
+  spawn: ReturnType<typeof vi.fn>
+} {
+  const spawn = vi
+    .fn()
+    .mockRejectedValueOnce(new Error('PTY "pty-1" not found'))
+    .mockResolvedValueOnce({ id: `ssh:${CONNECTION_ID}@@pty-2`, isReattach: false })
+  const requestHostRpc = vi.fn().mockResolvedValue(relayStatus)
+  return {
+    provider: { spawn, requestHostRpc } as unknown as IPtyProvider,
+    requestHostRpc,
+    spawn
+  }
+}
+
+const STARTUP_INTENT: PtySpawnOptions = {
+  cols: 80,
+  rows: 24,
+  command: 'codex resume session-1',
+  commandDelivery: 'provider',
+  startupCommandDelivery: 'shell-ready',
+  launchAgent: 'codex',
+  startupIngress: { colors: { foreground: 'rgb:ffff/ffff/ffff' }, deadlineMs: 1_000 },
+  env: { ORCA_AGENT_LAUNCH_TOKEN: 'launch-1', KEEP_ME: 'yes' },
+  onPtySpawnCommitted: vi.fn(),
+  agentSessionCreateOperationId: 'create-1'
+}
+
+async function runFallback(relayStatus: unknown): Promise<{
+  result: AbsenceFallbackResult
+  requestHostRpc: ReturnType<typeof vi.fn>
+  spawn: ReturnType<typeof vi.fn>
+}> {
+  const store = createStore()
+  const owner = resolveStablePaneOwner(undefined, store, PANE_KEY, WORKTREE_ID, CONNECTION_ID)
+  expect(owner).not.toBeNull()
+  const { provider, requestHostRpc, spawn } = createProvider(relayStatus)
+  const result = (await spawnForStablePane({
+    runtime: undefined,
+    store,
+    provider,
+    spawnOptions: STARTUP_INTENT,
+    owner,
+    connectionId: CONNECTION_ID,
+    resolveOwner: () => null
+  })) as AbsenceFallbackResult
+  return { result, requestHostRpc, spawn }
+}
+
+describe('stable pane relay-age-aware absence fallback', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    unregisterSshPtyProvider(CONNECTION_ID)
+    vi.useRealTimers()
+  })
+
+  it('degrades a stale binding answered by a younger live relay to unverifiable', async () => {
+    const { result, requestHostRpc, spawn } = await runFallback({
+      pid: 42,
+      uptimeMs: BINDING_AGE - 1
+    })
+
+    expect(result.absenceVerdict.status).toBe('unverifiable')
+    expect(requestHostRpc).toHaveBeenCalledWith('relay.status', {}, expect.any(Object))
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(spawn.mock.calls[1]?.[0]).toMatchObject({
+      command: undefined,
+      commandDelivery: undefined,
+      startupCommandDelivery: undefined,
+      launchAgent: undefined,
+      startupIngress: STARTUP_INTENT.startupIngress,
+      env: { KEEP_ME: 'yes' },
+      onPtySpawnCommitted: STARTUP_INTENT.onPtySpawnCommitted,
+      agentSessionCreateOperationId: undefined
+    })
+  })
+
+  it.each([
+    ['exactly as old as the binding', BINDING_AGE],
+    ['one millisecond older than the binding', BINDING_AGE + 1]
+  ])('keeps genuine positive absence exited when the relay is %s', async (_label, uptimeMs) => {
+    const { result, spawn } = await runFallback({ pid: 42, uptimeMs })
+
+    expect(result.absenceVerdict.status).toBe('exited')
+    expect(spawn.mock.calls[1]?.[0]).toMatchObject({
+      command: STARTUP_INTENT.command,
+      launchAgent: STARTUP_INTENT.launchAgent
+    })
+  })
+
+  it('keeps an older host without relay age compatible with the prior fallback', async () => {
+    const { result, spawn } = await runFallback({ pid: 42 })
+
+    expect(result.absenceVerdict.status).toBe('exited')
+    expect(spawn.mock.calls[1]?.[0]).toMatchObject({
+      command: STARTUP_INTENT.command,
+      launchAgent: STARTUP_INTENT.launchAgent
+    })
+  })
+
+  it('carries an early adoption verdict into the later full spawn', async () => {
+    const store = createStore()
+    const { provider, spawn } = createProvider({ pid: 42, uptimeMs: BINDING_AGE - 1 })
+    registerSshPtyProvider(CONNECTION_ID, provider)
+
+    const adoption = await adoptStablePane(undefined, store, {
+      cols: 80,
+      rows: 24,
+      connectionId: CONNECTION_ID,
+      worktreeId: WORKTREE_ID,
+      tabId: TAB_ID,
+      leafId: LEAF_ID
+    })
+    expect(adoption?.result).toBeNull()
+    if (!adoption || adoption.result !== null) {
+      throw new Error('expected an absence outcome')
+    }
+    expect(adoption.absenceVerdict.status).toBe('unverifiable')
+
+    const result = await spawnForStablePane({
+      runtime: undefined,
+      store,
+      provider,
+      spawnOptions: STARTUP_INTENT,
+      owner: null,
+      connectionId: CONNECTION_ID,
+      absenceVerdict: adoption.absenceVerdict
+    })
+
+    expect(result.absenceVerdict?.status).toBe('unverifiable')
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(spawn.mock.calls[1]?.[0]).toMatchObject({
+      command: undefined,
+      launchAgent: undefined,
+      startupIngress: STARTUP_INTENT.startupIngress,
+      env: { KEEP_ME: 'yes' }
+    })
+  })
+
+  it('suppresses runtime agent-session claims after an unverifiable early adoption', async () => {
+    const spawn = vi.fn(async (_options: PtySpawnOptions) => ({
+      id: `ssh:${CONNECTION_ID}@@pty-2`
+    }))
+    registerSshPtyProvider(CONNECTION_ID, {
+      spawn,
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => []),
+      getForegroundProcess: vi.fn(async () => null)
+    } as never)
+
+    const result = await spawnPtyFromRuntimeController(
+      {
+        assertFolderWorkspacePtyPathUsable: vi.fn(),
+        resolvePtySpawnStartupCwd: (_worktreeId: string | undefined, cwd: string | undefined) =>
+          cwd,
+        prepareCodexResumeHome: vi.fn(() => null),
+        noCodexResumeLaunch,
+        resolveCodexResumeLaunch: vi.fn(),
+        reconcileSharedRuntimeResumeHome: vi.fn(),
+        stripSequencedStartupResumeArgv: (env: Record<string, string> | undefined) => env,
+        getLocalPtyStartupPromise: vi.fn(() => undefined),
+        trustedTerminalHandleEnv: new Set(),
+        sendPtySpawnedToRenderer: vi.fn()
+      } as never,
+      {
+        cols: 80,
+        rows: 24,
+        connectionId: CONNECTION_ID,
+        command: STARTUP_INTENT.command,
+        commandDelivery: STARTUP_INTENT.commandDelivery,
+        startupCommandDelivery: STARTUP_INTENT.startupCommandDelivery,
+        launchAgent: STARTUP_INTENT.launchAgent,
+        env: STARTUP_INTENT.env,
+        agentSessionEnsure: {
+          claim: { identityDigest: 'claim-digest' },
+          surface: {
+            worktreeId: WORKTREE_ID,
+            tabId: TAB_ID,
+            leafId: LEAF_ID,
+            terminalHandle: 'term-1'
+          }
+        },
+        stablePaneAbsenceVerdict: {
+          status: 'unverifiable',
+          reason: 'the answering SSH relay is younger than the persisted PTY binding'
+        }
+      } as never
+    )
+
+    expect(result.agentStartupSuppressed).toBe(true)
+    expect(spawn).toHaveBeenCalledOnce()
+    expect(spawn.mock.calls[0]?.[0]).toMatchObject({
+      command: undefined,
+      commandDelivery: undefined,
+      startupCommandDelivery: undefined,
+      launchAgent: undefined,
+      agentSessionEnsure: undefined,
+      env: { KEEP_ME: 'yes' }
+    })
+  })
+})

--- a/src/main/ipc/pty/pane/stable-pane-spawn-fallback.ts
+++ b/src/main/ipc/pty/pane/stable-pane-spawn-fallback.ts
@@ -1,0 +1,35 @@
+import type { PtyLivenessVerdict } from '../../../../shared/pty-liveness-verdict'
+import type { Store } from '../../../persistence'
+import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../../../providers/types'
+import type { OrcaRuntimeService } from '../../../runtime/orca-runtime'
+import type { StablePaneOwner } from './stable-pane-types'
+
+export type StablePaneSpawnContext = {
+  runtime: OrcaRuntimeService | undefined
+  store?: Store
+  provider: IPtyProvider
+  spawnOptions: PtySpawnOptions
+  owner: StablePaneOwner | null
+  worktreeId?: string
+  connectionId?: string | null
+  resolveOwner?: () => StablePaneOwner | null
+  onFreshSpawn?: (result: PtySpawnResult) => void
+  absenceVerdict?: PtyLivenessVerdict
+}
+
+export function withoutAgentStartupIntent(options: PtySpawnOptions): PtySpawnOptions {
+  const env = options.env ? { ...options.env } : undefined
+  if (env) {
+    delete env.ORCA_AGENT_LAUNCH_TOKEN
+  }
+  return {
+    ...options,
+    ...(env ? { env } : {}),
+    command: undefined,
+    commandDelivery: undefined,
+    startupCommandDelivery: undefined,
+    launchAgent: undefined,
+    agentSessionEnsure: undefined,
+    agentSessionCreateOperationId: undefined
+  }
+}

--- a/src/main/ipc/pty/pane/stable-pane-types.ts
+++ b/src/main/ipc/pty/pane/stable-pane-types.ts
@@ -1,0 +1,26 @@
+import type { PtyLivenessVerdict } from '../../../../shared/pty-liveness-verdict'
+import type { PtySpawnResult } from '../../../providers/types'
+
+export type StablePaneOwner = {
+  handle?: string
+  tabId: string
+  leafId: string
+  ptyId: string
+  incarnationId?: string
+  hasPersistedBinding?: true
+  bindingCreatedAt?: number
+  persistedIncarnationId?: string
+  runtimeIncarnationId?: string
+}
+
+export type StablePaneAdoption =
+  | {
+      result: PtySpawnResult
+      owner: StablePaneOwner
+      materialized?: true
+    }
+  | {
+      result: null
+      owner: null
+      absenceVerdict: PtyLivenessVerdict
+    }

--- a/src/main/ipc/pty/pane/stable-pane-types.ts
+++ b/src/main/ipc/pty/pane/stable-pane-types.ts
@@ -8,7 +8,7 @@ export type StablePaneOwner = {
   ptyId: string
   incarnationId?: string
   hasPersistedBinding?: true
-  bindingCreatedAt?: number
+  bindingRelayProcessId?: string
   persistedIncarnationId?: string
   runtimeIncarnationId?: string
 }

--- a/src/main/ipc/pty/provider/liveness.ts
+++ b/src/main/ipc/pty/provider/liveness.ts
@@ -3,7 +3,10 @@ import type { AgentSessionOwnerBinding } from '../../../../shared/agent-session-
 import { agentSessionOwnerBindingsEqual } from '../../../../shared/claimed-agent-pty-owner'
 import { addNodePtyRecoveryHint } from '../../../daemon/node-pty-error-hints'
 import type { Store } from '../../../persistence'
-import { isSshPtyNotFoundError } from '../../../providers/ssh-pty-errors'
+import {
+  isSshPtyAbsentFromRelayError,
+  isSshPtyNotFoundError
+} from '../../../providers/ssh-pty-errors'
 import type { IPtyProvider } from '../../../providers/types'
 import { markClaudePtyExited } from '../../../claude-accounts/live-pty-gate'
 import { ptyIncarnationById, ptyOwnership } from './ownership-state'
@@ -54,7 +57,11 @@ export function normalizeNodePtySpawnError(err: unknown): Error {
 
 export function isPtyAlreadyGoneError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err)
-  return isSshPtyNotFoundError(err) || /Session not found/i.test(message)
+  return (
+    isSshPtyNotFoundError(err) ||
+    isSshPtyAbsentFromRelayError(err) ||
+    /Session not found/i.test(message)
+  )
 }
 
 export function delay(ms: number): Promise<void> {

--- a/src/main/ipc/pty/runtime/controller-deps.ts
+++ b/src/main/ipc/pty/runtime/controller-deps.ts
@@ -16,13 +16,13 @@ import type {
 } from '../host-env/types'
 import type { CodexResumeLaunch, PreparedCodexResumeHome } from '../host-env/codex-resume'
 import type { StablePaneOwner } from '../pane/stable-owner'
-import type { AdoptStablePaneArgs, AdoptStablePaneResult } from '../ipc/spawn-types'
+import type { AdoptStablePaneArgs, AdoptStablePaneOutcome } from '../ipc/spawn-types'
 import type { finishPtyShutdown } from '../provider/liveness'
 
 export type PtyRuntimeControllerDeps = {
   runtime?: OrcaRuntimeService
   store?: Store
-  adoptStablePane: (args: AdoptStablePaneArgs) => Promise<AdoptStablePaneResult | null>
+  adoptStablePane: (args: AdoptStablePaneArgs) => Promise<AdoptStablePaneOutcome | null>
   getLocalPtyStartupPromise: (connectionId?: string | null) => Promise<void> | undefined
   getLocalPtyProviderStartupPromise: (connectionId?: string | null) => Promise<void> | undefined
   prepareCodexResumeHome: (args: {

--- a/src/main/ipc/pty/runtime/spawn-commit.ts
+++ b/src/main/ipc/pty/runtime/spawn-commit.ts
@@ -111,7 +111,6 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
   ) {
     markNativeWindowsConptyPty(ctx.result.id)
   }
-  const relayResultId = getRelayPtyId(args.connectionId, ctx.result.id)
   const persistSshLease = (): void => {
     if (!ctx.deps.store || !args.connectionId) {
       return
@@ -119,13 +118,14 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
     // Why: SSH leases keep relay ids for remote reconciliation, while session bindings keep app-facing ids for hydration.
     ctx.deps.store.upsertSshRemotePtyLease({
       targetId: args.connectionId,
-      ptyId: relayResultId,
+      ptyId: getRelayPtyId(args.connectionId, ctx.result.id),
       ...(typeof args.worktreeId === 'string' ? { worktreeId: args.worktreeId } : {}),
       ...(typeof args.tabId === 'string' ? { tabId: args.tabId } : {}),
       ...(typeof args.leafId === 'string' && isTerminalLeafId(args.leafId)
         ? { leafId: args.leafId }
         : {}),
       state: 'attached',
+      ...(ctx.result.relayProcessId ? { relayProcessId: ctx.result.relayProcessId } : {}),
       lastAttachedAt: Date.now()
     })
   }

--- a/src/main/ipc/pty/runtime/spawn-commit.ts
+++ b/src/main/ipc/pty/runtime/spawn-commit.ts
@@ -37,6 +37,7 @@ import type { RuntimePtySpawnState } from './spawn-state'
 
 export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
   const args = ctx.args
+  const agentStartupSuppressed = ctx.stablePaneAbsenceVerdict?.status === 'unverifiable'
   try {
     ctx.stablePaneBindingPersisted = persistAdmittedStablePaneBinding({
       store: ctx.hostSessionBinding?.store,
@@ -219,12 +220,15 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
   seedTerminalRestoreRecordsFromSpawnResult(ctx.deps.runtime, ctx.result)
   // Why: arms main's per-PTY Command Code output detector from the launch command (renderer startupCommand parity).
   if (!ctx.stablePaneOwner) {
-    ctx.deps.runtime?.noteTerminalSpawnCommand?.(ctx.result.id, ctx.launchCommand ?? null)
+    ctx.deps.runtime?.noteTerminalSpawnCommand?.(
+      ctx.result.id,
+      agentStartupSuppressed ? null : (ctx.launchCommand ?? null)
+    )
   }
-  if (ctx.isClaudeLaunch && !ctx.stablePaneOwner) {
+  if (!agentStartupSuppressed && ctx.isClaudeLaunch && !ctx.stablePaneOwner) {
     markClaudePtySpawned(ctx.result.id)
   }
-  if (args.telemetry && !ctx.stablePaneOwner) {
+  if (!agentStartupSuppressed && args.telemetry && !ctx.stablePaneOwner) {
     const agentKindParse = agentKindSchema.safeParse(args.telemetry.agent_kind)
     const launchSourceParse = launchSourceSchema.safeParse(args.telemetry.launch_source)
     const requestKindParse = requestKindSchema.safeParse(args.telemetry.request_kind)
@@ -283,6 +287,7 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
   const response = {
     id: ctx.result.id,
     ...(ctx.result.incarnationId ? { incarnationId: ctx.result.incarnationId } : {}),
+    ...(agentStartupSuppressed ? { agentStartupSuppressed: true as const } : {}),
     ...(ctx.stablePaneOwner && (ctx.stablePaneOwner.handle || args.preAllocatedHandle)
       ? {
           stablePaneOwner: {

--- a/src/main/ipc/pty/runtime/spawn-execute.ts
+++ b/src/main/ipc/pty/runtime/spawn-execute.ts
@@ -60,7 +60,11 @@ export async function executeRuntimePtySpawn(ctx: RuntimePtySpawnState): Promise
         throw new Error('client_disconnected')
       }
     }
-    if (args.agentSessionEnsure && !ctx.preAdoptedStablePane) {
+    if (
+      args.agentSessionEnsure &&
+      !ctx.preAdoptedStablePane &&
+      ctx.stablePaneAbsenceVerdict?.status !== 'unverifiable'
+    ) {
       // Why: daemon-backed claims can outlive this controller; import all
       // proven owners before deciding that an identity is absent.
       await reconcileAgentSessionOwnerListings()
@@ -136,6 +140,7 @@ export async function executeRuntimePtySpawn(ctx: RuntimePtySpawnState): Promise
             owner: stablePaneOwnerCandidate,
             worktreeId: args.worktreeId,
             connectionId: args.connectionId,
+            absenceVerdict: ctx.stablePaneAbsenceVerdict,
             resolveOwner: () =>
               resolveStablePaneOwner(
                 ctx.deps.runtime,
@@ -148,6 +153,10 @@ export async function executeRuntimePtySpawn(ctx: RuntimePtySpawnState): Promise
           })
       ctx.result = stablePaneSpawn.result
       ctx.stablePaneOwner = stablePaneSpawn.owner
+      ctx.stablePaneAbsenceVerdict =
+        'absenceVerdict' in stablePaneSpawn
+          ? stablePaneSpawn.absenceVerdict
+          : ctx.stablePaneAbsenceVerdict
       if (
         ctx.stablePaneOwner &&
         ctx.isNewDaemonSession &&

--- a/src/main/ipc/pty/runtime/spawn-state.ts
+++ b/src/main/ipc/pty/runtime/spawn-state.ts
@@ -10,11 +10,13 @@ import type { PtyRuntimeControllerDeps } from './controller-deps'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { AgentProviderSessionMetadata } from '../../../../shared/agent-session-resume'
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
+import type { PtyLivenessVerdict } from '../../../../shared/pty-liveness-verdict'
 import type {
   AgentSessionExecutionClaim,
   AgentSessionSurfaceBinding
 } from '../../../../shared/agent-session-host-authority'
 import { localProvider } from '../provider/registry'
+import { withoutAgentStartupIntent } from '../pane/stable-pane-spawn-fallback'
 
 export type RuntimePtySpawnState = {
   deps: PtyRuntimeControllerDeps
@@ -70,6 +72,7 @@ export type RuntimePtySpawnState = {
     agentSessionEnsure?: unknown
   }
   stablePaneOwner: StablePaneOwner | null
+  stablePaneAbsenceVerdict: PtyLivenessVerdict | undefined
   stablePaneBindingPersisted: boolean
   rejectedRegistrationCandidate: PtySpawnResult | null
   pendingRegistrationPtyId: string | null
@@ -124,15 +127,25 @@ export type RuntimePtySpawnArgs = {
     }
     materialized?: true
   }
+  stablePaneAbsenceVerdict?: PtyLivenessVerdict
 }
 
 export function createRuntimePtySpawnState(
   deps: PtyRuntimeControllerDeps,
   args: RuntimePtySpawnArgs
 ): RuntimePtySpawnState {
+  const effectiveArgs =
+    args.stablePaneAbsenceVerdict?.status === 'unverifiable'
+      ? {
+          ...args,
+          ...withoutAgentStartupIntent(args),
+          resumeProviderSession: undefined,
+          telemetry: undefined
+        }
+      : args
   return {
     deps,
-    args,
+    args: effectiveArgs,
     codexHomeLaunchStartedAt: undefined,
     codexHomeLaunchStartedSequence: undefined,
     preAdoptedStablePane: null,
@@ -173,6 +186,7 @@ export function createRuntimePtySpawnState(
     finishTerminalInstall: () => {},
     result: { id: '' },
     stablePaneOwner: null,
+    stablePaneAbsenceVerdict: effectiveArgs.stablePaneAbsenceVerdict,
     stablePaneBindingPersisted: false,
     rejectedRegistrationCandidate: null,
     pendingRegistrationPtyId: null,

--- a/src/main/ipc/pty/runtime/spawn.ts
+++ b/src/main/ipc/pty/runtime/spawn.ts
@@ -23,13 +23,15 @@ function toRuntimeSpawnReply(result: {
   wslDistro?: string | null
   stablePaneOwner?: { handle: string; tabId: string; leafId: string }
   agentSessionEnsure?: AgentSessionClaimedSpawnResult
+  agentStartupSuppressed?: true
 }) {
   return {
     id: result.id,
     ...(result.incarnationId ? { incarnationId: result.incarnationId } : {}),
     ...(typeof result.wslDistro === 'string' ? { wslDistro: result.wslDistro } : {}),
     ...(result.stablePaneOwner ? { stablePaneOwner: result.stablePaneOwner } : {}),
-    ...(result.agentSessionEnsure ? { agentSessionEnsure: result.agentSessionEnsure } : {})
+    ...(result.agentSessionEnsure ? { agentSessionEnsure: result.agentSessionEnsure } : {}),
+    ...(result.agentStartupSuppressed ? { agentStartupSuppressed: true as const } : {})
   }
 }
 

--- a/src/main/persistence/leasing-ssh-ptys/ssh-normalization.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-normalization.ts
@@ -70,7 +70,12 @@ export function normalizeSshRemotePtyLease(value: unknown): SshRemotePtyLease | 
     createdAt: typeof raw.createdAt === 'number' ? raw.createdAt : now,
     updatedAt: typeof raw.updatedAt === 'number' ? raw.updatedAt : now,
     ...(typeof raw.lastAttachedAt === 'number' ? { lastAttachedAt: raw.lastAttachedAt } : {}),
-    ...(typeof raw.lastDetachedAt === 'number' ? { lastDetachedAt: raw.lastDetachedAt } : {})
+    ...(typeof raw.lastDetachedAt === 'number' ? { lastDetachedAt: raw.lastDetachedAt } : {}),
+    ...(typeof raw.relayProcessId === 'string' &&
+    raw.relayProcessId.length > 0 &&
+    raw.relayProcessId.length <= 128
+      ? { relayProcessId: raw.relayProcessId }
+      : {})
   }
 }
 

--- a/src/main/persistence/leasing-ssh-ptys/ssh-relay-process-id-normalization.test.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-relay-process-id-normalization.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeSshRemotePtyLease } from './ssh-normalization'
+
+const LEASE = {
+  targetId: 'ssh-1',
+  ptyId: 'pty-1',
+  state: 'detached' as const,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+describe('SSH relay process identity persistence', () => {
+  it('preserves a bounded process identity', () => {
+    expect(
+      normalizeSshRemotePtyLease({ ...LEASE, relayProcessId: 'relay-process-1' })
+    ).toMatchObject({ relayProcessId: 'relay-process-1' })
+  })
+
+  it.each(['', 'x'.repeat(129), 42])('drops malformed process identity %j', (relayProcessId) => {
+    expect(normalizeSshRemotePtyLease({ ...LEASE, relayProcessId })).not.toHaveProperty(
+      'relayProcessId'
+    )
+  })
+})

--- a/src/main/providers/pty-spawn-result.ts
+++ b/src/main/providers/pty-spawn-result.ts
@@ -12,6 +12,8 @@ export type PtySpawnResult = {
   id: string
   /** Opaque provider-owned identity for this process behind a reusable PTY id. */
   incarnationId?: PtyIncarnationId
+  /** Opaque identity of the SSH relay process that owns this PTY. */
+  relayProcessId?: string
   /** Relay source identity installed before adjacent source frames are decoded. */
   sourceActivation?: PtySourceReceivingActivation
   /** The provider observed this exact spawn exit before its control reply settled. */

--- a/src/main/providers/ssh-agent-session-create-operation.ts
+++ b/src/main/providers/ssh-agent-session-create-operation.ts
@@ -10,6 +10,7 @@ import {
   type PtySourceReceivingActivation
 } from '../../shared/pty-source-receiving-activation'
 import { validateClaimedSshSpawn } from './ssh-agent-session-claim-validation'
+import { parseSshRelayProcessId } from './ssh-relay-process-id'
 
 export const SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS = 5_000
 
@@ -171,6 +172,7 @@ function parseSshPtySpawnResult(value: unknown): PtySpawnResult {
       ? (value as PtySpawnResult)
       : ({} as PtySpawnResult)
   const activation = parsePtySourceReceivingActivation(result.sourceActivation)
+  const relayProcessId = parseSshRelayProcessId(result.relayProcessId)
   if (
     activation &&
     (typeof result.id !== 'string' ||
@@ -180,5 +182,9 @@ function parseSshPtySpawnResult(value: unknown): PtySpawnResult {
   ) {
     throw new Error('Invalid SSH PTY source activation identity')
   }
-  return activation ? { ...result, sourceActivation: activation } : result
+  return {
+    ...result,
+    ...(relayProcessId ? { relayProcessId } : {}),
+    ...(activation ? { sourceActivation: activation } : {})
+  }
 }

--- a/src/main/providers/ssh-pty-errors.ts
+++ b/src/main/providers/ssh-pty-errors.ts
@@ -10,3 +10,15 @@ export function isSshPtyIdentityMismatchError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error)
   return message.includes(SSH_PTY_IDENTITY_MISMATCH_ERROR) || /identity mismatch/i.test(message)
 }
+
+/** A reachable relay answered that this exact PTY id is absent. */
+export class SshPtyAbsentFromRelayError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SshPtyAbsentFromRelayError'
+  }
+}
+
+export function isSshPtyAbsentFromRelayError(error: unknown): boolean {
+  return error instanceof SshPtyAbsentFromRelayError
+}

--- a/src/main/providers/ssh-pty-provider-agent-session-create-operation.test.ts
+++ b/src/main/providers/ssh-pty-provider-agent-session-create-operation.test.ts
@@ -113,6 +113,7 @@ describe('SSH fresh agent-session create operations', () => {
         cwd: undefined,
         env: { POWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD: 'true' },
         command: 'codex',
+        requestRelayProcessId: true,
         agentSessionCreateOperationId: 'a'.repeat(43)
       },
       expect.objectContaining({ beforeResolve: expect.any(Function) })
@@ -133,7 +134,7 @@ describe('SSH fresh agent-session create operations', () => {
     expect(request).toHaveBeenCalledOnce()
   })
 
-  it('keeps a client-selected old-relay spawn byte-for-byte legacy', async () => {
+  it('keeps a client-selected old-relay spawn free of structured-create fields', async () => {
     request.mockResolvedValueOnce({ id: 'pty-legacy' })
 
     await expect(
@@ -152,7 +153,8 @@ describe('SSH fresh agent-session create operations', () => {
         rows: 24,
         cwd: undefined,
         env: { POWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD: 'true' },
-        command: 'codex'
+        command: 'codex',
+        requestRelayProcessId: true
       },
       expect.objectContaining({ beforeResolve: expect.any(Function) })
     )

--- a/src/main/providers/ssh-pty-provider-reattach-incarnation.test.ts
+++ b/src/main/providers/ssh-pty-provider-reattach-incarnation.test.ts
@@ -30,6 +30,43 @@ describe('SSH PTY provider session reattach incarnation', () => {
     )
   })
 
+  it('requests and returns the relay process identity on reattach', async () => {
+    const mux = {
+      request: vi.fn().mockResolvedValue({
+        incarnationId: 'incarnation-reattached',
+        relayProcessId: 'relay-process-1'
+      }),
+      notify: vi.fn(),
+      onNotification: vi.fn().mockReturnValue(vi.fn())
+    }
+    const provider = new SshPtyProvider('conn-1', mux as never)
+
+    await expect(
+      provider.spawn({ cols: 80, rows: 24, sessionId: 'pty-old' })
+    ).resolves.toMatchObject({ relayProcessId: 'relay-process-1' })
+    expect(mux.request).toHaveBeenCalledWith(
+      'pty.attach',
+      expect.objectContaining({ requestRelayProcessId: true }),
+      expect.any(Object)
+    )
+  })
+
+  it('rejects a malformed relay process identity on reattach', async () => {
+    const mux = {
+      request: vi.fn().mockResolvedValue({
+        incarnationId: 'incarnation-reattached',
+        relayProcessId: 42
+      }),
+      notify: vi.fn(),
+      onNotification: vi.fn().mockReturnValue(vi.fn())
+    }
+    const provider = new SshPtyProvider('conn-1', mux as never)
+
+    await expect(provider.spawn({ cols: 80, rows: 24, sessionId: 'pty-old' })).rejects.toThrow(
+      'Invalid SSH relay process identity'
+    )
+  })
+
   it('fails closed when generic reattach requires source restoration', async () => {
     const mux = {
       request: vi.fn().mockResolvedValue({

--- a/src/main/providers/ssh-pty-provider-spawn.test.ts
+++ b/src/main/providers/ssh-pty-provider-spawn.test.ts
@@ -225,19 +225,31 @@ describe('spawn', () => {
   })
 
   it('sends pty.spawn request through multiplexer', async () => {
-    mux.request.mockResolvedValue({ id: 'pty-1' })
+    mux.request.mockResolvedValue({ id: 'pty-1', relayProcessId: 'relay-process-1' })
 
     const result = await provider.spawn({ cols: 80, rows: 24 })
 
     expectRequest(mux.request, 'pty.spawn', {
+      requestRelayProcessId: true,
       cols: 80,
       rows: 24,
       cwd: undefined,
       env: { [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true' }
     })
-    expect(result).toEqual({ id: scopedPty1 })
+    expect(result).toEqual({ id: scopedPty1, relayProcessId: 'relay-process-1' })
     expect(provider.hasPty(scopedPty1)).toBe(true)
   })
+
+  it.each(['', 'x'.repeat(129), 42])(
+    'rejects a malformed relay process identity %j',
+    async (relayProcessId) => {
+      mux.request.mockResolvedValue({ id: 'pty-1', relayProcessId })
+
+      await expect(provider.spawn({ cols: 80, rows: 24 })).rejects.toThrow(
+        'Invalid SSH relay process identity'
+      )
+    }
+  )
 
   it('keeps a spawned PTY live across an overlapping stale process list', async () => {
     mux.request.mockResolvedValueOnce({ id: 'pty-new' }).mockResolvedValueOnce([])
@@ -278,6 +290,7 @@ describe('spawn', () => {
     })
 
     expectRequest(mux.request, 'pty.spawn', {
+      requestRelayProcessId: true,
       cols: 120,
       rows: 40,
       cwd: '/home/user',
@@ -316,6 +329,7 @@ describe('spawn', () => {
     })
 
     expectRequest(mux.request, 'pty.spawn', {
+      requestRelayProcessId: true,
       cols: 120,
       rows: 40,
       cwd: undefined,
@@ -338,6 +352,7 @@ describe('spawn', () => {
     })
 
     expectRequest(mux.request, 'pty.spawn', {
+      requestRelayProcessId: true,
       cols: 120,
       rows: 40,
       cwd: undefined,
@@ -359,6 +374,7 @@ describe('spawn', () => {
     })
 
     expectRequest(mux.request, 'pty.spawn', {
+      requestRelayProcessId: true,
       cols: 120,
       rows: 40,
       cwd: undefined,
@@ -377,6 +393,7 @@ describe('spawn', () => {
     })
 
     expectRequest(mux.request, 'pty.spawn', {
+      requestRelayProcessId: true,
       cols: 120,
       rows: 40,
       cwd: undefined,
@@ -401,6 +418,7 @@ describe('spawn', () => {
     })
 
     expectRequest(mux.request, 'pty.spawn', {
+      requestRelayProcessId: true,
       cols: 120,
       rows: 40,
       cwd: undefined,
@@ -427,6 +445,7 @@ describe('spawn', () => {
     })
 
     expectRequest(mux.request, 'pty.spawn', {
+      requestRelayProcessId: true,
       cols: 120,
       rows: 40,
       cwd: undefined,
@@ -453,6 +472,7 @@ describe('spawn', () => {
     })
 
     expectRequest(mux.request, 'pty.spawn', {
+      requestRelayProcessId: true,
       cols: 120,
       rows: 40,
       cwd: undefined,
@@ -484,6 +504,7 @@ describe('spawn', () => {
     })
 
     expectRequest(mux.request, 'pty.spawn', {
+      requestRelayProcessId: true,
       cols: 120,
       rows: 40,
       cwd: undefined,
@@ -515,6 +536,7 @@ describe('spawn', () => {
     })
 
     expectRequest(mux.request, 'pty.spawn', {
+      requestRelayProcessId: true,
       cols: 120,
       rows: 40,
       cwd: undefined,
@@ -542,6 +564,7 @@ describe('spawn', () => {
       'pty.attach',
       {
         id: 'pty-old',
+        requestRelayProcessId: true,
         cols: 80,
         rows: 24,
         suppressReplayNotification: true,
@@ -589,6 +612,7 @@ describe('spawn', () => {
 
     expectRequest(mux.request, 'pty.attach', {
       id: 'pty-old',
+      requestRelayProcessId: true,
       cols: 80,
       rows: 24,
       suppressReplayNotification: true,
@@ -614,6 +638,7 @@ describe('spawn', () => {
 
     expectRequest(mux.request, 'pty.attach', {
       id: 'pty-old',
+      requestRelayProcessId: true,
       cols: 80,
       rows: 24,
       suppressReplayNotification: true,
@@ -635,6 +660,7 @@ describe('spawn', () => {
       'pty.attach',
       {
         id: 'pty-old',
+        requestRelayProcessId: true,
         cols: 80,
         rows: 24,
         suppressReplayNotification: true,

--- a/src/main/providers/ssh-pty-relay-absence-verdict.test.ts
+++ b/src/main/providers/ssh-pty-relay-absence-verdict.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  SSH_PTY_IDENTITY_MISMATCH_ERROR,
+  SSH_SESSION_EXPIRED_ERROR,
+  isSshPtyAbsentFromRelayError
+} from './ssh-pty-errors'
+import { SshPtyProvider } from './ssh-pty-provider'
+
+function providerRejectingAttach(error: unknown): SshPtyProvider {
+  return new SshPtyProvider('ssh-1', {
+    request: vi.fn().mockRejectedValue(error),
+    notify: vi.fn(),
+    onNotification: vi.fn().mockReturnValue(vi.fn())
+  } as never)
+}
+
+async function spawnRejection(error: unknown): Promise<unknown> {
+  return await providerRejectingAttach(error)
+    .spawn({ cols: 80, rows: 24, sessionId: 'pty-1' })
+    .then(
+      () => undefined,
+      (rejection: unknown) => rejection
+    )
+}
+
+describe('SSH relay PTY absence evidence', () => {
+  it('preserves a relay-delivered not-found as positive absence', async () => {
+    const rejection = await spawnRejection(new Error('PTY "pty-1" not found'))
+
+    expect(isSshPtyAbsentFromRelayError(rejection)).toBe(true)
+    expect((rejection as Error).message).toBe(`${SSH_SESSION_EXPIRED_ERROR}: pty-1`)
+  })
+
+  it('does not classify a live PTY identity collision as absence', async () => {
+    const rejection = await spawnRejection(new Error('PTY "pty-1" not found (identity mismatch)'))
+
+    expect(isSshPtyAbsentFromRelayError(rejection)).toBe(false)
+    expect((rejection as Error).message).toBe(
+      `${SSH_SESSION_EXPIRED_ERROR}: pty-1 ${SSH_PTY_IDENTITY_MISMATCH_ERROR}`
+    )
+  })
+
+  it.each([
+    ['lost link', 'SSH connection lost, reconnecting...'],
+    ['disposed multiplexer', 'Multiplexer disposed'],
+    ['request timeout', 'Request "pty.attach" timed out after 10000ms']
+  ])('does not classify %s as absence', async (_label, message) => {
+    const rejection = await spawnRejection(new Error(message))
+
+    expect(isSshPtyAbsentFromRelayError(rejection)).toBe(false)
+    expect((rejection as Error).message).toBe(message)
+  })
+})

--- a/src/main/providers/ssh-pty-session-reattach.ts
+++ b/src/main/providers/ssh-pty-session-reattach.ts
@@ -3,6 +3,7 @@ import { isPtyIncarnationId, type PtyIncarnationId } from '../../shared/pty-inca
 import {
   SSH_PTY_IDENTITY_MISMATCH_ERROR,
   SSH_SESSION_EXPIRED_ERROR,
+  SshPtyAbsentFromRelayError,
   isSshPtyIdentityMismatchError,
   isSshPtyNotFoundError
 } from './ssh-pty-errors'
@@ -225,10 +226,12 @@ export async function reattachSshPtySession(args: {
     // Why: an expired relay lease must be surfaced distinctly so the renderer clears its binding.
     console.warn(`[ssh-pty] pty.attach FAILED for ${args.sessionId}:`, error)
     if (isSshPtyNotFoundError(error)) {
-      const mismatchMarker = isSshPtyIdentityMismatchError(error)
-        ? ` ${SSH_PTY_IDENTITY_MISMATCH_ERROR}`
-        : ''
-      throw new Error(`${SSH_SESSION_EXPIRED_ERROR}: ${relaySessionId}${mismatchMarker}`)
+      if (isSshPtyIdentityMismatchError(error)) {
+        throw new Error(
+          `${SSH_SESSION_EXPIRED_ERROR}: ${relaySessionId} ${SSH_PTY_IDENTITY_MISMATCH_ERROR}`
+        )
+      }
+      throw new SshPtyAbsentFromRelayError(`${SSH_SESSION_EXPIRED_ERROR}: ${relaySessionId}`)
     }
     throw error
   }

--- a/src/main/providers/ssh-pty-session-reattach.ts
+++ b/src/main/providers/ssh-pty-session-reattach.ts
@@ -19,10 +19,12 @@ import {
   type PtySourceReceivingActivation
 } from '../../shared/pty-source-receiving-activation'
 import type { SshPtyReceivingActivationLease } from './ssh-pty-notification-routing'
+import { parseSshRelayProcessId } from './ssh-relay-process-id'
 
 export type SshPtyAttachResult = {
   replay?: string
   incarnationId?: PtyIncarnationId
+  relayProcessId?: string
   sourceRecovery?: PtySourceRecoveryResult
   sourceActivation?: PtySourceReceivingActivation
   sourceActivationLease?: SshPtyReceivingActivationLease
@@ -45,6 +47,7 @@ export function parseSshPtyAttachResult(value: unknown): SshPtyAttachResult {
     incarnationId?: unknown
     sourceRecovery?: unknown
     sourceActivation?: unknown
+    relayProcessId?: unknown
   }
   if (result.replay !== undefined && typeof result.replay !== 'string') {
     throw new Error('Invalid SSH PTY attach replay')
@@ -53,6 +56,7 @@ export function parseSshPtyAttachResult(value: unknown): SshPtyAttachResult {
     // Why: a present-but-invalid identity cannot safely fence delayed exits from a reused relay id.
     throw new Error('Invalid SSH PTY attach incarnation')
   }
+  const relayProcessId = parseSshRelayProcessId(result.relayProcessId)
   const sourceRecovery = parseSourceRecoveryResult(result.sourceRecovery)
   const sourceActivation = parsePtySourceReceivingActivation(result.sourceActivation)
   const activation =
@@ -68,6 +72,7 @@ export function parseSshPtyAttachResult(value: unknown): SshPtyAttachResult {
   return {
     ...(typeof result.replay === 'string' ? { replay: result.replay } : {}),
     ...(isPtyIncarnationId(result.incarnationId) ? { incarnationId: result.incarnationId } : {}),
+    ...(relayProcessId ? { relayProcessId } : {}),
     ...(sourceRecovery ? { sourceRecovery } : {}),
     ...(activation ? { sourceActivation: activation } : {})
   }
@@ -202,6 +207,7 @@ export async function reattachSshPtySession(args: {
         // buffer. Without this the relay sees a delivery still open under our unchanged client id,
         // answers "you already have this", and the pane stays blank until new output arrives.
         requireReplay: true,
+        requestRelayProcessId: true,
         ...(expectedPaneKey ? { expectedPaneKey } : {}),
         ...(expectedTabId ? { expectedTabId } : {})
       },
@@ -216,6 +222,7 @@ export async function reattachSshPtySession(args: {
       isReattach: true,
       ...(attachResult.replay ? { replay: attachResult.replay } : {}),
       ...(attachResult.incarnationId ? { incarnationId: attachResult.incarnationId } : {}),
+      ...(attachResult.relayProcessId ? { relayProcessId: attachResult.relayProcessId } : {}),
       ...(attachResult.sourceRecovery ? { sourceRecovery: attachResult.sourceRecovery } : {}),
       ...(attachResult.sourceActivation ? { sourceActivation: attachResult.sourceActivation } : {}),
       ...(attachResult.sourceActivationLease

--- a/src/main/providers/ssh-pty-spawn-request.ts
+++ b/src/main/providers/ssh-pty-spawn-request.ts
@@ -10,6 +10,7 @@ export function buildSshPtySpawnRequest(args: {
 }): Record<string, unknown> {
   const { options } = args
   return {
+    requestRelayProcessId: true,
     cols: options.cols,
     rows: options.rows,
     cwd: options.cwd,

--- a/src/main/providers/ssh-relay-process-id.ts
+++ b/src/main/providers/ssh-relay-process-id.ts
@@ -1,0 +1,9 @@
+export function parseSshRelayProcessId(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  if (typeof value !== 'string' || value.length === 0 || value.length > 128) {
+    throw new Error('Invalid SSH relay process identity')
+  }
+  return value
+}

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1952,17 +1952,21 @@ type RuntimePtyController = {
     preAllocatedHandle: string
     tabId: string
     leafId: string
-  }): Promise<{
-    result: PtySpawnResult
-    owner: {
-      handle?: string
-      tabId: string
-      leafId: string
-      ptyId: string
-      incarnationId?: string
-    }
-    materialized?: true
-  } | null>
+  }): Promise<
+    | {
+        result: PtySpawnResult
+        owner: {
+          handle?: string
+          tabId: string
+          leafId: string
+          ptyId: string
+          incarnationId?: string
+        }
+        materialized?: true
+      }
+    | { result: null; owner: null; absenceVerdict: PtyLivenessVerdict }
+    | null
+  >
   spawn?(opts: {
     cols: number
     rows: number
@@ -2003,12 +2007,14 @@ type RuntimePtyController = {
       }
       materialized?: true
     }
+    stablePaneAbsenceVerdict?: PtyLivenessVerdict
   }): Promise<{
     id: string
     incarnationId?: PtyIncarnationId
     wslDistro?: string
     stablePaneOwner?: { handle: string; tabId: string; leafId: string }
     agentSessionEnsure?: AgentSessionClaimedSpawnResult
+    agentStartupSuppressed?: true
   }>
   write(ptyId: string, data: string): boolean
   writeWithSettlement?(ptyId: string, data: string): Promise<boolean>
@@ -28978,7 +28984,7 @@ export class OrcaRuntimeService {
         if (launchOpts.signal?.aborted) {
           throw new Error('client_disconnected')
         }
-        const adoptedBeforeLaunch = await this.ptyController.adoptStablePane?.({
+        const stablePaneAdoption = await this.ptyController.adoptStablePane?.({
           cols: 120,
           rows: 40,
           cwd,
@@ -28988,9 +28994,14 @@ export class OrcaRuntimeService {
           tabId,
           leafId
         })
-        const launchToken = launchOpts.launchConfig
-          ? (launchOpts.launchToken ?? randomUUID())
-          : undefined
+        const adoptedBeforeLaunch = stablePaneAdoption?.result ? stablePaneAdoption : null
+        const stablePaneAbsenceVerdict =
+          stablePaneAdoption?.result === null ? stablePaneAdoption.absenceVerdict : undefined
+        const earlyAgentStartupSuppressed = stablePaneAbsenceVerdict?.status === 'unverifiable'
+        const launchToken =
+          !earlyAgentStartupSuppressed && launchOpts.launchConfig
+            ? (launchOpts.launchToken ?? randomUUID())
+            : undefined
         const baseEnv = {
           ...launchOpts.env,
           ...(launchToken ? { ORCA_AGENT_LAUNCH_TOKEN: launchToken } : {})
@@ -29007,26 +29018,27 @@ export class OrcaRuntimeService {
         )
         let agentTeamsPlan: Awaited<ReturnType<typeof buildClaudeAgentTeamsLaunchPlan>> | undefined
         try {
-          agentTeamsPlan = adoptedBeforeLaunch
-            ? undefined
-            : await buildClaudeAgentTeamsLaunchPlan({
-                command: claudeAgentTeamsSourceCommand,
-                mode: effectiveClaudeAgentTeamsMode,
-                baseEnv: {
-                  ...process.env,
-                  ...baseEnv
-                },
-                createTeamEnv: (shimDir, shimBin) =>
-                  this.claudeAgentTeams.createLaunchEnv({
-                    leaderHandle: preAllocatedHandle,
-                    baseEnv: {
-                      ...process.env,
-                      ...baseEnv
-                    },
-                    shimDir,
-                    shimBin
-                  }).env
-              })
+          agentTeamsPlan =
+            adoptedBeforeLaunch || earlyAgentStartupSuppressed
+              ? undefined
+              : await buildClaudeAgentTeamsLaunchPlan({
+                  command: claudeAgentTeamsSourceCommand,
+                  mode: effectiveClaudeAgentTeamsMode,
+                  baseEnv: {
+                    ...process.env,
+                    ...baseEnv
+                  },
+                  createTeamEnv: (shimDir, shimBin) =>
+                    this.claudeAgentTeams.createLaunchEnv({
+                      leaderHandle: preAllocatedHandle,
+                      baseEnv: {
+                        ...process.env,
+                        ...baseEnv
+                      },
+                      shimDir,
+                      shimBin
+                    }).env
+                })
         } catch (error) {
           releaseStablePaneCreate?.()
           throw error
@@ -29038,8 +29050,9 @@ export class OrcaRuntimeService {
           claudeAgentTeamsSourceCommand !== launchOpts.command
             ? agentTeamsPlan.command
             : undefined
-        const effectiveLaunchConfig =
-          launchOpts.launchConfig && agentTeamsPlan
+        const effectiveLaunchConfig = earlyAgentStartupSuppressed
+          ? undefined
+          : launchOpts.launchConfig && agentTeamsPlan
             ? {
                 ...launchOpts.launchConfig,
                 agentCommand: launchOpts.launchConfig.agentCommand
@@ -29079,26 +29092,32 @@ export class OrcaRuntimeService {
             cols: 120,
             rows: 40,
             cwd,
-            command: sequencedStartupCommand
-              ? launchOpts.command
-              : (agentTeamsPlan?.command ?? launchOpts.command),
-            launchAgent: launchOpts.launchAgent,
+            command: earlyAgentStartupSuppressed
+              ? undefined
+              : sequencedStartupCommand
+                ? launchOpts.command
+                : (agentTeamsPlan?.command ?? launchOpts.command),
+            launchAgent: earlyAgentStartupSuppressed ? undefined : launchOpts.launchAgent,
             commandDelivery: 'provider',
-            startupCommandDelivery: launchOpts.startupCommandDelivery,
+            startupCommandDelivery: earlyAgentStartupSuppressed
+              ? undefined
+              : launchOpts.startupCommandDelivery,
             env,
             envToDelete: mergeTerminalEnvDeletionKeys(
               launchOpts.envToDelete,
               agentTeamsPlan?.envToDelete
             ),
-            resumeProviderSession: launchOpts.resumeProviderSession,
-            telemetry: launchOpts.telemetry,
+            resumeProviderSession: earlyAgentStartupSuppressed
+              ? undefined
+              : launchOpts.resumeProviderSession,
+            telemetry: earlyAgentStartupSuppressed ? undefined : launchOpts.telemetry,
             connectionId: workspace.connectionId,
             worktreeId: workspace.id,
             preAllocatedHandle,
             tabId,
             leafId,
             ...(terminalColorQueryReplies ? { terminalColorQueryReplies } : {}),
-            ...(launchOpts.agentSessionClaim
+            ...(!earlyAgentStartupSuppressed && launchOpts.agentSessionClaim
               ? {
                   agentSessionEnsure: {
                     claim: launchOpts.agentSessionClaim,
@@ -29111,7 +29130,7 @@ export class OrcaRuntimeService {
                   }
                 }
               : {}),
-            ...(launchOpts.agentSessionCreateOperationId
+            ...(!earlyAgentStartupSuppressed && launchOpts.agentSessionCreateOperationId
               ? { agentSessionCreateOperationId: launchOpts.agentSessionCreateOperationId }
               : {}),
             ...(launchOpts.signal ? { signal: launchOpts.signal } : {}),
@@ -29119,6 +29138,7 @@ export class OrcaRuntimeService {
               ? { onPtySpawnCommitted: reportPtySpawnCommitted }
               : {}),
             ...(adoptedBeforeLaunch ? { adoptedStablePane: adoptedBeforeLaunch } : {}),
+            ...(stablePaneAbsenceVerdict ? { stablePaneAbsenceVerdict } : {}),
             ...(launchOpts.sessionId ? { sessionId: launchOpts.sessionId } : {}),
             ...(!adoptedBeforeLaunch && launchOpts.isNewSession ? { isNewSession: true } : {}),
             // Why: a host-initiated create has no renderer session writer, so
@@ -29132,6 +29152,10 @@ export class OrcaRuntimeService {
         if (!result.stablePaneOwner) {
           reportPtySpawnCommitted()
         }
+        const agentStartupSuppressed = result.agentStartupSuppressed === true
+        const publishedLaunchConfig = agentStartupSuppressed ? undefined : effectiveLaunchConfig
+        const publishedLaunchToken = agentStartupSuppressed ? undefined : launchToken
+        const publishedLaunchAgent = agentStartupSuppressed ? undefined : launchOpts.launchAgent
         const adoptedStablePane = Boolean(result.stablePaneOwner)
         if (result.agentSessionEnsure) {
           const canonicalSurface = result.agentSessionEnsure.owner.surface
@@ -29177,12 +29201,12 @@ export class OrcaRuntimeService {
               pty.title = null
               pty.titleUpdatedAt = null
             }
-            pty.launchConfig = effectiveLaunchConfig
-              ? copySleepingAgentLaunchConfig(effectiveLaunchConfig)
+            pty.launchConfig = publishedLaunchConfig
+              ? copySleepingAgentLaunchConfig(publishedLaunchConfig)
               : null
-            pty.launchToken = launchToken ?? null
-            pty.launchIncarnationId = launchToken ? pty.incarnationId : null
-            pty.launchAgent = launchOpts.launchAgent ?? null
+            pty.launchToken = publishedLaunchToken ?? null
+            pty.launchIncarnationId = publishedLaunchToken ? pty.incarnationId : null
+            pty.launchAgent = publishedLaunchAgent ?? null
           }
           pty.tabId = tabId
           pty.paneKey = paneKey
@@ -29213,9 +29237,9 @@ export class OrcaRuntimeService {
               ptyId: result.id,
               title: launchOpts.title ?? null,
               ...(cwd !== workspace.path ? { cwd } : {}),
-              ...(effectiveLaunchConfig ? { launchConfig: effectiveLaunchConfig } : {}),
-              ...(launchToken ? { launchToken } : {}),
-              ...(launchOpts.launchAgent ? { launchAgent: launchOpts.launchAgent } : {}),
+              ...(publishedLaunchConfig ? { launchConfig: publishedLaunchConfig } : {}),
+              ...(publishedLaunchToken ? { launchToken: publishedLaunchToken } : {}),
+              ...(publishedLaunchAgent ? { launchAgent: publishedLaunchAgent } : {}),
               ...(launchOpts.viewMode ? { viewMode: launchOpts.viewMode } : {}),
               activate: presentation === 'focused',
               ...(presentation ? { presentation } : {}),

--- a/src/relay/pty-handler-spawn-admission.test.ts
+++ b/src/relay/pty-handler-spawn-admission.test.ts
@@ -53,7 +53,8 @@ describe('PtyHandler', () => {
     ;({ dispatcher, handler, originalPlatform } = beginPtyHandlerTest({
       mockPtySpawn,
       mockPtyInstance,
-      mockCreateShellPromptReadinessProbe
+      mockCreateShellPromptReadinessProbe,
+      relayProcessId: 'relay-process-1'
     }))
   })
 
@@ -96,6 +97,16 @@ describe('PtyHandler', () => {
     expect(result).toEqual({ id: 'pty-1', incarnationId: expect.any(String) })
     expect(mockPtySpawn).toHaveBeenCalled()
     expect(handler.activePtyCount).toBe(1)
+  })
+
+  it('returns process identity only when a client requests it', async () => {
+    const legacySpawn = await spawnPty({ cols: 80, rows: 24 })
+    const spawned = await spawnPty({ cols: 80, rows: 24, requestRelayProcessId: true })
+    const attached = await attachPty({ id: spawned.id, requestRelayProcessId: true })
+
+    expect(legacySpawn).not.toHaveProperty('relayProcessId')
+    expect(spawned).toMatchObject({ relayProcessId: 'relay-process-1' })
+    expect(attached).toMatchObject({ relayProcessId: 'relay-process-1' })
   })
 
   it('replays an operation-owned spawn after its first response becomes stale', async () => {

--- a/src/relay/pty-handler-test-harness.ts
+++ b/src/relay/pty-handler-test-harness.ts
@@ -77,6 +77,7 @@ export type PtyHandlerTestMocks = {
   mockPtySpawn: Mock
   mockPtyInstance: MockPtyInstance
   mockCreateShellPromptReadinessProbe: Mock
+  relayProcessId?: string
 }
 
 /** Mirrors the shared beforeEach: pin the platform, reset node-pty mocks, build handler + dispatcher. */
@@ -85,7 +86,8 @@ export function beginPtyHandlerTest(mocks: PtyHandlerTestMocks): {
   handler: PtyHandler
   originalPlatform: PropertyDescriptor | undefined
 } {
-  const { mockPtySpawn, mockPtyInstance, mockCreateShellPromptReadinessProbe } = mocks
+  const { mockPtySpawn, mockPtyInstance, mockCreateShellPromptReadinessProbe, relayProcessId } =
+    mocks
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
   Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
   vi.useFakeTimers()
@@ -108,7 +110,11 @@ export function beginPtyHandlerTest(mocks: PtyHandlerTestMocks): {
   mockPtySpawn.mockReturnValue({ ...mockPtyInstance })
 
   const dispatcher = createMockDispatcher()
-  const handler = new PtyHandler(dispatcher as unknown as RelayDispatcher)
+  const handler = new PtyHandler(
+    dispatcher as unknown as RelayDispatcher,
+    undefined,
+    relayProcessId
+  )
   return { dispatcher, handler, originalPlatform }
 }
 

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -186,6 +186,7 @@ type ManagedPty = {
 type RelayAgentSessionCreateResult = {
   id: string
   incarnationId: string
+  relayProcessId?: string
   replay?: string
   agentSessionEnsure?: unknown
   sourceActivation?: PtySourceReceivingActivation
@@ -453,7 +454,11 @@ export class PtyHandler {
     Promise<RelayAgentSessionCreateResult>
   >()
 
-  constructor(dispatcher: RelayDispatcher, graceTimeMs = DEFAULT_GRACE_TIME_MS) {
+  constructor(
+    dispatcher: RelayDispatcher,
+    graceTimeMs = DEFAULT_GRACE_TIME_MS,
+    private readonly relayProcessId?: string
+  ) {
     this.dispatcher = dispatcher
     this.graceTimeMs = graceTimeMs
     this.registerHandlers()
@@ -1414,7 +1419,11 @@ export class PtyHandler {
       const sourceActivation =
         context && this.sourcePublication?.receivingActivation?.(result.id, context.clientId)
       const { sourceActivation: _staleActivation, ...stableResult } = result
-      return { ...stableResult, ...(sourceActivation ? { sourceActivation } : {}) }
+      return {
+        ...stableResult,
+        ...this.requestedRelayProcess(params),
+        ...(sourceActivation ? { sourceActivation } : {})
+      }
     }
     if (this.agentSessionCreateOperations.size >= AGENT_SESSION_CREATE_OPERATION_LIMIT) {
       throw new Error('agent_session_operation_capacity')
@@ -1528,6 +1537,7 @@ export class PtyHandler {
       return {
         id: managed.id,
         incarnationId: managed.incarnationId,
+        ...this.requestedRelayProcess(params),
         agentSessionEnsure: result,
         ...(sourceActivation ? { sourceActivation } : {}),
         ...(adoptedReplay ? { replay: adoptedReplay } : {})
@@ -1552,6 +1562,7 @@ export class PtyHandler {
   ): Promise<{
     id: string
     incarnationId: string
+    relayProcessId?: string
     sourceActivation?: PtySourceReceivingActivation
   }> {
     const pty = await this.loadPty()
@@ -1756,8 +1767,15 @@ export class PtyHandler {
     return {
       id,
       incarnationId: managed.incarnationId,
+      ...this.requestedRelayProcess(params),
       ...(sourceActivation ? { sourceActivation } : {})
     }
+  }
+
+  private requestedRelayProcess(params: Record<string, unknown>): { relayProcessId?: string } {
+    return params.requestRelayProcessId === true && this.relayProcessId
+      ? { relayProcessId: this.relayProcessId }
+      : {}
   }
 
   private async attach(
@@ -1765,6 +1783,7 @@ export class PtyHandler {
     context?: RequestContext
   ): Promise<{
     incarnationId: string
+    relayProcessId?: string
     replay?: string
     sourceRecovery?: PtySourceRecoveryResult
     sourceActivation?: PtySourceReceivingActivation
@@ -1821,6 +1840,7 @@ export class PtyHandler {
     if (typeof activation === 'object') {
       return {
         incarnationId: managed.incarnationId,
+        ...this.requestedRelayProcess(params),
         sourceRecovery: activation,
         ...(sourceActivation ? { sourceActivation } : {})
       }
@@ -1844,6 +1864,7 @@ export class PtyHandler {
     ) {
       return {
         incarnationId: managed.incarnationId,
+        ...this.requestedRelayProcess(params),
         ...(sourceActivation ? { sourceActivation } : {})
       }
     }
@@ -1859,6 +1880,7 @@ export class PtyHandler {
       if (params.suppressReplayNotification) {
         return {
           incarnationId: managed.incarnationId,
+          ...this.requestedRelayProcess(params),
           replay,
           ...(sourceActivation ? { sourceActivation } : {})
         }
@@ -1867,6 +1889,7 @@ export class PtyHandler {
     }
     return {
       incarnationId: managed.incarnationId,
+      ...this.requestedRelayProcess(params),
       ...(sourceActivation ? { sourceActivation } : {})
     }
   }

--- a/src/relay/relay-daemon.ts
+++ b/src/relay/relay-daemon.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { installRelayLogRotation } from './rotating-log-writer'
 import { readLaunchVersion } from './relay-handshake'
 import type { RelayLaunchOptions } from './relay-launch-options'
@@ -31,10 +32,12 @@ export async function runRelayDaemon(
 
   const primaryChannel = new RelayPrimaryChannel()
   const launchVersion = readLaunchVersion()
+  const relayProcessId = randomUUID()
   const runtime = new RelayRuntimeServices(
     primaryChannel.dispatcher,
     options.graceTimeMs,
-    launchVersion
+    launchVersion,
+    relayProcessId
   )
   let reconnectListener: RelayReconnectListener | null = null
   const agentHooks = new RelayAgentHookRuntime(
@@ -85,7 +88,8 @@ export async function runRelayDaemon(
     socketOwnership,
     lifecycle,
     options,
-    startedAt
+    startedAt,
+    relayProcessId
   )
 
   try {
@@ -123,12 +127,14 @@ function registerRelayStatus(
   socketOwnership: RelaySocketOwnership,
   lifecycle: RelayGraceLifecycle,
   options: RelayLaunchOptions,
-  startedAt: number
+  startedAt: number,
+  relayProcessId: string
 ): void {
   primaryChannel.dispatcher.onRequest('relay.status', async () => ({
     capabilities: SKILL_RELAY_CAPABILITIES,
     pid: process.pid,
     uptimeMs: Date.now() - startedAt,
+    relayProcessId,
     detached: options.detached,
     stdoutAlive: primaryChannel.isAlive,
     memory: process.memoryUsage(),

--- a/src/relay/relay-runtime-services.ts
+++ b/src/relay/relay-runtime-services.ts
@@ -33,11 +33,12 @@ export class RelayRuntimeServices {
   constructor(
     readonly dispatcher: RelayDispatcher,
     graceTimeMs: number,
-    launchVersion: string
+    launchVersion: string,
+    relayProcessId?: string
   ) {
     const context = new RelayContext()
     this.registerSessionHandlers(context)
-    this.ptyHandler = new PtyHandler(dispatcher, graceTimeMs)
+    this.ptyHandler = new PtyHandler(dispatcher, graceTimeMs, relayProcessId)
     this.ptyConsumerSessionAdapter = new SshPtyConsumerSessionAdapter(
       dispatcher,
       launchVersion,

--- a/src/relay/subprocess.test.ts
+++ b/src/relay/subprocess.test.ts
@@ -768,11 +768,13 @@ describe('Subprocess: Relay entry point', () => {
     expect(resp.error).toBeUndefined()
     const status = resp.result as {
       pid: number
+      relayProcessId: string
       memory: { rss: number }
       ptys: { active: number }
       socket: { owned: boolean; listening: boolean; clients: number }
     }
     expect(status.pid).toBeGreaterThan(0)
+    expect(status.relayProcessId).toMatch(/^[0-9a-f-]{36}$/)
     expect(status.memory.rss).toBeGreaterThan(0)
     expect(status.ptys.active).toBe(0)
     expect(status.socket).toMatchObject({ owned: true, listening: true, clients: 0 })

--- a/src/shared/ssh-types.ts
+++ b/src/shared/ssh-types.ts
@@ -211,6 +211,7 @@ export type SshRemotePtyLease = {
   updatedAt: number
   lastAttachedAt?: number
   lastDetachedAt?: number
+  relayProcessId?: string
 }
 
 /** Main-owned relay lease needed to reclaim PTY delivery after a desktop restart. */


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​743 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​735 |
| Prod | 30 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​408 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​132 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​276 |

<!-- /orca-pr-loc -->

## Summary

- treat a reachable SSH relay's "that terminal isn't here" as typed evidence with an authority check, instead of flattening it into a generic session-expired error
- each relay stamps a unique process identity at startup; the client persists it with the SSH PTY lease and accepts positive absence as authoritative (`exited`) only when the answering relay is the exact instance that owned the binding — any other answer (replacement relay, older relay with no identity, malformed or failed status) degrades to `unverifiable`, never `exited`
- on `unverifiable`, retire the unusable binding but start a plain shell with no agent launch authority, launch metadata, claim, or telemetry, and surface the existing resume-unavailable banner

## What this means for users (ELI5)

Orca keeps a small helper process — the relay — running on your SSH host. It owns the terminal processes for your remote workspace, and Orca reconnects to it whenever you come back.

**Before this fix.** You reopen an SSH workspace whose relay was replaced while you were away — an Orca update restarted it, the host rebooted, or host-side cleanup swapped it out. The replacement relay truthfully answers "I don't have that terminal", but it isn't the relay that was holding your terminal, so it cannot actually know what happened to the process. Orca took that answer as proof your agent had exited: it marked the pane as a clean exit and automatically re-ran the original agent launch/resume command in a fresh terminal. If the old process was in fact still alive on the host, you now had a second agent silently resuming into the same session — duplicate work, contested session state, and agent-launch claims and telemetry for a launch you never asked for.

**After this fix.** Orca checks *who* is answering before believing "it's gone". If the same relay that owned your terminal says the terminal is gone, that is authoritative and nothing changes: normal exit handling, resume works as before. If a replacement relay answers, Orca refuses to guess: the pane opens as a plain shell — no automatic agent relaunch, no session claim, no launch telemetry — with the existing "resume unavailable" banner, so you decide what to run next. Nothing is silently resumed on an answer that could not prove anything.

**When you'd hit it:** reconnecting to an SSH workspace after its relay restarted — typically after an Orca upgrade, a host reboot, or host-side cleanup — while a persisted terminal binding for that workspace still exists.

## Root cause

The stable-pane fallback replayed the original `launchAgent` / resume command after a reachable SSH relay answered that the persisted PTY was absent. It did not distinguish the relay instance that owned the binding — and could authoritatively prove process exit — from a younger replacement relay that could never have observed the bound process.

## Remote wire compatibility

The relay mints its process identity at startup and reports it in `relay.status`, and — only when the client asks via a new optional `requestRelayProcessId` request field — in spawn/attach results; the client persists it on the SSH PTY lease as a new optional field. These are additive optional fields on existing RPCs: no new stream opcode, no removed field. An older host simply omits the identity, so the client classifies its positive absence as `unverifiable` and takes the conservative plain-shell path instead of the old replay — a deliberate behavior change, since such a host cannot prove ownership. An older client never requests the identity and keeps its prior behavior.

## Verification

- failing-first proof: before the production fix, all 4 initial relay-age tests failed because `absenceVerdict` was absent
- `pnpm test` across 7 focused/adjacent files: 38 passed
- final focused relay suite: 3 files, 12 passed
- `pnpm tc` and `pnpm tc:node`
- direct code-quality, type-aware, and React Doctor oxlint scans on all changed files
- max-lines ratchet, oxfmt, and `git diff --check`
- same-model adversarial review: CLEAN after fixing IPC and runtime-owned suppression paths
- isolated Electron/CDP identity verified for this worktree; production resume-unavailable banner rendered visibly in a real terminal pane

## Scope note

This focused PR is based directly on `main`. It overlaps the relay-age fallback area in draft PR #16763, but it does not stack on, retarget, close, or modify that PR.

Closes STA-5698.
