### PR TITLE
fix(ui): label agent state glyphs and swap monitoring to a heartbeat

### DIFF
--- a/mobile/src/components/AgentSpinner.tsx
+++ b/mobile/src/components/AgentSpinner.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { Radio } from 'lucide-react-native'
+import { Activity } from 'lucide-react-native'
 import { Animated, Easing, StyleSheet, View } from 'react-native'
 import type { AgentWorkingMode } from '../../../src/shared/agent-status-types'
 
@@ -50,7 +50,7 @@ export function AgentSpinner({
   if (monitoring) {
     return (
       <View style={styles.wrapper} accessibilityLabel="Monitoring background tasks">
-        <Radio size={12} color={STATUS_COLORS.working} />
+        <Activity size={12} color={STATUS_COLORS.working} />
       </View>
     )
   }

--- a/mobile/src/components/AgentStateDot.tsx
+++ b/mobile/src/components/AgentStateDot.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { Radio } from 'lucide-react-native'
+import { Activity } from 'lucide-react-native'
 import { Animated, Easing, StyleSheet, View } from 'react-native'
 import type { AgentDotState } from '../worktree/agent-row-display'
 
@@ -49,7 +49,7 @@ export function AgentStateDot({ state }: { state: AgentDotState }) {
   if (state === 'monitoring') {
     return (
       <View style={styles.wrapper} accessibilityLabel="Monitoring background tasks">
-        <Radio size={10} color={WORKING_COLOR} />
+        <Activity size={10} color={WORKING_COLOR} />
       </View>
     )
   }

--- a/mobile/src/components/agent-monitoring-indicators.test.ts
+++ b/mobile/src/components/agent-monitoring-indicators.test.ts
@@ -19,7 +19,7 @@ const { animationLoop, animationTiming, setValue } = vi.hoisted(() => ({
   setValue: vi.fn()
 }))
 
-vi.mock('lucide-react-native', () => ({ Radio: 'Radio' }))
+vi.mock('lucide-react-native', () => ({ Activity: 'Activity' }))
 vi.mock('react-native', () => ({
   Animated: {
     Value: function Value() {
@@ -48,12 +48,12 @@ describe('mobile monitoring indicators', () => {
     renderer = null
   })
 
-  it('renders a static Radio for a monitoring agent', async () => {
+  it('renders a static Activity heartbeat for a monitoring agent', async () => {
     await act(async () => {
       renderer = create(createElement(AgentStateDot, { state: 'monitoring' }))
     })
 
-    expect(renderer?.root.findByType('Radio').props).toMatchObject({
+    expect(renderer?.root.findByType('Activity').props).toMatchObject({
       color: DESKTOP_WORKING_COLOR,
       size: 10
     })
@@ -61,14 +61,14 @@ describe('mobile monitoring indicators', () => {
     expect(animationLoop).not.toHaveBeenCalled()
   })
 
-  it('renders a static Radio for an all-monitoring workspace', async () => {
+  it('renders a static Activity heartbeat for an all-monitoring workspace', async () => {
     await act(async () => {
       renderer = create(
         createElement(AgentSpinner, { status: 'working', workingMode: 'monitoring' })
       )
     })
 
-    expect(renderer?.root.findByType('Radio').props).toMatchObject({
+    expect(renderer?.root.findByType('Activity').props).toMatchObject({
       color: DESKTOP_WORKING_COLOR,
       size: 12
     })

--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -127,7 +127,11 @@ describe('AgentStateDot', () => {
       React.createElement(AgentStateDot, { state: 'interrupted', title: null })
     )
 
-    expect(markup).not.toContain(' title=')
+    expect(markup.match(/<span[^>]*\stitle="([^"]*)"/)?.[1]).toBe(undefined)
     expect(markup).toContain('aria-label="Interrupted"')
+    // Differential: the same state still labels itself when the caller omits `title`.
+    expect(renderMarkup('interrupted').match(/<span[^>]*\stitle="([^"]*)"/)?.[1]).toBe(
+      agentStateLabel('interrupted')
+    )
   })
 })

--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -121,4 +121,13 @@ describe('AgentStateDot', () => {
     expect(markup).toContain('title="Finished 2m ago"')
     expect(markup).toContain('aria-label="Done"')
   })
+
+  it('lets a caller with an existing tooltip suppress the native title', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(AgentStateDot, { state: 'interrupted', title: null })
+    )
+
+    expect(markup).not.toContain(' title=')
+    expect(markup).toContain('aria-label="Interrupted"')
+  })
 })

--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { AgentStateDot, type AgentDotState } from './AgentStateDot'
+import { AgentStateDot, agentStateLabel, type AgentDotState } from './AgentStateDot'
 
 function renderMarkup(state: AgentDotState): string {
   return renderToStaticMarkup(React.createElement(AgentStateDot, { state }))
@@ -42,11 +42,11 @@ describe('AgentStateDot', () => {
     expect(markup).toContain('motion-reduce:border-t-yellow-500')
   })
 
-  it('renders monitoring as a static yellow radio glyph', () => {
+  it('renders monitoring as a static yellow heartbeat glyph', () => {
     const markup = renderMarkup('monitoring')
 
     expect(markup).toContain('aria-label="Monitoring background tasks"')
-    expect(markup).toContain('lucide-radio')
+    expect(markup).toContain('lucide-activity')
     expect(markup).toContain('text-yellow-500')
     expect(markup).not.toContain('data-agent-spinner')
   })
@@ -86,4 +86,39 @@ describe('AgentStateDot', () => {
       expect(classNames).not.toContain('bg-amber-500')
     }
   )
+
+  // Why: aria-label renders no hover tooltip, so every glyph read as unlabeled
+  // to sighted users until each branch also emitted a native title (STA-5794).
+  const ALL_STATES = [
+    'working',
+    'monitoring',
+    'blocked',
+    'waiting',
+    'interrupted',
+    'failed',
+    'done',
+    'idle',
+    'permission'
+  ] satisfies AgentDotState[]
+
+  it.each(ALL_STATES)('labels %s with a native hover tooltip', (state) => {
+    const title = renderMarkup(state).match(/<span[^>]*\stitle="([^"]*)"/)?.[1]
+
+    expect(title).toBe(agentStateLabel(state))
+  })
+
+  // Typecheck-time guard: a new AgentDotState member that ALL_STATES omits
+  // fails `pnpm tc`, so the tooltip case above can never silently skip a state.
+  type UncoveredState = Exclude<AgentDotState, (typeof ALL_STATES)[number]>
+  const _allStatesAreCovered: UncoveredState extends never ? true : never = true
+  void _allStatesAreCovered
+
+  it('lets a caller override the tooltip', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(AgentStateDot, { state: 'done', title: 'Finished 2m ago' })
+    )
+
+    expect(markup).toContain('title="Finished 2m ago"')
+    expect(markup).toContain('aria-label="Done"')
+  })
 })

--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -2,8 +2,24 @@ import React from 'react'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { AgentStateDot, agentStateLabel, type AgentDotState } from './AgentStateDot'
+
+vi.mock('@/components/StateIndicatorTooltip', async () => {
+  const { createElement } = await import('react')
+  return {
+    StateIndicatorTooltip: ({
+      label,
+      children
+    }: {
+      label: string | null
+      children: React.ReactElement
+    }) =>
+      label === null
+        ? children
+        : createElement('span', { 'data-state-indicator-tooltip': label }, children)
+  }
+})
 
 function renderMarkup(state: AgentDotState): string {
   return renderToStaticMarkup(React.createElement(AgentStateDot, { state }))
@@ -87,8 +103,6 @@ describe('AgentStateDot', () => {
     }
   )
 
-  // Why: aria-label renders no hover tooltip, so every glyph read as unlabeled
-  // to sighted users until each branch also emitted a native title (STA-5794).
   const ALL_STATES = [
     'working',
     'monitoring',
@@ -101,10 +115,11 @@ describe('AgentStateDot', () => {
     'permission'
   ] satisfies AgentDotState[]
 
-  it.each(ALL_STATES)('labels %s with a native hover tooltip', (state) => {
-    const title = renderMarkup(state).match(/<span[^>]*\stitle="([^"]*)"/)?.[1]
+  it.each(ALL_STATES)('labels %s with the shared hover tooltip', (state) => {
+    const markup = renderMarkup(state)
 
-    expect(title).toBe(agentStateLabel(state))
+    expect(markup).toContain(`data-state-indicator-tooltip="${agentStateLabel(state)}"`)
+    expect(markup).not.toContain(' title=')
   })
 
   // Typecheck-time guard: a new AgentDotState member that ALL_STATES omits
@@ -118,20 +133,20 @@ describe('AgentStateDot', () => {
       React.createElement(AgentStateDot, { state: 'done', title: 'Finished 2m ago' })
     )
 
-    expect(markup).toContain('title="Finished 2m ago"')
+    expect(markup).toContain('data-state-indicator-tooltip="Finished 2m ago"')
+    expect(markup).not.toContain(' title=')
     expect(markup).toContain('aria-label="Done"')
   })
 
-  it('lets a caller with an existing tooltip suppress the native title', () => {
+  it('lets a caller with an existing tooltip suppress the shared tooltip', () => {
     const markup = renderToStaticMarkup(
       React.createElement(AgentStateDot, { state: 'interrupted', title: null })
     )
 
-    expect(markup.match(/<span[^>]*\stitle="([^"]*)"/)?.[1]).toBe(undefined)
+    expect(markup).not.toContain('data-state-indicator-tooltip')
     expect(markup).toContain('aria-label="Interrupted"')
-    // Differential: the same state still labels itself when the caller omits `title`.
-    expect(renderMarkup('interrupted').match(/<span[^>]*\stitle="([^"]*)"/)?.[1]).toBe(
-      agentStateLabel('interrupted')
+    expect(renderMarkup('interrupted')).toContain(
+      `data-state-indicator-tooltip="${agentStateLabel('interrupted')}"`
     )
   })
 })

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -3,6 +3,10 @@ import { Activity, CircleCheck } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
 import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
+import {
+  StateIndicatorTooltip,
+  type StateIndicatorTooltipSide
+} from '@/components/StateIndicatorTooltip'
 
 // Why: shared state-indicator primitive so the dashboard and the sidebar's
 // agent hover share a single state vocabulary. Most states render as a dot;
@@ -61,8 +65,9 @@ type Props = {
   state: AgentDotState
   size?: 'sm' | 'md'
   className?: string
-  /** Overrides the native hover tooltip; null suppresses it for an existing tooltip. */
+  /** Overrides the hover tooltip; null suppresses it for an existing tooltip. */
   title?: string | null
+  tooltipSide?: StateIndicatorTooltipSide
 }
 
 /** Render the compact state glyph used by agent rows and terminal tabs. */
@@ -70,82 +75,78 @@ export const AgentStateDot = React.memo(function AgentStateDot({
   state,
   size = 'sm',
   className,
-  title
+  title,
+  tooltipSide
 }: Props): React.JSX.Element {
   const box = size === 'md' ? 'h-3 w-3' : 'h-2.5 w-2.5'
   const inner = size === 'md' ? 'size-2' : 'size-1.5'
   const icon = size === 'md' ? 'size-3' : 'size-2.5'
-  // Why: aria-label alone never renders a hover tooltip, so these glyphs read as
-  // unlabeled to sighted users (STA-5794). Mirrors StatusIndicator's `title`.
-  const resolvedTitle = title === null ? undefined : (title ?? agentStateLabel(state))
+  const tooltipLabel = title === null ? null : (title ?? agentStateLabel(state))
+
+  let indicator: React.JSX.Element
 
   if (state === 'working') {
-    return (
+    indicator = (
       <span
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
         aria-label={agentStateLabel(state)}
-        title={resolvedTitle}
       >
         <AgentWorkingSpinner className={inner} />
       </span>
     )
-  }
-
-  if (state === 'monitoring') {
-    return (
+  } else if (state === 'monitoring') {
+    indicator = (
       <span
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
         aria-label={agentStateLabel(state)}
-        title={resolvedTitle}
       >
         <Activity className={cn('text-yellow-500', icon)} aria-hidden="true" />
       </span>
     )
-  }
-
-  if (state === 'done') {
+  } else if (state === 'done') {
     // Why: the dashboard lists many agents, so a check glyph scans well for
     // agent-reported completion and keeps 'done' visually distinct from
     // 'idle' and other dot states at a glance. The sidebar's StatusIndicator
     // intentionally diverges (emerald dot + tooltip) — see file header.
-    return (
+    indicator = (
       <span
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
         aria-label={agentStateLabel(state)}
-        title={resolvedTitle}
       >
         <CircleCheck className={cn('text-emerald-500', icon)} aria-hidden="true" />
       </span>
     )
-  }
-
-  if (state === 'permission' || state === 'waiting') {
-    return (
+  } else if (state === 'permission' || state === 'waiting') {
+    indicator = (
       <span
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
         aria-label={agentStateLabel(state)}
-        title={resolvedTitle}
       >
         <AgentQuestionIcon className={icon} />
+      </span>
+    )
+  } else {
+    indicator = (
+      <span
+        className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
+        aria-label={agentStateLabel(state)}
+      >
+        <span
+          className={cn(
+            'block rounded-full',
+            inner,
+            state === 'blocked' || state === 'interrupted' || state === 'failed'
+              ? 'bg-red-500'
+              : 'bg-neutral-500/40'
+          )}
+        />
       </span>
     )
   }
 
   return (
-    <span
-      className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
-      aria-label={agentStateLabel(state)}
-      title={resolvedTitle}
-    >
-      <span
-        className={cn(
-          'block rounded-full',
-          inner,
-          state === 'blocked' || state === 'interrupted' || state === 'failed'
-            ? 'bg-red-500'
-            : 'bg-neutral-500/40'
-        )}
-      />
-    </span>
+    <StateIndicatorTooltip label={tooltipLabel} side={tooltipSide}>
+      {indicator}
+    </StateIndicatorTooltip>
   )
 })

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { CircleCheck, Radio } from 'lucide-react'
+import { Activity, CircleCheck } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
 import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
@@ -61,23 +61,30 @@ type Props = {
   state: AgentDotState
   size?: 'sm' | 'md'
   className?: string
+  /** Overrides the native hover tooltip; defaults to the state's label. */
+  title?: string
 }
 
 /** Render the compact state glyph used by agent rows and terminal tabs. */
 export const AgentStateDot = React.memo(function AgentStateDot({
   state,
   size = 'sm',
-  className
+  className,
+  title
 }: Props): React.JSX.Element {
   const box = size === 'md' ? 'h-3 w-3' : 'h-2.5 w-2.5'
   const inner = size === 'md' ? 'size-2' : 'size-1.5'
   const icon = size === 'md' ? 'size-3' : 'size-2.5'
+  // Why: aria-label alone never renders a hover tooltip, so these glyphs read as
+  // unlabeled to sighted users (STA-5794). Mirrors StatusIndicator's `title`.
+  const resolvedTitle = title ?? agentStateLabel(state)
 
   if (state === 'working') {
     return (
       <span
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
         aria-label={agentStateLabel(state)}
+        title={resolvedTitle}
       >
         <AgentWorkingSpinner className={inner} />
       </span>
@@ -89,8 +96,9 @@ export const AgentStateDot = React.memo(function AgentStateDot({
       <span
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
         aria-label={agentStateLabel(state)}
+        title={resolvedTitle}
       >
-        <Radio className={cn('text-yellow-500', icon)} aria-hidden="true" />
+        <Activity className={cn('text-yellow-500', icon)} aria-hidden="true" />
       </span>
     )
   }
@@ -104,6 +112,7 @@ export const AgentStateDot = React.memo(function AgentStateDot({
       <span
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
         aria-label={agentStateLabel(state)}
+        title={resolvedTitle}
       >
         <CircleCheck className={cn('text-emerald-500', icon)} aria-hidden="true" />
       </span>
@@ -115,6 +124,7 @@ export const AgentStateDot = React.memo(function AgentStateDot({
       <span
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
         aria-label={agentStateLabel(state)}
+        title={resolvedTitle}
       >
         <AgentQuestionIcon className={icon} />
       </span>
@@ -125,6 +135,7 @@ export const AgentStateDot = React.memo(function AgentStateDot({
     <span
       className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
       aria-label={agentStateLabel(state)}
+      title={resolvedTitle}
     >
       <span
         className={cn(

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -61,8 +61,8 @@ type Props = {
   state: AgentDotState
   size?: 'sm' | 'md'
   className?: string
-  /** Overrides the native hover tooltip; defaults to the state's label. */
-  title?: string
+  /** Overrides the native hover tooltip; null suppresses it for an existing tooltip. */
+  title?: string | null
 }
 
 /** Render the compact state glyph used by agent rows and terminal tabs. */
@@ -77,7 +77,7 @@ export const AgentStateDot = React.memo(function AgentStateDot({
   const icon = size === 'md' ? 'size-3' : 'size-2.5'
   // Why: aria-label alone never renders a hover tooltip, so these glyphs read as
   // unlabeled to sighted users (STA-5794). Mirrors StatusIndicator's `title`.
-  const resolvedTitle = title ?? agentStateLabel(state)
+  const resolvedTitle = title === null ? undefined : (title ?? agentStateLabel(state))
 
   if (state === 'working') {
     return (

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -14,7 +14,7 @@ import {
 // sidebar's StatusIndicator: the dashboard uses a check icon so completion
 // is visually distinct from 'idle' (grey dot) and the sidebar's 'active'
 // (emerald dot), while the sidebar collapses 'done'/'active' to the same
-// emerald dot and relies on a tooltip. It sits next to the agent icon
+// emerald dot with separate accessible text and no tooltip. It sits next to the agent icon
 // (Claude/Codex/etc.) — two distinct glyphs: one for *who* (agent icon) and
 // one for *what state* (this indicator). Keeping them separate keeps each
 // scannable instead of fused into one decorated icon.
@@ -107,7 +107,7 @@ export const AgentStateDot = React.memo(function AgentStateDot({
     // Why: the dashboard lists many agents, so a check glyph scans well for
     // agent-reported completion and keeps 'done' visually distinct from
     // 'idle' and other dot states at a glance. The sidebar's StatusIndicator
-    // intentionally diverges (emerald dot + tooltip) — see file header.
+    // intentionally diverges (emerald dot with separate accessible text) — see file header.
     indicator = (
       <span
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -14,7 +14,7 @@ import {
 // sidebar's StatusIndicator: the dashboard uses a check icon so completion
 // is visually distinct from 'idle' (grey dot) and the sidebar's 'active'
 // (emerald dot), while the sidebar collapses 'done'/'active' to the same
-// emerald dot with separate accessible text and no tooltip. It sits next to the agent icon
+// emerald dot and relies on a tooltip. It sits next to the agent icon
 // (Claude/Codex/etc.) — two distinct glyphs: one for *who* (agent icon) and
 // one for *what state* (this indicator). Keeping them separate keeps each
 // scannable instead of fused into one decorated icon.
@@ -107,7 +107,7 @@ export const AgentStateDot = React.memo(function AgentStateDot({
     // Why: the dashboard lists many agents, so a check glyph scans well for
     // agent-reported completion and keeps 'done' visually distinct from
     // 'idle' and other dot states at a glance. The sidebar's StatusIndicator
-    // intentionally diverges (emerald dot with separate accessible text) — see file header.
+    // intentionally diverges (emerald dot + tooltip) — see file header.
     indicator = (
       <span
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}

--- a/src/renderer/src/components/StateIndicatorTooltip.test.tsx
+++ b/src/renderer/src/components/StateIndicatorTooltip.test.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { STATE_INDICATOR_TOOLTIP_DELAY_MS, StateIndicatorTooltip } from './StateIndicatorTooltip'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ delayDuration, children }: { delayDuration: number; children: ReactNode }) => (
+    <span data-delay-duration={delayDuration}>{children}</span>
+  ),
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children, side }: { children: ReactNode; side: string }) => (
+    <span data-tooltip-content="" data-side={side}>
+      {children}
+    </span>
+  )
+}))
+
+describe('StateIndicatorTooltip', () => {
+  it('uses Orca tooltip chrome with an explicit 200ms delay', () => {
+    const markup = renderToStaticMarkup(
+      <StateIndicatorTooltip label="Monitoring background tasks">
+        <span data-heartbeat="" />
+      </StateIndicatorTooltip>
+    )
+
+    expect(STATE_INDICATOR_TOOLTIP_DELAY_MS).toBe(200)
+    expect(markup).toContain('data-delay-duration="200"')
+    expect(markup).toContain('data-tooltip-content=""')
+    expect(markup).toContain('data-side="top"')
+    expect(markup).toContain('Monitoring background tasks')
+  })
+
+  it('supports surface-aware placement without changing the delay', () => {
+    const markup = renderToStaticMarkup(
+      <StateIndicatorTooltip label="Monitoring background tasks" side="right">
+        <span data-heartbeat="" />
+      </StateIndicatorTooltip>
+    )
+
+    expect(markup).toContain('data-delay-duration="200"')
+    expect(markup).toContain('data-side="right"')
+  })
+
+  it('renders only the indicator when a caller already owns the tooltip', () => {
+    const markup = renderToStaticMarkup(
+      <StateIndicatorTooltip label={null}>
+        <span data-heartbeat="" />
+      </StateIndicatorTooltip>
+    )
+
+    expect(markup).toBe('<span data-heartbeat=""></span>')
+  })
+})

--- a/src/renderer/src/components/StateIndicatorTooltip.tsx
+++ b/src/renderer/src/components/StateIndicatorTooltip.tsx
@@ -1,0 +1,28 @@
+import type { ComponentProps, ReactElement } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+export const STATE_INDICATOR_TOOLTIP_DELAY_MS = 200
+export type StateIndicatorTooltipSide = ComponentProps<typeof TooltipContent>['side']
+
+export function StateIndicatorTooltip({
+  label,
+  side = 'top',
+  children
+}: {
+  label: string | null
+  side?: StateIndicatorTooltipSide
+  children: ReactElement
+}): React.JSX.Element {
+  if (label === null) {
+    return children
+  }
+
+  return (
+    <Tooltip delayDuration={STATE_INDICATOR_TOOLTIP_DELAY_MS}>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side={side} sideOffset={6}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
@@ -827,11 +827,10 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
     })
     await flushEffects()
 
-    // Why: the row stays where the frozen order put it, and its badge must keep resolving — row
-    // data covers every open tab, so inclusion dropping it can't blank the pip mid-open.
+    // Why: a frozen row must retain its live badge while staying in its original slot.
     expect(getTabRowIds()).toContain('tab-alpha')
     expect(testContainer.textContent).toContain('Alpha chat')
-    expect(testContainer.querySelector('[title="Working"]')).not.toBeNull()
+    expect(document.querySelector('[data-slot=tooltip-trigger]')?.textContent).toContain('Working')
   })
 
   it('keeps a frozen current row listed when its agent finishes mid-open', async () => {
@@ -859,10 +858,9 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
     })
     await flushEffects()
 
-    // Why: `done` gates entry, not rendering — a row already in the frozen order keeps its slot and
-    // flips to the completed check rather than blanking under the cursor.
+    // Why: completion changes the frozen row's badge without removing its reserved slot.
     expect(getTabRowIds()).toContain('tab-alpha')
-    expect(testContainer.querySelector('[title="Done"]')).not.toBeNull()
+    expect(document.querySelector('[data-slot=tooltip-trigger]')?.textContent).toContain('Done')
   })
 
   it('activates the row a digit chord addresses while open', async () => {
@@ -920,8 +918,7 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       })
     )
 
-    // Why not optional-call: a skipped setter would leave the empty-query Recent section standing
-    // and the assertions below would pass without the query path ever running.
+    // Why: require the setter so this cannot silently exercise the empty-query section.
     const applyQuery = setCommandQuery
     if (!applyQuery) {
       throw new Error('CommandInput never installed a query setter')
@@ -937,7 +934,7 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
     const alphaRow = testContainer.querySelector<HTMLElement>(
       '[data-command-item="workspace-tab:tab-alpha"]'
     )
-    expect(alphaRow?.querySelector('[title="Working"]')).not.toBeNull()
+    expect(alphaRow?.querySelector('[data-slot=tooltip-trigger]')?.textContent).toContain('Working')
   })
 
   it('keeps create-worktree below the matches it would otherwise outrank', async () => {

--- a/src/renderer/src/components/activity/ActivityPrototypePage.thread-grouping.test.ts
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.thread-grouping.test.ts
@@ -1,11 +1,15 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import { formatAgentTypeLabel } from '@/lib/agent-status'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import {
   buildActivityThreadGroups,
   buildActivityEvents,
   buildAgentPaneThreads,
-  getActivityThreadGroup
+  getActivityThreadGroup,
+  ThreadAgentStateIndicator
 } from './ActivityPrototypePage'
 import {
   makeActivityResult,
@@ -22,6 +26,28 @@ import {
   PANE_KEY_B1,
   UNKNOWN_PANE_KEY
 } from './ActivityPrototypePage-test-fixtures'
+
+describe('ThreadAgentStateIndicator', () => {
+  it('labels the state through its Radix tooltip only', () => {
+    const threads = makeThreads(
+      makeActivityResult({ entries: { [PANE_KEY]: makeWorkingEntryWithoutHistory() } })
+    )
+
+    const markup = renderToStaticMarkup(
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(ThreadAgentStateIndicator, { thread: threads[0]! })
+      )
+    )
+    const titles = [...markup.matchAll(/\stitle="([^"]*)"/g)].map((match) => match[1])
+
+    expect(markup).toContain('data-slot="tooltip-trigger"')
+    expect(markup).toContain('aria-label="Working"')
+    // A native title here would fire alongside the Radix tooltip as a double label.
+    expect(titles).toEqual([])
+  })
+})
 
 describe('activity thread grouping', () => {
   it('status grouping separates interrupted done from normal done and keeps Interrupted label', () => {

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1187,7 +1187,7 @@ function ThreadAgentStateIndicator({ thread }: { thread: AgentPaneThread }): Rea
     <Tooltip>
       <TooltipTrigger asChild>
         <span className="inline-flex size-4 shrink-0 items-center justify-center">
-          <AgentStateDot state={state} size="md" />
+          <AgentStateDot state={state} size="md" title={null} />
         </span>
       </TooltipTrigger>
       <TooltipContent side="top" sideOffset={4}>

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1180,7 +1180,11 @@ export function handleActivityFilterFocusShortcut({
   return true
 }
 
-function ThreadAgentStateIndicator({ thread }: { thread: AgentPaneThread }): React.JSX.Element {
+export function ThreadAgentStateIndicator({
+  thread
+}: {
+  thread: AgentPaneThread
+}): React.JSX.Element {
   const state = threadAgentState(thread)
   const label = threadAgentStateLabel(thread)
   return (

--- a/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
@@ -136,7 +136,7 @@ describe('palette live status', () => {
     setAgentState('working')
     await render()
     expect(dotLabels()).toEqual(['Working'])
-    expect(testContainer.querySelector('[data-slot="tooltip-trigger"]')).not.toBeNull()
+    expect(testContainer.querySelector('[data-slot="tooltip-trigger"]')).toBeNull()
 
     await act(async () => {
       setAgentState('blocked')

--- a/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
@@ -136,7 +136,7 @@ describe('palette live status', () => {
     await render()
 
     expect(testContainer.querySelector('[data-spinner]')).toBeNull()
-    expect(testContainer.querySelector('.lucide-radio')?.classList).toContain('text-yellow-500')
+    expect(testContainer.querySelector('.lucide-activity')?.classList).toContain('text-yellow-500')
     expect(dotLabels()).toEqual(['Monitoring background tasks'])
   })
 
@@ -276,7 +276,7 @@ describe('palette live status', () => {
     })
 
     expect(testContainer.querySelector('[data-spinner]')).toBeNull()
-    expect(testContainer.querySelector('.lucide-radio')?.classList).toContain('text-yellow-500')
+    expect(testContainer.querySelector('.lucide-activity')?.classList).toContain('text-yellow-500')
     expect(dotLabels()).toEqual(['Monitoring background tasks'])
     expect(testContainer.querySelector('[title="Monitoring background tasks"]')).not.toBeNull()
   })

--- a/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
@@ -4,12 +4,13 @@ import React, { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore } from '@/store'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import type { AppState } from '@/store/types'
 import type { AgentStatusEntry, AgentStatusState } from '../../../../shared/agent-status-types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import {
-  PaletteLiveStatusProvider,
+  PaletteLiveStatusProvider as ProductionPaletteLiveStatusProvider,
   PaletteRecentTabStatusDot,
   PaletteWorktreeStatusDot
 } from './palette-live-status'
@@ -20,6 +21,16 @@ vi.mock('@/components/AgentWorkingSpinner', () => ({
 
 const initialAppState = useAppStore.getInitialState()
 const LEAF = '11111111-2222-4333-8444-555555555555'
+
+function PaletteLiveStatusProvider(
+  props: React.ComponentProps<typeof ProductionPaletteLiveStatusProvider>
+): React.JSX.Element {
+  return (
+    <TooltipProvider>
+      <ProductionPaletteLiveStatusProvider {...props} />
+    </TooltipProvider>
+  )
+}
 
 let testRoot: Root
 let testContainer: HTMLDivElement
@@ -77,6 +88,13 @@ function dotLabels(): string[] {
   return [...testContainer.querySelectorAll<HTMLElement>('.sr-only')].map(
     (node) => node.textContent ?? ''
   )
+}
+
+function expectStyledStatusTooltip(label: string): void {
+  const trigger = testContainer.querySelector<HTMLElement>('[data-slot="tooltip-trigger"]')
+  expect(trigger).not.toBeNull()
+  expect(trigger?.getAttribute('title')).toBeNull()
+  expect(trigger?.textContent).toContain(label)
 }
 
 describe('palette live status', () => {
@@ -244,8 +262,7 @@ describe('palette live status', () => {
     expect(testContainer.querySelector('[data-fallback]')).not.toBeNull()
     expect(testContainer.querySelector('[data-spinner]')).not.toBeNull()
     expect(dotLabels()).toEqual(['Working'])
-    // Hover tooltip on the outer hit target (badge is pointer-events-none).
-    expect(testContainer.querySelector('[title="Working"]')).not.toBeNull()
+    expectStyledStatusTooltip('Working')
 
     await act(async () => {
       setAgentState('blocked')
@@ -253,7 +270,7 @@ describe('palette live status', () => {
     expect(testContainer.querySelector('[data-fallback]')).not.toBeNull()
     expect(testContainer.querySelector('[data-spinner]')).toBeNull()
     expect(dotLabels()).toEqual(['Needs permission'])
-    expect(testContainer.querySelector('[title="Needs permission"]')).not.toBeNull()
+    expectStyledStatusTooltip('Needs permission')
   })
 
   it('shows monitoring with a static radio instead of the working spinner', async () => {
@@ -278,7 +295,7 @@ describe('palette live status', () => {
     expect(testContainer.querySelector('[data-spinner]')).toBeNull()
     expect(testContainer.querySelector('.lucide-activity')?.classList).toContain('text-yellow-500')
     expect(dotLabels()).toEqual(['Monitoring background tasks'])
-    expect(testContainer.querySelector('[title="Monitoring background tasks"]')).not.toBeNull()
+    expectStyledStatusTooltip('Monitoring background tasks')
   })
 
   it('shows only the content icon when a terminal-backed row is inactive', async () => {
@@ -331,7 +348,7 @@ describe('palette live status', () => {
     expect(testContainer.querySelector('[data-fallback]')).not.toBeNull()
     expect(testContainer.querySelector('[data-spinner]')).toBeNull()
     expect(dotLabels()).toEqual(['Unread agent completion'])
-    expect(testContainer.querySelector('[title="Unread agent completion"]')).not.toBeNull()
+    expectStyledStatusTooltip('Unread agent completion')
   })
 
   it('prefers working over unread on the same row', async () => {
@@ -379,7 +396,7 @@ describe('palette live status', () => {
     })
     expect(testContainer.querySelector('[data-fallback]')).not.toBeNull()
     expect(dotLabels()).toEqual(['Done'])
-    expect(testContainer.querySelector('[title="Done"]')).not.toBeNull()
+    expectStyledStatusTooltip('Done')
     // lucide CircleCheck class marker
     expect(testContainer.innerHTML).toContain('lucide-circle-check')
   })

--- a/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
@@ -136,7 +136,7 @@ describe('palette live status', () => {
     setAgentState('working')
     await render()
     expect(dotLabels()).toEqual(['Working'])
-    expect(testContainer.querySelector('[data-slot="tooltip-trigger"]')).toBeNull()
+    expect(testContainer.querySelector('[data-slot="tooltip-trigger"]')).not.toBeNull()
 
     await act(async () => {
       setAgentState('blocked')

--- a/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
@@ -136,6 +136,7 @@ describe('palette live status', () => {
     setAgentState('working')
     await render()
     expect(dotLabels()).toEqual(['Working'])
+    expect(testContainer.querySelector('[data-slot="tooltip-trigger"]')).toBeNull()
 
     await act(async () => {
       setAgentState('blocked')

--- a/src/renderer/src/components/cmd-j/palette-live-status.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
 import { AgentStateDot } from '@/components/AgentStateDot'
+import { StateIndicatorTooltip } from '@/components/StateIndicatorTooltip'
 import StatusIndicator from '@/components/sidebar/StatusIndicator'
 import { FilledBellIcon } from '@/components/sidebar/WorktreeCardHelpers'
 import {
@@ -244,30 +245,28 @@ export function PaletteRecentTabStatusDot({
           'Unread agent completion'
         )
       : getWorktreeStatusLabel(badge)
-  // Why: title on the outer hit target (not the pointer-events-none pip) so hover still reveals
-  // status — matches StatusIndicator's tooltip placement.
+  // Why: the outer hit target owns the tooltip because the overlaid pip ignores pointer events.
   return (
-    <span
-      className="relative inline-flex size-3.5 shrink-0 items-center justify-center"
-      title={statusLabel}
-    >
-      {fallback}
-      <span
-        className={cn(
-          // Why popover, not background: the dialog surface is --popover (#171717 in dark), while
-          // --background is the app canvas (#0a0a0a) — using it punched a dark halo through every
-          // dark-mode row. Selected rows use --jump-palette-selection-surface so the cutout tracks
-          // the stronger keyboard highlight from main.css.
-          'pointer-events-none absolute -right-0.5 -bottom-0.5 flex items-center justify-center rounded-full',
-          'bg-popover ring-2 ring-popover',
-          'group-data-[selected=true]:bg-[var(--jump-palette-selection-surface)] group-data-[selected=true]:ring-[var(--jump-palette-selection-surface)]'
-        )}
-        aria-hidden="true"
-      >
-        <RecentTabAttentionBadgeGlyph badge={badge} />
+    <StateIndicatorTooltip label={statusLabel}>
+      <span className="relative inline-flex size-3.5 shrink-0 items-center justify-center">
+        {fallback}
+        <span
+          className={cn(
+            // Why popover, not background: the dialog surface is --popover (#171717 in dark), while
+            // --background is the app canvas (#0a0a0a) — using it punched a dark halo through every
+            // dark-mode row. Selected rows use --jump-palette-selection-surface so the cutout tracks
+            // the stronger keyboard highlight from main.css.
+            'pointer-events-none absolute -right-0.5 -bottom-0.5 flex items-center justify-center rounded-full',
+            'bg-popover ring-2 ring-popover',
+            'group-data-[selected=true]:bg-[var(--jump-palette-selection-surface)] group-data-[selected=true]:ring-[var(--jump-palette-selection-surface)]'
+          )}
+          aria-hidden="true"
+        >
+          <RecentTabAttentionBadgeGlyph badge={badge} />
+        </span>
+        <span className="sr-only">{statusLabel}</span>
       </span>
-      <span className="sr-only">{statusLabel}</span>
-    </span>
+    </StateIndicatorTooltip>
   )
 }
 
@@ -281,5 +280,5 @@ function RecentTabAttentionBadgeGlyph({
     return <FilledBellIcon className="size-2.5 text-amber-500 drop-shadow-sm" />
   }
   // Why: AgentStateDot owns working/permission/done glyphs app-wide (spinner / ? / check).
-  return <AgentStateDot state={badge} size="sm" />
+  return <AgentStateDot state={badge} size="sm" title={null} />
 }

--- a/src/renderer/src/components/dashboard-popout/agent-map-render-test-harness.tsx
+++ b/src/renderer/src/components/dashboard-popout/agent-map-render-test-harness.tsx
@@ -7,6 +7,7 @@ import type {
   DashboardSpawnAgentArgs
 } from '../../../../shared/dashboard-snapshot'
 import type { TuiAgent } from '../../../../shared/tui-agent'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { AgentMap } from './AgentMap'
 import type { AgentMapState } from './agent-map-filter'
 
@@ -76,7 +77,8 @@ export function renderMap(
       launchableAgentsByWorktreeId={launchableAgentsByWorktreeId}
       onSpawnAgent={onSpawnAgent}
       onSleepWorkspace={onSleepWorkspace}
-    />
+    />,
+    { wrapper: TooltipProvider }
   )
 }
 

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -362,7 +362,7 @@ describe('DashboardAgentRow', () => {
     )
 
     expect(markup).toContain('Monitoring background tasks')
-    expect(markup).toContain('lucide-radio')
+    expect(markup).toContain('lucide-activity')
     expect(classTokens(markup)).toContain('text-yellow-500')
     expect(markup).not.toContain('data-agent-spinner')
     expect(markup).not.toContain('data-agent-row-tool-slot')

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -320,6 +320,7 @@ describe('DashboardAgentRow', () => {
     // on the response line so it does not compete with the user's prompt.
     expect(markup).toContain('data-slot="tooltip-trigger"')
     expect(markup).toContain('aria-label="Interrupted by user"')
+    expect(markup).not.toContain('title="Interrupted"')
     expect(markup).toContain('bg-red-500')
     expect(markup).not.toContain('data-slot="badge"')
     expect(interruptedIndex).toBeGreaterThan(promptIndex)

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -253,7 +253,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
               className="inline-flex shrink-0 items-center justify-center"
               aria-label={dotTooltipLabel}
             >
-              <AgentStateDot state={dotState} size={stateDotSize} />
+              <AgentStateDot state={dotState} size={stateDotSize} title={null} />
             </span>
           </TooltipTrigger>
           <TooltipContent side="top" sideOffset={4}>

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
@@ -506,9 +506,11 @@ describe('ReviewNotesSendMenuContent', () => {
 
     const tree = render()
     const item = findByType(tree, 'DropdownMenuItem')
+    const stateDot = findByType(item, 'AgentStateDot')
 
     expect(item.props.disabled).toBe(true)
     expect(item.props.title).toBe('Agent needs permission')
+    expect(stateDot.props.title).toBeNull()
     ;(item.props.onSelect as () => void)()
     expect(harness.sendNotesToActiveAgentSession).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
@@ -247,6 +247,7 @@ function AgentTargetMenuItem({
   const tabTitle = target.tabTitle.trim()
   const state = asDotState(agent?.state ?? 'idle', agent?.entry.workingMode)
   const timeAgo = agent ? formatAgentRelativeTime(agent, now) : null
+  const disabledReason = target.status === 'disabled' ? target.disabledReason : undefined
   const secondaryParts = [
     agentStateLabel(state),
     ...(timeAgo ? [timeAgo] : []),
@@ -259,10 +260,16 @@ function AgentTargetMenuItem({
       // Why: surface the ineligibility reason (permission/stale/no-terminal) as a
       // hover tooltip rather than inline text, matching DashboardAgentRow's
       // title-attribute treatment of the same disabledReason.
-      title={target.status === 'disabled' ? target.disabledReason : undefined}
+      title={disabledReason}
       className="min-w-[240px] gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
     >
-      <AgentStateDot state={state} size="sm" className="shrink-0" />
+      {/* Why: the ancestor's actionable disabled reason must win on every hit area. */}
+      <AgentStateDot
+        state={state}
+        size="sm"
+        className="shrink-0"
+        title={disabledReason ? null : undefined}
+      />
       <AgentIcon agent={agentTypeToIconAgent(target.agentType ?? agent?.agentType)} size={14} />
       <span className="grid min-w-0 flex-1 text-left">
         <span className="truncate">

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionSubagents.test.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionSubagents.test.tsx
@@ -86,6 +86,22 @@ describe('SessionSubagentsSection', () => {
     expect(queryByText('First pass')).toBeNull()
   })
 
+  it('labels the subagent run state exactly once, on the dot itself', async () => {
+    listSubagentSessions.mockResolvedValueOnce({
+      sessions: [makeSubagent('Running task')],
+      issues: []
+    })
+    const { container } = render(<SessionSubagentsSection session={makeSession()} />)
+    await act(async () => {})
+
+    const titles = [...container.querySelectorAll('[title]')].map((element) =>
+      element.getAttribute('title')
+    )
+
+    // A wrapper title would stack a second identical tooltip on the dot's own hit area.
+    expect(titles).toEqual(['Working', 'Running task', 'View Log'])
+  })
+
   it('does not fetch for remote sessions even when the scan counted transcripts', async () => {
     const { container } = render(
       <SessionSubagentsSection

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionSubagents.test.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionSubagents.test.tsx
@@ -1,11 +1,23 @@
 // @vitest-environment happy-dom
 
+import type { ComponentProps, JSX } from 'react'
 import { act, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import type { AiVaultSession, AiVaultSubagentListResult } from '../../../../shared/ai-vault-types'
-import { SessionSubagentsSection } from './AiVaultSessionSubagents'
+import { SessionSubagentsSection as ProductionSessionSubagentsSection } from './AiVaultSessionSubagents'
 
 const listSubagentSessions = vi.fn<(args: unknown) => Promise<AiVaultSubagentListResult>>()
+
+function SessionSubagentsSection(
+  props: ComponentProps<typeof ProductionSessionSubagentsSection>
+): JSX.Element {
+  return (
+    <TooltipProvider>
+      <ProductionSessionSubagentsSection {...props} />
+    </TooltipProvider>
+  )
+}
 
 beforeEach(() => {
   listSubagentSessions.mockReset()
@@ -98,8 +110,8 @@ describe('SessionSubagentsSection', () => {
       element.getAttribute('title')
     )
 
-    // A wrapper title would stack a second identical tooltip on the dot's own hit area.
-    expect(titles).toEqual(['Working', 'Running task', 'View Log'])
+    expect(titles).toEqual(['Running task', 'View Log'])
+    expect(container.querySelector('[data-slot="tooltip-trigger"]')).not.toBeNull()
   })
 
   it('does not fetch for remote sessions even when the scan counted transcripts', async () => {

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionSubagents.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionSubagents.tsx
@@ -3,7 +3,7 @@ import type React from 'react'
 import { Bot, FileJson } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { AgentStateDot, agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
+import { AgentStateDot, type AgentDotState } from '@/components/AgentStateDot'
 import type { AiVaultSession, AiVaultSubagentRunStatus } from '../../../../shared/ai-vault-types'
 import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
 import { canOpenAiVaultSessionLogInOrca } from './ai-vault-session-path-actions'
@@ -120,7 +120,7 @@ function SubagentSessionLine({ session }: { session: AiVaultSession }): React.JS
       {dotState ? (
         // Why: a plain inline span would baseline-align the dot; flex keeps it
         // vertically centered with the row text.
-        <span className="flex shrink-0 items-center" title={agentStateLabel(dotState)}>
+        <span className="flex shrink-0 items-center">
           <AgentStateDot state={dotState} />
         </span>
       ) : null}

--- a/src/renderer/src/components/sidebar/StatusIndicator.test.ts
+++ b/src/renderer/src/components/sidebar/StatusIndicator.test.ts
@@ -1,23 +1,7 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import StatusIndicator, { type Status } from './StatusIndicator'
-
-vi.mock('@/components/StateIndicatorTooltip', async () => {
-  const { createElement } = await import('react')
-  return {
-    StateIndicatorTooltip: ({
-      label,
-      children
-    }: {
-      label: string | null
-      children: React.ReactElement
-    }) =>
-      label === null
-        ? children
-        : createElement('span', { 'data-state-indicator-tooltip': label }, children)
-  }
-})
 
 function renderMarkup(status: Status): string {
   return renderToStaticMarkup(React.createElement(StatusIndicator, { status }))
@@ -50,7 +34,7 @@ describe('StatusIndicator', () => {
   it('renders monitoring as a static heartbeat glyph', () => {
     const markup = renderMarkup('monitoring')
 
-    expect(markup).toContain('data-state-indicator-tooltip="Monitoring background tasks"')
+    expect(markup).not.toContain('data-state-indicator-tooltip')
     expect(markup).not.toContain(' title=')
     expect(markup).toContain('lucide-activity')
     expect(markup).toContain('text-yellow-500')
@@ -85,35 +69,18 @@ describe('StatusIndicator', () => {
     expect(classNames).not.toContain('bg-emerald-500')
   })
 
-  it.each([
-    ['working', 'Working'],
-    ['monitoring', 'Monitoring background tasks'],
-    ['permission', 'Needs permission'],
-    ['interrupted', 'Interrupted'],
-    ['done', 'Done']
-  ] as const)('labels the agent-derived %s workspace state', (status, label) => {
+  it.each<Status>([
+    'active',
+    'working',
+    'monitoring',
+    'permission',
+    'interrupted',
+    'done',
+    'inactive'
+  ])('keeps the workspace-level %s indicator tooltip-free', (status) => {
     const markup = renderMarkup(status)
 
-    expect(markup).toContain(`data-state-indicator-tooltip="${label}"`)
+    expect(markup).not.toContain('data-slot="tooltip-trigger"')
     expect(markup).not.toContain(' title=')
-  })
-
-  it.each(['active', 'inactive'] as const)(
-    'does not label the passive %s workspace state',
-    (status) => {
-      const markup = renderMarkup(status)
-
-      expect(markup).not.toContain('data-state-indicator-tooltip')
-      expect(markup).not.toContain(' title=')
-    }
-  )
-
-  it('lets an enclosing action own the tooltip', () => {
-    const markup = renderToStaticMarkup(
-      React.createElement(StatusIndicator, { status: 'working', showTooltip: false })
-    )
-
-    expect(markup).not.toContain('data-state-indicator-tooltip')
-    expect(markup).toContain('data-agent-spinner')
   })
 })

--- a/src/renderer/src/components/sidebar/StatusIndicator.test.ts
+++ b/src/renderer/src/components/sidebar/StatusIndicator.test.ts
@@ -31,11 +31,11 @@ describe('StatusIndicator', () => {
     expect(markup).toContain('motion-reduce:border-t-yellow-500')
   })
 
-  it('renders monitoring as a static radio glyph', () => {
+  it('renders monitoring as a static heartbeat glyph', () => {
     const markup = renderMarkup('monitoring')
 
     expect(markup).toContain('title="Monitoring background tasks"')
-    expect(markup).toContain('lucide-radio')
+    expect(markup).toContain('lucide-activity')
     expect(markup).toContain('text-yellow-500')
     expect(markup).not.toContain('data-agent-spinner')
   })

--- a/src/renderer/src/components/sidebar/StatusIndicator.test.ts
+++ b/src/renderer/src/components/sidebar/StatusIndicator.test.ts
@@ -1,7 +1,23 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import StatusIndicator, { type Status } from './StatusIndicator'
+
+vi.mock('@/components/StateIndicatorTooltip', async () => {
+  const { createElement } = await import('react')
+  return {
+    StateIndicatorTooltip: ({
+      label,
+      children
+    }: {
+      label: string | null
+      children: React.ReactElement
+    }) =>
+      label === null
+        ? children
+        : createElement('span', { 'data-state-indicator-tooltip': label }, children)
+  }
+})
 
 function renderMarkup(status: Status): string {
   return renderToStaticMarkup(React.createElement(StatusIndicator, { status }))
@@ -34,7 +50,7 @@ describe('StatusIndicator', () => {
   it('renders monitoring as a static heartbeat glyph', () => {
     const markup = renderMarkup('monitoring')
 
-    expect(markup).not.toContain('data-state-indicator-tooltip')
+    expect(markup).toContain('data-state-indicator-tooltip="Monitoring background tasks"')
     expect(markup).not.toContain(' title=')
     expect(markup).toContain('lucide-activity')
     expect(markup).toContain('text-yellow-500')
@@ -69,18 +85,35 @@ describe('StatusIndicator', () => {
     expect(classNames).not.toContain('bg-emerald-500')
   })
 
-  it.each<Status>([
-    'active',
-    'working',
-    'monitoring',
-    'permission',
-    'interrupted',
-    'done',
-    'inactive'
-  ])('keeps the workspace-level %s indicator tooltip-free', (status) => {
+  it.each([
+    ['working', 'Working'],
+    ['monitoring', 'Monitoring background tasks'],
+    ['permission', 'Needs permission'],
+    ['interrupted', 'Interrupted'],
+    ['done', 'Done']
+  ] as const)('labels the agent-derived %s workspace state', (status, label) => {
     const markup = renderMarkup(status)
 
-    expect(markup).not.toContain('data-slot="tooltip-trigger"')
+    expect(markup).toContain(`data-state-indicator-tooltip="${label}"`)
     expect(markup).not.toContain(' title=')
+  })
+
+  it.each(['active', 'inactive'] as const)(
+    'does not label the passive %s workspace state',
+    (status) => {
+      const markup = renderMarkup(status)
+
+      expect(markup).not.toContain('data-state-indicator-tooltip')
+      expect(markup).not.toContain(' title=')
+    }
+  )
+
+  it('lets an enclosing action own the tooltip', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(StatusIndicator, { status: 'working', showTooltip: false })
+    )
+
+    expect(markup).not.toContain('data-state-indicator-tooltip')
+    expect(markup).toContain('data-agent-spinner')
   })
 })

--- a/src/renderer/src/components/sidebar/StatusIndicator.test.ts
+++ b/src/renderer/src/components/sidebar/StatusIndicator.test.ts
@@ -1,23 +1,7 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import StatusIndicator, { type Status } from './StatusIndicator'
-
-vi.mock('@/components/StateIndicatorTooltip', async () => {
-  const { createElement } = await import('react')
-  return {
-    StateIndicatorTooltip: ({
-      label,
-      children
-    }: {
-      label: string | null
-      children: React.ReactElement
-    }) =>
-      label === null
-        ? children
-        : createElement('span', { 'data-state-indicator-tooltip': label }, children)
-  }
-})
 
 function renderMarkup(status: Status): string {
   return renderToStaticMarkup(React.createElement(StatusIndicator, { status }))
@@ -50,7 +34,7 @@ describe('StatusIndicator', () => {
   it('renders monitoring as a static heartbeat glyph', () => {
     const markup = renderMarkup('monitoring')
 
-    expect(markup).toContain('data-state-indicator-tooltip="Monitoring background tasks"')
+    expect(markup).not.toContain('data-state-indicator-tooltip')
     expect(markup).not.toContain(' title=')
     expect(markup).toContain('lucide-activity')
     expect(markup).toContain('text-yellow-500')

--- a/src/renderer/src/components/sidebar/StatusIndicator.test.ts
+++ b/src/renderer/src/components/sidebar/StatusIndicator.test.ts
@@ -1,7 +1,23 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import StatusIndicator, { type Status } from './StatusIndicator'
+
+vi.mock('@/components/StateIndicatorTooltip', async () => {
+  const { createElement } = await import('react')
+  return {
+    StateIndicatorTooltip: ({
+      label,
+      children
+    }: {
+      label: string | null
+      children: React.ReactElement
+    }) =>
+      label === null
+        ? children
+        : createElement('span', { 'data-state-indicator-tooltip': label }, children)
+  }
+})
 
 function renderMarkup(status: Status): string {
   return renderToStaticMarkup(React.createElement(StatusIndicator, { status }))
@@ -34,7 +50,8 @@ describe('StatusIndicator', () => {
   it('renders monitoring as a static heartbeat glyph', () => {
     const markup = renderMarkup('monitoring')
 
-    expect(markup).toContain('title="Monitoring background tasks"')
+    expect(markup).toContain('data-state-indicator-tooltip="Monitoring background tasks"')
+    expect(markup).not.toContain(' title=')
     expect(markup).toContain('lucide-activity')
     expect(markup).toContain('text-yellow-500')
     expect(markup).not.toContain('data-agent-spinner')

--- a/src/renderer/src/components/sidebar/StatusIndicator.test.ts
+++ b/src/renderer/src/components/sidebar/StatusIndicator.test.ts
@@ -1,7 +1,23 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import StatusIndicator, { type Status } from './StatusIndicator'
+
+vi.mock('@/components/StateIndicatorTooltip', async () => {
+  const { createElement } = await import('react')
+  return {
+    StateIndicatorTooltip: ({
+      label,
+      children
+    }: {
+      label: string | null
+      children: React.ReactElement
+    }) =>
+      label === null
+        ? children
+        : createElement('span', { 'data-state-indicator-tooltip': label }, children)
+  }
+})
 
 function renderMarkup(status: Status): string {
   return renderToStaticMarkup(React.createElement(StatusIndicator, { status }))
@@ -34,7 +50,7 @@ describe('StatusIndicator', () => {
   it('renders monitoring as a static heartbeat glyph', () => {
     const markup = renderMarkup('monitoring')
 
-    expect(markup).not.toContain('data-state-indicator-tooltip')
+    expect(markup).toContain('data-state-indicator-tooltip="Monitoring background tasks"')
     expect(markup).not.toContain(' title=')
     expect(markup).toContain('lucide-activity')
     expect(markup).toContain('text-yellow-500')
@@ -67,5 +83,37 @@ describe('StatusIndicator', () => {
 
     expect(classNames).toContain('bg-red-500')
     expect(classNames).not.toContain('bg-emerald-500')
+  })
+
+  it.each([
+    ['working', 'Working'],
+    ['monitoring', 'Monitoring background tasks'],
+    ['permission', 'Needs permission'],
+    ['interrupted', 'Interrupted'],
+    ['done', 'Done']
+  ] as const)('labels the agent-derived %s workspace state', (status, label) => {
+    const markup = renderMarkup(status)
+
+    expect(markup).toContain(`data-state-indicator-tooltip="${label}"`)
+    expect(markup).not.toContain(' title=')
+  })
+
+  it.each(['active', 'inactive'] as const)(
+    'does not label the passive %s workspace state',
+    (status) => {
+      const markup = renderMarkup(status)
+
+      expect(markup).not.toContain('data-state-indicator-tooltip')
+      expect(markup).not.toContain(' title=')
+    }
+  )
+
+  it('lets an enclosing action own the tooltip', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(StatusIndicator, { status: 'working', showTooltip: false })
+    )
+
+    expect(markup).not.toContain('data-state-indicator-tooltip')
+    expect(markup).toContain('data-agent-spinner')
   })
 })

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -2,12 +2,8 @@ import React from 'react'
 import { Activity } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
-import {
-  StateIndicatorTooltip,
-  type StateIndicatorTooltipSide
-} from '@/components/StateIndicatorTooltip'
 import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
-import { getWorktreeStatusLabel, type WorktreeStatus } from '@/lib/worktree-status'
+import type { WorktreeStatus } from '@/lib/worktree-status'
 
 // Why: re-export WorktreeStatus under the existing `Status` alias so the
 // sidebar component and the canonical lib share one source of truth — the
@@ -17,20 +13,13 @@ export type Status = WorktreeStatus
 
 type StatusIndicatorProps = Omit<React.ComponentProps<'span'>, 'title'> & {
   status: Status
-  /** Overrides the hover tooltip; null suppresses it for an existing tooltip. */
-  title?: string | null
-  tooltipSide?: StateIndicatorTooltipSide
 }
 
 const StatusIndicator = React.memo(function StatusIndicator({
   status,
   className,
-  title,
-  tooltipSide,
   ...rest
 }: StatusIndicatorProps) {
-  const tooltipLabel = title === null ? null : (title ?? getWorktreeStatusLabel(status))
-
   let indicator: React.JSX.Element
 
   if (status === 'working') {
@@ -90,11 +79,7 @@ const StatusIndicator = React.memo(function StatusIndicator({
     )
   }
 
-  return (
-    <StateIndicatorTooltip label={tooltipLabel} side={tooltipSide}>
-      {indicator}
-    </StateIndicatorTooltip>
-  )
+  return indicator
 })
 
 export default StatusIndicator

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -2,6 +2,10 @@ import React from 'react'
 import { Activity } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
+import {
+  StateIndicatorTooltip,
+  type StateIndicatorTooltipSide
+} from '@/components/StateIndicatorTooltip'
 import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
 import { getWorktreeStatusLabel, type WorktreeStatus } from '@/lib/worktree-status'
 
@@ -11,90 +15,85 @@ import { getWorktreeStatusLabel, type WorktreeStatus } from '@/lib/worktree-stat
 // (e.g., 'error') and the other didn't.
 export type Status = WorktreeStatus
 
-type StatusIndicatorProps = React.ComponentProps<'span'> & {
+type StatusIndicatorProps = Omit<React.ComponentProps<'span'>, 'title'> & {
   status: Status
+  /** Overrides the hover tooltip; null suppresses it for an existing tooltip. */
+  title?: string | null
+  tooltipSide?: StateIndicatorTooltipSide
 }
 
 const StatusIndicator = React.memo(function StatusIndicator({
   status,
   className,
   title,
+  tooltipSide,
   ...rest
 }: StatusIndicatorProps) {
-  // Why: surface the status label as a native tooltip so hovering the dot
-  // reveals the state — matters especially for 'active' vs 'done', which
-  // share the same emerald dot. Callers pass aria-hidden="true" alongside
-  // an sr-only label, so the `title` attribute is ignored by AT and only
-  // serves sighted users on hover. Callers can override by passing their
-  // own `title`.
-  const resolvedTitle = title ?? getWorktreeStatusLabel(status)
+  const tooltipLabel = title === null ? null : (title ?? getWorktreeStatusLabel(status))
+
+  let indicator: React.JSX.Element
 
   if (status === 'working') {
-    return (
+    indicator = (
       <span
         className={cn('inline-flex h-3 w-3 shrink-0 items-center justify-center', className)}
-        title={resolvedTitle}
         {...rest}
       >
         <AgentWorkingSpinner className="size-2" />
       </span>
     )
-  }
-
-  if (status === 'monitoring') {
-    return (
+  } else if (status === 'monitoring') {
+    indicator = (
       <span
         className={cn('inline-flex h-3 w-3 shrink-0 items-center justify-center', className)}
-        title={resolvedTitle}
         {...rest}
       >
         <Activity className="size-3 text-yellow-500" aria-hidden="true" />
       </span>
     )
-  }
-
-  if (status === 'interrupted') {
-    return (
+  } else if (status === 'interrupted') {
+    indicator = (
       <span
         className={cn('inline-flex h-3 w-3 shrink-0 items-center justify-center', className)}
-        title={resolvedTitle}
         {...rest}
       >
         <span className="block size-1.5 rounded-full bg-red-500" />
       </span>
     )
-  }
-
-  if (status === 'permission') {
-    return (
+  } else if (status === 'permission') {
+    indicator = (
       <span
         className={cn('inline-flex h-3 w-3 shrink-0 items-center justify-center', className)}
-        title={resolvedTitle}
         {...rest}
       >
         <AgentQuestionIcon className="size-3" />
       </span>
     )
+  } else {
+    indicator = (
+      <span
+        className={cn('inline-flex h-3 w-3 shrink-0 items-center justify-center', className)}
+        {...rest}
+      >
+        <span
+          className={cn(
+            'block size-2 rounded-full',
+            status === 'done' || status === 'active'
+              ? // Green dot for both hook-reported 'done' and the heuristic
+                // 'active' (terminal open, quiet). Working uses a yellow
+                // ring above; 'inactive' stays grey.
+                'bg-emerald-500'
+              : 'bg-neutral-500/40'
+          )}
+        />
+      </span>
+    )
   }
 
   return (
-    <span
-      className={cn('inline-flex h-3 w-3 shrink-0 items-center justify-center', className)}
-      title={resolvedTitle}
-      {...rest}
-    >
-      <span
-        className={cn(
-          'block size-2 rounded-full',
-          status === 'done' || status === 'active'
-            ? // Green dot for both hook-reported 'done' and the heuristic
-              // 'active' (terminal open, quiet). Working uses a yellow
-              // ring above; 'inactive' stays grey.
-              'bg-emerald-500'
-            : 'bg-neutral-500/40'
-        )}
-      />
-    </span>
+    <StateIndicatorTooltip label={tooltipLabel} side={tooltipSide}>
+      {indicator}
+    </StateIndicatorTooltip>
   )
 })
 

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Radio } from 'lucide-react'
+import { Activity } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
 import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
@@ -48,7 +48,7 @@ const StatusIndicator = React.memo(function StatusIndicator({
         title={resolvedTitle}
         {...rest}
       >
-        <Radio className="size-3 text-yellow-500" aria-hidden="true" />
+        <Activity className="size-3 text-yellow-500" aria-hidden="true" />
       </span>
     )
   }

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -3,11 +3,7 @@ import { Activity } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
 import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
-import {
-  StateIndicatorTooltip,
-  type StateIndicatorTooltipSide
-} from '@/components/StateIndicatorTooltip'
-import { getWorktreeStatusLabel, type WorktreeStatus } from '@/lib/worktree-status'
+import type { WorktreeStatus } from '@/lib/worktree-status'
 
 // Why: re-export WorktreeStatus under the existing `Status` alias so the
 // sidebar component and the canonical lib share one source of truth — the
@@ -17,27 +13,13 @@ export type Status = WorktreeStatus
 
 type StatusIndicatorProps = Omit<React.ComponentProps<'span'>, 'title'> & {
   status: Status
-  showTooltip?: boolean
-  tooltipSide?: StateIndicatorTooltipSide
 }
-
-const AGENT_STATUS_TOOLTIP_STATUSES = new Set<Status>([
-  'working',
-  'monitoring',
-  'permission',
-  'interrupted',
-  'done'
-])
 
 const StatusIndicator = React.memo(function StatusIndicator({
   status,
   className,
-  showTooltip = true,
-  tooltipSide,
   ...rest
 }: StatusIndicatorProps) {
-  const tooltipLabel =
-    showTooltip && AGENT_STATUS_TOOLTIP_STATUSES.has(status) ? getWorktreeStatusLabel(status) : null
   let indicator: React.JSX.Element
 
   if (status === 'working') {
@@ -97,11 +79,7 @@ const StatusIndicator = React.memo(function StatusIndicator({
     )
   }
 
-  return (
-    <StateIndicatorTooltip label={tooltipLabel} side={tooltipSide}>
-      {indicator}
-    </StateIndicatorTooltip>
-  )
+  return indicator
 })
 
 export default StatusIndicator

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -3,7 +3,11 @@ import { Activity } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
 import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
-import type { WorktreeStatus } from '@/lib/worktree-status'
+import {
+  StateIndicatorTooltip,
+  type StateIndicatorTooltipSide
+} from '@/components/StateIndicatorTooltip'
+import { getWorktreeStatusLabel, type WorktreeStatus } from '@/lib/worktree-status'
 
 // Why: re-export WorktreeStatus under the existing `Status` alias so the
 // sidebar component and the canonical lib share one source of truth — the
@@ -13,13 +17,27 @@ export type Status = WorktreeStatus
 
 type StatusIndicatorProps = Omit<React.ComponentProps<'span'>, 'title'> & {
   status: Status
+  showTooltip?: boolean
+  tooltipSide?: StateIndicatorTooltipSide
 }
+
+const AGENT_STATUS_TOOLTIP_STATUSES = new Set<Status>([
+  'working',
+  'monitoring',
+  'permission',
+  'interrupted',
+  'done'
+])
 
 const StatusIndicator = React.memo(function StatusIndicator({
   status,
   className,
+  showTooltip = true,
+  tooltipSide,
   ...rest
 }: StatusIndicatorProps) {
+  const tooltipLabel =
+    showTooltip && AGENT_STATUS_TOOLTIP_STATUSES.has(status) ? getWorktreeStatusLabel(status) : null
   let indicator: React.JSX.Element
 
   if (status === 'working') {
@@ -79,7 +97,11 @@ const StatusIndicator = React.memo(function StatusIndicator({
     )
   }
 
-  return indicator
+  return (
+    <StateIndicatorTooltip label={tooltipLabel} side={tooltipSide}>
+      {indicator}
+    </StateIndicatorTooltip>
+  )
 })
 
 export default StatusIndicator

--- a/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
@@ -168,7 +168,7 @@ function makeHostedReview(overrides: Partial<HostedReviewInfo> = {}): HostedRevi
   }
 }
 
-function expectParentBodyIsHoverTrigger(markup: string): void {
+function expectIdentityBodyIsHoverTrigger(markup: string): void {
   const surfaceTag = markup.match(/<div[^>]*data-worktree-card-surface="true"[^>]*>/)?.[0]
   const triggerTag = markup.match(/<div[^>]*data-worktree-card-hover-trigger=""[^>]*>/)?.[0]
 
@@ -236,7 +236,7 @@ describe('WorktreeCard compact hover details', () => {
     )
 
     expect(markup).toContain('data-worktree-title-inline-rename=""')
-    expectParentBodyIsHoverTrigger(markup)
+    expectIdentityBodyIsHoverTrigger(markup)
     expect(markup).toContain('data-hover-open-delay="100"')
     expect(markup).toContain('PR #456')
     expect(markup).toContain('Fix stale GH PR')
@@ -288,7 +288,7 @@ describe('WorktreeCard compact hover details', () => {
     )
 
     expect(markup).toContain('data-hover-open-delay="100"')
-    expectParentBodyIsHoverTrigger(markup)
+    expectIdentityBodyIsHoverTrigger(markup)
     expect(markup).toContain('Issue #123')
     expect(markup).toContain('Linear ENG-123')
     expect(markup).toContain('Reviewer handoff note')
@@ -397,7 +397,7 @@ describe('WorktreeCard compact hover details', () => {
     expect(markup).toContain('Human title')
   })
 
-  it('uses one whole-card hover even when detailed metadata icons are visible when new card style is on', async () => {
+  it('uses one identity hover even when detailed metadata icons are visible when new card style is on', async () => {
     settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: true }
     worktreeCardProperties = ['status', 'issue', 'linear-issue', 'comment', 'ports']
     const { default: WorktreeCard } = await import('./WorktreeCard')
@@ -417,12 +417,12 @@ describe('WorktreeCard compact hover details', () => {
 
     expect(markup).toContain('Workspace metadata')
     expect(markup).not.toContain('data-worktree-card-meta-row=""')
-    expectParentBodyIsHoverTrigger(markup)
+    expectIdentityBodyIsHoverTrigger(markup)
     expect(markup.match(/data-hover-open-delay="100"/g)).toHaveLength(1)
     expect(markup).toContain('Reviewer handoff note')
   })
 
-  it('keeps long workspace and branch identity in whole-card hover details when the branch row is hidden', async () => {
+  it('keeps long workspace and branch identity in hover details when the branch row is hidden', async () => {
     settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: true }
     worktreeCardProperties = ['status', 'comment']
     const { default: WorktreeCard } = await import('./WorktreeCard')
@@ -440,13 +440,13 @@ describe('WorktreeCard compact hover details', () => {
     )
 
     expect(markup).not.toContain('data-worktree-card-meta-row=""')
-    expectParentBodyIsHoverTrigger(markup)
+    expectIdentityBodyIsHoverTrigger(markup)
     expect(markup).toContain('[Bug]: Hold-to-talk speech-to-text option no longer works')
     expect(markup).toContain('bug-hold-to-talk-speech-to-text-option-no-longer-works')
     expect(markup).toContain('Reviewer handoff note')
   })
 
-  it('repeats a long workspace title inside the whole-card hover when branch is already visible', async () => {
+  it('repeats a long workspace title inside the identity hover when branch is already visible', async () => {
     settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: true }
     worktreeCardProperties = ['status', 'branch', 'comment']
     const longTitle =
@@ -461,13 +461,13 @@ describe('WorktreeCard compact hover details', () => {
       />
     )
 
-    expectParentBodyIsHoverTrigger(markup)
+    expectIdentityBodyIsHoverTrigger(markup)
     expect(markup.match(new RegExp(longTitle, 'g'))).toHaveLength(2)
     expect(markup).toContain('feature/local-branch')
     expect(markup).toContain('Reviewer handoff note')
   })
 
-  it('uses whole-card hover for identity-only new card worktrees with branch row visible', async () => {
+  it('uses identity hover for identity-only new card worktrees with branch row visible', async () => {
     settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: true }
     worktreeCardProperties = ['status', 'branch']
     const { default: WorktreeCard } = await import('./WorktreeCard')
@@ -481,7 +481,7 @@ describe('WorktreeCard compact hover details', () => {
     )
 
     expect(markup).toContain('data-worktree-card-meta-row=""')
-    expectParentBodyIsHoverTrigger(markup)
+    expectIdentityBodyIsHoverTrigger(markup)
     expect(markup.match(/data-hover-open-delay="100"/g)).toHaveLength(1)
     expect(markup.match(/Readable identity only/g)).toHaveLength(2)
     expect(markup).toContain('feature/local-branch')
@@ -502,7 +502,7 @@ describe('WorktreeCard compact hover details', () => {
       />
     )
 
-    expectParentBodyIsHoverTrigger(markup)
+    expectIdentityBodyIsHoverTrigger(markup)
     expect(markup.match(/feature\/local-branch/g)).toHaveLength(3)
   })
 
@@ -605,6 +605,28 @@ describe('WorktreeCard compact hover details', () => {
     )
   })
 
+  it('keeps status and agent tooltip targets outside the worktree details hover trigger', async () => {
+    settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: true }
+    worktreeCardProperties = ['status', 'inline-agents']
+    agentActivityDisplayMode = 'compact'
+    mockInlineAgentRows = [{} as DashboardAgentRowData]
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
+    )
+    const statusIndex = markup.indexOf('data-worktree-card-status-slot=""')
+    const triggerIndex = markup.indexOf('data-worktree-card-hover-trigger=""')
+    const hoverContentIndex = markup.indexOf('data-hover-card-content=""')
+    const agentsIndex = markup.indexOf('data-worktree-agents=""')
+
+    expectIdentityBodyIsHoverTrigger(markup)
+    expect(statusIndex).toBeGreaterThanOrEqual(0)
+    expect(statusIndex).toBeLessThan(triggerIndex)
+    expect(hoverContentIndex).toBeGreaterThan(triggerIndex)
+    expect(agentsIndex).toBeGreaterThan(hoverContentIndex)
+  })
+
   it('preserves the aggregate cache timer when compact inline agents are enabled but absent', async () => {
     settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: true }
     worktreeCardProperties = ['status', 'inline-agents']
@@ -643,7 +665,7 @@ describe('WorktreeCard compact hover details', () => {
     const hoverContentIndex = markup.indexOf('data-hover-card-content=""')
     const childIndex = markup.indexOf('data-lineage-child-card=""')
 
-    expectParentBodyIsHoverTrigger(markup)
+    expectIdentityBodyIsHoverTrigger(markup)
     expect(markup).toContain('data-worktree-lineage-children=""')
     expect(markup).toContain('group/worktree-card')
     expect(markup).not.toContain('group relative flex cursor-pointer')

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import type * as ActivateTabAndFocusPaneModule from '@/lib/activate-tab-and-focus-pane'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 
@@ -395,7 +396,11 @@ describe('WorktreeCardAgents activation', () => {
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
     await act(async () => {
-      root.render(<WorktreeCardAgents worktreeId="wt-1" />)
+      root.render(
+        <TooltipProvider>
+          <WorktreeCardAgents worktreeId="wt-1" />
+        </TooltipProvider>
+      )
     })
     const row = host.querySelector('.compact-agent-row')
     expect(row).toBeInstanceOf(HTMLElement)

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -771,7 +771,9 @@ describe('WorktreeCardAgents', () => {
     const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
     const iconTitles = [...markup.matchAll(/title="([^"]+)"/g)].map((match) => match[1])
 
-    expect(iconTitles).toEqual([])
+    // Variety icons stay identity-free; the lone title is the group's state
+    // label, which every state glyph now carries (STA-5794).
+    expect(iconTitles).toEqual(['Working'])
     expect(markup).not.toContain('>5 working<')
     expect(markup).toContain('>+2<')
   })

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -771,9 +771,9 @@ describe('WorktreeCardAgents', () => {
     const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
     const iconTitles = [...markup.matchAll(/title="([^"]+)"/g)].map((match) => match[1])
 
-    // Variety icons stay identity-free; the lone title is the group's state
-    // label, which every state glyph now carries (STA-5794).
-    expect(iconTitles).toEqual(['Working'])
+    // Variety icons stay identity-free; the state label belongs to the shared tooltip.
+    expect(iconTitles).toEqual([])
+    expect(markup).toContain('>Working<')
     expect(markup).not.toContain('>5 working<')
     expect(markup).toContain('>+2<')
   })

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -9,8 +9,10 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/components/ui/tooltip', () => ({
-  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
-  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: ReactNode }) => <span data-tooltip-root="">{children}</span>,
+  TooltipContent: ({ children }: { children: ReactNode }) => (
+    <span data-tooltip-content="">{children}</span>
+  ),
   TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
 }))
 
@@ -212,6 +214,7 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).toContain('size-[13px] translate-x-px')
     expect(markup).toContain('text-rose-500/85')
     expect(markup).not.toContain('bg-emerald-500')
+    expect(markup).not.toContain('data-tooltip-root')
   })
 
   it('uses the unified compact review glyph for GitLab MR status', () => {
@@ -277,7 +280,7 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).not.toContain('bg-neutral-500/40')
   })
 
-  it('uses a branch icon with branch-only tooltip copy by default', () => {
+  it('uses a branch icon with branch-only accessible copy by default', () => {
     const markup = renderToStaticMarkup(
       <WorktreeCardStatusSlot
         worktreeId="wt-1"
@@ -298,9 +301,10 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).toContain('size-[13px] translate-x-px text-muted-foreground/70')
     expect(markup).toContain('text-muted-foreground/70')
     expect(markup).not.toContain('bg-emerald-500')
+    expect(markup).not.toContain('data-tooltip-root')
   })
 
-  it('uses context-aware branch or folder path tooltip copy', () => {
+  it('uses context-aware branch or folder path accessible copy', () => {
     const markup = renderToStaticMarkup(
       <WorktreeCardStatusSlot
         worktreeId="wt-1"
@@ -318,6 +322,7 @@ describe('WorktreeCardStatusSlot', () => {
 
     expect(markup).toContain('Branch or folder path')
     expect(markup).toContain('lucide-git-branch')
+    expect(markup).not.toContain('data-tooltip-root')
   })
 
   it('keeps the quiet dot when the row has no branch identity', () => {
@@ -338,6 +343,7 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).toContain('Active')
     expect(markup).toContain('bg-emerald-500')
     expect(markup).not.toContain('lucide-git-branch')
+    expect(markup).not.toContain('data-tooltip-root')
   })
 
   it('keeps working activity ahead of PR status in new card style', () => {
@@ -433,6 +439,7 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).not.toContain('lucide-bell')
     expect(markup).not.toContain('text-amber-500')
     expect(markup).not.toContain('bg-emerald-500')
+    expect(markup).not.toContain('data-tooltip-root')
   })
 
   it('overlays an unread badge on the branch icon in new card style', () => {
@@ -461,5 +468,6 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).not.toContain('lucide-bell')
     expect(markup).not.toContain('text-amber-500')
     expect(markup).not.toContain('bg-emerald-500')
+    expect(markup).not.toContain('data-tooltip-root')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -173,6 +173,7 @@ describe('WorktreeCardStatusSlot', () => {
 
     expect(markup).toContain('Active · Mark as unread')
     expect(markup).toContain('bg-emerald-500')
+    expect(markup.match(/data-tooltip-root/g)).toHaveLength(1)
   })
 
   it('keeps the quiet active dot ahead of PR status by default', () => {
@@ -365,6 +366,8 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).toContain('Working')
     expect(markup).toContain('inline-flex size-5 items-center justify-center')
     expect(markup).toContain('border-yellow-500')
+    expect(markup).toContain('data-tooltip-root')
+    expect(markup).toContain('data-tooltip-content="">Working')
     expect(markup).not.toContain('PR checks: Failed')
   })
 
@@ -387,6 +390,8 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).toContain('Needs permission')
     expect(markup).toContain('lucide-message-circle-question-mark')
     expect(markup).toContain('text-agent-question')
+    expect(markup).toContain('data-tooltip-root')
+    expect(markup).toContain('data-tooltip-content="">Needs permission')
     expect(markup).not.toContain('PR checks: Failed')
   })
 

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -366,8 +366,7 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).toContain('Working')
     expect(markup).toContain('inline-flex size-5 items-center justify-center')
     expect(markup).toContain('border-yellow-500')
-    expect(markup).toContain('data-tooltip-root')
-    expect(markup).toContain('data-tooltip-content="">Working')
+    expect(markup).not.toContain('data-tooltip-root')
     expect(markup).not.toContain('PR checks: Failed')
   })
 
@@ -390,8 +389,7 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).toContain('Needs permission')
     expect(markup).toContain('lucide-message-circle-question-mark')
     expect(markup).toContain('text-agent-question')
-    expect(markup).toContain('data-tooltip-root')
-    expect(markup).toContain('data-tooltip-content="">Needs permission')
+    expect(markup).not.toContain('data-tooltip-root')
     expect(markup).not.toContain('PR checks: Failed')
   })
 

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -366,7 +366,8 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).toContain('Working')
     expect(markup).toContain('inline-flex size-5 items-center justify-center')
     expect(markup).toContain('border-yellow-500')
-    expect(markup).not.toContain('data-tooltip-root')
+    expect(markup).toContain('data-tooltip-root')
+    expect(markup).toContain('data-tooltip-content="">Working')
     expect(markup).not.toContain('PR checks: Failed')
   })
 
@@ -389,7 +390,8 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).toContain('Needs permission')
     expect(markup).toContain('lucide-message-circle-question-mark')
     expect(markup).toContain('text-agent-question')
-    expect(markup).not.toContain('data-tooltip-root')
+    expect(markup).toContain('data-tooltip-root')
+    expect(markup).toContain('data-tooltip-content="">Needs permission')
     expect(markup).not.toContain('PR checks: Failed')
   })
 

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -141,18 +141,13 @@ export function WorktreeCardStatusSlot({
     ) : newCardStyle && showStatus ? (
       <>
         <span className={cn('inline-flex size-5 items-center justify-center', className)}>
-          <StatusIndicator status={status} aria-hidden="true" tooltipSide="right" />
+          <StatusIndicator status={status} aria-hidden="true" />
         </span>
         <span className="sr-only">{passiveStatusAnnouncement}</span>
       </>
     ) : (
       <>
-        <StatusIndicator
-          status={status}
-          aria-hidden="true"
-          className={className}
-          tooltipSide="right"
-        />
+        <StatusIndicator status={status} aria-hidden="true" className={className} />
         <span className="sr-only">{statusLabel}</span>
       </>
     )
@@ -203,7 +198,7 @@ export function WorktreeCardStatusSlot({
                   {branchStatusIcon}
                 </span>
               ) : showStatus ? (
-                <StatusIndicator status={status} aria-hidden="true" showTooltip={false} />
+                <StatusIndicator status={status} aria-hidden="true" />
               ) : (
                 <span className="sr-only">{actionLabel}</span>
               )
@@ -214,7 +209,6 @@ export function WorktreeCardStatusSlot({
                 <StatusIndicator
                   status={status}
                   aria-hidden="true"
-                  showTooltip={false}
                   className="transition-opacity group-hover/unread:opacity-0 group-focus-within/unread:opacity-0"
                 />
                 <Bell className="absolute size-3 text-muted-foreground/40 opacity-0 transition-opacity group-hover/unread:opacity-100 group-focus-within/unread:opacity-100" />

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -141,13 +141,18 @@ export function WorktreeCardStatusSlot({
     ) : newCardStyle && showStatus ? (
       <>
         <span className={cn('inline-flex size-5 items-center justify-center', className)}>
-          <StatusIndicator status={status} aria-hidden="true" />
+          <StatusIndicator status={status} aria-hidden="true" tooltipSide="right" />
         </span>
         <span className="sr-only">{passiveStatusAnnouncement}</span>
       </>
     ) : (
       <>
-        <StatusIndicator status={status} aria-hidden="true" className={className} />
+        <StatusIndicator
+          status={status}
+          aria-hidden="true"
+          className={className}
+          tooltipSide="right"
+        />
         <span className="sr-only">{statusLabel}</span>
       </>
     )
@@ -198,7 +203,7 @@ export function WorktreeCardStatusSlot({
                   {branchStatusIcon}
                 </span>
               ) : showStatus ? (
-                <StatusIndicator status={status} aria-hidden="true" />
+                <StatusIndicator status={status} aria-hidden="true" showTooltip={false} />
               ) : (
                 <span className="sr-only">{actionLabel}</span>
               )
@@ -209,6 +214,7 @@ export function WorktreeCardStatusSlot({
                 <StatusIndicator
                   status={status}
                   aria-hidden="true"
+                  showTooltip={false}
                   className="transition-opacity group-hover/unread:opacity-0 group-focus-within/unread:opacity-0"
                 />
                 <Bell className="absolute size-3 text-muted-foreground/40 opacity-0 transition-opacity group-hover/unread:opacity-100 group-focus-within/unread:opacity-100" />

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -159,13 +159,18 @@ export function WorktreeCardStatusSlot({
     ) : newCardStyle && showStatus ? (
       <>
         <span className={cn('inline-flex size-5 items-center justify-center', className)}>
-          <StatusIndicator status={status} aria-hidden="true" />
+          <StatusIndicator status={status} aria-hidden="true" tooltipSide="right" />
         </span>
         <span className="sr-only">{passiveStatusTooltip}</span>
       </>
     ) : (
       <>
-        <StatusIndicator status={status} aria-hidden="true" className={className} />
+        <StatusIndicator
+          status={status}
+          aria-hidden="true"
+          className={className}
+          tooltipSide="right"
+        />
         <span className="sr-only">{statusLabel}</span>
       </>
     )
@@ -216,7 +221,7 @@ export function WorktreeCardStatusSlot({
                   {branchStatusIcon}
                 </span>
               ) : showStatus ? (
-                <StatusIndicator status={status} aria-hidden="true" />
+                <StatusIndicator status={status} aria-hidden="true" title={null} />
               ) : (
                 <span className="sr-only">{actionLabel}</span>
               )
@@ -227,6 +232,7 @@ export function WorktreeCardStatusSlot({
                 <StatusIndicator
                   status={status}
                   aria-hidden="true"
+                  title={null}
                   className="transition-opacity group-hover/unread:opacity-0 group-focus-within/unread:opacity-0"
                 />
                 <Bell className="absolute size-3 text-muted-foreground/40 opacity-0 transition-opacity group-hover/unread:opacity-100 group-focus-within/unread:opacity-100" />

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -63,7 +63,7 @@ function overlayNewCardUnreadStatus(
   )
 }
 
-function getReviewStatusTooltip(review: WorktreeCardPrDisplay): string {
+function getReviewStatusLabel(review: WorktreeCardPrDisplay): string {
   const label = getReviewLabel(review)
   if (review.state === 'merged') {
     return `${label}: Merged`
@@ -115,62 +115,39 @@ export function WorktreeCardStatusSlot({
     QUIET_REVIEW_REPLACEABLE_STATUSES.has(status)
   const passiveStatusLabel =
     canShowReviewStatus && prDisplay
-      ? getReviewStatusTooltip(prDisplay)
+      ? getReviewStatusLabel(prDisplay)
       : canShowBranchStatus
         ? (branchIdentityLabel ?? getDefaultBranchIdentityLabel())
         : statusLabel
-  const passiveStatusTooltip =
+  const passiveStatusAnnouncement =
     newCardStyle && isUnread ? `${passiveStatusLabel} · Unread` : passiveStatusLabel
   // Why: working and permission already own the new-card status lane, but
-  // unread state should still surface in tooltip/sr-only copy and reappear afterward.
+  // unread state should still surface to assistive technology and reappear afterward.
   const showNewCardUnreadAlert =
     newCardStyle && isUnread && showStatus && status !== 'working' && status !== 'permission'
   const reviewStatusIconClassName = compactReviewAndBranchStatusIconClassName
   const branchStatusIcon = <GitBranch className={branchStatusIconClassName} aria-hidden="true" />
   const passiveStatus =
     canShowReviewStatus && prDisplay ? (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className={cn('inline-flex size-5 items-center justify-center p-0.5', className)}>
-            <ReviewIcon
-              review={prDisplay}
-              className={reviewStatusIconClassName}
-              variant="generic"
-            />
-            <span className="sr-only">{passiveStatusTooltip}</span>
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="right" sideOffset={8}>
-          <span>{passiveStatusTooltip}</span>
-        </TooltipContent>
-      </Tooltip>
+      <span className={cn('inline-flex size-5 items-center justify-center p-0.5', className)}>
+        <ReviewIcon review={prDisplay} className={reviewStatusIconClassName} variant="generic" />
+        <span className="sr-only">{passiveStatusAnnouncement}</span>
+      </span>
     ) : canShowBranchStatus ? (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className={cn('inline-flex size-5 items-center justify-center p-0.5', className)}>
-            {branchStatusIcon}
-            <span className="sr-only">{passiveStatusTooltip}</span>
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="right" sideOffset={8}>
-          <span>{passiveStatusTooltip}</span>
-        </TooltipContent>
-      </Tooltip>
+      <span className={cn('inline-flex size-5 items-center justify-center p-0.5', className)}>
+        {branchStatusIcon}
+        <span className="sr-only">{passiveStatusAnnouncement}</span>
+      </span>
     ) : newCardStyle && showStatus ? (
       <>
         <span className={cn('inline-flex size-5 items-center justify-center', className)}>
-          <StatusIndicator status={status} aria-hidden="true" tooltipSide="right" />
+          <StatusIndicator status={status} aria-hidden="true" />
         </span>
-        <span className="sr-only">{passiveStatusTooltip}</span>
+        <span className="sr-only">{passiveStatusAnnouncement}</span>
       </>
     ) : (
       <>
-        <StatusIndicator
-          status={status}
-          aria-hidden="true"
-          className={className}
-          tooltipSide="right"
-        />
+        <StatusIndicator status={status} aria-hidden="true" className={className} />
         <span className="sr-only">{statusLabel}</span>
       </>
     )
@@ -221,7 +198,7 @@ export function WorktreeCardStatusSlot({
                   {branchStatusIcon}
                 </span>
               ) : showStatus ? (
-                <StatusIndicator status={status} aria-hidden="true" title={null} />
+                <StatusIndicator status={status} aria-hidden="true" />
               ) : (
                 <span className="sr-only">{actionLabel}</span>
               )
@@ -232,7 +209,6 @@ export function WorktreeCardStatusSlot({
                 <StatusIndicator
                   status={status}
                   aria-hidden="true"
-                  title={null}
                   className="transition-opacity group-hover/unread:opacity-0 group-focus-within/unread:opacity-0"
                 />
                 <Bell className="absolute size-3 text-muted-foreground/40 opacity-0 transition-opacity group-hover/unread:opacity-100 group-focus-within/unread:opacity-100" />

--- a/src/renderer/src/components/sidebar/worktree-card-agent-summary.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-agent-summary.test.ts
@@ -33,6 +33,10 @@ function monitoringAgent(): DashboardAgentRowData {
   }
 }
 
+function orderedTitles(markup: string): string[] {
+  return [...markup.matchAll(/\stitle="([^"]*)"/g)].map((match) => match[1])
+}
+
 describe('worktree card agent summary', () => {
   it('presents passive working as monitoring', () => {
     const agent = monitoringAgent()
@@ -54,6 +58,34 @@ describe('worktree card agent summary', () => {
     expect(markup).toMatch(
       /Monitoring background tasks<\/span><span[^>]*> - Run background checks<\/span>/
     )
+  })
+
+  it('hands the whole row to the send-target reason, and only then', () => {
+    const agent = monitoringAgent()
+    agent.entry.prompt = 'Run background checks'
+
+    const disabled = renderToStaticMarkup(
+      createElement(CompactAgentRow, {
+        agent,
+        now: 2000,
+        onActivate: vi.fn(),
+        sendTargetStatus: 'disabled',
+        sendTargetDisabledReason: 'Agent needs permission'
+      })
+    )
+
+    // The dot sits inside the row, so its own state title would shadow the reason on hover.
+    expect(orderedTitles(disabled)).toEqual(['Agent needs permission', 'Claude'])
+
+    const eligible = renderToStaticMarkup(
+      createElement(CompactAgentRow, { agent, now: 2000, onActivate: vi.fn() })
+    )
+
+    expect(orderedTitles(eligible)).toEqual([
+      'Monitoring background tasks - Run background checks',
+      'Monitoring background tasks',
+      'Claude'
+    ])
   })
 
   it('lists interrupted outcomes before clean completions', () => {

--- a/src/renderer/src/components/sidebar/worktree-card-agent-summary.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-agent-summary.test.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
 import { CompactAgentRow, getCompactAgentSecondary } from './worktree-card-compact-agent-row'
 import { getAgentDotState, summarizeAgents } from './worktree-card-agent-summary'
@@ -37,6 +38,12 @@ function orderedTitles(markup: string): string[] {
   return [...markup.matchAll(/\stitle="([^"]*)"/g)].map((match) => match[1])
 }
 
+function renderCompactAgentRow(props: React.ComponentProps<typeof CompactAgentRow>): string {
+  return renderToStaticMarkup(
+    createElement(TooltipProvider, null, createElement(CompactAgentRow, props))
+  )
+}
+
 describe('worktree card agent summary', () => {
   it('presents passive working as monitoring', () => {
     const agent = monitoringAgent()
@@ -50,9 +57,7 @@ describe('worktree card agent summary', () => {
     const agent = monitoringAgent()
     agent.entry.prompt = 'Run background checks'
 
-    const markup = renderToStaticMarkup(
-      createElement(CompactAgentRow, { agent, now: 2000, onActivate: vi.fn() })
-    )
+    const markup = renderCompactAgentRow({ agent, now: 2000, onActivate: vi.fn() })
 
     expect(markup).toContain('title="Monitoring background tasks - Run background checks"')
     expect(markup).toMatch(
@@ -64,28 +69,24 @@ describe('worktree card agent summary', () => {
     const agent = monitoringAgent()
     agent.entry.prompt = 'Run background checks'
 
-    const disabled = renderToStaticMarkup(
-      createElement(CompactAgentRow, {
-        agent,
-        now: 2000,
-        onActivate: vi.fn(),
-        sendTargetStatus: 'disabled',
-        sendTargetDisabledReason: 'Agent needs permission'
-      })
-    )
+    const disabled = renderCompactAgentRow({
+      agent,
+      now: 2000,
+      onActivate: vi.fn(),
+      sendTargetStatus: 'disabled',
+      sendTargetDisabledReason: 'Agent needs permission'
+    })
 
     // The dot sits inside the row, so its own state title would shadow the reason on hover.
     expect(orderedTitles(disabled)).toEqual(['Agent needs permission', 'Claude'])
 
-    const eligible = renderToStaticMarkup(
-      createElement(CompactAgentRow, { agent, now: 2000, onActivate: vi.fn() })
-    )
+    const eligible = renderCompactAgentRow({ agent, now: 2000, onActivate: vi.fn() })
 
     expect(orderedTitles(eligible)).toEqual([
-      'Monitoring background tasks - Run background checks',
-      'Monitoring background tasks',
-      'Claude'
+      'Claude',
+      'Monitoring background tasks - Run background checks'
     ])
+    expect(eligible).toContain('data-slot="tooltip-trigger"')
   })
 
   it('lists interrupted outcomes before clean completions', () => {

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -205,13 +205,17 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
         state={dotState}
         size="sm"
         title={sendTargetDisabledReason ? null : undefined}
+        tooltipSide="right"
       />
       {!hideIcon && (
         <span className="inline-flex shrink-0" title={formatAgentTypeLabel(agent.agentType)}>
           <AgentIcon agent={agentTypeToIconAgent(agent.agentType)} size={13} />
         </span>
       )}
-      <span className="min-w-0 flex-1 truncate">
+      <span
+        className="min-w-0 flex-1 truncate"
+        title={sendTargetDisabledReason ? undefined : rowTitle}
+      >
         {/* Why: the selected-row fill is strong enough to wash out the dimmed
             prompt/secondary text, so lift both toward full foreground when focused. */}
         <span className={isFocusedPane ? 'text-foreground' : 'text-muted-foreground/90'}>
@@ -283,7 +287,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
       role={agent.lineage ? 'treeitem' : undefined}
       aria-level={agent.lineage ? agent.lineage.depth + 1 : undefined}
       aria-expanded={hasChildDisclosure ? childAgentsExpanded : undefined}
-      title={sendTargetDisabledReason ?? rowTitle}
+      title={sendTargetDisabledReason}
     >
       {rowBody}
     </div>

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -200,7 +200,12 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
       ) : reserveDisclosureGutter ? (
         <span className="size-4 shrink-0" aria-hidden />
       ) : null}
-      <AgentStateDot state={dotState} size="sm" />
+      {/* Why: the row's actionable disabled reason must win on every hit area. */}
+      <AgentStateDot
+        state={dotState}
+        size="sm"
+        title={sendTargetDisabledReason ? null : undefined}
+      />
       {!hideIcon && (
         <span className="inline-flex shrink-0" title={formatAgentTypeLabel(agent.agentType)}>
           <AgentIcon agent={agentTypeToIconAgent(agent.agentType)} size={13} />

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx
@@ -150,7 +150,7 @@ export function CompactAgentSummaryButton({
                   key={group.state}
                   className="inline-flex min-w-0 shrink-0 items-center gap-0.5 rounded-sm bg-worktree-sidebar/70 px-1 py-0.5"
                 >
-                  <AgentStateDot state={group.state} size="sm" />
+                  <AgentStateDot state={group.state} size="sm" tooltipSide="right" />
                   {/* Why: same-state agent identities read as one status cluster;
                       overlapping them saves width without merging different states. */}
                   <span className="inline-flex shrink-0 items-center -space-x-0.5 pl-0.5">

--- a/src/renderer/src/components/sidebar/worktree-card-parent-content.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-parent-content.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import { cn } from '@/lib/utils'
 import { WorktreeCardHeader } from './worktree-card-header'
 import { WorktreeCardMetaRow } from './worktree-card-meta-row'
+import { WorktreeCardDetailsHover } from './WorktreeCardMeta'
+import { WorktreeCardPortsDetails } from './WorktreeCardPorts'
 import type { WorktreeCardPresentation } from './worktree-card-presentation'
 import { WorktreeCardSecondaryRows } from './worktree-card-secondary-rows'
 import { WorktreeCardStatusSlot } from './WorktreeCardStatusSlot'
@@ -26,10 +28,91 @@ export function WorktreeCardParentContent({
     handleToggleUnreadQuick,
     statusLaneReview,
     branchIdentityDisplay,
-    showInlineAgentList
+    showInlineAgentList,
+    titleRenaming,
+    isDeleting,
+    hoverIssue,
+    hoverLinearIssue,
+    hoverJiraIssue,
+    hoverReview,
+    hoverComment,
+    metaAutomationProvenance,
+    metaCliProvenance,
+    workspacePorts,
+    detailsHoverControl,
+    handleRenameTitle,
+    handleEditIssue,
+    handleEditComment,
+    handleOpenGitHubIssueInOrca,
+    linearIssue,
+    handleOpenLinearIssueInOrca,
+    handleOpenReviewInOrca,
+    handleOpenAutomation,
+    handleOpenAutomationRun,
+    hasExplicitLinkedReview,
+    handleUnlinkReview
   } = card
-  const { titleOnlyCard, parentContentMarginLeft, showCombinedStatusSlot, showUnreadQuickAction } =
-    presentation
+  const {
+    titleOnlyCard,
+    parentContentMarginLeft,
+    showCombinedStatusSlot,
+    showUnreadQuickAction,
+    hasHoverDetails,
+    hoverBranchName,
+    hoverWorkspaceTitle
+  } = presentation
+
+  const identityContent = (
+    <div
+      className="group/worktree-card flex w-full min-w-0 flex-col gap-1.5"
+      data-worktree-card-hover-trigger=""
+    >
+      <WorktreeCardHeader card={card} presentation={presentation} />
+      {presentation.hasMetaRow && <WorktreeCardMetaRow card={card} presentation={presentation} />}
+    </div>
+  )
+  // Why: status glyphs and agent rows own their tooltips; only identity content should open the larger details card.
+  const identityContentWithHover =
+    hasHoverDetails && !titleRenaming ? (
+      <WorktreeCardDetailsHover
+        issue={hoverIssue}
+        linearIssue={hoverLinearIssue}
+        jiraIssue={hoverJiraIssue}
+        review={hoverReview}
+        comment={hoverComment}
+        automationProvenance={metaAutomationProvenance}
+        cliProvenance={metaCliProvenance}
+        branchName={hoverBranchName}
+        workspaceTitle={hoverWorkspaceTitle}
+        workspaceTitleRenameDisabled={isDeleting || affiliateListMode}
+        detailsAfter={
+          workspacePorts.length > 0 ? <WorktreeCardPortsDetails ports={workspacePorts} /> : null
+        }
+        openDelay={100}
+        hoverControl={detailsHoverControl}
+        onRenameWorkspaceTitle={affiliateListMode ? undefined : handleRenameTitle}
+        onEditIssue={affiliateListMode ? undefined : handleEditIssue}
+        onEditComment={affiliateListMode ? undefined : handleEditComment}
+        onOpenGitHubIssueInOrca={
+          hoverIssue && 'url' in hoverIssue && hoverIssue.url
+            ? handleOpenGitHubIssueInOrca
+            : undefined
+        }
+        onOpenLinearIssueInOrca={linearIssue?.url ? handleOpenLinearIssueInOrca : undefined}
+        onOpenReviewInOrca={
+          hoverReview?.url && hoverReview.provider === 'github' ? handleOpenReviewInOrca : undefined
+        }
+        onOpenAutomation={affiliateListMode ? undefined : handleOpenAutomation}
+        onOpenAutomationRun={affiliateListMode ? undefined : handleOpenAutomationRun}
+        onUnlinkReview={
+          !affiliateListMode && hasExplicitLinkedReview ? handleUnlinkReview : undefined
+        }
+      >
+        {identityContent}
+      </WorktreeCardDetailsHover>
+    ) : (
+      identityContent
+    )
 
   return (
     <div
@@ -76,9 +159,7 @@ export function WorktreeCardParentContent({
             : 'overflow-hidden'
         )}
       >
-        {/* Header row: Title */}
-        <WorktreeCardHeader card={card} presentation={presentation} />
-        {presentation.hasMetaRow && <WorktreeCardMetaRow card={card} presentation={presentation} />}
+        {identityContentWithHover}
         <WorktreeCardSecondaryRows card={card} presentation={presentation} />
       </div>
     </div>

--- a/src/renderer/src/components/sidebar/worktree-card-surface.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-surface.tsx
@@ -4,8 +4,6 @@ import { LoaderCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { AutoRenameFailedDialog } from './AutoRenameFailedDialog'
 import WorktreeContextMenu from './WorktreeContextMenu'
-import { WorktreeCardDetailsHover } from './WorktreeCardMeta'
-import { WorktreeCardPortsDetails } from './WorktreeCardPorts'
 import { WorktreeCardParentContent } from './worktree-card-parent-content'
 import { buildWorktreeCardPresentation } from './worktree-card-presentation'
 import type { WorktreeCardController } from './use-worktree-card-controller'
@@ -38,82 +36,12 @@ export function WorktreeCardSurface({ card }: { card: WorktreeCardController }):
     handleDragStart,
     handleDragEnd,
     handleContextMenuSelect,
-    hoverIssue,
-    hoverLinearIssue,
-    hoverJiraIssue,
-    hoverReview,
-    hoverComment,
-    metaAutomationProvenance,
-    metaCliProvenance,
-    workspacePorts,
-    detailsHoverControl,
-    handleRenameTitle,
-    handleEditIssue,
-    handleEditComment,
-    handleOpenGitHubIssueInOrca,
-    linearIssue,
-    handleOpenLinearIssueInOrca,
-    handleOpenReviewInOrca,
-    handleOpenAutomation,
-    handleOpenAutomationRun,
-    hasExplicitLinkedReview,
-    handleUnlinkReview,
     showRenameErrorDialog,
     setShowRenameErrorDialog
   } = card
-  const { titleOnlyCard, hasHoverDetails, hoverBranchName, hoverWorkspaceTitle, cardStyle } =
-    presentation
+  const { titleOnlyCard, cardStyle } = presentation
 
   const parentCardContent = <WorktreeCardParentContent card={card} presentation={presentation} />
-
-  const parentHoverTriggerBody = (
-    <div className="group/worktree-card w-full min-w-0" data-worktree-card-hover-trigger="">
-      {parentCardContent}
-    </div>
-  )
-
-  const parentCardBodyWithHoverDetails =
-    hasHoverDetails && !titleRenaming ? (
-      <WorktreeCardDetailsHover
-        issue={hoverIssue}
-        linearIssue={hoverLinearIssue}
-        jiraIssue={hoverJiraIssue}
-        review={hoverReview}
-        comment={hoverComment}
-        automationProvenance={metaAutomationProvenance}
-        cliProvenance={metaCliProvenance}
-        branchName={hoverBranchName}
-        workspaceTitle={hoverWorkspaceTitle}
-        workspaceTitleRenameDisabled={isDeleting || affiliateListMode}
-        detailsAfter={
-          workspacePorts.length > 0 ? <WorktreeCardPortsDetails ports={workspacePorts} /> : null
-        }
-        openDelay={100}
-        hoverControl={detailsHoverControl}
-        onRenameWorkspaceTitle={affiliateListMode ? undefined : handleRenameTitle}
-        onEditIssue={affiliateListMode ? undefined : handleEditIssue}
-        onEditComment={affiliateListMode ? undefined : handleEditComment}
-        onOpenGitHubIssueInOrca={
-          hoverIssue && 'url' in hoverIssue && hoverIssue.url
-            ? handleOpenGitHubIssueInOrca
-            : undefined
-        }
-        onOpenLinearIssueInOrca={linearIssue?.url ? handleOpenLinearIssueInOrca : undefined}
-        onOpenReviewInOrca={
-          hoverReview?.url && hoverReview.provider === 'github' ? handleOpenReviewInOrca : undefined
-        }
-        onOpenAutomation={affiliateListMode ? undefined : handleOpenAutomation}
-        onOpenAutomationRun={affiliateListMode ? undefined : handleOpenAutomationRun}
-        // Why: branch lookup can surface a review without persisted metadata; only unlink when explicitly linked.
-        onUnlinkReview={
-          !affiliateListMode && hasExplicitLinkedReview ? handleUnlinkReview : undefined
-        }
-      >
-        {parentHoverTriggerBody}
-      </WorktreeCardDetailsHover>
-    ) : (
-      parentHoverTriggerBody
-    )
 
   const cardBody = (
     <div
@@ -163,7 +91,7 @@ export function WorktreeCardSurface({ card }: { card: WorktreeCardController }):
           </div>
         </div>
       )}
-      {parentCardBodyWithHoverDetails}
+      {parentCardContent}
 
       {newCardStyle && lineageChildren ? (
         <div

--- a/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { describe, expect, it } from 'vitest'
 import type { WorktreeLineage } from '../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../shared/worktree/types'
@@ -44,6 +46,20 @@ describe('getWorktreeLineageDropTargetId', () => {
 
     expect(getWorktreeLineageDropTargetId({ container, target, pointerY: 150 })).toBeNull()
   })
+
+  it.each(['status', 'agent'] as const)(
+    'keeps the %s region in the lineage nesting hit zone',
+    (targetRole) => {
+      const { container, target } = makeTarget({
+        worktreeId: 'parent',
+        top: 100,
+        bottom: 200,
+        targetRole
+      })
+
+      expect(getWorktreeLineageDropTargetId({ container, target, pointerY: 150 })).toBe('parent')
+    }
+  )
 })
 
 describe('getReorderedWorktreeIdsToUnnest', () => {
@@ -168,24 +184,30 @@ function makeTarget(args: {
   top: number
   bottom: number
   contained?: boolean
+  targetRole?: 'identity' | 'status' | 'agent'
 }): {
   container: HTMLElement
   target: Element
 } {
-  const row = {
-    getAttribute: (name: string) => (name === 'data-worktree-drag-id' ? args.worktreeId : null)
-  } as HTMLElement
-  const content = {
-    getBoundingClientRect: () => ({ top: args.top, bottom: args.bottom }),
-    closest: (selector: string) => (selector === '[data-worktree-drag-id]' ? row : null)
-  } as HTMLElement
-  const target = {
-    closest: (selector: string) =>
-      selector === '[data-worktree-card-hover-trigger]' ? content : null
-  } as Element
+  const container = document.createElement('div')
+  const row = document.createElement('div')
+  row.setAttribute('data-worktree-drag-id', args.worktreeId)
+  const content = document.createElement('div')
+  content.setAttribute('data-worktree-card-parent-content', '')
+  content.getBoundingClientRect = () => ({ top: args.top, bottom: args.bottom }) as DOMRect
+  const status = document.createElement('div')
+  const identity = document.createElement('div')
+  identity.setAttribute('data-worktree-card-hover-trigger', '')
+  const agent = document.createElement('div')
+  content.append(status, identity, agent)
+  row.append(content)
+  container.append(row)
+
+  const targetByRole = { status, identity, agent }
+  const target = targetByRole[args.targetRole ?? 'identity']
   const contained = args.contained ?? true
-  const container = {
-    contains: (element: Element) => contained && (element === content || element === row)
-  } as HTMLElement
+  if (!contained) {
+    container.removeChild(row)
+  }
   return { container, target }
 }

--- a/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.ts
@@ -2,7 +2,7 @@ import type { WorktreeLineage } from '../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { getLineageRenderInfo } from './worktree-lineage-projection'
 
-const WORKTREE_CARD_CONTENT_TARGET_SELECTOR = '[data-worktree-card-hover-trigger]'
+const WORKTREE_CARD_CONTENT_TARGET_SELECTOR = '[data-worktree-card-parent-content]'
 const WORKTREE_DRAG_ROW_SELECTOR = '[data-worktree-drag-id]'
 
 const LINEAGE_DROP_ZONE_RATIO = 0.4

--- a/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.test.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.test.tsx
@@ -1,18 +1,21 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { TerminalTabLeadingIcon } from './TerminalTabLeadingIcon'
 import type { TerminalTabActivityStatus } from './terminal-tab-activity-status'
 
 /** Render one activity status through the production leading-icon component. */
 function renderStatus(status: TerminalTabActivityStatus): string {
   return renderToStaticMarkup(
-    <TerminalTabLeadingIcon
-      agent="codex"
-      activityStatus={status}
-      shell={undefined}
-      showUnreadActivity={false}
-      isActive={false}
-    />
+    <TooltipProvider>
+      <TerminalTabLeadingIcon
+        agent="codex"
+        activityStatus={status}
+        shell={undefined}
+        showUnreadActivity={false}
+        isActive={false}
+      />
+    </TooltipProvider>
   )
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​413 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​76 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​337 |
| Prod | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​293 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​229 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​64 |

<!-- /orca-pr-loc -->

## ELI5

Each agent row in the sidebar carries a small coloured glyph telling you what that agent is doing.
The amber one means *"the main turn has finished, but background work is still running."* Nobody
could have guessed that: the icon was a broadcast/radio symbol, which reads as "broadcasting", and
hovering it explained nothing — it had no hover label of its own, so you got the row's own truncated
text back. A user asked what it meant and guessed "monitor".

Now it's a heartbeat line, and **all nine** states have a hover label saying what they mean — the
other eight had exactly the same gap.

## User-facing before / after

| | Before | After |
|---|---|---|
| Hover the amber agent glyph | No label of its own; you got the row's text, which was already on screen and truncated | A label saying what the state actually means |
| Hover any of the other eight state glyphs | Same gap — none of them had a label either | All nine now have one |
| Reading the amber glyph at a glance | A broadcast/radio icon, which suggests "broadcasting" | A heartbeat line, much closer to what it means |
| The same glyphs on the worktree card, tab bar, dashboard, kanban board, command palette and AI Vault | Same gaps everywhere | One shared change covers all of them |
| The same glyph on your phone | Still the old radio icon, so phone and desktop disagreed about the same state | Matched to desktop |
| How fast the label appears on hover | — | The OS default (roughly half a second to a second), not Orca's faster styled tooltip — the reason is explained below, and a faster sidebar-only version is a small follow-up |

## When it bites

Anyone reading agent state in the sidebar and wondering what a glyph means. The mobile rows are
scope beyond the original report and are called out as droppable below.


Fixes STA-5794.

## The report

[@jinjing](https://stablygroup.slack.com/archives/C0AK2T3JEF4/p1787885339897729) on the amber glyph in the sidebar agent row: *"not sure what this icon means — later one I guessed it means 'monitor'"*, and suggested a tooltip plus a heartbeat icon.

## What was wrong

Two separate things.

**It had no hover tooltip at all.** `AgentStateDot` set only `aria-label`, and native tooltips don't fire from `aria-label`. Hovering the glyph surfaced the *row's* `title` — the same truncated text already on screen. Its own row siblings both had hover titles (agent icon, model chip), so this glyph was the odd one out.

**`Radio` reads as "broadcasting."** The state actually means *the lead turn finished but background tasks or a session cron are still running* (`claude-roster-state.ts:137-146`). The guess of "monitor" was closer than the icon was.

## The change

- **`Radio` → `Activity`** (the EKG/heartbeat line) in `AgentStateDot.tsx` and the worktree-card copy `StatusIndicator.tsx`, so the two stay consistent.
- **A native `title` on all nine states**, not just monitoring — `done`, `working`, `blocked`, `idle` and the rest had the identical gap. One `resolvedTitle` in the shared primitive covers the sidebar, tab bar, dashboard, kanban, cmd-J palette and AI Vault at once. New optional `title` prop lets callers override; `AiVaultSessionSubagents` drops its now-redundant wrapper title.

### Why a native `title` and not the Radix tooltip

Radix inside the primitive would **crash** two surfaces: the dashboard popout is its own React root with no app-level provider (`AgentKanbanBoard.tsx:240-242` documents this), and `AgentMapScene` renders `AgentStateDot` with no provider above it. `StatusIndicator` already uses a native `title` for the same reason.

The tradeoff is hover delay — OS default (~500ms–1s) rather than the ~200ms suggested. If we want the faster styled tooltip specifically in the sidebar, where `TooltipProvider delayDuration={400}` already exists, that's a small follow-up wrapping the dot at `worktree-card-compact-agent-row.tsx:203`.

## Mobile

`mobile/src/components/AgentStateDot.tsx` is documented "1:1 with desktop AgentStateDot" and still rendered `Radio`, as did `AgentSpinner.tsx`. Both swapped so phone and desktop don't diverge on the same state. Verified `Activity` is exported from `lucide-react-native@1.14.0` — mobile is on a different major than desktop's lucide-react.

**Reviewer note:** this is scope beyond the original report, which was desktop-only. Happy to drop the three mobile files if you'd rather keep it tight.

## Visual proof

![sta5794-proof.png](https://github.com/user-attachments/assets/8ff3c0af-598c-452c-bac7-fa5eac91a128)

Before is rendered from the **real component at `HEAD~1`** (extracted with `git show`, not a mock); after is this PR. Same wrapper, same sizes, real compiled app CSS. The `((o))` broadcast glyph becomes the `/\/\` heartbeat.

The capture asserts the DOM before it shoots, so the image can't show something the code doesn't do: before must be `lucide-radio` with **no** `title`, after must be `lucide-activity` with `title="Monitoring background tasks"`, the glyph must actually paint `yellow-500`, and every state must render a non-zero glyph.

⚠️ **The hover tooltip itself is not screenshot-able.** A native `title` is drawn by the OS, outside the page's compositing surface, so it never appears in a page capture. The table shows the `title` value each state now carries; the assertions above and the 10 ablation-checked tests are what actually prove it's on the element.

## Testing

- **169 tests pass across 12 suites.**
- **Ablation-checked, not vacuous:** stripping `title={resolvedTitle}` fails 10 of the new assertions; dropping a state from the covered list fails typecheck with `TS2322: Type 'true' is not assignable to type 'never'` (a compile-time guard so a future `AgentDotState` member can't ship without a tooltip).
- `pnpm tc` clean, `oxlint` clean.

Updated 5 pre-existing `lucide-radio` assertions that were pinned to the old icon. One test needed a real fix rather than a rename: `WorktreeCardAgents.test.tsx:774` sweeps the whole rendered markup for `title=` and asserted `toEqual([])`, which the new title turns into `['Working']`. Kept as exact equality so a leaked agent-identity title still fails it.

⚠️ Mobile tests are **not** run here — `mobile/node_modules` isn't populated in this worktree. Those three files are verified statically only (component, mock and `findByType` string are mutually consistent; no `Radio` references remain).


