### PR TITLE
fix(pty): stop fish printing a test error when codex is absent (#16893)

### DIFF
--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-fish-init.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-fish-init.txt
@@ -2,9 +2,14 @@ function __orca_shell_ready_marker --on-event fish_prompt
   builtin printf "\033]777;orca-shell-ready\007"
   functions -e __orca_shell_ready_marker
 end
-if test -x "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test (type -t codex 2>/dev/null) = file
+# Why captured: an unquoted (type -t codex) expands to zero words when codex is
+# absent, leaving "test = file" — fish then errors instead of failing closed.
+# Quoting in place is not the fix; fish never substitutes inside double quotes.
+set -l __orca_codex_type (type -t codex 2>/dev/null)
+if test -x "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test "$__orca_codex_type" = file
   function codex
     command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
     command codex $argv
   end
 end
+set -e __orca_codex_type

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-fish-init.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-fish-init.txt
@@ -2,9 +2,14 @@ function __orca_shell_ready_marker --on-event fish_prompt
   builtin printf "\033]777;orca-shell-ready\007"
   functions -e __orca_shell_ready_marker
 end
-if test -x "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test (type -t codex 2>/dev/null) = file
+# Why captured: an unquoted (type -t codex) expands to zero words when codex is
+# absent, leaving "test = file" — fish then errors instead of failing closed.
+# Quoting in place is not the fix; fish never substitutes inside double quotes.
+set -l __orca_codex_type (type -t codex 2>/dev/null)
+if test -x "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test "$__orca_codex_type" = file
   function codex
     command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
     command codex $argv
   end
 end
+set -e __orca_codex_type

--- a/src/main/pty/codex-shell-launch-preflight.test.ts
+++ b/src/main/pty/codex-shell-launch-preflight.test.ts
@@ -5,6 +5,8 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
+  symlinkSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -17,13 +19,69 @@ import {
   getPowerShellCodexShellLaunchPreflight,
   resolveCodexShellLaunchPreflightCommand
 } from './codex-shell-launch-preflight'
+import { fishRequirementViolation, resolveFishBinary } from '../../shared/fish-binary-requirement'
 
 const roots: string[] = []
 const zshAvailable = existsSync('/bin/zsh')
 const bashAvailable = existsSync('/bin/bash')
-const fishAvailable = spawnSync('fish', ['--version']).status === 0
+// Why the shared lookup: it also finds a Homebrew fish that is off PATH, and it
+// carries the ORCA_REQUIRE_FISH contract asserted below.
+const fishLookup = resolveFishBinary()
+const fishAvailable = fishLookup.available
 const pwshAvailable =
   spawnSync('pwsh', ['-NoLogo', '-NoProfile', '-Command', 'exit 0']).status === 0
+// Sandboxing needs an absolute path to symlink; the lookup may report a bare name.
+const fishBinary = fishLookup.available
+  ? isAbsolute(fishLookup.path)
+    ? fishLookup.path
+    : resolveOnPath(fishLookup.path)
+  : null
+
+/** Absolute path of an executable file on the host PATH, or null. */
+function resolveOnPath(name: string): string | null {
+  for (const dir of (process.env.PATH ?? '').split(delimiter)) {
+    if (!dir) {
+      continue
+    }
+    const candidate = join(dir, name)
+    try {
+      if (statSync(candidate).isFile()) {
+        return candidate
+      }
+    } catch {
+      // Not in this directory.
+    }
+  }
+  return null
+}
+
+/** Sandbox whose bin is the *entire* PATH, so codex provably cannot resolve.
+ *
+ *  Why symlink fish in rather than append its directory: fish routinely ships
+ *  alongside a real codex (both land in Homebrew's bin), which would silently
+ *  turn the absent-codex regression below into a no-op on a normal dev machine. */
+function createFishSandbox(prefix: string): { bin: string; preflight: string; marker: string } {
+  if (!fishBinary) {
+    throw new Error('fish ran but could not be resolved to a file to symlink')
+  }
+  const root = mkdtempSync(join(tmpdir(), prefix))
+  roots.push(root)
+  const bin = join(root, 'bin')
+  mkdirSync(bin)
+  symlinkSync(fishBinary, join(bin, 'fish'))
+  const marker = join(root, 'preflight-ran')
+  const preflight = join(bin, 'orca-preflight')
+  writeExecutable(preflight, `#!/bin/sh\nprintf ran > ${JSON.stringify(marker)}\n`)
+  return { bin, preflight, marker }
+}
+
+// Reports Orca's own wrapper (not a user-defined codex function) and any capture leak.
+const FISH_STATE_PROBE = `if functions -q codex; and functions codex | string match -q '*prepare-codex*'
+  echo -n wrapper=YES
+else
+  echo -n wrapper=NO
+end
+echo " var=[$__orca_codex_type]"`
 
 function writeExecutable(path: string, content: string): void {
   writeFileSync(path, content)
@@ -241,6 +299,66 @@ describe.skipIf(process.platform === 'win32')('Codex shell launch preflight', ()
     )
 
     expect(output.trim()).toBe('custom-codex')
+  })
+
+  // Always runs, so the fish lane cannot report green with the #16893 regression
+  // unexercised — the skips below would otherwise hide a missing binary.
+  it('has fish when CI demanded it', () => {
+    expect(fishRequirementViolation(fishLookup)).toBeNull()
+  })
+
+  // Regression for #16893: an unquoted `(type -t codex)` expands to zero words when
+  // codex is absent, so `test` saw `= file` (2 args) and printed "Missing argument
+  // at index 3" on every fish pane launch. Needs a valid executable
+  // ORCA_CODEX_LAUNCH_PREFLIGHT so the `and` chain reaches the second `test`, and
+  // the real `-l -C` launch shape both shell-ready call sites use.
+  it.skipIf(!fishAvailable)('stays silent and installs no wrapper when codex is absent', () => {
+    const { bin, preflight } = createFishSandbox('orca-codex-fish-absent-')
+
+    const result = spawnSync(
+      join(bin, 'fish'),
+      ['--no-config', '-l', '-C', getFishCodexShellLaunchPreflight(), '-c', FISH_STATE_PROBE],
+      { encoding: 'utf-8', env: { PATH: bin, ORCA_CODEX_LAUNCH_PREFLIGHT: preflight } }
+    )
+
+    expect(result.stderr).not.toContain('Missing argument')
+    expect(result.status).toBe(0)
+    expect(result.stdout.trim()).toBe('wrapper=NO var=[]')
+  })
+
+  it.skipIf(!fishAvailable)('wraps codex and runs the preflight when codex is a real file', () => {
+    const { bin, preflight, marker } = createFishSandbox('orca-codex-fish-present-')
+    writeExecutable(join(bin, 'codex'), '#!/bin/sh\nprintf "real codex $*"\n')
+
+    const output = execFileSync(
+      join(bin, 'fish'),
+      ['--no-config', '-l', '-C', getFishCodexShellLaunchPreflight(), '-c', 'codex hi'],
+      { encoding: 'utf-8', env: { PATH: bin, ORCA_CODEX_LAUNCH_PREFLIGHT: preflight } }
+    )
+
+    expect(output.trim()).toBe('real codex hi')
+    expect(existsSync(marker)).toBe(true)
+  })
+
+  it.skipIf(!fishAvailable)('leaves a codex alias unwrapped', () => {
+    const { bin, preflight } = createFishSandbox('orca-codex-fish-alias-')
+    writeExecutable(join(bin, 'codex'), '#!/bin/sh\nprintf "real codex"\n')
+
+    const result = spawnSync(
+      join(bin, 'fish'),
+      [
+        '--no-config',
+        '-l',
+        '-C',
+        `alias codex='echo aliased'\n${getFishCodexShellLaunchPreflight()}`,
+        '-c',
+        FISH_STATE_PROBE
+      ],
+      { encoding: 'utf-8', env: { PATH: bin, ORCA_CODEX_LAUNCH_PREFLIGHT: preflight } }
+    )
+
+    expect(result.stderr).not.toContain('Missing argument')
+    expect(result.stdout.trim()).toBe('wrapper=NO var=[]')
   })
 })
 

--- a/src/main/pty/codex-shell-launch-preflight.ts
+++ b/src/main/pty/codex-shell-launch-preflight.ts
@@ -85,12 +85,17 @@ unset __orca_codex_binary
 }
 
 export function getFishCodexShellLaunchPreflight(): string {
-  return `if test -x "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test (type -t codex 2>/dev/null) = file
+  return `# Why captured: an unquoted (type -t codex) expands to zero words when codex is
+# absent, leaving "test = file" — fish then errors instead of failing closed.
+# Quoting in place is not the fix; fish never substitutes inside double quotes.
+set -l __orca_codex_type (type -t codex 2>/dev/null)
+if test -x "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test "$__orca_codex_type" = file
   function codex
     command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
     command codex $argv
   end
-end`
+end
+set -e __orca_codex_type`
 }
 
 export function getPowerShellCodexShellLaunchPreflight(): string {


### PR DESCRIPTION
## ELI5

When your shell is fish and `codex` isn't installed, Orca printed a scary-looking `test: Missing argument at index 3` to the terminal on every pane/agent launch. Nothing broke — just noise on every single launch.

This PR combines the two independent fixes for #16893 (#16923 and #16928). Both landed on the same correct idiom; this takes the stronger production form from one and the stronger test coverage from the other, with both authors credited.

## What Changed

- `codex-shell-launch-preflight.ts`: `getFishCodexShellLaunchPreflight()` captures `(type -t codex 2>/dev/null)` into a local before comparing it, then clears it with `set -e` so the guard leaves nothing behind in the user's session.
- `codex-shell-launch-preflight.test.ts`: absent / real-file / alias regression tests, and the file now uses the repo's shared `resolveFishBinary()` + `fishRequirementViolation()` contract instead of an ad-hoc `spawnSync('fish')` gate.

## Why

fish splices an unquoted command substitution that produces zero words out of the argument list entirely, so

```fish
test (type -t codex 2>/dev/null) = file
```

becomes literally `test = file` (2 tokens) whenever `type -t codex` prints nothing. fish's `test` rejects that as malformed and writes to stderr on every launch.

Capturing into `$__orca_codex_type` first makes it a well-defined single argument (empty string when codex is absent), so the comparison is always a normal 3-token binary test — the same idiom the bash/zsh variant directly above already uses.

Naive quoting is **not** a fix: `test "(type -t codex 2>/dev/null)" = file` does not work, because fish never performs command substitution inside double quotes. The wrapper would silently never be installed even when codex is a real file.

## Why `set -e` at the end

`set -l` at the top level of a `-C` script persists for the rest of the session, so without the cleanup a stray `__orca_codex_type=file` is left in every fish user's shell. The bash variant already `unset`s its equivalent; this matches.

Verified the cleanup is safe: `set -e` erases only the local shadow, so a user's own `-g` or `-U` variable of the same name survives untouched (checked on both fish 3.1.0 and 4.7.1).

## Verification

Ran the generated script through the exact `fish -l -C '<init>\n<preflight>'` shape both call sites (`local-pty-shell-ready.ts`, `daemon/shell-ready.ts`) use, on **fish 4.7.1 and fish 3.1.0** (the version floor; 3.1 words the same error "Missing argument at index 2"):

| codex state | before | after |
|---|---|---|
| absent | **`test: Missing argument`**, no wrapper | clean, no wrapper |
| real file | wrapper installed | wrapper installed |
| user function | no wrapper | no wrapper |
| alias | no wrapper | no wrapper |
| function + file | no wrapper | no wrapper |
| no preflight set | no wrapper | no wrapper |

Wrapper behavior is byte-identical to before in all five non-erroring states — the only change is that the error goes away.

## Test hermeticity

The absent-codex regression test symlinks fish into a sandbox directory that is the **entire** `PATH`. Both original PRs appended fish's own directory to the test PATH, which quietly turns the regression into a no-op on any machine where fish and codex share a directory — i.e. the standard `brew install fish` + `brew install codex` layout, where both land in `/opt/homebrew/bin`. Confirmed the new test still fails on the pre-fix code on a machine that has codex installed.

The suite also now asserts `fishRequirementViolation()` in a test that always runs, so the fish lane cannot report green with the regression unexercised.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

`pnpm exec vitest run src/main/pty/codex-shell-launch-preflight.test.ts` — 29 passed, 2 skipped (pwsh absent), also green under `ORCA_REQUIRE_FISH=1`. Reverting just the fish function to the pre-fix form fails the absent-codex test with the exact reported error; removing only `set -e` fails the leak assertion.

Broader: `src/main/pty`, `src/main/daemon/shell-ready.test.ts`, `src/main/providers/__tests__` — 313 passed, 2 skipped. `pnpm tc:node` clean, `oxlint` clean, `check:code-quality:changed` 0 new findings.

## Review notes

- **No non-fish impact**: only `getFishCodexShellLaunchPreflight()` changes. bash/zsh and PowerShell variants are untouched and were never affected (bash captures into a variable; PowerShell uses `Get-Command`).
- **SSH/remote**: `getShellLaunchConfig` is consumed by `local-pty-provider.ts` and `daemon/pty-subprocess/shell-launch-plan.ts` — the script is generated where the shell spawns and never crosses the wire, so there's no client/host version-skew contract.
- **Cross-platform**: fish is not supported on Windows and WSL is already excluded from the preflight. Uses no construct newer than fish 2.x.
- **Backwards compatibility / data**: no persisted state, schema, or serialized contract touched.
- **Performance**: `type -t` was already being run; net change is one variable set and erase per fish pane launch.

## Linked Issue

Fixes #16893

## Visual Proof

N/A — shell startup script generation, no UI surface.

## AI Disclosure

Both original PRs were AI-assisted (see #16923 and #16928). This combined revision was prepared with Claude, with the fish 3.1.0 / 4.7.1 behavior matrix and the hermeticity failure reproduced directly.

## Credits

Root cause and the correct fix were diagnosed by @Fuzzwah in #16893 — the issue write-up already contained the working patch and the warning about naive quoting. Fix implementations by @erishforG (#16923) and @Fuzzwah (#16928); both are `Co-authored-by` on the commit. The alias coverage and the "installs no wrapper" assertion come from #16928.
