### PR TITLE
perf(editor): stop re-rendering every code block on each keystroke

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -115,7 +115,9 @@ export function RichMarkdownCodeBlock({
         )}
         {/* If the document has a language not in our list, show it as-is */}
         {languageListMounted && language && !isKnownCodeBlockLanguage(language) ? (
-          <option value={language}>{language}</option>
+          <option key={language} value={language}>
+            {language}
+          </option>
         ) : null}
       </select>
       <button

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useRef, useState } from 'react'
+import { flushSync } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import type { NodeViewProps } from '@tiptap/react'
@@ -6,159 +7,11 @@ import { Copy, Check } from 'lucide-react'
 import { useAppStore } from '@/store'
 import MermaidBlock from './MermaidBlock'
 import { translate } from '@/i18n/i18n'
-
-/**
- * Common languages shown in the selector. The user can also type a language
- * name directly in the markdown fence (```rust) and it will be preserved —
- * this list is just for quick picking in the UI.
- */
-const LANGUAGES = [
-  {
-    value: '',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.13822cdfda', 'Plain text')
-    }
-  },
-  {
-    value: 'bash',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.4227cf50fe', 'Bash')
-    }
-  },
-  { value: 'c', label: 'C' },
-  {
-    value: 'cpp',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.4daed43ae3', 'C++')
-    }
-  },
-  {
-    value: 'css',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.026653f21f', 'CSS')
-    }
-  },
-  {
-    value: 'diff',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.bf6ee5caaa', 'Diff')
-    }
-  },
-  {
-    value: 'go',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.edfcc64182', 'Go')
-    }
-  },
-  {
-    value: 'graphql',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.706fd85738', 'GraphQL')
-    }
-  },
-  {
-    value: 'html',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.8c4a3fa02d', 'HTML')
-    }
-  },
-  {
-    value: 'java',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.36536ad539', 'Java')
-    }
-  },
-  {
-    value: 'javascript',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.a209c57063', 'JavaScript')
-    }
-  },
-  {
-    value: 'json',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.78eba32de4', 'JSON')
-    }
-  },
-  {
-    value: 'kotlin',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.bcb236e2d8', 'Kotlin')
-    }
-  },
-  {
-    value: 'markdown',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.983b9576b4', 'Markdown')
-    }
-  },
-  {
-    value: 'mermaid',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.89d6cc14fb', 'Mermaid')
-    }
-  },
-  {
-    value: 'python',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.2391f9cda9', 'Python')
-    }
-  },
-  {
-    value: 'ruby',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.96182a2f64', 'Ruby')
-    }
-  },
-  {
-    value: 'rust',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.e72e6b03f4', 'Rust')
-    }
-  },
-  {
-    value: 'scss',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.5af8251002', 'SCSS')
-    }
-  },
-  {
-    value: 'shell',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.d01f55be57', 'Shell')
-    }
-  },
-  {
-    value: 'sql',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.3009f722b9', 'SQL')
-    }
-  },
-  {
-    value: 'swift',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.9e384d48dc', 'Swift')
-    }
-  },
-  {
-    value: 'typescript',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.88d777bc07', 'TypeScript')
-    }
-  },
-  {
-    value: 'xml',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.5ef5605cb7', 'XML')
-    }
-  },
-  {
-    value: 'yaml',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownCodeBlock.74eab1d9b2', 'YAML')
-    }
-  }
-]
+import {
+  getCodeBlockLanguageLabel,
+  getCodeBlockLanguages,
+  isKnownCodeBlockLanguage
+} from './rich-markdown-code-block-languages'
 
 export function RichMarkdownCodeBlock({
   node,
@@ -167,6 +20,10 @@ export function RichMarkdownCodeBlock({
   useTranslation()
   const language = (node.attrs.language as string) || ''
   const [copied, setCopied] = useState(false)
+  // Why: ProseMirror renders every node view in the document, so eagerly
+  // mounting the full language list cost ~25 <option> elements per code block —
+  // in a large document that dwarfs the prose DOM and slows every keystroke.
+  const [languageListMounted, setLanguageListMounted] = useState(false)
   const copiedResetTimerRef = useRef<number | null>(null)
   // Why: clipboard IPC can resolve after the node view unmounts; avoid
   // starting a reset timer that will outlive the component.
@@ -194,6 +51,15 @@ export function RichMarkdownCodeBlock({
     },
     [clearCopiedResetTimer]
   )
+
+  const mountLanguageList = useCallback(() => {
+    if (languageListMounted) {
+      return
+    }
+    // Why: the native popup opens as this same discrete event's default action,
+    // so the list must be in the DOM before React's normal flush would land.
+    flushSync(() => setLanguageListMounted(true))
+  }, [languageListMounted])
 
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -233,14 +99,22 @@ export function RichMarkdownCodeBlock({
         contentEditable={false}
         value={language}
         onChange={onChange}
+        onMouseDown={mountLanguageList}
+        onFocus={mountLanguageList}
       >
-        {LANGUAGES.map((lang) => (
-          <option key={lang.value} value={lang.value}>
-            {lang.label}
-          </option>
-        ))}
+        {languageListMounted ? (
+          getCodeBlockLanguages().map((lang) => (
+            <option key={lang.value} value={lang.value}>
+              {lang.label}
+            </option>
+          ))
+        ) : (
+          // Why: a closed <select> only paints its selected option, so until the
+          // user reaches for the list one entry renders the same visible label.
+          <option value={language}>{getCodeBlockLanguageLabel(language)}</option>
+        )}
         {/* If the document has a language not in our list, show it as-is */}
-        {language && !LANGUAGES.some((l) => l.value === language) ? (
+        {languageListMounted && language && !isKnownCodeBlockLanguage(language) ? (
           <option value={language}>{language}</option>
         ) : null}
       </select>

--- a/src/renderer/src/components/editor/position-stable-node-view-update.test.ts
+++ b/src/renderer/src/components/editor/position-stable-node-view-update.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import { positionStableNodeViewUpdate } from './position-stable-node-view-update'
+
+type UpdateArgs = Parameters<typeof positionStableNodeViewUpdate>[0]
+
+function updateArgs(overrides: Partial<UpdateArgs> = {}): UpdateArgs {
+  const node = { type: 'codeBlock' }
+  const decorations = [] as unknown as UpdateArgs['newDecorations']
+  const innerDecorations = { inner: true } as unknown as UpdateArgs['innerDecorations']
+  return {
+    oldNode: node,
+    newNode: node,
+    oldDecorations: decorations,
+    newDecorations: decorations,
+    oldInnerDecorations: innerDecorations,
+    innerDecorations,
+    updateProps: vi.fn(),
+    ...overrides
+  } as UpdateArgs
+}
+
+describe('positionStableNodeViewUpdate', () => {
+  it('skips the re-render when only the document position moved', () => {
+    const args = updateArgs()
+
+    expect(positionStableNodeViewUpdate(args)).toBe(true)
+    expect(args.updateProps).not.toHaveBeenCalled()
+  })
+
+  it('re-renders when the node itself changed', () => {
+    const args = updateArgs({ newNode: { type: 'codeBlock' } as unknown as UpdateArgs['newNode'] })
+
+    expect(positionStableNodeViewUpdate(args)).toBe(true)
+    expect(args.updateProps).toHaveBeenCalledOnce()
+  })
+
+  it('re-renders when decorations changed', () => {
+    // Why: search highlights and review annotations arrive as decorations — dropping
+    // those updates would leave a code block visually stale.
+    const args = updateArgs({ newDecorations: [] as unknown as UpdateArgs['newDecorations'] })
+
+    expect(positionStableNodeViewUpdate(args)).toBe(true)
+    expect(args.updateProps).toHaveBeenCalledOnce()
+  })
+
+  it('re-renders when inner decorations changed', () => {
+    const args = updateArgs({
+      innerDecorations: { inner: false } as unknown as UpdateArgs['innerDecorations']
+    })
+
+    expect(positionStableNodeViewUpdate(args)).toBe(true)
+    expect(args.updateProps).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/editor/position-stable-node-view-update.ts
+++ b/src/renderer/src/components/editor/position-stable-node-view-update.ts
@@ -1,0 +1,39 @@
+import type { ReactNodeViewRendererOptions } from '@tiptap/react'
+
+type NodeViewUpdate = NonNullable<ReactNodeViewRendererOptions['update']>
+
+/**
+ * Tiptap re-renders a React node view whenever its document position changes,
+ * even when the node and its decorations are untouched (`@tiptap/react` 3.22.5,
+ * ReactNodeView.update). Typing anywhere shifts the position of every node after
+ * the caret, so one keystroke in a document with N node views costs N React
+ * renders — the dominant per-keystroke cost in large Markdown files.
+ *
+ * That re-render only exists so a component can observe a fresh `getPos()`.
+ * Node views that never read `getPos` can skip it. Position bookkeeping still
+ * happens in Tiptap before this runs, so `getPos()` stays correct for callers
+ * that invoke it later (it is passed as a live function, not a captured value).
+ *
+ * Only use this for components that do not read `getPos` during render.
+ */
+export const positionStableNodeViewUpdate: NodeViewUpdate = ({
+  oldNode,
+  oldDecorations,
+  oldInnerDecorations,
+  newNode,
+  newDecorations,
+  innerDecorations,
+  updateProps
+}) => {
+  if (
+    oldNode === newNode &&
+    oldDecorations === newDecorations &&
+    oldInnerDecorations === innerDecorations
+  ) {
+    // Why: nothing this component renders from has changed — only its position.
+    return true
+  }
+
+  updateProps()
+  return true
+}

--- a/src/renderer/src/components/editor/rich-markdown-code-block-languages.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-code-block-languages.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getCodeBlockLanguageLabel,
+  getCodeBlockLanguages,
+  isKnownCodeBlockLanguage
+} from './rich-markdown-code-block-languages'
+
+describe('rich markdown code block languages', () => {
+  it('caches the resolved list so repeated renders skip i18next lookups', () => {
+    expect(getCodeBlockLanguages()).toBe(getCodeBlockLanguages())
+  })
+
+  it('exposes a plain-text entry for unset fences and never blank labels', () => {
+    const languages = getCodeBlockLanguages()
+
+    expect(languages.some((language) => language.value === '')).toBe(true)
+    expect(languages.every((language) => language.label.length > 0)).toBe(true)
+  })
+
+  it('labels known languages and passes unknown fences through verbatim', () => {
+    expect(getCodeBlockLanguageLabel('')).toBe('Plain text')
+    expect(getCodeBlockLanguageLabel('rust')).toBe('Rust')
+    expect(getCodeBlockLanguageLabel('c')).toBe('C')
+    // Why: a fence may name any language; the collapsed <select> still has to show it.
+    expect(getCodeBlockLanguageLabel('brainfuck')).toBe('brainfuck')
+  })
+
+  it('reports membership for the unknown-language fallback option', () => {
+    expect(isKnownCodeBlockLanguage('rust')).toBe(true)
+    expect(isKnownCodeBlockLanguage('brainfuck')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-code-block-languages.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-code-block-languages.test.ts
@@ -1,13 +1,46 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { i18n, setRendererPluginLanguagePacks } from '@/i18n/i18n'
+import { pluginLanguageResourceId } from '../../../../shared/plugins/plugin-language-pack-artifact'
 import {
   getCodeBlockLanguageLabel,
   getCodeBlockLanguages,
   isKnownCodeBlockLanguage
 } from './rich-markdown-code-block-languages'
 
+afterEach(async () => {
+  setRendererPluginLanguagePacks([])
+  await i18n.changeLanguage('en')
+})
+
 describe('rich markdown code block languages', () => {
   it('caches the resolved list so repeated renders skip i18next lookups', () => {
     expect(getCodeBlockLanguages()).toBe(getCodeBlockLanguages())
+  })
+
+  it('refreshes cached labels when a plugin replaces the active resource bundle', async () => {
+    const id = 'plugin:test.rich-markdown-languages' as const
+    const resourceLanguage = pluginLanguageResourceId(id)
+    const pack = (plainText: string) => ({
+      id,
+      resourceLanguage,
+      pluginKey: 'test.rich-markdown-languages',
+      locale: 'en',
+      catalog: {
+        auto: {
+          components: {
+            editor: { RichMarkdownCodeBlock: { '13822cdfda': plainText } }
+          }
+        }
+      }
+    })
+    setRendererPluginLanguagePacks([pack('Plugin plain text')])
+    await i18n.changeLanguage(resourceLanguage)
+    const firstLanguages = getCodeBlockLanguages()
+
+    setRendererPluginLanguagePacks([pack('Updated plugin plain text')])
+
+    expect(getCodeBlockLanguages()).not.toBe(firstLanguages)
+    expect(getCodeBlockLanguageLabel('')).toBe('Updated plugin plain text')
   })
 
   it('exposes a plain-text entry for unset fences and never blank labels', () => {

--- a/src/renderer/src/components/editor/rich-markdown-code-block-languages.ts
+++ b/src/renderer/src/components/editor/rich-markdown-code-block-languages.ts
@@ -40,13 +40,16 @@ const LANGUAGE_ENTRIES: readonly LanguageEntry[] = [
 ]
 
 let cachedLocale: string | null = null
+let cachedResourceBundle: unknown = null
 let cachedLanguages: CodeBlockLanguage[] = []
 
 /** Why: labels were getters that re-translated on every property read, so one
  *  render of a code-block-heavy document cost thousands of i18next lookups. */
 export function getCodeBlockLanguages(): CodeBlockLanguage[] {
-  if (cachedLocale !== i18n.language) {
+  const resourceBundle = i18n.getResourceBundle(i18n.language, 'translation')
+  if (cachedLocale !== i18n.language || cachedResourceBundle !== resourceBundle) {
     cachedLocale = i18n.language
+    cachedResourceBundle = resourceBundle
     cachedLanguages = LANGUAGE_ENTRIES.map(([value, key, label]) => ({
       value,
       label: key === null ? label : translate(key, label)

--- a/src/renderer/src/components/editor/rich-markdown-code-block-languages.ts
+++ b/src/renderer/src/components/editor/rich-markdown-code-block-languages.ts
@@ -1,0 +1,64 @@
+import { i18n, translate } from '@/i18n/i18n'
+
+export type CodeBlockLanguage = { value: string; label: string }
+
+/**
+ * Common languages shown in the selector. The user can also type a language
+ * name directly in the markdown fence (```rust) and it will be preserved —
+ * this list is just for quick picking in the UI.
+ *
+ * A null key means the label is identical in every locale.
+ */
+type LanguageEntry = readonly [value: string, key: string | null, label: string]
+
+const LANGUAGE_ENTRIES: readonly LanguageEntry[] = [
+  ['', 'auto.components.editor.RichMarkdownCodeBlock.13822cdfda', 'Plain text'],
+  ['bash', 'auto.components.editor.RichMarkdownCodeBlock.4227cf50fe', 'Bash'],
+  ['c', null, 'C'],
+  ['cpp', 'auto.components.editor.RichMarkdownCodeBlock.4daed43ae3', 'C++'],
+  ['css', 'auto.components.editor.RichMarkdownCodeBlock.026653f21f', 'CSS'],
+  ['diff', 'auto.components.editor.RichMarkdownCodeBlock.bf6ee5caaa', 'Diff'],
+  ['go', 'auto.components.editor.RichMarkdownCodeBlock.edfcc64182', 'Go'],
+  ['graphql', 'auto.components.editor.RichMarkdownCodeBlock.706fd85738', 'GraphQL'],
+  ['html', 'auto.components.editor.RichMarkdownCodeBlock.8c4a3fa02d', 'HTML'],
+  ['java', 'auto.components.editor.RichMarkdownCodeBlock.36536ad539', 'Java'],
+  ['javascript', 'auto.components.editor.RichMarkdownCodeBlock.a209c57063', 'JavaScript'],
+  ['json', 'auto.components.editor.RichMarkdownCodeBlock.78eba32de4', 'JSON'],
+  ['kotlin', 'auto.components.editor.RichMarkdownCodeBlock.bcb236e2d8', 'Kotlin'],
+  ['markdown', 'auto.components.editor.RichMarkdownCodeBlock.983b9576b4', 'Markdown'],
+  ['mermaid', 'auto.components.editor.RichMarkdownCodeBlock.89d6cc14fb', 'Mermaid'],
+  ['python', 'auto.components.editor.RichMarkdownCodeBlock.2391f9cda9', 'Python'],
+  ['ruby', 'auto.components.editor.RichMarkdownCodeBlock.96182a2f64', 'Ruby'],
+  ['rust', 'auto.components.editor.RichMarkdownCodeBlock.e72e6b03f4', 'Rust'],
+  ['scss', 'auto.components.editor.RichMarkdownCodeBlock.5af8251002', 'SCSS'],
+  ['shell', 'auto.components.editor.RichMarkdownCodeBlock.d01f55be57', 'Shell'],
+  ['sql', 'auto.components.editor.RichMarkdownCodeBlock.3009f722b9', 'SQL'],
+  ['swift', 'auto.components.editor.RichMarkdownCodeBlock.9e384d48dc', 'Swift'],
+  ['typescript', 'auto.components.editor.RichMarkdownCodeBlock.88d777bc07', 'TypeScript'],
+  ['xml', 'auto.components.editor.RichMarkdownCodeBlock.5ef5605cb7', 'XML'],
+  ['yaml', 'auto.components.editor.RichMarkdownCodeBlock.74eab1d9b2', 'YAML']
+]
+
+let cachedLocale: string | null = null
+let cachedLanguages: CodeBlockLanguage[] = []
+
+/** Why: labels were getters that re-translated on every property read, so one
+ *  render of a code-block-heavy document cost thousands of i18next lookups. */
+export function getCodeBlockLanguages(): CodeBlockLanguage[] {
+  if (cachedLocale !== i18n.language) {
+    cachedLocale = i18n.language
+    cachedLanguages = LANGUAGE_ENTRIES.map(([value, key, label]) => ({
+      value,
+      label: key === null ? label : translate(key, label)
+    }))
+  }
+  return cachedLanguages
+}
+
+export function getCodeBlockLanguageLabel(value: string): string {
+  return getCodeBlockLanguages().find((language) => language.value === value)?.label ?? value
+}
+
+export function isKnownCodeBlockLanguage(value: string): boolean {
+  return getCodeBlockLanguages().some((language) => language.value === value)
+}

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -27,6 +27,7 @@ import {
 import { createMarkdownDocLink } from './rich-markdown-doc-link'
 import { RichMarkdownCodeBlock } from './RichMarkdownCodeBlock'
 import { safeReactNodeViewRenderer } from './safe-react-node-view-renderer'
+import { positionStableNodeViewUpdate } from './position-stable-node-view-update'
 import { DragSelectionGuard } from './drag-selection-guard'
 import { createRichMarkdownAnnotationHighlightExtension } from './rich-markdown-annotation-highlight'
 import type { RichMarkdownEditorCodec } from './rich-markdown-source-transport'
@@ -74,7 +75,11 @@ export function createRichMarkdownExtensions({
     RichMarkdownCode,
     CodeBlockLowlight.extend({
       addNodeView() {
-        return safeReactNodeViewRenderer(RichMarkdownCodeBlock)
+        // Why: RichMarkdownCodeBlock never reads getPos, so it must not re-render
+        // just because earlier edits shifted this block's document position.
+        return safeReactNodeViewRenderer(RichMarkdownCodeBlock, {
+          update: positionStableNodeViewUpdate
+        })
       }
     }).configure({
       lowlight,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -83,13 +83,15 @@ export const getDefaultTerminalRightClickToPaste = (
   platform = typeof process !== 'undefined' ? process.platform : ''
 ): boolean => platform === 'win32'
 
-/** Why: ProseMirror renders the whole document — no virtualization — so cost is
- *  linear in file size and every keystroke re-runs it. Measured in a packaged
- *  build (M-series, `out/`), typing latency and the blocking mount on open:
- *  100 KB 17 ms / 0 ms · 200 KB 46 ms / 0 ms · 300 KB 84 ms / 1.4 s ·
- *  600 KB 265 ms / 4.2 s. 300 KB is already the knee, so this is a ceiling to
- *  hold rather than raise; past it, fall back to source mode (Monaco) with a
- *  per-file "Open anyway" escape hatch. Real headroom needs #7056. */
+/** Why: ProseMirror renders the whole document — no virtualization — so opening
+ *  one blocks the main thread for as long as it takes to build the DOM. Measured
+ *  in a packaged build (M-series) on a doc with a code block every ~570 bytes,
+ *  blocking mount / median keystroke: 300 KB 1.7 s / 59 ms · 600 KB 4.2 s / 201 ms
+ *  · 900 KB 8.8 s / 431 ms. The same 300 KB as pure prose is 0.8 s / 16 ms, so
+ *  node-view count drives the cost far more than byte size — but bytes are the
+ *  only thing cheap enough to test before parsing. The blocking mount is what
+ *  pins this ceiling; past it, fall back to source mode (Monaco) with a per-file
+ *  "Open anyway" escape hatch. Real headroom needs #7056. */
 export const RICH_MARKDOWN_MAX_SIZE_BYTES = 300 * 1024
 
 export const DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS = 1000


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​157 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​168 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 |

<!-- /orca-pr-loc -->

Follow-up to #16971, which asked whether the rich Markdown editor's perf could actually be improved rather than just fenced off by the size limit.

Profiling a 305 KB document in a **packaged build** showed that typing was dominated by two things that have nothing to do with the text being typed.

## 1. Every code block re-rendered on every keystroke

Tiptap re-renders a React node view whenever its document **position** changes, even when the node and its decorations are untouched (`@tiptap/react` 3.22.5, `ReactNodeView.update`):

```js
if (node === this.node && this.decorations === decorations && this.innerDecorations === innerDecorations) {
  if (newPos === this.currentPos) return true
  this.currentPos = newPos
  rerenderComponent({ ... })   // <- position moved, so re-render anyway
  return true
}
```

Typing anywhere shifts the position of every node after the caret. In a document with 533 code blocks, **one keystroke cost 533 React renders** of untouched blocks. That was 25% of the profile (`setRenderer`), the single largest entry.

That re-render exists only so a component can observe a fresh `getPos()`. `RichMarkdownCodeBlock` — the only React node view in the editor — never reads it, so it now opts out through an explicit `update`. Position bookkeeping still happens in Tiptap *before* `update` runs, and `getPos` is handed to components as a live function rather than a captured value, so it stays correct for anything that calls it later. Decoration changes (search highlights, review annotations) still re-render normally; that's covered by a test, since silently dropping those would leave a block visually stale.

## 2. ~25 `<option>` elements per code block, for a dropdown nobody opened

The language `<select>` eagerly mounted the full language list in every code block: **13,858 `<option>` elements**, over a quarter of that document's DOM. The list now mounts on first interaction (`mousedown`/`focus`, flushed synchronously so the native popup never paints a stale list); until then one option renders the same visible label a closed `<select>` would show.

The labels were also getters that re-translated on **every property read**, so a single render cost thousands of i18next lookups (~15% of the profile across `translate`/`extractFromKey`/`extendTranslation`). They're now resolved once per locale.

## Result

Median keystroke latency of 15 keystrokes, 3 repeats, packaged build, M-series:

| document | before | after |
| --- | --- | --- |
| 305 KB | 84 ms | **59 ms** |
| 600 KB | 265 ms | **201 ms** |

DOM nodes for the 305 KB document: 45,841 → 32,516.

## This does not move the size limit

The blocking mount on open (1.7 s at 300 KB) is what actually pins the 300 KB ceiling, and it is unchanged. The constant's comment is updated with the measured numbers — including the more useful finding that **node-view count drives cost far more than byte size**: the same 305 KB as pure prose is 16 ms/keystroke and 0.8 s mount, versus 59 ms / 1.7 s with a code block every ~570 bytes. Bytes remain the limit's input only because they're the one thing cheap enough to measure before parsing.

## Verified against regressions

Exercised in the running packaged app, not just unit tests:

- dropdown expands to the full list by **mouse** (`mousedown`) and by **keyboard** (`focus`)
- an unknown fence (` ```brainfuck `) keeps its verbatim label when collapsed and still gets its fallback option when expanded
- changing the language still applies to the node and persists in the select
- typing **inside** a code block still updates, with syntax-highlight spans intact
- `pnpm tc` clean; 11,421 tests pass; changed-code quality gate reports 0 new findings

New unit tests cover the `update` predicate (skips on position-only change, re-renders on node/decoration/inner-decoration change) and the language catalogue (per-locale caching, known/unknown label resolution).

## Visual proof

Collapsed state: all 12 code blocks keep the selector compact and mount only the selected option before interaction.

![Rich Markdown editor with compact collapsed language selectors](https://github.com/user-attachments/assets/cba17bba-1ace-4002-a8b3-c54e3249c1d6)

Interacted state: the real native selector expands to the full language list; the code-block copy action is also visibly exercised.

![Rich Markdown editor with expanded language selector and copy interaction](https://github.com/user-attachments/assets/32fa4b4d-1d70-40da-9fc7-a7ebc12b73a8)