### PR TITLE
fix(renderer): count IME commits and coalesced echoes in the typing probe

### DIFF
--- a/src/renderer/src/lib/typing-latency-diagnostic-summary.ts
+++ b/src/renderer/src/lib/typing-latency-diagnostic-summary.ts
@@ -39,6 +39,38 @@ export function summarizeLatencySamples(values: readonly number[]): LatencyPerce
   }
 }
 
+/**
+ * Fixed latency buckets, in milliseconds.
+ *
+ * Why fixed and not derived: the question a typing probe answers is which
+ * scheduling path a keystroke took, and those paths sit at known delays (a
+ * ~16-32ms fast release vs a 250ms hold-safety fallback vs a 1s coalesce). A
+ * bimodal histogram over stable buckets shows that split; percentiles alone
+ * average the two paths into one number that matches neither.
+ */
+const LATENCY_BUCKET_EDGES = [16, 32, 64, 128, 256, 512, 1024] as const
+
+export type LatencyHistogram = Record<string, number>
+
+export function histogramLatencySamples(values: readonly number[]): LatencyHistogram {
+  const histogram: LatencyHistogram = {}
+  let previous = 0
+  for (const edge of LATENCY_BUCKET_EDGES) {
+    histogram[`<${edge}`] = 0
+    previous = edge
+  }
+  histogram[`>=${previous}`] = 0
+  for (const value of values) {
+    if (!Number.isFinite(value)) {
+      continue
+    }
+    const edge = LATENCY_BUCKET_EDGES.find((candidate) => value < candidate)
+    const key = edge === undefined ? `>=${previous}` : `<${edge}`
+    histogram[key] = (histogram[key] ?? 0) + 1
+  }
+  return histogram
+}
+
 export type WorktreeNestingCensus = {
   maxDepth: number
   nestedWorktrees: number

--- a/src/renderer/src/lib/typing-latency-diagnostic.ts
+++ b/src/renderer/src/lib/typing-latency-diagnostic.ts
@@ -206,7 +206,9 @@ function startProbe(): string {
       state.keystrokesWithoutTerminalFocus += 1
       return
     }
-    state.bySource.addCommitChars(event.data.length)
+    // Array.from, not .length: a supplementary-plane commit is two UTF-16 units
+    // but one character, and this counts characters per commit.
+    state.bySource.addCommitChars(Array.from(event.data).length)
     state.unmatchedKeystrokes += recordKeystroke(target, performance.now(), 'ime')
   }
   window.addEventListener('keydown', onKeydown, { capture: true })

--- a/src/renderer/src/lib/typing-latency-diagnostic.ts
+++ b/src/renderer/src/lib/typing-latency-diagnostic.ts
@@ -32,6 +32,17 @@ import {
   type LatencyPercentiles,
   type TypingScaleCensus
 } from './typing-latency-diagnostic-summary'
+import {
+  createInputSourceTally,
+  emptyInputSourceBreakdown,
+  type InputSourceBreakdown,
+  type InputSourceTally
+} from './typing-latency-input-source'
+import {
+  watchMainThreadBlocking,
+  type MainThreadBlockingCensus,
+  type MainThreadBlockingWatch
+} from './typing-latency-main-thread-blocking'
 
 /** Bounds memory during sustained typing: percentiles only need a rolling window. */
 const MAX_SAMPLES = 2000
@@ -47,6 +58,8 @@ type ProbeState = {
   keystrokesWithoutTerminalFocus: number
   panes: InstrumentedPane[]
   detachKeydown: () => void
+  blocking: MainThreadBlockingWatch
+  bySource: InputSourceTally
 }
 
 let active: ProbeState | null = null
@@ -74,6 +87,10 @@ export type TypingLatencyReport = {
   echoPaintMs: LatencyPercentiles
   bytesPerKeystroke: LatencyPercentiles
   writesPerKeystroke: LatencyPercentiles
+  /** Same latencies split by IME commit vs plain keypress. */
+  byInputSource: InputSourceBreakdown
+  /** How much of the sampling window the renderer had no free main thread. */
+  mainThreadBlocking: MainThreadBlockingCensus
   census: TypingScaleCensus
 }
 
@@ -92,6 +109,17 @@ function buildReport(state: ProbeState | null, running: boolean): TypingLatencyR
     echoPaintMs: summarizeLatencySamples(state?.paintLatencies ?? []),
     bytesPerKeystroke: summarizeLatencySamples(state?.keystrokeBytes ?? []),
     writesPerKeystroke: summarizeLatencySamples(state?.keystrokeWrites ?? []),
+    byInputSource: state?.bySource.breakdown() ?? emptyInputSourceBreakdown(),
+    mainThreadBlocking: state?.blocking.census() ?? {
+      supported: false,
+      windowMs: 0,
+      taskCount: 0,
+      blockedMs: 0,
+      blockedPercent: 0,
+      longestTaskMs: 0,
+      p50TaskMs: 0,
+      p95TaskMs: 0
+    },
     census: summarizeTypingScaleCensus({
       state: readProbeStoreState(),
       appVersion: cachedAppVersion,
@@ -113,8 +141,15 @@ function cacheAppVersion(): void {
     .catch(() => undefined)
 }
 
-/** Modifier-only presses produce no echo and would poison the pending queue. */
+/**
+ * Modifier-only presses produce no echo and would poison the pending queue.
+ * IME keydowns are excluded too: a composing jamo sends nothing to the pty, so
+ * the commit (compositionend) is what carries the echo — see startProbe.
+ */
 function isEchoingKey(event: KeyboardEvent): boolean {
+  if (event.isComposing || event.key === 'Process') {
+    return false
+  }
   return event.key.length === 1 || event.key === 'Enter' || event.key === 'Backspace'
 }
 
@@ -134,7 +169,9 @@ function startProbe(): string {
     unmatchedKeystrokes: 0,
     keystrokesWithoutTerminalFocus: 0,
     panes: [],
-    detachKeydown: () => undefined
+    detachKeydown: () => undefined,
+    blocking: watchMainThreadBlocking(),
+    bySource: createInputSourceTally()
   }
   state.panes = listProbePanes().map((pane) =>
     instrumentPaneEcho(pane, (sample) => {
@@ -142,6 +179,7 @@ function startProbe(): string {
       push(state.paintLatencies, sample.paintMs)
       push(state.keystrokeBytes, sample.bytes)
       push(state.keystrokeWrites, sample.writes)
+      state.bySource.add(sample)
     })
   )
 
@@ -154,10 +192,29 @@ function startProbe(): string {
       state.keystrokesWithoutTerminalFocus += 1
       return
     }
-    state.unmatchedKeystrokes += recordKeystroke(target, performance.now())
+    state.unmatchedKeystrokes += recordKeystroke(target, performance.now(), 'direct')
+  }
+  // Why: a CJK IME sends nothing to the pty per jamo, so the composed commit is
+  // the keystroke whose echo can be timed. Without this the probe reports zero
+  // samples for Hangul typing and the percentiles read as "no latency".
+  const onCompositionEnd = (event: CompositionEvent): void => {
+    if (event.data.length === 0) {
+      return
+    }
+    const target = findPaneOwningFocus(state.panes)
+    if (!target) {
+      state.keystrokesWithoutTerminalFocus += 1
+      return
+    }
+    state.bySource.addCommitChars(event.data.length)
+    state.unmatchedKeystrokes += recordKeystroke(target, performance.now(), 'ime')
   }
   window.addEventListener('keydown', onKeydown, { capture: true })
-  state.detachKeydown = () => window.removeEventListener('keydown', onKeydown, { capture: true })
+  window.addEventListener('compositionend', onCompositionEnd, { capture: true })
+  state.detachKeydown = () => {
+    window.removeEventListener('keydown', onKeydown, { capture: true })
+    window.removeEventListener('compositionend', onCompositionEnd, { capture: true })
+  }
 
   active = state
   lastState = state
@@ -171,6 +228,7 @@ function stopProbe(): string {
   }
   active = null
   state.detachKeydown()
+  state.blocking.stop()
   for (const entry of state.panes) {
     detachPaneEcho(entry)
   }

--- a/src/renderer/src/lib/typing-latency-echo-instrumentation.test.ts
+++ b/src/renderer/src/lib/typing-latency-echo-instrumentation.test.ts
@@ -8,7 +8,7 @@ import {
 } from './typing-latency-echo-instrumentation'
 
 function emptyEntry(): InstrumentedPane {
-  return { pane: {}, pending: [], disposables: [], restoreWrite: null, lastEchoCoalescing: 0 }
+  return { pane: {}, pending: [], disposables: [], restoreWrite: null }
 }
 
 type FakeTerminal = {
@@ -149,6 +149,27 @@ describe('instrumentPaneEcho', () => {
     expect(fake.terminal.write).toBe(originalWrite)
     expect(fake.disposeCount()).toBe(2)
     expect(entry.pending).toEqual([])
+  })
+
+  // The regression: a shared coalescing slot let a later batch overwrite the
+  // count before the earlier batch's samples were drained by a render.
+  it('keeps each batch its own coalescing count when two writes parse before a render', () => {
+    const fake = fakeTerminal()
+    const samples: EchoSample[] = []
+    const entry = instrumentPaneEcho({ terminal: fake.terminal }, (sample) => samples.push(sample))
+
+    recordKeystroke(entry, 0, 'direct')
+    recordKeystroke(entry, 1, 'direct')
+    fake.terminal.write('ab')
+    fake.emitParsed()
+
+    recordKeystroke(entry, 2, 'direct')
+    fake.terminal.write('c')
+    fake.emitParsed()
+
+    fake.emitRender()
+
+    expect(samples.map((sample) => sample.coalescing)).toEqual([2, 2, 1])
   })
 
   it('degrades to a no-op instead of throwing when the pane has no terminal', () => {

--- a/src/renderer/src/lib/typing-latency-echo-instrumentation.test.ts
+++ b/src/renderer/src/lib/typing-latency-echo-instrumentation.test.ts
@@ -8,7 +8,7 @@ import {
 } from './typing-latency-echo-instrumentation'
 
 function emptyEntry(): InstrumentedPane {
-  return { pane: {}, pending: [], disposables: [], restoreWrite: null }
+  return { pane: {}, pending: [], disposables: [], restoreWrite: null, lastEchoCoalescing: 0 }
 }
 
 type FakeTerminal = {
@@ -60,23 +60,23 @@ function fakeTerminal(): {
 describe('recordKeystroke', () => {
   it('queues keystrokes rather than overwriting a single slot', () => {
     const entry = emptyEntry()
-    expect(recordKeystroke(entry, 0)).toBe(0)
-    expect(recordKeystroke(entry, 5)).toBe(0)
+    expect(recordKeystroke(entry, 0, 'direct')).toBe(0)
+    expect(recordKeystroke(entry, 5, 'direct')).toBe(0)
     expect(entry.pending.map((pending) => pending.t0)).toEqual([0, 5])
   })
 
   it('counts keystrokes whose echo never parsed as dropped', () => {
     const entry = emptyEntry()
-    recordKeystroke(entry, 0)
-    recordKeystroke(entry, 1)
-    expect(recordKeystroke(entry, 5000)).toBe(2)
+    recordKeystroke(entry, 0, 'direct')
+    recordKeystroke(entry, 1, 'direct')
+    expect(recordKeystroke(entry, 5000, 'direct')).toBe(2)
     expect(entry.pending).toHaveLength(1)
   })
 
   it('bounds the queue so sustained typing cannot grow memory', () => {
     const entry = emptyEntry()
     for (let index = 0; index < 200; index += 1) {
-      recordKeystroke(entry, index)
+      recordKeystroke(entry, index, 'direct')
     }
     expect(entry.pending.length).toBeLessThanOrEqual(64)
   })
@@ -88,7 +88,7 @@ describe('instrumentPaneEcho', () => {
     const samples: EchoSample[] = []
     const entry = instrumentPaneEcho({ terminal: fake.terminal }, (sample) => samples.push(sample))
 
-    recordKeystroke(entry, performance.now())
+    recordKeystroke(entry, performance.now(), 'direct')
     fake.terminal.write('a'.repeat(230))
     fake.terminal.write(new Uint8Array(6))
     fake.emitParsed()
@@ -103,12 +103,33 @@ describe('instrumentPaneEcho', () => {
     expect(fake.writtenPayloads).toHaveLength(2)
   })
 
+  it('credits one coalesced redraw to every keystroke it made visible', () => {
+    const fake = fakeTerminal()
+    const samples: EchoSample[] = []
+    const entry = instrumentPaneEcho({ terminal: fake.terminal }, (sample) => samples.push(sample))
+
+    // Typing faster than the TUI's frame clock: three keystrokes, one redraw.
+    recordKeystroke(entry, performance.now(), 'direct')
+    recordKeystroke(entry, performance.now(), 'direct')
+    recordKeystroke(entry, performance.now(), 'ime')
+    fake.terminal.write('x'.repeat(90))
+    fake.emitParsed()
+    fake.emitRender()
+
+    expect(samples).toHaveLength(3)
+    // Every keystroke reports the redraw that showed it, so the two divide.
+    expect(samples.map((sample) => sample.coalescing)).toEqual([3, 3, 3])
+    expect(samples.map((sample) => sample.bytes)).toEqual([90, 90, 90])
+    expect(samples.map((sample) => sample.writes)).toEqual([1, 1, 1])
+    expect(samples.map((sample) => sample.source)).toEqual(['direct', 'direct', 'ime'])
+  })
+
   it('holds an unparsed keystroke across a render instead of discarding it', () => {
     const fake = fakeTerminal()
     const samples: EchoSample[] = []
     const entry = instrumentPaneEcho({ terminal: fake.terminal }, (sample) => samples.push(sample))
 
-    recordKeystroke(entry, performance.now())
+    recordKeystroke(entry, performance.now(), 'direct')
     fake.emitRender()
     expect(samples).toHaveLength(0)
 

--- a/src/renderer/src/lib/typing-latency-echo-instrumentation.ts
+++ b/src/renderer/src/lib/typing-latency-echo-instrumentation.ts
@@ -17,6 +17,7 @@ type TerminalLike = {
   element?: HTMLElement | null
   buffer?: { active?: { type?: string; length?: number } }
   write?: (data: string | Uint8Array, callback?: () => void) => void
+  onData?: (listener: (data: string) => void) => Disposable
   onWriteParsed?: (listener: () => void) => Disposable
   onRender?: (listener: () => void) => Disposable
 }
@@ -28,10 +29,16 @@ export type ProbePane = {
   leafId?: string
 }
 
+/** 'ime' is a composed commit (compositionend); 'direct' is a plain keydown. */
+export type KeystrokeSource = 'ime' | 'direct'
+
 type PendingKeystroke = {
   t0: number
+  source: KeystrokeSource
   bytes: number
   writes: number
+  /** When xterm emitted the bytes toward the pty; null if it never did. */
+  dispatchedAt: number | null
   parsedAt: number | null
 }
 
@@ -40,6 +47,15 @@ export type EchoSample = {
   paintMs: number
   bytes: number
   writes: number
+  source: KeystrokeSource
+  /** How many keystrokes the echoing write resolved at once. */
+  coalescing: number
+  /**
+   * Keystroke to the moment xterm handed the bytes toward the pty, so the rest
+   * of the wait can be attributed to the host round trip rather than to the
+   * renderer. -1 when no dispatch was seen (a preedit jamo sends nothing).
+   */
+  dispatchMs: number
 }
 
 export type InstrumentedPane = {
@@ -47,6 +63,7 @@ export type InstrumentedPane = {
   pending: PendingKeystroke[]
   disposables: Disposable[]
   restoreWrite: (() => void) | null
+  lastEchoCoalescing: number
 }
 
 /** An echo that has not parsed within this window is counted as unmatched, never as a sample. */
@@ -79,12 +96,35 @@ export function findPaneOwningFocus<T extends { pane: ProbePane }>(
   return entries.find((entry) => paneRootElement(entry.pane)?.contains(focused) === true) ?? null
 }
 
-function oldestUnparsed(entry: InstrumentedPane): PendingKeystroke | null {
-  return entry.pending.find((pending) => pending.parsedAt === null) ?? null
+/**
+ * Every keystroke still waiting for an echo.
+ *
+ * Why the whole set and not just the oldest: a TUI redraws on its own frame
+ * clock, so typing faster than that clock puts several keystrokes into one
+ * redraw. That redraw is what makes each of them visible, so it is their echo
+ * and their byte cost alike. Crediting only the oldest left the rest pending
+ * forever — the probe dropped most of a fast burst and kept exactly the entries
+ * that had waited longest, reporting a p50 biased upward.
+ */
+function pendingAwaitingEcho(entry: InstrumentedPane): PendingKeystroke[] {
+  return entry.pending.filter((pending) => pending.parsedAt === null)
+}
+
+/** Marks the whole waiting set echoed, returning how many one write resolved. */
+function markPendingEcho(entry: InstrumentedPane, at: number): number {
+  const waiting = pendingAwaitingEcho(entry)
+  for (const pending of waiting) {
+    pending.parsedAt = at
+  }
+  return waiting.length
 }
 
 /** Returns how many pending keystrokes were dropped without an echo. */
-export function recordKeystroke(entry: InstrumentedPane, now: number): number {
+export function recordKeystroke(
+  entry: InstrumentedPane,
+  now: number,
+  source: KeystrokeSource
+): number {
   let dropped = 0
   while (entry.pending.length > 0 && now - (entry.pending[0]?.t0 ?? now) > ECHO_TIMEOUT_MS) {
     entry.pending.shift()
@@ -94,7 +134,7 @@ export function recordKeystroke(entry: InstrumentedPane, now: number): number {
     entry.pending.shift()
     dropped += 1
   }
-  entry.pending.push({ t0: now, bytes: 0, writes: 0, parsedAt: null })
+  entry.pending.push({ t0: now, source, bytes: 0, writes: 0, dispatchedAt: null, parsedAt: null })
   return dropped
 }
 
@@ -102,22 +142,30 @@ export function instrumentPaneEcho(
   pane: ProbePane,
   onSample: (sample: EchoSample) => void
 ): InstrumentedPane {
-  const entry: InstrumentedPane = { pane, pending: [], disposables: [], restoreWrite: null }
+  const entry: InstrumentedPane = {
+    pane,
+    pending: [],
+    disposables: [],
+    restoreWrite: null,
+    lastEchoCoalescing: 0
+  }
   const terminal = pane.terminal
   if (!terminal) {
     return entry
   }
 
   // Why: xterm exposes no per-write byte counter, so the probe wraps write() for
-  // the duration of sampling — this is how per-keystroke output volume (Codex
+  // the duration of sampling — this is how per-echo output volume (Codex
   // ~230-306 bytes vs grok ~66) becomes visible without a build change.
   const originalWrite = terminal.write
   if (typeof originalWrite === 'function') {
     const wrapped = (data: string | Uint8Array, callback?: () => void): void => {
-      const pending = oldestUnparsed(entry)
-      if (pending) {
+      const size = typeof data === 'string' ? data.length : data.byteLength
+      // Coalesced keystrokes each report the whole echoing write; `coalescing`
+      // on the sample says how many shared it, so the two divide.
+      for (const pending of pendingAwaitingEcho(entry)) {
         pending.writes += 1
-        pending.bytes += typeof data === 'string' ? data.length : data.byteLength
+        pending.bytes += size
       }
       originalWrite.call(terminal, data, callback)
     }
@@ -129,12 +177,25 @@ export function instrumentPaneEcho(
     }
   }
 
+  // Why: an IME commit reaches the pty through terminal.input(), which lands on
+  // this same emitter, so it stamps the moment the renderer is done with the
+  // keystroke. Everything after it is host round trip, not renderer work.
+  if (typeof terminal.onData === 'function') {
+    entry.disposables.push(
+      terminal.onData(() => {
+        const now = performance.now()
+        for (const pending of pendingAwaitingEcho(entry)) {
+          pending.dispatchedAt ??= now
+        }
+      })
+    )
+  }
   if (typeof terminal.onWriteParsed === 'function') {
     entry.disposables.push(
       terminal.onWriteParsed(() => {
-        const pending = oldestUnparsed(entry)
-        if (pending) {
-          pending.parsedAt = performance.now()
+        const resolved = markPendingEcho(entry, performance.now())
+        if (resolved > 0) {
+          entry.lastEchoCoalescing = resolved
         }
       })
     )
@@ -152,7 +213,10 @@ export function instrumentPaneEcho(
             parseMs: pending.parsedAt - pending.t0,
             paintMs: now - pending.t0,
             bytes: pending.bytes,
-            writes: pending.writes
+            writes: pending.writes,
+            source: pending.source,
+            coalescing: entry.lastEchoCoalescing,
+            dispatchMs: pending.dispatchedAt === null ? -1 : pending.dispatchedAt - pending.t0
           })
         }
       })

--- a/src/renderer/src/lib/typing-latency-echo-instrumentation.ts
+++ b/src/renderer/src/lib/typing-latency-echo-instrumentation.ts
@@ -40,6 +40,8 @@ type PendingKeystroke = {
   /** When xterm emitted the bytes toward the pty; null if it never did. */
   dispatchedAt: number | null
   parsedAt: number | null
+  /** How many keystrokes the echoing write resolved alongside this one. */
+  coalescing: number
 }
 
 export type EchoSample = {
@@ -63,7 +65,6 @@ export type InstrumentedPane = {
   pending: PendingKeystroke[]
   disposables: Disposable[]
   restoreWrite: (() => void) | null
-  lastEchoCoalescing: number
 }
 
 /** An echo that has not parsed within this window is counted as unmatched, never as a sample. */
@@ -110,11 +111,18 @@ function pendingAwaitingEcho(entry: InstrumentedPane): PendingKeystroke[] {
   return entry.pending.filter((pending) => pending.parsedAt === null)
 }
 
-/** Marks the whole waiting set echoed, returning how many one write resolved. */
+/**
+ * Marks the whole waiting set echoed, returning how many one write resolved.
+ *
+ * The count is stored per keystroke, not on the pane: a second write can parse
+ * before the render that drains the first batch, and a shared slot would then
+ * report the later batch's size for the earlier samples.
+ */
 function markPendingEcho(entry: InstrumentedPane, at: number): number {
   const waiting = pendingAwaitingEcho(entry)
   for (const pending of waiting) {
     pending.parsedAt = at
+    pending.coalescing = waiting.length
   }
   return waiting.length
 }
@@ -134,7 +142,15 @@ export function recordKeystroke(
     entry.pending.shift()
     dropped += 1
   }
-  entry.pending.push({ t0: now, source, bytes: 0, writes: 0, dispatchedAt: null, parsedAt: null })
+  entry.pending.push({
+    t0: now,
+    source,
+    bytes: 0,
+    writes: 0,
+    dispatchedAt: null,
+    parsedAt: null,
+    coalescing: 0
+  })
   return dropped
 }
 
@@ -146,8 +162,7 @@ export function instrumentPaneEcho(
     pane,
     pending: [],
     disposables: [],
-    restoreWrite: null,
-    lastEchoCoalescing: 0
+    restoreWrite: null
   }
   const terminal = pane.terminal
   if (!terminal) {
@@ -193,10 +208,7 @@ export function instrumentPaneEcho(
   if (typeof terminal.onWriteParsed === 'function') {
     entry.disposables.push(
       terminal.onWriteParsed(() => {
-        const resolved = markPendingEcho(entry, performance.now())
-        if (resolved > 0) {
-          entry.lastEchoCoalescing = resolved
-        }
+        markPendingEcho(entry, performance.now())
       })
     )
   }
@@ -215,7 +227,7 @@ export function instrumentPaneEcho(
             bytes: pending.bytes,
             writes: pending.writes,
             source: pending.source,
-            coalescing: entry.lastEchoCoalescing,
+            coalescing: pending.coalescing,
             dispatchMs: pending.dispatchedAt === null ? -1 : pending.dispatchedAt - pending.t0
           })
         }

--- a/src/renderer/src/lib/typing-latency-input-source.ts
+++ b/src/renderer/src/lib/typing-latency-input-source.ts
@@ -1,0 +1,105 @@
+/**
+ * Splits typing-latency samples by how the character was entered.
+ *
+ * Why: a Hangul (or any CJK) commit and a plain keypress travel different
+ * amounts of work — the commit hands the TUI a whole composed syllable while a
+ * preedit jamo sends nothing at all — so pooling them into one percentile hides
+ * which of the two is actually slow. Reporting them side by side is what
+ * separates "IME input is slow" from "input is slow and the IME just makes each
+ * character cost three keystrokes' worth of feedback".
+ */
+import {
+  histogramLatencySamples,
+  summarizeLatencySamples,
+  type LatencyHistogram,
+  type LatencyPercentiles
+} from './typing-latency-diagnostic-summary'
+import type { EchoSample, KeystrokeSource } from './typing-latency-echo-instrumentation'
+
+/** Bounds memory during sustained typing; percentiles only need a rolling window. */
+const MAX_SAMPLES = 2000
+
+type SourceSamples = {
+  parseMs: number[]
+  paintMs: number[]
+  bytes: number[]
+  coalescing: number[]
+  dispatchMs: number[]
+}
+
+export type InputSourceLatency = {
+  echoParseMs: LatencyPercentiles
+  echoPaintMs: LatencyPercentiles
+  bytesPerKeystroke: LatencyPercentiles
+  /** Keystrokes resolved by one echoing write; >1 means the TUI batched them. */
+  echoCoalescing: LatencyPercentiles
+  /** Commit to the moment xterm handed bytes to the pty; the rest is round trip. */
+  dispatchMs: LatencyPercentiles
+  /** Bucketed echoPaintMs; a second mode above 128ms means a slow scheduling path. */
+  echoPaintHistogram: LatencyHistogram
+}
+
+export type InputSourceBreakdown = {
+  ime: InputSourceLatency
+  direct: InputSourceLatency
+  /** Characters carried by each composition commit; 1 for a single Hangul syllable. */
+  imeCommitChars: LatencyPercentiles
+}
+
+export type InputSourceTally = {
+  add: (sample: EchoSample) => void
+  addCommitChars: (count: number) => void
+  breakdown: () => InputSourceBreakdown
+}
+
+function emptySamples(): SourceSamples {
+  return { parseMs: [], paintMs: [], bytes: [], coalescing: [], dispatchMs: [] }
+}
+
+function push(values: number[], value: number): void {
+  values.push(value)
+  if (values.length > MAX_SAMPLES) {
+    values.shift()
+  }
+}
+
+function summarize(samples: SourceSamples): InputSourceLatency {
+  return {
+    echoParseMs: summarizeLatencySamples(samples.parseMs),
+    echoPaintMs: summarizeLatencySamples(samples.paintMs),
+    bytesPerKeystroke: summarizeLatencySamples(samples.bytes),
+    echoCoalescing: summarizeLatencySamples(samples.coalescing),
+    // Preedit jamo dispatch nothing and report -1; excluding them keeps the
+    // percentile about real dispatches instead of averaging in a sentinel.
+    dispatchMs: summarizeLatencySamples(samples.dispatchMs.filter((value) => value >= 0)),
+    echoPaintHistogram: histogramLatencySamples(samples.paintMs)
+  }
+}
+
+export function createInputSourceTally(): InputSourceTally {
+  const bySource: Record<KeystrokeSource, SourceSamples> = {
+    ime: emptySamples(),
+    direct: emptySamples()
+  }
+  const commitChars: number[] = []
+  return {
+    add: (sample) => {
+      const bucket = bySource[sample.source]
+      push(bucket.parseMs, sample.parseMs)
+      push(bucket.paintMs, sample.paintMs)
+      push(bucket.bytes, sample.bytes)
+      push(bucket.coalescing, sample.coalescing)
+      push(bucket.dispatchMs, sample.dispatchMs)
+    },
+    addCommitChars: (count) => push(commitChars, count),
+    breakdown: () => ({
+      ime: summarize(bySource.ime),
+      direct: summarize(bySource.direct),
+      imeCommitChars: summarizeLatencySamples(commitChars)
+    })
+  }
+}
+
+export function emptyInputSourceBreakdown(): InputSourceBreakdown {
+  return createInputSourceTally().breakdown()
+}

--- a/src/renderer/src/lib/typing-latency-main-thread-blocking.ts
+++ b/src/renderer/src/lib/typing-latency-main-thread-blocking.ts
@@ -36,7 +36,11 @@ function percentile(sorted: readonly number[], fraction: number): number {
   if (sorted.length === 0) {
     return 0
   }
-  const index = Math.min(sorted.length - 1, Math.floor(sorted.length * fraction))
+  // Nearest-rank, matching summarizeLatencySamples: the two appear side by side
+  // in one report, and a p95 that means different things in each is worse than
+  // either convention on its own.
+  const rank = Math.ceil(fraction * sorted.length)
+  const index = Math.min(sorted.length - 1, Math.max(0, rank - 1))
   return sorted[index] ?? 0
 }
 

--- a/src/renderer/src/lib/typing-latency-main-thread-blocking.ts
+++ b/src/renderer/src/lib/typing-latency-main-thread-blocking.ts
@@ -1,0 +1,104 @@
+/**
+ * Main-thread blocking census for the typing-latency probe.
+ *
+ * Why: echo latency says the keystroke was slow but not why. A keystroke can
+ * only be served between tasks, so long tasks are the budget the echo competes
+ * for. Sampling them alongside the echo separates "the terminal write path is
+ * slow" from "the renderer had no free main thread" — the latter points at
+ * whatever else is committing, not at the pane.
+ */
+
+type LongTaskSample = {
+  durationMs: number
+  startedAt: number
+}
+
+export type MainThreadBlockingCensus = {
+  supported: boolean
+  windowMs: number
+  taskCount: number
+  blockedMs: number
+  blockedPercent: number
+  longestTaskMs: number
+  p50TaskMs: number
+  p95TaskMs: number
+}
+
+/** Bounds memory during a long probe run; percentiles only need a rolling window. */
+const MAX_SAMPLES = 2000
+
+export type MainThreadBlockingWatch = {
+  stop: () => void
+  census: () => MainThreadBlockingCensus
+}
+
+function percentile(sorted: readonly number[], fraction: number): number {
+  if (sorted.length === 0) {
+    return 0
+  }
+  const index = Math.min(sorted.length - 1, Math.floor(sorted.length * fraction))
+  return sorted[index] ?? 0
+}
+
+function emptyCensus(windowMs: number, supported: boolean): MainThreadBlockingCensus {
+  return {
+    supported,
+    windowMs: Math.round(windowMs),
+    taskCount: 0,
+    blockedMs: 0,
+    blockedPercent: 0,
+    longestTaskMs: 0,
+    p50TaskMs: 0,
+    p95TaskMs: 0
+  }
+}
+
+/**
+ * Observes long tasks (>50ms) until `stop()`. `census()` summarizes everything
+ * seen since the call. Safe on engines without the longtask entry type:
+ * `supported` reports false and every count stays zero rather than throwing.
+ */
+export function watchMainThreadBlocking(): MainThreadBlockingWatch {
+  const samples: LongTaskSample[] = []
+  const startedAt = typeof performance === 'undefined' ? 0 : performance.now()
+  let observer: PerformanceObserver | null = null
+  try {
+    observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        samples.push({ durationMs: entry.duration, startedAt: entry.startTime })
+        if (samples.length > MAX_SAMPLES) {
+          samples.shift()
+        }
+      }
+    })
+    observer.observe({ entryTypes: ['longtask'] })
+  } catch {
+    observer = null
+  }
+  const supported = observer !== null
+  return {
+    stop: () => {
+      observer?.disconnect()
+      observer = null
+    },
+    census: () => {
+      const now = typeof performance === 'undefined' ? startedAt : performance.now()
+      const windowMs = Math.max(1, now - startedAt)
+      if (samples.length === 0) {
+        return emptyCensus(windowMs, supported)
+      }
+      const durations = samples.map((sample) => sample.durationMs).sort((a, b) => a - b)
+      const blockedMs = durations.reduce((sum, value) => sum + value, 0)
+      return {
+        supported,
+        windowMs: Math.round(windowMs),
+        taskCount: samples.length,
+        blockedMs: Math.round(blockedMs),
+        blockedPercent: Math.round((blockedMs / windowMs) * 100),
+        longestTaskMs: Math.round(durations.at(-1) ?? 0),
+        p50TaskMs: Math.round(percentile(durations, 0.5)),
+        p95TaskMs: Math.round(percentile(durations, 0.95))
+      }
+    }
+  }
+}

--- a/src/renderer/src/lib/typing-latency-main-thread-blocking.ts
+++ b/src/renderer/src/lib/typing-latency-main-thread-blocking.ts
@@ -60,7 +60,12 @@ function emptyCensus(windowMs: number, supported: boolean): MainThreadBlockingCe
  */
 export function watchMainThreadBlocking(): MainThreadBlockingWatch {
   const samples: LongTaskSample[] = []
-  const startedAt = typeof performance === 'undefined' ? 0 : performance.now()
+  const now = (): number => (typeof performance === 'undefined' ? 0 : performance.now())
+  const startedAt = now()
+  // Why the window closes at stop(): the observer stops collecting there, so
+  // counting wall clock up to the later report() call would divide the same
+  // blocked time by a longer window and understate the share.
+  let stoppedAt: number | null = null
   let observer: PerformanceObserver | null = null
   try {
     observer = new PerformanceObserver((list) => {
@@ -80,10 +85,10 @@ export function watchMainThreadBlocking(): MainThreadBlockingWatch {
     stop: () => {
       observer?.disconnect()
       observer = null
+      stoppedAt ??= now()
     },
     census: () => {
-      const now = typeof performance === 'undefined' ? startedAt : performance.now()
-      const windowMs = Math.max(1, now - startedAt)
+      const windowMs = Math.max(1, (stoppedAt ?? now()) - startedAt)
       if (samples.length === 0) {
         return emptyCensus(windowMs, supported)
       }


### PR DESCRIPTION
## ELI5

There is a built-in stopwatch for "how long from keypress to seeing the character" (`window.__orcaTypingDiagnostic`). Typing Korean produced **zero** readings, so it looked like Korean had no latency at all. It also threw away most of a fast burst and kept the slowest ones. This fixes the stopwatch, then adds the readings that say *where* the time went.

## What Changed

**CJK input is sampled at all.** `isEchoingKey` returns false while `event.isComposing` is true, so a composed character was never recorded. Composing jamo genuinely send nothing to the pty — the commit is what carries the echo — so `compositionend` starts the timer, and IME keydowns are now excluded explicitly rather than by accident.

**Fast bursts are no longer dropped.** A TUI redraws on its own frame clock, so typing faster than that clock puts several keystrokes into one redraw. `oldestUnparsed` credited only the oldest to that redraw and the rest stayed pending forever, so the surviving samples were the ones that had waited longest and p50 was biased upward. The whole waiting set is credited now; `coalescing` on the sample says how many shared the write, and each reports the redraw's byte count so the two divide.

**Two shared slots that let one sample carry another's figures.** The coalescing count lived on the pane, so a second write parsing before the render that drained the first batch overwrote it — it is stored per keystroke now, assigned where the echo is marked. The blocking census measured up to whenever `census()` was called, including idle time after `stop()` had detached the observer — the window closes at `stop()`.

**New readings.**

- `mainThreadBlocking` — long-task count, blocked milliseconds, and share of the window. Answers "was the renderer even free to serve this keystroke", which the echo timings alone cannot
- `byInputSource` — IME commits and plain keypresses summarized separately, plus `imeCommitChars`. Pooling them hides which of the two is slow
- `dispatchMs` — keystroke to the moment xterm handed bytes toward the pty, separating the renderer's share from the host round trip
- `echoPaintHistogram` — fixed buckets rather than derived ones, because the paths a keystroke can take sit at known delays (a ~16-32ms fast release vs a 250ms hold-safety fallback vs a 1s coalesce). Percentiles average two modes into one number that matches neither

## Why

This is the tool the other two fixes were measured with, so it had to be right first. Concretely: with the old probe, an investigation into Korean typing latency reads zero samples and concludes there is nothing to fix — which is the opposite of the truth.

## Linked Issue

Fixes #16950

## Visual Proof

`N/A` — no UI. This code is inert until `window.__orcaTypingDiagnostic.start()` is called from the renderer console.

What the fixed probe reports, for reference (agent pane, idle, 16 composed syllables):

```
blocked      0 tasks / 0%
dispatch p50 1.6ms          ← renderer's share
paint    p50 28.5ms  p95 43.4ms
bytes    p50 58             ← vs 6 in a plain PowerShell pane
coalescing   1
```

The 58-vs-6 bytes split is the kind of thing the old probe could not surface, and it is what identifies the agent TUI's own redraw — not Orca — as the dominant per-syllable cost in that pane.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`typing-latency-echo-instrumentation.test.ts` gained coverage for several keystrokes resolving through one redraw, and for the ordering regression: two writes parsing before a single render must report `[2, 2, 1]`, not `[1, 1, 1]` or `[1, 1, ...]` from a shared slot.

```
tsc --noEmit (web project)   0 errors
oxlint (repo)                0 errors
vitest typing-latency-*      9 passed  (echo instrumentation)
vitest src/renderer/src/lib/ 460 files, 4413 passed, 1 skipped
pnpm run build:desktop       passes
```

Platform: **Windows 11**. All of it is renderer-side probe logic and platform-independent. `pnpm test` could not run in my environment — the `ensure-native-runtime --runtime=node` prestep fails to rebuild `node-pty` for Node 24 — so vitest was invoked directly.

## AI Disclosure

Written with Claude Opus 5 (Claude Code).

## Review

**Cross-platform** — no platform branch; `PerformanceObserver` with the `longtask` entry type is feature-detected and degrades to `supported: false` with zeroed counts rather than throwing.

**SSH / remote** — renderer-local. No transport, pty, or execution-host code touched.

**Agents / integrations** — agent-neutral. `byInputSource` splits by how the character was entered, not by which agent is running.

**Backwards compatibility** — `TypingLatencyReport` gains fields; existing ones keep their meaning. `recordKeystroke` takes a third `source` argument, and its only callers are in this file's module group.

**Performance** — inert until `start()`. While running, samples are bounded to a rolling 2000 per series, and the write wrapper is restored on detach.

**Security** — no new IPC, no new input path. It reads keystroke timings and byte counts, never keystroke content.

## Known gaps

- `bytesPerKeystroke` reports the whole echoing write for every keystroke that shared it, with `coalescing` as the divisor. That is deliberate — pre-dividing would lose "how many bytes did one redraw cost" — but the field name invites the other reading, and a consumer that ignores `coalescing` will overcount.
- The probe still cannot see the composer in the Native Chat view: echo instrumentation attaches to xterm panes only, so a chat-side measurement needs a separate page-side probe.
