### PR TITLE
Fix STA-5661: prevent rolldown const-folding of bridged exports

### DIFF
--- a/src/main/ipc/pty/delivery/debug.ts
+++ b/src/main/ipc/pty/delivery/debug.ts
@@ -88,31 +88,51 @@ export const EMPTY_PTY_RENDERER_DELIVERY_DEBUG_SNAPSHOT: PtyRendererDeliveryDebu
   rendererDispatcherReadyForcedCount: 0
 }
 
-export let readPtyRendererDeliveryDebugSnapshot = (): PtyRendererDeliveryDebugSnapshot => ({
-  ...EMPTY_PTY_RENDERER_DELIVERY_DEBUG_SNAPSHOT
-})
-export let resetPtyRendererDeliveryDebugSnapshot = (): void => {}
+// Why null-init + wrapper fns (not `export let fn = noop`): rolldown const-folds the noop into
+// call sites and drops the setter's reassignment, so bridged closures never run in the built app (STA-5661).
+let readPtyRendererDeliveryDebugSnapshotImpl: (() => PtyRendererDeliveryDebugSnapshot) | null = null
+let resetPtyRendererDeliveryDebugSnapshotImpl: (() => void) | null = null
 // Bridged into the registerPtyHandlers closure so the module-scope lifecycle-reset handler can zero closure-owned delivery accounting on renderer reload/crash.
-export let resetRendererDeliveryAccountingForLifecycleReset = (): void => {}
+let resetRendererDeliveryAccountingForLifecycleResetImpl: (() => void) | null = null
 // Bridged so a re-registration can cancel the prior closure's dispatcher-ready watchdog before wiring its own.
-export let clearRendererDispatcherReadyWatchdog = (): void => {}
+let clearRendererDispatcherReadyWatchdogImpl: (() => void) | null = null
+
+export function readPtyRendererDeliveryDebugSnapshot(): PtyRendererDeliveryDebugSnapshot {
+  return (
+    readPtyRendererDeliveryDebugSnapshotImpl?.() ?? {
+      ...EMPTY_PTY_RENDERER_DELIVERY_DEBUG_SNAPSHOT
+    }
+  )
+}
+
+export function resetPtyRendererDeliveryDebugSnapshot(): void {
+  resetPtyRendererDeliveryDebugSnapshotImpl?.()
+}
+
+export function resetRendererDeliveryAccountingForLifecycleReset(): void {
+  resetRendererDeliveryAccountingForLifecycleResetImpl?.()
+}
+
+export function clearRendererDispatcherReadyWatchdog(): void {
+  clearRendererDispatcherReadyWatchdogImpl?.()
+}
 
 export function setReadPtyRendererDeliveryDebugSnapshot(
   fn: () => PtyRendererDeliveryDebugSnapshot
 ): void {
-  readPtyRendererDeliveryDebugSnapshot = fn
+  readPtyRendererDeliveryDebugSnapshotImpl = fn
 }
 
 export function setResetPtyRendererDeliveryDebugSnapshot(fn: () => void): void {
-  resetPtyRendererDeliveryDebugSnapshot = fn
+  resetPtyRendererDeliveryDebugSnapshotImpl = fn
 }
 
 export function setResetRendererDeliveryAccountingForLifecycleReset(fn: () => void): void {
-  resetRendererDeliveryAccountingForLifecycleReset = fn
+  resetRendererDeliveryAccountingForLifecycleResetImpl = fn
 }
 
 export function setClearRendererDispatcherReadyWatchdog(fn: () => void): void {
-  clearRendererDispatcherReadyWatchdog = fn
+  clearRendererDispatcherReadyWatchdogImpl = fn
 }
 
 export function getPtyRendererDeliveryDebugSnapshot(): PtyRendererDeliveryDebugSnapshot {

--- a/src/main/ipc/pty/delivery/visibility-state.ts
+++ b/src/main/ipc/pty/delivery/visibility-state.ts
@@ -9,8 +9,17 @@ export const interactiveOutputCharsByPty = new Map<string, number>()
 export const activeRendererPtys = new Set<string>()
 export const visibleRendererPtys = new Set<string>()
 export const rendererVisibilityKnownPtys = new Set<string>()
-export let invalidatePendingPtyDrainPriority = (_id?: string, _schedule?: boolean): void => {}
-export let invalidatePendingPtyDrainPolicy = (_id?: string, _schedule?: boolean): void => {}
+// Why null-init + wrapper fns: see debug.ts — rolldown const-folds `export let fn = noop` bridges (STA-5661).
+let invalidatePendingPtyDrainPriorityImpl: ((id?: string, schedule?: boolean) => void) | null = null
+let invalidatePendingPtyDrainPolicyImpl: ((id?: string, schedule?: boolean) => void) | null = null
+
+export function invalidatePendingPtyDrainPriority(id?: string, schedule?: boolean): void {
+  invalidatePendingPtyDrainPriorityImpl?.(id, schedule)
+}
+
+export function invalidatePendingPtyDrainPolicy(id?: string, schedule?: boolean): void {
+  invalidatePendingPtyDrainPolicyImpl?.(id, schedule)
+}
 export const pendingHiddenRendererResizeOutputPtys = new Set<string>()
 export const deliveredHiddenRendererResizeOutputPtys = new Set<string>()
 export const KEEP_HISTORY_STOP_SETTLE_MS = 1_000
@@ -21,11 +30,11 @@ export const providerSnapshotRequiredPtys = new Set<string>()
 export function setInvalidatePendingPtyDrainPriority(
   fn: (id?: string, schedule?: boolean) => void
 ): void {
-  invalidatePendingPtyDrainPriority = fn
+  invalidatePendingPtyDrainPriorityImpl = fn
 }
 
 export function setInvalidatePendingPtyDrainPolicy(
   fn: (id?: string, schedule?: boolean) => void
 ): void {
-  invalidatePendingPtyDrainPolicy = fn
+  invalidatePendingPtyDrainPolicyImpl = fn
 }

--- a/src/main/ipc/pty/provider/listener-lifecycle.ts
+++ b/src/main/ipc/pty/provider/listener-lifecycle.ts
@@ -17,7 +17,12 @@ export let rendererGateResetLoadHandler: (() => void) | null = null
 export let rendererGateResetGoneHandler: (() => void) | null = null
 export let rendererGateResetWebContents: WebContents | null = null
 // Why: the backgrounded-delivery dedupe map lives in the registerPtyHandlers closure but teardown funnels through module-scope clearProviderPtyState.
-export let clearBackgroundedDeliverySyncForPty: (id: string) => void = () => {}
+// Why null-init + wrapper fn: see delivery/debug.ts — rolldown const-folds `export let fn = noop` bridges (STA-5661).
+let clearBackgroundedDeliverySyncForPtyImpl: ((id: string) => void) | null = null
+
+export function clearBackgroundedDeliverySyncForPty(id: string): void {
+  clearBackgroundedDeliverySyncForPtyImpl?.(id)
+}
 
 export type RendererNavigationDetails = {
   isMainFrame: boolean
@@ -42,7 +47,7 @@ export function setRebindProviderListeners(fn: (() => void) | null): void {
 }
 
 export function setClearBackgroundedDeliverySyncForPty(fn: (id: string) => void): void {
-  clearBackgroundedDeliverySyncForPty = fn
+  clearBackgroundedDeliverySyncForPtyImpl = fn
 }
 
 export function setSshOutputIntakeCleanup(fn: (() => void) | null): void {

--- a/src/shared/export-let-function-initializer-ban.test.ts
+++ b/src/shared/export-let-function-initializer-ban.test.ts
@@ -1,0 +1,176 @@
+import { join, resolve } from 'node:path'
+import { beforeAll, describe, expect, it } from 'vitest'
+import type { parseAst as ParseAstFn } from 'vite' with { 'resolution-mode': 'import' }
+import { scanSourceTree } from './source-scan/source-tree-scan'
+
+// Dynamic import: vite is ESM-only and this file typechecks under tsconfig.tc.cli.json's node16/CJS.
+let parseAst: typeof ParseAstFn
+
+beforeAll(async () => {
+  ;({ parseAst } = await import('vite'))
+})
+
+/**
+ * Ban `export let fn = <function>` tree-wide: rolldown const-folds the
+ * initializer into call sites and drops the setter's reassignment, so the
+ * bridged closure silently never runs in the built app (dev is fine). Use a
+ * module-local null-initialized impl var behind exported wrapper functions
+ * instead (see src/main/ipc/pty/delivery/debug.ts); null-initialized
+ * `export let` slots compile correctly and stay allowed. Detection uses
+ * vite/rolldown's own oxc parser so this test sees exactly what the bundler sees.
+ */
+
+type AstNode = {
+  type: string
+  start?: number
+  expression?: AstNode
+  expressions?: AstNode[]
+  declaration?: AstNode
+  kind?: string
+  declarations?: {
+    id?: { name?: string }
+    init?: AstNode | null
+    start?: number
+  }[]
+  specifiers?: { local?: { name?: string } }[]
+}
+
+/** Casts, parens, `!`, and comma sequences around the function don't change what rolldown folds. */
+function unwrapInitializer(node: AstNode): AstNode {
+  let current = node
+  for (;;) {
+    if (
+      current.expression &&
+      [
+        'ParenthesizedExpression',
+        'TSAsExpression',
+        'TSSatisfiesExpression',
+        'TSTypeAssertion',
+        'TSNonNullExpression'
+      ].includes(current.type)
+    ) {
+      current = current.expression
+      continue
+    }
+    // A sequence evaluates to its last expression — that's what gets folded.
+    const sequenceTail =
+      current.type === 'SequenceExpression' ? current.expressions?.at(-1) : undefined
+    if (sequenceTail) {
+      current = sequenceTail
+      continue
+    }
+    return current
+  }
+}
+
+export type FunctionInitializedExportLet = { name: string; line: number }
+
+export function findFunctionInitializedExportLets(
+  fileName: string,
+  sourceText: string
+): FunctionInitializedExportLet[] {
+  // Cheap prefilter: full parses only for files that could contain the pattern.
+  if (!/\bexport\b/.test(sourceText) || !/\blet\b/.test(sourceText)) {
+    return []
+  }
+  const lineOf = (offset: number): number => sourceText.slice(0, offset).split('\n').length
+  const program = parseAst(sourceText, {
+    lang: fileName.endsWith('.tsx') ? 'tsx' : 'ts'
+  }) as unknown as { body: AstNode[] }
+  const functionLets: (FunctionInitializedExportLet & { exported: boolean })[] = []
+  const exportedNames = new Set<string>()
+  const collectLets = (declaration: AstNode | undefined, exported: boolean): void => {
+    if (declaration?.type !== 'VariableDeclaration' || declaration.kind !== 'let') {
+      return
+    }
+    for (const declarator of declaration.declarations ?? []) {
+      const initializer = declarator.init && unwrapInitializer(declarator.init)
+      if (
+        initializer &&
+        ['ArrowFunctionExpression', 'FunctionExpression'].includes(initializer.type)
+      ) {
+        functionLets.push({
+          name: declarator.id?.name ?? '<destructured>',
+          line: lineOf(declarator.start ?? 0),
+          exported
+        })
+      }
+    }
+  }
+  for (const statement of program.body) {
+    if (statement.type === 'ExportNamedDeclaration') {
+      collectLets(statement.declaration, true)
+      // `let fn = () => {}; export { fn }` is the same live binding — same hazard.
+      for (const specifier of statement.specifiers ?? []) {
+        if (specifier.local?.name) {
+          exportedNames.add(specifier.local.name)
+        }
+      }
+      continue
+    }
+    collectLets(statement, false)
+  }
+  return functionLets
+    .filter((candidate) => candidate.exported || exportedNames.has(candidate.name))
+    .map(({ name, line }) => ({ name, line }))
+}
+
+describe('function-initialized export let ban', () => {
+  it('flags the shapes rolldown miscompiles', () => {
+    const flagged = [
+      'export let f = () => {}',
+      'export let f = function () {}',
+      'export let f = async () => {}',
+      'export let f = (() => {}) as () => void',
+      'export let f = (() => {})!',
+      'export let f = (0, () => {})',
+      'export let f: (id: string) => void = (_id) => {}',
+      'let f = () => {}\nexport { f }',
+      'let f = () => {}\nexport { f as g }'
+    ]
+    for (const source of flagged) {
+      expect(findFunctionInitializedExportLets('a.ts', source), source).toHaveLength(1)
+    }
+  })
+
+  it('reports the declaration line', () => {
+    const source = 'const a = 1\n\nexport let f = () => {}'
+    expect(findFunctionInitializedExportLets('a.ts', source)).toEqual([{ name: 'f', line: 3 }])
+  })
+
+  it('allows the safe shapes', () => {
+    const allowed = [
+      'export let f: (() => void) | null = null',
+      'export const f = () => {}',
+      'let f = () => {}',
+      'let f: (() => void) | null = null\nexport { f }',
+      'export let n = 0',
+      'export let f'
+    ]
+    for (const source of allowed) {
+      expect(findFunctionInitializedExportLets('a.ts', source), source).toEqual([])
+    }
+  })
+
+  const repoRoot = resolve(__dirname, '..', '..')
+  // Tests are not rolldown-bundled (scanSourceTree excludes them by default);
+  // several drive the banned shape on purpose.
+  const files = scanSourceTree(join(repoRoot, 'src'))
+
+  it('scans a plausible number of files', () => {
+    // A broken root or extension list would make the guard silently vacuous.
+    expect(files.length).toBeGreaterThan(500)
+  })
+
+  it('has no function-initialized export let in shipped code', () => {
+    const offenders = files.flatMap(({ relativePath, source }) =>
+      findFunctionInitializedExportLets(relativePath, source).map(
+        (offender) => `src/${relativePath}:${offender.line} (${offender.name})`
+      )
+    )
+    expect(
+      offenders,
+      'Rolldown miscompiles `export let fn = <function>` bridges: the initializer is folded into call sites and the setter reassignment is dropped in the built app. Use a module-local null-initialized impl var behind an exported wrapper function instead — see src/main/ipc/pty/delivery/debug.ts.'
+    ).toEqual([])
+  })
+})

--- a/src/shared/source-scan/source-tree-scan.ts
+++ b/src/shared/source-scan/source-tree-scan.ts
@@ -18,7 +18,11 @@ const IGNORED_DIRECTORIES = new Set(['node_modules', 'dist', 'out', 'build', '.g
 export function isTestFile(relativePath: string): boolean {
   return (
     /\.(?:test|spec)\.tsx?$/.test(relativePath) ||
-    /(?:test-harness|test-utils|test-setup|test-fixture|repro)/.test(relativePath) ||
+    // `repro` must be a whole token: a bare substring exempted the shipped
+    // windows-terminal-capability-reprobe.ts from every guard using this walk.
+    /(?:test-harness|test-utils|test-setup|test-fixture|\brepro\b|reproduction)/.test(
+      relativePath
+    ) ||
     relativePath.includes('/__tests__/')
   )
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​176 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​176 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |

<!-- /orca-pr-loc -->

## Problem

Rolldown was const-folding `export let fn = noop` initializers into call sites and dropping setter reassignments, so bridged closures never executed in the built app. This silently broke lifecycle handlers and priority invalidation in PTY delivery.

## Solution

Replace `export let fn = () => {}` with module-local null-initialized impl vars behind exported wrapper functions. This prevents const-folding while maintaining the same public API, and adds a test to catch regressions.

## What Changed

Refactored bridged exports in debug.ts, visibility-state.ts, and listener-lifecycle.ts to use the null-init + wrapper pattern. Added test suite to detect and ban the pattern across src/. Fixed regex in source-tree-scan.ts to avoid false matches.

## Testing

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below
  - Added `export-let-function-initializer-ban.test.ts` with comprehensive pattern detection using vite's oxc parser

## Visual Proof

N/A — internal refactoring, no user-facing changes.

## Cross-platform, SSH/remote, and path/shortcut impact

N/A — implementation detail affecting bundler output only.

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)