### PR TITLE
fix(claude-usage): bill 1-hour cache writes at 2x base input

### DIFF
--- a/src/main/claude-usage/claude-model-pricing.test.ts
+++ b/src/main/claude-usage/claude-model-pricing.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { estimateCostUsd } from './claude-model-pricing'
+
+describe('estimateCostUsd cache-write TTL rates', () => {
+  it('bills 5-minute cache writes at 1.25x base input', () => {
+    expect(estimateCostUsd('claude-opus-5', 0, 0, 0, 1_000_000, 0)).toBeCloseTo(6.25)
+  })
+
+  it('keeps the legacy five-argument call billing every write at the 5-minute rate', () => {
+    expect(estimateCostUsd('claude-opus-5', 0, 0, 0, 1_000_000)).toBeCloseTo(6.25)
+  })
+
+  it('bills 1-hour cache writes at 2x base input', () => {
+    expect(estimateCostUsd('claude-opus-5', 0, 0, 0, 1_000_000, 1_000_000)).toBeCloseTo(10)
+  })
+
+  it('splits a mixed write bucket without double-billing the 1-hour share', () => {
+    expect(estimateCostUsd('claude-opus-5', 0, 0, 0, 1_000_000, 400_000)).toBeCloseTo(7.75)
+  })
+
+  it('clamps a 1-hour count that exceeds the reported write total', () => {
+    expect(estimateCostUsd('claude-opus-5', 0, 0, 0, 1_000, 5_000)).toBeCloseTo(0.01)
+  })
+
+  it('applies the long-context tier to 1-hour writes', () => {
+    expect(estimateCostUsd('claude-sonnet-4-6', 0, 0, 0, 400_000, 400_000)).toBeCloseTo(3.6)
+  })
+
+  it('still returns null for unknown models', () => {
+    expect(estimateCostUsd('gpt-5', 0, 0, 0, 1_000_000, 1_000_000)).toBeNull()
+  })
+})

--- a/src/main/claude-usage/claude-model-pricing.test.ts
+++ b/src/main/claude-usage/claude-model-pricing.test.ts
@@ -45,3 +45,33 @@ describe('estimateCostUsd cache-write TTL rates', () => {
     expect(estimateCostUsd('gpt-5', 0, 0, 0, 1_000_000, 1_000_000)).toBeNull()
   })
 })
+
+// Published Claude Sonnet 5 rates (platform.claude.com/docs/en/about-claude/pricing):
+// $2 base input, $10 output, $0.20 cache hit, $2.50 5m write, $4 1h write per MTok.
+// The $2/$10 launch price, announced as introductory through 2026-08-31, is now the
+// standard price — the scheduled 2026-09-01 rise to $3/$15 was cancelled — so the rate
+// is date-independent.
+describe('estimateCostUsd Claude Sonnet 5 rates', () => {
+  it('bills base input at $2/MTok', () => {
+    expect(estimateCostUsd('claude-sonnet-5', 1_000_000, 0, 0, 0, 0)).toBeCloseTo(2)
+  })
+
+  it('bills output at $10/MTok', () => {
+    expect(estimateCostUsd('claude-sonnet-5', 0, 1_000_000, 0, 0, 0)).toBeCloseTo(10)
+  })
+
+  it('bills cache hits at $0.20/MTok', () => {
+    expect(estimateCostUsd('claude-sonnet-5', 0, 0, 1_000_000, 0, 0)).toBeCloseTo(0.2)
+  })
+
+  it('bills 5-minute cache writes at $2.50/MTok and 1-hour writes at $4/MTok', () => {
+    expect(estimateCostUsd('claude-sonnet-5', 0, 0, 0, 1_000_000, 0)).toBeCloseTo(2.5)
+    expect(estimateCostUsd('claude-sonnet-5', 0, 0, 0, 1_000_000, 1_000_000)).toBeCloseTo(4)
+  })
+
+  it('keeps the full 1M window at flat rates with no long-context tier', () => {
+    expect(estimateCostUsd('claude-sonnet-5', 1_000_000, 0, 0, 0, 0)).toBeCloseTo(
+      estimateCostUsd('claude-sonnet-5', 500_000, 0, 0, 0, 0)! * 2
+    )
+  })
+})

--- a/src/main/claude-usage/claude-model-pricing.test.ts
+++ b/src/main/claude-usage/claude-model-pricing.test.ts
@@ -26,6 +26,21 @@ describe('estimateCostUsd cache-write TTL rates', () => {
     expect(estimateCostUsd('claude-sonnet-4-6', 0, 0, 0, 400_000, 400_000)).toBeCloseTo(3.6)
   })
 
+  it('shares one long-context allowance across both TTL buckets', () => {
+    // 400k writes split evenly: 200k @ (3.75/7.5) and 200k @ (6/12), each tier
+    // getting half of the 200k allowance.
+    expect(estimateCostUsd('claude-sonnet-4-6', 0, 0, 0, 400_000, 200_000)).toBeCloseTo(2.925)
+  })
+
+  it('never lowers a long-context estimate as writes shift from 5-minute to 1-hour', () => {
+    const costs = [0, 50_000, 100_000, 200_000, 300_000, 400_000].map(
+      (write1h) => estimateCostUsd('claude-sonnet-4-6', 0, 0, 0, 400_000, write1h)!
+    )
+    for (let index = 1; index < costs.length; index++) {
+      expect(costs[index]).toBeGreaterThan(costs[index - 1])
+    }
+  })
+
   it('still returns null for unknown models', () => {
     expect(estimateCostUsd('gpt-5', 0, 0, 0, 1_000_000, 1_000_000)).toBeNull()
   })

--- a/src/main/claude-usage/claude-model-pricing.ts
+++ b/src/main/claude-usage/claude-model-pricing.ts
@@ -211,6 +211,13 @@ export function estimateCostUsd(
   }
   const pricing = MODEL_PRICING[normalized]
   const write1hTokens = Math.min(Math.max(cacheWrite1hTokens, 0), cacheWriteTokens)
+  // Why: both TTL buckets share one long-context allowance. Giving each its own
+  // would make a split bucket cheaper than the same tokens billed entirely at 5m.
+  const write1hShare = cacheWriteTokens > 0 ? write1hTokens / cacheWriteTokens : 0
+  const write5mThreshold =
+    pricing.thresholdTokens === undefined ? undefined : pricing.thresholdTokens * (1 - write1hShare)
+  const write1hThreshold =
+    pricing.thresholdTokens === undefined ? undefined : pricing.thresholdTokens * write1hShare
   return (
     (calculateTieredCost(
       inputTokens,
@@ -234,13 +241,13 @@ export function estimateCostUsd(
         cacheWriteTokens - write1hTokens,
         pricing.cacheWrite,
         pricing.cacheWriteAboveThreshold,
-        pricing.thresholdTokens
+        write5mThreshold
       ) +
       calculateTieredCost(
         write1hTokens,
         pricing.cacheWrite1h,
         pricing.cacheWrite1hAboveThreshold,
-        pricing.thresholdTokens
+        write1hThreshold
       )) /
     1_000_000
   )

--- a/src/main/claude-usage/claude-model-pricing.ts
+++ b/src/main/claude-usage/claude-model-pricing.ts
@@ -28,8 +28,9 @@ const MODEL_PRICING: Record<string, ClaudeModelPricing> = {
   'claude-fable-5': { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5, cacheWrite1h: 20 },
   'claude-opus-5': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25, cacheWrite1h: 10 },
   // Why: Sonnet 5 bills its full 1M window at flat rates, so no long-context tier here.
-  // Why: standard rates, not the $2/$10 introductory rate ending 2026-08-31 — no date dimension.
-  'claude-sonnet-5': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75, cacheWrite1h: 6 },
+  // Why: $2/$10 needs no date dimension — it launched as introductory pricing through
+  // 2026-08-31 but is now the standard price; the 2026-09-01 rise to $3/$15 was cancelled.
+  'claude-sonnet-5': { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5, cacheWrite1h: 4 },
   'claude-opus-4-8': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25, cacheWrite1h: 10 },
   'claude-opus-4-7': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25, cacheWrite1h: 10 },
   'claude-opus-4-6': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25, cacheWrite1h: 10 },

--- a/src/main/claude-usage/claude-model-pricing.ts
+++ b/src/main/claude-usage/claude-model-pricing.ts
@@ -2,12 +2,16 @@ type ClaudeModelPricing = {
   input: number
   output: number
   cacheRead: number
+  /** 5-minute TTL cache write (1.25x base input). */
   cacheWrite: number
+  /** 1-hour TTL cache write (2x base input). */
+  cacheWrite1h: number
   thresholdTokens?: number
   inputAboveThreshold?: number
   outputAboveThreshold?: number
   cacheReadAboveThreshold?: number
   cacheWriteAboveThreshold?: number
+  cacheWrite1hAboveThreshold?: number
 }
 
 const LONG_CONTEXT_THRESHOLD_TOKENS = 200_000
@@ -16,26 +20,28 @@ const SONNET_LONG_CONTEXT_PRICING = {
   inputAboveThreshold: 6,
   outputAboveThreshold: 22.5,
   cacheReadAboveThreshold: 0.6,
-  cacheWriteAboveThreshold: 7.5
+  cacheWriteAboveThreshold: 7.5,
+  cacheWrite1hAboveThreshold: 12
 } satisfies Partial<ClaudeModelPricing>
 
 const MODEL_PRICING: Record<string, ClaudeModelPricing> = {
-  'claude-fable-5': { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
-  'claude-opus-5': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  'claude-fable-5': { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5, cacheWrite1h: 20 },
+  'claude-opus-5': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25, cacheWrite1h: 10 },
   // Why: Sonnet 5 bills its full 1M window at flat rates, so no long-context tier here.
   // Why: standard rates, not the $2/$10 introductory rate ending 2026-08-31 — no date dimension.
-  'claude-sonnet-5': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-  'claude-opus-4-8': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
-  'claude-opus-4-7': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
-  'claude-opus-4-6': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
-  'claude-opus-4-5': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
-  'claude-opus-4-1': { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
-  'claude-opus-4': { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+  'claude-sonnet-5': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75, cacheWrite1h: 6 },
+  'claude-opus-4-8': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25, cacheWrite1h: 10 },
+  'claude-opus-4-7': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25, cacheWrite1h: 10 },
+  'claude-opus-4-6': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25, cacheWrite1h: 10 },
+  'claude-opus-4-5': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25, cacheWrite1h: 10 },
+  'claude-opus-4-1': { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75, cacheWrite1h: 30 },
+  'claude-opus-4': { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75, cacheWrite1h: 30 },
   'claude-sonnet-4-6': {
     input: 3,
     output: 15,
     cacheRead: 0.3,
     cacheWrite: 3.75,
+    cacheWrite1h: 6,
     ...SONNET_LONG_CONTEXT_PRICING
   },
   'claude-sonnet-4-5': {
@@ -43,6 +49,7 @@ const MODEL_PRICING: Record<string, ClaudeModelPricing> = {
     output: 15,
     cacheRead: 0.3,
     cacheWrite: 3.75,
+    cacheWrite1h: 6,
     ...SONNET_LONG_CONTEXT_PRICING
   },
   'claude-sonnet-4': {
@@ -50,13 +57,20 @@ const MODEL_PRICING: Record<string, ClaudeModelPricing> = {
     output: 15,
     cacheRead: 0.3,
     cacheWrite: 3.75,
+    cacheWrite1h: 6,
     ...SONNET_LONG_CONTEXT_PRICING
   },
-  'claude-sonnet-3-7': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-  'claude-sonnet-3-5': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-  'claude-haiku-4-5': { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 },
-  'claude-haiku-3-5': { input: 0.8, output: 4, cacheRead: 0.08, cacheWrite: 1 },
-  'claude-haiku-3': { input: 0.25, output: 1.25, cacheRead: 0.03, cacheWrite: 0.3 }
+  'claude-sonnet-3-7': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75, cacheWrite1h: 6 },
+  'claude-sonnet-3-5': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75, cacheWrite1h: 6 },
+  'claude-haiku-4-5': { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25, cacheWrite1h: 2 },
+  'claude-haiku-3-5': { input: 0.8, output: 4, cacheRead: 0.08, cacheWrite: 1, cacheWrite1h: 1.6 },
+  'claude-haiku-3': {
+    input: 0.25,
+    output: 1.25,
+    cacheRead: 0.03,
+    cacheWrite: 0.3,
+    cacheWrite1h: 0.5
+  }
 }
 
 const MODEL_ALIASES: Record<string, string> = {
@@ -179,18 +193,24 @@ function calculateTieredCost(
   return belowTokens * basePrice + aboveTokens * abovePrice
 }
 
+/**
+ * @param cacheWriteTokens every cache write, both TTLs
+ * @param cacheWrite1hTokens the 1-hour-TTL subset of `cacheWriteTokens`
+ */
 export function estimateCostUsd(
   model: string | null,
   inputTokens: number,
   outputTokens: number,
   cacheReadTokens: number,
-  cacheWriteTokens: number
+  cacheWriteTokens: number,
+  cacheWrite1hTokens = 0
 ): number | null {
   const normalized = normalizeModelForPricing(model)
   if (!normalized) {
     return null
   }
   const pricing = MODEL_PRICING[normalized]
+  const write1hTokens = Math.min(Math.max(cacheWrite1hTokens, 0), cacheWriteTokens)
   return (
     (calculateTieredCost(
       inputTokens,
@@ -211,9 +231,15 @@ export function estimateCostUsd(
         pricing.thresholdTokens
       ) +
       calculateTieredCost(
-        cacheWriteTokens,
+        cacheWriteTokens - write1hTokens,
         pricing.cacheWrite,
         pricing.cacheWriteAboveThreshold,
+        pricing.thresholdTokens
+      ) +
+      calculateTieredCost(
+        write1hTokens,
+        pricing.cacheWrite1h,
+        pricing.cacheWrite1hAboveThreshold,
         pricing.thresholdTokens
       )) /
     1_000_000

--- a/src/main/claude-usage/claude-usage-automation-attribution.ts
+++ b/src/main/claude-usage/claude-usage-automation-attribution.ts
@@ -106,6 +106,7 @@ export async function resolveAutomationRunUsage(
       acc.outputTokens += entry.outputTokens
       acc.cacheReadTokens += entry.cacheReadTokens
       acc.cacheWriteTokens += entry.cacheWriteTokens
+      acc.cacheWrite1hTokens += entry.cacheWrite1hTokens
       return acc
     },
     {
@@ -113,7 +114,8 @@ export async function resolveAutomationRunUsage(
       inputTokens: 0,
       outputTokens: 0,
       cacheReadTokens: 0,
-      cacheWriteTokens: 0
+      cacheWriteTokens: 0,
+      cacheWrite1hTokens: 0
     }
   )
   const estimatedCostUsd = estimateCostUsd(
@@ -121,7 +123,8 @@ export async function resolveAutomationRunUsage(
     totals.inputTokens,
     totals.outputTokens,
     totals.cacheReadTokens,
-    totals.cacheWriteTokens
+    totals.cacheWriteTokens,
+    totals.cacheWrite1hTokens
   )
 
   return {

--- a/src/main/claude-usage/claude-usage-report-aggregation.test.ts
+++ b/src/main/claude-usage/claude-usage-report-aggregation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import type { ClaudeUsageDailyAggregate, ClaudeUsagePersistedState } from './types'
+import { buildSummary } from './claude-usage-report-aggregation'
+
+function dailyRow(day: string, model: string): ClaudeUsageDailyAggregate {
+  return {
+    day,
+    model,
+    projectKey: 'project',
+    projectLabel: 'project',
+    repoId: null,
+    worktreeId: 'worktree-1',
+    turnCount: 1,
+    zeroCacheReadTurnCount: 0,
+    inputTokens: 1_000_000,
+    outputTokens: 1_000_000,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    cacheWrite1hTokens: 0
+  }
+}
+
+function stateWithDaily(dailyAggregates: ClaudeUsageDailyAggregate[]): ClaudeUsagePersistedState {
+  return {
+    schemaVersion: 6,
+    worktreeFingerprint: null,
+    processedFiles: [],
+    sessions: [],
+    dailyAggregates,
+    scanState: {
+      enabled: true,
+      lastScanStartedAt: null,
+      lastScanCompletedAt: null,
+      lastScanError: null
+    }
+  }
+}
+
+describe('buildSummary Claude Sonnet 5 pricing over time', () => {
+  // Why: the "All" range re-prices historical days on every render, so a day inside the
+  // announced 2026-08-31 introductory window has to price the same as a later day —
+  // the scheduled $3/$15 increase was cancelled and never took effect.
+  it('prices an introductory-window day and a post-window day at the same $2/$10 rate', () => {
+    const inWindow = buildSummary(
+      stateWithDaily([dailyRow('2026-08-15', 'claude-sonnet-5')]),
+      'all',
+      'all'
+    )
+    const afterWindow = buildSummary(
+      stateWithDaily([dailyRow('2026-09-15', 'claude-sonnet-5')]),
+      'all',
+      'all'
+    )
+
+    expect(inWindow.estimatedCostUsd).toBeCloseTo(12)
+    expect(afterWindow.estimatedCostUsd).toBeCloseTo(12)
+  })
+
+  it('sums both days in the All range without re-pricing history upward', () => {
+    const summary = buildSummary(
+      stateWithDaily([
+        dailyRow('2026-08-15', 'claude-sonnet-5'),
+        dailyRow('2026-09-15', 'claude-sonnet-5')
+      ]),
+      'all',
+      'all'
+    )
+
+    expect(summary.estimatedCostUsd).toBeCloseTo(24)
+  })
+})

--- a/src/main/claude-usage/claude-usage-report-aggregation.ts
+++ b/src/main/claude-usage/claude-usage-report-aggregation.ts
@@ -47,7 +47,8 @@ export function buildSummary(
       row.inputTokens,
       row.outputTokens,
       row.cacheReadTokens,
-      row.cacheWriteTokens
+      row.cacheWriteTokens,
+      row.cacheWrite1hTokens
     )
     if (cost !== null) {
       hasAnyBillableCost = true
@@ -111,6 +112,8 @@ export function buildBreakdown(
   kind: ClaudeUsageBreakdownKind
 ): ClaudeUsageBreakdownRow[] {
   const rows = new Map<string, ClaudeUsageBreakdownRow>()
+  // Why: the 1h cache-write split only feeds pricing, so it stays off the renderer row type.
+  const cacheWrite1hTokensByKey = new Map<string, number>()
   const filteredDaily = getFilteredDaily(state, scope, range)
   const filteredSessions = getFilteredSessions(state, scope, range)
 
@@ -133,6 +136,10 @@ export function buildBreakdown(
     existing.outputTokens += daily.outputTokens
     existing.cacheReadTokens += daily.cacheReadTokens
     existing.cacheWriteTokens += daily.cacheWriteTokens
+    cacheWrite1hTokensByKey.set(
+      key,
+      (cacheWrite1hTokensByKey.get(key) ?? 0) + daily.cacheWrite1hTokens
+    )
     rows.set(key, existing)
   }
 
@@ -168,7 +175,8 @@ export function buildBreakdown(
         row.inputTokens,
         row.outputTokens,
         row.cacheReadTokens,
-        row.cacheWriteTokens
+        row.cacheWriteTokens,
+        cacheWrite1hTokensByKey.get(row.key) ?? 0
       )
     }
   }

--- a/src/main/claude-usage/scanner.test.ts
+++ b/src/main/claude-usage/scanner.test.ts
@@ -36,8 +36,57 @@ describe('parseClaudeUsageRecord', () => {
       inputTokens: 100,
       outputTokens: 25,
       cacheReadTokens: 10,
-      cacheWriteTokens: 5
+      cacheWriteTokens: 5,
+      cacheWrite1hTokens: 0
     })
+  })
+
+  it('splits the cache-write total by TTL when the breakdown is present', () => {
+    const parsed = parseClaudeUsageRecord(
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: 'session-1',
+        timestamp: '2026-04-09T10:00:00.000Z',
+        message: {
+          model: 'claude-sonnet-4-6',
+          usage: {
+            input_tokens: 100,
+            output_tokens: 25,
+            cache_read_input_tokens: 10,
+            cache_creation_input_tokens: 1000,
+            cache_creation: {
+              ephemeral_5m_input_tokens: 600,
+              ephemeral_1h_input_tokens: 400
+            }
+          }
+        }
+      })
+    )
+
+    expect(parsed?.cacheWriteTokens).toBe(1000)
+    expect(parsed?.cacheWrite1hTokens).toBe(400)
+  })
+
+  it('clamps a 1-hour breakdown that exceeds the reported cache-write total', () => {
+    const parsed = parseClaudeUsageRecord(
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: 'session-1',
+        timestamp: '2026-04-09T10:00:00.000Z',
+        message: {
+          model: 'claude-sonnet-4-6',
+          usage: {
+            input_tokens: 100,
+            output_tokens: 25,
+            cache_creation_input_tokens: 100,
+            cache_creation: { ephemeral_1h_input_tokens: 400 }
+          }
+        }
+      })
+    )
+
+    expect(parsed?.cacheWriteTokens).toBe(100)
+    expect(parsed?.cacheWrite1hTokens).toBe(100)
   })
 
   it('merges duplicate streamed assistant usage by message and request id', async () => {
@@ -92,7 +141,8 @@ describe('parseClaudeUsageRecord', () => {
           inputTokens: 120,
           outputTokens: 30,
           cacheReadTokens: 12,
-          cacheWriteTokens: 7
+          cacheWriteTokens: 7,
+          cacheWrite1hTokens: 0
         }
       ])
     } finally {
@@ -114,7 +164,8 @@ describe('Claude usage aggregation', () => {
           inputTokens: 100,
           outputTokens: 20,
           cacheReadTokens: 10,
-          cacheWriteTokens: 5
+          cacheWriteTokens: 5,
+          cacheWrite1hTokens: 0
         },
         {
           sessionId: 'session-1',
@@ -125,7 +176,8 @@ describe('Claude usage aggregation', () => {
           inputTokens: 50,
           outputTokens: 10,
           cacheReadTokens: 0,
-          cacheWriteTokens: 0
+          cacheWriteTokens: 0,
+          cacheWrite1hTokens: 0
         }
       ],
       new Map([
@@ -154,7 +206,8 @@ describe('Claude usage aggregation', () => {
         inputTokens: 100,
         outputTokens: 20,
         cacheReadTokens: 10,
-        cacheWriteTokens: 5
+        cacheWriteTokens: 5,
+        cacheWrite1hTokens: 0
       },
       {
         locationKey: 'cwd:/outside/repo-b',
@@ -165,7 +218,8 @@ describe('Claude usage aggregation', () => {
         inputTokens: 50,
         outputTokens: 10,
         cacheReadTokens: 0,
-        cacheWriteTokens: 0
+        cacheWriteTokens: 0,
+        cacheWrite1hTokens: 0
       }
     ])
   })
@@ -182,7 +236,8 @@ describe('Claude usage aggregation', () => {
           inputTokens: 100,
           outputTokens: 20,
           cacheReadTokens: 10,
-          cacheWriteTokens: 5
+          cacheWriteTokens: 5,
+          cacheWrite1hTokens: 0
         }
       ],
       new Map([

--- a/src/main/claude-usage/store.test.ts
+++ b/src/main/claude-usage/store.test.ts
@@ -401,7 +401,7 @@ describe('ClaudeUsageStore', () => {
     ).toBeCloseTo(73.5)
     expect(
       breakdown.find((row) => row.key === 'claude-sonnet-5-thinking')?.estimatedCostUsd
-    ).toBeCloseTo(22.05)
+    ).toBeCloseTo(14.7)
   })
 
   it('prices Sonnet 5 long-context usage at flat rates', async () => {
@@ -428,7 +428,7 @@ describe('ClaudeUsageStore', () => {
     const summary = await store.getSummary('orca', '30d')
 
     // Why: Sonnet 4.6 and earlier bill above 200k at a premium; Sonnet 5 does not.
-    expect(summary.estimatedCostUsd).toBeCloseTo(6.615)
+    expect(summary.estimatedCostUsd).toBeCloseTo(4.41)
   })
 
   it('does not collapse Opus 4.5 or Sonnet 4.5 usage into Claude 5 pricing', async () => {

--- a/src/main/claude-usage/store.test.ts
+++ b/src/main/claude-usage/store.test.ts
@@ -101,6 +101,7 @@ describe('ClaudeUsageStore', () => {
           totalOutputTokens: 20,
           totalCacheReadTokens: 10,
           totalCacheWriteTokens: 5,
+          totalCacheWrite1hTokens: 0,
           locationBreakdown: [
             {
               locationKey: 'cwd:/outside/repo',
@@ -111,7 +112,8 @@ describe('ClaudeUsageStore', () => {
               inputTokens: 100,
               outputTokens: 20,
               cacheReadTokens: 10,
-              cacheWriteTokens: 5
+              cacheWriteTokens: 5,
+              cacheWrite1hTokens: 0
             }
           ]
         }
@@ -129,7 +131,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 100,
           outputTokens: 20,
           cacheReadTokens: 10,
-          cacheWriteTokens: 5
+          cacheWriteTokens: 5,
+          cacheWrite1hTokens: 0
         }
       ]
     })
@@ -159,6 +162,7 @@ describe('ClaudeUsageStore', () => {
           totalOutputTokens: 20,
           totalCacheReadTokens: 10,
           totalCacheWriteTokens: 5,
+          totalCacheWrite1hTokens: 0,
           locationBreakdown: [
             {
               locationKey: 'worktree:repo-1::/workspace/repo-a',
@@ -169,7 +173,8 @@ describe('ClaudeUsageStore', () => {
               inputTokens: 100,
               outputTokens: 20,
               cacheReadTokens: 10,
-              cacheWriteTokens: 5
+              cacheWriteTokens: 5,
+              cacheWrite1hTokens: 0
             }
           ]
         }
@@ -187,7 +192,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 100,
           outputTokens: 20,
           cacheReadTokens: 10,
-          cacheWriteTokens: 5
+          cacheWriteTokens: 5,
+          cacheWrite1hTokens: 0
         }
       ]
     })
@@ -213,7 +219,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 100,
           outputTokens: 20,
           cacheReadTokens: 10,
-          cacheWriteTokens: 5
+          cacheWriteTokens: 5,
+          cacheWrite1hTokens: 0
         }
       ]
     })
@@ -239,7 +246,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 1_000_000,
           outputTokens: 1_000_000,
           cacheReadTokens: 1_000_000,
-          cacheWriteTokens: 1_000_000
+          cacheWriteTokens: 1_000_000,
+          cacheWrite1hTokens: 0
         }
       ]
     })
@@ -251,6 +259,37 @@ describe('ClaudeUsageStore', () => {
     expect(
       breakdown.find((row) => row.key === 'claude-opus-4-7-20260416')?.estimatedCostUsd
     ).toBeCloseTo(36.75)
+  })
+
+  it('prices the 1-hour cache-write share above the 5-minute rate', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-04-09',
+          model: 'claude-opus-4-7-20260416',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000,
+          cacheWrite1hTokens: 400_000
+        }
+      ]
+    })
+
+    const summary = await store.getSummary('orca', '30d')
+    const breakdown = await store.getBreakdown('orca', '30d', 'model')
+
+    // 5 + 25 + 0.5 + (0.6 * 6.25 + 0.4 * 10); the flat 5m rate would give 36.75.
+    expect(summary.estimatedCostUsd).toBeCloseTo(38.25)
+    expect(
+      breakdown.find((row) => row.key === 'claude-opus-4-7-20260416')?.estimatedCostUsd
+    ).toBeCloseTo(38.25)
   })
 
   it('prices Claude Opus 4.8 with current Anthropic rates', async () => {
@@ -268,7 +307,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 1_000_000,
           outputTokens: 1_000_000,
           cacheReadTokens: 1_000_000,
-          cacheWriteTokens: 1_000_000
+          cacheWriteTokens: 1_000_000,
+          cacheWrite1hTokens: 0
         },
         {
           day: '2026-04-09',
@@ -282,7 +322,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 1_000_000,
           outputTokens: 1_000_000,
           cacheReadTokens: 1_000_000,
-          cacheWriteTokens: 1_000_000
+          cacheWriteTokens: 1_000_000,
+          cacheWrite1hTokens: 0
         }
       ]
     })
@@ -314,7 +355,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 1_000_000,
           outputTokens: 1_000_000,
           cacheReadTokens: 1_000_000,
-          cacheWriteTokens: 1_000_000
+          cacheWriteTokens: 1_000_000,
+          cacheWrite1hTokens: 0
         },
         {
           day: '2026-04-09',
@@ -328,7 +370,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 1_000_000,
           outputTokens: 1_000_000,
           cacheReadTokens: 1_000_000,
-          cacheWriteTokens: 1_000_000
+          cacheWriteTokens: 1_000_000,
+          cacheWrite1hTokens: 0
         },
         {
           day: '2026-04-09',
@@ -342,7 +385,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 1_000_000,
           outputTokens: 1_000_000,
           cacheReadTokens: 1_000_000,
-          cacheWriteTokens: 1_000_000
+          cacheWriteTokens: 1_000_000,
+          cacheWrite1hTokens: 0
         }
       ]
     })
@@ -375,7 +419,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 300_000,
           outputTokens: 300_000,
           cacheReadTokens: 300_000,
-          cacheWriteTokens: 300_000
+          cacheWriteTokens: 300_000,
+          cacheWrite1hTokens: 0
         }
       ]
     })
@@ -400,7 +445,8 @@ describe('ClaudeUsageStore', () => {
         inputTokens: 300_000,
         outputTokens: 300_000,
         cacheReadTokens: 300_000,
-        cacheWriteTokens: 300_000
+        cacheWriteTokens: 300_000,
+        cacheWrite1hTokens: 0
       }))
     })
 
@@ -433,7 +479,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 1_000_000,
           outputTokens: 1_000_000,
           cacheReadTokens: 1_000_000,
-          cacheWriteTokens: 1_000_000
+          cacheWriteTokens: 1_000_000,
+          cacheWrite1hTokens: 0
         },
         {
           day: '2026-04-09',
@@ -447,7 +494,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 1_000_000,
           outputTokens: 1_000_000,
           cacheReadTokens: 1_000_000,
-          cacheWriteTokens: 1_000_000
+          cacheWriteTokens: 1_000_000,
+          cacheWrite1hTokens: 0
         }
       ]
     })
@@ -472,7 +520,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 1_000_000,
           outputTokens: 1_000_000,
           cacheReadTokens: 1_000_000,
-          cacheWriteTokens: 1_000_000
+          cacheWriteTokens: 1_000_000,
+          cacheWrite1hTokens: 0
         },
         {
           day: '2026-04-09',
@@ -486,7 +535,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 1_000_000,
           outputTokens: 1_000_000,
           cacheReadTokens: 1_000_000,
-          cacheWriteTokens: 1_000_000
+          cacheWriteTokens: 1_000_000,
+          cacheWrite1hTokens: 0
         }
       ]
     })
@@ -511,7 +561,8 @@ describe('ClaudeUsageStore', () => {
           inputTokens: 300_000,
           outputTokens: 300_000,
           cacheReadTokens: 300_000,
-          cacheWriteTokens: 300_000
+          cacheWriteTokens: 300_000,
+          cacheWrite1hTokens: 0
         }
       ]
     })
@@ -546,6 +597,7 @@ describe('ClaudeUsageStore', () => {
           totalOutputTokens: 500,
           totalCacheReadTokens: 200,
           totalCacheWriteTokens: 100,
+          totalCacheWrite1hTokens: 0,
           locationBreakdown: [
             {
               locationKey: `worktree:${worktreeId}`,
@@ -556,7 +608,8 @@ describe('ClaudeUsageStore', () => {
               inputTokens: 1000,
               outputTokens: 500,
               cacheReadTokens: 200,
-              cacheWriteTokens: 100
+              cacheWriteTokens: 100,
+              cacheWrite1hTokens: 0
             }
           ]
         }

--- a/src/main/claude-usage/store.ts
+++ b/src/main/claude-usage/store.ts
@@ -22,8 +22,9 @@ import { resolveAutomationRunUsage } from './claude-usage-automation-attribution
 
 // Why: v5 widens Claude ownership keys (message-id / uuid fallbacks). Older
 // caches either lack ownership or used narrower keys and can under/over-count
-// after fork reclaim (#8006).
-const SCHEMA_VERSION = 5
+// after fork reclaim (#8006). v6 adds the 1-hour cache-write split, which older
+// caches never recorded, so their cost estimates stay stuck at the 5m rate (#15993).
+const SCHEMA_VERSION = 6
 
 // Why: capture the path after configureDevUserDataPath() but before app.setName()
 // mutates Electron's derived userData location, matching the persistence/store pattern.

--- a/src/main/claude-usage/transcript-record-parser.ts
+++ b/src/main/claude-usage/transcript-record-parser.ts
@@ -23,6 +23,11 @@ type ClaudeUsageSourceRecord = {
       output_tokens?: number
       cache_read_input_tokens?: number
       cache_creation_input_tokens?: number
+      /** TTL split of `cache_creation_input_tokens`; 1h writes bill at 2x base input. */
+      cache_creation?: {
+        ephemeral_5m_input_tokens?: number
+        ephemeral_1h_input_tokens?: number
+      }
     }
   }
 }
@@ -43,7 +48,8 @@ export function stripClaudeSourceMetadata(
     inputTokens: turn.inputTokens,
     outputTokens: turn.outputTokens,
     cacheReadTokens: turn.cacheReadTokens,
-    cacheWriteTokens: turn.cacheWriteTokens
+    cacheWriteTokens: turn.cacheWriteTokens,
+    cacheWrite1hTokens: turn.cacheWrite1hTokens
   }
 }
 
@@ -64,6 +70,7 @@ function dedupeClaudeUsageTurns(
         existing.outputTokens = Math.max(existing.outputTokens, turn.outputTokens)
         existing.cacheReadTokens = Math.max(existing.cacheReadTokens, turn.cacheReadTokens)
         existing.cacheWriteTokens = Math.max(existing.cacheWriteTokens, turn.cacheWriteTokens)
+        existing.cacheWrite1hTokens = Math.max(existing.cacheWrite1hTokens, turn.cacheWrite1hTokens)
         continue
       }
     }
@@ -101,6 +108,11 @@ function parseClaudeUsageSourceRecord(
   const outputTokens = usage?.output_tokens ?? 0
   const cacheReadTokens = usage?.cache_read_input_tokens ?? 0
   const cacheWriteTokens = usage?.cache_creation_input_tokens ?? 0
+  // Why: clamp so the implied 5m remainder can never go negative on a partial row.
+  const cacheWrite1hTokens = Math.min(
+    usage?.cache_creation?.ephemeral_1h_input_tokens ?? 0,
+    cacheWriteTokens
+  )
 
   if (inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens <= 0) {
     return null
@@ -119,7 +131,8 @@ function parseClaudeUsageSourceRecord(
     inputTokens,
     outputTokens,
     cacheReadTokens,
-    cacheWriteTokens
+    cacheWriteTokens,
+    cacheWrite1hTokens
   }
 }
 

--- a/src/main/claude-usage/types.ts
+++ b/src/main/claude-usage/types.ts
@@ -15,6 +15,7 @@ export type ClaudeUsageLocationBreakdown = {
   outputTokens: number
   cacheReadTokens: number
   cacheWriteTokens: number
+  cacheWrite1hTokens: number
 }
 
 export type ClaudeUsageSession = {
@@ -31,6 +32,7 @@ export type ClaudeUsageSession = {
   totalOutputTokens: number
   totalCacheReadTokens: number
   totalCacheWriteTokens: number
+  totalCacheWrite1hTokens: number
   locationBreakdown: ClaudeUsageLocationBreakdown[]
 }
 
@@ -47,6 +49,7 @@ export type ClaudeUsageDailyAggregate = {
   outputTokens: number
   cacheReadTokens: number
   cacheWriteTokens: number
+  cacheWrite1hTokens: number
 }
 
 export type ClaudeUsagePersistedState = {
@@ -86,6 +89,8 @@ export type ClaudeUsageParsedTurn = {
   outputTokens: number
   cacheReadTokens: number
   cacheWriteTokens: number
+  /** 1-hour-TTL subset of `cacheWriteTokens`; billed at 2x base input. */
+  cacheWrite1hTokens: number
 }
 
 export type ClaudeUsageAttributedTurn = ClaudeUsageParsedTurn & {

--- a/src/main/claude-usage/usage-aggregation.ts
+++ b/src/main/claude-usage/usage-aggregation.ts
@@ -30,6 +30,7 @@ export function mergeClaudeSessions(
     existing.totalOutputTokens += session.totalOutputTokens
     existing.totalCacheReadTokens += session.totalCacheReadTokens
     existing.totalCacheWriteTokens += session.totalCacheWriteTokens
+    existing.totalCacheWrite1hTokens += session.totalCacheWrite1hTokens
 
     for (const location of session.locationBreakdown) {
       const existingLocation =
@@ -41,6 +42,7 @@ export function mergeClaudeSessions(
         existingLocation.outputTokens += location.outputTokens
         existingLocation.cacheReadTokens += location.cacheReadTokens
         existingLocation.cacheWriteTokens += location.cacheWriteTokens
+        existingLocation.cacheWrite1hTokens += location.cacheWrite1hTokens
       } else {
         existing.locationBreakdown.push({ ...location })
       }
@@ -65,6 +67,7 @@ export function mergeClaudeDailyAggregates(
     existing.outputTokens += aggregate.outputTokens
     existing.cacheReadTokens += aggregate.cacheReadTokens
     existing.cacheWriteTokens += aggregate.cacheWriteTokens
+    existing.cacheWrite1hTokens += aggregate.cacheWrite1hTokens
   }
 }
 
@@ -113,6 +116,7 @@ export function aggregateClaudeUsage(turns: ClaudeUsageAttributedTurn[]): {
         totalOutputTokens: 0,
         totalCacheReadTokens: 0,
         totalCacheWriteTokens: 0,
+        totalCacheWrite1hTokens: 0,
         locationBreakdown: []
       })
     }
@@ -132,6 +136,7 @@ export function aggregateClaudeUsage(turns: ClaudeUsageAttributedTurn[]): {
     session.totalOutputTokens += turn.outputTokens
     session.totalCacheReadTokens += turn.cacheReadTokens
     session.totalCacheWriteTokens += turn.cacheWriteTokens
+    session.totalCacheWrite1hTokens += turn.cacheWrite1hTokens
 
     const location =
       session.locationBreakdown.find((entry) => entry.locationKey === turn.projectKey) ?? null
@@ -141,6 +146,7 @@ export function aggregateClaudeUsage(turns: ClaudeUsageAttributedTurn[]): {
       location.outputTokens += turn.outputTokens
       location.cacheReadTokens += turn.cacheReadTokens
       location.cacheWriteTokens += turn.cacheWriteTokens
+      location.cacheWrite1hTokens += turn.cacheWrite1hTokens
     } else {
       session.locationBreakdown.push({
         locationKey: turn.projectKey,
@@ -151,7 +157,8 @@ export function aggregateClaudeUsage(turns: ClaudeUsageAttributedTurn[]): {
         inputTokens: turn.inputTokens,
         outputTokens: turn.outputTokens,
         cacheReadTokens: turn.cacheReadTokens,
-        cacheWriteTokens: turn.cacheWriteTokens
+        cacheWriteTokens: turn.cacheWriteTokens,
+        cacheWrite1hTokens: turn.cacheWrite1hTokens
       })
     }
 
@@ -166,6 +173,7 @@ export function aggregateClaudeUsage(turns: ClaudeUsageAttributedTurn[]): {
       existingDaily.outputTokens += turn.outputTokens
       existingDaily.cacheReadTokens += turn.cacheReadTokens
       existingDaily.cacheWriteTokens += turn.cacheWriteTokens
+      existingDaily.cacheWrite1hTokens += turn.cacheWrite1hTokens
     } else {
       dailyByKey.set(dailyKey, {
         day: turn.day,
@@ -179,7 +187,8 @@ export function aggregateClaudeUsage(turns: ClaudeUsageAttributedTurn[]): {
         inputTokens: turn.inputTokens,
         outputTokens: turn.outputTokens,
         cacheReadTokens: turn.cacheReadTokens,
-        cacheWriteTokens: turn.cacheWriteTokens
+        cacheWriteTokens: turn.cacheWriteTokens,
+        cacheWrite1hTokens: turn.cacheWrite1hTokens
       })
     }
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​284 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​256 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 |

<!-- /orca-pr-loc -->

## ELI5

Claude charges more to write something into its prompt cache if you ask it to stay
cached for an hour instead of five minutes — 2x the base input price instead of 1.25x.
Orca's usage stats knew only about the cheaper 5-minute rate, so every 1-hour cache
write showed up at 62.5% of what it actually cost. Anyone whose Claude Code sessions
use 1-hour caching (the split is already recorded in the on-disk transcripts) was
seeing an "Estimated cost" that was too low. Now Orca reads the per-TTL breakdown and
prices each share at its real rate.

Separately, Orca charged Sonnet 5 at $3/$15 per million tokens. Sonnet 5 costs $2/$10 —
the launch price, announced as "introductory through 2026-08-31", was made permanent and
the scheduled increase was cancelled. That row is now the published rate, which also fixes
the historical over-estimate the **All** range recomputes on every render.

## Root cause

- `src/main/claude-usage/claude-model-pricing.ts:1-11` — `ClaudeModelPricing` had one
  flat `cacheWrite: number` and no per-TTL dimension. Every row's `cacheWrite` is
  `input * 1.25`, i.e. the 5-minute rate.
- `src/main/claude-usage/claude-model-pricing.ts:182-221` — `estimateCostUsd(...)` billed
  the entire write bucket through a single `calculateTieredCost(cacheWriteTokens,
  pricing.cacheWrite, ...)` call, so a 1-hour write was charged as if it were a 5-minute one.
- `src/main/claude-usage/transcript-record-parser.ts:103` — the parser read only
  `usage.cache_creation_input_tokens`. The nested
  `usage.cache_creation.{ephemeral_5m,ephemeral_1h}_input_tokens` object was not even
  declared on the source-record type, so the split was discarded at parse time and could
  never reach pricing. Real transcripts under `~/.claude/projects/**/*.jsonl` do carry it,
  with large non-zero `ephemeral_1h_input_tokens` values.

Confirmed against the `claude-api` skill, `shared/prompt-caching.md:142`: "Cache reads cost
~0.1x base input price. Cache writes cost **1.25x for 5-minute TTL, 2x for 1-hour TTL**."

## Proof

New test file: `src/main/claude-usage/claude-model-pricing.test.ts`
Extended: `src/main/claude-usage/scanner.test.ts`

Command: `pnpm test src/main/claude-usage/claude-model-pricing.test.ts` and
`pnpm test src/main/claude-usage/scanner.test.ts`

### BEFORE (tests written, fix not yet applied)

```
 FAIL  src/main/claude-usage/claude-model-pricing.test.ts > estimateCostUsd cache-write TTL rates > bills 1-hour cache writes at 2x base input
AssertionError: expected 6.25 to be close to 10, received difference is 3.75, but expected 0.005

 FAIL  src/main/claude-usage/claude-model-pricing.test.ts > estimateCostUsd cache-write TTL rates > splits a mixed write bucket without double-billing the 1-hour share
AssertionError: expected 6.25 to be close to 7.75, received difference is 1.5, but expected 0.005

 FAIL  src/main/claude-usage/claude-model-pricing.test.ts > estimateCostUsd cache-write TTL rates > applies the long-context tier to 1-hour writes
AssertionError: expected 2.25 to be close to 3.6, received difference is 1.35, but expected 0.005

 Test Files  1 failed (1)
      Tests  3 failed | 4 passed (7)
```

```
 FAIL  src/main/claude-usage/scanner.test.ts > parseClaudeUsageRecord > extracts token usage from assistant transcript lines
AssertionError: expected { sessionId: 'session-1', ...(8) } to deeply equal { sessionId: 'session-1', ...(9) }

 FAIL  src/main/claude-usage/scanner.test.ts > parseClaudeUsageRecord > splits the cache-write total by TTL when the breakdown is present
AssertionError: expected undefined to be 400 // Object.is equality

 FAIL  src/main/claude-usage/scanner.test.ts > parseClaudeUsageRecord > clamps a 1-hour breakdown that exceeds the reported cache-write total
AssertionError: expected undefined to be 100 // Object.is equality

 FAIL  src/main/claude-usage/scanner.test.ts > parseClaudeUsageRecord > merges duplicate streamed assistant usage by message and request id
AssertionError: expected [ { sessionId: 'session-1', ...(8) } ] to deeply equal [ { sessionId: 'session-1', ...(9) } ]

 Test Files  1 failed (1)
      Tests  4 failed | 2 passed (6)
```

(Reverting every production hunk at once, keeping only the tests, is redder still:
`Tests  9 failed | 29 passed (38)` across the whole directory, because
`scanner.test.ts > Claude usage aggregation` and the new `store.test.ts` case also
depend on the split.)

### AFTER (whole directory, including the two sibling suites and the new store-level case)

```
$ pnpm test src/main/claude-usage

 RUN  v4.1.5

 Test Files  5 passed (5)
      Tests  40 passed (40)
```

`pnpm run tc:node` and `pnpm run check:code-quality:changed` are clean.

### Follow-up commit: shared long-context allowance

Review caught that pricing the 5m and 1h buckets with two independent
`calculateTieredCost` calls handed each bucket its own 200k below-threshold
allowance. For a Sonnet row with a mixed bucket that made the estimate go *down*
versus billing the same tokens entirely at the 5m rate — the opposite of this PR's
intent — and made cost non-monotonic in the 1h share:

```
400k writes on claude-sonnet-4-6, by 1h share:
0 -> $2.25   50k -> $2.175   100k -> $2.10   200k -> $1.95   300k -> $2.775   400k -> $3.60
```

Fixed by splitting the single 200k allowance between the two buckets in proportion
to each one's share of the write total. Pure-5m rows are byte-identical to `main`;
the all-1h case still prices at $3.60. Two regression tests cover the mixed value
($2.925) and monotonicity; both fail on the previous head of this branch.

### Second commit: Sonnet 5 priced at its published rate (defect 1)

Review pushed back on the original punt ("the introductory period ends 2026-08-31, after
which the hardcoded rate is correct") and was right to: the **All** range re-prices every
historical day on each render, so an over-estimate on tokens spent during the launch window
never expires.

Checking the authoritative source changed the shape of the fix. Anthropic's pricing page
(`platform.claude.com/docs/en/about-claude/pricing`) carries this note:

> The $2/$10 per million input/output token pricing for Claude Sonnet 5, announced at launch
> as introductory pricing through August 31, 2026, is now the standard price. The previously
> scheduled increase to $3/$15 per million input/output tokens on September 1, 2026 will not
> occur.

So **Sonnet 5 never had two rates**. The published row is $2 input / $10 output / $0.20 cache
hit / $2.50 5m write / $4 1h write per MTok, for every day past and future. A date dimension
in `MODEL_PRICING` would encode a $3/$15 tier that no token was ever billed at; the correct
minimal fix is the flat rate. `claude-model-pricing.ts` keeps its one-rate-per-model shape —
no new type fields, no per-row date list, no allocation on the pricing path.

The old row was wrong for *all* Sonnet 5 usage, not just the window, so this raises spend
accuracy for current days too (the previous row over-estimated Sonnet 5 by 50%).

New test file: `src/main/claude-usage/claude-usage-report-aggregation.test.ts` — prices a
day inside the announced window (`2026-08-15`) and a day after it (`2026-09-15`) through
`buildSummary(..., 'all')`, which is exactly the path the reviewer flagged.
Extended: `claude-model-pricing.test.ts` (per-rate assertions incl. both cache-write TTLs).
Updated: `store.test.ts` (two Sonnet 5 expectations rebased onto the published rate:
`22.05 -> 14.7`, `6.615 -> 4.41`).

#### BEFORE (tests written, rate not yet corrected)

```
 FAIL  src/main/claude-usage/claude-model-pricing.test.ts > estimateCostUsd Claude Sonnet 5 rates > bills base input at $2/MTok
AssertionError: expected 3 to be close to 2, received difference is 1, but expected 0.005

 FAIL  src/main/claude-usage/claude-model-pricing.test.ts > estimateCostUsd Claude Sonnet 5 rates > bills output at $10/MTok
AssertionError: expected 15 to be close to 10, received difference is 5, but expected 0.005

 FAIL  src/main/claude-usage/claude-model-pricing.test.ts > estimateCostUsd Claude Sonnet 5 rates > bills cache hits at $0.20/MTok
AssertionError: expected 0.3 to be close to 0.2, received difference is 0.09999999999999998, but expected 0.005

 FAIL  src/main/claude-usage/claude-model-pricing.test.ts > estimateCostUsd Claude Sonnet 5 rates > bills 5-minute cache writes at $2.50/MTok and 1-hour writes at $4/MTok
AssertionError: expected 3.75 to be close to 2.5, received difference is 1.25, but expected 0.005

 FAIL  src/main/claude-usage/claude-usage-report-aggregation.test.ts > buildSummary Claude Sonnet 5 pricing over time > prices an introductory-window day and a post-window day at the same $2/$10 rate
AssertionError: expected 18 to be close to 12, received difference is 6, but expected 0.005

 FAIL  src/main/claude-usage/claude-usage-report-aggregation.test.ts > buildSummary Claude Sonnet 5 pricing over time > sums both days in the All range without re-pricing history upward
AssertionError: expected 36 to be close to 24, received difference is 12, but expected 0.005

 Test Files  2 failed (2)
      Tests  6 failed | 10 passed (16)
```

#### AFTER

```
$ npx vitest run --config config/vitest.config.ts src/main/claude-usage

 RUN  v4.1.5

 Test Files  6 passed (6)
      Tests  47 passed (47)
   Duration  815ms
```

```
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/usage-overview-model.test.ts src/main/rate-limits/

 RUN  v4.1.5

 Test Files  45 passed (45)
      Tests  444 passed (444)
   Duration  6.56s
```

## Risk

**Low.** The change is confined to `src/main/claude-usage/`; `grep` finds no consumer of
`ClaudeUsagePersistedState`, `ClaudeUsageDailyAggregate`, `ClaudeUsageLocationBreakdown`,
or `ClaudeUsageParsedTurn` outside that directory. No shared/IPC type
(`src/shared/claude-usage-types.ts`) changed, so there is no renderer or remote-wire
surface to negotiate — the 1-hour split is kept main-process-local via a lookup map in
`buildBreakdown` rather than being added to `ClaudeUsageBreakdownRow`. Transcripts without
the `cache_creation` object parse to `cacheWrite1hTokens: 0` and price exactly as before,
so the change is a strict superset of current behavior (pinned by a test).

## User-facing regressions

- **Estimated Claude cost goes up** for anyone with 1-hour cache writes. That is the fix,
  not a regression — the previous number was under-reported by up to 37.5% of the cache-write
  line. Costs for 5-minute-only usage are unchanged to the cent.
- **One full Claude transcript rescan on first launch after upgrade.** `SCHEMA_VERSION` goes
  5 -> 6 in `src/main/claude-usage/store.ts` because existing caches never recorded the split
  and would otherwise stay stuck at the 5-minute rate. `normalizePersistedState` already
  preserves the `scanState.enabled` opt-in across resets, so tracking stays on; only the
  derived cache is rebuilt. This is the same mechanism used for the v5 bump. Rolling back to
  an older Orca is also safe: it sees the version mismatch and resets the same way.
- **Checked adjacent behavior:** token counts shown in the UI are untouched (`cacheWriteTokens`
  remains the full write total, 5m + 1h), so the Stats charts, share card, session rows, and
  `cacheReuseRate` render identically. Automation run cost
  (`claude-usage-automation-attribution.ts`) and the Stats model breakdown were both wired to
  the new bucket so the two never disagree. Codex usage pricing
  (`src/main/codex-usage/`) has its own `estimateCostUsd` and is untouched.
- **Estimated Claude cost goes down ~33% for Sonnet 5 usage.** The old `$3/$15` row over-priced
  every Sonnet 5 token, historical and current. Correcting it lowers the Sonnet 5 line by a
  third; the two defects push in opposite directions, which is exactly the partial cancellation
  the reporter measured (Orca $3,860.48 vs their tool $3,914.30 on the same corpus).
- **No rescan needed for this commit.** The rate lives in `MODEL_PRICING` and is applied at
  render time from cached token counts, so the corrected number appears immediately.
  `SCHEMA_VERSION` stays at 6.

## Follow-up (not in this PR)

`claude-sonnet-4-6` still carries `SONNET_LONG_CONTEXT_PRICING` (>200k tokens at $6/$22.50),
but the pricing page's Long context section now reads: "Claude 4.6 and later models ... include
the full 1M token context window at standard pricing." That looks like a third over-estimate,
independent of this issue — filing separately rather than widening this PR.

Fixes #15993 — both defects are now covered. Defect **2** (1-hour cache writes at 2x base
input) in `a7963108a6a` + `ec6a2de711c`; defect **1** (Sonnet 5 rate) in `591fbd41ddb`.
Defect 1 landed as a flat-rate correction rather than the date dimension the issue proposes,
because the $3/$15 tier the issue expects on 2026-09-01 was cancelled and never took effect —
$2/$10 is the standard price for every day, so there is no second rate to date-bound. The
`All`-range re-pricing concern is covered by a test that prices a launch-window day and a
post-window day through `buildSummary(..., 'all')`.
