### PR TITLE
fix(relay): reap owned PTYs when the daemon dies on an uncaught exception (STA-5697)

### DIFF
--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -2474,14 +2474,23 @@ export class PtyHandler {
     }
   }
 
+  /**
+   * Reap every owned PTY synchronously, for the fatal-exit path only.
+   *
+   * Runs to completion across all PTYs: one shell that refuses to die must not
+   * strand the rest. The first failure is rethrown so the caller can record it --
+   * a reap that failed on a remote host is otherwise invisible.
+   */
   forceKillAllPtyProcesses(): void {
     let firstError: unknown
     let hasError = false
     for (const managed of this.ptys.values()) {
       try {
+        // Why mark rather than skip: the job already took the whole tree, and the
+        // flag is what suppresses the redundant signal -- here in requestForceKill,
+        // and in any dispose that still runs after this.
         if (process.platform === 'win32' && terminatePtyJob(managed.pty) === 'terminated') {
           managed.forceKillSent = true
-          continue
         }
         this.requestForceKill(managed)
       } catch (error) {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -49,6 +49,7 @@ import {
 import { isTuiAgent } from '../shared/tui-agent-config'
 import type { TuiAgent } from '../shared/tui-agent'
 import { forceKillPosixPtyProcessGroups } from '../main/pty/posix-pty-process-groups'
+import { terminatePtyJob } from '../main/windows/windows-pty-job'
 import { stripInheritedBuildModeEnv } from '../main/pty/build-mode-env'
 import { stripLegacyTerminalShimEnv } from '../main/pty/legacy-terminal-shim-dir'
 import { dropIncoherentCondaActivationEnv } from '../main/pty/conda-activation-env'
@@ -2470,6 +2471,28 @@ export class PtyHandler {
     if (this.graceTimer) {
       clearTimeout(this.graceTimer)
       this.graceTimer = null
+    }
+  }
+
+  forceKillAllPtyProcesses(): void {
+    let firstError: unknown
+    let hasError = false
+    for (const managed of this.ptys.values()) {
+      try {
+        if (process.platform === 'win32' && terminatePtyJob(managed.pty) === 'terminated') {
+          managed.forceKillSent = true
+          continue
+        }
+        this.requestForceKill(managed)
+      } catch (error) {
+        if (!hasError) {
+          firstError = error
+          hasError = true
+        }
+      }
+    }
+    if (hasError) {
+      throw firstError
     }
   }
 

--- a/src/relay/relay-daemon-fatal-reap.test.ts
+++ b/src/relay/relay-daemon-fatal-reap.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PtyHandler } from './pty-handler'
+
+const daemonMocks = vi.hoisted(() => ({
+  dispatcher: null as unknown,
+  runtimePtyHandler: null as unknown,
+  mockCreateShellPromptReadinessProbe: vi.fn(),
+  mockPtySpawn: vi.fn(),
+  socketCleanup: vi.fn()
+}))
+
+vi.mock('node-pty', () => ({ spawn: daemonMocks.mockPtySpawn }))
+
+vi.mock('../main/shell-prompt-readiness-probe', () => ({
+  createShellPromptReadinessProbe: daemonMocks.mockCreateShellPromptReadinessProbe
+}))
+
+vi.mock('../main/pty/posix-pty-process-groups', () => ({
+  forceKillPosixPtyProcessGroups: vi.fn((_pid: number, fallback: () => void) => fallback())
+}))
+
+vi.mock('./relay-diagnostic-log', () => ({ relayLogLine: vi.fn() }))
+vi.mock('./relay-handshake', () => ({ readLaunchVersion: vi.fn(() => 'test-version') }))
+
+vi.mock('./relay-primary-channel', () => ({
+  RelayPrimaryChannel: class {
+    readonly dispatcher = daemonMocks.dispatcher
+    readonly isAlive = true
+    detachInput(): void {}
+    startOutputFailureHandling(): void {}
+    startInput(): void {}
+    writeSentinel(): void {}
+    detachPrimaryClient(): void {}
+  }
+}))
+
+vi.mock('./relay-runtime-services', async () => {
+  const { PtyHandler: ActualPtyHandler } = (await vi.importActual('./pty-handler')) as {
+    PtyHandler: new (dispatcher: never) => PtyHandler
+  }
+  return {
+    RelayRuntimeServices: class {
+      readonly ptyHandler = new ActualPtyHandler(daemonMocks.dispatcher as never)
+      readonly ptyConsumerSessionAdapter = { getDebugSnapshot: vi.fn() }
+      readonly ptySourcePublication = { getDebugSnapshot: vi.fn() }
+      constructor() {
+        daemonMocks.runtimePtyHandler = this.ptyHandler
+      }
+      async disposeOwnedProcesses(): Promise<void> {}
+      disposeHandlers(): void {}
+    }
+  }
+})
+
+vi.mock('./relay-agent-hook-runtime', () => ({
+  RelayAgentHookRuntime: class {
+    async start(): Promise<void> {}
+    publishEndpointFile(): void {}
+    stop(): void {}
+  }
+}))
+
+vi.mock('./relay-socket-ownership', () => ({
+  RelaySocketOwnership: class {
+    readonly owned = false
+    readonly server = null
+    cleanup(): void {
+      daemonMocks.socketCleanup()
+    }
+    closeAndCleanup(): void {}
+  }
+}))
+
+vi.mock('./relay-reconnect-listener', () => ({
+  RelayReconnectListener: class {
+    readonly clientCount = 0
+    readonly hasAcceptedClient = false
+    readonly acceptedConnections = 0
+    async start(): Promise<void> {}
+  }
+}))
+
+vi.mock('./relay-grace-lifecycle', () => ({
+  RelayGraceLifecycle: class {
+    readonly deadlineAt = null
+    readonly reason = null
+    cancel(): void {}
+    start(): void {}
+    installProcessLifecycle(): void {}
+  }
+}))
+
+import { createMockDispatcher } from './pty-handler-test-harness'
+import { runRelayDaemon } from './relay-daemon'
+import { __setConptyJobNativeForTests } from '../main/windows/windows-pty-job'
+
+describe('relay daemon fatal PTY reap', () => {
+  let originalPlatform: PropertyDescriptor | undefined
+  let originalUncaughtListeners: Set<NodeJS.UncaughtExceptionListener>
+  let originalRejectionListeners: Set<NodeJS.UnhandledRejectionListener>
+
+  beforeEach(() => {
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    originalUncaughtListeners = new Set(process.listeners('uncaughtException'))
+    originalRejectionListeners = new Set(process.listeners('unhandledRejection'))
+    daemonMocks.dispatcher = createMockDispatcher()
+    daemonMocks.runtimePtyHandler = null
+    daemonMocks.mockPtySpawn.mockReset()
+    daemonMocks.mockCreateShellPromptReadinessProbe.mockReset()
+    daemonMocks.mockCreateShellPromptReadinessProbe.mockReturnValue({
+      notifyOutput: vi.fn(),
+      dispose: vi.fn()
+    })
+    daemonMocks.socketCleanup.mockReset()
+  })
+
+  afterEach(async () => {
+    for (const listener of process.listeners('uncaughtException')) {
+      if (!originalUncaughtListeners.has(listener)) {
+        process.removeListener('uncaughtException', listener)
+      }
+    }
+    for (const listener of process.listeners('unhandledRejection')) {
+      if (!originalRejectionListeners.has(listener)) {
+        process.removeListener('unhandledRejection', listener)
+      }
+    }
+    const handler = daemonMocks.runtimePtyHandler as PtyHandler | null
+    await handler?.dispose({ waitForPhysicalExit: false }).catch(() => {})
+    __setConptyJobNativeForTests()
+    vi.restoreAllMocks()
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  })
+
+  it('synchronously reaps every Windows PTY job before fatal exit', async () => {
+    const firstKill = vi.fn(() => {
+      throw new Error('ConPTY close failed')
+    })
+    const secondKill = vi.fn()
+    daemonMocks.mockPtySpawn
+      .mockReturnValueOnce(createMockPty(11, 101, firstKill))
+      .mockReturnValueOnce(createMockPty(22, 202, secondKill))
+    const terminateJob = vi.fn((id: number) => id === 22)
+    __setConptyJobNativeForTests(() => ({
+      terminateJob,
+      listJobProcessIds: vi.fn(),
+      assignCurrentProcessToJob: vi.fn()
+    }))
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+
+    await runRelayDaemon(
+      {
+        graceTimeMs: 0,
+        connectMode: false,
+        detached: false,
+        cliMode: false,
+        sockPath: 'relay-test-socket'
+      },
+      undefined
+    )
+    const dispatcher = daemonMocks.dispatcher as ReturnType<typeof createMockDispatcher>
+    await dispatcher.callRequest('pty.spawn', {})
+    await dispatcher.callRequest('pty.spawn', {})
+    const fatalListener = process
+      .listeners('uncaughtException')
+      .find((listener) => !originalUncaughtListeners.has(listener))
+
+    expect(fatalListener).toBeDefined()
+    fatalListener!(new Error('relay crashed'), 'uncaughtException')
+
+    expect(terminateJob.mock.calls).toEqual([
+      [11, 101],
+      [22, 202]
+    ])
+    expect(firstKill).toHaveBeenCalledOnce()
+    expect(firstKill.mock.calls[0]).toEqual([])
+    expect(secondKill).not.toHaveBeenCalled()
+    expect(daemonMocks.socketCleanup).toHaveBeenCalledOnce()
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+})
+
+function createMockPty(id: number, pid: number, kill: ReturnType<typeof vi.fn>) {
+  return {
+    _pty: id,
+    pid,
+    process: 'cmd.exe',
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill,
+    clear: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn()
+  }
+}

--- a/src/relay/relay-daemon-fatal-reap.test.ts
+++ b/src/relay/relay-daemon-fatal-reap.test.ts
@@ -6,7 +6,9 @@ const daemonMocks = vi.hoisted(() => ({
   runtimePtyHandler: null as unknown,
   mockCreateShellPromptReadinessProbe: vi.fn(),
   mockPtySpawn: vi.fn(),
-  socketCleanup: vi.fn()
+  socketCleanup: vi.fn(),
+  relayLogLine: vi.fn(),
+  forceKillPosixPtyProcessGroups: vi.fn((_pid: number, fallback: () => void) => fallback())
 }))
 
 vi.mock('node-pty', () => ({ spawn: daemonMocks.mockPtySpawn }))
@@ -16,10 +18,10 @@ vi.mock('../main/shell-prompt-readiness-probe', () => ({
 }))
 
 vi.mock('../main/pty/posix-pty-process-groups', () => ({
-  forceKillPosixPtyProcessGroups: vi.fn((_pid: number, fallback: () => void) => fallback())
+  forceKillPosixPtyProcessGroups: daemonMocks.forceKillPosixPtyProcessGroups
 }))
 
-vi.mock('./relay-diagnostic-log', () => ({ relayLogLine: vi.fn() }))
+vi.mock('./relay-diagnostic-log', () => ({ relayLogLine: daemonMocks.relayLogLine }))
 vi.mock('./relay-handshake', () => ({ readLaunchVersion: vi.fn(() => 'test-version') }))
 
 vi.mock('./relay-primary-channel', () => ({
@@ -101,7 +103,6 @@ describe('relay daemon fatal PTY reap', () => {
 
   beforeEach(() => {
     originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
-    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     originalUncaughtListeners = new Set(process.listeners('uncaughtException'))
     originalRejectionListeners = new Set(process.listeners('unhandledRejection'))
     daemonMocks.dispatcher = createMockDispatcher()
@@ -113,7 +114,13 @@ describe('relay daemon fatal PTY reap', () => {
       dispose: vi.fn()
     })
     daemonMocks.socketCleanup.mockReset()
+    daemonMocks.relayLogLine.mockReset()
+    daemonMocks.forceKillPosixPtyProcessGroups.mockClear()
   })
+
+  function usePlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  }
 
   afterEach(async () => {
     for (const listener of process.listeners('uncaughtException')) {
@@ -136,6 +143,7 @@ describe('relay daemon fatal PTY reap', () => {
   })
 
   it('synchronously reaps every Windows PTY job before fatal exit', async () => {
+    usePlatform('win32')
     const firstKill = vi.fn(() => {
       throw new Error('ConPTY close failed')
     })
@@ -178,6 +186,70 @@ describe('relay daemon fatal PTY reap', () => {
     expect(firstKill).toHaveBeenCalledOnce()
     expect(firstKill.mock.calls[0]).toEqual([])
     expect(secondKill).not.toHaveBeenCalled()
+    expect(daemonMocks.socketCleanup).toHaveBeenCalledOnce()
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+
+  async function bootDaemonWithTwoPtys(
+    firstKill: ReturnType<typeof vi.fn>,
+    secondKill: ReturnType<typeof vi.fn>
+  ) {
+    daemonMocks.mockPtySpawn
+      .mockReturnValueOnce(createMockPty(11, 101, firstKill))
+      .mockReturnValueOnce(createMockPty(22, 202, secondKill))
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+    await runRelayDaemon(
+      {
+        graceTimeMs: 0,
+        connectMode: false,
+        detached: false,
+        cliMode: false,
+        sockPath: 'relay-test-socket'
+      },
+      undefined
+    )
+    const dispatcher = daemonMocks.dispatcher as ReturnType<typeof createMockDispatcher>
+    await dispatcher.callRequest('pty.spawn', {})
+    await dispatcher.callRequest('pty.spawn', {})
+    const fatalListener = process
+      .listeners('uncaughtException')
+      .find((listener) => !originalUncaughtListeners.has(listener))
+    expect(fatalListener).toBeDefined()
+    return { exit, crash: () => fatalListener!(new Error('relay crashed'), 'uncaughtException') }
+  }
+
+  it('reaps every POSIX PTY process group before fatal exit', async () => {
+    usePlatform('linux')
+    const firstKill = vi.fn()
+    const secondKill = vi.fn()
+
+    const { exit, crash } = await bootDaemonWithTwoPtys(firstKill, secondKill)
+    crash()
+
+    // Why the group, not the pid: a shell setpgid's its children away from the root.
+    expect(daemonMocks.forceKillPosixPtyProcessGroups.mock.calls.map(([pid]) => pid)).toEqual([
+      101, 202
+    ])
+    expect(firstKill.mock.calls).toEqual([['SIGKILL']])
+    expect(secondKill.mock.calls).toEqual([['SIGKILL']])
+    expect(daemonMocks.socketCleanup).toHaveBeenCalledOnce()
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+
+  it('reaps past a failing PTY and records the failure instead of exiting silently', async () => {
+    usePlatform('linux')
+    const firstKill = vi.fn(() => {
+      throw new Error('SIGKILL refused')
+    })
+    const secondKill = vi.fn()
+
+    const { exit, crash } = await bootDaemonWithTwoPtys(firstKill, secondKill)
+    crash()
+
+    expect(secondKill.mock.calls).toEqual([['SIGKILL']])
+    expect(daemonMocks.relayLogLine.mock.calls.map(([line]) => String(line)).join('\n')).toContain(
+      '[relay] Fatal PTY reap failed: SIGKILL refused'
+    )
     expect(daemonMocks.socketCleanup).toHaveBeenCalledOnce()
     expect(exit).toHaveBeenCalledWith(1)
   })

--- a/src/relay/relay-daemon.ts
+++ b/src/relay/relay-daemon.ts
@@ -20,8 +20,14 @@ export async function runRelayDaemon(
   }
 
   const socketOwnership = new RelaySocketOwnership(options.sockPath)
+  let fatalPtyHandler: RelayRuntimeServices['ptyHandler'] | null = null
   process.on('uncaughtException', (error) => {
     relayLogLine(`[relay] Uncaught exception: ${error.message}\n${error.stack}`)
+    try {
+      fatalPtyHandler?.forceKillAllPtyProcesses()
+    } catch {
+      // Exit must win over best-effort reap failure.
+    }
     socketOwnership.cleanup()
     process.exit(1)
   })
@@ -36,6 +42,7 @@ export async function runRelayDaemon(
     options.graceTimeMs,
     launchVersion
   )
+  fatalPtyHandler = runtime.ptyHandler
   let reconnectListener: RelayReconnectListener | null = null
   const agentHooks = new RelayAgentHookRuntime(
     primaryChannel.dispatcher,

--- a/src/relay/relay-daemon.ts
+++ b/src/relay/relay-daemon.ts
@@ -25,8 +25,12 @@ export async function runRelayDaemon(
     relayLogLine(`[relay] Uncaught exception: ${error.message}\n${error.stack}`)
     try {
       fatalPtyHandler?.forceKillAllPtyProcesses()
-    } catch {
-      // Exit must win over best-effort reap failure.
+    } catch (reapError) {
+      // Why log rather than swallow: exit must still win, but this line is the only
+      // forensic trace a crashed remote daemon leaves behind for an orphaned shell.
+      relayLogLine(
+        `[relay] Fatal PTY reap failed: ${reapError instanceof Error ? reapError.message : String(reapError)}`
+      )
     }
     socketOwnership.cleanup()
     process.exit(1)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​272 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​272 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |

<!-- /orca-pr-loc -->

## In plain terms

You have terminals open on a remote machine over SSH. Orca runs a small helper program on that machine to look after them.

If that helper hit an unexpected error, it quit — and **left your terminal programs running**. Orca could no longer see or control them, but they were still there: still running, still holding your project folder open, still using the machine. You'd have no way to notice except that things gradually got slower and messier.

This makes the helper shut your terminals down on its way out, instead of walking away and leaving them behind.

**What you'll notice:** nothing, when things are working. That's the point — after a crash, the leftovers you never knew about simply aren't there any more.

## How the three PRs fit together

The original report (STA-5698) was: after the remote helper restarts, Orca might start your AI agent a **second time** while the first one is still running — two agents editing the same files at once.

That needs two ingredients:

1. **Leftover programs that survive the helper's death** — otherwise there's no first agent left to collide with.
2. **Orca being unable to tell whether a remembered terminal name still means the same terminal** — otherwise it wouldn't get confused in the first place.

These three PRs remove both ingredients rather than trying to detect the collision afterwards:

| | Removes | Covers |
| --- | --- | --- |
| **#16894** | ingredient 1 | the helper crashing on an error |
| **#16895** | ingredient 1 | the helper being force-killed, running out of memory, or losing power — Windows only, where the OS doesn't clean up for us |
| **#16901** | ingredient 2 | terminal names that restart from 1 and get reused |

Each stands alone and they can land in any order.

**Why not just detect the collision?** That was the first attempt (#16843, now closed). It tried to work out "has the helper been replaced?" by comparing how long it had been running against when Orca last saw the terminal. It couldn't tell a helper *restart* apart from the whole machine having *rebooted* — and after a reboot nothing survives, so there's nothing to protect against. It would have refused to restore your agent in a case that was completely safe. A live reproduction also failed to produce the collision at all on Linux: killing the helper took the agent down with it in 0.3 seconds.

So: prevent the leftovers, fix the names, and the problem doesn't arise instead of being guessed at.

---

Fixes STA-5697.

## The bug

`src/relay/relay-daemon.ts` installs an `uncaughtException` handler that logs, cleans up the socket, and calls `process.exit(1)`. It never disposes the PTYs the relay owns — even though the teardown already exists and is used on every other exit path (`PtyHandler.dispose()` → `disposePtys()`).

So a relay that crashes leaves every shell it owned behind.

## Why it matters, measured

**On Windows it orphans.** On build 26200, after `taskkill /F` of a process owning a ConPTY, the shell died but a descendant survived. Windows has no SIGHUP-on-master-close semantics, and the per-PTY job is deliberately *not* kill-on-close (its comment explains why: with that flag, typing `exit` in a pane also reaped whatever the user had backgrounded).

**On Linux it usually doesn't** — closing the pty master delivers SIGHUP and the shell and its agent die, measured at 0.3s in a live SSH repro. But the crash path must not depend on that being true for every shell, every agent, and every platform.

## The fix

A bounded, synchronous, best-effort reap on the fatal path before `process.exit(1)`.

- **Synchronous by necessity.** The handler runs in an already-broken process, so `dispose()` — which is async and waits for physical exit — is the wrong tool. This uses the existing synchronous primitives instead.
- **The handler stays where it is,** installed before `RelayRuntimeServices` is constructed so an exception during construction is still caught. A mutable holder is set once the runtime exists; the reap is a no-op until then.
- **Wrapped in try/catch** so a failure to reap can never prevent the exit.
- **`unhandledRejection` deliberately unchanged.** It logs and does not exit, so the process keeps running and its PTYs must keep running with it.

### One correction to the original design

The task described reusing `killPtyProcess(pty, 'SIGKILL')`, whose win32 branch calls `pty.kill()`. That is not sufficient: **`pty.kill()` does not terminate the non-kill-on-close per-PTY job**, so the descendants that actually orphan on Windows would have survived. The implementation uses `terminatePtyJob` first — which is exact, because job membership is the kernel's answer rather than a pid walk — and falls back to the POSIX group kill path only when that is unavailable.

## Tests

`src/relay/relay-daemon-fatal-reap.test.ts` asserts the derived behaviour: that the owned PTYs are actually killed on the fatal path. It was confirmed red before the production change (expected the Windows job kills, received `[]`) and green after.

## Verification

`pnpm tc`, `npx oxlint` on the changed files, the new test file, and `pnpm oxfmt` all pass. Integrated with the sibling Windows PR, `pnpm build:relay` succeeds and the relay suite shows no new failures — the two that fail (`pty-handler-spawn-environment`, `pty-handler-startup-command-delivery`) fail identically on `origin/main`.

## Relationship to the other relay PRs

This removes the orphan on paths that *run a handler*. Its sibling covers deaths that run nothing at all (`taskkill /F`, OOM) by putting the relay in a kill-on-close job. They are independent and can land in either order.
