### PR TITLE
Fix fish codex preflight 'test: Missing argument' when codex is absent

### DIFF
--- a/src/main/pty/codex-shell-launch-preflight.test.ts
+++ b/src/main/pty/codex-shell-launch-preflight.test.ts
@@ -242,6 +242,81 @@ describe.skipIf(process.platform === 'win32')('Codex shell launch preflight', ()
 
     expect(output.trim()).toBe('custom-codex')
   })
+
+  it.skipIf(!fishAvailable)(
+    'emits no test error and installs no wrapper when codex is absent',
+    () => {
+      const root = mkdtempSync(join(tmpdir(), 'orca-codex-absent-fish-'))
+      roots.push(root)
+      const bin = join(root, 'bin')
+      mkdirSync(bin)
+      writeExecutable(join(bin, 'orca-test'), '#!/bin/sh\nexit 0\n')
+
+      const result = spawnSync(
+        'fish',
+        [
+          '--no-config',
+          '-c',
+          [
+            getFishCodexShellLaunchPreflight(),
+            'functions -q codex; and echo WRAPPER; or echo NO_WRAPPER'
+          ].join('\n')
+        ],
+        {
+          encoding: 'utf-8',
+          env: {
+            ...process.env,
+            PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+            ORCA_CODEX_LAUNCH_PREFLIGHT: join(bin, 'orca-test')
+          }
+        }
+      )
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(result.stderr).not.toContain('Missing argument')
+      expect(result.stdout.trim()).toBe('NO_WRAPPER')
+    }
+  )
+
+  it.skipIf(!fishAvailable)('skips the wrapper when codex is a fish alias', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-codex-alias-fish-'))
+    roots.push(root)
+    const bin = join(root, 'bin')
+    mkdirSync(bin)
+    writeExecutable(join(bin, 'orca-test'), '#!/bin/sh\nexit 0\n')
+
+    const result = spawnSync(
+      'fish',
+      [
+        '--no-config',
+        '-c',
+        [`alias codex='echo aliased'`, getFishCodexShellLaunchPreflight(), 'functions codex'].join(
+          '\n'
+        )
+      ],
+      {
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+          ORCA_CODEX_LAUNCH_PREFLIGHT: join(bin, 'orca-test')
+        }
+      }
+    )
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stderr).not.toContain('Missing argument')
+    // the alias body survives untouched — no wrapper installed
+    expect(result.stdout).not.toContain('prepare-codex')
+    expect(result.stdout).toContain('echo aliased')
+  })
+
+  it('captures type -t into a variable before the fish wrapper guard', () => {
+    expect(getFishCodexShellLaunchPreflight()).toContain(
+      'set -l __orca_codex_type (type -t codex 2>/dev/null)\n' +
+        'if test -x "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test "$__orca_codex_type" = file'
+    )
+  })
 })
 
 describe('PowerShell Codex shell launch preflight', () => {

--- a/src/main/pty/codex-shell-launch-preflight.test.ts
+++ b/src/main/pty/codex-shell-launch-preflight.test.ts
@@ -8,7 +8,7 @@ import {
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { delimiter, isAbsolute, join } from 'node:path'
+import { delimiter, dirname, isAbsolute, join } from 'node:path'
 import { execFileSync, spawnSync } from 'node:child_process'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
@@ -24,6 +24,20 @@ const bashAvailable = existsSync('/bin/bash')
 const fishAvailable = spawnSync('fish', ['--version']).status === 0
 const pwshAvailable =
   spawnSync('pwsh', ['-NoLogo', '-NoProfile', '-Command', 'exit 0']).status === 0
+
+/** Absolute path of an executable on the host PATH, or null. */
+function resolveOnPath(name: string): string | null {
+  for (const dir of (process.env.PATH ?? '').split(delimiter)) {
+    if (!dir) {
+      continue
+    }
+    const candidate = join(dir, name)
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
 
 function writeExecutable(path: string, content: string): void {
   writeFileSync(path, content)
@@ -266,7 +280,7 @@ describe.skipIf(process.platform === 'win32')('Codex shell launch preflight', ()
           encoding: 'utf-8',
           env: {
             ...process.env,
-            PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+            PATH: `${bin}${delimiter}${dirname(resolveOnPath('fish') ?? '')}`,
             ORCA_CODEX_LAUNCH_PREFLIGHT: join(bin, 'orca-test')
           }
         }

--- a/src/main/pty/codex-shell-launch-preflight.ts
+++ b/src/main/pty/codex-shell-launch-preflight.ts
@@ -85,7 +85,8 @@ unset __orca_codex_binary
 }
 
 export function getFishCodexShellLaunchPreflight(): string {
-  return `if test -x "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test (type -t codex 2>/dev/null) = file
+  return `set -l __orca_codex_type (type -t codex 2>/dev/null)
+if test -x "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test "$__orca_codex_type" = file
   function codex
     command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
     command codex $argv


### PR DESCRIPTION
## ELI5

Fish-shell users without `codex` installed saw a `test: Missing argument at index 3` error printed on stderr at every Orca-launched pane/app start. The preflight's guard evaluated an empty command substitution, so fish's `test` received too few arguments. The fix captures the `type -t` result in a variable before the guard, so the test always has an argument — and the wrapper is only installed when `codex` really is an executable file.

## What Changed

- `getFishCodexShellLaunchPreflight()`: capture `(type -t codex 2>/dev/null)` into a local variable before the guard, and quote it in the `test`:

  ```fish
  set -l __orca_codex_type (type -t codex 2>/dev/null)
  if test -x "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test "$__orca_codex_type" = file
  ```

  Deliberately *not* `test "(type -t codex 2>/dev/null)" = file` — fish never expands command substitutions inside double quotes, so the wrapper would silently never activate.

- Tests: added absent-codex regression, alias-skip, and emitted-template assertions; the absent-codex test now isolates the child fish `PATH` so a host with `codex` installed can't produce a false failure.

## Why

The unquoted substitution expands to zero arguments when `codex` is absent (or shadowed), so `test` receives `test = file` and fish aborts with `test: Missing argument at index 3`. Non-fatal but noisy — it hit every fish-shell user without `codex` installed. Capturing into a variable (the same pattern the bash variant already uses) keeps the `= file` semantics: an alias/function resolves to `function`, skipping the wrapper and preventing recursion into a typed alias.

## Linked Issue

Fixes #16893

## Visual Proof

N/A — no visual or interaction change; the fix removes stderr noise from a startup script.

## Testing

Verified on macOS (fish 4.3.3) via `fish -l -C` — the same invocation shape `getShellLaunchConfig` uses:

1. `codex` absent from PATH → no `test: Missing argument` error, no `codex` wrapper defined.
2. `codex` present as an executable file → wrapper defined; function body contains `prepare-codex`.
3. `codex` defined as a fish alias → no wrapper; alias body untouched.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`src/main/pty/codex-shell-launch-preflight.test.ts`: 28 passed, 2 skipped (pwsh absent on host). `pnpm tc:node` clean; oxlint clean on changed files.

## AI Disclosure

Assisted by an AI coding agent (opencode-go/deepseek-v4-flash) working from issue #16893, with the fix verified by the agent and the human author.

## Review

- CodeRabbit: addressed the one actionable comment — the absent-command test now restricts fish's command search path to the temp bin plus the directory of the resolved fish binary, so environments with `codex` installed cannot produce a false failure (commit `da8b60ca`).
- Docstring-coverage warning from CodeRabbit not applied: repo convention is concise brief comments (see AGENTS.md); sibling preflight getters carry no docstrings.

## Agent skill upstream boundary

- [x] Not applicable — no agent-skill installer source touched.

## Notes

- Security: no new surface; the preflight path check (`-x`) is unchanged.
- Cross-platform: fish-only change; macOS/Linux fish panes. WSL already excluded from the preflight; bash/zsh and PowerShell variants untouched.
- Remote SSH: the preflight ships via `getShellLaunchConfig` on the execution host, unchanged plumbing.
- Performance: one extra `type -t` capture per pane start; negligible.
- Backwards compatibility: wrapper behavior for file/alias/function resolution is identical.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)