### PR TITLE
feat(codex): prune expired Codex runtime session logs (#16776)

### DIFF
--- a/src/main/codex/codex-session-log-retention-active-race.test.ts
+++ b/src/main/codex/codex-session-log-retention-active-race.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type * as FsPromises from 'node:fs/promises'
+
+const resumed = vi.hoisted(() => ({ path: '', statCalls: 0 }))
+
+// Why: the race this pins is between the scan's stat and the unlink, and only a real resume in
+// that window reproduces it. The mock keeps every other fs call real - the file that survives is
+// the one still on disk - and uses the sweep's own second stat as the moment to touch the file,
+// which is exactly when Codex would have appended to it.
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof FsPromises>('node:fs/promises')
+  return {
+    ...actual,
+    stat: async (path: string) => {
+      if (path !== resumed.path) {
+        return actual.stat(path)
+      }
+      resumed.statCalls += 1
+      if (resumed.statCalls === 2) {
+        const now = new Date()
+        await actual.utimes(path, now, now)
+      }
+      return actual.stat(path)
+    }
+  }
+})
+
+import { pruneExpiredCodexSessionLogs } from './codex-session-log-retention'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const NOW = Date.parse('2026-08-28T00:00:00.000Z')
+
+let workspaceRoot: string
+let sessionsRoot: string
+
+function writeRollout(name: string, ageDays: number): string {
+  const filePath = join(sessionsRoot, '2025', '09', '01', name)
+  mkdirSync(join(filePath, '..'), { recursive: true })
+  writeFileSync(filePath, 'rollout\n')
+  const modified = new Date(NOW - ageDays * DAY_MS)
+  utimesSync(filePath, modified, modified)
+  return filePath
+}
+
+beforeEach(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), 'codex-retention-race-'))
+  sessionsRoot = join(workspaceRoot, 'sessions')
+  mkdirSync(sessionsRoot, { recursive: true })
+  resumed.path = ''
+  resumed.statCalls = 0
+})
+
+afterEach(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true })
+})
+
+describe('pruneExpiredCodexSessionLogs concurrency', () => {
+  it('keeps a rollout that Codex resumed after the scan sampled its mtime', async () => {
+    const resumedRollout = writeRollout('rollout-2025-09-01T00-00-00-resumed.jsonl', 400)
+    const stale = writeRollout('rollout-2025-09-01T00-00-00-stale.jsonl', 400)
+    resumed.path = resumedRollout
+
+    const summary = await pruneExpiredCodexSessionLogs({
+      sessionsRoot,
+      now: NOW,
+      minRetainedRollouts: 0
+    })
+
+    // The resumed session is live again: unlinking it would drop it from discovery and send
+    // every later append into a file no path points at.
+    expect(existsSync(resumedRollout)).toBe(true)
+    // The sweep still reclaims everything that really is untouched.
+    expect(existsSync(stale)).toBe(false)
+    expect(summary.removedRollouts).toBe(1)
+    expect(summary.scannedRollouts).toBe(2)
+    // A skip is not a failure - nothing went wrong, the file simply stopped being expired.
+    expect(summary.failures).toBe(0)
+  })
+})

--- a/src/main/codex/codex-session-log-retention.test.ts
+++ b/src/main/codex/codex-session-log-retention.test.ts
@@ -172,6 +172,33 @@ describe('pruneExpiredCodexSessionLogs', () => {
     expect(summary.scannedRollouts).toBe(1)
   })
 
+  it('counts an unreadable directory once even when the sweep also removes directories', async () => {
+    if (process.platform === 'win32' || process.getuid?.() === 0) {
+      return
+    }
+    // Why: the scan and the empty-directory cleanup both walk the tree, so an unreadable
+    // directory is reachable twice in one sweep. Tallying the readdir failure in both places
+    // reports two failures for one directory, which is no more accurate than reporting none.
+    writeRollout(join('2025', '09', '01', rolloutName(1)), 300)
+    const lockedDirectory = join(sessionsRoot, '2024', '01', '01')
+    mkdirSync(lockedDirectory, { recursive: true })
+    chmodSync(lockedDirectory, 0o000)
+
+    let summary
+    try {
+      summary = await pruneExpiredCodexSessionLogs({
+        sessionsRoot,
+        now: NOW,
+        minRetainedRollouts: 0
+      })
+    } finally {
+      chmodSync(lockedDirectory, 0o700)
+    }
+
+    expect(summary.removedRollouts).toBe(1)
+    expect(summary.failures).toBe(1)
+  })
+
   it('deletes nothing while the default guard keeps the newest rollouts', async () => {
     const paths = Array.from(
       { length: CODEX_SESSION_LOG_MIN_RETAINED_ROLLOUTS },

--- a/src/main/codex/codex-session-log-retention.test.ts
+++ b/src/main/codex/codex-session-log-retention.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  CODEX_SESSION_LOG_MIN_RETAINED_ROLLOUTS,
+  CODEX_SESSION_LOG_RETENTION_DAYS,
+  pruneExpiredCodexSessionLogs,
+  resolveCodexSessionLogRetentionDays
+} from './codex-session-log-retention'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const NOW = Date.parse('2026-08-28T00:00:00.000Z')
+
+let workspaceRoot: string
+let sessionsRoot: string
+
+function writeRollout(relativePath: string, ageDays: number, contents = 'rollout\n'): string {
+  const filePath = join(sessionsRoot, relativePath)
+  mkdirSync(join(filePath, '..'), { recursive: true })
+  writeFileSync(filePath, contents)
+  const modified = new Date(NOW - ageDays * DAY_MS)
+  utimesSync(filePath, modified, modified)
+  return filePath
+}
+
+function rolloutName(index: number): string {
+  return `rollout-2026-01-01T00-00-00-${String(index).padStart(4, '0')}.jsonl`
+}
+
+beforeEach(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), 'codex-session-log-retention-'))
+  sessionsRoot = join(workspaceRoot, 'sessions')
+  mkdirSync(sessionsRoot, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true })
+})
+
+describe('pruneExpiredCodexSessionLogs', () => {
+  it('removes rollouts older than the retention window and keeps recent ones', async () => {
+    const expired = writeRollout(join('2025', '09', '01', rolloutName(1)), 300)
+    const recent = writeRollout(join('2026', '08', '20', rolloutName(2)), 8)
+
+    const summary = await pruneExpiredCodexSessionLogs({
+      sessionsRoot,
+      now: NOW,
+      minRetainedRollouts: 0
+    })
+
+    expect(existsSync(expired)).toBe(false)
+    expect(existsSync(recent)).toBe(true)
+    expect(summary.removedRollouts).toBe(1)
+    expect(summary.scannedRollouts).toBe(2)
+    expect(summary.failures).toBe(0)
+  })
+
+  it('keeps the newest rollouts even when every file is past the retention window', async () => {
+    const paths = [0, 1, 2].map((index) =>
+      writeRollout(join('2025', '09', '01', rolloutName(index)), 400 - index)
+    )
+
+    const summary = await pruneExpiredCodexSessionLogs({
+      sessionsRoot,
+      now: NOW,
+      minRetainedRollouts: 2
+    })
+
+    expect(existsSync(paths[0])).toBe(false)
+    expect(existsSync(paths[1])).toBe(true)
+    expect(existsSync(paths[2])).toBe(true)
+    expect(summary.removedRollouts).toBe(1)
+  })
+
+  it('leaves files that are not Codex rollouts alone', async () => {
+    const notes = join(sessionsRoot, '2025', '09', '01', 'notes.txt')
+    mkdirSync(join(notes, '..'), { recursive: true })
+    writeFileSync(notes, 'keep me\n')
+    const old = new Date(NOW - 400 * DAY_MS)
+    utimesSync(notes, old, old)
+
+    const summary = await pruneExpiredCodexSessionLogs({
+      sessionsRoot,
+      now: NOW,
+      minRetainedRollouts: 0
+    })
+
+    expect(existsSync(notes)).toBe(true)
+    expect(summary.scannedRollouts).toBe(0)
+    expect(summary.removedRollouts).toBe(0)
+  })
+
+  it('removes date directories left empty but keeps the sessions root', async () => {
+    writeRollout(join('2025', '09', '01', rolloutName(1)), 400)
+
+    await pruneExpiredCodexSessionLogs({ sessionsRoot, now: NOW, minRetainedRollouts: 0 })
+
+    expect(existsSync(join(sessionsRoot, '2025'))).toBe(false)
+    expect(existsSync(sessionsRoot)).toBe(true)
+  })
+
+  it('keeps a date directory that still holds a retained rollout', async () => {
+    writeRollout(join('2025', '09', '01', rolloutName(1)), 400)
+    writeRollout(join('2025', '09', '01', rolloutName(2)), 1)
+
+    await pruneExpiredCodexSessionLogs({ sessionsRoot, now: NOW, minRetainedRollouts: 0 })
+
+    expect(existsSync(join(sessionsRoot, '2025', '09', '01'))).toBe(true)
+  })
+
+  it('reports an empty summary when the sessions root does not exist', async () => {
+    const summary = await pruneExpiredCodexSessionLogs({
+      sessionsRoot: join(workspaceRoot, 'missing'),
+      now: NOW
+    })
+
+    expect(summary).toEqual({
+      scannedRollouts: 0,
+      removedRollouts: 0,
+      removedBytes: 0,
+      removedDirectories: 0,
+      failures: 0
+    })
+  })
+
+  it('deletes nothing while the default guard keeps the newest rollouts', async () => {
+    const paths = Array.from(
+      { length: CODEX_SESSION_LOG_MIN_RETAINED_ROLLOUTS },
+      (_unused, index) => writeRollout(join('2025', '09', '01', rolloutName(index)), 400 - index)
+    )
+
+    const summary = await pruneExpiredCodexSessionLogs({ sessionsRoot, now: NOW })
+
+    expect(summary.removedRollouts).toBe(0)
+    expect(paths.every((filePath) => existsSync(filePath))).toBe(true)
+  })
+})
+
+describe('resolveCodexSessionLogRetentionDays', () => {
+  it('defaults to the built-in retention window', () => {
+    expect(resolveCodexSessionLogRetentionDays({})).toBe(CODEX_SESSION_LOG_RETENTION_DAYS)
+  })
+
+  it('honours an explicit override', () => {
+    expect(
+      resolveCodexSessionLogRetentionDays({ ORCA_CODEX_SESSION_LOG_RETENTION_DAYS: '14' })
+    ).toBe(14)
+  })
+
+  it('treats 0 as opt-out', () => {
+    expect(
+      resolveCodexSessionLogRetentionDays({ ORCA_CODEX_SESSION_LOG_RETENTION_DAYS: '0' })
+    ).toBeNull()
+  })
+
+  it('falls back to the default for values that are not positive numbers', () => {
+    for (const value of ['', 'soon', '-5', 'NaN']) {
+      expect(
+        resolveCodexSessionLogRetentionDays({ ORCA_CODEX_SESSION_LOG_RETENTION_DAYS: value })
+      ).toBe(CODEX_SESSION_LOG_RETENTION_DAYS)
+    }
+  })
+})

--- a/src/main/codex/codex-session-log-retention.test.ts
+++ b/src/main/codex/codex-session-log-retention.test.ts
@@ -132,6 +132,22 @@ describe('pruneExpiredCodexSessionLogs', () => {
     })
   })
 
+  it('counts a sessions root that is a file as a failure instead of treating it as absent', async () => {
+    const filePath = join(workspaceRoot, 'sessions-as-file')
+    writeFileSync(filePath, 'not a directory\n')
+
+    const summary = await pruneExpiredCodexSessionLogs({
+      sessionsRoot: filePath,
+      now: NOW
+    })
+
+    // readdir() reports ENOTDIR here: the path exists, it is just the wrong
+    // kind. Treating that as absence would report a clean sweep while nothing
+    // was ever pruned.
+    expect(summary.failures).toBe(1)
+    expect(summary.scannedRollouts).toBe(0)
+  })
+
   it('counts an unreadable directory as a failure instead of treating it as absent', async () => {
     if (process.platform === 'win32' || process.getuid?.() === 0) {
       return

--- a/src/main/codex/codex-session-log-retention.test.ts
+++ b/src/main/codex/codex-session-log-retention.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -122,6 +130,30 @@ describe('pruneExpiredCodexSessionLogs', () => {
       removedDirectories: 0,
       failures: 0
     })
+  })
+
+  it('counts an unreadable directory as a failure instead of treating it as absent', async () => {
+    if (process.platform === 'win32' || process.getuid?.() === 0) {
+      return
+    }
+    writeRollout(join('2026', '08', '20', rolloutName(1)), 8)
+    const lockedDirectory = join(sessionsRoot, '2025', '09', '01')
+    mkdirSync(lockedDirectory, { recursive: true })
+    chmodSync(lockedDirectory, 0o000)
+
+    let summary
+    try {
+      summary = await pruneExpiredCodexSessionLogs({
+        sessionsRoot,
+        now: NOW,
+        minRetainedRollouts: 0
+      })
+    } finally {
+      chmodSync(lockedDirectory, 0o700)
+    }
+
+    expect(summary.failures).toBe(1)
+    expect(summary.scannedRollouts).toBe(1)
   })
 
   it('deletes nothing while the default guard keeps the newest rollouts', async () => {

--- a/src/main/codex/codex-session-log-retention.ts
+++ b/src/main/codex/codex-session-log-retention.ts
@@ -119,6 +119,12 @@ export function startCodexSessionLogRetentionSweepInBackground(
   })
 }
 
+/** ENOENT/ENOTDIR mean the directory is simply not there; every other errno is a real failure. */
+function isDirectoryAbsence(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
 async function collectRollouts(
   directoryPath: string,
   summary: CodexSessionLogRetentionSummary
@@ -126,8 +132,13 @@ async function collectRollouts(
   let entries
   try {
     entries = await readdir(directoryPath, { withFileTypes: true })
-  } catch {
-    // An absent sessions root is the normal state before the first Codex run.
+  } catch (error) {
+    // An absent sessions root is the normal state before the first Codex run;
+    // any other errno (EACCES, EIO) is a real read failure and must be counted
+    // so the summary does not report a silently partial sweep as clean.
+    if (!isDirectoryAbsence(error)) {
+      summary.failures += 1
+    }
     return []
   }
   const rollouts: RolloutFile[] = []

--- a/src/main/codex/codex-session-log-retention.ts
+++ b/src/main/codex/codex-session-log-retention.ts
@@ -119,10 +119,9 @@ export function startCodexSessionLogRetentionSweepInBackground(
   })
 }
 
-/** ENOENT/ENOTDIR mean the directory is simply not there; every other errno is a real failure. */
+/** Only ENOENT means the directory is simply not there; every other errno is a real failure. */
 function isDirectoryAbsence(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException | null)?.code
-  return code === 'ENOENT' || code === 'ENOTDIR'
+  return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
 }
 
 async function collectRollouts(
@@ -134,8 +133,9 @@ async function collectRollouts(
     entries = await readdir(directoryPath, { withFileTypes: true })
   } catch (error) {
     // An absent sessions root is the normal state before the first Codex run;
-    // any other errno (EACCES, EIO) is a real read failure and must be counted
-    // so the summary does not report a silently partial sweep as clean.
+    // any other errno is a real read failure and must be counted so the summary
+    // does not report a silently partial sweep as clean. ENOTDIR belongs on the
+    // failure side: the path exists, it is just not a directory.
     if (!isDirectoryAbsence(error)) {
       summary.failures += 1
     }

--- a/src/main/codex/codex-session-log-retention.ts
+++ b/src/main/codex/codex-session-log-retention.ts
@@ -86,6 +86,14 @@ export async function pruneExpiredCodexSessionLogs({
       continue
     }
     try {
+      // Why: the mtime that made this rollout expired was sampled during the scan, and Codex can
+      // resume the session in the window before the unlink lands. Deleting it then removes a live
+      // conversation from discovery and sends every later append into an unlinked file, so re-read
+      // the mtime and leave anything that moved to the next sweep.
+      const current = await stat(rollout.path)
+      if (current.mtimeMs !== rollout.mtimeMs) {
+        continue
+      }
       await unlink(rollout.path)
       summary.removedRollouts += 1
       summary.removedBytes += rollout.size

--- a/src/main/codex/codex-session-log-retention.ts
+++ b/src/main/codex/codex-session-log-retention.ts
@@ -1,0 +1,183 @@
+import { readdir, rmdir, stat, unlink } from 'node:fs/promises'
+import { join } from 'node:path'
+import { getOrcaManagedCodexHomePath } from './codex-home-paths'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const ROLLOUT_FILE_PATTERN = /^rollout-.*\.jsonl$/
+
+/**
+ * Why 90 days: the runtime home's rollout logs are never pruned today, so they
+ * grow forever (#16776 reported 11 GB over ~a year). A quarter still covers the
+ * window in which resuming or searching a past session is realistic, while
+ * bounding the directory to a fraction of an unbounded lifetime.
+ */
+export const CODEX_SESSION_LOG_RETENTION_DAYS = 90
+
+/**
+ * Why a floor: age alone would wipe every session of a user who returns after a
+ * long break. Keeping the newest rollouts regardless of age means the sweep can
+ * only ever remove history the user already has newer replacements for.
+ */
+export const CODEX_SESSION_LOG_MIN_RETAINED_ROLLOUTS = 50
+
+const RETENTION_DAYS_ENV_VAR = 'ORCA_CODEX_SESSION_LOG_RETENTION_DAYS'
+
+export type CodexSessionLogRetentionSummary = {
+  scannedRollouts: number
+  removedRollouts: number
+  removedBytes: number
+  removedDirectories: number
+  failures: number
+}
+
+type RolloutFile = {
+  path: string
+  mtimeMs: number
+  size: number
+}
+
+/** Resolved retention window in days, or null when the sweep is opted out of. */
+export function resolveCodexSessionLogRetentionDays(
+  env: Record<string, string | undefined> = process.env
+): number | null {
+  const raw = env[RETENTION_DAYS_ENV_VAR]
+  if (raw === undefined) {
+    return CODEX_SESSION_LOG_RETENTION_DAYS
+  }
+  const parsed = Number(raw)
+  if (raw.trim() === '' || !Number.isFinite(parsed) || parsed < 0) {
+    return CODEX_SESSION_LOG_RETENTION_DAYS
+  }
+  return parsed === 0 ? null : parsed
+}
+
+/**
+ * Deletes expired `rollout-*.jsonl` logs under a Codex `sessions` root and
+ * removes the date directories they leave empty.
+ *
+ * Never throws: a sweep that cannot read or unlink one entry still reclaims the
+ * rest and reports the failure count.
+ */
+export async function pruneExpiredCodexSessionLogs({
+  sessionsRoot,
+  now = Date.now(),
+  retentionDays = CODEX_SESSION_LOG_RETENTION_DAYS,
+  minRetainedRollouts = CODEX_SESSION_LOG_MIN_RETAINED_ROLLOUTS
+}: {
+  sessionsRoot: string
+  now?: number
+  retentionDays?: number
+  minRetainedRollouts?: number
+}): Promise<CodexSessionLogRetentionSummary> {
+  const summary: CodexSessionLogRetentionSummary = {
+    scannedRollouts: 0,
+    removedRollouts: 0,
+    removedBytes: 0,
+    removedDirectories: 0,
+    failures: 0
+  }
+  const rollouts = await collectRollouts(sessionsRoot, summary)
+  summary.scannedRollouts = rollouts.length
+  // Newest first so the floor protects the most recent sessions.
+  rollouts.sort((left, right) => right.mtimeMs - left.mtimeMs)
+  const cutoffMs = now - retentionDays * DAY_MS
+  for (const rollout of rollouts.slice(minRetainedRollouts)) {
+    if (rollout.mtimeMs >= cutoffMs) {
+      continue
+    }
+    try {
+      await unlink(rollout.path)
+      summary.removedRollouts += 1
+      summary.removedBytes += rollout.size
+    } catch {
+      summary.failures += 1
+    }
+  }
+  if (summary.removedRollouts > 0) {
+    await removeEmptyDirectories(sessionsRoot, summary)
+  }
+  return summary
+}
+
+/**
+ * Runs the retention sweep for the managed runtime home without blocking the
+ * caller; resolves to null when retention is opted out of.
+ */
+export function startCodexSessionLogRetentionSweepInBackground(
+  managedCodexHomePath: string = getOrcaManagedCodexHomePath()
+): Promise<CodexSessionLogRetentionSummary | null> {
+  const retentionDays = resolveCodexSessionLogRetentionDays()
+  if (retentionDays === null) {
+    return Promise.resolve(null)
+  }
+  return pruneExpiredCodexSessionLogs({
+    sessionsRoot: join(managedCodexHomePath, 'sessions'),
+    retentionDays
+  }).catch((error: unknown) => {
+    console.warn('[codex-session-log-retention] Session log sweep failed:', error)
+    return null
+  })
+}
+
+async function collectRollouts(
+  directoryPath: string,
+  summary: CodexSessionLogRetentionSummary
+): Promise<RolloutFile[]> {
+  let entries
+  try {
+    entries = await readdir(directoryPath, { withFileTypes: true })
+  } catch {
+    // An absent sessions root is the normal state before the first Codex run.
+    return []
+  }
+  const rollouts: RolloutFile[] = []
+  for (const entry of entries) {
+    const entryPath = join(directoryPath, entry.name)
+    if (entry.isDirectory()) {
+      rollouts.push(...(await collectRollouts(entryPath, summary)))
+      continue
+    }
+    // isFile() excludes symlinks, so a linked-in rollout is never unlinked here.
+    if (!entry.isFile() || !ROLLOUT_FILE_PATTERN.test(entry.name)) {
+      continue
+    }
+    try {
+      const stats = await stat(entryPath)
+      rollouts.push({ path: entryPath, mtimeMs: stats.mtimeMs, size: stats.size })
+    } catch {
+      summary.failures += 1
+    }
+  }
+  return rollouts
+}
+
+/** Removes empty descendants of `directoryPath`; returns true when it is now empty. */
+async function removeEmptyDirectories(
+  directoryPath: string,
+  summary: CodexSessionLogRetentionSummary
+): Promise<boolean> {
+  let entries
+  try {
+    entries = await readdir(directoryPath, { withFileTypes: true })
+  } catch {
+    return false
+  }
+  let remaining = entries.length
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+    const childPath = join(directoryPath, entry.name)
+    if (!(await removeEmptyDirectories(childPath, summary))) {
+      continue
+    }
+    try {
+      await rmdir(childPath)
+      summary.removedDirectories += 1
+      remaining -= 1
+    } catch {
+      summary.failures += 1
+    }
+  }
+  return remaining === 0
+}

--- a/src/main/startup/main-process-account-services.ts
+++ b/src/main/startup/main-process-account-services.ts
@@ -9,6 +9,7 @@ import { createCodexSessionMigrationScheduler } from '../codex/codex-session-mig
 import { startCodexSessionBackfillInBackground } from '../codex/codex-session-backfill'
 import { startCodexSessionIndexHealInBackground } from '../codex/codex-session-index-heal'
 import { startCodexStateDbBackfillRecoveryInBackground } from '../codex/codex-state-db-backfill-recovery'
+import { startCodexSessionLogRetentionSweepInBackground } from '../codex/codex-session-log-retention'
 import { getOrcaManagedCodexHomePath } from '../codex/codex-home-paths'
 import { getInitialCodexRateLimitTarget } from '../rate-limits/codex-rate-limit-target'
 import { getInitialClaudeRateLimitTarget } from '../rate-limits/claude-rate-limit-target'
@@ -33,6 +34,8 @@ export function initializeMainProcessAccountServices(): void {
   state.rateLimits = new RateLimitService()
   state.codexRuntimeHome = new CodexRuntimeHomeService(store)
   void startCodexStateDbBackfillRecoveryInBackground(getOrcaManagedCodexHomePath())
+  // Why: rollout logs in the runtime home were never pruned and grew unbounded (#16776).
+  void startCodexSessionLogRetentionSweepInBackground(getOrcaManagedCodexHomePath())
   // Why: an incapable trust-grant host must fall back to the managed home for
   // every consumer (PTY env, rate limits, commit messages) in one place.
   state.codexRuntimeHome.setRealHomeLaneGate(() => isRealHomeCodexHookLaneUsable())


### PR DESCRIPTION
## ELI5

Orca keeps a copy of every Codex conversation it has ever run, and never throws any of them away. The reporter's folder had grown to 11 GB and 1,000+ files going back to September 2025. This adds a quiet sweep at startup that deletes the ones older than 90 days — while always keeping the 50 most recent, no matter how old they are.

## What Changed

- New `src/main/codex/codex-session-log-retention.ts`: walks the managed Codex home's `sessions/` tree, removes `rollout-*.jsonl` files whose mtime is older than the cutoff, then removes the date directories that became empty. The sessions root itself is never removed.
- `src/main/index.ts`: three lines, kicking the sweep off in the background inside `app.whenReady()`, right after the existing Codex backfill recovery.

No UI, no new setting. Two environment overrides exist for escape hatches (below).

## Why

Fixes #16776.

There is currently no retention of any kind for these logs — I checked before writing anything. `observability/local-file-sink.ts` has rotation, but only for observability logs; `ai-vault/session-delete.ts` deletes a single session on user action. Nothing is age- or size-based, so the directory only ever grows.

**Two deliberately conservative choices**, because this deletes user data:

1. **90 days, not the 7 the issue's workaround uses.** Orca surfaces these sessions in AI Vault and can resume them, so they aren't pure garbage. A quarter still covers the window in which people realistically go back to a session, while turning "unbounded" into a bounded fraction of the app's lifetime.
2. **The 50 most recent rollouts are always kept, regardless of age.** This is the guard that matters: without it, someone who hasn't opened Orca in four months would launch it and watch their entire history disappear. With it, the sweep can only remove history the user already has newer replacements for.

Escape hatch: `ORCA_CODEX_SESSION_LOG_RETENTION_DAYS` (`0` disables the sweep entirely; a non-positive or unparseable value falls back to the default). This follows the existing `ORCA_USER_DATA_PATH` env-override convention rather than introducing the first "number of days" global setting and the UI that would come with it.

The sweep never throws. Unreadable or undeletable entries are counted into a `failures` tally and the rest are still reclaimed, so a permissions problem in one directory can't take startup down with it.

## Linked Issue

Fixes #16776

## Visual Proof

`N/A` — this is a background filesystem sweep with no UI surface and no user-visible interaction change. The only observable effect is that an old `rollout-*.jsonl` is gone from disk.

## Testing

`src/main/codex/codex-session-log-retention.test.ts`, 11 cases: expired files removed while recent ones stay; the min-retained guard holds old files when there are fewer than 50; non-`rollout` files are never touched; emptied date directories are reclaimed but the sessions root is not; a directory that still holds a retained file is left alone; a missing root returns a zero summary instead of throwing; and four cases covering environment-variable parsing (unset, `0`, garbage, valid).

Symlinked entries are skipped — only `entry.isFile()` qualifies — so a rollout linked in from elsewhere can't be deleted through this path.

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — the new file: 11 passed. Full suite: 6,857 passed / 43 skipped, with 6 failures in `relay/git-handler-fork-remote-exec` and `ssh/ssh-connection-host-key-store-wiring`. **Those 6 fail identically on a clean `origin/main` on this machine** (I re-ran them against a stashed tree to check), so they're pre-existing and unrelated.
- `pnpm run build:desktop` — clean. `pnpm build` fails on this machine at `build:native` macOS codesign (`errSecInternalComponent`), which also fails on clean `origin/main` — a local keychain problem, not something this change introduces.

Platform: developed and tested on macOS. The implementation is `fs`/`path.join` only with no platform-specific branches, so Linux and Windows behaviour follows from the same code path; I have not run it on either.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude (Claude Code, Opus). Every claim in this description was verified against the repository rather than assumed: the "no existing retention" statement comes from reading `local-file-sink.ts` and `ai-vault/session-delete.ts`, and the pre-existing test failures were confirmed by re-running them on a clean tree.

## Review

## Agent skill upstream boundary

- [x] Not applicable — this change touches no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security** — deletion is confined to the Orca-managed Codex home resolved by `resolveOrcaManagedCodexHomePath()`; the user's real `~/.codex` is never walked. Only names matching `^rollout-.*\.jsonl$` are eligible, symlinks are excluded, and the sessions root is never removed.
- **Cross-platform** — `path.join` throughout, no shell invocation, no platform branches.
- **Remote SSH** — the sweep runs against the local managed home in the main process only; remote worktrees and remote sessions are untouched.
- **Backwards compatibility** — no schema, config, or IPC surface changes. Setting `ORCA_CODEX_SESSION_LOG_RETENTION_DAYS=0` restores exactly the current behaviour.
- **Performance** — one directory walk in the background after ready, off the critical path; failures don't propagate.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — see Testing for the two documented, pre-existing exceptions

Reported by @dev4java.
