### PR TITLE
Feat/orca canvas view and control room

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -94,6 +94,7 @@ export const FeatureInteractionIdParam = z.custom<FeatureInteractionId>(isFeatur
 })
 const TopLevelViewSchema = z.enum([
   'terminal',
+  'control-room',
   'settings',
   'tasks',
   'activity',

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -16,6 +16,7 @@ import { AppWorkspaceShell } from './app-shell/AppWorkspaceShell'
 import { WindowControls } from './app-shell/WindowControls'
 import {
   MAC_TRAFFIC_LIGHTS_WIDTH,
+  RIGHT_SIDEBAR_TOGGLE_WIDTH,
   WINDOW_CONTROLS_HEIGHT,
   WINDOW_CONTROLS_WIDTH,
   hasCustomTitleBar
@@ -58,6 +59,7 @@ function App(): React.JSX.Element {
     const root = document.documentElement.style
     root.setProperty('--window-controls-width', WINDOW_CONTROLS_WIDTH)
     root.setProperty('--window-controls-height', WINDOW_CONTROLS_HEIGHT)
+    root.setProperty('--right-sidebar-toggle-width', RIGHT_SIDEBAR_TOGGLE_WIDTH)
     root.setProperty('--mac-traffic-lights-width', MAC_TRAFFIC_LIGHTS_WIDTH)
   }, [])
 
@@ -84,6 +86,8 @@ function App(): React.JSX.Element {
           '--window-controls-width': WINDOW_CONTROLS_WIDTH,
           // Side-position activity bar uses this to push icons below the Windows/Linux window-controls overlay.
           '--window-controls-height': WINDOW_CONTROLS_HEIGHT,
+          // Shared by tab strips and Canvas so the floating right-sidebar toggle has one width contract.
+          '--right-sidebar-toggle-width': RIGHT_SIDEBAR_TOGGLE_WIDTH,
           // Full-bleed surfaces use this to keep the macOS traffic lights uncovered.
           '--mac-traffic-lights-width': MAC_TRAFFIC_LIGHTS_WIDTH
         } as React.CSSProperties

--- a/src/renderer/src/app-shell/app-window-chrome.ts
+++ b/src/renderer/src/app-shell/app-window-chrome.ts
@@ -16,6 +16,8 @@ export const hasCustomTitleBar = shouldRenderDesktopWindowChrome({
 // Surfaces offset by these instead of hardcoding the pixels.
 export const WINDOW_CONTROLS_WIDTH = hasCustomTitleBar ? '138px' : '0px'
 export const WINDOW_CONTROLS_HEIGHT = hasCustomTitleBar ? '36px' : '0px'
+// Why: workspace tab strips and Canvas both stop before the floating right-sidebar toggle.
+export const RIGHT_SIDEBAR_TOGGLE_WIDTH = '40px'
 
 // Why: macOS paints traffic lights on the window's top-left edge. Windows and Linux paint their
 // controls on the right, so only macOS needs a surface to keep the left edge uncovered.

--- a/src/renderer/src/app-shell/use-app-chrome-layout.ts
+++ b/src/renderer/src/app-shell/use-app-chrome-layout.ts
@@ -53,7 +53,8 @@ export function useAppChromeLayout() {
     [settings, systemPrefersDark]
   ) as React.CSSProperties | undefined
 
-  const canMountTerminalWorkbenchNow = activeWorktreeId !== null || backgroundTerminalMountRequested
+  const canMountTerminalWorkbenchNow =
+    activeView === 'control-room' || activeWorktreeId !== null || backgroundTerminalMountRequested
   // Why a latch in state, not a ref: the write has to be visible to the next render, and a
   // render-phase ref write would also survive a render React discards. Setting state during
   // render is the supported way to derive it, and the `||` below keeps this render correct.
@@ -70,7 +71,8 @@ export function useAppChromeLayout() {
     hasActivePendingCreation: activePendingCreationExists
   })
   const workspaceChromeActive =
-    activeView === 'terminal' && activeWorktreeId !== null && !creationLayoutActive
+    (activeView === 'terminal' && activeWorktreeId !== null && !creationLayoutActive) ||
+    activeView === 'control-room'
   const hasTabBar = tabCount >= 2
   // Activity/Space are full-page navigation surfaces (like Settings), so the worktree sidebar is hidden there.
   const showSidebar =
@@ -136,7 +138,11 @@ export function useAppChromeLayout() {
     // Full-page navigation surfaces own the whole content area, so suppress right-sidebar controls.
     showRightSidebarControls: !creationLayoutActive && canShowRightSidebarForView(activeView),
     showTitlebarAppName: settings?.showTitlebarAppName !== false,
-    showTitlebarExpandButton: workspaceChromeActive && !hasTabBar && effectiveActiveTabExpanded,
+    showTitlebarExpandButton:
+      activeView === 'terminal' &&
+      workspaceChromeActive &&
+      !hasTabBar &&
+      effectiveActiveTabExpanded,
     sidebarOpen,
     stackedSidebarOpen,
     // Why: the workbench stays mounted while hidden, so visibility tracks the same condition separately.

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -404,7 +404,7 @@ describe('renderer startup runtime routing', () => {
     expect(shellSource).toContain("const Terminal = lazy(() => import('../components/Terminal'))")
     expect(shellSource).not.toContain("from '../components/Terminal'")
     expect(layoutSource).toContain(
-      'const canMountTerminalWorkbenchNow = activeWorktreeId !== null || backgroundTerminalMountRequested'
+      "activeView === 'control-room' || activeWorktreeId !== null || backgroundTerminalMountRequested"
     )
     // Why pin the latch: once the workbench has mounted it must stay mounted, so hidden
     // terminal/browser/editor panes survive activeWorktreeId briefly going null.

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -913,6 +913,30 @@ html.native-shell .app-layout {
   -webkit-app-region: drag;
 }
 
+/* Keep Canvas toolbar actions clickable while the unused header surface retains
+   the same native window-drag behavior as Orca's ordinary tab strips. */
+[data-pane-canvas-toolbar-control='true'],
+[data-pane-canvas-toolbar-controls='true'] {
+  -webkit-app-region: no-drag;
+}
+
+/* Why: Windows/Linux caption buttons are a fixed overlay above the workspace.
+   Canvas replaces the ordinary tab strip and therefore must reserve the same
+   right-side width whenever it reaches the window edge. On macOS the shared
+   variable is 0px, so this preserves the native traffic-light layout. */
+.pane-canvas-toolbar-window-controls-inset {
+  padding-right: calc(0.5rem + var(--window-controls-width, 0px));
+}
+
+/* Project workspaces also expose the floating right-sidebar toggle immediately
+   before the caption buttons. Match the ordinary tab strip's 40px reservation
+   when that sidebar is closed; open sidebars own the edge and request no inset. */
+.pane-canvas-toolbar-window-controls-and-toggle-inset {
+  padding-right: calc(
+    0.5rem + var(--right-sidebar-toggle-width, 40px) + var(--window-controls-width, 0px)
+  );
+}
+
 /* Why: Electron drag regions swallow renderer pointer events. While regular
    xterm owns focus, make the next top-chrome click observable so it can release
    terminal zoom ownership; after release these surfaces become draggable again. */
@@ -951,7 +975,10 @@ html.native-shell .app-layout {
    the close button clears the minimize button. max(0px, ...) keeps this a no-op
    when the var is 0px and the subtraction would otherwise go negative. */
 .right-sidebar-header-side-inset {
-  padding-right: max(0px, calc(var(--window-controls-width, 0px) - 40px));
+  padding-right: max(
+    0px,
+    calc(var(--window-controls-width, 0px) - var(--right-sidebar-toggle-width, 40px))
+  );
 }
 
 .sidebar-toggle {

--- a/src/renderer/src/assets/terminal-scrollbar-style.test.ts
+++ b/src/renderer/src/assets/terminal-scrollbar-style.test.ts
@@ -14,4 +14,10 @@ describe('terminal scrollbar styling', () => {
     )
     expect(terminalCss).not.toContain('--xterm-scrollbar-thumb')
   })
+
+  it('keeps terminal wheel input from chaining into surrounding canvases', () => {
+    expect(terminalCss).toMatch(
+      /\.pane-manager-root \.xterm-viewport\s*{[^}]*overscroll-behavior:\s*contain/s
+    )
+  })
 })

--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -34,6 +34,9 @@
   /* Why: xterm/VS Code keep the scrollbar gutter stable. `auto` lets Linux
      DOM scrollbars appear/disappear, which can feed resize/reflow jitter. */
   overflow-y: scroll;
+  /* Why: reaching either end of terminal scrollback must not hand the same
+     wheel gesture to a surrounding Canvas viewport. */
+  overscroll-behavior: contain;
 }
 
 /* xterm.css hard-codes the viewport background to #000 (for opaque macOS

--- a/src/renderer/src/components/TerminalSplitWorkspaceSurfaces.tsx
+++ b/src/renderer/src/components/TerminalSplitWorkspaceSurfaces.tsx
@@ -1,4 +1,5 @@
 import { useAnyBrowserGuestNeedsPaint } from './browser-pane/host-guest/browser-guest-paint-retention'
+import ControlRoomTerminalCanvas from './control-room/ControlRoomTerminalCanvas'
 import { WorktreeSplitSurface } from './TerminalWorktreeSplitSurface'
 import type { TerminalController } from './use-terminal-controller'
 
@@ -14,10 +15,12 @@ export function TerminalSplitWorkspaceSurfaces({
     activityTerminalPortals,
     anyMountedWorktreeHasLayout,
     backgroundMountTabIdsByWorktreeRef,
+    controlRoomVisibility,
     effectiveActiveLayout,
     effectiveParkedTerminalWorktreeIds,
     forceParkedTerminalWorktreeIds,
     getEffectiveLayoutForWorktree,
+    handleControlRoomVisibilityChange,
     measurableBackgroundWorktreeIdsRef,
     mountedWorktreeIdsRef,
     renderedActiveWorktreeId,
@@ -27,19 +30,22 @@ export function TerminalSplitWorkspaceSurfaces({
   // remote controller needs each to drop `hidden` — the per-worktree surface hatch below cannot
   // override an ancestor that stopped compositing.
   const retainBrowserGuestPaint = useAnyBrowserGuestNeedsPaint(!effectiveActiveLayout)
-  if (!anyMountedWorktreeHasLayout) {
+  if (!anyMountedWorktreeHasLayout && activeView !== 'control-room') {
     return null
   }
   return (
     <div
       className={`relative flex flex-1 min-w-0 min-h-0 overflow-hidden${
-        effectiveActiveLayout
+        effectiveActiveLayout || activeView === 'control-room'
           ? ''
           : retainBrowserGuestPaint
             ? ' opacity-0 pointer-events-none'
             : ' hidden'
       }`}
     >
+      {activeView === 'control-room' ? (
+        <ControlRoomTerminalCanvas onTerminalVisibilityChange={handleControlRoomVisibilityChange} />
+      ) : null}
       {workspaceSurfaces
         .filter((workspace) => mountedWorktreeIdsRef.current.has(workspace.id))
         .map((workspace) => {
@@ -47,7 +53,12 @@ export function TerminalSplitWorkspaceSurfaces({
           if (!layout) {
             return null
           }
-          const isVisible = activeView === 'terminal' && workspace.id === renderedActiveWorktreeId
+          const isControlRoomVisible =
+            activeView === 'control-room' &&
+            controlRoomVisibility.terminalTabIdsByWorktree[workspace.id] !== undefined
+          const isVisible =
+            (activeView === 'terminal' && workspace.id === renderedActiveWorktreeId) ||
+            isControlRoomVisible
           const shouldMeasureHiddenWorktree =
             !isVisible && measurableBackgroundWorktreeIdsRef.current.has(workspace.id)
           const shouldColdParkTerminalPanes =
@@ -62,15 +73,28 @@ export function TerminalSplitWorkspaceSurfaces({
               layout={layout}
               focusedGroupId={activeGroupIdByWorktree[workspace.id]}
               isVisible={isVisible}
+              isControlRoomVisible={isControlRoomVisible}
+              controlRoomTerminalTabIds={
+                controlRoomVisibility.terminalTabIdsByWorktree[workspace.id] ?? null
+              }
+              controlRoomVisibleTerminalTabIds={
+                controlRoomVisibility.visibleTerminalTabIdsByWorktree[workspace.id] ?? null
+              }
               shouldMeasureHiddenWorktree={shouldMeasureHiddenWorktree}
               shouldColdParkTerminalPanes={shouldColdParkTerminalPanes}
-              isForceParked={forceParkedTerminalWorktreeIds.has(workspace.id)}
+              isForceParked={
+                !isControlRoomVisible && forceParkedTerminalWorktreeIds.has(workspace.id)
+              }
               activityTerminalPortals={activityTerminalPortals}
               backgroundMountTabIds={
-                backgroundMountTabIdsByWorktreeRef.current.get(workspace.id) ?? null
+                isControlRoomVisible
+                  ? null
+                  : (backgroundMountTabIdsByWorktreeRef.current.get(workspace.id) ?? null)
               }
               activationDeferredMountTabIds={
-                activationDeferredMountTabIdsByWorktreeRef.current.get(workspace.id) ?? null
+                isControlRoomVisible
+                  ? null
+                  : (activationDeferredMountTabIdsByWorktreeRef.current.get(workspace.id) ?? null)
               }
             />
           )

--- a/src/renderer/src/components/TerminalSurface.tsx
+++ b/src/renderer/src/components/TerminalSurface.tsx
@@ -11,14 +11,14 @@ export function TerminalSurface({
 }: {
   controller: TerminalController
 }): React.JSX.Element {
-  const { renderedActiveWorktreeId } = controller
+  const { activeView, renderedActiveWorktreeId } = controller
   const retainBrowserGuestPaint = useAnyBrowserGuestNeedsPaint(!renderedActiveWorktreeId)
   return (
     <div
       // Why: already out of flow via the workbench container when hidden, so retention only
       // has to drop `hidden` — it does not need to leave the flex column a second time.
       className={`flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden${
-        renderedActiveWorktreeId
+        renderedActiveWorktreeId || activeView === 'control-room'
           ? ''
           : retainBrowserGuestPaint
             ? ' opacity-0 pointer-events-none'

--- a/src/renderer/src/components/TerminalWorktreeSplitSurface.tsx
+++ b/src/renderer/src/components/TerminalWorktreeSplitSurface.tsx
@@ -1,5 +1,9 @@
-import React from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import type { TabGroupLayoutNode } from '../../../shared/tab-types'
+import { resolveCanvasTerminalLabel } from '../../../shared/tab-title-resolution'
+import { getResolvedExecutionHostIdForWorktree } from '@/lib/resolved-worktree-execution-host'
+import { useAppStore } from '../store'
+import { dedupeTabOrder } from '../store/slices/tab-group-state'
 import type { ActivityTerminalPortalTarget } from './activity/activity-terminal-portal'
 import {
   useBrowserGuestPaintRetention,
@@ -10,6 +14,10 @@ import {
   shouldMountRetainedBrowserOverlay
 } from './browser-pane/host-guest/browser-worktree-surface-paintability'
 import TabGroupSplitLayout from './tab-group/TabGroupSplitLayout'
+import TabGroupCanvasLayout from './tab-group/TabGroupCanvasLayout'
+import type { CanvasTerminalItem } from './tab-group/CanvasTerminalCard'
+import { collectPaneCanvasGroupIds } from './tab-group/pane-canvas-layout-state'
+import { usePaneCanvasWorkspaceState } from './tab-group/use-pane-canvas-workspace-state'
 import TerminalPaneOverlayLayer from './terminal-pane/TerminalPaneOverlayLayer'
 import { RetainedBrowserPaneOverlayLayer } from './browser-pane/assemble-chrome/BrowserPaneOverlayLayer'
 import EmulatorPaneOverlayLayer from './emulator-pane/EmulatorPaneOverlayLayer'
@@ -22,6 +30,9 @@ export const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   layout,
   focusedGroupId,
   isVisible,
+  isControlRoomVisible,
+  controlRoomTerminalTabIds,
+  controlRoomVisibleTerminalTabIds,
   shouldMeasureHiddenWorktree,
   shouldColdParkTerminalPanes,
   isForceParked,
@@ -34,6 +45,9 @@ export const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   layout: TabGroupLayoutNode
   focusedGroupId?: string
   isVisible: boolean
+  isControlRoomVisible: boolean
+  controlRoomTerminalTabIds: ReadonlySet<string> | null
+  controlRoomVisibleTerminalTabIds: ReadonlySet<string> | null
   shouldMeasureHiddenWorktree: boolean
   shouldColdParkTerminalPanes: boolean
   isForceParked: boolean
@@ -43,6 +57,117 @@ export const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
 }): React.JSX.Element {
   const browserPageIds = useWorktreeBrowserPageIds(worktreeId)
   const needsBrowserGuestPaint = useBrowserGuestPaintRetention(browserPageIds)
+  const executionHostId = useAppStore((state) =>
+    getResolvedExecutionHostIdForWorktree(state, worktreeId)
+  )
+  const isSelectedWorktree = useAppStore((state) => state.activeWorktreeId === worktreeId)
+  const rightSidebarOpen = useAppStore((state) => state.rightSidebarOpen)
+  const canvasGroupIds = useMemo(() => collectPaneCanvasGroupIds(layout), [layout])
+  const canvasGroups = useAppStore((state) => state.groupsByWorktree[worktreeId])
+  const canvasUnifiedTabs = useAppStore((state) => state.unifiedTabsByWorktree[worktreeId])
+  const canvasTerminalTabs = useAppStore((state) => state.tabsByWorktree[worktreeId])
+  const generatedTabTitlesEnabled = useAppStore(
+    (state) => state.settings?.tabAutoGenerateTitle === true
+  )
+  const canvasActiveTabType = useAppStore(
+    (state) =>
+      state.activeTabTypeByWorktree[worktreeId] ??
+      (state.activeWorktreeId === worktreeId ? state.activeTabType : 'terminal')
+  )
+  const canvasTerminalItems = useMemo<CanvasTerminalItem[]>(() => {
+    const groupsById = new Map((canvasGroups ?? []).map((group) => [group.id, group]))
+    const unifiedById = new Map((canvasUnifiedTabs ?? []).map((tab) => [tab.id, tab]))
+    const unifiedIdsByGroup = new Map<string, string[]>()
+    for (const tab of canvasUnifiedTabs ?? []) {
+      const groupIds = unifiedIdsByGroup.get(tab.groupId) ?? []
+      groupIds.push(tab.id)
+      unifiedIdsByGroup.set(tab.groupId, groupIds)
+    }
+    const terminalById = new Map((canvasTerminalTabs ?? []).map((tab) => [tab.id, tab]))
+    const items: CanvasTerminalItem[] = []
+    for (const groupId of canvasGroupIds) {
+      const group = groupsById.get(groupId)
+      if (!group) {
+        continue
+      }
+      const orderedIds = dedupeTabOrder([
+        ...group.tabOrder.filter((tabId) => unifiedById.get(tabId)?.groupId === groupId),
+        ...(unifiedIdsByGroup.get(groupId) ?? [])
+      ])
+      for (const unifiedTabId of orderedIds) {
+        const tab = unifiedById.get(unifiedTabId)
+        if (!tab || tab.contentType !== 'terminal') {
+          continue
+        }
+        const terminal = terminalById.get(tab.entityId)
+        if (!terminal) {
+          continue
+        }
+        items.push({
+          terminalTabId: terminal.id,
+          unifiedTabId: tab.id,
+          groupId,
+          label: resolveCanvasTerminalLabel(tab, terminal, generatedTabTitlesEnabled),
+          color: tab.color ?? terminal.color
+        })
+      }
+    }
+    return items
+  }, [
+    canvasGroupIds,
+    canvasGroups,
+    canvasTerminalTabs,
+    canvasUnifiedTabs,
+    generatedTabTitlesEnabled
+  ])
+  const canvasTerminalTabIds = useMemo(
+    () => canvasTerminalItems.map((item) => item.terminalTabId),
+    [canvasTerminalItems]
+  )
+  const canvasTerminalTabIdSet = useMemo(
+    () => new Set(canvasTerminalTabIds),
+    [canvasTerminalTabIds]
+  )
+  const [visibleCanvasTerminalTabIds, setVisibleCanvasTerminalTabIds] =
+    useState<ReadonlySet<string> | null>(null)
+  const handleVisibleCanvasTerminalTabIdsChange = useCallback((next: ReadonlySet<string>) => {
+    setVisibleCanvasTerminalTabIds((current) => {
+      if (
+        current &&
+        current.size === next.size &&
+        Array.from(current).every((id) => next.has(id))
+      ) {
+        return current
+      }
+      return next
+    })
+  }, [])
+  const focusedTerminalTabId = useMemo(() => {
+    if (!focusedGroupId) {
+      return undefined
+    }
+    const group = canvasGroups?.find((candidate) => candidate.id === focusedGroupId)
+    if (!group?.activeTabId) {
+      return undefined
+    }
+    return canvasTerminalItems.find((item) => item.unifiedTabId === group.activeTabId)
+      ?.terminalTabId
+  }, [canvasGroups, canvasTerminalItems, focusedGroupId])
+  const { canvasState, updateCanvasState } = usePaneCanvasWorkspaceState({
+    ownerKey: `${executionHostId ?? 'unresolved'}:${worktreeId}`,
+    terminalTabIds: canvasTerminalTabIds
+  })
+  useEffect(() => {
+    if (
+      !isControlRoomVisible &&
+      canvasState.mode === 'canvas' &&
+      canvasActiveTabType !== 'terminal'
+    ) {
+      // Canvas presents terminal sessions only. Reveal the split surface when
+      // an editor, browser, simulator, or structured agent session becomes active.
+      updateCanvasState((current) => ({ ...current, mode: 'split' }))
+    }
+  }, [canvasActiveTabType, canvasState.mode, isControlRoomVisible, updateCanvasState])
   const shouldKeepPaintable = shouldKeepHiddenWorktreeSurfacePaintable({
     shouldMeasureHiddenWorktree,
     needsBrowserGuestPaint
@@ -51,49 +176,91 @@ export const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   return (
     <div
       className={
-        isVisible
-          ? 'absolute inset-0 flex'
-          : shouldKeepPaintable
-            ? 'absolute inset-0 flex opacity-0 pointer-events-none'
-            : 'absolute inset-0 hidden'
+        isControlRoomVisible
+          ? 'absolute inset-0 pointer-events-none'
+          : isVisible
+            ? 'absolute inset-0 flex'
+            : shouldKeepPaintable
+              ? 'absolute inset-0 flex opacity-0 pointer-events-none'
+              : 'absolute inset-0 hidden'
       }
       inert={!isVisible}
       aria-hidden={!isVisible}
     >
-      <TabGroupSplitLayout
-        layout={layout}
-        worktreeId={worktreeId}
-        focusedGroupId={focusedGroupId}
-        isWorktreeActive={isVisible}
-      />
+      {isControlRoomVisible ? null : canvasState.mode === 'canvas' ? (
+        <TabGroupCanvasLayout
+          terminalItems={canvasTerminalItems}
+          worktreeId={worktreeId}
+          focusedTerminalTabId={focusedTerminalTabId}
+          canvasState={canvasState}
+          updateCanvasState={updateCanvasState}
+          onVisibleTerminalTabIdsChange={handleVisibleCanvasTerminalTabIdsChange}
+          trailingChromeInset={rightSidebarOpen ? 'none' : 'window-controls-and-sidebar-toggle'}
+        />
+      ) : (
+        <TabGroupSplitLayout
+          layout={layout}
+          worktreeId={worktreeId}
+          focusedGroupId={focusedGroupId}
+          isWorktreeActive={isVisible}
+          onOpenCanvas={() => {
+            setVisibleCanvasTerminalTabIds(null)
+            updateCanvasState((current) => ({ ...current, mode: 'canvas' }))
+          }}
+        />
+      )}
       <TerminalPaneOverlayLayer
         worktreeId={worktreeId}
         worktreePath={worktreePath}
         isWorktreeActive={isVisible}
+        executionHostId={executionHostId ?? undefined}
+        terminalSelectionActive={!isControlRoomVisible || isSelectedWorktree}
         coldParkTerminalPanes={shouldColdParkTerminalPanes}
         isForceParked={isForceParked}
         shouldMeasureHiddenWorktree={shouldMeasureHiddenWorktree}
+        roundBottomCorners={isControlRoomVisible || canvasState.mode === 'canvas'}
+        canvasTerminalTabIds={
+          isControlRoomVisible
+            ? controlRoomTerminalTabIds
+            : canvasState.mode === 'canvas'
+              ? canvasTerminalTabIdSet
+              : null
+        }
+        visibleCanvasTerminalTabIds={
+          isControlRoomVisible
+            ? controlRoomVisibleTerminalTabIds
+            : canvasState.mode === 'canvas'
+              ? visibleCanvasTerminalTabIds
+              : null
+        }
+        forceCanvasFallbackPositioning={isControlRoomVisible}
         activityTerminalPortals={activityTerminalPortals}
         backgroundMountTabIds={backgroundMountTabIds}
         activationDeferredMountTabIds={activationDeferredMountTabIds}
       />
       <RetainedBrowserPaneOverlayLayer
         worktreeId={worktreeId}
-        isWorktreeActive={isVisible}
+        isWorktreeActive={isVisible && !isControlRoomVisible && canvasState.mode === 'split'}
         mountEligible={shouldMountRetainedBrowserOverlay({
-          isWorktreeVisible: isVisible,
+          isWorktreeVisible: isVisible && !isControlRoomVisible,
           hasDeferredBackgroundMounts: backgroundMountTabIds !== null,
           needsBrowserGuestPaint
         })}
       />
-      {isVisible || backgroundMountTabIds === null ? (
-        <EmulatorPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
+      {!isControlRoomVisible && (isVisible || backgroundMountTabIds === null) ? (
+        <EmulatorPaneOverlayLayer
+          worktreeId={worktreeId}
+          isWorktreeActive={isVisible && canvasState.mode === 'split'}
+        />
       ) : null}
       <StructuredAgentSessionPaneOverlayLayer
         worktreeId={worktreeId}
-        isWorktreeActive={isVisible}
+        isWorktreeActive={isVisible && !isControlRoomVisible && canvasState.mode === 'split'}
       />
-      <AiVaultSessionDropLayer worktreeId={worktreeId} enabled={isVisible} />
+      <AiVaultSessionDropLayer
+        worktreeId={worktreeId}
+        enabled={isVisible && !isControlRoomVisible}
+      />
     </div>
   )
 })

--- a/src/renderer/src/components/control-room/ControlRoomTerminalCanvas.test.tsx
+++ b/src/renderer/src/components/control-room/ControlRoomTerminalCanvas.test.tsx
@@ -298,4 +298,24 @@ describe('ControlRoomTerminalCanvas', () => {
       terminalTabId: 'shell-b'
     })
   })
+
+  it('restores pinned agents after the Control Room remounts', async () => {
+    const renderControlRoom = (): void => {
+      root.render(<ControlRoomTerminalCanvas onTerminalVisibilityChange={() => undefined} />)
+    }
+
+    await act(async () => renderControlRoom())
+    const pinLast = container.querySelector('[aria-label="Pin last terminal"]') as HTMLButtonElement
+    await act(async () => pinLast.click())
+
+    await act(async () => root.render(null))
+    await act(async () => renderControlRoom())
+    const pinned = container.querySelector('[aria-label="Pinned"]') as HTMLButtonElement
+    await act(async () => pinned.click())
+
+    expect(container.querySelector('[data-testid="terminal-labels"]')?.textContent).toBe('Agent A')
+    expect(mocks.canvasProps?.terminalItems).toEqual([
+      expect.objectContaining({ terminalTabId: 'agent-a', pinned: true })
+    ])
+  })
 })

--- a/src/renderer/src/components/control-room/ControlRoomTerminalCanvas.test.tsx
+++ b/src/renderer/src/components/control-room/ControlRoomTerminalCanvas.test.tsx
@@ -1,0 +1,301 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DashboardSnapshot } from '../../../../shared/dashboard-snapshot'
+import type { Tab } from '../../../../shared/tab-types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import type { CanvasTerminalItem } from '../tab-group/CanvasTerminalCard'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const mocks = vi.hoisted(() => ({
+  snapshot: null as DashboardSnapshot | null,
+  storeState: null as Record<string, unknown> | null,
+  canvasProps: null as Record<string, unknown> | null,
+  workspaceStateInput: null as Record<string, unknown> | null,
+  activateCanvasTerminal: vi.fn()
+}))
+
+vi.mock('../dashboard/useLiveDashboardSnapshot', () => ({
+  useLiveDashboardSnapshot: () => mocks.snapshot
+}))
+
+vi.mock('@/store', () => {
+  const useAppStore = (selector: (state: Record<string, unknown>) => unknown): unknown =>
+    selector(mocks.storeState ?? {})
+  useAppStore.getState = (): Record<string, unknown> => mocks.storeState ?? {}
+  return { useAppStore }
+})
+
+vi.mock('../tab-group/activate-canvas-terminal', () => ({
+  activateCanvasTerminal: mocks.activateCanvasTerminal
+}))
+
+vi.mock('@/lib/focus-terminal-tab-surface', () => ({
+  focusTerminalTabSurface: vi.fn()
+}))
+
+vi.mock('../tab-group/use-pane-canvas-workspace-state', () => ({
+  usePaneCanvasWorkspaceState: (input: Record<string, unknown>) => {
+    mocks.workspaceStateInput = input
+    return {
+      canvasState: {
+        mode: 'canvas',
+        boundsByTerminalTabId: {}
+      },
+      updateCanvasState: vi.fn()
+    }
+  }
+}))
+
+vi.mock('../tab-group/TabGroupCanvasLayout', () => ({
+  default: (props: Record<string, unknown>) => {
+    mocks.canvasProps = props
+    const items = props.terminalItems as CanvasTerminalItem[]
+    const onVisible = props.onVisibleTerminalTabIdsChange as (
+      terminalTabIds: ReadonlySet<string>
+    ) => void
+    const onTogglePinned = props.onTogglePinned as (item: CanvasTerminalItem) => void
+    const onActivateItem = props.onActivateItem as (item: CanvasTerminalItem) => void
+    return (
+      <div>
+        {props.toolbarContent as React.ReactNode}
+        <span data-testid="terminal-labels">{items.map((item) => item.label).join('|')}</span>
+        <button
+          type="button"
+          aria-label="Publish visible terminals"
+          onClick={() => onVisible(new Set(items.map((item) => item.terminalTabId)))}
+        />
+        <button
+          type="button"
+          aria-label="Pin last terminal"
+          onClick={() => items.at(-1) && onTogglePinned(items.at(-1)!)}
+        />
+        <button
+          type="button"
+          aria-label="Activate first terminal"
+          onClick={() => items[0] && onActivateItem(items[0])}
+        />
+      </div>
+    )
+  }
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+import ControlRoomTerminalCanvas, {
+  type ControlRoomTerminalVisibility
+} from './ControlRoomTerminalCanvas'
+
+function unifiedTab(worktreeId: string, terminalTabId: string, label: string, order: number): Tab {
+  return {
+    id: `unified-${terminalTabId}`,
+    entityId: terminalTabId,
+    groupId: `group-${worktreeId}`,
+    worktreeId,
+    contentType: 'terminal',
+    label,
+    customLabel: null,
+    color: null,
+    sortOrder: order,
+    createdAt: order
+  }
+}
+
+function terminalTab(worktreeId: string, id: string, title: string, order: number): TerminalTab {
+  return {
+    id,
+    ptyId: `pty-${id}`,
+    worktreeId,
+    title,
+    customTitle: null,
+    color: null,
+    sortOrder: order,
+    createdAt: order
+  }
+}
+
+describe('ControlRoomTerminalCanvas', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    localStorage.clear()
+    mocks.activateCanvasTerminal.mockClear()
+    mocks.canvasProps = null
+    mocks.workspaceStateInput = null
+    mocks.snapshot = {
+      generatedAt: 1,
+      cards: [
+        {
+          paneKey: 'agent-a:leaf',
+          ptyId: 'pty-agent-a',
+          agentType: 'codex',
+          bucket: 'working',
+          dotState: 'working',
+          task: 'Agent A',
+          repoId: 'repo-a',
+          worktreeId: 'worktree-a',
+          tabId: 'agent-a',
+          leafId: 'leaf',
+          repoName: 'Alpha',
+          worktreeName: 'Alpha',
+          startedAt: 1,
+          finishedAt: null,
+          stateChangedAt: 1,
+          unseen: false
+        },
+        {
+          paneKey: 'agent-b:leaf',
+          ptyId: 'pty-agent-b',
+          agentType: 'claude',
+          bucket: 'attention',
+          dotState: 'waiting',
+          task: 'Agent B',
+          repoId: 'repo-b',
+          worktreeId: 'worktree-b',
+          tabId: 'agent-b',
+          leafId: 'leaf',
+          repoName: 'Beta',
+          worktreeName: 'Beta',
+          startedAt: 2,
+          finishedAt: null,
+          stateChangedAt: 2,
+          unseen: true
+        }
+      ],
+      workspaces: [
+        {
+          repoId: 'repo-a',
+          worktreeId: 'worktree-a',
+          repoName: 'Alpha',
+          worktreeName: 'Alpha',
+          hostKind: 'local',
+          executionHostId: 'local',
+          workspaceKind: 'worktree'
+        },
+        {
+          repoId: 'repo-b',
+          worktreeId: 'worktree-b',
+          repoName: 'Beta',
+          worktreeName: 'Beta',
+          hostKind: 'local',
+          executionHostId: 'local',
+          workspaceKind: 'worktree'
+        }
+      ]
+    }
+    const setActiveWorktree = vi.fn()
+    mocks.storeState = {
+      unifiedTabsByWorktree: {
+        'worktree-a': [unifiedTab('worktree-a', 'agent-a', 'Agent A', 1)],
+        'worktree-b': [
+          unifiedTab('worktree-b', 'agent-b', 'Agent B', 1),
+          unifiedTab('worktree-b', 'shell-b', 'Shell B', 2)
+        ]
+      },
+      tabsByWorktree: {
+        'worktree-a': [terminalTab('worktree-a', 'agent-a', 'Agent A', 1)],
+        'worktree-b': [
+          terminalTab('worktree-b', 'agent-b', 'Agent B', 1),
+          terminalTab('worktree-b', 'shell-b', 'Shell B', 2)
+        ]
+      },
+      ptyIdsByTabId: {
+        'agent-a': ['pty-agent-a'],
+        'agent-b': ['pty-agent-b'],
+        'shell-b': ['pty-shell-b']
+      },
+      settings: { tabAutoGenerateTitle: false },
+      activeWorktreeId: null,
+      activeTabId: null,
+      terminalLayoutsByTabId: {},
+      setActiveWorktree
+    }
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    localStorage.clear()
+  })
+
+  it('coordinates live sessions across worktrees without discarding dormant geometry', async () => {
+    const visibilityChanges: ControlRoomTerminalVisibility[] = []
+    await act(async () => {
+      root.render(
+        <ControlRoomTerminalCanvas
+          onTerminalVisibilityChange={(visibility) => visibilityChanges.push(visibility)}
+        />
+      )
+    })
+
+    expect(mocks.workspaceStateInput).toMatchObject({
+      ownerKey: 'control-room:active',
+      terminalTabIds: ['agent-b', 'agent-a'],
+      preserveMissingBounds: true
+    })
+    expect(container.querySelector('[data-testid="terminal-labels"]')?.textContent).toBe(
+      'Agent B|Agent A'
+    )
+    expect(visibilityChanges.at(-1)?.terminalTabIdsByWorktree).toEqual({
+      'worktree-b': new Set(['agent-b']),
+      'worktree-a': new Set(['agent-a'])
+    })
+
+    const publishVisible = container.querySelector(
+      '[aria-label="Publish visible terminals"]'
+    ) as HTMLButtonElement
+    await act(async () => publishVisible.click())
+    expect(visibilityChanges.at(-1)?.visibleTerminalTabIdsByWorktree).toEqual({
+      'worktree-b': new Set(['agent-b']),
+      'worktree-a': new Set(['agent-a'])
+    })
+
+    const allSessions = container.querySelector(
+      '[aria-label="All live sessions"]'
+    ) as HTMLButtonElement
+    await act(async () => allSessions.click())
+    expect(mocks.workspaceStateInput).toMatchObject({
+      ownerKey: 'control-room:all',
+      preserveMissingBounds: true
+    })
+    expect(container.querySelector('[data-testid="terminal-labels"]')?.textContent).toContain(
+      'Shell B'
+    )
+
+    const pinLast = container.querySelector('[aria-label="Pin last terminal"]') as HTMLButtonElement
+    await act(async () => pinLast.click())
+    const pinned = container.querySelector('[aria-label="Pinned"]') as HTMLButtonElement
+    await act(async () => pinned.click())
+    expect(mocks.workspaceStateInput).toMatchObject({
+      ownerKey: 'control-room:pinned',
+      terminalTabIds: ['shell-b'],
+      preserveMissingBounds: true
+    })
+
+    const activate = container.querySelector(
+      '[aria-label="Activate first terminal"]'
+    ) as HTMLButtonElement
+    await act(async () => activate.click())
+    expect(mocks.storeState?.setActiveWorktree as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+      'worktree-b',
+      'local'
+    )
+    expect(mocks.activateCanvasTerminal).toHaveBeenCalledWith({
+      worktreeId: 'worktree-b',
+      groupId: 'group-worktree-b',
+      unifiedTabId: 'unified-shell-b',
+      terminalTabId: 'shell-b'
+    })
+  })
+})

--- a/src/renderer/src/components/control-room/ControlRoomTerminalCanvas.tsx
+++ b/src/renderer/src/components/control-room/ControlRoomTerminalCanvas.tsx
@@ -118,17 +118,19 @@ export default function ControlRoomTerminalCanvas({
 
   const setPreferences = useCallback(
     (updater: (current: ControlRoomPreferences) => ControlRoomPreferences) => {
-      setPreferencesState((current) => {
-        const next = updater(current)
-        const storage = browserStorage()
-        if (storage) {
-          writeControlRoomPreferences(storage, next)
-        }
-        return next
-      })
+      setPreferencesState(updater)
     },
     []
   )
+
+  useEffect(() => {
+    const storage = browserStorage()
+    if (storage) {
+      // Persist after React commits the preference change. Keeping this write
+      // outside the state updater also survives remounts and concurrent renders.
+      writeControlRoomPreferences(storage, preferences)
+    }
+  }, [preferences])
 
   const setScope = useCallback(
     (scope: ControlRoomScope) => setPreferences((current) => ({ ...current, scope })),

--- a/src/renderer/src/components/control-room/ControlRoomTerminalCanvas.tsx
+++ b/src/renderer/src/components/control-room/ControlRoomTerminalCanvas.tsx
@@ -1,0 +1,301 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Bot, Pin, SquareTerminal } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
+import { useAppStore } from '@/store'
+import { useLiveDashboardSnapshot } from '../dashboard/useLiveDashboardSnapshot'
+import { activateCanvasTerminal } from '../tab-group/activate-canvas-terminal'
+import type { CanvasTerminalItem } from '../tab-group/CanvasTerminalCard'
+import TabGroupCanvasLayout from '../tab-group/TabGroupCanvasLayout'
+import { usePaneCanvasWorkspaceState } from '../tab-group/use-pane-canvas-workspace-state'
+import {
+  DEFAULT_CONTROL_ROOM_PREFERENCES,
+  readControlRoomPreferences,
+  writeControlRoomPreferences,
+  type ControlRoomPreferences,
+  type ControlRoomScope
+} from './control-room-preferences'
+import { buildControlRoomTerminalItems } from './control-room-terminal-items'
+
+export type ControlRoomTerminalVisibility = {
+  terminalTabIdsByWorktree: Readonly<Record<string, ReadonlySet<string>>>
+  visibleTerminalTabIdsByWorktree: Readonly<Record<string, ReadonlySet<string>>>
+}
+
+function browserStorage(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null
+  } catch {
+    return null
+  }
+}
+
+function idsByWorktree(
+  items: readonly CanvasTerminalItem[],
+  includedTerminalTabIds?: ReadonlySet<string>
+): Record<string, ReadonlySet<string>> {
+  const mutable = new Map<string, Set<string>>()
+  for (const item of items) {
+    if (
+      !item.worktreeId ||
+      (includedTerminalTabIds && !includedTerminalTabIds.has(item.terminalTabId))
+    ) {
+      continue
+    }
+    const ids = mutable.get(item.worktreeId) ?? new Set<string>()
+    ids.add(item.terminalTabId)
+    mutable.set(item.worktreeId, ids)
+  }
+  return Object.fromEntries(mutable)
+}
+
+function haveSameIds(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  return left.size === right.size && Array.from(left).every((id) => right.has(id))
+}
+
+export default function ControlRoomTerminalCanvas({
+  onTerminalVisibilityChange
+}: {
+  onTerminalVisibilityChange: (visibility: ControlRoomTerminalVisibility) => void
+}): React.JSX.Element {
+  const snapshot = useLiveDashboardSnapshot()
+  const unifiedTabsByWorktree = useAppStore((state) => state.unifiedTabsByWorktree)
+  const terminalTabsByWorktree = useAppStore((state) => state.tabsByWorktree)
+  const ptyIdsByTabId = useAppStore((state) => state.ptyIdsByTabId)
+  const generatedTabTitlesEnabled = useAppStore(
+    (state) => state.settings?.tabAutoGenerateTitle === true
+  )
+  const activeWorktreeId = useAppStore((state) => state.activeWorktreeId)
+  const activeTabId = useAppStore((state) => state.activeTabId)
+  const [preferences, setPreferencesState] = useState<ControlRoomPreferences>(() => {
+    const storage = browserStorage()
+    return storage ? readControlRoomPreferences(storage) : DEFAULT_CONTROL_ROOM_PREFERENCES
+  })
+  const pinnedSessionKeys = useMemo(
+    () => new Set(preferences.pinnedSessionKeys),
+    [preferences.pinnedSessionKeys]
+  )
+  const terminalItems = useMemo(
+    () =>
+      buildControlRoomTerminalItems({
+        cards: snapshot.cards,
+        workspaces: snapshot.workspaces,
+        unifiedTabsByWorktree,
+        terminalTabsByWorktree,
+        ptyIdsByTabId,
+        generatedTabTitlesEnabled,
+        pinnedSessionKeys,
+        scope: preferences.scope
+      }),
+    [
+      generatedTabTitlesEnabled,
+      pinnedSessionKeys,
+      preferences.scope,
+      ptyIdsByTabId,
+      snapshot.cards,
+      snapshot.workspaces,
+      terminalTabsByWorktree,
+      unifiedTabsByWorktree
+    ]
+  )
+  const terminalTabIds = useMemo(
+    () => terminalItems.map((item) => item.terminalTabId),
+    [terminalItems]
+  )
+  const [visibleTerminalTabIds, setVisibleTerminalTabIds] = useState<ReadonlySet<string>>(
+    () => new Set()
+  )
+  const handleVisibleTerminalTabIdsChange = useCallback((next: ReadonlySet<string>) => {
+    setVisibleTerminalTabIds((current) => (haveSameIds(current, next) ? current : next))
+  }, [])
+  const { canvasState, updateCanvasState } = usePaneCanvasWorkspaceState({
+    ownerKey: `control-room:${preferences.scope}`,
+    terminalTabIds,
+    preserveMissingBounds: true
+  })
+
+  const setPreferences = useCallback(
+    (updater: (current: ControlRoomPreferences) => ControlRoomPreferences) => {
+      setPreferencesState((current) => {
+        const next = updater(current)
+        const storage = browserStorage()
+        if (storage) {
+          writeControlRoomPreferences(storage, next)
+        }
+        return next
+      })
+    },
+    []
+  )
+
+  const setScope = useCallback(
+    (scope: ControlRoomScope) => setPreferences((current) => ({ ...current, scope })),
+    [setPreferences]
+  )
+
+  const togglePinned = useCallback(
+    (item: CanvasTerminalItem) => {
+      if (!item.sessionKey) {
+        return
+      }
+      setPreferences((current) => {
+        const pins = new Set(current.pinnedSessionKeys)
+        if (pins.has(item.sessionKey!)) {
+          pins.delete(item.sessionKey!)
+        } else {
+          pins.add(item.sessionKey!)
+        }
+        return { ...current, pinnedSessionKeys: Array.from(pins) }
+      })
+    },
+    [setPreferences]
+  )
+
+  const activateTerminal = useCallback((item: CanvasTerminalItem) => {
+    if (!item.worktreeId) {
+      return
+    }
+    const store = useAppStore.getState()
+    if (store.activeWorktreeId !== item.worktreeId) {
+      store.setActiveWorktree(item.worktreeId, item.executionHostId)
+    }
+    activateCanvasTerminal({
+      worktreeId: item.worktreeId,
+      groupId: item.groupId,
+      unifiedTabId: item.unifiedTabId,
+      terminalTabId: item.terminalTabId
+    })
+    const activeLeafId = store.terminalLayoutsByTabId[item.terminalTabId]?.activeLeafId ?? null
+    requestAnimationFrame(() => focusTerminalTabSurface(item.terminalTabId, activeLeafId))
+  }, [])
+
+  useEffect(() => {
+    const selected = idsByWorktree(terminalItems)
+    const visible = idsByWorktree(terminalItems, visibleTerminalTabIds)
+    onTerminalVisibilityChange({
+      terminalTabIdsByWorktree: selected,
+      visibleTerminalTabIdsByWorktree: visible
+    })
+  }, [onTerminalVisibilityChange, terminalItems, visibleTerminalTabIds])
+
+  useEffect(
+    () => () =>
+      onTerminalVisibilityChange({
+        terminalTabIdsByWorktree: {},
+        visibleTerminalTabIdsByWorktree: {}
+      }),
+    [onTerminalVisibilityChange]
+  )
+
+  const focusedTerminalTabId = terminalItems.some(
+    (item) => item.worktreeId === activeWorktreeId && item.terminalTabId === activeTabId
+  )
+    ? (activeTabId ?? undefined)
+    : undefined
+
+  const scopeButton = (
+    scope: ControlRoomScope,
+    label: string,
+    icon: React.JSX.Element
+  ): React.JSX.Element => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          size="icon-xs"
+          variant={preferences.scope === scope ? 'secondary' : 'ghost'}
+          aria-label={label}
+          aria-pressed={preferences.scope === scope}
+          onClick={() => setScope(scope)}
+        >
+          {icon}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
+  )
+
+  return (
+    <TabGroupCanvasLayout
+      terminalItems={terminalItems}
+      focusedTerminalTabId={focusedTerminalTabId}
+      canvasState={canvasState}
+      updateCanvasState={updateCanvasState}
+      onVisibleTerminalTabIdsChange={handleVisibleTerminalTabIdsChange}
+      title={translate(
+        'auto.components.control.room.ControlRoomTerminalCanvas.title',
+        'Control Room'
+      )}
+      showSplitsButton={false}
+      allowTerminalCreation={false}
+      trailingChromeInset="window-controls"
+      onActivateItem={activateTerminal}
+      onTogglePinned={togglePinned}
+      toolbarContent={
+        <div className="ml-1 flex shrink-0 items-center gap-1 border-l border-border pl-1">
+          {scopeButton(
+            'active',
+            translate(
+              'auto.components.control.room.ControlRoomTerminalCanvas.active',
+              'Active agents'
+            ),
+            <Bot />
+          )}
+          {scopeButton(
+            'all',
+            translate(
+              'auto.components.control.room.ControlRoomTerminalCanvas.all',
+              'All live sessions'
+            ),
+            <SquareTerminal />
+          )}
+          {scopeButton(
+            'pinned',
+            translate('auto.components.control.room.ControlRoomTerminalCanvas.pinned', 'Pinned'),
+            <Pin />
+          )}
+          <span
+            className="min-w-4 text-center text-[10px] tabular-nums text-muted-foreground"
+            aria-label={translate(
+              'auto.components.control.room.ControlRoomTerminalCanvas.sessionCount',
+              'Sessions in this view: {{value0}}',
+              { value0: terminalItems.length }
+            )}
+          >
+            {translate(
+              'auto.components.control.room.ControlRoomTerminalCanvas.sessionCountCompact',
+              '{{value0}}',
+              { value0: terminalItems.length }
+            )}
+          </span>
+        </div>
+      }
+      emptyState={
+        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center p-8">
+          <div className="max-w-sm text-center">
+            <Bot className="mx-auto mb-3 size-8 text-muted-foreground/60" />
+            <p className="text-sm font-medium text-foreground">
+              {preferences.scope === 'pinned'
+                ? translate(
+                    'auto.components.control.room.ControlRoomTerminalCanvas.noPinned',
+                    'No pinned sessions yet'
+                  )
+                : translate(
+                    'auto.components.control.room.ControlRoomTerminalCanvas.noAgents',
+                    'No agents match this view'
+                  )}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {translate(
+                'auto.components.control.room.ControlRoomTerminalCanvas.emptyHelp',
+                'Active shows recognized agents. All adds ordinary live terminals. Recognized subagents stay folded into their parent count.'
+              )}
+            </p>
+          </div>
+        </div>
+      }
+    />
+  )
+}

--- a/src/renderer/src/components/control-room/control-room-preferences.test.ts
+++ b/src/renderer/src/components/control-room/control-room-preferences.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_CONTROL_ROOM_PREFERENCES,
+  normalizeControlRoomPreferences,
+  readControlRoomPreferences,
+  writeControlRoomPreferences
+} from './control-room-preferences'
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>()
+  return {
+    get length() {
+      return values.size
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value)
+  }
+}
+
+describe('control room preferences', () => {
+  it('falls back safely and keeps only unique string pin identities', () => {
+    expect(normalizeControlRoomPreferences(null)).toEqual(DEFAULT_CONTROL_ROOM_PREFERENCES)
+    expect(
+      normalizeControlRoomPreferences({
+        scope: 'pinned',
+        pinnedSessionKeys: ['one', 'one', '', 42, 'two']
+      })
+    ).toEqual({ version: 1, scope: 'pinned', pinnedSessionKeys: ['one', 'two'] })
+  })
+
+  it('round-trips the selected view and pins', () => {
+    const storage = memoryStorage()
+    writeControlRoomPreferences(storage, {
+      version: 1,
+      scope: 'all',
+      pinnedSessionKeys: ['local:worktree:tab']
+    })
+    expect(readControlRoomPreferences(storage)).toEqual({
+      version: 1,
+      scope: 'all',
+      pinnedSessionKeys: ['local:worktree:tab']
+    })
+  })
+
+  it('recovers from malformed persisted data', () => {
+    const storage = memoryStorage()
+    storage.setItem('orca:control-room:v1', '{broken')
+    expect(readControlRoomPreferences(storage)).toEqual(DEFAULT_CONTROL_ROOM_PREFERENCES)
+  })
+})

--- a/src/renderer/src/components/control-room/control-room-preferences.ts
+++ b/src/renderer/src/components/control-room/control-room-preferences.ts
@@ -1,0 +1,59 @@
+export type ControlRoomScope = 'active' | 'all' | 'pinned'
+
+export type ControlRoomPreferences = {
+  version: 1
+  scope: ControlRoomScope
+  pinnedSessionKeys: string[]
+}
+
+const STORAGE_KEY = 'orca:control-room:v1'
+const MAX_PINNED_SESSIONS = 500
+
+export const DEFAULT_CONTROL_ROOM_PREFERENCES: ControlRoomPreferences = {
+  version: 1,
+  scope: 'active',
+  pinnedSessionKeys: []
+}
+
+function normalizeScope(value: unknown): ControlRoomScope {
+  return value === 'all' || value === 'pinned' ? value : 'active'
+}
+
+export function normalizeControlRoomPreferences(value: unknown): ControlRoomPreferences {
+  const candidate = value && typeof value === 'object' ? value : {}
+  const rawPins =
+    'pinnedSessionKeys' in candidate && Array.isArray(candidate.pinnedSessionKeys)
+      ? candidate.pinnedSessionKeys
+      : []
+  return {
+    version: 1,
+    scope: normalizeScope('scope' in candidate ? candidate.scope : undefined),
+    pinnedSessionKeys: Array.from(
+      new Set(
+        rawPins.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0)
+      )
+    ).slice(0, MAX_PINNED_SESSIONS)
+  }
+}
+
+export function readControlRoomPreferences(
+  storage: Pick<Storage, 'getItem'>
+): ControlRoomPreferences {
+  try {
+    const raw = storage.getItem(STORAGE_KEY)
+    return raw ? normalizeControlRoomPreferences(JSON.parse(raw)) : DEFAULT_CONTROL_ROOM_PREFERENCES
+  } catch {
+    return DEFAULT_CONTROL_ROOM_PREFERENCES
+  }
+}
+
+export function writeControlRoomPreferences(
+  storage: Pick<Storage, 'setItem'>,
+  preferences: ControlRoomPreferences
+): void {
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(normalizeControlRoomPreferences(preferences)))
+  } catch {
+    // Why: a blocked localStorage must not make the live Control Room unusable.
+  }
+}

--- a/src/renderer/src/components/control-room/control-room-terminal-items.test.ts
+++ b/src/renderer/src/components/control-room/control-room-terminal-items.test.ts
@@ -140,6 +140,12 @@ describe('control room terminal items', () => {
         ptyIdsByTabId: {}
       })
     ).toEqual([])
+    expect(
+      build([done], 'pinned', {
+        terminalTabsByWorktree: { 'worktree-1': [stopped] },
+        ptyIdsByTabId: {}
+      })
+    ).toHaveLength(1)
   })
 
   it('adds live ordinary terminals only in the All view', () => {

--- a/src/renderer/src/components/control-room/control-room-terminal-items.test.ts
+++ b/src/renderer/src/components/control-room/control-room-terminal-items.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import type { DashboardCard, DashboardWorkspace } from '../../../../shared/dashboard-snapshot'
+import type { Tab } from '../../../../shared/tab-types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import { buildControlRoomTerminalItems, controlRoomSessionKey } from './control-room-terminal-items'
+
+function card(overrides: Partial<DashboardCard> = {}): DashboardCard {
+  return {
+    paneKey: 'tab-1:leaf-1',
+    ptyId: 'pty-1',
+    agentType: 'codex',
+    bucket: 'working',
+    dotState: 'working',
+    task: 'Build it',
+    repoId: 'repo-1',
+    worktreeId: 'worktree-1',
+    tabId: 'tab-1',
+    leafId: 'leaf-1',
+    repoName: 'Ronin',
+    worktreeName: 'agent-ledger',
+    startedAt: 1,
+    finishedAt: null,
+    stateChangedAt: 1,
+    unseen: true,
+    ...overrides
+  }
+}
+
+function unifiedTab(overrides: Partial<Tab> = {}): Tab {
+  return {
+    id: 'unified-1',
+    entityId: 'tab-1',
+    groupId: 'group-1',
+    worktreeId: 'worktree-1',
+    contentType: 'terminal',
+    label: 'Ledger',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    ...overrides
+  }
+}
+
+function terminalTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: 'tab-1',
+    ptyId: 'pty-1',
+    worktreeId: 'worktree-1',
+    title: 'Ledger',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    ...overrides
+  }
+}
+
+function workspace(overrides: Partial<DashboardWorkspace> = {}): DashboardWorkspace {
+  return {
+    repoId: 'repo-1',
+    worktreeId: 'worktree-1',
+    repoName: 'Ronin',
+    worktreeName: 'agent-ledger',
+    hostKind: 'local',
+    executionHostId: 'local',
+    workspaceKind: 'worktree',
+    ...overrides
+  }
+}
+
+function build(
+  cards: DashboardCard[],
+  scope: 'active' | 'all' | 'pinned' = 'active',
+  overrides: {
+    unifiedTabsByWorktree?: Record<string, Tab[]>
+    terminalTabsByWorktree?: Record<string, TerminalTab[]>
+    ptyIdsByTabId?: Record<string, string[]>
+  } = {}
+) {
+  return buildControlRoomTerminalItems({
+    cards,
+    workspaces: [workspace()],
+    unifiedTabsByWorktree: overrides.unifiedTabsByWorktree ?? {
+      'worktree-1': [unifiedTab()]
+    },
+    terminalTabsByWorktree: overrides.terminalTabsByWorktree ?? {
+      'worktree-1': [terminalTab()]
+    },
+    ptyIdsByTabId: overrides.ptyIdsByTabId ?? { 'tab-1': ['pty-1'] },
+    generatedTabTitlesEnabled: false,
+    pinnedSessionKeys: new Set(['local:worktree-1:tab-1']),
+    scope
+  })
+}
+
+describe('control room terminal items', () => {
+  it('groups top-level agents by terminal and folds subagents into a count', () => {
+    const items = build([
+      card({ subagents: [{ id: 'child-1', name: 'helper', dotState: 'working' }] }),
+      card({ paneKey: 'tab-1:leaf-2', leafId: 'leaf-2', dotState: 'waiting' })
+    ])
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      terminalTabId: 'tab-1',
+      worktreeId: 'worktree-1',
+      ownerLabel: 'Ronin / agent-ledger',
+      agentState: 'waiting',
+      agentCount: 2,
+      subagentCount: 1,
+      pinned: true
+    })
+  })
+
+  it('does not promote explicit child agents into separate cards', () => {
+    const items = build([
+      card(),
+      card({ paneKey: 'tab-1:child', parentPaneKey: 'tab-1:leaf-1', leafId: 'child' })
+    ])
+    expect(items).toHaveLength(1)
+    expect(items[0].agentCount).toBe(1)
+  })
+
+  it('keeps live recognized agents in every applicable view and omits stopped sessions', () => {
+    const done = card({ dotState: 'done', bucket: 'idle', unseen: false })
+    expect(build([done], 'active')).toHaveLength(1)
+    expect(build([done], 'all')).toHaveLength(1)
+    expect(build([done], 'pinned')).toHaveLength(1)
+
+    const stopped = terminalTab({ ptyId: null })
+    expect(
+      build([done], 'active', {
+        terminalTabsByWorktree: { 'worktree-1': [stopped] },
+        ptyIdsByTabId: {}
+      })
+    ).toEqual([])
+    expect(
+      build([done], 'all', {
+        terminalTabsByWorktree: { 'worktree-1': [stopped] },
+        ptyIdsByTabId: {}
+      })
+    ).toEqual([])
+  })
+
+  it('adds live ordinary terminals only in the All view', () => {
+    expect(build([])).toEqual([])
+    const items = build([], 'all')
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      terminalTabId: 'tab-1',
+      ownerLabel: 'Ronin / agent-ledger'
+    })
+    expect(items[0].agentState).toBeUndefined()
+  })
+
+  it('includes execution host identity in persisted pin keys', () => {
+    expect(controlRoomSessionKey(card({ executionHostId: 'ssh:server' }))).toBe(
+      'ssh:server:worktree-1:tab-1'
+    )
+  })
+})

--- a/src/renderer/src/components/control-room/control-room-terminal-items.ts
+++ b/src/renderer/src/components/control-room/control-room-terminal-items.ts
@@ -64,11 +64,14 @@ function includeForScope(
   hasAgent: boolean,
   pinned: boolean
 ): boolean {
+  if (scope === 'pinned') {
+    // A pin is a durable user choice. Keep its restored terminal card visible
+    // while the PTY is offline so an app restart does not look like it forgot
+    // every pinned agent.
+    return pinned
+  }
   if (!live) {
     return false
-  }
-  if (scope === 'pinned') {
-    return pinned
   }
   if (scope === 'all') {
     return true

--- a/src/renderer/src/components/control-room/control-room-terminal-items.ts
+++ b/src/renderer/src/components/control-room/control-room-terminal-items.ts
@@ -1,0 +1,182 @@
+import type { AgentDotState } from '@/components/AgentStateDot'
+import type { CanvasTerminalItem } from '@/components/tab-group/CanvasTerminalCard'
+import type {
+  DashboardCard,
+  DashboardCardDisplayState,
+  DashboardWorkspace
+} from '../../../../shared/dashboard-snapshot'
+import { dashboardCardDisplayState } from '../../../../shared/dashboard-snapshot'
+import type { Tab } from '../../../../shared/tab-types'
+import { resolveCanvasTerminalLabel } from '../../../../shared/tab-title-resolution'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import type { ControlRoomScope } from './control-room-preferences'
+
+type ControlRoomItemInput = {
+  cards: readonly DashboardCard[]
+  workspaces?: readonly DashboardWorkspace[]
+  unifiedTabsByWorktree: Readonly<Record<string, readonly Tab[] | undefined>>
+  terminalTabsByWorktree: Readonly<Record<string, readonly TerminalTab[] | undefined>>
+  ptyIdsByTabId: Readonly<Record<string, readonly string[] | undefined>>
+  generatedTabTitlesEnabled: boolean
+  pinnedSessionKeys: ReadonlySet<string>
+  scope: ControlRoomScope
+}
+
+const STATE_PRIORITY: Record<DashboardCardDisplayState, number> = {
+  blocked: 6,
+  waiting: 5,
+  working: 4,
+  monitoring: 3,
+  done: 2,
+  idle: 1
+}
+
+type ControlRoomSessionIdentity = {
+  executionHostId?: string
+  worktreeId: string
+  tabId: string
+}
+
+export function controlRoomSessionKey(identity: ControlRoomSessionIdentity): string {
+  return `${identity.executionHostId ?? 'local'}:${identity.worktreeId}:${identity.tabId}`
+}
+
+function ownerLabel(card: Pick<DashboardCard, 'repoName' | 'worktreeName'>): string {
+  return card.repoName === card.worktreeName
+    ? card.repoName
+    : `${card.repoName} / ${card.worktreeName}`
+}
+
+function strongestState(cards: readonly DashboardCard[]): DashboardCardDisplayState {
+  let state: DashboardCardDisplayState = 'idle'
+  for (const card of cards) {
+    const candidate = dashboardCardDisplayState(card)
+    if (STATE_PRIORITY[candidate] > STATE_PRIORITY[state]) {
+      state = candidate
+    }
+  }
+  return state
+}
+
+function includeForScope(
+  scope: ControlRoomScope,
+  live: boolean,
+  hasAgent: boolean,
+  pinned: boolean
+): boolean {
+  if (!live) {
+    return false
+  }
+  if (scope === 'pinned') {
+    return pinned
+  }
+  if (scope === 'all') {
+    return true
+  }
+  return hasAgent
+}
+
+/**
+ * Maps Orca's cross-project agent snapshot back to the existing terminal tabs.
+ * One Canvas card represents one terminal tab; split agents inside it remain
+ * inside that terminal, while provider subagents stay folded into the count.
+ */
+export function buildControlRoomTerminalItems({
+  cards,
+  workspaces,
+  unifiedTabsByWorktree,
+  terminalTabsByWorktree,
+  ptyIdsByTabId,
+  generatedTabTitlesEnabled,
+  pinnedSessionKeys,
+  scope
+}: ControlRoomItemInput): CanvasTerminalItem[] {
+  const cardsByRoute = new Map<string, DashboardCard[]>()
+  for (const card of cards) {
+    if (card.parentPaneKey) {
+      continue
+    }
+    const key = `${card.worktreeId}:${card.tabId}`
+    const existing = cardsByRoute.get(key)
+    if (existing) {
+      existing.push(card)
+    } else {
+      cardsByRoute.set(key, [card])
+    }
+  }
+
+  const workspaceByWorktree = new Map(
+    (workspaces ?? []).map((workspace) => [workspace.worktreeId, workspace])
+  )
+
+  const items: CanvasTerminalItem[] = []
+  for (const [worktreeId, unifiedTabs] of Object.entries(unifiedTabsByWorktree)) {
+    const terminals = new Map(
+      (terminalTabsByWorktree[worktreeId] ?? []).map((terminal) => [terminal.id, terminal])
+    )
+    const workspace = workspaceByWorktree.get(worktreeId)
+
+    for (const unifiedTab of unifiedTabs ?? []) {
+      if (unifiedTab.contentType !== 'terminal') {
+        continue
+      }
+      const terminal = terminals.get(unifiedTab.entityId)
+      if (!terminal) {
+        continue
+      }
+      const sessionCards = cardsByRoute.get(`${worktreeId}:${terminal.id}`) ?? []
+      const card = sessionCards[0]
+      const executionHostId =
+        card?.executionHostId ?? unifiedTab.executionHostId ?? workspace?.executionHostId
+      const sessionKey = controlRoomSessionKey({
+        executionHostId,
+        worktreeId,
+        tabId: terminal.id
+      })
+      const pinned = pinnedSessionKeys.has(sessionKey)
+      const live = terminal.ptyId !== null || (ptyIdsByTabId[terminal.id]?.length ?? 0) > 0
+      if (!includeForScope(scope, live, sessionCards.length > 0, pinned)) {
+        continue
+      }
+      const state = sessionCards.length > 0 ? strongestState(sessionCards) : undefined
+      const fallbackOwner = workspace ? ownerLabel(workspace) : card ? ownerLabel(card) : worktreeId
+      items.push({
+        terminalTabId: terminal.id,
+        unifiedTabId: unifiedTab.id,
+        groupId: unifiedTab.groupId,
+        worktreeId,
+        executionHostId,
+        sessionKey,
+        label: resolveCanvasTerminalLabel(unifiedTab, terminal, generatedTabTitlesEnabled),
+        color: unifiedTab.color ?? terminal.color,
+        ownerLabel: fallbackOwner,
+        ...(state ? { agentState: state as AgentDotState } : {}),
+        ...(sessionCards.length > 0
+          ? {
+              agentCount: sessionCards.length,
+              subagentCount: sessionCards.reduce(
+                (count, entry) => count + (entry.subagents?.length ?? 0),
+                0
+              )
+            }
+          : {}),
+        pinned
+      })
+    }
+  }
+
+  return items.sort((left, right) => {
+    const leftPriority = left.agentState
+      ? STATE_PRIORITY[left.agentState as DashboardCardDisplayState]
+      : 0
+    const rightPriority = right.agentState
+      ? STATE_PRIORITY[right.agentState as DashboardCardDisplayState]
+      : 0
+    const stateDelta = rightPriority - leftPriority
+    return (
+      stateDelta ||
+      (left.ownerLabel ?? '').localeCompare(right.ownerLabel ?? '') ||
+      left.label.localeCompare(right.label)
+    )
+  })
+}

--- a/src/renderer/src/components/sidebar/SidebarNav.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.test.tsx
@@ -13,6 +13,7 @@ import { PSEUDO_LOCALIZATION_LOCALE } from '../../i18n/pseudo-localization'
 
 const mocks = vi.hoisted(() => ({
   state: {} as Record<string, unknown>,
+  openControlRoomPage: vi.fn(),
   openTaskPage: vi.fn(),
   openAutomationsPage: vi.fn(),
   openActivityPage: vi.fn(),
@@ -128,6 +129,7 @@ function setSidebarState({
     settings,
     repos,
     activeView: 'worktrees',
+    openControlRoomPage: mocks.openControlRoomPage,
     openTaskPage: mocks.openTaskPage,
     openAutomationsPage: mocks.openAutomationsPage,
     openActivityPage: mocks.openActivityPage,
@@ -216,6 +218,12 @@ describe('SidebarNav', () => {
     mocks.hasPairedMobileDevice = false
     mocks.agentBucketCounts = { attention: 0, working: 0, done: 0, idle: 0 }
     setSidebarState()
+  })
+
+  it('opens the cross-project Control Room from its persistent sidebar entry', async () => {
+    const container = await renderSidebarNav()
+    await clickButton(getButtonByText(container, 'Control Room'))
+    expect(mocks.openControlRoomPage).toHaveBeenCalledTimes(1)
   })
 
   it('keeps the Agent Dashboard row unmounted while its experiment is off', async () => {

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -1,5 +1,13 @@
 import React from 'react'
-import { BookOpen, CalendarClock, EyeOff, Files, Search, Smartphone } from 'lucide-react'
+import {
+  BookOpen,
+  CalendarClock,
+  EyeOff,
+  Files,
+  LayoutDashboard,
+  Search,
+  Smartphone
+} from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
@@ -56,6 +64,7 @@ const SidebarNav = React.memo(function SidebarNav() {
   useTranslation()
   const worktreePaletteShortcutCombos = useShortcutKeyComboDetails('worktree.palette')
   const openAutomationsPage = useAppStore((s) => s.openAutomationsPage)
+  const openControlRoomPage = useAppStore((s) => s.openControlRoomPage)
   const openMobilePage = useAppStore((s) => s.openMobilePage)
   const openArtifactsPage = useAppStore((s) => s.openArtifactsPage)
   const openSkillsPage = useAppStore((s) => s.openSkillsPage)
@@ -68,6 +77,7 @@ const SidebarNav = React.memo(function SidebarNav() {
   const showArtifactsButton = useAppStore((s) => shouldShowArtifactsButton(s.settings))
   const showSkillsButton = useAppStore((s) => shouldShowSkillsButton(s.settings))
   const automationsActive = activeView === 'automations'
+  const controlRoomActive = activeView === 'control-room'
   const mobileActive = activeView === 'mobile'
   const artifactsActive = activeView === 'artifacts'
   const skillsActive = activeView === 'skills'
@@ -121,6 +131,28 @@ const SidebarNav = React.memo(function SidebarNav() {
       </button>
       <SetupGuideSidebarEntry />
       <SidebarTaskNavButton />
+      <button
+        type="button"
+        onClick={openControlRoomPage}
+        aria-current={controlRoomActive ? 'page' : undefined}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
+          controlRoomActive
+            ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
+            : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'
+        )}
+      >
+        <LayoutDashboard
+          className={cn(
+            'size-4 shrink-0',
+            !controlRoomActive && 'text-worktree-sidebar-foreground/30'
+          )}
+          strokeWidth={controlRoomActive ? 2.25 : 1.75}
+        />
+        <span className="flex-1">
+          {translate('auto.components.sidebar.SidebarNav.controlRoom', 'Control Room')}
+        </span>
+      </button>
       {showArtifactsButton ? (
         <ContextMenu>
           <ContextMenuTrigger asChild>

--- a/src/renderer/src/components/tab-group/CanvasTerminalCard.tsx
+++ b/src/renderer/src/components/tab-group/CanvasTerminalCard.tsx
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import type { AgentDotState } from '@/components/AgentStateDot'
+import { translate } from '@/i18n/i18n'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { CanvasTerminalCardHeader } from './CanvasTerminalCardHeader'
+import { terminalCanvasBodyAnchorName } from './tab-group-body-anchor'
+import {
+  PANE_CANVAS_MIN_HEIGHT,
+  PANE_CANVAS_MIN_WIDTH,
+  resolvePaneCanvasDrop,
+  type PaneCanvasBounds
+} from './pane-canvas-layout-state'
+
+export type CanvasTerminalItem = {
+  terminalTabId: string
+  unifiedTabId: string
+  groupId: string
+  label: string
+  color: string | null
+  /** Global canvases retain each terminal's workspace ownership. */
+  worktreeId?: string
+  executionHostId?: ExecutionHostId
+  /** Stable cross-workspace identity used for pinning and saved arrangements. */
+  sessionKey?: string
+  ownerLabel?: string
+  agentState?: AgentDotState
+  agentCount?: number
+  subagentCount?: number
+  pinned?: boolean
+}
+
+type CanvasGesture = 'move' | 'resize-x' | 'resize-y' | 'resize-both'
+
+function applyCardBounds(element: HTMLElement, bounds: PaneCanvasBounds): void {
+  element.style.left = `${bounds.x}px`
+  element.style.top = `${bounds.y}px`
+  element.style.width = `${bounds.width}px`
+  element.style.height = `${bounds.height}px`
+}
+
+export default function CanvasTerminalCard({
+  item,
+  worktreeId,
+  bounds,
+  otherBounds,
+  isFocused,
+  onActivate,
+  onCreateTerminal,
+  onTogglePinned,
+  onClose,
+  onCommitBounds
+}: {
+  item: CanvasTerminalItem
+  worktreeId: string
+  bounds: PaneCanvasBounds
+  otherBounds: readonly PaneCanvasBounds[]
+  isFocused: boolean
+  onActivate: (item: CanvasTerminalItem) => void
+  onCreateTerminal?: (groupId: string) => void
+  onTogglePinned?: (item: CanvasTerminalItem) => void
+  onClose?: (terminalTabId: string) => void
+  onCommitBounds: (bounds: PaneCanvasBounds) => void
+}): React.JSX.Element {
+  const cardRef = useRef<HTMLDivElement | null>(null)
+  const liveBoundsRef = useRef(bounds)
+  const gestureCleanupRef = useRef<(() => void) | null>(null)
+  const bodyAnchorName = terminalCanvasBodyAnchorName(item.terminalTabId)
+  const bodyAnchorStyle = useMemo(
+    () => ({ anchorName: bodyAnchorName }) as React.CSSProperties,
+    [bodyAnchorName]
+  )
+
+  useEffect(() => {
+    liveBoundsRef.current = bounds
+  }, [bounds])
+
+  useEffect(
+    () => () => {
+      gestureCleanupRef.current?.()
+    },
+    []
+  )
+
+  const beginGesture = useCallback(
+    (event: React.PointerEvent<HTMLElement>, gesture: CanvasGesture) => {
+      if (event.button !== 0 || gestureCleanupRef.current) {
+        return
+      }
+      const card = cardRef.current
+      if (!card) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      onActivate(item)
+
+      const handle = event.currentTarget
+      const pointerId = event.pointerId
+      const startPointer = { x: event.clientX, y: event.clientY }
+      const startBounds = liveBoundsRef.current
+      handle.setPointerCapture(pointerId)
+
+      const update = (moveEvent: PointerEvent): void => {
+        if (moveEvent.pointerId !== pointerId || !handle.hasPointerCapture(pointerId)) {
+          return
+        }
+        const deltaX = moveEvent.clientX - startPointer.x
+        const deltaY = moveEvent.clientY - startPointer.y
+        const resizingX = gesture === 'resize-x' || gesture === 'resize-both'
+        const resizingY = gesture === 'resize-y' || gesture === 'resize-both'
+        const next: PaneCanvasBounds = {
+          x: gesture === 'move' ? Math.max(0, startBounds.x + deltaX) : startBounds.x,
+          y: gesture === 'move' ? Math.max(0, startBounds.y + deltaY) : startBounds.y,
+          width: resizingX
+            ? Math.max(PANE_CANVAS_MIN_WIDTH, startBounds.width + deltaX)
+            : startBounds.width,
+          height: resizingY
+            ? Math.max(PANE_CANVAS_MIN_HEIGHT, startBounds.height + deltaY)
+            : startBounds.height
+        }
+        liveBoundsRef.current = next
+        applyCardBounds(card, next)
+      }
+
+      let cleaned = false
+      const cleanup = (): void => {
+        if (cleaned) {
+          return
+        }
+        cleaned = true
+        try {
+          if (handle.hasPointerCapture(pointerId)) {
+            handle.releasePointerCapture(pointerId)
+          }
+        } catch {
+          // Chromium can drop pointer capture before unmount cleanup.
+        }
+        handle.removeEventListener('pointermove', update)
+        handle.removeEventListener('pointerup', finish)
+        handle.removeEventListener('pointercancel', cancel)
+        handle.removeEventListener('lostpointercapture', finish)
+        if (gestureCleanupRef.current === cleanup) {
+          gestureCleanupRef.current = null
+        }
+      }
+
+      const finish = (finishEvent: PointerEvent): void => {
+        if (cleaned || finishEvent.pointerId !== pointerId) {
+          return
+        }
+        const committed = resolvePaneCanvasDrop(liveBoundsRef.current, otherBounds)
+        liveBoundsRef.current = committed
+        applyCardBounds(card, committed)
+        cleanup()
+        onCommitBounds(committed)
+      }
+
+      const cancel = (cancelEvent: PointerEvent): void => {
+        if (cancelEvent.pointerId !== pointerId) {
+          return
+        }
+        liveBoundsRef.current = startBounds
+        applyCardBounds(card, startBounds)
+        cleanup()
+      }
+
+      handle.addEventListener('pointermove', update)
+      handle.addEventListener('pointerup', finish)
+      handle.addEventListener('pointercancel', cancel)
+      handle.addEventListener('lostpointercapture', finish)
+      gestureCleanupRef.current = cleanup
+    },
+    [item, onActivate, onCommitBounds, otherBounds]
+  )
+
+  const moveFromHeader = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const target = event.target
+      if (!(target instanceof Node) || !event.currentTarget.contains(target)) {
+        return
+      }
+      if (
+        target instanceof Element &&
+        target.closest(
+          'button, a, input, textarea, select, [role="button"], [role="tab"], [contenteditable="true"]'
+        )
+      ) {
+        return
+      }
+      beginGesture(event, 'move')
+    },
+    [beginGesture]
+  )
+
+  const resizeFromKeyboard = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>, axis: 'width' | 'height') => {
+      const step = event.shiftKey ? 64 : 16
+      const delta =
+        axis === 'width'
+          ? event.key === 'ArrowRight'
+            ? step
+            : event.key === 'ArrowLeft'
+              ? -step
+              : null
+          : event.key === 'ArrowDown'
+            ? step
+            : event.key === 'ArrowUp'
+              ? -step
+              : null
+      if (delta === null) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      onActivate(item)
+      const current = liveBoundsRef.current
+      const resized: PaneCanvasBounds = {
+        ...current,
+        width:
+          axis === 'width' ? Math.max(PANE_CANVAS_MIN_WIDTH, current.width + delta) : current.width,
+        height:
+          axis === 'height'
+            ? Math.max(PANE_CANVAS_MIN_HEIGHT, current.height + delta)
+            : current.height
+      }
+      const next = resolvePaneCanvasDrop(resized, otherBounds)
+      liveBoundsRef.current = next
+      const card = cardRef.current
+      if (card) {
+        applyCardBounds(card, next)
+      }
+      onCommitBounds(next)
+    },
+    [item, onActivate, onCommitBounds, otherBounds]
+  )
+
+  return (
+    <div
+      ref={cardRef}
+      className={`absolute left-0 top-0 flex flex-col overflow-hidden rounded-md border bg-card shadow-xs${
+        isFocused ? ' border-ring ring-1 ring-ring/80' : ' border-border/90 ring-1 ring-border/50'
+      }`}
+      style={{ left: bounds.x, top: bounds.y, width: bounds.width, height: bounds.height }}
+      data-pane-canvas-terminal-id={item.terminalTabId}
+      data-pane-canvas-group-id={item.groupId}
+    >
+      <CanvasTerminalCardHeader
+        item={item}
+        worktreeId={worktreeId}
+        onHeaderPointerDown={moveFromHeader}
+        onMovePointerDown={(event) => beginGesture(event, 'move')}
+        onCreateTerminal={onCreateTerminal}
+        onTogglePinned={onTogglePinned}
+        onClose={onClose}
+      />
+      <div
+        className="relative min-h-0 min-w-0 flex-1 overflow-hidden rounded-b-md"
+        data-terminal-canvas-body-id={item.terminalTabId}
+        data-tab-group-body-id={item.groupId}
+        data-worktree-id={worktreeId}
+        style={bodyAnchorStyle}
+        onPointerDown={() => onActivate(item)}
+      />
+      <div
+        role="separator"
+        tabIndex={0}
+        aria-orientation="vertical"
+        aria-valuemin={PANE_CANVAS_MIN_WIDTH}
+        aria-valuemax={10_000}
+        aria-valuenow={Math.round(bounds.width)}
+        aria-label={translate(
+          'auto.components.tab.group.TabGroupCanvasLayout.resizePaneWidth',
+          'Resize terminal width'
+        )}
+        className="absolute inset-y-8 right-0 z-30 w-2 cursor-ew-resize touch-none bg-transparent focus-visible:bg-ring/60 focus-visible:outline-none"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        onPointerDown={(event) => beginGesture(event, 'resize-x')}
+        onKeyDown={(event) => resizeFromKeyboard(event, 'width')}
+      />
+      <div
+        role="separator"
+        tabIndex={0}
+        aria-orientation="horizontal"
+        aria-valuemin={PANE_CANVAS_MIN_HEIGHT}
+        aria-valuemax={10_000}
+        aria-valuenow={Math.round(bounds.height)}
+        aria-label={translate(
+          'auto.components.tab.group.TabGroupCanvasLayout.resizePaneHeight',
+          'Resize terminal height'
+        )}
+        className="absolute inset-x-0 bottom-0 z-30 h-2 cursor-ns-resize touch-none bg-transparent focus-visible:bg-ring/60 focus-visible:outline-none"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        onPointerDown={(event) => beginGesture(event, 'resize-y')}
+        onKeyDown={(event) => resizeFromKeyboard(event, 'height')}
+      />
+      <div
+        aria-hidden="true"
+        data-pane-canvas-resize-corner="true"
+        className="absolute bottom-0 right-0 z-40 size-4 cursor-nwse-resize touch-none rounded-br-md bg-transparent"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        onPointerDown={(event) => beginGesture(event, 'resize-both')}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/tab-group/CanvasTerminalCardHeader.tsx
+++ b/src/renderer/src/components/tab-group/CanvasTerminalCardHeader.tsx
@@ -1,0 +1,157 @@
+import type { PointerEvent } from 'react'
+import { GripVertical, Pin, PinOff, Plus, SquareTerminal, X } from 'lucide-react'
+import { AgentStateDot, agentStateLabel } from '@/components/AgentStateDot'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+import { TabBarQuickCommandsButton } from '../tab-bar/TabBarQuickCommandsButton'
+import type { CanvasTerminalItem } from './CanvasTerminalCard'
+
+export function CanvasTerminalCardHeader({
+  item,
+  worktreeId,
+  onHeaderPointerDown,
+  onMovePointerDown,
+  onCreateTerminal,
+  onTogglePinned,
+  onClose
+}: {
+  item: CanvasTerminalItem
+  worktreeId: string
+  onHeaderPointerDown: (event: PointerEvent<HTMLDivElement>) => void
+  onMovePointerDown: (event: PointerEvent<HTMLButtonElement>) => void
+  onCreateTerminal?: (groupId: string) => void
+  onTogglePinned?: (item: CanvasTerminalItem) => void
+  onClose?: (terminalTabId: string) => void
+}): React.JSX.Element {
+  const pinLabel = item.pinned
+    ? translate('auto.components.tab.group.CanvasTerminalCard.unpin', 'Remove from pinned view')
+    : translate('auto.components.tab.group.CanvasTerminalCard.pin', 'Pin to Control Room')
+
+  return (
+    <div
+      className="flex h-8 shrink-0 cursor-grab touch-none items-center border-b border-border bg-card active:cursor-grabbing"
+      data-pane-canvas-card-header="true"
+      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      onPointerDown={onHeaderPointerDown}
+    >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={translate(
+              'auto.components.tab.group.TabGroupCanvasLayout.movePane',
+              'Move terminal'
+            )}
+            className="flex h-full w-7 shrink-0 cursor-grab touch-none items-center justify-center text-muted-foreground hover:bg-accent/50 hover:text-foreground active:cursor-grabbing"
+            onPointerDown={onMovePointerDown}
+          >
+            <GripVertical className="size-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6}>
+          {translate('auto.components.tab.group.TabGroupCanvasLayout.movePane', 'Move terminal')}
+        </TooltipContent>
+      </Tooltip>
+      {item.agentState ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="mr-1 inline-flex shrink-0">
+              <AgentStateDot state={item.agentState} />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            {agentStateLabel(item.agentState)}
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <SquareTerminal className="mr-1 size-3.5 shrink-0 text-muted-foreground" />
+      )}
+      {item.color ? (
+        <span
+          className="mr-1 size-2 shrink-0 rounded-full"
+          style={{ backgroundColor: item.color }}
+        />
+      ) : null}
+      <span className="min-w-0 truncate text-xs text-foreground">{item.label}</span>
+      {item.ownerLabel ? (
+        <span className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground">
+          · {item.ownerLabel}
+        </span>
+      ) : (
+        <span className="flex-1" />
+      )}
+      {item.agentCount && item.agentCount > 1 ? (
+        <span className="shrink-0 text-[10px] text-muted-foreground">
+          {translate(
+            'auto.components.tab.group.CanvasTerminalCard.agentCount',
+            '{{value0}} agents',
+            {
+              value0: item.agentCount
+            }
+          )}
+        </span>
+      ) : null}
+      {item.subagentCount ? (
+        <span className="shrink-0 text-[10px] text-muted-foreground">
+          {translate(
+            'auto.components.tab.group.CanvasTerminalCard.subagentCount',
+            '+{{value0}} subagents',
+            { value0: item.subagentCount }
+          )}
+        </span>
+      ) : null}
+      <TabBarQuickCommandsButton worktreeId={worktreeId} groupId={item.groupId} />
+      {onTogglePinned ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={pinLabel}
+              className="flex size-7 shrink-0 items-center justify-center text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+              onClick={() => onTogglePinned(item)}
+            >
+              {item.pinned ? <PinOff className="size-3.5" /> : <Pin className="size-3.5" />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{pinLabel}</TooltipContent>
+        </Tooltip>
+      ) : null}
+      {onCreateTerminal ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={translate(
+                'auto.components.tab.group.TabGroupCanvasLayout.newTerminal',
+                'New terminal'
+              )}
+              className="flex size-7 shrink-0 items-center justify-center text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+              onClick={() => onCreateTerminal(item.groupId)}
+            >
+              <Plus className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {translate(
+              'auto.components.tab.group.TabGroupCanvasLayout.newTerminal',
+              'New terminal'
+            )}
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
+      {onClose ? (
+        <button
+          type="button"
+          aria-label={translate(
+            'auto.components.tab.group.TabGroupCanvasLayout.closeTerminal',
+            'Close terminal'
+          )}
+          className="flex size-7 shrink-0 items-center justify-center text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+          onClick={() => onClose(item.terminalTabId)}
+        >
+          <X className="size-3.5" />
+        </button>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/tab-group/PaneCanvasToolbar.tsx
+++ b/src/renderer/src/components/tab-group/PaneCanvasToolbar.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from 'react'
+import { AlignStartVertical, Columns3, LayoutDashboard } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+import {
+  paneCanvasToolbarTrailingInsetClassName,
+  type PaneCanvasToolbarTrailingInset
+} from './pane-canvas-toolbar-chrome'
+
+export function PaneCanvasToolbarAction({
+  label,
+  icon,
+  onClick
+}: {
+  label: string
+  icon: ReactNode
+  onClick: () => void
+}): React.JSX.Element {
+  const button = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      aria-label={label}
+      data-pane-canvas-toolbar-control="true"
+      onClick={onClick}
+    >
+      {icon}
+    </Button>
+  )
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+export function PaneCanvasToolbar({
+  title,
+  showSplitsButton,
+  trailingChromeInset,
+  toolbarContent,
+  onShowSplits,
+  onArrange
+}: {
+  title?: string
+  showSplitsButton: boolean
+  trailingChromeInset: PaneCanvasToolbarTrailingInset
+  toolbarContent?: ReactNode
+  onShowSplits: () => void
+  onArrange: () => void
+}): React.JSX.Element {
+  return (
+    <div
+      className={`relative z-50 flex h-8 shrink-0 items-center gap-1 border-b border-border bg-card px-2${paneCanvasToolbarTrailingInsetClassName(
+        trailingChromeInset
+      )}`}
+      data-pane-canvas-toolbar="true"
+      data-terminal-focus-release-surface="true"
+    >
+      <LayoutDashboard className="size-3.5 text-muted-foreground" />
+      <span className="mr-2 text-xs font-medium text-foreground">
+        {title ?? translate('auto.components.tab.group.TabGroupCanvasLayout.canvas', 'Canvas')}
+      </span>
+      <div className="ml-auto flex items-center gap-1" data-pane-canvas-toolbar-controls="true">
+        {showSplitsButton ? (
+          <PaneCanvasToolbarAction
+            label={translate('auto.components.tab.group.TabGroupCanvasLayout.splits', 'Splits')}
+            icon={<Columns3 />}
+            onClick={onShowSplits}
+          />
+        ) : null}
+        <PaneCanvasToolbarAction
+          label={translate('auto.components.tab.group.TabGroupCanvasLayout.arrange', 'Arrange')}
+          icon={<AlignStartVertical />}
+          onClick={onArrange}
+        />
+        {toolbarContent}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/tab-group/TabGroupCanvasLayout.drag.test.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupCanvasLayout.drag.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../tab-bar/TabBarQuickCommandsButton', () => ({
+  TabBarQuickCommandsButton: () => <button type="button">Command</button>
+}))
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+import CanvasTerminalCard, { type CanvasTerminalItem } from './CanvasTerminalCard'
+
+function pointerEvent(
+  type: string,
+  init: { pointerId?: number; clientX?: number; clientY?: number; button?: number }
+): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperties(event, {
+    pointerId: { value: init.pointerId ?? 1 },
+    clientX: { value: init.clientX ?? 0 },
+    clientY: { value: init.clientY ?? 0 },
+    button: { value: init.button ?? 0 }
+  })
+  return event
+}
+
+const terminalItem: CanvasTerminalItem = {
+  terminalTabId: 'terminal-1',
+  unifiedTabId: 'unified-1',
+  groupId: 'group-1',
+  label: 'Terminal 1',
+  color: null
+}
+
+describe('CanvasTerminalCard gestures', () => {
+  let container: HTMLDivElement
+  let root: Root | null
+  const commitBoundsMock = vi.fn()
+  const activateMock = vi.fn()
+
+  beforeEach(async () => {
+    activateMock.mockClear()
+    commitBoundsMock.mockClear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    await act(async () => {
+      root?.render(
+        <CanvasTerminalCard
+          item={terminalItem}
+          worktreeId="worktree-1"
+          bounds={{ x: 8, y: 8, width: 320, height: 220 }}
+          otherBounds={[{ x: 200, y: 8, width: 320, height: 220 }]}
+          isFocused={true}
+          onActivate={activateMock}
+          onCreateTerminal={vi.fn()}
+          onClose={vi.fn()}
+          onCommitBounds={commitBoundsMock}
+        />
+      )
+    })
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    container.remove()
+  })
+
+  function installPointerCapture(handle: HTMLElement): void {
+    const capturedPointers = new Set<number>()
+    Object.assign(handle, {
+      setPointerCapture: (pointerId: number) => capturedPointers.add(pointerId),
+      releasePointerCapture: (pointerId: number) => capturedPointers.delete(pointerId),
+      hasPointerCapture: (pointerId: number) => capturedPointers.has(pointerId)
+    })
+  }
+
+  it('moves with direct style writes and commits a smart non-overlapping drop once', async () => {
+    const card = container.querySelector('[data-pane-canvas-terminal-id]') as HTMLElement
+    const handle = container.querySelector('[aria-label="Move terminal"]') as HTMLElement
+    installPointerCapture(handle)
+
+    await act(async () => {
+      handle.dispatchEvent(pointerEvent('pointerdown', { clientX: 0, clientY: 0 }))
+      handle.dispatchEvent(pointerEvent('pointermove', { clientX: 192, clientY: 0 }))
+    })
+
+    expect(activateMock).toHaveBeenCalledWith(terminalItem)
+    expect(card.style.left).toBe('200px')
+    expect(card.style.top).toBe('8px')
+    expect(commitBoundsMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      handle.dispatchEvent(pointerEvent('pointerup', { clientX: 192, clientY: 0 }))
+    })
+
+    expect(commitBoundsMock).toHaveBeenCalledOnce()
+    const committed = commitBoundsMock.mock.calls[0][0]
+    expect(committed.x).toBeGreaterThanOrEqual(200)
+    expect(committed.y).toBeGreaterThanOrEqual(8)
+    expect(committed.x > 200 || committed.y > 8).toBe(true)
+  })
+
+  it('enforces minimum dimensions while resizing', async () => {
+    const widthHandle = container.querySelector(
+      '[aria-label="Resize terminal width"]'
+    ) as HTMLElement
+    installPointerCapture(widthHandle)
+
+    await act(async () => {
+      widthHandle.dispatchEvent(pointerEvent('pointerdown', { clientX: 0 }))
+      widthHandle.dispatchEvent(pointerEvent('pointermove', { clientX: -500 }))
+      widthHandle.dispatchEvent(pointerEvent('pointerup', { clientX: -500 }))
+    })
+
+    expect(commitBoundsMock.mock.calls[0][0].width).toBe(320)
+  })
+
+  it('supports keyboard resizing from the accessible edge handles', async () => {
+    const widthHandle = container.querySelector(
+      '[aria-label="Resize terminal width"]'
+    ) as HTMLElement
+
+    await act(async () => {
+      widthHandle.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true })
+      )
+    })
+
+    expect(commitBoundsMock).toHaveBeenCalledOnce()
+    expect(commitBoundsMock.mock.calls[0][0].width).toBe(336)
+  })
+
+  it('moves from unused header space without hijacking header controls', async () => {
+    const card = container.querySelector('[data-pane-canvas-terminal-id]') as HTMLElement
+    const header = container.querySelector('[data-pane-canvas-card-header]') as HTMLElement
+    const blank = container.querySelector('span.flex-1') as HTMLElement
+    const interactive = container.querySelector('[aria-label="New terminal"]') as HTMLElement
+    installPointerCapture(header)
+
+    await act(async () => {
+      interactive.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10 }))
+    })
+    expect(commitBoundsMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      blank.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10 }))
+      header.dispatchEvent(pointerEvent('pointermove', { clientX: 10, clientY: 310 }))
+      header.dispatchEvent(pointerEvent('pointerup', { clientX: 10, clientY: 310 }))
+    })
+
+    expect(card.style.top).toBe('308px')
+    expect(commitBoundsMock).toHaveBeenCalledOnce()
+  })
+
+  it('resizes from the invisible bottom-right corner', async () => {
+    const card = container.querySelector('[data-pane-canvas-terminal-id]') as HTMLElement
+    const corner = container.querySelector('[data-pane-canvas-resize-corner]') as HTMLElement
+    installPointerCapture(corner)
+
+    await act(async () => {
+      corner.dispatchEvent(pointerEvent('pointerdown', { clientX: 0, clientY: 0 }))
+      corner.dispatchEvent(pointerEvent('pointermove', { clientX: 96, clientY: 80 }))
+      corner.dispatchEvent(pointerEvent('pointerup', { clientX: 96, clientY: 80 }))
+    })
+
+    expect(card.style.width).toBe('416px')
+    expect(card.style.height).toBe('300px')
+  })
+
+  it('exposes the canonical pane body attributes used by terminal overlays and AI Vault drops', () => {
+    const body = container.querySelector('[data-terminal-canvas-body-id]')
+    expect(body?.getAttribute('data-terminal-canvas-body-id')).toBe('terminal-1')
+    expect(body?.getAttribute('data-tab-group-body-id')).toBe('group-1')
+    expect(body?.getAttribute('data-worktree-id')).toBe('worktree-1')
+  })
+})

--- a/src/renderer/src/components/tab-group/TabGroupCanvasLayout.titlebar.test.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupCanvasLayout.titlebar.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PaneCanvasWorkspaceState } from './pane-canvas-layout-state'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+import TabGroupCanvasLayout from './TabGroupCanvasLayout'
+
+class ResizeObserverStub {
+  observe(): void {}
+  disconnect(): void {}
+}
+
+describe('TabGroupCanvasLayout titlebar', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(async () => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    const canvasState: PaneCanvasWorkspaceState = {
+      mode: 'canvas',
+      boundsByTerminalTabId: {}
+    }
+    await act(async () => {
+      root.render(
+        <TabGroupCanvasLayout
+          terminalItems={[]}
+          canvasState={canvasState}
+          updateCanvasState={vi.fn()}
+          onVisibleTerminalTabIdsChange={vi.fn()}
+          allowTerminalCreation={false}
+          toolbarContent={<button type="button">Scope</button>}
+        />
+      )
+    })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps unused header space draggable and only marks controls no-drag', () => {
+    const toolbar = container.querySelector('[data-pane-canvas-toolbar]') as HTMLElement
+    const controls = container.querySelector('[data-pane-canvas-toolbar-controls]') as HTMLElement
+    const splits = container.querySelector('button') as HTMLButtonElement
+
+    expect(toolbar.dataset.terminalFocusReleaseSurface).toBe('true')
+    expect(toolbar.classList.contains('pane-canvas-toolbar-window-controls-inset')).toBe(true)
+    expect(toolbar.dataset.paneCanvasToolbarControls).toBeUndefined()
+    expect(controls.dataset.paneCanvasToolbarControls).toBe('true')
+    expect(controls.classList.contains('ml-auto')).toBe(true)
+    expect(splits.getAttribute('aria-label')).toBe('Splits')
+    expect(splits.dataset.paneCanvasToolbarControl).toBe('true')
+  })
+
+  it('omits the window-control inset when another surface owns the right edge', async () => {
+    const canvasState: PaneCanvasWorkspaceState = {
+      mode: 'canvas',
+      boundsByTerminalTabId: {}
+    }
+    await act(async () => {
+      root.render(
+        <TabGroupCanvasLayout
+          terminalItems={[]}
+          canvasState={canvasState}
+          updateCanvasState={vi.fn()}
+          onVisibleTerminalTabIdsChange={vi.fn()}
+          allowTerminalCreation={false}
+          trailingChromeInset="none"
+        />
+      )
+    })
+
+    const toolbar = container.querySelector('[data-pane-canvas-toolbar]') as HTMLElement
+    expect(toolbar.classList.contains('pane-canvas-toolbar-window-controls-inset')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/tab-group/TabGroupCanvasLayout.titlebar.test.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupCanvasLayout.titlebar.test.tsx
@@ -88,4 +88,26 @@ describe('TabGroupCanvasLayout titlebar', () => {
     const toolbar = container.querySelector('[data-pane-canvas-toolbar]') as HTMLElement
     expect(toolbar.classList.contains('pane-canvas-toolbar-window-controls-inset')).toBe(false)
   })
+
+  it('contains browser zoom gestures without blocking ordinary canvas scrolling', () => {
+    const viewport = container.querySelector('[data-pane-canvas-viewport]') as HTMLElement
+    const zoomWheel = new WheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 120
+    })
+    // happy-dom does not currently copy ctrlKey from WheelEventInit.
+    Object.defineProperty(zoomWheel, 'ctrlKey', { value: true })
+    const scrollWheel = new WheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 120
+    })
+
+    viewport.dispatchEvent(zoomWheel)
+    viewport.dispatchEvent(scrollWheel)
+
+    expect(zoomWheel.defaultPrevented).toBe(true)
+    expect(scrollWheel.defaultPrevented).toBe(false)
+  })
 })

--- a/src/renderer/src/components/tab-group/TabGroupCanvasLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupCanvasLayout.tsx
@@ -1,0 +1,375 @@
+import { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react'
+import { SquareTerminal } from 'lucide-react'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
+import { translate } from '@/i18n/i18n'
+import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
+import { useAppStore } from '../../store'
+import { closeTerminalTab } from '../terminal/terminal-tab-actions'
+import { activateCanvasTerminal } from './activate-canvas-terminal'
+import CanvasTerminalCard, { type CanvasTerminalItem } from './CanvasTerminalCard'
+import type { PaneCanvasToolbarTrailingInset } from './pane-canvas-toolbar-chrome'
+import { PaneCanvasToolbar } from './PaneCanvasToolbar'
+import { paneCanvasExtent } from './pane-canvas-extent'
+import {
+  arrangePaneCanvasBounds,
+  PANE_CANVAS_DEFAULT_HEIGHT,
+  PANE_CANVAS_DEFAULT_WIDTH,
+  resolvePaneCanvasDrop,
+  type PaneCanvasBounds,
+  type PaneCanvasWorkspaceState
+} from './pane-canvas-layout-state'
+import { usePaneCanvasViewportVisibility } from './use-pane-canvas-viewport-visibility'
+
+export default function TabGroupCanvasLayout({
+  terminalItems,
+  worktreeId,
+  focusedTerminalTabId,
+  canvasState,
+  updateCanvasState,
+  onVisibleTerminalTabIdsChange,
+  title,
+  showSplitsButton = true,
+  allowTerminalCreation = true,
+  toolbarContent,
+  trailingChromeInset = 'window-controls',
+  emptyState,
+  onActivateItem,
+  onTogglePinned,
+  onCloseItem
+}: {
+  terminalItems: readonly CanvasTerminalItem[]
+  /** Project Canvas has one owner; global canvases carry worktreeId per item. */
+  worktreeId?: string
+  focusedTerminalTabId?: string
+  canvasState: PaneCanvasWorkspaceState
+  updateCanvasState: (
+    updater: (current: PaneCanvasWorkspaceState) => PaneCanvasWorkspaceState
+  ) => void
+  onVisibleTerminalTabIdsChange: (terminalTabIds: ReadonlySet<string>) => void
+  title?: string
+  showSplitsButton?: boolean
+  allowTerminalCreation?: boolean
+  toolbarContent?: ReactNode
+  /** Reserve fixed titlebar controls when this surface reaches the window edge. */
+  trailingChromeInset?: PaneCanvasToolbarTrailingInset
+  emptyState?: ReactNode
+  onActivateItem?: (item: CanvasTerminalItem) => void
+  onTogglePinned?: (item: CanvasTerminalItem) => void
+  onCloseItem?: (item: CanvasTerminalItem) => void
+}): React.JSX.Element {
+  const canvasContextPointRef = useRef({ x: 8, y: 8 })
+  const canvasPanCleanupRef = useRef<(() => void) | null>(null)
+  const terminalTabIds = useMemo(
+    () => terminalItems.map((item) => item.terminalTabId),
+    [terminalItems]
+  )
+  const boundsByTerminalTabId = canvasState.boundsByTerminalTabId
+  const extent = paneCanvasExtent(terminalTabIds, boundsByTerminalTabId, 1280, 800)
+  const viewportRef = usePaneCanvasViewportVisibility({
+    terminalTabIds,
+    boundsByTerminalTabId,
+    onVisibleTerminalTabIdsChange
+  })
+
+  const commitBounds = useCallback(
+    (terminalTabId: string, bounds: PaneCanvasBounds) => {
+      updateCanvasState((current) => ({
+        ...current,
+        boundsByTerminalTabId: {
+          ...current.boundsByTerminalTabId,
+          [terminalTabId]: bounds
+        }
+      }))
+    },
+    [updateCanvasState]
+  )
+
+  const otherBoundsByTerminalTabId = useMemo<Record<string, PaneCanvasBounds[]>>(
+    () =>
+      Object.fromEntries(
+        terminalTabIds.map((terminalTabId) => [
+          terminalTabId,
+          terminalTabIds
+            .filter((candidateId) => candidateId !== terminalTabId)
+            .map((candidateId) => boundsByTerminalTabId[candidateId])
+            .filter((bounds): bounds is PaneCanvasBounds => bounds !== undefined)
+        ])
+      ),
+    [boundsByTerminalTabId, terminalTabIds]
+  )
+
+  const activateTerminal = useCallback(
+    (item: CanvasTerminalItem) => {
+      if (onActivateItem) {
+        onActivateItem(item)
+        return
+      }
+      if (!worktreeId) {
+        return
+      }
+      activateCanvasTerminal({
+        worktreeId,
+        groupId: item.groupId,
+        unifiedTabId: item.unifiedTabId,
+        terminalTabId: item.terminalTabId
+      })
+      const activeLeafId =
+        useAppStore.getState().terminalLayoutsByTabId[item.terminalTabId]?.activeLeafId ?? null
+      requestAnimationFrame(() => focusTerminalTabSurface(item.terminalTabId, activeLeafId))
+    },
+    [onActivateItem, worktreeId]
+  )
+
+  const leaveWorktreeIfEmpty = useCallback(() => {
+    if (!worktreeId) {
+      return
+    }
+    const store = useAppStore.getState()
+    if (store.activeWorktreeId !== worktreeId) {
+      return
+    }
+    if (store.reconcileWorktreeTabModel(worktreeId).renderableTabCount === 0) {
+      store.setActiveWorktree(null)
+    }
+  }, [worktreeId])
+
+  const createTerminal = useCallback(async (groupId: string): Promise<string | undefined> => {
+    return await useAppStore.getState().openNewTerminalTabInActiveWorkspace(groupId)
+  }, [])
+
+  const createTerminalAt = useCallback(
+    async (point: { x: number; y: number }) => {
+      if (!allowTerminalCreation || !worktreeId) {
+        return
+      }
+      const sourceGroupId =
+        terminalItems.find((item) => item.terminalTabId === focusedTerminalTabId)?.groupId ??
+        terminalItems[0]?.groupId ??
+        useAppStore.getState().activeGroupIdByWorktree[worktreeId]
+      if (!sourceGroupId) {
+        return
+      }
+      const created = await createTerminal(sourceGroupId)
+      if (!created) {
+        return
+      }
+      updateCanvasState((current) => {
+        const others = Object.entries(current.boundsByTerminalTabId)
+          .filter(([id]) => id !== created)
+          .map(([, bounds]) => bounds)
+        let nextBounds: PaneCanvasBounds = {
+          x: Math.max(0, point.x),
+          y: Math.max(0, point.y),
+          width: PANE_CANVAS_DEFAULT_WIDTH,
+          height: PANE_CANVAS_DEFAULT_HEIGHT
+        }
+        nextBounds = resolvePaneCanvasDrop(nextBounds, others)
+        return {
+          ...current,
+          boundsByTerminalTabId: { ...current.boundsByTerminalTabId, [created]: nextBounds }
+        }
+      })
+    },
+    [
+      allowTerminalCreation,
+      createTerminal,
+      focusedTerminalTabId,
+      terminalItems,
+      updateCanvasState,
+      worktreeId
+    ]
+  )
+
+  useEffect(
+    () => () => {
+      canvasPanCleanupRef.current?.()
+    },
+    []
+  )
+
+  const beginCanvasPan = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0 || canvasPanCleanupRef.current) {
+        return
+      }
+      const viewport = viewportRef.current
+      if (!viewport) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      const surface = event.currentTarget
+      const pointerId = event.pointerId
+      const start = {
+        x: event.clientX,
+        y: event.clientY,
+        scrollLeft: viewport.scrollLeft,
+        scrollTop: viewport.scrollTop
+      }
+      try {
+        surface.setPointerCapture(pointerId)
+      } catch {
+        // Window listeners keep panning alive if Chromium refuses capture.
+      }
+      surface.style.cursor = 'grabbing'
+
+      const move = (moveEvent: PointerEvent): void => {
+        if (moveEvent.pointerId !== pointerId) {
+          return
+        }
+        moveEvent.preventDefault()
+        viewport.scrollLeft = start.scrollLeft - (moveEvent.clientX - start.x)
+        viewport.scrollTop = start.scrollTop - (moveEvent.clientY - start.y)
+      }
+      let cleaned = false
+      const cleanup = (): void => {
+        if (cleaned) {
+          return
+        }
+        cleaned = true
+        try {
+          if (surface.hasPointerCapture(pointerId)) {
+            surface.releasePointerCapture(pointerId)
+          }
+        } catch {
+          // The background can unmount during a drag.
+        }
+        surface.style.cursor = ''
+        window.removeEventListener('pointermove', move, true)
+        window.removeEventListener('pointerup', finish, true)
+        window.removeEventListener('pointercancel', finish, true)
+        if (canvasPanCleanupRef.current === cleanup) {
+          canvasPanCleanupRef.current = null
+        }
+      }
+      const finish = (finishEvent: PointerEvent): void => {
+        if (finishEvent.pointerId === pointerId) {
+          cleanup()
+        }
+      }
+      window.addEventListener('pointermove', move, true)
+      window.addEventListener('pointerup', finish, true)
+      window.addEventListener('pointercancel', finish, true)
+      canvasPanCleanupRef.current = cleanup
+    },
+    [viewportRef]
+  )
+
+  return (
+    <div
+      className="flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden border-l border-border bg-background"
+      data-pane-canvas-root="true"
+    >
+      <div className="h-[4px] shrink-0 bg-card" data-terminal-focus-release-surface="true" />
+      <PaneCanvasToolbar
+        title={title}
+        showSplitsButton={showSplitsButton}
+        trailingChromeInset={trailingChromeInset}
+        toolbarContent={toolbarContent}
+        onShowSplits={() => updateCanvasState((current) => ({ ...current, mode: 'split' }))}
+        onArrange={() => {
+          const width = viewportRef.current?.clientWidth ?? 1280
+          updateCanvasState((current) => ({
+            ...current,
+            boundsByTerminalTabId: arrangePaneCanvasBounds(
+              terminalTabIds,
+              width,
+              current.boundsByTerminalTabId
+            )
+          }))
+        }}
+      />
+      <div
+        ref={viewportRef}
+        className="scrollbar-sleek relative flex-1 min-h-0 min-w-0 overflow-auto overscroll-contain"
+        data-pane-canvas-viewport="true"
+        data-terminal-focus-release-surface="true"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      >
+        <div
+          className="relative"
+          style={{ width: extent.width, height: extent.height }}
+          data-pane-canvas-surface="true"
+        >
+          {allowTerminalCreation && worktreeId ? (
+            <ContextMenu>
+              <ContextMenuTrigger asChild>
+                <div
+                  className="absolute inset-0 cursor-grab"
+                  data-pane-canvas-background="true"
+                  data-terminal-focus-release-surface="true"
+                  style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+                  onPointerDown={beginCanvasPan}
+                  onContextMenu={(event) => {
+                    const viewport = viewportRef.current
+                    if (!viewport) {
+                      return
+                    }
+                    const rect = viewport.getBoundingClientRect()
+                    canvasContextPointRef.current = {
+                      x: viewport.scrollLeft + event.clientX - rect.left,
+                      y: viewport.scrollTop + event.clientY - rect.top
+                    }
+                  }}
+                />
+              </ContextMenuTrigger>
+              <ContextMenuContent>
+                <ContextMenuItem
+                  onSelect={() => void createTerminalAt(canvasContextPointRef.current)}
+                >
+                  <SquareTerminal className="size-4" />
+                  {translate(
+                    'auto.components.tab.group.TabGroupCanvasLayout.newTerminalHere',
+                    'New terminal here'
+                  )}
+                </ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu>
+          ) : (
+            <div
+              className="absolute inset-0 cursor-grab"
+              data-pane-canvas-background="true"
+              data-terminal-focus-release-surface="true"
+              style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+              onPointerDown={beginCanvasPan}
+            />
+          )}
+          {terminalItems.length === 0 ? emptyState : null}
+          {terminalItems.map((item) => {
+            const bounds = boundsByTerminalTabId[item.terminalTabId]
+            if (!bounds) {
+              return null
+            }
+            return (
+              <CanvasTerminalCard
+                key={item.terminalTabId}
+                item={item}
+                worktreeId={item.worktreeId ?? worktreeId ?? ''}
+                bounds={bounds}
+                otherBounds={otherBoundsByTerminalTabId[item.terminalTabId] ?? []}
+                isFocused={item.terminalTabId === focusedTerminalTabId}
+                onActivate={activateTerminal}
+                onCreateTerminal={allowTerminalCreation && worktreeId ? createTerminal : undefined}
+                onTogglePinned={onTogglePinned}
+                onClose={
+                  onCloseItem
+                    ? () => onCloseItem(item)
+                    : worktreeId
+                      ? (terminalTabId) =>
+                          closeTerminalTab(terminalTabId, { onClosed: leaveWorktreeIfEmpty })
+                      : undefined
+                }
+                onCommitBounds={(nextBounds) => commitBounds(item.terminalTabId, nextBounds)}
+              />
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/tab-group/TabGroupCanvasLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupCanvasLayout.tsx
@@ -192,6 +192,25 @@ export default function TabGroupCanvasLayout({
     []
   )
 
+  useEffect(() => {
+    const viewport = viewportRef.current
+    if (!viewport) {
+      return
+    }
+    const containBrowserZoom = (event: WheelEvent): void => {
+      if (!event.ctrlKey) {
+        return
+      }
+      // Ctrl+wheel belongs to the Canvas while the pointer is over it. Until
+      // Canvas zoom is exposed deliberately, do not let Chromium shrink the
+      // entire Orca UI as an accidental workaround for reaching blank space.
+      event.preventDefault()
+      event.stopPropagation()
+    }
+    viewport.addEventListener('wheel', containBrowserZoom, { passive: false })
+    return () => viewport.removeEventListener('wheel', containBrowserZoom)
+  }, [viewportRef])
+
   const beginCanvasPan = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       if (event.button !== 0 || canvasPanCleanupRef.current) {

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,7 +1,7 @@
 import { Suspense, useMemo } from 'react'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import { useDroppable } from '@dnd-kit/core'
-import { Ellipsis, X } from 'lucide-react'
+import { Ellipsis, LayoutDashboard, X } from 'lucide-react'
 import { useAppStore } from '../../store'
 import {
   DropdownMenu,
@@ -42,6 +42,7 @@ export default function TabGroupPanel({
   suppressBottomBorder = false,
   reserveClosedExplorerToggleSpace,
   reserveCollapsedSidebarHeaderSpace,
+  onOpenCanvas,
   isTabDragActive = false,
   hoveredTabInsertion = null
 }: {
@@ -58,6 +59,7 @@ export default function TabGroupPanel({
   suppressBottomBorder?: boolean
   reserveClosedExplorerToggleSpace: boolean
   reserveCollapsedSidebarHeaderSpace: boolean
+  onOpenCanvas?: () => void
   isTabDragActive?: boolean
   hoveredTabInsertion?: HoveredTabInsertion | null
 }): React.JSX.Element {
@@ -269,6 +271,30 @@ export default function TabGroupPanel({
             className="ml-1.5 flex shrink-0 items-center gap-0.5"
             style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
           >
+            {onOpenCanvas ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={translate(
+                      'auto.components.tab.group.TabGroupCanvasLayout.canvas',
+                      'Canvas'
+                    )}
+                    data-pane-canvas-entry-control="true"
+                    className={menuButtonClassName}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      onOpenCanvas()
+                    }}
+                  >
+                    <LayoutDashboard className="size-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={6}>
+                  {translate('auto.components.tab.group.TabGroupCanvasLayout.canvas', 'Canvas')}
+                </TooltipContent>
+              </Tooltip>
+            ) : null}
             <div className={focusedActionChromeClassName}>
               {isFocused ? (
                 <TabBarQuickCommandsButton worktreeId={worktreeId} groupId={groupId} />
@@ -324,7 +350,8 @@ export default function TabGroupPanel({
               className="shrink-0"
               style={
                 {
-                  width: 'calc(40px + var(--window-controls-width, 0px))',
+                  width:
+                    'calc(var(--right-sidebar-toggle-width, 40px) + var(--window-controls-width, 0px))',
                   WebkitAppRegion: 'no-drag'
                 } as React.CSSProperties
               }

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
@@ -89,11 +89,13 @@ describe('TabGroupSplitLayout', () => {
   }
 
   function getLeafPanelProps(isWorktreeActive: boolean) {
+    const onOpenCanvas = vi.fn()
     const element = TabGroupSplitLayout({
       layout: { type: 'leaf', groupId: 'group-1' },
       worktreeId: 'wt-1',
       focusedGroupId: 'group-1',
-      isWorktreeActive
+      isWorktreeActive,
+      onOpenCanvas
     })
 
     const tabGroupPanelElement = asElement(getSplitNodeElement(element))
@@ -105,6 +107,7 @@ describe('TabGroupSplitLayout', () => {
       hasSplitGroups: boolean
       reserveClosedExplorerToggleSpace: boolean
       reserveCollapsedSidebarHeaderSpace: boolean
+      onOpenCanvas?: () => void
     }
   }
 
@@ -117,7 +120,8 @@ describe('TabGroupSplitLayout', () => {
         isFocused: false,
         hasSplitGroups: false,
         reserveClosedExplorerToggleSpace: true,
-        reserveCollapsedSidebarHeaderSpace: true
+        reserveCollapsedSidebarHeaderSpace: true,
+        onOpenCanvas: expect.any(Function)
       })
     )
   })
@@ -131,7 +135,8 @@ describe('TabGroupSplitLayout', () => {
         isFocused: true,
         hasSplitGroups: false,
         reserveClosedExplorerToggleSpace: true,
-        reserveCollapsedSidebarHeaderSpace: true
+        reserveCollapsedSidebarHeaderSpace: true,
+        onOpenCanvas: expect.any(Function)
       })
     )
   })
@@ -148,6 +153,7 @@ describe('TabGroupSplitLayout', () => {
   })
 
   it('only reserves top-right header space for the floating explorer toggle', () => {
+    const onOpenCanvas = vi.fn()
     const element = TabGroupSplitLayout({
       layout: {
         type: 'split',
@@ -158,7 +164,8 @@ describe('TabGroupSplitLayout', () => {
       },
       worktreeId: 'wt-1',
       focusedGroupId: 'right-group',
-      isWorktreeActive: true
+      isWorktreeActive: true,
+      onOpenCanvas
     })
 
     const rootElement = asElement(getSplitNodeElement(element))
@@ -168,22 +175,26 @@ describe('TabGroupSplitLayout', () => {
     const leftPanelProps = asElement(invokeComponent(asElement(leftChild))).props as {
       reserveClosedExplorerToggleSpace: boolean
       reserveCollapsedSidebarHeaderSpace: boolean
+      onOpenCanvas?: () => void
     }
     const rightPanelProps = asElement(invokeComponent(asElement(rightChild))).props as {
       reserveClosedExplorerToggleSpace: boolean
       reserveCollapsedSidebarHeaderSpace: boolean
+      onOpenCanvas?: () => void
     }
 
     expect(leftPanelProps).toEqual(
       expect.objectContaining({
         reserveClosedExplorerToggleSpace: false,
-        reserveCollapsedSidebarHeaderSpace: true
+        reserveCollapsedSidebarHeaderSpace: true,
+        onOpenCanvas: undefined
       })
     )
     expect(rightPanelProps).toEqual(
       expect.objectContaining({
         reserveClosedExplorerToggleSpace: true,
-        reserveCollapsedSidebarHeaderSpace: false
+        reserveCollapsedSidebarHeaderSpace: false,
+        onOpenCanvas
       })
     )
   })

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -156,7 +156,8 @@ function SplitNode({
   suppressRightBorder,
   suppressBottomBorder,
   isTabDragActive,
-  hoveredTabInsertion
+  hoveredTabInsertion,
+  onOpenCanvas
 }: {
   node: TabGroupLayoutNode
   nodePath: string
@@ -173,6 +174,7 @@ function SplitNode({
   suppressBottomBorder: boolean
   isTabDragActive: boolean
   hoveredTabInsertion: HoveredTabInsertion | null
+  onOpenCanvas?: () => void
 }): React.JSX.Element {
   const setTabGroupSplitRatio = useAppStore((state) => state.setTabGroupSplitRatio)
   const recordFeatureInteraction = useAppStore((state) => state.recordFeatureInteraction)
@@ -197,6 +199,7 @@ function SplitNode({
         suppressBottomBorder={suppressBottomBorder}
         reserveClosedExplorerToggleSpace={touchesTopEdge && touchesRightEdge}
         reserveCollapsedSidebarHeaderSpace={touchesTopEdge && touchesLeftEdge}
+        onOpenCanvas={touchesTopEdge && touchesRightEdge ? onOpenCanvas : undefined}
         isTabDragActive={isTabDragActive}
         hoveredTabInsertion={
           hoveredTabInsertion?.groupId === node.groupId ? hoveredTabInsertion : null
@@ -232,6 +235,7 @@ function SplitNode({
           suppressBottomBorder={isHorizontal ? suppressBottomBorder : true}
           isTabDragActive={isTabDragActive}
           hoveredTabInsertion={hoveredTabInsertion}
+          onOpenCanvas={onOpenCanvas}
         />
       </div>
       <ResizeHandle
@@ -256,6 +260,7 @@ function SplitNode({
           suppressBottomBorder={suppressBottomBorder}
           isTabDragActive={isTabDragActive}
           hoveredTabInsertion={hoveredTabInsertion}
+          onOpenCanvas={onOpenCanvas}
         />
       </div>
     </div>
@@ -266,12 +271,14 @@ export default function TabGroupSplitLayout({
   layout,
   worktreeId,
   focusedGroupId,
-  isWorktreeActive
+  isWorktreeActive,
+  onOpenCanvas
 }: {
   layout: TabGroupLayoutNode
   worktreeId: string
   focusedGroupId?: string
   isWorktreeActive: boolean
+  onOpenCanvas?: () => void
 }): React.JSX.Element {
   const dragSplit = useTabDragSplit({ worktreeId, enabled: isWorktreeActive })
   const hasSplits = layout.type === 'split'
@@ -334,6 +341,7 @@ export default function TabGroupSplitLayout({
               suppressBottomBorder={false}
               isTabDragActive={dragSplit.activeDrag !== null}
               hoveredTabInsertion={dragSplit.hoveredTabInsertion}
+              onOpenCanvas={onOpenCanvas}
             />
           </div>
         </div>

--- a/src/renderer/src/components/tab-group/activate-canvas-terminal.test.ts
+++ b/src/renderer/src/components/tab-group/activate-canvas-terminal.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  activateWebRuntimeSessionTab: vi.fn(),
+  getRuntimeEnvironmentIdForWorktree: vi.fn(),
+  isWebRuntimeSessionActive: vi.fn(),
+  focusGroup: vi.fn(),
+  activateTab: vi.fn(),
+  setActiveTab: vi.fn(),
+  setActiveTabType: vi.fn()
+}))
+
+vi.mock('@/lib/worktree-runtime-owner', () => ({
+  getRuntimeEnvironmentIdForWorktree: mocks.getRuntimeEnvironmentIdForWorktree
+}))
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  activateWebRuntimeSessionTab: mocks.activateWebRuntimeSessionTab,
+  isWebRuntimeSessionActive: mocks.isWebRuntimeSessionActive
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({
+      focusGroup: mocks.focusGroup,
+      activateTab: mocks.activateTab,
+      setActiveTab: mocks.setActiveTab,
+      setActiveTabType: mocks.setActiveTabType
+    })
+  }
+}))
+
+import { activateCanvasTerminal } from './activate-canvas-terminal'
+
+const target = {
+  worktreeId: 'worktree-1',
+  groupId: 'group-1',
+  unifiedTabId: 'unified-1',
+  terminalTabId: 'terminal-1'
+}
+
+describe('activateCanvasTerminal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getRuntimeEnvironmentIdForWorktree.mockReturnValue('environment-1')
+  })
+
+  it("selects the terminal through Orca's canonical group and tab state", () => {
+    mocks.isWebRuntimeSessionActive.mockReturnValue(false)
+
+    activateCanvasTerminal(target)
+
+    expect(mocks.focusGroup).toHaveBeenCalledWith('worktree-1', 'group-1')
+    expect(mocks.activateTab).toHaveBeenCalledWith('unified-1')
+    expect(mocks.setActiveTab).toHaveBeenCalledWith('terminal-1')
+    expect(mocks.setActiveTabType).toHaveBeenCalledWith('terminal')
+    expect(mocks.activateWebRuntimeSessionTab).not.toHaveBeenCalled()
+  })
+
+  it('also activates the host tab for a web runtime session', () => {
+    mocks.isWebRuntimeSessionActive.mockReturnValue(true)
+
+    activateCanvasTerminal(target)
+
+    expect(mocks.activateWebRuntimeSessionTab).toHaveBeenCalledWith({
+      worktreeId: 'worktree-1',
+      tabId: 'terminal-1',
+      environmentId: 'environment-1'
+    })
+  })
+})

--- a/src/renderer/src/components/tab-group/activate-canvas-terminal.ts
+++ b/src/renderer/src/components/tab-group/activate-canvas-terminal.ts
@@ -1,0 +1,34 @@
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import {
+  activateWebRuntimeSessionTab,
+  isWebRuntimeSessionActive
+} from '@/runtime/web-runtime-session'
+import { useAppStore } from '@/store'
+
+export function activateCanvasTerminal({
+  worktreeId,
+  groupId,
+  unifiedTabId,
+  terminalTabId
+}: {
+  worktreeId: string
+  groupId: string
+  unifiedTabId: string
+  terminalTabId: string
+}): void {
+  const store = useAppStore.getState()
+  store.focusGroup(worktreeId, groupId)
+  store.activateTab(unifiedTabId)
+
+  const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(store, worktreeId)
+  if (isWebRuntimeSessionActive(runtimeEnvironmentId)) {
+    void activateWebRuntimeSessionTab({
+      worktreeId,
+      tabId: terminalTabId,
+      environmentId: runtimeEnvironmentId
+    })
+  }
+
+  store.setActiveTab(terminalTabId)
+  store.setActiveTabType('terminal')
+}

--- a/src/renderer/src/components/tab-group/pane-canvas-extent.test.ts
+++ b/src/renderer/src/components/tab-group/pane-canvas-extent.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { collectVisiblePaneCanvasTerminalIds, paneCanvasExtent } from './pane-canvas-extent'
+
+describe('pane canvas extent', () => {
+  it('grows beyond the viewport to retain off-screen cards', () => {
+    expect(
+      paneCanvasExtent(['far'], { far: { x: 1400, y: 900, width: 480, height: 320 } }, 1280, 800)
+    ).toEqual({ width: 1888, height: 1228 })
+  })
+
+  it('ignores retained bounds for sessions outside the current scope', () => {
+    expect(
+      paneCanvasExtent(
+        ['active'],
+        {
+          active: { x: 20, y: 20, width: 480, height: 320 },
+          dormant: { x: 5000, y: 4000, width: 480, height: 320 }
+        },
+        1280,
+        800
+      )
+    ).toEqual({ width: 1280, height: 800 })
+  })
+
+  it('reports only cards intersecting the viewport margin', () => {
+    const visible = collectVisiblePaneCanvasTerminalIds(
+      ['onscreen', 'nearby', 'offscreen'],
+      {
+        onscreen: { x: 20, y: 20, width: 320, height: 220 },
+        nearby: { x: 920, y: 20, width: 320, height: 220 },
+        offscreen: { x: 1400, y: 20, width: 320, height: 220 }
+      },
+      { scrollLeft: 0, scrollTop: 0, clientWidth: 800, clientHeight: 600 },
+      128
+    )
+
+    expect([...visible]).toEqual(['onscreen', 'nearby'])
+  })
+
+  it('updates visibility after scrolling without treating every canvas card as foreground', () => {
+    const bounds = {
+      first: { x: 20, y: 20, width: 320, height: 220 },
+      second: { x: 20, y: 900, width: 320, height: 220 }
+    }
+
+    expect(
+      collectVisiblePaneCanvasTerminalIds(
+        ['first', 'second'],
+        bounds,
+        { scrollLeft: 0, scrollTop: 760, clientWidth: 800, clientHeight: 600 },
+        64
+      )
+    ).toEqual(new Set(['second']))
+  })
+})

--- a/src/renderer/src/components/tab-group/pane-canvas-extent.test.ts
+++ b/src/renderer/src/components/tab-group/pane-canvas-extent.test.ts
@@ -5,7 +5,13 @@ describe('pane canvas extent', () => {
   it('grows beyond the viewport to retain off-screen cards', () => {
     expect(
       paneCanvasExtent(['far'], { far: { x: 1400, y: 900, width: 480, height: 320 } }, 1280, 800)
-    ).toEqual({ width: 1888, height: 1228 })
+    ).toEqual({ width: 2528, height: 1628 })
+  })
+
+  it('keeps trailing workspace below a viewport-height card for panning and resizing', () => {
+    expect(
+      paneCanvasExtent(['tall'], { tall: { x: 8, y: 8, width: 560, height: 760 } }, 1280, 800)
+    ).toEqual({ width: 1280, height: 1176 })
   })
 
   it('ignores retained bounds for sessions outside the current scope', () => {

--- a/src/renderer/src/components/tab-group/pane-canvas-extent.ts
+++ b/src/renderer/src/components/tab-group/pane-canvas-extent.ts
@@ -1,0 +1,54 @@
+import { PANE_CANVAS_GAP, type PaneCanvasBounds } from './pane-canvas-layout-state'
+
+export type PaneCanvasViewport = {
+  scrollLeft: number
+  scrollTop: number
+  clientWidth: number
+  clientHeight: number
+}
+
+export function collectVisiblePaneCanvasTerminalIds(
+  terminalTabIds: readonly string[],
+  boundsByTerminalTabId: Readonly<Record<string, PaneCanvasBounds>>,
+  viewport: PaneCanvasViewport,
+  margin: number
+): Set<string> {
+  const left = Math.max(0, viewport.scrollLeft - margin)
+  const top = Math.max(0, viewport.scrollTop - margin)
+  const right = viewport.scrollLeft + viewport.clientWidth + margin
+  const bottom = viewport.scrollTop + viewport.clientHeight + margin
+  const visible = new Set<string>()
+  for (const terminalTabId of terminalTabIds) {
+    const bounds = boundsByTerminalTabId[terminalTabId]
+    if (
+      bounds &&
+      bounds.x < right &&
+      bounds.x + bounds.width > left &&
+      bounds.y < bottom &&
+      bounds.y + bounds.height > top
+    ) {
+      visible.add(terminalTabId)
+    }
+  }
+  return visible
+}
+
+export function paneCanvasExtent(
+  terminalTabIds: readonly string[],
+  boundsByTerminalTabId: Readonly<Record<string, PaneCanvasBounds>>,
+  minimumWidth: number,
+  minimumHeight: number
+): { width: number; height: number } {
+  return terminalTabIds.reduce(
+    (extent, terminalTabId) => {
+      const bounds = boundsByTerminalTabId[terminalTabId]
+      return bounds
+        ? {
+            width: Math.max(extent.width, bounds.x + bounds.width + PANE_CANVAS_GAP),
+            height: Math.max(extent.height, bounds.y + bounds.height + PANE_CANVAS_GAP)
+          }
+        : extent
+    },
+    { width: minimumWidth, height: minimumHeight }
+  )
+}

--- a/src/renderer/src/components/tab-group/pane-canvas-extent.ts
+++ b/src/renderer/src/components/tab-group/pane-canvas-extent.ts
@@ -1,5 +1,8 @@
 import { PANE_CANVAS_GAP, type PaneCanvasBounds } from './pane-canvas-layout-state'
 
+const PANE_CANVAS_MIN_TRAILING_WORKSPACE = 256
+const PANE_CANVAS_TRAILING_VIEWPORT_RATIO = 0.5
+
 export type PaneCanvasViewport = {
   scrollLeft: number
   scrollTop: number
@@ -39,13 +42,30 @@ export function paneCanvasExtent(
   minimumWidth: number,
   minimumHeight: number
 ): { width: number; height: number } {
+  const trailingWidth = Math.max(
+    PANE_CANVAS_MIN_TRAILING_WORKSPACE,
+    minimumWidth * PANE_CANVAS_TRAILING_VIEWPORT_RATIO
+  )
+  const trailingHeight = Math.max(
+    PANE_CANVAS_MIN_TRAILING_WORKSPACE,
+    minimumHeight * PANE_CANVAS_TRAILING_VIEWPORT_RATIO
+  )
   return terminalTabIds.reduce(
     (extent, terminalTabId) => {
       const bounds = boundsByTerminalTabId[terminalTabId]
       return bounds
         ? {
-            width: Math.max(extent.width, bounds.x + bounds.width + PANE_CANVAS_GAP),
-            height: Math.max(extent.height, bounds.y + bounds.height + PANE_CANVAS_GAP)
+            // Keep useful blank workspace beyond the last card. Without it a
+            // viewport-height terminal puts its resize edge at the scroll
+            // boundary, so there is nowhere to pan before extending it.
+            width: Math.max(
+              extent.width,
+              bounds.x + bounds.width + PANE_CANVAS_GAP + trailingWidth
+            ),
+            height: Math.max(
+              extent.height,
+              bounds.y + bounds.height + PANE_CANVAS_GAP + trailingHeight
+            )
           }
         : extent
     },

--- a/src/renderer/src/components/tab-group/pane-canvas-layout-state.test.ts
+++ b/src/renderer/src/components/tab-group/pane-canvas-layout-state.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest'
+import {
+  arrangePaneCanvasBounds,
+  collectPaneCanvasGroupIds,
+  createPaneCanvasWorkspaceState,
+  reconcilePaneCanvasWorkspaceState,
+  resolvePaneCanvasDrop,
+  resolvePaneCanvasOverlaps
+} from './pane-canvas-layout-state'
+import {
+  paneCanvasStorageKey,
+  readPaneCanvasWorkspaceState,
+  writePaneCanvasWorkspaceState
+} from './pane-canvas-layout-storage'
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>()
+  return {
+    get length() {
+      return values.size
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value)
+  }
+}
+
+describe('pane canvas layout state', () => {
+  it('collects groups in split-tree order', () => {
+    expect(
+      collectPaneCanvasGroupIds({
+        type: 'split',
+        direction: 'horizontal',
+        first: { type: 'leaf', groupId: 'left' },
+        second: {
+          type: 'split',
+          direction: 'vertical',
+          first: { type: 'leaf', groupId: 'top-right' },
+          second: { type: 'leaf', groupId: 'bottom-right' }
+        }
+      })
+    ).toEqual(['left', 'top-right', 'bottom-right'])
+  })
+
+  it('packs panes into deterministic rows', () => {
+    const arranged = arrangePaneCanvasBounds(['a', 'b', 'c'], 1200)
+    expect(arranged.a).toMatchObject({ x: 8, y: 8 })
+    expect(arranged.b.x).toBeGreaterThan(arranged.a.x)
+    expect(arranged.c).toMatchObject({ x: 8, y: 376 })
+  })
+
+  it('arranges positions without changing pane dimensions', () => {
+    const arranged = arrangePaneCanvasBounds(['a', 'b'], 1200, {
+      a: { x: 900, y: 700, width: 420, height: 280 },
+      b: { x: 20, y: 900, width: 640, height: 520 }
+    })
+    expect(arranged.a).toEqual({ x: 8, y: 8, width: 420, height: 280 })
+    expect(arranged.b).toEqual({ x: 436, y: 8, width: 640, height: 520 })
+  })
+
+  it('repairs existing overlaps deterministically', () => {
+    const shared = { x: 8, y: 8, width: 560, height: 360 }
+    const resolved = resolvePaneCanvasOverlaps(['first', 'second'], {
+      first: shared,
+      second: shared
+    })
+
+    expect(resolved.first).toEqual(shared)
+    expect(resolved.second).not.toEqual(shared)
+    expect(
+      resolved.second.x >= shared.x + shared.width + 8 ||
+        resolved.second.y >= shared.y + shared.height + 8
+    ).toBe(true)
+  })
+
+  it('can retain bounded dormant bounds for global canvases', () => {
+    const original = createPaneCanvasWorkspaceState(['active', 'dormant'])
+    original.boundsByTerminalTabId.dormant = {
+      x: 744,
+      y: 456,
+      width: 640,
+      height: 480
+    }
+
+    const whileStopped = reconcilePaneCanvasWorkspaceState(original, ['active'], undefined, {
+      preserveMissingBounds: true
+    })
+    expect(whileStopped.boundsByTerminalTabId.dormant).toEqual({
+      x: 744,
+      y: 456,
+      width: 640,
+      height: 480
+    })
+
+    const restarted = reconcilePaneCanvasWorkspaceState(
+      whileStopped,
+      ['active', 'dormant'],
+      undefined,
+      { preserveMissingBounds: true }
+    )
+    expect(restarted.boundsByTerminalTabId.dormant).toEqual({
+      x: 744,
+      y: 456,
+      width: 640,
+      height: 480
+    })
+  })
+
+  it('still prunes missing bounds for ordinary project canvases', () => {
+    const original = createPaneCanvasWorkspaceState(['active', 'closed'])
+    const reconciled = reconcilePaneCanvasWorkspaceState(original, ['active'])
+    expect(reconciled.boundsByTerminalTabId).not.toHaveProperty('closed')
+  })
+
+  it('repairs an overlapping saved layout even when the legacy toggle was off', () => {
+    const storage = memoryStorage()
+    const shared = { x: 8, y: 8, width: 560, height: 360 }
+    storage.setItem(
+      paneCanvasStorageKey('legacy-overlap'),
+      JSON.stringify({
+        version: 2,
+        mode: 'canvas',
+        preferences: { snap: true, preventOverlap: false },
+        boundsByTerminalTabId: { first: shared, second: shared }
+      })
+    )
+
+    const restored = readPaneCanvasWorkspaceState(storage, 'legacy-overlap', ['first', 'second'])
+    expect(restored).not.toHaveProperty('preferences')
+    expect(restored.boundsByTerminalTabId.first).toEqual(shared)
+    expect(restored.boundsByTerminalTabId.second).not.toEqual(shared)
+  })
+
+  it('round-trips mode and bounds per owner', () => {
+    const storage = memoryStorage()
+    const state = createPaneCanvasWorkspaceState(['a'])
+    state.mode = 'canvas'
+    state.boundsByTerminalTabId.a.x = 88
+    writePaneCanvasWorkspaceState(storage, 'ssh:host/worktree', state)
+
+    expect(readPaneCanvasWorkspaceState(storage, 'ssh:host/worktree', ['a'])).toEqual(state)
+    expect(storage.getItem(paneCanvasStorageKey('another-owner'))).toBeNull()
+  })
+
+  it('falls back safely for corrupt storage and sanitizes individual bounds', () => {
+    const storage = memoryStorage()
+    storage.setItem(paneCanvasStorageKey('broken'), '{ nope')
+    expect(readPaneCanvasWorkspaceState(storage, 'broken', ['a']).mode).toBe('split')
+
+    storage.setItem(
+      paneCanvasStorageKey('partial'),
+      JSON.stringify({
+        mode: 'canvas',
+        preferences: { snap: false },
+        boundsByTerminalTabId: { a: { x: 'bad', y: 12, width: 4, height: 400 } }
+      })
+    )
+    const partial = readPaneCanvasWorkspaceState(storage, 'partial', ['a'])
+    expect(partial.mode).toBe('canvas')
+    expect(partial).not.toHaveProperty('preferences')
+    expect(partial.boundsByTerminalTabId.a).toMatchObject({
+      x: 8,
+      y: 12,
+      width: 320,
+      height: 400
+    })
+  })
+
+  it('adds and prunes terminal geometry without moving retained cards', () => {
+    const original = createPaneCanvasWorkspaceState(['a', 'b'])
+    original.boundsByTerminalTabId.b.x = 904
+    const reconciled = reconcilePaneCanvasWorkspaceState(original, ['b', 'c'])
+    expect(Object.keys(reconciled.boundsByTerminalTabId)).toEqual(['b', 'c'])
+    expect(reconciled.boundsByTerminalTabId.b.x).toBe(904)
+  })
+
+  it('places a new terminal clear of custom retained geometry', () => {
+    const original = createPaneCanvasWorkspaceState(['a'])
+    original.boundsByTerminalTabId.a = { x: 8, y: 8, width: 1200, height: 500 }
+    const reconciled = reconcilePaneCanvasWorkspaceState(original, ['a', 'new-terminal'])
+    expect(reconciled.boundsByTerminalTabId.a).toEqual(original.boundsByTerminalTabId.a)
+    expect(reconciled.boundsByTerminalTabId['new-terminal'].y).toBeGreaterThan(500)
+  })
+
+  it('allows travel across panes but resolves an overlapping drop down or right', () => {
+    const requested = { x: 100, y: 100, width: 320, height: 220 }
+    const resolved = resolvePaneCanvasDrop(requested, [{ x: 80, y: 80, width: 400, height: 300 }])
+    expect(resolved.x).toBeGreaterThanOrEqual(requested.x)
+    expect(resolved.y).toBeGreaterThanOrEqual(requested.y)
+    expect(resolved.x > requested.x || resolved.y > requested.y).toBe(true)
+  })
+})

--- a/src/renderer/src/components/tab-group/pane-canvas-layout-state.test.ts
+++ b/src/renderer/src/components/tab-group/pane-canvas-layout-state.test.ts
@@ -184,11 +184,16 @@ describe('pane canvas layout state', () => {
     expect(reconciled.boundsByTerminalTabId['new-terminal'].y).toBeGreaterThan(500)
   })
 
-  it('allows travel across panes but resolves an overlapping drop down or right', () => {
+  it('allows travel across panes and resolves an overlapping drop to nearby open space', () => {
     const requested = { x: 100, y: 100, width: 320, height: 220 }
     const resolved = resolvePaneCanvasDrop(requested, [{ x: 80, y: 80, width: 400, height: 300 }])
-    expect(resolved.x).toBeGreaterThanOrEqual(requested.x)
-    expect(resolved.y).toBeGreaterThanOrEqual(requested.y)
-    expect(resolved.x > requested.x || resolved.y > requested.y).toBe(true)
+    expect(resolved).not.toEqual(requested)
+  })
+
+  it('moves a right-side overlap left when that is the nearest open space', () => {
+    const requested = { x: 900, y: 100, width: 560, height: 360 }
+    const resolved = resolvePaneCanvasDrop(requested, [{ x: 1000, y: 0, width: 560, height: 900 }])
+
+    expect(resolved).toEqual({ x: 432, y: 100, width: 560, height: 360 })
   })
 })

--- a/src/renderer/src/components/tab-group/pane-canvas-layout-state.ts
+++ b/src/renderer/src/components/tab-group/pane-canvas-layout-state.ts
@@ -1,0 +1,226 @@
+import type { TabGroupLayoutNode } from '../../../../shared/tab-types'
+
+export type PaneCanvasBounds = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export type PaneCanvasWorkspaceState = {
+  mode: 'split' | 'canvas'
+  boundsByTerminalTabId: Record<string, PaneCanvasBounds>
+}
+
+export type PaneCanvasReconcileOptions = {
+  preserveMissingBounds?: boolean
+  maxPreservedBounds?: number
+}
+
+export const PANE_CANVAS_GAP = 8
+export const PANE_CANVAS_MIN_WIDTH = 320
+export const PANE_CANVAS_MIN_HEIGHT = 220
+export const PANE_CANVAS_DEFAULT_WIDTH = 560
+export const PANE_CANVAS_DEFAULT_HEIGHT = 360
+const DEFAULT_MAX_PRESERVED_BOUNDS = 500
+
+function finiteNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function normalizeBounds(value: unknown, fallback: PaneCanvasBounds): PaneCanvasBounds {
+  const candidate = value && typeof value === 'object' ? (value as Partial<PaneCanvasBounds>) : {}
+  return {
+    x: Math.max(0, finiteNumber(candidate.x, fallback.x)),
+    y: Math.max(0, finiteNumber(candidate.y, fallback.y)),
+    width: Math.max(PANE_CANVAS_MIN_WIDTH, finiteNumber(candidate.width, fallback.width)),
+    height: Math.max(PANE_CANVAS_MIN_HEIGHT, finiteNumber(candidate.height, fallback.height))
+  }
+}
+
+export function collectPaneCanvasGroupIds(layout: TabGroupLayoutNode): string[] {
+  if (layout.type === 'leaf') {
+    return [layout.groupId]
+  }
+  return [...collectPaneCanvasGroupIds(layout.first), ...collectPaneCanvasGroupIds(layout.second)]
+}
+
+export function arrangePaneCanvasBounds(
+  terminalTabIds: readonly string[],
+  viewportWidth = 1280,
+  currentBounds: Readonly<Record<string, PaneCanvasBounds>> = {}
+): Record<string, PaneCanvasBounds> {
+  const rightEdge = Math.max(PANE_CANVAS_DEFAULT_WIDTH, viewportWidth - PANE_CANVAS_GAP)
+  const arranged: Record<string, PaneCanvasBounds> = {}
+  let x = PANE_CANVAS_GAP
+  let y = PANE_CANVAS_GAP
+  let rowHeight = 0
+  for (const terminalTabId of terminalTabIds) {
+    const current = currentBounds[terminalTabId]
+    const width = current?.width ?? PANE_CANVAS_DEFAULT_WIDTH
+    const height = current?.height ?? PANE_CANVAS_DEFAULT_HEIGHT
+    if (x > PANE_CANVAS_GAP && x + width > rightEdge) {
+      x = PANE_CANVAS_GAP
+      y += rowHeight + PANE_CANVAS_GAP
+      rowHeight = 0
+    }
+    arranged[terminalTabId] = { x, y, width, height }
+    x += width + PANE_CANVAS_GAP
+    rowHeight = Math.max(rowHeight, height)
+  }
+  return arranged
+}
+
+/** Repair already-overlapping panes without otherwise rearranging the Canvas. */
+export function resolvePaneCanvasOverlaps(
+  terminalTabIds: readonly string[],
+  currentBounds: Readonly<Record<string, PaneCanvasBounds>>
+): Record<string, PaneCanvasBounds> {
+  const resolved: Record<string, PaneCanvasBounds> = {}
+  const placed: PaneCanvasBounds[] = []
+  for (const terminalTabId of terminalTabIds) {
+    const bounds = currentBounds[terminalTabId]
+    if (!bounds) {
+      continue
+    }
+    const next = resolvePaneCanvasDrop(bounds, placed)
+    resolved[terminalTabId] = next
+    placed.push(next)
+  }
+  return resolved
+}
+
+export function createPaneCanvasWorkspaceState(
+  terminalTabIds: readonly string[],
+  viewportWidth?: number
+): PaneCanvasWorkspaceState {
+  return {
+    mode: 'split',
+    boundsByTerminalTabId: arrangePaneCanvasBounds(terminalTabIds, viewportWidth)
+  }
+}
+
+export function reconcilePaneCanvasWorkspaceState(
+  state: PaneCanvasWorkspaceState,
+  terminalTabIds: readonly string[],
+  viewportWidth?: number,
+  options: PaneCanvasReconcileOptions = {}
+): PaneCanvasWorkspaceState {
+  const arranged = arrangePaneCanvasBounds(terminalTabIds, viewportWidth)
+  const boundsByTerminalTabId: Record<string, PaneCanvasBounds> = {}
+  for (const terminalTabId of terminalTabIds) {
+    const retained = state.boundsByTerminalTabId[terminalTabId]
+    if (retained) {
+      boundsByTerminalTabId[terminalTabId] = normalizeBounds(retained, arranged[terminalTabId])
+    }
+  }
+  for (const terminalTabId of terminalTabIds) {
+    if (boundsByTerminalTabId[terminalTabId]) {
+      continue
+    }
+    const arrangedBounds = arranged[terminalTabId]
+    boundsByTerminalTabId[terminalTabId] = resolvePaneCanvasDrop(
+      arrangedBounds,
+      Object.values(boundsByTerminalTabId)
+    )
+  }
+  const activeBounds = resolvePaneCanvasOverlaps(terminalTabIds, boundsByTerminalTabId)
+  if (!options.preserveMissingBounds) {
+    return {
+      ...state,
+      boundsByTerminalTabId: activeBounds
+    }
+  }
+
+  const activeIds = new Set(terminalTabIds)
+  const maximum = Math.max(
+    terminalTabIds.length,
+    options.maxPreservedBounds ?? DEFAULT_MAX_PRESERVED_BOUNDS
+  )
+  const dormantLimit = maximum - terminalTabIds.length
+  const dormantCandidates = Object.entries(state.boundsByTerminalTabId).filter(
+    ([terminalTabId]) => !activeIds.has(terminalTabId)
+  )
+  const dormantEntries = (dormantLimit > 0 ? dormantCandidates.slice(-dormantLimit) : []).map(
+    ([terminalTabId, bounds]) => [
+      terminalTabId,
+      normalizeBounds(bounds, {
+        x: PANE_CANVAS_GAP,
+        y: PANE_CANVAS_GAP,
+        width: PANE_CANVAS_DEFAULT_WIDTH,
+        height: PANE_CANVAS_DEFAULT_HEIGHT
+      })
+    ]
+  )
+
+  return {
+    ...state,
+    // Why: global canvases render only live sessions, but a stopped session may
+    // return with the same tab id. Keep a bounded dormant tail so that restart
+    // restores its previous location without allowing localStorage to grow forever.
+    boundsByTerminalTabId: { ...Object.fromEntries(dormantEntries), ...activeBounds }
+  }
+}
+
+function boundsOverlap(
+  candidate: PaneCanvasBounds,
+  other: PaneCanvasBounds,
+  gap = PANE_CANVAS_GAP
+): boolean {
+  return !(
+    candidate.x + candidate.width + gap <= other.x ||
+    other.x + other.width + gap <= candidate.x ||
+    candidate.y + candidate.height + gap <= other.y ||
+    other.y + other.height + gap <= candidate.y
+  )
+}
+
+/** Finds the nearest clear position at or below/right of the requested drop.
+ *  Why: distant panes must never pull a dropped pane up or inward. */
+export function resolvePaneCanvasDrop(
+  requested: PaneCanvasBounds,
+  otherBounds: readonly PaneCanvasBounds[]
+): PaneCanvasBounds {
+  const queue: PaneCanvasBounds[] = [requested]
+  const seen = new Set<string>()
+  const maxAttempts = Math.max(64, otherBounds.length * otherBounds.length * 4)
+  let attempts = 0
+
+  while (queue.length > 0 && attempts < maxAttempts) {
+    queue.sort(
+      (left, right) =>
+        (left.x - requested.x) ** 2 +
+        (left.y - requested.y) ** 2 -
+        ((right.x - requested.x) ** 2 + (right.y - requested.y) ** 2)
+    )
+    const candidate = queue.shift()!
+    const key = `${candidate.x}:${candidate.y}`
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    attempts += 1
+    const collisions = otherBounds.filter((other) => boundsOverlap(candidate, other))
+    if (collisions.length === 0) {
+      return candidate
+    }
+    for (const collision of collisions) {
+      queue.push(
+        {
+          ...candidate,
+          x: Math.max(candidate.x, collision.x + collision.width + PANE_CANVAS_GAP)
+        },
+        {
+          ...candidate,
+          y: Math.max(candidate.y, collision.y + collision.height + PANE_CANVAS_GAP)
+        }
+      )
+    }
+  }
+
+  const bottom = otherBounds.reduce(
+    (maximum, bounds) => Math.max(maximum, bounds.y + bounds.height),
+    requested.y
+  )
+  return { ...requested, y: bottom + PANE_CANVAS_GAP }
+}

--- a/src/renderer/src/components/tab-group/pane-canvas-layout-state.ts
+++ b/src/renderer/src/components/tab-group/pane-canvas-layout-state.ts
@@ -175,8 +175,7 @@ function boundsOverlap(
   )
 }
 
-/** Finds the nearest clear position at or below/right of the requested drop.
- *  Why: distant panes must never pull a dropped pane up or inward. */
+/** Finds the nearest clear position around the requested drop. */
 export function resolvePaneCanvasDrop(
   requested: PaneCanvasBounds,
   otherBounds: readonly PaneCanvasBounds[]
@@ -205,15 +204,17 @@ export function resolvePaneCanvasDrop(
       return candidate
     }
     for (const collision of collisions) {
+      const left = collision.x - candidate.width - PANE_CANVAS_GAP
+      const above = collision.y - candidate.height - PANE_CANVAS_GAP
+      if (left >= 0) {
+        queue.push({ ...candidate, x: left })
+      }
+      if (above >= 0) {
+        queue.push({ ...candidate, y: above })
+      }
       queue.push(
-        {
-          ...candidate,
-          x: Math.max(candidate.x, collision.x + collision.width + PANE_CANVAS_GAP)
-        },
-        {
-          ...candidate,
-          y: Math.max(candidate.y, collision.y + collision.height + PANE_CANVAS_GAP)
-        }
+        { ...candidate, x: collision.x + collision.width + PANE_CANVAS_GAP },
+        { ...candidate, y: collision.y + collision.height + PANE_CANVAS_GAP }
       )
     }
   }

--- a/src/renderer/src/components/tab-group/pane-canvas-layout-storage.ts
+++ b/src/renderer/src/components/tab-group/pane-canvas-layout-storage.ts
@@ -1,0 +1,50 @@
+import {
+  createPaneCanvasWorkspaceState,
+  reconcilePaneCanvasWorkspaceState,
+  type PaneCanvasReconcileOptions,
+  type PaneCanvasWorkspaceState
+} from './pane-canvas-layout-state'
+
+const PANE_CANVAS_STORAGE_PREFIX = 'orca:pane-canvas:v2:'
+
+export function paneCanvasStorageKey(ownerKey: string): string {
+  return `${PANE_CANVAS_STORAGE_PREFIX}${encodeURIComponent(ownerKey)}`
+}
+
+export function readPaneCanvasWorkspaceState(
+  storage: Pick<Storage, 'getItem'>,
+  ownerKey: string,
+  terminalTabIds: readonly string[],
+  options: PaneCanvasReconcileOptions = {}
+): PaneCanvasWorkspaceState {
+  const fallback = createPaneCanvasWorkspaceState(terminalTabIds)
+  try {
+    const raw = storage.getItem(paneCanvasStorageKey(ownerKey))
+    if (!raw) {
+      return fallback
+    }
+    const parsed = JSON.parse(raw) as Partial<PaneCanvasWorkspaceState>
+    const state: PaneCanvasWorkspaceState = {
+      mode: parsed.mode === 'canvas' ? 'canvas' : 'split',
+      boundsByTerminalTabId:
+        parsed.boundsByTerminalTabId && typeof parsed.boundsByTerminalTabId === 'object'
+          ? parsed.boundsByTerminalTabId
+          : {}
+    }
+    return reconcilePaneCanvasWorkspaceState(state, terminalTabIds, undefined, options)
+  } catch {
+    return fallback
+  }
+}
+
+export function writePaneCanvasWorkspaceState(
+  storage: Pick<Storage, 'setItem'>,
+  ownerKey: string,
+  state: PaneCanvasWorkspaceState
+): void {
+  try {
+    storage.setItem(paneCanvasStorageKey(ownerKey), JSON.stringify(state))
+  } catch {
+    // Why: blocked local storage should leave Canvas usable for the current session.
+  }
+}

--- a/src/renderer/src/components/tab-group/pane-canvas-toolbar-chrome.ts
+++ b/src/renderer/src/components/tab-group/pane-canvas-toolbar-chrome.ts
@@ -1,0 +1,13 @@
+export type PaneCanvasToolbarTrailingInset =
+  | 'none'
+  | 'window-controls'
+  | 'window-controls-and-sidebar-toggle'
+
+export function paneCanvasToolbarTrailingInsetClassName(
+  inset: PaneCanvasToolbarTrailingInset
+): string {
+  if (inset === 'window-controls-and-sidebar-toggle') {
+    return ' pane-canvas-toolbar-window-controls-and-toggle-inset'
+  }
+  return inset === 'window-controls' ? ' pane-canvas-toolbar-window-controls-inset' : ''
+}

--- a/src/renderer/src/components/tab-group/tab-group-body-anchor.ts
+++ b/src/renderer/src/components/tab-group/tab-group-body-anchor.ts
@@ -4,6 +4,11 @@
 // heavyweight pane DOM.
 
 const ANCHOR_PREFIX = '--orca-tab-group-body-'
+const CANVAS_TERMINAL_ANCHOR_PREFIX = '--orca-canvas-terminal-body-'
+
+function encodeAnchorId(id: string): string {
+  return Array.from(id, (char) => char.codePointAt(0)?.toString(16) ?? '').join('-') || 'empty'
+}
 
 /**
  * Returns the CSS anchor name for a given tab-group id. Anchor names must be
@@ -11,6 +16,10 @@ const ANCHOR_PREFIX = '--orca-tab-group-body-'
  * the full id into hex code points before appending it to the custom prefix.
  */
 export function tabGroupBodyAnchorName(groupId: string): string {
-  const encoded = Array.from(groupId, (char) => char.codePointAt(0)?.toString(16) ?? '').join('-')
-  return `${ANCHOR_PREFIX}${encoded || 'empty'}`
+  return `${ANCHOR_PREFIX}${encodeAnchorId(groupId)}`
+}
+
+/** Positions a persistent terminal overlay inside its independent Canvas card. */
+export function terminalCanvasBodyAnchorName(terminalTabId: string): string {
+  return `${CANVAS_TERMINAL_ANCHOR_PREFIX}${encodeAnchorId(terminalTabId)}`
 }

--- a/src/renderer/src/components/tab-group/use-pane-canvas-viewport-visibility.ts
+++ b/src/renderer/src/components/tab-group/use-pane-canvas-viewport-visibility.ts
@@ -1,0 +1,61 @@
+import { useCallback, useLayoutEffect, useRef } from 'react'
+import { collectVisiblePaneCanvasTerminalIds } from './pane-canvas-extent'
+import type { PaneCanvasBounds } from './pane-canvas-layout-state'
+
+const CANVAS_VISIBILITY_MARGIN_PX = 128
+
+export function usePaneCanvasViewportVisibility({
+  terminalTabIds,
+  boundsByTerminalTabId,
+  onVisibleTerminalTabIdsChange
+}: {
+  terminalTabIds: readonly string[]
+  boundsByTerminalTabId: Readonly<Record<string, PaneCanvasBounds>>
+  onVisibleTerminalTabIdsChange: (terminalTabIds: ReadonlySet<string>) => void
+}): React.RefObject<HTMLDivElement | null> {
+  const viewportRef = useRef<HTMLDivElement | null>(null)
+  const publishViewportVisibility = useCallback(() => {
+    const viewport = viewportRef.current
+    onVisibleTerminalTabIdsChange(
+      viewport
+        ? collectVisiblePaneCanvasTerminalIds(
+            terminalTabIds,
+            boundsByTerminalTabId,
+            viewport,
+            CANVAS_VISIBILITY_MARGIN_PX
+          )
+        : new Set(terminalTabIds)
+    )
+  }, [boundsByTerminalTabId, onVisibleTerminalTabIdsChange, terminalTabIds])
+
+  useLayoutEffect(() => {
+    const viewport = viewportRef.current
+    if (!viewport) {
+      publishViewportVisibility()
+      return
+    }
+    let frameId: number | null = null
+    const schedulePublish = (): void => {
+      if (frameId !== null) {
+        return
+      }
+      frameId = requestAnimationFrame(() => {
+        frameId = null
+        publishViewportVisibility()
+      })
+    }
+    publishViewportVisibility()
+    const resizeObserver = new ResizeObserver(schedulePublish)
+    resizeObserver.observe(viewport)
+    viewport.addEventListener('scroll', schedulePublish, { passive: true })
+    return () => {
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId)
+      }
+      resizeObserver.disconnect()
+      viewport.removeEventListener('scroll', schedulePublish)
+    }
+  }, [publishViewportVisibility])
+
+  return viewportRef
+}

--- a/src/renderer/src/components/tab-group/use-pane-canvas-workspace-state.test.tsx
+++ b/src/renderer/src/components/tab-group/use-pane-canvas-workspace-state.test.tsx
@@ -1,0 +1,53 @@
+/** @vitest-environment happy-dom */
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createPaneCanvasWorkspaceState } from './pane-canvas-layout-state'
+import { paneCanvasStorageKey } from './pane-canvas-layout-storage'
+import { usePaneCanvasWorkspaceState } from './use-pane-canvas-workspace-state'
+
+describe('usePaneCanvasWorkspaceState', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('does not reload geometry when only the terminal-id array identity changes', () => {
+    const { result, rerender } = renderHook(
+      ({ terminalTabIds }: { terminalTabIds: string[] }) =>
+        usePaneCanvasWorkspaceState({ ownerKey: 'owner-1', terminalTabIds }),
+      { initialProps: { terminalTabIds: ['terminal-1'] } }
+    )
+
+    act(() => {
+      result.current.updateCanvasState((current) => ({
+        ...current,
+        boundsByTerminalTabId: {
+          ...current.boundsByTerminalTabId,
+          'terminal-1': { ...current.boundsByTerminalTabId['terminal-1'], x: 144 }
+        }
+      }))
+    })
+
+    const stalePersisted = createPaneCanvasWorkspaceState(['terminal-1'])
+    stalePersisted.boundsByTerminalTabId['terminal-1'].x = 999
+    localStorage.setItem(paneCanvasStorageKey('owner-1'), JSON.stringify(stalePersisted))
+
+    rerender({ terminalTabIds: ['terminal-1'] })
+
+    expect(result.current.canvasState.boundsByTerminalTabId['terminal-1'].x).toBe(144)
+  })
+
+  it('reconciles persisted geometry when the terminal ids actually change', () => {
+    const { result, rerender } = renderHook(
+      ({ terminalTabIds }: { terminalTabIds: string[] }) =>
+        usePaneCanvasWorkspaceState({ ownerKey: 'owner-2', terminalTabIds }),
+      { initialProps: { terminalTabIds: ['terminal-1'] } }
+    )
+
+    rerender({ terminalTabIds: ['terminal-1', 'terminal-2'] })
+
+    expect(Object.keys(result.current.canvasState.boundsByTerminalTabId)).toEqual([
+      'terminal-1',
+      'terminal-2'
+    ])
+  })
+})

--- a/src/renderer/src/components/tab-group/use-pane-canvas-workspace-state.ts
+++ b/src/renderer/src/components/tab-group/use-pane-canvas-workspace-state.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  reconcilePaneCanvasWorkspaceState,
+  type PaneCanvasWorkspaceState
+} from './pane-canvas-layout-state'
+import {
+  readPaneCanvasWorkspaceState,
+  writePaneCanvasWorkspaceState
+} from './pane-canvas-layout-storage'
+
+type PaneCanvasStateUpdater = (current: PaneCanvasWorkspaceState) => PaneCanvasWorkspaceState
+
+function browserStorage(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null
+  } catch {
+    return null
+  }
+}
+
+export function usePaneCanvasWorkspaceState({
+  ownerKey,
+  terminalTabIds,
+  preserveMissingBounds = false
+}: {
+  ownerKey: string
+  terminalTabIds: readonly string[]
+  preserveMissingBounds?: boolean
+}): {
+  canvasState: PaneCanvasWorkspaceState
+  updateCanvasState: (updater: PaneCanvasStateUpdater) => void
+} {
+  const terminalTabIdsKey = terminalTabIds.join('\0')
+  const [canvasState, setCanvasState] = useState<PaneCanvasWorkspaceState>(() => {
+    const storage = browserStorage()
+    return storage
+      ? readPaneCanvasWorkspaceState(storage, ownerKey, terminalTabIds, {
+          preserveMissingBounds
+        })
+      : reconcilePaneCanvasWorkspaceState(
+          {
+            mode: 'split',
+            boundsByTerminalTabId: {}
+          },
+          terminalTabIds,
+          undefined,
+          { preserveMissingBounds }
+        )
+  })
+
+  useEffect(() => {
+    const storage = browserStorage()
+    const currentTerminalTabIds = terminalTabIdsKey ? terminalTabIdsKey.split('\0') : []
+    setCanvasState((current) => {
+      const reconciled = storage
+        ? readPaneCanvasWorkspaceState(storage, ownerKey, currentTerminalTabIds, {
+            preserveMissingBounds
+          })
+        : reconcilePaneCanvasWorkspaceState(current, currentTerminalTabIds, undefined, {
+            preserveMissingBounds
+          })
+      if (storage) {
+        writePaneCanvasWorkspaceState(storage, ownerKey, reconciled)
+      }
+      return reconciled
+    })
+  }, [ownerKey, preserveMissingBounds, terminalTabIdsKey])
+
+  const updateCanvasState = useCallback(
+    (updater: PaneCanvasStateUpdater) => {
+      setCanvasState((current) => {
+        // Do not reconcile here. A Canvas action can create a terminal tab and
+        // assign its bounds in the same event, before React has rendered the
+        // new terminalTabIds value. Reconciling against that stale list would drop
+        // the new bounds and make the card jump to the default arrangement.
+        // The terminalTabIds effect above performs reconciliation once the store and
+        // render agree on the current layout.
+        const next = updater(current)
+        const storage = browserStorage()
+        if (storage) {
+          writePaneCanvasWorkspaceState(storage, ownerKey, next)
+        }
+        return next
+      })
+    },
+    [ownerKey]
+  )
+
+  return { canvasState, updateCanvasState }
+}

--- a/src/renderer/src/components/terminal-cold-activation.ts
+++ b/src/renderer/src/components/terminal-cold-activation.ts
@@ -20,9 +20,11 @@ export function applyTerminalColdActivation(controller: TerminalParkingFoundatio
     activeGroupIdByWorktree,
     activeTabId,
     activeTabIdByWorktree,
+    activeView,
     activeWorktreeDeferralHostId,
     activityTerminalPortals,
     backgroundMountTabIdsByWorktreeRef,
+    controlRoomVisibility,
     groupsByWorktree,
     hydrationSucceeded,
     lastActivationWorktreeIdRef,
@@ -151,6 +153,11 @@ export function applyTerminalColdActivation(controller: TerminalParkingFoundatio
     tabsByWorktree,
     activationDeferredMountTabIdsByWorktreeRef.current
   )
+  if (activeView === 'control-room') {
+    for (const worktreeId of Object.keys(controlRoomVisibility.terminalTabIdsByWorktree)) {
+      mountedWorktreeIdsRef.current.add(worktreeId)
+    }
+  }
   for (const id of mountedWorktreeIdsRef.current) {
     if (!workspaceSurfaceIdSet.has(id)) {
       mountedWorktreeIdsRef.current.delete(id)

--- a/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.tsx
@@ -1,9 +1,12 @@
-import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useAppStore } from '../../store'
 import { isProvenProcessExit } from '../../../../shared/terminal-exit-cause'
 import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
-import { tabGroupBodyAnchorName } from '../tab-group/tab-group-body-anchor'
+import {
+  tabGroupBodyAnchorName,
+  terminalCanvasBodyAnchorName
+} from '../tab-group/tab-group-body-anchor'
 import type { ActivityTerminalPortalTarget } from '../activity/activity-terminal-portal'
 import TerminalPane from './TerminalPane'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
@@ -39,11 +42,17 @@ type TerminalOverlaySlotProps = {
   worktreePath: string
   startupCwd: string | undefined
   groupId: string | undefined
+  unifiedTabId?: string
+  canvasTerminalTabId?: string
+  /** Global Canvas cards live outside the owning worktree's containing block, so CSS anchors cannot resolve them. */
+  forceMeasuredCanvasPositioning?: boolean
   isWorktreeActive: boolean
   isVisible: boolean
   isActive: boolean
   activityTerminalPortal: ActivityTerminalPortalTarget | null
   onFocusOwningGroup: ((groupId: string) => void) | undefined
+  onActivateCanvasTerminal?: (terminalTabId: string, unifiedTabId: string, groupId: string) => void
+  roundBottomCorners?: boolean
   consumeSuppressedPtyExit: (ptyId: string) => boolean
   leaveWorktreeIfEmpty: () => void
 }
@@ -55,16 +64,26 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
   worktreePath,
   startupCwd,
   groupId,
+  unifiedTabId,
+  canvasTerminalTabId,
+  forceMeasuredCanvasPositioning = false,
   isWorktreeActive,
   isVisible,
   isActive,
   activityTerminalPortal,
   onFocusOwningGroup,
+  onActivateCanvasTerminal,
+  roundBottomCorners = false,
   consumeSuppressedPtyExit,
   leaveWorktreeIfEmpty
 }: TerminalOverlaySlotProps): React.JSX.Element {
-  const anchorName = groupId !== undefined ? tabGroupBodyAnchorName(groupId) : undefined
+  const anchorName = canvasTerminalTabId
+    ? terminalCanvasBodyAnchorName(canvasTerminalTabId)
+    : groupId !== undefined
+      ? tabGroupBodyAnchorName(groupId)
+      : undefined
   const overlayRef = useRef<HTMLDivElement | null>(null)
+  const useCssAnchorPositioning = shouldUseCssAnchorPositioning() && !forceMeasuredCanvasPositioning
   const [measuredFallbackRect, setMeasuredFallbackRect] = useState<MeasuredFallbackRect | null>(
     null
   )
@@ -77,24 +96,36 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
     }
   }, [isVisible, shouldMeasureHiddenStartup])
   useLayoutEffect(() => {
-    if (!anchorName || shouldUseCssAnchorPositioning() || !groupId) {
+    const anchorTargetId = canvasTerminalTabId ?? groupId
+    if (!anchorName || useCssAnchorPositioning || !anchorTargetId) {
       return
     }
 
     const findBody = (): HTMLElement | null => {
-      for (const candidate of document.querySelectorAll<HTMLElement>('[data-tab-group-body-id]')) {
-        if (candidate.dataset.tabGroupBodyId === groupId) {
+      const selector = canvasTerminalTabId
+        ? '[data-terminal-canvas-body-id]'
+        : '[data-tab-group-body-id]'
+      for (const candidate of document.querySelectorAll<HTMLElement>(selector)) {
+        const candidateId = canvasTerminalTabId
+          ? candidate.dataset.terminalCanvasBodyId
+          : candidate.dataset.tabGroupBodyId
+        if (candidateId === anchorTargetId) {
           return candidate
         }
       }
       return null
     }
 
+    const body = findBody()
+    if (!body) {
+      setMeasuredFallbackRect(null)
+      return
+    }
+
     const updateRect = (): void => {
       const overlay = overlayRef.current
       const parent = overlay?.parentElement
-      const body = findBody()
-      if (!parent || !body) {
+      if (!parent) {
         setMeasuredFallbackRect(null)
         return
       }
@@ -119,21 +150,52 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
     }
 
     updateRect()
-    const body = findBody()
     const parent = overlayRef.current?.parentElement
     const resizeObserver = new ResizeObserver(updateRect)
-    if (body) {
-      resizeObserver.observe(body)
-    }
+    resizeObserver.observe(body)
     if (parent) {
       resizeObserver.observe(parent)
     }
+    const canvasCard = canvasTerminalTabId
+      ? body.closest<HTMLElement>('[data-pane-canvas-terminal-id]')
+      : null
+    const cardStyleObserver = canvasCard ? new MutationObserver(updateRect) : null
+    if (canvasCard && cardStyleObserver) {
+      // Canvas movement changes only the card's inline left/top. ResizeObserver
+      // does not see position changes, so web clients need this targeted style observer.
+      cardStyleObserver.observe(canvasCard, { attributes: true, attributeFilter: ['style'] })
+    }
+    const canvasViewport = canvasTerminalTabId
+      ? body.closest<HTMLElement>('[data-pane-canvas-viewport]')
+      : null
     window.addEventListener('resize', updateRect)
+    canvasViewport?.addEventListener('scroll', updateRect, { passive: true })
     return () => {
       resizeObserver.disconnect()
+      cardStyleObserver?.disconnect()
       window.removeEventListener('resize', updateRect)
+      canvasViewport?.removeEventListener('scroll', updateRect)
     }
-  }, [anchorName, groupId, isVisible])
+  }, [anchorName, canvasTerminalTabId, groupId, isVisible, useCssAnchorPositioning])
+
+  useEffect(() => {
+    const overlay = overlayRef.current
+    if (!overlay || !canvasTerminalTabId) {
+      return
+    }
+    const containReleasedWheel = (event: WheelEvent): void => {
+      // xterm consumes wheel events while its own scroll position changes, but
+      // deliberately releases them at either boundary. A Canvas terminal is
+      // positioned in a sibling overlay, so that released event can otherwise
+      // scroll the Canvas viewport underneath it. React delegates wheel events
+      // through a passive listener in Chromium, so this boundary guard must be
+      // a native non-passive listener for preventDefault() to take effect.
+      event.preventDefault()
+      event.stopPropagation()
+    }
+    overlay.addEventListener('wheel', containReleasedWheel, { passive: false })
+    return () => overlay.removeEventListener('wheel', containReleasedWheel)
+  }, [canvasTerminalTabId])
 
   useLayoutEffect(() => {
     if (!isVisible || !anchorName) {
@@ -172,7 +234,7 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
 
   const style: React.CSSProperties = useMemo(
     () =>
-      anchorName && shouldUseCssAnchorPositioning()
+      anchorName && useCssAnchorPositioning
         ? {
             position: 'absolute',
             positionAnchor: anchorName,
@@ -207,14 +269,50 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
               display: 'none',
               pointerEvents: 'none'
             },
-    [anchorName, isVisible, measuredFallbackRect, shouldMeasureHiddenStartup]
+    [
+      anchorName,
+      isVisible,
+      measuredFallbackRect,
+      shouldMeasureHiddenStartup,
+      useCssAnchorPositioning
+    ]
   )
   const focusGroup = useCallback(() => {
+    if (
+      canvasTerminalTabId !== undefined &&
+      unifiedTabId !== undefined &&
+      groupId !== undefined &&
+      onActivateCanvasTerminal
+    ) {
+      onActivateCanvasTerminal(canvasTerminalTabId, unifiedTabId, groupId)
+      return
+    }
     if (groupId !== undefined && onFocusOwningGroup) {
       onFocusOwningGroup(groupId)
     }
-  }, [groupId, onFocusOwningGroup])
-
+  }, [canvasTerminalTabId, groupId, onActivateCanvasTerminal, onFocusOwningGroup, unifiedTabId])
+  const focusClickedTerminal = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      focusGroup()
+      const target = event.target
+      const terminalRoot = target instanceof Element ? target.closest('.xterm') : null
+      const terminalInput = terminalRoot?.querySelector<HTMLTextAreaElement>(
+        'textarea.xterm-helper-textarea'
+      )
+      if (!terminalInput) {
+        return
+      }
+      // Why: activating another Canvas group updates the overlay state during
+      // the same pointer event. Reassert focus after that render so the first
+      // keystroke always reaches the terminal that was clicked.
+      requestAnimationFrame(() => {
+        if (terminalInput.isConnected) {
+          terminalInput.focus({ preventScroll: true })
+        }
+      })
+    },
+    [focusGroup]
+  )
   const terminalPane = (
     <TerminalPane
       key={`${terminalTabId}-${terminalGeneration ?? 0}`}
@@ -269,9 +367,12 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
   return (
     <div
       ref={overlayRef}
+      className={roundBottomCorners ? 'overflow-hidden rounded-b-md' : undefined}
       style={style}
       data-terminal-overlay-tab-id={terminalTabId}
-      onPointerDown={focusGroup}
+      // xterm consumes pointer input inside its viewport. Capture first so a
+      // Canvas card still becomes Orca's active group before xterm handles it.
+      onPointerDownCapture={focusClickedTerminal}
       onFocusCapture={focusGroup}
     >
       {terminalPane}

--- a/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.tsx
@@ -21,6 +21,29 @@ const MIN_OVERLAY_FIT_WIDTH_PX = 48
 const MIN_OVERLAY_FIT_HEIGHT_PX = 24
 const FALLBACK_RECT_MIN_CHANGE_PX = 1
 
+function findCanvasViewport(terminalTabId: string): HTMLElement | null {
+  for (const body of document.querySelectorAll<HTMLElement>('[data-terminal-canvas-body-id]')) {
+    if (body.dataset.terminalCanvasBodyId === terminalTabId) {
+      return body.closest<HTMLElement>('[data-pane-canvas-viewport]')
+    }
+  }
+  return null
+}
+
+function wheelDeltaPixels(delta: number, deltaMode: number, pageSize: number): number {
+  if (deltaMode === 1) {
+    return delta * 16
+  }
+  if (deltaMode === 2) {
+    return delta * pageSize
+  }
+  return delta
+}
+
+function clampScroll(value: number, maximum: number): number {
+  return Math.max(0, Math.min(Math.max(0, maximum), value))
+}
+
 function shouldUseCssAnchorPositioning(): boolean {
   return (
     HAS_CSS_ANCHOR_POSITIONING &&
@@ -187,9 +210,23 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
       // xterm consumes wheel events while its own scroll position changes, but
       // deliberately releases them at either boundary. A Canvas terminal is
       // positioned in a sibling overlay, so that released event can otherwise
-      // scroll the Canvas viewport underneath it. React delegates wheel events
-      // through a passive listener in Chromium, so this boundary guard must be
-      // a native non-passive listener for preventDefault() to take effect.
+      // never reach the Canvas viewport. Hand those released deltas back to the
+      // viewport so users can pan in either direction without first finding a
+      // sliver of empty background. React delegates wheel events through a
+      // passive listener in Chromium, so this bridge must be native/non-passive.
+      if (!event.defaultPrevented) {
+        const viewport = findCanvasViewport(canvasTerminalTabId)
+        if (viewport) {
+          const nextLeft =
+            viewport.scrollLeft +
+            wheelDeltaPixels(event.deltaX, event.deltaMode, viewport.clientWidth)
+          const nextTop =
+            viewport.scrollTop +
+            wheelDeltaPixels(event.deltaY, event.deltaMode, viewport.clientHeight)
+          viewport.scrollLeft = clampScroll(nextLeft, viewport.scrollWidth - viewport.clientWidth)
+          viewport.scrollTop = clampScroll(nextTop, viewport.scrollHeight - viewport.clientHeight)
+        }
+      }
       event.preventDefault()
       event.stopPropagation()
     }

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
@@ -247,17 +247,35 @@ describe('TerminalPaneOverlayLayer fallback measure<->fit loop (React #185)', ()
     expect(overlay?.style.left).toBe('360px')
   })
 
-  it('contains wheel input that xterm releases with a non-passive native listener', () => {
+  it('hands wheel input released by xterm back to the Canvas viewport', () => {
     const addEventListener = vi.spyOn(HTMLElement.prototype, 'addEventListener')
     renderCanvasSlot()
     const overlay = container.querySelector<HTMLElement>('[data-terminal-overlay-tab-id]')
-    const wheel = new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 120 })
+    if (!canvasViewport) {
+      throw new Error('Canvas viewport unavailable')
+    }
+    Object.defineProperties(canvasViewport, {
+      clientHeight: { value: 400 },
+      clientWidth: { value: 800 },
+      scrollHeight: { value: 1600 },
+      scrollWidth: { value: 1800 }
+    })
+    canvasViewport.scrollTop = 600
+    canvasViewport.scrollLeft = 500
+    const wheel = new WheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      deltaX: -80,
+      deltaY: -120
+    })
 
     act(() => {
       overlay?.dispatchEvent(wheel)
     })
 
     expect(wheel.defaultPrevented).toBe(true)
+    expect(canvasViewport.scrollTop).toBe(480)
+    expect(canvasViewport.scrollLeft).toBe(420)
     expect(
       addEventListener.mock.calls.some(
         ([type, , options]) =>

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
@@ -49,10 +49,12 @@ function createRect({
 const PARENT_RECT = createRect()
 
 let capturedResizeCallback: (() => void) | null = null
+let capturedMutationCallback: (() => void) | null = null
 let container: HTMLDivElement
 let bodyEl: HTMLDivElement
 let bodyRect: DOMRect
 let root: Root
+let canvasViewport: HTMLDivElement | null = null
 
 class CapturingResizeObserver {
   constructor(cb: () => void) {
@@ -61,6 +63,17 @@ class CapturingResizeObserver {
   observe(): void {}
   unobserve(): void {}
   disconnect(): void {}
+}
+
+class CapturingMutationObserver {
+  constructor(cb: () => void) {
+    capturedMutationCallback = cb
+  }
+  observe(): void {}
+  disconnect(): void {}
+  takeRecords(): MutationRecord[] {
+    return []
+  }
 }
 
 function renderSlot(): void {
@@ -86,13 +99,52 @@ function renderSlot(): void {
   })
 }
 
+function renderCanvasSlot(onActivateCanvasTerminal = vi.fn()): void {
+  bodyEl.removeAttribute('data-tab-group-body-id')
+  bodyEl.setAttribute('data-terminal-canvas-body-id', TAB_ID)
+  const canvasCard = document.createElement('div')
+  canvasCard.setAttribute('data-pane-canvas-terminal-id', TAB_ID)
+  canvasViewport = document.createElement('div')
+  canvasViewport.setAttribute('data-pane-canvas-viewport', 'true')
+  canvasCard.appendChild(bodyEl)
+  canvasViewport.appendChild(canvasCard)
+  document.body.appendChild(canvasViewport)
+
+  root = createRoot(container)
+  act(() => {
+    root.render(
+      <TerminalOverlaySlot
+        terminalTabId={TAB_ID}
+        terminalGeneration={0}
+        worktreeId="wt-1"
+        worktreePath="wt-1"
+        startupCwd={undefined}
+        groupId={GROUP_ID}
+        unifiedTabId="unified-1"
+        canvasTerminalTabId={TAB_ID}
+        isWorktreeActive
+        isVisible
+        isActive
+        activityTerminalPortal={null}
+        onFocusOwningGroup={vi.fn()}
+        onActivateCanvasTerminal={onActivateCanvasTerminal}
+        consumeSuppressedPtyExit={() => false}
+        leaveWorktreeIfEmpty={vi.fn()}
+      />
+    )
+  })
+}
+
 beforeEach(() => {
   terminalPaneRenderCount = 0
   terminalPaneProps = null
   markUnverifiedPtyLoss.mockReset()
   capturedResizeCallback = null
+  capturedMutationCallback = null
+  canvasViewport = null
   ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
   vi.stubGlobal('ResizeObserver', CapturingResizeObserver)
+  vi.stubGlobal('MutationObserver', CapturingMutationObserver)
 
   container = document.createElement('div')
   container.getBoundingClientRect = () => PARENT_RECT
@@ -111,6 +163,7 @@ afterEach(() => {
   })
   container?.remove()
   bodyEl?.remove()
+  canvasViewport?.remove()
   vi.unstubAllGlobals()
   delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
 })
@@ -177,5 +230,70 @@ describe('TerminalPaneOverlayLayer fallback measure<->fit loop (React #185)', ()
     expect(terminalPaneRenderCount - rendersAfterMount).toBe(1)
     expect(overlay?.style.top).toBe('34px')
     expect(overlay?.style.width).toBe('760px')
+  })
+
+  it('tracks Canvas card movement in web clients where CSS anchors are unavailable', () => {
+    bodyRect = createRect({ top: 80, left: 120, width: 560, height: 360 })
+    renderCanvasSlot()
+    const overlay = container.querySelector<HTMLElement>('[data-terminal-overlay-tab-id]')
+    expect(overlay?.style.top).toBe('80px')
+    expect(overlay?.style.left).toBe('120px')
+    expect(capturedMutationCallback).toBeTypeOf('function')
+
+    bodyRect = createRect({ top: 240, left: 360, width: 560, height: 360 })
+    act(() => capturedMutationCallback?.())
+
+    expect(overlay?.style.top).toBe('240px')
+    expect(overlay?.style.left).toBe('360px')
+  })
+
+  it('contains wheel input that xterm releases with a non-passive native listener', () => {
+    const addEventListener = vi.spyOn(HTMLElement.prototype, 'addEventListener')
+    renderCanvasSlot()
+    const overlay = container.querySelector<HTMLElement>('[data-terminal-overlay-tab-id]')
+    const wheel = new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 120 })
+
+    act(() => {
+      overlay?.dispatchEvent(wheel)
+    })
+
+    expect(wheel.defaultPrevented).toBe(true)
+    expect(
+      addEventListener.mock.calls.some(
+        ([type, , options]) =>
+          type === 'wheel' && typeof options === 'object' && options?.passive === false
+      )
+    ).toBe(true)
+  })
+
+  it('activates a Canvas terminal before xterm consumes its pointer event', () => {
+    const activateCanvasTerminal = vi.fn()
+    renderCanvasSlot(activateCanvasTerminal)
+    const overlay = container.querySelector<HTMLElement>('[data-terminal-overlay-tab-id]')
+    const xterm = document.createElement('div')
+    xterm.className = 'xterm'
+    const input = document.createElement('textarea')
+    input.className = 'xterm-helper-textarea'
+    xterm.appendChild(input)
+    xterm.addEventListener('pointerdown', (event) => event.stopPropagation())
+    overlay?.appendChild(xterm)
+
+    act(() => {
+      xterm.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    })
+
+    expect(activateCanvasTerminal).toHaveBeenCalledWith(TAB_ID, 'unified-1', GROUP_ID)
+  })
+
+  it('does not contain wheel input outside Canvas mode', () => {
+    renderSlot()
+    const overlay = container.querySelector<HTMLElement>('[data-terminal-overlay-tab-id]')
+    const wheel = new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 120 })
+
+    act(() => {
+      overlay?.dispatchEvent(wheel)
+    })
+
+    expect(wheel.defaultPrevented).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -2,12 +2,14 @@ import { memo, useCallback, useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import type { Tab, TabGroup } from '../../../../shared/tab-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import { useAppStore } from '../../store'
 import {
   findActivityTerminalPortal,
   type ActivityTerminalPortalTarget
 } from '../activity/activity-terminal-portal'
 import { shouldMountBackgroundWorktreeTab } from '../terminal/background-terminal-worktree-mount'
+import { activateCanvasTerminal as activateCanvasTerminalTab } from '../tab-group/activate-canvas-terminal'
 import { TerminalOverlaySlot } from './TerminalOverlaySlot'
 import { useTerminalTabColdParking } from './use-terminal-tab-cold-parking'
 
@@ -26,9 +28,15 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
   worktreeId,
   worktreePath,
   isWorktreeActive,
+  executionHostId,
+  terminalSelectionActive = isWorktreeActive,
   coldParkTerminalPanes = false,
   isForceParked = false,
   shouldMeasureHiddenWorktree = false,
+  roundBottomCorners = false,
+  canvasTerminalTabIds = null,
+  visibleCanvasTerminalTabIds = null,
+  forceCanvasFallbackPositioning = false,
   activityTerminalPortals = EMPTY_ACTIVITY_PORTALS,
   backgroundMountTabIds = null,
   activationDeferredMountTabIds = null
@@ -36,10 +44,21 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
   worktreeId: string
   worktreePath: string
   isWorktreeActive: boolean
+  executionHostId?: ExecutionHostId
+  /** A global canvas can show many worktrees, but only the selected one owns keyboard focus. */
+  terminalSelectionActive?: boolean
   coldParkTerminalPanes?: boolean
   /** Retention-budget force-park keeps eviction-exempt tabs mounted. */
   isForceParked?: boolean
   shouldMeasureHiddenWorktree?: boolean
+  /** Canvas cards round their visible body instead of meeting a window edge. */
+  roundBottomCorners?: boolean
+  /** Canvas renders every terminal tab in its own card instead of only each group's active tab. */
+  canvasTerminalTabIds?: ReadonlySet<string> | null
+  /** Canvas tabs intersecting (or just outside) the scroll viewport. */
+  visibleCanvasTerminalTabIds?: ReadonlySet<string> | null
+  /** Global Canvas anchors are outside this worktree's containing block. */
+  forceCanvasFallbackPositioning?: boolean
   activityTerminalPortals?: ActivityTerminalPortalTarget[]
   /** Targeted mounts connect only these terminal tabs. */
   backgroundMountTabIds?: ReadonlySet<string> | null
@@ -73,6 +92,16 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
   const focusOwningGroup = useCallback(
     (groupId: string) => focusGroup(worktreeId, groupId),
     [focusGroup, worktreeId]
+  )
+
+  const activateCanvasTerminal = useCallback(
+    (terminalTabId: string, unifiedTabId: string, groupId: string) => {
+      if (useAppStore.getState().activeWorktreeId !== worktreeId) {
+        setActiveWorktree(worktreeId, executionHostId)
+      }
+      activateCanvasTerminalTab({ worktreeId, groupId, unifiedTabId, terminalTabId })
+    },
+    [executionHostId, setActiveWorktree, worktreeId]
   )
 
   const groupActiveTabById = useMemo(() => {
@@ -110,10 +139,24 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
     return null
   }, [activeGroupId, assignments])
 
+  const parkingAssignments = useMemo(() => {
+    if (!canvasTerminalTabIds) {
+      return assignments
+    }
+    const visibleAssignments = new Map(assignments)
+    for (const terminalTabId of visibleCanvasTerminalTabIds ?? canvasTerminalTabIds) {
+      const assignment = visibleAssignments.get(terminalTabId)
+      if (assignment) {
+        visibleAssignments.set(terminalTabId, { ...assignment, isActiveInGroup: true })
+      }
+    }
+    return visibleAssignments
+  }, [assignments, canvasTerminalTabIds, visibleCanvasTerminalTabIds])
+
   const parkedTerminalTabIds = useTerminalTabColdParking({
     worktreeId,
     terminalTabs,
-    assignments,
+    assignments: parkingAssignments,
     isWorktreeActive,
     activeTerminalTabId,
     coldParkTerminalPanes,
@@ -135,8 +178,21 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
         )
         .map((terminalTab) => {
           const assignment = assignments.get(terminalTab.id)
-          const isVisible = Boolean(isWorktreeActive && assignment?.isActiveInGroup)
-          const isActive = Boolean(isVisible && assignment?.groupId === activeGroupId)
+          const isCanvasTerminal = canvasTerminalTabIds?.has(terminalTab.id) === true
+          const isCanvasTerminalVisible = Boolean(
+            isCanvasTerminal && (visibleCanvasTerminalTabIds?.has(terminalTab.id) ?? true)
+          )
+          const isVisible = Boolean(
+            isWorktreeActive &&
+            (canvasTerminalTabIds ? isCanvasTerminalVisible : assignment?.isActiveInGroup)
+          )
+          const isActive = Boolean(
+            isVisible &&
+            terminalSelectionActive &&
+            (canvasTerminalTabIds
+              ? terminalTab.id === activeTerminalTabId
+              : assignment?.groupId === activeGroupId)
+          )
           const activityTerminalPortal = findActivityTerminalPortal(activityTerminalPortals, {
             worktreeId,
             tabId: terminalTab.id
@@ -153,11 +209,16 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
               worktreePath={worktreePath}
               startupCwd={terminalTab.startupCwd}
               groupId={assignment?.groupId}
+              unifiedTabId={assignment?.unifiedTabId}
+              canvasTerminalTabId={isCanvasTerminal ? terminalTab.id : undefined}
+              forceMeasuredCanvasPositioning={forceCanvasFallbackPositioning && isCanvasTerminal}
               isWorktreeActive={isWorktreeActive}
               isVisible={isVisible}
               isActive={isActive}
               activityTerminalPortal={activityTerminalPortal}
               onFocusOwningGroup={focusOwningGroup}
+              onActivateCanvasTerminal={activateCanvasTerminal}
+              roundBottomCorners={roundBottomCorners}
               consumeSuppressedPtyExit={consumeSuppressedPtyExit}
               leaveWorktreeIfEmpty={leaveWorktreeIfEmpty}
             />

--- a/src/renderer/src/components/use-terminal-workspace-foundation.ts
+++ b/src/renderer/src/components/use-terminal-workspace-foundation.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import { useAppStore } from '../store'
@@ -10,6 +10,46 @@ import { useReusedArrayIdentity } from './sidebar/worktree-list/listing/use-reus
 import { selectPairedRuntimeParkingEnvironmentIds } from './terminal-pane/terminal-hidden-view-parking'
 import { createTerminalWorktreeTopologyProjection } from './terminal-pane/terminal-hidden-worktree-retention'
 import { isMainTerminalSideEffectAuthorityForPty } from './terminal-pane/terminal-side-effect-facts-handler'
+import type { ControlRoomTerminalVisibility } from './control-room/ControlRoomTerminalCanvas'
+
+function haveSameIdSet(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  if (left.size !== right.size) {
+    return false
+  }
+  for (const id of left) {
+    if (!right.has(id)) {
+      return false
+    }
+  }
+  return true
+}
+
+function haveSameIdsByWorktree(
+  left: Readonly<Record<string, ReadonlySet<string>>>,
+  right: Readonly<Record<string, ReadonlySet<string>>>
+): boolean {
+  const leftIds = Object.keys(left)
+  const rightIds = Object.keys(right)
+  return (
+    leftIds.length === rightIds.length &&
+    leftIds.every(
+      (worktreeId) => right[worktreeId] && haveSameIdSet(left[worktreeId], right[worktreeId])
+    )
+  )
+}
+
+function haveSameControlRoomVisibility(
+  left: ControlRoomTerminalVisibility,
+  right: ControlRoomTerminalVisibility
+): boolean {
+  return (
+    haveSameIdsByWorktree(left.terminalTabIdsByWorktree, right.terminalTabIdsByWorktree) &&
+    haveSameIdsByWorktree(
+      left.visibleTerminalTabIdsByWorktree,
+      right.visibleTerminalTabIdsByWorktree
+    )
+  )
+}
 
 export function useTerminalWorkspaceFoundation() {
   const terminalTopologyProjectionRef = useRef<WorktreeTabBucketProjection<
@@ -59,6 +99,19 @@ export function useTerminalWorkspaceFoundation() {
     [workspaceSurfaceIds]
   )
   const activeView = useAppStore((state) => state.activeView)
+  const [controlRoomVisibility, setControlRoomVisibility] = useState<ControlRoomTerminalVisibility>(
+    {
+      terminalTabIdsByWorktree: {},
+      visibleTerminalTabIdsByWorktree: {}
+    }
+  )
+  const handleControlRoomVisibilityChange = useCallback(
+    (next: ControlRoomTerminalVisibility) =>
+      setControlRoomVisibility((current) =>
+        haveSameControlRoomVisibility(current, next) ? current : next
+      ),
+    []
+  )
   // Why: terminal titles are leaf chrome. The root host only subscribes to
   // mount/parking semantics; a real transition publishes fresh tab objects,
   // while LiveTerminalTabBar reads title-only updates from the active bucket.
@@ -106,6 +159,8 @@ export function useTerminalWorkspaceFoundation() {
     renderedActiveWorktreeId,
     activeWorktreeDeferralHostId,
     activeView,
+    controlRoomVisibility,
+    handleControlRoomVisibilityChange,
     tabsByWorktree,
     pendingStartupByTabId,
     terminalParkingEnabled,

--- a/src/renderer/src/components/use-terminal-workspace-projection.ts
+++ b/src/renderer/src/components/use-terminal-workspace-projection.ts
@@ -18,6 +18,7 @@ export function useTerminalWorkspaceProjection(controller: TerminalWorkspaceStor
     activeWorktreeId,
     activityTerminalPortals,
     browserTabsByWorktree,
+    controlRoomVisibility,
     ensureWorktreeRootGroup,
     groupsByWorktree,
     hydrationSucceeded,
@@ -35,8 +36,17 @@ export function useTerminalWorkspaceProjection(controller: TerminalWorkspaceStor
     for (const portal of activityTerminalPortals) {
       ids.add(portal.tabId)
     }
+    if (activeView === 'control-room') {
+      for (const worktreeIds of Object.values(
+        controlRoomVisibility.visibleTerminalTabIdsByWorktree
+      )) {
+        for (const terminalTabId of worktreeIds) {
+          ids.add(terminalTabId)
+        }
+      }
+    }
     return Array.from(ids)
-  }, [activeTabId, activeTabType, activeView, activityTerminalPortals])
+  }, [activeTabId, activeTabType, activeView, activityTerminalPortals, controlRoomVisibility])
 
   useEffect(() => {
     setForegroundTerminalTabIds(foregroundTerminalTabIds)

--- a/src/renderer/src/components/use-worktree-jump-palette-quick-actions.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-quick-actions.ts
@@ -103,7 +103,9 @@ export function useWorktreeJumpPaletteQuickActions({
         activeGroupSnapshot: activeGroupSnapshotRef.current,
         openNewBrowserTab: openNewBrowserTabInActiveWorkspace,
         openNewMarkdownFile: openNewMarkdownInActiveWorkspace,
-        openNewTerminalTab: openNewTerminalTabInActiveWorkspace,
+        openNewTerminalTab: async (groupId) => {
+          await openNewTerminalTabInActiveWorkspace(groupId)
+        },
         openCreateWorkspace: openCreateWorkspaceAction,
         deleteActiveWorkspace: deleteActiveWorkspaceAction,
         openAddQuickCommand: openAddQuickCommandAction

--- a/src/renderer/src/hooks/resolve-zoom-target.ts
+++ b/src/renderer/src/hooks/resolve-zoom-target.ts
@@ -32,7 +32,7 @@ export function resolveZoomTarget(args: {
       )
     )
 
-  if (activeView !== 'terminal') {
+  if (activeView !== 'terminal' && activeView !== 'control-room') {
     return 'ui'
   }
   if (activeTabType === 'simulator') {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3298,6 +3298,23 @@
           },
           "TabGroupDropOverlay": {
             "paneColumnLabel": "New split"
+          },
+          "TabGroupCanvasLayout": {
+            "resizePaneWidth": "Resize terminal width",
+            "resizePaneHeight": "Resize terminal height",
+            "movePane": "Move terminal",
+            "newTerminal": "New terminal",
+            "closeTerminal": "Close terminal",
+            "canvas": "Canvas",
+            "splits": "Splits",
+            "arrange": "Arrange",
+            "newTerminalHere": "New terminal here"
+          },
+          "CanvasTerminalCard": {
+            "unpin": "Remove from pinned view",
+            "pin": "Pin to Control Room",
+            "agentCount": "{{value0}} agents",
+            "subagentCount": "+{{value0}} subagents"
           }
         },
         "bar": {
@@ -5268,7 +5285,8 @@
           "fee535205b": "Tasks",
           "d599269755": "Hide from sidebar",
           "artifacts": "Artifacts",
-          "skills": "Skills"
+          "skills": "Skills",
+          "controlRoom": "Control Room"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "Clear",
@@ -16564,6 +16582,21 @@
         "remoteLabel": "Browsers on {{value0}}",
         "clientNoteLocalStorage": "Imports read this device’s browsers. Cookies are stored locally.",
         "remoteNoteRemoteStorage": "Imports read browsers on {{value0}}. Cookies are stored on that machine, and a permission prompt may appear on its screen."
+      },
+      "control": {
+        "room": {
+          "ControlRoomTerminalCanvas": {
+            "title": "Control Room",
+            "active": "Active agents",
+            "all": "All live sessions",
+            "pinned": "Pinned",
+            "sessionCount": "Sessions in this view: {{value0}}",
+            "sessionCountCompact": "{{value0}}",
+            "noPinned": "No pinned sessions yet",
+            "noAgents": "No agents match this view",
+            "emptyHelp": "Active shows recognized agents. All adds ordinary live terminals. Recognized subagents stay folded into their parent count."
+          }
+        }
       },
       "native": {
         "chat": {

--- a/src/renderer/src/lib/right-sidebar-visibility.ts
+++ b/src/renderer/src/lib/right-sidebar-visibility.ts
@@ -5,6 +5,7 @@ import { isFolderRepo } from '../../../shared/repo-kind'
 type ActiveView = AppState['activeView']
 
 const RIGHT_SIDEBAR_SUPPRESSED_VIEWS = new Set<ActiveView>([
+  'control-room',
   'settings',
   'tasks',
   'activity',

--- a/src/renderer/src/lib/titlebar-worktree-history-controls.ts
+++ b/src/renderer/src/lib/titlebar-worktree-history-controls.ts
@@ -3,6 +3,7 @@ import type { UISlice } from '@/store/slices/ui'
 export function shouldShowWorktreeHistoryControls(activeView: UISlice['activeView']): boolean {
   return (
     activeView === 'terminal' ||
+    activeView === 'control-room' ||
     activeView === 'tasks' ||
     activeView === 'automations' ||
     activeView === 'artifacts' ||

--- a/src/renderer/src/lib/worktree-nav-view-history-replay.ts
+++ b/src/renderer/src/lib/worktree-nav-view-history-replay.ts
@@ -3,7 +3,12 @@ import type { WorktreeNavHistoryViewEntry } from '@/store/slices/worktree-nav-hi
 
 // Why: page entries replay via setActiveView (not open*Page) so back/forward doesn't mutate previousViewBefore* or duplicate history (see navigateToIndex).
 export function applyWorktreeNavViewEntry(entry: WorktreeNavHistoryViewEntry): void {
-  if (entry === 'automations' || entry === 'artifacts' || entry === 'skills') {
+  if (
+    entry === 'control-room' ||
+    entry === 'automations' ||
+    entry === 'artifacts' ||
+    entry === 'skills'
+  ) {
     useAppStore.getState().setActiveView(entry)
     return
   }

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -10,6 +10,7 @@ export { isWebRuntimeSessionActive } from './web-runtime-session-environment'
 export type { WebRuntimeTerminalCreateOutcome } from './web-runtime-session-types'
 export {
   createWebRuntimeSessionTerminal,
+  createWebRuntimeSessionTerminalWithIdentity,
   createWebRuntimeAgentSessionTerminal,
   createWebRuntimeAgentSessionTerminalWithLaunchDraft
 } from './web-runtime-terminal-creation'

--- a/src/renderer/src/runtime/web-runtime-terminal-creation.ts
+++ b/src/renderer/src/runtime/web-runtime-terminal-creation.ts
@@ -16,6 +16,16 @@ export async function createWebRuntimeSessionTerminal(
   return (await createWebRuntimeSessionTerminalResult(args)).outcome
 }
 
+export async function createWebRuntimeSessionTerminalWithIdentity(
+  args: CreateWebRuntimeSessionTerminalArgs
+): Promise<{ outcome: WebRuntimeTerminalCreateOutcome; terminalTabId?: string }> {
+  const created = await createWebRuntimeSessionTerminalResult(args)
+  return {
+    outcome: created.outcome,
+    ...(created.hostTabId ? { terminalTabId: toWebTerminalSurfaceTabId(created.hostTabId) } : {})
+  }
+}
+
 export async function createWebRuntimeAgentSessionTerminal(
   args: CreateWebRuntimeSessionTerminalArgs & {
     agent: TuiAgent

--- a/src/renderer/src/store/slices/cmd-j-create-actions.test.ts
+++ b/src/renderer/src/store/slices/cmd-j-create-actions.test.ts
@@ -13,7 +13,8 @@ const createWebRuntimeSessionTerminalMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/runtime/web-runtime-session', () => ({
   createWebRuntimeSessionBrowserTab: createWebRuntimeSessionBrowserTabMock,
-  createWebRuntimeSessionTerminal: createWebRuntimeSessionTerminalMock
+  createWebRuntimeSessionTerminal: createWebRuntimeSessionTerminalMock,
+  createWebRuntimeSessionTerminalWithIdentity: createWebRuntimeSessionTerminalMock
 }))
 
 vi.mock('@/lib/focus-terminal-tab-surface', () => ({
@@ -250,7 +251,10 @@ describe('Cmd+J lifted creation actions', () => {
 
   it('creates desktop remote-server terminal tabs through the owning runtime', async () => {
     delete pairedWebFlag.__ORCA_WEB_CLIENT__
-    createWebRuntimeSessionTerminalMock.mockResolvedValue(false)
+    createWebRuntimeSessionTerminalMock.mockResolvedValue({
+      outcome: { status: 'created' },
+      terminalTabId: 'web-terminal-1'
+    })
     const store = createTestStore()
     seedActiveWorkspace(store)
     store.setState({
@@ -268,7 +272,7 @@ describe('Cmd+J lifted creation actions', () => {
       settings: { activeRuntimeEnvironmentId: null } as AppState['settings']
     })
 
-    await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+    const terminalTabId = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
 
     expect(createWebRuntimeSessionTerminalMock).toHaveBeenCalledWith({
       worktreeId: 'wt-1',
@@ -276,6 +280,7 @@ describe('Cmd+J lifted creation actions', () => {
       targetGroupId: 'group-1',
       activate: true
     })
+    expect(terminalTabId).toBe('web-terminal-1')
     expect(store.getState().tabsByWorktree['wt-1'] ?? []).toEqual([])
   })
 
@@ -313,9 +318,10 @@ describe('Cmd+J lifted creation actions', () => {
       settings: { activeRuntimeEnvironmentId: null } as AppState['settings']
     })
 
-    await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+    const terminalTabId = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
 
     expect(createWebRuntimeSessionTerminalMock).not.toHaveBeenCalled()
     expect(store.getState().tabsByWorktree['wt-1'] ?? []).toHaveLength(1)
+    expect(terminalTabId).toBe(store.getState().tabsByWorktree['wt-1'][0].id)
   })
 })

--- a/src/renderer/src/store/slices/ui/ui-slice-contract-core.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-contract-core.ts
@@ -105,6 +105,7 @@ export type NewWorkspaceDraft = {
 
 export type UiViewHistory =
   | 'terminal'
+  | 'control-room'
   | 'settings'
   | 'tasks'
   | 'activity'
@@ -162,6 +163,7 @@ export type UISliceCore = {
     options?: { recordTasksInteraction?: boolean }
   ) => void
   closeTaskPage: () => void
+  openControlRoomPage: () => void
   openActivityPage: () => void
   closeActivityPage: () => void
   selectedAutomationId: string | null

--- a/src/renderer/src/store/slices/ui/ui-slice-view-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-view-actions.ts
@@ -3,6 +3,10 @@ import { rewindHistoryIndexPastView } from '../worktree-nav-history'
 
 export function createUiViewActions(set: UISliceSet, get: UISliceGet): Partial<UISlice> {
   return {
+    openControlRoomPage: () => {
+      get().recordViewVisit('control-room')
+      set({ activeView: 'control-room' })
+    },
     openActivityPage: () => {
       set((state) => ({
         activeView: 'activity',

--- a/src/renderer/src/store/slices/worktree-nav-history-view-entries.test.ts
+++ b/src/renderer/src/store/slices/worktree-nav-history-view-entries.test.ts
@@ -45,6 +45,7 @@ function createHistoryStore(worktreeIds: string[] = []): StoreApi<MinimalState> 
 }
 
 const viewCases: { entry: WorktreeNavHistorySimpleViewEntry; label: string }[] = [
+  { entry: 'control-room', label: 'Control Room' },
   { entry: 'tasks', label: 'Tasks' },
   { entry: 'automations', label: 'Automations' },
   { entry: 'artifacts', label: 'Artifacts' },

--- a/src/renderer/src/store/slices/worktree-nav-history.ts
+++ b/src/renderer/src/store/slices/worktree-nav-history.ts
@@ -15,8 +15,14 @@ import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 const MAX_HISTORY = 50
 
 // Why: entries may be page sentinels, not just worktree IDs; names keep the "worktree" prefix for call-site stability.
-export type WorktreeNavHistorySimpleViewEntry = 'tasks' | 'automations' | 'artifacts' | 'skills'
+export type WorktreeNavHistorySimpleViewEntry =
+  | 'control-room'
+  | 'tasks'
+  | 'automations'
+  | 'artifacts'
+  | 'skills'
 const SIMPLE_VIEW_ENTRIES: readonly WorktreeNavHistorySimpleViewEntry[] = [
+  'control-room',
   'tasks',
   'automations',
   'artifacts',

--- a/src/renderer/src/store/terminals/terminal-actions.ts
+++ b/src/renderer/src/store/terminals/terminal-actions.ts
@@ -84,7 +84,7 @@ export type TerminalActions = {
       forceHostRuntime?: boolean
     }
   ) => TerminalTab
-  openNewTerminalTabInActiveWorkspace: (groupId: string) => Promise<void>
+  openNewTerminalTabInActiveWorkspace: (groupId: string) => Promise<string | undefined>
   /** Synchronous retirement: provider teardown starts before state removal but is never awaited. */
   closeTab: (
     tabId: string,

--- a/src/renderer/src/store/terminals/terminal-active-workspace-creation.ts
+++ b/src/renderer/src/store/terminals/terminal-active-workspace-creation.ts
@@ -29,14 +29,15 @@ export function createActiveWorkspaceTerminalActions(
         ? worktreeRoute.route.runtimeEnvironmentId
         : getRuntimeEnvironmentIdForWorktree(state, worktreeId)
       if (runtimeEnvironmentId) {
-        const { createWebRuntimeSessionTerminal } = await import('@/runtime/web-runtime-session')
-        await createWebRuntimeSessionTerminal({
+        const { createWebRuntimeSessionTerminalWithIdentity } =
+          await import('@/runtime/web-runtime-session')
+        const created = await createWebRuntimeSessionTerminalWithIdentity({
           worktreeId,
           environmentId: runtimeEnvironmentId,
           targetGroupId: groupId,
           activate: true
         })
-        return
+        return created.terminalTabId
       }
       if (isWebClientLocation() && worktreeId !== FLOATING_TERMINAL_WORKTREE_ID) {
         return
@@ -64,6 +65,7 @@ export function createActiveWorkspaceTerminalActions(
       // Why: Cmd+J shares the titlebar-button creation path, so append the new terminal after mixed editor/browser tabs, not first.
       get().setTabBarOrder(worktreeId, [...base.filter((id) => id !== terminal.id), terminal.id])
       focusTerminalTabSurface(terminal.id)
+      return terminal.id
     }
   }
 }

--- a/src/shared/tab-title-resolution.test.ts
+++ b/src/shared/tab-title-resolution.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { resolveTerminalTabTitle, resolveUnifiedTabLabel } from './tab-title-resolution'
+import {
+  resolveCanvasTerminalLabel,
+  resolveTerminalTabTitle,
+  resolveUnifiedTabLabel
+} from './tab-title-resolution'
 
 describe('tab title resolution', () => {
   it('uses live terminal titles when generated titles are disabled', () => {
@@ -204,5 +208,25 @@ describe('tab title resolution', () => {
         true
       )
     ).toBe('Run build')
+  })
+
+  it('merges terminal title fallbacks consistently for Canvas labels', () => {
+    expect(
+      resolveCanvasTerminalLabel(
+        {
+          customLabel: null,
+          label: '',
+          generatedLabel: null,
+          quickCommandLabel: null
+        },
+        {
+          generatedTitle: 'Generated terminal title',
+          quickCommandLabel: null,
+          defaultTitle: 'Terminal 4',
+          title: 'shell'
+        },
+        true
+      )
+    ).toBe('Generated terminal title')
   })
 })

--- a/src/shared/tab-title-resolution.ts
+++ b/src/shared/tab-title-resolution.ts
@@ -40,3 +40,19 @@ export function resolveUnifiedTabLabel(
     fallback
   )
 }
+
+export function resolveCanvasTerminalLabel(
+  tab: Pick<Tab, 'customLabel' | 'quickCommandLabel' | 'aiVaultTitle' | 'generatedLabel' | 'label'>,
+  terminal: Pick<TerminalTab, 'quickCommandLabel' | 'generatedTitle' | 'defaultTitle' | 'title'>,
+  generatedTitlesEnabled: boolean
+): string {
+  return resolveUnifiedTabLabel(
+    {
+      ...tab,
+      generatedLabel: tab.generatedLabel ?? terminal.generatedTitle,
+      quickCommandLabel: tab.quickCommandLabel ?? terminal.quickCommandLabel
+    },
+    generatedTitlesEnabled,
+    terminal.defaultTitle ?? terminal.title ?? 'Terminal'
+  )
+}

--- a/src/shared/top-level-view.ts
+++ b/src/shared/top-level-view.ts
@@ -4,6 +4,7 @@ import type { TopLevelView } from './ui-chrome-types'
 // persistence boundary that validates values loaded from disk or IPC.
 const TOP_LEVEL_VIEW_LOOKUP: Record<TopLevelView, true> = {
   terminal: true,
+  'control-room': true,
   settings: true,
   tasks: true,
   activity: true,

--- a/src/shared/ui-chrome-types.ts
+++ b/src/shared/ui-chrome-types.ts
@@ -112,6 +112,7 @@ export type ManualRepoOrderEntry = {
 /** The active top-level section shown in the main content area. */
 export type TopLevelView =
   | 'terminal'
+  | 'control-room'
   | 'settings'
   | 'tasks'
   | 'activity'

--- a/tests/e2e/pane-canvas-layout.spec.ts
+++ b/tests/e2e/pane-canvas-layout.spec.ts
@@ -1,0 +1,194 @@
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { waitForActiveTerminalManager } from './helpers/terminal'
+import { execInTerminal } from './helpers/terminal-pane-operations'
+import { splitMarkerEchoCommand } from './terminal-marker-echo-command'
+
+test('presents normal terminal tabs as independent Canvas cards without remounting PTYs', async ({
+  orcaPage
+}) => {
+  await waitForSessionReady(orcaPage)
+  const worktreeId = await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage, 30_000)
+
+  const seeded = await orcaPage.evaluate((activeWorktreeId) => {
+    const state = window.__store?.getState()
+    if (!state) {
+      throw new Error('store unavailable')
+    }
+    const sourceGroupId = state.activeGroupIdByWorktree[activeWorktreeId]
+    const originalTerminalTabId = state.activeTabIdByWorktree[activeWorktreeId]
+    if (!sourceGroupId || !originalTerminalTabId) {
+      throw new Error('active terminal group unavailable')
+    }
+    const splitGroupId = state.createEmptySplitGroup(activeWorktreeId, sourceGroupId, 'right')
+    if (!splitGroupId) {
+      throw new Error('could not create second terminal group')
+    }
+    const terminal = state.createTab(activeWorktreeId, splitGroupId)
+    state.setActiveTab(terminal.id)
+    state.setActiveTabType('terminal')
+    state.focusGroup(activeWorktreeId, splitGroupId)
+    return {
+      sourceGroupId,
+      splitGroupId,
+      originalGroupCount:
+        window.__store?.getState().groupsByWorktree[activeWorktreeId]?.length ?? 0,
+      newTerminalTabId: terminal.id,
+      originalTerminalTabId
+    }
+  }, worktreeId)
+
+  const originalTerminalOverlay = orcaPage.locator(
+    `[data-terminal-overlay-tab-id="${seeded.originalTerminalTabId}"]`
+  )
+  const originalTerminalElement = await originalTerminalOverlay.elementHandle()
+  if (!originalTerminalElement) {
+    throw new Error('original terminal overlay unavailable')
+  }
+
+  await orcaPage.getByRole('button', { name: 'Canvas', exact: true }).press('Enter')
+  const canvas = orcaPage.locator('[data-pane-canvas-root="true"]')
+  await expect(canvas).toBeVisible()
+  await expect(canvas.locator('[data-pane-canvas-terminal-id]')).toHaveCount(2)
+  await expect(orcaPage.getByRole('button', { name: 'Splits' })).toBeVisible()
+  expect(await originalTerminalElement.evaluate((element) => element.isConnected)).toBe(true)
+
+  const typeIntoCanvasTerminal = async (
+    terminalTabId: string,
+    markerPrefix: string
+  ): Promise<void> => {
+    const overlay = orcaPage.locator(`[data-terminal-overlay-tab-id="${terminalTabId}"]`)
+    await overlay.locator('.xterm-screen').first().dispatchEvent('pointerdown', { button: 0 })
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(
+          (tabId) => window.__store?.getState().activeTabId === tabId,
+          terminalTabId
+        )
+      )
+      .toBe(true)
+    const markerSuffix = `-${Date.now()}`
+    const marker = `${markerPrefix}${markerSuffix}`
+    let ptyId: string | null = null
+    await expect
+      .poll(async () => {
+        ptyId = await orcaPage.evaluate((tabId) => {
+          const manager = window.__paneManagers?.get(tabId)
+          const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+          return pane?.container.dataset.ptyId ?? null
+        }, terminalTabId)
+        return ptyId
+      })
+      .not.toBeNull()
+    if (!ptyId) {
+      throw new Error(`Canvas terminal ${terminalTabId} has no active PTY`)
+    }
+    await execInTerminal(orcaPage, ptyId, splitMarkerEchoCommand(markerPrefix, markerSuffix))
+    await expect
+      .poll(async () => {
+        const content = await orcaPage.evaluate((tabId) => {
+          const manager = window.__paneManagers?.get(tabId)
+          const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+          return pane?.serializeAddon?.serialize?.() ?? ''
+        }, terminalTabId)
+        return content.includes(marker)
+      })
+      .toBe(true)
+  }
+
+  await typeIntoCanvasTerminal(seeded.originalTerminalTabId, 'orca-canvas-original')
+  await typeIntoCanvasTerminal(seeded.newTerminalTabId, 'orca-canvas-new')
+
+  const newTerminalOverlay = orcaPage.locator(
+    `[data-terminal-overlay-tab-id="${seeded.newTerminalTabId}"]`
+  )
+  await newTerminalOverlay.locator('.xterm-screen').first().click({ button: 'right', force: true })
+  await orcaPage.getByRole('menuitem', { name: 'Split Terminal Right' }).click({ force: true })
+  await expect(newTerminalOverlay.locator('.xterm')).toHaveCount(2)
+
+  const movedCard = canvas.locator(`[data-pane-canvas-terminal-id="${seeded.newTerminalTabId}"]`)
+  const moveHandle = movedCard.getByRole('button', { name: 'Move terminal' })
+  const before = await movedCard.boundingBox()
+  if (!before) {
+    throw new Error('Canvas terminal has no bounds')
+  }
+  await moveHandle.hover({ force: true })
+  await orcaPage.mouse.down()
+  await orcaPage.mouse.move(before.x + 120, before.y + 120, { steps: 4 })
+  await orcaPage.mouse.up()
+  const after = await movedCard.boundingBox()
+  expect(after?.x).not.toBe(before.x)
+
+  const resizeHandle = movedCard.locator('[data-pane-canvas-resize-corner="true"]')
+  const beforeResize = await movedCard.boundingBox()
+  if (!beforeResize) {
+    throw new Error('Canvas terminal has no resize bounds')
+  }
+  await resizeHandle.hover({ force: true })
+  await orcaPage.mouse.down()
+  await orcaPage.mouse.move(
+    beforeResize.x + beforeResize.width + 96,
+    beforeResize.y + beforeResize.height + 80,
+    { steps: 4 }
+  )
+  await orcaPage.mouse.up()
+  const afterResize = await movedCard.boundingBox()
+  expect(afterResize?.width).toBeGreaterThan(beforeResize.width)
+  expect(afterResize?.height).toBeGreaterThan(beforeResize.height)
+
+  const canvasBackground = canvas.locator('[data-pane-canvas-background="true"]')
+  await canvasBackground.click({ button: 'right', position: { x: 900, y: 650 }, force: true })
+  await orcaPage.getByRole('menuitem', { name: 'New terminal here' }).click({ force: true })
+  await expect(canvas.locator('[data-pane-canvas-terminal-id]')).toHaveCount(3)
+
+  const firstCard = canvas.locator('[data-pane-canvas-terminal-id]').first()
+  await firstCard.getByRole('button', { name: 'New terminal' }).click({ force: true })
+  await expect(canvas.locator('[data-pane-canvas-terminal-id]')).toHaveCount(4)
+
+  const canvasViewport = canvas.locator('[data-pane-canvas-viewport="true"]')
+  const overflowCard = canvas.locator('[data-pane-canvas-terminal-id]').last()
+  const overflowResizeHandle = overflowCard.getByRole('separator', {
+    name: 'Resize terminal height'
+  })
+  for (let step = 0; step < 10; step += 1) {
+    await overflowResizeHandle.press('Shift+ArrowDown')
+  }
+  await expect
+    .poll(() => canvasViewport.evaluate((element) => element.scrollHeight > element.clientHeight))
+    .toBe(true)
+
+  await orcaPage.getByRole('button', { name: 'Splits' }).click({ force: true })
+  await expect(canvas).toBeHidden()
+  await expect(orcaPage.locator('[data-tab-group-strip-id]')).toHaveCount(seeded.originalGroupCount)
+  await expect(
+    orcaPage.locator(`[data-tab-group-strip-id="${seeded.sourceGroupId}"] [data-tab-id]`)
+  ).toHaveCount(2)
+  await expect(
+    orcaPage.locator(`[data-tab-group-strip-id="${seeded.splitGroupId}"] [data-tab-id]`)
+  ).toHaveCount(2)
+  expect(await originalTerminalElement.evaluate((element) => element.isConnected)).toBe(true)
+
+  await orcaPage.getByRole('button', { name: 'Canvas', exact: true }).press('Enter')
+  await expect(canvas).toBeVisible()
+  const browserTabId = await orcaPage.evaluate(
+    ({ activeWorktreeId, targetGroupId }) => {
+      const state = window.__store?.getState()
+      if (!state) {
+        throw new Error('store unavailable')
+      }
+      return state.createBrowserTab(activeWorktreeId, 'about:blank', {
+        targetGroupId,
+        activate: true
+      }).id
+    },
+    { activeWorktreeId: worktreeId, targetGroupId: seeded.sourceGroupId }
+  )
+  await expect(canvas).toBeHidden()
+  await expect(orcaPage.locator(`[data-tab-id="${browserTabId}"]`)).toBeVisible()
+  await orcaPage.evaluate(
+    (tabId) => window.__store?.getState().closeBrowserTab(tabId),
+    browserTabId
+  )
+})


### PR DESCRIPTION
## ELI5

Orca normally shows terminals inside one project at a time.

This adds:

- **Canvas** — arrange that project’s existing terminals as movable, resizable cards.
- **Control Room** — see and supervise active agents and terminals from multiple projects in one place.

The terminals are not copied or moved. They still belong to their original projects; these are additional ways to view and organize them. It is like keeping every agent at its own project desk while adding one wall of monitors where you can supervise the whole team.

## What Changed

### Project Canvas

- Added Canvas as an alternative to the existing Splits view.
- Places the Canvas entry action in Orca’s existing project tab strip.
- Displays existing terminal tabs as movable and resizable cards.
- Preserves the existing terminal process, scrollback, input, and session lifecycle.
- Prevents cards from overlapping.
- Provides Arrange for producing a tidy non-overlapping layout.
- Persists card positions and sizes.
- Keeps unused titlebar space draggable as a native Electron window region.
- Allows switching back to Splits at any time.

### Cross-project Control Room

Added a top-level Control Room with three scopes:

- **Active agents** — recognized top-level agents from every project.
- **All live sessions** — agents plus ordinary running terminals.
- **Pinned** — a user-selected subset of live sessions.

Recognized provider subagents remain folded into their parent agent’s count instead of becoming separate cards.

Control Room reuses Orca’s existing terminal overlays. It does not create duplicate PTYs or move sessions out of their owning projects.

### Interaction and layout

- Cards can be moved using their full header.
- Cards have subtle visible boundaries.
- Arrange creates a non-overlapping layout.
- Layout remains stable when sessions stop, restart, appear, or disappear.
- Control Room retains bounded layout information for returning sessions.
- Toolbar actions follow Orca’s compact icon and button styling.

## Why

Orca’s project boundary is useful: agents and terminals should remain associated with the project or worktree where they were created.   

A concrete example is supervising 11–13 long-running primary agents across separate repositories. With project-only navigation, checking their status requires opening each project individually. Control Room fits those primary sessions into one visual workspace, while folding short-lived subagents into their parent sessions so the overview remains manageable.

That becomes difficult when someone supervises long-running agents across many repositories. Opening every project individually makes it hard to see which agents are working, waiting, or finished. Moving everything into one project would weaken Orca’s project model, while showing every automatically spawned subagent would create unnecessary noise.

This approach preserves project ownership while adding a cross-project supervision layer:

- Canvas organizes work inside one project.
- Control Room provides an overview across projects.
- Primary agents remain visible.
- Subagents remain summarized under their parent.
- Existing terminal sessions are reused rather than duplicated.

## Visual Proof

### Before

<img width="1859" height="1148" alt="CleanShot 2026-08-27 at 14 46 07" src="https://github.com/user-attachments/assets/a5252963-1e80-4f0c-9787-822f1bdca7ac" />

### After — project Canvas

<img width="2014" height="1257" alt="CleanShot 2026-08-27 at 15 10 30" src="https://github.com/user-attachments/assets/77f1bd0a-c12c-4ade-acb6-b43a202f9505" />

### After — cross-project Control Room

<img width="2011" height="1251" alt="CleanShot 2026-08-27 at 15 17 47" src="https://github.com/user-attachments/assets/2dbb3b0d-ccdd-497f-92f3-e89b0831fc64" />

## Testing

Reviewer steps:

1. Open a project containing multiple terminal tabs.
2. Switch from Splits to Canvas.
3. Type in each terminal and verify the existing sessions remain interactive.
4. Move and resize terminal cards.
5. Enable Snap and verify card positioning.
6. Use Arrange and verify the cards form a non-overlapping layout.
7. Switch back to Splits and confirm the same terminal sessions remain intact.
8. Start agents or terminals in multiple projects.
9. Open Control Room and verify:
   - Active agents shows recognized top-level agents.
   - All live sessions adds ordinary running terminals.
   - Pinned shows only sessions explicitly pinned by the user.
   - Recognized subagents are summarized under their parent.
10. Stop and restart a session and verify its Control Room layout is recovered.
11. Drag the window using unused titlebar space.

Tested locally on:

- macOS: manually tested in the Electron development build.
- Linux: not manually tested.
- Windows: not manually tested.
- Remote SSH: not manually tested.
- Mobile: not manually tested.

Automated verification performed:

- 132 targeted Canvas, Control Room, terminal-layout, and navigation tests passed.
- Full TypeScript check passed.
- Production Electron build passed.
- Changed-code and React quality checks reported no findings.
- Repository pre-commit checks passed.
- `git diff --check` passed.

Full cross-platform behavior will also rely on CI and reviewer testing.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

OpenAI Codex (GPT-5) was used to help inspect the existing architecture, implement the feature, write tests, investigate interaction bugs, and draft this PR description. The changes were manually exercised and reviewed before committing.

## Review

Areas where reviewer feedback would be especially useful:

- Whether Control Room belongs as a permanent top-level destination.
- Whether the Active agents / All live sessions / Pinned scopes are the right defaults.
- Whether retaining dormant layout entries, capped at 500, is appropriate.
- Whether recognized subagents should remain summarized or eventually become optionally expandable.
- Cross-platform terminal-overlay behavior on Linux, Windows, and Remote SSH.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security and compatibility considerations:

- Control Room does not create additional terminal processes or PTYs.
- Sessions remain owned by their original projects.
- No filesystem access, command execution, or permission boundary was added.
- Persistent Canvas state is presentation data only.
- Dormant Control Room layout storage is capped to prevent unbounded growth.
- The implementation reuses existing terminal overlays and lifecycle behavior.
- No deliberate platform-specific path or shortcut behavior was introduced.
- macOS was manually tested; Linux, Windows, Remote SSH, and Mobile still require CI or reviewer validation.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)