### PR TITLE
Never read an unanswerable hasPty probe as proven PTY absence

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -34101,6 +34101,12 @@ export class OrcaRuntimeService {
           break
         case 'exited':
           provenAbsent = isConfirmedPtyAbsence(unlistedPresence)
+          // The probe positively answered absence, so lost-contact doubt from an
+          // earlier unanswerable probe is stale; leaving it would publish a pane
+          // we hold proof about as `unverifiable`.
+          if (provenAbsent) {
+            this.forgetPtyLivenessVerdict(leaf.ptyId)
+          }
           break
       }
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -34091,8 +34091,13 @@ export class OrcaRuntimeService {
           this.markPtyLivenessUnverifiable(leaf.ptyId, unlistedPresence.reason)
           break
         case 'live':
-          // The rescue observed the pane; any recorded lost-contact doubt is stale.
-          this.forgetPtyLivenessVerdict(leaf.ptyId)
+          // The rescue observed the pane, so recorded lost-contact doubt is stale
+          // — but only clear it while the leaf still publishes as connected.
+          // Dropping it under `connected:false` leaves no verdict at all, and
+          // worker observation reads that pair as a confirmed exit.
+          if (leaf.connected) {
+            this.forgetPtyLivenessVerdict(leaf.ptyId)
+          }
           break
         case 'exited':
           provenAbsent = isConfirmedPtyAbsence(unlistedPresence)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -742,7 +742,9 @@ import {
 } from './mobile-session-terminal-retirement'
 import { retireTerminalSurfaceFromPersistence } from './mobile-session-terminal-persistence-retirement'
 import {
+  isConfirmedPtyAbsence,
   NO_OBSERVING_PROVIDER_REASON,
+  resolveUnlistedPtyPresence,
   SSH_EXIT_UNCONFIRMED_REASON,
   SSH_PROVIDER_UNREGISTERED_REASON,
   type PtyLivenessVerdict
@@ -34069,14 +34071,34 @@ export class OrcaRuntimeService {
     // be legitimately missing from it, and unknown liveness never demotes.
     // The sync hasPty rescue closes the spawn/list race: a just-spawned PTY can
     // register after the inventory snapshot, and federation reads one
-    // connected:false as exited.
-    const provenAbsent =
+    // connected:false as exited. A `null` rescue answer means the probe could
+    // not be asked; that records doubt instead of confirming the absence.
+    const unlistedPresence =
       provenLivePtyIds !== null &&
       leaf.ptyId !== null &&
       !provenLivePtyIds.has(leaf.ptyId) &&
       !leaf.ptyId.startsWith('remote:') &&
-      parseAppSshPtyId(leaf.ptyId) === null &&
-      this.ptyController?.hasPty?.(leaf.ptyId) !== true
+      parseAppSshPtyId(leaf.ptyId) === null
+        ? resolveUnlistedPtyPresence(
+            this.ptyController?.hasPty?.(leaf.ptyId),
+            NO_OBSERVING_PROVIDER_REASON
+          )
+        : null
+    let provenAbsent = false
+    if (unlistedPresence && leaf.ptyId !== null) {
+      switch (unlistedPresence.status) {
+        case 'unverifiable':
+          this.markPtyLivenessUnverifiable(leaf.ptyId, unlistedPresence.reason)
+          break
+        case 'live':
+          // The rescue observed the pane; any recorded lost-contact doubt is stale.
+          this.forgetPtyLivenessVerdict(leaf.ptyId)
+          break
+        case 'exited':
+          provenAbsent = isConfirmedPtyAbsence(unlistedPresence)
+          break
+      }
+    }
     return {
       handle: this.issueHandle(leaf),
       ptyId: leaf.ptyId,

--- a/src/main/runtime/orchestration/coordinator-task-dispatch.test.ts
+++ b/src/main/runtime/orchestration/coordinator-task-dispatch.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../orca-runtime'
+import { getDefaultWorkspaceSession } from '../../../shared/constants'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { listAvailableWorkerTerminals } from './coordinator-task-dispatch'
+import type { OrchestrationDb } from './db'
+
+// Coercion site 4 repro at the orchestration level: a live worker terminal whose
+// pane misses one inventory snapshot while the per-id presence query answers
+// `null` (unanswerable) must stay dispatchable. Pre-fix the `null` was read as
+// proven absence, the summary demoted to connected:false, and the coordinator
+// wrote the worker terminal off.
+
+const WORKTREE_ID = 'repo-1::/tmp/probe-worktree'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+function makeStore() {
+  const session: WorkspaceSessionState = getDefaultWorkspaceSession()
+  return {
+    getWorkspaceSession: vi.fn(() => session),
+    setWorkspaceSession: vi.fn(),
+    getRepos: vi.fn(() => [
+      {
+        id: 'repo-1',
+        path: '/tmp/probe-worktree',
+        displayName: 'probe',
+        badgeColor: '#000000',
+        addedAt: 0
+      }
+    ]),
+    getAllWorktreeMeta: vi.fn(() => ({})),
+    getWorktreeMeta: vi.fn(() => undefined),
+    setWorktreeMeta: vi.fn(),
+    getSettings: vi.fn(() => ({ workspaceDir: '/tmp/workspaces' })),
+    getProjects: vi.fn(() => [])
+  }
+}
+
+function makeRuntimeWithLeaf(options: {
+  leafPtyId: string
+  controllerSessions: { id: string; cwd: string }[]
+  hasPty: (ptyId: string) => boolean | null
+}): OrcaRuntimeService {
+  const runtime = new OrcaRuntimeService(makeStore() as never)
+  runtime.setPtyController({
+    spawn: vi.fn(async () => ({ id: 'never' })),
+    write: () => true,
+    kill: () => true,
+    hasPty: options.hasPty,
+    listProcesses: vi.fn(async () => options.controllerSessions)
+  } as never)
+  runtime.attachWindow(1)
+  runtime.syncWindowGraph(1, {
+    tabs: [
+      {
+        tabId: 'tab-1',
+        worktreeId: WORKTREE_ID,
+        title: '',
+        activeLeafId: LEAF_ID,
+        layout: null
+      }
+    ],
+    leaves: [
+      {
+        tabId: 'tab-1',
+        worktreeId: WORKTREE_ID,
+        leafId: LEAF_ID,
+        paneRuntimeId: 1,
+        ptyId: options.leafPtyId,
+        paneTitle: null,
+        title: ''
+      }
+    ]
+  })
+  return runtime
+}
+
+const idleDb = {
+  listTasks: vi.fn(() => []),
+  getDispatchContext: vi.fn(() => undefined)
+} as unknown as OrchestrationDb
+
+describe('listAvailableWorkerTerminals liveness truth', () => {
+  it('keeps a worker terminal dispatchable when its presence query cannot answer', async () => {
+    const runtime = makeRuntimeWithLeaf({
+      leafPtyId: 'pty-worker-unqueryable',
+      controllerSessions: [],
+      hasPty: () => null
+    })
+    const { terminals } = await runtime.listTerminals(`id:${WORKTREE_ID}`)
+    expect(terminals).toHaveLength(1)
+
+    const available = await listAvailableWorkerTerminals(
+      idleDb,
+      runtime,
+      'term_coordinator-elsewhere',
+      `id:${WORKTREE_ID}`
+    )
+
+    expect(available).toEqual([terminals[0].handle])
+  })
+
+  it('still excludes a worker terminal whose absence the controller confirmed', async () => {
+    const runtime = makeRuntimeWithLeaf({
+      leafPtyId: 'pty-worker-exited',
+      controllerSessions: [],
+      hasPty: () => false
+    })
+
+    const available = await listAvailableWorkerTerminals(
+      idleDb,
+      runtime,
+      'term_coordinator-elsewhere',
+      `id:${WORKTREE_ID}`
+    )
+
+    expect(available).toEqual([])
+  })
+})

--- a/src/main/runtime/terminal-list-stale-leaf-liveness.test.ts
+++ b/src/main/runtime/terminal-list-stale-leaf-liveness.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { OrcaRuntimeService } from './orca-runtime'
 import { getDefaultWorkspaceSession } from '../../shared/constants'
+import { NO_OBSERVING_PROVIDER_REASON } from '../../shared/pty-liveness-verdict'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 
 // run6-review-pr-11959 repro: leaf.connected mirrors the graph (`ptyId !== null`),
@@ -146,6 +147,83 @@ describe('listTerminals liveness truth for restored leaves', () => {
       connected: true,
       writable: true
     })
+  })
+
+  // Coercion site 4 of the failure-becomes-fact class: `hasPty` answering `null`
+  // means "the query could not be answered" — the controller adapter returns it
+  // for a failed provider lookup or a probe-less provider. That is doubt, never
+  // a confirmation of the inventory's absence, so it must not demote the pane.
+  it('keeps a leaf connected when the per-id presence query cannot answer (null)', async () => {
+    const runtime = makeRuntimeWithLeaf({
+      leafPtyId: 'pty-unqueryable',
+      controllerSessions: [],
+      hasPty: () => null
+    })
+
+    const { terminals } = await runtime.listTerminals(`id:${WORKTREE_ID}`)
+
+    expect(terminals).toHaveLength(1)
+    expect(terminals[0]).toMatchObject({
+      ptyId: 'pty-unqueryable',
+      connected: true,
+      writable: true
+    })
+    // The unanswerable query is recorded as its own answer, so worker
+    // observation reports `unverifiable` instead of inventing a verdict.
+    expect(runtime.getPtyLivenessVerdict('pty-unqueryable')).toEqual({
+      status: 'unverifiable',
+      reason: NO_OBSERVING_PROVIDER_REASON
+    })
+  })
+
+  it('still demotes on an observed-false answer, with no doubt recorded', async () => {
+    const runtime = makeRuntimeWithLeaf({
+      leafPtyId: 'pty-proven-absent',
+      controllerSessions: [],
+      hasPty: () => false
+    })
+
+    const { terminals } = await runtime.listTerminals(`id:${WORKTREE_ID}`)
+
+    expect(terminals).toHaveLength(1)
+    expect(terminals[0]).toMatchObject({
+      ptyId: 'pty-proven-absent',
+      connected: false,
+      writable: false
+    })
+    expect(runtime.getPtyLivenessVerdict('pty-proven-absent')).toBeNull()
+  })
+
+  it('clears recorded doubt when the presence query later proves the pane live', async () => {
+    let answer: boolean | null = null
+    const runtime = makeRuntimeWithLeaf({
+      leafPtyId: 'pty-recovering',
+      controllerSessions: [],
+      hasPty: () => answer
+    })
+
+    await runtime.listTerminals(`id:${WORKTREE_ID}`)
+    expect(runtime.getPtyLivenessVerdict('pty-recovering')?.status).toBe('unverifiable')
+
+    answer = true
+    const { terminals } = await runtime.listTerminals(`id:${WORKTREE_ID}`)
+    expect(terminals[0]).toMatchObject({ connected: true, writable: true })
+    expect(runtime.getPtyLivenessVerdict('pty-recovering')).toBeNull()
+  })
+
+  it('never consults the per-id probe for panes the inventory already lists', async () => {
+    const hasPty = vi.fn(() => null)
+    const runtime = makeRuntimeWithLeaf({
+      leafPtyId: 'pty-live-listed',
+      controllerSessions: [{ id: 'pty-live-listed', cwd: '/tmp/probe-worktree' }],
+      hasPty
+    })
+
+    const { terminals } = await runtime.listTerminals(`id:${WORKTREE_ID}`)
+
+    expect(terminals[0]).toMatchObject({ connected: true, writable: true })
+    expect(hasPty).not.toHaveBeenCalled()
+    expect(runtime.getPtyLivenessVerdict('pty-live-listed')).toBeNull()
   })
 
   it('does not demote remote-runtime-scoped leaves the local inventory never covers', async () => {

--- a/src/main/runtime/terminal-list-stale-leaf-liveness.test.ts
+++ b/src/main/runtime/terminal-list-stale-leaf-liveness.test.ts
@@ -195,6 +195,27 @@ describe('listTerminals liveness truth for restored leaves', () => {
     expect(runtime.getPtyLivenessVerdict('pty-proven-absent')).toBeNull()
   })
 
+  // A confirmed absence is positive evidence of the exit, so lost-contact doubt
+  // recorded by an earlier unanswerable probe is stale. Publishing
+  // `connected:false` while still reporting `unverifiable` would under-report a
+  // pane we hold proof about.
+  it('clears recorded doubt when the presence query later proves the pane absent', async () => {
+    let answer: boolean | null = null
+    const runtime = makeRuntimeWithLeaf({
+      leafPtyId: 'pty-doubted-then-absent',
+      controllerSessions: [],
+      hasPty: () => answer
+    })
+
+    await runtime.listTerminals(`id:${WORKTREE_ID}`)
+    expect(runtime.getPtyLivenessVerdict('pty-doubted-then-absent')?.status).toBe('unverifiable')
+
+    answer = false
+    const { terminals } = await runtime.listTerminals(`id:${WORKTREE_ID}`)
+    expect(terminals[0]).toMatchObject({ connected: false, writable: false })
+    expect(runtime.getPtyLivenessVerdict('pty-doubted-then-absent')).toBeNull()
+  })
+
   it('clears recorded doubt when the presence query later proves the pane live', async () => {
     let answer: boolean | null = null
     const runtime = makeRuntimeWithLeaf({

--- a/src/main/runtime/terminal-list-stale-leaf-liveness.test.ts
+++ b/src/main/runtime/terminal-list-stale-leaf-liveness.test.ts
@@ -10,6 +10,7 @@ import type { WorkspaceSessionState } from '../../shared/workspace-session-state
 
 const WORKTREE_ID = 'repo-1::/tmp/probe-worktree'
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const STOP_UNVERIFIED_REASON = 'a follow-up stop was issued but its outcome could not be verified'
 
 function makeStore() {
   const session: WorkspaceSessionState = getDefaultWorkspaceSession()
@@ -209,6 +210,29 @@ describe('listTerminals liveness truth for restored leaves', () => {
     const { terminals } = await runtime.listTerminals(`id:${WORKTREE_ID}`)
     expect(terminals[0]).toMatchObject({ connected: true, writable: true })
     expect(runtime.getPtyLivenessVerdict('pty-recovering')).toBeNull()
+  })
+
+  // A stop nobody confirmed records doubt while the exit marks the leaf
+  // disconnected. Clearing that doubt on a live rescue answer would publish
+  // `connected:false` with no verdict on record, and worker observation reads
+  // exactly that pair as a confirmed exit.
+  it('keeps recorded doubt for a disconnected leaf the presence query answers live', async () => {
+    const runtime = makeRuntimeWithLeaf({
+      leafPtyId: 'pty-unstopped',
+      controllerSessions: [],
+      hasPty: () => true
+    })
+    runtime.markPtyLivenessUnverifiable('pty-unstopped', STOP_UNVERIFIED_REASON)
+    // A synthetic -1 from an unverified stop is not a death certificate.
+    runtime.onPtyExit('pty-unstopped', -1)
+
+    const { terminals } = await runtime.listTerminals(`id:${WORKTREE_ID}`)
+
+    expect(terminals[0]).toMatchObject({ ptyId: 'pty-unstopped', connected: false })
+    expect(runtime.getPtyLivenessVerdict('pty-unstopped')).toEqual({
+      status: 'unverifiable',
+      reason: STOP_UNVERIFIED_REASON
+    })
   })
 
   it('never consults the per-id probe for panes the inventory already lists', async () => {

--- a/src/shared/pty-liveness-verdict.ts
+++ b/src/shared/pty-liveness-verdict.ts
@@ -11,6 +11,44 @@ export type PtyLivenessVerdict =
   | { status: 'live'; ptyIds: string[] }
   | { status: 'unverifiable'; reason: string }
 
+/**
+ * A pane-presence observation resolved from the controller's synchronous
+ * per-id `hasPty` answer, for a pane a successful aggregate inventory did not
+ * list.
+ *
+ * `exited` requires a confirmed answer: an observed `false` from the pane's
+ * controller, or a controller with no per-id probe at all — there the
+ * successful inventory that failed to list the pane stays the authority. A
+ * `null` answer means the probe exists but could not be answered (a failed
+ * provider lookup, a probe-less provider behind the adapter); that is
+ * `unverifiable`, never absence.
+ */
+export type PtyPresenceObservation =
+  | { status: 'live' }
+  | { status: 'exited' }
+  | { status: 'unverifiable'; reason: string }
+
+/** A presence answer with the doubt arm excluded: the only shape a demotion decision may consume. */
+export type ConfirmedPtyPresence = Exclude<PtyPresenceObservation, { status: 'unverifiable' }>
+
+export function resolveUnlistedPtyPresence(
+  hasPtyAnswer: boolean | null | undefined,
+  unverifiableReason: string
+): PtyPresenceObservation {
+  if (hasPtyAnswer === true) {
+    return { status: 'live' }
+  }
+  if (hasPtyAnswer === null) {
+    return { status: 'unverifiable', reason: unverifiableReason }
+  }
+  return { status: 'exited' }
+}
+
+/** Typed demotion gate: `unverifiable` is not assignable here, so doubt cannot demote. */
+export function isConfirmedPtyAbsence(presence: ConfirmedPtyPresence): boolean {
+  return presence.status === 'exited'
+}
+
 export const SSH_PROVIDER_UNREGISTERED_REASON = 'its SSH provider is no longer registered'
 export const NO_OBSERVING_PROVIDER_REASON = 'no registered provider can observe its host'
 export const SSH_EXIT_UNCONFIRMED_REASON = 'the owning SSH host did not confirm the PTY exit'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​242 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​242 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​75 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |

<!-- /orca-pr-loc -->

## Summary

- resolve the terminal-list "proven absence" rescue through an exhaustive `live | unverifiable | exited` presence observation instead of `hasPty !== true`
- a `null` (unanswerable) per-pane presence answer now records an `unverifiable` liveness verdict instead of demoting the pane to `connected:false`
- a later confirmed `live` observation clears the recorded doubt; a confirmed `false` still demotes exactly as before

Author: @BrennanKB5

## ELI5

Orca keeps a list of your terminals and asks the terminal engine "does this pane still have a live process?" The engine has three honest answers: "yes", "no", and "I couldn't check right now." Before this fix, "I couldn't check right now" was treated the same as "no" — so a terminal whose agent was alive and working could be shown as disconnected, and the orchestrator would write the worker off. Now "I couldn't check" is kept as its own answer: the pane stays connected, the doubt is recorded, and it's re-checked on the next look.

## User-facing before / after

**When you'd hit this:** you're coordinating worker agents in Orca terminals (or just running `orca terminal list`) at a moment when the PTY backend can't answer the per-pane presence probe — e.g. the daemon-backed provider is mid-restart/being swapped, or the pane's provider lookup fails — and the same refresh's inventory snapshot happens to miss that pane.

**Before:** the pane flips to `disconnected` in `terminal.list` / `orca terminal list`, the coordinator's availability filter drops that worker terminal from the dispatchable pool, and worker/federation status surfaces read the pane's `connected:false` as *exited* — while the agent process is alive and still working. A live worker gets written off from one unanswerable query.

**After:** the pane stays `connected` in the list, and the unanswerable query is recorded as an `unverifiable` liveness verdict with a reason — the same verdict vocabulary `orchestration.workerShow` / `federationShow` already publish — so observation surfaces say "unverifiable", never "exited", until a confirmed answer arrives. A confirmed "no" (the engine positively observed the pane absent) demotes exactly as before, and a confirmed "yes" clears any recorded doubt.

## Reliability contract

- **Invariant:** an unanswerable pane-presence query can never become a confirmed "no PTY". `exited` requires positive evidence; loss of the ability to ask is `unverifiable` (docs/reference/ssh-execution-boundary.md rule 2).
- **Failure source:** `buildTerminalSummary`'s rescue read `hasPty !== true`, so the controller adapter's documented `null` ("the query could not be answered": failed provider lookup, probe-less provider, probe threw) counted as proof of absence.
- **Type carry:** the answer resolves through `PtyPresenceObservation` (`live | exited | unverifiable`); the demotion gate `isConfirmedPtyAbsence(presence: ConfirmedPtyPresence)` excludes the `unverifiable` arm at the type level — doubt is not assignable where a confirmed answer is expected. No casts or widenings.
- **Oracle:** pre-fix, the new tests fail with `connected:false`, no recorded verdict, and `listAvailableWorkerTerminals` returning `[]` for a live worker terminal; the pre-existing inventory-absence, hasPty-rescue, SSH/remote-exclusion, and unavailable-inventory tests all still pass unchanged.
- **Ablation:** each production hunk reverted individually goes red — resolver `null` arm (3 tests), unverifiable-marking arm (2), live-rescue forget arm (1), exited demotion arm (3, including the pre-existing proven-absence test).
- **Consumers checked** (all readers of the changed field/verdict): coordinator `listAvailableWorkerTerminals` (now keeps the terminal dispatchable); CLI `terminal list` formatter (prints connected truthfully); `resolveGroupAddress`, plugin `listWorktreeTerminals`, federation/topology terminal-effect recorders, and the active-terminal fallback (none read `connected` — unaffected); renderer `remote-worktree-sleep` (reads `connected === true` for ssh panes, which this predicate never demoted); verdict readers `inspectWorkerTerminal` (workerShow/workerRead/workerStop/release-completion) and `inspectRemoteAttachment` (federationShow/Read/ReadOutput/Stop) — both branch on `unverifiable` before the `connected === false → exited` fallback; `unverifiableStopVerdict` keeps a failed stop unverifiable.
- **Remote wire:** no RPC params, stream frames, or opcodes change. Value-level (Rule 3) review: `terminal.list` stops publishing a false `connected:false` during an unanswerable blip (old clients read `connected:true` exactly as before), and `observation.status: 'unverifiable'` can occur in a window that previously misreported — that value and its `reason` field already ship on these surfaces, so mixed-version peers parse it today. No capability gating needed.
- **Performance:** the inventory-hit path short-circuits before the probe (pinned by test) — zero added work; the missed-pane path makes the same single sync `hasPty` call as before plus O(1) writes to the existing 256-capped verdict map. No new polling, timers, subprocesses, or unbounded state.
- **Residual risk:** a provider that answers a confident-but-wrong `false` for a pane it does not own (e.g. the pre-swap local provider during daemon startup) is a separate coercion site of this class and is deliberately not touched here, matching the sibling-site split in #16900/#16908/#16926.

## Verification

- `pnpm test src/main/runtime/terminal-list-stale-leaf-liveness.test.ts src/main/runtime/orchestration/coordinator-task-dispatch.test.ts` (12/12 post-fix; 3 fail pre-fix)
- `pnpm test src/main/runtime/orca-runtime.test.ts` (1213 passed) and `src/main/runtime` liveness + `src/main/runtime/rpc` suites (201 files, 1695 passed)
- `pnpm tc` (all projects), `oxlint` + `oxfmt --check` on changed files (lint gate proven live with a canary)
