### PR TITLE
fix(workspaces): preserve terminals during transient mount loss

### DIFF
--- a/src/main/ipc/repos/folder-workspace-path-status-schema.test.ts
+++ b/src/main/ipc/repos/folder-workspace-path-status-schema.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { FolderWorkspacePathStatusArgs } from './repo-ipc-arg-schemas'
+
+describe('folder workspace path status IPC schema', () => {
+  it('normalizes repo execution host ids', () => {
+    expect(
+      FolderWorkspacePathStatusArgs.parse({
+        scope: 'repo',
+        repoId: 'repo-1',
+        executionHostId: ' local '
+      })
+    ).toEqual({ scope: 'repo', repoId: 'repo-1', executionHostId: 'local' })
+  })
+})

--- a/src/main/ipc/repos/repo-ipc-arg-schemas.ts
+++ b/src/main/ipc/repos/repo-ipc-arg-schemas.ts
@@ -181,6 +181,14 @@ export const FolderWorkspacePathStatusArgs = z.discriminatedUnion('scope', [
     scope: z.literal('path'),
     path: z.string().min(1),
     connectionId: z.string().min(1).nullable().optional()
+  }),
+  z.object({
+    scope: z.literal('repo'),
+    repoId: z.string().min(1),
+    executionHostId: z
+      .string()
+      .min(1)
+      .refine((value) => normalizeExecutionHostId(value) !== null)
   })
 ])
 

--- a/src/main/ipc/repos/repo-ipc-arg-schemas.ts
+++ b/src/main/ipc/repos/repo-ipc-arg-schemas.ts
@@ -188,7 +188,14 @@ export const FolderWorkspacePathStatusArgs = z.discriminatedUnion('scope', [
     executionHostId: z
       .string()
       .min(1)
-      .refine((value) => normalizeExecutionHostId(value) !== null)
+      .transform((value, ctx) => {
+        const executionHostId = normalizeExecutionHostId(value)
+        if (!executionHostId) {
+          ctx.addIssue({ code: 'custom', message: 'Invalid execution host ID' })
+          return z.NEVER
+        }
+        return executionHostId
+      })
   })
 ])
 

--- a/src/main/ipc/worktrees/listing/detected-worktree-scan-cache.ts
+++ b/src/main/ipc/worktrees/listing/detected-worktree-scan-cache.ts
@@ -4,6 +4,7 @@ import type { Repo } from '../../../../shared/repo-types'
 import { getLocalProjectWorktreeGitOptions } from '../../../project-runtime-git-options'
 import { isFolderRepo } from '../../../../shared/repo-kind'
 import { listRepoWorktrees } from '../../../repo-worktrees'
+import { listWorktreesStrict } from '../../../git/worktree'
 import { registerWorktreeRootsForRepo } from '../../registered-worktree-roots-cache'
 
 // Why: absorb renderer polling bursts while bounding external worktree-change lag to one short refresh window.
@@ -77,6 +78,11 @@ export async function listDetectedGitWorktrees(
     }
   }
 
+  const scanLocalWorktrees = (): Promise<GitWorktreeInfo[]> =>
+    localWorktreeGitOptions.wslDistro
+      ? listWorktreesStrict(repo.path, localWorktreeGitOptions)
+      : listWorktreesStrict(repo.path)
+
   const cacheKey = getDetectedWorktreeScanCacheKey(repo.id, localWorktreeGitOptions)
   const cached = detectedWorktreeScanCache.get(cacheKey)
   if (cached && cached.expiresAt > Date.now()) {
@@ -90,7 +96,9 @@ export async function listDetectedGitWorktrees(
 
   const scan: DetectedWorktreeScan = {
     invalidated: false,
-    promise: listRepoWorktrees(repo, localWorktreeGitOptions)
+    // Why: deletion is destructive downstream; a transient mount failure must stay
+    // non-authoritative instead of becoming a successful empty worktree list.
+    promise: scanLocalWorktrees()
   }
   detectedWorktreeScanInFlight.set(cacheKey, scan)
   try {

--- a/src/main/ipc/worktrees/listing/detected-worktree-scan-transient-path-loss.test.ts
+++ b/src/main/ipc/worktrees/listing/detected-worktree-scan-transient-path-loss.test.ts
@@ -1,0 +1,35 @@
+import { randomUUID } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Store } from '../../../persistence/loading-store/store'
+import {
+  __resetDetectedWorktreeScanCacheForTests,
+  listDetectedGitWorktrees
+} from './detected-worktree-scan-cache'
+
+function createStore(): Store {
+  return {
+    getProjects: () => [],
+    getSettings: () => ({})
+  } as unknown as Store
+}
+
+describe('detected worktree scan during transient path loss', () => {
+  beforeEach(() => {
+    __resetDetectedWorktreeScanCacheForTests()
+  })
+
+  it('keeps an unreachable local repo scan non-authoritative', async () => {
+    const repo: Repo = {
+      id: 'repo-1',
+      path: join(tmpdir(), `orca-unreachable-repo-${randomUUID()}`),
+      displayName: 'Repo',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+
+    await expect(listDetectedGitWorktrees(createStore(), repo)).rejects.toThrow()
+  })
+})

--- a/src/main/local-project-runtime-resolution.ts
+++ b/src/main/local-project-runtime-resolution.ts
@@ -14,7 +14,12 @@ import {
 import { getRepoIdFromWorktreeId } from '../shared/worktree/id'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../shared/execution-host'
 
-function canResolveProjectRuntimeForRepo(store: Store): boolean {
+export type LocalProjectRuntimeStore = Partial<Pick<Store, 'getProjects' | 'getSettings'>>
+type ReadyLocalProjectRuntimeStore = Pick<Store, 'getProjects' | 'getSettings'>
+
+function canResolveProjectRuntimeForRepo(
+  store: LocalProjectRuntimeStore
+): store is ReadyLocalProjectRuntimeStore {
   return typeof store.getProjects === 'function' && typeof store.getSettings === 'function'
 }
 
@@ -23,9 +28,9 @@ function canResolveProjectRuntimeForWorktreeId(store: Store): boolean {
 }
 
 function resolveLocalProjectRuntime(
-  store: Store,
+  store: ReadyLocalProjectRuntimeStore,
   project: Project,
-  settings: ReturnType<Store['getSettings']> = store.getSettings()
+  settings: ReturnType<ReadyLocalProjectRuntimeStore['getSettings']> = store.getSettings()
 ): ProjectExecutionRuntimeResolution {
   const wslAvailable = hasCachedWslAvailability()
     ? (getCachedWslAvailability() ?? undefined)
@@ -42,7 +47,7 @@ function resolveLocalProjectRuntime(
 }
 
 export function resolveLocalProjectRuntimeForRepo(
-  store: Store,
+  store: LocalProjectRuntimeStore,
   repo: Repo
 ): ProjectExecutionRuntimeResolution | undefined {
   if (
@@ -59,7 +64,7 @@ export function resolveLocalProjectRuntimeForRepo(
 }
 
 export function resolveLocalProjectRuntimesForRepos(
-  store: Store,
+  store: LocalProjectRuntimeStore,
   repos: readonly Repo[]
 ): ReadonlyMap<string, ProjectExecutionRuntimeResolution> {
   const runtimeByRepoId = new Map<string, ProjectExecutionRuntimeResolution>()

--- a/src/main/project-groups/folder-workspace-path-status.ts
+++ b/src/main/project-groups/folder-workspace-path-status.ts
@@ -18,6 +18,8 @@ type FolderWorkspacePathStatusStore = {
   getRepos: () => Repo[]
   getProjectGroups?: () => ProjectGroup[]
   getFolderWorkspaces?: () => FolderWorkspace[]
+  getProjects?: Store['getProjects']
+  getSettings?: Store['getSettings']
 }
 
 export type FolderWorkspacePathConnectionResolution =
@@ -161,7 +163,7 @@ async function statRepoPath(
   }
   let wslDistro: string | undefined
   try {
-    wslDistro = getLocalProjectWorktreeGitOptions(store as Store, repo).wslDistro
+    wslDistro = getLocalProjectWorktreeGitOptions(store, repo).wslDistro
   } catch {
     return { path: repo.path, exists: false, reason: 'unavailable' }
   }

--- a/src/main/project-groups/folder-workspace-path-status.ts
+++ b/src/main/project-groups/folder-workspace-path-status.ts
@@ -9,6 +9,10 @@ import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../shared/project-group-types'
 import type { Repo } from '../../shared/repo-types'
 import type { IFilesystemProvider } from '../providers/types'
+import type { Store } from '../persistence'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
+import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
+import { getLocalWorktreePathAccess } from '../local-worktree-filesystem'
 
 type FolderWorkspacePathStatusStore = {
   getRepos: () => Repo[]
@@ -137,6 +141,44 @@ async function statFolderPath(
   }
 }
 
+async function statRepoPath(
+  store: FolderWorkspacePathStatusStore,
+  request: Extract<FolderWorkspacePathStatusRequest, { scope: 'repo' }>,
+  deps: FolderWorkspacePathStatusDeps
+): Promise<FolderWorkspacePathStatus> {
+  const repo = store
+    .getRepos()
+    .find(
+      (candidate) =>
+        candidate.id === request.repoId &&
+        getRepoExecutionHostId(candidate) === request.executionHostId
+    )
+  if (!repo) {
+    throw new Error('folder_workspace_path_scope_not_found')
+  }
+  if (repo.connectionId) {
+    return statFolderPath(repo.path, { kind: 'ssh', connectionId: repo.connectionId }, deps)
+  }
+  let wslDistro: string | undefined
+  try {
+    wslDistro = getLocalProjectWorktreeGitOptions(store as Store, repo).wslDistro
+  } catch {
+    return { path: repo.path, exists: false, reason: 'unavailable' }
+  }
+  if (!wslDistro) {
+    return statFolderPath(repo.path, { kind: 'local' }, deps)
+  }
+  try {
+    const stats = await getLocalWorktreePathAccess({ wslDistro }).statPath(repo.path)
+    const type = (stats as { type?: unknown } | null)?.type
+    return type === 'directory'
+      ? { path: repo.path, exists: true }
+      : { path: repo.path, exists: false, reason: 'not-directory' }
+  } catch (error) {
+    return { path: repo.path, exists: false, reason: pathStatErrorReason(error) }
+  }
+}
+
 export async function getFolderWorkspacePathStatusForPath(
   args: {
     folderPath: string
@@ -153,7 +195,7 @@ export async function getFolderWorkspacePathStatusForPath(
 
 export function resolveFolderWorkspaceStatusPath(args: {
   store: FolderWorkspacePathStatusStore
-  request: FolderWorkspacePathStatusRequest
+  request: Exclude<FolderWorkspacePathStatusRequest, { scope: 'repo' }>
 }): { folderPath: string; projectGroupId: string | null; connectionId?: string | null } {
   const { request } = args
   if (request.scope === 'project-group') {
@@ -199,6 +241,9 @@ export async function getFolderWorkspacePathStatus(
   request: FolderWorkspacePathStatusRequest,
   deps: FolderWorkspacePathStatusDeps
 ): Promise<FolderWorkspacePathStatus> {
+  if (request.scope === 'repo') {
+    return statRepoPath(store, request, deps)
+  }
   const scope = resolveFolderWorkspaceStatusPath({ store, request })
   return getFolderWorkspacePathStatusForPath(
     {

--- a/src/main/project-groups/repo-path-status-wsl-routing.test.ts
+++ b/src/main/project-groups/repo-path-status-wsl-routing.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import type { Repo } from '../../shared/repo-types'
+
+const { getLocalProjectWorktreeGitOptionsMock, getLocalWorktreePathAccessMock, statPathMock } =
+  vi.hoisted(() => ({
+    getLocalProjectWorktreeGitOptionsMock: vi.fn(() => ({ wslDistro: 'Ubuntu' })),
+    getLocalWorktreePathAccessMock: vi.fn(() => ({ statPath: statPathMock })),
+    statPathMock: vi.fn(async () => ({ type: 'directory' }))
+  }))
+
+vi.mock('../project-runtime-git-options', () => ({
+  getLocalProjectWorktreeGitOptions: getLocalProjectWorktreeGitOptionsMock
+}))
+
+vi.mock('../local-worktree-filesystem', () => ({
+  getLocalWorktreePathAccess: getLocalWorktreePathAccessMock
+}))
+
+import { getFolderWorkspacePathStatus } from './folder-workspace-path-status'
+
+describe('repo path status WSL routing', () => {
+  it('stats a local WSL repo through its selected distro', async () => {
+    const repo: Repo = {
+      id: 'repo-wsl',
+      path: '/home/me/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 1,
+      executionHostId: 'local'
+    }
+    const store = {
+      getRepos: () => [repo],
+      getProjects: () => [],
+      getSettings: () => ({})
+    } as unknown as Store
+
+    await expect(
+      getFolderWorkspacePathStatus(
+        store,
+        { scope: 'repo', repoId: repo.id, executionHostId: 'local' } as never,
+        { getSshFilesystemProvider: () => undefined }
+      )
+    ).resolves.toEqual({ path: repo.path, exists: true })
+    expect(getLocalProjectWorktreeGitOptionsMock).toHaveBeenCalledWith(store, repo)
+    expect(getLocalWorktreePathAccessMock).toHaveBeenCalledWith({ wslDistro: 'Ubuntu' })
+    expect(statPathMock).toHaveBeenCalledWith(repo.path)
+  })
+})

--- a/src/main/project-runtime-git-options.ts
+++ b/src/main/project-runtime-git-options.ts
@@ -1,6 +1,8 @@
-import type { Store } from './persistence'
 import type { Repo } from '../shared/repo-types'
-import { resolveLocalProjectRuntimeForRepo } from './local-project-runtime-resolution'
+import {
+  resolveLocalProjectRuntimeForRepo,
+  type LocalProjectRuntimeStore
+} from './local-project-runtime-resolution'
 import type { ProjectExecutionRuntimeResolution } from '../shared/project-execution-runtime'
 
 export {
@@ -18,7 +20,7 @@ export type LocalProjectWorktreeGitOptions = {
 }
 
 export function getLocalProjectGitExecOptions(
-  store: Store,
+  store: LocalProjectRuntimeStore,
   repo: Repo
 ): LocalProjectGitExecOptions {
   // Why: local git must run in the same resolved project runtime as agents,
@@ -48,7 +50,7 @@ function getLocalProjectGitExecOptionsForRuntime(
 }
 
 export function getLocalProjectWorktreeGitOptions(
-  store: Store,
+  store: LocalProjectRuntimeStore,
   repo: Repo
 ): LocalProjectWorktreeGitOptions {
   const { wslDistro } = getLocalProjectGitExecOptions(store, repo)

--- a/src/main/runtime/missing-worktree-terminal-reconciliation.test.ts
+++ b/src/main/runtime/missing-worktree-terminal-reconciliation.test.ts
@@ -48,7 +48,10 @@ describe('stopMissingWorktreeTerminals', () => {
       }
     )
 
-    expect(result).toEqual({ stoppedWorktreeIds: [deletedId] })
+    expect(result).toEqual({
+      stoppedWorktreeIds: [deletedId],
+      verifiedStoppedWorktreeIds: [deletedId]
+    })
     expect(provider.shutdown).toHaveBeenCalledWith(
       `${deletedId}@@deleted-session`,
       expect.objectContaining({ immediate: true })
@@ -103,7 +106,10 @@ describe('stopMissingWorktreeTerminals', () => {
       }
     )
 
-    expect(result).toEqual({ stoppedWorktreeIds: [deletedId] })
+    expect(result).toEqual({
+      stoppedWorktreeIds: [deletedId],
+      verifiedStoppedWorktreeIds: []
+    })
     // The graph fallback still names the owning connection: this repo's inventory must not
     // stop a same-id workspace's terminals on another host.
     expect(runtime.stopTerminalsForWorktree).toHaveBeenCalledWith(deletedId, {
@@ -220,5 +226,25 @@ describe('stopMissingWorktreeTerminals', () => {
       `${ids[1]}@@session`,
       expect.objectContaining({ immediate: true })
     )
+  })
+
+  it('does not report a worktree stopped while its terminal is still live', async () => {
+    const worktreeId = 'repo-1::/workspace/live'
+    const session = { id: `${worktreeId}@@codex`, cwd: '/workspace/live', title: 'codex' }
+    const provider = {
+      listProcesses: vi.fn(async () => [session]),
+      shutdown: vi.fn(async () => {
+        throw new Error('kill failed')
+      })
+    } as unknown as IPtyProvider
+
+    const result = await stopMissingWorktreeTerminals(localRepo, [worktreeId], [], {
+      runtime: createRuntime(),
+      getLocalProvider: () => provider,
+      getSshProvider: () => undefined
+    })
+
+    expect(result).toEqual({ stoppedWorktreeIds: [], verifiedStoppedWorktreeIds: [] })
+    expect(provider.listProcesses).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/runtime/missing-worktree-terminal-reconciliation.ts
+++ b/src/main/runtime/missing-worktree-terminal-reconciliation.ts
@@ -4,6 +4,7 @@ import { splitWorktreeId } from '../../shared/worktree/id'
 import { mapWithConcurrency } from '../../shared/map-with-concurrency'
 import type { OrcaRuntimeService } from './orca-runtime'
 import { killAllProcessesForWorktree } from './worktree-teardown'
+import type { MissingWorktreeTerminalTeardownResult } from '../../shared/worktree/missing-terminal-teardown'
 
 const MISSING_WORKTREE_TEARDOWN_CONCURRENCY = 4
 
@@ -12,9 +13,7 @@ const MISSING_WORKTREE_TEARDOWN_CONCURRENCY = 4
 // deletes N workspaces costs N full host enumerations — O(N) relay round-trips
 // carrying O(N^2) rows, which is minutes of stalled teardown on a remote host.
 //
-// Safe only because this sweep is best-effort. Do NOT reuse this wrapper on a
-// `requirePhysicalStop` path: that re-lists *after* shutdown to prove a PTY
-// exited, and a pre-shutdown snapshot would make the proof read stale rows.
+// A physical-stop caller must verify against the uncached provider, never this snapshot.
 function withSharedProcessSnapshot(provider: IPtyProvider): IPtyProvider {
   let snapshot: Promise<Awaited<ReturnType<IPtyProvider['listProcesses']>>> | null = null
   return new Proxy(provider, {
@@ -70,7 +69,7 @@ export async function stopMissingWorktreeTerminals(
   knownWorktreeIds: readonly string[],
   detectedWorktreeIds: readonly string[],
   deps: MissingWorktreeTerminalReconciliationDeps
-): Promise<{ stoppedWorktreeIds: string[] }> {
+): Promise<Required<MissingWorktreeTerminalTeardownResult>> {
   const detectedIds = new Set(detectedWorktreeIds)
   const missingIds = [
     ...new Set(
@@ -81,7 +80,7 @@ export async function stopMissingWorktreeTerminals(
     )
   ]
   if (missingIds.length === 0) {
-    return { stoppedWorktreeIds: [] }
+    return { stoppedWorktreeIds: [], verifiedStoppedWorktreeIds: [] }
   }
 
   const ownedProvider = repo.connectionId
@@ -103,7 +102,7 @@ export async function stopMissingWorktreeTerminals(
         }
       )
     ).filter((worktreeId): worktreeId is string => worktreeId !== null)
-    return { stoppedWorktreeIds }
+    return { stoppedWorktreeIds, verifiedStoppedWorktreeIds: [] }
   }
 
   const stoppedWorktreeIds = (
@@ -116,10 +115,9 @@ export async function stopMissingWorktreeTerminals(
             runtime: deps.runtime,
             ...hostFence(repo, worktreeId),
             localProvider: provider,
+            verificationProvider: ownedProvider ?? undefined,
             onPtyStopped: deps.onPtyStopped,
-            // Why: the shared process snapshot is only valid while nothing needs a
-            // post-shutdown re-list, so this sweep stays explicitly best-effort.
-            requirePhysicalStop: false,
+            requirePhysicalStop: true,
             ...(repo.connectionId ? { includeLocalRegistry: false } : {})
           })
           return worktreeId
@@ -131,5 +129,5 @@ export async function stopMissingWorktreeTerminals(
     )
   ).filter((worktreeId): worktreeId is string => worktreeId !== null)
 
-  return { stoppedWorktreeIds }
+  return { stoppedWorktreeIds, verifiedStoppedWorktreeIds: stoppedWorktreeIds }
 }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -42607,7 +42607,10 @@ describe('OrcaRuntimeService', () => {
       survivingId
     ])
 
-    expect(result).toEqual({ stoppedWorktreeIds: [deletedId] })
+    expect(result).toEqual({
+      stoppedWorktreeIds: [deletedId],
+      verifiedStoppedWorktreeIds: [deletedId]
+    })
     expect(localProvider.shutdown).toHaveBeenCalledWith(
       `${deletedId}@@deleted-session`,
       expect.objectContaining({ immediate: true })
@@ -42646,7 +42649,10 @@ describe('OrcaRuntimeService', () => {
       deletedId
     ])
 
-    expect(result).toEqual({ stoppedWorktreeIds: [deletedId] })
+    expect(result).toEqual({
+      stoppedWorktreeIds: [deletedId],
+      verifiedStoppedWorktreeIds: [deletedId]
+    })
     expect(localProvider.shutdown).toHaveBeenCalledWith(
       `${deletedId}@@deleted-session`,
       expect.objectContaining({ immediate: true })
@@ -42712,7 +42718,10 @@ describe('OrcaRuntimeService', () => {
       null
     )
 
-    expect(result).toEqual({ stoppedWorktreeIds: [deletedId] })
+    expect(result).toEqual({
+      stoppedWorktreeIds: [deletedId],
+      verifiedStoppedWorktreeIds: [deletedId]
+    })
     expect(localProvider.shutdown).toHaveBeenCalledWith(
       `${deletedId}@@deleted-session`,
       expect.objectContaining({ immediate: true })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1225,6 +1225,7 @@ import {
 } from './terminal-view-attribute-store'
 import { killAllProcessesForWorktree, teardownRpcDeadline } from './worktree-teardown'
 import { stopMissingWorktreeTerminals } from './missing-worktree-terminal-reconciliation'
+import type { MissingWorktreeTerminalTeardownResult } from '../../shared/worktree/missing-terminal-teardown'
 import {
   MobileNotificationReplayBuffer,
   type ReplayableMobileNotification
@@ -24353,7 +24354,7 @@ export class OrcaRuntimeService {
     repoSelector: string,
     knownWorktreeIds: readonly string[],
     connectionId?: string | null
-  ): Promise<{ stoppedWorktreeIds: string[] }> {
+  ): Promise<Required<MissingWorktreeTerminalTeardownResult>> {
     const repo = await this.resolveRepoSelectorForConnection(repoSelector, connectionId)
     // Why: killing PTYs must be proven against the host right now — a cached scan
     // (30s TTL) can still list a directory git already dropped, and the renderer
@@ -24364,7 +24365,7 @@ export class OrcaRuntimeService {
     // even though the caller's selector was unique — losing the sweep entirely.
     const detected = await this.listDetectedWorktreesForResolvedRepo(repo)
     if (!detected.authoritative) {
-      return { stoppedWorktreeIds: [] }
+      return { stoppedWorktreeIds: [], verifiedStoppedWorktreeIds: [] }
     }
     return stopMissingWorktreeTerminals(
       repo,

--- a/src/main/runtime/rpc/methods/folder-workspace.ts
+++ b/src/main/runtime/rpc/methods/folder-workspace.ts
@@ -7,7 +7,7 @@ import { WorkspaceLinkedItemSchema } from '../../../../shared/workspace-linked-i
 import { isWorkspaceLinkedItemSourceContextMatch } from '../../../../shared/workspace-linked-item-source-context'
 import { resolveRpcWorkspaceCreatorProvenance } from '../workspace-creator-context'
 import { DiffCommentSchema } from '../../../../shared/diff-comment-schema'
-import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import { normalizeExecutionHostId } from '../../../../shared/execution-host'
 
 const FolderWorkspaceLinkedTask = WorkspaceLinkedItemSchema.nullable()
 
@@ -71,10 +71,17 @@ const FolderWorkspaceSelector = z.object({
   folderWorkspaceId: requiredString('Missing folder workspace id')
 })
 
-const ExecutionHostIdSchema = z.custom<ExecutionHostId>(
-  (value) => typeof value === 'string' && parseExecutionHostId(value) !== null,
-  'Invalid execution host id'
-)
+const ExecutionHostIdSchema = z
+  .string()
+  .min(1)
+  .transform((value, ctx) => {
+    const executionHostId = normalizeExecutionHostId(value)
+    if (!executionHostId) {
+      ctx.addIssue({ code: 'custom', message: 'Invalid execution host ID' })
+      return z.NEVER
+    }
+    return executionHostId
+  })
 
 const FolderWorkspacePathStatus = z.discriminatedUnion('scope', [
   z.object({

--- a/src/main/runtime/rpc/methods/folder-workspace.ts
+++ b/src/main/runtime/rpc/methods/folder-workspace.ts
@@ -7,6 +7,7 @@ import { WorkspaceLinkedItemSchema } from '../../../../shared/workspace-linked-i
 import { isWorkspaceLinkedItemSourceContextMatch } from '../../../../shared/workspace-linked-item-source-context'
 import { resolveRpcWorkspaceCreatorProvenance } from '../workspace-creator-context'
 import { DiffCommentSchema } from '../../../../shared/diff-comment-schema'
+import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
 
 const FolderWorkspaceLinkedTask = WorkspaceLinkedItemSchema.nullable()
 
@@ -70,6 +71,11 @@ const FolderWorkspaceSelector = z.object({
   folderWorkspaceId: requiredString('Missing folder workspace id')
 })
 
+const ExecutionHostIdSchema = z.custom<ExecutionHostId>(
+  (value) => typeof value === 'string' && parseExecutionHostId(value) !== null,
+  'Invalid execution host id'
+)
+
 const FolderWorkspacePathStatus = z.discriminatedUnion('scope', [
   z.object({
     scope: z.literal('folder-workspace'),
@@ -83,6 +89,11 @@ const FolderWorkspacePathStatus = z.discriminatedUnion('scope', [
     scope: z.literal('path'),
     path: requiredString('Missing folder path'),
     connectionId: OptionalString.nullable().optional()
+  }),
+  z.object({
+    scope: z.literal('repo'),
+    repoId: requiredString('Missing repo id'),
+    executionHostId: ExecutionHostIdSchema
   })
 ])
 

--- a/src/main/runtime/rpc/methods/repo.test.ts
+++ b/src/main/runtime/rpc/methods/repo.test.ts
@@ -564,6 +564,13 @@ describe('repo RPC methods', () => {
         path: '/srv/platform'
       })
     )
+    const repoPathStatusResponse = await dispatcher.dispatch(
+      makeRequest('folderWorkspace.getPathStatus', {
+        scope: 'repo',
+        repoId: 'repo-1',
+        executionHostId: ' local '
+      })
+    )
 
     expect(runtime.listProjectGroups).toHaveBeenCalled()
     expect(runtime.createProjectGroup).toHaveBeenCalledWith({
@@ -595,6 +602,11 @@ describe('repo RPC methods', () => {
       scope: 'path',
       path: '/srv/platform'
     })
+    expect(runtime.getFolderWorkspacePathStatus).toHaveBeenCalledWith({
+      scope: 'repo',
+      repoId: 'repo-1',
+      executionHostId: 'local'
+    })
     expect(moveResponse).toMatchObject({
       ok: true,
       result: { repo: { id: 'repo-1', projectGroupId: group.id } }
@@ -610,6 +622,10 @@ describe('repo RPC methods', () => {
       result: { status: { path: '/srv/platform', exists: true } }
     })
     expect(directPathStatusResponse).toMatchObject({
+      ok: true,
+      result: { status: { path: '/srv/platform', exists: true } }
+    })
+    expect(repoPathStatusResponse).toMatchObject({
       ok: true,
       result: { status: { path: '/srv/platform', exists: true } }
     })

--- a/src/main/runtime/rpc/methods/worktree-missing-terminal-teardown.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-missing-terminal-teardown.test.ts
@@ -7,9 +7,10 @@ describe('worktree missing-terminal teardown RPC', () => {
   it('routes the connection-scoped request through the runtime owner', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
-      teardownMissingManagedWorktreeTerminals: vi
-        .fn()
-        .mockResolvedValue({ stoppedWorktreeIds: ['repo-1::/workspace/deleted'] })
+      teardownMissingManagedWorktreeTerminals: vi.fn().mockResolvedValue({
+        stoppedWorktreeIds: ['repo-1::/workspace/deleted'],
+        verifiedStoppedWorktreeIds: ['repo-1::/workspace/deleted']
+      })
     } as unknown as OrcaRuntimeService
     const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
 

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -31,6 +31,8 @@ export type WorktreeTeardownDeps = {
   /** Runtime environment owning a mirrored `resolvedWorktreeId`. */
   resolvedRuntimeEnvironmentId?: string
   localProvider: IPtyProvider
+  /** Uncached owning-host provider used to verify failed stop attempts. */
+  verificationProvider?: IPtyProvider
   onPtyStopped?: (ptyId: string) => void
   timeoutMs?: number
   requirePhysicalStop?: boolean
@@ -232,7 +234,7 @@ export async function killAllProcessesForWorktree(
     const failedPtyIds = stopResults.filter(([, stopped]) => !stopped).map(([ptyId]) => ptyId)
     const verdict = await resolveUnstoppedPtyVerdict(
       failedPtyIds,
-      deps.localProvider,
+      deps.verificationProvider ?? deps.localProvider,
       sweepBudgetMs,
       deps.includeProviderInventory !== false ||
         (deps.resolvedConnectionId === undefined &&

--- a/src/renderer/src/components/sidebar/WorktreeList.group-headers.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.group-headers.test.ts
@@ -145,6 +145,36 @@ describe('WorktreeList lineage child card renderer', () => {
     expect(markup).toContain('-rotate-90')
   })
 
+  it('marks local folder repo cards when their folder is missing', async () => {
+    setLineageFixtureState('repo')
+    const repos = (mockStore.state.repos as Repo[]).map((repo) => ({
+      ...repo,
+      kind: 'folder' as const
+    }))
+    mockStore.state = {
+      ...mockStore.state,
+      repos,
+      detectedWorktreesByRepo: {
+        'repo-1': {
+          repoId: 'repo-1',
+          authoritative: false,
+          source: 'metadata-fallback',
+          worktrees: []
+        }
+      },
+      getFreshFolderWorkspacePathStatus: vi.fn(
+        (request: { scope?: string; executionHostId?: string }) =>
+          request.scope === 'repo' && request.executionHostId === 'local'
+            ? { path: '/tmp/lineage-order', exists: false, reason: 'missing' }
+            : null
+      )
+    }
+
+    const markup = await renderWorktreeListMarkup()
+
+    expect(markup).toContain('aria-label="Folder not found"')
+  })
+
   it('does not render the project collapse affordance on flat section headers', async () => {
     setLineageFixtureState('none')
     const markup = await renderWorktreeListMarkup()

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-folder-path-statuses.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-folder-path-statuses.ts
@@ -6,25 +6,34 @@ import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { Repo } from '../../../../../../shared/repo-types'
 import type { AppState } from '@/store/types'
-import { getFolderPathStatusRouteOptionsForRows } from './host-filtering'
+import {
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID
+} from '../../../../../../shared/execution-host'
+import {
+  getFolderPathStatusRouteOptionsForRows,
+  getRuntimeEnvironmentIdForFolderPathStatusHost
+} from './host-filtering'
 
 type FolderPathStatusRequest = Parameters<AppState['fetchFolderWorkspacePathStatus']>[0]
+type RepoPathStatusRequest = Extract<FolderPathStatusRequest, { scope: 'repo' }>
 
 // Keeps the sidebar's folder-path probes fresh for every project group and folder workspace
 // it renders, and hands rows a cache reader that ignores expired negative results.
 export function useFolderWorkspacePathStatusRows(args: {
-  allRepoIds: string[]
+  repoIds: string[]
   repoMap: Map<string, Repo>
   projectGroups: readonly ProjectGroup[]
   folderWorkspaces: readonly FolderWorkspace[]
   sshConnectionStates: AppState['sshConnectionStates']
 }) {
-  const { allRepoIds, repoMap, projectGroups, folderWorkspaces, sshConnectionStates } = args
+  const { repoIds, repoMap, projectGroups, folderWorkspaces, sshConnectionStates } = args
   const {
     folderWorkspacePathStatuses,
     fetchFolderWorkspacePathStatus,
     getFolderWorkspacePathStatusCacheKey,
     getFreshFolderWorkspacePathStatus,
+    repos,
     activeRuntimeEnvironmentId
   } = useAppStore(
     useShallow((s) => ({
@@ -32,18 +41,34 @@ export function useFolderWorkspacePathStatusRows(args: {
       fetchFolderWorkspacePathStatus: s.fetchFolderWorkspacePathStatus,
       getFolderWorkspacePathStatusCacheKey: s.getFolderWorkspacePathStatusCacheKey,
       getFreshFolderWorkspacePathStatus: s.getFreshFolderWorkspacePathStatus,
+      repos: s.repos,
       activeRuntimeEnvironmentId: s.settings?.activeRuntimeEnvironmentId ?? null
     }))
   )
+  const localRepoPathStatusRequests = useMemo(() => {
+    const visibleRepoIds = new Set(repoIds)
+    const requests = new Map<string, RepoPathStatusRequest>()
+    for (const repo of repos) {
+      const executionHostId = getRepoExecutionHostId(repo)
+      if (visibleRepoIds.has(repo.id) && executionHostId === LOCAL_EXECUTION_HOST_ID) {
+        requests.set(`${executionHostId}\0${repo.id}`, {
+          scope: 'repo',
+          repoId: repo.id,
+          executionHostId
+        })
+      }
+    }
+    return [...requests.values()]
+  }, [repoIds, repos])
   const folderPathStatusRepoMembershipKey = useMemo(
     () =>
-      allRepoIds
+      repoIds
         .map((repoId) => {
           const repo = repoMap.get(repoId)
           return `${repoId}:${repo?.path ?? ''}:${repo?.projectGroupId ?? ''}:${repo?.connectionId ?? ''}`
         })
         .join('\0'),
-    [allRepoIds, repoMap]
+    [repoIds, repoMap]
   )
   const folderPathStatusSshConnectionKey = useMemo(
     () =>
@@ -56,6 +81,24 @@ export function useFolderWorkspacePathStatusRows(args: {
   const folderPathStatusCacheExpiryTick = useFolderWorkspacePathStatusCacheExpiryTick(
     folderWorkspacePathStatuses
   )
+  const localRepoPathStatusEntries = useMemo(() => {
+    const entries: typeof folderWorkspacePathStatuses = {}
+    for (const request of localRepoPathStatusRequests) {
+      const key = getFolderWorkspacePathStatusCacheKey(request, { runtimeEnvironmentId: null })
+      const entry = folderWorkspacePathStatuses[key]
+      if (entry) {
+        entries[key] = entry
+      }
+    }
+    return entries
+  }, [
+    folderWorkspacePathStatuses,
+    getFolderWorkspacePathStatusCacheKey,
+    localRepoPathStatusRequests
+  ])
+  const localRepoPathStatusCacheExpiryTick = useFolderWorkspacePathStatusCacheExpiryTick(
+    localRepoPathStatusEntries
+  )
   const projectGroupByIdForFolderPathStatus = useMemo(
     () => new Map(projectGroups.map((group) => [group.id, group])),
     [projectGroups]
@@ -65,12 +108,23 @@ export function useFolderWorkspacePathStatusRows(args: {
     [folderWorkspaces]
   )
   const getFolderPathStatusRouteOptions = useCallback(
-    (request: FolderPathStatusRequest) =>
-      getFolderPathStatusRouteOptionsForRows({
+    (request: FolderPathStatusRequest) => {
+      if (request.scope === 'path') {
+        return { runtimeEnvironmentId: null }
+      }
+      if (request.scope === 'repo') {
+        return {
+          runtimeEnvironmentId: getRuntimeEnvironmentIdForFolderPathStatusHost(
+            request.executionHostId
+          )
+        }
+      }
+      return getFolderPathStatusRouteOptionsForRows({
         request,
         projectGroupsById: projectGroupByIdForFolderPathStatus,
         folderWorkspacesById: folderWorkspaceByIdForFolderPathStatus
-      }),
+      })
+    },
     [folderWorkspaceByIdForFolderPathStatus, projectGroupByIdForFolderPathStatus]
   )
   useEffect(() => {
@@ -105,6 +159,15 @@ export function useFolderWorkspacePathStatusRows(args: {
     getFolderPathStatusRouteOptions,
     getFolderWorkspacePathStatusCacheKey,
     projectGroups
+  ])
+  useEffect(() => {
+    for (const request of localRepoPathStatusRequests) {
+      void fetchFolderWorkspacePathStatus(request, { force: true, runtimeEnvironmentId: null })
+    }
+  }, [
+    fetchFolderWorkspacePathStatus,
+    localRepoPathStatusCacheExpiryTick,
+    localRepoPathStatusRequests
   ])
   const getCachedFolderWorkspacePathStatus = useCallback(
     (request: FolderPathStatusRequest) => {

--- a/src/renderer/src/components/sidebar/worktree-list/rows/item-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/item-row.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { cn } from '@/lib/utils'
 import type { AppState } from '@/store/types'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import { getRepoExecutionHostId } from '../../../../../../shared/execution-host'
 import type { Worktree } from '../../../../../../shared/worktree/types'
+import type { FolderWorkspacePathStatus } from '../../../../../../shared/folder-workspace-path-status'
 import {
   composeWorktreeHostIdentity,
   getWorktreeHostIdentity
@@ -24,6 +26,7 @@ import { stopNestedWorktreeCardBubble } from './header-event-guards'
 import type { WorktreeItemRow } from '../listing/renderable-rows'
 import { getWorktreeOptionId } from './option-dom'
 import type { WorktreePointerDrag, WorktreeRowDragState } from '../drag/row-state'
+import { FolderPathStatusIndicator } from './FolderPathStatusIndicator'
 
 export type WorktreeItemRowContext = {
   settings: AppState['settings']
@@ -41,6 +44,11 @@ export type WorktreeItemRowContext = {
   highlightedRevealRowKey: string | null
   selectedWorktreeIds: ReadonlySet<string>
   selectedWorktrees: readonly Worktree[]
+  getCachedRepoPathStatus: (request: {
+    scope: 'repo'
+    repoId: string
+    executionHostId: ExecutionHostId
+  }) => FolderWorkspacePathStatus | null
   getActiveSurfaceVariant: (row: WorktreeItemRow) => ActiveSurfaceVariant
   getLineageToggleHandler: (groupKey: string) => LineageToggleHandler
   onSelectionGesture: (event: React.MouseEvent<HTMLElement>, worktree: Worktree) => boolean
@@ -147,6 +155,13 @@ export function renderWorktreeItemRow(
     (!ctx.activeWorkspaceExecutionHostId ||
       worktreeIdentity ===
         composeWorktreeHostIdentity(ctx.activeWorkspaceExecutionHostId, itemRow.worktree.id))
+  const repoPathStatus = itemRow.repo
+    ? ctx.getCachedRepoPathStatus({
+        scope: 'repo',
+        repoId: itemRow.repo.id,
+        executionHostId: getRepoExecutionHostId(itemRow.repo)
+      })
+    : null
   return (
     <div
       key={itemRow.rowKey}
@@ -225,6 +240,9 @@ export function renderWorktreeItemRow(
           itemRow.lineageGroupKey ? ctx.getLineageToggleHandler(itemRow.lineageGroupKey) : undefined
         }
       />
+      <div className="pointer-events-auto absolute right-3 top-1.5">
+        <FolderPathStatusIndicator status={repoPathStatus} />
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/VirtualizedWorktreeViewport.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/VirtualizedWorktreeViewport.tsx
@@ -78,6 +78,10 @@ export const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktr
       ),
     [projectGroups]
   )
+  const visibleRepoIdsForPathStatus = useMemo(
+    () => [...new Set(props.worktrees.map((worktree) => worktree.repoId))],
+    [props.worktrees]
+  )
 
   const headerDrag = useWorktreeSidebarHeaderDrag({
     rows,
@@ -117,7 +121,7 @@ export const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktr
   })
 
   const getCachedFolderWorkspacePathStatus = useFolderWorkspacePathStatusRows({
-    allRepoIds: props.allRepoIds,
+    repoIds: visibleRepoIdsForPathStatus,
     repoMap,
     projectGroups,
     folderWorkspaces: props.folderWorkspaces,

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
@@ -125,6 +125,7 @@ export function buildWorktreeVirtualRowContext(args: BuildArgs): WorktreeVirtual
       highlightedRevealRowKey: reveal.highlightedRevealRowKey,
       selectedWorktreeIds: props.selectedWorktreeIds,
       selectedWorktrees: props.selectedWorktrees,
+      getCachedRepoPathStatus: args.getCachedFolderWorkspacePathStatus,
       getActiveSurfaceVariant: primaryActive.getActiveSurfaceVariant,
       getLineageToggleHandler: args.getLineageToggleHandler,
       onSelectionGesture: props.onSelectionGesture,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -807,10 +807,10 @@
           "unrecognized": "Folder is not usable"
         },
         "description": {
-          "missing": "Orca cannot find {{path}}. Remove and re-import this folder workspace.",
+          "missing": "Orca cannot find {{path}}. Restore the folder or update its location.",
           "notDirectory": "{{path}} exists, but it is not a folder.",
           "ambiguousConnection": "Orca cannot tell which SSH connection owns this folder scope.",
-          "unavailable": "Orca cannot verify this folder right now. Check the runtime or SSH connection and try again.",
+          "unavailable": "Orca cannot verify this folder right now. Check the drive or host connection and try again.",
           "unrecognized": "Orca cannot use {{path}}, and this version does not recognize the reason. Update Orca to see the details."
         },
         "createError": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -601,10 +601,10 @@
           "unavailable": "无法检查文件夹"
         },
         "description": {
-          "missing": "Orca 找不到 {{path}}。请移除并重新导入此文件夹工作区。",
+          "missing": "Orca 找不到 {{path}}。请恢复该文件夹或更新其位置。",
           "notDirectory": "{{path}} 存在，但它不是文件夹。",
           "ambiguousConnection": "Orca 无法判断哪个 SSH 连接拥有此文件夹范围。",
-          "unavailable": "Orca 现在无法验证此文件夹。请检查运行时或 SSH 连接，然后重试。"
+          "unavailable": "Orca 现在无法验证此文件夹。请检查磁盘或主机连接，然后重试。"
         },
         "createError": {
           "title": {

--- a/src/renderer/src/lib/folder-workspace-path-status.test.ts
+++ b/src/renderer/src/lib/folder-workspace-path-status.test.ts
@@ -50,10 +50,10 @@ describe('getFolderWorkspacePathStatusTitle', () => {
 describe('getFolderWorkspacePathStatusDescription', () => {
   it('keeps the declared reasons on their own copy', () => {
     expect(getFolderWorkspacePathStatusDescription(wireStatus('missing'))).toBe(
-      'Orca cannot find /srv/scans. Remove and re-import this folder workspace.'
+      'Orca cannot find /srv/scans. Restore the folder or update its location.'
     )
     expect(getFolderWorkspacePathStatusDescription(wireStatus(undefined))).toBe(
-      'Orca cannot verify this folder right now. Check the runtime or SSH connection and try again.'
+      'Orca cannot verify this folder right now. Check the drive or host connection and try again.'
     )
   })
 
@@ -71,7 +71,7 @@ describe('getFolderWorkspacePathStatusDescription', () => {
     expect(typeof description).toBe('string')
     expect(description).not.toBe('')
     expect(description).not.toBe(
-      'Orca cannot find /srv/scans. Remove and re-import this folder workspace.'
+      'Orca cannot find /srv/scans. Restore the folder or update its location.'
     )
   })
 })

--- a/src/renderer/src/lib/folder-workspace-path-status.ts
+++ b/src/renderer/src/lib/folder-workspace-path-status.ts
@@ -73,7 +73,7 @@ export function getFolderWorkspacePathStatusDescription(
     case 'missing':
       return translate(
         'auto.lib.folderWorkspacePathStatus.description.missing',
-        'Orca cannot find {{path}}. Remove and re-import this folder workspace.',
+        'Orca cannot find {{path}}. Restore the folder or update its location.',
         { path: status.path }
       )
     case 'not-directory':
@@ -91,7 +91,7 @@ export function getFolderWorkspacePathStatusDescription(
     case 'unavailable':
       return translate(
         'auto.lib.folderWorkspacePathStatus.description.unavailable',
-        'Orca cannot verify this folder right now. Check the runtime or SSH connection and try again.'
+        'Orca cannot verify this folder right now. Check the drive or host connection and try again.'
       )
   }
 }

--- a/src/renderer/src/store/folder-workspaces/folder-path-status.ts
+++ b/src/renderer/src/store/folder-workspaces/folder-path-status.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../../../shared/folder-workspace-path-status'
 import { getProjectGroupSubtreeIds } from '../../../../shared/project-groups'
 import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 import type { FolderWorkspacePathStatusCacheEntry } from '../repos/repo-state'
 
 export function getFolderWorkspaceStatusRequestSnapshot(
@@ -41,6 +42,28 @@ export function getFolderWorkspaceStatusRequestSnapshot(
     return [request.path, '', request.connectionId ?? '', sshFingerprint, repoFingerprint].join(
       '\0'
     )
+  }
+
+  if (request.scope === 'repo') {
+    const repo = state.repos.find(
+      (candidate) =>
+        candidate.id === request.repoId &&
+        getRepoExecutionHostId(candidate) === request.executionHostId
+    )
+    if (!repo) {
+      return null
+    }
+    const sshFingerprint = repo.connectionId
+      ? `${repo.connectionId}:${state.sshConnectionStates.get(repo.connectionId)?.status ?? 'missing'}`
+      : ''
+    return [
+      repo.path,
+      repo.id,
+      request.executionHostId,
+      repo.projectGroupId ?? '',
+      repo.connectionId ?? '',
+      sshFingerprint
+    ].join('\0')
   }
 
   const scope =

--- a/src/renderer/src/store/folder-workspaces/folder-workspace-routing.ts
+++ b/src/renderer/src/store/folder-workspaces/folder-workspace-routing.ts
@@ -14,6 +14,9 @@ export function getFolderWorkspacePathStatusScopeKey(
   if (request.scope === 'path') {
     return `path:${request.connectionId ?? ''}:${request.path}`
   }
+  if (request.scope === 'repo') {
+    return `repo:${request.executionHostId}:${request.repoId}`
+  }
   return `folder-workspace:${request.folderWorkspaceId}`
 }
 

--- a/src/renderer/src/store/folder-workspaces/repo-path-status-cache-key.test.ts
+++ b/src/renderer/src/store/folder-workspaces/repo-path-status-cache-key.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { getFolderWorkspacePathStatusScopeKey } from './folder-workspace-routing'
+
+describe('repo path status cache keys', () => {
+  it('fences the same repo path to its execution host', () => {
+    const local = getFolderWorkspacePathStatusScopeKey({
+      scope: 'repo',
+      repoId: 'repo-1',
+      executionHostId: 'local'
+    } as never)
+    const ssh = getFolderWorkspacePathStatusScopeKey({
+      scope: 'repo',
+      repoId: 'repo-1',
+      executionHostId: 'ssh:builder'
+    } as never)
+
+    expect(local).not.toBe(ssh)
+  })
+})

--- a/src/renderer/src/store/slices/worktrees-fetch-refresh-coalescing.test.ts
+++ b/src/renderer/src/store/slices/worktrees-fetch-refresh-coalescing.test.ts
@@ -174,8 +174,10 @@ describe('fetchWorktrees', () => {
     )
     const settings = createTestStore().getState().settings
     const detected = makeDetectedResult('repo1', [])
-    const firstIds = ['repo1::/a\nb', 'repo1::/c']
-    const secondIds = ['repo1::/a', 'repo1::/b\nc']
+    const firstIds = ['repo1::/a', 'repo1::/b\nrepo1::/c']
+    const secondIds = ['repo1::/a\nrepo1::/b', 'repo1::/c']
+
+    expect([...firstIds].sort().join('\n')).toBe([...secondIds].sort().join('\n'))
 
     const first = teardownMissingWorktreeTerminalsBestEffort(
       settings,

--- a/src/renderer/src/store/slices/worktrees-fetch-refresh-coalescing.test.ts
+++ b/src/renderer/src/store/slices/worktrees-fetch-refresh-coalescing.test.ts
@@ -18,6 +18,7 @@ import {
   resetRemoteRuntimeMocks,
   resetWorktreeSliceModuleMemory
 } from './worktrees-slice-test-harness'
+import { teardownMissingWorktreeTerminalsBestEffort } from './worktrees/teardown/missing-worktree-terminal-teardown'
 
 const requestWorktreeBaseFallbackNotice = vi.hoisted(() => vi.fn())
 
@@ -151,6 +152,52 @@ describe('fetchWorktrees', () => {
 
     expect(mockApi.runtime.call).toHaveBeenCalledTimes(1)
     expect(store.getState().tabsByWorktree[deleted.id]).toBeUndefined()
+  })
+
+  it('does not coalesce distinct newline-containing missing-worktree sets', async () => {
+    const releases: (() => void)[] = []
+    mockApi.runtime.call.mockImplementation(
+      ({ params }: { params?: { worktreeIds?: string[] } }) =>
+        new Promise((resolve) => {
+          const worktreeIds = params?.worktreeIds ?? []
+          releases.push(() =>
+            resolve({
+              id: `teardown-${releases.length}`,
+              ok: true,
+              result: {
+                stoppedWorktreeIds: worktreeIds,
+                verifiedStoppedWorktreeIds: worktreeIds
+              }
+            })
+          )
+        })
+    )
+    const settings = createTestStore().getState().settings
+    const detected = makeDetectedResult('repo1', [])
+    const firstIds = ['repo1::/a\nb', 'repo1::/c']
+    const secondIds = ['repo1::/a', 'repo1::/b\nc']
+
+    const first = teardownMissingWorktreeTerminalsBestEffort(
+      settings,
+      'repo1',
+      null,
+      firstIds,
+      detected
+    )
+    await vi.waitFor(() => expect(mockApi.runtime.call).toHaveBeenCalledTimes(1))
+    const second = teardownMissingWorktreeTerminalsBestEffort(
+      settings,
+      'repo1',
+      null,
+      secondIds,
+      detected
+    )
+    await vi.waitFor(() => expect(mockApi.runtime.call).toHaveBeenCalledTimes(2))
+
+    for (const release of releases) {
+      release()
+    }
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true])
   })
 
   // Why (#10562): "I can't reach the host" must never be read as "the worktree is

--- a/src/renderer/src/store/slices/worktrees-fetch-removal-purge.test.ts
+++ b/src/renderer/src/store/slices/worktrees-fetch-removal-purge.test.ts
@@ -223,7 +223,10 @@ describe('fetchWorktrees', () => {
             resolve({
               id: 'teardown',
               ok: true,
-              result: { stoppedWorktreeIds: [deleted.id] }
+              result: {
+                stoppedWorktreeIds: [deleted.id],
+                verifiedStoppedWorktreeIds: [deleted.id]
+              }
             })
         })
     )
@@ -263,6 +266,89 @@ describe('fetchWorktrees', () => {
     await refresh
 
     expect(store.getState().tabsByWorktree[deleted.id]).toBeUndefined()
+  })
+
+  it('preserves renderer state when missing-worktree terminal teardown is unverifiable', async () => {
+    const store = createTestStore()
+    const missing = makeWorktree({
+      id: 'repo1::/path/missing',
+      repoId: 'repo1',
+      path: '/path/missing'
+    })
+    const surviving = makeWorktree({
+      id: 'repo1::/path/surviving',
+      repoId: 'repo1',
+      path: '/path/surviving'
+    })
+    mockApi.runtime.call.mockResolvedValueOnce({
+      id: 'teardown',
+      ok: true,
+      result: { stoppedWorktreeIds: [], verifiedStoppedWorktreeIds: [] }
+    })
+    mockApi.worktrees.listDetected.mockImplementationOnce(async (args) =>
+      qualifyDetectedResult(args, makeDetectedResult('repo1', [surviving]))
+    )
+    store.setState({
+      repos: [
+        {
+          id: 'repo1',
+          path: '/path/repo1',
+          displayName: 'Repo 1',
+          badgeColor: '#000',
+          addedAt: 0
+        }
+      ],
+      worktreesByRepo: { repo1: [missing, surviving] },
+      detectedWorktreesByRepo: {
+        repo1: makeDetectedResult('repo1', [missing, surviving])
+      },
+      tabsByWorktree: {
+        [missing.id]: [{ id: 'tab-missing', worktreeId: missing.id }]
+      }
+    } as unknown as Partial<AppState>)
+
+    await store.getState().fetchWorktrees('repo1')
+
+    expect(store.getState().worktreesByRepo.repo1).toEqual([missing, surviving])
+    expect(store.getState().tabsByWorktree[missing.id]).toBeDefined()
+  })
+
+  it('preserves renderer state when an older host reports stops without verification proof', async () => {
+    const store = createTestStore()
+    const missing = makeWorktree({
+      id: 'repo1::/path/missing-old-host',
+      repoId: 'repo1',
+      path: '/path/missing-old-host'
+    })
+    mockApi.runtime.call.mockResolvedValueOnce({
+      id: 'teardown',
+      ok: true,
+      result: { stoppedWorktreeIds: [missing.id] }
+    })
+    mockApi.worktrees.listDetected.mockImplementationOnce(async (args) =>
+      qualifyDetectedResult(args, makeDetectedResult('repo1', []))
+    )
+    store.setState({
+      repos: [
+        {
+          id: 'repo1',
+          path: '/path/repo1',
+          displayName: 'Repo 1',
+          badgeColor: '#000',
+          addedAt: 0
+        }
+      ],
+      worktreesByRepo: { repo1: [missing] },
+      detectedWorktreesByRepo: { repo1: makeDetectedResult('repo1', [missing]) },
+      tabsByWorktree: {
+        [missing.id]: [{ id: 'tab-missing-old-host', worktreeId: missing.id }]
+      }
+    } as unknown as Partial<AppState>)
+
+    await store.getState().fetchWorktrees('repo1')
+
+    expect(store.getState().worktreesByRepo.repo1).toEqual([missing])
+    expect(store.getState().tabsByWorktree[missing.id]).toBeDefined()
   })
 
   it('clears a hidden dismissal across hydrated fetch-all delete and recreation', async () => {

--- a/src/renderer/src/store/slices/worktrees-slice-test-harness.ts
+++ b/src/renderer/src/store/slices/worktrees-slice-test-harness.ts
@@ -100,11 +100,16 @@ export const mockApi = {
     call: runtimeEnvironmentTransportCall
   },
   runtime: {
-    call: stubMock().mockResolvedValue({
-      id: 'runtime-call',
-      ok: true,
-      result: { stoppedWorktreeIds: [] }
-    })
+    call: stubMock<[{ params?: { worktreeIds?: string[] } }]>().mockImplementation(
+      async ({ params }) => ({
+        id: 'runtime-call',
+        ok: true,
+        result: {
+          stoppedWorktreeIds: params?.worktreeIds ?? [],
+          verifiedStoppedWorktreeIds: params?.worktreeIds ?? []
+        }
+      })
+    )
   },
   ephemeralVm: {
     cancelProvision: stubMock().mockResolvedValue({ cancelled: true }),

--- a/src/renderer/src/store/slices/worktrees/listing/detected-worktree-refresh.ts
+++ b/src/renderer/src/store/slices/worktrees/listing/detected-worktree-refresh.ts
@@ -164,13 +164,16 @@ export async function listDetectedWorktreesForRepoCoalesced(
       // Why (#10562): the scan coalesces, but teardown must not — each caller carries
       // its own known-id snapshot and purges its own state, so a caller that joined
       // an in-flight scan would otherwise purge without ever stopping those terminals.
-      await teardownMissingWorktreeTerminalsBestEffort(
+      const teardownConfirmed = await teardownMissingWorktreeTerminalsBestEffort(
         settings,
         repoId,
         options.connectionId,
         options.knownWorktreeIds,
         result
       )
+      if (!teardownConfirmed) {
+        throw new Error('missing_worktree_terminal_teardown_unverifiable')
+      }
       return {
         status: 'admitted',
         result,
@@ -218,13 +221,16 @@ export async function listDetectedWorktreesForRepoCoalesced(
       directSshAuthority: options.directSshAuthority
     }
   }
-  await teardownMissingWorktreeTerminalsBestEffort(
+  const teardownConfirmed = await teardownMissingWorktreeTerminalsBestEffort(
     settings,
     repoId,
     options.connectionId,
     options.knownWorktreeIds,
     providerResult.result
   )
+  if (!teardownConfirmed) {
+    throw new Error('missing_worktree_terminal_teardown_unverifiable')
+  }
   return {
     status: 'admitted',
     result: providerResult.result,

--- a/src/renderer/src/store/slices/worktrees/teardown/missing-worktree-terminal-teardown.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/missing-worktree-terminal-teardown.ts
@@ -2,11 +2,12 @@ import { callRuntimeRpc, getActiveRuntimeTarget } from '../../../../runtime/runt
 import type { AppState } from '../../../types'
 import type { DetectedWorktreeListResult } from '../../../../../../shared/worktree/types'
 import { isRuntimeMethodNotFoundError } from '../listing/runtime-worktree-rpc-errors'
+import type { MissingWorktreeTerminalTeardownResult } from '../../../../../../shared/worktree/missing-terminal-teardown'
 
 // Why: teardown cannot ride the scan's coalescing (each caller has its own known-id
 // snapshot), so dedupe on the request it actually produces — identical fan-out
 // requests share one host sweep instead of re-scanning per caller.
-const missingWorktreeTeardownsInFlight = new Map<string, Promise<void>>()
+const missingWorktreeTeardownsInFlight = new Map<string, Promise<boolean>>()
 
 export async function teardownMissingWorktreeTerminalsBestEffort(
   settings: AppState['settings'],
@@ -16,14 +17,14 @@ export async function teardownMissingWorktreeTerminalsBestEffort(
   // "nothing to reconcile", never "purge everything".
   knownWorktreeIds: readonly string[] | undefined,
   detected: DetectedWorktreeListResult
-): Promise<void> {
+): Promise<boolean> {
   if (!detected.authoritative || !knownWorktreeIds || knownWorktreeIds.length === 0) {
-    return
+    return true
   }
   const detectedIds = new Set(detected.worktrees.map((worktree) => worktree.id))
   const missingIds = knownWorktreeIds.filter((worktreeId) => !detectedIds.has(worktreeId))
   if (missingIds.length === 0) {
-    return
+    return true
   }
   const target = getActiveRuntimeTarget(settings)
   const normalizedConnectionId = connectionId ?? null
@@ -39,21 +40,28 @@ export async function teardownMissingWorktreeTerminalsBestEffort(
   }
   const teardown = (async () => {
     try {
-      await callRuntimeRpc(
+      const result = await callRuntimeRpc<MissingWorktreeTerminalTeardownResult>(
         target,
         'worktree.teardownMissingTerminals',
         { repo: repoId, worktreeIds: missingIds, connectionId: normalizedConnectionId },
         { timeoutMs: 30_000 }
       )
+      // Why: absence means a legacy host, not proof of exit; mixed versions must fail closed.
+      if (!Array.isArray(result.verifiedStoppedWorktreeIds)) {
+        return false
+      }
+      const verifiedIds = new Set(result.verifiedStoppedWorktreeIds)
+      return missingIds.every((worktreeId) => verifiedIds.has(worktreeId))
     } catch (error) {
       if (!isRuntimeMethodNotFoundError(error)) {
         console.warn(`Failed to stop terminals for missing worktrees in repo ${repoId}:`, error)
       }
+      return false
     }
   })()
   missingWorktreeTeardownsInFlight.set(key, teardown)
   try {
-    await teardown
+    return await teardown
   } finally {
     if (missingWorktreeTeardownsInFlight.get(key) === teardown) {
       missingWorktreeTeardownsInFlight.delete(key)

--- a/src/renderer/src/store/slices/worktrees/teardown/missing-worktree-terminal-teardown.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/missing-worktree-terminal-teardown.ts
@@ -32,7 +32,7 @@ export async function teardownMissingWorktreeTerminalsBestEffort(
     target.kind === 'local' ? 'local' : `runtime:${target.environmentId}`,
     repoId,
     normalizedConnectionId ?? '',
-    [...missingIds].sort().join('\n')
+    JSON.stringify([...missingIds].sort())
   ].join('\0')
   const existing = missingWorktreeTeardownsInFlight.get(key)
   if (existing) {

--- a/src/shared/folder-workspace-path-status.ts
+++ b/src/shared/folder-workspace-path-status.ts
@@ -1,3 +1,5 @@
+import type { ExecutionHostId } from './execution-host'
+
 export type FolderWorkspacePathStatusReason =
   | 'missing'
   | 'not-directory'
@@ -10,6 +12,7 @@ export type FolderWorkspacePathStatusRequest =
   | { scope: 'folder-workspace'; folderWorkspaceId: string }
   | { scope: 'project-group'; projectGroupId: string }
   | { scope: 'path'; path: string; connectionId?: string | null }
+  | { scope: 'repo'; repoId: string; executionHostId: ExecutionHostId }
 
 export type FolderWorkspacePathStatus = {
   path: string

--- a/src/shared/worktree/missing-terminal-teardown.ts
+++ b/src/shared/worktree/missing-terminal-teardown.ts
@@ -1,0 +1,5 @@
+export type MissingWorktreeTerminalTeardownResult = {
+  stoppedWorktreeIds: string[]
+  /** Absent on legacy hosts; present IDs were physically verified exited. */
+  verifiedStoppedWorktreeIds?: string[]
+}


### PR DESCRIPTION
## ELI5

When a folder lives on an SMB or other network-mounted volume, a brief disconnect should not make Orca erase its terminals. This change keeps live terminals attached, marks the folder unavailable, and recovers the normal UI when the mount returns.

## What Changed

- Treat failed local worktree scans as non-authoritative instead of successful empty results.
- Require a new optional `verifiedStoppedWorktreeIds` proof before an authoritative refresh may purge terminal state. Its absence means a legacy host and fails closed.
- Physically verify failed PTY stops against the uncached owning-host provider.
- Poll visible local project roots through repo- and host-scoped path-status keys.
- Route Windows projects configured for WSL through the selected distro filesystem instead of native Windows `stat`.
- Reuse the existing `FolderPathStatusIndicator` on workspace cards, with host/drive-aware copy.

## Why

A transient SMB disconnect could be interpreted as permanent workspace deletion. Orca removed every terminal from the UI, while an agent process could survive without UI ownership. Codex sessions then failed to resume because the previous process still held an active writer.

The fix separates three states that must not be collapsed: a missing path, an unverifiable host, and a physically verified terminal exit.

## Linked Issue

N/A — no issue was filed before implementation.

## Visual Proof

### Before — pre-fix behavior

No screenshot is available for the destructive pre-fix state. When the folder mount disappeared, Orca removed every terminal belonging to that folder from the UI.

### After — folder online

The mounted folder workspace and its existing terminal remain available normally.

![Folder online](https://github.com/user-attachments/assets/d62482f2-97f7-4d15-a987-ec61ea1b09d5)

### After — folder offline

The existing `Terminal 1` remains visible and active while the workspace shows a missing-folder indicator. The file explorer may still show its last cached listing, but new filesystem operations remain unavailable until the volume is remounted.

![Folder offline](https://github.com/user-attachments/assets/a738683f-9c78-4c52-9b74-d785d1aac620)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Manual macOS SMB flow:

1. Mounted `smb://dsm.ye4241.com/docker` at `/Volumes/docker`.
2. Opened the folder project and a live terminal.
3. Force-unmounted the volume.
4. Verified the workspace and terminal stayed visible, the activity state remained live, and the folder warning appeared.
5. Remounted the share and verified the warning cleared.

Local automated verification after rebasing onto upstream `main`:

- 184 focused unit/integration tests passed.
- 5 cross-version terminal-wire tests passed.
- `pnpm tc` passed.
- max-lines, localization catalog, localization coverage, formatting, and changed-file lint checks passed.
- Full platform/package matrix will run in CI.

## AI Disclosure

OpenAI Codex (GPT-5) was used for diagnosis, implementation, tests, review fixes, and PR preparation.

## Review

- **Cross-platform:** Native macOS was manually tested. Windows/WSL routing has a focused regression test proving the selected distro filesystem is used. Linux and Windows packaging remain for CI.
- **Local/SSH/remote:** Repo path status is keyed by repo and execution host. Direct SSH or mixed-version host uncertainty cannot prove PTY exit. Legacy hosts omit the optional verification field and therefore fail closed.
- **Agents/integrations:** The lifecycle change is provider-neutral. Codex exposed the original active-writer symptom, but no Codex-specific behavior was added.
- **Performance:** Path probes are limited to visible local repos and reuse the existing 10-second TTL. A stalled probe does not schedule an unbounded queue of additional probes.
- **UI quality:** Reuses the existing folder status indicator and design-system tokens; no new color or component system was introduced.
- **Security:** No credentials or project contents are transmitted. New request identities are schema-validated and host-scoped.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no upstream skill-installer source or assets.

## Notes

- Git-provider behavior is unchanged.
- No version or release files are changed.

## Author

- GitHub: @ye4241
- X: @ye4241

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why, including an ELI5
- [x] Visual proof attached with the unavailable pre-fix capture explicitly documented
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered
- [x] Full `pnpm lint`, `pnpm test`, and `pnpm build` matrix will be covered by CI; focused local checks passed