### PR TITLE
fix(terminal): stop park-verdict oscillation remounting a pane at commit cadence (#15136)

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
@@ -7,6 +7,7 @@ import {
   TERMINAL_TAB_PARK_FLIP_WINDOW_MS,
   getParkVerdictUnparkPinUntilMs,
   recordParkVerdictFlips,
+  selectParkVerdictPinnedTabIds,
   type ParkVerdictFlipRecord
 } from './terminal-park-verdict-flip-telemetry'
 
@@ -335,5 +336,29 @@ describe('expired pins stop gating breadcrumbs', () => {
       'terminal_park_verdict_churn',
       expect.objectContaining({ trigger: 'window' })
     )
+  })
+
+  // Why: the pin is set from flips on the rendered verdict, so it has to be
+  // readable — and expirable — for any live tab, not only cold-park candidates
+  // (issue #15136: the driver was the worktree-level park prop).
+  it('selects and expires pins for tabs the cold-park selector never proposed', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    for (let i = 0; i < 40; i += 1) {
+      observe({ records, parked: i % 2 === 0, nowMs: 1_000 + i * 10 })
+    }
+
+    const pinned = selectParkVerdictPinnedTabIds({ records, tabIds: [TAB], nowMs: 1_500 })
+    expect(pinned.pinnedTabIds).toEqual(new Set([TAB]))
+    expect(pinned.earliestPinExpiryMs).toBe(records.get(TAB)?.pinnedUntilMs)
+
+    // Past the deadline the pin lapses in place, so damping never latches on.
+    const lapsed = selectParkVerdictPinnedTabIds({
+      records,
+      tabIds: [TAB],
+      nowMs: 1_000 + TERMINAL_TAB_PARK_FLIP_WINDOW_MS * 3
+    })
+    expect(lapsed.pinnedTabIds.size).toBe(0)
+    expect(lapsed.earliestPinExpiryMs).toBeNull()
+    expect(records.get(TAB)?.pinnedUntilMs).toBeNull()
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
@@ -3,11 +3,12 @@
  * Field breadcrumbs prove render-cadence flips, but not which eligibility input
  * oscillates; burst damping keeps the pane mounted before React reaches #185.
  *
- * Scope: flips are counted on the rendered verdict, but the pin can only
- * subtract from the cold-park candidate set. Churn driven by the other parked
- * inputs (forced parking, portal ownership, deferred activation mounts) is
- * observed and breadcrumbed, not damped — read a repeating `burst` crumb for
- * one tab as "damping did not reach the oscillating input".
+ * Scope: flips are counted on the rendered verdict and the pin subtracts from
+ * that same verdict (selectParkVerdictPinnedTabIds), so churn driven by any
+ * parked input — worktree-level park, portal ownership, deferred activation
+ * mounts — is damped, not only the cold-park candidate set. A repeating `burst`
+ * crumb for one tab therefore means the driver keeps re-proposing the park once
+ * each pin lapses, not that damping never reached it.
  */
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import { REACT_NESTED_UPDATE_LIMIT } from '../../../../shared/react-update-depth-attribution'
@@ -168,4 +169,42 @@ export function recordParkVerdictFlips(args: {
       })
     }
   }
+}
+
+export type ParkVerdictPinSelection = {
+  pinnedTabIds: Set<string>
+  /** Earliest live pin deadline, so a caller can wake exactly when damping lapses. */
+  earliestPinExpiryMs: number | null
+}
+
+/**
+ * Tab ids a flip burst pinned unparked, expiring lapsed pins in place.
+ *
+ * Why every live tab and not only cold-park candidates: flips are counted on
+ * the rendered verdict, so the oscillating input can be one the cold-park
+ * selector never sees (worktree-level park, activation-deferred mounts). A pin
+ * consulted only through the cold set then damps nothing and never lapses —
+ * it just silences its own breadcrumb for the window and re-arms forever.
+ */
+export function selectParkVerdictPinnedTabIds(args: {
+  records: Map<string, ParkVerdictFlipRecord>
+  tabIds: Iterable<string>
+  nowMs: number
+}): ParkVerdictPinSelection {
+  const pinnedTabIds = new Set<string>()
+  let earliestPinExpiryMs: number | null = null
+  for (const tabId of args.tabIds) {
+    const pinnedUntilMs = getParkVerdictUnparkPinUntilMs({
+      records: args.records,
+      tabId,
+      nowMs: args.nowMs
+    })
+    if (pinnedUntilMs === null) {
+      continue
+    }
+    pinnedTabIds.add(tabId)
+    earliestPinExpiryMs =
+      earliestPinExpiryMs === null ? pinnedUntilMs : Math.min(earliestPinExpiryMs, pinnedUntilMs)
+  }
+  return { pinnedTabIds, earliestPinExpiryMs }
 }

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-worktree-driver-loop.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-worktree-driver-loop.test.tsx
@@ -1,0 +1,197 @@
+/** @vitest-environment happy-dom */
+/**
+ * Park-verdict oscillation driven by an input the cold-park selector never sees.
+ *
+ * Why this shape (issue #15136): Terminal.tsx vetoes a WORKTREE park with
+ * worktreeTabsAreWatcherCovered → canWatcherCoverParkedTerminalTab, which a
+ * mounted pane grants and a parked pane withdraws. That verdict arrives here as
+ * the coldParkTerminalPanes prop, which short-circuits the cold-park branch of
+ * the rendered verdict — so withholdUnparkableTerminalTabs, which only filters
+ * the cold-park candidate list, can never damp it.
+ *
+ * The single tab is deliberate: selectIdsBeyondHotRetain spares the lone
+ * most-recently-hidden candidate, so the cold-park set stays empty and
+ * coldParkTerminalPanes is provably the only driver of the rendered verdict.
+ *
+ * Field signature this reproduces: one tab, `trigger: burst` crumbs recurring
+ * 60 008 / 60 020 / 60 012 ms apart (the pin window), i.e. flips continuing at
+ * commit cadence underneath a live pin instead of stopping.
+ */
+import { act, useEffect, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const park = vi.hoisted(() => ({ worktreeId: 'repo::/wt-worktree-driver' }))
+
+vi.mock('../../store', async () => {
+  const { create } = await import('zustand')
+  const useAppStore = create(() => ({
+    pendingStartupByTabId: {} as Record<string, unknown>,
+    ptyIdsByTabId: {} as Record<string, string[]>,
+    runtimeStatusByEnvironmentId: new Map<string, unknown>(),
+    settings: {} as Record<string, unknown>,
+    terminalLayoutsByTabId: {} as Record<string, unknown>,
+    runtimePaneTitlesByTabId: {} as Record<string, unknown>,
+    tabsByWorktree: {} as Record<string, TerminalTab[]>
+  }))
+  return { useAppStore }
+})
+
+vi.mock('./terminal-parked-tab-watchers', () => ({
+  canWatcherCoverParkedTerminalTab: () => true,
+  disposeParkedTerminalWatchersForWorktree: () => {},
+  resolveParkedTerminalPaneCandidates: () => [],
+  syncParkedTerminalTabWatchers: () => {}
+}))
+
+vi.mock('./terminal-parking-e2e-overrides', () => ({
+  getTerminalParkingPolicyOverrides: () => ({ coldParkDelayMs: 0, hotRetainMs: 0 })
+}))
+
+import { useAppStore } from '../../store'
+import { TERMINAL_TAB_PARK_FLIP_BURST_LIMIT } from './terminal-park-verdict-flip-telemetry'
+import { useTerminalTabColdParking } from './use-terminal-tab-cold-parking'
+
+const TAB_ID = 'tab-worktree-driven'
+/** Stops an unfixed loop from hanging the run if React ever raises its bail. */
+const RENDER_HARD_STOP = 400
+/** +1: the pin lands in the passive effect observing the burst flip. */
+const SETTLED_FLIP_BUDGET = TERMINAL_TAB_PARK_FLIP_BURST_LIMIT + 1
+const EMPTY_ASSIGNMENTS = new Map<string, { groupId: string; isActiveInGroup: boolean }>()
+const EMPTY_PORTALS: never[] = []
+
+type ParkingStoreState = { tabsByWorktree: Record<string, TerminalTab[]> }
+
+const parkingStore = useAppStore as unknown as {
+  setState: (partial: (state: ParkingStoreState) => Partial<ParkingStoreState>) => void
+}
+
+let hostRenderCount = 0
+let parkVerdictFlipCount = 0
+let lastParkVerdict = false
+let paneMountCount = 0
+
+/** The pane whose mount/unmount the park verdict authorizes. */
+function TerminalPaneStandIn(): null {
+  useEffect(() => {
+    paneMountCount += 1
+  }, [])
+  return null
+}
+
+/**
+ * Terminal.tsx's worktree-level verdict, modelled: a mounted pane grants the
+ * byte-watcher coverage the worktree park requires, and a parked pane withdraws
+ * it. Runs in a passive effect, so each turn of the loop costs one commit.
+ */
+function WorktreeParkVerdict({
+  parked,
+  onVerdict
+}: {
+  parked: boolean
+  onVerdict: (coldParkTerminalPanes: boolean) => void
+}): null {
+  useEffect(() => {
+    onVerdict(!parked)
+  }, [parked, onVerdict])
+  return null
+}
+
+function OverlayHost(): React.JSX.Element | null {
+  hostRenderCount += 1
+  const [coldParkTerminalPanes, setColdParkTerminalPanes] = useState(false)
+  const terminalTabs = useAppStore(
+    (state) => (state as ParkingStoreState).tabsByWorktree[park.worktreeId]
+  ) as TerminalTab[]
+  const parkedTerminalTabIds = useTerminalTabColdParking({
+    worktreeId: park.worktreeId,
+    terminalTabs,
+    assignments: EMPTY_ASSIGNMENTS,
+    isWorktreeActive: false,
+    activeTerminalTabId: null,
+    coldParkTerminalPanes,
+    shouldMeasureHiddenWorktree: false,
+    activityTerminalPortals: EMPTY_PORTALS,
+    activationDeferredMountTabIds: null
+  })
+  const parked = parkedTerminalTabIds.has(TAB_ID)
+  if (parked !== lastParkVerdict) {
+    parkVerdictFlipCount += 1
+  }
+  lastParkVerdict = parked
+  if (hostRenderCount > RENDER_HARD_STOP) {
+    return null
+  }
+  return (
+    <>
+      {parked ? null : <TerminalPaneStandIn />}
+      <WorktreeParkVerdict parked={parked} onVerdict={setColdParkTerminalPanes} />
+    </>
+  )
+}
+
+function renderOverlayHost(root: Root): unknown {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  let thrown: unknown = null
+  try {
+    act(() => {
+      root.render(<OverlayHost />)
+    })
+  } catch (error) {
+    thrown = error
+  }
+  consoleError.mockRestore()
+  return thrown
+}
+
+describe('park-verdict damping reaches the worktree-level driver', () => {
+  let container: HTMLDivElement
+  let root: Root | undefined
+
+  beforeEach(() => {
+    hostRenderCount = 0
+    parkVerdictFlipCount = 0
+    lastParkVerdict = false
+    paneMountCount = 0
+    parkingStore.setState(() => ({
+      tabsByWorktree: {
+        [park.worktreeId]: [
+          { id: TAB_ID, ptyId: `${park.worktreeId}@@session-1`, title: TAB_ID } as TerminalTab
+        ]
+      }
+    }))
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount()
+    })
+    root = undefined
+    container.remove()
+  })
+
+  it('settles a verdict whose only driver is the worktree-level park prop', () => {
+    root = createRoot(container)
+    const thrown = renderOverlayHost(root)
+
+    expect(thrown).toBeNull()
+    // Without damping on the rendered verdict this runs to RENDER_HARD_STOP:
+    // the burst pin only subtracts from the cold-park candidate set, which is
+    // empty here, so it silences its breadcrumb and damps nothing.
+    expect(parkVerdictFlipCount).toBeLessThanOrEqual(SETTLED_FLIP_BUDGET)
+    // Settles on the safe side: the pane stays mounted, so bells/titles/
+    // completions never go silent behind a wedged verdict.
+    expect(lastParkVerdict).toBe(false)
+    // Measured: 4 flips / 3 mounts / 6 renders with damping, against
+    // 400 flips / 200 mounts before it — the pre-fix run only stops because
+    // RENDER_HARD_STOP stops it.
+    expect(paneMountCount).toBeGreaterThan(0)
+    expect(paneMountCount).toBeLessThanOrEqual(SETTLED_FLIP_BUDGET)
+    expect(hostRenderCount).toBeLessThan(RENDER_HARD_STOP)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-terminal-park-verdict-pin.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-park-verdict-pin.ts
@@ -1,0 +1,131 @@
+/**
+ * Applies verdict-flip damping to the *rendered* park verdict.
+ *
+ * Why here and not inside the cold-park selector: every park input feeds one
+ * rendered set, and several of them (worktree-level park, activation-deferred
+ * mounts) bypass the cold-park candidate list entirely. Damping only that list
+ * left those drivers free to remount a pane at commit cadence while the burst
+ * pin silenced its own breadcrumb for the window — issue #15136, where one tab
+ * re-burst 60 008 / 60 020 / 60 012 ms apart, i.e. the instant each pin lapsed.
+ *
+ * The pin lags the verdict by one commit (it is set from the passive effect
+ * that observes the flip), which is what lets the loop settle instead of
+ * feeding itself: pinned tabs render unparked, so the next observation records
+ * no flip.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import {
+  recordParkVerdictFlips,
+  selectParkVerdictPinnedTabIds,
+  type ParkVerdictFlipRecord
+} from './terminal-park-verdict-flip-telemetry'
+
+const EMPTY_TAB_IDS: ReadonlySet<string> = new Set()
+
+export function haveSameTerminalTabIds(
+  left: ReadonlySet<string>,
+  right: ReadonlySet<string>
+): boolean {
+  if (left.size !== right.size) {
+    return false
+  }
+  for (const id of left) {
+    if (!right.has(id)) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Returns the park verdict with flip-pinned tabs removed, and records churn on
+ * that same (rendered) verdict.
+ */
+export function useTerminalParkVerdictPin(args: {
+  records: React.RefObject<Map<string, ParkVerdictFlipRecord>>
+  terminalTabs: readonly TerminalTab[]
+  /** Park verdict before damping — every input already merged. */
+  candidateParkedTabIds: ReadonlySet<string>
+}): ReadonlySet<string> {
+  const { records, terminalTabs, candidateParkedTabIds } = args
+  const [pinnedTabIds, setPinnedTabIds] = useState<ReadonlySet<string>>(EMPTY_TAB_IDS)
+  const pinnedTabIdsRef = useRef(pinnedTabIds)
+  // Why a revision and not a raw timer callback: the pin lapse must re-run the
+  // observation effect, which is also what expires the record in place.
+  const [pinExpiryRevision, setPinExpiryRevision] = useState(0)
+  // Why armed-deadline bookkeeping: this effect re-runs on every tab-model
+  // write (runtime titles, unread bumps), which on a busy agent pane is many
+  // times a second. Re-arming an unchanged absolute deadline each time is pure
+  // churn — keep the live timer instead.
+  const armedPinExpiryRef = useRef<{ deadlineMs: number; timer: number } | null>(null)
+
+  const parkedTabIds = useMemo(() => {
+    if (pinnedTabIds.size === 0) {
+      return candidateParkedTabIds
+    }
+    const parked = new Set<string>()
+    for (const tabId of candidateParkedTabIds) {
+      if (!pinnedTabIds.has(tabId)) {
+        parked.add(tabId)
+      }
+    }
+    return parked
+  }, [candidateParkedTabIds, pinnedTabIds])
+
+  useEffect(() => {
+    const flipRecords = records.current
+    const liveTabIds = new Set(terminalTabs.map((terminalTab) => terminalTab.id))
+    const nowMs = Date.now()
+    recordParkVerdictFlips({
+      records: flipRecords,
+      liveTabIds,
+      nextParkedTabIds: parkedTabIds,
+      nowMs
+    })
+    const { pinnedTabIds: nextPinnedTabIds, earliestPinExpiryMs } = selectParkVerdictPinnedTabIds({
+      records: flipRecords,
+      tabIds: liveTabIds,
+      nowMs
+    })
+    if (!haveSameTerminalTabIds(pinnedTabIdsRef.current, nextPinnedTabIds)) {
+      pinnedTabIdsRef.current = nextPinnedTabIds
+      setPinnedTabIds(nextPinnedTabIds)
+    }
+    const armed = armedPinExpiryRef.current
+    if (earliestPinExpiryMs === null) {
+      if (armed) {
+        window.clearTimeout(armed.timer)
+        armedPinExpiryRef.current = null
+      }
+      return
+    }
+    if (armed?.deadlineMs === earliestPinExpiryMs) {
+      return
+    }
+    if (armed) {
+      window.clearTimeout(armed.timer)
+    }
+    armedPinExpiryRef.current = {
+      deadlineMs: earliestPinExpiryMs,
+      timer: window.setTimeout(
+        () => setPinExpiryRevision((revision) => revision + 1),
+        Math.max(1, earliestPinExpiryMs - nowMs)
+      )
+    }
+  }, [parkedTabIds, pinExpiryRevision, records, terminalTabs])
+
+  // Why separate from the observation effect: that effect intentionally keeps a
+  // live timer across its own re-runs, so its cleanup cannot own disposal.
+  useEffect(() => {
+    const armedPinExpiry = armedPinExpiryRef
+    return () => {
+      if (armedPinExpiry.current) {
+        window.clearTimeout(armedPinExpiry.current.timer)
+        armedPinExpiry.current = null
+      }
+    }
+  }, [])
+
+  return parkedTabIds
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
@@ -75,6 +75,7 @@ import {
 } from './terminal-hidden-view-parking'
 import {
   TERMINAL_TAB_PARK_FLIP_BURST_LIMIT,
+  TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS,
   TERMINAL_TAB_PARK_FLIP_WINDOW_MS
 } from './terminal-park-verdict-flip-telemetry'
 import { useTerminalTabColdParking } from './use-terminal-tab-cold-parking'
@@ -459,6 +460,10 @@ describe('useTerminalTabColdParking measure-clock contract', () => {
       }
     }
     act(() => {
+      // Why the clock advance: the verdict-flip burst limit is expressed per
+      // second, and fake timers freeze Date.now(), so back-to-back rerenders
+      // would read as an oscillation the damping is supposed to pin.
+      vi.advanceTimersByTime(TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS)
       rerender(hookArgs(false))
     })
     expect(result.current.size).toBe(0)
@@ -472,6 +477,7 @@ describe('useTerminalTabColdParking measure-clock contract', () => {
       }
     }
     act(() => {
+      vi.advanceTimersByTime(TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS)
       rerender(hookArgs(false))
     })
     expect(result.current).toEqual(new Set(['tab-2']))

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -20,10 +20,11 @@ import {
   selectPairedRuntimeParkingEnvironmentIdsFromState,
   selectColdParkedTerminalTabs
 } from './terminal-hidden-view-parking'
+import type { ParkVerdictFlipRecord } from './terminal-park-verdict-flip-telemetry'
 import {
-  recordParkVerdictFlips,
-  type ParkVerdictFlipRecord
-} from './terminal-park-verdict-flip-telemetry'
+  haveSameTerminalTabIds,
+  useTerminalParkVerdictPin
+} from './use-terminal-park-verdict-pin'
 import { withholdUnparkableTerminalTabs } from './terminal-cold-park-withheld-tabs'
 import { getTerminalParkingPolicyOverrides } from './terminal-parking-e2e-overrides'
 import {
@@ -47,18 +48,6 @@ type TerminalOverlayTabAssignment = {
 }
 
 const EMPTY_TAB_IDS: ReadonlySet<string> = new Set()
-
-function haveSameTerminalTabIds(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
-  if (left.size !== right.size) {
-    return false
-  }
-  for (const id of left) {
-    if (!right.has(id)) {
-      return false
-    }
-  }
-  return true
-}
 
 export function useTerminalTabColdParking(args: {
   worktreeId: string
@@ -296,11 +285,11 @@ export function useTerminalTabColdParking(args: {
     [evictionExemptLayoutKey, isForceParked, terminalTabs, worktreeId]
   )
 
-  // Why: the rendered park verdict — worktree-level park (prop from
+  // Why: the park verdict before damping — worktree-level park (prop from
   // Terminal.tsx) or per-tab cold park, never portal-hosted tabs. Render and
-  // the watcher-sync effect must share this exact set so watcher lifecycle
-  // tracks the committed unmounts.
-  const parkedTerminalTabIds = useMemo(() => {
+  // the watcher-sync effect must share the pinned result below so watcher
+  // lifecycle tracks the committed unmounts.
+  const candidateParkedTerminalTabIds = useMemo(() => {
     const parked = new Set<string>()
     for (const terminalTab of terminalTabs) {
       const assignment = assignments.get(terminalTab.id)
@@ -357,19 +346,15 @@ export function useTerminalTabColdParking(args: {
     worktreeId
   ])
 
-  // Why: observation only — records whether the *rendered* park verdict churns,
-  // so a crash bundle can confirm or refute a park-flip update loop. Watching
-  // the pre-gate cold set instead would miss loops driven by coldParkTerminalPanes
-  // or the portal/measuring gates. Changes no verdict; see
-  // terminal-park-verdict-flip-telemetry.ts.
-  useEffect(() => {
-    recordParkVerdictFlips({
-      records: parkVerdictRecordsRef.current,
-      liveTabIds: new Set(terminalTabs.map((terminalTab) => terminalTab.id)),
-      nextParkedTabIds: parkedTerminalTabIds,
-      nowMs: Date.now()
-    })
-  }, [parkedTerminalTabIds, terminalTabs])
+  // Why the last gate: flips are counted on the *rendered* verdict, so damping
+  // has to subtract from that same set — coldParkTerminalPanes and the
+  // activation-deferred branch never pass through the cold-park candidate list
+  // withholdUnparkableTerminalTabs filters (issue #15136).
+  const parkedTerminalTabIds = useTerminalParkVerdictPin({
+    records: parkVerdictRecordsRef,
+    terminalTabs,
+    candidateParkedTabIds: candidateParkedTerminalTabIds
+  })
 
   // Why: runs in the same effect flush as the commit that parked/revealed the
   // panes — watcher disposal therefore lands before any PTY data IPC can


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​192 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​37 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 |

<!-- /orca-pr-loc -->

Fixes the CPU/heat half of #15136.

### ELI5

Orca can put a terminal "to sleep" (park) when you can't see it, and wake it up when you look at it. Waking up is expensive — it rebuilds the terminal from scratch.

The rule for "is it safe to sleep?" is: *can the background watchers still hear this terminal while its screen is gone?* But the honest answer to that question changes depending on whether the screen is there right now. So: screen is up → "yes, safe to sleep" → screen goes away → "no, not safe" → screen comes back → "yes, safe" → … The terminal ends up flickering between asleep and awake dozens of times a second, and each flicker pays the full wake-up cost. That's the fan.

Someone already noticed this and added a brake: if a terminal flips 3 times in a second, hold it awake for 60 seconds. The brake was wired to only one of the several things that can order a terminal to sleep. When any of the *other* things was the one flapping, the brake pressed on nothing — but it still turned off the warning light for 60 seconds. So the terminal kept thrashing all session, silently, and the counter in the log ticked once a minute forever.

This PR wires the brake to the final answer instead of one input, so it actually stops the wheel it is supposed to stop.

---

### Counters, before and after

The reporter's session (issue body):

| Counter | Count |
| --- | --- |
| `terminal_replay_guard_wedged_release` | 2125 (all one pane) |
| `terminal_webgl_diagnostic` / `webgl-atlas-reset` | 950 (`visibility-resume`, `settled-reveal`, `tab-reveal`) |
| `terminal_park_verdict_churn` | 39 |

I reproduced the same signature in a local `main.trace.ndjson` (25 h session, ~10 mounted pane managers). **The hypothesis in the issue thread holds.** Evidence:

```
terminal_park_verdict_churn  x10 — every one for the SAME tabId
  web-terminal-65bee935-64b8-416a-92fe-c3b413801333
  trigger=burst  flips=3..6  elapsedMs=75..153  windowMs=1000  pinnedForMs=60000
```

Two things fall straight out of that:

1. **3–6 flips in 75–153 ms = 20–45 park/reveal flips per second on one pane** — the reporter's "3–11 times within one second", worse.
2. **The bursts recur at 60 008 / 60 020 / 60 012 ms spacing.** That is exactly `pinnedForMs`. The pin engages, goes quiet, expires, and the very next flip (8–31 ms later) re-bursts. `flips: 6` crumbs prove flips kept accumulating *while a pin was live*. **The existing damping was a treadmill: it silenced its own breadcrumb and stopped nothing.**

Atlas resets in the same log: `visibility-resume` 122 / `settled-reveal` 122 — a perfect 1:1 pair, both reveal-shaped, exactly the reporter's reason mix. Every heavy reveal pays two registry-wide glyph-atlas wipes.

The wedged replay guards line up too: `replayIntoTerminal` arms a 10 s probe on reveal; if the pane is unmounted again before xterm drains, the write never parses and 10 s later releases as `wedged`. 2125 of them on one pane ≈ 2125 reveal→re-park cycles, at the code's own stated ~170 ms flat remount cost ≈ **6 minutes of pure remount CPU**, plus the GC churn of allocating and destroying a multi-MB xterm buffer 2000 times. That is the heat. **Park churn is the driver; the atlas resets and the wedged guards are symptoms**, as @OrcaWin suspected.

Measured on the deterministic repro added here (one park/reveal loop, one tab):

| | flips | pane mounts | renders |
| --- | --- | --- | --- |
| before | **400** | **200** | 401 (stopped only by the test's hard stop) |
| after | **4** | **3** | 6, settled |

`terminal_park_verdict_churn` goes from ~1 crumb per 60 s *with churn continuing underneath it* to ~1 crumb per 60 s *with the verdict actually held still*, which drops the reveal-driven `webgl-atlas-reset` and `terminal_replay_guard_wedged_release` traffic with it.

---

### Root cause

The park verdict a tab renders is built here:

`src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts:303`

```ts
if (
  (coldParkTerminalPanes ||          // <- worktree-level park (prop from Terminal.tsx)
    (!isVisible && coldParkedTerminalTabIds.has(terminalTab.id) && …)) && …
) parked.add(terminalTab.id)
…
if (activationDeferredMountTabIds?.has(terminalTab.id) && … canWatcherCoverParkedTerminalTab(…))
  parked.add(terminalTab.id)   // second, entirely separate branch
```

The oscillation itself is the one this repo already documents in `terminal-cold-park-verdict-loop.test.tsx:5-9`: `canWatcherCoverParkedTerminalTab` is re-derived from store and registry state that mounting/unmounting the very pane the verdict controls rewrites. `Terminal.tsx:1035-1046` runs that same predicate as a **worktree-level** park veto (`worktreeTabsAreWatcherCovered`), and that verdict arrives here as `coldParkTerminalPanes`.

The loop-breaker was `withholdUnparkableTerminalTabs` (`terminal-cold-park-withheld-tabs.ts:32`), which filters only `coldParkedTabIds` — the right-hand side of that `||`. So:

- a loop driven by `coldParkTerminalPanes` short-circuits past the pin entirely;
- so does the `activationDeferredMountTabIds` branch;
- and `getParkVerdictUnparkPinUntilMs`, which is also the *only* place a pin expires, is likewise reached only for cold-park candidates — so the record never re-arms cleanly, which is why the field trace shows a clean 60 s re-burst cadence forever instead of a settle.

The module's own docstring said so out loud (`terminal-park-verdict-flip-telemetry.ts:6-10`, before this PR): *"the pin can only subtract from the cold-park candidate set … read a repeating `burst` crumb for one tab as 'damping did not reach the oscillating input'."* The field data is exactly that repeating crumb.

### Fix

`selectParkVerdictPinnedTabIds` (`terminal-park-verdict-flip-telemetry.ts:188`) resolves and expires pins for **every live tab**, and `useTerminalParkVerdictPin` (`use-terminal-park-verdict-pin.ts`) applies them as the last gate on the rendered verdict — the same quantity the flip telemetry observes. Whichever input oscillates, the loop is now broken, on the safe (mounted) side that the existing contract already chose.

**Why damping is the correct fix here, not a cop-out.** The plant is *inside* the feedback path by design: parking's precondition is "will the byte watchers cover this tab once its pane is gone?", and the honest answer depends on state only the pane's presence establishes. You cannot delete that feedback without redesigning watcher coverage. What you *can* do — and what was already agreed as the mechanism — is break the loop at the actuator. This PR does not add a new threshold, raise an existing one, or debounce a symptom: it changes **where** the existing, already-derived brake is applied, from one input to the verdict, and makes it expire on its own. The atlas reset and the replay guard are deliberately untouched; they are downstream of the reveal.

### Fix evidence

Test: `terminal-park-verdict-worktree-driver-loop.test.tsx`. Single tab, so `selectIdsBeyondHotRetain` spares it via the last-active exemption and the cold-park set is provably empty — `coldParkTerminalPanes` is the only driver, which is exactly what the old pin could not reach.

Reverted (`pinnedTabIds.size === 0` → `>= 0`, i.e. the pin never reaches the rendered verdict):

```
 FAIL  src/renderer/src/components/terminal-pane/terminal-park-verdict-worktree-driver-loop.test.tsx > park-verdict damping reaches the worktree-level driver > settles a verdict whose only driver is the worktree-level park prop
AssertionError: expected 400 to be less than or equal to 4
 ❯ src/renderer/src/components/terminal-pane/terminal-park-verdict-worktree-driver-loop.test.tsx:186:34
    186|     expect(parkVerdictFlipCount).toBeLessThanOrEqual(SETTLED_FLIP_BUDG…
       |                                  ^

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

Restored: passes at 4 flips / 3 mounts / 6 renders.

Also added a direct unit case in `terminal-park-verdict-flip-telemetry.test.ts` for the property the old wiring broke — a pin must be selectable *and expirable* for a tab the cold-park selector never proposed.

### Checks

- `tsc` clean on all three configs (`tsconfig.node.json`, `tsconfig.tc.cli.json`, `tsconfig.tc.web.json`)
- `oxlint` clean on every changed file; no `max-lines` disable added (the new hook is a separate module precisely so `use-terminal-tab-cold-parking.ts` stays under the 300-line budget)
- `vitest` — 2179 files / 17 813 tests pass across `src/renderer/src/components`, `src/renderer/src/lib/pane-manager`, `src/renderer/src/store/terminals`
- The pin-expiry wakeup is a single `setTimeout` per live pin, armed off an absolute deadline and skipped when that deadline is unchanged, so a busy agent pane re-minting the tab model many times a second does not re-arm it. No polling added.

### Behaviour change worth knowing

A pinned tab now stays **mounted** even when the worktree-level verdict (including retention-budget force-park) says park. That is bounded to the 60 s pin window and only triggers after ≥3 verdict round-trips inside one second — which the policy's own hysteresis (30 s cold-park delay) says cannot happen honestly. Two existing assertions in `use-terminal-tab-cold-parking.test.ts` drove three park round-trips with frozen fake timers and so read as an oscillation; they now advance the clock past the burst window between transitions.

### What this does not fix, honestly

This stops the pane from remounting at commit cadence. It does **not** remove the self-referential coverage predicate that makes the loop possible in the first place — `canWatcherCoverParkedTerminalTab` still answers differently depending on whether the pane it gates is currently mounted, and `Terminal.tsx`'s worktree-level use of it still has no damping of its own. I could not isolate, from static reading alone, exactly which term inside that predicate flips for the reporter's SSH panes; the trace records the flip, not the input. Making the churn breadcrumb carry the deciding input is the obvious follow-up, and is now much cheaper to act on because the pane is no longer thrashing while you read it.

Closes the perf half of #15136.
