### PR TITLE
test(release): bound Windows skill budget fixture

### DIFF
--- a/src/main/skills/skill-freshness-inventory.test.ts
+++ b/src/main/skills/skill-freshness-inventory.test.ts
@@ -911,5 +911,5 @@ describe('read-only skill freshness inventory', () => {
     expect(inventory.installations).toEqual([
       expect.objectContaining({ name: 'orca-cli', status: 'current', topology: 'canonical-copy' })
     ])
-  })
+  }, 90_000)
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Summary

- give the real 4,097-entry plugin-cache budget fixture a bounded 90-second timeout
- keep the production entry limit and assertions unchanged

## Why

Production recovery run 33154149149 completed this Windows stress fixture in about 39 seconds, but Vitest inherited the global 30-second timeout and marked it failed after execution. The JSON report showed no failed correctness assertion. The release remained draft and unpublished.

## Validation

- `pnpm test src/main/skills/skill-freshness-inventory.test.ts` (29/29)
- `pnpm run check:code-quality:changed` (zero findings)
- `git diff --check`

## Release safety

Test-only change. Product code, immutable `v1.4.191`, and release artifacts are unchanged.

## Visual proof

N/A — test harness only.

## AI disclosure

Implemented with Codex assistance and validated with focused automated checks.