### PR TITLE
Add copy buttons to check run details sections

### DIFF
--- a/src/renderer/src/components/editor/CheckRunAnnotations.tsx
+++ b/src/renderer/src/components/editor/CheckRunAnnotations.tsx
@@ -7,6 +7,8 @@ import {
   getOpenableAnnotationLine,
   openAnnotationLocation
 } from './check-annotation-open'
+import { formatAnnotationsForClipboard } from './check-run-clipboard-text'
+import { CheckRunCopyButton } from './CheckRunCopyButton'
 
 export function CheckRunAnnotations({
   annotations,
@@ -34,18 +36,29 @@ export function CheckRunAnnotations({
     [worktreeId]
   )
 
+  const annotationFallback = translate(
+    'auto.components.editor.CheckRunDetailsPanel.cdbfda4dec',
+    'Annotation'
+  )
+  const clipboardText = formatAnnotationsForClipboard(annotations, annotationFallback)
+
   return (
     <section className="rounded-md border border-border bg-background">
-      <div className="border-b border-border px-3 py-2 text-sm font-medium">
-        {translate('auto.components.editor.CheckRunDetailsPanel.f2fe8a4e8f', 'Annotations')}
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <div className="text-sm font-medium">
+          {translate('auto.components.editor.CheckRunDetailsPanel.f2fe8a4e8f', 'Annotations')}
+        </div>
+        <CheckRunCopyButton
+          text={clipboardText}
+          label={translate('auto.components.editor.CheckRunAnnotations.copy', 'Copy annotations')}
+        />
       </div>
       <div className="divide-y divide-border/50">
         {annotations.map((annotation, index) => {
           const openable = worktreeId ? getOpenableAnnotationLine(annotation) : null
-          const locationLabel = `${
-            annotation.path ??
-            translate('auto.components.editor.CheckRunDetailsPanel.cdbfda4dec', 'Annotation')
-          }${annotation.startLine ? `:${annotation.startLine}` : ''}`
+          const locationLabel = `${annotation.path ?? annotationFallback}${
+            annotation.startLine ? `:${annotation.startLine}` : ''
+          }`
           return (
             <div key={`${annotation.path ?? 'annotation'}-${index}`} className="px-3 py-3">
               <div className="flex min-w-0 flex-wrap items-center gap-2">

--- a/src/renderer/src/components/editor/CheckRunCopyButton.test.tsx
+++ b/src/renderer/src/components/editor/CheckRunCopyButton.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { CheckRunCopyButton } from './CheckRunCopyButton'
+
+const writeClipboardText = vi.fn<(text: string) => Promise<void>>()
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+afterEach(cleanup)
+
+beforeEach(() => {
+  writeClipboardText.mockReset().mockResolvedValue(undefined)
+  Object.assign(window, { api: { ui: { writeClipboardText } } })
+})
+
+function renderCopyButton(text: string): void {
+  render(
+    <TooltipProvider>
+      <CheckRunCopyButton text={text} label="Copy annotations" />
+    </TooltipProvider>
+  )
+}
+
+describe('CheckRunCopyButton', () => {
+  it('copies the card text and shows copied feedback', async () => {
+    renderCopyButton('src/main.ts:10\nBuild failed')
+
+    const copyButton = screen.getByRole('button', { name: 'Copy annotations' })
+    fireEvent.click(copyButton)
+
+    await waitFor(() =>
+      expect(writeClipboardText).toHaveBeenCalledWith('src/main.ts:10\nBuild failed')
+    )
+    expect(await screen.findByRole('button', { name: 'Copied' })).toBeDefined()
+  })
+
+  it('disables the action when there is no card text', () => {
+    renderCopyButton('')
+
+    const copyButton = screen.getByRole('button', { name: 'Nothing to copy' })
+    expect((copyButton as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.click(copyButton)
+    expect(writeClipboardText).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/editor/CheckRunCopyButton.tsx
+++ b/src/renderer/src/components/editor/CheckRunCopyButton.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Check, Copy } from 'lucide-react'
+import { useClipboardTextCopyFeedback } from '@/hooks/use-clipboard-text-copy-feedback'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+export function CheckRunCopyButton({
+  text,
+  label
+}: {
+  text: string
+  label: string
+}): React.JSX.Element {
+  const { canCopy, copyText, status } = useClipboardTextCopyFeedback(text)
+  const accessibleLabel =
+    status === 'copied'
+      ? translate('auto.components.editor.CheckRunCopyButton.copied', 'Copied')
+      : status === 'failed'
+        ? translate('auto.components.editor.CheckRunCopyButton.failed', "Couldn't copy")
+        : canCopy
+          ? label
+          : translate('auto.components.editor.CheckRunCopyButton.empty', 'Nothing to copy')
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label={accessibleLabel}
+          disabled={!canCopy}
+          onClick={() => void copyText()}
+          className={cn(
+            'text-muted-foreground',
+            status === 'copied' && 'text-status-success',
+            status === 'failed' && 'text-destructive'
+          )}
+        >
+          {status === 'copied' ? <Check /> : <Copy />}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        {accessibleLabel}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/editor/CheckRunDetailsPanel.tsx
+++ b/src/renderer/src/components/editor/CheckRunDetailsPanel.tsx
@@ -7,8 +7,10 @@ import type { PRCheckDetail, PRCheckRunDetails } from '../../../../shared/github
 import { SourceControlFixSplitButton } from '@/components/right-sidebar/source-control-fix-split-button'
 import { translate } from '@/i18n/i18n'
 import { useCheckRunDetailsFixWithAI } from './check-run-details-fix-with-ai'
+import { formatCheckRunOutputForClipboard } from './check-run-clipboard-text'
 import { CheckRunAnnotations } from './CheckRunAnnotations'
 import { CheckRunJobs } from './CheckRunJobs'
+import { CheckRunCopyButton } from './CheckRunCopyButton'
 
 function formatCheckTimestamp(value: string | null | undefined): string | null {
   if (!value) {
@@ -124,6 +126,7 @@ export function CheckRunDetailsPanel({
   const hasOutput = Boolean(details?.title || details?.summary || details?.text)
   const hasAnnotations = (details?.annotations.length ?? 0) > 0
   const hasJobs = jobs.length > 0
+  const outputClipboardText = details ? formatCheckRunOutputForClipboard(details) : ''
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-editor-surface">
@@ -268,8 +271,17 @@ export function CheckRunDetailsPanel({
 
             {hasOutput && (
               <section className="rounded-md border border-border bg-background">
-                <div className="border-b border-border px-3 py-2 text-sm font-medium">
-                  {translate('auto.components.editor.CheckRunDetailsPanel.d098e5529a', 'Output')}
+                <div className="flex items-center justify-between border-b border-border px-3 py-2">
+                  <div className="text-sm font-medium">
+                    {translate('auto.components.editor.CheckRunDetailsPanel.d098e5529a', 'Output')}
+                  </div>
+                  <CheckRunCopyButton
+                    text={outputClipboardText}
+                    label={translate(
+                      'auto.components.editor.CheckRunDetailsPanel.copyOutput',
+                      'Copy output'
+                    )}
+                  />
                 </div>
                 <div className="px-3 py-3">
                   {details?.title && (

--- a/src/renderer/src/components/editor/CheckRunJobs.tsx
+++ b/src/renderer/src/components/editor/CheckRunJobs.tsx
@@ -5,6 +5,8 @@ import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 import type { PRCheckJob, PRCheckStep } from '../../../../shared/github/check-types'
 import { resolveStepOutcome, summarizeJobSteps, type StepOutcome } from './check-job-step-status'
+import { formatJobsForClipboard } from './check-run-clipboard-text'
+import { CheckRunCopyButton } from './CheckRunCopyButton'
 
 function StepOutcomeIcon({ outcome }: { outcome: StepOutcome }): React.JSX.Element {
   switch (outcome) {
@@ -149,12 +151,23 @@ export function CheckRunJobs({
   jobs: PRCheckJob[]
   hasFailedJobs: boolean
 }): React.JSX.Element {
+  const clipboardText = formatJobsForClipboard(
+    jobs,
+    translate('auto.components.editor.CheckRunDetailsPanel.ee07b33924', 'unknown')
+  )
+
   return (
     <section className="rounded-md border border-border bg-background">
-      <div className="border-b border-border px-3 py-2 text-sm font-medium">
-        {hasFailedJobs
-          ? translate('auto.components.editor.CheckRunDetailsPanel.066fedd446', 'Failed jobs')
-          : translate('auto.components.editor.CheckRunDetailsPanel.49731703ea', 'Jobs')}
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <div className="text-sm font-medium">
+          {hasFailedJobs
+            ? translate('auto.components.editor.CheckRunDetailsPanel.066fedd446', 'Failed jobs')
+            : translate('auto.components.editor.CheckRunDetailsPanel.49731703ea', 'Jobs')}
+        </div>
+        <CheckRunCopyButton
+          text={clipboardText}
+          label={translate('auto.components.editor.CheckRunJobs.copy', 'Copy jobs')}
+        />
       </div>
       <div className="divide-y divide-border/50">
         {jobs.map((job, index) => (

--- a/src/renderer/src/components/editor/check-run-clipboard-text.test.ts
+++ b/src/renderer/src/components/editor/check-run-clipboard-text.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import type { PRCheckAnnotation, PRCheckJob } from '../../../../shared/github/check-types'
+import {
+  formatAnnotationsForClipboard,
+  formatCheckRunOutputForClipboard,
+  formatJobsForClipboard
+} from './check-run-clipboard-text'
+
+describe('check run clipboard text', () => {
+  it('formats all output sections in display order', () => {
+    expect(
+      formatCheckRunOutputForClipboard({
+        title: 'Build failed',
+        summary: 'One test failed.',
+        text: 'Run the suite locally.'
+      })
+    ).toBe('Build failed\n\nOne test failed.\n\nRun the suite locally.')
+
+    expect(
+      formatCheckRunOutputForClipboard({ title: null, summary: 'Summary only', text: null })
+    ).toBe('Summary only')
+  })
+
+  it('formats annotations with localized missing-path labels and separators', () => {
+    const annotations: PRCheckAnnotation[] = [
+      {
+        path: 'src/main.ts',
+        startLine: 10,
+        endLine: 10,
+        annotationLevel: 'failure',
+        title: 'Type error',
+        message: 'Expected string',
+        rawDetails: 'Actual: number'
+      },
+      {
+        path: null,
+        startLine: null,
+        endLine: null,
+        annotationLevel: null,
+        title: null,
+        message: 'Workflow failed',
+        rawDetails: null
+      }
+    ]
+
+    expect(formatAnnotationsForClipboard(annotations, 'Anotacion')).toBe(
+      'src/main.ts:10\nfailure\nType error\nExpected string\nActual: number\n\nAnotacion\nWorkflow failed'
+    )
+  })
+
+  it('formats jobs with localized unknown states and log excerpts', () => {
+    const jobs: PRCheckJob[] = [
+      {
+        id: 1,
+        name: 'unit',
+        status: null,
+        conclusion: 'failure',
+        startedAt: null,
+        completedAt: null,
+        url: null,
+        logTail: 'AssertionError: expected true',
+        steps: [
+          {
+            name: 'test',
+            status: null,
+            conclusion: null,
+            startedAt: null,
+            completedAt: null
+          }
+        ]
+      },
+      {
+        id: 2,
+        name: 'deploy',
+        status: null,
+        conclusion: null,
+        startedAt: null,
+        completedAt: null,
+        url: null,
+        logTail: null,
+        steps: []
+      }
+    ]
+
+    expect(formatJobsForClipboard(jobs, 'desconocido')).toBe(
+      'unit: failure\ntest: desconocido\nAssertionError: expected true\n\ndeploy: desconocido'
+    )
+  })
+})

--- a/src/renderer/src/components/editor/check-run-clipboard-text.ts
+++ b/src/renderer/src/components/editor/check-run-clipboard-text.ts
@@ -1,0 +1,48 @@
+import type {
+  PRCheckAnnotation,
+  PRCheckJob,
+  PRCheckRunDetails
+} from '../../../../shared/github/check-types'
+
+export function formatCheckRunOutputForClipboard(
+  details: Pick<PRCheckRunDetails, 'title' | 'summary' | 'text'>
+): string {
+  return [details.title, details.summary, details.text]
+    .filter((value): value is string => Boolean(value))
+    .join('\n\n')
+}
+
+export function formatAnnotationsForClipboard(
+  annotations: PRCheckAnnotation[],
+  annotationFallback: string
+): string {
+  return annotations
+    .map((annotation) => {
+      const location = `${annotation.path ?? annotationFallback}${
+        annotation.startLine ? `:${annotation.startLine}` : ''
+      }`
+      return [
+        location,
+        annotation.annotationLevel,
+        annotation.title,
+        annotation.message,
+        annotation.rawDetails
+      ]
+        .filter((value): value is string => Boolean(value))
+        .join('\n')
+    })
+    .join('\n\n')
+}
+
+export function formatJobsForClipboard(jobs: PRCheckJob[], unknownLabel: string): string {
+  return jobs
+    .map((job) => {
+      const steps = job.steps.map(
+        (step) => `${step.name}: ${step.conclusion ?? step.status ?? unknownLabel}`
+      )
+      return [`${job.name}: ${job.conclusion ?? job.status ?? unknownLabel}`, ...steps, job.logTail]
+        .filter((value): value is string => Boolean(value))
+        .join('\n')
+    })
+    .join('\n\n')
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14676,14 +14676,16 @@
           "d5a8c2f1b9": "Start the default AI agent to fix this check",
           "e2b4d7c8a1": "Choose an agent for this check",
           "f1c9e3a6d4": "Choose agent to fix check",
-          "actionRequired": "Action required"
+          "actionRequired": "Action required",
+          "copyOutput": "Copy output"
         },
         "CheckRunJobs": {
           "1c0a4d7e02": "succeeded",
           "2d3b8f1a55": "skipped",
           "3e6c9a2b71": "pending",
           "4f7d0c3e88": "steps failed",
-          "5a8e1d4f23": " · "
+          "5a8e1d4f23": " · ",
+          "copy": "Copy jobs"
         },
         "check": {
           "run": {
@@ -14763,6 +14765,14 @@
           "insertColumnRight": "Insert column right",
           "deleteRow": "Delete row",
           "deleteColumn": "Delete column"
+        },
+        "CheckRunAnnotations": {
+          "copy": "Copy annotations"
+        },
+        "CheckRunCopyButton": {
+          "copied": "Copied",
+          "failed": "Couldn't copy",
+          "empty": "Nothing to copy"
         }
       },
       "diff": {


### PR DESCRIPTION
## Problem

Users need to frequently share check run details (build errors, test failures, job logs) in chats, docs, or issue discussions. Currently they must manually select and copy text, which is tedious and loses formatting.

## Solution

Added copy-to-clipboard buttons in the Annotations, Output, and Jobs sections of check run details panels. Each button formats the relevant data consistently and provides instant visual feedback when copied.

## What Changed

- Added `CheckRunCopyButton` component with clipboard feedback UI (shows "Copied" confirmation, disables when empty)
- Created `check-run-clipboard-text` formatting utilities to prepare structured data for clipboard:
  - Output: title, summary, text sections joined with blank lines
  - Annotations: file paths, line numbers, messages, and raw details
  - Jobs: job names, conclusions, step statuses, and log excerpts
- Integrated copy buttons into `CheckRunAnnotations`, `CheckRunDetailsPanel`, and `CheckRunJobs`
- Added comprehensive unit tests and i18n strings

## Testing

- Unit tests verify clipboard formatting for each check run data type
- Component tests verify copy button state, feedback, and disabled states
- Formatting utilities tested with real GitHub check run data structures

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Automated tests added/updated
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (N/A — UI-only change)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass