### PR TITLE
fix(native-chat): keep Hangul composition intact while a turn streams

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -1,4 +1,12 @@
-import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import {
+  forwardRef,
+  memo,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import { useAppStore } from '../../store'
 import { sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
@@ -31,6 +39,7 @@ import { useNativeChatComposerAttachments } from './use-native-chat-composer-att
 import { useNativeChatComposerPaste } from './use-native-chat-composer-paste'
 import { useNativeChatExternalAttachments } from './use-native-chat-external-attachments'
 import { useNativeChatComposerKeyDown } from './use-native-chat-composer-keydown'
+import { useNativeChatComposerDraftChange } from './use-native-chat-composer-draft-change'
 import { useNativeChatSendLifecycle } from './use-native-chat-send-lifecycle'
 import { useNativeChatSessionOptions } from './use-native-chat-session-options'
 import { useNativeChatFileAttachmentActions } from './use-native-chat-file-attachment-actions'
@@ -63,8 +72,9 @@ const ESC = '\x1b'
  * Slash-command and `@file` autocomplete are agent-aware; image paste persists a
  * temp file and injects the agent-appropriate path (or reports unsupported).
  */
-export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeChatComposerProps>(
-  function NativeChatComposer(
+// memo: a streaming re-render here rewrites the controlled textarea mid-composition.
+export const NativeChatComposer = memo(
+  forwardRef<NativeChatComposerHandle, NativeChatComposerProps>(function NativeChatComposer(
     {
       terminalTabId,
       paneKey,
@@ -380,16 +390,16 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
       setHistory
     })
 
-    const handleDraftChange = useCallback(
-      (value: string, element: HTMLTextAreaElement) => {
-        setDraft(value)
-        setHistory((prev) => ({ entries: prev.entries, index: null }))
-        syncCaret(element)
-        handleDraftOrCaretChange(value, element.selectionStart ?? value.length)
-        setActiveSuggestion(0)
-      },
-      [handleDraftOrCaretChange, setDraft, syncCaret]
-    )
+    const { handleDraftChange, handleCaretChange, handleCompositionEnd } =
+      useNativeChatComposerDraftChange({
+        draft,
+        isComposingRef,
+        setDraft,
+        syncCaret,
+        setHistory,
+        setActiveSuggestion,
+        handleDraftOrCaretChange
+      })
 
     return (
       <NativeChatComposerField
@@ -409,21 +419,12 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
         isDictating={isDictating}
         isDictationHoldMode={isDictationHoldMode}
         onDraftChange={handleDraftChange}
-        onTextareaSelect={(element) => {
-          syncCaret(element)
-          handleDraftOrCaretChange(element.value, element.selectionStart ?? element.value.length)
-          setActiveSuggestion(0)
-        }}
+        onTextareaSelect={handleCaretChange}
         onKeyDown={handleKeyDown}
         onCompositionStart={() => {
           isComposingRef.current = true
         }}
-        onCompositionEnd={(event) => {
-          isComposingRef.current = false
-          if (event.currentTarget.value !== draft) {
-            handleDraftChange(event.currentTarget.value, event.currentTarget)
-          }
-        }}
+        onCompositionEnd={(event) => handleCompositionEnd(event.currentTarget)}
         onPaste={handlePaste}
         pickerListboxId={picker.listboxId}
         onChoosePickerItem={completeItem}
@@ -450,5 +451,5 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
         sessionOptionsSnapshot={sessionOptionsSnapshot}
       />
     )
-  }
+  })
 )

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-draft-change.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-draft-change.ts
@@ -1,0 +1,95 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react'
+import type { HistoryState } from './native-chat-composer-state'
+
+export type NativeChatComposerDraftChange = {
+  /** `onChange` for the composer textarea. */
+  handleDraftChange: (value: string, element: HTMLTextAreaElement) => void
+  /** `onSelect` for the composer textarea. */
+  handleCaretChange: (element: HTMLTextAreaElement) => void
+  /** `onCompositionEnd` for the composer textarea; clears the composing flag. */
+  handleCompositionEnd: (element: HTMLTextAreaElement) => void
+}
+
+/**
+ * Splits the composer's per-keystroke work into the half that must run on every
+ * input event and the half that only has to be right once a character is
+ * committed.
+ *
+ * Why: a Hangul IME emits one input event per jamo, so a three-jamo syllable
+ * runs this path three times for one visible character (and any CJK IME does the
+ * same over a longer preedit). The draft and caret have to stay in sync on every
+ * one of them — the textarea is controlled, so a stale `draft` would be written
+ * back over the live preedit — but the derived state (picker derivation, history
+ * index reset, suggestion reset) is only meaningful for committed text.
+ */
+export function useNativeChatComposerDraftChange(args: {
+  draft: string
+  isComposingRef: { current: boolean }
+  setDraft: (value: string) => void
+  syncCaret: (element: HTMLTextAreaElement) => void
+  setHistory: Dispatch<SetStateAction<HistoryState>>
+  setActiveSuggestion: Dispatch<SetStateAction<number>>
+  handleDraftOrCaretChange: (value: string, caret: number) => void
+}): NativeChatComposerDraftChange {
+  const {
+    draft,
+    isComposingRef,
+    setDraft,
+    syncCaret,
+    setHistory,
+    setActiveSuggestion,
+    handleDraftOrCaretChange
+  } = args
+
+  const applyDerived = useCallback(
+    (value: string, caret: number) => {
+      setHistory((prev) => ({ entries: prev.entries, index: null }))
+      handleDraftOrCaretChange(value, caret)
+      setActiveSuggestion(0)
+    },
+    [handleDraftOrCaretChange, setActiveSuggestion, setHistory]
+  )
+
+  const handleDraftChange = useCallback(
+    (value: string, element: HTMLTextAreaElement) => {
+      setDraft(value)
+      syncCaret(element)
+      if (isComposingRef.current) {
+        return
+      }
+      applyDerived(value, element.selectionStart ?? value.length)
+    },
+    [applyDerived, isComposingRef, setDraft, syncCaret]
+  )
+
+  const handleCaretChange = useCallback(
+    (element: HTMLTextAreaElement) => {
+      syncCaret(element)
+      // The IME moves the selection on every preedit keystroke; the picker only
+      // needs the caret the user actually committed to.
+      if (isComposingRef.current) {
+        return
+      }
+      applyDerived(element.value, element.selectionStart ?? element.value.length)
+    },
+    [applyDerived, isComposingRef, syncCaret]
+  )
+
+  const handleCompositionEnd = useCallback(
+    (element: HTMLTextAreaElement) => {
+      isComposingRef.current = false
+      const committed = element.value
+      if (committed !== draft) {
+        handleDraftChange(committed, element)
+        return
+      }
+      // The composing keystrokes already adopted this value, so re-adopting it
+      // would be a duplicate write. Only the derived work they deferred is still
+      // owed — without it the picker keeps looking at pre-composition text.
+      applyDerived(committed, element.selectionStart ?? committed.length)
+    },
+    [applyDerived, draft, handleDraftChange, isComposingRef]
+  )
+
+  return { handleDraftChange, handleCaretChange, handleCompositionEnd }
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  startTransition,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import {
   NATIVE_CHAT_SOURCE_PRIORITY,
   type AgentType,
@@ -268,7 +276,10 @@ export function useNativeChatLiveSession(
         }
         transcriptLifecycleControl.append(frame.lifecycle)
         // Merge by id then bound to the window; the base read + assembler re-dedup mean trimming the append tail can't drop a covered turn (#6).
-        setAppended(applyAppend(appendMergerRef.current, frame.messages, limitRef.current))
+        const merged = applyAppend(appendMergerRef.current, frame.messages, limitRef.current)
+        // Non-urgent so an in-flight streaming render yields to the user's next
+        // keystroke; the replace path above stays urgent so a reset is never late.
+        startTransition(() => setAppended(merged))
       }
     )
 


### PR DESCRIPTION
## ELI5

When an agent is streaming a reply, typing Korean into the Native Chat box used to lose and mangle syllables: every incoming chunk re-rendered the box and overwrote the half-finished character before it could be committed. This makes the box stop fighting the IME.

## What Changed

The transcript watcher emits one frame per 40ms debounce, and each landed as an **urgent** `setAppended` in `use-native-chat-live-session.ts`, so React could not interrupt it. That render redraws `NativeChatView`, whose pass contains both the (non-virtualized) message list and the composer — and the composer's textarea is controlled, so every frame rewrote its DOM value, including while an IME composition was in flight.

- the tail append is now a transition, so an in-flight streaming render yields to the user's next keystroke; the authoritative replace path stays urgent, so a session reset is never shown late
- `NativeChatComposer` is memoized, so a message change no longer re-renders it. Its props are strings, booleans and `useCallback`s, and the launch-draft signal is spread, so a shallow compare actually holds
- the composer's derived work — picker derivation over the command/skill catalog, history-index reset, suggestion reset — is deferred to `compositionend`. The draft and caret still sync on every input event, because the controlled textarea would otherwise write a stale draft over the live preedit. That logic moved into `use-native-chat-composer-draft-change.ts`, which also brings `onSelect` under the same guard; it previously ran the derived work on every preedit selection change

## Why

This is not a general "typing is slow" problem. A plain keypress goes straight to the pty, so nothing is ever drawn ahead of it. A CJK preedit lives only in the renderer until it commits, and that window is exactly what a streaming re-render can trample.

## Linked Issue

Fixes #16911

Refs #12829 (same class, wider scope — search fields and the macOS candidate window are not addressed here), #16260 (proposes the same composition guard, app-wide).

## Visual Proof

`N/A` — nothing in the layout changes, and the defect is a character that fails to survive one frame. Measured instead, on the dev build over a 14s window, 16 composed syllables, ~105 transcript frames, ~1200 DOM nodes in the chat:

| | before | after |
|---|---|---|
| frames the textarea held a value other than the committed one | 111 | **0** |
| main thread blocked (long tasks) | 49% | **5–9%** |
| commit → paint p50 / p95 | 74.9 / 140.4ms | **32.6 / 76.5ms** |
| syllables that never settled | 2 of 16 | **0** |

One run out of several measured 46% blocked with a larger transcript (~1670 DOM nodes), so the win is not uniform at every conversation length — see Known gaps.

## Testing

Reproduced without running an agent: point a pane's `providerSession.transcriptPath` at a synthetic Claude transcript JSONL and append assistant turns every 40ms, then type through the IME. Deterministic and costs no tokens.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

No new test file here: the change is render scheduling and memoization, which the existing `native-chat` suite covers for behavior (74 files, 788 tests pass unchanged). The measurable effect is timing, and the numbers above came from `window.__orcaTypingDiagnostic` plus a page-side probe on the composer.

```
tsc --noEmit (web project)   0 errors
oxlint (repo)                0 errors
vitest src/renderer/src/components/native-chat/   74 files, 788 passed
pnpm run build:desktop       passes
```

Platform: developed and measured on **Windows 11**. This is React render scheduling, so it is not platform-specific; macOS and Linux are unverified by me. `pnpm test` could not run in my environment — the `ensure-native-runtime --runtime=node` prestep fails to rebuild `node-pty` for Node 24 — so vitest was invoked directly.

## AI Disclosure

Written with Claude Opus 5 (Claude Code). Every number above was taken by driving the running app over CDP, not estimated.

## Review

**Cross-platform** — no platform branch added; `navigator` / `process.platform` untouched.

**SSH / remote** — the change is a React scheduling change on frames that have already arrived. No transport, pty, or execution-host code is touched; nothing here reports on, stops, or lists remote work.

**Agents / integrations** — `native-chat` paths are agent-neutral. No provider-specific naming introduced.

**Backwards compatibility** — no wire change: no RPC params, no stream opcodes, no change to what a host publishes.

**Performance** — the point of the change. `startTransition` makes an existing render interruptible rather than adding work; the memo removes renders.

**UI quality** — no visual change. The one behavioral nuance is that the picker and history index now update on commit instead of mid-composition, which is what a user composing a syllable would expect.

**Security** — no new IPC, no new input path, no parsing of user content.

## Known gaps

- The message list is neither memoized nor virtualized. With ~1200 DOM nodes the two changes here bring blocking to 5–9%, but one run at ~1670 nodes measured 46%, so a long enough conversation can still saturate. Virtualization was deliberately not attempted here: it carries scroll-position, search and selection regressions, and the measured headroom did not justify it yet.
- The `reverts` figure counts *frames during which the textarea held a value other than the committed one*, not distinct overwrites. Under a heavier render it inflates for the same underlying event.
