### PR TITLE
fix(gpu): persist the safe-graphics marker before the restart prompt

### DIFF
--- a/src/main/crash-reporting/gpu-crash-fallback-field-sessions.test.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-field-sessions.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
+  DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
+  GpuCrashFallbackTracker,
+  isGpuFallbackCrashCandidate
+} from './gpu-crash-fallback-decision'
+import { shouldRecordProcessGoneCrash } from './process-gone-classification'
+
+/**
+ * Replays the win32 GPU-child deaths from the 1.4.190 'crashed' renderer cluster
+ * through the production decision path, so the reason no host was ever offered
+ * Safe Graphics Mode is pinned rather than argued about.
+ *
+ * Each session below is one crash report's `Recent activity`; a breadcrumb's
+ * `suppressedSinceLast=N` means N further identical GPU deaths were coalesced
+ * into it, so the session saw N+1 GPU crashes.
+ */
+
+type FieldSession = {
+  /** Crash-report id from the field bundle. */
+  report: string
+  /** GPU child crash times, ms since main-process start. */
+  gpuCrashesMsSinceLaunch: number[]
+}
+
+// crashed.txt: every win32 report in the cluster. Times are (breadcrumb ts -
+// mainProcessStartedAt); coalesced repeats are placed inside the same second,
+// which is the only interval the emitted breadcrumb pins them to.
+const CRASHED_CLUSTER_SESSIONS: FieldSession[] = [
+  // 23:36:54.200 - 23:36:49.931, suppressedSinceLast=1 -> 2 crashes
+  { report: 'db1f1ee2', gpuCrashesMsSinceLaunch: [4_269, 4_800] },
+  // 02:58:25.287 - 02:58:20.749, no suppression -> 1 crash
+  { report: '66cc54d8', gpuCrashesMsSinceLaunch: [4_538] },
+  // 21:47:05.776 - 21:46:59.584, suppressedSinceLast=1 -> 2 crashes
+  { report: '1f5564de', gpuCrashesMsSinceLaunch: [6_192, 6_240] },
+  // 00:17:17.840 - 00:17:15.732, no suppression -> 1 crash
+  { report: '96d8c63b', gpuCrashesMsSinceLaunch: [2_108] }
+]
+
+/** index.ts's `child-process-gone` listener body — the wiring these claims rest on. */
+function readChildProcessGoneListener(): string {
+  const source = readFileSync(join(__dirname, '..', 'index.ts'), 'utf8')
+  const start = source.indexOf("app.on('child-process-gone'")
+  expect(start).toBeGreaterThan(0)
+  return source.slice(start, source.indexOf('\n  })', start))
+}
+
+function newTracker(): GpuCrashFallbackTracker {
+  return new GpuCrashFallbackTracker({
+    windowMs: DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
+    threshold: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
+  })
+}
+
+const FIELD_GPU_EVENT = {
+  source: 'child',
+  processType: 'GPU',
+  serviceName: 'GPU',
+  reason: 'crashed',
+  expectedTeardown: 'none'
+} as const
+
+describe('1.4.190 win32 GPU-child crash cluster', () => {
+  it('does not let process_gone_suppressed gate the fallback candidate check', () => {
+    // The GPU death is suppressed as recoverable churn (no user-facing report)...
+    expect(shouldRecordProcessGoneCrash({ ...FIELD_GPU_EVENT, exitCode: -2147483645 })).toBe(false)
+    // ...but the fallback path reads the raw child-process-gone event, so the
+    // suppression cannot hide a broken driver from recovery.
+    expect(
+      isGpuFallbackCrashCandidate({
+        platform: 'win32',
+        processType: 'GPU',
+        reason: 'crashed'
+      })
+    ).toBe(true)
+    // Both assertions above still pass if the candidate check is moved behind the
+    // suppressed-report path, so pin that nothing branches ahead of it in index.ts.
+    const listener = readChildProcessGoneListener()
+    const guardStart = listener.indexOf('isGpuFallbackCrashCandidate(')
+    expect(guardStart).toBeGreaterThan(0)
+    expect(listener.slice(0, guardStart).match(/\bif\s*\(/g) ?? []).toHaveLength(1)
+    expect(listener).toMatch(/isGpuFallbackCrashCandidate\([\s\S]*?void handleGpuChildCrash\(/)
+    // The `if (` count alone still allows `recorded && isGpuFallbackCrashCandidate(...)`, which
+    // re-couples recovery to the suppression decision, so pin the guard to that check alone.
+    const recoveryGuard = listener.slice(
+      listener.lastIndexOf('if (', guardStart),
+      listener.indexOf('void handleGpuChildCrash(')
+    )
+    expect(recoveryGuard).not.toMatch(/&&|\|\|/)
+  })
+
+  it('never reaches the burst threshold in any observed cluster session', () => {
+    const outcomes = CRASHED_CLUSTER_SESSIONS.map((session) => {
+      // Each launch constructs a fresh tracker (src/main/index.ts), so evidence
+      // does not survive the relaunch these users performed after every crash.
+      const tracker = newTracker()
+      const engaged = session.gpuCrashesMsSinceLaunch.some(
+        (at) => tracker.recordGpuCrash(at).shouldEngageFallback
+      )
+      return {
+        report: session.report,
+        gpuCrashes: session.gpuCrashesMsSinceLaunch.length,
+        engagedSafeGraphicsPrompt: engaged
+      }
+    })
+    expect(outcomes).toEqual([
+      { report: 'db1f1ee2', gpuCrashes: 2, engagedSafeGraphicsPrompt: false },
+      { report: '66cc54d8', gpuCrashes: 1, engagedSafeGraphicsPrompt: false },
+      { report: '1f5564de', gpuCrashes: 2, engagedSafeGraphicsPrompt: false },
+      { report: '96d8c63b', gpuCrashes: 1, engagedSafeGraphicsPrompt: false }
+    ])
+  })
+
+  it('engages on the session that did reach three crashes (field launch 51b9e93c)', () => {
+    // oom.txt, win32: GPU crashed/exitCode=34 with suppressedSinceLast=2, then
+    // `gpu_fallback_engaged (crashesInWindow=3)` and `gpu_fallback_restart_deferred`.
+    const tracker = newTracker()
+    expect(tracker.recordGpuCrash(3_600_000).shouldEngageFallback).toBe(false)
+    expect(tracker.recordGpuCrash(3_601_000).shouldEngageFallback).toBe(false)
+    expect(tracker.recordGpuCrash(3_601_890)).toEqual({
+      shouldEngageFallback: true,
+      crashesInWindow: 3
+    })
+  })
+})

--- a/src/main/crash-reporting/gpu-fallback-engagement.test.ts
+++ b/src/main/crash-reporting/gpu-fallback-engagement.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  engageGpuFallbackAfterCrashBurst,
+  type GpuFallbackEngagement,
+  type GpuFallbackEngagementHandlers
+} from './gpu-fallback-engagement'
+import type { GpuFallbackRestartDecision } from './gpu-fallback-restart-prompt'
+
+const ENGAGEMENT: GpuFallbackEngagement = {
+  reason: 'crashed',
+  // 0x80000003 STATUS_BREAKPOINT — the production Windows signature.
+  exitCode: -2147483645,
+  crashesInWindow: 3,
+  engagedAt: 1_700_000_000_000
+}
+
+function createHandlers(overrides: Partial<GpuFallbackEngagementHandlers> = {}): {
+  handlers: GpuFallbackEngagementHandlers
+  order: string[]
+} {
+  const order: string[] = []
+  const handlers: GpuFallbackEngagementHandlers = {
+    isQuitting: () => false,
+    persistMarker: vi.fn(() => {
+      order.push('persistMarker')
+      return true
+    }),
+    clearMarker: vi.fn(() => order.push('clearMarker')),
+    promptForRestart: vi.fn(async () => {
+      order.push('prompt')
+      return 'restart' as GpuFallbackRestartDecision
+    }),
+    onPromptFailed: vi.fn(),
+    onEngaged: vi.fn(),
+    onRestartDeferred: vi.fn(() => order.push('restartDeferred')),
+    restartIntoSafeGraphics: vi.fn(() => order.push('restart')),
+    ...overrides
+  }
+  return { handlers, order }
+}
+
+describe('engageGpuFallbackAfterCrashBurst', () => {
+  // Repro for the Windows startup GPU cluster (v1.4.190, exit -2147483645).
+  // Measured on Windows 11 26200 / Electron 43.1.0: Chromium's own ladder aborts
+  // the whole browser ("GPU process isn't usable. Goodbye.") on the 6th GPU
+  // crash, 1.285s after the 3rd — the crash that trips this threshold. If the
+  // marker is only written after the user answers the modal, the app dies first
+  // and the next launch retries hardware acceleration, looping forever.
+  it('persists the safe-graphics marker before the restart prompt is answered', async () => {
+    let resolvePrompt: ((decision: GpuFallbackRestartDecision) => void) | undefined
+    const { handlers } = createHandlers({
+      promptForRestart: vi.fn(
+        () =>
+          new Promise<GpuFallbackRestartDecision>((resolve) => {
+            resolvePrompt = resolve
+          })
+      )
+    })
+
+    const engaging = engageGpuFallbackAfterCrashBurst(ENGAGEMENT, handlers)
+    await Promise.resolve()
+
+    // Chromium kills the process here; whatever is on disk now is all the next launch gets.
+    expect(handlers.persistMarker).toHaveBeenCalledWith(ENGAGEMENT)
+
+    resolvePrompt?.('restart')
+    await engaging
+  })
+
+  it('relaunches into safe graphics when the user accepts', async () => {
+    const { handlers, order } = createHandlers()
+    await engageGpuFallbackAfterCrashBurst(ENGAGEMENT, handlers)
+    expect(order).toEqual(['persistMarker', 'prompt', 'restart'])
+    expect(handlers.clearMarker).not.toHaveBeenCalled()
+  })
+
+  it('undoes the marker when the user chooses Keep Running', async () => {
+    const { handlers, order } = createHandlers({
+      promptForRestart: vi.fn(async () => 'continue' as GpuFallbackRestartDecision)
+    })
+    await engageGpuFallbackAfterCrashBurst(ENGAGEMENT, handlers)
+    expect(order).toEqual(['persistMarker', 'clearMarker', 'restartDeferred'])
+    expect(handlers.restartIntoSafeGraphics).not.toHaveBeenCalled()
+  })
+
+  it('keeps the marker when the prompt itself fails, so the next launch is still safe', async () => {
+    const error = new Error('no display')
+    const { handlers } = createHandlers({
+      promptForRestart: vi.fn(async () => {
+        throw error
+      })
+    })
+    await engageGpuFallbackAfterCrashBurst(ENGAGEMENT, handlers)
+    expect(handlers.persistMarker).toHaveBeenCalledTimes(1)
+    expect(handlers.clearMarker).not.toHaveBeenCalled()
+    expect(handlers.onPromptFailed).toHaveBeenCalledWith(error)
+  })
+
+  it('does not relaunch when a quit began while the prompt was open', async () => {
+    const { handlers } = createHandlers({ isQuitting: () => true })
+    await engageGpuFallbackAfterCrashBurst(ENGAGEMENT, handlers)
+    expect(handlers.restartIntoSafeGraphics).not.toHaveBeenCalled()
+    // The marker stays: a quit is not the user declining safe graphics.
+    expect(handlers.clearMarker).not.toHaveBeenCalled()
+  })
+
+  it('does not claim a restart when the marker could not be written', async () => {
+    const { handlers } = createHandlers({ persistMarker: vi.fn(() => false) })
+    await engageGpuFallbackAfterCrashBurst(ENGAGEMENT, handlers)
+    expect(handlers.restartIntoSafeGraphics).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/crash-reporting/gpu-fallback-engagement.test.ts
+++ b/src/main/crash-reporting/gpu-fallback-engagement.test.ts
@@ -25,6 +25,7 @@ function createHandlers(overrides: Partial<GpuFallbackEngagementHandlers> = {}):
       order.push('persistMarker')
       return true
     }),
+    confirmMarker: vi.fn(() => order.push('confirmMarker')),
     clearMarker: vi.fn(() => order.push('clearMarker')),
     promptForRestart: vi.fn(async () => {
       order.push('prompt')
@@ -70,7 +71,7 @@ describe('engageGpuFallbackAfterCrashBurst', () => {
   it('relaunches into safe graphics when the user accepts', async () => {
     const { handlers, order } = createHandlers()
     await engageGpuFallbackAfterCrashBurst(ENGAGEMENT, handlers)
-    expect(order).toEqual(['persistMarker', 'prompt', 'restart'])
+    expect(order).toEqual(['persistMarker', 'prompt', 'confirmMarker', 'restart'])
     expect(handlers.clearMarker).not.toHaveBeenCalled()
   })
 

--- a/src/main/crash-reporting/gpu-fallback-engagement.ts
+++ b/src/main/crash-reporting/gpu-fallback-engagement.ts
@@ -13,6 +13,8 @@ export type GpuFallbackEngagementHandlers = {
   isQuitting: () => boolean
   /** Writes the build-scoped safe-graphics marker; false when it could not be persisted. */
   persistMarker: (engagement: GpuFallbackEngagement) => boolean
+  /** Marks that the user explicitly accepted safe graphics before relaunching. */
+  confirmMarker: (engagement: GpuFallbackEngagement) => void
   clearMarker: () => void
   promptForRestart: () => Promise<GpuFallbackRestartDecision>
   onPromptFailed: (error: unknown) => void
@@ -59,5 +61,6 @@ export async function engageGpuFallbackAfterCrashBurst(
   if (!persisted) {
     return
   }
+  handlers.confirmMarker(engagement)
   handlers.restartIntoSafeGraphics(engagement)
 }

--- a/src/main/crash-reporting/gpu-fallback-engagement.ts
+++ b/src/main/crash-reporting/gpu-fallback-engagement.ts
@@ -1,0 +1,63 @@
+import type { GpuFallbackRestartDecision } from './gpu-fallback-restart-prompt'
+
+/** The GPU-crash burst that tripped the software-rendering fallback. */
+export type GpuFallbackEngagement = {
+  reason: string
+  exitCode: number | null
+  crashesInWindow: number
+  /** Wall-clock ms stamped into the persisted marker. */
+  engagedAt: number
+}
+
+export type GpuFallbackEngagementHandlers = {
+  isQuitting: () => boolean
+  /** Writes the build-scoped safe-graphics marker; false when it could not be persisted. */
+  persistMarker: (engagement: GpuFallbackEngagement) => boolean
+  clearMarker: () => void
+  promptForRestart: () => Promise<GpuFallbackRestartDecision>
+  onPromptFailed: (error: unknown) => void
+  onEngaged: (engagement: GpuFallbackEngagement) => void
+  onRestartDeferred: (engagement: GpuFallbackEngagement) => void
+  restartIntoSafeGraphics: (engagement: GpuFallbackEngagement) => void
+}
+
+/**
+ * Drives the safe-graphics handover once a GPU crash burst trips the threshold.
+ *
+ * Why the marker is written before the prompt: measured on Windows 11 26200 /
+ * Electron 43.1.0, Chromium's own GPU ladder aborts the whole browser process
+ * (`FATAL gpu_data_manager_impl_private.cc: GPU process isn't usable. Goodbye.`)
+ * on the 6th GPU crash — 1.285s after the 3rd, which is the crash that trips
+ * this threshold. Persisting only after the user answers a modal means the app
+ * dies first, no marker survives, and the next launch retries hardware
+ * acceleration: the crash loop never ends. An explicit "Keep Running" undoes it.
+ */
+export async function engageGpuFallbackAfterCrashBurst(
+  engagement: GpuFallbackEngagement,
+  handlers: GpuFallbackEngagementHandlers
+): Promise<void> {
+  handlers.onEngaged(engagement)
+  const persisted = handlers.persistMarker(engagement)
+  let decision: GpuFallbackRestartDecision
+  try {
+    decision = await handlers.promptForRestart()
+  } catch (error) {
+    // Marker stays: the next launch is safe even though the user was never asked.
+    handlers.onPromptFailed(error)
+    return
+  }
+  if (handlers.isQuitting()) {
+    return
+  }
+  if (decision !== 'restart') {
+    if (persisted) {
+      handlers.clearMarker()
+    }
+    handlers.onRestartDeferred(engagement)
+    return
+  }
+  if (!persisted) {
+    return
+  }
+  handlers.restartIntoSafeGraphics(engagement)
+}

--- a/src/main/crash-reporting/gpu-fallback-recovered-launch.test.ts
+++ b/src/main/crash-reporting/gpu-fallback-recovered-launch.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { showMessageBoxMock } = vi.hoisted(() => ({
+  showMessageBoxMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  dialog: { showMessageBox: showMessageBoxMock }
+}))
+
+import {
+  handleGpuFallbackRecoveredLaunch,
+  promptForGpuFallbackRecoveredLaunch,
+  type GpuFallbackRecoveredLaunchDecision,
+  type GpuFallbackRecoveredLaunchHandlers
+} from './gpu-fallback-recovered-launch'
+
+beforeEach(() => {
+  showMessageBoxMock.mockReset()
+})
+
+function createHandlers(
+  decision: GpuFallbackRecoveredLaunchDecision = 'keep-safe',
+  overrides: Partial<GpuFallbackRecoveredLaunchHandlers> = {}
+): { handlers: GpuFallbackRecoveredLaunchHandlers; order: string[] } {
+  const order: string[] = []
+  const handlers: GpuFallbackRecoveredLaunchHandlers = {
+    isQuitting: () => false,
+    prompt: vi.fn(async () => {
+      order.push('prompt')
+      return decision
+    }),
+    confirmSafeGraphics: vi.fn(() => order.push('confirm')),
+    clearSafeGraphics: vi.fn(() => order.push('clear')),
+    onPromptFailed: vi.fn(),
+    onSafeGraphicsKept: vi.fn(() => order.push('kept')),
+    restartWithHardware: vi.fn(() => order.push('restart')),
+    ...overrides
+  }
+  return { handlers, order }
+}
+
+describe('promptForGpuFallbackRecoveredLaunch', () => {
+  it('defaults dismissal to the stable safe-graphics choice', async () => {
+    const parentWindow = { id: 1 }
+    showMessageBoxMock.mockResolvedValue({ response: 0 })
+
+    await expect(promptForGpuFallbackRecoveredLaunch(parentWindow as never)).resolves.toBe(
+      'keep-safe'
+    )
+    expect(showMessageBoxMock).toHaveBeenCalledWith(parentWindow, {
+      type: 'info',
+      buttons: ['Keep Safe Graphics Mode', 'Try Hardware Acceleration'],
+      defaultId: 0,
+      cancelId: 0,
+      title: 'Safe Graphics Mode is Active',
+      message: 'Orca recovered in Safe Graphics Mode.',
+      detail:
+        'Safe Graphics Mode was enabled after repeated graphics crashes. Keep it for stability, or restart and try hardware acceleration again.'
+    })
+  })
+
+  it('returns the explicit hardware retry choice', async () => {
+    showMessageBoxMock.mockResolvedValue({ response: 1 })
+    await expect(promptForGpuFallbackRecoveredLaunch()).resolves.toBe('retry-hardware')
+  })
+})
+
+describe('handleGpuFallbackRecoveredLaunch', () => {
+  it('confirms safe graphics so later launches do not prompt again', async () => {
+    const { handlers, order } = createHandlers()
+    await handleGpuFallbackRecoveredLaunch(handlers)
+    expect(order).toEqual(['prompt', 'confirm', 'kept'])
+    expect(handlers.clearSafeGraphics).not.toHaveBeenCalled()
+    expect(handlers.restartWithHardware).not.toHaveBeenCalled()
+  })
+
+  it('clears the marker before restarting with hardware acceleration', async () => {
+    const { handlers, order } = createHandlers('retry-hardware')
+    await handleGpuFallbackRecoveredLaunch(handlers)
+    expect(order).toEqual(['prompt', 'clear', 'restart'])
+    expect(handlers.confirmSafeGraphics).not.toHaveBeenCalled()
+  })
+
+  it('leaves the unconfirmed marker intact when the prompt fails', async () => {
+    const error = new Error('dialog failed')
+    const { handlers } = createHandlers('keep-safe', {
+      prompt: vi.fn(async () => {
+        throw error
+      })
+    })
+    await handleGpuFallbackRecoveredLaunch(handlers)
+    expect(handlers.onPromptFailed).toHaveBeenCalledWith(error)
+    expect(handlers.confirmSafeGraphics).not.toHaveBeenCalled()
+    expect(handlers.clearSafeGraphics).not.toHaveBeenCalled()
+  })
+
+  it('does not mutate the marker when shutdown starts while the prompt is open', async () => {
+    const { handlers } = createHandlers('retry-hardware', { isQuitting: () => true })
+    await handleGpuFallbackRecoveredLaunch(handlers)
+    expect(handlers.confirmSafeGraphics).not.toHaveBeenCalled()
+    expect(handlers.clearSafeGraphics).not.toHaveBeenCalled()
+    expect(handlers.restartWithHardware).not.toHaveBeenCalled()
+  })
+})
+
+describe('recovered safe-graphics production wiring', () => {
+  it('prompts only after the recovered window is shown and persists both consent states', () => {
+    const source = readFileSync(join(__dirname, '..', 'index.ts'), 'utf8')
+    expect(source).toMatch(
+      /window\.once\('show',[\s\S]*?presentGpuFallbackRecoveredLaunchPrompt\(window\)/
+    )
+    expect(source).toMatch(
+      /persistMarker:[\s\S]*?userConfirmed: false[\s\S]*?confirmMarker:[\s\S]*?userConfirmed: true/
+    )
+  })
+})

--- a/src/main/crash-reporting/gpu-fallback-recovered-launch.ts
+++ b/src/main/crash-reporting/gpu-fallback-recovered-launch.ts
@@ -1,0 +1,56 @@
+import { dialog, type BrowserWindow, type MessageBoxOptions } from 'electron'
+
+export type GpuFallbackRecoveredLaunchDecision = 'keep-safe' | 'retry-hardware'
+
+const GPU_FALLBACK_RECOVERED_LAUNCH_OPTIONS: MessageBoxOptions = {
+  type: 'info',
+  buttons: ['Keep Safe Graphics Mode', 'Try Hardware Acceleration'],
+  defaultId: 0,
+  cancelId: 0,
+  title: 'Safe Graphics Mode is Active',
+  message: 'Orca recovered in Safe Graphics Mode.',
+  detail:
+    'Safe Graphics Mode was enabled after repeated graphics crashes. Keep it for stability, or restart and try hardware acceleration again.'
+}
+
+export async function promptForGpuFallbackRecoveredLaunch(
+  parentWindow?: BrowserWindow
+): Promise<GpuFallbackRecoveredLaunchDecision> {
+  const { response } = parentWindow
+    ? await dialog.showMessageBox(parentWindow, GPU_FALLBACK_RECOVERED_LAUNCH_OPTIONS)
+    : await dialog.showMessageBox(GPU_FALLBACK_RECOVERED_LAUNCH_OPTIONS)
+  return response === 1 ? 'retry-hardware' : 'keep-safe'
+}
+
+export type GpuFallbackRecoveredLaunchHandlers = {
+  isQuitting: () => boolean
+  prompt: () => Promise<GpuFallbackRecoveredLaunchDecision>
+  confirmSafeGraphics: () => void
+  clearSafeGraphics: () => void
+  onPromptFailed: (error: unknown) => void
+  onSafeGraphicsKept: () => void
+  restartWithHardware: () => void
+}
+
+/** Resolves consent after an unanswered crash-time prompt recovered into safe graphics. */
+export async function handleGpuFallbackRecoveredLaunch(
+  handlers: GpuFallbackRecoveredLaunchHandlers
+): Promise<void> {
+  let decision: GpuFallbackRecoveredLaunchDecision
+  try {
+    decision = await handlers.prompt()
+  } catch (error) {
+    handlers.onPromptFailed(error)
+    return
+  }
+  if (handlers.isQuitting()) {
+    return
+  }
+  if (decision === 'retry-hardware') {
+    handlers.clearSafeGraphics()
+    handlers.restartWithHardware()
+    return
+  }
+  handlers.confirmSafeGraphics()
+  handlers.onSafeGraphicsKept()
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -173,6 +173,7 @@ import {
   clearGpuFallbackMarker,
   readActiveGpuFallbackMarker,
   writeGpuFallbackMarker,
+  type GpuFallbackMarker,
   type GpuFallbackEnvironment,
   type WindowsGpuFallbackEnvironment
 } from './startup/gpu-fallback-marker'
@@ -185,6 +186,10 @@ import {
 } from './crash-reporting/gpu-crash-fallback-decision'
 import { promptForGpuFallbackRestart } from './crash-reporting/gpu-fallback-restart-prompt'
 import { engageGpuFallbackAfterCrashBurst } from './crash-reporting/gpu-fallback-engagement'
+import {
+  handleGpuFallbackRecoveredLaunch,
+  promptForGpuFallbackRecoveredLaunch
+} from './crash-reporting/gpu-fallback-recovered-launch'
 import {
   shouldSuppressDevEducation,
   suppressDevEducationForStore
@@ -460,6 +465,7 @@ const gpuCrashFallbackTracker = new GpuCrashFallbackTracker({
   windowMs: DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
   threshold: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
 })
+let activeGpuFallbackMarker: GpuFallbackMarker | null = null
 let gpuFallbackActiveThisLaunch = false
 let gpuFeatureStatus: Electron.GPUFeatureStatus | null = null
 let localPtyStartupReady: Promise<void> = Promise.resolve()
@@ -1568,6 +1574,7 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
   })
   window.once('show', () => {
     logStartupMilestone('window-shown')
+    void presentGpuFallbackRecoveredLaunchPrompt(window)
   })
   const trayCreateFallback = setTimeout(createSystemTrayDeferred, TRAY_CREATE_FALLBACK_MS)
   trayCreateFallback.unref?.()
@@ -1854,7 +1861,25 @@ function getWindowsGpuFallbackEnvironment(): WindowsGpuFallbackEnvironment | nul
   return { ...environment, platform: 'win32' }
 }
 
-// Why: read the GPU-fallback marker before app.whenReady() so app.disableHardwareAcceleration() takes effect. Windows desktop only.
+// Writes both crash-time and post-recovery consent states through one build-scoped path.
+function persistGpuFallbackMarker(
+  userDataPath: string,
+  info: { engagedAt: number; crashesInWindow: number; userConfirmed: boolean }
+): boolean {
+  const environment = getWindowsGpuFallbackEnvironment()
+  if (!environment) {
+    return false
+  }
+  try {
+    writeGpuFallbackMarker(userDataPath, info, environment)
+    return true
+  } catch (error) {
+    console.warn('[gpu-fallback] failed to persist marker:', error)
+    return false
+  }
+}
+
+// Read before app.whenReady() so app.disableHardwareAcceleration() takes effect. Windows desktop only.
 function maybeApplyGpuFallbackForThisLaunch(): void {
   if (isServeMode || process.platform !== 'win32') {
     return
@@ -1863,6 +1888,7 @@ function maybeApplyGpuFallbackForThisLaunch(): void {
   if (!marker) {
     return
   }
+  activeGpuFallbackMarker = marker
   app.disableHardwareAcceleration()
   const appliedSwitches = applyGpuFallbackCommandLineSwitches(app.commandLine, process.platform)
   gpuFallbackActiveThisLaunch = true
@@ -1871,6 +1897,43 @@ function maybeApplyGpuFallbackForThisLaunch(): void {
   recordCrashBreadcrumb('gpu_fallback_applied', {
     crashesInWindow: marker.crashesInWindow,
     switches: appliedSwitches.join(',')
+  })
+}
+
+async function presentGpuFallbackRecoveredLaunchPrompt(window: BrowserWindow): Promise<void> {
+  const marker = activeGpuFallbackMarker
+  if (!marker || marker.userConfirmed || window.isDestroyed() || isQuitting) {
+    return
+  }
+  // One prompt per process. A failure leaves the on-disk marker unconfirmed so the next launch retries.
+  activeGpuFallbackMarker = null
+  const userDataPath = app.getPath('userData')
+  await handleGpuFallbackRecoveredLaunch({
+    isQuitting: () => isQuitting,
+    prompt: () => promptForGpuFallbackRecoveredLaunch(window),
+    confirmSafeGraphics: () => {
+      persistGpuFallbackMarker(userDataPath, {
+        engagedAt: marker.engagedAt,
+        crashesInWindow: marker.crashesInWindow,
+        userConfirmed: true
+      })
+    },
+    clearSafeGraphics: () => clearGpuFallbackMarker(userDataPath),
+    onPromptFailed: (error) =>
+      console.warn('[gpu-fallback] failed to show recovered-launch prompt:', error),
+    onSafeGraphicsKept: () =>
+      recordDurableCrashBreadcrumb('gpu_fallback_safe_graphics_kept', {
+        crashesInWindow: marker.crashesInWindow
+      }),
+    restartWithHardware: () => {
+      isQuitting = true
+      relaunchApp('gpu-fallback', {
+        mode: 'hardware-retry',
+        crashesInWindow: marker.crashesInWindow
+      })
+      destroySystemTray()
+      app.exit(0)
+    }
   })
 }
 
@@ -1900,22 +1963,18 @@ async function handleGpuChildCrash(reason: string, exitCode: number | null): Pro
           exitCode: engagement.exitCode,
           crashesInWindow: engagement.crashesInWindow
         }),
-      persistMarker: (engagement) => {
-        const environment = getWindowsGpuFallbackEnvironment()
-        if (!environment) {
-          return false
-        }
-        try {
-          writeGpuFallbackMarker(
-            userDataPath,
-            { engagedAt: engagement.engagedAt, crashesInWindow: engagement.crashesInWindow },
-            environment
-          )
-          return true
-        } catch (error) {
-          console.warn('[gpu-fallback] failed to persist marker:', error)
-          return false
-        }
+      persistMarker: (engagement) =>
+        persistGpuFallbackMarker(userDataPath, {
+          engagedAt: engagement.engagedAt,
+          crashesInWindow: engagement.crashesInWindow,
+          userConfirmed: false
+        }),
+      confirmMarker: (engagement) => {
+        persistGpuFallbackMarker(userDataPath, {
+          engagedAt: engagement.engagedAt,
+          crashesInWindow: engagement.crashesInWindow,
+          userConfirmed: true
+        })
       },
       clearMarker: () => clearGpuFallbackMarker(userDataPath),
       promptForRestart: () =>

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -153,6 +153,7 @@ import {
   configureDevUserDataPath,
   configureOrcaUserDataPathEnv,
   disableUnsupportedChromiumFeatures,
+  optOutOfHiddenPageWakeUpThrottling,
   enableMainProcessGpuFeatures,
   installDevParentDisconnectQuit,
   installDevParentSignalQuit,
@@ -169,6 +170,7 @@ import { enableRendererHeapHeadroom } from './startup/renderer-heap-headroom'
 import { argvRequestsServeMode, normalizeServeModeArgv } from './startup/serve-mode-argv'
 import { ensureVirtualDisplayForHeadlessServe } from './startup/ensure-virtual-display'
 import {
+  clearGpuFallbackMarker,
   readActiveGpuFallbackMarker,
   writeGpuFallbackMarker,
   type GpuFallbackEnvironment,
@@ -181,10 +183,8 @@ import {
   GpuCrashFallbackTracker,
   isGpuFallbackCrashCandidate
 } from './crash-reporting/gpu-crash-fallback-decision'
-import {
-  promptForGpuFallbackRestart,
-  type GpuFallbackRestartDecision
-} from './crash-reporting/gpu-fallback-restart-prompt'
+import { promptForGpuFallbackRestart } from './crash-reporting/gpu-fallback-restart-prompt'
+import { engageGpuFallbackAfterCrashBurst } from './crash-reporting/gpu-fallback-engagement'
 import {
   shouldSuppressDevEducation,
   suppressDevEducationForStore
@@ -980,6 +980,8 @@ if (hasSingleInstanceLock) {
     ...getMainProcessLifecycleIdentity()
   })
   disableUnsupportedChromiumFeatures()
+  // Why: unconditional — a GPU-fallback launch skips enableMainProcessGpuFeatures() below.
+  optOutOfHiddenPageWakeUpThrottling()
   configureElectronNetworkCompatibility()
   enableRendererHeapHeadroom()
   maybeApplyGpuFallbackForThisLaunch()
@@ -1882,54 +1884,57 @@ async function handleGpuChildCrash(reason: string, exitCode: number | null): Pro
   if (!result.shouldEngageFallback) {
     return
   }
-  recordCrashBreadcrumb('gpu_fallback_engaged', {
-    reason,
-    exitCode,
-    crashesInWindow: result.crashesInWindow
-  })
-  const engagedAt = Date.now()
-  const window = mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined
-  let restartDecision: GpuFallbackRestartDecision
-  try {
-    restartDecision = await promptForGpuFallbackRestart(window)
-  } catch (error) {
-    console.warn('[gpu-fallback] failed to show restart prompt:', error)
-    return
-  }
   const fallbackData = {
     processReason: reason,
     exitCode,
     crashesInWindow: result.crashesInWindow
   }
-  if (isQuitting) {
-    return
-  }
-  if (restartDecision !== 'restart') {
-    recordDurableCrashBreadcrumb('gpu_fallback_restart_deferred', fallbackData)
-    return
-  }
-  const environment = getWindowsGpuFallbackEnvironment()
-  if (!environment) {
-    return
-  }
-  try {
-    writeGpuFallbackMarker(
-      app.getPath('userData'),
-      {
-        engagedAt,
-        crashesInWindow: result.crashesInWindow
+  const userDataPath = app.getPath('userData')
+  await engageGpuFallbackAfterCrashBurst(
+    { reason, exitCode, crashesInWindow: result.crashesInWindow, engagedAt: Date.now() },
+    {
+      isQuitting: () => isQuitting,
+      onEngaged: (engagement) =>
+        recordCrashBreadcrumb('gpu_fallback_engaged', {
+          reason: engagement.reason,
+          exitCode: engagement.exitCode,
+          crashesInWindow: engagement.crashesInWindow
+        }),
+      persistMarker: (engagement) => {
+        const environment = getWindowsGpuFallbackEnvironment()
+        if (!environment) {
+          return false
+        }
+        try {
+          writeGpuFallbackMarker(
+            userDataPath,
+            { engagedAt: engagement.engagedAt, crashesInWindow: engagement.crashesInWindow },
+            environment
+          )
+          return true
+        } catch (error) {
+          console.warn('[gpu-fallback] failed to persist marker:', error)
+          return false
+        }
       },
-      environment
-    )
-  } catch (error) {
-    console.warn('[gpu-fallback] failed to persist marker:', error)
-    return
-  }
-  isQuitting = true
-  relaunchApp('gpu-fallback', fallbackData)
-  // Why: app.exit(0) skips before-quit, so destroy the Windows tray manually to avoid a stale icon.
-  destroySystemTray()
-  app.exit(0)
+      clearMarker: () => clearGpuFallbackMarker(userDataPath),
+      promptForRestart: () =>
+        promptForGpuFallbackRestart(
+          mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined
+        ),
+      onPromptFailed: (error) =>
+        console.warn('[gpu-fallback] failed to show restart prompt:', error),
+      onRestartDeferred: () =>
+        recordDurableCrashBreadcrumb('gpu_fallback_restart_deferred', fallbackData),
+      restartIntoSafeGraphics: () => {
+        isQuitting = true
+        relaunchApp('gpu-fallback', fallbackData)
+        // Why: app.exit(0) skips before-quit, so destroy the Windows tray manually to avoid a stale icon.
+        destroySystemTray()
+        app.exit(0)
+      }
+    }
+  )
 }
 
 function recordProcessGoneCrash(

--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -508,20 +508,6 @@ describe('enableMainProcessGpuFeatures', () => {
     expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('enable-unsafe-webgpu')
   })
 
-  it('opts hidden pages out of intensive wake-up throttling', async () => {
-    const { app } = await import('electron')
-    const { enableMainProcessGpuFeatures } = await import('./configure-process')
-
-    delete process.env.ORCA_E2E_USER_DATA_DIR
-    vi.mocked(app.commandLine.appendSwitch).mockClear()
-    enableMainProcessGpuFeatures()
-
-    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith(
-      'disable-features',
-      'IntensiveWakeUpThrottling'
-    )
-  })
-
   it('raises the WebGL context budget above the 16-context Blink default', async () => {
     const { app } = await import('electron')
     const { enableMainProcessGpuFeatures } = await import('./configure-process')
@@ -752,5 +738,79 @@ describe('enableMainProcessGpuFeatures', () => {
 
     expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('disable-gpu-sandbox')
     expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('enable-features', 'ExistingFeature')
+  })
+})
+
+describe('safe graphics mode startup switches', () => {
+  const originalE2EUserDataDir = process.env.ORCA_E2E_USER_DATA_DIR
+
+  afterEach(() => {
+    if (originalE2EUserDataDir === undefined) {
+      delete process.env.ORCA_E2E_USER_DATA_DIR
+    } else {
+      process.env.ORCA_E2E_USER_DATA_DIR = originalE2EUserDataDir
+    }
+  })
+
+  function disabledFeaturesFrom(appendSwitch: ReturnType<typeof vi.fn>): string[] {
+    return appendSwitch.mock.calls
+      .filter(([name]) => name === 'disable-features')
+      .flatMap(([, value]) => String(value ?? '').split(','))
+      .filter(Boolean)
+  }
+
+  it('opts hidden pages out of intensive wake-up throttling', async () => {
+    const { app } = await import('electron')
+    const { optOutOfHiddenPageWakeUpThrottling } = await import('./configure-process')
+
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+    optOutOfHiddenPageWakeUpThrottling()
+
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith(
+      'disable-features',
+      'IntensiveWakeUpThrottling'
+    )
+  })
+
+  // Why: the defect was the call site, not the switch — a win32 safe-graphics launch runs
+  // `if (!gpuFallbackActiveThisLaunch) enableMainProcessGpuFeatures()` and skips everything
+  // parked inside it, so only an unconditional call site reaches the users a GPU crash already hit.
+  it('calls the throttling opt-out outside the GPU-fallback gate in index.ts', () => {
+    const mainSource = readFileSync(join(__dirname, '..', 'index.ts'), 'utf8')
+    const gateStart = mainSource.indexOf('if (!gpuFallbackActiveThisLaunch) {')
+    expect(gateStart).toBeGreaterThanOrEqual(0)
+    const gateEnd = mainSource.indexOf('\n  }', gateStart)
+    expect(gateEnd).toBeGreaterThan(gateStart)
+
+    expect(mainSource.match(/\boptOutOfHiddenPageWakeUpThrottling\(\)/g)).toHaveLength(1)
+    expect(mainSource.slice(gateStart, gateEnd)).not.toContain('optOutOfHiddenPageWakeUpThrottling')
+  })
+
+  // Why: Chromium consumes the command line at ready, so this must stay in the pre-ready
+  // top-level block and never move into the whenReady callback, where appendSwitch is a silent
+  // no-op — the same invisible failure as parking it behind the GPU gate.
+  it('appends the throttling opt-out before app ready in index.ts', () => {
+    const mainSource = readFileSync(join(__dirname, '..', 'index.ts'), 'utf8')
+    const readyStart = mainSource.indexOf('void app.whenReady()')
+    expect(readyStart).toBeGreaterThan(0)
+
+    const callIndex = mainSource.indexOf('optOutOfHiddenPageWakeUpThrottling()')
+    expect(callIndex).toBeGreaterThan(0)
+    expect(callIndex).toBeLessThan(readyStart)
+  })
+
+  // Why: Chromium enables IntensiveWakeUpThrottling on every desktop platform, so the opt-out
+  // must never become reachable only through the GPU-feature path again.
+  it('does not couple the throttling opt-out to GPU feature setup', async () => {
+    const { app } = await import('electron')
+    const { enableMainProcessGpuFeatures } = await import('./configure-process')
+
+    delete process.env.ORCA_E2E_USER_DATA_DIR
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+    enableMainProcessGpuFeatures()
+
+    expect(disabledFeaturesFrom(vi.mocked(app.commandLine.appendSwitch))).not.toContain(
+      'IntensiveWakeUpThrottling'
+    )
   })
 })

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -71,6 +71,12 @@ export function disableUnsupportedChromiumFeatures(): void {
   appendDisabledChromiumFeatures([...DISABLED_CHROMIUM_FEATURES])
 }
 
+// Why: Chromium clamps hidden-page timers to 1/min after 5min on every desktop platform,
+// delaying agent-done/bell notifications ~60s. Call site is unconditional (see index.ts).
+export function optOutOfHiddenPageWakeUpThrottling(): void {
+  appendDisabledChromiumFeatures(['IntensiveWakeUpThrottling'])
+}
+
 function appendDisabledChromiumFeatures(features: string[]): void {
   const existingFeatures = app.commandLine
     .getSwitchValue('disable-features')
@@ -314,8 +320,4 @@ export function enableMainProcessGpuFeatures(): void {
   if (features) {
     app.commandLine.appendSwitch('enable-features', features)
   }
-
-  // Why: IntensiveWakeUpThrottling clamps hidden-page timers to 1/min after 5min, delaying agent-done/bell notifications ~60s.
-  // This opt-out is skipped under GPU fallback (win32-only today); if throttling ever reaches Windows it must move out of this path.
-  appendDisabledChromiumFeatures(['IntensiveWakeUpThrottling'])
 }

--- a/src/main/startup/gpu-fallback-marker.test.ts
+++ b/src/main/startup/gpu-fallback-marker.test.ts
@@ -27,15 +27,29 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('round-trips a written marker', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 123, crashesInWindow: 3 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 123, crashesInWindow: 3, userConfirmed: false },
+      environment
+    )
     expect(readGpuFallbackMarker(userDataPath)).toEqual({
-      schemeVersion: 2,
+      schemeVersion: 3,
       engagedAt: 123,
       crashesInWindow: 3,
+      userConfirmed: false,
       appVersion: '1.2.3',
       electronVersion: '42.3.3',
       platform: 'win32'
     })
+  })
+
+  it('persists explicit safe-graphics consent across launches', () => {
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 123, crashesInWindow: 3, userConfirmed: true },
+      environment
+    )
+    expect(readActiveGpuFallbackMarker(userDataPath, environment)?.userConfirmed).toBe(true)
   })
 
   it('returns null when no marker exists', () => {
@@ -44,7 +58,11 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('keeps an active marker for repeated launches on the same build', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 4, userConfirmed: false },
+      environment
+    )
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
 
     const firstRead = readActiveGpuFallbackMarker(userDataPath, environment)
@@ -56,7 +74,11 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('clears an active marker when the app build changes', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 4, userConfirmed: false },
+      environment
+    )
 
     expect(
       readActiveGpuFallbackMarker(userDataPath, {
@@ -68,7 +90,11 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('clears an active marker outside Windows', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 4, userConfirmed: false },
+      environment
+    )
 
     expect(
       readActiveGpuFallbackMarker(userDataPath, {
@@ -83,7 +109,11 @@ describe('gpu-fallback-marker', () => {
   // carries the macOS disable-skia-graphite fix. A marker that survived on darwin would silently
   // strip the fix from the Macs it targets, so pin the platform gate for darwin specifically.
   it('clears an active marker on macOS so the Graphite fix is never skipped', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 4, userConfirmed: false },
+      environment
+    )
 
     expect(
       readActiveGpuFallbackMarker(userDataPath, {
@@ -110,7 +140,11 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('can explicitly clear the marker', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 4, userConfirmed: false },
+      environment
+    )
     clearGpuFallbackMarker(userDataPath)
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
   })

--- a/src/main/startup/gpu-fallback-marker.ts
+++ b/src/main/startup/gpu-fallback-marker.ts
@@ -11,7 +11,7 @@ import { join } from 'node:path'
  */
 
 export const GPU_FALLBACK_MARKER_FILE = 'gpu-fallback.json'
-export const GPU_FALLBACK_SCHEME_VERSION = 2
+export const GPU_FALLBACK_SCHEME_VERSION = 3
 
 export type GpuFallbackEnvironment = {
   appVersion: string
@@ -25,6 +25,7 @@ export type GpuFallbackMarker = {
   schemeVersion: number
   engagedAt: number
   crashesInWindow: number
+  userConfirmed: boolean
   appVersion: string
   electronVersion: string
   platform: 'win32'
@@ -47,6 +48,7 @@ export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker |
       !Number.isFinite(parsed.engagedAt) ||
       typeof parsed.crashesInWindow !== 'number' ||
       !Number.isFinite(parsed.crashesInWindow) ||
+      typeof parsed.userConfirmed !== 'boolean' ||
       typeof parsed.appVersion !== 'string' ||
       typeof parsed.electronVersion !== 'string' ||
       parsed.platform !== 'win32'
@@ -57,6 +59,7 @@ export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker |
       schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
       engagedAt: parsed.engagedAt,
       crashesInWindow: parsed.crashesInWindow,
+      userConfirmed: parsed.userConfirmed,
       appVersion: parsed.appVersion,
       electronVersion: parsed.electronVersion,
       platform: parsed.platform
@@ -69,13 +72,14 @@ export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker |
 
 export function writeGpuFallbackMarker(
   userDataPath: string,
-  info: { engagedAt: number; crashesInWindow: number },
+  info: { engagedAt: number; crashesInWindow: number; userConfirmed: boolean },
   environment: WindowsGpuFallbackEnvironment
 ): void {
   const marker: GpuFallbackMarker = {
     schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
     engagedAt: info.engagedAt,
     crashesInWindow: info.crashesInWindow,
+    userConfirmed: info.userConfirmed,
     appVersion: environment.appVersion,
     electronVersion: environment.electronVersion,
     platform: 'win32'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​476 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​454 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​244 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​52 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​192 |

<!-- /orca-pr-loc -->

## Make the Windows safe-graphics fallback survive a fast GPU crash burst

Reproduced the recovery race with a **live Electron 43.1.0 run on a real Windows 11 (10.0.26200) box** (`awin`), killing the GPU child with `TerminateProcess(h, 0x80000003)` to produce the field exit code.

This experiment proves the recovery ordering bug. It does **not** reproduce or attribute the originating field GPU fault.

### Field evidence and attribution limits

The v1.4.190 Windows `crashed` renderer cluster contains 10 reports. Four sessions show the GPU child dying 47ms–1030ms after `main_window_created`, followed by the renderer 72ms–2522ms later:

```
process_gone_suppressed (source=child, processType=GPU, reason=crashed,
                         exitCode=-2147483645, serviceName=GPU)
```

`-2147483645` = `0x80000003` = `STATUS_BREAKPOINT`. In Chromium this commonly represents a `CHECK`/`DCHECK`; the exit code alone cannot identify the failing check or distinguish a driver, Chromium/Electron, injected software, resource pressure, or Orca-triggered path. The current reports do not contain enough Windows GPU vendor/device/driver data to attribute the root fault.

The four relevant v1.4.190 reports contain exact observed GPU-crash counts of 2, 1, 2, and 1. None reached Orca's threshold of 3 crashes in 30 seconds. They establish a GPU-adjacent renderer-crash cluster, but do not prove that these sessions entered the marker/prompt race fixed here.

A separate field launch (`51b9e93c`) did reach the threshold and recorded `gpu_fallback_restart_deferred`; that proves the engagement path was reachable in the field, but not that the process died while its prompt was unresolved.

### The recovery race

`handleGpuChildCrash` engages the software-rendering fallback at 3 GPU crashes in 30 seconds. Before this change it awaited a modal dialog and only then wrote the marker:

```
recordCrashBreadcrumb('gpu_fallback_engaged', …)
restartDecision = await promptForGpuFallbackRestart(window)   // blocks on a human
…
writeGpuFallbackMarker(…)                                     // only after the click
```

On the controlled box, Chromium exhausted its GPU fallback modes and aborted the browser process on the 6th injected GPU death — 1.285 seconds after the 3rd death that tripped Orca's threshold:

```
[+ 1130ms] child-process-gone {"type":"GPU","exitCode":-2147483645}  ← Orca decides here
[+ 2415ms] FATAL:gpu_data_manager_impl_private.cc:416] GPU process isn't usable. Goodbye.
```

A machine with an equivalently fast real burst can therefore die while Orca waits for the prompt. With no marker on disk, the next launch retries hardware acceleration and can repeat the loop.

### Controlled bracketing

| Injected GPU deaths | Result |
|---|---|
| 1 | survives — Chromium respawns the GPU child |
| 3 | Chromium self-demotes to software (`gpu_compositing: disabled_software`), still alive |
| 4, 5 | still alive |
| **6** | `FATAL … Goodbye.`, `electron exit=3` |

Negative control: `DebugBreakProcess` returned `ok=True` but the GPU child survived; Chromium swallowed the injected breakpoint. `TerminateProcess(h, 0x80000003)` exercised the required death/restart sequence.

### Breadcrumb-count integrity

Suppressed breadcrumbs coalesce for 30 seconds, but a crash-report snapshot resolves pending repetitions into the retained breadcrumb. Therefore `suppressedSinceLast=N` represents N additional observed deaths and a report created inside the window still carries the running count. The field-session regression test treats those counts as exact.

This is separate from events Electron never emits: an unobserved child death cannot appear in breadcrumbs and also cannot advance Orca's in-process fallback tracker.

### Fix

New `src/main/crash-reporting/gpu-fallback-engagement.ts` extracts the engagement orchestration from `index.ts` so ordering is testable. Its behavioral change is: **`persistMarker` runs before the prompt is awaited.** An explicit "Keep Running" clears it; an explicit restart marks the safe-mode choice as confirmed.

If Chromium kills the app before the user answers, the unconfirmed marker starts the next launch safely. Once that recovered window is visible, Orca explains why Safe Graphics Mode is active and offers **Keep Safe Graphics Mode** or **Try Hardware Acceleration**. Keeping it confirms the marker so the prompt does not repeat. Retrying clears the marker and relaunches with hardware acceleration.

Also fixed here: the `IntensiveWakeUpThrottling` opt-out lived inside `enableMainProcessGpuFeatures()`, which a win32 safe-graphics launch skips. Safe-graphics users could therefore get hidden-page timers clamped to 1/min after five minutes, delaying agent-done/bell notifications by roughly 60 seconds. The opt-out is now unconditional.

### Verification

```
pnpm test src/main/crash-reporting/gpu-fallback-recovered-launch.test.ts \
          src/main/crash-reporting/gpu-fallback-engagement.test.ts \
          src/main/crash-reporting/gpu-fallback-restart-prompt.test.ts \
          src/main/startup/gpu-fallback-marker.test.ts \
          src/main/startup/configure-process.test.ts \
          src/main/crash-reporting/gpu-crash-fallback-field-sessions.test.ts
# 6 files, 65 tests passed

pnpm tc
pnpm run check:code-quality:changed
# 0 new findings
```

The crash-time reproduction leaves `promptForRestart` unresolved and asserts that the unconfirmed marker already exists. Recovered-launch tests pin the safe default, explicit hardware retry, marker confirmation, failure behavior, and production window-show wiring.

A live Electron 43.1.0 native-dialog harness rendered the recovered-launch choice against the actual module. The visible default was **Keep Safe Graphics Mode**, with **Try Hardware Acceleration** available as the secondary action.

### ELI5

Orca's window is drawn by a helper process. If that helper dies repeatedly, Orca writes down "use safe graphics next time" before asking what to do. If Chromium closes Orca before the user answers, the next launch opens safely, explains that Safe Graphics Mode is active, and lets the user keep it or restart and try hardware acceleration.

### Trade-offs

- **The marker is written before crash-time consent.** "Keep Running" clears it. If the app dies before an answer, the next launch starts in safe graphics, then presents the recovered-launch choice once the window is visible.
- Explicitly accepting safe graphics confirms the marker so later launches do not repeat the prompt. Choosing hardware retry clears it and relaunches normally.
- If either prompt throws or shutdown begins while it is open, the unconfirmed marker remains so the next launch stays recoverable and asks again.
- This change does not diagnose or fix the originating GPU fault. It makes Orca's existing recovery survive a sufficiently fast crash burst.

### Review

Four adversarial review loops plus a performance pass. Earlier rounds replaced two tests that asserted pure helpers without pinning the production wiring and corrected a FeatureList timing comment.

**Perf: NO_REGRESSION.**

### Follow-up diagnostics

#16973 captures a narrow Windows GPU vendor/device/driver breadcrumb so future renderer reports can identify affected hardware cohorts.



Wall time: 0.39 seconds