### PR TITLE
fix(source-control): allow an empty AI-generated PR description in Create PR

### DIFF
--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
@@ -345,12 +345,6 @@ describe('source-control Create PR intent flow helpers', () => {
     expect(
       resolveCreatePrIntentGeneratedReviewFields(current, {
         success: true,
-        fields: { ...current, title: 'Generated title', body: '   ' }
-      })
-    ).toEqual({ ok: false, error: null })
-    expect(
-      resolveCreatePrIntentGeneratedReviewFields(current, {
-        success: true,
         fields: {
           base: 'other-base',
           title: 'Generated title',
@@ -366,6 +360,33 @@ describe('source-control Create PR intent flow helpers', () => {
         body: '## Problem\n\nDetails',
         draft: true
       }
+    })
+  })
+
+  it('accepts generated review fields with an empty description', () => {
+    expect(
+      resolveCreatePrIntentGeneratedReviewFields(
+        { base: 'main', title: 'Feature branch', body: '', draft: false },
+        {
+          success: true,
+          fields: { base: 'main', title: 'chore: add new app config', body: '', draft: false }
+        }
+      )
+    ).toEqual({
+      ok: true,
+      fields: { base: 'main', title: 'chore: add new app config', body: '', draft: false }
+    })
+  })
+
+  it('falls back to the current title when the generated title is blank and the body is empty', () => {
+    expect(
+      resolveCreatePrIntentGeneratedReviewFields(
+        { base: 'main', title: 'Feature branch', body: '', draft: false },
+        { success: true, fields: { base: 'main', title: '  ', body: '   ', draft: true } }
+      )
+    ).toEqual({
+      ok: true,
+      fields: { base: 'main', title: 'Feature branch', body: '   ', draft: true }
     })
   })
 

--- a/src/renderer/src/components/right-sidebar/source-control/review/create-pr-intent-flow.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/review/create-pr-intent-flow.ts
@@ -53,7 +53,7 @@ type CreatePrIntentReviewGeneration =
 
 export type CreatePrIntentGeneratedReviewFields =
   | { ok: true; fields: CreatePrIntentReviewFields }
-  | { ok: false; error: string | null }
+  | { ok: false; error: string }
 
 export function createCreatePrIntentRunToken(input: Omit<CreatePrIntentRunToken, 'startedAt'>) {
   return { ...input, startedAt: Date.now() }
@@ -208,15 +208,13 @@ export function resolveCreatePrIntentGeneratedReviewFields(
   if (!generated.success) {
     return { ok: false, error: generated.error }
   }
-  if (!generated.fields.body.trim()) {
-    return { ok: false, error: null }
-  }
   return {
     ok: true,
     fields: {
       // Why: intent auto-submits, so generated details must not retarget the review without confirmation.
       base: current.base,
       title: generated.fields.title.trim() || current.title,
+      // Why: a description is optional everywhere else (composer, GitHub/GitLab), so an intentionally empty generated body is a valid result, not a failure.
       body: generated.fields.body,
       draft: generated.fields.draft
     }

--- a/src/renderer/src/components/right-sidebar/source-control/review/use-create-pr-intent-review.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/review/use-create-pr-intent-review.ts
@@ -132,12 +132,7 @@ export function useSourceControlCreatePrIntentReview({
           if (!resolved.ok) {
             setCreatePrIntentNoticeForWorktree(token.worktreeId, {
               tone: 'destructive',
-              message:
-                resolved.error ??
-                translate(
-                  'auto.components.right.sidebar.SourceControl.createPrIntentEmptyGeneratedBody',
-                  'Generated review details did not include a description. Retry Create PR.'
-                )
+              message: resolved.error
             })
             return false
           }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12000,7 +12000,6 @@
             "a4e93c21d7": "Current branch: {{value0}}",
             "c7d4e2f801": "Change base ref: {{value0}}",
             "f3a1b8c204": "upstream",
-            "createPrIntentEmptyGeneratedBody": "Generated review details did not include a description. Retry Create PR.",
             "createPrIntentGenerateDetailsFailed": "Could not generate review details. Retry Create PR."
           },
           "SourceControlAgentActionDialog": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10779,7 +10779,6 @@
             "a4e93c21d7": "Rama actual: {{value0}}",
             "c7d4e2f801": "Cambiar ref base: {{value0}}",
             "f3a1b8c204": "upstream",
-            "createPrIntentEmptyGeneratedBody": "Los detalles de revisión generados no incluyeron una descripción. Reintentar Crear PR.",
             "createPrIntentGenerateDetailsFailed": "No se pudieron generar los detalles de revisión. Reintentar Crear PR."
           },
           "SourceControlAgentActionDialog": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10770,7 +10770,6 @@
             "a4e93c21d7": "現在のブランチ: {{value0}}",
             "c7d4e2f801": "ベース ref を変更: {{value0}}",
             "f3a1b8c204": "upstream",
-            "createPrIntentEmptyGeneratedBody": "生成されたレビューの詳細に説明が含まれていませんでした。PR の作成を再試行してください。",
             "createPrIntentGenerateDetailsFailed": "レビューの詳細を生成できませんでした。PR の作成を再試行してください。"
           },
           "SourceControlAgentActionDialog": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10791,7 +10791,6 @@
             "a4e93c21d7": "현재 브랜치: {{value0}}",
             "c7d4e2f801": "베이스 ref 변경: {{value0}}",
             "f3a1b8c204": "upstream",
-            "createPrIntentEmptyGeneratedBody": "생성된 검토 세부 정보에 설명이 포함되지 않았습니다. PR 생성을 다시 시도하세요.",
             "createPrIntentGenerateDetailsFailed": "검토 세부 정보를 생성할 수 없습니다. PR 생성을 다시 시도하세요."
           },
           "SourceControlAgentActionDialog": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10826,7 +10826,6 @@
             "a4e93c21d7": "当前分支：{{value0}}",
             "c7d4e2f801": "更改基引用：{{value0}}",
             "f3a1b8c204": "upstream",
-            "createPrIntentEmptyGeneratedBody": "生成的评审详情未包含描述。请重试创建 PR。",
             "createPrIntentGenerateDetailsFailed": "无法生成评审详情。请重试创建 PR。"
           },
           "SourceControlAgentActionDialog": {

--- a/src/shared/pull-request-generation.test.ts
+++ b/src/shared/pull-request-generation.test.ts
@@ -173,6 +173,20 @@ describe('parseGeneratedPullRequestFields', () => {
     })
   })
 
+  it('keeps an explicitly empty body instead of falling back', () => {
+    const fields = parseGeneratedPullRequestFields(
+      '{"base":"main","title":"chore: add new app config","body":"","draft":false}',
+      context
+    )
+
+    expect(fields).toEqual({
+      base: 'main',
+      title: 'chore: add new app config',
+      body: '',
+      draft: false
+    })
+  })
+
   it('rejects excessive nesting before JSON.parse', () => {
     const parseSpy = vi.spyOn(JSON, 'parse')
     const depth = GENERATED_PULL_REQUEST_JSON_STRUCTURE_LIMITS.nestingDepth + 1


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

Orca's one-click **Create PR** asks the AI for a title and description, then submits. If the AI came back with an empty description — which is exactly what a custom PR-details prompt like `"body": ""` is supposed to produce — Orca refused to create the PR and showed "Generated review details did not include a description. Retry Create PR." Retrying never helped, because the AI kept returning the same (correct) empty description. A description is optional in the manual PR composer and on GitHub/GitLab, so now the intent flow accepts an empty one too and creates the PR.

## Root cause

`src/renderer/src/components/right-sidebar/source-control/review/create-pr-intent-flow.ts:211` in `resolveCreatePrIntentGeneratedReviewFields`:

```ts
if (!generated.fields.body.trim()) {
  return { ok: false, error: null }
}
```

A *successful* generation whose body is empty/whitespace was classified as a failure. `use-create-pr-intent-review.ts:131-145` turned that `ok:false, error:null` into a destructive notice and returned `false`, aborting creation.

The guard was never protective: a genuinely empty agent response is already rejected in the main process (`src/main/text-generation/source-control-text-generation-requests.ts:157` passes `emptyResultName: 'details'`, producing "…returned an empty details."). So the renderer guard only caught valid JSON that legitimately carried `body: ""`. The parser deliberately preserves it (`src/shared/pull-request-generation.ts:226-227`), the composer path applies a generated body with no emptiness check, the intent flow only requires a non-empty *title*, and `createHostedReview` does no body validation for any provider (GitLab even substitutes the MR template when the body is blank and `useTemplate` is set). Introduced by 7aba9b306ba "Validate auto-generated PR details; abort with clear errors (#12752)".

## Proof

Test file: `src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts`
Command: `pnpm test src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts`

**BEFORE the fix** (new tests added first, on unmodified source):

```
 ❯ src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts (14 tests | 2 failed) 9ms
     × accepts generated review fields with an empty description 3ms
     × falls back to the current title when the generated title is blank and the body is empty 1ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts > source-control Create PR intent flow helpers > accepts generated review fields with an empty description
AssertionError: expected { ok: false, error: null } to deeply equal { ok: true, …(1) }

- Expected
+ Received

  {
-   "fields": {
-     "base": "main",
-     "body": "",
-     "draft": false,
-     "title": "chore: add new app config",
-   },
-   "ok": true,
+   "error": null,
+   "ok": false,
  }

 Test Files  1 failed (1)
      Tests  2 failed | 12 passed (14)
```

**AFTER the fix** (both touched test files):

```
 Test Files  2 passed (2)
      Tests  26 passed (26)
   Start at  14:51:20
   Duration  359ms
```

(`src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts` + `src/shared/pull-request-generation.test.ts`. Also re-ran the create-PR-intent siblings — `source-control-create-pr-intent-state`, `source-control-primary-action.create-pr-intent`, `source-control-dropdown-items.create-pr-intent`, `use-source-control-ai` — 61 passed, and the whole `src/renderer/src/i18n/` suite, 145 passed, for the locale-key removal.)

## Risk

**Low.** The change deletes a rejection branch in a pure, dependency-free renderer helper; nothing new is computed. Both other invariants of that helper are unchanged and still covered by the existing "keeps generated review fields fail-closed" test: a failed generation still propagates its error string, and a generated `base` still cannot retarget the review (it is pinned to `current.base`). Because the `error: null` branch is gone, `CreatePrIntentGeneratedReviewFields` narrows to `{ ok: false; error: string }`, which matches the only producer (`RuntimeGeneratePullRequestFieldsResult` declares `error: string` on failure), so the notice can never render blank where it previously fell back.

## User-facing regressions

- **Empty-title protection:** unchanged — a blank generated title still falls back to `current.title`, and the flow still hard-stops on an empty final title ("Enter a … title."). Covered by a new test.
- **Empty-agent-output errors:** unchanged — an agent that returns nothing still fails in the main process with "…returned an empty details.", surfaced verbatim in the destructive notice.
- **Base pinning / branch-changed guard:** unchanged.
- **Providers:** checked GitHub and GitLab creation paths; neither requires a body. GitLab still swaps in the MR template when the body is blank and `useTemplate` is on.
- **i18n:** the now-unreachable `createPrIntentEmptyGeneratedBody` string was removed from all five locale files (en/es/ja/ko/zh); no other reference to that key exists in the repo, and the i18n suite passes.
- No persisted state, IPC payload, or remote-wire shape changed.

Fixes #16642
