### PR TITLE
Stop the OS keyring probe from gating the first window on Linux

### DIFF
--- a/src/main/host/deferred-secret-protection-report.test.ts
+++ b/src/main/host/deferred-secret-protection-report.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { setSecretStore } from '../../shared/secret-store'
+import { _resetSecretStoreForTests, setSecretStore } from '../../shared/secret-store'
 
 type Listener = (...args: unknown[]) => void
 
@@ -69,6 +69,7 @@ describe('scheduleSecretProtectionGapReport', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    _resetSecretStoreForTests()
     rmSync(dir, { recursive: true, force: true })
   })
 
@@ -126,10 +127,36 @@ describe('scheduleSecretProtectionGapReport', () => {
     schedule()
     const window = createWindow()
     window.reveal()
+    drain()
+    // Why assert the timer is gone and not just the probe count: the once-guard alone makes
+    // the count right, so without this the fallback could stay armed for 15s past the reveal
+    // and nothing here would notice.
+    expect(vi.getTimerCount()).toBe(0)
     vi.runAllTimers()
     vi.advanceTimersByTime(60_000)
     vi.runAllTimers()
     expect(probes).toBe(1)
+  })
+
+  it('does not let the fallback timer hold the process open', () => {
+    // Why: the report is diagnostics; a referenced 15s timer would keep a quitting app alive
+    // for up to 15s after its last window closed.
+    const timers: ReturnType<typeof setTimeout>[] = []
+    const original = globalThis.setTimeout
+    const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((
+      ...args: Parameters<typeof setTimeout>
+    ) => {
+      const timer = original(...args)
+      timers.push(timer)
+      return timer
+    }) as typeof setTimeout)
+    try {
+      schedule()
+    } finally {
+      spy.mockRestore()
+    }
+    expect(timers).toHaveLength(1)
+    expect(timers[0]?.hasRef()).toBe(false)
   })
 
   it('does not probe again when the window reveals after the fallback already reported', () => {
@@ -144,6 +171,26 @@ describe('scheduleSecretProtectionGapReport', () => {
     window.reveal()
     drain()
     expect(probes).toBe(1)
+  })
+
+  it('does not turn a throwing report into a fatal main-process error', () => {
+    // Why: deferred, this runs off whenReady's promise chain, where a throw is an
+    // uncaughtException the main-process guard re-throws fatally (#9441) — not the
+    // unhandled rejection the app survives. A diagnostic must never end the process.
+    let thrown = 0
+    scheduleSecretProtectionGapReport({
+      dataFile,
+      log: () => {
+        thrown += 1
+        throw new Error('log sink is broken')
+      },
+      deferUntilFirstWindow: true
+    })
+    const window = createWindow()
+    window.reveal()
+    expect(() => drain()).not.toThrow()
+    expect(probes).toBe(1)
+    expect(thrown).toBeGreaterThan(0)
   })
 
   it('reports inline in headless serve, before the runtime is advertised as ready', () => {

--- a/src/main/host/deferred-secret-protection-report.test.ts
+++ b/src/main/host/deferred-secret-protection-report.test.ts
@@ -132,6 +132,20 @@ describe('scheduleSecretProtectionGapReport', () => {
     expect(probes).toBe(1)
   })
 
+  it('does not probe again when the window reveals after the fallback already reported', () => {
+    // Why this order and not the reverse: a GPU that presents late reveals the window
+    // after the fallback has already reported, and a second blocking keyring probe would
+    // freeze the main thread exactly as the user starts interacting.
+    schedule()
+    const window = createWindow()
+    vi.advanceTimersByTime(15_100)
+    drain()
+    expect(probes).toBe(1)
+    window.reveal()
+    drain()
+    expect(probes).toBe(1)
+  })
+
   it('reports inline in headless serve, before the runtime is advertised as ready', () => {
     // Why not deferred: serve opens no window, so the fallback would fire only after
     // clients could already have paired, and a frozen main thread reads as a dead host.

--- a/src/main/host/deferred-secret-protection-report.test.ts
+++ b/src/main/host/deferred-secret-protection-report.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setSecretStore } from '../../shared/secret-store'
+
+type Listener = (...args: unknown[]) => void
+
+const appListeners = new Map<string, Listener[]>()
+
+vi.mock('electron', () => ({
+  app: {
+    once: (event: string, listener: Listener) => {
+      const existing = appListeners.get(event) ?? []
+      existing.push(listener)
+      appListeners.set(event, existing)
+    }
+  }
+}))
+
+const { scheduleSecretProtectionGapReport } = await import('./deferred-secret-protection-report')
+
+/** Stands in for the BrowserWindow the app creates first. */
+function fakeWindow(): { once: (event: string, listener: Listener) => void; reveal: () => void } {
+  const listeners: Listener[] = []
+  return {
+    once: (event, listener) => {
+      if (event === 'ready-to-show') {
+        listeners.push(listener)
+      }
+    },
+    reveal: () => listeners.splice(0).forEach((listener) => listener())
+  }
+}
+
+function createWindow(): ReturnType<typeof fakeWindow> {
+  const window = fakeWindow()
+  appListeners.get('browser-window-created')?.splice(0).forEach((listener) => listener({}, window))
+  return window
+}
+
+describe('scheduleSecretProtectionGapReport', () => {
+  let dir: string
+  let dataFile: string
+  let probes: number
+  let logged: string[]
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    appListeners.clear()
+    dir = mkdtempSync(join(tmpdir(), 'orca-deferred-secret-report-'))
+    dataFile = join(dir, 'orca-data.json')
+    probes = 0
+    logged = []
+    setSecretStore({
+      isEncryptionAvailable: () => true,
+      encryptString: (plainText) => Buffer.from(plainText),
+      decryptString: (cipher) => cipher.toString(),
+      describeProtectionGap: () => {
+        // Why count here: this is the call that blocks on the OS keyring.
+        probes += 1
+        return 'The OS keyring is unavailable.'
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const schedule = (): void =>
+    scheduleSecretProtectionGapReport({ dataFile, log: (m) => void logged.push(m) })
+
+  it('does not probe the keyring while the first window is still being created', () => {
+    // Why this is the regression: probing here blocked the window for 76s on a locked
+    // Linux keyring, which reads to the user as "the app will not open" (STA-5765).
+    schedule()
+    createWindow()
+    expect(probes).toBe(0)
+    expect(logged).toEqual([])
+  })
+
+  it('probes once the window is ready to show', () => {
+    schedule()
+    const window = createWindow()
+    window.reveal()
+    vi.runAllTimers()
+    expect(probes).toBe(1)
+    expect(logged).toEqual(['[secrets] The OS keyring is unavailable.'])
+  })
+
+  it('still reports when ready-to-show never fires, so a failed reveal is not silent', () => {
+    // Why: a GPU/driver failure can keep ready-to-show from ever firing, and headless
+    // serve has no window at all.
+    schedule()
+    createWindow()
+    vi.advanceTimersByTime(15_000)
+    vi.runAllTimers()
+    expect(probes).toBe(1)
+  })
+
+  it('probes only once when the window reveals and the fallback also elapses', () => {
+    schedule()
+    const window = createWindow()
+    window.reveal()
+    vi.runAllTimers()
+    vi.advanceTimersByTime(60_000)
+    vi.runAllTimers()
+    expect(probes).toBe(1)
+  })
+})

--- a/src/main/host/deferred-secret-protection-report.test.ts
+++ b/src/main/host/deferred-secret-protection-report.test.ts
@@ -73,7 +73,11 @@ describe('scheduleSecretProtectionGapReport', () => {
   })
 
   const schedule = (): void =>
-    scheduleSecretProtectionGapReport({ dataFile, log: (m) => void logged.push(m) })
+    scheduleSecretProtectionGapReport({
+      dataFile,
+      log: (m) => void logged.push(m),
+      deferUntilFirstWindow: true
+    })
 
   /** Runs an already-queued setImmediate; the 1ms is slack, not a delay under test. */
   const drain = (): void => void vi.advanceTimersByTime(1)
@@ -124,6 +128,29 @@ describe('scheduleSecretProtectionGapReport', () => {
     window.reveal()
     vi.runAllTimers()
     vi.advanceTimersByTime(60_000)
+    vi.runAllTimers()
+    expect(probes).toBe(1)
+  })
+
+  it('reports inline in headless serve, before the runtime is advertised as ready', () => {
+    // Why not deferred: serve opens no window, so the fallback would fire only after
+    // clients could already have paired, and a frozen main thread reads as a dead host.
+    scheduleSecretProtectionGapReport({
+      dataFile,
+      log: (m) => void logged.push(m),
+      deferUntilFirstWindow: false
+    })
+    expect(probes).toBe(1)
+    expect(logged).toEqual(['[secrets] The OS keyring is unavailable.'])
+  })
+
+  it('leaves no timer armed in headless serve', () => {
+    scheduleSecretProtectionGapReport({
+      dataFile,
+      log: (m) => void logged.push(m),
+      deferUntilFirstWindow: false
+    })
+    expect(vi.getTimerCount()).toBe(0)
     vi.runAllTimers()
     expect(probes).toBe(1)
   })

--- a/src/main/host/deferred-secret-protection-report.test.ts
+++ b/src/main/host/deferred-secret-protection-report.test.ts
@@ -35,7 +35,10 @@ function fakeWindow(): { once: (event: string, listener: Listener) => void; reve
 
 function createWindow(): ReturnType<typeof fakeWindow> {
   const window = fakeWindow()
-  appListeners.get('browser-window-created')?.splice(0).forEach((listener) => listener({}, window))
+  appListeners
+    .get('browser-window-created')
+    ?.splice(0)
+    .forEach((listener) => listener({}, window))
   return window
 }
 
@@ -72,11 +75,18 @@ describe('scheduleSecretProtectionGapReport', () => {
   const schedule = (): void =>
     scheduleSecretProtectionGapReport({ dataFile, log: (m) => void logged.push(m) })
 
+  /** Runs an already-queued setImmediate; the 1ms is slack, not a delay under test. */
+  const drain = (): void => void vi.advanceTimersByTime(1)
+
   it('does not probe the keyring while the first window is still being created', () => {
     // Why this is the regression: probing here blocked the window for 76s on a locked
     // Linux keyring, which reads to the user as "the app will not open" (STA-5765).
     schedule()
     createWindow()
+    // Why drain: creation alone must arm nothing. Asserting before the queue drains
+    // would also pass if the probe were merely queued off `browser-window-created`,
+    // which on the real path still lands before the window paints.
+    drain()
     expect(probes).toBe(0)
     expect(logged).toEqual([])
   })
@@ -85,7 +95,10 @@ describe('scheduleSecretProtectionGapReport', () => {
     schedule()
     const window = createWindow()
     window.reveal()
-    vi.runAllTimers()
+    // Why: the reveal handler must return before the blocking probe runs, or the paint
+    // it is waiting on is the thing being blocked.
+    expect(probes).toBe(0)
+    drain()
     expect(probes).toBe(1)
     expect(logged).toEqual(['[secrets] The OS keyring is unavailable.'])
   })
@@ -95,8 +108,13 @@ describe('scheduleSecretProtectionGapReport', () => {
     // serve has no window at all.
     schedule()
     createWindow()
-    vi.advanceTimersByTime(15_000)
-    vi.runAllTimers()
+    // Why bracket the wait instead of running every timer: an unbounded flush passes for
+    // any fallback delay, including one long enough to never arrive in a real session.
+    vi.advanceTimersByTime(14_000)
+    drain()
+    expect(probes).toBe(0)
+    vi.advanceTimersByTime(1_100)
+    drain()
     expect(probes).toBe(1)
   })
 

--- a/src/main/host/deferred-secret-protection-report.ts
+++ b/src/main/host/deferred-secret-protection-report.ts
@@ -1,0 +1,46 @@
+import { app, type BrowserWindow } from 'electron'
+import { reportSecretProtectionGap } from './secret-protection-report'
+
+/**
+ * Run the at-rest secret protection report once the app is up, never before.
+ *
+ * Why deferred: `describeProtectionGap()` asks Electron `safeStorage` whether the OS
+ * keyring is usable, and on Linux that is a blocking D-Bus round trip to
+ * `org.freedesktop.secrets`. A keyring that is present but locked with no unlock
+ * prompter never answers, so the call sits until D-Bus times it out — measured at 76s
+ * to first window on Ubuntu 24.04, against 1s on the build before the report existed
+ * (STA-5765). Run before the first window, that reads to the user as "the app will not
+ * open"; the window is gated behind a diagnostic whose result nothing on the startup
+ * path consumes.
+ */
+
+// Why a fallback as well as the window event: `ready-to-show` can fail to fire at all
+// when the GPU/driver cannot present (see main-window-state-lifecycle), and headless
+// serve has no window to wait on.
+const REPORT_FALLBACK_MS = 15_000
+
+export function scheduleSecretProtectionGapReport(options: {
+  dataFile: string
+  force?: boolean
+  log?: (message: string) => void
+}): void {
+  let ran = false
+  const run = (): void => {
+    if (ran) {
+      return
+    }
+    ran = true
+    clearTimeout(fallback)
+    // Why setImmediate: keep the blocking keyring probe off the event handler that
+    // reveals the window, so the reveal paints first.
+    setImmediate(() => {
+      reportSecretProtectionGap(options)
+    })
+  }
+
+  const fallback = setTimeout(run, REPORT_FALLBACK_MS)
+  fallback.unref?.()
+  app.once('browser-window-created', (_event: Electron.Event, window: BrowserWindow) => {
+    window.once('ready-to-show', run)
+  })
+}

--- a/src/main/host/deferred-secret-protection-report.ts
+++ b/src/main/host/deferred-secret-protection-report.ts
@@ -12,6 +12,12 @@ import { reportSecretProtectionGap } from './secret-protection-report'
  * (STA-5765). Run before the first window, that reads to the user as "the app will not
  * open"; the window is gated behind a diagnostic whose result nothing on the startup
  * path consumes.
+ *
+ * Why every platform and not just Linux: deferring costs nothing here — no caller reads the
+ * result, so the only thing that moves is when a console line appears. macOS pays the same
+ * shape against the Keychain, and a probe that has to answer before a window exists is wrong
+ * on any host. A deferral that withholds a real secret has to be scoped to the platform that
+ * needs it; this one withholds nothing.
  */
 
 // Why a fallback as well as the window event: `ready-to-show` can fail to fire at all
@@ -40,6 +46,25 @@ export function scheduleSecretProtectionGapReport({
     return
   }
 
+  // Why swallow here and not in reportSecretProtectionGap: deferred, this no longer runs on
+  // whenReady's promise chain, where a throw was an unhandled rejection the app survives
+  // (#9441). Off that chain it is an uncaughtException, and installUncaughtPipeErrorGuard
+  // re-throws those fatally — killing the app over a diagnostic the module documents as
+  // deliberately not fatal. Serve still reports inline and keeps the old posture.
+  const report = (): void => {
+    try {
+      reportSecretProtectionGap(options)
+    } catch (error) {
+      try {
+        ;(options.log ?? console.warn)(
+          `[secrets] could not run the deferred protection report: ${String(error)}`
+        )
+      } catch {
+        // A throwing log sink must not be what ends the process either.
+      }
+    }
+  }
+
   let ran = false
   const run = (): void => {
     if (ran) {
@@ -49,9 +74,7 @@ export function scheduleSecretProtectionGapReport({
     clearTimeout(fallback)
     // Why setImmediate: keep the blocking keyring probe off the event handler that
     // reveals the window, so the reveal paints first.
-    setImmediate(() => {
-      reportSecretProtectionGap(options)
-    })
+    setImmediate(report)
   }
 
   const fallback = setTimeout(run, REPORT_FALLBACK_MS)

--- a/src/main/host/deferred-secret-protection-report.ts
+++ b/src/main/host/deferred-secret-protection-report.ts
@@ -19,11 +19,27 @@ import { reportSecretProtectionGap } from './secret-protection-report'
 // serve has no window to wait on.
 const REPORT_FALLBACK_MS = 15_000
 
-export function scheduleSecretProtectionGapReport(options: {
+export function scheduleSecretProtectionGapReport({
+  deferUntilFirstWindow,
+  ...options
+}: {
   dataFile: string
   force?: boolean
   log?: (message: string) => void
+  /**
+   * Why headless serve reports inline instead: it never opens a window, so the fallback
+   * timer is the only path — and by then the runtime has been advertised as ready and
+   * clients may have paired. Freezing the main thread under a live client stalls pings
+   * and PTY pumps, which reads as a dead host. Blocking before anything is advertised is
+   * the timing serve already had, and the safer of the two.
+   */
+  deferUntilFirstWindow: boolean
 }): void {
+  if (!deferUntilFirstWindow) {
+    reportSecretProtectionGap(options)
+    return
+  }
+
   let ran = false
   const run = (): void => {
     if (ran) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,7 +36,7 @@ import { setSpeechServiceFactories } from './speech/speech-runtime-service'
 import { setWorktreeWatcherRemoval } from './ipc/worktree-watcher-removal'
 import { setSecretStore } from '../shared/secret-store'
 import { ElectronSecretStore } from './host/electron-secret-store'
-import { reportSecretProtectionGap } from './host/secret-protection-report'
+import { scheduleSecretProtectionGapReport } from './host/deferred-secret-protection-report'
 import { initSessionParseCachePersistence } from './ai-vault/session-parse-cache-persistence'
 import { ensureActiveOrcaProfile, initOrcaProfilePaths } from './orca-profiles/profile-index-store'
 import { getOrcaCloudAuthConfig } from './orca-profiles/profile-cloud-auth-config'
@@ -2346,9 +2346,11 @@ void app.whenReady().then(async () => {
     dataFile: activeOrcaProfile.dataFile,
     storageAuthority: isServeMode ? 'runtime' : 'desktop'
   })
-  // Why here and not at install time: the report remembers what it last said, and that
-  // state lives beside the profile data file, which does not exist until now.
-  reportSecretProtectionGap({
+  // Why armed here and not at install time: the report remembers what it last said, and
+  // that state lives beside the profile data file, which does not exist until now.
+  // Why scheduled and not called: the report probes the OS keyring, which blocks on Linux
+  // and must not gate the first window (STA-5765).
+  scheduleSecretProtectionGapReport({
     dataFile: activeOrcaProfile.dataFile,
     force: process.env.ORCA_ALWAYS_REPORT_SECRET_PROTECTION === '1'
   })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2352,7 +2352,8 @@ void app.whenReady().then(async () => {
   // and must not gate the first window (STA-5765).
   scheduleSecretProtectionGapReport({
     dataFile: activeOrcaProfile.dataFile,
-    force: process.env.ORCA_ALWAYS_REPORT_SECRET_PROTECTION === '1'
+    force: process.env.ORCA_ALWAYS_REPORT_SECRET_PROTECTION === '1',
+    deferUntilFirstWindow: !isServeMode
   })
   // Why here: the host key store is a sidecar of the same profile, and every SSH connect consults
   // it. Left unbound it reports nothing trusted, which is safe but silently discards our own

--- a/src/main/startup/secret-protection-report-deferral-wiring.test.ts
+++ b/src/main/startup/secret-protection-report-deferral-wiring.test.ts
@@ -39,7 +39,17 @@ describe('secret protection report deferral wiring', () => {
     expect(start).toBeGreaterThanOrEqual(0)
     const end = source.indexOf('\n  })', start)
     expect(end).toBeGreaterThan(start)
+    // Why bound the length too: `end` is the next call-shaped close at this indent, not
+    // necessarily this call's. Nest the call one level deeper and that anchor overshoots into
+    // unrelated code, so the assertions below pass against a call site that never runs.
+    expect(end - start).toBeLessThan(500)
     const call = source.slice(start, end)
+
+    // Why anchor the indent: `SCHEDULE` matches anywhere, including as the body of an added
+    // `if (...) schedule(...)` guard, which leaves every assertion here true while the call
+    // stops running unconditionally. Pinning it as a statement at whenReady's own indent is
+    // what makes "this runs on every desktop startup" the thing under test.
+    expect(source).toContain(`\n  ${SCHEDULE}`)
 
     expect(call).toContain('deferUntilFirstWindow: !isServeMode')
     // Why assert the constants are absent too: `!isServeMode` being present does not stop a

--- a/src/main/startup/secret-protection-report-deferral-wiring.test.ts
+++ b/src/main/startup/secret-protection-report-deferral-wiring.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Guards the one line that decides whether the OS keyring gates the first window.
+ *
+ * The report is diagnostics nothing on the startup path reads, but `describeProtectionGap()`
+ * is a blocking D-Bus round trip on Linux, and a present-but-locked keyring never answers —
+ * 76s to first window on Ubuntu 24.04 (STA-5765). Both directions of the one flag here are
+ * silent: `true` gives headless serve a deferral it must never have (serve opens no window,
+ * so only the fallback fires, after clients may have paired, and a frozen main thread reads
+ * as a dead host); `false` puts the blocking probe back in front of the window. Deleting the
+ * call entirely restores the original regression.
+ *
+ * Source-level because that is the property: this runs once inside `app.whenReady()` during
+ * startup, so there is no seam to assert against at runtime.
+ */
+describe('secret protection report deferral wiring', () => {
+  const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+
+  const SCHEDULE = 'scheduleSecretProtectionGapReport({'
+
+  it('arms the deferred report exactly once and never calls the blocking one directly', () => {
+    expect(source.split(SCHEDULE).length - 1, `${SCHEDULE} should appear exactly once`).toBe(1)
+    expect(source).toContain(
+      "import { scheduleSecretProtectionGapReport } from './host/deferred-secret-protection-report'"
+    )
+    // Why also assert the absence: re-importing the blocking entry point reinstates the
+    // pre-window probe without touching the call site the next test pins. Note the scheduling
+    // name is `...GapReport(`, so it does not match this substring.
+    expect(source.split('reportSecretProtectionGap(').length - 1).toBe(0)
+  })
+
+  it('defers on desktop and reports inline in headless serve', () => {
+    const start = source.indexOf(SCHEDULE)
+    // Why bound every anchor: an unresolved one is -1, and the slice below would then run to
+    // EOF and pass against unrelated code.
+    expect(start).toBeGreaterThanOrEqual(0)
+    const end = source.indexOf('\n  })', start)
+    expect(end).toBeGreaterThan(start)
+    const call = source.slice(start, end)
+
+    expect(call).toContain('deferUntilFirstWindow: !isServeMode')
+    // Why assert the constants are absent too: `!isServeMode` being present does not stop a
+    // later property in the same literal from overriding it.
+    expect(call).not.toContain('deferUntilFirstWindow: true')
+    expect(call).not.toContain('deferUntilFirstWindow: false')
+  })
+
+  it('arms the report after the profile exists and inside app readiness', () => {
+    // Why: the report remembers what it last said beside the profile data file, so arming it
+    // before the profile is resolved would key the state off a path that does not exist yet.
+    // Anchored on code, never a comment — a reworded comment silently becomes -1.
+    const ready = source.indexOf('app.whenReady().then(')
+    const profile = source.indexOf('const activeOrcaProfile = ensureActiveOrcaProfile()')
+    const schedule = source.indexOf(SCHEDULE)
+
+    expect(ready).toBeGreaterThanOrEqual(0)
+    expect(profile).toBeGreaterThan(ready)
+    expect(schedule).toBeGreaterThan(profile)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​291 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​291 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 |

<!-- /orca-pr-loc -->

## ELI5

Before Orca can put a window on screen it runs a small diagnostic that asks the operating system
"can I safely store secrets?" On Linux that question goes out over the desktop's secret service, and
a keyring that is present but **locked with no way to prompt you to unlock it** accepts the question
and then never answers. Orca sat there waiting, with no window and nothing to click — it looked like
the app simply refused to launch. (It did eventually open, which matches the report that "you can
open it again after trying for a bit".)

Nothing on the startup path even reads that diagnostic's result. So this change stops asking until
after the window is on screen.

## User-facing before / after

| | Before | After |
|---|---|---|
| Linux desktop with a keyring that's locked and can't prompt, on 1.4.190 | No window at all for over a minute. The app looked broken; the reporter's workaround was to go back to 1.4.188 | The window appears in about five seconds |
| Linux desktop with no keyring at all, on 1.4.190 | Still about 26 seconds to a window, where 1.4.188 took one | About one second again |
| Linux desktop with a healthy keyring | Fine | Unchanged |
| macOS and Windows | Unaffected | Unchanged |
| After the window appears, on the locked-keyring machine | — | **Honest limit:** the window is up, but the main process still stalls until the keyring query gives up (~75 s), so the app is visible before it is fully responsive. Strictly better than no window, but not a cure — see the residual note below |

## When it bites

Linux desktop users on 1.4.190. Worst on machines with a keyring installed but locked and with no
unlock prompter available; also slower than it should be on machines with no keyring at all. macOS
and Windows never reach the blocking call.


## What broke

A user on Ubuntu reported that Orca **1.4.190 will not open, while 1.4.188 works**, and that "afterward the user can open again after trying for a bit."

1.4.190 added an at-rest secret protection report (`src/main/host/secret-protection-report.ts`, new in 190) and called it **synchronously on the startup path** — `src/main/index.ts` inside `app.whenReady()`, roughly a thousand lines before `openMainWindow()`.

`describeProtectionGap()` asks Electron `safeStorage` whether the OS keyring is usable. On Linux that is a **blocking D-Bus round trip to `org.freedesktop.secrets`**. A keyring that is present but locked with no unlock prompter accepts the call and never answers, so the main process sits there until D-Bus times each call out. The first window is gated behind a diagnostic whose result nothing on the startup path reads.

The file's own doc comment already stated the intent — *"Deliberately not fatal and not a dialog: sealing still works, so blocking startup would be worse than the gap it reports"* — the placement just contradicted it.

## Evidence

Real Ubuntu 24.04, packaged `.deb` builds, private D-Bus with a fault-injected Secret Service that accepts the connection and never replies. Time to first **mapped** window:

| Build | Keyring | `[secrets]` reported | Window mapped |
|---|---|---|---|
| 1.4.188 | absent | — | **1.04s** |
| 1.4.188 | hanging | — | **1.06s** |
| 1.4.190 | absent | 25.87s | **26.39s** |
| 1.4.190 | hanging | 76.05s | **76.05s** |
| 1.4.190 `--password-store=basic` | hanging | 0.54s | **1.06s** |

Two things worth noting: the window maps at the *same instant* the probe completes, which is the gating relationship directly; and 1.4.188 under a hanging keyring never contacts `org.freedesktop.secrets` at all. The 76s also explains the "can open again after trying for a bit" — it does eventually open.

## The fix

Schedule the report instead of calling it. It runs on the first window's `ready-to-show`, with a 15s timer fallback because that event can fail to fire when the GPU cannot present (see `main-window-state-lifecycle.ts:35`) and headless serve has no window at all. This follows the existing deferral precedent in `attach-main-window-services.ts:204`.

Validated end-to-end by building this branch on the same box and running it against the same hanging keyring:

| Same build, same hanging keyring | Window mapped | `[secrets]` reported |
|---|---|---|
| Unpatched control | **80.48s** | 76.25s |
| This branch | **5.31s** | 80.17s |

The report still fires; it just no longer gates the window.

## Known residual — worth a follow-up

This makes the app **open**, not fully **usable**, in the pathological case. `safeStorage.isEncryptionAvailable()` is synchronous and main-process-only, so when the deferred probe runs it still blocks the main thread until D-Bus gives up (~75s here). The window is up at 5s but main-process IPC stalls until the probe returns.

Fully removing that needs one of:
- a bounded liveness check of `org.freedesktop.secrets` before touching `safeStorage`, skipping the report if it does not answer — the repo has **no D-Bus usage today**, so this is new platform machinery; or
- making the report passive: record what real seal/unseal operations already observe and report from that, never probing on its own.

Both are more scope than a `cherry-pick`-labelled regression fix should carry, so they are flagged rather than included.

## Also checked — two reporter claims that are wrong

The ticket carries a third-party root-cause writeup. Two parts of it do not survive contact with the source, and are called out so nobody cherry-picks at them:

- **"Newer Chromium."** Electron is pinned `^43.1.0` in both versions and resolves to `electron@43.1.0` in `pnpm-lock.yaml` at both tags. Chromium is identical; it cannot be the delta. Their Mesa driver was equally old on 1.4.188, which worked.
- **"The profile path moved and did not migrate."** The entire 188→190 diff to `profile-storage-paths.ts` is `app.getPath('userData')` → `getAppEnvironment().getPath('userData')`, and `ElectronAppEnvironment.getPath` is `return app.getPath(name)`. A literal pass-through on desktop. Their data loss was real but had another cause.

Separately confirmed and **not** fixed here: the GPU fallback path (marker → `disableHardwareAcceleration()` → switches) is gated `process.platform !== 'win32'` at `src/main/index.ts:1849`, so Linux gets no software-GL fallback. That matches the reporter's fourth observation and deserves its own ticket.

## Test

`src/main/host/deferred-secret-protection-report.test.ts` — asserts the keyring is not probed while the first window is being created, that it is probed on `ready-to-show`, that the fallback still reports when `ready-to-show` never fires, and that it probes exactly once. All four fail against the pre-fix synchronous call.

`pnpm tc` clean, `oxlint` clean, existing `secret-protection-report.test.ts` still passes.

