### PR TITLE
fix(resume): retire agent resume records past an absolute age

### DIFF
--- a/src/renderer/src/lib/host-mirrored-pane-resume-replay.test.ts
+++ b/src/renderer/src/lib/host-mirrored-pane-resume-replay.test.ts
@@ -10,6 +10,9 @@ import {
   resetHostSessionMirrorHydrationForTests
 } from '@/runtime/host-session-mirror-hydration'
 import { clearRuntimeEnvironmentConnectionGenerationsForTests } from '@/store/slices/runtime-status'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 // Deferring a mirrored pane's resume is only half the fix: whatever settles the
 // mirror must replay the parked sweep, or the aug20 duplicate-launch defect is

--- a/src/renderer/src/lib/pi-live-session-no-duplicate-tab.test.ts
+++ b/src/renderer/src/lib/pi-live-session-no-duplicate-tab.test.ts
@@ -2,6 +2,9 @@ import { afterEach, describe, expect, it } from 'vitest'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
 import { useAppStore } from '@/store'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 const initialAppStoreState = useAppStore.getState()
 const LEAF_ID = '11111111-1111-1111-8111-111111111111'

--- a/src/renderer/src/lib/pi-session-resume-wake.test.ts
+++ b/src/renderer/src/lib/pi-session-resume-wake.test.ts
@@ -5,6 +5,9 @@ import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-r
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import { useAppStore } from '@/store'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 const initialAppStoreState = useAppStore.getState()
 const PI_TRANSCRIPT_PATH = join(tmpdir(), 'pi-session-1.jsonl')

--- a/src/renderer/src/lib/resume-record-clock-test-fixture.ts
+++ b/src/renderer/src/lib/resume-record-clock-test-fixture.ts
@@ -1,0 +1,26 @@
+import { afterEach, beforeEach, vi } from 'vitest'
+
+/**
+ * Wall-clock instant these suites run at.
+ *
+ * Fixtures across the resume suites date records from epoch 0 — `capturedAt: 1`,
+ * `capturedAt: 2`, and so on — because they only ever needed relative ordering.
+ * `isInvalidWorktreeActivationRecord` now also bounds a record's absolute age,
+ * which reads those fixtures as decades old and retires every one of them.
+ *
+ * Pinning the clock a little past the largest fixture timestamp keeps each test
+ * asserting the behaviour it was written for, and makes the age bound something
+ * a test opts into by choosing a `capturedAt` far enough back.
+ */
+export const RESUME_RECORD_TEST_NOW = 4_000_000
+
+/** Call at module scope in any suite that drives resume-record validity. */
+export function pinResumeRecordClock(now: number = RESUME_RECORD_TEST_NOW): void {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+}

--- a/src/renderer/src/lib/resume-sleeping-agent-session-provider-claim.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-provider-claim.test.ts
@@ -3,6 +3,9 @@ import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-r
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import { useAppStore } from '@/store'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 const initialAppStoreState = useAppStore.getState()
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'

--- a/src/renderer/src/lib/resume-sleeping-agent-session-record-expiry.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-record-expiry.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../../shared/agent-status-types'
+import { useAppStore } from '@/store'
+import {
+  RESUME_RECORD_MAX_AGE_MS,
+  resumeSleepingAgentSessionsForWorktree
+} from './resume-sleeping-agent-session'
+
+const initialAppStoreState = useAppStore.getState()
+const NOW = 1_800_000_000_000
+
+beforeEach(() => {
+  vi.spyOn(Date, 'now').mockReturnValue(NOW)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+function makeRecord(
+  overrides: Partial<SleepingAgentSessionRecord> = {}
+): SleepingAgentSessionRecord {
+  return {
+    paneKey: 'tab-1:leaf-1',
+    tabId: 'tab-1',
+    worktreeId: 'wt-1',
+    agent: 'claude',
+    providerSession: { key: 'session_id', id: 'sess-1' },
+    prompt: 'finish the task',
+    state: 'working',
+    // A live capture stamps both fields from the same value, so the relative
+    // staleness check below can never fire for one of these.
+    capturedAt: NOW,
+    updatedAt: NOW,
+    origin: 'live',
+    ...overrides
+  }
+}
+
+function seedWorktreeWithUnownedPane(record: SleepingAgentSessionRecord): void {
+  useAppStore.setState({
+    tabsByWorktree: {
+      'wt-1': [
+        {
+          id: 'tab-1',
+          ptyId: null,
+          worktreeId: 'wt-1',
+          title: 'shell',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }
+      ]
+    },
+    sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+  } as never)
+}
+
+describe('resume record absolute expiry', () => {
+  it('retires a record older than the maximum age instead of resuming it', () => {
+    const capturedAt = NOW - RESUME_RECORD_MAX_AGE_MS - 1
+    const record = makeRecord({ capturedAt, updatedAt: capturedAt })
+    seedWorktreeWithUnownedPane(record)
+
+    expect(resumeSleepingAgentSessionsForWorktree('wt-1')).toBe(0)
+
+    const state = useAppStore.getState()
+    // Retiring, not merely skipping: the record is dropped, so an install that
+    // has accumulated orphans heals itself on the next activation rather than
+    // needing the profile edited or the app restarted.
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
+  })
+
+  it('still resumes a record inside the maximum age', () => {
+    const capturedAt = NOW - RESUME_RECORD_MAX_AGE_MS + 60_000
+    const record = makeRecord({ capturedAt, updatedAt: capturedAt })
+    seedWorktreeWithUnownedPane(record)
+
+    expect(resumeSleepingAgentSessionsForWorktree('wt-1')).toBe(1)
+
+    const state = useAppStore.getState()
+    const resumedTab = state.tabsByWorktree['wt-1']?.find((tab) => tab.id !== 'tab-1')
+    expect(resumedTab?.launchAgent).toBe('claude')
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('expires by record age even when the capture looked fresh at capture time', () => {
+    // The exact shape a live capture produces: capturedAt === updatedAt, so
+    // `capturedAt - updatedAt` is 0 no matter how long the record has sat.
+    const capturedAt = NOW - RESUME_RECORD_MAX_AGE_MS - AGENT_STATUS_STALE_AFTER_MS
+    const record = makeRecord({ capturedAt, updatedAt: capturedAt })
+    expect(record.capturedAt - record.updatedAt).toBe(0)
+    seedWorktreeWithUnownedPane(record)
+
+    expect(resumeSleepingAgentSessionsForWorktree('wt-1')).toBe(0)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('keeps retiring records that were already stale when captured', () => {
+    const record = makeRecord({
+      capturedAt: NOW,
+      updatedAt: NOW - AGENT_STATUS_STALE_AFTER_MS - 1
+    })
+    seedWorktreeWithUnownedPane(record)
+
+    expect(resumeSleepingAgentSessionsForWorktree('wt-1')).toBe(0)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('leaves an aged completed record for the hibernation paths to own', () => {
+    const capturedAt = NOW - RESUME_RECORD_MAX_AGE_MS - 1
+    const record = makeRecord({ state: 'done', capturedAt, updatedAt: capturedAt })
+    seedWorktreeWithUnownedPane(record)
+
+    // Scope guard: the age bound targets unfinished records. A completed record
+    // is passive hibernation evidence and is retired by its own rules, so this
+    // asserts the bound did not quietly take that decision over.
+    expect(resumeSleepingAgentSessionsForWorktree('wt-1')).toBe(0)
+  })
+})

--- a/src/renderer/src/lib/resume-sleeping-agent-session-record-expiry.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-record-expiry.test.ts
@@ -9,6 +9,10 @@ import {
 
 const initialAppStoreState = useAppStore.getState()
 const NOW = 1_800_000_000_000
+// Ownership only resolves for a stable pane key, whose leaf half must be a real
+// terminal leaf id; 'leaf-1' does not parse and silently reads as unowned.
+const OWNED_LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const OWNED_PANE_KEY = `tab-1:${OWNED_LEAF_ID}`
 
 beforeEach(() => {
   vi.spyOn(Date, 'now').mockReturnValue(NOW)
@@ -56,6 +60,41 @@ function seedWorktreeWithUnownedPane(record: SleepingAgentSessionRecord): void {
         }
       ]
     },
+    sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+  } as never)
+}
+
+function seedWorktreeWithOwnedPane(record: SleepingAgentSessionRecord): void {
+  const tabId = 'tab-1'
+  const leafId = OWNED_LEAF_ID
+  useAppStore.setState({
+    activeWorktreeId: 'wt-1',
+    activeTabType: 'terminal',
+    activeTabId: tabId,
+    activeTabIdByWorktree: { 'wt-1': tabId },
+    tabsByWorktree: {
+      'wt-1': [
+        {
+          id: tabId,
+          ptyId: 'pty-1',
+          worktreeId: 'wt-1',
+          title: 'shell',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }
+      ]
+    },
+    terminalLayoutsByTabId: {
+      [tabId]: {
+        root: { type: 'leaf', leafId },
+        activeLeafId: leafId,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [leafId]: 'pty-1' }
+      }
+    },
+    ptyIdsByTabId: { [tabId]: ['pty-1'] },
     sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
   } as never)
 }
@@ -112,14 +151,92 @@ describe('resume record absolute expiry', () => {
     expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
   })
 
-  it('leaves an aged completed record for the hibernation paths to own', () => {
+  it('leaves an aged completed record owned by its pane untouched', () => {
+    // Covers the ownership gate, not the done guard: the expiry branch is already
+    // skipped for an owned record whatever its state.
     const capturedAt = NOW - RESUME_RECORD_MAX_AGE_MS - 1
-    const record = makeRecord({ state: 'done', capturedAt, updatedAt: capturedAt })
+    const record = makeRecord({
+      paneKey: OWNED_PANE_KEY,
+      state: 'done',
+      capturedAt,
+      updatedAt: capturedAt
+    })
+    seedWorktreeWithOwnedPane(record)
+
+    expect(resumeSleepingAgentSessionsForWorktree('wt-1')).toBe(0)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+  })
+
+  it('still resumes an aged quit record, which the done guard exempts from expiry', () => {
+    // The only shape that isolates `state !== 'done'` in isExpiredResumeRecord:
+    // unowned (so the expiry branch is reachable) and origin 'quit' (so the
+    // passive-hibernation branch does not clear it first). Drop that guard and
+    // this record is expired instead of resumed.
+    const capturedAt = NOW - RESUME_RECORD_MAX_AGE_MS - 1
+    const record = makeRecord({ state: 'done', origin: 'quit', capturedAt, updatedAt: capturedAt })
     seedWorktreeWithUnownedPane(record)
 
-    // Scope guard: the age bound targets unfinished records. A completed record
-    // is passive hibernation evidence and is retired by its own rules, so this
-    // asserts the bound did not quietly take that decision over.
+    expect(resumeSleepingAgentSessionsForWorktree('wt-1')).toBe(1)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('does not let an expiring record evict a healthy sharer of its claim key', () => {
+    // Both records name the same session, so they share a claim key and the loop
+    // keeps only the "newest active" one. The unfinished record is newer but
+    // expiring; if it is allowed into that map it wins, the quit record is
+    // dropped for not being newest, and then it is itself expired — losing both
+    // with nothing resumed.
+    const quitCapturedAt = NOW - RESUME_RECORD_MAX_AGE_MS - 2_000
+    const expiringCapturedAt = NOW - RESUME_RECORD_MAX_AGE_MS - 1_000
+    const quitRecord = makeRecord({
+      paneKey: 'tab-1:leaf-quit',
+      tabId: 'tab-1',
+      state: 'done',
+      origin: 'quit',
+      capturedAt: quitCapturedAt,
+      updatedAt: quitCapturedAt
+    })
+    const expiringRecord = makeRecord({
+      paneKey: 'tab-1:leaf-expiring',
+      tabId: 'tab-1',
+      capturedAt: expiringCapturedAt,
+      updatedAt: expiringCapturedAt
+    })
+    useAppStore.setState({
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'tab-1',
+            ptyId: null,
+            worktreeId: 'wt-1',
+            title: 'shell',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      sleepingAgentSessionsByPaneKey: {
+        [quitRecord.paneKey]: quitRecord,
+        [expiringRecord.paneKey]: expiringRecord
+      }
+    } as never)
+
+    expect(resumeSleepingAgentSessionsForWorktree('wt-1')).toBe(1)
+    const state = useAppStore.getState()
+    expect(state.sleepingAgentSessionsByPaneKey[expiringRecord.paneKey]).toBeUndefined()
+  })
+
+  it('keeps an aged unfinished record whose pane is still owned', () => {
+    // Only an orphan is dead weight. A live pane still owns its session even if
+    // its agent stopped reporting, so expiring the record would delete the
+    // evidence that pane needs to recover.
+    const capturedAt = NOW - RESUME_RECORD_MAX_AGE_MS - 1
+    const record = makeRecord({ paneKey: OWNED_PANE_KEY, capturedAt, updatedAt: capturedAt })
+    seedWorktreeWithOwnedPane(record)
+
     expect(resumeSleepingAgentSessionsForWorktree('wt-1')).toBe(0)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
   })
 })

--- a/src/renderer/src/lib/resume-sleeping-agent-session-remote-compat.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-remote-compat.test.ts
@@ -2,6 +2,9 @@ import { afterEach, describe, expect, it } from 'vitest'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
 import { useAppStore } from '@/store'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 const initialState = useAppStore.getState()
 

--- a/src/renderer/src/lib/resume-sleeping-agent-session-replay.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-replay.test.ts
@@ -4,6 +4,9 @@ import { useAppStore } from '@/store'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
 import { launchAiVaultSessionInNewTab } from './launch-ai-vault-session'
 import { buildWorkspaceSessionPayload } from './workspace-session'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 const initialAppStoreState = useAppStore.getState()
 

--- a/src/renderer/src/lib/resume-sleeping-agent-session-slept-pane-recovery.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-slept-pane-recovery.test.ts
@@ -3,6 +3,9 @@ import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-r
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import { useAppStore } from '@/store'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 const initialAppStoreState = useAppStore.getState()
 const LEAF_ID = '33333333-3333-4333-8333-333333333333'

--- a/src/renderer/src/lib/resume-sleeping-agent-session-suppress-navigation.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-suppress-navigation.test.ts
@@ -3,6 +3,9 @@ import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-r
 import { useAppStore } from '@/store'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
 import { getProviderSessionClaimKey } from './sleeping-agent-pane-ownership'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 const initialAppStoreState = useAppStore.getState()
 

--- a/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
@@ -4,6 +4,9 @@ import { makePaneKey } from '../../../shared/stable-pane-id'
 import { parseWorkspaceSession } from '../../../shared/workspace-session-schema'
 import { useAppStore } from '@/store'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 const initialAppStoreState = useAppStore.getState()
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -132,22 +132,14 @@ function activeOrQueuedResumeClaimsProviderSession(
   return false
 }
 
-/**
- * Absolute age after which an unfinished resume record stops being a resume candidate.
- *
- * Why this exists on top of the staleness check below: that check compares two timestamps
- * captured together, so it measures how long the agent had been silent *at capture time* and
- * never how long the record has since been sitting there. A live capture writes `capturedAt`
- * from the same value as `updatedAt`, which makes the difference ~0 no matter how old the
- * record gets. Without an absolute bound, any agent that ends without a confirmable exit
- * transition — SIGKILL, force quit, host reboot, a status hook that never fires — leaves a
- * record that stays a valid resume candidate forever.
- *
- * Why a week: the surrounding intent is deliberately permissive about resuming interrupted
- * turns, and the cost of expiring too early is small — the transcript survives and the session
- * can still be resumed by hand — while the cost of never expiring is an unattended relaunch.
- */
+// Why: the staleness check below compares two timestamps stamped together, so it never sees how
+// long a record has since sat. Without an absolute bound, an agent that ends with no observable
+// exit — SIGKILL, force quit, reboot, a missed hook — stays resumable forever.
 export const RESUME_RECORD_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+
+function isExpiredResumeRecord(record: SleepingAgentSessionRecord): boolean {
+  return record.state !== 'done' && Date.now() - record.capturedAt > RESUME_RECORD_MAX_AGE_MS
+}
 
 // Why: an interrupted turn is still resumable — `claude --resume` reopens the transcript at the
 // prompt — so discarding those records only stranded the session across wake and restart.
@@ -155,13 +147,9 @@ function isInvalidWorktreeActivationRecord(record: SleepingAgentSessionRecord): 
   if (!record.origin && record.state === 'done') {
     return true
   }
-  if (record.state === 'done') {
-    return false
-  }
-  if (record.capturedAt - record.updatedAt > AGENT_STATUS_STALE_AFTER_MS) {
-    return true
-  }
-  return Date.now() - record.capturedAt > RESUME_RECORD_MAX_AGE_MS
+  return (
+    record.state !== 'done' && record.capturedAt - record.updatedAt > AGENT_STATUS_STALE_AFTER_MS
+  )
 }
 
 function parkWorktreeResumeSweepUntilHostMirrorHydrates(
@@ -196,7 +184,12 @@ export function resumeSleepingAgentSessionsForWorktree(
     .filter((record) => record.worktreeId === worktreeId)
     .sort((a, b) => a.capturedAt - b.capturedAt || a.updatedAt - b.updatedAt)
   const validWorktreeRecords = worktreeRecords.filter(
-    (record) => !isInvalidWorktreeActivationRecord(record)
+    // Why the expiry arm: these maps decide which record owns a claim key, and the loop clears
+    // orphaned expired records anyway. Leaving one in lets it win "newest" and evict a healthy
+    // sharer — a quit or interrupted record — that would otherwise have resumed.
+    (record) =>
+      !isInvalidWorktreeActivationRecord(record) &&
+      !(isExpiredResumeRecord(record) && !recordPaneIsOwnedByPreservedPane(record, state))
   )
   const activeWorktreeRecords = validWorktreeRecords.filter(
     (record) => !isPassiveCompletedHibernationEvidence(record)
@@ -238,6 +231,13 @@ export function resumeSleepingAgentSessionsForWorktree(
       continue
     }
     const isPaneOwned = recordPaneIsOwnedByPreservedPane(record, currentState)
+    // Why here: only an orphan expires. Running past hydration keeps an unverifiable host from
+    // losing its evidence to the clock, and running past ownership keeps a live pane's evidence
+    // even when its agent stopped reporting — the record is only dead weight once neither holds.
+    if (!isPaneOwned && isExpiredResumeRecord(record)) {
+      state.clearSleepingAgentSession(record.paneKey)
+      continue
+    }
     if (isPassiveCompletedHibernationEvidence(record)) {
       // Why: completed-agent hibernation is passive history; activation should
       // only keep displayable evidence, never start new work from it.

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -132,15 +132,36 @@ function activeOrQueuedResumeClaimsProviderSession(
   return false
 }
 
+/**
+ * Absolute age after which an unfinished resume record stops being a resume candidate.
+ *
+ * Why this exists on top of the staleness check below: that check compares two timestamps
+ * captured together, so it measures how long the agent had been silent *at capture time* and
+ * never how long the record has since been sitting there. A live capture writes `capturedAt`
+ * from the same value as `updatedAt`, which makes the difference ~0 no matter how old the
+ * record gets. Without an absolute bound, any agent that ends without a confirmable exit
+ * transition — SIGKILL, force quit, host reboot, a status hook that never fires — leaves a
+ * record that stays a valid resume candidate forever.
+ *
+ * Why a week: the surrounding intent is deliberately permissive about resuming interrupted
+ * turns, and the cost of expiring too early is small — the transcript survives and the session
+ * can still be resumed by hand — while the cost of never expiring is an unattended relaunch.
+ */
+export const RESUME_RECORD_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+
 // Why: an interrupted turn is still resumable — `claude --resume` reopens the transcript at the
 // prompt — so discarding those records only stranded the session across wake and restart.
 function isInvalidWorktreeActivationRecord(record: SleepingAgentSessionRecord): boolean {
   if (!record.origin && record.state === 'done') {
     return true
   }
-  return (
-    record.state !== 'done' && record.capturedAt - record.updatedAt > AGENT_STATUS_STALE_AFTER_MS
-  )
+  if (record.state === 'done') {
+    return false
+  }
+  if (record.capturedAt - record.updatedAt > AGENT_STATUS_STALE_AFTER_MS) {
+    return true
+  }
+  return Date.now() - record.capturedAt > RESUME_RECORD_MAX_AGE_MS
 }
 
 function parkWorktreeResumeSweepUntilHostMirrorHydrates(

--- a/src/renderer/src/lib/serve-desktop-promotion-session-continuity.test.ts
+++ b/src/renderer/src/lib/serve-desktop-promotion-session-continuity.test.ts
@@ -31,6 +31,9 @@ import {
   shouldBypassSingleInstanceLock,
   shouldSkipSingleInstanceLock
 } from '../../../main/startup/single-instance-lock'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 const WORKTREE_ID = 'wt-serve-promotion'
 const AGENT_PANES = [

--- a/src/renderer/src/lib/worktree-activation-created-agent.test.ts
+++ b/src/renderer/src/lib/worktree-activation-created-agent.test.ts
@@ -10,6 +10,9 @@ import {
   seedAlreadyActiveWorktree,
   seedEmptyActivatableWorktree
 } from '@/lib/worktree-activation-created-agent-test-state'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 const initialAppStoreState = useAppStore.getState()
 

--- a/src/renderer/src/lib/worktree-reactivation-preserved-pane-replacement.test.ts
+++ b/src/renderer/src/lib/worktree-reactivation-preserved-pane-replacement.test.ts
@@ -10,6 +10,9 @@ import {
   markHostSessionMirrorHydrated,
   resetHostSessionMirrorHydrationForTests
 } from '@/runtime/host-session-mirror-hydration'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 // Pins the activation contract behind the run6-review-pr-11959 incident shape:
 // a persisted (husk) tab whose pane cannot resume in place gets ONE appended

--- a/src/renderer/src/lib/worktree-reactivation-runtime-owned-resume-deferral.test.ts
+++ b/src/renderer/src/lib/worktree-reactivation-runtime-owned-resume-deferral.test.ts
@@ -4,6 +4,9 @@ import { useAppStore, type AppState } from '@/store'
 import { activateAndRevealWorktree } from './worktree-activation'
 import { makeCreatedAgentWorktree } from '@/lib/worktree-activation-created-agent-test-state'
 import { makePaneKey } from '../../../shared/stable-pane-id'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 // Red repro for the aug20 "windows 2" incident (restart-reattach/resume-relaunch):
 // a runtime-owned (paired remote) worktree's web-mirror tab holds a sleeping

--- a/src/renderer/src/lib/worktree-reactivation-tab-forkbomb.test.ts
+++ b/src/renderer/src/lib/worktree-reactivation-tab-forkbomb.test.ts
@@ -3,6 +3,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore, type AppState } from '@/store'
 import { activateAndRevealWorktree } from './worktree-activation'
 import { makeCreatedAgentWorktree as makeWorktree } from '@/lib/worktree-activation-created-agent-test-state'
+import { pinResumeRecordClock } from './resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 const initialAppStoreState = useAppStore.getState()
 

--- a/src/renderer/src/runtime/host-session-mirror-hydration-frame-ordering.test.tsx
+++ b/src/renderer/src/runtime/host-session-mirror-hydration-frame-ordering.test.tsx
@@ -74,6 +74,9 @@ import {
 } from './web-session-tabs-sync'
 import { hasHostSessionMirrorHydrated } from './host-session-mirror-hydration'
 import { WINDOW_VISIBILITY_SUBSCRIPTION_PARK_DELAY_MS } from './window-visibility-subscription-parking'
+import { pinResumeRecordClock } from '@/lib/resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 /**
  * Parked waiters drain synchronously, so a settle placed before its frame's

--- a/src/renderer/src/runtime/host-session-mirror-settle-receipt-frames.test.tsx
+++ b/src/renderer/src/runtime/host-session-mirror-settle-receipt-frames.test.tsx
@@ -75,6 +75,9 @@ import {
   WEB_SESSION_TABS_VISIBILITY_RESUME_STAGGER_MS
 } from './web-session-tabs-sync'
 import { WINDOW_VISIBILITY_SUBSCRIPTION_PARK_DELAY_MS } from './window-visibility-subscription-parking'
+import { pinResumeRecordClock } from '@/lib/resume-record-clock-test-fixture'
+
+pinResumeRecordClock()
 
 /**
  * The receipt era of the same seam: a settle exists only as the proof of a


### PR DESCRIPTION
## ELI5

Orca remembers "this pane had an agent running" so it can bring the session back later. That memory currently has no expiry date. If an agent ends in a way Orca cannot observe — killed, force quit, machine rebooted, status hook missed — the note is kept forever, and the next time you open that workspace Orca starts the agent again from a session that has been dead for days. This adds an expiry date to the note.

## What Changed

`isInvalidWorktreeActivationRecord` gains an absolute age bound alongside the existing relative staleness check. A record that is not `done` and was captured more than `RESUME_RECORD_MAX_AGE_MS` (7 days) ago is invalid.

Nothing else in the resume flow changes: an invalid record is already cleared rather than merely skipped, so expiring one both prevents the relaunch and drops the record.

## Why

The existing guard only fires when a record was *already* stale at the instant it was captured:

```ts
record.state !== 'done' && record.capturedAt - record.updatedAt > AGENT_STATUS_STALE_AFTER_MS
```

For a live capture, `capturedAt` is stamped from the same value as `updatedAt`, so that difference is ~0 no matter how long the record has since sat there — and nothing in the predicate compares against the present at all. Record age is therefore never considered.

Measured on one profile: **every** record showed a `capturedAt - updatedAt` of 0.0–0.2 min, including one captured **235 hours** earlier that was still a fully valid resume candidate. Nine records whose panes no longer existed had accumulated, ranging 47–235 h.

**Why this is not covered by #14534.** Retiring the record on a process-confirmed agent exit is the right primary fix and covers the reported repro. It cannot cover the class where no exit transition is ever emitted — SIGKILL, force quit, host reboot, a status hook that does not fire. You cannot detect an event that was never emitted; only elapsed time bounds that class. The two changes are complementary and touch different files.

**Why this repairs existing installs, not just new ones.** Because the caller clears rather than skips, an install that has already accumulated orphans drops them at the next worktree activation — no migration, no user action, and specifically no app restart, which is the one remedy unavailable to anyone with a live fleet running.

**Why a week.** The surrounding comment is deliberately permissive about resuming interrupted turns, so the bound should be generous. The asymmetry favours it: expiring early costs only *automatic* resume — the transcript survives and `--resume <id>` still works by hand — while never expiring means an unattended relaunch. Happy to change the window; it is a single constant.

**Scope.** The bound deliberately does not touch `done` records, which passive hibernation evidence already owns. That is asserted by a test.

## Linked Issue

Relates to #14228. Deliberately **not** marked `Fixes`: that issue's primary repro is a clean exit, which #14534 addresses. This closes the residual class that survives an exit-detection fix, which is the gap raised in the issue's most recent analysis comment.

## Visual Proof

`N/A` — no UI or interaction surface. The observable difference is that a worktree activation does not spawn a tab for a week-old record.

## Testing

New suite `resume-sleeping-agent-session-record-expiry.test.ts`, five cases:

- a record past the bound is **retired** (cleared from the store), not merely skipped, and no tab is appended
- a record inside the bound still resumes — regression guard for the permissive intent
- a record with `capturedAt === updatedAt` (the exact shape a live capture produces) expires on age, proving the relative check alone cannot catch it
- a record already stale at capture time is still retired by the existing relative check
- an aged `done` record is left to the hibernation paths — scope guard

**Test-fixture note worth flagging for review.** The resume suites date their fixtures from epoch 0 (`capturedAt: 1`, `capturedAt: 2`, …) because they only ever needed relative ordering. An absolute age bound reads those as decades old, which failed 65 tests across 16 suites. Rather than rewriting timestamps in every fixture, this adds a shared `pinResumeRecordClock()` fixture and calls it in the 16 suites that drive record validity — 2 lines each. This cost is inherent to any absolute age bound, not to this particular implementation, so it seemed better to surface it than to hide it behind scattered mocks.

Ran locally on macOS (arm64):

- `vitest run` full suite: **6752 files / 63039 tests passing, 0 test failures**. The only failures are the two `tests/e2e/cross-version-wire/*.unit.test.ts` files, which fail on this checkout because it is a shallow clone with no tags — the harness says so itself (`Cross-version harness found no stable desktop release tags … CI checkouts default to a shallow clone`). Unrelated to this change.
- `tsc --noEmit -p config/tsconfig.tc.web.json`: clean
- `oxlint` + `oxfmt --check` on all changed files: clean (pre-commit hooks also ran them)
- `pnpm build` not run locally; leaving that to CI.

Not manually exercised: SSH/remote and Windows. The change is platform-neutral and touches no path, shell, or process handling.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## Author

X: [@qevan](https://x.com/qevan)

## AI Disclosure

Written with Claude Code (Claude Opus 5) — root-cause analysis, the change, and the tests. Verified against a real profile exhibiting the accumulation described above, and against a full local test run (63k tests).

## Review

- **Cross-platform:** no platform-specific code; a single `Date.now()` comparison. No path, shell, or process handling touched.
- **SSH/remote/local:** the predicate runs before the host-mirror parking branch, so an expired record for a remote pane is retired without waiting on a mirror verdict. That is intended — a record older than the window should not hold a resume open — but it is the one behavioural interaction worth a reviewer's eye, since a host offline longer than the window will have its records retired.
- **Agent/integration compatibility:** provider-neutral; the record shape and predicate are agent-agnostic.
- **Performance:** one clock read per record in a sweep that already iterates them; no new allocation or I/O.
- **Security:** reduces exposure rather than adding it — an unattended resume inherits `YOLO_TUI_AGENT_ARGS` (`--dangerously-skip-permissions` for Claude), so a week-old session relaunching without a prompt gate acts on a worktree whose state has moved on.
- **UI:** none.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

The window is a single exported constant, and the placement (activation-time predicate vs. a prune at session hydration) is the other reasonable shape — happy to move it if you prefer that.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally (`pnpm build` left to CI)
