### PR TITLE
test(orchestration): pin recoverable worker start receipt (STA-4674)

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -11715,6 +11715,7 @@
         "https://linear.app/stably/issue/STA-3800",
         "https://linear.app/stably/issue/STA-3904",
         "https://linear.app/stably/issue/STA-4328",
+        "https://linear.app/stably/issue/STA-4674",
         "https://github.com/stablyai/orca/issues/7226",
         "https://github.com/stablyai/orca/issues/13821",
         "https://github.com/stablyai/orca/issues/14347"
@@ -11724,6 +11725,7 @@
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-prompt-injection.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts src/main/runtime/orchestration/coordinator.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/orchestration-worker-start-prompt-contract.test.ts --reporter=dot",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts --reporter=dot",
         "node tests/tools/repro-orchestration-long-prompt.mjs --cli out/bin/orca-dev --mode codex-like --size-kb 32 --timeout-ms 20000"
       ],
       "testFiles": [
@@ -11731,6 +11733,7 @@
         "src/main/runtime/orca-runtime.test.ts",
         "src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts",
         "src/main/runtime/rpc/methods/orchestration-worker-start-prompt-contract.test.ts",
+        "src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts",
         "src/main/runtime/orchestration/coordinator.test.ts",
         "tests/tools/repro-orchestration-long-prompt.mjs"
       ],
@@ -11773,6 +11776,12 @@
           ]
         },
         {
+          "file": "src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts",
+          "assertions": [
+            "an unobserved new-child prompt acceptance retains its exact assignee, capability, owned terminal resource, and one-send effects until authenticated worker_done settles the Dispatch"
+          ]
+        },
+        {
           "file": "src/main/runtime/orchestration/coordinator.test.ts",
           "assertions": [
             "coordinator dispatch failures from prompt injection circuit-break through the DB",
@@ -11789,6 +11798,15 @@
         }
       ],
       "evidenceRuns": [
+        {
+          "date": "2026-08-27",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts --reporter=dot",
+          "result": "passed",
+          "durationSeconds": 32.1,
+          "summary": "Twenty-one new-worktree worker-start contracts passed, including a new-child prompt whose unobserved acceptance retained the exact assignee, capability, owned terminal resource, and one-send effects until authenticated worker_done settled the Dispatch."
+        },
         {
           "date": "2026-08-23",
           "runner": "local",

--- a/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
@@ -522,6 +522,71 @@ describe('orchestration new-worktree workers', () => {
     expect(db.getTask(task.id)?.status).toBe('blocked')
   })
 
+  it('keeps new-child authority recoverable when prompt acceptance is unobserved', async () => {
+    mockCreatedWorktree({ hookFound: false })
+    vi.mocked(runtime.sendTerminalAgentPrompt).mockRejectedValueOnce(
+      new Error('agent_prompt_stalled')
+    )
+
+    const { result, task } = await startWorker({ name: 'recoverable-input-worker' })
+    const dispatchId = (result as { dispatchId: string }).dispatchId
+
+    expect(result).toMatchObject({
+      state: 'failed',
+      failedStage: 'dispatch_input',
+      lastError: 'agent_prompt_stalled',
+      residualResources: expect.arrayContaining([
+        expect.objectContaining({ kind: 'worktree', id: 'repo::created' }),
+        expect.objectContaining({ kind: 'terminal', id: 'term_worker' })
+      ])
+    })
+    expect(db.getDispatchContextById(dispatchId)).toMatchObject({
+      assignee_handle: 'term_worker',
+      status: 'failed',
+      capability_hash: expect.any(String),
+      capability_revoked_at: null
+    })
+    expect(db.getWorkerTerminalResourceByOwner(dispatchId)).toMatchObject({
+      terminal_handle: 'term_worker',
+      ownership_state: 'owned'
+    })
+    const prompt = vi.mocked(runtime.sendTerminalAgentPrompt).mock.calls[0]?.[1] ?? ''
+    const capability = prompt.match(/--dispatch-capability (dcap_[A-Za-z0-9_-]+)/)?.[1]
+    if (!capability) {
+      throw new Error('Worker preamble did not carry its Dispatch capability.')
+    }
+    const send = ORCHESTRATION_METHODS.find((candidate) => candidate.name === 'orchestration.send')
+    if (!send?.params) {
+      throw new Error('orchestration.send method is not registered')
+    }
+    const report = await send.handler(
+      send.params.parse({
+        from: 'term_worker',
+        subject: 'Worker recovered the start receipt',
+        body: 'worker received the prompt',
+        type: 'worker_done',
+        payload: JSON.stringify({
+          taskId: task.id,
+          dispatchId,
+          outcome: 'succeeded'
+        })
+      }),
+      { runtime, orchestrationCapability: capability }
+    )
+    expect(report).toMatchObject({ lifecycle: { action: 'completed' } })
+    const settledTask = db.getTask(task.id)
+    expect(settledTask?.status).toBe('completed')
+    expect(JSON.parse(settledTask?.result ?? 'null')).toMatchObject({
+      provenance: 'worker_report',
+      outcome: 'succeeded',
+      body: 'worker received the prompt'
+    })
+    expect(db.getDispatchContextById(dispatchId)?.status).toBe('completed')
+    expect(db.getWorkerDispatch(dispatchId)).toMatchObject({ state: 'succeeded', stage: 'settled' })
+    expect(runtime.createManagedWorktree).toHaveBeenCalledOnce()
+    expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledOnce()
+  })
+
   it('persists the retry request with the starting Dispatch before worktree effects', async () => {
     const task = db.createTask({ spec: 'atomic worker acceptance', runId })
     let finishCreate: ((value: CreateWorktreeResult) => void) | undefined


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |

<!-- /orca-pr-loc -->

## ELI5

Orca could successfully send an agent its task but briefly report that startup failed because it could not confirm the agent accepted the prompt. Retrying could then start duplicate work even though the first agent was already running.

The actual behavior fix is already on `main`. This PR only adds a regression test proving Orca keeps control of the original running agent so it can finish safely. Merging this PR improves protection against the bug returning; it does not change user behavior by itself.

## User-facing before / after

| | Before | After |
|---|---|---|
| Anything you do in the app or the CLI | — | **No change.** This PR adds a test only |
| (Context — what the already-shipped fix does) Orca sends a worker agent its task but can't confirm the agent read it | Orca reported that startup failed and let go of its handle on that agent. A retry could then start the same work a second time, with the first agent still running | The receipt says the confirmation failed, but Orca keeps the assignee, the permission handle and the worker's terminal until the worker itself reports back — so a retry can't double-start |

## When it bites

Nobody directly, today. This PR exists so the behaviour above cannot quietly regress; the honest
limits of what it proves are in the "Residual gaps" note below.


## Root-Cause Classification

**Classification: This PR adds regression proof for a root-cause production fix already on `main`; it does not itself change production behavior and is not a mitigation patch.**

**Production fix already on `main`:** #16590 (`68d5b9206e`) fixed the causal failure chain behind STA-4674: post-Enter verification could misread an already-delivered prompt as stalled, then re-paste work, revoke the bound capability, and reject the live worker report. It expanded valid acceptance evidence and made residual `agent_prompt_stalled` outcomes non-destructive by retaining the exact assignee, capability, and owned terminal until authenticated settlement.

**Scope of this PR:** one new-child `worker-start` failing-first regression oracle plus reliability-gate registration. It forces the remaining unobserved-acceptance path and proves that the authority established before prompt verification survives through a one-send authenticated `worker_done`; there is no runtime or product-code change here.

**Residual gaps:** a genuinely unobserved acceptance can still return `state: failed`, `failedStage: dispatch_input`, and `lastError: agent_prompt_stalled`, so this PR does not guarantee an `ok: true` / `status: dispatched` receipt in every environment. Before the final `worker_done` corrects that record, non-final lifecycle interactions such as questions and heartbeats remain outside this oracle; readiness failures before authority binding and argv-based startup are also outside scope and are being addressed separately in #16548. Validation here is deterministic and local: there was no live Windows, WSL, SSH, Claude, or other non-Codex provider reproduction.

## What Changed

- Added an issue-specific new-child worker-start regression that simulates an unobserved prompt acceptance after worktree, terminal, capability, and input effects exist.
- Proved the receipt reports the failed dispatch-input observation while retaining the exact assignee, capability, and owned worker resource until authenticated `worker_done` settlement.
- Registered the oracle and its successful run in the orchestration prompt-delivery reliability gate.

## Why

STA-4674 exposed a dangerous commit boundary: prompt input was committed before submission verification, but a false `agent_prompt_stalled` verdict then failed the Dispatch and revoked its capability. The worker could already be executing, leaving callers unable to distinguish confirmed failure from an outcome-unknown effect and making retries unsafe. The production recovery behavior landed in #16590; this focused PR pins that contract against regression.

## Linked Issue

[STA-4674](https://linear.app/stably/issue/STA-4674)

Author: @BrennanKB5

## Visual Proof

N/A — this is deterministic orchestration contract coverage with no rendered UI change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- Failing-first: temporarily restored capability revocation after `agent_prompt_stalled`; the new test failed on non-null `capability_revoked_at`. Restoring the production behavior passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts --reporter=dot` — 21/21 passed in 32.10s.
- Broader orchestration matrix — 15 files, 135/135 passed across new/current worktrees, folder placement, federation, SSH compatibility, Windows submit/ask behavior, mutation replay, and lifecycle settlement.
- Live CLI: current-worktree Codex start returned `ready` / `input_accepted` with a non-null assignee and capability; replaying the request ID returned the same Dispatch with `mutation.replayed: true`; authenticated completion succeeded.
- `pnpm tc`
- `npm_config_loglevel=error pnpm run check:code-quality:changed`
- `pnpm run check:reliability-gates`
- `pnpm run check:max-lines-ratchet`
- `git diff --check`

Actual live validation was on macOS. Windows/WSL/SSH and provider-neutral routing are covered by deterministic suites; no live Windows/WSL/SSH or Claude launch was performed in this evidence-only PR.

## Review

Three independent adversarial reviews were run. The reliability evidence-run omission and an initial direct-settlement shortcut were fixed; the final review-until-clean pass reported no in-scope findings.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

This is test and reliability-gate metadata only: no production hot path, wire contract, UI, polling, subprocess, listener, resource lifetime, or mobile behavior changes. Runtime performance overhead is zero. The residual compatibility risk is limited to test fidelity across live Windows/WSL/SSH hosts and non-Codex providers; existing platform and federation suites provide deterministic coverage.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Relevant typecheck, focused tests, changed-code quality, reliability gates, max-lines, and diff checks pass; CI will cover the full build and repo-wide suites

