### PR TITLE
fix(browser-preview): enforce canonical runtime grants

### DIFF
--- a/src/main/browser/doc-preview-file-reader.test.ts
+++ b/src/main/browser/doc-preview-file-reader.test.ts
@@ -258,7 +258,10 @@ describe('readDocPreviewFile — paired runtime owner', () => {
     expect(await readDocPreviewFile(runtimeGrant(), 'assets/logo.png')).toMatchObject({
       ok: false,
       status: 404,
-      reason: 'unreadable'
+      reason: 'unreadable',
+      // Why: fail-closed is deliberate, so the reader is told the host is old, not that it broke.
+      message:
+        'Secure document previews require a newer Orca on the paired machine. Update it and try again.'
     })
     expect(mocks.callRuntimeEnvironment).toHaveBeenCalledOnce()
   })

--- a/src/main/browser/doc-preview-file-reader.test.ts
+++ b/src/main/browser/doc-preview-file-reader.test.ts
@@ -2,8 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   callRuntimeEnvironment: vi.fn(),
-  readFile: vi.fn(),
-  realpath: vi.fn(),
+  readDocPreviewFile: vi.fn(),
   requireSshFilesystemProvider: vi.fn()
 }))
 
@@ -15,7 +14,6 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
   requireSshFilesystemProvider: mocks.requireSshFilesystemProvider
 }))
 
-import { FileReadCapExceededError } from '../ssh/ssh-filesystem-stream-reader'
 import { docPreviewContentType, readDocPreviewFile } from './doc-preview-file-reader'
 import {
   authorizeDocPreviewDirectory,
@@ -55,11 +53,8 @@ function runtimeGrant(root = '/srv/repo/docs'): ReturnType<typeof mintDocPreview
 beforeEach(() => {
   vi.clearAllMocks()
   revokeAllDocPreviewGrants()
-  // Why: an unsymlinked host canonicalizes to the path it was given.
-  mocks.realpath.mockImplementation((path: string) => Promise.resolve(path))
   mocks.requireSshFilesystemProvider.mockReturnValue({
-    readFile: mocks.readFile,
-    realpath: mocks.realpath
+    readDocPreviewFile: mocks.readDocPreviewFile
   })
 })
 
@@ -74,12 +69,20 @@ describe('docPreviewContentType', () => {
 
 describe('readDocPreviewFile — ssh owner', () => {
   it('reads text through the SSH filesystem provider', async () => {
-    mocks.readFile.mockResolvedValue({ content: '<h1>hi</h1>', isBinary: false })
+    mocks.readDocPreviewFile.mockResolvedValue({ content: '<h1>hi</h1>', isBinary: false })
 
     const outcome = await readDocPreviewFile(sshGrant(), 'index.html')
 
     expect(mocks.requireSshFilesystemProvider).toHaveBeenCalledWith('ssh-1')
-    expect(mocks.readFile).toHaveBeenCalledWith('/home/alice/docs/index.html')
+    expect(mocks.readDocPreviewFile).toHaveBeenCalledWith({
+      boundaryPath: '/home/alice/docs',
+      entryPath: '/home/alice/docs/index.html',
+      implicitRootPath: null,
+      authorizedRootPaths: ['/home/alice/docs'],
+      targetPath: '/home/alice/docs/index.html',
+      maxTextBytes: 10 * 1024 * 1024,
+      maxBinaryBytes: 10 * 1024 * 1024
+    })
     expect(outcome).toEqual({
       ok: true,
       bytes: Buffer.from('<h1>hi</h1>', 'utf8'),
@@ -89,7 +92,7 @@ describe('readDocPreviewFile — ssh owner', () => {
 
   it('decodes a base64 binary asset', async () => {
     const png = Buffer.from([0x89, 0x50, 0x4e, 0x47])
-    mocks.readFile.mockResolvedValue({ content: png.toString('base64'), isBinary: true })
+    mocks.readDocPreviewFile.mockResolvedValue({ content: png.toString('base64'), isBinary: true })
 
     const outcome = await readDocPreviewFile(sshGrant(), 'assets/logo.png')
 
@@ -99,7 +102,7 @@ describe('readDocPreviewFile — ssh owner', () => {
   // Why: the SSH reader rejects an over-cap file rather than clamping it, so a completed read is
   // always whole and needs no truncation flag.
   it('serves a whole SSH read that carries no truncation flag', async () => {
-    mocks.readFile.mockResolvedValue({ content: '<h1>whole</h1>', isBinary: false })
+    mocks.readDocPreviewFile.mockResolvedValue({ content: '<h1>whole</h1>', isBinary: false })
 
     expect(await readDocPreviewFile(sshGrant(), 'index.html')).toMatchObject({ ok: true })
   })
@@ -107,7 +110,7 @@ describe('readDocPreviewFile — ssh owner', () => {
   // Why: the SSH read path only serves images and PDFs as bytes, so a font is refused there by
   // design — the failure must name the file type, not a stale server.
   it('reports a file type the host will not send as unsupported-asset', async () => {
-    mocks.readFile.mockResolvedValue({ content: '', isBinary: true })
+    mocks.readDocPreviewFile.mockResolvedValue({ content: '', isBinary: true })
 
     const outcome = await readDocPreviewFile(sshGrant(), 'assets/font.woff2')
 
@@ -117,55 +120,25 @@ describe('readDocPreviewFile — ssh owner', () => {
   // Why: a host that still named the type read a 0-byte file, so 0 bytes is the honest answer —
   // reporting it as a refused format would be a failure the workspace never reported.
   it('serves an empty file the host still typed instead of calling it unsupported', async () => {
-    mocks.readFile.mockResolvedValue({ content: '', isBinary: true, mimeType: 'image/png' })
+    mocks.readDocPreviewFile.mockResolvedValue({
+      content: '',
+      isBinary: true,
+      mimeType: 'image/png'
+    })
 
     const outcome = await readDocPreviewFile(sshGrant(), 'assets/logo.png')
 
     expect(outcome).toEqual({ ok: true, bytes: Buffer.alloc(0), contentType: 'image/png' })
   })
 
-  // Why: containment above is lexical, and the SSH read RPC enforces no root of its own, so a
-  // symlink inside the grant would otherwise read anything the account can reach.
-  it('404s a path that canonicalizes outside the grant root', async () => {
-    mocks.realpath.mockImplementation((path: string) =>
-      Promise.resolve(path === '/home/alice/docs/escape.html' ? '/etc/shadow' : path)
-    )
-
-    const outcome = await readDocPreviewFile(sshGrant(), 'escape.html')
-
-    expect(outcome).toMatchObject({ ok: false, status: 404 })
-    expect(mocks.readFile).not.toHaveBeenCalled()
-  })
-
-  it('reads the canonical path once containment holds', async () => {
-    mocks.realpath.mockImplementation((path: string) =>
-      Promise.resolve(path === '/home/alice/docs/link.html' ? '/home/alice/docs/real.html' : path)
-    )
-    mocks.readFile.mockResolvedValue({ content: '<h1>real</h1>', isBinary: false })
-
-    expect(await readDocPreviewFile(sshGrant(), 'link.html')).toMatchObject({ ok: true })
-    expect(mocks.readFile).toHaveBeenCalledWith('/home/alice/docs/real.html')
-  })
-
-  // Why: a symlinked root is legitimate; containment must be judged on what both sides resolve to.
-  it('keeps serving a grant whose own root is a symlink', async () => {
-    mocks.realpath.mockImplementation((path: string) =>
-      Promise.resolve(path.replace('/home/alice/docs', '/mnt/data/docs'))
-    )
-    mocks.readFile.mockResolvedValue({ content: '<h1>hi</h1>', isBinary: false })
-
-    expect(await readDocPreviewFile(sshGrant(), 'index.html')).toMatchObject({ ok: true })
-    expect(mocks.readFile).toHaveBeenCalledWith('/mnt/data/docs/index.html')
-  })
-
   it('404s when the host cannot canonicalize the path at all', async () => {
-    mocks.realpath.mockRejectedValue(new Error('no such file'))
+    mocks.readDocPreviewFile.mockRejectedValue(new Error('no such file'))
 
     expect(await readDocPreviewFile(sshGrant(), 'index.html')).toMatchObject({
       ok: false,
       status: 404
     })
-    expect(mocks.readFile).not.toHaveBeenCalled()
+    expect(mocks.readDocPreviewFile).toHaveBeenCalledOnce()
   })
 
   it('404s a path outside the grant root without touching the provider', async () => {
@@ -192,14 +165,21 @@ describe('readDocPreviewFile — ssh owner', () => {
     expect(mocks.requireSshFilesystemProvider).not.toHaveBeenCalled()
 
     authorizeDocPreviewDirectory(grant.id, 'assets/logo.png')
-    mocks.readFile.mockResolvedValue({ content: 'logo', isBinary: false })
+    mocks.readDocPreviewFile.mockResolvedValue({ content: 'logo', isBinary: false })
 
     await expect(readDocPreviewFile(grant, 'assets/logo.png')).resolves.toMatchObject({ ok: true })
-    expect(mocks.readFile).toHaveBeenCalledWith('/home/alice/assets/logo.png')
+    expect(mocks.readDocPreviewFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boundaryPath: '/home/alice',
+        implicitRootPath: '/home/alice/docs',
+        authorizedRootPaths: ['/home/alice/assets'],
+        targetPath: '/home/alice/assets/logo.png'
+      })
+    )
   })
 
   it('reports an over-cap SSH file as too large rather than unreadable', async () => {
-    mocks.readFile.mockRejectedValue(new FileReadCapExceededError('exceeds client cap'))
+    mocks.readDocPreviewFile.mockRejectedValue(new Error('file_too_large'))
 
     expect(await readDocPreviewFile(sshGrant(), 'huge.html')).toMatchObject({
       ok: false,
@@ -208,7 +188,7 @@ describe('readDocPreviewFile — ssh owner', () => {
   })
 
   it('404s when the provider read fails', async () => {
-    mocks.readFile.mockRejectedValue(new Error('no such file'))
+    mocks.readDocPreviewFile.mockRejectedValue(new Error('no such file'))
 
     expect(await readDocPreviewFile(sshGrant(), 'missing.html')).toMatchObject({
       ok: false,
@@ -218,10 +198,10 @@ describe('readDocPreviewFile — ssh owner', () => {
 })
 
 describe('readDocPreviewFile — paired runtime owner', () => {
-  it('reads text over worktree-relative files.read', async () => {
+  it('reads text over the host-enforced preview method', async () => {
     mocks.callRuntimeEnvironment.mockResolvedValue({
       ok: true,
-      result: { content: '<h1>remote</h1>', truncated: false, byteLength: 15 }
+      result: { content: '<h1>remote</h1>', isBinary: false }
     })
 
     const outcome = await readDocPreviewFile(runtimeGrant(), 'index.html')
@@ -229,8 +209,14 @@ describe('readDocPreviewFile — paired runtime owner', () => {
     expect(mocks.callRuntimeEnvironment).toHaveBeenCalledWith(
       '/user-data',
       'env-1',
-      'files.read',
-      { worktree: 'id:wt-1', relativePath: 'docs/index.html' },
+      'files.readDocPreview',
+      {
+        worktree: 'id:wt-1',
+        relativePath: 'docs/index.html',
+        entryRelativePath: 'docs/index.html',
+        implicitRootRelativePath: null,
+        authorizedRootRelativePaths: ['docs']
+      },
       15_000
     )
     expect(outcome).toEqual({
@@ -240,61 +226,48 @@ describe('readDocPreviewFile — paired runtime owner', () => {
     })
   })
 
-  it('falls back to the base64 preview RPC for a binary asset', async () => {
+  it('reads a base64 asset through the same host-enforced method', async () => {
     const png = Buffer.from([0x89, 0x50, 0x4e, 0x47])
-    mocks.callRuntimeEnvironment
-      .mockResolvedValueOnce({
-        ok: false,
-        error: { code: 'runtime_error', message: 'binary_file' }
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        result: {
-          content: png.toString('base64'),
-          isBinary: true,
-          isImage: true,
-          mimeType: 'image/png'
-        }
-      })
+    mocks.callRuntimeEnvironment.mockResolvedValue({
+      ok: true,
+      result: {
+        content: png.toString('base64'),
+        isBinary: true,
+        mimeType: 'image/png'
+      }
+    })
 
     const outcome = await readDocPreviewFile(runtimeGrant(), 'assets/logo.png')
 
-    expect(mocks.callRuntimeEnvironment).toHaveBeenNthCalledWith(
-      2,
+    expect(mocks.callRuntimeEnvironment).toHaveBeenCalledWith(
       '/user-data',
       'env-1',
-      'files.readPreview',
-      { worktree: 'id:wt-1', relativePath: 'docs/assets/logo.png' },
+      'files.readDocPreview',
+      expect.objectContaining({ relativePath: 'docs/assets/logo.png' }),
       15_000
     )
     expect(outcome).toEqual({ ok: true, bytes: png, contentType: 'image/png' })
   })
 
-  it('degrades on an old server whose empty binary preview carries no metadata', async () => {
-    mocks.callRuntimeEnvironment
-      .mockResolvedValueOnce({
-        ok: false,
-        error: { code: 'runtime_error', message: 'binary_file' }
-      })
-      .mockResolvedValueOnce({ ok: true, result: { content: '', isBinary: true } })
+  it('fails closed when an old server does not implement the scoped method', async () => {
+    mocks.callRuntimeEnvironment.mockResolvedValue({
+      ok: false,
+      error: { code: 'method_not_found', message: 'Unknown method: files.readDocPreview' }
+    })
 
     expect(await readDocPreviewFile(runtimeGrant(), 'assets/logo.png')).toMatchObject({
       ok: false,
-      status: 415,
-      reason: 'unsupported-asset'
+      status: 404,
+      reason: 'unreadable'
     })
+    expect(mocks.callRuntimeEnvironment).toHaveBeenCalledOnce()
   })
 
   it('serves an empty paired asset the host typed rather than reporting a refusal', async () => {
-    mocks.callRuntimeEnvironment
-      .mockResolvedValueOnce({
-        ok: false,
-        error: { code: 'runtime_error', message: 'binary_file' }
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        result: { content: '', isBinary: true, isImage: true, mimeType: 'image/png' }
-      })
+    mocks.callRuntimeEnvironment.mockResolvedValue({
+      ok: true,
+      result: { content: '', isBinary: true, mimeType: 'image/png' }
+    })
 
     expect(await readDocPreviewFile(runtimeGrant(), 'assets/logo.png')).toEqual({
       ok: true,
@@ -303,12 +276,10 @@ describe('readDocPreviewFile — paired runtime owner', () => {
     })
   })
 
-  // Why: files.read clamps text at the host cap and only says so in `truncated`; serving the
-  // clamped bytes renders a document that silently stops halfway.
-  it('refuses a truncated text read instead of serving the clamped bytes', async () => {
+  it('refuses an over-cap text read instead of serving partial bytes', async () => {
     mocks.callRuntimeEnvironment.mockResolvedValue({
-      ok: true,
-      result: { content: '<h1>half of', truncated: true, byteLength: 40_000_000 }
+      ok: false,
+      error: { code: 'runtime_error', message: 'file_too_large' }
     })
 
     const outcome = await readDocPreviewFile(runtimeGrant(), 'index.html')
@@ -320,23 +291,17 @@ describe('readDocPreviewFile — paired runtime owner', () => {
   it('serves a read the host reports as complete', async () => {
     mocks.callRuntimeEnvironment.mockResolvedValue({
       ok: true,
-      result: { content: '<h1>all</h1>', truncated: false, byteLength: 12 }
+      result: { content: '<h1>all</h1>', isBinary: false }
     })
 
     expect(await readDocPreviewFile(runtimeGrant(), 'index.html')).toMatchObject({ ok: true })
   })
 
-  // Why: the binary RPC has no `truncated` field — it rejects an over-cap asset with this error.
   it('reports the host rejecting an over-cap binary as too large', async () => {
-    mocks.callRuntimeEnvironment
-      .mockResolvedValueOnce({
-        ok: false,
-        error: { code: 'runtime_error', message: 'binary_file' }
-      })
-      .mockResolvedValueOnce({
-        ok: false,
-        error: { code: 'runtime_error', message: 'file_too_large' }
-      })
+    mocks.callRuntimeEnvironment.mockResolvedValue({
+      ok: false,
+      error: { code: 'runtime_error', message: 'file_too_large' }
+    })
 
     expect(await readDocPreviewFile(runtimeGrant(), 'assets/huge.png')).toMatchObject({
       ok: false,
@@ -388,15 +353,21 @@ describe('readDocPreviewFile — paired runtime owner', () => {
     authorizeDocPreviewDirectory(grant.id, 'assets/app.js')
     mocks.callRuntimeEnvironment.mockResolvedValue({
       ok: true,
-      result: { content: 'console.log(1)', truncated: false, byteLength: 14 }
+      result: { content: 'console.log(1)', isBinary: false }
     })
 
     await expect(readDocPreviewFile(grant, 'assets/app.js')).resolves.toMatchObject({ ok: true })
     expect(mocks.callRuntimeEnvironment).toHaveBeenCalledWith(
       '/user-data',
       'env-1',
-      'files.read',
-      { worktree: 'id:wt-1', relativePath: 'assets/app.js' },
+      'files.readDocPreview',
+      {
+        worktree: 'id:wt-1',
+        relativePath: 'assets/app.js',
+        entryRelativePath: 'docs/index.html',
+        implicitRootRelativePath: 'docs',
+        authorizedRootRelativePaths: ['assets']
+      },
       15_000
     )
   })

--- a/src/main/browser/doc-preview-file-reader.ts
+++ b/src/main/browser/doc-preview-file-reader.ts
@@ -1,22 +1,22 @@
 import { extname } from 'node:path'
-import type {
-  RuntimeFilePreviewResult,
-  RuntimeFileReadResult
-} from '../../shared/runtime-file-contracts'
+import type { RuntimeFilePreviewResult } from '../../shared/runtime-file-contracts'
 import type { DocPreviewFileFailureReason } from '../../shared/doc-preview-scheme'
 import { callRuntimeEnvironment } from '../ipc/runtime-environment-transport-routing'
 import { FileReadCapExceededError } from '../ssh/ssh-filesystem-stream-reader'
 import { getCanonicalUserDataPath } from '../persistence'
 import { requireSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
-  resolveCanonicalDocPreviewPath,
+  resolveDocPreviewAuthorityPaths,
   resolveDocPreviewCandidatePath,
   resolveDocPreviewTargetPath,
+  toRuntimeWorktreeRelativeDirectoryPath,
   toRuntimeWorktreeRelativePath,
   type DocPreviewGrant
 } from './doc-preview-grant-registry'
 
 const DOC_PREVIEW_READ_TIMEOUT_MS = 15_000
+const DIRECT_SSH_DOC_PREVIEW_TEXT_MAX_BYTES = 10 * 1024 * 1024
+const DIRECT_SSH_DOC_PREVIEW_BINARY_MAX_BYTES = 10 * 1024 * 1024
 
 /** Why not "needs a newer server": the SSH read path only ever serves images and PDFs as bytes, so
  *  a font is refused there by design, not by version. Name the file type, not the host's age. */
@@ -106,38 +106,29 @@ function toOutcome(source: PreviewFileBytes, contentType: string): DocPreviewRea
 async function readRuntimeDocPreviewFile(
   environmentId: string,
   worktreeSelector: string,
-  relativePath: string
+  relativePath: string,
+  entryRelativePath: string,
+  implicitRootRelativePath: string | null,
+  authorizedRootRelativePaths: string[]
 ): Promise<PreviewFileBytes> {
   const userDataPath = getCanonicalUserDataPath()
   const response = await callRuntimeEnvironment(
     userDataPath,
     environmentId,
-    'files.read',
-    { worktree: worktreeSelector, relativePath },
+    'files.readDocPreview',
+    {
+      worktree: worktreeSelector,
+      relativePath,
+      entryRelativePath,
+      implicitRootRelativePath,
+      authorizedRootRelativePaths
+    },
     DOC_PREVIEW_READ_TIMEOUT_MS
   )
-  if (response.ok) {
-    const result = response.result as RuntimeFileReadResult
-    return { content: result.content, isBinary: false, truncated: result.truncated === true }
-  }
-  // Why: files.read rejects binaries with a typed error; the base64 preview RPC serves
-  // images and fonts the same way it does for markdown previews. Match the exact
-  // message so an unrelated failure can't spoof the fallback.
-  if (response.error.message !== 'binary_file') {
+  if (!response.ok) {
     throw new Error(response.error.message)
   }
-  const previewResponse = await callRuntimeEnvironment(
-    userDataPath,
-    environmentId,
-    'files.readPreview',
-    { worktree: worktreeSelector, relativePath },
-    DOC_PREVIEW_READ_TIMEOUT_MS
-  )
-  if (!previewResponse.ok) {
-    throw new Error(previewResponse.error.message)
-  }
-  const preview = previewResponse.result as RuntimeFilePreviewResult
-  // Why: readPreview never clamps — it rejects an over-cap asset — so its body is whole or absent.
+  const preview = response.result as RuntimeFilePreviewResult
   return {
     content: preview.content,
     isBinary: preview.isBinary,
@@ -171,32 +162,53 @@ export async function readDocPreviewFile(
   try {
     if (grant.owner.kind === 'ssh') {
       const provider = requireSshFilesystemProvider(grant.owner.connectionId)
-      // Why: the SSH read RPC enforces no root of its own, so containment has to survive a symlink
-      // before the read — the lexical check above only proves the requested path looked contained.
-      const canonicalPath = await resolveCanonicalDocPreviewPath(grant, absolutePath, (path) =>
-        provider.realpath(path)
-      )
-      if (!canonicalPath) {
+      const authority = resolveDocPreviewAuthorityPaths(grant)
+      if (!authority.entryPath || !provider.readDocPreviewFile) {
         return notFoundOutcome()
       }
-      // Why: the SSH reader rejects an over-cap file outright, so its result is never partial.
-      return toOutcome(await provider.readFile(canonicalPath), contentType)
+      return toOutcome(
+        await provider.readDocPreviewFile({
+          boundaryPath: grant.requestBase,
+          entryPath: authority.entryPath,
+          implicitRootPath: authority.implicitRootPath,
+          authorizedRootPaths: authority.authorizedRootPaths,
+          targetPath: absolutePath,
+          maxTextBytes: DIRECT_SSH_DOC_PREVIEW_TEXT_MAX_BYTES,
+          maxBinaryBytes: DIRECT_SSH_DOC_PREVIEW_BINARY_MAX_BYTES
+        }),
+        contentType
+      )
     }
+    const runtimeOwner = grant.owner
     const worktreeRelativePath = toRuntimeWorktreeRelativePath(
-      grant.owner.worktreeRoot,
+      runtimeOwner.worktreeRoot,
       absolutePath
     )
-    if (!worktreeRelativePath) {
+    const authority = resolveDocPreviewAuthorityPaths(grant)
+    const entryRelativePath = authority.entryPath
+      ? toRuntimeWorktreeRelativePath(runtimeOwner.worktreeRoot, authority.entryPath)
+      : null
+    const implicitRootRelativePath = authority.implicitRootPath
+      ? toRuntimeWorktreeRelativeDirectoryPath(
+          runtimeOwner.worktreeRoot,
+          authority.implicitRootPath
+        )
+      : null
+    const authorizedRootRelativePaths = authority.authorizedRootPaths
+      .map((root) => toRuntimeWorktreeRelativeDirectoryPath(runtimeOwner.worktreeRoot, root))
+      .filter((root): root is string => root !== null)
+    if (!worktreeRelativePath || !entryRelativePath) {
       // Why: files.read is worktree-scoped, so a doc outside the worktree has no client-side channel.
       return notFoundOutcome()
     }
-    // Why no realpath pass here: the host resolves this path through resolveAuthorizedPath, which
-    // canonicalizes and re-checks the worktree root server-side before reading.
     return toOutcome(
       await readRuntimeDocPreviewFile(
-        grant.owner.environmentId,
-        grant.owner.worktreeSelector,
-        worktreeRelativePath
+        runtimeOwner.environmentId,
+        runtimeOwner.worktreeSelector,
+        worktreeRelativePath,
+        entryRelativePath,
+        implicitRootRelativePath,
+        authorizedRootRelativePaths
       ),
       contentType
     )

--- a/src/main/browser/doc-preview-file-reader.ts
+++ b/src/main/browser/doc-preview-file-reader.ts
@@ -29,6 +29,10 @@ const TRUNCATED_PREVIEW_MESSAGE = 'This document is too large for the server to 
 /** The paired host rejects an over-cap asset outright instead of clamping it. */
 const RUNTIME_TOO_LARGE_ERROR = 'file_too_large'
 
+/** Same stance as the SSH relay message: previews fail closed on a host without scoped reads. */
+const RUNTIME_DOC_PREVIEW_UPDATE_REQUIRED_MESSAGE =
+  'Secure document previews require a newer Orca on the paired machine. Update it and try again.'
+
 /** Both owners refuse an over-cap file; only their error shapes differ. */
 function isTooLargeReadError(error: unknown): boolean {
   return (
@@ -126,7 +130,13 @@ async function readRuntimeDocPreviewFile(
     DOC_PREVIEW_READ_TIMEOUT_MS
   )
   if (!response.ok) {
-    throw new Error(response.error.message)
+    // Why the rewrite: fail-closed on an old host is deliberate, so tell the reader what to do —
+    // the raw method_not_found wording reads as a broken preview, not an out-of-date machine.
+    throw new Error(
+      response.error.code === 'method_not_found'
+        ? RUNTIME_DOC_PREVIEW_UPDATE_REQUIRED_MESSAGE
+        : response.error.message
+    )
   }
   const preview = response.result as RuntimeFilePreviewResult
   return {

--- a/src/main/browser/doc-preview-grant-registry.test.ts
+++ b/src/main/browser/doc-preview-grant-registry.test.ts
@@ -7,6 +7,7 @@ import {
   resolveDocPreviewTargetPath,
   revokeAllDocPreviewGrants,
   revokeDocPreviewGrant,
+  toRuntimeWorktreeRelativeDirectoryPath,
   toRuntimeWorktreeRelativePath,
   type DocPreviewGrant
 } from './doc-preview-grant-registry'
@@ -279,5 +280,10 @@ describe('toRuntimeWorktreeRelativePath', () => {
       'docs/index.html'
     )
     expect(toRuntimeWorktreeRelativePath('C:\\srv\\repo', 'D:\\other\\index.html')).toBeNull()
+  })
+
+  it('represents an explicitly authorized worktree root as the empty relative directory', () => {
+    expect(toRuntimeWorktreeRelativeDirectoryPath('/srv/repo', '/srv/repo')).toBe('')
+    expect(toRuntimeWorktreeRelativeDirectoryPath('C:\\srv\\repo', 'C:\\srv\\repo')).toBe('')
   })
 })

--- a/src/main/browser/doc-preview-grant-registry.ts
+++ b/src/main/browser/doc-preview-grant-registry.ts
@@ -184,6 +184,18 @@ function directoryAuthorityRoots(grant: DocPreviewGrant): string[] {
     : [grant.root, ...grant.authorizedRoots]
 }
 
+export function resolveDocPreviewAuthorityPaths(grant: DocPreviewGrant): {
+  entryPath: string | null
+  implicitRootPath: string | null
+  authorizedRootPaths: string[]
+} {
+  return {
+    entryPath: resolveEntryAbsolutePath(grant),
+    implicitRootPath: grant.root === grant.requestBase ? null : grant.root,
+    authorizedRootPaths: [...grant.authorizedRoots]
+  }
+}
+
 /** The one path an entry-only grant can read before the reader approves a directory. */
 function resolveEntryAbsolutePath(grant: DocPreviewGrant): string | null {
   return resolveDocPreviewCandidatePath(grant, grant.entryRelativePath)
@@ -302,4 +314,14 @@ export function toRuntimeWorktreeRelativePath(
     return null
   }
   return relative.replace(/\\/g, '/')
+}
+
+export function toRuntimeWorktreeRelativeDirectoryPath(
+  worktreeRoot: string,
+  absolutePath: string
+): string | null {
+  const normalizedRoot = normalizeRootPath(worktreeRoot)
+  return normalizeRootPath(absolutePath) === normalizedRoot
+    ? ''
+    : toRuntimeWorktreeRelativePath(worktreeRoot, absolutePath)
 }

--- a/src/main/providers/filesystem-provider-contract.ts
+++ b/src/main/providers/filesystem-provider-contract.ts
@@ -1,4 +1,8 @@
 import type { SearchOptions, SearchResult } from '../../shared/code-search-types'
+import type {
+  DocPreviewFileAccessRequest,
+  DocPreviewFileAccessResult
+} from '../../shared/doc-preview-file-access'
 import type { DirEntry, FsChangeEvent } from '../../shared/filesystem-entry-types'
 import type { WorkspaceSpaceDirectoryScanResult } from '../../shared/workspace-space-types'
 
@@ -48,6 +52,7 @@ export class FileRangeReadUnsupportedError extends Error {
 export type IFilesystemProvider = {
   readDir(dirPath: string): Promise<DirEntry[]>
   readFile(filePath: string, limits?: FileReadLimits): Promise<FileReadResult>
+  readDocPreviewFile?(request: DocPreviewFileAccessRequest): Promise<DocPreviewFileAccessResult>
   /** Positional read. Optional because an older remote host cannot serve one.
    *  Strict by design: it throws `FileRangeReadUnsupportedError` rather than
    *  silently degrading, so a caller cannot accidentally pay a whole-file

--- a/src/main/providers/ssh-filesystem-doc-preview.test.ts
+++ b/src/main/providers/ssh-filesystem-doc-preview.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { DocPreviewFileAccessRequest } from '../../shared/doc-preview-file-access'
+import { readSshDocPreviewFile } from './ssh-filesystem-doc-preview'
+
+const request: DocPreviewFileAccessRequest = {
+  boundaryPath: '/repo',
+  entryPath: '/repo/docs/index.html',
+  implicitRootPath: '/repo/docs',
+  authorizedRootPaths: ['/repo/assets'],
+  targetPath: '/repo/docs/app.js',
+  maxTextBytes: 1024,
+  maxBinaryBytes: 2048
+}
+
+describe('readSshDocPreviewFile', () => {
+  it('delegates canonical authorization and reading to the relay host', async () => {
+    const mux = { request: vi.fn().mockResolvedValue({ content: 'ok', isBinary: false }) }
+
+    await expect(readSshDocPreviewFile(mux as never, request)).resolves.toEqual({
+      content: 'ok',
+      isBinary: false
+    })
+    expect(mux.request).toHaveBeenCalledWith('fs.readDocPreview', request)
+  })
+
+  it('fails closed when the relay predates scoped preview reads', async () => {
+    const mux = {
+      request: vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error('Method not found'), { code: -32601 }))
+    }
+
+    await expect(readSshDocPreviewFile(mux as never, request)).rejects.toThrow(
+      'Reconnect the SSH target'
+    )
+  })
+})

--- a/src/main/providers/ssh-filesystem-doc-preview.ts
+++ b/src/main/providers/ssh-filesystem-doc-preview.ts
@@ -1,0 +1,23 @@
+import type {
+  DocPreviewFileAccessRequest,
+  DocPreviewFileAccessResult
+} from '../../shared/doc-preview-file-access'
+import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+import { isMethodNotFoundError } from '../ssh/ssh-filesystem-stream-reader'
+
+const REMOTE_DOC_PREVIEW_UPDATE_REQUIRED =
+  'Secure document previews require a newer SSH relay. Reconnect the SSH target and try again.'
+
+export async function readSshDocPreviewFile(
+  mux: SshChannelMultiplexer,
+  request: DocPreviewFileAccessRequest
+): Promise<DocPreviewFileAccessResult> {
+  try {
+    return (await mux.request('fs.readDocPreview', request)) as DocPreviewFileAccessResult
+  } catch (error) {
+    if (isMethodNotFoundError(error)) {
+      throw new Error(REMOTE_DOC_PREVIEW_UPDATE_REQUIRED)
+    }
+    throw error
+  }
+}

--- a/src/main/providers/ssh-filesystem-provider.ts
+++ b/src/main/providers/ssh-filesystem-provider.ts
@@ -37,6 +37,7 @@ import {
   readSshTerminalArtifact,
   writeSshTerminalArtifact
 } from './ssh-filesystem-terminal-artifact'
+import { readSshDocPreviewFile } from './ssh-filesystem-doc-preview'
 const WORKSPACE_SPACE_SCAN_TIMEOUT_MS = 130_000
 export class SshFilesystemProvider implements IFilesystemProvider {
   private connectionId: string
@@ -118,6 +119,12 @@ export class SshFilesystemProvider implements IFilesystemProvider {
       }
       throw err
     }
+  }
+
+  readDocPreviewFile(
+    request: Parameters<NonNullable<IFilesystemProvider['readDocPreviewFile']>>[0]
+  ): ReturnType<NonNullable<IFilesystemProvider['readDocPreviewFile']>> {
+    return readSshDocPreviewFile(this.mux, request)
   }
 
   readFileRange(

--- a/src/main/runtime/orca-runtime-files-preview-budget.test.ts
+++ b/src/main/runtime/orca-runtime-files-preview-budget.test.ts
@@ -229,5 +229,37 @@ describe('RuntimeFileCommands', () => {
         'file_too_large'
       )
     })
+
+    it('sends preview authority to the SSH execution host in one read', async () => {
+      const { commands, store } = createRuntimeFileCommands({ path: '/repo' })
+      store.getRepo.mockReturnValue({ connectionId: 'ssh-1' })
+      const readDocPreviewFile = vi.fn().mockResolvedValue({ content: 'ok', isBinary: false })
+      vi.mocked(getSshFilesystemProvider).mockReturnValue({ readDocPreviewFile } as never)
+
+      await expect(
+        commands.readDocPreviewFile('id:wt-1', 'docs/index.html', 'docs/index.html', 'docs', [
+          'assets'
+        ])
+      ).resolves.toEqual({ content: 'ok', isBinary: false })
+      expect(readDocPreviewFile).toHaveBeenCalledWith({
+        boundaryPath: '/repo',
+        entryPath: '/repo/docs/index.html',
+        implicitRootPath: '/repo/docs',
+        authorizedRootPaths: ['/repo/assets'],
+        targetPath: '/repo/docs/index.html',
+        maxTextBytes: 512 * 1024,
+        maxBinaryBytes: 10 * 1024 * 1024
+      })
+    })
+
+    it('fails closed when the SSH execution host lacks scoped preview reads', async () => {
+      const { commands, store } = createRuntimeFileCommands({ path: '/repo' })
+      store.getRepo.mockReturnValue({ connectionId: 'ssh-1' })
+      vi.mocked(getSshFilesystemProvider).mockReturnValue({} as never)
+
+      await expect(
+        commands.readDocPreviewFile('id:wt-1', 'docs/index.html', 'docs/index.html', 'docs', [])
+      ).rejects.toThrow('newer SSH relay')
+    })
   })
 })

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -104,6 +104,11 @@ import {
   readNodeFileWithinLimit
 } from '../../shared/node-bounded-file-reader'
 import { QUICK_OPEN_LISTING_MAX_RESULTS } from '../../shared/quick-open-listing-limits'
+import {
+  readAuthorizedDocPreviewFile,
+  type DocPreviewFileAccessRequest,
+  type DocPreviewFileAccessResult
+} from '../../shared/doc-preview-file-access'
 
 const MOBILE_FILE_LIST_LIMIT = 5000
 // Legacy SSH relays cannot enforce a byte budget; 32 max-length paths stay under one 4 MiB frame.
@@ -1692,6 +1697,53 @@ export class RuntimeFileCommands {
       { content: buffer.toString('utf-8'), isBinary: false },
       maxContentBytes
     )
+  }
+
+  async readDocPreviewFile(
+    worktreeSelector: string,
+    relativePath: string,
+    entryRelativePath: string,
+    implicitRootRelativePath: string | null,
+    authorizedRootRelativePaths: string[],
+    maxContentBytes?: number
+  ): Promise<DocPreviewFileAccessResult> {
+    const relativePaths = [
+      '',
+      entryRelativePath,
+      relativePath,
+      ...(implicitRootRelativePath === null ? [] : [implicitRootRelativePath]),
+      ...authorizedRootRelativePaths
+    ]
+    const [boundary, entry, target, ...authorityRoots] = await this.resolveFileExplorerPaths(
+      worktreeSelector,
+      relativePaths
+    )
+    const implicitRoot = implicitRootRelativePath === null ? null : authorityRoots[0]
+    const authorizedRoots = authorityRoots.slice(implicitRoot === null ? 0 : 1)
+    const binaryMaxBytes =
+      maxContentBytes === undefined
+        ? LOCAL_PREVIEWABLE_BINARY_MAX_BYTES
+        : previewableBinaryByteLimit(maxContentBytes)
+    const request: DocPreviewFileAccessRequest = {
+      boundaryPath: boundary.path,
+      entryPath: entry.path,
+      implicitRootPath: implicitRoot?.path ?? null,
+      authorizedRootPaths: authorizedRoots.map((root) => root.path),
+      targetPath: target.path,
+      maxTextBytes: MOBILE_FILE_READ_MAX_BYTES,
+      maxBinaryBytes: binaryMaxBytes
+    }
+    const provider = target.connectionId ? getSshFilesystemProvider(target.connectionId) : null
+    if (target.connectionId && !provider) {
+      throw new Error(SSH_FILESYSTEM_PROVIDER_UNAVAILABLE_MESSAGE)
+    }
+    if (target.connectionId && !provider?.readDocPreviewFile) {
+      throw new Error('Secure document previews require a newer SSH relay')
+    }
+    const result = provider?.readDocPreviewFile
+      ? await provider.readDocPreviewFile(request)
+      : await readAuthorizedDocPreviewFile(request)
+    return assertPreviewWithinTransportBudget(result, maxContentBytes)
   }
 
   async readFileExplorerChunk(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10992,6 +10992,8 @@ export class OrcaRuntimeService {
   }
   readFileExplorerPreview: RuntimeFileCommands['readFileExplorerPreview'] =
     this.fileCommands.readFileExplorerPreview.bind(this.fileCommands)
+  readDocPreviewFile: RuntimeFileCommands['readDocPreviewFile'] =
+    this.fileCommands.readDocPreviewFile.bind(this.fileCommands)
   readFileExplorerChunk: RuntimeFileCommands['readFileExplorerChunk'] =
     this.fileCommands.readFileExplorerChunk.bind(this.fileCommands)
   writeFileExplorerFile: RuntimeFileCommands['writeFileExplorerFile'] =

--- a/src/main/runtime/rpc/methods/files-doc-preview.test.ts
+++ b/src/main/runtime/rpc/methods/files-doc-preview.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { RpcRequest } from '../core'
+import { RpcDispatcher } from '../dispatcher'
+import { FILE_METHODS } from './files'
+
+describe('files.readDocPreview', () => {
+  it('passes document-preview authority to the dedicated host method', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      readDocPreviewFile: vi.fn().mockResolvedValue({
+        content: '<h1>safe</h1>',
+        isBinary: false
+      })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: FILE_METHODS })
+    const request: RpcRequest = {
+      id: 'req-1',
+      authToken: 'tok',
+      method: 'files.readDocPreview',
+      params: {
+        worktree: 'id:wt-1',
+        relativePath: 'docs/index.html',
+        entryRelativePath: 'docs/index.html',
+        implicitRootRelativePath: 'docs',
+        authorizedRootRelativePaths: ['assets']
+      }
+    }
+
+    const response = await dispatcher.dispatch(request)
+
+    expect(runtime.readDocPreviewFile).toHaveBeenCalledWith(
+      'id:wt-1',
+      'docs/index.html',
+      'docs/index.html',
+      'docs',
+      ['assets'],
+      undefined
+    )
+    expect(response).toMatchObject({ ok: true, result: { content: '<h1>safe</h1>' } })
+  })
+})

--- a/src/main/runtime/rpc/methods/files.ts
+++ b/src/main/runtime/rpc/methods/files.ts
@@ -51,6 +51,12 @@ const FileOpenDiff = FileOpen.extend({
   staged: z.boolean().optional()
 })
 
+const DocPreviewFileRead = FileOpen.extend({
+  entryRelativePath: z.string().min(1),
+  implicitRootRelativePath: z.string().nullable(),
+  authorizedRootRelativePaths: z.array(z.string())
+})
+
 const FileTreePath = WorktreeSelector.extend({
   relativePath: z
     .unknown()
@@ -147,6 +153,19 @@ export const FILE_METHODS: RpcAnyMethod[] = [
     params: FileOpen,
     handler: async (params, { runtime }) =>
       runtime.readMobileFile(params.worktree, params.relativePath)
+  }),
+  defineMethod({
+    name: 'files.readDocPreview',
+    params: DocPreviewFileRead,
+    handler: async (params, { runtime, clientKind, requestId }) =>
+      runtime.readDocPreviewFile(
+        params.worktree,
+        params.relativePath,
+        params.entryRelativePath,
+        params.implicitRootRelativePath,
+        params.authorizedRootRelativePaths,
+        remoteFileContentBudget(clientKind, requestId)
+      )
   }),
   defineMethod({
     name: 'files.resolveTerminalPath',

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -236,6 +236,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'files.open',
   'files.openDiff',
   'files.read',
+  'files.readDocPreview',
   'files.readChunk',
   'files.readDir',
   'files.readPreview',

--- a/src/relay/fs-handler-doc-preview.test.ts
+++ b/src/relay/fs-handler-doc-preview.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { FsHandler } from './fs-handler'
+
+const fixtureRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    fixtureRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  )
+})
+
+describe('FsHandler document previews', () => {
+  it('registers an execution-host read that rejects canonical symlink escapes', async () => {
+    const requestHandlers = new Map<string, (params: Record<string, unknown>) => Promise<unknown>>()
+    const dispatcher = {
+      onRequest: vi.fn(
+        (method: string, handler: (params: Record<string, unknown>) => Promise<unknown>) => {
+          requestHandlers.set(method, handler)
+        }
+      ),
+      onNotification: vi.fn(),
+      onClientDetached: vi.fn(),
+      notify: vi.fn(),
+      notifyClient: vi.fn()
+    }
+    new FsHandler(dispatcher as never, {} as never)
+    const readDocPreview = requestHandlers.get('fs.readDocPreview')
+    expect(readDocPreview).toBeTypeOf('function')
+
+    const fixture = await mkdtemp(join(tmpdir(), 'orca-relay-doc-preview-'))
+    fixtureRoots.push(fixture)
+    const workspace = join(fixture, 'workspace')
+    const docs = join(workspace, 'docs')
+    const outside = join(fixture, 'outside')
+    await Promise.all([mkdir(docs, { recursive: true }), mkdir(outside)])
+    const entryPath = join(docs, 'index.html')
+    await writeFile(entryPath, '<h1>entry</h1>')
+    await writeFile(join(outside, 'secret.txt'), 'secret')
+    const linkedOutside = join(docs, 'linked')
+    await symlink(outside, linkedOutside, process.platform === 'win32' ? 'junction' : 'dir')
+    const request = {
+      boundaryPath: workspace,
+      entryPath,
+      implicitRootPath: docs,
+      authorizedRootPaths: [],
+      maxTextBytes: 1024,
+      maxBinaryBytes: 1024
+    }
+
+    await expect(readDocPreview!({ ...request, targetPath: entryPath })).resolves.toEqual({
+      content: '<h1>entry</h1>',
+      isBinary: false
+    })
+    await expect(
+      readDocPreview!({ ...request, targetPath: join(linkedOutside, 'secret.txt') })
+    ).rejects.toThrow('doc_preview_path_unauthorized')
+  })
+})

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -37,6 +37,10 @@ import { scanWorkspaceSpaceDirectory } from './workspace-space-scan'
 import { RipgrepUnavailableError } from '../shared/ripgrep-process-availability'
 import { RelayFilesystemWatchRegistry } from './relay-filesystem-watch-registry'
 import type { RelayWatcherProcessPool } from './relay-watcher-process-pool'
+import {
+  readAuthorizedDocPreviewFile,
+  type DocPreviewFileAccessRequest
+} from '../shared/doc-preview-file-access'
 
 export class FsHandler {
   private dispatcher: RelayDispatcher
@@ -69,6 +73,9 @@ export class FsHandler {
     this.dispatcher.onRequest('fs.readFile', (p) => this.readFile(p))
     this.dispatcher.onRequest('fs.readFileStream', (p, c) => this.readFileStream(p, c))
     this.dispatcher.onRequest('fs.readFileRange', (p) => this.readFileRange(p))
+    this.dispatcher.onRequest('fs.readDocPreview', (p) =>
+      readAuthorizedDocPreviewFile(p as DocPreviewFileAccessRequest)
+    )
     this.dispatcher.onRequest('fs.readTerminalArtifact', (p) => this.readTerminalArtifact(p))
     this.dispatcher.onRequest('fs.tempDir', () => this.tempDir())
     this.dispatcher.onRequest('fs.writeFile', (p) => writeRelayFile(p))

--- a/src/shared/doc-preview-file-access.test.ts
+++ b/src/shared/doc-preview-file-access.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it } from 'vitest'
+import { execFile } from 'node:child_process'
 import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { promisify } from 'node:util'
 import {
   DOC_PREVIEW_PATH_AUTHORIZATION_ERROR,
   readAuthorizedDocPreviewFile
@@ -113,6 +115,29 @@ describe('readAuthorizedDocPreviewFile', () => {
       })
     ).rejects.toThrow(DOC_PREVIEW_PATH_AUTHORIZATION_ERROR)
   })
+
+  // Why the skip: FIFOs are a POSIX shape; Windows has no mkfifo and no equivalent hazard here.
+  it.skipIf(process.platform === 'win32')(
+    'refuses a writer-less FIFO instead of blocking the open forever',
+    async () => {
+      const fixture = await createFixture()
+      const fifo = join(fixture.assets, 'pipe')
+      await promisify(execFile)('mkfifo', [fifo])
+
+      // Without O_NONBLOCK this open never returns, so the timeout itself is the regression oracle.
+      await expect(
+        readAuthorizedDocPreviewFile({
+          boundaryPath: fixture.workspace,
+          entryPath: fixture.entry,
+          implicitRootPath: null,
+          authorizedRootPaths: [fixture.assets],
+          targetPath: fifo,
+          maxTextBytes: 1024,
+          maxBinaryBytes: 1024
+        })
+      ).rejects.toThrow(DOC_PREVIEW_PATH_AUTHORIZATION_ERROR)
+    }
+  )
 
   it('returns typed binary bytes and enforces the read cap', async () => {
     const fixture = await createFixture()

--- a/src/shared/doc-preview-file-access.test.ts
+++ b/src/shared/doc-preview-file-access.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  DOC_PREVIEW_PATH_AUTHORIZATION_ERROR,
+  readAuthorizedDocPreviewFile
+} from './doc-preview-file-access'
+
+const fixtureRoots: string[] = []
+
+async function createFixture(): Promise<{
+  workspace: string
+  entry: string
+  docs: string
+  assets: string
+}> {
+  const fixture = await mkdtemp(join(tmpdir(), 'orca-doc-preview-access-'))
+  fixtureRoots.push(fixture)
+  const workspace = join(fixture, 'workspace')
+  const docs = join(workspace, 'docs')
+  const assets = join(workspace, 'assets')
+  await Promise.all([mkdir(docs, { recursive: true }), mkdir(assets, { recursive: true })])
+  const entry = join(docs, 'index.html')
+  await writeFile(entry, '<h1>entry</h1>')
+  return { workspace, entry, docs, assets }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    fixtureRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  )
+})
+
+describe('readAuthorizedDocPreviewFile', () => {
+  it('reads the entry file without granting its containing directory', async () => {
+    const fixture = await createFixture()
+
+    await expect(
+      readAuthorizedDocPreviewFile({
+        boundaryPath: fixture.workspace,
+        entryPath: fixture.entry,
+        implicitRootPath: null,
+        authorizedRootPaths: [],
+        targetPath: fixture.entry,
+        maxTextBytes: 1024,
+        maxBinaryBytes: 1024
+      })
+    ).resolves.toEqual({ content: '<h1>entry</h1>', isBinary: false })
+  })
+
+  it('reads a file only after its canonical directory is authorized', async () => {
+    const fixture = await createFixture()
+    const asset = join(fixture.assets, 'app.js')
+    await writeFile(asset, 'console.log(1)')
+    const request = {
+      boundaryPath: fixture.workspace,
+      entryPath: fixture.entry,
+      implicitRootPath: null,
+      authorizedRootPaths: [] as string[],
+      targetPath: asset,
+      maxTextBytes: 1024,
+      maxBinaryBytes: 1024
+    }
+
+    await expect(readAuthorizedDocPreviewFile(request)).rejects.toThrow(
+      DOC_PREVIEW_PATH_AUTHORIZATION_ERROR
+    )
+    await expect(
+      readAuthorizedDocPreviewFile({ ...request, authorizedRootPaths: [fixture.assets] })
+    ).resolves.toEqual({ content: 'console.log(1)', isBinary: false })
+  })
+
+  it('rejects an authorized-directory symlink that resolves outside the workspace', async () => {
+    const fixture = await createFixture()
+    const outside = join(fixture.workspace, '..', 'outside')
+    await mkdir(outside)
+    await writeFile(join(outside, 'secret.txt'), 'secret')
+    const linked = join(fixture.assets, 'linked')
+    await symlink(outside, linked, process.platform === 'win32' ? 'junction' : 'dir')
+
+    await expect(
+      readAuthorizedDocPreviewFile({
+        boundaryPath: fixture.workspace,
+        entryPath: fixture.entry,
+        implicitRootPath: fixture.docs,
+        authorizedRootPaths: [fixture.assets],
+        targetPath: join(linked, 'secret.txt'),
+        maxTextBytes: 1024,
+        maxBinaryBytes: 1024
+      })
+    ).rejects.toThrow(DOC_PREVIEW_PATH_AUTHORIZATION_ERROR)
+  })
+
+  it('does not let an implicit nested root canonicalize into whole-workspace authority', async () => {
+    const fixture = await createFixture()
+    const rootEntry = join(fixture.workspace, 'index.html')
+    const secret = join(fixture.workspace, 'secret.txt')
+    await writeFile(rootEntry, '<h1>entry</h1>')
+    await writeFile(secret, 'secret')
+    const linkedRoot = join(fixture.workspace, 'linked-root')
+    await symlink(fixture.workspace, linkedRoot, process.platform === 'win32' ? 'junction' : 'dir')
+
+    await expect(
+      readAuthorizedDocPreviewFile({
+        boundaryPath: fixture.workspace,
+        entryPath: join(linkedRoot, 'index.html'),
+        implicitRootPath: linkedRoot,
+        authorizedRootPaths: [],
+        targetPath: secret,
+        maxTextBytes: 1024,
+        maxBinaryBytes: 1024
+      })
+    ).rejects.toThrow(DOC_PREVIEW_PATH_AUTHORIZATION_ERROR)
+  })
+
+  it('returns typed binary bytes and enforces the read cap', async () => {
+    const fixture = await createFixture()
+    const image = join(fixture.assets, 'logo.png')
+    await writeFile(image, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+    const request = {
+      boundaryPath: fixture.workspace,
+      entryPath: fixture.entry,
+      implicitRootPath: fixture.docs,
+      authorizedRootPaths: [fixture.assets],
+      targetPath: image,
+      maxTextBytes: 1024,
+      maxBinaryBytes: 4
+    }
+
+    await expect(readAuthorizedDocPreviewFile(request)).resolves.toEqual({
+      content: Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'),
+      isBinary: true,
+      mimeType: 'image/png'
+    })
+    await expect(readAuthorizedDocPreviewFile({ ...request, maxBinaryBytes: 3 })).rejects.toThrow(
+      'file_too_large'
+    )
+  })
+})

--- a/src/shared/doc-preview-file-access.ts
+++ b/src/shared/doc-preview-file-access.ts
@@ -35,6 +35,9 @@ const DOC_PREVIEW_MAX_TEXT_BYTES = 10 * 1024 * 1024
 const DOC_PREVIEW_MAX_BINARY_BYTES = 50 * 1024 * 1024
 
 const OPEN_NOFOLLOW = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0
+// Why: opening a writer-less FIFO blocks before the regular-file check can refuse it, pinning a
+// threadpool slot for good; non-blocking open returns at once and does not change regular-file reads.
+const OPEN_NONBLOCK = typeof constants.O_NONBLOCK === 'number' ? constants.O_NONBLOCK : 0
 
 function authorizationError(): Error {
   return new Error(DOC_PREVIEW_PATH_AUTHORIZATION_ERROR)
@@ -83,7 +86,7 @@ async function openAuthorizedDocPreviewTarget(
     throw authorizationError()
   }
 
-  const handle = await open(canonicalTarget, constants.O_RDONLY | OPEN_NOFOLLOW)
+  const handle = await open(canonicalTarget, constants.O_RDONLY | OPEN_NOFOLLOW | OPEN_NONBLOCK)
   try {
     const [openedStats, currentCanonicalTarget, currentTargetStats] = await Promise.all([
       handle.stat(),

--- a/src/shared/doc-preview-file-access.ts
+++ b/src/shared/doc-preview-file-access.ts
@@ -1,0 +1,134 @@
+import { constants, type Stats } from 'node:fs'
+import { open, realpath, stat, type FileHandle } from 'node:fs/promises'
+import { extname } from 'node:path'
+import { isBinaryBuffer } from './binary-buffer'
+import { isPathInsideOrEqual } from './cross-platform-path'
+import { IMAGE_FILE_MIME_TYPES } from './image-file-extensions'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileHandleWithinLimit
+} from './node-bounded-file-reader'
+
+export const DOC_PREVIEW_PATH_AUTHORIZATION_ERROR = 'doc_preview_path_unauthorized'
+
+export type DocPreviewFileAccessRequest = {
+  boundaryPath: string
+  entryPath: string
+  implicitRootPath: string | null
+  authorizedRootPaths: string[]
+  targetPath: string
+  maxTextBytes: number
+  maxBinaryBytes: number
+}
+
+export type DocPreviewFileAccessResult = {
+  content: string
+  isBinary: boolean
+  mimeType?: string
+}
+
+const DOC_PREVIEW_BINARY_MIME_TYPES: Record<string, string> = {
+  ...IMAGE_FILE_MIME_TYPES,
+  '.pdf': 'application/pdf'
+}
+const DOC_PREVIEW_MAX_TEXT_BYTES = 10 * 1024 * 1024
+const DOC_PREVIEW_MAX_BINARY_BYTES = 50 * 1024 * 1024
+
+const OPEN_NOFOLLOW = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0
+
+function authorizationError(): Error {
+  return new Error(DOC_PREVIEW_PATH_AUTHORIZATION_ERROR)
+}
+
+function clampReadLimit(requested: number, maximum: number): number {
+  if (!Number.isSafeInteger(requested) || requested < 0) {
+    throw new RangeError('Document preview read limit must be a non-negative safe integer')
+  }
+  return Math.min(requested, maximum)
+}
+
+function sameFileIdentity(opened: Stats, current: Stats): boolean {
+  return opened.dev === current.dev && opened.ino === current.ino
+}
+
+async function openAuthorizedDocPreviewTarget(
+  request: DocPreviewFileAccessRequest
+): Promise<{ handle: FileHandle; canonicalTarget: string }> {
+  const [canonicalBoundary, canonicalEntry, canonicalTarget, canonicalImplicitRoot] =
+    await Promise.all([
+      realpath(request.boundaryPath),
+      realpath(request.entryPath),
+      realpath(request.targetPath),
+      request.implicitRootPath === null ? Promise.resolve(null) : realpath(request.implicitRootPath)
+    ])
+  const canonicalAuthorizedRoots = await Promise.all(
+    request.authorizedRootPaths.map((root) => realpath(root))
+  )
+
+  const entryAuthorized =
+    isPathInsideOrEqual(canonicalBoundary, canonicalEntry) && canonicalTarget === canonicalEntry
+  const implicitRootAuthorized =
+    canonicalImplicitRoot !== null &&
+    canonicalImplicitRoot !== canonicalBoundary &&
+    isPathInsideOrEqual(canonicalBoundary, canonicalImplicitRoot) &&
+    isPathInsideOrEqual(canonicalImplicitRoot, canonicalTarget)
+  const explicitRootAuthorized = canonicalAuthorizedRoots.some(
+    (root) =>
+      isPathInsideOrEqual(canonicalBoundary, root) && isPathInsideOrEqual(root, canonicalTarget)
+  )
+  if (
+    !isPathInsideOrEqual(canonicalBoundary, canonicalTarget) ||
+    (!entryAuthorized && !implicitRootAuthorized && !explicitRootAuthorized)
+  ) {
+    throw authorizationError()
+  }
+
+  const handle = await open(canonicalTarget, constants.O_RDONLY | OPEN_NOFOLLOW)
+  try {
+    const [openedStats, currentCanonicalTarget, currentTargetStats] = await Promise.all([
+      handle.stat(),
+      realpath(canonicalTarget),
+      stat(canonicalTarget)
+    ])
+    if (
+      !openedStats.isFile() ||
+      currentCanonicalTarget !== canonicalTarget ||
+      !sameFileIdentity(openedStats, currentTargetStats)
+    ) {
+      throw authorizationError()
+    }
+    return { handle, canonicalTarget }
+  } catch (error) {
+    await handle.close()
+    throw error
+  }
+}
+
+/** Canonicalizes, authorizes, opens, and reads on the filesystem's execution host. */
+export async function readAuthorizedDocPreviewFile(
+  request: DocPreviewFileAccessRequest
+): Promise<DocPreviewFileAccessResult> {
+  const { handle, canonicalTarget } = await openAuthorizedDocPreviewTarget(request)
+  try {
+    const mimeType = DOC_PREVIEW_BINARY_MIME_TYPES[extname(canonicalTarget).toLowerCase()]
+    const { buffer } = await readNodeFileHandleWithinLimit(
+      handle,
+      mimeType
+        ? clampReadLimit(request.maxBinaryBytes, DOC_PREVIEW_MAX_BINARY_BYTES)
+        : clampReadLimit(request.maxTextBytes, DOC_PREVIEW_MAX_TEXT_BYTES)
+    )
+    if (mimeType) {
+      return { content: buffer.toString('base64'), isBinary: true, mimeType }
+    }
+    return isBinaryBuffer(buffer)
+      ? { content: '', isBinary: true }
+      : { content: buffer.toString('utf8'), isBinary: false }
+  } catch (error) {
+    if (error instanceof NodeFileReadTooLargeError) {
+      throw new Error('file_too_large')
+    }
+    throw error
+  } finally {
+    await handle.close()
+  }
+}

--- a/src/shared/node-bounded-file-reader.ts
+++ b/src/shared/node-bounded-file-reader.ts
@@ -1,5 +1,5 @@
 import { closeSync, fstatSync, openSync, readSync, type Stats } from 'node:fs'
-import { open } from 'node:fs/promises'
+import { open, type FileHandle } from 'node:fs/promises'
 
 const MIN_GROWTH_BYTES = 64 * 1024
 
@@ -33,48 +33,55 @@ export async function readNodeFileWithinLimit(
   filePath: string,
   maxBytes: number
 ): Promise<BoundedNodeFileRead> {
+  const handle = await open(filePath, 'r')
+  try {
+    return await readNodeFileHandleWithinLimit(handle, maxBytes)
+  } finally {
+    await handle.close()
+  }
+}
+
+export async function readNodeFileHandleWithinLimit(
+  handle: FileHandle,
+  maxBytes: number
+): Promise<BoundedNodeFileRead> {
   if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
     throw new RangeError('File read limit must be a non-negative safe integer')
   }
 
-  const handle = await open(filePath, 'r')
-  try {
-    const stats = await handle.stat()
-    validateSize(stats.size, maxBytes)
+  const stats = await handle.stat()
+  validateSize(stats.size, maxBytes)
 
-    let buffer = Buffer.allocUnsafe(stats.size)
-    let offset = 0
-    while (true) {
-      while (offset < buffer.length) {
-        const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset)
-        if (bytesRead === 0) {
-          return { buffer: buffer.subarray(0, offset), stats }
-        }
-        offset += bytesRead
-      }
-
-      const probe = Buffer.allocUnsafe(1)
-      const { bytesRead } = await handle.read(probe, 0, 1, offset)
+  let buffer = Buffer.allocUnsafe(stats.size)
+  let offset = 0
+  while (true) {
+    while (offset < buffer.length) {
+      const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset)
       if (bytesRead === 0) {
         return { buffer: buffer.subarray(0, offset), stats }
       }
-      if (offset >= maxBytes) {
-        throw new NodeFileReadTooLargeError(offset + bytesRead, maxBytes)
-      }
-
-      // Why: ordinary readFile includes concurrent growth, so retain that behavior while capacity stays bounded.
-      const nextCapacity = Math.min(
-        maxBytes,
-        Math.max(MIN_GROWTH_BYTES, buffer.length * 2, offset + bytesRead)
-      )
-      const expanded = Buffer.allocUnsafe(nextCapacity)
-      buffer.copy(expanded, 0, 0, offset)
-      expanded[offset] = probe[0]!
-      buffer = expanded
       offset += bytesRead
     }
-  } finally {
-    await handle.close()
+
+    const probe = Buffer.allocUnsafe(1)
+    const { bytesRead } = await handle.read(probe, 0, 1, offset)
+    if (bytesRead === 0) {
+      return { buffer: buffer.subarray(0, offset), stats }
+    }
+    if (offset >= maxBytes) {
+      throw new NodeFileReadTooLargeError(offset + bytesRead, maxBytes)
+    }
+
+    // Why: ordinary readFile includes concurrent growth, so retain that behavior while capacity stays bounded.
+    const nextCapacity = Math.min(
+      maxBytes,
+      Math.max(MIN_GROWTH_BYTES, buffer.length * 2, offset + bytesRead)
+    )
+    const expanded = Buffer.allocUnsafe(nextCapacity)
+    buffer.copy(expanded, 0, 0, offset)
+    expanded[offset] = probe[0]!
+    buffer = expanded
+    offset += bytesRead
   }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​430 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​113 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​317 |
| Prod | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​381 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​77 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​304 |

<!-- /orca-pr-loc -->

## Summary

- replace paired-runtime preview reads with a dedicated host-enforced `files.readDocPreview` RPC
- canonicalize the worktree boundary, entry file, implicit document root, explicit directory grants, and requested target on the filesystem-owning host
- open with no-follow semantics, verify the opened handle still matches the canonical target, and read through that same bounded handle
- use the same execution-host operation for direct SSH and paired-runtime-over-SSH previews
- fail closed when an older paired runtime or SSH relay does not support scoped preview reads
- open preview targets with a guarded `O_NONBLOCK` so a writer-less FIFO in an authorized directory cannot pin an execution-host threadpool slot forever (the regular-file check then refuses it)
- surface a paired host without the scoped method as "update the paired machine", matching the SSH relay wording

## Security behavior

This closes the symlink escape reported in [CodeRabbit's #16921 finding](https://github.com/stablyai/orca/pull/16921#discussion_r3877948072). For example, an approved `docs` preview can no longer read `docs/leak -> ../.env`. It also refuses a nested implicit root that canonicalizes to the worktree root, so a directory symlink cannot silently widen authority to the whole workspace.

Mixed-version behavior is deliberate: this is a new RPC method rather than an optional field on `files.read`, so a new client paired with an old runtime receives method-not-found and does not fall back to an unscoped read.

## Validation

- `pnpm test` — 6,853 files passed; 64,074 tests passed
- focused post-rebase suite — 10 files / 76 tests passed
- `pnpm tc`
- `pnpm run check:code-quality:changed` — 0 findings

