### PR TITLE
fix(linear): collapse duplicate per-team status rows in the Tasks filter

### DIFF
--- a/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx
@@ -2,46 +2,61 @@
 
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { LinearTeam } from '../../../shared/linear/workspace-types'
 import {
   clearLinearIssueAttributeFacet,
   countLinearIssueAttributeFilters,
   linearIssueAttributeFilterPillLabels
 } from './linear-issue-attribute-filter-sections'
-import type { LinearIssueAttributeFilter } from '../../../shared/linear/issue-attribute-filter'
+import {
+  LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS,
+  type LinearIssueAttributeFilter
+} from '../../../shared/linear/issue-attribute-filter'
 import LinearIssueAttributeFilterDropdowns from './linear-issue-attribute-filter-dropdowns'
 
 const metadataMocks = vi.hoisted(() => ({
-  useTeamsStates: vi.fn((teamIds: readonly string[]) => ({
-    data: teamIds.length > 0 ? [{ id: 'state-1', name: 'Todo' }] : [],
-    loading: false,
-    error: null
-  })),
-  useTeamsLabels: vi.fn((teamIds: readonly string[]) => ({
-    data: teamIds.length > 0 ? [{ id: 'label-1', name: 'Bug' }] : [],
-    loading: false,
-    error: null
-  })),
-  useTeamsMembers: vi.fn((teamIds: readonly string[]) => ({
-    data: teamIds.length > 0 ? [{ id: 'member-1', displayName: 'Ada Lovelace' }] : [],
-    loading: false,
-    error: null
-  }))
+  useTeamsStates: vi.fn(),
+  useTeamsLabels: vi.fn(),
+  useTeamsMembers: vi.fn()
 }))
 
 vi.mock('@/hooks/useIssueMetadata', () => metadataMocks)
 
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const defaultStates = (teamIds: readonly string[]): unknown => ({
+  data: teamIds.length > 0 ? [{ id: 'state-1', name: 'Todo' }] : [],
+  loading: false,
+  error: null
+})
+const defaultLabels = (teamIds: readonly string[]): unknown => ({
+  data: teamIds.length > 0 ? [{ id: 'label-1', name: 'Bug' }] : [],
+  loading: false,
+  error: null
+})
+const defaultMembers = (teamIds: readonly string[]): unknown => ({
+  data: teamIds.length > 0 ? [{ id: 'member-1', displayName: 'Ada Lovelace' }] : [],
+  loading: false,
+  error: null
+})
+
 const roots: Root[] = []
+
+beforeEach(() => {
+  metadataMocks.useTeamsStates.mockImplementation(defaultStates)
+  metadataMocks.useTeamsLabels.mockImplementation(defaultLabels)
+  metadataMocks.useTeamsMembers.mockImplementation(defaultMembers)
+})
 
 afterEach(() => {
   roots.splice(0).forEach((root) => {
     act(() => root.unmount())
   })
   document.body.replaceChildren()
-  metadataMocks.useTeamsStates.mockClear()
-  metadataMocks.useTeamsLabels.mockClear()
-  metadataMocks.useTeamsMembers.mockClear()
+  metadataMocks.useTeamsStates.mockReset()
+  metadataMocks.useTeamsLabels.mockReset()
+  metadataMocks.useTeamsMembers.mockReset()
 })
 
 const sample: LinearIssueAttributeFilter = {
@@ -58,6 +73,20 @@ describe('linear-issue-attribute-filter helpers', () => {
     expect(clearLinearIssueAttributeFacet(sample, 'priority').priorities).toEqual([])
     expect(clearLinearIssueAttributeFacet(sample, 'assignee').assignee).toBeNull()
     expect(clearLinearIssueAttributeFacet(sample, 'labels').labelIds).toEqual([])
+  })
+
+  // Why: Linear workflow states are per team, so every team owns its own "Todo" id (#16785).
+  it('collapses same-named status ids into one pill label', () => {
+    const pills = linearIssueAttributeFilterPillLabels({
+      value: { stateIds: ['be-todo', 'fe-todo'], priorities: [], assignee: null, labelIds: [] },
+      stateNamesById: new Map([
+        ['be-todo', 'Todo'],
+        ['fe-todo', 'Todo']
+      ]),
+      memberNamesById: new Map(),
+      labelNamesById: new Map()
+    })
+    expect(pills[0]?.value).toBe('Todo')
   })
 
   it('builds pill labels from metadata maps', () => {
@@ -217,6 +246,115 @@ describe('LinearIssueAttributeFilterDropdowns', () => {
     renderWith(true)
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ stateIds: [], labelIds: [], assignee: null })
+    )
+  })
+})
+
+const multiTeamStates = [
+  { id: 'be-backlog', name: 'Backlog', type: 'backlog' },
+  { id: 'be-todo', name: 'Todo', type: 'unstarted' },
+  { id: 'fe-backlog', name: 'Backlog', type: 'backlog' },
+  { id: 'fe-todo', name: 'Todo', type: 'unstarted' }
+]
+
+const teamBe: LinearTeam = { id: 'team-be', name: 'Backend', key: 'BE' }
+const teamFe: LinearTeam = { id: 'team-fe', name: 'Frontend', key: 'FE' }
+
+function openStatusSection(onChange: (next: LinearIssueAttributeFilter) => void): void {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+
+  act(() => {
+    root.render(
+      <LinearIssueAttributeFilterDropdowns
+        value={{ stateIds: [], priorities: [], assignee: null, labelIds: [] }}
+        onChange={onChange}
+        workspaceId="workspace-1"
+        primaryTeam={teamBe}
+        selectedTeamIds={['team-be', 'team-fe']}
+        availableTeams={[teamBe, teamFe]}
+        teamsSettled
+      />
+    )
+  })
+
+  const trigger = container.querySelector('button')
+  act(() => {
+    trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+
+  const statusButton = [...document.body.querySelectorAll('button')].find(
+    (button) => button.textContent?.trim() === 'Status'
+  )
+  act(() => {
+    statusButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+function statusRowsNamed(name: string): HTMLElement[] {
+  return [...document.body.querySelectorAll<HTMLElement>('[role="option"]')].filter(
+    (row) => row.textContent?.trim() === name
+  )
+}
+
+// Why: two teams share Linear's default state template, so the picker used to list
+// "Todo"/"Backlog" once per team and each row filtered to a single team's issues (#16785).
+describe('LinearIssueAttributeFilterDropdowns status options across teams', () => {
+  it('lists one row per status name instead of one per team state id', () => {
+    metadataMocks.useTeamsStates.mockImplementation(() => ({
+      data: multiTeamStates,
+      loading: false,
+      error: null
+    }))
+
+    openStatusSection(() => undefined)
+
+    expect(statusRowsNamed('Todo')).toHaveLength(1)
+    expect(statusRowsNamed('Backlog')).toHaveLength(1)
+  })
+
+  it('selects every team state id behind the picked status name', () => {
+    metadataMocks.useTeamsStates.mockImplementation(() => ({
+      data: multiTeamStates,
+      loading: false,
+      error: null
+    }))
+    const onChange = vi.fn()
+
+    openStatusSection(onChange)
+    act(() => {
+      statusRowsNamed('Todo')[0]?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ stateIds: ['be-todo', 'fe-todo'] })
+    )
+  })
+
+  // Why: "All teams" in a large workspace expands one status into an id per team, and the
+  // IPC parser rejects a filter over the transport cap instead of trimming it.
+  it('keeps the expanded status selection within the transport id cap', () => {
+    const overCap = LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS + 20
+    metadataMocks.useTeamsStates.mockImplementation(() => ({
+      data: Array.from({ length: overCap }, (_unused, index) => ({
+        id: `team-${index}-todo`,
+        name: 'Todo',
+        type: 'unstarted'
+      })),
+      loading: false,
+      error: null
+    }))
+    const onChange = vi.fn()
+
+    openStatusSection(onChange)
+    act(() => {
+      statusRowsNamed('Todo')[0]?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(onChange.mock.calls[0]?.[0].stateIds).toHaveLength(
+      LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS
     )
   })
 })

--- a/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.tsx
@@ -8,6 +8,7 @@ import { useTeamsLabels, useTeamsMembers, useTeamsStates } from '@/hooks/useIssu
 import type { RuntimeLinearSettings } from '@/runtime/runtime-linear-client'
 import { translate } from '@/i18n/i18n'
 import {
+  boundLinearIssueAttributeFilter,
   canonicalizeLinearIssueAttributeFilter,
   emptyLinearIssueAttributeFilter,
   type LinearIssueAttributeFilter
@@ -21,7 +22,10 @@ import {
   linearIssueAttributeFilterPillLabels,
   type LinearIssueFilterSectionKey
 } from './linear-issue-attribute-filter-sections'
-import { resolveLinearIssueAttributeFilterTeamIds } from './linear-issue-attribute-filter-team-ids'
+import {
+  groupLinearMetadataByName,
+  resolveLinearIssueAttributeFilterTeamIds
+} from './linear-issue-attribute-filter-team-ids'
 
 type Props = {
   value: LinearIssueAttributeFilter
@@ -166,12 +170,24 @@ export default function LinearIssueAttributeFilterDropdowns({
     onChange
   ])
 
+  // Why: workflow states and team labels are per team, so several ids share one name —
+  // one row per name, selecting every id behind it (#16785).
   const statusOptions = useMemo(
-    () => states.data.map((state) => ({ key: state.id, primary: state.name })),
+    () =>
+      groupLinearMetadataByName(states.data).map((group) => ({
+        key: group.key,
+        primary: group.name,
+        ids: group.ids
+      })),
     [states.data]
   )
   const labelOptions = useMemo(
-    () => labels.data.map((label) => ({ key: label.id, primary: label.name })),
+    () =>
+      groupLinearMetadataByName(labels.data).map((group) => ({
+        key: group.key,
+        primary: group.name,
+        ids: group.ids
+      })),
     [labels.data]
   )
   const assigneeOptions = useMemo(
@@ -267,7 +283,13 @@ export default function LinearIssueAttributeFilterDropdowns({
                 <LinearIssueFilterSectionDetail
                   section={openSection}
                   value={value}
-                  onChange={(next) => onChange(canonicalizeLinearIssueAttributeFilter(next))}
+                  // Why: one status now expands to an id per team, so bound here — the
+                  // IPC/RPC parser rejects a filter over the transport id cap outright.
+                  onChange={(next) =>
+                    onChange(
+                      boundLinearIssueAttributeFilter(canonicalizeLinearIssueAttributeFilter(next))
+                    )
+                  }
                   statusOptions={statusOptions}
                   assigneeOptions={assigneeOptions}
                   labelOptions={labelOptions}
@@ -281,7 +303,12 @@ export default function LinearIssueAttributeFilterDropdowns({
                   onBack={() => setOpenSection(null)}
                 />
               ) : (
-                <LinearIssueFilterSectionMenu value={value} onOpenSection={setOpenSection} />
+                <LinearIssueFilterSectionMenu
+                  value={value}
+                  stateNamesById={stateNamesById}
+                  labelNamesById={labelNamesById}
+                  onOpenSection={setOpenSection}
+                />
               )}
               {activeCount > 0 ? (
                 <div className="border-t border-border/50 p-2">

--- a/src/renderer/src/components/linear-issue-attribute-filter-sections.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-sections.tsx
@@ -12,8 +12,20 @@ import {
   type LinearIssueAttributeFilter
 } from '../../../shared/linear/issue-attribute-filter'
 import { getLinearPriorityLabel } from './task-page-localized-options'
+import {
+  expandLinearMetadataGroupKeys,
+  selectedLinearMetadataGroupKeys
+} from './linear-issue-attribute-filter-team-ids'
 
 export type LinearIssueFilterSectionKey = 'status' | 'priority' | 'assignee' | 'labels'
+
+/** Picker row backed by every same-named id across the selected teams (#16785). */
+export type LinearIssueFilterGroupedOption = PickerOption & { ids: string[] }
+
+/** Same-named ids from different teams are one selection to the user. */
+function distinctFacetNames(ids: readonly string[], namesById: Map<string, string>): string[] {
+  return [...new Set(ids.map((id) => namesById.get(id) ?? id))]
+}
 
 export function countLinearIssueAttributeFilters(value: LinearIssueAttributeFilter): number {
   const canonical = canonicalizeLinearIssueAttributeFilter(value)
@@ -53,7 +65,7 @@ export function linearIssueAttributeFilterPillLabels(options: {
     pills.push({
       key: 'status',
       label: translate('auto.components.linear-issue-attribute-filter-sections.status', 'Status'),
-      value: canonical.stateIds.map((id) => options.stateNamesById.get(id) ?? id).join(', ')
+      value: distinctFacetNames(canonical.stateIds, options.stateNamesById).join(', ')
     })
   }
   if (canonical.priorities.length > 0) {
@@ -92,7 +104,7 @@ export function linearIssueAttributeFilterPillLabels(options: {
     pills.push({
       key: 'labels',
       label: translate('auto.components.linear-issue-attribute-filter-sections.labels', 'Labels'),
-      value: canonical.labelIds.map((id) => options.labelNamesById.get(id) ?? id).join(', ')
+      value: distinctFacetNames(canonical.labelIds, options.labelNamesById).join(', ')
     })
   }
   return pills
@@ -107,21 +119,27 @@ function priorityOptions(): PickerOption[] {
 
 export function LinearIssueFilterSectionMenu({
   value,
+  stateNamesById,
+  labelNamesById,
   onOpenSection
 }: {
   value: LinearIssueAttributeFilter
+  stateNamesById: Map<string, string>
+  labelNamesById: Map<string, string>
   onOpenSection: (section: LinearIssueFilterSectionKey) => void
 }): React.JSX.Element {
+  const selectedStatusCount = distinctFacetNames(value.stateIds, stateNamesById).length
+  const selectedLabelCount = distinctFacetNames(value.labelIds, labelNamesById).length
   const sections: { key: LinearIssueFilterSectionKey; label: string; summary: string }[] = [
     {
       key: 'status',
       label: translate('auto.components.linear-issue-attribute-filter-sections.status', 'Status'),
       summary:
-        value.stateIds.length > 0
+        selectedStatusCount > 0
           ? translate(
               'auto.components.linear-issue-attribute-filter-sections.countSelected',
               '{{count}} selected',
-              { count: value.stateIds.length }
+              { count: selectedStatusCount }
             )
           : ''
     },
@@ -159,11 +177,11 @@ export function LinearIssueFilterSectionMenu({
       key: 'labels',
       label: translate('auto.components.linear-issue-attribute-filter-sections.labels', 'Labels'),
       summary:
-        value.labelIds.length > 0
+        selectedLabelCount > 0
           ? translate(
               'auto.components.linear-issue-attribute-filter-sections.countSelected',
               '{{count}} selected',
-              { count: value.labelIds.length }
+              { count: selectedLabelCount }
             )
           : ''
     }
@@ -210,9 +228,9 @@ export function LinearIssueFilterSectionDetail({
   section: LinearIssueFilterSectionKey
   value: LinearIssueAttributeFilter
   onChange: (next: LinearIssueAttributeFilter) => void
-  statusOptions: PickerOption[]
+  statusOptions: LinearIssueFilterGroupedOption[]
   assigneeOptions: PickerOption[]
-  labelOptions: PickerOption[]
+  labelOptions: LinearIssueFilterGroupedOption[]
   statusLoading: boolean
   statusError: string | null
   assigneeLoading: boolean
@@ -288,14 +306,16 @@ export function LinearIssueFilterSectionDetail({
         <SectionBack onBack={onBack} />
         <MultiSelectList
           options={statusOptions}
-          selected={value.stateIds}
+          selected={selectedLinearMetadataGroupKeys(statusOptions, value.stateIds)}
           loading={statusLoading}
           error={statusError}
           searchPlaceholder={translate(
             'auto.components.linear-issue-attribute-filter-sections.searchStatus',
             'Filter status…'
           )}
-          onChange={(stateIds) => onChange({ ...value, stateIds })}
+          onChange={(keys) =>
+            onChange({ ...value, stateIds: expandLinearMetadataGroupKeys(statusOptions, keys) })
+          }
         />
       </div>
     )
@@ -307,14 +327,16 @@ export function LinearIssueFilterSectionDetail({
         <SectionBack onBack={onBack} />
         <MultiSelectList
           options={labelOptions}
-          selected={value.labelIds}
+          selected={selectedLinearMetadataGroupKeys(labelOptions, value.labelIds)}
           loading={labelLoading}
           error={labelError}
           searchPlaceholder={translate(
             'auto.components.linear-issue-attribute-filter-sections.searchLabels',
             'Filter labels…'
           )}
-          onChange={(labelIds) => onChange({ ...value, labelIds })}
+          onChange={(keys) =>
+            onChange({ ...value, labelIds: expandLinearMetadataGroupKeys(labelOptions, keys) })
+          }
         />
       </div>
     )

--- a/src/renderer/src/components/linear-issue-attribute-filter-team-ids.test.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-team-ids.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { LinearTeam } from '../../../shared/linear/workspace-types'
 import {
+  expandLinearMetadataGroupKeys,
+  groupLinearMetadataByName,
   resolveLinearIssueAttributeFilterTeamIds,
+  selectedLinearMetadataGroupKeys,
   unionLinearMetadataById
 } from './linear-issue-attribute-filter-team-ids'
 
@@ -81,5 +84,50 @@ describe('unionLinearMetadataById', () => {
       [{ id: 'shared', name: 'From FE' }]
     ])
     expect(unioned).toEqual([{ id: 'shared', name: 'From BE' }])
+  })
+})
+
+describe('groupLinearMetadataByName', () => {
+  // Why: Linear workflow states are per team, so "Todo" exists once per selected team (#16785).
+  const states = [
+    { id: 'be-backlog', name: 'Backlog' },
+    { id: 'be-todo', name: 'Todo' },
+    { id: 'fe-backlog', name: 'Backlog' },
+    { id: 'fe-todo', name: 'Todo' },
+    { id: 'fe-review', name: 'In Review' }
+  ]
+
+  it('collapses same-named ids into one keyed group in first-seen order', () => {
+    expect(groupLinearMetadataByName(states)).toEqual([
+      { key: 'be-backlog', name: 'Backlog', ids: ['be-backlog', 'fe-backlog'] },
+      { key: 'be-todo', name: 'Todo', ids: ['be-todo', 'fe-todo'] },
+      { key: 'fe-review', name: 'In Review', ids: ['fe-review'] }
+    ])
+  })
+
+  it('marks a group selected when any of its team ids is selected', () => {
+    const groups = groupLinearMetadataByName(states)
+    expect(selectedLinearMetadataGroupKeys(groups, ['fe-todo'])).toEqual(['be-todo'])
+    expect(selectedLinearMetadataGroupKeys(groups, ['be-todo', 'fe-todo'])).toEqual(['be-todo'])
+    expect(selectedLinearMetadataGroupKeys(groups, [])).toEqual([])
+  })
+
+  it('expands picked group keys back to every team id behind them', () => {
+    const groups = groupLinearMetadataByName(states)
+    expect(expandLinearMetadataGroupKeys(groups, ['be-todo', 'fe-review'])).toEqual([
+      'be-todo',
+      'fe-todo',
+      'fe-review'
+    ])
+  })
+
+  // Why: metadata for another team may still be loading; toggling a row must not drop
+  // the ids it does not know about yet (R12).
+  it('passes ids no group covers through both directions', () => {
+    const groups = groupLinearMetadataByName(states)
+    expect(selectedLinearMetadataGroupKeys(groups, ['other-team-todo'])).toEqual([
+      'other-team-todo'
+    ])
+    expect(expandLinearMetadataGroupKeys(groups, ['other-team-todo'])).toEqual(['other-team-todo'])
   })
 })

--- a/src/renderer/src/components/linear-issue-attribute-filter-team-ids.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-team-ids.ts
@@ -47,3 +47,54 @@ export function unionLinearMetadataById<T extends { id: string }>(groups: readon
   }
   return out
 }
+
+/** One picker row standing for every id that shares a display name. */
+export type LinearMetadataNameGroup = { key: string; name: string; ids: string[] }
+
+/**
+ * Collapse metadata rows that share a display name. Linear workflow states (and team
+ * labels) are per team, so every selected team contributes its own "Todo" id — the app
+ * already treats status identity as the name, so the picker must too (#16785).
+ */
+export function groupLinearMetadataByName<T extends { id: string; name: string }>(
+  rows: readonly T[]
+): LinearMetadataNameGroup[] {
+  const byName = new Map<string, LinearMetadataNameGroup>()
+  for (const row of rows) {
+    const group = byName.get(row.name)
+    if (group) {
+      group.ids.push(row.id)
+      continue
+    }
+    // First id doubles as the row key: unique, and stable while metadata is unchanged.
+    byName.set(row.name, { key: row.id, name: row.name, ids: [row.id] })
+  }
+  return [...byName.values()]
+}
+
+/**
+ * Group keys for the selected ids. An id no loaded group covers — a facet from a team
+ * whose metadata is not in yet — passes through as its own key so toggling another row
+ * never drops it (R12).
+ */
+export function selectedLinearMetadataGroupKeys(
+  groups: readonly { key: string; ids: readonly string[] }[],
+  selectedIds: readonly string[]
+): string[] {
+  const keyById = new Map<string, string>()
+  for (const group of groups) {
+    for (const id of group.ids) {
+      keyById.set(id, group.key)
+    }
+  }
+  return [...new Set(selectedIds.map((id) => keyById.get(id) ?? id))]
+}
+
+/** Every id behind the picked group keys; an unknown key is itself an id. */
+export function expandLinearMetadataGroupKeys(
+  groups: readonly { key: string; ids: readonly string[] }[],
+  keys: readonly string[]
+): string[] {
+  const idsByKey = new Map(groups.map((group) => [group.key, group.ids] as const))
+  return keys.flatMap((key) => [...(idsByKey.get(key) ?? [key])])
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​206 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​186 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​117 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 |

<!-- /orca-pr-loc -->

## ELI5

If you had more than one Linear team selected (or "All teams") on the Tasks page, the **Status** filter listed the whole default state template once per team — "Backlog / Todo / In Progress / Done / Canceled / Duplicate / In Review" twice for two teams. Worse than ugly: each of those rows was one team's private state id, so picking "Todo" hid the other team's Todo issues, and the pill read "Todo, Todo" with "2 selected". Now there is one row per status name, ticking it filters on that status across every selected team, and the pill/summary count statuses instead of ids. Team labels, which have the same per-team id shape, get the same treatment.

## Root cause

`src/renderer/src/components/linear-issue-attribute-filter-dropdowns.tsx:169-172` (pre-fix) mapped workflow states to picker rows 1:1 by id:

```ts
const statusOptions = useMemo(
  () => states.data.map((state) => ({ key: state.id, primary: state.name })),
  [states.data]
)
```

`states.data` is the multi-team union from `useTeamsStates`, and its union helper `unionLinearMetadataById` (`src/renderer/src/components/linear-issue-attribute-filter-team-ids.ts:36-49`) dedupes by `item.id` only. Linear workflow-state ids are per team, so N teams sharing the default template produce N rows per status name. The same id-shaped assumption leaked into `src/renderer/src/components/linear-issue-attribute-filter-sections.tsx:52-57` (pill text `"Todo, Todo"`) and `:120-127` ("2 selected" for one status). The rest of the app already treats status identity as name (+type): `findLinearWorkflowStateForStatus` and the board's `getLinearIssueGroup` both key on `state.name`.

Fix: `groupLinearMetadataByName` builds one picker row per distinct name holding every underlying id; `selectedLinearMetadataGroupKeys` / `expandLinearMetadataGroupKeys` map between rows and ids (ids no loaded group covers pass through untouched, so R12's "never delete another team's facets while metadata is incomplete" still holds). `state: { id: { in: [...] } }` in `src/main/linear/issue-list-filter.ts:49-50` is already OR semantics, so no wire change was needed.

## Proof

Test file: `src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx`
Command: `pnpm test src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx`

BEFORE (re-verified on the final test file by reverting only the two production
hunks — `linear-issue-attribute-filter-dropdowns.tsx` and
`linear-issue-attribute-filter-sections.tsx` — back to `main` and keeping the tests):

```
 ❯ src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx (11 tests | 4 failed)
     × collapses same-named status ids into one pill label
     × lists one row per status name instead of one per team state id
     × selects every team state id behind the picked status name
     × keeps the expanded status selection within the transport id cap

AssertionError: expected 'Todo, Todo' to be 'Todo' // Object.is equality
AssertionError: expected [ <div …(10)>…(2)</div>, …(1) ] to have a length of 1 but got 2
AssertionError: expected "vi.fn()" to be called with arguments: [ ObjectContaining{…} ]
  1st vi.fn() call: { ..., "stateIds": [ "be-todo" ] }   // "fe-todo" missing
AssertionError: expected [ 'team-0-todo' ] to have a length of 100 but got 1

 Test Files  1 failed (1)
      Tests  4 failed | 7 passed (11)
```

AFTER:

```
 RUN  v4.1.5 /Users/nwparker/projects/orca/.claude/worktrees/wf_4e2387be-31a-16

 Test Files  1 passed (1)
      Tests  11 passed (11)
```

Also green (no regressions):

```
pnpm test src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx \
  src/renderer/src/components/linear-issue-attribute-filter-team-ids.test.ts \
  src/renderer/src/components/linear-issue-attribute-filter-primary-team.test.ts \
  src/renderer/src/components/github/PRFilterPickers.test.ts \
  src/renderer/src/hooks/useIssueMetadata.test.tsx \
  src/main/linear/issue-list-filter.test.ts \
  src/shared/linear src/renderer/src/components/task-page/linear

 Test Files  11 passed (11)
      Tests  105 passed (105)
```

`pnpm run check:code-quality:changed`: 0 new findings across the 5 changed files.

## Risk

Low. Renderer-only, confined to the Linear attribute-filter picker; no schema, no persisted format, no IPC/RPC shape change (still `stateIds` / `labelIds` string ids, still `state: { id: { in: [...] } }` on the host). Old persisted filters holding a single team's state id keep working — that id now marks its name's row as selected. Grouping is exact-name (`type` intentionally not used as a splitter, so the picker matches how the board groups issues by `state.name`).

One behavior worth calling out: one click now expands to one id per selected team, so a workspace with many teams reaches the transport cap sooner. `boundLinearIssueAttributeFilter` is applied where the picker emits the filter, so we clamp at `LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS` (100) exactly as the resume-state serializer already does, instead of handing the IPC parser a filter it would reject outright. Covered by a test.

## User-facing regressions

Checked adjacent behavior; none found:

- **Assignees** are deliberately left keyed by id — two people can share a display name, so merging them would be wrong.
- **Priority** section untouched.
- **Clear all / per-facet pill clear** unchanged (still empties the facet).
- **Search inside the status/label picker** filters on the row name, and toggling a visible row preserves selections hidden by the query (`MultiSelectList` still receives the full selected-key set).
- **Metadata-still-loading (R12)**: ids belonging to a team whose metadata is not loaded yet pass through both directions, so toggling a row cannot delete them; the existing prune-after-settle path is unchanged. Pinned by a test.
- **Single-team workspaces**: grouping is a no-op — one id per name.

Fixes #16785

