### PR TITLE
fix(mobile): keep current notification session

### DIFF
--- a/mobile/src/navigation/host-stack-navigation.test.ts
+++ b/mobile/src/navigation/host-stack-navigation.test.ts
@@ -43,7 +43,14 @@ function navigationHarness(initialState: HostStackNavigationState | undefined) {
   }
 }
 
-function committedHostState(hostIdParam: string): HostStackNavigationState {
+function committedHostState(
+  hostIdParam: string,
+  activeRoute: HostStackNavigationState['routes'][number] = {
+    key: 'host-index',
+    name: '[hostId]/index',
+    params: { hostId: hostIdParam }
+  }
+): HostStackNavigationState {
   return {
     index: 0,
     routes: [
@@ -52,7 +59,7 @@ function committedHostState(hostIdParam: string): HostStackNavigationState {
         state: {
           key: '/h',
           index: 0,
-          routes: [{ key: 'host-index', name: '[hostId]/index', params: { hostId: hostIdParam } }]
+          routes: [activeRoute]
         }
       }
     ]
@@ -66,6 +73,50 @@ function rootLayoutScopedState(inner: HostStackNavigationState): HostStackNaviga
 }
 
 describe('host stack navigation', () => {
+  it('does not navigate when the target session is already focused', () => {
+    const harness = navigationHarness(
+      committedHostState('host/one', {
+        key: 'session',
+        name: '[hostId]/session/[worktreeId]',
+        params: { hostId: 'host/one', worktreeId: 'repo::/tmp/wt' }
+      })
+    )
+    const push = vi.fn()
+    const replace = vi.fn()
+
+    const controller = navigateToHostStackRoute(
+      harness.navigation,
+      { push, replace },
+      'host/one',
+      OTHER_TARGET
+    )
+
+    expect(controller.isActive()).toBe(false)
+    expect(push).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
+    expect(harness.navigation.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('preserves navigation for matching non-session routes with different context', () => {
+    const harness = navigationHarness(
+      committedHostState('host/one', {
+        name: '[hostId]/tasks',
+        params: { hostId: 'host/one', taskSource: 'linear' }
+      })
+    )
+    const push = vi.fn()
+
+    const controller = navigateToHostStackRoute(
+      harness.navigation,
+      { push, replace: vi.fn() },
+      'host/one',
+      TARGET
+    )
+
+    expect(controller.isActive()).toBe(true)
+    expect(push).toHaveBeenCalledWith(hostStackHostRoute('host/one'))
+  })
+
   it('matches a host committed as the encoded segment it was pushed as', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
     const push = vi.fn()
@@ -219,5 +270,36 @@ describe('host stack navigation', () => {
     expect(harness.navigation.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ payload: OTHER_TARGET })
     )
+  })
+
+  it('cancels a pending transition when its next target is already focused', () => {
+    const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
+    const push = vi.fn()
+    const router = { push, replace: vi.fn() }
+    const pending = coordinateHostStackNavigation(
+      null,
+      harness.navigation,
+      router,
+      'host/one',
+      TARGET
+    )
+    harness.setState(
+      committedHostState('host/one', {
+        name: '[hostId]/session/[worktreeId]',
+        params: { hostId: 'host/one', worktreeId: 'repo::/tmp/wt' }
+      })
+    )
+
+    const result = coordinateHostStackNavigation(
+      pending,
+      harness.navigation,
+      router,
+      'host/one',
+      OTHER_TARGET
+    )
+
+    expect(result.controller.isActive()).toBe(false)
+    expect(harness.listenerCount()).toBe(0)
+    expect(push).toHaveBeenCalledTimes(1)
   })
 })

--- a/mobile/src/navigation/host-stack-navigation.ts
+++ b/mobile/src/navigation/host-stack-navigation.ts
@@ -7,7 +7,7 @@ export type HostStackNavigationState = Readonly<{
 export type HostStackNavigationRoute = Readonly<{
   key?: string
   name: string
-  params?: Readonly<{ hostId?: unknown }>
+  params?: Readonly<Record<string, unknown>>
   state?: HostStackNavigationState
 }>
 
@@ -80,6 +80,27 @@ function hostParamMatches(param: unknown, expectedHostId: string): boolean {
   }
 }
 
+function routeMatchesTarget(
+  route: HostStackNavigationRoute | undefined,
+  target: HostStackRouteTarget
+): boolean {
+  return (
+    route?.name === '[hostId]/session/[worktreeId]' &&
+    target.name === route.name &&
+    hostParamMatches(route.params?.hostId, target.params.hostId) &&
+    route.params?.worktreeId === target.params.worktreeId
+  )
+}
+
+function navigationMatchesTarget(
+  navigation: HostStackRootNavigation,
+  target: HostStackRouteTarget
+): boolean {
+  const state = navigation.getState()
+  const host = state && focusedHostRoute(state)
+  return routeMatchesTarget(host?.state?.routes[host.state.index], target)
+}
+
 /** The focused `h` route, however deep the caller's navigator sits above it: a screen
  *  inside the root stack sees it at the top, but app/_layout.tsx is itself a screen of
  *  Expo Router's internal navigator, so from there the root stack is one level down. */
@@ -124,6 +145,10 @@ export function navigateToHostStackRoute(
   hostId: string,
   target: HostStackRouteTarget
 ): HostStackNavigationController {
+  if (navigationMatchesTarget(navigation, target)) {
+    return { cancel: () => {}, isActive: () => false, retarget: () => {} }
+  }
+
   let active = true
   let hostRouteSeen = false
   let selectedTarget = target
@@ -194,6 +219,13 @@ export function coordinateHostStackNavigation(
   hostId: string,
   target: HostStackRouteTarget
 ): PendingHostStackNavigation {
+  if (navigationMatchesTarget(navigation, target)) {
+    current?.controller.cancel()
+    return {
+      hostId,
+      controller: navigateToHostStackRoute(navigation, router, hostId, target)
+    }
+  }
   if (current?.hostId === hostId && current.controller.isActive()) {
     current.controller.retarget(target)
     return current


### PR DESCRIPTION
## ELI5

Tapping a notification for the screen already open on Mobile no longer reloads that session and disables chat sending.

## What Changed

- Treat an already-focused mobile session with the same `hostId` and `worktreeId` as a navigation no-op.
- Cancel a pending same-host transition before it can retarget away from the already-focused session.
- Preserve existing navigation for cold starts, different sessions, and non-session routes.
- Add regression coverage for the same-session path, pending-transition race, and non-session route context.

## Why

Notification routing previously pushed and replaced the host stack even when its target session was already focused. That detach cleared the Native Chat terminal input lease, while unchanged route identity could prevent hydration effects from rearming it, leaving Send disabled.

## Linked Issue

Fixes #16995

## Visual Proof

N/A — no layout or styling change; navigation side effects are covered by regression tests.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `cd mobile && pnpm test` — 476 files passed, 3,849 tests passed, 3 skipped
- `cd mobile && pnpm typecheck` — no errors
- `cd mobile && pnpm exec oxlint src/navigation/host-stack-navigation.ts src/navigation/host-stack-navigation.test.ts` — passed

## AI Disclosure

## Review

Independent code review completed; no remaining findings after addressing the pending-transition and route-scope edge cases.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The guard is scoped to the shared mobile session route and compares only host/worktree identity. It does not change wire data, execution ownership, filesystem paths, SSH behavior, or platform-specific input handling.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Mobile tests and typecheck passed locally; targeted lint passed. CI will cover the remaining repository-wide lint/build gates.