### PR TITLE
fix(agent-hooks): stop test runs and secondary profiles deleting the user's agent hooks (STA-5679)

### DIFF
--- a/src/cli/runtime-client-deferral.test.ts
+++ b/src/cli/runtime-client-deferral.test.ts
@@ -1,11 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { readFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 
-const { constructorArgsMock, callMock, getCliStatusMock } = vi.hoisted(() => ({
+const {
+  applyAgentStatusHooksEnabledMock,
+  constructorArgsMock,
+  callMock,
+  getCliStatusMock,
+  testUserDataPathRef
+} = vi.hoisted(() => ({
+  applyAgentStatusHooksEnabledMock: vi.fn(async () => []),
   constructorArgsMock: vi.fn(),
   callMock: vi.fn(),
-  getCliStatusMock: vi.fn()
+  getCliStatusMock: vi.fn(),
+  testUserDataPathRef: { current: '' }
 }))
 
 // Why: `main` reaches RuntimeClient through `await import('./runtime-client.js')`
@@ -30,7 +39,7 @@ vi.mock('./runtime/environments', async (importOriginal) => {
 // Stubbed, not dropped: the row is the only case that reads ctx.client, so it carries the
 // null-vs-undefined coverage the rest of the table cannot.
 vi.mock('../main/agent-hooks/managed-agent-hook-controls', () => ({
-  applyAgentStatusHooksEnabled: vi.fn(async () => []),
+  applyAgentStatusHooksEnabled: applyAgentStatusHooksEnabledMock,
   getManagedAgentHookStatuses: vi.fn(() => []),
   prepareManagedCodexHomeBeforeShellLaunch: vi.fn(async () => {})
 }))
@@ -45,7 +54,7 @@ vi.mock('./runtime-client', () => {
       constructorArgsMock(...args)
     }
   }
-  return { RuntimeClient, getDefaultUserDataPath: () => '/tmp/orca-user-data' }
+  return { RuntimeClient, getDefaultUserDataPath: () => testUserDataPathRef.current }
 })
 
 import { main } from './index'
@@ -58,6 +67,8 @@ describe('RuntimeClient module-graph deferral', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    testUserDataPathRef.current = mkdtempSync(join(tmpdir(), 'orca-runtime-deferral-userdata-'))
+    applyAgentStatusHooksEnabledMock.mockClear()
     constructorArgsMock.mockClear()
     callMock.mockReset()
     getCliStatusMock.mockReset()
@@ -69,6 +80,7 @@ describe('RuntimeClient module-graph deferral', () => {
     logSpy.mockRestore()
     errorSpy.mockRestore()
     vi.unstubAllEnvs()
+    rmSync(testUserDataPathRef.current, { recursive: true, force: true })
     process.exitCode = 0
   })
 
@@ -145,6 +157,20 @@ describe('RuntimeClient module-graph deferral', () => {
       for (const call of calls) {
         expect(call[2], `${argv.join(' ')} pairing code`).toBeNull()
         expect(call[3], `${argv.join(' ')} environment`).toBeNull()
+      }
+      if (argv.join(' ') === 'agent hooks off') {
+        expect(
+          applyAgentStatusHooksEnabledMock,
+          `${argv.join(' ')} hook application`
+        ).toHaveBeenCalledExactlyOnceWith(false, {
+          agentCmdOverrides: {},
+          disabledTuiAgents: []
+        })
+      } else {
+        expect(
+          applyAgentStatusHooksEnabledMock,
+          `${argv.join(' ')} hook application`
+        ).not.toHaveBeenCalled()
       }
     }
   )

--- a/src/cli/runtime-client-deferral.test.ts
+++ b/src/cli/runtime-client-deferral.test.ts
@@ -21,6 +21,20 @@ vi.mock('./runtime/environments', async (importOriginal) => {
   }
 })
 
+// Why: this suite runs the REAL `main()`, and `agent hooks off` below reaches the production
+// handler, which calls removeManagedAgentHooks() against the developer's OWN ~/.claude and
+// ~/.cursor — a green test run silently deleted every Orca-managed hook on the machine, so agent
+// status stopped reporting until the next Orca restart (STA-5679). The byte-for-byte equivalence
+// twin already refuses these tokens for exactly this reason
+// (config/scripts/cli-runtime-client-deferral-equivalence.mjs); this is the same guard for vitest.
+// Stubbed, not dropped: the row is the only case that reads ctx.client, so it carries the
+// null-vs-undefined coverage the rest of the table cannot.
+vi.mock('../main/agent-hooks/managed-agent-hook-controls', () => ({
+  applyAgentStatusHooksEnabled: vi.fn(async () => []),
+  getManagedAgentHookStatuses: vi.fn(() => []),
+  prepareManagedCodexHomeBeforeShellLaunch: vi.fn(async () => {})
+}))
+
 vi.mock('./runtime-client', () => {
   class RuntimeClient {
     call = callMock

--- a/src/main/agent-hooks/managed-agent-hook-controls.test.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.test.ts
@@ -45,6 +45,7 @@ import {
   applyAgentStatusHooksEnabled,
   installManagedAgentHooks,
   removeManagedAgentHooksAsync,
+  resolveStartupManagedHookAction,
   shouldContinueManagedHookStartup
 } from './managed-agent-hook-controls'
 
@@ -271,5 +272,35 @@ describe('managed agent hook controls', () => {
     expect(mocks.removeClaudeAsync).not.toHaveBeenCalled()
     expect(mocks.removeCodexAsync).toHaveBeenCalledTimes(1)
     expect(results).toEqual([expect.objectContaining({ agent: 'codex', state: 'not_installed' })])
+  })
+})
+
+describe('startup managed hook reconciliation (STA-5679)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('skips instead of removing when this profile has the off switch set', () => {
+    // Why this matters: the hook files are user-global. Startup removal here deleted the hooks that
+    // every other Orca instance depends on, and Cursor then reads as idle with no status at all.
+    expect(resolveStartupManagedHookAction({ agentStatusHooksEnabled: false })).toBe('skip')
+  })
+
+  it('installs when hooks are enabled or the setting is unset', () => {
+    expect(resolveStartupManagedHookAction({ agentStatusHooksEnabled: true })).toBe('install')
+    expect(resolveStartupManagedHookAction({})).toBe('install')
+    expect(resolveStartupManagedHookAction(null)).toBe('install')
+  })
+
+  it('still removes through the explicit Settings toggle', async () => {
+    // Anchors the assertion above: the removers really are wired, so 'skip' is a behavioral
+    // difference rather than a vacuous constant.
+    mocks.removeClaude.mockResolvedValue(status('claude', 'not_installed'))
+    mocks.removeCodex.mockResolvedValue(status('codex', 'not_installed'))
+
+    await applyAgentStatusHooksEnabled(false, { agentStatusHooksEnabled: false })
+
+    expect(mocks.removeClaude).toHaveBeenCalledTimes(1)
+    expect(mocks.removeCodex).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/agent-hooks/managed-agent-hook-controls.test.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.test.ts
@@ -46,6 +46,7 @@ import {
   installManagedAgentHooks,
   removeManagedAgentHooksAsync,
   resolveStartupManagedHookAction,
+  shouldInstallStartupManagedAgentHook,
   shouldContinueManagedHookStartup
 } from './managed-agent-hook-controls'
 
@@ -290,6 +291,41 @@ describe('startup managed hook reconciliation (STA-5679)', () => {
     expect(resolveStartupManagedHookAction({ agentStatusHooksEnabled: true })).toBe('install')
     expect(resolveStartupManagedHookAction({})).toBe('install')
     expect(resolveStartupManagedHookAction(null)).toBe('install')
+  })
+
+  it('only allows startup installs for globally enabled and agent-enabled hooks', () => {
+    expect(shouldInstallStartupManagedAgentHook({ agentStatusHooksEnabled: false }, 'codex')).toBe(
+      false
+    )
+    expect(
+      shouldInstallStartupManagedAgentHook(
+        { agentStatusHooksEnabled: true, disabledTuiAgents: ['codex'] },
+        'codex'
+      )
+    ).toBe(false)
+    expect(
+      shouldInstallStartupManagedAgentHook(
+        { agentStatusHooksEnabled: true, disabledTuiAgents: ['claude'] },
+        'codex'
+      )
+    ).toBe(true)
+  })
+
+  it('does not remove disabled agents during startup install reconciliation', async () => {
+    const settings = {
+      agentStatusHooksEnabled: true,
+      agentCmdOverrides: {},
+      disabledTuiAgents: ['claude' as const]
+    }
+    mocks.detect.mockResolvedValue({ codex: { state: 'found' } })
+
+    await installManagedAgentHooks(settings, {
+      shouldContinue: (agent) => shouldContinueManagedHookStartup(false, settings, agent)
+    })
+
+    expect(mocks.removeClaude).not.toHaveBeenCalled()
+    expect(mocks.installClaude).not.toHaveBeenCalled()
+    expect(mocks.installCodex).toHaveBeenCalledTimes(1)
   })
 
   it('still removes through the explicit Settings toggle', async () => {

--- a/src/main/agent-hooks/managed-agent-hook-controls.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.ts
@@ -54,6 +54,16 @@ export function resolveStartupManagedHookAction(
   return isAgentStatusHooksEnabled(settings) ? 'install' : 'skip'
 }
 
+export function shouldInstallStartupManagedAgentHook(
+  settings: ManagedHookSettings,
+  agent: AgentHookTarget
+): boolean {
+  return (
+    resolveStartupManagedHookAction(settings) === 'install' &&
+    !normalizeDisabledTuiAgents(settings?.disabledTuiAgents).includes(agent)
+  )
+}
+
 export function shouldContinueManagedHookStartup(
   isQuitting: boolean,
   settings: ManagedHookSettings,

--- a/src/main/agent-hooks/managed-agent-hook-controls.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.ts
@@ -41,6 +41,19 @@ export function isAgentStatusHooksEnabled(
   return settings?.agentStatusHooksEnabled !== false
 }
 
+export type StartupManagedHookAction = 'install' | 'skip'
+
+// Why never 'remove': this reads THIS instance's settings, but the managed hook files are
+// user-global (~/.claude/settings.json, ~/.cursor/hooks.json). A second Orca profile with the off
+// switch set would delete the hooks every other instance depends on, and Cursor — the one agent
+// with no title-derived status fallback — then goes silently idle (STA-5679). Honoring the off
+// switch only requires skipping the install; explicit removal stays on the Settings toggle.
+export function resolveStartupManagedHookAction(
+  settings: ManagedHookSettings
+): StartupManagedHookAction {
+  return isAgentStatusHooksEnabled(settings) ? 'install' : 'skip'
+}
+
 export function shouldContinueManagedHookStartup(
   isQuitting: boolean,
   settings: ManagedHookSettings,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -91,8 +91,8 @@ import {
 import {
   applyAgentStatusHooksEnabled,
   isAgentStatusHooksEnabled,
-  removeManagedAgentHooks,
   removeManagedAgentHooksAsync,
+  resolveStartupManagedHookAction,
   shouldContinueManagedHookStartup
 } from './agent-hooks/managed-agent-hook-controls'
 import { initCohortClassifier } from './telemetry/cohort-classifier'
@@ -3097,29 +3097,28 @@ void app.whenReady().then(async () => {
         console.warn('[codex-real-home-hooks] startup ensure failed:', error)
       })
     : Promise.resolve()
-  if (shouldInstallManagedHooks(is.dev)) {
-    // Why: check the persisted off switch before any auto-install so removed hooks don't silently reappear on launch.
-    if (isAgentStatusHooksEnabled(store.getSettings())) {
-      const managedHookStore = store
-      void realHomeCodexHookState
-        .then(() =>
-          applyAgentStatusHooksEnabled(true, managedHookStore.getSettings(), {
-            shouldHydrateShellPath: app.isPackaged,
-            onInstallError: recordManagedHookInstallFailure,
-            shouldContinue: (agent) => {
-              const settings = managedHookStore.getSettings()
-              return shouldContinueManagedHookStartup(isQuitting, settings, agent)
-            }
-          })
-        )
-        .catch((error: unknown) => {
-          console.warn('[agent-hooks] failed to reconcile managed hooks on startup:', error)
+  // Why skip rather than remove when the off switch is set: the hook files are user-global but this
+  // decision reads only THIS profile's settings, so removing here deletes the hooks every other Orca
+  // instance depends on (STA-5679). Skipping already keeps removed hooks from reappearing on launch.
+  if (
+    shouldInstallManagedHooks(is.dev) &&
+    resolveStartupManagedHookAction(store.getSettings()) === 'install'
+  ) {
+    const managedHookStore = store
+    void realHomeCodexHookState
+      .then(() =>
+        applyAgentStatusHooksEnabled(true, managedHookStore.getSettings(), {
+          shouldHydrateShellPath: app.isPackaged,
+          onInstallError: recordManagedHookInstallFailure,
+          shouldContinue: (agent) => {
+            const settings = managedHookStore.getSettings()
+            return shouldContinueManagedHookStartup(isQuitting, settings, agent)
+          }
         })
-    } else {
-      void removeManagedAgentHooks().catch((error: unknown) => {
-        console.warn('[agent-hooks] failed to remove managed hooks on startup:', error)
+      )
+      .catch((error: unknown) => {
+        console.warn('[agent-hooks] failed to reconcile managed hooks on startup:', error)
       })
-    }
   }
   // Why: process-gone metrics only see survivors; retain a recent whole-app
   // snapshot for comparison in crash reports.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -89,10 +89,11 @@ import {
   sweepRestoredSubagentsWithoutLiveAgent
 } from './agent-hooks/restored-subagent-liveness-sweep'
 import {
-  applyAgentStatusHooksEnabled,
+  installManagedAgentHooks,
   isAgentStatusHooksEnabled,
   removeManagedAgentHooksAsync,
   resolveStartupManagedHookAction,
+  shouldInstallStartupManagedAgentHook,
   shouldContinueManagedHookStartup
 } from './agent-hooks/managed-agent-hook-controls'
 import { initCohortClassifier } from './telemetry/cohort-classifier'
@@ -3089,25 +3090,29 @@ void app.whenReady().then(async () => {
   // ordered before managed-hook reconciliation — an incapable host must re-arm
   // and complete the legacy real-home sweep first — but awaiting it inline
   // stalled app init behind that session, so chain instead of blocking.
-  const realHomeCodexHookState = codexRuntimeHome.isHostSystemDefaultRealHomeSelected()
-    ? ensureRealHomeCodexHookState({
-        hooksEnabled: isAgentStatusHooksEnabled(store.getSettings()),
-        userDataPath: app.getPath('userData')
-      }).catch((error: unknown) => {
-        console.warn('[codex-real-home-hooks] startup ensure failed:', error)
-      })
-    : Promise.resolve()
+  const startupManagedHookSettings = store.getSettings()
+  const shouldReconcileStartupManagedHooks =
+    shouldInstallManagedHooks(is.dev) &&
+    resolveStartupManagedHookAction(startupManagedHookSettings) === 'install'
+  const realHomeCodexHookState =
+    shouldReconcileStartupManagedHooks &&
+    shouldInstallStartupManagedAgentHook(startupManagedHookSettings, 'codex') &&
+    codexRuntimeHome.isHostSystemDefaultRealHomeSelected()
+      ? ensureRealHomeCodexHookState({
+          hooksEnabled: true,
+          userDataPath: app.getPath('userData')
+        }).catch((error: unknown) => {
+          console.warn('[codex-real-home-hooks] startup ensure failed:', error)
+        })
+      : Promise.resolve()
   // Why skip rather than remove when the off switch is set: the hook files are user-global but this
   // decision reads only THIS profile's settings, so removing here deletes the hooks every other Orca
   // instance depends on (STA-5679). Skipping already keeps removed hooks from reappearing on launch.
-  if (
-    shouldInstallManagedHooks(is.dev) &&
-    resolveStartupManagedHookAction(store.getSettings()) === 'install'
-  ) {
+  if (shouldReconcileStartupManagedHooks) {
     const managedHookStore = store
     void realHomeCodexHookState
       .then(() =>
-        applyAgentStatusHooksEnabled(true, managedHookStore.getSettings(), {
+        installManagedAgentHooks(managedHookStore.getSettings(), {
           shouldHydrateShellPath: app.isPackaged,
           onInstallError: recordManagedHookInstallFailure,
           shouldContinue: (agent) => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​111 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​107 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​31 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 |

<!-- /orca-pr-loc -->

Two ways Orca deletes the user's own agent hooks. Both empty the **user-global** files `~/.claude/settings.json` and `~/.cursor/hooks.json`, and both are silent — the hook POSTs keep returning `204` afterwards.

## 1. A green test run deletes the developer's real hooks (the one that bites)

`src/cli/runtime-client-deferral.test.ts:113` feeds `['agent','hooks','off']` to the **real** `main()`. It mocks only `./runtime/environments` and `./runtime-client`, so the production handler runs end to end — `agent-hooks.ts:197` writes its state file, then `:202` calls `applyAgentStatusHooksEnabled(false)` → `removeManagedAgentHooks()` → the developer's own `~/.claude` and `~/.cursor`.

Measured with a sandboxed `HOME`:

```
BEFORE -> claude:5 cursor:2
$ vitest run src/cli/runtime-client-deferral.test.ts
   Tests  23 passed (23)
AFTER  -> claude:0 cursor:0      # after this PR: 5 / 2
```

The repo already knew. The byte-for-byte equivalence twin refuses these exact tokens:

> *"MUTATING — writes outside ORCA_USER_DATA_PATH (`agent hooks off` parks the real ~/.claude hooks)"*
> — `config/scripts/cli-runtime-client-deferral-equivalence.mjs`

The vitest twin never got that guard. Live since #10919 (2026-07-27).

**Stubbed rather than dropped:** `agent hooks off` is the only row in that table that reads `ctx.client`, so it carries the null-vs-undefined coverage the other four cannot. All 23 tests still pass.

## 2. Startup removal is per-profile but user-global

`src/main/index.ts` removed the hooks whenever *this* profile had the off switch set. The decision reads one profile's settings; the files are shared by every instance — so a secondary profile with the switch off deletes the primary's hooks. `shouldInstallManagedHooks()` returns `true` unconditionally, so dev builds and test rigs do this to the real config too.

Honoring the off switch only needs the **install skipped**; removal stays on the explicit Settings toggle, which is the user-initiated path that should own it.

Verified end to end in Electron with a sandboxed `HOME` and a profile whose own `agentStatusHooksEnabled` is `false`:

| build | seeded | after launch |
|---|---|---|
| without this fix | claude 5 / cursor 4 | **0 / 0** |
| with this fix | claude 5 / cursor 4 | **5 / 4** |

Only the `hooks` key is affected either way — other settings survive.

## Why this shows up as "Cursor status missing"

Cursor is the only agent with no title-derived status fallback: its native title is deliberately parsed as status-less (`agent-title-status.ts:175-177`), never reaches the tracker (`terminal-output-side-effects.ts:167-180`), and STA-2472 floors the row at `'idle'` (`worktree-title-derived-agent-rows.ts:152-154`). So a hook wipe makes Cursor go **completely silent** while Claude and Codex still paint status from their own titles. Codex is unaffected regardless — its hooks live in an Orca-owned runtime home.

## Tests

Three in `managed-agent-hook-controls.test.ts`, verified **failing-first**: restoring the pre-fix behavior fails with `expected 'remove' to be 'skip'`. A third test asserts removers still fire on the explicit toggle, anchoring the first against being a vacuous constant.

## Scope

Deliberately **not** included: the Settings toggle still removes user-globally by design — a user with two profiles who flips it in one loses hooks in both. That is a product decision, not a bug, and is left alone here.
