### PR TITLE
fix(relay): don't re-run an agent resume against a relay that never held the terminal (STA-5698)

### DIFF
--- a/src/main/ipc/pty/ipc/spawn-commit.ts
+++ b/src/main/ipc/pty/ipc/spawn-commit.ts
@@ -130,7 +130,7 @@ export async function commitPtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<PtySpawn
       typeof ctx.launchCommand === 'string' ? ctx.launchCommand : null
     )
   }
-  if (ctx.isClaudeLaunch && !ctx.stablePaneOwner) {
+  if (ctx.isClaudeLaunch && !ctx.stablePaneOwner && !ctx.result.agentResumeUnavailable) {
     markClaudePtySpawned(ctx.result.id)
   }
   // Why: record the paneKey mapping so clearProviderPtyState can clear the agent-hooks server's per-paneKey caches on exit.
@@ -179,7 +179,8 @@ export async function commitPtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<PtySpawn
     })
   }
   // Why: telemetry-plan.md§Agent launch semantics — fire agent_started only after spawn resolved; safeParse each field so a spoofed IPC payload can't poison the event (missing required field skips it).
-  if (args.telemetry && !ctx.stablePaneOwner) {
+  // Why: a suppressed resume produced a plain shell, so there is no agent launch to report.
+  if (args.telemetry && !ctx.stablePaneOwner && !ctx.result.agentResumeUnavailable) {
     const agentKindParse = agentKindSchema.safeParse(args.telemetry.agent_kind)
     const launchSourceParse = launchSourceSchema.safeParse(args.telemetry.launch_source)
     const requestKindParse = requestKindSchema.safeParse(args.telemetry.request_kind)

--- a/src/main/ipc/pty/pane/relay-replacement-resume-suppression.ts
+++ b/src/main/ipc/pty/pane/relay-replacement-resume-suppression.ts
@@ -1,0 +1,145 @@
+import type { Store } from '../../../persistence'
+import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../../../providers/types'
+import { parseAppSshPtyId, toRelaySshPtyId } from '../../../providers/ssh-pty-id'
+
+/** Bounded so a slow relay leaves the fallback spawn on today's timing, not blocked behind a probe. */
+export const RELAY_AGE_STATUS_TIMEOUT_MS = 2_000
+
+/**
+ * Slack between two independently measured elapsed times — the client's clock over the binding and
+ * the host's own uptime counter. Both are durations, so no clock-offset correction is possible or
+ * needed; this only absorbs jitter and the gap between daemon start and the first binding write.
+ */
+export const RELAY_AGE_CLOCK_SLACK_MS = 30_000
+
+/**
+ * Startup intent replayed by the absence fallback. Mirrors the set `attachStablePaneOwner` already
+ * strips for an attach: everything that would run an agent, a resume argv, or a claim in the shell.
+ */
+export function stripStartupIntent(options: PtySpawnOptions): PtySpawnOptions {
+  return {
+    ...options,
+    command: undefined,
+    commandDelivery: undefined,
+    startupCommandDelivery: undefined,
+    launchAgent: undefined,
+    startupIngress: undefined,
+    agentSessionEnsure: undefined,
+    agentSessionCreateOperationId: undefined
+  }
+}
+
+export function carriesStartupIntent(options: PtySpawnOptions): boolean {
+  return Boolean(
+    options.command ||
+    options.launchAgent ||
+    options.startupIngress ||
+    options.agentSessionEnsure ||
+    options.agentSessionCreateOperationId
+  )
+}
+
+/** Age of the lease that recorded this SSH binding, or null when nothing dates it. */
+function bindingAgeMs(
+  store: Store | undefined,
+  connectionId: string,
+  ptyId: string,
+  now: number
+): number | null {
+  if (!store || typeof store.getSshRemotePtyLeases !== 'function') {
+    return null
+  }
+  const parsed = parseAppSshPtyId(ptyId)
+  if (!parsed || parsed.connectionId !== connectionId) {
+    return null
+  }
+  let createdAt: number | null = null
+  for (const lease of store.getSshRemotePtyLeases(connectionId)) {
+    if (
+      toRelaySshPtyId(connectionId, lease.ptyId) !== parsed.relayPtyId ||
+      typeof lease.createdAt !== 'number' ||
+      !Number.isFinite(lease.createdAt)
+    ) {
+      continue
+    }
+    createdAt = createdAt === null ? lease.createdAt : Math.min(createdAt, lease.createdAt)
+  }
+  if (createdAt === null) {
+    return null
+  }
+  const age = now - createdAt
+  return Number.isFinite(age) && age > 0 ? age : null
+}
+
+/**
+ * Does the relay that just answered "that PTY is absent" predate the binding it answered about?
+ *
+ * A daemon whose reported uptime is shorter than the binding's age cannot have owned the bound
+ * process, so its positive absence is `unverifiable` rather than `exited`
+ * (docs/reference/ssh-execution-boundary.md) — the shell it named may still be alive as an orphan
+ * of the daemon it replaced. Only an answer that ARRIVES and is demonstrably younger says so:
+ * a missing provider, a rejected or timed-out `relay.status`, an absent or unusable `uptimeMs`,
+ * and an undatable binding all return false, leaving the caller on today's behavior. Silence is
+ * never promoted to a verdict here.
+ *
+ * Reads only fields `relay.status` already publishes; adds no request field and no opcode.
+ */
+export async function answeringRelayPredatesBinding(args: {
+  provider: IPtyProvider
+  store?: Store | undefined
+  connectionId?: string | null
+  ptyId: string
+  now?: () => number
+}): Promise<boolean> {
+  const { provider, connectionId, ptyId } = args
+  if (!connectionId) {
+    return false
+  }
+  const age = bindingAgeMs(args.store, connectionId, ptyId, (args.now ?? Date.now)())
+  if (age === null) {
+    return false
+  }
+  let status: unknown
+  try {
+    // Optional call: a provider with no host RPC yields undefined, which is not an answer.
+    status = await provider.requestHostRpc?.(
+      'relay.status',
+      {},
+      {
+        timeoutMs: RELAY_AGE_STATUS_TIMEOUT_MS
+      }
+    )
+  } catch {
+    return false
+  }
+  if (!status || typeof status !== 'object') {
+    return false
+  }
+  const uptimeMs = (status as { uptimeMs?: unknown }).uptimeMs
+  if (typeof uptimeMs !== 'number' || !Number.isFinite(uptimeMs) || uptimeMs < 0) {
+    return false
+  }
+  return age > uptimeMs + RELAY_AGE_CLOCK_SLACK_MS
+}
+
+/**
+ * The absence fallback's spawn, minus the startup intent a replacement relay never held.
+ *
+ * Returns null whenever nothing proves a replacement, leaving the caller on its unchanged path —
+ * the spawn itself is never gated here, only the intent replayed into it.
+ */
+export async function spawnWithoutReplayedIntent(args: {
+  provider: IPtyProvider
+  store?: Store | undefined
+  connectionId?: string | null
+  ptyId: string
+  spawnOptions: PtySpawnOptions
+  onFreshSpawn?: (result: PtySpawnResult) => void
+}): Promise<PtySpawnResult | null> {
+  if (!carriesStartupIntent(args.spawnOptions) || !(await answeringRelayPredatesBinding(args))) {
+    return null
+  }
+  const result = await args.provider.spawn(stripStartupIntent(args.spawnOptions))
+  args.onFreshSpawn?.(result)
+  return { ...result, agentResumeUnavailable: true as const }
+}

--- a/src/main/ipc/pty/pane/stable-owner.ts
+++ b/src/main/ipc/pty/pane/stable-owner.ts
@@ -12,6 +12,8 @@ import {
 } from '../../../daemon/daemon-errors'
 import { ptyIncarnationById, ptyOwnership } from '../provider/ownership-state'
 import { isPtyAlreadyGoneError } from '../provider/liveness'
+import { isSshPtyAbsentFromRelayError } from '../../../providers/ssh-pty-errors'
+import { spawnWithoutReplayedIntent } from './relay-replacement-resume-suppression'
 import { clearProviderPtyState } from '../provider/state-cleanup'
 
 export type StablePaneOwner = {
@@ -166,6 +168,8 @@ export type StablePaneSpawnContext = {
   connectionId?: string | null
   resolveOwner?: () => StablePaneOwner | null
   onFreshSpawn?: (result: PtySpawnResult) => void
+  /** Fired when a reachable relay positively answered this exact PTY id absent. */
+  onRelayPositiveAbsence?: () => void
 }
 
 export function stablePanePersistenceFence(
@@ -242,6 +246,9 @@ export async function attachStablePaneOwner(
     if (!isPtyAlreadyGoneError(error)) {
       throw error
     }
+    if (isSshPtyAbsentFromRelayError(error)) {
+      args.onRelayPositiveAbsence?.()
+    }
     const ownerBeforeRetire = args.resolveOwner?.()
     if (
       ownerBeforeRetire &&
@@ -282,9 +289,24 @@ export async function spawnForStablePane(
   args: StablePaneSpawnContext
 ): Promise<{ result: PtySpawnResult; owner: StablePaneOwner | null }> {
   if (args.owner) {
-    const attached = await attachStablePaneOwner({ ...args, owner: args.owner })
+    let relayAnsweredAbsent = false
+    const attached = await attachStablePaneOwner({
+      ...args,
+      owner: args.owner,
+      onRelayPositiveAbsence: () => {
+        relayAnsweredAbsent = true
+      }
+    })
     if (attached) {
       return attached
+    }
+    // Why: the user still needs a terminal, so the spawn itself is never gated — only the startup
+    // intent is, and only when the answering relay proves it never held the binding it answered for.
+    const plain = relayAnsweredAbsent
+      ? await spawnWithoutReplayedIntent({ ...args, ptyId: args.owner.ptyId })
+      : null
+    if (plain) {
+      return { result: plain, owner: null }
     }
   }
   const result = await args.provider.spawn(args.spawnOptions)

--- a/src/main/ipc/pty/pane/stable-pane-relay-age-resume-suppression.test.ts
+++ b/src/main/ipc/pty/pane/stable-pane-relay-age-resume-suppression.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  SSH_SESSION_EXPIRED_ERROR,
+  SshPtyAbsentFromRelayError
+} from '../../../providers/ssh-pty-errors'
+import type { Store } from '../../../persistence'
+import type { IPtyProvider, PtySpawnOptions } from '../../../providers/types'
+import { spawnForStablePane, type StablePaneOwner } from './stable-owner'
+
+const LEAF = '1b3f2c4d-5e6a-4b7c-8d9e-0f1a2b3c4d5e'
+const CONNECTION = 'conn-1'
+const PTY_ID = `ssh:${CONNECTION}@@pty-1`
+const OWNER: StablePaneOwner = {
+  tabId: 'tab-1',
+  leafId: LEAF,
+  ptyId: PTY_ID,
+  hasPersistedBinding: true
+}
+const BINDING_AGE_MS = 2 * 60 * 60_000
+
+/** Only the lease read matters here; the retirement path is covered by the absence-respawn suite. */
+function leaseStore(createdAt: number | undefined): Store {
+  return {
+    getSshRemotePtyLeases: () =>
+      createdAt === undefined
+        ? []
+        : [
+            {
+              targetId: CONNECTION,
+              ptyId: 'pty-1',
+              state: 'detached',
+              createdAt,
+              updatedAt: createdAt
+            }
+          ],
+    getWorkspaceSession: () => ({}) as never,
+    setWorkspaceSession: () => {},
+    flushOrThrow: () => {}
+  } as unknown as Store
+}
+
+function runFallback(options: {
+  spawnOptions: PtySpawnOptions
+  relayStatus: () => Promise<unknown>
+  leaseCreatedAt?: number | undefined
+  now?: number
+}): {
+  run: () => ReturnType<typeof spawnForStablePane>
+  spawn: ReturnType<typeof vi.fn>
+  requestHostRpc: ReturnType<typeof vi.fn>
+} {
+  const now = options.now ?? Date.now()
+  const spawn = vi
+    .fn()
+    .mockRejectedValueOnce(new SshPtyAbsentFromRelayError(`${SSH_SESSION_EXPIRED_ERROR}: pty-1`))
+    .mockResolvedValueOnce({ id: `ssh:${CONNECTION}@@pty-2`, isReattach: false })
+  const requestHostRpc = vi.fn().mockImplementation(() => options.relayStatus())
+  return {
+    spawn,
+    requestHostRpc,
+    run: () =>
+      spawnForStablePane({
+        runtime: undefined,
+        store: leaseStore(
+          'leaseCreatedAt' in options ? options.leaseCreatedAt : now - BINDING_AGE_MS
+        ),
+        provider: { spawn, requestHostRpc } as unknown as IPtyProvider,
+        spawnOptions: options.spawnOptions,
+        owner: OWNER,
+        worktreeId: 'worktree-1',
+        connectionId: CONNECTION,
+        resolveOwner: () => null
+      })
+  }
+}
+
+/** A replacement relay: up 5 minutes against a 2-hour-old binding. */
+const youngerRelay = () => Promise.resolve({ uptimeMs: 5 * 60_000, pid: 4242 })
+/** The relay that could have owned the binding: up 4 hours. */
+const olderRelay = () => Promise.resolve({ uptimeMs: 4 * 60 * 60_000, pid: 4242 })
+
+const RESUME_ARGV: PtySpawnOptions = {
+  cols: 80,
+  rows: 24,
+  command: 'claude --resume abc123',
+  commandDelivery: 'provider'
+}
+const LAUNCH_AGENT: PtySpawnOptions = { cols: 80, rows: 24, launchAgent: 'claude' }
+const BARE_COMMAND: PtySpawnOptions = { cols: 80, rows: 24, command: 'npm run dev' }
+
+describe('absence fallback against a relay younger than the binding', () => {
+  it('spawns a shell but drops a resume argv the replacement relay never held', async () => {
+    const { run, spawn } = runFallback({ spawnOptions: RESUME_ARGV, relayStatus: youngerRelay })
+
+    const { result } = await run()
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(spawn.mock.calls[1]![0]).toMatchObject({
+      command: undefined,
+      commandDelivery: undefined
+    })
+    expect(result.id).toBe(`ssh:${CONNECTION}@@pty-2`)
+    expect(result.agentResumeUnavailable).toBe(true)
+  })
+
+  it('drops launchAgent rather than starting a second agent over the same worktree', async () => {
+    const { run, spawn } = runFallback({ spawnOptions: LAUNCH_AGENT, relayStatus: youngerRelay })
+
+    const { result } = await run()
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(spawn.mock.calls[1]![0]).toMatchObject({ launchAgent: undefined })
+    expect(result.agentResumeUnavailable).toBe(true)
+  })
+
+  it('drops a startup command', async () => {
+    const { run, spawn } = runFallback({ spawnOptions: BARE_COMMAND, relayStatus: youngerRelay })
+
+    const { result } = await run()
+
+    expect(spawn.mock.calls[1]![0]).toMatchObject({ command: undefined })
+    expect(result.agentResumeUnavailable).toBe(true)
+  })
+
+  it('never gates the spawn itself — a shell is always produced', async () => {
+    for (const spawnOptions of [RESUME_ARGV, LAUNCH_AGENT, BARE_COMMAND]) {
+      const { run, spawn } = runFallback({ spawnOptions, relayStatus: youngerRelay })
+
+      const { result } = await run()
+
+      expect(result.id).toBe(`ssh:${CONNECTION}@@pty-2`)
+      expect(spawn).toHaveBeenCalledTimes(2)
+    }
+  })
+})
+
+describe('absence fallback when nothing proves the relay was replaced', () => {
+  it('replays the resume when the answering relay predates the binding', async () => {
+    const { run, spawn } = runFallback({ spawnOptions: RESUME_ARGV, relayStatus: olderRelay })
+
+    const { result } = await run()
+
+    expect(spawn.mock.calls[1]![0]).toMatchObject({ command: 'claude --resume abc123' })
+    expect(result.agentResumeUnavailable).toBeUndefined()
+  })
+
+  it('replays the resume when relay.status rejects — silence is not a verdict', async () => {
+    const { run, spawn } = runFallback({
+      spawnOptions: RESUME_ARGV,
+      relayStatus: () => Promise.reject(new Error('relay status failed'))
+    })
+
+    const { result } = await run()
+
+    expect(spawn.mock.calls[1]![0]).toMatchObject({ command: 'claude --resume abc123' })
+    expect(result.agentResumeUnavailable).toBeUndefined()
+  })
+
+  it('replays the resume when relay.status answers with a non-object', async () => {
+    const { run, spawn } = runFallback({
+      spawnOptions: RESUME_ARGV,
+      relayStatus: () => Promise.resolve(null)
+    })
+
+    const { result } = await run()
+
+    expect(spawn.mock.calls[1]![0]).toMatchObject({ command: 'claude --resume abc123' })
+    expect(result.agentResumeUnavailable).toBeUndefined()
+  })
+
+  it('replays the resume when relay.status omits uptimeMs', async () => {
+    const { run, spawn } = runFallback({
+      spawnOptions: RESUME_ARGV,
+      relayStatus: () => Promise.resolve({ pid: 4242 })
+    })
+
+    const { result } = await run()
+
+    expect(spawn.mock.calls[1]![0]).toMatchObject({ command: 'claude --resume abc123' })
+    expect(result.agentResumeUnavailable).toBeUndefined()
+  })
+
+  it('replays the resume on a cold restore with no lease to date the binding', async () => {
+    const { run, spawn, requestHostRpc } = runFallback({
+      spawnOptions: RESUME_ARGV,
+      relayStatus: youngerRelay,
+      leaseCreatedAt: undefined
+    })
+
+    const { result } = await run()
+
+    expect(requestHostRpc).not.toHaveBeenCalled()
+    expect(spawn.mock.calls[1]![0]).toMatchObject({ command: 'claude --resume abc123' })
+    expect(result.agentResumeUnavailable).toBeUndefined()
+  })
+
+  it('replays the resume when the relay is younger only inside the clock slack', async () => {
+    // Two independently measured elapsed times; a sub-slack gap is jitter, not a replacement.
+    const { run, spawn } = runFallback({
+      spawnOptions: RESUME_ARGV,
+      relayStatus: () => Promise.resolve({ uptimeMs: BINDING_AGE_MS - 10_000 })
+    })
+
+    const { result } = await run()
+
+    expect(spawn.mock.calls[1]![0]).toMatchObject({ command: 'claude --resume abc123' })
+    expect(result.agentResumeUnavailable).toBeUndefined()
+  })
+
+  it('replays the resume for a provider with no host RPC to ask', async () => {
+    const spawn = vi
+      .fn()
+      .mockRejectedValueOnce(new SshPtyAbsentFromRelayError(`${SSH_SESSION_EXPIRED_ERROR}: pty-1`))
+      .mockResolvedValueOnce({ id: `ssh:${CONNECTION}@@pty-2`, isReattach: false })
+
+    const { result } = await spawnForStablePane({
+      runtime: undefined,
+      store: leaseStore(Date.now() - BINDING_AGE_MS),
+      provider: { spawn } as unknown as IPtyProvider,
+      spawnOptions: RESUME_ARGV,
+      owner: OWNER,
+      worktreeId: 'worktree-1',
+      connectionId: CONNECTION,
+      resolveOwner: () => null
+    })
+
+    expect(spawn.mock.calls[1]![0]).toMatchObject({ command: 'claude --resume abc123' })
+    expect(result.agentResumeUnavailable).toBeUndefined()
+  })
+
+  it('asks nothing at all when the request carried no startup intent', async () => {
+    const { run, spawn, requestHostRpc } = runFallback({
+      spawnOptions: { cols: 80, rows: 24 },
+      relayStatus: youngerRelay
+    })
+
+    const { result } = await run()
+
+    expect(requestHostRpc).not.toHaveBeenCalled()
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(result.agentResumeUnavailable).toBeUndefined()
+  })
+})

--- a/src/main/ipc/pty/runtime/spawn-commit.ts
+++ b/src/main/ipc/pty/runtime/spawn-commit.ts
@@ -225,10 +225,11 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
   if (!ctx.stablePaneOwner) {
     ctx.deps.runtime?.noteTerminalSpawnCommand?.(ctx.result.id, ctx.launchCommand ?? null)
   }
-  if (ctx.isClaudeLaunch && !ctx.stablePaneOwner) {
+  if (ctx.isClaudeLaunch && !ctx.stablePaneOwner && !ctx.result.agentResumeUnavailable) {
     markClaudePtySpawned(ctx.result.id)
   }
-  if (args.telemetry && !ctx.stablePaneOwner) {
+  // Why: a suppressed resume produced a plain shell, so there is no agent launch to report.
+  if (args.telemetry && !ctx.stablePaneOwner && !ctx.result.agentResumeUnavailable) {
     const agentKindParse = agentKindSchema.safeParse(args.telemetry.agent_kind)
     const launchSourceParse = launchSourceSchema.safeParse(args.telemetry.launch_source)
     const requestKindParse = requestKindSchema.safeParse(args.telemetry.request_kind)

--- a/src/main/providers/pty-spawn-result.ts
+++ b/src/main/providers/pty-spawn-result.ts
@@ -57,6 +57,9 @@ export type PtySpawnResult = {
   snapshotTerminalOwner?: TerminalOwner
   /** True when the spawn reattached to an existing daemon session. */
   isReattach?: boolean
+  /** Main dropped this spawn's resume/launch intent, so the pane is a NEW session. Set by main,
+   *  not the provider; the renderer swaps the restored banner for "resume unavailable". */
+  agentResumeUnavailable?: true
   /** Last OSC title tracked by the daemon session the snapshot came from.
    *  Seeds main's terminal title records after a relaunch; never replayed
    *  into a terminal. */


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​243 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​243 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​177 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​172 |

<!-- /orca-pr-loc -->

## What this fixes (ELI5)

Orca keeps a small helper process — the **relay** — running on your SSH host. It owns your remote terminals, and Orca reconnects to it when you come back.

When Orca reconnects and the relay answers *"I don't have that terminal"*, Orca starts a fresh shell and **replays whatever started the original terminal** — the agent launch, the `claude --resume …` argv, the startup command. On a normal cold restore that is exactly right: your agent comes back.

But the relay can be **replaced** while you're away (an Orca upgrade, a host reboot, host-side cleanup). The replacement relay truthfully says "I don't have that terminal" — it never did. Meanwhile the *old* relay's shell may still be alive on the host as an orphan. Orca then replayed the resume, and you got **a second agent running against the same worktree**, fighting the first one over the same session state.

**After this change**, Orca checks *how old the answering relay is* before believing it. `relay.status` already reports the daemon's `uptimeMs`. A daemon that has only been up 5 minutes cannot have owned a binding created 2 hours ago — so its "it's absent" answer proves nothing about that process. In that case Orca:

- **still opens a terminal** (you always get a shell — the spawn is never blocked),
- **does not** replay `launchAgent` / the resume argv / `command`,
- **tells you**, via the existing "resume unavailable" banner, so you decide what to run.

A plain shell is recoverable. A duplicate agent racing an orphan over one worktree is not.

## Before / after

| | Before | After |
| --- | --- | --- |
| Cold restore, same relay still running | Resume replays | **Unchanged** — resume replays |
| Relay replaced, binding older than the daemon | Resume replays → 2nd agent vs. live orphan | Plain shell, resume dropped, banner shown |
| `relay.status` times out / rejects / errors | Resume replays | **Unchanged** — resume replays |
| `relay.status` answers, no `uptimeMs` (older host) | Resume replays | **Unchanged** — resume replays |
| Local / non-SSH provider (no host RPC) | Resume replays | **Unchanged** — resume replays |

## Verdict vocabulary

Per `docs/reference/ssh-execution-boundary.md`, the vocabulary stays exactly `live` / `unverifiable` / `exited`. This change narrows one specific case from `exited` to `unverifiable`: a positive absence answer from a daemon that provably never held the binding is **not** positive evidence about that process.

**Silence is never promoted to a verdict.** Every one of these leaves today's behavior byte-for-byte unchanged, by construction — each is an early `return false`:

- provider has no `requestHostRpc` (optional call → `undefined`)
- `relay.status` rejects, times out, or throws (`catch → return false`)
- the reply is not an object
- `uptimeMs` is absent, non-numeric, non-finite, or negative
- no lease dates the binding (cold restore, older persisted state)
- the answering relay is older than, equal to, or younger-only-inside-the-clock-slack

Only an answer that **arrives** and is **demonstrably younger** suppresses the resume.

### On the clock comparison

`uptimeMs` is the host's own elapsed-time counter; binding age is the client's elapsed time since the lease's `createdAt`. **Both are durations**, so this compares two independently measured elapsed times — no clock-offset correction is possible or needed, and no wall-clock sync between client and host is assumed. A 30s slack (`RELAY_AGE_CLOCK_SLACK_MS`) absorbs jitter and the gap between daemon start and the first binding write.

## Remote wire compatibility

Confirmed against `docs/reference/remote-wire-compatibility.md`: **no wire change**.

- No new RPC request field; `relay.status` is called with `{}` exactly as `skill-ssh-relay-client.ts` already does.
- No new response field — `uptimeMs` is already published at `src/relay/relay-daemon.ts:131`.
- No new stream opcode.
- `agentResumeUnavailable` already exists in the **preload/renderer** contract (`src/preload/api/pty-api.ts:68`) and is already produced by `ipc/spawn-commit.ts` for the Codex resume path. It is added to main's `PtySpawnResult` and rides the existing IPC response spread. The **runtime** spawn response builds an explicit field whitelist (`id`, `incarnationId`, `stablePaneOwner`, `agentSessionEnsure`), so the flag does **not** reach the remote wire.

An older host simply omits `uptimeMs` → no verdict → unchanged behavior.

## Failing-first proof

Production reverted (`git checkout` the 4 modified files + `rm` the new module), new test file kept:

```
########## PRE-FIX (production reverted, new test kept) ##########
     × spawns a shell but drops a resume argv the replacement relay never held 6ms
     × drops launchAgent rather than starting a second agent over the same worktree 1ms
     × drops a startup command 0ms
 Test Files  1 failed (1)
      Tests  3 failed | 7 passed (10)

########## POST-FIX ##########
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

(The suite has since grown to 12 tests with two added coverage cases; the three suppression tests are the ones that can fail pre-fix.)

**Honest note on the other tests.** The task asked that *every* new test fail pre-fix. Only the three suppression tests can: the remaining nine pin *"behavior is unchanged"* (older relay, rejection, missing `uptimeMs`, non-object reply, no lease, no host RPC, no startup intent, sub-slack gap, spawn never gated). A test asserting that today's behavior is preserved **cannot** fail before the change — that is what it means. Their value is proven by the ablation table below instead: each goes red when the gate is made too permissive. I have not claimed failing-first for them.

## Ablation table

Each production hunk reverted individually against the 12-test suite:

| # | Hunk | Result |
| --- | --- | --- |
| H1 | record relay-positive absence (`onRelayPositiveAbsence`) | **RED** — 3 failed / 8 passed |
| H2 | fallback branch call in `spawnForStablePane` | **RED** — 3 failed / 8 passed |
| H3 | `carriesStartupIntent` guard | **RED** — 1 failed / 10 passed |
| H4 | `answeringRelayPredatesBinding` guard | **RED** — 6 failed / 5 passed |
| H5 | `stripStartupIntent` | **RED** — 2 failed / 9 passed |
| H6 | `agentResumeUnavailable` flag | **RED** — 3 failed / 8 passed |
| H7 | undatable-binding guard (`age === null`) | **RED** — 1 failed / 10 passed |
| H8 | `uptimeMs` type guard | **RED** — 1 failed / 10 passed |
| H9 | `relay.status` failure `catch` | **RED** — 1 failed / 10 passed |
| H10 | non-object status guard *(true deletion)* | **RED** — 2 failed / 10 passed |
| H11 | clock slack | **RED** — 1 failed / 10 passed |
| H12 | lease `createdAt` lookup | **RED** — 3 failed / 8 passed |
| H13 | ipc `agent_started` gate | **GREEN — UNCOVERED** |
| H14 | ipc `markClaudePtySpawned` gate | **GREEN — UNCOVERED** |
| H15 | runtime `agent_started` / claude-marker gates | **GREEN — UNCOVERED** |

**H13–H15 are uncovered and I am saying so rather than papering over it.** They are three one-line consequential gates: a suppressed resume produced a plain shell, so `agent_started` telemetry and the Claude-launch marker must not fire for an agent that never started. Without them this change would *introduce* a false `agent_started`. Covering them needs a full `setupPtyIpcSuite` run with a registered SSH provider, a lease store, and a relay-absence rejection driven through `executePtyIpcSpawn` — disproportionate to three one-line conditions, so I left them uncovered rather than write a test that only restates the condition.

Note on H10: my first mutation (`status = status ?? {}`) left the suite green because it re-introduced a null guard. True deletion is red. Reporting both because the weak mutation is the kind that makes an ablation table lie.

## Gates

- `pnpm tc` — exit 0
- `oxlint` (incl. `--type-aware` and react-doctor configs) on all changed files — clean, no `max-lines` disable added (the fallback body was extracted into the new module to stay under 300)
- `npx oxfmt --write <changed paths>` only — never `pnpm format`
- `git diff --check` — clean
- `pnpm test src/main/ipc/pty` — **10 pre-existing failures on both the clean tree and this branch** (identical set, in `pty-spawn-env-agent-overlays`, `pty-login-shell-startup-commands`, `pty-serializer-settlement-mapping`, `pty-spawn-env-codex-home-routing`); this branch adds 12 passing tests (594 → 606 passing)

## What I did NOT verify

- **No live SSH relay-replacement reproduction.** I did not stand up a real SSH host, kill and replace its relay daemon with an orphaned shell surviving, and observe the banner. All evidence here is unit-level against `spawnForStablePane`.
- **No Electron/CDP run.** I did not render the resume-unavailable banner in the running app for this branch. I reused the existing `agentResumeUnavailable` → `showSessionRestoredBanner('resume-unavailable')` path rather than adding a new surface, but I did not visually confirm it end to end.
- **H13–H15 have no test** (above).
- **Runtime/paired-host path surfaces nothing to the user.** The *suppression itself* applies on both the IPC and runtime spawn paths (both go through `spawnForStablePane`). The *banner* only reaches the renderer on the IPC path, because the runtime spawn response is an explicit whitelist and adding the field there would be a wire change this ticket forbids. A paired-runtime user gets the plain shell without the banner.
- **Lease `createdAt` and recycled PTY ids.** `upsertSshRemotePtyLease` preserves the *oldest* `createdAt` when a relay recycles a `pty-N` id (see the STA-3077 note in `ssh-pty-lease-operations.ts`). That biases binding age older, i.e. toward suppression. I judged that acceptable — the conservative direction here is a plain shell — but I did not measure how often it fires in practice.
- **No perf measurement** of the added `relay.status` round-trip. It is bounded at 2s and only runs on the absence fallback when startup intent is present, but I did not time it against a real relay.

## Relationship to the other STA-5698 PRs

This is a **different approach** from the two open siblings, and deliberately narrower:

- **#16839** solves it with a relay *process identity*: the relay mints an identity, the client asks for it via a new optional `requestRelayProcessId` request field and persists it on the lease. That is additive-but-real wire surface.
- **#16901** mints PTY ids carrying the relay incarnation.
- **This PR** adds **no wire surface at all** — it only reads `uptimeMs`, which `relay.status` already publishes.

`uptimeMs` is strictly weaker evidence than a minted identity (it cannot distinguish two daemons that both predate the binding), but it works against **every existing host** with no negotiation, including hosts that will never ship an identity field. These are alternatives, not stackable; whichever lands, the others should close. Flagging this rather than assuming — the merge choice is yours.

Closes STA-5698.
