### PR TITLE
feat(pet): keep pet visible when main window is minimized

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -299,8 +299,8 @@ export const electronViteConfig: UserConfig = {
       manifest: true,
       modulePreload: { polyfill: true },
       target: 'es2020',
-      // Why: the pop-out dashboard is a second top-level window with its own
-      // React root. It gets its own HTML entry so it can boot independently of
+      // Why: the pop-out dashboard and the detached desktop pet are top-level windows with
+      // their own React roots. Each gets its own HTML entry so it can boot independently of
       // the main window while reusing the same preload/window.api. `index` must
       // stay listed — overriding input otherwise drops electron-vite's default
       // renderer entry.
@@ -311,6 +311,7 @@ export const electronViteConfig: UserConfig = {
         input: {
           index: resolve('src/renderer/index.html'),
           popout: resolve('src/renderer/popout.html'),
+          pet: resolve('src/renderer/pet.html'),
           web: resolve('src/renderer/web-index.html')
         }
       }

--- a/src/main/ipc/crash-reporting-renderer-error-report.ts
+++ b/src/main/ipc/crash-reporting-renderer-error-report.ts
@@ -31,7 +31,8 @@ const REACT_ERROR_BOUNDARY_SURFACES = new Set<ReactErrorBoundaryReportArgs['surf
   'modal',
   'overlay',
   'rich-markdown-editor',
-  'dashboard-popout'
+  'dashboard-popout',
+  'desktop-pet'
 ])
 
 function stringField(value: unknown, maxLength: number): string | undefined {

--- a/src/main/ipc/desktop-pet.test.ts
+++ b/src/main/ipc/desktop-pet.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  handlers,
+  ipcMainMock,
+  createWindowMock,
+  closeWindowMock,
+  getWindowMock,
+  isPetRendererMock,
+  moveWindowMock,
+  setInteractiveMock,
+  isTrustedUIRendererMock,
+  sendToTrustedMock
+} = vi.hoisted(() => {
+  const map = new Map<string, (...args: unknown[]) => unknown>()
+  return {
+    handlers: map,
+    ipcMainMock: {
+      removeHandler: vi.fn(),
+      handle: (channel: string, fn: (...args: unknown[]) => unknown) => map.set(channel, fn)
+    },
+    createWindowMock: vi.fn(),
+    closeWindowMock: vi.fn(),
+    getWindowMock: vi.fn((): unknown => null),
+    isPetRendererMock: vi.fn((_sender: unknown) => false),
+    moveWindowMock: vi.fn(),
+    setInteractiveMock: vi.fn(),
+    isTrustedUIRendererMock: vi.fn((_sender: unknown) => false),
+    sendToTrustedMock: vi.fn()
+  }
+})
+
+vi.mock('electron', () => ({ ipcMain: ipcMainMock }))
+vi.mock('../window/desktop-pet-window', () => ({
+  createOrRevealDesktopPetWindow: createWindowMock,
+  closeDesktopPetWindow: closeWindowMock,
+  getDesktopPetWindow: getWindowMock,
+  isDesktopPetRenderer: isPetRendererMock,
+  moveDesktopPetWindow: moveWindowMock,
+  setDesktopPetInteractive: setInteractiveMock
+}))
+vi.mock('./ui', () => ({
+  isTrustedUIRenderer: isTrustedUIRendererMock,
+  sendToTrustedUIRenderer: sendToTrustedMock
+}))
+
+import { registerDesktopPetHandlers, shouldShowDesktopPetWindow } from './desktop-pet'
+
+const mainSender = { id: 1, send: vi.fn() }
+const petSender = { id: 2, send: vi.fn() }
+
+function createStore() {
+  const uiListeners: (() => void)[] = []
+  const settingsListeners: ((updates: Record<string, unknown>) => void)[] = []
+  const store = {
+    ui: { petDetached: false, petVisible: true } as Record<string, unknown>,
+    settings: { experimentalPet: true } as Record<string, unknown>,
+    getUI: () => store.ui,
+    getSettings: () => store.settings,
+    updateUI: vi.fn(),
+    onUIChanged: (listener: () => void) => uiListeners.push(listener),
+    onSettingsChanged: (listener: (updates: Record<string, unknown>) => void) =>
+      settingsListeners.push(listener),
+    emitUIChanged: () => uiListeners.forEach((listener) => listener()),
+    emitSettingsChanged: (updates: Record<string, unknown>) =>
+      settingsListeners.forEach((listener) => listener(updates))
+  }
+  return store
+}
+
+describe('shouldShowDesktopPetWindow', () => {
+  it('requires the experiment, the detach toggle, and a pet that is not hidden', () => {
+    expect(shouldShowDesktopPetWindow({ petDetached: true, petVisible: true }, true)).toBe(true)
+    expect(shouldShowDesktopPetWindow({ petDetached: true, petVisible: true }, false)).toBe(false)
+    expect(shouldShowDesktopPetWindow({ petDetached: false, petVisible: true }, true)).toBe(false)
+    expect(shouldShowDesktopPetWindow({ petDetached: true, petVisible: false }, true)).toBe(false)
+  })
+
+  it('treats an absent petVisible as visible, matching the persisted default', () => {
+    expect(shouldShowDesktopPetWindow({ petDetached: true }, true)).toBe(true)
+  })
+})
+
+describe('registerDesktopPetHandlers', () => {
+  let store: ReturnType<typeof createStore>
+
+  beforeEach(() => {
+    handlers.clear()
+    store = createStore()
+    isTrustedUIRendererMock.mockImplementation((sender) => sender === mainSender)
+    isPetRendererMock.mockImplementation((sender) => sender === petSender)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    getWindowMock.mockReturnValue(null)
+  })
+
+  it('opens and closes the window as the detach toggle flips', () => {
+    registerDesktopPetHandlers(store as never)
+    expect(closeWindowMock).toHaveBeenCalled()
+    expect(createWindowMock).not.toHaveBeenCalled()
+
+    store.ui.petDetached = true
+    store.emitUIChanged()
+    expect(createWindowMock).toHaveBeenCalledWith(store)
+
+    store.ui.petDetached = false
+    store.emitUIChanged()
+    expect(closeWindowMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('closes the window when the pet experiment is turned off', () => {
+    store.ui.petDetached = true
+    registerDesktopPetHandlers(store as never)
+    expect(createWindowMock).toHaveBeenCalledTimes(1)
+
+    store.settings.experimentalPet = false
+    store.emitSettingsChanged({ experimentalPet: false })
+    expect(closeWindowMock).toHaveBeenCalled()
+  })
+
+  it('forwards a published animation to the pet window', () => {
+    const petWindow = { webContents: { send: vi.fn() } }
+    getWindowMock.mockReturnValue(petWindow)
+    registerDesktopPetHandlers(store as never)
+
+    handlers.get('desktopPet:publishAnimation')?.({ sender: mainSender }, 'running')
+    expect(petWindow.webContents.send).toHaveBeenCalledWith('desktopPet:animation', 'running')
+  })
+
+  it('drops publishes from an untrusted sender or with an unknown animation', () => {
+    const petWindow = { webContents: { send: vi.fn() } }
+    getWindowMock.mockReturnValue(petWindow)
+    registerDesktopPetHandlers(store as never)
+
+    handlers.get('desktopPet:publishAnimation')?.({ sender: petSender }, 'running')
+    handlers.get('desktopPet:publishAnimation')?.({ sender: mainSender }, 'sprinting')
+    expect(petWindow.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('replays the last animation to a pet window that just mounted, then asks for a fresh one', () => {
+    getWindowMock.mockReturnValue({ webContents: { send: vi.fn() } })
+    registerDesktopPetHandlers(store as never)
+    handlers.get('desktopPet:publishAnimation')?.({ sender: mainSender }, 'waiting')
+
+    handlers.get('desktopPet:requestAnimation')?.({ sender: petSender })
+    expect(petSender.send).toHaveBeenCalledWith('desktopPet:animation', 'waiting')
+    expect(sendToTrustedMock).toHaveBeenCalledWith('desktopPet:animationRequested', null)
+  })
+
+  it('forgets the cached animation once the window closes so a re-detach cannot replay it', () => {
+    getWindowMock.mockReturnValue({ webContents: { send: vi.fn() } })
+    store.ui.petDetached = true
+    registerDesktopPetHandlers(store as never)
+    handlers.get('desktopPet:publishAnimation')?.({ sender: mainSender }, 'waiting')
+
+    store.ui.petDetached = false
+    store.emitUIChanged()
+    petSender.send.mockClear()
+    handlers.get('desktopPet:requestAnimation')?.({ sender: petSender })
+    expect(petSender.send).not.toHaveBeenCalled()
+  })
+
+  it('accepts move and interactivity only from the pet window itself', () => {
+    registerDesktopPetHandlers(store as never)
+
+    handlers.get('desktopPet:move')?.({ sender: petSender }, { x: 12, y: 34 })
+    expect(moveWindowMock).toHaveBeenCalledWith(store, { x: 12, y: 34 })
+
+    handlers.get('desktopPet:move')?.({ sender: mainSender }, { x: 1, y: 2 })
+    handlers.get('desktopPet:move')?.({ sender: petSender }, { x: 'left', y: 2 })
+    expect(moveWindowMock).toHaveBeenCalledTimes(1)
+
+    handlers.get('desktopPet:setInteractive')?.({ sender: petSender }, true)
+    handlers.get('desktopPet:setInteractive')?.({ sender: mainSender }, false)
+    handlers.get('desktopPet:setInteractive')?.({ sender: petSender }, 'yes')
+    expect(setInteractiveMock).toHaveBeenCalledTimes(1)
+    expect(setInteractiveMock).toHaveBeenCalledWith(true)
+  })
+})

--- a/src/main/ipc/desktop-pet.ts
+++ b/src/main/ipc/desktop-pet.ts
@@ -1,0 +1,95 @@
+import { ipcMain } from 'electron'
+import type { Store } from '../persistence'
+import type { PersistedUIState } from '../../shared/persisted-ui-state-types'
+import {
+  isPetAgentAnimation,
+  isPetWindowPosition,
+  type PetAgentAnimation
+} from '../../shared/pet-types'
+import {
+  closeDesktopPetWindow,
+  createOrRevealDesktopPetWindow,
+  getDesktopPetWindow,
+  isDesktopPetRenderer,
+  moveDesktopPetWindow,
+  setDesktopPetInteractive
+} from '../window/desktop-pet-window'
+import { isTrustedUIRenderer, sendToTrustedUIRenderer } from './ui'
+
+// The last animation the main renderer published, replayed the instant the pet window mounts so
+// it doesn't idle through the first agent tick. Cleared on close so a re-detach never resumes a
+// stale state.
+let lastAnimation: PetAgentAnimation | null = null
+
+/** The pet is detached only when the experimental flag is on, the pet is not hidden, and the
+ *  user asked for it to live on the desktop. */
+export function shouldShowDesktopPetWindow(
+  ui: Pick<PersistedUIState, 'petDetached' | 'petVisible'>,
+  petExperimentEnabled: boolean
+): boolean {
+  return petExperimentEnabled && ui.petDetached === true && ui.petVisible !== false
+}
+
+export function registerDesktopPetHandlers(store: Store): void {
+  ipcMain.removeHandler('desktopPet:publishAnimation')
+  ipcMain.removeHandler('desktopPet:requestAnimation')
+  ipcMain.removeHandler('desktopPet:move')
+  ipcMain.removeHandler('desktopPet:setInteractive')
+
+  const reconcile = (): void => {
+    const shouldShow = shouldShowDesktopPetWindow(
+      store.getUI(),
+      store.getSettings().experimentalPet === true
+    )
+    if (shouldShow) {
+      createOrRevealDesktopPetWindow(store)
+      return
+    }
+    lastAnimation = null
+    closeDesktopPetWindow()
+  }
+
+  store.onUIChanged(reconcile)
+  store.onSettingsChanged((updates) => {
+    if ('experimentalPet' in updates) {
+      reconcile()
+    }
+  })
+
+  // Relay: only the main renderer knows the agent store, so it derives the animation and the
+  // pet window is a pure consumer.
+  ipcMain.handle('desktopPet:publishAnimation', (event, animation: unknown): void => {
+    if (!isTrustedUIRenderer(event.sender) || !isPetAgentAnimation(animation)) {
+      return
+    }
+    lastAnimation = animation
+    getDesktopPetWindow()?.webContents.send('desktopPet:animation', animation)
+  })
+
+  // The pet window asks on mount: replay the cache, then nudge the main renderer to republish.
+  ipcMain.handle('desktopPet:requestAnimation', (event): void => {
+    if (!isDesktopPetRenderer(event.sender)) {
+      return
+    }
+    if (lastAnimation) {
+      event.sender.send('desktopPet:animation', lastAnimation)
+    }
+    sendToTrustedUIRenderer('desktopPet:animationRequested', null)
+  })
+
+  ipcMain.handle('desktopPet:move', (event, position: unknown): void => {
+    if (!isDesktopPetRenderer(event.sender) || !isPetWindowPosition(position)) {
+      return
+    }
+    moveDesktopPetWindow(store, position)
+  })
+
+  ipcMain.handle('desktopPet:setInteractive', (event, interactive: unknown): void => {
+    if (!isDesktopPetRenderer(event.sender) || typeof interactive !== 'boolean') {
+      return
+    }
+    setDesktopPetInteractive(interactive)
+  })
+
+  reconcile()
+}

--- a/src/main/ipc/register-core-handlers/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers/register-core-handlers.test.ts
@@ -22,6 +22,7 @@ const {
   registerTerminalRenderDesyncEvidenceHandlerMock,
   registerShellHandlersMock,
   registerPetHandlersMock,
+  registerDesktopPetHandlersMock,
   registerSessionHandlersMock,
   registerUIHandlersMock,
   setTrustedUIRendererWebContentsIdMock,
@@ -88,6 +89,7 @@ const {
   registerTerminalRenderDesyncEvidenceHandlerMock: vi.fn(),
   registerShellHandlersMock: vi.fn(),
   registerPetHandlersMock: vi.fn(),
+  registerDesktopPetHandlersMock: vi.fn(),
   registerSessionHandlersMock: vi.fn(),
   registerUIHandlersMock: vi.fn(),
   setTrustedUIRendererWebContentsIdMock: vi.fn(),
@@ -264,6 +266,10 @@ vi.mock('../pet', () => ({
   registerPetHandlers: registerPetHandlersMock
 }))
 
+vi.mock('../desktop-pet', () => ({
+  registerDesktopPetHandlers: registerDesktopPetHandlersMock
+}))
+
 vi.mock('../session', () => ({
   registerSessionHandlers: registerSessionHandlersMock
 }))
@@ -414,6 +420,7 @@ describe('registerCoreHandlers', () => {
     registerTerminalRenderDesyncEvidenceHandlerMock.mockReset()
     registerShellHandlersMock.mockReset()
     registerPetHandlersMock.mockReset()
+    registerDesktopPetHandlersMock.mockReset()
     registerSessionHandlersMock.mockReset()
     registerUIHandlersMock.mockReset()
     setTrustedUIRendererWebContentsIdMock.mockReset()
@@ -514,6 +521,7 @@ describe('registerCoreHandlers', () => {
       codexAccounts.runtimeHomeService
     )
     expect(registerPetHandlersMock).toHaveBeenCalled()
+    expect(registerDesktopPetHandlersMock).toHaveBeenCalledWith(store)
     expect(registerClaudeAccountHandlersMock).toHaveBeenCalledWith(claudeAccounts)
     expect(registerMiniMaxCredentialsHandlersMock).toHaveBeenCalledWith(rateLimits)
     expect(registerGrokAccountHandlersMock).toHaveBeenCalled()

--- a/src/main/ipc/register-core-handlers/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers/register-core-handlers.ts
@@ -48,6 +48,7 @@ import { registerKeybindingHandlers } from '../keybindings'
 import { registerTelemetryHandlers } from '../telemetry'
 import { registerShellHandlers } from '../shell'
 import { registerPetHandlers } from '../pet'
+import { registerDesktopPetHandlers } from '../desktop-pet'
 import { registerPluginHandlers } from '../plugins'
 import { registerUIHandlers, setTrustedUIRendererWebContentsId } from '../ui'
 import { registerEmulatorFrameStreamHandlers } from '../emulator-frame-stream'
@@ -198,6 +199,7 @@ export function registerCoreHandlers(
   registerBrowserHandlers()
   registerShellHandlers(store)
   registerPetHandlers()
+  registerDesktopPetHandlers(store)
   registerSessionHandlers(store)
   registerUIHandlers(store, { isDashboardPopoutRenderer })
   registerEmulatorFrameStreamHandlers()

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -208,6 +208,7 @@ const UiUpdateFields = z
     petId: z.string().optional(),
     customPets: UnknownRecordArray.optional(),
     petSize: z.number().finite().optional(),
+    petDetached: z.boolean().optional(),
     sidekickVisible: z.boolean().optional(),
     sidekickId: z.string().optional(),
     customSidekicks: UnknownRecordArray.optional(),

--- a/src/main/runtime/rpc/methods/ui-state-schema-parity-checks.ts
+++ b/src/main/runtime/rpc/methods/ui-state-schema-parity-checks.ts
@@ -11,6 +11,7 @@ import type { AssertNoMissingKeys, AssertNoMissingValues } from './ui-state-sche
 type MainOwnedUIState =
   | 'trayMinimizeNoticeShown'
   | 'dashboardPopoutBounds'
+  | 'petWindowPosition'
   | '_expandedWorktreeCardPropertiesDefaulted'
   | '_jiraIssueWorktreeCardPropertyDefaulted'
   | 'starNagBaselineAgents'

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -10,6 +10,7 @@ import { recordDurableCrashBreadcrumb } from '../crash-reporting/durable-crash-b
 import { clearTrustedUIRendererWebContentsId, setTrustedUIRendererWebContentsId } from '../ipc/ui'
 import type { Store } from '../persistence'
 import { closeDashboardPopout } from './dashboard-popout-window'
+import { closeDesktopPetWindow } from './desktop-pet-window'
 import {
   installMainWindowCloseLifecycle,
   WINDOW_QUIT_RENDERER_ACK_TIMEOUT_MS
@@ -187,6 +188,7 @@ export function createMainWindow(
 
   mainWindow.on('closed', () => {
     closeDashboardPopout()
+    closeDesktopPetWindow()
     state.clearInitialRevealFallbackTimer()
     closeLifecycle.dispose()
     focus.dispose()

--- a/src/main/window/desktop-pet-window.test.ts
+++ b/src/main/window/desktop-pet-window.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type Rect = { x: number; y: number; width: number; height: number }
+
+const { instances, BrowserWindowMock, getAllDisplaysMock, getPrimaryDisplayMock, isMock } =
+  vi.hoisted(() => {
+    const created: FakeWindow[] = []
+
+    class FakeWindow {
+      options: Electron.BrowserWindowConstructorOptions
+      destroyed = false
+      bounds: Rect
+      private handlers: Record<string, ((...args: unknown[]) => void)[]> = {}
+      private onceHandlers: Record<string, ((...args: unknown[]) => void)[]> = {}
+      webContents = {
+        id: created.length + 1,
+        send: vi.fn(),
+        isDestroyed: () => this.destroyed,
+        session: {
+          setPermissionRequestHandler: vi.fn(),
+          setPermissionCheckHandler: vi.fn()
+        },
+        on: vi.fn()
+      }
+      showInactive = vi.fn()
+      loadURL = vi.fn()
+      loadFile = vi.fn()
+      setAlwaysOnTop = vi.fn()
+      setVisibleOnAllWorkspaces = vi.fn()
+      setIgnoreMouseEvents = vi.fn()
+      setPosition = vi.fn((x: number, y: number) => {
+        this.bounds = { ...this.bounds, x, y }
+      })
+      setBounds = vi.fn((next: Rect) => {
+        this.bounds = next
+      })
+      getBounds = vi.fn(() => this.bounds)
+      isDestroyed = (): boolean => this.destroyed
+      destroy = vi.fn(() => {
+        this.destroyed = true
+        this.emit('closed')
+      })
+
+      constructor(options: Electron.BrowserWindowConstructorOptions) {
+        this.options = options
+        this.bounds = {
+          x: options.x ?? 0,
+          y: options.y ?? 0,
+          width: options.width ?? 0,
+          height: options.height ?? 0
+        }
+        created.push(this)
+      }
+
+      on(event: string, cb: (...args: unknown[]) => void): this {
+        ;(this.handlers[event] ||= []).push(cb)
+        return this
+      }
+      once(event: string, cb: (...args: unknown[]) => void): this {
+        ;(this.onceHandlers[event] ||= []).push(cb)
+        return this
+      }
+      emit(event: string, ...args: unknown[]): void {
+        for (const cb of this.handlers[event] ?? []) {
+          cb(...args)
+        }
+        for (const cb of this.onceHandlers[event] ?? []) {
+          cb(...args)
+        }
+        this.onceHandlers[event] = []
+      }
+    }
+
+    const primary = { workArea: { x: 0, y: 0, width: 1920, height: 1080 } }
+    return {
+      instances: created,
+      BrowserWindowMock: FakeWindow,
+      getAllDisplaysMock: vi.fn(() => [primary]),
+      getPrimaryDisplayMock: vi.fn(() => primary),
+      isMock: { dev: false }
+    }
+  })
+
+vi.mock('electron', () => ({
+  BrowserWindow: BrowserWindowMock,
+  screen: { getAllDisplays: getAllDisplaysMock, getPrimaryDisplay: getPrimaryDisplayMock }
+}))
+vi.mock('@electron-toolkit/utils', () => ({ is: isMock }))
+vi.mock('./privileged-window-navigation', () => ({
+  installPrivilegedWindowNavigationPolicy: vi.fn()
+}))
+
+import {
+  closeDesktopPetWindow,
+  createOrRevealDesktopPetWindow,
+  getDesktopPetWindow,
+  moveDesktopPetWindow,
+  setDesktopPetInteractive
+} from './desktop-pet-window'
+import { PET_WINDOW_MARGIN } from '../../shared/pet-window-geometry'
+
+function createStore(ui: Record<string, unknown> = {}) {
+  const listeners: ((ui: Record<string, unknown>) => void)[] = []
+  const store = {
+    ui: { petSize: 180, ...ui },
+    getUI: () => store.ui,
+    updateUI: vi.fn((partial: Record<string, unknown>) => {
+      Object.assign(store.ui, partial)
+    }),
+    onUIChanged: (listener: (ui: Record<string, unknown>) => void) => {
+      listeners.push(listener)
+      return () => listeners.splice(listeners.indexOf(listener), 1)
+    },
+    emitUIChanged: () => listeners.forEach((listener) => listener(store.ui))
+  }
+  return store
+}
+
+describe('desktop pet window', () => {
+  beforeEach(() => {
+    instances.length = 0
+  })
+
+  afterEach(() => {
+    closeDesktopPetWindow()
+    vi.clearAllMocks()
+    getAllDisplaysMock.mockReturnValue([{ workArea: { x: 0, y: 0, width: 1920, height: 1080 } }])
+  })
+
+  it('opens frameless, transparent, and above other windows without stealing focus', () => {
+    createOrRevealDesktopPetWindow(createStore() as never)
+    const options = instances[0]!.options
+    expect(options.frame).toBe(false)
+    expect(options.transparent).toBe(true)
+    expect(options.skipTaskbar).toBe(true)
+    expect(options.focusable).toBe(false)
+    expect(options.resizable).toBe(false)
+    expect(instances[0]!.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver')
+
+    instances[0]!.emit('ready-to-show')
+    expect(instances[0]!.showInactive).toHaveBeenCalled()
+  })
+
+  it('sizes the window to the persisted pet size plus its bob margin', () => {
+    createOrRevealDesktopPetWindow(createStore({ petSize: 240 }) as never)
+    expect(instances[0]!.options.width).toBe(240 + PET_WINDOW_MARGIN * 2)
+    expect(instances[0]!.options.height).toBe(240 + PET_WINDOW_MARGIN * 2)
+  })
+
+  it('resizes in place when the user drags the size slider', () => {
+    const store = createStore({ petSize: 180 })
+    createOrRevealDesktopPetWindow(store as never)
+    store.ui.petSize = 300
+    store.emitUIChanged()
+    expect(instances[0]!.bounds.width).toBe(300 + PET_WINDOW_MARGIN * 2)
+  })
+
+  it('reveals the existing window instead of opening a second pet', () => {
+    const store = createStore()
+    createOrRevealDesktopPetWindow(store as never)
+    createOrRevealDesktopPetWindow(store as never)
+    expect(instances).toHaveLength(1)
+    expect(instances[0]!.showInactive).toHaveBeenCalled()
+  })
+
+  it('restores a saved position', () => {
+    createOrRevealDesktopPetWindow(createStore({ petWindowPosition: { x: 640, y: 320 } }) as never)
+    expect(instances[0]!.options.x).toBe(640)
+    expect(instances[0]!.options.y).toBe(320)
+  })
+
+  it('falls back to the work-area corner when the saved position is off every display', () => {
+    createOrRevealDesktopPetWindow(
+      createStore({ petWindowPosition: { x: 9000, y: 9000 } }) as never
+    )
+    expect(instances[0]!.options.x).toBeLessThan(1920)
+    expect(instances[0]!.options.y).toBeLessThan(1080)
+  })
+
+  it('persists a drag so the pet returns to the same spot next launch', () => {
+    const store = createStore()
+    createOrRevealDesktopPetWindow(store as never)
+    moveDesktopPetWindow(store as never, { x: 400, y: 200 })
+    expect(instances[0]!.setPosition).toHaveBeenCalledWith(400, 200)
+    expect(store.updateUI).toHaveBeenCalledWith({ petWindowPosition: { x: 400, y: 200 } })
+  })
+
+  it('refuses a drag that would strand the pet off-screen', () => {
+    const store = createStore()
+    createOrRevealDesktopPetWindow(store as never)
+    moveDesktopPetWindow(store as never, { x: 5000, y: 5000 })
+    expect(instances[0]!.setPosition).not.toHaveBeenCalled()
+    expect(store.updateUI).not.toHaveBeenCalled()
+  })
+
+  it('passes clicks through when the pointer is off the pet, and takes them back when on it', () => {
+    createOrRevealDesktopPetWindow(createStore() as never)
+    setDesktopPetInteractive(false)
+    expect(instances[0]!.setIgnoreMouseEvents).toHaveBeenCalledWith(true, { forward: true })
+    setDesktopPetInteractive(true)
+    expect(instances[0]!.setIgnoreMouseEvents).toHaveBeenLastCalledWith(false, { forward: true })
+  })
+
+  it('drops its singleton on close so a later detach opens a fresh window', () => {
+    const store = createStore()
+    createOrRevealDesktopPetWindow(store as never)
+    closeDesktopPetWindow()
+    expect(instances[0]!.destroy).toHaveBeenCalled()
+    expect(getDesktopPetWindow()).toBe(null)
+
+    createOrRevealDesktopPetWindow(store as never)
+    expect(instances).toHaveLength(2)
+  })
+})

--- a/src/main/window/desktop-pet-window.ts
+++ b/src/main/window/desktop-pet-window.ts
@@ -1,0 +1,191 @@
+import { BrowserWindow, screen, type WebContents } from 'electron'
+import { join } from 'node:path'
+import { is } from '@electron-toolkit/utils'
+import type { Store } from '../persistence'
+import { rectHasVisibleAreaOnAnyDisplay } from './window-bounds-validation'
+import { installPrivilegedWindowNavigationPolicy } from './privileged-window-navigation'
+import { clampPetSize, type PetWindowPosition } from '../../shared/pet-types'
+import { defaultPetWindowPosition, petWindowSizeForPetSize } from '../../shared/pet-window-geometry'
+
+const DESKTOP_PET_PARTITION = 'orca-desktop-pet'
+// Why: the pet must stay grabbable after a monitor unplug, so require most of the window
+// on-screen rather than the sliver rule that suits a titlebar-draggable window.
+const MIN_VISIBLE_FRACTION = 0.5
+
+// Why: singleton — one pet, so a second detach request just re-reveals this window.
+let desktopPetWindow: BrowserWindow | null = null
+
+export function getDesktopPetWindow(): BrowserWindow | null {
+  return desktopPetWindow &&
+    !desktopPetWindow.isDestroyed() &&
+    !desktopPetWindow.webContents.isDestroyed()
+    ? desktopPetWindow
+    : null
+}
+
+export function isDesktopPetRenderer(sender: WebContents): boolean {
+  return getDesktopPetWindow()?.webContents === sender
+}
+
+function resolvePetWindowSize(store: Store | null): number {
+  return petWindowSizeForPetSize(clampPetSize(store?.getUI().petSize))
+}
+
+function resolveStartPosition(store: Store | null, windowSize: number): PetWindowPosition {
+  const saved = store?.getUI().petWindowPosition ?? null
+  if (
+    saved &&
+    Number.isFinite(saved.x) &&
+    Number.isFinite(saved.y) &&
+    rectHasVisibleAreaOnAnyDisplay(
+      { x: saved.x, y: saved.y, width: windowSize, height: windowSize },
+      windowSize * MIN_VISIBLE_FRACTION,
+      windowSize * MIN_VISIBLE_FRACTION
+    )
+  ) {
+    return { x: Math.round(saved.x), y: Math.round(saved.y) }
+  }
+  if (saved) {
+    console.warn('[desktop-pet] Discarding off-screen pet window position:', saved)
+  }
+  return defaultPetWindowPosition(screen.getPrimaryDisplay().workArea, windowSize)
+}
+
+function loadDesktopPet(window: BrowserWindow): void {
+  // Why: mirror loadMainWindow's dev/prod branch — the dev server serves the
+  // extra HTML entry, prod loads the emitted file.
+  if (is.dev && process.env.ELECTRON_RENDERER_URL) {
+    void window.loadURL(`${process.env.ELECTRON_RENDERER_URL}/pet.html`)
+  } else {
+    void window.loadFile(join(__dirname, '../renderer/pet.html'))
+  }
+}
+
+/**
+ * Open the detached pet window, or reveal it if already open. It is a frameless transparent
+ * always-on-top BrowserWindow that reuses the same preload/window.api as the main window but
+ * renders its own React root (pet.html) — so the pet outlives a minimized or backgrounded
+ * main window instead of being clipped to it.
+ */
+export function createOrRevealDesktopPetWindow(store: Store | null): BrowserWindow {
+  const existing = getDesktopPetWindow()
+  if (existing) {
+    existing.showInactive()
+    return existing
+  }
+
+  const windowSize = resolvePetWindowSize(store)
+  const position = resolveStartPosition(store, windowSize)
+
+  const window = new BrowserWindow({
+    width: windowSize,
+    height: windowSize,
+    x: position.x,
+    y: position.y,
+    show: false,
+    frame: false,
+    transparent: true,
+    backgroundColor: '#00000000',
+    hasShadow: false,
+    resizable: false,
+    movable: false,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    skipTaskbar: true,
+    // Why: a pet that steals focus from the editor on every pat is worse than no pet. Mouse
+    // events still reach a non-focusable window on all three platforms.
+    focusable: false,
+    alwaysOnTop: true,
+    acceptFirstMouse: true,
+    title: 'Orca Pet',
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      sandbox: true,
+      // Why: Chromium shares zoom by origin; an isolated session keeps the app-wide UI zoom
+      // off the pet, whose window is sized in raw pixels by the main process.
+      partition: DESKTOP_PET_PARTITION,
+      webviewTag: false,
+      backgroundThrottling: false
+    }
+  })
+  installPrivilegedWindowNavigationPolicy(window.webContents)
+  // Why: isolated sessions do not inherit the main session's deny-by-default permission policy.
+  window.webContents.session.setPermissionRequestHandler((_webContents, _permission, callback) =>
+    callback(false)
+  )
+  window.webContents.session.setPermissionCheckHandler(() => false)
+  // Why: 'screen-saver' is the level that keeps an overlay above full-screen apps; plain
+  // alwaysOnTop sits below them on macOS.
+  window.setAlwaysOnTop(true, 'screen-saver')
+  window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
+  desktopPetWindow = window
+
+  const unsubscribeUIChanged = store?.onUIChanged((ui) => {
+    const nextSize = petWindowSizeForPetSize(clampPetSize(ui.petSize))
+    if (window.isDestroyed() || window.getBounds().width === nextSize) {
+      return
+    }
+    const bounds = window.getBounds()
+    window.setBounds({ x: bounds.x, y: bounds.y, width: nextSize, height: nextSize })
+  })
+
+  window.once('ready-to-show', () => {
+    if (!window.isDestroyed()) {
+      // Why: showInactive, not show — revealing the pet must not pull focus off the terminal.
+      window.showInactive()
+    }
+  })
+
+  window.on('closed', () => {
+    unsubscribeUIChanged?.()
+    if (desktopPetWindow === window) {
+      desktopPetWindow = null
+    }
+  })
+
+  loadDesktopPet(window)
+  return window
+}
+
+/** Move the pet window to a screen position and remember it. Called from the pet renderer's
+ *  drag; the position is clamped to a display so a fling can't strand the pet off-screen. */
+export function moveDesktopPetWindow(store: Store | null, position: PetWindowPosition): void {
+  const window = getDesktopPetWindow()
+  if (!window) {
+    return
+  }
+  const { width } = window.getBounds()
+  const next = { x: Math.round(position.x), y: Math.round(position.y) }
+  if (
+    !rectHasVisibleAreaOnAnyDisplay(
+      { ...next, width, height: width },
+      width * MIN_VISIBLE_FRACTION,
+      width * MIN_VISIBLE_FRACTION
+    )
+  ) {
+    return
+  }
+  window.setPosition(next.x, next.y)
+  store?.updateUI({ petWindowPosition: next })
+}
+
+/** Let clicks fall through to whatever is behind the pet's transparent corners. The renderer
+ *  drives this from its own hit test; `forward` keeps mouse moves flowing so it can flip back. */
+export function setDesktopPetInteractive(interactive: boolean): void {
+  const window = getDesktopPetWindow()
+  if (!window) {
+    return
+  }
+  window.setIgnoreMouseEvents(!interactive, { forward: true })
+}
+
+/** Close the detached pet. Called when the pet is re-docked, disabled, or the main window
+ *  closes — an orphaned pet window would otherwise keep the app alive on Windows/Linux. */
+export function closeDesktopPetWindow(): void {
+  const window = desktopPetWindow
+  desktopPetWindow = null
+  if (window && !window.isDestroyed()) {
+    window.destroy()
+  }
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -44,7 +44,7 @@ import type {
   MacosTccPromptsApi,
   NotificationsApi
 } from './api/os-permission-api'
-import type { PetApi } from './api/pet-api'
+import type { DesktopPetApi, PetApi } from './api/pet-api'
 import type { PluginsApi } from './api/plugin-host-api'
 import type { PreflightApi } from './api/preflight-api'
 import type { PtyApi } from './api/pty-api'
@@ -117,6 +117,7 @@ export type PreloadApi = {
   shell: ShellApi
   skills: SkillsApi
   pet: PetApi
+  desktopPet: DesktopPetApi
   browser: BrowserApi
   emulator: EmulatorApi
   hooks: HooksApi

--- a/src/preload/api/pet-api.ts
+++ b/src/preload/api/pet-api.ts
@@ -1,8 +1,24 @@
-import type { CustomPet } from '../../shared/pet-types'
+import type { CustomPet, PetAgentAnimation, PetWindowPosition } from '../../shared/pet-types'
 
 export type PetApi = {
   import: () => Promise<CustomPet | null>
   importPetBundle: () => Promise<CustomPet | null>
   read: (id: string, fileName: string, kind?: 'image' | 'bundle') => Promise<ArrayBuffer | null>
   delete: (id: string, fileName: string, kind?: 'image' | 'bundle') => Promise<void>
+}
+
+/** Bridge between the main window (which owns agent state) and the detached pet window
+ *  (which owns its own position and hit testing). */
+export type DesktopPetApi = {
+  /** Main window → pet window: the agent-derived animation to play. */
+  publishAnimation: (animation: PetAgentAnimation) => Promise<void>
+  /** Main window: republish because a pet window just mounted. */
+  onAnimationRequested: (callback: () => void) => () => void
+  /** Pet window: ask for the current animation on mount. */
+  requestAnimation: () => Promise<void>
+  onAnimation: (callback: (animation: PetAgentAnimation) => void) => () => void
+  /** Pet window: move its own OS window to a screen position mid-drag. */
+  move: (position: PetWindowPosition) => Promise<void>
+  /** Pet window: take or release the mouse, so clicks pass through transparent corners. */
+  setInteractive: (interactive: boolean) => Promise<void>
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -115,7 +115,7 @@ import type {
 } from '../shared/notification-settings-types'
 import type { OnboardingState } from '../shared/onboarding-state-types'
 import type { PersistedUIState } from '../shared/persisted-ui-state-types'
-import type { CustomPet } from '../shared/pet-types'
+import type { CustomPet, PetAgentAnimation, PetWindowPosition } from '../shared/pet-types'
 import type { MemorySnapshot } from '../shared/process-stats-types'
 import type { NestedRepoScanResult } from '../shared/project-group-types'
 import type { BaseRefDefaultResult, BaseRefSearchResult } from '../shared/repo-types'
@@ -2708,6 +2708,27 @@ const api = {
       ipcRenderer.invoke('pet:read', id, fileName, kind),
     delete: (id: string, fileName: string, kind?: 'image' | 'bundle'): Promise<void> =>
       ipcRenderer.invoke('pet:delete', id, fileName, kind)
+  },
+
+  desktopPet: {
+    publishAnimation: (animation: PetAgentAnimation): Promise<void> =>
+      ipcRenderer.invoke('desktopPet:publishAnimation', animation),
+    onAnimationRequested: (callback: () => void): (() => void) => {
+      const listener = (): void => callback()
+      ipcRenderer.on('desktopPet:animationRequested', listener)
+      return () => ipcRenderer.removeListener('desktopPet:animationRequested', listener)
+    },
+    requestAnimation: (): Promise<void> => ipcRenderer.invoke('desktopPet:requestAnimation'),
+    onAnimation: (callback: (animation: PetAgentAnimation) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, animation: PetAgentAnimation): void =>
+        callback(animation)
+      ipcRenderer.on('desktopPet:animation', listener)
+      return () => ipcRenderer.removeListener('desktopPet:animation', listener)
+    },
+    move: (position: PetWindowPosition): Promise<void> =>
+      ipcRenderer.invoke('desktopPet:move', position),
+    setInteractive: (interactive: boolean): Promise<void> =>
+      ipcRenderer.invoke('desktopPet:setInteractive', interactive)
   },
 
   browser: {

--- a/src/renderer/pet.html
+++ b/src/renderer/pet.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html class="native-shell">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Orca Pet</title>
+    <!-- CSP is relaxed during development; electron-vite injects a stricter policy for production builds -->
+    <style>
+      /* The window itself is transparent — the pet is the only thing that paints. */
+      html,
+      body {
+        margin: 0;
+        background: transparent;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/pet.tsx"></script>
+  </body>
+</html>

--- a/src/renderer/src/app-shell/AppRootSurfaces.tsx
+++ b/src/renderer/src/app-shell/AppRootSurfaces.tsx
@@ -13,6 +13,7 @@ import { StarNagToastHost } from '../components/star-nag/StarNagToastHost'
 import { TelemetryFirstLaunchSurface } from '../components/TelemetryFirstLaunchSurface'
 import { ZoomOverlay } from '../components/ZoomOverlay'
 import { shouldRenderPetOverlay } from '../components/pet/pet-overlay-visibility'
+import { DesktopPetAnimationPublisher } from '../components/pet/DesktopPetAnimationPublisher'
 import { useAppStore } from '../store'
 import type { UpdateStatus } from '../../../shared/update-status-types'
 import { useLazyModalMounts } from './use-lazy-modal-mounts'
@@ -127,6 +128,7 @@ export function AppRootSurfaces(props: {
   const persistedUIReady = useAppStore((s) => s.persistedUIReady)
   const petVisible = useAppStore((s) => s.petVisible)
   const petEnabled = useAppStore((s) => s.settings?.experimentalPet === true)
+  const petDetached = useAppStore((s) => s.petDetached)
   const dictationState = useAppStore((s) => s.dictationState)
   const updateStatus = useAppStore((s) => s.updateStatus)
   const activeContextualTourId = useAppStore((s) => s.activeContextualTourId)
@@ -136,7 +138,12 @@ export function AppRootSurfaces(props: {
   const shouldMountUpdateCard = shouldMountUpdateCardForStatus(updateStatus)
   const shouldMountDictationController =
     settings?.voice?.enabled === true || dictationState !== 'idle'
-  const renderPetOverlay = shouldRenderPetOverlay({ persistedUIReady, petEnabled, petVisible })
+  const renderPetOverlay = shouldRenderPetOverlay({
+    persistedUIReady,
+    petEnabled,
+    petVisible,
+    petDetached
+  })
 
   return (
     <>
@@ -265,6 +272,10 @@ export function AppRootSurfaces(props: {
             <PetOverlay />
           </OverlayBoundary>
         </Suspense>
+      ) : null}
+      {/* Why: the detached pet window has no agent store of its own — this publishes it. */}
+      {persistedUIReady && petEnabled && petVisible && petDetached ? (
+        <DesktopPetAnimationPublisher />
       ) : null}
       {shouldMountUpdateCard ? (
         <Suspense fallback={null}>

--- a/src/renderer/src/components/pet/DesktopPetAnimationPublisher.test.tsx
+++ b/src/renderer/src/components/pet/DesktopPetAnimationPublisher.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const storeState = vi.hoisted(() => ({
+  agentStatusByPaneKey: {} as Record<string, unknown>,
+  agentStatusEpoch: 0,
+  retainedAgentsByPaneKey: {} as Record<string, unknown>
+}))
+
+const desktopPetApi = vi.hoisted(() => ({
+  publishAnimation: vi.fn(() => Promise.resolve()),
+  onAnimationRequested: vi.fn((_callback: () => void) => () => {})
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: Object.assign(
+    <T,>(selector: (state: typeof storeState) => T): T => selector(storeState),
+    { getState: () => storeState }
+  )
+}))
+
+import { DesktopPetAnimationPublisher } from './DesktopPetAnimationPublisher'
+
+function render(): Root {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(<DesktopPetAnimationPublisher />)
+  })
+  return root
+}
+
+describe('DesktopPetAnimationPublisher', () => {
+  beforeEach(() => {
+    Object.assign(window, { api: { desktopPet: desktopPetApi } })
+    storeState.agentStatusByPaneKey = {}
+    storeState.retainedAgentsByPaneKey = {}
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('publishes the agent-derived animation, without the pointer states the pet window owns', () => {
+    storeState.agentStatusByPaneKey = {
+      'tab-1:leaf-1': { state: 'working', workingMode: 'active', updatedAt: Date.now() }
+    }
+    const root = render()
+    expect(desktopPetApi.publishAnimation).toHaveBeenCalledWith('running')
+    act(() => root.unmount())
+  })
+
+  it('republishes on request even when the animation has not changed', () => {
+    let requestReplay = (): void => {}
+    desktopPetApi.onAnimationRequested.mockImplementation((callback) => {
+      requestReplay = callback
+      return () => {}
+    })
+    const root = render()
+    expect(desktopPetApi.publishAnimation).toHaveBeenCalledTimes(1)
+
+    act(() => requestReplay())
+    expect(desktopPetApi.publishAnimation).toHaveBeenCalledTimes(2)
+    act(() => root.unmount())
+  })
+})

--- a/src/renderer/src/components/pet/DesktopPetAnimationPublisher.tsx
+++ b/src/renderer/src/components/pet/DesktopPetAnimationPublisher.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from 'react'
+import { useAppStore } from '../../store'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
+import { selectPetAgentAnimation } from './pet-agent-state'
+
+/** Runs in the main window only: the detached pet window has no agent store, so publish the
+ *  agent-derived animation to main, which relays it. Mounted only while the pet is detached. */
+export function useDesktopPetAnimationPublisher(): void {
+  const agentStatusByPaneKey = useAppStore((s) => s.agentStatusByPaneKey)
+  const agentStatusEpoch = useAppStore((s) => s.agentStatusEpoch)
+  const retainedAgentsByPaneKey = useAppStore((s) => s.retainedAgentsByPaneKey)
+  // Why: a pet window that just mounted asks for a replay; bumping this republishes even when
+  // the animation is unchanged, so a reopened window is never left on the wrong state.
+  const [republishEpoch, setRepublishEpoch] = useState(0)
+  const lastPublishedRef = useRef<string | null>(null)
+
+  // Re-render when the freshness scheduler ticks so stale live states stop driving the pet.
+  void agentStatusEpoch
+
+  useEffect(
+    () =>
+      window.api.desktopPet.onAnimationRequested(() => {
+        lastPublishedRef.current = null
+        setRepublishEpoch((epoch) => epoch + 1)
+      }),
+    []
+  )
+
+  useEffect(() => {
+    void republishEpoch
+    const animation = selectPetAgentAnimation({
+      entries: Object.values(agentStatusByPaneKey),
+      retainedCount: Object.keys(retainedAgentsByPaneKey).length,
+      now: Date.now(),
+      staleAfterMs: AGENT_STATUS_STALE_AFTER_MS
+    })
+    if (animation === lastPublishedRef.current) {
+      return
+    }
+    lastPublishedRef.current = animation
+    window.api.desktopPet.publishAnimation(animation).catch(console.error)
+  }, [agentStatusByPaneKey, agentStatusEpoch, retainedAgentsByPaneKey, republishEpoch])
+}
+
+/** Renders nothing; mounted in the main window while the pet is detached. */
+export function DesktopPetAnimationPublisher(): null {
+  useDesktopPetAnimationPublisher()
+  return null
+}

--- a/src/renderer/src/components/pet/DesktopPetRoot.test.tsx
+++ b/src/renderer/src/components/pet/DesktopPetRoot.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const storeState = vi.hoisted(() => ({
+  petSize: 180,
+  hydratePersistedUI: vi.fn()
+}))
+
+const desktopPetApi = vi.hoisted(() => ({
+  onAnimation: vi.fn((_callback: (animation: string) => void) => () => {}),
+  requestAnimation: vi.fn(() => Promise.resolve()),
+  move: vi.fn(() => Promise.resolve()),
+  setInteractive: vi.fn(() => Promise.resolve())
+}))
+
+const uiApi = vi.hoisted(() => ({
+  onStateChanged: vi.fn((_callback: (ui: unknown) => void) => () => {}),
+  get: vi.fn(() => Promise.resolve({}))
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: Object.assign(
+    <T,>(selector: (state: typeof storeState) => T): T => selector(storeState),
+    { getState: () => storeState }
+  )
+}))
+
+vi.mock('./usePetUrl', () => ({
+  usePetUrl: () => ({ url: 'blob:pet', ready: true, sprite: null, detected: null })
+}))
+
+import { DesktopPetRoot } from './DesktopPetRoot'
+
+function render(): { container: HTMLDivElement; root: Root } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(<DesktopPetRoot />)
+  })
+  return { container, root }
+}
+
+function petWrapper(container: HTMLDivElement): HTMLElement {
+  const wrapper = container.querySelector<HTMLElement>('[style*="grab"]')
+  if (!wrapper) {
+    throw new Error('pet wrapper not found')
+  }
+  return wrapper
+}
+
+function pointerEvent(type: string, props: Record<string, unknown>): PointerEvent {
+  return Object.assign(new Event(type, { bubbles: true }), {
+    button: 0,
+    pointerId: 1,
+    screenX: 0,
+    screenY: 0,
+    clientX: 0,
+    clientY: 0,
+    ...props
+  }) as PointerEvent
+}
+
+describe('DesktopPetRoot', () => {
+  beforeEach(() => {
+    Object.assign(window, {
+      api: { desktopPet: desktopPetApi, ui: uiApi },
+      screenX: 300,
+      screenY: 200
+    })
+    Element.prototype.setPointerCapture = vi.fn()
+    Element.prototype.hasPointerCapture = vi.fn(() => false)
+    Element.prototype.releasePointerCapture = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('asks main for the current animation on mount, so a reopened pet is never blank', () => {
+    const { root } = render()
+    expect(desktopPetApi.requestAnimation).toHaveBeenCalled()
+    expect(desktopPetApi.onAnimation).toHaveBeenCalled()
+    act(() => root.unmount())
+  })
+
+  it('mirrors persisted UI state into its own store so it renders the same pet', () => {
+    const { root } = render()
+    expect(uiApi.onStateChanged).toHaveBeenCalled()
+    expect(uiApi.get).toHaveBeenCalled()
+    act(() => root.unmount())
+  })
+
+  it('starts click-through, so the transparent corners never swallow a click', () => {
+    const { root } = render()
+    expect(desktopPetApi.setInteractive).toHaveBeenCalledWith(false)
+    act(() => root.unmount())
+  })
+
+  it('takes the mouse back once the pointer is over the pet', () => {
+    const { container, root } = render()
+    const petBox = container.querySelector<HTMLElement>('[data-desktop-pet-hit-area]')!
+    petBox.getBoundingClientRect = () => ({ left: 16, top: 16, right: 196, bottom: 196 }) as DOMRect
+
+    act(() => {
+      window.dispatchEvent(Object.assign(new Event('mousemove'), { clientX: 100, clientY: 100 }))
+    })
+    expect(desktopPetApi.setInteractive).toHaveBeenLastCalledWith(true)
+
+    act(() => {
+      window.dispatchEvent(Object.assign(new Event('mousemove'), { clientX: 2, clientY: 2 }))
+    })
+    expect(desktopPetApi.setInteractive).toHaveBeenLastCalledWith(false)
+    act(() => root.unmount())
+  })
+
+  it('translates a drag into an absolute window move in screen coordinates', () => {
+    const { container, root } = render()
+    const wrapper = petWrapper(container)
+
+    act(() => {
+      wrapper.dispatchEvent(pointerEvent('pointerdown', { screenX: 350, screenY: 260 }))
+    })
+    act(() => {
+      wrapper.dispatchEvent(pointerEvent('pointermove', { screenX: 400, screenY: 300 }))
+    })
+
+    // Grabbed 50/60 into a window at (300, 200); the same grip at (400, 300) puts it at (350, 240).
+    expect(desktopPetApi.move).toHaveBeenLastCalledWith({ x: 350, y: 240 })
+    act(() => root.unmount())
+  })
+})

--- a/src/renderer/src/components/pet/DesktopPetRoot.tsx
+++ b/src/renderer/src/components/pet/DesktopPetRoot.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useAppStore } from '../../store'
+import {
+  clampPetSize,
+  type PetAgentAnimation,
+  type PetWindowPosition
+} from '../../../../shared/pet-types'
+import { PET_WINDOW_MARGIN } from '../../../../shared/pet-window-geometry'
+import { applyPetPointerAnimation } from './pet-agent-state'
+import { PetCharacter } from './PetCharacter'
+import { usePetPointerInteraction } from './usePetPointerInteraction'
+
+/** The agent animation relayed from the main window, replayed on mount. */
+function useRelayedPetAnimation(): PetAgentAnimation {
+  const [animation, setAnimation] = useState<PetAgentAnimation>('idle')
+  useEffect(() => {
+    const off = window.api.desktopPet.onAnimation(setAnimation)
+    window.api.desktopPet.requestAnimation().catch(console.error)
+    return off
+  }, [])
+  return animation
+}
+
+/** Mirror the persisted pet selection into this window's own store so `usePetUrl` resolves the
+ *  same pet as the main window. Main broadcasts ui:stateChanged to every window. */
+function usePetUIStateSync(): void {
+  useEffect(() => {
+    const hydrate = useAppStore.getState().hydratePersistedUI
+    const off = window.api.ui.onStateChanged((ui) => hydrate(ui))
+    window.api.ui
+      .get()
+      .then((ui) => hydrate(ui))
+      .catch(console.error)
+    return off
+  }, [])
+}
+
+/** The pet window is a square with transparent corners. Hand the mouse back to whatever is
+ *  behind it unless the pointer is actually over the pet, so the pet never blocks a click. */
+function useMouseThrough(petRef: React.RefObject<HTMLDivElement | null>, dragging: boolean): void {
+  // Why: seeded true because a fresh BrowserWindow does take mouse events — the mount effect
+  // below must actually send the first "stop taking them", not dedupe it away.
+  const interactiveRef = useRef(true)
+  const setInteractive = useCallback((next: boolean): void => {
+    if (interactiveRef.current === next) {
+      return
+    }
+    interactiveRef.current = next
+    window.api.desktopPet.setInteractive(next).catch(console.error)
+  }, [])
+
+  useEffect(() => {
+    setInteractive(false)
+    const onMove = (event: MouseEvent): void => {
+      // Why: a drag must keep the mouse even when the pointer outruns the window mid-fling.
+      if (dragging) {
+        setInteractive(true)
+        return
+      }
+      const rect = petRef.current?.getBoundingClientRect()
+      setInteractive(
+        !!rect &&
+          event.clientX >= rect.left &&
+          event.clientX <= rect.right &&
+          event.clientY >= rect.top &&
+          event.clientY <= rect.bottom
+      )
+    }
+    window.addEventListener('mousemove', onMove)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      setInteractive(true)
+    }
+  }, [dragging, petRef, setInteractive])
+}
+
+export function DesktopPetRoot(): React.JSX.Element {
+  usePetUIStateSync()
+  const size = clampPetSize(useAppStore((s) => s.petSize))
+  const agentAnimation = useRelayedPetAnimation()
+  const petRef = useRef<HTMLDivElement | null>(null)
+
+  // Why: the pet is pinned inside its own window, so the drag's "position" is the window's
+  // own screen origin and moving it is an OS window move, not a CSS offset.
+  const windowOrigin = useCallback(
+    (): PetWindowPosition => ({ x: window.screenX, y: window.screenY }),
+    []
+  )
+  const interaction = usePetPointerInteraction(
+    windowOrigin,
+    (next) => {
+      window.api.desktopPet.move({ x: next.x, y: next.y }).catch(console.error)
+    },
+    'screen'
+  )
+  useMouseThrough(petRef, interaction.dragging)
+
+  const animationName = applyPetPointerAnimation(agentAnimation, interaction)
+
+  return (
+    <div
+      className="flex h-screen w-screen items-center justify-center bg-transparent"
+      style={{ padding: PET_WINDOW_MARGIN }}
+    >
+      {/* Why: the hit test measures THIS box, which shrink-wraps the sprite — measuring the
+          full-window box would make every transparent corner swallow clicks. */}
+      <div ref={petRef} data-desktop-pet-hit-area className="flex h-fit w-fit">
+        <PetCharacter size={size} animationName={animationName} interaction={interaction} />
+      </div>
+    </div>
+  )
+}
+
+export default DesktopPetRoot

--- a/src/renderer/src/components/pet/PetCharacter.tsx
+++ b/src/renderer/src/components/pet/PetCharacter.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react'
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
+import { usePetUrl } from './usePetUrl'
+import { DetectedSpriteFrame, SpriteFrame } from './pet-sprite-frames'
+import type { PetAnimationName } from './pet-agent-state'
+import type { PetPointerInteraction } from './usePetPointerInteraction'
+
+// Why: the bob float is runtime CSS, not user-visible copy; keep CSS keywords
+// out of i18n so translated locales cannot invalidate the keyframes.
+const PET_BOB_KEYFRAMES_CSS =
+  '@keyframes pet-bob { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-4px); } }'
+
+function useDocumentVisible(): boolean {
+  const [visible, setVisible] = useState(() =>
+    typeof document === 'undefined' ? true : document.visibilityState === 'visible'
+  )
+  useEffect(() => {
+    const onChange = (): void => {
+      setVisible(document.visibilityState === 'visible')
+    }
+    document.addEventListener('visibilitychange', onChange)
+    return () => document.removeEventListener('visibilitychange', onChange)
+  }, [])
+  return visible
+}
+
+/** The pet itself: sprite playback plus the bob float and grab hit area. Shared by the in-window
+ *  overlay and the detached desktop window, which differ only in how they position and move it. */
+export function PetCharacter({
+  size,
+  animationName,
+  interaction,
+  className
+}: {
+  size: number
+  animationName: PetAnimationName
+  interaction: PetPointerInteraction
+  className?: string
+}): React.JSX.Element {
+  const documentVisible = useDocumentVisible()
+  const reducedMotion = usePrefersReducedMotion()
+  const { url, sprite, detected } = usePetUrl()
+  const { dragging, dragAnimation, dragGeneration, handlers } = interaction
+
+  const motionAllowed = documentVisible && !reducedMotion
+  // Why: a still/vertical grab freezes on frame 0 (Codex grab-and-hold); a
+  // horizontal drag keeps animating so the running rows show. Bob always pauses.
+  const spriteAnimate = motionAllowed && (!dragging || dragAnimation !== null)
+  const bobAnimate = motionAllowed && !dragging
+
+  return (
+    <div
+      {...handlers}
+      className={`flex h-fit w-fit select-none ${className ?? ''}`}
+      style={{
+        cursor: dragging ? 'grabbing' : 'grab',
+        animation: 'pet-bob 1.2s ease-in-out infinite',
+        animationPlayState: bobAnimate ? 'running' : 'paused',
+        touchAction: 'none',
+        // Why: floor so the wrapper stays grabbable while w-fit/h-fit would
+        // otherwise collapse to 0×0 during the image-load window.
+        minWidth: 24,
+        minHeight: 24
+      }}
+    >
+      <style>{PET_BOB_KEYFRAMES_CSS}</style>
+      {sprite ? (
+        // Why: remount per pet so a switched-to sprite starts a fresh
+        // animation instead of inheriting the prior pet's currentTime.
+        <SpriteFrame
+          key={url}
+          url={url}
+          sprite={sprite}
+          animate={spriteAnimate}
+          maxSize={size}
+          animationName={animationName}
+          restartKey={dragGeneration}
+        />
+      ) : detected ? (
+        <DetectedSpriteFrame detected={detected} animate={spriteAnimate} maxSize={size} />
+      ) : (
+        // Why: cap explicitly at the pet size — the w-fit/h-fit wrapper is
+        // fit-content, so max-w/h-full has no fixed box to resolve against
+        // and the image would otherwise render at its intrinsic size and
+        // overflow the persisted size box that clamping still assumes.
+        <img
+          src={url}
+          alt=""
+          className="max-h-full max-w-full object-contain"
+          style={{ maxWidth: size, maxHeight: size }}
+          draggable={false}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/pet/PetOverlay.tsx
+++ b/src/renderer/src/components/pet/PetOverlay.tsx
@@ -1,19 +1,14 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
-import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
-import { usePetUrl } from './usePetUrl'
-import type { DetectedSpriteCacheEntry } from './pet-blob-cache'
-import type { CustomPet } from '../../../../shared/pet-types'
+import { useCallback, useEffect, useState } from 'react'
 import { useAppStore } from '../../store'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
+import { PET_SIZE_DEFAULT } from '../../../../shared/pet-types'
 import {
   selectPetAnimationName,
   type PetAnimationName,
   type PetDragAnimation
 } from './pet-agent-state'
+import { PetCharacter } from './PetCharacter'
 import { usePetPointerInteraction } from './usePetPointerInteraction'
-import { buildSpriteAnimationCss } from './sprite-animation-css'
-
-type Sprite = NonNullable<CustomPet['sprite']>
 
 function usePetAnimationName(
   dragging: boolean,
@@ -39,198 +34,9 @@ function usePetAnimationName(
   })
 }
 
-// Why: pet bundles ship a sprite sheet — animate by stepping a CSS background
-// across the cells of one row. We pick the row from the live pet state
-// when the manifest provides that animation, then fall back to the bundle's
-// default animation. imageRendering: 'pixelated' keeps edges crisp even when
-// scale is fractional (needed when frames exceed maxSize).
-function SpriteFrame({
-  url,
-  sprite,
-  animate,
-  maxSize,
-  animationName,
-  restartKey
-}: {
-  url: string
-  sprite: Sprite
-  animate: boolean
-  maxSize: number
-  animationName: PetAnimationName
-  // Why: folded into the keyframes name, so bumping it mints a fresh animation
-  // that restarts from frame 0 even when the state row is unchanged.
-  restartKey: number
-}): React.JSX.Element {
-  const baseId = useId().replace(/[^a-zA-Z0-9_-]/g, '')
-  const anim =
-    sprite.animations?.[animationName] ||
-    (sprite.defaultAnimation && sprite.animations?.[sprite.defaultAnimation]) ||
-    (sprite.animations ? Object.values(sprite.animations)[0] : undefined)
-  const row = anim?.row ?? 0
-  // Why: clamp to >=1 so an empty/invalid manifest can't produce steps(0),
-  // which is rejected as invalid CSS and freezes the animation.
-  const frames = Math.max(1, anim?.frames ?? sprite.columns ?? 1)
-  // Why: name the @keyframes by the RESOLVED track (+restartKey for same-row
-  // grabs), so a genuine row change starts at frame 0 while a state that falls
-  // back to the same row (e.g. hover on a pet without a jumping row) doesn't
-  // needlessly restart.
-  const animKeyframesId = `${baseId}-${row}-${frames}-${restartKey}`
-  // Why: allow fractional downscaling so frames larger than maxSize shrink to
-  // fit instead of overflowing the overlay; mirrors DetectedSpriteFrame's math.
-  const scale = Math.min(maxSize / sprite.frameWidth, maxSize / sprite.frameHeight)
-  const renderedW = sprite.frameWidth * scale
-  const renderedH = sprite.frameHeight * scale
-  const bgW = sprite.sheetWidth * scale
-  const bgH = sprite.sheetHeight * scale
-  const startX = 0
-  const startY = -(row * sprite.frameHeight * scale)
-  const { keyframesCss, animationCss } = buildSpriteAnimationCss({
-    keyframesId: animKeyframesId,
-    frames,
-    fps: sprite.fps,
-    frameWidth: sprite.frameWidth,
-    scale,
-    rowOffsetY: startY,
-    frameDurationsMs: anim?.frameDurationsMs
-  })
-  return (
-    <>
-      <style>{keyframesCss}</style>
-      <div
-        style={{
-          width: renderedW,
-          height: renderedH,
-          backgroundImage: `url(${url})`,
-          backgroundRepeat: 'no-repeat',
-          backgroundSize: `${bgW}px ${bgH}px`,
-          backgroundPosition: `${startX}px ${startY}px`,
-          imageRendering: 'pixelated',
-          animation: animationCss,
-          animationPlayState: animate ? 'running' : 'paused'
-        }}
-      />
-    </>
-  )
-}
-
-// Why: when the manifest doesn't declare frame size, we auto-detect frames
-// from the keyed sheet. Render via canvas because the frames may be different
-// sizes; we scale each one to fit the overlay box and step through them at a
-// fixed fps. requestAnimationFrame is paused when `animate` is false so the
-// overlay respects reduced motion / hidden window.
-function DetectedSpriteFrame({
-  detected,
-  animate,
-  maxSize
-}: {
-  detected: DetectedSpriteCacheEntry
-  animate: boolean
-  maxSize: number
-}): React.JSX.Element {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null)
-  const frameIndexRef = useRef(0)
-  const lastTimeRef = useRef(0)
-  // Why: honor manifest fps captured at import time so bundles play at their
-  // intended speed; default to 8 only when the manifest didn't declare one.
-  const fps = detected.fps > 0 ? detected.fps : 8
-
-  // Why: size the canvas to one fixed footprint bounding the largest scaled
-  // frame so the drag wrapper hugs the pet instead of a maxSize square. A
-  // single size across frames avoids the jitter a per-frame resize would cause.
-  const { footprintW, footprintH } = useMemo(() => {
-    let w = 0
-    let h = 0
-    for (const f of detected.frames) {
-      const s = Math.min(maxSize / f.w, maxSize / f.h)
-      w = Math.max(w, f.w * s)
-      h = Math.max(h, f.h * s)
-    }
-    return { footprintW: Math.max(1, Math.round(w)), footprintH: Math.max(1, Math.round(h)) }
-  }, [detected, maxSize])
-
-  useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas) {
-      return
-    }
-    const ctx = canvas.getContext('2d')
-    if (!ctx) {
-      return
-    }
-    canvas.width = footprintW
-    canvas.height = footprintH
-    // Why: reset playback when the underlying sprite changes so the new
-    // animation starts from frame 0 rather than wherever the prior one stopped.
-    frameIndexRef.current = 0
-    lastTimeRef.current = 0
-    if (detected.frames.length === 0) {
-      ctx.clearRect(0, 0, canvas.width, canvas.height)
-      return
-    }
-    let raf = 0
-    const draw = (): void => {
-      const f = detected.frames[frameIndexRef.current % detected.frames.length]
-      const bmp = detected.bitmaps[frameIndexRef.current % detected.bitmaps.length]
-      if (!f || !bmp) {
-        return
-      }
-      ctx.imageSmoothingEnabled = false
-      ctx.clearRect(0, 0, canvas.width, canvas.height)
-      const scale = Math.min(maxSize / f.w, maxSize / f.h)
-      const w = f.w * scale
-      const h = f.h * scale
-      // Why: center each frame within the fixed footprint so frames of differing
-      // sizes stay aligned without resizing the canvas per frame.
-      ctx.drawImage(bmp, (footprintW - w) / 2, (footprintH - h) / 2, w, h)
-    }
-    const tick = (now: number): void => {
-      const dt = now - lastTimeRef.current
-      if (dt >= 1000 / fps) {
-        lastTimeRef.current = now
-        frameIndexRef.current = (frameIndexRef.current + 1) % detected.frames.length
-        draw()
-      }
-      if (animate) {
-        raf = requestAnimationFrame(tick)
-      }
-    }
-    draw()
-    if (animate) {
-      lastTimeRef.current = performance.now()
-      raf = requestAnimationFrame(tick)
-    }
-    return () => {
-      if (raf) {
-        cancelAnimationFrame(raf)
-      }
-    }
-  }, [detected, animate, footprintW, footprintH, maxSize, fps])
-
-  return (
-    <canvas
-      ref={canvasRef}
-      style={{ width: footprintW, height: footprintH, imageRendering: 'pixelated' }}
-    />
-  )
-}
-
-function useDocumentVisible(): boolean {
-  const [visible, setVisible] = useState(() =>
-    typeof document === 'undefined' ? true : document.visibilityState === 'visible'
-  )
-  useEffect(() => {
-    const onChange = (): void => {
-      setVisible(document.visibilityState === 'visible')
-    }
-    document.addEventListener('visibilitychange', onChange)
-    return () => document.removeEventListener('visibilitychange', onChange)
-  }, [])
-  return visible
-}
-
 // Why: keep a default for the cached helpers below; the live size now comes
 // from the store so the user can resize from the status-bar menu.
-const SIZE = 180
+const SIZE = PET_SIZE_DEFAULT
 const POSITION_STORAGE_KEY = 'pet-overlay-position'
 const LEGACY_POSITION_STORAGE_KEY = 'sidekick-overlay-position'
 
@@ -306,14 +112,7 @@ function defaultPosition(size: number = SIZE): Position {
   )
 }
 
-// Why: the bob float is runtime CSS, not user-visible copy; keep CSS keywords
-// out of i18n so translated locales cannot invalidate the keyframes.
-const PET_BOB_KEYFRAMES_CSS =
-  '@keyframes pet-bob { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-4px); } }'
 export function PetOverlay(): React.JSX.Element {
-  const documentVisible = useDocumentVisible()
-  const reducedMotion = usePrefersReducedMotion()
-  const { url, sprite, detected } = usePetUrl()
   const size = useAppStore((s) => s.petSize)
 
   const [positionState, setPositionState] = useState<{
@@ -349,10 +148,10 @@ export function PetOverlay(): React.JSX.Element {
     },
     [size]
   )
-  const { dragging, dragAnimation, hovering, dragGeneration, handlers } = usePetPointerInteraction(
-    position,
-    (next) => setPosition(clampToViewport(next, size))
+  const interaction = usePetPointerInteraction(position, (next) =>
+    setPosition(clampToViewport(next, size))
   )
+  const { dragging, dragAnimation, hovering } = interaction
 
   useEffect(() => {
     const onResize = (): void => setPosition((prev) => clampToViewport(prev, size))
@@ -371,11 +170,6 @@ export function PetOverlay(): React.JSX.Element {
     }
   }, [dragging, position])
 
-  const motionAllowed = documentVisible && !reducedMotion
-  // Why: a still/vertical grab freezes on frame 0 (Codex grab-and-hold); a
-  // horizontal drag keeps animating so the running rows show. Bob always pauses.
-  const spriteAnimate = motionAllowed && (!dragging || dragAnimation !== null)
-  const bobAnimate = motionAllowed && !dragging
   const animationName = usePetAnimationName(dragging, dragAnimation, hovering)
 
   return (
@@ -393,49 +187,12 @@ export function PetOverlay(): React.JSX.Element {
       }}
     >
       <div className="pointer-events-none flex size-full items-center justify-end">
-        <div
-          {...handlers}
-          className="pointer-events-auto flex h-fit w-fit select-none"
-          style={{
-            cursor: dragging ? 'grabbing' : 'grab',
-            animation: 'pet-bob 1.2s ease-in-out infinite',
-            animationPlayState: bobAnimate ? 'running' : 'paused',
-            touchAction: 'none',
-            // Why: floor so the wrapper stays grabbable while w-fit/h-fit would
-            // otherwise collapse to 0×0 during the image-load window.
-            minWidth: 24,
-            minHeight: 24
-          }}
-        >
-          <style>{PET_BOB_KEYFRAMES_CSS}</style>
-          {sprite ? (
-            // Why: remount per pet so a switched-to sprite starts a fresh
-            // animation instead of inheriting the prior pet's currentTime.
-            <SpriteFrame
-              key={url}
-              url={url}
-              sprite={sprite}
-              animate={spriteAnimate}
-              maxSize={size}
-              animationName={animationName}
-              restartKey={dragGeneration}
-            />
-          ) : detected ? (
-            <DetectedSpriteFrame detected={detected} animate={spriteAnimate} maxSize={size} />
-          ) : (
-            // Why: cap explicitly at the pet size — the w-fit/h-fit wrapper is
-            // fit-content, so max-w/h-full has no fixed box to resolve against
-            // and the image would otherwise render at its intrinsic size and
-            // overflow the persisted size box that clamping still assumes.
-            <img
-              src={url}
-              alt=""
-              className="max-h-full max-w-full object-contain"
-              style={{ maxWidth: size, maxHeight: size }}
-              draggable={false}
-            />
-          )}
-        </div>
+        <PetCharacter
+          size={size}
+          animationName={animationName}
+          interaction={interaction}
+          className="pointer-events-auto"
+        />
       </div>
     </div>
   )

--- a/src/renderer/src/components/pet/pet-agent-state.ts
+++ b/src/renderer/src/components/pet/pet-agent-state.ts
@@ -1,14 +1,8 @@
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { PetAgentAnimation } from '../../../../shared/pet-types'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 
-export type PetAnimationName =
-  | 'idle'
-  | 'running'
-  | 'waiting'
-  | 'review'
-  | 'jumping'
-  | 'running-right'
-  | 'running-left'
+export type PetAnimationName = PetAgentAnimation | 'jumping' | 'running-right' | 'running-left'
 
 export type PetDragAnimation = 'running-right' | 'running-left' | null
 
@@ -27,22 +21,29 @@ export function nextPetDragAnimation(
   return { animation: current, accepted: false }
 }
 
-export type PetAnimationInput = {
+export type PetAgentAnimationInput = {
   entries: AgentStatusEntry[]
   retainedCount: number
-  dragging: boolean
-  dragAnimation: PetDragAnimation
-  hovering: boolean
   now: number
   staleAfterMs: number
 }
 
-function agentStateAnimation(
-  entries: AgentStatusEntry[],
-  retainedCount: number,
-  now: number,
-  staleAfterMs: number
-): PetAnimationName {
+export type PetPointerAnimationInput = {
+  dragging: boolean
+  dragAnimation: PetDragAnimation
+  hovering: boolean
+}
+
+export type PetAnimationInput = PetAgentAnimationInput & PetPointerAnimationInput
+
+/** The agent-driven half of the pet's animation. Split out so the detached pet window can be
+ *  handed this over IPC and still layer its own pointer states on top. */
+export function selectPetAgentAnimation({
+  entries,
+  retainedCount,
+  now,
+  staleAfterMs
+}: PetAgentAnimationInput): PetAgentAnimation {
   let hasWorking = false
   let hasDone = false
 
@@ -69,6 +70,21 @@ function agentStateAnimation(
   return 'idle'
 }
 
+// Why: aligned with Codex. A horizontal drag runs toward the pointer,
+// grab-and-hold keeps the live agent state, and only a plain hover jumps.
+export function applyPetPointerAnimation(
+  base: PetAnimationName,
+  { dragging, dragAnimation, hovering }: PetPointerAnimationInput
+): PetAnimationName {
+  if (dragging) {
+    return dragAnimation ?? base
+  }
+  if (hovering) {
+    return 'jumping'
+  }
+  return base
+}
+
 export function selectPetAnimationName({
   entries,
   retainedCount,
@@ -78,14 +94,8 @@ export function selectPetAnimationName({
   now,
   staleAfterMs
 }: PetAnimationInput): PetAnimationName {
-  const base = agentStateAnimation(entries, retainedCount, now, staleAfterMs)
-  // Why: aligned with Codex. A horizontal drag runs toward the pointer,
-  // grab-and-hold keeps the live agent state, and only a plain hover jumps.
-  if (dragging) {
-    return dragAnimation ?? base
-  }
-  if (hovering) {
-    return 'jumping'
-  }
-  return base
+  return applyPetPointerAnimation(
+    selectPetAgentAnimation({ entries, retainedCount, now, staleAfterMs }),
+    { dragging, dragAnimation, hovering }
+  )
 }

--- a/src/renderer/src/components/pet/pet-overlay-visibility.test.ts
+++ b/src/renderer/src/components/pet/pet-overlay-visibility.test.ts
@@ -1,38 +1,25 @@
 import { describe, expect, it } from 'vitest'
 import { shouldRenderPetOverlay } from './pet-overlay-visibility'
 
+const BASE = {
+  persistedUIReady: true,
+  petEnabled: true,
+  petVisible: true,
+  petDetached: false
+}
+
 describe('shouldRenderPetOverlay', () => {
   it('does not render before persisted UI hydration even when the feature is enabled', () => {
-    expect(
-      shouldRenderPetOverlay({
-        persistedUIReady: false,
-        petEnabled: true,
-        petVisible: true
-      })
-    ).toBe(false)
+    expect(shouldRenderPetOverlay({ ...BASE, persistedUIReady: false })).toBe(false)
   })
 
   it('renders only after hydration when both pet switches allow it', () => {
-    expect(
-      shouldRenderPetOverlay({
-        persistedUIReady: true,
-        petEnabled: true,
-        petVisible: true
-      })
-    ).toBe(true)
-    expect(
-      shouldRenderPetOverlay({
-        persistedUIReady: true,
-        petEnabled: true,
-        petVisible: false
-      })
-    ).toBe(false)
-    expect(
-      shouldRenderPetOverlay({
-        persistedUIReady: true,
-        petEnabled: false,
-        petVisible: true
-      })
-    ).toBe(false)
+    expect(shouldRenderPetOverlay(BASE)).toBe(true)
+    expect(shouldRenderPetOverlay({ ...BASE, petVisible: false })).toBe(false)
+    expect(shouldRenderPetOverlay({ ...BASE, petEnabled: false })).toBe(false)
+  })
+
+  it('yields to the detached pet window so the pet is never drawn twice', () => {
+    expect(shouldRenderPetOverlay({ ...BASE, petDetached: true })).toBe(false)
   })
 })

--- a/src/renderer/src/components/pet/pet-overlay-visibility.ts
+++ b/src/renderer/src/components/pet/pet-overlay-visibility.ts
@@ -1,13 +1,16 @@
 export function shouldRenderPetOverlay({
   persistedUIReady,
   petEnabled,
-  petVisible
+  petVisible,
+  petDetached
 }: {
   persistedUIReady: boolean
   petEnabled: boolean
   petVisible: boolean
+  petDetached: boolean
 }): boolean {
   // Why: petVisible defaults true until persisted UI hydrates. Waiting avoids
   // flashing the pet for users who previously hid it.
-  return persistedUIReady && petEnabled && petVisible
+  // Why: a detached pet lives in its own window — drawing it here too would double it.
+  return persistedUIReady && petEnabled && petVisible && !petDetached
 }

--- a/src/renderer/src/components/pet/pet-sprite-frames.tsx
+++ b/src/renderer/src/components/pet/pet-sprite-frames.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useId, useMemo, useRef } from 'react'
+import type { DetectedSpriteCacheEntry } from './pet-blob-cache'
+import type { CustomPet } from '../../../../shared/pet-types'
+import type { PetAnimationName } from './pet-agent-state'
+import { buildSpriteAnimationCss } from './sprite-animation-css'
+
+type Sprite = NonNullable<CustomPet['sprite']>
+
+// Why: pet bundles ship a sprite sheet — animate by stepping a CSS background
+// across the cells of one row. We pick the row from the live pet state
+// when the manifest provides that animation, then fall back to the bundle's
+// default animation. imageRendering: 'pixelated' keeps edges crisp even when
+// scale is fractional (needed when frames exceed maxSize).
+export function SpriteFrame({
+  url,
+  sprite,
+  animate,
+  maxSize,
+  animationName,
+  restartKey
+}: {
+  url: string
+  sprite: Sprite
+  animate: boolean
+  maxSize: number
+  animationName: PetAnimationName
+  // Why: folded into the keyframes name, so bumping it mints a fresh animation
+  // that restarts from frame 0 even when the state row is unchanged.
+  restartKey: number
+}): React.JSX.Element {
+  const baseId = useId().replace(/[^a-zA-Z0-9_-]/g, '')
+  const anim =
+    sprite.animations?.[animationName] ||
+    (sprite.defaultAnimation && sprite.animations?.[sprite.defaultAnimation]) ||
+    (sprite.animations ? Object.values(sprite.animations)[0] : undefined)
+  const row = anim?.row ?? 0
+  // Why: clamp to >=1 so an empty/invalid manifest can't produce steps(0),
+  // which is rejected as invalid CSS and freezes the animation.
+  const frames = Math.max(1, anim?.frames ?? sprite.columns ?? 1)
+  // Why: name the @keyframes by the RESOLVED track (+restartKey for same-row
+  // grabs), so a genuine row change starts at frame 0 while a state that falls
+  // back to the same row (e.g. hover on a pet without a jumping row) doesn't
+  // needlessly restart.
+  const animKeyframesId = `${baseId}-${row}-${frames}-${restartKey}`
+  // Why: allow fractional downscaling so frames larger than maxSize shrink to
+  // fit instead of overflowing the overlay; mirrors DetectedSpriteFrame's math.
+  const scale = Math.min(maxSize / sprite.frameWidth, maxSize / sprite.frameHeight)
+  const renderedW = sprite.frameWidth * scale
+  const renderedH = sprite.frameHeight * scale
+  const bgW = sprite.sheetWidth * scale
+  const bgH = sprite.sheetHeight * scale
+  const startX = 0
+  const startY = -(row * sprite.frameHeight * scale)
+  const { keyframesCss, animationCss } = buildSpriteAnimationCss({
+    keyframesId: animKeyframesId,
+    frames,
+    fps: sprite.fps,
+    frameWidth: sprite.frameWidth,
+    scale,
+    rowOffsetY: startY,
+    frameDurationsMs: anim?.frameDurationsMs
+  })
+  return (
+    <>
+      <style>{keyframesCss}</style>
+      <div
+        style={{
+          width: renderedW,
+          height: renderedH,
+          backgroundImage: `url(${url})`,
+          backgroundRepeat: 'no-repeat',
+          backgroundSize: `${bgW}px ${bgH}px`,
+          backgroundPosition: `${startX}px ${startY}px`,
+          imageRendering: 'pixelated',
+          animation: animationCss,
+          animationPlayState: animate ? 'running' : 'paused'
+        }}
+      />
+    </>
+  )
+}
+
+// Why: when the manifest doesn't declare frame size, we auto-detect frames
+// from the keyed sheet. Render via canvas because the frames may be different
+// sizes; we scale each one to fit the overlay box and step through them at a
+// fixed fps. requestAnimationFrame is paused when `animate` is false so the
+// overlay respects reduced motion / hidden window.
+export function DetectedSpriteFrame({
+  detected,
+  animate,
+  maxSize
+}: {
+  detected: DetectedSpriteCacheEntry
+  animate: boolean
+  maxSize: number
+}): React.JSX.Element {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const frameIndexRef = useRef(0)
+  const lastTimeRef = useRef(0)
+  // Why: honor manifest fps captured at import time so bundles play at their
+  // intended speed; default to 8 only when the manifest didn't declare one.
+  const fps = detected.fps > 0 ? detected.fps : 8
+
+  // Why: size the canvas to one fixed footprint bounding the largest scaled
+  // frame so the drag wrapper hugs the pet instead of a maxSize square. A
+  // single size across frames avoids the jitter a per-frame resize would cause.
+  const { footprintW, footprintH } = useMemo(() => {
+    let w = 0
+    let h = 0
+    for (const f of detected.frames) {
+      const s = Math.min(maxSize / f.w, maxSize / f.h)
+      w = Math.max(w, f.w * s)
+      h = Math.max(h, f.h * s)
+    }
+    return { footprintW: Math.max(1, Math.round(w)), footprintH: Math.max(1, Math.round(h)) }
+  }, [detected, maxSize])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) {
+      return
+    }
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      return
+    }
+    canvas.width = footprintW
+    canvas.height = footprintH
+    // Why: reset playback when the underlying sprite changes so the new
+    // animation starts from frame 0 rather than wherever the prior one stopped.
+    frameIndexRef.current = 0
+    lastTimeRef.current = 0
+    if (detected.frames.length === 0) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      return
+    }
+    let raf = 0
+    const draw = (): void => {
+      const f = detected.frames[frameIndexRef.current % detected.frames.length]
+      const bmp = detected.bitmaps[frameIndexRef.current % detected.bitmaps.length]
+      if (!f || !bmp) {
+        return
+      }
+      ctx.imageSmoothingEnabled = false
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      const scale = Math.min(maxSize / f.w, maxSize / f.h)
+      const w = f.w * scale
+      const h = f.h * scale
+      // Why: center each frame within the fixed footprint so frames of differing
+      // sizes stay aligned without resizing the canvas per frame.
+      ctx.drawImage(bmp, (footprintW - w) / 2, (footprintH - h) / 2, w, h)
+    }
+    const tick = (now: number): void => {
+      const dt = now - lastTimeRef.current
+      if (dt >= 1000 / fps) {
+        lastTimeRef.current = now
+        frameIndexRef.current = (frameIndexRef.current + 1) % detected.frames.length
+        draw()
+      }
+      if (animate) {
+        raf = requestAnimationFrame(tick)
+      }
+    }
+    draw()
+    if (animate) {
+      lastTimeRef.current = performance.now()
+      raf = requestAnimationFrame(tick)
+    }
+    return () => {
+      if (raf) {
+        cancelAnimationFrame(raf)
+      }
+    }
+  }, [detected, animate, footprintW, footprintH, maxSize, fps])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ width: footprintW, height: footprintH, imageRendering: 'pixelated' }}
+    />
+  )
+}

--- a/src/renderer/src/components/pet/usePetPointerInteraction.screen-space.test.ts
+++ b/src/renderer/src/components/pet/usePetPointerInteraction.screen-space.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { usePetPointerInteraction } from './usePetPointerInteraction'
+
+type Handlers = ReturnType<typeof usePetPointerInteraction>['handlers']
+
+function fakeTarget(): {
+  setPointerCapture: (id: number) => void
+  hasPointerCapture: (id: number) => boolean
+  releasePointerCapture: (id: number) => void
+} {
+  const captured = new Set<number>()
+  return {
+    setPointerCapture: (id) => void captured.add(id),
+    hasPointerCapture: (id) => captured.has(id),
+    releasePointerCapture: (id) => void captured.delete(id)
+  }
+}
+
+function setup(origin: () => { x: number; y: number }) {
+  const moveTo = vi.fn()
+  const target = fakeTarget()
+  const { result } = renderHook(() => usePetPointerInteraction(origin, moveTo, 'screen'))
+  const fire = (
+    name: keyof Handlers,
+    props: { screenX?: number; screenY?: number; clientX?: number; clientY?: number } = {}
+  ): void => {
+    act(() =>
+      result.current.handlers[name]({
+        button: 0,
+        pointerId: 1,
+        screenX: 0,
+        screenY: 0,
+        clientX: 0,
+        clientY: 0,
+        currentTarget: target,
+        preventDefault: () => {},
+        ...props
+      } as unknown as Parameters<Handlers['onPointerDown']>[0])
+    )
+  }
+  return { result, moveTo, fire }
+}
+
+describe('usePetPointerInteraction in screen space', () => {
+  it('reports desktop coordinates, so a window moving under the cursor still tracks it', () => {
+    // The detached pet window moves itself: clientX stays put while screenX advances.
+    const { moveTo, fire } = setup(() => ({ x: 800, y: 400 }))
+    fire('onPointerDown', { screenX: 850, screenY: 430, clientX: 50, clientY: 30 })
+    fire('onPointerMove', { screenX: 900, screenY: 500, clientX: 50, clientY: 30 })
+    expect(moveTo).toHaveBeenLastCalledWith({ x: 850, y: 470 })
+  })
+
+  it('turns horizontal desktop travel into a running direction', () => {
+    const { result, fire } = setup(() => ({ x: 0, y: 0 }))
+    fire('onPointerDown', { screenX: 100, screenY: 100 })
+    fire('onPointerMove', { screenX: 120, screenY: 100 })
+    expect(result.current.dragAnimation).toBe('running-right')
+    fire('onPointerMove', { screenX: 90, screenY: 100 })
+    expect(result.current.dragAnimation).toBe('running-left')
+  })
+
+  it('re-reads the origin getter per grab, so a window moved since the last drag does not jump', () => {
+    let origin = { x: 0, y: 0 }
+    const { moveTo, fire } = setup(() => origin)
+    fire('onPointerDown', { screenX: 10, screenY: 10 })
+    fire('onPointerUp', { screenX: 10, screenY: 10 })
+
+    origin = { x: 500, y: 500 }
+    fire('onPointerDown', { screenX: 510, screenY: 510 })
+    fire('onPointerMove', { screenX: 511, screenY: 511 })
+    expect(moveTo).toHaveBeenLastCalledWith({ x: 501, y: 501 })
+  })
+})

--- a/src/renderer/src/components/pet/usePetPointerInteraction.ts
+++ b/src/renderer/src/components/pet/usePetPointerInteraction.ts
@@ -21,11 +21,27 @@ export type PetPointerInteraction = {
   }
 }
 
+/** Where drag coordinates are measured. The in-window overlay positions itself against the
+ *  viewport ('client'); the detached pet window moves the OS window itself, whose own motion
+ *  cancels out client coordinates, so it reads desktop coordinates instead. */
+export type PetPointerCoordinateSpace = 'client' | 'screen'
+
+function readPointerPoint(
+  event: ReactPointerEvent<HTMLDivElement>,
+  space: PetPointerCoordinateSpace
+): Point {
+  return space === 'screen'
+    ? { x: event.screenX, y: event.screenY }
+    : { x: event.clientX, y: event.clientY }
+}
+
 // Drag/hover state for the pet overlay. `position` is the overlay's current
-// top-left corner and `moveTo` receives the unclamped position the drag wants.
+// top-left corner — pass a getter when the pet moves without re-rendering (the detached
+// window moves itself) — and `moveTo` receives the unclamped position the drag wants.
 export function usePetPointerInteraction(
-  position: Point,
-  moveTo: (next: Point) => void
+  position: Point | (() => Point),
+  moveTo: (next: Point) => void,
+  coordinateSpace: PetPointerCoordinateSpace = 'client'
 ): PetPointerInteraction {
   const [dragging, setDragging] = useState(false)
   const [dragAnimation, setDragAnimation] = useState<PetDragAnimation>(null)
@@ -50,11 +66,13 @@ export function usePetPointerInteraction(
       return
     }
     activePointerRef.current = event.pointerId
+    const point = readPointerPoint(event, coordinateSpace)
+    const origin = typeof position === 'function' ? position() : position
     dragOffsetRef.current = {
-      x: event.clientX - position.x,
-      y: event.clientY - position.y
+      x: point.x - origin.x,
+      y: point.y - origin.y
     }
-    dragBaselineXRef.current = event.clientX
+    dragBaselineXRef.current = point.x
     dragDirectionRef.current = null
     event.currentTarget.setPointerCapture(event.pointerId)
     setDragging(true)
@@ -67,20 +85,18 @@ export function usePetPointerInteraction(
     if (event.pointerId !== activePointerRef.current) {
       return
     }
-    const next = nextPetDragAnimation(
-      dragDirectionRef.current,
-      event.clientX - dragBaselineXRef.current
-    )
+    const point = readPointerPoint(event, coordinateSpace)
+    const next = nextPetDragAnimation(dragDirectionRef.current, point.x - dragBaselineXRef.current)
     if (next.accepted) {
-      dragBaselineXRef.current = event.clientX
+      dragBaselineXRef.current = point.x
       if (next.animation !== dragDirectionRef.current) {
         dragDirectionRef.current = next.animation
         setDragAnimation(next.animation)
       }
     }
     moveTo({
-      x: event.clientX - dragOffsetRef.current.x,
-      y: event.clientY - dragOffsetRef.current.y
+      x: point.x - dragOffsetRef.current.x,
+      y: point.y - dragOffsetRef.current.y
     })
   }
 

--- a/src/renderer/src/components/status-bar/PetStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/PetStatusSegment.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Check, PackageOpen, Trash2, Upload } from 'lucide-react'
+import { Check, ExternalLink, PackageOpen, PictureInPicture2, Trash2, Upload } from 'lucide-react'
 import { toast } from 'sonner'
 import {
   DropdownMenu,
@@ -33,6 +33,8 @@ function PetStatusSegmentInner(): React.JSX.Element {
   const removeCustomPet = useAppStore((s) => s.removeCustomPet)
   const petSize = useAppStore((s) => s.petSize)
   const setPetSize = useAppStore((s) => s.setPetSize)
+  const petDetached = useAppStore((s) => s.petDetached)
+  const setPetDetached = useAppStore((s) => s.setPetDetached)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
 
@@ -142,6 +144,26 @@ function PetStatusSegmentInner(): React.JSX.Element {
           {petVisible
             ? translate('auto.components.status.bar.PetStatusSegment.1fbc51cc77', 'Hide pet')
             : translate('auto.components.status.bar.PetStatusSegment.6d0a8cd179', 'Show pet')}
+        </DropdownMenuItem>
+        {/* Why: detaching moves the pet into its own always-on-top window so it survives a
+            minimized Orca; docking brings it back inside the app window. */}
+        <DropdownMenuItem
+          onSelect={(event) => {
+            event.preventDefault()
+            if (!petVisible) {
+              setPetVisible(true)
+            }
+            setPetDetached(!petDetached)
+          }}
+        >
+          {petDetached ? (
+            <PictureInPicture2 className="size-3.5" aria-hidden />
+          ) : (
+            <ExternalLink className="size-3.5" aria-hidden />
+          )}
+          {petDetached
+            ? translate('components.status-bar.PetStatusSegment.dockPet', 'Dock pet in Orca window')
+            : translate('components.status-bar.PetStatusSegment.detachPet', 'Keep pet on desktop')}
         </DropdownMenuItem>
         {/* Why: in-menu range so users can resize the overlay without leaving
             the dropdown — pet sprites can import larger than the default 180px

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16848,6 +16848,12 @@
         "days": "{{value0}}d",
         "underOneMinute": "<1m"
       }
+    },
+    "status-bar": {
+      "PetStatusSegment": {
+        "dockPet": "Dock pet in Orca window",
+        "detachPet": "Keep pet on desktop"
+      }
     }
   },
   "dashboardPopout": {

--- a/src/renderer/src/lib/renderer-memory-sampling.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.ts
@@ -26,7 +26,7 @@ const RENDERER_MEMORY_HIGHWATER_RATIOS = [0.6, 0.8] as const
  */
 const RENDERER_PRIVATE_HIGHWATER_MB = [600, 1000] as const
 
-export type RendererSurface = 'main' | 'dashboard-popout'
+export type RendererSurface = 'main' | 'dashboard-popout' | 'desktop-pet'
 
 type BrowserPerformanceMemory = {
   usedJSHeapSize?: number

--- a/src/renderer/src/pet.tsx
+++ b/src/renderer/src/pet.tsx
@@ -1,0 +1,35 @@
+// Why first, and why the import-free shim: react-dom reads
+// __REACT_DEVTOOLS_GLOBAL_HOOK__ once at module evaluation, so the global has to
+// exist before it.
+import './lib/react-devtools-commit-hook-shim'
+import './assets/main.css'
+
+import { StrictMode } from 'react'
+import { DesktopPetRoot } from './components/pet/DesktopPetRoot'
+import { RecoverableRenderErrorBoundary } from './components/error-boundaries/RecoverableRenderErrorBoundary'
+import {
+  installRendererCrashDiagnostics,
+  recordRendererCrashBreadcrumb
+} from './lib/crash-diagnostics'
+import { getOrCreateRendererRoot } from './lib/react-renderer-root'
+
+// Why: the detached pet is a separate BrowserWindow with its own React root, so it runs its own
+// renderer bootstrap. It deliberately skips theme/i18n: the pet is a transparent sprite with no
+// chrome and no copy, so there is nothing for either to style or translate.
+recordRendererCrashBreadcrumb('desktop_pet_bootstrap_started', { dev: import.meta.env.DEV })
+installRendererCrashDiagnostics('desktop-pet')
+
+const rootElement = document.getElementById('root')
+if (!rootElement) {
+  recordRendererCrashBreadcrumb('desktop_pet_root_missing')
+  throw new Error('Desktop pet root element not found.')
+}
+
+getOrCreateRendererRoot(rootElement, import.meta.hot?.data).render(
+  <StrictMode>
+    <RecoverableRenderErrorBoundary boundaryId="desktop-pet.root" surface="desktop-pet">
+      <DesktopPetRoot />
+    </RecoverableRenderErrorBoundary>
+  </StrictMode>
+)
+recordRendererCrashBreadcrumb('desktop_pet_bootstrap_rendered')

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -50,7 +50,7 @@ import {
 import type { GitLabWorkItem } from '../../../../shared/gitlab-types'
 import type { LaunchSource } from '../../../../shared/telemetry-events'
 import type { TaskSourceContext } from '../../../../shared/task-source-context'
-import { PET_SIZE_DEFAULT, PET_SIZE_MAX, PET_SIZE_MIN } from '../../../../shared/pet-types'
+import { clampPetSize, PET_SIZE_DEFAULT } from '../../../../shared/pet-types'
 import {
   WORKSPACE_CLEANUP_CLASSIFIER_VERSION,
   type WorkspaceCleanupDismissal
@@ -247,13 +247,6 @@ function getContextualTourProgressionForFeatureInteraction(
     return 'reveal-sidebar-and-advance'
   }
   return 'complete'
-}
-
-function clampPetSize(size: number): number {
-  if (!Number.isFinite(size)) {
-    return PET_SIZE_DEFAULT
-  }
-  return Math.max(PET_SIZE_MIN, Math.min(PET_SIZE_MAX, Math.round(size)))
 }
 
 // Why: local copy of TaskPage's preset→query mapping avoids a store ↔ lib circular import while warming the exact cache key.
@@ -994,6 +987,9 @@ export type UISlice = {
   /** Pet overlay size in CSS pixels (square). User-adjustable so an oversized imported sprite isn't stuck on screen. */
   petSize: number
   setPetSize: (size: number) => void
+  /** Whether the pet lives in its own always-on-top desktop window instead of inside this one. */
+  petDetached: boolean
+  setPetDetached: (v: boolean) => void
   pendingRevealWorktree: PendingSidebarWorktreeReveal | null
   pendingRevealSidebarRow: PendingSidebarRowReveal | null
   revealWorktreeInSidebar: (
@@ -2415,6 +2411,13 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     set({ petSize: clamped })
   },
 
+  // Why: main watches this key to open/close the pet window, so persisting it IS the toggle.
+  petDetached: false,
+  setPetDetached: (v) => {
+    window.api.ui.set({ petDetached: v }).catch(console.error)
+    set({ petDetached: v })
+  },
+
   customPets: [],
   addCustomPet: (model) =>
     set((s) => {
@@ -2612,6 +2615,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         // Why: default true so existing users see the pet on first enabling the flag; only an explicit Hide persists false.
         petVisible: ui.petVisible ?? ui.sidekickVisible ?? true,
         petSize: clampPetSize(ui.petSize ?? ui.sidekickSize ?? PET_SIZE_DEFAULT),
+        petDetached: ui.petDetached === true,
         customPets,
         // Why: fall back to default when the persisted id is unknown (e.g. custom pet removed elsewhere) so the overlay renders.
         petId: ((): string => {

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -78,6 +78,7 @@ export type ReactErrorBoundarySurface =
   | 'overlay'
   | 'rich-markdown-editor'
   | 'dashboard-popout'
+  | 'desktop-pet'
 
 export type ReactErrorBoundaryReportArgs = {
   boundaryId: string

--- a/src/shared/persisted-ui-state-types.ts
+++ b/src/shared/persisted-ui-state-types.ts
@@ -188,6 +188,10 @@ export type PersistedUIState = {
   customPets?: CustomPet[]
   /** Pet overlay size in CSS pixels (square); clamped to [PET_SIZE_MIN, PET_SIZE_MAX] on read. */
   petSize?: number
+  /** Whether the pet renders in its own always-on-top desktop window instead of inside the main window. */
+  petDetached?: boolean
+  /** Saved top-left of the detached pet window in screen coordinates. Main-owned: the window persists its own drags. */
+  petWindowPosition?: { x: number; y: number } | null
   /** Legacy keys from before the sidekick -> pet rename; read only during migration, new writes use pet* above. */
   sidekickVisible?: boolean
   sidekickId?: string

--- a/src/shared/pet-types.ts
+++ b/src/shared/pet-types.ts
@@ -2,6 +2,13 @@ export const PET_SIZE_MIN = 60
 export const PET_SIZE_MAX = 360
 export const PET_SIZE_DEFAULT = 180
 
+export function clampPetSize(size: number | undefined): number {
+  if (typeof size !== 'number' || !Number.isFinite(size)) {
+    return PET_SIZE_DEFAULT
+  }
+  return Math.max(PET_SIZE_MIN, Math.min(PET_SIZE_MAX, Math.round(size)))
+}
+
 /** User-uploaded pet image metadata; renderer fetches bytes from main via pet:read (id, fileName), never learning the on-disk path. */
 export type CustomPet = {
   id: string
@@ -33,4 +40,26 @@ export type SpriteAnimation = {
   frames: number
   /** Per-frame holds in ms (length === frames). Absent means uniform sheet fps. */
   frameDurationsMs?: number[]
+}
+
+/** Pet animation driven purely by agent state. The detached pet window renders in its own
+ *  BrowserWindow with no access to the agent store, so the main window publishes this slice
+ *  and the pet window layers its local drag/hover states on top. */
+export type PetAgentAnimation = 'idle' | 'running' | 'waiting' | 'review'
+
+const PET_AGENT_ANIMATIONS: readonly PetAgentAnimation[] = ['idle', 'running', 'waiting', 'review']
+
+export function isPetAgentAnimation(value: unknown): value is PetAgentAnimation {
+  return typeof value === 'string' && PET_AGENT_ANIMATIONS.includes(value as PetAgentAnimation)
+}
+
+/** Top-left of the detached pet window in screen (DIP) coordinates. */
+export type PetWindowPosition = { x: number; y: number }
+
+export function isPetWindowPosition(value: unknown): value is PetWindowPosition {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const { x, y } = value as { x?: unknown; y?: unknown }
+  return Number.isFinite(x) && Number.isFinite(y)
 }

--- a/src/shared/pet-window-geometry.test.ts
+++ b/src/shared/pet-window-geometry.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { PET_SIZE_MAX } from './pet-types'
+import {
+  PET_WINDOW_MARGIN,
+  defaultPetWindowPosition,
+  petWindowSizeForPetSize
+} from './pet-window-geometry'
+
+describe('petWindowSizeForPetSize', () => {
+  it('leaves room on every side for the bob float', () => {
+    expect(petWindowSizeForPetSize(180)).toBe(180 + PET_WINDOW_MARGIN * 2)
+  })
+
+  it('caps at the largest pet so a corrupt persisted size cannot size a giant window', () => {
+    expect(petWindowSizeForPetSize(10_000)).toBe(PET_SIZE_MAX + PET_WINDOW_MARGIN * 2)
+  })
+
+  it('rounds fractional sizes — window bounds are whole pixels', () => {
+    expect(Number.isInteger(petWindowSizeForPetSize(123.4))).toBe(true)
+  })
+})
+
+describe('defaultPetWindowPosition', () => {
+  it('lands in the work area bottom-right, offset from the display origin', () => {
+    const position = defaultPetWindowPosition({ x: 100, y: 50, width: 1000, height: 800 }, 200)
+    expect(position).toEqual({ x: 100 + 1000 - 200 - 48, y: 50 + 800 - 200 - 24 })
+  })
+
+  it('never places the pet before the work area origin on a display smaller than the window', () => {
+    const position = defaultPetWindowPosition({ x: 0, y: 0, width: 120, height: 120 }, 400)
+    expect(position).toEqual({ x: 0, y: 0 })
+  })
+})

--- a/src/shared/pet-window-geometry.ts
+++ b/src/shared/pet-window-geometry.ts
@@ -1,0 +1,23 @@
+import { PET_SIZE_MAX, type PetWindowPosition } from './pet-types'
+
+/** Slack around the pet inside its detached window: the bob float lifts 4px and sprite
+ *  footprints round up, so a window sized exactly to petSize clips the top of the arc. */
+export const PET_WINDOW_MARGIN = 16
+
+export function petWindowSizeForPetSize(petSize: number): number {
+  return Math.round(Math.min(petSize, PET_SIZE_MAX)) + PET_WINDOW_MARGIN * 2
+}
+
+export type PetWindowWorkArea = { x: number; y: number; width: number; height: number }
+
+/** Where a freshly detached pet lands: bottom-right of the work area, mirroring the in-window
+ *  overlay's default corner. */
+export function defaultPetWindowPosition(
+  workArea: PetWindowWorkArea,
+  windowSize: number
+): PetWindowPosition {
+  return {
+    x: Math.round(workArea.x + Math.max(0, workArea.width - windowSize - 48)),
+    y: Math.round(workArea.y + Math.max(0, workArea.height - windowSize - 24))
+  }
+}


### PR DESCRIPTION
## ELI5

Today the pet is drawn *inside* the Orca window, like a sticker on the glass. Put another app in front and the pet disappears behind it; minimize Orca and the pet minimizes too. This PR adds a "Keep pet on desktop" switch. Flip it and the pet hops out into its own tiny see-through window that floats above everything, so it keeps running around while you work in your editor — and you can drag it anywhere on any monitor. Flip it back and it hops into the Orca window again.

## What Changed

**New**

- `src/renderer/pet.html` + `src/renderer/src/pet.tsx` — a third renderer entry (alongside `index` and `popout`) with its own React root.
- `src/main/window/desktop-pet-window.ts` — a frameless, transparent, always-on-top `BrowserWindow` sized to the pet. Singleton, own session partition, deny-all permissions, privileged-navigation policy — same hardening as the dashboard pop-out.
- `src/main/ipc/desktop-pet.ts` — opens/closes the window off persisted UI state, and relays the pet's animation from the main renderer.
- `src/renderer/src/components/pet/DesktopPetRoot.tsx` — the pet window's root.
- `src/shared/pet-window-geometry.ts` — window sizing and the default corner.

**Changed**

- Status-bar pet menu gains **Keep pet on desktop** / **Dock pet in Orca window**.
- `shouldRenderPetOverlay` now yields when detached, so the pet is never drawn twice.
- `usePetPointerInteraction` gained a `'screen'` coordinate space and accepts a lazy origin getter.
- `pet-agent-state.ts` splits into `selectPetAgentAnimation` (agent-driven) and `applyPetPointerAnimation` (drag/hover), with `selectPetAnimationName` composing them as before.

**Refactor, no behavior change**

- `SpriteFrame` / `DetectedSpriteFrame` moved out of `PetOverlay.tsx` into `pet-sprite-frames.tsx`; the bob-float + grab wrapper into `PetCharacter.tsx`. Both surfaces render the same `PetCharacter`, so animations, sizing, reduced-motion, and the shrink-wrapped hit area stay in one place. `PetOverlay.tsx` drops from 444 to ~200 lines.
- `clampPetSize` moved from the renderer ui slice to `shared/pet-types` so main can size the window from the same rule.

### How the pieces talk

Only the main renderer knows agent state, so it derives the agent half of the animation and publishes it; main caches and relays it to the pet window. This mirrors the dashboard pop-out's existing snapshot relay rather than inventing a second pattern. The pet window layers its own drag/hover states locally, so grabbing it still plays the running-left/right rows.

- `desktopPet:publishAnimation` — main renderer → main (trusted-sender checked).
- `desktopPet:requestAnimation` — pet window → main on mount; replays the cache, then nudges the main renderer to republish.
- `desktopPet:move` / `desktopPet:setInteractive` — pet window → main (pet-sender checked).

Pet selection, size, and custom pets need no new channel: main already broadcasts `ui:stateChanged` to every window, so the pet window hydrates through the existing `hydratePersistedUI` and `usePetUrl` resolves the same pet, custom `.codex-pet` bundles included.

### Notable details

- **Dragging moves the OS window.** Because the window moves under the cursor, client coordinates cancel out to zero delta — hence the `screen` coordinate space. The origin is read through a getter so a window moved since the last drag doesn't make the next grab jump.
- **Click-through.** The window is a square around a non-square sprite, so its transparent corners would swallow clicks. The renderer hit-tests the sprite's own shrink-wrapped box on `mousemove` and toggles `setIgnoreMouseEvents(…, { forward: true })`. A drag holds the mouse even if the pointer outruns the window.
- **`focusable: false`.** Patting the pet must not steal focus from the terminal you were typing in.
- **Position persistence.** `petWindowPosition` is main-owned (added to `MainOwnedUIState`, so the schema-parity guard stays honest). Restore and every drag are validated against the attached displays, so an unplugged monitor can't strand the pet somewhere unreachable.
- **Lifecycle.** The window closes with the main window — an orphan would block the `window-all-closed` quit on Windows/Linux. A tray minimize only *hides* the main window, so the pet survives that, which is the case this feature is for.
- **`alwaysOnTop(true, 'screen-saver')`** + `setVisibleOnAllWorkspaces(…, { visibleOnFullScreen: true })` so it floats over full-screen apps on macOS.

## Why

The pet's whole lifecycle was the main window's, because it was a `position: fixed` node in the main window's React tree. That is exactly backwards for a mascot whose job is to show you what your agents are doing *while you are working somewhere else* — the moment you switch to your editor, the thing reporting agent status is hidden behind it.

A separate `BrowserWindow` is the only way to leave the parent window's bounds and z-order in Electron, and the repo already has the pattern (`dashboard-popout-window.ts`) for a second top-level window that shares the preload and `window.api`. This follows it rather than inventing a parallel one.

It is behind the existing `experimentalPet` flag and off by default: `petDetached` defaults false, so nothing changes for anyone who doesn't flip the switch.

## Linked Issue

Fixes #16982

## Visual Proof

**Not attached — and I want to be upfront about that.** I could not launch the app on my machine: `node-pty` fails to build (no MSVC toolchain), so the main process won't start. Everything below was verified by unit tests and a full production build, not by watching it run.

A reviewer who can run the app should check, in order:

1. Enable `experimentalPet`, open the pet menu, click **Keep pet on desktop** → in-window pet disappears, desktop pet appears bottom-right.
2. Put another app in front, then minimize Orca → pet stays visible and keeps animating.
3. Start an agent → pet switches to `running`; let it ask a question → `waiting`; finish → `review`.
4. Drag the pet across to a second monitor, quit, relaunch → it comes back where you left it.
5. Click *just outside* the sprite but inside its square → the click should land on the window behind.
6. **Dock pet in Orca window** → desktop window closes, in-window overlay returns.

## Testing

- [x] Automated tests added
- [ ] I manually tested these changes locally — **no.** See Visual Proof; I could not run the app.

**Added** (39 new assertions):

| File | Covers |
| --- | --- |
| `src/main/ipc/desktop-pet.test.ts` | toggle→open/close, experiment-off closes, sender authorization on all four channels, animation validation, replay-on-mount, cache cleared on close |
| `src/main/window/desktop-pet-window.test.ts` | window flags, sizing from `petSize`, live resize, singleton reveal, position restore + off-screen rejection, drag persistence, off-screen drag refusal, click-through toggle, close/reopen |
| `src/renderer/src/components/pet/DesktopPetRoot.test.tsx` | mount handshake, UI-state mirroring, click-through starts off, hit test on/off, drag → absolute window move |
| `src/renderer/src/components/pet/DesktopPetAnimationPublisher.test.tsx` | publishes the agent half only; republishes on request even when unchanged |
| `src/renderer/src/components/pet/usePetPointerInteraction.screen-space.test.ts` | screen-space tracking, direction hysteresis, lazy origin re-read |
| `src/shared/pet-window-geometry.test.ts` | margin, `PET_SIZE_MAX` cap, integer bounds, default corner |

The `DesktopPetRoot` click-through test caught a real bug while I was writing it: the interactive-state ref was seeded `false`, which deduped away the mount-time "stop taking the mouse" call and left the pet's transparent corners eating clicks forever. Fixed and pinned by that test.

**Ran locally (Windows 11, Node 24):**

- `pnpm tc` — clean.
- `oxlint` (default, `--type-aware`, and React Doctor configs) — clean.
- `pnpm run build:electron-vite` — clean; `out/renderer/pet.html` emits with its chunk graph.
- `pnpm run check:reliability-gates`, `check:max-lines-ratchet`, `check:runtime-electron-ratchet` — pass.
- `pnpm run verify:localization-catalog` / `-extraction` / `-coverage` — pass (2 new `en.json` keys via `sync:localization-catalog`).
- `vitest run` over the pet, window, IPC, store, and app-shell suites — **312 files / 2991 tests pass.**

Two failures in `src/main/runtime/rpc/methods/ai-vault.test.ts` are pre-existing and unrelated (POSIX path separators asserted on a Windows checkout: `expected ['\runtime\codex\home\sessions'] to include '/runtime/codex/home/sessions'`).

`pnpm test` itself could not run — its `ensure-native-runtime` step rebuilds `node-pty`, which needs MSVC. I ran `vitest` directly instead.

## Author

X: [@janjonghwa](https://x.com/janjonghwa)

## AI Disclosure

Written with Claude Code (Opus 5), reviewed and directed by me.

## Review

Self-review against the areas CONTRIBUTING asks about:

- **Cross-platform.** No `process.platform` branches were needed. `alwaysOnTop('screen-saver')` and `visibleOnFullScreen` are the macOS-correct spelling and are harmless elsewhere. `focusable: false` implies `skipTaskbar` on Windows (also set explicitly). Paths use `join`. **Untested on macOS and Linux** — the one thing I'd most want a reviewer on a Mac to confirm is that a `focusable: false` transparent window still receives mouse events there, and on Linux that the compositor honors `transparent: true` (a WM without a compositor will paint the window black; that's the known Electron limitation, not something this PR can work around).
- **SSH / remote.** Nothing here touches execution. The pet consumes agent status the main renderer has already derived, wherever those agents run; local and SSH panes reach it identically.
- **Mobile / web.** Untouched. The new entry is Electron-only and not in `vite.web.config.ts`.
- **Backwards compatibility.** Two new optional `PersistedUIState` keys, both absent-means-off. `petDetached` goes through the strict client `ui.set` schema; `petWindowPosition` is main-owned and declared as such, so the parity assertion stays meaningful. Old clients paired with a new host see fields they ignore. No new stream opcodes.
- **Security.** New IPC handlers all check the sender (`isTrustedUIRenderer` for publishes, `isDesktopPetRenderer` for pet-originated calls) and validate payloads (`isPetAgentAnimation`, `isPetWindowPosition`, `typeof === 'boolean'`) before acting. The window gets `sandbox: true`, `webviewTag: false`, an isolated partition, deny-all permission handlers, and the privileged-navigation policy — matching the dashboard pop-out. The relayed payload is one enum string.
- **Performance.** One extra renderer process, only while detached. The relay publishes on animation *change* (deduped by a ref), so a busy agent status stream does not become IPC chatter. `backgroundThrottling: false` is deliberate — the pet's whole purpose is animating while unfocused; the cost is one small always-animating window, which the existing reduced-motion and `visibilitychange` handling still gates.
- **UI quality.** The detached pet renders through the same `PetCharacter` as the in-window one, so sizing, sprite-sheet playback, per-frame durations, bob float, reduced-motion, and the shrink-wrapped grab area are shared rather than duplicated — they cannot drift apart. No new colors, fonts, or shadow tiers.

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation involved.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached — **no**, see Visual Proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Lint, typecheck, build, and the relevant test suites pass locally (see Testing for the two exceptions and why)
