### PR TITLE
fix(release): trust Linux floor workspace

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1005,6 +1005,9 @@ jobs:
         with:
           ref: refs/tags/${{ needs.cut.outputs.tag }}
 
+      - name: Trust the checked-out workspace in the job container
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Restore skill-sharing test harness from the workflow ref
         shell: bash
         env:

--- a/config/scripts/skill-sharing-release-workflow.test.mjs
+++ b/config/scripts/skill-sharing-release-workflow.test.mjs
@@ -51,6 +51,13 @@ describe('skill-sharing release workflow', () => {
     expect(prerequisites.run).toMatch(/apt-get install[^\n]*\bunzip\b/)
   })
 
+  it('trusts only the checked-out workspace before container git operations', () => {
+    const linux = workflow.jobs['skill-sharing-linux-floor-release-gate']
+    const trustWorkspace = stepNamed(linux, 'Trust the checked-out workspace in the job container')
+
+    expect(trustWorkspace.run).toBe('git config --global --add safe.directory "$GITHUB_WORKSPACE"')
+  })
+
   it('validates immutable tags with the current skill-sharing test harness', () => {
     for (const jobName of [
       'skill-sharing-release-gate',

--- a/config/scripts/skill-sharing-release-workflow.test.mjs
+++ b/config/scripts/skill-sharing-release-workflow.test.mjs
@@ -54,8 +54,19 @@ describe('skill-sharing release workflow', () => {
   it('trusts only the checked-out workspace before container git operations', () => {
     const linux = workflow.jobs['skill-sharing-linux-floor-release-gate']
     const trustWorkspace = stepNamed(linux, 'Trust the checked-out workspace in the job container')
+    const restoreHarness = stepNamed(
+      linux,
+      'Restore skill-sharing test harness from the workflow ref'
+    )
+    const safeDirectoryCommands = linux.steps
+      .filter((step) => typeof step.run === 'string' && step.run.includes('safe.directory'))
+      .map((step) => step.run)
 
     expect(trustWorkspace.run).toBe('git config --global --add safe.directory "$GITHUB_WORKSPACE"')
+    expect(linux.steps.indexOf(trustWorkspace)).toBeLessThan(linux.steps.indexOf(restoreHarness))
+    expect(safeDirectoryCommands).toEqual([
+      'git config --global --add safe.directory "$GITHUB_WORKSPACE"'
+    ])
   })
 
   it('validates immutable tags with the current skill-sharing test harness', () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## Summary

- trust only the checked-out workspace inside the Ubuntu 20.04 release-gate container
- preserve the immutable-tag test-harness overlay
- ratchet the behavior with a workflow contract test

## Why

Production recovery run 33153364729 failed before tests because Git 2.25 rejected the container-mounted checkout as dubious ownership. The release remained draft and unpublished.

## Validation

- `pnpm test config/scripts/release-e2e-dispatch-contract.test.mjs config/scripts/skill-sharing-release-workflow.test.mjs` (12/12)
- `pnpm run check:code-quality:changed` (zero findings)
- `git diff --check`

## Release safety

This changes only the release harness. It does not modify the immutable `v1.4.191` tag or product/build source. The trust scope is exactly `$GITHUB_WORKSPACE`, not a wildcard.

## Visual proof

N/A — CI workflow-only change.

## AI disclosure

Implemented with Codex assistance and validated with focused automated checks.