### PR TITLE
Fix Windows daemon host pruning on unverifiable liveness

### DIFF
--- a/src/main/daemon/daemon-host-relocation.test.ts
+++ b/src/main/daemon/daemon-host-relocation.test.ts
@@ -6,6 +6,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  utimesSync,
   writeFileSync
 } from 'node:fs'
 import os from 'node:os'
@@ -267,6 +268,13 @@ describe('getRelocatedDaemonHost', () => {
   })
 })
 
+// Why: quarantine refuses records written in the last minute, because an in-flight publish is
+// indistinguishable from a torn one. Age a record so it stands for a settled corrupt record.
+function ageRecordPastQuarantineFloor(recordPath: string): void {
+  const aged = new Date(Date.now() - 5 * 60_000)
+  utimesSync(recordPath, aged, aged)
+}
+
 describe('pruneOldDaemonHosts', () => {
   it('removes unpinned non-current version dirs, keeping current and pinned', () => {
     const root = join(localAppDataDir, 'Orca', 'daemon-host')
@@ -437,6 +445,7 @@ describe('pruneOldDaemonHosts', () => {
     // writer of a mid-digits tear died mid-write, so quarantine must not consult any probe.
     const pidPath = join(runtimeDir, 'daemon-v7.pid')
     writeFileSync(pidPath, '{"pid":123')
+    ageRecordPastQuarantineFloor(pidPath)
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
       throw Object.assign(new Error('no such process'), { code: 'ESRCH' })
     })
@@ -464,6 +473,7 @@ describe('pruneOldDaemonHosts', () => {
     // Trusting it would re-create for this one record the eternal veto pruning must not have.
     const pidPath = join(runtimeDir, 'daemon-v7.pid')
     writeFileSync(pidPath, '{"pid":4')
+    ageRecordPastQuarantineFloor(pidPath)
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
       throw Object.assign(new Error('access denied'), { code: 'EPERM' })
     })
@@ -483,6 +493,57 @@ describe('pruneOldDaemonHosts', () => {
     expect(existsSync(join(root, '1.0.0'))).toBe(false)
     warnSpy.mockRestore()
     killSpy.mockRestore()
+  })
+
+  it('never quarantines a corrupt record that was just written', () => {
+    // A live daemon's record is created before it is written (writeFileSync 'wx'), so a
+    // concurrent launch can read it as empty. Quarantining it would strand the running daemon's
+    // record and let the NEXT launch reclaim its host image.
+    const root = join(localAppDataDir, 'Orca', 'daemon-host')
+    const runtimeDir = join(userDataDir, 'daemon')
+    mkdirSync(join(root, '1.0.0'), { recursive: true })
+    mkdirSync(runtimeDir, { recursive: true })
+    const pidPath = join(runtimeDir, 'daemon-v7.pid')
+    writeFileSync(pidPath, '')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const evidence = collectPinnedDaemonVersions(runtimeDir)
+
+    expect(evidence).toEqual({
+      status: 'unverifiable',
+      reason:
+        'the daemon pid file could not be parsed and was written too recently to quarantine: daemon-v7.pid'
+    })
+    expect(existsSync(pidPath)).toBe(true)
+    expect(existsSync(join(runtimeDir, 'daemon-v7.pid.corrupt'))).toBe(false)
+    pruneOldDaemonHosts(evidence)
+    expect(existsSync(join(root, '1.0.0'))).toBe(true)
+    warnSpy.mockRestore()
+  })
+
+  it('never treats a settled empty record as a valid pre-relocation daemon', () => {
+    // Number('') === 0, so the parser's legacy bare-integer fallback accepts an empty record as
+    // pid 0 with appVersion null. Skipping it as "pins no host dir" would leave the version
+    // unpinned and let the prune below reclaim a live daemon's host image. Aged past the
+    // quarantine floor so this pins the pid guard rather than the freshness guard.
+    const root = join(localAppDataDir, 'Orca', 'daemon-host')
+    const runtimeDir = join(userDataDir, 'daemon')
+    mkdirSync(join(root, '1.0.0'), { recursive: true })
+    mkdirSync(runtimeDir, { recursive: true })
+    const pidPath = join(runtimeDir, 'daemon-v7.pid')
+    writeFileSync(pidPath, '   ')
+    ageRecordPastQuarantineFloor(pidPath)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const evidence = collectPinnedDaemonVersions(runtimeDir)
+
+    expect(evidence).toEqual({
+      status: 'unverifiable',
+      reason: 'the daemon pid file could not be parsed and was quarantined: daemon-v7.pid'
+    })
+    pruneOldDaemonHosts(evidence)
+    expect(existsSync(join(root, '1.0.0'))).toBe(true)
+    warnSpy.mockRestore()
   })
 
   it('vetoes pruning while a pid salvaged from a corrupt record still answers', () => {
@@ -518,6 +579,7 @@ describe('pruneOldDaemonHosts', () => {
     mkdirSync(runtimeDir, { recursive: true })
     const pidPath = join(runtimeDir, 'daemon-v7.pid')
     writeFileSync(pidPath, 'not a daemon record')
+    ageRecordPastQuarantineFloor(pidPath)
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     // Launch with the corrupt record: prune skips once, and the record is quarantined in place

--- a/src/main/daemon/daemon-host-relocation.test.ts
+++ b/src/main/daemon/daemon-host-relocation.test.ts
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -109,6 +110,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  // A test that fails between spyOn and mockRestore must not leak its mock into later tests.
+  vi.restoreAllMocks()
   setProcessProp('platform', originalPlatform)
   setProcessProp('execPath', originalExecPath)
   setProcessProp('resourcesPath', originalResourcesPath)
@@ -327,6 +330,165 @@ describe('pruneOldDaemonHosts', () => {
     expect(existsSync(join(root, '7.0.0'))).toBe(true)
     expect(existsSync(join(root, '6.0.0'))).toBe(false)
     killSpy.mockRestore()
+  })
+
+  it('prunes nothing and never throws when the evidence is unverifiable', () => {
+    const root = join(localAppDataDir, 'Orca', 'daemon-host')
+    for (const v of ['1.0.0', '2.0.0']) {
+      mkdirSync(join(root, v), { recursive: true })
+    }
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(() =>
+      pruneOldDaemonHosts({
+        status: 'unverifiable',
+        reason: 'the daemon runtime directory could not be read'
+      })
+    ).not.toThrow()
+
+    expect(existsSync(join(root, '1.0.0'))).toBe(true)
+    expect(existsSync(join(root, '2.0.0'))).toBe(true)
+    // The reason must reach the field log — an unobservable no-op is undiagnosable.
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[daemon] Skipping daemon-host prune: the daemon runtime directory could not be read'
+    )
+    warnSpy.mockRestore()
+  })
+
+  it('skips pruning when the runtime directory cannot be read', () => {
+    const root = join(localAppDataDir, 'Orca', 'daemon-host')
+    mkdirSync(join(root, '1.0.0'), { recursive: true })
+
+    const evidence = collectPinnedDaemonVersions(join(userDataDir, 'daemon-never-created'))
+
+    expect(evidence).toEqual({
+      status: 'unverifiable',
+      reason: 'the daemon runtime directory could not be read'
+    })
+    pruneOldDaemonHosts(evidence)
+    expect(existsSync(join(root, '1.0.0'))).toBe(true)
+  })
+
+  it('keeps a version live when any of its pid records is live', () => {
+    const root = join(localAppDataDir, 'Orca', 'daemon-host')
+    const runtimeDir = join(userDataDir, 'daemon')
+    mkdirSync(join(root, '7.0.0'), { recursive: true })
+    mkdirSync(runtimeDir, { recursive: true })
+    // Two protocol generations of the same app version: one daemon live, one exited. The live
+    // record must win the merged verdict whichever order the directory scan visits them.
+    writeFileSync(
+      join(runtimeDir, 'daemon-v7.pid'),
+      JSON.stringify({ pid: 5001, startedAtMs: null, appVersion: '7.0.0' })
+    )
+    writeFileSync(
+      join(runtimeDir, 'daemon-v8.pid'),
+      JSON.stringify({ pid: 5002, startedAtMs: null, appVersion: '7.0.0' })
+    )
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+      if (pid === 5001) {
+        return true
+      }
+      throw Object.assign(new Error('no such process'), { code: 'ESRCH' })
+    })
+
+    const evidence = collectPinnedDaemonVersions(runtimeDir)
+    expect(evidence).toEqual({
+      status: 'complete',
+      versionLiveness: new Map([['7.0.0', { status: 'live' }]])
+    })
+    pruneOldDaemonHosts(evidence)
+
+    expect(existsSync(join(root, '7.0.0'))).toBe(true)
+    killSpy.mockRestore()
+  })
+
+  it('vetoes pruning while a pid salvaged from a corrupt record still answers', () => {
+    const root = join(localAppDataDir, 'Orca', 'daemon-host')
+    const runtimeDir = join(userDataDir, 'daemon')
+    mkdirSync(join(root, '1.0.0'), { recursive: true })
+    mkdirSync(runtimeDir, { recursive: true })
+    // A torn write preserves the pid prefix; the process behind it still answers, so the
+    // record may belong to a live daemon of unknown version and must keep its veto un-quarantined.
+    const pidPath = join(runtimeDir, 'daemon-v7.pid')
+    writeFileSync(pidPath, '{"pid": 4242, "startedAtMs": 17')
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const evidence = collectPinnedDaemonVersions(runtimeDir)
+
+    expect(evidence).toEqual({
+      status: 'unverifiable',
+      reason:
+        'the daemon pid file could not be parsed and salvaged pid 4242 may still be running: daemon-v7.pid'
+    })
+    expect(existsSync(pidPath)).toBe(true)
+    pruneOldDaemonHosts(evidence)
+    expect(existsSync(join(root, '1.0.0'))).toBe(true)
+    warnSpy.mockRestore()
+    killSpy.mockRestore()
+  })
+
+  it('quarantines a corrupt record naming no live pid so pruning resumes next launch', () => {
+    const root = join(localAppDataDir, 'Orca', 'daemon-host')
+    const runtimeDir = join(userDataDir, 'daemon')
+    mkdirSync(join(root, '1.0.0'), { recursive: true })
+    mkdirSync(runtimeDir, { recursive: true })
+    const pidPath = join(runtimeDir, 'daemon-v7.pid')
+    writeFileSync(pidPath, 'not a daemon record')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Launch with the corrupt record: prune skips once, and the record is quarantined in place
+    // (bytes preserved) instead of vetoing every future launch.
+    const evidence = collectPinnedDaemonVersions(runtimeDir)
+    expect(evidence).toEqual({
+      status: 'unverifiable',
+      reason: 'the daemon pid file could not be parsed and was quarantined: daemon-v7.pid'
+    })
+    pruneOldDaemonHosts(evidence)
+    expect(existsSync(join(root, '1.0.0'))).toBe(true)
+    expect(existsSync(pidPath)).toBe(false)
+    expect(readFileSync(join(runtimeDir, 'daemon-v7.pid.corrupt'), 'utf8')).toBe(
+      'not a daemon record'
+    )
+
+    // Next launch: the listing is complete again and the unowned host is reclaimed.
+    const nextEvidence = collectPinnedDaemonVersions(runtimeDir)
+    expect(nextEvidence).toEqual({ status: 'complete', versionLiveness: new Map() })
+    pruneOldDaemonHosts(nextEvidence)
+    expect(existsSync(join(root, '1.0.0'))).toBe(false)
+    warnSpy.mockRestore()
+  })
+
+  it('vetoes pruning without quarantine when a pid record cannot be read', (ctx) => {
+    // The suite mocks process.platform; the chmod trick needs the REAL host to be POSIX.
+    if (originalPlatform === 'win32') {
+      return ctx.skip()
+    }
+    const root = join(localAppDataDir, 'Orca', 'daemon-host')
+    const runtimeDir = join(userDataDir, 'daemon')
+    mkdirSync(join(root, '1.0.0'), { recursive: true })
+    mkdirSync(runtimeDir, { recursive: true })
+    const pidPath = join(runtimeDir, 'daemon-v7.pid')
+    writeFileSync(pidPath, JSON.stringify({ pid: 4242, startedAtMs: null, appVersion: '1.0.0' }))
+    chmodSync(pidPath, 0o000)
+    try {
+      readFileSync(pidPath)
+      return ctx.skip() // Running as root: the permission bit cannot make the read fail.
+    } catch {
+      // The read fails as intended.
+    }
+
+    const evidence = collectPinnedDaemonVersions(runtimeDir)
+
+    // A read failure is transient (AV lock, vanished file): veto this launch, but leave the
+    // record alone so a launch that can read it re-evaluates from the real bytes.
+    expect(evidence).toEqual({
+      status: 'unverifiable',
+      reason: 'the daemon pid file could not be read: daemon-v7.pid'
+    })
+    expect(existsSync(pidPath)).toBe(true)
+    pruneOldDaemonHosts(evidence)
+    expect(existsSync(join(root, '1.0.0'))).toBe(true)
   })
 
   it('reclaims nothing for a packaged host with no asar root (orcad on win32)', () => {

--- a/src/main/daemon/daemon-host-relocation.test.ts
+++ b/src/main/daemon/daemon-host-relocation.test.ts
@@ -268,7 +268,10 @@ describe('pruneOldDaemonHosts', () => {
     for (const v of ['9.9.9', '1.0.0', '2.0.0']) {
       mkdirSync(join(root, v), { recursive: true })
     }
-    pruneOldDaemonHosts({ status: 'complete', pinnedVersions: new Set(['2.0.0']) })
+    pruneOldDaemonHosts({
+      status: 'complete',
+      versionLiveness: new Map([['2.0.0', { status: 'live' }]])
+    })
     expect(existsSync(join(root, '9.9.9'))).toBe(true)
     expect(existsSync(join(root, '2.0.0'))).toBe(true)
     expect(existsSync(join(root, '1.0.0'))).toBe(false)
@@ -288,6 +291,10 @@ describe('pruneOldDaemonHosts', () => {
     })
 
     const evidence = collectPinnedDaemonVersions(runtimeDir)
+    expect(evidence).toEqual({
+      status: 'complete',
+      versionLiveness: new Map([['8.0.0', { status: 'live' }]])
+    })
     pruneOldDaemonHosts(evidence)
 
     expect(existsSync(join(root, '8.0.0'))).toBe(true)
@@ -298,6 +305,7 @@ describe('pruneOldDaemonHosts', () => {
     const root = join(localAppDataDir, 'Orca', 'daemon-host')
     const runtimeDir = join(userDataDir, 'daemon')
     mkdirSync(join(root, '7.0.0'), { recursive: true })
+    mkdirSync(join(root, '6.0.0'), { recursive: true })
     mkdirSync(runtimeDir, { recursive: true })
     writeFileSync(
       join(runtimeDir, 'daemon-v7.pid'),
@@ -309,12 +317,15 @@ describe('pruneOldDaemonHosts', () => {
 
     const evidence = collectPinnedDaemonVersions(runtimeDir)
     expect(evidence).toEqual({
-      status: 'unverifiable',
-      reason: 'the daemon process could not be queried'
+      status: 'complete',
+      versionLiveness: new Map([
+        ['7.0.0', { status: 'unverifiable', reason: 'the daemon process could not be queried' }]
+      ])
     })
     pruneOldDaemonHosts(evidence)
 
     expect(existsSync(join(root, '7.0.0'))).toBe(true)
+    expect(existsSync(join(root, '6.0.0'))).toBe(false)
     killSpy.mockRestore()
   })
 
@@ -323,7 +334,7 @@ describe('pruneOldDaemonHosts', () => {
     mkdirSync(join(root, '1.0.0'), { recursive: true })
     hostApp.appPath = join(installDir, 'resources', 'app')
     installHostApp()
-    pruneOldDaemonHosts({ status: 'complete', pinnedVersions: new Set() })
+    pruneOldDaemonHosts({ status: 'complete', versionLiveness: new Map() })
     // A Node host owns no daemon-host tree, so deleting under it would be reaching into a
     // directory layout it never created.
     expect(existsSync(join(root, '1.0.0'))).toBe(true)
@@ -343,6 +354,12 @@ describe('collectPinnedDaemonVersions', () => {
       JSON.stringify({ pid: 2147483646, startedAtMs: null, appVersion: '6.0.0' })
     )
     const pinned = collectPinnedDaemonVersions(runtimeDir)
-    expect(pinned).toEqual({ status: 'complete', pinnedVersions: new Set(['7.0.0']) })
+    expect(pinned).toEqual({
+      status: 'complete',
+      versionLiveness: new Map([
+        ['7.0.0', { status: 'live' }],
+        ['6.0.0', { status: 'exited' }]
+      ])
+    })
   })
 })

--- a/src/main/daemon/daemon-host-relocation.test.ts
+++ b/src/main/daemon/daemon-host-relocation.test.ts
@@ -9,7 +9,7 @@ import {
 } from 'node:fs'
 import os from 'node:os'
 import { dirname, join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { setAppEnvironment, type AppEnvironment } from '../../shared/app-environment'
 
@@ -268,10 +268,54 @@ describe('pruneOldDaemonHosts', () => {
     for (const v of ['9.9.9', '1.0.0', '2.0.0']) {
       mkdirSync(join(root, v), { recursive: true })
     }
-    pruneOldDaemonHosts(new Set(['2.0.0']))
+    pruneOldDaemonHosts({ status: 'complete', pinnedVersions: new Set(['2.0.0']) })
     expect(existsSync(join(root, '9.9.9'))).toBe(true)
     expect(existsSync(join(root, '2.0.0'))).toBe(true)
     expect(existsSync(join(root, '1.0.0'))).toBe(false)
+  })
+
+  it('keeps a host when its pid liveness query is permission denied', () => {
+    const root = join(localAppDataDir, 'Orca', 'daemon-host')
+    const runtimeDir = join(userDataDir, 'daemon')
+    mkdirSync(join(root, '8.0.0'), { recursive: true })
+    mkdirSync(runtimeDir, { recursive: true })
+    writeFileSync(
+      join(runtimeDir, 'daemon-v8.pid'),
+      JSON.stringify({ pid: 4242, startedAtMs: null, appVersion: '8.0.0' })
+    )
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('access denied'), { code: 'EPERM' })
+    })
+
+    const evidence = collectPinnedDaemonVersions(runtimeDir)
+    pruneOldDaemonHosts(evidence)
+
+    expect(existsSync(join(root, '8.0.0'))).toBe(true)
+    killSpy.mockRestore()
+  })
+
+  it('keeps a host when its pid liveness query is unavailable', () => {
+    const root = join(localAppDataDir, 'Orca', 'daemon-host')
+    const runtimeDir = join(userDataDir, 'daemon')
+    mkdirSync(join(root, '7.0.0'), { recursive: true })
+    mkdirSync(runtimeDir, { recursive: true })
+    writeFileSync(
+      join(runtimeDir, 'daemon-v7.pid'),
+      JSON.stringify({ pid: 4242, startedAtMs: null, appVersion: '7.0.0' })
+    )
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' })
+    })
+
+    const evidence = collectPinnedDaemonVersions(runtimeDir)
+    expect(evidence).toEqual({
+      status: 'unverifiable',
+      reason: 'the daemon process could not be queried'
+    })
+    pruneOldDaemonHosts(evidence)
+
+    expect(existsSync(join(root, '7.0.0'))).toBe(true)
+    killSpy.mockRestore()
   })
 
   it('reclaims nothing for a packaged host with no asar root (orcad on win32)', () => {
@@ -279,7 +323,7 @@ describe('pruneOldDaemonHosts', () => {
     mkdirSync(join(root, '1.0.0'), { recursive: true })
     hostApp.appPath = join(installDir, 'resources', 'app')
     installHostApp()
-    pruneOldDaemonHosts(new Set())
+    pruneOldDaemonHosts({ status: 'complete', pinnedVersions: new Set() })
     // A Node host owns no daemon-host tree, so deleting under it would be reaching into a
     // directory layout it never created.
     expect(existsSync(join(root, '1.0.0'))).toBe(true)
@@ -299,7 +343,6 @@ describe('collectPinnedDaemonVersions', () => {
       JSON.stringify({ pid: 2147483646, startedAtMs: null, appVersion: '6.0.0' })
     )
     const pinned = collectPinnedDaemonVersions(runtimeDir)
-    expect(pinned.has('7.0.0')).toBe(true)
-    expect(pinned.has('6.0.0')).toBe(false)
+    expect(pinned).toEqual({ status: 'complete', pinnedVersions: new Set(['7.0.0']) })
   })
 })

--- a/src/main/daemon/daemon-host-relocation.test.ts
+++ b/src/main/daemon/daemon-host-relocation.test.ts
@@ -40,8 +40,10 @@ import {
   collectPinnedDaemonVersions,
   getRelocatedDaemonHost,
   materializeRelocatedDaemonHost,
-  pruneOldDaemonHosts
+  pruneOldDaemonHosts,
+  reclaimUnownedDaemonHostDir
 } from './daemon-host-relocation'
+import type { ProcessLivenessVerdict } from './daemon-incarnation-evidence-types'
 
 let tempDir: string
 let installDir: string
@@ -399,6 +401,87 @@ describe('pruneOldDaemonHosts', () => {
     pruneOldDaemonHosts(evidence)
 
     expect(existsSync(join(root, '7.0.0'))).toBe(true)
+    killSpy.mockRestore()
+  })
+
+  it('preserves a host dir for any verdict that is not positively exited', () => {
+    const root = join(localAppDataDir, 'Orca', 'daemon-host')
+    mkdirSync(join(root, '1.0.0'), { recursive: true })
+    // Why: deliberate out-of-contract cast — deletion must require a positive 'exited' match,
+    // so a future verdict status the prune does not know preserves the host dir, not deletes it.
+    const futureVerdict = {
+      status: 'suspended',
+      reason: 'hypothetical future verdict'
+    } as unknown as ProcessLivenessVerdict
+
+    pruneOldDaemonHosts({
+      status: 'complete',
+      versionLiveness: new Map([['1.0.0', futureVerdict]])
+    })
+    expect(existsSync(join(root, '1.0.0'))).toBe(true)
+
+    reclaimUnownedDaemonHostDir(futureVerdict, join(root, '1.0.0'))
+    expect(existsSync(join(root, '1.0.0'))).toBe(true)
+
+    reclaimUnownedDaemonHostDir({ status: 'exited' }, join(root, '1.0.0'))
+    expect(existsSync(join(root, '1.0.0'))).toBe(false)
+  })
+
+  it('quarantines a record torn inside the pid digits without probing the truncated prefix', () => {
+    const root = join(localAppDataDir, 'Orca', 'daemon-host')
+    const runtimeDir = join(userDataDir, 'daemon')
+    mkdirSync(join(root, '1.0.0'), { recursive: true })
+    mkdirSync(runtimeDir, { recursive: true })
+    // A tear inside the digits of pid 12345 leaves the prefix 123 — a DIFFERENT pid. Probing
+    // it would attribute an unrelated (here: dead) process's verdict to this record; the
+    // writer of a mid-digits tear died mid-write, so quarantine must not consult any probe.
+    const pidPath = join(runtimeDir, 'daemon-v7.pid')
+    writeFileSync(pidPath, '{"pid":123')
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('no such process'), { code: 'ESRCH' })
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const evidence = collectPinnedDaemonVersions(runtimeDir)
+
+    expect(evidence).toEqual({
+      status: 'unverifiable',
+      reason: 'the daemon pid file could not be parsed and was quarantined: daemon-v7.pid'
+    })
+    expect(killSpy).not.toHaveBeenCalled()
+    expect(existsSync(pidPath)).toBe(false)
+    expect(readFileSync(join(runtimeDir, 'daemon-v7.pid.corrupt'), 'utf8')).toBe('{"pid":123')
+    warnSpy.mockRestore()
+    killSpy.mockRestore()
+  })
+
+  it('never lets an immortal-pid prefix turn a torn record into a permanent prune veto', () => {
+    const root = join(localAppDataDir, 'Orca', 'daemon-host')
+    const runtimeDir = join(userDataDir, 'daemon')
+    mkdirSync(join(root, '1.0.0'), { recursive: true })
+    mkdirSync(runtimeDir, { recursive: true })
+    // Pid 41234 torn to the prefix 4 — the Windows System pid, which answers probes forever.
+    // Trusting it would re-create for this one record the eternal veto pruning must not have.
+    const pidPath = join(runtimeDir, 'daemon-v7.pid')
+    writeFileSync(pidPath, '{"pid":4')
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('access denied'), { code: 'EPERM' })
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const evidence = collectPinnedDaemonVersions(runtimeDir)
+
+    expect(evidence).toEqual({
+      status: 'unverifiable',
+      reason: 'the daemon pid file could not be parsed and was quarantined: daemon-v7.pid'
+    })
+    expect(killSpy).not.toHaveBeenCalled()
+    expect(readFileSync(join(runtimeDir, 'daemon-v7.pid.corrupt'), 'utf8')).toBe('{"pid":4')
+
+    // Next launch: the listing is complete again and the unowned host is reclaimed.
+    pruneOldDaemonHosts(collectPinnedDaemonVersions(runtimeDir))
+    expect(existsSync(join(root, '1.0.0'))).toBe(false)
+    warnSpy.mockRestore()
     killSpy.mockRestore()
   })
 

--- a/src/main/daemon/daemon-host-relocation.ts
+++ b/src/main/daemon/daemon-host-relocation.ts
@@ -345,6 +345,23 @@ export function collectPinnedDaemonVersions(runtimeDir: string): PinnedDaemonVer
   return { status: 'complete', versionLiveness }
 }
 
+// Why: deletion is the destructive direction and this is a statement position the compiler does
+// not police for exhaustiveness — reclaim must be opted into by a positively matched 'exited',
+// so any future unhandled verdict status preserves the host dir instead of deleting it.
+export function reclaimUnownedDaemonHostDir(
+  verdict: ProcessLivenessVerdict,
+  hostDir: string
+): void {
+  if (verdict.status !== 'exited') {
+    return
+  }
+  try {
+    rmSync(hostDir, { recursive: true, force: true })
+  } catch {
+    // Still locked or already gone — retry on a future launch.
+  }
+}
+
 /**
  * Reclaim daemon-host/<ver> dirs that are neither the current version nor pinned by a live daemon.
  * Best-effort — never throws; a locked/staging dir is retried on a future launch.
@@ -371,17 +388,6 @@ export function pruneOldDaemonHosts(evidence: PinnedDaemonVersionsEvidence): voi
     }
     // A complete runtime-dir listing with no pid record for this version proves it is unowned.
     const verdict = evidence.versionLiveness.get(entry.name) ?? { status: 'exited' }
-    switch (verdict.status) {
-      case 'live':
-      case 'unverifiable':
-        continue
-      case 'exited':
-        break
-    }
-    try {
-      rmSync(join(root, entry.name), { recursive: true, force: true })
-    } catch {
-      // Still locked or already gone — retry on a future launch.
-    }
+    reclaimUnownedDaemonHostDir(verdict, join(root, entry.name))
   }
 }

--- a/src/main/daemon/daemon-host-relocation.ts
+++ b/src/main/daemon/daemon-host-relocation.ts
@@ -12,7 +12,7 @@ import {
 import { dirname, join, win32 as winPath } from 'node:path'
 import { getAppEnvironment } from '../../shared/app-environment'
 import { parseDaemonPidFile } from './daemon-pid-file-parse'
-import { startTimeMatches } from './daemon-process-start-time'
+import { inspectProcessLiveness } from './daemon-process-inspection'
 
 /**
  * Relocate the terminal daemon's process image out of the app install dir into LOCAL userData so it
@@ -293,26 +293,21 @@ export function materializeRelocatedDaemonHost(): RelocatedDaemonHost | null {
   return getRelocatedDaemonHost()
 }
 
-function isDaemonPidAlive(pid: number, startedAtMs: number | null): boolean {
-  try {
-    process.kill(pid, 0)
-  } catch {
-    return false
-  }
-  return startTimeMatches(pid, startedAtMs)
-}
+export type PinnedDaemonVersionsEvidence =
+  | { status: 'complete'; pinnedVersions: ReadonlySet<string> }
+  | { status: 'unverifiable'; reason: string }
 
 /**
  * App versions still pinned by a live daemon (from daemon-v<N>.pid files under `runtimeDir`), whose
  * host dir must not be reclaimed while alive. On win32 start-time can't verify, so a matching pid pins conservatively.
  */
-export function collectPinnedDaemonVersions(runtimeDir: string): Set<string> {
+export function collectPinnedDaemonVersions(runtimeDir: string): PinnedDaemonVersionsEvidence {
   const pinned = new Set<string>()
   let entries
   try {
     entries = readdirSync(runtimeDir, { withFileTypes: true })
   } catch {
-    return pinned
+    return { status: 'unverifiable', reason: 'the daemon runtime directory could not be read' }
   }
   for (const entry of entries) {
     if (!entry.isFile() || !/^daemon-v\d+\.pid$/.test(entry.name)) {
@@ -322,22 +317,46 @@ export function collectPinnedDaemonVersions(runtimeDir: string): Set<string> {
     try {
       parsed = parseDaemonPidFile(readFileSync(join(runtimeDir, entry.name), 'utf8'))
     } catch {
-      continue
+      return {
+        status: 'unverifiable',
+        reason: `the daemon pid file could not be read: ${entry.name}`
+      }
+    }
+    if (!parsed) {
+      return {
+        status: 'unverifiable',
+        reason: `the daemon pid file could not be parsed: ${entry.name}`
+      }
     }
     // appVersion null => pre-relocation daemon forked from the install dir; pins no host dir here.
-    if (parsed && parsed.appVersion !== null && isDaemonPidAlive(parsed.pid, parsed.startedAtMs)) {
-      pinned.add(parsed.appVersion)
+    if (parsed.appVersion === null) {
+      continue
+    }
+    const verdict = inspectProcessLiveness(parsed.pid)
+    switch (verdict.status) {
+      case 'live':
+        pinned.add(parsed.appVersion)
+        break
+      case 'exited':
+        break
+      case 'unverifiable':
+        return verdict
+      default:
+        verdict satisfies never
     }
   }
-  return pinned
+  return { status: 'complete', pinnedVersions: pinned }
 }
 
 /**
  * Reclaim daemon-host/<ver> dirs that are neither the current version nor pinned by a live daemon.
  * Best-effort — never throws; a locked/staging dir is retried on a future launch.
  */
-export function pruneOldDaemonHosts(pinnedVersions: ReadonlySet<string>): void {
+export function pruneOldDaemonHosts(evidence: PinnedDaemonVersionsEvidence): void {
   if (!isPackagedElectronWin32()) {
+    return
+  }
+  if (evidence.status === 'unverifiable') {
     return
   }
   const version = getAppEnvironment().getVersion()
@@ -349,7 +368,7 @@ export function pruneOldDaemonHosts(pinnedVersions: ReadonlySet<string>): void {
     return
   }
   for (const entry of entries) {
-    if (!entry.isDirectory() || entry.name === version || pinnedVersions.has(entry.name)) {
+    if (!entry.isDirectory() || entry.name === version || evidence.pinnedVersions.has(entry.name)) {
       continue
     }
     try {

--- a/src/main/daemon/daemon-host-relocation.ts
+++ b/src/main/daemon/daemon-host-relocation.ts
@@ -373,8 +373,6 @@ export function pruneOldDaemonHosts(evidence: PinnedDaemonVersionsEvidence): voi
         continue
       case 'exited':
         break
-      default:
-        verdict satisfies never
     }
     try {
       rmSync(join(root, entry.name), { recursive: true, force: true })

--- a/src/main/daemon/daemon-host-relocation.ts
+++ b/src/main/daemon/daemon-host-relocation.ts
@@ -11,8 +11,9 @@ import {
 } from 'node:fs'
 import { dirname, join, win32 as winPath } from 'node:path'
 import { getAppEnvironment } from '../../shared/app-environment'
+import type { ProcessLivenessVerdict } from './daemon-incarnation-evidence-types'
 import { parseDaemonPidFile } from './daemon-pid-file-parse'
-import { inspectProcessLiveness } from './daemon-process-inspection'
+import { inspectProcessLiveness, mergeProcessLivenessVerdict } from './daemon-process-inspection'
 
 /**
  * Relocate the terminal daemon's process image out of the app install dir into LOCAL userData so it
@@ -294,7 +295,7 @@ export function materializeRelocatedDaemonHost(): RelocatedDaemonHost | null {
 }
 
 export type PinnedDaemonVersionsEvidence =
-  | { status: 'complete'; pinnedVersions: ReadonlySet<string> }
+  | { status: 'complete'; versionLiveness: ReadonlyMap<string, ProcessLivenessVerdict> }
   | { status: 'unverifiable'; reason: string }
 
 /**
@@ -302,7 +303,7 @@ export type PinnedDaemonVersionsEvidence =
  * host dir must not be reclaimed while alive. On win32 start-time can't verify, so a matching pid pins conservatively.
  */
 export function collectPinnedDaemonVersions(runtimeDir: string): PinnedDaemonVersionsEvidence {
-  const pinned = new Set<string>()
+  const versionLiveness = new Map<string, ProcessLivenessVerdict>()
   let entries
   try {
     entries = readdirSync(runtimeDir, { withFileTypes: true })
@@ -333,19 +334,12 @@ export function collectPinnedDaemonVersions(runtimeDir: string): PinnedDaemonVer
       continue
     }
     const verdict = inspectProcessLiveness(parsed.pid)
-    switch (verdict.status) {
-      case 'live':
-        pinned.add(parsed.appVersion)
-        break
-      case 'exited':
-        break
-      case 'unverifiable':
-        return verdict
-      default:
-        verdict satisfies never
-    }
+    versionLiveness.set(
+      parsed.appVersion,
+      mergeProcessLivenessVerdict(versionLiveness.get(parsed.appVersion), verdict)
+    )
   }
-  return { status: 'complete', pinnedVersions: pinned }
+  return { status: 'complete', versionLiveness }
 }
 
 /**
@@ -368,8 +362,19 @@ export function pruneOldDaemonHosts(evidence: PinnedDaemonVersionsEvidence): voi
     return
   }
   for (const entry of entries) {
-    if (!entry.isDirectory() || entry.name === version || evidence.pinnedVersions.has(entry.name)) {
+    if (!entry.isDirectory() || entry.name === version) {
       continue
+    }
+    // A complete runtime-dir listing with no pid record for this version proves it is unowned.
+    const verdict = evidence.versionLiveness.get(entry.name) ?? { status: 'exited' }
+    switch (verdict.status) {
+      case 'live':
+      case 'unverifiable':
+        continue
+      case 'exited':
+        break
+      default:
+        verdict satisfies never
     }
     try {
       rmSync(join(root, entry.name), { recursive: true, force: true })

--- a/src/main/daemon/daemon-host-relocation.ts
+++ b/src/main/daemon/daemon-host-relocation.ts
@@ -326,7 +326,15 @@ export function collectPinnedDaemonVersions(runtimeDir: string): PinnedDaemonVer
       }
     }
     const parsed = parseDaemonPidFile(contents)
-    if (!parsed) {
+    // Why not just `!parsed`: the parser's legacy bare-integer fallback coerces an empty or
+    // whitespace-only record to pid 0 (Number('') === 0), which is the exact shape a concurrent
+    // read sees while a live daemon publishes its record — writeFileSync 'wx' creates the file
+    // before writing it. Such a record would otherwise pass as a valid pre-relocation daemon,
+    // skip on appVersion === null, and leave its version unpinned, so the prune below would
+    // reclaim a running daemon's host image. A pid that is not a positive integer names no
+    // process — process.kill(0, 0) probes the caller's own process group, never a daemon — so
+    // it is not liveness evidence and must veto rather than be skipped.
+    if (!parsed || !Number.isInteger(parsed.pid) || parsed.pid <= 0) {
       return {
         status: 'unverifiable',
         reason: quarantineCorruptDaemonPidRecord(runtimeDir, entry.name, contents)

--- a/src/main/daemon/daemon-host-relocation.ts
+++ b/src/main/daemon/daemon-host-relocation.ts
@@ -13,6 +13,7 @@ import { dirname, join, win32 as winPath } from 'node:path'
 import { getAppEnvironment } from '../../shared/app-environment'
 import type { ProcessLivenessVerdict } from './daemon-incarnation-evidence-types'
 import { parseDaemonPidFile } from './daemon-pid-file-parse'
+import { quarantineCorruptDaemonPidRecord } from './daemon-pid-record-quarantine'
 import { inspectProcessLiveness, mergeProcessLivenessVerdict } from './daemon-process-inspection'
 
 /**
@@ -314,19 +315,21 @@ export function collectPinnedDaemonVersions(runtimeDir: string): PinnedDaemonVer
     if (!entry.isFile() || !/^daemon-v\d+\.pid$/.test(entry.name)) {
       continue
     }
-    let parsed
+    let contents
     try {
-      parsed = parseDaemonPidFile(readFileSync(join(runtimeDir, entry.name), 'utf8'))
+      contents = readFileSync(join(runtimeDir, entry.name), 'utf8')
     } catch {
+      // Read failures (AV lock, vanished file) are transient; the veto re-evaluates next launch.
       return {
         status: 'unverifiable',
         reason: `the daemon pid file could not be read: ${entry.name}`
       }
     }
+    const parsed = parseDaemonPidFile(contents)
     if (!parsed) {
       return {
         status: 'unverifiable',
-        reason: `the daemon pid file could not be parsed: ${entry.name}`
+        reason: quarantineCorruptDaemonPidRecord(runtimeDir, entry.name, contents)
       }
     }
     // appVersion null => pre-relocation daemon forked from the install dir; pins no host dir here.
@@ -351,6 +354,7 @@ export function pruneOldDaemonHosts(evidence: PinnedDaemonVersionsEvidence): voi
     return
   }
   if (evidence.status === 'unverifiable') {
+    console.warn(`[daemon] Skipping daemon-host prune: ${evidence.reason}`)
     return
   }
   const version = getAppEnvironment().getVersion()

--- a/src/main/daemon/daemon-incarnation-evidence-types.ts
+++ b/src/main/daemon/daemon-incarnation-evidence-types.ts
@@ -54,6 +54,11 @@ export type DaemonProcessEvidence =
 
 export type ProcessSignalEvidence = 'occupied' | 'permission_denied' | 'missing' | 'unavailable'
 
+export type ProcessLivenessVerdict =
+  | { status: 'live' }
+  | { status: 'unverifiable'; reason: string }
+  | { status: 'exited' }
+
 export type LinuxStatEvidence =
   | { status: 'present'; value: string }
   | { status: 'missing' }

--- a/src/main/daemon/daemon-pid-file-parse.test.ts
+++ b/src/main/daemon/daemon-pid-file-parse.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { salvagePidFromCorruptDaemonRecord } from './daemon-pid-file-parse'
+
+describe('salvagePidFromCorruptDaemonRecord', () => {
+  it('salvages a pid whose digit run is terminated by a following byte', () => {
+    expect(salvagePidFromCorruptDaemonRecord('{"pid":4242,"startedAtMs":17')).toBe(4242)
+    expect(salvagePidFromCorruptDaemonRecord('{"pid": 4242, "startedAtMs"')).toBe(4242)
+    expect(salvagePidFromCorruptDaemonRecord('{"pid":4242}')).toBe(4242)
+  })
+
+  it('refuses digits at end-of-bytes: a tear inside the digits leaves a different pid', () => {
+    // Pid 42420 torn mid-digits — the surviving prefix 4242 must not be mistaken for a pid.
+    expect(salvagePidFromCorruptDaemonRecord('{"pid":4242')).toBe(null)
+    expect(salvagePidFromCorruptDaemonRecord('{"pid":4')).toBe(null)
+  })
+
+  it('refuses records with no usable pid field', () => {
+    expect(salvagePidFromCorruptDaemonRecord('not a daemon record')).toBe(null)
+    expect(salvagePidFromCorruptDaemonRecord('{"pid":0,"startedAtMs":17')).toBe(null)
+    expect(salvagePidFromCorruptDaemonRecord('{"pid":-42,')).toBe(null)
+  })
+})

--- a/src/main/daemon/daemon-pid-file-parse.ts
+++ b/src/main/daemon/daemon-pid-file-parse.ts
@@ -13,9 +13,15 @@ export type ParsedDaemonPid = {
  * Best-effort pid recovery from a record parseDaemonPidFile rejected. The pid is the first key
  * JSON.stringify writes, so a torn write usually preserves it; it gates whether a corrupt record
  * may be quarantined (a process still answering for this pid keeps its conservative veto).
+ *
+ * The digit run must be terminated by a following non-digit byte: a torn write can cut inside
+ * the digits, and a truncated prefix is a different pid — probing it attributes an unrelated
+ * process's liveness to this record (a dead prefix would quarantine on false evidence; an
+ * immortal one, e.g. Windows System pid 4, would veto forever). Digits at end-of-bytes are
+ * therefore unsalvageable; the writer of such a prefix died mid-write, so no probe is needed.
  */
 export function salvagePidFromCorruptDaemonRecord(contents: string): number | null {
-  const match = /"pid"\s*:\s*(\d+)/.exec(contents)
+  const match = /"pid"\s*:\s*(\d+)(?=\D)/.exec(contents)
   if (!match) {
     return null
   }

--- a/src/main/daemon/daemon-pid-file-parse.ts
+++ b/src/main/daemon/daemon-pid-file-parse.ts
@@ -9,6 +9,20 @@ export type ParsedDaemonPid = {
   spawnerExecPath: string | null
 }
 
+/**
+ * Best-effort pid recovery from a record parseDaemonPidFile rejected. The pid is the first key
+ * JSON.stringify writes, so a torn write usually preserves it; it gates whether a corrupt record
+ * may be quarantined (a process still answering for this pid keeps its conservative veto).
+ */
+export function salvagePidFromCorruptDaemonRecord(contents: string): number | null {
+  const match = /"pid"\s*:\s*(\d+)/.exec(contents)
+  if (!match) {
+    return null
+  }
+  const pid = Number(match[1])
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null
+}
+
 export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
   const trimmed = contents.trim()
   try {

--- a/src/main/daemon/daemon-pid-record-quarantine.ts
+++ b/src/main/daemon/daemon-pid-record-quarantine.ts
@@ -1,0 +1,36 @@
+import { renameSync } from 'node:fs'
+import { join } from 'node:path'
+import { salvagePidFromCorruptDaemonRecord } from './daemon-pid-file-parse'
+import { inspectProcessLiveness } from './daemon-process-inspection'
+
+/**
+ * A pid record that parses to nothing would otherwise veto daemon-host pruning on every future
+ * launch: nothing ever rewrites a retired protocol version's pid file, so the veto never expires.
+ * Quarantine the record (rename in place, bytes kept for diagnosis) so the next launch scans a
+ * complete listing again — unless a process still answers for a pid salvaged from the corrupt
+ * bytes, in which case the record may belong to a live daemon and keeps its conservative veto
+ * until that pid exits. Returns the unverifiable reason; every branch is logged because this
+ * state suppresses pruning.
+ */
+export function quarantineCorruptDaemonPidRecord(
+  runtimeDir: string,
+  name: string,
+  contents: string
+): string {
+  const salvagedPid = salvagePidFromCorruptDaemonRecord(contents)
+  if (salvagedPid !== null && inspectProcessLiveness(salvagedPid).status !== 'exited') {
+    const reason = `the daemon pid file could not be parsed and salvaged pid ${salvagedPid} may still be running: ${name}`
+    console.warn(`[daemon] Keeping corrupt daemon pid record: ${reason}`)
+    return reason
+  }
+  try {
+    renameSync(join(runtimeDir, name), join(runtimeDir, `${name}.corrupt`))
+  } catch {
+    const reason = `the daemon pid file could not be parsed or quarantined: ${name}`
+    console.warn(`[daemon] ${reason}`)
+    return reason
+  }
+  const reason = `the daemon pid file could not be parsed and was quarantined: ${name}`
+  console.warn(`[daemon] ${reason}`)
+  return reason
+}

--- a/src/main/daemon/daemon-pid-record-quarantine.ts
+++ b/src/main/daemon/daemon-pid-record-quarantine.ts
@@ -1,7 +1,17 @@
-import { renameSync } from 'node:fs'
+import { renameSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { salvagePidFromCorruptDaemonRecord } from './daemon-pid-file-parse'
 import { inspectProcessLiveness } from './daemon-process-inspection'
+
+/**
+ * A record that was just written is never quarantined: publishDaemonPidFile creates the record
+ * before writing it (writeFileSync with flag 'wx'), so a concurrent launch can read a LIVE
+ * daemon's record as empty or torn. Renaming it aside would strand that daemon's record, and the
+ * next launch — seeing a complete listing with no record for its version — would reclaim the
+ * running daemon's host image. An in-flight publish is by definition fresh; a record left corrupt
+ * by a dead writer ages past this floor and is quarantined on a later launch.
+ */
+const QUARANTINE_MIN_RECORD_AGE_MS = 60_000
 
 /**
  * A pid record that parses to nothing would otherwise veto daemon-host pruning on every future
@@ -23,8 +33,23 @@ export function quarantineCorruptDaemonPidRecord(
     console.warn(`[daemon] Keeping corrupt daemon pid record: ${reason}`)
     return reason
   }
+  const recordPath = join(runtimeDir, name)
+  let modifiedAtMs: number
   try {
-    renameSync(join(runtimeDir, name), join(runtimeDir, `${name}.corrupt`))
+    modifiedAtMs = statSync(recordPath).mtimeMs
+  } catch {
+    const reason = `the daemon pid file could not be parsed or aged: ${name}`
+    console.warn(`[daemon] ${reason}`)
+    return reason
+  }
+  // A future mtime (clock adjustment) reads as negative age and is treated as fresh.
+  if (Date.now() - modifiedAtMs < QUARANTINE_MIN_RECORD_AGE_MS) {
+    const reason = `the daemon pid file could not be parsed and was written too recently to quarantine: ${name}`
+    console.warn(`[daemon] Keeping corrupt daemon pid record: ${reason}`)
+    return reason
+  }
+  try {
+    renameSync(recordPath, join(runtimeDir, `${name}.corrupt`))
   } catch {
     const reason = `the daemon pid file could not be parsed or quarantined: ${name}`
     console.warn(`[daemon] ${reason}`)

--- a/src/main/daemon/daemon-process-inspection.test.ts
+++ b/src/main/daemon/daemon-process-inspection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  mergeProcessLivenessVerdict,
   queryWindowsProcess,
   readLinuxProcessStartedAtMs,
   readMacosProcessStartedAtMs,
@@ -112,6 +113,48 @@ describe('daemon process inspection', () => {
     await expect(
       readLinuxProcessStartedAtMs(42, { readTextFile: readProcStat, runCommand })
     ).resolves.toBe(1_699_000_010_000)
+  })
+
+  // Several daemon-v<N>.pid records can name the same app version; the merged verdict decides
+  // whether pruneOldDaemonHosts may delete that version's host dir, so a wrong winner deletes a
+  // live host. Precedence: live > unverifiable > exited, regardless of record order.
+  describe('mergeProcessLivenessVerdict', () => {
+    const unverifiable = { status: 'unverifiable', reason: 'probe failed' } as const
+
+    it('keeps a live verdict when a later record for the same version reports exited', () => {
+      expect(mergeProcessLivenessVerdict({ status: 'live' }, { status: 'exited' })).toEqual({
+        status: 'live'
+      })
+    })
+
+    it('keeps a live verdict when a later record reports unverifiable', () => {
+      expect(mergeProcessLivenessVerdict({ status: 'live' }, unverifiable)).toEqual({
+        status: 'live'
+      })
+    })
+
+    it('never lets an exited record downgrade an unverifiable verdict', () => {
+      expect(mergeProcessLivenessVerdict(unverifiable, { status: 'exited' })).toEqual(unverifiable)
+    })
+
+    it('lets a live record supersede an earlier exited or unverifiable verdict', () => {
+      expect(mergeProcessLivenessVerdict({ status: 'exited' }, { status: 'live' })).toEqual({
+        status: 'live'
+      })
+      expect(mergeProcessLivenessVerdict(unverifiable, { status: 'live' })).toEqual({
+        status: 'live'
+      })
+    })
+
+    it('lets an unverifiable record upgrade an earlier exited verdict', () => {
+      expect(mergeProcessLivenessVerdict({ status: 'exited' }, unverifiable)).toEqual(unverifiable)
+    })
+
+    it('adopts the first verdict when there is no prior one', () => {
+      expect(mergeProcessLivenessVerdict(undefined, { status: 'exited' })).toEqual({
+        status: 'exited'
+      })
+    })
   })
 
   it.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, Number.NaN])(

--- a/src/main/daemon/daemon-process-inspection.ts
+++ b/src/main/daemon/daemon-process-inspection.ts
@@ -43,8 +43,6 @@ export function inspectProcessLiveness(pid: number): ProcessLivenessVerdict {
       return { status: 'exited' }
     case 'unavailable':
       return { status: 'unverifiable', reason: 'the daemon process could not be queried' }
-    default:
-      return signal satisfies never
   }
 }
 
@@ -59,8 +57,6 @@ export function mergeProcessLivenessVerdict(
       return current?.status === 'live' ? current : next
     case 'exited':
       return current ?? next
-    default:
-      return next satisfies never
   }
 }
 

--- a/src/main/daemon/daemon-process-inspection.ts
+++ b/src/main/daemon/daemon-process-inspection.ts
@@ -48,6 +48,22 @@ export function inspectProcessLiveness(pid: number): ProcessLivenessVerdict {
   }
 }
 
+export function mergeProcessLivenessVerdict(
+  current: ProcessLivenessVerdict | undefined,
+  next: ProcessLivenessVerdict
+): ProcessLivenessVerdict {
+  switch (next.status) {
+    case 'live':
+      return next
+    case 'unverifiable':
+      return current?.status === 'live' ? current : next
+    case 'exited':
+      return current ?? next
+    default:
+      return next satisfies never
+  }
+}
+
 export async function readLinuxStat(pid: number): Promise<LinuxStatEvidence> {
   try {
     return { status: 'present', value: await readFile(`/proc/${pid}/stat`, 'utf8') }

--- a/src/main/daemon/daemon-process-inspection.ts
+++ b/src/main/daemon/daemon-process-inspection.ts
@@ -4,6 +4,7 @@ import { promisify } from 'node:util'
 import { parseLinuxBootTimeSeconds, parseLinuxProcStartTicks } from './daemon-process-start-time'
 import type {
   LinuxStatEvidence,
+  ProcessLivenessVerdict,
   ProcessSignalEvidence,
   WindowsProcessEvidence
 } from './daemon-incarnation-evidence-types'
@@ -29,6 +30,21 @@ export function inspectProcessSignal(pid: number): ProcessSignalEvidence {
       return 'permission_denied'
     }
     return 'unavailable'
+  }
+}
+
+export function inspectProcessLiveness(pid: number): ProcessLivenessVerdict {
+  const signal = inspectProcessSignal(pid)
+  switch (signal) {
+    case 'occupied':
+    case 'permission_denied':
+      return { status: 'live' }
+    case 'missing':
+      return { status: 'exited' }
+    case 'unavailable':
+      return { status: 'unverifiable', reason: 'the daemon process could not be queried' }
+    default:
+      return signal satisfies never
   }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​438 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​432 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​179 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​154 |

<!-- /orca-pr-loc -->

## ELI5

Windows keeps versioned daemon host copies so live terminals survive app updates. This change prevents a failed PID/liveness check from being mistaken for proof that a host is dead and safe to delete.

Put another way: on Windows, Orca keeps one copy of its terminal helper per app version, so the
terminals you already had open keep running after you update. At each launch Orca deletes the copies
for versions nobody is using any more. The bug was in how it decided "nobody is using this": if the
check failed — the folder could not be listed, a bookkeeping file could not be read, or Windows
refused to answer whether a process was alive — Orca read that silence as "nothing is running" and
deleted **every** old version's copy, including the one a still-running helper was executing from.
The terminals that helper owns are exactly the ones you had open before you updated.

Now a check that cannot answer stops the cleanup instead of authorising it, and a bookkeeping file
that is unreadable for good gets set aside after a minute so the cleanup does not stay blocked
forever.

## User-facing before / after

| | Before | After |
|---|---|---|
| You update Orca on Windows with terminals still running from the old version, and Orca's check on the old helper cannot complete (folder unlistable, record unreadable, process query refused) | Orca deleted the old version's helper folder anyway — out from under the helper that was still running your terminals | Orca skips the cleanup this launch and tries again next time; the running helper and its terminals are left alone |
| One old version can't be checked, but another is provably finished | Either everything was deleted, or (with the safest possible fix) nothing would be | Only the version proved finished is deleted; the unclear one is kept |
| A bookkeeping file is permanently corrupt | It would veto the cleanup on every future launch, so old helper copies pile up on disk forever | The corrupt file is renamed aside after a minute (bytes kept for diagnosis) and cleanup resumes |
| A bookkeeping file is corrupt only because a helper is writing it right now | — | Left alone; a record younger than a minute is never set aside |
| Nothing is in doubt | Old versions cleaned up | Unchanged — still cleaned up |

## When it bites

Windows users only, on packaged builds, at the moment Orca restarts after an update while terminals
from the previous version are still alive. Antivirus locks, a vanishing file, and permission-denied
process queries are the realistic triggers.


## What Changed

- Added an exhaustive `live` / `unverifiable` / `exited` process-liveness verdict.
- Carried per-version evidence into the pruning site so only `exited` authorizes deletion.
- Kept unrelated, positively absent versions prunable when another version is unverifiable.
- Added regression coverage for permission denial, unavailable queries, live pins, and genuinely absent hosts.

## Why

The prior collector caught process-query and PID-file failures and returned an ordinary empty pin set. The pruning caller then acted on that coerced value by recursively deleting every non-current, unpinned host directory, which could remove the survival substrate for every PTY in a live daemon generation.

## Linked Issue

N/A — focused reliability follow-up to the liveness-contract work in #16900.

## Visual Proof

N/A — main-process filesystem/liveness behavior with no UI change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated
- `pnpm test src/main/daemon/daemon-host-relocation.test.ts src/main/daemon/daemon-process-inspection.test.ts --run` (26/26)
- `pnpm tc:node`
- `pnpm exec oxlint` on all changed files
- Physical Windows high-spec host: exact SHA `14f56edbcf1ec8b9cfca2e4924212d4ec8d126de`, 12/12 focused relocation tests passed
- Windows Electron dev build attached through dedicated CDP port 9467; identity confirmed the validation worktree and branch

## Reliability Contract

- **Invariant (`daemon-host.update-survival`):** a live or unverifiable daemon generation retains its versioned Windows host directory; only positively exited or absent evidence authorizes recursive removal.
- **Failure source:** a process-query/PID-read failure was coerced into an empty pin set, and the prune caller acted on it as fact.
- **Oracle:** the regression test asserts the derived filesystem result: EPERM and unavailable queries preserve the named host, while an unrelated positively absent host and an explicitly exited host are removed.
- **Gate:** no matching manifest gate exists; accepted gap is covered by the deterministic focused test plus an exact-SHA physical Windows run.
- **Coverage:** packaged Electron Win32 is covered by deterministic tests and physical Windows execution; local PTY/daemon ownership is affected only through host-file survival. SSH, WSL, remote runtime, relay, mobile, macOS, and Linux paths are unaffected by the Win32-packaged guard.
- **Performance budget:** one bounded map entry per discovered PID record and one constant-time lookup per host directory; no subprocess, polling, retry, timer, listener, or startup await added.
- **Diagnostics:** focused test output and the exact-SHA PR status comment identify both verdict branches; no production telemetry or customer data added.
- **Residual gap:** a destructive real auto-update was not run against a live customer-style PTY generation; the lower-layer filesystem oracle directly covers the prune authority decision.

## Review

Same-worktree independent review found and drove a per-version evidence refinement; the updated branch was re-tested on macOS and physical Windows. A final in-scope pass found no remaining proven issues.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- No mobile-facing, remote-wire, persisted-data, provider, or UI surface changed.
- SSH/folder workspaces are unaffected; pruning is gated to packaged Electron on Win32.
- `pnpm run check:code-quality:changed` under an outer `pnpm run` mixes the Node 26 engine warning into its JSON parsing; running `node config/scripts/check-changed-code-quality.mjs` directly passes: 0 new findings (code quality, type-aware, React Doctor).
- Author X handle: @BrennanKB5

## Hardening at d87c20c2 (fail-safe delete-gate + salvage attribution)

- The prune verdict switch shared #16900's delete-gate shape: an unhandled future verdict status fell through into `rmSync`, protected only by the lint exhaustiveness rule. Deletion is now opted into by a positively matched `'exited'` via `reclaimUnownedDaemonHostDir` (same shape as #16900's `reclaimLegacyDaemonOwnershipFiles`); a pinning test feeds an out-of-contract verdict through `pruneOldDaemonHosts` and asserts the host dir survives. No default arm added; `config/oxlint-code-quality-type-aware.json` is untouched (diff vs the previous head is empty).
- Pid salvage from corrupt records now requires the digit run to be terminated by a following non-digit byte. A tear inside the digits leaves a truncated prefix that is a *different* pid: probing it could quarantine a record on an unrelated process's death, or — when the prefix collides with an immortal pid such as Windows System pid 4 — re-create the permanent prune veto for that one record. Unterminated digits mean the writer died mid-write, so such records quarantine without consulting any probe. Both cases are pinned by failing-first tests (ablation of the terminator check turns 3 tests red; ablation of the delete-gate turns the pinning test red).

## Recorded follow-up + scope note

- Follow-up (deliberately not fixed here): prune-skip reasons are `console.warn`-only — visible in dev stdout, absent from the diagnostic bundle / main.trace. They should be routed through the daemon milestone/trace log so field skips are diagnosable.
- Platform asymmetry: `collectPinnedDaemonVersions` (liveness probes + corrupt-record quarantine renames) runs on all platforms while the prune it feeds is win32-only. The win32 gate deliberately sits at the destructive sink (`pruneOldDaemonHosts`); the off-win32 side effects were not a design goal but are benign (probes of recorded pids, rename of already-unparseable records nothing else consumes — `killStaleDaemon` re-reads current-protocol records itself). If off-win32 work is unwanted, hoisting the platform check around the `daemon-init.ts` call site is a safe follow-up.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Visual proof is N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and compatibility impact considered
- [x] Focused tests, node typecheck, formatting, and changed-file lint pass; CI will cover full-suite/build gates

