### PR TITLE
fix(native-chat): keep a tab launch draft out of split sibling composers

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -72,8 +72,7 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
       onSlashCommand,
       onSwitchToTerminal,
       readTerminalScreen,
-      launchDraft,
-      launchDraftResolved = false,
+      launchSeed,
       structuredTransport
     },
     ref
@@ -88,8 +87,9 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
     useNativeChatLaunchDraftAdoption({
       terminalTabId,
       agent,
-      launchDraft,
-      launchDraftResolved,
+      launchDraft: launchSeed?.launchDraft,
+      launchDraftResolved: launchSeed?.launchDraftResolved === true,
+      ownsTabWideLaunchDraft: launchSeed?.ownsTabWideLaunchDraft === true,
       draft,
       setDraft,
       setCaret
@@ -285,8 +285,8 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
       imageAttachments,
       disabled,
       isDispatchingSessionOption,
-      launchDraft,
-      launchDraftResolved,
+      launchDraft: launchSeed?.launchDraft,
+      launchDraftResolved: launchSeed?.launchDraftResolved === true,
       readTerminalScreen,
       resolveTarget,
       classifySend,

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -143,15 +143,13 @@ function NativeChatResolvedView({
   const paneLaunchPrompt = launchPrompt?.agent === agent ? launchPrompt : null
   // Launch context prefilled into the TUI input as an unsent draft; the
   // composer adopts it so the GUI view shows the same context as the TUI.
-  // Shape matches NativeChatComposer's two launch-draft props, so it spreads.
   const launchDraftSignal = useNativeChatLaunchDraftSignal({
     terminalTabId,
     agent,
     messages: session.messages,
     // 'awaiting' counts too: adopting a prefill against a transcript that hasn't
     // flushed would re-offer a prompt the user already submitted.
-    transcriptLoading: isNativeChatTranscriptUnsettled(session.readPhase),
-    ownsTabWideLaunchDraft
+    transcriptLoading: isNativeChatTranscriptUnsettled(session.readPhase)
   })
   // The live-session merge reconciles hooks with replayable transcript turn
   // boundaries; all working consumers must use that one lifecycle decision.
@@ -454,7 +452,7 @@ function NativeChatResolvedView({
           onSlashCommand={onSlashCommand}
           onSwitchToTerminal={onSwitchToTerminal}
           readTerminalScreen={readTerminalScreen}
-          {...launchDraftSignal}
+          launchSeed={{ ...launchDraftSignal, ownsTabWideLaunchDraft }}
         />
       )}
       {contextMenu.menu}

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -73,6 +73,7 @@ function NativeChatBridgeView({
   targetPtyId = null,
   launchAgent,
   resolvedAgent,
+  ownsTabWideLaunchDraft,
   onSwitchToTerminal,
   readTerminalScreen,
   contextMenuActions,
@@ -99,6 +100,7 @@ function NativeChatBridgeView({
           isVisible={isVisible}
           targetPtyId={targetPtyId}
           terminalTabId={terminalTabId}
+          ownsTabWideLaunchDraft={ownsTabWideLaunchDraft}
           onSwitchToTerminal={onSwitchToTerminal}
           readTerminalScreen={readTerminalScreen}
           contextMenuActions={contextMenuActions}
@@ -117,6 +119,7 @@ function NativeChatResolvedView({
   isVisible,
   targetPtyId,
   terminalTabId,
+  ownsTabWideLaunchDraft,
   onSwitchToTerminal,
   readTerminalScreen,
   contextMenuActions,
@@ -147,7 +150,8 @@ function NativeChatResolvedView({
     messages: session.messages,
     // 'awaiting' counts too: adopting a prefill against a transcript that hasn't
     // flushed would re-offer a prompt the user already submitted.
-    transcriptLoading: isNativeChatTranscriptUnsettled(session.readPhase)
+    transcriptLoading: isNativeChatTranscriptUnsettled(session.readPhase),
+    ownsTabWideLaunchDraft
   })
   // The live-session merge reconciles hooks with replayable transcript turn
   // boundaries; all working consumers must use that one lifecycle decision.

--- a/src/renderer/src/components/native-chat/native-chat-composer-types.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-types.ts
@@ -47,12 +47,20 @@ export type NativeChatComposerProps = {
   onSwitchToTerminal?: () => void
   /** Reads the hosted TUI's current rendered screen when chat is entered. */
   readTerminalScreen?: () => string | null
-  /** Launch context prefilled into the TUI input as an unsent draft; adopted as the composer draft. */
-  launchDraft?: NativeChatLaunchDraft | null
-  /** True once the transcript shows the TUI-side draft was submitted or cleared. */
-  launchDraftResolved?: boolean
+  /** The tab's launch seed as this pane sees it. */
+  launchSeed?: NativeChatLaunchSeed
   /** Structured journal transport; absent keeps the existing PTY path unchanged. */
   structuredTransport?: NativeChatStructuredComposerTransport
+}
+
+/** Launch context prefilled into the TUI input as an unsent draft, plus the two
+ *  facts that decide its fate in this pane's composer. */
+export type NativeChatLaunchSeed = {
+  launchDraft: NativeChatLaunchDraft | null
+  /** True once the transcript shows the TUI-side draft was submitted or cleared. */
+  launchDraftResolved: boolean
+  /** False for every pane of a split tab; gates adopting the seed, not cleanup. */
+  ownsTabWideLaunchDraft: boolean
 }
 
 export type NativeChatComposerHandle = {

--- a/src/renderer/src/components/native-chat/native-chat-leaf-routing.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-leaf-routing.test.ts
@@ -1,8 +1,44 @@
 import { describe, expect, it } from 'vitest'
 import {
   nativeChatLaunchAgentForLeaf,
+  nativeChatLeafOwnsTabWideEvidence,
   resolveNativeChatLeafRoute
 } from './native-chat-leaf-routing'
+
+describe('nativeChatLeafOwnsTabWideEvidence', () => {
+  it("owns tab-wide evidence only while the bound leaf is still the tab's sole pane", () => {
+    expect(
+      nativeChatLeafOwnsTabWideEvidence({
+        ownerLeafId: 'leaf-a',
+        leafId: 'leaf-a',
+        leafIds: ['leaf-a']
+      })
+    ).toBe(true)
+    // A split sibling must not inherit the tab's launch draft (issue #16695).
+    expect(
+      nativeChatLeafOwnsTabWideEvidence({
+        ownerLeafId: 'leaf-a',
+        leafId: 'leaf-b',
+        leafIds: ['leaf-a', 'leaf-b']
+      })
+    ).toBe(false)
+    // Not even the original pane keeps it once the tab is split.
+    expect(
+      nativeChatLeafOwnsTabWideEvidence({
+        ownerLeafId: 'leaf-a',
+        leafId: 'leaf-a',
+        leafIds: ['leaf-a', 'leaf-b']
+      })
+    ).toBe(false)
+    expect(
+      nativeChatLeafOwnsTabWideEvidence({
+        ownerLeafId: null,
+        leafId: 'leaf-a',
+        leafIds: ['leaf-a']
+      })
+    ).toBe(false)
+  })
+})
 
 describe('nativeChatLaunchAgentForLeaf', () => {
   it('uses the tab launch hint only for its sole leaf', () => {

--- a/src/renderer/src/components/native-chat/native-chat-leaf-routing.ts
+++ b/src/renderer/src/components/native-chat/native-chat-leaf-routing.ts
@@ -44,6 +44,22 @@ export function isNativeChatTabWideFallbackSafe(
   return !layout.activeLeafId || layout.activeLeafId === layout.root.leafId
 }
 
+/** Whether tab-wide launch evidence (agent hint, launch draft) describes this
+ *  leaf: it must still be the tab's sole pane and the one the evidence bound to. */
+export function nativeChatLeafOwnsTabWideEvidence(args: {
+  ownerLeafId: string | null
+  leafId: string | null
+  leafIds: readonly string[]
+}): boolean {
+  const { ownerLeafId, leafId, leafIds } = args
+  if (!ownerLeafId || !leafId) {
+    return false
+  }
+  // Why: the evidence belongs to the tab's original pane. Once a split exists,
+  // it says nothing about any particular sibling.
+  return leafIds.length === 1 && leafIds[0] === leafId && ownerLeafId === leafId
+}
+
 export function nativeChatLaunchAgentForLeaf(args: {
   launchAgent?: TuiAgent | null
   launchAgentLeafId: string | null
@@ -51,12 +67,14 @@ export function nativeChatLaunchAgentForLeaf(args: {
   leafIds: readonly string[]
 }): TuiAgent | null {
   const { launchAgent, launchAgentLeafId, leafId, leafIds } = args
-  if (!launchAgent || !launchAgentLeafId || !leafId) {
+  if (!launchAgent) {
     return null
   }
-  // Why: launchAgent belongs to the tab's original pane. Once a split exists,
-  // it is not evidence that an agent is running in any particular sibling.
-  return leafIds.length === 1 && leafIds[0] === leafId && launchAgentLeafId === leafId
+  return nativeChatLeafOwnsTabWideEvidence({
+    ownerLeafId: launchAgentLeafId,
+    leafId,
+    leafIds
+  })
     ? launchAgent
     : null
 }

--- a/src/renderer/src/components/native-chat/native-chat-view-types.ts
+++ b/src/renderer/src/components/native-chat/native-chat-view-types.ts
@@ -25,6 +25,8 @@ export type NativeChatBridgeViewProps = NativeChatOrchestrationProps & {
   launchAgent?: TuiAgent | null
   /** Trusted title/foreground fallback for manually-started agents. */
   resolvedAgent?: TuiAgent | null
+  /** Whether this pane owns the tab's launch draft; false for split siblings. */
+  ownsTabWideLaunchDraft: boolean
   /** Return this pane to the hosted terminal surface. */
   onSwitchToTerminal?: () => void
   /** Current xterm screen reader used to recover agent-reported session state. */
@@ -50,6 +52,7 @@ export type NativeChatResolvedViewProps = NativeChatOrchestrationProps & {
   isVisible: boolean
   targetPtyId: string | null
   terminalTabId: string
+  ownsTabWideLaunchDraft: boolean
   onSwitchToTerminal?: () => void
   readTerminalScreen?: () => string | null
   contextMenuActions?: Omit<NativeChatContextMenuActions, 'onPaste'>

--- a/src/renderer/src/components/native-chat/use-native-chat-launch-draft-adoption.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-launch-draft-adoption.test.tsx
@@ -67,7 +67,11 @@ function userTurn(id: string, timestamp: number | null): NativeChatMessage {
   return { id, role: 'user', blocks: [{ type: 'text', text: id }], timestamp, source: 'transcript' }
 }
 
-type SignalProps = { messages: NativeChatMessage[]; transcriptLoading?: boolean }
+type SignalProps = {
+  messages: NativeChatMessage[]
+  transcriptLoading?: boolean
+  ownsTabWideLaunchDraft?: boolean
+}
 
 function renderSignal(messages: NativeChatMessage[], transcriptLoading = false) {
   const initialProps: SignalProps = { messages, transcriptLoading }
@@ -77,7 +81,8 @@ function renderSignal(messages: NativeChatMessage[], transcriptLoading = false) 
         terminalTabId: 'tab-1',
         agent: 'claude',
         messages: props.messages,
-        transcriptLoading: props.transcriptLoading === true
+        transcriptLoading: props.transcriptLoading === true,
+        ownsTabWideLaunchDraft: props.ownsTabWideLaunchDraft !== false
       }),
     { initialProps }
   )
@@ -186,6 +191,28 @@ describe('useNativeChatLaunchDraftSignal', () => {
     expect(result.current.launchDraft?.resolved).toBe(true)
   })
 
+  it('does not hand the tab launch draft to a split sibling pane', () => {
+    // The seed describes the tab's original pane; a pane created by splitting
+    // must not inherit it (issue #16695).
+    const { result } = renderHook(() =>
+      useNativeChatLaunchDraftSignal({
+        terminalTabId: 'tab-1',
+        agent: 'claude',
+        messages: [],
+        ownsTabWideLaunchDraft: false
+      })
+    )
+
+    expect(result.current.launchDraft).toBeNull()
+    expect(result.current.launchDraftResolved).toBe(false)
+  })
+
+  it("still hands the draft to the tab's sole owning pane", () => {
+    const { result } = renderSignal([])
+
+    expect(result.current.launchDraft?.text).toBe('https://github.com/o/r/issues/12')
+  })
+
   it('ignores a draft seeded for another agent', () => {
     mocks.storeState.nativeChatLaunchDraftByTabId = {
       'tab-1': launchDraft({ agent: 'codex', createdAt: SEEDED_AT })
@@ -264,5 +291,52 @@ describe('useNativeChatLaunchDraftAdoption', () => {
     expect(setDraft).not.toHaveBeenCalled()
     expect(mocks.markNativeChatLaunchDraftAdopted).not.toHaveBeenCalled()
     expect(mocks.clearNativeChatLaunchDraft).toHaveBeenCalledWith('tab-1')
+  })
+})
+
+describe('launch draft adoption across a split', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.storeState.nativeChatLaunchDraftByTabId = {
+      'tab-1': launchDraft({ createdAt: SEEDED_AT })
+    }
+  })
+
+  function renderPaneComposer(ownsTabWideLaunchDraft: boolean): {
+    setDraft: ReturnType<typeof vi.fn>
+  } {
+    const setDraft = vi.fn()
+    renderHook(() => {
+      const signal = useNativeChatLaunchDraftSignal({
+        terminalTabId: 'tab-1',
+        agent: 'claude',
+        messages: [],
+        transcriptLoading: false,
+        ownsTabWideLaunchDraft
+      })
+      useNativeChatLaunchDraftAdoption({
+        terminalTabId: 'tab-1',
+        agent: 'claude',
+        launchDraft: signal.launchDraft,
+        launchDraftResolved: signal.launchDraftResolved,
+        draft: '',
+        setDraft,
+        setCaret: vi.fn()
+      })
+    })
+    return { setDraft }
+  }
+
+  it("never fills a split sibling composer with the tab's stale launch draft", () => {
+    const { setDraft } = renderPaneComposer(false)
+
+    expect(setDraft).not.toHaveBeenCalled()
+    expect(mocks.markNativeChatLaunchDraftAdopted).not.toHaveBeenCalled()
+  })
+
+  it('still mirrors the launch draft into the owning pane composer', () => {
+    const { setDraft } = renderPaneComposer(true)
+
+    expect(setDraft).toHaveBeenCalledWith('https://github.com/o/r/issues/12')
   })
 })

--- a/src/renderer/src/components/native-chat/use-native-chat-launch-draft-adoption.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-launch-draft-adoption.test.tsx
@@ -29,11 +29,13 @@ vi.mock('../../store', () => {
   return { useAppStore }
 })
 
+const SEED_TEXT = 'https://github.com/o/r/issues/12'
+
 function launchDraft(overrides: Partial<NativeChatLaunchDraft> = {}): NativeChatLaunchDraft {
   return {
     tabId: 'tab-1',
     agent: 'claude',
-    text: 'https://github.com/o/r/issues/12',
+    text: SEED_TEXT,
     createdAt: 1000,
     ...overrides
   }
@@ -44,6 +46,7 @@ function setup(args: {
   launchDraftResolved?: boolean
   draft?: string
   agent?: string
+  ownsTabWideLaunchDraft?: boolean
 }): { setDraft: ReturnType<typeof vi.fn>; setCaret: ReturnType<typeof vi.fn> } {
   const setDraft = vi.fn()
   const setCaret = vi.fn()
@@ -55,7 +58,8 @@ function setup(args: {
       launchDraftResolved: args.launchDraftResolved ?? false,
       draft: args.draft ?? '',
       setDraft,
-      setCaret
+      setCaret,
+      ownsTabWideLaunchDraft: args.ownsTabWideLaunchDraft ?? true
     })
   )
   return { setDraft, setCaret }
@@ -70,7 +74,6 @@ function userTurn(id: string, timestamp: number | null): NativeChatMessage {
 type SignalProps = {
   messages: NativeChatMessage[]
   transcriptLoading?: boolean
-  ownsTabWideLaunchDraft?: boolean
 }
 
 function renderSignal(messages: NativeChatMessage[], transcriptLoading = false) {
@@ -81,8 +84,7 @@ function renderSignal(messages: NativeChatMessage[], transcriptLoading = false) 
         terminalTabId: 'tab-1',
         agent: 'claude',
         messages: props.messages,
-        transcriptLoading: props.transcriptLoading === true,
-        ownsTabWideLaunchDraft: props.ownsTabWideLaunchDraft !== false
+        transcriptLoading: props.transcriptLoading === true
       }),
     { initialProps }
   )
@@ -191,26 +193,12 @@ describe('useNativeChatLaunchDraftSignal', () => {
     expect(result.current.launchDraft?.resolved).toBe(true)
   })
 
-  it('does not hand the tab launch draft to a split sibling pane', () => {
-    // The seed describes the tab's original pane; a pane created by splitting
-    // must not inherit it (issue #16695).
-    const { result } = renderHook(() =>
-      useNativeChatLaunchDraftSignal({
-        terminalTabId: 'tab-1',
-        agent: 'claude',
-        messages: [],
-        ownsTabWideLaunchDraft: false
-      })
-    )
-
-    expect(result.current.launchDraft).toBeNull()
-    expect(result.current.launchDraftResolved).toBe(false)
-  })
-
-  it("still hands the draft to the tab's sole owning pane", () => {
+  it("selects the tab's seed for every pane so the resolution machine keeps running", () => {
+    // Pane ownership gates the composer *write*, not the signal: nulling it here
+    // would also kill the resolved/cleanup branch for a split tab.
     const { result } = renderSignal([])
 
-    expect(result.current.launchDraft?.text).toBe('https://github.com/o/r/issues/12')
+    expect(result.current.launchDraft?.text).toBe(SEED_TEXT)
   })
 
   it('ignores a draft seeded for another agent', () => {
@@ -285,6 +273,21 @@ describe('useNativeChatLaunchDraftAdoption', () => {
     expect(mocks.clearNativeChatLaunchDraft).toHaveBeenCalledWith('tab-1')
   })
 
+  it('does not mirror the seed into a pane that does not own the tab-wide evidence', () => {
+    const { setDraft } = setup({ launchDraft: launchDraft(), ownsTabWideLaunchDraft: false })
+
+    expect(setDraft).not.toHaveBeenCalled()
+    expect(mocks.markNativeChatLaunchDraftAdopted).not.toHaveBeenCalled()
+  })
+
+  it('leaves an unadopted seed alone when a non-owning pane resolves it', () => {
+    // The owner may not have mirrored it yet; a sibling's transcript is no
+    // evidence about the owner's copy.
+    setup({ launchDraft: launchDraft(), launchDraftResolved: true, ownsTabWideLaunchDraft: false })
+
+    expect(mocks.clearNativeChatLaunchDraft).not.toHaveBeenCalled()
+  })
+
   it('drops an unadopted seed once the transcript resolves it', () => {
     const { setDraft } = setup({ launchDraft: launchDraft(), launchDraftResolved: true })
 
@@ -302,41 +305,73 @@ describe('launch draft adoption across a split', () => {
     }
   })
 
-  function renderPaneComposer(ownsTabWideLaunchDraft: boolean): {
-    setDraft: ReturnType<typeof vi.fn>
-  } {
+  function renderPaneComposer(args: {
+    ownsTabWideLaunchDraft: boolean
+    draft?: string
+    messages?: NativeChatMessage[]
+  }): { setDraft: ReturnType<typeof vi.fn>; setCaret: ReturnType<typeof vi.fn> } {
     const setDraft = vi.fn()
+    const setCaret = vi.fn()
     renderHook(() => {
       const signal = useNativeChatLaunchDraftSignal({
         terminalTabId: 'tab-1',
         agent: 'claude',
-        messages: [],
-        transcriptLoading: false,
-        ownsTabWideLaunchDraft
+        messages: args.messages ?? [],
+        transcriptLoading: false
       })
       useNativeChatLaunchDraftAdoption({
         terminalTabId: 'tab-1',
         agent: 'claude',
         launchDraft: signal.launchDraft,
         launchDraftResolved: signal.launchDraftResolved,
-        draft: '',
+        draft: args.draft ?? '',
         setDraft,
-        setCaret: vi.fn()
+        setCaret,
+        ownsTabWideLaunchDraft: args.ownsTabWideLaunchDraft
       })
     })
-    return { setDraft }
+    return { setDraft, setCaret }
   }
 
-  it("never fills a split sibling composer with the tab's stale launch draft", () => {
-    const { setDraft } = renderPaneComposer(false)
+  it("never fills a non-owning pane's composer with the tab's launch draft", () => {
+    const { setDraft } = renderPaneComposer({ ownsTabWideLaunchDraft: false })
 
     expect(setDraft).not.toHaveBeenCalled()
     expect(mocks.markNativeChatLaunchDraftAdopted).not.toHaveBeenCalled()
   })
 
-  it('still mirrors the launch draft into the owning pane composer', () => {
-    const { setDraft } = renderPaneComposer(true)
+  it('never lets a non-owning pane destroy a seed nobody has adopted yet', () => {
+    const { setDraft } = renderPaneComposer({
+      ownsTabWideLaunchDraft: false,
+      messages: [userTurn('u1', null)]
+    })
 
-    expect(setDraft).toHaveBeenCalledWith('https://github.com/o/r/issues/12')
+    expect(setDraft).not.toHaveBeenCalled()
+    expect(mocks.clearNativeChatLaunchDraft).not.toHaveBeenCalled()
+  })
+
+  it('still mirrors the launch draft into the owning pane composer', () => {
+    const { setDraft } = renderPaneComposer({ ownsTabWideLaunchDraft: true })
+
+    expect(setDraft).toHaveBeenCalledWith(SEED_TEXT)
+  })
+
+  it('clears the adopted copy after a split once the transcript resolves the seed', () => {
+    // Splitting drops ownership for *both* panes, so the pane that already
+    // mirrored the seed must still clean up — otherwise the submitted prompt
+    // sits in its composer forever and a later Enter re-sends it (#16695).
+    mocks.storeState.nativeChatLaunchDraftByTabId = {
+      'tab-1': launchDraft({ adopted: true, createdAt: SEEDED_AT })
+    }
+
+    const { setDraft, setCaret } = renderPaneComposer({
+      ownsTabWideLaunchDraft: false,
+      draft: SEED_TEXT,
+      messages: [userTurn('u1', null)]
+    })
+
+    expect(setDraft).toHaveBeenCalledWith('')
+    expect(setCaret).toHaveBeenCalledWith(0)
+    expect(mocks.clearNativeChatLaunchDraft).toHaveBeenCalledWith('tab-1')
   })
 })

--- a/src/renderer/src/components/native-chat/use-native-chat-launch-draft-adoption.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-launch-draft-adoption.ts
@@ -16,8 +16,15 @@ export function useNativeChatLaunchDraftSignal(args: {
   /** The transcript read is still in flight, so `messages` is not yet the
    *  session's real history. Same gate mobile's drafts hook uses. */
   transcriptLoading?: boolean
+  /** This pane is the tab-wide draft's owner (`nativeChatLeafOwnsTabWideEvidence`).
+   *  The seed is keyed by tab, so a split sibling must not inherit it. */
+  ownsTabWideLaunchDraft: boolean
 }): { launchDraft: NativeChatLaunchDraft | null; launchDraftResolved: boolean } {
-  const launchDraft = useAppStore((s) => s.nativeChatLaunchDraftByTabId[args.terminalTabId] ?? null)
+  const launchDraft = useAppStore((s) =>
+    args.ownsTabWideLaunchDraft
+      ? (s.nativeChatLaunchDraftByTabId[args.terminalTabId] ?? null)
+      : null
+  )
   const paneLaunchDraft = launchDraft?.agent === args.agent ? launchDraft : null
   const messages = args.messages
   const transcriptLoading = args.transcriptLoading === true

--- a/src/renderer/src/components/native-chat/use-native-chat-launch-draft-adoption.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-launch-draft-adoption.ts
@@ -16,15 +16,11 @@ export function useNativeChatLaunchDraftSignal(args: {
   /** The transcript read is still in flight, so `messages` is not yet the
    *  session's real history. Same gate mobile's drafts hook uses. */
   transcriptLoading?: boolean
-  /** This pane is the tab-wide draft's owner (`nativeChatLeafOwnsTabWideEvidence`).
-   *  The seed is keyed by tab, so a split sibling must not inherit it. */
-  ownsTabWideLaunchDraft: boolean
 }): { launchDraft: NativeChatLaunchDraft | null; launchDraftResolved: boolean } {
-  const launchDraft = useAppStore((s) =>
-    args.ownsTabWideLaunchDraft
-      ? (s.nativeChatLaunchDraftByTabId[args.terminalTabId] ?? null)
-      : null
-  )
+  // Deliberately pane-agnostic: pane ownership gates the composer *write* in
+  // useNativeChatLaunchDraftAdoption. Nulling the seed here would also strand a
+  // copy an owning pane already mirrored, since the adoption effect early-returns.
+  const launchDraft = useAppStore((s) => s.nativeChatLaunchDraftByTabId[args.terminalTabId] ?? null)
   const paneLaunchDraft = launchDraft?.agent === args.agent ? launchDraft : null
   const messages = args.messages
   const transcriptLoading = args.transcriptLoading === true
@@ -73,10 +69,11 @@ export function useNativeChatLaunchDraftSignal(args: {
  * transcript shows the TUI-side copy was resolved (submitted or cleared).
  *
  * State machine per seeded draft:
- * - unadopted + composer empty  → copy text into the composer, mark adopted
- * - unadopted + composer in use → mark adopted without copying (never stomp)
- * - resolved by transcript      → clear the seed; also clear the composer copy
- *                                 only when it is still the untouched seed text
+ * - unadopted + not the owning pane → ignore (the seed is keyed by tab; #16695)
+ * - unadopted + composer empty      → copy text into the composer, mark adopted
+ * - unadopted + composer in use     → mark adopted without copying (never stomp)
+ * - resolved by transcript          → clear the composer copy while it is still
+ *                                     the untouched seed text, and drop the seed
  */
 export function useNativeChatLaunchDraftAdoption(args: {
   terminalTabId: string
@@ -86,21 +83,45 @@ export function useNativeChatLaunchDraftAdoption(args: {
   draft: string
   setDraft: (next: string) => void
   setCaret: (next: number) => void
+  /** This pane is the tab-wide evidence's owner (`nativeChatLeafOwnsTabWideEvidence`).
+   *  Splitting drops it for every pane, so it gates pickup, never cleanup. */
+  ownsTabWideLaunchDraft: boolean
 }): void {
-  const { terminalTabId, agent, launchDraft, launchDraftResolved, draft, setDraft, setCaret } = args
+  const {
+    terminalTabId,
+    agent,
+    launchDraft,
+    launchDraftResolved,
+    draft,
+    setDraft,
+    setCaret,
+    ownsTabWideLaunchDraft
+  } = args
   useEffect(() => {
     if (!launchDraft || launchDraft.agent !== agent) {
       return
     }
     if (launchDraftResolved) {
-      if (launchDraft.adopted && draft === launchDraft.text) {
+      // Cleanup must survive a split: ownership is gone for both panes by then,
+      // so the pane still holding the untouched copy is the one that cleans up.
+      const holdsUntouchedCopy = launchDraft.adopted && draft === launchDraft.text
+      if (holdsUntouchedCopy) {
         setDraft('')
         setCaret(0)
       }
-      useAppStore.getState().clearNativeChatLaunchDraft(terminalTabId)
+      // A pane that neither owns the seed nor holds its copy has no standing to
+      // drop it — the owning pane may not have mirrored it yet.
+      if (ownsTabWideLaunchDraft || holdsUntouchedCopy) {
+        useAppStore.getState().clearNativeChatLaunchDraft(terminalTabId)
+      }
       return
     }
     if (launchDraft.adopted) {
+      return
+    }
+    // #16695: the seed describes the tab's original sole pane, so once a split
+    // exists no pane may mirror it into a composer.
+    if (!ownsTabWideLaunchDraft) {
       return
     }
     // Mark adopted before copying so a composer that already holds user text
@@ -110,5 +131,14 @@ export function useNativeChatLaunchDraftAdoption(args: {
       setDraft(launchDraft.text)
       setCaret(launchDraft.text.length)
     }
-  }, [agent, draft, launchDraft, launchDraftResolved, setCaret, setDraft, terminalTabId])
+  }, [
+    agent,
+    draft,
+    launchDraft,
+    launchDraftResolved,
+    ownsTabWideLaunchDraft,
+    setCaret,
+    setDraft,
+    terminalTabId
+  ])
 }

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -116,6 +116,7 @@ import { shouldChatTakeOverMobileSurface } from '../native-chat/native-chat-send
 import { canToggleNativeChat } from '../native-chat/native-chat-availability'
 import {
   nativeChatLaunchAgentForLeaf,
+  nativeChatLeafOwnsTabWideEvidence,
   resolveNativeChatLeafRoute,
   type NativeChatLeafRoute
 } from '../native-chat/native-chat-leaf-routing'
@@ -2983,6 +2984,13 @@ function TerminalPane(
   })
   const structuredChatAgent = structuredSessionAgent ?? chatPaneResolvedAgent ?? chatPaneLaunchAgent
   const structuredChatTarget = useMemo(() => ({ kind: 'local' as const }), [])
+  // The launch draft is keyed by tab, so gate it on the same pane ownership the
+  // launch agent uses: a split sibling must not inherit the seeded text.
+  const chatPaneOwnsTabWideLaunchDraft = nativeChatLeafOwnsTabWideEvidence({
+    ownerLeafId: getTabWideAgentHintLeafId(),
+    leafId: chatPane?.leafId ?? null,
+    leafIds: getNativeChatLeafIds()
+  })
   // A split can host different agents, so continuation resolves the specific leaf before using tab-wide hints.
   const resolveAgentForLeaf = (leafId: string | null): string | null => {
     const detectedAgent = leafId ? (tabAgentTypeByLeaf[leafId] ?? null) : null
@@ -3155,6 +3163,7 @@ function TerminalPane(
                   targetPtyId={chatPanePtyId}
                   launchAgent={chatPaneLaunchAgent}
                   resolvedAgent={chatPaneResolvedAgent}
+                  ownsTabWideLaunchDraft={chatPaneOwnsTabWideLaunchDraft}
                   onSwitchToTerminal={switchNativeChatToTerminal}
                   readTerminalScreen={readNativeChatTerminalScreen}
                   contextMenuActions={{


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​148 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​145 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​101 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 |

<!-- /orca-pr-loc -->

## ELI5

When Orca starts an agent with a prompt it does not send (an issue link, a brief), it mirrors that unsent text into the GUI chat composer so the context is visible. That mirror was stored per **tab**, not per **pane**, so *any* pane of the tab could claim it. Split a pane in that tab — even a day later — open chat in the new pane, and yesterday's unsent prompt appeared in its empty composer, ready to be submitted by an Enter or `orca terminal send --enter`. Now only the pane the draft was seeded for can adopt it; a split sibling always starts empty.

## Root cause

`src/renderer/src/components/native-chat/use-native-chat-launch-draft-adoption.ts`

```ts
const launchDraft = useAppStore((s) => s.nativeChatLaunchDraftByTabId[args.terminalTabId] ?? null)
```

The only additional filter was `launchDraft?.agent === args.agent`. There is no pane/leaf gate, so every pane of the tab that resolves to the same agent sees the same draft, and `useNativeChatLaunchDraftAdoption` writes it into whichever composer mounted with an empty draft.

The asymmetry was local and explicit: in the same render tree `TerminalPane.tsx:2976` gates the tab's *launch agent* through `nativeChatLaunchAgentForLeaf`, which refuses tab-wide evidence as soon as `leafIds.length !== 1`, and the mobile publisher `buildMobileLaunchDraftsByPaneKey` (`src/renderer/src/runtime/sync-runtime-graph.ts:1900`) runs the *same store draft* through that identical predicate before emitting `launchDraftByPaneKey`. Only the desktop composer's draft signal skipped it.

Fix: extract that ownership rule as `nativeChatLeafOwnsTabWideEvidence` in `native-chat-leaf-routing.ts` (now also the body of `nativeChatLaunchAgentForLeaf`, so desktop and mobile share one predicate), compute it for the chat pane in `TerminalPane`, and apply it to the composer **write**.

### Where the gate goes, and why not in the signal

The first revision of this PR gated the *signal*: `useNativeChatLaunchDraftSignal` returned `null` for a non-owning pane. That was wrong. `useNativeChatLaunchDraftAdoption` early-returns on `!launchDraft`, so nulling the signal did not merely block the pickup branch — it disabled the whole per-draft state machine for every pane of a split tab, including the resolution branch that calls `setDraft('')` and `clearNativeChatLaunchDraft`.

Splitting flips `ownsTabWideLaunchDraft` to `false` for **both** panes (the predicate requires `leafIds.length === 1`), so the pane that had *already* mirrored the seed lost its cleanup path too: launch with a seeded prompt, open chat so the owning pane adopts it, split the tab, submit from the TUI — and the seeded text stayed in the original pane's composer permanently (`useNativeChatDraft(paneKey)` is pane-scoped and survives TUI/GUI toggles), where a later Enter re-submits an already-submitted prompt. That is #16695's own harm class, reintroduced in the original pane.

The gate now sits on the only branch that writes text into a composer:

```ts
if (launchDraftResolved) {
  const holdsUntouchedCopy = launchDraft.adopted && draft === launchDraft.text
  if (holdsUntouchedCopy) { setDraft(''); setCaret(0) }
  if (ownsTabWideLaunchDraft || holdsUntouchedCopy) {
    useAppStore.getState().clearNativeChatLaunchDraft(terminalTabId)
  }
  return
}
if (launchDraft.adopted) return
if (!ownsTabWideLaunchDraft) return   // #16695: never mirror into a split tab's pane
```

Cleanup is keyed on *holding the copy* rather than on ownership, because ownership is gone for every pane once the tab is split. The `clearNativeChatLaunchDraft` guard is the mirror-image protection: a pane that neither owns the seed nor holds its copy must not drop it, or a sibling's transcript could destroy a seed the owner has not adopted yet.

The composer's three launch-draft props are folded into one `launchSeed` object (`NativeChatLaunchSeed`) — they are one unit produced by one hook, and `NativeChatView` already passed them as a group.

## Proof

Test file: `src/renderer/src/components/native-chat/use-native-chat-launch-draft-adoption.test.tsx`
Command: `npx vitest run --config config/vitest.config.ts src/renderer/src/components/native-chat/use-native-chat-launch-draft-adoption.test.tsx`

BEFORE the fix (tests written first, run against `ad4e8bd`'s source): 12 of 23 fail. Most fail because the ownership flag moved from the signal hook to the adoption hook, but the load-bearing one is the regression itself — an adopted seed on a split tab, resolved by the transcript, is never cleaned up:

```
 FAIL  src/renderer/src/components/native-chat/use-native-chat-launch-draft-adoption.test.tsx > launch draft adoption across a split > clears the adopted copy after a split once the transcript resolves the seed
AssertionError: expected "vi.fn()" to be called with arguments: [ '' ]

Number of calls: 0

 ❯ src/renderer/src/components/native-chat/use-native-chat-launch-draft-adoption.test.tsx:373:22
    371|     })
    372|
    373|     expect(setDraft).toHaveBeenCalledWith('')
       |                      ^
    374|     expect(setCaret).toHaveBeenCalledWith(0)
    375|     expect(mocks.clearNativeChatLaunchDraft).toHaveBeenCalledWith('tab…

 Test Files  1 failed (1)
      Tests  12 failed | 11 passed (23)
```

AFTER the fix:

```
 Test Files  1 passed (1)
      Tests  23 passed (23)
   Duration  569ms
```

Wider runs, all green:

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/native-chat/
 Test Files  74 passed (74)
      Tests  796 passed (796)
   Duration  3.86s

$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/
 Test Files  397 passed (397)
      Tests  3831 passed (3831)
   Duration  17.21s
```

`oxlint` and `oxfmt --check` are clean over both directories. `pnpm run tc:web` reports one pre-existing error unrelated to this change (`useSessionRestoredBannerDismiss.test.tsx(26,3)`, a `querySelector` cast in an untouched file).

Regression guards now live in the composed signal-plus-adoption suite, so they assert composer behavior rather than signal shape. The two earlier tests that asserted a sibling's `launchDraft` is `null` were rewritten, since the signal is deliberately pane-agnostic now:

- `never fills a non-owning pane's composer with the tab's launch draft` — #16695's original protection.
- `never lets a non-owning pane destroy a seed nobody has adopted yet`.
- `still mirrors the launch draft into the owning pane composer`.
- `clears the adopted copy after a split once the transcript resolves the seed` — the regression above.
- Plus two unit-level cases on the adoption hook (`does not mirror the seed into a pane that does not own the tab-wide evidence`, `leaves an unadopted seed alone when a non-owning pane resolves it`) and the pure-predicate test in `native-chat-leaf-routing.test.ts`.

## Risk

Low. Renderer-only; the gate reuses the predicate that already governs the launch agent on the very same pane. `nativeChatLaunchAgentForLeaf` was refactored to call the extracted predicate with identical semantics (`!launchAgent` short-circuit first, then the same `leafIds.length === 1 && leafIds[0] === leafId && ownerLeafId === leafId`), and its existing tests pass unchanged. `NativeChatComposer`'s `launchDraft` / `launchDraftResolved` props became one optional `launchSeed` prop; the component has a single production call site and no test passes those props. No persisted state, no store shape change, no IPC/RPC or remote-wire field, no mobile publisher behavior change, no platform-specific code.

## User-facing regressions

- **Mirroring into the original pane (#11253): unchanged.** The sole-leaf owner still adopts the launch draft; covered by two tests.
- **While a tab is split, no pane adopts the launch draft** — including the original pane. This is deliberate and matches mobile: after a split the text is only in the TUI input buffer, where the user put it. The unsent context is not lost, just not duplicated into a GUI composer that cannot prove it owns it.
- **Closing the sibling restores adoption in the original pane.** Ownership is `nativeChatLeafOwnsTabWideEvidence({ ownerLeafId: getTabWideAgentHintLeafId(), leafId, leafIds: getNativeChatLeafIds() })`. `tabWideAgentHintLeafId` binds once, but `getNativeChatLeafIds()` is recomputed on every call — it unions the live pane list with `expectedLayoutLeafIds`, which is derived from the tab's layout root and *shrinks* when a pane closes. So after split-then-close-sibling, `leafIds.length` returns to `1` and matches the bound owner leaf, and the original pane adopts the seed again — unless the transcript has already resolved it, in which case the resolved branch runs first and drops the seed instead of re-offering it. An earlier revision of this description claimed adoption was lost permanently once a tab had been split; that was wrong.
- **Composer cleanup now survives a split.** The pane still holding the untouched adopted copy clears its own composer and retires the seed when the transcript resolves it, whether or not it currently owns the tab-wide evidence. The complementary guard is that a pane holding no copy and owning nothing will not call `clearNativeChatLaunchDraft`, so a split sibling cannot delete a seed the owner has yet to adopt.
- **The seed can now outlive adoption on a split tab**, staying in the in-memory `nativeChatLaunchDraftByTabId` until ownership returns, the transcript resolves it in the pane holding the copy, or the tab closes. It is inert in that state: the pickup branch refuses it and the cleanup branch is its only other consumer. No growth beyond one entry per tab.
- **Not addressed here (checked, left alone):** `nativeChatLaunchPromptByTabId` — the *submitted* launch prompt rendered as a transcript bubble — is still tab-keyed and can render in a split sibling's chat view. It is display-only, cannot be submitted by an Enter, and untangling it from `shouldPruneLaunchPrompt` is a separate change.

## Why `Refs`, not `Fixes`

This lands the pane gate the reported scenario needs, but it must not auto-close #16695. The reporter says **Ctrl-U cleared the text**. Per the #16290 discriminator, Ctrl-U is a PTY-side line kill: text that Ctrl-U erases was living in the agent TUI's input buffer, not in Orca's GUI composer (a React textarea, which does not respond to Ctrl-U that way). So the occurrence actually reported was PTY-side, and this renderer-layer change cannot be shown to fix it. Leaving the issue open keeps that unexplained PTY-side path visible.

Refs #16695
