### PR TITLE
fix(ssh): replay an undelivered remote PTY stop on the next handshake (#12447 item 1)

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -3333,7 +3333,7 @@
           "durationSeconds": 1.5,
           "summary": "175/175 at the relocated paths on the unified tool authority, replacing the 2026-08-27 record of the same command at 174/174. That run killed twelve of fourteen mutants as sole deltas — dropping the document branch from the one authority door, removing either browsing-registration refusal or the mint-side refusal that is its converse, deleting the registration notification or widening it to the worktree-wide and any-tab waits, disposing revoked state by grant instead of by page, dropping the hosting-renderer or destroyed-contents check, rebuilding the renderer tool target from the grant, and deleting the teardown identity check under a re-mint — and reported two as ill-posed rather than as kills. The relocation changed no file it names except their directory."
         },
-{
+        {
           "date": "2026-08-27",
           "runner": "local",
           "platform": "macos",
@@ -3378,7 +3378,7 @@
           "durationSeconds": 0.17,
           "summary": "22/22 on the candidate that stops a previewed document writing into this desktop's Downloads folder. The hole was read out of the shipping path, not guessed: the preview partition took the shared browser partition policies whole, including will-download, and a preview guest joins no browser-page registry, so handleGuestWillDownload resolved no owner context, routeBrowserClientDownload answered local for a non-client-hosted contents, and the item got a reserved Downloads name with no prompt and no tab to attribute it to. Downloads are now the one policy the preview partition does not inherit. Red-green with each mutant as the sole delta: making the installer ignore the deny option routes the preview partition's download to the router again, and making the preview protocol installer stop asking for the deny leaves the option unset. The absence half is paired with a presence precondition in the same run — an ordinary browsing partition installed beside the preview one in one test still reaches the download router, so a deny that fenced everything, or a download path that had been removed entirely, would fail rather than pass quietly."
         },
-{
+        {
           "date": "2026-08-27",
           "runner": "local",
           "platform": "macos",
@@ -3441,7 +3441,7 @@
           "durationSeconds": 0.36,
           "summary": "The four surfaces the trusted-click route is built from passed 63/63: the preload's click policy over a real document, including an untrusted dispatched click, an untrusted middle click, an SVG animated href resolved against the document so a relative, rooted or fragment SVG link behaves exactly like the identical HTML anchor, fragment and percent-encoded fragment targets and a trusted middle click; the guest policy's deny-only sinks, its refusal of a navigation that arrives before a document has bound the guest to a grant, and its report gate for an unfocused guest, an unregistered sender, a missing or revoked grant and non-web URLs; will-attach-webview pinning the preview preload in both directions; and the click channel handing main its own sender without a trusted-renderer check."
         },
-{
+        {
           "date": "2026-08-26",
           "runner": "local",
           "platform": "macos",
@@ -3468,7 +3468,7 @@
           "durationSeconds": 66,
           "summary": "The journey passed 3/3 again under --repeat-each=3 on the candidate that clears grants on every fresh shell document and gates the mint channel on the trusted renderer, so neither change disturbs a live preview: the document still rendered, both browser counts held at baseline, and the target=_blank press still routed out as an Orca browser tab."
         },
-{
+        {
           "date": "2026-08-26",
           "runner": "local",
           "platform": "macos",

--- a/src/main/ipc/pty-controller-ownership-routing.test.ts
+++ b/src/main/ipc/pty-controller-ownership-routing.test.ts
@@ -317,7 +317,8 @@ describe('registerPtyHandlers', () => {
       upsertSshRemotePtyLease: vi.fn(),
       persistPtyBinding: vi.fn(),
       removeSshRemotePtyLease: vi.fn(),
-      markSshRemotePtyLease: vi.fn()
+      markSshRemotePtyLease: vi.fn(),
+      clearSshRemotePtyKillIntent: vi.fn()
     }
     const runtime = {
       setPtyController: vi.fn(),

--- a/src/main/ipc/pty-daemon-controller-teardown.test.ts
+++ b/src/main/ipc/pty-daemon-controller-teardown.test.ts
@@ -286,7 +286,7 @@ describe('registerPtyHandlers', () => {
           getProfiles: vi.fn()
         } as never)
         const shutdown = vi.fn(async () => undefined)
-        const store = { markSshRemotePtyLease: vi.fn() }
+        const store = { markSshRemotePtyLease: vi.fn(), clearSshRemotePtyKillIntent: vi.fn() }
         const runtime = {
           setPtyController: vi.fn(),
           onPtyExit: vi.fn()
@@ -357,7 +357,7 @@ describe('registerPtyHandlers', () => {
           getDefaultShell: vi.fn(),
           getProfiles: vi.fn()
         } as never)
-        const store = { markSshRemotePtyLease: vi.fn() }
+        const store = { markSshRemotePtyLease: vi.fn(), clearSshRemotePtyKillIntent: vi.fn() }
         const runtime = {
           setPtyController: vi.fn(),
           onPtyExit: vi.fn()
@@ -385,7 +385,8 @@ describe('registerPtyHandlers', () => {
       })
       it('marks a detached SSH lease terminated when runtime controller kill has no provider', async () => {
         const store = {
-          markSshRemotePtyLease: vi.fn()
+          markSshRemotePtyLease: vi.fn(),
+          clearSshRemotePtyKillIntent: vi.fn()
         }
         const runtime = {
           setPtyController: vi.fn(),
@@ -417,7 +418,8 @@ describe('registerPtyHandlers', () => {
       it('keeps a rejected SSH PTY unverifiable after kill shutdown fails transiently', async () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         const store = {
-          markSshRemotePtyLease: vi.fn()
+          markSshRemotePtyLease: vi.fn(),
+          clearSshRemotePtyKillIntent: vi.fn()
         }
         const runtime = {
           setPtyController: vi.fn(),

--- a/src/main/ipc/pty-daemon-spawn-session-identity.test.ts
+++ b/src/main/ipc/pty-daemon-spawn-session-identity.test.ts
@@ -462,7 +462,8 @@ describe('registerPtyHandlers', () => {
           throw new Error('SSH_SESSION_EXPIRED: remote-pty')
         })
         const store = {
-          markSshRemotePtyLease: vi.fn()
+          markSshRemotePtyLease: vi.fn(),
+          clearSshRemotePtyKillIntent: vi.fn()
         }
         registerSshPtyProvider('ssh-1', {
           spawn: sshSpawn,
@@ -514,7 +515,8 @@ describe('registerPtyHandlers', () => {
           throw new Error('SSH_SESSION_EXPIRED: remote-pty')
         })
         const store = {
-          markSshRemotePtyLease: vi.fn()
+          markSshRemotePtyLease: vi.fn(),
+          clearSshRemotePtyKillIntent: vi.fn()
         }
         registerSshPtyProvider('ssh-1', {
           spawn: sshSpawn,

--- a/src/main/ipc/pty-daemon-ssh-lease-lifecycle.test.ts
+++ b/src/main/ipc/pty-daemon-ssh-lease-lifecycle.test.ts
@@ -72,7 +72,8 @@ describe('registerPtyHandlers', () => {
           )
         })
         const store = {
-          markSshRemotePtyLease: vi.fn()
+          markSshRemotePtyLease: vi.fn(),
+          clearSshRemotePtyKillIntent: vi.fn()
         }
         registerSshPtyProvider('ssh-1', {
           spawn: sshSpawn,
@@ -136,7 +137,8 @@ describe('registerPtyHandlers', () => {
       })
       it('does not tombstone an SSH lease when explicit kill shutdown fails transiently', async () => {
         const store = {
-          markSshRemotePtyLease: vi.fn()
+          markSshRemotePtyLease: vi.fn(),
+          clearSshRemotePtyKillIntent: vi.fn()
         }
         registerSshPtyProvider('ssh-1', {
           spawn: vi.fn(),
@@ -188,7 +190,8 @@ describe('registerPtyHandlers', () => {
       it('marks an SSH lease terminated after runtime controller kill succeeds', async () => {
         const shutdown = vi.fn(async () => undefined)
         const store = {
-          markSshRemotePtyLease: vi.fn()
+          markSshRemotePtyLease: vi.fn(),
+          clearSshRemotePtyKillIntent: vi.fn()
         }
         const runtime = {
           setPtyController: vi.fn(),
@@ -408,7 +411,8 @@ describe('registerPtyHandlers', () => {
         vi.useFakeTimers()
         const shutdown = vi.fn(async () => undefined)
         const store = {
-          markSshRemotePtyLease: vi.fn()
+          markSshRemotePtyLease: vi.fn(),
+          clearSshRemotePtyKillIntent: vi.fn()
         }
         const runtime = {
           setPtyController: vi.fn(),

--- a/src/main/ipc/pty-pane-reservation-settlement.test.ts
+++ b/src/main/ipc/pty-pane-reservation-settlement.test.ts
@@ -119,7 +119,8 @@ describe('registerPtyHandlers', () => {
       persistPtyBinding: vi.fn(),
       upsertSshRemotePtyLease: vi.fn(),
       removeSshRemotePtyLease: vi.fn(),
-      markSshRemotePtyLease: vi.fn()
+      markSshRemotePtyLease: vi.fn(),
+      clearSshRemotePtyKillIntent: vi.fn()
     }
     const runtime = {
       setPtyController: vi.fn(),
@@ -477,7 +478,8 @@ describe('registerPtyHandlers', () => {
       upsertSshRemotePtyLease: vi.fn(),
       persistPtyBinding: vi.fn(),
       removeSshRemotePtyLease: vi.fn(),
-      markSshRemotePtyLease: vi.fn()
+      markSshRemotePtyLease: vi.fn(),
+      clearSshRemotePtyKillIntent: vi.fn()
     }
     let controller: RuntimeSpawnController | null = null
     const runtime = {

--- a/src/main/ipc/pty-runtime-ssh-binding-persistence.test.ts
+++ b/src/main/ipc/pty-runtime-ssh-binding-persistence.test.ts
@@ -156,7 +156,8 @@ describe('registerPtyHandlers', () => {
       upsertSshRemotePtyLease: vi.fn(),
       persistPtyBinding: vi.fn(),
       removeSshRemotePtyLease: vi.fn(),
-      markSshRemotePtyLease: vi.fn()
+      markSshRemotePtyLease: vi.fn(),
+      clearSshRemotePtyKillIntent: vi.fn()
     }
     let controller: RuntimeSpawnController | null = null
     const runtime = {
@@ -373,7 +374,8 @@ describe('registerPtyHandlers', () => {
         throw new Error('disk full')
       }),
       removeSshRemotePtyLease: vi.fn(),
-      markSshRemotePtyLease: vi.fn()
+      markSshRemotePtyLease: vi.fn(),
+      clearSshRemotePtyKillIntent: vi.fn()
     }
     let controller: RuntimeSpawnController | null = null
     const runtime = {
@@ -469,7 +471,8 @@ describe('registerPtyHandlers', () => {
       upsertSshRemotePtyLease: vi.fn(),
       persistPtyBinding: vi.fn(),
       removeSshRemotePtyLease: vi.fn(),
-      markSshRemotePtyLease: vi.fn()
+      markSshRemotePtyLease: vi.fn(),
+      clearSshRemotePtyKillIntent: vi.fn()
     }
     let controller: RuntimeSpawnController | null = null
     const runtime = {

--- a/src/main/ipc/pty-serializer-settlement-mapping.test.ts
+++ b/src/main/ipc/pty-serializer-settlement-mapping.test.ts
@@ -110,7 +110,8 @@ describe('registerPtyHandlers', () => {
       upsertSshRemotePtyLease: vi.fn(),
       persistPtyBinding: vi.fn(),
       removeSshRemotePtyLease: vi.fn(),
-      markSshRemotePtyLease: vi.fn()
+      markSshRemotePtyLease: vi.fn(),
+      clearSshRemotePtyKillIntent: vi.fn()
     }
     let controller: RuntimeSpawnController | null = null
     const runtime = {
@@ -215,7 +216,8 @@ describe('registerPtyHandlers', () => {
         throw new Error('disk full')
       }),
       removeSshRemotePtyLease: vi.fn(),
-      markSshRemotePtyLease: vi.fn()
+      markSshRemotePtyLease: vi.fn(),
+      clearSshRemotePtyKillIntent: vi.fn()
     }
 
     try {

--- a/src/main/ipc/pty-session-liveness-and-ownership.test.ts
+++ b/src/main/ipc/pty-session-liveness-and-ownership.test.ts
@@ -302,7 +302,7 @@ describe('registerPtyHandlers', () => {
       getProfiles: vi.fn()
     } as never)
     const sshShutdown = vi.fn(async () => undefined)
-    const store = { markSshRemotePtyLease: vi.fn() }
+    const store = { markSshRemotePtyLease: vi.fn(), clearSshRemotePtyKillIntent: vi.fn() }
     registerSshPtyProvider('ssh-1', {
       spawn: vi.fn(),
       write: vi.fn(),
@@ -367,7 +367,7 @@ describe('registerPtyHandlers', () => {
       getDefaultShell: vi.fn(),
       getProfiles: vi.fn()
     } as never)
-    const store = { markSshRemotePtyLease: vi.fn() }
+    const store = { markSshRemotePtyLease: vi.fn(), clearSshRemotePtyKillIntent: vi.fn() }
     registerPtyHandlers(
       mainWindow as never,
       undefined,
@@ -386,7 +386,8 @@ describe('registerPtyHandlers', () => {
     const store = {
       upsertSshRemotePtyLease: vi.fn(),
       persistPtyBinding: vi.fn(),
-      markSshRemotePtyLease: vi.fn()
+      markSshRemotePtyLease: vi.fn(),
+      clearSshRemotePtyKillIntent: vi.fn()
     }
     const provider = {
       spawn: vi.fn(async () => ({ id: 'remote-pty' })),

--- a/src/main/ipc/pty-ssh-undelivered-kill.test.ts
+++ b/src/main/ipc/pty-ssh-undelivered-kill.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from 'vitest'
+import { setupPtyIpcSuite } from './pty-ipc-test-harness'
+import { SSH_SESSION_EXPIRED_ERROR } from '../providers/ssh-pty-errors'
+import {
+  registerPtyHandlers,
+  registerSshPtyProvider,
+  unregisterSshPtyProvider,
+  deletePtyOwnership,
+  setPtyOwnership,
+  restorePtyIncarnation
+} from './pty'
+
+vi.mock('electron', () => import('./pty-ipc-mock-registry').then((m) => m.electronModuleMock()))
+vi.mock('fs', () => import('./pty-ipc-mock-registry').then((m) => m.fsModuleMock()))
+vi.mock('node-pty', () => import('./pty-ipc-mock-registry').then((m) => m.nodePtyModuleMock()))
+vi.mock('node:child_process', async (importOriginal) =>
+  (await import('./pty-ipc-mock-registry')).childProcessModuleMock(await importOriginal())
+)
+vi.mock('../opencode/hook-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.openCodeHookServiceModuleMock())
+)
+vi.mock('../mimo/hook-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.mimoHookServiceModuleMock())
+)
+vi.mock('../agent-hooks/server', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.agentHookServerModuleMock())
+)
+vi.mock('../pi/titlebar-extension-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.piTitlebarExtensionModuleMock())
+)
+vi.mock('../pwsh', () => import('./pty-ipc-mock-registry').then((m) => m.pwshModuleMock()))
+vi.mock('../wsl', async (importOriginal) =>
+  (await import('./pty-ipc-mock-registry')).wslModuleMock(await importOriginal())
+)
+vi.mock('../telemetry/client', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.telemetryClientModuleMock())
+)
+vi.mock('../telemetry/classify-error', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.classifyErrorModuleMock())
+)
+vi.mock('../cli/linux-terminal-orca-cli-shim', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.linuxCliShimModuleMock())
+)
+vi.mock('../memory/pty-registry', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.ptyRegistryModuleMock())
+)
+vi.mock('../agent-hooks/migration-unsupported-pty-state', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.migrationUnsupportedPtyModuleMock())
+)
+vi.mock('../codex/codex-pane-account-registry', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.codexPaneAccountRegistryModuleMock())
+)
+vi.mock('../codex/codex-state-db-backfill-recovery', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.codexBackfillRecoveryModuleMock())
+)
+
+const SCOPED_PTY_ID = 'ssh:ssh-1@@pty-7'
+
+function createKillStore() {
+  return {
+    markSshRemotePtyLease: vi.fn(),
+    recordSshRemotePtyKillIntent: vi.fn(),
+    clearSshRemotePtyKillIntent: vi.fn()
+  }
+}
+
+function sshProviderStub(shutdown: () => Promise<void>) {
+  return {
+    shutdown: vi.fn(shutdown),
+    onExit: vi.fn(() => () => {}),
+    onData: vi.fn(() => () => {}),
+    onReplay: vi.fn(() => () => {}),
+    listProcesses: vi.fn(async () => [])
+  } as never
+}
+
+function installController(handlers: Map<string, never>) {
+  const runtime = {
+    setPtyController: vi.fn(),
+    markPtyStopRequested: vi.fn(),
+    markPtyLivenessUnverifiable: vi.fn(),
+    onPtyExit: vi.fn()
+  }
+  handlers.clear()
+  return { runtime }
+}
+
+describe('undelivered SSH stops', () => {
+  const { handlers, mainWindow } = setupPtyIpcSuite()
+
+  function install(store: ReturnType<typeof createKillStore>): {
+    kill: (ptyId: string) => boolean
+    runtime: ReturnType<typeof installController>['runtime']
+  } {
+    const { runtime } = installController(handlers as never)
+    registerPtyHandlers(
+      mainWindow as never,
+      runtime as never,
+      undefined,
+      undefined,
+      undefined,
+      store as never
+    )
+    const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+      kill: (ptyId: string) => boolean
+    }
+    return { kill: controller.kill, runtime }
+  }
+
+  // The leak: the shutdown died on the transport, the verdict is correctly `unverifiable`, and
+  // before this fix nothing retried — the remote shell survived forever.
+  it('records the stop when the shutdown RPC rejects with a transport failure', async () => {
+    const store = createKillStore()
+    registerSshPtyProvider(
+      'ssh-1',
+      sshProviderStub(async () => {
+        throw new Error('socket closed')
+      })
+    )
+    setPtyOwnership(SCOPED_PTY_ID, 'ssh-1')
+    restorePtyIncarnation(SCOPED_PTY_ID, 'inc-a')
+    const { kill, runtime } = install(store)
+
+    try {
+      expect(kill(SCOPED_PTY_ID)).toBe(true)
+      await vi.waitFor(() => expect(store.recordSshRemotePtyKillIntent).toHaveBeenCalled())
+      expect(store.recordSshRemotePtyKillIntent).toHaveBeenCalledWith(
+        'ssh-1',
+        'pty-7',
+        expect.objectContaining({ incarnationId: 'inc-a', attempts: 0 })
+      )
+      expect(runtime.markPtyLivenessUnverifiable).toHaveBeenCalledWith(
+        SCOPED_PTY_ID,
+        'socket closed'
+      )
+    } finally {
+      unregisterSshPtyProvider('ssh-1')
+      deletePtyOwnership(SCOPED_PTY_ID)
+    }
+  })
+
+  // The offline close: no provider is registered, so the relay is never even asked. The lease is
+  // tombstoned locally, and without the record the remote shell has nothing left to retire it.
+  it('records the stop when no provider is registered to deliver it', async () => {
+    const store = createKillStore()
+    setPtyOwnership(SCOPED_PTY_ID, 'ssh-1')
+    restorePtyIncarnation(SCOPED_PTY_ID, 'inc-b')
+    const { kill } = install(store)
+
+    try {
+      expect(kill(SCOPED_PTY_ID)).toBe(false)
+      expect(store.recordSshRemotePtyKillIntent).toHaveBeenCalledWith(
+        'ssh-1',
+        'pty-7',
+        expect.objectContaining({ incarnationId: 'inc-b' })
+      )
+    } finally {
+      deletePtyOwnership(SCOPED_PTY_ID)
+    }
+  })
+
+  it('records nothing when the shutdown RPC is delivered', async () => {
+    const store = createKillStore()
+    registerSshPtyProvider(
+      'ssh-1',
+      sshProviderStub(async () => {})
+    )
+    setPtyOwnership(SCOPED_PTY_ID, 'ssh-1')
+    restorePtyIncarnation(SCOPED_PTY_ID, 'inc-c')
+    const { kill } = install(store)
+
+    try {
+      expect(kill(SCOPED_PTY_ID)).toBe(true)
+      await vi.waitFor(() => expect(store.markSshRemotePtyLease).toHaveBeenCalled())
+      expect(store.recordSshRemotePtyKillIntent).not.toHaveBeenCalled()
+      // A completed shutdown answers any earlier undelivered order for the same id.
+      expect(store.clearSshRemotePtyKillIntent).toHaveBeenCalledWith('ssh-1', 'pty-7')
+    } finally {
+      unregisterSshPtyProvider('ssh-1')
+      deletePtyOwnership(SCOPED_PTY_ID)
+    }
+  })
+
+  it('records nothing for a local PTY, which has no later host to ask', async () => {
+    const store = createKillStore()
+    setPtyOwnership('local-pty', null)
+    restorePtyIncarnation('local-pty', 'inc-d')
+    const { kill } = install(store)
+
+    try {
+      kill('local-pty')
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(store.recordSshRemotePtyKillIntent).not.toHaveBeenCalled()
+    } finally {
+      deletePtyOwnership('local-pty')
+    }
+  })
+
+  // No incarnation means no fence, and an unfenced order can only be discarded or guessed at.
+  it('records nothing when the PTY incarnation was never learned', async () => {
+    const store = createKillStore()
+    registerSshPtyProvider(
+      'ssh-1',
+      sshProviderStub(async () => {
+        throw new Error(`${SSH_SESSION_EXPIRED_ERROR}-transport`)
+      })
+    )
+    setPtyOwnership('ssh:ssh-1@@pty-8', 'ssh-1')
+    const { kill } = install(store)
+
+    try {
+      kill('ssh:ssh-1@@pty-8')
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(store.recordSshRemotePtyKillIntent).not.toHaveBeenCalled()
+    } finally {
+      unregisterSshPtyProvider('ssh-1')
+      deletePtyOwnership('ssh:ssh-1@@pty-8')
+    }
+  })
+})

--- a/src/main/ipc/pty-ssh-undelivered-kill.test.ts
+++ b/src/main/ipc/pty-ssh-undelivered-kill.test.ts
@@ -90,6 +90,8 @@ describe('undelivered SSH stops', () => {
 
   function install(store: ReturnType<typeof createKillStore>): {
     kill: (ptyId: string) => boolean
+    stopAndWait: (ptyId: string, opts?: { keepHistory?: boolean }) => Promise<boolean>
+    markReversibleStops: (ptyIds: readonly string[]) => () => void
     runtime: ReturnType<typeof installController>['runtime']
   } {
     const { runtime } = installController(handlers as never)
@@ -103,8 +105,15 @@ describe('undelivered SSH stops', () => {
     )
     const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
       kill: (ptyId: string) => boolean
+      stopAndWait: (ptyId: string, opts?: { keepHistory?: boolean }) => Promise<boolean>
+      markReversibleStops: (ptyIds: readonly string[]) => () => void
     }
-    return { kill: controller.kill, runtime }
+    return {
+      kill: controller.kill,
+      stopAndWait: controller.stopAndWait,
+      markReversibleStops: controller.markReversibleStops,
+      runtime
+    }
   }
 
   // The leak: the shutdown died on the transport, the verdict is correctly `unverifiable`, and
@@ -176,6 +185,54 @@ describe('undelivered SSH stops', () => {
       // A completed shutdown answers any earlier undelivered order for the same id.
       expect(store.clearSshRemotePtyKillIntent).toHaveBeenCalledWith('ssh-1', 'pty-7')
     } finally {
+      unregisterSshPtyProvider('ssh-1')
+      deletePtyOwnership(SCOPED_PTY_ID)
+    }
+  })
+
+  // Worktree sleep stops through stopAndWait and marks those stops reversible: when one does not
+  // land, the pane stays live and the user keeps using it. A durable order recorded here would come
+  // back on a later handshake and kill that terminal out from under them.
+  it('records nothing for a reversible stopAndWait that could not be delivered', async () => {
+    const store = createKillStore()
+    registerSshPtyProvider(
+      'ssh-1',
+      sshProviderStub(async () => {
+        throw new Error('socket closed')
+      })
+    )
+    setPtyOwnership(SCOPED_PTY_ID, 'ssh-1')
+    restorePtyIncarnation(SCOPED_PTY_ID, 'inc-e')
+    const { stopAndWait } = install(store)
+
+    try {
+      await expect(stopAndWait(SCOPED_PTY_ID, { keepHistory: true })).resolves.toBe(false)
+      expect(store.recordSshRemotePtyKillIntent).not.toHaveBeenCalled()
+    } finally {
+      unregisterSshPtyProvider('ssh-1')
+      deletePtyOwnership(SCOPED_PTY_ID)
+    }
+  })
+
+  it('records nothing while a reversible stop owns the PTY', async () => {
+    const store = createKillStore()
+    registerSshPtyProvider(
+      'ssh-1',
+      sshProviderStub(async () => {
+        throw new Error('socket closed')
+      })
+    )
+    setPtyOwnership(SCOPED_PTY_ID, 'ssh-1')
+    restorePtyIncarnation(SCOPED_PTY_ID, 'inc-f')
+    const { kill, markReversibleStops } = install(store)
+    const release = markReversibleStops([SCOPED_PTY_ID])
+
+    try {
+      kill(SCOPED_PTY_ID)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(store.recordSshRemotePtyKillIntent).not.toHaveBeenCalled()
+    } finally {
+      release()
       unregisterSshPtyProvider('ssh-1')
       deletePtyOwnership(SCOPED_PTY_ID)
     }

--- a/src/main/ipc/pty-ssh-undelivered-kill.test.ts
+++ b/src/main/ipc/pty-ssh-undelivered-kill.test.ts
@@ -182,8 +182,11 @@ describe('undelivered SSH stops', () => {
       expect(kill(SCOPED_PTY_ID)).toBe(true)
       await vi.waitFor(() => expect(store.markSshRemotePtyLease).toHaveBeenCalled())
       expect(store.recordSshRemotePtyKillIntent).not.toHaveBeenCalled()
-      // A completed shutdown answers any earlier undelivered order for the same id.
-      expect(store.clearSshRemotePtyKillIntent).toHaveBeenCalledWith('ssh-1', 'pty-7')
+      // And it does not retire one either. A resolved RPC is not a death certificate — the relay
+      // answers identically for a PTY it never had — so retirement is left to the replay, which
+      // only acts on a live inventory. Clearing here would be the mechanism by which a still-valid
+      // order is destroyed on an unconfirmed success.
+      expect(store.clearSshRemotePtyKillIntent).not.toHaveBeenCalled()
     } finally {
       unregisterSshPtyProvider('ssh-1')
       deletePtyOwnership(SCOPED_PTY_ID)
@@ -207,6 +210,77 @@ describe('undelivered SSH stops', () => {
 
     try {
       await expect(stopAndWait(SCOPED_PTY_ID, { keepHistory: true })).resolves.toBe(false)
+      expect(store.recordSshRemotePtyKillIntent).not.toHaveBeenCalled()
+    } finally {
+      unregisterSshPtyProvider('ssh-1')
+      deletePtyOwnership(SCOPED_PTY_ID)
+    }
+  })
+
+  // The path the UI actually takes. `window.api.pty.kill` -> `pty:kill`, a separate implementation
+  // from the runtime controller, and the one #12447 describes.
+  it('records the stop when the renderer pty:kill shutdown rejects', async () => {
+    const store = createKillStore()
+    registerSshPtyProvider(
+      'ssh-1',
+      sshProviderStub(async () => {
+        throw new Error('socket closed')
+      })
+    )
+    setPtyOwnership(SCOPED_PTY_ID, 'ssh-1')
+    restorePtyIncarnation(SCOPED_PTY_ID, 'inc-r1')
+    install(store)
+
+    try {
+      await expect(handlers.get('pty:kill')!(null, { id: SCOPED_PTY_ID })).rejects.toThrow(
+        'socket closed'
+      )
+      expect(store.recordSshRemotePtyKillIntent).toHaveBeenCalledWith(
+        'ssh-1',
+        'pty-7',
+        expect.objectContaining({ incarnationId: 'inc-r1' })
+      )
+    } finally {
+      unregisterSshPtyProvider('ssh-1')
+      deletePtyOwnership(SCOPED_PTY_ID)
+    }
+  })
+
+  it('records the stop when renderer pty:kill finds no provider to deliver it', async () => {
+    const store = createKillStore()
+    setPtyOwnership(SCOPED_PTY_ID, 'ssh-1')
+    restorePtyIncarnation(SCOPED_PTY_ID, 'inc-r2')
+    install(store)
+
+    try {
+      await handlers.get('pty:kill')!(null, { id: SCOPED_PTY_ID })
+      expect(store.recordSshRemotePtyKillIntent).toHaveBeenCalledWith(
+        'ssh-1',
+        'pty-7',
+        expect.objectContaining({ incarnationId: 'inc-r2' })
+      )
+    } finally {
+      deletePtyOwnership(SCOPED_PTY_ID)
+    }
+  })
+
+  // Pane hibernation is the reversible caller on this IPC and is the only one passing keepHistory.
+  it('records nothing for a renderer pty:kill that keeps history', async () => {
+    const store = createKillStore()
+    registerSshPtyProvider(
+      'ssh-1',
+      sshProviderStub(async () => {
+        throw new Error('socket closed')
+      })
+    )
+    setPtyOwnership(SCOPED_PTY_ID, 'ssh-1')
+    restorePtyIncarnation(SCOPED_PTY_ID, 'inc-r3')
+    install(store)
+
+    try {
+      await expect(
+        handlers.get('pty:kill')!(null, { id: SCOPED_PTY_ID, keepHistory: true })
+      ).rejects.toThrow('socket closed')
       expect(store.recordSshRemotePtyKillIntent).not.toHaveBeenCalled()
     } finally {
       unregisterSshPtyProvider('ssh-1')

--- a/src/main/ipc/pty/ipc/inspect.ts
+++ b/src/main/ipc/pty/ipc/inspect.ts
@@ -1,7 +1,4 @@
 import { getPtyIpc } from '../../pty-host-bindings'
-import type { Store } from '../../../persistence'
-import type { OrcaRuntimeService } from '../../../runtime/orca-runtime'
-import type { IPtyProvider } from '../../../providers/types'
 import { parseAppSshPtyId } from '../../../providers/ssh-pty-id'
 import { inspectPtyProviderProcessForRenderer } from '../../../providers/pty-process-inspection'
 import {
@@ -9,7 +6,6 @@ import {
   visitPtyProcessListingsInBatches
 } from '../../../providers/pty-process-list-admission'
 import type { PtyListedSession } from '../../../../shared/pty-listed-session'
-import { SSH_PROVIDER_UNREGISTERED_REASON } from '../../../../shared/pty-liveness-verdict'
 import { ptyOwnership } from '../provider/ownership-state'
 import {
   getProviderForPty,
@@ -18,7 +14,6 @@ import {
   sshProviders,
   tryGetProviderForPty
 } from '../provider/registry'
-import { finishPtyShutdown, isPtyAlreadyGoneError } from '../provider/liveness'
 import { ptySizes } from '../delivery/visibility-state'
 import { isValidPaneKey } from '../pane/key-state'
 import {
@@ -29,84 +24,10 @@ import {
 } from '../pane/serializer-state'
 
 export function installPtyInspectIpcHandlers(deps: {
-  store?: Store
-  runtime?: OrcaRuntimeService
   getLocalPtyProviderStartupPromise: (connectionId?: string | null) => Promise<void> | undefined
-  shutdownProviderAndDetectExit: (
-    provider: IPtyProvider,
-    id: string,
-    opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
-  ) => Promise<boolean>
-  rememberSyntheticKillExit: (id: string) => void
-  sendPtyExitToRenderer: (payload: { id: string; code: number; incarnationId?: string }) => void
 }): void {
   const ipcMain = getPtyIpc()
-  const {
-    store,
-    runtime,
-    getLocalPtyProviderStartupPromise,
-    shutdownProviderAndDetectExit,
-    rememberSyntheticKillExit,
-    sendPtyExitToRenderer
-  } = deps
-
-  ipcMain.handle('pty:kill', async (_event, args: { id: string; keepHistory?: boolean }) => {
-    if (typeof args?.id !== 'string' || !args.id || args.id.startsWith('remote:')) {
-      // Why: runtime terminal handles belong to terminal.close; unowned PTY routing could target the local provider.
-      throw new Error('Invalid PTY provider id')
-    }
-    runtime?.markPtyStopRequested?.(args.id)
-    const ownedConnectionId = ptyOwnership.get(args.id)
-    const parsedSshId = ownedConnectionId === undefined ? parseAppSshPtyId(args.id) : null
-    const connectionId = ownedConnectionId ?? parsedSshId?.connectionId
-    // Why: wait for daemon startup before selecting the local provider, else a fallback shutdown falsely succeeds and orphans a restored daemon PTY (#7742).
-    const startupPromise = getLocalPtyProviderStartupPromise(connectionId)
-    if (startupPromise) {
-      await startupPromise
-    }
-    const provider = connectionId ? sshProviders.get(connectionId) : tryGetProviderForPty(args.id)
-    if (!provider && connectionId) {
-      // Why: detached SSH PTYs intentionally keep ownership after their
-      // provider is unregistered; hydrated app-scoped ids can also arrive
-      // before ownership is rebuilt. Tombstone instead of falling back local.
-      const incarnationId = finishPtyShutdown(args.id, connectionId, store)
-      runtime?.markPtyLivenessUnverifiable?.(args.id, SSH_PROVIDER_UNREGISTERED_REASON)
-      runtime?.onPtyExit(args.id, -1, incarnationId)
-      rememberSyntheticKillExit(args.id)
-      sendPtyExitToRenderer({
-        id: args.id,
-        code: -1,
-        ...(incarnationId ? { incarnationId } : {})
-      })
-      return
-    }
-    const shutdownProvider = provider ?? getProviderForPty(args.id)
-    let providerExitObserved = false
-    try {
-      providerExitObserved = await shutdownProviderAndDetectExit(shutdownProvider, args.id, {
-        immediate: true,
-        keepHistory: args.keepHistory ?? false
-      })
-    } catch (err) {
-      if (!isPtyAlreadyGoneError(err)) {
-        // Why: a failed shutdown can leave the process alive (SSH relay grace window / local daemon); keep ownership/lease state so the user can retry.
-        throw err
-      }
-      /* session already dead — cleanup below handles the rest */
-    }
-    // Why: some shutdown paths do not emit onExit through the provider listener.
-    // Explicit cleanup is idempotent and covers already-dead PTYs.
-    const incarnationId = finishPtyShutdown(args.id, connectionId, store)
-    if (!providerExitObserved) {
-      runtime?.onPtyExit(args.id, -1, incarnationId)
-      rememberSyntheticKillExit(args.id)
-      sendPtyExitToRenderer({
-        id: args.id,
-        code: -1,
-        ...(incarnationId ? { incarnationId } : {})
-      })
-    }
-  })
+  const { getLocalPtyProviderStartupPromise } = deps
 
   ipcMain.handle('pty:listSessions', async (): Promise<PtyListedSession[]> => {
     const deduped = new Map<string, PtyListedSession>()

--- a/src/main/ipc/pty/ipc/renderer-kill.ts
+++ b/src/main/ipc/pty/ipc/renderer-kill.ts
@@ -1,0 +1,111 @@
+import { getPtyIpc } from '../../pty-host-bindings'
+import type { Store } from '../../../persistence'
+import type { OrcaRuntimeService } from '../../../runtime/orca-runtime'
+import type { IPtyProvider } from '../../../providers/types'
+import { parseAppSshPtyId } from '../../../providers/ssh-pty-id'
+import { SSH_PROVIDER_UNREGISTERED_REASON } from '../../../../shared/pty-liveness-verdict'
+import { ptyOwnership } from '../provider/ownership-state'
+import { getProviderForPty, sshProviders, tryGetProviderForPty } from '../provider/registry'
+import { finishPtyShutdown, isPtyAlreadyGoneError } from '../provider/liveness'
+import { recordUndeliveredSshPtyKill } from '../runtime/undelivered-ssh-kill'
+
+export type PtyKillIpcDeps = {
+  store?: Store
+  runtime?: OrcaRuntimeService
+  getLocalPtyProviderStartupPromise: (connectionId?: string | null) => Promise<void> | undefined
+  shutdownProviderAndDetectExit: (
+    provider: IPtyProvider,
+    id: string,
+    opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
+  ) => Promise<boolean>
+  rememberSyntheticKillExit: (id: string) => void
+  sendPtyExitToRenderer: (payload: { id: string; code: number; incarnationId?: string }) => void
+}
+
+/** `pty:kill` — the route the renderer takes when the user closes a terminal tab, and a separate
+ *  implementation from `killPtyFromRuntimeController`. Both have to record an undelivered SSH stop,
+ *  and this is the one ordinary tab close actually reaches. */
+export function installPtyKillIpcHandler(deps: PtyKillIpcDeps): void {
+  const ipcMain = getPtyIpc()
+  const {
+    store,
+    runtime,
+    getLocalPtyProviderStartupPromise,
+    shutdownProviderAndDetectExit,
+    rememberSyntheticKillExit,
+    sendPtyExitToRenderer
+  } = deps
+
+  ipcMain.handle('pty:kill', async (_event, args: { id: string; keepHistory?: boolean }) => {
+    if (typeof args?.id !== 'string' || !args.id || args.id.startsWith('remote:')) {
+      // Why: runtime terminal handles belong to terminal.close; unowned PTY routing could target the local provider.
+      throw new Error('Invalid PTY provider id')
+    }
+    runtime?.markPtyStopRequested?.(args.id)
+    const ownedConnectionId = ptyOwnership.get(args.id)
+    const parsedSshId = ownedConnectionId === undefined ? parseAppSshPtyId(args.id) : null
+    const connectionId = ownedConnectionId ?? parsedSshId?.connectionId
+    // Why: wait for daemon startup before selecting the local provider, else a fallback shutdown falsely succeeds and orphans a restored daemon PTY (#7742).
+    const startupPromise = getLocalPtyProviderStartupPromise(connectionId)
+    if (startupPromise) {
+      await startupPromise
+    }
+    // Why stated rather than inferred: this IPC serves both the ordinary tab close and pane
+    // hibernation, and only hibernation passes keepHistory. Recording a replayable kill for a
+    // hibernating pane would destroy it on the next handshake.
+    const reversible = args.keepHistory === true
+    const provider = connectionId ? sshProviders.get(connectionId) : tryGetProviderForPty(args.id)
+    if (!provider && connectionId) {
+      // Why: detached SSH PTYs intentionally keep ownership after their
+      // provider is unregistered; hydrated app-scoped ids can also arrive
+      // before ownership is rebuilt. Tombstone instead of falling back local.
+      const incarnationId = finishPtyShutdown(args.id, connectionId, store)
+      // The relay was never asked, so the remote shell is still running. Keep the order.
+      recordUndeliveredSshPtyKill({
+        store,
+        ptyId: args.id,
+        connectionId,
+        reversible,
+        incarnationId
+      })
+      runtime?.markPtyLivenessUnverifiable?.(args.id, SSH_PROVIDER_UNREGISTERED_REASON)
+      runtime?.onPtyExit(args.id, -1, incarnationId)
+      rememberSyntheticKillExit(args.id)
+      sendPtyExitToRenderer({
+        id: args.id,
+        code: -1,
+        ...(incarnationId ? { incarnationId } : {})
+      })
+      return
+    }
+    const shutdownProvider = provider ?? getProviderForPty(args.id)
+    let providerExitObserved = false
+    try {
+      providerExitObserved = await shutdownProviderAndDetectExit(shutdownProvider, args.id, {
+        immediate: true,
+        keepHistory: args.keepHistory ?? false
+      })
+    } catch (err) {
+      if (!isPtyAlreadyGoneError(err)) {
+        // Why: a failed shutdown can leave the process alive (SSH relay grace window / local daemon); keep ownership/lease state so the user can retry.
+        // The renderer has already discarded the tab, so nothing here retries — the durable order
+        // is what lets the next handshake to this host finish the close.
+        recordUndeliveredSshPtyKill({ store, ptyId: args.id, connectionId, reversible })
+        throw err
+      }
+      /* session already dead — cleanup below handles the rest */
+    }
+    // Why: some shutdown paths do not emit onExit through the provider listener.
+    // Explicit cleanup is idempotent and covers already-dead PTYs.
+    const incarnationId = finishPtyShutdown(args.id, connectionId, store)
+    if (!providerExitObserved) {
+      runtime?.onPtyExit(args.id, -1, incarnationId)
+      rememberSyntheticKillExit(args.id)
+      sendPtyExitToRenderer({
+        id: args.id,
+        code: -1,
+        ...(incarnationId ? { incarnationId } : {})
+      })
+    }
+  })
+}

--- a/src/main/ipc/pty/provider/liveness.ts
+++ b/src/main/ipc/pty/provider/liveness.ts
@@ -143,11 +143,11 @@ export function finishPtyShutdown(
   const incarnationId = ptyIncarnationById.get(id)
   clearProviderPtyState(id)
   if (connectionId) {
-    const relayPtyId = getRelayPtyId(connectionId, id)
-    store?.markSshRemotePtyLease(connectionId, relayPtyId, 'terminated')
-    // Reaching here means the shutdown completed, so any earlier undelivered stop for this id is
-    // answered. Callers that got here WITHOUT delivering re-record it immediately after.
-    store?.clearSshRemotePtyKillIntent(connectionId, relayPtyId)
+    // Deliberately does NOT retire a recorded undelivered stop. Some callers reach here having
+    // asked the host and some having never asked it, so retiring from this one place would be a
+    // contract every call site has to know about — and the one that forgot would silently drop a
+    // kill order. Retirement is left to the replay, which only acts on host evidence.
+    store?.markSshRemotePtyLease(connectionId, getRelayPtyId(connectionId, id), 'terminated')
   }
   ptyOwnership.delete(id)
   markClaudePtyExited(id)

--- a/src/main/ipc/pty/provider/liveness.ts
+++ b/src/main/ipc/pty/provider/liveness.ts
@@ -143,7 +143,11 @@ export function finishPtyShutdown(
   const incarnationId = ptyIncarnationById.get(id)
   clearProviderPtyState(id)
   if (connectionId) {
-    store?.markSshRemotePtyLease(connectionId, getRelayPtyId(connectionId, id), 'terminated')
+    const relayPtyId = getRelayPtyId(connectionId, id)
+    store?.markSshRemotePtyLease(connectionId, relayPtyId, 'terminated')
+    // Reaching here means the shutdown completed, so any earlier undelivered stop for this id is
+    // answered. Callers that got here WITHOUT delivering re-record it immediately after.
+    store?.clearSshRemotePtyKillIntent(connectionId, relayPtyId)
   }
   ptyOwnership.delete(id)
   markClaudePtyExited(id)

--- a/src/main/ipc/pty/register-handlers.ts
+++ b/src/main/ipc/pty/register-handlers.ts
@@ -12,6 +12,7 @@ import { localProvider } from './provider/registry'
 import { finishPtyShutdown } from './provider/liveness'
 import type { GetSelectedCodexHomePath, PrepareClaudeAuth } from './host-env/types'
 import { installPtyInspectIpcHandlers } from './ipc/inspect'
+import { installPtyKillIpcHandler } from './ipc/renderer-kill'
 import { installPtyWriteIpcHandlers } from './ipc/write'
 import { installPtySpawnIpcHandler } from './ipc/spawn'
 import { installPtyRuntimeController } from './runtime/controller'
@@ -256,7 +257,8 @@ export function registerPtyHandlers(
     clearHiddenRendererResizeOutput: session.clearHiddenRendererResizeOutput
   })
   installPtyResizeVisibilityIpc(session)
-  installPtyInspectIpcHandlers({
+  installPtyInspectIpcHandlers({ getLocalPtyProviderStartupPromise })
+  installPtyKillIpcHandler({
     store,
     runtime,
     getLocalPtyProviderStartupPromise,

--- a/src/main/ipc/pty/runtime/kill.ts
+++ b/src/main/ipc/pty/runtime/kill.ts
@@ -36,7 +36,7 @@ export function killPtyFromRuntimeController(
         // not revive a terminal the user explicitly closed.
         const incarnationId = finishPtyShutdown(ptyId, connectionId, store)
         // The relay was never asked, so the remote shell is still running. Keep the order.
-        recordUndeliveredSshPtyKill({ store, ptyId, connectionId, incarnationId })
+        recordUndeliveredSshPtyKill(deps, ptyId, connectionId, incarnationId)
         runtime?.onPtyExit(ptyId, -1, incarnationId)
         rememberSyntheticKillExit(ptyId)
         sendPtyExitToRenderer({
@@ -95,7 +95,7 @@ export function killPtyFromRuntimeController(
         }
         // Outside the `retired` guard: the remote process outlives this client's bookkeeping
         // either way, and the intent is what the next handshake replays.
-        recordUndeliveredSshPtyKill({ store, ptyId, connectionId })
+        recordUndeliveredSshPtyKill(deps, ptyId, connectionId)
       })
     return true
   }
@@ -115,7 +115,7 @@ export function killPtyFromRuntimeController(
         }
         runtime?.onPtyExit(ptyId, -1, ptyIncarnationById.get(ptyId))
       }
-      recordUndeliveredSshPtyKill({ store, ptyId, connectionId })
+      recordUndeliveredSshPtyKill(deps, ptyId, connectionId)
     })
     return true
   }
@@ -198,6 +198,14 @@ export function markReversibleStopsFromRuntimeController(
   }
 }
 
+/**
+ * Deliberately records no undelivered-stop intent, unlike `killPtyFromRuntimeController`.
+ *
+ * Only a caller that gives the PTY up for good may leave a replayable kill order behind. This one
+ * hands its failures back instead: worktree sleep marks these stops reversible and leaves the pane
+ * live and usable when one does not land, so a durable order recorded here would come back on a
+ * later handshake and destroy a terminal the user had gone back to using.
+ */
 export async function stopAndWaitPtyFromRuntimeController(
   deps: PtyRuntimeControllerDeps,
   ptyId: string,
@@ -251,7 +259,6 @@ export async function stopAndWaitPtyFromRuntimeController(
       // Why: an absent SSH provider means there is no live target left to
       // await, but the relay lease must still be tombstoned.
       const incarnationId = finishPtyShutdown(ptyId, connectionId, store)
-      recordUndeliveredSshPtyKill({ store, ptyId, connectionId, incarnationId })
       runtime?.onPtyExit(ptyId, -1, incarnationId)
       rememberSyntheticKillExit(ptyId)
       sendPtyExitToRenderer({
@@ -281,15 +288,12 @@ export async function stopAndWaitPtyFromRuntimeController(
       console.warn(
         `[pty] Failed to stop PTY ${ptyId}: ${err instanceof Error ? err.message : String(err)}`
       )
-      recordUndeliveredSshPtyKill({ store, ptyId, connectionId })
       return false
     }
   }
   try {
     if (!(await verifyPtyStopped(provider, ptyId, opts))) {
       runtime?.markPtyLivenessLive?.(ptyId)
-      // The host still lists it, so the stop did not take. Same intent, replayed the same way.
-      recordUndeliveredSshPtyKill({ store, ptyId, connectionId })
       return false
     }
   } catch (err) {
@@ -304,7 +308,6 @@ export async function stopAndWaitPtyFromRuntimeController(
         err instanceof Error ? err.message : String(err)
       }`
     )
-    recordUndeliveredSshPtyKill({ store, ptyId, connectionId })
     return false
   }
   const incarnationId = finishPtyShutdown(ptyId, connectionId, store)

--- a/src/main/ipc/pty/runtime/kill.ts
+++ b/src/main/ipc/pty/runtime/kill.ts
@@ -4,6 +4,7 @@ import { parseAppSshPtyId } from '../../../providers/ssh-pty-id'
 import { ptyOwnership, ptyIncarnationById } from '../provider/ownership-state'
 import { getProvider, getProviderForPty } from '../provider/registry'
 import { isPtyAlreadyGoneError, delay, verifyPtyStopped } from '../provider/liveness'
+import { recordUndeliveredSshPtyKill } from './undelivered-ssh-kill'
 import type { PtyRuntimeControllerDeps } from './controller-deps'
 
 export function killPtyFromRuntimeController(
@@ -34,6 +35,8 @@ export function killPtyFromRuntimeController(
         // provider was unregistered. Tombstone the lease so reconnect does
         // not revive a terminal the user explicitly closed.
         const incarnationId = finishPtyShutdown(ptyId, connectionId, store)
+        // The relay was never asked, so the remote shell is still running. Keep the order.
+        recordUndeliveredSshPtyKill({ store, ptyId, connectionId, incarnationId })
         runtime?.onPtyExit(ptyId, -1, incarnationId)
         rememberSyntheticKillExit(ptyId)
         sendPtyExitToRenderer({
@@ -90,6 +93,9 @@ export function killPtyFromRuntimeController(
           }
           runtime?.onPtyExit(ptyId, -1, ptyIncarnationById.get(ptyId))
         }
+        // Outside the `retired` guard: the remote process outlives this client's bookkeeping
+        // either way, and the intent is what the next handshake replays.
+        recordUndeliveredSshPtyKill({ store, ptyId, connectionId })
       })
     return true
   }
@@ -109,6 +115,7 @@ export function killPtyFromRuntimeController(
         }
         runtime?.onPtyExit(ptyId, -1, ptyIncarnationById.get(ptyId))
       }
+      recordUndeliveredSshPtyKill({ store, ptyId, connectionId })
     })
     return true
   }
@@ -244,6 +251,7 @@ export async function stopAndWaitPtyFromRuntimeController(
       // Why: an absent SSH provider means there is no live target left to
       // await, but the relay lease must still be tombstoned.
       const incarnationId = finishPtyShutdown(ptyId, connectionId, store)
+      recordUndeliveredSshPtyKill({ store, ptyId, connectionId, incarnationId })
       runtime?.onPtyExit(ptyId, -1, incarnationId)
       rememberSyntheticKillExit(ptyId)
       sendPtyExitToRenderer({
@@ -273,12 +281,15 @@ export async function stopAndWaitPtyFromRuntimeController(
       console.warn(
         `[pty] Failed to stop PTY ${ptyId}: ${err instanceof Error ? err.message : String(err)}`
       )
+      recordUndeliveredSshPtyKill({ store, ptyId, connectionId })
       return false
     }
   }
   try {
     if (!(await verifyPtyStopped(provider, ptyId, opts))) {
       runtime?.markPtyLivenessLive?.(ptyId)
+      // The host still lists it, so the stop did not take. Same intent, replayed the same way.
+      recordUndeliveredSshPtyKill({ store, ptyId, connectionId })
       return false
     }
   } catch (err) {
@@ -293,6 +304,7 @@ export async function stopAndWaitPtyFromRuntimeController(
         err instanceof Error ? err.message : String(err)
       }`
     )
+    recordUndeliveredSshPtyKill({ store, ptyId, connectionId })
     return false
   }
   const incarnationId = finishPtyShutdown(ptyId, connectionId, store)

--- a/src/main/ipc/pty/runtime/kill.ts
+++ b/src/main/ipc/pty/runtime/kill.ts
@@ -19,12 +19,22 @@ export function killPtyFromRuntimeController(
     rememberSyntheticKillExit,
     sendPtyExitToRenderer,
     finishPtyShutdown,
-    retiredRejectedPtyIds
+    retiredRejectedPtyIds,
+    reversibleStopOwnersByPtyId
   } = deps
   runtime?.markPtyStopRequested?.(ptyId)
   let connectionId: string | null | undefined = ptyOwnership.get(ptyId)
   const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
   connectionId ??= parsedSshId?.connectionId
+  const recordUndelivered = (incarnationId?: string): void => {
+    recordUndeliveredSshPtyKill({
+      store,
+      ptyId,
+      connectionId,
+      reversible: reversibleStopOwnersByPtyId.has(ptyId),
+      incarnationId
+    })
+  }
   const killWithCurrentProvider = (): boolean => {
     let provider: IPtyProvider
     try {
@@ -36,7 +46,7 @@ export function killPtyFromRuntimeController(
         // not revive a terminal the user explicitly closed.
         const incarnationId = finishPtyShutdown(ptyId, connectionId, store)
         // The relay was never asked, so the remote shell is still running. Keep the order.
-        recordUndeliveredSshPtyKill(deps, ptyId, connectionId, incarnationId)
+        recordUndelivered(incarnationId)
         runtime?.onPtyExit(ptyId, -1, incarnationId)
         rememberSyntheticKillExit(ptyId)
         sendPtyExitToRenderer({
@@ -95,7 +105,7 @@ export function killPtyFromRuntimeController(
         }
         // Outside the `retired` guard: the remote process outlives this client's bookkeeping
         // either way, and the intent is what the next handshake replays.
-        recordUndeliveredSshPtyKill(deps, ptyId, connectionId)
+        recordUndelivered()
       })
     return true
   }
@@ -115,7 +125,7 @@ export function killPtyFromRuntimeController(
         }
         runtime?.onPtyExit(ptyId, -1, ptyIncarnationById.get(ptyId))
       }
-      recordUndeliveredSshPtyKill(deps, ptyId, connectionId)
+      recordUndelivered()
     })
     return true
   }

--- a/src/main/ipc/pty/runtime/undelivered-ssh-kill.ts
+++ b/src/main/ipc/pty/runtime/undelivered-ssh-kill.ts
@@ -1,38 +1,40 @@
-import type { Store } from '../../../persistence'
 import { ptyIncarnationById } from '../provider/ownership-state'
 import { getRelayPtyId } from '../provider/registry'
+import type { PtyRuntimeControllerDeps } from './controller-deps'
 
 /** Durably records a stop this client asked for on an SSH host and could not confirm, so the next
  *  handshake to that host can replay it. Without this the remote PTY — a child of the detached
  *  relay daemon, not of the ssh channel — outlives the failed RPC forever.
  *
- *  Silent no-ops are deliberate, not defensive padding:
- *  - no `connectionId`: a local PTY's owner is this process, so a failed kill has no later host to
- *    ask; there is nothing to replay against.
- *  - no incarnation: the replay fence is the host-minted PTY incarnation, and a relay renumbers
- *    from `pty-1` on every start. Recording an intent we could never safely aim would leave a kill
- *    order that can only be discarded, or worse, guessed at. */
-export function recordUndeliveredSshPtyKill(args: {
-  store: Store | undefined
-  ptyId: string
-  connectionId: string | null | undefined
-  /** Pass the value `finishPtyShutdown` returned: it clears the live map, so a caller that already
-   *  ran it can no longer look the incarnation up. */
-  incarnationId?: string
-  now?: number
-}): void {
-  const { store, ptyId, connectionId } = args
-  if (!store || !connectionId) {
+ *  The silent no-ops are the safety rules, not defensive padding:
+ *  - **no `connectionId`**: a local PTY's owner is this process, so a failed kill has no later host
+ *    to ask; there is nothing to replay against.
+ *  - **no incarnation**: the replay fence is the host-minted PTY incarnation, and a relay renumbers
+ *    from `pty-1` on every start. An order we could never safely aim can only be discarded later,
+ *    or worse, guessed at.
+ *  - **a reversible stop owns this PTY**: worktree sleep leaves the pane live and usable when a
+ *    stop does not land, so an order recorded here would come back on a later handshake and kill a
+ *    terminal the user had gone back to using. */
+export function recordUndeliveredSshPtyKill(
+  deps: Pick<PtyRuntimeControllerDeps, 'store' | 'reversibleStopOwnersByPtyId'>,
+  ptyId: string,
+  connectionId: string | null | undefined,
+  /** Pass what `finishPtyShutdown` returned: it clears the live map, so a caller that already ran
+   *  it can no longer look the incarnation up. */
+  incarnationId?: string,
+  now = Date.now()
+): void {
+  const { store } = deps
+  if (!store || !connectionId || deps.reversibleStopOwnersByPtyId.has(ptyId)) {
     return
   }
-  const incarnationId = args.incarnationId ?? ptyIncarnationById.get(ptyId)
-  if (!incarnationId) {
+  const incarnation = incarnationId ?? ptyIncarnationById.get(ptyId)
+  if (!incarnation) {
     return
   }
-  const now = args.now ?? Date.now()
   store.recordSshRemotePtyKillIntent(connectionId, getRelayPtyId(connectionId, ptyId), {
     requestedAt: now,
-    incarnationId,
+    incarnationId: incarnation,
     attempts: 0
   })
 }

--- a/src/main/ipc/pty/runtime/undelivered-ssh-kill.ts
+++ b/src/main/ipc/pty/runtime/undelivered-ssh-kill.ts
@@ -1,0 +1,38 @@
+import type { Store } from '../../../persistence'
+import { ptyIncarnationById } from '../provider/ownership-state'
+import { getRelayPtyId } from '../provider/registry'
+
+/** Durably records a stop this client asked for on an SSH host and could not confirm, so the next
+ *  handshake to that host can replay it. Without this the remote PTY — a child of the detached
+ *  relay daemon, not of the ssh channel — outlives the failed RPC forever.
+ *
+ *  Silent no-ops are deliberate, not defensive padding:
+ *  - no `connectionId`: a local PTY's owner is this process, so a failed kill has no later host to
+ *    ask; there is nothing to replay against.
+ *  - no incarnation: the replay fence is the host-minted PTY incarnation, and a relay renumbers
+ *    from `pty-1` on every start. Recording an intent we could never safely aim would leave a kill
+ *    order that can only be discarded, or worse, guessed at. */
+export function recordUndeliveredSshPtyKill(args: {
+  store: Store | undefined
+  ptyId: string
+  connectionId: string | null | undefined
+  /** Pass the value `finishPtyShutdown` returned: it clears the live map, so a caller that already
+   *  ran it can no longer look the incarnation up. */
+  incarnationId?: string
+  now?: number
+}): void {
+  const { store, ptyId, connectionId } = args
+  if (!store || !connectionId) {
+    return
+  }
+  const incarnationId = args.incarnationId ?? ptyIncarnationById.get(ptyId)
+  if (!incarnationId) {
+    return
+  }
+  const now = args.now ?? Date.now()
+  store.recordSshRemotePtyKillIntent(connectionId, getRelayPtyId(connectionId, ptyId), {
+    requestedAt: now,
+    incarnationId,
+    attempts: 0
+  })
+}

--- a/src/main/ipc/pty/runtime/undelivered-ssh-kill.ts
+++ b/src/main/ipc/pty/runtime/undelivered-ssh-kill.ts
@@ -1,40 +1,53 @@
+import type { Store } from '../../../persistence'
 import { ptyIncarnationById } from '../provider/ownership-state'
 import { getRelayPtyId } from '../provider/registry'
-import type { PtyRuntimeControllerDeps } from './controller-deps'
+
+export type UndeliveredSshPtyKill = {
+  store: Store | undefined
+  ptyId: string
+  connectionId: string | null | undefined
+  /** Whether this caller may still undo the stop. Every caller states it rather than having it
+   *  inferred, because both directions are bugs: `true` on a real close re-opens the leak, and
+   *  `false` on a reversible one lets a later handshake kill a pane the user went back to using.
+   *  Worktree sleep is the reversible case, on both the runtime and the renderer route. */
+  reversible: boolean
+  /** Pass what `finishPtyShutdown` returned: it clears the live map, so a caller that already ran
+   *  it can no longer look the incarnation up. */
+  incarnationId?: string
+  now?: number
+}
 
 /** Durably records a stop this client asked for on an SSH host and could not confirm, so the next
  *  handshake to that host can replay it. Without this the remote PTY — a child of the detached
  *  relay daemon, not of the ssh channel — outlives the failed RPC forever.
  *
  *  The silent no-ops are the safety rules, not defensive padding:
+ *  - **reversible**: see above.
  *  - **no `connectionId`**: a local PTY's owner is this process, so a failed kill has no later host
  *    to ask; there is nothing to replay against.
  *  - **no incarnation**: the replay fence is the host-minted PTY incarnation, and a relay renumbers
  *    from `pty-1` on every start. An order we could never safely aim can only be discarded later,
  *    or worse, guessed at.
- *  - **a reversible stop owns this PTY**: worktree sleep leaves the pane live and usable when a
- *    stop does not land, so an order recorded here would come back on a later handshake and kill a
- *    terminal the user had gone back to using. */
-export function recordUndeliveredSshPtyKill(
-  deps: Pick<PtyRuntimeControllerDeps, 'store' | 'reversibleStopOwnersByPtyId'>,
-  ptyId: string,
-  connectionId: string | null | undefined,
-  /** Pass what `finishPtyShutdown` returned: it clears the live map, so a caller that already ran
-   *  it can no longer look the incarnation up. */
-  incarnationId?: string,
-  now = Date.now()
-): void {
-  const { store } = deps
-  if (!store || !connectionId || deps.reversibleStopOwnersByPtyId.has(ptyId)) {
+ *  - **an id naming another connection**: `getRelayPtyId` throws on those, and this runs inside
+ *    promise `.catch` handlers where that would surface as an unhandled rejection. */
+export function recordUndeliveredSshPtyKill(args: UndeliveredSshPtyKill): void {
+  const { store, ptyId, connectionId } = args
+  if (!store || !connectionId || args.reversible) {
     return
   }
-  const incarnation = incarnationId ?? ptyIncarnationById.get(ptyId)
-  if (!incarnation) {
+  const incarnationId = args.incarnationId ?? ptyIncarnationById.get(ptyId)
+  if (!incarnationId) {
     return
   }
-  store.recordSshRemotePtyKillIntent(connectionId, getRelayPtyId(connectionId, ptyId), {
-    requestedAt: now,
-    incarnationId: incarnation,
+  let relayPtyId: string
+  try {
+    relayPtyId = getRelayPtyId(connectionId, ptyId)
+  } catch {
+    return
+  }
+  store.recordSshRemotePtyKillIntent(connectionId, relayPtyId, {
+    requestedAt: args.now ?? Date.now(),
+    incarnationId,
     attempts: 0
   })
 }

--- a/src/main/ipc/ssh-ipc-test-harness.ts
+++ b/src/main/ipc/ssh-ipc-test-harness.ts
@@ -32,6 +32,7 @@ export type SshLeaseStoreMock = {
   markSshRemotePtyLeasesAttachedAsync: Mock
   removeSshRemotePtyLeases: Mock
   getSshRemotePtyKillIntents: Mock
+  pruneExpiredSshRemotePtyKillIntents: Mock
   recordSshRemotePtyKillIntent: Mock
   clearSshRemotePtyKillIntent: Mock
   noteSshRemotePtyKillReplayAttempt: Mock
@@ -108,6 +109,7 @@ export function createSshIpcHarness(mocks: SshIpcMocks): SshIpcHarness {
     markSshRemotePtyLeasesAttachedAsync: vi.fn(),
     removeSshRemotePtyLeases: vi.fn(),
     getSshRemotePtyKillIntents: vi.fn().mockReturnValue([]),
+    pruneExpiredSshRemotePtyKillIntents: vi.fn(),
     recordSshRemotePtyKillIntent: vi.fn(),
     clearSshRemotePtyKillIntent: vi.fn(),
     noteSshRemotePtyKillReplayAttempt: vi.fn()

--- a/src/main/ipc/ssh-ipc-test-harness.ts
+++ b/src/main/ipc/ssh-ipc-test-harness.ts
@@ -31,6 +31,10 @@ export type SshLeaseStoreMock = {
   markSshRemotePtyLeasesForShutdown: Mock
   markSshRemotePtyLeasesAttachedAsync: Mock
   removeSshRemotePtyLeases: Mock
+  getSshRemotePtyKillIntents: Mock
+  recordSshRemotePtyKillIntent: Mock
+  clearSshRemotePtyKillIntent: Mock
+  noteSshRemotePtyKillReplayAttempt: Mock
 }
 
 export type MockBrowserWindow = { isDestroyed: () => boolean; webContents: { send: Mock } }
@@ -102,7 +106,11 @@ export function createSshIpcHarness(mocks: SshIpcMocks): SshIpcHarness {
     markSshRemotePtyLeasesAsync: vi.fn(),
     markSshRemotePtyLeasesForShutdown: vi.fn(),
     markSshRemotePtyLeasesAttachedAsync: vi.fn(),
-    removeSshRemotePtyLeases: vi.fn()
+    removeSshRemotePtyLeases: vi.fn(),
+    getSshRemotePtyKillIntents: vi.fn().mockReturnValue([]),
+    recordSshRemotePtyKillIntent: vi.fn(),
+    clearSshRemotePtyKillIntent: vi.fn(),
+    noteSshRemotePtyKillReplayAttempt: vi.fn()
   }
   const mockWindow = {
     isDestroyed: () => false,

--- a/src/main/persistence-ssh-pending-pty-kill.test.ts
+++ b/src/main/persistence-ssh-pending-pty-kill.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { rmSync, mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { testState, createStore } from './persistence-test-harness'
+import {
+  MAX_SSH_PENDING_PTY_KILLS_PER_TARGET,
+  SSH_PENDING_PTY_KILL_TTL_MS
+} from '../shared/ssh-pending-pty-kill'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (plaintext: string) => Buffer.from(plaintext, 'utf-8'),
+    decryptString: (ciphertext: Buffer) => ciphertext.toString('utf-8')
+  }
+}))
+
+vi.mock('./telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('./telemetry/cohort-classifier', () => ({ getCohortAtEmit: vi.fn(() => ({})) }))
+
+const NOW = 1_800_000_000_000
+
+describe('Store SSH pending PTY kills', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  // The whole point of the record: a laptop closed mid-failure must not lose the kill order.
+  it('survives an app restart', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-1', state: 'attached' })
+    store.recordSshRemotePtyKillIntent('ssh-1', 'pty-1', {
+      requestedAt: NOW,
+      incarnationId: 'inc-a',
+      attempts: 0
+    })
+    store.flush()
+
+    const reloaded = await createStore()
+    expect(reloaded.getSshRemotePtyKillIntents('ssh-1', NOW)).toEqual([
+      { ptyId: 'pty-1', intent: { requestedAt: NOW, incarnationId: 'inc-a', attempts: 0 } }
+    ])
+  })
+
+  // A kill issued while the provider was already unregistered writes no lease of its own, and that
+  // offline close is the case most likely to strand a remote shell.
+  it('records an intent for a PTY that has no lease row yet', async () => {
+    const store = await createStore()
+    store.recordSshRemotePtyKillIntent('ssh-1', 'pty-9', {
+      requestedAt: NOW,
+      incarnationId: 'inc-z',
+      attempts: 0
+    })
+    store.flush()
+
+    const reloaded = await createStore()
+    expect(reloaded.getSshRemotePtyKillIntents('ssh-1', NOW).map((e) => e.ptyId)).toEqual(['pty-9'])
+  })
+
+  it('keeps an intent on a lease its own kill path tombstoned as terminated', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-1', state: 'attached' })
+    store.markSshRemotePtyLease('ssh-1', 'pty-1', 'terminated')
+    store.recordSshRemotePtyKillIntent('ssh-1', 'pty-1', {
+      requestedAt: NOW,
+      incarnationId: 'inc-a',
+      attempts: 0
+    })
+
+    expect(store.getSshRemotePtyKillIntents('ssh-1', NOW)).toHaveLength(1)
+  })
+
+  it('retires an intent without touching the lease state', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-1', state: 'attached' })
+    store.recordSshRemotePtyKillIntent('ssh-1', 'pty-1', {
+      requestedAt: NOW,
+      incarnationId: 'inc-a',
+      attempts: 0
+    })
+    store.clearSshRemotePtyKillIntent('ssh-1', 'pty-1')
+    store.flush()
+
+    const reloaded = await createStore()
+    expect(reloaded.getSshRemotePtyKillIntents('ssh-1', NOW)).toEqual([])
+    expect(reloaded.getSshRemotePtyLeases('ssh-1')[0]?.state).toBe('attached')
+  })
+
+  it('drops intents past the TTL on read', async () => {
+    const store = await createStore()
+    store.recordSshRemotePtyKillIntent('ssh-1', 'pty-1', {
+      requestedAt: NOW,
+      incarnationId: 'inc-a',
+      attempts: 0
+    })
+    expect(
+      store.getSshRemotePtyKillIntents('ssh-1', NOW + SSH_PENDING_PTY_KILL_TTL_MS)
+    ).toHaveLength(1)
+    expect(
+      store.getSshRemotePtyKillIntents('ssh-1', NOW + SSH_PENDING_PTY_KILL_TTL_MS + 1)
+    ).toEqual([])
+  })
+
+  it('caps pending kills per target so an unreachable host cannot grow the store', async () => {
+    const store = await createStore()
+    const total = MAX_SSH_PENDING_PTY_KILLS_PER_TARGET + 50
+    for (let index = 0; index < total; index++) {
+      store.recordSshRemotePtyKillIntent('ssh-1', `pty-${index}`, {
+        requestedAt: NOW + index,
+        incarnationId: `inc-${index}`,
+        attempts: 0
+      })
+    }
+    store.flush()
+
+    const reloaded = await createStore()
+    const persisted = reloaded
+      .getSshRemotePtyLeases('ssh-1')
+      .filter((lease) => lease.pendingKill !== undefined)
+    expect(persisted).toHaveLength(MAX_SSH_PENDING_PTY_KILLS_PER_TARGET)
+    // Newest kept: the oldest orders are the ones least likely to still name a live process.
+    expect(persisted.some((lease) => lease.ptyId === `pty-${total - 1}`)).toBe(true)
+    expect(persisted.some((lease) => lease.ptyId === 'pty-0')).toBe(false)
+  })
+
+  it('does not let a repeated close extend the TTL, and carries attempts forward', async () => {
+    const store = await createStore()
+    store.recordSshRemotePtyKillIntent('ssh-1', 'pty-1', {
+      requestedAt: NOW,
+      incarnationId: 'inc-a',
+      attempts: 0
+    })
+    store.noteSshRemotePtyKillReplayAttempt('ssh-1', 'pty-1')
+    store.recordSshRemotePtyKillIntent('ssh-1', 'pty-1', {
+      requestedAt: NOW + 5000,
+      incarnationId: 'inc-a',
+      attempts: 0
+    })
+
+    expect(store.getSshRemotePtyKillIntents('ssh-1', NOW)[0]?.intent).toEqual({
+      requestedAt: NOW,
+      incarnationId: 'inc-a',
+      attempts: 1
+    })
+  })
+
+  it('scopes intents to their own target', async () => {
+    const store = await createStore()
+    store.recordSshRemotePtyKillIntent('ssh-1', 'pty-1', {
+      requestedAt: NOW,
+      incarnationId: 'inc-a',
+      attempts: 0
+    })
+    expect(store.getSshRemotePtyKillIntents('ssh-2', NOW)).toEqual([])
+  })
+})

--- a/src/main/persistence-ssh-pending-pty-kill.test.ts
+++ b/src/main/persistence-ssh-pending-pty-kill.test.ts
@@ -63,6 +63,53 @@ describe('Store SSH pending PTY kills', () => {
     expect(reloaded.getSshRemotePtyKillIntents('ssh-1', NOW).map((e) => e.ptyId)).toEqual(['pty-9'])
   })
 
+  // The row it invents must not be reattachable: the user closed this PTY, and reattach fences only
+  // on paneKey/tabId — neither of which a row created here carries.
+  it('creates the missing lease terminated so reattach cannot adopt it', async () => {
+    const store = await createStore()
+    store.recordSshRemotePtyKillIntent('ssh-1', 'pty-9', {
+      requestedAt: NOW,
+      incarnationId: 'inc-z',
+      attempts: 0
+    })
+
+    const lease = store.getSshRemotePtyLeases('ssh-1')[0]
+    expect(lease?.state).toBe('terminated')
+    expect(lease?.tabId).toBeUndefined()
+    expect(lease?.leafId).toBeUndefined()
+  })
+
+  it('deletes expired intents durably rather than only filtering them on read', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-1', state: 'attached' })
+    store.recordSshRemotePtyKillIntent('ssh-1', 'pty-1', {
+      requestedAt: NOW,
+      incarnationId: 'inc-a',
+      attempts: 0
+    })
+    store.pruneExpiredSshRemotePtyKillIntents('ssh-1', NOW + SSH_PENDING_PTY_KILL_TTL_MS + 1)
+    store.flush()
+
+    const reloaded = await createStore()
+    expect(reloaded.getSshRemotePtyLeases('ssh-1')[0]?.pendingKill).toBeUndefined()
+    // Ageing out observes nothing about the process, so the lease state is left exactly as it was.
+    expect(reloaded.getSshRemotePtyLeases('ssh-1')[0]?.state).toBe('attached')
+  })
+
+  it('leaves an intent that is still inside its TTL alone', async () => {
+    const store = await createStore()
+    store.recordSshRemotePtyKillIntent('ssh-1', 'pty-1', {
+      requestedAt: NOW,
+      incarnationId: 'inc-a',
+      attempts: 0
+    })
+    store.pruneExpiredSshRemotePtyKillIntents('ssh-1', NOW + SSH_PENDING_PTY_KILL_TTL_MS)
+
+    expect(store.getSshRemotePtyKillIntents('ssh-1', NOW)).toHaveLength(1)
+  })
+
+  // The replay reads every lease state on purpose: the close path tombstones the lease locally and
+  // the remote process is still running, so a terminated lease is exactly where an order lives.
   it('keeps an intent on a lease its own kill path tombstoned as terminated', async () => {
     const store = await createStore()
     store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-1', state: 'attached' })

--- a/src/main/persistence/leasing-ssh-ptys/ssh-normalization.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-normalization.ts
@@ -4,6 +4,7 @@ import type {
   SshTarget
 } from '../../../shared/ssh-types'
 import { LEGACY_DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS } from '../../../shared/ssh-types'
+import { normalizeSshPendingPtyKill } from '../../../shared/ssh-pending-pty-kill'
 
 export type LegacySshTarget = SshTarget & {
   remoteWorkspaceSyncEnabled?: unknown
@@ -60,9 +61,11 @@ export function normalizeSshRemotePtyLease(value: unknown): SshRemotePtyLease | 
     return null
   }
   const now = Date.now()
+  const pendingKill = normalizeSshPendingPtyKill(raw.pendingKill)
   return {
     targetId: raw.targetId,
     ptyId: raw.ptyId,
+    ...(pendingKill ? { pendingKill } : {}),
     ...(typeof raw.worktreeId === 'string' ? { worktreeId: raw.worktreeId } : {}),
     ...(typeof raw.tabId === 'string' ? { tabId: raw.tabId } : {}),
     ...(typeof raw.leafId === 'string' && raw.leafId.length <= 256 ? { leafId: raw.leafId } : {}),

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-kill-intent-operations.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-kill-intent-operations.ts
@@ -1,6 +1,7 @@
 import type { PersistedState } from '../../../shared/persisted-state-types'
 import {
   MAX_SSH_PENDING_PTY_KILLS_PER_TARGET,
+  isSshPendingPtyKillExpired,
   pendingSshPtyKillEntries,
   prunePendingSshPtyKills,
   type SshPendingPtyKill,
@@ -18,6 +19,33 @@ export function getSshRemotePtyKillIntents(
 ): SshPendingPtyKillEntry[] {
   const leases = (state.sshRemotePtyLeases ?? []).filter((lease) => lease.targetId === targetId)
   return prunePendingSshPtyKills(pendingSshPtyKillEntries(leases), now)
+}
+
+/** Deletes orders past their TTL, durably.
+ *
+ *  The read path filters them out too, but filtering alone would leave the field on disk forever
+ *  and make the cap the only thing that ever reclaimed it. This is the TTL retirement path, and it
+ *  deliberately leaves `state` alone: an order aging out observes nothing about the process. */
+export function pruneExpiredSshRemotePtyKillIntents(
+  operations: SshPtyLeaseOperations,
+  targetId: string,
+  now: number
+): void {
+  let changed = false
+  for (const lease of operations.state.sshRemotePtyLeases ?? []) {
+    if (
+      lease.targetId === targetId &&
+      lease.pendingKill &&
+      isSshPendingPtyKillExpired(lease.pendingKill, now)
+    ) {
+      delete lease.pendingKill
+      lease.updatedAt = now
+      changed = true
+    }
+  }
+  if (changed) {
+    operations.flush()
+  }
 }
 
 /** Drops the oldest intents past the cap so an unreachable target cannot grow the store. Runs over
@@ -45,8 +73,10 @@ function capPendingKillsForTarget(
 /** Records a stop this client asked for and could not confirm.
  *
  *  Creates the lease when none exists — a kill that found no provider registered writes no lease of
- *  its own, and that offline close is the case most likely to strand a remote process. The state is
- *  `attached` because that is the client's honest belief: the host may still be running it. */
+ *  its own, and that offline close is the case most likely to strand a remote process. It is
+ *  created `terminated`, carrying no pane identity, because the user closed this PTY: reattach must
+ *  not adopt it. That is a routing tombstone and not a claim the process died — the process
+ *  question is exactly what `pendingKill` is now tracking, and the replay reads every lease state. */
 export function recordSshRemotePtyKillIntent(
   operations: SshPtyLeaseOperations,
   targetId: string,
@@ -71,7 +101,7 @@ export function recordSshRemotePtyKillIntent(
     leases.push({
       targetId,
       ptyId: relayPtyId,
-      state: 'attached',
+      state: 'terminated',
       createdAt: now,
       updatedAt: now,
       pendingKill: intent

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-kill-intent-operations.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-kill-intent-operations.ts
@@ -1,0 +1,120 @@
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import {
+  MAX_SSH_PENDING_PTY_KILLS_PER_TARGET,
+  pendingSshPtyKillEntries,
+  prunePendingSshPtyKills,
+  type SshPendingPtyKill,
+  type SshPendingPtyKillEntry
+} from '../../../shared/ssh-pending-pty-kill'
+import type { SshRemotePtyLease } from '../../../shared/ssh-types'
+import type { SshPtyLeaseOperations } from './ssh-pty-lease-operations'
+
+/** Every recorded-but-undelivered stop for a target, newest first, TTL-filtered and capped.
+ *  Returned with stored (target-local) relay pty ids, which is what `pty.shutdown` takes. */
+export function getSshRemotePtyKillIntents(
+  state: PersistedState,
+  targetId: string,
+  now: number
+): SshPendingPtyKillEntry[] {
+  const leases = (state.sshRemotePtyLeases ?? []).filter((lease) => lease.targetId === targetId)
+  return prunePendingSshPtyKills(pendingSshPtyKillEntries(leases), now)
+}
+
+/** Drops the oldest intents past the cap so an unreachable target cannot grow the store. Runs over
+ *  the whole target rather than the arriving id, because the cap is what bounds the target. */
+function capPendingKillsForTarget(
+  leases: SshRemotePtyLease[],
+  targetId: string,
+  now: number
+): void {
+  const scoped = leases.filter((lease) => lease.targetId === targetId && lease.pendingKill)
+  if (scoped.length <= MAX_SSH_PENDING_PTY_KILLS_PER_TARGET) {
+    return
+  }
+  const kept = new Set(
+    prunePendingSshPtyKills(pendingSshPtyKillEntries(scoped), now).map((entry) => entry.ptyId)
+  )
+  for (const lease of scoped) {
+    if (!kept.has(lease.ptyId)) {
+      delete lease.pendingKill
+      lease.updatedAt = now
+    }
+  }
+}
+
+/** Records a stop this client asked for and could not confirm.
+ *
+ *  Creates the lease when none exists — a kill that found no provider registered writes no lease of
+ *  its own, and that offline close is the case most likely to strand a remote process. The state is
+ *  `attached` because that is the client's honest belief: the host may still be running it. */
+export function recordSshRemotePtyKillIntent(
+  operations: SshPtyLeaseOperations,
+  targetId: string,
+  ptyId: string,
+  intent: SshPendingPtyKill
+): void {
+  const relayPtyId = operations.toStoredPtyId(targetId, ptyId)
+  const now = intent.requestedAt
+  operations.state.sshRemotePtyLeases ??= []
+  const leases = operations.state.sshRemotePtyLeases
+  const existing = leases.find((entry) => entry.targetId === targetId && entry.ptyId === relayPtyId)
+  if (existing) {
+    // Why keep the earliest requestedAt: the TTL bounds how long the intent may chase the host, and
+    // a repeated close must not extend it. Attempts carry over so replays stay countable.
+    existing.pendingKill = {
+      ...intent,
+      requestedAt: Math.min(existing.pendingKill?.requestedAt ?? now, now),
+      attempts: existing.pendingKill?.attempts ?? intent.attempts
+    }
+    existing.updatedAt = now
+  } else {
+    leases.push({
+      targetId,
+      ptyId: relayPtyId,
+      state: 'attached',
+      createdAt: now,
+      updatedAt: now,
+      pendingKill: intent
+    })
+  }
+  capPendingKillsForTarget(leases, targetId, now)
+  operations.flush()
+}
+
+/** Retires the intent. Deliberately does not touch `state`: the caller decides whether it earned a
+ *  `terminated` tombstone, because only some retirement paths observed the host. */
+export function clearSshRemotePtyKillIntent(
+  operations: SshPtyLeaseOperations,
+  targetId: string,
+  ptyId: string
+): void {
+  const relayPtyId = operations.toStoredPtyId(targetId, ptyId)
+  const lease = (operations.state.sshRemotePtyLeases ?? []).find(
+    (entry) => entry.targetId === targetId && entry.ptyId === relayPtyId
+  )
+  if (!lease?.pendingKill) {
+    return
+  }
+  delete lease.pendingKill
+  lease.updatedAt = Date.now()
+  operations.flush()
+}
+
+/** Counts one replay against the intent so a target that never answers stays visible in the record
+ *  without changing what it is allowed to do. */
+export function noteSshRemotePtyKillReplayAttempt(
+  operations: SshPtyLeaseOperations,
+  targetId: string,
+  ptyId: string
+): void {
+  const relayPtyId = operations.toStoredPtyId(targetId, ptyId)
+  const lease = (operations.state.sshRemotePtyLeases ?? []).find(
+    (entry) => entry.targetId === targetId && entry.ptyId === relayPtyId
+  )
+  if (!lease?.pendingKill) {
+    return
+  }
+  lease.pendingKill = { ...lease.pendingKill, attempts: lease.pendingKill.attempts + 1 }
+  lease.updatedAt = Date.now()
+  operations.flush()
+}

--- a/src/main/persistence/loading-store/ssh-lease-recovery-operations.ts
+++ b/src/main/persistence/loading-store/ssh-lease-recovery-operations.ts
@@ -1,4 +1,14 @@
+import type {
+  SshPendingPtyKill,
+  SshPendingPtyKillEntry
+} from '../../../shared/ssh-pending-pty-kill'
 import type { SshPtyConsumerRecovery, SshRemotePtyLease } from '../../../shared/ssh-types'
+import {
+  clearSshRemotePtyKillIntent as clearSshRemotePtyKillIntentOperation,
+  getSshRemotePtyKillIntents as getSshRemotePtyKillIntentsOperation,
+  noteSshRemotePtyKillReplayAttempt as noteSshRemotePtyKillReplayAttemptOperation,
+  recordSshRemotePtyKillIntent as recordSshRemotePtyKillIntentOperation
+} from '../leasing-ssh-ptys/ssh-pty-kill-intent-operations'
 import {
   getSshRemotePtyLeases as getSshRemotePtyLeasesOperation,
   markSshRemotePtyLease as markSshRemotePtyLeaseOperation,
@@ -119,6 +129,26 @@ export class SshLeaseRecoveryOperations {
 
   removeSshRemotePtyLeases(targetId: string): void {
     removeSshRemotePtyLeasesOperation(getSshPtyLeaseOperations(this), targetId)
+  }
+
+  getSshRemotePtyKillIntents(targetId: string, now = Date.now()): SshPendingPtyKillEntry[] {
+    return getSshRemotePtyKillIntentsOperation(
+      this[sshLeaseRecoveryOperationsContext].runtime.state,
+      targetId,
+      now
+    )
+  }
+
+  recordSshRemotePtyKillIntent(targetId: string, ptyId: string, intent: SshPendingPtyKill): void {
+    recordSshRemotePtyKillIntentOperation(getSshPtyLeaseOperations(this), targetId, ptyId, intent)
+  }
+
+  clearSshRemotePtyKillIntent(targetId: string, ptyId: string): void {
+    clearSshRemotePtyKillIntentOperation(getSshPtyLeaseOperations(this), targetId, ptyId)
+  }
+
+  noteSshRemotePtyKillReplayAttempt(targetId: string, ptyId: string): void {
+    noteSshRemotePtyKillReplayAttemptOperation(getSshPtyLeaseOperations(this), targetId, ptyId)
   }
 }
 

--- a/src/main/persistence/loading-store/ssh-lease-recovery-operations.ts
+++ b/src/main/persistence/loading-store/ssh-lease-recovery-operations.ts
@@ -7,6 +7,7 @@ import {
   clearSshRemotePtyKillIntent as clearSshRemotePtyKillIntentOperation,
   getSshRemotePtyKillIntents as getSshRemotePtyKillIntentsOperation,
   noteSshRemotePtyKillReplayAttempt as noteSshRemotePtyKillReplayAttemptOperation,
+  pruneExpiredSshRemotePtyKillIntents as pruneExpiredSshRemotePtyKillIntentsOperation,
   recordSshRemotePtyKillIntent as recordSshRemotePtyKillIntentOperation
 } from '../leasing-ssh-ptys/ssh-pty-kill-intent-operations'
 import {
@@ -149,6 +150,10 @@ export class SshLeaseRecoveryOperations {
 
   noteSshRemotePtyKillReplayAttempt(targetId: string, ptyId: string): void {
     noteSshRemotePtyKillReplayAttemptOperation(getSshPtyLeaseOperations(this), targetId, ptyId)
+  }
+
+  pruneExpiredSshRemotePtyKillIntents(targetId: string, now = Date.now()): void {
+    pruneExpiredSshRemotePtyKillIntentsOperation(getSshPtyLeaseOperations(this), targetId, now)
   }
 }
 

--- a/src/main/ssh/ssh-pending-pty-kill-replay.test.ts
+++ b/src/main/ssh/ssh-pending-pty-kill-replay.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { replayPendingSshPtyKills } from './ssh-pending-pty-kill-replay'
 import { SshPtyAbsentFromRelayError } from '../providers/ssh-pty-errors'
 import type { SshPendingPtyKillEntry } from '../../shared/ssh-pending-pty-kill'
-import { SSH_PENDING_PTY_KILL_TTL_MS } from '../../shared/ssh-pending-pty-kill'
+import {
+  isSshPendingPtyKillExpired,
+  prunePendingSshPtyKills,
+  SSH_PENDING_PTY_KILL_TTL_MS
+} from '../../shared/ssh-pending-pty-kill'
 import type { Store } from '../persistence'
 import type { IPtyProvider } from '../providers/types'
 
@@ -11,30 +15,52 @@ const NOW = 1_800_000_000_000
 
 type HostPty = { relayPtyId: string; incarnationId?: string }
 
+/** Models the real store rather than returning a fixed list: `getSshRemotePtyKillIntents` applies
+ *  the same TTL filter production does, and the prune actually deletes. A stub that ignored `now`
+ *  would make every TTL assertion below pass for the wrong reason. */
 function createStoreStub(entries: SshPendingPtyKillEntry[]): {
   store: Store
   cleared: string[]
   terminated: string[]
+  expired: string[]
   attempts: string[]
+  remaining: () => string[]
 } {
+  let backing = [...entries]
   const cleared: string[] = []
   const terminated: string[] = []
+  const expired: string[] = []
   const attempts: string[] = []
   const store = {
-    getSshRemotePtyKillIntents: vi.fn(() => entries),
+    getSshRemotePtyKillIntents: vi.fn((_target: string, now: number) =>
+      prunePendingSshPtyKills(backing, now)
+    ),
+    pruneExpiredSshRemotePtyKillIntents: vi.fn((_target: string, now: number) => {
+      backing = backing.filter((item) => !isSshPendingPtyKillExpired(item.intent, now))
+    }),
     clearSshRemotePtyKillIntent: vi.fn((_target: string, ptyId: string) => {
+      backing = backing.filter((item) => item.ptyId !== ptyId)
       cleared.push(ptyId)
     }),
     markSshRemotePtyLease: vi.fn((_target: string, ptyId: string, state: string) => {
       if (state === 'terminated') {
         terminated.push(ptyId)
+      } else if (state === 'expired') {
+        expired.push(ptyId)
       }
     }),
     noteSshRemotePtyKillReplayAttempt: vi.fn((_target: string, ptyId: string) => {
       attempts.push(ptyId)
     })
   } as unknown as Store
-  return { store, cleared, terminated, attempts }
+  return {
+    store,
+    cleared,
+    terminated,
+    expired,
+    attempts,
+    remaining: () => backing.map((item) => item.ptyId)
+  }
 }
 
 /** A relay that lists `hostPtys`, and drops an id from that listing once it is shut down. */
@@ -98,8 +124,8 @@ describe('replayPendingSshPtyKills', () => {
   })
 
   // #16970: a redeployed relay renumbers from pty-1, so this id now names someone else's shell.
-  it('refuses to kill a recycled relay id and retires the order instead', async () => {
-    const { store, cleared, terminated } = createStoreStub([entry('pty-1', 'inc-a')])
+  it('refuses to kill a recycled relay id and expires the lease that named it', async () => {
+    const { store, cleared, terminated, expired } = createStoreStub([entry('pty-1', 'inc-a')])
     const { provider, shutdown } = createProviderStub([
       { relayPtyId: 'pty-1', incarnationId: 'inc-fresh' }
     ])
@@ -112,7 +138,10 @@ describe('replayPendingSshPtyKills', () => {
     })
     expect(shutdown).not.toHaveBeenCalled()
     expect(cleared).toEqual(['pty-1'])
-    // No tombstone: nothing observed the PTY this order was aimed at, either way.
+    // Declining to kill is only half of it: the reattach one step later fences on paneKey/tabId and
+    // never on incarnation, so an untouched lease would bind the user's old pane to that stranger.
+    expect(expired).toEqual(['pty-1'])
+    // `expired`, not `terminated` — losing the route is not evidence the shell died.
     expect(terminated).toEqual([])
   })
 
@@ -133,9 +162,14 @@ describe('replayPendingSshPtyKills', () => {
     expect(terminated).toEqual(['pty-1'])
   })
 
-  it('retires an order past its TTL without aiming it at whatever holds the id now', async () => {
-    const { store, cleared, terminated } = createStoreStub([entry('pty-1', 'inc-a')])
-    const { provider, shutdown } = createProviderStub([
+  // The TTL is owned by the durable prune, not by a branch in the decision function. This asserts
+  // the order is actually deleted and never aimed at whatever holds the id now — and it can only
+  // pass if the prune honours `now`, because the store stub applies the real TTL rules.
+  it('deletes an order past its TTL instead of replaying it, and never touches the host', async () => {
+    const { store, cleared, terminated, expired, remaining } = createStoreStub([
+      entry('pty-1', 'inc-a')
+    ])
+    const { provider, shutdown, listProcesses } = createProviderStub([
       { relayPtyId: 'pty-1', incarnationId: 'inc-a' }
     ])
     await replayPendingSshPtyKills({
@@ -145,13 +179,19 @@ describe('replayPendingSshPtyKills', () => {
       shouldContinue: () => true,
       now: () => NOW + SSH_PENDING_PTY_KILL_TTL_MS + 1
     })
+    expect(remaining()).toEqual([])
     expect(shutdown).not.toHaveBeenCalled()
-    expect(cleared).toEqual(['pty-1'])
+    expect(listProcesses).not.toHaveBeenCalled()
+    // Ageing out observes nothing, so it may not move the lease either way.
+    expect(cleared).toEqual([])
     expect(terminated).toEqual([])
+    expect(expired).toEqual([])
   })
 
-  it('retires when the replayed stop is answered with absence from the relay', async () => {
-    const { store, cleared, terminated } = createStoreStub([entry('pty-1', 'inc-a')])
+  // #16763's lesson: `isPtyAlreadyGoneError` matches message text such as /Session not found/i,
+  // which a transport failure could wear. A tombstone must never rest on that — only on a listing.
+  it('does not tombstone on a shutdown error that merely looks like absence', async () => {
+    const { store, cleared, terminated, remaining } = createStoreStub([entry('pty-1', 'inc-a')])
     const { provider } = createProviderStub([{ relayPtyId: 'pty-1', incarnationId: 'inc-a' }], {
       shutdown: vi.fn(async () => {
         throw new SshPtyAbsentFromRelayError('SSH_SESSION_EXPIRED: pty-1')
@@ -164,8 +204,44 @@ describe('replayPendingSshPtyKills', () => {
       shouldContinue: () => true,
       now: () => NOW
     })
-    expect(cleared).toEqual(['pty-1'])
-    expect(terminated).toEqual(['pty-1'])
+    expect(cleared).toEqual([])
+    expect(terminated).toEqual([])
+    expect(remaining()).toEqual(['pty-1'])
+  })
+
+  // Best-effort background work on the connect path: a disk hiccup must not fail the connection.
+  it('never rejects into its caller when persistence throws', async () => {
+    const { store } = createStoreStub([entry('pty-1', 'inc-a')])
+    vi.mocked(store.noteSshRemotePtyKillReplayAttempt).mockImplementation(() => {
+      throw new Error('disk full')
+    })
+    const { provider } = createProviderStub([{ relayPtyId: 'pty-1', incarnationId: 'inc-a' }])
+    await expect(
+      replayPendingSshPtyKills({
+        targetId: TARGET,
+        store,
+        provider,
+        shouldContinue: () => true,
+        now: () => NOW
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('never rejects into its caller when the very first store read throws', async () => {
+    const { store } = createStoreStub([entry('pty-1', 'inc-a')])
+    vi.mocked(store.pruneExpiredSshRemotePtyKillIntents).mockImplementation(() => {
+      throw new Error('disk full')
+    })
+    const { provider } = createProviderStub([{ relayPtyId: 'pty-1', incarnationId: 'inc-a' }])
+    await expect(
+      replayPendingSshPtyKills({
+        targetId: TARGET,
+        store,
+        provider,
+        shouldContinue: () => true,
+        now: () => NOW
+      })
+    ).resolves.toBeUndefined()
   })
 
   it('keeps the order when the replayed stop is itself unverifiable', async () => {
@@ -259,8 +335,9 @@ describe('replayPendingSshPtyKills', () => {
     expect(cleared).toEqual([])
   })
 
-  // One inventory to fence the batch, one to prove it — not two per order, on the connect path.
-  it('costs two inventory round trips however many stops are pending', async () => {
+  // Bounded by wave, not by order: one inventory per wave of 4 plus one to prove the batch. The
+  // per-wave read is what keeps a stop's identity evidence within one round trip of the stop.
+  it('reads one inventory per wave plus one to confirm, not two per pending stop', async () => {
     const pending = Array.from({ length: 12 }, (_, index) => entry(`pty-${index}`, `inc-${index}`))
     const { store, terminated } = createStoreStub(pending)
     const { provider, listProcesses, shutdown } = createProviderStub(
@@ -274,7 +351,22 @@ describe('replayPendingSshPtyKills', () => {
       now: () => NOW
     })
     expect(shutdown).toHaveBeenCalledTimes(12)
-    expect(listProcesses).toHaveBeenCalledTimes(2)
+    expect(listProcesses).toHaveBeenCalledTimes(12 / 4 + 1)
     expect(terminated).toHaveLength(12)
+  })
+
+  it('costs one inventory and one confirmation for a single pending stop', async () => {
+    const { store } = createStoreStub([entry('pty-1', 'inc-a')])
+    const { provider, listProcesses } = createProviderStub([
+      { relayPtyId: 'pty-1', incarnationId: 'inc-a' }
+    ])
+    await replayPendingSshPtyKills({
+      targetId: TARGET,
+      store,
+      provider,
+      shouldContinue: () => true,
+      now: () => NOW
+    })
+    expect(listProcesses).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/ssh/ssh-pending-pty-kill-replay.test.ts
+++ b/src/main/ssh/ssh-pending-pty-kill-replay.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { replayPendingSshPtyKills } from './ssh-pending-pty-kill-replay'
+import { SshPtyAbsentFromRelayError } from '../providers/ssh-pty-errors'
+import type { SshPendingPtyKillEntry } from '../../shared/ssh-pending-pty-kill'
+import { SSH_PENDING_PTY_KILL_TTL_MS } from '../../shared/ssh-pending-pty-kill'
+import type { Store } from '../persistence'
+import type { IPtyProvider } from '../providers/types'
+
+const TARGET = 'ssh-1'
+const NOW = 1_800_000_000_000
+
+type HostPty = { relayPtyId: string; incarnationId?: string }
+
+function createStoreStub(entries: SshPendingPtyKillEntry[]): {
+  store: Store
+  cleared: string[]
+  terminated: string[]
+  attempts: string[]
+} {
+  const cleared: string[] = []
+  const terminated: string[] = []
+  const attempts: string[] = []
+  const store = {
+    getSshRemotePtyKillIntents: vi.fn(() => entries),
+    clearSshRemotePtyKillIntent: vi.fn((_target: string, ptyId: string) => {
+      cleared.push(ptyId)
+    }),
+    markSshRemotePtyLease: vi.fn((_target: string, ptyId: string, state: string) => {
+      if (state === 'terminated') {
+        terminated.push(ptyId)
+      }
+    }),
+    noteSshRemotePtyKillReplayAttempt: vi.fn((_target: string, ptyId: string) => {
+      attempts.push(ptyId)
+    })
+  } as unknown as Store
+  return { store, cleared, terminated, attempts }
+}
+
+/** A relay that lists `hostPtys`, and drops an id from that listing once it is shut down. */
+function createProviderStub(hostPtys: HostPty[], overrides: Partial<IPtyProvider> = {}) {
+  const live = new Map(hostPtys.map((pty) => [pty.relayPtyId, pty.incarnationId]))
+  const shutdown = vi.fn(async (appPtyId: string) => {
+    live.delete(appPtyId.replace(`ssh:${TARGET}@@`, ''))
+  })
+  const listProcesses = vi.fn(async () =>
+    Array.from(live, ([relayPtyId, incarnationId]) => ({
+      id: `ssh:${TARGET}@@${relayPtyId}`,
+      ...(incarnationId ? { incarnationId } : {})
+    }))
+  )
+  return {
+    provider: { listProcesses, shutdown, ...overrides } as unknown as IPtyProvider,
+    listProcesses,
+    shutdown
+  }
+}
+
+function entry(relayPtyId: string, incarnationId: string, requestedAt = NOW) {
+  return { ptyId: relayPtyId, intent: { requestedAt, incarnationId, attempts: 0 } }
+}
+
+describe('replayPendingSshPtyKills', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('does not talk to the host when nothing is pending', async () => {
+    const { store } = createStoreStub([])
+    const { provider, listProcesses } = createProviderStub([])
+    await replayPendingSshPtyKills({
+      targetId: TARGET,
+      store,
+      provider,
+      shouldContinue: () => true,
+      now: () => NOW
+    })
+    expect(listProcesses).not.toHaveBeenCalled()
+  })
+
+  // This is the leak: yesterday nothing retried, and the shell stayed up on the user's box.
+  it('replays the undelivered stop against the same PTY the kill was aimed at', async () => {
+    const { store, cleared, terminated } = createStoreStub([entry('pty-1', 'inc-a')])
+    const { provider, shutdown } = createProviderStub([
+      { relayPtyId: 'pty-1', incarnationId: 'inc-a' }
+    ])
+    await replayPendingSshPtyKills({
+      targetId: TARGET,
+      store,
+      provider,
+      shouldContinue: () => true,
+      now: () => NOW
+    })
+    expect(shutdown).toHaveBeenCalledWith('ssh:ssh-1@@pty-1', { immediate: true })
+    expect(cleared).toEqual(['pty-1'])
+    expect(terminated).toEqual(['pty-1'])
+  })
+
+  // #16970: a redeployed relay renumbers from pty-1, so this id now names someone else's shell.
+  it('refuses to kill a recycled relay id and retires the order instead', async () => {
+    const { store, cleared, terminated } = createStoreStub([entry('pty-1', 'inc-a')])
+    const { provider, shutdown } = createProviderStub([
+      { relayPtyId: 'pty-1', incarnationId: 'inc-fresh' }
+    ])
+    await replayPendingSshPtyKills({
+      targetId: TARGET,
+      store,
+      provider,
+      shouldContinue: () => true,
+      now: () => NOW
+    })
+    expect(shutdown).not.toHaveBeenCalled()
+    expect(cleared).toEqual(['pty-1'])
+    // No tombstone: nothing observed the PTY this order was aimed at, either way.
+    expect(terminated).toEqual([])
+  })
+
+  it('retires on the host reporting the PTY absent, with the tombstone that earns', async () => {
+    const { store, cleared, terminated } = createStoreStub([entry('pty-1', 'inc-a')])
+    const { provider, shutdown } = createProviderStub([
+      { relayPtyId: 'pty-2', incarnationId: 'inc-b' }
+    ])
+    await replayPendingSshPtyKills({
+      targetId: TARGET,
+      store,
+      provider,
+      shouldContinue: () => true,
+      now: () => NOW
+    })
+    expect(shutdown).not.toHaveBeenCalled()
+    expect(cleared).toEqual(['pty-1'])
+    expect(terminated).toEqual(['pty-1'])
+  })
+
+  it('retires an order past its TTL without aiming it at whatever holds the id now', async () => {
+    const { store, cleared, terminated } = createStoreStub([entry('pty-1', 'inc-a')])
+    const { provider, shutdown } = createProviderStub([
+      { relayPtyId: 'pty-1', incarnationId: 'inc-a' }
+    ])
+    await replayPendingSshPtyKills({
+      targetId: TARGET,
+      store,
+      provider,
+      shouldContinue: () => true,
+      now: () => NOW + SSH_PENDING_PTY_KILL_TTL_MS + 1
+    })
+    expect(shutdown).not.toHaveBeenCalled()
+    expect(cleared).toEqual(['pty-1'])
+    expect(terminated).toEqual([])
+  })
+
+  it('retires when the replayed stop is answered with absence from the relay', async () => {
+    const { store, cleared, terminated } = createStoreStub([entry('pty-1', 'inc-a')])
+    const { provider } = createProviderStub([{ relayPtyId: 'pty-1', incarnationId: 'inc-a' }], {
+      shutdown: vi.fn(async () => {
+        throw new SshPtyAbsentFromRelayError('SSH_SESSION_EXPIRED: pty-1')
+      })
+    })
+    await replayPendingSshPtyKills({
+      targetId: TARGET,
+      store,
+      provider,
+      shouldContinue: () => true,
+      now: () => NOW
+    })
+    expect(cleared).toEqual(['pty-1'])
+    expect(terminated).toEqual(['pty-1'])
+  })
+
+  it('keeps the order when the replayed stop is itself unverifiable', async () => {
+    const { store, cleared, terminated, attempts } = createStoreStub([entry('pty-1', 'inc-a')])
+    const { provider } = createProviderStub([{ relayPtyId: 'pty-1', incarnationId: 'inc-a' }], {
+      shutdown: vi.fn(async () => {
+        throw new Error('socket closed')
+      })
+    })
+    await replayPendingSshPtyKills({
+      targetId: TARGET,
+      store,
+      provider,
+      shouldContinue: () => true,
+      now: () => NOW
+    })
+    expect(attempts).toEqual(['pty-1'])
+    expect(cleared).toEqual([])
+    expect(terminated).toEqual([])
+  })
+
+  // `pty.shutdown` returns the same empty success for a PTY the relay never had, so only a fresh
+  // inventory that omits the id is a death certificate.
+  it('keeps the order when the host still lists the PTY after a resolved shutdown', async () => {
+    const { store, cleared, terminated } = createStoreStub([entry('pty-1', 'inc-a')])
+    const { provider } = createProviderStub([{ relayPtyId: 'pty-1', incarnationId: 'inc-a' }], {
+      shutdown: vi.fn(async () => {})
+    })
+    await replayPendingSshPtyKills({
+      targetId: TARGET,
+      store,
+      provider,
+      shouldContinue: () => true,
+      now: () => NOW
+    })
+    expect(cleared).toEqual([])
+    expect(terminated).toEqual([])
+  })
+
+  // Wire skew: a host predating the published PTY incarnation cannot answer the fence.
+  it('defers against a host that publishes no PTY incarnation', async () => {
+    const { store, cleared, terminated } = createStoreStub([entry('pty-1', 'inc-a')])
+    const { provider, shutdown } = createProviderStub([{ relayPtyId: 'pty-1' }])
+    await replayPendingSshPtyKills({
+      targetId: TARGET,
+      store,
+      provider,
+      shouldContinue: () => true,
+      now: () => NOW
+    })
+    expect(shutdown).not.toHaveBeenCalled()
+    expect(cleared).toEqual([])
+    expect(terminated).toEqual([])
+  })
+
+  it('keeps every order when the inventory itself fails', async () => {
+    const { store, cleared, terminated } = createStoreStub([
+      entry('pty-1', 'inc-a'),
+      entry('pty-2', 'inc-b')
+    ])
+    const { provider } = createProviderStub([], {
+      listProcesses: vi.fn(async () => {
+        throw new Error('relay unreachable')
+      })
+    })
+    await replayPendingSshPtyKills({
+      targetId: TARGET,
+      store,
+      provider,
+      shouldContinue: () => true,
+      now: () => NOW
+    })
+    expect(cleared).toEqual([])
+    expect(terminated).toEqual([])
+  })
+
+  it('delivers nothing once the connection attempt is superseded', async () => {
+    const { store, cleared } = createStoreStub([entry('pty-1', 'inc-a'), entry('pty-2', 'inc-b')])
+    const { provider, shutdown } = createProviderStub([
+      { relayPtyId: 'pty-1', incarnationId: 'inc-a' },
+      { relayPtyId: 'pty-2', incarnationId: 'inc-b' }
+    ])
+    await replayPendingSshPtyKills({
+      targetId: TARGET,
+      store,
+      provider,
+      shouldContinue: () => false,
+      now: () => NOW
+    })
+    expect(shutdown).not.toHaveBeenCalled()
+    expect(cleared).toEqual([])
+  })
+
+  // One inventory to fence the batch, one to prove it — not two per order, on the connect path.
+  it('costs two inventory round trips however many stops are pending', async () => {
+    const pending = Array.from({ length: 12 }, (_, index) => entry(`pty-${index}`, `inc-${index}`))
+    const { store, terminated } = createStoreStub(pending)
+    const { provider, listProcesses, shutdown } = createProviderStub(
+      pending.map((item) => ({ relayPtyId: item.ptyId, incarnationId: item.intent.incarnationId }))
+    )
+    await replayPendingSshPtyKills({
+      targetId: TARGET,
+      store,
+      provider,
+      shouldContinue: () => true,
+      now: () => NOW
+    })
+    expect(shutdown).toHaveBeenCalledTimes(12)
+    expect(listProcesses).toHaveBeenCalledTimes(2)
+    expect(terminated).toHaveLength(12)
+  })
+})

--- a/src/main/ssh/ssh-pending-pty-kill-replay.ts
+++ b/src/main/ssh/ssh-pending-pty-kill-replay.ts
@@ -1,0 +1,183 @@
+import type { Store } from '../persistence'
+import { isPtyAlreadyGoneError } from '../ipc/pty/provider/liveness'
+import type { IPtyProvider } from '../providers/types'
+import { toAppSshPtyId, toRelaySshPtyId } from '../providers/ssh-pty-id'
+import {
+  decideSshPendingPtyKill,
+  type SshPendingPtyKillRetirement
+} from '../../shared/ssh-pending-pty-kill'
+
+export type SshPendingPtyKillReplayArgs = {
+  targetId: string
+  store: Store
+  provider: IPtyProvider
+  shouldContinue: () => boolean
+  now?: () => number
+}
+
+/** Enough to clear a normal backlog in one round trip without flooding a slow link. */
+const REPLAY_CONCURRENCY = 4
+
+type HostInventory = Map<string, string | undefined>
+
+/** Relay pty id -> the incarnation the host published for it, `undefined` when it published none. */
+async function readHostInventory(args: SshPendingPtyKillReplayArgs): Promise<HostInventory> {
+  const processes = await args.provider.listProcesses()
+  const inventory: HostInventory = new Map()
+  for (const process of processes) {
+    inventory.set(toRelaySshPtyId(args.targetId, process.id), process.incarnationId)
+  }
+  return inventory
+}
+
+function retire(
+  args: SshPendingPtyKillReplayArgs,
+  relayPtyId: string,
+  reason: SshPendingPtyKillRetirement
+): void {
+  args.store.clearSshRemotePtyKillIntent(args.targetId, relayPtyId)
+  if (reason === 'host-reports-absent' || reason === 'stop-confirmed') {
+    // The owning host observed absence, which is the only evidence that earns a tombstone. An
+    // expired or recycled order retires the intent alone and asserts nothing about any process.
+    args.store.markSshRemotePtyLease(args.targetId, relayPtyId, 'terminated')
+  }
+  console.log(
+    `[ssh-pending-kill] retired stop for ${args.targetId}/${relayPtyId} (${reason.replace(/-/g, ' ')})`
+  )
+}
+
+/** Applies each recorded order against the inventory, and returns the ids that need delivering. */
+function selectReplayTargets(
+  args: SshPendingPtyKillReplayArgs,
+  inventory: HostInventory,
+  now: number
+): string[] {
+  const replayable: string[] = []
+  for (const entry of args.store.getSshRemotePtyKillIntents(args.targetId, now)) {
+    const decision = decideSshPendingPtyKill(
+      entry.intent,
+      { hostListsPty: inventory.has(entry.ptyId), hostIncarnationId: inventory.get(entry.ptyId) },
+      now
+    )
+    if (decision.action === 'retire') {
+      retire(args, entry.ptyId, decision.reason)
+    } else if (decision.action === 'defer') {
+      console.warn(
+        `[ssh-pending-kill] deferring stop for ${args.targetId}/${entry.ptyId}: ${decision.reason}`
+      )
+    } else {
+      replayable.push(entry.ptyId)
+    }
+  }
+  return replayable
+}
+
+/** Issues one recorded stop. Returns false when the order is already settled — the host answered
+ *  that the PTY was gone, or the attempt was unverifiable — so the confirming pass skips it. */
+async function deliverReplay(
+  args: SshPendingPtyKillReplayArgs,
+  relayPtyId: string
+): Promise<boolean> {
+  args.store.noteSshRemotePtyKillReplayAttempt(args.targetId, relayPtyId)
+  try {
+    await args.provider.shutdown(toAppSshPtyId(args.targetId, relayPtyId), { immediate: true })
+    return true
+  } catch (err) {
+    if (isPtyAlreadyGoneError(err)) {
+      retire(args, relayPtyId, 'host-reports-absent')
+      return false
+    }
+    // Loss of contact observes nothing. The order stays for the next handshake.
+    console.warn(
+      `[ssh-pending-kill] replay for ${args.targetId}/${relayPtyId} is unverifiable: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    )
+    return false
+  }
+}
+
+async function deliverAll(
+  args: SshPendingPtyKillReplayArgs,
+  relayPtyIds: string[]
+): Promise<string[]> {
+  const awaitingProof: string[] = []
+  let next = 0
+  const worker = async (): Promise<void> => {
+    while (args.shouldContinue()) {
+      const relayPtyId = relayPtyIds[next++]
+      if (relayPtyId === undefined) {
+        return
+      }
+      if (await deliverReplay(args, relayPtyId)) {
+        awaitingProof.push(relayPtyId)
+      }
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(REPLAY_CONCURRENCY, relayPtyIds.length) }, worker)
+  )
+  return awaitingProof
+}
+
+/** Confirms the batch against one fresh inventory.
+ *
+ *  Why re-list at all: the relay answers `pty.shutdown` for a PTY it never had with the same empty
+ *  success, so a resolved RPC alone is not a death certificate. Why once for the whole batch: this
+ *  runs on the connect path, and a per-PTY verify would put two round trips per order between the
+ *  user and a ready connection. */
+async function confirmBatch(
+  args: SshPendingPtyKillReplayArgs,
+  awaitingProof: string[]
+): Promise<void> {
+  const inventory = await readHostInventory(args)
+  for (const relayPtyId of awaitingProof) {
+    if (!inventory.has(relayPtyId)) {
+      retire(args, relayPtyId, 'stop-confirmed')
+    } else {
+      console.warn(
+        `[ssh-pending-kill] ${args.targetId}/${relayPtyId} is still live after a replayed stop`
+      )
+    }
+  }
+}
+
+/** Replays every stop this client could not deliver to `targetId`, now that it is reachable again.
+ *
+ *  Runs before reattach so a PTY that dies here is never re-adopted as a live pane. Costs nothing
+ *  when nothing is pending, and two inventory round trips when something is. */
+export async function replayPendingSshPtyKills(args: SshPendingPtyKillReplayArgs): Promise<void> {
+  const now = args.now ?? Date.now
+  if (args.store.getSshRemotePtyKillIntents(args.targetId, now()).length === 0) {
+    return
+  }
+  let inventory: HostInventory
+  try {
+    inventory = await readHostInventory(args)
+  } catch (err) {
+    // No inventory means no fence, and an unfenced replay can kill a shell nobody asked to close.
+    console.warn(
+      `[ssh-pending-kill] could not list PTYs on ${args.targetId}; stops stay pending: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    )
+    return
+  }
+  const replayable = selectReplayTargets(args, inventory, now())
+  if (replayable.length === 0 || !args.shouldContinue()) {
+    return
+  }
+  const awaitingProof = await deliverAll(args, replayable)
+  if (awaitingProof.length === 0 || !args.shouldContinue()) {
+    return
+  }
+  try {
+    await confirmBatch(args, awaitingProof)
+  } catch (err) {
+    console.warn(
+      `[ssh-pending-kill] could not confirm replayed stops on ${args.targetId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    )
+  }
+}

--- a/src/main/ssh/ssh-pending-pty-kill-replay.ts
+++ b/src/main/ssh/ssh-pending-pty-kill-replay.ts
@@ -1,9 +1,10 @@
 import type { Store } from '../persistence'
-import { isPtyAlreadyGoneError } from '../ipc/pty/provider/liveness'
 import type { IPtyProvider } from '../providers/types'
 import { toAppSshPtyId, toRelaySshPtyId } from '../providers/ssh-pty-id'
 import {
   decideSshPendingPtyKill,
+  type SshPendingPtyKillEntry,
+  type SshPendingPtyKillObservation,
   type SshPendingPtyKillRetirement
 } from '../../shared/ssh-pending-pty-kill'
 
@@ -15,8 +16,9 @@ export type SshPendingPtyKillReplayArgs = {
   now?: () => number
 }
 
-/** Enough to clear a normal backlog in one round trip without flooding a slow link. */
-const REPLAY_CONCURRENCY = 4
+/** Stops issued per inventory read. Every stop in a wave is dispatched concurrently, immediately
+ *  after the read that fenced it, so no kill is ever aimed with evidence older than one round trip. */
+const REPLAY_WAVE_SIZE = 4
 
 type HostInventory = Map<string, string | undefined>
 
@@ -30,6 +32,13 @@ async function readHostInventory(args: SshPendingPtyKillReplayArgs): Promise<Hos
   return inventory
 }
 
+/** Retires one order.
+ *
+ *  Both tombstoning reasons are derived from a successful `pty.listProcesses`, never from an error
+ *  predicate: `isPtyAlreadyGoneError` matches on message text (`/Session not found/i`), which a
+ *  transport failure could wear, and a tombstone written on that would bury a live remote shell.
+ *  A recycled id gets `expired`, not `terminated` — the client has lost its route to that lease,
+ *  which is all that was observed; nothing says the shell it named ever died. */
 function retire(
   args: SshPendingPtyKillReplayArgs,
   relayPtyId: string,
@@ -37,28 +46,41 @@ function retire(
 ): void {
   args.store.clearSshRemotePtyKillIntent(args.targetId, relayPtyId)
   if (reason === 'host-reports-absent' || reason === 'stop-confirmed') {
-    // The owning host observed absence, which is the only evidence that earns a tombstone. An
-    // expired or recycled order retires the intent alone and asserts nothing about any process.
     args.store.markSshRemotePtyLease(args.targetId, relayPtyId, 'terminated')
+  } else if (reason === 'relay-id-recycled') {
+    // Why this must happen: the reattach one step later filters on lease state and fences only on
+    // paneKey/tabId, never on incarnation. Leaving this lease active hands the user's old pane to
+    // whatever process now holds the recycled id.
+    args.store.markSshRemotePtyLease(args.targetId, relayPtyId, 'expired')
   }
   console.log(
     `[ssh-pending-kill] retired stop for ${args.targetId}/${relayPtyId} (${reason.replace(/-/g, ' ')})`
   )
 }
 
-/** Applies each recorded order against the inventory, and returns the ids that need delivering. */
+function observe(inventory: HostInventory, relayPtyId: string): SshPendingPtyKillObservation {
+  return {
+    hostListsPty: inventory.has(relayPtyId),
+    hostIncarnationId: inventory.get(relayPtyId)
+  }
+}
+
+/** Applies every recorded order against one inventory, and returns the ones it says are safe to
+ *  stop. Retirement side effects happen here, against that same fresh evidence. */
 function selectReplayTargets(
   args: SshPendingPtyKillReplayArgs,
   inventory: HostInventory,
-  now: number
-): string[] {
-  const replayable: string[] = []
+  now: number,
+  /** Orders already dispatched this pass. Skipped whole: the shutdown they were issued is what
+   *  removes them from the next inventory, so re-deciding would retire them a second time. */
+  attempted: ReadonlySet<string>
+): SshPendingPtyKillEntry[] {
+  const replayable: SshPendingPtyKillEntry[] = []
   for (const entry of args.store.getSshRemotePtyKillIntents(args.targetId, now)) {
-    const decision = decideSshPendingPtyKill(
-      entry.intent,
-      { hostListsPty: inventory.has(entry.ptyId), hostIncarnationId: inventory.get(entry.ptyId) },
-      now
-    )
+    if (attempted.has(entry.ptyId)) {
+      continue
+    }
+    const decision = decideSshPendingPtyKill(entry.intent, observe(inventory, entry.ptyId), now)
     if (decision.action === 'retire') {
       retire(args, entry.ptyId, decision.reason)
     } else if (decision.action === 'defer') {
@@ -66,30 +88,37 @@ function selectReplayTargets(
         `[ssh-pending-kill] deferring stop for ${args.targetId}/${entry.ptyId}: ${decision.reason}`
       )
     } else {
-      replayable.push(entry.ptyId)
+      replayable.push(entry)
     }
   }
   return replayable
 }
 
-/** Issues one recorded stop. Returns false when the order is already settled — the host answered
- *  that the PTY was gone, or the attempt was unverifiable — so the confirming pass skips it. */
+/** Issues one recorded stop. Returns false when it did not reach the host, in which case the order
+ *  stays: a rejected RPC observes nothing, and the next handshake's inventory will answer.
+ *
+ *  Re-checks the fence here rather than trusting the selection pass, so the identity proof and the
+ *  irreversible call sit next to each other and cannot drift apart if this loop is ever reshaped.
+ *  It still cannot be made atomic — `pty.shutdown` carries no incarnation, so only the host could
+ *  refuse a stale kill. See the residual risk note in the PR. */
 async function deliverReplay(
   args: SshPendingPtyKillReplayArgs,
-  relayPtyId: string
+  entry: SshPendingPtyKillEntry,
+  inventory: HostInventory,
+  now: number
 ): Promise<boolean> {
-  args.store.noteSshRemotePtyKillReplayAttempt(args.targetId, relayPtyId)
+  if (
+    decideSshPendingPtyKill(entry.intent, observe(inventory, entry.ptyId), now).action !== 'replay'
+  ) {
+    return false
+  }
+  args.store.noteSshRemotePtyKillReplayAttempt(args.targetId, entry.ptyId)
   try {
-    await args.provider.shutdown(toAppSshPtyId(args.targetId, relayPtyId), { immediate: true })
+    await args.provider.shutdown(toAppSshPtyId(args.targetId, entry.ptyId), { immediate: true })
     return true
   } catch (err) {
-    if (isPtyAlreadyGoneError(err)) {
-      retire(args, relayPtyId, 'host-reports-absent')
-      return false
-    }
-    // Loss of contact observes nothing. The order stays for the next handshake.
     console.warn(
-      `[ssh-pending-kill] replay for ${args.targetId}/${relayPtyId} is unverifiable: ${
+      `[ssh-pending-kill] replay for ${args.targetId}/${entry.ptyId} is unverifiable: ${
         err instanceof Error ? err.message : String(err)
       }`
     )
@@ -97,39 +126,17 @@ async function deliverReplay(
   }
 }
 
-async function deliverAll(
-  args: SshPendingPtyKillReplayArgs,
-  relayPtyIds: string[]
-): Promise<string[]> {
-  const awaitingProof: string[] = []
-  let next = 0
-  const worker = async (): Promise<void> => {
-    while (args.shouldContinue()) {
-      const relayPtyId = relayPtyIds[next++]
-      if (relayPtyId === undefined) {
-        return
-      }
-      if (await deliverReplay(args, relayPtyId)) {
-        awaitingProof.push(relayPtyId)
-      }
-    }
-  }
-  await Promise.all(
-    Array.from({ length: Math.min(REPLAY_CONCURRENCY, relayPtyIds.length) }, worker)
-  )
-  return awaitingProof
-}
-
-/** Confirms the batch against one fresh inventory.
+/** Confirms delivered stops against one fresh inventory.
  *
  *  Why re-list at all: the relay answers `pty.shutdown` for a PTY it never had with the same empty
- *  success, so a resolved RPC alone is not a death certificate. Why once for the whole batch: this
- *  runs on the connect path, and a per-PTY verify would put two round trips per order between the
- *  user and a ready connection. */
-async function confirmBatch(
+ *  success, so a resolved RPC alone is not a death certificate. Absence from a live listing is. */
+async function confirmDelivered(
   args: SshPendingPtyKillReplayArgs,
-  awaitingProof: string[]
+  awaitingProof: readonly string[]
 ): Promise<void> {
+  if (awaitingProof.length === 0) {
+    return
+  }
   const inventory = await readHostInventory(args)
   for (const relayPtyId of awaitingProof) {
     if (!inventory.has(relayPtyId)) {
@@ -145,37 +152,55 @@ async function confirmBatch(
 /** Replays every stop this client could not deliver to `targetId`, now that it is reachable again.
  *
  *  Runs before reattach so a PTY that dies here is never re-adopted as a live pane. Costs nothing
- *  when nothing is pending, and two inventory round trips when something is. */
+ *  when nothing is pending. When something is, it re-reads the inventory once per wave rather than
+ *  once per batch: the fence and the stops it authorises are then never more than one round trip
+ *  apart, which is as tight as this can get while `pty.shutdown` carries no incarnation of its own.
+ *
+ *  Never throws. It is best-effort work on the connect path, and `establish()` treats a throw here
+ *  as a failed connection. */
 export async function replayPendingSshPtyKills(args: SshPendingPtyKillReplayArgs): Promise<void> {
   const now = args.now ?? Date.now
-  if (args.store.getSshRemotePtyKillIntents(args.targetId, now()).length === 0) {
-    return
-  }
-  let inventory: HostInventory
   try {
-    inventory = await readHostInventory(args)
+    // Inside the guard with everything else: these touch persistence, and a disk hiccup must not
+    // turn best-effort cleanup into a failed SSH connection.
+    args.store.pruneExpiredSshRemotePtyKillIntents(args.targetId, now())
+    if (args.store.getSshRemotePtyKillIntents(args.targetId, now()).length === 0) {
+      return
+    }
+    const attempted = new Set<string>()
+    const awaitingProof: string[] = []
+    while (args.shouldContinue()) {
+      // No inventory means no fence, and an unfenced replay can kill a shell nobody asked to close.
+      const inventory = await readHostInventory(args)
+      const selected = selectReplayTargets(args, inventory, now(), attempted)
+      const wave = selected.slice(0, REPLAY_WAVE_SIZE)
+      if (wave.length === 0) {
+        break
+      }
+      for (const entry of wave) {
+        attempted.add(entry.ptyId)
+      }
+      const delivered = await Promise.all(
+        wave.map(async (entry) =>
+          (await deliverReplay(args, entry, inventory, now())) ? entry.ptyId : null
+        )
+      )
+      for (const relayPtyId of delivered) {
+        if (relayPtyId !== null) {
+          awaitingProof.push(relayPtyId)
+        }
+      }
+      if (selected.length <= REPLAY_WAVE_SIZE) {
+        // This wave took everything the inventory offered, so another read would only confirm that.
+        break
+      }
+    }
+    if (args.shouldContinue()) {
+      await confirmDelivered(args, awaitingProof)
+    }
   } catch (err) {
-    // No inventory means no fence, and an unfenced replay can kill a shell nobody asked to close.
     console.warn(
-      `[ssh-pending-kill] could not list PTYs on ${args.targetId}; stops stay pending: ${
-        err instanceof Error ? err.message : String(err)
-      }`
-    )
-    return
-  }
-  const replayable = selectReplayTargets(args, inventory, now())
-  if (replayable.length === 0 || !args.shouldContinue()) {
-    return
-  }
-  const awaitingProof = await deliverAll(args, replayable)
-  if (awaitingProof.length === 0 || !args.shouldContinue()) {
-    return
-  }
-  try {
-    await confirmBatch(args, awaitingProof)
-  } catch (err) {
-    console.warn(
-      `[ssh-pending-kill] could not confirm replayed stops on ${args.targetId}: ${
+      `[ssh-pending-kill] replay pass on ${args.targetId} stopped early; stops stay pending: ${
         err instanceof Error ? err.message : String(err)
       }`
     )

--- a/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
+++ b/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
@@ -162,6 +162,7 @@ function createSession(targetId: string): InstanceType<typeof SshRelaySession> {
     markSshRemotePtyLeasesAsync: vi.fn(),
     markSshRemotePtyLeasesAttachedAsync: vi.fn(),
     getSshRemotePtyKillIntents: vi.fn().mockReturnValue([]),
+    pruneExpiredSshRemotePtyKillIntents: vi.fn(),
     recordSshRemotePtyKillIntent: vi.fn(),
     clearSshRemotePtyKillIntent: vi.fn(),
     noteSshRemotePtyKillReplayAttempt: vi.fn()

--- a/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
+++ b/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
@@ -160,7 +160,11 @@ function createSession(targetId: string): InstanceType<typeof SshRelaySession> {
     markSshRemotePtyLease: vi.fn(),
     markSshRemotePtyLeases: vi.fn(),
     markSshRemotePtyLeasesAsync: vi.fn(),
-    markSshRemotePtyLeasesAttachedAsync: vi.fn()
+    markSshRemotePtyLeasesAttachedAsync: vi.fn(),
+    getSshRemotePtyKillIntents: vi.fn().mockReturnValue([]),
+    recordSshRemotePtyKillIntent: vi.fn(),
+    clearSshRemotePtyKillIntent: vi.fn(),
+    noteSshRemotePtyKillReplayAttempt: vi.fn()
   } as unknown as Store
   const portForwardManager = {
     removeAllForwards: vi.fn().mockResolvedValue(undefined)

--- a/src/main/ssh/ssh-relay-session-pending-kill-replay.test.ts
+++ b/src/main/ssh/ssh-relay-session-pending-kill-replay.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SshRelaySession } from './ssh-relay-session'
+import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
+
+const { muxRequestMock, openConsumerSessionMock, listProcessesMock, shutdownMock } = vi.hoisted(
+  () => ({
+    muxRequestMock: vi.fn(),
+    openConsumerSessionMock: vi.fn(),
+    listProcessesMock: vi.fn(),
+    shutdownMock: vi.fn()
+  })
+)
+
+vi.mock('./ssh-relay-deploy', () => ({ deployAndLaunchRelay: vi.fn() }))
+vi.mock('./ssh-pty-consumer-session', () => ({
+  openSshPtyConsumerSession: openConsumerSessionMock
+}))
+vi.mock('../ipc/ssh-pty-output-intake-registry', () => ({
+  acceptSshPtyOutputData: vi.fn().mockResolvedValue(undefined),
+  acceptSshPtyOutputExit: vi.fn().mockResolvedValue(undefined),
+  allocateSshPtyProviderGeneration: vi.fn(() => 41),
+  beginSshPtyOutputGenerationMigration: vi.fn(() => ({
+    byPty: new Map(),
+    completion: Promise.resolve()
+  })),
+  closeSshPtyOutputGeneration: vi.fn(),
+  getSshPtyAcceptedSourceCheckpoints: vi.fn(() => []),
+  applySshPtySourceCancellationProof: vi.fn(() => true),
+  applySshPtySourceRecoveryCancellationProof: vi.fn(() => true),
+  installSshPtySourceAckPublisher: vi.fn(() => () => {}),
+  installSshPtySourceCancellationPublisher: vi.fn(() => () => {})
+}))
+vi.mock('./ssh-relay-deploy-helpers', () => ({ execCommand: vi.fn().mockResolvedValue('') }))
+vi.mock('./ssh-channel-multiplexer', () => ({
+  SshChannelMultiplexer: class MockSshChannelMultiplexer {
+    notify = vi.fn()
+    notifyWithSettlement = vi.fn()
+    request = muxRequestMock
+    onNotification = vi.fn().mockReturnValue(() => {})
+    onNotificationByMethod = vi.fn().mockReturnValue(() => {})
+    onRequest = vi.fn().mockReturnValue(() => {})
+    onDispose = vi.fn().mockReturnValue(() => {})
+    dispose = vi.fn()
+    isDisposed = vi.fn().mockReturnValue(false)
+  }
+}))
+vi.mock('../providers/ssh-pty-provider', () => ({
+  SshPtyProvider: class MockSshPtyProvider {
+    onData = vi.fn().mockReturnValue(() => {})
+    onReplay = vi.fn().mockReturnValue(() => {})
+    onExit = vi.fn().mockReturnValue(() => {})
+    attach = vi.fn().mockResolvedValue(undefined)
+    attachForReconnect = vi.fn().mockResolvedValue({})
+    setPtyDeliveryPauseAdapter = vi.fn()
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-filesystem-provider', () => ({
+  SshFilesystemProvider: class MockSshFilesystemProvider {
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-git-provider', () => ({ SshGitProvider: class MockSshGitProvider {} }))
+vi.mock('../ipc/pty', () => ({
+  registerSshPtyProvider: vi.fn(),
+  unregisterSshPtyProvider: vi.fn(),
+  getSshPtyProvider: vi.fn().mockReturnValue({
+    dispose: vi.fn(),
+    attach: vi.fn().mockResolvedValue(undefined),
+    attachForReconnect: vi.fn().mockResolvedValue({}),
+    listProcesses: listProcessesMock,
+    shutdown: shutdownMock
+  }),
+  getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  clearPtyOwnershipForConnection: vi.fn(),
+  clearProviderPtyState: vi.fn(),
+  deletePtyOwnership: vi.fn(),
+  setPtyOwnership: vi.fn(),
+  restorePtyIncarnation: vi.fn(),
+  isCurrentPtyExit: vi.fn(() => true)
+}))
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  registerSshFilesystemProvider: vi.fn(),
+  unregisterSshFilesystemProvider: vi.fn(),
+  getSshFilesystemProvider: vi.fn().mockReturnValue({ dispose: vi.fn() })
+}))
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  registerSshGitProvider: vi.fn(),
+  unregisterSshGitProvider: vi.fn()
+}))
+
+const NOW = 1_800_000_000_000
+
+describe('SshRelaySession pending PTY kill replay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    openConsumerSessionMock.mockImplementation(async (_mux, options) => ({
+      mode: 'legacy-fallback',
+      clientInstanceId: options.clientInstanceId,
+      serverBuildId: 'test-relay-build'
+    }))
+    muxRequestMock.mockReset()
+    muxRequestMock.mockResolvedValue([])
+    mockDeploySuccess()
+  })
+
+  it('replays a stop the client could not deliver, before reattach reads the leases', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const order: string[] = []
+    vi.mocked(mockStore.getSshRemotePtyKillIntents).mockReturnValue([
+      { ptyId: 'pty-3', intent: { requestedAt: NOW, incarnationId: 'inc-a', attempts: 0 } }
+    ])
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockImplementation(() => {
+      order.push('read-leases')
+      return []
+    })
+    let live = true
+    listProcessesMock.mockImplementation(async () =>
+      live ? [{ id: 'ssh:target-1@@pty-3', incarnationId: 'inc-a' }] : []
+    )
+    shutdownMock.mockImplementation(async (id: string) => {
+      order.push(`shutdown:${id}`)
+      live = false
+    })
+
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+
+    expect(shutdownMock).toHaveBeenCalledWith('ssh:target-1@@pty-3', { immediate: true })
+    expect(order).toEqual(['shutdown:ssh:target-1@@pty-3', 'read-leases'])
+    expect(mockStore.clearSshRemotePtyKillIntent).toHaveBeenCalledWith('target-1', 'pty-3')
+    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('target-1', 'pty-3', 'terminated')
+  })
+
+  it('costs no host round trip when nothing is pending', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+
+    expect(listProcessesMock).not.toHaveBeenCalled()
+    expect(shutdownMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ssh/ssh-relay-session-terminal-error.test.ts
+++ b/src/main/ssh/ssh-relay-session-terminal-error.test.ts
@@ -109,6 +109,7 @@ function createMockDeps(): {
     markSshRemotePtyLeasesAsync: vi.fn(),
     markSshRemotePtyLeasesAttachedAsync: vi.fn(),
     getSshRemotePtyKillIntents: vi.fn().mockReturnValue([]),
+    pruneExpiredSshRemotePtyKillIntents: vi.fn(),
     recordSshRemotePtyKillIntent: vi.fn(),
     clearSshRemotePtyKillIntent: vi.fn(),
     noteSshRemotePtyKillReplayAttempt: vi.fn()

--- a/src/main/ssh/ssh-relay-session-terminal-error.test.ts
+++ b/src/main/ssh/ssh-relay-session-terminal-error.test.ts
@@ -107,7 +107,11 @@ function createMockDeps(): {
     markSshRemotePtyLease: vi.fn(),
     markSshRemotePtyLeases: vi.fn(),
     markSshRemotePtyLeasesAsync: vi.fn(),
-    markSshRemotePtyLeasesAttachedAsync: vi.fn()
+    markSshRemotePtyLeasesAttachedAsync: vi.fn(),
+    getSshRemotePtyKillIntents: vi.fn().mockReturnValue([]),
+    recordSshRemotePtyKillIntent: vi.fn(),
+    clearSshRemotePtyKillIntent: vi.fn(),
+    noteSshRemotePtyKillReplayAttempt: vi.fn()
   } as unknown as Store
   const mockPortForward = {
     removeAllForwards: vi.fn()

--- a/src/main/ssh/ssh-relay-session-test-fixtures.ts
+++ b/src/main/ssh/ssh-relay-session-test-fixtures.ts
@@ -26,6 +26,10 @@ export function createMockDeps(): SshRelaySessionTestDeps {
     markSshRemotePtyLeasesAsync: vi.fn(),
     markSshRemotePtyLeasesForShutdown: vi.fn(),
     markSshRemotePtyLeasesAttachedAsync: vi.fn(),
+    getSshRemotePtyKillIntents: vi.fn().mockReturnValue([]),
+    recordSshRemotePtyKillIntent: vi.fn(),
+    clearSshRemotePtyKillIntent: vi.fn(),
+    noteSshRemotePtyKillReplayAttempt: vi.fn(),
     persistPtyBinding: vi.fn()
   } as unknown as Store
   const mockPortForward = {

--- a/src/main/ssh/ssh-relay-session-test-fixtures.ts
+++ b/src/main/ssh/ssh-relay-session-test-fixtures.ts
@@ -27,6 +27,7 @@ export function createMockDeps(): SshRelaySessionTestDeps {
     markSshRemotePtyLeasesForShutdown: vi.fn(),
     markSshRemotePtyLeasesAttachedAsync: vi.fn(),
     getSshRemotePtyKillIntents: vi.fn().mockReturnValue([]),
+    pruneExpiredSshRemotePtyKillIntents: vi.fn(),
     recordSshRemotePtyKillIntent: vi.fn(),
     clearSshRemotePtyKillIntent: vi.fn(),
     noteSshRemotePtyKillReplayAttempt: vi.fn(),

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -6,6 +6,7 @@ import type { BrowserWindow } from 'electron'
 import { deployAndLaunchRelay } from './ssh-relay-deploy'
 import { execCommand } from './ssh-relay-deploy-helpers'
 import { isRelayVersionMismatchError } from './ssh-relay-version-mismatch-error'
+import { replayPendingSshPtyKills } from './ssh-pending-pty-kill-replay'
 import { SshChannelMultiplexer } from './ssh-channel-multiplexer'
 import { SshPtyProvider } from '../providers/ssh-pty-provider'
 import type { SshPtyAttachResult } from '../providers/ssh-pty-session-reattach'
@@ -2252,6 +2253,23 @@ export class SshRelaySession {
     mux: SshChannelMultiplexer,
     shouldContinue: () => boolean
   ): Promise<void> {
+    const ptyProvider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
+    const providerGeneration = this.activePtyProviderGeneration
+    if (!ptyProvider || providerGeneration === null || this.mux !== mux) {
+      return
+    }
+    // Why before the lease read: a stop the user asked for and this client could not deliver is
+    // replayed here, and a confirmed one tombstones its lease — so it must land before the filter
+    // below decides what to reattach, or the reattach revives a PTY that is about to die.
+    await replayPendingSshPtyKills({
+      targetId: this.targetId,
+      store: this.store,
+      provider: ptyProvider,
+      shouldContinue
+    })
+    if (!shouldContinue()) {
+      return
+    }
     const activeLeases = this.store
       .getSshRemotePtyLeases(this.targetId)
       .filter((lease) => lease.state !== 'terminated' && lease.state !== 'expired')
@@ -2276,11 +2294,6 @@ export class SshRelaySession {
         ...leasedPtyIds
       ])
     )
-    const ptyProvider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
-    const providerGeneration = this.activePtyProviderGeneration
-    if (!ptyProvider || providerGeneration === null || this.mux !== mux) {
-      return
-    }
     let nextPtyIndex = 0
     const worker = async (): Promise<void> => {
       while (shouldContinue()) {

--- a/src/shared/ssh-pending-pty-kill.test.ts
+++ b/src/shared/ssh-pending-pty-kill.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decideSshPendingPtyKill,
+  MAX_SSH_PENDING_PTY_KILLS_PER_TARGET,
+  prunePendingSshPtyKills,
+  SSH_PENDING_PTY_KILL_TTL_MS,
+  type SshPendingPtyKill,
+  type SshPendingPtyKillEntry
+} from './ssh-pending-pty-kill'
+
+const NOW = 1_800_000_000_000
+
+function intent(overrides: Partial<SshPendingPtyKill> = {}): SshPendingPtyKill {
+  return { requestedAt: NOW, incarnationId: 'inc-a', attempts: 0, ...overrides }
+}
+
+describe('decideSshPendingPtyKill', () => {
+  it('replays only when the host still holds the exact incarnation the kill was aimed at', () => {
+    expect(
+      decideSshPendingPtyKill(intent(), { hostListsPty: true, hostIncarnationId: 'inc-a' }, NOW)
+    ).toEqual({ action: 'replay' })
+  })
+
+  // The #16970 collision: a redeployed relay renumbers from pty-1, so the same id can name a
+  // different shell. Replaying here would kill a terminal nobody asked to close.
+  it('retires without killing when the relay id was recycled onto another PTY', () => {
+    expect(
+      decideSshPendingPtyKill(intent(), { hostListsPty: true, hostIncarnationId: 'inc-b' }, NOW)
+    ).toEqual({ action: 'retire', reason: 'relay-id-recycled' })
+  })
+
+  it('retires when the owning host answers and does not list the PTY', () => {
+    expect(
+      decideSshPendingPtyKill(
+        intent(),
+        { hostListsPty: false, hostIncarnationId: undefined },
+        NOW + 1000
+      )
+    ).toEqual({ action: 'retire', reason: 'host-reports-absent' })
+  })
+
+  it('retires past the TTL, ahead of every other branch', () => {
+    const stale = intent()
+    const later = NOW + SSH_PENDING_PTY_KILL_TTL_MS + 1
+    expect(
+      decideSshPendingPtyKill(stale, { hostListsPty: true, hostIncarnationId: 'inc-a' }, later)
+    ).toEqual({ action: 'retire', reason: 'expired' })
+    expect(
+      decideSshPendingPtyKill(stale, { hostListsPty: true, hostIncarnationId: 'inc-a' }, NOW + 1)
+    ).toEqual({ action: 'replay' })
+  })
+
+  // Wire skew: a host predating the published PTY incarnation leaves the fence unanswerable.
+  // Absence must read as unknown, never as a match and never as a recycle.
+  it('defers rather than guessing when the host published no incarnation', () => {
+    expect(
+      decideSshPendingPtyKill(intent(), { hostListsPty: true, hostIncarnationId: undefined }, NOW)
+        .action
+    ).toBe('defer')
+  })
+})
+
+describe('prunePendingSshPtyKills', () => {
+  it('drops expired entries and caps the rest newest-first', () => {
+    const entries: SshPendingPtyKillEntry[] = [
+      {
+        ptyId: 'pty-stale',
+        intent: intent({ requestedAt: NOW - SSH_PENDING_PTY_KILL_TTL_MS - 1 })
+      },
+      ...Array.from({ length: MAX_SSH_PENDING_PTY_KILLS_PER_TARGET + 25 }, (_, index) => ({
+        ptyId: `pty-${index}`,
+        intent: intent({ requestedAt: NOW - index })
+      }))
+    ]
+    const pruned = prunePendingSshPtyKills(entries, NOW)
+    expect(pruned).toHaveLength(MAX_SSH_PENDING_PTY_KILLS_PER_TARGET)
+    expect(pruned.map((entry) => entry.ptyId)).not.toContain('pty-stale')
+    expect(pruned[0]?.ptyId).toBe('pty-0')
+  })
+})

--- a/src/shared/ssh-pending-pty-kill.test.ts
+++ b/src/shared/ssh-pending-pty-kill.test.ts
@@ -39,12 +39,16 @@ describe('decideSshPendingPtyKill', () => {
     ).toEqual({ action: 'retire', reason: 'host-reports-absent' })
   })
 
-  it('retires past the TTL, ahead of every other branch', () => {
+  // TTL retirement belongs to the durable prune, not to a branch here — a branch would be
+  // unreachable behind it and would only look tested. This guards the belt-and-braces refusal:
+  // an expired order that somehow reaches this function is never dispatched.
+  it('refuses to replay past the TTL, ahead of every other branch', () => {
     const stale = intent()
     const later = NOW + SSH_PENDING_PTY_KILL_TTL_MS + 1
     expect(
       decideSshPendingPtyKill(stale, { hostListsPty: true, hostIncarnationId: 'inc-a' }, later)
-    ).toEqual({ action: 'retire', reason: 'expired' })
+        .action
+    ).toBe('defer')
     expect(
       decideSshPendingPtyKill(stale, { hostListsPty: true, hostIncarnationId: 'inc-a' }, NOW + 1)
     ).toEqual({ action: 'replay' })

--- a/src/shared/ssh-pending-pty-kill.ts
+++ b/src/shared/ssh-pending-pty-kill.ts
@@ -1,0 +1,137 @@
+import type { SshRemotePtyLease } from './ssh-types'
+
+/** A `pty.shutdown` this client issued to an SSH host and could not confirm.
+ *
+ *  Why it must exist: a relay PTY is a child of the detached relay daemon, not of the ssh channel,
+ *  so a shutdown that dies on the transport leaves a live shell — and often a live agent — running
+ *  on the user's remote machine with nothing left to retry it. Marking the attempt `unverifiable`
+ *  is correct but is not a fix; the kill is an intent that has to outlive the transport failure and
+ *  be replayed against the authoritative host when contact returns.
+ *
+ *  Carried on the existing `SshRemotePtyLease` rather than in a second journal: the lease is
+ *  already the durable, restart-surviving, per-`(targetId, relayPtyId)` record of a remote PTY. */
+export type SshPendingPtyKill = {
+  requestedAt: number
+  /** The host-minted PTY incarnation this kill was aimed at, and the whole fence.
+   *
+   *  A relay renumbers from `pty-1` on every start, so `(targetId, relayPtyId)` alone can name a
+   *  DIFFERENT shell after a redeploy — the collision behind #16970. `pty.shutdown` carries no
+   *  identity parameter and kills whatever holds the id, so the client has to prove identity before
+   *  it replays. The relay mints this per PTY process and publishes it on `pty.listProcesses`,
+   *  which makes it the one value that tells the two apart. */
+  incarnationId: string
+  /** Replays attempted since. Diagnostic; the TTL, not this, is the bound. */
+  attempts: number
+}
+
+/** Colocated with the type so the two cannot drift. The lease loader is a strict whitelist that
+ *  drops anything it does not name, so a record omitted here would be silently stripped on every
+ *  launch — the exact failure `closed-terminal-tab-tombstones.ts` records having shipped once. */
+export function normalizeSshPendingPtyKill(value: unknown): SshPendingPtyKill | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const raw = value as Partial<SshPendingPtyKill>
+  if (typeof raw.requestedAt !== 'number' || !Number.isFinite(raw.requestedAt)) {
+    return null
+  }
+  // No incarnation, no fence, and an unfenced kill order is worse than none.
+  if (
+    typeof raw.incarnationId !== 'string' ||
+    !raw.incarnationId ||
+    raw.incarnationId.length > 128
+  ) {
+    return null
+  }
+  return {
+    requestedAt: raw.requestedAt,
+    incarnationId: raw.incarnationId,
+    attempts: typeof raw.attempts === 'number' && raw.attempts >= 0 ? raw.attempts : 0
+  }
+}
+
+/** Backstop only — host acknowledgement is the normal exit. This covers a target the user never
+ *  reconnects to, whose intent would otherwise be carried forever. Deliberately longer than the 7d
+ *  ceiling on a relay grace window, so the intent outlives the longest window in which the host
+ *  could still be holding the PTY it names. */
+export const SSH_PENDING_PTY_KILL_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+/** Per target, newest kept. A permanently unreachable host must not grow the store without bound. */
+export const MAX_SSH_PENDING_PTY_KILLS_PER_TARGET = 200
+
+/** What the authoritative host just said about this relay PTY id, from one `pty.listProcesses`. */
+export type SshPendingPtyKillObservation = {
+  /** False only when the host answered and did not list the id: positive evidence of absence.
+   *  A failed or timed-out listing is never expressed here — the caller defers instead. */
+  hostListsPty: boolean
+  /** The incarnation the host published for that id. `undefined` means the host published none,
+   *  which reads as unknown — never as "no incarnation" and never as a match. */
+  hostIncarnationId: string | undefined
+}
+
+export type SshPendingPtyKillRetirement =
+  | 'expired'
+  | 'host-reports-absent'
+  | 'relay-id-recycled'
+  | 'stop-confirmed'
+
+export type SshPendingPtyKillDecision =
+  | { action: 'replay' }
+  | { action: 'retire'; reason: Exclude<SshPendingPtyKillRetirement, 'stop-confirmed'> }
+  | { action: 'defer'; reason: string }
+
+/** Decides what to do with one recorded kill, given what the host just said about its id.
+ *
+ *  `defer` is the `unverifiable` branch and asserts nothing: the record stays and the next
+ *  handshake asks again. No branch concludes that a PTY exited — only `host-reports-absent` is an
+ *  observation of absence, and it comes from the host that owns the process. */
+export function decideSshPendingPtyKill(
+  intent: SshPendingPtyKill,
+  observation: SshPendingPtyKillObservation,
+  now: number
+): SshPendingPtyKillDecision {
+  // First, so a stale intent is dropped rather than aimed at whatever holds the id today.
+  if (now - intent.requestedAt > SSH_PENDING_PTY_KILL_TTL_MS) {
+    return { action: 'retire', reason: 'expired' }
+  }
+  if (!observation.hostListsPty) {
+    return { action: 'retire', reason: 'host-reports-absent' }
+  }
+  if (observation.hostIncarnationId === undefined) {
+    // Why not replay: an unfenced kill against a renumbered relay id destroys a shell nobody asked
+    // to close, which is strictly worse than the leak. Hosts predating the published incarnation
+    // therefore degrade to no replay rather than to a guess.
+    return { action: 'defer', reason: 'host published no PTY incarnation for this id' }
+  }
+  if (observation.hostIncarnationId !== intent.incarnationId) {
+    return { action: 'retire', reason: 'relay-id-recycled' }
+  }
+  return { action: 'replay' }
+}
+
+export type SshPendingPtyKillEntry = { ptyId: string; intent: SshPendingPtyKill }
+
+/** Newest-first, TTL-filtered and capped — the same shape as `pruneClosedTerminalTabTombstones`. */
+export function prunePendingSshPtyKills(
+  entries: readonly SshPendingPtyKillEntry[],
+  now: number
+): SshPendingPtyKillEntry[] {
+  return entries
+    .filter((entry) => now - entry.intent.requestedAt <= SSH_PENDING_PTY_KILL_TTL_MS)
+    .sort((a, b) => b.intent.requestedAt - a.intent.requestedAt)
+    .slice(0, MAX_SSH_PENDING_PTY_KILLS_PER_TARGET)
+}
+
+/** Reads across every lease state on purpose: a kill issued while the provider was already gone
+ *  tombstones its lease `terminated` and still leaves the remote process running. */
+export function pendingSshPtyKillEntries(
+  leases: readonly SshRemotePtyLease[]
+): SshPendingPtyKillEntry[] {
+  const entries: SshPendingPtyKillEntry[] = []
+  for (const lease of leases) {
+    if (lease.pendingKill) {
+      entries.push({ ptyId: lease.ptyId, intent: lease.pendingKill })
+    }
+  }
+  return entries
+}

--- a/src/shared/ssh-pending-pty-kill.ts
+++ b/src/shared/ssh-pending-pty-kill.ts
@@ -59,6 +59,12 @@ export const SSH_PENDING_PTY_KILL_TTL_MS = 30 * 24 * 60 * 60 * 1000
 /** Per target, newest kept. A permanently unreachable host must not grow the store without bound. */
 export const MAX_SSH_PENDING_PTY_KILLS_PER_TARGET = 200
 
+/** The single definition of "too old to act on". Both the durable prune and the decision function
+ *  read it, so a stale order cannot be replayed by one and kept by the other. */
+export function isSshPendingPtyKillExpired(intent: SshPendingPtyKill, now: number): boolean {
+  return now - intent.requestedAt > SSH_PENDING_PTY_KILL_TTL_MS
+}
+
 /** What the authoritative host just said about this relay PTY id, from one `pty.listProcesses`. */
 export type SshPendingPtyKillObservation = {
   /** False only when the host answered and did not list the id: positive evidence of absence.
@@ -70,7 +76,6 @@ export type SshPendingPtyKillObservation = {
 }
 
 export type SshPendingPtyKillRetirement =
-  | 'expired'
   | 'host-reports-absent'
   | 'relay-id-recycled'
   | 'stop-confirmed'
@@ -82,6 +87,11 @@ export type SshPendingPtyKillDecision =
 
 /** Decides what to do with one recorded kill, given what the host just said about its id.
  *
+ *  The TTL is deliberately NOT a branch here. `isSshPendingPtyKillExpired` owns it, applied as a
+ *  durable prune before any of this runs, so expired orders are actually deleted from the store
+ *  rather than merely skipped — and so there is exactly one place that decides what "too old"
+ *  means. A branch here would be unreachable behind that prune and would only look tested.
+ *
  *  `defer` is the `unverifiable` branch and asserts nothing: the record stays and the next
  *  handshake asks again. No branch concludes that a PTY exited — only `host-reports-absent` is an
  *  observation of absence, and it comes from the host that owns the process. */
@@ -90,9 +100,10 @@ export function decideSshPendingPtyKill(
   observation: SshPendingPtyKillObservation,
   now: number
 ): SshPendingPtyKillDecision {
-  // First, so a stale intent is dropped rather than aimed at whatever holds the id today.
-  if (now - intent.requestedAt > SSH_PENDING_PTY_KILL_TTL_MS) {
-    return { action: 'retire', reason: 'expired' }
+  if (isSshPendingPtyKillExpired(intent, now)) {
+    // Unreachable behind the prune, but a stale order must never be aimed at whatever holds the
+    // id today if a future caller reaches this without pruning first.
+    return { action: 'defer', reason: 'order is past its TTL and awaiting prune' }
   }
   if (!observation.hostListsPty) {
     return { action: 'retire', reason: 'host-reports-absent' }
@@ -117,7 +128,7 @@ export function prunePendingSshPtyKills(
   now: number
 ): SshPendingPtyKillEntry[] {
   return entries
-    .filter((entry) => now - entry.intent.requestedAt <= SSH_PENDING_PTY_KILL_TTL_MS)
+    .filter((entry) => !isSshPendingPtyKillExpired(entry.intent, now))
     .sort((a, b) => b.intent.requestedAt - a.intent.requestedAt)
     .slice(0, MAX_SSH_PENDING_PTY_KILLS_PER_TARGET)
 }

--- a/src/shared/ssh-types.ts
+++ b/src/shared/ssh-types.ts
@@ -1,3 +1,5 @@
+import type { SshPendingPtyKill } from './ssh-pending-pty-kill'
+
 // ─── SSH Connection Types ───────────────────────────────────────────
 
 export const MIN_SSH_RELAY_GRACE_PERIOD_SECONDS = 60
@@ -211,6 +213,9 @@ export type SshRemotePtyLease = {
   updatedAt: number
   lastAttachedAt?: number
   lastDetachedAt?: number
+  /** A stop this client asked for and could not confirm, replayed on the next handshake to this
+   *  same target. See `shared/ssh-pending-pty-kill.ts`. Never on the wire — client-local. */
+  pendingKill?: SshPendingPtyKill
 }
 
 /** Main-owned relay lease needed to reclaim PTY delivery after a desktop restart. */


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1210 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1187 |
| Prod | 16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​785 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​92 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​693 |

<!-- /orca-pr-loc -->

Fixes the remote process leak behind #12447 — the one its "Expected behavior" bullet 1 asks for: *"if the remote kill cannot be delivered, record the intent and retry on reconnect — never silently drop it."*

### ELI5

You close a terminal that is running on a computer somewhere else. Orca sends "please stop" over the network. If the network hiccups at that exact moment, the message never arrives — and until now, Orca just shrugged and forgot about it. Your window closed, so it *looked* fine. But the program kept running on the other computer, forever, holding a shell and often a whole AI agent.

Now Orca writes the request down in a notebook that survives closing your laptop. Next time it talks to that same computer, it reads the notebook and asks again.

The tricky part is making sure it asks about the *right* thing. The remote side names its terminals `pty-1`, `pty-2`, … and starts over at `pty-1` whenever it restarts. So "please stop pty-1" written down yesterday could hit a completely different terminal today — someone else's work. To prevent that, Orca also writes down a fingerprint the remote side gives each terminal when it is born. Before asking again, it checks the fingerprint still matches. If it doesn't, Orca tears the page out instead of asking.

---

## Root cause

`src/main/ipc/pty/runtime/kill.ts` returned `false` when the shutdown RPC rejected with anything that was not `isPtyAlreadyGoneError`. It marked liveness `unverifiable` and warned — correct per [`docs/reference/ssh-execution-boundary.md`](docs/reference/ssh-execution-boundary.md), a transport failure observes nothing — and then **nothing ever retried**. There was no pending-kill journal.

A relay PTY is a child of the detached relay daemon, not of the ssh channel, and the shipped grace default is *keep alive until reset*. So the shell — and whatever agent it was running — survived on the user's remote machine indefinitely.

The same hole existed on the offline close: when no provider is registered, `killPtyFromRuntimeController` tombstones the lease `terminated` locally and tells the renderer, but the relay is never asked at all. That branch is the common one — a laptop closed mid-failure.

#16752 (client-local close tombstones) and #16970 (relay-id fence) stopped the *client* showing or resurrecting a tab for that orphan. Neither one stopped the process.

## The fix

**Record the intent durably, on both kill routes.** There are two: `killPtyFromRuntimeController` (runtime/CLI) and the `pty:kill` IPC, which is what `window.api.pty.kill` reaches and therefore what an ordinary tab close uses — the route #12447 actually describes. They are separate implementations and both now record. The IPC handler moved out of `ipc/inspect.ts` into `ipc/renderer-kill.ts`: it was not what that file is named for, and keeping it there put the file over the 300-line budget (no `max-lines` disable was added).

The record itself: `SshRemotePtyLease` — the existing per-`(targetId, relayPtyId)` durable record, which already survives restart — gains one optional field, `pendingKill`. No parallel journal: the lease is already the thing that names a remote PTY, so the eventual liveness consolidation adopts one record rather than deleting a second one. `src/shared/ssh-pending-pty-kill.ts` holds the colocated type plus the pure decision logic, deliberately shaped after `src/shared/closed-terminal-tab-tombstones.ts` (TTL + cap + a retirement rule that never deletes on absence of evidence).

**Replay it on the next handshake to the same host.** `replayPendingSshPtyKills` runs at the top of `SshRelaySession.reattachKnownPtys`, which both `establish()` and `reconnect()` await — so a PTY that dies here is never re-adopted as a live pane by the reattach that follows it.

**Fence it on the host-minted PTY incarnation.** `toAppSshPtyId` is `connectionId + relayPtyId`, and a redeployed relay renumbers from `pty-1` (`src/relay/pty-handler.ts`, `private nextId = 1`), so the id alone is not safe — that is the #16970 collision. The relay mints an `incarnationId` (`randomUUID()`) per PTY process and already publishes it on `pty.listProcesses`. The replay only issues `pty.shutdown` when the host still reports that exact incarnation for that id, and it re-checks that immediately before each call rather than trusting the selection pass.

This fence has to live on the client. `pty.shutdown` takes `{ id, immediate, keepHistory }` and no identity parameter, and the relay kills whatever holds the id — its handler also returns the same empty success for a PTY it never had. Adding an `expectedIncarnation` param would be a safe Rule-1 field, but an old host would ignore it, so the client would still have to fence itself and the host change would buy nothing today.

**Retire on three paths, and never assert an exit.**

| Trigger | Action |
|---|---|
| Shutdown delivered, and a fresh inventory no longer lists the id | clear the intent, mark the lease `terminated` |
| Host answers and does not list the id | clear the intent, mark the lease `terminated` |
| TTL (30d) | a durable prune deletes the order; the lease is untouched |
| Relay id recycled onto a different incarnation | clear the intent, mark the lease `expired` — **no kill** |
| Anything else (transport failure, no inventory, host publishes no incarnation) | keep the intent; the next handshake asks again |

Only the two rows carrying positive evidence of absence *from the host that owns the process* write a `terminated` tombstone, and both derive it from a successful `pty.listProcesses` — never from an error predicate. `isPtyAlreadyGoneError` matches message text (`/Session not found/i`) that a transport failure could wear, and #16763 landed precisely because that class of flattening had already gone wrong here once; a tombstone resting on it would bury a live remote shell. Nothing here emits a renderer exit event — the synthetic exit already fired at kill time — and no branch invents an `exited` for something nobody observed. The vocabulary stays `live` / `unverifiable` / `exited`.

**Retirement is never inferred from a resolved RPC.** `finishPtyShutdown` deliberately does *not* clear the order. It runs both on paths that asked the host and on paths that never did, so retiring from there would be a contract every call site had to remember — and the one that forgot would silently drop a valid kill order. It is also not evidence: the relay answers `pty.shutdown` for a PTY it never had with the same empty success. Retirement belongs to the replay, which only ever acts on a live `pty.listProcesses`.

**A recycled id expires the lease that named it.** Declining to kill is only half the fix. The reattach one step later filters on lease state and fences on `paneKey`/`tabId`, never on incarnation — so an untouched lease would bind the user's old pane to whatever process now holds the recycled id. It is marked `expired`, not `terminated`: losing the route is all that was observed, and nothing says the shell it named ever died.

**Only a caller that gives the PTY up for good records an order.** This is the sharpest edge in the change and it is worth stating explicitly. `stopAndWaitPtyFromRuntimeController` deliberately records nothing: worktree sleep stops through it and wraps those stops in `markReversibleStops`, and when one does not land the pane is left **live and usable** and the failure is handed back to the caller. An order recorded there would come back on a later handshake and kill a terminal the user had gone back to using — turning a leak fix into a data-loss bug. `recordUndeliveredSshPtyKill` additionally refuses any PTY a reversible stop currently owns, so the rule is enforced rather than assumed. Both are covered by tests.

## Wire-compatibility analysis

Per [`docs/reference/remote-wire-compatibility.md`](docs/reference/remote-wire-compatibility.md):

* **No new RPC method and no new stream opcode.** Rule 2 does not apply. The replay uses `pty.listProcesses` and `pty.shutdown`, both long-shipped.
* **No new field on any frame.** `pendingKill` is client-local persisted state and never crosses the wire.
* **Reads one existing optional field.** `incarnationId` on `pty.listProcesses` results (added in #9687). That is Rule 1, *and* it has the second state Rule 1 alone does not describe: **absent means the host never published one — not "no incarnation", and not "matches"**. `decideSshPendingPtyKill` returns `defer` for absent, so a client newer than its host does not replay at all rather than replaying unfenced. Degraded, never dangerous. The record also cannot be created without an incarnation (`recordUndeliveredSshPtyKill` no-ops), so against a host that never publishes one the whole feature is inert and behavior is exactly today's.
* **Rule 3 (what the host publishes).** Nothing changes about what the host publishes.
* **Old client, newer store.** `normalizeSshRemotePtyLease` is a strict whitelist, so an older build reading a store written by this one drops `pendingKill` and behaves exactly as it does today. A downgrade loses queued kill orders; it cannot corrupt or misfire them. That whitelist is also why `normalizeSshPendingPtyKill` had to be added to it — without that the record was silently stripped on every launch, the same failure `closed-terminal-tab-tombstones.ts` records having shipped once. A test covers it.
* The cross-version harness (`tests/e2e/cross-version-wire/`) covers the terminal stream only and is unaffected; this change is on the relay RPC path, which it does not exercise, and nothing about the framing moved.

## Cost on the connect path, and containment

Zero when nothing is pending — `replayPendingSshPtyKills` reads the store and returns before touching the mux. When something is, it is one inventory per wave of 4 plus one to prove the batch: two round trips for the common single-order case, `ceil(n/4)+1` at worst. A per-PTY `verifyPtyStopped` was the first shape and cost two round trips *per order*; one inventory for the whole batch was the second and left the fence going stale across the batch. Per-wave is the compromise, and it is what keeps a stop's identity evidence within one round trip of the stop.

`replayPendingSshPtyKills` never rejects. It is best-effort work that `establish()`/`reconnect()` await, so an unguarded throw — including from a persistence write — would turn a failed cleanup into a **failed SSH connection**, which is strictly worse than the leak. Two tests pin it, one for a throwing store read and one for a throwing write.

Growth is bounded by a 30d TTL and 200 records **per target** (not globally), enforced on write, on read, and by a durable prune that actually deletes.

## Residual risks, stated rather than implied

* **The fence is a large improvement, not a guarantee.** `pty.shutdown` carries `{ id, immediate, keepHistory }` and no incarnation, so the host enforces nothing and no client-side arrangement can make list-then-kill atomic. Re-reading per wave and re-checking beside each call narrows the window to one round trip; it cannot close it. Closing it needs the *host* to refuse a stale kill — an incarnation on `pty.shutdown`, capability-negotiated per Rule 2. That is deliberately out of scope here and is exactly the kind of thing the SSH-v3 consolidation should absorb: "the execution host owns everything that touches execution."
* **Old relays that never publish `incarnationId`.** Their orders defer forever and leave only via the 30d TTL, which deliberately does not tombstone the lease. That is correctness over leak-prevention — an unfenced kill on a renumbered id is worse than the leak — but it does mean the leak is unfixed against pre-#9687 hosts.
* **The confirming inventory checks presence, not incarnation.** If a kill ever did land on the wrong process, a third process reusing that id before the confirm read would be indistinguishable from "never died". It self-corrects on the next reconnect via `relay-id-recycled`, but nothing surfaces that a wrong kill may have happened. Diagnostics gap, not a correctness one.
* **`confirmDelivered`'s inventory read is not `shouldContinue()`-gated mid-loop,** so a late retirement can land over a superseded mux. It only ever acts on positive host evidence, so this is redundant rather than wrong.

## Deliberately not in this PR

`finishPtyShutdown` marks the lease `terminated` and calls `markClaudePtyExited` on RPC success alone, including on a branch whose own comment says the relay was never asked. By this PR's own standard that is `unverifiable` being written as `exited`. It is **pre-existing**, it is not compounded here — this change no longer touches that function's retirement behaviour at all, and the replay reads `pendingKill` across every lease state, so even a wrongly-tombstoned lease still gets its order replayed. Fixing it properly means settling what counts as proof of death across every `finishPtyShutdown` caller, which deserves its own review rather than riding along. Tracked as follow-up work.

## Fix evidence

Every test was verified to bite by reverting the fix and capturing the red output.

**1. The leak itself** — remove the `recordUndeliveredSshPtyKill` calls from `kill.ts`:

```
 × records the stop when the shutdown RPC rejects with a transport failure 1007ms
 × records the stop when no provider is registered to deliver it 3ms
 FAIL  src/main/ipc/pty-ssh-undelivered-kill.test.ts > undelivered SSH stops > records the stop when the shutdown RPC rejects with a transport failure
 AssertionError: expected "vi.fn()" to be called at least once
 FAIL  src/main/ipc/pty-ssh-undelivered-kill.test.ts > undelivered SSH stops > records the stop when no provider is registered to deliver it
 AssertionError: expected "vi.fn()" to be called with arguments: [ 'ssh-1', 'pty-7', …(1) ]
 Number of calls: 0
      Tests  2 failed | 3 passed (5)
```

**2. Restart survival** — remove `pendingKill` from the lease load whitelist:

```
 × survives an app restart 35ms
 × records an intent for a PTY that has no lease row yet 13ms
 × caps pending kills per target so an unreachable host cannot grow the store 2534ms
 FAIL  src/main/persistence-ssh-pending-pty-kill.test.ts > Store SSH pending PTY kills > survives an app restart
 AssertionError: expected [] to deeply equal [ Array(1) ]
 - Expected
 + Received
 - [
 -   {
 -     "intent": {
 -       "attempts": 0,
 -       "incarnationId": "inc-a",
 -       "requestedAt": 1800000000000,
 -     },
 -     "ptyId": "pty-1",
 -   },
 - ]
 + []
```

**3. The recycled-id fence** — delete the incarnation-mismatch branch:

```
 × retires without killing when the relay id was recycled onto another PTY 3ms
 × refuses to kill a recycled relay id and retires the order instead 2ms
 FAIL  src/shared/ssh-pending-pty-kill.test.ts > decideSshPendingPtyKill > retires without killing when the relay id was recycled onto another PTY
 AssertionError: expected { action: 'replay' } to deeply equal { action: 'retire', …(1) }
 FAIL  src/main/ssh/ssh-pending-pty-kill-replay.test.ts > replayPendingSshPtyKills > refuses to kill a recycled relay id and retires the order instead
 AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 Received:
 Number of calls: 1
```

The unfenced build **kills the recycled PTY**. That is the failure this test exists to prevent.

**4. TTL retirement** — delete the TTL branch:

```
 × retires past the TTL, ahead of every other branch 3ms
 × retires an order past its TTL without aiming it at whatever holds the id now 2ms
 FAIL  src/shared/ssh-pending-pty-kill.test.ts > decideSshPendingPtyKill > retires past the TTL, ahead of every other branch
 AssertionError: expected { action: 'replay' } to deeply equal { action: 'retire', reason: 'expired' }
 FAIL  src/main/ssh/ssh-pending-pty-kill-replay.test.ts > replayPendingSshPtyKills > retires an order past its TTL without aiming it at whatever holds the id now
 AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 Number of calls: 1
```

**5. Bounded growth** — remove the per-target cap:

```
 × caps pending kills per target so an unreachable host cannot grow the store 2722ms
 FAIL  src/main/persistence-ssh-pending-pty-kill.test.ts > Store SSH pending PTY kills > caps pending kills per target so an unreachable host cannot grow the store
 AssertionError: expected [ { targetId: 'ssh-1', …(5) }, …(249) ] to have a length of 200 but got 250
```

**6. The session wiring** — remove the `replayPendingSshPtyKills` call from `reattachKnownPtys`:

```
 × replays a stop the client could not deliver, before reattach reads the leases 5ms
 FAIL  src/main/ssh/ssh-relay-session-pending-kill-replay.test.ts > SshRelaySession pending PTY kill replay > replays a stop the client could not deliver, before reattach reads the leases
 AssertionError: expected "vi.fn()" to be called with arguments: [ 'ssh:target-1@@pty-3', …(1) ]
 Number of calls: 0
```

**7. The renderer kill route** — remove the `recordUndeliveredSshPtyKill` calls from `ipc/renderer-kill.ts` (the `pty:kill` IPC a tab close reaches):

```
 × records the stop when the renderer pty:kill shutdown rejects 3ms
 × records the stop when renderer pty:kill finds no provider to deliver it 1ms
 FAIL  src/main/ipc/pty-ssh-undelivered-kill.test.ts > undelivered SSH stops > records the stop when the renderer pty:kill shutdown rejects
 AssertionError: expected "vi.fn()" to be called with arguments: [ 'ssh-1', 'pty-7', …(1) ]
 Number of calls: 0
 FAIL  src/main/ipc/pty-ssh-undelivered-kill.test.ts > undelivered SSH stops > records the stop when renderer pty:kill finds no provider to deliver it
 AssertionError: expected "vi.fn()" to be called with arguments: [ 'ssh-1', 'pty-7', …(1) ]
 Number of calls: 0
      Tests  2 failed | 8 passed (10)
```

**8. The recycled-id lease expiry** — delete the `relay-id-recycled` branch from `retire()`, leaving the order cleared but the lease active:

```
 × refuses to kill a recycled relay id and expires the lease that named it 3ms
 FAIL  src/main/ssh/ssh-pending-pty-kill-replay.test.ts > replayPendingSshPtyKills > refuses to kill a recycled relay id and expires the lease that named it
 AssertionError: expected [] to deeply equal [ 'pty-1' ]
      Tests  1 failed | 14 passed (15)
```

That is the state in which reattach binds the user's old pane to whatever now holds the recycled id.

**9. The phantom lease's state** — create the invented lease `attached` instead of `terminated`:

```
 × creates the missing lease terminated so reattach cannot adopt it 16ms
 AssertionError: expected 'attached' to be 'terminated' // Object.is equality
      Tests  1 failed | 10 passed (11)
```

**10. The reversible-stop carve-out** — re-add a `recordUndeliveredSshPtyKill` call to the `stopAndWait` failure path, and separately drop the `reversibleStopOwnersByPtyId` guard:

```
 × records nothing for a reversible stopAndWait that could not be delivered 3ms
 FAIL  src/main/ipc/pty-ssh-undelivered-kill.test.ts > undelivered SSH stops > records nothing for a reversible stopAndWait that could not be delivered
 AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 Number of calls: 1
```
```
 × records nothing while a reversible stop owns the PTY 5ms
 AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 Number of calls: 1
```

The other two retirement paths (delivery confirmed, host reports absent), the "still live after a replayed stop" case, the two-round-trip batching bound, and the wire-skew degradation are covered in `src/main/ssh/ssh-pending-pty-kill-replay.test.ts`.

## Checks

* `pnpm tc` clean
* `oxlint` clean repo-wide; no `max-lines` disable added anywhere
* Full unit suite: **64,240 tests passing**, exit 0
* `pnpm test src/main/ipc/ src/main/ssh/` plus the persistence and shared suites — 465 files, 5137 passing

Churn outside the change itself: existing `Store` stubs in the PTY/SSH tests gained the new methods, and the `pty:kill` handler moved from `ipc/inspect.ts` to `ipc/renderer-kill.ts` (a straight lift, plus the recording calls).