### PR TITLE
Preserve legacy daemon ownership when liveness is unavailable

### DIFF
--- a/src/main/daemon/daemon-init-provider-installation.test.ts
+++ b/src/main/daemon/daemon-init-provider-installation.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProcessLivenessVerdict } from './daemon-incarnation-evidence-types'
 
 const {
   isPackagedMock,
@@ -317,12 +318,165 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(legacyUnlinks).toEqual([])
   })
 
+  it('keeps legacy daemon ownership files when pid liveness is unverifiable', async () => {
+    const mod = await importFresh()
+    readFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    })
+
+    await mod.initDaemonPtyProvider()
+
+    const legacyUnlinks = unlinkSyncMock.mock.calls.filter(
+      ([p]) => typeof p === 'string' && (p.includes('.token') || p.includes('.pid'))
+    )
+    expect(legacyUnlinks).toEqual([])
+  })
+
+  it('keeps legacy daemon ownership files when the pid record is unparseable', async () => {
+    const mod = await importFresh()
+    readFileSyncMock.mockReturnValue('not a daemon pid record')
+    parseDaemonPidFileMock.mockReturnValue(null)
+
+    await mod.initDaemonPtyProvider()
+
+    const legacyUnlinks = unlinkSyncMock.mock.calls.filter(
+      ([p]) => typeof p === 'string' && (p.includes('.token') || p.includes('.pid'))
+    )
+    expect(legacyUnlinks).toEqual([])
+  })
+
+  it('keeps legacy daemon ownership files when the pid probe is unavailable', async () => {
+    // Why: a kill(0) failure that is neither ESRCH nor EPERM proves nothing about the process.
+    const mod = await importFresh()
+    readFileSyncMock.mockReturnValue('{"pid":123}')
+    parseDaemonPidFileMock.mockReturnValue({ pid: 999_999, startedAtMs: null })
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw new Error('kill probe rejected by the platform')
+    })
+
+    try {
+      await mod.initDaemonPtyProvider()
+    } finally {
+      killSpy.mockRestore()
+    }
+
+    const legacyUnlinks = unlinkSyncMock.mock.calls.filter(
+      ([p]) => typeof p === 'string' && (p.includes('.token') || p.includes('.pid'))
+    )
+    expect(legacyUnlinks).toEqual([])
+  })
+
+  it('keeps legacy daemon ownership files when the pid probe is denied with EPERM', async () => {
+    // Why: EPERM proves a process exists at the recorded pid — the daemon may be live.
+    const mod = await importFresh()
+    readFileSyncMock.mockReturnValue('{"pid":123}')
+    parseDaemonPidFileMock.mockReturnValue({ pid: 999_999, startedAtMs: null })
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('operation not permitted'), { code: 'EPERM' })
+    })
+
+    try {
+      await mod.initDaemonPtyProvider()
+    } finally {
+      killSpy.mockRestore()
+    }
+
+    const legacyUnlinks = unlinkSyncMock.mock.calls.filter(
+      ([p]) => typeof p === 'string' && (p.includes('.token') || p.includes('.pid'))
+    )
+    expect(legacyUnlinks).toEqual([])
+  })
+
+  it('preserves ownership files for any verdict that is not positively exited', async () => {
+    const mod = await importFresh()
+    const legacy = await import('./daemon-legacy-adapters')
+    readFileSyncMock.mockReturnValue('{"pid":123}')
+    // Why: deliberate out-of-contract cast — deletion must require a positive 'exited'
+    // match, so a future verdict status the gate does not know must preserve, not delete.
+    const futureVerdict = {
+      status: 'suspended',
+      reason: 'hypothetical future verdict'
+    } as unknown as ProcessLivenessVerdict
+    legacy.reclaimLegacyDaemonOwnershipFiles(
+      futureVerdict,
+      '{"pid":123}',
+      '/fake/daemon-v9.pid',
+      '/fake/daemon-v9.token'
+    )
+    expect(unlinkSyncMock).not.toHaveBeenCalled()
+
+    legacy.reclaimLegacyDaemonOwnershipFiles(
+      { status: 'exited' },
+      '{"pid":123}',
+      '/fake/daemon-v9.pid',
+      '/fake/daemon-v9.token'
+    )
+    expect(unlinkSyncMock).toHaveBeenCalledWith('/fake/daemon-v9.pid')
+    expect(unlinkSyncMock).toHaveBeenCalledWith('/fake/daemon-v9.token')
+  })
+
+  it('preserves ownership files when the record changed between the probe and the unlink', async () => {
+    // Cross-incarnation guard: an old build's own stale-kill can delete the dead
+    // record and republish in the probe→unlink window. Once the name holds any
+    // record other than the one proved dead, a new owner claimed it — deleting
+    // its pid/token would make a live legacy daemon's sessions unadoptable.
+    const mod = await importFresh()
+    const legacy = await import('./daemon-legacy-adapters')
+    readFileSyncMock.mockReturnValue('{"pid":456}')
+    legacy.reclaimLegacyDaemonOwnershipFiles(
+      { status: 'exited' },
+      '{"pid":123}',
+      '/fake/daemon-v9.pid',
+      '/fake/daemon-v9.token'
+    )
+    expect(unlinkSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('preserves the token when the proven-dead record is already gone', async () => {
+    // A missing record means another actor settled the name; the token's owner
+    // is now ambiguous, and ambiguity must preserve.
+    const mod = await importFresh()
+    const legacy = await import('./daemon-legacy-adapters')
+    readFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+    })
+    legacy.reclaimLegacyDaemonOwnershipFiles(
+      { status: 'exited' },
+      '{"pid":123}',
+      '/fake/daemon-v9.pid',
+      '/fake/daemon-v9.token'
+    )
+    expect(unlinkSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('leaves the token in place when the proven-dead record cannot be unlinked', async () => {
+    // Why: a token outliving its record is unattributable — a later reader cannot tell whose it is.
+    const mod = await importFresh()
+    const legacy = await import('./daemon-legacy-adapters')
+    readFileSyncMock.mockReturnValue('{"pid":123}')
+    // Why: mockImplementationOnce, not mockImplementation — afterEach runs clearAllMocks, which
+    // clears calls but keeps implementations, so a persistent throw would leak into later tests.
+    unlinkSyncMock.mockImplementationOnce(() => {
+      throw Object.assign(new Error('resource busy'), { code: 'EBUSY' })
+    })
+
+    legacy.reclaimLegacyDaemonOwnershipFiles(
+      { status: 'exited' },
+      '{"pid":123}',
+      '/fake/daemon-v9.pid',
+      '/fake/daemon-v9.token'
+    )
+
+    expect(unlinkSyncMock).toHaveBeenCalledWith('/fake/daemon-v9.pid')
+    expect(unlinkSyncMock).not.toHaveBeenCalledWith('/fake/daemon-v9.token')
+  })
+
   it('cleans up legacy daemon pid/token files when the probe fails and the process is gone', async () => {
     const mod = await importFresh()
     readFileSyncMock.mockReturnValue('{"pid":123}')
     // Why: spy process.kill to force a deterministic ESRCH instead of relying on an unallocated real pid.
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
-      throw new Error('ESRCH')
+      throw Object.assign(new Error('no such process'), { code: 'ESRCH' })
     })
     parseDaemonPidFileMock.mockReturnValue({ pid: 999_999, startedAtMs: null })
 
@@ -336,5 +490,106 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       ([p]) => typeof p === 'string' && p.includes('.token')
     )
     expect(tokenUnlinks.length).toBeGreaterThan(0)
+  })
+})
+
+describe('daemon-legacy-adapters: legacyDaemonProcessLiveness verdict mapping', () => {
+  beforeEach(() => {
+    installDefaultNetConnectStub()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports unverifiable and no proven record when the pid record cannot be read', async () => {
+    const mod = await importFresh()
+    const legacy = await import('./daemon-legacy-adapters')
+    readFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    })
+
+    const liveness = legacy.legacyDaemonProcessLiveness('/fake/runtime', 9)
+
+    expect(liveness.verdict.status).toBe('unverifiable')
+    expect(liveness.provenRecordText).toBeNull()
+  })
+
+  it('reports unverifiable and no proven record when the pid record does not parse', async () => {
+    const mod = await importFresh()
+    const legacy = await import('./daemon-legacy-adapters')
+    readFileSyncMock.mockReturnValue('not a daemon pid record')
+    parseDaemonPidFileMock.mockReturnValue(null)
+
+    const liveness = legacy.legacyDaemonProcessLiveness('/fake/runtime', 9)
+
+    expect(liveness.verdict.status).toBe('unverifiable')
+    expect(liveness.provenRecordText).toBeNull()
+  })
+
+  it('reports unverifiable when the record names no process', async () => {
+    // An empty record parses to pid 0 via the legacy bare-integer fallback, and process.kill(0, 0)
+    // probes the caller's own process group — it would answer 'occupied' and publish a false live.
+    const mod = await importFresh()
+    const legacy = await import('./daemon-legacy-adapters')
+    readFileSyncMock.mockReturnValue('')
+    parseDaemonPidFileMock.mockReturnValue({ pid: 0, startedAtMs: null })
+
+    const liveness = legacy.legacyDaemonProcessLiveness('/fake/runtime', 9)
+
+    expect(liveness.verdict.status).toBe('unverifiable')
+    expect(liveness.provenRecordText).toBeNull()
+  })
+
+  it('reports live when the pid probe is denied with EPERM', async () => {
+    const mod = await importFresh()
+    const legacy = await import('./daemon-legacy-adapters')
+    readFileSyncMock.mockReturnValue('{"pid":123}')
+    parseDaemonPidFileMock.mockReturnValue({ pid: 999_999, startedAtMs: null })
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('operation not permitted'), { code: 'EPERM' })
+    })
+
+    try {
+      const liveness = legacy.legacyDaemonProcessLiveness('/fake/runtime', 9)
+      expect(liveness.verdict.status).toBe('live')
+    } finally {
+      killSpy.mockRestore()
+    }
+  })
+
+  it('reports unverifiable when the pid probe fails with neither ESRCH nor EPERM', async () => {
+    const mod = await importFresh()
+    const legacy = await import('./daemon-legacy-adapters')
+    readFileSyncMock.mockReturnValue('{"pid":123}')
+    parseDaemonPidFileMock.mockReturnValue({ pid: 999_999, startedAtMs: null })
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw new Error('kill probe rejected by the platform')
+    })
+
+    try {
+      const liveness = legacy.legacyDaemonProcessLiveness('/fake/runtime', 9)
+      expect(liveness.verdict.status).toBe('unverifiable')
+    } finally {
+      killSpy.mockRestore()
+    }
+  })
+
+  it('reports exited carrying the exact record bytes proved dead', async () => {
+    const mod = await importFresh()
+    const legacy = await import('./daemon-legacy-adapters')
+    readFileSyncMock.mockReturnValue('{"pid":123}')
+    parseDaemonPidFileMock.mockReturnValue({ pid: 999_999, startedAtMs: null })
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('no such process'), { code: 'ESRCH' })
+    })
+
+    try {
+      const liveness = legacy.legacyDaemonProcessLiveness('/fake/runtime', 9)
+      expect(liveness.verdict.status).toBe('exited')
+      expect(liveness.provenRecordText).toBe('{"pid":123}')
+    } finally {
+      killSpy.mockRestore()
+    }
   })
 })

--- a/src/main/daemon/daemon-legacy-adapters.ts
+++ b/src/main/daemon/daemon-legacy-adapters.ts
@@ -3,23 +3,97 @@ import {
   getDaemonHistoryDir as getHistoryDir,
   probeDaemonSocket as probeSocket
 } from './daemon-launch-paths'
-import { parseDaemonPidFile } from './daemon-pid-file-parse'
+import { inspectProcessSignal } from './daemon-process-inspection'
+import { parseDaemonPidFile, type ParsedDaemonPid } from './daemon-pid-file-parse'
+import type { ProcessLivenessVerdict } from './daemon-incarnation-evidence-types'
 import { DaemonPtyAdapter } from './daemon-pty-adapter'
 import { getDaemonPidPath, getDaemonSocketPath, getDaemonTokenPath } from './daemon-spawner'
 import { PREVIOUS_DAEMON_PROTOCOL_VERSIONS } from './types'
 
-function legacyDaemonProcessMayBeAlive(runtimeDir: string, protocolVersion: number): boolean {
+// Why: exported so the signal->verdict mapping is pinned directly; the reclaim gates below each
+// independently preserve, so an "unlinked nothing" assertion cannot distinguish a correct
+// 'unverifiable' from the pre-fix coercion of "cannot tell" into "dead".
+export function legacyDaemonProcessLiveness(
+  runtimeDir: string,
+  protocolVersion: number
+): { verdict: ProcessLivenessVerdict; provenRecordText: string | null } {
+  let recordText: string
   try {
-    const parsed = parseDaemonPidFile(
-      readFileSync(getDaemonPidPath(runtimeDir, protocolVersion), 'utf8')
-    )
-    if (!parsed) {
-      return false
+    recordText = readFileSync(getDaemonPidPath(runtimeDir, protocolVersion), 'utf8')
+  } catch (error) {
+    return { verdict: { status: 'unverifiable', reason: String(error) }, provenRecordText: null }
+  }
+  const parsed: ParsedDaemonPid | null = parseDaemonPidFile(recordText)
+  if (!parsed) {
+    return {
+      verdict: { status: 'unverifiable', reason: 'the daemon PID record could not be parsed' },
+      provenRecordText: null
     }
-    process.kill(parsed.pid, 0)
-    return true
+  }
+  // Why: the parser's legacy bare-integer fallback coerces an empty or whitespace-only record to
+  // pid 0 (Number('') === 0) — the shape a concurrent read sees while a daemon publishes, since
+  // writeFileSync 'wx' creates the record before writing it. process.kill(0, 0) probes the
+  // caller's own process group rather than the daemon, so it answers 'occupied' and would publish
+  // a false 'live'. That is the client's own bookkeeping, not host evidence: report unverifiable.
+  if (!Number.isInteger(parsed.pid) || parsed.pid <= 0) {
+    return {
+      verdict: { status: 'unverifiable', reason: 'the daemon PID record does not name a process' },
+      provenRecordText: null
+    }
+  }
+  const evidence = inspectProcessSignal(parsed.pid)
+  switch (evidence) {
+    case 'occupied':
+    case 'permission_denied':
+      return { verdict: { status: 'live' }, provenRecordText: recordText }
+    case 'missing':
+      return { verdict: { status: 'exited' }, provenRecordText: recordText }
+    case 'unavailable':
+      return {
+        verdict: { status: 'unverifiable', reason: 'the daemon process could not be queried' },
+        provenRecordText: recordText
+      }
+  }
+}
+
+// Why: unlinking is the destructive direction and this is a statement position the compiler
+// does not police for exhaustiveness — deletion must be opted into by a positively matched
+// 'exited', so any future unhandled verdict status preserves ownership instead of deleting it.
+export function reclaimLegacyDaemonOwnershipFiles(
+  verdict: ProcessLivenessVerdict,
+  provenRecordText: string | null,
+  pidPath: string,
+  tokenPath: string
+): void {
+  if (verdict.status !== 'exited' || provenRecordText === null) {
+    return
+  }
+  // Cross-incarnation guard: 'exited' proves only that the RECORDED pid was
+  // absent at probe time. An old build's own stale-kill can delete that record
+  // and republish in the probe→unlink window, so delete only while the name
+  // still holds the exact record proved dead; any other content (or a missing
+  // record) means a new owner settled the name — preserve both files. A new
+  // owner writes its token after publishing its record, so the record compare
+  // shields the token too.
+  let currentRecordText: string
+  try {
+    currentRecordText = readFileSync(pidPath, 'utf8')
   } catch {
-    return false
+    return
+  }
+  if (currentRecordText !== provenRecordText) {
+    return
+  }
+  try {
+    unlinkSync(pidPath)
+  } catch {
+    // Record not removable — leave the token with it rather than orphan it.
+    return
+  }
+  try {
+    unlinkSync(tokenPath)
+  } catch {
+    // Best-effort
   }
 }
 
@@ -34,18 +108,13 @@ export async function createLegacyDaemonAdapters(
     const tokenPath = getDaemonTokenPath(runtimeDir, protocolVersion)
     if (!(await probeSocket(socketPath))) {
       // Why: a recycled stale pid later turns an identity check into a PowerShell spawn, so delete leaked pid/token files — but only when the pid-process is provably gone (a live daemon can transiently fail the probe, and dropping its token makes its sessions permanently unadoptable).
-      if (!legacyDaemonProcessMayBeAlive(runtimeDir, protocolVersion)) {
-        for (const stalePath of [
-          getDaemonPidPath(runtimeDir, protocolVersion),
-          getDaemonTokenPath(runtimeDir, protocolVersion)
-        ]) {
-          try {
-            unlinkSync(stalePath)
-          } catch {
-            // Best-effort
-          }
-        }
-      }
+      const liveness = legacyDaemonProcessLiveness(runtimeDir, protocolVersion)
+      reclaimLegacyDaemonOwnershipFiles(
+        liveness.verdict,
+        liveness.provenRecordText,
+        getDaemonPidPath(runtimeDir, protocolVersion),
+        getDaemonTokenPath(runtimeDir, protocolVersion)
+      )
       continue
     }
     // Keep old-protocol PTYs routed to their original daemon during upgrade; legacy adapters never respawn (new code would recreate stale env semantics).


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​256 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​255 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 |

<!-- /orca-pr-loc -->

## ELI5

Orca runs your terminals inside a background helper process. When you upgrade Orca, the new
version starts up and tidies away the leftover bookkeeping files of helpers from older versions —
but only the ones that are really gone. The bug: if Orca **could not tell** whether the old helper
was still running (its record was unreadable, or the OS refused to answer), it treated "I don't
know" as "it's dead" and deleted the credentials anyway. The old helper kept running with your
terminals inside it, and Orca could never reconnect to it again — those terminals and the agents in
them were gone for good, with nothing to click to bring them back.

Now Orca only deletes those credentials after it has positively proved the old helper exited. "I
can't tell" means "leave it alone".

## User-facing before / after

| | Before | After |
|---|---|---|
| You upgrade Orca while terminals from the previous version are still running, and the check on the old helper can't complete (record unreadable, permission error, OS query fails) | Orca assumed the helper was dead and threw away the credentials needed to reach it. The helper kept running, but your terminals and the agents inside them became permanently unreachable | Orca keeps the credentials and re-adopts those terminals |
| The old helper exits and a new one claims the same slot in the same moment | Orca could delete the **new** helper's freshly written credentials, orphaning terminals that had only just started | Orca deletes only while the record still matches exactly the one it proved dead — otherwise it leaves the new owner alone |
| The old helper really has exited | Its leftover files are cleaned up | Unchanged — still cleaned up |

## When it bites

Anyone upgrading Orca to a version with a new helper protocol while terminals from the old version
are still alive, on any platform. It needs the helper's record to come back unreadable at that exact
moment — most likely when Orca's runtime directory sits on a restricted or network-backed
filesystem, or when the record is caught half-written.


## Summary

- replace the legacy daemon ownership boolean with an exhaustive `live | unverifiable | exited` verdict
- preserve PID/token ownership when the record or process query is unavailable
- delete legacy ownership only after an explicit `ESRCH` absence proof

Author: @BrennanKB5

## Reliability contract

- **Invariant (`agent-session.provider-ownership`):** an unavailable ownership query cannot delete the credentials required to re-adopt a live legacy daemon and its PTYs.
- **Failure source:** a failed socket probe followed by an unreadable PID record was caught as `false`, authorizing PID/token deletion.
- **Oracle:** the EACCES regression test asserts zero legacy PID/token unlinks; the pre-fix code attempted 70 unlinks in the fixture. The existing ESRCH test still proves positively absent processes are reclaimed.
- **Gate:** focused unit coverage is the deterministic gate; no reliability manifest entry currently targets this startup-only legacy cleanup edge.
- **Coverage:** local daemon startup behavior is covered; macOS/Linux/Windows share the existing signal-evidence mapper. SSH, WSL, relay, mobile, remote wire, and renderer behavior are unaffected.
- **Performance budget:** no new polling, subprocess, inventory fanout, or unbounded state; the path retains one PID-record read and one signal probe per legacy protocol after a failed socket probe.
- **Diagnostics:** `unverifiable.reason` carries the failed observation category for future call-site diagnostics, though this cleanup path does not currently publish it.
- **Residual gap:** the EACCES branch is unit-injected rather than reproduced against a packaged daemon. The broader failure-to-fact sites remain separate follow-up work; this PR intentionally does not touch #15666.

## Verification

- `pnpm test src/main/daemon/daemon-process-inspection.test.ts src/main/daemon/daemon-init-provider-installation.test.ts`
- `pnpm tc:node`
- direct `oxlint` and `oxfmt --check` on all changed files
- isolated Electron/CDP smoke: intended branch identity attached and the empty-workspace Orca surface rendered with zero console errors

The repository changed-code-quality wrapper could not parse the Node 26 engine warning before lint output; the underlying linter and formatter both passed directly.


## Follow-up

- #16908 introduces a byte-identical `ProcessLivenessVerdict` plus an `inspectProcessLiveness` helper that duplicates this PR's inline signal→verdict switch; merge-tree is clean and there is no ordering constraint, but whichever PR lands second should dedup onto the shared helper.

