### PR TITLE
feat(ai-vault): add setting to skip WSL distros in session history scan

### DIFF
--- a/src/main/ai-vault/cached-session-list.ts
+++ b/src/main/ai-vault/cached-session-list.ts
@@ -4,7 +4,11 @@ import {
   resetAiVaultScannerBackgroundForTests,
   scanAiVaultSessionsInBackground
 } from './session-scanner-background'
-import { getWslHomeAsync, listWslDistrosAsync } from '../wsl'
+import {
+  configureWslSessionHomeDirs,
+  listWslSessionHomeDirs,
+  resetWslSessionHomeDirsForTests
+} from './wsl-session-home-dirs'
 import type { AiVaultListArgs, AiVaultListResult } from '../../shared/ai-vault-types'
 import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 import { AiVaultScanCoordinator } from './ai-vault-scan-coordinator'
@@ -26,6 +30,8 @@ const AI_VAULT_CACHE_TTL_MS = 60_000
 // drop managed-Codex sessions from remote/SSH results.
 export type AiVaultSessionSources = {
   getAdditionalCodexHomePaths?: () => readonly string[]
+  /** Windows-only opt-out: false skips the per-distro `$HOME` probe that boots stopped distros. */
+  isWslSessionScanEnabled?: () => boolean
 }
 
 type CachedAiVaultList = {
@@ -46,6 +52,7 @@ let cacheGeneration = 0
 
 export function configureAiVaultSessionSources(next: AiVaultSessionSources): void {
   sources = next
+  configureWslSessionHomeDirs({ isEnabled: next.isWslSessionScanEnabled })
 }
 
 export async function listAiVaultSessions(
@@ -120,14 +127,8 @@ export async function listAiVaultSessions(
 
 // Exported for the subagent-transcript IPC path, which validates
 // renderer-supplied paths against the same WSL-aware Claude roots the scan uses.
-export async function getAiVaultWslHomeDirs(): Promise<string[]> {
-  if (process.platform !== 'win32') {
-    return []
-  }
-  const homes = await Promise.all(
-    (await listWslDistrosAsync()).map((distro) => getWslHomeAsync(distro))
-  )
-  return homes.filter((homeDir): homeDir is string => Boolean(homeDir))
+export function getAiVaultWslHomeDirs(): Promise<string[]> {
+  return listWslSessionHomeDirs()
 }
 
 // Drops the scan-result cache after a session is deleted so a non-force
@@ -146,5 +147,6 @@ export function resetAiVaultSessionListCacheForTests(): void {
   invalidateAiVaultSessionListCache()
   scanCoordinator = new AiVaultScanCoordinator()
   sources = {}
+  resetWslSessionHomeDirsForTests()
   resetAiVaultScannerBackgroundForTests()
 }

--- a/src/main/ai-vault/session-scanner-background.ts
+++ b/src/main/ai-vault/session-scanner-background.ts
@@ -53,13 +53,19 @@ export function scanAiVaultSessionsInBackground(
     : scanAiVaultSessionsInWorker(options, signal)
 }
 
+export type AiVaultTitleResolveOptions = {
+  /** False skips WSL guest-path translation (and the distro boot it costs). */
+  includeWslHomes?: boolean
+}
+
 export function resolveAiVaultSessionTitlesInBackground(
   requests: AiVaultSessionTitleRequest[],
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  options: AiVaultTitleResolveOptions = {}
 ): Promise<AiVaultSessionTitlesResult> {
   return shouldUseAiVaultServiceProcess()
-    ? resolveAiVaultSessionTitlesInService(requests, signal)
-    : resolveAiVaultSessionTitlesInWorker(requests, signal)
+    ? resolveAiVaultSessionTitlesInService(requests, signal, options)
+    : resolveAiVaultSessionTitlesInWorker(requests, signal, options)
 }
 
 export function listAiVaultSubagentSessionsInBackground(

--- a/src/main/ai-vault/session-scanner-service-entry.ts
+++ b/src/main/ai-vault/session-scanner-service-entry.ts
@@ -52,6 +52,7 @@ async function executeRequest(request: AiVaultServiceRequest): Promise<AiVaultSe
     if (request.operation === 'titles') {
       const requests = await resolveHostReadableAiVaultTitleRequests(
         request.requests,
+        request.includeWslHomes !== false,
         controller.signal
       )
       return {

--- a/src/main/ai-vault/session-scanner-service-protocol.ts
+++ b/src/main/ai-vault/session-scanner-service-protocol.ts
@@ -30,6 +30,9 @@ export type AiVaultServiceRequestBody =
       type: 'request'
       operation: 'titles'
       requests: AiVaultSessionTitleRequest[]
+      // Why: per request, not init — init is snapshotted once per client, so a
+      // settings flip would otherwise wait for an app restart. Absent = on.
+      includeWslHomes?: boolean
     }
   | {
       type: 'request'

--- a/src/main/ai-vault/session-scanner-service-spawn.ts
+++ b/src/main/ai-vault/session-scanner-service-spawn.ts
@@ -62,9 +62,13 @@ export function scanAiVaultSessionsInService(
 
 export function resolveAiVaultSessionTitlesInService(
   requests: AiVaultSessionTitleRequest[],
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  options: { includeWslHomes?: boolean } = {}
 ): Promise<AiVaultSessionTitlesResult> {
-  return getSharedClient().request({ type: 'request', operation: 'titles', requests }, signal)
+  return getSharedClient().request(
+    { type: 'request', operation: 'titles', requests, ...options },
+    signal
+  )
 }
 
 export function listAiVaultSubagentSessionsInService(

--- a/src/main/ai-vault/session-scanner-worker-client.ts
+++ b/src/main/ai-vault/session-scanner-worker-client.ts
@@ -55,10 +55,11 @@ export class AiVaultScannerWorkerClient {
 
   resolveTitles(
     requests: AiVaultSessionTitleRequest[],
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    options: { includeWslHomes?: boolean } = {}
   ): Promise<AiVaultSessionTitlesResult> {
     return this.dispatch(
-      { kind: 'titles', requests },
+      { kind: 'titles', requests, ...options },
       TITLE_TIMEOUT_MS,
       signal
     ) as Promise<AiVaultSessionTitlesResult>

--- a/src/main/ai-vault/session-scanner-worker-entry.ts
+++ b/src/main/ai-vault/session-scanner-worker-entry.ts
@@ -51,6 +51,7 @@ async function handleRequest(request: AiVaultWorkerRequest): Promise<AiVaultWork
     if (request.kind === 'titles') {
       const requests = await resolveHostReadableAiVaultTitleRequests(
         request.requests,
+        request.includeWslHomes !== false,
         controller.signal
       )
       return {

--- a/src/main/ai-vault/session-scanner-worker-protocol.ts
+++ b/src/main/ai-vault/session-scanner-worker-protocol.ts
@@ -14,7 +14,12 @@ export type AiVaultWorkerData = {
 
 export type AiVaultWorkerRequest =
   | { id: number; kind: 'scan'; options: AiVaultWorkerScanOptions }
-  | { id: number; kind: 'titles'; requests: AiVaultSessionTitleRequest[] }
+  | {
+      id: number
+      kind: 'titles'
+      requests: AiVaultSessionTitleRequest[]
+      includeWslHomes?: boolean
+    }
 
 export type AiVaultWorkerControl = { id: number; kind: 'cancel' }
 

--- a/src/main/ai-vault/session-scanner-worker-spawn.ts
+++ b/src/main/ai-vault/session-scanner-worker-spawn.ts
@@ -46,9 +46,10 @@ export async function scanAiVaultSessionsInWorker(
 
 export function resolveAiVaultSessionTitlesInWorker(
   requests: AiVaultSessionTitleRequest[],
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  options: { includeWslHomes?: boolean } = {}
 ): Promise<AiVaultSessionTitlesResult> {
-  return getSharedClient().resolveTitles(requests, signal)
+  return getSharedClient().resolveTitles(requests, signal, options)
 }
 
 export function resetAiVaultScannerWorkerForTests(): void {

--- a/src/main/ai-vault/session-title-request-paths.test.ts
+++ b/src/main/ai-vault/session-title-request-paths.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const wslMocks = vi.hoisted(() => ({
+  listWslDistrosAsync: vi.fn(),
+  getWslHomeAsync: vi.fn()
+}))
+
+vi.mock('../wsl', () => ({
+  listWslDistrosAsync: wslMocks.listWslDistrosAsync,
+  getWslHomeAsync: wslMocks.getWslHomeAsync
+}))
+
+vi.mock('../native-chat/wsl-transcript-fs-access', () => ({
+  wslGatedAccess: vi.fn().mockResolvedValue(true)
+}))
+
+import { resetWslSessionHomeDirsForTests } from './wsl-session-home-dirs'
+import { resolveHostReadableAiVaultTitleRequests } from './session-title-request-paths'
+
+const GUEST_PATH = '/home/ada/.codex/sessions/2026/07/24/rollout-sess.jsonl'
+const UNC_PATH =
+  '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.codex\\sessions\\2026\\07\\24\\rollout-sess.jsonl'
+
+beforeEach(() => {
+  resetWslSessionHomeDirsForTests()
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+  wslMocks.listWslDistrosAsync.mockReset().mockResolvedValue(['Ubuntu'])
+  wslMocks.getWslHomeAsync.mockReset().mockResolvedValue('\\\\wsl.localhost\\Ubuntu\\home\\ada')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('resolveHostReadableAiVaultTitleRequests WSL opt-out', () => {
+  it('translates a guest path through the distro homes when WSL scanning is on', async () => {
+    await expect(
+      resolveHostReadableAiVaultTitleRequests(
+        [{ agent: 'codex', sessionId: 'sess', transcriptPath: GUEST_PATH }],
+        true
+      )
+    ).resolves.toEqual([{ agent: 'codex', sessionId: 'sess', transcriptPath: UNC_PATH }])
+    expect(wslMocks.listWslDistrosAsync).toHaveBeenCalledTimes(1)
+  })
+
+  // Why: the scanner child cannot read the store, so the request flag is the
+  // only thing standing between a titles batch and a distro boot.
+  it('degrades a guest path to id-only without touching wsl.exe when off', async () => {
+    await expect(
+      resolveHostReadableAiVaultTitleRequests(
+        [{ agent: 'codex', sessionId: 'sess', transcriptPath: GUEST_PATH }],
+        false
+      )
+    ).resolves.toEqual([{ agent: 'codex', sessionId: 'sess' }])
+    expect(wslMocks.listWslDistrosAsync).not.toHaveBeenCalled()
+    expect(wslMocks.getWslHomeAsync).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ai-vault/session-title-request-paths.ts
+++ b/src/main/ai-vault/session-title-request-paths.ts
@@ -1,15 +1,24 @@
 import type { AiVaultSessionTitleRequest } from '../../shared/ai-vault-session-title'
-import { toHostReadableTranscriptPath } from '../native-chat/host-readable-transcript-path'
+import {
+  needsWslHostTranslation,
+  toHostReadableTranscriptPath
+} from '../native-chat/host-readable-transcript-path'
 import { wslTranscriptFsRefusal } from '../native-chat/wsl-transcript-fs-gate'
 
 export function resolveHostReadableAiVaultTitleRequests(
   requests: AiVaultSessionTitleRequest[],
+  includeWslHomes = true,
   signal?: AbortSignal
 ): Promise<AiVaultSessionTitleRequest[]> {
   return Promise.all(
     requests.map(async (request): Promise<AiVaultSessionTitleRequest> => {
       if (!request.transcriptPath || signal?.aborted) {
         return request
+      }
+      // Why: with WSL scanning off, a guest path has no UNC twin to probe and
+      // translating it would boot the distro — degrade to id-only up front.
+      if (!includeWslHomes && needsWslHostTranslation(request.transcriptPath)) {
+        return { agent: request.agent, sessionId: request.sessionId }
       }
       let transcriptPath: string | null
       try {

--- a/src/main/ai-vault/session-title-resolver.ts
+++ b/src/main/ai-vault/session-title-resolver.ts
@@ -6,6 +6,7 @@ import {
   type AiVaultSessionTitlesResult
 } from '../../shared/ai-vault-session-title'
 import { resolveAiVaultSessionTitlesInBackground } from './session-scanner-background'
+import { isWslSessionScanEnabled } from './wsl-session-home-dirs'
 
 const TRANSCRIPT_PATH_MAX_LENGTH = 32_768
 
@@ -42,5 +43,8 @@ export async function resolveLocalAiVaultSessionTitles(
       deduped.set(key, normalized)
     }
   }
-  return resolveAiVaultSessionTitlesInBackground([...deduped.values()], signal)
+  // Why: the scanner child has no store; it learns the WSL opt-out from the request.
+  return resolveAiVaultSessionTitlesInBackground([...deduped.values()], signal, {
+    includeWslHomes: isWslSessionScanEnabled()
+  })
 }

--- a/src/main/ai-vault/wsl-session-home-dirs.test.ts
+++ b/src/main/ai-vault/wsl-session-home-dirs.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const wslMocks = vi.hoisted(() => ({
+  listWslDistrosAsync: vi.fn(),
+  getWslHomeAsync: vi.fn()
+}))
+
+vi.mock('../wsl', () => ({
+  listWslDistrosAsync: wslMocks.listWslDistrosAsync,
+  getWslHomeAsync: wslMocks.getWslHomeAsync
+}))
+
+import {
+  clearWslSessionHomeDirsCache,
+  configureWslSessionHomeDirs,
+  isWslSessionScanEnabled,
+  listWslSessionHomeDirs,
+  listWslSessionHomeDirsCached,
+  resetWslSessionHomeDirsForTests
+} from './wsl-session-home-dirs'
+
+const UBUNTU_HOME = '\\\\wsl.localhost\\Ubuntu\\home\\ada'
+
+function onWindows(): void {
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+}
+
+beforeEach(() => {
+  resetWslSessionHomeDirsForTests()
+  wslMocks.listWslDistrosAsync.mockReset().mockResolvedValue(['Ubuntu', 'Debian'])
+  wslMocks.getWslHomeAsync
+    .mockReset()
+    .mockImplementation(async (distro: string) => (distro === 'Ubuntu' ? UBUNTU_HOME : null))
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('isWslSessionScanEnabled', () => {
+  it('is on by default on Windows and always off elsewhere', () => {
+    onWindows()
+    expect(isWslSessionScanEnabled()).toBe(true)
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    expect(isWslSessionScanEnabled()).toBe(false)
+  })
+
+  it('follows the configured predicate', () => {
+    onWindows()
+    configureWslSessionHomeDirs({ isEnabled: () => false })
+    expect(isWslSessionScanEnabled()).toBe(false)
+    configureWslSessionHomeDirs({})
+    expect(isWslSessionScanEnabled()).toBe(true)
+  })
+})
+
+describe('listWslSessionHomeDirs', () => {
+  it('resolves each distro home and drops the ones without one', async () => {
+    onWindows()
+    await expect(listWslSessionHomeDirs()).resolves.toEqual([UBUNTU_HOME])
+    expect(wslMocks.getWslHomeAsync).toHaveBeenCalledTimes(2)
+  })
+
+  // The whole point of the opt-out: `wsl.exe -d <distro>` boots the distro, so
+  // a disabled scan must never reach the probe.
+  it('never spawns wsl.exe when the scan is disabled', async () => {
+    onWindows()
+    configureWslSessionHomeDirs({ isEnabled: () => false })
+    await expect(listWslSessionHomeDirs()).resolves.toEqual([])
+    expect(wslMocks.listWslDistrosAsync).not.toHaveBeenCalled()
+    expect(wslMocks.getWslHomeAsync).not.toHaveBeenCalled()
+  })
+
+  it('never spawns wsl.exe off Windows', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    await expect(listWslSessionHomeDirs()).resolves.toEqual([])
+    expect(wslMocks.listWslDistrosAsync).not.toHaveBeenCalled()
+  })
+
+  it('re-probes on every call so allowlists never judge a stale distro set', async () => {
+    onWindows()
+    await listWslSessionHomeDirs()
+    await listWslSessionHomeDirs()
+    expect(wslMocks.listWslDistrosAsync).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('listWslSessionHomeDirsCached', () => {
+  it('serves a non-empty answer from cache for five minutes', async () => {
+    vi.useFakeTimers()
+    onWindows()
+    await expect(listWslSessionHomeDirsCached()).resolves.toEqual([UBUNTU_HOME])
+    vi.advanceTimersByTime(5 * 60_000 - 1)
+    await listWslSessionHomeDirsCached()
+    expect(wslMocks.listWslDistrosAsync).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(2)
+    await listWslSessionHomeDirsCached()
+    expect(wslMocks.listWslDistrosAsync).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries an empty answer after thirty seconds', async () => {
+    vi.useFakeTimers()
+    onWindows()
+    wslMocks.getWslHomeAsync.mockResolvedValue(null)
+    await expect(listWslSessionHomeDirsCached()).resolves.toEqual([])
+    vi.advanceTimersByTime(30_000 - 1)
+    await listWslSessionHomeDirsCached()
+    expect(wslMocks.listWslDistrosAsync).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(2)
+    await listWslSessionHomeDirsCached()
+    expect(wslMocks.listWslDistrosAsync).toHaveBeenCalledTimes(2)
+  })
+
+  it('coalesces concurrent callers onto one probe', async () => {
+    onWindows()
+    await Promise.all([listWslSessionHomeDirsCached(), listWslSessionHomeDirsCached()])
+    expect(wslMocks.listWslDistrosAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not share its cache with the uncached lister', async () => {
+    onWindows()
+    await listWslSessionHomeDirsCached()
+    await listWslSessionHomeDirs()
+    expect(wslMocks.listWslDistrosAsync).toHaveBeenCalledTimes(2)
+  })
+
+  // A settings flip must take effect on the next poll tick, not after the TTL.
+  it('drops the cache on clear so a disable is honored immediately', async () => {
+    onWindows()
+    await expect(listWslSessionHomeDirsCached()).resolves.toEqual([UBUNTU_HOME])
+    configureWslSessionHomeDirs({ isEnabled: () => false })
+    await expect(listWslSessionHomeDirsCached()).resolves.toEqual([UBUNTU_HOME])
+    clearWslSessionHomeDirsCache()
+    await expect(listWslSessionHomeDirsCached()).resolves.toEqual([])
+    expect(wslMocks.listWslDistrosAsync).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ai-vault/wsl-session-home-dirs.test.ts
+++ b/src/main/ai-vault/wsl-session-home-dirs.test.ts
@@ -135,4 +135,25 @@ describe('listWslSessionHomeDirsCached', () => {
     await expect(listWslSessionHomeDirsCached()).resolves.toEqual([])
     expect(wslMocks.listWslDistrosAsync).toHaveBeenCalledTimes(1)
   })
+
+  // The probe spawns wsl.exe and takes seconds; a flip landing mid-probe must
+  // not be undone when that probe finally resolves.
+  it('does not let a probe that started before clear repopulate the cache', async () => {
+    onWindows()
+    let resolveDistros: (distros: string[]) => void = () => {}
+    wslMocks.listWslDistrosAsync.mockReturnValueOnce(
+      new Promise<string[]>((resolve) => {
+        resolveDistros = resolve
+      })
+    )
+    const inFlight = listWslSessionHomeDirsCached()
+    configureWslSessionHomeDirs({ isEnabled: () => false })
+    clearWslSessionHomeDirsCache()
+    resolveDistros(['Ubuntu'])
+    // The caller that started before the flip still gets its own answer.
+    await expect(inFlight).resolves.toEqual([UBUNTU_HOME])
+    // The next tick sees the disabled state, not the stale write-back.
+    await expect(listWslSessionHomeDirsCached()).resolves.toEqual([])
+    expect(wslMocks.listWslDistrosAsync).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/main/ai-vault/wsl-session-home-dirs.ts
+++ b/src/main/ai-vault/wsl-session-home-dirs.ts
@@ -1,0 +1,83 @@
+import { getWslHomeAsync, listWslDistrosAsync } from '../wsl'
+
+// Why: resolving a distro's `$HOME` spawns `wsl.exe -d <distro> --exec bash`,
+// which boots every stopped distro (~1.3 GB of vmmemWSL). One module owns the
+// probe so the Agent Session History scan, the delete/subagent allowlists, and
+// the native-chat transcript resolver all honor the same opt-out.
+let isEnabledFn: () => boolean = () => true
+
+export function configureWslSessionHomeDirs(options: { isEnabled?: () => boolean }): void {
+  isEnabledFn = options.isEnabled ?? (() => true)
+}
+
+export function isWslSessionScanEnabled(): boolean {
+  return process.platform === 'win32' && isEnabledFn()
+}
+
+/** Each installed distro's `$HOME` as a `\\wsl.localhost` UNC path. */
+async function probeWslSessionHomeDirs(): Promise<string[]> {
+  if (!isWslSessionScanEnabled()) {
+    return []
+  }
+  const homes = await Promise.all(
+    (await listWslDistrosAsync()).map((distro) => getWslHomeAsync(distro))
+  )
+  return homes.filter((home): home is string => Boolean(home))
+}
+
+/**
+ * Uncached: feeds the scan roots and the renderer-path allowlists (delete,
+ * subagent list), which must never judge against a stale distro set.
+ * listWslDistrosAsync caches the distro list and getWslHomeAsync caches hits.
+ */
+export function listWslSessionHomeDirs(): Promise<string[]> {
+  return probeWslSessionHomeDirs()
+}
+
+// Why: resolveSessionFilePath runs on a 500ms–5s poll loop. listWslDistrosAsync
+// caches, but getWslHomeAsync does NOT cache failures, so a cold/stopped distro
+// would re-spawn wsl.exe on every tick. Cache the composed answer here instead.
+const WSL_HOME_DIRS_EMPTY_RETRY_MS = 30_000
+// Why: a distro that was booting when we first probed resolves to no $HOME and
+// would otherwise be excluded for the whole session. Both branches expire so it
+// is retried; getWslHomeAsync caches successes, so a refresh only re-spawns
+// wsl.exe for the distros that actually failed.
+const WSL_HOME_DIRS_TTL_MS = 5 * 60_000
+let cachedWslHomeDirs: string[] | null = null
+let cachedWslHomeDirsExpiresAt = 0
+let inflightWslHomeDirs: Promise<string[]> | null = null
+
+/** TTL-cached twin of listWslSessionHomeDirs for the transcript poll loops.
+ *  `load` lets tests stand in for the probe; the cache applies either way. */
+export function listWslSessionHomeDirsCached(
+  load: () => Promise<string[]> = probeWslSessionHomeDirs
+): Promise<string[]> {
+  if (cachedWslHomeDirs && Date.now() < cachedWslHomeDirsExpiresAt) {
+    return Promise.resolve(cachedWslHomeDirs)
+  }
+  if (inflightWslHomeDirs) {
+    return inflightWslHomeDirs
+  }
+  inflightWslHomeDirs = load()
+    .catch(() => [] as string[])
+    .then((dirs) => {
+      cachedWslHomeDirs = dirs
+      cachedWslHomeDirsExpiresAt =
+        Date.now() + (dirs.length > 0 ? WSL_HOME_DIRS_TTL_MS : WSL_HOME_DIRS_EMPTY_RETRY_MS)
+      inflightWslHomeDirs = null
+      return dirs
+    })
+  return inflightWslHomeDirs
+}
+
+/** Drops the TTL cache so a settings flip takes effect on the next poll tick. */
+export function clearWslSessionHomeDirsCache(): void {
+  cachedWslHomeDirs = null
+  cachedWslHomeDirsExpiresAt = 0
+  inflightWslHomeDirs = null
+}
+
+export function resetWslSessionHomeDirsForTests(): void {
+  clearWslSessionHomeDirsCache()
+  isEnabledFn = () => true
+}

--- a/src/main/ai-vault/wsl-session-home-dirs.ts
+++ b/src/main/ai-vault/wsl-session-home-dirs.ts
@@ -46,6 +46,10 @@ const WSL_HOME_DIRS_TTL_MS = 5 * 60_000
 let cachedWslHomeDirs: string[] | null = null
 let cachedWslHomeDirsExpiresAt = 0
 let inflightWslHomeDirs: Promise<string[]> | null = null
+// Why: a probe that started before the setting flipped off must not write its
+// pre-flip homes back once clear() has run — the toggle would be undone for a
+// full TTL. Each clear bumps the generation; a probe only publishes its own.
+let cacheGeneration = 0
 
 /** TTL-cached twin of listWslSessionHomeDirs for the transcript poll loops.
  *  `load` lets tests stand in for the probe; the cache applies either way. */
@@ -58,20 +62,27 @@ export function listWslSessionHomeDirsCached(
   if (inflightWslHomeDirs) {
     return inflightWslHomeDirs
   }
-  inflightWslHomeDirs = load()
+  const generation = cacheGeneration
+  const probe = load()
     .catch(() => [] as string[])
     .then((dirs) => {
+      if (generation !== cacheGeneration) {
+        // Superseded by a clear: hand the caller its answer, keep the cache empty.
+        return dirs
+      }
       cachedWslHomeDirs = dirs
       cachedWslHomeDirsExpiresAt =
         Date.now() + (dirs.length > 0 ? WSL_HOME_DIRS_TTL_MS : WSL_HOME_DIRS_EMPTY_RETRY_MS)
       inflightWslHomeDirs = null
       return dirs
     })
-  return inflightWslHomeDirs
+  inflightWslHomeDirs = probe
+  return probe
 }
 
 /** Drops the TTL cache so a settings flip takes effect on the next poll tick. */
 export function clearWslSessionHomeDirsCache(): void {
+  cacheGeneration += 1
   cachedWslHomeDirs = null
   cachedWslHomeDirsExpiresAt = 0
   inflightWslHomeDirs = null

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,6 +38,9 @@ import { setSecretStore } from '../shared/secret-store'
 import { ElectronSecretStore } from './host/electron-secret-store'
 import { reportSecretProtectionGap } from './host/secret-protection-report'
 import { initSessionParseCachePersistence } from './ai-vault/session-parse-cache-persistence'
+import { invalidateAiVaultSessionListCache } from './ai-vault/cached-session-list'
+import { clearWslSessionHomeDirsCache } from './ai-vault/wsl-session-home-dirs'
+import { invalidateAiVaultHostLegCache } from './ipc/ai-vault-host-leg-cache'
 import { ensureActiveOrcaProfile, initOrcaProfilePaths } from './orca-profiles/profile-index-store'
 import { getOrcaCloudAuthConfig } from './orca-profiles/profile-cloud-auth-config'
 import { getProfileUserDataPath } from './orca-profiles/profile-storage-paths'
@@ -2376,6 +2379,13 @@ void app.whenReady().then(async () => {
     if ('terminalWindowsWslDistro' in updates) {
       // Why: synchronize fallback WSL distro updates to runner.
       setDefaultWslDistroOverride(settings.terminalWindowsWslDistro ?? null)
+    }
+    if ('aiVaultScanWslDistros' in updates) {
+      // Why: three caches would otherwise keep serving the old distro set — the
+      // composed home-dir TTL, the local scan result, and the merged all-hosts leg.
+      clearWslSessionHomeDirsCache()
+      invalidateAiVaultSessionListCache()
+      invalidateAiVaultHostLegCache()
     }
     if (
       ('terminalWindowsShell' in updates || 'terminalWindowsPowerShellImplementation' in updates) &&

--- a/src/main/ipc/ai-vault.test.ts
+++ b/src/main/ipc/ai-vault.test.ts
@@ -512,6 +512,8 @@ describe('resolveAiVaultSessionTitles host routing', () => {
   const titles = {
     titles: [{ agent: 'codex' as const, sessionId: 'session-1', title: 'Exact title' }]
   }
+  // WSL scanning defaults on, but only a Windows host can scan WSL at all.
+  const wsl = { includeWslHomes: process.platform === 'win32' }
 
   it('routes local identities to the worker without a broad scan', async () => {
     mocks.resolveAiVaultSessionTitlesInWorker.mockResolvedValue(titles)
@@ -520,7 +522,7 @@ describe('resolveAiVaultSessionTitles host routing', () => {
       _internals.resolveAiVaultSessionTitles({ executionHostScope: 'local', requests })
     ).resolves.toEqual(titles)
 
-    expect(mocks.resolveAiVaultSessionTitlesInWorker).toHaveBeenCalledWith(requests, undefined)
+    expect(mocks.resolveAiVaultSessionTitlesInWorker).toHaveBeenCalledWith(requests, undefined, wsl)
     expect(mocks.scanAiVaultSessionsInWorker).not.toHaveBeenCalled()
   })
 

--- a/src/main/ipc/register-core-handlers/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers/register-core-handlers.ts
@@ -216,6 +216,9 @@ export function registerCoreHandlers(
   registerEphemeralVmHandlers(store, pluginService)
   registerAiVaultHandlers({
     getAdditionalCodexHomePaths: lifecycleOptions.getAdditionalAiVaultCodexHomePaths,
+    // Why: configureAiVaultSessionSources replaces the whole source set, so this
+    // must repeat what the runtime ctor already wired or the opt-out is dropped.
+    isWslSessionScanEnabled: () => store.getSettings().aiVaultScanWslDistros !== false,
     prepareSessionResume: lifecycleOptions.prepareAiVaultSessionResume,
     getActiveRuntimeAiVaultHostInfos: () =>
       getSavedRuntimeAiVaultHostInfos(app.getPath('userData')),

--- a/src/main/native-chat/host-readable-transcript-path.ts
+++ b/src/main/native-chat/host-readable-transcript-path.ts
@@ -1,8 +1,11 @@
 import { existsSync } from 'node:fs'
 import { isAbsolute } from 'node:path'
 import { isWslUncPath, parseWslUncPath, toWindowsWslPath } from '../../shared/wsl-paths'
+import {
+  listWslSessionHomeDirsCached,
+  resetWslSessionHomeDirsForTests
+} from '../ai-vault/wsl-session-home-dirs'
 import { WSL_CODEX_RUNTIME_HOME_SEGMENTS } from '../pty/codex-home-wsl-env'
-import { getWslHomeAsync, listWslDistrosAsync } from '../wsl'
 import { wslGatedAccess } from './wsl-transcript-fs-access'
 import { WslTranscriptFsError, wslTranscriptFsRefusal } from './wsl-transcript-fs-gate'
 
@@ -60,18 +63,6 @@ async function pathExistsAsync(path: string, signal?: AbortSignal): Promise<bool
   }
 }
 
-// Why: resolveSessionFilePath runs on a 500ms–5s poll loop. listWslDistrosAsync
-// caches, but getWslHomeAsync does NOT cache failures, so a cold/stopped distro
-// would re-spawn wsl.exe on every tick. Cache the composed answer here instead.
-const WSL_HOME_DIRS_EMPTY_RETRY_MS = 30_000
-// Why: a distro that was booting when we first probed resolves to no $HOME and
-// would otherwise be excluded for the whole session. Both branches expire so it
-// is retried; getWslHomeAsync caches successes, so a refresh only re-spawns
-// wsl.exe for the distros that actually failed.
-const WSL_HOME_DIRS_TTL_MS = 5 * 60_000
-let cachedWslHomeDirs: string[] | null = null
-let cachedWslHomeDirsExpiresAt = 0
-let inflightWslHomeDirs: Promise<string[]> | null = null
 let getAdditionalCodexHomePaths: (() => readonly string[]) | undefined
 
 export function configureHostReadableTranscriptPathSources(options: {
@@ -80,36 +71,8 @@ export function configureHostReadableTranscriptPathSources(options: {
   getAdditionalCodexHomePaths = options.getAdditionalCodexHomePaths
 }
 
-async function defaultListWslHomeDirs(): Promise<string[]> {
-  const homes = await Promise.all(
-    (await listWslDistrosAsync()).map((distro) => getWslHomeAsync(distro))
-  )
-  return homes.filter((home): home is string => Boolean(home))
-}
-
-async function wslHomeDirs(load: () => Promise<string[]>): Promise<string[]> {
-  if (cachedWslHomeDirs && Date.now() < cachedWslHomeDirsExpiresAt) {
-    return cachedWslHomeDirs
-  }
-  if (inflightWslHomeDirs) {
-    return inflightWslHomeDirs
-  }
-  inflightWslHomeDirs = load()
-    .catch(() => [] as string[])
-    .then((dirs) => {
-      cachedWslHomeDirs = dirs
-      cachedWslHomeDirsExpiresAt =
-        Date.now() + (dirs.length > 0 ? WSL_HOME_DIRS_TTL_MS : WSL_HOME_DIRS_EMPTY_RETRY_MS)
-      inflightWslHomeDirs = null
-      return dirs
-    })
-  return inflightWslHomeDirs
-}
-
 export function resetHostReadableTranscriptPathCacheForTests(): void {
-  cachedWslHomeDirs = null
-  cachedWslHomeDirsExpiresAt = 0
-  inflightWslHomeDirs = null
+  resetWslSessionHomeDirsForTests()
   getAdditionalCodexHomePaths = undefined
 }
 
@@ -144,7 +107,7 @@ export async function toHostReadableTranscriptPath(
     return (await pathExists(path)) ? path : null
   }
 
-  const homeDirs = await wslHomeDirs(deps.listWslHomeDirs ?? defaultListWslHomeDirs)
+  const homeDirs = await listWslSessionHomeDirsCached(deps.listWslHomeDirs)
   // Sequential on purpose: the ranked order picks the owning distro, and probing
   // every distro at once would fan out 9P calls to ones the user left stopped.
   let unavailable: WslTranscriptFsError | undefined
@@ -196,7 +159,7 @@ export async function wslCodexSessionsDirs(
   if (platform !== 'win32') {
     return []
   }
-  const homeDirs = await wslHomeDirs(deps.listWslHomeDirs ?? defaultListWslHomeDirs)
+  const homeDirs = await listWslSessionHomeDirsCached(deps.listWslHomeDirs)
   const dirs = homeDirs.flatMap((home) => [
     joinUnderWslHome(home, ...WSL_CODEX_RUNTIME_HOME_SEGMENTS, 'sessions'),
     joinUnderWslHome(home, '.codex', 'sessions')

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1438,6 +1438,7 @@ type RuntimeStore = {
     // onPtyData to capture reply ownership at ingestion.
     terminalMainSideEffectAuthority?: GlobalSettings['terminalMainSideEffectAuthority']
     terminalHiddenDeliveryGate?: GlobalSettings['terminalHiddenDeliveryGate']
+    aiVaultScanWslDistros?: GlobalSettings['aiVaultScanWslDistros']
     terminalModelQueryAuthority?: GlobalSettings['terminalModelQueryAuthority']
   }
   // Why: narrow to `unknown` return so test mocks can return void without
@@ -3924,14 +3925,15 @@ export class OrcaRuntimeService {
     // Why: configure the shared AiVault scan cache from a serve-mode-reachable
     // seam so the aiVault.listSessions RPC includes managed-Codex + WSL sessions
     // even on headless `orca serve` hosts where registerCoreHandlers never runs.
-    if (deps?.getAdditionalAiVaultCodexHomePaths) {
-      configureAiVaultSessionSources({
-        getAdditionalCodexHomePaths: deps.getAdditionalAiVaultCodexHomePaths
-      })
-      configureHostReadableTranscriptPathSources({
-        getAdditionalCodexHomePaths: deps.getAdditionalAiVaultCodexHomePaths
-      })
-    }
+    // Unconditional: orcad passes no codex-home dep, and the WSL opt-out must
+    // still reach the scan there.
+    configureAiVaultSessionSources({
+      getAdditionalCodexHomePaths: deps?.getAdditionalAiVaultCodexHomePaths,
+      isWslSessionScanEnabled: () => this.store?.getSettings().aiVaultScanWslDistros !== false
+    })
+    configureHostReadableTranscriptPathSources({
+      getAdditionalCodexHomePaths: deps?.getAdditionalAiVaultCodexHomePaths
+    })
     // Why: the daemon adapter is installed via `setLocalPtyProvider()` during
     // attachMainWindowServices, AFTER this service is constructed. Capturing
     // `getLocalPtyProvider()` at construction time would freeze a reference to

--- a/src/renderer/src/components/settings/AdvancedPane.tsx
+++ b/src/renderer/src/components/settings/AdvancedPane.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react'
 import { Info, Loader2, RotateCw } from 'lucide-react'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import { useMountedRef } from '@/hooks/useMountedRef'
+import { isWindowsUserAgent } from '@/components/terminal-pane/pane-helpers'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
@@ -20,6 +21,13 @@ type AdvancedPaneProps = {
 
 export function AdvancedPane({ settings, updateSettings }: AdvancedPaneProps): React.JSX.Element {
   const mountedRef = useMountedRef()
+  // Why: the toggle governs this machine's own WSL, so it follows the local
+  // platform rather than the active runtime host.
+  const isWindows = isWindowsUserAgent()
+  const wslSessionScanEnabled = settings.aiVaultScanWslDistros !== false
+  const toggleWslSessionScan = (): void => {
+    updateSettings({ aiVaultScanWslDistros: !wslSessionScanEnabled })
+  }
   const http1CompatibilityInitialRef = useRef(Boolean(settings.electronHttp1CompatibilityMode))
   const [http1CompatibilityRelaunching, setHttp1CompatibilityRelaunching] = useState(false)
   const http1CompatibilityEnabled = Boolean(settings.electronHttp1CompatibilityMode)
@@ -135,6 +143,38 @@ export function AdvancedPane({ settings, updateSettings }: AdvancedPaneProps): R
             </div>
           ) : null}
         </SearchableSetting>
+
+        {isWindows ? (
+          <SearchableSetting
+            title={getAdvancedSearchEntry().wslSessionScan.title}
+            description={getAdvancedSearchEntry().wslSessionScan.description}
+            keywords={getAdvancedSearchEntry().wslSessionScan.keywords}
+            className="space-y-2 py-2"
+            id="advanced-wsl-session-scan"
+          >
+            <div className="flex items-center justify-between gap-4">
+              <div className="min-w-0 shrink space-y-1">
+                <Label id="advanced-wsl-session-scan-label">
+                  {translate(
+                    'auto.components.settings.AdvancedPane.wslSessionScanLabel',
+                    'Scan WSL for agent sessions'
+                  )}
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  {translate(
+                    'auto.components.settings.AdvancedPane.wslSessionScanDescription',
+                    'Includes WSL distros in Agent Session History. Each scan boots every stopped distro to find its home directory; turn off to keep WSL idle. Off also hides WSL sessions from history, delete, and live Codex chat.'
+                  )}
+                </p>
+              </div>
+              <SettingsSwitch
+                checked={wslSessionScanEnabled}
+                onChange={toggleWslSessionScan}
+                ariaLabelledBy="advanced-wsl-session-scan-label"
+              />
+            </div>
+          </SearchableSetting>
+        ) : null}
       </section>
 
       <section className="space-y-3">

--- a/src/renderer/src/components/settings/AdvancedPane.tsx
+++ b/src/renderer/src/components/settings/AdvancedPane.tsx
@@ -2,7 +2,6 @@ import { useRef, useState } from 'react'
 import { Info, Loader2, RotateCw } from 'lucide-react'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import { useMountedRef } from '@/hooks/useMountedRef'
-import { isWindowsUserAgent } from '@/components/terminal-pane/pane-helpers'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
@@ -21,13 +20,6 @@ type AdvancedPaneProps = {
 
 export function AdvancedPane({ settings, updateSettings }: AdvancedPaneProps): React.JSX.Element {
   const mountedRef = useMountedRef()
-  // Why: the toggle governs this machine's own WSL, so it follows the local
-  // platform rather than the active runtime host.
-  const isWindows = isWindowsUserAgent()
-  const wslSessionScanEnabled = settings.aiVaultScanWslDistros !== false
-  const toggleWslSessionScan = (): void => {
-    updateSettings({ aiVaultScanWslDistros: !wslSessionScanEnabled })
-  }
   const http1CompatibilityInitialRef = useRef(Boolean(settings.electronHttp1CompatibilityMode))
   const [http1CompatibilityRelaunching, setHttp1CompatibilityRelaunching] = useState(false)
   const http1CompatibilityEnabled = Boolean(settings.electronHttp1CompatibilityMode)
@@ -143,38 +135,6 @@ export function AdvancedPane({ settings, updateSettings }: AdvancedPaneProps): R
             </div>
           ) : null}
         </SearchableSetting>
-
-        {isWindows ? (
-          <SearchableSetting
-            title={getAdvancedSearchEntry().wslSessionScan.title}
-            description={getAdvancedSearchEntry().wslSessionScan.description}
-            keywords={getAdvancedSearchEntry().wslSessionScan.keywords}
-            className="space-y-2 py-2"
-            id="advanced-wsl-session-scan"
-          >
-            <div className="flex items-center justify-between gap-4">
-              <div className="min-w-0 shrink space-y-1">
-                <Label id="advanced-wsl-session-scan-label">
-                  {translate(
-                    'auto.components.settings.AdvancedPane.wslSessionScanLabel',
-                    'Scan WSL for agent sessions'
-                  )}
-                </Label>
-                <p className="text-xs text-muted-foreground">
-                  {translate(
-                    'auto.components.settings.AdvancedPane.wslSessionScanDescription',
-                    'Includes WSL distros in Agent Session History. Each scan boots every stopped distro to find its home directory; turn off to keep WSL idle. Off also hides WSL sessions from history, delete, and live Codex chat.'
-                  )}
-                </p>
-              </div>
-              <SettingsSwitch
-                checked={wslSessionScanEnabled}
-                onChange={toggleWslSessionScan}
-                ariaLabelledBy="advanced-wsl-session-scan-label"
-              />
-            </div>
-          </SearchableSetting>
-        ) : null}
       </section>
 
       <section className="space-y-3">

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -15,6 +15,10 @@ import {
 } from './agent-generated-tab-title-copy'
 import { getAgentStatusHooksDescription, getAgentStatusHooksTitle } from './agent-status-hooks-copy'
 import {
+  getAgentWslSessionScanDescription,
+  getAgentWslSessionScanTitle
+} from './agent-wsl-session-scan-copy'
+import {
   SettingsSegmentedControl,
   SettingsSubsectionHeader,
   SettingsSwitchRow
@@ -254,6 +258,9 @@ export function AgentsPane({
         wslDistros={wslDistros}
         wslCapabilitiesLoading={wslCapabilitiesLoading}
       />
+      {wslSupportedPlatform ? (
+        <AgentWslSessionScanSetting settings={settings} updateSettings={updateSettings} />
+      ) : null}
       <AgentStatusHooksSetting settings={settings} updateSettings={updateSettings} />
       <AgentGeneratedTabTitlesSetting settings={settings} updateSettings={updateSettings} />
       {!isPairedWebClientWindow() ? (
@@ -278,6 +285,23 @@ export function AgentsPane({
         getRowProps={getRowProps}
       />
     </div>
+  )
+}
+
+// Why: sits under Agent runtime because it is the same decision seen from the
+// history side — whether WSL is part of this machine's agent surface at all.
+export function AgentWslSessionScanSetting({ settings, updateSettings }: AgentsPaneProps) {
+  const enabled = settings.aiVaultScanWslDistros !== false
+  return (
+    <section className="space-y-3" id="agents-wsl-session-scan">
+      <SettingsSwitchRow
+        label={getAgentWslSessionScanTitle()}
+        description={getAgentWslSessionScanDescription()}
+        checked={enabled}
+        onChange={() => updateSettings({ aiVaultScanWslDistros: !enabled })}
+        ariaLabel={getAgentWslSessionScanTitle()}
+      />
+    </section>
   )
 }
 

--- a/src/renderer/src/components/settings/advanced-search.ts
+++ b/src/renderer/src/components/settings/advanced-search.ts
@@ -4,7 +4,49 @@ import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 
-export const getAdvancedPaneSearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
+// Why: mirrors the visible controls — the WSL toggle only renders on Windows, so
+// other platforms must not be able to search their way to a hidden control.
+export function getAdvancedPaneSearchEntries(platform: {
+  isWindows: boolean
+}): SettingsSearchEntry[] {
+  return [
+    ...getAdvancedCompatibilitySearchEntries(),
+    ...(platform.isWindows ? getAdvancedWslSessionScanSearchEntries() : [])
+  ]
+}
+
+const getAdvancedWslSessionScanSearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
+  {
+    title: translate(
+      'auto.components.settings.advanced.search.wslSessionScanTitle',
+      'Scan WSL for agent sessions'
+    ),
+    description: translate(
+      'auto.components.settings.advanced.search.wslSessionScanDescription',
+      'Include WSL distros in Agent Session History. Off keeps stopped distros from being booted.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.advanced.search.wslKeyword', 'wsl'),
+      ...translateSearchKeyword('auto.components.settings.advanced.search.distroKeyword', 'distro'),
+      ...translateSearchKeyword('auto.components.settings.advanced.search.vmmemKeyword', 'vmmem'),
+      ...translateSearchKeyword('auto.components.settings.advanced.search.memoryKeyword', 'memory'),
+      ...translateSearchKeyword(
+        'auto.components.settings.advanced.search.sessionHistoryKeyword',
+        'session history'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.advanced.search.aiVaultKeyword',
+        'ai vault'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.advanced.search.transcriptsKeyword',
+        'transcripts'
+      )
+    ]
+  }
+])
+
+const getAdvancedCompatibilitySearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   ...getAdvancedNetworkSearchEntries(),
   {
     title: translate(
@@ -45,7 +87,8 @@ export const getAdvancedPaneSearchEntries = createLocalizedCatalog((): SettingsS
 ])
 
 function findEntry(title: string): SettingsSearchEntry {
-  const entry = getAdvancedPaneSearchEntries().find((e) => e.title === title)
+  // Why: the superset — the pane itself decides per platform what to render.
+  const entry = getAdvancedPaneSearchEntries({ isWindows: true }).find((e) => e.title === title)
   if (!entry) {
     throw new Error(`Missing advanced-pane search entry: "${title}"`)
   }
@@ -56,6 +99,12 @@ export function getAdvancedSearchEntry() {
   return {
     http1Compatibility: findEntry(
       translate('auto.components.settings.advanced.search.11eea3da72', 'HTTP/1.1 Compatibility')
+    ),
+    wslSessionScan: findEntry(
+      translate(
+        'auto.components.settings.advanced.search.wslSessionScanTitle',
+        'Scan WSL for agent sessions'
+      )
     )
   } as const
 }

--- a/src/renderer/src/components/settings/advanced-search.ts
+++ b/src/renderer/src/components/settings/advanced-search.ts
@@ -4,49 +4,7 @@ import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 
-// Why: mirrors the visible controls — the WSL toggle only renders on Windows, so
-// other platforms must not be able to search their way to a hidden control.
-export function getAdvancedPaneSearchEntries(platform: {
-  isWindows: boolean
-}): SettingsSearchEntry[] {
-  return [
-    ...getAdvancedCompatibilitySearchEntries(),
-    ...(platform.isWindows ? getAdvancedWslSessionScanSearchEntries() : [])
-  ]
-}
-
-const getAdvancedWslSessionScanSearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
-  {
-    title: translate(
-      'auto.components.settings.advanced.search.wslSessionScanTitle',
-      'Scan WSL for agent sessions'
-    ),
-    description: translate(
-      'auto.components.settings.advanced.search.wslSessionScanDescription',
-      'Include WSL distros in Agent Session History. Off keeps stopped distros from being booted.'
-    ),
-    keywords: [
-      ...translateSearchKeyword('auto.components.settings.advanced.search.wslKeyword', 'wsl'),
-      ...translateSearchKeyword('auto.components.settings.advanced.search.distroKeyword', 'distro'),
-      ...translateSearchKeyword('auto.components.settings.advanced.search.vmmemKeyword', 'vmmem'),
-      ...translateSearchKeyword('auto.components.settings.advanced.search.memoryKeyword', 'memory'),
-      ...translateSearchKeyword(
-        'auto.components.settings.advanced.search.sessionHistoryKeyword',
-        'session history'
-      ),
-      ...translateSearchKeyword(
-        'auto.components.settings.advanced.search.aiVaultKeyword',
-        'ai vault'
-      ),
-      ...translateSearchKeyword(
-        'auto.components.settings.advanced.search.transcriptsKeyword',
-        'transcripts'
-      )
-    ]
-  }
-])
-
-const getAdvancedCompatibilitySearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
+export const getAdvancedPaneSearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   ...getAdvancedNetworkSearchEntries(),
   {
     title: translate(
@@ -87,8 +45,7 @@ const getAdvancedCompatibilitySearchEntries = createLocalizedCatalog((): Setting
 ])
 
 function findEntry(title: string): SettingsSearchEntry {
-  // Why: the superset — the pane itself decides per platform what to render.
-  const entry = getAdvancedPaneSearchEntries({ isWindows: true }).find((e) => e.title === title)
+  const entry = getAdvancedPaneSearchEntries().find((e) => e.title === title)
   if (!entry) {
     throw new Error(`Missing advanced-pane search entry: "${title}"`)
   }
@@ -99,12 +56,6 @@ export function getAdvancedSearchEntry() {
   return {
     http1Compatibility: findEntry(
       translate('auto.components.settings.advanced.search.11eea3da72', 'HTTP/1.1 Compatibility')
-    ),
-    wslSessionScan: findEntry(
-      translate(
-        'auto.components.settings.advanced.search.wslSessionScanTitle',
-        'Scan WSL for agent sessions'
-      )
     )
   } as const
 }

--- a/src/renderer/src/components/settings/agent-wsl-session-scan-copy.ts
+++ b/src/renderer/src/components/settings/agent-wsl-session-scan-copy.ts
@@ -1,0 +1,34 @@
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export function getAgentWslSessionScanTitle(): string {
+  return translate(
+    'auto.components.settings.agentWslSessionScan.title',
+    'Scan WSL for agent sessions'
+  )
+}
+
+export function getAgentWslSessionScanDescription(): string {
+  return translate(
+    'auto.components.settings.agentWslSessionScan.description',
+    'Include WSL distros in Agent Session History. Each scan boots every stopped distro to find its home directory; turn off to keep WSL idle. Off also hides WSL sessions from history, delete, and live Codex chat.'
+  )
+}
+
+export function getAgentWslSessionScanSearchKeywords(): string[] {
+  return [
+    ...translateSearchKeyword('auto.components.settings.agentWslSessionScan.wsl', 'wsl'),
+    ...translateSearchKeyword('auto.components.settings.agentWslSessionScan.distro', 'distro'),
+    ...translateSearchKeyword('auto.components.settings.agentWslSessionScan.vmmem', 'vmmem'),
+    ...translateSearchKeyword('auto.components.settings.agentWslSessionScan.memory', 'memory'),
+    ...translateSearchKeyword(
+      'auto.components.settings.agentWslSessionScan.sessionHistory',
+      'session history'
+    ),
+    ...translateSearchKeyword('auto.components.settings.agentWslSessionScan.aiVault', 'ai vault'),
+    ...translateSearchKeyword(
+      'auto.components.settings.agentWslSessionScan.transcripts',
+      'transcripts'
+    )
+  ]
+}

--- a/src/renderer/src/components/settings/agents-search.ts
+++ b/src/renderer/src/components/settings/agents-search.ts
@@ -15,6 +15,11 @@ import {
   getAgentStatusHooksTitle
 } from './agent-status-hooks-copy'
 import { getAgentCacheTimerSearchEntries } from './agent-cache-timer-search'
+import {
+  getAgentWslSessionScanDescription,
+  getAgentWslSessionScanSearchKeywords,
+  getAgentWslSessionScanTitle
+} from './agent-wsl-session-scan-copy'
 import { translate } from '@/i18n/i18n'
 import { searchKeywords, translateSearchKeyword, uniqueKeywords } from './settings-search-keywords'
 import { createLocalizedCatalog } from '@/i18n/localized-catalog'
@@ -62,10 +67,12 @@ function expandAgentSearchText(value: string): string[] {
 type AgentsPaneSearchOptions = {
   includeAgentAwake?: boolean
   includeAgentRuntime?: boolean
+  includeWslSessionScan?: boolean
 }
 
 const AGENT_AWAKE_SEARCH_ENTRY_ID = 'agent-awake'
 const AGENT_RUNTIME_SEARCH_ENTRY_ID = 'agent-runtime'
+const AGENT_WSL_SESSION_SCAN_SEARCH_ENTRY_ID = 'agent-wsl-session-scan'
 
 const getAllAgentsPaneSearchEntries = createLocalizedCatalog(() => [
   {
@@ -102,6 +109,12 @@ const getAllAgentsPaneSearchEntries = createLocalizedCatalog(() => [
       ),
       ...translateSearchKeyword('auto.components.settings.agents.search.719f53350c', 'path')
     ]
+  },
+  {
+    title: getAgentWslSessionScanTitle(),
+    id: AGENT_WSL_SESSION_SCAN_SEARCH_ENTRY_ID,
+    description: getAgentWslSessionScanDescription(),
+    keywords: getAgentWslSessionScanSearchKeywords()
   },
   {
     title: getAgentStatusHooksTitle(),
@@ -145,12 +158,16 @@ const getAllAgentsPaneSearchEntries = createLocalizedCatalog(() => [
 
 export function getAgentsPaneSearchEntries({
   includeAgentAwake = true,
-  includeAgentRuntime = true
+  includeAgentRuntime = true,
+  includeWslSessionScan = true
 }: AgentsPaneSearchOptions = {}) {
   const entries = getAllAgentsPaneSearchEntries()
   return entries.filter(
     (entry) =>
       (!('id' in entry) || entry.id !== AGENT_RUNTIME_SEARCH_ENTRY_ID || includeAgentRuntime) &&
-      (!('id' in entry) || entry.id !== AGENT_AWAKE_SEARCH_ENTRY_ID || includeAgentAwake)
+      (!('id' in entry) || entry.id !== AGENT_AWAKE_SEARCH_ENTRY_ID || includeAgentAwake) &&
+      (!('id' in entry) ||
+        entry.id !== AGENT_WSL_SESSION_SCAN_SEARCH_ENTRY_ID ||
+        includeWslSessionScan)
   )
 }

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -616,7 +616,7 @@ export function buildSettingsNavigationMetadata({
               'Low-level compatibility settings for troubleshooting.'
             ),
             icon: Wrench,
-            searchEntries: getAdvancedPaneSearchEntries(),
+            searchEntries: getAdvancedPaneSearchEntries({ isWindows: isLocalWindowsHost }),
             group: 'advanced'
           }
         ]

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -175,7 +175,8 @@ export function buildSettingsNavigationMetadata({
       icon: Bot,
       searchEntries: getAgentsPaneSearchEntries({
         includeAgentAwake: !isWebClient,
-        includeAgentRuntime: isLocalWindowsHost
+        includeAgentRuntime: isLocalWindowsHost,
+        includeWslSessionScan: isLocalWindowsHost
       }),
       group: 'capabilities'
     },
@@ -616,7 +617,7 @@ export function buildSettingsNavigationMetadata({
               'Low-level compatibility settings for troubleshooting.'
             ),
             icon: Wrench,
-            searchEntries: getAdvancedPaneSearchEntries({ isWindows: isLocalWindowsHost }),
+            searchEntries: getAdvancedPaneSearchEntries(),
             group: 'advanced'
           }
         ]

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6343,7 +6343,9 @@
           "8b7a8df299": "Low-level workarounds for support troubleshooting.",
           "8d8d8ac599": "Compatibility",
           "network": "Network",
-          "networkDescription": "App-level network routing for proxies and corporate environments."
+          "networkDescription": "App-level network routing for proxies and corporate environments.",
+          "wslSessionScanLabel": "Scan WSL for agent sessions",
+          "wslSessionScanDescription": "Includes WSL distros in Agent Session History. Each scan boots every stopped distro to find its home directory; turn off to keep WSL idle. Off also hides WSL sessions from history, delete, and live Codex chat."
         },
         "AgentLocationSetting": {
           "92f4238f1a": "WSL default",
@@ -8708,7 +8710,16 @@
             "2b4d26d11e": "networking",
             "e04e9db503": "advanced",
             "585f56fae0": "Use HTTP/1.1 for Electron networking when HTTP/2 fails behind a proxy.",
-            "11eea3da72": "HTTP/1.1 Compatibility"
+            "11eea3da72": "HTTP/1.1 Compatibility",
+            "wslSessionScanTitle": "Scan WSL for agent sessions",
+            "wslSessionScanDescription": "Include WSL distros in Agent Session History. Off keeps stopped distros from being booted.",
+            "wslKeyword": "wsl",
+            "distroKeyword": "distro",
+            "vmmemKeyword": "vmmem",
+            "memoryKeyword": "memory",
+            "sessionHistoryKeyword": "session history",
+            "aiVaultKeyword": "ai vault",
+            "transcriptsKeyword": "transcripts"
           }
         },
         "agents": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6343,9 +6343,7 @@
           "8b7a8df299": "Low-level workarounds for support troubleshooting.",
           "8d8d8ac599": "Compatibility",
           "network": "Network",
-          "networkDescription": "App-level network routing for proxies and corporate environments.",
-          "wslSessionScanLabel": "Scan WSL for agent sessions",
-          "wslSessionScanDescription": "Includes WSL distros in Agent Session History. Each scan boots every stopped distro to find its home directory; turn off to keep WSL idle. Off also hides WSL sessions from history, delete, and live Codex chat."
+          "networkDescription": "App-level network routing for proxies and corporate environments."
         },
         "AgentLocationSetting": {
           "92f4238f1a": "WSL default",
@@ -8710,16 +8708,7 @@
             "2b4d26d11e": "networking",
             "e04e9db503": "advanced",
             "585f56fae0": "Use HTTP/1.1 for Electron networking when HTTP/2 fails behind a proxy.",
-            "11eea3da72": "HTTP/1.1 Compatibility",
-            "wslSessionScanTitle": "Scan WSL for agent sessions",
-            "wslSessionScanDescription": "Include WSL distros in Agent Session History. Off keeps stopped distros from being booted.",
-            "wslKeyword": "wsl",
-            "distroKeyword": "distro",
-            "vmmemKeyword": "vmmem",
-            "memoryKeyword": "memory",
-            "sessionHistoryKeyword": "session history",
-            "aiVaultKeyword": "ai vault",
-            "transcriptsKeyword": "transcripts"
+            "11eea3da72": "HTTP/1.1 Compatibility"
           }
         },
         "agents": {
@@ -11484,6 +11473,17 @@
         },
         "NativeChatSupportedAgents": {
           "label": "Supported agents:"
+        },
+        "agentWslSessionScan": {
+          "title": "Scan WSL for agent sessions",
+          "description": "Include WSL distros in Agent Session History. Each scan boots every stopped distro to find its home directory; turn off to keep WSL idle. Off also hides WSL sessions from history, delete, and live Codex chat.",
+          "wsl": "wsl",
+          "distro": "distro",
+          "vmmem": "vmmem",
+          "memory": "memory",
+          "sessionHistory": "session history",
+          "aiVault": "ai vault",
+          "transcripts": "transcripts"
         }
       },
       "right": {

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -90,6 +90,7 @@ export function buildDefaultSettings(args: {
     terminalRightClickToPasteDefaultedForPlatform: true,
     terminalWindowsShell: 'powershell.exe',
     terminalWindowsWslDistro: null,
+    aiVaultScanWslDistros: true,
     localAccountRuntime: 'auto',
     localAccountRuntimeDefaultedToAutoForAllUsers: true,
     localAccountWslDistro: null,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -161,6 +161,9 @@ export type GlobalSettings = {
   terminalWindowsShell: string
   /** Pins the WSL distro for terminals/agent scans instead of WSL's current global default. */
   terminalWindowsWslDistro?: string | null
+  /** Windows-only: include WSL distros in Agent Session History. Off skips the per-distro `$HOME`
+   *  probe, which boots every stopped distro; runtime reads stay `!== false` (default on). */
+  aiVaultScanWslDistros?: boolean
   /** Account/auth location; auto follows the global Windows runtime while host/wsl pin it. */
   localAccountRuntime: 'auto' | 'host' | 'wsl'
   localAccountWslDistro?: string | null


### PR DESCRIPTION
## ELI5

On Windows, Orca's session history looks inside every WSL distro for agent transcripts. Finding a distro's home folder means starting that distro, so Orca quietly boots WSL (about 1.3 GB of RAM) every few minutes even when nothing runs there. This adds a switch under Settings → Agents, next to "Agent runtime", to turn that lookup off.

## What Changed

- New `aiVaultScanWslDistros` global setting (Windows-only, optional, default `true`; runtime reads `!== false` like the other kill switches).
- New `src/main/ai-vault/wsl-session-home-dirs.ts` owns the distro `$HOME` probe. It exposes an uncached lister for the scan roots and the delete/subagent path allowlists, and a TTL-cached lister (5 min / 30 s empty retry, moved verbatim from `host-readable-transcript-path.ts`) for the transcript poll loops. Both return `[]` when the setting is off, so `wsl.exe -d` is never spawned.
- `cached-session-list.ts` and `host-readable-transcript-path.ts` drop their duplicated probe and cache in favor of that module.
- The scanner child/worker cannot read the store, so the `titles` request now carries an optional `includeWslHomes` flag (absent = on). When off, guest Linux transcript paths degrade to id-only before any translation is attempted. The fork IPC protocol version is unchanged because the field is optional and both ends ship together.
- The setting is injected through the existing `AiVaultSessionSources` seam from both `OrcaRuntimeService` (now unconditional, so `orcad` gets it too) and `registerAiVaultHandlers`, because the latter replaces the whole source set.
- Flipping the setting clears the home-dir TTL cache, the local scan cache, and the merged all-hosts leg cache, so it applies without a restart.
- Settings → Agents gains a "Scan WSL for agent sessions" switch directly under "Agent runtime", behind the same Windows-host gate as that row; its search entry is filtered the same way the Agent Runtime entry is.

## Why

`getWslHomeAsync` runs `wsl.exe -d <distro> --exec bash -c "echo $HOME"`, which boots a stopped distro. The scan re-runs on panel open, window focus, and the transcript-path TTL, so `wsl --shutdown` is undone within minutes while Orca is open. Users who keep WSL installed for other work but run no agents inside it had no way to opt out.

Off is fail-closed: the delete and subagent-list allowlists derive from the same WSL root set, so disabling the scan removes WSL sessions from history rather than widening any check. Remote and SSH hosts are unaffected — the host that runs the scan reads its own store, and the relay sidecar does not use this path.

## Linked Issue

Fixes #16959

## Visual Proof

Windows 11, Settings → Agents (English UI). Images are hosted on a separate branch of my fork so no binaries enter the PR diff.

| Before (main) | After — default on | After — turned off |
|---|---|---|
| ![before](https://raw.githubusercontent.com/Crockyia/orca/pr-assets/16961/before-agents.png) | ![after on](https://raw.githubusercontent.com/Crockyia/orca/pr-assets/16961/after-agents.png) | ![after off](https://raw.githubusercontent.com/Crockyia/orca/pr-assets/16961/after-agents-off.png) |

Non-Windows platforms have no visual change (the row and its search entry are not rendered).

## Testing

Tested on Windows 11 (26200), WSL 2.7.11, two Ubuntu 22.04 distros. Not tested on macOS, Linux, or SSH hosts; the new code paths are behind `process.platform === 'win32'` / `isWindowsUserAgent()` and return early elsewhere.

- `pnpm tc` passes.
- `pnpm build` passes.
- `pnpm test` over `src/main/ai-vault`, `src/main/native-chat`, the AI Vault IPC/RPC tests, `src/renderer/src/components/settings`, and `useSettingsNavigationMetadata`: 275 files pass. The 9 files / 31 tests that fail are identical to the failure set on the untouched `main` checkout on this Windows machine (POSIX-path assertions), verified with `git stash`.
- `pnpm lint`: oxlint (default, type-aware, react-doctor), reliability gates, max-lines ratchet, runtime-electron ratchet, localization catalog/extraction/coverage all pass. `verify:skill-bundle-manifest` reports stale artifacts on this checkout, and does so identically on untouched `main`, so it is a local line-ending artifact rather than a result of this change.
- New tests: `wsl-session-home-dirs.test.ts` (zero `wsl.exe` calls when disabled or off-Windows, both listers keep independent cache semantics, TTL and empty-retry windows, clear-on-flip) and `session-title-request-paths.test.ts` (guest path degrades to id-only with zero WSL calls when the flag is off). `ipc/ai-vault.test.ts` updated for the new options argument.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude (Opus 5) via Claude Code, driven and reviewed by the author.

## Review

Self-review notes: cross-platform (all new logic is Windows-gated and returns early elsewhere); SSH/remote (host-local setting, relay sidecar untouched, no RPC wire change — `settings.get` projection does not include the key); agents/integrations (only the AI Vault scan and native-chat transcript resolution are affected; every other `getWslHome*` caller sits behind an explicit `runtime === 'wsl'` selection and is untouched); performance (one predicate call per probe; caches preserved); security (fail-closed, allowlists can only shrink).

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



