### PR TITLE
Stop Escape interrupting the agent from a dashboard preview

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
@@ -138,6 +138,19 @@ describe('AgentTerminalDialog', () => {
     })
   })
 
+  it('does not dismiss on a modified Escape, leaving it for the terminal to forward', () => {
+    // Radix handles Escape during the capture phase, ahead of the preview's own
+    // key-forwarding listener — onEscapeKeyDown must block dismissal itself for
+    // any modified Escape (bare Escape is still meant to close the dialog).
+    const onOpenChange = vi.fn()
+    render(<AgentTerminalDialog card={card()} onOpenChange={onOpenChange} onReveal={() => {}} />)
+
+    fireEvent.keyDown(document, { key: 'Escape', metaKey: true })
+
+    expect(onOpenChange).not.toHaveBeenCalled()
+    expect(screen.getByTestId('preview')).toBeInTheDocument()
+  })
+
   it('reuses the terminal surface as a non-modal adjacent panel', () => {
     render(<AgentTerminalPanel card={card()} onOpenChange={() => {}} onReveal={() => {}} />)
 

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
@@ -167,4 +167,20 @@ describe('AgentTerminalDialog', () => {
     fireEvent.keyDown(document.body, { key: 'Escape' })
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
+
+  it('closes on Escape pressed inside the terminal rather than interrupting', () => {
+    // The preview's key handler refuses Escape instead of writing \x1b, so the
+    // keystroke reaches this listener. Ctrl+C is the interrupt now.
+    const onOpenChange = vi.fn()
+    const { container } = render(
+      <AgentTerminalPanel card={card()} onOpenChange={onOpenChange} onReveal={() => {}} />
+    )
+    const xterm = document.createElement('div')
+    xterm.className = 'xterm'
+    container.append(xterm)
+
+    fireEvent.keyDown(xterm, { key: 'Escape' })
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
 })

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -127,6 +127,16 @@ export function AgentTerminalDialog({
               e.preventDefault()
             }
           }}
+          // Why: Radix handles Escape in the capture phase, before the
+          // preview's own key-forwarding listener (installPreviewTerminalKeyHandler)
+          // sees it — so a modified Escape (e.g. Cmd+Escape) would dismiss the
+          // dialog here even though the preview forwards it to the agent. Bare
+          // Escape still closes, matching previewTerminalSwallowsKey.
+          onEscapeKeyDown={(e) => {
+            if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+              e.preventDefault()
+            }
+          }}
         >
           <AgentTerminalFrame
             card={card}

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -120,14 +120,6 @@ export function AgentTerminalDialog({
           // dialogs), which misaligns against this p-0 compact header; render
           // it inside the header row instead so it centers with the title.
           showCloseButton={false}
-          // Why: Esc must reach the agent (interrupt) when typing in the
-          // terminal, not dismiss the dialog; xterm has already consumed the
-          // keystroke by the time Radix sees it. Click-outside still closes.
-          onEscapeKeyDown={(e) => {
-            if (e.target instanceof HTMLElement && e.target.closest('.xterm')) {
-              e.preventDefault()
-            }
-          }}
           // Why: the preview focuses its terminal once the snapshot paints;
           // Radix's default focus target would tug focus away first.
           onOpenAutoFocus={(e) => {
@@ -165,11 +157,10 @@ export function AgentTerminalPanel({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
-      if (
-        event.key === 'Escape' &&
-        !event.defaultPrevented &&
-        !(event.target instanceof HTMLElement && event.target.closest('.xterm'))
-      ) {
+      // Why: the preview's key handler refuses Escape rather than sending it,
+      // so it closes the panel here instead of interrupting the agent —
+      // interrupting is Ctrl+C, which still reaches the terminal.
+      if (event.key === 'Escape' && !event.defaultPrevented) {
         onOpenChange(false)
       }
     }

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-escape-guard.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-escape-guard.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { previewTerminalSwallowsKey } from './preview-terminal-escape-guard'
+
+function key(init: Partial<KeyboardEvent> & { key: string }): KeyboardEvent {
+  return {
+    type: 'keydown',
+    ctrlKey: false,
+    altKey: false,
+    metaKey: false,
+    shiftKey: false,
+    ...init
+  } as KeyboardEvent
+}
+
+describe('previewTerminalSwallowsKey', () => {
+  it('keeps a bare Escape from interrupting the agent', () => {
+    expect(previewTerminalSwallowsKey(key({ key: 'Escape' }))).toBe(true)
+  })
+
+  it('still lets Ctrl+C through, since that is the interrupt now', () => {
+    expect(previewTerminalSwallowsKey(key({ key: 'c', ctrlKey: true }))).toBe(false)
+  })
+
+  it('leaves a modified Escape alone — only the bare key is overloaded', () => {
+    expect(previewTerminalSwallowsKey(key({ key: 'Escape', altKey: true }))).toBe(false)
+    expect(previewTerminalSwallowsKey(key({ key: 'Escape', shiftKey: true }))).toBe(false)
+  })
+
+  it('ignores keyup, so the guard fires once per press', () => {
+    expect(previewTerminalSwallowsKey(key({ key: 'Escape', type: 'keyup' }))).toBe(false)
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-escape-guard.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-escape-guard.ts
@@ -1,0 +1,19 @@
+/**
+ * Keeps a bare Escape out of the preview's PTY.
+ *
+ * A pop-out preview is a glance surface, and Escape there means "back out of
+ * this" the way it does in every other dialog. Forwarding it interrupted the
+ * agent instead — a destructive outcome for the key people press to leave.
+ * Ctrl+C stays the interrupt. Modified Escape still reaches the agent, since
+ * only the bare keystroke carries the conflicting meaning.
+ */
+export function previewTerminalSwallowsKey(event: KeyboardEvent): boolean {
+  return (
+    event.type === 'keydown' &&
+    event.key === 'Escape' &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.metaKey &&
+    !event.shiftKey
+  )
+}

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
@@ -9,6 +9,7 @@ import {
 import { createTerminalNativeOnlyShortcutTracker } from '@/components/terminal-pane/terminal-native-only-shortcut'
 import { createOptionKeyLocationTracker } from '@/lib/keyboard-layout/option-key-location-state'
 import { createTerminalOptionKittyReleaseTracker } from '@/components/terminal-pane/terminal-option-kitty-release'
+import { previewTerminalSwallowsKey } from './preview-terminal-escape-guard'
 import {
   resolvePreviewShortcutAction,
   type PreviewShortcutContext
@@ -107,6 +108,11 @@ export function installPreviewTerminalKeyHandler(args: {
       return true
     }
     nativeOnlyShortcutTracker.prepareKeyDown(event)
+    if (previewTerminalSwallowsKey(event)) {
+      // Why: refusing the key stops xterm writing \x1b, and leaving the default
+      // alone lets the keystroke bubble out and close the preview instead.
+      return false
+    }
     const keybindings = useAppStore.getState().keybindings
     if (keybindingMatchesAction('terminal.copySelection', event, platform, keybindings)) {
       const selection = terminal.getSelection()


### PR DESCRIPTION
Escape in the Agent Dashboard preview was forwarded to the PTY as `\x1b`, so the agent read it as an interrupt.

That is the wrong default for a glance surface. Escape is the key people press to back out of something they just opened — here it silently killed the agent's turn instead, and the preview stayed open.

### What changed

The preview's key handler now **refuses** a bare Escape. Refusing rather than consuming is the point: xterm writes no bytes, and because the default is left alone the keystroke bubbles out and closes the preview — which is what pressing it meant.

- **Ctrl+C still reaches the terminal** and is now the only interrupt from this surface.
- **Modified Escape still goes through** (Alt+Esc, Shift+Esc), since only the bare keystroke was overloaded.
- The `.xterm` carve-outs in `AgentTerminalDialog` — which existed only to keep Escape away from the dialog — go away with it.

### Note on the implementation

The guard lives inside the existing `installPreviewTerminalKeyHandler` rather than in a second `attachCustomKeyEventHandler`. xterm keeps only one such handler, so a second call would have quietly replaced the entire copy/paste, IME and shortcut policy.

### Trade-off worth naming

Agent TUIs that use bare Escape for their own menus can no longer receive it *from the preview*. The main pane is unchanged. This is deliberate — it was the requested behaviour — but it is the thing to revisit if a TUI menu turns out to matter more than the interrupt safety.

### Verification

`pnpm tc` and `oxlint` clean. 343 tests pass in `src/renderer/src/components/dashboard-popout`, including a new guard suite and a panel test asserting Escape from inside the terminal now closes rather than interrupts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mx3KUL97GZo8ish2BR53B