### PR TITLE
fix(worktrees): unlink .asar files during host tree removal (#16958)

### DIFF
--- a/src/main/host-tree-removal.test.ts
+++ b/src/main/host-tree-removal.test.ts
@@ -1,0 +1,82 @@
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import type * as FsPromisesModule from 'node:fs/promises'
+import Module from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { removeHostTree, toHostRemovalPath } from './host-tree-removal'
+
+const { nodeFsRm } = vi.hoisted(() => ({
+  nodeFsRm: vi.fn()
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsPromisesModule>()
+  nodeFsRm.mockImplementation(actual.rm)
+  return { ...actual, rm: nodeFsRm }
+})
+
+const tempRoots: string[] = []
+
+beforeEach(() => {
+  nodeFsRm.mockClear()
+})
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+type NodeModuleLoader = {
+  _load(request: string, parent: unknown, isMain: boolean): unknown
+}
+
+async function withOriginalFs<T>(exports: unknown, run: () => Promise<T>): Promise<T> {
+  const loader = Module as unknown as NodeModuleLoader
+  const originalLoad = loader._load
+  loader._load = function (this: unknown, request: string, parent: unknown, isMain: boolean) {
+    if (request === 'original-fs') {
+      return exports
+    }
+    return Reflect.apply(originalLoad, this, [request, parent, isMain])
+  }
+  try {
+    return await run()
+  } finally {
+    loader._load = originalLoad
+  }
+}
+
+describe('removeHostTree', () => {
+  it('uses original-fs.promises.rm when original-fs is present', async () => {
+    const originalFsRm = vi.fn().mockResolvedValue(undefined)
+    const targetPath = join(tmpdir(), 'orca-host-tree-asar-probe')
+
+    await withOriginalFs({ promises: { rm: originalFsRm } }, async () => {
+      await removeHostTree(targetPath)
+    })
+
+    expect(originalFsRm).toHaveBeenCalledTimes(1)
+    expect(originalFsRm).toHaveBeenCalledWith(
+      toHostRemovalPath(targetPath),
+      expect.objectContaining({ recursive: true, force: true })
+    )
+    expect(nodeFsRm).not.toHaveBeenCalled()
+  })
+
+  it('deletes a directory tree that contains .asar files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-host-tree-asar-'))
+    tempRoots.push(root)
+    const electronDist = join(root, 'node_modules', 'electron', 'dist')
+    await mkdir(electronDist, { recursive: true })
+    await writeFile(join(root, 'app.asar'), 'asar-archive')
+    await writeFile(join(electronDist, 'default_app.asar'), 'default-app')
+    await writeFile(join(root, 'readme.txt'), 'keep-not')
+
+    await removeHostTree(root)
+
+    expect(existsSync(root)).toBe(false)
+    expect(existsSync(join(root, 'app.asar'))).toBe(false)
+    expect(existsSync(join(electronDist, 'default_app.asar'))).toBe(false)
+  })
+})

--- a/src/main/host-tree-removal.ts
+++ b/src/main/host-tree-removal.ts
@@ -2,7 +2,8 @@
 // generations) hits the same Windows stickiness — AV/indexers/late handle releases surface transient
 // EBUSY/ENOTEMPTY/EPERM on a tree Node just emptied. One helper so no call site forgets the retries.
 
-import { rm } from 'node:fs/promises'
+import { rm as nodeFsRm } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import { win32 } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { isWindowsAbsolutePathLike } from '../shared/cross-platform-path'
@@ -10,6 +11,26 @@ import { isWslUncPath } from '../shared/wsl-paths'
 import { transientLockRemovalOptions } from '../shared/windows-transient-lock-removal'
 
 const WINDOWS_REMOVE_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000]
+
+const requireFromMain = createRequire(__filename)
+
+type HostTreeRm = typeof nodeFsRm
+
+// Why: Electron patches node:fs so `.asar` archives look like read-only
+// directories; recursive rm walks into them and never unlinks the file.
+function loadHostTreeRm(): HostTreeRm {
+  try {
+    const originalFs = requireFromMain('original-fs') as {
+      promises?: { rm?: HostTreeRm }
+    }
+    if (typeof originalFs.promises?.rm === 'function') {
+      return originalFs.promises.rm.bind(originalFs.promises) as HostTreeRm
+    }
+  } catch {
+    // original-fs is Electron-only; Node tests and non-Electron hosts fall back.
+  }
+  return nodeFsRm
+}
 
 /** Convert a native host filesystem path to the Win32 long-path namespace. */
 export function toHostFilesystemPath(targetPath: string): string {
@@ -47,11 +68,12 @@ export async function removeHostTree(targetPath: string): Promise<void> {
   // Why: large Windows trees commonly surface transient ENOTEMPTY/EPERM while Node walks and
   // removes nested directories; Node's own retries absorb that before the loop below has to.
   const rmOptions = transientLockRemovalOptions()
+  const hostTreeRm = loadHostTreeRm()
   let attempt = 0
 
   while (true) {
     try {
-      await rm(removalPath, rmOptions)
+      await hostTreeRm(removalPath, rmOptions)
       return
     } catch (error) {
       if (attempt >= retryDelays.length || !isTransientWindowsRemovalError(error)) {


### PR DESCRIPTION
## ELI5

Deleting a worktree is supposed to wipe the leftover folder in the background. If that folder contains `.asar` files (Electron apps ship them), those files stay forever in `.orca-worktree-trash/` and the next-launch sweep cannot reclaim them. Electron pretends a `.asar` file is a read-only folder, so recursive delete walks into it instead of unlinking it. This uses Electron's unpatched filesystem for that delete, so `.asar` files go away like any other file.

## What Changed

- `removeHostTree` loads Electron `original-fs` at runtime via `createRequire(__filename)` (same pattern as `windows-native-registry.ts`) and calls `original-fs.promises.rm`.
- When `original-fs` is absent (plain Node, tests, non-Electron hosts), it falls back to `node:fs/promises.rm`.
- `process.noAsar` is not used: that flag is global and not reentrant against overlapping trash and history deletes.
- New `host-tree-removal.test.ts`: does not mock `removeHostTree`; when `original-fs` is present, asserts `original-fs.promises.rm` is the callee (not `node:fs` `rm`); builds a real directory tree that contains `.asar` files and asserts the whole tree is deleted.

Call sites (`worktree-trash` delete + sweep, terminal history, local worktree filesystem) are unchanged. No RPC/stream/wire change.

## Why

`removeHostTree` used Electron-patched `node:fs/promises.rm({ recursive, force })`. Under that patch, `.asar` archives are virtual read-only directories and are never unlinked. `worktree-trash` calls the same helper for both background trash delete and `sweepStaleWorktreeTrash`, so leftovers accumulate forever. This is residual of merged #11233 (the only prior commit on this file). `original-fs` is the unpatched Node `fs` Electron already ships, so it unlinks `.asar` as a regular file without mutating global asar state.

SSH / WSL / folder workspaces: this helper is the local (or remote-Orca-server) host recursive delete. Those environments still need the Node fallback when `original-fs` is missing. Paths still go through `toHostRemovalPath`. No Git command change.

## Linked Issue

Fixes #16958

## Visual Proof

N/A — host filesystem delete path only; no UI or interaction change.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Focused:

```
pnpm exec vitest run --config config/vitest.config.ts src/main/host-tree-removal.test.ts
```

2 passed (failed on main for the original-fs callee assertion, then passed after the fix). Related `worktree-trash.test.ts` and `local-worktree-filesystem.test.ts` also passed. Tests do not mock `removeHostTree`. I did not manually delete a multi-GB Electron worktree on a packaged Orca build.

## AI Disclosure

Implemented with grok-4.6 in the orca-ship-issue-pr workflow.

## Review

RC is real. `removeHostTree` now selects Electron `original-fs` via `createRequire` with a `node:fs` fallback, which is reentrant and does not touch `process.noAsar`. No covering PR; call sites, SSH/WSL/folder, and mixed-version wire are unchanged. Tests do not mock `removeHostTree`; vitest 2/2 passed.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
