### PR TITLE
fix(native-chat): keep attachments on multi-image sends

### DIFF
--- a/src/shared/native-chat-image-transcript-markers.test.ts
+++ b/src/shared/native-chat-image-transcript-markers.test.ts
@@ -240,3 +240,69 @@ describe('normalizeNativeChatUserText control bytes', () => {
     expect(normalizeNativeChatUserText('run\tthe\r\ntests')).toBe('run the tests')
   })
 })
+
+// Why: Claude writes one record per SEND, not per image, so a two-image send arrives as a single
+// user turn carrying one `[Image: source: …]` text block per image. Matching only a one-block turn
+// meant every multi-image send lost its attachments and leaked the raw markers as prose.
+function userTexts(id: string, texts: string[]): NativeChatMessage {
+  return {
+    id,
+    role: 'user',
+    blocks: texts.map((text) => ({ type: 'text', text })),
+    timestamp: 1,
+    source: 'transcript'
+  }
+}
+
+describe('normalizeImageTranscriptMessages with multi-image sends', () => {
+  it('merges a multi-marker source turn into the prompt that follows it', () => {
+    const out = normalizeImageTranscriptMessages([
+      userTexts('a', ['[Image: source: /tmp/a.png]', '[Image: source: /tmp/b.png]']),
+      userText('b', '[Image #1] [Image #2] describe these')
+    ])
+
+    expect(out).toHaveLength(1)
+    expect(out[0]!.blocks).toEqual([
+      { type: 'image-ref', path: '/tmp/a.png' },
+      { type: 'image-ref', path: '/tmp/b.png' },
+      { type: 'text', text: 'describe these' }
+    ])
+  })
+
+  it('keeps every path when a multi-marker turn stands alone', () => {
+    const out = normalizeImageTranscriptMessages([
+      userTexts('a', [
+        '[Image: source: /tmp/a.png]',
+        '[Image: source: /tmp/b.png]',
+        '[Image: source: /tmp/c.png]'
+      ])
+    ])
+
+    expect(out).toHaveLength(1)
+    expect(out[0]!.blocks).toEqual([
+      { type: 'image-ref', path: '/tmp/a.png' },
+      { type: 'image-ref', path: '/tmp/b.png' },
+      { type: 'image-ref', path: '/tmp/c.png' }
+    ])
+  })
+
+  // Why: a turn that also carries real prose is the user's message, not a marker record. Treating
+  // it as one would delete what they wrote.
+  it('leaves a turn that mixes markers with prose untouched', () => {
+    const mixed = userTexts('a', ['[Image: source: /tmp/a.png]', 'and here is my question'])
+    const out = normalizeImageTranscriptMessages([mixed])
+
+    expect(out[0]!.blocks).toEqual(mixed.blocks)
+  })
+
+  it('reports a multi-marker turn as an image-source turn', () => {
+    expect(
+      isImageSourceUserTurn(
+        userTexts('a', ['[Image: source: /tmp/a.png]', '[Image: source: /tmp/b.png]'])
+      )
+    ).toBe(true)
+    expect(
+      isImageSourceUserTurn(userTexts('b', ['[Image: source: /tmp/a.png]', 'my question']))
+    ).toBe(false)
+  })
+})

--- a/src/shared/native-chat-image-transcript-markers.ts
+++ b/src/shared/native-chat-image-transcript-markers.ts
@@ -12,18 +12,34 @@ const IMAGE_PROMPT_MARKER_AT_END = /\[Image #\d+\][^\S\r\n]*$/
 const HORIZONTAL_WHITESPACE_START = /^[^\S\r\n]+/
 const HORIZONTAL_WHITESPACE_END = /[^\S\r\n]+$/
 
-function soleText(message: NativeChatMessage): string | null {
-  return message.blocks.length === 1 && isTextBlock(message.blocks[0])
-    ? message.blocks[0].text
-    : null
-}
-
 export function imageSourcePathFromText(text: string): string | null {
   return text.match(IMAGE_SOURCE_MARKER)?.[1]?.trim() ?? null
 }
 
+// Why: Claude writes one record per SEND, not per image, so an N-image send arrives as a single
+// turn carrying N marker text blocks. Requiring a sole block matched only the one-image case and
+// dropped every other send's attachments. Empty unless EVERY block is a marker — a turn that also
+// carries prose is the user's own message and must not be rewritten into image refs.
+function imageSourcePaths(message: NativeChatMessage): string[] {
+  if (message.blocks.length === 0) {
+    return []
+  }
+  const paths: string[] = []
+  for (const block of message.blocks) {
+    if (!isTextBlock(block)) {
+      return []
+    }
+    const path = imageSourcePathFromText(block.text)
+    if (!path) {
+      return []
+    }
+    paths.push(path)
+  }
+  return paths
+}
+
 export function isImageSourceUserTurn(message: NativeChatMessage): boolean {
-  return message.role === 'user' && imageSourcePathFromText(soleText(message) ?? '') !== null
+  return message.role === 'user' && imageSourcePaths(message).length > 0
 }
 
 export function stripImagePromptMarker(text: string): string {
@@ -107,18 +123,22 @@ export function normalizeImageTranscriptMessages(
       normalized?.push(message)
       continue
     }
-    const imagePath = imageSourcePathFromText(soleText(message) ?? '')
-    if (imagePath) {
+    const messagePaths = imageSourcePaths(message)
+    if (messagePaths.length > 0) {
       normalized ??= messages.slice(0, index)
-      const imagePaths = [imagePath]
+      const imagePaths = [...messagePaths]
       let nextIndex = index + 1
       while (nextIndex < messages.length) {
         const candidate = messages[nextIndex]!
-        const candidatePath = imageSourcePathFromText(soleText(candidate) ?? '')
-        if (candidate.role !== 'user' || candidate.source !== message.source || !candidatePath) {
+        const candidatePaths = imageSourcePaths(candidate)
+        if (
+          candidate.role !== 'user' ||
+          candidate.source !== message.source ||
+          candidatePaths.length === 0
+        ) {
           break
         }
-        imagePaths.push(candidatePath)
+        imagePaths.push(...candidatePaths)
         nextIndex += 1
       }
       const prompt = messages[nextIndex]
@@ -137,9 +157,11 @@ export function normalizeImageTranscriptMessages(
         index = nextIndex
         continue
       }
+      // Why: only this turn's own paths — `index` is not advanced past the run here, so any
+      // following marker turns are emitted by their own iteration.
       normalized.push({
         ...message,
-        blocks: [{ type: 'image-ref', path: imagePath }]
+        blocks: messagePaths.map((path) => ({ type: 'image-ref', path }))
       })
       continue
     }


### PR DESCRIPTION
## ELI5

Attach one image to a chat message and it shows up. Attach two and both disappear, and the raw `[Image: source: /path]` text Claude uses to record them shows up as if you had typed it. The fold that turns those markers into attachments only ever matched a one-image send.

## What Changed

`src/shared/native-chat-image-transcript-markers.ts`:

- Replaced `soleText` with `imageSourcePaths(message)`, which collects a marker path from **every** block of a turn. It returns empty unless every block is a text block that is a marker, so a turn that also carries prose is never rewritten.
- `isImageSourceUserTurn` and `normalizeImageTranscriptMessages` both go through it; the run-walk over consecutive marker turns now appends each turn's whole path list.
- The standalone branch emits one `image-ref` per path from **that turn only** — `index` is not advanced past the run there, so following marker turns are still emitted by their own iteration.

No change to how a marker turn pairs with its prompt, to `[Image #N]` stripping, or to the ordering the fold expects. The only thing that moved is the block-count gate.

## Why

Claude writes one transcript record per **send**, not per image. An N-image send arrives as a prompt record with N `image` parts plus a marker record carrying N `[Image: source: …]` **text parts**, and `decodeClaudeTranscriptLine` maps that record to one message with N blocks. The gate required exactly one:

```ts
function soleText(message: NativeChatMessage): string | null {
  return message.blocks.length === 1 && isTextBlock(message.blocks[0])
    ? message.blocks[0].text
    : null
}
```

So only a single-image send took the fold. Everything above it produced **zero** `image-ref` blocks and left the markers as prose.

Shapes sampled from local Claude transcripts, prompt record ↔ its marker record:

| prompt `content` parts | marker `content` parts | occurrences |
|---|---|---|
| `text, image` | `text` | 44 |
| `text, image, image` | `text, text` | 6 |
| `text, image ×3` | `text ×3` | 3 |
| `text, image ×4` | `text ×4` | 1 |
| `text, image ×24` | `text ×24` | 1 |

Only the first row worked.

## Linked Issue

Fixes #16972

## Visual Proof

No new UI. The change is that a multi-image send renders as attachments instead of as raw marker text, which is the pipeline output below rather than a new surface.

Before, on `cf5e087246` — `normalizeImageTranscriptMessages` over a real-shaped two-image send:

```
user: [text<look at these>]
user: [text<[Image: source: /tmp/a.png]>, text<[Image: source: /tmp/b.png]>]
```

After:

```
user: [image-ref, image-ref, text<look at these>]
```

I did not capture the rendered pane; what I measured is the pipeline output the pane consumes.

## Testing

Final merge base: `cf5e087246`

**Automated** — four cases added to `src/shared/native-chat-image-transcript-markers.test.ts`:

| case | expectation |
|---|---|
| multi-marker turn followed by its prompt | merges to `image-ref ×2` + the prompt text |
| multi-marker turn standing alone | keeps all three paths as `image-ref ×3` |
| turn mixing a marker with prose | left untouched |
| `isImageSourceUserTurn` | true for marker-only, false when prose is mixed in |

Confirmed RED on the merge base: the first, second and fourth failed (`expected [ …(2) ] to have a length of 1 but got 2`, markers still text, `expected false to be true`). The mixed-prose case already passed, so it is a guard rather than new behavior — it fails if the collector is loosened to "any block is a marker".

```
npx vitest run --config config/vitest.config.ts \
  src/shared/ src/renderer/src/components/native-chat/ src/main/native-chat/
# Test Files 685 passed | 4 skipped (689) | Tests 7201 passed | 65 skipped (7266)
```

`tsc --noEmit` clean for both `config/tsconfig.tc.web.json` and `config/tsconfig.node.json`; oxlint and oxfmt clean on the changed files.

**Platforms:** mobile re-exports these functions verbatim from
`mobile/src/session/mobile-native-chat-image-transcript-markers.ts` ("Single-sources the marker logic"), so it picks the fix up with no mobile change. I could not run the mobile suite — `mobile/` fails to resolve `expo/tsconfig.base.json` in this environment and all 136 files fail that way on a clean merge base too. Exercised on macOS; the logic is pure and platform-independent.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Investigated and written with Claude (Opus 5) via Claude Code, then reviewed with Codex (`codex review`), which returned no findings. The transcript shapes above were measured from real local transcripts, and the RED/GREEN runs and suite numbers were actually run.

## Review

Adjacent open work, no overlap that I can see: #14939 touches the mobile re-export for literal-marker stripping, and #11712 preserves attachments across transcript refresh. Neither changes the block-count gate this PR fixes.

While reporting #16972 I also noticed the doc comment says marker turns come *before* the prompt, while every sampled occurrence has them *after* — the single-image case survives only via the standalone branch, so an image renders as its own bubble rather than as an attachment on the message it was sent with. That is left alone here; happy to follow up if it is not intended.
