### PR TITLE
fix(terminal): only the Windows console-limit failure keeps a dead terminal open (STA-5604)

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-git-bash-console-capacity.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-git-bash-console-capacity.test.ts
@@ -461,6 +461,48 @@ describe('Git Bash console-capacity pane retention (STA-5604)', () => {
     expect(started.deps.onPaneProcessDied).not.toHaveBeenCalled()
   })
 
+  it('tears the pane down when the host wired no process-died handler', async () => {
+    // Why: `onPaneProcessDied` is optional on PaneConnectionDeps. Without the
+    // presence check the capacity branch would call `undefined` and abort the exit
+    // handler mid-teardown, leaving the pane neither retained nor closed.
+    const started = await startPane({
+      paneCount: 2,
+      deps: {
+        onPaneProcessDied: undefined,
+        paneTransportsRef: { current: new Map([[2, createMockTransport('pty-pane-2')]]) }
+      }
+    })
+
+    started.spawn('tab-pty')
+    started.emitOutput(CAPACITY_OUTPUT)
+    started.exit('tab-pty', 1)
+
+    expect(started.manager.closePane).toHaveBeenCalledWith(1)
+  })
+
+  it('keys an in-flight write to the PTY bound at the time, not the incoming generation', async () => {
+    // Why: a new stream generation installs its exit state when its callbacks are
+    // captured, which is BEFORE the transport rebinds its PTY id. A write landing in
+    // that window belongs to the outgoing PTY; crediting it to the incoming one would
+    // make a newborn shell look typed-into and silently drop its capacity overlay.
+    const { installPtyExitHibernate } = await import('./pty-connection/pty-exit-hibernate')
+    const session = { paneStartup: { command: 'zsh' } } as never as Parameters<
+      typeof installPtyExitHibernate
+    >[0]
+    installPtyExitHibernate(session)
+
+    const outgoing = session.currentProcessExitState
+    session.bindProcessExitState('outgoing-pty')
+    // The incoming generation's state is installed before its PTY id is bound.
+    const incoming = session.createProcessExitState({ command: 'zsh' })
+    session.currentProcessExitState = incoming
+
+    session.noteTerminalInputForPty('outgoing-pty')
+
+    expect(outgoing.userInteracted).toBe(true)
+    expect(incoming.userInteracted).toBe(false)
+  })
+
   it('keeps a freshly split Windows pane visible when its newborn PTY hits the console ceiling', async () => {
     const startup = { command: 'codex' }
     const started = await startPane({

--- a/src/renderer/src/components/terminal-pane/pty-connection-git-bash-console-capacity.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-git-bash-console-capacity.test.ts
@@ -1,0 +1,480 @@
+import type * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { flushAsyncTicks } from './pty-connection-test-async'
+import {
+  sendTerminalInputThroughPane,
+  temporarilySetNavigatorUserAgent
+} from './pty-connection-test-dom'
+import {
+  LEAF_1,
+  createMockTransport,
+  createPane,
+  createManager,
+  type ConnectCallbacks,
+  type MockPane,
+  type MockTransport
+} from './pty-connection-test-pane-fixtures'
+import { buildPaneConnectionDeps } from './pty-connection-test-deps'
+import { createInitialStoreState } from './pty-connection-test-store-fixtures'
+import type { StoreState } from './pty-connection-test-store-state'
+import {
+  installTerminalTestGlobals,
+  restoreTerminalTestGlobals
+} from './pty-connection-test-environment'
+
+const {
+  resetAndRefreshAllTerminalWebglAtlases,
+  scheduleTerminalWebglAtlasRecovery,
+  scheduleRuntimeGraphSync,
+  shouldSeedCacheTimerOnInitialTitle,
+  toastInfo,
+  notifyCodexPaneBoundForStaleSweep
+} = vi.hoisted(() => ({
+  resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
+  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleRuntimeGraphSync: vi.fn(),
+  shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
+  toastInfo: vi.fn(),
+  notifyCodexPaneBoundForStaleSweep: vi.fn()
+}))
+
+let mockStoreState: StoreState
+let transportFactoryQueue: MockTransport[] = []
+let createdTransportOptions: Record<string, unknown>[] = []
+let storeSubscribers: ((state: StoreState) => void)[] = []
+let restoreUserAgent: (() => void) | null = null
+
+vi.mock('@/runtime/sync-runtime-graph', () => ({
+  scheduleRuntimeGraphSync
+}))
+
+vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resetAndRefreshAllTerminalWebglAtlases
+}))
+
+vi.mock('./terminal-webgl-atlas-recovery', () => ({
+  scheduleTerminalWebglAtlasRecovery
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mockStoreState,
+    subscribe: (listener: (state: StoreState) => void) => {
+      storeSubscribers.push(listener)
+      return () => {
+        storeSubscribers = storeSubscribers.filter((candidate) => candidate !== listener)
+      }
+    }
+  }
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const { buildAgentStatusModuleMock } = await import('./pty-connection-test-environment')
+  return buildAgentStatusModuleMock(await importOriginal<Record<string, unknown>>())
+})
+
+vi.mock('./cache-timer-seeding', () => ({
+  shouldSeedCacheTimerOnInitialTitle
+}))
+
+vi.mock('sonner', () => ({
+  toast: { info: toastInfo }
+}))
+
+vi.mock('@/lib/codex-stale-pane-sweep', () => ({
+  notifyCodexPaneBoundForStaleSweep
+}))
+
+// Why: the pane connection calls the real useNotificationDispatch hook outside React, so useCallback must pass through (safe suite-wide: no test here renders React).
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof React>()
+  return {
+    ...actual,
+    useCallback: <T extends (...args: unknown[]) => unknown>(fn: T): T => fn
+  }
+})
+
+vi.mock('./pty-transport', () => ({
+  createIpcPtyTransport: vi.fn((options: Record<string, unknown>) => {
+    createdTransportOptions.push(options)
+    const nextTransport = transportFactoryQueue.shift()
+    if (!nextTransport) {
+      throw new Error('No mock transport queued')
+    }
+    return nextTransport
+  })
+}))
+
+vi.mock('./remote-runtime-pty-transport', () => ({
+  createRemoteRuntimePtyTransport: vi.fn(
+    (_environmentId: string, options: Record<string, unknown>) => {
+      createdTransportOptions.push(options)
+      const nextTransport = transportFactoryQueue.shift()
+      if (!nextTransport) {
+        throw new Error('No mock transport queued')
+      }
+      return nextTransport
+    }
+  )
+}))
+
+vi.mock('./pty-dispatcher', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    getEagerPtyBufferHandle: vi.fn(() => undefined)
+  }
+})
+
+const WINDOWS_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+const MACOS_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
+const CAPACITY_MARKER = 'too many consoles in use, max consoles is 128'
+const CAPACITY_OUTPUT = `console device allocation failure - ${CAPACITY_MARKER}`
+
+function installSleepingCodexResumeState(restoredPtyId?: string) {
+  const paneKey = makePaneKey('tab-1', LEAF_1)
+  const launchConfig = {
+    agentCommand: "codex '--model' 'gpt-5'",
+    agentArgs: '--model gpt-5',
+    agentEnv: { CODEX_PROFILE: 'captured' }
+  }
+  mockStoreState = {
+    ...mockStoreState,
+    tabsByWorktree: {
+      'wt-1': [{ id: 'tab-1', ...(restoredPtyId ? { ptyId: restoredPtyId } : {}) }]
+    },
+    settings: { ...mockStoreState.settings, agentCmdOverrides: {} },
+    agentStatusByPaneKey: {},
+    sleepingAgentSessionsByPaneKey: {
+      [paneKey]: {
+        paneKey,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        agent: 'codex',
+        providerSession: { key: 'session_id', id: 'codex-session-1' },
+        prompt: 'finish the task',
+        state: 'working',
+        capturedAt: 1,
+        updatedAt: 1,
+        launchConfig
+      }
+    }
+  } as StoreState
+  return launchConfig
+}
+
+type StartedPane = {
+  pane: MockPane
+  manager: ReturnType<typeof createManager>
+  deps: ReturnType<typeof buildPaneConnectionDeps>
+  transport: MockTransport
+  emitOutput: (data: string) => void
+  spawn: (ptyId: string) => void
+  exit: (ptyId: string, exitCode?: number) => void
+}
+
+/** Connect a local pane whose transport hands back `ptyId`, with its output and lifecycle callbacks exposed. */
+async function startPane(
+  options: {
+    userAgent?: string
+    ptyId?: string
+    paneCount?: number
+    deps?: Record<string, unknown>
+  } = {}
+): Promise<StartedPane> {
+  restoreUserAgent = temporarilySetNavigatorUserAgent(options.userAgent ?? WINDOWS_USER_AGENT)
+  const { connectPanePty } = await import('./pty-connection')
+  const ptyId = options.ptyId ?? 'tab-pty'
+  const callbacks: ConnectCallbacks[] = []
+  const transport = createMockTransport(ptyId)
+  transport.connect.mockImplementation(async (connectOptions: { callbacks: ConnectCallbacks }) => {
+    callbacks.push(connectOptions.callbacks)
+    return ptyId
+  })
+  transportFactoryQueue.push(transport)
+  const pane = createPane(1)
+  const manager = createManager(options.paneCount ?? 1)
+  const deps = buildPaneConnectionDeps(() => mockStoreState, {
+    onPaneProcessDied: vi.fn(),
+    ...options.deps
+  })
+
+  connectPanePty(pane as never, manager as never, deps as never)
+
+  const transportOptions = createdTransportOptions[0] ?? {}
+  return {
+    pane,
+    manager,
+    deps,
+    transport,
+    emitOutput: (data) => callbacks.at(-1)?.onData?.(data),
+    spawn: (spawnedPtyId) => (transportOptions.onPtySpawn as (id: string) => void)?.(spawnedPtyId),
+    exit: (exitedPtyId, exitCode) =>
+      (transportOptions.onPtyExit as (id: string, code?: number) => void)?.(exitedPtyId, exitCode)
+  }
+}
+
+function expectCapacityRetention(started: StartedPane, startup: unknown): void {
+  expect(started.deps.onPaneProcessDied).toHaveBeenCalledWith({
+    paneId: 1,
+    exitCode: 1,
+    startup,
+    reason: 'git-bash-console-capacity'
+  })
+  expect(started.deps.onPtyExitRef.current).not.toHaveBeenCalled()
+  expect(started.manager.closePane).not.toHaveBeenCalled()
+}
+
+describe('Git Bash console-capacity pane retention (STA-5604)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    transportFactoryQueue = []
+    createdTransportOptions = []
+    storeSubscribers = []
+    restoreUserAgent = null
+    mockStoreState = createInitialStoreState(() => mockStoreState)
+    installTerminalTestGlobals()
+  })
+
+  afterEach(async () => {
+    restoreUserAgent?.()
+    await restoreTerminalTestGlobals()
+  })
+
+  it('retains a fresh native-Windows PTY that printed the exact capacity marker', async () => {
+    const startup = { command: 'codex --resume session-1' }
+    const started = await startPane({ deps: { startup } })
+
+    started.spawn('tab-pty')
+    started.emitOutput(CAPACITY_OUTPUT)
+    started.exit('tab-pty', 1)
+
+    expectCapacityRetention(started, startup)
+  })
+
+  it('detects the marker when it is split across output chunks', async () => {
+    const startup = { command: 'codex' }
+    const started = await startPane({ deps: { startup } })
+
+    started.spawn('tab-pty')
+    started.emitOutput('console device allocation failure - too many consoles ')
+    started.emitOutput('in use, max consoles is 128\r\n')
+    started.exit('tab-pty', 1)
+
+    expectCapacityRetention(started, startup)
+  })
+
+  it('does not classify near-miss console output as a capacity failure', async () => {
+    const started = await startPane()
+
+    started.spawn('tab-pty')
+    started.emitOutput('too many consoles in use, max consoles is 127')
+    started.exit('tab-pty', 1)
+
+    expect(started.deps.onPaneProcessDied).not.toHaveBeenCalled()
+  })
+
+  it('tears down an ordinary non-zero local exit the user asked for', async () => {
+    // Why (#16045 regression): `exit` after a failed command is a deliberate close, not a console-capacity failure.
+    const started = await startPane()
+
+    started.spawn('tab-pty')
+    started.emitOutput('bash: nope: command not found\r\n')
+    sendTerminalInputThroughPane(started.pane, 'exit\r')
+    started.exit('tab-pty', 1)
+
+    expect(started.deps.onPaneProcessDied).not.toHaveBeenCalled()
+    expect(started.deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
+  })
+
+  it('does not retain a capacity marker printed after user input', async () => {
+    const started = await startPane()
+
+    started.spawn('tab-pty')
+    sendTerminalInputThroughPane(started.pane, 'ls\r')
+    started.emitOutput(CAPACITY_OUTPUT)
+    started.exit('tab-pty', 1)
+
+    expect(started.deps.onPaneProcessDied).not.toHaveBeenCalled()
+    expect(started.deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
+  })
+
+  it('treats an unsettled user write as interaction when the exit beats its acknowledgement', async () => {
+    const started = await startPane()
+    started.transport.sendInputAccepted?.mockImplementation(() => new Promise<boolean>(() => {}))
+
+    started.spawn('tab-pty')
+    sendTerminalInputThroughPane(started.pane, '\u0003')
+    started.emitOutput(CAPACITY_OUTPUT)
+    started.exit('tab-pty', 1)
+
+    // The unchanged sole-pane guard still keeps a never-typed-into newborn mounted,
+    // so the load-bearing assertion is that no capacity overlay claims this exit.
+    expect(started.deps.onPaneProcessDied).not.toHaveBeenCalled()
+    expect(started.manager.closePane).not.toHaveBeenCalled()
+  })
+
+  it('retains the cold-restore resume startup when its replacement hits capacity', async () => {
+    restoreUserAgent = temporarilySetNavigatorUserAgent(WINDOWS_USER_AGENT)
+    const { connectPanePty } = await import('./pty-connection')
+    const callbacks: ConnectCallbacks[] = []
+    const transport = createMockTransport('resume-pty')
+    transport.connect.mockImplementation(async (options: { callbacks: ConnectCallbacks }) => {
+      callbacks.push(options.callbacks)
+      return 'resume-pty'
+    })
+    transportFactoryQueue.push(transport)
+    const launchConfig = installSleepingCodexResumeState()
+    const deps = buildPaneConnectionDeps(() => mockStoreState, {
+      startup: { command: 'codex stale-startup' },
+      onPaneProcessDied: vi.fn()
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+    const transportOptions = createdTransportOptions[0] ?? {}
+    ;(transportOptions.onPtySpawn as (id: string) => void)?.('resume-pty')
+    callbacks[0]?.onData?.(CAPACITY_MARKER)
+    ;(transportOptions.onPtyExit as (id: string, code?: number) => void)?.('resume-pty', 1)
+
+    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
+      paneId: 1,
+      exitCode: 1,
+      startup: expect.objectContaining({
+        command: expect.stringContaining("'resume' 'codex-session-1'"),
+        launchConfig,
+        resumeProviderSession: { key: 'session_id', id: 'codex-session-1' },
+        launchAgent: 'codex',
+        showSessionRestoredBanner: true
+      }),
+      reason: 'git-bash-console-capacity'
+    })
+  })
+
+  it('does not carry one PTY capacity match into its cold-restore replacement', async () => {
+    restoreUserAgent = temporarilySetNavigatorUserAgent(WINDOWS_USER_AGENT)
+    const { connectPanePty } = await import('./pty-connection')
+    const callbacks: ConnectCallbacks[] = []
+    let currentPtyId = 'lost-pty'
+    const transport = createMockTransport(currentPtyId)
+    transport.getPtyId.mockImplementation(() => currentPtyId)
+    transport.connect.mockImplementation(
+      async (options: { sessionId?: string; callbacks: ConnectCallbacks }) => {
+        callbacks.push(options.callbacks)
+        if (options.sessionId) {
+          // Only the lost session printed the marker; its replacement must not inherit the match.
+          options.callbacks.onData?.(CAPACITY_MARKER)
+          return { id: currentPtyId, sessionExpired: true }
+        }
+        currentPtyId = 'resume-pty'
+        return currentPtyId
+      }
+    )
+    transportFactoryQueue.push(transport)
+    installSleepingCodexResumeState('lost-pty')
+    const deps = buildPaneConnectionDeps(() => mockStoreState, {
+      onPaneProcessDied: vi.fn(),
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'lost-pty' }
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(30)
+    expect(callbacks).toHaveLength(2)
+    const transportOptions = createdTransportOptions[0] ?? {}
+    ;(transportOptions.onPtySpawn as (id: string) => void)?.('resume-pty')
+    ;(transportOptions.onPtyExit as (id: string, code?: number) => void)?.('resume-pty', 1)
+
+    expect(deps.onPaneProcessDied).not.toHaveBeenCalled()
+  })
+
+  it('does not retain a reattached PTY that was never freshly spawned', async () => {
+    const started = await startPane()
+
+    // No spawn callback: reattach and cold-restore skip onPtySpawn (pty-transport.ts).
+    started.emitOutput(CAPACITY_OUTPUT)
+    started.exit('tab-pty', 1)
+
+    expect(started.deps.onPaneProcessDied).not.toHaveBeenCalled()
+    expect(started.deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
+  })
+
+  it('leaves a clean exit alone even when the marker is somewhere in its output', async () => {
+    const started = await startPane()
+
+    started.spawn('tab-pty')
+    started.emitOutput(CAPACITY_OUTPUT)
+    started.exit('tab-pty', 0)
+
+    expect(started.deps.onPaneProcessDied).not.toHaveBeenCalled()
+  })
+
+  it('leaves a Windows-client remote-runtime pane on the unchanged teardown path', async () => {
+    // Why: a paired-web mirrored pane keeps its worktree's local execution host, so the
+    // native-ConPTY verdict is true on a Windows client even though the PTY runs on the HUB.
+    restoreUserAgent = temporarilySetNavigatorUserAgent(WINDOWS_USER_AGENT)
+    const { connectPanePty } = await import('./pty-connection')
+    const tabId = 'web-terminal-host-tab'
+    const ptyId = 'remote:hub-web@@terminal-1'
+    const transport = createMockTransport(ptyId)
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: tabId, ptyId }] },
+      ptyIdsByTabId: { [tabId]: [ptyId] },
+      worktreesByRepo: {
+        repo1: [{ id: 'wt-1', repoId: 'repo1', path: '/srv/wt-1', hostId: 'local' }]
+      },
+      repos: [{ id: 'repo1', connectionId: null, executionHostId: 'local' }]
+    } as StoreState
+    const deps = buildPaneConnectionDeps(() => mockStoreState, {
+      tabId,
+      onPaneProcessDied: vi.fn(),
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: ptyId }
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+    const attachCallbacks = (
+      transport.attach.mock.calls[0]?.[0] as { callbacks?: ConnectCallbacks } | undefined
+    )?.callbacks
+    expect(attachCallbacks?.onData).toBeTypeOf('function')
+    const transportOptions = createdTransportOptions[0] ?? {}
+    ;(transportOptions.onPtySpawn as (id: string) => void)?.(ptyId)
+    attachCallbacks?.onData?.(CAPACITY_OUTPUT)
+    ;(transportOptions.onPtyExit as (id: string, code?: number) => void)?.(ptyId, 1)
+
+    expect(deps.onPaneProcessDied).not.toHaveBeenCalled()
+  })
+
+  it('leaves macOS and Linux local exits on the unchanged teardown path', async () => {
+    const started = await startPane({ userAgent: MACOS_USER_AGENT })
+
+    started.spawn('tab-pty')
+    started.emitOutput(CAPACITY_OUTPUT)
+    started.exit('tab-pty', 1)
+
+    expect(started.deps.onPaneProcessDied).not.toHaveBeenCalled()
+  })
+
+  it('keeps a freshly split Windows pane visible when its newborn PTY hits the console ceiling', async () => {
+    const startup = { command: 'codex' }
+    const started = await startPane({
+      paneCount: 2,
+      deps: {
+        startup,
+        paneTransportsRef: { current: new Map([[2, createMockTransport('pty-pane-2')]]) }
+      }
+    })
+
+    started.spawn('tab-pty')
+    started.emitOutput(CAPACITY_OUTPUT)
+    started.exit('tab-pty', 1)
+
+    expectCapacityRetention(started, startup)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
@@ -1,8 +1,6 @@
 import type * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { sendTerminalInputThroughPane } from './pty-connection-test-dom'
-import { flushAsyncTicks } from './pty-connection-test-async'
 import {
   LEAF_1,
   LEAF_2,
@@ -129,38 +127,6 @@ vi.mock('./pty-dispatcher', async (importOriginal) => {
 
 function createDeps(overrides: Record<string, unknown> = {}) {
   return buildPaneConnectionDeps(() => mockStoreState, overrides)
-}
-
-function installSleepingCodexResumeState(restoredPtyId?: string) {
-  const paneKey = makePaneKey('tab-1', LEAF_1)
-  const launchConfig = {
-    agentCommand: "codex '--model' 'gpt-5'",
-    agentArgs: '--model gpt-5',
-    agentEnv: { CODEX_PROFILE: 'captured' }
-  }
-  mockStoreState = {
-    ...mockStoreState,
-    tabsByWorktree: {
-      'wt-1': [{ id: 'tab-1', ...(restoredPtyId ? { ptyId: restoredPtyId } : {}) }]
-    },
-    settings: { ...mockStoreState.settings, agentCmdOverrides: {} },
-    agentStatusByPaneKey: {},
-    sleepingAgentSessionsByPaneKey: {
-      [paneKey]: {
-        paneKey,
-        tabId: 'tab-1',
-        worktreeId: 'wt-1',
-        agent: 'codex',
-        providerSession: { key: 'session_id', id: 'codex-session-1' },
-        prompt: 'finish the task',
-        state: 'working',
-        capturedAt: 1,
-        updatedAt: 1,
-        launchConfig
-      }
-    }
-  } as StoreState
-  return launchConfig
 }
 
 describe('connectPanePty', () => {
@@ -422,7 +388,9 @@ describe('connectPanePty', () => {
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 
-  it('keeps a failed local terminal visible after user input', async () => {
+  it('tears down a failed local terminal the user typed into', async () => {
+    // Why (#16045 regression): a non-zero exit after user input is an ordinary
+    // teardown, not a console-capacity failure — the pane must not be retained.
     const { connectPanePty } = await import('./pty-connection')
     const pane = createPane(1)
     const transport = createMockTransport('tab-pty')
@@ -438,17 +406,12 @@ describe('connectPanePty', () => {
     sendTerminalInputThroughPane(pane, 'agent startup\r')
     onPtyExit?.('tab-pty', 1)
 
-    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
-      paneId: 1,
-      exitCode: 1,
-      startup: null,
-      reason: 'process-failed'
-    })
-    expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
+    expect(deps.onPaneProcessDied).not.toHaveBeenCalled()
+    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 
-  it('keeps a failed local split pane visible', async () => {
+  it('closes a failed local split pane whose PTY was never freshly spawned', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('tab-pty')
     transportFactoryQueue.push(transport)
@@ -461,123 +424,8 @@ describe('connectPanePty', () => {
       | undefined
     onPtyExit?.('tab-pty', 1)
 
-    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
-      paneId: 1,
-      exitCode: 1,
-      startup: null,
-      reason: 'process-failed'
-    })
-    expect(manager.closePane).not.toHaveBeenCalled()
-  })
-
-  it('classifies the Git Bash capacity failure before retaining its pane', async () => {
-    const { connectPanePty } = await import('./pty-connection')
-    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-    const transport = createMockTransport('tab-pty')
-    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-      capturedDataCallback.current = callbacks.onData ?? null
-      return 'tab-pty'
-    })
-    transportFactoryQueue.push(transport)
-    const manager = createManager(1)
-    const startup = { command: 'codex --resume session-1' }
-    const deps = createDeps({ onPaneProcessDied: vi.fn(), startup })
-
-    connectPanePty(createPane(1) as never, manager as never, deps as never)
-    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
-      | ((ptyId: string, exitCode?: number) => void)
-      | undefined
-
-    capturedDataCallback.current?.(
-      'console device allocation failure - too many consoles in use, max consoles is 128'
-    )
-    onPtyExit?.('tab-pty', 1)
-
-    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
-      paneId: 1,
-      exitCode: 1,
-      startup,
-      reason: 'git-bash-console-capacity'
-    })
-    expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
-  })
-
-  it('retains the cold-restore resume startup when its replacement hits capacity', async () => {
-    const { connectPanePty } = await import('./pty-connection')
-    const callbacks: ConnectCallbacks[] = []
-    const transport = createMockTransport('resume-pty')
-    transport.connect.mockImplementation(async (options: { callbacks: ConnectCallbacks }) => {
-      callbacks.push(options.callbacks)
-      return 'resume-pty'
-    })
-    transportFactoryQueue.push(transport)
-    const launchConfig = installSleepingCodexResumeState()
-    const deps = createDeps({
-      startup: { command: 'codex stale-startup' },
-      onPaneProcessDied: vi.fn()
-    })
-
-    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
-    await flushAsyncTicks(20)
-    callbacks[0]?.onData?.('too many consoles in use, max consoles is 128')
-    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
-      | ((ptyId: string, exitCode?: number) => void)
-      | undefined
-    onPtyExit?.('resume-pty', 1)
-
-    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
-      paneId: 1,
-      exitCode: 1,
-      startup: expect.objectContaining({
-        command: expect.stringContaining("'resume' 'codex-session-1'"),
-        launchConfig,
-        resumeProviderSession: { key: 'session_id', id: 'codex-session-1' },
-        launchAgent: 'codex',
-        showSessionRestoredBanner: true
-      }),
-      reason: 'git-bash-console-capacity'
-    })
-  })
-
-  it('does not carry capacity detection into a cold-restore replacement', async () => {
-    const { connectPanePty } = await import('./pty-connection')
-    const callbacks: ConnectCallbacks[] = []
-    let currentPtyId = 'lost-pty'
-    const transport = createMockTransport(currentPtyId)
-    transport.getPtyId.mockImplementation(() => currentPtyId)
-    transport.connect.mockImplementation(
-      async (options: { sessionId?: string; callbacks: ConnectCallbacks }) => {
-        callbacks.push(options.callbacks)
-        if (options.sessionId) {
-          options.callbacks.onData?.('too many consoles in use, max consoles is 128')
-          return { id: currentPtyId, sessionExpired: true }
-        }
-        currentPtyId = 'resume-pty'
-        return currentPtyId
-      }
-    )
-    transportFactoryQueue.push(transport)
-    installSleepingCodexResumeState('lost-pty')
-    const deps = createDeps({
-      onPaneProcessDied: vi.fn(),
-      restoredLeafId: LEAF_1,
-      restoredPtyIdByLeafId: { [LEAF_1]: 'lost-pty' }
-    })
-
-    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
-    await flushAsyncTicks(30)
-    expect(callbacks).toHaveLength(2)
-    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
-      | ((ptyId: string, exitCode?: number) => void)
-      | undefined
-    onPtyExit?.('resume-pty', 1)
-
-    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
-      paneId: 1,
-      exitCode: 1,
-      startup: null,
-      reason: 'process-failed'
-    })
+    expect(deps.onPaneProcessDied).not.toHaveBeenCalled()
+    expect(manager.closePane).toHaveBeenCalledWith(1)
   })
 
   it('does not retain a failed direct-SSH terminal locally', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection/pty-exit-hibernate.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pty-exit-hibernate.ts
@@ -25,10 +25,12 @@ export function installPtyExitHibernate(session: ConnectPanePtySession): void {
   type ProcessExitState = {
     startup: PtyPaneStartup
     detector: GitBashConsoleCapacityDetector
+    userInteracted: boolean
   }
   session.createProcessExitState = (startup: PtyPaneStartup): ProcessExitState => ({
     startup,
-    detector: createGitBashConsoleCapacityDetector()
+    detector: createGitBashConsoleCapacityDetector(),
+    userInteracted: false
   })
   session.currentProcessExitState = session.createProcessExitState(session.paneStartup)
   session.processExitStateByPtyId = new Map<string, ProcessExitState>()
@@ -40,6 +42,16 @@ export function installPtyExitHibernate(session: ConnectPanePtySession): void {
     if (replacedPtyId && replacedPtyId !== ptyId) {
       session.processExitStateByPtyId.delete(replacedPtyId)
     }
+  }
+  // Why: the capacity overlay may only claim a shell that died on startup. Mark
+  // at the write *attempt* (not the async accept) and key it to the PTY that was
+  // bound then, so an in-flight write counts as interaction and a late accept can
+  // never make a replacement PTY look typed-into.
+  session.noteTerminalInputForPty = (ptyId: string | null | undefined): void => {
+    const state: ProcessExitState =
+      (ptyId ? session.processExitStateByPtyId.get(ptyId) : undefined) ??
+      session.currentProcessExitState
+    state.userInteracted = true
   }
   session.focusSurvivingPtyPaneAfterKeptExit = (): void => {
     if (session.manager.getActivePane()?.id !== session.pane.id) {
@@ -280,15 +292,25 @@ export function installPtyExitHibernate(session: ConnectPanePtySession): void {
       return
     }
     session.manager.setPaneGpuRendering(session.pane.id, true)
-    const failedLocalProcess =
-      !session.connectionId && session.runtimeEnvironmentId === null && exitCode !== 0
-    if (failedLocalProcess && session.deps.onPaneProcessDied) {
-      const gitBashConsoleCapacityFailure = processExitState.detector.detected()
+    // Why (#16045 regression): retaining every non-zero local exit is not a
+    // capacity detector — an ordinary shell exiting after a failed command hit it
+    // on macOS/Linux too. Claim the exit only for the Windows Git Bash console
+    // ceiling: a native local ConPTY whose *own* fresh spawn died non-zero before
+    // any input, having printed the exact MSYS marker. Everything else falls
+    // through to the unchanged teardown path below.
+    const gitBashConsoleCapacityFailure =
+      session.isNativeWindowsConpty &&
+      session.runtimeEnvironmentId === null &&
+      exitCode !== 0 &&
+      session.spawnedFreshPtyId === ptyId &&
+      !processExitState.userInteracted &&
+      processExitState.detector.detected()
+    if (gitBashConsoleCapacityFailure && session.deps.onPaneProcessDied) {
       session.deps.onPaneProcessDied({
         paneId: session.pane.id,
         exitCode,
-        startup: gitBashConsoleCapacityFailure ? processExitState.startup : null,
-        reason: gitBashConsoleCapacityFailure ? 'git-bash-console-capacity' : 'process-failed'
+        startup: processExitState.startup,
+        reason: 'git-bash-console-capacity'
       })
       return
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection/pty-input-forward.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pty-input-forward.ts
@@ -90,6 +90,10 @@ export function installPtyInputForward(session: ConnectPanePtySession): void {
       session.clearPendingTerminalInputIntent()
       return
     }
+    // Why here: the last chokepoint every dropped-input guard has already passed,
+    // and before any send branch — so paste/drop/quick-command input marks this
+    // PTY as interacted without threading a signal through each caller.
+    session.noteTerminalInputForPty(currentPtyId)
     const intent = session.pendingTerminalInputIntent
     // Why: real xterm can deliver the terminal byte even when our DOM keydown
     // listener missed the press. Exact Ctrl+C/Escape bytes are still safe to


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​530 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​160 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​370 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |

<!-- /orca-pr-loc -->

## ELI5

On Windows, Git Bash refuses to start once 128 consoles are open. When that happens we keep the dead terminal on screen with an explanation and a **Restart** button instead of silently closing it. #16045 shipped that feature but wired the "keep it open" decision to the wrong condition: it kept **any** local terminal that exited non-zero. So on macOS and Linux, typing `exit` after a command that failed left a dead pane sitting there.

This PR makes the keep-it-open path fire only for the actual Windows console-limit failure. Everything else exits the way it did before #16045.

## What Changed

`onExit` in `pty-connection/pty-exit-hibernate.ts` no longer retains on `!connectionId && runtimeEnvironmentId === null && exitCode !== 0`. It now claims the exit only when **all** of these hold:

| Condition | Signal used |
| --- | --- |
| native Windows ConPTY **and** local pane | `session.isNativeWindowsConpty` (already resolves execution host + SSH + WSL) |
| not a remote-runtime pane | `session.runtimeEnvironmentId === null` |
| non-zero exit | `exitCode !== 0` |
| the same PTY whose **fresh spawn** we observed | `session.spawnedFreshPtyId === ptyId` (reattach / cold-restore never fire `onPtySpawn`) |
| that PTY received no user input | new `userInteracted` flag on the existing per-PTY process-exit record |
| that PTY printed the exact MSYS marker | existing `GitBashConsoleCapacityDetector` (already chunk-spanning) |

Anything else falls through to the **unchanged** teardown path — including the pre-existing sole-pane direnv guard and the fresh-split guard.

The per-PTY input flag reuses the record `#16045` already created per PTY (`createProcessExitState` / `bindProcessExitState` / delete-on-exit). It is set in one place — the `forwardPtyInput` chokepoint, after every drop guard and **before** any send branch — so:

- an **in-flight** write counts as interaction immediately (an exit that beats the acknowledgement cannot be misread as "never typed into");
- a **late** acknowledgement from an old PTY can never mark a replacement PTY, because the flag is keyed to the PTY bound at write time;
- paste / drop / programmatic / quick-command input is covered without threading a new signal through each caller.

No new RPC or wire fields. No transport-keyed global map. No SSH, relay, remote-runtime, reattach, macOS, Linux, or mobile behavior changed.

## Why

`!connectionId && runtimeEnvironmentId === null && exitCode !== 0` is not a console-capacity detector — it is "any failed local process". The marker match was only used to pick the overlay's label, so it never decided whether retention happened. This restores pre-#16045 teardown for every unrelated exit while keeping the Windows recovery UX intact.

## Linked Issue

STA-5604 — https://linear.app/stably/issue/STA-5604/forward-port-the-f6-terminal-exit-retention-fix-to-main-only-on-the

(Forward-port of the fix that until now existed only on the 1.4.189 cherry-pick branch, `ef7cd03ab8`. This version is stricter than that one: 1.4.189 still retained non-capacity failed local startups as `process-failed`; per the issue's contract, only the capacity path may call `onPaneProcessDied` here.)

## Visual Proof

N/A — I have no Windows host, so I cannot record the overlay. The behavior change on macOS/Linux is the *absence* of a pane that should not have been retained; it is covered by the automated tests below.

## Testing

`src/renderer/src/components/terminal-pane/pty-connection-git-bash-console-capacity.test.ts` (new, 13 tests) plus 2 rewritten tests in `pty-connection-pty-exit-teardown.test.ts`.

Local runs on macOS:

- `pnpm tc` — exit 0
- `npx oxlint src/renderer/src/components/terminal-pane/` — clean
- `oxlint --type-aware --config config/oxlint-code-quality-type-aware.json` and `--config config/oxlint-react-doctor.json` on the 4 changed files — clean
- `npx oxfmt --write` on the 4 changed files only (never `pnpm format`)
- `git diff --check` — clean
- Full `src/renderer/src/components/terminal-pane/` suite — **406 files / 3925 tests, all passing**

### Failing-first proof

Every test was run against the pre-fix tree by stashing **only** the two production hunks (`git stash push -- src/renderer/src/components/terminal-pane/pty-connection/`) and re-running with the new tests in place.

**9 of 15 fail pre-fix:**

```
× capacity > does not classify near-miss console output as a capacity failure
× capacity > tears down an ordinary non-zero local exit the user asked for
× capacity > does not retain a capacity marker printed after user input
× capacity > treats an unsettled user write as interaction when the exit beats its acknowledgement
× capacity > does not carry one PTY capacity match into its cold-restore replacement
× capacity > does not retain a reattached PTY that was never freshly spawned
× capacity > leaves macOS and Linux local exits on the unchanged teardown path
× teardown > tears down a failed local terminal the user typed into
× teardown > closes a failed local split pane whose PTY was never freshly spawned
```

After the fix, all 15 pass.

**The other 6 cannot fail pre-fix, and I want to be explicit about why rather than dress them up.** Pre-fix retention was a strict *superset* of correct retention (it kept everything), so no positive-retention assertion can distinguish pre-fix from post-fix. Those 6 are preservation tests:

| Test | Why it passes pre-fix |
| --- | --- |
| retains a fresh native-Windows PTY that printed the exact capacity marker | pre-fix retained it too (over-broadly) |
| detects the marker when it is split across output chunks | same |
| retains the cold-restore resume startup when its replacement hits capacity | same |
| keeps a freshly split Windows pane visible when its newborn PTY hits the console ceiling | same |
| leaves a clean exit alone even when the marker is in its output | `exitCode !== 0` was already in the #16045 condition |
| leaves a Windows-client remote-runtime pane on the unchanged teardown path | `runtimeEnvironmentId === null` was already in the #16045 condition |

Their value is proven by the ablation gate instead — each one goes red when the clause it guards is removed (rows A2, A3, A9 below).

### Ablation gate

Each production clause reverted **individually**, suite re-run. No clause is uncovered.

| # | Ablation | Failing tests | Which |
| --- | --- | --- | --- |
| A1 | drop `session.isNativeWindowsConpty` | 1 | leaves macOS and Linux local exits on the unchanged teardown path |
| A2 | drop `runtimeEnvironmentId === null` | 1 | leaves a Windows-client remote-runtime pane on the unchanged teardown path |
| A3 | drop `exitCode !== 0` | 1 | leaves a clean exit alone even when the marker is in its output |
| A4 | drop `spawnedFreshPtyId === ptyId` | 1 | does not retain a reattached PTY that was never freshly spawned |
| A5 | drop `!processExitState.userInteracted` | 2 | marker after user input; unsettled user write |
| A6 | drop `detector.detected()` | 2 | near-miss console output; cold-restore replacement |
| A7 | restore the whole #16045 broad policy | 9 | every failing-first test above |
| A8 | remove `noteTerminalInputForPty` at the input chokepoint | 2 | marker after user input; unsettled user write |
| A9 | delete the capacity branch entirely | 4 | all four positive-retention preservation tests |

A1–A3 were the gate working as intended: on the first pass A2 and A3 were uncovered, so I added the two tests that now cover them (and had to fix the remote-runtime test — my first version attached rather than connected, so its marker never reached the detector and it passed vacuously).

## What I did NOT verify

- **No Windows host.** I did not run Orca on Windows, did not exhaust Git Bash's 128-console limit, and did not see the capacity overlay or its Restart button render. Every Windows claim here rests on unit tests with a stubbed Windows user agent and the existing `isLocalNativeWindowsConpty` classifier — not on observed behavior on a real ConPTY.
- No manual macOS/Linux run either; the macOS/Linux claim is likewise test-only.
- No packaged-build or e2e verification.

## Known follow-ups (deliberately not in this PR)

- `PaneProcessExit.reason` still carries `'process-failed'`, and `TerminalProcessExitOverlay` still has its fallback copy in 5 locale files. Nothing in `pty-connection` emits that reason any more. Removing it would touch the overlay, its test, and every locale file — well outside "keep the code and test diff limited to this behavior", and the issue names a possible follow-up (a structured host-side spawn-failure reason) that would repopulate it.
- Conservative bias worth knowing: input typed while the transport has no PTY bound yet marks the current generation as interacted. Such a write never reaches a shell (`sendInput` returns `false` with no `ptyId`), so this can only suppress the overlay, never wrongly show it.

## AI Disclosure

<!-- internal contributor -->

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` with reason for visual proof (no Windows host)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered — the whole point of the change
- [x] Lint, typecheck, and the focused test suites pass locally; `pnpm build` left to CI
