### PR TITLE
fix(remote): focus host-delegated split panes

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -15944,6 +15944,92 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('returns the exact pre-minted leaf for concurrent renderer-backed splits', async () => {
+    const tabId = 'tab-concurrent-splits'
+    const sourceLeafId = '11111111-1111-4111-8111-111111111111'
+    const splitTerminal = vi.fn()
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setNotifier({ splitTerminal } as never)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId,
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'shell',
+          activeLeafId: sourceLeafId,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId,
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: sourceLeafId,
+          paneRuntimeId: 1,
+          ptyId: 'pty-source',
+          paneTitle: null
+        }
+      ]
+    })
+    const sourceHandle = runtime.getTerminalHandleForPaneKey(makePaneKey(tabId, sourceLeafId))
+    expect(sourceHandle).not.toBeNull()
+
+    const horizontal = runtime.splitTerminal(sourceHandle!, { direction: 'horizontal' })
+    const vertical = runtime.splitTerminal(sourceHandle!, { direction: 'vertical' })
+    await vi.waitFor(() => expect(splitTerminal).toHaveBeenCalledTimes(2))
+    const horizontalLeafId = splitTerminal.mock.calls.find(
+      (call) => call[2]?.direction === 'horizontal'
+    )?.[2]?.newLeafId
+    const verticalLeafId = splitTerminal.mock.calls.find(
+      (call) => call[2]?.direction === 'vertical'
+    )?.[2]?.newLeafId
+    expect(horizontalLeafId).toEqual(expect.any(String))
+    expect(verticalLeafId).toEqual(expect.any(String))
+    expect(horizontalLeafId).not.toBe(verticalLeafId)
+
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId,
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'shell',
+          activeLeafId: verticalLeafId,
+          layout: null
+        }
+      ],
+      // Reverse publication order so a first-new-leaf heuristic would swap the receipts.
+      leaves: [
+        {
+          tabId,
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: verticalLeafId!,
+          paneRuntimeId: 3,
+          ptyId: 'pty-vertical',
+          paneTitle: null
+        },
+        {
+          tabId,
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: horizontalLeafId!,
+          paneRuntimeId: 2,
+          ptyId: 'pty-horizontal',
+          paneTitle: null
+        },
+        {
+          tabId,
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: sourceLeafId,
+          paneRuntimeId: 1,
+          ptyId: 'pty-source',
+          paneTitle: null
+        }
+      ]
+    })
+
+    await expect(horizontal).resolves.toMatchObject({ leafId: horizontalLeafId })
+    await expect(vertical).resolves.toMatchObject({ leafId: verticalLeafId })
+  })
+
   it('splits visible pty-backed terminal sessions through the parent renderer tab', async () => {
     const spawn = vi
       .fn()
@@ -15980,7 +16066,8 @@ describe('OrcaRuntimeService', () => {
       (spawn.mock.calls[0]?.[0] as { env?: Record<string, string> } | undefined)?.env ?? {}
     const sourceLeafId = sourceEnv.ORCA_PANE_KEY.slice(`${sourceEnv.ORCA_TAB_ID}:`.length)
 
-    await expect(runtime.splitTerminal(handle, { direction: 'vertical' })).resolves.toMatchObject({
+    const split = await runtime.splitTerminal(handle, { direction: 'vertical' })
+    expect(split).toMatchObject({
       handle: expect.stringMatching(/^term_/),
       tabId: sourceEnv.ORCA_TAB_ID,
       paneRuntimeId: -1
@@ -15989,6 +16076,7 @@ describe('OrcaRuntimeService', () => {
     const splitEnv =
       (spawn.mock.calls[1]?.[0] as { env?: Record<string, string> } | undefined)?.env ?? {}
     const splitLeafId = splitEnv.ORCA_PANE_KEY.slice(`${sourceEnv.ORCA_TAB_ID}:`.length)
+    expect(split.leafId).toBe(splitLeafId)
     expect(splitTerminal).not.toHaveBeenCalled()
     expect(splitEnv.ORCA_TAB_ID).toBe(sourceEnv.ORCA_TAB_ID)
     expect(splitEnv.ORCA_WORKTREE_ID).toBe(TEST_WORKTREE_ID)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2406,6 +2406,7 @@ type RuntimeNotifier = {
       direction: 'horizontal' | 'vertical'
       command?: string
       telemetrySource?: TerminalPaneSplitSource
+      newLeafId?: string
     }
   ): void
   renameTerminal(tabId: string, title: string | null): void
@@ -32255,22 +32256,22 @@ export class OrcaRuntimeService {
     const { leaf } = this.getLiveLeafForHandle(handle)
     const direction = opts.direction ?? 'horizontal'
 
-    // Snapshot current leaf keys so the post-split graph-sync delta reveals the new pane.
-    const leafKeysBefore = new Set<string>()
-    for (const [key, l] of this.leaves) {
-      if (l.tabId === leaf.tabId) {
-        leafKeysBefore.add(key)
-      }
-    }
+    const newLeafId = randomUUID()
 
     this.notifier?.splitTerminal(leaf.tabId, leaf.paneRuntimeId, {
       direction,
       command: opts.command,
-      telemetrySource: opts.telemetrySource
+      telemetrySource: opts.telemetrySource,
+      newLeafId
     })
 
-    const newHandle = await this.waitForNewLeafInTab(leaf.tabId, leafKeysBefore)
-    return { handle: newHandle, tabId: leaf.tabId, paneRuntimeId: leaf.paneRuntimeId }
+    const newHandle = await this.waitForLeafInTab(leaf.tabId, newLeafId)
+    return {
+      handle: newHandle,
+      tabId: leaf.tabId,
+      paneRuntimeId: leaf.paneRuntimeId,
+      leafId: newLeafId
+    }
   }
 
   private async splitPtyBackedTerminal(
@@ -32460,7 +32461,12 @@ export class OrcaRuntimeService {
       void revealSplit().catch(() => undefined)
     }
 
-    return { handle: this.issuePtyHandle(createdPty ?? pty), tabId: parentTabId, paneRuntimeId: -1 }
+    return {
+      handle: this.issuePtyHandle(createdPty ?? pty),
+      tabId: parentTabId,
+      paneRuntimeId: -1,
+      leafId
+    }
   }
 
   private resolveTerminalSplitSourceAuthority(
@@ -32591,18 +32597,10 @@ export class OrcaRuntimeService {
     this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
   }
 
-  private waitForNewLeafInTab(
-    tabId: string,
-    existingLeafKeys: Set<string>,
-    timeoutMs = 10_000
-  ): Promise<string> {
+  private waitForLeafInTab(tabId: string, leafId: string, timeoutMs = 10_000): Promise<string> {
     const tryResolve = (): string | null => {
-      for (const [key, leaf] of this.leaves) {
-        if (leaf.tabId === tabId && !existingLeafKeys.has(key) && leaf.ptyId !== null) {
-          return this.issueHandle(leaf)
-        }
-      }
-      return null
+      const leaf = this.leaves.get(this.getLeafKey(tabId, leafId))
+      return leaf?.ptyId !== null && leaf?.ptyId !== undefined ? this.issueHandle(leaf) : null
     }
 
     const existing = tryResolve()

--- a/src/main/window/runtime-window-lifecycle.ts
+++ b/src/main/window/runtime-window-lifecycle.ts
@@ -155,7 +155,8 @@ export function registerRuntimeWindowLifecycle(
         paneRuntimeId,
         direction: opts.direction,
         command: opts.command,
-        telemetrySource: opts.telemetrySource
+        telemetrySource: opts.telemetrySource,
+        newLeafId: opts.newLeafId
       })
     },
     renameTerminal: (tabId, title) => send('ui:renameTerminal', { tabId, title }),

--- a/src/preload/api/ui-command-event-api.ts
+++ b/src/preload/api/ui-command-event-api.ts
@@ -170,6 +170,7 @@ export type UiCommandEventApi = {
       direction: 'horizontal' | 'vertical'
       command?: string
       telemetrySource?: TerminalPaneSplitSource
+      newLeafId?: string
     }) => void
   ) => () => void
   onRenameTerminal: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4249,6 +4249,7 @@ const api = {
         direction: 'horizontal' | 'vertical'
         command?: string
         telemetrySource?: TerminalPaneSplitSource
+        newLeafId?: string
       }) => void
     ): (() => void) => {
       const listener = (
@@ -4259,6 +4260,7 @@ const api = {
           direction: 'horizontal' | 'vertical'
           command?: string
           telemetrySource?: TerminalPaneSplitSource
+          newLeafId?: string
         }
       ) => callback(data)
       ipcRenderer.on('ui:splitTerminal', listener)

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -2868,6 +2868,8 @@ function TerminalPane(
         return
       }
       splitTerminalPaneWithInheritedCwd({
+        worktreeId,
+        tabId,
         manager,
         getManager: () => managerRef.current,
         paneTransports: paneTransportsRef.current,

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -2880,7 +2880,7 @@ function TerminalPane(
         source: 'context_menu'
       })
     },
-    [cwd]
+    [cwd, tabId, worktreeId]
   )
 
   const beginPaneDragFromHeader = useCallback(

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-action-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-action-dispatch.ts
@@ -13,6 +13,8 @@ import type { resolveTerminalKeyboardShortcutAction } from './terminal-keyboard-
 type TerminalShortcutAction = NonNullable<ReturnType<typeof resolveTerminalKeyboardShortcutAction>>
 
 type ActionDispatchContext = {
+  tabId: string
+  worktreeId: string
   fallbackCwd: string
   expandedPaneIdRef: React.RefObject<number | null>
   setExpandedPane: (paneId: number | null) => void
@@ -39,6 +41,8 @@ export function dispatchTerminalShortcutAction(
   context: ActionDispatchContext
 ): void {
   const {
+    tabId,
+    worktreeId,
     fallbackCwd,
     expandedPaneIdRef,
     setExpandedPane,
@@ -205,6 +209,8 @@ export function dispatchTerminalShortcutAction(
       return
     }
     splitTerminalPaneWithInheritedCwd({
+      worktreeId,
+      tabId,
       manager,
       getManager: () => managerRef.current,
       paneTransports: paneTransportsRef.current,

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-event-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-event-handlers.ts
@@ -46,6 +46,8 @@ type EventContext = KeyboardHandlersDeps & {
 
 export function createTerminalKeyboardEventHandlers(context: EventContext) {
   const {
+    tabId,
+    worktreeId,
     isMac,
     isWindows,
     shortcutPlatform,
@@ -263,6 +265,8 @@ export function createTerminalKeyboardEventHandlers(context: EventContext) {
     }
 
     dispatchTerminalShortcutAction(action, e, manager, {
+      tabId,
+      worktreeId,
       fallbackCwd,
       expandedPaneIdRef,
       setExpandedPane,

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.test.ts
@@ -46,11 +46,13 @@ describe('splitTerminalPaneWithInheritedCwd', () => {
       mocks.splitWebRuntimeTerminal.mockReturnValue(true)
 
       splitTerminalPaneWithInheritedCwd({
+        worktreeId: 'worktree-1',
+        tabId: 'tab-1',
         manager: makeManager(splitPane),
         paneTransports: new Map([[1, transport]]),
         paneCwdMap: new Map(),
         fallbackCwd: '/fallback',
-        pane: { id: 1 } as ManagedPane,
+        pane: { id: 1, leafId: 'leaf-1' } as ManagedPane,
         direction: 'vertical',
         source
       })
@@ -58,7 +60,8 @@ describe('splitTerminalPaneWithInheritedCwd', () => {
       expect(mocks.splitWebRuntimeTerminal).toHaveBeenCalledWith(
         'remote:web-env-1@@terminal-1',
         'vertical',
-        source
+        source,
+        { worktreeId: 'worktree-1', tabId: 'tab-1', leafId: 'leaf-1' }
       )
       expect(splitPane).not.toHaveBeenCalled()
     }
@@ -69,11 +72,13 @@ describe('splitTerminalPaneWithInheritedCwd', () => {
     const splitPane = vi.fn(() => createdPane)
 
     splitTerminalPaneWithInheritedCwd({
+      worktreeId: 'worktree-1',
+      tabId: 'tab-1',
       manager: makeManager(splitPane),
       paneTransports: new Map(),
       paneCwdMap: new Map([[1, { cwd: '/cached', confirmed: true }]]),
       fallbackCwd: '/fallback',
-      pane: { id: 1 } as ManagedPane,
+      pane: { id: 1, leafId: 'leaf-1' } as ManagedPane,
       direction: 'horizontal',
       source: 'keyboard'
     })
@@ -91,12 +96,14 @@ describe('splitTerminalPaneWithInheritedCwd', () => {
     mocks.resolveSplitCwd.mockResolvedValue('/resolved')
 
     splitTerminalPaneWithInheritedCwd({
+      worktreeId: 'worktree-1',
+      tabId: 'tab-1',
       manager: makeManager(staleSplitPane),
       getManager: () => makeManager(liveSplitPane),
       paneTransports: new Map<number, PtyTransport>(),
       paneCwdMap: new Map(),
       fallbackCwd: '/fallback',
-      pane: { id: 1 } as ManagedPane,
+      pane: { id: 1, leafId: 'leaf-1' } as ManagedPane,
       direction: 'vertical',
       source: 'context_menu'
     })
@@ -116,12 +123,14 @@ describe('splitTerminalPaneWithInheritedCwd', () => {
     mocks.resolveSplitCwd.mockResolvedValue('/resolved')
 
     splitTerminalPaneWithInheritedCwd({
+      worktreeId: 'worktree-1',
+      tabId: 'tab-1',
       manager: makeManager(staleSplitPane),
       getManager: () => null,
       paneTransports: new Map<number, PtyTransport>(),
       paneCwdMap: new Map(),
       fallbackCwd: '/fallback',
-      pane: { id: 1 } as ManagedPane,
+      pane: { id: 1, leafId: 'leaf-1' } as ManagedPane,
       direction: 'horizontal',
       source: 'context_menu'
     })

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.test.ts
@@ -38,6 +38,53 @@ describe('splitTerminalPaneWithInheritedCwd', () => {
     mocks.splitWebRuntimeTerminal.mockReturnValue(false)
   })
 
+  it.each(['keyboard', 'context_menu'] as const)(
+    'delegates remote %s splits without creating a competing local pane',
+    (source) => {
+      const splitPane = vi.fn()
+      const transport = { getPtyId: () => 'remote:web-env-1@@terminal-1' } as PtyTransport
+      mocks.splitWebRuntimeTerminal.mockReturnValue(true)
+
+      splitTerminalPaneWithInheritedCwd({
+        manager: makeManager(splitPane),
+        paneTransports: new Map([[1, transport]]),
+        paneCwdMap: new Map(),
+        fallbackCwd: '/fallback',
+        pane: { id: 1 } as ManagedPane,
+        direction: 'vertical',
+        source
+      })
+
+      expect(mocks.splitWebRuntimeTerminal).toHaveBeenCalledWith(
+        'remote:web-env-1@@terminal-1',
+        'vertical',
+        source
+      )
+      expect(splitPane).not.toHaveBeenCalled()
+    }
+  )
+
+  it('keeps the existing local split-and-focus path unchanged', () => {
+    const createdPane = { id: 2 }
+    const splitPane = vi.fn(() => createdPane)
+
+    splitTerminalPaneWithInheritedCwd({
+      manager: makeManager(splitPane),
+      paneTransports: new Map(),
+      paneCwdMap: new Map([[1, { cwd: '/cached', confirmed: true }]]),
+      fallbackCwd: '/fallback',
+      pane: { id: 1 } as ManagedPane,
+      direction: 'horizontal',
+      source: 'keyboard'
+    })
+
+    expect(splitPane).toHaveBeenCalledWith(1, 'horizontal', { cwd: '/cached' })
+    expect(mocks.recordCreatedTerminalPaneSplit).toHaveBeenCalledWith(createdPane, {
+      source: 'keyboard',
+      direction: 'horizontal'
+    })
+  })
+
   it('uses the live manager after async cwd resolution', async () => {
     const staleSplitPane = vi.fn()
     const liveSplitPane = vi.fn(() => ({ id: 2 }))

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.ts
@@ -6,6 +6,8 @@ import { resolveSplitCwd, type PaneCwdMap } from './resolve-split-cwd'
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 
 export function splitTerminalPaneWithInheritedCwd(args: {
+  worktreeId: string
+  tabId: string
   manager: PaneManager
   getManager?: () => PaneManager | null
   paneTransports: Map<number, PtyTransport>
@@ -16,7 +18,13 @@ export function splitTerminalPaneWithInheritedCwd(args: {
   source: TerminalPaneSplitSource
 }): void {
   const ptyId = args.paneTransports.get(args.pane.id)?.getPtyId() ?? null
-  if (splitWebRuntimeTerminal(ptyId, args.direction, args.source)) {
+  if (
+    splitWebRuntimeTerminal(ptyId, args.direction, args.source, {
+      worktreeId: args.worktreeId,
+      tabId: args.tabId,
+      leafId: args.pane.leafId
+    })
+  ) {
     return
   }
   const cached = args.paneCwdMap.get(args.pane.id)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -139,6 +139,7 @@ export function useTerminalPaneContextMenu({
     paneCwdRef,
     contextPaneIdRef,
     tabId,
+    worktreeId,
     fallbackCwd,
     resolveMenuPane
   })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-split-actions.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-split-actions.ts
@@ -26,6 +26,7 @@ type UseTerminalPaneSplitActionsDeps = {
   paneCwdRef: React.RefObject<PaneCwdMap>
   contextPaneIdRef: React.RefObject<number | null>
   tabId: string
+  worktreeId: string
   fallbackCwd: string
   resolveMenuPane: () => ManagedPane | null
 }
@@ -41,6 +42,7 @@ export function useTerminalPaneSplitActions({
   paneCwdRef,
   contextPaneIdRef,
   tabId,
+  worktreeId,
   fallbackCwd,
   resolveMenuPane
 }: UseTerminalPaneSplitActionsDeps): TerminalPaneSplitActions {
@@ -55,6 +57,8 @@ export function useTerminalPaneSplitActions({
         return
       }
       splitTerminalPaneWithInheritedCwd({
+        worktreeId,
+        tabId,
         manager,
         getManager: () => managerRef.current,
         paneTransports: paneTransportsRef.current,
@@ -65,7 +69,7 @@ export function useTerminalPaneSplitActions({
         source
       })
     },
-    [fallbackCwd, managerRef, paneCwdRef, paneTransportsRef, resolveMenuPane]
+    [fallbackCwd, managerRef, paneCwdRef, paneTransportsRef, resolveMenuPane, tabId, worktreeId]
   )
 
   const onSplitRight = (): void => splitWithInheritedCwd('vertical')

--- a/src/renderer/src/hooks/ipc-events/terminal-ui-routing-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/terminal-ui-routing-ipc-bridge.ts
@@ -11,13 +11,14 @@ import {
 export function registerTerminalUiRoutingIpcBridge(unsubs: (() => void)[]): void {
   unsubs.push(
     window.api.ui.onSplitTerminal(
-      ({ tabId, paneRuntimeId, direction, command, telemetrySource }) => {
+      ({ tabId, paneRuntimeId, direction, command, telemetrySource, newLeafId }) => {
         const detail: SplitTerminalPaneDetail = {
           tabId,
           paneRuntimeId,
           direction,
           command,
-          telemetrySource
+          telemetrySource,
+          newLeafId
         }
         window.dispatchEvent(new CustomEvent(SPLIT_TERMINAL_PANE_EVENT, { detail }))
       }

--- a/src/renderer/src/runtime/web-runtime-session-terminal-pane-delegation.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-terminal-pane-delegation.test.ts
@@ -132,6 +132,14 @@ function stubSplitSourceTab(hostTabId: string): void {
   mocks.getState.mockReturnValue(makeSplitSourceState(hostTabId))
 }
 
+function makeSplitResult(leafId: string): unknown {
+  return {
+    id: leafId,
+    ok: true,
+    result: { split: { handle: leafId, tabId: 'tab-1', paneRuntimeId: -1, leafId } }
+  }
+}
+
 describe('splitWebRuntimeTerminal', () => {
   beforeEach(() => {
     vi.stubGlobal('__ORCA_WEB_CLIENT__', true)
@@ -428,26 +436,14 @@ describe('splitWebRuntimeTerminal', () => {
     ).toBe(true)
     await vi.waitFor(() => expect(splitResolvers).toHaveLength(2))
 
-    splitResolvers[1]?.({
-      id: 'split-b',
-      ok: true,
-      result: {
-        split: { handle: 'terminal-b', tabId: 'tab-1', paneRuntimeId: -1, leafId: 'leaf-b' }
-      }
-    })
+    splitResolvers[1]?.(makeSplitResult('leaf-b'))
     await vi.waitFor(() =>
       expect(
         peekWebSessionFocusIntent({ environmentId: 'web-env-1' }, SPLIT_WORKTREE_ID)
       ).toMatchObject({ hostTabId: 'tab-1', leafId: 'leaf-b' })
     )
 
-    splitResolvers[0]?.({
-      id: 'split-a',
-      ok: true,
-      result: {
-        split: { handle: 'terminal-a', tabId: 'tab-1', paneRuntimeId: -1, leafId: 'leaf-a' }
-      }
-    })
+    splitResolvers[0]?.(makeSplitResult('leaf-a'))
     await Promise.resolve()
     await Promise.resolve()
     const intentAfterOlderCompletion = peekWebSessionFocusIntent(
@@ -479,6 +475,31 @@ describe('splitWebRuntimeTerminal', () => {
       toWebTerminalSurfaceTabId('tab-1'),
       'leaf-a'
     )
+  })
+
+  it('lets a newer split with an unreconciled source supersede older focus', async () => {
+    stubSplitSourceTab('tab-1')
+    const splitResolvers: ((response: unknown) => void)[] = []
+    const runtimeCall = vi.fn(() => new Promise((resolve) => splitResolvers.push(resolve)))
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+    const split = (): boolean =>
+      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard', SPLIT_SOURCE)
+    expect(split()).toBe(true)
+    await vi.waitFor(() => expect(splitResolvers).toHaveLength(1))
+    mocks.getState.mockReturnValue({
+      ...makeSplitSourceState('tab-1'),
+      terminalLayoutsByTabId: {}
+    })
+    expect(split()).toBe(true)
+    await vi.waitFor(() => expect(splitResolvers).toHaveLength(2))
+    splitResolvers[0]?.(makeSplitResult('leaf-a'))
+    await vi.waitFor(() =>
+      expect(
+        peekWebSessionFocusIntent({ environmentId: 'web-env-1' }, SPLIT_WORKTREE_ID)
+      ).toBeNull()
+    )
+    expect(mocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+    splitResolvers[1]?.(makeSplitResult('leaf-b'))
   })
 
   it('does not let an older snapshot completion clear or focus over a newer split', async () => {

--- a/src/renderer/src/runtime/web-runtime-session-terminal-pane-delegation.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-terminal-pane-delegation.test.ts
@@ -85,6 +85,11 @@ afterEach(() => {
 })
 
 const SPLIT_WORKTREE_ID = 'repo::/worktree'
+const SPLIT_SOURCE = {
+  worktreeId: SPLIT_WORKTREE_ID,
+  tabId: toWebTerminalSurfaceTabId('tab-1'),
+  leafId: 'leaf-1'
+}
 
 function makeSplitSourceState(
   hostTabId: string,
@@ -157,9 +162,14 @@ describe('splitWebRuntimeTerminal', () => {
       }
     })
 
-    expect(splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'horizontal', 'keyboard')).toBe(
-      true
-    )
+    expect(
+      splitWebRuntimeTerminal(
+        'remote:web-env-1@@terminal-1',
+        'horizontal',
+        'keyboard',
+        SPLIT_SOURCE
+      )
+    ).toBe(true)
     expect(
       consumePendingWebRuntimeSplitMirrorTelemetry('remote:web-env-1@@terminal-other', 'horizontal')
     ).toBe(false)
@@ -197,7 +207,12 @@ describe('splitWebRuntimeTerminal', () => {
     })
 
     expect(
-      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'context_menu')
+      splitWebRuntimeTerminal(
+        'remote:web-env-1@@terminal-1',
+        'vertical',
+        'context_menu',
+        SPLIT_SOURCE
+      )
     ).toBe(true)
 
     await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(1))
@@ -225,11 +240,18 @@ describe('splitWebRuntimeTerminal', () => {
       }
     })
 
-    expect(splitWebRuntimeTerminal('pty-local-1', 'horizontal', 'keyboard')).toBe(false)
-    vi.stubGlobal('__ORCA_WEB_CLIENT__', false)
-    expect(splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'horizontal', 'keyboard')).toBe(
-      true
+    expect(splitWebRuntimeTerminal('pty-local-1', 'horizontal', 'keyboard', SPLIT_SOURCE)).toBe(
+      false
     )
+    vi.stubGlobal('__ORCA_WEB_CLIENT__', false)
+    expect(
+      splitWebRuntimeTerminal(
+        'remote:web-env-1@@terminal-1',
+        'horizontal',
+        'keyboard',
+        SPLIT_SOURCE
+      )
+    ).toBe(true)
 
     await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(1))
   })
@@ -269,9 +291,9 @@ describe('splitWebRuntimeTerminal', () => {
     )
     vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
 
-    expect(splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard')).toBe(
-      true
-    )
+    expect(
+      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard', SPLIT_SOURCE)
+    ).toBe(true)
 
     await vi.waitFor(() =>
       expect(
@@ -301,6 +323,237 @@ describe('splitWebRuntimeTerminal', () => {
     )
   })
 
+  it('uses the gesture pane when a stale layout also records the source PTY', async () => {
+    const staleTabId = toWebTerminalSurfaceTabId('tab-stale')
+    const sourceTabId = toWebTerminalSurfaceTabId('tab-source')
+    const tabs = [
+      {
+        id: staleTabId,
+        worktreeId: SPLIT_WORKTREE_ID,
+        contentType: 'terminal',
+        ptyId: 'remote:web-env-1@@terminal-1'
+      },
+      {
+        id: sourceTabId,
+        worktreeId: SPLIT_WORKTREE_ID,
+        contentType: 'terminal',
+        ptyId: 'remote:web-env-1@@terminal-1'
+      }
+    ]
+    mocks.getState.mockReturnValue({
+      ...makeSplitSourceState('tab-source', 'leaf-source'),
+      tabsByWorktree: { [SPLIT_WORKTREE_ID]: tabs },
+      unifiedTabsByWorktree: { [SPLIT_WORKTREE_ID]: tabs },
+      ptyIdsByTabId: { [sourceTabId]: ['remote:web-env-1@@terminal-1'] },
+      terminalLayoutsByTabId: {
+        [staleTabId]: {
+          activeLeafId: 'leaf-stale',
+          ptyIdsByLeafId: { 'leaf-stale': 'remote:web-env-1@@terminal-1' }
+        },
+        [sourceTabId]: {
+          activeLeafId: 'leaf-source',
+          ptyIdsByLeafId: { 'leaf-source': 'remote:web-env-1@@terminal-1' }
+        }
+      }
+    })
+    const runtimeCall = vi.fn((request: { method: string }) =>
+      Promise.resolve(
+        request.method === 'terminal.split'
+          ? {
+              id: 'split',
+              ok: true,
+              result: {
+                split: {
+                  handle: 'terminal-2',
+                  tabId: 'tab-source',
+                  paneRuntimeId: -1,
+                  leafId: 'leaf-created'
+                }
+              }
+            }
+          : {
+              id: 'list',
+              ok: true,
+              result: {
+                worktree: SPLIT_WORKTREE_ID,
+                publicationEpoch: 'epoch-1',
+                snapshotVersion: 2,
+                activeGroupId: null,
+                activeTabId: null,
+                activeTabType: 'terminal',
+                tabs: []
+              }
+            }
+      )
+    )
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    expect(
+      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard', {
+        worktreeId: SPLIT_WORKTREE_ID,
+        tabId: sourceTabId,
+        leafId: 'leaf-source'
+      })
+    ).toBe(true)
+
+    await vi.waitFor(() =>
+      expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith(sourceTabId, 'leaf-created')
+    )
+  })
+
+  it('keeps the latest split focus intent when responses complete out of order', async () => {
+    stubSplitSourceTab('tab-1')
+    const splitResolvers: ((response: unknown) => void)[] = []
+    let resolveList!: (response: unknown) => void
+    const runtimeCall = vi.fn((request: { method: string }) => {
+      if (request.method === 'terminal.split') {
+        return new Promise((resolve) => splitResolvers.push(resolve))
+      }
+      return new Promise((resolve) => {
+        resolveList = resolve
+      })
+    })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+    const source = {
+      worktreeId: SPLIT_WORKTREE_ID,
+      tabId: toWebTerminalSurfaceTabId('tab-1'),
+      leafId: 'leaf-1'
+    }
+
+    expect(
+      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard', source)
+    ).toBe(true)
+    expect(
+      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard', source)
+    ).toBe(true)
+    await vi.waitFor(() => expect(splitResolvers).toHaveLength(2))
+
+    splitResolvers[1]?.({
+      id: 'split-b',
+      ok: true,
+      result: {
+        split: { handle: 'terminal-b', tabId: 'tab-1', paneRuntimeId: -1, leafId: 'leaf-b' }
+      }
+    })
+    await vi.waitFor(() =>
+      expect(
+        peekWebSessionFocusIntent({ environmentId: 'web-env-1' }, SPLIT_WORKTREE_ID)
+      ).toMatchObject({ hostTabId: 'tab-1', leafId: 'leaf-b' })
+    )
+
+    splitResolvers[0]?.({
+      id: 'split-a',
+      ok: true,
+      result: {
+        split: { handle: 'terminal-a', tabId: 'tab-1', paneRuntimeId: -1, leafId: 'leaf-a' }
+      }
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+    const intentAfterOlderCompletion = peekWebSessionFocusIntent(
+      { environmentId: 'web-env-1' },
+      SPLIT_WORKTREE_ID
+    )
+
+    resolveList({
+      id: 'list',
+      ok: true,
+      result: {
+        worktree: SPLIT_WORKTREE_ID,
+        publicationEpoch: 'epoch-1',
+        snapshotVersion: 2,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: 'terminal',
+        tabs: []
+      }
+    })
+    expect(intentAfterOlderCompletion).toMatchObject({ hostTabId: 'tab-1', leafId: 'leaf-b' })
+    await vi.waitFor(() =>
+      expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith(
+        toWebTerminalSurfaceTabId('tab-1'),
+        'leaf-b'
+      )
+    )
+    expect(mocks.activateTabAndFocusPane).not.toHaveBeenCalledWith(
+      toWebTerminalSurfaceTabId('tab-1'),
+      'leaf-a'
+    )
+  })
+
+  it('does not let an older snapshot completion clear or focus over a newer split', async () => {
+    stubSplitSourceTab('tab-1')
+    const splitResolvers: ((response: unknown) => void)[] = []
+    let resolveList!: (response: unknown) => void
+    const runtimeCall = vi.fn((request: { method: string }) => {
+      if (request.method === 'terminal.split') {
+        return new Promise((resolve) => splitResolvers.push(resolve))
+      }
+      return new Promise((resolve) => {
+        resolveList = resolve
+      })
+    })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    expect(
+      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard', SPLIT_SOURCE)
+    ).toBe(true)
+    await vi.waitFor(() => expect(splitResolvers).toHaveLength(1))
+    splitResolvers[0]?.({
+      id: 'split-a',
+      ok: true,
+      result: {
+        split: { handle: 'terminal-a', tabId: 'tab-1', paneRuntimeId: -1, leafId: 'leaf-a' }
+      }
+    })
+    await vi.waitFor(() =>
+      expect(
+        peekWebSessionFocusIntent({ environmentId: 'web-env-1' }, SPLIT_WORKTREE_ID)
+      ).toMatchObject({ leafId: 'leaf-a' })
+    )
+
+    expect(
+      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard', SPLIT_SOURCE)
+    ).toBe(true)
+    await vi.waitFor(() => expect(splitResolvers).toHaveLength(2))
+    splitResolvers[1]?.({
+      id: 'split-b',
+      ok: true,
+      result: {
+        split: { handle: 'terminal-b', tabId: 'tab-1', paneRuntimeId: -1, leafId: 'leaf-b' }
+      }
+    })
+    await vi.waitFor(() =>
+      expect(
+        peekWebSessionFocusIntent({ environmentId: 'web-env-1' }, SPLIT_WORKTREE_ID)
+      ).toMatchObject({ leafId: 'leaf-b' })
+    )
+
+    resolveList({
+      id: 'list',
+      ok: true,
+      result: {
+        worktree: SPLIT_WORKTREE_ID,
+        publicationEpoch: 'epoch-1',
+        snapshotVersion: 2,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: 'terminal',
+        tabs: []
+      }
+    })
+    await vi.waitFor(() =>
+      expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith(
+        toWebTerminalSurfaceTabId('tab-1'),
+        'leaf-b'
+      )
+    )
+    expect(mocks.activateTabAndFocusPane).not.toHaveBeenCalledWith(
+      toWebTerminalSurfaceTabId('tab-1'),
+      'leaf-a'
+    )
+  })
+
   it('does not claim focus from an old host that omits the leaf identity', async () => {
     stubSplitSourceTab('tab-1')
     const runtimeCall = vi.fn().mockResolvedValue({
@@ -312,9 +565,9 @@ describe('splitWebRuntimeTerminal', () => {
     })
     vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
 
-    expect(splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard')).toBe(
-      true
-    )
+    expect(
+      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard', SPLIT_SOURCE)
+    ).toBe(true)
 
     await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledOnce())
     expect(peekWebSessionFocusIntent({ environmentId: 'web-env-1' }, SPLIT_WORKTREE_ID)).toBeNull()
@@ -356,7 +609,12 @@ describe('splitWebRuntimeTerminal', () => {
     vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
 
     expect(
-      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'context_menu')
+      splitWebRuntimeTerminal(
+        'remote:web-env-1@@terminal-1',
+        'vertical',
+        'context_menu',
+        SPLIT_SOURCE
+      )
     ).toBe(true)
 
     await vi.waitFor(() =>
@@ -385,9 +643,9 @@ describe('splitWebRuntimeTerminal', () => {
     )
     vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
 
-    expect(splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard')).toBe(
-      true
-    )
+    expect(
+      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard', SPLIT_SOURCE)
+    ).toBe(true)
     await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledOnce())
     mocks.getState.mockReturnValue(makeSplitSourceState('tab-2'))
     resolveSplit({
@@ -421,9 +679,9 @@ describe('splitWebRuntimeTerminal', () => {
     )
     vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
 
-    expect(splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard')).toBe(
-      true
-    )
+    expect(
+      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard', SPLIT_SOURCE)
+    ).toBe(true)
     await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledOnce())
     replaceRuntimeEnvironmentRevisions([{ id: 'web-env-1', createdAt: 9 }])
     resolveSplit({
@@ -473,9 +731,9 @@ describe('splitWebRuntimeTerminal', () => {
     )
     vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
 
-    expect(splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard')).toBe(
-      true
-    )
+    expect(
+      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard', SPLIT_SOURCE)
+    ).toBe(true)
     await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(2))
     replaceRuntimeEnvironmentRevisions([{ id: 'web-env-1', createdAt: 9 }])
     resolveList({

--- a/src/renderer/src/runtime/web-runtime-session-terminal-pane-delegation.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-terminal-pane-delegation.test.ts
@@ -86,22 +86,40 @@ afterEach(() => {
 
 const SPLIT_WORKTREE_ID = 'repo::/worktree'
 
-function makeSplitSourceState(hostTabId: string, leafId = 'leaf-1'): Record<string, unknown> {
+function makeSplitSourceState(
+  hostTabId: string,
+  leafId = 'leaf-1',
+  activeHostTabId = hostTabId
+): Record<string, unknown> {
   const tabId = toWebTerminalSurfaceTabId(hostTabId)
+  const activeTabId = toWebTerminalSurfaceTabId(activeHostTabId)
+  const tabs = [
+    {
+      id: tabId,
+      worktreeId: SPLIT_WORKTREE_ID,
+      contentType: 'terminal',
+      ptyId: 'remote:web-env-1@@terminal-1'
+    },
+    ...(activeTabId === tabId
+      ? []
+      : [{ id: activeTabId, worktreeId: SPLIT_WORKTREE_ID, contentType: 'terminal' }])
+  ]
   return {
     activeWorktreeId: SPLIT_WORKTREE_ID,
     activeWorkspaceExecutionHostId: 'runtime:web-env-1',
     activeTabType: 'terminal',
     activeTabTypeByWorktree: { [SPLIT_WORKTREE_ID]: 'terminal' },
-    activeTabIdByWorktree: { [SPLIT_WORKTREE_ID]: tabId },
-    tabsByWorktree: {
-      [SPLIT_WORKTREE_ID]: [{ id: tabId, worktreeId: SPLIT_WORKTREE_ID }]
-    },
-    unifiedTabsByWorktree: {
-      [SPLIT_WORKTREE_ID]: [{ id: tabId, contentType: 'terminal' }]
-    },
+    activeTabIdByWorktree: { [SPLIT_WORKTREE_ID]: activeTabId },
+    tabsByWorktree: { [SPLIT_WORKTREE_ID]: tabs },
+    unifiedTabsByWorktree: { [SPLIT_WORKTREE_ID]: tabs },
     groupsByWorktree: {},
-    terminalLayoutsByTabId: { [tabId]: { activeLeafId: leafId } }
+    terminalLayoutsByTabId: {
+      [tabId]: {
+        activeLeafId: leafId,
+        ptyIdsByLeafId: { [leafId]: 'remote:web-env-1@@terminal-1' }
+      },
+      ...(activeTabId === tabId ? {} : { [activeTabId]: { activeLeafId: 'active-leaf' } })
+    }
   }
 }
 
@@ -301,6 +319,59 @@ describe('splitWebRuntimeTerminal', () => {
     await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledOnce())
     expect(peekWebSessionFocusIntent({ environmentId: 'web-env-1' }, SPLIT_WORKTREE_ID)).toBeNull()
     expect(mocks.acceptReplayedWebSessionTabsSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('focuses a split invoked from a non-focused group tab when the viewer stays put', async () => {
+    mocks.getState.mockReturnValue(makeSplitSourceState('tab-1', 'leaf-1', 'tab-2'))
+    const runtimeCall = vi.fn((request: { method: string }) =>
+      Promise.resolve(
+        request.method === 'terminal.split'
+          ? {
+              id: 'split',
+              ok: true,
+              result: {
+                split: {
+                  handle: 'terminal-2',
+                  tabId: 'tab-1',
+                  paneRuntimeId: -1,
+                  leafId: 'leaf-2'
+                }
+              }
+            }
+          : {
+              id: 'list',
+              ok: true,
+              result: {
+                worktree: SPLIT_WORKTREE_ID,
+                publicationEpoch: 'epoch-1',
+                snapshotVersion: 2,
+                activeGroupId: null,
+                activeTabId: null,
+                activeTabType: 'terminal',
+                tabs: []
+              }
+            }
+      )
+    )
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    expect(
+      splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'context_menu')
+    ).toBe(true)
+
+    await vi.waitFor(() =>
+      expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith(
+        toWebTerminalSurfaceTabId('tab-1'),
+        'leaf-2'
+      )
+    )
+    expect(
+      peekWebSessionFocusIntent({ environmentId: 'web-env-1' }, SPLIT_WORKTREE_ID)
+    ).toMatchObject({
+      hostTabId: 'tab-1',
+      leafId: 'leaf-2',
+      expectedCurrentLocalTabId: toWebTerminalSurfaceTabId('tab-2')
+    })
   })
 
   it('does not steal focus after the viewer switches tabs while the host splits', async () => {

--- a/src/renderer/src/runtime/web-runtime-session-terminal-pane-delegation.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-terminal-pane-delegation.test.ts
@@ -6,8 +6,15 @@ import {
   splitWebRuntimeTerminal
 } from './web-runtime-session'
 import { resetWebSessionCloseIntentForTests } from './web-session-close-intent'
+import {
+  peekWebSessionFocusIntent,
+  resetWebSessionFocusIntentForTests
+} from './web-session-focus-intent'
+import { toWebTerminalSurfaceTabId } from '../../../shared/terminal-surface-id'
+import { replaceRuntimeEnvironmentRevisions } from './runtime-environment-revision'
 
 const mocks = vi.hoisted(() => ({
+  activateTabAndFocusPane: vi.fn(),
   getState: vi.fn(),
   setState: vi.fn(),
   subscribe: vi.fn(),
@@ -35,6 +42,10 @@ vi.mock('../store', () => ({
     setState: mocks.setState,
     subscribe: mocks.subscribe
   }
+}))
+
+vi.mock('../lib/activate-tab-and-focus-pane', () => ({
+  activateTabAndFocusPane: mocks.activateTabAndFocusPane
 }))
 
 vi.mock('./web-session-tabs-sync', () => ({
@@ -67,7 +78,36 @@ vi.mock('./web-runtime-browser-materialization', () => ({
   hasMaterializedWebRuntimeBrowserPage: mocks.hasMaterializedWebRuntimeBrowserPage
 }))
 
-afterEach(() => resetWebSessionCloseIntentForTests())
+afterEach(() => {
+  resetWebSessionCloseIntentForTests()
+  resetWebSessionFocusIntentForTests()
+  replaceRuntimeEnvironmentRevisions([])
+})
+
+const SPLIT_WORKTREE_ID = 'repo::/worktree'
+
+function makeSplitSourceState(hostTabId: string, leafId = 'leaf-1'): Record<string, unknown> {
+  const tabId = toWebTerminalSurfaceTabId(hostTabId)
+  return {
+    activeWorktreeId: SPLIT_WORKTREE_ID,
+    activeWorkspaceExecutionHostId: 'runtime:web-env-1',
+    activeTabType: 'terminal',
+    activeTabTypeByWorktree: { [SPLIT_WORKTREE_ID]: 'terminal' },
+    activeTabIdByWorktree: { [SPLIT_WORKTREE_ID]: tabId },
+    tabsByWorktree: {
+      [SPLIT_WORKTREE_ID]: [{ id: tabId, worktreeId: SPLIT_WORKTREE_ID }]
+    },
+    unifiedTabsByWorktree: {
+      [SPLIT_WORKTREE_ID]: [{ id: tabId, contentType: 'terminal' }]
+    },
+    groupsByWorktree: {},
+    terminalLayoutsByTabId: { [tabId]: { activeLeafId: leafId } }
+  }
+}
+
+function stubSplitSourceTab(hostTabId: string): void {
+  mocks.getState.mockReturnValue(makeSplitSourceState(hostTabId))
+}
 
 describe('splitWebRuntimeTerminal', () => {
   beforeEach(() => {
@@ -112,6 +152,7 @@ describe('splitWebRuntimeTerminal', () => {
     await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(1))
     expect(runtimeCall).toHaveBeenCalledWith({
       selector: 'web-env-1',
+      expectedEnvironmentPairingRevision: undefined,
       method: 'terminal.split',
       params: {
         terminal: 'terminal-1',
@@ -173,6 +214,222 @@ describe('splitWebRuntimeTerminal', () => {
     )
 
     await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(1))
+  })
+
+  it('records the exact host-created leaf before replaying the mirrored layout', async () => {
+    stubSplitSourceTab('tab-1')
+    replaceRuntimeEnvironmentRevisions([{ id: 'web-env-1', createdAt: 7 }])
+    const runtimeCall = vi.fn((request: { method: string }) =>
+      Promise.resolve(
+        request.method === 'terminal.split'
+          ? {
+              id: 'split',
+              ok: true,
+              result: {
+                split: {
+                  handle: 'terminal-2',
+                  tabId: 'tab-1',
+                  paneRuntimeId: -1,
+                  leafId: 'leaf-2'
+                }
+              }
+            }
+          : {
+              id: 'list',
+              ok: true,
+              result: {
+                worktree: SPLIT_WORKTREE_ID,
+                publicationEpoch: 'epoch-1',
+                snapshotVersion: 2,
+                activeGroupId: null,
+                activeTabId: null,
+                activeTabType: 'terminal',
+                tabs: []
+              }
+            }
+      )
+    )
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    expect(splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard')).toBe(
+      true
+    )
+
+    await vi.waitFor(() =>
+      expect(
+        peekWebSessionFocusIntent(
+          { environmentId: 'web-env-1', pairingRevision: 7 },
+          SPLIT_WORKTREE_ID
+        )
+      ).toEqual({
+        hostTabId: 'tab-1',
+        leafId: 'leaf-2',
+        expectedCurrentLocalTabId: toWebTerminalSurfaceTabId('tab-1')
+      })
+    )
+    expect(mocks.acceptReplayedWebSessionTabsSnapshot).toHaveBeenCalledWith(
+      'web-env-1',
+      SPLIT_WORKTREE_ID
+    )
+    expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith(
+      toWebTerminalSurfaceTabId('tab-1'),
+      'leaf-2'
+    )
+    expect(runtimeCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'terminal.split',
+        expectedEnvironmentPairingRevision: 7
+      })
+    )
+  })
+
+  it('does not claim focus from an old host that omits the leaf identity', async () => {
+    stubSplitSourceTab('tab-1')
+    const runtimeCall = vi.fn().mockResolvedValue({
+      id: 'split',
+      ok: true,
+      result: {
+        split: { handle: 'terminal-2', tabId: 'tab-1', paneRuntimeId: -1 }
+      }
+    })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    expect(splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard')).toBe(
+      true
+    )
+
+    await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledOnce())
+    expect(peekWebSessionFocusIntent({ environmentId: 'web-env-1' }, SPLIT_WORKTREE_ID)).toBeNull()
+    expect(mocks.acceptReplayedWebSessionTabsSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('does not steal focus after the viewer switches tabs while the host splits', async () => {
+    stubSplitSourceTab('tab-1')
+    let resolveSplit!: (response: unknown) => void
+    const runtimeCall = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveSplit = resolve
+        })
+    )
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    expect(splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard')).toBe(
+      true
+    )
+    await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledOnce())
+    mocks.getState.mockReturnValue(makeSplitSourceState('tab-2'))
+    resolveSplit({
+      id: 'split',
+      ok: true,
+      result: {
+        split: {
+          handle: 'terminal-2',
+          tabId: 'tab-1',
+          paneRuntimeId: -1,
+          leafId: 'leaf-2'
+        }
+      }
+    })
+
+    await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledOnce())
+    expect(peekWebSessionFocusIntent({ environmentId: 'web-env-1' }, SPLIT_WORKTREE_ID)).toBeNull()
+    expect(mocks.acceptReplayedWebSessionTabsSnapshot).not.toHaveBeenCalled()
+    expect(mocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+  })
+
+  it('drops a completed split intent after the environment re-pairs', async () => {
+    stubSplitSourceTab('tab-1')
+    replaceRuntimeEnvironmentRevisions([{ id: 'web-env-1', createdAt: 7 }])
+    let resolveSplit!: (response: unknown) => void
+    const runtimeCall = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveSplit = resolve
+        })
+    )
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    expect(splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard')).toBe(
+      true
+    )
+    await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledOnce())
+    replaceRuntimeEnvironmentRevisions([{ id: 'web-env-1', createdAt: 9 }])
+    resolveSplit({
+      id: 'split',
+      ok: true,
+      result: {
+        split: {
+          handle: 'terminal-2',
+          tabId: 'tab-1',
+          paneRuntimeId: -1,
+          leafId: 'leaf-2'
+        }
+      }
+    })
+
+    await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledOnce())
+    expect(
+      peekWebSessionFocusIntent(
+        { environmentId: 'web-env-1', pairingRevision: 9 },
+        SPLIT_WORKTREE_ID
+      )
+    ).toBeNull()
+    expect(mocks.acceptReplayedWebSessionTabsSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('drops local focus when the environment re-pairs during snapshot replay', async () => {
+    stubSplitSourceTab('tab-1')
+    replaceRuntimeEnvironmentRevisions([{ id: 'web-env-1', createdAt: 7 }])
+    let resolveList!: (response: unknown) => void
+    const runtimeCall = vi.fn((request: { method: string }) =>
+      request.method === 'terminal.split'
+        ? Promise.resolve({
+            id: 'split',
+            ok: true,
+            result: {
+              split: {
+                handle: 'terminal-2',
+                tabId: 'tab-1',
+                paneRuntimeId: -1,
+                leafId: 'leaf-2'
+              }
+            }
+          })
+        : new Promise((resolve) => {
+            resolveList = resolve
+          })
+    )
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    expect(splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard')).toBe(
+      true
+    )
+    await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(2))
+    replaceRuntimeEnvironmentRevisions([{ id: 'web-env-1', createdAt: 9 }])
+    resolveList({
+      id: 'list',
+      ok: true,
+      result: {
+        worktree: SPLIT_WORKTREE_ID,
+        publicationEpoch: 'epoch-1',
+        snapshotVersion: 2,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: 'terminal',
+        tabs: []
+      }
+    })
+
+    await vi.waitFor(() =>
+      expect(
+        peekWebSessionFocusIntent(
+          { environmentId: 'web-env-1', pairingRevision: 7 },
+          SPLIT_WORKTREE_ID
+        )
+      ).toBeNull()
+    )
+    expect(mocks.activateTabAndFocusPane).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/src/runtime/web-runtime-session-terminal-pane-delegation.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-terminal-pane-delegation.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   closeWebRuntimeTerminal,
   consumePendingWebRuntimeSplitMirrorTelemetry,
-  isWebRuntimeSessionActive,
   splitWebRuntimeTerminal
 } from './web-runtime-session'
 import { resetWebSessionCloseIntentForTests } from './web-session-close-intent'
@@ -859,13 +858,5 @@ describe('closeWebRuntimeTerminal', () => {
     expect(closeWebRuntimeTerminal('remote:web-env-1@@terminal-1')).toBe(true)
 
     await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(1))
-  })
-
-  it('treats any configured remote runtime environment as a shared session', () => {
-    vi.stubGlobal('__ORCA_WEB_CLIENT__', false)
-
-    expect(isWebRuntimeSessionActive('env-1')).toBe(true)
-    expect(isWebRuntimeSessionActive('   ')).toBe(false)
-    expect(isWebRuntimeSessionActive(null)).toBe(false)
   })
 })

--- a/src/renderer/src/runtime/web-runtime-session-terminal-pane-delegation.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-terminal-pane-delegation.test.ts
@@ -486,11 +486,19 @@ describe('splitWebRuntimeTerminal', () => {
       splitWebRuntimeTerminal('remote:web-env-1@@terminal-1', 'vertical', 'keyboard', SPLIT_SOURCE)
     expect(split()).toBe(true)
     await vi.waitFor(() => expect(splitResolvers).toHaveLength(1))
-    mocks.getState.mockReturnValue({
-      ...makeSplitSourceState('tab-1'),
-      terminalLayoutsByTabId: {}
-    })
-    expect(split()).toBe(true)
+    const staleSource = {
+      worktreeId: SPLIT_WORKTREE_ID,
+      tabId: toWebTerminalSurfaceTabId('tab-missing'),
+      leafId: 'leaf-missing'
+    }
+    expect(
+      splitWebRuntimeTerminal(
+        'remote:web-env-1@@terminal-missing',
+        'vertical',
+        'keyboard',
+        staleSource
+      )
+    ).toBe(true)
     await vi.waitFor(() => expect(splitResolvers).toHaveLength(2))
     splitResolvers[0]?.(makeSplitResult('leaf-a'))
     await vi.waitFor(() =>

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -28,3 +28,4 @@ export {
   setWebRuntimeTabProps,
   clearWebRuntimeTerminalBuffer
 } from './web-runtime-terminal-actions'
+export type { WebRuntimeSplitSource } from './web-runtime-split-focus'

--- a/src/renderer/src/runtime/web-runtime-split-focus.ts
+++ b/src/renderer/src/runtime/web-runtime-split-focus.ts
@@ -1,0 +1,163 @@
+import { activateTabAndFocusPane } from '../lib/activate-tab-and-focus-pane'
+import { useAppStore } from '../store'
+import { matchesWebSessionIntentOwner } from './web-runtime-session-environment'
+import { refreshWebRuntimeSessionTabsSnapshot } from './web-runtime-session-snapshot'
+import { webSessionIntentOwnerKey, type WebSessionIntentOwner } from './web-session-intent-owner'
+import {
+  clearWebSessionFocusIntentIfMatches,
+  recordWebSessionFocusIntent,
+  resolveWebSessionVisibleTabId
+} from './web-session-focus-intent'
+import { toHostSessionTabId, toWebTerminalSurfaceTabId } from './web-terminal-surface-id'
+import type { RuntimeTerminalSplit } from '../../../shared/runtime-types'
+
+export type WebRuntimeSplitSource = { worktreeId: string; tabId: string; leafId: string }
+
+type WebRuntimeSplitFocusTarget = {
+  worktreeId: string
+  sourceTabId: string
+  sourceLeafId: string
+  sourcePtyId: string
+  expectedActiveWorktreeId: string | null
+  expectedExecutionHostId: string | null
+  expectedCurrentLocalTabId: string | null
+  expectedCurrentLocalLeafId: string | null
+}
+
+type WebRuntimeSplitFocusRequest = { key: string; id: number }
+const latestWebRuntimeSplitFocusRequestByKey = new Map<string, number>()
+let nextWebRuntimeSplitFocusRequestId = 0
+
+export function beginWebRuntimeSplitFocusRequest(
+  owner: WebSessionIntentOwner,
+  worktreeId: string
+): WebRuntimeSplitFocusRequest {
+  const request = {
+    key: `${webSessionIntentOwnerKey(owner)}\0${worktreeId}`,
+    id: ++nextWebRuntimeSplitFocusRequestId
+  }
+  latestWebRuntimeSplitFocusRequestByKey.set(request.key, request.id)
+  return request
+}
+
+function isLatestWebRuntimeSplitFocusRequest(request: WebRuntimeSplitFocusRequest | null): boolean {
+  return Boolean(request && latestWebRuntimeSplitFocusRequestByKey.get(request.key) === request.id)
+}
+
+export function finishWebRuntimeSplitFocusRequest(
+  request: WebRuntimeSplitFocusRequest | null
+): void {
+  if (request && isLatestWebRuntimeSplitFocusRequest(request)) {
+    latestWebRuntimeSplitFocusRequestByKey.delete(request.key)
+  }
+}
+
+export function captureWebRuntimeSplitFocusTarget(
+  ptyId: string,
+  source: WebRuntimeSplitSource
+): WebRuntimeSplitFocusTarget | null {
+  const state = useAppStore.getState()
+  if (!state) {
+    return null
+  }
+  const sourceTab = state.tabsByWorktree?.[source.worktreeId]?.find(
+    (tab) => tab.id === source.tabId
+  )
+  if (
+    !sourceTab ||
+    state.terminalLayoutsByTabId?.[source.tabId]?.ptyIdsByLeafId?.[source.leafId] !== ptyId
+  ) {
+    return null
+  }
+  const expectedActiveWorktreeId = state.activeWorktreeId ?? null
+  const expectedCurrentLocalTabId = expectedActiveWorktreeId
+    ? resolveWebSessionVisibleTabId(state, expectedActiveWorktreeId)
+    : null
+  return {
+    worktreeId: source.worktreeId,
+    sourceTabId: source.tabId,
+    sourceLeafId: source.leafId,
+    sourcePtyId: ptyId,
+    expectedActiveWorktreeId,
+    expectedExecutionHostId: state.activeWorkspaceExecutionHostId ?? null,
+    expectedCurrentLocalTabId,
+    expectedCurrentLocalLeafId: expectedCurrentLocalTabId
+      ? (state.terminalLayoutsByTabId?.[expectedCurrentLocalTabId]?.activeLeafId ?? null)
+      : null
+  }
+}
+
+function matchesWebRuntimeSplitFocusTarget(
+  target: WebRuntimeSplitFocusTarget,
+  hostTabId: string,
+  newLeafId?: string
+): boolean {
+  const state = useAppStore.getState()
+  if (
+    !state ||
+    toHostSessionTabId(target.sourceTabId) !== hostTabId ||
+    state.terminalLayoutsByTabId?.[target.sourceTabId]?.ptyIdsByLeafId?.[target.sourceLeafId] !==
+      target.sourcePtyId ||
+    (state.activeWorktreeId ?? null) !== target.expectedActiveWorktreeId ||
+    (state.activeWorkspaceExecutionHostId ?? null) !== target.expectedExecutionHostId
+  ) {
+    return false
+  }
+  const currentTabId = target.expectedActiveWorktreeId
+    ? resolveWebSessionVisibleTabId(state, target.expectedActiveWorktreeId)
+    : null
+  if (currentTabId === target.expectedCurrentLocalTabId) {
+    const currentLeafId = currentTabId
+      ? (state.terminalLayoutsByTabId?.[currentTabId]?.activeLeafId ?? null)
+      : null
+    return currentLeafId === target.expectedCurrentLocalLeafId
+  }
+  return Boolean(
+    currentTabId &&
+    newLeafId &&
+    toHostSessionTabId(currentTabId) === hostTabId &&
+    state.terminalLayoutsByTabId?.[currentTabId]?.activeLeafId === newLeafId
+  )
+}
+
+export async function focusSplitWebRuntimeTerminalPane(
+  owner: WebSessionIntentOwner,
+  target: WebRuntimeSplitFocusTarget | null,
+  request: WebRuntimeSplitFocusRequest | null,
+  split: RuntimeTerminalSplit | undefined
+): Promise<void> {
+  const hostTabId = split?.tabId?.trim()
+  const leafId = split?.leafId?.trim()
+  if (
+    !hostTabId ||
+    !leafId ||
+    !target ||
+    !isLatestWebRuntimeSplitFocusRequest(request) ||
+    !matchesWebSessionIntentOwner(owner) ||
+    !matchesWebRuntimeSplitFocusTarget(target, hostTabId)
+  ) {
+    return
+  }
+  recordWebSessionFocusIntent(
+    owner,
+    target.worktreeId,
+    hostTabId,
+    leafId,
+    target.expectedCurrentLocalTabId
+  )
+  await refreshWebRuntimeSessionTabsSnapshot(owner.environmentId, target.worktreeId, {
+    expectedEnvironmentPairingRevision: owner.pairingRevision,
+    acceptCurrentSnapshot: true
+  })
+  if (
+    !isLatestWebRuntimeSplitFocusRequest(request) ||
+    !matchesWebSessionIntentOwner(owner) ||
+    !matchesWebRuntimeSplitFocusTarget(target, hostTabId, leafId)
+  ) {
+    if (isLatestWebRuntimeSplitFocusRequest(request)) {
+      clearWebSessionFocusIntentIfMatches(owner, target.worktreeId, hostTabId, leafId)
+    }
+    return
+  }
+  activateTabAndFocusPane(toWebTerminalSurfaceTabId(hostTabId), leafId)
+}

--- a/src/renderer/src/runtime/web-runtime-terminal-actions.ts
+++ b/src/renderer/src/runtime/web-runtime-terminal-actions.ts
@@ -11,8 +11,16 @@ import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
 import { isWebTerminalSurfaceTabId, toHostSessionTabId } from './web-terminal-surface-id'
 import {
   captureRuntimeEnvironmentCall,
+  captureWebSessionIntentOwner,
   isWebRuntimeSessionActive
 } from './web-runtime-session-environment'
+import {
+  beginWebRuntimeSplitFocusRequest,
+  captureWebRuntimeSplitFocusTarget,
+  finishWebRuntimeSplitFocusRequest,
+  focusSplitWebRuntimeTerminalPane,
+  type WebRuntimeSplitSource
+} from './web-runtime-split-focus'
 
 const pendingWebRuntimeSplitMirrorTelemetry = new Map<string, Set<string>>()
 const WEB_RUNTIME_SPLIT_MIRROR_SUPPRESSION_TTL_MS = 30_000
@@ -21,7 +29,8 @@ let pendingWebRuntimeSplitMirrorTelemetryId = 0
 export function splitWebRuntimeTerminal(
   ptyId: string | null | undefined,
   direction: 'horizontal' | 'vertical',
-  telemetrySource: TerminalPaneSplitSource
+  telemetrySource: TerminalPaneSplitSource,
+  source?: WebRuntimeSplitSource
 ): boolean {
   if (!ptyId) {
     return false
@@ -39,19 +48,28 @@ export function splitWebRuntimeTerminal(
     direction,
     pendingMirrorSuppressionId
   )
-  void window.api.runtimeEnvironments
-    .call({
-      selector: environmentId,
-      method: 'terminal.split',
-      params: {
-        terminal: remote.handle,
-        direction,
-        telemetrySource
-      },
-      timeoutMs: 15_000
-    })
-    .then((response) => {
-      unwrapRuntimeRpcResult(response as RuntimeRpcResponse<{ split: RuntimeTerminalSplit }>)
+  const intentOwner = captureWebSessionIntentOwner(environmentId)
+  const focusTarget = source ? captureWebRuntimeSplitFocusTarget(ptyId, source) : null
+  const focusRequest = focusTarget
+    ? beginWebRuntimeSplitFocusRequest(intentOwner, focusTarget.worktreeId)
+    : null
+  void captureRuntimeEnvironmentCall(
+    environmentId,
+    intentOwner.pairingRevision
+  )({
+    method: 'terminal.split',
+    params: {
+      terminal: remote.handle,
+      direction,
+      telemetrySource
+    },
+    timeoutMs: 15_000
+  })
+    .then(async (response) => {
+      const result = unwrapRuntimeRpcResult(
+        response as RuntimeRpcResponse<{ split: RuntimeTerminalSplit }>
+      )
+      await focusSplitWebRuntimeTerminalPane(intentOwner, focusTarget, focusRequest, result?.split)
     })
     .catch((error) => {
       releasePendingMirrorSuppression()
@@ -61,6 +79,7 @@ export function splitWebRuntimeTerminal(
       toast.error(message)
       console.warn('[web-runtime-session] failed to split terminal:', message)
     })
+    .finally(() => finishWebRuntimeSplitFocusRequest(focusRequest))
   return true
 }
 

--- a/src/renderer/src/runtime/web-runtime-terminal-actions.ts
+++ b/src/renderer/src/runtime/web-runtime-terminal-actions.ts
@@ -50,8 +50,9 @@ export function splitWebRuntimeTerminal(
   )
   const intentOwner = captureWebSessionIntentOwner(environmentId)
   const focusTarget = source ? captureWebRuntimeSplitFocusTarget(ptyId, source) : null
-  const focusRequest = focusTarget
-    ? beginWebRuntimeSplitFocusRequest(intentOwner, focusTarget.worktreeId)
+  // Advance the fence for every source-bearing gesture, even when its pane metadata is stale.
+  const focusRequest = source
+    ? beginWebRuntimeSplitFocusRequest(intentOwner, source.worktreeId)
     : null
   void captureRuntimeEnvironmentCall(
     environmentId,

--- a/src/renderer/src/runtime/web-session-focus-intent.ts
+++ b/src/renderer/src/runtime/web-session-focus-intent.ts
@@ -164,10 +164,12 @@ export function clearWebSessionFocusIntent(owner: WebSessionIntentOwner, worktre
 export function clearWebSessionFocusIntentIfMatches(
   owner: WebSessionIntentOwner,
   worktreeId: string,
-  hostTabId: string
+  hostTabId: string,
+  leafId?: string
 ): void {
   const key = focusIntentPartitionKey(owner, worktreeId)
-  if (pendingFocusByOwnerAndWorktree.get(key)?.hostTabId === hostTabId) {
+  const intent = pendingFocusByOwnerAndWorktree.get(key)
+  if (intent?.hostTabId === hostTabId && (leafId === undefined || intent.leafId === leafId)) {
     pendingFocusByOwnerAndWorktree.delete(key)
   }
 }

--- a/src/renderer/src/runtime/web-session-tabs-sync-focus-intent.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-focus-intent.test.ts
@@ -691,4 +691,97 @@ describe('applyWebSessionTabsSnapshot', () => {
       SECOND_LEAF_ID
     )
   })
+
+  it('activates a host-created split leaf only for the client that requested it', () => {
+    const mirroredTabId = toWebTerminalSurfaceTabId('host-tab-1')
+    const sourceOnlyLayout = {
+      root: { type: 'leaf' as const, leafId: LEAF_ID },
+      activeLeafId: LEAF_ID,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [LEAF_ID]: 'remote:web-env-1@@terminal-1' }
+    }
+    const splitLayout = {
+      root: {
+        type: 'split' as const,
+        direction: 'vertical' as const,
+        first: { type: 'leaf' as const, leafId: LEAF_ID },
+        second: { type: 'leaf' as const, leafId: SECOND_LEAF_ID }
+      },
+      activeLeafId: SECOND_LEAF_ID,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [LEAF_ID]: 'remote:web-env-1@@terminal-1',
+        [SECOND_LEAF_ID]: 'remote:web-env-1@@terminal-2'
+      }
+    }
+    const state = makeState({
+      activeTabId: mirroredTabId,
+      activeTabIdByWorktree: { [WT]: mirroredTabId },
+      tabsByWorktree: {
+        [WT]: [
+          {
+            id: mirroredTabId,
+            ptyId: 'remote:web-env-1@@terminal-1',
+            worktreeId: WT,
+            title: 'shell',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: NOW
+          }
+        ]
+      },
+      terminalLayoutsByTabId: { [mirroredTabId]: sourceOnlyLayout }
+    })
+    const splitSnapshot = makeSnapshot([
+      {
+        type: 'terminal',
+        id: `host-tab-1::${LEAF_ID}`,
+        title: 'shell',
+        parentTabId: 'host-tab-1',
+        leafId: LEAF_ID,
+        parentLayout: splitLayout,
+        isActive: false,
+        status: 'ready',
+        terminal: 'terminal-1'
+      },
+      {
+        type: 'terminal',
+        id: `host-tab-1::${SECOND_LEAF_ID}`,
+        title: 'split',
+        parentTabId: 'host-tab-1',
+        leafId: SECOND_LEAF_ID,
+        parentLayout: splitLayout,
+        isActive: true,
+        status: 'ready',
+        terminal: 'terminal-2'
+      }
+    ])
+
+    const unclaimed = applyWebSessionTabsSnapshot(
+      state,
+      splitSnapshot,
+      ENV,
+      NOW + 10
+    ) as Partial<WebSessionTabsSyncState>
+    expect(unclaimed.terminalLayoutsByTabId?.[mirroredTabId]?.activeLeafId).toBe(LEAF_ID)
+
+    recordWebSessionFocusIntent({ environmentId: ENV }, WT, 'host-tab-1', SECOND_LEAF_ID)
+    const claimed = applyWebSessionTabsSnapshot(
+      state,
+      splitSnapshot,
+      ENV,
+      NOW + 20
+    ) as Partial<WebSessionTabsSyncState>
+    expect(claimed.terminalLayoutsByTabId?.[mirroredTabId]?.activeLeafId).toBe(SECOND_LEAF_ID)
+
+    recordWebSessionFocusIntent({ environmentId: 'web-env-2' }, WT, 'host-tab-1', SECOND_LEAF_ID)
+    const otherClient = applyWebSessionTabsSnapshot(
+      state,
+      splitSnapshot,
+      ENV,
+      NOW + 30
+    ) as Partial<WebSessionTabsSyncState>
+    expect(otherClient.terminalLayoutsByTabId?.[mirroredTabId]?.activeLeafId).toBe(LEAF_ID)
+  })
 })

--- a/src/shared/runtime-terminal-contracts.ts
+++ b/src/shared/runtime-terminal-contracts.ts
@@ -269,6 +269,8 @@ export type RuntimeTerminalSplit = {
   handle: string
   tabId: string
   paneRuntimeId: number
+  // Why: paired callers need the host-created leaf identity to focus the exact pane.
+  leafId?: string
 }
 
 export type RuntimeTerminalResolvePane = {

--- a/tests/e2e/helpers/paired-client-host-session.ts
+++ b/tests/e2e/helpers/paired-client-host-session.ts
@@ -1,0 +1,41 @@
+import type { Page } from '@stablyai/playwright-test'
+import { expect } from './orca-app'
+
+export async function callPairedRuntime<TResult>(
+  page: Page,
+  selector: string,
+  method: string,
+  params: unknown
+): Promise<TResult> {
+  return page.evaluate(
+    async ({ method, params, selector }) => {
+      const response = await window.api.runtimeEnvironments.call({ selector, method, params })
+      if (!response.ok) {
+        throw new Error(`${response.error.code}: ${response.error.message}`)
+      }
+      return response.result
+    },
+    { method, params, selector }
+  ) as Promise<TResult>
+}
+
+export async function waitForPairedClientWorktree(
+  page: Page,
+  expectedId?: string
+): Promise<string> {
+  const read = (): Promise<string | null> =>
+    page.evaluate(
+      (id) =>
+        window.__store
+          ?.getState()
+          .allWorktrees()
+          .find((worktree) => !id || worktree.id === id)?.id ?? null,
+      expectedId
+    )
+  await expect.poll(read, { timeout: 30_000 }).not.toBeNull()
+  const worktreeId = await read()
+  if (!worktreeId) {
+    throw new Error('Paired client did not receive the host workspace')
+  }
+  return worktreeId
+}

--- a/tests/e2e/helpers/terminal-pane-identity.ts
+++ b/tests/e2e/helpers/terminal-pane-identity.ts
@@ -3,6 +3,7 @@ import type { Page } from '@stablyai/playwright-test'
 export type PaneIdentitySnapshot = {
   tabId: string
   activeLeafId: string | null
+  storeActiveLeafId: string | null
   panes: {
     numericPaneId: number
     leafId: string
@@ -100,6 +101,7 @@ export async function readPaneIdentitySnapshot(page: Page): Promise<PaneIdentity
     return {
       tabId,
       activeLeafId: activePane?.leafId ?? null,
+      storeActiveLeafId: store.getState().terminalLayoutsByTabId[tabId]?.activeLeafId ?? null,
       panes: manager.getPanes().map((pane) => ({
         numericPaneId: pane.id,
         leafId: pane.leafId,

--- a/tests/e2e/helpers/terminal.ts
+++ b/tests/e2e/helpers/terminal.ts
@@ -49,11 +49,11 @@ export async function focusActiveTerminalInput(page: Page): Promise<void> {
           : null
     const manager = tabId ? window.__paneManagers?.get(tabId) : null
     const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
-    if (!pane) {
+    if (!state || !tabId || !pane) {
       throw new Error('No active terminal pane to focus')
     }
-    state?.setActiveTab(tabId)
-    state?.setActiveTabType('terminal')
+    state.setActiveTab(tabId)
+    state.setActiveTabType('terminal')
     pane.terminal.focus()
     const textarea = pane.container.querySelector(
       '.xterm-helper-textarea'

--- a/tests/e2e/helpers/terminal.ts
+++ b/tests/e2e/helpers/terminal.ts
@@ -99,29 +99,36 @@ export async function waitForPaneIdentitySnapshot(
   page: Page,
   paneCount: number
 ): Promise<PaneIdentitySnapshot> {
-  await expect
-    .poll(
-      async () => {
-        const snapshot = await readPaneIdentitySnapshot(page)
-        return Boolean(
-          snapshot &&
-          snapshot.panes.length === paneCount &&
-          snapshot.panes.every(
-            (pane) =>
-              UUID_RE.test(pane.leafId) &&
-              pane.stablePaneId === pane.leafId &&
-              pane.datasetLeafId === pane.leafId &&
-              pane.ptyId !== null &&
-              snapshot.ptyIdsByLeafId[pane.leafId] === pane.ptyId
+  let latestSnapshot: PaneIdentitySnapshot | null = null
+  try {
+    await expect
+      .poll(
+        async () => {
+          latestSnapshot = await readPaneIdentitySnapshot(page)
+          return Boolean(
+            latestSnapshot &&
+            latestSnapshot.panes.length === paneCount &&
+            latestSnapshot.panes.every(
+              (pane) =>
+                UUID_RE.test(pane.leafId) &&
+                pane.stablePaneId === pane.leafId &&
+                pane.datasetLeafId === pane.leafId &&
+                pane.ptyId !== null &&
+                latestSnapshot?.ptyIdsByLeafId[pane.leafId] === pane.ptyId
+            )
           )
-        )
-      },
-      {
-        timeout: 15_000,
-        message: 'Split terminal panes did not settle with UUID leaf-keyed PTY bindings'
-      }
-    )
-    .toBe(true)
+        },
+        {
+          timeout: 15_000,
+          message: 'Split terminal panes did not settle with UUID leaf-keyed PTY bindings'
+        }
+      )
+      .toBe(true)
+  } catch (error) {
+    throw new Error(`Last pane identity snapshot: ${JSON.stringify(latestSnapshot)}`, {
+      cause: error
+    })
+  }
 
   const snapshot = await readPaneIdentitySnapshot(page)
   if (!snapshot) {

--- a/tests/e2e/paired-remote-split-pane-focus.spec.ts
+++ b/tests/e2e/paired-remote-split-pane-focus.spec.ts
@@ -25,6 +25,8 @@ type HostTerminalSurface = {
   parentLayout?: { activeLeafId?: string | null }
 }
 
+const splitRightChord = process.platform === 'darwin' ? 'Meta+d' : 'Control+Shift+d'
+
 test('focuses the pane a client split creates on a paired remote workspace @headful', async ({
   orcaPage
 }, testInfo) => {
@@ -69,7 +71,7 @@ test('focuses the pane a client split creates on a paired remote workspace @head
     }
 
     await focusActiveTerminalInput(client.page)
-    await client.page.keyboard.press('Meta+d')
+    await client.page.keyboard.press(splitRightChord)
 
     let after = await waitForPaneIdentitySnapshot(client.page, 2)
     let createdPane = after.panes.find((pane) => pane.leafId !== sourceLeafId)

--- a/tests/e2e/paired-remote-split-pane-focus.spec.ts
+++ b/tests/e2e/paired-remote-split-pane-focus.spec.ts
@@ -118,7 +118,7 @@ test('focuses the pane a client split creates on a paired remote workspace @head
     expect(hostLeaves[0]?.parentLayout?.activeLeafId).toBe(createdPane.leafId)
 
     const marker = `STA_5518_FOCUSED_${Date.now()}`
-    await client.page.keyboard.insertText(`printf '%s\\n' ${JSON.stringify(marker)}`)
+    await client.page.keyboard.type(`printf '%s\\n' ${JSON.stringify(marker)}`)
     await client.page.keyboard.press('Enter')
 
     await expect

--- a/tests/e2e/paired-remote-split-pane-focus.spec.ts
+++ b/tests/e2e/paired-remote-split-pane-focus.spec.ts
@@ -88,7 +88,11 @@ test('focuses the pane a client split creates on a paired remote workspace @head
           }
           after = current
           createdPane = created
-          return current.activeLeafId === created.leafId && domLeafId === created.leafId
+          return (
+            current.activeLeafId === created.leafId &&
+            current.storeActiveLeafId === created.leafId &&
+            domLeafId === created.leafId
+          )
         },
         { timeout: 30_000, message: 'Host-created split leaf never claimed client focus' }
       )
@@ -105,20 +109,6 @@ test('focuses the pane a client split creates on a paired remote workspace @head
       () => document.activeElement?.closest<HTMLElement>('.pane')?.dataset.leafId ?? null
     )
     expect(focusedDomLeafId).toBe(createdPane.leafId)
-
-    const hostTabs = await callPairedRuntime<{ tabs: HostTerminalSurface[] }>(
-      client.page,
-      client.environmentId,
-      'session.tabs.list',
-      { worktree: `id:${hostWorktreeId}` }
-    )
-    const hostLeaves = hostTabs.tabs.filter(
-      (surface) => surface.type === 'terminal' && surface.parentTabId === created.tab.parentTabId
-    )
-    expect(hostLeaves.map((surface) => surface.leafId).sort()).toEqual(
-      after.panes.map((pane) => pane.leafId).sort()
-    )
-    expect(hostLeaves[0]?.parentLayout?.activeLeafId).toBe(createdPane.leafId)
 
     const marker = `STA_5518_FOCUSED_${Date.now()}`
     await client.page.keyboard.type(`printf '%s\\n' ${JSON.stringify(marker)}`)
@@ -139,6 +129,20 @@ test('focuses the pane a client split creates on a paired remote workspace @head
         { timeout: 30_000, message: 'Immediate post-split marker never reached the visible pane' }
       )
       .toMatchObject({ [createdLeafId]: expect.stringContaining(marker) })
+
+    const hostTabs = await callPairedRuntime<{ tabs: HostTerminalSurface[] }>(
+      client.page,
+      client.environmentId,
+      'session.tabs.list',
+      { worktree: `id:${hostWorktreeId}` }
+    )
+    const hostLeaves = hostTabs.tabs.filter(
+      (surface) => surface.type === 'terminal' && surface.parentTabId === created.tab.parentTabId
+    )
+    expect(hostLeaves.map((surface) => surface.leafId).sort()).toEqual(
+      after.panes.map((pane) => pane.leafId).sort()
+    )
+    expect(hostLeaves[0]?.parentLayout?.activeLeafId).toBe(createdPane.leafId)
 
     const surfaceByLeafId = new Map(hostLeaves.map((surface) => [surface.leafId, surface]))
     await expect
@@ -186,7 +190,11 @@ test('focuses the pane a client split creates on a paired remote workspace @head
           }
           afterHeaderSplit = current
           headerCreatedPane = created
-          return current.activeLeafId === created.leafId && domLeafId === created.leafId
+          return (
+            current.activeLeafId === created.leafId &&
+            current.storeActiveLeafId === created.leafId &&
+            domLeafId === created.leafId
+          )
         },
         { timeout: 30_000, message: 'Header-created split leaf never claimed client focus' }
       )
@@ -194,6 +202,26 @@ test('focuses the pane a client split creates on a paired remote workspace @head
     if (!headerCreatedPane) {
       throw new Error('Header split did not materialize a new pane')
     }
+    const headerCreatedLeafId = headerCreatedPane.leafId
+    const headerMarker = `STA_5518_HEADER_FOCUSED_${Date.now()}`
+    await client.page.keyboard.type(`printf '%s\\n' ${JSON.stringify(headerMarker)}`)
+    await client.page.keyboard.press('Enter')
+
+    await expect
+      .poll(
+        () =>
+          client.page.evaluate((tabId) => {
+            const manager = window.__paneManagers?.get(tabId)
+            return Object.fromEntries(
+              (manager?.getPanes() ?? []).map((pane) => [
+                pane.leafId,
+                pane.serializeAddon?.serialize?.() ?? ''
+              ])
+            )
+          }, webTabId),
+        { timeout: 30_000, message: 'Header split marker never reached the focused pane' }
+      )
+      .toMatchObject({ [headerCreatedLeafId]: expect.stringContaining(headerMarker) })
 
     const afterHeaderHostTabs = await callPairedRuntime<{ tabs: HostTerminalSurface[] }>(
       client.page,
@@ -208,6 +236,32 @@ test('focuses the pane a client split creates on a paired remote workspace @head
       afterHeaderSplit.panes.map((pane) => pane.leafId).sort()
     )
     expect(afterHeaderHostLeaves[0]?.parentLayout?.activeLeafId).toBe(headerCreatedPane.leafId)
+    const headerSurfaceByLeafId = new Map(
+      afterHeaderHostLeaves.map((surface) => [surface.leafId, surface])
+    )
+    await expect
+      .poll(
+        async () => {
+          const reads = await Promise.all(
+            afterHeaderSplit.panes.map(async ({ leafId }) => {
+              const surface = headerSurfaceByLeafId.get(leafId)
+              if (!surface) {
+                return false
+              }
+              const result = await callPairedRuntime<{ terminal: RuntimeTerminalRead }>(
+                client.page,
+                client.environmentId,
+                'terminal.read',
+                { terminal: surface.terminal }
+              )
+              return result.terminal.tail.join('\n').includes(headerMarker)
+            })
+          )
+          return reads
+        },
+        { timeout: 30_000, message: 'Header marker did not reach exactly its created host PTY' }
+      )
+      .toEqual(afterHeaderSplit.panes.map(({ leafId }) => leafId === headerCreatedLeafId))
 
     await testInfo.attach('paired-cmd-d-focused-pane', {
       body: await client.page.screenshot(),

--- a/tests/e2e/paired-remote-split-pane-focus.spec.ts
+++ b/tests/e2e/paired-remote-split-pane-focus.spec.ts
@@ -1,0 +1,216 @@
+import { toWebTerminalSurfaceTabId } from '../../src/shared/terminal-surface-id'
+import type { RuntimeTerminalRead } from '../../src/shared/runtime-types'
+import { expect, test } from './helpers/orca-app'
+import {
+  callPairedRuntime,
+  waitForPairedClientWorktree
+} from './helpers/paired-client-host-session'
+import { revealPairedClientWindow } from './helpers/paired-client-window-reveal'
+import {
+  createRuntimeDesktopPairingOffer,
+  launchPairedElectronClient
+} from './helpers/paired-electron-client'
+import {
+  focusActiveTerminalInput,
+  readPaneIdentitySnapshot,
+  waitForActivePanePtyId,
+  waitForPaneIdentitySnapshot
+} from './helpers/terminal'
+
+type HostTerminalSurface = {
+  type: 'terminal'
+  parentTabId: string
+  leafId: string
+  terminal: string
+  parentLayout?: { activeLeafId?: string | null }
+}
+
+test('focuses the pane a client split creates on a paired remote workspace @headful', async ({
+  orcaPage
+}, testInfo) => {
+  test.setTimeout(150_000)
+  const hostWorktreeId = await orcaPage.evaluate(() => window.__store?.getState().activeWorktreeId)
+  if (!hostWorktreeId) {
+    throw new Error('Headed host has no active seeded workspace')
+  }
+  const offer = await createRuntimeDesktopPairingOffer(orcaPage)
+  const client = await launchPairedElectronClient(offer, testInfo, 'paired-split-focus-client')
+  try {
+    await revealPairedClientWindow(client)
+    await waitForPairedClientWorktree(client.page, hostWorktreeId)
+
+    const created = await callPairedRuntime<{ tab: { parentTabId: string } }>(
+      client.page,
+      client.environmentId,
+      'session.tabs.createTerminal',
+      {
+        worktree: `id:${hostWorktreeId}`,
+        activate: false,
+        select: false,
+        navigation: 'caller'
+      }
+    )
+
+    const webTabId = toWebTerminalSurfaceTabId(created.tab.parentTabId)
+    await client.page.evaluate(
+      (id) => window.__store?.getState().setActiveWorktree(id),
+      hostWorktreeId
+    )
+    const tab = client.page.locator(`[data-testid="sortable-tab"][data-tab-id="${webTabId}"]`)
+    await expect(tab).toBeVisible({ timeout: 30_000 })
+    await tab.click()
+    await expect(tab).toHaveAttribute('data-active', 'true')
+
+    const sourcePtyId = await waitForActivePanePtyId(client.page, 30_000)
+    const before = await waitForPaneIdentitySnapshot(client.page, 1)
+    const sourceLeafId = before.activeLeafId
+    if (!sourceLeafId) {
+      throw new Error('Paired source pane has no stable leaf identity')
+    }
+
+    await focusActiveTerminalInput(client.page)
+    await client.page.keyboard.press('Meta+d')
+
+    let after = await waitForPaneIdentitySnapshot(client.page, 2)
+    let createdPane = after.panes.find((pane) => pane.leafId !== sourceLeafId)
+    await expect
+      .poll(
+        async () => {
+          const current = await readPaneIdentitySnapshot(client.page)
+          const created = current?.panes.find((pane) => pane.leafId !== sourceLeafId)
+          const domLeafId = await client.page.evaluate(
+            () => document.activeElement?.closest<HTMLElement>('.pane')?.dataset.leafId ?? null
+          )
+          if (!current || current.panes.length !== 2 || !created) {
+            return false
+          }
+          after = current
+          createdPane = created
+          return current.activeLeafId === created.leafId && domLeafId === created.leafId
+        },
+        { timeout: 30_000, message: 'Host-created split leaf never claimed client focus' }
+      )
+      .toBe(true)
+    if (!createdPane) {
+      throw new Error('Paired split did not materialize a new pane')
+    }
+    const focusedPtyId = await waitForActivePanePtyId(client.page, 30_000)
+    expect(focusedPtyId).toBe(createdPane.ptyId)
+    expect(focusedPtyId).not.toBe(sourcePtyId)
+
+    const focusedDomLeafId = await client.page.evaluate(
+      () => document.activeElement?.closest<HTMLElement>('.pane')?.dataset.leafId ?? null
+    )
+    expect(focusedDomLeafId).toBe(createdPane.leafId)
+
+    const hostTabs = await callPairedRuntime<{ tabs: HostTerminalSurface[] }>(
+      client.page,
+      client.environmentId,
+      'session.tabs.list',
+      { worktree: `id:${hostWorktreeId}` }
+    )
+    const hostLeaves = hostTabs.tabs.filter(
+      (surface) => surface.type === 'terminal' && surface.parentTabId === created.tab.parentTabId
+    )
+    expect(hostLeaves.map((surface) => surface.leafId).sort()).toEqual(
+      after.panes.map((pane) => pane.leafId).sort()
+    )
+    expect(hostLeaves[0]?.parentLayout?.activeLeafId).toBe(createdPane.leafId)
+
+    const marker = `STA_5518_FOCUSED_${Date.now()}`
+    await client.page.keyboard.insertText(`printf '%s\\n' ${JSON.stringify(marker)}`)
+    await client.page.keyboard.press('Enter')
+
+    await expect
+      .poll(
+        () =>
+          client.page.evaluate((tabId) => {
+            const manager = window.__paneManagers?.get(tabId)
+            return Object.fromEntries(
+              (manager?.getPanes() ?? []).map((pane) => [
+                pane.leafId,
+                pane.serializeAddon?.serialize?.() ?? ''
+              ])
+            )
+          }, webTabId),
+        { timeout: 30_000, message: 'Immediate post-split marker never reached the visible pane' }
+      )
+      .toMatchObject({ [createdPane.leafId]: expect.stringContaining(marker) })
+
+    const surfaceByLeafId = new Map(hostLeaves.map((surface) => [surface.leafId, surface]))
+    await expect
+      .poll(
+        async () => {
+          const reads = await Promise.all(
+            [sourceLeafId, createdPane.leafId].map(async (leafId) => {
+              const surface = surfaceByLeafId.get(leafId)
+              if (!surface) {
+                return false
+              }
+              const result = await callPairedRuntime<{ terminal: RuntimeTerminalRead }>(
+                client.page,
+                client.environmentId,
+                'terminal.read',
+                { terminal: surface.terminal }
+              )
+              return result.terminal.tail.join('\n').includes(marker)
+            })
+          )
+          return reads
+        },
+        { timeout: 30_000, message: 'Host PTY output did not identify one marker destination' }
+      )
+      .toEqual([false, true])
+
+    const headerSplit = client.page.locator(
+      'button[data-contextual-tour-target="terminal-pane-split-target"]'
+    )
+    await expect(headerSplit).toBeVisible()
+    await headerSplit.click()
+    let afterHeaderSplit = await waitForPaneIdentitySnapshot(client.page, 3)
+    const priorLeafIds = new Set(after.panes.map((pane) => pane.leafId))
+    let headerCreatedPane = afterHeaderSplit.panes.find((pane) => !priorLeafIds.has(pane.leafId))
+    await expect
+      .poll(
+        async () => {
+          const current = await readPaneIdentitySnapshot(client.page)
+          const created = current?.panes.find((pane) => !priorLeafIds.has(pane.leafId))
+          const domLeafId = await client.page.evaluate(
+            () => document.activeElement?.closest<HTMLElement>('.pane')?.dataset.leafId ?? null
+          )
+          if (!current || current.panes.length !== 3 || !created) {
+            return false
+          }
+          afterHeaderSplit = current
+          headerCreatedPane = created
+          return current.activeLeafId === created.leafId && domLeafId === created.leafId
+        },
+        { timeout: 30_000, message: 'Header-created split leaf never claimed client focus' }
+      )
+      .toBe(true)
+    if (!headerCreatedPane) {
+      throw new Error('Header split did not materialize a new pane')
+    }
+
+    const afterHeaderHostTabs = await callPairedRuntime<{ tabs: HostTerminalSurface[] }>(
+      client.page,
+      client.environmentId,
+      'session.tabs.list',
+      { worktree: `id:${hostWorktreeId}` }
+    )
+    const afterHeaderHostLeaves = afterHeaderHostTabs.tabs.filter(
+      (surface) => surface.type === 'terminal' && surface.parentTabId === created.tab.parentTabId
+    )
+    expect(afterHeaderHostLeaves.map((surface) => surface.leafId).sort()).toEqual(
+      afterHeaderSplit.panes.map((pane) => pane.leafId).sort()
+    )
+    expect(afterHeaderHostLeaves[0]?.parentLayout?.activeLeafId).toBe(headerCreatedPane.leafId)
+
+    await testInfo.attach('paired-cmd-d-focused-pane', {
+      body: await client.page.screenshot(),
+      contentType: 'image/png'
+    })
+  } finally {
+    await client.dispose()
+  }
+})

--- a/tests/e2e/paired-remote-split-pane-focus.spec.ts
+++ b/tests/e2e/paired-remote-split-pane-focus.spec.ts
@@ -96,6 +96,7 @@ test('focuses the pane a client split creates on a paired remote workspace @head
     if (!createdPane) {
       throw new Error('Paired split did not materialize a new pane')
     }
+    const createdLeafId = createdPane.leafId
     const focusedPtyId = await waitForActivePanePtyId(client.page, 30_000)
     expect(focusedPtyId).toBe(createdPane.ptyId)
     expect(focusedPtyId).not.toBe(sourcePtyId)
@@ -137,14 +138,14 @@ test('focuses the pane a client split creates on a paired remote workspace @head
           }, webTabId),
         { timeout: 30_000, message: 'Immediate post-split marker never reached the visible pane' }
       )
-      .toMatchObject({ [createdPane.leafId]: expect.stringContaining(marker) })
+      .toMatchObject({ [createdLeafId]: expect.stringContaining(marker) })
 
     const surfaceByLeafId = new Map(hostLeaves.map((surface) => [surface.leafId, surface]))
     await expect
       .poll(
         async () => {
           const reads = await Promise.all(
-            [sourceLeafId, createdPane.leafId].map(async (leafId) => {
+            [sourceLeafId, createdLeafId].map(async (leafId) => {
               const surface = surfaceByLeafId.get(leafId)
               if (!surface) {
                 return false


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1212 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​46 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1166 |
| Prod | 16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​260 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​44 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​216 |

<!-- /orca-pr-loc -->

## ELI5

In a paired remote workspace, Orca asked the host to split the terminal but never told the initiating viewer which exact pane to focus. The new pane appeared while typing stayed in the source pane.

This change makes the host return the authoritative new leaf identity, records that exact viewer-local focus intent, replays the mirrored layout behind the intent, and focuses the materialized pane without letting delayed responses pull the user back after they switch away.

## What Changed

- Add an optional `leafId` to `RuntimeTerminalSplit` for mixed-version compatibility.
- Return the already-authoritative leaf for PTY-backed splits.
- Pre-mint and propagate the exact leaf for renderer-backed splits, then wait for that leaf rather than the first new leaf observed.
- Fence paired split RPCs to the captured pairing revision.
- Resolve the actual source tab/leaf from its remote PTY, separately capture the viewer's current focus address, and claim focus only while that address is still current. This preserves splits invoked from non-focused group columns.
- Record the exact split focus intent before replaying the session-tabs snapshot, then issue the existing durable PaneManager focus request.
- Add deterministic runtime, renderer, compatibility, two-viewer, reconnect/reorder, local-path, and headed paired-Electron coverage.

## Why

The remote path short-circuits before the synchronous local split-and-focus helper. Its pane arrives later through session-tabs reconciliation, where snapshot precedence intentionally preserves the viewer's existing active leaf unless that viewer recorded an explicit focus intent. That precedence prevents host status echoes from stealing focus (#5435), so changing it globally would fix this symptom at the wrong boundary.

The split initiator did not have the new leaf identity needed to make that claim. Returning the exact host leaf fixes the authority gap. Pre-minting the renderer-backed leaf also avoids the concurrent identity race in a "first newly observed leaf" heuristic.

Old hosts omit `leafId`, so new clients safely retain source focus rather than guessing. Old clients ignore the optional field. No new opcode or protocol capability is required.

This is intended to supersede #16513: it keeps the same optional-leaf/focus-intent direction while using exact concurrent identity, a durable local focus handoff, current-main coverage, and explicit stale-viewer guards.

## Linked Issue

Fixes #16510

Linear: [STA-5518](https://linear.app/stably/issue/STA-5518/bug-cmdd-split-in-a-paired-remote-session-leaves-focus-on-the-source)

## Visual Proof

Before — the split exists, but the source pane still owns the cursor:

![Before: source pane remains focused](https://github.com/user-attachments/assets/db8fd434-4abc-4d20-b8ff-d507edaeeadb)

After — immediate marker input appears in the newly focused pane:

![After: new pane focused with marker output](https://github.com/user-attachments/assets/f48f87fb-0cb0-459f-9db3-116f4951431f)

Both images come from the same headed paired-Electron oracle. With the focus handoff disabled, it fails with `Host-created split leaf never claimed client focus`; with this commit, it passes and confirms the marker exists only in the new host PTY.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Validated on macOS with separate isolated headed Electron host/client processes:

- `pnpm tc`
- `pnpm run check:code-quality:changed` — zero findings across 13 files
- 33 focused renderer/runtime authority tests
- 2 exact split tests from `orca-runtime.test.ts` (1,210 unrelated cases skipped; the full 1,212-case file passed earlier in this investigation)
- `pnpm exec electron-vite build --mode e2e`
- headed `paired-remote-split-pane-focus.spec.ts` — literal `Meta+d`, pane-header split, host/client leaf equality, DOM focus, and immediate PTY marker routing
- same E2E with the focus handoff disabled — deterministic red negative control
- `git diff --check`

Not physically exercised on Windows/Linux or two separate Macs. The implementation is platform-neutral TypeScript and changes no key handling, paths, shells, processes, or native modules. SSH provider panes do not enter this paired-runtime delegation path. Folder workspaces remain workspace-kind agnostic.

## Review

Readiness audit found no P0/P1/P2 issues after hardening two timing edges:

- a re-pair while snapshot replay is in flight cannot issue stale local focus;
- a delayed split completion cannot steal focus after the viewer changes worktree, execution host, tab, or pane.
- a split invoked from a non-focused tab group still focuses its exact new pane when the viewer has not moved elsewhere since the gesture.

No dependencies, persistence schemas, destructive paths, mobile UI, subprocesses, polling loops, or unbounded collections changed. The one added session-tabs refresh occurs only after an explicit split gesture and closes the publication-before-RPC race.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: no new input or network surface; one optional result field on an existing RPC.
- Backward compatibility: old-host omission and old-client ignore behavior are explicit and tested.
- Performance: one bounded snapshot refresh per user-initiated paired split; no hot-path polling or fanout.
- Multi-client: focus intent remains viewer-local and cannot change another viewer's active leaf.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Typecheck, targeted tests, changed-code quality, E2E build, and headed Electron validation pass; CI will cover the full repository matrix
