### PR TITLE
Enforce complete TypeScript coverage

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
 
       - name: Load base mobile diagnostic baseline
         env:

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -34,6 +34,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Load base mobile diagnostic baseline
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git cat-file -e "$BASE_SHA^{commit}"
+          if git cat-file -e "$BASE_SHA:mobile/typecheck-test-diagnostics.json" 2>/dev/null; then
+            base_baseline="$RUNNER_TEMP/typecheck-mobile-base.json"
+            git show "$BASE_SHA:mobile/typecheck-test-diagnostics.json" > "$base_baseline"
+            echo "TYPECHECK_BASELINE_BASE_PATH=$base_baseline" >> "$GITHUB_ENV"
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -12,6 +12,13 @@ on:
       # Why: the mobile terminal link parsers are conformance-tested against
       # these shared fixtures; desktop-side fixture edits must re-run this suite.
       - 'src/shared/terminal-file-link-conformance.ts'
+      # Why all of src/shared: mobile's tsconfig pulls 300+ files from it, and the
+      # typecheck baseline now matches on message text, so a desktop-side rename can
+      # reword a mobile diagnostic and redden this job for an unrelated author.
+      - 'src/shared/**'
+      # Why: the mobile typecheck runs through this script and its baseline.
+      - 'config/scripts/typecheck-diagnostic-baseline.mjs'
+      - 'mobile/typecheck-test-diagnostics.json'
       # Why: this job holds the only checks that load the Fastfile, so edits to
       # it or to the release workflow it guards must re-run them.
       - '.github/workflows/mobile.yml'
@@ -44,10 +51,20 @@ jobs:
         run: |
           set -euo pipefail
           git cat-file -e "$BASE_SHA^{commit}"
-          if git cat-file -e "$BASE_SHA:mobile/typecheck-test-diagnostics.json" 2>/dev/null; then
+          # Why ls-tree --full-tree: it answers "does the base have this file" from tree
+          # objects alone, so a missing baseline is distinguishable from a git failure.
+          # Anything other than a clean absence aborts the step rather than silently
+          # leaving the growth guard unset, which would pass as "no drift".
+          # Why a bare assignment: inside `[ -n "$(...)" ]` the substitution's exit status
+          # is discarded, so a git failure would read as "base has no baseline" and pass.
+          base_entry="$(git ls-tree -r --full-tree --name-only "$BASE_SHA" -- mobile/typecheck-test-diagnostics.json)"
+          if [ -n "$base_entry" ]; then
             base_baseline="$RUNNER_TEMP/typecheck-mobile-base.json"
             git show "$BASE_SHA:mobile/typecheck-test-diagnostics.json" > "$base_baseline"
             echo "TYPECHECK_BASELINE_BASE_PATH=$base_baseline" >> "$GITHUB_ENV"
+            echo "Mobile growth guard ACTIVE against $BASE_SHA."
+          else
+            echo "Mobile base has no baseline; this is the introducing PR, growth guard INACTIVE."
           fi
 
       - name: Setup Node.js

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -64,7 +64,7 @@ jobs:
             echo "TYPECHECK_BASELINE_BASE_PATH=$base_baseline" >> "$GITHUB_ENV"
             echo "Mobile growth guard ACTIVE against $BASE_SHA."
           else
-            echo "Mobile base has no baseline; this is the introducing PR, growth guard INACTIVE."
+            echo "::warning::Mobile growth guard INACTIVE: base $BASE_SHA has no baseline yet. Expected only on the PR that introduces it."
           fi
 
       - name: Setup Node.js

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -232,7 +232,7 @@ jobs:
             echo "TYPECHECK_BASELINE_BASE_PATH=$base_baseline" >> "$GITHUB_ENV"
             echo "E2E growth guard ACTIVE against $BASE_SHA."
           else
-            echo "E2E base has no baseline; this is the introducing PR, growth guard INACTIVE."
+            echo "::warning::E2E growth guard INACTIVE: base $BASE_SHA has no baseline yet. Expected only on the PR that introduces it."
           fi
 
       - uses: ./.github/actions/install-node-dependencies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -219,10 +219,20 @@ jobs:
         run: |
           set -euo pipefail
           git cat-file -e "$BASE_SHA^{commit}"
-          if git cat-file -e "$BASE_SHA:config/typecheck-e2e-diagnostics.json" 2>/dev/null; then
+          # Why ls-tree --full-tree: it answers "does the base have this file" from tree
+          # objects alone, so a missing baseline is distinguishable from a git failure.
+          # Anything other than a clean absence aborts the step rather than silently
+          # leaving the growth guard unset, which would pass as "no drift".
+          # Why a bare assignment: inside `[ -n "$(...)" ]` the substitution's exit status
+          # is discarded, so a git failure would read as "base has no baseline" and pass.
+          base_entry="$(git ls-tree -r --full-tree --name-only "$BASE_SHA" -- config/typecheck-e2e-diagnostics.json)"
+          if [ -n "$base_entry" ]; then
             base_baseline="$RUNNER_TEMP/typecheck-e2e-base.json"
             git show "$BASE_SHA:config/typecheck-e2e-diagnostics.json" > "$base_baseline"
             echo "TYPECHECK_BASELINE_BASE_PATH=$base_baseline" >> "$GITHUB_ENV"
+            echo "E2E growth guard ACTIVE against $BASE_SHA."
+          else
+            echo "E2E base has no baseline; this is the introducing PR, growth guard INACTIVE."
           fi
 
       - uses: ./.github/actions/install-node-dependencies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -209,7 +209,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
           persist-credentials: false
 
       - name: Load base E2E diagnostic baseline

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -209,7 +209,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          fetch-depth: 2
           persist-credentials: false
+
+      - name: Load base E2E diagnostic baseline
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git cat-file -e "$BASE_SHA^{commit}"
+          if git cat-file -e "$BASE_SHA:config/typecheck-e2e-diagnostics.json" 2>/dev/null; then
+            base_baseline="$RUNNER_TEMP/typecheck-e2e-base.json"
+            git show "$BASE_SHA:config/typecheck-e2e-diagnostics.json" > "$base_baseline"
+            echo "TYPECHECK_BASELINE_BASE_PATH=$base_baseline" >> "$GITHUB_ENV"
+          fi
 
       - uses: ./.github/actions/install-node-dependencies
 

--- a/config/scripts/electron-vite-output-contract.test.ts
+++ b/config/scripts/electron-vite-output-contract.test.ts
@@ -72,6 +72,10 @@ function failBootstrapWithBanner(options: {
   return processMock
 }
 
+function invokeScheduledCallback(callback: (() => void) | null): void {
+  callback?.()
+}
+
 describe('Electron Vite output contract', () => {
   it('keeps main-process and plain-Node entries at stable CommonJS paths', () => {
     const output = electronViteConfig.main?.build?.rollupOptions?.output
@@ -98,12 +102,20 @@ describe('Electron Vite output contract', () => {
     expect(external('@xterm/addon-serialize', undefined, false)).toBe(false)
     expect(external('psl', undefined, false)).toBe(false)
     expect(external('zod', undefined, false)).toBe(false)
-    expect(electronViteConfig.main?.build?.externalizeDeps?.exclude).toContain('psl')
-    expect(electronViteConfig.main?.build?.externalizeDeps?.exclude).toContain('zod')
+    const externalizeDeps = electronViteConfig.main?.build?.externalizeDeps
+    if (!externalizeDeps || typeof externalizeDeps === 'boolean') {
+      throw new Error('Expected main-process externalizeDeps options')
+    }
+    expect(externalizeDeps.exclude).toContain('psl')
+    expect(externalizeDeps.exclude).toContain('zod')
   })
 
   it('bundles validation dependencies used by the sandboxed preload', () => {
-    expect(electronViteConfig.preload?.build?.externalizeDeps?.exclude).toContain('zod')
+    const externalizeDeps = electronViteConfig.preload?.build?.externalizeDeps
+    if (!externalizeDeps || typeof externalizeDeps === 'boolean') {
+      throw new Error('Expected preload externalizeDeps options')
+    }
+    expect(externalizeDeps.exclude).toContain('zod')
   })
 
   it('exits when a static import fails before source error guards load', () => {
@@ -136,7 +148,7 @@ describe('Electron Vite output contract', () => {
 
     expect(processMock.exitCode).toBe(1)
     expect(scheduledExit).not.toBeNull()
-    scheduledExit?.()
+    invokeScheduledCallback(scheduledExit)
     expect(exitedWith).toBe(1)
     expect(context).toHaveProperty(BOOTSTRAP_FATAL_EXIT_GUARD_KEY)
     expect(stderrWrites.join('')).toContain("Cannot find module 'zod'")

--- a/config/scripts/electron-vite-output-contract.test.ts
+++ b/config/scripts/electron-vite-output-contract.test.ts
@@ -72,10 +72,6 @@ function failBootstrapWithBanner(options: {
   return processMock
 }
 
-function invokeScheduledCallback(callback: (() => void) | null): void {
-  callback?.()
-}
-
 describe('Electron Vite output contract', () => {
   it('keeps main-process and plain-Node entries at stable CommonJS paths', () => {
     const output = electronViteConfig.main?.build?.rollupOptions?.output
@@ -148,7 +144,8 @@ describe('Electron Vite output contract', () => {
 
     expect(processMock.exitCode).toBe(1)
     expect(scheduledExit).not.toBeNull()
-    invokeScheduledCallback(scheduledExit)
+    // Assigned inside the scheduler mock, so tsc narrows it to never here.
+    ;(scheduledExit as (() => void) | null)?.()
     expect(exitedWith).toBe(1)
     expect(context).toHaveProperty(BOOTSTRAP_FATAL_EXIT_GUARD_KEY)
     expect(stderrWrites.join('')).toContain("Cannot find module 'zod'")

--- a/config/scripts/native-chat-live-session-benchmark.ts
+++ b/config/scripts/native-chat-live-session-benchmark.ts
@@ -33,12 +33,13 @@ let checksum = 0
 let expectedChecksum = 0
 let validatedCases = 0
 let cappedCalibrations = 0
+let sessionSink: NativeChatSession | null = null
 let messageArraySink: NativeChatMessage[] | null = null
 let contentSink = ''
 let pendingMatchSink: Set<number> | null = null
 let userRowSink: readonly NativeChatUserRow[] | null = null
 const benchmarkStartedAt = performance.now()
-const getPendingSink = (): Set<number> | null => pendingMatchSink
+const getSinks = () => [sessionSink, pendingMatchSink] as const
 
 function proseFixture(count: number, bytes: number, withTurnId: boolean): NativeChatMessage[] {
   const payload = 'Ab Cd  '.repeat(Math.ceil(bytes / 7)).slice(0, bytes)
@@ -127,6 +128,7 @@ function messageWeight(message: NativeChatMessage, content: string): number {
 }
 
 function consumeSession(session: NativeChatSession, index: number): number {
+  sessionSink = session
   messageArraySink = session.messages
   const message = session.messages[index % session.messages.length]
   if (!message) {
@@ -325,9 +327,10 @@ benchmark(
 )
 
 strictEqual(checksum, expectedChecksum, 'benchmark checksum accounting drifted')
+strictEqual(getSinks()[0]?.sessionId, 'benchmark', 'session outputs did not escape')
 strictEqual(Array.isArray(messageArraySink), true, 'message arrays did not escape')
 strictEqual(contentSink.length > 0, true, 'message content did not escape')
-strictEqual(getPendingSink() instanceof Set, true, 'pending baseline scan did not escape')
+strictEqual(getSinks()[1] instanceof Set, true, 'pending baseline scan did not escape')
 strictEqual(Array.isArray(userRowSink), true, 'user row scan did not escape')
 console.log(
   `validated=${validatedCases} cases, checksum=${checksum}, capped calibrations=${cappedCalibrations}, runtime=${(

--- a/config/scripts/native-chat-live-session-benchmark.ts
+++ b/config/scripts/native-chat-live-session-benchmark.ts
@@ -33,12 +33,12 @@ let checksum = 0
 let expectedChecksum = 0
 let validatedCases = 0
 let cappedCalibrations = 0
-let sessionSink: NativeChatSession | null = null
 let messageArraySink: NativeChatMessage[] | null = null
 let contentSink = ''
 let pendingMatchSink: Set<number> | null = null
 let userRowSink: readonly NativeChatUserRow[] | null = null
 const benchmarkStartedAt = performance.now()
+const getPendingSink = (): Set<number> | null => pendingMatchSink
 
 function proseFixture(count: number, bytes: number, withTurnId: boolean): NativeChatMessage[] {
   const payload = 'Ab Cd  '.repeat(Math.ceil(bytes / 7)).slice(0, bytes)
@@ -127,7 +127,6 @@ function messageWeight(message: NativeChatMessage, content: string): number {
 }
 
 function consumeSession(session: NativeChatSession, index: number): number {
-  sessionSink = session
   messageArraySink = session.messages
   const message = session.messages[index % session.messages.length]
   if (!message) {
@@ -326,10 +325,9 @@ benchmark(
 )
 
 strictEqual(checksum, expectedChecksum, 'benchmark checksum accounting drifted')
-strictEqual(sessionSink?.sessionId, 'benchmark', 'session outputs did not escape')
 strictEqual(Array.isArray(messageArraySink), true, 'message arrays did not escape')
 strictEqual(contentSink.length > 0, true, 'message content did not escape')
-strictEqual(pendingMatchSink instanceof Set, true, 'pending baseline scan did not escape')
+strictEqual(getPendingSink() instanceof Set, true, 'pending baseline scan did not escape')
 strictEqual(Array.isArray(userRowSink), true, 'user row scan did not escape')
 console.log(
   `validated=${validatedCases} cases, checksum=${checksum}, capped calibrations=${cappedCalibrations}, runtime=${(

--- a/config/scripts/native-chat-live-session-benchmark.ts
+++ b/config/scripts/native-chat-live-session-benchmark.ts
@@ -39,7 +39,8 @@ let contentSink = ''
 let pendingMatchSink: Set<number> | null = null
 let userRowSink: readonly NativeChatUserRow[] | null = null
 const benchmarkStartedAt = performance.now()
-const getSinks = () => [sessionSink, pendingMatchSink] as const
+// Sinks are assigned inside benchmark callbacks, so tsc narrows them to never at the asserts.
+const readSinks = () => ({ session: sessionSink, pendingMatch: pendingMatchSink })
 
 function proseFixture(count: number, bytes: number, withTurnId: boolean): NativeChatMessage[] {
   const payload = 'Ab Cd  '.repeat(Math.ceil(bytes / 7)).slice(0, bytes)
@@ -327,10 +328,10 @@ benchmark(
 )
 
 strictEqual(checksum, expectedChecksum, 'benchmark checksum accounting drifted')
-strictEqual(getSinks()[0]?.sessionId, 'benchmark', 'session outputs did not escape')
+strictEqual(readSinks().session?.sessionId, 'benchmark', 'session outputs did not escape')
 strictEqual(Array.isArray(messageArraySink), true, 'message arrays did not escape')
 strictEqual(contentSink.length > 0, true, 'message content did not escape')
-strictEqual(getSinks()[1] instanceof Set, true, 'pending baseline scan did not escape')
+strictEqual(readSinks().pendingMatch instanceof Set, true, 'pending baseline scan did not escape')
 strictEqual(Array.isArray(userRowSink), true, 'user row scan did not escape')
 console.log(
   `validated=${validatedCases} cases, checksum=${checksum}, capped calibrations=${cappedCalibrations}, runtime=${(

--- a/config/scripts/plain-node-entry-guard.test.ts
+++ b/config/scripts/plain-node-entry-guard.test.ts
@@ -22,17 +22,36 @@ function createOutputDir(): string {
   return outputDir
 }
 
+function outputChunk(
+  name: string,
+  code: string,
+  imports: string[] = [],
+  isEntry = true
+): Rollup.OutputChunk {
+  const fileName = `${name}.js`
+  // Rolldown brands chunks with a runtime-only symbol that fixture objects cannot construct.
+  return {
+    type: 'chunk',
+    code,
+    dynamicImports: [],
+    exports: [],
+    facadeModuleId: null,
+    fileName,
+    imports,
+    isDynamicEntry: false,
+    isEntry,
+    map: null,
+    modules: {},
+    moduleIds: [],
+    name,
+    preliminaryFileName: fileName,
+    sourcemapFileName: null
+  } as unknown as Rollup.OutputChunk
+}
+
 function createBundle(code = ''): Rollup.OutputBundle {
   return {
-    'daemon-entry.js': {
-      type: 'chunk',
-      code,
-      dynamicImports: [],
-      fileName: 'daemon-entry.js',
-      imports: [],
-      isEntry: true,
-      name: 'daemon-entry'
-    } as Rollup.OutputChunk
+    'daemon-entry.js': outputChunk('daemon-entry', code)
   }
 }
 
@@ -172,15 +191,7 @@ describe('worker thread entry guard', () => {
   }
 
   function workerChunk(name: string, code: string, imports: string[] = []): Rollup.OutputChunk {
-    return {
-      type: 'chunk',
-      code,
-      dynamicImports: [],
-      fileName: `${name}.js`,
-      imports,
-      isEntry: true,
-      name
-    } as Rollup.OutputChunk
+    return outputChunk(name, code, imports)
   }
 
   it('rejects an Electron require reachable from a worker entry', () => {
@@ -214,15 +225,7 @@ describe('worker thread entry guard', () => {
         'require("./chunks/shared.js")',
         ['chunks/shared.js']
       ),
-      'chunks/shared.js': {
-        type: 'chunk',
-        code: 'require("electron")',
-        dynamicImports: [],
-        fileName: 'chunks/shared.js',
-        imports: [],
-        isEntry: false,
-        name: 'shared'
-      } as Rollup.OutputChunk
+      'chunks/shared.js': outputChunk('chunks/shared', 'require("electron")', [], false)
     } as Rollup.OutputBundle
 
     expect(() => runWorkerWriteBundle(plugin, bundle)).toThrow('chunks/shared.js')

--- a/config/scripts/run-typecheck-projects-in-parallel.mjs
+++ b/config/scripts/run-typecheck-projects-in-parallel.mjs
@@ -2,18 +2,45 @@ import { spawn } from 'node:child_process'
 import { availableParallelism } from 'node:os'
 import { fileURLToPath } from 'node:url'
 
-// The three projects overlap heavily in src/shared but have no build dependency on
-// each other, so tsc can check them concurrently instead of in a `&&` chain.
-const projects = ['tsconfig.node.json', 'tsconfig.tc.cli.json', 'tsconfig.tc.web.json']
 const repoRoot = fileURLToPath(new URL('../..', import.meta.url))
 const tsc = fileURLToPath(new URL('../../node_modules/typescript/bin/tsc', import.meta.url))
 
-// Why serialize on a single-core runner: three tsc processes there thrash rather than overlap.
-const concurrent = availableParallelism() > 1
+// The projects overlap but have no build dependency, so they can check concurrently.
+const projects = [
+  {
+    name: 'tsconfig.node.json',
+    args: [tsc, '--noEmit', '-p', 'config/tsconfig.node.json']
+  },
+  {
+    name: 'tsconfig.tc.cli.json',
+    args: [tsc, '--noEmit', '-p', 'config/tsconfig.tc.cli.json']
+  },
+  {
+    name: 'tsconfig.tc.web.json',
+    args: [tsc, '--noEmit', '-p', 'config/tsconfig.tc.web.json']
+  },
+  {
+    name: 'tsconfig.tooling.json',
+    args: [tsc, '--noEmit', '-p', 'config/tsconfig.tooling.json']
+  },
+  {
+    name: 'tsconfig.e2e.json',
+    args: [
+      'config/scripts/typecheck-diagnostic-baseline.mjs',
+      '--project',
+      'config/tsconfig.e2e.json',
+      '--baseline',
+      'config/typecheck-e2e-diagnostics.json'
+    ]
+  }
+]
+
+// Keep the original three-process ceiling; each additional project holds a full compiler graph.
+const maxConcurrent = Math.min(availableParallelism(), 3)
 
 function checkProject(project) {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [tsc, '--noEmit', '-p', `config/${project}`], {
+    const child = spawn(process.execPath, project.args, {
       cwd: repoRoot,
       stdio: 'inherit'
     })
@@ -21,9 +48,9 @@ function checkProject(project) {
     child.on('error', reject)
     child.on('exit', (code, signal) => {
       if (signal) {
-        reject(new Error(`tsc ${project} exited with signal ${signal}`))
+        reject(new Error(`${project.name} exited with signal ${signal}`))
       } else if (code !== 0) {
-        reject(new Error(`tsc ${project} exited with code ${code}`))
+        reject(new Error(`${project.name} exited with code ${code}`))
       } else {
         resolve()
       }
@@ -31,12 +58,12 @@ function checkProject(project) {
   })
 }
 
-let failures = []
-if (concurrent) {
-  const results = await Promise.allSettled(projects.map(checkProject))
-  failures = results.filter((result) => result.status === 'rejected').map((result) => result.reason)
-} else {
-  for (const project of projects) {
+const failures = []
+let nextProject = 0
+async function runProjectWorker() {
+  while (nextProject < projects.length) {
+    const project = projects[nextProject]
+    nextProject += 1
     try {
       await checkProject(project)
     } catch (error) {
@@ -44,6 +71,9 @@ if (concurrent) {
     }
   }
 }
+await Promise.all(
+  Array.from({ length: Math.min(maxConcurrent, projects.length) }, runProjectWorker)
+)
 
 if (failures.length > 0) {
   for (const failure of failures) {

--- a/config/scripts/typecheck-diagnostic-baseline.mjs
+++ b/config/scripts/typecheck-diagnostic-baseline.mjs
@@ -1,9 +1,10 @@
 import { spawnSync } from 'node:child_process'
+import { realpathSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const repoRoot = fileURLToPath(new URL('../..', import.meta.url))
+const repoRoot = realpathSync(fileURLToPath(new URL('../..', import.meta.url)))
 
 function parseArgs(argv) {
   const options = { write: false }
@@ -95,10 +96,12 @@ function collectDiagnostics(projectPath, tscPath) {
   if (result.signal) {
     throw new Error(`TypeScript exited with signal ${result.signal}`)
   }
-  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`
-  const diagnostics = parseDiagnostics(output)
+  const stdout = result.stdout ?? ''
+  const diagnostics = parseDiagnostics(stdout)
   if (result.status !== 0 && diagnostics.length === 0) {
-    throw new Error(`TypeScript exited ${result.status} without parseable diagnostics:\n${output}`)
+    throw new Error(
+      `TypeScript exited ${result.status} without parseable diagnostics:\nstdout:\n${stdout}\nstderr:\n${result.stderr ?? ''}`
+    )
   }
   return diagnostics
 }

--- a/config/scripts/typecheck-diagnostic-baseline.mjs
+++ b/config/scripts/typecheck-diagnostic-baseline.mjs
@@ -1,0 +1,170 @@
+import { spawnSync } from 'node:child_process'
+import { readFile, writeFile } from 'node:fs/promises'
+import { relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url))
+
+function parseArgs(argv) {
+  const options = { write: false }
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]
+    if (value === '--write') {
+      options.write = true
+      continue
+    }
+    const next = argv[index + 1]
+    if (!next) {
+      throw new Error(`Missing value for ${value}`)
+    }
+    if (value === '--project') {
+      options.project = next
+    } else if (value === '--baseline') {
+      options.baseline = next
+    } else if (value === '--tsc') {
+      options.tsc = next
+    } else {
+      throw new Error(`Unknown option: ${value}`)
+    }
+    index += 1
+  }
+  if (!options.project || !options.baseline) {
+    throw new Error('Usage: --project <tsconfig> --baseline <json> [--tsc <binary>] [--write]')
+  }
+  return options
+}
+
+function sortDiagnostics(diagnostics) {
+  return diagnostics.sort((left, right) =>
+    JSON.stringify(left).localeCompare(JSON.stringify(right), 'en')
+  )
+}
+
+function parseDiagnostics(output) {
+  const diagnostics = []
+  let current = null
+  for (const line of output.split(/\r?\n/)) {
+    const match = line.match(/^(.*?)\((\d+),(\d+)\): error TS(\d+): (.*)$/)
+    if (match) {
+      current = {
+        file: match[1].replaceAll('\\', '/'),
+        line: Number(match[2]),
+        column: Number(match[3]),
+        code: Number(match[4]),
+        message: match[5]
+      }
+      diagnostics.push(current)
+      continue
+    }
+    const configMatch = line.match(/^error TS(\d+): (.*)$/)
+    if (configMatch) {
+      current = {
+        file: null,
+        line: null,
+        column: null,
+        code: Number(configMatch[1]),
+        message: configMatch[2]
+      }
+      diagnostics.push(current)
+      continue
+    }
+    if (current && line.trim().length > 0) {
+      current.message += `\n${line.trimEnd()}`
+    }
+  }
+  return sortDiagnostics(diagnostics)
+}
+
+function collectDiagnostics(projectPath, tscPath) {
+  const result = spawnSync(
+    process.execPath,
+    [tscPath, '--pretty', 'false', '--noEmit', '-p', projectPath],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024
+    }
+  )
+  if (result.error) {
+    throw result.error
+  }
+  if (result.signal) {
+    throw new Error(`TypeScript exited with signal ${result.signal}`)
+  }
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`
+  const diagnostics = parseDiagnostics(output)
+  if (result.status !== 0 && diagnostics.length === 0) {
+    throw new Error(`TypeScript exited ${result.status} without parseable diagnostics:\n${output}`)
+  }
+  return diagnostics
+}
+
+function diagnosticCounts(diagnostics) {
+  const counts = new Map()
+  for (const diagnostic of diagnostics) {
+    const key = JSON.stringify(diagnostic)
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+  return counts
+}
+
+function subtractDiagnostics(left, right) {
+  const remaining = diagnosticCounts(right)
+  return left.filter((diagnostic) => {
+    const key = JSON.stringify(diagnostic)
+    const count = remaining.get(key) ?? 0
+    if (count === 0) {
+      return true
+    }
+    remaining.set(key, count - 1)
+    return false
+  })
+}
+
+function formatDiagnostic(diagnostic) {
+  const location = diagnostic.file
+    ? `${diagnostic.file}:${diagnostic.line}:${diagnostic.column}`
+    : '<config>'
+  return `${location} TS${diagnostic.code}: ${diagnostic.message}`
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const projectPath = resolve(repoRoot, options.project)
+  const baselinePath = resolve(repoRoot, options.baseline)
+  const tscPath = resolve(repoRoot, options.tsc ?? 'node_modules/typescript/bin/tsc')
+  const diagnostics = collectDiagnostics(projectPath, tscPath)
+
+  if (options.write) {
+    const baseline = { version: 1, diagnostics }
+    await writeFile(baselinePath, `${JSON.stringify(baseline, null, 2)}\n`)
+    console.log(`Wrote ${diagnostics.length} diagnostics to ${relative(repoRoot, baselinePath)}`)
+    return
+  }
+
+  const baseline = JSON.parse(await readFile(baselinePath, 'utf8'))
+  if (baseline.version !== 1 || !Array.isArray(baseline.diagnostics)) {
+    throw new Error(`Invalid diagnostic baseline: ${relative(repoRoot, baselinePath)}`)
+  }
+  const unexpected = subtractDiagnostics(diagnostics, baseline.diagnostics)
+  const stale = subtractDiagnostics(baseline.diagnostics, diagnostics)
+  if (unexpected.length === 0 && stale.length === 0) {
+    console.log(`${options.project}: ${diagnostics.length} known diagnostics, no drift`)
+    return
+  }
+  if (unexpected.length > 0) {
+    console.error(`Unexpected diagnostics (${unexpected.length}):`)
+    for (const diagnostic of unexpected) {
+      console.error(formatDiagnostic(diagnostic))
+    }
+  }
+  if (stale.length > 0) {
+    console.error(`Stale allowlist entries (${stale.length}); remove fixed diagnostics:`)
+    for (const diagnostic of stale) {
+      console.error(formatDiagnostic(diagnostic))
+    }
+  }
+  process.exitCode = 1
+}
+
+await main()

--- a/config/scripts/typecheck-diagnostic-baseline.mjs
+++ b/config/scripts/typecheck-diagnostic-baseline.mjs
@@ -21,6 +21,8 @@ function parseArgs(argv) {
       options.project = next
     } else if (value === '--baseline') {
       options.baseline = next
+    } else if (value === '--base-baseline') {
+      options.baseBaseline = next
     } else if (value === '--tsc') {
       options.tsc = next
     } else {
@@ -29,7 +31,9 @@ function parseArgs(argv) {
     index += 1
   }
   if (!options.project || !options.baseline) {
-    throw new Error('Usage: --project <tsconfig> --baseline <json> [--tsc <binary>] [--write]')
+    throw new Error(
+      'Usage: --project <tsconfig> --baseline <json> [--base-baseline <json>] [--tsc <binary>] [--write]'
+    )
   }
   return options
 }
@@ -102,7 +106,11 @@ function collectDiagnostics(projectPath, tscPath) {
 function diagnosticCounts(diagnostics) {
   const counts = new Map()
   for (const diagnostic of diagnostics) {
-    const key = JSON.stringify(diagnostic)
+    const key = JSON.stringify({
+      file: diagnostic.file,
+      code: diagnostic.code,
+      message: diagnostic.message
+    })
     counts.set(key, (counts.get(key) ?? 0) + 1)
   }
   return counts
@@ -111,7 +119,11 @@ function diagnosticCounts(diagnostics) {
 function subtractDiagnostics(left, right) {
   const remaining = diagnosticCounts(right)
   return left.filter((diagnostic) => {
-    const key = JSON.stringify(diagnostic)
+    const key = JSON.stringify({
+      file: diagnostic.file,
+      code: diagnostic.code,
+      message: diagnostic.message
+    })
     const count = remaining.get(key) ?? 0
     if (count === 0) {
       return true
@@ -128,23 +140,51 @@ function formatDiagnostic(diagnostic) {
   return `${location} TS${diagnostic.code}: ${diagnostic.message}`
 }
 
+async function readBaseline(baselinePath) {
+  const baseline = JSON.parse(await readFile(baselinePath, 'utf8'))
+  if (baseline.version !== 1 || !Array.isArray(baseline.diagnostics)) {
+    throw new Error(`Invalid diagnostic baseline: ${relative(repoRoot, baselinePath)}`)
+  }
+  return baseline
+}
+
+function reportBaselineGrowth(diagnostics, baseDiagnostics) {
+  const added = subtractDiagnostics(diagnostics, baseDiagnostics)
+  if (added.length === 0) {
+    return false
+  }
+  console.error(`Diagnostic baseline grew (${added.length}); only removals are allowed:`)
+  for (const diagnostic of added) {
+    console.error(formatDiagnostic(diagnostic))
+  }
+  process.exitCode = 1
+  return true
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2))
   const projectPath = resolve(repoRoot, options.project)
   const baselinePath = resolve(repoRoot, options.baseline)
+  const baseBaselinePath = options.baseBaseline
+    ? resolve(repoRoot, options.baseBaseline)
+    : process.env.TYPECHECK_BASELINE_BASE_PATH
   const tscPath = resolve(repoRoot, options.tsc ?? 'node_modules/typescript/bin/tsc')
   const diagnostics = collectDiagnostics(projectPath, tscPath)
+  const baseBaseline = baseBaselinePath ? await readBaseline(baseBaselinePath) : null
 
   if (options.write) {
+    if (baseBaseline && reportBaselineGrowth(diagnostics, baseBaseline.diagnostics)) {
+      return
+    }
     const baseline = { version: 1, diagnostics }
     await writeFile(baselinePath, `${JSON.stringify(baseline, null, 2)}\n`)
     console.log(`Wrote ${diagnostics.length} diagnostics to ${relative(repoRoot, baselinePath)}`)
     return
   }
 
-  const baseline = JSON.parse(await readFile(baselinePath, 'utf8'))
-  if (baseline.version !== 1 || !Array.isArray(baseline.diagnostics)) {
-    throw new Error(`Invalid diagnostic baseline: ${relative(repoRoot, baselinePath)}`)
+  const baseline = await readBaseline(baselinePath)
+  if (baseBaseline && reportBaselineGrowth(baseline.diagnostics, baseBaseline.diagnostics)) {
+    return
   }
   const unexpected = subtractDiagnostics(diagnostics, baseline.diagnostics)
   const stale = subtractDiagnostics(baseline.diagnostics, diagnostics)

--- a/config/scripts/typecheck-diagnostic-baseline.mjs
+++ b/config/scripts/typecheck-diagnostic-baseline.mjs
@@ -139,7 +139,8 @@ function subtractDiagnostics(left, right) {
 /** Failures here are routine, so the message carries its own fix. */
 function regenerationHint() {
   const argv = process.argv.slice(2).filter((value) => value !== '--write')
-  return `Regenerate with: node ${relative(repoRoot, import.meta.filename)} ${argv.join(' ')} --write`
+  // Relative to the caller, not the repo: mobile runs this from mobile/.
+  return `Regenerate with: node ${relative(process.cwd(), import.meta.filename)} ${argv.join(' ')} --write`
 }
 
 function formatDiagnostic(diagnostic) {

--- a/config/scripts/typecheck-diagnostic-baseline.mjs
+++ b/config/scripts/typecheck-diagnostic-baseline.mjs
@@ -136,6 +136,12 @@ function subtractDiagnostics(left, right) {
   })
 }
 
+/** Failures here are routine, so the message carries its own fix. */
+function regenerationHint() {
+  const argv = process.argv.slice(2).filter((value) => value !== '--write')
+  return `Regenerate with: node ${relative(repoRoot, import.meta.filename)} ${argv.join(' ')} --write`
+}
+
 function formatDiagnostic(diagnostic) {
   const location = diagnostic.file
     ? `${diagnostic.file}:${diagnostic.line}:${diagnostic.column}`
@@ -168,9 +174,9 @@ async function main() {
   const options = parseArgs(process.argv.slice(2))
   const projectPath = resolve(repoRoot, options.project)
   const baselinePath = resolve(repoRoot, options.baseline)
-  const baseBaselinePath = options.baseBaseline
-    ? resolve(repoRoot, options.baseBaseline)
-    : process.env.TYPECHECK_BASELINE_BASE_PATH
+  // Resolve the env form like the flag: mobile runs with working-directory: mobile.
+  const baseBaselineOption = options.baseBaseline ?? process.env.TYPECHECK_BASELINE_BASE_PATH
+  const baseBaselinePath = baseBaselineOption ? resolve(repoRoot, baseBaselineOption) : undefined
   const tscPath = resolve(repoRoot, options.tsc ?? 'node_modules/typescript/bin/tsc')
   const diagnostics = collectDiagnostics(projectPath, tscPath)
   const baseBaseline = baseBaselinePath ? await readBaseline(baseBaselinePath) : null
@@ -207,6 +213,7 @@ async function main() {
       console.error(formatDiagnostic(diagnostic))
     }
   }
+  console.error(regenerationHint())
   process.exitCode = 1
 }
 

--- a/config/scripts/typecheck-diagnostic-baseline.test.mjs
+++ b/config/scripts/typecheck-diagnostic-baseline.test.mjs
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -32,11 +32,25 @@ function createFixture(source) {
   }
 }
 
-function runBaseline(paths, extraArgs = []) {
+function runBaseline(paths, extraArgs = [], spawnOptions = {}) {
   return spawnSync(
     process.execPath,
-    [script, '--project', paths.project, '--baseline', paths.baseline, '--tsc', tsc, ...extraArgs],
-    { cwd: repoRoot, encoding: 'utf8' }
+    [
+      ...(spawnOptions.nodeArgs ?? []),
+      spawnOptions.script ?? script,
+      '--project',
+      paths.project,
+      '--baseline',
+      paths.baseline,
+      '--tsc',
+      paths.tsc ?? tsc,
+      ...extraArgs
+    ],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: { ...process.env, ...spawnOptions.env }
+    }
   )
 }
 
@@ -89,6 +103,46 @@ describe('typecheck diagnostic baseline', () => {
 
     writeFileSync(paths.source, "\nconst value: number = 'bad'\n")
     expect(runBaseline(paths).status).toBe(0)
+  })
+
+  it('matches recorded diagnostics through a symlinked checkout path', () => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'orca-typecheck-symlink-'))
+    const linkedCheckout = join(fixtureDir, 'checkout')
+    symlinkSync(repoRoot, linkedCheckout, process.platform === 'win32' ? 'junction' : 'dir')
+
+    const result = runBaseline(
+      {
+        project: 'config/tsconfig.e2e.json',
+        baseline: 'config/typecheck-e2e-diagnostics.json'
+      },
+      [],
+      {
+        nodeArgs: ['--preserve-symlinks-main'],
+        script: join(linkedCheckout, 'config/scripts/typecheck-diagnostic-baseline.mjs')
+      }
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('240 known diagnostics, no drift')
+  })
+
+  it('ignores stderr warnings while parsing compiler diagnostics', () => {
+    const paths = createFixture("const value: number = 'bad'\n")
+    paths.tsc = join(fixtureDir, 'fake-tsc.mjs')
+    writeFileSync(
+      paths.tsc,
+      [
+        "if (process.env.INJECT_TSC_WARNING) process.stderr.write('pnpm warning: unsupported engine\\n')",
+        "process.stdout.write(\"source.ts(1,7): error TS2322: Type 'string' is not assignable to type 'number'.\\n\")",
+        'process.exitCode = 1'
+      ].join('\n')
+    )
+    expect(runBaseline(paths, ['--write']).status).toBe(0)
+
+    const result = runBaseline(paths, [], { env: { INJECT_TSC_WARNING: '1' } })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('1 known diagnostics, no drift')
   })
 
   it('refuses to regenerate a baseline that grows from the PR base', () => {

--- a/config/scripts/typecheck-diagnostic-baseline.test.mjs
+++ b/config/scripts/typecheck-diagnostic-baseline.test.mjs
@@ -1,0 +1,64 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url))
+const script = join(repoRoot, 'config/scripts/typecheck-diagnostic-baseline.mjs')
+const tsc = join(repoRoot, 'node_modules/typescript/bin/tsc')
+let fixtureDir
+
+afterEach(() => {
+  if (fixtureDir) {
+    rmSync(fixtureDir, { recursive: true, force: true })
+  }
+  fixtureDir = undefined
+})
+
+function createFixture(source) {
+  fixtureDir = mkdtempSync(join(tmpdir(), 'orca-typecheck-baseline-'))
+  writeFileSync(
+    join(fixtureDir, 'tsconfig.json'),
+    JSON.stringify({ compilerOptions: { strict: true, noEmit: true }, include: ['source.ts'] })
+  )
+  writeFileSync(join(fixtureDir, 'source.ts'), source)
+  return {
+    baseline: join(fixtureDir, 'baseline.json'),
+    project: join(fixtureDir, 'tsconfig.json'),
+    source: join(fixtureDir, 'source.ts')
+  }
+}
+
+function runBaseline(paths, extraArgs = []) {
+  return spawnSync(
+    process.execPath,
+    [script, '--project', paths.project, '--baseline', paths.baseline, '--tsc', tsc, ...extraArgs],
+    { cwd: repoRoot, encoding: 'utf8' }
+  )
+}
+
+describe('typecheck diagnostic baseline', () => {
+  it('accepts only the exact recorded diagnostics', () => {
+    const paths = createFixture("const value: number = 'bad'\n")
+    expect(runBaseline(paths, ['--write']).status).toBe(0)
+    expect(JSON.parse(readFileSync(paths.baseline, 'utf8')).diagnostics).toHaveLength(1)
+    expect(runBaseline(paths).status).toBe(0)
+
+    writeFileSync(paths.source, 'const value: number = 1\n')
+    const stale = runBaseline(paths)
+    expect(stale.status).toBe(1)
+    expect(stale.stderr).toContain('Stale allowlist entries (1)')
+  })
+
+  it('rejects a diagnostic added after a clean baseline', () => {
+    const paths = createFixture('const value: number = 1\n')
+    expect(runBaseline(paths, ['--write']).status).toBe(0)
+
+    writeFileSync(paths.source, "const value: number = 'bad'\n")
+    const unexpected = runBaseline(paths)
+    expect(unexpected.status).toBe(1)
+    expect(unexpected.stderr).toContain('Unexpected diagnostics (1)')
+  })
+})

--- a/config/scripts/typecheck-diagnostic-baseline.test.mjs
+++ b/config/scripts/typecheck-diagnostic-baseline.test.mjs
@@ -26,6 +26,7 @@ function createFixture(source) {
   writeFileSync(join(fixtureDir, 'source.ts'), source)
   return {
     baseline: join(fixtureDir, 'baseline.json'),
+    baseBaseline: join(fixtureDir, 'base-baseline.json'),
     project: join(fixtureDir, 'tsconfig.json'),
     source: join(fixtureDir, 'source.ts')
   }
@@ -40,7 +41,17 @@ function runBaseline(paths, extraArgs = []) {
 }
 
 describe('typecheck diagnostic baseline', () => {
-  it('accepts only the exact recorded diagnostics', () => {
+  it('loads PR-base baselines in desktop and mobile CI', () => {
+    const desktopWorkflow = readFileSync(join(repoRoot, '.github/workflows/pr.yml'), 'utf8')
+    const mobileWorkflow = readFileSync(join(repoRoot, '.github/workflows/mobile.yml'), 'utf8')
+
+    expect(desktopWorkflow).toContain('$BASE_SHA:config/typecheck-e2e-diagnostics.json')
+    expect(mobileWorkflow).toContain('$BASE_SHA:mobile/typecheck-test-diagnostics.json')
+    expect(desktopWorkflow).toContain('TYPECHECK_BASELINE_BASE_PATH=')
+    expect(mobileWorkflow).toContain('TYPECHECK_BASELINE_BASE_PATH=')
+  })
+
+  it('requires recorded diagnostics to remain present', () => {
     const paths = createFixture("const value: number = 'bad'\n")
     expect(runBaseline(paths, ['--write']).status).toBe(0)
     expect(JSON.parse(readFileSync(paths.baseline, 'utf8')).diagnostics).toHaveLength(1)
@@ -60,5 +71,35 @@ describe('typecheck diagnostic baseline', () => {
     const unexpected = runBaseline(paths)
     expect(unexpected.status).toBe(1)
     expect(unexpected.stderr).toContain('Unexpected diagnostics (1)')
+  })
+
+  it('rejects another occurrence of an allowlisted diagnostic', () => {
+    const paths = createFixture("const first: number = 'bad'\n")
+    expect(runBaseline(paths, ['--write']).status).toBe(0)
+
+    writeFileSync(paths.source, "const first: number = 'bad'\nconst second: number = 'also-bad'\n")
+    const unexpected = runBaseline(paths)
+    expect(unexpected.status).toBe(1)
+    expect(unexpected.stderr).toContain('Unexpected diagnostics (1)')
+  })
+
+  it('does not drift when only diagnostic positions move', () => {
+    const paths = createFixture("const value: number = 'bad'\n")
+    expect(runBaseline(paths, ['--write']).status).toBe(0)
+
+    writeFileSync(paths.source, "\nconst value: number = 'bad'\n")
+    expect(runBaseline(paths).status).toBe(0)
+  })
+
+  it('refuses to regenerate a baseline that grows from the PR base', () => {
+    const paths = createFixture("const first: number = 'bad'\n")
+    expect(runBaseline(paths, ['--write']).status).toBe(0)
+    writeFileSync(paths.baseBaseline, readFileSync(paths.baseline, 'utf8'))
+
+    writeFileSync(paths.source, "const first: number = 'bad'\nconst second: boolean = 'also-bad'\n")
+    const growth = runBaseline(paths, ['--write', '--base-baseline', paths.baseBaseline])
+    expect(growth.status).toBe(1)
+    expect(growth.stderr).toContain('Diagnostic baseline grew (1)')
+    expect(JSON.parse(readFileSync(paths.baseline, 'utf8')).diagnostics).toHaveLength(1)
   })
 })

--- a/config/scripts/typecheck-diagnostic-baseline.test.mjs
+++ b/config/scripts/typecheck-diagnostic-baseline.test.mjs
@@ -47,7 +47,7 @@ function runBaseline(paths, extraArgs = [], spawnOptions = {}) {
       ...extraArgs
     ],
     {
-      cwd: repoRoot,
+      cwd: spawnOptions.cwd ?? repoRoot,
       encoding: 'utf8',
       env: { ...process.env, ...spawnOptions.env }
     }
@@ -149,6 +149,80 @@ describe('typecheck diagnostic baseline', () => {
 
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('1 known diagnostics, no drift')
+  })
+
+  it('rejects a committed baseline that grew from the PR base', () => {
+    const paths = createFixture("const first: number = 'bad'\n")
+    expect(runBaseline(paths, ['--write']).status).toBe(0)
+    // Base knows only the first error; the committed baseline was raised to cover a second.
+    const base = JSON.parse(readFileSync(paths.baseline, 'utf8'))
+    writeFileSync(paths.baseBaseline, JSON.stringify(base))
+    writeFileSync(paths.source, "const first: number = 'bad'\nconst second: boolean = 'also-bad'\n")
+    expect(runBaseline(paths, ['--write', '--base-baseline', paths.baseBaseline]).status).toBe(1)
+    writeFileSync(
+      paths.baseline,
+      JSON.stringify({
+        version: 1,
+        diagnostics: [
+          ...base.diagnostics,
+          {
+            file: 'source.ts',
+            line: 2,
+            column: 7,
+            code: 2322,
+            message: "Type 'string' is not assignable to type 'boolean'."
+          }
+        ]
+      })
+    )
+
+    const check = runBaseline(paths, ['--base-baseline', paths.baseBaseline])
+
+    expect(check.status).toBe(1)
+    expect(check.stderr).toContain('Diagnostic baseline grew (1)')
+  })
+
+  it('reads the PR base from the environment the way CI passes it', () => {
+    const paths = createFixture("const value: number = 'bad'\n")
+    expect(runBaseline(paths, ['--write']).status).toBe(0)
+    writeFileSync(paths.baseBaseline, JSON.stringify({ version: 1, diagnostics: [] }))
+
+    const result = runBaseline(paths, [], {
+      env: { TYPECHECK_BASELINE_BASE_PATH: paths.baseBaseline }
+    })
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('Diagnostic baseline grew (1)')
+  })
+
+  it('resolves the env-supplied PR base against the repo, not the working directory', () => {
+    // Mobile CI runs this with working-directory: mobile, so a repo-relative base
+    // path must not resolve against the caller's cwd.
+    const result = runBaseline(
+      {
+        project: 'config/tsconfig.e2e.json',
+        baseline: 'config/typecheck-e2e-diagnostics.json'
+      },
+      [],
+      {
+        cwd: join(repoRoot, 'mobile'),
+        env: { TYPECHECK_BASELINE_BASE_PATH: 'config/typecheck-e2e-diagnostics.json' }
+      }
+    )
+
+    expect(result.stderr).not.toContain('ENOENT')
+    expect(result.status).toBe(0)
+  })
+
+  it('names the regeneration command when the baseline drifts', () => {
+    const paths = createFixture("const value: number = 'bad'\n")
+    expect(runBaseline(paths, ['--write']).status).toBe(0)
+    writeFileSync(paths.source, 'const value: number = 1\n')
+
+    const stale = runBaseline(paths)
+
+    expect(stale.status).toBe(1)
+    expect(stale.stderr).toContain('--write')
   })
 
   it('refuses to regenerate a baseline that grows from the PR base', () => {

--- a/config/scripts/typecheck-diagnostic-baseline.test.mjs
+++ b/config/scripts/typecheck-diagnostic-baseline.test.mjs
@@ -222,7 +222,20 @@ describe('typecheck diagnostic baseline', () => {
     const stale = runBaseline(paths)
 
     expect(stale.status).toBe(1)
+    expect(stale.stderr).toContain('config/scripts/typecheck-diagnostic-baseline.mjs')
     expect(stale.stderr).toContain('--write')
+  })
+
+  it('names a command runnable from the directory that printed it', () => {
+    // Mobile runs its typecheck from mobile/, where a repo-relative path is not runnable.
+    const paths = createFixture("const value: number = 'bad'\n")
+    expect(runBaseline(paths, ['--write']).status).toBe(0)
+    writeFileSync(paths.source, 'const value: number = 1\n')
+
+    const stale = runBaseline(paths, [], { cwd: join(repoRoot, 'mobile') })
+
+    expect(stale.status).toBe(1)
+    expect(stale.stderr).toContain('node ../config/scripts/typecheck-diagnostic-baseline.mjs')
   })
 
   it('refuses to regenerate a baseline that grows from the PR base', () => {

--- a/config/scripts/typecheck-diagnostic-baseline.test.mjs
+++ b/config/scripts/typecheck-diagnostic-baseline.test.mjs
@@ -122,8 +122,14 @@ describe('typecheck diagnostic baseline', () => {
       }
     )
 
+    // Derived, not hardcoded: the backlog shrinks by design, and a literal count
+    // would make the ratchet working as intended fail this test.
+    const recorded = JSON.parse(
+      readFileSync(join(repoRoot, 'config/typecheck-e2e-diagnostics.json'), 'utf8')
+    ).diagnostics.length
+
     expect(result.status).toBe(0)
-    expect(result.stdout).toContain('240 known diagnostics, no drift')
+    expect(result.stdout).toContain(`${recorded} known diagnostics, no drift`)
   })
 
   it('ignores stderr warnings while parsing compiler diagnostics', () => {

--- a/config/scripts/typecheck-extension-shadowing.test.mjs
+++ b/config/scripts/typecheck-extension-shadowing.test.mjs
@@ -22,8 +22,18 @@ const IGNORED_DIRECTORIES = new Set([
   'coverage',
   '.cross-version-checkouts'
 ])
-// TypeScript resolves these in order, so an earlier entry shadows a later one.
-const EXTENSION_PRIORITY = ['.ts', '.tsx', '.mts', '.cts', '.d.ts', '.d.mts', '.d.cts']
+/**
+ * Resolution groups, not one ranking: `.mts` and `.cts` are separate module formats
+ * that coexist with `.ts`. Only members of the same group shadow each other, so a
+ * routine `foo.ts` + `foo.mts` pairing must not be reported.
+ */
+const EXTENSION_GROUPS = [
+  ['.d.ts', '.ts', '.tsx'],
+  ['.d.mts', '.mts'],
+  ['.d.cts', '.cts']
+]
+// Within a group tsc prefers the implementation file over the declaration.
+const PRIORITY = ['.ts', '.tsx', '.mts', '.cts', '.d.ts', '.d.mts', '.d.cts']
 
 function collectFiles(root) {
   let found = []
@@ -51,37 +61,66 @@ function collectFiles(root) {
       found = found.concat(collectFiles(fullPath))
       continue
     }
-    if (EXTENSION_PRIORITY.some((extension) => entry.name.endsWith(extension))) {
-      found.push(fullPath)
-    }
+    found.push(fullPath)
   }
   return found
 }
 
 function extensionOf(path) {
-  return EXTENSION_PRIORITY.filter((extension) => path.endsWith(extension)).sort(
+  return PRIORITY.filter((extension) => path.endsWith(extension)).sort(
     (left, right) => right.length - left.length
   )[0]
 }
 
-describe('typecheck extension shadowing', () => {
-  it('has no file hidden from the program by a higher-priority extension', () => {
+/** Exported shape kept pure so the grouping rule is testable without touching the tree. */
+export function findShadowedFiles(paths) {
+  const shadowed = []
+  for (const group of EXTENSION_GROUPS) {
     const byStem = new Map()
-    for (const file of collectFiles(repoRoot)) {
-      const relativePath = relative(repoRoot, file).replaceAll('\\', '/')
-      const extension = extensionOf(relativePath)
-      const stem = relativePath.slice(0, -extension.length)
+    for (const path of paths) {
+      const extension = extensionOf(path)
+      if (!extension || !group.includes(extension)) {
+        continue
+      }
+      const stem = path.slice(0, -extension.length)
       byStem.set(stem, [...(byStem.get(stem) ?? []), extension])
     }
+    for (const [stem, extensions] of byStem) {
+      if (extensions.length < 2) {
+        continue
+      }
+      const ordered = PRIORITY.filter((extension) => extensions.includes(extension))
+      shadowed.push(`${stem}${ordered[1]} is shadowed by ${stem}${ordered[0]}`)
+    }
+  }
+  return shadowed.sort()
+}
 
-    const shadowed = [...byStem.entries()]
-      .filter(([, extensions]) => extensions.length > 1)
-      .map(([stem, extensions]) => {
-        const ordered = EXTENSION_PRIORITY.filter((extension) => extensions.includes(extension))
-        return `${stem}${ordered[1]} is shadowed by ${stem}${ordered[0]}`
-      })
-      .sort()
+describe('typecheck extension shadowing', () => {
+  it('has no file hidden from the program by a higher-priority extension', () => {
+    const paths = collectFiles(repoRoot).map((file) =>
+      relative(repoRoot, file).replaceAll('\\', '/')
+    )
 
-    expect(shadowed).toEqual([])
+    expect(findShadowedFiles(paths)).toEqual([])
+  })
+
+  it('reports a .tsx hidden behind a .ts of the same stem', () => {
+    expect(findShadowedFiles(['src/a.ts', 'src/a.tsx'])).toEqual([
+      'src/a.tsx is shadowed by src/a.ts'
+    ])
+  })
+
+  it('leaves .mts and .cts alone, since they are separate module formats', () => {
+    // Verified against tsc --listFilesOnly: a.ts, a.mts and a.cts all enter the
+    // program together; only a.tsx is dropped.
+    expect(findShadowedFiles(['src/a.ts', 'src/a.mts', 'src/a.cts'])).toEqual([])
+  })
+
+  it('still reports shadowing inside the .mts and .cts groups', () => {
+    expect(findShadowedFiles(['src/a.mts', 'src/a.d.mts', 'src/b.cts', 'src/b.d.cts'])).toEqual([
+      'src/a.d.mts is shadowed by src/a.mts',
+      'src/b.d.cts is shadowed by src/b.cts'
+    ])
   })
 })

--- a/config/scripts/typecheck-extension-shadowing.test.mjs
+++ b/config/scripts/typecheck-extension-shadowing.test.mjs
@@ -1,0 +1,77 @@
+import { readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * A `.tsx` file sitting next to a `.ts` of the same stem is silently dropped from
+ * the program: tsconfig `include` expansion keeps one file per extensionless path
+ * and `.ts` outranks `.tsx`. Nothing errors — the file just stops being typechecked,
+ * which is the exact hole the typecheck-coverage work exists to close.
+ */
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url))
+const SCANNED_ROOTS = ['src', 'tests', 'config', 'mobile/src', 'mobile/app']
+const IGNORED_DIRECTORIES = new Set([
+  'node_modules',
+  'dist',
+  'out',
+  'build',
+  '.git',
+  '.cross-version-checkouts'
+])
+// TypeScript resolves these in order, so an earlier entry shadows a later one.
+const EXTENSION_PRIORITY = ['.ts', '.tsx', '.d.ts']
+
+function collectFiles(root) {
+  let found = []
+  let entries
+  try {
+    entries = readdirSync(root)
+  } catch {
+    return found
+  }
+  for (const entry of entries) {
+    if (IGNORED_DIRECTORIES.has(entry)) {
+      continue
+    }
+    const fullPath = join(root, entry)
+    if (statSync(fullPath).isDirectory()) {
+      found = found.concat(collectFiles(fullPath))
+      continue
+    }
+    if (EXTENSION_PRIORITY.some((extension) => entry.endsWith(extension))) {
+      found.push(fullPath)
+    }
+  }
+  return found
+}
+
+function extensionOf(path) {
+  return path.endsWith('.d.ts') ? '.d.ts' : path.endsWith('.tsx') ? '.tsx' : '.ts'
+}
+
+function stemOf(path) {
+  return path.slice(0, -extensionOf(path).length)
+}
+
+describe('typecheck extension shadowing', () => {
+  it('has no file hidden from the program by a higher-priority extension', () => {
+    const byStem = new Map()
+    for (const root of SCANNED_ROOTS) {
+      for (const file of collectFiles(join(repoRoot, root))) {
+        const stem = stemOf(relative(repoRoot, file).replaceAll('\\', '/'))
+        byStem.set(stem, [...(byStem.get(stem) ?? []), extensionOf(file)])
+      }
+    }
+
+    const shadowed = [...byStem.entries()]
+      .filter(([, extensions]) => extensions.length > 1)
+      .map(([stem, extensions]) => {
+        const ordered = EXTENSION_PRIORITY.filter((extension) => extensions.includes(extension))
+        return `${stem}${ordered[1]} is shadowed by ${stem}${ordered[0]}`
+      })
+      .sort()
+
+    expect(shadowed).toEqual([])
+  })
+})

--- a/config/scripts/typecheck-extension-shadowing.test.mjs
+++ b/config/scripts/typecheck-extension-shadowing.test.mjs
@@ -8,38 +8,50 @@ import { describe, expect, it } from 'vitest'
  * the program: tsconfig `include` expansion keeps one file per extensionless path
  * and `.ts` outranks `.tsx`. Nothing errors — the file just stops being typechecked,
  * which is the exact hole the typecheck-coverage work exists to close.
+ *
+ * Why the whole tree rather than a list of roots: a hand-kept list drifts from the
+ * tsconfig `include` globs it is meant to shadow, and the gap is invisible.
  */
 const repoRoot = fileURLToPath(new URL('../..', import.meta.url))
-const SCANNED_ROOTS = ['src', 'tests', 'config', 'mobile/src', 'mobile/app']
 const IGNORED_DIRECTORIES = new Set([
+  '.git',
   'node_modules',
   'dist',
   'out',
   'build',
-  '.git',
+  'coverage',
   '.cross-version-checkouts'
 ])
 // TypeScript resolves these in order, so an earlier entry shadows a later one.
-const EXTENSION_PRIORITY = ['.ts', '.tsx', '.d.ts']
+const EXTENSION_PRIORITY = ['.ts', '.tsx', '.mts', '.cts', '.d.ts', '.d.mts', '.d.cts']
 
 function collectFiles(root) {
   let found = []
   let entries
   try {
-    entries = readdirSync(root)
+    entries = readdirSync(root, { withFileTypes: true })
   } catch {
     return found
   }
   for (const entry of entries) {
-    if (IGNORED_DIRECTORIES.has(entry)) {
+    if (IGNORED_DIRECTORIES.has(entry.name)) {
       continue
     }
-    const fullPath = join(root, entry)
-    if (statSync(fullPath).isDirectory()) {
+    const fullPath = join(root, entry.name)
+    let isDirectory = entry.isDirectory()
+    if (entry.isSymbolicLink()) {
+      // Why guarded: a dangling symlink must not fail the sweep with a raw ENOENT.
+      try {
+        isDirectory = statSync(fullPath).isDirectory()
+      } catch {
+        continue
+      }
+    }
+    if (isDirectory) {
       found = found.concat(collectFiles(fullPath))
       continue
     }
-    if (EXTENSION_PRIORITY.some((extension) => entry.endsWith(extension))) {
+    if (EXTENSION_PRIORITY.some((extension) => entry.name.endsWith(extension))) {
       found.push(fullPath)
     }
   }
@@ -47,21 +59,19 @@ function collectFiles(root) {
 }
 
 function extensionOf(path) {
-  return path.endsWith('.d.ts') ? '.d.ts' : path.endsWith('.tsx') ? '.tsx' : '.ts'
-}
-
-function stemOf(path) {
-  return path.slice(0, -extensionOf(path).length)
+  return EXTENSION_PRIORITY.filter((extension) => path.endsWith(extension)).sort(
+    (left, right) => right.length - left.length
+  )[0]
 }
 
 describe('typecheck extension shadowing', () => {
   it('has no file hidden from the program by a higher-priority extension', () => {
     const byStem = new Map()
-    for (const root of SCANNED_ROOTS) {
-      for (const file of collectFiles(join(repoRoot, root))) {
-        const stem = stemOf(relative(repoRoot, file).replaceAll('\\', '/'))
-        byStem.set(stem, [...(byStem.get(stem) ?? []), extensionOf(file)])
-      }
+    for (const file of collectFiles(repoRoot)) {
+      const relativePath = relative(repoRoot, file).replaceAll('\\', '/')
+      const extension = extensionOf(relativePath)
+      const stem = relativePath.slice(0, -extension.length)
+      byStem.set(stem, [...(byStem.get(stem) ?? []), extension])
     }
 
     const shadowed = [...byStem.entries()]

--- a/config/tsconfig.e2e.json
+++ b/config/tsconfig.e2e.json
@@ -1,6 +1,6 @@
 {
-  // Enforced by `pnpm typecheck`; the exact pre-existing diagnostics are ratcheted in
-  // typecheck-e2e-diagnostics.json so new errors fail while the backlog shrinks.
+  // Enforced by `pnpm typecheck`; pre-existing diagnostic identities and counts are ratcheted
+  // in typecheck-e2e-diagnostics.json so new errors fail while the backlog shrinks.
   "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
   // Why: specs import renderer and main modules directly, so the ambient declarations those
   // modules rely on (vite client types, build-time defines) have to be in the program too.

--- a/config/tsconfig.e2e.json
+++ b/config/tsconfig.e2e.json
@@ -1,10 +1,6 @@
 {
-  // NOT ENFORCED YET, and deliberately so: tests/ has never been typechecked, so this currently
-  // reports ~198 errors across ~94 files. Wiring it into `typecheck` or CI today would just paint
-  // the whole build red. It earns its place anyway — pointing it at the SSH reconnect spec found
-  // two real bugs a passing suite had hidden (a targetId read off the wrong type, and a required
-  // argument omitted), because that spec had never actually executed. Run `pnpm typecheck:e2e`,
-  // fix a file, repeat; when the count reaches zero, add it to the `typecheck` chain.
+  // Enforced by `pnpm typecheck`; the exact pre-existing diagnostics are ratcheted in
+  // typecheck-e2e-diagnostics.json so new errors fail while the backlog shrinks.
   "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
   // Why: specs import renderer and main modules directly, so the ambient declarations those
   // modules rely on (vite client types, build-time defines) have to be in the program too.
@@ -16,6 +12,8 @@
   ],
   "exclude": ["../tests/e2e/.cross-version-checkouts/**"],
   "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.e2e.tsbuildinfo",
     // Why: specs run browser code inside page.evaluate, so the DOM lib has to be visible here
     // even though the harness itself is Node.
     "lib": ["ESNext", "DOM", "DOM.Iterable"],

--- a/config/tsconfig.e2e.json
+++ b/config/tsconfig.e2e.json
@@ -1,6 +1,8 @@
 {
   // Enforced by `pnpm typecheck`; pre-existing diagnostic identities and counts are ratcheted
-  // in typecheck-e2e-diagnostics.json so new errors fail while the backlog shrinks.
+  // in typecheck-e2e-diagnostics.json so the backlog only shrinks. Identity is
+  // {file, code, message} without line/column, so a new error is caught unless it exactly
+  // matches one that was fixed in the same file. Regenerate with `pnpm typecheck:e2e:write`.
   "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
   // Why: specs import renderer and main modules directly, so the ambient declarations those
   // modules rely on (vite client types, build-time defines) have to be in the program too.

--- a/config/tsconfig.e2e.json
+++ b/config/tsconfig.e2e.json
@@ -3,6 +3,8 @@
   // in typecheck-e2e-diagnostics.json so the backlog only shrinks. Identity is
   // {file, code, message} without line/column, so a new error is caught unless it exactly
   // matches one that was fixed in the same file. Regenerate with `pnpm typecheck:e2e:write`.
+  // Renaming a file, or a type whose name these messages quote, reads as growth against the
+  // PR base and regenerating cannot clear it; fix those diagnostics instead.
   "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
   // Why: specs import renderer and main modules directly, so the ambient declarations those
   // modules rely on (vite client types, build-time defines) have to be in the program too.

--- a/config/tsconfig.tooling.json
+++ b/config/tsconfig.tooling.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
+  "include": ["../config/**/*.ts", "../*.ts", "../src/types/**/*"],
+  "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.tooling.tsbuildinfo",
+    "paths": {
+      "@renderer/*": ["../src/renderer/src/*"],
+      "@/*": ["../src/renderer/src/*"]
+    },
+    "types": ["electron-vite/node"]
+  }
+}

--- a/config/typecheck-e2e-diagnostics.json
+++ b/config/typecheck-e2e-diagnostics.json
@@ -1,0 +1,1685 @@
+{
+  "version": 1,
+  "diagnostics": [
+    {
+      "file": "tests/e2e/activity-agent-pane-isolation.spec.ts",
+      "line": 159,
+      "column": 13,
+      "code": 2551,
+      "message": "Property 'toggleWorktreeCardProperty' does not exist on type 'AppState'. Did you mean 'worktreeCardProperties'?"
+    },
+    {
+      "file": "tests/e2e/agent-dashboard-status-burst.spec.ts",
+      "line": 45,
+      "column": 11,
+      "code": 2322,
+      "message": "Type '\"drawer\"' is not assignable to type 'AgentDashboardMode | undefined'."
+    },
+    {
+      "file": "tests/e2e/ai-vault-typing-bench-renderer-probe.ts",
+      "line": 85,
+      "column": 9,
+      "code": 2322,
+      "message": "Type 'number' is not assignable to type 'null'."
+    },
+    {
+      "file": "tests/e2e/app-menu-paste-ownership.spec.ts",
+      "line": 75,
+      "column": 15,
+      "code": 2339,
+      "message": "Property 'customTitle' does not exist on type '{ id: string; title?: string | undefined; }'."
+    },
+    {
+      "file": "tests/e2e/artificial-opencode-main-pressure-scenario.ts",
+      "line": 244,
+      "column": 5,
+      "code": 2345,
+      "message": "Argument of type 'Awaited<TMainPressure> | null' is not assignable to parameter of type 'ScrollMainPressureSnapshot | null'.\n  Type 'Awaited<TMainPressure>' is not assignable to type 'ScrollMainPressureSnapshot | null'.\n    Type 'TMainPressure | (TMainPressure extends object & { then(onfulfilled: infer F, ...args: infer _): any; } ? F extends (value: infer V, ...args: infer _) => any ? Awaited<...> : never : TMainPressure)' is not assignable to type 'ScrollMainPressureSnapshot | null'.\n      Type '(null | undefined) & TMainPressure' is not assignable to type 'ScrollMainPressureSnapshot | null'.\n        Type 'undefined & TMainPressure' is not assignable to type 'ScrollMainPressureSnapshot | null'.\n          Type 'undefined & TMainPressure' is not assignable to type 'ScrollMainPressureSnapshot'.\n            Type 'Awaited<TMainPressure>' is not assignable to type 'ScrollMainPressureSnapshot'.\n              Type 'TMainPressure | (TMainPressure extends object & { then(onfulfilled: infer F, ...args: infer _): any; } ? F extends (value: infer V, ...args: infer _) => any ? Awaited<...> : never : TMainPressure)' is not assignable to type 'ScrollMainPressureSnapshot'.\n                Type '(null | undefined) & TMainPressure' is not assignable to type 'ScrollMainPressureSnapshot'.\n                  Type 'undefined & TMainPressure' is not assignable to type 'ScrollMainPressureSnapshot'."
+    },
+    {
+      "file": "tests/e2e/artificial-opencode-terminal-load.spec.ts",
+      "line": 450,
+      "column": 23,
+      "code": 2339,
+      "message": "Property 'rendererDroppedBacklogs' does not exist on type 'TerminalOutputSchedulerDebugSnapshot'."
+    },
+    {
+      "file": "tests/e2e/automation-hidden-terminal-first-mount.spec.ts",
+      "line": 99,
+      "column": 13,
+      "code": 2322,
+      "message": "Type '\"automation_hidden_first_mount_e2e\"' is not assignable to type '\"command_palette\" | \"conflict_resolution\" | \"diff_notes_send\" | \"new_workspace_composer\" | \"notes_send\" | \"onboarding\" | \"quick_command\" | \"shortcut\" | \"sidebar\" | \"source_control_recovery\" | ... 4 more ... | \"workspace_jump_palette\"'."
+    },
+    {
+      "file": "tests/e2e/automation-prompt-disclosure.spec.ts",
+      "line": 37,
+      "column": 36,
+      "code": 2339,
+      "message": "Property 'create' does not exist on type 'AutomationsApi'."
+    },
+    {
+      "file": "tests/e2e/automation-prompt-disclosure.spec.ts",
+      "line": 42,
+      "column": 36,
+      "code": 2339,
+      "message": "Property 'create' does not exist on type 'AutomationsApi'."
+    },
+    {
+      "file": "tests/e2e/automation-prompt-disclosure.spec.ts",
+      "line": 59,
+      "column": 36,
+      "code": 2339,
+      "message": "Property 'create' does not exist on type 'AutomationsApi'."
+    },
+    {
+      "file": "tests/e2e/browser-split-find-shortcut.spec.ts",
+      "line": 147,
+      "column": 27,
+      "code": 2322,
+      "message": "Type 'string' is not assignable to type '\"alt\" | \"capslock\" | \"cmd\" | \"command\" | \"control\" | \"ctrl\" | \"isautorepeat\" | \"iskeypad\" | \"left\" | \"leftbuttondown\" | \"meta\" | \"middlebuttondown\" | \"numlock\" | \"right\" | \"rightbuttondown\" | \"shift\"'."
+    },
+    {
+      "file": "tests/e2e/browser-split-find-shortcut.spec.ts",
+      "line": 152,
+      "column": 27,
+      "code": 2322,
+      "message": "Type 'string' is not assignable to type '\"alt\" | \"capslock\" | \"cmd\" | \"command\" | \"control\" | \"ctrl\" | \"isautorepeat\" | \"iskeypad\" | \"left\" | \"leftbuttondown\" | \"meta\" | \"middlebuttondown\" | \"numlock\" | \"right\" | \"rightbuttondown\" | \"shift\"'."
+    },
+    {
+      "file": "tests/e2e/browser-split-find-shortcut.spec.ts",
+      "line": 46,
+      "column": 3,
+      "code": 2322,
+      "message": "Type '{ firstBrowserPageId: string | null | undefined; firstBrowserTabId: string; secondBrowserTabId: string; }' is not assignable to type 'BrowserSplitFixture'.\n  Types of property 'firstBrowserPageId' are incompatible.\n    Type 'string | null | undefined' is not assignable to type 'string'.\n      Type 'undefined' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/browser-tab.spec.ts",
+      "line": 555,
+      "column": 68,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type '{ once: boolean; }' is not assignable to parameter of type 'boolean | undefined'."
+    },
+    {
+      "file": "tests/e2e/browser-tab.spec.ts",
+      "line": 600,
+      "column": 85,
+      "code": 2322,
+      "message": "Type 'string' is not assignable to type '\"alt\" | \"capslock\" | \"cmd\" | \"command\" | \"control\" | \"ctrl\" | \"isautorepeat\" | \"iskeypad\" | \"left\" | \"leftbuttondown\" | \"meta\" | \"middlebuttondown\" | \"numlock\" | \"right\" | \"rightbuttondown\" | \"shift\"'."
+    },
+    {
+      "file": "tests/e2e/browser-tab.spec.ts",
+      "line": 601,
+      "column": 83,
+      "code": 2322,
+      "message": "Type 'string' is not assignable to type '\"alt\" | \"capslock\" | \"cmd\" | \"command\" | \"control\" | \"ctrl\" | \"isautorepeat\" | \"iskeypad\" | \"left\" | \"leftbuttondown\" | \"meta\" | \"middlebuttondown\" | \"numlock\" | \"right\" | \"rightbuttondown\" | \"shift\"'."
+    },
+    {
+      "file": "tests/e2e/browser-tab.spec.ts",
+      "line": 665,
+      "column": 69,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type '{ once: boolean; }' is not assignable to parameter of type 'boolean | undefined'."
+    },
+    {
+      "file": "tests/e2e/chinese-ime-chat-input-repro.spec.ts",
+      "line": 679,
+      "column": 23,
+      "code": 2345,
+      "message": "Argument of type 'CDPSession | null' is not assignable to parameter of type 'CDPSession'.\n  Type 'null' is not assignable to type 'CDPSession'."
+    },
+    {
+      "file": "tests/e2e/chinese-ime-chat-input-repro.spec.ts",
+      "line": 697,
+      "column": 23,
+      "code": 2345,
+      "message": "Argument of type 'CDPSession | null' is not assignable to parameter of type 'CDPSession'.\n  Type 'null' is not assignable to type 'CDPSession'."
+    },
+    {
+      "file": "tests/e2e/chinese-ime-chat-input-repro.spec.ts",
+      "line": 717,
+      "column": 23,
+      "code": 2345,
+      "message": "Argument of type 'CDPSession | null' is not assignable to parameter of type 'CDPSession'.\n  Type 'null' is not assignable to type 'CDPSession'."
+    },
+    {
+      "file": "tests/e2e/combined-diff-scroll-restore.spec.ts",
+      "line": 403,
+      "column": 36,
+      "code": 2339,
+      "message": "Property 'x' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/combined-diff-scroll-restore.spec.ts",
+      "line": 403,
+      "column": 49,
+      "code": 2339,
+      "message": "Property 'y' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/completed-worker-retirement-resume.spec.ts",
+      "line": 29,
+      "column": 43,
+      "code": 2322,
+      "message": "Type '[{ PATH: string; ORCA_E2E_CODEX_LIFECYCLE_LEDGER: string; }, { option: true; }]' is not assignable to type '[TestFixtureValue<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>, { ...; }] | TestFixtureValue<...> | undefined'.\n  Type '[{ PATH: string; ORCA_E2E_CODEX_LIFECYCLE_LEDGER: string; }, { option: true; }]' is not assignable to type 'TestFixture<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures> | [...]'.\n    Type '[{ PATH: string; ORCA_E2E_CODEX_LIFECYCLE_LEDGER: string; }, { option: true; }]' is not assignable to type '[TestFixtureValue<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>, { ...; }]'.\n      Type at position 1 in source is not compatible with type at position 1 in target.\n        Object literal may only specify known properties, and 'option' does not exist in type '{ scope: \"test\"; timeout?: number | undefined; title?: string | undefined; box?: \"self\" | boolean | undefined; }'."
+    },
+    {
+      "file": "tests/e2e/daemon-generation-legacy-close-safety.spec.ts",
+      "line": 103,
+      "column": 5,
+      "code": 2353,
+      "message": "Object literal may only specify known properties, and 'windowsHide' does not exist in type 'ForkOptions'."
+    },
+    {
+      "file": "tests/e2e/daemon-generation-reconnect-safety.spec.ts",
+      "line": 137,
+      "column": 5,
+      "code": 2353,
+      "message": "Object literal may only specify known properties, and 'windowsHide' does not exist in type 'ForkOptions'."
+    },
+    {
+      "file": "tests/e2e/editable-context-paste-ownership.spec.ts",
+      "line": 54,
+      "column": 15,
+      "code": 2339,
+      "message": "Property 'customTitle' does not exist on type '{ id: string; title?: string | undefined; }'."
+    },
+    {
+      "file": "tests/e2e/ephemeral-vm-provisioned-root.spec.ts",
+      "line": 115,
+      "column": 50,
+      "code": 2345,
+      "message": "Argument of type 'DockerSshRelayTarget | null' is not assignable to parameter of type 'DockerSshRelayTarget'.\n  Type 'null' is not assignable to type 'DockerSshRelayTarget'."
+    },
+    {
+      "file": "tests/e2e/fixtures/daemon-generation-legacy-close-client.ts",
+      "line": 161,
+      "column": 56,
+      "code": 2345,
+      "message": "Argument of type 'string | null | undefined' is not assignable to parameter of type '{ deadlineMs?: number | undefined; } | undefined'.\n  Type 'null' is not assignable to type '{ deadlineMs?: number | undefined; } | undefined'."
+    },
+    {
+      "file": "tests/e2e/fixtures/daemon-generation-legacy-close-client.ts",
+      "line": 210,
+      "column": 34,
+      "code": 2339,
+      "message": "Property 'parentTabId' does not exist on type 'RuntimeMobileSessionSnapshotTab'.\n  Property 'parentTabId' does not exist on type 'RuntimeMobileSessionBrowserTab'."
+    },
+    {
+      "file": "tests/e2e/fixtures/daemon-generation-legacy-close-client.ts",
+      "line": 213,
+      "column": 41,
+      "code": 2339,
+      "message": "Property 'leafId' does not exist on type 'RuntimeMobileSessionSnapshotTab'.\n  Property 'leafId' does not exist on type 'RuntimeMobileSessionBrowserTab'."
+    },
+    {
+      "file": "tests/e2e/fixtures/daemon-generation-legacy-close-client.ts",
+      "line": 217,
+      "column": 34,
+      "code": 2339,
+      "message": "Property 'parentTabId' does not exist on type 'RuntimeMobileSessionSnapshotTab'.\n  Property 'parentTabId' does not exist on type 'RuntimeMobileSessionBrowserTab'."
+    },
+    {
+      "file": "tests/e2e/fixtures/daemon-generation-legacy-close-client.ts",
+      "line": 219,
+      "column": 35,
+      "code": 2339,
+      "message": "Property 'leafId' does not exist on type 'RuntimeMobileSessionSnapshotTab'.\n  Property 'leafId' does not exist on type 'RuntimeMobileSessionBrowserTab'."
+    },
+    {
+      "file": "tests/e2e/fixtures/daemon-generation-reconnect-client.ts",
+      "line": 162,
+      "column": 54,
+      "code": 2345,
+      "message": "Argument of type 'string | null | undefined' is not assignable to parameter of type '{ deadlineMs?: number | undefined; } | undefined'.\n  Type 'null' is not assignable to type '{ deadlineMs?: number | undefined; } | undefined'."
+    },
+    {
+      "file": "tests/e2e/fixtures/daemon-generation-reconnect-client.ts",
+      "line": 275,
+      "column": 92,
+      "code": 2345,
+      "message": "Argument of type 'DaemonPtyRouter | null' is not assignable to parameter of type 'DaemonPtyRouter'.\n  Type 'null' is not assignable to type 'DaemonPtyRouter'."
+    },
+    {
+      "file": "tests/e2e/fixtures/daemon-lifecycle-entry.ts",
+      "line": 5,
+      "column": 15,
+      "code": 2459,
+      "message": "Module '\"../../../src/main/daemon/session\"' declares 'SubprocessHandle' locally, but it is not exported."
+    },
+    {
+      "file": "tests/e2e/github-cli-stall-repro.spec.ts",
+      "line": 116,
+      "column": 59,
+      "code": 2322,
+      "message": "Type '{ id: string; type: string; number: number; title: string; state: string; url: string; labels: never[]; updatedAt: string; author: string; repoId: string; }' is not assignable to type 'GitHubWorkItem'.\n  Types of property 'type' are incompatible.\n    Type 'string' is not assignable to type '\"issue\" | \"pr\"'."
+    },
+    {
+      "file": "tests/e2e/github-cli-stall-repro.spec.ts",
+      "line": 59,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '[{ PATH: string; ORCA_GH_EXEC_TIMEOUT_MS: string; }, { option: true; }]' is not assignable to type '[TestFixtureValue<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>, { ...; }] | TestFixtureValue<...> | undefined'.\n  Type '[{ PATH: string; ORCA_GH_EXEC_TIMEOUT_MS: string; }, { option: true; }]' is not assignable to type 'TestFixture<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures> | [...]'.\n    Type '[{ PATH: string; ORCA_GH_EXEC_TIMEOUT_MS: string; }, { option: true; }]' is not assignable to type '[TestFixtureValue<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>, { ...; }]'.\n      Type at position 1 in source is not compatible with type at position 1 in target.\n        Object literal may only specify known properties, and 'option' does not exist in type '{ scope: \"test\"; timeout?: number | undefined; title?: string | undefined; box?: \"self\" | boolean | undefined; }'."
+    },
+    {
+      "file": "tests/e2e/github-created-issue-start-prefill.spec.ts",
+      "line": 102,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '[{ PATH: string; }, { option: true; }]' is not assignable to type '[TestFixtureValue<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>, { ...; }] | TestFixtureValue<...> | undefined'.\n  Type '[{ PATH: string; }, { option: true; }]' is not assignable to type 'TestFixture<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures> | [...]'.\n    Type '[{ PATH: string; }, { option: true; }]' is not assignable to type '[TestFixtureValue<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>, { ...; }]'.\n      Type at position 1 in source is not compatible with type at position 1 in target.\n        Object literal may only specify known properties, and 'option' does not exist in type '{ scope: \"test\"; timeout?: number | undefined; title?: string | undefined; box?: \"self\" | boolean | undefined; }'."
+    },
+    {
+      "file": "tests/e2e/golden-worktree-create-switch.spec.ts",
+      "line": 25,
+      "column": 53,
+      "code": 2345,
+      "message": "Argument of type 'string' is not assignable to parameter of type 'WorktreeRemovalTarget'."
+    },
+    {
+      "file": "tests/e2e/headless-serve-desktop-activation.spec.ts",
+      "line": 143,
+      "column": 7,
+      "code": 2322,
+      "message": "Type 'ProcessEnv' is not assignable to type '{ [key: string]: string; }'.\n  'string' index signatures are incompatible.\n    Type 'string | undefined' is not assignable to type 'string'.\n      Type 'undefined' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/helpers/daemon-generation-safety-fixtures.ts",
+      "line": 93,
+      "column": 7,
+      "code": 2353,
+      "message": "Object literal may only specify known properties, and 'windowsHide' does not exist in type 'ForkOptions'."
+    },
+    {
+      "file": "tests/e2e/helpers/dead-terminal.ts",
+      "line": 129,
+      "column": 55,
+      "code": 2345,
+      "message": "Argument of type 'string' is not assignable to parameter of type 'WorktreeRemovalTarget'."
+    },
+    {
+      "file": "tests/e2e/helpers/headless-paired-runtime-host.ts",
+      "line": 128,
+      "column": 9,
+      "code": 2322,
+      "message": "Type 'ProcessEnv' is not assignable to type '{ [key: string]: string; }'.\n  'string' index signatures are incompatible.\n    Type 'string | undefined' is not assignable to type 'string'.\n      Type 'undefined' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/helpers/headless-paired-runtime-host.ts",
+      "line": 165,
+      "column": 26,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'PathLike'.\n  Type 'null' is not assignable to type 'PathLike'."
+    },
+    {
+      "file": "tests/e2e/helpers/headless-paired-runtime-host.ts",
+      "line": 177,
+      "column": 49,
+      "code": 2345,
+      "message": "Argument of type 'ElectronApplication | undefined' is not assignable to parameter of type 'ElectronApplication'.\n  Type 'undefined' is not assignable to type 'ElectronApplication'."
+    },
+    {
+      "file": "tests/e2e/helpers/headless-paired-runtime-host.ts",
+      "line": 181,
+      "column": 27,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'PathLike'.\n  Type 'null' is not assignable to type 'PathLike'."
+    },
+    {
+      "file": "tests/e2e/helpers/nested-runtime-ssh-client-route.ts",
+      "line": 117,
+      "column": 29,
+      "code": 2339,
+      "message": "Property 'targets' does not exist on type 'RuntimeEnvironmentSshBucket'."
+    },
+    {
+      "file": "tests/e2e/helpers/nested-runtime-ssh-client-route.ts",
+      "line": 74,
+      "column": 37,
+      "code": 18047,
+      "message": "'state.settings' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/helpers/paired-html-preview-inventory.ts",
+      "line": 54,
+      "column": 9,
+      "code": 18046,
+      "message": "'response.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/helpers/paired-html-preview-inventory.ts",
+      "line": 76,
+      "column": 40,
+      "code": 18046,
+      "message": "'response.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/helpers/paired-html-preview-inventory.ts",
+      "line": 83,
+      "column": 11,
+      "code": 18046,
+      "message": "'response.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/helpers/paired-terminal-cold-activation-oracle.ts",
+      "line": 141,
+      "column": 70,
+      "code": 2538,
+      "message": "Type 'null' cannot be used as an index type."
+    },
+    {
+      "file": "tests/e2e/helpers/paired-terminal-cold-activation-oracle.ts",
+      "line": 161,
+      "column": 22,
+      "code": 18047,
+      "message": "'originalPtyIds' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/helpers/pr-comments-sidebar-fixture.ts",
+      "line": 125,
+      "column": 32,
+      "code": 6133,
+      "message": "'repoPath' is declared but its value is never read."
+    },
+    {
+      "file": "tests/e2e/helpers/pr-comments-sidebar-fixture.ts",
+      "line": 95,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '(current: AppState) => { prCache: { [x: string]: CacheEntry<PRInfo> | { data: PRInfo; fetchedAt: number; }; }; repos: Repo[]; gitStatusByWorktree: { ...; }; ... 7 more ...; setUpstreamStatus: () => undefined; }' is not assignable to parameter of type 'Partial<AppState> | ((state: AppState) => Partial<AppState>)'.\n  Type '(current: AppState) => { prCache: { [x: string]: CacheEntry<PRInfo> | { data: PRInfo; fetchedAt: number; }; }; repos: Repo[]; gitStatusByWorktree: { ...; }; ... 7 more ...; setUpstreamStatus: () => undefined; }' is not assignable to type '(state: AppState) => Partial<AppState>'.\n    Type '{ prCache: { [x: string]: CacheEntry<PRInfo> | { data: PRInfo; fetchedAt: number; }; }; repos: Repo[]; gitStatusByWorktree: { [x: string]: never[] | GitUncommittedEntry[]; }; ... 7 more ...; setUpstreamStatus: () => undefined; }' is not assignable to type 'Partial<AppState>'.\n      The types returned by 'fetchUpstreamStatus(...)' are incompatible between these types.\n        Type 'Promise<undefined>' is not assignable to type 'Promise<GitUpstreamStatus | null>'.\n          Type 'undefined' is not assignable to type 'GitUpstreamStatus | null'."
+    },
+    {
+      "file": "tests/e2e/helpers/shortcuts.ts",
+      "line": 35,
+      "column": 16,
+      "code": 2345,
+      "message": "Argument of type '\"Shift\"' is not assignable to parameter of type '\"Control\" | \"Meta\"'."
+    },
+    {
+      "file": "tests/e2e/helpers/shortcuts.ts",
+      "line": 37,
+      "column": 14,
+      "code": 2345,
+      "message": "Argument of type 'string' is not assignable to parameter of type '\"Control\" | \"Meta\"'."
+    },
+    {
+      "file": "tests/e2e/helpers/source-control-ai-generation.ts",
+      "line": 111,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '(current: AppState) => { repos: Repo[]; gitStatusByWorktree: { [x: string]: never[] | GitUncommittedEntry[]; }; remoteStatusesByWorktree: { [x: string]: GitUpstreamStatus | { ...; }; }; ... 4 more ...; setUpstreamStatus: () => undefined; }' is not assignable to parameter of type 'Partial<AppState> | ((state: AppState) => Partial<AppState>)'.\n  Type '(current: AppState) => { repos: Repo[]; gitStatusByWorktree: { [x: string]: never[] | GitUncommittedEntry[]; }; remoteStatusesByWorktree: { [x: string]: GitUpstreamStatus | { ...; }; }; ... 4 more ...; setUpstreamStatus: () => undefined; }' is not assignable to type '(state: AppState) => Partial<AppState>'.\n    Type '{ repos: Repo[]; gitStatusByWorktree: { [x: string]: never[] | GitUncommittedEntry[]; }; remoteStatusesByWorktree: { [x: string]: GitUpstreamStatus | { ...; }; }; ... 4 more ...; setUpstreamStatus: () => undefined; }' is not assignable to type 'Partial<AppState>'.\n      The types returned by 'fetchUpstreamStatus(...)' are incompatible between these types.\n        Type 'Promise<undefined>' is not assignable to type 'Promise<GitUpstreamStatus | null>'.\n          Type 'undefined' is not assignable to type 'GitUpstreamStatus | null'."
+    },
+    {
+      "file": "tests/e2e/helpers/source-control-ai-generation.ts",
+      "line": 216,
+      "column": 20,
+      "code": 2551,
+      "message": "Property 'gitBranchCompareEntriesByWorktree' does not exist on type 'AppState'. Did you mean 'gitBranchChangesByWorktree'?"
+    },
+    {
+      "file": "tests/e2e/helpers/source-control-ai-generation.ts",
+      "line": 284,
+      "column": 20,
+      "code": 2551,
+      "message": "Property 'gitBranchCompareEntriesByWorktree' does not exist on type 'AppState'. Did you mean 'gitBranchChangesByWorktree'?"
+    },
+    {
+      "file": "tests/e2e/helpers/ssh-port-forward-transport-evidence.ts",
+      "line": 93,
+      "column": 42,
+      "code": 2345,
+      "message": "Argument of type 'SshConnectionState' is not assignable to parameter of type 'CapturedSshState'.\n  Types of property 'providerEpoch' are incompatible.\n    Type 'SshProviderEpoch | null | undefined' is not assignable to type 'string | undefined'.\n      Type 'null' is not assignable to type 'string | undefined'."
+    },
+    {
+      "file": "tests/e2e/helpers/store.ts",
+      "line": 61,
+      "column": 37,
+      "code": 2741,
+      "message": "Property 'customTitle' is missing in type '{ id: string; title: string; }' but required in type 'TerminalTabSummary'."
+    },
+    {
+      "file": "tests/e2e/helpers/store.ts",
+      "line": 91,
+      "column": 9,
+      "code": 18048,
+      "message": "'activeGroup.tabOrder.length' is possibly 'undefined'."
+    },
+    {
+      "file": "tests/e2e/helpers/store.ts",
+      "line": 93,
+      "column": 14,
+      "code": 18048,
+      "message": "'activeGroup' is possibly 'undefined'."
+    },
+    {
+      "file": "tests/e2e/helpers/terminal-pty-write-spy.ts",
+      "line": 93,
+      "column": 52,
+      "code": 2345,
+      "message": "Argument of type 'typeof CrossProcessExports' is not assignable to parameter of type 'number'."
+    },
+    {
+      "file": "tests/e2e/helpers/terminal.ts",
+      "line": 408,
+      "column": 15,
+      "code": 2339,
+      "message": "Property 'movePane' does not exist on type 'PaneManagerLike'."
+    },
+    {
+      "file": "tests/e2e/helpers/terminal.ts",
+      "line": 43,
+      "column": 25,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/issue-12656-terminal-link-tooltip.spec.ts",
+      "line": 146,
+      "column": 57,
+      "code": 2339,
+      "message": "Property 'tabId' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/issue-12656-terminal-link-tooltip.spec.ts",
+      "line": 150,
+      "column": 36,
+      "code": 2345,
+      "message": "Argument of type 'LinkProbe | null' is not assignable to parameter of type 'LinkProbe'.\n  Type 'null' is not assignable to type 'LinkProbe'."
+    },
+    {
+      "file": "tests/e2e/issue-12656-terminal-link-tooltip.spec.ts",
+      "line": 151,
+      "column": 43,
+      "code": 18047,
+      "message": "'probe' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/issue-12656-terminal-link-tooltip.spec.ts",
+      "line": 155,
+      "column": 60,
+      "code": 2339,
+      "message": "Property 'tabId' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/issue-12656-terminal-link-tooltip.spec.ts",
+      "line": 165,
+      "column": 46,
+      "code": 18047,
+      "message": "'probe' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/issue-12656-terminal-link-tooltip.spec.ts",
+      "line": 167,
+      "column": 60,
+      "code": 2339,
+      "message": "Property 'tabId' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/korean-ime-terminal-shift-enter-commit.spec.ts",
+      "line": 483,
+      "column": 19,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type 'boolean | undefined' is not assignable to parameter of type 'ConditionBody<PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>'.\n      Type 'undefined' is not assignable to type 'ConditionBody<PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>'."
+    },
+    {
+      "file": "tests/e2e/large-diff-freeze-repro.spec.ts",
+      "line": 203,
+      "column": 79,
+      "code": 2345,
+      "message": "Argument of type '{ path: string; status: GitFileStatus; oldPath?: string | undefined; conflictKind?: GitConflictKind | undefined; conflictStatus?: GitConflictResolutionStatus | undefined; ... 5 more ...; area: string; }[]' is not assignable to parameter of type 'GitUncommittedEntry[]'.\n  Type '{ path: string; status: GitFileStatus; oldPath?: string; conflictKind?: GitConflictKind; conflictStatus?: GitConflictResolutionStatus; conflictStatusSource?: GitConflictStatusSource; ... 4 more ...; area: string; }' is not assignable to type 'GitUncommittedEntry'.\n    Types of property 'area' are incompatible.\n      Type 'string' is not assignable to type 'GitStagingArea'."
+    },
+    {
+      "file": "tests/e2e/linear-issue-view-persistence.spec.ts",
+      "line": 202,
+      "column": 17,
+      "code": 2352,
+      "message": "Conversion of type '{ readonly \"linear-team-a\": readonly [{ readonly id: 'linear-state-a'; readonly name: 'In Review'; readonly type: 'started'; readonly color: '#888888'; readonly position: 1; }]; readonly \"linear-team-b\": readonly [{ ...; }]; }' to type 'Record<string, { readonly id: \"linear-state-a\"; readonly name: \"In Review\"; readonly type: \"started\"; readonly color: \"#888888\"; readonly position: 1; }[]>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.\n  Property '\"linear-team-a\"' is incompatible with index signature.\n    The type 'readonly [{ readonly id: \"linear-state-a\"; readonly name: \"In Review\"; readonly type: \"started\"; readonly color: \"#888888\"; readonly position: 1; }]' is 'readonly' and cannot be assigned to the mutable type '{ readonly id: \"linear-state-a\"; readonly name: \"In Review\"; readonly type: \"started\"; readonly color: \"#888888\"; readonly position: 1; }[]'."
+    },
+    {
+      "file": "tests/e2e/live-background-terminal-mount-authority.spec.ts",
+      "line": 546,
+      "column": 11,
+      "code": 2322,
+      "message": "Type '{ mode?: \"auto\" | \"override\" | undefined; setupRunPolicy?: SetupRunPolicy; commandSourcePolicy?: HookCommandSourcePolicy; scripts?: { setup: string; archive: string; } | undefined; setupAgentStartupPolicy: \"start-immediately\"; }' is not assignable to type 'RepoHookSettings'.\n  Types of property 'mode' are incompatible.\n    Type '\"auto\" | \"override\" | undefined' is not assignable to type '\"auto\" | \"override\"'.\n      Type 'undefined' is not assignable to type '\"auto\" | \"override\"'."
+    },
+    {
+      "file": "tests/e2e/live-background-terminal-mount-authority.spec.ts",
+      "line": 655,
+      "column": 51,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/live-background-terminal-mount-authority.spec.ts",
+      "line": 673,
+      "column": 51,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/live-background-terminal-mount-authority.spec.ts",
+      "line": 763,
+      "column": 59,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/live-background-terminal-mount-authority.spec.ts",
+      "line": 777,
+      "column": 51,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/live-background-terminal-mount-authority.spec.ts",
+      "line": 804,
+      "column": 51,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/live-background-terminal-mount-authority.spec.ts",
+      "line": 82,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '[{ PATH: string; ORCA_E2E_CODEX_SPAWN_LEDGER: string; ORCA_E2E_SETUP_LEDGER: string; ORCA_E2E_CANARY_LEDGER: string; ORCA_E2E_SIGNAL_LEDGER: string; }, { option: true; }]' is not assignable to type '[TestFixtureValue<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>, { ...; }] | TestFixtureValue<...> | undefined'.\n  Type '[{ PATH: string; ORCA_E2E_CODEX_SPAWN_LEDGER: string; ORCA_E2E_SETUP_LEDGER: string; ORCA_E2E_CANARY_LEDGER: string; ORCA_E2E_SIGNAL_LEDGER: string; }, { option: true; }]' is not assignable to type 'TestFixture<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures> | [...]'.\n    Type '[{ PATH: string; ORCA_E2E_CODEX_SPAWN_LEDGER: string; ORCA_E2E_SETUP_LEDGER: string; ORCA_E2E_CANARY_LEDGER: string; ORCA_E2E_SIGNAL_LEDGER: string; }, { option: true; }]' is not assignable to type '[TestFixtureValue<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>, { ...; }]'.\n      Type at position 1 in source is not compatible with type at position 1 in target.\n        Object literal may only specify known properties, and 'option' does not exist in type '{ scope: \"test\"; timeout?: number | undefined; title?: string | undefined; box?: \"self\" | boolean | undefined; }'."
+    },
+    {
+      "file": "tests/e2e/local-worktree-visibility-runtime-active.spec.ts",
+      "line": 67,
+      "column": 32,
+      "code": 2345,
+      "message": "Argument of type '(current: AppState) => { settings: { workspaceDir?: string | undefined; worktreeVisibilityDefaults?: WorktreeVisibilityDefaults | undefined; ... 207 more ...; activeRuntimeEnvironmentId: string; }; }' is not assignable to parameter of type 'Partial<AppState> | ((state: AppState) => Partial<AppState>)'.\n  Type '(current: AppState) => { settings: { workspaceDir?: string | undefined; worktreeVisibilityDefaults?: WorktreeVisibilityDefaults | undefined; ... 207 more ...; activeRuntimeEnvironmentId: string; }; }' is not assignable to type '(state: AppState) => Partial<AppState>'.\n    Type '{ settings: { workspaceDir?: string | undefined; worktreeVisibilityDefaults?: WorktreeVisibilityDefaults; hostSettingOverrides?: Partial<Record<ExecutionHostId, HostSettingOverrides>>; ... 206 more ...; activeRuntimeEnvironmentId: string; }; }' is not assignable to type 'Partial<AppState>'.\n      The types of 'settings.workspaceDir' are incompatible between these types.\n        Type 'string | undefined' is not assignable to type 'string'.\n          Type 'undefined' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/multi-client-navigation-isolation.spec.ts",
+      "line": 301,
+      "column": 15,
+      "code": 18048,
+      "message": "'state' is possibly 'undefined'."
+    },
+    {
+      "file": "tests/e2e/multi-client-navigation-isolation.spec.ts",
+      "line": 301,
+      "column": 15,
+      "code": 2531,
+      "message": "Object is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/nested-runtime-ssh-lifecycle.spec.ts",
+      "line": 725,
+      "column": 31,
+      "code": 2551,
+      "message": "Property 'switchRuntimeEnvironment' does not exist on type 'AppState'. Did you mean 'setRuntimeEnvironments'?"
+    },
+    {
+      "file": "tests/e2e/onboarding.spec.ts",
+      "line": 507,
+      "column": 32,
+      "code": 2339,
+      "message": "Property 'requestPermission' does not exist on type 'NotificationsApi'."
+    },
+    {
+      "file": "tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts",
+      "line": 335,
+      "column": 60,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts",
+      "line": 337,
+      "column": 68,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/orchestration-worker-settlement-release-cli.spec.ts",
+      "line": 99,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '[{ PATH: string; ORCA_E2E_CLI_ENTRY: string; ORCA_E2E_CLI_LEDGER: string; }, { option: true; }]' is not assignable to type '[TestFixtureValue<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>, { ...; }] | TestFixtureValue<...> | undefined'.\n  Type '[{ PATH: string; ORCA_E2E_CLI_ENTRY: string; ORCA_E2E_CLI_LEDGER: string; }, { option: true; }]' is not assignable to type 'TestFixture<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures> | [...]'.\n    Type '[{ PATH: string; ORCA_E2E_CLI_ENTRY: string; ORCA_E2E_CLI_LEDGER: string; }, { option: true; }]' is not assignable to type '[TestFixtureValue<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>, { ...; }]'.\n      Type at position 1 in source is not compatible with type at position 1 in target.\n        Object literal may only specify known properties, and 'option' does not exist in type '{ scope: \"test\"; timeout?: number | undefined; title?: string | undefined; box?: \"self\" | boolean | undefined; }'."
+    },
+    {
+      "file": "tests/e2e/orchestration-worker-terminal-visibility.spec.ts",
+      "line": 75,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '[{ PATH: string; ORCA_E2E_SPAWN_LEDGER: string; ORCA_E2E_INTERRUPTION_LEDGER: string; }, { option: true; }]' is not assignable to type '[TestFixtureValue<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>, { ...; }] | TestFixtureValue<...> | undefined'.\n  Type '[{ PATH: string; ORCA_E2E_SPAWN_LEDGER: string; ORCA_E2E_INTERRUPTION_LEDGER: string; }, { option: true; }]' is not assignable to type 'TestFixture<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures> | [...]'.\n    Type '[{ PATH: string; ORCA_E2E_SPAWN_LEDGER: string; ORCA_E2E_INTERRUPTION_LEDGER: string; }, { option: true; }]' is not assignable to type '[TestFixtureValue<ProcessEnv, PlaywrightTestArgs & PlaywrightTestOptions & OrcaTestFixtures & PlaywrightWorkerArgs & PlaywrightWorkerOptions & OrcaWorkerFixtures>, { ...; }]'.\n      Type at position 1 in source is not compatible with type at position 1 in target.\n        Object literal may only specify known properties, and 'option' does not exist in type '{ scope: \"test\"; timeout?: number | undefined; title?: string | undefined; box?: \"self\" | boolean | undefined; }'."
+    },
+    {
+      "file": "tests/e2e/packaged-mixed-version-browser-placement.spec.ts",
+      "line": 199,
+      "column": 7,
+      "code": 2322,
+      "message": "Type 'RuntimeStatus' is not assignable to type '{ capabilities: string[]; }'.\n  Types of property 'capabilities' are incompatible.\n    Type 'RuntimeCapability[] | undefined' is not assignable to type 'string[]'.\n      Type 'undefined' is not assignable to type 'string[]'."
+    },
+    {
+      "file": "tests/e2e/packaged-mixed-version-browser-placement.spec.ts",
+      "line": 214,
+      "column": 47,
+      "code": 2345,
+      "message": "Argument of type 'ElectronApplication | undefined' is not assignable to parameter of type 'ElectronApplication'.\n  Type 'undefined' is not assignable to type 'ElectronApplication'."
+    },
+    {
+      "file": "tests/e2e/paired-quick-open-large-tree.spec.ts",
+      "line": 110,
+      "column": 12,
+      "code": 18046,
+      "message": "'stat' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-quick-open-large-tree.spec.ts",
+      "line": 111,
+      "column": 12,
+      "code": 18046,
+      "message": "'stat' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-quick-open-large-tree.spec.ts",
+      "line": 163,
+      "column": 12,
+      "code": 18046,
+      "message": "'response.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-quick-open-large-tree.spec.ts",
+      "line": 77,
+      "column": 18,
+      "code": 18046,
+      "message": "'response.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-quick-open-large-tree.spec.ts",
+      "line": 78,
+      "column": 23,
+      "code": 18046,
+      "message": "'response.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-quick-open-large-tree.spec.ts",
+      "line": 79,
+      "column": 22,
+      "code": 18046,
+      "message": "'response.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-browser-link-open-routing.spec.ts",
+      "line": 275,
+      "column": 66,
+      "code": 2345,
+      "message": "Argument of type 'string' is not assignable to parameter of type 'ExecutionHostId | undefined'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 101,
+      "column": 27,
+      "code": 2339,
+      "message": "Property 'hostResponseOk' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 102,
+      "column": 56,
+      "code": 18047,
+      "message": "'browserBaseline' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 134,
+      "column": 17,
+      "code": 18046,
+      "message": "'response.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 199,
+      "column": 29,
+      "code": 2339,
+      "message": "Property 'clientWorkspaceIds' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 200,
+      "column": 29,
+      "code": 2339,
+      "message": "Property 'clientUnifiedTabs' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 201,
+      "column": 29,
+      "code": 2339,
+      "message": "Property 'hostTabIds' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 202,
+      "column": 29,
+      "code": 2339,
+      "message": "Property 'clientRemotePageIds' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 202,
+      "column": 75,
+      "code": 2339,
+      "message": "Property 'hostPageIds' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 203,
+      "column": 29,
+      "code": 2339,
+      "message": "Property 'totalClientUnified' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 203,
+      "column": 70,
+      "code": 2339,
+      "message": "Property 'totalClientUnified' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 204,
+      "column": 29,
+      "code": 2339,
+      "message": "Property 'totalClientWorkspaces' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 204,
+      "column": 73,
+      "code": 2339,
+      "message": "Property 'totalClientWorkspaces' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 205,
+      "column": 29,
+      "code": 2339,
+      "message": "Property 'totalHost' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 205,
+      "column": 61,
+      "code": 2339,
+      "message": "Property 'totalHost' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 206,
+      "column": 29,
+      "code": 2339,
+      "message": "Property 'clientUnifiedTabs' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 208,
+      "column": 24,
+      "code": 2339,
+      "message": "Property 'hostTabGroups' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 209,
+      "column": 33,
+      "code": 18047,
+      "message": "'htmlTabInventory' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 212,
+      "column": 49,
+      "code": 2339,
+      "message": "Property 'hostTabGroups' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 213,
+      "column": 31,
+      "code": 18047,
+      "message": "'htmlTabInventory' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 218,
+      "column": 65,
+      "code": 2339,
+      "message": "Property 'clientUnifiedTabs' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 289,
+      "column": 17,
+      "code": 18046,
+      "message": "'response.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 289,
+      "column": 63,
+      "code": 18046,
+      "message": "'response.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 293,
+      "column": 30,
+      "code": 18047,
+      "message": "'client' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 298,
+      "column": 45,
+      "code": 2339,
+      "message": "Property 'hostTabs' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 351,
+      "column": 62,
+      "code": 18047,
+      "message": "'client' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 380,
+      "column": 19,
+      "code": 18046,
+      "message": "'response.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 380,
+      "column": 65,
+      "code": 18046,
+      "message": "'response.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 426,
+      "column": 21,
+      "code": 18046,
+      "message": "'response.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 437,
+      "column": 29,
+      "code": 18047,
+      "message": "'htmlTabInventory' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+      "line": 438,
+      "column": 28,
+      "code": 18047,
+      "message": "'htmlTabInventory' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-pane-layout-retry.spec.ts",
+      "line": 176,
+      "column": 11,
+      "code": 18047,
+      "message": "'client' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-pane-layout-retry.spec.ts",
+      "line": 179,
+      "column": 14,
+      "code": 18047,
+      "message": "'client' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-pane-layout-retry.spec.ts",
+      "line": 81,
+      "column": 9,
+      "code": 2339,
+      "message": "Property 'parentLayout' does not exist on type 'RuntimeMobileSessionClientTab'.\n  Property 'parentLayout' does not exist on type 'RuntimeMobileSessionBrowserTab'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-terminal-browser-link.spec.ts",
+      "line": 81,
+      "column": 39,
+      "code": 18046,
+      "message": "'sessionResponse.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-terminal-browser-link.spec.ts",
+      "line": 84,
+      "column": 37,
+      "code": 18046,
+      "message": "'browserResponse.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-terminal-browser-link.spec.ts",
+      "line": 85,
+      "column": 27,
+      "code": 18046,
+      "message": "'sessionResponse.result' is of type 'unknown'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-terminal-host-restart-background-sync.spec.ts",
+      "line": 292,
+      "column": 25,
+      "code": 2345,
+      "message": "Argument of type '\"editor\"' is not assignable to parameter of type 'TopLevelView'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-terminal-parked-reveal-interactivity.spec.ts",
+      "line": 227,
+      "column": 30,
+      "code": 2339,
+      "message": "Property 'paneLayout' does not exist on type 'TerminalTab'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-terminal-parked-reveal-interactivity.spec.ts",
+      "line": 227,
+      "column": 62,
+      "code": 2339,
+      "message": "Property 'paneLayout' does not exist on type 'TerminalTab'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-terminal-stall-recovery.spec.ts",
+      "line": 375,
+      "column": 38,
+      "code": 18047,
+      "message": "'observer' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-terminal-stall-recovery.spec.ts",
+      "line": 472,
+      "column": 38,
+      "code": 18047,
+      "message": "'observer' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/paired-remote-terminal-stall-recovery.spec.ts",
+      "line": 576,
+      "column": 13,
+      "code": 18047,
+      "message": "'observer' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/paired-startup-exec-readiness.spec.ts",
+      "line": 147,
+      "column": 15,
+      "code": 18048,
+      "message": "'client' is possibly 'undefined'."
+    },
+    {
+      "file": "tests/e2e/plugin-demo.spec.ts",
+      "line": 175,
+      "column": 59,
+      "code": 2345,
+      "message": "Argument of type 'string' is not assignable to parameter of type 'WorktreeRemovalTarget'."
+    },
+    {
+      "file": "tests/e2e/plugin-marketplace-content.spec.ts",
+      "line": 277,
+      "column": 62,
+      "code": 2345,
+      "message": "Argument of type 'ProcessEnv' is not assignable to parameter of type 'Record<string, string>'.\n  'string' index signatures are incompatible.\n    Type 'string | undefined' is not assignable to type 'string'.\n      Type 'undefined' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/pr11346-selected-runtime-identity-oracle.ts",
+      "line": 120,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '(repoId: string, options?: WorktreeFetchOptions | undefined) => Promise<boolean>' is not assignable to type '{ (repoId: string, options: DirectSshWorktreeFetchOptions): Promise<HostQualifiedDetectedWorktreeResult>; (repoId: string, options?: WorktreeFetchOptions | undefined): Promise<...>; }'.\n  Type 'Promise<boolean>' is not assignable to type 'Promise<HostQualifiedDetectedWorktreeResult>'.\n    Type 'boolean' is not assignable to type 'HostQualifiedDetectedWorktreeResult'."
+    },
+    {
+      "file": "tests/e2e/pr11346-selected-runtime-identity-oracle.ts",
+      "line": 206,
+      "column": 9,
+      "code": 2322,
+      "message": "Type '{ [x: string]: { head: string; branch: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; isMainWorktree: boolean; ... 44 more ...; runtimeOwnerEnvironmentId: null; }[] | Worktree[]; }' is not assignable to type 'Record<string, Worktree[]>'.\n  'string' index signatures are incompatible.\n    Type '{ head: string; branch: string; isBare: boolean; isSparse?: boolean | undefined; locked?: boolean | undefined; lockReason?: string | undefined; prunable?: boolean | undefined; prunableReason?: string | undefined; ... 45 more ...; runtimeOwnerEnvironmentId: null; }[] | Worktree[]' is not assignable to type 'Worktree[]'.\n      Type '{ head: string; branch: string; isBare: boolean; isSparse?: boolean | undefined; locked?: boolean | undefined; lockReason?: string | undefined; prunable?: boolean | undefined; prunableReason?: string | undefined; ... 45 more ...; runtimeOwnerEnvironmentId: null; }[]' is not assignable to type 'Worktree[]'.\n        Type '{ head: string; branch: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; isMainWorktree: boolean; id: string; ... 43 more ...; runtimeOwnerEnvironmentId: null; }' is not assignable to type 'Worktree'.\n          Type '{ head: string; branch: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; isMainWorktree: boolean; id: string; ... 43 more ...; runtimeOwnerEnvironmentId: null; }' is not assignable to type '{ id: string; instanceId?: string | undefined; repoId: string; projectId?: string | undefined; hostId?: ExecutionHostId | undefined; runtimeOwnerEnvironmentId?: string | undefined; ... 37 more ...; cliProvenance?: CliWorkspaceProvenance | undefined; }'.\n            Types of property 'runtimeOwnerEnvironmentId' are incompatible.\n              Type 'null' is not assignable to type 'string | undefined'."
+    },
+    {
+      "file": "tests/e2e/project-group-manual-sort.spec.ts",
+      "line": 146,
+      "column": 19,
+      "code": 2345,
+      "message": "Argument of type 'ProjectGroup' is not assignable to parameter of type 'never'."
+    },
+    {
+      "file": "tests/e2e/project-group-manual-sort.spec.ts",
+      "line": 150,
+      "column": 27,
+      "code": 2339,
+      "message": "Property 'id' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/project-group-manual-sort.spec.ts",
+      "line": 151,
+      "column": 27,
+      "code": 2339,
+      "message": "Property 'id' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/project-group-manual-sort.spec.ts",
+      "line": 152,
+      "column": 29,
+      "code": 2339,
+      "message": "Property 'id' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/project-group-manual-sort.spec.ts",
+      "line": 153,
+      "column": 27,
+      "code": 2339,
+      "message": "Property 'id' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/remote-session-bulk-open-freeze-repro.spec.ts",
+      "line": 188,
+      "column": 22,
+      "code": 2339,
+      "message": "Property 'dispose' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/remote-session-bulk-open-freeze-repro.spec.ts",
+      "line": 189,
+      "column": 26,
+      "code": 2339,
+      "message": "Property 'dispose' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/restored-terminal-input-readiness.unit.test.ts",
+      "line": 74,
+      "column": 39,
+      "code": 2493,
+      "message": "Tuple type '[data: string]' of length '1' has no element at index '1'."
+    },
+    {
+      "file": "tests/e2e/setup-guide-sidebar.spec.ts",
+      "line": 262,
+      "column": 9,
+      "code": 2322,
+      "message": "Type '{ terminalBell?: boolean | undefined; suppressWhenFocused?: boolean | undefined; customSoundId?: \"beep\" | \"blip\" | \"blop\" | \"bong\" | \"clack\" | \"custom\" | \"ding\" | \"sonar\" | \"system\" | \"thump\" | \"two-tone\" | undefined; customSoundPath?: string | ... 1 more ... | undefined; customSoundVolume?: number | undefined; enab...' is not assignable to type 'NotificationSettings'.\n  Types of property 'terminalBell' are incompatible.\n    Type 'boolean | undefined' is not assignable to type 'boolean'.\n      Type 'undefined' is not assignable to type 'boolean'."
+    },
+    {
+      "file": "tests/e2e/setup-guide-sidebar.spec.ts",
+      "line": 292,
+      "column": 15,
+      "code": 2322,
+      "message": "Type '{ id: string; path: string; displayName: string; badgeColor: string; repoIcon?: RepoIcon | null; upstream?: GitHubRepositoryIdentity | null; addedAt: number; gitUsername?: string; worktreeBaseRef?: string; ... 21 more ...; hookSettings: { mode: string; commandSourcePolicy: string; scripts: { setup: string; archive: ...' is not assignable to type 'Repo'.\n  Types of property 'kind' are incompatible.\n    Type 'string' is not assignable to type 'RepoKind | undefined'."
+    },
+    {
+      "file": "tests/e2e/setup-guide-sidebar.spec.ts",
+      "line": 292,
+      "column": 28,
+      "code": 2322,
+      "message": "Type '{ badgeColor: string; repoIcon?: RepoIcon | null; upstream?: GitHubRepositoryIdentity | null; addedAt: number; gitUsername?: string; worktreeBaseRef?: string; worktreeBasePath?: string; ... 23 more ...; displayName: string; }' is not assignable to type 'Repo'.\n  Types of property 'kind' are incompatible.\n    Type 'string' is not assignable to type 'RepoKind | undefined'."
+    },
+    {
+      "file": "tests/e2e/setup-guide-sidebar.spec.ts",
+      "line": 306,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ [x: string]: { id: string; title: string; }[]; }' is not assignable to type 'Record<string, TerminalTab[]>'.\n  'string' index signatures are incompatible.\n    Type '{ id: string; title: string; }[]' is not assignable to type 'TerminalTab[]'.\n      Type '{ id: string; title: string; }' is missing the following properties from type 'TerminalTab': ptyId, worktreeId, customTitle, color, and 2 more."
+    },
+    {
+      "file": "tests/e2e/setup-guide-sidebar.spec.ts",
+      "line": 310,
+      "column": 9,
+      "code": 2739,
+      "message": "Type '{ root: { type: \"split\"; direction: \"horizontal\"; first: { type: \"leaf\"; leafId: string; }; second: { type: \"leaf\"; leafId: string; }; }; }' is missing the following properties from type 'TerminalLayoutSnapshot': activeLeafId, expandedLeafId"
+    },
+    {
+      "file": "tests/e2e/sidebar-agent-row-identity.spec.ts",
+      "line": 53,
+      "column": 13,
+      "code": 2551,
+      "message": "Property 'toggleWorktreeCardProperty' does not exist on type 'AppState'. Did you mean 'worktreeCardProperties'?"
+    },
+    {
+      "file": "tests/e2e/source-control-create-pr-intent-switch.spec.ts",
+      "line": 101,
+      "column": 24,
+      "code": 2345,
+      "message": "Argument of type '(current: AppState) => { getHostedReviewCreationEligibility: () => Promise<{ provider: \"github\"; review: null; canCreate: false; blockedReason: \"needs_push\"; nextAction: \"push\"; defaultBaseRef: string; head: string; title?: undefined; body?: undefined; } | { ...; }>; ... 5 more ...; remoteStatusesByWorktree: { ...; ...' is not assignable to parameter of type 'Partial<AppState> | ((state: AppState) => Partial<AppState>)'.\n  Type '(current: AppState) => { getHostedReviewCreationEligibility: () => Promise<{ provider: \"github\"; review: null; canCreate: false; blockedReason: \"needs_push\"; nextAction: \"push\"; defaultBaseRef: string; head: string; title?: undefined; body?: undefined; } | { ...; }>; ... 5 more ...; remoteStatusesByWorktree: { ...; ...' is not assignable to type '(state: AppState) => Partial<AppState>'.\n    Type '{ getHostedReviewCreationEligibility: () => Promise<{ provider: \"github\"; review: null; canCreate: false; blockedReason: \"needs_push\"; nextAction: \"push\"; defaultBaseRef: string; head: string; title?: undefined; body?: undefined; } | { ...; }>; ... 5 more ...; remoteStatusesByWorktree: { ...; }; }' is not assignable to type 'Partial<AppState>'.\n      The types returned by 'getHostedReviewCreationEligibility(...)' are incompatible between these types.\n        Type 'Promise<{ provider: \"github\"; review: null; canCreate: false; blockedReason: \"needs_push\"; nextAction: \"push\"; defaultBaseRef: string; head: string; title?: undefined; body?: undefined; } | { provider: \"github\"; ... 7 more ...; head: string; }>' is not assignable to type 'Promise<HostedReviewCreationEligibility>'.\n          Type '{ provider: \"github\"; review: null; canCreate: false; blockedReason: \"needs_push\"; nextAction: \"push\"; defaultBaseRef: string; head: string; title?: undefined; body?: undefined; } | { provider: \"github\"; ... 7 more ...; head: string; }' is not assignable to type 'HostedReviewCreationEligibility'.\n            Property 'reviewLookupOutcome' is missing in type '{ provider: 'github'; review: null; canCreate: false; blockedReason: 'needs_push'; nextAction: 'push'; defaultBaseRef: string; head: string; title?: undefined; body?: undefined; }' but required in type 'HostedReviewCreationEligibility'."
+    },
+    {
+      "file": "tests/e2e/source-control-create-pr.spec.ts",
+      "line": 146,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '(current: AppState) => { repos: Repo[]; gitStatusByWorktree: { [x: string]: never[] | GitUncommittedEntry[]; }; remoteStatusesByWorktree: { [x: string]: GitUpstreamStatus | { ...; }; }; ... 7 more ...; createHostedReview: (repoPath: string, input: CreateHostedReviewStoreInput) => Promise<...>; }' is not assignable to parameter of type 'Partial<AppState> | ((state: AppState) => Partial<AppState>)'.\n  Type '(current: AppState) => { repos: Repo[]; gitStatusByWorktree: { [x: string]: never[] | GitUncommittedEntry[]; }; remoteStatusesByWorktree: { [x: string]: GitUpstreamStatus | { ...; }; }; ... 7 more ...; createHostedReview: (repoPath: string, input: CreateHostedReviewStoreInput) => Promise<...>; }' is not assignable to type '(state: AppState) => Partial<AppState>'.\n    Type '{ repos: Repo[]; gitStatusByWorktree: { [x: string]: never[] | GitUncommittedEntry[]; }; remoteStatusesByWorktree: { [x: string]: GitUpstreamStatus | { ...; }; }; ... 7 more ...; createHostedReview: (repoPath: string, input: CreateHostedReviewStoreInput) => Promise<...>; }' is not assignable to type 'Partial<AppState>'.\n      The types returned by 'fetchUpstreamStatus(...)' are incompatible between these types.\n        Type 'Promise<undefined>' is not assignable to type 'Promise<GitUpstreamStatus | null>'.\n          Type 'undefined' is not assignable to type 'GitUpstreamStatus | null'."
+    },
+    {
+      "file": "tests/e2e/source-control-create-pr.spec.ts",
+      "line": 40,
+      "column": 27,
+      "code": 18048,
+      "message": "'window.__store' is possibly 'undefined'."
+    },
+    {
+      "file": "tests/e2e/ssh-ai-vault-session-history.spec.ts",
+      "line": 55,
+      "column": 13,
+      "code": 2322,
+      "message": "Type 'string' is not assignable to type 'ExecutionHostScope | undefined'."
+    },
+    {
+      "file": "tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts",
+      "line": 62,
+      "column": 16,
+      "code": 2554,
+      "message": "Expected 1 arguments, but got 0."
+    },
+    {
+      "file": "tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts",
+      "line": 78,
+      "column": 13,
+      "code": 2554,
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "file": "tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts",
+      "line": 82,
+      "column": 15,
+      "code": 2554,
+      "message": "Expected 2 arguments, but got 1."
+    },
+    {
+      "file": "tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts",
+      "line": 85,
+      "column": 15,
+      "code": 2554,
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "file": "tests/e2e/ssh-docker-relay-perf.spec.ts",
+      "line": 101,
+      "column": 9,
+      "code": 2304,
+      "message": "Cannot find name 'Page'."
+    },
+    {
+      "file": "tests/e2e/ssh-docker-relay-perf.spec.ts",
+      "line": 121,
+      "column": 40,
+      "code": 2304,
+      "message": "Cannot find name 'Page'."
+    },
+    {
+      "file": "tests/e2e/ssh-docker-relay-perf.spec.ts",
+      "line": 131,
+      "column": 43,
+      "code": 2304,
+      "message": "Cannot find name 'Page'."
+    },
+    {
+      "file": "tests/e2e/ssh-docker-relay-perf.spec.ts",
+      "line": 137,
+      "column": 40,
+      "code": 2304,
+      "message": "Cannot find name 'Page'."
+    },
+    {
+      "file": "tests/e2e/ssh-docker-relay-perf.spec.ts",
+      "line": 143,
+      "column": 37,
+      "code": 2304,
+      "message": "Cannot find name 'Page'."
+    },
+    {
+      "file": "tests/e2e/ssh-route-error-card-preview.spec.ts",
+      "line": 80,
+      "column": 38,
+      "code": 2554,
+      "message": "Expected 1 arguments, but got 0."
+    },
+    {
+      "file": "tests/e2e/staging-skill-sharing.spec.ts",
+      "line": 208,
+      "column": 68,
+      "code": 2345,
+      "message": "Argument of type 'null' is not assignable to parameter of type 'string'."
+    },
+    {
+      "file": "tests/e2e/staging-skill-sharing.spec.ts",
+      "line": 211,
+      "column": 71,
+      "code": 2345,
+      "message": "Argument of type 'null' is not assignable to parameter of type 'string'."
+    },
+    {
+      "file": "tests/e2e/staging-skill-sharing.spec.ts",
+      "line": 423,
+      "column": 12,
+      "code": 18048,
+      "message": "'skill.canonicalPath' is possibly 'undefined'."
+    },
+    {
+      "file": "tests/e2e/staging-skill-sharing.spec.ts",
+      "line": 426,
+      "column": 12,
+      "code": 18048,
+      "message": "'skill.canonicalPath' is possibly 'undefined'."
+    },
+    {
+      "file": "tests/e2e/staging-skill-sharing.spec.ts",
+      "line": 457,
+      "column": 28,
+      "code": 2339,
+      "message": "Property 'executionTarget' does not exist on type '{ scope: \"workspace\"; worktreeId?: string | undefined; folderWorkspaceId?: string | undefined; } | { scope: \"global\"; environmentId?: string | undefined; executionTarget?: { kind: \"host\"; } | { ...; } | { ...; } | undefined; }'.\n  Property 'executionTarget' does not exist on type '{ scope: \"workspace\"; worktreeId?: string | undefined; folderWorkspaceId?: string | undefined; }'."
+    },
+    {
+      "file": "tests/e2e/tab-rename-paste-ownership.spec.ts",
+      "line": 39,
+      "column": 15,
+      "code": 2339,
+      "message": "Property 'customTitle' does not exist on type '{ id: string; title?: string | undefined; }'."
+    },
+    {
+      "file": "tests/e2e/tab-rename.spec.ts",
+      "line": 53,
+      "column": 17,
+      "code": 2339,
+      "message": "Property 'customTitle' does not exist on type '{ id: string; title?: string | undefined; }'."
+    },
+    {
+      "file": "tests/e2e/tabs.spec.ts",
+      "line": 191,
+      "column": 47,
+      "code": 2345,
+      "message": "Argument of type 'string | undefined' is not assignable to parameter of type 'string'.\n  Type 'undefined' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/tabs.spec.ts",
+      "line": 199,
+      "column": 47,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/tabs.spec.ts",
+      "line": 249,
+      "column": 11,
+      "code": 18048,
+      "message": "'activeGroup.tabOrder.length' is possibly 'undefined'."
+    },
+    {
+      "file": "tests/e2e/tabs.spec.ts",
+      "line": 251,
+      "column": 11,
+      "code": 18048,
+      "message": "'activeGroup' is possibly 'undefined'."
+    },
+    {
+      "file": "tests/e2e/tabs.spec.ts",
+      "line": 252,
+      "column": 11,
+      "code": 18048,
+      "message": "'activeGroup' is possibly 'undefined'."
+    },
+    {
+      "file": "tests/e2e/tabs.spec.ts",
+      "line": 253,
+      "column": 14,
+      "code": 18048,
+      "message": "'activeGroup' is possibly 'undefined'."
+    },
+    {
+      "file": "tests/e2e/tabs.spec.ts",
+      "line": 255,
+      "column": 34,
+      "code": 18048,
+      "message": "'activeGroup' is possibly 'undefined'."
+    },
+    {
+      "file": "tests/e2e/tasks-page.spec.ts",
+      "line": 318,
+      "column": 58,
+      "code": 2339,
+      "message": "Property 'remove' does not exist on type 'Node'."
+    },
+    {
+      "file": "tests/e2e/tasks-page.spec.ts",
+      "line": 349,
+      "column": 61,
+      "code": 2339,
+      "message": "Property 'remove' does not exist on type 'Node'."
+    },
+    {
+      "file": "tests/e2e/tasks-page.spec.ts",
+      "line": 390,
+      "column": 69,
+      "code": 2339,
+      "message": "Property 'remove' does not exist on type 'Node'."
+    },
+    {
+      "file": "tests/e2e/terminal-codex-hidden-startup-background.spec.ts",
+      "line": 141,
+      "column": 40,
+      "code": 2339,
+      "message": "Property '_core' does not exist on type 'Terminal'."
+    },
+    {
+      "file": "tests/e2e/terminal-codex-hidden-startup-background.spec.ts",
+      "line": 346,
+      "column": 14,
+      "code": 2339,
+      "message": "Property 'modelBackgroundCells' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/terminal-codex-hidden-startup-background.spec.ts",
+      "line": 346,
+      "column": 44,
+      "code": 2339,
+      "message": "Property 'cellWidth' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/terminal-codex-hidden-startup-background.spec.ts",
+      "line": 346,
+      "column": 63,
+      "code": 2339,
+      "message": "Property 'cellHeight' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/terminal-codex-home.spec.ts",
+      "line": 57,
+      "column": 19,
+      "code": 2339,
+      "message": "Property 'codexHome' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/terminal-codex-home.spec.ts",
+      "line": 57,
+      "column": 42,
+      "code": 2339,
+      "message": "Property 'orcaCodexHome' does not exist on type 'never'."
+    },
+    {
+      "file": "tests/e2e/terminal-codex-local-typing-latency.spec.ts",
+      "line": 121,
+      "column": 39,
+      "code": 2339,
+      "message": "Property '_core' does not exist on type 'Terminal'."
+    },
+    {
+      "file": "tests/e2e/terminal-codex-skill-preview-artifact-repro.spec.ts",
+      "line": 129,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ mode?: \"auto\" | \"override\" | undefined; commandSourcePolicy?: HookCommandSourcePolicy; scripts?: { setup: string; archive: string; } | undefined; setupRunPolicy: \"run-by-default\"; setupAgentStartupPolicy: \"start-immediately\"; }' is not assignable to type 'RepoHookSettings'.\n  Types of property 'mode' are incompatible.\n    Type '\"auto\" | \"override\" | undefined' is not assignable to type '\"auto\" | \"override\"'.\n      Type 'undefined' is not assignable to type '\"auto\" | \"override\"'."
+    },
+    {
+      "file": "tests/e2e/terminal-codex-skill-preview-artifact-repro.spec.ts",
+      "line": 555,
+      "column": 3,
+      "code": 2739,
+      "message": "Type '{ matches: boolean; diffPixels: number; diffRatio: number; width: number; height: number; leftPane: PaneDescriptor; beforeContent: string; afterContent: string; }' is missing the following properties from type 'ArtifactCapture': changedPixels, totalPixels"
+    },
+    {
+      "file": "tests/e2e/terminal-foreground-confirmation.unit.test.ts",
+      "line": 70,
+      "column": 7,
+      "code": 2322,
+      "message": "Type 'Mock<Constructable | Procedure>' is not assignable to type '(entry: PaneForegroundAgentEntry) => void'.\n  Type 'MockInstance<Constructable | Procedure> & (new (...args: any[]) => any) & {}' is not assignable to type '(entry: PaneForegroundAgentEntry) => void'.\n    Type 'MockInstance<Constructable | Procedure> & (new (...args: any[]) => any) & {}' provides no match for the signature '(entry: PaneForegroundAgentEntry): void'."
+    },
+    {
+      "file": "tests/e2e/terminal-foreground-redraw-freeze.spec.ts",
+      "line": 195,
+      "column": 13,
+      "code": 18049,
+      "message": "'manager' is possibly 'null' or 'undefined'."
+    },
+    {
+      "file": "tests/e2e/terminal-foreground-redraw-freeze.spec.ts",
+      "line": 204,
+      "column": 11,
+      "code": 18049,
+      "message": "'manager' is possibly 'null' or 'undefined'."
+    },
+    {
+      "file": "tests/e2e/terminal-long-table-scroll-restore.spec.ts",
+      "line": 198,
+      "column": 37,
+      "code": 2339,
+      "message": "Property '_core' does not exist on type 'Terminal'."
+    },
+    {
+      "file": "tests/e2e/terminal-opencode-emoji-table-rendering.spec.ts",
+      "line": 196,
+      "column": 38,
+      "code": 2339,
+      "message": "Property '_core' does not exist on type 'Terminal'."
+    },
+    {
+      "file": "tests/e2e/terminal-osc8-cold-park-restore.spec.ts",
+      "line": 149,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/terminal-osc8-cold-park-restore.spec.ts",
+      "line": 157,
+      "column": 56,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/terminal-osc8-cold-park-restore.spec.ts",
+      "line": 160,
+      "column": 39,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/terminal-osc8-cold-park-restore.spec.ts",
+      "line": 166,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/terminal-pane-divider-capture-loss.spec.ts",
+      "line": 101,
+      "column": 9,
+      "code": 2322,
+      "message": "Type 'ITerminalDimensions | null' is not assignable to type 'null'.\n  Type 'ITerminalDimensions' is not assignable to type 'null'."
+    },
+    {
+      "file": "tests/e2e/terminal-pane-divider-capture-loss.spec.ts",
+      "line": 145,
+      "column": 59,
+      "code": 2339,
+      "message": "Property 'pointerId' does not exist on type 'Event'."
+    },
+    {
+      "file": "tests/e2e/terminal-pane-title-strip-placement.spec.ts",
+      "line": 172,
+      "column": 11,
+      "code": 18048,
+      "message": "'titleBar' is possibly 'undefined'."
+    },
+    {
+      "file": "tests/e2e/terminal-raster-artifact-analysis.ts",
+      "line": 270,
+      "column": 18,
+      "code": 2339,
+      "message": "Property '__terminalOutputSchedulerDebug' does not exist on type 'Window & typeof globalThis'."
+    },
+    {
+      "file": "tests/e2e/terminal-raster-artifact-analysis.ts",
+      "line": 58,
+      "column": 11,
+      "code": 18047,
+      "message": "'pane' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/terminal-raster-artifact-analysis.ts",
+      "line": 58,
+      "column": 25,
+      "code": 2339,
+      "message": "Property '_core' does not exist on type 'Terminal'."
+    },
+    {
+      "file": "tests/e2e/terminal-raster-artifact-analysis.ts",
+      "line": 59,
+      "column": 11,
+      "code": 18047,
+      "message": "'pane' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/terminal-raster-artifact-analysis.ts",
+      "line": 59,
+      "column": 25,
+      "code": 2339,
+      "message": "Property '_core' does not exist on type 'Terminal'."
+    },
+    {
+      "file": "tests/e2e/terminal-raster-artifact-analysis.ts",
+      "line": 82,
+      "column": 38,
+      "code": 2339,
+      "message": "Property '_core' does not exist on type 'Terminal'."
+    },
+    {
+      "file": "tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts",
+      "line": 206,
+      "column": 15,
+      "code": 2322,
+      "message": "Type 'null' is not assignable to type 'BrowserTerminalPane'."
+    },
+    {
+      "file": "tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts",
+      "line": 208,
+      "column": 13,
+      "code": 2322,
+      "message": "Type 'BrowserTerminalPane | null' is not assignable to type 'BrowserTerminalPane'.\n  Type 'null' is not assignable to type 'BrowserTerminalPane'."
+    },
+    {
+      "file": "tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts",
+      "line": 406,
+      "column": 56,
+      "code": 2339,
+      "message": "Property 'id' does not exist on type 'BrowserTerminalPane'."
+    },
+    {
+      "file": "tests/e2e/terminal-reveal-paused-render-repro.spec.ts",
+      "line": 468,
+      "column": 42,
+      "code": 2339,
+      "message": "Property 'scheduleRevealRepaint' does not exist on type 'PaneManagerLike'."
+    },
+    {
+      "file": "tests/e2e/terminal-reveal-paused-render-repro.spec.ts",
+      "line": 588,
+      "column": 42,
+      "code": 2339,
+      "message": "Property 'scheduleRevealPresent' does not exist on type 'PaneManagerLike'."
+    },
+    {
+      "file": "tests/e2e/terminal-shortcuts.spec.ts",
+      "line": 376,
+      "column": 5,
+      "code": 18047,
+      "message": "'pane' is possibly 'null'."
+    },
+    {
+      "file": "tests/e2e/terminal-shortcuts.spec.ts",
+      "line": 665,
+      "column": 16,
+      "code": 2339,
+      "message": "Property 'translateBufferLineToString' does not exist on type 'IBuffer'."
+    },
+    {
+      "file": "tests/e2e/terminal-sleep-wake-restore.spec.ts",
+      "line": 101,
+      "column": 3,
+      "code": 2322,
+      "message": "Type '{ activeTabId: string | null; activeWorktreeId: string | null; tabs: { id: string; ptyId: string | null; generation: number | undefined; pendingActivationSpawn: number | boolean | undefined; }[]; ptyIdsByTabId: { ...; }; ptyIdsByLeafIdByTabId: { ...; }; }' is not assignable to type 'SleepWakeTerminalDebug'.\n  Types of property 'tabs' are incompatible.\n    Type '{ id: string; ptyId: string | null; generation: number | undefined; pendingActivationSpawn: number | boolean | undefined; }[]' is not assignable to type '{ id: string; ptyId?: string | undefined; generation?: number | undefined; pendingActivationSpawn?: number | boolean | undefined; }[]'.\n      Type '{ id: string; ptyId: string | null; generation: number | undefined; pendingActivationSpawn: number | boolean | undefined; }' is not assignable to type '{ id: string; ptyId?: string | undefined; generation?: number | undefined; pendingActivationSpawn?: number | boolean | undefined; }'.\n        Types of property 'ptyId' are incompatible.\n          Type 'string | null' is not assignable to type 'string | undefined'.\n            Type 'null' is not assignable to type 'string | undefined'."
+    },
+    {
+      "file": "tests/e2e/terminal-tab-switch-visual-restore.spec.ts",
+      "line": 458,
+      "column": 39,
+      "code": 2339,
+      "message": "Property '_core' does not exist on type 'Terminal'."
+    },
+    {
+      "file": "tests/e2e/terminal-tui-wheel-drain.spec.ts",
+      "line": 98,
+      "column": 23,
+      "code": 2339,
+      "message": "Property '_core' does not exist on type 'Terminal'."
+    },
+    {
+      "file": "tests/e2e/terminal-tui-wheel-reports.spec.ts",
+      "line": 155,
+      "column": 25,
+      "code": 2339,
+      "message": "Property '_core' does not exist on type 'Terminal'."
+    },
+    {
+      "file": "tests/e2e/terminal-tui-wheel-reports.spec.ts",
+      "line": 63,
+      "column": 25,
+      "code": 2339,
+      "message": "Property '_core' does not exist on type 'Terminal'."
+    },
+    {
+      "file": "tests/e2e/terminal-warm-reattach-split-live-output.spec.ts",
+      "line": 197,
+      "column": 55,
+      "code": 2345,
+      "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "file": "tests/e2e/workspace-space-git-status.spec.ts",
+      "line": 128,
+      "column": 15,
+      "code": 2322,
+      "message": "Type '{ worktreeId: string; repoId: string; repoDisplayName: string; repoPath: string; displayName: string; path: string; branch: string; isMainWorktree: boolean; isRemote: boolean; isSparse: boolean | undefined; ... 10 more ...; omittedTopLevelSizeBytes: number; }[]' is not assignable to type 'WorkspaceSpaceWorktree[]'.\n  Type '{ worktreeId: string; repoId: string; repoDisplayName: string; repoPath: string; displayName: string; path: string; branch: string; isMainWorktree: boolean; isRemote: boolean; isSparse: boolean | undefined; ... 10 more ...; omittedTopLevelSizeBytes: number; }' is not assignable to type 'WorkspaceSpaceWorktree'.\n    Types of property 'isSparse' are incompatible.\n      Type 'boolean | undefined' is not assignable to type 'boolean'.\n        Type 'undefined' is not assignable to type 'boolean'."
+    },
+    {
+      "file": "tests/e2e/worktree-jump-palette-filter.spec.ts",
+      "line": 66,
+      "column": 11,
+      "code": 2322,
+      "message": "Type 'Repo | { badgeColor: string; repoIcon?: RepoIcon | null | undefined; upstream?: GitHubRepositoryIdentity | null | undefined; addedAt: number; ... 26 more ...; executionHostId: string; }' is not assignable to type 'Repo'.\n  Type '{ badgeColor: string; repoIcon?: RepoIcon | null; upstream?: GitHubRepositoryIdentity | null; addedAt: number; kind?: RepoKind; gitUsername?: string; worktreeBaseRef?: string; worktreeBasePath?: string; ... 22 more ...; executionHostId: string; }' is not assignable to type 'Repo'.\n    Types of property 'executionHostId' are incompatible.\n      Type 'string' is not assignable to type '\"local\" | `runtime:${string}` | `ssh:${string}` | null | undefined'."
+    },
+    {
+      "file": "tests/e2e/worktree-jump-palette-filter.spec.ts",
+      "line": 69,
+      "column": 11,
+      "code": 2322,
+      "message": "Type '{ badgeColor: string; repoIcon?: RepoIcon | null; upstream?: GitHubRepositoryIdentity | null; addedAt: number; kind?: RepoKind; gitUsername?: string; worktreeBaseRef?: string; worktreeBasePath?: string; ... 22 more ...; executionHostId: string; }' is not assignable to type 'Repo'.\n  Types of property 'executionHostId' are incompatible.\n    Type 'string' is not assignable to type '\"local\" | `runtime:${string}` | `ssh:${string}` | null | undefined'."
+    },
+    {
+      "file": "tests/e2e/worktree-jump-palette-filter.spec.ts",
+      "line": 73,
+      "column": 9,
+      "code": 2322,
+      "message": "Type '{ [x: string]: { head: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; instanceId?: string; projectId?: string; ... 45 more ...; hostId: string; }[] | Worktree[]; }' is not assignable to type 'Record<string, Worktree[]>'.\n  'string' index signatures are incompatible.\n    Type '{ head: string; isBare: boolean; isSparse?: boolean | undefined; locked?: boolean | undefined; lockReason?: string | undefined; prunable?: boolean | undefined; prunableReason?: string | undefined; ... 47 more ...; hostId: string; }[] | Worktree[]' is not assignable to type 'Worktree[]'.\n      Type '{ head: string; isBare: boolean; isSparse?: boolean | undefined; locked?: boolean | undefined; lockReason?: string | undefined; prunable?: boolean | undefined; prunableReason?: string | undefined; ... 47 more ...; hostId: string; }[]' is not assignable to type 'Worktree[]'.\n        Type '{ head: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; instanceId?: string; projectId?: string; runtimeOwnerEnvironmentId?: string; ... 44 more ...; hostId: string; }' is not assignable to type 'Worktree'.\n          Type '{ head: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; instanceId?: string; projectId?: string; runtimeOwnerEnvironmentId?: string; ... 44 more ...; hostId: string; }' is not assignable to type '{ id: string; instanceId?: string | undefined; repoId: string; projectId?: string | undefined; hostId?: ExecutionHostId | undefined; runtimeOwnerEnvironmentId?: string | undefined; ... 37 more ...; cliProvenance?: CliWorkspaceProvenance | undefined; }'.\n            Types of property 'hostId' are incompatible.\n              Type 'string' is not assignable to type 'ExecutionHostId | undefined'."
+    },
+    {
+      "file": "tests/e2e/worktree-lineage-agent-expansion.spec.ts",
+      "line": 32,
+      "column": 13,
+      "code": 2551,
+      "message": "Property 'toggleWorktreeCardProperty' does not exist on type 'AppState'. Did you mean 'worktreeCardProperties'?"
+    },
+    {
+      "file": "tests/e2e/worktree-lineage-state.ts",
+      "line": 101,
+      "column": 15,
+      "code": 2551,
+      "message": "Property 'toggleWorktreeCardProperty' does not exist on type 'AppState'. Did you mean 'worktreeCardProperties'?"
+    },
+    {
+      "file": "tests/e2e/worktree-scroll-to-current.spec.ts",
+      "line": 265,
+      "column": 9,
+      "code": 2322,
+      "message": "Type 'string' is not assignable to type 'WorkspaceKey | null | undefined'."
+    }
+  ]
+}

--- a/config/typecheck-e2e-diagnostics.json
+++ b/config/typecheck-e2e-diagnostics.json
@@ -338,27 +338,6 @@
       "message": "'state.settings' is possibly 'null'."
     },
     {
-      "file": "tests/e2e/helpers/paired-html-preview-inventory.ts",
-      "line": 54,
-      "column": 9,
-      "code": 18046,
-      "message": "'response.result' is of type 'unknown'."
-    },
-    {
-      "file": "tests/e2e/helpers/paired-html-preview-inventory.ts",
-      "line": 76,
-      "column": 40,
-      "code": 18046,
-      "message": "'response.result' is of type 'unknown'."
-    },
-    {
-      "file": "tests/e2e/helpers/paired-html-preview-inventory.ts",
-      "line": 83,
-      "column": 11,
-      "code": 18046,
-      "message": "'response.result' is of type 'unknown'."
-    },
-    {
       "file": "tests/e2e/helpers/paired-terminal-cold-activation-oracle.ts",
       "line": 141,
       "column": 70,
@@ -450,6 +429,13 @@
       "message": "'activeGroup' is possibly 'undefined'."
     },
     {
+      "file": "tests/e2e/helpers/terminal-pane-operations.ts",
+      "line": 49,
+      "column": 15,
+      "code": 2339,
+      "message": "Property 'movePane' does not exist on type 'PaneManagerLike'."
+    },
+    {
       "file": "tests/e2e/helpers/terminal-pty-write-spy.ts",
       "line": 93,
       "column": 52,
@@ -458,14 +444,7 @@
     },
     {
       "file": "tests/e2e/helpers/terminal.ts",
-      "line": 408,
-      "column": 15,
-      "code": 2339,
-      "message": "Property 'movePane' does not exist on type 'PaneManagerLike'."
-    },
-    {
-      "file": "tests/e2e/helpers/terminal.ts",
-      "line": 43,
+      "line": 55,
       "column": 25,
       "code": 2345,
       "message": "Argument of type 'string | null' is not assignable to parameter of type 'string'.\n  Type 'null' is not assignable to type 'string'."
@@ -709,216 +688,6 @@
       "message": "Argument of type 'string' is not assignable to parameter of type 'ExecutionHostId | undefined'."
     },
     {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 101,
-      "column": 27,
-      "code": 2339,
-      "message": "Property 'hostResponseOk' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 102,
-      "column": 56,
-      "code": 18047,
-      "message": "'browserBaseline' is possibly 'null'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 134,
-      "column": 17,
-      "code": 18046,
-      "message": "'response.result' is of type 'unknown'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 199,
-      "column": 29,
-      "code": 2339,
-      "message": "Property 'clientWorkspaceIds' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 200,
-      "column": 29,
-      "code": 2339,
-      "message": "Property 'clientUnifiedTabs' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 201,
-      "column": 29,
-      "code": 2339,
-      "message": "Property 'hostTabIds' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 202,
-      "column": 29,
-      "code": 2339,
-      "message": "Property 'clientRemotePageIds' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 202,
-      "column": 75,
-      "code": 2339,
-      "message": "Property 'hostPageIds' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 203,
-      "column": 29,
-      "code": 2339,
-      "message": "Property 'totalClientUnified' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 203,
-      "column": 70,
-      "code": 2339,
-      "message": "Property 'totalClientUnified' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 204,
-      "column": 29,
-      "code": 2339,
-      "message": "Property 'totalClientWorkspaces' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 204,
-      "column": 73,
-      "code": 2339,
-      "message": "Property 'totalClientWorkspaces' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 205,
-      "column": 29,
-      "code": 2339,
-      "message": "Property 'totalHost' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 205,
-      "column": 61,
-      "code": 2339,
-      "message": "Property 'totalHost' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 206,
-      "column": 29,
-      "code": 2339,
-      "message": "Property 'clientUnifiedTabs' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 208,
-      "column": 24,
-      "code": 2339,
-      "message": "Property 'hostTabGroups' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 209,
-      "column": 33,
-      "code": 18047,
-      "message": "'htmlTabInventory' is possibly 'null'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 212,
-      "column": 49,
-      "code": 2339,
-      "message": "Property 'hostTabGroups' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 213,
-      "column": 31,
-      "code": 18047,
-      "message": "'htmlTabInventory' is possibly 'null'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 218,
-      "column": 65,
-      "code": 2339,
-      "message": "Property 'clientUnifiedTabs' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 289,
-      "column": 17,
-      "code": 18046,
-      "message": "'response.result' is of type 'unknown'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 289,
-      "column": 63,
-      "code": 18046,
-      "message": "'response.result' is of type 'unknown'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 293,
-      "column": 30,
-      "code": 18047,
-      "message": "'client' is possibly 'null'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 298,
-      "column": 45,
-      "code": 2339,
-      "message": "Property 'hostTabs' does not exist on type 'never'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 351,
-      "column": 62,
-      "code": 18047,
-      "message": "'client' is possibly 'null'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 380,
-      "column": 19,
-      "code": 18046,
-      "message": "'response.result' is of type 'unknown'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 380,
-      "column": 65,
-      "code": 18046,
-      "message": "'response.result' is of type 'unknown'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 426,
-      "column": 21,
-      "code": 18046,
-      "message": "'response.result' is of type 'unknown'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 437,
-      "column": 29,
-      "code": 18047,
-      "message": "'htmlTabInventory' is possibly 'null'."
-    },
-    {
-      "file": "tests/e2e/paired-remote-html-browser-focus.spec.ts",
-      "line": 438,
-      "column": 28,
-      "code": 18047,
-      "message": "'htmlTabInventory' is possibly 'null'."
-    },
-    {
       "file": "tests/e2e/paired-remote-pane-layout-retry.spec.ts",
       "line": 176,
       "column": 11,
@@ -1035,7 +804,7 @@
       "line": 206,
       "column": 9,
       "code": 2322,
-      "message": "Type '{ [x: string]: { head: string; branch: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; isMainWorktree: boolean; ... 44 more ...; runtimeOwnerEnvironmentId: null; }[] | Worktree[]; }' is not assignable to type 'Record<string, Worktree[]>'.\n  'string' index signatures are incompatible.\n    Type '{ head: string; branch: string; isBare: boolean; isSparse?: boolean | undefined; locked?: boolean | undefined; lockReason?: string | undefined; prunable?: boolean | undefined; prunableReason?: string | undefined; ... 45 more ...; runtimeOwnerEnvironmentId: null; }[] | Worktree[]' is not assignable to type 'Worktree[]'.\n      Type '{ head: string; branch: string; isBare: boolean; isSparse?: boolean | undefined; locked?: boolean | undefined; lockReason?: string | undefined; prunable?: boolean | undefined; prunableReason?: string | undefined; ... 45 more ...; runtimeOwnerEnvironmentId: null; }[]' is not assignable to type 'Worktree[]'.\n        Type '{ head: string; branch: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; isMainWorktree: boolean; id: string; ... 43 more ...; runtimeOwnerEnvironmentId: null; }' is not assignable to type 'Worktree'.\n          Type '{ head: string; branch: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; isMainWorktree: boolean; id: string; ... 43 more ...; runtimeOwnerEnvironmentId: null; }' is not assignable to type '{ id: string; instanceId?: string | undefined; repoId: string; projectId?: string | undefined; hostId?: ExecutionHostId | undefined; runtimeOwnerEnvironmentId?: string | undefined; ... 37 more ...; cliProvenance?: CliWorkspaceProvenance | undefined; }'.\n            Types of property 'runtimeOwnerEnvironmentId' are incompatible.\n              Type 'null' is not assignable to type 'string | undefined'."
+      "message": "Type '{ [x: string]: { head: string; branch: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; isMainWorktree: boolean; ... 45 more ...; runtimeOwnerEnvironmentId: null; }[] | Worktree[]; }' is not assignable to type 'Record<string, Worktree[]>'.\n  'string' index signatures are incompatible.\n    Type '{ head: string; branch: string; isBare: boolean; isSparse?: boolean | undefined; locked?: boolean | undefined; lockReason?: string | undefined; prunable?: boolean | undefined; prunableReason?: string | undefined; ... 46 more ...; runtimeOwnerEnvironmentId: null; }[] | Worktree[]' is not assignable to type 'Worktree[]'.\n      Type '{ head: string; branch: string; isBare: boolean; isSparse?: boolean | undefined; locked?: boolean | undefined; lockReason?: string | undefined; prunable?: boolean | undefined; prunableReason?: string | undefined; ... 46 more ...; runtimeOwnerEnvironmentId: null; }[]' is not assignable to type 'Worktree[]'.\n        Type '{ head: string; branch: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; isMainWorktree: boolean; id: string; ... 44 more ...; runtimeOwnerEnvironmentId: null; }' is not assignable to type 'Worktree'.\n          Type '{ head: string; branch: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; isMainWorktree: boolean; id: string; ... 44 more ...; runtimeOwnerEnvironmentId: null; }' is not assignable to type '{ id: string; instanceId?: string | undefined; identity?: WorktreeIdentity | undefined; repoId: string; projectId?: string | undefined; hostId?: ExecutionHostId | undefined; ... 38 more ...; cliProvenance?: CliWorkspaceProvenance | undefined; }'.\n            Types of property 'runtimeOwnerEnvironmentId' are incompatible.\n              Type 'null' is not assignable to type 'string | undefined'."
     },
     {
       "file": "tests/e2e/project-group-manual-sort.spec.ts",
@@ -1640,6 +1409,13 @@
       "message": "Type '{ worktreeId: string; repoId: string; repoDisplayName: string; repoPath: string; displayName: string; path: string; branch: string; isMainWorktree: boolean; isRemote: boolean; isSparse: boolean | undefined; ... 10 more ...; omittedTopLevelSizeBytes: number; }[]' is not assignable to type 'WorkspaceSpaceWorktree[]'.\n  Type '{ worktreeId: string; repoId: string; repoDisplayName: string; repoPath: string; displayName: string; path: string; branch: string; isMainWorktree: boolean; isRemote: boolean; isSparse: boolean | undefined; ... 10 more ...; omittedTopLevelSizeBytes: number; }' is not assignable to type 'WorkspaceSpaceWorktree'.\n    Types of property 'isSparse' are incompatible.\n      Type 'boolean | undefined' is not assignable to type 'boolean'.\n        Type 'undefined' is not assignable to type 'boolean'."
     },
     {
+      "file": "tests/e2e/worktree-card-downward-drag.spec.ts",
+      "line": 89,
+      "column": 42,
+      "code": 2339,
+      "message": "Property 'get' does not exist on type 'readonly WorktreeMetaBatchUpdate[]'."
+    },
+    {
       "file": "tests/e2e/worktree-jump-palette-filter.spec.ts",
       "line": 66,
       "column": 11,
@@ -1658,7 +1434,7 @@
       "line": 73,
       "column": 9,
       "code": 2322,
-      "message": "Type '{ [x: string]: { head: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; instanceId?: string; projectId?: string; ... 45 more ...; hostId: string; }[] | Worktree[]; }' is not assignable to type 'Record<string, Worktree[]>'.\n  'string' index signatures are incompatible.\n    Type '{ head: string; isBare: boolean; isSparse?: boolean | undefined; locked?: boolean | undefined; lockReason?: string | undefined; prunable?: boolean | undefined; prunableReason?: string | undefined; ... 47 more ...; hostId: string; }[] | Worktree[]' is not assignable to type 'Worktree[]'.\n      Type '{ head: string; isBare: boolean; isSparse?: boolean | undefined; locked?: boolean | undefined; lockReason?: string | undefined; prunable?: boolean | undefined; prunableReason?: string | undefined; ... 47 more ...; hostId: string; }[]' is not assignable to type 'Worktree[]'.\n        Type '{ head: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; instanceId?: string; projectId?: string; runtimeOwnerEnvironmentId?: string; ... 44 more ...; hostId: string; }' is not assignable to type 'Worktree'.\n          Type '{ head: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; instanceId?: string; projectId?: string; runtimeOwnerEnvironmentId?: string; ... 44 more ...; hostId: string; }' is not assignable to type '{ id: string; instanceId?: string | undefined; repoId: string; projectId?: string | undefined; hostId?: ExecutionHostId | undefined; runtimeOwnerEnvironmentId?: string | undefined; ... 37 more ...; cliProvenance?: CliWorkspaceProvenance | undefined; }'.\n            Types of property 'hostId' are incompatible.\n              Type 'string' is not assignable to type 'ExecutionHostId | undefined'."
+      "message": "Type '{ [x: string]: { head: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; instanceId?: string; identity?: WorktreeIdentity; ... 46 more ...; hostId: string; }[] | Worktree[]; }' is not assignable to type 'Record<string, Worktree[]>'.\n  'string' index signatures are incompatible.\n    Type '{ head: string; isBare: boolean; isSparse?: boolean | undefined; locked?: boolean | undefined; lockReason?: string | undefined; prunable?: boolean | undefined; prunableReason?: string | undefined; ... 48 more ...; hostId: string; }[] | Worktree[]' is not assignable to type 'Worktree[]'.\n      Type '{ head: string; isBare: boolean; isSparse?: boolean | undefined; locked?: boolean | undefined; lockReason?: string | undefined; prunable?: boolean | undefined; prunableReason?: string | undefined; ... 48 more ...; hostId: string; }[]' is not assignable to type 'Worktree[]'.\n        Type '{ head: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; instanceId?: string; identity?: WorktreeIdentity; projectId?: string; ... 45 more ...; hostId: string; }' is not assignable to type 'Worktree'.\n          Type '{ head: string; isBare: boolean; isSparse?: boolean; locked?: boolean; lockReason?: string; prunable?: boolean; prunableReason?: string; instanceId?: string; identity?: WorktreeIdentity; projectId?: string; ... 45 more ...; hostId: string; }' is not assignable to type '{ id: string; instanceId?: string | undefined; identity?: WorktreeIdentity | undefined; repoId: string; projectId?: string | undefined; hostId?: ExecutionHostId | undefined; ... 38 more ...; cliProvenance?: CliWorkspaceProvenance | undefined; }'.\n            Types of property 'hostId' are incompatible.\n              Type 'string' is not assignable to type 'ExecutionHostId | undefined'."
     },
     {
       "file": "tests/e2e/worktree-lineage-agent-expansion.spec.ts",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,7 +9,7 @@
     "ios": "expo run:ios",
     "postinstall": "node scripts/build-terminal-webview-engine.mjs && node scripts/build-mermaid-webview-engine.mjs",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "node ../config/scripts/typecheck-diagnostic-baseline.mjs --project mobile/tsconfig.json --baseline mobile/typecheck-test-diagnostics.json --tsc mobile/node_modules/typescript/bin/tsc",
     "lint": "oxlint",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,6 +10,7 @@
     "postinstall": "node scripts/build-terminal-webview-engine.mjs && node scripts/build-mermaid-webview-engine.mjs",
     "test": "vitest run",
     "typecheck": "node ../config/scripts/typecheck-diagnostic-baseline.mjs --project mobile/tsconfig.json --baseline mobile/typecheck-test-diagnostics.json --tsc mobile/node_modules/typescript/bin/tsc",
+    "typecheck:write": "node ../config/scripts/typecheck-diagnostic-baseline.mjs --project mobile/tsconfig.json --baseline mobile/typecheck-test-diagnostics.json --tsc mobile/node_modules/typescript/bin/tsc --write",
     "lint": "oxlint",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",

--- a/mobile/src/components/MobileHostCard.actions.test.tsx
+++ b/mobile/src/components/MobileHostCard.actions.test.tsx
@@ -1,4 +1,5 @@
 import { createElement } from 'react'
+import { Text } from 'react-native'
 import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ConnectionVerdict } from '../transport/connection-health'
@@ -36,7 +37,7 @@ const loaded: HostWorktreeInfo = {
   countsProvenAt: Date.now()
 }
 
-describe('MobileHostCard', () => {
+describe('MobileHostCard actions', () => {
   let renderer: ReactTestRenderer | null = null
 
   afterEach(() => {
@@ -69,7 +70,7 @@ describe('MobileHostCard', () => {
       )
     })
     return renderer!.root
-      .findAllByType('Text')
+      .findAllByType(Text)
       .flatMap((node) => node.children.filter((child) => typeof child === 'string'))
   }
 

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -13,6 +13,5 @@
       "zod": ["./node_modules/zod"]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/mobile/typecheck-test-diagnostics.json
+++ b/mobile/typecheck-test-diagnostics.json
@@ -1,0 +1,2532 @@
+{
+  "version": 1,
+  "diagnostics": [
+    {
+      "file": "mobile/src/accounts-route-reset-credit.test.ts",
+      "line": 174,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/accounts-route-reset-credit.test.ts",
+      "line": 180,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/accounts-route-reset-credit.test.ts",
+      "line": 182,
+      "column": 26,
+      "code": 2345,
+      "message": "Argument of type '\"Text\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/browser/mobile-browser-frameless-stream.test.tsx",
+      "line": 107,
+      "column": 38,
+      "code": 2454,
+      "message": "Variable 'renderer' is used before being assigned."
+    },
+    {
+      "file": "mobile/src/browser/mobile-browser-frameless-stream.test.tsx",
+      "line": 109,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '\"View\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/browser/mobile-browser-frameless-stream.test.tsx",
+      "line": 149,
+      "column": 22,
+      "code": 2345,
+      "message": "Argument of type '\"Image\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/browser/mobile-browser-frameless-stream.test.tsx",
+      "line": 58,
+      "column": 38,
+      "code": 2345,
+      "message": "Argument of type '\"ActivityIndicator\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/agent-monitoring-indicators.test.ts",
+      "line": 53,
+      "column": 7,
+      "code": 2322,
+      "message": "Type 'ReactTestRenderer' is not assignable to type 'MonitoringTestRenderer'.\n  The types of 'root.findByType' are incompatible between these types.\n    Type '(type: ElementType) => ReactTestInstance' is not assignable to type '(type: string) => { props: Record<string, unknown>; }'.\n      Types of parameters 'type' and 'type' are incompatible.\n        Type 'string' is not assignable to type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/agent-monitoring-indicators.test.ts",
+      "line": 66,
+      "column": 7,
+      "code": 2322,
+      "message": "Type 'ReactTestRenderer' is not assignable to type 'MonitoringTestRenderer'.\n  The types of 'root.findByType' are incompatible between these types.\n    Type '(type: ElementType) => ReactTestInstance' is not assignable to type '(type: string) => { props: Record<string, unknown>; }'.\n      Types of parameters 'type' and 'type' are incompatible.\n        Type 'string' is not assignable to type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/agent-monitoring-indicators.test.ts",
+      "line": 81,
+      "column": 7,
+      "code": 2322,
+      "message": "Type 'ReactTestRenderer' is not assignable to type 'MonitoringTestRenderer'.\n  The types of 'root.findByType' are incompatible between these types.\n    Type '(type: ElementType) => ReactTestInstance' is not assignable to type '(type: string) => { props: Record<string, unknown>; }'.\n      Types of parameters 'type' and 'type' are incompatible.\n        Type 'string' is not assignable to type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/bottom-drawer-close-lifecycle.test.ts",
+      "line": 20,
+      "column": 9,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type '{ visible: boolean; onClose: () => void; onAfterClose: () => void; }' is not assignable to parameter of type 'Attributes & Props'.\n      Property 'children' is missing in type '{ visible: boolean; onClose: () => void; onAfterClose: () => void; }' but required in type 'Props'."
+    },
+    {
+      "file": "mobile/src/components/bottom-drawer-close-lifecycle.test.ts",
+      "line": 41,
+      "column": 9,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type '{ visible: boolean; onClose: () => void; onAfterClose: () => void; }' is not assignable to parameter of type 'Attributes & Props'.\n      Property 'children' is missing in type '{ visible: boolean; onClose: () => void; onAfterClose: () => void; }' but required in type 'Props'."
+    },
+    {
+      "file": "mobile/src/components/bottom-drawer-close-lifecycle.test.ts",
+      "line": 49,
+      "column": 35,
+      "code": 2345,
+      "message": "Argument of type '\"MountedBottomDrawer\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/codex-reset-credit-capability.test.ts",
+      "line": 72,
+      "column": 38,
+      "code": 2345,
+      "message": "Argument of type '\"CapabilityResult\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/codex-reset-credit-capability.test.ts",
+      "line": 75,
+      "column": 38,
+      "code": 2345,
+      "message": "Argument of type '\"CapabilityResult\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/CodexResetCreditAction.test.ts",
+      "line": 44,
+      "column": 45,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/CodexResetCreditAction.test.ts",
+      "line": 56,
+      "column": 45,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/CodexResetCreditAction.test.ts",
+      "line": 58,
+      "column": 22,
+      "code": 2345,
+      "message": "Argument of type '\"Text\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/HostProtocolGate.test.ts",
+      "line": 120,
+      "column": 44,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/HostProtocolGate.test.ts",
+      "line": 197,
+      "column": 22,
+      "code": 2345,
+      "message": "Argument of type '\"View\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/HostProtocolGate.test.ts",
+      "line": 59,
+      "column": 5,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type '{ hostId: string; }' is not assignable to parameter of type 'Attributes & Props'.\n      Property 'children' is missing in type '{ hostId: string; }' but required in type 'Props'."
+    },
+    {
+      "file": "mobile/src/components/mobile-agent-icon-gradient.test.ts",
+      "line": 55,
+      "column": 12,
+      "code": 18047,
+      "message": "'renderer' is possibly 'null'."
+    },
+    {
+      "file": "mobile/src/components/mobile-agent-icon-gradient.test.ts",
+      "line": 55,
+      "column": 40,
+      "code": 2345,
+      "message": "Argument of type '\"Stop\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/MobileHomeQuickActions.test.ts",
+      "line": 22,
+      "column": 73,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type 'unknown' is not assignable to parameter of type 'Attributes | null | undefined'."
+    },
+    {
+      "file": "mobile/src/components/MobileHomeQuickActions.test.ts",
+      "line": 73,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/MobileHomeQuickActions.test.ts",
+      "line": 77,
+      "column": 38,
+      "code": 2345,
+      "message": "Argument of type '\"PickerModal\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 118,
+      "column": 30,
+      "code": 18047,
+      "message": "'renderer' is possibly 'null'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 118,
+      "column": 58,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 155,
+      "column": 30,
+      "code": 18047,
+      "message": "'renderer' is possibly 'null'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 155,
+      "column": 58,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 160,
+      "column": 7,
+      "code": 18047,
+      "message": "'renderer' is possibly 'null'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 161,
+      "column": 24,
+      "code": 2345,
+      "message": "Argument of type '\"Text\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 194,
+      "column": 30,
+      "code": 18047,
+      "message": "'renderer' is possibly 'null'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 194,
+      "column": 58,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 66,
+      "column": 21,
+      "code": 18047,
+      "message": "'renderer' is possibly 'null'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 66,
+      "column": 49,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 74,
+      "column": 12,
+      "code": 18047,
+      "message": "'renderer' is possibly 'null'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 74,
+      "column": 40,
+      "code": 2345,
+      "message": "Argument of type '\"MoreVertical\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 75,
+      "column": 12,
+      "code": 18047,
+      "message": "'renderer' is possibly 'null'."
+    },
+    {
+      "file": "mobile/src/components/MobileHostCard.test.ts",
+      "line": 75,
+      "column": 40,
+      "code": 2345,
+      "message": "Argument of type '\"ChevronRight\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/MobileMarkdown.file-links.test.ts",
+      "line": 9,
+      "column": 48,
+      "code": 2554,
+      "message": "Expected 0 arguments, but got 1."
+    },
+    {
+      "file": "mobile/src/components/MobileRichMarkdownEditor.test.tsx",
+      "line": 21,
+      "column": 48,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'."
+    },
+    {
+      "file": "mobile/src/components/NewWorktreeModal.test.tsx",
+      "line": 66,
+      "column": 51,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"PickerListDrawer\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/components/NewWorktreeModal.test.tsx",
+      "line": 74,
+      "column": 7,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"TextInput\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/components/PickerModal.accessibility.test.ts",
+      "line": 57,
+      "column": 47,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/pr-sidebar/PRCommentsSection.test.ts",
+      "line": 100,
+      "column": 17,
+      "code": 2345,
+      "message": "Argument of type 'ReactTestInstance' is not assignable to parameter of type '{ props: { onPress: () => void; }; }'.\n  Types of property 'props' are incompatible.\n    Property 'onPress' is missing in type '{ [propName: string]: any; }' but required in type '{ onPress: () => void; }'."
+    },
+    {
+      "file": "mobile/src/components/pr-sidebar/PRCommentsSection.test.ts",
+      "line": 101,
+      "column": 40,
+      "code": 2345,
+      "message": "Argument of type '\"PRCommentCard\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/pr-sidebar/PRCommentsSection.test.ts",
+      "line": 104,
+      "column": 17,
+      "code": 2345,
+      "message": "Argument of type 'ReactTestInstance' is not assignable to parameter of type '{ props: { onPress: () => void; }; }'.\n  Types of property 'props' are incompatible.\n    Property 'onPress' is missing in type '{ [propName: string]: any; }' but required in type '{ onPress: () => void; }'."
+    },
+    {
+      "file": "mobile/src/components/pr-sidebar/PRCommentsSection.test.ts",
+      "line": 105,
+      "column": 40,
+      "code": 2345,
+      "message": "Argument of type '\"PRCommentCard\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/pr-sidebar/PRCommentsSection.test.ts",
+      "line": 107,
+      "column": 17,
+      "code": 2345,
+      "message": "Argument of type 'ReactTestInstance' is not assignable to parameter of type '{ props: { onPress: () => void; }; }'.\n  Types of property 'props' are incompatible.\n    Property 'onPress' is missing in type '{ [propName: string]: any; }' but required in type '{ onPress: () => void; }'."
+    },
+    {
+      "file": "mobile/src/components/pr-sidebar/PRCommentsSection.test.ts",
+      "line": 108,
+      "column": 40,
+      "code": 2345,
+      "message": "Argument of type '\"PRCommentCard\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/pr-sidebar/PRCommentsSection.test.ts",
+      "line": 111,
+      "column": 17,
+      "code": 2345,
+      "message": "Argument of type 'ReactTestInstance' is not assignable to parameter of type '{ props: { onPress: () => void; }; }'.\n  Types of property 'props' are incompatible.\n    Property 'onPress' is missing in type '{ [propName: string]: any; }' but required in type '{ onPress: () => void; }'."
+    },
+    {
+      "file": "mobile/src/components/pr-sidebar/PRCommentsSection.test.ts",
+      "line": 112,
+      "column": 40,
+      "code": 2345,
+      "message": "Argument of type '\"PRCommentCard\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/pr-sidebar/PRCommentsSection.test.ts",
+      "line": 68,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/pr-sidebar/PRCommentsSection.test.ts",
+      "line": 74,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/pr-sidebar/PRCommentsSection.test.ts",
+      "line": 98,
+      "column": 40,
+      "code": 2345,
+      "message": "Argument of type '\"PRCommentCard\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/WorktreeAgentList.test.tsx",
+      "line": 59,
+      "column": 47,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/WorktreeAgentList.test.tsx",
+      "line": 62,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type '\"WorktreeAgentRow\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/WorktreeAgentList.test.tsx",
+      "line": 67,
+      "column": 38,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/WorktreeAgentList.test.tsx",
+      "line": 70,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type '\"WorktreeAgentRow\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/WorktreeAgentList.test.tsx",
+      "line": 84,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/WorktreeAgentList.test.tsx",
+      "line": 85,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type '\"WorktreeAgentRow\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/components/WorktreeAgentList.test.tsx",
+      "line": 99,
+      "column": 38,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/dictation/mobile-dictation-setup.test.ts",
+      "line": 105,
+      "column": 11,
+      "code": 2741,
+      "message": "Property 'dictationMode' is missing in type '{ enabled: true; selectedModelId: string; models: never[]; }' but required in type 'RuntimeSpeechSetupState'."
+    },
+    {
+      "file": "mobile/src/dictation/mobile-dictation-setup.test.ts",
+      "line": 181,
+      "column": 24,
+      "code": 2345,
+      "message": "Argument of type '{ enabled: true; selectedModelId: string; models: RuntimeSpeechModelSummary[]; }' is not assignable to parameter of type 'RuntimeSpeechSetupState'.\n  Property 'dictationMode' is missing in type '{ enabled: true; selectedModelId: string; models: RuntimeSpeechModelSummary[]; }' but required in type 'RuntimeSpeechSetupState'."
+    },
+    {
+      "file": "mobile/src/dictation/mobile-dictation-setup.test.ts",
+      "line": 188,
+      "column": 24,
+      "code": 2345,
+      "message": "Argument of type '{ enabled: false; selectedModelId: string; models: RuntimeSpeechModelSummary[]; }' is not assignable to parameter of type 'RuntimeSpeechSetupState'.\n  Property 'dictationMode' is missing in type '{ enabled: false; selectedModelId: string; models: RuntimeSpeechModelSummary[]; }' but required in type 'RuntimeSpeechSetupState'."
+    },
+    {
+      "file": "mobile/src/dictation/mobile-dictation-setup.test.ts",
+      "line": 195,
+      "column": 24,
+      "code": 2345,
+      "message": "Argument of type '{ enabled: true; selectedModelId: string; models: RuntimeSpeechModelSummary[]; }' is not assignable to parameter of type 'RuntimeSpeechSetupState'.\n  Property 'dictationMode' is missing in type '{ enabled: true; selectedModelId: string; models: RuntimeSpeechModelSummary[]; }' but required in type 'RuntimeSpeechSetupState'."
+    },
+    {
+      "file": "mobile/src/dictation/mobile-dictation-setup.test.ts",
+      "line": 201,
+      "column": 29,
+      "code": 2345,
+      "message": "Argument of type '{ enabled: true; selectedModelId: string; models: never[]; }' is not assignable to parameter of type 'RuntimeSpeechSetupState'.\n  Property 'dictationMode' is missing in type '{ enabled: true; selectedModelId: string; models: never[]; }' but required in type 'RuntimeSpeechSetupState'."
+    },
+    {
+      "file": "mobile/src/dictation/mobile-dictation-setup.test.ts",
+      "line": 65,
+      "column": 11,
+      "code": 2741,
+      "message": "Property 'dictationMode' is missing in type '{ enabled: false; selectedModelId: string; models: never[]; }' but required in type 'RuntimeSpeechSetupState'."
+    },
+    {
+      "file": "mobile/src/dictation/mobile-dictation-setup.test.ts",
+      "line": 72,
+      "column": 11,
+      "code": 2741,
+      "message": "Property 'dictationMode' is missing in type '{ enabled: false; selectedModelId: string; models: never[]; }' but required in type 'RuntimeSpeechSetupState'."
+    },
+    {
+      "file": "mobile/src/dictation/mobile-dictation-setup.test.ts",
+      "line": 98,
+      "column": 11,
+      "code": 2741,
+      "message": "Property 'dictationMode' is missing in type '{ enabled: true; selectedModelId: string; models: never[]; }' but required in type 'RuntimeSpeechSetupState'."
+    },
+    {
+      "file": "mobile/src/files/MobileFileExplorerPanel.test.ts",
+      "line": 138,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/files/MobileFileExplorerPanel.test.ts",
+      "line": 150,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '\"Text\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/files/MobileFileExplorerPanel.test.ts",
+      "line": 38,
+      "column": 13,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'."
+    },
+    {
+      "file": "mobile/src/files/MobileFileMarkdownPreview.test.ts",
+      "line": 55,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/hooks/mobile-dictation-desktop-start.test.ts",
+      "line": 117,
+      "column": 5,
+      "code": 2322,
+      "message": "Type '() => void' is not assignable to type '() => undefined'.\n  Type 'void' is not assignable to type 'undefined'."
+    },
+    {
+      "file": "mobile/src/hooks/mobile-dictation-desktop-start.test.ts",
+      "line": 178,
+      "column": 5,
+      "code": 2322,
+      "message": "Type '() => void' is not assignable to type '() => undefined'.\n  Type 'void' is not assignable to type 'undefined'."
+    },
+    {
+      "file": "mobile/src/hooks/mobile-dictation-desktop-start.test.ts",
+      "line": 72,
+      "column": 5,
+      "code": 2322,
+      "message": "Type '() => void' is not assignable to type '() => undefined'.\n  Type 'void' is not assignable to type 'undefined'."
+    },
+    {
+      "file": "mobile/src/hooks/mobile-dictation-desktop-start.test.ts",
+      "line": 92,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '() => void' is not assignable to type '() => undefined'.\n  Type 'void' is not assignable to type 'undefined'."
+    },
+    {
+      "file": "mobile/src/hooks/use-now.test.ts",
+      "line": 62,
+      "column": 15,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/hooks/use-now.test.ts",
+      "line": 66,
+      "column": 15,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/hooks/use-now.test.ts",
+      "line": 72,
+      "column": 15,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/hooks/use-now.test.ts",
+      "line": 78,
+      "column": 15,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/host-edit-route-accessibility.test.ts",
+      "line": 82,
+      "column": 48,
+      "code": 2345,
+      "message": "Argument of type '\"TextInput\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/host-edit-save-flow.test.ts",
+      "line": 107,
+      "column": 38,
+      "code": 2345,
+      "message": "Argument of type '\"Text\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/host-edit-save-flow.test.ts",
+      "line": 287,
+      "column": 40,
+      "code": 2345,
+      "message": "Argument of type '\"TextInput\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/host-edit-save-flow.test.ts",
+      "line": 297,
+      "column": 40,
+      "code": 2345,
+      "message": "Argument of type '\"TextInput\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/host-edit-save-flow.test.ts",
+      "line": 307,
+      "column": 40,
+      "code": 2345,
+      "message": "Argument of type '\"TextInput\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/host-edit-save-flow.test.ts",
+      "line": 77,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '\"TextInput\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/host-edit-save-flow.test.ts",
+      "line": 89,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/mock-server-key-pair.test.ts",
+      "line": 63,
+      "column": 11,
+      "code": 2339,
+      "message": "Property 'unref' does not exist on type 'number'."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 130,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 139,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 148,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 186,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 193,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 230,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 238,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 270,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 278,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 286,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 290,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 317,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 348,
+      "column": 7,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 350,
+      "column": 7,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 354,
+      "column": 7,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 359,
+      "column": 7,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 495,
+      "column": 12,
+      "code": 2352,
+      "message": "Conversion of type 'NotificationRequestInput' to type '{ content: { data: { notificationId: string; }; }; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.\n  The types of 'content.data' are incompatible between these types.\n    Type 'Record<string, unknown> | undefined' is not comparable to type '{ notificationId: string; }'.\n      Property 'notificationId' is missing in type 'Record<string, unknown>' but required in type '{ notificationId: string; }'."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 674,
+      "column": 12,
+      "code": 2352,
+      "message": "Conversion of type 'NotificationRequestInput' to type '{ content: { data: { notificationId: string; }; }; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.\n  The types of 'content.data' are incompatible between these types.\n    Type 'Record<string, unknown> | undefined' is not comparable to type '{ notificationId: string; }'.\n      Property 'notificationId' is missing in type 'Record<string, unknown>' but required in type '{ notificationId: string; }'."
+    },
+    {
+      "file": "mobile/src/notifications/mobile-notifications.test.ts",
+      "line": 869,
+      "column": 58,
+      "code": 2345,
+      "message": "Argument of type '(method: string) => Promise<{ ok: true; result: { epoch: string; notifications: { type: string; notificationId: string; notificationSeq: number; notificationEpoch: string; title: string; body: string; }[]; }; } | { ...; }>' is not assignable to parameter of type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n  Type 'Promise<{ ok: true; result: { epoch: string; notifications: { type: string; notificationId: string; notificationSeq: number; notificationEpoch: string; title: string; body: string; }[]; }; } | { ok: true; result: { ...; }; }>' is not assignable to type 'Promise<RpcResponse>'.\n    Type '{ ok: true; result: { epoch: string; notifications: { type: string; notificationId: string; notificationSeq: number; notificationEpoch: string; title: string; body: string; }[]; }; } | { ok: true; result: { ...; }; }' is not assignable to type 'RpcResponse'.\n      Type '{ ok: true; result: { epoch: string; notifications: { type: string; notificationId: string; notificationSeq: number; notificationEpoch: string; title: string; body: string; }[]; }; }' is not assignable to type 'RpcResponse'.\n        Type '{ ok: true; result: { epoch: string; notifications: { type: string; notificationId: string; notificationSeq: number; notificationEpoch: string; title: string; body: string; }[]; }; }' is missing the following properties from type 'RpcSuccess': id, _meta"
+    },
+    {
+      "file": "mobile/src/notifications/notification-delivery-ordering.test.ts",
+      "line": 119,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/notification-delivery-ordering.test.ts",
+      "line": 123,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/notification-delivery-ordering.test.ts",
+      "line": 192,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/notification-delivery-ordering.test.ts",
+      "line": 197,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/notification-delivery-ordering.test.ts",
+      "line": 230,
+      "column": 7,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/notifications/notification-delivery-ordering.test.ts",
+      "line": 231,
+      "column": 7,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/onboarding/legacy-notification-opt-in-route.test.ts",
+      "line": 32,
+      "column": 49,
+      "code": 2322,
+      "message": "Type 'readonly [] | readonly [\"first-host\", \"second-host\"] | undefined' is not assignable to type 'string | string[] | undefined'.\n  Type 'readonly []' is not assignable to type 'string | string[] | undefined'.\n    The type 'readonly []' is 'readonly' and cannot be assigned to the mutable type 'string[]'."
+    },
+    {
+      "file": "mobile/src/onboarding/mobile-onboarding-screen.test.ts",
+      "line": 89,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type '\"MobileOnboardingPage\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/onboarding/MobileOnboardingPage.test.ts",
+      "line": 12,
+      "column": 48,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'."
+    },
+    {
+      "file": "mobile/src/onboarding/MobileOnboardingPage.test.ts",
+      "line": 63,
+      "column": 17,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Pressable\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/onboarding/MobileOnboardingPage.test.ts",
+      "line": 94,
+      "column": 50,
+      "code": 2345,
+      "message": "Argument of type '\"ScrollView\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/ai-vault-resume-launch.test.ts",
+      "line": 266,
+      "column": 9,
+      "code": 2353,
+      "message": "Object literal may only specify known properties, and 'activate' does not exist in type 'MobileAiVaultResumeLaunch & { clientMutationId?: string | undefined; }'."
+    },
+    {
+      "file": "mobile/src/session/mobile-file-tap-open.test.ts",
+      "line": 115,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ sendRequest: Mock<() => Promise<unknown>>; }' is not assignable to type 'Pick<RpcClient, \"sendRequest\">'.\n  The types returned by 'sendRequest(...)' are incompatible between these types.\n    Type 'Promise<unknown>' is not assignable to type 'Promise<RpcResponse>'.\n      Type 'unknown' is not assignable to type 'RpcResponse'."
+    },
+    {
+      "file": "mobile/src/session/mobile-file-tap-open.test.ts",
+      "line": 162,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ sendRequest: Mock<() => Promise<unknown>>; }' is not assignable to type 'Pick<RpcClient, \"sendRequest\">'.\n  The types returned by 'sendRequest(...)' are incompatible between these types.\n    Type 'Promise<unknown>' is not assignable to type 'Promise<RpcResponse>'.\n      Type 'unknown' is not assignable to type 'RpcResponse'."
+    },
+    {
+      "file": "mobile/src/session/mobile-file-tap-open.test.ts",
+      "line": 213,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ sendRequest: Mock<() => Promise<unknown>>; }' is not assignable to type 'Pick<RpcClient, \"sendRequest\">'.\n  The types returned by 'sendRequest(...)' are incompatible between these types.\n    Type 'Promise<unknown>' is not assignable to type 'Promise<RpcResponse>'.\n      Type 'unknown' is not assignable to type 'RpcResponse'."
+    },
+    {
+      "file": "mobile/src/session/mobile-file-tap-open.test.ts",
+      "line": 267,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ sendRequest: Mock<() => Promise<unknown>>; }' is not assignable to type 'Pick<RpcClient, \"sendRequest\">'.\n  The types returned by 'sendRequest(...)' are incompatible between these types.\n    Type 'Promise<unknown>' is not assignable to type 'Promise<RpcResponse>'.\n      Type 'unknown' is not assignable to type 'RpcResponse'."
+    },
+    {
+      "file": "mobile/src/session/mobile-file-tap-open.test.ts",
+      "line": 308,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ sendRequest: Mock<() => Promise<unknown>>; }' is not assignable to type 'Pick<RpcClient, \"sendRequest\">'.\n  The types returned by 'sendRequest(...)' are incompatible between these types.\n    Type 'Promise<unknown>' is not assignable to type 'Promise<RpcResponse>'.\n      Type 'unknown' is not assignable to type 'RpcResponse'."
+    },
+    {
+      "file": "mobile/src/session/mobile-file-tap-open.test.ts",
+      "line": 361,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ sendRequest: Mock<() => Promise<unknown>>; }' is not assignable to type 'Pick<RpcClient, \"sendRequest\">'.\n  The types returned by 'sendRequest(...)' are incompatible between these types.\n    Type 'Promise<unknown>' is not assignable to type 'Promise<RpcResponse>'.\n      Type 'unknown' is not assignable to type 'RpcResponse'."
+    },
+    {
+      "file": "mobile/src/session/mobile-file-tap-open.test.ts",
+      "line": 402,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ sendRequest: Mock<() => Promise<unknown>>; }' is not assignable to type 'Pick<RpcClient, \"sendRequest\">'.\n  The types returned by 'sendRequest(...)' are incompatible between these types.\n    Type 'Promise<unknown>' is not assignable to type 'Promise<RpcResponse>'.\n      Type 'unknown' is not assignable to type 'RpcResponse'."
+    },
+    {
+      "file": "mobile/src/session/mobile-file-tap-open.test.ts",
+      "line": 46,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ sendRequest: Mock<() => Promise<unknown>>; }' is not assignable to type 'Pick<RpcClient, \"sendRequest\">'.\n  The types returned by 'sendRequest(...)' are incompatible between these types.\n    Type 'Promise<unknown>' is not assignable to type 'Promise<RpcResponse>'.\n      Type 'unknown' is not assignable to type 'RpcResponse'."
+    },
+    {
+      "file": "mobile/src/session/mobile-file-tap-open.test.ts",
+      "line": 465,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ sendRequest: Mock<() => Promise<unknown>>; }' is not assignable to type 'Pick<RpcClient, \"sendRequest\">'.\n  The types returned by 'sendRequest(...)' are incompatible between these types.\n    Type 'Promise<unknown>' is not assignable to type 'Promise<RpcResponse>'.\n      Type 'unknown' is not assignable to type 'RpcResponse'."
+    },
+    {
+      "file": "mobile/src/session/mobile-file-tap-open.test.ts",
+      "line": 510,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ sendRequest: Mock<() => Promise<unknown>>; }' is not assignable to type 'Pick<RpcClient, \"sendRequest\">'.\n  The types returned by 'sendRequest(...)' are incompatible between these types.\n    Type 'Promise<unknown>' is not assignable to type 'Promise<RpcResponse>'.\n      Type 'unknown' is not assignable to type 'RpcResponse'."
+    },
+    {
+      "file": "mobile/src/session/mobile-file-tap-open.test.ts",
+      "line": 548,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ sendRequest: Mock<() => Promise<unknown>>; }' is not assignable to type 'Pick<RpcClient, \"sendRequest\">'.\n  The types returned by 'sendRequest(...)' are incompatible between these types.\n    Type 'Promise<unknown>' is not assignable to type 'Promise<RpcResponse>'.\n      Type 'unknown' is not assignable to type 'RpcResponse'."
+    },
+    {
+      "file": "mobile/src/session/mobile-file-tap-open.test.ts",
+      "line": 593,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ sendRequest: Mock<() => Promise<unknown>>; }' is not assignable to type 'Pick<RpcClient, \"sendRequest\">'.\n  The types returned by 'sendRequest(...)' are incompatible between these types.\n    Type 'Promise<unknown>' is not assignable to type 'Promise<RpcResponse>'.\n      Type 'unknown' is not assignable to type 'RpcResponse'."
+    },
+    {
+      "file": "mobile/src/session/mobile-file-tap-open.test.ts",
+      "line": 641,
+      "column": 7,
+      "code": 2322,
+      "message": "Type '{ sendRequest: Mock<() => Promise<unknown>>; }' is not assignable to type 'Pick<RpcClient, \"sendRequest\">'.\n  The types returned by 'sendRequest(...)' are incompatible between these types.\n    Type 'Promise<unknown>' is not assignable to type 'Promise<RpcResponse>'.\n      Type 'unknown' is not assignable to type 'RpcResponse'."
+    },
+    {
+      "file": "mobile/src/session/mobile-native-chat-open-file.test.ts",
+      "line": 120,
+      "column": 33,
+      "code": 2345,
+      "message": "Argument of type '{ pathText: string; client: { sendRequest: ReturnType<typeof vi.fn>; }; hostId: string; worktreeId: string; pushPreviewRoute: Mock<Procedure>; openBrowser: Mock<Procedure>; ... 7 more ...; onOpenFailed: Mock<...>; }' is not assignable to parameter of type 'OpenMobileNativeChatFileTapOptions<any>'.\n  The types of 'client.sendRequest' are incompatible between these types.\n    Type 'Mock<Procedure | Constructable>' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n      Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n        Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(method: string, params?: unknown, options?: SendRequestOptions | undefined): Promise<RpcResponse>'."
+    },
+    {
+      "file": "mobile/src/session/mobile-native-chat-open-file.test.ts",
+      "line": 153,
+      "column": 33,
+      "code": 2345,
+      "message": "Argument of type '{ pathText: string; client: { sendRequest: ReturnType<typeof vi.fn>; }; hostId: string; worktreeId: string; pushPreviewRoute: Mock<Procedure>; openBrowser: Mock<Procedure>; ... 7 more ...; onOpenFailed: Mock<...>; }' is not assignable to parameter of type 'OpenMobileNativeChatFileTapOptions<any>'.\n  The types of 'client.sendRequest' are incompatible between these types.\n    Type 'Mock<Procedure | Constructable>' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n      Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n        Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(method: string, params?: unknown, options?: SendRequestOptions | undefined): Promise<RpcResponse>'."
+    },
+    {
+      "file": "mobile/src/session/mobile-native-chat-open-file.test.ts",
+      "line": 168,
+      "column": 33,
+      "code": 2345,
+      "message": "Argument of type '{ pathText: string; client: { sendRequest: ReturnType<typeof vi.fn>; }; hostId: string; worktreeId: string; pushPreviewRoute: Mock<Procedure>; openBrowser: Mock<Procedure>; ... 7 more ...; onOpenFailed: Mock<...>; }' is not assignable to parameter of type 'OpenMobileNativeChatFileTapOptions<any>'.\n  The types of 'client.sendRequest' are incompatible between these types.\n    Type 'Mock<Procedure | Constructable>' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n      Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n        Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(method: string, params?: unknown, options?: SendRequestOptions | undefined): Promise<RpcResponse>'."
+    },
+    {
+      "file": "mobile/src/session/mobile-native-chat-open-file.test.ts",
+      "line": 188,
+      "column": 33,
+      "code": 2345,
+      "message": "Argument of type '{ pathText: string; getSessionTabs: () => { id: string; relativePath: string; }[]; getActiveSessionTabId: () => string; switchSessionTab: Mock<Procedure>; scheduleDelayedAction: Mock<...>; ... 8 more ...; onOpenFailed: Mock<...>; }' is not assignable to parameter of type 'OpenMobileNativeChatFileTapOptions<{ id: string; relativePath: string; }>'.\n  The types of 'client.sendRequest' are incompatible between these types.\n    Type 'Mock<Procedure | Constructable>' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n      Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n        Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(method: string, params?: unknown, options?: SendRequestOptions | undefined): Promise<RpcResponse>'."
+    },
+    {
+      "file": "mobile/src/session/mobile-native-chat-open-file.test.ts",
+      "line": 58,
+      "column": 33,
+      "code": 2345,
+      "message": "Argument of type '{ pathText: string; client: { sendRequest: ReturnType<typeof vi.fn>; }; hostId: string; worktreeId: string; pushPreviewRoute: Mock<Procedure>; openBrowser: Mock<Procedure>; ... 7 more ...; onOpenFailed: Mock<...>; }' is not assignable to parameter of type 'OpenMobileNativeChatFileTapOptions<any>'.\n  The types of 'client.sendRequest' are incompatible between these types.\n    Type 'Mock<Procedure | Constructable>' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n      Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n        Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(method: string, params?: unknown, options?: SendRequestOptions | undefined): Promise<RpcResponse>'."
+    },
+    {
+      "file": "mobile/src/session/mobile-native-chat-open-file.test.ts",
+      "line": 87,
+      "column": 33,
+      "code": 2345,
+      "message": "Argument of type '{ pathText: string; nativeChatContext: { tabId: string; sessionId: string; }; client: { sendRequest: ReturnType<typeof vi.fn>; }; hostId: string; worktreeId: string; pushPreviewRoute: Mock<Procedure>; ... 8 more ...; onOpenFailed: Mock<...>; }' is not assignable to parameter of type 'OpenMobileNativeChatFileTapOptions<any>'.\n  The types of 'client.sendRequest' are incompatible between these types.\n    Type 'Mock<Procedure | Constructable>' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n      Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n        Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(method: string, params?: unknown, options?: SendRequestOptions | undefined): Promise<RpcResponse>'."
+    },
+    {
+      "file": "mobile/src/session/mobile-session-tab-activation.test.ts",
+      "line": 75,
+      "column": 57,
+      "code": 2345,
+      "message": "Argument of type '{ worktree: string; tabId: string; notifyClients: false; navigation: \"caller\"; }' is not assignable to parameter of type 'MobileSessionTabActivationParams'.\n  Property 'intent' is missing in type '{ worktree: string; tabId: string; notifyClients: false; navigation: \"caller\"; }' but required in type 'MobileSessionTabActivationParams'."
+    },
+    {
+      "file": "mobile/src/session/mobile-terminal-records.test.ts",
+      "line": 144,
+      "column": 15,
+      "code": 2322,
+      "message": "Type 'string' is not assignable to type '\"working\" | \"blocked\" | \"waiting\" | \"done\"'."
+    },
+    {
+      "file": "mobile/src/session/MobileMarkdownReader.test.tsx",
+      "line": 101,
+      "column": 40,
+      "code": 2345,
+      "message": "Argument of type '\"Text\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/MobileMarkdownReader.test.tsx",
+      "line": 108,
+      "column": 40,
+      "code": 2345,
+      "message": "Argument of type '\"Text\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/MobileMarkdownReader.test.tsx",
+      "line": 18,
+      "column": 47,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 15,
+      "column": 48,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 172,
+      "column": 7,
+      "code": 2352,
+      "message": "Conversion of type 'ReactTestInstance' to type '{ props: { accessibilityState: { disabled: boolean; }; }; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.\n  Types of property 'props' are incompatible.\n    Property 'accessibilityState' is missing in type '{ [propName: string]: any; }' but required in type '{ accessibilityState: { disabled: boolean; }; }'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 173,
+      "column": 19,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Pressable\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 250,
+      "column": 49,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"TextInput\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 273,
+      "column": 20,
+      "code": 2352,
+      "message": "Conversion of type 'ReactTestInstance[]' to type '{ props: { source: { uri: string; }; }; }[]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.\n  Type 'ReactTestInstance' is not comparable to type '{ props: { source: { uri: string; }; }; }'.\n    Types of property 'props' are incompatible.\n      Property 'source' is missing in type '{ [propName: string]: any; }' but required in type '{ source: { uri: string; }; }'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 273,
+      "column": 53,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Image\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 278,
+      "column": 20,
+      "code": 2352,
+      "message": "Conversion of type 'ReactTestInstance[]' to type '{ props: { onPress: () => void; }; }[]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.\n  Type 'ReactTestInstance' is not comparable to type '{ props: { onPress: () => void; }; }'.\n    Types of property 'props' are incompatible.\n      Property 'onPress' is missing in type '{ [propName: string]: any; }' but required in type '{ onPress: () => void; }'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 279,
+      "column": 17,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Pressable\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 315,
+      "column": 37,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"TextInput\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 315,
+      "column": 7,
+      "code": 2352,
+      "message": "Conversion of type 'ReactTestInstance' to type '{ props: { selection?: { start: number; end: number; } | undefined; onSelectionChange: (e: { nativeEvent: { selection: { end: number; }; }; }) => void; }; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.\n  Types of property 'props' are incompatible.\n    Property 'onSelectionChange' is missing in type '{ [propName: string]: any; }' but required in type '{ selection?: { start: number; end: number; } | undefined; onSelectionChange: (e: { nativeEvent: { selection: { end: number; }; }; }) => void; }'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 327,
+      "column": 29,
+      "code": 2352,
+      "message": "Conversion of type 'ReactTestInstance' to type '{ props: { onPress: () => void; }; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.\n  Types of property 'props' are incompatible.\n    Property 'onPress' is missing in type '{ [propName: string]: any; }' but required in type '{ onPress: () => void; }'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 328,
+      "column": 17,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Pressable\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 352,
+      "column": 19,
+      "code": 2352,
+      "message": "Conversion of type 'ReactTestInstance' to type '{ props: { onSelectionChange: (e: { nativeEvent: { selection: { end: number; }; }; }) => void; }; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.\n  Types of property 'props' are incompatible.\n    Property 'onSelectionChange' is missing in type '{ [propName: string]: any; }' but required in type '{ onSelectionChange: (e: { nativeEvent: { selection: { end: number; }; }; }) => void; }'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 352,
+      "column": 49,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"TextInput\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 357,
+      "column": 26,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Text\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 372,
+      "column": 19,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Pressable\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 42,
+      "column": 66,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 75,
+      "column": 12,
+      "code": 2352,
+      "message": "Conversion of type 'ReactTestInstance' to type '{ props: { onPress: () => Promise<void>; }; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.\n  Types of property 'props' are incompatible.\n    Property 'onPress' is missing in type '{ [propName: string]: any; }' but required in type '{ onPress: () => Promise<void>; }'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 76,
+      "column": 17,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Pressable\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatComposer.test.ts",
+      "line": 99,
+      "column": 35,
+      "code": 2345,
+      "message": "Argument of type '\"TextInput\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatMessage.test.ts",
+      "line": 13,
+      "column": 42,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatMessage.test.ts",
+      "line": 15,
+      "column": 42,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatOverlay.test.ts",
+      "line": 43,
+      "column": 49,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type '{ controller: MobileNativeChatController; images: never; onMicPress: Mock<Procedure>; micActive: false; dictationMode: \"toggle\"; onMicPressIn: Mock<...>; ... 4 more ...; keyboardInset: number; }' is not assignable to parameter of type 'Attributes & Props'.\n      Property 'onOpenFile' is missing in type '{ controller: MobileNativeChatController; images: never; onMicPress: Mock<Procedure>; micActive: false; dictationMode: \"toggle\"; onMicPressIn: Mock<...>; ... 4 more ...; keyboardInset: number; }' but required in type 'Props'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatOverlay.test.ts",
+      "line": 80,
+      "column": 52,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"ChatView\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatPermission.test.ts",
+      "line": 35,
+      "column": 20,
+      "code": 18047,
+      "message": "'renderer' is possibly 'null'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatPermission.test.ts",
+      "line": 35,
+      "column": 45,
+      "code": 2345,
+      "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatSessionOptionPickers.test.ts",
+      "line": 103,
+      "column": 5,
+      "code": 2352,
+      "message": "Conversion of type 'ReactTestInstance' to type '{ props: { onPress: () => void; accessibilityLabel?: string | undefined; disabled?: boolean | undefined; accessibilityRole?: string | undefined; accessibilityState?: { disabled?: boolean | undefined; } | undefined; }; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.\n  Types of property 'props' are incompatible.\n    Property 'onPress' is missing in type '{ [propName: string]: any; }' but required in type '{ onPress: () => void; accessibilityLabel?: string | undefined; disabled?: boolean | undefined; accessibilityRole?: string | undefined; accessibilityState?: { disabled?: boolean | undefined; } | undefined; }'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatSessionOptionPickers.test.ts",
+      "line": 105,
+      "column": 9,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Pressable\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatSessionOptionPickers.test.ts",
+      "line": 129,
+      "column": 26,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Text\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatSessionOptionPickers.test.ts",
+      "line": 135,
+      "column": 22,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Pressable\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatSessionOptionPickers.test.ts",
+      "line": 176,
+      "column": 26,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Text\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatSessionOptionPickers.test.ts",
+      "line": 184,
+      "column": 38,
+      "code": 2345,
+      "message": "Argument of type '\"BottomDrawer\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatSessionOptionPickers.test.ts",
+      "line": 27,
+      "column": 66,
+      "code": 2769,
+      "message": "No overload matches this call.\n  The last overload gave the following error.\n    Argument of type 'unknown' is not assignable to parameter of type 'ReactNode'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatView.test.ts",
+      "line": 117,
+      "column": 48,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"FlatList\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatView.test.ts",
+      "line": 122,
+      "column": 48,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"FlatList\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatView.test.ts",
+      "line": 133,
+      "column": 42,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Composer\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatView.test.ts",
+      "line": 140,
+      "column": 26,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Text\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatView.test.ts",
+      "line": 146,
+      "column": 22,
+      "code": 2352,
+      "message": "Conversion of type 'ReactTestInstance' to type '{ props: { onPress: () => Promise<boolean>; }; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.\n  Types of property 'props' are incompatible.\n    Property 'onPress' is missing in type '{ [propName: string]: any; }' but required in type '{ onPress: () => Promise<boolean>; }'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatView.test.ts",
+      "line": 146,
+      "column": 52,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Composer\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatView.test.ts",
+      "line": 211,
+      "column": 29,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatView.test.ts",
+      "line": 216,
+      "column": 29,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatView.test.ts",
+      "line": 218,
+      "column": 29,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatView.test.ts",
+      "line": 231,
+      "column": 29,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatView.test.ts",
+      "line": 233,
+      "column": 29,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/MobileNativeChatView.test.ts",
+      "line": 236,
+      "column": 29,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/QuickCommandsList.test.ts",
+      "line": 63,
+      "column": 46,
+      "code": 2345,
+      "message": "Argument of type '\"TextInput\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/QuickCommandsList.test.ts",
+      "line": 89,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type '\"TextInput\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/QuickCommandsSheet.test.ts",
+      "line": 117,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type '\"QuickCommandsList\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/QuickCommandsSheet.test.ts",
+      "line": 118,
+      "column": 46,
+      "code": 2345,
+      "message": "Argument of type '\"QuickCommandEditorForm\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/QuickCommandsSheet.test.ts",
+      "line": 123,
+      "column": 51,
+      "code": 2345,
+      "message": "Argument of type '\"QuickCommandEditorForm\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/QuickCommandsSheet.test.ts",
+      "line": 154,
+      "column": 44,
+      "code": 2345,
+      "message": "Argument of type '\"QuickCommandsList\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/QuickCommandsSheet.test.ts",
+      "line": 157,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type '\"QuickCommandEditorForm\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/QuickCommandsSheet.test.ts",
+      "line": 180,
+      "column": 44,
+      "code": 2345,
+      "message": "Argument of type '\"QuickCommandsList\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/QuickCommandsSheet.test.ts",
+      "line": 184,
+      "column": 38,
+      "code": 2345,
+      "message": "Argument of type '\"QuickCommandEditorForm\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/QuickCommandsSheet.test.ts",
+      "line": 203,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type '\"QuickCommandsList\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/QuickCommandsSheet.test.ts",
+      "line": 95,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type '\"QuickCommandsList\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-diff-review-send-actions.test.ts",
+      "line": 40,
+      "column": 26,
+      "code": 2322,
+      "message": "Type '\"none\"' is not assignable to type 'GitConflictOperation'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-diff-review-send-actions.test.ts",
+      "line": 74,
+      "column": 7,
+      "code": 2322,
+      "message": "Type 'Mock<Procedure | Constructable>' is not assignable to type 'Dispatch<SetStateAction<string | null>>'.\n  Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type 'Dispatch<SetStateAction<string | null>>'.\n    Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(value: SetStateAction<string | null>): void'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-diff-review-send-actions.test.ts",
+      "line": 75,
+      "column": 7,
+      "code": 2322,
+      "message": "Type 'Mock<Procedure | Constructable>' is not assignable to type 'Dispatch<SetStateAction<SendSheetState | null>>'.\n  Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type 'Dispatch<SetStateAction<SendSheetState | null>>'.\n    Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(value: SetStateAction<SendSheetState | null>): void'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-diff-review-send-actions.test.ts",
+      "line": 76,
+      "column": 7,
+      "code": 2322,
+      "message": "Type 'Mock<Procedure | Constructable>' is not assignable to type '(comments: DiffComment[], reviewState: MobileDiffReviewState) => Promise<void>'.\n  Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '(comments: DiffComment[], reviewState: MobileDiffReviewState) => Promise<void>'.\n    Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(comments: DiffComment[], reviewState: MobileDiffReviewState): Promise<void>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-file-tap-handlers.test.ts",
+      "line": 52,
+      "column": 41,
+      "code": 2345,
+      "message": "Argument of type '{ client: { sendRequest: Mock<Procedure | Constructable>; }; hostId: string; worktreeId: string; worktreeName: string; nativeChatSessionId: string; activeHandleRef: { ...; }; ... 8 more ...; reportChatTapFailure: Mock<...>; }' is not assignable to parameter of type 'MobileFileTapHandlerOptions<any>'.\n  The types of 'client.sendRequest' are incompatible between these types.\n    Type 'Mock<Procedure | Constructable>' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n      Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'.\n        Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(method: string, params?: unknown, options?: SendRequestOptions | undefined): Promise<RpcResponse>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-answer-send.test.ts",
+      "line": 136,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-answer-send.test.ts",
+      "line": 138,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-answer-send.test.ts",
+      "line": 140,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-answer-send.test.ts",
+      "line": 159,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-answer-send.test.ts",
+      "line": 189,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-answer-send.test.ts",
+      "line": 190,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-answer-send.test.ts",
+      "line": 207,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-answer-send.test.ts",
+      "line": 250,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-answer-send.test.ts",
+      "line": 352,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-answer-send.test.ts",
+      "line": 396,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-answer-send.test.ts",
+      "line": 453,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-drafts.test.ts",
+      "line": 187,
+      "column": 17,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-drafts.test.ts",
+      "line": 464,
+      "column": 17,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-drafts.test.ts",
+      "line": 511,
+      "column": 17,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-drafts.test.ts",
+      "line": 568,
+      "column": 17,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-drafts.test.ts",
+      "line": 587,
+      "column": 17,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-drafts.test.ts",
+      "line": 589,
+      "column": 17,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-drafts.test.ts",
+      "line": 624,
+      "column": 17,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-drafts.test.ts",
+      "line": 658,
+      "column": 17,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-drafts.test.ts",
+      "line": 685,
+      "column": 17,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-drafts.test.ts",
+      "line": 711,
+      "column": 17,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-drafts.test.ts",
+      "line": 761,
+      "column": 17,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-file-search.test.ts",
+      "line": 110,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-file-search.test.ts",
+      "line": 136,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-file-search.test.ts",
+      "line": 138,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-file-search.test.ts",
+      "line": 51,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-file-search.test.ts",
+      "line": 54,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-file-search.test.ts",
+      "line": 79,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-file-search.test.ts",
+      "line": 83,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-file-search.test.ts",
+      "line": 99,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 115,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 136,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 199,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 233,
+      "column": 30,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 271,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 312,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 336,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 356,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 378,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 417,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 429,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type 'never[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type 'never[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 445,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 479,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 502,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 551,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 587,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 625,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 679,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 721,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 765,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 809,
+      "column": 30,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 810,
+      "column": 30,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+      "line": 887,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type '{ base64: string; uri: string; }[]' is not assignable to parameter of type 'AsyncIterable<PickedMobileImage>'.\n  Property '[Symbol.asyncIterator]' is missing in type '{ base64: string; uri: string; }[]' but required in type 'AsyncIterable<PickedMobileImage>'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-input-lease.test.ts",
+      "line": 33,
+      "column": 15,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'boolean | undefined' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'undefined' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'boolean | undefined' is not assignable to type 'VoidOrUndefinedOnly'.\n      Type 'boolean' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-stop.test.ts",
+      "line": 179,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-stop.test.ts",
+      "line": 71,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-mobile-native-chat-stop.test.ts",
+      "line": 98,
+      "column": 27,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'Promise<VoidOrUndefinedOnly>'.\n      Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'.\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'Promise<VitestUtils>' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-throttled-latest-value.test.ts",
+      "line": 46,
+      "column": 15,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/session/use-throttled-latest-value.test.ts",
+      "line": 56,
+      "column": 15,
+      "code": 2769,
+      "message": "No overload matches this call.\n  Overload 1 of 2, '(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>', gave the following error.\n    Type 'VitestUtils' is missing the following properties from type 'Promise<VoidOrUndefinedOnly>': then, catch, finally, [Symbol.toStringTag]\n  Overload 2 of 2, '(callback: () => VoidOrUndefinedOnly): DebugPromiseLike', gave the following error.\n    Type 'VitestUtils' is not assignable to type 'VoidOrUndefinedOnly'."
+    },
+    {
+      "file": "mobile/src/source-control/mobile-create-pr-action.test.ts",
+      "line": 14,
+      "column": 3,
+      "code": 2322,
+      "message": "Type '{ provider: HostedReviewProvider; review: HostedReviewSummary | null; canCreate: boolean; ... 7 more ...; stackedCreationSupported?: boolean | undefined; }' is not assignable to type 'HostedReviewCreationEligibility'.\n  Types of property 'reviewLookupOutcome' are incompatible.\n    Type 'HostedReviewLookupOutcome | undefined' is not assignable to type 'HostedReviewLookupOutcome'.\n      Type 'undefined' is not assignable to type 'HostedReviewLookupOutcome'."
+    },
+    {
+      "file": "mobile/src/source-control/mobile-create-pr-action.test.ts",
+      "line": 63,
+      "column": 56,
+      "code": 2304,
+      "message": "Cannot find name 'HostedReviewProvider'."
+    },
+    {
+      "file": "mobile/src/source-control/mobile-hosted-review-create-intent-runner.test.ts",
+      "line": 169,
+      "column": 11,
+      "code": 2322,
+      "message": "Type '{ entries: unknown[]; conflictOperation: string; branch: string; head: string; upstreamStatus: { hasUpstream: boolean; ahead: number; behind: number; }; }' is not assignable to type 'GitStatusResult'.\n  Types of property 'entries' are incompatible.\n    Type 'unknown[]' is not assignable to type 'GitUncommittedEntry[]'.\n      Type 'unknown' is not assignable to type 'GitUncommittedEntry'."
+    },
+    {
+      "file": "mobile/src/source-control/mobile-hosted-review-create-intent-runner.test.ts",
+      "line": 182,
+      "column": 11,
+      "code": 2322,
+      "message": "Type '{ entries: unknown[]; conflictOperation: string; branch: string; head: string; upstreamStatus: { hasUpstream: boolean; ahead: number; behind: number; }; }' is not assignable to type 'GitStatusResult'.\n  Types of property 'entries' are incompatible.\n    Type 'unknown[]' is not assignable to type 'GitUncommittedEntry[]'.\n      Type 'unknown' is not assignable to type 'GitUncommittedEntry'."
+    },
+    {
+      "file": "mobile/src/source-control/mobile-hosted-review-create-intent-runner.test.ts",
+      "line": 194,
+      "column": 11,
+      "code": 2322,
+      "message": "Type '{ entries: unknown[]; conflictOperation: string; branch: string; head: string; upstreamStatus: { hasUpstream: boolean; ahead: number; behind: number; }; }' is not assignable to type 'GitStatusResult'.\n  Types of property 'entries' are incompatible.\n    Type 'unknown[]' is not assignable to type 'GitUncommittedEntry[]'.\n      Type 'unknown' is not assignable to type 'GitUncommittedEntry'."
+    },
+    {
+      "file": "mobile/src/source-control/MobileGitHistoryList.test.tsx",
+      "line": 148,
+      "column": 17,
+      "code": 2367,
+      "message": "This comparison appears to be unintentional because the types 'ElementType' and '\"Pressable\"' have no overlap."
+    },
+    {
+      "file": "mobile/src/source-control/use-mobile-hosted-review-eligibility.test.ts",
+      "line": 19,
+      "column": 3,
+      "code": 2322,
+      "message": "Type '{ provider: HostedReviewProvider; review: HostedReviewSummary | null; canCreate: boolean; ... 7 more ...; stackedCreationSupported?: boolean | undefined; }' is not assignable to type 'HostedReviewCreationEligibility'.\n  Types of property 'reviewLookupOutcome' are incompatible.\n    Type 'HostedReviewLookupOutcome | undefined' is not assignable to type 'HostedReviewLookupOutcome'.\n      Type 'undefined' is not assignable to type 'HostedReviewLookupOutcome'."
+    },
+    {
+      "file": "mobile/src/terminal/terminal-caret-rendering-oracle.test.ts",
+      "line": 78,
+      "column": 60,
+      "code": 2345,
+      "message": "Argument of type '(this: EventTarget, type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) => void' is not assignable to parameter of type '(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions | undefined) => void'.\n  Types of parameters 'listener' and 'callback' are incompatible.\n    Type 'EventListenerOrEventListenerObject | null' is not assignable to type 'EventListenerOrEventListenerObject'.\n      Type 'null' is not assignable to type 'EventListenerOrEventListenerObject'."
+    },
+    {
+      "file": "mobile/src/terminal/terminal-caret-rendering-oracle.test.ts",
+      "line": 95,
+      "column": 63,
+      "code": 2345,
+      "message": "Argument of type '(this: EventTarget, type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions) => void' is not assignable to parameter of type '(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | EventListenerOptions | undefined) => void'.\n  Types of parameters 'listener' and 'callback' are incompatible.\n    Type 'EventListenerOrEventListenerObject | null' is not assignable to type 'EventListenerOrEventListenerObject'.\n      Type 'null' is not assignable to type 'EventListenerOrEventListenerObject'."
+    },
+    {
+      "file": "mobile/src/terminal/terminal-webview-engine-error.test.ts",
+      "line": 241,
+      "column": 30,
+      "code": 2339,
+      "message": "Property 'root' does not exist on type 'never'."
+    },
+    {
+      "file": "mobile/src/terminal/terminal-webview-engine-error.test.ts",
+      "line": 64,
+      "column": 44,
+      "code": 2345,
+      "message": "Argument of type '\"WebView\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/terminal/terminal-webview-engine-error.test.ts",
+      "line": 72,
+      "column": 20,
+      "code": 2345,
+      "message": "Argument of type '\"Text\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/terminal/terminal-webview-query-reply-routing.test.ts",
+      "line": 40,
+      "column": 44,
+      "code": 2345,
+      "message": "Argument of type '\"WebView\"' is not assignable to parameter of type 'ElementType'."
+    },
+    {
+      "file": "mobile/src/terminal/terminal-webview-wheel-scroll.test.ts",
+      "line": 178,
+      "column": 45,
+      "code": 2345,
+      "message": "Argument of type 'Mock<Procedure | Constructable>' is not assignable to parameter of type '(lines: number) => void'.\n  Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '(lines: number) => void'.\n    Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(lines: number): void'."
+    },
+    {
+      "file": "mobile/src/terminal/terminal-webview-wheel-scroll.test.ts",
+      "line": 182,
+      "column": 38,
+      "code": 2322,
+      "message": "Type 'Mock<Procedure | Constructable>' is not assignable to type '(data: string) => void'.\n  Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '(data: string) => void'.\n    Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(data: string): void'."
+    },
+    {
+      "file": "mobile/src/transport/client-context.test.ts",
+      "line": 458,
+      "column": 15,
+      "code": 18047,
+      "message": "'renderer' is possibly 'null'."
+    },
+    {
+      "file": "mobile/src/transport/connection-revival-triggers.test.ts",
+      "line": 51,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type 'Mock<Procedure | Constructable>' is not assignable to parameter of type '() => void'.\n  Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '() => void'.\n    Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(): void'."
+    },
+    {
+      "file": "mobile/src/transport/connection-revival-triggers.test.ts",
+      "line": 59,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type 'Mock<Procedure | Constructable>' is not assignable to parameter of type '() => void'.\n  Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '() => void'.\n    Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(): void'."
+    },
+    {
+      "file": "mobile/src/transport/connection-revival-triggers.test.ts",
+      "line": 68,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type 'Mock<Procedure | Constructable>' is not assignable to parameter of type '() => void'.\n  Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '() => void'.\n    Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(): void'."
+    },
+    {
+      "file": "mobile/src/transport/connection-revival-triggers.test.ts",
+      "line": 74,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type 'Mock<Procedure | Constructable>' is not assignable to parameter of type '() => void'.\n  Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '() => void'.\n    Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(): void'."
+    },
+    {
+      "file": "mobile/src/transport/connection-revival-triggers.test.ts",
+      "line": 80,
+      "column": 28,
+      "code": 2345,
+      "message": "Argument of type 'Mock<Procedure | Constructable>' is not assignable to parameter of type '() => void'.\n  Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '() => void'.\n    Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(): void'."
+    },
+    {
+      "file": "mobile/src/transport/connection-revival-triggers.test.ts",
+      "line": 88,
+      "column": 60,
+      "code": 2345,
+      "message": "Argument of type 'Mock<Procedure | Constructable>' is not assignable to parameter of type '(reason: \"app-resume\" | \"network-change\") => void'.\n  Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '(reason: \"app-resume\" | \"network-change\") => void'.\n    Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(reason: \"app-resume\" | \"network-change\"): void'."
+    },
+    {
+      "file": "mobile/src/transport/host-credential-cleanup.test.ts",
+      "line": 146,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/host-credential-cleanup.test.ts",
+      "line": 171,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/host-credential-cleanup.test.ts",
+      "line": 262,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/host-edit-navigation.test.ts",
+      "line": 121,
+      "column": 9,
+      "code": 2345,
+      "message": "Argument of type '{ push: () => never; }' is not assignable to parameter of type 'HostStackRouter'.\n  Property 'replace' is missing in type '{ push: () => never; }' but required in type 'HostStackRouter'."
+    },
+    {
+      "file": "mobile/src/transport/host-list-load-sharing.test.ts",
+      "line": 22,
+      "column": 37,
+      "code": 2345,
+      "message": "Argument of type 'Mock<() => Promise<HostProfile[]>>' is not assignable to parameter of type '() => Promise<HostListSnapshot>'.\n  Type 'Promise<HostProfile[]>' is not assignable to type 'Promise<HostListSnapshot>'.\n    Type 'HostProfile[]' is missing the following properties from type 'HostListSnapshot': catalog, profiles"
+    },
+    {
+      "file": "mobile/src/transport/host-list-load-sharing.test.ts",
+      "line": 23,
+      "column": 38,
+      "code": 2345,
+      "message": "Argument of type 'Mock<() => Promise<HostProfile[]>>' is not assignable to parameter of type '() => Promise<HostListSnapshot>'.\n  Type 'Promise<HostProfile[]>' is not assignable to type 'Promise<HostListSnapshot>'.\n    Type 'HostProfile[]' is missing the following properties from type 'HostListSnapshot': catalog, profiles"
+    },
+    {
+      "file": "mobile/src/transport/host-removal-lifecycle.test.ts",
+      "line": 43,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/host-status-gates.test.ts",
+      "line": 104,
+      "column": 17,
+      "code": 2339,
+      "message": "Property 'unmount' does not exist on type 'never'."
+    },
+    {
+      "file": "mobile/src/transport/host-status-gates.test.ts",
+      "line": 134,
+      "column": 21,
+      "code": 2339,
+      "message": "Property 'floatingWorkspaceEnabled' does not exist on type 'never'."
+    },
+    {
+      "file": "mobile/src/transport/host-status-gates.test.ts",
+      "line": 168,
+      "column": 17,
+      "code": 2339,
+      "message": "Property 'unmount' does not exist on type 'never'."
+    },
+    {
+      "file": "mobile/src/transport/host-status-gates.test.ts",
+      "line": 195,
+      "column": 21,
+      "code": 2339,
+      "message": "Property 'hostCapabilities' does not exist on type 'never'."
+    },
+    {
+      "file": "mobile/src/transport/host-status-gates.test.ts",
+      "line": 202,
+      "column": 17,
+      "code": 2339,
+      "message": "Property 'unmount' does not exist on type 'never'."
+    },
+    {
+      "file": "mobile/src/transport/host-status-gates.test.ts",
+      "line": 71,
+      "column": 17,
+      "code": 2339,
+      "message": "Property 'unmount' does not exist on type 'never'."
+    },
+    {
+      "file": "mobile/src/transport/host-store.test.ts",
+      "line": 596,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/host-store.test.ts",
+      "line": 625,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/mobile-endpoint-supervisor-nudge.test.ts",
+      "line": 180,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-background-grace.test.ts",
+      "line": 33,
+      "column": 9,
+      "code": 2741,
+      "message": "Property '__promisify__' is missing in type 'MockInstance<() => ReturnType<typeof setTimeout>> & { (): number; new (): number; } & {}' but required in type 'typeof setTimeout'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-background-grace.test.ts",
+      "line": 52,
+      "column": 9,
+      "code": 2741,
+      "message": "Property '__promisify__' is missing in type 'MockInstance<(next: any) => ReturnType<typeof setTimeout>> & { (next: any): number; new (next: any): number; } & {}' but required in type 'typeof setTimeout'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-background-lifecycle.test.ts",
+      "line": 155,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-direct-upgrade.test.ts",
+      "line": 110,
+      "column": 26,
+      "code": 2339,
+      "message": "Property 'mock' does not exist on type '(method: string, params?: unknown, options?: SendRequestOptions | undefined) => Promise<RpcResponse>'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-outage-escalation.test.ts",
+      "line": 28,
+      "column": 44,
+      "code": 2322,
+      "message": "Type 'number' is not assignable to type 'null'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-pairing-recovery.test.ts",
+      "line": 134,
+      "column": 44,
+      "code": 2345,
+      "message": "Argument of type '{ loadJournal: Mock<() => Promise<{ metadata: { winner: \"relay\" | \"direct\"; authorizationMode: \"relay-basis\" | \"authenticated-direct\"; v: 1; journalId: string; offerFingerprint: string; host: { id: string; name: string; endpoint: string; publicKeyB64: string; lastConnected: number; }; relay: { ...; }; installReqId: ...' is not assignable to parameter of type 'Partial<RecoveryDependencies>'.\n  Types of property 'connectRelay' are incompatible.\n    Type 'Mock<Procedure | Constructable>' is not assignable to type '((args: { relay: { v: 1; directorUrl: string; cellUrl: string; assignmentEpoch: number; relayHostId: string; inviteToken: string; inviteExpiresAt: number; e2eeFraming: 2; }; deviceToken: string; desktopPublicKeyB64: string; ... 4 more ...; onLog?: ConnectionLogSink | undefined; }) => PairingCandidateClient) | undefi...'.\n      Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '((args: { relay: { v: 1; directorUrl: string; cellUrl: string; assignmentEpoch: number; relayHostId: string; inviteToken: string; inviteExpiresAt: number; e2eeFraming: 2; }; deviceToken: string; desktopPublicKeyB64: string; ... 4 more ...; onLog?: ConnectionLogSink | undefined; }) => PairingCandidateClient) | undefi...'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-pairing-recovery.test.ts",
+      "line": 185,
+      "column": 44,
+      "code": 2345,
+      "message": "Argument of type '{ loadJournal: Mock<() => Promise<{ metadata: { winner: \"relay\" | \"direct\"; authorizationMode: \"relay-basis\" | \"authenticated-direct\"; v: 1; journalId: string; offerFingerprint: string; host: { id: string; name: string; endpoint: string; publicKeyB64: string; lastConnected: number; }; relay: { ...; }; installReqId: ...' is not assignable to parameter of type 'Partial<RecoveryDependencies>'.\n  Types of property 'connectRelay' are incompatible.\n    Type 'Mock<Procedure | Constructable>' is not assignable to type '((args: { relay: { v: 1; directorUrl: string; cellUrl: string; assignmentEpoch: number; relayHostId: string; inviteToken: string; inviteExpiresAt: number; e2eeFraming: 2; }; deviceToken: string; desktopPublicKeyB64: string; ... 4 more ...; onLog?: ConnectionLogSink | undefined; }) => PairingCandidateClient) | undefi...'.\n      Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '((args: { relay: { v: 1; directorUrl: string; cellUrl: string; assignmentEpoch: number; relayHostId: string; inviteToken: string; inviteExpiresAt: number; e2eeFraming: 2; }; deviceToken: string; desktopPublicKeyB64: string; ... 4 more ...; onLog?: ConnectionLogSink | undefined; }) => PairingCandidateClient) | undefi...'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-pairing-recovery.test.ts",
+      "line": 217,
+      "column": 44,
+      "code": 2345,
+      "message": "Argument of type '{ loadJournal: Mock<() => Promise<{ metadata: { winner: \"relay\" | \"direct\"; authorizationMode: \"relay-basis\" | \"authenticated-direct\"; v: 1; journalId: string; offerFingerprint: string; host: { id: string; name: string; endpoint: string; publicKeyB64: string; lastConnected: number; }; relay: { ...; }; installReqId: ...' is not assignable to parameter of type 'Partial<RecoveryDependencies>'.\n  Types of property 'connectRelay' are incompatible.\n    Type 'Mock<Procedure | Constructable>' is not assignable to type '((args: { relay: { v: 1; directorUrl: string; cellUrl: string; assignmentEpoch: number; relayHostId: string; inviteToken: string; inviteExpiresAt: number; e2eeFraming: 2; }; deviceToken: string; desktopPublicKeyB64: string; ... 4 more ...; onLog?: ConnectionLogSink | undefined; }) => PairingCandidateClient) | undefi...'.\n      Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '((args: { relay: { v: 1; directorUrl: string; cellUrl: string; assignmentEpoch: number; relayHostId: string; inviteToken: string; inviteExpiresAt: number; e2eeFraming: 2; }; deviceToken: string; desktopPublicKeyB64: string; ... 4 more ...; onLog?: ConnectionLogSink | undefined; }) => PairingCandidateClient) | undefi...'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-pairing-recovery.test.ts",
+      "line": 218,
+      "column": 63,
+      "code": 2493,
+      "message": "Tuple type '[]' of length '0' has no element at index '0'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-pairing-recovery.test.ts",
+      "line": 219,
+      "column": 12,
+      "code": 18048,
+      "message": "'written' is possibly 'undefined'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-pairing-recovery.test.ts",
+      "line": 235,
+      "column": 44,
+      "code": 2345,
+      "message": "Argument of type '{ now: () => number; loadJournal: Mock<() => Promise<{ metadata: { winner: \"relay\" | \"direct\"; authorizationMode: \"relay-basis\" | \"authenticated-direct\"; v: 1; journalId: string; offerFingerprint: string; ... 4 more ...; pendingResumeTokenHash: string; }; secrets: MobileRelayPairingJournalSecrets; }>>; ... 8 more .....' is not assignable to parameter of type 'Partial<RecoveryDependencies>'.\n  Types of property 'connectRelay' are incompatible.\n    Type 'Mock<Procedure | Constructable>' is not assignable to type '((args: { relay: { v: 1; directorUrl: string; cellUrl: string; assignmentEpoch: number; relayHostId: string; inviteToken: string; inviteExpiresAt: number; e2eeFraming: 2; }; deviceToken: string; desktopPublicKeyB64: string; ... 4 more ...; onLog?: ConnectionLogSink | undefined; }) => PairingCandidateClient) | undefi...'.\n      Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '((args: { relay: { v: 1; directorUrl: string; cellUrl: string; assignmentEpoch: number; relayHostId: string; inviteToken: string; inviteExpiresAt: number; e2eeFraming: 2; }; deviceToken: string; desktopPublicKeyB64: string; ... 4 more ...; onLog?: ConnectionLogSink | undefined; }) => PairingCandidateClient) | undefi...'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-pairing-recovery.test.ts",
+      "line": 249,
+      "column": 44,
+      "code": 2345,
+      "message": "Argument of type '{ now: () => number; loadJournal: Mock<() => Promise<{ metadata: { winner: \"relay\" | \"direct\"; authorizationMode: \"relay-basis\" | \"authenticated-direct\"; v: 1; journalId: string; offerFingerprint: string; ... 4 more ...; pendingResumeTokenHash: string; }; secrets: MobileRelayPairingJournalSecrets; }>>; ... 8 more .....' is not assignable to parameter of type 'Partial<RecoveryDependencies>'.\n  Types of property 'connectRelay' are incompatible.\n    Type 'Mock<Procedure | Constructable>' is not assignable to type '((args: { relay: { v: 1; directorUrl: string; cellUrl: string; assignmentEpoch: number; relayHostId: string; inviteToken: string; inviteExpiresAt: number; e2eeFraming: 2; }; deviceToken: string; desktopPublicKeyB64: string; ... 4 more ...; onLog?: ConnectionLogSink | undefined; }) => PairingCandidateClient) | undefi...'.\n      Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '((args: { relay: { v: 1; directorUrl: string; cellUrl: string; assignmentEpoch: number; relayHostId: string; inviteToken: string; inviteExpiresAt: number; e2eeFraming: 2; }; deviceToken: string; desktopPublicKeyB64: string; ... 4 more ...; onLog?: ConnectionLogSink | undefined; }) => PairingCandidateClient) | undefi...'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-pairing-recovery.test.ts",
+      "line": 269,
+      "column": 44,
+      "code": 2345,
+      "message": "Argument of type '{ now: () => number; writeCredentialBundle: Mock<() => Promise<never>>; loadJournal: Mock<() => Promise<{ metadata: { winner: \"relay\" | \"direct\"; authorizationMode: \"relay-basis\" | \"authenticated-direct\"; ... 7 more ...; pendingResumeTokenHash: string; }; secrets: MobileRelayPairingJournalSecrets; }>>; ... 7 more .....' is not assignable to parameter of type 'Partial<RecoveryDependencies>'.\n  Types of property 'connectRelay' are incompatible.\n    Type 'Mock<Procedure | Constructable>' is not assignable to type '((args: { relay: { v: 1; directorUrl: string; cellUrl: string; assignmentEpoch: number; relayHostId: string; inviteToken: string; inviteExpiresAt: number; e2eeFraming: 2; }; deviceToken: string; desktopPublicKeyB64: string; ... 4 more ...; onLog?: ConnectionLogSink | undefined; }) => PairingCandidateClient) | undefi...'.\n      Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '((args: { relay: { v: 1; directorUrl: string; cellUrl: string; assignmentEpoch: number; relayHostId: string; inviteToken: string; inviteExpiresAt: number; e2eeFraming: 2; }; deviceToken: string; desktopPublicKeyB64: string; ... 4 more ...; onLog?: ConnectionLogSink | undefined; }) => PairingCandidateClient) | undefi...'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-pairing-recovery.test.ts",
+      "line": 39,
+      "column": 3,
+      "code": 2502,
+      "message": "'journal' is referenced directly or indirectly in its own type annotation."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-pairing-recovery.test.ts",
+      "line": 52,
+      "column": 3,
+      "code": 2502,
+      "message": "'journal' is referenced directly or indirectly in its own type annotation."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-pairing-rejection-escalation.test.ts",
+      "line": 47,
+      "column": 44,
+      "code": 2322,
+      "message": "Type 'number' is not assignable to type 'null'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-physical-client.test.ts",
+      "line": 105,
+      "column": 32,
+      "code": 2352,
+      "message": "Conversion of type 'undefined' to type 'string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-physical-client.test.ts",
+      "line": 105,
+      "column": 62,
+      "code": 2493,
+      "message": "Tuple type '[]' of length '0' has no element at index '0'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-reconnect-controller.test.ts",
+      "line": 321,
+      "column": 21,
+      "code": 2352,
+      "message": "Conversion of type '{ getFailure: () => RelayOuterError; }' to type 'MobileRelayRpcSession' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.\n  Type '{ getFailure: () => RelayOuterError; }' is missing the following properties from type 'RpcClient': sendRequest, subscribe, updateTerminalSubscriptionViewport, getState, and 5 more."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-resume-director.test.ts",
+      "line": 31,
+      "column": 12,
+      "code": 2493,
+      "message": "Tuple type '[]' of length '0' has no element at index '0'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-resume-director.test.ts",
+      "line": 31,
+      "column": 17,
+      "code": 2493,
+      "message": "Tuple type '[]' of length '0' has no element at index '1'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-resume-director.test.ts",
+      "line": 35,
+      "column": 29,
+      "code": 2339,
+      "message": "Property 'body' does not exist on type 'never'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts",
+      "line": 82,
+      "column": 29,
+      "code": 2352,
+      "message": "Conversion of type 'undefined' to type 'string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts",
+      "line": 82,
+      "column": 7,
+      "code": 2493,
+      "message": "Tuple type '[]' of length '0' has no element at index '0'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-rpc-session.test.ts",
+      "line": 148,
+      "column": 40,
+      "code": 2352,
+      "message": "Conversion of type 'undefined' to type 'string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-rpc-session.test.ts",
+      "line": 148,
+      "column": 70,
+      "code": 2493,
+      "message": "Tuple type '[]' of length '0' has no element at index '0'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-rpc-session.test.ts",
+      "line": 177,
+      "column": 39,
+      "code": 2352,
+      "message": "Conversion of type 'undefined' to type 'string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-rpc-session.test.ts",
+      "line": 177,
+      "column": 69,
+      "code": 2493,
+      "message": "Tuple type '[]' of length '0' has no element at index '0'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-rpc-session.test.ts",
+      "line": 71,
+      "column": 30,
+      "code": 2352,
+      "message": "Conversion of type 'undefined' to type 'string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-rpc-session.test.ts",
+      "line": 71,
+      "column": 60,
+      "code": 2493,
+      "message": "Tuple type '[]' of length '0' has no element at index '0'."
+    },
+    {
+      "file": "mobile/src/transport/mobile-relay-runtime-failover.test.ts",
+      "line": 274,
+      "column": 30,
+      "code": 2345,
+      "message": "Argument of type 'null' is not assignable to parameter of type '{ v: 1; hostId: string; deviceToken: string; current: { token: string; hash: string; version: number; expiresAt: number; }; grace?: { token: string; hash: string; version: number; expiresAt: number; } | undefined; pending?: { ...; } | undefined; invite?: { ...; } | undefined; }'."
+    },
+    {
+      "file": "mobile/src/transport/pairing-relay-candidate.test.ts",
+      "line": 325,
+      "column": 35,
+      "code": 2493,
+      "message": "Tuple type '[]' of length '0' has no element at index '0'."
+    },
+    {
+      "file": "mobile/src/transport/pre-profile-pairing-coordinator.test.ts",
+      "line": 359,
+      "column": 42,
+      "code": 2345,
+      "message": "Argument of type '(connectArgs: any) => RpcClient' is not assignable to parameter of type '() => RpcClient'.\n  Target signature provides too few arguments. Expected 1 or more, but got 0."
+    },
+    {
+      "file": "mobile/src/transport/pre-profile-pairing-coordinator.test.ts",
+      "line": 359,
+      "column": 43,
+      "code": 7006,
+      "message": "Parameter 'connectArgs' implicitly has an 'any' type."
+    },
+    {
+      "file": "mobile/src/transport/pre-profile-pairing-coordinator.test.ts",
+      "line": 412,
+      "column": 42,
+      "code": 2345,
+      "message": "Argument of type '(connectArgs: any) => RpcClient' is not assignable to parameter of type '() => RpcClient'.\n  Target signature provides too few arguments. Expected 1 or more, but got 0."
+    },
+    {
+      "file": "mobile/src/transport/pre-profile-pairing-coordinator.test.ts",
+      "line": 412,
+      "column": 43,
+      "code": 7006,
+      "message": "Parameter 'connectArgs' implicitly has an 'any' type."
+    },
+    {
+      "file": "mobile/src/transport/rpc-client-synthesized-close-diagnostics.test.ts",
+      "line": 132,
+      "column": 8,
+      "code": 7006,
+      "message": "Parameter 'call' implicitly has an 'any' type."
+    },
+    {
+      "file": "mobile/src/transport/rpc-client-synthesized-close-diagnostics.test.ts",
+      "line": 141,
+      "column": 50,
+      "code": 7006,
+      "message": "Parameter 'call' implicitly has an 'any' type."
+    },
+    {
+      "file": "mobile/src/transport/rpc-client-synthesized-close-diagnostics.test.ts",
+      "line": 75,
+      "column": 14,
+      "code": 7006,
+      "message": "Parameter 'call' implicitly has an 'any' type."
+    },
+    {
+      "file": "mobile/src/transport/rpc-client-synthesized-close-diagnostics.test.ts",
+      "line": 76,
+      "column": 11,
+      "code": 7006,
+      "message": "Parameter 'call' implicitly has an 'any' type."
+    },
+    {
+      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
+      "line": 104,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
+      "line": 106,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
+      "line": 118,
+      "column": 18,
+      "code": 7006,
+      "message": "Parameter 'callback' implicitly has an 'any' type."
+    },
+    {
+      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
+      "line": 118,
+      "column": 7,
+      "code": 2741,
+      "message": "Property '__promisify__' is missing in type '(callback: any) => ReturnType<typeof setTimeout>' but required in type 'typeof setTimeout'."
+    },
+    {
+      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
+      "line": 66,
+      "column": 7,
+      "code": 2322,
+      "message": "Type 'Mock<typeof setTimeout>' is not assignable to type 'typeof setTimeout | undefined'.\n  Type 'Mock<typeof setTimeout>' is not assignable to type 'typeof setTimeout'.\n    Types of parameters 'handler' and 'handler' are incompatible.\n      Type 'TimerHandler' is not assignable to type '(...args: any[]) => void'.\n        Type 'string' is not assignable to type '(...args: any[]) => void'."
+    },
+    {
+      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
+      "line": 94,
+      "column": 18,
+      "code": 7006,
+      "message": "Parameter 'next' implicitly has an 'any' type."
+    },
+    {
+      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
+      "line": 94,
+      "column": 7,
+      "code": 2741,
+      "message": "Property '__promisify__' is missing in type '(next: any) => ReturnType<typeof setTimeout>' but required in type 'typeof setTimeout'."
+    },
+    {
+      "file": "mobile/src/transport/runtime-capability-probe.test.ts",
+      "line": 181,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/settings-host-client-lifecycle.test.ts",
+      "line": 273,
+      "column": 15,
+      "code": 18047,
+      "message": "'renderer' is possibly 'null'."
+    },
+    {
+      "file": "mobile/src/transport/settings-host-client-lifecycle.test.ts",
+      "line": 365,
+      "column": 15,
+      "code": 18047,
+      "message": "'renderer' is possibly 'null'."
+    },
+    {
+      "file": "mobile/src/worktree/agent-row-display.test.ts",
+      "line": 12,
+      "column": 3,
+      "code": 2322,
+      "message": "Type '{ paneKey: string; parentPaneKey: string | null; state: AgentStatusState; workingMode?: AgentWorkingMode | undefined; ... 10 more ...; restoredUnconfirmed?: boolean | undefined; }' is not assignable to type 'RuntimeWorktreeAgentRow'.\n  Types of property 'taskTitle' are incompatible.\n    Type 'string | null | undefined' is not assignable to type 'string | null'.\n      Type 'undefined' is not assignable to type 'string | null'."
+    },
+    {
+      "file": "mobile/src/worktree/agent-row-lineage.test.ts",
+      "line": 10,
+      "column": 3,
+      "code": 2322,
+      "message": "Type '{ paneKey: string; parentPaneKey: string | null; state: AgentStatusState; workingMode?: AgentWorkingMode | undefined; ... 10 more ...; restoredUnconfirmed?: boolean | undefined; }' is not assignable to type 'RuntimeWorktreeAgentRow'.\n  Types of property 'taskTitle' are incompatible.\n    Type 'string | null | undefined' is not assignable to type 'string | null'.\n      Type 'undefined' is not assignable to type 'string | null'."
+    },
+    {
+      "file": "mobile/src/worktree/host-worktree-refresh.test.ts",
+      "line": 51,
+      "column": 47,
+      "code": 2322,
+      "message": "Type 'Mock<Procedure | Constructable>' is not assignable to type '(options?: WorktreeRefreshOptions | undefined) => Promise<void>'.\n  Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '(options?: WorktreeRefreshOptions | undefined) => Promise<void>'.\n    Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(options?: WorktreeRefreshOptions | undefined): Promise<void>'."
+    },
+    {
+      "file": "mobile/src/worktree/host-worktree-refresh.test.ts",
+      "line": 51,
+      "column": 63,
+      "code": 2322,
+      "message": "Type 'Mock<Procedure | Constructable>' is not assignable to type '(options?: RepoRefreshOptions | undefined) => Promise<void>'.\n  Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' is not assignable to type '(options?: RepoRefreshOptions | undefined) => Promise<void>'.\n    Type 'MockInstance<Procedure | Constructable> & (new (...args: any[]) => any) & {}' provides no match for the signature '(options?: RepoRefreshOptions | undefined): Promise<void>'."
+    },
+    {
+      "file": "mobile/src/worktree/workspace-view-settings.test.ts",
+      "line": 12,
+      "column": 7,
+      "code": 2741,
+      "message": "Property 'alwaysShowDefaultBranch' is missing in type '{ groupMode: \"repo\"; sortMode: \"recent\"; hideSleeping: false; hideDefaultBranch: false; filterRepoIds: never[]; collapsedGroups: never[]; workspaceStatuses: readonly [{ readonly id: \"completed\"; readonly label: \"Done\"; readonly color: \"conductor-done\"; readonly icon: \"conductor-done\"; }, { ...; }, { ...; }, { ...; }...' but required in type 'MobileViewState'."
+    },
+    {
+      "file": "mobile/src/worktree/worktree-list-completeness.test.ts",
+      "line": 39,
+      "column": 7,
+      "code": 2741,
+      "message": "Property 'alwaysShowDefaultBranch' is missing in type '{ groupMode: \"repo\"; sortMode: \"recent\"; hideSleeping: false; hideDefaultBranch: false; filterRepoIds: never[]; collapsedGroups: never[]; workspaceStatuses: readonly [{ readonly id: \"completed\"; readonly label: \"Done\"; readonly color: \"conductor-done\"; readonly icon: \"conductor-done\"; }, { ...; }, { ...; }, { ...; }...' but required in type 'MobileViewState'."
+    },
+    {
+      "file": "mobile/src/worktree/worktree-list-snapshot.test.ts",
+      "line": 8,
+      "column": 3,
+      "code": 2322,
+      "message": "Type '{ paneKey: string; parentPaneKey: string | null; state: AgentStatusState; workingMode?: AgentWorkingMode | undefined; ... 10 more ...; restoredUnconfirmed?: boolean | undefined; }' is not assignable to type 'RuntimeWorktreeAgentRow'.\n  Types of property 'taskTitle' are incompatible.\n    Type 'string | null | undefined' is not assignable to type 'string | null'.\n      Type 'undefined' is not assignable to type 'string | null'."
+    }
+  ]
+}

--- a/mobile/typecheck-test-diagnostics.json
+++ b/mobile/typecheck-test-diagnostics.json
@@ -443,6 +443,20 @@
       "message": "Argument of type '\"Pressable\"' is not assignable to parameter of type 'ElementType'."
     },
     {
+      "file": "mobile/src/diagnostics/connection-diagnostics-submission.test.ts",
+      "line": 12,
+      "column": 7,
+      "code": 2345,
+      "message": "Argument of type 'Mock<{ (input: URL | RequestInfo, init?: RequestInit | undefined): Promise<Response>; (input: string | URL | Request, init?: RequestInit | undefined): Promise<...>; (input: RequestInfo, init?: RequestInit | undefined): Promise<...>; }>' is not assignable to parameter of type '{ (input: URL | RequestInfo, init?: RequestInit | undefined): Promise<Response>; (input: string | URL | Request, init?: RequestInit | undefined): Promise<...>; (input: RequestInfo, init?: RequestInit | undefined): Promise<...>; } | undefined'.\n  Type 'Mock<{ (input: URL | RequestInfo, init?: RequestInit | undefined): Promise<Response>; (input: string | URL | Request, init?: RequestInit | undefined): Promise<...>; (input: RequestInfo, init?: RequestInit | undefined): Promise<...>; }>' is not assignable to type '{ (input: URL | RequestInfo, init?: RequestInit | undefined): Promise<Response>; (input: string | URL | Request, init?: RequestInit | undefined): Promise<...>; (input: RequestInfo, init?: RequestInit | undefined): Promise<...>; }'.\n    Types of parameters 'input' and 'input' are incompatible.\n      Type 'URL | RequestInfo' is not assignable to type 'RequestInfo'.\n        Type 'URL' is not assignable to type 'RequestInfo'.\n          Type 'URL' is missing the following properties from type 'Request': cache, credentials, destination, headers, and 18 more."
+    },
+    {
+      "file": "mobile/src/diagnostics/connection-diagnostics-submission.test.ts",
+      "line": 31,
+      "column": 9,
+      "code": 2345,
+      "message": "Argument of type 'Mock<{ (input: URL | RequestInfo, init?: RequestInit | undefined): Promise<Response>; (input: string | URL | Request, init?: RequestInit | undefined): Promise<...>; (input: RequestInfo, init?: RequestInit | undefined): Promise<...>; }>' is not assignable to parameter of type '{ (input: URL | RequestInfo, init?: RequestInit | undefined): Promise<Response>; (input: string | URL | Request, init?: RequestInit | undefined): Promise<...>; (input: RequestInfo, init?: RequestInit | undefined): Promise<...>; } | undefined'.\n  Type 'Mock<{ (input: URL | RequestInfo, init?: RequestInit | undefined): Promise<Response>; (input: string | URL | Request, init?: RequestInit | undefined): Promise<...>; (input: RequestInfo, init?: RequestInit | undefined): Promise<...>; }>' is not assignable to type '{ (input: URL | RequestInfo, init?: RequestInit | undefined): Promise<Response>; (input: string | URL | Request, init?: RequestInit | undefined): Promise<...>; (input: RequestInfo, init?: RequestInit | undefined): Promise<...>; }'.\n    Types of parameters 'input' and 'input' are incompatible.\n      Type 'URL | RequestInfo' is not assignable to type 'RequestInfo'.\n        Type 'URL' is not assignable to type 'RequestInfo'.\n          Type 'URL' is missing the following properties from type 'Request': cache, credentials, destination, headers, and 18 more."
+    },
+    {
       "file": "mobile/src/dictation/mobile-dictation-setup.test.ts",
       "line": 105,
       "column": 11,
@@ -2068,42 +2082,42 @@
     },
     {
       "file": "mobile/src/transport/host-status-gates.test.ts",
-      "line": 104,
+      "line": 114,
       "column": 17,
       "code": 2339,
       "message": "Property 'unmount' does not exist on type 'never'."
     },
     {
       "file": "mobile/src/transport/host-status-gates.test.ts",
-      "line": 134,
+      "line": 144,
       "column": 21,
       "code": 2339,
       "message": "Property 'floatingWorkspaceEnabled' does not exist on type 'never'."
     },
     {
       "file": "mobile/src/transport/host-status-gates.test.ts",
-      "line": 168,
+      "line": 178,
       "column": 17,
       "code": 2339,
       "message": "Property 'unmount' does not exist on type 'never'."
     },
     {
       "file": "mobile/src/transport/host-status-gates.test.ts",
-      "line": 195,
+      "line": 205,
       "column": 21,
       "code": 2339,
       "message": "Property 'hostCapabilities' does not exist on type 'never'."
     },
     {
       "file": "mobile/src/transport/host-status-gates.test.ts",
-      "line": 202,
+      "line": 212,
       "column": 17,
       "code": 2339,
       "message": "Property 'unmount' does not exist on type 'never'."
     },
     {
       "file": "mobile/src/transport/host-status-gates.test.ts",
-      "line": 71,
+      "line": 78,
       "column": 17,
       "code": 2339,
       "message": "Property 'unmount' does not exist on type 'never'."
@@ -2285,14 +2299,14 @@
     },
     {
       "file": "mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts",
-      "line": 82,
+      "line": 84,
       "column": 29,
       "code": 2352,
       "message": "Conversion of type 'undefined' to type 'string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."
     },
     {
       "file": "mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts",
-      "line": 82,
+      "line": 84,
       "column": 7,
       "code": 2493,
       "message": "Tuple type '[]' of length '0' has no element at index '0'."
@@ -2411,52 +2425,52 @@
     },
     {
       "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
-      "line": 104,
-      "column": 5,
-      "code": 2349,
-      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
-    },
-    {
-      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
-      "line": 106,
-      "column": 5,
-      "code": 2349,
-      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
-    },
-    {
-      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
-      "line": 118,
-      "column": 18,
-      "code": 7006,
-      "message": "Parameter 'callback' implicitly has an 'any' type."
-    },
-    {
-      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
-      "line": 118,
-      "column": 7,
-      "code": 2741,
-      "message": "Property '__promisify__' is missing in type '(callback: any) => ReturnType<typeof setTimeout>' but required in type 'typeof setTimeout'."
-    },
-    {
-      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
-      "line": 66,
-      "column": 7,
-      "code": 2322,
-      "message": "Type 'Mock<typeof setTimeout>' is not assignable to type 'typeof setTimeout | undefined'.\n  Type 'Mock<typeof setTimeout>' is not assignable to type 'typeof setTimeout'.\n    Types of parameters 'handler' and 'handler' are incompatible.\n      Type 'TimerHandler' is not assignable to type '(...args: any[]) => void'.\n        Type 'string' is not assignable to type '(...args: any[]) => void'."
-    },
-    {
-      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
-      "line": 94,
+      "line": 125,
       "column": 18,
       "code": 7006,
       "message": "Parameter 'next' implicitly has an 'any' type."
     },
     {
       "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
-      "line": 94,
+      "line": 125,
       "column": 7,
       "code": 2741,
       "message": "Property '__promisify__' is missing in type '(next: any) => ReturnType<typeof setTimeout>' but required in type 'typeof setTimeout'."
+    },
+    {
+      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
+      "line": 135,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
+      "line": 137,
+      "column": 5,
+      "code": 2349,
+      "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
+      "line": 149,
+      "column": 18,
+      "code": 7006,
+      "message": "Parameter 'callback' implicitly has an 'any' type."
+    },
+    {
+      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
+      "line": 149,
+      "column": 7,
+      "code": 2741,
+      "message": "Property '__promisify__' is missing in type '(callback: any) => ReturnType<typeof setTimeout>' but required in type 'typeof setTimeout'."
+    },
+    {
+      "file": "mobile/src/transport/rpc-session-liveness-watchdog.test.ts",
+      "line": 97,
+      "column": 7,
+      "code": 2322,
+      "message": "Type 'Mock<typeof setTimeout>' is not assignable to type 'typeof setTimeout | undefined'.\n  Type 'Mock<typeof setTimeout>' is not assignable to type 'typeof setTimeout'.\n    Types of parameters 'handler' and 'handler' are incompatible.\n      Type 'TimerHandler' is not assignable to type '(...args: any[]) => void'.\n        Type 'string' is not assignable to type '(...args: any[]) => void'."
     },
     {
       "file": "mobile/src/transport/runtime-capability-probe.test.ts",
@@ -2464,6 +2478,20 @@
       "column": 5,
       "code": 2349,
       "message": "This expression is not callable.\n  Type 'never' has no call signatures."
+    },
+    {
+      "file": "mobile/src/transport/settings-host-client-lifecycle.test.ts",
+      "line": 11,
+      "column": 8,
+      "code": 2724,
+      "message": "'\"./client-context\"' has no exported member named 'RpcClientContextValue'. Did you mean 'useRpcClientContext'?"
+    },
+    {
+      "file": "mobile/src/transport/settings-host-client-lifecycle.test.ts",
+      "line": 185,
+      "column": 13,
+      "code": 7031,
+      "message": "Binding element 'hostId' implicitly has an 'any' type."
     },
     {
       "file": "mobile/src/transport/settings-host-client-lifecycle.test.ts",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typecheck:node": "tsc --noEmit -p config/tsconfig.node.json",
     "typecheck:cli": "tsc --noEmit -p config/tsconfig.tc.cli.json",
     "typecheck:web": "tsc --noEmit -p config/tsconfig.tc.web.json",
-    "typecheck:e2e": "tsc --noEmit -p config/tsconfig.e2e.json",
+    "typecheck:e2e": "node config/scripts/typecheck-diagnostic-baseline.mjs --project config/tsconfig.e2e.json --baseline config/typecheck-e2e-diagnostics.json",
     "typecheck": "node config/scripts/run-typecheck-projects-in-parallel.mjs",
     "typecheck:tsc:node": "tsc --noEmit -p config/tsconfig.node.json --composite false",
     "typecheck:tsc:cli": "tsc --noEmit -p config/tsconfig.cli.json --composite false",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "typecheck:cli": "tsc --noEmit -p config/tsconfig.tc.cli.json",
     "typecheck:web": "tsc --noEmit -p config/tsconfig.tc.web.json",
     "typecheck:e2e": "node config/scripts/typecheck-diagnostic-baseline.mjs --project config/tsconfig.e2e.json --baseline config/typecheck-e2e-diagnostics.json",
+    "typecheck:e2e:write": "node config/scripts/typecheck-diagnostic-baseline.mjs --project config/tsconfig.e2e.json --baseline config/typecheck-e2e-diagnostics.json --write",
     "typecheck": "node config/scripts/run-typecheck-projects-in-parallel.mjs",
     "typecheck:tsc:node": "tsc --noEmit -p config/tsconfig.node.json --composite false",
     "typecheck:tsc:cli": "tsc --noEmit -p config/tsconfig.cli.json --composite false",

--- a/src/renderer/src/components/settings/GitPane.branch-prefix-feedback.test.tsx
+++ b/src/renderer/src/components/settings/GitPane.branch-prefix-feedback.test.tsx
@@ -37,7 +37,7 @@ function gitUsernamePrefixSettings(): GlobalSettings {
   }
 }
 
-describe('GitPane branch prefix feedback', () => {
+describe('GitPane branch-prefix feedback', () => {
   it('previews the resulting branch name and drops a redundant trailing slash', () => {
     const html = renderGitPane(customPrefixSettings('team/'))
     expect(html).toContain('team/feature')

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/use-scroll-to-top.pointer-drag.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/use-scroll-to-top.pointer-drag.test.tsx
@@ -35,7 +35,7 @@ afterEach(() => {
   document.body.replaceChildren()
 })
 
-describe('useWorktreeListScrollToTop', () => {
+describe('useWorktreeListScrollToTop pointer drag', () => {
   it('ignores fast programmatic scrolling', () => {
     const element = createScroller()
     let now = 0


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​434 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​41 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​393 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4364 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4344 |

<!-- /orca-pr-loc -->

## ELI5

Orca's type checker is what catches "you passed a number where a string was expected" before the code
ever runs. It turned out that whole areas of the repo were not being checked at all — test files,
build tooling, and the mobile app's tests — so a broken change in those places sailed through every
gate. One merged change failed its typecheck *after* it was already in. Worse, a few files had names
that collided with other files, and the type checker silently skipped them entirely.

This wires those areas into the check, renames the colliding files, and fixes the errors that
suddenly became visible. Existing problems that can't all be fixed at once are recorded exactly, so
new ones fail immediately and fixed ones must be struck off the list.

## User-facing before / after

| | Before | After |
|---|---|---|
| Anything you do in the app | — | **No change.** Nothing in the shipped product changes |
| A type error in a test, in build tooling, or in a mobile test | Passed every gate and could reach `main` | Fails the type check |
| A file whose name collided with another module | Silently skipped by the type checker, so it was never checked | Renamed, and now checked |
| How long the checks take | — | A cold full type check is about 5s slower and the mobile one about 11s slower; a warm run is unchanged |

## When it bites

Contributors rather than users. The payoff for users is indirect: a class of broken change now stops
at the gate instead of reaching the app.


## Summary

- add tooling and top-level E2E projects to pnpm tc, and include mobile tests in the mobile typecheck
- ratchet the 601 pre-existing E2E/mobile diagnostics exactly by file, location, code, and message so new errors fail and fixed entries must be removed
- rename three colliding test modules that TypeScript previously ignored and fix the 10 newly exposed tooling/mobile errors

## Coverage proof

Before this change, planted TS2322 errors under tests, config/scripts, a root TypeScript file, and mobile test files all passed their applicable typecheck gates. The finalized gate fails on those planted errors and covers all 18,357 TypeScript/TSX files in the root and mobile project census. A planted missing import in AutomationsPage.tsx also fails the existing web project with TS2304; PR #16532 had a failed typecheck after it was already merged, so that incident was gate enforcement rather than project coverage.

## Verification

- pnpm tc
- mobile typecheck with pnpm 10.24.0
- pnpm lint
- pnpm run check:code-quality:changed under Node 24
- focused root tests: 33 passed
- full mobile tests: 3,764 passed, 3 skipped
- oxfmt check on explicit changed paths
- git diff --check

The full root Vitest run encountered unrelated existing resource/timing failures and stalled during worker teardown; no failure involved a changed file.

## Performance

Cold pnpm tc: 14.37s to 19.27s (+4.90s). Warm pnpm tc: 3.30s to 3.28s (-0.02s). Mobile typecheck: approximately 7.4s to 18.22s (+10.8s).

Linear: STA-5695
