### PR TITLE
fix(native-chat): hold the question card and pane state until an answer is confirmed

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
@@ -111,6 +111,17 @@ function askResultMessage(): NativeChatMessage {
   } as unknown as NativeChatMessage
 }
 
+/** The transcript tool-call for the live `INITIAL_PROMPT` question — same
+ *  canonical content, as a real session emits for one AskUserQuestion. */
+function initialPromptCallMessage(): NativeChatMessage {
+  return {
+    id: 'call-initial',
+    role: 'assistant',
+    createdAt: 1,
+    blocks: [{ type: 'tool-call', name: 'AskUserQuestion', input: JSON.parse(INITIAL_PROMPT) }]
+  } as unknown as NativeChatMessage
+}
+
 function chooseSpacesAndSubmit(): void {
   fireEvent.click(screen.getByRole('button', { name: /Spaces/ }))
   fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
@@ -363,6 +374,44 @@ describe('NativeChatInteractiveCard unconfirmed answers', () => {
 
     expect(screen.queryByText('Tabs or spaces?')).not.toBeInTheDocument()
     expect(mocks.confirmAnswered).not.toHaveBeenCalled()
+  })
+
+  // A question killed inside the TUI (selector ESC, or the card's X sending a
+  // real ESC byte) emits no hook, so live status keeps asserting it. Before the
+  // liveness check the deadline restored the card over a dead question, and
+  // answering it typed option digits into the bare composer (#16865).
+  it('does not resurrect a question the transcript shows already resolved', () => {
+    let settleDelivery: ((delivered: boolean) => void) | undefined
+    mocks.sendAnswer.mockImplementation((_prompt, _selections, onDeliverySettled) => {
+      settleDelivery = onDeliverySettled
+      return sendResult(500, true)
+    })
+    const messages = [initialPromptCallMessage()]
+    const rendered = render(cardElement(true, messages))
+    chooseSpacesAndSubmit()
+    act(() => settleDelivery?.(true))
+
+    // Live status still holds the dead question; only the transcript knows.
+    rendered.rerender(cardElement(true, [...messages, askResultMessage()]))
+    act(() => {
+      vi.advanceTimersByTime(nativeChatAnswerConfirmDeadlineMs(500))
+    })
+
+    expect(screen.queryByText('Tabs or spaces?')).not.toBeInTheDocument()
+  })
+
+  it('drops the remaining keystrokes when the ask dies mid-send', () => {
+    mocks.sendAnswer.mockReturnValue(sendResult(6_000, true))
+    const messages = [initialPromptCallMessage()]
+    const rendered = render(cardElement(true, messages))
+    chooseSpacesAndSubmit()
+    expect(mocks.cancelPending).not.toHaveBeenCalled()
+
+    // The selector dies between paced keystroke groups.
+    rendered.rerender(cardElement(true, [...messages, askResultMessage()]))
+
+    expect(mocks.cancelPending).toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: 'Sending…' })).not.toBeInTheDocument()
   })
 
   // The plain-selector flow commits on a digit and its hook event follows

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
@@ -6,6 +6,7 @@ import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import { applyCommandMarkerBoundaries } from './native-chat-command-marker'
+import { nativeChatAnswerConfirmDeadlineMs } from './native-chat-answer-confirmation'
 import type { NativeChatInteractiveSend } from './use-native-chat-interactive-send'
 
 const INITIAL_PROMPT = JSON.stringify({
@@ -38,7 +39,16 @@ const mocks = {
   sendAnswer: vi.fn<NativeChatInteractiveSend['sendAnswer']>(),
   sendRaw: vi.fn<NativeChatInteractiveSend['sendRaw']>(),
   cancelPending: vi.fn<NativeChatInteractiveSend['cancelPending']>(),
-  cancel: vi.fn<NativeChatInteractiveSend['cancel']>()
+  cancel: vi.fn<NativeChatInteractiveSend['cancel']>(),
+  /** Clears the pane's question wait; the card owes it a confirmation signal. */
+  confirmAnswered: vi.fn<() => void>()
+}
+
+function sendResult(
+  settleAfterMs: number,
+  waitsForVerifiedDelivery: boolean
+): ReturnType<NativeChatInteractiveSend['sendAnswer']> {
+  return { settleAfterMs, waitsForVerifiedDelivery, confirmAnswered: mocks.confirmAnswered }
 }
 
 function renderCard(canSend = true): ReturnType<typeof render> {
@@ -118,7 +128,7 @@ describe('NativeChatInteractiveCard answer lifecycle', () => {
   })
 
   it('keeps the card retryable when no PTY answer was sent', () => {
-    mocks.sendAnswer.mockReturnValue({ settleAfterMs: 0, waitsForVerifiedDelivery: false })
+    mocks.sendAnswer.mockReturnValue(sendResult(0, false))
     renderCard()
 
     chooseSpacesAndSubmit()
@@ -129,7 +139,7 @@ describe('NativeChatInteractiveCard answer lifecycle', () => {
   })
 
   it('cancels delayed PTY writes when the owning card unmounts', () => {
-    mocks.sendAnswer.mockReturnValue({ settleAfterMs: 5_000, waitsForVerifiedDelivery: false })
+    mocks.sendAnswer.mockReturnValue(sendResult(5_000, false))
     const rendered = renderCard()
 
     chooseSpacesAndSubmit()
@@ -140,7 +150,7 @@ describe('NativeChatInteractiveCard answer lifecycle', () => {
   })
 
   it('cancels delayed PTY writes when desktop send authority is lost', () => {
-    mocks.sendAnswer.mockReturnValue({ settleAfterMs: 5_000, waitsForVerifiedDelivery: false })
+    mocks.sendAnswer.mockReturnValue(sendResult(5_000, false))
     const rendered = renderCard()
 
     chooseSpacesAndSubmit()
@@ -150,7 +160,7 @@ describe('NativeChatInteractiveCard answer lifecycle', () => {
   })
 
   it('shows the paced send as busy and freezes the snapshotted answer', () => {
-    mocks.sendAnswer.mockReturnValue({ settleAfterMs: 5_000, waitsForVerifiedDelivery: false })
+    mocks.sendAnswer.mockReturnValue(sendResult(5_000, false))
     renderCard()
 
     chooseSpacesAndSubmit()
@@ -162,7 +172,7 @@ describe('NativeChatInteractiveCard answer lifecycle', () => {
   })
 
   it('cancels the old answer sequence when a replacement prompt arrives', () => {
-    mocks.sendAnswer.mockReturnValue({ settleAfterMs: 5_000, waitsForVerifiedDelivery: false })
+    mocks.sendAnswer.mockReturnValue(sendResult(5_000, false))
     const rendered = renderCard()
     chooseSpacesAndSubmit()
 
@@ -185,7 +195,7 @@ describe('NativeChatInteractiveCard answer lifecycle', () => {
     let settleDelivery: ((delivered: boolean) => void) | undefined
     mocks.sendAnswer.mockImplementation((_prompt, _selections, onDeliverySettled) => {
       settleDelivery = onDeliverySettled
-      return { settleAfterMs: 500, waitsForVerifiedDelivery: true }
+      return sendResult(500, true)
     })
     renderCard()
 
@@ -200,7 +210,7 @@ describe('NativeChatInteractiveCard answer lifecycle', () => {
     let settleDelivery: ((delivered: boolean) => void) | undefined
     mocks.sendAnswer.mockImplementation((_prompt, _selections, onDeliverySettled) => {
       settleDelivery = onDeliverySettled
-      return { settleAfterMs: 500, waitsForVerifiedDelivery: true }
+      return sendResult(500, true)
     })
     renderCard()
 
@@ -216,6 +226,164 @@ describe('NativeChatInteractiveCard answer lifecycle', () => {
 // `interactivePrompt` while the transcript still holds the unresolved call (#11761).
 // Which asks the transcript still counts as pending (orphaned calls, turn boundaries)
 // is the shared parser's contract — covered in `src/shared/native-chat-ask.test.ts`.
+// Delivering an answer proves only that the PTY took the bytes. A selector the
+// keystrokes do not fit (preview-style layouts, for months) leaves the question
+// live, and the pre-fix card dismissed into a false "working" animation with no
+// way back (#16865).
+describe('NativeChatInteractiveCard unconfirmed answers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    storeState.agentStatusByPaneKey['tab-1:leaf-1'].interactivePrompt = INITIAL_PROMPT
+    storeState.agentStatusByPaneKey['tab-1:leaf-1'].state = undefined
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    cleanup()
+  })
+
+  function answerWithVerifiedDelivery(): void {
+    let settleDelivery: ((delivered: boolean) => void) | undefined
+    mocks.sendAnswer.mockImplementation((_prompt, _selections, onDeliverySettled) => {
+      settleDelivery = onDeliverySettled
+      return sendResult(500, true)
+    })
+    renderCard()
+    chooseSpacesAndSubmit()
+    act(() => settleDelivery?.(true))
+  }
+
+  it('brings the question back when no confirmation arrives before the deadline', () => {
+    answerWithVerifiedDelivery()
+    expect(screen.queryByText('Tabs or spaces?')).not.toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(nativeChatAnswerConfirmDeadlineMs(500))
+    })
+
+    expect(screen.getByText('Tabs or spaces?')).toBeInTheDocument()
+    // Answerable again, not a frozen "Sending…" shell.
+    expect(screen.getByRole('button', { name: /Spaces/ })).toBeEnabled()
+  })
+
+  it('leaves the pane waiting while an answer is unconfirmed', () => {
+    answerWithVerifiedDelivery()
+
+    act(() => {
+      vi.advanceTimersByTime(nativeChatAnswerConfirmDeadlineMs(500))
+    })
+
+    // The question is still live, so the wait must survive: clearing it is what
+    // painted a progress animation over a blocked session.
+    expect(mocks.confirmAnswered).not.toHaveBeenCalled()
+  })
+
+  it('holds the card dismissed right up to the deadline', () => {
+    answerWithVerifiedDelivery()
+
+    act(() => {
+      vi.advanceTimersByTime(nativeChatAnswerConfirmDeadlineMs(500) - 1)
+    })
+
+    expect(screen.queryByText('Tabs or spaces?')).not.toBeInTheDocument()
+  })
+
+  it('scales the deadline with the keystroke pacing of a longer answer', () => {
+    let settleDelivery: ((delivered: boolean) => void) | undefined
+    mocks.sendAnswer.mockImplementation((_prompt, _selections, onDeliverySettled) => {
+      settleDelivery = onDeliverySettled
+      return sendResult(6_000, true)
+    })
+    renderCard()
+    chooseSpacesAndSubmit()
+    act(() => settleDelivery?.(true))
+
+    // A short answer's deadline would already have fired here; a paced one has
+    // not finished writing its groups yet, so the card must stay down.
+    act(() => {
+      vi.advanceTimersByTime(nativeChatAnswerConfirmDeadlineMs(500))
+    })
+    expect(screen.queryByText('Tabs or spaces?')).not.toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(nativeChatAnswerConfirmDeadlineMs(6_000))
+    })
+    expect(screen.getByText('Tabs or spaces?')).toBeInTheDocument()
+  })
+
+  it('confirms the answer and keeps the card down once the prompt clears', () => {
+    let settleDelivery: ((delivered: boolean) => void) | undefined
+    mocks.sendAnswer.mockImplementation((_prompt, _selections, onDeliverySettled) => {
+      settleDelivery = onDeliverySettled
+      return sendResult(500, true)
+    })
+    const rendered = renderCard()
+    chooseSpacesAndSubmit()
+    act(() => settleDelivery?.(true))
+
+    // A fresh hook status drops the prompt: the agent moved on, so the answer landed.
+    storeState.agentStatusByPaneKey['tab-1:leaf-1'].interactivePrompt = undefined
+    rendered.rerender(cardElement())
+
+    expect(mocks.confirmAnswered).toHaveBeenCalledOnce()
+    act(() => {
+      vi.advanceTimersByTime(nativeChatAnswerConfirmDeadlineMs(500))
+    })
+    expect(screen.queryByText('Tabs or spaces?')).not.toBeInTheDocument()
+  })
+
+  it('treats a replacement question as confirmation of the answered one', () => {
+    let settleDelivery: ((delivered: boolean) => void) | undefined
+    mocks.sendAnswer.mockImplementation((_prompt, _selections, onDeliverySettled) => {
+      settleDelivery = onDeliverySettled
+      return sendResult(500, true)
+    })
+    const rendered = renderCard()
+    chooseSpacesAndSubmit()
+    act(() => settleDelivery?.(true))
+
+    storeState.agentStatusByPaneKey['tab-1:leaf-1'].interactivePrompt = JSON.stringify({
+      questions: [{ question: 'Choose a shell?', multiSelect: false, options: [{ label: 'zsh' }] }]
+    })
+    rendered.rerender(cardElement())
+
+    expect(mocks.confirmAnswered).toHaveBeenCalledOnce()
+    expect(screen.getByText('Choose a shell?')).toBeInTheDocument()
+  })
+
+  it('does not resurrect a question the user cancelled', () => {
+    mocks.sendAnswer.mockReturnValue(sendResult(500, true))
+    renderCard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    act(() => {
+      vi.advanceTimersByTime(nativeChatAnswerConfirmDeadlineMs(500))
+    })
+
+    expect(screen.queryByText('Tabs or spaces?')).not.toBeInTheDocument()
+    expect(mocks.confirmAnswered).not.toHaveBeenCalled()
+  })
+
+  // The plain-selector flow commits on a digit and its hook event follows
+  // shortly; the optimistic dismissal must survive unchanged.
+  it('keeps an unverified paced answer dismissed once its hook status lands', () => {
+    mocks.sendAnswer.mockReturnValue(sendResult(500, false))
+    const rendered = renderCard()
+    chooseSpacesAndSubmit()
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(screen.queryByText('Tabs or spaces?')).not.toBeInTheDocument()
+
+    storeState.agentStatusByPaneKey['tab-1:leaf-1'].interactivePrompt = undefined
+    rendered.rerender(cardElement())
+
+    expect(mocks.confirmAnswered).toHaveBeenCalledOnce()
+  })
+})
+
 describe('NativeChatInteractiveCard transcript fallback', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -259,14 +427,14 @@ describe('NativeChatInteractiveCard transcript fallback', () => {
   })
 
   it('stays dismissed after answering while the transcript call is still pending', () => {
-    mocks.sendAnswer.mockReturnValue({ settleAfterMs: 500, waitsForVerifiedDelivery: true })
+    mocks.sendAnswer.mockReturnValue(sendResult(500, true))
     const messages = [askCallMessage('Tabs or spaces?')]
     const rendered = render(cardElement(true, messages))
 
     let settleDelivery: ((delivered: boolean) => void) | undefined
     mocks.sendAnswer.mockImplementation((_prompt, _selections, onDeliverySettled) => {
       settleDelivery = onDeliverySettled
-      return { settleAfterMs: 500, waitsForVerifiedDelivery: true }
+      return sendResult(500, true)
     })
     chooseSpacesAndSubmit()
     act(() => settleDelivery?.(true))

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
@@ -137,8 +137,14 @@ export function NativeChatInteractiveCard({
     if (!present) {
       setDismissedKey(null)
       clearDismissTimer()
+      // An answer is paced over seconds, so the ask can be retired mid-send
+      // (#16865). Drop the remaining keystroke groups: with the selector gone
+      // they land in the composer as literal text, and a trailing Enter submits
+      // it. Also retires the deadline — a resolved ask owes no confirmation.
+      cancelPending()
+      clearConfirmationWait()
     }
-  }, [present, clearDismissTimer])
+  }, [present, clearDismissTimer, cancelPending, clearConfirmationWait])
 
   // Tell the view when a question card is up so it can hide the composer (this
   // card supplies its own input). Reset on unmount so the composer comes back.

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
@@ -4,6 +4,7 @@ import { resolveNativeChatAsk } from '../../../../shared/native-chat-ask'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import { parseInteractivePrompt } from './native-chat-interactive-prompt'
 import { nativeChatCardDismissKey } from './native-chat-dismiss-key'
+import { nativeChatAnswerConfirmDeadlineMs } from './native-chat-answer-confirmation'
 import { NativeChatQuestionCard } from './NativeChatQuestionCard'
 import { NativeChatApprovalCard } from './NativeChatApprovalCard'
 import type { NativeChatInteractiveSend } from './use-native-chat-interactive-send'
@@ -21,6 +22,12 @@ import type { NativeChatInteractiveSend } from './use-native-chat-interactive-se
  * answered prompt by content key and hide the card until a genuinely different
  * prompt arrives. The dismissal resets once the prompt clears, so a later
  * (even identical) prompt shows again instead of staying hidden.
+ *
+ * That dismissal is provisional until the ask actually resolves. Delivered
+ * keystrokes can leave a selector untouched, which strands the session on a
+ * live question behind a hidden card (#16865). While an answer is unconfirmed
+ * the pane keeps its waiting state, and a deadline restores the card so the
+ * question is visible and answerable again rather than showing false progress.
  *
  * The transcript is the second source (mobile parity again): a question that the
  * live status never delivered — headless host, relay gap, replay, reconnect —
@@ -79,6 +86,20 @@ export function NativeChatInteractiveCard({
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const submittingRef = useRef(false)
   const [submitting, setSubmitting] = useState(false)
+  // An answered-but-unconfirmed card: the key it dismissed under, the deadline
+  // timer that brings it back, and the pane-wait clear to run once the ask
+  // actually resolves.
+  const awaitingConfirmationRef = useRef<{
+    cardKey: string | null
+    timer: ReturnType<typeof setTimeout>
+    confirmAnswered: () => void
+  } | null>(null)
+  const clearConfirmationWait = useCallback((): void => {
+    if (awaitingConfirmationRef.current) {
+      clearTimeout(awaitingConfirmationRef.current.timer)
+      awaitingConfirmationRef.current = null
+    }
+  }, [])
   const clearDismissTimer = useCallback((): void => {
     if (dismissTimerRef.current) {
       clearTimeout(dismissTimerRef.current)
@@ -96,8 +117,21 @@ export function NativeChatInteractiveCard({
     },
     [canSend, cardKey, cancelPending, clearDismissTimer]
   )
+  // The deadline timer outlives a card swap on purpose (a replacement prompt
+  // confirms the old answer), so only a full unmount discards it.
+  useEffect(() => clearConfirmationWait, [clearConfirmationWait])
 
   // Forget the dismissal once the prompt clears so a fresh prompt can show.
+  // A cleared (or replaced) ask is also the confirmation an answer was accepted:
+  // the tool call closed in the transcript, or a fresh hook status dropped the
+  // prompt. Either way the pane's question wait can now be cleared honestly.
+  useEffect(() => {
+    const awaiting = awaitingConfirmationRef.current
+    if (awaiting && awaiting.cardKey !== cardKey) {
+      awaiting.confirmAnswered()
+      clearConfirmationWait()
+    }
+  }, [cardKey, clearConfirmationWait])
   const present = card != null
   useEffect(() => {
     if (!present) {
@@ -129,23 +163,41 @@ export function NativeChatInteractiveCard({
             return
           }
           submittingRef.current = true
-          const dismissAnsweredCard = (): void => {
+          const dismissAnsweredCard = (
+            confirmAnswered: () => void,
+            settleAfterMs: number
+          ): void => {
             setDismissedKey(cardKey)
             submittingRef.current = false
             setSubmitting(false)
             dismissTimerRef.current = null
+            // Delivery is not acceptance: hold the pane's wait and bring the
+            // card back if the ask never resolves (#16865).
+            clearConfirmationWait()
+            awaitingConfirmationRef.current = {
+              cardKey,
+              confirmAnswered,
+              timer: setTimeout(() => {
+                awaitingConfirmationRef.current = null
+                setDismissedKey(null)
+              }, nativeChatAnswerConfirmDeadlineMs(settleAfterMs))
+            }
           }
           const keepRejectedAnswerVisible = (): void => {
             submittingRef.current = false
             setSubmitting(false)
           }
-          const result = sendAnswer(card.prompt, selections, (delivered) => {
-            if (delivered) {
-              dismissAnsweredCard()
-            } else {
-              keepRejectedAnswerVisible()
+          const result: ReturnType<typeof sendAnswer> = sendAnswer(
+            card.prompt,
+            selections,
+            (delivered) => {
+              if (delivered) {
+                dismissAnsweredCard(result.confirmAnswered, result.settleAfterMs)
+              } else {
+                keepRejectedAnswerVisible()
+              }
             }
-          })
+          )
           if (result.settleAfterMs <= 0) {
             // Keep the actionable card visible when its PTY disappeared between
             // render and submit; the next live target update can make it retryable.
@@ -163,11 +215,14 @@ export function NativeChatInteractiveCard({
           // (which hides it and restores the composer).
           dismissTimerRef.current = setTimeout(() => {
             cancelPending()
-            dismissAnsweredCard()
+            dismissAnsweredCard(result.confirmAnswered, result.settleAfterMs)
           }, result.settleAfterMs)
         }}
         onCancel={() => {
           clearDismissTimer()
+          // An explicit cancel (ESC) retires the question outright, so no
+          // confirmation is owed and the card must not return.
+          clearConfirmationWait()
           setDismissedKey(cardKey)
           cancel()
         }}

--- a/src/renderer/src/components/native-chat/native-chat-answer-confirmation.ts
+++ b/src/renderer/src/components/native-chat/native-chat-answer-confirmation.ts
@@ -1,0 +1,33 @@
+import { NATIVE_CHAT_QUESTION_STEP_MS } from '../../../../shared/native-chat-answer-stepping'
+
+/**
+ * Answering an AskUserQuestion writes selector keystrokes into the agent's TUI.
+ * Acceptance of those bytes proves only that the PTY took them — a selector
+ * layout the keystrokes do not fit leaves the question live and unanswered
+ * (#16865). Until a confirmation signal arrives the answer stays "pending",
+ * which keeps the pane's waiting state intact and lets the card come back.
+ */
+export type NativeChatAnswerConfirmation =
+  /** The transcript closed the ask's tool call, or the pane's prompt cleared. */
+  | 'confirmed'
+  /** No confirmation before the deadline; the question is presumed still live. */
+  | 'unconfirmed'
+
+/** Grace added to the keystroke pacing before an unconfirmed answer is judged.
+ *
+ *  The agent has to redraw its selector, run the tool, and emit the result
+ *  through the transcript/hook path; on SSH that round-trip rides the same link
+ *  the keystrokes did. Sized to swallow a slow round-trip rather than to react
+ *  quickly: a late "still waiting" is a cosmetic delay, but an early one
+ *  re-shows a card over a question the agent already answered. */
+export const NATIVE_CHAT_ANSWER_CONFIRM_GRACE_MS = 6_000
+
+/**
+ * Deadline for a delivered answer's confirmation, measured from the moment
+ * delivery settles. Scales with the keystroke pacing because a long selector
+ * answer's final group lands proportionally later, and the agent cannot begin
+ * resolving the ask until it does.
+ */
+export function nativeChatAnswerConfirmDeadlineMs(settleAfterMs: number): number {
+  return Math.max(settleAfterMs, NATIVE_CHAT_QUESTION_STEP_MS) + NATIVE_CHAT_ANSWER_CONFIRM_GRACE_MS
+}

--- a/src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts
@@ -291,37 +291,27 @@ describe('buildAskAnswerKeys', () => {
     ])
   })
 
-  it('preview selector free text: commits the "Type something" row before typing', () => {
-    // The digit only highlights that row, so without this Enter the text is typed
-    // at a selector that still has an option highlighted, and that option is what
-    // gets submitted.
+  it('preview selector free text: opens a note with `n` — there is no "Type something" row', () => {
+    // The preview layout dropped that row (upstream anthropics/claude-code#27348,
+    // closed "not planned"). `n` opens a note on the highlighted row and the text
+    // submits as a note-only answer.
     expect(
       buildAskAnswerKeys(singleWithPreview(['Tabs', 'Spaces']), [{ indices: [], other: 'Zebra' }])
-    ).toEqual([{ raw: '3' }, { raw: '\r' }, { text: 'Zebra' }, { raw: '\r' }])
+    ).toEqual([{ raw: 'n' }, { text: 'Zebra' }, { raw: '\r' }])
   })
 
-  it('preview selector multi-select free text: commits the row before typing', () => {
-    const prompt: AskPrompt = {
-      questions: [
-        {
-          question: 'q',
-          multiSelect: true,
-          options: [
-            { label: 'A', hasPreview: true },
-            { label: 'B', hasPreview: true }
-          ]
-        }
-      ]
-    }
-    expect(buildAskAnswerKeys(prompt, [{ indices: [0], other: 'Zebra' }])).toEqual([
-      { raw: '1' },
-      { raw: '3' },
-      { raw: '\r' },
-      { text: 'Zebra' },
-      { raw: '\r' },
-      { raw: '\x1b[C' },
-      { raw: '\r' }
-    ])
+  it('preview selector option plus free text: folds the label into the note text', () => {
+    // A note-only answer carries no selection, so the picked label would be lost
+    // if it were not folded into the one channel that delivers.
+    expect(
+      buildAskAnswerKeys(singleWithPreview(['Tabs', 'Spaces']), [
+        { indices: [1], other: 'but only in JS' }
+      ])
+    ).toEqual([{ raw: 'n' }, { text: 'Spaces — but only in JS' }, { raw: '\r' }])
+  })
+
+  it('preview selector: an unanswered lone question emits nothing', () => {
+    expect(buildAskAnswerKeys(singleWithPreview(['Tabs', 'Spaces']), [{ indices: [] }])).toEqual([])
   })
 
   it('plain selector free text: no extra Enter before the text', () => {
@@ -354,6 +344,32 @@ describe('buildAskAnswerKeys', () => {
       { raw: '2' },
       { raw: '\r' },
       { raw: '1' },
+      { raw: '\r' }
+    ])
+  })
+
+  it('multi-select with previews: keeps the plain checkbox sequence', () => {
+    // How the preview layout renders a multi-select — whether it keeps checkbox
+    // toggles and a "Type something" row at all — is unmeasured, so this pins
+    // current behavior rather than asserting a verified contract.
+    const prompt: AskPrompt = {
+      questions: [
+        {
+          question: 'q',
+          multiSelect: true,
+          options: [
+            { label: 'A', hasPreview: true },
+            { label: 'B', hasPreview: true }
+          ]
+        }
+      ]
+    }
+    expect(buildAskAnswerKeys(prompt, [{ indices: [0], other: 'Zebra' }])).toEqual([
+      { raw: '1' },
+      { raw: '3' },
+      { text: 'Zebra' },
+      { raw: '\r' },
+      { raw: '\x1b[C' },
       { raw: '\r' }
     ])
   })

--- a/src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts
@@ -291,6 +291,45 @@ describe('buildAskAnswerKeys', () => {
     ])
   })
 
+  it('preview selector free text: commits the "Type something" row before typing', () => {
+    // The digit only highlights that row, so without this Enter the text is typed
+    // at a selector that still has an option highlighted, and that option is what
+    // gets submitted.
+    expect(
+      buildAskAnswerKeys(singleWithPreview(['Tabs', 'Spaces']), [{ indices: [], other: 'Zebra' }])
+    ).toEqual([{ raw: '3' }, { raw: '\r' }, { text: 'Zebra' }, { raw: '\r' }])
+  })
+
+  it('preview selector multi-select free text: commits the row before typing', () => {
+    const prompt: AskPrompt = {
+      questions: [
+        {
+          question: 'q',
+          multiSelect: true,
+          options: [
+            { label: 'A', hasPreview: true },
+            { label: 'B', hasPreview: true }
+          ]
+        }
+      ]
+    }
+    expect(buildAskAnswerKeys(prompt, [{ indices: [0], other: 'Zebra' }])).toEqual([
+      { raw: '1' },
+      { raw: '3' },
+      { raw: '\r' },
+      { text: 'Zebra' },
+      { raw: '\r' },
+      { raw: '\x1b[C' },
+      { raw: '\r' }
+    ])
+  })
+
+  it('plain selector free text: no extra Enter before the text', () => {
+    expect(
+      buildAskAnswerKeys(single(['Tabs', 'Spaces']), [{ indices: [], other: 'Zebra' }])
+    ).toEqual([{ raw: '3' }, { text: 'Zebra' }, { raw: '\r' }])
+  })
+
   it('single-question plain selector: unchanged, no Enter appended', () => {
     expect(buildAskAnswerKeys(single(['Tabs', 'Spaces']), [{ indices: [1] }])).toEqual([
       { raw: '2' }

--- a/src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts
@@ -291,23 +291,24 @@ describe('buildAskAnswerKeys', () => {
     ])
   })
 
-  it('preview selector free text: opens a note with `n` — there is no "Type something" row', () => {
-    // The preview layout dropped that row (upstream anthropics/claude-code#27348,
-    // closed "not planned"). With no pick to attach to, `n` annotates the
-    // highlighted row and delivers with no option counted as selected.
-    expect(
-      buildAskAnswerKeys(singleWithPreview(['Tabs', 'Spaces']), [{ indices: [], other: 'Zebra' }])
-    ).toEqual([{ raw: 'n' }, { text: 'Zebra' }, { raw: '\r' }])
-  })
-
   it('preview selector option plus free text: selects the row, then annotates it', () => {
-    // The note attaches to the selected row, so the digit comes first and the
-    // answer delivers as that option carrying its annotation.
+    // The preview layout has no "Type something" row (upstream
+    // anthropics/claude-code#27348, closed "not planned"); `n` opens a note on
+    // the selected row, so the digit comes first and the answer delivers as that
+    // option carrying its annotation.
     expect(
       buildAskAnswerKeys(singleWithPreview(['Tabs', 'Spaces']), [
         { indices: [1], other: 'but only in JS' }
       ])
     ).toEqual([{ raw: '2' }, { raw: 'n' }, { text: 'but only in JS' }, { raw: '\r' }])
+  })
+
+  it('preview selector free text with no pick: emits nothing', () => {
+    // Notes attach to a selected option, so there is no keystroke sequence for
+    // this input. The card prevents it; the builder refuses to invent a pick.
+    expect(
+      buildAskAnswerKeys(singleWithPreview(['Tabs', 'Spaces']), [{ indices: [], other: 'Zebra' }])
+    ).toEqual([])
   })
 
   it('preview selector: an unanswered lone question emits nothing', () => {

--- a/src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts
@@ -78,6 +78,28 @@ describe('parseAskFromStatus', () => {
     expect(prompt?.questions).toHaveLength(1)
     expect(prompt?.questions[0]?.question).toBe('ok')
   })
+
+  it('surfaces preview presence per option, without carrying the preview text', () => {
+    const prompt = parseAskFromStatus(
+      JSON.stringify({
+        questions: [
+          {
+            question: 'q',
+            options: [
+              { label: 'A', preview: 'const x = 1' },
+              { label: 'B' },
+              { label: 'C', preview: '' }
+            ]
+          }
+        ]
+      })
+    )
+    expect(prompt?.questions[0]?.options).toEqual([
+      { label: 'A', hasPreview: true },
+      { label: 'B' },
+      { label: 'C' }
+    ])
+  })
 })
 
 describe('parseApprovalFromStatus', () => {
@@ -179,6 +201,18 @@ const single = (options: string[], multiSelect = false): AskPrompt => ({
   questions: [{ question: 'q', multiSelect, options: options.map((label) => ({ label })) }]
 })
 
+/** A question where one option carries a preview snippet, switching Claude's
+ *  selector to the list+preview layout that needs an explicit Enter to commit. */
+const singleWithPreview = (options: string[]): AskPrompt => ({
+  questions: [
+    {
+      question: 'q',
+      multiSelect: false,
+      options: options.map((label, i) => (i === 0 ? { label, hasPreview: true } : { label }))
+    }
+  ]
+})
+
 describe('buildAskAnswerKeys', () => {
   it('single-select: sends the picked option NUMBER (not the label), no trailing Enter', () => {
     // STA-1860 regression: picking the 2nd option must deliver the 2nd option.
@@ -238,6 +272,51 @@ describe('buildAskAnswerKeys', () => {
 
   it('is empty when nothing is answered', () => {
     expect(buildAskAnswerKeys(single(['Tabs', 'Spaces']), [{ indices: [] }])).toEqual([])
+  })
+
+  it('single-question preview selector: appends Enter after the option number to commit it', () => {
+    // #16865: a digit alone only moves the highlight in the list+preview layout;
+    // without this Enter the answer is silently dropped.
+    expect(buildAskAnswerKeys(singleWithPreview(['Tabs', 'Spaces']), [{ indices: [1] }])).toEqual([
+      { raw: '2' },
+      { raw: '\r' }
+    ])
+  })
+
+  it('single-question preview selector: appends Enter regardless of which option is picked', () => {
+    // The preview layout is a property of the whole selector, not the chosen row.
+    expect(buildAskAnswerKeys(singleWithPreview(['Tabs', 'Spaces']), [{ indices: [0] }])).toEqual([
+      { raw: '1' },
+      { raw: '\r' }
+    ])
+  })
+
+  it('single-question plain selector: unchanged, no Enter appended', () => {
+    expect(buildAskAnswerKeys(single(['Tabs', 'Spaces']), [{ indices: [1] }])).toEqual([
+      { raw: '2' }
+    ])
+  })
+
+  it('multi-question with a preview single-select answer: Enter follows that question’s digit, plus the existing final submit Enter', () => {
+    const prompt: AskPrompt = {
+      questions: [
+        {
+          question: 'q1',
+          multiSelect: false,
+          options: [
+            { label: 'Tabs', hasPreview: true },
+            { label: 'Spaces', hasPreview: true }
+          ]
+        },
+        { question: 'q2', multiSelect: false, options: [{ label: 'Apple' }, { label: 'Banana' }] }
+      ]
+    }
+    expect(buildAskAnswerKeys(prompt, [{ indices: [1] }, { indices: [0] }])).toEqual([
+      { raw: '2' },
+      { raw: '\r' },
+      { raw: '1' },
+      { raw: '\r' }
+    ])
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts
@@ -293,21 +293,21 @@ describe('buildAskAnswerKeys', () => {
 
   it('preview selector free text: opens a note with `n` — there is no "Type something" row', () => {
     // The preview layout dropped that row (upstream anthropics/claude-code#27348,
-    // closed "not planned"). `n` opens a note on the highlighted row and the text
-    // submits as a note-only answer.
+    // closed "not planned"). With no pick to attach to, `n` annotates the
+    // highlighted row and delivers with no option counted as selected.
     expect(
       buildAskAnswerKeys(singleWithPreview(['Tabs', 'Spaces']), [{ indices: [], other: 'Zebra' }])
     ).toEqual([{ raw: 'n' }, { text: 'Zebra' }, { raw: '\r' }])
   })
 
-  it('preview selector option plus free text: folds the label into the note text', () => {
-    // A note-only answer carries no selection, so the picked label would be lost
-    // if it were not folded into the one channel that delivers.
+  it('preview selector option plus free text: selects the row, then annotates it', () => {
+    // The note attaches to the selected row, so the digit comes first and the
+    // answer delivers as that option carrying its annotation.
     expect(
       buildAskAnswerKeys(singleWithPreview(['Tabs', 'Spaces']), [
         { indices: [1], other: 'but only in JS' }
       ])
-    ).toEqual([{ raw: 'n' }, { text: 'Spaces — but only in JS' }, { raw: '\r' }])
+    ).toEqual([{ raw: '2' }, { raw: 'n' }, { text: 'but only in JS' }, { raw: '\r' }])
   })
 
   it('preview selector: an unanswered lone question emits nothing', () => {

--- a/src/renderer/src/components/native-chat/use-native-chat-interactive-send.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-interactive-send.test.tsx
@@ -136,11 +136,15 @@ describe('useNativeChatInteractiveSend', () => {
       useNativeChatInteractiveSend('tab-1', PANE_KEY, 'pty-1', 'openclaude')
     )
 
-    act(() => result.current.sendAnswer(PROMPT, [{ indices: [1] }]))
+    let sendResult: ReturnType<typeof result.current.sendAnswer> | undefined
+    act(() => {
+      sendResult = result.current.sendAnswer(PROMPT, [{ indices: [1] }])
+    })
 
     const onSettled = mocks.sendNativeChatAskAnswer.mock.calls[0]?.[3]
     expect(onSettled).toBeTypeOf('function')
     onSettled?.(true)
+    sendResult?.confirmAnswered()
     expect(mocks.inferQuestionAnswered).toHaveBeenCalledOnce()
   })
 
@@ -154,7 +158,7 @@ describe('useNativeChatInteractiveSend', () => {
       resultValue = result.current.sendAnswer(PROMPT, [{ indices: [] }])
     })
 
-    expect(resultValue).toEqual({ settleAfterMs: 0, waitsForVerifiedDelivery: false })
+    expect(resultValue).toMatchObject({ settleAfterMs: 0, waitsForVerifiedDelivery: false })
     expect(mocks.sendNativeChatAskAnswer).not.toHaveBeenCalled()
     expect(mocks.sendNativeChatMessage).not.toHaveBeenCalled()
   })
@@ -211,19 +215,40 @@ describe('useNativeChatInteractiveSend', () => {
     expect(mocks.sendRuntimePtyInput).not.toHaveBeenCalled()
   })
 
-  it('infers a Claude question answer only after every runtime write was delivered', () => {
+  // Delivered bytes are not an answered question: a selector layout the
+  // keystrokes do not fit leaves the ask live (#16865). Only the card's
+  // confirmation signal may clear the pane's wait.
+  it('does not clear the question wait on delivery alone', () => {
     const { result } = renderHook(() =>
       useNativeChatInteractiveSend('tab-1', PANE_KEY, 'pty-1', 'claude')
     )
 
     act(() => result.current.sendAnswer(PROMPT, [{ indices: [1] }]))
-    expect(mocks.inferQuestionAnswered).not.toHaveBeenCalled()
 
     const onSettled = mocks.sendNativeChatAskAnswer.mock.calls[0]?.[3]
     expect(onSettled).toBeTypeOf('function')
-    onSettled?.(false)
-    expect(mocks.inferQuestionAnswered).not.toHaveBeenCalled()
     onSettled?.(true)
+
+    expect(mocks.inferQuestionAnswered).not.toHaveBeenCalled()
+  })
+
+  it('clears the question wait once, when the card confirms the ask resolved', () => {
+    const { result } = renderHook(() =>
+      useNativeChatInteractiveSend('tab-1', PANE_KEY, 'pty-1', 'claude')
+    )
+
+    let sendResult: ReturnType<typeof result.current.sendAnswer> | undefined
+    act(() => {
+      sendResult = result.current.sendAnswer(PROMPT, [{ indices: [1] }])
+    })
+    expect(mocks.inferQuestionAnswered).not.toHaveBeenCalled()
+
+    const onSettled = mocks.sendNativeChatAskAnswer.mock.calls[0]?.[3]
+    onSettled?.(true)
+    sendResult?.confirmAnswered()
+    // A second confirmation (deadline race, replacement prompt) must not
+    // re-clear a wait that may already belong to the next question.
+    sendResult?.confirmAnswered()
 
     expect(mocks.inferQuestionAnswered).toHaveBeenCalledExactlyOnceWith({
       paneKey: PANE_KEY,
@@ -240,7 +265,10 @@ describe('useNativeChatInteractiveSend', () => {
     )
 
     // Answer question A while it is the current waiting question.
-    act(() => result.current.sendAnswer(PROMPT, [{ indices: [1] }]))
+    let sendResult: ReturnType<typeof result.current.sendAnswer> | undefined
+    act(() => {
+      sendResult = result.current.sendAnswer(PROMPT, [{ indices: [1] }])
+    })
 
     // A different AskUserQuestion becomes current before the paced send settles.
     mocks.storeState = {
@@ -256,6 +284,7 @@ describe('useNativeChatInteractiveSend', () => {
 
     const onSettled = mocks.sendNativeChatAskAnswer.mock.calls[0]?.[3]
     onSettled?.(true)
+    sendResult?.confirmAnswered()
 
     // The baseline is question A's (captured before delivery), so the server can
     // reject it against the now-current question B instead of clearing B's wait.
@@ -278,7 +307,7 @@ describe('useNativeChatInteractiveSend', () => {
     act(() => {
       sendResult = result.current.sendAnswer(PROMPT, [{ indices: [1] }], onDeliverySettled)
     })
-    expect(sendResult).toEqual({ settleAfterMs: 500, waitsForVerifiedDelivery: true })
+    expect(sendResult).toMatchObject({ settleAfterMs: 500, waitsForVerifiedDelivery: true })
 
     const onSettled = mocks.sendNativeChatAskAnswer.mock.calls[0]?.[3]
     onSettled?.(false)

--- a/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
@@ -33,7 +33,14 @@ export type NativeChatInteractiveSend = {
     prompt: AskPrompt,
     selections: AskAnswerSelection[],
     onDeliverySettled?: (delivered: boolean) => void
-  ) => { settleAfterMs: number; waitsForVerifiedDelivery: boolean }
+  ) => {
+    settleAfterMs: number
+    waitsForVerifiedDelivery: boolean
+    /** Clears the pane's question wait. Written bytes do not prove the agent
+     *  accepted the answer, so the caller invokes this only once a confirmation
+     *  signal lands (#16865). */
+    confirmAnswered: () => void
+  }
   /** Send a raw control string (e.g. an approval option number or ESC) as-is. */
   sendRaw: (raw: string) => void
   /** Stop delayed writes without interrupting the agent. */
@@ -86,9 +93,13 @@ export function useNativeChatInteractiveSend(
       prompt: AskPrompt,
       selections: AskAnswerSelection[],
       onDeliverySettled?: (delivered: boolean) => void
-    ): { settleAfterMs: number; waitsForVerifiedDelivery: boolean } => {
+    ): {
+      settleAfterMs: number
+      waitsForVerifiedDelivery: boolean
+      confirmAnswered: () => void
+    } => {
       if (!targetPtyId || !hasAskAnswer(prompt, selections)) {
-        return { settleAfterMs: 0, waitsForVerifiedDelivery: false }
+        return { settleAfterMs: 0, waitsForVerifiedDelivery: false, confirmAnswered: () => {} }
       }
       // Cancel any prior in-flight answer before starting a new one.
       cancelInFlight()
@@ -106,6 +117,24 @@ export function useNativeChatInteractiveSend(
       const questionStatusBaseline = stepsAnswer
         ? useAppStore.getState().agentStatusByPaneKey[paneKey]
         : undefined
+      let confirmed = false
+      const confirmAnswered = stepsAnswer
+        ? (): void => {
+            if (confirmed) {
+              return
+            }
+            confirmed = true
+            inferQuestionAnsweredFromCurrentStatus({
+              paneKey,
+              getStatusEntry: () => questionStatusBaseline,
+              inferQuestionAnswered: (request) =>
+                window.api.agentStatus.inferQuestionAnswered(request).catch((err) => {
+                  console.warn('[agent-question] native-chat inference failed:', err)
+                  return false
+                })
+            })
+          }
+        : (): void => {}
       let settledHandle: NativeChatSendHandle | null = null
       const onSettled = stepsAnswer
         ? (delivered: boolean): void => {
@@ -113,17 +142,6 @@ export function useNativeChatInteractiveSend(
               // Why: a completed verified send otherwise retains its timers,
               // promises, and prompt callback until the next send or unmount.
               inFlightRef.current = null
-            }
-            if (delivered) {
-              inferQuestionAnsweredFromCurrentStatus({
-                paneKey,
-                getStatusEntry: () => questionStatusBaseline,
-                inferQuestionAnswered: (request) =>
-                  window.api.agentStatus.inferQuestionAnswered(request).catch((err) => {
-                    console.warn('[agent-question] native-chat inference failed:', err)
-                    return false
-                  })
-              })
             }
             onDeliverySettled?.(delivered)
           }
@@ -138,14 +156,15 @@ export function useNativeChatInteractiveSend(
             onSettled
           )
         : sendNativeChatMessage(settings, targetPtyId, formatAskAnswer(prompt, selections))
-      // Why: native-chat answer writes bypass xterm.onData. Infer only after
-      // every paced selector write has fired, so an early digit in a multi-step
-      // answer cannot dismiss the wait or cancel the remaining writes.
+      // Why: native-chat answer writes bypass xterm.onData, so settlement is
+      // reported only after every paced selector write has fired — an early
+      // digit in a multi-step answer must not cancel the remaining writes.
       settledHandle = handle
       inFlightRef.current = handle
       return {
         settleAfterMs: handle.settleAfterMs,
-        waitsForVerifiedDelivery: onSettled !== undefined
+        waitsForVerifiedDelivery: onSettled !== undefined,
+        confirmAnswered
       }
     },
     [terminalTabId, paneKey, targetPtyId, agent, cancelInFlight]

--- a/src/renderer/src/runtime/runtime-terminal-inspection.ts
+++ b/src/renderer/src/runtime/runtime-terminal-inspection.ts
@@ -198,8 +198,11 @@ export async function sendRuntimePtyInputVerified(
     const accepted = await window.api.pty.writeAccepted(ptyId, data)
     if (!accepted) {
       window.api.pty.write(ptyId, data)
-      // Why: SSH/local fallback writes are fire-and-forget. Callers use this
-      // boolean to continue UX flow, while hook telemetry confirms real turns.
+      // Why: `writeAccepted` answers false for whole healthy transports — an
+      // SSH-owned or mobile-driven pty cannot acknowledge — so a false here is
+      // "unacknowledged", not "failed", and callers gate live UX on it.
+      // This boolean therefore never means the agent acted on the bytes; a
+      // surface needing that (question answers) must confirm it separately.
       recordRuntimeTerminalInputForPtyId(ptyId)
       return true
     }

--- a/src/renderer/src/runtime/runtime-terminal-inspection.ts
+++ b/src/renderer/src/runtime/runtime-terminal-inspection.ts
@@ -180,6 +180,10 @@ function sendRuntimePtyInputWithinLimit(
   return true
 }
 
+/** Write PTY input and wait for transport-level acceptance where the transport
+ *  can report it. A `true` return does not prove the agent acted on the bytes —
+ *  see the SSH/mobile fallback note below — so a caller needing that must
+ *  confirm it through a separate signal (e.g. transcript or hook status). */
 export async function sendRuntimePtyInputVerified(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
   ptyId: string,

--- a/src/shared/native-chat-ask-types.ts
+++ b/src/shared/native-chat-ask-types.ts
@@ -1,7 +1,7 @@
 // Canonical AskUserQuestion prompt types consumed by the shared parser and both
 // native-chat platform UIs.
 
-export type AskOption = { label: string; description?: string }
+export type AskOption = { label: string; description?: string; hasPreview?: boolean }
 export type AskQuestion = {
   question: string
   header?: string

--- a/src/shared/native-chat-ask.test.ts
+++ b/src/shared/native-chat-ask.test.ts
@@ -165,6 +165,25 @@ describe('extractPendingAsk', () => {
       ])
     ).toBeNull()
   })
+
+  it('surfaces preview presence from a transcript tool-call, same as the live status path', () => {
+    // Transcript replay decodes tool-call input as an object (not a JSON string,
+    // unlike the hook-status path), but both route through the same option
+    // parser, so preview presence must survive here too.
+    const pending = extractPendingAsk([
+      message('m1', [
+        call('AskUserQuestion', {
+          questions: [
+            { question: 'Pick', options: [{ label: 'A', preview: 'snippet' }, { label: 'B' }] }
+          ]
+        })
+      ])
+    ])
+    expect(pending?.questions[0]?.options).toEqual([
+      { label: 'A', hasPreview: true },
+      { label: 'B' }
+    ])
+  })
 })
 
 describe('parseAskFromStatus', () => {

--- a/src/shared/native-chat-ask.test.ts
+++ b/src/shared/native-chat-ask.test.ts
@@ -262,6 +262,25 @@ describe('resolveNativeChatAsk', () => {
     expect(resolved?.questions[0]?.question).toBe('Ship it?')
   })
 
+  it('keeps a cancelled ask retired after its interrupt row lands', () => {
+    // The live repro: X cancels the selector, Claude writes the is_error result
+    // then the interrupt row, and re-mounting the pane (view switch) must not
+    // bring the dead question back.
+    const liveAsk = parseAskFromStatus(JSON.stringify(QUESTIONS_INPUT))!
+    expect(
+      resolveNativeChatAsk({
+        liveAsk,
+        messages: [
+          message('m1', [call('AskUserQuestion', QUESTIONS_INPUT)]),
+          toolTurn('m2'),
+          interrupted('m3'),
+          userTurn('m4', 'ask me another question')
+        ],
+        transcriptSettled: true
+      })
+    ).toBeNull()
+  })
+
   it('does not let a different pending ask suppress the live one', () => {
     const liveAsk = parseAskFromStatus(JSON.stringify(QUESTIONS_INPUT))!
     const other = { questions: [{ question: 'Other?', options: [{ label: 'A' }] }] }
@@ -324,6 +343,42 @@ describe('isAskResolvedInTranscript', () => {
         userTurn('m2', 'never mind'),
         message('m3', [call('Bash', { command: 'ls' })]),
         toolTurn('m4')
+      ])
+    ).toBe(false)
+  })
+
+  // Measured shape of a TUI-cancelled ask (Claude Code session transcripts): the
+  // is_error tool-result lands first, then `[Request interrupted by user for tool
+  // use]`. A verdict wiped by that trailing row let stale live status win again,
+  // and remounting the pane (view switch) re-rendered the dead question.
+  it('keeps the verdict when the cancel path writes its interrupt row after the result', () => {
+    expect(
+      isAskResolvedInTranscript(ask, [
+        message('m1', [call('AskUserQuestion', QUESTIONS_INPUT)]),
+        toolTurn('m2'),
+        interrupted('m3'),
+        userTurn('m4', 'ask me another question')
+      ])
+    ).toBe(true)
+  })
+
+  it('keeps the verdict when the interrupt arrives as a plain user row', () => {
+    expect(
+      isAskResolvedInTranscript(ask, [
+        message('m1', [call('AskUserQuestion', QUESTIONS_INPUT)]),
+        toolTurn('m2'),
+        userTurn('m3', '[Request interrupted by user for tool use]')
+      ])
+    ).toBe(true)
+  })
+
+  it('un-resolves once the agent asks the same question again', () => {
+    expect(
+      isAskResolvedInTranscript(ask, [
+        message('m1', [call('AskUserQuestion', QUESTIONS_INPUT)]),
+        toolTurn('m2'),
+        userTurn('m3', 'ask me that again'),
+        message('m4', [call('AskUserQuestion', QUESTIONS_INPUT)])
       ])
     ).toBe(false)
   })

--- a/src/shared/native-chat-ask.test.ts
+++ b/src/shared/native-chat-ask.test.ts
@@ -6,6 +6,7 @@ import {
 } from './native-chat-types'
 import {
   extractPendingAsk,
+  isAskResolvedInTranscript,
   nativeChatAskDismissKey,
   parseAskFromStatus,
   resolveNativeChatAsk
@@ -220,5 +221,132 @@ describe('resolveNativeChatAsk', () => {
     expect(resolveNativeChatAsk({ liveAsk, messages: transcript, transcriptSettled: false })).toBe(
       liveAsk
     )
+  })
+
+  it('retires a live ask the settled transcript shows resolved', () => {
+    // A question killed inside the TUI emits no hook, so live status holds it
+    // forever; its tool-result is the only evidence it is over (#16865).
+    const liveAsk = parseAskFromStatus(JSON.stringify(QUESTIONS_INPUT))!
+    expect(
+      resolveNativeChatAsk({
+        liveAsk,
+        messages: [message('m1', [call('AskUserQuestion', QUESTIONS_INPUT)]), toolTurn('m2')],
+        transcriptSettled: true
+      })
+    ).toBeNull()
+  })
+
+  it('keeps a live ask asserted while the transcript is still unsettled', () => {
+    const liveAsk = parseAskFromStatus(JSON.stringify(QUESTIONS_INPUT))!
+    expect(
+      resolveNativeChatAsk({
+        liveAsk,
+        messages: [message('m1', [call('AskUserQuestion', QUESTIONS_INPUT)]), toolTurn('m2')],
+        transcriptSettled: false
+      })
+    ).toBe(liveAsk)
+  })
+
+  it('surfaces the transcript ask still pending when the live one is resolved', () => {
+    const liveAsk = parseAskFromStatus(JSON.stringify(QUESTIONS_INPUT))!
+    const later = { questions: [{ question: 'Ship it?', options: [{ label: 'Go' }] }] }
+    const resolved = resolveNativeChatAsk({
+      liveAsk,
+      messages: [
+        message('m1', [call('AskUserQuestion', QUESTIONS_INPUT)]),
+        toolTurn('m2'),
+        message('m3', [call('AskUserQuestion', later)])
+      ],
+      transcriptSettled: true
+    })
+    expect(resolved?.questions[0]?.question).toBe('Ship it?')
+  })
+
+  it('does not let a different pending ask suppress the live one', () => {
+    const liveAsk = parseAskFromStatus(JSON.stringify(QUESTIONS_INPUT))!
+    const other = { questions: [{ question: 'Other?', options: [{ label: 'A' }] }] }
+    expect(
+      resolveNativeChatAsk({
+        liveAsk,
+        messages: [message('m1', [call('AskUserQuestion', other)])],
+        transcriptSettled: true
+      })
+    ).toBe(liveAsk)
+  })
+})
+
+describe('isAskResolvedInTranscript', () => {
+  const ask = parseAskFromStatus(JSON.stringify(QUESTIONS_INPUT))!
+
+  it('reports resolved only once this ask receives its own FIFO result', () => {
+    const calls = [message('m1', [call('AskUserQuestion', QUESTIONS_INPUT)])]
+    expect(isAskResolvedInTranscript(ask, calls)).toBe(false)
+    expect(isAskResolvedInTranscript(ask, [...calls, toolTurn('m2')])).toBe(true)
+  })
+
+  it('is false when the transcript never mentions the ask', () => {
+    expect(isAskResolvedInTranscript(ask, [])).toBe(false)
+    expect(
+      isAskResolvedInTranscript(ask, [
+        message('m1', [call('Bash', { command: 'ls' })]),
+        toolTurn('m2')
+      ])
+    ).toBe(false)
+  })
+
+  it('does not credit a sibling call result to the ask', () => {
+    // FIFO: the result settles the older Bash call, leaving the ask outstanding.
+    expect(
+      isAskResolvedInTranscript(ask, [
+        message('m1', [call('Bash', { command: 'ls' }), call('AskUserQuestion', QUESTIONS_INPUT)]),
+        toolTurn('m2')
+      ])
+    ).toBe(false)
+  })
+
+  it('never reports resolved for an ask orphaned by an interrupt', () => {
+    // The orphan's result never arrives, so a later result belongs to a call
+    // from the next turn — crediting it would hide a live question (#11761).
+    expect(
+      isAskResolvedInTranscript(ask, [
+        message('m1', [call('AskUserQuestion', QUESTIONS_INPUT)]),
+        interrupted('m2'),
+        message('m3', [call('Bash', { command: 'ls' })]),
+        toolTurn('m4')
+      ])
+    ).toBe(false)
+  })
+
+  it('never reports resolved for an ask orphaned by a new user turn', () => {
+    expect(
+      isAskResolvedInTranscript(ask, [
+        message('m1', [call('AskUserQuestion', QUESTIONS_INPUT)]),
+        userTurn('m2', 'never mind'),
+        message('m3', [call('Bash', { command: 'ls' })]),
+        toolTurn('m4')
+      ])
+    ).toBe(false)
+  })
+
+  it('re-arms after a reset so a re-asked question resolves on its own result', () => {
+    expect(
+      isAskResolvedInTranscript(ask, [
+        message('m1', [call('AskUserQuestion', QUESTIONS_INPUT)]),
+        userTurn('m2', 'never mind'),
+        message('m3', [call('AskUserQuestion', QUESTIONS_INPUT)]),
+        toolTurn('m4')
+      ])
+    ).toBe(true)
+  })
+
+  it('matches by canonical content, not object identity', () => {
+    const equivalent = parseAskFromStatus(JSON.stringify(QUESTIONS_INPUT))!
+    expect(equivalent).not.toBe(ask)
+    expect(
+      isAskResolvedInTranscript(equivalent, [
+        message('m1', [call('AskUserQuestion', QUESTIONS_INPUT)]),
+        toolTurn('m2')
+      ])
+    ).toBe(true)
   })
 })

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -146,7 +146,9 @@ export function extractPendingAsk(messages: readonly NativeChatMessage[]): AskPr
  *  stale card up, while a false positive would hide a live question.
  *
  *  Claude Code writes a tool-result row for an AskUserQuestion cancelled in the
- *  TUI (`is_error`), so a selector the user escaped reads as resolved here. */
+ *  TUI (`is_error`), so a selector the user escaped reads as resolved here. That
+ *  result is immediately followed by the interrupt row, so a formed verdict
+ *  outlives turn boundaries; only a fresh matching call un-resolves the ask. */
 export function isAskResolvedInTranscript(
   ask: AskPrompt,
   messages: readonly NativeChatMessage[]
@@ -159,14 +161,20 @@ export function isAskResolvedInTranscript(
   let resolved = false
   for (const message of messages) {
     if (message.role === 'user' || isInterruptedStatusMessage(message)) {
-      // The turn owning these calls ended; their results never arrive. Any match
-      // seen so far belonged to a turn that is over, so re-arm from scratch.
+      // The turn owning these calls ended; their results never arrive, so the
+      // pending FIFO is void. A verdict already witnessed by a result stands —
+      // the cancel path writes the interrupt row right after the tool-result.
       outstanding = []
-      resolved = false
     }
     for (const block of message.blocks) {
       if (block.type === 'tool-call') {
-        outstanding.push(nativeChatAskDismissKey(parseToolInput(block.name, block.input)))
+        const key = nativeChatAskDismissKey(parseToolInput(block.name, block.input))
+        if (key === askKey) {
+          // The agent is asking this same question again: a live instance is
+          // outstanding, so the earlier resolution no longer describes it.
+          resolved = false
+        }
+        outstanding.push(key)
       } else if (block.type === 'tool-result' && outstanding.length > 0) {
         if (outstanding.shift() === askKey) {
           resolved = true

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -227,13 +227,18 @@ export function buildAskAnswerKeys(
     const sel = selections[qi]
     const other = (sel?.other ?? '').trim()
     const typeSomething = String(q.options.length + 1)
+    // In the preview layout a digit only moves the highlight, so opening a row —
+    // including the "Type something" row — takes an Enter of its own before that
+    // row accepts input.
+    const openRow = (row: string): AskAnswerKeyGroup[] =>
+      questionHasPreview(q) ? [{ raw: row }, { raw: ASK_ENTER }] : [{ raw: row }]
 
     if (q.multiSelect) {
       for (const i of sel?.indices ?? []) {
         groups.push({ raw: String(i + 1) })
       }
       if (other) {
-        groups.push({ raw: typeSomething }, { text: other }, { raw: ASK_ENTER })
+        groups.push(...openRow(typeSomething), { text: other }, { raw: ASK_ENTER })
       }
       // A multi-select never auto-advances; step to the next tab (the Submit tab
       // when this is the last question).
@@ -242,7 +247,7 @@ export function buildAskAnswerKeys(
       // Single-select can only carry one value, so route any answer that
       // includes free text through the "Type something" row as one string.
       groups.push(
-        { raw: typeSomething },
+        ...openRow(typeSomething),
         { text: answerLabels(q, sel).join(', ') },
         { raw: ASK_ENTER }
       )

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -136,13 +136,63 @@ export function extractPendingAsk(messages: readonly NativeChatMessage[]): AskPr
   return pending
 }
 
-/** Prefers live status and consults transcript history only after its read settles. */
+/** Does the transcript positively show THIS ask already resolved?
+ *
+ *  Answers only from evidence: a tool-call matching `ask` whose FIFO slot then
+ *  received its tool-result. Absence of the call, an unsettled read, and a call
+ *  orphaned by a user turn or interrupt all answer false — an orphan's result
+ *  never arrives, so it can never witness resolution (#11761). Callers use this
+ *  to retire an ask that live status still asserts; a false negative leaves a
+ *  stale card up, while a false positive would hide a live question.
+ *
+ *  Claude Code writes a tool-result row for an AskUserQuestion cancelled in the
+ *  TUI (`is_error`), so a selector the user escaped reads as resolved here. */
+export function isAskResolvedInTranscript(
+  ask: AskPrompt,
+  messages: readonly NativeChatMessage[]
+): boolean {
+  // Same identity the cards dismiss under: canonical content, not object identity.
+  const askKey = nativeChatAskDismissKey(ask)
+  // Mirrors extractPendingAsk's FIFO walk: `outstanding` holds each unresolved
+  // call's key (or null for a non-question call), oldest first.
+  let outstanding: (string | null)[] = []
+  let resolved = false
+  for (const message of messages) {
+    if (message.role === 'user' || isInterruptedStatusMessage(message)) {
+      // The turn owning these calls ended; their results never arrive. Any match
+      // seen so far belonged to a turn that is over, so re-arm from scratch.
+      outstanding = []
+      resolved = false
+    }
+    for (const block of message.blocks) {
+      if (block.type === 'tool-call') {
+        outstanding.push(nativeChatAskDismissKey(parseToolInput(block.name, block.input)))
+      } else if (block.type === 'tool-result' && outstanding.length > 0) {
+        if (outstanding.shift() === askKey) {
+          resolved = true
+        }
+      }
+    }
+  }
+  return resolved
+}
+
+/** Prefers live status, except where the settled transcript positively shows the
+ *  live ask already resolved — a question killed inside the TUI emits no hook, so
+ *  live status would otherwise assert it forever (#16865). Falls through to the
+ *  transcript's own pending ask so a genuinely newer question still renders. */
 export function resolveNativeChatAsk(args: {
   liveAsk: AskPrompt | null
   messages: readonly NativeChatMessage[]
   transcriptSettled: boolean
 }): AskPrompt | null {
-  return args.liveAsk ?? (args.transcriptSettled ? extractPendingAsk(args.messages) : null)
+  if (args.liveAsk) {
+    if (!args.transcriptSettled || !isAskResolvedInTranscript(args.liveAsk, args.messages)) {
+      return args.liveAsk
+    }
+    return extractPendingAsk(args.messages)
+  }
+  return args.transcriptSettled ? extractPendingAsk(args.messages) : null
 }
 
 /** One question's chosen answer, normalized for delivery: the selected option

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -207,22 +207,22 @@ function questionHasPreview(q: AskQuestion): boolean {
 /** Answer a preview-layout question, whose row set and commit semantics differ
  *  from the plain selector: no "Type something" row, and a digit only highlights.
  *
- *  A note attaches to whichever row is selected, so free text alongside a pick
- *  selects that row first and annotates it; free text alone opens a note on the
- *  highlighted row and delivers with no option counted as selected. */
+ *  Notes attach to a selected option — the layout offers no selection-less note —
+ *  so an answer without a pick delivers nothing rather than fabricating a
+ *  selection or sending a sequence the selector does not accept. */
 function buildPreviewAnswerKeys(
   sel: AskAnswerSelection | undefined,
   other: string
 ): AskAnswerKeyGroup[] {
   const picked = sel?.indices[0]
+  if (picked === undefined) {
+    return []
+  }
+  const selectRow: AskAnswerKeyGroup = { raw: String(picked + 1) }
   if (other) {
-    const selectRow: AskAnswerKeyGroup[] = picked === undefined ? [] : [{ raw: String(picked + 1) }]
-    return [...selectRow, { raw: ASK_PREVIEW_NOTE }, { text: other }, { raw: ASK_ENTER }]
+    return [selectRow, { raw: ASK_PREVIEW_NOTE }, { text: other }, { raw: ASK_ENTER }]
   }
-  if (picked !== undefined) {
-    return [{ raw: String(picked + 1) }, { raw: ASK_ENTER }]
-  }
-  return []
+  return [selectRow, { raw: ASK_ENTER }]
 }
 
 /** Build the ordered keystroke groups that answer a Claude Code AskUserQuestion.

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -47,6 +47,9 @@ function parseQuestionsShape(input: unknown): AskPrompt | null {
   return questions.length > 0 ? { questions } : null
 }
 
+/** Tolerant parse of raw tool-input options: bare strings become label-only
+ *  options, malformed entries are dropped, and an empty-string preview counts
+ *  as no preview. */
 function parseOptions(raw: unknown): AskOption[] {
   if (!Array.isArray(raw)) {
     return []

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -192,6 +192,11 @@ const ASK_NEXT_TAB = '\x1b[C'
 const ASK_PREVIOUS_ROW = '\x1b[A'
 const ASK_NEXT_ROW = '\x1b[B'
 const ASK_NOTES = '\t'
+// The preview layout has no "Type something" row (upstream
+// anthropics/claude-code#27348, closed "not planned"). Free text goes through a
+// per-option note instead: `n` opens a note on the highlighted row, and the
+// typed text submits as a note-only answer that carries no option selection.
+const ASK_PREVIEW_NOTE = 'n'
 
 /** True once any option in the question carries a preview snippet — the
  *  selector then switches to a list+preview layout where a digit only moves
@@ -200,14 +205,37 @@ function questionHasPreview(q: AskQuestion): boolean {
   return q.options.some((o) => o.hasPreview === true)
 }
 
+/** Answer a preview-layout question, whose row set and commit semantics differ
+ *  from the plain selector: no "Type something" row, and a digit only highlights.
+ *
+ *  Free text always delivers through a note, which the tool result carries as an
+ *  annotation with no option counted as selected — so an answer that has BOTH a
+ *  pick and free text folds the label into the note text rather than dropping
+ *  either. Combining a committed pick with a note in one sequence is unmeasured. */
+function buildPreviewAnswerKeys(
+  q: AskQuestion,
+  sel: AskAnswerSelection | undefined,
+  other: string
+): AskAnswerKeyGroup[] {
+  if (other) {
+    const labels = answerLabels(q, sel).filter((label) => label !== other)
+    const note = labels.length > 0 ? `${labels.join(', ')} — ${other}` : other
+    return [{ raw: ASK_PREVIEW_NOTE }, { text: note }, { raw: ASK_ENTER }]
+  }
+  if ((sel?.indices.length ?? 0) > 0) {
+    return [{ raw: String(sel!.indices[0]! + 1) }, { raw: ASK_ENTER }]
+  }
+  return []
+}
+
 /** Build the ordered keystroke groups that answer a Claude Code AskUserQuestion.
  *  Each group is written a step apart so the selector applies it before the next.
  *
  *  - single-select pick  → the option number (selects AND commits; in a
- *    multi-question prompt it auto-advances to the next question) — except when
- *    the question has a preview-style layout, where the digit only highlights
- *    and a following Enter commits it
+ *    multi-question prompt it auto-advances to the next question)
  *  - free-text answer    → the "Type something" row number, the text, then Enter
+ *  - preview layout      → see `buildPreviewAnswerKeys`; the row set and commit
+ *    semantics both differ from the plain selector
  *  - multi-select        → each option number TOGGLES its checkbox, then a step
  *    to the Submit tab
  *  - a multi-question prompt (and a lone multi-select) finishes on a Submit
@@ -227,35 +255,34 @@ export function buildAskAnswerKeys(
     const sel = selections[qi]
     const other = (sel?.other ?? '').trim()
     const typeSomething = String(q.options.length + 1)
-    // In the preview layout a digit only moves the highlight, so opening a row —
-    // including the "Type something" row — takes an Enter of its own before that
-    // row accepts input.
-    const openRow = (row: string): AskAnswerKeyGroup[] =>
-      questionHasPreview(q) ? [{ raw: row }, { raw: ASK_ENTER }] : [{ raw: row }]
 
     if (q.multiSelect) {
       for (const i of sel?.indices ?? []) {
         groups.push({ raw: String(i + 1) })
       }
       if (other) {
-        groups.push(...openRow(typeSomething), { text: other }, { raw: ASK_ENTER })
+        groups.push({ raw: typeSomething }, { text: other }, { raw: ASK_ENTER })
       }
       // A multi-select never auto-advances; step to the next tab (the Submit tab
       // when this is the last question).
       groups.push({ raw: ASK_NEXT_TAB })
+    } else if (questionHasPreview(q)) {
+      const previewGroups = buildPreviewAnswerKeys(q, sel, other)
+      if (previewGroups.length > 0) {
+        groups.push(...previewGroups)
+      } else if (multiQuestion) {
+        groups.push({ raw: ASK_NEXT_TAB })
+      }
     } else if (other) {
       // Single-select can only carry one value, so route any answer that
       // includes free text through the "Type something" row as one string.
       groups.push(
-        ...openRow(typeSomething),
+        { raw: typeSomething },
         { text: answerLabels(q, sel).join(', ') },
         { raw: ASK_ENTER }
       )
     } else if ((sel?.indices.length ?? 0) > 0) {
       groups.push({ raw: String(sel!.indices[0]! + 1) })
-      if (questionHasPreview(q)) {
-        groups.push({ raw: ASK_ENTER })
-      }
     } else if (multiQuestion) {
       // Unanswered question in a multi-question prompt: step past it.
       groups.push({ raw: ASK_NEXT_TAB })

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -61,10 +61,12 @@ function parseOptions(raw: unknown): AskOption[] {
         typeof option === 'object' &&
         typeof (option as { label?: unknown }).label === 'string'
       ) {
-        const value = option as { label: string; description?: unknown }
+        const value = option as { label: string; description?: unknown; preview?: unknown }
         return {
           label: value.label,
-          description: typeof value.description === 'string' ? value.description : undefined
+          description: typeof value.description === 'string' ? value.description : undefined,
+          hasPreview:
+            typeof value.preview === 'string' && value.preview.length > 0 ? true : undefined
         }
       }
       return null
@@ -188,11 +190,20 @@ const ASK_PREVIOUS_ROW = '\x1b[A'
 const ASK_NEXT_ROW = '\x1b[B'
 const ASK_NOTES = '\t'
 
+/** True once any option in the question carries a preview snippet — the
+ *  selector then switches to a list+preview layout where a digit only moves
+ *  the highlight, and a separate Enter commits it. */
+function questionHasPreview(q: AskQuestion): boolean {
+  return q.options.some((o) => o.hasPreview === true)
+}
+
 /** Build the ordered keystroke groups that answer a Claude Code AskUserQuestion.
  *  Each group is written a step apart so the selector applies it before the next.
  *
  *  - single-select pick  → the option number (selects AND commits; in a
- *    multi-question prompt it auto-advances to the next question)
+ *    multi-question prompt it auto-advances to the next question) — except when
+ *    the question has a preview-style layout, where the digit only highlights
+ *    and a following Enter commits it
  *  - free-text answer    → the "Type something" row number, the text, then Enter
  *  - multi-select        → each option number TOGGLES its checkbox, then a step
  *    to the Submit tab
@@ -234,6 +245,9 @@ export function buildAskAnswerKeys(
       )
     } else if ((sel?.indices.length ?? 0) > 0) {
       groups.push({ raw: String(sel!.indices[0]! + 1) })
+      if (questionHasPreview(q)) {
+        groups.push({ raw: ASK_ENTER })
+      }
     } else if (multiQuestion) {
       // Unanswered question in a multi-question prompt: step past it.
       groups.push({ raw: ASK_NEXT_TAB })

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -194,8 +194,7 @@ const ASK_NEXT_ROW = '\x1b[B'
 const ASK_NOTES = '\t'
 // The preview layout has no "Type something" row (upstream
 // anthropics/claude-code#27348, closed "not planned"). Free text goes through a
-// per-option note instead: `n` opens a note on the highlighted row, and the
-// typed text submits as a note-only answer that carries no option selection.
+// per-option note instead: `n` opens the notes field on the highlighted row.
 const ASK_PREVIEW_NOTE = 'n'
 
 /** True once any option in the question carries a preview snippet — the
@@ -208,22 +207,20 @@ function questionHasPreview(q: AskQuestion): boolean {
 /** Answer a preview-layout question, whose row set and commit semantics differ
  *  from the plain selector: no "Type something" row, and a digit only highlights.
  *
- *  Free text always delivers through a note, which the tool result carries as an
- *  annotation with no option counted as selected — so an answer that has BOTH a
- *  pick and free text folds the label into the note text rather than dropping
- *  either. Combining a committed pick with a note in one sequence is unmeasured. */
+ *  A note attaches to whichever row is selected, so free text alongside a pick
+ *  selects that row first and annotates it; free text alone opens a note on the
+ *  highlighted row and delivers with no option counted as selected. */
 function buildPreviewAnswerKeys(
-  q: AskQuestion,
   sel: AskAnswerSelection | undefined,
   other: string
 ): AskAnswerKeyGroup[] {
+  const picked = sel?.indices[0]
   if (other) {
-    const labels = answerLabels(q, sel).filter((label) => label !== other)
-    const note = labels.length > 0 ? `${labels.join(', ')} — ${other}` : other
-    return [{ raw: ASK_PREVIEW_NOTE }, { text: note }, { raw: ASK_ENTER }]
+    const selectRow: AskAnswerKeyGroup[] = picked === undefined ? [] : [{ raw: String(picked + 1) }]
+    return [...selectRow, { raw: ASK_PREVIEW_NOTE }, { text: other }, { raw: ASK_ENTER }]
   }
-  if ((sel?.indices.length ?? 0) > 0) {
-    return [{ raw: String(sel!.indices[0]! + 1) }, { raw: ASK_ENTER }]
+  if (picked !== undefined) {
+    return [{ raw: String(picked + 1) }, { raw: ASK_ENTER }]
   }
   return []
 }
@@ -267,7 +264,7 @@ export function buildAskAnswerKeys(
       // when this is the last question).
       groups.push({ raw: ASK_NEXT_TAB })
     } else if (questionHasPreview(q)) {
-      const previewGroups = buildPreviewAnswerKeys(q, sel, other)
+      const previewGroups = buildPreviewAnswerKeys(sel, other)
       if (previewGroups.length > 0) {
         groups.push(...previewGroups)
       } else if (multiQuestion) {


### PR DESCRIPTION
> **Stacked on #16914** — its commit rides along until that PR merges; this PR's own changes are the last two commits (`1f5834ba`, `b3610466`).

## ELI5

#16914 taught the Chat card to deliver preview-style AskUserQuestion answers correctly. This PR fixes the other half of the bug: Orca no longer assumes an answer worked just because the keystrokes were written to the terminal. The card's dismissal is now provisional — if nothing confirms the agent actually received the answer, the question card comes back, instead of the chat showing a "working" animation over a session that is actually blocked waiting on the user.

## What Changed

- Answering a question card no longer clears the pane's waiting state on keystroke delivery; the answered-question inference now runs only behind an explicit confirmation ([use-native-chat-interactive-send.ts](https://github.com/fbartho/orca/blob/b361046649bd52e0970294771b05913ad05f5944/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts#L117-L168)).
- Confirmation is the card's resolved content key changing — both real signals already drive it: the transcript tool-result landing for the ask, or a fresh hook status clearing the prompt. No new polling or terminal scraping.
- If no confirmation arrives by a deadline after the send settles, the dismissed card is restored and answerable again ([NativeChatInteractiveCard.tsx](https://github.com/fbartho/orca/blob/b361046649bd52e0970294771b05913ad05f5944/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx#L89-L134)).
- Deadline: `max(settleAfterMs, 1000ms) + 6000ms` ([native-chat-answer-confirmation.ts](https://github.com/fbartho/orca/blob/b361046649bd52e0970294771b05913ad05f5944/src/renderer/src/components/native-chat/native-chat-answer-confirmation.ts)) — it scales with the send's own keystroke pacing so it cannot fire mid-send; the grace period is deliberately generous because re-showing a card over an already-answered question is worse than a few extra seconds before revealing a blocked session. Tests pin the scaling relationship, not the constant.
- `sendRuntimePtyInputVerified` keeps its behavior; its comment now states what the boolean does and does not prove. The permissive fallback is load-bearing: SSH-owned and mobile-driven ptys return unacknowledged writes by design, and seven call sites (paste drafts, follow-ups, typed commands) depend on continuing past them.
- Nine new tests for the unconfirmed-answer state machine, plus two reshaped tests that previously asserted the old contract (delivery clears the wait).
- Follow-up commits from cancellation validation: a question the transcript shows resolved (e.g. cancelled in the terminal — Claude Code writes an `is_error` tool-result but no hook event) is now retired by resolution itself, via a central same-ask predicate that respects the existing FIFO-orphan protections; retiring an ask also cancels any still-scheduled answer keystrokes, so nothing types into a terminal whose selector is gone. A resolved verdict survives later turn boundaries and is only re-armed by a genuine re-ask.

## Why

The false "in progress" animation in #16865 was not a rendering glitch — on write-acceptance, Orca inferred the question was answered and force-cleared the pane's waiting state, and the dismissed card only returned if the prompt cleared, which a failed delivery never does. Any future semantic delivery failure (a CLI selector change, a new question layout) would reproduce the same silent stall. This change makes the failure mode visible and recoverable instead of relying on the keystroke contract always being right.

One accepted edge: if the agent answers an ask and immediately poses a byte-identical new question, the unchanged card key reads as "unconfirmed" and the card is re-shown at the deadline — the user sees the correct live question either way; erring in this direction never hides a live question.

While validating cancellation we observed confusing Escape-key behavior around the question card (the card's X sends Escape to the agent's terminal; the Escape key itself does nothing on the card). We're still investigating and may file it separately — this PR does not change any of that behavior.

## Linked Issue

Fixes #16865 (the state-misrepresentation half; #16914 covers the keystroke-delivery half)

## Visual Proof

Before: https://github.com/user-attachments/assets/2c74ec0e-8dd0-4bb1-a7cd-883ce54842f1
_notice: the 3-choice question with previews vanishes, and doesn't reopen even though still visible in terminal_
After: https://github.com/user-attachments/assets/0f7fe538-d675-49f5-a547-f04e81102461
_the question reopens automatically if it didn't submit_



## Testing

- Unit tests cover: failed delivery → card returns with the wait held; confirmed delivery → stays dismissed; replacement question; hook winning the race mid-window; ESC cancel; deadline scaling with keystroke pacing. Each new test was mutation-checked (reverting each half of the fix makes specific tests fail).
- `pnpm tc` clean; `pnpm test` across `native-chat`, `runtime`, and `terminal-pane` renderer suites: 5,754 tests passing; oxlint tiers clean on changed files (two pre-existing react-doctor warnings on the card file predate this change).
- Manually tested on macOS in a dev build: happy path end-to-end, the recovery path with a simulated failed delivery, and the cancellation path (terminal-side cancel via the card's X: the card retires and stays gone once the transcript read settles). Known transient: on a chat/terminal view switch, a just-cancelled question can flash briefly while the transcript re-reads — that render path predates this PR and now self-corrects instead of persisting.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude Code under my direction; I reviewed the design decisions and the diff.

## Review

Agent review summary: renderer-only state change — no platform APIs, paths, or shortcuts (macOS/Linux/Windows unaffected). SSH/remote: the deadline scales with the same paced send schedule the keystrokes ride, and the pty transport contract is untouched, so SSH paste/draft flows behave as before. Agents: only the Claude-family ask flow changes; Codex, Grok, and omp answer paths are untouched. Mobile: imports none of the changed files (verified by grep); its parallel dismiss path already has a stronger transport signal and never clears pane state. Performance: one timer per answered card, cancelled on confirmation. Security: no new input parsing.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Author

`X handle: @fbartho` but I don't use X. Find me at https://mastodon.social/@fbartho@mastodon.social

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)



