### PR TITLE
fix(codex): keep archived Codex sessions out of the real-home backfill

### DIFF
--- a/src/main/codex/codex-legacy-session-resume.ts
+++ b/src/main/codex/codex-legacy-session-resume.ts
@@ -175,6 +175,7 @@ async function materializeLegacyRollout(
     linkedFiles: 0,
     copiedFiles: 0,
     skippedExistingFiles: 0,
+    skippedArchivedFiles: 0,
     skippedUnexpectedFiles: 0,
     skippedSymlinkFiles: 0,
     skippedUnsupportedFilesystemFiles: 0,

--- a/src/main/codex/codex-session-archive.test.ts
+++ b/src/main/codex/codex-session-archive.test.ts
@@ -1,0 +1,139 @@
+import {
+  existsSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { backfillManagedCodexSessionsIntoSystemHome } from './codex-session-backfill'
+import type { CodexSessionBackfillPaths } from './codex-session-backfill-types'
+
+const ROLLOUT_NAME = 'rollout-2026-05-26T10-00-00-0f0e0d0c-0b0a-4908-8706-050403020100.jsonl'
+const ROLLOUT_RELATIVE_PATH = join('2026', '05', '26', ROLLOUT_NAME)
+const ROLLOUT_CONTENTS = '{"type":"session_meta"}\n'
+
+let tempRoots: string[] = []
+
+afterEach(() => {
+  for (const root of tempRoots) {
+    rmSync(root, { recursive: true, force: true })
+  }
+  tempRoots = []
+})
+
+type ArchiveRig = {
+  paths: CodexSessionBackfillPaths
+  managedPath: string
+  activePath: string
+  archivedSessionsRoot: string
+}
+
+function createArchiveRig(): ArchiveRig {
+  const root = mkdtempSync(join(tmpdir(), 'orca-codex-session-archive-'))
+  tempRoots.push(root)
+  const systemCodexHome = join(root, 'home', '.codex')
+  const paths: CodexSessionBackfillPaths = {
+    managedSessionsRoot: join(root, 'managed-home', 'sessions'),
+    systemSessionsRoot: join(systemCodexHome, 'sessions'),
+    auditLogPath: join(root, 'state', 'audit.jsonl'),
+    markerPath: join(root, 'state', 'backfill-complete.json')
+  }
+  const managedPath = join(paths.managedSessionsRoot, ROLLOUT_RELATIVE_PATH)
+  mkdirSync(dirname(managedPath), { recursive: true })
+  writeFileSync(managedPath, ROLLOUT_CONTENTS, 'utf-8')
+  return {
+    paths,
+    managedPath,
+    activePath: join(paths.systemSessionsRoot, ROLLOUT_RELATIVE_PATH),
+    archivedSessionsRoot: join(systemCodexHome, 'archived_sessions')
+  }
+}
+
+/** Mirrors `fs::rename` into Codex's flat archive directory. */
+function archiveRollout(rig: ArchiveRig, fileName = ROLLOUT_NAME): string {
+  const archivedPath = join(rig.archivedSessionsRoot, fileName)
+  mkdirSync(rig.archivedSessionsRoot, { recursive: true })
+  writeFileSync(archivedPath, ROLLOUT_CONTENTS, 'utf-8')
+  return archivedPath
+}
+
+describe('archived Codex sessions and the managed-home backfill', () => {
+  it('does not republish a rollout the user archived in Codex', async () => {
+    const rig = createArchiveRig()
+    archiveRollout(rig)
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(rig.paths)
+
+    expect(existsSync(rig.activePath)).toBe(false)
+    expect(summary).toMatchObject({ linkedFiles: 0, skippedArchivedFiles: 1, failedFiles: 0 })
+  })
+
+  it('treats a compressed archived rollout as archived', async () => {
+    const rig = createArchiveRig()
+    archiveRollout(rig, `${ROLLOUT_NAME}.zst`)
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(rig.paths)
+
+    expect(existsSync(rig.activePath)).toBe(false)
+    expect(summary.linkedFiles).toBe(0)
+  })
+
+  it('still publishes a rollout that was never archived', async () => {
+    const rig = createArchiveRig()
+    mkdirSync(rig.archivedSessionsRoot, { recursive: true })
+    archiveRollout(rig, 'rollout-2026-05-26T09-00-00-11112222-3333-4444-8555-666677778888.jsonl')
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(rig.paths)
+
+    expect(existsSync(rig.activePath)).toBe(true)
+    expect(summary.linkedFiles).toBe(1)
+  })
+
+  it('drops the redundant active hardlink an earlier republication left behind', async () => {
+    const rig = createArchiveRig()
+    mkdirSync(dirname(rig.activePath), { recursive: true })
+    mkdirSync(rig.archivedSessionsRoot, { recursive: true })
+    const archivedPath = join(rig.archivedSessionsRoot, ROLLOUT_NAME)
+    linkSync(rig.managedPath, archivedPath)
+    linkSync(rig.managedPath, rig.activePath)
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(rig.paths)
+
+    expect(existsSync(rig.activePath)).toBe(false)
+    expect(lstatSync(archivedPath).ino).toBe(lstatSync(rig.managedPath).ino)
+    expect(summary.failedFiles).toBe(0)
+  })
+
+  it('keeps an unrelated active file that merely shares the archived name', async () => {
+    const rig = createArchiveRig()
+    archiveRollout(rig)
+    mkdirSync(dirname(rig.activePath), { recursive: true })
+    writeFileSync(rig.activePath, '{"type":"session_meta","other":true}\n', 'utf-8')
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(rig.paths)
+
+    expect(existsSync(rig.activePath)).toBe(true)
+    expect(summary.failedFiles).toBe(0)
+  })
+
+  // ENOTDIR is the portable POSIX signal for an unreadable archive location;
+  // Windows reports the same shape as a missing path, which is a different case.
+  it.skipIf(process.platform === 'win32')(
+    'fails the file closed when the archive location cannot be read',
+    async () => {
+      const rig = createArchiveRig()
+      mkdirSync(dirname(rig.archivedSessionsRoot), { recursive: true })
+      writeFileSync(rig.archivedSessionsRoot, 'not a directory\n', 'utf-8')
+
+      const summary = await backfillManagedCodexSessionsIntoSystemHome(rig.paths)
+
+      expect(existsSync(rig.activePath)).toBe(false)
+      expect(summary).toMatchObject({ linkedFiles: 0, failedFiles: 1 })
+    }
+  )
+})

--- a/src/main/codex/codex-session-archive.ts
+++ b/src/main/codex/codex-session-archive.ts
@@ -1,0 +1,109 @@
+import type { Stats } from 'node:fs'
+import { lstat, readdir, unlink } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+// Codex archives a thread by renaming every rollout of that thread out of
+// `<CODEX_HOME>/sessions/YYYY/MM/DD/` into this flat sibling directory. A cold
+// archived rollout is later replaced by a `<name>.zst` sibling by Codex's
+// background compression worker, so both spellings mean "archived".
+const CODEX_ARCHIVED_SESSIONS_DIR_NAME = 'archived_sessions'
+const CODEX_COMPRESSED_ROLLOUT_SUFFIX = '.zst'
+
+/** Mirrors `dirname(systemSessionsRoot)` as the real Codex home, like the heal does. */
+export function resolveCodexArchivedSessionsRoot(systemSessionsRoot: string): string {
+  return join(dirname(systemSessionsRoot), CODEX_ARCHIVED_SESSIONS_DIR_NAME)
+}
+
+/**
+ * Stats the archived copy of a rollout, or null when the user has not archived it.
+ *
+ * Throws on anything but ENOENT: an unreadable archive must never read back as
+ * "not archived", because the caller would then resurrect the thread.
+ */
+export async function readArchivedCodexRolloutStat(
+  systemSessionsRoot: string,
+  rolloutFileName: string
+): Promise<Stats | null> {
+  const archivedSessionsRoot = resolveCodexArchivedSessionsRoot(systemSessionsRoot)
+  for (const fileName of [
+    rolloutFileName,
+    `${rolloutFileName}${CODEX_COMPRESSED_ROLLOUT_SUFFIX}`
+  ]) {
+    try {
+      return await lstat(join(archivedSessionsRoot, fileName))
+    } catch (error) {
+      if (!isNotFoundError(error)) {
+        throw error
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Reads every archived rollout name once, compressed siblings normalized back to
+ * their plain `.jsonl` spelling, so a whole audit ledger can be classified
+ * against one directory read. Async so a large archive cannot stall the main thread.
+ */
+export async function readArchivedCodexRolloutNames(
+  systemSessionsRoot: string
+): Promise<Set<string>> {
+  const archivedSessionsRoot = resolveCodexArchivedSessionsRoot(systemSessionsRoot)
+  let entries: string[]
+  try {
+    entries = await readdir(archivedSessionsRoot)
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw error
+    }
+    return new Set()
+  }
+  return new Set(
+    entries.map((entry) =>
+      entry.endsWith(CODEX_COMPRESSED_ROLLOUT_SUFFIX)
+        ? entry.slice(0, -CODEX_COMPRESSED_ROLLOUT_SUFFIX.length)
+        : entry
+    )
+  )
+}
+
+/**
+ * Removes an active rollout name that is provably a second hardlink to the
+ * already-archived inode — residue from a backfill pass that republished the
+ * managed copy before the archive was consulted. Any other file is left alone,
+ * so no rollout contents can be lost.
+ */
+export async function removeResurrectedActiveCodexRollout(
+  systemSessionFilePath: string,
+  archivedStat: Stats
+): Promise<void> {
+  let activeStat: Stats
+  try {
+    activeStat = await lstat(systemSessionFilePath)
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return
+    }
+    throw error
+  }
+  if (!isSameHardLink(activeStat, archivedStat)) {
+    return
+  }
+  try {
+    await unlink(systemSessionFilePath)
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw error
+    }
+  }
+}
+
+// Why: Windows reports ino 0 on filesystems without a stable file index, where
+// two unrelated zeros would otherwise read as one shared inode.
+function isSameHardLink(left: Stats, right: Stats): boolean {
+  return left.ino !== 0 && left.dev === right.dev && left.ino === right.ino
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
+}

--- a/src/main/codex/codex-session-backfill-marker.test.ts
+++ b/src/main/codex/codex-session-backfill-marker.test.ts
@@ -32,6 +32,7 @@ function createSummary(scannedFiles = 3): CodexSessionBackfillSummary {
     linkedFiles: scannedFiles,
     copiedFiles: 0,
     skippedExistingFiles: 0,
+    skippedArchivedFiles: 0,
     skippedUnexpectedFiles: 0,
     skippedSymlinkFiles: 0,
     skippedUnsupportedFilesystemFiles: 0,

--- a/src/main/codex/codex-session-backfill-publish.ts
+++ b/src/main/codex/codex-session-backfill-publish.ts
@@ -1,0 +1,143 @@
+import { link, lstat, mkdir } from 'node:fs/promises'
+import { basename, dirname, join, relative } from 'node:path'
+import {
+  readArchivedCodexRolloutStat,
+  removeResurrectedActiveCodexRollout
+} from './codex-session-archive'
+import { describeCodexSessionBackfillErrorCode } from './codex-session-backfill-audit'
+import {
+  readCodexSessionTargetStat,
+  type CodexSessionBackfillAuditPass
+} from './codex-session-backfill-audit-pass'
+import type {
+  CodexSessionBackfillPaths,
+  CodexSessionBackfillSummary
+} from './codex-session-backfill-types'
+
+/**
+ * Publishes one managed-home rollout into the user's real Codex home.
+ *
+ * Existing target files are never overwritten, and an archived rollout is left
+ * archived. The only removal is an active name that is provably a second
+ * hardlink to an already-archived rollout.
+ */
+export async function backfillOneManagedSessionFile(
+  paths: CodexSessionBackfillPaths,
+  managedSessionFilePath: string,
+  summary: CodexSessionBackfillSummary,
+  ensuredTargetDirectories: Set<string>,
+  auditPass: CodexSessionBackfillAuditPass
+): Promise<void> {
+  if (await isSymbolicLink(managedSessionFilePath)) {
+    // Why: bridge-created symlinks already point at a file in the user's own
+    // home; materializing them here could duplicate a foreign tree.
+    summary.skippedSymlinkFiles += 1
+    return
+  }
+  const relativePath = relative(paths.managedSessionsRoot, managedSessionFilePath)
+  const systemSessionFilePath = join(paths.systemSessionsRoot, relativePath)
+
+  let linkAttempted = false
+  try {
+    // Why: archiving a thread renames its rollout out of `sessions/`, so the
+    // active path being absent is not "not published yet". Relinking the
+    // still-present managed copy would silently reverse the user's archive.
+    const archivedStat = await readArchivedCodexRolloutStat(
+      paths.systemSessionsRoot,
+      basename(managedSessionFilePath)
+    )
+    if (archivedStat) {
+      await removeResurrectedActiveCodexRollout(systemSessionFilePath, archivedStat)
+      summary.skippedArchivedFiles += 1
+      return
+    }
+    const existingTargetStat = await readCodexSessionTargetStat(systemSessionFilePath)
+    if (existingTargetStat) {
+      await auditPass.recordExisting(
+        summary,
+        managedSessionFilePath,
+        systemSessionFilePath,
+        existingTargetStat
+      )
+      return
+    }
+    const targetDirectory = dirname(systemSessionFilePath)
+    if (!ensuredTargetDirectories.has(targetDirectory)) {
+      // Why: one date directory can contain thousands of rollouts; avoid a
+      // redundant filesystem round trip before every hardlink.
+      await mkdir(targetDirectory, { recursive: true })
+      ensuredTargetDirectories.add(targetDirectory)
+    }
+    linkAttempted = true
+    await link(managedSessionFilePath, systemSessionFilePath)
+    summary.linkedFiles += 1
+    await auditPass.recordPublished(
+      summary,
+      'hardlink',
+      managedSessionFilePath,
+      systemSessionFilePath
+    )
+  } catch (linkError) {
+    if (linkAttempted && isExistsError(linkError)) {
+      // Why: another window can publish the target after our existence probe;
+      // enqueue it here too in case that writer died before its audit append.
+      await auditPass.recordExisting(
+        summary,
+        managedSessionFilePath,
+        systemSessionFilePath,
+        await readCodexSessionTargetStat(systemSessionFilePath)
+      )
+      return
+    }
+    if (isNotFoundError(linkError)) {
+      ensuredTargetDirectories.delete(dirname(systemSessionFilePath))
+    }
+    const sourceStat = await readCodexSessionTargetStat(managedSessionFilePath)
+    if (linkAttempted && isUnsupportedHardlinkError(linkError)) {
+      // Why: a mutable rollout cannot be kept coherent by a cross-volume snapshot.
+      summary.skippedUnsupportedFilesystemFiles += 1
+      await auditPass.recordDiagnostic(
+        {
+          action: 'copy-unsupported',
+          source: managedSessionFilePath,
+          target: systemSessionFilePath,
+          linkErrorCode: describeCodexSessionBackfillErrorCode(linkError)
+        },
+        sourceStat
+      )
+      return
+    }
+    summary.failedFiles += 1
+    await auditPass.recordDiagnostic(
+      {
+        action: 'failed',
+        source: managedSessionFilePath,
+        target: systemSessionFilePath,
+        linkError: linkError instanceof Error ? linkError.message : String(linkError),
+        linkErrorCode: describeCodexSessionBackfillErrorCode(linkError)
+      },
+      sourceStat
+    )
+  }
+}
+
+async function isSymbolicLink(filePath: string): Promise<boolean> {
+  try {
+    return (await lstat(filePath)).isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
+function isExistsError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === 'EEXIST'
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
+}
+
+function isUnsupportedHardlinkError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code
+  return code === 'EXDEV' || code === 'ENOTSUP' || code === 'EOPNOTSUPP' || code === 'ENOSYS'
+}

--- a/src/main/codex/codex-session-backfill-types.ts
+++ b/src/main/codex/codex-session-backfill-types.ts
@@ -6,6 +6,8 @@ export type CodexSessionBackfillSummary = {
   linkedFiles: number
   copiedFiles: number
   skippedExistingFiles: number
+  /** Rollouts the user archived in Codex, which this pass must never republish. */
+  skippedArchivedFiles: number
   skippedUnexpectedFiles: number
   skippedSymlinkFiles: number
   skippedUnsupportedFilesystemFiles: number

--- a/src/main/codex/codex-session-backfill.ts
+++ b/src/main/codex/codex-session-backfill.ts
@@ -1,5 +1,5 @@
-import { link, lstat, mkdir } from 'node:fs/promises'
-import { dirname, join, relative } from 'node:path'
+import { lstat } from 'node:fs/promises'
+import { join } from 'node:path'
 import {
   getCodexSessionBackfillStateDirPath,
   getOrcaManagedCodexHomePath,
@@ -7,10 +7,9 @@ import {
 } from './codex-home-paths'
 import {
   createCodexSessionBackfillAuditPass,
-  readCodexSessionTargetStat,
   type CodexSessionBackfillAuditPass
 } from './codex-session-backfill-audit-pass'
-import { describeCodexSessionBackfillErrorCode } from './codex-session-backfill-audit'
+import { backfillOneManagedSessionFile } from './codex-session-backfill-publish'
 import {
   isCodexSessionRolloutPath,
   listCodexSessionBackfillFilesForDates
@@ -152,9 +151,11 @@ function resolveCodexSessionBackfillScanPlan(
 /**
  * Backfills managed-home session rollout files into the real Codex home.
  *
- * Non-destructive by contract: existing target files are always skipped, and
- * nothing in either home is deleted or moved. A hardlink keeps mutable rollout
- * contents coherent; cross-volume snapshots are skipped as unsupported.
+ * Non-destructive by contract: existing target files are always skipped, and a
+ * rollout the user archived in Codex is neither republished nor read. The one
+ * removal is a redundant active hardlink to an already-archived rollout, which
+ * loses no contents. A hardlink keeps mutable rollout contents coherent;
+ * cross-volume snapshots are skipped as unsupported.
  */
 export async function backfillManagedCodexSessionsIntoSystemHome(
   paths: CodexSessionBackfillPaths,
@@ -166,6 +167,7 @@ export async function backfillManagedCodexSessionsIntoSystemHome(
     linkedFiles: 0,
     copiedFiles: 0,
     skippedExistingFiles: 0,
+    skippedArchivedFiles: 0,
     skippedUnexpectedFiles: 0,
     skippedSymlinkFiles: 0,
     skippedUnsupportedFilesystemFiles: 0,
@@ -245,113 +247,8 @@ async function checkManagedSessionsRoot(
   }
 }
 
-async function backfillOneManagedSessionFile(
-  paths: CodexSessionBackfillPaths,
-  managedSessionFilePath: string,
-  summary: CodexSessionBackfillSummary,
-  ensuredTargetDirectories: Set<string>,
-  auditPass: CodexSessionBackfillAuditPass
-): Promise<void> {
-  if (await isSymbolicLink(managedSessionFilePath)) {
-    // Why: bridge-created symlinks already point at a file in the user's own
-    // home; materializing them here could duplicate a foreign tree.
-    summary.skippedSymlinkFiles += 1
-    return
-  }
-  const relativePath = relative(paths.managedSessionsRoot, managedSessionFilePath)
-  const systemSessionFilePath = join(paths.systemSessionsRoot, relativePath)
-  const existingTargetStat = await readCodexSessionTargetStat(systemSessionFilePath)
-  if (existingTargetStat) {
-    await auditPass.recordExisting(
-      summary,
-      managedSessionFilePath,
-      systemSessionFilePath,
-      existingTargetStat
-    )
-    return
-  }
-
-  let linkAttempted = false
-  try {
-    const targetDirectory = dirname(systemSessionFilePath)
-    if (!ensuredTargetDirectories.has(targetDirectory)) {
-      // Why: one date directory can contain thousands of rollouts; avoid a
-      // redundant filesystem round trip before every hardlink.
-      await mkdir(targetDirectory, { recursive: true })
-      ensuredTargetDirectories.add(targetDirectory)
-    }
-    linkAttempted = true
-    await link(managedSessionFilePath, systemSessionFilePath)
-    summary.linkedFiles += 1
-    await auditPass.recordPublished(
-      summary,
-      'hardlink',
-      managedSessionFilePath,
-      systemSessionFilePath
-    )
-  } catch (linkError) {
-    if (linkAttempted && isExistsError(linkError)) {
-      // Why: another window can publish the target after our existence probe;
-      // enqueue it here too in case that writer died before its audit append.
-      await auditPass.recordExisting(
-        summary,
-        managedSessionFilePath,
-        systemSessionFilePath,
-        await readCodexSessionTargetStat(systemSessionFilePath)
-      )
-      return
-    }
-    if (isNotFoundError(linkError)) {
-      ensuredTargetDirectories.delete(dirname(systemSessionFilePath))
-    }
-    const sourceStat = await readCodexSessionTargetStat(managedSessionFilePath)
-    if (linkAttempted && isUnsupportedHardlinkError(linkError)) {
-      // Why: a mutable rollout cannot be kept coherent by a cross-volume snapshot.
-      summary.skippedUnsupportedFilesystemFiles += 1
-      await auditPass.recordDiagnostic(
-        {
-          action: 'copy-unsupported',
-          source: managedSessionFilePath,
-          target: systemSessionFilePath,
-          linkErrorCode: describeCodexSessionBackfillErrorCode(linkError)
-        },
-        sourceStat
-      )
-      return
-    }
-    summary.failedFiles += 1
-    await auditPass.recordDiagnostic(
-      {
-        action: 'failed',
-        source: managedSessionFilePath,
-        target: systemSessionFilePath,
-        linkError: describeError(linkError),
-        linkErrorCode: describeCodexSessionBackfillErrorCode(linkError)
-      },
-      sourceStat
-    )
-  }
-}
-
-async function isSymbolicLink(filePath: string): Promise<boolean> {
-  try {
-    return (await lstat(filePath)).isSymbolicLink()
-  } catch {
-    return false
-  }
-}
-
-function isExistsError(error: unknown): boolean {
-  return (error as NodeJS.ErrnoException | null)?.code === 'EEXIST'
-}
-
 function isNotFoundError(error: unknown): boolean {
   return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
-}
-
-function isUnsupportedHardlinkError(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException | null)?.code
-  return code === 'EXDEV' || code === 'ENOTSUP' || code === 'EOPNOTSUPP' || code === 'ENOSYS'
 }
 
 function describeError(error: unknown): string {

--- a/src/main/codex/codex-session-index-heal-state.test.ts
+++ b/src/main/codex/codex-session-index-heal-state.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { appendFileSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -104,6 +104,53 @@ describe('codex session index heal state', () => {
 
     expect(await collectPendingHealThreads(paths)).toEqual([
       expect.objectContaining({ threadId: THREAD_ID, auditRecordId: 'audit-2' })
+    ])
+  })
+
+  it.each([
+    ['plain', `rollout-2026-07-01T10-00-00-${THREAD_ID}.jsonl`],
+    ['compressed', `rollout-2026-07-01T10-00-00-${THREAD_ID}.jsonl.zst`]
+  ])(
+    'drops a thread whose %s rollout Codex moved into archived_sessions',
+    async (_, archivedName) => {
+      const systemCodexHome = mkdtempSync(join(tmpdir(), 'orca-codex-heal-home-'))
+      tempRoots.push(systemCodexHome)
+      const paths = createPaths(join(systemCodexHome, 'sessions'))
+      const rolloutName = `rollout-2026-07-01T10-00-00-${THREAD_ID}.jsonl`
+      appendAuditRecord(
+        paths,
+        join(paths.systemSessionsRoot, '2026', '07', '01', rolloutName),
+        'audit-1'
+      )
+      mkdirSync(join(systemCodexHome, 'archived_sessions'), { recursive: true })
+      writeFileSync(join(systemCodexHome, 'archived_sessions', archivedName), 'archived\n', 'utf-8')
+
+      expect(await collectPendingHealThreads(paths)).toEqual([])
+    }
+  )
+
+  it('still heals a thread whose newer rollout is back in the sessions tree', async () => {
+    const systemCodexHome = mkdtempSync(join(tmpdir(), 'orca-codex-heal-home-'))
+    tempRoots.push(systemCodexHome)
+    const paths = createPaths(join(systemCodexHome, 'sessions'))
+    const archivedName = `rollout-2026-07-01T10-00-00-${THREAD_ID}.jsonl`
+    appendAuditRecord(paths, join(paths.systemSessionsRoot, '2026', '07', '01', archivedName), 'a1')
+    appendAuditRecord(
+      paths,
+      join(
+        paths.systemSessionsRoot,
+        '2026',
+        '07',
+        '02',
+        `rollout-2026-07-02T10-00-00-${THREAD_ID}.jsonl`
+      ),
+      'a2'
+    )
+    mkdirSync(join(systemCodexHome, 'archived_sessions'), { recursive: true })
+    writeFileSync(join(systemCodexHome, 'archived_sessions', archivedName), 'archived\n', 'utf-8')
+
+    expect(await collectPendingHealThreads(paths)).toEqual([
+      expect.objectContaining({ threadId: THREAD_ID, auditRecordId: 'a2' })
     ])
   })
 

--- a/src/main/codex/codex-session-index-heal-state.ts
+++ b/src/main/codex/codex-session-index-heal-state.ts
@@ -5,6 +5,7 @@ import {
   normalizeRuntimePathForComparison
 } from '../../shared/cross-platform-path'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
+import { readArchivedCodexRolloutNames } from './codex-session-archive'
 import { streamCodexSessionLedgerRecords } from './codex-session-ledger-stream'
 
 // State files for the session index heal: which backfilled rollouts exist
@@ -49,12 +50,14 @@ export type HealMarkerSummary = {
 
 /**
  * Diffs the backfill audit ledger against the heal ledger: every hardlinked or
- * copied rollout whose thread id has not been processed yet, most recent first.
+ * copied rollout that this pass has not processed yet and that the user has not
+ * archived in Codex, most recent first.
  */
 export async function collectPendingHealThreads(
   paths: CodexSessionIndexHealPaths
 ): Promise<PendingHealThread[]> {
   const processed = await readProcessedHealThreads(paths)
+  const archivedRolloutNames = await readArchivedCodexRolloutNames(paths.systemSessionsRoot)
   const pendingByThreadId = new Map<string, PendingHealThread>()
   for await (const line of streamCodexSessionLedgerRecords(paths.auditLogPath, {
     throwOnReadFailure: true
@@ -70,11 +73,19 @@ export async function collectPendingHealThreads(
     if (!isPathInsideOrEqual(paths.systemSessionsRoot, line.target)) {
       continue
     }
-    const match = CODEX_ROLLOUT_THREAD_ID_PATTERN.exec(lastPathSegment(line.target))
+    const rolloutFileName = lastPathSegment(line.target)
+    const match = CODEX_ROLLOUT_THREAD_ID_PATTERN.exec(rolloutFileName)
     if (!match) {
       continue
     }
     const threadId = match[2].toLowerCase()
+    if (archivedRolloutNames.has(rolloutFileName)) {
+      // Why: `thread/read` re-indexes the rollout into Codex's state DB, which
+      // would resurface a thread the user archived. The append-only publication
+      // record stays, but it must cancel any older pending event for the thread.
+      pendingByThreadId.delete(threadId)
+      continue
+    }
     const auditRecordId = typeof line.recordId === 'string' ? line.recordId : null
     if (
       auditRecordId


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​188 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​187 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​277 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​114 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​163 |

<!-- /orca-pr-loc -->

## ELI5

If you archived a Codex/ChatGPT conversation that you had started through Orca, Orca could quietly bring it back to life. Codex archives a thread by *moving* its transcript file out of the active `sessions/` folder, and Orca's background "copy my sessions into your real Codex home" pass only ever looked at the active folder — so it saw an empty slot, assumed the session had never been published, and re-created it from its own copy. On the next launch the archived conversation was active again, and Orca then asked Codex to re-index it.

Now both passes look at Codex's `archived_sessions/` folder first. An archived thread is left archived, is never re-indexed, and an active copy that an earlier buggy pass left behind is cleaned up.

## Root cause

`src/main/codex/codex-session-backfill.ts:262-284` (pre-change): `backfillOneManagedSessionFile` computed `systemSessionFilePath = join(paths.systemSessionsRoot, relativePath)`, treated a null `readCodexSessionTargetStat(systemSessionFilePath)` as "not published yet", and unconditionally `mkdir` + `link`ed the managed copy back in. Codex's archive is an `fs::rename` from `<CODEX_HOME>/sessions/YYYY/MM/DD/rollout-*.jsonl` to `<CODEX_HOME>/archived_sessions/rollout-*.jsonl` (`ARCHIVED_SESSIONS_SUBDIR` in codex-rs `rollout/src/lib.rs`; the file is later rewritten as `.jsonl.zst` by Codex's compression worker), so the active-path probe was null precisely *because* the user archived the thread. `grep -rn "archived_sessions" src/` returned zero hits repo-wide.

Secondary site: `src/main/codex/codex-session-index-heal-state.ts:54-96`, `collectPendingHealThreads` derived pending threads purely from `hardlink`/`copy`/`existing` audit lines and never checked the archive, so `codex-session-index-heal.ts:216` issued `thread/read` for archived threads — re-upserting them into Codex's state DB.

The doc comment claiming the pass is "non-destructive by contract" was true of file *contents* but not of lifecycle state.

## Proof

Test files: `src/main/codex/codex-session-archive.test.ts` (new) and `src/main/codex/codex-session-index-heal-state.test.ts`.

Command:

```
pnpm test src/main/codex/codex-session-archive.test.ts src/main/codex/codex-session-index-heal-state.test.ts
```

### BEFORE the fix (archive checks disabled, same tests)

```
 ❯ src/main/codex/codex-session-archive.test.ts (6 tests | 3 failed) 71ms
     × does not republish a rollout the user archived in Codex 19ms
     × treats a compressed archived rollout as archived 9ms
     × drops the redundant active hardlink an earlier republication left behind 6ms
 ❯ src/main/codex/codex-session-index-heal-state.test.ts (12 tests | 2 failed) 3133ms
     × drops a thread whose plain rollout Codex moved into archived_sessions 9ms
     × drops a thread whose compressed rollout Codex moved into archived_sessions 3ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/main/codex/codex-session-archive.test.ts > archived Codex sessions and the managed-home backfill > does not republish a rollout the user archived in Codex
AssertionError: expected true to be false // Object.is equality

- Expected
+ Received

- false
+ true

 ❯ src/main/codex/codex-session-archive.test.ts:72:40
     70|     const summary = await backfillManagedCodexSessionsIntoSystemHome(r…
     71|
     72|     expect(existsSync(rig.activePath)).toBe(false)
       |                                        ^
     73|     expect(summary).toMatchObject({ linkedFiles: 0, skippedArchivedFil…
     74|   })

 FAIL  src/main/codex/codex-session-index-heal-state.test.ts > codex session index heal state > drops a thread whose plain rollout Codex moved into archived_sessions
 FAIL  src/main/codex/codex-session-index-heal-state.test.ts > codex session index heal state > drops a thread whose compressed rollout Codex moved into archived_sessions
AssertionError: expected [ { …(3) } ] to deeply equal []

- Expected
+ Received

- []
+ [
+   {
+     "auditRecordId": "audit-1",
+     "rolloutStamp": "2026-07-01T10-00-00",
+     "threadId": "019f0000-1111-7222-8333-000000000001",
+   },
+ ]

 Test Files  2 failed (2)
      Tests  5 failed | 13 passed (18)
```

### AFTER the fix

```
 Test Files  2 passed (2)
      Tests  18 passed (18)
   Start at  15:00:17
   Duration  3.00s (transform 798ms, setup 248ms, import 765ms, tests 2.29s, environment 0ms)
```

Whole-module regression run (`src/main/codex/` + `src/main/codex-accounts/`):

```
 Test Files  107 passed | 1 skipped (108)
      Tests  1147 passed | 6 skipped (1153)
```

`pnpm run check:code-quality:changed`: `0 new finding(s) across 9 changed file(s)` for all three gates.

## Risk

**Low-to-medium.** Low for the skip path: it adds at most two `lstat`s per managed rollout in a background, once-per-host pass, and every existing backfill/heal test still passes unchanged.

Medium only because this PR introduces the first `unlink` in the backfill. It is tightly fenced: the active name is removed **only** when `lstat` proves it shares `dev` + `ino` with the archived file (and `ino !== 0`, since Windows reports 0 on filesystems without a stable file index). That means the archived name still references the same inode, so no rollout contents can be lost — it removes a redundant directory entry, nothing else. A file that merely shares the archived *name* is left alone (covered by a test). An unreadable archive location fails the file closed (`failedFiles += 1`, pass stays retryable) rather than defaulting to "not archived".

## User-facing regressions

Checked adjacent behavior; enumerating honestly:

- **Archived-then-resumed threads**: if a thread is unarchived and gets a *new* rollout in `sessions/`, that newer rollout still heals normally — only the archived file name is skipped. Test: `still heals a thread whose newer rollout is back in the sessions tree`.
- **Never-archived sessions**: unaffected; still hardlinked. Test: `still publishes a rollout that was never archived`.
- **Explicit resume**: `codex-legacy-session-resume.ts` deliberately keeps publishing on an explicit user resume — this PR only changes the automatic background pass. That file is touched solely to add the new summary counter field.
- **Completion marker / audit ledger**: `skippedArchivedFiles` is an additive summary field. `readMarkerRecord` parses markers field-by-field and ignores unknown keys, and `codex-session-migration-scheduler.ts` reads only named counters, so old markers upgrade and new markers downgrade cleanly. The heal ledger format and `CODEX_SESSION_INDEX_HEAL_VERSION` are unchanged — the new semantics are strictly more restrictive, so no re-drive is needed.
- **Cross-platform**: all paths built with `join`/`dirname`; the Windows `ino === 0` case is guarded; the one ENOTDIR-dependent test is skipped on win32 because Windows reports that shape as a missing path.
- **SSH / WSL / folder workspaces**: unaffected. This pass only ever operates on the local execution host's own `CODEX_HOME`; the WSL bridge (`wsl-codex-session-bridge.ts`) has its own path plumbing and reads only `sessions/`, which archived files are by definition no longer in. No RPC params, stream frames, or published content changed, so there is no remote-wire surface.
- **Pre-existing residue**: a session already resurrected by the old code *and* whose archived copy was since compressed to `.zst` is a different inode, so it is not auto-cleaned. It is no longer re-resurrected, and archiving it once in Codex resolves it. Deliberately conservative.

Prior art: adopted the approach from #14029 by @darrentmorgan (filed against the narrower #14028), rebased onto current `main` and reworked to avoid the `max-lines` disable that PR needed, to derive the archive root the way `codex-session-index-heal.ts` already derives `CODEX_HOME`, and to handle Codex's compressed `.jsonl.zst` archive form. Credited via `Co-authored-by`.

Fixes #16411
