### PR TITLE
Keep the preview open when it sends you to the worktree

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
@@ -138,6 +138,17 @@ describe('AgentTerminalDialog', () => {
     })
   })
 
+  it('keeps the preview open after revealing, so the view is not thrown away', () => {
+    // From the pop-out, revealing focuses the pane in the MAIN window — the
+    // preview the user was watching should still be there behind it.
+    const onOpenChange = vi.fn()
+    render(<AgentTerminalDialog card={card()} onOpenChange={onOpenChange} onReveal={() => {}} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open worktree' }))
+
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
   it('reuses the terminal surface as a non-modal adjacent panel', () => {
     render(<AgentTerminalPanel card={card()} onOpenChange={() => {}} onReveal={() => {}} />)
 

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -39,6 +39,11 @@ function AgentTerminalFrame({
   onOpenChange,
   onReveal
 }: AgentTerminalFrameProps): React.JSX.Element {
+  // Why: revealing does not dismiss the preview. From the pop-out this focuses
+  // the pane in the MAIN window, so closing the pop-out's own preview threw
+  // away the view the user was watching to get somewhere else. The in-window
+  // board still closes, but that is its host's call — the drawer overlays the
+  // very pane being revealed, so it dismisses itself in onRevealAgent.
   const reveal = (): void => {
     onReveal({
       repoId: card.repoId,
@@ -47,7 +52,6 @@ function AgentTerminalFrame({
       tabId: card.tabId,
       leafId: card.leafId
     })
-    onOpenChange(false)
   }
 
   return (


### PR DESCRIPTION
"Open worktree" dismissed the preview it was launched from.

From the pop-out that is backwards. Revealing focuses the pane in the **main** window — so the pop-out was throwing away the view the user was watching in order to get them somewhere else, in a window that is still sitting there, now showing nothing.

### What changed

`reveal()` no longer calls `onOpenChange(false)`.

The in-window board still disappears on reveal, but that is now its **host's** decision rather than this component's: `AgentDashboardDrawer.handleRevealAgent` already calls `onClose()`, and it should — the drawer overlays the very pane being revealed, so leaving it up would cover the thing you just navigated to.

Moving the call out of the shared frame lets each host keep the behaviour that suits it, instead of the pop-out inheriting one that only makes sense in-window.

### Verification

`pnpm tc` and `oxlint` clean. 339 tests pass in `dashboard-popout`, including a new case asserting `onOpenChange` is not called when "Open worktree" is clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mx3KUL97GZo8ish2BR53B