### PR TITLE
Fix Chromium descriptor inheritance into the terminal daemon and its PTY children (Linux/Windows)

### DIFF
--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -277,7 +277,20 @@ describe('electron-builder config', () => {
     const viteConfig = await readFile(join(REPO_ROOT, 'electron.vite.config.ts'), 'utf8')
     expect(viteConfig).toMatch(new RegExp(`'${entryFilename.replace(/\.js$/, '')}':\\s*resolve\\(`))
     // utilityProcess reads asar directly, so the shim deliberately stays packed.
-    expect(electronBuilderConfig.asarUnpack).not.toContain(`out/main/${entryFilename}`)
+    // Drive the real matcher: an exact-string check would let a future broad
+    // pattern (e.g. out/main/**) unpack the shim without tripping the pin.
+    const unpacksPath = (patterns, repoPath) =>
+      new FileMatcher('/app', '/dest', (value) => value, patterns).createFilter()(
+        join('/app', repoPath),
+        { isDirectory: () => false }
+      )
+    expect(unpacksPath(electronBuilderConfig.asarUnpack, `out/main/${entryFilename}`)).toBe(false)
+    // Controls: the same matcher sees the entry that must stay unpacked, and a
+    // broad glob does trip the shim check — so the assertion cannot go vacuous.
+    expect(unpacksPath(electronBuilderConfig.asarUnpack, 'out/main/daemon-entry.js')).toBe(true)
+    expect(
+      unpacksPath([...electronBuilderConfig.asarUnpack, 'out/main/**'], `out/main/${entryFilename}`)
+    ).toBe(true)
   })
 
   it('uses the multi-size icon source for Linux packages', () => {

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -262,6 +262,24 @@ describe('electron-builder config', () => {
     )
   })
 
+  // Why: the descriptor-clean daemon fork loads this entry with
+  // utilityProcess.fork; a dropped rollup input would silently put every
+  // Linux/Windows launch on the direct-fork fallback, resurrecting the
+  // inherited-descriptor leak into the daemon and its PTY children.
+  it('bundles the utility launcher shim the descriptor-clean daemon fork loads', async () => {
+    const forkSource = await readFile(
+      join(SRC_MAIN_DIR, 'daemon', 'daemon-utility-process-fork.ts'),
+      'utf8'
+    )
+    const entryFilename = forkSource.match(/'(daemon-utility-launcher-shim\.js)'/)?.[1]
+    expect(entryFilename).toBeDefined()
+
+    const viteConfig = await readFile(join(REPO_ROOT, 'electron.vite.config.ts'), 'utf8')
+    expect(viteConfig).toMatch(new RegExp(`'${entryFilename.replace(/\.js$/, '')}':\\s*resolve\\(`))
+    // utilityProcess reads asar directly, so the shim deliberately stays packed.
+    expect(electronBuilderConfig.asarUnpack).not.toContain(`out/main/${entryFilename}`)
+  })
+
   it('uses the multi-size icon source for Linux packages', () => {
     expect(electronBuilderConfig.linux.icon).toBe('resources/build/icon.icns')
   })

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -211,6 +211,11 @@ export const electronViteConfig: UserConfig = {
           'browser-window-close-preload': resolve('src/preload/browser-window-close.ts'),
           'doc-preview-link-preload': resolve('src/preload/doc-preview-link.ts'),
           'daemon-entry': resolve('src/main/daemon/daemon-entry.ts'),
+          // Why: forked as an Electron utility process so the detached daemon it
+          // spawns starts without inherited Chromium descriptors (Linux/Windows).
+          'daemon-utility-launcher-shim': resolve(
+            'src/main/daemon/daemon-utility-launcher-shim.ts'
+          ),
           'plugin-host-entry': resolve('src/main/plugins/plugin-host-entry.ts'),
           'computer-sidecar': resolve('src/main/computer/sidecar-entry.ts'),
           'stt-worker': resolve('src/main/speech/stt-worker.ts'),

--- a/src/main/daemon/__fixtures__/utility-shim-exiting-daemon.cjs
+++ b/src/main/daemon/__fixtures__/utility-shim-exiting-daemon.cjs
@@ -1,0 +1,3 @@
+// Fake daemon that dies during startup so the shim's exit relay is observable.
+process.send({ type: 'starting' })
+process.exit(7)

--- a/src/main/daemon/__fixtures__/utility-shim-ready-daemon.cjs
+++ b/src/main/daemon/__fixtures__/utility-shim-ready-daemon.cjs
@@ -1,0 +1,5 @@
+// Fake daemon for the utility-launcher shim tests: reports ready over IPC,
+// writes a stderr marker, then waits to be killed (self-exits as a backstop).
+process.send({ type: 'ready', startedAtMs: 123 })
+process.stderr.write('utility-shim-fixture-stderr')
+setTimeout(() => process.exit(0), 15000)

--- a/src/main/daemon/daemon-init-utility-fork.test.ts
+++ b/src/main/daemon/daemon-init-utility-fork.test.ts
@@ -13,10 +13,18 @@ const {
   (await import('./daemon-init-test-harness')).createDaemonInitMocks()
 )
 
-const { canForkThroughUtilityMock, forkThroughUtilityMock } = vi.hoisted(() => ({
-  canForkThroughUtilityMock: vi.fn(() => false),
-  forkThroughUtilityMock: vi.fn()
-}))
+const { canForkThroughUtilityMock, forkThroughUtilityMock, materializeRelocatedHostMock } =
+  vi.hoisted(() => ({
+    canForkThroughUtilityMock: vi.fn(() => false),
+    forkThroughUtilityMock: vi.fn(),
+    materializeRelocatedHostMock: vi.fn<() => { execPath: string; entryPath: string } | null>(
+      () => null
+    )
+  }))
+
+const RELOCATED_EXEC_PATH = 'C:\\fake\\localappdata\\daemon-host\\1.2.3\\Orca.exe'
+const RELOCATED_ENTRY_PATH =
+  'C:\\fake\\localappdata\\daemon-host\\1.2.3\\resources\\app.asar.unpacked\\out\\main\\daemon-entry.js'
 
 vi.mock('fs', () => moduleFactories.fs())
 vi.mock('child_process', async (importOriginal) =>
@@ -38,6 +46,11 @@ vi.mock('../ipc/pty', () => moduleFactories.ipcPty())
 vi.mock('./daemon-utility-process-fork', () => ({
   canForkDaemonThroughUtilityProcess: canForkThroughUtilityMock,
   forkDaemonThroughUtilityProcess: forkThroughUtilityMock
+}))
+vi.mock('./daemon-host-relocation', () => ({
+  materializeRelocatedDaemonHost: materializeRelocatedHostMock,
+  collectPinnedDaemonVersions: () => new Set<string>(),
+  pruneOldDaemonHosts: () => {}
 }))
 
 function fakeLaunchedChild(): {
@@ -63,6 +76,27 @@ function fakeLaunchedChild(): {
   }
 }
 
+/**
+ * The harness's endpoint-identity reader derives the launch nonce from forkMock's
+ * argv; the utility path never calls forkMock, so read it from the utility spec.
+ */
+function readAdoptionIdentityFromUtilitySpec(): void {
+  daemonClientMock.mockImplementation(function MockUtilityAdoptionClient() {
+    return {
+      ensureConnected: vi.fn(async () => {}),
+      getDaemonIdentity: vi.fn(() => {
+        const spec = forkThroughUtilityMock.mock.calls.at(-1)?.[0] as { args: string[] } | undefined
+        const nonceIndex = spec ? spec.args.indexOf('--launch-nonce') : -1
+        return nonceIndex >= 0 && spec
+          ? { pid: 12345, startedAtMs: 1_000_000, launchNonce: spec.args[nonceIndex + 1] }
+          : null
+      }),
+      request: vi.fn(async () => ({ sessions: [] })),
+      disconnect: vi.fn()
+    }
+  })
+}
+
 /** importFresh resets forkMock, so callers must queue fork results AFTER this. */
 async function primeLauncher(): Promise<
   (socketPath: string, tokenPath: string) => Promise<unknown>
@@ -79,6 +113,8 @@ describe('daemon-init: descriptor-clean daemon fork', () => {
     canForkThroughUtilityMock.mockReset()
     canForkThroughUtilityMock.mockReturnValue(false)
     forkThroughUtilityMock.mockReset()
+    materializeRelocatedHostMock.mockReset()
+    materializeRelocatedHostMock.mockReturnValue(null)
   })
 
   afterEach(() => {
@@ -89,25 +125,7 @@ describe('daemon-init: descriptor-clean daemon fork', () => {
     const launcher = await primeLauncher()
     canForkThroughUtilityMock.mockReturnValue(true)
     forkThroughUtilityMock.mockImplementation(async () => fakeLaunchedChild())
-    // Why: the harness's endpoint-identity reader derives the launch nonce from
-    // forkMock's argv; the utility path never calls forkMock, so read it from
-    // the utility spec instead.
-    daemonClientMock.mockImplementation(function MockUtilityAdoptionClient() {
-      return {
-        ensureConnected: vi.fn(async () => {}),
-        getDaemonIdentity: vi.fn(() => {
-          const spec = forkThroughUtilityMock.mock.calls.at(-1)?.[0] as
-            | { args: string[] }
-            | undefined
-          const nonceIndex = spec ? spec.args.indexOf('--launch-nonce') : -1
-          return nonceIndex >= 0 && spec
-            ? { pid: 12345, startedAtMs: 1_000_000, launchNonce: spec.args[nonceIndex + 1] }
-            : null
-        }),
-        request: vi.fn(async () => ({ sessions: [] })),
-        disconnect: vi.fn()
-      }
-    })
+    readAdoptionIdentityFromUtilitySpec()
 
     await launcher('/fake/socket', '/fake/token')
 
@@ -145,6 +163,32 @@ describe('daemon-init: descriptor-clean daemon fork', () => {
 
     expect(forkThroughUtilityMock).toHaveBeenCalledOnce()
     expect(forkMock).toHaveBeenCalledOnce()
+  })
+
+  // Why: on Windows the daemon must run a byte-identical host staged outside the
+  // updater's kill zone. Reverting either arm of the utility spec to the install-dir
+  // values puts the daemon image back where the updater deletes it mid-run.
+  it('forks the relocated host image and its mirrored entry, not the install-dir pair', async () => {
+    const launcher = await primeLauncher()
+    canForkThroughUtilityMock.mockReturnValue(true)
+    materializeRelocatedHostMock.mockReturnValue({
+      execPath: RELOCATED_EXEC_PATH,
+      entryPath: RELOCATED_ENTRY_PATH
+    })
+    forkThroughUtilityMock.mockImplementation(async () => fakeLaunchedChild())
+    readAdoptionIdentityFromUtilitySpec()
+
+    await launcher('/fake/socket', '/fake/token')
+
+    const spec = forkThroughUtilityMock.mock.calls[0][0] as {
+      entryPath: string
+      args: string[]
+      execPath: string
+    }
+    expect(spec.execPath).toBe(RELOCATED_EXEC_PATH)
+    expect(spec.entryPath).toBe(RELOCATED_ENTRY_PATH)
+    // --entry-path stays the install-dir entry: it is the daemon's staleness identity.
+    expect(spec.args[spec.args.indexOf('--entry-path') + 1]).toBe(FAKE_DAEMON_ENTRY_PATH)
   })
 
   it('keeps the direct fork where the utility hop is unavailable (macOS, plain-node hosts)', async () => {

--- a/src/main/daemon/daemon-init-utility-fork.test.ts
+++ b/src/main/daemon/daemon-init-utility-fork.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FAKE_DAEMON_ENTRY_PATH, FAKE_USER_DATA_PATH } from './daemon-init-test-harness'
+
+const {
+  forkMock,
+  checkDaemonHealthMock,
+  daemonClientMock,
+  spawnerInstances,
+  importFresh,
+  installDefaultNetConnectStub,
+  moduleFactories
+} = await vi.hoisted(async () =>
+  (await import('./daemon-init-test-harness')).createDaemonInitMocks()
+)
+
+const { canForkThroughUtilityMock, forkThroughUtilityMock } = vi.hoisted(() => ({
+  canForkThroughUtilityMock: vi.fn(() => false),
+  forkThroughUtilityMock: vi.fn()
+}))
+
+vi.mock('fs', () => moduleFactories.fs())
+vi.mock('child_process', async (importOriginal) =>
+  moduleFactories.childProcess(await importOriginal<Record<string, unknown>>())
+)
+vi.mock('net', () => moduleFactories.net())
+vi.mock('./daemon-health', () => moduleFactories.daemonHealth())
+vi.mock('./daemon-pid-identity', () => moduleFactories.daemonPidIdentity())
+vi.mock('./daemon-tcc-attribution', () => moduleFactories.daemonTccAttribution())
+vi.mock('./daemon-bundle-staleness', () => moduleFactories.daemonBundleStaleness())
+vi.mock('./daemon-stale-kill', () => moduleFactories.daemonStaleKill())
+vi.mock('./daemon-process-start-time', () => moduleFactories.daemonProcessStartTime())
+vi.mock('./daemon-pid-file-parse', () => moduleFactories.daemonPidFileParse())
+vi.mock('./client', () => moduleFactories.client())
+vi.mock('./daemon-lifecycle-event', () => moduleFactories.daemonLifecycleEvent())
+vi.mock('./daemon-spawner', () => moduleFactories.daemonSpawner())
+vi.mock('./daemon-pty-adapter', () => moduleFactories.daemonPtyAdapter())
+vi.mock('../ipc/pty', () => moduleFactories.ipcPty())
+vi.mock('./daemon-utility-process-fork', () => ({
+  canForkDaemonThroughUtilityProcess: canForkThroughUtilityMock,
+  forkDaemonThroughUtilityProcess: forkThroughUtilityMock
+}))
+
+function fakeLaunchedChild(): {
+  pid: number
+  on(event: string, cb: (arg?: unknown) => void): unknown
+  off(): unknown
+  disconnect: ReturnType<typeof vi.fn>
+  unref: ReturnType<typeof vi.fn>
+} {
+  return {
+    pid: 12345,
+    on(event: string, cb: (arg?: unknown) => void) {
+      if (event === 'message') {
+        queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+      }
+      return this
+    },
+    off() {
+      return this
+    },
+    disconnect: vi.fn(),
+    unref: vi.fn()
+  }
+}
+
+/** importFresh resets forkMock, so callers must queue fork results AFTER this. */
+async function primeLauncher(): Promise<
+  (socketPath: string, tokenPath: string) => Promise<unknown>
+> {
+  const mod = await importFresh()
+  checkDaemonHealthMock.mockResolvedValue('unreachable')
+  await mod.initDaemonPtyProvider()
+  return spawnerInstances[0].launcher as (socketPath: string, tokenPath: string) => Promise<unknown>
+}
+
+describe('daemon-init: descriptor-clean daemon fork', () => {
+  beforeEach(() => {
+    installDefaultNetConnectStub()
+    canForkThroughUtilityMock.mockReset()
+    canForkThroughUtilityMock.mockReturnValue(false)
+    forkThroughUtilityMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('forks through the utility-process launcher when it is available', async () => {
+    const launcher = await primeLauncher()
+    canForkThroughUtilityMock.mockReturnValue(true)
+    forkThroughUtilityMock.mockImplementation(async () => fakeLaunchedChild())
+    // Why: the harness's endpoint-identity reader derives the launch nonce from
+    // forkMock's argv; the utility path never calls forkMock, so read it from
+    // the utility spec instead.
+    daemonClientMock.mockImplementation(function MockUtilityAdoptionClient() {
+      return {
+        ensureConnected: vi.fn(async () => {}),
+        getDaemonIdentity: vi.fn(() => {
+          const spec = forkThroughUtilityMock.mock.calls.at(-1)?.[0] as
+            | { args: string[] }
+            | undefined
+          const nonceIndex = spec ? spec.args.indexOf('--launch-nonce') : -1
+          return nonceIndex >= 0 && spec
+            ? { pid: 12345, startedAtMs: 1_000_000, launchNonce: spec.args[nonceIndex + 1] }
+            : null
+        }),
+        request: vi.fn(async () => ({ sessions: [] })),
+        disconnect: vi.fn()
+      }
+    })
+
+    await launcher('/fake/socket', '/fake/token')
+
+    expect(forkThroughUtilityMock).toHaveBeenCalledOnce()
+    expect(forkMock).not.toHaveBeenCalled()
+    const spec = forkThroughUtilityMock.mock.calls[0][0] as {
+      entryPath: string
+      args: string[]
+      cwd: string
+      env: NodeJS.ProcessEnv
+      execPath: string
+    }
+    expect(spec.entryPath).toBe(FAKE_DAEMON_ENTRY_PATH)
+    expect(spec.cwd).toBe(FAKE_USER_DATA_PATH)
+    expect(spec.execPath).toBe(process.execPath)
+    expect(spec.env.ELECTRON_RUN_AS_NODE).toBe('1')
+    expect(spec.env.ORCA_USER_DATA_PATH).toBe(FAKE_USER_DATA_PATH)
+    expect(spec.args).toEqual(
+      expect.arrayContaining(['--socket', '/fake/socket', '--entry-path', FAKE_DAEMON_ENTRY_PATH])
+    )
+  })
+
+  it('falls back to the direct fork when the utility launch fails, so the daemon still exists', async () => {
+    const launcher = await primeLauncher()
+    canForkThroughUtilityMock.mockReturnValue(true)
+    forkThroughUtilityMock.mockRejectedValue(new Error('utility spawn refused'))
+    forkMock.mockReturnValueOnce(fakeLaunchedChild())
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      await launcher('/fake/socket', '/fake/token')
+    } finally {
+      warnSpy.mockRestore()
+    }
+
+    expect(forkThroughUtilityMock).toHaveBeenCalledOnce()
+    expect(forkMock).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the direct fork where the utility hop is unavailable (macOS, plain-node hosts)', async () => {
+    const launcher = await primeLauncher()
+    canForkThroughUtilityMock.mockReturnValue(false)
+    forkMock.mockReturnValueOnce(fakeLaunchedChild())
+
+    await launcher('/fake/socket', '/fake/token')
+
+    expect(forkThroughUtilityMock).not.toHaveBeenCalled()
+    expect(forkMock).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/daemon/daemon-launched-child.ts
+++ b/src/main/daemon/daemon-launched-child.ts
@@ -1,10 +1,15 @@
-import { fork, type ChildProcess } from 'node:child_process'
+import { fork } from 'node:child_process'
 import { getAppEnvironment } from '../../shared/app-environment'
 import { DAEMON_EXIT_ENDPOINT_OCCUPIED } from './daemon-endpoint-ownership'
 import type { DaemonEndpointIdentity } from './daemon-hello-protocol'
 import { daemonLogArgs } from './daemon-launch-paths'
 import { parseDaemonReadyIdentity } from './daemon-ready-identity'
 import { unlinkOwnedDaemonPidFile } from './daemon-spawner'
+import {
+  canForkDaemonThroughUtilityProcess,
+  forkDaemonThroughUtilityProcess,
+  type LaunchedDaemonChild as UtilityLaunchedDaemonChild
+} from './daemon-utility-process-fork'
 
 const DAEMON_CHILD_TERMINATION_GRACE_MS = 5_000
 const DAEMON_CHILD_FORCE_EXIT_WAIT_MS = 1_000
@@ -19,8 +24,7 @@ export class DaemonEndpointUnavailableError extends Error {
   }
 }
 
-export type LaunchedDaemonChild = {
-  child: ChildProcess
+export type LaunchedDaemonChild = UtilityLaunchedDaemonChild & {
   identity: DaemonEndpointIdentity
 }
 
@@ -50,27 +54,57 @@ export async function launchDaemonChild(
     launchNonce,
     macosLoginSessionWatch
   } = options
-  const child = fork(
-    forkEntryPath,
-    [
-      '--socket',
-      socketPath,
-      '--token',
-      tokenPath,
-      '--pid-record',
-      pidPath,
-      '--launch-nonce',
-      launchNonce,
-      '--entry-path',
-      entryPath,
-      '--app-version',
-      getAppEnvironment().getVersion(),
-      '--spawner-exec-path',
-      process.execPath,
-      ...(macosLoginSessionWatch ? ['--login-session-watch'] : []),
-      ...daemonLogArgs()
-    ],
-    {
+  const daemonArgs = [
+    '--socket',
+    socketPath,
+    '--token',
+    tokenPath,
+    '--pid-record',
+    pidPath,
+    '--launch-nonce',
+    launchNonce,
+    '--entry-path',
+    entryPath,
+    '--app-version',
+    getAppEnvironment().getVersion(),
+    '--spawner-exec-path',
+    process.execPath,
+    ...(macosLoginSessionWatch ? ['--login-session-watch'] : []),
+    ...daemonLogArgs()
+  ]
+  const daemonEnv = {
+    ...process.env,
+    ELECTRON_RUN_AS_NODE: '1',
+    // Why: the detached plain-Node daemon has no AppEnvironment, but shell rcfiles must live outside swept tmp.
+    ORCA_USER_DATA_PATH: userDataPath
+  }
+  // Why the utility-process hop on Linux/Windows: a daemon forked directly from
+  // main inherits Chromium descriptors that are not close-on-exec/non-inheritable
+  // (CDP listener, crashpad channel, profile file descriptors) and hands them to
+  // every PTY child for its detached lifetime — a restarted app then finds its
+  // debug port bound by the old daemon lineage. A utility-process child starts
+  // with a clean table. macOS posix_spawn already strips these and its TCC
+  // attribution needs the direct fork, so it keeps the old path. Fail-open: the
+  // leak is recoverable, a missing daemon is not.
+  const child: UtilityLaunchedDaemonChild = await forkDaemonChildForLaunch()
+  async function forkDaemonChildForLaunch(): Promise<UtilityLaunchedDaemonChild> {
+    if (canForkDaemonThroughUtilityProcess()) {
+      try {
+        return await forkDaemonThroughUtilityProcess({
+          entryPath: forkEntryPath,
+          args: daemonArgs,
+          cwd: userDataPath,
+          env: daemonEnv,
+          execPath: relocatedExecPath ?? process.execPath
+        })
+      } catch (error) {
+        console.warn(
+          '[daemon] Utility-process launch failed; falling back to a direct fork (children may inherit Chromium descriptors):',
+          error instanceof Error ? error.message : error
+        )
+      }
+    }
+    return fork(forkEntryPath, daemonArgs, {
       // Why: detached daemons outlive dev worktrees; userData keeps process.cwd() valid after a repo/worktree is deleted.
       cwd: userDataPath,
       // Why: detached+unref outlives Electron; stdout 'ignore' (else blocks exit), stderr 'pipe' captures startup crashes lost in v1.4.129-rc.1.
@@ -79,14 +113,9 @@ export async function launchDaemonChild(
       // Why: run the byte-identical relocated Orca.exe so the image path sits outside the updater's kill zone.
       ...(relocatedExecPath ? { execPath: relocatedExecPath } : {}),
       // Why: run the fork as plain Node so Electron's GPU/display init can't interfere with node-pty's posix_spawn of the spawn-helper.
-      env: {
-        ...process.env,
-        ELECTRON_RUN_AS_NODE: '1',
-        // Why: the detached plain-Node daemon has no AppEnvironment, but shell rcfiles must live outside swept tmp.
-        ORCA_USER_DATA_PATH: userDataPath
-      }
-    }
-  )
+      env: daemonEnv
+    })
+  }
 
   // Why: keep only the startup-window stderr tail so a crash cause is visible without unbounded memory.
   let startupStderr = ''
@@ -226,7 +255,9 @@ export async function launchDaemonChild(
   return { child, identity: launchedIdentity }
 }
 
-export async function terminateLaunchedDaemonChild(child: ChildProcess): Promise<void> {
+export async function terminateLaunchedDaemonChild(
+  child: UtilityLaunchedDaemonChild
+): Promise<void> {
   try {
     if (
       (child.exitCode !== null && child.exitCode !== undefined) ||

--- a/src/main/daemon/daemon-launched-child.ts
+++ b/src/main/daemon/daemon-launched-child.ts
@@ -24,7 +24,8 @@ export class DaemonEndpointUnavailableError extends Error {
   }
 }
 
-export type LaunchedDaemonChild = UtilityLaunchedDaemonChild & {
+export type LaunchedDaemonChild = {
+  child: UtilityLaunchedDaemonChild
   identity: DaemonEndpointIdentity
 }
 

--- a/src/main/daemon/daemon-utility-fork-messages.ts
+++ b/src/main/daemon/daemon-utility-fork-messages.ts
@@ -1,0 +1,28 @@
+/**
+ * Wire types between the daemon-forking main process and the utility-process
+ * launcher shim. Both sides bundle separately, so the contract lives alone.
+ */
+
+export type UtilityDaemonForkSpec = {
+  /** Absolute path to daemon-entry.js (unpacked in packaged builds). */
+  entryPath: string
+  args: readonly string[]
+  cwd: string
+  /** Full daemon environment, composed by main — never placed in argv. */
+  env: NodeJS.ProcessEnv
+  /** Binary to run as plain Node; the relocated Windows host when staged. */
+  execPath: string
+}
+
+export type DaemonShimDownMessage =
+  | { kind: 'spawn'; spec: UtilityDaemonForkSpec }
+  | { kind: 'release' }
+
+export type DaemonShimUpMessage =
+  | { kind: 'shim-ready' }
+  | { kind: 'spawned'; pid: number }
+  | { kind: 'spawn-error'; message: string }
+  | { kind: 'daemon-message'; message: unknown }
+  | { kind: 'daemon-stderr'; text: string }
+  | { kind: 'daemon-error'; message: string }
+  | { kind: 'daemon-exit'; code: number | null; signal: NodeJS.Signals | null }

--- a/src/main/daemon/daemon-utility-launcher-shim.test.ts
+++ b/src/main/daemon/daemon-utility-launcher-shim.test.ts
@@ -75,6 +75,31 @@ function specFor(
   }
 }
 
+type SpawnDouble = EventEmitter & {
+  pid: number
+  connected: boolean
+  stderr: EventEmitter & { destroy: ReturnType<typeof vi.fn> }
+  disconnect: ReturnType<typeof vi.fn>
+  unref: ReturnType<typeof vi.fn>
+  kill: ReturnType<typeof vi.fn>
+}
+
+/** A daemon child that records the detach calls a real ChildProcess would take. */
+function createSpawnDouble(): SpawnDouble {
+  const child = new EventEmitter() as SpawnDouble
+  const stderr = new EventEmitter() as SpawnDouble['stderr']
+  stderr.destroy = vi.fn()
+  child.pid = 4242
+  child.connected = true
+  child.stderr = stderr
+  child.disconnect = vi.fn(() => {
+    child.connected = false
+  })
+  child.unref = vi.fn()
+  child.kill = vi.fn()
+  return child
+}
+
 const spawnedPids: number[] = []
 
 afterEach(() => {
@@ -146,6 +171,37 @@ describe('daemon-utility-launcher-shim', () => {
     expect(port.posted).toContainEqual({ kind: 'spawn-error', message: 'daemon child has no pid' })
     expect(child.kill).toHaveBeenCalled()
     expect(exit).toHaveBeenCalledWith(1)
+  })
+
+  // The real-child case below proves release leaves the daemon alive; it cannot see
+  // WHICH of the detach steps ran, so a dropped disconnect/destroy/unref stays green
+  // there. Assert each one, and that release is idempotent.
+  it('release detaches the daemon child without killing it, exactly once', () => {
+    const port = createFakePort()
+    const child = createSpawnDouble()
+    const exit = vi.fn()
+    runDaemonUtilityLauncherShim(port, () => child as never, exit)
+    port.deliver({ kind: 'spawn', spec: specFor('/fake/daemon-entry.js') })
+
+    port.deliver({ kind: 'release' })
+    port.deliver({ kind: 'release' })
+
+    expect(child.disconnect).toHaveBeenCalledOnce()
+    expect(child.stderr.destroy).toHaveBeenCalledOnce()
+    expect(child.unref).toHaveBeenCalledOnce()
+    expect(child.kill).not.toHaveBeenCalled()
+    expect(exit).toHaveBeenCalledExactlyOnceWith(0)
+  })
+
+  it('relays a daemon spawn error to the parent instead of dropping it', () => {
+    const port = createFakePort()
+    const child = createSpawnDouble()
+    runDaemonUtilityLauncherShim(port, () => child as never, vi.fn())
+    port.deliver({ kind: 'spawn', spec: specFor('/fake/daemon-entry.js') })
+
+    child.emit('error', new Error('EPERM'))
+
+    expect(port.posted).toContainEqual({ kind: 'daemon-error', message: 'EPERM' })
   })
 
   it('relays IPC readiness and stderr from a real daemon child', async () => {

--- a/src/main/daemon/daemon-utility-launcher-shim.test.ts
+++ b/src/main/daemon/daemon-utility-launcher-shim.test.ts
@@ -131,6 +131,23 @@ describe('daemon-utility-launcher-shim', () => {
     expect(exit).toHaveBeenCalledWith(1)
   })
 
+  it('kills a pid-less child before exiting so the reported spawn failure leaves no orphan', () => {
+    const port = createFakePort()
+    const child = new EventEmitter() as EventEmitter & {
+      pid: undefined
+      stderr: null
+      kill: ReturnType<typeof vi.fn>
+    }
+    child.stderr = null
+    child.kill = vi.fn()
+    const exit = vi.fn()
+    runDaemonUtilityLauncherShim(port, () => child as never, exit)
+    port.deliver({ kind: 'spawn', spec: specFor('/fake/daemon-entry.js') })
+    expect(port.posted).toContainEqual({ kind: 'spawn-error', message: 'daemon child has no pid' })
+    expect(child.kill).toHaveBeenCalled()
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+
   it('relays IPC readiness and stderr from a real daemon child', async () => {
     const port = createFakePort()
     const exit = vi.fn()

--- a/src/main/daemon/daemon-utility-launcher-shim.test.ts
+++ b/src/main/daemon/daemon-utility-launcher-shim.test.ts
@@ -172,12 +172,33 @@ describe('daemon-utility-launcher-shim', () => {
 
   it('relays the daemon exit code from a real child', async () => {
     const port = createFakePort()
-    runDaemonUtilityLauncherShim(port, undefined, () => {})
+    const exit = vi.fn()
+    runDaemonUtilityLauncherShim(port, undefined, exit)
     port.deliver({ kind: 'spawn', spec: specFor(EXITING_FIXTURE) })
 
     const spawned = await port.waitFor('spawned')
     spawnedPids.push(spawned.pid)
     const exited = await port.waitFor('daemon-exit')
     expect(exited).toEqual({ kind: 'daemon-exit', code: 7, signal: null })
+    // Exiting inside the relay would race process.exit against delivery of the
+    // exit code the launcher reports as the startup-failure cause.
+    expect(exit).not.toHaveBeenCalled()
+  })
+
+  it('releases a shim whose daemon already exited without posting a phantom daemon error', async () => {
+    const port = createFakePort()
+    const exit = vi.fn()
+    runDaemonUtilityLauncherShim(port, undefined, exit)
+    port.deliver({ kind: 'spawn', spec: specFor(EXITING_FIXTURE) })
+
+    const spawned = await port.waitFor('spawned')
+    spawnedPids.push(spawned.pid)
+    await port.waitFor('daemon-exit')
+
+    // Release still arrives here: the parent kills this shim on the exit relay,
+    // but its own cleanup path calls disconnect() and kills are not instant.
+    port.deliver({ kind: 'release' })
+    expect(exit).toHaveBeenCalledWith(0)
+    expect(port.posted.filter((message) => message.kind === 'daemon-error')).toEqual([])
   })
 })

--- a/src/main/daemon/daemon-utility-launcher-shim.test.ts
+++ b/src/main/daemon/daemon-utility-launcher-shim.test.ts
@@ -1,0 +1,166 @@
+import { EventEmitter } from 'node:events'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { runDaemonUtilityLauncherShim, type ShimParentPort } from './daemon-utility-launcher-shim'
+import type { DaemonShimUpMessage, UtilityDaemonForkSpec } from './daemon-utility-fork-messages'
+
+const READY_FIXTURE = join(__dirname, '__fixtures__', 'utility-shim-ready-daemon.cjs')
+const EXITING_FIXTURE = join(__dirname, '__fixtures__', 'utility-shim-exiting-daemon.cjs')
+
+type FakePort = ShimParentPort & {
+  posted: DaemonShimUpMessage[]
+  deliver(message: unknown): void
+  started: boolean
+  waitFor<K extends DaemonShimUpMessage['kind']>(
+    kind: K,
+    timeoutMs?: number
+  ): Promise<Extract<DaemonShimUpMessage, { kind: K }>>
+}
+
+function createFakePort(): FakePort {
+  const emitter = new EventEmitter()
+  const posted: DaemonShimUpMessage[] = []
+  const port: FakePort = {
+    posted,
+    started: false,
+    on(_event, listener) {
+      emitter.on('message', listener)
+      return port
+    },
+    start() {
+      port.started = true
+    },
+    postMessage(message) {
+      posted.push(message as DaemonShimUpMessage)
+      emitter.emit('posted', message)
+    },
+    deliver(message) {
+      emitter.emit('message', { data: message })
+    },
+    waitFor(kind, timeoutMs = 10_000) {
+      const existing = posted.find((message) => message.kind === kind)
+      if (existing) {
+        return Promise.resolve(existing as Extract<DaemonShimUpMessage, { kind: typeof kind }>)
+      }
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error(`timed out waiting for shim message ${kind}`)),
+          timeoutMs
+        )
+        const onPosted = (message: DaemonShimUpMessage): void => {
+          if (message.kind === kind) {
+            clearTimeout(timer)
+            emitter.off('posted', onPosted)
+            resolve(message as Extract<DaemonShimUpMessage, { kind: typeof kind }>)
+          }
+        }
+        emitter.on('posted', onPosted)
+      })
+    }
+  }
+  return port
+}
+
+function specFor(
+  entryPath: string,
+  overrides: Partial<UtilityDaemonForkSpec> = {}
+): UtilityDaemonForkSpec {
+  return {
+    entryPath,
+    args: ['--socket', '/fake/sock'],
+    cwd: process.cwd(),
+    env: { ...process.env, ORCA_SHIM_TEST: '1' },
+    execPath: process.execPath,
+    ...overrides
+  }
+}
+
+const spawnedPids: number[] = []
+
+afterEach(() => {
+  for (const pid of spawnedPids.splice(0)) {
+    try {
+      process.kill(pid, 'SIGKILL')
+    } catch {
+      // already gone
+    }
+  }
+})
+
+describe('daemon-utility-launcher-shim', () => {
+  it('spawns the daemon detached as plain args on the provided binary', () => {
+    const port = createFakePort()
+    const child = new EventEmitter() as EventEmitter & { pid: number; stderr: null }
+    child.pid = 4242
+    child.stderr = null
+    const spawn = vi.fn(() => child as never)
+    runDaemonUtilityLauncherShim(port, spawn, () => {})
+
+    expect(port.started).toBe(true)
+    expect(port.posted[0]).toEqual({ kind: 'shim-ready' })
+
+    const spec = specFor('/fake/daemon-entry.js')
+    port.deliver({ kind: 'spawn', spec })
+    expect(spawn).toHaveBeenCalledWith({
+      program: process.execPath,
+      args: ['/fake/daemon-entry.js', '--socket', '/fake/sock'],
+      cwd: spec.cwd,
+      env: spec.env,
+      detached: true,
+      stdio: ['ignore', 'ignore', 'pipe', 'ipc']
+    })
+    expect(port.posted).toContainEqual({ kind: 'spawned', pid: 4242 })
+
+    // A duplicate spawn request must not fork a second daemon.
+    port.deliver({ kind: 'spawn', spec })
+    expect(spawn).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a spawn failure and exits nonzero', () => {
+    const port = createFakePort()
+    const exit = vi.fn()
+    runDaemonUtilityLauncherShim(
+      port,
+      () => {
+        throw new Error('no binary')
+      },
+      exit
+    )
+    port.deliver({ kind: 'spawn', spec: specFor('/fake/daemon-entry.js') })
+    expect(port.posted).toContainEqual({ kind: 'spawn-error', message: 'no binary' })
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+
+  it('relays IPC readiness and stderr from a real daemon child', async () => {
+    const port = createFakePort()
+    const exit = vi.fn()
+    runDaemonUtilityLauncherShim(port, undefined, exit)
+    port.deliver({ kind: 'spawn', spec: specFor(READY_FIXTURE) })
+
+    const spawned = await port.waitFor('spawned')
+    spawnedPids.push(spawned.pid)
+    expect(spawned.pid).toBeGreaterThan(0)
+
+    const ready = await port.waitFor('daemon-message')
+    expect(ready.message).toMatchObject({ type: 'ready', startedAtMs: 123 })
+
+    const stderr = await port.waitFor('daemon-stderr')
+    expect(stderr.text).toContain('utility-shim-fixture-stderr')
+
+    // Release must detach without killing: the shim exits, the daemon stays.
+    port.deliver({ kind: 'release' })
+    expect(exit).toHaveBeenCalledWith(0)
+    expect(() => process.kill(spawned.pid, 0)).not.toThrow()
+  })
+
+  it('relays the daemon exit code from a real child', async () => {
+    const port = createFakePort()
+    runDaemonUtilityLauncherShim(port, undefined, () => {})
+    port.deliver({ kind: 'spawn', spec: specFor(EXITING_FIXTURE) })
+
+    const spawned = await port.waitFor('spawned')
+    spawnedPids.push(spawned.pid)
+    const exited = await port.waitFor('daemon-exit')
+    expect(exited).toEqual({ kind: 'daemon-exit', code: 7, signal: null })
+  })
+})

--- a/src/main/daemon/daemon-utility-launcher-shim.ts
+++ b/src/main/daemon/daemon-utility-launcher-shim.ts
@@ -1,0 +1,124 @@
+/**
+ * Utility-process launcher shim for the detached terminal daemon.
+ *
+ * Why this hop exists: the Electron main process carries Chromium-owned
+ * descriptors that are not close-on-exec (POSIX) / not inheritance-protected
+ * (Windows) — the DevTools CDP listener, the crashpad client channel, mojo
+ * socketpairs, and writable profile file descriptors among them. A daemon
+ * forked directly from main inherits all of them on Linux and Windows, passes
+ * them to every PTY child, and — because the daemon outlives the app — keeps
+ * dead-instance resources alive: the CDP port stays bound with no acceptor, so
+ * a relaunched app comes back debugger-less. A utility process is launched by
+ * Chromium's own process launcher, which grants children an explicit
+ * stdio/ipc-only descriptor set, so a daemon forked from HERE starts clean.
+ *
+ * Runs inside `utilityProcess.fork` with no window and no electron imports;
+ * talks to the main process only through `process.parentPort`.
+ */
+import { spawnProcess, type SpawnedProcess } from '../../shared/child-process/run-process'
+import type {
+  DaemonShimDownMessage,
+  DaemonShimUpMessage,
+  UtilityDaemonForkSpec
+} from './daemon-utility-fork-messages'
+
+export type ShimParentPort = {
+  on(event: 'message', listener: (event: { data: unknown }) => void): unknown
+  postMessage(message: unknown): void
+  start?: () => void
+}
+
+type ShimSpawn = (spec: {
+  program: string
+  args: readonly string[]
+  cwd: string
+  env: NodeJS.ProcessEnv
+  detached: boolean
+  stdio: ('ignore' | 'pipe' | 'ipc')[]
+}) => SpawnedProcess
+
+/** Delay before self-exit after relaying the daemon's exit, so the message wins the race. */
+const EXIT_RELAY_LINGER_MS = 2000
+
+export function runDaemonUtilityLauncherShim(
+  port: ShimParentPort,
+  spawn: ShimSpawn = spawnProcess,
+  exit: (code: number) => void = (code) => process.exit(code)
+): void {
+  let child: SpawnedProcess | null = null
+  let launched = false
+  let released = false
+
+  const post = (message: DaemonShimUpMessage): void => port.postMessage(message)
+
+  const release = (): void => {
+    if (released) {
+      return
+    }
+    released = true
+    if (child) {
+      // Mirror of the direct-fork launcher: drop IPC and stderr so the daemon
+      // runs detached, then leave; the daemon must not die with this shim.
+      if (child.connected) {
+        child.disconnect()
+      }
+      child.stderr?.destroy()
+      child.unref()
+    }
+    exit(0)
+  }
+
+  const launch = (spec: UtilityDaemonForkSpec): void => {
+    try {
+      child = spawn({
+        program: spec.execPath,
+        args: [spec.entryPath, ...spec.args],
+        cwd: spec.cwd,
+        env: spec.env,
+        detached: true,
+        stdio: ['ignore', 'ignore', 'pipe', 'ipc']
+      })
+    } catch (error) {
+      post({ kind: 'spawn-error', message: error instanceof Error ? error.message : String(error) })
+      exit(1)
+      return
+    }
+    child.on('message', (message) => post({ kind: 'daemon-message', message }))
+    child.stderr?.on('data', (chunk: Buffer | string) =>
+      post({ kind: 'daemon-stderr', text: chunk.toString('utf8') })
+    )
+    child.on('error', (error) => post({ kind: 'daemon-error', message: error.message }))
+    child.on('exit', (code, signal) => {
+      post({ kind: 'daemon-exit', code, signal })
+      // The parent kills this shim on receipt; the linger only covers a parent
+      // that is already gone.
+      setTimeout(() => exit(0), EXIT_RELAY_LINGER_MS)
+    })
+    if (typeof child.pid === 'number') {
+      post({ kind: 'spawned', pid: child.pid })
+    } else {
+      post({ kind: 'spawn-error', message: 'daemon child has no pid' })
+      exit(1)
+    }
+  }
+
+  port.on('message', (event) => {
+    const message = event.data as DaemonShimDownMessage | null
+    if (!message || typeof message !== 'object') {
+      return
+    }
+    if (message.kind === 'spawn' && !launched) {
+      launched = true
+      launch(message.spec)
+    } else if (message.kind === 'release') {
+      release()
+    }
+  })
+  port.start?.()
+  post({ kind: 'shim-ready' })
+}
+
+const parentPort = (process as unknown as { parentPort?: ShimParentPort }).parentPort
+if (parentPort) {
+  runDaemonUtilityLauncherShim(parentPort)
+}

--- a/src/main/daemon/daemon-utility-launcher-shim.ts
+++ b/src/main/daemon/daemon-utility-launcher-shim.ts
@@ -98,6 +98,13 @@ export function runDaemonUtilityLauncherShim(
       post({ kind: 'spawned', pid: child.pid })
     } else {
       post({ kind: 'spawn-error', message: 'daemon child has no pid' })
+      // A pid-less child may still be a live process the parent can never
+      // address (it never learns a pid to kill); don't leave an orphan behind.
+      try {
+        child.kill()
+      } catch {
+        // already gone
+      }
       exit(1)
     }
   }

--- a/src/main/daemon/daemon-utility-process-fork.test.ts
+++ b/src/main/daemon/daemon-utility-process-fork.test.ts
@@ -82,6 +82,23 @@ describe('canForkDaemonThroughUtilityProcess', () => {
     expect(canForkDaemonThroughUtilityProcess('linux')).toBe(false)
     expect(canForkDaemonThroughUtilityProcess('win32')).toBe(false)
   })
+
+  it('warns when an ELECTRON host has no port: a dropped bootstrap install is a silent revert to the leaky fork', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      expect(canForkDaemonThroughUtilityProcess('linux', { electron: '37.2.0' })).toBe(false)
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No utility-process fork installed')
+      )
+      warnSpy.mockClear()
+      // Plain-node serve installs nothing by design; macOS never takes the hop. Both stay quiet.
+      expect(canForkDaemonThroughUtilityProcess('linux', {})).toBe(false)
+      expect(canForkDaemonThroughUtilityProcess('darwin', { electron: '37.2.0' })).toBe(false)
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
 })
 
 describe('forkDaemonThroughUtilityProcess', () => {
@@ -154,6 +171,54 @@ describe('forkDaemonThroughUtilityProcess', () => {
     expect(() =>
       shim.emit('message', { kind: 'daemon-error', message: 'late failure' })
     ).not.toThrow()
+  })
+
+  // Pre-guard, every leg below re-raised as [main_uncaught_exception]: the relay
+  // emitted 'error' on a child no caller ever received, and an unlistened
+  // EventEmitter 'error' throws.
+  describe('failed-handshake crash guard', () => {
+    it('a shim exit after a rejected handshake degrades to a warn instead of crashing main', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const promise = forkDaemonThroughUtilityProcess(SPEC, forkFn)
+        shim.emit('message', { kind: 'shim-ready' })
+        shim.emit('message', { kind: 'spawn-error', message: 'ENOENT' })
+        await expect(promise).rejects.toThrow('ENOENT')
+        expect(() => shim.emit('exit', 1)).not.toThrow()
+        expect(warnSpy).toHaveBeenCalled()
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    it('a shim exit after a handshake timeout degrades instead of crashing main', async () => {
+      vi.useFakeTimers()
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const promise = forkDaemonThroughUtilityProcess(SPEC, forkFn)
+        const assertion = expect(promise).rejects.toThrow('handshake timed out')
+        await vi.advanceTimersByTimeAsync(10_001)
+        await assertion
+        expect(() => shim.emit('exit', 1)).not.toThrow()
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    it('a late daemon-error relay after a rejected handshake degrades instead of crashing main', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const promise = forkDaemonThroughUtilityProcess(SPEC, forkFn)
+        shim.emit('message', { kind: 'shim-ready' })
+        shim.emit('message', { kind: 'spawn-error', message: 'ENOENT' })
+        await expect(promise).rejects.toThrow('ENOENT')
+        expect(() =>
+          shim.emit('message', { kind: 'daemon-error', message: 'late failure' })
+        ).not.toThrow()
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
   })
 
   it('disconnect releases the shim instead of killing the daemon', async () => {

--- a/src/main/daemon/daemon-utility-process-fork.test.ts
+++ b/src/main/daemon/daemon-utility-process-fork.test.ts
@@ -155,6 +155,31 @@ describe('forkDaemonThroughUtilityProcess', () => {
     expect(shim.killed).toBe(true)
   })
 
+  it('fails an unsettled handshake on the utility process error event instead of crashing main', async () => {
+    const promise = forkDaemonThroughUtilityProcess(SPEC, forkFn)
+    shim.emit('message', { kind: 'shim-ready' })
+    // Electron forwards V8 fatal errors through EventEmitter 'error'; with no
+    // listener that is an uncaught exception in the main process, thrown before
+    // the launcher ever sees the handshake rejection.
+    expect(() => shim.emit('error', 'FatalError', 'v8::internal::Heap', '{}')).not.toThrow()
+    await expect(promise).rejects.toThrow('FatalError')
+    expect(shim.killed).toBe(true)
+  })
+
+  it('routes no late shim events to the orphan child after a rejected launch', async () => {
+    vi.useFakeTimers()
+    const promise = forkDaemonThroughUtilityProcess(SPEC, forkFn)
+    const assertion = expect(promise).rejects.toThrow('handshake timed out')
+    await vi.advanceTimersByTimeAsync(10_001)
+    await assertion
+    // The rejected launch was the only consumer — the child was never handed
+    // out, so a relayed 'error' emission has no listener and would crash main.
+    expect(() => shim.emit('exit', 1)).not.toThrow()
+    expect(() =>
+      shim.emit('message', { kind: 'daemon-error', message: 'late failure' })
+    ).not.toThrow()
+  })
+
   it('surfaces an unexpected shim death after launch as a child error', async () => {
     const child = await forkSettledChild()
     const errors: Error[] = []

--- a/src/main/daemon/daemon-utility-process-fork.test.ts
+++ b/src/main/daemon/daemon-utility-process-fork.test.ts
@@ -1,0 +1,170 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setAppEnvironment, type AppEnvironment } from '../../shared/app-environment'
+import {
+  canForkDaemonThroughUtilityProcess,
+  forkDaemonThroughUtilityProcess,
+  setDaemonUtilityProcessFork,
+  type UtilityProcessForkFn,
+  type UtilityProcessLike
+} from './daemon-utility-process-fork'
+import type { DaemonShimDownMessage, UtilityDaemonForkSpec } from './daemon-utility-fork-messages'
+
+class FakeShim extends EventEmitter implements UtilityProcessLike {
+  pid = 999
+  posted: DaemonShimDownMessage[] = []
+  killed = false
+  postMessage(message: unknown): void {
+    this.posted.push(message as DaemonShimDownMessage)
+  }
+  kill(): boolean {
+    this.killed = true
+    return true
+  }
+}
+
+const SPEC: UtilityDaemonForkSpec = {
+  entryPath: '/fake/daemon-entry.js',
+  args: ['--socket', '/fake/sock'],
+  cwd: '/fake/userData',
+  env: { ELECTRON_RUN_AS_NODE: '1' },
+  execPath: '/fake/electron'
+}
+
+let shim: FakeShim
+let forkedPaths: string[]
+
+const forkFn: UtilityProcessForkFn = (modulePath) => {
+  forkedPaths.push(modulePath)
+  return shim
+}
+
+/** Runs the handshake to a resolved child: shim-ready -> spawn -> spawned. */
+async function forkSettledChild() {
+  const promise = forkDaemonThroughUtilityProcess(SPEC, forkFn)
+  shim.emit('message', { kind: 'shim-ready' })
+  shim.emit('message', { kind: 'spawned', pid: 777 })
+  return await promise
+}
+
+beforeEach(() => {
+  shim = new FakeShim()
+  forkedPaths = []
+  setAppEnvironment({
+    getAppPath: () => '/fake/app',
+    getPath: () => '/fake/userData',
+    getVersion: () => '1.2.3',
+    isPackaged: () => false,
+    onWillQuit: () => {},
+    exit: () => {},
+    getAppMetrics: () => []
+  } as unknown as AppEnvironment)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  setDaemonUtilityProcessFork(null)
+})
+
+describe('canForkDaemonThroughUtilityProcess', () => {
+  it('never uses the utility hop on macOS: posix_spawn already strips descriptors and TCC needs the direct fork', () => {
+    setDaemonUtilityProcessFork(forkFn)
+    expect(canForkDaemonThroughUtilityProcess('darwin')).toBe(false)
+  })
+
+  it('uses the utility hop on Linux and Windows once the desktop installs the port', () => {
+    setDaemonUtilityProcessFork(forkFn)
+    expect(canForkDaemonThroughUtilityProcess('linux')).toBe(true)
+    expect(canForkDaemonThroughUtilityProcess('win32')).toBe(true)
+  })
+
+  it('declines on hosts that install no port (plain-node serve)', () => {
+    expect(canForkDaemonThroughUtilityProcess('linux')).toBe(false)
+    expect(canForkDaemonThroughUtilityProcess('win32')).toBe(false)
+  })
+})
+
+describe('forkDaemonThroughUtilityProcess', () => {
+  it('forks the shim entry and hands it the spawn spec over postMessage, never argv', async () => {
+    const child = await forkSettledChild()
+    expect(forkedPaths[0]).toContain('daemon-utility-launcher-shim.js')
+    expect(shim.posted).toEqual([{ kind: 'spawn', spec: SPEC }])
+    expect(child.pid).toBe(777)
+    expect(child.connected).toBe(true)
+  })
+
+  it('relays daemon IPC messages, stderr, and exit through the ChildProcess surface', async () => {
+    const child = await forkSettledChild()
+    const messages: unknown[] = []
+    const stderrChunks: string[] = []
+    const exits: [number | null, NodeJS.Signals | null][] = []
+    child.on('message', (message) => messages.push(message))
+    child.stderr?.on('data', (chunk) => stderrChunks.push(chunk.toString('utf8')))
+    child.on('exit', (code, signal) => exits.push([code, signal]))
+
+    shim.emit('message', { kind: 'daemon-message', message: { type: 'ready' } })
+    shim.emit('message', { kind: 'daemon-stderr', text: 'boom trace' })
+    shim.emit('message', { kind: 'daemon-exit', code: 1, signal: null })
+
+    expect(messages).toEqual([{ type: 'ready' }])
+    expect(stderrChunks).toEqual(['boom trace'])
+    expect(exits).toEqual([[1, null]])
+    expect(child.exitCode).toBe(1)
+    // Nothing left to relay once the daemon is gone.
+    expect(shim.killed).toBe(true)
+  })
+
+  it('rejects when the shim reports a spawn failure', async () => {
+    const promise = forkDaemonThroughUtilityProcess(SPEC, forkFn)
+    shim.emit('message', { kind: 'shim-ready' })
+    shim.emit('message', { kind: 'spawn-error', message: 'ENOENT' })
+    await expect(promise).rejects.toThrow('ENOENT')
+    expect(shim.killed).toBe(true)
+  })
+
+  it('rejects when the shim dies during the handshake', async () => {
+    const promise = forkDaemonThroughUtilityProcess(SPEC, forkFn)
+    shim.emit('message', { kind: 'shim-ready' })
+    shim.emit('exit', 1)
+    await expect(promise).rejects.toThrow('exited during the launch handshake')
+  })
+
+  it('rejects when the shim never answers', async () => {
+    vi.useFakeTimers()
+    const promise = forkDaemonThroughUtilityProcess(SPEC, forkFn)
+    const assertion = expect(promise).rejects.toThrow('handshake timed out')
+    await vi.advanceTimersByTimeAsync(10_001)
+    await assertion
+    expect(shim.killed).toBe(true)
+  })
+
+  it('surfaces an unexpected shim death after launch as a child error', async () => {
+    const child = await forkSettledChild()
+    const errors: Error[] = []
+    child.on('error', (error) => errors.push(error))
+    shim.emit('exit', 1)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain('before the daemon settled')
+  })
+
+  it('suppresses late daemon-error relays after release: no listener remains to catch them', async () => {
+    const child = await forkSettledChild()
+    child.disconnect()
+    // Would be an uncaught exception if emitted with no 'error' listener.
+    expect(() =>
+      shim.emit('message', { kind: 'daemon-error', message: 'late failure' })
+    ).not.toThrow()
+  })
+
+  it('disconnect releases the shim instead of killing the daemon', async () => {
+    const child = await forkSettledChild()
+    const errors: Error[] = []
+    child.on('error', (error) => errors.push(error))
+    child.disconnect()
+    expect(child.connected).toBe(false)
+    expect(shim.posted).toContainEqual({ kind: 'release' })
+    // The shim exiting after release is the expected shutdown, not a failure.
+    shim.emit('exit', 0)
+    expect(errors).toEqual([])
+  })
+})

--- a/src/main/daemon/daemon-utility-process-fork.test.ts
+++ b/src/main/daemon/daemon-utility-process-fork.test.ts
@@ -1,4 +1,7 @@
 import { EventEmitter } from 'node:events'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setAppEnvironment, type AppEnvironment } from '../../shared/app-environment'
 import {
@@ -34,8 +37,11 @@ const SPEC: UtilityDaemonForkSpec = {
 let shim: FakeShim
 let forkedPaths: string[]
 
-const forkFn: UtilityProcessForkFn = (modulePath) => {
+let forkOptions: (Record<string, unknown> | undefined)[]
+
+const forkFn: UtilityProcessForkFn = (modulePath, _args, options) => {
   forkedPaths.push(modulePath)
+  forkOptions.push(options)
   return shim
 }
 
@@ -47,11 +53,9 @@ async function forkSettledChild() {
   return await promise
 }
 
-beforeEach(() => {
-  shim = new FakeShim()
-  forkedPaths = []
+function setFakeAppEnvironment(appPath: string): void {
   setAppEnvironment({
-    getAppPath: () => '/fake/app',
+    getAppPath: () => appPath,
     getPath: () => '/fake/userData',
     getVersion: () => '1.2.3',
     isPackaged: () => false,
@@ -59,6 +63,20 @@ beforeEach(() => {
     exit: () => {},
     getAppMetrics: () => []
   } as unknown as AppEnvironment)
+}
+
+/** Runs a body against a throwaway bundle root so shim-path resolution is real. */
+function withBundleRoot(body: (appPath: string) => Promise<void>): Promise<void> {
+  const appPath = mkdtempSync(join(tmpdir(), 'orca-shim-path-'))
+  setFakeAppEnvironment(appPath)
+  return body(appPath).finally(() => rmSync(appPath, { recursive: true, force: true }))
+}
+
+beforeEach(() => {
+  shim = new FakeShim()
+  forkedPaths = []
+  forkOptions = []
+  setFakeAppEnvironment('/fake/app')
 })
 
 afterEach(() => {
@@ -186,16 +204,65 @@ describe('forkDaemonThroughUtilityProcess', () => {
     child.on('error', (error) => errors.push(error))
     shim.emit('exit', 1)
     expect(errors).toHaveLength(1)
-    expect(errors[0].message).toContain('before the daemon settled')
+    // Exact: with no fatal error recorded the message must not trail a cause.
+    expect(errors[0].message).toBe('Daemon utility launcher exited before the daemon settled')
+  })
+
+  it('carries a post-launch fatal shim error into the child error as the cause', async () => {
+    const child = await forkSettledChild()
+    const errors: Error[] = []
+    child.on('error', (error) => errors.push(error))
+    // Electron emits 'error' then 'exit'; failing the settled launch again would
+    // drop the cause, leaving only "exited before the daemon settled" to triage.
+    shim.emit('error', 'FatalError', 'v8::internal::Heap', '{}')
+    shim.emit('exit', 1)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toBe(
+      'Daemon utility launcher exited before the daemon settled: Daemon utility launcher hit a fatal error: FatalError at v8::internal::Heap'
+    )
   })
 
   it('suppresses late daemon-error relays after release: no listener remains to catch them', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const child = await forkSettledChild()
+      child.disconnect()
+      // Would be an uncaught exception if emitted with no 'error' listener.
+      expect(() =>
+        shim.emit('message', { kind: 'daemon-error', message: 'late failure' })
+      ).not.toThrow()
+      // The launch already succeeded and the daemon is detached; degrading this
+      // to the no-listener warn would log a launch failure that did not happen.
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('treats the shim exit that follows a relayed daemon exit as shutdown, not a launch failure', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      await forkSettledChild()
+      shim.emit('message', { kind: 'daemon-exit', code: 1, signal: null })
+      expect(shim.killed).toBe(true)
+      // Electron emits 'exit' after that kill(), by which point the launcher has
+      // already dropped its startup listeners and reported the real exit code.
+      shim.emit('exit', 0)
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('releases a shim that is already gone without throwing out of disconnect', async () => {
     const child = await forkSettledChild()
-    child.disconnect()
-    // Would be an uncaught exception if emitted with no 'error' listener.
-    expect(() =>
-      shim.emit('message', { kind: 'daemon-error', message: 'late failure' })
-    ).not.toThrow()
+    // Reachable: a daemon that dies during startup makes the exit relay kill the
+    // shim, and the launcher's cleanup path still calls disconnect() afterwards.
+    shim.postMessage = () => {
+      throw new Error('Utility process is not running')
+    }
+    expect(() => child.disconnect()).not.toThrow()
+    expect(child.connected).toBe(false)
   })
 
   // Pre-guard, every leg below re-raised as [main_uncaught_exception]: the relay
@@ -243,6 +310,44 @@ describe('forkDaemonThroughUtilityProcess', () => {
       } finally {
         warnSpy.mockRestore()
       }
+    })
+  })
+
+  it('forks through the port the desktop installed when called with a spec alone', async () => {
+    // The only shape production uses: daemon-init passes no fork argument.
+    setDaemonUtilityProcessFork(forkFn)
+    const promise = forkDaemonThroughUtilityProcess(SPEC)
+    shim.emit('message', { kind: 'shim-ready' })
+    shim.emit('message', { kind: 'spawned', pid: 777 })
+    await expect(promise).resolves.toMatchObject({ pid: 777 })
+    expect(forkedPaths).toHaveLength(1)
+  })
+
+  it('gives the shim no inheritable stdio and a named service entry', async () => {
+    await forkSettledChild()
+    // 'ignore': nobody drains the shim's output, and an unread pipe from main
+    // both blocks exit and hands the shim descriptors this hop exists to avoid.
+    expect(forkOptions[0]).toEqual({ stdio: 'ignore', serviceName: 'orca-daemon-launcher' })
+  })
+
+  it('rejects by name when no port is installed rather than throwing a bare TypeError', async () => {
+    await expect(forkDaemonThroughUtilityProcess(SPEC)).rejects.toThrow(
+      'No utility-process fork is installed on this host'
+    )
+  })
+
+  it('resolves the shim under out/main, the layout every host taking the hop ships', async () => {
+    await withBundleRoot(async (appPath) => {
+      await forkSettledChild()
+      expect(forkedPaths[0]).toBe(join(appPath, 'out', 'main', 'daemon-utility-launcher-shim.js'))
+    })
+  })
+
+  it('prefers a shim sitting directly in the bundle root when one is there', async () => {
+    await withBundleRoot(async (appPath) => {
+      writeFileSync(join(appPath, 'daemon-utility-launcher-shim.js'), '')
+      await forkSettledChild()
+      expect(forkedPaths[0]).toBe(join(appPath, 'daemon-utility-launcher-shim.js'))
     })
   })
 

--- a/src/main/daemon/daemon-utility-process-fork.ts
+++ b/src/main/daemon/daemon-utility-process-fork.ts
@@ -86,12 +86,25 @@ export function setDaemonUtilityProcessFork(fork: UtilityProcessForkFn | null): 
 }
 
 export function canForkDaemonThroughUtilityProcess(
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  versions: { electron?: string } = process.versions
 ): boolean {
   if (platform === 'darwin') {
     return false
   }
-  return installedUtilityProcessFork !== null
+  if (installedUtilityProcessFork !== null) {
+    return true
+  }
+  // An Electron host with no installed port means the bootstrap install line was
+  // dropped — a silent revert of every Linux/Windows launch to the leaky direct
+  // fork. Plain-node hosts (orca serve) legitimately install nothing: their
+  // parent has no Chromium descriptors, so stay quiet there.
+  if (versions.electron) {
+    console.warn(
+      '[daemon] No utility-process fork installed on this Electron host; the daemon will inherit Chromium descriptors (was the bootstrap wiring dropped?)'
+    )
+  }
+  return false
 }
 
 function getDaemonUtilityLauncherShimPath(): string {
@@ -122,6 +135,18 @@ class UtilityForkedDaemonChild extends EventEmitter implements LaunchedDaemonChi
 
   constructor(private readonly shim: UtilityProcessLike) {
     super()
+  }
+
+  // A launch abandoned mid-handshake (or a shim crash after startup listeners
+  // detach) can still relay errors into a child nobody holds, and an unlistened
+  // EventEmitter 'error' throws — in main that is an uncaught exception, the
+  // exact failure mode this launcher exists to prevent. Degrade to a warn.
+  override emit(event: string | symbol, ...args: unknown[]): boolean {
+    if (event === 'error' && this.listenerCount('error') === 0) {
+      console.warn('[daemon] Utility-forked daemon launch error with no listener:', args[0])
+      return false
+    }
+    return super.emit(event, ...args)
   }
 
   handleShimMessage(message: DaemonShimUpMessage): void {

--- a/src/main/daemon/daemon-utility-process-fork.ts
+++ b/src/main/daemon/daemon-utility-process-fork.ts
@@ -60,6 +60,9 @@ export type UtilityProcessLike = {
   on(event: 'message', listener: (message: unknown) => void): unknown
   on(event: 'spawn', listener: () => void): unknown
   on(event: 'exit', listener: (code: number) => void): unknown
+  // Electron's experimental V8 fatal-error event; unlistened, its EventEmitter
+  // 'error' emission is an uncaught exception in the main process.
+  on(event: 'error', listener: (type: string, location: string, report: string) => void): unknown
   kill(): boolean
 }
 
@@ -132,6 +135,7 @@ class UtilityForkedDaemonChild extends EventEmitter implements LaunchedDaemonChi
 
   private daemonExited = false
   private releasedShim = false
+  private shimFatalError: Error | null = null
 
   constructor(private readonly shim: UtilityProcessLike) {
     super()
@@ -147,6 +151,11 @@ class UtilityForkedDaemonChild extends EventEmitter implements LaunchedDaemonChi
       return false
     }
     return super.emit(event, ...args)
+  }
+
+  /** A fatal shim error is always followed by shim exit; keep the cause for it. */
+  noteShimFatalError(error: Error): void {
+    this.shimFatalError = error
   }
 
   handleShimMessage(message: DaemonShimUpMessage): void {
@@ -187,7 +196,14 @@ class UtilityForkedDaemonChild extends EventEmitter implements LaunchedDaemonChi
     // The relay died while the launch still depended on it. The daemon may be
     // fine, but readiness/exit can no longer be observed — surface it like a
     // fork error so the launcher's failure path owns cleanup by pid.
-    this.emit('error', new Error('Daemon utility launcher exited before the daemon settled'))
+    this.emit(
+      'error',
+      new Error(
+        `Daemon utility launcher exited before the daemon settled${
+          this.shimFatalError ? `: ${this.shimFatalError.message}` : ''
+        }`
+      )
+    )
   }
 
   disconnect(): void {
@@ -244,6 +260,15 @@ export async function forkDaemonThroughUtilityProcess(
       reject(error)
     }
 
+    shim.on('error', (type, location) => {
+      const error = new Error(`Daemon utility launcher hit a fatal error: ${type} at ${location}`)
+      if (!settled) {
+        fail(error)
+        return
+      }
+      // Electron always follows 'error' with 'exit'; the exit path surfaces it.
+      child.noteShimFatalError(error)
+    })
     shim.on('message', (raw) => {
       const message = raw as DaemonShimUpMessage | null
       if (!message || typeof message !== 'object') {

--- a/src/main/daemon/daemon-utility-process-fork.ts
+++ b/src/main/daemon/daemon-utility-process-fork.ts
@@ -1,0 +1,255 @@
+/**
+ * Forks the detached terminal daemon through an Electron utility process on
+ * Linux and Windows so it starts with a clean descriptor/handle table.
+ *
+ * Why: Chromium descriptors in the Electron main process (the CDP listener,
+ * crashpad channel, mojo socketpairs, writable profile files) are inheritable
+ * on Linux and Windows, and a daemon forked directly from main carries them —
+ * and hands them to every PTY child — for its whole detached lifetime. The
+ * observable damage: after the app exits or restarts, the daemon lineage keeps
+ * the CDP port bound with no acceptor (the relaunched app comes back
+ * debugger-less), keeps a dead instance's crashpad handler alive, and pins
+ * deleted shared-memory segments. Chromium launches utility processes with an
+ * explicit stdio-only descriptor grant on both platforms, so a daemon forked
+ * from a utility-process shim inherits none of that.
+ *
+ * macOS keeps the direct fork: libuv spawns with POSIX_SPAWN_CLOEXEC_DEFAULT
+ * there (children already start clean), and macOS TCC attribution relies on
+ * the direct app→daemon fork chain (STA-3491).
+ */
+import { EventEmitter } from 'node:events'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { getAppEnvironment } from '../../shared/app-environment'
+import type {
+  DaemonShimDownMessage,
+  DaemonShimUpMessage,
+  UtilityDaemonForkSpec
+} from './daemon-utility-fork-messages'
+
+/**
+ * The structural slice of ChildProcess the daemon launcher consumes. The
+ * direct-fork path returns a real ChildProcess, which satisfies this.
+ */
+export type LaunchedDaemonChild = {
+  pid?: number | undefined
+  exitCode: number | null
+  signalCode: NodeJS.Signals | null
+  connected: boolean
+  stderr: LaunchedDaemonStderr | null
+  on(event: 'message', listener: (message: unknown) => void): unknown
+  on(event: 'error', listener: (error: Error) => void): unknown
+  on(event: 'exit', listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown
+  once(event: 'exit', listener: (code: number | null) => void): unknown
+  // Why any[] not never[]: mirrors EventEmitter.off, which class implements-checks compare non-bivariantly.
+  off(event: string, listener: (...args: any[]) => void): unknown
+  disconnect(): void
+  unref(): void
+}
+
+export type LaunchedDaemonStderr = {
+  on(event: 'data', listener: (chunk: Buffer) => void): unknown
+  off(event: 'data', listener: (chunk: Buffer) => void): unknown
+  destroy(): void
+}
+
+/** The slice of Electron's UtilityProcess this module drives. */
+export type UtilityProcessLike = {
+  pid?: number
+  postMessage(message: unknown): void
+  on(event: 'message', listener: (message: unknown) => void): unknown
+  on(event: 'spawn', listener: () => void): unknown
+  on(event: 'exit', listener: (code: number) => void): unknown
+  kill(): boolean
+}
+
+export type UtilityProcessForkFn = (
+  modulePath: string,
+  args?: string[],
+  options?: { stdio?: string; serviceName?: string }
+) => UtilityProcessLike
+
+/** How long the shim gets to spawn and report the daemon pid. */
+const SHIM_HANDSHAKE_TIMEOUT_MS = 10_000
+/** After release, how long the shim gets to exit on its own before a kill. */
+const SHIM_RELEASE_KILL_DELAY_MS = 5_000
+
+// Why a host port and not an electron import: this module sits in the daemon
+// launcher's graph, which the Orca runtime must be able to load on plain Node
+// (`orca serve`). The desktop installs the real utilityProcess.fork from
+// src/main/host/ at bootstrap; a Node host installs nothing — its parent
+// process has no Chromium descriptors, so the direct fork is already clean.
+let installedUtilityProcessFork: UtilityProcessForkFn | null = null
+
+export function setDaemonUtilityProcessFork(fork: UtilityProcessForkFn | null): void {
+  installedUtilityProcessFork = fork
+}
+
+export function canForkDaemonThroughUtilityProcess(
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  if (platform === 'darwin') {
+    return false
+  }
+  return installedUtilityProcessFork !== null
+}
+
+function getDaemonUtilityLauncherShimPath(): string {
+  // Why not the app.asar.unpacked redirect daemon-entry needs: the shim runs
+  // under the Electron runtime, which reads asar directly.
+  const appPath = getAppEnvironment().getAppPath()
+  const directPath = join(appPath, 'daemon-utility-launcher-shim.js')
+  return existsSync(directPath)
+    ? directPath
+    : join(appPath, 'out', 'main', 'daemon-utility-launcher-shim.js')
+}
+
+class UtilityForkedDaemonStderr extends EventEmitter implements LaunchedDaemonStderr {
+  destroy(): void {
+    this.removeAllListeners()
+  }
+}
+
+class UtilityForkedDaemonChild extends EventEmitter implements LaunchedDaemonChild {
+  pid: number | undefined
+  exitCode: number | null = null
+  signalCode: NodeJS.Signals | null = null
+  connected = true
+  readonly stderr = new UtilityForkedDaemonStderr()
+
+  private daemonExited = false
+  private releasedShim = false
+
+  constructor(private readonly shim: UtilityProcessLike) {
+    super()
+  }
+
+  handleShimMessage(message: DaemonShimUpMessage): void {
+    switch (message.kind) {
+      case 'daemon-message':
+        this.emit('message', message.message)
+        break
+      case 'daemon-stderr':
+        this.stderr.emit('data', Buffer.from(message.text, 'utf8'))
+        break
+      case 'daemon-error':
+        // After release the launcher has dropped its listeners; an unlistened
+        // 'error' emission is an uncaught exception in the main process.
+        if (!this.releasedShim) {
+          this.emit('error', new Error(message.message))
+        }
+        break
+      case 'daemon-exit':
+        this.daemonExited = true
+        this.exitCode = message.code
+        this.signalCode = message.signal
+        this.emit('exit', message.code, message.signal)
+        // The shim has nothing left to relay.
+        this.shim.kill()
+        break
+      case 'shim-ready':
+      case 'spawned':
+      case 'spawn-error':
+        // Handshake messages; the launch promise consumes them before routing here.
+        break
+    }
+  }
+
+  handleShimExit(): void {
+    if (this.daemonExited || this.releasedShim) {
+      return
+    }
+    // The relay died while the launch still depended on it. The daemon may be
+    // fine, but readiness/exit can no longer be observed — surface it like a
+    // fork error so the launcher's failure path owns cleanup by pid.
+    this.emit('error', new Error('Daemon utility launcher exited before the daemon settled'))
+  }
+
+  disconnect(): void {
+    if (!this.connected) {
+      return
+    }
+    this.connected = false
+    this.releasedShim = true
+    const down: DaemonShimDownMessage = { kind: 'release' }
+    try {
+      this.shim.postMessage(down)
+    } catch {
+      // Shim already gone; the daemon is detached either way.
+    }
+    // Fallback if the shim ignores the release; timer must not hold the loop.
+    const killTimer = setTimeout(() => this.shim.kill(), SHIM_RELEASE_KILL_DELAY_MS)
+    killTimer.unref?.()
+    this.shim.on('exit', () => clearTimeout(killTimer))
+  }
+
+  unref(): void {
+    // The shim exits right after release and the daemon is already detached;
+    // there is no parent-side handle left to unref.
+  }
+}
+
+export async function forkDaemonThroughUtilityProcess(
+  spec: UtilityDaemonForkSpec,
+  forkUtilityProcess?: UtilityProcessForkFn
+): Promise<LaunchedDaemonChild> {
+  const fork = forkUtilityProcess ?? installedUtilityProcessFork
+  if (!fork) {
+    throw new Error('No utility-process fork is installed on this host')
+  }
+  const shim = fork(getDaemonUtilityLauncherShimPath(), [], {
+    stdio: 'ignore',
+    serviceName: 'orca-daemon-launcher'
+  })
+  const child = new UtilityForkedDaemonChild(shim)
+
+  return await new Promise<LaunchedDaemonChild>((resolve, reject) => {
+    let settled = false
+    const timer = setTimeout(() => {
+      fail(new Error('Daemon utility launcher handshake timed out'))
+    }, SHIM_HANDSHAKE_TIMEOUT_MS)
+
+    function fail(error: Error): void {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      shim.kill()
+      reject(error)
+    }
+
+    shim.on('message', (raw) => {
+      const message = raw as DaemonShimUpMessage | null
+      if (!message || typeof message !== 'object') {
+        return
+      }
+      if (message.kind === 'shim-ready') {
+        const down: DaemonShimDownMessage = { kind: 'spawn', spec }
+        shim.postMessage(down)
+        return
+      }
+      if (message.kind === 'spawned') {
+        if (!settled) {
+          settled = true
+          clearTimeout(timer)
+          child.pid = message.pid
+          resolve(child)
+        }
+        return
+      }
+      if (message.kind === 'spawn-error') {
+        fail(new Error(`Daemon spawn failed in utility launcher: ${message.message}`))
+        return
+      }
+      child.handleShimMessage(message)
+    })
+    shim.on('exit', () => {
+      if (!settled) {
+        fail(new Error('Daemon utility launcher exited during the launch handshake'))
+        return
+      }
+      child.handleShimExit()
+    })
+  })
+}

--- a/src/main/host/electron-daemon-utility-process-fork.ts
+++ b/src/main/host/electron-daemon-utility-process-fork.ts
@@ -1,0 +1,14 @@
+import { utilityProcess } from 'electron'
+import type { UtilityProcessForkFn } from '../daemon/daemon-utility-process-fork'
+
+/**
+ * The desktop implementation of the daemon launcher's utility-process port.
+ *
+ * Why it exists: on Linux and Windows a daemon forked directly from the Electron
+ * main process inherits Chromium descriptors (the CDP listener among them) for
+ * its whole detached lifetime. Chromium launches utility processes with a clean
+ * stdio-only descriptor grant, so the daemon launcher forks through one where a
+ * desktop host installs this.
+ */
+export const electronDaemonUtilityProcessFork: UtilityProcessForkFn = (modulePath, args, options) =>
+  utilityProcess.fork(modulePath, args ? [...args] : [], options)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,6 +27,8 @@ import { ElectronAppEnvironment } from './host/electron-app-environment'
 import { setPtyHostBindings } from './ipc/pty-host-bindings'
 import { electronRuntimeDesktopSurface } from './host/electron-runtime-desktop-surface'
 import { setRuntimeDesktopSurface } from './runtime/runtime-desktop-surface'
+import { electronDaemonUtilityProcessFork } from './host/electron-daemon-utility-process-fork'
+import { setDaemonUtilityProcessFork } from './daemon/daemon-utility-process-fork'
 import { electronRuntimeBrowserCommandsFactory } from './host/electron-browser-commands'
 import { setRuntimeBrowserCommandsFactory } from './runtime/runtime-browser-commands-factory'
 import { electronHttpClient } from './host/electron-http-client'
@@ -949,6 +951,10 @@ if (hasSingleInstanceLock) {
   // tab-create-reply channel are desktop-only. A Node host installs none and the
   // runtime routes notifications to paired clients instead.
   setRuntimeDesktopSurface(electronRuntimeDesktopSurface)
+  // Why: on Linux/Windows the daemon forks through a utility process so it does not
+  // inherit Chromium descriptors (CDP listener, crashpad channel, profile fds). A Node
+  // host installs nothing — its parent has no Chromium descriptors to leak.
+  setDaemonUtilityProcessFork(electronDaemonUtilityProcessFork)
   // Why here: constructing RuntimeBrowserCommands is what pulls the Chromium browser
   // cluster into the graph. The desktop installs it; a Node host installs none and every
   // browser RPC rejects, which capability filtering already tells clients about.

--- a/src/main/startup/host-port-bootstrap-wiring.test.ts
+++ b/src/main/startup/host-port-bootstrap-wiring.test.ts
@@ -24,6 +24,7 @@ describe('host port bootstrap wiring', () => {
     'setSecretStore(new ElectronSecretStore())',
     'setPtyHostBindings({',
     'setRuntimeDesktopSurface(electronRuntimeDesktopSurface)',
+    'setDaemonUtilityProcessFork(electronDaemonUtilityProcessFork)',
     'setRuntimeBrowserCommandsFactory(electronRuntimeBrowserCommandsFactory)',
     'setDefaultProxySessionResolver(',
     'setMainHttpClient(electronHttpClient)',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​869 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​869 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​553 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​32 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​521 |

<!-- /orca-pr-loc -->

## ELI5

On Linux and Windows, the terminal daemon is forked straight out of the Electron main process — and it silently inherits a pile of Chromium's open file descriptors/handles: the DevTools (CDP) listener socket, the crash-reporter channel, and even writable descriptors into the user profile. The daemon then hands all of that to every terminal shell it spawns, and because the daemon deliberately outlives the app, those borrowed resources stay alive after the app exits. The visible casualty: restart the app and the debug port is still "in use" by the old daemon lineage, so the restarted app comes back with CDP dead.

This PR adds one hop: on Linux and Windows the daemon is now forked from a tiny Electron **utility process** launcher. Utility processes are started by Chromium's own process launcher, which gives children an explicit stdio-only descriptor grant on both platforms — so the daemon (and every PTY under it) starts with a clean table. macOS keeps the direct fork: its spawn path already closes non-stdio descriptors, and macOS TCC attribution depends on the direct app→daemon chain.

Said without the jargon: on Linux and Windows, Orca starts its terminal helper as a direct offshoot
of the app itself, and the helper quietly inherits a pile of the app's own open connections and
files — the debug port, the crash reporter's private channel, even write access to your Orca profile
data. The helper then passes all of it down to every shell it starts. And because the helper is
designed to keep your terminals alive after you close the app, that borrowed material stays open once
you have quit. This PR starts the helper one step removed, through a launcher that hands its children
nothing but their own input and output.

## User-facing before / after

| | Before | After |
|---|---|---|
| You restart Orca on Linux or Windows (dev/QA builds started with a debug port) | The old helper generation still held the port, so the restarted app came back with debugging dead and the port stuck "in use" | The port is released; the restarted app gets it back |
| You quit Orca on a packaged Linux install with terminals still running | The helper kept dozens of files inside your Orca profile open, pinned deleted shared-memory segments, and stranded one orphaned crash-handler process per helper generation for as long as any terminal from that era lived | None of that is inherited any more |
| Any command you run in an Orca terminal on Linux or Windows | It inherited dozens of the app's internal connections — including one it could have accepted debugger connections on | It starts with only its own input and output |
| The same on macOS | Already clean | Unchanged — macOS deliberately keeps the direct start |
| The new launch path fails for any reason | — | Orca logs loudly and falls back to the old way; you never lose your terminals over this |

## When it bites

Linux and Windows users. The most visible symptom — debugging dead after an app restart — is a dev
and QA build thing, but the leaked profile files, pinned shared memory and orphaned crash-handler
processes happen on ordinary packaged Linux installs too. macOS is unaffected either way.


## What Changed

- `src/main/daemon/daemon-utility-launcher-shim.ts` (new rollup input): runs inside `utilityProcess.fork`, spawns the detached daemon via the sanctioned `spawnProcess` wrapper with the exact same argv/env/stdio contract as before, and relays the IPC readiness handshake, stderr tail, and exit events to main over `parentPort`. The spawn spec travels over `postMessage`, never argv, so the daemon environment cannot leak into process listings.
- `src/main/daemon/daemon-utility-process-fork.ts` (new): the main-process side — capability gate (`linux`/`win32` + `utilityProcess` present), the shim handshake, and a ChildProcess-compatible wrapper so the launcher logic in `daemon-init.ts` is minimally disturbed. Fail-open: if the utility launch fails, it logs loudly and falls back to the direct fork — a leaky daemon beats no daemon.
- `src/main/daemon/daemon-init.ts`: the fork site now routes through the gate. macOS, serve/headless, and any context without `utilityProcess` keep the byte-identical direct fork.
- `electron.vite.config.ts`: the shim is a new main entry; it deliberately stays inside app.asar (utility processes read asar directly).
- Tests: shim relay tests against a real forked child, wrapper/handshake tests, daemon-init gate tests on the existing harness, and a config pin that fails if the shim entry is dropped (which would silently put every Linux/Windows launch back on the leaky fallback).

## Why

Reproduced on `origin/main` (25fa6a9920) on a Linux box, dev build launched with `--remote-debugging-port=9460`:

- `ss -ltnp` on the CDP port showed the listener held by **four processes**: the app main, the detached daemon, and the PTY children (`bash`, `codex`) — all at the same fd 66, `/proc/<pid>/fdinfo` flags `04002` (no `O_CLOEXEC`).
- The user's interactive `bash` held **38 inherited Chromium descriptors**: the CDP listener, the crashpad client channel, mojo socketpairs to the GPU/renderer processes, deleted `/dev/shm` Chromium segments, and writable fds into `Local Storage` LevelDB and GPUCache. Any program run in any terminal inherits these — including an fd it could `accept()` DevTools connections on.
- `window.api.app.restart()`: the relaunched app came back **CDP-dead** — the port stayed LISTENING, held only by the old daemon + bash, with no acceptor (`curl /json/version` times out).
- The first instance's `chrome_crashpad_handler` stayed alive, orphaned to init, because the daemon lineage held its client socket — one leaked crashpad process per daemon generation, for as long as any terminal from that era lives.
- LevelDB locks are POSIX advisory (fcntl) locks and do **not** travel with the inherited fds, so relaunches acquire Local Storage cleanly — the profile fds are resource/hygiene damage, not corruption.

Windows reproduced independently on a dev build at the same SHA: after killing the app main with the daemon **still alive**, `netstat` kept the CDP port LISTENING (attributed to the dead pid) and a fresh bind failed with `EADDRINUSE`; killing the daemon freed it. POSIX close-on-exec and the Windows handle-inheritance flag are different mechanisms, and both legs leak today — which is why the fix is a spawn-path change that Chromium enforces on both platforms rather than per-descriptor flag surgery (the leaking descriptors are Chromium's, created outside our code; Node exposes no `fcntl`/`SetHandleInformation`).

**Dev vs packaged:** the CDP-port symptom is dev/QA-only — packaged builds don't pass `--remote-debugging-port`. But the leak itself is not: on a packaged Linux install (1.4.190), the daemon holds **27 profile-file descriptors** plus the crashpad channel and mojo socketpairs (87 fds total). Packaged Linux users are affected by the crashpad orphaning, pinned deleted shared memory, and profile-writable fds in every terminal child. macOS (dev and packaged) is clean — verified during the original investigation — because its spawn path closes non-stdio descriptors.

**Verified fix, same rigs, this branch (2e09a04f7b):**

- Linux: CDP listener held by the main process **only**; daemon fd table has **zero** profile/shm/crashpad/mojo strays (31 fds vs ~95); bash PTY child has 10 fds vs 57; `app.restart()` **rebinds the same CDP port and answers `/json/version`**, while the pre-restart terminal session survives (daemon persistence intact through the shim: readiness handshake, PTY spawn, socket adoption all exercised live).
- Windows: PTY spawn works through the shim-launched daemon; after killing the app main the daemon stays alive **and** the CDP port is immediately free (`BIND_OK`) — versus alive-daemon + `EADDRINUSE` on main.

Remaining residuals, stated plainly: processes spawned *directly* by the main process (short-lived agent/version probes, the plugin host, and local-provider PTYs used only in degraded daemon fallback) still inherit main's descriptors for their own lifetime on Linux/Windows; none of them outlive the app, so no port wedge. The daemon also inherits one benign netlink-style socket and a self-pipe from the shim's own runtime — no port binding, no user data. Plain-node hosts (serve/SSH relay) never had the leak (no Chromium descriptors in the parent) and keep the direct fork.

Ablation (each production hunk reverted individually, suite result):

| Hunk reverted | Red signal |
| --- | --- |
| `daemon-init.ts` utility branch | `daemon-init-utility-fork.test.ts` 2 failures |
| `daemon-utility-process-fork.ts` deleted | fork suite import failure (file red) |
| `daemon-utility-launcher-shim.ts` deleted | shim suite file red |
| `daemon-utility-fork-messages.ts` deleted | `tc:node` 4 errors |
| `electron.vite.config.ts` input line | `electron-builder-config.test.mjs` 1 failure |

## Linked Issue

Found and reported while re-validating PR #15666's host arms (see the CDP-loss note in that PR's validation discussion); no standing GitHub issue existed for this defect.

## Visual Proof

N/A — daemon spawn plumbing with no UI or interaction change; the observable behavior is process/descriptor state, evidenced by the fd tables and port probes above.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- Linux (Ubuntu 24.04, real dev build at this SHA): full before/after cycle — repro on main, then fd-table audit, PTY spawn, `app.restart()` CDP recovery, and session survival on this branch.
- Windows (real dev build at this SHA): PTY spawn through the shim-launched daemon; kill-main → daemon-alive + port-free probe.
- macOS: unchanged direct-fork path; full daemon unit battery green locally (130 tests across the new suites + all `daemon-init-*` suites + config pins).
- `pnpm tc:node`, `oxlint --max-warnings=0` on changed files, changed-code quality gate (including type-aware pass), `git diff --check`, and a full `electron-vite` build (the plain-node entry guard and the new rollup input both exercised).
- The fd-cleanliness property itself is an Electron runtime behavior and is not unit-testable under vitest; it is pinned by the live evidence above, and the unit suites pin every seam that keeps the utility path selected and functional.

## Review

Reliability contract:

- Invariant: `daemon-spawn.descriptor-isolation` — a detached daemon and its PTY children hold no descriptors owned by the Electron main process's browser runtime.
- Failure source: the daemon fork inherited every non-close-on-exec / inheritable descriptor from main on Linux and Windows; the daemon's detached lifetime turned transient inheritance into persistent resource capture (bound CDP port, live crashpad channel, profile file descriptors).
- Oracle: on Linux, the CDP listener's socket inode appears in exactly one process (main); the daemon fd table contains no profile/shm/crashpad/mojo entries. On Windows, killing main with a live daemon leaves the CDP port bindable.
- Gate: the launcher-selection tests plus the config pin (a dropped shim input silently reverts every Linux/Windows launch to the leaky fallback — that pin is the one that guards the regression).
- Platform coverage: Linux and Windows take the new path (both live-validated); macOS and plain-node hosts are compile-time routed to the unchanged direct fork. No RPC, wire, persistence, provider, SSH-boundary, or mobile contract changes; daemon argv/env byte-compatible, so old daemons adopt and new daemons publish identically.
- Residual gap: degraded-mode local-provider PTYs and other direct children of main still inherit for their own lifetime (documented above); Windows non-socket handle classes were not enumerated (socket class proven; file-handle probe was inconclusive because Chromium opens profile files share-delete).

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No mobile-facing surface, persisted state, remote wire, Git provider, or SSH execution boundary changed. The daemon launch protocol (argv, env, IPC readiness, pid-record publication) is unchanged on the wire — only which process performs the fork moved. Security posture improves: terminal children no longer hold an fd on which they could accept DevTools (full-control) connections, nor writable descriptors into the app profile.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


## Hardening round r2 (post-review, 2026-08-28)

Closes review finding F1 and re-validates the Windows legs live on a real Windows host (`awin`, Win11, Electron 43.1.0 dev build; details in the exact-SHA comment below).

- **F1 (crash guard, fixed in `28dc51b779` + `110eed0f1b`)**: a failed shim handshake (spawn-error / timeout / handshake-window death) left the unresolved launch child wired to shim `'exit'` and late `'daemon-error'` relays; the resulting unlistened EventEmitter `'error'` was an uncaught exception in main. Guarded at the child emitter (degrades to a warn), the launch now detaches routing on rejection, and the shim's own experimental `'error'` (V8 fatal) event has a listener that fails an unsettled handshake. All legs have failing-first tests, each ablated red.
- **A3 tripwire**: an Electron host with no installed utility-fork port now warns loudly (`canForkDaemonThroughUtilityProcess`) — a dropped bootstrap install line was previously silent, with only the wiring pin as a tripwire. Plain-node `orca serve` stays quiet by design.
- **Shim orphan hardening**: the shim now kills a pid-less child before reporting `spawn-error` and exiting — previously that child was an orphan no parent could ever address.
- **Recorded residual (not fixed, ms-wide)**: a handshake timeout that fires after the shim spawned the daemon but before the `spawned` relay is consumed kills the shim without the parent ever learning the daemon pid — that daemon is orphaned (app stays up; terminals degrade). Window is milliseconds-wide; a fix needs a pid side-channel or shim-side kill-on-release-timeout and is deliberately deferred.
- **Recorded nit (not fixed)**: `terminateLaunchedDaemonChild` reports "Daemon did not exit after SIGKILL" for a utility-forked child whose relay is dead even when the SIGKILL worked, because no `exit` event source remains; an ESRCH probe after SIGKILL would fix the message. Cosmetic — the kill itself is effective.

