### PR TITLE
fix(terminal): a restarted relay must not hand a new tab a dead PTY's exit

### DIFF
--- a/src/renderer/src/components/terminal-pane/ipc-pty-connect.ts
+++ b/src/renderer/src/components/terminal-pane/ipc-pty-connect.ts
@@ -3,6 +3,8 @@ import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import { ensurePtyDispatcher } from './pty-dispatcher'
 import {
   clearConsumedPreHandlerPtyExit,
+  currentPreHandlerPtySequence,
+  discardPreHandlerPtyStateFromPriorIncarnation,
   hasPreHandlerPtyExit,
   isPreHandlerPtyStateDiscarded
 } from './pty-pre-handler-buffer'
@@ -68,6 +70,10 @@ export async function connectIpcPty(
     if (options.shouldContinue && !options.shouldContinue()) {
       return
     }
+    // Why read it before the request and not after: a redeployed SSH relay renumbers from pty-1, so
+    // this spawn can be handed an id a dead PTY used to own. State dated at or below this fence was
+    // recorded before we asked for a PTY, so it belongs to that earlier owner, not to us.
+    const priorIncarnationFence = currentPreHandlerPtySequence()
     const spawnResult = await spawnIpcPty(transportOptions, options, admittedSessionId)
     const retireFreshSpawn = async (): Promise<void> => {
       if (!spawnResult.isReattach && !spawnResult.coldRestore) {
@@ -87,6 +93,11 @@ export async function connectIpcPty(
       context.getCallbacks().onReattachDetermined?.()
     }
 
+    if (!admittedSessionId && !spawnResult.isReattach && !spawnResult.coldRestore) {
+      // Why only a fresh spawn: a reattach deliberately re-owns an id that already existed, so its
+      // buffered exit is the real thing. A fresh spawn's PTY did not exist yet.
+      discardPreHandlerPtyStateFromPriorIncarnation(spawnResult.id, priorIncarnationFence)
+    }
     context.bind(spawnResult.id)
     if (!spawnResult.isReattach && !spawnResult.coldRestore) {
       onPtySpawn?.(spawnResult.id)

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
@@ -5,9 +5,11 @@ import {
   clearConsumedPreHandlerPtyExit,
   clearPreHandlerPtyState,
   consumePreHandlerPtyState,
+  currentPreHandlerPtySequence,
   drainPreHandlerPtyData,
   drainPreHandlerPtyExit,
   discardPreHandlerPtyState,
+  discardPreHandlerPtyStateFromPriorIncarnation,
   hasPreHandlerPtyExit,
   replayPreHandlerPtyData
 } from './pty-pre-handler-buffer'
@@ -16,6 +18,7 @@ const RESCAN_PTY_ID = 'pty-pre-handler-rescan'
 const TRIM_PTY_ID = 'pty-pre-handler-trim'
 const EXIT_PTY_ID = 'pty-pre-handler-exit'
 const CAPPED_EXIT_PTY_IDS = Array.from({ length: 65 }, (_, index) => `pty-capped-exit-${index}`)
+const RECYCLED_PTY_ID = 'ssh:target@@pty-2'
 
 describe('pre-handler PTY buffer', () => {
   afterEach(() => {
@@ -25,6 +28,7 @@ describe('pre-handler PTY buffer', () => {
     for (const ptyId of CAPPED_EXIT_PTY_IDS) {
       clearPreHandlerPtyState(ptyId)
     }
+    clearPreHandlerPtyState(RECYCLED_PTY_ID)
   })
 
   it('does not rescan historical chunks while buffering small startup output', () => {
@@ -186,5 +190,52 @@ describe('pre-handler PTY buffer', () => {
     expect(exits).toHaveLength(64)
     expect(exits).not.toContain(0)
     expect(exits).toContain(64)
+  })
+
+  // A redeployed SSH relay renumbers from pty-1, so a fresh spawn is handed an id whose dead owner
+  // left an exit here. Applying it reports the brand-new shell as already exited and the pane never
+  // binds a PTY at all — the tab comes up blank forever.
+  it("drops a recycled id's exit recorded before the fresh spawn was requested", () => {
+    bufferPreHandlerPtyExit(RECYCLED_PTY_ID, 0)
+    bufferPreHandlerPtyData(RECYCLED_PTY_ID, 'output from the dead shell')
+
+    const fence = currentPreHandlerPtySequence()
+    discardPreHandlerPtyStateFromPriorIncarnation(RECYCLED_PTY_ID, fence)
+
+    const exit = vi.fn()
+    const data = vi.fn()
+    expect(hasPreHandlerPtyExit(RECYCLED_PTY_ID)).toBe(false)
+    drainPreHandlerPtyExit(RECYCLED_PTY_ID, exit)
+    drainPreHandlerPtyData(RECYCLED_PTY_ID, data)
+    expect(exit).not.toHaveBeenCalled()
+    expect(data).not.toHaveBeenCalled()
+  })
+
+  it('keeps state recorded after the fence, so a shell that dies instantly still reports its exit', () => {
+    const fence = currentPreHandlerPtySequence()
+    bufferPreHandlerPtyExit(RECYCLED_PTY_ID, 1)
+    bufferPreHandlerPtyData(RECYCLED_PTY_ID, 'startup bytes')
+
+    discardPreHandlerPtyStateFromPriorIncarnation(RECYCLED_PTY_ID, fence)
+
+    const exit = vi.fn()
+    const data = vi.fn()
+    expect(hasPreHandlerPtyExit(RECYCLED_PTY_ID)).toBe(true)
+    // Data first: draining the exit transfers ownership and clears the buffered bytes with it.
+    drainPreHandlerPtyData(RECYCLED_PTY_ID, data)
+    drainPreHandlerPtyExit(RECYCLED_PTY_ID, exit)
+    expect(exit).toHaveBeenCalledWith(1)
+    expect(data).toHaveBeenCalledWith('startup bytes', undefined)
+  })
+
+  it('re-admits exits for a recycled id whose prior incarnation was consumed', () => {
+    consumePreHandlerPtyState(RECYCLED_PTY_ID)
+
+    discardPreHandlerPtyStateFromPriorIncarnation(RECYCLED_PTY_ID, currentPreHandlerPtySequence())
+    bufferPreHandlerPtyExit(RECYCLED_PTY_ID, 3)
+
+    const exit = vi.fn()
+    drainPreHandlerPtyExit(RECYCLED_PTY_ID, exit)
+    expect(exit).toHaveBeenCalledWith(3)
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
@@ -11,10 +11,17 @@ type BufferedPreHandlerPtyState = {
   chunks: BufferedPreHandlerPtyData[]
   head: number
   bytes: number
+  /** Sequence of the newest chunk, used to fence state left by a prior incarnation of a reused id. */
+  sequence: number
+}
+
+type BufferedPreHandlerPtyExit = {
+  code: number
+  sequence: number
 }
 
 const preHandlerPtyData = new Map<string, BufferedPreHandlerPtyState>()
-const preHandlerPtyExit = new Map<string, number>()
+const preHandlerPtyExit = new Map<string, BufferedPreHandlerPtyExit>()
 const consumedPreHandlerPtyExits = new Map<string, true>()
 const discardedPreHandlerPtyStates = new Map<string, ReturnType<typeof setTimeout>>()
 const DISCARDED_PRE_HANDLER_PTY_STATE_TTL_MS = 60_000
@@ -30,6 +37,21 @@ const PRE_HANDLER_PTY_EXIT_MAX_PTYS = 64
 // frozen-pane detach/attach race) — leave a breadcrumb for trace capture.
 const PRE_HANDLER_PTY_DATA_WARN_BYTES = 64 * 1024
 const warnedLostHandlerPtyIds = new Set<string>()
+
+// Why: pty ids are NOT unique over time — a redeployed SSH relay renumbers from pty-1, so a fresh
+// spawn can be handed an id whose previous incarnation left buffered state here. A monotonic
+// counter dates every record so a spawn can tell "arrived before I asked for this PTY" (someone
+// else's) from "arrived while it was starting" (mine).
+let preHandlerPtySequence = 0
+
+function nextPreHandlerPtySequence(): number {
+  preHandlerPtySequence += 1
+  return preHandlerPtySequence
+}
+
+export function currentPreHandlerPtySequence(): number {
+  return preHandlerPtySequence
+}
 
 export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyDataMeta): void {
   if (discardedPreHandlerPtyStates.has(ptyId)) {
@@ -51,9 +73,10 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
       : meta
   let state = preHandlerPtyData.get(ptyId)
   if (!state) {
-    state = { chunks: [], head: 0, bytes: 0 }
+    state = { chunks: [], head: 0, bytes: 0, sequence: 0 }
     preHandlerPtyData.set(ptyId, state)
   }
+  state.sequence = nextPreHandlerPtySequence()
   state.chunks.push({
     data: chunk.data,
     bytes: chunk.bytes,
@@ -117,7 +140,31 @@ export function bufferPreHandlerPtyExit(ptyId: string, code: number): void {
       preHandlerPtyExit.delete(oldestPtyId)
     }
   }
-  preHandlerPtyExit.set(ptyId, code)
+  preHandlerPtyExit.set(ptyId, { code, sequence: nextPreHandlerPtySequence() })
+}
+
+/** Drop pre-handler state a freshly spawned PTY inherited from an earlier owner of its id.
+ *
+ *  `fenceSequence` is read before the spawn request leaves the renderer, so anything at or below it
+ *  was recorded when this PTY did not yet exist and cannot describe it. Bytes and exits recorded
+ *  after the fence are kept: that is the real pre-attach race (a shell that dies instantly, or
+ *  writes before the pane registers its handler) and losing it would blank a legitimate pane. */
+export function discardPreHandlerPtyStateFromPriorIncarnation(
+  ptyId: string,
+  fenceSequence: number
+): void {
+  const exit = preHandlerPtyExit.get(ptyId)
+  if (exit && exit.sequence <= fenceSequence) {
+    preHandlerPtyExit.delete(ptyId)
+  }
+  const data = preHandlerPtyData.get(ptyId)
+  if (data && data.sequence <= fenceSequence) {
+    preHandlerPtyData.delete(ptyId)
+    warnedLostHandlerPtyIds.delete(ptyId)
+  }
+  // Why: the id now names a different, live PTY, so a prior incarnation's consumed/discarded marks
+  // must not suppress this one's own exit — the same admission boundary a same-id reattach gets.
+  clearConsumedPreHandlerPtyExit(ptyId)
 }
 
 // Why: primary handlers and pane-less parked owners have fully handled this
@@ -173,13 +220,13 @@ export function hasPreHandlerPtyExit(ptyId: string): boolean {
 }
 
 export function drainPreHandlerPtyExit(ptyId: string, handler: (code: number) => void): void {
-  const code = preHandlerPtyExit.get(ptyId)
-  if (code === undefined) {
+  const exit = preHandlerPtyExit.get(ptyId)
+  if (exit === undefined) {
     return
   }
   preHandlerPtyExit.delete(ptyId)
   try {
-    handler(code)
+    handler(exit.code)
   } finally {
     // Why: draining transfers ownership to this handler. Even when it throws,
     // a duplicate exit must not become a new pre-handler event.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​64 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 |

<!-- /orca-pr-loc -->

## What was red

`tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts:178` — *"does not resurrect tabs whose kill was lost to a killed relay daemon"* — the end-to-end oracle for the headline user report (*"every day I come back to my SSH session there are more tabs"*, STA-4658 / #16752).

It failed in **SETUP**, never reaching a resurrection assertion:

```
Error: Active terminal pane did not receive a PTY binding
    at waitForActivePanePtyId (tests/e2e/helpers/terminal.ts:70:3)
    at createRemoteTerminalTab (tests/e2e/helpers/docker-ssh-relay-terminal-tabs.ts:23:3)
    at runResurrectionCycles (tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts:124:7)
```

Reproduced locally against real Docker (`pnpm test:e2e:ssh-docker`) and confirmed red in CI, on this branch's merge-base and on `main`. Its sibling at `:190` passed, so the harness itself was fine.

## Root cause — this was a PRODUCT bug, not a test problem

`src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts:24` keeps a process-global map of PTY exits that arrived with **no registered pane handler**, keyed on the PTY id *alone*:

```ts
const preHandlerPtyExit = new Map<string, number>()
```

PTY ids are **not unique over time**. A redeployed SSH relay renumbers from `pty-1`. So:

1. A tab closed while the transport is down leaves an exit for `ssh:<target>@@pty-2` buffered — its pane is already unmounted, so nothing consumes it.
2. The relay daemon dies and Orca redeploys it. The counter restarts at `pty-1`.
3. The user opens a **new** tab. The restarted relay mints a genuinely new shell and hands it the recycled id `ssh:<target>@@pty-2`.
4. `src/renderer/src/components/terminal-pane/ipc-pty-connect.ts:95` does `handlers.registerExit(spawnResult.id)`, which finds the **dead previous incarnation's** buffered exit and returns `exitedBeforeAttach: true`.
5. The pane treats the brand-new, live shell as already dead. `data-pty-id` is never set. The tab is blank forever.

### Evidence (instrumented Docker run)

The host really did create the shell — the relay had a live child for it:

```
946     1 node  relay.js --detached --grace-time 60 ...
1177  946 bash  /bin/bash --rcfile /root/.orca-relay/shell-ready/bash/rcfile
1192  946 bash  /bin/bash --rcfile /root/.orca-relay/shell-ready/bash/rcfile
```

Main resolved the spawn normally:

```
[orca-diag] pty:spawn IN  tab=874c4d79-… leaf=0e054bd9-… session=undefined conn=ssh-…
[orca-diag] spawnFreshSshPty resolved relayId=pty-2 appId=ssh:…@@pty-2 tab=874c4d79-…
[orca-diag] pty:spawn OUT tab=874c4d79-… id=ssh:…@@pty-2
```

The renderer threw that live shell away:

```
pane=1 tab=874c4d79-… SPAWN RESOLVED raw={"id":"ssh:…@@pty-2","exitedBeforeAttach":true} genMatch=true
```

…while the SSH target reported `status: "connected"`. Nothing was down, nothing was racing — the client misattributed a dead PTY's exit to a live one.

**Why the sibling test passes:** an orderly `ssh.disconnect` never kills the remote relay, so ids are never renumbered and never collide.

### User-facing impact

Kill or crash the relay daemon (host reboot, network partition, laptop sleep, relay crash) and close a tab in that window — the **next** terminal tab you open on that host comes up permanently dead. Silent: no error, just a blank pane. The same stale-id reuse also let a dead PTY's buffered **bytes** paint into the new pane.

## The fix

Date every buffered record with a monotonic sequence, and fence a fresh spawn against it.

- `pty-pre-handler-buffer.ts`: buffered exits and buffered data now carry a `sequence`; new `currentPreHandlerPtySequence()` and `discardPreHandlerPtyStateFromPriorIncarnation(ptyId, fenceSequence)`.
- `ipc-pty-connect.ts:76` reads the fence **before** the spawn request leaves the renderer; `:99` applies it once the id comes back, for fresh spawns only.

State recorded at or below the fence was recorded when this PTY did not yet exist, so it belongs to the id's earlier owner and is dropped. State recorded *after* the fence is kept — that is the genuine pre-attach race (a shell that dies instantly, or writes before the pane registers its handler), and losing it would blank a legitimate pane. Reattach and cold-restore are untouched: they deliberately re-own an id that already existed, so their buffered exit is the real thing.

Renderer-local only — no IPC shape change, no relay protocol change, nothing persisted, so no remote wire-compatibility surface.

### ELI5

Terminals on a remote machine get numbered tickets: shell #1, shell #2. When the remote helper program restarts, it forgets everything and starts handing out tickets from #1 again.

Orca had a lost-and-found box for "this shell died" notes, filed by ticket number. An old note saying *"shell #2 died"* was still sitting in the box. Then you opened a new terminal, the restarted helper gave it ticket #2, Orca checked the box, found the old note, and concluded your brand-new terminal was already dead. So it showed you an empty black rectangle — even though a perfectly good shell was running on the other end, waiting.

The fix stamps every note with a timestamp. When a new terminal is created, Orca ignores any note written *before* it asked for that terminal, because a note about something that didn't exist yet cannot be about it. Notes written after — like a shell that really did crash a split second after starting — still count.

## Verification

`pnpm tc` clean · `oxlint` clean on changed files · `pnpm test src/renderer/src/components/terminal-pane/` → 403 files, 3899 tests passed · 3 new unit tests covering drop-before-fence, keep-after-fence, and consumed-mark re-admission.

### Three consecutive Docker E2E runs (literal output)

```
=== RUN 1 ===
  ✓  1 [electron-headless] › tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts:178:7 › SSH lost kill tab resurrection › does not resurrect tabs whose kill was lost to a killed relay daemon (40.5s)
  ✓  2 [electron-headless] › tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts:190:7 › SSH lost kill tab resurrection › does not resurrect tabs closed while the host is disconnected (41.2s)
  2 passed (1.5m)

=== RUN 2 ===
  ✓  1 [electron-headless] › tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts:178:7 › SSH lost kill tab resurrection › does not resurrect tabs whose kill was lost to a killed relay daemon (39.9s)
  ✓  2 [electron-headless] › tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts:190:7 › SSH lost kill tab resurrection › does not resurrect tabs closed while the host is disconnected (38.6s)
  2 passed (1.5m)

=== RUN 3 ===
  ✓  1 [electron-headless] › tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts:178:7 › SSH lost kill tab resurrection › does not resurrect tabs whose kill was lost to a killed relay daemon (40.0s)
  ✓  2 [electron-headless] › tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts:190:7 › SSH lost kill tab resurrection › does not resurrect tabs closed while the host is disconnected (40.7s)
  2 passed (1.5m)
```

Both tests in the file, three times, no retries. The oracle for the tab-accumulation fix now actually runs — and its resurrection assertions pass, so #16752's fix is confirmed end-to-end rather than merely assumed.

## Residual risk

The fence catches stale state recorded before the spawn request. It would not catch a stale exit for a recycled id that arrives *after* the request was dispatched — a delayed duplicate crossing the spawn. Closing that window exactly needs the buffer keyed on PTY incarnation id, which means threading `incarnationId` through the `pty:exit` IPC. Larger change, deliberately not taken on release day. The observed failure records the stale exit during the reconnect, well before the next tab exists.
