### PR TITLE
Lead the dashboard card with its review, its CI, and its ticket

### DIFF
--- a/src/main/ipc/dashboard-payload-primitives.ts
+++ b/src/main/ipc/dashboard-payload-primitives.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared bounds and scalar guards for the dashboard IPC validators.
+ *
+ * These sit in their own module because the snapshot, workspace, review and
+ * file-link validators each need them, and every copy of a trust-boundary
+ * check is a chance for one of them to drift looser than the rest.
+ */
+
+import { DASHBOARD_MAX_LABEL_LENGTH } from '../../shared/dashboard-snapshot'
+
+export const MAX_ID_LENGTH = 4_096
+export const MAX_LABEL_LENGTH = DASHBOARD_MAX_LABEL_LENGTH
+
+export function isBoundedString(
+  value: unknown,
+  maxLength: number,
+  allowEmpty = false
+): value is string {
+  return typeof value === 'string' && value.length <= maxLength && (allowEmpty || value.length > 0)
+}
+
+export function isOptionalBoundedString(value: unknown, maxLength: number): boolean {
+  return value === undefined || isBoundedString(value, maxLength, true)
+}
+
+export function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+/** The pop-out hands these straight to the OS opener, so only http(s) passes. */
+export function isOptionalWebUrl(value: unknown): boolean {
+  if (value === undefined) {
+    return true
+  }
+  if (!isBoundedString(value, MAX_ID_LENGTH)) {
+    return false
+  }
+  try {
+    const protocol = new URL(value).protocol
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}

--- a/src/main/ipc/dashboard-payload-validation.test.ts
+++ b/src/main/ipc/dashboard-payload-validation.test.ts
@@ -579,3 +579,45 @@ describe('dashboard payload validation', () => {
     ).toBe(false)
   })
 })
+
+describe('review and linked-ticket card fields', () => {
+  function withCard(fields: Record<string, unknown>): unknown {
+    return { ...SNAPSHOT, cards: [{ ...SNAPSHOT.cards[0], ...fields }] }
+  }
+
+  it('accepts a review carrying its CI rollup and web URL', () => {
+    expect(
+      isDashboardSnapshot(
+        withCard({
+          review: {
+            number: 42,
+            state: 'open',
+            checksStatus: 'failure',
+            url: 'https://github.test/o/r/pull/42'
+          },
+          linearIssue: { identifier: 'STA-335', url: 'https://linear.app/acme/issue/STA-335' }
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('rejects a link the pop-out would hand to the OS opener', () => {
+    // The badges call shell.openUrl directly, so anything but http(s) is a hole.
+    expect(
+      isDashboardSnapshot(
+        withCard({ review: { number: 42, state: 'open', url: 'javascript:alert(1)' } })
+      )
+    ).toBe(false)
+    expect(
+      isDashboardSnapshot(
+        withCard({ linearIssue: { identifier: 'STA-335', url: 'file:///etc/passwd' } })
+      )
+    ).toBe(false)
+  })
+
+  it('rejects an unknown CI rollup', () => {
+    expect(
+      isDashboardSnapshot(withCard({ review: { number: 42, state: 'open', checksStatus: 'oops' } }))
+    ).toBe(false)
+  })
+})

--- a/src/main/ipc/dashboard-payload-validation.ts
+++ b/src/main/ipc/dashboard-payload-validation.ts
@@ -1,8 +1,7 @@
-import {
-  DASHBOARD_MAX_LABEL_LENGTH,
-  type DashboardRevealAgentArgs,
-  type DashboardSleepWorkspaceArgs,
-  type DashboardSnapshot
+import type {
+  DashboardRevealAgentArgs,
+  DashboardSleepWorkspaceArgs,
+  DashboardSnapshot
 } from '../../shared/dashboard-snapshot'
 import { BoundedMap } from '../../shared/bounded-map'
 import { normalizeExecutionHostId } from '../../shared/execution-host'
@@ -19,6 +18,14 @@ import {
   isDashboardWorkspaceList
 } from './dashboard-workspace-payload-validation'
 import { isDashboardFilterOptions } from './dashboard-filter-payload-validation'
+import {
+  isBoundedString,
+  isFiniteNumber,
+  isOptionalBoundedString,
+  MAX_ID_LENGTH,
+  MAX_LABEL_LENGTH
+} from './dashboard-payload-primitives'
+import { isDashboardLinearIssue, isDashboardReview } from './dashboard-review-payload-validation'
 export { isDashboardSpawnAgentArgs } from './dashboard-agent-launch-validation'
 
 const MAX_DASHBOARD_CARDS = 1_000
@@ -32,13 +39,10 @@ const imageIconValidity = new BoundedMap<string, boolean>({
   maxBytes: MAX_CACHED_ICON_SRC_BYTES,
   sizeOf: (_valid, key) => key.length * 2
 })
-const MAX_ID_LENGTH = 4_096
-const MAX_LABEL_LENGTH = DASHBOARD_MAX_LABEL_LENGTH
 const DASHBOARD_BUCKETS = new Set(['attention', 'working', 'done', 'idle'])
 const DASHBOARD_DOT_STATES = new Set(['working', 'blocked', 'waiting', 'done', 'idle'])
 const DASHBOARD_HOST_KINDS = new Set(['local', 'ssh', 'wsl', 'remote'])
 const DASHBOARD_WORKSPACE_KINDS = new Set(['worktree', 'folder'])
-const DASHBOARD_REVIEW_STATES = new Set(['open', 'closed', 'merged', 'draft'])
 const DASHBOARD_HOST_PLATFORMS = new Set([
   'aix',
   'android',
@@ -54,18 +58,6 @@ const DASHBOARD_HOST_PLATFORMS = new Set([
 ])
 const WINDOWS_SHIFT_ENTER_ENCODINGS = new Set(['alt-enter', 'csi-u'])
 const WINDOWS_INPUT_RECORD_PASTE_NEWLINES = new Set(['alt-enter', 'csi-u'])
-
-function isBoundedString(value: unknown, maxLength: number, allowEmpty = false): value is string {
-  return typeof value === 'string' && value.length <= maxLength && (allowEmpty || value.length > 0)
-}
-
-function isOptionalBoundedString(value: unknown, maxLength: number): boolean {
-  return value === undefined || isBoundedString(value, maxLength, true)
-}
-
-function isFiniteNumber(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value)
-}
 
 export function isDashboardRevealAgentArgs(value: unknown): value is DashboardRevealAgentArgs {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -174,22 +166,6 @@ function isDashboardRepoIcons(value: unknown): boolean {
   )
 }
 
-function isDashboardReview(value: unknown): boolean {
-  if (value === undefined) {
-    return true
-  }
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return false
-  }
-  const review = value as Record<string, unknown>
-  return (
-    isFiniteNumber(review.number) &&
-    review.number > 0 &&
-    typeof review.state === 'string' &&
-    DASHBOARD_REVIEW_STATES.has(review.state)
-  )
-}
-
 function isDashboardSubagents(value: unknown): boolean {
   if (value === undefined) {
     return true
@@ -284,6 +260,7 @@ function isDashboardCard(value: unknown): boolean {
     isOptionalBoundedString(card.workspaceStatusColor, MAX_ID_LENGTH) &&
     (card.hasReview === undefined || typeof card.hasReview === 'boolean') &&
     isDashboardReview(card.review) &&
+    isDashboardLinearIssue(card.linearIssue) &&
     isDashboardSubagents(card.subagents) &&
     isFiniteNumber(card.startedAt) &&
     (card.finishedAt === null || isFiniteNumber(card.finishedAt)) &&

--- a/src/main/ipc/dashboard-review-payload-validation.ts
+++ b/src/main/ipc/dashboard-review-payload-validation.ts
@@ -1,0 +1,42 @@
+/** Validators for the review / linked-ticket corner of a dashboard card. */
+
+import {
+  isBoundedString,
+  isFiniteNumber,
+  isOptionalWebUrl,
+  MAX_LABEL_LENGTH
+} from './dashboard-payload-primitives'
+
+const DASHBOARD_REVIEW_STATES = new Set(['open', 'closed', 'merged', 'draft'])
+const DASHBOARD_CHECK_STATUSES = new Set(['pending', 'success', 'failure', 'neutral'])
+
+export function isDashboardReview(value: unknown): boolean {
+  if (value === undefined) {
+    return true
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const review = value as Record<string, unknown>
+  return (
+    isFiniteNumber(review.number) &&
+    review.number > 0 &&
+    typeof review.state === 'string' &&
+    DASHBOARD_REVIEW_STATES.has(review.state) &&
+    (review.checksStatus === undefined ||
+      (typeof review.checksStatus === 'string' &&
+        DASHBOARD_CHECK_STATUSES.has(review.checksStatus))) &&
+    isOptionalWebUrl(review.url)
+  )
+}
+
+export function isDashboardLinearIssue(value: unknown): boolean {
+  if (value === undefined) {
+    return true
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const issue = value as Record<string, unknown>
+  return isBoundedString(issue.identifier, MAX_LABEL_LENGTH) && isOptionalWebUrl(issue.url)
+}

--- a/src/main/ipc/dashboard-workspace-payload-validation.ts
+++ b/src/main/ipc/dashboard-workspace-payload-validation.ts
@@ -4,11 +4,11 @@ import {
   type DashboardWorkspace
 } from '../../shared/dashboard-snapshot'
 import { normalizeExecutionHostId } from '../../shared/execution-host'
+import { MAX_ID_LENGTH } from './dashboard-payload-primitives'
+import { isDashboardReview } from './dashboard-review-payload-validation'
 
-const MAX_ID_LENGTH = 4_096
 const HOST_KINDS = new Set(['local', 'ssh', 'wsl', 'remote'])
 const WORKSPACE_KINDS = new Set(['worktree', 'folder'])
-const REVIEW_STATES = new Set(['open', 'closed', 'merged', 'draft'])
 
 function isString(value: unknown, maxLength: number, allowEmpty = false): value is string {
   return typeof value === 'string' && value.length <= maxLength && (allowEmpty || value.length > 0)
@@ -16,23 +16,6 @@ function isString(value: unknown, maxLength: number, allowEmpty = false): value 
 
 function isOptionalString(value: unknown, maxLength: number): boolean {
   return value === undefined || isString(value, maxLength, true)
-}
-
-function isReview(value: unknown): boolean {
-  if (value === undefined) {
-    return true
-  }
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return false
-  }
-  const review = value as Record<string, unknown>
-  return (
-    typeof review.number === 'number' &&
-    Number.isFinite(review.number) &&
-    review.number > 0 &&
-    typeof review.state === 'string' &&
-    REVIEW_STATES.has(review.state)
-  )
 }
 
 export function isDashboardWorkspace(value: unknown): value is DashboardWorkspace {
@@ -57,7 +40,7 @@ export function isDashboardWorkspace(value: unknown): value is DashboardWorkspac
     isOptionalString(workspace.workspaceStatusLabel, DASHBOARD_MAX_LABEL_LENGTH) &&
     isOptionalString(workspace.workspaceStatusColor, MAX_ID_LENGTH) &&
     (workspace.hasReview === undefined || typeof workspace.hasReview === 'boolean') &&
-    isReview(workspace.review)
+    isDashboardReview(workspace.review)
   )
 }
 

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
@@ -158,7 +158,7 @@ describe('AgentKanbanCard', () => {
       onOpenTerminal
     })
 
-    fireEvent.click(screen.getByText('#11042'))
+    fireEvent.click(screen.getByText('dashboard-review'))
     expect(onOpenTerminal).toHaveBeenCalledTimes(1)
 
     fireEvent.click(screen.getByRole('button', { name: '1 subagent' }))

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -194,7 +194,13 @@ export const AgentKanbanCard = memo(
           className="flex w-full flex-col gap-1.5 text-left focus-visible:rounded-md focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
         >
           <div
-            className={cn('flex w-full items-center gap-1.5', hasCornerBadges ? 'pe-28' : 'pe-4')}
+            className={cn(
+              'flex w-full items-center gap-1.5',
+              // Why: the corner overlay (review badge + capped-width ticket
+              // badge + gaps + state dot) can reach ~185px at its widest —
+              // pe-28 (112px) let it render under the heading text.
+              hasCornerBadges ? 'pe-48' : 'pe-4'
+            )}
           >
             <span
               className={cn(

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -1,12 +1,6 @@
 import { memo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import {
-  ChevronRight,
-  GitMerge,
-  GitPullRequest,
-  GitPullRequestClosed,
-  GitPullRequestDraft
-} from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
@@ -21,6 +15,7 @@ import {
 import type { RepoIcon } from '../../../../shared/repo-icon'
 import { translate } from '@/i18n/i18n'
 import { DashboardHostBadge } from './DashboardHostBadge'
+import { AgentKanbanCardBadges } from './AgentKanbanCardBadges'
 
 /** Compact "started N ago" (the card is glanceable — coarse units are fine). */
 function formatStartedAgo(startedAt: number, now: number): string {
@@ -103,6 +98,10 @@ function sameCard(a: DashboardCard, b: DashboardCard): boolean {
     a.hasReview === b.hasReview &&
     a.review?.number === b.review?.number &&
     a.review?.state === b.review?.state &&
+    a.review?.checksStatus === b.review?.checksStatus &&
+    a.review?.url === b.review?.url &&
+    a.linearIssue?.identifier === b.linearIssue?.identifier &&
+    a.linearIssue?.url === b.linearIssue?.url &&
     sameSubagents(a.subagents, b.subagents) &&
     a.startedAt === b.startedAt &&
     a.finishedAt === b.finishedAt &&
@@ -110,57 +109,6 @@ function sameCard(a: DashboardCard, b: DashboardCard): boolean {
     a.unseen === b.unseen &&
     a.askSummary === b.askSummary &&
     a.conversationName === b.conversationName
-  )
-}
-
-const REVIEW_PRESENTATION = {
-  open: {
-    icon: GitPullRequest,
-    className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
-  },
-  draft: {
-    icon: GitPullRequestDraft,
-    className: 'border-border bg-muted/60 text-muted-foreground'
-  },
-  merged: {
-    icon: GitMerge,
-    className: 'border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300'
-  },
-  closed: {
-    icon: GitPullRequestClosed,
-    className: 'border-destructive/30 bg-destructive/10 text-destructive'
-  }
-} as const
-
-function ReviewPill({ card }: { card: DashboardCard }): React.JSX.Element | null {
-  if (!card.review) {
-    return null
-  }
-  const presentation = REVIEW_PRESENTATION[card.review.state]
-  const Icon = presentation.icon
-  const title = (() => {
-    switch (card.review.state) {
-      case 'open':
-        return translate('dashboardPopout.card.review.open', 'Open review')
-      case 'draft':
-        return translate('dashboardPopout.card.review.draft', 'Draft review')
-      case 'merged':
-        return translate('dashboardPopout.card.review.merged', 'Merged review')
-      case 'closed':
-        return translate('dashboardPopout.card.review.closed', 'Closed review')
-    }
-  })()
-  return (
-    <span
-      role="img"
-      aria-label={`${title} #${card.review.number}`}
-      className={cn(
-        'inline-flex shrink-0 items-center gap-0.5 rounded-full border px-1 py-px text-[10px] leading-none tabular-nums',
-        presentation.className
-      )}
-    >
-      <Icon className="size-2.5" aria-hidden />#{card.review.number}
-    </span>
   )
 }
 
@@ -214,6 +162,7 @@ export const AgentKanbanCard = memo(
     // the best heading left — and then the footer drops it rather than say it
     // twice.
     const heading = card.conversationName ?? card.worktreeName
+    const hasCornerBadges = Boolean(card.review || card.linearIssue)
     const worktreeInFooter = card.conversationName !== undefined
 
     return (
@@ -223,7 +172,7 @@ export const AgentKanbanCard = memo(
         // paneKey has ':'/'/' which aren't valid in a custom-ident, so slugify.
         style={{ viewTransitionName: `agentcard-${card.paneKey.replace(/[^a-zA-Z0-9]/g, '-')}` }}
         className={cn(
-          'group flex w-full flex-col gap-1.5 rounded-lg border p-2.5 text-left transition-colors',
+          'group relative flex w-full flex-col gap-1.5 rounded-lg border p-2.5 text-left transition-colors',
           needsYou
             ? 'border-agent-question/40 bg-agent-question/[0.06] hover:border-agent-question/60 hover:bg-agent-question/10'
             : isDone
@@ -231,16 +180,22 @@ export const AgentKanbanCard = memo(
               : 'border-border/60 bg-card hover:border-border hover:bg-accent/40'
         )}
       >
+        {/* Why: the corner sits above the open-terminal button because the
+            review and ticket are their own links — a button cannot nest in a
+            button — and the heading reserves room so it truncates, not overlaps. */}
+        <div className="absolute top-2 right-2 z-10 flex items-center gap-1.5">
+          <AgentKanbanCardBadges card={card} />
+          {card.askSummary ? null : <AgentStateDot state={displayState} />}
+        </div>
+
         <button
           type="button"
           onClick={() => onOpenTerminal(card)}
           className="flex w-full flex-col gap-1.5 text-left focus-visible:rounded-md focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
         >
-          <div className="flex w-full items-center gap-1.5">
-            {/* Why: a bare <svg> flex item shrinks with the row. */}
-            <span className="inline-flex shrink-0">
-              <AgentIcon agent={agentTypeToIconAgent(card.agentType)} size={14} />
-            </span>
+          <div
+            className={cn('flex w-full items-center gap-1.5', hasCornerBadges ? 'pe-28' : 'pe-4')}
+          >
             <span
               className={cn(
                 'truncate text-[12.5px]',
@@ -249,7 +204,6 @@ export const AgentKanbanCard = memo(
             >
               {heading}
             </span>
-            {card.askSummary ? null : <AgentStateDot state={displayState} className="ml-auto" />}
           </div>
 
           {card.lastUserMessage || card.lastAgentMessage ? (
@@ -317,15 +271,22 @@ export const AgentKanbanCard = memo(
         <button
           type="button"
           onClick={() => onOpenTerminal(card)}
-          className="flex w-full items-center gap-2 rounded-md text-left text-[11px] text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+          className="flex w-full items-center gap-1.5 rounded-md text-left text-[11px] text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
         >
+          <span className="inline-flex shrink-0 items-center gap-1 text-[10px] text-muted-foreground">
+            {/* Why: a bare <svg> flex item shrinks with the row. */}
+            <span className="inline-flex shrink-0">
+              <AgentIcon agent={agentTypeToIconAgent(card.agentType)} size={11} />
+            </span>
+            {formatAgentTypeLabel(card.agentType)}
+          </span>
           <Tooltip>
             <TooltipTrigger asChild>
               <span
-                className="inline-flex size-[18px] shrink-0 items-center justify-center rounded-[5px] bg-muted-foreground/10 text-muted-foreground transition-colors group-hover:text-foreground"
+                className="inline-flex size-[16px] shrink-0 items-center justify-center rounded-[4px] bg-muted-foreground/10 text-muted-foreground transition-colors group-hover:text-foreground"
                 aria-label={card.repoName}
               >
-                <RepoIconGlyph repoIcon={repoIcon} className="size-3" iconClassName="size-3" />
+                <RepoIconGlyph repoIcon={repoIcon} className="size-2.5" iconClassName="size-2.5" />
               </span>
             </TooltipTrigger>
             <TooltipContent side="top" sideOffset={4}>
@@ -336,10 +297,9 @@ export const AgentKanbanCard = memo(
             hostKind={card.hostKind}
             executionHostId={card.executionHostId}
             hostLabel={card.hostLabel}
-            className="size-[18px] rounded-[5px] bg-muted-foreground/10 transition-colors group-hover:text-foreground"
+            className="size-[16px] rounded-[4px] bg-muted-foreground/10 transition-colors group-hover:text-foreground"
           />
           {worktreeInFooter ? <span className="truncate">{card.worktreeName}</span> : null}
-          <ReviewPill card={card} />
           {displayTimestamp(card) > 0 ? (
             <span className="ml-auto shrink-0 pl-1 tabular-nums">
               {formatStartedAgo(displayTimestamp(card), now)}

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCardBadges.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCardBadges.tsx
@@ -1,0 +1,160 @@
+import { GitMerge, GitPullRequest, GitPullRequestClosed, GitPullRequestDraft } from 'lucide-react'
+import { LinearIcon } from '@/components/icons/LinearIcon'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { DashboardCard } from '../../../../shared/dashboard-snapshot'
+
+const REVIEW_PRESENTATION = {
+  open: {
+    icon: GitPullRequest,
+    className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+  },
+  draft: {
+    icon: GitPullRequestDraft,
+    className: 'border-border bg-muted/60 text-muted-foreground'
+  },
+  merged: {
+    icon: GitMerge,
+    className: 'border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300'
+  },
+  closed: {
+    icon: GitPullRequestClosed,
+    className: 'border-destructive/30 bg-destructive/10 text-destructive'
+  }
+} as const
+
+const CHECKS_PRESENTATION = {
+  pending: { className: 'bg-amber-500 animate-pulse', label: 'CI running' },
+  success: { className: 'bg-emerald-500', label: 'CI passing' },
+  failure: { className: 'bg-destructive', label: 'CI failing' },
+  neutral: { className: 'bg-muted-foreground/50', label: 'CI neutral' }
+} as const
+
+type ReviewState = NonNullable<DashboardCard['review']>['state']
+
+function reviewTitle(state: ReviewState): string {
+  switch (state) {
+    case 'open':
+      return translate('dashboardPopout.card.review.open', 'Open review')
+    case 'draft':
+      return translate('dashboardPopout.card.review.draft', 'Draft review')
+    case 'merged':
+      return translate('dashboardPopout.card.review.merged', 'Merged review')
+    default:
+      return translate('dashboardPopout.card.review.closed', 'Closed review')
+  }
+}
+
+/** The pop-out hosts no browser pane, so external links go to the system browser. */
+function openExternal(url: string): void {
+  void window.api.shell.openUrl(url).catch(() => undefined)
+}
+
+const BADGE_BASE =
+  'inline-flex shrink-0 items-center gap-1 rounded-md border px-1.5 py-0.5 text-[11px] leading-none font-medium tabular-nums'
+
+function ReviewBadge({ card }: { card: DashboardCard }): React.JSX.Element | null {
+  const review = card.review
+  if (!review) {
+    return null
+  }
+  const url = review.url
+  const presentation = REVIEW_PRESENTATION[review.state]
+  const Icon = presentation.icon
+  const checks = review.checksStatus ? CHECKS_PRESENTATION[review.checksStatus] : null
+  const title = reviewTitle(review.state)
+  const label = `${title} #${review.number}${checks ? ` — ${checks.label}` : ''}`
+  const content = (
+    <>
+      <Icon className="size-3" aria-hidden />#{review.number}
+      {checks ? (
+        <span className={cn('size-1.5 rounded-full', checks.className)} aria-hidden />
+      ) : null}
+    </>
+  )
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {url ? (
+          <button
+            type="button"
+            aria-label={label}
+            onClick={(event) => {
+              event.stopPropagation()
+              openExternal(url)
+            }}
+            className={cn(BADGE_BASE, presentation.className, 'hover:brightness-110')}
+          >
+            {content}
+          </button>
+        ) : (
+          <span role="img" aria-label={label} className={cn(BADGE_BASE, presentation.className)}>
+            {content}
+          </span>
+        )}
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function LinearBadge({ card }: { card: DashboardCard }): React.JSX.Element | null {
+  const issue = card.linearIssue
+  if (!issue) {
+    return null
+  }
+  const url = issue.url
+  const content = (
+    <>
+      <LinearIcon className="size-3" aria-hidden />
+      {issue.identifier}
+    </>
+  )
+  const className = cn(BADGE_BASE, 'border-border bg-muted/60 text-muted-foreground')
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {url ? (
+          <button
+            type="button"
+            aria-label={issue.identifier}
+            onClick={(event) => {
+              event.stopPropagation()
+              openExternal(url)
+            }}
+            className={cn(className, 'hover:text-foreground')}
+          >
+            {content}
+          </button>
+        ) : (
+          <span role="img" aria-label={issue.identifier} className={className}>
+            {content}
+          </span>
+        )}
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        {issue.identifier}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+/**
+ * The card's top-right corner: the review and its CI, then the linked ticket.
+ * Lives outside the card's open-terminal button — these are their own links,
+ * and a button cannot nest inside a button.
+ */
+export function AgentKanbanCardBadges({ card }: { card: DashboardCard }): React.JSX.Element | null {
+  if (!card.review && !card.linearIssue) {
+    return null
+  }
+  return (
+    <div className="flex items-center gap-1">
+      <ReviewBadge card={card} />
+      <LinearBadge card={card} />
+    </div>
+  )
+}

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCardBadges.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCardBadges.tsx
@@ -25,13 +25,14 @@ const REVIEW_PRESENTATION = {
 } as const
 
 const CHECKS_PRESENTATION = {
-  pending: { className: 'bg-amber-500 animate-pulse', label: 'CI running' },
-  success: { className: 'bg-emerald-500', label: 'CI passing' },
-  failure: { className: 'bg-destructive', label: 'CI failing' },
-  neutral: { className: 'bg-muted-foreground/50', label: 'CI neutral' }
+  pending: { className: 'bg-amber-500 animate-pulse' },
+  success: { className: 'bg-emerald-500' },
+  failure: { className: 'bg-destructive' },
+  neutral: { className: 'bg-muted-foreground/50' }
 } as const
 
 type ReviewState = NonNullable<DashboardCard['review']>['state']
+type ChecksStatus = NonNullable<DashboardCard['review']>['checksStatus']
 
 function reviewTitle(state: ReviewState): string {
   switch (state) {
@@ -43,6 +44,19 @@ function reviewTitle(state: ReviewState): string {
       return translate('dashboardPopout.card.review.merged', 'Merged review')
     default:
       return translate('dashboardPopout.card.review.closed', 'Closed review')
+  }
+}
+
+function checksLabel(status: NonNullable<ChecksStatus>): string {
+  switch (status) {
+    case 'pending':
+      return translate('dashboardPopout.card.checks.pending', 'CI running')
+    case 'success':
+      return translate('dashboardPopout.card.checks.success', 'CI passing')
+    case 'failure':
+      return translate('dashboardPopout.card.checks.failure', 'CI failing')
+    default:
+      return translate('dashboardPopout.card.checks.neutral', 'CI neutral')
   }
 }
 
@@ -63,8 +77,9 @@ function ReviewBadge({ card }: { card: DashboardCard }): React.JSX.Element | nul
   const presentation = REVIEW_PRESENTATION[review.state]
   const Icon = presentation.icon
   const checks = review.checksStatus ? CHECKS_PRESENTATION[review.checksStatus] : null
+  const checksLabelText = review.checksStatus ? checksLabel(review.checksStatus) : null
   const title = reviewTitle(review.state)
-  const label = `${title} #${review.number}${checks ? ` — ${checks.label}` : ''}`
+  const label = `${title} #${review.number}${checksLabelText ? ` — ${checksLabelText}` : ''}`
   const content = (
     <>
       <Icon className="size-3" aria-hidden />#{review.number}
@@ -110,7 +125,10 @@ function LinearBadge({ card }: { card: DashboardCard }): React.JSX.Element | nul
   const content = (
     <>
       <LinearIcon className="size-3" aria-hidden />
-      {issue.identifier}
+      {/* Why: identifiers are unbounded-length (long team prefixes), unlike the
+          review's numeric PR count — cap so the badge can't blow past the
+          heading's reserved pe-* space. Full text stays in the tooltip. */}
+      <span className="max-w-14 truncate">{issue.identifier}</span>
     </>
   )
   const className = cn(BADGE_BASE, 'border-border bg-muted/60 text-muted-foreground')

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -275,6 +275,7 @@ export function buildDashboardSnapshot(
         workspaceStatusColor: context?.workspaceStatus.color,
         hasReview: context ? context.hasReview || context.review !== undefined : undefined,
         review: context?.review,
+        linearIssue: context?.linearIssue,
         subagents: subagentsByParentPaneKey?.get(row.paneKey),
         lastUserMessage: isTitleDerived ? undefined : nonEmpty(row.entry.prompt),
         lastAgentMessage: isTitleDerived ? undefined : nonEmpty(row.entry.lastAssistantMessage),

--- a/src/renderer/src/components/dashboard/dashboard-card-context.test.ts
+++ b/src/renderer/src/components/dashboard/dashboard-card-context.test.ts
@@ -82,7 +82,13 @@ describe('resolveDashboardCardContext', () => {
         repo,
         worktree(link)
       ).review
-    ).toEqual({ number: 77, state: 'open' })
+      // The card's CI dot and its click target both ride along with the review.
+    ).toEqual({
+      number: 77,
+      state: 'open',
+      checksStatus: 'success',
+      url: 'https://example.test/review/77'
+    })
   })
 
   it('keeps validated GitHub PR cache metadata as a fallback', () => {
@@ -107,7 +113,12 @@ describe('resolveDashboardCardContext', () => {
         repo,
         worktree({ linkedPR: 42 })
       ).review
-    ).toEqual({ number: 42, state: 'draft' })
+    ).toEqual({
+      number: 42,
+      state: 'draft',
+      checksStatus: 'pending',
+      url: 'https://example.test/pull/42'
+    })
   })
 
   it('rejects cached review metadata from the previous linked review', () => {
@@ -128,5 +139,30 @@ describe('resolveDashboardCardContext', () => {
         worktree()
       ).review
     ).toBeUndefined()
+  })
+})
+
+describe('resolveDashboardCardContext linked ticket', () => {
+  it('links the ticket badge to Linear when the org key is known', () => {
+    expect(
+      resolveDashboardCardContext(
+        {},
+        repo,
+        worktree({
+          linkedLinearIssue: 'STA-335',
+          linkedLinearIssueOrganizationUrlKey: 'acme'
+        })
+      ).linearIssue
+    ).toEqual({ identifier: 'STA-335', url: 'https://linear.app/acme/issue/STA-335' })
+  })
+
+  it('still names the ticket when no org key is known, so the badge stays inert', () => {
+    expect(
+      resolveDashboardCardContext({}, repo, worktree({ linkedLinearIssue: 'STA-335' })).linearIssue
+    ).toEqual({ identifier: 'STA-335' })
+  })
+
+  it('has no ticket when the workspace links none', () => {
+    expect(resolveDashboardCardContext({}, repo, worktree()).linearIssue).toBeUndefined()
   })
 })

--- a/src/renderer/src/components/dashboard/dashboard-card-context.ts
+++ b/src/renderer/src/components/dashboard/dashboard-card-context.ts
@@ -1,7 +1,12 @@
 import { branchName } from '@/lib/git-utils'
 import { getHostedReviewCacheKey } from '@/store/slices/hosted-review-cache-identity'
 import type { AppState } from '@/store/types'
-import type { DashboardCardReview } from '../../../../shared/dashboard-snapshot'
+import type {
+  DashboardCardLinearIssue,
+  DashboardCardReview
+} from '../../../../shared/dashboard-snapshot'
+import { buildLinearIssueUrl } from '../../../../shared/linear/links'
+import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import { hostedReviewInfoFromGitHubPRInfo } from '../../../../shared/hosted-review-github'
 import { isPositiveHostedReviewNumber } from '../../../../shared/hosted-review'
 import type { Repo } from '../../../../shared/repo-types'
@@ -24,6 +29,29 @@ export type DashboardCardContext = {
   workspaceStatus: WorkspaceStatusDefinition
   hasReview: boolean
   review?: DashboardCardReview
+  linearIssue?: DashboardCardLinearIssue
+}
+
+/** Keeps the two cache paths below emitting the same shape. */
+function toCardReview(review: HostedReviewInfo): DashboardCardReview {
+  return {
+    number: review.number,
+    state: review.state,
+    ...(review.status ? { checksStatus: review.status } : {}),
+    ...(review.url ? { url: review.url } : {})
+  }
+}
+
+function resolveLinearIssue(worktree: Worktree): DashboardCardLinearIssue | undefined {
+  const identifier = worktree.linkedLinearIssue?.trim()
+  if (!identifier) {
+    return undefined
+  }
+  const url = buildLinearIssueUrl({
+    identifier,
+    organizationUrlKey: worktree.linkedLinearIssueOrganizationUrlKey
+  })
+  return { identifier, ...(url ? { url } : {}) }
 }
 
 function hasLinkedReview(worktree: Worktree): boolean {
@@ -62,7 +90,7 @@ function resolveReview(
     hostedReview &&
     canUseParentPrChecksHostedReviewCacheEntry(worktree, hostedReview, hostedReviewEntry)
   ) {
-    return { number: hostedReview.number, state: hostedReview.state }
+    return toCardReview(hostedReview)
   }
   const prEntry = getParentPrChecksGitHubPRCacheEntry({
     prCache: state.prCache,
@@ -73,7 +101,7 @@ function resolveReview(
   const review = canUseParentPrChecksGitHubPRCacheEntry(worktree, prEntry, hostedReviewEntry)
     ? hostedReviewInfoFromGitHubPRInfo(prEntry.data)
     : undefined
-  return review ? { number: review.number, state: review.state } : undefined
+  return review ? toCardReview(review) : undefined
 }
 
 export function resolveDashboardCardContext(
@@ -90,6 +118,7 @@ export function resolveDashboardCardContext(
     workspaceStatus:
       statuses.find((status) => status.id === workspaceStatusId) ?? DEFAULT_WORKSPACE_STATUSES[0],
     review: resolveReview(state, repo, worktree),
+    linearIssue: resolveLinearIssue(worktree),
     hasReview: hasLinkedReview(worktree)
   }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16884,6 +16884,12 @@
         "merged": "Merged review",
         "closed": "Closed review"
       },
+      "checks": {
+        "pending": "CI running",
+        "success": "CI passing",
+        "failure": "CI failing",
+        "neutral": "CI neutral"
+      },
       "subagents_one": "{{count}} subagent",
       "subagents_other": "{{count}} subagents"
     },

--- a/src/shared/dashboard-snapshot.ts
+++ b/src/shared/dashboard-snapshot.ts
@@ -1,4 +1,5 @@
 import type { AgentType, AgentWorkingMode } from './agent-status-types'
+import type { CheckStatus } from './github/pull-request-types'
 import type { ExecutionHostId } from './execution-host'
 import type { RepoIcon } from './repo-icon'
 import type { TuiAgent } from './tui-agent'
@@ -50,6 +51,17 @@ export function dashboardCardDisplayState(
 export type DashboardCardReview = {
   number: number
   state: 'open' | 'closed' | 'merged' | 'draft'
+  /** CI rollup for the review's head. Additive — older pop-outs ignore it. */
+  checksStatus?: CheckStatus
+  /** Absent when the cache entry carries no URL; the badge then stays inert. */
+  url?: string
+}
+
+/** The Linear issue a workspace is linked to, for the card's ticket badge. */
+export type DashboardCardLinearIssue = {
+  identifier: string
+  /** Absent until the workspace knows its Linear org key — badge stays inert. */
+  url?: string
 }
 
 export type DashboardCardSubagent = {
@@ -121,6 +133,7 @@ export type DashboardCard = {
   /** True when the workspace links a review whose live state is not cached yet. */
   hasReview?: boolean
   review?: DashboardCardReview
+  linearIssue?: DashboardCardLinearIssue
   subagents?: DashboardCardSubagent[]
   /** "Started … ago" display. */
   startedAt: number


### PR DESCRIPTION
The Agent Dashboard's job is to answer *what needs me* at a glance. The two answers that travel with a workspace — is the review green, and which ticket is this — were the least visible things on the card: a 10px pill buried in the footer, and nothing at all for the ticket.

Both now sit in the card's top-right corner at a size worth glancing at, and both are links: the review opens the PR, the ticket opens Linear.

### What changed

- **PR badge moved to the top-right, enlarged, and given a CI dot.** The checks rollup already existed as `HostedReviewInfo.status`, but `resolveReview()` kept only `{number, state}` and dropped it. It now carries the rollup and the review URL through to the card.
- **Linear ticket badge beside it**, from `worktree.linkedLinearIssue`, using the existing `buildLinearIssueUrl`. Inert (still named) when the workspace has no Linear org key.
- **Provider moved the other way** — down to the footer, smaller, but with its name spelled out. "Which agent is this" reads better as a word than as a 14px glyph.

### Wire compatibility

`checksStatus`, `url` and `linearIssue` are all additive optional fields, so an older pop-out renders the card exactly as it did before.

### Trust boundary

The pop-out hands these URLs straight to `shell.openUrl`, so the main process admits only `http(s)`. That guard, and the bounds it needs, now live in one module — the review check had already drifted into three copies (snapshot, workspace, file-link validators), which is exactly how one of them ends up looser than the rest.

The badges live outside the card's open-terminal button, because a button cannot nest inside a button; the heading reserves room beside them so it truncates rather than collides.

### Verification

`pnpm tc`, `oxlint` (+ react-doctor) clean. 540 tests pass across `src/main/ipc` and `src/renderer/src/components/dashboard*`, including new cases for the Linear resolution, the CI rollup, and rejection of a `javascript:`/`file:` URL reaching the opener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mx3KUL97GZo8ish2BR53B