### PR TITLE
test: make shard 15 failures deterministic

### DIFF
--- a/src/main/ipc/pty-login-shell-startup-commands.test.ts
+++ b/src/main/ipc/pty-login-shell-startup-commands.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   loginPreflightExecFileMock,
   spawnMock,
-  openCodeBuildPtyEnvMock
+  openCodeBuildPtyEnvMock,
+  piBuildPtyEnvMock
 } from './pty-ipc-mock-registry'
 import { posixOnlyIt } from './pty-ipc-test-constants'
 import { setupPtyIpcSuite } from './pty-ipc-test-harness'
@@ -137,20 +138,25 @@ describe('registerPtyHandlers', () => {
       }
     }
   })
-  it('uses the POSIX shell wrapper so Pi config survives shell startup files', async () => {
+  it('does not classify managed-extension Pi source metadata as an overlay', async () => {
     const originalPlatform = process.platform
     const originalShell = process.env.SHELL
+    const originalZdotdir = process.env.ZDOTDIR
 
     Object.defineProperty(process, 'platform', {
       configurable: true,
       value: 'darwin'
     })
     process.env.SHELL = '/bin/zsh'
+    process.env.ZDOTDIR = '/tmp/user-zdotdir'
     openCodeBuildPtyEnvMock.mockImplementationOnce(() => ({
       ORCA_OPENCODE_HOOK_PORT: '4567',
       ORCA_OPENCODE_HOOK_TOKEN: 'opencode-token',
       ORCA_OPENCODE_PTY_ID: 'test-pty'
     }))
+    piBuildPtyEnvMock.mockImplementation((_ptyId, existingAgentDir, kind) =>
+      kind === 'pi' ? { ORCA_PI_SOURCE_AGENT_DIR: existingAgentDir } : {}
+    )
 
     try {
       const [shell, args, options] = await spawnAndGetCall({
@@ -164,8 +170,10 @@ describe('registerPtyHandlers', () => {
       expect(options.env.PI_CODING_AGENT_DIR).toBe('/tmp/user-pi-agent')
       expect(options.env.ORCA_PI_CODING_AGENT_DIR).toBeUndefined()
       expect(options.env.ORCA_PI_SOURCE_AGENT_DIR).toBe('/tmp/user-pi-agent')
-      expect(options.env.ZDOTDIR).toBe(join(getShellReadyWrapperRoot(), 'zsh'))
-      expect(options.env.ORCA_SHELL_FEATURES).not.toContain('ready')
+      expect(options.env.ORCA_OMP_STATUS_EXTENSION).toBeUndefined()
+      expect(options.env.ZDOTDIR).toBe('/tmp/user-zdotdir')
+      expect(options.env.ZDOTDIR).not.toBe(join(getShellReadyWrapperRoot(), 'zsh'))
+      expect(options.env.ORCA_SHELL_FEATURES).toBeUndefined()
     } finally {
       Object.defineProperty(process, 'platform', {
         configurable: true,
@@ -175,6 +183,11 @@ describe('registerPtyHandlers', () => {
         delete process.env.SHELL
       } else {
         process.env.SHELL = originalShell
+      }
+      if (originalZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = originalZdotdir
       }
     }
   })

--- a/src/main/pi/titlebar-extension-service.test.ts
+++ b/src/main/pi/titlebar-extension-service.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { execFileSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import {
-  chmodSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -285,37 +284,53 @@ describe('PiTitlebarExtensionService', () => {
     )
   })
 
-  it.skipIf(process.platform === 'win32')(
-    'retries a legacy SQLite migration as a whole set after sidecar copy failure',
-    () => {
-      const overlayDir = legacySourceOverlayPath('omp', piHome)
-      mkdirSync(overlayDir, { recursive: true })
-      const walPath = join(overlayDir, 'agent.db-wal')
-      writeFileSync(join(overlayDir, 'agent.db'), 'legacy sqlite credentials')
-      writeFileSync(walPath, 'legacy sqlite wal')
-      chmodSync(walPath, 0o000)
+  it('retries a legacy SQLite migration as a whole set after sidecar copy failure', async () => {
+    const overlayDir = legacySourceOverlayPath('omp', piHome)
+    mkdirSync(overlayDir, { recursive: true })
+    const walPath = join(overlayDir, 'agent.db-wal')
+    writeFileSync(join(overlayDir, 'agent.db'), 'legacy sqlite credentials')
+    writeFileSync(walPath, 'legacy sqlite wal')
 
-      try {
-        const svc = new PiTitlebarExtensionService()
-        svc.buildPtyEnv('pty-omp-sidecar-fail-1', piHome, 'omp')
-
-        expect(existsSync(join(piHome, 'agent.db'))).toBe(false)
-        expect(existsSync(join(piHome, 'agent.db-wal'))).toBe(false)
-        expect(existsSync(join(overlayDir, '.orca-omp-overlay-migration-complete'))).toBe(false)
-
-        chmodSync(walPath, 0o600)
-        svc.buildPtyEnv('pty-omp-sidecar-fail-2', piHome, 'omp')
-
-        expect(readFileSync(join(piHome, 'agent.db'), 'utf-8')).toBe('legacy sqlite credentials')
-        expect(readFileSync(join(piHome, 'agent.db-wal'), 'utf-8')).toBe('legacy sqlite wal')
-        expect(
-          readFileSync(join(overlayDir, '.orca-omp-overlay-migration-complete'), 'utf-8')
-        ).toBe('complete\n')
-      } finally {
-        chmodSync(walPath, 0o600)
+    let failNextWalCopy = true
+    vi.resetModules()
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof fsModule>()
+      return {
+        ...actual,
+        cpSync: (
+          source: Parameters<typeof actual.cpSync>[0],
+          destination: Parameters<typeof actual.cpSync>[1],
+          options?: Parameters<typeof actual.cpSync>[2]
+        ) => {
+          if (String(source) === walPath && failNextWalCopy) {
+            failNextWalCopy = false
+            throw new Error('transient copy failure')
+          }
+          return actual.cpSync(source, destination, options)
+        }
       }
+    })
+
+    try {
+      const { migrateLegacyOmpOverlayState } = await import('./legacy-omp-overlay-migration')
+      migrateLegacyOmpOverlayState(piHome, overlayDir)
+
+      expect(existsSync(join(piHome, 'agent.db'))).toBe(false)
+      expect(existsSync(join(piHome, 'agent.db-wal'))).toBe(false)
+      expect(existsSync(join(overlayDir, '.orca-omp-overlay-migration-complete'))).toBe(false)
+
+      migrateLegacyOmpOverlayState(piHome, overlayDir)
+
+      expect(readFileSync(join(piHome, 'agent.db'), 'utf-8')).toBe('legacy sqlite credentials')
+      expect(readFileSync(join(piHome, 'agent.db-wal'), 'utf-8')).toBe('legacy sqlite wal')
+      expect(readFileSync(join(overlayDir, '.orca-omp-overlay-migration-complete'), 'utf-8')).toBe(
+        'complete\n'
+      )
+    } finally {
+      vi.doUnmock('node:fs')
+      vi.resetModules()
     }
-  )
+  })
 
   it('retries a legacy SQLite migration as a whole set after sidecar stat failure', async () => {
     const overlayDir = legacySourceOverlayPath('omp', piHome)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​31 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Two tests were failing on a clean checkout — not because anything was broken in Orca, but because the
tests themselves were out of date. One still expected behaviour the product deliberately changed; the
other tried to simulate an unreadable file by removing its permissions, which does nothing when the
Linux CI container runs as root. Failures like these are noise that hides real ones. This fixes both
tests; no product code changes.

## User-facing before / after

| | Before | After |
|---|---|---|
| Anything you do in the app | — | **No change.** No production code is touched |
| The CI shard these two tests live in | Failed on clean `main` — on macOS for one test and on Linux for the other — so a genuine failure landing there was easy to miss | Green, with both tests rewritten to check what the product actually does |

## When it bites

Nobody in the app. It bites contributors, who could not tell a real regression from these two stale
failures.


Author: @BrennanKB5

## Summary

- Correct the Pi login-shell test to model managed extension source metadata without treating it as a shell overlay, while proving an inherited user ZDOTDIR is preserved.
- Replace permission-bit fault injection in the legacy SQLite migration test with a deterministic one-shot WAL copy failure that works even when Linux CI runs as root.
- Keep production behavior unchanged; both failures were stale or non-portable test assumptions reproduced on clean main.

## Root-cause evidence

- pty-login-shell-startup-commands.test.ts failed both alone and in Node 24 shard 15/16 on macOS: expected the shell-ready ZDOTDIR wrapper, received undefined. Production intentionally no longer treats ORCA_PI_SOURCE_AGENT_DIR as an overlay after Pi moved to managed extension files; the corrected test proves source metadata alone does not force wrapping.
- titlebar-extension-service.test.ts failed both alone and in Node 24 shard 15/16 on Linux: expected agent.db not to exist, received true. chmod 000 did not make the WAL unreadable because the container runs as root; explicit cpSync fault injection now proves rollback, marker withholding, and successful whole-set retry.
- Neither failure is order-dependent.

## Verification

- macOS Node 24 focused: 38/38 passed, including an externally set ZDOTDIR regression run
- Linux Node 24 focused: 38/38 passed
- macOS Node 24 shard 15/16: 420 files passed, 4 skipped; 3,787 tests passed, 18 skipped
- Linux Node 24 shard 15/16: 419 files passed, 5 skipped; 3,779 tests passed, 26 skipped
- pnpm tc:node
- explicit-path oxfmt and oxlint
- changed-code quality, max-lines ratchet, and git diff --check
- same-model adversarial review: CLEAN
