### PR TITLE
test(pty): pin terminal query-reply order; align one renderer call site

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-hidden-backlog-reconciliation.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hidden-backlog-reconciliation.test.ts
@@ -356,10 +356,12 @@ describe('connectPanePty', () => {
         await flushAsyncTicks(8)
 
         const replies = transport.sendInputImmediate.mock.calls.map((call) => String(call[0]))
-        expect(replies.some((reply) => reply.startsWith('\x1b]11;rgb:'))).toBe(true)
         // oxlint-disable-next-line no-control-regex -- the ESC byte IS the payload: this matches the CPR reply
-        expect(replies.some((reply) => /^\u001b\[\d+;\d+R$/.test(reply))).toBe(true)
-        expect(replies).toContain(DEFAULT_DA1_RESPONSE)
+        const cprReply = replies.find((reply) => /^\u001b\[\d+;\d+R$/.test(reply))
+        const oscReply = replies.find((reply) => reply.startsWith('\x1b]11;rgb:'))
+        expect(oscReply).toBeDefined()
+        expect(cprReply).toBeDefined()
+        expect(replies).toEqual([oscReply, cprReply, DEFAULT_DA1_RESPONSE])
         const written = writtenFloodData(pane)
         expect(written).not.toContain('aaaa')
         expect(written).not.toContain('bbbb')

--- a/src/renderer/src/components/terminal-pane/pty-connection/live-data-callback.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/live-data-callback.ts
@@ -123,11 +123,6 @@ export function bindLiveDataCallback(session: ConnectPanePtySession): void {
       session.schedulePendingStartupCommandDelivery()
       return
     }
-    if (pendingForegroundQuery?.statelessQueryData) {
-      session.writePtyOutputToXterm(pendingForegroundQuery.statelessQueryData, true, {
-        hiddenStartupRendererQuery: true
-      })
-    }
     if (pendingForegroundQuery?.oscColorQueryData) {
       sendTerminalOscColorQueryReplies(
         pendingForegroundQuery.oscColorQueryData,
@@ -135,6 +130,11 @@ export function bindLiveDataCallback(session: ConnectPanePtySession): void {
         // Why: OSC color reply sent immediately so the remote debounce can't delay it past the program's read window (#7329).
         session.sendDesktopQueryReplyImmediate
       )
+    }
+    if (pendingForegroundQuery?.statelessQueryData) {
+      session.writePtyOutputToXterm(pendingForegroundQuery.statelessQueryData, true, {
+        hiddenStartupRendererQuery: true
+      })
     }
     const restoreAppliesToCurrentPty =
       session.hiddenOutputRestorePtyId !== null &&

--- a/src/renderer/src/components/terminal-pane/pty-connection/live-data-callback.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/live-data-callback.ts
@@ -123,6 +123,7 @@ export function bindLiveDataCallback(session: ConnectPanePtySession): void {
       session.schedulePendingStartupCommandDelivery()
       return
     }
+    // Keep source order aligned with sibling producers; xterm's async write buffer made the old inversion latent.
     if (pendingForegroundQuery?.oscColorQueryData) {
       sendTerminalOscColorQueryReplies(
         pendingForegroundQuery.oscColorQueryData,

--- a/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
@@ -88,6 +88,34 @@ describe('installTerminalCapabilityReplyHandlers', () => {
     }
   })
 
+  it.each([
+    ['OSC 11 then CPR', '\x1b]11;?\x1b\\\x1b[6n', ['osc', 'cpr']],
+    ['CPR then OSC 11', '\x1b[6n\x1b]11;?\x1b\\', ['cpr', 'osc']]
+  ] as const)('preserves combined query order (%s)', async (_name, input, expectedKinds) => {
+    const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    term.options.theme = { background: '#ffffff' }
+    const replies: string[] = []
+    const disposable = installTerminalCapabilityReplyHandlers({
+      terminal: term as never,
+      parser: term.parser,
+      sendInput: (data) => {
+        replies.push(data)
+      },
+      isReplaying: () => false
+    })
+    const onData = term.onData((data) => replies.push(data))
+
+    try {
+      await writeTerminal(term, input)
+      const kinds = replies.map((reply) => (reply.startsWith('\x1b]11;') ? 'osc' : 'cpr'))
+      expect(kinds).toEqual(expectedKinds)
+    } finally {
+      onData.dispose()
+      disposable.dispose()
+      term.dispose()
+    }
+  })
+
   it('answers OSC color queries for active rgba and modern rgb theme colors', async () => {
     const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
     term.options.theme = {

--- a/src/shared/terminal-query-reply.test.ts
+++ b/src/shared/terminal-query-reply.test.ts
@@ -176,6 +176,25 @@ describe('query reply ordering (termenv OSC-then-CPR)', () => {
     vi.useRealTimers()
   })
 
+  it('preserves reverse query order when CPR arrives before the color query', async () => {
+    vi.useFakeTimers()
+    const pty: string[] = []
+    const ingress = new PtyStartupIngress({
+      ownerBackend: 'posix-pty',
+      write: (data) => pty.push(data),
+      onEmission: () => {}
+    })
+    const write = hostWrites(ingress, pty)
+
+    write(CPR_REPLY)
+    write(OSC_11_REPLY)
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(pty).toEqual([CPR_REPLY, OSC_11_REPLY])
+    ingress.drainAndClose()
+    vi.useRealTimers()
+  })
+
   it('keeps a CPR immediate when no color reply is deferred', () => {
     vi.useFakeTimers()
     const pty: string[] = []


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## Summary

- Root-cause status: mitigation/consistency-only. The originally reported CPR-before-OSC defect was fixed by #15559 and #15578 (both absent from v1.4.187 and present from v1.4.188); it does not reproduce on the current tree or shipped 1.4.191. Evidence, captured with the ticket's own probe (`stty raw -echo; printf '\033]11;?\033\\\033[6n'; hexdump`):

```
Apple Terminal (control):  1b5d 3131 3b72 6762 3a32 3133 642f ...  -> ESC ] 11 ;   OSC first
Orca 1.4.191 foreground:   1b5d 3131 3b72 6762 3a32 3832 382f ...  -> ESC ] 11 ;   OSC first
Orca, this tree (dev):     1b5d 3131 3b72 6762 3a32 3832 382f ...  -> ESC ] 11 ;   OSC first
Linux SSH/relay, 3/3:      1b5d 3131 3b72 6762 3a32 3832 382f ...  -> ESC ] 11 ;   OSC first

Reporter, Orca 1.4.187:    1b5b 373b 3152 1b5d 3131 3b ...         -> ESC [ 7;1R   CPR first (the defect)
```

The probe is sensitive, not vacuously passing: feeding the queries in reverse (`CSI 6n` then
`OSC 11`) returns a CPR-first dump on every surface, so it demonstrably can still detect the
inverted shape. Controls: Apple Terminal on macOS; on Linux, a plain OpenSSH tty answers
*nothing* (proving no other layer synthesizes the replies) and an in-order emulator on the
same PTY answers OSC-first.
- Reorders the hidden-to-foreground renderer path so OSC color replies are sent before stateless xterm query writes, matching the sibling producers.
- Pins exact reply order for renderer parsing and host delivery, including reversed CSI-then-OSC input.

## Validation

- `pnpm tc` passes.
- Focused terminal query, hidden backlog, and hidden query restore suites pass (49 tests).
- Direct oxlint over all changed files and commit hooks pass; the changed-code wrapper is currently blocked by a pnpm Node-engine warning parse issue under Node 26.
- The inverted call site is latent in current xterm behavior: `writePtyOutputToXterm` enters the renderer output scheduler and xterm's asynchronous WriteBuffer, while OSC dispatch is synchronous. Therefore the new order assertion cannot fail pre-fix without an artificial synchronous double; none was used.
- macOS local probes: not reproduced across 7 surfaces. Linux SSH/relay probes: not reproduced across 3/3 controls. Windows/ConPTY: unverifiable because the remote runtime was unreachable; no Windows claim is made.
- Full `pnpm test` was attempted; it reported load/environment-sensitive failures and was interrupted after extended runtime.

Do not merge; coordinator will gate that separately.

