### PR TITLE
fix(appearance): keep low-contrast themes legible in match-terminal sidebar and terminal ghost text

### DIFF
--- a/src/renderer/src/components/dashboard-popout/preview-terminal-options.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-options.ts
@@ -80,7 +80,8 @@ export function buildPreviewTerminalOptions(args: {
     theme: args.theme ?? undefined,
     minimumContrastRatio: resolveTerminalMinimumContrastRatio(
       args.theme?.background,
-      args.themeMode
+      args.themeMode,
+      args.theme?.foreground
     )
   }
 }

--- a/src/renderer/src/components/settings/SettingsSidebar.tsx
+++ b/src/renderer/src/components/settings/SettingsSidebar.tsx
@@ -130,7 +130,7 @@ function SettingsSetupGuideNavRow({
         'flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left outline-none transition-colors focus-visible:ring-[3px] focus-visible:ring-worktree-sidebar-ring/50',
         setupActive
           ? 'bg-worktree-sidebar-accent font-medium text-worktree-sidebar-accent-foreground'
-          : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8 hover:text-worktree-sidebar-foreground'
+          : 'text-muted-foreground hover:bg-worktree-sidebar-foreground/8 hover:text-worktree-sidebar-foreground'
       )}
     >
       <SetupGuideProgressRing
@@ -175,7 +175,7 @@ export function SettingsSidebar({
       'flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-left text-[13px] outline-none transition-colors duration-150 focus-visible:ring-[3px] focus-visible:ring-worktree-sidebar-ring/50',
       isActive
         ? 'bg-worktree-sidebar-accent font-medium text-worktree-sidebar-accent-foreground ring-1 ring-worktree-sidebar-ring/25'
-        : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-accent/60 hover:text-worktree-sidebar-foreground'
+        : 'text-muted-foreground hover:bg-worktree-sidebar-accent/60 hover:text-worktree-sidebar-foreground'
     )
   const installStatusLabel = (status: VisibleInstallStatus): string => {
     switch (status) {

--- a/src/renderer/src/components/settings/SettingsSidebar.tsx
+++ b/src/renderer/src/components/settings/SettingsSidebar.tsx
@@ -111,6 +111,7 @@ type SettingsSetupGuideRowProps = {
   onSelect: () => void
 }
 
+/** Setup-guide row above the section list; mirrors `SetupGuideSidebarEntry` styling inside settings. */
 function SettingsSetupGuideNavRow({
   progress,
   setupActive,
@@ -148,6 +149,7 @@ function SettingsSetupGuideNavRow({
   )
 }
 
+/** Settings navigation column: search, general section groups, and one per-repo section. */
 export function SettingsSidebar({
   activeSectionId,
   settings,

--- a/src/renderer/src/components/settings/SettingsSidebar.tsx
+++ b/src/renderer/src/components/settings/SettingsSidebar.tsx
@@ -179,6 +179,7 @@ export function SettingsSidebar({
         ? 'bg-worktree-sidebar-accent font-medium text-worktree-sidebar-accent-foreground ring-1 ring-worktree-sidebar-ring/25'
         : 'text-muted-foreground hover:bg-worktree-sidebar-accent/60 hover:text-worktree-sidebar-foreground'
     )
+  /** Localized pill text for a repo section's skill-install status. */
   const installStatusLabel = (status: VisibleInstallStatus): string => {
     switch (status) {
       case 'update-available':

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -49,6 +49,7 @@ function resolveAppMode(
   return settings.theme
 }
 
+/** Live xterm preview that mirrors `applyTerminalAppearance` so settings render exactly as real panes will. */
 export function TerminalSettingsPreview({
   title,
   description,

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -206,7 +206,8 @@ export function TerminalSettingsPreview({
     // Why: share applyTerminalAppearance's gating helper (#7934) so the preview can't drift from live panes.
     terminal.options.minimumContrastRatio = resolveTerminalMinimumContrastRatio(
       composedTheme.background,
-      effectiveMode
+      effectiveMode,
+      composedTheme.foreground
     )
     // Why: xterm renders an alpha-channel background opaque unless allowTransparency is set (matches applyTerminalAppearance).
     terminal.options.allowTransparency =

--- a/src/renderer/src/components/sidebar/AgentDashboardSidebarEntry.tsx
+++ b/src/renderer/src/components/sidebar/AgentDashboardSidebarEntry.tsx
@@ -44,7 +44,7 @@ function DashboardBucketCounts({
         <span
           key={bucket}
           aria-label={`${dashboardBucketLabel(bucket)}: ${counts[bucket]}`}
-          className="inline-flex items-center gap-1 text-[10px] tabular-nums text-worktree-sidebar-foreground/55"
+          className="inline-flex items-center gap-1 text-[10px] tabular-nums text-muted-foreground/90"
         >
           {bucket === 'attention' ? (
             <AgentQuestionIcon className="size-2.5" />
@@ -77,13 +77,10 @@ export default function AgentDashboardSidebarEntry(): React.JSX.Element {
       }}
       className={cn(
         'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
-        'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'
+        'text-muted-foreground hover:bg-worktree-sidebar-foreground/8'
       )}
     >
-      <LayoutDashboard
-        className="size-4 shrink-0 text-worktree-sidebar-foreground/30"
-        strokeWidth={1.75}
-      />
+      <LayoutDashboard className="size-4 shrink-0 text-muted-foreground/50" strokeWidth={1.75} />
       <span className="flex-1">{translate('dashboard.sidebar.label', 'Agent Dashboard')}</span>
       <DashboardBucketCounts counts={dashboardBucketCounts} showIdle={showIdle} />
     </button>

--- a/src/renderer/src/components/sidebar/AgentDashboardSidebarEntry.tsx
+++ b/src/renderer/src/components/sidebar/AgentDashboardSidebarEntry.tsx
@@ -25,6 +25,7 @@ function dashboardBucketLabel(bucket: DashboardBucket): string {
   }
 }
 
+/** Inline per-bucket agent counts; hides empty buckets and idle unless `showIdle`. */
 function DashboardBucketCounts({
   counts,
   showIdle
@@ -58,6 +59,7 @@ function DashboardBucketCounts({
   )
 }
 
+/** Sidebar nav row that opens the agent dashboard as a drawer or popout per settings. */
 export default function AgentDashboardSidebarEntry(): React.JSX.Element {
   const dashboardBucketCounts = useAgentBucketCounts()
   const showIdle = useAppStore((s) => s.settings?.experimentalAgentDashboardShowIdle === true)

--- a/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.tsx
+++ b/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.tsx
@@ -92,7 +92,7 @@ export function SetupGuideSidebarEntry(): React.JSX.Element | null {
             'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
             setupActive
               ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
-              : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'
+              : 'text-muted-foreground hover:bg-worktree-sidebar-foreground/8'
           )}
         >
           <SetupGuideProgressRing

--- a/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.tsx
+++ b/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.tsx
@@ -38,6 +38,7 @@ function isSetupGuideSidebarComplete(progress: FeatureWallSetupProgress): boolea
   return progress.coreDoneCount >= progress.coreTotal
 }
 
+/** Dismissible sidebar row with setup progress; hidden once setup completes or the user dismisses it. */
 export function SetupGuideSidebarEntry(): React.JSX.Element | null {
   const openModal = useAppStore((s) => s.openModal)
   const activeModal = useAppStore((s) => s.activeModal)

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -113,12 +113,9 @@ const SidebarNav = React.memo(function SidebarNav() {
           'auto.components.sidebar.SidebarNav.0c3395fd32',
           'Search worktrees and browser tabs'
         )}
-        className="group flex w-full items-center gap-2 rounded-md bg-worktree-sidebar-foreground/5 px-2 py-1.5 text-left text-[13px] font-medium tracking-tight text-worktree-sidebar-foreground/60 transition-colors hover:bg-worktree-sidebar-foreground/8"
+        className="group flex w-full items-center gap-2 rounded-md bg-worktree-sidebar-foreground/5 px-2 py-1.5 text-left text-[13px] font-medium tracking-tight text-muted-foreground transition-colors hover:bg-worktree-sidebar-foreground/8"
       >
-        <Search
-          className="size-4 shrink-0 text-worktree-sidebar-foreground/30"
-          strokeWidth={1.75}
-        />
+        <Search className="size-4 shrink-0 text-muted-foreground/50" strokeWidth={1.75} />
         <span className="flex-1">
           {translate('auto.components.sidebar.SidebarNav.80611a8b10', 'Search')}
         </span>
@@ -129,8 +126,8 @@ const SidebarNav = React.memo(function SidebarNav() {
               keys={combo.keys}
               doubleTap={combo.doubleTap}
               className="inline-flex gap-0.5"
-              keyCapClassName="min-w-4 border-worktree-sidebar-border/80 bg-worktree-sidebar-foreground/8 px-1 py-px text-[9px] text-worktree-sidebar-foreground/55 shadow-none"
-              separatorClassName="text-[9px] text-worktree-sidebar-foreground/45"
+              keyCapClassName="min-w-4 border-worktree-sidebar-border/80 bg-worktree-sidebar-foreground/8 px-1 py-px text-[9px] text-muted-foreground/90 shadow-none"
+              separatorClassName="text-[9px] text-muted-foreground/75"
             />
           ))}
         </span>
@@ -148,14 +145,11 @@ const SidebarNav = React.memo(function SidebarNav() {
                 'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
                 artifactsActive
                   ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
-                  : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'
+                  : 'text-muted-foreground hover:bg-worktree-sidebar-foreground/8'
               )}
             >
               <Files
-                className={cn(
-                  'size-4 shrink-0',
-                  !artifactsActive && 'text-worktree-sidebar-foreground/30'
-                )}
+                className={cn('size-4 shrink-0', !artifactsActive && 'text-muted-foreground/50')}
                 strokeWidth={artifactsActive ? 2.25 : 1.75}
               />
               <span className="flex-1">
@@ -177,14 +171,11 @@ const SidebarNav = React.memo(function SidebarNav() {
                 'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
                 skillsActive
                   ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
-                  : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'
+                  : 'text-muted-foreground hover:bg-worktree-sidebar-foreground/8'
               )}
             >
               <BookOpen
-                className={cn(
-                  'size-4 shrink-0',
-                  !skillsActive && 'text-worktree-sidebar-foreground/30'
-                )}
+                className={cn('size-4 shrink-0', !skillsActive && 'text-muted-foreground/50')}
                 strokeWidth={skillsActive ? 2.25 : 1.75}
               />
               <span className="flex-1">
@@ -206,14 +197,11 @@ const SidebarNav = React.memo(function SidebarNav() {
                 'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
                 automationsActive
                   ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
-                  : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'
+                  : 'text-muted-foreground hover:bg-worktree-sidebar-foreground/8'
               )}
             >
               <CalendarClock
-                className={cn(
-                  'size-4 shrink-0',
-                  !automationsActive && 'text-worktree-sidebar-foreground/30'
-                )}
+                className={cn('size-4 shrink-0', !automationsActive && 'text-muted-foreground/50')}
                 strokeWidth={automationsActive ? 2.25 : 1.75}
               />
               <span className="flex-1">
@@ -238,14 +226,11 @@ const SidebarNav = React.memo(function SidebarNav() {
             'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
             activityActive
               ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
-              : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'
+              : 'text-muted-foreground hover:bg-worktree-sidebar-foreground/8'
           )}
         >
           <Bell
-            className={cn(
-              'size-4 shrink-0',
-              !activityActive && 'text-worktree-sidebar-foreground/30'
-            )}
+            className={cn('size-4 shrink-0', !activityActive && 'text-muted-foreground/50')}
             strokeWidth={activityActive ? 2.25 : 1.75}
           />
           <span className="flex-1">
@@ -266,7 +251,7 @@ const SidebarNav = React.memo(function SidebarNav() {
                 'group flex w-full items-center rounded-md text-[13px] font-medium tracking-tight transition-colors',
                 mobileActive
                   ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
-                  : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'
+                  : 'text-muted-foreground hover:bg-worktree-sidebar-foreground/8'
               )}
             >
               <button
@@ -279,10 +264,7 @@ const SidebarNav = React.memo(function SidebarNav() {
                 className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left"
               >
                 <Smartphone
-                  className={cn(
-                    'size-4 shrink-0',
-                    !mobileActive && 'text-worktree-sidebar-foreground/30'
-                  )}
+                  className={cn('size-4 shrink-0', !mobileActive && 'text-muted-foreground/50')}
                   strokeWidth={mobileActive ? 2.25 : 1.75}
                 />
                 <span className="min-w-0 flex-1 truncate">
@@ -302,7 +284,7 @@ const SidebarNav = React.memo(function SidebarNav() {
                       variant="ghost"
                       size="icon-xs"
                       className={cn(
-                        'mr-1 text-worktree-sidebar-foreground/55 hover:bg-worktree-sidebar-foreground/10 hover:text-worktree-sidebar-foreground',
+                        'mr-1 text-muted-foreground/90 hover:bg-worktree-sidebar-foreground/10 hover:text-worktree-sidebar-foreground',
                         mobileActive &&
                           'text-worktree-sidebar-accent-foreground/70 hover:text-worktree-sidebar-accent-foreground'
                       )}

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -57,6 +57,7 @@ export function shouldShowSkillsButton(
 
 const AgentDashboardSidebarEntry = lazyWithRetry(() => import('./AgentDashboardSidebarEntry'))
 
+/** Top-of-sidebar navigation: search, setup guide, tasks, artifacts, skills, automations, dashboard, activity, mobile. */
 const SidebarNav = React.memo(function SidebarNav() {
   // Why: this memo boundary needs its own language subscription, while
   // translate() preserves Orca's pseudo-localization behavior.

--- a/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
+++ b/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
@@ -169,14 +169,11 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
               'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
               tasksActive
                 ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
-                : 'text-worktree-sidebar-foreground/60 group-hover:bg-worktree-sidebar-foreground/8'
+                : 'text-muted-foreground group-hover:bg-worktree-sidebar-foreground/8'
             )}
           >
             <List
-              className={cn(
-                'size-4 shrink-0',
-                !tasksActive && 'text-worktree-sidebar-foreground/30'
-              )}
+              className={cn('size-4 shrink-0', !tasksActive && 'text-muted-foreground/50')}
               strokeWidth={tasksActive ? 2.25 : 1.75}
             />
             <span className="flex-1">

--- a/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
+++ b/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
@@ -54,6 +54,7 @@ function TaskProviderShortcut({
   )
 }
 
+/** Tasks nav row that opens the task page; hidden when `showTasksButton` is off in settings. */
 export function SidebarTaskNavButton(): React.JSX.Element | null {
   const openTaskPage = useAppStore((s) => s.openTaskPage)
   const updateSettings = useAppStore((s) => s.updateSettings)

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -132,6 +132,7 @@ function composedTerminalThemesEqual(a: ITheme | undefined, b: ITheme): boolean 
   return extA.length === extB.length && extA.every((value, i) => value === extB[i])
 }
 
+/** Pushes the effective theme, fonts, and contrast settings to every live pane; value-gated so no-op re-applies skip xterm cache invalidation. */
 export function applyTerminalAppearance(
   manager: PaneManager,
   settings: GlobalSettings,

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -169,7 +169,8 @@ export function applyTerminalAppearance(
     // Why value-gated: writing minimumContrastRatio clears xterm's contrast cache, so skip on no-op re-applies.
     const minimumContrastRatio = resolveTerminalMinimumContrastRatio(
       theme?.background,
-      appearance.mode
+      appearance.mode,
+      theme?.foreground
     )
     if (pane.terminal.options.minimumContrastRatio !== minimumContrastRatio) {
       pane.terminal.options.minimumContrastRatio = minimumContrastRatio

--- a/src/renderer/src/lib/left-sidebar-appearance.test.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.test.ts
@@ -2,6 +2,7 @@ import { tmpdir } from 'node:os'
 import { describe, expect, it } from 'vitest'
 import { getDefaultSettings } from '../../../shared/constants'
 import { resolveLeftSidebarStyleVariables } from './left-sidebar-appearance'
+import { resolveMutedForegroundMixPercent } from './muted-foreground-contrast'
 
 function settings(overrides = {}) {
   return {
@@ -37,6 +38,19 @@ describe('resolveLeftSidebarStyleVariables', () => {
     })
     expect(vars?.['--worktree-sidebar-accent']).toContain('#f0f4f8 9%')
     expect(vars?.['--sidebar-accent']).toBe(vars?.['--worktree-sidebar-accent'])
+  })
+
+  it('gates matched-terminal muted text on contrast so low-contrast themes stay legible (#16999)', () => {
+    const vars = resolveLeftSidebarStyleVariables(
+      settings({
+        leftSidebarAppearanceMode: 'match-terminal',
+        terminalColorOverrides: { background: '#fdf6e3', foreground: '#586e75' }
+      }),
+      false
+    )
+    const percent = resolveMutedForegroundMixPercent('#fdf6e3', '#586e75')
+    expect(percent).toBeGreaterThan(62)
+    expect(vars?.['--muted-foreground']).toBe(`color-mix(in srgb, #586e75 ${percent}%, #fdf6e3)`)
   })
 
   it('honors terminal background opacity for matched terminal surfaces', () => {

--- a/src/renderer/src/lib/left-sidebar-appearance.test.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.test.ts
@@ -54,6 +54,25 @@ describe('resolveLeftSidebarStyleVariables', () => {
     expect(vars?.['--muted-foreground']).toBe(`color-mix(in srgb, #586e75 ${percent}%, #fdf6e3)`)
   })
 
+  it('gates muted text on the background as composited over the app surface', () => {
+    const vars = resolveLeftSidebarStyleVariables(
+      settings({
+        leftSidebarAppearanceMode: 'match-terminal',
+        terminalColorOverrides: { background: '#fdf6e3', foreground: '#586e75' },
+        terminalBackgroundOpacity: 0.5,
+        theme: 'dark'
+      }),
+      true
+    )
+    const percent = resolveMutedForegroundMixPercent('rgba(253, 246, 227, 0.5)', '#586e75', {
+      appSurface: 'dark'
+    })
+    expect(percent).toBeGreaterThan(resolveMutedForegroundMixPercent('#fdf6e3', '#586e75'))
+    expect(vars?.['--muted-foreground']).toBe(
+      `color-mix(in srgb, #586e75 ${percent}%, rgba(253, 246, 227, 0.5))`
+    )
+  })
+
   it('honors terminal background opacity for matched terminal surfaces', () => {
     const vars = resolveLeftSidebarStyleVariables(
       settings({

--- a/src/renderer/src/lib/left-sidebar-appearance.test.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.test.ts
@@ -4,6 +4,7 @@ import { getDefaultSettings } from '../../../shared/constants'
 import { resolveLeftSidebarStyleVariables } from './left-sidebar-appearance'
 import { resolveMutedForegroundMixPercent } from './muted-foreground-contrast'
 
+/** Default global settings with per-test overrides. */
 function settings(overrides = {}) {
   return {
     ...getDefaultSettings(tmpdir()),

--- a/src/renderer/src/lib/left-sidebar-appearance.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.ts
@@ -47,6 +47,7 @@ function applyAlpha(color: string, alpha: number | undefined): string {
   return hexToRgba(color, Math.min(1, Math.max(0, alpha)))
 }
 
+/** Derives every sidebar-scoped CSS variable from one background/foreground pair via `color-mix`. */
 function buildSurfaceVariables(args: {
   background: string
   foreground: string

--- a/src/renderer/src/lib/left-sidebar-appearance.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.ts
@@ -94,6 +94,7 @@ function buildSurfaceVariables(args: {
   return vars
 }
 
+/** Match-terminal mode: sidebar variables derived from the active terminal theme. */
 function resolveTerminalSurfaceVariables(
   settings: LeftSidebarAppearanceSettings,
   systemPrefersDark: boolean

--- a/src/renderer/src/lib/left-sidebar-appearance.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.ts
@@ -5,6 +5,7 @@ import {
   normalizeLeftSidebarTintOpacity
 } from '../../../shared/left-sidebar-appearance'
 import { resolveEffectiveTerminalAppearance } from './terminal-theme'
+import { resolveMutedForegroundMixPercent } from './muted-foreground-contrast'
 
 type LeftSidebarAppearanceSettings = Pick<
   GlobalSettings,
@@ -82,7 +83,9 @@ function buildSurfaceVariables(args: {
     vars['--accent'] = `color-mix(in srgb, ${foreground} 9%, ${background})`
     vars['--accent-foreground'] = foreground
     vars['--muted'] = `color-mix(in srgb, ${foreground} 7%, ${background})`
-    vars['--muted-foreground'] = `color-mix(in srgb, ${foreground} 62%, ${background})`
+    // Contrast-gated (#16999): a fixed 62% vanishes on low-contrast themes such as Solarized.
+    const mutedPercent = resolveMutedForegroundMixPercent(background, foreground)
+    vars['--muted-foreground'] = `color-mix(in srgb, ${foreground} ${mutedPercent}%, ${background})`
     // Match the global --border (7%) so sidebar-scoped dividers aren't brighter (#5906).
     vars['--border'] = `color-mix(in srgb, ${foreground} 7%, ${background})`
   }

--- a/src/renderer/src/lib/left-sidebar-appearance.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.ts
@@ -52,8 +52,9 @@ function buildSurfaceVariables(args: {
   background: string
   foreground: string
   overrideTextTokens?: boolean
+  appSurface?: 'dark' | 'light'
 }): LeftSidebarStyleVariables {
-  const { background, foreground, overrideTextTokens = false } = args
+  const { background, foreground, overrideTextTokens = false, appSurface } = args
   const accent = `color-mix(in srgb, ${foreground} 9%, ${background})`
   // 7% keeps the sidebar divider at the same prominence as the global --border
   // (7% in dark mode) so it reads like the rest of the UI; 14% rendered brighter (#5906).
@@ -85,7 +86,7 @@ function buildSurfaceVariables(args: {
     vars['--accent-foreground'] = foreground
     vars['--muted'] = `color-mix(in srgb, ${foreground} 7%, ${background})`
     // Contrast-gated (#16999): a fixed 62% vanishes on low-contrast themes such as Solarized.
-    const mutedPercent = resolveMutedForegroundMixPercent(background, foreground)
+    const mutedPercent = resolveMutedForegroundMixPercent(background, foreground, { appSurface })
     vars['--muted-foreground'] = `color-mix(in srgb, ${foreground} ${mutedPercent}%, ${background})`
     // Match the global --border (7%) so sidebar-scoped dividers aren't brighter (#5906).
     vars['--border'] = `color-mix(in srgb, ${foreground} 7%, ${background})`
@@ -104,7 +105,12 @@ function resolveTerminalSurfaceVariables(
   )
   const foreground =
     settings.terminalColorOverrides?.foreground ?? appearance.theme?.foreground ?? '#fafafa'
-  return buildSurfaceVariables({ background, foreground, overrideTextTokens: true })
+  return buildSurfaceVariables({
+    background,
+    foreground,
+    overrideTextTokens: true,
+    appSurface: appearance.mode
+  })
 }
 
 function resolveTintedSurfaceVariables(

--- a/src/renderer/src/lib/muted-foreground-contrast.test.ts
+++ b/src/renderer/src/lib/muted-foreground-contrast.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MUTED_FOREGROUND_MIN_CONTRAST,
+  MUTED_FOREGROUND_MIX_PERCENT,
+  resolveMutedForegroundMixPercent
+} from './muted-foreground-contrast'
+
+// WCAG contrast of `color-mix(in srgb, fg P%, bg)` over bg, mirroring the browser's sRGB mix.
+function mixedContrast(background: string, foreground: string, percent: number): number {
+  const channels = (hex: string): number[] =>
+    [1, 3, 5].map((index) => Number.parseInt(hex.slice(index, index + 2), 16))
+  const luminance = (rgb: number[]): number => {
+    const [r, g, b] = rgb.map((channel) => {
+      const c = channel / 255
+      return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+    })
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+  }
+  const bg = channels(background)
+  const fg = channels(foreground)
+  const mixed = fg.map(
+    (channel, index) => channel * (percent / 100) + bg[index] * (1 - percent / 100)
+  )
+  const lb = luminance(bg)
+  const lm = luminance(mixed)
+  return (Math.max(lb, lm) + 0.05) / (Math.min(lb, lm) + 0.05)
+}
+
+describe('resolveMutedForegroundMixPercent', () => {
+  it('keeps the global mix ratio for a high-contrast pair', () => {
+    expect(resolveMutedForegroundMixPercent('#101820', '#f0f4f8')).toBe(
+      MUTED_FOREGROUND_MIX_PERCENT
+    )
+    expect(resolveMutedForegroundMixPercent('#fafafa', '#0a0a0a')).toBe(
+      MUTED_FOREGROUND_MIX_PERCENT
+    )
+  })
+
+  it('raises the mix until muted text clears the contrast floor on a low-contrast light theme', () => {
+    // Solarized Light: fg #586e75 is ~5:1, so the fixed 62% mix lands at ~2.4:1 (#16999).
+    const percent = resolveMutedForegroundMixPercent('#fdf6e3', '#586e75')
+    expect(percent).toBeGreaterThan(MUTED_FOREGROUND_MIX_PERCENT)
+    expect(percent).toBeLessThan(100)
+    expect(mixedContrast('#fdf6e3', '#586e75', percent)).toBeGreaterThanOrEqual(
+      MUTED_FOREGROUND_MIN_CONTRAST
+    )
+    expect(mixedContrast('#fdf6e3', '#586e75', percent - 1)).toBeLessThan(
+      MUTED_FOREGROUND_MIN_CONTRAST
+    )
+  })
+
+  it('raises the mix on a low-contrast dark theme too', () => {
+    const percent = resolveMutedForegroundMixPercent('#002b36', '#839496')
+    expect(percent).toBeGreaterThan(MUTED_FOREGROUND_MIX_PERCENT)
+    expect(mixedContrast('#002b36', '#839496', percent)).toBeGreaterThanOrEqual(
+      MUTED_FOREGROUND_MIN_CONTRAST
+    )
+  })
+
+  it('falls back to the foreground itself when even that misses the floor', () => {
+    expect(resolveMutedForegroundMixPercent('#fdf6e3', '#93a1a1')).toBe(100)
+  })
+
+  it('reads rgba() backgrounds (terminal background opacity applied)', () => {
+    expect(resolveMutedForegroundMixPercent('rgba(253, 246, 227, 0.9)', '#586e75')).toBe(
+      resolveMutedForegroundMixPercent('#fdf6e3', '#586e75')
+    )
+  })
+
+  it('keeps the global ratio for colors it cannot parse', () => {
+    expect(resolveMutedForegroundMixPercent('var(--background)', 'var(--foreground)')).toBe(
+      MUTED_FOREGROUND_MIX_PERCENT
+    )
+  })
+})

--- a/src/renderer/src/lib/muted-foreground-contrast.test.ts
+++ b/src/renderer/src/lib/muted-foreground-contrast.test.ts
@@ -25,6 +25,11 @@ function luminance([r, g, b]: number[]): number {
   return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
 }
 
+/** WCAG contrast ratio from two relative luminances. */
+function contrastFromLuminance(a: number, b: number): number {
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05)
+}
+
 /** WCAG contrast of `color-mix(in srgb, fg P%, bg)` over bg, mirroring the browser's sRGB mix. */
 function mixedContrast(background: string, foreground: string, percent: number): number {
   const bg = hexChannels(background)
@@ -35,9 +40,35 @@ function mixedContrast(background: string, foreground: string, percent: number):
     fg[1] * weight + bg[1] * (1 - weight),
     fg[2] * weight + bg[2] * (1 - weight)
   ]
-  const lb = luminance(bg)
-  const lm = luminance(mixed)
-  return (Math.max(lb, lm) + 0.05) / (Math.min(lb, lm) + 0.05)
+  return contrastFromLuminance(luminance(bg), luminance(mixed))
+}
+
+/** Contrast the browser renders for muted text on a translucent sidebar: the sidebar is `bg` at
+ *  `bgAlpha` over `surface`; the text is the premultiplied `color-mix(fg P%, bg)` composited over
+ *  that sidebar (CSS Color 4 §12.3). Written independently of the implementation under test. */
+function renderedContrast(
+  background: string,
+  bgAlpha: number,
+  foreground: string,
+  surface: string,
+  percent: number
+): number {
+  const bg = hexChannels(background)
+  const fg = hexChannels(foreground)
+  const app = hexChannels(surface)
+  const sidebar = [
+    bg[0] * bgAlpha + app[0] * (1 - bgAlpha),
+    bg[1] * bgAlpha + app[1] * (1 - bgAlpha),
+    bg[2] * bgAlpha + app[2] * (1 - bgAlpha)
+  ]
+  const weight = percent / 100
+  const textAlpha = weight + (1 - weight) * bgAlpha
+  const text = [
+    weight * fg[0] + (1 - weight) * bgAlpha * bg[0] + (1 - textAlpha) * sidebar[0],
+    weight * fg[1] + (1 - weight) * bgAlpha * bg[1] + (1 - textAlpha) * sidebar[1],
+    weight * fg[2] + (1 - weight) * bgAlpha * bg[2] + (1 - textAlpha) * sidebar[2]
+  ]
+  return contrastFromLuminance(luminance(sidebar), luminance(text))
 }
 
 describe('resolveMutedForegroundMixPercent', () => {
@@ -81,7 +112,7 @@ describe('resolveMutedForegroundMixPercent', () => {
     )
   })
 
-  it('composites a translucent background over the app surface before gating', () => {
+  it('gates a translucent background on the pixel the browser renders, per app surface', () => {
     const translucent = 'rgba(253, 246, 227, 0.5)'
     // 50% Solarized Light over the light surface (#ffffff) / the dark surface (#0a0a0a).
     const overLight = resolveMutedForegroundMixPercent(translucent, '#586e75', {
@@ -90,10 +121,41 @@ describe('resolveMutedForegroundMixPercent', () => {
     const overDark = resolveMutedForegroundMixPercent(translucent, '#586e75', {
       appSurface: 'dark'
     })
-    expect(overLight).toBe(resolveMutedForegroundMixPercent('#fefbf1', '#586e75'))
-    expect(overDark).toBe(resolveMutedForegroundMixPercent('#848077', '#586e75'))
-    // The dark surface pulls the composited background toward the foreground, so it needs far more mix.
-    expect(overDark).toBeGreaterThan(overLight)
+    expect(
+      renderedContrast('#fdf6e3', 0.5, '#586e75', '#ffffff', overLight)
+    ).toBeGreaterThanOrEqual(MUTED_FOREGROUND_MIN_CONTRAST)
+    expect(renderedContrast('#fdf6e3', 0.5, '#586e75', '#ffffff', overLight - 1)).toBeLessThan(
+      MUTED_FOREGROUND_MIN_CONTRAST
+    )
+    // Over the dark surface the sidebar turns mid-gray (~#848077), which #586e75 cannot clear even
+    // undiluted (~1.4:1), so the gate falls back to the foreground itself.
+    expect(overDark).toBe(100)
+    expect(renderedContrast('#fdf6e3', 0.5, '#586e75', '#0a0a0a', 100)).toBeLessThan(
+      MUTED_FOREGROUND_MIN_CONTRAST
+    )
+  })
+
+  it('does not stop short because the text still shows the raw background layer through it', () => {
+    // Solarized Dark at 50% on the dark surface: an opaque mix against the composited sidebar
+    // would pass at a lower percent whose rendered pixel is still below the floor.
+    const percent = resolveMutedForegroundMixPercent('rgba(0, 43, 54, 0.5)', '#839496', {
+      appSurface: 'dark'
+    })
+    expect(percent).toBeLessThan(100)
+    expect(renderedContrast('#002b36', 0.5, '#839496', '#0a0a0a', percent)).toBeGreaterThanOrEqual(
+      MUTED_FOREGROUND_MIN_CONTRAST
+    )
+    expect(renderedContrast('#002b36', 0.5, '#839496', '#0a0a0a', percent - 1)).toBeLessThan(
+      MUTED_FOREGROUND_MIN_CONTRAST
+    )
+  })
+
+  it('accounts for a translucent foreground', () => {
+    // Half-transparent black on white can never reach 4.5:1 (its 100% is mid-gray, ~4:1).
+    expect(resolveMutedForegroundMixPercent('#ffffff', 'rgba(0, 0, 0, 0.5)')).toBe(100)
+    expect(resolveMutedForegroundMixPercent('#ffffff', 'rgba(0, 0, 0, 0.8)')).toBeGreaterThan(
+      resolveMutedForegroundMixPercent('#ffffff', '#000000')
+    )
   })
 
   it('keeps the global ratio for colors it cannot parse', () => {

--- a/src/renderer/src/lib/muted-foreground-contrast.test.ts
+++ b/src/renderer/src/lib/muted-foreground-contrast.test.ts
@@ -66,10 +66,25 @@ describe('resolveMutedForegroundMixPercent', () => {
     expect(resolveMutedForegroundMixPercent('#fdf6e3', '#93a1a1')).toBe(100)
   })
 
-  it('reads rgba() backgrounds (terminal background opacity applied)', () => {
-    expect(resolveMutedForegroundMixPercent('rgba(253, 246, 227, 0.9)', '#586e75')).toBe(
+  it('treats a fully opaque rgba() background like its hex form', () => {
+    expect(resolveMutedForegroundMixPercent('rgba(253, 246, 227, 1)', '#586e75')).toBe(
       resolveMutedForegroundMixPercent('#fdf6e3', '#586e75')
     )
+  })
+
+  it('composites a translucent background over the app surface before gating', () => {
+    const translucent = 'rgba(253, 246, 227, 0.5)'
+    // 50% Solarized Light over the light surface (#ffffff) / the dark surface (#0a0a0a).
+    const overLight = resolveMutedForegroundMixPercent(translucent, '#586e75', {
+      appSurface: 'light'
+    })
+    const overDark = resolveMutedForegroundMixPercent(translucent, '#586e75', {
+      appSurface: 'dark'
+    })
+    expect(overLight).toBe(resolveMutedForegroundMixPercent('#fefbf1', '#586e75'))
+    expect(overDark).toBe(resolveMutedForegroundMixPercent('#848077', '#586e75'))
+    // The dark surface pulls the composited background toward the foreground, so it needs far more mix.
+    expect(overDark).toBeGreaterThan(overLight)
   })
 
   it('keeps the global ratio for colors it cannot parse', () => {

--- a/src/renderer/src/lib/muted-foreground-contrast.test.ts
+++ b/src/renderer/src/lib/muted-foreground-contrast.test.ts
@@ -5,19 +5,24 @@ import {
   resolveMutedForegroundMixPercent
 } from './muted-foreground-contrast'
 
-// WCAG contrast of `color-mix(in srgb, fg P%, bg)` over bg, mirroring the browser's sRGB mix.
+/** `#rrggbb` → [r, g, b] in 0–255. */
+function hexChannels(hex: string): number[] {
+  return [1, 3, 5].map((index) => Number.parseInt(hex.slice(index, index + 2), 16))
+}
+
+/** WCAG 2.x relative luminance of an [r, g, b] triple; independent of the implementation under test. */
+function luminance(rgb: number[]): number {
+  const [r, g, b] = rgb.map((channel) => {
+    const c = channel / 255
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+  })
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+/** WCAG contrast of `color-mix(in srgb, fg P%, bg)` over bg, mirroring the browser's sRGB mix. */
 function mixedContrast(background: string, foreground: string, percent: number): number {
-  const channels = (hex: string): number[] =>
-    [1, 3, 5].map((index) => Number.parseInt(hex.slice(index, index + 2), 16))
-  const luminance = (rgb: number[]): number => {
-    const [r, g, b] = rgb.map((channel) => {
-      const c = channel / 255
-      return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
-    })
-    return 0.2126 * r + 0.7152 * g + 0.0722 * b
-  }
-  const bg = channels(background)
-  const fg = channels(foreground)
+  const bg = hexChannels(background)
+  const fg = hexChannels(foreground)
   const mixed = fg.map(
     (channel, index) => channel * (percent / 100) + bg[index] * (1 - percent / 100)
   )

--- a/src/renderer/src/lib/muted-foreground-contrast.test.ts
+++ b/src/renderer/src/lib/muted-foreground-contrast.test.ts
@@ -7,25 +7,34 @@ import {
 
 /** `#rrggbb` → [r, g, b] in 0–255. */
 function hexChannels(hex: string): number[] {
-  return [1, 3, 5].map((index) => Number.parseInt(hex.slice(index, index + 2), 16))
+  return [
+    Number.parseInt(hex.slice(1, 3), 16),
+    Number.parseInt(hex.slice(3, 5), 16),
+    Number.parseInt(hex.slice(5, 7), 16)
+  ]
 }
 
-/** WCAG 2.x relative luminance of an [r, g, b] triple; independent of the implementation under test. */
-function luminance(rgb: number[]): number {
-  const [r, g, b] = rgb.map((channel) => {
-    const c = channel / 255
-    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
-  })
-  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+/** sRGB 0–255 channel → linear-light value per WCAG 2.x; independent of the implementation under test. */
+function linearize(channel: number): number {
+  const c = channel / 255
+  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+}
+
+/** WCAG 2.x relative luminance of an [r, g, b] triple. */
+function luminance([r, g, b]: number[]): number {
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
 }
 
 /** WCAG contrast of `color-mix(in srgb, fg P%, bg)` over bg, mirroring the browser's sRGB mix. */
 function mixedContrast(background: string, foreground: string, percent: number): number {
   const bg = hexChannels(background)
   const fg = hexChannels(foreground)
-  const mixed = fg.map(
-    (channel, index) => channel * (percent / 100) + bg[index] * (1 - percent / 100)
-  )
+  const weight = percent / 100
+  const mixed = [
+    fg[0] * weight + bg[0] * (1 - weight),
+    fg[1] * weight + bg[1] * (1 - weight),
+    fg[2] * weight + bg[2] * (1 - weight)
+  ]
   const lb = luminance(bg)
   const lm = luminance(mixed)
   return (Math.max(lb, lm) + 0.05) / (Math.min(lb, lm) + 0.05)

--- a/src/renderer/src/lib/muted-foreground-contrast.ts
+++ b/src/renderer/src/lib/muted-foreground-contrast.ts
@@ -1,8 +1,4 @@
-import {
-  compositeTerminalBackground,
-  parseCssRgbColor,
-  type RgbaColor
-} from './terminal-title-contrast'
+import { APP_SURFACE_COLORS, parseCssRgbColor, type RgbaColor } from './terminal-title-contrast'
 
 /** Global --muted-foreground ratio; the light default (#737373 on #fafafa) sits right at 4.5:1. */
 export const MUTED_FOREGROUND_MIX_PERCENT = 62
@@ -26,13 +22,23 @@ function contrastRatio(a: RgbaColor, b: RgbaColor): number {
   return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05)
 }
 
-/** `color-mix(in srgb, fg P%, bg)` as the browser computes it (gamma-space channel interpolation). */
-function mixSrgb(foreground: RgbaColor, background: RgbaColor, percent: number): RgbaColor {
+/** What `color-mix(in srgb, fg P%, bg)` text looks like on `surface`: CSS Color 4 mixes premultiplied
+ *  (so a translucent bg contributes `bg.a` of its weight), and the browser then composites the
+ *  still-translucent result over the surface the text sits on. */
+function renderMixedText(
+  foreground: RgbaColor,
+  background: RgbaColor,
+  surface: RgbaColor,
+  percent: number
+): RgbaColor {
   const weight = percent / 100
+  const fgWeight = weight * foreground.a
+  const bgWeight = (1 - weight) * background.a
+  const alpha = fgWeight + bgWeight
   return {
-    r: foreground.r * weight + background.r * (1 - weight),
-    g: foreground.g * weight + background.g * (1 - weight),
-    b: foreground.b * weight + background.b * (1 - weight),
+    r: fgWeight * foreground.r + bgWeight * background.r + (1 - alpha) * surface.r,
+    g: fgWeight * foreground.g + bgWeight * background.g + (1 - alpha) * surface.g,
+    b: fgWeight * foreground.b + bgWeight * background.b + (1 - alpha) * surface.b,
     a: 1
   }
 }
@@ -45,15 +51,27 @@ export function resolveMutedForegroundMixPercent(
   foreground: string,
   options: { appSurface?: 'dark' | 'light' } = {}
 ): number {
-  // Why: a translucent background renders over the app surface, and `color-mix(fg P%, rgba-bg)`
-  // composited over that surface equals `mixSrgb(fg, composited-bg, P)` — so gate on the composited color.
-  const bg = compositeTerminalBackground(background, { appSurface: options.appSurface })
+  // Why: the text sits on the sidebar as rendered — the (possibly translucent) background over the
+  // app surface — while its own transparent part still shows the raw background layer; rate the
+  // pixel the browser produces, not the opaque mix.
+  const bg = parseCssRgbColor(background)
   const fg = parseCssRgbColor(foreground)
   if (!bg || !fg) {
     return MUTED_FOREGROUND_MIX_PERCENT
   }
+  // Unrounded on purpose: the gate sits on a 4.5 boundary, and 8-bit rounding here can flip it.
+  const app = APP_SURFACE_COLORS[options.appSurface ?? 'dark']
+  const surface: RgbaColor = {
+    r: bg.r * bg.a + app.r * (1 - bg.a),
+    g: bg.g * bg.a + app.g * (1 - bg.a),
+    b: bg.b * bg.a + app.b * (1 - bg.a),
+    a: 1
+  }
   for (let percent = MUTED_FOREGROUND_MIX_PERCENT; percent < 100; percent += 1) {
-    if (contrastRatio(mixSrgb(fg, bg, percent), bg) >= MUTED_FOREGROUND_MIN_CONTRAST) {
+    if (
+      contrastRatio(renderMixedText(fg, bg, surface, percent), surface) >=
+      MUTED_FOREGROUND_MIN_CONTRAST
+    ) {
       return percent
     }
   }

--- a/src/renderer/src/lib/muted-foreground-contrast.ts
+++ b/src/renderer/src/lib/muted-foreground-contrast.ts
@@ -1,0 +1,47 @@
+import { parseCssRgbColor, type RgbaColor } from './terminal-title-contrast'
+
+/** Global --muted-foreground ratio; the light default (#737373 on #fafafa) sits right at 4.5:1. */
+export const MUTED_FOREGROUND_MIX_PERCENT = 62
+export const MUTED_FOREGROUND_MIN_CONTRAST = 4.5
+
+function relativeLuminance({ r, g, b }: RgbaColor): number {
+  const linear = (channel: number): number => {
+    const c = channel / 255
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+  }
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b)
+}
+
+function contrastRatio(a: RgbaColor, b: RgbaColor): number {
+  const la = relativeLuminance(a)
+  const lb = relativeLuminance(b)
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05)
+}
+
+/** `color-mix(in srgb, fg P%, bg)` as the browser computes it (gamma-space channel interpolation). */
+function mixSrgb(foreground: RgbaColor, background: RgbaColor, percent: number): RgbaColor {
+  const weight = percent / 100
+  return {
+    r: foreground.r * weight + background.r * (1 - weight),
+    g: foreground.g * weight + background.g * (1 - weight),
+    b: foreground.b * weight + background.b * (1 - weight),
+    a: 1
+  }
+}
+
+/** Why: a fixed 62% mix assumes a near-black/near-white foreground. Low-contrast themes (Solarized
+ *  Light's #586e75 on #fdf6e3 is ~5:1) mix down to ~2.4:1 and sidebar captions vanish, so raise the
+ *  mix until muted text clears the floor — up to the foreground itself when nothing less will. */
+export function resolveMutedForegroundMixPercent(background: string, foreground: string): number {
+  const bg = parseCssRgbColor(background)
+  const fg = parseCssRgbColor(foreground)
+  if (!bg || !fg) {
+    return MUTED_FOREGROUND_MIX_PERCENT
+  }
+  for (let percent = MUTED_FOREGROUND_MIX_PERCENT; percent < 100; percent += 1) {
+    if (contrastRatio(mixSrgb(fg, bg, percent), bg) >= MUTED_FOREGROUND_MIN_CONTRAST) {
+      return percent
+    }
+  }
+  return 100
+}

--- a/src/renderer/src/lib/muted-foreground-contrast.ts
+++ b/src/renderer/src/lib/muted-foreground-contrast.ts
@@ -4,13 +4,15 @@ import { parseCssRgbColor, type RgbaColor } from './terminal-title-contrast'
 export const MUTED_FOREGROUND_MIX_PERCENT = 62
 export const MUTED_FOREGROUND_MIN_CONTRAST = 4.5
 
-/** WCAG 2.x relative luminance (sRGB linearized); alpha is ignored. */
+/** sRGB 0–255 channel → linear-light value per WCAG 2.x. */
+function linearizeChannel(channel: number): number {
+  const c = channel / 255
+  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+}
+
+/** WCAG 2.x relative luminance; alpha is ignored. */
 function relativeLuminance({ r, g, b }: RgbaColor): number {
-  const linear = (channel: number): number => {
-    const c = channel / 255
-    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
-  }
-  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b)
+  return 0.2126 * linearizeChannel(r) + 0.7152 * linearizeChannel(g) + 0.0722 * linearizeChannel(b)
 }
 
 /** WCAG contrast ratio in [1, 21]; order-independent. */

--- a/src/renderer/src/lib/muted-foreground-contrast.ts
+++ b/src/renderer/src/lib/muted-foreground-contrast.ts
@@ -4,6 +4,7 @@ import { parseCssRgbColor, type RgbaColor } from './terminal-title-contrast'
 export const MUTED_FOREGROUND_MIX_PERCENT = 62
 export const MUTED_FOREGROUND_MIN_CONTRAST = 4.5
 
+/** WCAG 2.x relative luminance (sRGB linearized); alpha is ignored. */
 function relativeLuminance({ r, g, b }: RgbaColor): number {
   const linear = (channel: number): number => {
     const c = channel / 255
@@ -12,6 +13,7 @@ function relativeLuminance({ r, g, b }: RgbaColor): number {
   return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b)
 }
 
+/** WCAG contrast ratio in [1, 21]; order-independent. */
 function contrastRatio(a: RgbaColor, b: RgbaColor): number {
   const la = relativeLuminance(a)
   const lb = relativeLuminance(b)

--- a/src/renderer/src/lib/muted-foreground-contrast.ts
+++ b/src/renderer/src/lib/muted-foreground-contrast.ts
@@ -1,4 +1,8 @@
-import { parseCssRgbColor, type RgbaColor } from './terminal-title-contrast'
+import {
+  compositeTerminalBackground,
+  parseCssRgbColor,
+  type RgbaColor
+} from './terminal-title-contrast'
 
 /** Global --muted-foreground ratio; the light default (#737373 on #fafafa) sits right at 4.5:1. */
 export const MUTED_FOREGROUND_MIX_PERCENT = 62
@@ -36,8 +40,14 @@ function mixSrgb(foreground: RgbaColor, background: RgbaColor, percent: number):
 /** Why: a fixed 62% mix assumes a near-black/near-white foreground. Low-contrast themes (Solarized
  *  Light's #586e75 on #fdf6e3 is ~5:1) mix down to ~2.4:1 and sidebar captions vanish, so raise the
  *  mix until muted text clears the floor — up to the foreground itself when nothing less will. */
-export function resolveMutedForegroundMixPercent(background: string, foreground: string): number {
-  const bg = parseCssRgbColor(background)
+export function resolveMutedForegroundMixPercent(
+  background: string,
+  foreground: string,
+  options: { appSurface?: 'dark' | 'light' } = {}
+): number {
+  // Why: a translucent background renders over the app surface, and `color-mix(fg P%, rgba-bg)`
+  // composited over that surface equals `mixSrgb(fg, composited-bg, P)` — so gate on the composited color.
+  const bg = compositeTerminalBackground(background, { appSurface: options.appSurface })
   const fg = parseCssRgbColor(foreground)
   if (!bg || !fg) {
     return MUTED_FOREGROUND_MIX_PERCENT

--- a/src/renderer/src/lib/terminal-contrast-correction.test.ts
+++ b/src/renderer/src/lib/terminal-contrast-correction.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   DARK_BG_MIN_CONTRAST,
+  DIM_TEXT_CONTRAST_HEADROOM,
   LIGHT_BG_MIN_CONTRAST,
   resolveTerminalMinimumContrastRatio
 } from './terminal-contrast-correction'
@@ -39,6 +40,70 @@ describe('resolveTerminalMinimumContrastRatio', () => {
 
   it('treats an undefined/transparent background as dark', () => {
     expect(resolveTerminalMinimumContrastRatio(undefined, 'dark')).toBe(DARK_BG_MIN_CONTRAST)
+  })
+})
+
+// Dimmed palette text (ANSI 8: zsh-autosuggestions / fish ghost text, prompt hints) must stay visibly
+// dimmer than body text. xterm lifts every below-floor color to the floor, so on a low-contrast light
+// theme the floor lands beside the foreground and both collapse into one gray.
+describe('resolveTerminalMinimumContrastRatio foreground headroom', () => {
+  // Solarized Light (Warp/termio import): fg #586e75 is ~5.0:1, brightBlack #93a1a1 is ~2.5:1. At the
+  // 4.5 floor xterm darkens brightBlack to #5f6868 — indistinguishable from the foreground.
+  const SOLARIZED_LIGHT = { background: '#fdf6e3', foreground: '#586e75' }
+
+  it('keeps the light floor when the foreground has plenty of contrast', () => {
+    expect(resolveTerminalMinimumContrastRatio('#ffffff', 'light', '#000000')).toBe(
+      LIGHT_BG_MIN_CONTRAST
+    )
+    expect(resolveTerminalMinimumContrastRatio('#fbf1c7', 'dark', '#3c3836')).toBe(
+      LIGHT_BG_MIN_CONTRAST
+    )
+  })
+
+  it('lowers the light floor to leave headroom below a low-contrast foreground', () => {
+    const floor = resolveTerminalMinimumContrastRatio(
+      SOLARIZED_LIGHT.background,
+      'dark',
+      SOLARIZED_LIGHT.foreground
+    )
+    const fgContrast = contrastRatio(SOLARIZED_LIGHT.background, SOLARIZED_LIGHT.foreground)
+    expect(floor).toBeLessThan(LIGHT_BG_MIN_CONTRAST)
+    expect(floor).toBeCloseTo(fgContrast / DIM_TEXT_CONTRAST_HEADROOM, 5)
+  })
+
+  it('keeps the ghost-text slot of a low-contrast theme at its designed contrast', () => {
+    // Solarized Light ships brightBlack #93a1a1 at ~2.5:1; the floor must not lift it.
+    const floor = resolveTerminalMinimumContrastRatio(
+      SOLARIZED_LIGHT.background,
+      'dark',
+      SOLARIZED_LIGHT.foreground
+    )
+    expect(contrastRatio(SOLARIZED_LIGHT.background, '#93a1a1')).toBeGreaterThanOrEqual(
+      floor - 0.05
+    )
+  })
+
+  it('keeps the dark floor for a high-contrast dark theme', () => {
+    expect(resolveTerminalMinimumContrastRatio('#1e242a', 'dark', '#e6edf3')).toBe(
+      DARK_BG_MIN_CONTRAST
+    )
+  })
+
+  it('lowers the dark floor too when the dark theme foreground is low-contrast', () => {
+    // Solarized Dark: fg #839496 ~4.75:1, brightBlack #586e75 ~2.8:1 — must stay untouched.
+    const floor = resolveTerminalMinimumContrastRatio('#002b36', 'dark', '#839496')
+    expect(floor).toBeLessThan(DARK_BG_MIN_CONTRAST)
+    expect(contrastRatio('#002b36', '#586e75')).toBeGreaterThanOrEqual(floor)
+  })
+
+  it('bottoms out at 1 (correction off) for a pathological foreground', () => {
+    expect(resolveTerminalMinimumContrastRatio('#fdf6e3', 'light', '#f0ead8')).toBe(1)
+  })
+
+  it('falls back to the plain floor for an unparseable foreground', () => {
+    expect(resolveTerminalMinimumContrastRatio('#fdf6e3', 'light', 'not-a-color')).toBe(
+      LIGHT_BG_MIN_CONTRAST
+    )
   })
 })
 

--- a/src/renderer/src/lib/terminal-contrast-correction.test.ts
+++ b/src/renderer/src/lib/terminal-contrast-correction.test.ts
@@ -8,21 +8,26 @@ import {
 import { TERMINAL_THEME_CATALOG } from './terminal-themes'
 import { resolveTerminalTextContrastRatio } from './terminal-title-contrast'
 
-// WCAG relative-luminance contrast ratio, matching xterm's minimumContrastRatio gate.
+/** sRGB 0–255 channel → linear-light value per WCAG 2.x. */
+function toLinear(channel: number): number {
+  const c = channel / 255
+  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+}
+
+/** WCAG 2.x relative luminance of a `#rrggbb` color. */
+function luminance(hex: string): number {
+  const n = Number.parseInt(hex.replace('#', ''), 16)
+  return (
+    0.2126 * toLinear((n >> 16) & 0xff) +
+    0.7152 * toLinear((n >> 8) & 0xff) +
+    0.0722 * toLinear(n & 0xff)
+  )
+}
+
+/** WCAG relative-luminance contrast ratio, matching xterm's minimumContrastRatio gate. */
 function contrastRatio(a: string, b: string): number {
-  const lum = (hex: string): number => {
-    const n = Number.parseInt(hex.replace('#', ''), 16)
-    const toLinear = (channel: number): number => {
-      const c = channel / 255
-      return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
-    }
-    const r = toLinear((n >> 16) & 0xff)
-    const g = toLinear((n >> 8) & 0xff)
-    const bl = toLinear(n & 0xff)
-    return 0.2126 * r + 0.7152 * g + 0.0722 * bl
-  }
-  const la = lum(a)
-  const lb = lum(b)
+  const la = luminance(a)
+  const lb = luminance(b)
   return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05)
 }
 

--- a/src/renderer/src/lib/terminal-contrast-correction.test.ts
+++ b/src/renderer/src/lib/terminal-contrast-correction.test.ts
@@ -6,6 +6,7 @@ import {
   resolveTerminalMinimumContrastRatio
 } from './terminal-contrast-correction'
 import { TERMINAL_THEME_CATALOG } from './terminal-themes'
+import { resolveTerminalTextContrastRatio } from './terminal-title-contrast'
 
 // WCAG relative-luminance contrast ratio, matching xterm's minimumContrastRatio gate.
 function contrastRatio(a: string, b: string): number {
@@ -102,6 +103,17 @@ describe('resolveTerminalMinimumContrastRatio foreground headroom', () => {
 
   it('falls back to the plain floor for an unparseable foreground', () => {
     expect(resolveTerminalMinimumContrastRatio('#fdf6e3', 'light', 'not-a-color')).toBe(
+      LIGHT_BG_MIN_CONTRAST
+    )
+  })
+
+  it('rates a translucent foreground by the color actually seen over the background', () => {
+    // rgba(0,0,0,0.1) over white renders as #e6e6e6 (~1.25:1), not black (21:1).
+    expect(resolveTerminalTextContrastRatio('#ffffff', 'rgba(0, 0, 0, 0.1)')).toBe(
+      resolveTerminalTextContrastRatio('#ffffff', '#e6e6e6')
+    )
+    expect(resolveTerminalMinimumContrastRatio('#ffffff', 'light', 'rgba(0, 0, 0, 0.1)')).toBe(1)
+    expect(resolveTerminalMinimumContrastRatio('#ffffff', 'light', '#000000')).toBe(
       LIGHT_BG_MIN_CONTRAST
     )
   })

--- a/src/renderer/src/lib/terminal-contrast-correction.ts
+++ b/src/renderer/src/lib/terminal-contrast-correction.ts
@@ -21,8 +21,12 @@ export const DARK_BG_MIN_CONTRAST = 3
 // light, <6:1 on dark) ever pull the floor down; a floor of 1 disables correction entirely.
 export const DIM_TEXT_CONTRAST_HEADROOM = 2
 
-// Why gate by background luminance, not app mode (#7934): either theme slot can hold either kind of
-// theme (match-dark-mode, or a light theme in the dark slot), so follow the composed background.
+/**
+ * xterm `minimumContrastRatio` for a composed theme: the luminance-gated floor, capped below the
+ * theme's own foreground contrast so dim palette slots survive (see `DIM_TEXT_CONTRAST_HEADROOM`).
+ * Why gate by background luminance, not app mode (#7934): either theme slot can hold either kind of
+ * theme (match-dark-mode, or a light theme in the dark slot), so follow the composed background.
+ */
 export function resolveTerminalMinimumContrastRatio(
   background: string | undefined,
   appSurface: 'dark' | 'light',

--- a/src/renderer/src/lib/terminal-contrast-correction.ts
+++ b/src/renderer/src/lib/terminal-contrast-correction.ts
@@ -1,4 +1,7 @@
-import { isTerminalBackgroundLight } from '@/lib/terminal-title-contrast'
+import {
+  isTerminalBackgroundLight,
+  resolveTerminalTextContrastRatio
+} from '@/lib/terminal-title-contrast'
 
 // xterm minimumContrastRatio tuning (#7934, #9599, #10104). Light backgrounds keep WCAG-AA correction so
 // invisible white/bright-white ANSI body text stays readable. Dark backgrounds use a mild floor of 3
@@ -10,14 +13,29 @@ import { isTerminalBackgroundLight } from '@/lib/terminal-title-contrast'
 // than harms (see the builtin-catalog exceptions pinned in terminal-contrast-correction.test.ts).
 export const LIGHT_BG_MIN_CONTRAST = 4.5
 export const DARK_BG_MIN_CONTRAST = 3
+// xterm lifts every below-floor color to the floor, so a floor near the theme's own foreground contrast
+// collapses dimmed palette text (ANSI 8: zsh-autosuggestions/fish ghost text, prompt hints) into the
+// body-text gray — Solarized Light's brightBlack #93a1a1 became #5f6868 beside fg #586e75. Keep the
+// floor at half the foreground contrast: that reproduces the ~20 L* step theme authors give their
+// dim slot (Solarized Light: fg 5:1, brightBlack 2.5:1). Only low-contrast foregrounds (<9:1 on
+// light, <6:1 on dark) ever pull the floor down; a floor of 1 disables correction entirely.
+export const DIM_TEXT_CONTRAST_HEADROOM = 2
 
 // Why gate by background luminance, not app mode (#7934): either theme slot can hold either kind of
 // theme (match-dark-mode, or a light theme in the dark slot), so follow the composed background.
 export function resolveTerminalMinimumContrastRatio(
   background: string | undefined,
-  appSurface: 'dark' | 'light'
+  appSurface: 'dark' | 'light',
+  foreground?: string
 ): number {
-  return isTerminalBackgroundLight(background, { appSurface })
+  const floor = isTerminalBackgroundLight(background, { appSurface })
     ? LIGHT_BG_MIN_CONTRAST
     : DARK_BG_MIN_CONTRAST
+  const foregroundContrast = resolveTerminalTextContrastRatio(background, foreground, {
+    appSurface
+  })
+  if (foregroundContrast === null) {
+    return floor
+  }
+  return Math.max(1, Math.min(floor, foregroundContrast / DIM_TEXT_CONTRAST_HEADROOM))
 }

--- a/src/renderer/src/lib/terminal-title-contrast.ts
+++ b/src/renderer/src/lib/terminal-title-contrast.ts
@@ -45,11 +45,16 @@ export function resolveTerminalTextContrastRatio(
 ): number | null {
   const composited = compositeTerminalBackground(background, options)
   const text = parseCssRgbColor(foreground)
-  return composited && text ? contrastRatio(text, composited) : null
+  if (!composited || !text) {
+    return null
+  }
+  // Why: a translucent foreground shows the background through it; rate the color actually seen.
+  const visibleText = text.a < 1 ? compositeRgb(text, composited, text.a) : text
+  return contrastRatio(visibleText, composited)
 }
 
 /** Terminal background as the opaque color actually seen: alpha × opacity blended over the app surface. */
-function compositeTerminalBackground(
+export function compositeTerminalBackground(
   background: string | undefined,
   options: { backgroundOpacity?: number; appSurface?: 'dark' | 'light' } = {}
 ): RgbaColor | null {

--- a/src/renderer/src/lib/terminal-title-contrast.ts
+++ b/src/renderer/src/lib/terminal-title-contrast.ts
@@ -48,6 +48,7 @@ export function resolveTerminalTextContrastRatio(
   return composited && text ? contrastRatio(text, composited) : null
 }
 
+/** Terminal background as the opaque color actually seen: alpha × opacity blended over the app surface. */
 function compositeTerminalBackground(
   background: string | undefined,
   options: { backgroundOpacity?: number; appSurface?: 'dark' | 'light' } = {}

--- a/src/renderer/src/lib/terminal-title-contrast.ts
+++ b/src/renderer/src/lib/terminal-title-contrast.ts
@@ -64,6 +64,7 @@ function compositeTerminalBackground(
   return alpha < 1 ? compositeRgb(color, appSurface, alpha) : { ...color, a: 1 }
 }
 
+/** Parses a named, `#hex[a]`, or `rgb[a]()` (comma or space syntax) color; null for anything else. */
 export function parseCssRgbColor(color: string | undefined): RgbaColor | null {
   const value = color?.trim().toLowerCase()
   if (!value) {

--- a/src/renderer/src/lib/terminal-title-contrast.ts
+++ b/src/renderer/src/lib/terminal-title-contrast.ts
@@ -1,6 +1,7 @@
 export type RgbaColor = { r: number; g: number; b: number; a: number }
 
-const APP_SURFACE_COLORS: Record<'dark' | 'light', RgbaColor> = {
+/** Opaque stand-ins for the app window behind translucent terminal surfaces. */
+export const APP_SURFACE_COLORS: Record<'dark' | 'light', RgbaColor> = {
   dark: { r: 10, g: 10, b: 10, a: 1 },
   light: { r: 255, g: 255, b: 255, a: 1 }
 }

--- a/src/renderer/src/lib/terminal-title-contrast.ts
+++ b/src/renderer/src/lib/terminal-title-contrast.ts
@@ -1,4 +1,4 @@
-type RgbaColor = { r: number; g: number; b: number; a: number }
+export type RgbaColor = { r: number; g: number; b: number; a: number }
 
 const APP_SURFACE_COLORS: Record<'dark' | 'light', RgbaColor> = {
   dark: { r: 10, g: 10, b: 10, a: 1 },
@@ -37,6 +37,17 @@ export function resolveOpaqueTerminalBackground(
   return composited ? `rgb(${composited.r} ${composited.g} ${composited.b})` : null
 }
 
+/** WCAG contrast of a text color over the composited terminal background; null when either fails to parse. */
+export function resolveTerminalTextContrastRatio(
+  background: string | undefined,
+  foreground: string | undefined,
+  options: { backgroundOpacity?: number; appSurface?: 'dark' | 'light' } = {}
+): number | null {
+  const composited = compositeTerminalBackground(background, options)
+  const text = parseCssRgbColor(foreground)
+  return composited && text ? contrastRatio(text, composited) : null
+}
+
 function compositeTerminalBackground(
   background: string | undefined,
   options: { backgroundOpacity?: number; appSurface?: 'dark' | 'light' } = {}
@@ -53,7 +64,7 @@ function compositeTerminalBackground(
   return alpha < 1 ? compositeRgb(color, appSurface, alpha) : { ...color, a: 1 }
 }
 
-function parseCssRgbColor(color: string | undefined): RgbaColor | null {
+export function parseCssRgbColor(color: string | undefined): RgbaColor | null {
   const value = color?.trim().toLowerCase()
   if (!value) {
     return null


### PR DESCRIPTION
## ELI5

On "soft" low-contrast terminal themes (Solarized, Everforest, Rosé Pine Dawn, Catppuccin Latte…) two things fade out: sidebar text in *Match terminal* mode, and shell autosuggestion "ghost text" in the terminal, which gets pushed to the same gray as typed text. Both derive dim colors from the theme foreground using ratios tuned for a near-black/near-white foreground; this PR makes those derivations contrast-aware, so high-contrast themes look exactly as before and low-contrast ones stay readable.

## What Changed

Two focused commits:

**1. `fix(sidebar)` — match-terminal muted text** (`left-sidebar-appearance.ts`, new `muted-foreground-contrast.ts`)
- `--muted-foreground` was a fixed `color-mix(fg 62%, bg)`. It is now gated on contrast: the mix is raised from 62 % until the result clears 4.5:1 against the background (the light default `#737373`/`#fafafa` sits at exactly 4.5:1), capped at the foreground itself. High-contrast pairs stay at 62 %, so existing expectations are unchanged.
- Sidebar nav / task nav / dashboard entry / setup-guide entry / settings sidebar used `text-worktree-sidebar-foreground/60|55|45|30` alpha tiers, which have the same flaw and can't be fixed by tokens. They now use `text-muted-foreground` tiers (`/60`→muted, `/55`→`/90`, `/45`→`/75`, `/30`→`/50`) chosen so the default light and dark looks are visually unchanged (e.g. dark `/30` = 2.64:1 before and after).

**2. `fix(terminal)` — xterm contrast floor** (`terminal-contrast-correction.ts`, `terminal-title-contrast.ts` + 3 call sites)
- `resolveTerminalMinimumContrastRatio` now takes the theme foreground and caps the floor at half the foreground's contrast (`DIM_TEXT_CONTRAST_HEADROOM = 2`, bottoming out at 1). The 4.5 / 3 floors from #7934 / #10104 are untouched whenever fg ≥ 9:1 on light or ≥ 6:1 on dark backgrounds — i.e. every builtin theme except the low-contrast ones.

## Why

Fixed mix ratios and alpha tiers assume the default theme's foreground (~19:1). Solarized Light's `#586e75` on `#fdf6e3` is ~5:1, so:

| | Solarized Light | GitHub Light (14.7:1 fg) |
|---|---|---|
| derived `--muted-foreground` (62 %) | **2.2–2.4:1** | 4.3:1 |
| nav icon tier `fg/30` | **1.5:1** | 3.9:1 |
| ghost text (`brightBlack #93a1a1`, 2.5:1) after xterm's 4.5 floor | lifted to `#5f6868` — fg is `#586e75` | untouched |

Editing the theme is not a workaround: a 60 % alpha tier only reaches 4.5:1 on a light background with a near-black foreground (even Gruvbox Light's 10:1 fg yields 3.4:1), and any `brightBlack` under 4.5:1 is lifted onto the foreground by xterm regardless of its value. Gating on the actual contrast fixes the whole family of themes (Everforest Light, Rosé Pine Dawn, Catppuccin Latte, Solarized Dark…) without touching high-contrast ones.

## Linked Issue

Fixes #16999

## Visual Proof

Solarized Light, *Left sidebar: Match terminal*, macOS.

| Before | After |
|---|---|
| ![before worktree sidebar](https://github.com/user-attachments/assets/58d85105-f2a6-497d-ae8e-fba63cf54035) | ![after worktree sidebar](https://github.com/user-attachments/assets/5677fba3-0156-4127-8a36-7eba5e69617d) |

Settings sidebar:

| Before | After |
|---|---|
| ![before settings sidebar](https://github.com/user-attachments/assets/25db10e9-27e8-4ec1-b448-858f9f9e548a) | ![after settings sidebar](https://github.com/user-attachments/assets/84034bd0-acb0-47e2-b795-b1138df416c9) |

Terminal (zsh-autosuggestions, `fg=8`): before, typed text and ghost text both render as ~`#5f6868`; after, ghost text stays at the theme's `brightBlack` (`#93a1a1`, 2.5:1) while typed text remains `#586e75` (5:1).

## Testing

- macOS: `pnpm dev` with Solarized Light (builtin and a Ghostty/Warp-imported variant), sidebar in match-terminal mode; verified sidebar labels/subtitles/settings sidebar and ghost text in a zsh pane. Also checked GitHub Light / Ghostty Default Dark render unchanged.
- Not a platform-specific change (pure color derivation in the renderer); no SSH/remote or path impact.
- `pnpm test` (281 files / 2387 tests), `pnpm tc:web`, changed-file lint all pass locally.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

New/updated tests: `muted-foreground-contrast.test.ts` (7), `left-sidebar-appearance.test.ts` (+1 match-terminal Solarized case), `terminal-contrast-correction.test.ts` (+7 headroom cases, incl. pinning that Solarized's own `brightBlack` is no longer lifted and that high-contrast themes keep their floors).

## AI Disclosure

Root-cause analysis, implementation and tests were done with Claude (Claude Code), reviewed and verified manually by me.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Renderer-only color derivation; no security, cross-platform, SSH, mobile, wire or performance surface. The contrast search in `resolveMutedForegroundMixPercent` is at most 38 iterations of a few multiplications and runs only when sidebar style variables are recomputed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
