### PR TITLE
docs(headless-server): fix package list, extraction perms, and ldd command

### DIFF
--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -43,13 +43,19 @@ substitute the unsuffixed names:
 - `libcups2t64` becomes `libcups2`
 - `libatspi2.0-0t64` becomes `libatspi2.0-0`
 
-The other names are identical on every supported release. The two sets are not
-interchangeable: `apt-get install` fails outright on a name the release does not
-carry, and on Ubuntu 24.04 `libasound2` survives only as a virtual package for an
-unrelated library, so it installs without giving Electron what it needs.
+The other names are identical on every supported release. The substitution is not
+symmetric, so use the list that matches the release. A `t64` name on Ubuntu 20.04,
+Ubuntu 22.04, or Debian 12 fails immediately with `E: Unable to locate package
+libgtk-3-0t64`. In the other direction the old names mostly still resolve, because
+each renamed package declares `Provides:` its unsuffixed name — except `libasound2`
+on Ubuntu 24.04, where `liboss4-salsa-asound2` in `universe` claims that name too.
+apt will not choose between two providers and exits with `E: Package 'libasound2'
+has no installation candidate`, which aborts the entire install line and leaves none
+of the libraries installed.
 
-On Ubuntu 22.04, install `libfuse2` to execute the AppImage through FUSE. On
-Ubuntu 24.04 and Debian, the equivalent package may be `libfuse2t64`. FUSE is
+On Ubuntu 20.04 and 22.04, install `libfuse2` to execute the AppImage through
+FUSE. On Ubuntu 24.04 and Debian 13 the package is `libfuse2t64`, though the plain
+`libfuse2` name also resolves there because nothing else provides it. FUSE is
 optional: without it, use the AppImage's supported extraction path:
 
 ```bash

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -17,12 +17,36 @@ differ on other Debian-derived releases.
 
 ## Ubuntu and Debian prerequisites
 
-Install the AppImage runtime dependency and Xvfb:
+Install the CLI tools, Xvfb, and the shared libraries Electron links against.
+A minimal server or container image ships none of the Electron libraries, and
+`orca serve` then fails before Electron starts:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y curl file jq xvfb zlib1g-dev
+sudo apt-get install -y \
+  curl file jq xvfb zlib1g-dev ca-certificates git \
+  libgtk-3-0t64 libnss3 libatk1.0-0t64 libatk-bridge2.0-0t64 libgbm1 libasound2t64 \
+  libxtst6 libcups2t64 libdrm2 libxkbcommon0 libpango-1.0-0 libcairo2 libatspi2.0-0t64 \
+  libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libxrender1 libx11-xcb1 \
+  libxcb-dri3-0 libxss1
 ```
+
+That command is for Ubuntu 24.04 and newer and Debian 13 and newer. Those
+releases carried out the 64-bit `time_t` transition, which renamed six of the
+packages with a `t64` suffix. On Ubuntu 20.04, Ubuntu 22.04, and Debian 12,
+substitute the unsuffixed names:
+
+- `libgtk-3-0t64` becomes `libgtk-3-0`
+- `libatk1.0-0t64` becomes `libatk1.0-0`
+- `libatk-bridge2.0-0t64` becomes `libatk-bridge2.0-0`
+- `libasound2t64` becomes `libasound2`
+- `libcups2t64` becomes `libcups2`
+- `libatspi2.0-0t64` becomes `libatspi2.0-0`
+
+The other names are identical on every supported release. The two sets are not
+interchangeable: `apt-get install` fails outright on a name the release does not
+carry, and on Ubuntu 24.04 `libasound2` survives only as a virtual package for an
+unrelated library, so it installs without giving Electron what it needs.
 
 On Ubuntu 22.04, install `libfuse2` to execute the AppImage through FUSE. On
 Ubuntu 24.04 and Debian, the equivalent package may be `libfuse2t64`. FUSE is
@@ -31,8 +55,14 @@ optional: without it, use the AppImage's supported extraction path:
 ```bash
 cd /opt/orca
 ./orca-linux.AppImage --appimage-extract
+sudo chmod -R a+rX /opt/orca/squashfs-root
 /opt/orca/squashfs-root/AppRun serve --port 6768
 ```
+
+The `chmod` is required whenever the extraction runs as a different user than
+the server: `--appimage-extract` creates `squashfs-root` as `drwx------` owned by
+the extracting user, so anyone else — including a dedicated service user — cannot
+even traverse it, and the run fails before Electron starts.
 
 Docker commonly has no FUSE device. Use `--appimage-extract` once or
 `--appimage-extract-and-run`; neither requires a privileged container. The
@@ -144,7 +174,14 @@ AppImage, but must not be able to replace it or the rollback artifacts.
 sudo useradd --system --create-home --shell /usr/sbin/nologin orca
 sudo chown root:root /opt/orca /opt/orca/orca-linux.AppImage
 sudo chmod 755 /opt/orca /opt/orca/orca-linux.AppImage
+# Only if you ran --appimage-extract: extraction leaves squashfs-root root-only.
+sudo chmod -R a+rX /opt/orca/squashfs-root
 ```
+
+The last line matters because the two halves of this guide combine badly without
+it. `--appimage-extract` writes `squashfs-root` as `drwx------ root root`, so the
+`orca` service user cannot read or traverse the extracted tree and the unit fails
+at startup. `chmod 755 /opt/orca` alone does not reach into it.
 
 For most hosts, one `orca serve` service is enough because Orca starts Xvfb on
 display `:99` when no display exists:
@@ -834,7 +871,8 @@ refuse to run there and print the command to run on the machine you want.
 - GPU or DRI warnings on a VPS: keep `LIBGL_ALWAYS_SOFTWARE=1` in the service
   environment.
 - Chromium sandbox errors: confirm the service is running as the non-root
-  `orca` user and that `/opt/orca` is readable by that user.
+  `orca` user and that `/opt/orca` is readable by that user, including
+  `/opt/orca/squashfs-root` if you extracted the AppImage.
 - Clients cannot connect: make sure `--pairing-address` is an address reachable
   from the client, and make sure firewalls allow the selected `--port`.
 - Journal shows `Another Orca instance is already running for this userData
@@ -857,4 +895,7 @@ profile` and the unit exits `3`: another process already owns the profile, so
   `sudo systemctl reset-failed orca-serve.service` first.
 - Diagnosing other missing libraries: extract the AppImage without launching it
   with `./orca-linux.AppImage --appimage-extract`, then run
-  `ldd squashfs-root/orca` to list any shared libraries the host is missing.
+  `ldd squashfs-root/orca-ide` to list any shared libraries the host is missing.
+  The Electron binary is `orca-ide`, not `orca`; `ldd` on a path that does not
+  exist prints nothing and exits cleanly, which reads as a clean result in
+  exactly the situation where you are hunting a missing library.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |

<!-- /orca-pr-loc -->

## What this fixes

Three bugs in the headless Linux server guide. Each one stops a first-time setup from working, and two of them fail in ways that look like something else.

## ELI5

**1. The shopping list was missing most of the ingredients.**

The guide said to install `curl file jq xvfb zlib1g-dev`. But Orca is an Electron app, and Electron needs a pile of graphics and audio libraries to even start — GTK, NSS, ATK, ALSA and friends. A desktop machine has them already, which is why nobody noticed. A minimal server or container image has none of them, so `orca serve` dies before Electron gets going.

Now the list includes them.

There's a wrinkle: Ubuntu 24.04 and Debian 13 renamed six of these packages with a `t64` suffix (a 64-bit clock change — `time_t` — that rippled through library names). So the doc gives both sets and says which release needs which.

Getting it wrong fails in two different ways. Using a `t64` name on an older release fails immediately and obviously (`E: Unable to locate package libgtk-3-0t64`). Going the other way is subtler: old names mostly still work on 24.04, because each renamed package advertises its old name — **except `libasound2`**, which an unrelated OSS compatibility shim in `universe` also claims. apt won't pick between two candidates, so it aborts with `E: Package 'libasound2' has no installation candidate` and installs *none* of the libraries on that line.

**2. Two correct instructions that break each other.**

The guide tells you to unpack the AppImage with `--appimage-extract`. Elsewhere it tells you to run the service as a dedicated `orca` user, keeping the install directory root-owned so the service can't overwrite its own binary. Both sensible.

But unpacking creates `squashfs-root` as `drwx------` — readable only by whoever unpacked it, normally root. The `orca` user can't even walk into the directory. And the `chmod 755 /opt/orca` the guide already had only fixes the *parent*; it doesn't reach inside.

So following the guide exactly gives you a service that won't start. Adds the one missing `chmod -R a+rX`, in both places.

**3. The debugging command looked for a file that isn't there.**

To find missing libraries the guide said to run `ldd squashfs-root/orca`. The binary is actually called `orca-ide`.

This is the nastiest of the three, because `ldd` on a path that doesn't exist prints nothing and exits 0. So you run the command meant to list your missing libraries, see an empty result, and conclude nothing is missing — in precisely the situation where something is.

## How these were found

By standing up a headless server on a bare Ubuntu container and hitting each one in order. After the corrected package list, `ldd squashfs-root/orca-ide | grep "not found"` returns empty.

## Verification

- Package list, `chmod` behaviour, binary name and the `ldd` false negative: reproduced on a live Ubuntu 26.04 container.
- All six name mappings confirmed in both directions against the raw archive indexes (`archive.ubuntu.com`, `old-releases.ubuntu.com`, `ports.ubuntu.com`, `deb.debian.org` `Packages.gz`) for focal, jammy, bookworm, noble and trixie, and the install behaviour reproduced with `apt-get install -s` in `ubuntu:20.04`, `ubuntu:22.04`, `ubuntu:24.04` and `debian:13` containers.
- The Debian 13 / Ubuntu 24.04 cutoff matches the [Debian 64-bit time_t release goal](https://wiki.debian.org/ReleaseGoals/64bit-time). Ubuntu 23.10 is not involved — `mantic/main` contains no `t64` names.
- The compat `Provides:` are present on arm64 as well as amd64, which matters because Orca ships an arm64 AppImage.

Worth noting for anyone verifying this independently: `packages.ubuntu.com` is misleading for `libasound2` on noble. It appears to index only unversioned `Provides:`, so it shows the OSS shim and omits `libasound2t64` entirely. The archive metadata is authoritative and disagrees — an earlier draft of this PR got the mechanism wrong by trusting the search page.

## Scope

Documentation only. No behaviour change.