### PR TITLE
fix(routing): resolve unstamped local worktrees to the local host (STA-5683)

### DIFF
--- a/src/renderer/src/lib/terminal-worktree-route.test.ts
+++ b/src/renderer/src/lib/terminal-worktree-route.test.ts
@@ -65,6 +65,25 @@ describe('resolveTerminalWorktreeRoute', () => {
     })
   })
 
+  it('routes and tears down an unstamped local worktree despite an unrelated saved runtime', () => {
+    const ownerlessWorktree = { id: 'repo-1::/w', repoId: 'repo-1' }
+    const state = localState({
+      repos: [{ id: 'repo-1' }],
+      worktreesByRepo: { 'repo-1': [ownerlessWorktree] },
+      detectedWorktreesByRepo: { 'repo-1': { worktrees: [ownerlessWorktree] } },
+      runtimeEnvironments: [{ id: 'saved-runtime' }],
+      settings: { activeRuntimeEnvironmentId: null }
+    } as unknown as Partial<AppState>)
+
+    expect(resolveTerminalWorktreeRoute(state, 'repo-1::/w')).toEqual({
+      runtimeEnvironmentId: null
+    })
+    expect(resolveTerminalHostOwnership(state, 'repo-1::/w', 'teardown')).toEqual({
+      kind: 'local-or-ssh',
+      runtimeEnvironmentId: null
+    })
+  })
+
   it('still fails a genuinely unknown/stale worktree closed', () => {
     expect(resolveTerminalWorktreeRoute(localState(), 'repo-9::/stale')).toBeNull()
   })

--- a/src/renderer/src/lib/worktree-operation-route.test.ts
+++ b/src/renderer/src/lib/worktree-operation-route.test.ts
@@ -326,6 +326,23 @@ describe('resolveWorktreeOperationRouteResult', () => {
     })
   })
 
+  it('preserves ownerless local compatibility before detected scan with no saved runtimes', () => {
+    expect(
+      resolveWorktreeOperationRouteResult(
+        {
+          repos: [{ id: 'repo-1' } as never],
+          runtimeEnvironments: [],
+          runtimeEnvironmentCatalogHydrated: true,
+          worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+        },
+        WORKTREE_ID
+      )
+    ).toEqual({
+      kind: 'resolved',
+      route: { executionHostId: 'local', runtimeEnvironmentId: null }
+    })
+  })
+
   it('fails an unknown stale worktree closed instead of routing it through focus', () => {
     expect(
       resolveWorktreeOperationRouteResult(

--- a/src/renderer/src/lib/worktree-operation-route.test.ts
+++ b/src/renderer/src/lib/worktree-operation-route.test.ts
@@ -155,17 +155,126 @@ describe('resolveWorktreeOperationRouteResult', () => {
     expect(resolveWorktreeOperationRouteResult({}, WORKTREE_ID)).toEqual({ kind: 'missing' })
   })
 
-  it('fails a paired-client ownerless stale publication closed instead of routing it locally', () => {
+  it('routes the reported unstamped local shape with one saved runtime', () => {
     expect(
       resolveWorktreeOperationRouteResult(
         {
           repos: [{ id: 'repo-1' } as never],
-          runtimeEnvironments: [{ id: 'disconnected-hub' }],
+          runtimeEnvironments: [{ id: 'saved-runtime' }],
+          runtimeEnvironmentCatalogHydrated: true,
+          settings: { activeRuntimeEnvironmentId: null } as never,
+          worktreesByRepo: { 'repo-1': [worktree(undefined)] },
+          detectedWorktreesByRepo: {
+            'repo-1': { worktrees: [worktree(undefined)] }
+          }
+        },
+        WORKTREE_ID
+      )
+    ).toEqual({
+      kind: 'resolved',
+      route: { executionHostId: 'local', runtimeEnvironmentId: null }
+    })
+  })
+
+  it('ignores the number of unrelated saved runtimes for unstamped local identity', () => {
+    expect(
+      resolveWorktreeOperationRouteResult(
+        {
+          repos: [{ id: 'repo-1' } as never],
+          runtimeEnvironments: [{ id: 'runtime-a' }, { id: 'runtime-b' }, { id: 'runtime-c' }],
+          runtimeEnvironmentCatalogHydrated: true,
+          settings: { activeRuntimeEnvironmentId: null } as never,
           worktreesByRepo: { 'repo-1': [worktree(undefined)] }
         },
         WORKTREE_ID
       )
-    ).toEqual({ kind: 'missing' })
+    ).toEqual({
+      kind: 'resolved',
+      route: { executionHostId: 'local', runtimeEnvironmentId: null }
+    })
+  })
+
+  it('treats a known repo without a worktree row as positive local identity', () => {
+    expect(
+      resolveWorktreeOperationRouteResult(
+        {
+          repos: [{ id: 'repo-1' } as never],
+          runtimeEnvironments: [{ id: 'saved-runtime' }],
+          runtimeEnvironmentCatalogHydrated: true
+        },
+        WORKTREE_ID
+      )
+    ).toEqual({
+      kind: 'resolved',
+      route: { executionHostId: 'local', runtimeEnvironmentId: null }
+    })
+  })
+
+  it('treats a known worktree without a repo row as positive local identity', () => {
+    expect(
+      resolveWorktreeOperationRouteResult(
+        {
+          worktreesByRepo: { 'repo-1': [worktree(undefined)] },
+          runtimeEnvironments: [{ id: 'saved-runtime' }],
+          runtimeEnvironmentCatalogHydrated: true
+        },
+        WORKTREE_ID
+      )
+    ).toEqual({
+      kind: 'resolved',
+      route: { executionHostId: 'local', runtimeEnvironmentId: null }
+    })
+  })
+
+  it('keeps an unstamped row ambiguous when another owner names a different host', () => {
+    expect(
+      resolveWorktreeOperationRouteResult(
+        {
+          repos: [{ id: 'repo-1' } as never],
+          runtimeEnvironments: [{ id: 'saved-runtime' }],
+          runtimeEnvironmentCatalogHydrated: true,
+          worktreesByRepo: {
+            'repo-1': [worktree('local'), worktree('runtime:hub-a')]
+          }
+        },
+        WORKTREE_ID
+      )
+    ).toEqual({ kind: 'ambiguous' })
+  })
+
+  it('routes a focused runtime only when it is the single saved runtime', () => {
+    expect(
+      resolveWorktreeOperationRouteResult(
+        {
+          settings: { activeRuntimeEnvironmentId: 'hub-a' } as never,
+          runtimeEnvironments: [{ id: 'hub-a' }],
+          runtimeEnvironmentCatalogHydrated: true,
+          worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+        },
+        WORKTREE_ID
+      )
+    ).toEqual({
+      kind: 'resolved',
+      route: { executionHostId: 'runtime:hub-a', runtimeEnvironmentId: 'hub-a' }
+    })
+  })
+
+  it('ignores unrelated removed-runtime tombstones for positive local identity', () => {
+    expect(
+      resolveWorktreeOperationRouteResult(
+        {
+          repos: [{ id: 'repo-1' } as never],
+          runtimeEnvironments: [{ id: 'saved-runtime' }],
+          runtimeEnvironmentCatalogHydrated: true,
+          removedRuntimeEnvironmentIds: new Set(['removed-runtime']),
+          worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+        },
+        WORKTREE_ID
+      )
+    ).toEqual({
+      kind: 'resolved',
+      route: { executionHostId: 'local', runtimeEnvironmentId: null }
+    })
   })
 
   it('fails ownerless rows closed until the saved-runtime catalog is hydrated', () => {

--- a/src/renderer/src/lib/worktree-operation-route.test.ts
+++ b/src/renderer/src/lib/worktree-operation-route.test.ts
@@ -184,7 +184,10 @@ describe('resolveWorktreeOperationRouteResult', () => {
           runtimeEnvironments: [{ id: 'runtime-a' }, { id: 'runtime-b' }, { id: 'runtime-c' }],
           runtimeEnvironmentCatalogHydrated: true,
           settings: { activeRuntimeEnvironmentId: null } as never,
-          worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          worktreesByRepo: { 'repo-1': [worktree(undefined)] },
+          detectedWorktreesByRepo: {
+            'repo-1': { worktrees: [worktree(undefined)] }
+          }
         },
         WORKTREE_ID
       )
@@ -194,7 +197,7 @@ describe('resolveWorktreeOperationRouteResult', () => {
     })
   })
 
-  it('treats a known repo without a worktree row as positive local identity', () => {
+  it('does not treat a repo row alone as positive local identity', () => {
     expect(
       resolveWorktreeOperationRouteResult(
         {
@@ -204,13 +207,10 @@ describe('resolveWorktreeOperationRouteResult', () => {
         },
         WORKTREE_ID
       )
-    ).toEqual({
-      kind: 'resolved',
-      route: { executionHostId: 'local', runtimeEnvironmentId: null }
-    })
+    ).toEqual({ kind: 'missing' })
   })
 
-  it('treats a known worktree without a repo row as positive local identity', () => {
+  it('fails a paired-client ownerless stale publication closed instead of routing it locally', () => {
     expect(
       resolveWorktreeOperationRouteResult(
         {
@@ -220,10 +220,7 @@ describe('resolveWorktreeOperationRouteResult', () => {
         },
         WORKTREE_ID
       )
-    ).toEqual({
-      kind: 'resolved',
-      route: { executionHostId: 'local', runtimeEnvironmentId: null }
-    })
+    ).toEqual({ kind: 'missing' })
   })
 
   it('keeps an unstamped row ambiguous when another owner names a different host', () => {
@@ -267,7 +264,10 @@ describe('resolveWorktreeOperationRouteResult', () => {
           runtimeEnvironments: [{ id: 'saved-runtime' }],
           runtimeEnvironmentCatalogHydrated: true,
           removedRuntimeEnvironmentIds: new Set(['removed-runtime']),
-          worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          worktreesByRepo: { 'repo-1': [worktree(undefined)] },
+          detectedWorktreesByRepo: {
+            'repo-1': { worktrees: [worktree(undefined)] }
+          }
         },
         WORKTREE_ID
       )
@@ -313,7 +313,10 @@ describe('resolveWorktreeOperationRouteResult', () => {
           repos: [{ id: 'repo-1' } as never],
           runtimeEnvironments: [],
           runtimeEnvironmentCatalogHydrated: true,
-          worktreesByRepo: { 'repo-1': [worktree(undefined)] }
+          worktreesByRepo: { 'repo-1': [worktree(undefined)] },
+          detectedWorktreesByRepo: {
+            'repo-1': { worktrees: [worktree(undefined)] }
+          }
         },
         WORKTREE_ID
       )

--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -220,10 +220,11 @@ export function resolveWorktreeOperationRouteResult(
       }
     }
   }
-  // Why: with a runtime catalog, only a current local scan affirms local identity for an ownerless row.
+  // Why: no saved runtime can publish a remote ownerless row; otherwise current detected presence affirms identity under the stamped-writer invariant.
   const mayBeLegacyLocal =
     savedRuntimeIds === undefined ||
-    (state.runtimeEnvironmentCatalogHydrated === true && hasDetectedWorktree)
+    (state.runtimeEnvironmentCatalogHydrated === true &&
+      (savedRuntimeIds.length === 0 || hasDetectedWorktree))
   return mayBeLegacyLocal
     ? { kind: 'resolved', route: { executionHostId: 'local', runtimeEnvironmentId: null } }
     : { kind: 'missing' }

--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -192,9 +192,10 @@ export function resolveWorktreeOperationRouteResult(
     return explicitResolution
   }
 
+  const hasDetectedWorktree = hasIndexedDetectedWorktree(state.detectedWorktreesByRepo, worktreeId)
   const hasKnownWorktree =
     resolveIndexedWorktreeOwner(state.worktreesByRepo, worktreeId).kind !== 'missing' ||
-    hasIndexedDetectedWorktree(state.detectedWorktreesByRepo, worktreeId)
+    hasDetectedWorktree
   const repoId = getRepoIdFromWorktreeId(worktreeId)
   const hasKnownRepo = state.repos?.some((repo) => repo.id === repoId) === true
   if (!hasKnownWorktree && !hasKnownRepo) {
@@ -219,9 +220,10 @@ export function resolveWorktreeOperationRouteResult(
       }
     }
   }
-  // Why: global saved-runtime entries and tombstones cannot own a known identity without row provenance.
+  // Why: with a runtime catalog, only a current local scan affirms local identity for an ownerless row.
   const mayBeLegacyLocal =
-    savedRuntimeIds === undefined || state.runtimeEnvironmentCatalogHydrated === true
+    savedRuntimeIds === undefined ||
+    (state.runtimeEnvironmentCatalogHydrated === true && hasDetectedWorktree)
   return mayBeLegacyLocal
     ? { kind: 'resolved', route: { executionHostId: 'local', runtimeEnvironmentId: null } }
     : { kind: 'missing' }

--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -219,10 +219,9 @@ export function resolveWorktreeOperationRouteResult(
       }
     }
   }
+  // Why: global saved-runtime entries and tombstones cannot own a known identity without row provenance.
   const mayBeLegacyLocal =
-    (savedRuntimeIds === undefined ||
-      (state.runtimeEnvironmentCatalogHydrated === true && savedRuntimeIds.length === 0)) &&
-    (state.removedRuntimeEnvironmentIds?.size ?? 0) === 0
+    savedRuntimeIds === undefined || state.runtimeEnvironmentCatalogHydrated === true
   return mayBeLegacyLocal
     ? { kind: 'resolved', route: { executionHostId: 'local', runtimeEnvironmentId: null } }
     : { kind: 'missing' }

--- a/src/renderer/src/store/slices/worktrees-fetch-owner-routing.test.ts
+++ b/src/renderer/src/store/slices/worktrees-fetch-owner-routing.test.ts
@@ -45,7 +45,7 @@ describe('fetchWorktrees', () => {
     clearHugeRepoWarningDismissalsForTests()
   })
 
-  it('fetches worktrees from the active remote runtime environment', async () => {
+  it('stamps ownerless worktrees from an older active remote runtime before repos hydrate', async () => {
     const store = createTestStore()
     const remote = makeWorktree({
       id: 'repo1::/remote/wt1',
@@ -63,7 +63,15 @@ describe('fetchWorktrees', () => {
 
     await store.getState().fetchWorktrees('repo1')
 
-    expect(store.getState().worktreesByRepo.repo1).toEqual([remote])
+    const expected = {
+      ...remote,
+      hostId: 'runtime:env-1',
+      runtimeOwnerEnvironmentId: 'env-1'
+    }
+    expect(store.getState().worktreesByRepo.repo1).toEqual([expected])
+    expect(store.getState().detectedWorktreesByRepo.repo1?.worktrees).toEqual([
+      expect.objectContaining(expected)
+    ])
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'worktree.detectedList',
@@ -581,12 +589,26 @@ describe('fetchWorktrees', () => {
 
     await store.getState().fetchWorktrees('repo1')
 
-    expect(store.getState().worktreesByRepo.repo1).toEqual([remote])
+    expect(store.getState().worktreesByRepo.repo1).toEqual([
+      {
+        ...remote,
+        hostId: 'runtime:env-1',
+        runtimeOwnerEnvironmentId: 'env-1'
+      }
+    ])
     expect(store.getState().detectedWorktreesByRepo.repo1).toMatchObject({
       repoId: 'repo1',
       authoritative: true,
       source: 'session-fallback',
-      worktrees: [{ id: remote.id, ownership: 'orca-managed', visible: true }]
+      worktrees: [
+        {
+          id: remote.id,
+          ownership: 'orca-managed',
+          visible: true,
+          hostId: 'runtime:env-1',
+          runtimeOwnerEnvironmentId: 'env-1'
+        }
+      ]
     })
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',

--- a/src/renderer/src/store/slices/worktrees-fetch-remote-lineage.test.ts
+++ b/src/renderer/src/store/slices/worktrees-fetch-remote-lineage.test.ts
@@ -44,7 +44,9 @@ describe('fetchWorktrees', () => {
       id: 'repo1::/remote/wt1',
       repoId: 'repo1',
       path: '/remote/wt1',
-      branch: 'refs/heads/remote'
+      branch: 'refs/heads/remote',
+      hostId: 'runtime:env-1',
+      runtimeOwnerEnvironmentId: 'env-1'
     })
     const lineage = makeLineage({ worktreeId: initial.id })
     const refreshed = { ...initial, lineage }
@@ -100,7 +102,9 @@ describe('fetchWorktrees', () => {
       id: 'repo1::/remote/wt1',
       repoId: 'repo1',
       path: '/remote/wt1',
-      branch: 'refs/heads/remote'
+      branch: 'refs/heads/remote',
+      hostId: 'runtime:env-1',
+      runtimeOwnerEnvironmentId: 'env-1'
     })
     const staleLineage = makeLineage({
       worktreeId: worktree.id,
@@ -292,7 +296,13 @@ describe('fetchWorktrees', () => {
 
     await store.getState().fetchWorktrees('repo1')
 
-    expect(store.getState().worktreesByRepo.repo1).toEqual([refreshed])
+    expect(store.getState().worktreesByRepo.repo1).toEqual([
+      {
+        ...refreshed,
+        hostId: 'runtime:env-1',
+        runtimeOwnerEnvironmentId: 'env-1'
+      }
+    ])
     expect(store.getState().worktreeLineageById).toEqual({
       [staleLineage.worktreeId]: staleLineage
     })

--- a/src/renderer/src/store/slices/worktrees-lineage-state.test.ts
+++ b/src/renderer/src/store/slices/worktrees-lineage-state.test.ts
@@ -453,7 +453,11 @@ describe('worktree lineage state', () => {
     })
     expect(mockApi.worktrees.updateLineage).not.toHaveBeenCalled()
     expect(store.getState().worktreeLineageById).toEqual({ [lineage.worktreeId]: lineage })
-    expect(store.getState().worktreesByRepo.repo1?.[0]).toEqual(updatedChild)
+    expect(store.getState().worktreesByRepo.repo1?.[0]).toEqual({
+      ...updatedChild,
+      hostId: 'runtime:env-1',
+      runtimeOwnerEnvironmentId: 'env-1'
+    })
     expect(store.getState().sortEpoch).toBe(4)
   })
 
@@ -537,7 +541,11 @@ describe('worktree lineage state', () => {
     })
     expect(mockApi.worktrees.updateLineage).not.toHaveBeenCalled()
     expect(store.getState().worktreeLineageById).toEqual({ [lineage.worktreeId]: lineage })
-    expect(store.getState().worktreesByRepo.repo1?.[0]).toEqual(updatedChild)
+    expect(store.getState().worktreesByRepo.repo1?.[0]).toEqual({
+      ...updatedChild,
+      hostId: 'runtime:env-1',
+      runtimeOwnerEnvironmentId: 'env-1'
+    })
     expect(store.getState().sortEpoch).toBe(4)
 
     runtimeEnvironmentCall
@@ -701,7 +709,11 @@ describe('worktree lineage state', () => {
       timeoutMs: 15_000
     })
     expect(store.getState().worktreeLineageById).toEqual({})
-    expect(store.getState().worktreesByRepo.repo1?.[0]).toEqual(updatedChild)
+    expect(store.getState().worktreesByRepo.repo1?.[0]).toEqual({
+      ...updatedChild,
+      hostId: 'runtime:env-1',
+      runtimeOwnerEnvironmentId: 'env-1'
+    })
   })
 
   // An unresolvable owner route must reach the caller so the sidebar can toast it, rather than

--- a/src/renderer/src/store/slices/worktrees-remote-runtime-create.test.ts
+++ b/src/renderer/src/store/slices/worktrees-remote-runtime-create.test.ts
@@ -90,7 +90,13 @@ describe('worktree remote runtime mutations', () => {
       timeoutMs: 10 * 60_000
     })
     expect(mockApi.worktrees.create).not.toHaveBeenCalled()
-    expect(store.getState().worktreesByRepo.repo1).toEqual([wt])
+    expect(store.getState().worktreesByRepo.repo1).toEqual([
+      {
+        ...wt,
+        hostId: 'runtime:env-1',
+        runtimeOwnerEnvironmentId: 'env-1'
+      }
+    ])
   })
 
   it('forwards generated-name provenance through paired-runtime create', async () => {

--- a/src/renderer/src/store/slices/worktrees/listing/worktree-host-ownership.ts
+++ b/src/renderer/src/store/slices/worktrees/listing/worktree-host-ownership.ts
@@ -6,6 +6,7 @@ import { reuseEqualCatalogRows } from '../../worktree-catalog-reconciliation'
 import { getRepoIdFromWorktreeId } from '../../worktree-helpers'
 import {
   getRepoExecutionHostId,
+  getSettingsFocusedExecutionHostId,
   LOCAL_EXECUTION_HOST_ID,
   parseExecutionHostId,
   toSshExecutionHostId,
@@ -60,7 +61,9 @@ export function repoHostId(
   if (repo) {
     return getRepoExecutionHostId(repo)
   }
-  return hostId && parseExecutionHostId(hostId) ? hostId : LOCAL_EXECUTION_HOST_ID
+  return hostId && parseExecutionHostId(hostId)
+    ? hostId
+    : getSettingsFocusedExecutionHostId(state.settings)
 }
 
 export function repoHasExactlyOneExecutionHostOwner(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​211 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​198 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5

### What this looked like before

You had a perfectly normal local worktree that worked fine. Then you saved a remote server in **Settings → Remote Orca Servers** — maybe to try it once, maybe for a different project entirely. You didn't select it. You didn't use it.

That workspace stopped working. Specifically:

- Clicking **`+` → New Terminal** did nothing at all. No terminal, no error, no toast — the click just went nowhere.
- The **File Explorer** showed `Could not load files for this workspace: Couldn't determine which host owns this workspace.`
- **Resuming an agent session** from Agent Session History or the AI Vault failed with *"Terminal creation is unavailable because the worktree owner could not be resolved."*
- The workspace otherwise looked completely normal in the sidebar, so there was no hint about what was wrong.

And the obvious fix didn't work. **Deleting the saved server did not bring the workspace back** — Orca remembered that a server had once existed, and that memory kept the workspace shut. Restarting didn't help either. In practice the only way out was to never save a remote server at all, which means giving up remote runtimes entirely.

On one real setup this hit **181 of 569 worktrees** the moment a single server was saved.

### What this looks like after

- `+` → **New Terminal** opens a terminal, like it always should have.
- File Explorer lists your files.
- Agent sessions resume.
- Saving, using, and deleting remote servers has **no effect** on your local worktrees — they're unrelated, and now Orca treats them that way.
- If you delete a server, nothing stays broken behind you.

You no longer have to choose between using remote servers and using your local worktrees.

### What was actually going wrong

Every workspace lives on some machine — your laptop, an SSH box, or a remote server. Before opening a terminal, Orca has to answer: **which machine does this belong to?** If it can't answer, it refuses, because guessing could run your commands on the wrong computer. That refusal is the right instinct; it was just firing on the wrong input.

Older workspace records don't have the machine written on them. To decide whether a blank record meant "your laptop", Orca looked at something unrelated: **how many remote servers you had saved**. None saved meant "must be local, go ahead". One or more meant "I can't tell" — even though that server had nothing to do with the folder in question. The count of servers in your Settings says nothing about where one particular folder lives, and that was the bug.

While fixing it we found the blank records weren't only old leftovers — **Orca was still creating them.** When it asked a remote server for its list of worktrees, it addressed the request to the remote server but filed the answers as if they'd come from your laptop, leaving the machine blank. So genuinely-remote workspaces were being recorded with no owner. A naive fix would have then confidently called those "local", which is the dangerous direction — that's how a delete lands on the wrong machine.

### What changed

1. **Records get labelled correctly when they arrive.** If Orca asks a remote server for worktrees, it now writes that server down as the owner instead of leaving it blank.
2. **Saying "local" now requires real evidence** — the workspace actually turning up in a scan of your machine — rather than being assumed because nothing said otherwise. And the number of servers you've saved is no longer treated as evidence of anything.

The safety behaviour people rely on is unchanged: a workspace on an SSH box still routes to that box, a workspace on a remote runtime still routes to that runtime, a workspace that genuinely could be on two machines still refuses rather than guessing, and an unknown workspace still fails closed.

## Summary

- Stamp ownerless worktree results from a remote runtime with the captured execution host before repo hydration, including modern detected-list, legacy `worktree.list`, remote create, and lineage responses.
- Tighten legacy ownerless routing so saved-runtime configurations require current detected presence while preserving the hydrated empty-catalog local fallback during the create-before-scan window.
- Keep explicit SSH/runtime ownership, duplicate-host ambiguity, unknown identities, and ownerless stale remote publications fail-closed.

## Reachability and root cause

YES: the fully ownerless remote shape was reachable before this fix. When an active runtime worktree refresh ran before its repo row hydrated, the RPC used the focused runtime settings, but `repoHostId` fell back to `local`; `withRepoHostOwnership` intentionally does not stamp a local host, so an older remote host that omitted ownership fields placed fully ownerless remote rows in both `worktreesByRepo` and `detectedWorktreesByRepo`. The same gap covered the legacy `worktree.list` fallback.

Persistence does not directly seed either worktree map: they initialize empty, and persisted session rehydration only synthesizes runtime placeholders with explicit repo/worktree host IDs or SSH placeholders beneath repos with a `connectionId`. Runtime repo RPC rows are client-stamped, and push-style worktree notifications trigger a host-qualified refresh instead of carrying raw rows.

The ingest fix makes `repoHostId` fall back to the focused execution host, matching the host that receives the RPC and stamping remote results with `hostId` and `runtimeOwnerEnvironmentId` before indexing. The resolver fix then permits an ownerless row only when the runtime catalog is unavailable, when the catalog is hydrated and empty, or when the row has current detected presence.

## Detected catalog safety invariant

`detectedWorktreesByRepo` is host-aggregated, not local-only. Both visible and detected-only refreshes call `mergeDetectedWorktreesForHost` for whichever local, runtime, or SSH host was fetched.

The safety property is the conjunction of ownerless identity and current detected presence, under the writer invariant that every remote origin stamps ownership before indexing, with explicit owner routing evaluated first. A detected row is therefore not local evidence by itself: stamped remote rows resolve through their explicit owner and never reach the legacy local fallback. With a hydrated empty saved-runtime catalog, no runtime can originate a remote ownerless row, and SSH ingest is always explicitly host-qualified; preserving the empty-catalog fallback restores the pre-PR local behavior without reopening the reachable remote path.

## Tests and safety guards

- Added modern and old-host ingestion regressions proving pre-repo remote results are stamped in both worktree maps.
- Restored the paired-client ownerless stale-publication fail-closed regression.
- Added and mutation-tested the zero-saved-runtime create-before-detected-scan regression.
- Kept one-runtime and several-runtime unstamped-local reproductions green with current detected evidence, including the removed-runtime tombstone case.
- Updated remote create, refresh, and lineage tests to require client-side runtime ownership projection.
- Existing unknown-id, unhydrated-catalog, focused-runtime, explicit-owner, SSH, folder-workspace, generation-fence, terminal-route, and ambiguity guards remain green.

