### PR TITLE
build: isolate candidates and make checks portable

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,7 +86,7 @@ jobs:
           native-runtime: node
 
       - name: Lint
-        run: pnpm exec oxlint --format github
+        run: node config/scripts/oxlint-executable.mjs --format github
 
       - name: Enforce focused code-quality plugins
         run: pnpm run audit:code-quality:native

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ node_modules
 dist/
 dist-electron/
 out/
+output/
 /build/
 release/
 native/**/.build/
@@ -90,6 +91,7 @@ design-docs/
 # Durable docs that should be tracked must live in one of the allow-listed
 # locations below (assets, readme, STYLEGUIDE, mobile terminal shortcut bar,
 # and the tracked reference docs linked from AGENTS.md / README.md).
+plans/
 docs/**
 !docs/
 !docs/assets/

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -140,6 +140,16 @@ module.exports = {
     // it is gitignored, but exclude it defensively so a stray local capture at
     // package time never bloats app.asar.
     '!pr-evidence{,/**/*}',
+    // Why: local packaging may target a nested dist/<candidate>/ directory; exclude
+    // every repository build output so older candidates cannot recurse into app.asar.
+    '!dist{,/**/*}',
+    // Why: plans, test reports, and Chromium's root debug log are local evidence,
+    // not runtime inputs, and must never leak into a user package.
+    '!plans{,/**/*}',
+    '!output{,/**/*}',
+    '!test-results{,/**/*}',
+    '!debug.log',
+    '!NUL',
     '!Casks{,/**/*}',
     '!{AGENTS.md,CLAUDE.md,DEVELOPING.md,bundle-size-progress.md,ORCHESTRATION_IMPLEMENTATION_CHECKLIST.md,ORCHESTRATION_STRUCTURED_OUTPUT_DESIGN.md}',
     '!out/**/*.test.js',

--- a/config/scripts/check-changed-code-quality.mjs
+++ b/config/scripts/check-changed-code-quality.mjs
@@ -4,6 +4,7 @@ import path from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 import { resolvePullRequestDiffBase } from './git-pull-request-diff-base.mjs'
+import { oxlintPath } from './oxlint-executable.mjs'
 
 const SOURCE_FILE_PATTERN = /\.(?:[cm]?[jt]sx?)$/
 export const OXLINT_SCANS = [
@@ -263,9 +264,13 @@ function printDiagnostic(diagnostic, root) {
   console.error(`${file}:${line} ${code}: ${diagnostic.message}`)
 }
 
+export function buildOxlintInvocation(args) {
+  return { command: process.execPath, args: [oxlintPath, ...args] }
+}
+
 function runOxlintScan(root, scan, files) {
-  const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
-  const result = spawnSync(pnpm, ['exec', 'oxlint', ...scan.args, '--format', 'json', ...files], {
+  const invocation = buildOxlintInvocation([...scan.args, '--format', 'json', ...files])
+  const result = spawnSync(invocation.command, invocation.args, {
     cwd: root,
     encoding: 'utf8',
     maxBuffer: 128 * 1024 * 1024

--- a/config/scripts/check-changed-code-quality.test.mjs
+++ b/config/scripts/check-changed-code-quality.test.mjs
@@ -1,11 +1,23 @@
 import { describe, expect, it } from 'vitest'
+import process from 'node:process'
 import {
   OXLINT_SCANS,
+  buildOxlintInvocation,
   diagnosticTouchesAddedLines,
   isMovedCode,
   overlapsAddedLines,
   parseAddedLineRanges
 } from './check-changed-code-quality.mjs'
+
+describe('Oxlint invocation', () => {
+  it('runs the workspace Oxlint entrypoint through Node without a pnpm subprocess', () => {
+    const invocation = buildOxlintInvocation(['--format', 'json', 'src/example.ts'])
+
+    expect(invocation.command).toBe(process.execPath)
+    expect(invocation.args[0]).toMatch(/[\\/]oxlint[\\/]bin[\\/]oxlint$/)
+    expect(invocation.args.slice(1)).toEqual(['--format', 'json', 'src/example.ts'])
+  })
+})
 
 describe('changed-code quality line matching', () => {
   it('parses added and replaced hunk ranges while ignoring deletions', () => {

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -44,6 +44,12 @@ describe('electron-builder config', () => {
         '!tests{,/**/*}',
         '!examples{,/**/*}',
         '!pr-evidence{,/**/*}',
+        '!dist{,/**/*}',
+        '!plans{,/**/*}',
+        '!output{,/**/*}',
+        '!test-results{,/**/*}',
+        '!debug.log',
+        '!NUL',
         '!Casks{,/**/*}',
         '!{AGENTS.md,CLAUDE.md,DEVELOPING.md,bundle-size-progress.md,ORCHESTRATION_IMPLEMENTATION_CHECKLIST.md,ORCHESTRATION_STRUCTURED_OUTPUT_DESIGN.md}',
         '!out/**/*.test.js',
@@ -92,6 +98,25 @@ describe('electron-builder config', () => {
     // The real build outputs sit beside it under out/ and must still ship.
     expect(packs('out/main/index.js')).toBe(true)
     expect(packs('out/renderer/index.html')).toBe(true)
+  })
+
+  it('keeps local build and evidence outputs out of app.asar', () => {
+    const matcher = new FileMatcher('/app', '/dest', (value) => value, electronBuilderConfig.files)
+    matcher.prependPattern('**/*')
+    const isPacked = matcher.createFilter()
+    const packs = (repoPath) => isPacked(join('/app', repoPath), { isDirectory: () => false })
+
+    for (const localOnly of [
+      'dist/old-candidate/win-unpacked/Orca.exe',
+      'plans/009-prove-orca-dev-and-gate-live-recovery.md',
+      'output/playwright/real-gate-profile/daemon/daemon-v38.token',
+      'test-results/failed-test/error-context.md',
+      'debug.log',
+      'NUL'
+    ]) {
+      expect(packs(localOnly)).toBe(false)
+    }
+    expect(packs('out/main/index.js')).toBe(true)
   })
 
   it('keeps runtime resources available through extraResources', () => {

--- a/config/scripts/lint-react-doctor-changed.mjs
+++ b/config/scripts/lint-react-doctor-changed.mjs
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
+import { oxlintPath } from './oxlint-executable.mjs'
 
 const SOURCE_FILE_PATTERN = /\.(?:[cm]?[jt]sx?)$/
 
@@ -31,10 +32,9 @@ if (lintTargets.length === 0) {
   process.exit(0)
 }
 
-const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const result = spawnSync(
-  pnpm,
-  ['exec', 'oxlint', '--config', 'config/oxlint-react-doctor.json', ...lintTargets],
+  process.execPath,
+  [oxlintPath, '--config', 'config/oxlint-react-doctor.json', ...lintTargets],
   { stdio: 'inherit' }
 )
 

--- a/config/scripts/mobile-pairing-qrcode-import-plugin.test.mjs
+++ b/config/scripts/mobile-pairing-qrcode-import-plugin.test.mjs
@@ -3,11 +3,9 @@ import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { oxlintPath } from './oxlint-executable.mjs'
 
 const pluginPath = path.resolve('config/oxlint-plugins/mobile-pairing-qrcode-import.mjs')
-const oxlintPath = path.resolve(
-  process.platform === 'win32' ? 'node_modules/.bin/oxlint.cmd' : 'node_modules/.bin/oxlint'
-)
 
 function lintSource(source) {
   const directory = mkdtempSync(path.join(tmpdir(), 'orca-qrcode-import-lint-'))
@@ -22,9 +20,11 @@ function lintSource(source) {
       rules: { 'mobile-pairing/no-eager-qrcode-import': 'error' }
     })
   )
-  const result = spawnSync(oxlintPath, ['--config', configPath, '--format', 'json', sourcePath], {
-    encoding: 'utf8'
-  })
+  const result = spawnSync(
+    process.execPath,
+    [oxlintPath, '--config', configPath, '--format', 'json', sourcePath],
+    { encoding: 'utf8' }
+  )
   if (result.error) {
     throw result.error
   }

--- a/config/scripts/oxlint-executable.mjs
+++ b/config/scripts/oxlint-executable.mjs
@@ -1,0 +1,8 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
+
+const oxlintPackageDirectory = path.dirname(
+  createRequire(import.meta.url).resolve('oxlint/package.json')
+)
+
+export const oxlintPath = path.join(oxlintPackageDirectory, 'bin', 'oxlint')

--- a/config/scripts/oxlint-executable.mjs
+++ b/config/scripts/oxlint-executable.mjs
@@ -1,8 +1,29 @@
+import { spawnSync } from 'node:child_process'
 import { createRequire } from 'node:module'
 import path from 'node:path'
+import process from 'node:process'
+import { pathToFileURL } from 'node:url'
 
-const oxlintPackageDirectory = path.dirname(
-  createRequire(import.meta.url).resolve('oxlint/package.json')
-)
+const repositoryRoot = path.resolve(import.meta.dirname, '..', '..')
 
-export const oxlintPath = path.join(oxlintPackageDirectory, 'bin', 'oxlint')
+export function resolveOxlintPath(packageRoot = repositoryRoot) {
+  const requireFromPackage = createRequire(path.join(packageRoot, 'package.json'))
+  const packageDirectory = path.dirname(requireFromPackage.resolve('oxlint/package.json'))
+  return path.join(packageDirectory, 'bin', 'oxlint')
+}
+
+export const oxlintPath = resolveOxlintPath()
+
+export function runOxlint(args, packageRoot = process.cwd()) {
+  const result = spawnSync(process.execPath, [resolveOxlintPath(packageRoot), ...args], {
+    stdio: 'inherit'
+  })
+  if (result.error) {
+    throw result.error
+  }
+  return result.status ?? 1
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = runOxlint(process.argv.slice(2))
+}

--- a/config/scripts/oxlint-executable.test.mjs
+++ b/config/scripts/oxlint-executable.test.mjs
@@ -1,0 +1,23 @@
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import process from 'node:process'
+import { describe, expect, it } from 'vitest'
+import { oxlintPath, resolveOxlintPath } from './oxlint-executable.mjs'
+
+describe('Oxlint executable', () => {
+  it('resolves the workspace JavaScript entrypoint', () => {
+    expect(oxlintPath).toBe(resolveOxlintPath())
+    expect(oxlintPath).toMatch(/[\\/]oxlint[\\/]bin[\\/]oxlint$/)
+  })
+
+  it('runs through Node without relying on a platform shim', () => {
+    const result = spawnSync(
+      process.execPath,
+      [path.resolve('config/scripts/oxlint-executable.mjs'), '--version'],
+      { encoding: 'utf8' }
+    )
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout).toMatch(/^Version: \d+\.\d+\.\d+/)
+  })
+})

--- a/config/scripts/oxlint-plugin-test-runner.mjs
+++ b/config/scripts/oxlint-plugin-test-runner.mjs
@@ -1,14 +1,9 @@
 import { spawnSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
-
-const oxlintPackageDirectory = path.dirname(
-  createRequire(import.meta.url).resolve('oxlint/package.json')
-)
-const oxlintPath = path.join(oxlintPackageDirectory, 'bin', 'oxlint')
+import { oxlintPath } from './oxlint-executable.mjs'
 
 export function runOxlintPluginOnSource({
   pluginName,

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,7 +10,7 @@
     "postinstall": "node scripts/build-terminal-webview-engine.mjs && node scripts/build-mermaid-webview-engine.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "lint": "oxlint",
+    "lint": "node ../config/scripts/oxlint-executable.mjs",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
     "mock-server": "npx tsx scripts/mock-server.ts",

--- a/package.json
+++ b/package.json
@@ -11,17 +11,17 @@
   "main": "./out/main/index.js",
   "scripts": {
     "format": "oxfmt --write .",
-    "lint": "oxlint && pnpm run audit:code-quality:native && pnpm run audit:code-quality:type-aware && pnpm run check:reliability-gates && pnpm run check:max-lines-ratchet && pnpm run check:runtime-electron-ratchet && pnpm run verify:bundled-skill-guides && pnpm run verify:skill-bundle-manifest && pnpm run verify:localization-catalog && pnpm run verify:localization-extraction && pnpm run verify:localization-coverage",
+    "lint": "node config/scripts/oxlint-executable.mjs && pnpm run audit:code-quality:native && pnpm run audit:code-quality:type-aware && pnpm run check:reliability-gates && pnpm run check:max-lines-ratchet && pnpm run check:runtime-electron-ratchet && pnpm run verify:bundled-skill-guides && pnpm run verify:skill-bundle-manifest && pnpm run verify:localization-catalog && pnpm run verify:localization-extraction && pnpm run verify:localization-coverage",
     "audit:code-quality": "pnpm run audit:code-quality:native && pnpm run audit:code-quality:type-aware && pnpm run audit:react-doctor",
-    "audit:code-quality:native": "oxlint --config config/oxlint-code-quality-native-plugins.json src config tests mobile --deny-warnings",
-    "audit:code-quality:type-aware": "oxlint --type-aware --config config/oxlint-code-quality-type-aware.json src config tests --deny-warnings",
+    "audit:code-quality:native": "node config/scripts/oxlint-executable.mjs --config config/oxlint-code-quality-native-plugins.json src config tests mobile --deny-warnings",
+    "audit:code-quality:type-aware": "node config/scripts/oxlint-executable.mjs --type-aware --config config/oxlint-code-quality-type-aware.json src config tests --deny-warnings",
     "audit:react-doctor": "pnpm dlx react-doctor@0.9.1 . --yes --no-supply-chain --no-telemetry --blocking none",
     "audit:dead-code": "pnpm dlx knip@5.88.1 --config config/knip.json",
     "check:code-quality:changed": "node config/scripts/check-changed-code-quality.mjs",
     "check:react-doctor:changed": "node config/scripts/check-react-doctor-changed.mjs",
     "check:zustand-selector-fanout": "node config/scripts/zustand-selector-fanout-benchmark.mjs --check",
     "doctor": "pnpm dlx react-doctor@0.9.1 . --no-telemetry",
-    "lint:react-doctor": "oxlint --config config/oxlint-react-doctor.json",
+    "lint:react-doctor": "node config/scripts/oxlint-executable.mjs --config config/oxlint-react-doctor.json",
     "lint:react-doctor:changed": "node config/scripts/lint-react-doctor-changed.mjs",
     "prepare": "husky",
     "test": "node config/scripts/ensure-native-runtime.mjs --runtime=node && vitest run --config config/vitest.config.ts",
@@ -283,8 +283,8 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,mjs,mts,cts}": [
-      "oxlint",
-      "oxlint --config config/oxlint-react-doctor.json",
+      "node config/scripts/oxlint-executable.mjs",
+      "node config/scripts/oxlint-executable.mjs --config config/oxlint-react-doctor.json",
       "oxfmt --write"
     ],
     "*.{json,css}": [

--- a/tests/e2e/helpers/electron-process-logs.ts
+++ b/tests/e2e/helpers/electron-process-logs.ts
@@ -1,0 +1,19 @@
+import type { ElectronApplication, TestInfo } from '@stablyai/playwright-test'
+
+export function forwardElectronProcessLogs(app: ElectronApplication, testInfo: TestInfo): void {
+  if (process.env.ORCA_E2E_FORWARD_APP_LOGS !== '1') {
+    return
+  }
+
+  const child = app.process()
+  const prefix = `[electron:${testInfo.title}]`
+  child.stdout?.on('data', (chunk: Buffer) => {
+    console.log(`${prefix} stdout: ${chunk.toString().trimEnd()}`)
+  })
+  child.stderr?.on('data', (chunk: Buffer) => {
+    console.error(`${prefix} stderr: ${chunk.toString().trimEnd()}`)
+  })
+  child.on('exit', (code, signal) => {
+    console.log(`${prefix} exit: code=${code ?? 'null'} signal=${signal ?? 'null'}`)
+  })
+}

--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -33,6 +33,9 @@ import {
   createElectronHomeIsolation
 } from './electron-home-isolation'
 import { createSeededTestRepo, isValidGitRepo } from './seeded-test-repo'
+import { forwardElectronProcessLogs } from './electron-process-logs'
+
+export { forwardElectronProcessLogs } from './electron-process-logs'
 
 type OrcaTestFixtures = {
   electronApp: ElectronApplication
@@ -108,27 +111,6 @@ function shouldLaunchHeadful(testInfo: TestInfo): boolean {
     return true
   }
   return testInfo.project.metadata.orcaHeadful === true
-}
-
-// Why: exported so specs that launch their own ElectronApplication outside
-// this fixture (e.g. multi-instance lifecycle tests) can still opt into the
-// same ORCA_E2E_FORWARD_APP_LOGS-gated stdout/stderr capture.
-export function forwardElectronProcessLogs(app: ElectronApplication, testInfo: TestInfo): void {
-  if (process.env.ORCA_E2E_FORWARD_APP_LOGS !== '1') {
-    return
-  }
-
-  const child = app.process()
-  const prefix = `[electron:${testInfo.title}]`
-  child.stdout?.on('data', (chunk: Buffer) => {
-    console.log(`${prefix} stdout: ${chunk.toString().trimEnd()}`)
-  })
-  child.stderr?.on('data', (chunk: Buffer) => {
-    console.error(`${prefix} stderr: ${chunk.toString().trimEnd()}`)
-  })
-  child.on('exit', (code, signal) => {
-    console.log(`${prefix} exit: code=${code ?? 'null'} signal=${signal ?? 'null'}`)
-  })
 }
 
 /**
@@ -226,8 +208,21 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
     if (recordVideoDir) {
       mkdirSync(recordVideoDir, { recursive: true })
     }
+    const packagedExecutable = process.env.ORCA_E2E_PACKAGED_EXECUTABLE?.trim()
+    const launchArgs = packagedExecutable
+      ? headful
+        ? orcaAppExtraArgs
+        : [
+            ...orcaAppExtraArgs,
+            '--disable-gpu',
+            '--disable-gpu-compositing',
+            '--disable-gpu-sandbox',
+            '--in-process-gpu'
+          ]
+      : [...orcaAppExtraArgs, ...getOrcaElectronLaunchArgs(mainPath, headful)]
     const app = await electron.launch({
-      args: [...orcaAppExtraArgs, ...getOrcaElectronLaunchArgs(mainPath, headful)],
+      ...(packagedExecutable ? { executablePath: packagedExecutable } : {}),
+      args: launchArgs,
       ...(slowMo > 0 ? { slowMo } : {}),
       ...(recordVideoDir ? { recordVideo: { dir: recordVideoDir } } : {}),
       // Why: keep NODE_ENV=development so window.__store is exposed and


### PR DESCRIPTION
**Base/head:** `8b99c8365d6bd9cbc7e50d9d4a5a73b5005c2f80..d41deb7917c98f30f741e425eb87dc8886257505`  
**Size:** 4 commits, 15 files, +162 / -47

### ELI5

Local build/test leftovers can no longer leak into Electron packages, packaged E2E can select an explicit Orca executable, and Oxlint always runs through Node instead of an OS-specific shell shim.

### What Changed

- Exclude `dist/`, `plans/`, `output/`, `test-results/`, `debug.log`, and `NUL` from Electron packages; ignore Playwright `output/`.
- Add `ORCA_E2E_PACKAGED_EXECUTABLE` and reusable Electron process-log extraction to the existing candidate E2E seam.
- Launch Oxlint with `process.execPath` plus its resolved JS entrypoint from root scripts, lint-staged, PR CI, and mobile.
- Test package-root resolution, Node execution, changed-file/workflow parity, and packaging exclusions.

No worker lifecycle, schema, runtime, RPC, CLI recovery, or business flow is included. The lifecycle doc allowlist follows PR2, where the doc is introduced.

### Why

Windows may lack a usable `.cmd` shim while macOS/Linux never use it. `createRequire` + `path.join` + `process.execPath` avoids shell and extension assumptions. Package exclusions also make candidate contents auditable.

### Linked Issue

N/A — stacked maintenance prerequisite. The umbrella Issue is associated only by PR2.

Depends on: none  
Required by: PR1 `https://github.com/stablyai/orca/pull/17006`

> External-fork stack: GitHub temporarily compares this PR with main. The logical review boundary is 8b99c8365d..d41deb7917; later PRs depend on this one.

### Visual Proof

N/A — maintenance/test infrastructure only; no UI or interaction change.

### Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

```text
pnpm test config/scripts/oxlint-executable.test.mjs config/scripts/check-changed-code-quality.test.mjs config/scripts/pr-workflow-lint-parity.test.mjs
# 3 files, 17 passed
pnpm lint
pnpm --dir mobile lint
pnpm typecheck
pnpm build
# passed on a local Windows runner; exact tool/OS versions retained in private evidence
```

CI should cover Linux/macOS static checks and the mobile workflow.

### AI Disclosure

<!-- Internal contributor: leave blank. External contributor: add model/tool details. -->

### Review

- **Cross-platform:** no shell, `.cmd`, or separator assumption; root and mobile package roots are tested.
- **SSH/remote/local:** build-time only; no wire, host, terminal, or remote behavior changes.
- **Agents/integrations:** generic candidate seam; no provider launch path added.
- **Security/privacy:** local evidence cannot enter `app.asar`; no credentials/logs are added.
- **Performance/UI/mobile:** equivalent one-process lint launch; no UI behavior; mobile invocation only.

### Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer material was copied or translated.

### Notes

Canonical formatting was limited to owned paths. No translation semantics, `NUL`, Expo `.gradle/`, candidate, or evidence artifact is committed.

### Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and shortcut impact considered
- [ ] Full aggregate tests (targeted/lint/typecheck/build pass locally; full Windows suite reproduces current-main path/timing failures; CI covers supported runners)

### Author

X (Twitter): `N/A`