### PR TITLE
fix(daemon): close #16924 review P2s — degrade warn, reap comment, Windows claim-reap CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -707,6 +707,7 @@ jobs:
           src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
           src/shared/secure-file-fsync-flags.test.ts
           src/main/daemon/daemon-pid-publish-disk-contract.test.ts
+          src/main/daemon/daemon-pid-publish-claim-reap.test.ts
           src/main/ipc/pty-codex-account-attribution.test.ts
           src/main/ipc/pty-spawn-env-codex-resume-provenance.test.ts
 

--- a/config/scripts/pr-code-change-scope.mjs
+++ b/config/scripts/pr-code-change-scope.mjs
@@ -196,6 +196,7 @@ const WINDOWS_PACKAGE_TESTS = [
   'src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts',
   'src/shared/secure-file-fsync-flags.test.ts',
   'src/main/daemon/daemon-pid-publish-disk-contract.test.ts',
+  'src/main/daemon/daemon-pid-publish-claim-reap.test.ts',
   'src/main/ipc/pty-codex-account-attribution.test.ts',
   'src/main/ipc/pty-spawn-env-codex-resume-provenance.test.ts'
 ]

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -274,14 +274,18 @@ async function main(): Promise<void> {
     ...(pidPath && launchNonce
       ? {
           publishEndpointOwnership: () =>
-            publishDaemonPidFile(pidPath, {
-              pid: process.pid,
-              ...readyIdentity,
-              ...(entryPath ? { entryPath } : {}),
-              ...(appVersion ? { appVersion } : {}),
-              ...(spawnerExecPath ? { spawnerExecPath } : {}),
-              launchNonce
-            })
+            publishDaemonPidFile(
+              pidPath,
+              {
+                pid: process.pid,
+                ...readyIdentity,
+                ...(entryPath ? { entryPath } : {}),
+                ...(appVersion ? { appVersion } : {}),
+                ...(spawnerExecPath ? { spawnerExecPath } : {}),
+                launchNonce
+              },
+              daemonLog
+            )
         }
       : {}),
     log: daemonLog,

--- a/src/main/daemon/daemon-pid-publish-atomicity.test.ts
+++ b/src/main/daemon/daemon-pid-publish-atomicity.test.ts
@@ -130,6 +130,9 @@ describe('publishDaemonPidFile atomicity', () => {
     expect(() => publishDaemonPidFile(pidPath, RECORD)).toThrow(/EEXIST/)
     expect(readFileSync(pidPath, 'utf8')).toBe(existing)
     expect(listPublishScratch()).toEqual([])
+    // An ownership conflict is routine, not a degrade: warning here would make the
+    // real non-atomic warning below indistinguishable from a lost publish race.
+    expect(warnSpy).not.toHaveBeenCalled()
   })
 
   it('degrades to the exclusive direct write when the filesystem cannot hard-link', () => {

--- a/src/main/daemon/daemon-pid-publish-atomicity.test.ts
+++ b/src/main/daemon/daemon-pid-publish-atomicity.test.ts
@@ -55,15 +55,19 @@ function listPublishScratch(): string[] {
   return readdirSync(dir).filter((name) => name !== 'daemon-v1.pid')
 }
 
+let warnSpy: ReturnType<typeof vi.spyOn>
+
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'daemon-pid-atomic-'))
   pidPath = join(dir, 'daemon-v1.pid')
   fsFaults.tornWriteBytes = null
   fsFaults.linkError = null
   fsFaults.events = []
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 })
 
 afterEach(() => {
+  warnSpy.mockRestore()
   rmSync(dir, { recursive: true, force: true })
 })
 
@@ -100,6 +104,9 @@ describe('publishDaemonPidFile atomicity', () => {
 
     expect(parseDaemonPidFile(readFileSync(pidPath, 'utf8'))).toMatchObject(RECORD)
     expect(listPublishScratch()).toEqual([])
+    // The atomic path is the normal one; warning on it would train operators to ignore
+    // the degrade warning below.
+    expect(warnSpy).not.toHaveBeenCalled()
   })
 
   it('flushes the record to disk before it becomes visible at the canonical path', () => {
@@ -132,6 +139,11 @@ describe('publishDaemonPidFile atomicity', () => {
 
     expect(parseDaemonPidFile(readFileSync(pidPath, 'utf8'))).toMatchObject(RECORD)
     expect(listPublishScratch()).toEqual([])
+    // The degrade must be operator-visible: on a volume without hard links every publish
+    // silently loses torn-write protection otherwise.
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('ENOTSUP'))
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('non-atomic'))
   })
 
   it('keeps exclusive-create semantics on the degraded path too', () => {

--- a/src/main/daemon/daemon-pid-publish-atomicity.test.ts
+++ b/src/main/daemon/daemon-pid-publish-atomicity.test.ts
@@ -149,6 +149,27 @@ describe('publishDaemonPidFile atomicity', () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('non-atomic'))
   })
 
+  it('records the degrade on the daemon file log, which is the only channel the detached daemon keeps', () => {
+    // The daemon runs with stdio 'ignore' and its startup stderr pipe is destroyed once
+    // it is up, so a console-only warning never reaches the operator it is written for.
+    const entries: { event: string; details?: Record<string, unknown> }[] = []
+    fsFaults.linkError = Object.assign(new Error('injected ENOTSUP'), { code: 'ENOTSUP' })
+
+    publishDaemonPidFile(pidPath, RECORD, {
+      log: (event, details) => entries.push({ event, ...(details ? { details } : {}) })
+    })
+
+    expect(entries).toEqual([{ event: 'pid-publish-degraded', details: { errno: 'ENOTSUP' } }])
+  })
+
+  it('leaves the daemon file log untouched when the atomic path succeeds', () => {
+    const entries: string[] = []
+
+    publishDaemonPidFile(pidPath, RECORD, { log: (event) => entries.push(event) })
+
+    expect(entries).toEqual([])
+  })
+
   it('keeps exclusive-create semantics on the degraded path too', () => {
     publishDaemonPidFile(pidPath, { pid: 1, startedAtMs: 5, launchNonce: 'other' })
     fsFaults.linkError = Object.assign(new Error('injected ENOTSUP'), { code: 'ENOTSUP' })

--- a/src/main/daemon/daemon-pid-publish-atomicity.test.ts
+++ b/src/main/daemon/daemon-pid-publish-atomicity.test.ts
@@ -170,6 +170,28 @@ describe('publishDaemonPidFile atomicity', () => {
     expect(entries).toEqual([])
   })
 
+  it('stays silent when the degraded write itself loses the ownership race', () => {
+    // Same catch arm as the degrade, but nothing was published: announcing lost
+    // torn-write protection for a record that was never written is a false alarm.
+    const entries: string[] = []
+    publishDaemonPidFile(pidPath, { pid: 1, startedAtMs: 5, launchNonce: 'other' })
+    fsFaults.linkError = Object.assign(new Error('injected ENOTSUP'), { code: 'ENOTSUP' })
+
+    expect(() =>
+      publishDaemonPidFile(pidPath, RECORD, { log: (event) => entries.push(event) })
+    ).toThrow(/EEXIST/)
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(entries).toEqual([])
+  })
+
+  it('names the errno even when the link error carries none', () => {
+    fsFaults.linkError = new Error('injected link failure with no code')
+
+    publishDaemonPidFile(pidPath, RECORD)
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no errno'))
+  })
+
   it('keeps exclusive-create semantics on the degraded path too', () => {
     publishDaemonPidFile(pidPath, { pid: 1, startedAtMs: 5, launchNonce: 'other' })
     fsFaults.linkError = Object.assign(new Error('injected ENOTSUP'), { code: 'ENOTSUP' })

--- a/src/main/daemon/daemon-pid-publish-atomicity.test.ts
+++ b/src/main/daemon/daemon-pid-publish-atomicity.test.ts
@@ -14,14 +14,20 @@ import { parseDaemonPidFile } from './daemon-pid-file-parse'
  */
 const fsFaults: {
   tornWriteBytes: number | null
+  claimWriteError: NodeJS.ErrnoException | null
   linkError: NodeJS.ErrnoException | null
   events: string[]
-} = { tornWriteBytes: null, linkError: null, events: [] }
+} = { tornWriteBytes: null, claimWriteError: null, linkError: null, events: [] }
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof NodeFs>()
   const writeFileSync: typeof actual.writeFileSync = (file, data, options) => {
     fsFaults.events.push(`write:${String(file)}`)
+    // A full-disk or permission failure on the claim leaves no file behind at all,
+    // unlike the torn write above which persists a prefix first.
+    if (fsFaults.claimWriteError && String(file).includes('.publish-')) {
+      throw fsFaults.claimWriteError
+    }
     if (fsFaults.tornWriteBytes !== null && typeof data === 'string') {
       actual.writeFileSync(file, data.slice(0, fsFaults.tornWriteBytes), options)
       throw Object.assign(new Error('injected crash mid-write'), { code: 'EIO' })
@@ -61,6 +67,7 @@ beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'daemon-pid-atomic-'))
   pidPath = join(dir, 'daemon-v1.pid')
   fsFaults.tornWriteBytes = null
+  fsFaults.claimWriteError = null
   fsFaults.linkError = null
   fsFaults.events = []
   warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -133,6 +140,31 @@ describe('publishDaemonPidFile atomicity', () => {
     // An ownership conflict is routine, not a degrade: warning here would make the
     // real non-atomic warning below indistinguishable from a lost publish race.
     expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('refuses an ownership conflict outright instead of retrying it as a direct write', () => {
+    // Why the conflict is modelled at link time with the canonical path FREE: the record
+    // can be reclaimed between the failed link and the fallback write. Retrying the
+    // conflict as an exclusive write would then succeed and silently take ownership the
+    // EEXIST exists to deny. The conflict must be refused where it is detected.
+    fsFaults.linkError = Object.assign(new Error('injected EEXIST'), { code: 'EEXIST' })
+
+    expect(() => publishDaemonPidFile(pidPath, RECORD)).toThrow(/EEXIST/)
+
+    expect(fsFaults.events).not.toContain(`write:${pidPath}`)
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(listPublishScratch()).toEqual([])
+  })
+
+  it('surfaces the original publish failure, not the failure of its own cleanup', () => {
+    // Why: when the claim write fails outright no claim exists, so the `finally` unlink
+    // fails too. An unswallowed cleanup error replaces the real cause — an operator
+    // debugging a full disk would be handed ENOENT instead of ENOSPC.
+    fsFaults.claimWriteError = Object.assign(new Error('injected claim write failure'), {
+      code: 'ENOSPC'
+    })
+
+    expect(() => publishDaemonPidFile(pidPath, RECORD)).toThrow('injected claim write failure')
   })
 
   it('degrades to the exclusive direct write when the filesystem cannot hard-link', () => {

--- a/src/main/daemon/daemon-pid-publish-claim-reap.test.ts
+++ b/src/main/daemon/daemon-pid-publish-claim-reap.test.ts
@@ -99,6 +99,24 @@ describe('reapOrphanedDaemonPidPublishClaims', () => {
     expect(existsSync(foreign)).toBe(true)
   })
 
+  it('keeps a claim whose owner is live but unsignalable on Windows', () => {
+    // Why a second errno: Windows reports a live foreign owner as EACCES, not the POSIX
+    // EPERM above (isPermissionError in win32-utils treats both as one). Only ESRCH reaps.
+    const foreign = join(dir, `daemon-v7.pid.publish-424242-${CLAIM_UUID}`)
+    writeFileSync(foreign, '{"pid":1')
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    })
+
+    try {
+      reapOrphanedDaemonPidPublishClaims(dir)
+    } finally {
+      kill.mockRestore()
+    }
+
+    expect(existsSync(foreign)).toBe(true)
+  })
+
   it('never lets an unremovable claim abort the sweep or the launch', () => {
     // Why: reaping is hygiene on the launch funnel, so any failure here — a Windows file
     // lock, a permission error, a stray directory under a claim name — must not escape

--- a/src/main/daemon/daemon-pid-publish-claim-reap.test.ts
+++ b/src/main/daemon/daemon-pid-publish-claim-reap.test.ts
@@ -1,8 +1,8 @@
 import { spawn, spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { reapOrphanedDaemonPidPublishClaims } from './daemon-pid-publish-claim-reap'
 import { DaemonSpawner, getDaemonPidPublishClaimPath } from './daemon-spawner'
 
@@ -77,6 +77,42 @@ describe('reapOrphanedDaemonPidPublishClaims', () => {
     for (const path of untouchable) {
       expect(existsSync(path)).toBe(true)
     }
+  })
+
+  it('keeps a claim whose owner exists under another user', () => {
+    // Why EPERM is not death: `kill(pid, 0)` reports EPERM for a live process owned by
+    // another user (a root-launched daemon, a shared machine). Reaping on any errno
+    // would delete a LIVE publisher's claim between its write and its link, knocking
+    // that publish off the atomic path onto the non-atomic degraded write.
+    const foreign = join(dir, `daemon-v7.pid.publish-424242-${CLAIM_UUID}`)
+    writeFileSync(foreign, '{"pid":1')
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('operation not permitted'), { code: 'EPERM' })
+    })
+
+    try {
+      reapOrphanedDaemonPidPublishClaims(dir)
+    } finally {
+      kill.mockRestore()
+    }
+
+    expect(existsSync(foreign)).toBe(true)
+  })
+
+  it('never lets an unremovable claim abort the sweep or the launch', () => {
+    // Why: reaping is hygiene on the launch funnel, so any failure here — a Windows file
+    // lock, a permission error, a stray directory under a claim name — must not escape
+    // into ensureRunning and stop the daemon from starting.
+    const pid = deadPid()
+    const unremovable = join(dir, `daemon-v7.pid.publish-${pid}-${CLAIM_UUID}`)
+    mkdirSync(unremovable)
+    writeFileSync(join(unremovable, 'occupant'), 'x')
+    const removable = join(dir, `daemon-v9.pid.publish-${pid}-${CLAIM_UUID}`)
+    writeFileSync(removable, '{"pid":1')
+
+    expect(() => reapOrphanedDaemonPidPublishClaims(dir)).not.toThrow()
+
+    expect(existsSync(removable)).toBe(false)
   })
 
   it('tolerates a missing runtime dir', () => {

--- a/src/main/daemon/daemon-pid-publish-claim-reap.ts
+++ b/src/main/daemon/daemon-pid-publish-claim-reap.ts
@@ -13,8 +13,10 @@ const PUBLISH_CLAIM_PATTERN = /^daemon-v\d+\.pid\.publish-(\d+)-[0-9a-f-]+$/
 
 /**
  * Why proven death and not age: a claim is only scratch — its content was never canonical —
- * but deleting a LIVE publisher's claim between its write and its link would fail that
- * publish. Only ESRCH proves the owner is gone; EPERM means it exists under another user,
+ * but deleting a LIVE publisher's claim between its write and its link knocks that publish
+ * off the atomic path: the link fails non-EEXIST and degrades to the exclusive direct
+ * write, which succeeds but reopens the torn-write window this discipline exists to close.
+ * Only ESRCH proves the owner is gone; EPERM means it exists under another user,
  * and pid recycling merely preserves junk a little longer, which is the safe direction.
  */
 function claimOwnerIsProvenDead(pid: number): boolean {

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -11,6 +11,7 @@ import {
 } from 'node:fs'
 import { join } from 'node:path'
 import { fsyncFileSync } from '../../shared/secure-file'
+import type { DaemonFileLog } from './daemon-file-log'
 import { PROTOCOL_VERSION } from './types'
 import { reapOrphanedDaemonPidPublishClaims } from './daemon-pid-publish-claim-reap'
 import { DaemonCrashLoopError, DaemonRespawnThrottle } from './daemon-respawn-throttle'
@@ -176,7 +177,11 @@ export function getDaemonPidPublishClaimPath(pidPath: string): string {
   return `${pidPath}.publish-${process.pid}-${randomUUID()}`
 }
 
-export function publishDaemonPidFile(pidPath: string, pidFile: DaemonPidFile): void {
+export function publishDaemonPidFile(
+  pidPath: string,
+  pidFile: DaemonPidFile,
+  log?: Pick<DaemonFileLog, 'log'>
+): void {
   const claimPath = getDaemonPidPublishClaimPath(pidPath)
   try {
     writeFileSync(claimPath, serializeDaemonPidFile(pidFile), { mode: 0o600, flag: 'wx' })
@@ -199,6 +204,10 @@ export function publishDaemonPidFile(pidPath: string, pidFile: DaemonPidFile): v
       // instead of trading a torn-write window for no pid record at all. Warn because the
       // degrade is otherwise invisible: an operator on such a volume (network mount,
       // container overlay) should be able to tell the atomic path is not in use.
+      // Both channels, matching daemon-endpoint-lifecycle.ts: inside the detached
+      // daemon stdio is 'ignore' and its startup stderr pipe is destroyed once it is
+      // up, so console alone reaches nobody on the path this warning exists for.
+      log?.log('pid-publish-degraded', { errno: describeErrnoCode(error) })
       console.warn(
         `[daemon] pid-record hard-link publish failed (${describeErrnoCode(error)}); ` +
           'degrading to the non-atomic exclusive write — torn-write protection is off for this record'

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -204,6 +204,10 @@ export function publishDaemonPidFile(
       // instead of trading a torn-write window for no pid record at all. Warn because the
       // degrade is otherwise invisible: an operator on such a volume (network mount,
       // container overlay) should be able to tell the atomic path is not in use.
+      writeFileSync(pidPath, serializeDaemonPidFile(pidFile), { mode: 0o600, flag: 'wx' })
+      // Announced only once the degraded write has actually landed: this same arm is
+      // reached by a lost ownership race, where the write throws EEXIST and nothing
+      // was published — claiming torn-write exposure for that would be a lie.
       // Both channels, matching daemon-endpoint-lifecycle.ts: inside the detached
       // daemon stdio is 'ignore' and its startup stderr pipe is destroyed once it is
       // up, so console alone reaches nobody on the path this warning exists for.
@@ -212,7 +216,6 @@ export function publishDaemonPidFile(
         `[daemon] pid-record hard-link publish failed (${describeErrnoCode(error)}); ` +
           'degrading to the non-atomic exclusive write — torn-write protection is off for this record'
       )
-      writeFileSync(pidPath, serializeDaemonPidFile(pidFile), { mode: 0o600, flag: 'wx' })
     }
   } finally {
     try {

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -160,6 +160,12 @@ function isExistingFileError(error: unknown): boolean {
   return typeof error === 'object' && error !== null && 'code' in error && error.code === 'EEXIST'
 }
 
+function describeErrnoCode(error: unknown): string {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String(error.code)
+    : 'no errno'
+}
+
 /**
  * Scratch for the atomic publish below. Distinct from the swap/hold claims: those can hold
  * the ONLY copy of a live record and must be restored, while publish scratch holds a record
@@ -190,7 +196,13 @@ export function publishDaemonPidFile(pidPath: string, pidFile: DaemonPidFile): v
       }
       // Why: hard links can be unsupported on exotic volumes. The exclusive direct write
       // is exactly the pre-atomic behavior, so those filesystems keep a working daemon
-      // instead of trading a torn-write window for no pid record at all.
+      // instead of trading a torn-write window for no pid record at all. Warn because the
+      // degrade is otherwise invisible: an operator on such a volume (network mount,
+      // container overlay) should be able to tell the atomic path is not in use.
+      console.warn(
+        `[daemon] pid-record hard-link publish failed (${describeErrnoCode(error)}); ` +
+          'degrading to the non-atomic exclusive write — torn-write protection is off for this record'
+      )
       writeFileSync(pidPath, serializeDaemonPidFile(pidFile), { mode: 0o600, flag: 'wx' })
     }
   } finally {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​147 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​144 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 |

<!-- /orca-pr-loc -->

## ELI5

Its parent PR made Orca's terminal helper write its "I'm running, here's my id" note in one
all-or-nothing move, so a crash mid-write can't leave half a note behind. That trick needs a
filesystem feature that a few setups don't have — network drives and some container filesystems —
and on those Orca quietly went back to the old, interruptible way of writing. Quietly is the problem:
nobody could tell which mode they were in.

This PR makes Orca say so in its log when it has to fall back, corrects a comment that described the
wrong failure, and makes the existing safety check for leftover scratch files actually run on Windows
in CI. Nothing you click behaves differently.

## User-facing before / after

| | Before | After |
|---|---|---|
| Your Orca data directory sits on a filesystem without hard links (a network mount, some container overlays) | Orca silently used the old, interruptible way of writing its helper record. If you later hit the crash-corruption problem, there was no way to tell why | Orca logs a warning naming the exact filesystem error, so the fallback is visible when you go looking |
| Everything else about starting, using, or closing terminals | — | Unchanged. The remaining changes are a corrected code comment and running an existing safety test on Windows in CI |

## When it bites

Only people whose Orca data directory is on a filesystem that refuses hard links — network home
directories and some container/VM setups. Everyone else sees no change at all; this PR adds a
diagnostic, not a behaviour.


Follow-up to #16924 closing the three P2s from its review (comment 5447786752). Stacked on `brennanb2025/daemon-pid-atomic-publish-r1` because the code under change exists only there; after #16924 merges this needs a manual retarget onto main.

- **P2a** — the reap rationale comment in `daemon-pid-publish-claim-reap.ts` claimed deleting a live publisher's claim "would fail that publish". It actually knocks the publish off the atomic path: the link fails non-EEXIST and degrades to the exclusive direct write, which succeeds but reopens the torn-write window. Comment now says exactly that.
- **P2b** — the no-hardlink degrade path in `publishDaemonPidFile` was silent. It now `console.warn`s with the errno, so an operator on a filesystem without hard links (network mounts, container overlays) can tell the atomic path is not in use. Pinned by the atomicity test: warn fires exactly once on the degrade path (ablation-proven failing-first — reverting the production hunk fails the test), and the normal atomic path asserts no warn.
- **P2c** — the reaper's proven-dead gate (`process.kill(pid, 0)` / ESRCH) was untested on Windows CI, and Windows process-existence probing is a different mechanism (OpenProcess, not POSIX signals). `daemon-pid-publish-claim-reap.test.ts` already asserts with real fs and real processes that the reaper does NOT reap a claim whose owner is alive and DOES reap one whose owner is gone; it is now wired into the package (windows) job the same way #16924 wired the disk-contract test — added to BOTH the `pr.yml` "Test Windows-specific boundaries" vitest list AND `WINDOWS_PACKAGE_TESTS` in `config/scripts/pr-code-change-scope.mjs`. Editing those two files is GLOBAL_FORCE, so this PR's own CI run executes the file on windows-2022 as the proof.

No change to the link-vs-rename design (the three EEXIST-dependent call sites are untouched). Local: 37/37 daemon pid tests green, `pnpm tc:node` clean, oxlint clean, both CI-wiring pin suites green (25/25).

