### PR TITLE
fix: settle exited worker release when tab is absent

### DIFF
--- a/src/cli/terminal-format.test.ts
+++ b/src/cli/terminal-format.test.ts
@@ -58,4 +58,19 @@ describe('formatTerminalClose', () => {
       })
     ).toBe('Closed terminal term_live. The PTY is live.')
   })
+
+  it('does not claim a replacement incarnation was closed', () => {
+    expect(
+      formatTerminalClose({
+        close: {
+          handle: 'term_replaced',
+          tabId: 'tab-1',
+          ptyKilled: false,
+          closeRefusedReason: 'incarnation_replaced'
+        }
+      })
+    ).toBe(
+      'Terminal term_replaced changed process incarnation during close; the replacement PTY was not stopped.'
+    )
+  })
 })

--- a/src/cli/terminal-format.test.ts
+++ b/src/cli/terminal-format.test.ts
@@ -59,18 +59,20 @@ describe('formatTerminalClose', () => {
     ).toBe('Closed terminal term_live. The PTY is live.')
   })
 
+  // The refusal can also come from the pre-teardown incarnation check, so the copy must not
+  // place the replacement inside the close.
   it('does not claim a replacement incarnation was closed', () => {
-    expect(
-      formatTerminalClose({
-        close: {
-          handle: 'term_replaced',
-          tabId: 'tab-1',
-          ptyKilled: false,
-          closeRefusedReason: 'incarnation_replaced'
-        }
-      })
-    ).toBe(
-      'Terminal term_replaced changed process incarnation during close; the replacement PTY was not stopped.'
+    const message = formatTerminalClose({
+      close: {
+        handle: 'term_replaced',
+        tabId: 'tab-1',
+        ptyKilled: false,
+        closeRefusedReason: 'incarnation_replaced'
+      }
+    })
+    expect(message).toBe(
+      'Terminal term_replaced no longer holds the expected process incarnation; the replacement PTY was not stopped.'
     )
+    expect(message).not.toMatch(/during close/)
   })
 })

--- a/src/cli/terminal-format.ts
+++ b/src/cli/terminal-format.ts
@@ -229,6 +229,7 @@ function describePtyStop(close: RuntimeTerminalClose): string {
   return ''
 }
 
+/** A refused close reports the refusal, never a stop it did not perform. */
 export function formatTerminalClose(result: { close: RuntimeTerminalClose }): string {
   if (result.close.closeRefusedReason === 'incarnation_replaced') {
     // Timing-neutral: the refusal can predate teardown, so it cannot claim when the swap happened.

--- a/src/cli/terminal-format.ts
+++ b/src/cli/terminal-format.ts
@@ -231,7 +231,8 @@ function describePtyStop(close: RuntimeTerminalClose): string {
 
 export function formatTerminalClose(result: { close: RuntimeTerminalClose }): string {
   if (result.close.closeRefusedReason === 'incarnation_replaced') {
-    return `Terminal ${result.close.handle} changed process incarnation during close; the replacement PTY was not stopped.`
+    // Timing-neutral: the refusal can predate teardown, so it cannot claim when the swap happened.
+    return `Terminal ${result.close.handle} no longer holds the expected process incarnation; the replacement PTY was not stopped.`
   }
   if (result.close.closeMode === 'tab') {
     return `Closed terminal tab ${result.close.tabId} (${result.close.handle}).`

--- a/src/cli/terminal-format.ts
+++ b/src/cli/terminal-format.ts
@@ -230,6 +230,9 @@ function describePtyStop(close: RuntimeTerminalClose): string {
 }
 
 export function formatTerminalClose(result: { close: RuntimeTerminalClose }): string {
+  if (result.close.closeRefusedReason === 'incarnation_replaced') {
+    return `Terminal ${result.close.handle} changed process incarnation during close; the replacement PTY was not stopped.`
+  }
   if (result.close.closeMode === 'tab') {
     return `Closed terminal tab ${result.close.tabId} (${result.close.handle}).`
   }

--- a/src/main/ipc/pty-daemon-controller-teardown.test.ts
+++ b/src/main/ipc/pty-daemon-controller-teardown.test.ts
@@ -252,12 +252,29 @@ describe('registerPtyHandlers', () => {
         handlers.clear()
         registerPtyHandlers(mainWindow as never, runtime as never)
         const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
-          spawn: (args: { cols: number; rows: number }) => Promise<{ id: string }>
-          stopAndWait: (ptyId: string) => Promise<boolean>
+          kill: (ptyId: string, opts?: { expectedIncarnationId?: string }) => boolean
+          restorePtyIncarnation: (ptyId: string, incarnationId: string) => void
+          stopAndWait: (
+            ptyId: string,
+            opts?: { expectedIncarnationId?: string }
+          ) => Promise<boolean>
         }
 
-        await controller.spawn({ cols: 80, rows: 24 })
-        await expect(controller.stopAndWait('local-incarnated')).resolves.toBe(true)
+        controller.restorePtyIncarnation('local-incarnated', 'incarnation-live')
+        expect(
+          controller.kill('local-incarnated', { expectedIncarnationId: 'incarnation-replaced' })
+        ).toBe(false)
+        await expect(
+          controller.stopAndWait('local-incarnated', {
+            expectedIncarnationId: 'incarnation-replaced'
+          })
+        ).resolves.toBe(false)
+        expect(provider.shutdown).not.toHaveBeenCalled()
+        await expect(
+          controller.stopAndWait('local-incarnated', {
+            expectedIncarnationId: 'incarnation-live'
+          })
+        ).resolves.toBe(true)
 
         expect(runtime.onPtyExit).toHaveBeenCalledWith('local-incarnated', 0, 'incarnation-live')
       })

--- a/src/main/ipc/pty/provider/ownership-state.ts
+++ b/src/main/ipc/pty/provider/ownership-state.ts
@@ -9,6 +9,11 @@ export function isCurrentPtyExit(payload: { id: string; incarnationId?: string }
   return !current || payload.incarnationId === current
 }
 
+/** An unset expectation fences nothing; a set one must still own `id` after every await. */
+export function ptyIncarnationStillExpected(id: string, expectedIncarnationId?: string): boolean {
+  return !expectedIncarnationId || ptyIncarnationById.get(id) === expectedIncarnationId
+}
+
 export function deletePtyOwnership(id: string): void {
   ptyOwnership.delete(id)
 }

--- a/src/main/ipc/pty/runtime/controller.ts
+++ b/src/main/ipc/pty/runtime/controller.ts
@@ -1,5 +1,6 @@
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { claimRuntimePaneCreate, makePaneSpawnReservationKey } from '../pane/spawn-reservation'
+import { restorePtyIncarnation } from '../provider/ownership-state'
 import type { PtyRuntimeControllerDeps } from './controller-deps'
 import { spawnPtyFromRuntimeController } from './spawn'
 import {
@@ -51,7 +52,8 @@ export function installPtyRuntimeController(deps: PtyRuntimeControllerDeps): voi
     // lease machinery, and the in-process local provider streams without
     // attach. Attach-only and false-on-doubt: never creates or resizes.
     attach: (ptyId) => attachPtyFromRuntimeController(deps, ptyId),
-    kill: (ptyId) => killPtyFromRuntimeController(deps, ptyId),
+    kill: (ptyId, opts) => killPtyFromRuntimeController(deps, ptyId, opts),
+    restorePtyIncarnation,
     retireRejectedPty: (ptyId, stopConfirmed) =>
       retireRejectedPtyFromRuntimeController(deps, ptyId, stopConfirmed),
     markReversibleStops: (ptyIds) => markReversibleStopsFromRuntimeController(deps, ptyIds),

--- a/src/main/ipc/pty/runtime/controller.ts
+++ b/src/main/ipc/pty/runtime/controller.ts
@@ -5,10 +5,10 @@ import type { PtyRuntimeControllerDeps } from './controller-deps'
 import { spawnPtyFromRuntimeController } from './spawn'
 import {
   killPtyFromRuntimeController,
-  markReversibleStopsFromRuntimeController,
   retireRejectedPtyFromRuntimeController,
   stopAndWaitPtyFromRuntimeController
 } from './kill'
+import { markReversibleStopsFromRuntimeController } from './reversible-stop-ownership'
 import {
   attachPtyFromRuntimeController,
   clearBufferFromRuntimeController,

--- a/src/main/ipc/pty/runtime/controller.ts
+++ b/src/main/ipc/pty/runtime/controller.ts
@@ -32,6 +32,7 @@ import {
   writePtyFromRuntimeController
 } from './operations'
 
+/** Binds the runtime's PTY controller surface to this process's provider registry. */
 export function installPtyRuntimeController(deps: PtyRuntimeControllerDeps): void {
   const { runtime, adoptStablePane, requestSerializedBuffer } = deps
 

--- a/src/main/ipc/pty/runtime/kill-incarnation-fence.test.ts
+++ b/src/main/ipc/pty/runtime/kill-incarnation-fence.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { IPtyProvider } from '../../../providers/types'
 import { ptyIncarnationById, ptyOwnership } from '../provider/ownership-state'
 import { killPtyFromRuntimeController, stopAndWaitPtyFromRuntimeController } from './kill'
+import { verifyPtyStopped } from '../provider/liveness'
 import type * as PtyLiveness from '../provider/liveness'
 import type { PtyRuntimeControllerDeps } from './controller-deps'
 
@@ -174,4 +175,115 @@ describe('runtime controller stopAndWait fences the incarnation through asynchro
     expect(finishPtyShutdown).toHaveBeenCalledWith(PTY_ID, undefined, undefined)
     expect(runtime.onPtyExit).toHaveBeenCalledWith(PTY_ID, 0, EXPECTED)
   })
+})
+
+describe('runtime controller kill fences the reversible-stop flag by incarnation', () => {
+  it('keeps a failed remote stop replayable when only the replacement stop was reversible', async () => {
+    ptyIncarnationById.set(PTY_ID, EXPECTED)
+    ptyOwnership.set(PTY_ID, 'conn-1')
+    const recordSshRemotePtyKillIntent = vi.fn()
+    const { deps } = makeDeps({
+      store: { recordSshRemotePtyKillIntent } as never,
+      shutdownProviderAndDetectExit: (async () => {
+        ptyIncarnationById.set(PTY_ID, REPLACEMENT)
+        deps.reversibleStopOwnersByPtyId.set(PTY_ID, 1)
+        throw new Error('relay rpc failed')
+      }) as never
+    })
+
+    killPtyFromRuntimeController(deps, PTY_ID, { expectedIncarnationId: EXPECTED })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(recordSshRemotePtyKillIntent).toHaveBeenCalledWith(
+      'conn-1',
+      'conn-1:pty-fenced',
+      expect.objectContaining({ incarnationId: EXPECTED })
+    )
+  })
+
+  it('still drops the order when this call itself addressed a reversible stop', async () => {
+    ptyIncarnationById.set(PTY_ID, EXPECTED)
+    ptyOwnership.set(PTY_ID, 'conn-1')
+    const recordSshRemotePtyKillIntent = vi.fn()
+    const { deps } = makeDeps({
+      store: { recordSshRemotePtyKillIntent } as never,
+      shutdownProviderAndDetectExit: (async () => {
+        throw new Error('relay rpc failed')
+      }) as never
+    })
+    deps.reversibleStopOwnersByPtyId.set(PTY_ID, 1)
+
+    killPtyFromRuntimeController(deps, PTY_ID, { expectedIncarnationId: EXPECTED })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(recordSshRemotePtyKillIntent).not.toHaveBeenCalled()
+  })
+})
+
+/** Each arms one `stopAndWait` failure return and runs `onAwait` inside the await it fails in. */
+const stopAndWaitFailurePaths = [
+  {
+    name: 'a provider shutdown that failed outright',
+    verdict: 'markPtyLivenessUnverifiable' as const,
+    arm: (onAwait: () => void) => async () => {
+      onAwait()
+      throw new Error('relay rpc failed')
+    }
+  },
+  {
+    name: 'a stop the provider inventory could not confirm',
+    verdict: 'markPtyLivenessLive' as const,
+    arm: (onAwait: () => void) => {
+      vi.mocked(verifyPtyStopped).mockImplementationOnce(async () => {
+        onAwait()
+        return false
+      })
+      return async () => false
+    }
+  },
+  {
+    name: 'a stop verification that threw',
+    verdict: 'markPtyLivenessUnverifiable' as const,
+    arm: (onAwait: () => void) => {
+      vi.mocked(verifyPtyStopped).mockImplementationOnce(async () => {
+        onAwait()
+        throw new Error('inventory rpc failed')
+      })
+      return async () => false
+    }
+  }
+]
+
+describe('runtime controller stopAndWait fences its liveness verdicts by incarnation', () => {
+  it.each(stopAndWaitFailurePaths)(
+    'withholds $verdict from a replacement that appeared during $name',
+    async ({ verdict, arm }) => {
+      ptyIncarnationById.set(PTY_ID, EXPECTED)
+      ptyOwnership.set(PTY_ID, 'conn-1')
+      const shutdown = arm(() => ptyIncarnationById.set(PTY_ID, REPLACEMENT))
+      const { deps, runtime } = makeDeps({ shutdownProviderAndDetectExit: shutdown as never })
+
+      await expect(
+        stopAndWaitPtyFromRuntimeController(deps, PTY_ID, { expectedIncarnationId: EXPECTED })
+      ).resolves.toBe(false)
+
+      expect(runtime[verdict]).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(stopAndWaitFailurePaths)(
+    'still publishes $verdict for $name on the expected incarnation',
+    async ({ verdict, arm }) => {
+      ptyIncarnationById.set(PTY_ID, EXPECTED)
+      ptyOwnership.set(PTY_ID, 'conn-1')
+      const shutdown = arm(() => {})
+      const { deps, runtime } = makeDeps({ shutdownProviderAndDetectExit: shutdown as never })
+
+      await expect(
+        stopAndWaitPtyFromRuntimeController(deps, PTY_ID, { expectedIncarnationId: EXPECTED })
+      ).resolves.toBe(false)
+
+      expect(runtime[verdict]).toHaveBeenCalled()
+    }
+  )
 })

--- a/src/main/ipc/pty/runtime/kill-incarnation-fence.test.ts
+++ b/src/main/ipc/pty/runtime/kill-incarnation-fence.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { IPtyProvider } from '../../../providers/types'
+import { ptyIncarnationById, ptyOwnership } from '../provider/ownership-state'
+import { killPtyFromRuntimeController, stopAndWaitPtyFromRuntimeController } from './kill'
+import type * as PtyLiveness from '../provider/liveness'
+import type { PtyRuntimeControllerDeps } from './controller-deps'
+
+type PtyLivenessModule = typeof PtyLiveness
+
+const provider = {} as IPtyProvider
+
+vi.mock('../provider/registry', () => ({
+  getProvider: vi.fn(() => provider),
+  getProviderForPty: vi.fn(() => provider),
+  getRelayPtyId: (connectionId: string | null | undefined, ptyId: string) =>
+    connectionId ? `${connectionId}:${ptyId}` : ptyId
+}))
+
+vi.mock('../provider/liveness', async (importOriginal) => ({
+  ...(await importOriginal<PtyLivenessModule>()),
+  verifyPtyStopped: vi.fn(async () => true)
+}))
+
+const PTY_ID = 'pty-fenced'
+const EXPECTED = 'pty-fenced:incarnation-1'
+const REPLACEMENT = 'pty-fenced:incarnation-2'
+
+function makeDeps(overrides: {
+  shutdownProviderAndDetectExit: PtyRuntimeControllerDeps['shutdownProviderAndDetectExit']
+  store?: PtyRuntimeControllerDeps['store']
+}) {
+  const runtime = {
+    markPtyStopRequested: vi.fn(),
+    markPtyLivenessUnverifiable: vi.fn(),
+    markPtyLivenessLive: vi.fn(),
+    onPtyExit: vi.fn()
+  }
+  const finishPtyShutdown = vi.fn(() => EXPECTED)
+  const sendPtyExitToRenderer = vi.fn()
+  const rememberSyntheticKillExit = vi.fn()
+  const deps = {
+    runtime,
+    store: overrides.store,
+    getLocalPtyProviderStartupPromise: () => undefined,
+    shutdownProviderAndDetectExit: vi.fn(overrides.shutdownProviderAndDetectExit),
+    rememberSyntheticKillExit,
+    sendPtyExitToRenderer,
+    finishPtyShutdown,
+    retiredRejectedPtyIds: new Map(),
+    reversibleStopOwnersByPtyId: new Map()
+  } as unknown as PtyRuntimeControllerDeps
+  return { deps, runtime, finishPtyShutdown, sendPtyExitToRenderer, rememberSyntheticKillExit }
+}
+
+/** Resolves the teardown await only after the caller has swapped in a replacement incarnation. */
+function replaceIncarnationDuring<T>(outcome: () => Promise<T>): () => Promise<T> {
+  return async () => {
+    ptyIncarnationById.set(PTY_ID, REPLACEMENT)
+    return outcome()
+  }
+}
+
+afterEach(() => {
+  ptyIncarnationById.delete(PTY_ID)
+  ptyOwnership.delete(PTY_ID)
+  vi.clearAllMocks()
+})
+
+describe('runtime controller kill fences the incarnation through asynchronous teardown', () => {
+  it.each([
+    {
+      name: 'a provider shutdown that observed no exit',
+      outcome: async () => false
+    },
+    {
+      name: 'a provider shutdown that reports the PTY already gone',
+      outcome: async () => {
+        throw new Error('Session not found')
+      }
+    }
+  ])('retains a replacement that appeared during $name', async ({ outcome }) => {
+    ptyIncarnationById.set(PTY_ID, EXPECTED)
+    ptyOwnership.set(PTY_ID, null)
+    const { deps, runtime, finishPtyShutdown, sendPtyExitToRenderer } = makeDeps({
+      shutdownProviderAndDetectExit: replaceIncarnationDuring(outcome) as never
+    })
+
+    expect(killPtyFromRuntimeController(deps, PTY_ID, { expectedIncarnationId: EXPECTED })).toBe(
+      true
+    )
+    await vi.waitFor(() => expect(deps.shutdownProviderAndDetectExit).toHaveBeenCalled())
+    // A macrotask turn drains the whole `.then`/`.catch` continuation chain the kill left running.
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(finishPtyShutdown).not.toHaveBeenCalled()
+    expect(runtime.onPtyExit).not.toHaveBeenCalled()
+    expect(sendPtyExitToRenderer).not.toHaveBeenCalled()
+    expect(ptyIncarnationById.get(PTY_ID)).toBe(REPLACEMENT)
+  })
+
+  it('still settles the expected incarnation when no replacement appeared', async () => {
+    ptyIncarnationById.set(PTY_ID, EXPECTED)
+    ptyOwnership.set(PTY_ID, null)
+    const { deps, runtime, finishPtyShutdown, sendPtyExitToRenderer } = makeDeps({
+      shutdownProviderAndDetectExit: (async () => false) as never
+    })
+
+    expect(killPtyFromRuntimeController(deps, PTY_ID, { expectedIncarnationId: EXPECTED })).toBe(
+      true
+    )
+    await vi.waitFor(() => expect(runtime.onPtyExit).toHaveBeenCalledWith(PTY_ID, -1, EXPECTED))
+
+    expect(finishPtyShutdown).toHaveBeenCalledWith(PTY_ID, undefined, undefined)
+    expect(sendPtyExitToRenderer).toHaveBeenCalledWith({
+      id: PTY_ID,
+      code: -1,
+      incarnationId: EXPECTED
+    })
+  })
+
+  it('aims a failed remote stop at the expected incarnation, never at the replacement', async () => {
+    ptyIncarnationById.set(PTY_ID, EXPECTED)
+    ptyOwnership.set(PTY_ID, 'conn-1')
+    const recordSshRemotePtyKillIntent = vi.fn()
+    const { deps, runtime } = makeDeps({
+      store: { recordSshRemotePtyKillIntent } as never,
+      shutdownProviderAndDetectExit: replaceIncarnationDuring(async () => {
+        throw new Error('relay rpc failed')
+      }) as never
+    })
+
+    killPtyFromRuntimeController(deps, PTY_ID, { expectedIncarnationId: EXPECTED })
+    await vi.waitFor(() => expect(recordSshRemotePtyKillIntent).toHaveBeenCalled())
+
+    expect(recordSshRemotePtyKillIntent).toHaveBeenCalledWith(
+      'conn-1',
+      'conn-1:pty-fenced',
+      expect.objectContaining({ incarnationId: EXPECTED })
+    )
+    expect(runtime.onPtyExit).not.toHaveBeenCalled()
+    expect(runtime.markPtyLivenessUnverifiable).not.toHaveBeenCalled()
+  })
+})
+
+describe('runtime controller stopAndWait fences the incarnation through asynchronous teardown', () => {
+  it('refuses to finalize a replacement that appeared during the provider shutdown', async () => {
+    ptyIncarnationById.set(PTY_ID, EXPECTED)
+    ptyOwnership.set(PTY_ID, null)
+    const { deps, runtime, finishPtyShutdown, sendPtyExitToRenderer } = makeDeps({
+      shutdownProviderAndDetectExit: replaceIncarnationDuring(async () => false) as never
+    })
+
+    await expect(
+      stopAndWaitPtyFromRuntimeController(deps, PTY_ID, { expectedIncarnationId: EXPECTED })
+    ).resolves.toBe(false)
+
+    expect(finishPtyShutdown).not.toHaveBeenCalled()
+    expect(runtime.onPtyExit).not.toHaveBeenCalled()
+    expect(sendPtyExitToRenderer).not.toHaveBeenCalled()
+    expect(ptyIncarnationById.get(PTY_ID)).toBe(REPLACEMENT)
+  })
+
+  it('settles the expected incarnation when it still owns the PTY id', async () => {
+    ptyIncarnationById.set(PTY_ID, EXPECTED)
+    ptyOwnership.set(PTY_ID, null)
+    const { deps, runtime, finishPtyShutdown } = makeDeps({
+      shutdownProviderAndDetectExit: (async () => false) as never
+    })
+
+    await expect(
+      stopAndWaitPtyFromRuntimeController(deps, PTY_ID, { expectedIncarnationId: EXPECTED })
+    ).resolves.toBe(true)
+
+    expect(finishPtyShutdown).toHaveBeenCalledWith(PTY_ID, undefined, undefined)
+    expect(runtime.onPtyExit).toHaveBeenCalledWith(PTY_ID, 0, EXPECTED)
+  })
+})

--- a/src/main/ipc/pty/runtime/kill.ts
+++ b/src/main/ipc/pty/runtime/kill.ts
@@ -11,6 +11,11 @@ import { isPtyAlreadyGoneError, delay, verifyPtyStopped } from '../provider/live
 import { recordUndeliveredSshPtyKill } from './undelivered-ssh-kill'
 import type { PtyRuntimeControllerDeps } from './controller-deps'
 
+/**
+ * Stops one PTY, optionally fenced to `expectedIncarnationId`: every await re-checks the fence, so
+ * a replacement that took the id over is never stopped and never inherits this call's exit.
+ * Returns whether the stop was dispatched, not whether the process died.
+ */
 export function killPtyFromRuntimeController(
   deps: PtyRuntimeControllerDeps,
   ptyId: string,
@@ -35,8 +40,10 @@ export function killPtyFromRuntimeController(
   let connectionId: string | null | undefined = ptyOwnership.get(ptyId)
   const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
   connectionId ??= parsedSshId?.connectionId
-  // Defaulted so a replayable order aims at the incarnation this call addressed, never at one
-  // that took the id over while the stop was in flight.
+  /**
+   * Records a replayable SSH stop order. Defaulted so it aims at the incarnation this call
+   * addressed, never at one that took the id over while the stop was in flight.
+   */
   const recordUndelivered = (incarnationId = expectedIncarnationId): void => {
     recordUndeliveredSshPtyKill({
       store,
@@ -46,11 +53,13 @@ export function killPtyFromRuntimeController(
       incarnationId
     })
   }
+  /** Publishes an exit the provider never reported, tagged so listeners can reject a stale one. */
   const announceSyntheticExit = (code: number, incarnationId?: string): void => {
     runtime?.onPtyExit(ptyId, code, incarnationId)
     rememberSyntheticKillExit(ptyId)
     sendPtyExitToRenderer({ id: ptyId, code, ...(incarnationId ? { incarnationId } : {}) })
   }
+  /** Closes out a shutdown that threw, without ever claiming the process died. */
   const reportFailedStop = (err: unknown): void => {
     console.warn(
       `[pty] Failed to stop PTY ${ptyId}: ${err instanceof Error ? err.message : String(err)}`
@@ -73,6 +82,7 @@ export function killPtyFromRuntimeController(
     // either way, and the intent is what the next handshake replays.
     recordUndelivered()
   }
+  /** Resolves the provider only now — after any daemon swap — and fires the shutdown through it. */
   const killWithCurrentProvider = (): boolean => {
     if (!ptyIncarnationStillExpected(ptyId, expectedIncarnationId)) {
       return false

--- a/src/main/ipc/pty/runtime/kill.ts
+++ b/src/main/ipc/pty/runtime/kill.ts
@@ -1,7 +1,11 @@
 import type { IPtyProvider } from '../../../providers/types'
 import { SSH_PROVIDER_UNREGISTERED_REASON } from '../../../../shared/pty-liveness-verdict'
 import { parseAppSshPtyId } from '../../../providers/ssh-pty-id'
-import { ptyOwnership, ptyIncarnationById } from '../provider/ownership-state'
+import {
+  ptyOwnership,
+  ptyIncarnationById,
+  ptyIncarnationStillExpected
+} from '../provider/ownership-state'
 import { getProvider, getProviderForPty } from '../provider/registry'
 import { isPtyAlreadyGoneError, delay, verifyPtyStopped } from '../provider/liveness'
 import { recordUndeliveredSshPtyKill } from './undelivered-ssh-kill'
@@ -24,14 +28,16 @@ export function killPtyFromRuntimeController(
     reversibleStopOwnersByPtyId
   } = deps
   const expectedIncarnationId = opts?.expectedIncarnationId
-  if (expectedIncarnationId && ptyIncarnationById.get(ptyId) !== expectedIncarnationId) {
+  if (!ptyIncarnationStillExpected(ptyId, expectedIncarnationId)) {
     return false
   }
   runtime?.markPtyStopRequested?.(ptyId)
   let connectionId: string | null | undefined = ptyOwnership.get(ptyId)
   const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
   connectionId ??= parsedSshId?.connectionId
-  const recordUndelivered = (incarnationId?: string): void => {
+  // Defaulted so a replayable order aims at the incarnation this call addressed, never at one
+  // that took the id over while the stop was in flight.
+  const recordUndelivered = (incarnationId = expectedIncarnationId): void => {
     recordUndeliveredSshPtyKill({
       store,
       ptyId,
@@ -40,8 +46,35 @@ export function killPtyFromRuntimeController(
       incarnationId
     })
   }
+  const announceSyntheticExit = (code: number, incarnationId?: string): void => {
+    runtime?.onPtyExit(ptyId, code, incarnationId)
+    rememberSyntheticKillExit(ptyId)
+    sendPtyExitToRenderer({ id: ptyId, code, ...(incarnationId ? { incarnationId } : {}) })
+  }
+  const reportFailedStop = (err: unknown): void => {
+    console.warn(
+      `[pty] Failed to stop PTY ${ptyId}: ${err instanceof Error ? err.message : String(err)}`
+    )
+    // Why: close runtime tails without clearing provider ownership, so a retry can still target a
+    // PTY that survived the failed shutdown — and never one that replaced it during the await.
+    if (
+      !retiredRejectedPtyIds.has(ptyId) &&
+      ptyIncarnationStillExpected(ptyId, expectedIncarnationId)
+    ) {
+      if (connectionId) {
+        runtime?.markPtyLivenessUnverifiable?.(
+          ptyId,
+          err instanceof Error ? err.message : String(err)
+        )
+      }
+      runtime?.onPtyExit(ptyId, -1, ptyIncarnationById.get(ptyId))
+    }
+    // Outside the `retired` guard: the remote process outlives this client's bookkeeping
+    // either way, and the intent is what the next handshake replays.
+    recordUndelivered()
+  }
   const killWithCurrentProvider = (): boolean => {
-    if (expectedIncarnationId && ptyIncarnationById.get(ptyId) !== expectedIncarnationId) {
+    if (!ptyIncarnationStillExpected(ptyId, expectedIncarnationId)) {
       return false
     }
     let provider: IPtyProvider
@@ -55,86 +88,44 @@ export function killPtyFromRuntimeController(
         const incarnationId = finishPtyShutdown(ptyId, connectionId, store)
         // The relay was never asked, so the remote shell is still running. Keep the order.
         recordUndelivered(incarnationId)
-        runtime?.onPtyExit(ptyId, -1, incarnationId)
-        rememberSyntheticKillExit(ptyId)
-        sendPtyExitToRenderer({
-          id: ptyId,
-          code: -1,
-          ...(incarnationId ? { incarnationId } : {})
-        })
+        announceSyntheticExit(-1, incarnationId)
         runtime?.markPtyLivenessUnverifiable?.(ptyId, SSH_PROVIDER_UNREGISTERED_REASON)
-        return false
       }
       return false
     }
     // Why: keep ownership until async shutdown proves whether the provider emitted an exit.
     void shutdownProviderAndDetectExit(provider, ptyId, { immediate: false })
       .then((providerExitObserved) => {
+        // Why: finalization clears ownership and incarnation state for `ptyId`, so a replacement
+        // that took the id over during the await would be cleared and reported as this exit.
+        if (!ptyIncarnationStillExpected(ptyId, expectedIncarnationId)) {
+          return
+        }
         const retired = retiredRejectedPtyIds.has(ptyId)
         const incarnationId = finishPtyShutdown(ptyId, connectionId, store)
         if (!providerExitObserved && !retired) {
-          runtime?.onPtyExit(ptyId, -1, incarnationId)
-          rememberSyntheticKillExit(ptyId)
-          sendPtyExitToRenderer({
-            id: ptyId,
-            code: -1,
-            ...(incarnationId ? { incarnationId } : {})
-          })
+          announceSyntheticExit(-1, incarnationId)
         }
       })
       .catch((err) => {
-        const retired = retiredRejectedPtyIds.has(ptyId)
-        if (isPtyAlreadyGoneError(err)) {
-          const incarnationId = finishPtyShutdown(ptyId, connectionId, store)
-          if (!retired) {
-            runtime?.onPtyExit(ptyId, -1, incarnationId)
-            rememberSyntheticKillExit(ptyId)
-            sendPtyExitToRenderer({
-              id: ptyId,
-              code: -1,
-              ...(incarnationId ? { incarnationId } : {})
-            })
-          }
+        if (!isPtyAlreadyGoneError(err)) {
+          reportFailedStop(err)
           return
         }
-        console.warn(
-          `[pty] Failed to stop PTY ${ptyId}: ${err instanceof Error ? err.message : String(err)}`
-        )
-        // Why: close runtime tails without clearing provider ownership, so
-        // a retry can still target a PTY that survived the failed shutdown.
-        if (!retired) {
-          if (connectionId) {
-            runtime?.markPtyLivenessUnverifiable?.(
-              ptyId,
-              err instanceof Error ? err.message : String(err)
-            )
-          }
-          runtime?.onPtyExit(ptyId, -1, ptyIncarnationById.get(ptyId))
+        if (!ptyIncarnationStillExpected(ptyId, expectedIncarnationId)) {
+          return
         }
-        // Outside the `retired` guard: the remote process outlives this client's bookkeeping
-        // either way, and the intent is what the next handshake replays.
-        recordUndelivered()
+        const incarnationId = finishPtyShutdown(ptyId, connectionId, store)
+        if (!retiredRejectedPtyIds.has(ptyId)) {
+          announceSyntheticExit(-1, incarnationId)
+        }
       })
     return true
   }
   const startupPromise = getLocalPtyProviderStartupPromise(connectionId)
   if (startupPromise) {
     // Why: select the provider after the daemon swap; the fallback first can report success while orphaning a daemon PTY.
-    void startupPromise.then(killWithCurrentProvider).catch((err) => {
-      console.warn(
-        `[pty] Failed to stop PTY ${ptyId}: ${err instanceof Error ? err.message : String(err)}`
-      )
-      if (!retiredRejectedPtyIds.has(ptyId)) {
-        if (connectionId) {
-          runtime?.markPtyLivenessUnverifiable?.(
-            ptyId,
-            err instanceof Error ? err.message : String(err)
-          )
-        }
-        runtime?.onPtyExit(ptyId, -1, ptyIncarnationById.get(ptyId))
-      }
-      recordUndelivered()
-    })
+    void startupPromise.then(killWithCurrentProvider).catch(reportFailedStop)
     return true
   }
   return killWithCurrentProvider()
@@ -214,7 +205,7 @@ export async function stopAndWaitPtyFromRuntimeController(
     finishPtyShutdown
   } = deps
   const expectedIncarnationId = opts?.expectedIncarnationId
-  if (expectedIncarnationId && ptyIncarnationById.get(ptyId) !== expectedIncarnationId) {
+  if (!ptyIncarnationStillExpected(ptyId, expectedIncarnationId)) {
     return false
   }
   runtime?.markPtyStopRequested?.(ptyId)
@@ -245,7 +236,7 @@ export async function stopAndWaitPtyFromRuntimeController(
       await startupPromise
     }
   }
-  if (expectedIncarnationId && ptyIncarnationById.get(ptyId) !== expectedIncarnationId) {
+  if (!ptyIncarnationStillExpected(ptyId, expectedIncarnationId)) {
     return false
   }
   let provider: IPtyProvider
@@ -305,6 +296,11 @@ export async function stopAndWaitPtyFromRuntimeController(
         err instanceof Error ? err.message : String(err)
       }`
     )
+    return false
+  }
+  // Why: the awaits above can hand this id to a replacement; finalizing then would clear its
+  // ownership and publish a death certificate for a process nobody stopped.
+  if (!ptyIncarnationStillExpected(ptyId, expectedIncarnationId)) {
     return false
   }
   const incarnationId = finishPtyShutdown(ptyId, connectionId, store)

--- a/src/main/ipc/pty/runtime/kill.ts
+++ b/src/main/ipc/pty/runtime/kill.ts
@@ -40,6 +40,9 @@ export function killPtyFromRuntimeController(
   let connectionId: string | null | undefined = ptyOwnership.get(ptyId)
   const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
   connectionId ??= parsedSshId?.connectionId
+  // Read before any await: a replacement that took the id over could have marked its own stop
+  // reversible, and that mark would silently discard this incarnation's replayable order.
+  const addressedStopIsReversible = reversibleStopOwnersByPtyId.has(ptyId)
   /**
    * Records a replayable SSH stop order. Defaulted so it aims at the incarnation this call
    * addressed, never at one that took the id over while the stop was in flight.
@@ -49,7 +52,7 @@ export function killPtyFromRuntimeController(
       store,
       ptyId,
       connectionId,
-      reversible: reversibleStopOwnersByPtyId.has(ptyId),
+      reversible: addressedStopIsReversible,
       incarnationId
     })
   }
@@ -269,6 +272,8 @@ export async function stopAndWaitPtyFromRuntimeController(
     return false
   }
   let providerExitObserved = false
+  // Why: every failure return below publishes a liveness verdict for `ptyId`, and the awaits can
+  // hand that id to a replacement; fence each one so it cannot inherit this stop's outcome.
   try {
     providerExitObserved = await shutdownProviderAndDetectExit(provider, ptyId, {
       immediate: true,
@@ -277,7 +282,7 @@ export async function stopAndWaitPtyFromRuntimeController(
     })
   } catch (err) {
     if (!isPtyAlreadyGoneError(err)) {
-      if (connectionId) {
+      if (connectionId && ptyIncarnationStillExpected(ptyId, expectedIncarnationId)) {
         runtime?.markPtyLivenessUnverifiable?.(
           ptyId,
           err instanceof Error ? err.message : String(err)
@@ -291,11 +296,13 @@ export async function stopAndWaitPtyFromRuntimeController(
   }
   try {
     if (!(await verifyPtyStopped(provider, ptyId, opts))) {
-      runtime?.markPtyLivenessLive?.(ptyId)
+      if (ptyIncarnationStillExpected(ptyId, expectedIncarnationId)) {
+        runtime?.markPtyLivenessLive?.(ptyId)
+      }
       return false
     }
   } catch (err) {
-    if (connectionId) {
+    if (connectionId && ptyIncarnationStillExpected(ptyId, expectedIncarnationId)) {
       runtime?.markPtyLivenessUnverifiable?.(
         ptyId,
         err instanceof Error ? err.message : String(err)

--- a/src/main/ipc/pty/runtime/kill.ts
+++ b/src/main/ipc/pty/runtime/kill.ts
@@ -191,31 +191,6 @@ export function retireRejectedPtyFromRuntimeController(
   })
 }
 
-export function markReversibleStopsFromRuntimeController(
-  deps: PtyRuntimeControllerDeps,
-  ptyIds: readonly string[]
-): () => void {
-  const { reversibleStopOwnersByPtyId } = deps
-  for (const ptyId of ptyIds) {
-    reversibleStopOwnersByPtyId.set(ptyId, (reversibleStopOwnersByPtyId.get(ptyId) ?? 0) + 1)
-  }
-  let released = false
-  return () => {
-    if (released) {
-      return
-    }
-    released = true
-    for (const ptyId of ptyIds) {
-      const owners = (reversibleStopOwnersByPtyId.get(ptyId) ?? 0) - 1
-      if (owners > 0) {
-        reversibleStopOwnersByPtyId.set(ptyId, owners)
-      } else {
-        reversibleStopOwnersByPtyId.delete(ptyId)
-      }
-    }
-  }
-}
-
 /**
  * Deliberately records no undelivered-stop intent, unlike `killPtyFromRuntimeController`.
  *

--- a/src/main/ipc/pty/runtime/kill.ts
+++ b/src/main/ipc/pty/runtime/kill.ts
@@ -9,7 +9,8 @@ import type { PtyRuntimeControllerDeps } from './controller-deps'
 
 export function killPtyFromRuntimeController(
   deps: PtyRuntimeControllerDeps,
-  ptyId: string
+  ptyId: string,
+  opts?: { expectedIncarnationId?: string }
 ): boolean {
   const {
     runtime,
@@ -22,6 +23,10 @@ export function killPtyFromRuntimeController(
     retiredRejectedPtyIds,
     reversibleStopOwnersByPtyId
   } = deps
+  const expectedIncarnationId = opts?.expectedIncarnationId
+  if (expectedIncarnationId && ptyIncarnationById.get(ptyId) !== expectedIncarnationId) {
+    return false
+  }
   runtime?.markPtyStopRequested?.(ptyId)
   let connectionId: string | null | undefined = ptyOwnership.get(ptyId)
   const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
@@ -36,6 +41,9 @@ export function killPtyFromRuntimeController(
     })
   }
   const killWithCurrentProvider = (): boolean => {
+    if (expectedIncarnationId && ptyIncarnationById.get(ptyId) !== expectedIncarnationId) {
+      return false
+    }
     let provider: IPtyProvider
     try {
       provider = connectionId ? getProvider(connectionId) : getProviderForPty(ptyId)
@@ -59,7 +67,7 @@ export function killPtyFromRuntimeController(
       }
       return false
     }
-    // Why: controller is synchronous, but keep ownership until async shutdown proves whether the provider emitted an exit.
+    // Why: keep ownership until async shutdown proves whether the provider emitted an exit.
     void shutdownProviderAndDetectExit(provider, ptyId, { immediate: false })
       .then((providerExitObserved) => {
         const retired = retiredRejectedPtyIds.has(ptyId)
@@ -219,7 +227,7 @@ export function markReversibleStopsFromRuntimeController(
 export async function stopAndWaitPtyFromRuntimeController(
   deps: PtyRuntimeControllerDeps,
   ptyId: string,
-  opts?: { keepHistory?: boolean; deadlineMs?: number }
+  opts?: { keepHistory?: boolean; deadlineMs?: number; expectedIncarnationId?: string }
 ): Promise<boolean> {
   const {
     runtime,
@@ -230,18 +238,19 @@ export async function stopAndWaitPtyFromRuntimeController(
     sendPtyExitToRenderer,
     finishPtyShutdown
   } = deps
+  const expectedIncarnationId = opts?.expectedIncarnationId
+  if (expectedIncarnationId && ptyIncarnationById.get(ptyId) !== expectedIncarnationId) {
+    return false
+  }
   runtime?.markPtyStopRequested?.(ptyId)
   let connectionId: string | null | undefined = ptyOwnership.get(ptyId)
   const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
   connectionId ??= parsedSshId?.connectionId
-  // Why: destructive teardown threads one absolute deadline through every await
-  // below; each RPC leaf converts it to the remaining time when it issues, so
-  // sequential RPCs share the budget and cannot overrun the sweep deadline.
+  // Why: one absolute deadline bounds every awaited RPC during destructive teardown.
   const deadlineMs = opts?.deadlineMs
   const startupPromise = getLocalPtyProviderStartupPromise(connectionId)
   if (startupPromise) {
-    // Why: exact-stop must resolve the provider after daemon startup just
-    // like renderer kills, or the fallback can falsely confirm teardown.
+    // Why: resolve exact-stop provider after daemon startup to avoid false fallback confirmation.
     if (deadlineMs !== undefined) {
       // Why: bound the cold-start await by the teardown deadline instead of the
       // 60s startup fail-open cap; fail closed so the sweep records the miss.
@@ -260,6 +269,9 @@ export async function stopAndWaitPtyFromRuntimeController(
     } else {
       await startupPromise
     }
+  }
+  if (expectedIncarnationId && ptyIncarnationById.get(ptyId) !== expectedIncarnationId) {
+    return false
   }
   let provider: IPtyProvider
   try {

--- a/src/main/ipc/pty/runtime/reversible-stop-ownership.ts
+++ b/src/main/ipc/pty/runtime/reversible-stop-ownership.ts
@@ -1,0 +1,27 @@
+import type { PtyRuntimeControllerDeps } from './controller-deps'
+
+/** Ref-counted so nested reversible-stop scopes cannot clear a sibling's mark on the first release. */
+export function markReversibleStopsFromRuntimeController(
+  deps: PtyRuntimeControllerDeps,
+  ptyIds: readonly string[]
+): () => void {
+  const { reversibleStopOwnersByPtyId } = deps
+  for (const ptyId of ptyIds) {
+    reversibleStopOwnersByPtyId.set(ptyId, (reversibleStopOwnersByPtyId.get(ptyId) ?? 0) + 1)
+  }
+  let released = false
+  return () => {
+    if (released) {
+      return
+    }
+    released = true
+    for (const ptyId of ptyIds) {
+      const owners = (reversibleStopOwnersByPtyId.get(ptyId) ?? 0) - 1
+      if (owners > 0) {
+        reversibleStopOwnersByPtyId.set(ptyId, owners)
+      } else {
+        reversibleStopOwnersByPtyId.delete(ptyId)
+      }
+    }
+  }
+}

--- a/src/main/runtime/orca-runtime-process-incarnation-liveness.test.ts
+++ b/src/main/runtime/orca-runtime-process-incarnation-liveness.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { PtyProcessInfo } from '../providers/pty-process-info'
 import { OrcaRuntimeService } from './orca-runtime'
 
@@ -72,6 +72,44 @@ describe('terminal process incarnation liveness', () => {
       runtime.inspectTerminalProcessIncarnationLiveness(PROCESS_INCARNATION, '{"kind":"ssh"}')
     ).resolves.toBe('unverifiable')
     expect(listProcesses).not.toHaveBeenCalled()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // Absence from the listing is a death certificate only because every way of *losing contact* with
+  // the execution host is converted to `unverifiable` before the classifier is reached. These pin
+  // the two conversions that no other test covers.
+  it('keeps a stalled inventory unverifiable rather than reading absence as death', async () => {
+    vi.useFakeTimers()
+    const runtime = runtimeWithInventory(() => new Promise(() => {}))
+
+    const verdict = runtime.inspectTerminalProcessIncarnationLiveness(
+      PROCESS_INCARNATION,
+      SSH_SCOPE
+    )
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    await expect(verdict).resolves.toBe('unverifiable')
+  })
+
+  it('does not judge liveness without a controller that can list processes', async () => {
+    const runtime = new OrcaRuntimeService()
+
+    await expect(
+      runtime.inspectTerminalProcessIncarnationLiveness(PROCESS_INCARNATION, SSH_SCOPE)
+    ).resolves.toBe('unverifiable')
+
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    } as never)
+
+    await expect(
+      runtime.inspectTerminalProcessIncarnationLiveness(PROCESS_INCARNATION, SSH_SCOPE)
+    ).resolves.toBe('unverifiable')
   })
 
   it.each([

--- a/src/main/runtime/orca-runtime-terminal-close-continuity.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-close-continuity.test.ts
@@ -4,6 +4,7 @@ import { makePaneKey } from '../../shared/stable-pane-id'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 import { OrcaRuntimeService } from './orca-runtime'
 
+type RuntimePtyRegistry = { ptysById: Map<string, { incarnationId: string | null }> }
 const REPO_ID = 'repo-close-continuity'
 const WORKTREE_PATH = '/tmp/terminal-close-continuity'
 const WORKTREE_ID = `${REPO_ID}::${WORKTREE_PATH}`
@@ -556,6 +557,18 @@ describe('terminal close and handle incarnation continuity', () => {
 
     expect(close).toMatchObject({ ptyKilled: false, closeRefusedReason: 'incarnation_replaced' })
     expect(harness.stopAndWait).toHaveBeenCalledOnce()
+    expect(harness.kill).not.toHaveBeenCalled()
+  })
+  it('does not stop a PTY whose pre-teardown incarnation is missing', async () => {
+    const harness = createHarness()
+    const [{ handle }] = (await harness.runtime.listTerminals(`id:${WORKTREE_ID}`)).terminals
+    const runtime = harness.runtime as unknown as RuntimePtyRegistry
+    runtime.ptysById.get(PTY_ID)!.incarnationId = null
+    harness.setCloseTerminalTabAction(() => harness.retirePersistedTab())
+    expect((await harness.runtime.closeTerminal(handle)).closeRefusedReason).toBe(
+      'incarnation_replaced'
+    )
+    expect(harness.stopAndWait).not.toHaveBeenCalled()
     expect(harness.kill).not.toHaveBeenCalled()
   })
 

--- a/src/main/runtime/orca-runtime-terminal-close-continuity.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-close-continuity.test.ts
@@ -19,6 +19,12 @@ const CANARY_PTY_ID = 'pty-close-continuity-canary'
 const INCARNATION_ID = '22222222-2222-4222-8222-222222222222'
 const SIBLING_INCARNATION_ID = '44444444-4444-4444-8444-444444444444'
 const CANARY_INCARNATION_ID = '66666666-6666-4666-8666-666666666666'
+const EXPECTED_KILL_OPTIONS = { expectedIncarnationId: INCARNATION_ID }
+const EXPECTED_SIBLING_KILL_OPTIONS = { expectedIncarnationId: SIBLING_INCARNATION_ID }
+const EXPECTED_STOP_OPTIONS = {
+  deadlineMs: expect.any(Number),
+  expectedIncarnationId: INCARNATION_ID
+}
 const canarySessionTab = {
   id: CANARY_TAB_ID,
   ptyId: CANARY_PTY_ID,
@@ -121,6 +127,7 @@ function createHarness(
   let session = makeSession(ptyId, options.includeCanary)
   let sessionAvailable = true
   let incarnationId = INCARNATION_ID
+  let siblingIncarnationId = SIBLING_INCARNATION_ID
   let includeSiblingPty = false
   let victimPtyListed = true
   const repo = {
@@ -178,7 +185,7 @@ function createHarness(
       ? [
           {
             id: SIBLING_PTY_ID,
-            incarnationId: SIBLING_INCARNATION_ID,
+            incarnationId: siblingIncarnationId,
             cwd: WORKTREE_PATH,
             title: 'Fixture sibling shell'
           }
@@ -403,6 +410,9 @@ function createHarness(
     },
     replaceIncarnation: (next: string) => {
       incarnationId = next
+    },
+    replaceSiblingIncarnation: (next: string) => {
+      siblingIncarnationId = next
     }
   }
 }
@@ -437,7 +447,7 @@ describe('terminal close and handle incarnation continuity', () => {
     harness.retirePersistedTab()
     harness.acknowledged.resolve()
     await expect(closing).resolves.toMatchObject({ handle, tabId: TAB_ID, ptyKilled: false })
-    expect(harness.kill).toHaveBeenCalledWith(PTY_ID)
+    expect(harness.kill).toHaveBeenCalledWith(PTY_ID, EXPECTED_KILL_OPTIONS)
     expect(harness.closeTerminal).not.toHaveBeenCalled()
     expect(harness.getSession().tabsByWorktree[WORKTREE_ID]).toEqual([])
   })
@@ -484,9 +494,7 @@ describe('terminal close and handle incarnation continuity', () => {
       'idempotent-session-retirement'
     ])
     expect(harness.stopAndWait).toHaveBeenCalledTimes(1)
-    expect(harness.stopAndWait).toHaveBeenCalledWith(PTY_ID, {
-      deadlineMs: expect.any(Number)
-    })
+    expect(harness.stopAndWait).toHaveBeenCalledWith(PTY_ID, EXPECTED_STOP_OPTIONS)
     expect(harness.kill).not.toHaveBeenCalled()
     expect(closeMobileSessionTab).toHaveBeenCalledTimes(1)
     expect(closeMobileSessionTab).toHaveBeenCalledWith(`id:${WORKTREE_ID}`, TAB_ID, {
@@ -526,6 +534,31 @@ describe('terminal close and handle incarnation continuity', () => {
     expect(harness.getSession().tabsByWorktree[WORKTREE_ID]).toHaveLength(1)
   })
 
+  it('does not stop replacement tab PTYs after terminal retirement yields', async () => {
+    const harness = createHarness()
+    harness.syncSplitFixtureGraph()
+    const [terminal] = (await harness.runtime.listTerminals(`id:${WORKTREE_ID}`)).terminals
+    harness.syncFixtureGraph()
+    harness.setCloseTerminalTabAction(async () => {
+      harness.runtime.markRendererReloading(1)
+      harness.replaceIncarnation('77777777-7777-4777-8777-777777777777')
+      harness.syncFixtureGraph()
+      await harness.runtime.listTerminals(`id:${WORKTREE_ID}`)
+    })
+    harness.setStopAndWaitAction(async () => {
+      harness.replaceSiblingIncarnation('88888888-8888-4888-8888-888888888888')
+      await harness.runtime.listTerminals(`id:${WORKTREE_ID}`)
+    })
+
+    const close = await harness.runtime.closeTerminal(terminal.handle, {
+      expectedProcessIncarnation: `${PTY_ID}:${INCARNATION_ID}`
+    })
+
+    expect(close).toMatchObject({ ptyKilled: false, closeRefusedReason: 'incarnation_replaced' })
+    expect(harness.stopAndWait).toHaveBeenCalledOnce()
+    expect(harness.kill).not.toHaveBeenCalled()
+  })
+
   it('requests a stop for every live tab PTY after retirement when the renderer graph is stale', async () => {
     const harness = createHarness()
     harness.syncSplitFixtureGraph()
@@ -541,8 +574,8 @@ describe('terminal close and handle incarnation continuity', () => {
     harness.retirePersistedTab()
     harness.acknowledged.resolve()
     await expect(closing).resolves.toMatchObject({ ptyKilled: false })
-    expect(harness.kill).toHaveBeenCalledWith(PTY_ID)
-    expect(harness.kill).toHaveBeenCalledWith(SIBLING_PTY_ID)
+    expect(harness.kill).toHaveBeenCalledWith(PTY_ID, EXPECTED_KILL_OPTIONS)
+    expect(harness.kill).toHaveBeenCalledWith(SIBLING_PTY_ID, EXPECTED_SIBLING_KILL_OPTIONS)
   })
 
   it('uses verified teardown after retirement before falling back to kill', async () => {
@@ -557,9 +590,7 @@ describe('terminal close and handle incarnation continuity', () => {
     harness.retirePersistedTab()
     harness.acknowledged.resolve()
     await expect(closing).resolves.toMatchObject({ ptyKilled: true })
-    expect(harness.stopAndWait).toHaveBeenCalledWith(PTY_ID, {
-      deadlineMs: expect.any(Number)
-    })
+    expect(harness.stopAndWait).toHaveBeenCalledWith(PTY_ID, EXPECTED_STOP_OPTIONS)
     expect(harness.kill).not.toHaveBeenCalled()
   })
 
@@ -601,7 +632,7 @@ describe('terminal close and handle incarnation continuity', () => {
       ptyStopVerdict: 'unverifiable',
       ptyStopReason: 'a follow-up stop was issued but its outcome could not be verified'
     })
-    expect(harness.kill).toHaveBeenCalledWith(PTY_ID)
+    expect(harness.kill).toHaveBeenCalledWith(PTY_ID, EXPECTED_KILL_OPTIONS)
   })
 
   it('leaves a confirmed kill receipt free of any stop verdict', async () => {
@@ -635,10 +666,8 @@ describe('terminal close and handle incarnation continuity', () => {
       ptyStopVerdict: 'unverifiable',
       ptyStopReason: 'provider_unavailable'
     })
-    expect(harness.stopAndWait).toHaveBeenCalledWith(PTY_ID, {
-      deadlineMs: expect.any(Number)
-    })
-    expect(harness.kill).toHaveBeenCalledWith(PTY_ID)
+    expect(harness.stopAndWait).toHaveBeenCalledWith(PTY_ID, EXPECTED_STOP_OPTIONS)
+    expect(harness.kill).toHaveBeenCalledWith(PTY_ID, EXPECTED_KILL_OPTIONS)
   })
 
   it('finishes PTY teardown when the session store disappears after retirement', async () => {
@@ -659,9 +688,7 @@ describe('terminal close and handle incarnation continuity', () => {
 
     await expect(closing).resolves.toMatchObject({ handle, tabId: TAB_ID, ptyKilled: false })
     expect(harness.closeTerminal).toHaveBeenCalledWith(TAB_ID)
-    expect(harness.stopAndWait).toHaveBeenCalledWith(RUNTIME_OWNED_PTY_ID, {
-      deadlineMs: expect.any(Number)
-    })
+    expect(harness.stopAndWait).toHaveBeenCalledWith(RUNTIME_OWNED_PTY_ID, EXPECTED_STOP_OPTIONS)
   })
 
   it('does not tear down a published PTY when retirement fails before acknowledgement', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -31901,6 +31901,11 @@ export class OrcaRuntimeService {
     return [...ptyIds]
   }
 
+  /**
+   * Stops the tab's PTYs, each fenced to the incarnation snapshotted before teardown began. A PTY
+   * that was replaced mid-flight is skipped, not stopped; `addressedPtyReplaced` reports that for
+   * the handle the caller addressed so the close can refuse instead of claiming a kill.
+   */
   private async stopExplicitlyClosedTabPtys(
     ptyIds: readonly string[],
     addressedPtyId: string,
@@ -31980,6 +31985,7 @@ export class OrcaRuntimeService {
     return { addressedPtyStopped, addressedPtyReplaced }
   }
 
+  /** Taken before tab teardown yields; absent ids stay out so a later spawn is never fenced in. */
   private snapshotPtyIncarnations(ptyIds: readonly string[]): Map<string, PtyIncarnationId | null> {
     const snapshot = new Map<string, PtyIncarnationId | null>()
     for (const ptyId of ptyIds) {
@@ -32158,6 +32164,11 @@ export class OrcaRuntimeService {
     })
   }
 
+  /**
+   * Closes the terminal behind `handle`. With `expectedProcessIncarnation`, the handle must still
+   * resolve to that process both before teardown and after it — otherwise the close is refused with
+   * `incarnation_replaced` and the replacement PTY is left running.
+   */
   async closeTerminal(
     handle: string,
     options: RuntimeTerminalCloseOptions = {}
@@ -32311,6 +32322,7 @@ export class OrcaRuntimeService {
     return { handle, tabId, ptyKilled }
   }
 
+  /** The refusal shape: nothing was stopped, so it reports no kill and no stop verdict. */
   private describeTerminalIncarnationReplacement(
     handle: string,
     tabId: string

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -522,6 +522,7 @@ import {
   type RuntimeTerminalSplit,
   type RuntimeTerminalFocus,
   type RuntimeTerminalClose,
+  type RuntimeTerminalCloseOptions,
   type RuntimeTerminalListHostScope,
   type RuntimeTerminalListResult,
   type RuntimeTerminalOrphanAdoptionRequest,
@@ -2101,11 +2102,16 @@ type RuntimePtyController = {
    *  to main without a renderer pane; never creates, resizes, or focuses.
    *  False on doubt (absent session, SSH-scoped id, non-daemon provider). */
   attach?(ptyId: string): Promise<boolean>
-  kill(ptyId: string): boolean
+  kill(ptyId: string, opts?: { expectedIncarnationId?: PtyIncarnationId }): boolean
+  restorePtyIncarnation?(ptyId: string, incarnationId: PtyIncarnationId): void
   retireRejectedPty?(ptyId: string, stopConfirmed: boolean): void
   stopAndWait?(
     ptyId: string,
-    opts?: { keepHistory?: boolean; deadlineMs?: number }
+    opts?: {
+      keepHistory?: boolean
+      deadlineMs?: number
+      expectedIncarnationId?: PtyIncarnationId
+    }
   ): Promise<boolean>
   markReversibleStops?(ptyIds: readonly string[]): () => void
   getCwd?(ptyId: string): Promise<string | null>
@@ -31897,32 +31903,62 @@ export class OrcaRuntimeService {
 
   private async stopExplicitlyClosedTabPtys(
     ptyIds: readonly string[],
-    addressedPtyId: string
-  ): Promise<boolean> {
+    addressedPtyId: string,
+    expectedIncarnations: ReadonlyMap<string, PtyIncarnationId | null>
+  ): Promise<{ addressedPtyStopped: boolean; addressedPtyReplaced: boolean }> {
     let addressedPtyStopped = false
+    let addressedPtyReplaced = false
     const deadlineMs = Date.now() + EXPLICIT_TERMINAL_CLOSE_STOP_TIMEOUT_MS
     for (const ptyId of ptyIds) {
+      if (!expectedIncarnations.has(ptyId)) {
+        continue
+      }
+      const expectedIncarnation = expectedIncarnations.get(ptyId)
+      const livePty = this.ptysById.get(ptyId)
+      if (!livePty) {
+        continue
+      }
+      if (livePty.incarnationId !== expectedIncarnation) {
+        addressedPtyReplaced ||= ptyId === addressedPtyId
+        continue
+      }
       // Why here: this is the single funnel for an explicit close, and the
       // intent must be on record before the stop, since the provider may report
       // the exit itself with a status that reads like a natural finish.
       this.markPtyStopRequested(ptyId)
       let stopped = false
+      let stopError: string | null = null
       if (this.ptyController?.stopAndWait) {
         try {
-          stopped = await this.ptyController.stopAndWait(ptyId, { deadlineMs })
+          stopped = await this.ptyController.stopAndWait(ptyId, {
+            deadlineMs,
+            ...(expectedIncarnation ? { expectedIncarnationId: expectedIncarnation } : {})
+          })
         } catch (error) {
-          this.markPtyLivenessUnverifiable(
-            ptyId,
-            error instanceof Error ? error.message : String(error)
-          )
+          stopError = error instanceof Error ? error.message : String(error)
         }
         if (!stopped) {
+          const currentPty = this.ptysById.get(ptyId)
+          if (!currentPty) {
+            continue
+          }
+          if (currentPty.incarnationId !== expectedIncarnation) {
+            addressedPtyReplaced ||= ptyId === addressedPtyId
+            continue
+          }
+          if (stopError) {
+            this.markPtyLivenessUnverifiable(ptyId, stopError)
+          }
           const verdict = this.getPtyLivenessVerdict(ptyId)
           const providerAlreadyRetiredPty =
             verdict?.status === 'unverifiable' &&
             verdict.reason === SSH_PROVIDER_UNREGISTERED_REASON
           if (!providerAlreadyRetiredPty) {
-            this.ptyController.kill(ptyId)
+            if (expectedIncarnation) {
+              this.ptyController.kill(ptyId, { expectedIncarnationId: expectedIncarnation })
+            } else {
+              this.ptyController.kill(ptyId)
+            }
             if (!verdict || verdict.status === 'live') {
               this.markPtyLivenessUnverifiable(
                 ptyId,
@@ -31932,13 +31968,27 @@ export class OrcaRuntimeService {
           }
         }
       } else {
-        stopped = this.ptyController?.kill(ptyId) ?? false
+        stopped =
+          (expectedIncarnation
+            ? this.ptyController?.kill(ptyId, { expectedIncarnationId: expectedIncarnation })
+            : this.ptyController?.kill(ptyId)) ?? false
       }
       if (ptyId === addressedPtyId) {
         addressedPtyStopped = stopped
       }
     }
-    return addressedPtyStopped
+    return { addressedPtyStopped, addressedPtyReplaced }
+  }
+
+  private snapshotPtyIncarnations(ptyIds: readonly string[]): Map<string, PtyIncarnationId | null> {
+    const snapshot = new Map<string, PtyIncarnationId | null>()
+    for (const ptyId of ptyIds) {
+      const pty = this.ptysById.get(ptyId)
+      if (pty) {
+        snapshot.set(ptyId, pty.incarnationId)
+      }
+    }
+    return snapshot
   }
 
   private resolveHandleForTab(tabId: string): string | null {
@@ -32108,10 +32158,20 @@ export class OrcaRuntimeService {
     })
   }
 
-  async closeTerminal(handle: string): Promise<RuntimeTerminalClose> {
+  async closeTerminal(
+    handle: string,
+    options: RuntimeTerminalCloseOptions = {}
+  ): Promise<RuntimeTerminalClose> {
     const pty = this.getLivePtyForHandle(handle)
-    this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
     if (pty) {
+      const initialTabId = pty.pty.tabId ?? pty.record.tabId
+      if (
+        options.expectedProcessIncarnation &&
+        this.getTerminalProcessIncarnation(handle) !== options.expectedProcessIncarnation
+      ) {
+        return this.describeTerminalIncarnationReplacement(handle, initialTabId)
+      }
+      this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
       // Why: PTY exit can immediately replace a ready SSH publication with a pending one, so capture its durable HUB surface before killing it.
       const surface =
         (pty.pty.tabId
@@ -32124,6 +32184,7 @@ export class OrcaRuntimeService {
         : this.countLeavesInTab(tabId)
       if (siblingCount <= 1 && surface && this.tabs.has(tabId) && this.notifier?.closeTerminalTab) {
         const ptyIdsToKill = this.getPtyIdsForExplicitTabClose(pty.pty.worktreeId, tabId)
+        const expectedIncarnations = this.snapshotPtyIncarnations(ptyIdsToKill)
         try {
           await this.closeMobileSessionTab(`id:${pty.pty.worktreeId}`, tabId, {
             localPtyTeardownOwnedExternally: true
@@ -32134,16 +32195,40 @@ export class OrcaRuntimeService {
           }
           this.notifier.closeTerminal?.(tabId)
         }
-        const ptyKilled = await this.stopExplicitlyClosedTabPtys(ptyIdsToKill, pty.pty.ptyId)
-        return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
+        const stop = await this.stopExplicitlyClosedTabPtys(
+          ptyIdsToKill,
+          pty.pty.ptyId,
+          expectedIncarnations
+        )
+        if (stop.addressedPtyReplaced) {
+          return this.describeTerminalIncarnationReplacement(handle, tabId)
+        }
+        return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, stop.addressedPtyStopped)
       }
       if (siblingCount <= 1 && !surface && pty.pty.tabId && this.notifier?.closeTerminalTab) {
         const ptyIdsToKill = this.getPtyIdsForExplicitTabClose(pty.pty.worktreeId, tabId)
+        const expectedIncarnations = this.snapshotPtyIncarnations(ptyIdsToKill)
         await this.notifier.closeTerminalTab(tabId, { localPtyTeardownOwnedExternally: true })
-        const ptyKilled = await this.stopExplicitlyClosedTabPtys(ptyIdsToKill, pty.pty.ptyId)
-        return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
+        const stop = await this.stopExplicitlyClosedTabPtys(
+          ptyIdsToKill,
+          pty.pty.ptyId,
+          expectedIncarnations
+        )
+        if (stop.addressedPtyReplaced) {
+          return this.describeTerminalIncarnationReplacement(handle, tabId)
+        }
+        return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, stop.addressedPtyStopped)
       }
-      const ptyKilled = await this.stopExplicitlyClosedTabPtys([pty.pty.ptyId], pty.pty.ptyId)
+      const ptyIdsToKill = [pty.pty.ptyId]
+      const stop = await this.stopExplicitlyClosedTabPtys(
+        ptyIdsToKill,
+        pty.pty.ptyId,
+        this.snapshotPtyIncarnations(ptyIdsToKill)
+      )
+      if (stop.addressedPtyReplaced) {
+        return this.describeTerminalIncarnationReplacement(handle, tabId)
+      }
+      const ptyKilled = stop.addressedPtyStopped
       if (!ptyKilled || siblingCount <= 1) {
         if (surface) {
           // Why: paired viewers keep ended streams mounted until the HUB publishes removal, so explicit close uses the durable host-tab transaction instead of viewer-local exit handling.
@@ -32163,6 +32248,13 @@ export class OrcaRuntimeService {
     }
     this.assertGraphReady()
     const { leaf } = this.getLiveLeafForHandle(handle)
+    if (
+      options.expectedProcessIncarnation &&
+      this.getTerminalProcessIncarnation(handle) !== options.expectedProcessIncarnation
+    ) {
+      return this.describeTerminalIncarnationReplacement(handle, leaf.tabId)
+    }
+    this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
     // Why: in a multi-pane tab, killing the PTY is enough (renderer's exit handler closes the pane); an extra IPC close would race it and close the whole tab.
     const siblingCount = this.countLeavesInTab(leaf.tabId)
     const ptyIdsToKill =
@@ -32171,14 +32263,19 @@ export class OrcaRuntimeService {
         : leaf.ptyId
           ? [leaf.ptyId]
           : []
+    const expectedIncarnations = this.snapshotPtyIncarnations(ptyIdsToKill)
     if (siblingCount <= 1 && this.notifier?.closeTerminalTab) {
       await this.notifier.closeTerminalTab(leaf.tabId, {
         localPtyTeardownOwnedExternally: true
       })
     }
-    const ptyKilled = leaf.ptyId
-      ? await this.stopExplicitlyClosedTabPtys(ptyIdsToKill, leaf.ptyId)
-      : false
+    const stop = leaf.ptyId
+      ? await this.stopExplicitlyClosedTabPtys(ptyIdsToKill, leaf.ptyId, expectedIncarnations)
+      : { addressedPtyStopped: false, addressedPtyReplaced: false }
+    if (stop.addressedPtyReplaced) {
+      return this.describeTerminalIncarnationReplacement(handle, leaf.tabId)
+    }
+    const ptyKilled = stop.addressedPtyStopped
     if (siblingCount > 1 ? !ptyKilled : !this.notifier?.closeTerminalTab) {
       this.notifier?.closeTerminal(leaf.tabId, leaf.paneRuntimeId)
     }
@@ -32212,6 +32309,13 @@ export class OrcaRuntimeService {
       return { handle, tabId, ptyKilled, ptyStopVerdict: 'live' }
     }
     return { handle, tabId, ptyKilled }
+  }
+
+  private describeTerminalIncarnationReplacement(
+    handle: string,
+    tabId: string
+  ): RuntimeTerminalClose {
+    return { handle, tabId, ptyKilled: false, closeRefusedReason: 'incarnation_replaced' }
   }
 
   async closeTerminalTab(handle: string): Promise<RuntimeTerminalClose> {
@@ -35079,12 +35183,16 @@ export class OrcaRuntimeService {
         persistedSurface.incarnationId === session.incarnationId &&
         Boolean(worktreeId) &&
         runtimeWorktreeIdsEqual(persistedSurface.worktreeId, worktreeId as string)
+      const restoredIncarnationId = controllerIdentity?.incarnationId ?? session.incarnationId
       this.adoptControllerTerminalHandle(
         session.id,
         controllerIdentity?.handle ?? session.terminalHandle,
-        controllerIdentity?.incarnationId ?? session.incarnationId,
+        restoredIncarnationId,
         { exactRestoredSurface: Boolean(restoresExactSurface && controllerIdentity) }
       )
+      if (restoredIncarnationId) {
+        this.ptyController?.restorePtyIncarnation?.(session.id, restoredIncarnationId)
+      }
       if (
         !targetWorktreeId ||
         (worktreeId && runtimeWorktreeIdsEqual(worktreeId, targetWorktreeId))
@@ -35105,7 +35213,7 @@ export class OrcaRuntimeService {
       if (worktreeId) {
         const pty = this.recordPtyWorktree(session.id, worktreeId, {
           connected: true,
-          ...(session.incarnationId ? { incarnationId: session.incarnationId } : {}),
+          ...(restoredIncarnationId ? { incarnationId: restoredIncarnationId } : {}),
           agentSessionOwners: session.incarnationId ? (session.agentSessionOwners ?? []) : [],
           ...(session.wslDistro !== undefined
             ? { isWsl: Boolean(session.wslDistro), wslDistro: session.wslDistro }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -31919,6 +31919,11 @@ export class OrcaRuntimeService {
         continue
       }
       const expectedIncarnation = expectedIncarnations.get(ptyId)
+      if (!expectedIncarnation) {
+        // A legacy PTY cannot be distinguished from a replacement that reused its id.
+        addressedPtyReplaced ||= ptyId === addressedPtyId
+        continue
+      }
       const livePty = this.ptysById.get(ptyId)
       if (!livePty) {
         continue

--- a/src/main/runtime/orchestration/worker-terminal-process-liveness.ts
+++ b/src/main/runtime/orchestration/worker-terminal-process-liveness.ts
@@ -36,6 +36,8 @@ export function parseWorkerTerminalHostScope(value: string | null): WorkerTermin
   return null
 }
 
+/** Absence means `exited`, not "lost contact": this reads the execution host's own table, and every
+ *  way of losing it is already `unverifiable` before the listing reaches here. */
 export function classifyWorkerTerminalProcessIncarnation(
   processIncarnation: string,
   sessions: readonly PtyProcessInfo[]

--- a/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
@@ -17,6 +17,10 @@ export type WorkerTerminalObservationStatus =
   | 'exited'
   | 'unverifiable'
 
+/**
+ * Reads a worker's terminal into one verdict. `exact` is false the moment the pane or incarnation
+ * differs from the dispatch's, and lost contact reports `unverifiable` — never `exited`.
+ */
 export async function inspectWorkerTerminal(
   runtime: OrcaRuntimeService,
   db: OrchestrationDb,
@@ -71,6 +75,10 @@ export async function inspectWorkerTerminal(
   }
 }
 
+/**
+ * Re-asks the execution host about the recorded incarnation specifically. A handle that no longer
+ * resolves to it answers `unverifiable`, so a replacement never supplies this worker's death proof.
+ */
 export async function recheckProcessLiveness(
   runtime: OrcaRuntimeService,
   resource: WorkerTerminalResourceRow

--- a/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
@@ -2,6 +2,7 @@ import type { RuntimeTerminalInteractiveWait } from '../../../../shared/runtime-
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import type { OrchestrationDb } from '../../orchestration/db'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
+import type { WorkerTerminalResourceRow } from '../../orchestration/worker-terminal-ownership'
 import type {
   DispatchContextRow,
   FederatedDispatchRow,
@@ -60,6 +61,19 @@ export async function inspectWorkerTerminal(
     status: terminal.connected === false ? 'exited' : 'live',
     agentWait
   }
+}
+
+export async function recheckProcessLiveness(
+  runtime: OrcaRuntimeService,
+  resource: WorkerTerminalResourceRow
+): Promise<'live' | 'exited' | 'unverifiable'> {
+  const processIncarnation = runtime.getTerminalProcessIncarnation(resource.terminal_handle)
+  if (!processIncarnation || processIncarnation !== resource.process_incarnation) {
+    return 'unverifiable'
+  }
+  return runtime
+    .inspectTerminalProcessIncarnationLiveness(processIncarnation, resource.host_scope)
+    .catch(() => 'unverifiable' as const)
 }
 
 export function exposeContextOnlyWorker(dispatch: DispatchContextRow) {

--- a/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
@@ -9,6 +9,14 @@ import type {
   WorkerDispatchRow
 } from '../../orchestration/types'
 
+export type WorkerTerminalObservationStatus =
+  | 'unattached'
+  | 'missing'
+  | 'identity_changed'
+  | 'live'
+  | 'exited'
+  | 'unverifiable'
+
 export async function inspectWorkerTerminal(
   runtime: OrcaRuntimeService,
   db: OrchestrationDb,
@@ -16,7 +24,7 @@ export async function inspectWorkerTerminal(
 ): Promise<{
   terminal: Awaited<ReturnType<OrcaRuntimeService['showTerminal']>> | null
   exact: boolean
-  status: 'unattached' | 'missing' | 'identity_changed' | 'live' | 'exited' | 'unverifiable'
+  status: WorkerTerminalObservationStatus
   /** Set with `unverifiable`; names what we lost contact with. */
   reason?: string
   /** Set only on a proven-exact worker parked on a prompt that needs a human. */

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
@@ -10,20 +10,15 @@ import {
   type WorkerTerminalTailArchive
 } from '../../orchestration/worker-output-archive'
 import type { OrcaRuntimeService } from '../../orca-runtime'
-import { describeUnconfirmedAgentStop } from '../../../../shared/pty-liveness-verdict'
-import { inspectWorkerTerminal, recheckProcessLiveness } from './orchestration-worker-observation'
+import { inspectWorkerTerminal } from './orchestration-worker-observation'
 import { orchestrationTimestampToMs } from './orchestration-worker-output'
+import {
+  closeAndSettleWorkerTerminalRelease,
+  type WorkerReleaseReceipt
+} from './orchestration-worker-release-settlement'
 import { workerTerminalLeaseIsCurrent } from './orchestration-worker-terminal-lease'
 
-export type WorkerReleaseReceipt = {
-  dispatchId: string
-  state: 'released' | 'already_released' | 'retained' | 'release_pending' | 'release_unknown'
-  reason?: WorkerTerminalRetainedReason
-  processAction: 'closed_agent_terminal' | 'closed_exited_terminal' | 'none'
-  archive: { source: string | null; status: string | null } | null
-  recovery?: string
-  lastError?: string
-}
+export type { WorkerReleaseReceipt } from './orchestration-worker-release-settlement'
 
 type WorkerTerminalReleaseArgs = {
   runtime: OrcaRuntimeService
@@ -227,68 +222,15 @@ async function completeWorkerTerminalReleaseOnce(
     }
   }
 
-  try {
-    const close = await runtime.closeTerminal(resource.terminal_handle)
-    if (!close.ptyKilled) {
-      const reason = describeUnconfirmedAgentStop(close)
-      const unknown = db.markWorkerTerminalReleaseUnknown(resource.id, reason)
-      return {
-        dispatchId,
-        state: 'release_unknown',
-        processAction: 'closed_agent_terminal',
-        archive: { source: archiveSource, status: archiveStatus },
-        lastError: unknown.release_error ?? reason,
-        recovery: `Inspect with: orca orchestration worker-show --dispatch ${dispatchId} --json — then repeat worker-release with the same --retry-request. Never substitute a broad terminal close.`
-      }
-    }
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error)
-    if (
-      observation.status === 'exited' &&
-      reason === 'tab_not_found' &&
-      (await recheckProcessLiveness(runtime, resource)) === 'exited'
-    ) {
-      // The exact process is still proven gone, so an absent tab makes the close idempotently complete.
-      const released = db.settleWorkerTerminalRelease(resource.id)
-      runtime.notifyMessageArrived(`dispatch:${dispatchId}`, 'status')
-      return {
-        dispatchId,
-        state: 'released',
-        processAction: 'none',
-        archive: archiveSummary(released)
-      }
-    }
-    if (/disposed|not connected|unavailable/i.test(reason)) {
-      // Durable intent exists; the owning endpoint is temporarily unreachable. Recovery retries.
-      return {
-        dispatchId,
-        state: 'release_pending',
-        processAction: 'none',
-        archive: { source: archiveSource, status: archiveStatus },
-        lastError: reason,
-        recovery:
-          'The owning endpoint is temporarily unavailable; recovery will retry this release after reconnect without another coordinator decision.'
-      }
-    }
-    const unknown = db.markWorkerTerminalReleaseUnknown(resource.id, reason)
-    return {
-      dispatchId,
-      state: 'release_unknown',
-      processAction: 'none',
-      archive: { source: archiveSource, status: archiveStatus },
-      lastError: unknown.release_error ?? reason,
-      recovery: `Inspect with: orca orchestration worker-show --dispatch ${dispatchId} --json — then repeat worker-release with the same --retry-request. Never substitute a broad terminal close.`
-    }
-  }
-  const released = db.settleWorkerTerminalRelease(resource.id)
-  runtime.notifyMessageArrived(`dispatch:${dispatchId}`, 'status')
-  return {
+  return closeAndSettleWorkerTerminalRelease({
+    runtime,
+    db,
     dispatchId,
-    state: 'released',
-    processAction:
-      observation.status === 'exited' ? 'closed_exited_terminal' : 'closed_agent_terminal',
-    archive: archiveSummary(released)
-  }
+    resource: releasing,
+    observationStatus: observation.status,
+    archiveSource,
+    archiveStatus
+  })
 }
 
 function summarizeStoredArchive(archive: WorkerTerminalArchiveRow): {

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
@@ -11,7 +11,7 @@ import {
 } from '../../orchestration/worker-output-archive'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import { describeUnconfirmedAgentStop } from '../../../../shared/pty-liveness-verdict'
-import { inspectWorkerTerminal } from './orchestration-worker-observation'
+import { inspectWorkerTerminal, recheckProcessLiveness } from './orchestration-worker-observation'
 import { orchestrationTimestampToMs } from './orchestration-worker-output'
 
 export type WorkerReleaseReceipt = {
@@ -32,10 +32,8 @@ type WorkerTerminalReleaseArgs = {
   mode?: 'interactive' | 'recovery'
 }
 
-const activeReleaseByRuntime = new WeakMap<
-  OrcaRuntimeService,
-  Map<string, Promise<WorkerReleaseReceipt>>
->()
+type ActiveReleaseMap = Map<string, Promise<WorkerReleaseReceipt>>
+const activeReleaseByRuntime = new WeakMap<OrcaRuntimeService, ActiveReleaseMap>()
 
 export function exposeWorkerTerminalResource(resource: WorkerTerminalResourceRow): {
   id: string
@@ -228,6 +226,21 @@ async function completeWorkerTerminalReleaseOnce(
     }
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error)
+    if (
+      observation.status === 'exited' &&
+      reason === 'tab_not_found' &&
+      (await recheckProcessLiveness(runtime, resource)) === 'exited'
+    ) {
+      // The exact process is still proven gone, so an absent tab makes the close idempotently complete.
+      const released = db.settleWorkerTerminalRelease(resource.id)
+      runtime.notifyMessageArrived(`dispatch:${dispatchId}`, 'status')
+      return {
+        dispatchId,
+        state: 'released',
+        processAction: 'none',
+        archive: archiveSummary(released)
+      }
+    }
     if (/disposed|not connected|unavailable/i.test(reason)) {
       // Durable intent exists; the owning endpoint is temporarily unreachable. Recovery retries.
       return {

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
@@ -13,6 +13,7 @@ import type { OrcaRuntimeService } from '../../orca-runtime'
 import { describeUnconfirmedAgentStop } from '../../../../shared/pty-liveness-verdict'
 import { inspectWorkerTerminal, recheckProcessLiveness } from './orchestration-worker-observation'
 import { orchestrationTimestampToMs } from './orchestration-worker-output'
+import { workerTerminalLeaseIsCurrent } from './orchestration-worker-terminal-lease'
 
 export type WorkerReleaseReceipt = {
   dispatchId: string
@@ -126,7 +127,15 @@ async function completeWorkerTerminalReleaseOnce(
       archive: archiveSummary(retained)
     }
   }
-  if (!workerTerminalLeaseIsCurrent(runtime, db, dispatchId, resource)) {
+  if (
+    !workerTerminalLeaseIsCurrent(
+      runtime,
+      db,
+      dispatchId,
+      resource,
+      observation.status === 'exited'
+    )
+  ) {
     const retained = db.revertWorkerTerminalReleaseToRetained(resource.id, 'identity_unproven')
     return {
       dispatchId,
@@ -199,7 +208,15 @@ async function completeWorkerTerminalReleaseOnce(
       archive: archiveSummary(releasing)
     }
   }
-  if (!workerTerminalLeaseIsCurrent(runtime, db, dispatchId, releasing)) {
+  if (
+    !workerTerminalLeaseIsCurrent(
+      runtime,
+      db,
+      dispatchId,
+      releasing,
+      observation.status === 'exited'
+    )
+  ) {
     const retained = db.revertWorkerTerminalReleaseToRetained(resource.id, 'identity_unproven')
     return {
       dispatchId,
@@ -272,27 +289,6 @@ async function completeWorkerTerminalReleaseOnce(
       observation.status === 'exited' ? 'closed_exited_terminal' : 'closed_agent_terminal',
     archive: archiveSummary(released)
   }
-}
-
-function workerTerminalLeaseIsCurrent(
-  runtime: OrcaRuntimeService,
-  db: OrchestrationDb,
-  dispatchId: string,
-  resource: WorkerTerminalResourceRow
-): boolean {
-  const worker = db.getWorkerDispatch(dispatchId)
-  const authority = runtime.getOrchestrationDispatchAuthority(resource.terminal_handle)
-  return Boolean(
-    worker?.agent_terminal_handle === resource.terminal_handle &&
-    authority &&
-    resource.host_scope === JSON.stringify(authority.hostScope) &&
-    db.isDispatchProcessCurrent({
-      dispatchId,
-      paneKey: runtime.getTerminalPaneKey(resource.terminal_handle),
-      processIncarnation: runtime.getTerminalProcessIncarnation(resource.terminal_handle)
-    }) &&
-    !db.workerTerminalResourceHasIdentityConflict(resource.id)
-  )
 }
 
 function summarizeStoredArchive(archive: WorkerTerminalArchiveRow): {

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
@@ -15,6 +15,7 @@ import { orchestrationTimestampToMs } from './orchestration-worker-output'
 import {
   closeAndSettleWorkerTerminalRelease,
   summarizeWorkerTerminalArchive,
+  workerTerminalReleaseRecovery,
   type WorkerReleaseReceipt
 } from './orchestration-worker-release-settlement'
 import { workerTerminalLeaseIsCurrent } from './orchestration-worker-terminal-lease'
@@ -164,7 +165,7 @@ async function completeWorkerTerminalReleaseOnce(
       processAction: 'none',
       archive: archiveSummary(unknown),
       lastError: unknown.release_error ?? undefined,
-      recovery: `Inspect with: orca orchestration worker-show --dispatch ${dispatchId} --json — then repeat worker-release with the same --retry-request. Never substitute a broad terminal close.`
+      recovery: workerTerminalReleaseRecovery(dispatchId)
     }
   }
 

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
@@ -14,6 +14,7 @@ import { inspectWorkerTerminal } from './orchestration-worker-observation'
 import { orchestrationTimestampToMs } from './orchestration-worker-output'
 import {
   closeAndSettleWorkerTerminalRelease,
+  summarizeWorkerTerminalArchive,
   type WorkerReleaseReceipt
 } from './orchestration-worker-release-settlement'
 import { workerTerminalLeaseIsCurrent } from './orchestration-worker-terminal-lease'
@@ -67,10 +68,7 @@ export function archiveSummary(
   if (!resource) {
     return null
   }
-  if (!resource.archive_source && !resource.archive_status) {
-    return null
-  }
-  return { source: resource.archive_source, status: resource.archive_status }
+  return summarizeWorkerTerminalArchive(resource)
 }
 
 // Completes a durably requested release: re-prove exact identity, freeze output, close only the

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-completion.ts
@@ -62,6 +62,7 @@ export function exposeWorkerTerminalResource(resource: WorkerTerminalResourceRow
   }
 }
 
+/** Receipt-shaped archive field for a row that may not exist at all. */
 export function archiveSummary(
   resource: WorkerTerminalResourceRow | null
 ): { source: string | null; status: string | null } | null {
@@ -94,6 +95,7 @@ export function completeWorkerTerminalRelease(
   return release
 }
 
+/** The un-deduplicated body of {@link completeWorkerTerminalRelease}; never call it directly. */
 async function completeWorkerTerminalReleaseOnce(
   args: WorkerTerminalReleaseArgs
 ): Promise<WorkerReleaseReceipt> {

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-liveness-verdict.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-liveness-verdict.test.ts
@@ -83,8 +83,9 @@ describe('orchestration worker release liveness verdict', () => {
   })
 
   // Why every row pins one half of the guard: settling an absent tab is only safe when the exact
-  // worker was observed exited AND the close failed for exactly that absence. Rows that exercise
-  // only one half would let the other be widened without a red test.
+  // recorded incarnation is proven exited by the post-close recheck AND the close failed for
+  // exactly that absence. Rows that exercise only one half would let the other be widened
+  // without a red test.
   it.each([
     {
       name: 'an exact exited worker after its tab was removed',
@@ -121,7 +122,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
-      processRecheckCount: 0
+      processRecheckCount: 1
     },
     {
       // An observed exit is not a blank cheque: only an absent tab proves the close itself finished.
@@ -150,7 +151,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
-      processRecheckCount: 0
+      processRecheckCount: 1
     },
     {
       name: 'an exact exited worker whose process is still listed',
@@ -162,7 +163,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
-      processRecheckCount: 1
+      processRecheckCount: 2
     },
     {
       name: 'an exact exited worker whose process can no longer be verified',
@@ -174,7 +175,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
-      processRecheckCount: 1
+      processRecheckCount: 2
     },
     {
       name: 'an exact exited worker whose process incarnation changed',
@@ -210,7 +211,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
-      processRecheckCount: 1
+      processRecheckCount: 2
     }
   ])(
     'handles $closeError after trying to close $name',

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-liveness-verdict.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-liveness-verdict.test.ts
@@ -81,4 +81,231 @@ describe('orchestration worker release liveness verdict', () => {
       `The agent terminal was closed but its process could not be confirmed stopped: ${detail}.`
     )
   })
+
+  // Why every row pins one half of the guard: settling an absent tab is only safe when the exact
+  // worker was observed exited AND the close failed for exactly that absence. Rows that exercise
+  // only one half would let the other be widened without a red test.
+  it.each([
+    {
+      name: 'an exact exited worker',
+      connected: false,
+      verdict: { status: 'exited' as const },
+      closeError: 'tab_not_found',
+      currentProcessIncarnation: 'pty-worker:incarnation-1',
+      processLiveness: 'exited' as const,
+      expectedState: 'released',
+      expectedProcessAction: 'none',
+      settles: true,
+      rechecksProcess: true
+    },
+    {
+      name: 'a live worker',
+      connected: true,
+      verdict: { status: 'live' as const },
+      closeError: 'tab_not_found',
+      currentProcessIncarnation: 'pty-worker:incarnation-1',
+      processLiveness: 'live' as const,
+      expectedState: 'release_unknown',
+      expectedProcessAction: 'none',
+      settles: false,
+      rechecksProcess: false
+    },
+    {
+      // An observed exit is not a blank cheque: only an absent tab proves the close itself finished.
+      name: 'an exact exited worker whose handle went stale',
+      connected: false,
+      verdict: { status: 'exited' as const },
+      closeError: 'terminal_handle_stale',
+      currentProcessIncarnation: 'pty-worker:incarnation-1',
+      processLiveness: 'exited' as const,
+      expectedState: 'release_unknown',
+      expectedProcessAction: 'none',
+      settles: false,
+      rechecksProcess: false
+    },
+    {
+      // Lost contact is not a death certificate; an absent tab cannot settle an unobserved process.
+      name: 'a worker whose liveness we lost contact with',
+      connected: false,
+      verdict: {
+        status: 'unverifiable' as const,
+        reason: 'its SSH provider is no longer registered'
+      },
+      closeError: 'tab_not_found',
+      currentProcessIncarnation: 'pty-worker:incarnation-1',
+      processLiveness: 'unverifiable' as const,
+      expectedState: 'release_unknown',
+      expectedProcessAction: 'none',
+      settles: false,
+      rechecksProcess: false
+    },
+    {
+      name: 'an exact exited worker whose process is still listed',
+      connected: false,
+      verdict: { status: 'exited' as const },
+      closeError: 'tab_not_found',
+      currentProcessIncarnation: 'pty-worker:incarnation-1',
+      processLiveness: 'live' as const,
+      expectedState: 'release_unknown',
+      expectedProcessAction: 'none',
+      settles: false,
+      rechecksProcess: true
+    },
+    {
+      name: 'an exact exited worker whose process can no longer be verified',
+      connected: false,
+      verdict: { status: 'exited' as const },
+      closeError: 'tab_not_found',
+      currentProcessIncarnation: 'pty-worker:incarnation-1',
+      processLiveness: 'unverifiable' as const,
+      expectedState: 'release_unknown',
+      expectedProcessAction: 'none',
+      settles: false,
+      rechecksProcess: true
+    },
+    {
+      name: 'an exact exited worker whose process incarnation changed',
+      connected: false,
+      verdict: { status: 'exited' as const },
+      closeError: 'tab_not_found',
+      currentProcessIncarnation: 'pty-worker:incarnation-2',
+      processLiveness: 'exited' as const,
+      expectedState: 'release_unknown',
+      expectedProcessAction: 'none',
+      settles: false,
+      rechecksProcess: false
+    },
+    {
+      name: 'an exact exited worker whose process incarnation disappeared',
+      connected: false,
+      verdict: { status: 'exited' as const },
+      closeError: 'tab_not_found',
+      currentProcessIncarnation: null,
+      processLiveness: 'exited' as const,
+      expectedState: 'release_unknown',
+      expectedProcessAction: 'none',
+      settles: false,
+      rechecksProcess: false
+    },
+    {
+      name: 'an exact exited worker whose process oracle failed',
+      connected: false,
+      verdict: { status: 'exited' as const },
+      closeError: 'tab_not_found',
+      currentProcessIncarnation: 'pty-worker:incarnation-1',
+      processLiveness: 'throws' as const,
+      expectedState: 'release_unknown',
+      expectedProcessAction: 'none',
+      settles: false,
+      rechecksProcess: true
+    }
+  ])(
+    'handles $closeError after trying to close $name',
+    async ({
+      connected,
+      verdict,
+      closeError,
+      currentProcessIncarnation,
+      processLiveness,
+      expectedState,
+      expectedProcessAction,
+      settles,
+      rechecksProcess
+    }) => {
+      const resource = {
+        id: 'resource-1',
+        terminal_handle: 'term_worker',
+        process_incarnation: 'pty-worker:incarnation-1',
+        host_scope: JSON.stringify({ kind: 'local', hostId: 'local' }),
+        archive_source: 'terminal',
+        archive_status: 'captured',
+        ownership_state: 'owned',
+        release_state: 'requested'
+      } as WorkerTerminalResourceRow
+      const runtime = {
+        showTerminal: vi.fn(async () => ({ handle: 'term_worker', connected })),
+        getTerminalPaneKey: vi.fn(() => 'tab-worker:leaf-worker'),
+        getTerminalProcessIncarnation: vi.fn(() => currentProcessIncarnation),
+        getTerminalLivenessVerdict: vi.fn(() => verdict),
+        inspectTerminalProcessIncarnationLiveness: vi.fn(async () => {
+          if (processLiveness === 'throws') {
+            throw new Error('listProcesses failed')
+          }
+          return processLiveness
+        }),
+        getOrchestrationDispatchAuthority: vi.fn(() => ({
+          hostScope: { kind: 'local', hostId: 'local' }
+        })),
+        closeTerminal: vi.fn(async () => {
+          throw new Error(closeError)
+        }),
+        notifyMessageArrived: vi.fn()
+      } as unknown as OrcaRuntimeService
+      const settleWorkerTerminalRelease = vi.fn(() => ({
+        ...resource,
+        ownership_state: 'released',
+        release_state: 'released'
+      }))
+      const markWorkerTerminalReleaseUnknown = vi.fn(
+        (_resourceId: string, releaseError: string) => ({
+          ...resource,
+          release_state: 'unknown',
+          release_error: releaseError
+        })
+      )
+      const db = {
+        getWorkerDispatch: vi.fn(() => ({
+          agent_terminal_handle: 'term_worker',
+          created_at: '2026-08-16T00:00:00.000Z'
+        })),
+        isDispatchProcessCurrent: vi.fn(() => true),
+        workerTerminalResourceHasIdentityConflict: vi.fn(() => false),
+        getWorkerTerminalArchive: vi.fn(() => ({ kind: 'transcript_pin' })),
+        commitWorkerTerminalArchiveForRelease: vi.fn(() => ({
+          ...resource,
+          release_state: 'releasing'
+        })),
+        settleWorkerTerminalRelease,
+        markWorkerTerminalReleaseUnknown
+      } as unknown as OrchestrationDb
+
+      await expect(
+        completeWorkerTerminalRelease({
+          runtime,
+          db,
+          dispatchId: 'ctx-worker',
+          resource
+        })
+      ).resolves.toMatchObject({
+        state: expectedState,
+        processAction: expectedProcessAction,
+        // The frozen archive must survive either verdict; a settled release that forgets it
+        // would strand the only readable record of the worker's output.
+        archive: { source: 'terminal', status: 'captured' }
+      })
+      if (rechecksProcess) {
+        expect(runtime.inspectTerminalProcessIncarnationLiveness).toHaveBeenCalledWith(
+          'pty-worker:incarnation-1',
+          resource.host_scope
+        )
+        expect(runtime.inspectTerminalProcessIncarnationLiveness).toHaveBeenCalledTimes(1)
+      } else {
+        expect(runtime.inspectTerminalProcessIncarnationLiveness).not.toHaveBeenCalled()
+      }
+      if (settles) {
+        expect(settleWorkerTerminalRelease).toHaveBeenCalledWith('resource-1')
+        expect(settleWorkerTerminalRelease).toHaveBeenCalledTimes(1)
+        expect(markWorkerTerminalReleaseUnknown).not.toHaveBeenCalled()
+        // Without this the coordinator never wakes on the release it is blocked on.
+        expect(runtime.notifyMessageArrived).toHaveBeenCalledWith('dispatch:ctx-worker', 'status')
+        expect(runtime.notifyMessageArrived).toHaveBeenCalledTimes(1)
+        return
+      }
+      expect(settleWorkerTerminalRelease).not.toHaveBeenCalled()
+      expect(markWorkerTerminalReleaseUnknown).toHaveBeenCalledWith('resource-1', closeError)
+      expect(markWorkerTerminalReleaseUnknown).toHaveBeenCalledTimes(1)
+      // An unsettled release must not announce itself as a completed one.
+      expect(runtime.notifyMessageArrived).not.toHaveBeenCalled()
+    }
+  )
 })

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-liveness-verdict.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-liveness-verdict.test.ts
@@ -74,7 +74,9 @@ describe('orchestration worker release liveness verdict', () => {
     ).resolves.toMatchObject({
       state: 'release_unknown',
       processAction: 'closed_agent_terminal',
-      lastError: `The agent terminal was closed but its process could not be confirmed stopped: ${detail}.`
+      lastError: `The agent terminal was closed but its process could not be confirmed stopped: ${detail}.`,
+      recovery:
+        'Inspect with: orca orchestration worker-show --dispatch ctx-worker --json — if it proves the exact process exited after this request, run a fresh worker-release without --retry-request to re-observe it. Use --retry-request only when the prior response was lost; it replays the request and does not re-measure. Never substitute a broad terminal close.'
     })
     expect(markWorkerTerminalReleaseUnknown).toHaveBeenCalledWith(
       'resource-1',

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-liveness-verdict.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-liveness-verdict.test.ts
@@ -87,6 +87,19 @@ describe('orchestration worker release liveness verdict', () => {
   // only one half would let the other be widened without a red test.
   it.each([
     {
+      name: 'an exact exited worker after its tab was removed',
+      connected: false,
+      verdict: { status: 'exited' as const },
+      closeError: 'tab_not_found',
+      currentProcessIncarnation: 'pty-worker:incarnation-1',
+      processLiveness: 'exited' as const,
+      dispatchAuthority: null,
+      expectedState: 'released',
+      expectedProcessAction: 'none',
+      settles: true,
+      rechecksProcess: true
+    },
+    {
       name: 'an exact exited worker',
       connected: false,
       verdict: { status: 'exited' as const },
@@ -207,6 +220,7 @@ describe('orchestration worker release liveness verdict', () => {
       closeError,
       currentProcessIncarnation,
       processLiveness,
+      dispatchAuthority,
       expectedState,
       expectedProcessAction,
       settles,
@@ -233,9 +247,9 @@ describe('orchestration worker release liveness verdict', () => {
           }
           return processLiveness
         }),
-        getOrchestrationDispatchAuthority: vi.fn(() => ({
-          hostScope: { kind: 'local', hostId: 'local' }
-        })),
+        getOrchestrationDispatchAuthority: vi.fn(() =>
+          dispatchAuthority === null ? null : { hostScope: { kind: 'local', hostId: 'local' } }
+        ),
         closeTerminal: vi.fn(async () => {
           throw new Error(closeError)
         }),
@@ -264,6 +278,11 @@ describe('orchestration worker release liveness verdict', () => {
         commitWorkerTerminalArchiveForRelease: vi.fn(() => ({
           ...resource,
           release_state: 'releasing'
+        })),
+        revertWorkerTerminalReleaseToRetained: vi.fn(() => ({
+          ...resource,
+          release_state: 'retained',
+          retained_reason: 'identity_unproven'
         })),
         settleWorkerTerminalRelease,
         markWorkerTerminalReleaseUnknown

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-liveness-verdict.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-liveness-verdict.test.ts
@@ -97,7 +97,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'released',
       expectedProcessAction: 'none',
       settles: true,
-      rechecksProcess: true
+      processRecheckCount: 2
     },
     {
       name: 'an exact exited worker',
@@ -109,7 +109,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'released',
       expectedProcessAction: 'none',
       settles: true,
-      rechecksProcess: true
+      processRecheckCount: 2
     },
     {
       name: 'a live worker',
@@ -121,7 +121,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
-      rechecksProcess: false
+      processRecheckCount: 0
     },
     {
       // An observed exit is not a blank cheque: only an absent tab proves the close itself finished.
@@ -134,7 +134,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
-      rechecksProcess: false
+      processRecheckCount: 1
     },
     {
       // Lost contact is not a death certificate; an absent tab cannot settle an unobserved process.
@@ -150,7 +150,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
-      rechecksProcess: false
+      processRecheckCount: 0
     },
     {
       name: 'an exact exited worker whose process is still listed',
@@ -162,7 +162,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
-      rechecksProcess: true
+      processRecheckCount: 1
     },
     {
       name: 'an exact exited worker whose process can no longer be verified',
@@ -174,7 +174,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
-      rechecksProcess: true
+      processRecheckCount: 1
     },
     {
       name: 'an exact exited worker whose process incarnation changed',
@@ -186,7 +186,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
-      rechecksProcess: false
+      processRecheckCount: 0
     },
     {
       name: 'an exact exited worker whose process incarnation disappeared',
@@ -198,7 +198,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
-      rechecksProcess: false
+      processRecheckCount: 0
     },
     {
       name: 'an exact exited worker whose process oracle failed',
@@ -210,7 +210,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
-      rechecksProcess: true
+      processRecheckCount: 1
     }
   ])(
     'handles $closeError after trying to close $name',
@@ -224,7 +224,7 @@ describe('orchestration worker release liveness verdict', () => {
       expectedState,
       expectedProcessAction,
       settles,
-      rechecksProcess
+      processRecheckCount
     }) => {
       const resource = {
         id: 'resource-1',
@@ -302,12 +302,14 @@ describe('orchestration worker release liveness verdict', () => {
         // would strand the only readable record of the worker's output.
         archive: { source: 'terminal', status: 'captured' }
       })
-      if (rechecksProcess) {
+      if (processRecheckCount > 0) {
         expect(runtime.inspectTerminalProcessIncarnationLiveness).toHaveBeenCalledWith(
           'pty-worker:incarnation-1',
           resource.host_scope
         )
-        expect(runtime.inspectTerminalProcessIncarnationLiveness).toHaveBeenCalledTimes(1)
+        expect(runtime.inspectTerminalProcessIncarnationLiveness).toHaveBeenCalledTimes(
+          processRecheckCount
+        )
       } else {
         expect(runtime.inspectTerminalProcessIncarnationLiveness).not.toHaveBeenCalled()
       }

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-preclosed-tab.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-preclosed-tab.test.ts
@@ -9,60 +9,136 @@ describe('orchestration worker release after its tab was already closed', () => 
     {
       processLiveness: 'exited' as const,
       postCloseProcessLiveness: 'exited' as const,
+      incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: false,
       closeError: null,
+      closeRefusedReason: null,
       expectedState: 'released',
-      settles: true
+      expectedProcessAction: 'closed_exited_terminal',
+      settles: true,
+      expectedCloseAttempts: 1,
+      marksUnknown: false
     },
     {
       processLiveness: 'live' as const,
       postCloseProcessLiveness: 'live' as const,
+      incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: false,
       closeError: null,
+      closeRefusedReason: null,
       expectedState: 'release_unknown',
-      settles: false
+      expectedProcessAction: 'closed_agent_terminal',
+      settles: false,
+      expectedCloseAttempts: 1,
+      marksUnknown: true
     },
     {
       processLiveness: 'unverifiable' as const,
       postCloseProcessLiveness: 'unverifiable' as const,
+      incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: false,
       closeError: null,
+      closeRefusedReason: null,
       expectedState: 'release_unknown',
-      settles: false
+      expectedProcessAction: 'closed_agent_terminal',
+      settles: false,
+      expectedCloseAttempts: 1,
+      marksUnknown: true
     },
     {
       processLiveness: 'exited' as const,
       postCloseProcessLiveness: 'exited' as const,
+      incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: true,
       closeError: null,
-      expectedState: 'release_unknown',
-      settles: false
+      closeRefusedReason: null,
+      expectedState: 'retained',
+      expectedProcessAction: 'none',
+      settles: false,
+      expectedCloseAttempts: 1,
+      marksUnknown: false
     },
     {
       processLiveness: 'exited' as const,
       postCloseProcessLiveness: 'exited' as const,
+      incarnationChangesDuringLiveness: true,
+      incarnationChangesOnClose: false,
+      closeError: null,
+      closeRefusedReason: null,
+      expectedState: 'retained',
+      expectedProcessAction: 'none',
+      settles: false,
+      expectedCloseAttempts: 0,
+      marksUnknown: false
+    },
+    {
+      processLiveness: 'exited' as const,
+      postCloseProcessLiveness: 'exited' as const,
+      incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: false,
       closeError: 'tab_not_found',
+      closeRefusedReason: null,
       expectedState: 'released',
-      settles: true
+      expectedProcessAction: 'none',
+      settles: true,
+      expectedCloseAttempts: 1,
+      marksUnknown: false
     },
     {
       processLiveness: 'exited' as const,
       postCloseProcessLiveness: 'live' as const,
+      incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: false,
       closeError: 'tab_not_found',
+      closeRefusedReason: null,
       expectedState: 'release_unknown',
-      settles: false
+      expectedProcessAction: 'none',
+      settles: false,
+      expectedCloseAttempts: 1,
+      marksUnknown: true
+    },
+    {
+      processLiveness: 'exited' as const,
+      postCloseProcessLiveness: 'exited' as const,
+      incarnationChangesDuringLiveness: false,
+      incarnationChangesOnClose: false,
+      closeError: null,
+      closeRefusedReason: 'incarnation_replaced' as const,
+      expectedState: 'retained',
+      expectedProcessAction: 'none',
+      settles: false,
+      expectedCloseAttempts: 1,
+      marksUnknown: false
+    },
+    {
+      processLiveness: 'exited' as const,
+      postCloseProcessLiveness: 'exited' as const,
+      incarnationChangesDuringLiveness: false,
+      incarnationChangesOnClose: true,
+      closeError: null,
+      closeRefusedReason: null,
+      closePtyKilled: true,
+      expectedState: 'retained',
+      expectedProcessAction: 'none',
+      settles: false,
+      expectedCloseAttempts: 1,
+      marksUnknown: false
     }
   ])(
-    'settles only when the exact process is $processLiveness before an unconfirmed close',
+    'handles process=$processLiveness postClose=$postCloseProcessLiveness close=$closeError refusal=$closeRefusedReason killed=$closePtyKilled changeDuringCheck=$incarnationChangesDuringLiveness changeOnClose=$incarnationChangesOnClose',
     async ({
       processLiveness,
       postCloseProcessLiveness,
+      incarnationChangesDuringLiveness,
       incarnationChangesOnClose,
       closeError,
+      closeRefusedReason,
+      closePtyKilled = false,
       expectedState,
-      settles
+      expectedProcessAction,
+      settles,
+      expectedCloseAttempts,
+      marksUnknown
     }) => {
       const resource = {
         id: 'resource-1',
@@ -75,18 +151,21 @@ describe('orchestration worker release after its tab was already closed', () => 
         release_state: 'requested'
       } as WorkerTerminalResourceRow
       let closeAttempted = false
+      let processLivenessChecked = false
       const runtime = {
         showTerminal: vi.fn(async () => ({ handle: 'term_worker', connected: false })),
         getTerminalPaneKey: vi.fn(() => 'tab-worker:leaf-worker'),
         getTerminalProcessIncarnation: vi.fn(() =>
-          closeAttempted && incarnationChangesOnClose
+          (processLivenessChecked && incarnationChangesDuringLiveness) ||
+          (closeAttempted && incarnationChangesOnClose)
             ? 'pty-worker:incarnation-2'
             : 'pty-worker:incarnation-1'
         ),
         getTerminalLivenessVerdict: vi.fn(() => ({ status: 'exited' as const })),
-        inspectTerminalProcessIncarnationLiveness: vi.fn(async () =>
-          closeAttempted ? postCloseProcessLiveness : processLiveness
-        ),
+        inspectTerminalProcessIncarnationLiveness: vi.fn(async () => {
+          processLivenessChecked = true
+          return closeAttempted ? postCloseProcessLiveness : processLiveness
+        }),
         getOrchestrationDispatchAuthority: vi.fn(() => null),
         closeTerminal: vi.fn(async () => {
           closeAttempted = true
@@ -96,7 +175,8 @@ describe('orchestration worker release after its tab was already closed', () => 
           return {
             handle: 'term_worker',
             tabId: 'tab-worker',
-            ptyKilled: false
+            ptyKilled: closePtyKilled,
+            ...(closeRefusedReason ? { closeRefusedReason } : {})
           }
         }),
         notifyMessageArrived: vi.fn()
@@ -146,6 +226,7 @@ describe('orchestration worker release after its tab was already closed', () => 
         })
       ).resolves.toMatchObject({
         state: expectedState,
+        processAction: expectedProcessAction,
         archive: { source: 'terminal', status: 'captured' }
       })
       expect(runtime.inspectTerminalProcessIncarnationLiveness).toHaveBeenCalledWith(
@@ -155,12 +236,18 @@ describe('orchestration worker release after its tab was already closed', () => 
       expect(runtime.inspectTerminalProcessIncarnationLiveness).toHaveBeenCalledTimes(
         closeError ? 2 : 1
       )
+      expect(runtime.closeTerminal).toHaveBeenCalledTimes(expectedCloseAttempts)
+      if (expectedCloseAttempts > 0) {
+        expect(runtime.closeTerminal).toHaveBeenCalledWith('term_worker', {
+          expectedProcessIncarnation: 'pty-worker:incarnation-1'
+        })
+      }
       if (settles) {
         expect(settleWorkerTerminalRelease).toHaveBeenCalledWith('resource-1')
         expect(markWorkerTerminalReleaseUnknown).not.toHaveBeenCalled()
       } else {
         expect(settleWorkerTerminalRelease).not.toHaveBeenCalled()
-        expect(markWorkerTerminalReleaseUnknown).toHaveBeenCalledTimes(1)
+        expect(markWorkerTerminalReleaseUnknown).toHaveBeenCalledTimes(marksUnknown ? 1 : 0)
       }
     }
   )

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-preclosed-tab.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-preclosed-tab.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { OrchestrationDb } from '../../orchestration/db'
+import type { WorkerTerminalResourceRow } from '../../orchestration/worker-terminal-ownership'
+import { completeWorkerTerminalRelease } from './orchestration-worker-release-completion'
+
+describe('orchestration worker release after its tab was already closed', () => {
+  it.each([
+    {
+      processLiveness: 'exited' as const,
+      postCloseProcessLiveness: 'exited' as const,
+      incarnationChangesOnClose: false,
+      closeError: null,
+      expectedState: 'released',
+      settles: true
+    },
+    {
+      processLiveness: 'live' as const,
+      postCloseProcessLiveness: 'live' as const,
+      incarnationChangesOnClose: false,
+      closeError: null,
+      expectedState: 'release_unknown',
+      settles: false
+    },
+    {
+      processLiveness: 'unverifiable' as const,
+      postCloseProcessLiveness: 'unverifiable' as const,
+      incarnationChangesOnClose: false,
+      closeError: null,
+      expectedState: 'release_unknown',
+      settles: false
+    },
+    {
+      processLiveness: 'exited' as const,
+      postCloseProcessLiveness: 'exited' as const,
+      incarnationChangesOnClose: true,
+      closeError: null,
+      expectedState: 'release_unknown',
+      settles: false
+    },
+    {
+      processLiveness: 'exited' as const,
+      postCloseProcessLiveness: 'exited' as const,
+      incarnationChangesOnClose: false,
+      closeError: 'tab_not_found',
+      expectedState: 'released',
+      settles: true
+    },
+    {
+      processLiveness: 'exited' as const,
+      postCloseProcessLiveness: 'live' as const,
+      incarnationChangesOnClose: false,
+      closeError: 'tab_not_found',
+      expectedState: 'release_unknown',
+      settles: false
+    }
+  ])(
+    'settles only when the exact process is $processLiveness before an unconfirmed close',
+    async ({
+      processLiveness,
+      postCloseProcessLiveness,
+      incarnationChangesOnClose,
+      closeError,
+      expectedState,
+      settles
+    }) => {
+      const resource = {
+        id: 'resource-1',
+        terminal_handle: 'term_worker',
+        process_incarnation: 'pty-worker:incarnation-1',
+        host_scope: JSON.stringify({ kind: 'local', hostId: 'local' }),
+        archive_source: 'terminal',
+        archive_status: 'captured',
+        ownership_state: 'owned',
+        release_state: 'requested'
+      } as WorkerTerminalResourceRow
+      let closeAttempted = false
+      const runtime = {
+        showTerminal: vi.fn(async () => ({ handle: 'term_worker', connected: false })),
+        getTerminalPaneKey: vi.fn(() => 'tab-worker:leaf-worker'),
+        getTerminalProcessIncarnation: vi.fn(() =>
+          closeAttempted && incarnationChangesOnClose
+            ? 'pty-worker:incarnation-2'
+            : 'pty-worker:incarnation-1'
+        ),
+        getTerminalLivenessVerdict: vi.fn(() => ({ status: 'exited' as const })),
+        inspectTerminalProcessIncarnationLiveness: vi.fn(async () =>
+          closeAttempted ? postCloseProcessLiveness : processLiveness
+        ),
+        getOrchestrationDispatchAuthority: vi.fn(() => null),
+        closeTerminal: vi.fn(async () => {
+          closeAttempted = true
+          if (closeError) {
+            throw new Error(closeError)
+          }
+          return {
+            handle: 'term_worker',
+            tabId: 'tab-worker',
+            ptyKilled: false
+          }
+        }),
+        notifyMessageArrived: vi.fn()
+      } as unknown as OrcaRuntimeService
+      const settleWorkerTerminalRelease = vi.fn(() => ({
+        ...resource,
+        ownership_state: 'released',
+        release_state: 'released'
+      }))
+      const markWorkerTerminalReleaseUnknown = vi.fn(
+        (_resourceId: string, releaseError: string) => ({
+          ...resource,
+          release_state: 'unknown',
+          release_error: releaseError
+        })
+      )
+      const db = {
+        getWorkerDispatch: vi.fn(() => ({
+          agent_terminal_handle: 'term_worker',
+          created_at: '2026-08-16T00:00:00.000Z'
+        })),
+        isDispatchProcessCurrent: vi.fn(
+          ({ processIncarnation }: { processIncarnation: string | null }) =>
+            processIncarnation === 'pty-worker:incarnation-1'
+        ),
+        workerTerminalResourceHasIdentityConflict: vi.fn(() => false),
+        getWorkerTerminalArchive: vi.fn(() => ({ kind: 'transcript_pin' })),
+        commitWorkerTerminalArchiveForRelease: vi.fn(() => ({
+          ...resource,
+          release_state: 'releasing'
+        })),
+        revertWorkerTerminalReleaseToRetained: vi.fn(() => ({
+          ...resource,
+          release_state: 'retained',
+          retained_reason: 'identity_unproven'
+        })),
+        settleWorkerTerminalRelease,
+        markWorkerTerminalReleaseUnknown
+      } as unknown as OrchestrationDb
+
+      await expect(
+        completeWorkerTerminalRelease({
+          runtime,
+          db,
+          dispatchId: 'ctx-worker',
+          resource
+        })
+      ).resolves.toMatchObject({
+        state: expectedState,
+        archive: { source: 'terminal', status: 'captured' }
+      })
+      expect(runtime.inspectTerminalProcessIncarnationLiveness).toHaveBeenCalledWith(
+        'pty-worker:incarnation-1',
+        resource.host_scope
+      )
+      expect(runtime.inspectTerminalProcessIncarnationLiveness).toHaveBeenCalledTimes(
+        closeError ? 2 : 1
+      )
+      if (settles) {
+        expect(settleWorkerTerminalRelease).toHaveBeenCalledWith('resource-1')
+        expect(markWorkerTerminalReleaseUnknown).not.toHaveBeenCalled()
+      } else {
+        expect(settleWorkerTerminalRelease).not.toHaveBeenCalled()
+        expect(markWorkerTerminalReleaseUnknown).toHaveBeenCalledTimes(1)
+      }
+    }
+  )
+})

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-preclosed-tab.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-preclosed-tab.test.ts
@@ -4,117 +4,145 @@ import type { OrchestrationDb } from '../../orchestration/db'
 import type { WorkerTerminalResourceRow } from '../../orchestration/worker-terminal-ownership'
 import { completeWorkerTerminalRelease } from './orchestration-worker-release-completion'
 
+const LOCAL_HOST_SCOPE = { kind: 'local', hostId: 'local' } as const
+
 describe('orchestration worker release after its tab was already closed', () => {
   it.each([
     {
+      observation: 'exited' as const,
       processLiveness: 'exited' as const,
       postCloseProcessLiveness: 'exited' as const,
       incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: false,
+      identityConflictOnClose: false,
       closeError: null,
       closeRefusedReason: null,
       expectedState: 'released',
       expectedProcessAction: 'closed_exited_terminal',
       settles: true,
       expectedCloseAttempts: 1,
+      expectedLivenessChecks: 1,
       marksUnknown: false
     },
     {
+      observation: 'exited' as const,
       processLiveness: 'live' as const,
       postCloseProcessLiveness: 'live' as const,
       incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: false,
+      identityConflictOnClose: false,
       closeError: null,
       closeRefusedReason: null,
       expectedState: 'release_unknown',
       expectedProcessAction: 'closed_agent_terminal',
       settles: false,
       expectedCloseAttempts: 1,
+      expectedLivenessChecks: 1,
       marksUnknown: true
     },
     {
+      observation: 'exited' as const,
       processLiveness: 'unverifiable' as const,
       postCloseProcessLiveness: 'unverifiable' as const,
       incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: false,
+      identityConflictOnClose: false,
       closeError: null,
       closeRefusedReason: null,
       expectedState: 'release_unknown',
       expectedProcessAction: 'closed_agent_terminal',
       settles: false,
       expectedCloseAttempts: 1,
+      expectedLivenessChecks: 1,
       marksUnknown: true
     },
     {
+      observation: 'exited' as const,
       processLiveness: 'exited' as const,
       postCloseProcessLiveness: 'exited' as const,
       incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: true,
+      identityConflictOnClose: false,
       closeError: null,
       closeRefusedReason: null,
       expectedState: 'retained',
       expectedProcessAction: 'none',
       settles: false,
       expectedCloseAttempts: 1,
+      expectedLivenessChecks: 1,
       marksUnknown: false
     },
     {
+      observation: 'exited' as const,
       processLiveness: 'exited' as const,
       postCloseProcessLiveness: 'exited' as const,
       incarnationChangesDuringLiveness: true,
       incarnationChangesOnClose: false,
+      identityConflictOnClose: false,
       closeError: null,
       closeRefusedReason: null,
       expectedState: 'retained',
       expectedProcessAction: 'none',
       settles: false,
       expectedCloseAttempts: 0,
+      expectedLivenessChecks: 1,
       marksUnknown: false
     },
     {
+      observation: 'exited' as const,
       processLiveness: 'exited' as const,
       postCloseProcessLiveness: 'exited' as const,
       incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: false,
+      identityConflictOnClose: false,
       closeError: 'tab_not_found',
       closeRefusedReason: null,
       expectedState: 'released',
       expectedProcessAction: 'none',
       settles: true,
       expectedCloseAttempts: 1,
+      expectedLivenessChecks: 2,
       marksUnknown: false
     },
     {
+      observation: 'exited' as const,
       processLiveness: 'exited' as const,
       postCloseProcessLiveness: 'live' as const,
       incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: false,
+      identityConflictOnClose: false,
       closeError: 'tab_not_found',
       closeRefusedReason: null,
       expectedState: 'release_unknown',
       expectedProcessAction: 'none',
       settles: false,
       expectedCloseAttempts: 1,
+      expectedLivenessChecks: 2,
       marksUnknown: true
     },
     {
+      observation: 'exited' as const,
       processLiveness: 'exited' as const,
       postCloseProcessLiveness: 'exited' as const,
       incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: false,
+      identityConflictOnClose: false,
       closeError: null,
       closeRefusedReason: 'incarnation_replaced' as const,
       expectedState: 'retained',
       expectedProcessAction: 'none',
       settles: false,
       expectedCloseAttempts: 1,
+      expectedLivenessChecks: 1,
       marksUnknown: false
     },
     {
+      observation: 'exited' as const,
       processLiveness: 'exited' as const,
       postCloseProcessLiveness: 'exited' as const,
       incarnationChangesDuringLiveness: false,
       incarnationChangesOnClose: true,
+      identityConflictOnClose: false,
       closeError: null,
       closeRefusedReason: null,
       closePtyKilled: true,
@@ -122,15 +150,102 @@ describe('orchestration worker release after its tab was already closed', () => 
       expectedProcessAction: 'none',
       settles: false,
       expectedCloseAttempts: 1,
+      expectedLivenessChecks: 1,
+      marksUnknown: false
+    },
+    // The lost-ACK path: live before close, the exact recorded incarnation exited during it, and
+    // the tab acknowledgement was lost. Only the post-close recheck can see that transition.
+    {
+      observation: 'live' as const,
+      processLiveness: 'live' as const,
+      postCloseProcessLiveness: 'exited' as const,
+      incarnationChangesDuringLiveness: false,
+      incarnationChangesOnClose: false,
+      identityConflictOnClose: false,
+      closeError: 'tab_not_found',
+      closeRefusedReason: null,
+      expectedState: 'released',
+      expectedProcessAction: 'none',
+      settles: true,
+      expectedCloseAttempts: 1,
+      expectedLivenessChecks: 1,
+      marksUnknown: false
+    },
+    {
+      observation: 'live' as const,
+      processLiveness: 'live' as const,
+      postCloseProcessLiveness: 'live' as const,
+      incarnationChangesDuringLiveness: false,
+      incarnationChangesOnClose: false,
+      identityConflictOnClose: false,
+      closeError: 'tab_not_found',
+      closeRefusedReason: null,
+      expectedState: 'release_unknown',
+      expectedProcessAction: 'none',
+      settles: false,
+      expectedCloseAttempts: 1,
+      expectedLivenessChecks: 1,
+      marksUnknown: true
+    },
+    {
+      observation: 'live' as const,
+      processLiveness: 'live' as const,
+      postCloseProcessLiveness: 'unverifiable' as const,
+      incarnationChangesDuringLiveness: false,
+      incarnationChangesOnClose: false,
+      identityConflictOnClose: false,
+      closeError: 'tab_not_found',
+      closeRefusedReason: null,
+      expectedState: 'release_unknown',
+      expectedProcessAction: 'none',
+      settles: false,
+      expectedCloseAttempts: 1,
+      expectedLivenessChecks: 1,
+      marksUnknown: true
+    },
+    {
+      observation: 'live' as const,
+      processLiveness: 'live' as const,
+      postCloseProcessLiveness: 'exited' as const,
+      incarnationChangesDuringLiveness: false,
+      incarnationChangesOnClose: true,
+      identityConflictOnClose: false,
+      closeError: 'tab_not_found',
+      closeRefusedReason: null,
+      expectedState: 'release_unknown',
+      expectedProcessAction: 'none',
+      settles: false,
+      expectedCloseAttempts: 1,
+      expectedLivenessChecks: 0,
+      marksUnknown: true
+    },
+    // A stale lease found after the process proved dead keeps the retained outcome instead of
+    // degrading to unknown.
+    {
+      observation: 'exited' as const,
+      processLiveness: 'exited' as const,
+      postCloseProcessLiveness: 'exited' as const,
+      incarnationChangesDuringLiveness: false,
+      incarnationChangesOnClose: false,
+      identityConflictOnClose: true,
+      closeError: 'tab_not_found',
+      closeRefusedReason: null,
+      expectedState: 'retained',
+      expectedProcessAction: 'none',
+      settles: false,
+      expectedCloseAttempts: 1,
+      expectedLivenessChecks: 2,
       marksUnknown: false
     }
   ])(
-    'handles process=$processLiveness postClose=$postCloseProcessLiveness close=$closeError refusal=$closeRefusedReason killed=$closePtyKilled changeDuringCheck=$incarnationChangesDuringLiveness changeOnClose=$incarnationChangesOnClose',
+    'handles observed=$observation process=$processLiveness postClose=$postCloseProcessLiveness close=$closeError refusal=$closeRefusedReason killed=$closePtyKilled changeDuringCheck=$incarnationChangesDuringLiveness changeOnClose=$incarnationChangesOnClose conflictOnClose=$identityConflictOnClose',
     async ({
+      observation,
       processLiveness,
       postCloseProcessLiveness,
       incarnationChangesDuringLiveness,
       incarnationChangesOnClose,
+      identityConflictOnClose,
       closeError,
       closeRefusedReason,
       closePtyKilled = false,
@@ -138,13 +253,14 @@ describe('orchestration worker release after its tab was already closed', () => 
       expectedProcessAction,
       settles,
       expectedCloseAttempts,
+      expectedLivenessChecks,
       marksUnknown
     }) => {
       const resource = {
         id: 'resource-1',
         terminal_handle: 'term_worker',
         process_incarnation: 'pty-worker:incarnation-1',
-        host_scope: JSON.stringify({ kind: 'local', hostId: 'local' }),
+        host_scope: JSON.stringify(LOCAL_HOST_SCOPE),
         archive_source: 'terminal',
         archive_status: 'captured',
         ownership_state: 'owned',
@@ -153,7 +269,10 @@ describe('orchestration worker release after its tab was already closed', () => 
       let closeAttempted = false
       let processLivenessChecked = false
       const runtime = {
-        showTerminal: vi.fn(async () => ({ handle: 'term_worker', connected: false })),
+        showTerminal: vi.fn(async () => ({
+          handle: 'term_worker',
+          connected: observation === 'live'
+        })),
         getTerminalPaneKey: vi.fn(() => 'tab-worker:leaf-worker'),
         getTerminalProcessIncarnation: vi.fn(() =>
           (processLivenessChecked && incarnationChangesDuringLiveness) ||
@@ -161,12 +280,12 @@ describe('orchestration worker release after its tab was already closed', () => 
             ? 'pty-worker:incarnation-2'
             : 'pty-worker:incarnation-1'
         ),
-        getTerminalLivenessVerdict: vi.fn(() => ({ status: 'exited' as const })),
+        getTerminalLivenessVerdict: vi.fn(() => ({ status: observation })),
         inspectTerminalProcessIncarnationLiveness: vi.fn(async () => {
           processLivenessChecked = true
           return closeAttempted ? postCloseProcessLiveness : processLiveness
         }),
-        getOrchestrationDispatchAuthority: vi.fn(() => null),
+        getOrchestrationDispatchAuthority: vi.fn(() => ({ hostScope: LOCAL_HOST_SCOPE })),
         closeTerminal: vi.fn(async () => {
           closeAttempted = true
           if (closeError) {
@@ -193,6 +312,11 @@ describe('orchestration worker release after its tab was already closed', () => 
           release_error: releaseError
         })
       )
+      const revertWorkerTerminalReleaseToRetained = vi.fn(() => ({
+        ...resource,
+        release_state: 'retained',
+        retained_reason: 'identity_unproven'
+      }))
       const db = {
         getWorkerDispatch: vi.fn(() => ({
           agent_terminal_handle: 'term_worker',
@@ -202,17 +326,15 @@ describe('orchestration worker release after its tab was already closed', () => 
           ({ processIncarnation }: { processIncarnation: string | null }) =>
             processIncarnation === 'pty-worker:incarnation-1'
         ),
-        workerTerminalResourceHasIdentityConflict: vi.fn(() => false),
+        workerTerminalResourceHasIdentityConflict: vi.fn(
+          () => closeAttempted && identityConflictOnClose
+        ),
         getWorkerTerminalArchive: vi.fn(() => ({ kind: 'transcript_pin' })),
         commitWorkerTerminalArchiveForRelease: vi.fn(() => ({
           ...resource,
           release_state: 'releasing'
         })),
-        revertWorkerTerminalReleaseToRetained: vi.fn(() => ({
-          ...resource,
-          release_state: 'retained',
-          retained_reason: 'identity_unproven'
-        })),
+        revertWorkerTerminalReleaseToRetained,
         settleWorkerTerminalRelease,
         markWorkerTerminalReleaseUnknown
       } as unknown as OrchestrationDb
@@ -229,12 +351,14 @@ describe('orchestration worker release after its tab was already closed', () => 
         processAction: expectedProcessAction,
         archive: { source: 'terminal', status: 'captured' }
       })
-      expect(runtime.inspectTerminalProcessIncarnationLiveness).toHaveBeenCalledWith(
-        'pty-worker:incarnation-1',
-        resource.host_scope
-      )
+      if (expectedLivenessChecks > 0) {
+        expect(runtime.inspectTerminalProcessIncarnationLiveness).toHaveBeenCalledWith(
+          'pty-worker:incarnation-1',
+          resource.host_scope
+        )
+      }
       expect(runtime.inspectTerminalProcessIncarnationLiveness).toHaveBeenCalledTimes(
-        closeError ? 2 : 1
+        expectedLivenessChecks
       )
       expect(runtime.closeTerminal).toHaveBeenCalledTimes(expectedCloseAttempts)
       if (expectedCloseAttempts > 0) {
@@ -248,6 +372,12 @@ describe('orchestration worker release after its tab was already closed', () => 
       } else {
         expect(settleWorkerTerminalRelease).not.toHaveBeenCalled()
         expect(markWorkerTerminalReleaseUnknown).toHaveBeenCalledTimes(marksUnknown ? 1 : 0)
+      }
+      if (expectedState === 'retained') {
+        expect(revertWorkerTerminalReleaseToRetained).toHaveBeenCalledWith(
+          'resource-1',
+          'identity_unproven'
+        )
       }
     }
   )

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-preclosed-tab.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-preclosed-tab.test.ts
@@ -378,6 +378,8 @@ describe('orchestration worker release after its tab was already closed', () => 
           'resource-1',
           'identity_unproven'
         )
+      } else {
+        expect(revertWorkerTerminalReleaseToRetained).not.toHaveBeenCalled()
       }
     }
   )

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-settlement.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-settlement.ts
@@ -58,17 +58,16 @@ export async function closeAndSettleWorkerTerminalRelease(args: {
       return retainWorkerTerminalRelease(db, dispatchId, resource)
     }
     if (!close.ptyKilled) {
-      const settled = exactProcessWasAlreadyExited
-        ? settleExitedWorkerTerminalRelease({
+      if (exactProcessWasAlreadyExited) {
+        return (
+          settleExitedWorkerTerminalRelease({
             runtime,
             db,
             dispatchId,
             resource,
             processAction: 'closed_exited_terminal'
-          })
-        : null
-      if (settled) {
-        return settled
+          }) ?? retainWorkerTerminalRelease(db, dispatchId, resource)
+        )
       }
       const reason = describeUnconfirmedAgentStop(close)
       const unknown = db.markWorkerTerminalReleaseUnknown(resource.id, reason)
@@ -83,20 +82,22 @@ export async function closeAndSettleWorkerTerminalRelease(args: {
     }
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error)
-    const settled =
-      exactProcessWasAlreadyExited &&
+    // The tab acknowledgement can be lost while the addressed process dies inside close, so the
+    // pre-close snapshot cannot express live -> exited. Only the post-close recheck may settle it,
+    // and it answers `unverifiable` once the handle stops resolving the recorded incarnation.
+    if (
       reason === 'tab_not_found' &&
       (await recheckProcessLiveness(runtime, resource)) === 'exited'
-        ? settleExitedWorkerTerminalRelease({
-            runtime,
-            db,
-            dispatchId,
-            resource,
-            processAction: 'none'
-          })
-        : null
-    if (settled) {
-      return settled
+    ) {
+      return (
+        settleExitedWorkerTerminalRelease({
+          runtime,
+          db,
+          dispatchId,
+          resource,
+          processAction: 'none'
+        }) ?? retainWorkerTerminalRelease(db, dispatchId, resource)
+      )
     }
     if (/disposed|not connected|unavailable/i.test(reason)) {
       return {

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-settlement.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-settlement.ts
@@ -64,15 +64,15 @@ export async function closeAndSettleWorkerTerminalRelease(args: {
     }
     if (!close.ptyKilled) {
       if (exactProcessWasAlreadyExited) {
-        return (
-          settleExitedWorkerTerminalRelease({
-            runtime,
-            db,
-            dispatchId,
-            resource,
-            processAction: 'closed_exited_terminal'
-          }) ?? retainWorkerTerminalRelease(db, dispatchId, resource)
-        )
+        // No second lease proof: the one above ran in this same synchronous turn. Keep it that way —
+        // an await introduced between them would need its own proof, as the catch path below has.
+        return settleExitedWorkerTerminalRelease({
+          runtime,
+          db,
+          dispatchId,
+          resource,
+          processAction: 'closed_exited_terminal'
+        })
       }
       const reason = describeUnconfirmedAgentStop(close)
       const unknown = db.markWorkerTerminalReleaseUnknown(resource.id, reason)
@@ -94,15 +94,16 @@ export async function closeAndSettleWorkerTerminalRelease(args: {
       reason === 'tab_not_found' &&
       (await recheckProcessLiveness(runtime, resource)) === 'exited'
     ) {
-      return (
-        settleExitedWorkerTerminalRelease({
-          runtime,
-          db,
-          dispatchId,
-          resource,
-          processAction: 'none'
-        }) ?? retainWorkerTerminalRelease(db, dispatchId, resource)
-      )
+      // The recheck yielded, so re-prove the lease before a replacement inherits this death proof.
+      return workerTerminalLeaseIsCurrent(runtime, db, dispatchId, resource, true)
+        ? settleExitedWorkerTerminalRelease({
+            runtime,
+            db,
+            dispatchId,
+            resource,
+            processAction: 'none'
+          })
+        : retainWorkerTerminalRelease(db, dispatchId, resource)
     }
     if (/disposed|not connected|unavailable/i.test(reason)) {
       return {
@@ -143,12 +144,8 @@ function settleExitedWorkerTerminalRelease(args: {
   dispatchId: string
   resource: WorkerTerminalResourceRow
   processAction: 'closed_exited_terminal' | 'none'
-}): WorkerReleaseReceipt | null {
+}): WorkerReleaseReceipt {
   const { runtime, db, dispatchId, resource, processAction } = args
-  // Re-prove the lease after close so a replacement process cannot inherit the old death proof.
-  if (!workerTerminalLeaseIsCurrent(runtime, db, dispatchId, resource, true)) {
-    return null
-  }
   const released = db.settleWorkerTerminalRelease(resource.id)
   runtime.notifyMessageArrived(`dispatch:${dispatchId}`, 'status')
   return {

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-settlement.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-settlement.ts
@@ -82,7 +82,7 @@ export async function closeAndSettleWorkerTerminalRelease(args: {
         processAction: 'closed_agent_terminal',
         archive: { source: archiveSource, status: archiveStatus },
         lastError: unknown.release_error ?? reason,
-        recovery: inspectRecovery(dispatchId)
+        recovery: workerTerminalReleaseRecovery(dispatchId)
       }
     }
   } catch (error) {
@@ -123,7 +123,7 @@ export async function closeAndSettleWorkerTerminalRelease(args: {
       processAction: 'none',
       archive: { source: archiveSource, status: archiveStatus },
       lastError: unknown.release_error ?? reason,
-      recovery: inspectRecovery(dispatchId)
+      recovery: workerTerminalReleaseRecovery(dispatchId)
     }
   }
   const released = db.settleWorkerTerminalRelease(resource.id)
@@ -181,6 +181,6 @@ function retainWorkerTerminalRelease(
 }
 
 /** Operator instructions carried on receipts that could not settle. */
-function inspectRecovery(dispatchId: string): string {
-  return `Inspect with: orca orchestration worker-show --dispatch ${dispatchId} --json — then repeat worker-release with the same --retry-request. Never substitute a broad terminal close.`
+export function workerTerminalReleaseRecovery(dispatchId: string): string {
+  return `Inspect with: orca orchestration worker-show --dispatch ${dispatchId} --json — if it proves the exact process exited after this request, run a fresh worker-release without --retry-request to re-observe it. Use --retry-request only when the prior response was lost; it replays the request and does not re-measure. Never substitute a broad terminal close.`
 }

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-settlement.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-settlement.ts
@@ -22,6 +22,11 @@ export type WorkerReleaseReceipt = {
   lastError?: string
 }
 
+/**
+ * Closes the exact leased terminal and turns the outcome into a receipt. Every unproven path lands
+ * on `retained` rather than a release, and a close that refuses on incarnation, or a lease that
+ * stopped being current across any await, is one of them.
+ */
 export async function closeAndSettleWorkerTerminalRelease(args: {
   runtime: OrcaRuntimeService
   db: OrchestrationDb
@@ -131,6 +136,7 @@ export async function closeAndSettleWorkerTerminalRelease(args: {
   }
 }
 
+/** Settles a release on a proven-exited process; null when the lease no longer proves ownership. */
 function settleExitedWorkerTerminalRelease(args: {
   runtime: OrcaRuntimeService
   db: OrchestrationDb
@@ -153,6 +159,7 @@ function settleExitedWorkerTerminalRelease(args: {
   }
 }
 
+/** Null rather than a pair of nulls, so a receipt distinguishes "no archive" from an empty one. */
 export function summarizeWorkerTerminalArchive(resource: WorkerTerminalResourceRow) {
   if (!resource.archive_source && !resource.archive_status) {
     return null
@@ -160,6 +167,7 @@ export function summarizeWorkerTerminalArchive(resource: WorkerTerminalResourceR
   return { source: resource.archive_source, status: resource.archive_status }
 }
 
+/** The one landing for unproven identity: keep the resource retained, claim no process action. */
 function retainWorkerTerminalRelease(
   db: OrchestrationDb,
   dispatchId: string,
@@ -175,6 +183,7 @@ function retainWorkerTerminalRelease(
   }
 }
 
+/** Operator instructions carried on receipts that could not settle. */
 function inspectRecovery(dispatchId: string): string {
   return `Inspect with: orca orchestration worker-show --dispatch ${dispatchId} --json — then repeat worker-release with the same --retry-request. Never substitute a broad terminal close.`
 }

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-settlement.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-settlement.ts
@@ -6,7 +6,10 @@ import type {
   WorkerTerminalRetainedReason
 } from '../../orchestration/worker-terminal-ownership'
 import type { OrcaRuntimeService } from '../../orca-runtime'
-import { recheckProcessLiveness } from './orchestration-worker-observation'
+import {
+  recheckProcessLiveness,
+  type WorkerTerminalObservationStatus
+} from './orchestration-worker-observation'
 import { workerTerminalLeaseIsCurrent } from './orchestration-worker-terminal-lease'
 
 export type WorkerReleaseReceipt = {
@@ -24,7 +27,7 @@ export async function closeAndSettleWorkerTerminalRelease(args: {
   db: OrchestrationDb
   dispatchId: string
   resource: WorkerTerminalResourceRow
-  observationStatus: string
+  observationStatus: WorkerTerminalObservationStatus
   archiveSource: 'transcript' | 'terminal' | null
   archiveStatus: WorkerTerminalArchiveStatus | null
 }): Promise<WorkerReleaseReceipt> {
@@ -34,8 +37,26 @@ export async function closeAndSettleWorkerTerminalRelease(args: {
   // clean up a tab that the user already removed. Freeze the exact process verdict first.
   const exactProcessWasAlreadyExited =
     observationStatus === 'exited' && (await recheckProcessLiveness(runtime, resource)) === 'exited'
+  // The liveness query above yields. Re-prove the lease in the same synchronous turn that enters
+  // closeTerminal so a replacement incarnation cannot be closed with the stale worker's handle.
+  if (
+    !workerTerminalLeaseIsCurrent(runtime, db, dispatchId, resource, observationStatus === 'exited')
+  ) {
+    return retainWorkerTerminalRelease(db, dispatchId, resource)
+  }
   try {
-    const close = await runtime.closeTerminal(resource.terminal_handle)
+    const close = await runtime.closeTerminal(
+      resource.terminal_handle,
+      resource.process_incarnation
+        ? { expectedProcessIncarnation: resource.process_incarnation }
+        : {}
+    )
+    if (
+      close.closeRefusedReason === 'incarnation_replaced' ||
+      !workerTerminalLeaseIsCurrent(runtime, db, dispatchId, resource, true)
+    ) {
+      return retainWorkerTerminalRelease(db, dispatchId, resource)
+    }
     if (!close.ptyKilled) {
       const settled = exactProcessWasAlreadyExited
         ? settleExitedWorkerTerminalRelease({
@@ -105,7 +126,7 @@ export async function closeAndSettleWorkerTerminalRelease(args: {
     state: 'released',
     processAction:
       observationStatus === 'exited' ? 'closed_exited_terminal' : 'closed_agent_terminal',
-    archive: summarizeArchive(released)
+    archive: summarizeWorkerTerminalArchive(released)
   }
 }
 
@@ -123,14 +144,34 @@ function settleExitedWorkerTerminalRelease(args: {
   }
   const released = db.settleWorkerTerminalRelease(resource.id)
   runtime.notifyMessageArrived(`dispatch:${dispatchId}`, 'status')
-  return { dispatchId, state: 'released', processAction, archive: summarizeArchive(released) }
+  return {
+    dispatchId,
+    state: 'released',
+    processAction,
+    archive: summarizeWorkerTerminalArchive(released)
+  }
 }
 
-function summarizeArchive(resource: WorkerTerminalResourceRow) {
+export function summarizeWorkerTerminalArchive(resource: WorkerTerminalResourceRow) {
   if (!resource.archive_source && !resource.archive_status) {
     return null
   }
   return { source: resource.archive_source, status: resource.archive_status }
+}
+
+function retainWorkerTerminalRelease(
+  db: OrchestrationDb,
+  dispatchId: string,
+  resource: WorkerTerminalResourceRow
+): WorkerReleaseReceipt {
+  const retained = db.revertWorkerTerminalReleaseToRetained(resource.id, 'identity_unproven')
+  return {
+    dispatchId,
+    state: 'retained',
+    reason: 'identity_unproven',
+    processAction: 'none',
+    archive: summarizeWorkerTerminalArchive(retained)
+  }
 }
 
 function inspectRecovery(dispatchId: string): string {

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-settlement.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-settlement.ts
@@ -1,0 +1,138 @@
+import { describeUnconfirmedAgentStop } from '../../../../shared/pty-liveness-verdict'
+import type { OrchestrationDb } from '../../orchestration/db'
+import type {
+  WorkerTerminalArchiveStatus,
+  WorkerTerminalResourceRow,
+  WorkerTerminalRetainedReason
+} from '../../orchestration/worker-terminal-ownership'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { recheckProcessLiveness } from './orchestration-worker-observation'
+import { workerTerminalLeaseIsCurrent } from './orchestration-worker-terminal-lease'
+
+export type WorkerReleaseReceipt = {
+  dispatchId: string
+  state: 'released' | 'already_released' | 'retained' | 'release_pending' | 'release_unknown'
+  reason?: WorkerTerminalRetainedReason
+  processAction: 'closed_agent_terminal' | 'closed_exited_terminal' | 'none'
+  archive: { source: string | null; status: string | null } | null
+  recovery?: string
+  lastError?: string
+}
+
+export async function closeAndSettleWorkerTerminalRelease(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  dispatchId: string
+  resource: WorkerTerminalResourceRow
+  observationStatus: string
+  archiveSource: 'transcript' | 'terminal' | null
+  archiveStatus: WorkerTerminalArchiveStatus | null
+}): Promise<WorkerReleaseReceipt> {
+  const { runtime, db, dispatchId, resource, observationStatus, archiveSource, archiveStatus } =
+    args
+  // closeTerminal may turn a retained, already-dead PTY into stop_unverified while trying to
+  // clean up a tab that the user already removed. Freeze the exact process verdict first.
+  const exactProcessWasAlreadyExited =
+    observationStatus === 'exited' && (await recheckProcessLiveness(runtime, resource)) === 'exited'
+  try {
+    const close = await runtime.closeTerminal(resource.terminal_handle)
+    if (!close.ptyKilled) {
+      const settled = exactProcessWasAlreadyExited
+        ? settleExitedWorkerTerminalRelease({
+            runtime,
+            db,
+            dispatchId,
+            resource,
+            processAction: 'closed_exited_terminal'
+          })
+        : null
+      if (settled) {
+        return settled
+      }
+      const reason = describeUnconfirmedAgentStop(close)
+      const unknown = db.markWorkerTerminalReleaseUnknown(resource.id, reason)
+      return {
+        dispatchId,
+        state: 'release_unknown',
+        processAction: 'closed_agent_terminal',
+        archive: { source: archiveSource, status: archiveStatus },
+        lastError: unknown.release_error ?? reason,
+        recovery: inspectRecovery(dispatchId)
+      }
+    }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    const settled =
+      exactProcessWasAlreadyExited &&
+      reason === 'tab_not_found' &&
+      (await recheckProcessLiveness(runtime, resource)) === 'exited'
+        ? settleExitedWorkerTerminalRelease({
+            runtime,
+            db,
+            dispatchId,
+            resource,
+            processAction: 'none'
+          })
+        : null
+    if (settled) {
+      return settled
+    }
+    if (/disposed|not connected|unavailable/i.test(reason)) {
+      return {
+        dispatchId,
+        state: 'release_pending',
+        processAction: 'none',
+        archive: { source: archiveSource, status: archiveStatus },
+        lastError: reason,
+        recovery:
+          'The owning endpoint is temporarily unavailable; recovery will retry this release after reconnect without another coordinator decision.'
+      }
+    }
+    const unknown = db.markWorkerTerminalReleaseUnknown(resource.id, reason)
+    return {
+      dispatchId,
+      state: 'release_unknown',
+      processAction: 'none',
+      archive: { source: archiveSource, status: archiveStatus },
+      lastError: unknown.release_error ?? reason,
+      recovery: inspectRecovery(dispatchId)
+    }
+  }
+  const released = db.settleWorkerTerminalRelease(resource.id)
+  runtime.notifyMessageArrived(`dispatch:${dispatchId}`, 'status')
+  return {
+    dispatchId,
+    state: 'released',
+    processAction:
+      observationStatus === 'exited' ? 'closed_exited_terminal' : 'closed_agent_terminal',
+    archive: summarizeArchive(released)
+  }
+}
+
+function settleExitedWorkerTerminalRelease(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  dispatchId: string
+  resource: WorkerTerminalResourceRow
+  processAction: 'closed_exited_terminal' | 'none'
+}): WorkerReleaseReceipt | null {
+  const { runtime, db, dispatchId, resource, processAction } = args
+  // Re-prove the lease after close so a replacement process cannot inherit the old death proof.
+  if (!workerTerminalLeaseIsCurrent(runtime, db, dispatchId, resource, true)) {
+    return null
+  }
+  const released = db.settleWorkerTerminalRelease(resource.id)
+  runtime.notifyMessageArrived(`dispatch:${dispatchId}`, 'status')
+  return { dispatchId, state: 'released', processAction, archive: summarizeArchive(released) }
+}
+
+function summarizeArchive(resource: WorkerTerminalResourceRow) {
+  if (!resource.archive_source && !resource.archive_status) {
+    return null
+  }
+  return { source: resource.archive_source, status: resource.archive_status }
+}
+
+function inspectRecovery(dispatchId: string): string {
+  return `Inspect with: orca orchestration worker-show --dispatch ${dispatchId} --json — then repeat worker-release with the same --retry-request. Never substitute a broad terminal close.`
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
@@ -25,8 +25,10 @@ describe('orchestration worker release', () => {
 
   const coordinatorPaneKey = 'tab_coord:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
   const workerPaneKey = 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+  const closeOptions = { expectedProcessIncarnation: 'runtime_test:term_worker:1' }
 
   function setup(): void {
+    let closeAttempted = false
     db = new OrchestrationDb(':memory:')
     dbOpen = true
     runtime = new OrcaRuntimeService()
@@ -48,7 +50,7 @@ describe('orchestration worker release', () => {
       handle === 'term_worker' || handle === 'term_reminted' ? 'runtime_test:term_worker:1' : null
     )
     vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
-      handle === 'term_worker' || handle === 'term_reminted'
+      !closeAttempted && (handle === 'term_worker' || handle === 'term_reminted')
         ? ({
             terminalHandle: handle,
             paneKey: workerPaneKey,
@@ -91,11 +93,10 @@ describe('orchestration worker release', () => {
       truncated: false,
       nextCursor: '2'
     })
-    vi.spyOn(runtime, 'closeTerminal').mockResolvedValue({
-      handle: 'term_worker',
-      tabId: 'tab-worker',
-      ptyKilled: true
-    } as never)
+    vi.spyOn(runtime, 'closeTerminal').mockImplementation(async (handle) => {
+      closeAttempted = true
+      return { handle, tabId: 'tab-worker', ptyKilled: true }
+    })
     vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
     activeRunId = db.createRun({
       objective: 'Release test Run',
@@ -188,8 +189,7 @@ describe('orchestration worker release', () => {
       processAction: 'closed_agent_terminal',
       archive: { source: 'terminal', status: 'captured' }
     })
-    expect(runtime.closeTerminal).toHaveBeenCalledTimes(1)
-    expect(runtime.closeTerminal).toHaveBeenCalledWith('term_worker')
+    expect(runtime.closeTerminal).toHaveBeenCalledWith('term_worker', closeOptions)
     const resource = db.getWorkerTerminalResourceByOwner(dispatchId)
     expect(resource?.release_state).toBe('released')
     expect(resource?.ownership_state).toBe('released')
@@ -725,8 +725,7 @@ describe('orchestration worker release', () => {
       dispatch: second.dispatchId
     })) as { state: string }
     expect(newRelease.state).toBe('released')
-    expect(runtime.closeTerminal).toHaveBeenCalledTimes(1)
-    expect(runtime.closeTerminal).toHaveBeenCalledWith('term_reminted')
+    expect(runtime.closeTerminal).toHaveBeenCalledWith('term_reminted', closeOptions)
   })
 
   it('reconciles dead transferred ownership after the current owner settles', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
@@ -489,7 +489,7 @@ describe('orchestration worker release', () => {
       recovery?: string
     }
     expect(receipt.state).toBe('release_unknown')
-    expect(receipt.recovery).toContain('worker-show')
+    expect(receipt.recovery).toContain('fresh worker-release without --retry-request')
     expect(runtime.closeTerminal).not.toHaveBeenCalled()
 
     vi.mocked(runtime.showTerminal).mockImplementation(

--- a/src/main/runtime/rpc/methods/orchestration-worker-terminal-lease.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-terminal-lease.ts
@@ -1,0 +1,26 @@
+import type { OrchestrationDb } from '../../orchestration/db'
+import type { WorkerTerminalResourceRow } from '../../orchestration/worker-terminal-ownership'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+
+export function workerTerminalLeaseIsCurrent(
+  runtime: OrcaRuntimeService,
+  db: OrchestrationDb,
+  dispatchId: string,
+  resource: WorkerTerminalResourceRow,
+  terminalWasObservedExited: boolean
+): boolean {
+  const worker = db.getWorkerDispatch(dispatchId)
+  const authority = runtime.getOrchestrationDispatchAuthority(resource.terminal_handle)
+  return Boolean(
+    worker?.agent_terminal_handle === resource.terminal_handle &&
+    (authority
+      ? resource.host_scope === JSON.stringify(authority.hostScope)
+      : terminalWasObservedExited) &&
+    db.isDispatchProcessCurrent({
+      dispatchId,
+      paneKey: runtime.getTerminalPaneKey(resource.terminal_handle),
+      processIncarnation: runtime.getTerminalProcessIncarnation(resource.terminal_handle)
+    }) &&
+    !db.workerTerminalResourceHasIdentityConflict(resource.id)
+  )
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-terminal-lease.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-terminal-lease.ts
@@ -2,6 +2,12 @@ import type { OrchestrationDb } from '../../orchestration/db'
 import type { WorkerTerminalResourceRow } from '../../orchestration/worker-terminal-ownership'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 
+/**
+ * Whether this dispatch still owns the exact handle, host scope, process incarnation and resource
+ * row it leased. Callers re-prove it after every await, because a yield is enough for the handle to
+ * be re-bound to a replacement. `terminalWasObservedExited` waives only the host-scope check, which
+ * no longer resolves once the process is gone.
+ */
 export function workerTerminalLeaseIsCurrent(
   runtime: OrcaRuntimeService,
   db: OrchestrationDb,

--- a/src/shared/runtime-terminal-contracts.ts
+++ b/src/shared/runtime-terminal-contracts.ts
@@ -296,8 +296,13 @@ export type RuntimeTerminalClose = {
   tabId: string
   closeMode?: 'tab'
   ptyKilled: boolean
+  closeRefusedReason?: 'incarnation_replaced'
   ptyStopVerdict?: 'live' | 'unverifiable'
   ptyStopReason?: string
+}
+
+export type RuntimeTerminalCloseOptions = {
+  expectedProcessIncarnation?: string
 }
 
 export type RuntimeTerminalWaitCondition = 'exit' | 'tui-idle'

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -145,6 +145,7 @@ export type {
   RuntimeTerminalAgentStatus,
   RuntimeTerminalAgentStatusState,
   RuntimeTerminalClose,
+  RuntimeTerminalCloseOptions,
   RuntimeTerminalCreate,
   RuntimeTerminalCreateRequestPayload,
   RuntimeTerminalFocus,


### PR DESCRIPTION
## ELI5

A worker release can race with terminal reuse. Orca may prove that one PTY process exited, wait while closing the tab, and then accidentally act on a replacement PTY that reused the same terminal identity. This change carries the expected process incarnation through worker settlement, runtime close, and the PTY controller so a replacement process is retained rather than stopped.

## What Changed

- Re-check the worker terminal lease after the liveness await and again after close settlement.
- Carry `expectedProcessIncarnation` into `closeTerminal` and refuse closure when the addressed PTY incarnation changed.
- Snapshot every tab PTY incarnation before close awaits, then re-check before `stopAndWait` and before fallback `kill`.
- Extend `PtyController.kill` / `stopAndWait` with an expected-incarnation fence, including the provider-startup await boundary.
- Synchronize restored PTY incarnations into the controller registry before runtime bookkeeping.
- Return `identity_unproven` and retain the worker when close authority changes instead of claiming release.
- Make CLI output truthful when a replacement PTY was intentionally not stopped.
- Preserve the earlier idempotent handling for proven-dead workers whose tab is already absent.

## Why

The earlier fix covered `tab_not_found` and `ptyKilled: false`, but review found a deeper time-of-check/time-of-use gap: terminal identity could change inside the close path itself. The safety boundary now follows the process incarnation through every destructive await boundary. Unknown or replaced identity fails closed.

This follows the retained-worker reconciliation in #13860 / #13927 and addresses the release-path reproduction in #15920. It intentionally does not change the separate `agent_prompt_stalled` startup-detection behavior reported there.

## Linked Issue

Addresses the release-path portion of #15920.

## Visual Proof

N/A — this changes main-process orchestration and CLI reporting; there is no renderer UI change.

## Testing

Verified on Windows 11 against current `main`:

- Six directly changed/affected test files: 1,295 assertions passed.
  - `orca-runtime.test.ts`: 1,214/1,214 passed after the final call-arity fix.
  - The other five changed regression files: 81/81 assertions passed; the only suite-level red was the known Windows temp cleanup `EPERM` after all assertions completed.
- Additional call-scope references found by a repository-wide search: 29 assertions passed, 15 skipped; again only the known temp cleanup `EPERM` remained.
- Focused 19-file regression group: 208/208 assertions passed.
- Node and CLI TypeScript checks passed.
- Plain, native-plugin, type-aware, and React Doctor oxlint checks passed.
- Changed-file `oxfmt --check` and `lint-staged` passed.
- Reliability manifest: 99 gates passed.
- Max-lines ratchet: 87 grandfathered suppressions, no new bypass.
- Runtime-electron ratchet: 0 entries, unchanged.
- `git diff --check` and pre-commit hooks passed.
- Independent visible Claude review returned `READY — Critical/Important 없음` after the controller and restore-path fences were added.

A repository-wide run on the final commit was completed and is not claimed green: 6,609 test files / 62,210 tests passed; 161 files / 351 tests failed; 71 files / 926 tests were skipped; 5 unhandled errors remained; and pnpm exited 1. The failures are dominated by Windows host prerequisites and cross-platform assumptions (`/bin/sh`, symlink permissions, path separators, native `node-pty`, temp cleanup `EPERM`). The two PR-related call-arity failures from the earlier run are gone. No PR-related assertion failed; the only PR-path suite failures were the known Windows `afterAll` temp cleanup `EPERM` after their assertions passed.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

Implemented with OpenAI Codex (GPT-5.6) assistance and independently reviewed in visible Orca panes with Claude. The final diff and verification receipts were rechecked before push.

## Review

- Security: destructive PTY actions are narrower because they now require the expected process incarnation.
- Cross-platform: no shell or path behavior was added; provider liveness and incarnation contracts are reused.
- SSH/remote: dropped, unregistered, or replaced provider inventory remains fail-closed.
- Performance: bounded identity checks occur only in terminal close/release paths.
- Backwards compatibility: only optional internal contract fields were added; refusal is surfaced without stopping the replacement PTY.
- Mobile: N/A; main-process worker-release bookkeeping only.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Focused lint, typecheck, tests, static gates, and live E2E pass locally; full CI awaits maintainer approval

