### PR TITLE
feat(editor): add "Open anyway" for oversized rich Markdown files (#16964)

### DIFF
--- a/src/renderer/src/components/editor/EditorContent.monaco-lifecycle.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.monaco-lifecycle.test.tsx
@@ -122,6 +122,9 @@ vi.mock('@/store', () => ({
     (selector: (state: Record<string, unknown>) => unknown) =>
       selector({
         worktreesByRepo: {},
+        settings: {},
+        markdownRichModeSizeOverride: {},
+        setMarkdownRichModeSizeOverride: vi.fn(),
         openFile: vi.fn(),
         openMarkdownPreview: vi.fn(),
         openConflictReviewFile: vi.fn(),

--- a/src/renderer/src/components/editor/EditorMarkdownFileSurface.tsx
+++ b/src/renderer/src/components/editor/EditorMarkdownFileSurface.tsx
@@ -1,5 +1,9 @@
 import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
 import type { MarkdownViewMode, OpenFile } from '@/store/slices/editor'
+import { Button } from '@/components/ui/button'
+import { RICH_MARKDOWN_MAX_SIZE_BYTES } from '../../../../shared/constants'
+import { formatBytes } from '../status-bar/workspace-space-format'
 import { MarkdownPreview, RichMarkdownEditor } from './editor-lazy-views'
 import { exceedsMarkdownRichModeSizeLimit } from './markdown-rich-size-limit'
 import { extractFrontMatter, prependFrontMatter } from './markdown-frontmatter'
@@ -41,9 +45,11 @@ export function EditorMarkdownFileSurface({
   handleDirtyStateHint: (dirty: boolean) => void
   monacoEditor: React.JSX.Element
 }): React.JSX.Element {
+  const sizeOverridden = useAppStore((s) => s.markdownRichModeSizeOverride[activeFile.id] === true)
+  const setSizeOverride = useAppStore((s) => s.setMarkdownRichModeSizeOverride)
   const richModeUnsupportedMessage = getMarkdownRichModeUnsupportedMessage(currentContent)
   const renderMode = getMarkdownRenderMode({
-    exceedsRichModeSizeLimit: exceedsMarkdownRichModeSizeLimit(currentContent),
+    exceedsRichModeSizeLimit: !sizeOverridden && exceedsMarkdownRichModeSizeLimit(currentContent),
     hasRichModeUnsupportedContent: richModeUnsupportedMessage !== null,
     viewMode: mdViewMode
   })
@@ -52,13 +58,30 @@ export function EditorMarkdownFileSurface({
     return <div className="h-full min-h-0">{monacoEditor}</div>
   }
   if (renderMode === 'source' && mdViewMode === 'rich') {
+    // Why: only a size fallback is recoverable — unsupported syntax would round-trip badly, so it gets no override.
+    const isSizeFallback = richModeUnsupportedMessage === null
     const richFallbackMessage =
       richModeUnsupportedMessage ??
-      'File is too large for rich editing. Showing source mode instead.'
+      translate(
+        'editor.richMarkdown.tooLarge',
+        'File is larger than the {{limit}} rich editing limit. Showing source mode instead.',
+        { limit: formatBytes(RICH_MARKDOWN_MAX_SIZE_BYTES) }
+      )
     return (
       <div className="flex h-full min-h-0 flex-col">
-        <div className="border-b border-border/60 bg-blue-500/10 px-3 py-2 text-xs text-blue-950 dark:text-blue-100">
-          {richFallbackMessage}
+        <div className="flex items-center gap-3 border-b border-border/60 bg-blue-500/10 px-3 py-2 text-xs text-blue-950 dark:text-blue-100">
+          <span className="min-w-0 flex-1">{richFallbackMessage}</span>
+          {isSizeFallback ? (
+            <Button
+              type="button"
+              variant="secondary"
+              size="xs"
+              className="shrink-0"
+              onClick={() => setSizeOverride(activeFile.id, true)}
+            >
+              {translate('editor.richMarkdown.openAnyway', 'Open anyway')}
+            </Button>
+          ) : null}
         </div>
         <div className="min-h-0 flex-1 h-full">{monacoEditor}</div>
       </div>

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -62,6 +62,7 @@ function EditorPanelInner({
   )
   const markdownViewMode = useAppStore((s) => s.markdownViewMode)
   const setMarkdownViewMode = useAppStore((s) => s.setMarkdownViewMode)
+  const markdownRichModeSizeOverride = useAppStore((s) => s.markdownRichModeSizeOverride)
   const editorViewMode = useAppStore((s) => s.editorViewMode)
   const setEditorViewMode = useAppStore((s) => s.setEditorViewMode)
   const openFile = useAppStore((s) => s.openFile)
@@ -234,6 +235,7 @@ function EditorPanelInner({
     gitStatusEntries,
     gitBranchEntries,
     markdownViewMode,
+    markdownRichModeSizeOverride,
     isChangesMode,
     canOpenWorkspaceFileBrowser
   })

--- a/src/renderer/src/components/editor/editor-panel-render-model.test.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.test.ts
@@ -31,6 +31,7 @@ function renderModel(args: {
   fileContents?: Record<string, FileContent>
   editorDrafts?: Record<string, string>
   markdownViewMode?: Record<string, 'source' | 'rich' | 'preview'>
+  markdownRichModeSizeOverride?: Record<string, boolean>
   isChangesMode?: boolean
   gitStatusByWorktree?: Record<string, GitStatusEntry[]>
 }) {
@@ -42,6 +43,7 @@ function renderModel(args: {
     gitStatusEntries: args.gitStatusByWorktree?.[activeFile.worktreeId],
     gitBranchEntries: undefined,
     markdownViewMode: args.markdownViewMode ?? {},
+    markdownRichModeSizeOverride: args.markdownRichModeSizeOverride ?? {},
     isChangesMode: args.isChangesMode ?? false,
     canOpenWorkspaceFileBrowser: true
   })
@@ -76,6 +78,7 @@ describe('getEditorPanelRenderModel HTML preview affordance', () => {
       gitStatusEntries: undefined,
       gitBranchEntries: undefined,
       markdownViewMode: {},
+      markdownRichModeSizeOverride: {},
       isChangesMode: false,
       canOpenWorkspaceFileBrowser: false
     })
@@ -168,10 +171,32 @@ describe('getEditorPanelRenderModel markdown export affordance', () => {
   it('disables rich export when a multibyte character crosses the byte limit', () => {
     const model = renderModel({
       markdownViewMode: { '/repo/README.md': 'rich' },
-      editorDrafts: { '/repo/README.md': `${'a'.repeat(RICH_MARKDOWN_MAX_SIZE_BYTES)}\u00e9` }
+      editorDrafts: {
+        '/repo/README.md': `${'a'.repeat(RICH_MARKDOWN_MAX_SIZE_BYTES)}\u00e9`
+      }
     })
 
     expect(model.shouldShowMarkdownExportAction).toBe(true)
+    expect(model.canExportMarkdownToPdf).toBe(false)
+  })
+
+  it('keeps rich mode for an oversized file the user chose to open anyway', () => {
+    const model = renderModel({
+      markdownViewMode: { '/repo/README.md': 'rich' },
+      editorDrafts: { '/repo/README.md': 'a'.repeat(RICH_MARKDOWN_MAX_SIZE_BYTES + 1) },
+      markdownRichModeSizeOverride: { '/repo/README.md': true }
+    })
+
+    expect(model.canExportMarkdownToPdf).toBe(true)
+  })
+
+  it('scopes the open-anyway override to its own file', () => {
+    const model = renderModel({
+      markdownViewMode: { '/repo/README.md': 'rich' },
+      editorDrafts: { '/repo/README.md': 'a'.repeat(RICH_MARKDOWN_MAX_SIZE_BYTES + 1) },
+      markdownRichModeSizeOverride: { '/repo/OTHER.md': true }
+    })
+
     expect(model.canExportMarkdownToPdf).toBe(false)
   })
 

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -25,6 +25,7 @@ type EditorPanelRenderModelParams = {
   gitStatusEntries: StoreState['gitStatusByWorktree'][string] | undefined
   gitBranchEntries: StoreState['gitBranchChangesByWorktree'][string] | undefined
   markdownViewMode: StoreState['markdownViewMode']
+  markdownRichModeSizeOverride: StoreState['markdownRichModeSizeOverride']
   isChangesMode: boolean
   canOpenWorkspaceFileBrowser: boolean
 }
@@ -36,6 +37,7 @@ export function getEditorPanelRenderModel({
   gitStatusEntries,
   gitBranchEntries,
   markdownViewMode,
+  markdownRichModeSizeOverride,
   isChangesMode,
   canOpenWorkspaceFileBrowser
 }: EditorPanelRenderModelParams) {
@@ -130,7 +132,9 @@ export function getEditorPanelRenderModel({
   const inlineMarkdownRenderMode =
     activeFile.mode === 'edit' && inlineMarkdownContent !== null
       ? getMarkdownRenderMode({
-          exceedsRichModeSizeLimit: exceedsMarkdownRichModeSizeLimit(inlineMarkdownContent),
+          exceedsRichModeSizeLimit:
+            markdownRichModeSizeOverride[activeFile.id] !== true &&
+            exceedsMarkdownRichModeSizeLimit(inlineMarkdownContent),
           hasRichModeUnsupportedContent:
             getMarkdownRichModeUnsupportedMessage(inlineMarkdownContent) !== null,
           viewMode: mdViewMode

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -100,6 +100,12 @@
       "findUnavailable": "Find in page is not available while this page streams from the remote host."
     }
   },
+  "editor": {
+    "richMarkdown": {
+      "tooLarge": "File is larger than the {{limit}} rich editing limit. Showing source mode instead.",
+      "openAnyway": "Open anyway"
+    }
+  },
   "githubChecks": {
     "retrying": "Retrying…"
   },

--- a/src/renderer/src/store/slices/editor-rich-markdown-size-override.test.ts
+++ b/src/renderer/src/store/slices/editor-rich-markdown-size-override.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createEditorStore } from './editor-slice-test-harness'
+
+const { toastErrorMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: toastErrorMock }
+}))
+
+const { notifyHostOfMirroredEditorCloseMock } = vi.hoisted(() => ({
+  notifyHostOfMirroredEditorCloseMock: vi.fn()
+}))
+vi.mock('@/runtime/close-mirrored-editor-tab', () => ({
+  notifyHostOfMirroredEditorClose: (...args: unknown[]) =>
+    notifyHostOfMirroredEditorCloseMock(...args)
+}))
+
+function openMarkdown(store: ReturnType<typeof createEditorStore>, filePath: string): void {
+  store.getState().openFile({
+    filePath,
+    relativePath: filePath.replace('/repo/', ''),
+    worktreeId: 'wt-1',
+    language: 'markdown',
+    mode: 'edit'
+  })
+}
+
+describe('createEditorSlice rich markdown size override', () => {
+  it('records an opt-in per file and clears it when turned back off', () => {
+    const store = createEditorStore()
+    openMarkdown(store, '/repo/big.md')
+
+    store.getState().setMarkdownRichModeSizeOverride('/repo/big.md', true)
+    expect(store.getState().markdownRichModeSizeOverride).toEqual({ '/repo/big.md': true })
+
+    store.getState().setMarkdownRichModeSizeOverride('/repo/big.md', false)
+    expect(store.getState().markdownRichModeSizeOverride).toEqual({})
+  })
+
+  it('drops the opt-in when the file is closed', async () => {
+    const store = createEditorStore()
+    openMarkdown(store, '/repo/big.md')
+    store.getState().setMarkdownRichModeSizeOverride('/repo/big.md', true)
+
+    await store.getState().closeFile('/repo/big.md')
+
+    expect(store.getState().markdownRichModeSizeOverride).toEqual({})
+  })
+
+  it('drops the opt-in for a replaced preview tab', () => {
+    const store = createEditorStore()
+
+    store.getState().openFile(
+      {
+        filePath: '/repo/docs/README.md',
+        relativePath: 'docs/README.md',
+        worktreeId: 'wt-1',
+        language: 'markdown',
+        mode: 'edit'
+      },
+      { preview: true }
+    )
+    store.getState().setMarkdownRichModeSizeOverride('/repo/docs/README.md', true)
+
+    store.getState().openFile(
+      {
+        filePath: '/repo/docs/guide.md',
+        relativePath: 'docs/guide.md',
+        worktreeId: 'wt-1',
+        language: 'markdown',
+        mode: 'edit'
+      },
+      { preview: true }
+    )
+
+    expect(store.getState().markdownRichModeSizeOverride).toEqual({})
+  })
+})

--- a/src/renderer/src/store/slices/editor/actions/close-file-action.ts
+++ b/src/renderer/src/store/slices/editor/actions/close-file-action.ts
@@ -32,6 +32,8 @@ export function createCloseFileAction(
         delete newEditorDrafts[fileId]
         const newMarkdownViewMode = { ...s.markdownViewMode }
         delete newMarkdownViewMode[fileId]
+        const newMarkdownRichModeSizeOverride = { ...s.markdownRichModeSizeOverride }
+        delete newMarkdownRichModeSizeOverride[fileId]
         const newEditorViewMode = { ...s.editorViewMode }
         delete newEditorViewMode[fileId]
         const markdownVisibilityKeys = new Set([fileId])
@@ -179,6 +181,7 @@ export function createCloseFileAction(
           activeFileIdByWorktree: newActiveFileIdByWorktree,
           activeTabTypeByWorktree: newActiveTabTypeByWorktree,
           markdownViewMode: newMarkdownViewMode,
+          markdownRichModeSizeOverride: newMarkdownRichModeSizeOverride,
           editorViewMode: newEditorViewMode,
           markdownFrontmatterVisible: newMarkdownFrontmatterVisible,
           markdownTableOfContentsVisible: newMarkdownTableOfContentsVisible,

--- a/src/renderer/src/store/slices/editor/actions/editor-draft-state.ts
+++ b/src/renderer/src/store/slices/editor/actions/editor-draft-state.ts
@@ -14,6 +14,9 @@ export type EditorDraftState = {
   clearEditorDrafts: (fileIds: string[]) => void
   markdownViewMode: Record<string, MarkdownViewMode>
   setMarkdownViewMode: (fileId: string, mode: MarkdownViewMode) => void
+  // Why: per-file opt-in to open an oversized markdown file in the rich editor despite the size limit.
+  markdownRichModeSizeOverride: Record<string, boolean>
+  setMarkdownRichModeSizeOverride: (fileId: string, enabled: boolean) => void
   editorViewMode: Record<string, EditorViewMode>
   setEditorViewMode: (fileId: string, mode: EditorViewMode) => void
   markdownFrontmatterVisible: Record<string, boolean>
@@ -69,6 +72,24 @@ export function createEditorDraftState(set: EditorSet, _get: EditorGet): EditorD
       set((s) => ({
         markdownViewMode: { ...s.markdownViewMode, [fileId]: mode }
       })),
+
+    // Rich-markdown size-limit override
+    markdownRichModeSizeOverride: {},
+    setMarkdownRichModeSizeOverride: (fileId, enabled) =>
+      set((s) => {
+        // Why: default is false — delete rather than store it so the record stays minimal.
+        if (!enabled) {
+          if (!(fileId in s.markdownRichModeSizeOverride)) {
+            return s
+          }
+          const next = { ...s.markdownRichModeSizeOverride }
+          delete next[fileId]
+          return { markdownRichModeSizeOverride: next }
+        }
+        return {
+          markdownRichModeSizeOverride: { ...s.markdownRichModeSizeOverride, [fileId]: true }
+        }
+      }),
 
     // Editor view mode (edit vs changes-diff). See EditorViewMode.
     editorViewMode: {},

--- a/src/renderer/src/store/slices/editor/actions/open-file-apply.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-file-apply.ts
@@ -174,6 +174,7 @@ export function applyOpenFileToState(
         editorDrafts: nextEditorDrafts,
         editorCursorLine: nextEditorCursorLine,
         markdownViewMode: nextMarkdownViewMode,
+        markdownRichModeSizeOverride: nextMarkdownRichModeSizeOverride,
         editorViewMode: nextEditorViewMode,
         markdownFrontmatterVisible: nextMarkdownFrontmatterVisible,
         markdownTableOfContentsVisible: nextMarkdownTableOfContentsVisible
@@ -235,6 +236,7 @@ export function applyOpenFileToState(
         editorDrafts: nextEditorDrafts,
         editorCursorLine: nextEditorCursorLine,
         markdownViewMode: nextMarkdownViewMode,
+        markdownRichModeSizeOverride: nextMarkdownRichModeSizeOverride,
         editorViewMode: nextEditorViewMode,
         markdownFrontmatterVisible: nextMarkdownFrontmatterVisible,
         markdownTableOfContentsVisible: nextMarkdownTableOfContentsVisible,

--- a/src/renderer/src/store/slices/editor/actions/recently-closed-editor-tabs.ts
+++ b/src/renderer/src/store/slices/editor/actions/recently-closed-editor-tabs.ts
@@ -77,6 +77,7 @@ export function createRecentlyClosedEditorTabs(
             activeFileId: null,
             activeTabType: 'terminal',
             markdownViewMode: {},
+            markdownRichModeSizeOverride: {},
             editorViewMode: {},
             markdownFrontmatterVisible: {},
             markdownTableOfContentsVisible: {},
@@ -92,6 +93,11 @@ export function createRecentlyClosedEditorTabs(
         )
         const newMarkdownViewMode = Object.fromEntries(
           Object.entries(s.markdownViewMode).filter(([fileId]) => remainingFileIds.has(fileId))
+        )
+        const newMarkdownRichModeSizeOverride = Object.fromEntries(
+          Object.entries(s.markdownRichModeSizeOverride).filter(([fileId]) =>
+            remainingFileIds.has(fileId)
+          )
         )
         const newEditorViewMode = Object.fromEntries(
           Object.entries(s.editorViewMode).filter(([fileId]) => remainingFileIds.has(fileId))
@@ -175,6 +181,7 @@ export function createRecentlyClosedEditorTabs(
               : s.activeBrowserTabId,
           activeTabType: browserTabsForWorktree.length > 0 ? 'browser' : 'terminal',
           markdownViewMode: newMarkdownViewMode,
+          markdownRichModeSizeOverride: newMarkdownRichModeSizeOverride,
           editorViewMode: newEditorViewMode,
           markdownFrontmatterVisible: newMarkdownFrontmatterVisible,
           markdownTableOfContentsVisible: newMarkdownTableOfContentsVisible,

--- a/src/renderer/src/store/slices/editor/actions/rekey-open-files-action.ts
+++ b/src/renderer/src/store/slices/editor/actions/rekey-open-files-action.ts
@@ -117,6 +117,10 @@ export function createRekeyOpenFilesAction(
           editorDrafts: rekeyFileIdRecord(s.editorDrafts, migrations),
           editorCursorLine: rekeyFileIdRecord(s.editorCursorLine, migrations),
           markdownViewMode: rekeyFileIdRecord(s.markdownViewMode, migrations),
+          markdownRichModeSizeOverride: rekeyFileIdRecord(
+            s.markdownRichModeSizeOverride,
+            migrations
+          ),
           editorViewMode: rekeyFileIdRecord(s.editorViewMode, migrations),
           markdownFrontmatterVisible: rekeyFileIdRecord(s.markdownFrontmatterVisible, migrations),
           markdownTableOfContentsVisible: rekeyFileIdRecord(

--- a/src/renderer/src/store/slices/editor/actions/restored-editor-owner-transition.ts
+++ b/src/renderer/src/store/slices/editor/actions/restored-editor-owner-transition.ts
@@ -205,6 +205,7 @@ export function buildRestoredEditorOwnerTransition(
         editorDrafts: rekeyFileIdRecord(s.editorDrafts, migrations),
         editorCursorLine: rekeyFileIdRecord(s.editorCursorLine, migrations),
         markdownViewMode: rekeyFileIdRecord(s.markdownViewMode, migrations),
+        markdownRichModeSizeOverride: rekeyFileIdRecord(s.markdownRichModeSizeOverride, migrations),
         editorViewMode: rekeyFileIdRecord(s.editorViewMode, migrations),
         markdownFrontmatterVisible: rekeyFileIdRecord(s.markdownFrontmatterVisible, migrations),
         markdownTableOfContentsVisible: rekeyFileIdRecord(

--- a/src/renderer/src/store/slices/editor/tabs/workspace-editor-item.ts
+++ b/src/renderer/src/store/slices/editor/tabs/workspace-editor-item.ts
@@ -77,6 +77,7 @@ export function removeEditorStateForReplacedPreview(
     | 'editorDrafts'
     | 'editorCursorLine'
     | 'markdownViewMode'
+    | 'markdownRichModeSizeOverride'
     | 'editorViewMode'
     | 'markdownFrontmatterVisible'
     | 'markdownTableOfContentsVisible'
@@ -89,6 +90,7 @@ export function removeEditorStateForReplacedPreview(
   | 'editorDrafts'
   | 'editorCursorLine'
   | 'markdownViewMode'
+  | 'markdownRichModeSizeOverride'
   | 'editorViewMode'
   | 'markdownFrontmatterVisible'
   | 'markdownTableOfContentsVisible'
@@ -110,6 +112,7 @@ export function removeEditorStateForReplacedPreview(
       editorDrafts: state.editorDrafts,
       editorCursorLine: state.editorCursorLine,
       markdownViewMode: state.markdownViewMode,
+      markdownRichModeSizeOverride: state.markdownRichModeSizeOverride,
       editorViewMode: state.editorViewMode,
       markdownFrontmatterVisible: state.markdownFrontmatterVisible,
       markdownTableOfContentsVisible: state.markdownTableOfContentsVisible
@@ -124,6 +127,11 @@ export function removeEditorStateForReplacedPreview(
     ),
     markdownViewMode: Object.fromEntries(
       Object.entries(state.markdownViewMode).filter(([fileId]) => fileId !== replacedFile.id)
+    ),
+    markdownRichModeSizeOverride: Object.fromEntries(
+      Object.entries(state.markdownRichModeSizeOverride).filter(
+        ([fileId]) => fileId !== replacedFile.id
+      )
     ),
     editorViewMode: Object.fromEntries(
       Object.entries(state.editorViewMode).filter(([fileId]) => fileId !== replacedFile.id)

--- a/src/renderer/src/store/slices/worktrees-slice-test-harness.ts
+++ b/src/renderer/src/store/slices/worktrees-slice-test-harness.ts
@@ -166,6 +166,7 @@ export function createTestStore() {
         openFiles: [],
         editorDrafts: {},
         markdownViewMode: {},
+        markdownRichModeSizeOverride: {},
         editorViewMode: {},
         showDotfilesByWorktree: {},
         expandedDirs: {},

--- a/src/renderer/src/store/slices/worktrees/teardown/remove-worktree-store-cleanup.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/remove-worktree-store-cleanup.ts
@@ -116,6 +116,10 @@ export function applyRemoveWorktreeSuccessState(
     const nextEditorDrafts = removedFileIds.size > 0 ? { ...s.editorDrafts } : s.editorDrafts
     const nextMarkdownViewMode =
       removedFileIds.size > 0 ? { ...s.markdownViewMode } : s.markdownViewMode
+    const nextMarkdownRichModeSizeOverride =
+      removedFileIds.size > 0
+        ? { ...s.markdownRichModeSizeOverride }
+        : s.markdownRichModeSizeOverride
     const nextEditorViewMode = removedFileIds.size > 0 ? { ...s.editorViewMode } : s.editorViewMode
     const nextMarkdownFrontmatterVisible =
       removedFileIds.size > 0 ? { ...s.markdownFrontmatterVisible } : s.markdownFrontmatterVisible
@@ -126,6 +130,7 @@ export function applyRemoveWorktreeSuccessState(
       for (const fileId of removedFileIds) {
         delete nextEditorDrafts[fileId]
         delete nextMarkdownViewMode[fileId]
+        delete nextMarkdownRichModeSizeOverride[fileId]
         delete nextEditorViewMode[fileId]
         delete nextMarkdownFrontmatterVisible[fileId]
         delete nextEditorCursorLine[fileId]
@@ -233,6 +238,7 @@ export function applyRemoveWorktreeSuccessState(
       activeGroupIdByWorktree: nextActiveGroupIdByWorktree,
       editorDrafts: nextEditorDrafts,
       markdownViewMode: nextMarkdownViewMode,
+      markdownRichModeSizeOverride: nextMarkdownRichModeSizeOverride,
       editorViewMode: nextEditorViewMode,
       markdownFrontmatterVisible: nextMarkdownFrontmatterVisible,
       editorCursorLine: nextEditorCursorLine,

--- a/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
@@ -169,6 +169,7 @@ export function buildWorktreePurgeState(
     // Per-file editor state for removed files
     editorDrafts: omitByFileId(s.editorDrafts),
     markdownViewMode: omitByFileId(s.markdownViewMode),
+    markdownRichModeSizeOverride: omitByFileId(s.markdownRichModeSizeOverride),
     markdownFrontmatterVisible: omitByFileId(s.markdownFrontmatterVisible),
     // Why: keyed by fileId; the bulk reconcile path previously kept these, leaking a cursor-line / view-mode entry per removed file.
     editorCursorLine: omitByFileId(s.editorCursorLine),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -83,7 +83,13 @@ export const getDefaultTerminalRightClickToPaste = (
   platform = typeof process !== 'undefined' ? process.platform : ''
 ): boolean => platform === 'win32'
 
-/** Why: ProseMirror's full-document tree lags on large files; above this, fall back to source mode (Monaco). */
+/** Why: ProseMirror renders the whole document — no virtualization — so cost is
+ *  linear in file size and every keystroke re-runs it. Measured in a packaged
+ *  build (M-series, `out/`), typing latency and the blocking mount on open:
+ *  100 KB 17 ms / 0 ms · 200 KB 46 ms / 0 ms · 300 KB 84 ms / 1.4 s ·
+ *  600 KB 265 ms / 4.2 s. 300 KB is already the knee, so this is a ceiling to
+ *  hold rather than raise; past it, fall back to source mode (Monaco) with a
+ *  per-file "Open anyway" escape hatch. Real headroom needs #7056. */
 export const RICH_MARKDOWN_MAX_SIZE_BYTES = 300 * 1024
 
 export const DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS = 1000


### PR DESCRIPTION
Closes #16964.

Markdown over 300 KB is forced into source mode with no way out. This adds the issue's simpler alternative — a per-file **"Open anyway"** — and deliberately does **not** add a setting.

## No new config

The issue proposed a `richMarkdownMaxSizeBytes` setting. I skipped it. Orca has enough config, and a knob would just push a performance judgement onto the user. The banner action covers the same need with zero settings surface.

## "Open anyway"

The fallback banner now carries an action, mirroring VS Code's `createTooLargeFileError` affordance and the in-repo `LargeDiffFallback` precedent. It is:

- **Per file** — `markdownRichModeSizeOverride`, a renderer-only record mirroring `markdownViewMode`'s full lifecycle (close, rekey, preview replacement, recently-closed, worktree removal, purge). Not persisted, so it resets when the tab closes.
- **Only for the size fallback.** Unsupported syntax (HTML/JSX, reference links, footnotes) still has no override — it would round-trip badly, which is a correctness problem, not a performance trade-off a user can accept.

The banner also names the limit it hit.

## On raising the default: measured, and no

The ask was whether the default could simply be better. I measured it in a **packaged build** (`out/`, M-series Mac) rather than guessing — per-keystroke latency and the blocking mount when the file opens:

| file size | per keystroke | blocking mount |
| --- | --- | --- |
| 100 KB | 17 ms | 0 ms |
| 200 KB | 46 ms | 0 ms |
| **300 KB** (current limit) | **84 ms** | **1.4 s** |
| 600 KB | 265 ms | 4.2 s |

ProseMirror renders the whole document with no virtualization, so cost is linear in size and **every keystroke re-runs it**. 300 KB is already the knee: past it, typing crosses the ~100 ms "feels instant" line and opening the file freezes the UI for over a second. Raising the default would ship a worse editor to everyone who edits large Markdown.

So the default stays at 300 KB — but the number is no longer folklore. The measurements are now recorded on the constant, along with the pointer to #7056 as the work that would actually buy headroom. Users who accept the trade-off for one file get "Open anyway".

## Visual proof

Packaged build, 305 KB file — the exact size from the issue report.

**Before — the fallback banner now carries the action:**

![proof-1-banner.png](https://github.com/user-attachments/assets/a9d0d501-941c-4196-9435-349a5b29f280)

**After clicking "Open anyway" — same file, rich editor, formatting toolbar and rendered tables/code blocks:**

![proof-2-rich.png](https://github.com/user-attachments/assets/0dfd8c49-b9fb-44e4-b1a3-4c666f7877b9)

## Verification

- `pnpm tc` — clean
- `pnpm test` over `src/renderer/src/components/{editor,settings}`, `src/renderer/src/store`, `src/shared` — 11413 passed, 0 failed
- `pnpm run check:code-quality:changed` — 0 new findings (code quality, type-aware, React Doctor)
- `oxlint` / `oxfmt --check` clean on changed files
- Exercised end-to-end in a packaged build via CDP: banner renders, action promotes the file to the rich editor, and the measurements above come from that same session

New tests cover the render model's override behaviour, override file-scoping, and the store record's set/clear/close/preview-replacement lifecycle.
