### PR TITLE
Name the command each agent is running, on its card

### DIFF
--- a/src/main/ipc/dashboard-payload-validation.ts
+++ b/src/main/ipc/dashboard-payload-validation.ts
@@ -290,6 +290,7 @@ function isDashboardCard(value: unknown): boolean {
     isFiniteNumber(card.stateChangedAt) &&
     (card.statusUpdatedAt === undefined || isFiniteNumber(card.statusUpdatedAt)) &&
     typeof card.unseen === 'boolean' &&
+    isOptionalBoundedString(card.activity, MAX_LABEL_LENGTH) &&
     isOptionalBoundedString(card.askSummary, AGENT_STATUS_INTERACTIVE_PROMPT_MAX_LENGTH) &&
     isOptionalBoundedString(card.conversationName, MAX_LABEL_LENGTH) &&
     isDashboardTerminalInput(card.terminalInput)

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
@@ -165,6 +165,20 @@ describe('AgentKanbanCard', () => {
     expect(onOpenTerminal).toHaveBeenCalledTimes(1)
   })
 
+  it('names the command the agent is running', () => {
+    renderCard({ card: card({ activity: 'Bash: pnpm test' }), now: 2_000 })
+
+    expect(screen.getByText('Bash: pnpm test')).toBeInTheDocument()
+  })
+
+  it('reserves the activity row even with nothing to say, so cards do not jump', () => {
+    // A row that appears and disappears resizes every card as its agent moves
+    // between tools, and the whole board shifts under the pointer.
+    const { container } = renderCard({ card: card({ activity: undefined }), now: 2_000 })
+
+    expect(container.querySelector('.h-4')).toBeInTheDocument()
+  })
+
   it('labels one subagent accessibly and never renders a workspace-status dot', () => {
     renderCard({
       card: card({

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -89,6 +89,7 @@ function sameCard(a: DashboardCard, b: DashboardCard): boolean {
     a.dotState === b.dotState &&
     a.workingMode === b.workingMode &&
     a.task === b.task &&
+    a.activity === b.activity &&
     a.lastUserMessage === b.lastUserMessage &&
     a.lastAgentMessage === b.lastAgentMessage &&
     a.repoId === b.repoId &&
@@ -243,8 +244,11 @@ export const AgentKanbanCard = memo(
             </span>
             <span
               className={cn(
-                'truncate text-[12.5px]',
-                card.unseen ? 'font-semibold text-foreground' : 'font-normal text-muted-foreground'
+                // Why: the heading is what you scan a column by, so it leads
+                // the card outright. Unseen is carried by colour alone now —
+                // the weight is already at the top of the scale.
+                'truncate text-[15px] leading-tight font-bold tracking-tight',
+                card.unseen ? 'text-foreground' : 'text-muted-foreground'
               )}
             >
               {heading}
@@ -276,6 +280,17 @@ export const AgentKanbanCard = memo(
               {card.task}
             </div>
           ) : null}
+
+          {/* Why: the row is always present, filled or not. Sizing it to its
+            content makes every card grow and shrink as its agent moves between
+            tools, and a board of those jumps under the pointer. */}
+          <div className="flex h-4 w-full items-center">
+            {card.activity ? (
+              <span className="truncate font-mono text-[10.5px] leading-none text-muted-foreground">
+                {card.activity}
+              </span>
+            ) : null}
+          </div>
 
           {card.askSummary ? (
             <div className="flex w-full items-start gap-1 rounded-md bg-agent-question/15 px-1.5 py-1 text-[11px] text-agent-question-text ring-1 ring-inset ring-agent-question/25">

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
@@ -176,6 +176,33 @@ describe('buildDashboardSnapshot', () => {
     })
   })
 
+  it('reports the command a working agent is running', () => {
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        agentStatusByPaneKey: {
+          [PANE_KEY]: entry({ state: 'working', toolName: 'Bash', toolInput: 'pnpm test' })
+        }
+      }),
+      NOW
+    )
+
+    expect(snapshot.cards[0].activity).toBe('Bash: pnpm test')
+  })
+
+  it('reports no command once the tool is no longer running', () => {
+    // A leftover tool line on a finished agent reads as still-running.
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        agentStatusByPaneKey: {
+          [PANE_KEY]: entry({ state: 'done', toolName: 'Bash', toolInput: 'pnpm test' })
+        }
+      }),
+      NOW
+    )
+
+    expect(snapshot.cards[0].activity).toBeUndefined()
+  })
+
   it('maps a live working agent to the working bucket with a resolved ptyId', () => {
     const snapshot = buildDashboardSnapshot(
       baseState({

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -34,6 +34,7 @@ import {
   selectLivePtyIdsForWorktree,
   selectRuntimePaneTitlesForWorktree
 } from '../sidebar/worktree-card-status-inputs'
+import { formatAgentToolPreview } from '@/lib/agent-row-tool-preview'
 import {
   resolveDashboardCardContext,
   type DashboardCardContextState
@@ -257,6 +258,12 @@ export function buildDashboardSnapshot(
         dotState,
         ...(workingMode ? { workingMode } : {}),
         task: isTitleDerived ? '' : rowTask(row),
+        // Why: the same one-line tool preview the agent list shows, so the two
+        // surfaces name the running command identically. Title-derived rows
+        // have no hook behind them, so they have no tool to report.
+        activity: isTitleDerived
+          ? undefined
+          : boundedLabelOrUndefined(nonEmpty(formatAgentToolPreview(row.entry, row.state))),
         repoId: workspace.projectId,
         worktreeId,
         tabId,

--- a/src/shared/dashboard-snapshot.ts
+++ b/src/shared/dashboard-snapshot.ts
@@ -92,6 +92,10 @@ export type DashboardCard = {
   workingMode?: AgentWorkingMode
   /** One-line task/prompt text shown on the card. */
   task: string
+  /** What the agent is running right now: "Bash: pnpm test", "Edit: src/app.ts".
+   *  Comes from the agent's own hook, so no terminal has to be read for it.
+   *  Absent whenever a running tool is not the truth (done, idle, monitoring). */
+  activity?: string
   /** The most recent message the user sent this agent (its current prompt). */
   lastUserMessage?: string
   /** The most recent message the agent sent back. */


### PR DESCRIPTION
The board could tell you an agent was *working* but not what it was working on — and the last message goes stale the moment a turn starts, which is exactly when you want to look.

> **Rewritten.** The first version of this PR opened a live PTY subscription per visible card. That was wrong and I've dropped it entirely — see *What changed and why* below.

### The agents already report this

Every status hook carries `toolName` and `toolInput`, and `formatAgentToolPreview` already turns them into the `Bash: pnpm test` line the agent list shows. The card now carries that same string, so the two surfaces name the running command identically — and **no terminal has to be read to produce it**.

Reusing `showsAgentToolPreview` brings its honesty rule along: a tool line shows only while `working` or `waiting`. On a finished agent, a leftover tool name reads as still-running, so there is none.

### The row is reserved

Shown or empty, the row occupies the same height. Sizing it to its content makes every card grow and shrink as its agent moves between tools, and a board of those jumps under the pointer.

### Heading

15px bold, with unseen carried by colour alone — the weight is already at the top of the scale, so it had nothing left to say.

### What changed and why

The original implementation gave each visible card its own `terminalPreview.connect`. Three things were wrong with it, and they showed up as **input lag in the real terminal**:

1. `connect` is keyed per `(webContents, ptyId)` and **disposes any existing subscription for that key**. In the in-window board, cards share a renderer with the terminal dialog — so a card would silently kill the dialog's stream for the pty you were typing into.
2. Each connect runs `serializeTerminalBuffer` in the **main process**, the same process pumping keystrokes. Viewport flapping while scrolling turned that into a serialization storm.
3. It registered a raw view subscriber per card, up to a dozen at once.

Reading the hook data the store already has costs nothing on any of those axes.

### Verification

`pnpm tc`, `oxlint` and react-doctor clean. 515 tests pass across `dashboard`, `dashboard-popout` and the IPC validator, including new cases for the working/finished distinction and for the reserved row. One of those tests caught an empty string shipping on every non-working card before this landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mx3KUL97GZo8ish2BR53B