### PR TITLE
fix(session): defer session writes suppressed by a direct-SSH apply instead of dropping them

### DIFF
--- a/src/renderer/src/app-shell/use-app-session-persistence.ts
+++ b/src/renderer/src/app-shell/use-app-session-persistence.ts
@@ -1,7 +1,10 @@
 import { useEffect } from 'react'
 import { translate } from '@/i18n/i18n'
 import { useAppStore } from '../store'
-import { isDirectSshRemoteWorkspaceApplyInProgress } from '../hooks/remote-workspace-snapshot-apply'
+import {
+  isDirectSshRemoteWorkspaceApplyInProgress,
+  onDirectSshRemoteWorkspaceApplyWindowClosed
+} from '../hooks/remote-workspace-snapshot-apply'
 import { createSessionWriteSubscriber } from '../lib/session-write-subscriber'
 import { buildActiveViewUnloadPatch } from '../lib/active-view-persist'
 import {
@@ -84,6 +87,7 @@ export function useAppSessionPersistence(): void {
     return createSessionWriteSubscriber({
       store: useAppStore,
       shouldSchedulePersist: () => !isDirectSshRemoteWorkspaceApplyInProgress(),
+      subscribeToPersistGateOpen: onDirectSshRemoteWorkspaceApplyWindowClosed,
       persist: ({ patch }) => {
         const state = useAppStore.getState()
         // Why: route each host's worktree-scoped slice to its own partition; return the local write so the remote-workspace upload chain below keeps its ordering.

--- a/src/renderer/src/hooks/remote-workspace-snapshot-apply-deferred-session-write.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-snapshot-apply-deferred-session-write.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Drives the real apply path with the real session writer wired exactly as the app wires it.
+ *
+ * The write gate closes for the whole apply plus a 1s suppression tail that expires on a wall
+ * clock — no store update follows it. So a tab the user closes on an unrelated target during
+ * target A's reconnect has to be held and written when the tail ends, or the close and its
+ * tombstone are lost until the next unrelated mutation (a crash or kill in between loses both).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+import type { RemoteWorkspaceSnapshot } from '../../../shared/remote-workspace-types'
+import type { DirectSshAuthority, SshProviderEpoch } from '../../../shared/ssh-types'
+import { createTestStore, makeWorktree } from '../store/slices/store-test-helpers'
+import {
+  createSessionWriteSubscriber,
+  type WorkspaceSessionWrite
+} from '../lib/session-write-subscriber'
+import {
+  applyDirectSshRemoteWorkspaceSnapshot,
+  isDirectSshRemoteWorkspaceApplyInProgress,
+  onDirectSshRemoteWorkspaceApplyWindowClosed
+} from './remote-workspace-snapshot-apply'
+import type { DirectSshSnapshotApplyToken } from './direct-ssh-reconnect-coordinator-types'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() }
+}))
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return {
+    ...actual,
+    detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
+  }
+})
+
+const TARGET_A = 'ssh-target-a'
+const PATH_A = '/srv/proj/target-a'
+const WORKTREE_A = `repoA::${PATH_A}`
+const WORKTREE_B = 'repoB::/srv/other/target-b'
+
+const authority: DirectSshAuthority = {
+  targetId: TARGET_A,
+  providerEpoch: 'provider-epoch-1' as SshProviderEpoch,
+  connectionGeneration: 1
+}
+
+type TestStore = ReturnType<typeof createTestStore>
+
+function token(snapshotRevision: number): DirectSshSnapshotApplyToken {
+  return {
+    authority,
+    catalogRevision: 0,
+    repoFingerprint: 'fp',
+    authorityRequirement: 'required',
+    snapshotRevision,
+    outcome: 'complete'
+  }
+}
+
+function snapshot(revision: number): RemoteWorkspaceSnapshot {
+  return {
+    namespace: 'workspace',
+    revision,
+    updatedAt: revision,
+    schemaVersion: 1,
+    session: {
+      activeWorktreePath: PATH_A,
+      activeTabId: 'tab-a',
+      tabsByWorktreePath: {
+        [PATH_A]: [
+          {
+            id: 'tab-a',
+            worktreePath: PATH_A,
+            ptyId: 'pty-tab-a',
+            title: 'Terminal 1',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {},
+      activeWorktreePathsOnShutdown: [],
+      activeTabIdByWorktreePath: { [PATH_A]: 'tab-a' },
+      remoteSessionIdsByTabId: { 'tab-a': 'pty-tab-a' },
+      lastVisitedAtByWorktreePath: { [PATH_A]: revision },
+      defaultTerminalTabsAppliedByWorktreePath: { [PATH_A]: true }
+    }
+  } satisfies RemoteWorkspaceSnapshot
+}
+
+function seedCatalog(store: TestStore): void {
+  store.setState({
+    worktreesByRepo: {
+      repoA: [
+        makeWorktree({
+          id: WORKTREE_A,
+          repoId: 'repoA',
+          path: PATH_A,
+          hostId: `ssh:${TARGET_A}`
+        } as never)
+      ]
+    },
+    repos: [
+      {
+        id: 'repoA',
+        path: '/srv/proj',
+        displayName: 'Proj',
+        badgeColor: '#000',
+        addedAt: 0,
+        connectionId: TARGET_A
+      } as never
+    ],
+    reconnectPersistedTerminals: (async () => {}) as never,
+    markRemoteWorkspaceHydrated: (() => {}) as never,
+    setRemoteWorkspaceSyncStatus: (() => {}) as never
+  })
+}
+
+/** A second target's tab the user closes while target A is mid-apply. */
+function closeUnrelatedTargetTab(store: TestStore): void {
+  store.setState({
+    tabsByWorktree: { ...store.getState().tabsByWorktree, [WORKTREE_B]: [] },
+    closedTerminalTabTombstonesByTabId: {
+      'tab-b': { closedAt: Date.now(), worktreeId: WORKTREE_B }
+    }
+  })
+}
+
+/** Everything here is timer-driven, so fake timers make the tail deterministic and instant. */
+describe('session writes deferred by a direct-SSH apply', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  async function applyTargetA(store: TestStore, onApplied: () => void): Promise<void> {
+    await applyDirectSshRemoteWorkspaceSnapshot({
+      store,
+      snapshot: snapshot(1),
+      token: token(1),
+      arrival: 1,
+      isArrivalCurrent: () => true,
+      isPreparationTokenCurrent: () => true,
+      waitForWorkspaceSessionReady: async () => true,
+      // Runs inside the apply, which is when the write gate is shut.
+      finalizeHydratedTerminals: () => {
+        onApplied()
+        return 0
+      }
+    })
+  }
+
+  function seedBothTargets(store: TestStore): void {
+    seedCatalog(store)
+    store.setState({
+      tabsByWorktree: {
+        [WORKTREE_B]: [
+          {
+            id: 'tab-b',
+            ptyId: 'pty-tab-b',
+            worktreeId: WORKTREE_B,
+            title: 'Other host',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          } as never
+        ]
+      }
+    })
+  }
+
+  it('lands an unrelated target\u2019s tab close once the suppression tail expires', async () => {
+    const store = createTestStore()
+    seedBothTargets(store)
+
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    const cleanup = createSessionWriteSubscriber({
+      store,
+      persist,
+      shouldSchedulePersist: () => !isDirectSshRemoteWorkspaceApplyInProgress(),
+      subscribeToPersistGateOpen: onDirectSshRemoteWorkspaceApplyWindowClosed
+    })
+    try {
+      store.setState({ workspaceSessionReady: true, hydrationSucceeded: true })
+      vi.advanceTimersByTime(200)
+      expect(persist).toHaveBeenCalled()
+      persist.mockClear()
+
+      await applyTargetA(store, () => closeUnrelatedTargetTab(store))
+
+      expect(
+        isDirectSshRemoteWorkspaceApplyInProgress(),
+        'the suppression tail should still be holding writes here'
+      ).toBe(true)
+      expect(persist).not.toHaveBeenCalled()
+
+      // Tail (1000ms) + the notice's 1ms margin + the writer's 150ms debounce.
+      vi.advanceTimersByTime(1_200)
+
+      expect(persist, 'the close made during the apply never reached disk').toHaveBeenCalledTimes(1)
+      const patch = persist.mock.calls[0][0].patch
+      expect(patch.closedTerminalTabTombstonesByTabId?.['tab-b']?.worktreeId).toBe(WORKTREE_B)
+      expect(patch.tabsByWorktree?.[WORKTREE_B]).toEqual([])
+      expect(patch.tabsByWorktree?.[WORKTREE_A]).toHaveLength(1)
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('still wakes the deferred write when the wall clock steps back during the tail', async () => {
+    const store = createTestStore()
+    seedBothTargets(store)
+    const startedAt = Date.now()
+
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    const cleanup = createSessionWriteSubscriber({
+      store,
+      persist,
+      shouldSchedulePersist: () => !isDirectSshRemoteWorkspaceApplyInProgress(),
+      subscribeToPersistGateOpen: onDirectSshRemoteWorkspaceApplyWindowClosed
+    })
+    try {
+      store.setState({ workspaceSessionReady: true, hydrationSucceeded: true })
+      vi.advanceTimersByTime(200)
+      persist.mockClear()
+
+      await applyTargetA(store, () => closeUnrelatedTargetTab(store))
+
+      // The notice's delay is wall-clock arithmetic on a monotonic timer, so an NTP step back
+      // leaves the deadline in the future when it fires. It must wait, not give up.
+      vi.setSystemTime(startedAt - 5_000)
+      vi.advanceTimersByTime(1_200)
+      expect(persist, 'the notice fired before its own deadline').not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(5_200)
+
+      expect(persist, 'a clock step back stranded the deferred write').toHaveBeenCalledTimes(1)
+      expect(
+        persist.mock.calls[0][0].patch.closedTerminalTabTombstonesByTabId?.['tab-b']
+      ).toBeDefined()
+    } finally {
+      cleanup()
+    }
+  })
+})

--- a/src/renderer/src/hooks/remote-workspace-snapshot-apply.ts
+++ b/src/renderer/src/hooks/remote-workspace-snapshot-apply.ts
@@ -27,6 +27,45 @@ export function isDirectSshRemoteWorkspaceApplyInProgress(): boolean {
   return snapshotApplyDepth > 0 || Date.now() < snapshotWriteSuppressUntil
 }
 
+const applyWindowCloseListeners = new Set<() => void>()
+
+/**
+ * Fires once after the write-suppression tail expires. Why: the tail ends on a wall clock with no
+ * store update behind it, so a session write deferred during an apply has nothing else to wake it.
+ */
+export function onDirectSshRemoteWorkspaceApplyWindowClosed(listener: () => void): () => void {
+  applyWindowCloseListeners.add(listener)
+  return () => {
+    applyWindowCloseListeners.delete(listener)
+  }
+}
+
+/**
+ * One timer in flight per apply. It never polls: the tail deadline only moves forward, and each
+ * re-arm waits exactly the time still left on it, so the wait converges instead of spinning.
+ */
+function scheduleApplyWindowClosedNotice(): void {
+  // +1ms because the gate compares `Date.now() < suppressUntil`; fire strictly past the deadline.
+  const delayMs = Math.max(0, snapshotWriteSuppressUntil - Date.now()) + 1
+  setTimeout(() => {
+    // An apply still in flight schedules the next notice from its own `finally`.
+    if (snapshotApplyDepth > 0) {
+      return
+    }
+    // Why re-arm rather than return: `delayMs` is wall-clock arithmetic handed to a monotonic
+    // timer, so a clock step back (NTP) can leave the deadline in the future when this fires.
+    // Dropping the notice there would strand every write deferred in this window.
+    if (Date.now() < snapshotWriteSuppressUntil) {
+      scheduleApplyWindowClosedNotice()
+      return
+    }
+    // Safe to iterate live: Set iteration tolerates a listener unsubscribing itself.
+    for (const listener of applyWindowCloseListeners) {
+      listener()
+    }
+  }, delayMs)
+}
+
 type RemoteWorkspaceSnapshotApplyInput = {
   store: Pick<StoreApi<AppState>, 'getState'>
   snapshot: RemoteWorkspaceSnapshot
@@ -195,5 +234,6 @@ export async function applyDirectSshRemoteWorkspaceSnapshot({
   } finally {
     snapshotWriteSuppressUntil = Date.now() + REMOTE_WORKSPACE_SNAPSHOT_WRITE_SUPPRESS_MS
     snapshotApplyDepth -= 1
+    scheduleApplyWindowClosedNotice()
   }
 }

--- a/src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts
@@ -1,0 +1,299 @@
+/**
+ * A session mutation made while the direct-SSH write gate is closed must be deferred, never
+ * dropped.
+ *
+ * Why this is data loss and not a delay: the subscriber advances its change-detection baseline
+ * (`prev = next`) before it consults the gate, and detection is identity-based
+ * (`prev[key] !== next[key]`). A field cleared out of the pending set at that point can never be
+ * re-detected, so the mutation is gone until something else happens to touch the same field. The
+ * gate is closed for up to SNAPSHOT_TERMINAL_RECONNECT_TIMEOUT_MS plus a 1s tail on every SSH
+ * connect and reconnect — and a tab closed in that window loses both the removal and the tombstone
+ * that was supposed to stop the host from resurrecting it.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore, type AppState } from '@/store'
+import {
+  createSessionWriteSubscriber,
+  type WorkspaceSessionWrite
+} from './session-write-subscriber'
+
+let initialState: AppState
+
+function terminalTab(id: string, worktreeId: string): AppState['tabsByWorktree'][string][number] {
+  return {
+    id,
+    ptyId: `pty-${id}`,
+    worktreeId,
+    title: id,
+    defaultTitle: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+/** Stands in for the direct-SSH apply gate: `isOpen` is the flag, and the wake-up fires on demand
+ *  the way the apply's suppression tail fires it. */
+function createTestPersistGate(isOpen: () => boolean) {
+  const listeners: (() => void)[] = []
+  return {
+    deps: {
+      shouldSchedulePersist: isOpen,
+      subscribeToPersistGateOpen: (onGateOpen: () => void) => {
+        listeners.push(onGateOpen)
+        return () => {
+          listeners.length = 0
+        }
+      }
+    },
+    listenerCount: (): number => listeners.length,
+    notifyGateOpen: (): void => {
+      for (const listener of listeners) {
+        listener()
+      }
+    }
+  }
+}
+
+describe('session write subscriber defers writes across a closed persistence gate', () => {
+  beforeEach(() => {
+    initialState = useAppStore.getState()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    useAppStore.setState(initialState, true)
+  })
+
+  it('writes a mutation made while the gate was closed once a later mutation reopens it', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    let gateOpen = true
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      ...createTestPersistGate(() => gateOpen).deps
+    })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    // The user closes an SSH tab while a snapshot apply is running.
+    gateOpen = false
+    useAppStore.setState({
+      activeTabId: 'still-open-tab',
+      closedTerminalTabTombstonesByTabId: {
+        'closed-during-apply': {
+          closedAt: Date.now(),
+          worktreeId: 'wt-remote'
+        }
+      }
+    })
+    vi.advanceTimersByTime(200)
+    expect(persist).not.toHaveBeenCalled()
+
+    // The apply finishes and an unrelated field changes. The deferred close must ride along.
+    gateOpen = true
+    useAppStore.setState({ activeRepoId: 'repo-1' })
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    const patch = persist.mock.calls[0][0].patch
+    expect(
+      patch.closedTerminalTabTombstonesByTabId,
+      'the tombstone written during the apply window was discarded, not deferred'
+    ).toEqual({
+      'closed-during-apply': {
+        closedAt: expect.any(Number),
+        worktreeId: 'wt-remote'
+      }
+    })
+    expect(patch.activeTabId).toBe('still-open-tab')
+    expect(patch.activeRepoId).toBe('repo-1')
+    cleanup()
+  })
+
+  it('writes a mutation whose debounce expired inside the apply window', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    let gateOpen = true
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      ...createTestPersistGate(() => gateOpen).deps
+    })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    // Mutation lands with the gate open, but the apply starts before the debounce expires.
+    useAppStore.setState({ activeTabId: 'closed-mid-debounce' })
+    vi.advanceTimersByTime(50)
+    gateOpen = false
+    vi.advanceTimersByTime(200)
+    expect(persist).not.toHaveBeenCalled()
+
+    gateOpen = true
+    useAppStore.setState({ activeRepoId: 'repo-2' })
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(
+      persist.mock.calls[0][0].patch.activeTabId,
+      'the debounce fired inside the apply window and threw the mutation away'
+    ).toBe('closed-mid-debounce')
+    cleanup()
+  })
+
+  it('keeps an unrelated target’s tab close across another target’s apply', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    let gateOpen = true
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      ...createTestPersistGate(() => gateOpen).deps
+    })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      tabsByWorktree: {
+        'wt-target-a': [terminalTab('tab-a', 'wt-target-a')],
+        'wt-target-b': [terminalTab('tab-b', 'wt-target-b')]
+      }
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    // The gate is global: target A's apply suppresses writes for every other target too.
+    gateOpen = false
+    useAppStore.setState({
+      tabsByWorktree: {
+        'wt-target-a': [terminalTab('tab-a', 'wt-target-a')],
+        'wt-target-b': []
+      },
+      closedTerminalTabTombstonesByTabId: {
+        'tab-b': { closedAt: Date.now(), worktreeId: 'wt-target-b' }
+      }
+    })
+    vi.advanceTimersByTime(200)
+    expect(persist).not.toHaveBeenCalled()
+
+    gateOpen = true
+    useAppStore.setState({ activeRepoId: 'repo-3' })
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    const patch = persist.mock.calls[0][0].patch
+    expect(
+      patch.tabsByWorktree?.['wt-target-b'],
+      'target B lost a tab close because target A was mid-apply'
+    ).toEqual([])
+    expect(patch.tabsByWorktree?.['wt-target-a']).toHaveLength(1)
+    expect(patch.closedTerminalTabTombstonesByTabId?.['tab-b']?.worktreeId).toBe('wt-target-b')
+    cleanup()
+  })
+
+  it('writes on the gate-open wake-up when no further store update follows', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    let gateOpen = true
+    const gate = createTestPersistGate(() => gateOpen)
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      ...gate.deps
+    })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    gateOpen = false
+    useAppStore.setState({ activeTabId: 'closed-during-apply' })
+    vi.advanceTimersByTime(200)
+    expect(persist).not.toHaveBeenCalled()
+
+    // The suppression tail expires on a wall clock, so nothing touches the store afterwards.
+    gateOpen = true
+    expect(gate.listenerCount(), 'the subscriber never registered for the gate-open wake-up').toBe(
+      1
+    )
+    gate.notifyGateOpen()
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.activeTabId).toBe('closed-during-apply')
+    cleanup()
+  })
+
+  it('arms no timer while the gate stays closed', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    let gateOpen = true
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      ...createTestPersistGate(() => gateOpen).deps
+    })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    gateOpen = false
+    useAppStore.setState({ activeTabId: 'closed-during-apply' })
+    vi.advanceTimersByTime(10_000)
+
+    expect(persist).not.toHaveBeenCalled()
+    // A gate that never reopens must not turn deferral into a polling loop.
+    expect(vi.getTimerCount(), 'the deferred write is polling on a re-armed timer').toBe(0)
+    cleanup()
+  })
+
+  it('does not let an unrelated update reset a debounce armed by the gate-open wake-up', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    let gateOpen = true
+    const gate = createTestPersistGate(() => gateOpen)
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      ...gate.deps
+    })
+
+    useAppStore.setState({ workspaceSessionReady: true, hydrationSucceeded: true })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    gateOpen = false
+    useAppStore.setState({ activeTabId: 'closed-during-apply' })
+    vi.advanceTimersByTime(200)
+    expect(persist).not.toHaveBeenCalled()
+
+    // The wake-up arms the debounce; agent-status and usage ticks keep arriving while it runs.
+    gateOpen = true
+    gate.notifyGateOpen()
+    vi.advanceTimersByTime(100)
+    useAppStore.getState().setCacheTimerStartedAt('tab-1:pane-1', Date.now())
+    vi.advanceTimersByTime(60)
+
+    expect(
+      persist,
+      'an unrelated update pushed the deferred write past its debounce'
+    ).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.activeTabId).toBe('closed-during-apply')
+    cleanup()
+  })
+})

--- a/src/renderer/src/lib/session-write-subscriber.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber.test.ts
@@ -62,6 +62,9 @@ function makeTerminalSessionState(title: string, label = title): Partial<AppStat
   }
 }
 
+/** These cases reopen the gate through a store update, so they need no wake-up of their own. */
+const noGateOpenWakeUp = (): (() => void) => () => {}
+
 describe('createSessionWriteSubscriber', () => {
   beforeEach(() => {
     initialState = useAppStore.getState()
@@ -571,13 +574,14 @@ describe('createSessionWriteSubscriber', () => {
     cleanup()
   })
 
-  it('updates its baseline without scheduling when shouldSchedulePersist returns false', () => {
+  it('defers rather than drops a change made while shouldSchedulePersist returns false', () => {
     const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
     let shouldSchedule = false
     const cleanup = createSessionWriteSubscriber({
       store: useAppStore,
       persist,
-      shouldSchedulePersist: () => shouldSchedule
+      shouldSchedulePersist: () => shouldSchedule,
+      subscribeToPersistGateOpen: noGateOpenWakeUp
     })
 
     useAppStore.setState({ workspaceSessionReady: true, hydrationSucceeded: true })
@@ -588,25 +592,34 @@ describe('createSessionWriteSubscriber', () => {
     useAppStore.setState({ activeTabId: 'tab-1' })
     vi.advanceTimersByTime(200)
     expect(persist).toHaveBeenCalledTimes(1)
+    // The suppressed first pass owed every field; only activeTabId changed after the gate opened.
+    expect(persist.mock.calls[0][0].patch.tabsByWorktree).toBeDefined()
     cleanup()
   })
 
-  it('cancels a pending debounce when shouldSchedulePersist returns false', () => {
+  it('holds a write whose change arrived while shouldSchedulePersist returned false', () => {
     const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
     let shouldSchedule = true
     const cleanup = createSessionWriteSubscriber({
       store: useAppStore,
       persist,
-      shouldSchedulePersist: () => shouldSchedule
+      shouldSchedulePersist: () => shouldSchedule,
+      subscribeToPersistGateOpen: noGateOpenWakeUp
     })
 
-    useAppStore.setState({ workspaceSessionReady: true })
+    useAppStore.setState({ workspaceSessionReady: true, hydrationSucceeded: true })
     vi.advanceTimersByTime(50)
     shouldSchedule = false
     useAppStore.setState({ activeTabId: 'remote-tab' })
     vi.advanceTimersByTime(200)
 
     expect(persist).not.toHaveBeenCalled()
+
+    shouldSchedule = true
+    useAppStore.setState({ activeRepoId: 'repo-after-remote-pull' })
+    vi.advanceTimersByTime(200)
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.activeTabId).toBe('remote-tab')
     cleanup()
   })
 
@@ -616,7 +629,8 @@ describe('createSessionWriteSubscriber', () => {
     const cleanup = createSessionWriteSubscriber({
       store: useAppStore,
       persist,
-      shouldSchedulePersist: () => shouldSchedule
+      shouldSchedulePersist: () => shouldSchedule,
+      subscribeToPersistGateOpen: noGateOpenWakeUp
     })
 
     useAppStore.setState({ workspaceSessionReady: true, hydrationSucceeded: true })
@@ -629,6 +643,13 @@ describe('createSessionWriteSubscriber', () => {
     vi.advanceTimersByTime(200)
 
     expect(persist).not.toHaveBeenCalled()
+
+    // The suppressed write is owed, not forgotten: it lands when the gate reopens.
+    shouldSchedule = true
+    useAppStore.setState({ activeTabId: 'tab-after-remote-pull' })
+    vi.advanceTimersByTime(200)
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.activeWorktreeId).toBe('wt-before-remote-pull')
     cleanup()
   })
 

--- a/src/renderer/src/lib/session-write-subscriber.ts
+++ b/src/renderer/src/lib/session-write-subscriber.ts
@@ -77,15 +77,30 @@ export type WorkspaceSessionWrite = {
   patch: WorkspaceSessionPatch
 }
 
+/**
+ * Why the two are one unit and not two optional callbacks: a gate can reopen on a wall clock (the
+ * direct-SSH apply's suppression tail) with no store update behind it. A caller that supplies the
+ * gate but no wake-up would strand every write deferred in that window until some unrelated
+ * mutation happened along — the failure this deferral exists to prevent. Pairing them in the type
+ * makes that combination unwriteable rather than merely discouraged.
+ */
+type SessionWritePersistGate =
+  | { shouldSchedulePersist?: undefined; subscribeToPersistGateOpen?: undefined }
+  | {
+      /** False defers the write; it never drops it. */
+      shouldSchedulePersist: () => boolean
+      /** Called when the gate may have reopened. Returns an unsubscribe. */
+      subscribeToPersistGateOpen: (onGateOpen: () => void) => () => void
+    }
+
 export type SessionWriteSubscriberDeps = {
   store: {
     subscribe: (listener: (state: AppState) => void) => () => void
     getState: () => AppState
   }
   persist: (payload: WorkspaceSessionWrite) => void
-  shouldSchedulePersist?: () => boolean
   debounceMs?: number
-}
+} & SessionWritePersistGate
 
 /**
  * Why: factored out so a vitest can drive the real Zustand store and assert
@@ -97,6 +112,7 @@ export function createSessionWriteSubscriber({
   store,
   persist,
   shouldSchedulePersist,
+  subscribeToPersistGateOpen,
   debounceMs = 150
 }: SessionWriteSubscriberDeps): () => void {
   let timer: ReturnType<typeof setTimeout> | null = null
@@ -108,9 +124,49 @@ export function createSessionWriteSubscriber({
   // reuse the prior identity while a real session change keeps fresh tabs for
   // the eventual getState() patch build. `null` makes the first fire proceed.
   let prev: Record<string, unknown> | null = null
+  // Why: this set is the only record that a mutation still owes a write — `prev` has already
+  // advanced past it, and change detection is identity-based, so a field dropped from here can
+  // never be re-detected. It is retired only by a flush that reached `persist` (or found nothing
+  // left to write), and by unsubscribe. A closed gate never retires it.
   const pendingChangedFields = new Set<SessionRelevantField>()
   const terminalTabsProjection = createTerminalSessionTabsProjection()
   const unifiedTabsProjection = createUnifiedSessionTabsProjection()
+
+  const flushPendingWrite = (): void => {
+    timer = null
+    // Why: rebuild from the freshest store state rather than the snapshot
+    // captured when this timer was scheduled. Today this is equivalent
+    // because buildWorkspaceSessionPayload reads only SESSION_RELEVANT_FIELDS
+    // (the same fields gating the timer reset), so the captured `state` is
+    // already current for those fields. Calling getState() guards against a
+    // future refactor that adds a non-relevant field read to the payload
+    // builder — without this, such a change would silently start emitting
+    // stale values for that field.
+    const fresh = store.getState()
+    // Why: a closed gate defers, it never discards. Returning with the pending set intact leaves
+    // the write owed; the next store update or gate-open wake-up re-arms it. Nothing re-arms from
+    // here, so a gate that never reopens costs no timer.
+    if (!shouldPersistWorkspaceSession(fresh)) {
+      return
+    }
+    if (shouldSchedulePersist && !shouldSchedulePersist()) {
+      return
+    }
+    const changed = new Set(pendingChangedFields)
+    pendingChangedFields.clear()
+    const patch = buildWorkspaceSessionPatch(fresh, changed)
+    if (Object.keys(patch).length === 0) {
+      return
+    }
+    persist({ patch })
+  }
+
+  const armFlushTimer = (): void => {
+    if (timer !== null) {
+      clearTimeout(timer)
+    }
+    timer = setTimeout(flushPendingWrite, debounceMs)
+  }
 
   const unsub = store.subscribe((state) => {
     if (!shouldPersistWorkspaceSession(state)) {
@@ -130,7 +186,7 @@ export function createSessionWriteSubscriber({
       prev === null
         ? [...SESSION_RELEVANT_FIELDS]
         : SESSION_RELEVANT_FIELDS.filter((key) => prev?.[key] !== next[key])
-    if (changedFields.length === 0) {
+    if (changedFields.length === 0 && pendingChangedFields.size === 0) {
       return
     }
     prev = next
@@ -138,47 +194,26 @@ export function createSessionWriteSubscriber({
       pendingChangedFields.add(field)
     }
     if (shouldSchedulePersist && !shouldSchedulePersist()) {
-      if (timer !== null) {
-        clearTimeout(timer)
-        timer = null
-      }
-      pendingChangedFields.clear()
       return
     }
-    if (timer !== null) {
-      clearTimeout(timer)
+    // Why: an unrelated update may wake a deferred write but must never reset an armed debounce —
+    // that reset storm is exactly what the changed-field gate above exists to prevent.
+    if (timer !== null && changedFields.length === 0) {
+      return
     }
-    timer = setTimeout(() => {
-      timer = null
-      // Why: rebuild from the freshest store state rather than the snapshot
-      // captured when this timer was scheduled. Today this is equivalent
-      // because buildWorkspaceSessionPayload reads only SESSION_RELEVANT_FIELDS
-      // (the same fields gating the timer reset), so the captured `state` is
-      // already current for those fields. Calling getState() guards against a
-      // future refactor that adds a non-relevant field read to the payload
-      // builder — without this, such a change would silently start emitting
-      // stale values for that field.
-      const fresh = store.getState()
-      if (!shouldPersistWorkspaceSession(fresh)) {
-        pendingChangedFields.clear()
-        return
-      }
-      if (shouldSchedulePersist && !shouldSchedulePersist()) {
-        pendingChangedFields.clear()
-        return
-      }
-      const changed = new Set(pendingChangedFields)
-      pendingChangedFields.clear()
-      const patch = buildWorkspaceSessionPatch(fresh, changed)
-      if (Object.keys(patch).length === 0) {
-        return
-      }
-      persist({ patch })
-    }, debounceMs)
+    armFlushTimer()
+  })
+
+  const unsubGateOpen = subscribeToPersistGateOpen?.(() => {
+    if (pendingChangedFields.size === 0 || timer !== null) {
+      return
+    }
+    armFlushTimer()
   })
 
   return () => {
     unsub()
+    unsubGateOpen?.()
     if (timer !== null) {
       clearTimeout(timer)
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​577 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​571 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​117 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​38 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 |

<!-- /orca-pr-loc -->

## Session writes suppressed during an SSH apply were discarded, not deferred

### User-visible symptom

Close a terminal tab (or rename one, move one between groups, change the active workspace — any durable session edit) in the ~30 seconds after an SSH workspace connects or reconnects, and the edit could be **silently lost**. Nothing tells you: the UI shows the tab gone, the session file on disk still has it, and the next launch brings it back.

The worst version is the one PR #16752 just built machinery for. Closing an SSH tab writes two pieces of durable state: the tab's removal *and* a closed-tab tombstone, which is the client's only record that "the user closed this" for the direct-SSH pull merge. Both live in the same session state. A close made inside the suppression window lost **both**, so the tab came back on the next reconnect and the tombstone that was supposed to make the close stick was never written. That window is open on every connect and every reconnect — which is precisely when a user is looking at phantom tabs and cleaning them up.

### Root cause

`src/renderer/src/lib/session-write-subscriber.ts` is the debounced Zustand → disk session writer. It tracks *which* session fields changed in `pendingChangedFields`, and detects change by object identity against a baseline: `prev?.[key] !== next[key]`.

On `origin/main` it advanced that baseline **before** consulting the persist gate:

- `session-write-subscriber.ts:136` — `prev = next`
- `session-write-subscriber.ts:140-146` — gate closed at change time → `pendingChangedFields.clear()`
- `session-write-subscriber.ts:162-164` — debounce fired but `shouldPersistWorkspaceSession(fresh)` false → `pendingChangedFields.clear()`
- `session-write-subscriber.ts:165-168` — debounce fired but `shouldSchedulePersist()` false → `pendingChangedFields.clear()`

Once `prev` has advanced, the identity comparison for that field will never differ again. Clearing it from the pending set therefore does not delay the write — it **destroys** it. The only recovery is an unrelated future mutation of the *same* field, or a clean quit (the shutdown checkpoint writes the whole payload); a crash, kill, or forced update in between loses it for good.

The gate that trips this is `shouldSchedulePersist: () => !isDirectSshRemoteWorkspaceApplyInProgress()` (`src/renderer/src/app-shell/use-app-session-persistence.ts:89`), and it is closed for the whole snapshot apply — bounded by `SNAPSHOT_TERMINAL_RECONNECT_TIMEOUT_MS` (30s) — plus a 1s `REMOTE_WORKSPACE_SNAPSHOT_WRITE_SUPPRESS_MS` tail (`src/renderer/src/hooks/remote-workspace-snapshot-apply.ts:22-27`).

**Cross-target variant:** that flag is a module-level global, not per target. Target A reconnecting suppresses writes for every other target, so a tab closed on target B during A's apply is lost too, even though B was never involved.

### The fix

Defer, never discard.

1. `pendingChangedFields` is no longer cleared on a closed gate. It is cleared only when a write is actually issued (or on unsubscribe). It is the sole record that a mutation still owes a write, and it is bounded by `SESSION_RELEVANT_FIELDS` (31 entries).
2. The store-update early return changed from `changedFields.length === 0` to `changedFields.length === 0 && pendingChangedFields.size === 0`, so *any* subsequent store notification can wake a deferred write — not just one that touches the same field again.
3. The gate owner now emits a one-shot wake-up. `onDirectSshRemoteWorkspaceApplyWindowClosed` (`src/renderer/src/hooks/remote-workspace-snapshot-apply.ts`) fires a single `setTimeout` per apply, scheduled at the exact suppression deadline, and `use-app-session-persistence.ts` wires it into the subscriber as `subscribeToPersistGateOpen`.

Values are never deferred — only the *field selection* is. Every flush rebuilds the patch from `store.getState()`, so a deferred write publishes current post-merge state and can never resurrect a pre-apply value over what the host just sent.

#### The three hazards, and which choice addresses each

The brief called these out explicitly, so here they are one by one.

**1. No unbounded loop if the gate never opens.** Nothing in `flushPendingWrite` re-arms. A timer is armed by exactly two things: a real session-field change, or the one-shot gate-open notice. If `shouldPersistWorkspaceSession` stays false forever (a hydration failure — issue #1158 says that state must *never* be written), the pending set just sits there costing nothing: no timer, no poll, no retry budget to get wrong. Locked by the test `arms no timer while the gate stays closed`, which asserts `vi.getTimerCount() === 0` after 10s with the gate shut.

**2. No lost wake-up when the gate opens with nothing else happening.** The `shouldPersistWorkspaceSession` gate lives in store state, so its reopening *is* a store notification and (2) above catches it. The SSH gate does not: its tail expires on a wall clock with no store write behind it. That is why the notice is emitted by the gate owner rather than polled by the subscriber — it fires at the deadline, once, from the code that knows the deadline. Overlapping applies are safe: a notice that finds the window still shut returns without notifying, and the later apply schedules its own.

**3. No discarded mutation.** The pending set is retired only on the path that calls `persist`.

Deliberately *not* built: a retry chain, a backoff ladder, an attempt budget, or a re-armed poll. This subsystem produced twelve defects across five review rounds in exactly that shape earlier today. There is one timer here and it is the pre-existing debounce.

#### Performance property preserved

The comment at the top of the subscriber documents why unrelated updates (agent status, usage refreshes, title ticks) must not reset the debounce: they used to, and the eventual payload build crossed 70-110ms and tripped `setTimeout` violations. An unrelated update can now *arm* a flush when work is owed, but `if (timer !== null && changedFields.length === 0) return` stops it from ever *resetting* one. Covered by `does not let an unrelated update reset the debounce of a deferred write`.

### ELI5

Think of the app as a person writing your notes into a notebook.

Every time you change something, they jot the change on a sticky note ("tab closed"), and a moment later copy it into the notebook. But while the app is syncing with an SSH machine, the notebook is held shut for up to half a minute.

The old behavior: they'd look at the shut notebook, **throw the sticky note in the bin**, and — this is the bad part — also tick the change off their checklist as handled. So when the notebook opened again, nobody remembered anything was owed. Your closed tab came back the next time you launched the app, as if you had never closed it.

The new behavior: they keep the sticky note. When the notebook opens, they write it in. And because the notebook can open on a timer with nothing else happening to remind them, the sync itself now taps them on the shoulder when it's done.

Two things it deliberately does *not* do: it doesn't keep knocking on a notebook that stays shut (no spinning retry loop), and it doesn't write down the old value — it looks at what's true *now*, so a note written before the sync can't undo what the sync brought in.

### Fix evidence — the tests bite

Reverting `session-write-subscriber.ts` and `remote-workspace-snapshot-apply.ts` to `origin/main` and re-running the new specs, unchanged:

```
 ❯ src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts (6 tests | 5 failed) 12ms
     × writes a mutation made while the gate was closed once a later mutation reopens it 6ms
     × writes a mutation whose debounce expired inside the apply window 1ms
     × keeps an unrelated target’s tab close across another target’s apply 1ms
     × writes on the gate-open wake-up when no further store update follows 1ms
     × does not let an unrelated update reset a debounce armed by the gate-open wake-up 1ms
 ❯ src/renderer/src/lib/session-write-subscriber.test.ts (24 tests | 3 failed) 24ms
     × defers rather than drops a change made while shouldSchedulePersist returns false 2ms
     × holds a write whose change arrived while shouldSchedulePersist returned false 2ms
     × re-checks shouldSchedulePersist when a pending debounce fires 1ms
 ❯ src/renderer/src/hooks/remote-workspace-snapshot-apply-deferred-session-write.test.ts (2 tests | 2 failed) 25ms
     × lands an unrelated target’s tab close once the suppression tail expires 21ms
     × still wakes the deferred write when the wall clock steps back during the tail 3ms

⎯⎯⎯⎯⎯⎯ Failed Tests 10 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/renderer/src/hooks/remote-workspace-snapshot-apply-deferred-session-write.test.ts > session writes deferred by a direct-SSH apply > lands an unrelated target’s tab close once the suppression tail expires
AssertionError: the close made during the apply never reached disk: expected "vi.fn()" to be called 1 times, but got 0 times
 ❯ src/renderer/src/hooks/remote-workspace-snapshot-apply-deferred-session-write.test.ts:206:77
    204|       vi.advanceTimersByTime(1_200)
    205|
    206|       expect(persist, 'the close made during the apply never reached d…
       |                                                                             ^
    207|       const patch = persist.mock.calls[0][0].patch
    208|       expect(patch.closedTerminalTabTombstonesByTabId?.['tab-b']?.work…

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/10]⎯

 FAIL  src/renderer/src/hooks/remote-workspace-snapshot-apply-deferred-session-write.test.ts > session writes deferred by a direct-SSH apply > still wakes the deferred write when the wall clock steps back during the tail
AssertionError: a clock step back stranded the deferred write: expected "vi.fn()" to be called 1 times, but got 0 times
 ❯ src/renderer/src/hooks/remote-workspace-snapshot-apply-deferred-session-write.test.ts:243:72
    241|       vi.advanceTimersByTime(5_200)
    242|
    243|       expect(persist, 'a clock step back stranded the deferred write')…
       |                                                                        ^
    244|       expect(
    245|         persist.mock.calls[0][0].patch.closedTerminalTabTombstonesByTa…

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/10]⎯

 FAIL  src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts > session write subscriber defers writes across a closed persistence gate > writes a mutation made while the gate was closed once a later mutation reopens it
AssertionError: the tombstone written during the apply window was discarded, not deferred: expected undefined to deeply equal { 'closed-during-apply': { …(2) } }

- Expected:
{
  "closed-during-apply": {
    "closedAt": Any<Number>,
    "worktreeId": "wt-remote",
  },
}

+ Received:
undefined

 ❯ src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts:110:7
    108|       patch.closedTerminalTabTombstonesByTabId,
    109|       'the tombstone written during the apply window was discarded, no…
    110|     ).toEqual({
       |       ^
    111|       'closed-during-apply': {
    112|         closedAt: expect.any(Number),

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/10]⎯

 FAIL  src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts > session write subscriber defers writes across a closed persistence gate > writes a mutation whose debounce expired inside the apply window
AssertionError: the debounce fired inside the apply window and threw the mutation away: expected undefined to be 'closed-mid-debounce' // Object.is equality

- Expected:
"closed-mid-debounce"

+ Received:
undefined

 ❯ src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts:152:7
    150|       persist.mock.calls[0][0].patch.activeTabId,
    151|       'the debounce fired inside the apply window and threw the mutati…
    152|     ).toBe('closed-mid-debounce')
       |       ^
    153|     cleanup()
    154|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/10]⎯

 FAIL  src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts > session write subscriber defers writes across a closed persistence gate > keeps an unrelated target’s tab close across another target’s apply
AssertionError: target B lost a tab close because target A was mid-apply: expected undefined to deeply equal []

- Expected:
[]

+ Received:
undefined

 ❯ src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts:199:7
    197|       patch.tabsByWorktree?.['wt-target-b'],
    198|       'target B lost a tab close because target A was mid-apply'
    199|     ).toEqual([])
       |       ^
    200|     expect(patch.tabsByWorktree?.['wt-target-a']).toHaveLength(1)
    201|     expect(patch.closedTerminalTabTombstonesByTabId?.['tab-b']?.worktr…

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/10]⎯

 FAIL  src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts > session write subscriber defers writes across a closed persistence gate > writes on the gate-open wake-up when no further store update follows
AssertionError: the subscriber never registered for the gate-open wake-up: expected +0 to be 1 // Object.is equality

- Expected
+ Received

- 1
+ 0

 ❯ src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts:229:95
    227|     // The suppression tail expires on a wall clock, so nothing touche…
    228|     gateOpen = true
    229|     expect(gate.listenerCount(), 'the subscriber never registered for …
       |                                                                                               ^
    230|       1
    231|     )

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/10]⎯

 FAIL  src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts > session write subscriber defers writes across a closed persistence gate > does not let an unrelated update reset a debounce armed by the gate-open wake-up
AssertionError: an unrelated update pushed the deferred write past its debounce: expected "vi.fn()" to be called 1 times, but got 0 times
 ❯ src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts:295:7
    293|       persist,
    294|       'an unrelated update pushed the deferred write past its debounce'
    295|     ).toHaveBeenCalledTimes(1)
       |       ^
    296|     expect(persist.mock.calls[0][0].patch.activeTabId).toBe('closed-du…
    297|     cleanup()

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[7/10]⎯

 FAIL  src/renderer/src/lib/session-write-subscriber.test.ts > createSessionWriteSubscriber > defers rather than drops a change made while shouldSchedulePersist returns false
AssertionError: expected undefined to be defined
 ❯ src/renderer/src/lib/session-write-subscriber.test.ts:596:59
    594|     expect(persist).toHaveBeenCalledTimes(1)
    595|     // The suppressed first pass owed every field; only activeTabId ch…
    596|     expect(persist.mock.calls[0][0].patch.tabsByWorktree).toBeDefined()
       |                                                           ^
    597|     cleanup()
    598|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[8/10]⎯

 FAIL  src/renderer/src/lib/session-write-subscriber.test.ts > createSessionWriteSubscriber > holds a write whose change arrived while shouldSchedulePersist returned false
AssertionError: expected undefined to be 'remote-tab' // Object.is equality

- Expected:
"remote-tab"

+ Received:
undefined

 ❯ src/renderer/src/lib/session-write-subscriber.test.ts:622:56
    620|     vi.advanceTimersByTime(200)
    621|     expect(persist).toHaveBeenCalledTimes(1)
    622|     expect(persist.mock.calls[0][0].patch.activeTabId).toBe('remote-ta…
       |                                                        ^
    623|     cleanup()
    624|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[9/10]⎯

 FAIL  src/renderer/src/lib/session-write-subscriber.test.ts > createSessionWriteSubscriber > re-checks shouldSchedulePersist when a pending debounce fires
AssertionError: expected undefined to be 'wt-before-remote-pull' // Object.is equality

- Expected:
"wt-before-remote-pull"

+ Received:
undefined

 ❯ src/renderer/src/lib/session-write-subscriber.test.ts:652:61
    650|     vi.advanceTimersByTime(200)
    651|     expect(persist).toHaveBeenCalledTimes(1)
    652|     expect(persist.mock.calls[0][0].patch.activeWorktreeId).toBe('wt-b…
       |                                                             ^
    653|     cleanup()
    654|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[10/10]⎯


 Test Files  3 failed (3)
      Tests  10 failed | 22 passed (32)
   Start at  22:12:26
```

With the fix, all green:

```
 RUN  v4.1.5 /Users/nwparker/projects/orca/.claude/worktrees/agent-ae4988a06f7aa66c2


 Test Files  3 passed (3)
      Tests  32 passed (32)
   Start at  22:12:18
```

Only one case in the whole change — `arms no timer while the gate stays closed` — passes with and without the fix, by design: it is the guard rail on hazard 1 (no polling loop), not proof of the fix. The other ten bite.

The integration spec drives the real `applyDirectSshRemoteWorkspaceSnapshot` path with the real subscriber wired exactly as `use-app-session-persistence` wires it — real gate, real 1s suppression tail, real wake-up — and closes a tab on an unrelated target from inside the apply. That is requirement 3 (cross-target) end to end; the unit suite covers it at patch level too.

### Review round 1 (independent adversarial review)

An independent reviewer traced the overlapping-apply depth math, the `+1ms` tail arithmetic, re-entrancy of `persist()` into the subscriber, listener-set mutation during notification, staleness, cleanup, and StrictMode, and found **no P0/P1**. Two P2s, both fixed in this branch:

1. **The gate and its wake-up were independently optional**, so a future call site could supply `shouldSchedulePersist` without `subscribeToPersistGateOpen` and silently strand deferred writes again. They are now a single discriminated union (`SessionWritePersistGate`), so the unsafe combination does not typecheck. Call sites that reopen the gate through a store update pass an explicit no-op wake-up, which documents the choice at each site.
2. **One new test did not bite.** The debounce-reset guard never closed the gate, so it only re-exercised a pre-existing early return. It now defers a write through a closed gate, arms the flush via the gate-open wake-up, and *then* fires an unrelated update — proving the reset guard holds on the new arming path too. It fails against `origin/main`.

Also fixed: `cancels a pending debounce when shouldSchedulePersist returns false` had a stale title *and* was silently inert — it left `hydrationSucceeded` false, so the outer hydration gate short-circuited before the schedule gate was ever consulted. It now opens both flags, exercises the change-time gate for real, and asserts the deferred write lands.

### Review round 2 (second independent reviewer)

A second reviewer independently cleared backward compatibility, the remote-push path, concurrency, the SSH execution boundary, and code organization, and found **no P0/P1**. It did find a real hole in my hazard-2 claim, now fixed:

**The gate-open notice could still be dropped.** The callback skipped when `isDirectSshRemoteWorkspaceApplyInProgress()` was true, and my comment justified that with "an overlapping apply owns its own notice". That reasoning only covers `snapshotApplyDepth > 0`. The other half of the predicate is the wall-clock tail — and `delayMs` is wall-clock arithmetic handed to a *monotonic* timer, so a clock step back (NTP) can leave the deadline in the future when the timer fires. In that case the notice returned, nothing rescheduled, and the deferred write was stranded until the next store update: exactly the hole this PR exists to close.

The two halves are now separated. `depth > 0` still returns (that apply's `finally` schedules the next notice); an outstanding tail **re-arms for the time still left on it** instead of giving up. This does not reintroduce hazard 1: the deadline only moves forward and each re-arm waits the exact remainder, so the wait converges rather than polling.

`still wakes the deferred write when the wall clock steps back during the tail` covers it, and it is targeted — it fails against the *previous revision of this branch*, not just against `main`:

```
     × still wakes the deferred write when the wall clock steps back during the tail 5ms
AssertionError: a clock step back stranded the deferred write: expected "vi.fn()" to be called 1 times, but got 0 times
```

The same reviewer flagged the integration spec's ~1.2s of real-clock waiting as load-sensitive. It now runs on fake timers (vitest fakes `Date` too, so the `Date.now() < suppressUntil` comparison stays coherent): the file's test time went from ~1.4s of wall-clock waiting to 22ms, and the `vi.waitFor` timeout race is gone entirely.

### Backward compatibility

- **No wire change.** No RPC params, no stream opcodes, no schema fields added or altered. `docs/reference/remote-wire-compatibility.md` third case (what the host is *published*) does apply in one narrow sense and it is the point of the change: a tab close made during the apply window now reaches the host on the next debounced push, where it previously vanished. The payload shape is identical, it is scoped per target by the existing `exportSessionForTarget`, and an older host sees an ordinary session patch.
- **No persisted-schema change.** `closedTerminalTabTombstonesByTabId` and every other field keep their shapes; the fix only changes *when* a patch is emitted.
- **Rollback is safe.** Downgrading to a build without this change reverts to the old drop-on-suppression behavior; nothing new is written to disk that an older client cannot read.
- **New optional dep only.** `subscribeToPersistGateOpen` is optional on `SessionWriteSubscriberDeps`; existing call sites and tests that omit it behave exactly as before.
- **No mobile-facing surface touched.** Renderer session persistence only.
- **No platform-dependent code.** No paths, shells, processes, or native modules involved.

### Verification

- `pnpm tc` — clean
- `oxlint` + `oxfmt --check` on all six changed files — clean
- `pnpm run check:code-quality:changed` — `0 new finding(s) across 6 changed file(s)`, React Doctor clean
- `pnpm test src/renderer/src/lib src/renderer/src/app-shell src/renderer/src/hooks` — 610 files, 5404 passed
- `pnpm test src/renderer/src/store` — 304 files, 2983 passed
- No `max-lines` disable added; `session-write-subscriber.ts` stays well inside the 300-line budget.

### On e2e

`tests/e2e/ssh-cold-hydration-gap-tab-seeding.spec.ts` was evaluated and deliberately not extended. Hitting this bug e2e requires closing a tab *inside* the suppression window, and the window's state is renderer-module-internal — a spec cannot observe it without a new test hook, so the timing would be a guess. The neighbouring `remote-workspace-snapshot-local-tab-survival.test.ts` documents the same trade for a sibling bug ("the end-to-end version of the same scenario only reproduces about one run in three"). The new integration spec drives the real apply path deterministically instead.
