### PR TITLE
fix(ssh): stop the absence fallback resuming an agent a replaced relay never held (STA-5698)

### DIFF
--- a/src/main/ipc/pty/ipc/spawn-execute.ts
+++ b/src/main/ipc/pty/ipc/spawn-execute.ts
@@ -3,6 +3,7 @@ import {
   SSH_SESSION_EXPIRED_ERROR,
   isSshPtyIdentityMismatchError
 } from '../../../providers/ssh-pty-errors'
+import { markSshExpiryFromReplacedRelay } from '../../../providers/ssh-relay-replacement-verdict'
 import { classifyError } from '../../../telemetry/classify-error'
 import { track } from '../../../telemetry/client'
 import { getCohortAtEmit } from '../../../telemetry/cohort-classifier'
@@ -158,6 +159,18 @@ export async function executePtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<void> {
       }
     }
     if (args.connectionId && ctx.effectiveSessionRelayId !== undefined && isExpiredSshSession) {
+      if (!isIdentityMismatch) {
+        // Why before the lease is expired: the fallback spawn that follows re-runs this request's
+        // launchAgent/command/resumeProviderSession, and only the lease still records when we last
+        // proved the PTY existed (STA-5698).
+        await markSshExpiryFromReplacedRelay({
+          error: spawnError,
+          provider: ctx.provider,
+          store: ctx.deps.store,
+          connectionId: args.connectionId,
+          relayPtyId: ctx.effectiveSessionRelayId
+        })
+      }
       // Why: expired remote reattach = relay already dropped the PTY; clear the lease so writes can't restore the stale binding.
       if (ctx.effectiveSessionAppId !== undefined && !isIdentityMismatch) {
         clearProviderPtyState(ctx.effectiveSessionAppId)

--- a/src/main/ipc/pty/runtime/spawn-execute.ts
+++ b/src/main/ipc/pty/runtime/spawn-execute.ts
@@ -15,6 +15,7 @@ import {
   SSH_SESSION_EXPIRED_ERROR,
   isSshPtyIdentityMismatchError
 } from '../../../providers/ssh-pty-errors'
+import { markSshExpiryFromReplacedRelay } from '../../../providers/ssh-relay-replacement-verdict'
 import type { RuntimePtySpawnState } from './spawn-state'
 
 export async function executeRuntimePtySpawn(ctx: RuntimePtySpawnState): Promise<void> {
@@ -238,6 +239,18 @@ export async function executeRuntimePtySpawn(ctx: RuntimePtySpawnState): Promise
       }
     }
     if (args.connectionId && ctx.effectiveSessionRelayId !== undefined && isExpiredSshSession) {
+      if (!isIdentityMismatch) {
+        // Why before the lease is expired: the fallback spawn that follows re-runs this request's
+        // launchAgent/command/resumeProviderSession, and only the lease still records when we last
+        // proved the PTY existed (STA-5698).
+        await markSshExpiryFromReplacedRelay({
+          error: spawnError,
+          provider: ctx.provider,
+          store: ctx.deps.store,
+          connectionId: args.connectionId,
+          relayPtyId: ctx.effectiveSessionRelayId
+        })
+      }
       if (ctx.effectiveSessionAppId !== undefined && !isIdentityMismatch) {
         clearProviderPtyState(ctx.effectiveSessionAppId)
         deletePtyOwnership(ctx.effectiveSessionAppId)

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
@@ -139,6 +139,19 @@ export async function markSshRemotePtyLeasesAttachedAsync(
   }
 }
 
+export function getSshRemotePtyLease(
+  operations: Pick<SshPtyLeaseOperations, 'state' | 'toStoredPtyId'>,
+  targetId: string,
+  ptyId: string
+): SshRemotePtyLease | null {
+  const relayPtyId = operations.toStoredPtyId(targetId, ptyId)
+  return (
+    operations.state.sshRemotePtyLeases?.find(
+      (entry) => entry.targetId === targetId && entry.ptyId === relayPtyId
+    ) ?? null
+  )
+}
+
 export function markSshRemotePtyLease(
   operations: SshPtyLeaseOperations,
   targetId: string,

--- a/src/main/persistence/loading-store/ssh-lease-recovery-operations.ts
+++ b/src/main/persistence/loading-store/ssh-lease-recovery-operations.ts
@@ -1,5 +1,6 @@
 import type { SshPtyConsumerRecovery, SshRemotePtyLease } from '../../../shared/ssh-types'
 import {
+  getSshRemotePtyLease as getSshRemotePtyLeaseOperation,
   getSshRemotePtyLeases as getSshRemotePtyLeasesOperation,
   markSshRemotePtyLease as markSshRemotePtyLeaseOperation,
   markSshRemotePtyLeases as markSshRemotePtyLeasesOperation,
@@ -74,6 +75,10 @@ export class SshLeaseRecoveryOperations {
       this[sshLeaseRecoveryOperationsContext].runtime.state,
       targetId
     )
+  }
+
+  getSshRemotePtyLease(targetId: string, ptyId: string): SshRemotePtyLease | null {
+    return getSshRemotePtyLeaseOperation(getSshPtyLeaseOperations(this), targetId, ptyId)
   }
 
   upsertSshRemotePtyLease(

--- a/src/main/providers/ssh-pty-errors.ts
+++ b/src/main/providers/ssh-pty-errors.ts
@@ -10,3 +10,12 @@ export function isSshPtyIdentityMismatchError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error)
   return message.includes(SSH_PTY_IDENTITY_MISMATCH_ERROR) || /identity mismatch/i.test(message)
 }
+
+/** Appended to `SSH_SESSION_EXPIRED` when the relay that reported the PTY absent demonstrably
+ *  started after the client last attached it, so the shell it named belonged to a dead daemon. */
+export const SSH_RELAY_REPLACED_ERROR = 'SSH_RELAY_REPLACED'
+
+export function isSshRelayReplacedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes(SSH_RELAY_REPLACED_ERROR)
+}

--- a/src/main/providers/ssh-relay-replacement-verdict.test.ts
+++ b/src/main/providers/ssh-relay-replacement-verdict.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { IPtyProvider } from './types'
+import type { SshRemotePtyLease } from '../../shared/ssh-types'
+import { SSH_RELAY_REPLACED_ERROR, SSH_SESSION_EXPIRED_ERROR } from './ssh-pty-errors'
+import { markSshExpiryFromReplacedRelay } from './ssh-relay-replacement-verdict'
+
+const BOUND_AT = 1_000_000
+const CONNECTION_ID = 'target-a'
+const RELAY_PTY_ID = 'pty-7'
+
+function lease(overrides: Partial<SshRemotePtyLease> = {}): SshRemotePtyLease {
+  return {
+    targetId: CONNECTION_ID,
+    ptyId: RELAY_PTY_ID,
+    state: 'attached',
+    createdAt: BOUND_AT,
+    updatedAt: BOUND_AT,
+    lastAttachedAt: BOUND_AT,
+    ...overrides
+  }
+}
+
+async function mark(args: {
+  lease: SshRemotePtyLease | null
+  requestHostRpc?: IPtyProvider['requestHostRpc']
+}): Promise<string> {
+  const error = new Error(`${SSH_SESSION_EXPIRED_ERROR}: ${RELAY_PTY_ID}`)
+  await markSshExpiryFromReplacedRelay({
+    error,
+    provider: { requestHostRpc: args.requestHostRpc },
+    store: { getSshRemotePtyLease: () => args.lease },
+    connectionId: CONNECTION_ID,
+    relayPtyId: RELAY_PTY_ID
+  })
+  return error.message
+}
+
+describe('markSshExpiryFromReplacedRelay', () => {
+  it('marks the expiry when the answering relay started after the last attach', async () => {
+    // now() - uptimeMs lands after BOUND_AT: this daemon cannot have held the PTY.
+    vi.spyOn(Date, 'now').mockReturnValue(BOUND_AT + 60_000)
+    const requestHostRpc = vi.fn().mockResolvedValue({ pid: 42, uptimeMs: 30_000 })
+
+    const message = await mark({ lease: lease(), requestHostRpc })
+
+    expect(message).toBe(
+      `${SSH_SESSION_EXPIRED_ERROR}: ${RELAY_PTY_ID} ${SSH_RELAY_REPLACED_ERROR}`
+    )
+    expect(requestHostRpc).toHaveBeenCalledWith('relay.status', {}, expect.objectContaining({}))
+    vi.restoreAllMocks()
+  })
+
+  it('leaves the expiry alone when the relay predates the last attach', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(BOUND_AT + 60_000)
+    const requestHostRpc = vi.fn().mockResolvedValue({ pid: 42, uptimeMs: 120_000 })
+
+    expect(await mark({ lease: lease(), requestHostRpc })).toBe(
+      `${SSH_SESSION_EXPIRED_ERROR}: ${RELAY_PTY_ID}`
+    )
+    vi.restoreAllMocks()
+  })
+
+  it('produces no verdict when the relay never answers', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(BOUND_AT + 60_000)
+    const requestHostRpc = vi.fn().mockRejectedValue(new Error('request timed out'))
+
+    expect(await mark({ lease: lease(), requestHostRpc })).toBe(
+      `${SSH_SESSION_EXPIRED_ERROR}: ${RELAY_PTY_ID}`
+    )
+    vi.restoreAllMocks()
+  })
+
+  it('produces no verdict against a relay too old to report its uptime', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(BOUND_AT + 60_000)
+    const requestHostRpc = vi.fn().mockResolvedValue({ capabilities: ['skills.install.bundle.v1'] })
+
+    expect(await mark({ lease: lease(), requestHostRpc })).toBe(
+      `${SSH_SESSION_EXPIRED_ERROR}: ${RELAY_PTY_ID}`
+    )
+    vi.restoreAllMocks()
+  })
+
+  it('does not ask the relay when nothing records an attach for the binding', async () => {
+    const requestHostRpc = vi.fn()
+
+    expect(await mark({ lease: lease({ lastAttachedAt: undefined }), requestHostRpc })).toBe(
+      `${SSH_SESSION_EXPIRED_ERROR}: ${RELAY_PTY_ID}`
+    )
+    expect(await mark({ lease: null, requestHostRpc })).toBe(
+      `${SSH_SESSION_EXPIRED_ERROR}: ${RELAY_PTY_ID}`
+    )
+    expect(requestHostRpc).not.toHaveBeenCalled()
+  })
+
+  it('produces no verdict when the provider cannot reach a relay at all', async () => {
+    expect(await mark({ lease: lease() })).toBe(`${SSH_SESSION_EXPIRED_ERROR}: ${RELAY_PTY_ID}`)
+  })
+})

--- a/src/main/providers/ssh-relay-replacement-verdict.ts
+++ b/src/main/providers/ssh-relay-replacement-verdict.ts
@@ -1,0 +1,73 @@
+import type { Store } from '../persistence'
+import { SSH_RELAY_REPLACED_ERROR } from './ssh-pty-errors'
+import type { IPtyProvider } from './types'
+
+/** Bounded so a wedged relay costs the absence fallback nothing: no answer is no verdict. */
+const RELAY_STATUS_TIMEOUT_MS = 3_000
+
+/**
+ * Did the relay that just answered start AFTER we last attached this PTY?
+ *
+ * `relay.status` reports the daemon's own `uptimeMs`, and a duration carries no clock skew, so
+ * anchoring it to our clock yields a start time comparable to the lease timestamp we wrote
+ * ourselves. A daemon that started after our last successful attach cannot be the daemon that
+ * held the PTY — the binding names a shell from a previous daemon, which may still be running.
+ *
+ * Only a relay that actually answers can produce this verdict. A transport failure, a timeout, a
+ * relay too old to report `uptimeMs`, or a lease with no attach on record all return false and
+ * leave the fallback exactly as it was: loss of contact is never evidence
+ * (docs/reference/ssh-execution-boundary.md).
+ */
+export async function relayStartedAfterLastPtyAttach(args: {
+  requestHostRpc: IPtyProvider['requestHostRpc']
+  lastAttachedAtMs: number | undefined
+  now?: () => number
+}): Promise<boolean> {
+  if (
+    !args.requestHostRpc ||
+    typeof args.lastAttachedAtMs !== 'number' ||
+    !Number.isFinite(args.lastAttachedAtMs)
+  ) {
+    return false
+  }
+  let status: unknown
+  try {
+    status = await args.requestHostRpc('relay.status', {}, { timeoutMs: RELAY_STATUS_TIMEOUT_MS })
+  } catch {
+    return false
+  }
+  const uptimeMs = (status as { uptimeMs?: unknown } | null | undefined)?.uptimeMs
+  if (typeof uptimeMs !== 'number' || !Number.isFinite(uptimeMs) || uptimeMs < 0) {
+    return false
+  }
+  // Round-trip latency inflates the uptime we read, ageing the daemon — which can only ever
+  // withdraw the verdict, never invent one.
+  return (args.now ?? Date.now)() - uptimeMs > args.lastAttachedAtMs
+}
+
+/**
+ * Marks a positive-absence reattach failure whose relay post-dates the binding, so the fallback
+ * that follows can spawn the shell the user needs without re-running the agent that shell was
+ * running. Silent — including on an unreachable relay — for every other reason a PTY is absent.
+ */
+export async function markSshExpiryFromReplacedRelay(args: {
+  error: Error
+  provider: Pick<IPtyProvider, 'requestHostRpc'>
+  store: Pick<Store, 'getSshRemotePtyLease'> | undefined
+  connectionId: string
+  relayPtyId: string
+}): Promise<void> {
+  const lease = args.store?.getSshRemotePtyLease(args.connectionId, args.relayPtyId)
+  if (
+    !lease ||
+    !(await relayStartedAfterLastPtyAttach({
+      requestHostRpc: args.provider.requestHostRpc,
+      lastAttachedAtMs: lease.lastAttachedAt
+    }))
+  ) {
+    return
+  }
+  // Why the message: this rides the SSH_SESSION_EXPIRED error the renderer already branches on,
+  // the same way SSH_PTY_IDENTITY_MISMATCH does, so no consumer has to learn a new failure shape.
+  args.error.message = `${args.error.message} ${SSH_RELAY_REPLACED_ERROR}`
+}

--- a/src/renderer/src/components/terminal-pane/ipc-pty-connect.ts
+++ b/src/renderer/src/components/terminal-pane/ipc-pty-connect.ts
@@ -13,6 +13,7 @@ import { spawnIpcPty } from './ipc-pty-spawn-request'
 import type { IpcPtyTransportOptions, PtyConnectResult, PtyTransport } from './pty-transport-types'
 
 const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
+const SSH_RELAY_REPLACED_ERROR = 'SSH_RELAY_REPLACED'
 const SSH_PTY_CONNECTION_MISMATCH_MARKER = 'belongs to SSH connection'
 
 type PtyConnectOptions = Parameters<PtyTransport['connect']>[0]
@@ -124,7 +125,11 @@ function handleConnectError(
     (message.includes(SSH_SESSION_EXPIRED_ERROR) ||
       message.includes(SSH_PTY_CONNECTION_MISMATCH_MARKER))
   ) {
-    return { id: options.sessionId, sessionExpired: true }
+    return {
+      id: options.sessionId,
+      sessionExpired: true,
+      ...(message.includes(SSH_RELAY_REPLACED_ERROR) ? { relayReplaced: true as const } : {})
+    }
   }
   if (message.includes('was explicitly killed')) {
     return undefined

--- a/src/renderer/src/components/terminal-pane/pty-connection-relay-replaced-resume-suppression.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-relay-replaced-resume-suppression.test.ts
@@ -1,0 +1,238 @@
+import type * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { toAppSshPtyId } from '../../../../shared/ssh-pty-id'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { flushAsyncTicks } from './pty-connection-test-async'
+import {
+  LEAF_1,
+  createMockTransport,
+  createPane,
+  createManager,
+  type ConnectCallbacks,
+  type MockTransport
+} from './pty-connection-test-pane-fixtures'
+import { buildPaneConnectionDeps } from './pty-connection-test-deps'
+import { createInitialStoreState } from './pty-connection-test-store-fixtures'
+import type { StoreState } from './pty-connection-test-store-state'
+import {
+  installTerminalTestGlobals,
+  restoreTerminalTestGlobals
+} from './pty-connection-test-environment'
+
+const {
+  resetAndRefreshAllTerminalWebglAtlases,
+  scheduleTerminalWebglAtlasRecovery,
+  scheduleRuntimeGraphSync,
+  shouldSeedCacheTimerOnInitialTitle,
+  toastInfo,
+  notifyCodexPaneBoundForStaleSweep
+} = vi.hoisted(() => ({
+  resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
+  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleRuntimeGraphSync: vi.fn(),
+  shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
+  toastInfo: vi.fn(),
+  notifyCodexPaneBoundForStaleSweep: vi.fn()
+}))
+
+let mockStoreState: StoreState
+let transportFactoryQueue: MockTransport[] = []
+let createdTransportOptions: Record<string, unknown>[] = []
+let storeSubscribers: ((state: StoreState) => void)[] = []
+
+vi.mock('@/runtime/sync-runtime-graph', () => ({
+  scheduleRuntimeGraphSync
+}))
+
+vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resetAndRefreshAllTerminalWebglAtlases
+}))
+
+vi.mock('./terminal-webgl-atlas-recovery', () => ({
+  scheduleTerminalWebglAtlasRecovery
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mockStoreState,
+    subscribe: (listener: (state: StoreState) => void) => {
+      storeSubscribers.push(listener)
+      return () => {
+        storeSubscribers = storeSubscribers.filter((candidate) => candidate !== listener)
+      }
+    }
+  }
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const { buildAgentStatusModuleMock } = await import('./pty-connection-test-environment')
+  return buildAgentStatusModuleMock(await importOriginal<Record<string, unknown>>())
+})
+
+vi.mock('./cache-timer-seeding', () => ({
+  shouldSeedCacheTimerOnInitialTitle
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    info: toastInfo
+  }
+}))
+
+vi.mock('@/lib/codex-stale-pane-sweep', () => ({
+  notifyCodexPaneBoundForStaleSweep
+}))
+
+// Why: the working→idle test invokes the real useNotificationDispatch hook outside React, so useCallback must pass through (safe suite-wide: no test here renders React).
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof React>()
+  return {
+    ...actual,
+    useCallback: <T extends (...args: unknown[]) => unknown>(fn: T): T => fn
+  }
+})
+
+vi.mock('./pty-transport', () => ({
+  createIpcPtyTransport: vi.fn((options: Record<string, unknown>) => {
+    createdTransportOptions.push(options)
+    const nextTransport = transportFactoryQueue.shift()
+    if (!nextTransport) {
+      throw new Error('No mock transport queued')
+    }
+    return nextTransport
+  })
+}))
+
+vi.mock('./remote-runtime-pty-transport', () => ({
+  createRemoteRuntimePtyTransport: vi.fn(
+    (_environmentId: string, options: Record<string, unknown>) => {
+      createdTransportOptions.push(options)
+      const nextTransport = transportFactoryQueue.shift()
+      if (!nextTransport) {
+        throw new Error('No mock transport queued')
+      }
+      return nextTransport
+    }
+  )
+}))
+
+// Why: stub only getEagerPtyBufferHandle so tests can simulate a live eager buffer (adopt path) without standing up the real IPC dispatcher.
+vi.mock('./pty-dispatcher', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    getEagerPtyBufferHandle: vi.fn(() => undefined)
+  }
+})
+
+function createDeps(overrides: Record<string, unknown> = {}) {
+  return buildPaneConnectionDeps(() => mockStoreState, overrides)
+}
+
+const RESTORED_PTY_ID = toAppSshPtyId('target-a', 'pty-from-dead-daemon')
+const PROVIDER_SESSION = {
+  key: 'session_id',
+  id: 'codex-session-1',
+  transcriptPath: '/Users/example/.codex/sessions/2026/07/20/rollout-session.jsonl'
+} as const
+
+function seedResumableSshPane(): void {
+  const paneKey = makePaneKey('tab-1', LEAF_1)
+  mockStoreState = {
+    ...mockStoreState,
+    tabsByWorktree: {
+      'wt-1': [{ id: 'tab-1', ptyId: RESTORED_PTY_ID }]
+    },
+    ptyIdsByTabId: { 'tab-1': [RESTORED_PTY_ID] },
+    repos: [{ id: 'repo1', connectionId: 'target-a', displayName: 'orca' }],
+    sshConnectionStates: new Map([
+      ['target-a', { targetId: 'target-a', status: 'connected', connectionGeneration: 1 }]
+    ]),
+    settings: { ...mockStoreState.settings, agentCmdOverrides: {} },
+    agentStatusByPaneKey: {
+      [paneKey]: {
+        state: 'working',
+        prompt: 'finish the task',
+        agentType: 'codex',
+        paneKey,
+        updatedAt: 1,
+        stateStartedAt: 1,
+        stateHistory: [],
+        providerSession: PROVIDER_SESSION
+      }
+    }
+  } as StoreState
+}
+
+/** Fails the reattach the way a relay that no longer knows the PTY does, then lets the
+ *  fallback run. `expiry` is the exact message main surfaces for that absence. */
+async function runAbsenceFallback(
+  expiry: string
+): Promise<{ transport: MockTransport; deps: ReturnType<typeof createDeps> }> {
+  const { connectPanePty } = await import('./pty-connection')
+  const transport = createMockTransport('fresh-pty')
+  transport.connect
+    .mockImplementationOnce(async (options: { callbacks?: ConnectCallbacks }) => {
+      options.callbacks?.onError?.(expiry)
+      return undefined
+    })
+    .mockResolvedValue('fresh-pty')
+  transportFactoryQueue.push(transport)
+  seedResumableSshPane()
+  const deps = createDeps({
+    restoredLeafId: LEAF_1,
+    restoredPtyIdByLeafId: { [LEAF_1]: RESTORED_PTY_ID }
+  })
+
+  connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+  await flushAsyncTicks(20)
+  await new Promise((resolve) => setTimeout(resolve, 70))
+  return { transport, deps }
+}
+
+describe('absence fallback after a relay daemon replacement', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    transportFactoryQueue = []
+    createdTransportOptions = []
+    storeSubscribers = []
+    mockStoreState = createInitialStoreState(() => mockStoreState)
+    installTerminalTestGlobals()
+  })
+
+  afterEach(async () => {
+    await restoreTerminalTestGlobals()
+  })
+
+  it('still resumes the agent when the relay that answered predates the binding', async () => {
+    const { transport, deps } = await runAbsenceFallback(`SSH_SESSION_EXPIRED: ${RESTORED_PTY_ID}`)
+
+    expect(transport.connect).toHaveBeenCalledTimes(2)
+    const freshSpawn = transport.connect.mock.calls[1]?.[0] as Record<string, unknown>
+    expect(freshSpawn.sessionId).toBeUndefined()
+    expect(freshSpawn.launchAgent).toBe('codex')
+    expect(freshSpawn.resumeProviderSession).toEqual(PROVIDER_SESSION)
+    expect(deps.onShowSessionRestoredBanner).not.toHaveBeenCalledWith(1, 'resume-unavailable')
+  })
+
+  it('spawns a plain shell instead of re-running the agent when the relay is younger than the binding', async () => {
+    const { transport, deps } = await runAbsenceFallback(
+      `SSH_SESSION_EXPIRED: ${RESTORED_PTY_ID} SSH_RELAY_REPLACED`
+    )
+
+    // The user still gets a terminal...
+    expect(transport.connect).toHaveBeenCalledTimes(2)
+    const freshSpawn = transport.connect.mock.calls[1]?.[0] as Record<string, unknown>
+    expect(freshSpawn.sessionId).toBeUndefined()
+    // ...but nothing that would start a second agent on the same worktree.
+    expect(freshSpawn.launchAgent).toBeUndefined()
+    expect(freshSpawn.resumeProviderSession).toBeUndefined()
+    expect(freshSpawn.command).toBeUndefined()
+    expect(freshSpawn.launchConfig).toBeUndefined()
+    expect(freshSpawn.launchToken).toBeUndefined()
+    // ...and the pane says the agent did not come back.
+    expect(deps.onShowSessionRestoredBanner).toHaveBeenCalledWith(1, 'resume-unavailable')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection-relay-replaced-resume-suppression.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-relay-replaced-resume-suppression.test.ts
@@ -166,14 +166,18 @@ function seedResumableSshPane(): void {
 }
 
 /** Fails the reattach the way a relay that no longer knows the PTY does, then lets the
- *  fallback run. `expiry` is the exact message main surfaces for that absence. */
+ *  fallback run. A string is the exact message main surfaces for that absence; an object is
+ *  the expiry the IPC transport reports as a result instead of a rejection. */
 async function runAbsenceFallback(
-  expiry: string
+  expiry: string | { relayReplaced: true }
 ): Promise<{ transport: MockTransport; deps: ReturnType<typeof createDeps> }> {
   const { connectPanePty } = await import('./pty-connection')
   const transport = createMockTransport('fresh-pty')
   transport.connect
     .mockImplementationOnce(async (options: { callbacks?: ConnectCallbacks }) => {
+      if (typeof expiry !== 'string') {
+        return { id: RESTORED_PTY_ID, sessionExpired: true, ...expiry }
+      }
       options.callbacks?.onError?.(expiry)
       return undefined
     })
@@ -233,6 +237,17 @@ describe('absence fallback after a relay daemon replacement', () => {
     expect(freshSpawn.launchConfig).toBeUndefined()
     expect(freshSpawn.launchToken).toBeUndefined()
     // ...and the pane says the agent did not come back.
+    expect(deps.onShowSessionRestoredBanner).toHaveBeenCalledWith(1, 'resume-unavailable')
+  })
+
+  it('declines the resume when the expiry arrives as a result rather than a rejection', async () => {
+    const { transport, deps } = await runAbsenceFallback({ relayReplaced: true })
+
+    expect(transport.connect).toHaveBeenCalledTimes(2)
+    const freshSpawn = transport.connect.mock.calls[1]?.[0] as Record<string, unknown>
+    expect(freshSpawn.launchAgent).toBeUndefined()
+    expect(freshSpawn.resumeProviderSession).toBeUndefined()
+    expect(freshSpawn.command).toBeUndefined()
     expect(deps.onShowSessionRestoredBanner).toHaveBeenCalledWith(1, 'resume-unavailable')
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-connection/deferred-session-attach.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/deferred-session-attach.ts
@@ -8,6 +8,10 @@ import {
   waitForUserInitiatedSshConnect,
   waitForSshConnection
 } from './ssh-session-connect'
+import {
+  isRelayReplacedSinceBindingError,
+  withRelayReplacedResumeSuppressed
+} from './relay-replaced-resume-suppression'
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
 import { toProcessExitStartup } from './process-exit-startup'
 
@@ -141,13 +145,25 @@ export function runDeferredSessionAttach(session: ConnectPanePtySession): void {
             }
           }
           let expiredReattachError = false
+          let relayReplacedSinceBinding = false
           const coldRestoreStartup = session.buildColdRestoreAgentResumeStartup()
           session.clearPaneMode2031State()
           session.clearHiddenOutputRestoreState()
+          const restartPaneAfterRelayAbsence = (relayReplaced: boolean): void => {
+            useAppStore.getState().removeDeferredSshSessionId(session.deps.tabId)
+            session.deps.clearExitedPanePtyLayoutBinding(session.pane.id, pendingSessionId)
+            session.deps.clearTabPtyId(session.deps.tabId, pendingSessionId)
+            session.startFreshColdRestoreAgentResume(
+              ...withRelayReplacedResumeSuppressed(coldRestoreStartup, relayReplaced, {
+                forceBlankRestoredViewport: true
+              })
+            )
+          }
           const outputCallbacks = session.captureTransportOutputCallbacks(
             (message) => {
               if (isSshSessionExpiredError(message)) {
                 expiredReattachError = true
+                relayReplacedSinceBinding ||= isRelayReplacedSinceBindingError(message)
                 return
               }
               if (!session.isCapturedDirectSshReattachCurrent(pendingSessionId)) {
@@ -214,12 +230,7 @@ export function runDeferredSessionAttach(session: ConnectPanePtySession): void {
                 if (session.rejectObsoleteDirectSshReattach(pendingSessionId)) {
                   return
                 }
-                useAppStore.getState().removeDeferredSshSessionId(session.deps.tabId)
-                session.deps.clearExitedPanePtyLayoutBinding(session.pane.id, pendingSessionId)
-                session.deps.clearTabPtyId(session.deps.tabId, pendingSessionId)
-                session.startFreshColdRestoreAgentResume(coldRestoreStartup, {
-                  forceBlankRestoredViewport: true
-                })
+                restartPaneAfterRelayAbsence(relayReplacedSinceBinding)
                 return
               }
               const accepted = await session.handleReattachResult(
@@ -277,12 +288,7 @@ export function runDeferredSessionAttach(session: ConnectPanePtySession): void {
                 return
               }
               if (isSshSessionExpiredError(err)) {
-                useAppStore.getState().removeDeferredSshSessionId(session.deps.tabId)
-                session.deps.clearExitedPanePtyLayoutBinding(session.pane.id, pendingSessionId)
-                session.deps.clearTabPtyId(session.deps.tabId, pendingSessionId)
-                session.startFreshColdRestoreAgentResume(coldRestoreStartup, {
-                  forceBlankRestoredViewport: true
-                })
+                restartPaneAfterRelayAbsence(isRelayReplacedSinceBindingError(err))
                 return
               }
               session.reportError(err instanceof Error ? err.message : String(err))

--- a/src/renderer/src/components/terminal-pane/pty-connection/deferred-session-reattach-connect.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/deferred-session-reattach-connect.ts
@@ -1,6 +1,10 @@
 import { warnTerminalLifecycleAnomaly } from '../terminal-lifecycle-diagnostics'
 import { recordPtyConnectDiagnostic } from './pty-connect-limits'
 import { isSshSessionExpiredError } from './ssh-session-connect'
+import {
+  isRelayReplacedSinceBindingError,
+  withRelayReplacedResumeSuppressed
+} from './relay-replaced-resume-suppression'
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
 import { toProcessExitStartup } from './process-exit-startup'
 import { recoverUnverifiableDirectSshReattach } from './direct-ssh-reattach-recovery'
@@ -22,11 +26,13 @@ export function startDeferredSessionReattach(
       : window.api.pty.declarePendingPaneSerializer(session.cacheKey).catch(() => null)
 
   let expiredReattachError = false
+  let relayReplacedSinceBinding = false
   const coldRestoreStartup = session.buildColdRestoreAgentResumeStartup()
   const outputCallbacks = session.captureTransportOutputCallbacks(
     (message) => {
       if (isSshSessionExpiredError(message)) {
         expiredReattachError = true
+        relayReplacedSinceBinding ||= isRelayReplacedSinceBindingError(message)
         return
       }
       if (!session.isCapturedDirectSshReattachCurrent(deferredReattachSessionId)) {
@@ -89,9 +95,11 @@ export function startDeferredSessionReattach(
         }
         session.deps.clearExitedPanePtyLayoutBinding(session.pane.id, deferredReattachSessionId)
         session.deps.clearTabPtyId(session.deps.tabId, deferredReattachSessionId)
-        session.startFreshColdRestoreAgentResume(coldRestoreStartup, {
-          forceBlankRestoredViewport: true
-        })
+        session.startFreshColdRestoreAgentResume(
+          ...withRelayReplacedResumeSuppressed(coldRestoreStartup, relayReplacedSinceBinding, {
+            forceBlankRestoredViewport: true
+          })
+        )
         return
       }
       const accepted = await session.handleReattachResult(
@@ -144,9 +152,13 @@ export function startDeferredSessionReattach(
       if (session.connectionId && isSshSessionExpiredError(err)) {
         session.deps.clearExitedPanePtyLayoutBinding(session.pane.id, deferredReattachSessionId)
         session.deps.clearTabPtyId(session.deps.tabId, deferredReattachSessionId)
-        session.startFreshColdRestoreAgentResume(coldRestoreStartup, {
-          forceBlankRestoredViewport: true
-        })
+        session.startFreshColdRestoreAgentResume(
+          ...withRelayReplacedResumeSuppressed(
+            coldRestoreStartup,
+            isRelayReplacedSinceBindingError(err),
+            { forceBlankRestoredViewport: true }
+          )
+        )
         return
       }
       session.reportError(message)

--- a/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-start.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-start.ts
@@ -207,12 +207,14 @@ export function bindStartFreshSpawn(session: ConnectPanePtySession): void {
             })
           }
           if (
-            spawnedPtyId &&
-            typeof spawnedPtyId === 'object' &&
-            spawnedPtyId.agentResumeUnavailable
+            options.notifyResumeUnavailable ||
+            (spawnedPtyId &&
+              typeof spawnedPtyId === 'object' &&
+              spawnedPtyId.agentResumeUnavailable)
           ) {
-            // Why: main dropped the resume argv, so this pane is a NEW session —
-            // the plain restored banner would claim the old one came back.
+            // Why: the resume argv was dropped — by main, or by the caller when the relay
+            // that answered post-dated the binding — so this pane is a NEW session, and the
+            // plain restored banner would claim the old one came back.
             session.showSessionRestoredBanner('resume-unavailable')
           } else if (coldRestoreOverride?.hasSleepingRecord) {
             session.showSessionRestoredBanner()

--- a/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-types.ts
@@ -12,6 +12,8 @@ export type PendingStartupCommand = {
 
 export type FreshSpawnOptions = {
   forceBlankRestoredViewport?: boolean
+  /** The caller already declined this pane's agent resume, so the fresh shell must say so. */
+  notifyResumeUnavailable?: true
 }
 
 export type ColdRestoreAgentResumeStartup = PendingStartupCommand & {

--- a/src/renderer/src/components/terminal-pane/pty-connection/pty-connect-limits.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pty-connect-limits.ts
@@ -3,6 +3,9 @@ import { e2eConfig } from '@/lib/e2e-config'
 export const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 export const pendingSpawnGenerationByPaneKey = new Map<string, number>()
 export const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
+// Why mirrored from main: the marker rides the expiry message across IPC, the same way
+// SSH_SESSION_EXPIRED itself does (src/main/providers/ssh-pty-errors.ts).
+export const SSH_RELAY_REPLACED_ERROR = 'SSH_RELAY_REPLACED'
 // Why: relay requests expire at 30s; leave one second for their fallback before re-arming locally.
 export const DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS = 31_000
 export const REMOTE_PTY_ID_PREFIX = 'remote:'

--- a/src/renderer/src/components/terminal-pane/pty-connection/reattach-result-handler.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/reattach-result-handler.ts
@@ -18,6 +18,7 @@ import type { ReattachPayloadContext } from './reattach-payload-context'
 import { createReattachPayloadHandlers } from './apply-reattach-payload'
 import type { ReattachPayloadSession } from './reattach-payload-session'
 import { recoverUnverifiableDirectSshReattach } from './direct-ssh-reattach-recovery'
+import { withRelayReplacedResumeSuppressed } from './relay-replaced-resume-suppression'
 
 type ReattachResultSession = ReattachPayloadSession &
   Pick<
@@ -127,9 +128,13 @@ export function bindHandleReattachResult(sessionBag: ConnectPanePtySession): voi
         session.deps.clearTabPtyId(session.deps.tabId, staleSessionId)
       }
       // Why: SSH sleep/reconnect can invalidate the relay PTY while the tab stays mounted; replace the dead lease in-place, not a stale overlay.
-      session.startFreshColdRestoreAgentResume(coldRestoreStartup, {
-        forceBlankRestoredViewport: true
-      })
+      session.startFreshColdRestoreAgentResume(
+        ...withRelayReplacedResumeSuppressed(
+          coldRestoreStartup,
+          connectResult.relayReplaced === true,
+          { forceBlankRestoredViewport: true }
+        )
+      )
       return false
     }
     const isCurrentReattachPayload = (): boolean => {

--- a/src/renderer/src/components/terminal-pane/pty-connection/relay-replaced-resume-suppression.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/relay-replaced-resume-suppression.ts
@@ -1,0 +1,30 @@
+import { SSH_RELAY_REPLACED_ERROR } from './pty-connect-limits'
+import type { ColdRestoreAgentResumeStartup, FreshSpawnOptions } from './fresh-spawn-types'
+
+/** Main marks the expiry when `relay.status` proved the answering relay post-dates the binding. */
+export function isRelayReplacedSinceBindingError(err: unknown): boolean {
+  return (err instanceof Error ? err.message : String(err)).includes(SSH_RELAY_REPLACED_ERROR)
+}
+
+/**
+ * The absence fallback's spawn arguments once the relay that answered is known to have started
+ * after we last attached this PTY.
+ *
+ * The pane still gets a shell — the user asked for a terminal and is owed one. It does not get the
+ * agent back: the binding named a PTY from a dead daemon, whose shell may still be running as an
+ * orphan, and re-running the resume would put a second agent on that worktree. Declining is
+ * recoverable; the duplicate is not (STA-5698).
+ *
+ * Anything else — an ordinary expiry, a relay too old to report its uptime, a relay that never
+ * answered — leaves the fallback untouched.
+ */
+export function withRelayReplacedResumeSuppressed(
+  startup: ColdRestoreAgentResumeStartup | null | undefined,
+  relayReplaced: boolean,
+  options: FreshSpawnOptions
+): [ColdRestoreAgentResumeStartup | null, FreshSpawnOptions] {
+  if (!startup || !relayReplaced) {
+    return [startup ?? null, options]
+  }
+  return [null, { ...options, notifyResumeUnavailable: true }]
+}

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -93,6 +93,9 @@ export type PtyConnectResult = {
   snapshotSeq?: number
   isAlternateScreen?: boolean
   sessionExpired?: boolean
+  /** The relay that reported the PTY absent started after we last attached it, so the pane's
+   *  binding named a shell from a dead daemon and its agent must not be resumed (STA-5698). */
+  relayReplaced?: true
   coldRestore?: { scrollback: string; cwd: string; cols?: number; rows?: number }
   replay?: string
   startupCwdFallback?: { kind: 'worktree'; cwd: string }


### PR DESCRIPTION
Fixes STA-5698.

## What was wrong

When a stable pane's reattach fails with **positive absence** — the relay answers for that exact PTY id and reports it absent — Orca falls back to a fresh spawn built from the *original* request's options. Those options still carry `launchAgent`, `command`, and `resumeProviderSession`.

On a cold restore that is exactly right. After a **relay daemon replacement** it is not. A restarted relay has no record of any pre-restart id, so it reports *every* one of them absent, and the pane's binding names a PTY the previous daemon created — whose shell can still be alive as an orphan (that orphan is the sibling ticket, STA-5697). Re-running the resume then starts a **second agent against the same worktree**.

The client could already tell and never looked: `relay.status` reports `pid` and `uptimeMs` (`src/relay/relay-daemon.ts:128-131`), and before this change `uptimeMs` had exactly one reference in the tree — the producer.

## The fix

On the expiry path, main asks the relay once whether it post-dates the binding it was asked to restore:

- **The daemon's start time** is `Date.now() - uptimeMs`. A *duration* carries no clock skew, so anchoring it to our own clock makes it directly comparable to a timestamp we wrote ourselves.
- **The binding's age** is the SSH lease's `lastAttachedAt` — the last moment we positively attached that PTY. It is refreshed on every successful spawn/attach commit and, crucially, only for PTYs a reconnect actually reattached, so it never claims proof we do not have.
- If the daemon started **after** that moment, it demonstrably did not hold the PTY.

When that holds, main marks the `SSH_SESSION_EXPIRED` error the same way an identity mismatch is already marked, and the absence fallback:

- **still spawns the shell** — the user asked for a terminal and is owed one;
- **declines** `launchAgent` / `command` / `resumeProviderSession`;
- raises the existing *"previous session unavailable, started fresh"* banner, so silence never reads as a successful restore.

A plain shell is a recoverable outcome. A duplicate agent racing an orphan over one worktree is not.

### Deliberately narrow

- The verdict **never gates the spawn**, and it is not a general "is the PTY alive" probe.
- Only a relay that **actually answers** can produce it. A transport failure, a request timeout, a relay too old to report `uptimeMs`, or a lease with no attach on record all produce **no verdict** and leave the fallback byte-for-byte as it was. Loss of contact is never evidence (`docs/reference/ssh-execution-boundary.md`).
- The `relay.status` call is bounded at 3s and only runs on the expiry path, after the relay has already answered once.
- An identity mismatch is excluded: that id names a *live* PTY owned by another pane, which is not absence.

### Wire compatibility

Client-side policy only, no wire change — `relay.status` already carries the fields, so this reaches old hosts unchanged (`docs/reference/remote-wire-compatibility.md`). Against a host too old to report `uptimeMs`, the verdict simply never fires and behaviour is identical to today.

## Changes

| Area | Change |
| --- | --- |
| `src/main/providers/ssh-relay-replacement-verdict.ts` | New. Asks `relay.status`, compares its start time against the lease's `lastAttachedAt`, marks the expiry. Every failure mode returns "no verdict". |
| `src/main/providers/ssh-pty-errors.ts` | `SSH_RELAY_REPLACED` marker, alongside the existing `SSH_PTY_IDENTITY_MISMATCH`. |
| `src/main/ipc/pty/{ipc,runtime}/spawn-execute.ts` | Ask for the verdict before the lease is expired, on both spawn pipelines. |
| `src/main/persistence/.../ssh-pty-lease-operations.ts`, `ssh-lease-recovery-operations.ts` | `getSshRemotePtyLease(targetId, ptyId)` — a single-lease read using the same id normalisation as `markSshRemotePtyLease`. |
| `src/renderer/.../relay-replaced-resume-suppression.ts` | New. Turns the marked expiry into the fallback's spawn arguments. |
| `src/renderer/.../{deferred-session-attach,deferred-session-reattach-connect,reattach-result-handler}.ts` | Consume the verdict at all three absence-fallback sites (message-borne and result-borne). |
| `src/renderer/.../fresh-spawn-{types,start}.ts` | `notifyResumeUnavailable` routes into the existing `resume-unavailable` banner rather than a second surface. |
| `src/renderer/.../ipc-pty-connect.ts`, `pty-transport-types.ts` | Carry the marker onto the `sessionExpired` connect result. |

`deferred-session-attach.ts` also collapses its two duplicated absence-fallback blocks into one local helper; that is what keeps it inside the `max-lines` budget.

## Tests

Both new suites were confirmed to **fail without the fix** and pass with it.

- `src/main/providers/ssh-relay-replacement-verdict.test.ts` — marks a younger relay; stays silent for an older relay, an unreachable relay, a relay with no `uptimeMs`, a lease with no attach, and no lease at all (and does not even issue the RPC in the last two).
- `src/renderer/.../pty-connection-relay-replaced-resume-suppression.test.ts` — drives the real pane connect path over SSH. Asserts the **derived outcome**: an unmarked expiry still resumes the agent (guarding against over-suppression), and a marked expiry spawns a shell carrying no `launchAgent` / `resumeProviderSession` / `command` / `launchConfig` / `launchToken` and raises the `resume-unavailable` banner — covered both for the message-borne and the result-borne expiry.

Also green: cold-restore agent resume, direct-SSH reattach retry, sleeping-resume banner, SSH remote PTY leases, SSH PTY provider spawn + reattach incarnation, PTY persisted-incarnation repair, listener teardown/orphans, provider dispatch. `pnpm tc` and `oxlint` clean.


## Reproduction

Run against a throwaway Linux Docker SSH target with a real repo, an isolated Electron dev instance driven over CDP, and a stub agent that logs its argv. **Partially reproduced** — the precondition reproduces exactly, the duplicate-agent end state did not fire in that particular pane state.

**Reproduced.** After `kill -9` on the relay daemon, the replacement daemon answered for the exact PTY id and reported it absent — `PTY "pty-2" not found` → `SSH_SESSION_EXPIRED: pty-2` — so this is positive absence, not loss of contact. And the answering daemon was demonstrably younger than the binding: `relay.status` returned `pid=1120, uptimeMs=270523` against a simultaneous remote clock sample of `1787859380091`, putting its start at `1787859109568`, about 159s **after** the lease was written at `1787858950290`. That is the predicate this PR adds, evaluating true on live data from a real relay replacement.

**Did not reproduce.** Two things, both worth stating plainly:

1. **The orphan did not survive this death mode.** `kill -9` on the daemon reaped its node-pty children — the stub agent (pid 875) and both shells were gone 0.3s later. The orphan the ticket describes comes from the sibling issue STA-5697 (the `uncaughtException` handler exiting without disposing PTYs), which is a different exit path and was not exercised here.
2. **The fallback did not re-run the agent in that run.** The pane was in `pendingActivationSpawn` with a direct-SSH retry armed, so it kept re-attaching the dead session id instead of falling through to a fresh spawn; the new daemon ended with `ptys.active=0` and the stub agent log had exactly one invocation, with no `--resume`. That is a real finding about the restore path, and it is separate from this ticket — it is the gap #16763 exists to close.

So the harm is demonstrated as a **reachable code path** rather than as a live duplicate agent: the re-run branch is covered by the control case in the new renderer suite, which drives the real pane connect path and asserts that an unmarked expiry still spawns with `launchAgent` and `resumeProviderSession`. Once #16763 lands, that branch runs in main-process `spawnForStablePane` for every positive absence, unconditionally.

Separately confirmed against a real profile: every SSH lease on disk carries `lastAttachedAt`, so the guard's input is populated in practice rather than only in tests.

## Relationship to #16763

#16763 introduces the same fallback on the main-process SSH path and names this risk in its safety section. It is currently a draft and conflicting with main, so this PR is written against **main**, where the identical re-run already happens through the renderer's absence fallback. The verdict lives in main next to the relay handle and the lease, so it is available to #16763's `spawnForStablePane` fallback as-is when that lands.

## Residual risk

- A backward system-clock jump between the last attach and the verdict could suppress a resume that was safe. The cost is a plain shell plus a banner, and the alternative machinery is not worth it.
- Leases written by older builds may have no `lastAttachedAt`; those simply never produce a verdict.
- The local (non-relay) daemon-restart case is untouched. `relay.status` is relay-only, and widening it is a separate change.
