### PR TITLE
fix(agent-status): lift the closed-tab blackhole when a retracted tab comes back (STA-5679)

### DIFF
--- a/src/main/agent-hooks/server-closed-tab-suppression.test.ts
+++ b/src/main/agent-hooks/server-closed-tab-suppression.test.ts
@@ -743,3 +743,76 @@ describe('AgentHookServer closed-tab suppression bound', () => {
     expect(internals.closedAgentStatusTabIds.has(`closed-tab-${total - 1}`)).toBe(true)
   })
 })
+
+describe('closed-tab lift for a republished tab (STA-5679)', () => {
+  it('suppresses before the lift and accepts after it', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      const listener = vi.fn()
+      server.setListener(listener)
+
+      server.dropStatusEntriesByTabPrefix('tab-1')
+
+      // Control arm: proves the tab really is blackholed, so the accept below is a behavioral
+      // difference rather than a vacuous pass.
+      listener.mockClear()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          payload: { state: 'working', prompt: 'while suppressed', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+      expect(listener).not.toHaveBeenCalled()
+
+      // The renderer saw this mirrored id republished, so the tab is provably alive again.
+      server.liftClosedAgentStatusTabs(['tab-1'])
+
+      listener.mockClear()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          payload: { state: 'working', prompt: 'after lift', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+      expect(listener).toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('lifts only the named tabs', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      const listener = vi.fn()
+      server.setListener(listener)
+      server.dropStatusEntriesByTabPrefix('tab-1')
+      server.dropStatusEntriesByTabPrefix('tab-2')
+
+      server.liftClosedAgentStatusTabs(['tab-1'])
+
+      listener.mockClear()
+      server.ingestRemote(
+        {
+          paneKey: makePaneKey('tab-2', LEAF_2),
+          tabId: 'tab-2',
+          worktreeId: 'wt-1',
+          payload: { state: 'working', prompt: 'still closed', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+      expect(listener).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -2892,6 +2892,19 @@ export class AgentHookServer {
     return existing
   }
 
+  /**
+   * Lift the closed-tab suppression for tab ids the renderer has proven alive again (a mirrored
+   * id republished in a snapshot). The pane-key set below has a new-turn revive path; this set had
+   * none, so a tab retracted by a transient/subset frame stayed suppressed in `getAgentStatusDisposition`
+   * for the whole session — upstream of the renderer, so the renderer's own marker lift could not
+   * reach it, and every later hook 204'd into nothing (STA-5679).
+   */
+  liftClosedAgentStatusTabs(tabIds: readonly string[]): void {
+    for (const tabId of tabIds) {
+      this.closedAgentStatusTabIds.delete(tabId)
+    }
+  }
+
   dropStatusEntriesByTabPrefix(tabId: string): void {
     this.markTabClosedForAgentStatus(tabId)
     const paneKeysToClear = new Set<string>()

--- a/src/main/ipc/agent-hooks.test.ts
+++ b/src/main/ipc/agent-hooks.test.ts
@@ -9,6 +9,7 @@ import { makePaneKey } from '../../shared/stable-pane-id'
 
 const dropStatusEntry = vi.fn()
 const dropStatusEntriesByTabPrefix = vi.fn()
+const liftClosedAgentStatusTabs = vi.fn()
 const retirePaneAuthority = vi.fn()
 const transferPaneAuthority = vi.fn()
 const canTransferPaneAuthority = vi.fn(() => true)
@@ -45,6 +46,7 @@ vi.mock('../agent-hooks/server', async () => {
     agentHookServer: {
       dropStatusEntry,
       dropStatusEntriesByTabPrefix,
+      liftClosedAgentStatusTabs,
       retirePaneAuthority,
       transferPaneAuthority,
       canTransferPaneAuthority,
@@ -106,6 +108,7 @@ vi.mock('../kimi/hook-service', () => ({
 beforeEach(() => {
   dropStatusEntry.mockReset()
   dropStatusEntriesByTabPrefix.mockReset()
+  liftClosedAgentStatusTabs.mockReset()
   retirePaneAuthority.mockReset()
   transferPaneAuthority.mockReset()
   canTransferPaneAuthority.mockReset()
@@ -386,6 +389,65 @@ describe('agentStatus:dropByTabPrefix IPC', () => {
     registerAgentHookHandlers()
 
     expect(removeAllListeners).toHaveBeenCalledWith('agentStatus:dropByTabPrefix')
+  })
+})
+
+describe('agentStatus:liftClosedTabs IPC', () => {
+  it('forwards validated tab ids so a returning tab stops being suppressed', async () => {
+    const { registerAgentHookHandlers } = await import('./agent-hooks')
+    registerAgentHookHandlers()
+
+    const handler = onHandlers.get('agentStatus:liftClosedTabs')
+    expect(handler).toBeDefined()
+    handler!({}, ['tab-1', 'tab-2'])
+
+    expect(liftClosedAgentStatusTabs).toHaveBeenCalledWith(['tab-1', 'tab-2'])
+  })
+
+  it('ignores a payload that is not an array', async () => {
+    const { registerAgentHookHandlers } = await import('./agent-hooks')
+    registerAgentHookHandlers()
+
+    const handler = onHandlers.get('agentStatus:liftClosedTabs')!
+    for (const value of ['tab-1', 123, undefined, null, {}] as unknown[]) {
+      expect(() => handler({}, value)).not.toThrow()
+    }
+
+    expect(liftClosedAgentStatusTabs).not.toHaveBeenCalled()
+  })
+
+  it('filters malformed ids out of an otherwise valid array', async () => {
+    const { registerAgentHookHandlers } = await import('./agent-hooks')
+    registerAgentHookHandlers()
+
+    onHandlers.get('agentStatus:liftClosedTabs')!({}, [
+      'tab-1',
+      123,
+      null,
+      'tab-1:leaf',
+      ' leading-space',
+      'x'.repeat(161)
+    ])
+
+    // Why assert the exact argument: a filter that let a malformed id through would still
+    // "have been called", so only the forwarded value proves the boundary held.
+    expect(liftClosedAgentStatusTabs).toHaveBeenCalledWith(['tab-1'])
+  })
+
+  it('skips the server entirely when every id is rejected', async () => {
+    const { registerAgentHookHandlers } = await import('./agent-hooks')
+    registerAgentHookHandlers()
+
+    onHandlers.get('agentStatus:liftClosedTabs')!({}, ['', 'tab-1:leaf', 'x'.repeat(161)])
+
+    expect(liftClosedAgentStatusTabs).not.toHaveBeenCalled()
+  })
+
+  it('removes any existing listener before registering the lift channel', async () => {
+    const { registerAgentHookHandlers } = await import('./agent-hooks')
+    registerAgentHookHandlers()
+
+    expect(removeAllListeners).toHaveBeenCalledWith('agentStatus:liftClosedTabs')
   })
 })
 

--- a/src/main/ipc/agent-status-row-teardown-ipc.ts
+++ b/src/main/ipc/agent-status-row-teardown-ipc.ts
@@ -16,6 +16,7 @@ import { isValidAgentStatusDropTabId } from './agent-status-ipc-boundary'
  * the pane's next event straight back to `working`.
  */
 export function registerAgentStatusRowTeardownIpcHandlers(): void {
+  ipcMain.removeAllListeners('agentStatus:liftClosedTabs')
   ipcMain.removeAllListeners('agentStatus:drop')
   ipcMain.removeAllListeners('agentStatus:reconcileEndedProcess')
   ipcMain.removeAllListeners('agentStatus:dropByTabPrefix')
@@ -52,6 +53,25 @@ export function registerAgentStatusRowTeardownIpcHandlers(): void {
       clearMigrationUnsupportedPtysForPaneKey(paneKey)
     } catch (err) {
       console.warn('[agent-hooks] reconcileEndedProcessForPaneKeys failed:', err)
+    }
+  })
+
+  // Why: the drop above marks the tab closed with no expiry, and the main-side gate checks that
+  // set before anything else — so a tab retracted by a transient snapshot frame and then
+  // republished stayed blackholed for the session. The renderer already lifts its own marker on
+  // re-mirror; this is the other half of that lift (STA-5679).
+  ipcMain.on('agentStatus:liftClosedTabs', (_event, tabIds: unknown) => {
+    if (!Array.isArray(tabIds)) {
+      return
+    }
+    const valid = tabIds.filter((tabId): tabId is string => isValidAgentStatusDropTabId(tabId))
+    if (valid.length === 0) {
+      return
+    }
+    try {
+      agentHookServer.liftClosedAgentStatusTabs(valid)
+    } catch (err) {
+      console.warn('[agent-hooks] liftClosedAgentStatusTabs failed:', err)
     }
   })
 

--- a/src/preload/api/agent-status-api.ts
+++ b/src/preload/api/agent-status-api.ts
@@ -35,6 +35,7 @@ export type AgentStatusApi = {
   reconcileEndedProcess: (paneKey: string) => void
   /** Drop every cached hook status under one terminal tab prefix. Fire-and-forget. */
   dropByTabPrefix: (tabId: string) => void
+  liftClosedTabs: (tabIds: string[]) => void
   /** Permanently retire one pane's hook authority while siblings stay live. */
   retirePaneAuthority: (paneKey: string) => void
   /** Lift one pane's retirement fence when a live PTY re-attaches to it. Closed tabs stay retired. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5158,6 +5158,9 @@ const api = {
     dropByTabPrefix: (tabId: string): void => {
       ipcRenderer.send('agentStatus:dropByTabPrefix', tabId)
     },
+    liftClosedTabs: (tabIds: string[]): void => {
+      ipcRenderer.send('agentStatus:liftClosedTabs', tabIds)
+    },
     retirePaneAuthority: (paneKey: string): void => {
       ipcRenderer.send('agentStatus:retirePaneAuthority', paneKey)
     },

--- a/src/renderer/src/runtime/web-session-tabs-sync-host-tab-retraction-ghost-rows.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-host-tab-retraction-ghost-rows.test.ts
@@ -273,16 +273,23 @@ function observeSidebar(store: TestStore, now: number): SidebarObservation {
   }
 }
 
+const liftClosedTabs = vi.fn()
+
 describe('a host-retracted paired tab leaves no ghost agent row behind', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(T0)
     resetWebSessionTabsSnapshotFreshnessForTests()
     resetRendererOwnedAgentStatusPanesForTests()
+    liftClosedTabs.mockClear()
+    // Why stub the bridge: lifting only the renderer marker leaves the tab suppressed in the
+    // main-process closed-tab set, which gates every hook event upstream of the renderer.
+    vi.stubGlobal('window', { ...globalThis.window, api: { agentStatus: { liftClosedTabs } } })
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.unstubAllGlobals()
     resetRendererOwnedAgentStatusPanesForTests()
   })
 
@@ -591,6 +598,10 @@ describe('a host-retracted paired tab leaves no ghost agent row behind', () => {
       store.getState().recentlyClosedAgentStatusTabIds[mirrorTabId(RETRACTED_TAB)],
       'a re-mirrored tab id kept its closed-tab marker'
     ).toBeUndefined()
+    expect(
+      liftClosedTabs.mock.calls.flatMap(([tabIds]) => tabIds as string[]),
+      'the renderer lifted its own marker but left the tab suppressed in the main process'
+    ).toContain(mirrorTabId(RETRACTED_TAB))
 
     // The returning pane's byte-derived status must land again.
     const release2 = replayClientByteStatus(

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1302,15 +1302,17 @@ function updateBatchAgentPaneKey(
 function buildRemirroredClosedTabMarkerLiftPatch(
   recentlyClosedAgentStatusTabIds: WebSessionTabsSyncState['recentlyClosedAgentStatusTabIds'],
   mirroredTerminalIds: ReadonlySet<string>
-): Partial<WebSessionTabsSyncState> | null {
+): { patch: Partial<WebSessionTabsSyncState>; liftedTabIds: string[] } | null {
   let next: WebSessionTabsSyncState['recentlyClosedAgentStatusTabIds'] | null = null
+  const liftedTabIds: string[] = []
   for (const tabId of mirroredTerminalIds) {
     if (tabId in (recentlyClosedAgentStatusTabIds ?? {})) {
       next ??= { ...recentlyClosedAgentStatusTabIds }
       delete next[tabId]
+      liftedTabIds.push(tabId)
     }
   }
-  return next ? { recentlyClosedAgentStatusTabIds: next } : null
+  return next ? { patch: { recentlyClosedAgentStatusTabIds: next }, liftedTabIds } : null
 }
 
 /**
@@ -3794,11 +3796,17 @@ function applyWebSessionTabsSnapshotWithContext(
   // a lingering closed-tab marker would blackhole its byte-derived status for the whole
   // session (host-restart subset frames, cross-host collision replays). The close-intent
   // filter already holds genuinely closing tabs out of the snapshot.
-  const remirroredClosedTabLiftPatch = buildRemirroredClosedTabMarkerLiftPatch(
+  const remirroredClosedTabLift = buildRemirroredClosedTabMarkerLiftPatch(
     retractedTabSweepPatch?.recentlyClosedAgentStatusTabIds ??
       state.recentlyClosedAgentStatusTabIds,
     mirroredTerminalIds
   )
+  const remirroredClosedTabLiftPatch = remirroredClosedTabLift?.patch ?? null
+  // Why: main's closed-tab set gates every hook event and had no expiry or revive path, so lifting
+  // only the renderer marker left the tab blackholed upstream of the renderer entirely (STA-5679).
+  if (remirroredClosedTabLift && typeof window !== 'undefined') {
+    window.api?.agentStatus?.liftClosedTabs?.(remirroredClosedTabLift.liftedTabIds)
+  }
 
   const patch: Partial<WebSessionTabsSyncState> = {
     ...agentStatusPatch,

--- a/src/renderer/src/web/preload-api/web-agent-status-api.ts
+++ b/src/renderer/src/web/preload-api/web-agent-status-api.ts
@@ -16,6 +16,7 @@ export function createWebAgentStatusApi(): Partial<PreloadApi> {
       drop: () => {},
       reconcileEndedProcess: () => {},
       dropByTabPrefix: () => {},
+      liftClosedTabs: () => {},
       retirePaneAuthority: () => {},
       restorePaneAuthority: () => {},
       transferPaneAuthority: () => {}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 |

<!-- /orca-pr-loc -->

## ELI5

When you close a terminal tab, Orca stops accepting agent-status updates for it. Sensible — except
Orca could believe a tab was closed when it wasn't. A host restart, or a refresh that only carries
part of the picture, can briefly retract a tab that is still sitting there with an agent working in
it. Once that happened, the tab was on the "closed" list for the **rest of the session** with no way
off it. Every status update for it was accepted and thrown away, silently, so the tab showed no agent
status at all and nothing anywhere reported a problem. Restarting Orca was the only cure.

Even starting a brand-new turn in that tab — the strongest possible "I am alive" signal there is —
did not bring it back.

## User-facing before / after

| | Before | After |
|---|---|---|
| A host restart or a partial refresh briefly retracts a tab that is still open, with an agent working in it | That tab's agent status went dark for the rest of the session — no working indicator, no completion, nothing. A new turn didn't revive it | The status comes back once Orca has confirmed the tab really is still there |
| A tab you genuinely closed | Its status stays suppressed | Unchanged |
| Noticing it was happening | Nothing surfaced it — the updates were accepted and quietly discarded, so it looked like the agent had simply stopped reporting | The condition clears itself, so there is nothing left to notice |

## When it bites

Anyone whose Orca host restarts, or replays a partial snapshot, while agents are working. The symptom
is a tab whose agent status stops updating and never recovers until you restart the app.


## The bug

`getAgentStatusDisposition` suppresses every hook event whose tab id is in `closedAgentStatusTabIds` (`server.ts:1185`), and that check runs **first** — ahead of the pane-key gate and ahead of any new-turn revive.

Unlike `closedAgentStatusPaneKeys`, which a `UserPromptSubmit`/`SessionStart` lifts a few lines below, the tab set is **add-only**. Only a 1024-entry LRU eviction or a full server reset ever clears it.

So a tab retracted by a transient or subset snapshot frame — a host restart, a cross-host collision replay — is blackholed for the rest of the session **even though it is still open and its agent is still working**. The POSTs keep returning `204`, so nothing reports a problem anywhere.

## Reproduced on a live pane

Real hook events over the real HTTP path, against a tab confirmed still present in `tabsByWorktree`:

| step | result |
|---|---|
| hook on a live, never-closed tab | row appears — `claude / working` |
| retract that still-open tab | row cleared |
| `UserPromptSubmit` | `204`, **no row** |
| `SessionStart` | `204`, **no row** |
| `PreToolUse` | `204`, **no row** |

`UserPromptSubmit` and `SessionStart` are the strongest revive signals in the system. The tab-level set ignores all of them.

## The fix

The renderer already recognized this hazard and fixed **its** half — `buildRemirroredClosedTabMarkerLiftPatch`, commented:

> *"a lingering closed-tab marker would blackhole its byte-derived status for the whole session (host-restart subset frames, cross-host collision replays)"*

But main's set is checked upstream of the renderer, so lifting only the renderer marker could never reach it. This adds the other half: `liftClosedAgentStatusTabs()` behind an `agentStatus:liftClosedTabs` IPC, called with exactly the ids the renderer just proved alive.

This does **not** weaken the existing `re-attach does not lift a closed-tab tombstone` rule — a re-attach is an inference about a pane, whereas a republished mirrored id is the host reporting that the tab exists.

## Tests

Two in `server-closed-tab-suppression.test.ts`, verified **non-vacuous**: stubbing the lift to a no-op fails with `expected "vi.fn()" to be called at least once`. The first test also asserts the suppressed state *before* lifting, so it cannot pass by accident. Second test pins that only the named tabs lift. 22/22 pass; `tc:node`, `tc:web`, oxlint and oxfmt clean.

## Scope

Deliberately narrow. Not touched: the 1024 LRU cap, the launch-token fence, the pane-key revive rules, or the retraction logic that decides a tab is gone in the first place. Whether `web-session-tabs-sync` *should* retract a live tab is a separate question — this makes the consequence recoverable rather than permanent.

