### PR TITLE
test(automations): cover editor reference-error paths

### DIFF
--- a/src/renderer/src/components/automations/AutomationsPage.test.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.test.tsx
@@ -164,6 +164,14 @@ describe('AutomationsPage list rendering', () => {
     // first row and the user's edit appears to open someone else's automation.
     expect(api.automations.updateExternalForOwner).toHaveBeenCalled()
     expect(mocks.listPanel?.selectedExternal?.key).toBe(entry.key)
+    expect(mocks.editorDialog?.draft).toMatchObject({
+      name: 'Hermes job',
+      prompt: 'Sweep',
+      agentId: 'hermes',
+      preset: 'custom',
+      customSchedule: '0 9 * * *',
+      scheduleWarning: null
+    })
   })
 
   it('routes each authority’s action to its own host when both report hermes:local', async () => {
@@ -373,6 +381,18 @@ describe('AutomationsPage mutations', () => {
     // Step 6: hydration re-reads the row's own scope; the ambient list is untouched.
     expect(api.automations.list).not.toHaveBeenCalled()
     expect(api.automations.listScoped).toHaveBeenCalledWith({ selector: { kind: 'self' } })
+    expect(mocks.editorDialog?.open).toBe(true)
+    expect(mocks.editorDialog?.isEditing).toBe(true)
+  })
+
+  it('opens the editor for a legacy row without a captured owner', async () => {
+    api.automations.listScoped.mockRejectedValue(new Error('offline'))
+
+    await renderPage()
+    await act(async () => {
+      mocks.listPanel?.openEditDialog(listedRow('a-1'))
+    })
+
     expect(mocks.editorDialog?.open).toBe(true)
     expect(mocks.editorDialog?.isEditing).toBe(true)
   })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Orca can open an automation for editing, including ones created by older versions of Orca and ones
created outside Orca. Filling that edit form in from the saved automation was broken; the fix is
already on `main`. This PR adds the tests that prove the form comes back filled in correctly, so the
same breakage cannot return unnoticed.

## User-facing before / after

| | Before | After |
|---|---|---|
| Anything you do in the app | — | **No change.** This PR is test coverage only; the behaviour fix already shipped |
| (Context) Opening an older or externally-created automation for editing | Its schedule and prompt did not come back into the form correctly | Already fixed on `main`; this pins that behaviour with a test that fails without the fix |

## When it bites

Nobody today. The value is that the fix now has a regression test behind it.


## Summary
- add regression coverage for legacy Orca edit rows and external Hermes edit draft hydration
- assert derived external draft schedule and prompt fields

## Context
The production fix is already on main (imports `getAutomationOwnerTarget` and centralizes external draft construction); this PR adds failing-first regression coverage for STA-5621.

## Verification
- focused AutomationsPage tests
- pnpm tc
- oxlint and oxfmt

STA-5621
