### PR TITLE
fix(fork-sync): address runtime repos by main worktree id, not repo id

### DIFF
--- a/src/renderer/src/components/settings/RepositoryForkSyncSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryForkSyncSection.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import { RepositoryForkSyncSection } from './RepositoryForkSyncSection'
+
+const syncRuntimeGitForkDefaultBranch = vi.fn()
+
+vi.mock('../../runtime/runtime-git-client', () => ({
+  syncRuntimeGitForkDefaultBranch: (...args: unknown[]) => syncRuntimeGitForkDefaultBranch(...args)
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ settingsSearchQuery: '', settings: { activeRuntimeEnvironmentId: 'env-1' } })
+}))
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), { message: vi.fn(), success: vi.fn(), error: vi.fn() })
+}))
+
+const RUNTIME_REPO: Repo = {
+  id: 'repo-1',
+  path: '/srv/repo-1',
+  displayName: 'repo-1',
+  badgeColor: '#000000',
+  addedAt: 0,
+  kind: 'git',
+  executionHostId: 'runtime:env-1',
+  forkSyncMode: 'ask',
+  upstream: { owner: 'up', repo: 'r' }
+}
+
+describe('RepositoryForkSyncSection', () => {
+  afterEach(() => {
+    cleanup()
+    syncRuntimeGitForkDefaultBranch.mockReset()
+  })
+
+  it('syncs a runtime-hosted repo by its main worktree id, not the bare repo id', () => {
+    // Why: the runtime rejects `id:<repo-id>` with worktree_id_requires_full_path (#16447).
+    syncRuntimeGitForkDefaultBranch.mockResolvedValue({ status: 'up-to-date', behind: 0 })
+    render(
+      <RepositoryForkSyncSection repo={RUNTIME_REPO} updateRepo={vi.fn()} forceVisible={true} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /sync now/i }))
+
+    expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: 'repo-1::/srv/repo-1', worktreePath: '/srv/repo-1' }),
+      { owner: 'up', repo: 'r' }
+    )
+  })
+})

--- a/src/renderer/src/components/settings/RepositoryForkSyncSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryForkSyncSection.tsx
@@ -3,6 +3,7 @@ import { RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import type { ForkSyncMode, GitForkSyncResult } from '../../../../shared/git-fork-sync'
 import type { Repo } from '../../../../shared/repo-types'
+import { getRepoMainWorktreeId } from '../../../../shared/worktree/id'
 import { Button } from '../ui/button'
 import { SearchableSetting } from './SearchableSetting'
 import { SettingsSegmentedControl } from './SettingsFormControls'
@@ -128,7 +129,7 @@ export function RepositoryForkSyncSection({
       const result = await syncRuntimeGitForkDefaultBranch(
         {
           settings: getRepoOwnerRoutedSettings(settings, repo),
-          worktreeId: repo.id,
+          worktreeId: getRepoMainWorktreeId(repo),
           worktreePath: repo.path,
           connectionId: repo.connectionId ?? undefined
         },

--- a/src/renderer/src/store/repos/safe-auto-fork-sync.test.ts
+++ b/src/renderer/src/store/repos/safe-auto-fork-sync.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '../types'
+import type { Repo } from '../../../../shared/repo-types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import { safeAutoForkSyncAttempts, scheduleSafeAutoForkSync } from './safe-auto-fork-sync'
+
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+const gitSyncFork = vi.fn()
+
+const RUNTIME_REPO: Repo = {
+  id: 'repo-1',
+  path: '/srv/repo-1',
+  displayName: 'repo-1',
+  badgeColor: '#000000',
+  addedAt: 0,
+  kind: 'git',
+  executionHostId: 'runtime:env-1',
+  forkSyncMode: 'safe-auto',
+  upstream: { owner: 'up', repo: 'r' }
+}
+
+function stateWith(repo: Repo): AppState {
+  return {
+    repos: [repo],
+    settings: { activeRuntimeEnvironmentId: 'env-1' }
+  } as unknown as AppState
+}
+
+async function flushScheduledSyncs(): Promise<void> {
+  await Promise.all([...safeAutoForkSyncAttempts.values()].map((attempt) => attempt.promise))
+}
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  safeAutoForkSyncAttempts.clear()
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentTransportCall.mockReset()
+  gitSyncFork.mockReset()
+  gitSyncFork.mockResolvedValue({ status: 'up-to-date', behind: 0 })
+  runtimeEnvironmentCall.mockResolvedValue({
+    id: 'rpc-1',
+    ok: true,
+    result: { status: 'up-to-date', behind: 0 },
+    _meta: { runtimeId: 'remote-runtime' }
+  })
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  vi.stubGlobal('window', {
+    api: {
+      git: { syncFork: gitSyncFork },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+describe('scheduleSafeAutoForkSync', () => {
+  it('addresses a runtime-hosted repo by its main worktree id, not the bare repo id', async () => {
+    // Why: the runtime rejects `id:<repo-id>` with worktree_id_requires_full_path (#16447).
+    scheduleSafeAutoForkSync(() => stateWith(RUNTIME_REPO), [RUNTIME_REPO])
+    await flushScheduledSyncs()
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'git.forkSync',
+        params: expect.objectContaining({ worktree: 'id:repo-1::/srv/repo-1' })
+      })
+    )
+  })
+
+  it('still runs local repos against the repo path over local git IPC', async () => {
+    const localRepo: Repo = {
+      ...RUNTIME_REPO,
+      id: 'repo-2',
+      path: '/home/me/repo-2',
+      executionHostId: 'local'
+    }
+
+    scheduleSafeAutoForkSync(
+      () =>
+        ({ ...stateWith(localRepo), settings: { activeRuntimeEnvironmentId: null } }) as AppState,
+      [localRepo]
+    )
+    await flushScheduledSyncs()
+
+    expect(gitSyncFork).toHaveBeenCalledWith({
+      worktreePath: '/home/me/repo-2',
+      connectionId: undefined,
+      expectedUpstream: { owner: 'up', repo: 'r' }
+    })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/store/repos/safe-auto-fork-sync.ts
+++ b/src/renderer/src/store/repos/safe-auto-fork-sync.ts
@@ -2,6 +2,7 @@ import type { AppState } from '../types'
 import type { Repo } from '../../../../shared/repo-types'
 import { syncRuntimeGitForkDefaultBranch } from '../../runtime/runtime-git-client'
 import { getRepoExecutionHostId } from '../../../../shared/execution-host'
+import { getRepoMainWorktreeId } from '../../../../shared/worktree/id'
 import { settingsForRepoOwner } from './owner-routing'
 
 export const SAFE_AUTO_FORK_SYNC_COOLDOWN_MS = 10 * 60 * 1000
@@ -32,7 +33,7 @@ export function scheduleSafeAutoForkSync(get: () => AppState, repos: readonly Re
     const promise = syncRuntimeGitForkDefaultBranch(
       {
         settings: settingsForRepoOwner(get(), repo.id),
-        worktreeId: repo.id,
+        worktreeId: getRepoMainWorktreeId(repo),
         worktreePath: repo.path,
         connectionId: repo.connectionId ?? undefined
       },

--- a/src/shared/worktree/id.test.ts
+++ b/src/shared/worktree/id.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   WORKTREE_ID_SEPARATOR,
   getRepoIdFromWorktreeId,
+  getRepoMainWorktreeId,
   getWorktreePathBasenameFromId,
   splitWorktreeId,
   splitWorktreeIdForFilesystem,
@@ -11,6 +12,19 @@ import {
 describe('WORKTREE_ID_SEPARATOR', () => {
   it('is the literal "::" separator', () => {
     expect(WORKTREE_ID_SEPARATOR).toBe('::')
+  })
+})
+
+describe('getRepoMainWorktreeId', () => {
+  it('round-trips through the id parsers on posix and Windows paths', () => {
+    for (const repo of [
+      { id: 'repo-123', path: '/abs/path' },
+      { id: 'repo-123', path: 'C:\\Users\\me\\repo' }
+    ]) {
+      const worktreeId = getRepoMainWorktreeId(repo)
+      expect(worktreeId).toBe(`${repo.id}${WORKTREE_ID_SEPARATOR}${repo.path}`)
+      expect(splitWorktreeId(worktreeId)).toEqual({ repoId: repo.id, worktreePath: repo.path })
+    }
   })
 })
 

--- a/src/shared/worktree/id.ts
+++ b/src/shared/worktree/id.ts
@@ -1,5 +1,6 @@
 import { normalizeRuntimePathForComparison } from '../cross-platform-path'
 import { WORKTREE_ID_SEPARATOR } from '../pty-session-id-format'
+import type { Repo } from '../repo-types'
 
 export { WORKTREE_ID_SEPARATOR } from '../pty-session-id-format'
 
@@ -12,6 +13,14 @@ export const FOLDER_WORKSPACE_INSTANCE_SEPARATOR = '::workspace:'
 const FOLDER_WORKSPACE_INSTANCE_SUFFIX = new RegExp(
   `${FOLDER_WORKSPACE_INSTANCE_SEPARATOR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[0-9a-f-]{36}$`
 )
+
+/**
+ * Worktree id of the repo's own checkout. A bare repo id is never a valid worktree id —
+ * runtimes reject it with `worktree_id_requires_full_path` (#16447).
+ */
+export function getRepoMainWorktreeId(repo: Pick<Repo, 'id' | 'path'>): string {
+  return `${repo.id}${WORKTREE_ID_SEPARATOR}${repo.path}`
+}
 
 export function getRepoIdFromWorktreeId(worktreeId: string): string {
   const separatorIdx = worktreeId.indexOf(WORKTREE_ID_SEPARATOR)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​166 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​166 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## ELI5

If your project is a fork and it lives on a remote Orca runtime host, Orca's "Keep Fork Up to Date" never worked: both the Safe Auto background sync and the **Sync Now** button asked the runtime to sync a workspace using the *project's* id instead of a *workspace* id, and the runtime always refused it. Safe Auto swallowed the error silently, so forks just quietly stopped tracking upstream; Sync Now showed a "Fork sync failed" toast every time. Now both address the project's own checkout with a real workspace id, so the fast-forward actually runs.

## Root cause

`RuntimeGitContext.worktreeId` must be a worktree id (`<repoId>::<worktreePath>`), but both fork-sync call sites passed the bare repo id:

- `src/renderer/src/store/repos/safe-auto-fork-sync.ts:35` — `worktreeId: repo.id`
- `src/renderer/src/components/settings/RepositoryForkSyncSection.tsx:131` — `worktreeId: repo.id`

That flows into `syncRuntimeGitForkDefaultBranch` (`src/renderer/src/runtime/runtime-git-sync-client.ts:104`), which sends `{ worktree: toRuntimeWorktreeSelector(context.worktreeId) }` → `id:<repo-id>`. The runtime rejects exactly that shape in `OrcaRuntime.getValidatedExplicitWorktreeIdSelector` (`src/main/runtime/orca-runtime.ts:32293-32302`): an `id:` selector with no `::` separator that matches a registered repo throws `WorktreeIdRequiresFullPathError` (`worktree_id_requires_full_path`, `src/main/runtime/orca-runtime.ts:2985`). The repo's own checkout is the worktree whose path equals `repo.path`, and its id is built as `` `${repoId}::${git.path}` `` (`src/main/ipc/worktree-metadata-merge.ts:20`).

Fix: a shared `getRepoMainWorktreeId(repo)` in `src/shared/worktree/id.ts` (alongside the existing `splitWorktreeId` parsers) composes `<repo.id>::<repo.path>`, and both call sites use it. Local/SSH targets are unchanged: they never reach the runtime RPC, and `resolveLocalWorktreePath` extracts `repo.path` right back out of the full id via `splitWorktreeIdForFilesystem`.

## Proof

Command: `pnpm test src/renderer/src/store/repos/safe-auto-fork-sync.test.ts src/renderer/src/components/settings/RepositoryForkSyncSection.test.tsx src/shared/worktree/id.test.ts`

New tests: `src/renderer/src/store/repos/safe-auto-fork-sync.test.ts` (Safe Auto, asserted at the runtime RPC wire), `src/renderer/src/components/settings/RepositoryForkSyncSection.test.tsx` (Sync Now button), `src/shared/worktree/id.test.ts` (helper, posix + Windows paths).

**BEFORE the fix** — `pnpm test src/renderer/src/store/repos/safe-auto-fork-sync.test.ts`:

```
 FAIL  src/renderer/src/store/repos/safe-auto-fork-sync.test.ts > scheduleSafeAutoForkSync > addresses a runtime-hosted repo by its main worktree id, not the bare repo id
AssertionError: expected "vi.fn()" to be called with arguments: [ ObjectContaining{…} ]

Received:

  1st vi.fn() call:

  [
-   ObjectContaining {
+   {
+     "expectedEnvironmentPairingRevision": undefined,
      "method": "git.forkSync",
-     "params": ObjectContaining {
-       "worktree": "id:repo-1::/srv/repo-1",
+     "params": {
+       "expectedUpstream": {
+         "owner": "up",
+         "repo": "r",
+       },
+       "worktree": "id:repo-1",
      },
+     "selector": "env-1",
+     "timeoutMs": 60000,
    },
  ]

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

**BEFORE the fix** — `pnpm test src/renderer/src/components/settings/RepositoryForkSyncSection.test.tsx`:

```
  [
-   ObjectContaining {
-     "worktreeId": "repo-1::/srv/repo-1",
+   {
+     "connectionId": undefined,
+     "settings": {
+       "activeRuntimeEnvironmentId": "env-1",
+     },
+     "worktreeId": "repo-1",
      "worktreePath": "/srv/repo-1",
    },

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

**AFTER the fix** — same command over all three files, plus the sibling suites for the modules touched (`runtime-git-client.test.ts`, `repos-module-lifetime-coordinators.test.ts`):

```
 Test Files  5 passed (5)
      Tests  55 passed (55)
```

## Risk

**Low.** Two one-line call-site changes plus a pure string-composition helper. The value sent on the wire moves from a selector the runtime *always* rejected to the same `id:<repoId>::<path>` shape every other renderer git RPC (`git.status`, `git.diff`, `git.pull`, …) already sends for this repo's main worktree, so no new wire shape, field, or opcode is introduced and nothing needs capability negotiation — an older runtime that predates the `worktree_id_requires_full_path` guard also resolved `id:<repoId>` to nothing, so the new selector is strictly better there too.

## User-facing regressions

None found. Checked adjacent behavior explicitly:

- **Local repos**: `syncRuntimeGitForkDefaultBranch` short-circuits to `window.api.git.syncFork` for `target.kind === 'local'`, and `resolveLocalWorktreePath` splits the full id back to `repo.path`. Covered by a regression test asserting the local IPC still gets `worktreePath: '/home/me/repo-2'` and no runtime call is made.
- **SSH repos**: same local-IPC branch, with `connectionId` passed through unchanged.
- **Folder workspaces**: unreachable — `scheduleSafeAutoForkSync` skips `kind === 'folder'`, and `RepositoryForkSyncSection` returns `null` without `repo.upstream`.
- **Windows paths**: the id is composed exactly as `mergeWorktree` already composes it, and `splitWorktreeId` splits on the *first* `::`, so a `C:\...` drive letter is unaffected (covered in `id.test.ts`).
- **Cooldown/dedup**: `getSafeAutoForkSyncKey` is untouched, so Safe Auto's 10-minute cooldown and in-flight guard behave identically.
- **Other call sites**: `worktreeId: repo.id` no longer appears anywhere in the codebase.
- **GitLab/other providers**: no provider-specific code paths touched; fork sync is provider-neutral above this layer.

Fixes #16447
