### PR TITLE
fix(gpu): capture hardware identity in crash reports

### DIFF
--- a/src/main/crash-reporting/gpu-crash-diagnostics.test.ts
+++ b/src/main/crash-reporting/gpu-crash-diagnostics.test.ts
@@ -1,0 +1,189 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { buildGpuCrashDiagnostics, GpuCrashDiagnosticsRecorder } from './gpu-crash-diagnostics'
+
+const FEATURE_STATUS = {
+  gpu_compositing: 'enabled',
+  rasterization: 'enabled',
+  webgl: 'enabled',
+  webgl2: 'enabled',
+  video_decode: 'enabled'
+}
+
+const BASIC_INFO = {
+  gpuDevice: [
+    {
+      active: false,
+      vendorId: 0x8086,
+      deviceId: 0x9a49,
+      vendorString: 'Intel',
+      deviceString: 'Integrated GPU'
+    },
+    {
+      active: true,
+      vendorId: 0x10de,
+      deviceId: 0x2684,
+      vendorString: 'NVIDIA',
+      deviceString: 'Discrete GPU',
+      driverVendor: 'NVIDIA',
+      driverVersion: '32.0.15.6094'
+    }
+  ],
+  auxAttributes: {
+    glVendor: 'Google Inc.',
+    glRenderer: 'ANGLE (NVIDIA, D3D11)',
+    glVersion: 'OpenGL ES 3.0'
+  }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolvePromise: ((value: T) => void) | undefined
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve
+  })
+  return {
+    promise,
+    resolve: (value) => resolvePromise?.(value)
+  }
+}
+
+describe('buildGpuCrashDiagnostics', () => {
+  it('keeps only the active GPU identity, driver, rendering backend, and feature status', () => {
+    expect(
+      buildGpuCrashDiagnostics({ info: BASIC_INFO, level: 'complete' }, FEATURE_STATUS)
+    ).toEqual({
+      gpuInfoLevel: 'complete',
+      gpuDeviceCount: 2,
+      gpuVendorId: 0x10de,
+      gpuDeviceId: 0x2684,
+      gpuVendor: 'NVIDIA',
+      gpuDevice: 'Discrete GPU',
+      gpuDriverVendor: 'NVIDIA',
+      gpuDriverVersion: '32.0.15.6094',
+      gpuGlVendor: 'Google Inc.',
+      gpuGlRenderer: 'ANGLE (NVIDIA, D3D11)',
+      gpuGlVersion: 'OpenGL ES 3.0',
+      gpuCompositingStatus: 'enabled',
+      gpuRasterizationStatus: 'enabled',
+      gpuWebglStatus: 'enabled',
+      gpuWebgl2Status: 'enabled',
+      gpuVideoDecodeStatus: 'enabled'
+    })
+  })
+
+  it('degrades malformed or unavailable GPU info without copying arbitrary fields', () => {
+    expect(
+      buildGpuCrashDiagnostics(
+        {
+          level: 'basic',
+          info: {
+            gpuDevice: [{ active: true, vendorId: Number.NaN, secret: 'do not copy' }],
+            machineModelName: 'do not copy'
+          }
+        },
+        { webgl: 'unavailable', unexpected: 'do not copy' }
+      )
+    ).toEqual({
+      gpuInfoLevel: 'basic',
+      gpuDeviceCount: 1,
+      gpuWebglStatus: 'unavailable'
+    })
+    expect(buildGpuCrashDiagnostics(null, null)).toEqual({ gpuInfoLevel: 'unavailable' })
+  })
+})
+
+describe('GpuCrashDiagnosticsRecorder', () => {
+  it('warms complete info and records one breadcrumb across a crash burst', async () => {
+    const recordBreadcrumb = vi.fn()
+    const provider = {
+      getGPUInfo: vi.fn(async (level: 'basic' | 'complete') => ({
+        ...BASIC_INFO,
+        gpuDevice: BASIC_INFO.gpuDevice.map((device) => ({
+          ...device,
+          ...(level === 'complete' ? { driverVersion: 'complete-driver' } : {})
+        }))
+      })),
+      getGPUFeatureStatus: vi.fn(() => FEATURE_STATUS)
+    }
+    const recorder = new GpuCrashDiagnosticsRecorder({ provider, recordBreadcrumb })
+
+    recorder.warm()
+    await vi.waitFor(() => {
+      expect(provider.getGPUInfo).toHaveBeenCalledTimes(2)
+    })
+    await Promise.resolve()
+    await recorder.record()
+    await recorder.record()
+
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
+    expect(recordBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gpuInfoLevel: 'complete',
+        gpuVendorId: 0x10de,
+        gpuDeviceId: 0x2684,
+        gpuDriverVersion: 'complete-driver'
+      })
+    )
+  })
+
+  it('uses promptly available basic info when complete collection is still pending', async () => {
+    const complete = deferred<unknown>()
+    const recordBreadcrumb = vi.fn()
+    const provider = {
+      getGPUInfo: vi.fn((level: 'basic' | 'complete') =>
+        level === 'basic' ? Promise.resolve(BASIC_INFO) : complete.promise
+      ),
+      getGPUFeatureStatus: vi.fn(() => FEATURE_STATUS)
+    }
+    const recorder = new GpuCrashDiagnosticsRecorder({ provider, recordBreadcrumb })
+
+    recorder.warm()
+    await recorder.record()
+
+    expect(recordBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gpuInfoLevel: 'basic',
+        gpuVendorId: 0x10de,
+        gpuDriverVersion: '32.0.15.6094'
+      })
+    )
+    complete.resolve(BASIC_INFO)
+  })
+
+  it('still records collection status when Electron rejects both GPU info calls', async () => {
+    const recordBreadcrumb = vi.fn()
+    const provider = {
+      getGPUInfo: vi.fn(async () => {
+        throw new Error('GPU access disabled')
+      }),
+      getGPUFeatureStatus: vi.fn(() => {
+        throw new Error('GPU teardown')
+      })
+    }
+    const recorder = new GpuCrashDiagnosticsRecorder({ provider, recordBreadcrumb })
+
+    recorder.warm()
+    await recorder.record()
+
+    expect(recordBreadcrumb).toHaveBeenCalledWith({ gpuInfoLevel: 'unavailable' })
+  })
+})
+
+describe('GPU crash diagnostics production wiring', () => {
+  it('records hardware diagnostics before engaging fallback from the raw GPU event', () => {
+    const source = readFileSync(join(__dirname, '..', 'index.ts'), 'utf8')
+    const listenerStart = source.indexOf("app.on('child-process-gone'")
+    expect(listenerStart).toBeGreaterThan(0)
+    const listener = source.slice(listenerStart, source.indexOf('\n  })', listenerStart))
+    expect(source).toMatch(
+      /recordBreadcrumb: \(data\) =>\s*recordDurableCrashBreadcrumb\('gpu_crash_hardware', data\)/
+    )
+    expect(listener).toMatch(
+      /isGpuFallbackCrashCandidate\([\s\S]*?gpuCrashDiagnostics\?\.record\(\)[\s\S]*?handleGpuChildCrash\(/
+    )
+  })
+})

--- a/src/main/crash-reporting/gpu-crash-diagnostics.test.ts
+++ b/src/main/crash-reporting/gpu-crash-diagnostics.test.ts
@@ -225,7 +225,7 @@ describe('GpuCrashDiagnosticsRecorder', () => {
 })
 
 describe('GPU crash diagnostics production wiring', () => {
-  it('records hardware diagnostics before engaging fallback from the raw GPU event', () => {
+  it('starts diagnostics without delaying safe-graphics fallback', () => {
     const source = readFileSync(join(__dirname, '..', 'index.ts'), 'utf8')
     const listenerStart = source.indexOf("app.on('child-process-gone'")
     expect(listenerStart).toBeGreaterThan(0)
@@ -234,7 +234,8 @@ describe('GPU crash diagnostics production wiring', () => {
       /recordBreadcrumb: \(data\) =>\s*recordDurableCrashBreadcrumb\('gpu_crash_hardware', data\)/
     )
     expect(listener).toMatch(
-      /isGpuFallbackCrashCandidate\([\s\S]*?const crashedAt = performance\.now\(\)[\s\S]*?gpuCrashDiagnostics\?\.record\(\)[\s\S]*?\.then\(\(\) =>\s*handleGpuChildCrash\(details\.reason, details\.exitCode \?\? null, crashedAt\)/
+      /const crashedAt = performance\.now\(\)[\s\S]*?void gpuCrashDiagnostics\?\.record\(\)[\s\S]*?void handleGpuChildCrash\(details\.reason, details\.exitCode \?\? null, crashedAt\)/
     )
+    expect(listener).not.toMatch(/gpuCrashDiagnostics\?\.record\(\)[\s\S]*?\.then\(/)
   })
 })

--- a/src/main/crash-reporting/gpu-crash-diagnostics.test.ts
+++ b/src/main/crash-reporting/gpu-crash-diagnostics.test.ts
@@ -97,7 +97,7 @@ describe('buildGpuCrashDiagnostics', () => {
 })
 
 describe('GpuCrashDiagnosticsRecorder', () => {
-  it('warms complete info and records one breadcrumb across a crash burst', async () => {
+  it('warms only complete info and records one breadcrumb across a crash burst', async () => {
     const recordBreadcrumb = vi.fn()
     const provider = {
       getGPUInfo: vi.fn(async (level: 'basic' | 'complete') => ({
@@ -113,11 +113,14 @@ describe('GpuCrashDiagnosticsRecorder', () => {
 
     recorder.warm()
     await vi.waitFor(() => {
-      expect(provider.getGPUInfo).toHaveBeenCalledTimes(2)
+      expect(provider.getGPUInfo).toHaveBeenCalledTimes(1)
     })
     await Promise.resolve()
     await recorder.record()
     await recorder.record()
+
+    expect(provider.getGPUInfo).toHaveBeenCalledOnce()
+    expect(provider.getGPUInfo).toHaveBeenCalledWith('complete')
 
     expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
     expect(recordBreadcrumb).toHaveBeenCalledWith(
@@ -142,6 +145,8 @@ describe('GpuCrashDiagnosticsRecorder', () => {
     const recorder = new GpuCrashDiagnosticsRecorder({ provider, recordBreadcrumb })
 
     recorder.warm()
+    expect(provider.getGPUInfo).toHaveBeenCalledOnce()
+    expect(provider.getGPUInfo).toHaveBeenCalledWith('complete')
     await recorder.record()
 
     expect(recordBreadcrumb).toHaveBeenCalledWith(
@@ -154,10 +159,56 @@ describe('GpuCrashDiagnosticsRecorder', () => {
     complete.resolve(BASIC_INFO)
   })
 
-  it('still records collection status when Electron rejects both GPU info calls', async () => {
+  it('shares pending capture work and releases it when complete info arrives first', async () => {
+    const complete = deferred<unknown>()
+    const basic = deferred<unknown>()
     const recordBreadcrumb = vi.fn()
     const provider = {
-      getGPUInfo: vi.fn(async () => {
+      getGPUInfo: vi.fn((level: 'basic' | 'complete') =>
+        level === 'basic' ? basic.promise : complete.promise
+      ),
+      getGPUFeatureStatus: vi.fn(() => FEATURE_STATUS)
+    }
+    const recorder = new GpuCrashDiagnosticsRecorder({ provider, recordBreadcrumb })
+
+    recorder.warm()
+    const first = recorder.record()
+    const second = recorder.record()
+
+    expect(second).toBe(first)
+    expect(recordBreadcrumb).not.toHaveBeenCalled()
+    complete.resolve(BASIC_INFO)
+    await first
+    expect(recordBreadcrumb).toHaveBeenCalledOnce()
+    expect(recordBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({ gpuInfoLevel: 'complete' })
+    )
+  })
+
+  it('does not let stalled GPU info block crash recovery', async () => {
+    const never = Promise.withResolvers<unknown>().promise
+    const recordBreadcrumb = vi.fn()
+    const provider = {
+      getGPUInfo: vi.fn(() => never),
+      getGPUFeatureStatus: vi.fn(() => FEATURE_STATUS)
+    }
+    const recorder = new GpuCrashDiagnosticsRecorder({
+      provider,
+      recordBreadcrumb,
+      recordTimeoutMs: 0
+    })
+
+    await recorder.record()
+
+    expect(recordBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({ gpuInfoLevel: 'unavailable' })
+    )
+  })
+
+  it('still records collection status when Electron throws during both GPU info calls', async () => {
+    const recordBreadcrumb = vi.fn()
+    const provider = {
+      getGPUInfo: vi.fn(() => {
         throw new Error('GPU access disabled')
       }),
       getGPUFeatureStatus: vi.fn(() => {
@@ -183,7 +234,7 @@ describe('GPU crash diagnostics production wiring', () => {
       /recordBreadcrumb: \(data\) =>\s*recordDurableCrashBreadcrumb\('gpu_crash_hardware', data\)/
     )
     expect(listener).toMatch(
-      /isGpuFallbackCrashCandidate\([\s\S]*?gpuCrashDiagnostics\?\.record\(\)[\s\S]*?handleGpuChildCrash\(/
+      /isGpuFallbackCrashCandidate\([\s\S]*?const crashedAt = performance\.now\(\)[\s\S]*?gpuCrashDiagnostics\?\.record\(\)[\s\S]*?\.then\(\(\) =>\s*handleGpuChildCrash\(details\.reason, details\.exitCode \?\? null, crashedAt\)/
     )
   })
 })

--- a/src/main/crash-reporting/gpu-crash-diagnostics.ts
+++ b/src/main/crash-reporting/gpu-crash-diagnostics.ts
@@ -1,0 +1,171 @@
+import type { CrashReportBreadcrumbData } from '../../shared/crash-reporting'
+
+type GpuInfoLevel = 'basic' | 'complete'
+
+type GpuInfoProvider = {
+  getGPUInfo(infoType: GpuInfoLevel): Promise<unknown>
+  getGPUFeatureStatus(): unknown
+}
+
+type GpuCrashDiagnosticsRecorderOptions = {
+  provider: GpuInfoProvider
+  recordBreadcrumb: (data: CrashReportBreadcrumbData) => void
+}
+
+type GpuInfoSnapshot = {
+  info: unknown
+  level: GpuInfoLevel
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function addString(target: CrashReportBreadcrumbData, key: string, value: unknown): void {
+  const safe = nonEmptyString(value)
+  if (safe !== undefined) {
+    target[key] = safe
+  }
+}
+
+function addNumber(target: CrashReportBreadcrumbData, key: string, value: unknown): void {
+  const safe = finiteNumber(value)
+  if (safe !== undefined) {
+    target[key] = safe
+  }
+}
+
+function activeGpuDevice(info: Record<string, unknown>): {
+  device: Record<string, unknown> | null
+  count: number
+} {
+  const devices = Array.isArray(info.gpuDevice)
+    ? info.gpuDevice.map(recordValue).filter((device) => device !== null)
+    : []
+  return {
+    device: devices.find((device) => device.active === true) ?? devices[0] ?? null,
+    count: devices.length
+  }
+}
+
+function addFeatureStatuses(details: CrashReportBreadcrumbData, featureStatus: unknown): void {
+  const status = recordValue(featureStatus)
+  if (!status) {
+    return
+  }
+  addString(details, 'gpuCompositingStatus', status.gpu_compositing)
+  addString(details, 'gpuRasterizationStatus', status.rasterization)
+  addString(details, 'gpuWebglStatus', status.webgl)
+  addString(details, 'gpuWebgl2Status', status.webgl2)
+  addString(details, 'gpuVideoDecodeStatus', status.video_decode)
+}
+
+export function buildGpuCrashDiagnostics(
+  snapshot: GpuInfoSnapshot | null,
+  featureStatus: unknown
+): CrashReportBreadcrumbData {
+  const details: CrashReportBreadcrumbData = {
+    gpuInfoLevel: snapshot?.level ?? 'unavailable'
+  }
+  addFeatureStatuses(details, featureStatus)
+  const info = recordValue(snapshot?.info)
+  if (!info) {
+    return details
+  }
+
+  const { device, count } = activeGpuDevice(info)
+  details.gpuDeviceCount = count
+  if (device) {
+    addNumber(details, 'gpuVendorId', device.vendorId)
+    addNumber(details, 'gpuDeviceId', device.deviceId)
+    addString(details, 'gpuVendor', device.vendorString)
+    addString(details, 'gpuDevice', device.deviceString)
+    addString(details, 'gpuDriverVendor', device.driverVendor)
+    addString(details, 'gpuDriverVersion', device.driverVersion)
+  }
+
+  const aux = recordValue(info.auxAttributes)
+  if (aux) {
+    addString(details, 'gpuGlVendor', aux.glVendor)
+    addString(details, 'gpuGlRenderer', aux.glRenderer)
+    addString(details, 'gpuGlVersion', aux.glVersion)
+  }
+  return details
+}
+
+/** Captures GPU identity before a crash and emits it once when a Windows GPU burst starts. */
+export class GpuCrashDiagnosticsRecorder {
+  private readonly provider: GpuInfoProvider
+  private readonly recordBreadcrumb: (data: CrashReportBreadcrumbData) => void
+  private basicInfoPromise: Promise<void> | null = null
+  private completeInfoPromise: Promise<void> | null = null
+  private basicInfo: unknown = null
+  private completeInfo: unknown = null
+  private recorded = false
+
+  constructor(options: GpuCrashDiagnosticsRecorderOptions) {
+    this.provider = options.provider
+    this.recordBreadcrumb = options.recordBreadcrumb
+  }
+
+  warm(): void {
+    void this.ensureBasicInfo()
+    void this.ensureCompleteInfo()
+  }
+
+  async record(): Promise<void> {
+    if (this.recorded) {
+      return
+    }
+    this.recorded = true
+    let featureStatus: unknown = null
+    try {
+      featureStatus = this.provider.getGPUFeatureStatus()
+    } catch {
+      // GPU teardown can race this read; device identity is still useful.
+    }
+    await this.ensureBasicInfo()
+    const snapshot = this.preferredSnapshot()
+    this.recordBreadcrumb(buildGpuCrashDiagnostics(snapshot, featureStatus))
+  }
+
+  private ensureBasicInfo(): Promise<void> {
+    this.basicInfoPromise ??= this.provider
+      .getGPUInfo('basic')
+      .then((info) => {
+        this.basicInfo = info
+      })
+      .catch(() => undefined)
+    return this.basicInfoPromise
+  }
+
+  private ensureCompleteInfo(): Promise<void> {
+    this.completeInfoPromise ??= this.provider
+      .getGPUInfo('complete')
+      .then((info) => {
+        this.completeInfo = info
+      })
+      .catch(() => undefined)
+    return this.completeInfoPromise
+  }
+
+  private preferredSnapshot(): GpuInfoSnapshot | null {
+    if (this.completeInfo !== null) {
+      return { info: this.completeInfo, level: 'complete' }
+    }
+    if (this.basicInfo !== null) {
+      return { info: this.basicInfo, level: 'basic' }
+    }
+    return null
+  }
+}

--- a/src/main/crash-reporting/gpu-crash-diagnostics.ts
+++ b/src/main/crash-reporting/gpu-crash-diagnostics.ts
@@ -1,6 +1,7 @@
 import type { CrashReportBreadcrumbData } from '../../shared/crash-reporting'
 
 type GpuInfoLevel = 'basic' | 'complete'
+const DEFAULT_GPU_CRASH_DIAGNOSTICS_WAIT_MS = 1_000
 
 type GpuInfoProvider = {
   getGPUInfo(infoType: GpuInfoLevel): Promise<unknown>
@@ -10,11 +11,36 @@ type GpuInfoProvider = {
 type GpuCrashDiagnosticsRecorderOptions = {
   provider: GpuInfoProvider
   recordBreadcrumb: (data: CrashReportBreadcrumbData) => void
+  recordTimeoutMs?: number
 }
 
 type GpuInfoSnapshot = {
   info: unknown
   level: GpuInfoLevel
+}
+
+async function waitAtMost(promise: Promise<void>, timeoutMs: number): Promise<void> {
+  const timeoutGate = Promise.withResolvers<void>()
+  const timeout = setTimeout(timeoutGate.resolve, timeoutMs)
+  try {
+    await Promise.race([promise, timeoutGate.promise])
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function waitForFirstAvailable(promises: Promise<boolean>[]): Promise<void> {
+  const availableGate = Promise.withResolvers<void>()
+  let remaining = promises.length
+  for (const promise of promises) {
+    void promise.then((available) => {
+      remaining -= 1
+      if (available || remaining === 0) {
+        availableGate.resolve()
+      }
+    })
+  }
+  return availableGate.promise
 }
 
 function recordValue(value: unknown): Record<string, unknown> | null {
@@ -107,55 +133,80 @@ export function buildGpuCrashDiagnostics(
 export class GpuCrashDiagnosticsRecorder {
   private readonly provider: GpuInfoProvider
   private readonly recordBreadcrumb: (data: CrashReportBreadcrumbData) => void
-  private basicInfoPromise: Promise<void> | null = null
-  private completeInfoPromise: Promise<void> | null = null
+  private readonly recordTimeoutMs: number
+  private basicInfoPromise: Promise<boolean> | null = null
+  private completeInfoPromise: Promise<boolean> | null = null
+  private recordingPromise: Promise<void> | null = null
   private basicInfo: unknown = null
   private completeInfo: unknown = null
-  private recorded = false
 
   constructor(options: GpuCrashDiagnosticsRecorderOptions) {
     this.provider = options.provider
     this.recordBreadcrumb = options.recordBreadcrumb
+    this.recordTimeoutMs = options.recordTimeoutMs ?? DEFAULT_GPU_CRASH_DIAGNOSTICS_WAIT_MS
   }
 
   warm(): void {
-    void this.ensureBasicInfo()
     void this.ensureCompleteInfo()
   }
 
-  async record(): Promise<void> {
-    if (this.recorded) {
-      return
-    }
-    this.recorded = true
+  record(): Promise<void> {
+    this.recordingPromise ??= this.recordOnce()
+    return this.recordingPromise
+  }
+
+  private async recordOnce(): Promise<void> {
     let featureStatus: unknown = null
     try {
       featureStatus = this.provider.getGPUFeatureStatus()
     } catch {
       // GPU teardown can race this read; device identity is still useful.
     }
-    await this.ensureBasicInfo()
+    if (this.completeInfo === null) {
+      await waitAtMost(
+        waitForFirstAvailable([this.ensureBasicInfo(), this.ensureCompleteInfo()]),
+        this.recordTimeoutMs
+      )
+    }
     const snapshot = this.preferredSnapshot()
-    this.recordBreadcrumb(buildGpuCrashDiagnostics(snapshot, featureStatus))
+    try {
+      this.recordBreadcrumb(buildGpuCrashDiagnostics(snapshot, featureStatus))
+    } catch {
+      // Diagnostics must never block safe-graphics recovery.
+    }
   }
 
-  private ensureBasicInfo(): Promise<void> {
-    this.basicInfoPromise ??= this.provider
-      .getGPUInfo('basic')
-      .then((info) => {
-        this.basicInfo = info
-      })
-      .catch(() => undefined)
+  private ensureBasicInfo(): Promise<boolean> {
+    if (this.basicInfoPromise === null) {
+      try {
+        this.basicInfoPromise = this.provider.getGPUInfo('basic').then(
+          (info) => {
+            this.basicInfo = info
+            return true
+          },
+          () => false
+        )
+      } catch {
+        this.basicInfoPromise = Promise.resolve(false)
+      }
+    }
     return this.basicInfoPromise
   }
 
-  private ensureCompleteInfo(): Promise<void> {
-    this.completeInfoPromise ??= this.provider
-      .getGPUInfo('complete')
-      .then((info) => {
-        this.completeInfo = info
-      })
-      .catch(() => undefined)
+  private ensureCompleteInfo(): Promise<boolean> {
+    if (this.completeInfoPromise === null) {
+      try {
+        this.completeInfoPromise = this.provider.getGPUInfo('complete').then(
+          (info) => {
+            this.completeInfo = info
+            return true
+          },
+          () => false
+        )
+      } catch {
+        this.completeInfoPromise = Promise.resolve(false)
+      }
+    }
     return this.completeInfoPromise
   }
 

--- a/src/main/crash-reporting/gpu-crash-fallback-field-sessions.test.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-field-sessions.test.ts
@@ -82,12 +82,14 @@ describe('1.4.190 win32 GPU-child crash cluster', () => {
     const guardStart = listener.indexOf('isGpuFallbackCrashCandidate(')
     expect(guardStart).toBeGreaterThan(0)
     expect(listener.slice(0, guardStart).match(/\bif\s*\(/g) ?? []).toHaveLength(1)
-    expect(listener).toMatch(/isGpuFallbackCrashCandidate\([\s\S]*?void handleGpuChildCrash\(/)
+    expect(listener).toMatch(
+      /isGpuFallbackCrashCandidate\([\s\S]*?gpuCrashDiagnostics\?\.record\(\)[\s\S]*?handleGpuChildCrash\(/
+    )
     // The `if (` count alone still allows `recorded && isGpuFallbackCrashCandidate(...)`, which
     // re-couples recovery to the suppression decision, so pin the guard to that check alone.
     const recoveryGuard = listener.slice(
       listener.lastIndexOf('if (', guardStart),
-      listener.indexOf('void handleGpuChildCrash(')
+      listener.indexOf('handleGpuChildCrash(')
     )
     expect(recoveryGuard).not.toMatch(/&&|\|\|/)
   })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3236,9 +3236,8 @@ void app.whenReady().then(async () => {
       })
     ) {
       const crashedAt = performance.now()
-      void (gpuCrashDiagnostics?.record() ?? Promise.resolve())
-        .catch(() => undefined)
-        .then(() => handleGpuChildCrash(details.reason, details.exitCode ?? null, crashedAt))
+      void gpuCrashDiagnostics?.record()
+      void handleGpuChildCrash(details.reason, details.exitCode ?? null, crashedAt)
     }
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -187,6 +187,7 @@ import {
 } from './crash-reporting/gpu-crash-fallback-decision'
 import { promptForGpuFallbackRestart } from './crash-reporting/gpu-fallback-restart-prompt'
 import { engageGpuFallbackAfterCrashBurst } from './crash-reporting/gpu-fallback-engagement'
+import { GpuCrashDiagnosticsRecorder } from './crash-reporting/gpu-crash-diagnostics'
 import {
   handleGpuFallbackRecoveredLaunch,
   promptForGpuFallbackRecoveredLaunch
@@ -470,6 +471,16 @@ const gpuCrashFallbackTracker = new GpuCrashFallbackTracker({
 let activeGpuFallbackMarker: GpuFallbackMarker | null = null
 let gpuFallbackActiveThisLaunch = false
 let gpuFeatureStatus: Electron.GPUFeatureStatus | null = null
+const gpuCrashDiagnostics =
+  process.platform === 'win32'
+    ? new GpuCrashDiagnosticsRecorder({
+        provider: {
+          getGPUInfo: (infoType) => app.getGPUInfo(infoType),
+          getGPUFeatureStatus: () => app.getGPUFeatureStatus()
+        },
+        recordBreadcrumb: (data) => recordDurableCrashBreadcrumb('gpu_crash_hardware', data)
+      })
+    : null
 let localPtyStartupReady: Promise<void> = Promise.resolve()
 let localPtyProviderStartupReady: Promise<void> = Promise.resolve()
 const AGENT_STATE_CRASH_BREADCRUMB_MIN_INTERVAL_MS = 30_000
@@ -556,6 +567,7 @@ function updateGpuAccelerationAboutPanel(): void {
 
 app.on('gpu-info-update', () => {
   gpuFeatureStatus = app.getGPUFeatureStatus()
+  gpuCrashDiagnostics?.warm()
   if (app.isReady()) {
     updateGpuAccelerationAboutPanel()
   }
@@ -3219,6 +3231,7 @@ void app.whenReady().then(async () => {
         reason: details.reason
       })
     ) {
+      void gpuCrashDiagnostics?.record()
       void handleGpuChildCrash(details.reason, details.exitCode ?? null)
     }
   })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1957,12 +1957,16 @@ async function presentGpuFallbackRecoveredLaunchPrompt(window: BrowserWindow): P
 }
 
 // Why: a burst of GPU child crashes means HW acceleration is unusable — persist a build-scoped marker and offer software rendering.
-async function handleGpuChildCrash(reason: string, exitCode: number | null): Promise<void> {
+async function handleGpuChildCrash(
+  reason: string,
+  exitCode: number | null,
+  crashedAt: number
+): Promise<void> {
   // Software rendering already active or shutting down: nothing more to do.
   if (gpuFallbackActiveThisLaunch || isQuitting || isServeMode) {
     return
   }
-  const result = gpuCrashFallbackTracker.recordGpuCrash(performance.now())
+  const result = gpuCrashFallbackTracker.recordGpuCrash(crashedAt)
   if (!result.shouldEngageFallback) {
     return
   }
@@ -3231,8 +3235,10 @@ void app.whenReady().then(async () => {
         reason: details.reason
       })
     ) {
-      void gpuCrashDiagnostics?.record()
-      void handleGpuChildCrash(details.reason, details.exitCode ?? null)
+      const crashedAt = performance.now()
+      void (gpuCrashDiagnostics?.record() ?? Promise.resolve())
+        .catch(() => undefined)
+        .then(() => handleGpuChildCrash(details.reason, details.exitCode ?? null, crashedAt))
     }
   })
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​245 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​243 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​243 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​240 |

<!-- /orca-pr-loc -->

## Description

Capture a narrow, privacy-bounded Windows GPU hardware snapshot when the first recoverable GPU child crash occurs, so any subsequent renderer crash report identifies the affected graphics stack.

Stacked on #16945. The base PR makes safe-graphics recovery survive a fast burst; this follow-up makes future field reports capable of narrowing the originating device/driver cohort.

## Behavior

- Warm only Electron's asynchronous complete GPU information after `gpu-info-update`; the potentially blocking basic probe now runs only after a real GPU crash.
- On the first raw Windows GPU crash candidate, start one durable `gpu_crash_hardware` breadcrumb capture concurrently with fallback.
- Safe-graphics tracking and synchronous marker persistence run immediately; they never await GPU diagnostics.
- Prefer already-cached complete information. After a crash, diagnostics wait for the first usable complete/basic snapshot for at most 1 second and share that bounded capture across concurrent crash events.
- Record only allowlisted system metadata:
  - active GPU vendor/device IDs and names
  - driver vendor/version when Electron exposes them
  - GPU count
  - GL vendor/renderer/version
  - compositing, rasterization, WebGL/WebGL2, and video-decode status
- Do not capture machine model, arbitrary GPUInfo fields, command lines, or user data.
- Emit `gpuInfoLevel=unavailable` when collection fails, preserving diagnostic honesty.

The breadcrumb uses the existing durable crash-health path and is also part of the in-memory crash snapshot. Telemetry-enabled launches therefore emit the allowlisted GPU identity on the first crash even if safe-graphics recovery prevents a later renderer report. If the renderer subsequently dies, the submitted crash report carries the same identity. No user-facing report is manufactured solely for telemetry.

## Clear fix evidence

- Deterministic startup contract: `GpuCrashDiagnosticsRecorder.warm()` calls `getGPUInfo` exactly once with `complete`; it makes **zero** basic probes on ordinary startup.
- Deterministic crash contract: concurrent crash calls return the same recording promise and write exactly one breadcrumb.
- Failure contract: synchronous provider throws, asynchronous rejection, and permanently stalled GPU-info requests all resolve to an `unavailable` breadcrumb without touching fallback.
- Timing contract: each GPU event captures `performance.now()` before either path, so the inclusive 30-second burst window is unchanged.
- Ordering contract: diagnostics start first but are not awaited; `handleGpuChildCrash` runs in the same listener turn and synchronously persists the marker at threshold before yielding to its prompt.

```text
pnpm test src/main/crash-reporting/gpu-crash-diagnostics.test.ts \
          src/main/crash-reporting/gpu-crash-fallback-field-sessions.test.ts \
          src/main/crash-reporting/gpu-crash-fallback-decision.test.ts \
          src/main/crash-reporting/gpu-fallback-engagement.test.ts
# 4 files passed; 24 tests passed

pnpm tc:node
# passed

pnpm run check:code-quality:changed
# 0 new findings; type-aware and React Doctor gates passed
```

## ELI5

When graphics crashes, Orca starts taking one small, safe “graphics ID card” snapshot while the recovery path continues immediately. Normal launches do not do the slower emergency lookup. A slow or broken Windows GPU query can lose detail, but it can never delay Safe Graphics Mode.

## Trade-offs

- GPU identity can arrive up to 1 second after the first qualifying crash. Safe-graphics marker persistence and prompting do not wait for it.
- One asynchronous complete-info request still starts after `gpu-info-update`; no startup path awaits it.
- Only allowlisted device/driver/rendering fields are retained. No machine model, command line, arbitrary GPUInfo field, or user content is added.
- No ordinary user-facing behavior changes. The only negative-path change is the bounded delay after a GPU crash.

## Adversarial review

**5 adversarial review rounds until clean.**

1. Found fallback could overtake the async breadcrumb; fixed with shared bounded recording and explicit sequencing.
2. Found a broken existing wiring assertion, crash-time distortion of the 30-second window, and needless waiting after complete info became available; fixed all three.
3. Found synchronous Electron provider throws could permanently skip fallback; provider calls now degrade to unavailable and the listener defensively continues.
4. Found that awaiting the bounded diagnostic write still consumed most of Chromium's measured 1.285-second recovery window; fallback now runs concurrently and persists its marker immediately.
5. **Clean:** no remaining recovery, relaunch-ordering, startup-latency, timestamp, timeout, concurrency, resource-retention, or changed-test finding.

Performance review independently found the unconditional basic startup probe. It was moved to the exceptional crash path; a fresh perf recheck was clean.



Wall time: 0.33 seconds