### PR TITLE
fix(add-project): use the entered group name when opening a folder

### DIFF
--- a/src/main/ipc/repos-local-add-and-project-setup.test.ts
+++ b/src/main/ipc/repos-local-add-and-project-setup.test.ts
@@ -67,6 +67,22 @@ describe('repos:add + repos:clone', () => {
     expect(result).toHaveProperty('repo.badgeColor', DEFAULT_REPO_BADGE_COLOR)
   })
 
+  it('uses the requested display name for repos:add folder repos', async () => {
+    const result = await handlers.get('repos:add')!(null, {
+      path: '/tmp/from-add',
+      kind: 'folder',
+      displayName: 'inf-오케스트레이터'
+    })
+
+    expect(mockStore.addRepo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/tmp/from-add',
+        displayName: 'inf-오케스트레이터'
+      })
+    )
+    expect(result).toHaveProperty('repo.displayName', 'inf-오케스트레이터')
+  })
+
   it('inherits global non-Orca visibility while retaining the mixed-version safety marker', async () => {
     const result = await handlers.get('repos:add')!(null, { path: '/tmp/from-add', kind: 'git' })
 

--- a/src/main/ipc/repos/local-repo-registration.ts
+++ b/src/main/ipc/repos/local-repo-registration.ts
@@ -17,7 +17,8 @@ import { prepareLocalWorktreeRootForRepo } from '../../worktree-root-preparation
 export async function addLocalRepoFromPath(
   store: Store,
   path: string,
-  kind: 'git' | 'folder' = 'git'
+  kind: 'git' | 'folder' = 'git',
+  displayName?: string
 ): Promise<{ repo: Repo; alreadyExisted: boolean } | { error: string }> {
   const repoKind = kind === 'folder' ? 'folder' : 'git'
   if (repoKind === 'git') {
@@ -76,7 +77,7 @@ export async function addLocalRepoFromPath(
   const repo: Repo = {
     id: randomUUID(),
     path: resolvedPath,
-    displayName: getRepoName(resolvedPath),
+    displayName: displayName?.trim() || getRepoName(resolvedPath),
     badgeColor: DEFAULT_REPO_BADGE_COLOR,
     ...detected,
     addedAt: Date.now(),

--- a/src/main/ipc/repos/repo-creation-handlers.ts
+++ b/src/main/ipc/repos/repo-creation-handlers.ts
@@ -70,9 +70,9 @@ export function registerRepoCreationHandlers(mainWindow: BrowserWindow, store: S
     'repos:add',
     async (
       _event,
-      args: { path: string; kind?: 'git' | 'folder' }
+      args: { path: string; kind?: 'git' | 'folder'; displayName?: string }
     ): Promise<{ repo: Repo } | { error: string }> => {
-      const result = await addLocalRepoFromPath(store, args.path, args.kind)
+      const result = await addLocalRepoFromPath(store, args.path, args.kind, args.displayName)
       if ('error' in result) {
         return result
       }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -21938,7 +21938,8 @@ export class OrcaRuntimeService {
   async addRepo(
     path: string,
     kind: 'git' | 'folder' = 'git',
-    executionHostId?: ExecutionHostId | null
+    executionHostId?: ExecutionHostId | null,
+    displayName?: string
   ): Promise<Repo> {
     if (!this.store) {
       throw new Error('runtime_unavailable')
@@ -21986,7 +21987,7 @@ export class OrcaRuntimeService {
     const repo: Repo = {
       id: randomUUID(),
       path,
-      displayName: getRepoName(path),
+      displayName: displayName?.trim() || getRepoName(path),
       badgeColor: DEFAULT_REPO_BADGE_COLOR,
       ...(executionHostId != null ? { executionHostId } : {}),
       ...detected,

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -15,7 +15,8 @@ const RepoSelector = z.object({
 
 const RepoPath = z.object({
   path: requiredString('Missing repo path'),
-  kind: z.enum(['git', 'folder']).optional()
+  kind: z.enum(['git', 'folder']).optional(),
+  displayName: OptionalString
 })
 
 const RepoCreate = z.object({
@@ -190,7 +191,7 @@ export const REPO_METHODS: RpcMethod[] = [
     params: RepoPath,
     handler: async (params, context) => ({
       repo: projectRepoVisibilityForClient(
-        await context.runtime.addRepo(params.path, params.kind),
+        await context.runtime.addRepo(params.path, params.kind, undefined, params.displayName),
         context
       )
     })

--- a/src/preload/api/repository-api.ts
+++ b/src/preload/api/repository-api.ts
@@ -31,6 +31,7 @@ export type RepositoryApi = {
   add: (args: {
     path: string
     kind?: 'git' | 'folder'
+    displayName?: string
   }) => Promise<{ repo: Repo } | { error: string }>
   remove: (args: { repoId: string }) => Promise<void>
   // Forget a project on one execution host only, leaving the same repo id on other hosts intact.

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.test.tsx
@@ -156,6 +156,55 @@ describe('NonGitFolderDialog', () => {
     expect(mocks.state.closeModal).toHaveBeenCalled()
   })
 
+  it('names the runtime folder project after the requested display name', () => {
+    mocks.state.modalData = {
+      folderPath: '/srv/non-git',
+      runtimeEnvironmentId: 'env-1',
+      displayName: 'inf-오케스트레이터'
+    }
+    renderToStaticMarkup(<NonGitFolderDialog />)
+
+    const button = mocks.buttons.find((entry) => entry.label.includes('Open as Folder'))
+    button?.onClick?.()
+
+    expect(mocks.state.addNonGitFolder).toHaveBeenCalledWith('/srv/non-git', {
+      runtimeEnvironmentId: 'env-1',
+      displayName: 'inf-오케스트레이터'
+    })
+  })
+
+  it('names the SSH folder project after the requested display name', async () => {
+    mocks.state.modalData = {
+      folderPath: '/srv/non-git',
+      connectionId: 'ssh-1',
+      displayName: 'inf-오케스트레이터'
+    }
+    mocks.addRemote.mockResolvedValue({
+      repo: {
+        id: 'ssh-repo',
+        path: '/srv/non-git',
+        displayName: 'inf-오케스트레이터',
+        badgeColor: '#111',
+        addedAt: 1,
+        kind: 'folder',
+        connectionId: 'ssh-1'
+      } satisfies Repo
+    })
+    renderToStaticMarkup(<NonGitFolderDialog />)
+
+    const button = mocks.buttons.find((entry) => entry.label.includes('Open as Folder'))
+    button?.onClick?.()
+
+    await vi.waitFor(() =>
+      expect(mocks.addRemote).toHaveBeenCalledWith({
+        connectionId: 'ssh-1',
+        remotePath: '/srv/non-git',
+        kind: 'folder',
+        displayName: 'inf-오케스트레이터'
+      })
+    )
+  })
+
   it('activates only the selected SSH folder when repo IDs collide', async () => {
     const repo: Repo = {
       id: 'shared-repo',

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
@@ -30,6 +30,7 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
   const connectionId = typeof modalData.connectionId === 'string' ? modalData.connectionId : ''
   const runtimeEnvironmentId =
     typeof modalData.runtimeEnvironmentId === 'string' ? modalData.runtimeEnvironmentId : ''
+  const displayName = typeof modalData.displayName === 'string' ? modalData.displayName.trim() : ''
   const runtimeEnvironmentName =
     runtimeEnvironmentId &&
     (runtimeEnvironments.find((environment) => environment.id === runtimeEnvironmentId)?.name ||
@@ -58,7 +59,8 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
           const result = await window.api.repos.addRemote({
             connectionId,
             remotePath: folderPath,
-            kind: 'folder'
+            kind: 'folder',
+            ...(displayName ? { displayName } : {})
           })
           if ('error' in result) {
             throw new Error(result.error)
@@ -111,11 +113,12 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
       })()
     } else if (folderPath) {
       void addNonGitFolder(folderPath, {
-        runtimeEnvironmentId: runtimeEnvironmentId || null
+        runtimeEnvironmentId: runtimeEnvironmentId || null,
+        ...(displayName ? { displayName } : {})
       })
     }
     closeModal()
-  }, [addNonGitFolder, closeModal, folderPath, connectionId, runtimeEnvironmentId])
+  }, [addNonGitFolder, closeModal, displayName, folderPath, connectionId, runtimeEnvironmentId])
 
   const handleOpenChange = useCallback(
     (open: boolean) => {

--- a/src/renderer/src/components/sidebar/complete-nested-folder-open.ts
+++ b/src/renderer/src/components/sidebar/complete-nested-folder-open.ts
@@ -14,6 +14,8 @@ export async function completeNestedFolderOpen(args: {
   selectedCount: number
   getRuntimeKind: Parameters<typeof trackNestedFolderOpen>[0]['getRuntimeKind']
   owner: CapturedRuntimeOwner
+  /** User-entered project name; falls back to the host's basename naming when absent. */
+  displayName?: string
   closeModal: () => void
   setIsAdding: (value: boolean) => void
 }): Promise<void> {
@@ -26,12 +28,14 @@ export async function completeNestedFolderOpen(args: {
       state.openModal('confirm-non-git-folder', {
         folderPath: args.scan.selectedPath,
         connectionId: args.connectionId,
-        runtimeEnvironmentId: args.owner
+        runtimeEnvironmentId: args.owner,
+        ...(args.displayName ? { displayName: args.displayName } : {})
       })
       return
     }
     const repo = await state.addNonGitFolder(args.scan.selectedPath, {
-      runtimeEnvironmentId: args.owner ?? null
+      runtimeEnvironmentId: args.owner ?? null,
+      ...(args.displayName ? { displayName: args.displayName } : {})
     })
     if (args.generation !== args.currentGeneration()) {
       return

--- a/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts
@@ -126,6 +126,46 @@ describe('useAddRepoNestedImportFlow open folder fallback', () => {
     })
   })
 
+  it('names the folder project after the edited group name', async () => {
+    const { handleOpenNestedRootFolder } = useTestAddRepoNestedImportFlow({
+      nestedGroupName: '  inf-오케스트레이터  '
+    })
+
+    await handleOpenNestedRootFolder()
+
+    expect(mocks.state.addNonGitFolder).toHaveBeenCalledWith('/workspace/platform', {
+      runtimeEnvironmentId: null,
+      displayName: 'inf-오케스트레이터'
+    })
+  })
+
+  it('leaves host basename naming alone when the group name is untouched', async () => {
+    const { handleOpenNestedRootFolder } = useTestAddRepoNestedImportFlow({
+      nestedGroupName: '  platform  '
+    })
+
+    await handleOpenNestedRootFolder()
+
+    expect(mocks.state.addNonGitFolder).toHaveBeenCalledWith('/workspace/platform', {
+      runtimeEnvironmentId: null
+    })
+  })
+
+  it('carries the edited group name into the SSH folder confirmation', async () => {
+    const { handleOpenNestedRootFolder } = useTestAddRepoNestedImportFlow({
+      nestedConnectionId: 'ssh-builder',
+      nestedRuntimeKind: 'ssh',
+      nestedGroupName: 'inf-오케스트레이터'
+    })
+
+    await handleOpenNestedRootFolder()
+
+    expect(mocks.state.openModal).toHaveBeenCalledWith(
+      'confirm-non-git-folder',
+      expect.objectContaining({ displayName: 'inf-오케스트레이터' })
+    )
+  })
+
   it('tracks the open-as-folder recovery action with zero selection', async () => {
     const { handleOpenNestedRootFolder } = useTestAddRepoNestedImportFlow()
 

--- a/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
@@ -18,6 +18,7 @@ import type { WorktreeFetchOptions } from '@/store/slices/worktree-helpers'
 import { translate } from '@/i18n/i18n'
 import { worktreeRefreshOptions, type CapturedRuntimeOwner } from './add-repo-runtime-owner'
 import { completeNestedFolderOpen } from './complete-nested-folder-open'
+import { defaultProjectGroupNameForPath } from './add-repo-dialog-types'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
 
 export function useAddRepoNestedImportFlow({
@@ -255,6 +256,13 @@ export function useAddRepoNestedImportFlow({
       return Promise.resolve()
     }
     const generation = ++nestedImportGenRef.current
+    // Why: only an edited name overrides host naming, so an untouched prefill still lets the host
+    // pick (e.g. the SSH target label for `~`).
+    const enteredName = nestedGroupName.trim()
+    const displayName =
+      enteredName && enteredName !== defaultProjectGroupNameForPath(nestedScan.selectedPath)
+        ? enteredName
+        : undefined
     return completeNestedFolderOpen({
       scan: nestedScan,
       generation,
@@ -265,6 +273,7 @@ export function useAddRepoNestedImportFlow({
       selectedCount: nestedSelectedPaths.size,
       getRuntimeKind: getNestedRepoRuntimeKind,
       owner: nestedRuntimeEnvironmentId,
+      ...(displayName ? { displayName } : {}),
       closeModal,
       setIsAdding
     })
@@ -273,6 +282,7 @@ export function useAddRepoNestedImportFlow({
     getNestedRepoRuntimeKind,
     nestedAttemptId,
     nestedConnectionId,
+    nestedGroupName,
     nestedRuntimeKind,
     nestedRuntimeEnvironmentId,
     nestedScan,

--- a/src/renderer/src/store/repos/owner-routing.ts
+++ b/src/renderer/src/store/repos/owner-routing.ts
@@ -16,7 +16,7 @@ import {
   parseExecutionHostId
 } from '../../../../shared/execution-host'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
-import type { AddRepoPathRouteOptions } from './repo-state'
+import type { AddRepoPathOptions } from './repo-state'
 import { getRuntimeTargetHostId } from '../runtime-target-host'
 
 export function repoWithFetchedOwner(
@@ -60,7 +60,7 @@ export function settingsForRepoOwner(
 }
 
 export function getAddRepoPathRouteSettings(
-  options: AddRepoPathRouteOptions | undefined,
+  options: AddRepoPathOptions | undefined,
   fallbackSettings: GlobalSettings | null
 ): Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined {
   return options && 'runtimeEnvironmentId' in options

--- a/src/renderer/src/store/repos/repo-add-actions.ts
+++ b/src/renderer/src/store/repos/repo-add-actions.ts
@@ -33,10 +33,15 @@ export function createRepoAddActions(
     addRepoPath: async (path, kind = 'git', options) => {
       try {
         const target = getActiveRuntimeTarget(getAddRepoPathRouteSettings(options, get().settings))
+        const displayName = options?.displayName?.trim() || undefined
         let repo: Repo
         try {
           if (target.kind === 'local') {
-            const result = await window.api.repos.add({ path, kind })
+            const result = await window.api.repos.add({
+              path,
+              kind,
+              ...(displayName ? { displayName } : {})
+            })
             if ('error' in result) {
               throw new Error(result.error)
             }
@@ -46,7 +51,7 @@ export function createRepoAddActions(
               await callRuntimeRpc<{ repo: Repo }>(
                 target,
                 'repo.add',
-                { path, kind },
+                { path, kind, ...(displayName ? { displayName } : {}) },
                 { timeoutMs: 15_000 }
               )
             ).repo
@@ -81,6 +86,7 @@ export function createRepoAddActions(
           const { openModal } = get()
           openModal('confirm-non-git-folder', {
             folderPath: path,
+            ...(displayName ? { displayName } : {}),
             ...(target.kind === 'environment' ? { runtimeEnvironmentId: target.environmentId } : {})
           })
           return null

--- a/src/renderer/src/store/repos/repo-state.ts
+++ b/src/renderer/src/store/repos/repo-state.ts
@@ -130,7 +130,11 @@ export type DeleteProjectGroupWithContainedProjectsResult =
 
 export type FolderWorkspacePathStatusRouteOptions = { runtimeEnvironmentId?: string | null }
 
-export type AddRepoPathRouteOptions = { runtimeEnvironmentId?: string | null }
+export type AddRepoPathOptions = {
+  runtimeEnvironmentId?: string | null
+  /** Overrides the host's basename naming for the new project. */
+  displayName?: string
+}
 
 export type RuntimeCatalogFetchOptions = { runtimeEnvironmentId?: string | null }
 
@@ -158,7 +162,7 @@ export type RepoSlice = {
   addRepoPath: (
     path: string,
     kind?: 'git' | 'folder',
-    options?: AddRepoPathRouteOptions
+    options?: AddRepoPathOptions
   ) => Promise<Repo | null>
   setupProjectExistingFolder: (
     args: ProjectHostSetupExistingFolderArgs
@@ -173,7 +177,7 @@ export type RepoSlice = {
     args: ProjectHostSetupDeleteArgs
   ) => Promise<ProjectHostSetupDeleteResult | null>
   setupProjectClone: (args: ProjectHostSetupCloneArgs) => Promise<ProjectHostSetupResult | null>
-  addNonGitFolder: (path: string, options?: AddRepoPathRouteOptions) => Promise<Repo | null>
+  addNonGitFolder: (path: string, options?: AddRepoPathOptions) => Promise<Repo | null>
   scanNestedRepos: (
     path: string,
     connectionId?: string,

--- a/src/renderer/src/web/preload-api/web-repositories-api.ts
+++ b/src/renderer/src/web/preload-api/web-repositories-api.ts
@@ -17,11 +17,11 @@ export function createReposApi(): NonNullable<Partial<PreloadApi>['repos']> {
       const owned = await callRuntimeResultWithOwner<{ repos: Repo[] }>('repo.list')
       return owned.result.repos.map((repo) => withRuntimeRepoOwner(repo, owned.hostId))
     },
-    add: async ({ path, kind }) => {
+    add: async ({ path, kind, displayName }) => {
       invalidateRuntimeWorktreeCaches()
       const owned = await callRuntimeResultWithOwner<{ repo: Repo } | { error: string }>(
         'repo.add',
-        { path, kind }
+        { path, kind, displayName }
       )
       return withRuntimeRepoMutationOwner(owned.result, owned.hostId)
     },


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​105 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​105 |
| Prod | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 |

<!-- /orca-pr-loc -->

## ELI5

In **Add Project → Import repositories from folder**, when you deselect every repo the dialog still shows a **Group name** box next to **Open as Folder**. Typing a name there did nothing: the new folder project was always named after the folder on disk, so `inf-오케스트레이터` became `inf`, which looked like Orca had stripped the hyphen and the Korean characters. The typed name is now carried through to project creation, so the folder project is created with exactly what you entered — on local, runtime-server, and SSH hosts alike. Leaving the prefilled name untouched behaves exactly as before.

## Visual proof

Real Orca dev build, driven through the actual **Add Project → Import repositories from folder** surface. Same fixture both runs: a folder named `inf` on disk containing nested repos `api-gateway` + `scheduler`. Both repos deselected (`0 of 2 selected`), then `inf-오케스트레이터` typed into **Group name**, then **Open as Folder**.

Left run is the PR's parent commit (`249d93bc5d2`), right run is this branch (`6dd5b887732`); each used a fresh user-data dir.

**1. Identical input — the name typed into the Group name box**

| BEFORE (`249d93bc5d2`) | AFTER (`6dd5b887732`) |
| :--- | :--- |
| ![before-01-typed-name.png](https://github.com/user-attachments/assets/7d626add-36b8-42f9-8f57-f62b8b113a55) | ![after-01-typed-name.png](https://github.com/user-attachments/assets/bb948e47-89ec-4f0d-b394-fcc6441216e7) |

**2. Result after clicking "Open as Folder" — the project name in the sidebar**

| BEFORE — project is named `inf` (typed name discarded) | AFTER — project is named `inf-오케스트레이터` |
| :--- | :--- |
| ![before-02-result.png](https://github.com/user-attachments/assets/0308dbf6-57be-4cb3-a27a-0c01b4c66b79) | ![after-02-result.png](https://github.com/user-attachments/assets/9e4f0106-0e01-4da6-ba6d-89d635b12bbd) |

Store state matches what is rendered:

```jsonc
// BEFORE
[{ "name": "inf", "displayName": "inf", "path": "/tmp/.../inf", "kind": "folder" }]
// AFTER
[{ "name": "inf-오케스트레이터", "path": "/tmp/.../inf", "kind": "folder" }]
```

The on-disk folder is still `inf` — visible as the workspace subtitle under the project row and in the terminal prompt — confirming only the project's display name changed, not anything on the filesystem.

## Root cause

`src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts:257` — `handleOpenNestedRootFolder` built the `completeNestedFolderOpen({...})` argument object without `nestedGroupName` (the sibling group-import path forwards it at line 138 as `groupName: nestedGroupName`). With no name in the payload, `src/renderer/src/components/sidebar/complete-nested-folder-open.ts:33` called `state.addNonGitFolder(args.scan.selectedPath, { runtimeEnvironmentId })`, and the SSH branch at `complete-nested-folder-open.ts:26` opened `confirm-non-git-folder` with only `{ folderPath, connectionId, runtimeEnvironmentId }`. By the time the add reached main, `src/main/ipc/repos/local-repo-registration.ts:79` (and the runtime host at `src/main/runtime/orca-runtime.ts:21989`) had nothing to use but `displayName: getRepoName(resolvedPath)`. The value was dropped in the renderer, never sanitized in main.

The fix forwards an optional `displayName` down the existing add path: flow → `completeNestedFolderOpen` → `addNonGitFolder` / `confirm-non-git-folder` → `repos:add` / `repos:addRemote` / the `repo.add` RPC → `addLocalRepoFromPath` / `OrcaRuntimeService.addRepo`. `repos:addRemote` already accepted `displayName`, so the SSH host needed no main-side change.

## Proof

Command: `pnpm test src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts src/renderer/src/components/sidebar/NonGitFolderDialog.test.tsx src/main/ipc/repos-local-add-and-project-setup.test.ts`

BEFORE the fix (tests present, source changes stashed):

```
 ❯ src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts (8 tests | 2 failed) 16ms
 ❯ src/renderer/src/components/sidebar/NonGitFolderDialog.test.tsx (5 tests | 2 failed) 1067ms
 ❯ src/main/ipc/repos-local-add-and-project-setup.test.ts (17 tests | 1 failed) 70ms

 FAIL  src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts > useAddRepoNestedImportFlow open folder fallback > names the folder project after the edited group name
AssertionError: expected "vi.fn()" to be called with arguments: [ '/workspace/platform', { …(2) } ]

Received:

  1st vi.fn() call:

  [
    "/workspace/platform",
    {
-     "displayName": "inf-오케스트레이터",
      "runtimeEnvironmentId": null,
    },
  ]

 FAIL  src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts > useAddRepoNestedImportFlow open folder fallback > carries the edited group name into the SSH folder confirmation
AssertionError: expected "vi.fn()" to be called with arguments: [ 'confirm-non-git-folder', …(1) ]

Received:

  1st vi.fn() call:

  [
    "confirm-non-git-folder",
-   ObjectContaining {
-     "displayName": "inf-오케스트레이터",
+   {
+     "connectionId": "ssh-builder",
+     "folderPath": "/workspace/platform",
+     "runtimeEnvironmentId": undefined,
    },
  ]

 FAIL  src/main/ipc/repos-local-add-and-project-setup.test.ts > repos:add + repos:clone > uses the requested display name for repos:add folder repos
AssertionError: expected "vi.fn()" to be called with arguments: [ ObjectContaining{…} ]

Received:

  1st vi.fn() call:

  [
-   ObjectContaining {
-     "displayName": "inf-오케스트레이터",
+   {
+     "addedAt": 1787867467870,
+     "badgeColor": "#737373",
+     "displayName": "from-add",
+     "id": "096dbbc0-78c9-44d3-b72a-b93c69524e03",
+     "kind": "folder",
      "path": "/tmp/from-add",
    },
  ]

 Test Files  3 failed (3)
```

AFTER the fix:

```
 Test Files  3 passed (3)
      Tests  30 passed (30)
   Duration  7.11s
```

Wider regression runs, all green: `src/renderer/src/components/sidebar` (275 files / 2354 tests), `src/renderer/src/store/repos` + `src/renderer/src/store/slices/repos*` (34 files / 246 tests), `src/main/ipc/repos*` + `src/main/runtime/rpc` (208 files / 1823 tests), `src/main/runtime/orca-runtime.test.ts` (1210 tests). Sequential `tsc --noEmit` on the node, web, and cli projects is clean; `pnpm run check:code-quality:changed` reports 0 new findings.

## Risk

Low. The new `displayName` is optional at every hop and is only populated by the one UI path that has a name field; every other caller of `addRepoPath` / `addNonGitFolder` / `repos:add` / `repo.add` is unchanged and still falls back to `getRepoName(path)`. The only rename of an existing symbol is the renderer-local type `AddRepoPathRouteOptions` → `AddRepoPathOptions` (it now carries more than routing).

Wire compatibility: `repo.add` gains one optional param. New client → old host: the zod object strips the unknown key and the host names the project by basename, i.e. today's behavior, no error. Old client → new host: no param, unchanged. No new stream opcodes and no capability negotiation needed. Paired-web `repos.add` passes the same field through the same RPC.

## User-facing regressions

- **None found.** Adjacent behavior I checked explicitly:
  - Grouped/separate nested import (`handleImportNestedRepos`) is untouched; it already forwarded the name as `groupName`.
  - "Open as Folder" with the prefilled name left alone sends no `displayName` at all, so host naming (including the SSH-target-label special case `addRemoteRepoFromPath` applies for a `~` path) is byte-for-byte unchanged. This is what the `leaves host basename naming alone when the group name is untouched` test pins.
  - Whitespace-only or empty input trims to nothing and falls back to the basename; trimming happens in the renderer *and* again in main/runtime so a hand-rolled IPC/RPC call cannot store a blank name.
  - Re-adding an already-registered path still returns the existing project untouched — an entered name never renames a project you already have (matches the pre-existing SSH `addRemoteRepoFromPath` dedupe behavior).
  - The `confirm-non-git-folder` dialog (also reached from Add Project's git→folder downgrade) only sends a name when one was supplied; its existing local/runtime/SSH branches are otherwise unchanged.
- Not changed (out of scope): the field is still labeled **Group name** in the zero-selection state, and the filesystem folder is never renamed.

Fixes #16355

