### PR TITLE
Fix inherited PTY setup launch state

### DIFF
--- a/src/main/daemon/pty-subprocess-env-inheritance.test.ts
+++ b/src/main/daemon/pty-subprocess-env-inheritance.test.ts
@@ -119,17 +119,21 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('does not inherit parent Orca pane identity when caller omits pane env', async () => {
+  it('does not inherit parent-scoped Orca env when caller omits it', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const saved = {
       ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
       ORCA_TAB_ID: process.env.ORCA_TAB_ID,
-      ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID
+      ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
+      ORCA_SEQUENCED_STARTUP_COMMAND: process.env.ORCA_SEQUENCED_STARTUP_COMMAND,
+      ORCA_SEQUENCED_STARTUP_SCRIPT: process.env.ORCA_SEQUENCED_STARTUP_SCRIPT
     }
     process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
     process.env.ORCA_TAB_ID = 'parent-tab'
     process.env.ORCA_WORKTREE_ID = 'parent-worktree'
+    process.env.ORCA_SEQUENCED_STARTUP_COMMAND = 'parent-agent'
+    process.env.ORCA_SEQUENCED_STARTUP_SCRIPT = 'parent-gate'
 
     try {
       await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
@@ -147,19 +151,25 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_PANE_KEY).toBeUndefined()
     expect(env.ORCA_TAB_ID).toBeUndefined()
     expect(env.ORCA_WORKTREE_ID).toBeUndefined()
+    expect(env.ORCA_SEQUENCED_STARTUP_COMMAND).toBeUndefined()
+    expect(env.ORCA_SEQUENCED_STARTUP_SCRIPT).toBeUndefined()
   })
 
-  it('preserves explicit child Orca pane identity over parent env', async () => {
+  it('preserves explicit child-scoped Orca env over parent env', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const saved = {
       ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
       ORCA_TAB_ID: process.env.ORCA_TAB_ID,
-      ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID
+      ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
+      ORCA_SEQUENCED_STARTUP_COMMAND: process.env.ORCA_SEQUENCED_STARTUP_COMMAND,
+      ORCA_SEQUENCED_STARTUP_SCRIPT: process.env.ORCA_SEQUENCED_STARTUP_SCRIPT
     }
     process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
     process.env.ORCA_TAB_ID = 'parent-tab'
     process.env.ORCA_WORKTREE_ID = 'parent-worktree'
+    process.env.ORCA_SEQUENCED_STARTUP_COMMAND = 'parent-agent'
+    process.env.ORCA_SEQUENCED_STARTUP_SCRIPT = 'parent-gate'
 
     try {
       await createPtySubprocess({
@@ -169,7 +179,9 @@ describe('createPtySubprocess', () => {
         env: {
           ORCA_PANE_KEY: 'child-tab:child-leaf',
           ORCA_TAB_ID: 'child-tab',
-          ORCA_WORKTREE_ID: 'child-worktree'
+          ORCA_WORKTREE_ID: 'child-worktree',
+          ORCA_SEQUENCED_STARTUP_COMMAND: 'child-agent',
+          ORCA_SEQUENCED_STARTUP_SCRIPT: 'child-gate'
         }
       })
     } finally {
@@ -186,6 +198,8 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_PANE_KEY).toBe('child-tab:child-leaf')
     expect(env.ORCA_TAB_ID).toBe('child-tab')
     expect(env.ORCA_WORKTREE_ID).toBe('child-worktree')
+    expect(env.ORCA_SEQUENCED_STARTUP_COMMAND).toBe('child-agent')
+    expect(env.ORCA_SEQUENCED_STARTUP_SCRIPT).toBe('child-gate')
   })
 
   it.each([

--- a/src/main/daemon/pty-subprocess/spawn-environment.ts
+++ b/src/main/daemon/pty-subprocess/spawn-environment.ts
@@ -7,6 +7,7 @@ import { stripLegacyTerminalShimEnv } from '../../pty/legacy-terminal-shim-dir'
 import { removeInheritedNoColor } from '../../pty/terminal-color-env'
 import { resolvePathEnvKey } from '../../pty/windows-environment-path'
 import { dropInheritedOrcaHistFile } from '../../worktree-history-file-path'
+import { removeUnspecifiedPtyChildScopedEnv } from '../../../shared/pty-child-scoped-env'
 import {
   gitCredentialPromptGuardEnv,
   mergeGitConfigEnvProtocol
@@ -19,12 +20,6 @@ import {
 import type { TuiAgent } from '../../../shared/tui-agent'
 import type { PtySubprocessOptions } from '../pty-subprocess'
 
-const PANE_IDENTITY_ENV_KEYS = [
-  'ORCA_PANE_KEY',
-  'ORCA_TAB_ID',
-  'ORCA_WORKTREE_ID',
-  'ORCA_AGENT_LAUNCH_TOKEN'
-] as const
 const WINDOWS_PATH_ENV_KEY_RE = /^path$/i
 
 function composeGuardedDaemonGitConfigEnv(
@@ -55,17 +50,6 @@ function deleteRequestedDaemonEnvKeys(
   }
   if (deleteOrcaOwnedCodexHome) {
     delete env.CODEX_HOME
-  }
-}
-
-function removeUnspecifiedPaneIdentityEnv(
-  env: Record<string, string>,
-  explicitEnv: Record<string, string> | undefined
-): void {
-  for (const key of PANE_IDENTITY_ENV_KEYS) {
-    if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
-      delete env[key]
-    }
   }
 }
 
@@ -146,7 +130,7 @@ export function createDaemonPtyEnvironment(opts: PtySubprocessOptions): Record<s
   if (opts.env?.TERM) {
     env.TERM = opts.env.TERM
   }
-  removeUnspecifiedPaneIdentityEnv(env, opts.env)
+  removeUnspecifiedPtyChildScopedEnv(env, opts.env)
   if (opts.env?.fish_history === undefined) {
     dropInheritedOrcaFishHistory(env)
   }

--- a/src/main/ipc/pty-serializer-settlement-mapping.test.ts
+++ b/src/main/ipc/pty-serializer-settlement-mapping.test.ts
@@ -461,6 +461,8 @@ describe('registerPtyHandlers', () => {
   })
   it('forwards the trusted Orca terminal handle into managed WSL terminals', async () => {
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    const savedSequencedStartupCommand = process.env.ORCA_SEQUENCED_STARTUP_COMMAND
+    const savedSequencedStartupScript = process.env.ORCA_SEQUENCED_STARTUP_SCRIPT
     Object.defineProperty(process, 'platform', {
       configurable: true,
       value: 'win32'
@@ -473,6 +475,8 @@ describe('registerPtyHandlers', () => {
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()
     }
+    process.env.ORCA_SEQUENCED_STARTUP_COMMAND = 'parent-agent'
+    process.env.ORCA_SEQUENCED_STARTUP_SCRIPT = 'parent-gate'
 
     try {
       registerPtyHandlers(mainWindow as never, runtime as never)
@@ -485,6 +489,16 @@ describe('registerPtyHandlers', () => {
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
       }
+      if (savedSequencedStartupCommand === undefined) {
+        delete process.env.ORCA_SEQUENCED_STARTUP_COMMAND
+      } else {
+        process.env.ORCA_SEQUENCED_STARTUP_COMMAND = savedSequencedStartupCommand
+      }
+      if (savedSequencedStartupScript === undefined) {
+        delete process.env.ORCA_SEQUENCED_STARTUP_SCRIPT
+      } else {
+        process.env.ORCA_SEQUENCED_STARTUP_SCRIPT = savedSequencedStartupScript
+      }
     }
 
     const spawnCall = spawnMock.mock.calls.at(-1)!
@@ -493,6 +507,8 @@ describe('registerPtyHandlers', () => {
     expect(env.ORCA_TERMINAL_HANDLE).toBe('term_wsl')
     expect(env.ORCA_USER_DATA_PATH).toBe('/tmp/orca-user-data')
     expect(env.ORCA_CLI_COMMAND).toBe('orca-ide')
+    expect(env.ORCA_SEQUENCED_STARTUP_COMMAND).toBeUndefined()
+    expect(env.ORCA_SEQUENCED_STARTUP_SCRIPT).toBeUndefined()
     expect(env.WSLENV?.split(':')).toEqual(
       expect.arrayContaining([
         'ORCA_TERMINAL_HANDLE/u',

--- a/src/main/providers/local-pty-launch-helpers.ts
+++ b/src/main/providers/local-pty-launch-helpers.ts
@@ -5,26 +5,8 @@ import { resolvePathEnvKey } from '../pty/windows-environment-path'
 import { expandWindowsEnvironmentVariables } from '../../shared/windows-environment-expansion'
 import { resolveSafePtyDefaultCwd } from './pty-default-cwd'
 
-const PANE_IDENTITY_ENV_KEYS = [
-  'ORCA_PANE_KEY',
-  'ORCA_TAB_ID',
-  'ORCA_WORKTREE_ID',
-  'ORCA_AGENT_LAUNCH_TOKEN'
-] as const
-
 export function getDefaultCwd(): string {
   return resolveSafePtyDefaultCwd()
-}
-
-export function removeUnspecifiedPaneIdentityEnv(
-  env: Record<string, string>,
-  explicitEnv: Record<string, string> | undefined
-): void {
-  for (const key of PANE_IDENTITY_ENV_KEYS) {
-    if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
-      delete env[key]
-    }
-  }
 }
 
 export function promoteAgentTeamsShimPath(

--- a/src/main/providers/local-pty-provider-spawn-env.test.ts
+++ b/src/main/providers/local-pty-provider-spawn-env.test.ts
@@ -543,15 +543,19 @@ describe('LocalPtyProvider', () => {
       expect(spawnEnv.Path.split(':')[0]).toBe('/tmp/orca-agent-teams-bin')
     })
 
-    it('does not inherit parent Orca pane identity when caller omits pane env', async () => {
+    it('does not inherit parent-scoped Orca env when caller omits it', async () => {
       const saved = {
         ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
         ORCA_TAB_ID: process.env.ORCA_TAB_ID,
-        ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID
+        ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
+        ORCA_SEQUENCED_STARTUP_COMMAND: process.env.ORCA_SEQUENCED_STARTUP_COMMAND,
+        ORCA_SEQUENCED_STARTUP_SCRIPT: process.env.ORCA_SEQUENCED_STARTUP_SCRIPT
       }
       process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
       process.env.ORCA_TAB_ID = 'parent-tab'
       process.env.ORCA_WORKTREE_ID = 'parent-worktree'
+      process.env.ORCA_SEQUENCED_STARTUP_COMMAND = 'parent-agent'
+      process.env.ORCA_SEQUENCED_STARTUP_SCRIPT = 'parent-gate'
 
       try {
         await provider.spawn({ cols: 80, rows: 24 })
@@ -569,17 +573,23 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.ORCA_PANE_KEY).toBeUndefined()
       expect(spawnCall[2].env.ORCA_TAB_ID).toBeUndefined()
       expect(spawnCall[2].env.ORCA_WORKTREE_ID).toBeUndefined()
+      expect(spawnCall[2].env.ORCA_SEQUENCED_STARTUP_COMMAND).toBeUndefined()
+      expect(spawnCall[2].env.ORCA_SEQUENCED_STARTUP_SCRIPT).toBeUndefined()
     })
 
-    it('preserves explicit child Orca pane identity over parent env', async () => {
+    it('preserves explicit child-scoped Orca env over parent env', async () => {
       const saved = {
         ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
         ORCA_TAB_ID: process.env.ORCA_TAB_ID,
-        ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID
+        ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
+        ORCA_SEQUENCED_STARTUP_COMMAND: process.env.ORCA_SEQUENCED_STARTUP_COMMAND,
+        ORCA_SEQUENCED_STARTUP_SCRIPT: process.env.ORCA_SEQUENCED_STARTUP_SCRIPT
       }
       process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
       process.env.ORCA_TAB_ID = 'parent-tab'
       process.env.ORCA_WORKTREE_ID = 'parent-worktree'
+      process.env.ORCA_SEQUENCED_STARTUP_COMMAND = 'parent-agent'
+      process.env.ORCA_SEQUENCED_STARTUP_SCRIPT = 'parent-gate'
 
       try {
         await provider.spawn({
@@ -588,7 +598,9 @@ describe('LocalPtyProvider', () => {
           env: {
             ORCA_PANE_KEY: 'child-tab:child-leaf',
             ORCA_TAB_ID: 'child-tab',
-            ORCA_WORKTREE_ID: 'child-worktree'
+            ORCA_WORKTREE_ID: 'child-worktree',
+            ORCA_SEQUENCED_STARTUP_COMMAND: 'child-agent',
+            ORCA_SEQUENCED_STARTUP_SCRIPT: 'child-gate'
           }
         })
       } finally {
@@ -605,6 +617,8 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.ORCA_PANE_KEY).toBe('child-tab:child-leaf')
       expect(spawnCall[2].env.ORCA_TAB_ID).toBe('child-tab')
       expect(spawnCall[2].env.ORCA_WORKTREE_ID).toBe('child-worktree')
+      expect(spawnCall[2].env.ORCA_SEQUENCED_STARTUP_COMMAND).toBe('child-agent')
+      expect(spawnCall[2].env.ORCA_SEQUENCED_STARTUP_SCRIPT).toBe('child-gate')
     })
   })
 })

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -42,6 +42,7 @@ import type { ShellReadySignal } from './local-pty-shell-ready-startup-command'
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
 import { removeAppImageRuntimeEnv } from '../pty/appimage-terminal-env'
 import { stripInheritedBuildModeEnv } from '../pty/build-mode-env'
+import { removeUnspecifiedPtyChildScopedEnv } from '../../shared/pty-child-scoped-env'
 import { stripLegacyTerminalShimEnv } from '../pty/legacy-terminal-shim-dir'
 import { dropIncoherentCondaActivationEnv } from '../pty/conda-activation-env'
 import { SessionNotFoundError } from '../daemon/daemon-errors'
@@ -103,7 +104,6 @@ import {
   getWslContextFromWorktreeId,
   normalizeLocalCallerSessionId,
   promoteAgentTeamsShimPath,
-  removeUnspecifiedPaneIdentityEnv,
   resolveForegroundFallbackProcess
 } from './local-pty-launch-helpers'
 
@@ -613,8 +613,8 @@ export class LocalPtyProvider implements IPtyProvider {
       // Why: supports-hyperlinks rejects TERM_PROGRAM=Orca, so tools drop OSC 8 links; force it since xterm.js parses them.
       FORCE_HYPERLINK: '1'
     } as Record<string, string>
-    // Why: Orca can be launched from an Orca terminal; pane identity belongs to the child PTY, not the parent shell.
-    removeUnspecifiedPaneIdentityEnv(spawnEnv, args.env)
+    // Why: Orca can be launched from an Orca terminal; pane identity and setup launch state belong to the child PTY.
+    removeUnspecifiedPtyChildScopedEnv(spawnEnv, args.env)
     removeAppImageRuntimeEnv(spawnEnv)
     removeInheritedNoColor(spawnEnv)
     for (const key of args.envToDelete ?? []) {

--- a/src/relay/pty-handler-revive.test.ts
+++ b/src/relay/pty-handler-revive.test.ts
@@ -422,8 +422,13 @@ describe('PtyHandler', () => {
   })
 
   it('revive preserves attach identity metadata without exporting hook identity env', async () => {
-    const oldPaneKey = process.env.ORCA_PANE_KEY
-    const oldTabId = process.env.ORCA_TAB_ID
+    const keys = [
+      'ORCA_PANE_KEY',
+      'ORCA_TAB_ID',
+      'ORCA_SEQUENCED_STARTUP_COMMAND',
+      'ORCA_SEQUENCED_STARTUP_SCRIPT'
+    ] as const
+    const saved = Object.fromEntries(keys.map((key) => [key, process.env[key]]))
     delete process.env.ORCA_PANE_KEY
     delete process.env.ORCA_TAB_ID
     try {
@@ -436,15 +441,12 @@ describe('PtyHandler', () => {
         tabId: 'tab-5'
       })
     } finally {
-      if (oldPaneKey === undefined) {
-        delete process.env.ORCA_PANE_KEY
-      } else {
-        process.env.ORCA_PANE_KEY = oldPaneKey
-      }
-      if (oldTabId === undefined) {
-        delete process.env.ORCA_TAB_ID
-      } else {
-        process.env.ORCA_TAB_ID = oldTabId
+      for (const key of keys) {
+        if (saved[key] === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = saved[key]
+        }
       }
     }
     const state = (await dispatcher.callRequest('pty.serialize', { ids: ['pty-1'] })) as string
@@ -454,27 +456,27 @@ describe('PtyHandler', () => {
     dispatcher = createMockDispatcher()
     handler = new PtyHandler(dispatcher as unknown as RelayDispatcher)
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
-    delete process.env.ORCA_PANE_KEY
-    delete process.env.ORCA_TAB_ID
+    for (const key of keys) {
+      process.env[key] = `parent-${key}`
+    }
     try {
       await dispatcher.callRequest('pty.revive', { state })
     } finally {
       killSpy.mockRestore()
-      if (oldPaneKey === undefined) {
-        delete process.env.ORCA_PANE_KEY
-      } else {
-        process.env.ORCA_PANE_KEY = oldPaneKey
-      }
-      if (oldTabId === undefined) {
-        delete process.env.ORCA_TAB_ID
-      } else {
-        process.env.ORCA_TAB_ID = oldTabId
+      for (const key of keys) {
+        if (saved[key] === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = saved[key]
+        }
       }
     }
 
     const callArgs = mockPtySpawn.mock.calls[0][2] as { env: Record<string, string> }
     expect(callArgs.env.ORCA_PANE_KEY).toBeUndefined()
     expect(callArgs.env.ORCA_TAB_ID).toBeUndefined()
+    expect(callArgs.env.ORCA_SEQUENCED_STARTUP_COMMAND).toBeUndefined()
+    expect(callArgs.env.ORCA_SEQUENCED_STARTUP_SCRIPT).toBeUndefined()
 
     await expect(
       dispatcher.callRequest('pty.attach', {

--- a/src/relay/pty-handler-spawn-environment.test.ts
+++ b/src/relay/pty-handler-spawn-environment.test.ts
@@ -89,6 +89,43 @@ describe('PtyHandler', () => {
     expect(spawnOptions.env.PATH).toBe(expectedEnv.PATH)
   })
 
+  it('does not inherit parent-scoped Orca env and preserves explicit child values', async () => {
+    const keys = [
+      'ORCA_PANE_KEY',
+      'ORCA_TAB_ID',
+      'ORCA_WORKTREE_ID',
+      'ORCA_AGENT_LAUNCH_TOKEN',
+      'ORCA_SEQUENCED_STARTUP_COMMAND',
+      'ORCA_SEQUENCED_STARTUP_SCRIPT'
+    ] as const
+    const saved = Object.fromEntries(keys.map((key) => [key, process.env[key]]))
+    for (const key of keys) {
+      process.env[key] = `parent-${key}`
+    }
+
+    try {
+      await dispatcher.callRequest('pty.spawn', {})
+      await dispatcher.callRequest('pty.spawn', {
+        env: Object.fromEntries(keys.map((key) => [key, `child-${key}`]))
+      })
+    } finally {
+      for (const key of keys) {
+        if (saved[key] === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = saved[key]
+        }
+      }
+    }
+
+    const inherited = mockPtySpawn.mock.calls[0][2] as { env: Record<string, string> }
+    const explicit = mockPtySpawn.mock.calls[1][2] as { env: Record<string, string> }
+    for (const key of keys) {
+      expect(inherited.env[key]).toBeUndefined()
+      expect(explicit.env[key]).toBe(`child-${key}`)
+    }
+  })
+
   describe('half-activated conda env (#14195)', () => {
     const CONDA_KEYS = [
       'CONDA_SHLVL',

--- a/src/relay/pty-handler-spawn-environment.test.ts
+++ b/src/relay/pty-handler-spawn-environment.test.ts
@@ -126,6 +126,29 @@ describe('PtyHandler', () => {
     }
   })
 
+  it('leaves an ordinary user terminal unguarded when the relay itself was launched from a gated agent pane', async () => {
+    // Why: the scrub has to run BEFORE buildSpawnEnv's consumers read the env.
+    // An inherited sequencing command otherwise becomes this pane's launch-command
+    // hint, and the credential guard then disables Git prompts in a user terminal.
+    const saved = process.env[SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV]
+    process.env[SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV] = 'claude --dangerously-skip-permissions'
+
+    try {
+      await dispatcher.callRequest('pty.spawn', { env: { GIT_TERMINAL_PROMPT: '1' } })
+    } finally {
+      if (saved === undefined) {
+        delete process.env[SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV]
+      } else {
+        process.env[SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV] = saved
+      }
+    }
+
+    const userEnv = mockPtySpawn.mock.calls[0][2].env as Record<string, string>
+    expect(userEnv.GIT_TERMINAL_PROMPT).toBe('1')
+    const state = (await dispatcher.callRequest('pty.serialize', { ids: ['pty-1'] })) as string
+    expect(JSON.parse(state)[0]?.gitCredentialPromptGuarded).toBe(false)
+  })
+
   describe('half-activated conda env (#14195)', () => {
     const CONDA_KEYS = [
       'CONDA_SHLVL',

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -23,6 +23,7 @@ import { DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS } from '../shared/ssh-types'
 import { shouldUseShellReadyStartupDelivery } from '../shared/codex-startup-delivery'
 import { buildStartupCommandSubmission } from '../shared/startup-command-submission'
 import { resolveSetupAgentSequenceLaunchCommand } from '../shared/setup-agent-sequencing'
+import { removeUnspecifiedPtyChildScopedEnv } from '../shared/pty-child-scoped-env'
 import {
   isPathInsideOrEqual,
   normalizeRuntimePathForComparison
@@ -654,6 +655,7 @@ export class PtyHandler {
       },
       rendererEnv
     ) as Record<string, string>
+    removeUnspecifiedPtyChildScopedEnv(baseEnv, rendererEnv)
     const augmented: Record<string, string> = {}
     for (const augmenter of this.envAugmenters) {
       try {

--- a/src/shared/pty-child-scoped-env.ts
+++ b/src/shared/pty-child-scoped-env.ts
@@ -1,0 +1,24 @@
+import {
+  SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV,
+  SETUP_AGENT_SEQUENCE_STARTUP_SCRIPT_ENV
+} from './setup-agent-sequencing'
+
+const PTY_CHILD_SCOPED_ENV_KEYS = [
+  'ORCA_PANE_KEY',
+  'ORCA_TAB_ID',
+  'ORCA_WORKTREE_ID',
+  'ORCA_AGENT_LAUNCH_TOKEN',
+  SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV,
+  SETUP_AGENT_SEQUENCE_STARTUP_SCRIPT_ENV
+] as const
+
+export function removeUnspecifiedPtyChildScopedEnv(
+  env: Record<string, string>,
+  explicitEnv: Record<string, string> | undefined
+): void {
+  for (const key of PTY_CHILD_SCOPED_ENV_KEYS) {
+    if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
+      delete env[key]
+    }
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​138 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​32 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​106 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​39 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 |

<!-- /orca-pr-loc -->

## ELI5

Some Orca terminals are "gated": the workspace has a setup script, so instead of starting the agent immediately, Orca gives that terminal two private environment variables that mean "wait for setup to finish, then run this agent command." Environment variables are inherited by every program a process starts — and that is the bug. If you launched Orca itself from inside one of those gated terminals (for example, typing `orca` in that pane's shell), the new Orca process inherited the "you are launching an agent" markers and passed them on to **every terminal it opened**. Every plain terminal then looked like it was launching an agent.

Two things you could actually notice:

1. **Git stopped asking for credentials.** Orca deliberately disables interactive Git credential prompts in unattended agent terminals (`GIT_TERMINAL_PROMPT=0`, blanked `GIT_ASKPASS`/`SSH_ASKPASS`, `GCM_INTERACTIVE=never`, `credential.interactive=false`) so an agent can never hang on an invisible "Username:" prompt. With the inherited markers, that guard fired in ordinary user terminals too: a `git clone`/`fetch`/`push` over HTTPS that needed to ask for credentials failed immediately with `fatal: could not read Username … terminal prompts disabled` instead of prompting. Cached credentials kept working (the credential helper is preserved), so it presented as intermittent auth failure rather than an obvious config problem.
2. **OMP status entries disappeared** (the originally reported symptom): the terminal "already" seemed to be launching an agent, so the derived OMP status setup was suppressed.

## When you'd hit it

- A pane is setup-gated: the workspace has a setup command, so the agent pane's shell carries `ORCA_SEQUENCED_STARTUP_COMMAND` (plus `ORCA_SEQUENCED_STARTUP_SCRIPT` on POSIX) for its whole lifetime.
- From that shell you start an Orca process — the desktop app or CLI locally, or an Orca relay server on an SSH host. That process's `process.env` now carries the sequencing variables.
- Every terminal that instance spawns then inherits them: local spawns build on `process.env` (`buildPtyHostEnv`), the persistent daemon inherits by fork, and the SSH relay's `buildSpawnEnv` spreads the relay server's `process.env`. `resolveSetupAgentSequenceLaunchCommand` turns the inherited startup command into that terminal's launch-command hint, so `applyTerminalGitCredentialPromptGuard` and the OMP-shadow logic both treat the plain terminal as an agent launch.

Before this PR, the local and daemon boundaries already scrubbed the four pane-identity keys (`ORCA_PANE_KEY`, `ORCA_TAB_ID`, `ORCA_WORKTREE_ID`, `ORCA_AGENT_LAUNCH_TOKEN`) — but not the two sequencing keys, and the SSH relay boundary scrubbed none of the six.

## What Changed

- Treat pane identity, launch tokens, and setup-sequencing variables as child-PTY-scoped environment.
- Apply the ownership rule at local, persistent-daemon, and SSH relay spawn boundaries.
- Preserve values explicitly supplied for the child PTY.
- Add regression coverage for local, daemon, WSL, relay fresh-spawn, and relay revive paths.
- Concretely: one shared scrubber (`removeUnspecifiedPtyChildScopedEnv`) removes all six keys above at every spawn boundary unless the caller explicitly supplied them for that child. The relay previously had no scrub of any of these keys; it now scrubs all six at fresh spawn and at revive.

## Why

The WSLENV test exposed a production environment ownership bug, not an order-dependent assertion. The 16-to-8 shard change made the test visible in a different batch, but the failure also reproduced isolated because the parent Orca process carries setup-sequencing variables.

The blast radius is wider than the OMP status symptom: the same inherited state made `applyTerminalGitCredentialPromptGuard` treat ordinary user terminals as agent launches, forcing `GIT_TERMINAL_PROMPT=0` (overriding both an explicit `=1` and Git's prompt-by-default) along with the askpass/GCM guards — a user-visible behavior change in terminals where people run Git by hand, not an internal detail. An independent review reproduced this from its own gated pane: with the inherited environment present, pre-PR code fails 7 existing tests in isolation, including the relay assertion that an ordinary user terminal's `GIT_TERMINAL_PROMPT` is left unchanged.

The E2E native build blocker is already resolved on main by `9e0704b9d46209885e95f1a24292a486b041dc73`; this PR does not duplicate that fix.

## Linked Issue

N/A — current-main CI health blocker.

## Visual Proof

N/A — no visible UI or interaction surface changes; this changes PTY child environment construction.

## Testing

- [x] Automated tests added/updated
- Focused local/daemon/WSL/relay suite — 106 passed
- Exact PR shard `--shard=1/8` — 847 files passed, 6 skipped; 7,644 tests passed, 26 skipped
- `pnpm tc:node`
- Three changed-file oxlint lenses
- E2E workflow contract — 34 passed
- Linux x64 Node 24 Docker target coverage and native-runtime E2E build validation

## Review

Independent same-model adversarial review found the missing relay parity path; it was fixed and the updated diff was re-reviewed clean. Performance is bounded to six key checks per PTY spawn with no polling, fanout, retained state, or output-path work. A second independent adversarial review at head `f875c0ff72ba` reproduced the bug from its own gated review pane and confirmed the wider user-facing blast radius described above.

## Agent skill upstream boundary

- [x] Not applicable

## Notes

No persisted state, IPC/RPC wire contract, mobile surface, renderer UI, or user-owned data changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Visual proof is N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform and SSH/remote impact considered
- [x] Focused tests, typecheck, code-quality checks, and exact CI shard pass; CI will cover the remaining matrix
