### PR TITLE
fix(relay): stop advertising an agent session for a pane whose tab is gone (#12447)

### DIFF
--- a/src/relay/agent-hook-cached-pane-status.ts
+++ b/src/relay/agent-hook-cached-pane-status.ts
@@ -1,0 +1,60 @@
+import type { AgentHookEventPayload } from '../shared/agent-hook-listener/listener-event'
+import type { AgentHookSource } from '../shared/agent-hook-relay'
+
+export type CachedPaneEnvelopeMeta = { source: AgentHookSource; env?: string; version?: string }
+
+export type CachedPaneReplaySelection = {
+  event: AgentHookEventPayload
+  meta: CachedPaneEnvelopeMeta
+}
+
+/**
+ * Chooses which cached pane statuses a reconnecting client may be re-told about, and drops the rest.
+ *
+ * Two panes are refused, for opposite reasons:
+ * - a pane whose surface has been retired — the tab is gone, so replaying its status would hand the
+ *   client a live agent pane nobody owns, which is what drives an auto-resume onto a transcript an
+ *   orphaned agent is still writing;
+ * - a pane whose envelope metadata is missing — the status cache and the metadata map are populated
+ *   and cleared in lockstep, so a key present in one and not the other is drift. Skip rather than
+ *   guess a source that mis-tags the replay downstream.
+ */
+export function selectReplayableCachedPanes(input: {
+  cachedByPaneKey: ReadonlyMap<string, AgentHookEventPayload>
+  metaByPaneKey: ReadonlyMap<string, CachedPaneEnvelopeMeta>
+  isPaneSurfaceRetired: (paneKey: string) => boolean
+  dropPane: (paneKey: string) => void
+}): CachedPaneReplaySelection[] {
+  const selected: CachedPaneReplaySelection[] = []
+  // Snapshot: dropping a retired pane mutates the map being read.
+  for (const [paneKey, event] of Array.from(input.cachedByPaneKey.entries())) {
+    if (input.isPaneSurfaceRetired(paneKey)) {
+      input.dropPane(paneKey)
+      continue
+    }
+    const meta = input.metaByPaneKey.get(paneKey)
+    if (meta) {
+      selected.push({ event, meta })
+    }
+  }
+  return selected
+}
+
+/** How many panes keep a cached status. Bounds a long-lived relay's per-pane state. */
+export const MAX_CACHED_PANES = 256
+
+/** Drop the longest-idle panes until the cache is back under its cap. Map insertion order is
+ *  recency (writers delete-then-set), so the first key is always the oldest. */
+export function evictCachedPanesOverCap(
+  cachedByPaneKey: ReadonlyMap<string, unknown>,
+  dropPane: (paneKey: string) => void,
+  maxPanes: number = MAX_CACHED_PANES
+): void {
+  while (cachedByPaneKey.size > maxPanes) {
+    const oldest = cachedByPaneKey.keys().next().value
+    if (oldest === undefined) {
+      return
+    }
+    dropPane(oldest)
+  }
+}

--- a/src/relay/agent-hook-retired-pane-suppression.test.ts
+++ b/src/relay/agent-hook-retired-pane-suppression.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { RelayAgentHookServer } from './agent-hook-server'
+import { RelayAgentHookRuntime } from './relay-agent-hook-runtime'
+import { RetiredPaneSurfaceRegistry } from './retired-pane-surfaces'
+import type { AgentHookRelayEnvelope } from '../shared/agent-hook-relay'
+import { makePaneKey } from '../shared/stable-pane-id'
+import type { PtyHandler, PtySurfaceRetiredListener } from './pty-handler'
+import type { RelayDispatcher } from './dispatcher'
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const PANE_KEY = makePaneKey('tab-1', LEAF_ID)
+
+function hookMeta(paneKey: string): string {
+  return Buffer.from([paneKey, 'tab-1', '', 'wt-1', 'remote', '1'].join('\x1f')).toString('base64')
+}
+
+async function postHook(
+  server: RelayAgentHookServer,
+  paneKey: string,
+  prompt = 'hi'
+): Promise<number> {
+  const { port, token } = server.getCoordinates()
+  const res = await fetch(`http://127.0.0.1:${port}/hook/claude`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Orca-Agent-Hook-Token': token,
+      'X-Orca-Agent-Hook-Meta-Encoding': 'base64',
+      'X-Orca-Agent-Hook-Meta': hookMeta(paneKey)
+    },
+    body: JSON.stringify({ hook_event_name: 'UserPromptSubmit', prompt })
+  })
+  return res.status
+}
+
+type CachedPanes = { state: { lastStatusByPaneKey: Map<string, unknown> } }
+
+function cachedPaneKeys(server: RelayAgentHookServer): string[] {
+  return [...(server as unknown as CachedPanes).state.lastStatusByPaneKey.keys()]
+}
+
+describe('relay hook forwarding for a retired pane surface', () => {
+  let dir: string
+  let servers: RelayAgentHookServer[]
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'relay-retired-pane-'))
+    servers = []
+  })
+
+  afterEach(() => {
+    for (const server of servers) {
+      server.stop()
+    }
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  async function startServer(options: {
+    forward: (envelope: AgentHookRelayEnvelope) => void
+    isPaneSurfaceRetired?: (paneKey: string) => boolean
+  }): Promise<RelayAgentHookServer> {
+    const server = new RelayAgentHookServer({ endpointDir: dir, ...options })
+    servers.push(server)
+    await server.start({ publishEndpoint: false })
+    return server
+  }
+
+  it('forwards and caches a post from a pane that still has a tab', async () => {
+    const retired = new RetiredPaneSurfaceRegistry()
+    const forward = vi.fn<(envelope: AgentHookRelayEnvelope) => void>()
+    const server = await startServer({
+      forward,
+      isPaneSurfaceRetired: (paneKey) => retired.isRetired(paneKey)
+    })
+
+    expect(await postHook(server, PANE_KEY)).toBe(204)
+
+    expect(forward).toHaveBeenCalledTimes(1)
+    expect(cachedPaneKeys(server)).toEqual([PANE_KEY])
+  })
+
+  it('does not advertise an orphan agent whose tab was closed', async () => {
+    const retired = new RetiredPaneSurfaceRegistry()
+    const forward = vi.fn<(envelope: AgentHookRelayEnvelope) => void>()
+    const server = await startServer({
+      forward,
+      isPaneSurfaceRetired: (paneKey) => retired.isRetired(paneKey)
+    })
+
+    expect(await postHook(server, PANE_KEY, 'first')).toBe(204)
+    forward.mockClear()
+
+    // The user closes the tab; the agent inside the pane shell survives and keeps posting.
+    retired.retire(PANE_KEY)
+    expect(await postHook(server, PANE_KEY, 'orphan')).toBe(204)
+
+    expect(forward).not.toHaveBeenCalled()
+    // The pre-close status must go too, or a reconnect replays it as a live agent pane.
+    expect(cachedPaneKeys(server)).toEqual([])
+  })
+
+  it('does not replay a cached status for a pane retired after it was cached', async () => {
+    const retired = new RetiredPaneSurfaceRegistry()
+    const forward = vi.fn<(envelope: AgentHookRelayEnvelope) => void>()
+    const server = await startServer({
+      forward,
+      isPaneSurfaceRetired: (paneKey) => retired.isRetired(paneKey)
+    })
+
+    expect(await postHook(server, PANE_KEY)).toBe(204)
+    forward.mockClear()
+    retired.retire(PANE_KEY)
+
+    expect(server.replayCachedPayloadsForPanes()).toBe(0)
+    expect(forward).not.toHaveBeenCalled()
+    expect(cachedPaneKeys(server)).toEqual([])
+  })
+
+  it('forwards again once the pane key is bound by a new PTY', async () => {
+    const retired = new RetiredPaneSurfaceRegistry()
+    const forward = vi.fn<(envelope: AgentHookRelayEnvelope) => void>()
+    const server = await startServer({
+      forward,
+      isPaneSurfaceRetired: (paneKey) => retired.isRetired(paneKey)
+    })
+
+    retired.retire(PANE_KEY)
+    expect(await postHook(server, PANE_KEY, 'orphan')).toBe(204)
+    expect(forward).not.toHaveBeenCalled()
+
+    retired.restore(PANE_KEY)
+    expect(await postHook(server, PANE_KEY, 'reopened')).toBe(204)
+
+    expect(forward).toHaveBeenCalledTimes(1)
+  })
+
+  it('an embedder that supplies no retirement source keeps forwarding everything', async () => {
+    const forward = vi.fn<(envelope: AgentHookRelayEnvelope) => void>()
+    const server = await startServer({ forward })
+
+    expect(await postHook(server, PANE_KEY)).toBe(204)
+
+    expect(forward).toHaveBeenCalledTimes(1)
+    expect(cachedPaneKeys(server)).toEqual([PANE_KEY])
+  })
+})
+
+describe('RelayAgentHookRuntime wiring', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'relay-retired-pane-runtime-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('routes hook admission through the PTY handler and drops the cache on retirement', async () => {
+    const retired = new RetiredPaneSurfaceRegistry()
+    const surfaceRetiredListeners: PtySurfaceRetiredListener[] = []
+    const ptyHandler = {
+      addEnvAugmenter: vi.fn(),
+      setExitListener: vi.fn(),
+      setSurfaceRetiredListener: vi.fn((listener: PtySurfaceRetiredListener | null) => {
+        if (listener) {
+          surfaceRetiredListeners.push(listener)
+        }
+      }),
+      isPaneSurfaceRetired: (paneKey: string) => retired.isRetired(paneKey)
+    } as unknown as PtyHandler
+    // Zero attached clients: publishAgentHookEnvelope returns before touching any sink.
+    const dispatcher = {
+      onRequest: vi.fn(),
+      activeClientIds: () => [] as number[]
+    } as unknown as RelayDispatcher
+
+    const runtime = new RelayAgentHookRuntime(
+      dispatcher,
+      ptyHandler,
+      join(dir, 'relay.sock'),
+      join(dir, 'hooks')
+    )
+    await runtime.start()
+    try {
+      const server = (runtime as unknown as { hookServer: RelayAgentHookServer }).hookServer
+      expect(await postHook(server, PANE_KEY)).toBe(204)
+      expect(cachedPaneKeys(server)).toEqual([PANE_KEY])
+
+      // The PTY handler retires the surface: the runtime must drop the cached status immediately,
+      // rather than waiting for a process exit a surviving shell never produces.
+      retired.retire(PANE_KEY)
+      expect(surfaceRetiredListeners).toHaveLength(1)
+      surfaceRetiredListeners[0]({ id: 'pty-1', paneKey: PANE_KEY })
+      expect(cachedPaneKeys(server)).toEqual([])
+
+      expect(await postHook(server, PANE_KEY, 'orphan')).toBe(204)
+      expect(cachedPaneKeys(server)).toEqual([])
+    } finally {
+      runtime.stop()
+    }
+  })
+})

--- a/src/relay/agent-hook-server.ts
+++ b/src/relay/agent-hook-server.ts
@@ -41,10 +41,12 @@ import {
 import { buildRelayHookPtyEnv, defaultEndpointDir } from './agent-hook-endpoint-coordinates'
 import { buildRelayHookEnvelope, hookBodyEnv, hookBodyVersion } from './agent-hook-envelope-build'
 import { AgentHookResultRetryScheduler } from './agent-hook-result-retry-scheduler'
+import {
+  evictCachedPanesOverCap,
+  selectReplayableCachedPanes
+} from './agent-hook-cached-pane-status'
 
 export type RelayHookForward = (envelope: AgentHookRelayEnvelope) => void
-
-const MAX_CACHED_PANES = 256
 
 export type RelayHookServerOptions = {
   /** Where to put endpoint.env / endpoint.cmd. Defaults to `$HOME/.orca-relay/agent-hooks`. */
@@ -56,6 +58,13 @@ export type RelayHookServerOptions = {
   /** Preferred bind port. WSL relay passes the Windows listener's port so env-sourced client coords stay truthful; falls back to :0 if occupied. Defaults to :0. */
   preferredPort?: number
   forward: RelayHookForward
+  /**
+   * True when the host has been told this pane's tab is gone and no PTY has re-bound the paneKey.
+   * Posts from such a pane come from a process the user already closed, so they describe no surface
+   * any client owns. Defaults to "never retired", which is the pre-existing behaviour — a listener
+   * with no PTY handler behind it (the WSL relay) keeps forwarding everything.
+   */
+  isPaneSurfaceRetired?: (paneKey: string) => boolean
 }
 
 export type RelayHookServerStartOptions = {
@@ -81,6 +90,7 @@ export class RelayAgentHookServer {
     { source: AgentHookSource; env?: string; version?: string }
   >()
   private forward: RelayHookForward
+  private isPaneSurfaceRetired: (paneKey: string) => boolean
   private fixedToken: string | undefined
   private preferredPort: number
   private portFallbackApplied = false
@@ -93,6 +103,7 @@ export class RelayAgentHookServer {
     this.fixedToken = options.token
     this.preferredPort = options.preferredPort ?? 0
     this.forward = options.forward
+    this.isPaneSurfaceRetired = options.isPaneSurfaceRetired ?? (() => false)
     this.retryScheduler = new AgentHookResultRetryScheduler({
       state: this.state,
       env: this.env,
@@ -198,19 +209,18 @@ export class RelayAgentHookServer {
   /** Request-driven replay: re-forwards each cached paneKey payload as a fresh notification. Forwards are
    *  issued before the request handler returns, so the response trails all replayed notifications. */
   replayCachedPayloadsForPanes(): number {
-    let count = 0
-    for (const [paneKey, event] of this.state.lastStatusByPaneKey.entries()) {
-      const meta = this.lastEnvelopeMetaByPaneKey.get(paneKey)
-      // Why: invariant — status-cache keys always have meta; if it drifted, skip rather than guess a source that mis-tags downstream.
-      if (!meta) {
-        continue
-      }
+    const replayable = selectReplayableCachedPanes({
+      cachedByPaneKey: this.state.lastStatusByPaneKey,
+      metaByPaneKey: this.lastEnvelopeMetaByPaneKey,
+      isPaneSurfaceRetired: this.isPaneSurfaceRetired,
+      dropPane: (paneKey) => this.clearPaneState(paneKey)
+    })
+    for (const { event, meta } of replayable) {
       this.forward(
         buildRelayHookEnvelope(event, meta.source, meta.env, meta.version, { isReplay: true })
       )
-      count++
     }
-    return count
+    return replayable.length
   }
 
   /** Drop a paneKey's cached entries on PTY exit so a terminated pane can't resurface as a ghost event on reconnect. */
@@ -301,6 +311,14 @@ export class RelayAgentHookServer {
     version?: string,
     options: { isReplay?: boolean } = {}
   ): void {
+    // Why: this post came from a process still running inside a pane whose tab the user closed.
+    // Caching or forwarding it makes every connected client advertise a live, resumable agent pane
+    // that no tab owns — the advertisement that ends up auto-typing a second `--resume` onto a
+    // transcript the orphan is still writing (#12447). Drop the stale cache with it.
+    if (this.isPaneSurfaceRetired(event.paneKey)) {
+      this.clearPaneState(event.paneKey)
+      return
+    }
     if (event.payload.state !== 'done' || event.payload.lastAssistantMessage) {
       this.retryScheduler.clearAssistantMessageRetry(event.paneKey)
     }
@@ -313,13 +331,7 @@ export class RelayAgentHookServer {
     this.state.lastStatusByPaneKey.set(event.paneKey, cachedEvent)
     this.lastEnvelopeMetaByPaneKey.delete(event.paneKey)
     this.lastEnvelopeMetaByPaneKey.set(event.paneKey, { source, env, version })
-    while (this.state.lastStatusByPaneKey.size > MAX_CACHED_PANES) {
-      const oldest = this.state.lastStatusByPaneKey.keys().next().value
-      if (oldest === undefined) {
-        break
-      }
-      this.clearPaneState(oldest)
-    }
+    evictCachedPanesOverCap(this.state.lastStatusByPaneKey, (key) => this.clearPaneState(key))
     this.forward(buildRelayHookEnvelope(event, source, env, version, options))
   }
 

--- a/src/relay/pty-handler-retired-pane-surface.test.ts
+++ b/src/relay/pty-handler-retired-pane-surface.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+const { mockPtySpawn, mockPtyInstance, mockCreateShellPromptReadinessProbe } = vi.hoisted(() => ({
+  mockPtySpawn: vi.fn(),
+  mockCreateShellPromptReadinessProbe: vi.fn(),
+  mockPtyInstance: {
+    pid: process.pid,
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    clear: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn()
+  }
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: mockPtySpawn
+}))
+
+vi.mock('../main/pty/posix-pty-process-groups', () => ({
+  forceKillPosixPtyProcessGroups: vi.fn((_pid: number, fallback: () => void) => fallback())
+}))
+
+vi.mock('../main/shell-prompt-readiness-probe', () => ({
+  createShellPromptReadinessProbe: mockCreateShellPromptReadinessProbe
+}))
+
+import * as ptyShellUtils from './pty-shell-utils'
+import type { PtyHandler } from './pty-handler'
+import {
+  IMMEDIATE_PTY_EXIT_TIMEOUT_MS,
+  SHUTDOWN_REAP_MAX_SWEEPS,
+  SHUTDOWN_REAP_VERIFY_DELAY_MS
+} from './pty-handler'
+import {
+  beginPtyHandlerTest,
+  createPtyRequestHelpers,
+  endPtyHandlerTest
+} from './pty-handler-test-harness'
+import type { MockDispatcher } from './pty-handler-test-harness'
+
+const PANE_KEY = 'tab-agent:22222222-2222-4222-8222-222222222222'
+
+const AGENT_SESSION_ENSURE = {
+  claim: {
+    digestVersion: 1,
+    keyId: 'claim-key',
+    identityDigest: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    worktreeScopeDigest: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    agent: 'claude'
+  },
+  surface: {
+    worktreeId: 'repo::/tmp/worktree',
+    tabId: '11111111-1111-4111-8111-111111111111',
+    leafId: '22222222-2222-4222-8222-222222222222',
+    terminalHandle: 'term_claimed'
+  }
+}
+
+type ProcessSummary = {
+  id: string
+  agentSessionOwners?: unknown[]
+}
+
+describe('PtyHandler retires a closed pane surface', () => {
+  let dispatcher: MockDispatcher
+  let handler: PtyHandler
+  let originalPlatform: PropertyDescriptor | undefined
+
+  const { spawnPty } = createPtyRequestHelpers(() => dispatcher)
+
+  async function spawnAgentPane(
+    params: Record<string, unknown> = {}
+  ): Promise<{ id: string; term: typeof mockPtyInstance }> {
+    const term = { ...mockPtyInstance, kill: vi.fn(), onData: vi.fn(), onExit: vi.fn() }
+    mockPtySpawn.mockReturnValue(term)
+    const spawned = await spawnPty({
+      env: { ORCA_PANE_KEY: PANE_KEY },
+      agentSessionEnsure: AGENT_SESSION_ENSURE,
+      ...params
+    })
+    return { id: spawned.id, term }
+  }
+
+  async function listProcesses(): Promise<ProcessSummary[]> {
+    return (await dispatcher.callRequest('pty.listProcesses', {})) as ProcessSummary[]
+  }
+
+  beforeEach(() => {
+    ;({ dispatcher, handler, originalPlatform } = beginPtyHandlerTest({
+      mockPtySpawn,
+      mockPtyInstance,
+      mockCreateShellPromptReadinessProbe
+    }))
+  })
+
+  afterEach(async () => {
+    await endPtyHandlerTest(handler, originalPlatform)
+  })
+
+  it('marks the pane surface retired as soon as its tab is closed', async () => {
+    const retired: { id: string; paneKey: string }[] = []
+    handler.setSurfaceRetiredListener((event) => retired.push(event))
+    const { id } = await spawnAgentPane()
+
+    expect(handler.isPaneSurfaceRetired(PANE_KEY)).toBe(false)
+
+    await dispatcher.callRequest('pty.shutdown', { id })
+
+    expect(handler.isPaneSurfaceRetired(PANE_KEY)).toBe(true)
+    expect(retired).toEqual([{ id, paneKey: PANE_KEY }])
+  })
+
+  it('retires the surface even when the shell survives the kill request', async () => {
+    vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValue(true)
+    const { id } = await spawnAgentPane()
+
+    await dispatcher.callRequest('pty.shutdown', { id })
+    await vi.advanceTimersByTimeAsync(
+      SHUTDOWN_REAP_VERIFY_DELAY_MS * (SHUTDOWN_REAP_MAX_SWEEPS + 2)
+    )
+
+    // The process could not be verified gone, so the claim is deliberately kept — releasing it is
+    // what would let a reopened project fork a second agent onto the same transcript.
+    expect(handler.isPaneSurfaceRetired(PANE_KEY)).toBe(true)
+    const sessions = await listProcesses()
+    expect(sessions.map((session) => session.id)).toEqual([id])
+  })
+
+  it('re-issues the force kill instead of letting a detached shell outlive its tab', async () => {
+    vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValue(true)
+    const { id, term } = await spawnAgentPane()
+
+    await dispatcher.callRequest('pty.shutdown', { id })
+    // The graceful path's own armed fallback fires first; count only what the sweep adds.
+    await vi.advanceTimersByTimeAsync(SHUTDOWN_REAP_VERIFY_DELAY_MS - 1)
+    const killsBeforeSweep = term.kill.mock.calls.filter(([signal]) => signal === 'SIGKILL').length
+
+    await vi.advanceTimersByTimeAsync(
+      SHUTDOWN_REAP_VERIFY_DELAY_MS * (SHUTDOWN_REAP_MAX_SWEEPS + 2)
+    )
+
+    const killsAfterSweep = term.kill.mock.calls.filter(([signal]) => signal === 'SIGKILL').length
+    expect(killsAfterSweep - killsBeforeSweep).toBe(SHUTDOWN_REAP_MAX_SWEEPS)
+  })
+
+  it('never re-closes a ConPTY handle on Windows, where the first kill is already final', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValue(true)
+    const { id, term } = await spawnAgentPane()
+
+    // The immediate path is the one that reaches ConPTY's kill without setting gracefulKillSent.
+    const shutdown = dispatcher.callRequest('pty.shutdown', { id, immediate: true })
+    const rejected = expect(shutdown).rejects.toThrow('Timed out waiting for PTY process exit')
+    await vi.advanceTimersByTimeAsync(IMMEDIATE_PTY_EXIT_TIMEOUT_MS)
+    await rejected
+    await vi.advanceTimersByTimeAsync(
+      SHUTDOWN_REAP_VERIFY_DELAY_MS * (SHUTDOWN_REAP_MAX_SWEEPS + 2)
+    )
+
+    expect(term.kill.mock.calls).toHaveLength(1)
+  })
+
+  it('retires the relay session once the sweep proves the process is gone', async () => {
+    const exits: { id: string; paneKey?: string }[] = []
+    handler.setExitListener((event) => exits.push(event))
+    const alive = vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValue(true)
+    const { id } = await spawnAgentPane()
+
+    expect((await listProcesses())[0]?.agentSessionOwners).toHaveLength(1)
+
+    await dispatcher.callRequest('pty.shutdown', { id })
+    alive.mockReturnValue(false)
+    await vi.advanceTimersByTimeAsync(SHUTDOWN_REAP_VERIFY_DELAY_MS + 1)
+
+    // The sweep itself must retire it — node-pty produced no exit, and nothing here polls a listing.
+    expect(exits).toEqual([{ id, paneKey: PANE_KEY }])
+    expect(await listProcesses()).toEqual([])
+  })
+
+  it('stops advertising an agent session whose process died without a node-pty exit', async () => {
+    const alive = vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValue(true)
+    await spawnAgentPane()
+
+    expect((await listProcesses())[0]?.agentSessionOwners).toHaveLength(1)
+
+    // No shutdown, no onExit — the shell just went away. The relay has to look.
+    alive.mockReturnValue(false)
+
+    expect(await listProcesses()).toEqual([])
+  })
+
+  it('restores the surface when a new PTY binds the same pane key', async () => {
+    const { id } = await spawnAgentPane()
+    await dispatcher.callRequest('pty.shutdown', { id })
+    expect(handler.isPaneSurfaceRetired(PANE_KEY)).toBe(true)
+
+    const term = { ...mockPtyInstance, kill: vi.fn(), onData: vi.fn(), onExit: vi.fn() }
+    mockPtySpawn.mockReturnValue(term)
+    await spawnPty({ env: { ORCA_PANE_KEY: PANE_KEY } })
+
+    expect(handler.isPaneSurfaceRetired(PANE_KEY)).toBe(false)
+  })
+
+  it('restores the surface when a client reattaches to a shut-down PTY that survived', async () => {
+    vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValue(true)
+    const { id } = await spawnAgentPane()
+    await dispatcher.callRequest('pty.shutdown', { id })
+    expect(handler.isPaneSurfaceRetired(PANE_KEY)).toBe(true)
+
+    await dispatcher.callRequest('pty.attach', { id })
+
+    expect(handler.isPaneSurfaceRetired(PANE_KEY)).toBe(false)
+  })
+
+  it('shutting down a pane with no pane key retires nothing', async () => {
+    const retired: { id: string; paneKey: string }[] = []
+    handler.setSurfaceRetiredListener((event) => retired.push(event))
+    const term = { ...mockPtyInstance, kill: vi.fn(), onData: vi.fn(), onExit: vi.fn() }
+    mockPtySpawn.mockReturnValue(term)
+    const spawned = await spawnPty({})
+
+    await dispatcher.callRequest('pty.shutdown', { id: spawned.id })
+
+    expect(retired).toEqual([])
+  })
+})

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -17,6 +17,7 @@ import {
   listShellProfiles
 } from './pty-shell-utils'
 import { getRelayShellLaunchConfig, isRelayWslShell } from './pty-shell-launch'
+import { RetiredPaneSurfaceRegistry } from './retired-pane-surfaces'
 import { addWslEnvKeys } from '../shared/wsl-env'
 import { SHELL_STARTUP_FEATURE_ENV } from '../main/shell-startup-features'
 import { DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS } from '../shared/ssh-types'
@@ -151,6 +152,9 @@ type ManagedPty = {
   buffered: RecentPtyOutputBuffer
   /** Timer for SIGKILL fallback after a graceful SIGTERM shutdown. */
   killTimer?: ReturnType<typeof setTimeout>
+  /** Timer for the post-shutdown reap sweep: re-probes liveness after a kill request instead of
+   *  assuming the request landed. */
+  reapTimer?: ReturnType<typeof setTimeout>
   /** True once disposeManagedPty has run; blocks double-dispose and makes post-dispose calls fail "not found" not silently. */
   disposed?: boolean
   /** True once external cleanup observers have been notified. */
@@ -242,6 +246,10 @@ function disposeManagedPty(managed: ManagedPty): void {
     clearTimeout(managed.killTimer)
     managed.killTimer = undefined
   }
+  if (managed.reapTimer) {
+    clearTimeout(managed.reapTimer)
+    managed.reapTimer = undefined
+  }
   // Why: neutralize pty.kill before destroy() so UnixTerminal's async 'close' SIGHUP can't hit a recycled pid.
   // Windows exempt: its destroy() IS a kill() (via _deferNoArgs), so neutralizing leaks the ConPTY agent.
   if (process.platform !== 'win32') {
@@ -258,6 +266,9 @@ function disposeManagedPty(managed: ManagedPty): void {
 }
 const DEFAULT_GRACE_TIME_MS = DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS * 1000
 export const IMMEDIATE_PTY_EXIT_TIMEOUT_MS = 8_000
+/** Longer than the 5s armed SIGKILL fallback, so the first sweep observes the post-kill state. */
+export const SHUTDOWN_REAP_VERIFY_DELAY_MS = 6_000
+export const SHUTDOWN_REAP_MAX_SWEEPS = 3
 export const MAX_RELAY_PTY_SESSIONS = 50
 export const REPLAY_BUFFER_MAX = 100 * 1024
 const PTY_OUTPUT_BATCH_INTERVAL_MS = 8
@@ -389,6 +400,10 @@ function sanitizeEnvToDelete(value: unknown): string[] {
 
 export type PtyExitListener = (event: { id: string; paneKey?: string }) => void
 
+/** Notified when a client retires a pane's surface (`pty.shutdown`). Deliberately separate from
+ *  {@link PtyExitListener}: retirement says the tab is gone, never that the process exited. */
+export type PtySurfaceRetiredListener = (event: { id: string; paneKey: string }) => void
+
 type PtyIdentity = { paneKey?: string; tabId?: string }
 
 /**
@@ -443,6 +458,8 @@ export class PtyHandler {
   private reloadPtyModuleFromDisk = false
   // Why: single optional slot is intentional — callers compose externally; a throw is swallowed so it can't block cleanup.
   private exitListener: PtyExitListener | null = null
+  private surfaceRetiredListener: PtySurfaceRetiredListener | null = null
+  private readonly retiredPaneSurfaces = new RetiredPaneSurfaceRegistry()
   private ptyPoolEmptyListener: (() => void) | null = null
   private ptyPoolActiveListener: (() => void) | null = null
   // Why: augment environment on every spawn so PTYs receive current hook coordinates.
@@ -569,6 +586,19 @@ export class PtyHandler {
   /** Subscribe to PTY-exit events (relay-hook server uses this to evict per-paneKey caches). */
   setExitListener(listener: PtyExitListener | null): void {
     this.exitListener = listener
+  }
+
+  /** Subscribe to pane-surface retirement (relay-hook server uses this to drop the pane's cached
+   *  agent status the moment the tab goes away, rather than waiting for a process exit that a
+   *  surviving shell may never produce). */
+  setSurfaceRetiredListener(listener: PtySurfaceRetiredListener | null): void {
+    this.surfaceRetiredListener = listener
+  }
+
+  /** True when the client has told this host the pane's tab is gone and no PTY has re-bound the
+   *  paneKey since. Nothing this pane emits can belong to a surface any client still owns. */
+  isPaneSurfaceRetired(paneKey: string): boolean {
+    return this.retiredPaneSurfaces.isRetired(paneKey)
   }
 
   /** Notified when the last PTY leaves the pool, so the relay can re-arm its idle grace. */
@@ -786,6 +816,12 @@ export class PtyHandler {
   private wireAndStore(managed: ManagedPty): void {
     managed.physicalExit = new PhysicalExitTracker()
     this.ptys.set(managed.id, managed)
+    // Why: a PTY joining the pool under this paneKey means the surface exists again (reopened pane
+    // or revive), so a prior retirement no longer describes anything and must not mute its hooks.
+    const boundPaneKey = managed.paneKey ?? managed.attachIdentity?.paneKey
+    if (boundPaneKey) {
+      this.retiredPaneSurfaces.restore(boundPaneKey)
+    }
     // Why: a second announce covers any store whose admission window has already closed.
     this.notifyPoolListener(this.ptyPoolActiveListener, 'pty-pool-active')
     const emitIngressData = (emission: PtyIngressEmission): void => {
@@ -1778,14 +1814,7 @@ export class PtyHandler {
 
     // Why: verify liveness because shells can exit without node-pty onExit.
     if (managed.pty.pid && !isProcessAlive(managed.pty.pid)) {
-      managed.physicalExit?.markExited()
-      this.releaseRelayIngress(managed)
-      this.flushPtyOutput(id)
-      this.notifyExitListener(managed)
-      this.agentSessionOwners.release(managed.id)
-      disposeManagedPty(managed)
-      this.removePty(id)
-      this.clearPtyFlowState(id)
+      this.reapExitedPty(managed)
       throw new Error(`PTY "${id}" not found`)
     }
 
@@ -1799,6 +1828,14 @@ export class PtyHandler {
     )
     if (mismatch) {
       throw new Error(`PTY "${id}" not found (identity mismatch)`)
+    }
+
+    // Why: an accepted attach is a client surface for this pane, so a prior retirement no longer
+    // describes anything — without this a reattach to a shut-down-but-surviving PTY would keep the
+    // pane's agent hooks muted for the rest of the daemon's life.
+    const attachedPaneKey = managed.paneKey ?? managed.attachIdentity?.paneKey
+    if (attachedPaneKey) {
+      this.retiredPaneSurfaces.restore(attachedPaneKey)
     }
 
     managed.startupIngress?.snapshotBarrier()
@@ -1917,6 +1954,17 @@ export class PtyHandler {
     if (!managed) {
       return
     }
+    // Why: `pty.shutdown` is the only authoritative statement this host ever gets that a tab is
+    // gone. Record it before the kill request, because the kill is the part that can fail: an agent
+    // that survives teardown otherwise keeps posting hooks the relay forwards as a live agent pane
+    // with no tab, and that advertisement is what drives a second `--resume` onto its transcript.
+    // Why gated on an actual retirement: the teardown below is fire-and-forget — one SIGTERM, one
+    // armed SIGKILL, and nobody ever looks again. Re-probing is what stops a retired pane's shell
+    // outliving its tab; a PTY with no pane surface has nothing to outlive, so its long-standing
+    // teardown contract is left exactly as it was.
+    if (this.retirePaneSurface(managed)) {
+      this.armShutdownReapSweep(managed, SHUTDOWN_REAP_MAX_SWEEPS)
+    }
 
     if (immediate) {
       this.releaseStartupCommand(managed)
@@ -1928,6 +1976,93 @@ export class PtyHandler {
       this.releaseStartupCommand(managed)
       this.requestGracefulKill(managed, 'force-kill')
     }
+  }
+
+  /** Record that this pane's client surface is gone, and tell the hook server so the pane's cached
+   *  agent status stops being replayed to reconnecting clients. Returns false when there is no pane
+   *  surface to retire. */
+  private retirePaneSurface(managed: ManagedPty): boolean {
+    const paneKey = managed.paneKey ?? managed.attachIdentity?.paneKey
+    if (!paneKey) {
+      return false
+    }
+    this.retiredPaneSurfaces.retire(paneKey)
+    const listener = this.surfaceRetiredListener
+    if (!listener) {
+      return true
+    }
+    try {
+      listener({ id: managed.id, paneKey })
+    } catch (err) {
+      process.stderr.write(
+        `[pty-handler] surface-retired listener threw: ${err instanceof Error ? err.message : String(err)}\n`
+      )
+    }
+    return true
+  }
+
+  /**
+   * After a retirement, verify the host actually reaped the shell rather than trusting the kill
+   * request. Two outcomes matter and both are bookkeeping the relay previously never did:
+   *
+   * - the pid is gone but node-pty never produced `onExit` — retire the record here, so the entry
+   *   and its agent-session owners stop being published by `pty.listProcesses`;
+   * - the pid is still alive — re-issue the force kill instead of leaving a detached shell (and the
+   *   agent inside it) outliving its tab for the life of the daemon.
+   *
+   * Bounded: after {@link SHUTDOWN_REAP_MAX_SWEEPS} the owner claim is deliberately *retained*.
+   * Releasing a claim we cannot prove dead is what lets a reopened project spawn a second agent
+   * over one transcript; keeping it makes the next `pty.spawn` adopt this PTY instead.
+   */
+  private armShutdownReapSweep(managed: ManagedPty, attemptsRemaining: number): void {
+    if (managed.reapTimer) {
+      return
+    }
+    const timer = setTimeout(() => {
+      managed.reapTimer = undefined
+      if (this.ptys.get(managed.id) !== managed || managed.disposed) {
+        return
+      }
+      const pid = managed.pty.pid
+      if (pid && !isProcessAlive(pid)) {
+        this.reapExitedPty(managed)
+        return
+      }
+      if (attemptsRemaining <= 0) {
+        process.stderr.write(
+          `[pty-handler] retired pane PTY ${managed.id} still alive after force kill; ownership retained as unverifiable\n`
+        )
+        return
+      }
+      // Why POSIX-only: a SIGKILL that returned success is not proof of death there — the group
+      // probe can degrade to a root-pid kill, leaving the agent running under a shell nobody is
+      // watching. On Windows ConPTY's kill is already force-final and closing its handle twice is
+      // the hazard disposeManagedPty guards against, so the probe above is the whole sweep.
+      if (process.platform !== 'win32') {
+        managed.forceKillSent = false
+        try {
+          this.requestForceKill(managed)
+        } catch {
+          /* Re-probed on the next sweep; a transient failure must not end the escalation. */
+        }
+      }
+      this.armShutdownReapSweep(managed, attemptsRemaining - 1)
+    }, SHUTDOWN_REAP_VERIFY_DELAY_MS)
+    timer.unref?.()
+    managed.reapTimer = timer
+  }
+
+  /** Retire every record for a PTY whose process is proven gone. Shared by the attach probe, the
+   *  listing probe and the post-shutdown sweep so the three cannot drift on what "gone" retires. */
+  private reapExitedPty(managed: ManagedPty): void {
+    managed.physicalExit?.markExited()
+    this.releaseRelayIngress(managed)
+    this.flushPtyOutput(managed.id)
+    this.notifyExitListener(managed)
+    this.agentSessionOwners.release(managed.id)
+    disposeManagedPty(managed)
+    this.removePty(managed.id)
+    this.clearPtyFlowState(managed.id)
   }
 
   private async sendSignal(params: Record<string, unknown>): Promise<void> {
@@ -2101,7 +2236,15 @@ export class PtyHandler {
 
   private async listProcesses(): Promise<PtyProcessSummary[]> {
     const results: PtyProcessSummary[] = []
-    for (const [id, managed] of this.ptys) {
+    // Why (SSH-v3 P2 — the host is the authoritative liveness source, so it has to look): this
+    // listing is what publishes `agentSessionOwners`, i.e. "there is a live agent session here you
+    // can adopt". A shell can exit without node-pty's onExit, and an unverified entry advertised
+    // that session forever. Snapshot the map because reaping mutates it.
+    for (const [id, managed] of Array.from(this.ptys)) {
+      if (managed.disposed || (managed.pty.pid && !isProcessAlive(managed.pty.pid))) {
+        this.reapExitedPty(managed)
+        continue
+      }
       const title =
         (await getForegroundProcessName(managed.pty.pid, managed.pty.process || null)) || 'shell'
       results.push({

--- a/src/relay/relay-agent-hook-runtime.ts
+++ b/src/relay/relay-agent-hook-runtime.ts
@@ -30,7 +30,10 @@ export class RelayAgentHookRuntime {
   ) {
     this.hookServer = new RelayAgentHookServer({
       endpointDir: endpointDir ?? endpointDirForRelaySocket(sockPath),
-      forward: (envelope) => publishAgentHookEnvelope(dispatcher, envelope)
+      forward: (envelope) => publishAgentHookEnvelope(dispatcher, envelope),
+      // Why: the PTY handler is the only component that knows which panes still have a client
+      // surface, so it — not the client — decides whether a hook post describes a live pane.
+      isPaneSurfaceRetired: (paneKey) => ptyHandler.isPaneSurfaceRetired(paneKey)
     })
   }
 
@@ -62,6 +65,12 @@ export class RelayAgentHookRuntime {
         this.hookServer.clearPaneState(paneKey)
       }
       this.pluginOverlay.clearOverlay(paneKey ?? id)
+    })
+    // Why: the exit listener above only fires on proof of process death, which a shell that
+    // survives teardown never produces. Drop the pane's cached status the moment its tab goes, so a
+    // reconnecting client cannot be handed a replay of an agent nobody owns.
+    this.ptyHandler.setSurfaceRetiredListener(({ paneKey }) => {
+      this.hookServer.clearPaneState(paneKey)
     })
   }
 

--- a/src/relay/retired-pane-surfaces.test.ts
+++ b/src/relay/retired-pane-surfaces.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { RETIRED_PANE_SURFACE_LIMIT, RetiredPaneSurfaceRegistry } from './retired-pane-surfaces'
+
+describe('RetiredPaneSurfaceRegistry', () => {
+  it('records a retired pane and forgets it once the surface exists again', () => {
+    const registry = new RetiredPaneSurfaceRegistry()
+
+    expect(registry.isRetired('pane-a')).toBe(false)
+    registry.retire('pane-a')
+    expect(registry.isRetired('pane-a')).toBe(true)
+
+    registry.restore('pane-a')
+    expect(registry.isRetired('pane-a')).toBe(false)
+  })
+
+  it('ignores empty pane keys rather than retiring a catch-all entry', () => {
+    const registry = new RetiredPaneSurfaceRegistry()
+
+    registry.retire('')
+    expect(registry.size).toBe(0)
+    expect(registry.isRetired('')).toBe(false)
+  })
+
+  it('caps growth by evicting the longest-retired pane', () => {
+    const registry = new RetiredPaneSurfaceRegistry()
+
+    for (let index = 0; index < RETIRED_PANE_SURFACE_LIMIT + 25; index += 1) {
+      registry.retire(`pane-${index}`)
+    }
+
+    expect(registry.size).toBe(RETIRED_PANE_SURFACE_LIMIT)
+    expect(registry.isRetired('pane-0')).toBe(false)
+    expect(registry.isRetired('pane-24')).toBe(false)
+    expect(registry.isRetired('pane-25')).toBe(true)
+    expect(registry.isRetired(`pane-${RETIRED_PANE_SURFACE_LIMIT + 24}`)).toBe(true)
+  })
+
+  it('re-retiring refreshes recency so an active pane is not evicted first', () => {
+    const registry = new RetiredPaneSurfaceRegistry()
+
+    registry.retire('pane-oldest')
+    for (let index = 0; index < RETIRED_PANE_SURFACE_LIMIT - 1; index += 1) {
+      registry.retire(`pane-${index}`)
+    }
+    registry.retire('pane-oldest')
+    registry.retire('pane-overflow')
+
+    expect(registry.isRetired('pane-oldest')).toBe(true)
+    expect(registry.isRetired('pane-0')).toBe(false)
+  })
+})

--- a/src/relay/retired-pane-surfaces.ts
+++ b/src/relay/retired-pane-surfaces.ts
@@ -1,0 +1,55 @@
+/**
+ * PaneKeys whose client surface the host has been told is gone — a `pty.shutdown` arrived for the
+ * PTY bound to them — but whose host-side process the relay has not proven dead.
+ *
+ * Retirement is deliberately NOT a liveness verdict. Per docs/reference/ssh-execution-boundary.md
+ * the vocabulary stays `live` / `unverifiable` / `exited`, and this registry asserts none of them
+ * about the process: it records only that no client tab can own this pane any more. That is the
+ * fact the relay needs to tell an orphaned agent's hook post apart from a live agent pane, and it
+ * is knowable without guessing, because the client stated it.
+ */
+
+/** Bounded so a long-lived relay cannot accumulate one entry per pane ever closed. Insertion order
+ *  is age, so eviction drops the longest-retired pane first; an evicted pane simply degrades to the
+ *  pre-fix behaviour (its posts are forwarded again) rather than failing. */
+export const RETIRED_PANE_SURFACE_LIMIT = 512
+
+export class RetiredPaneSurfaceRegistry {
+  private readonly retired = new Set<string>()
+
+  retire(paneKey: string): void {
+    if (!paneKey) {
+      return
+    }
+    // Delete-then-add makes iteration order = recency of retirement for the cap below.
+    this.retired.delete(paneKey)
+    this.retired.add(paneKey)
+    while (this.retired.size > RETIRED_PANE_SURFACE_LIMIT) {
+      const oldest = this.retired.values().next().value
+      if (oldest === undefined) {
+        break
+      }
+      this.retired.delete(oldest)
+    }
+  }
+
+  /** A PTY joining the pool under this paneKey means the surface exists again — the user reopened
+   *  the pane, or a revive re-bound it — so the retirement no longer describes anything. */
+  restore(paneKey: string): void {
+    if (paneKey) {
+      this.retired.delete(paneKey)
+    }
+  }
+
+  isRetired(paneKey: string): boolean {
+    return Boolean(paneKey) && this.retired.has(paneKey)
+  }
+
+  get size(): number {
+    return this.retired.size
+  }
+
+  clear(): void {
+    this.retired.clear()
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​487 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​487 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​307 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​279 |

<!-- /orca-pr-loc -->

Closes the server-side half of #12447 — @chanmuzi's relay dataset. Relay-side only; no wire change.

### ELI5

Orca runs a small helper — the **relay** — on your SSH host. It owns your remote terminals, and it also runs a tiny web server that your agent (`claude`, `codex`, …) posts status updates to: *"I'm working"*, *"I'm waiting for you"*, *"I'm done"*. The relay forwards those to every connected Orca so the sidebar can show a live agent.

When you close an agent tab, Orca asks the relay to kill that terminal. Usually it dies. Sometimes it doesn't — an interactive shell ignores the polite signal, or the forceful one only reaches the shell and not the agent inside it. When that happens, **the agent is still alive and still posting status updates**, and the relay had no idea it should stop listening. It kept forwarding them. So every Orca on that host kept being told there was a live agent in a pane that no longer had a tab — and the next time you opened the project, Orca did what you'd want it to do for a live agent it had lost track of: it opened a terminal and typed `claude --resume <that session>`.

Now you have **two `claude` processes writing into one conversation transcript**. That is not recoverable.

The relay's mistake was believing the kill worked. It never asked again, and it never wrote down the one thing it *did* know for certain: **you closed the tab.**

After this change the relay writes that down. The moment `pty.shutdown` arrives, the pane is *retired*:

- its cached agent status is dropped, so a reconnecting Orca is never replayed a live agent for it;
- anything that pane posts afterwards is **thrown away, not forwarded** — an orphan can no longer advertise itself;
- the relay comes back a few seconds later and **checks whether the shell actually died**, and force-kills again if it didn't, instead of assuming;
- if it can prove the process is gone, it retires the whole record — even when the terminal library never reported the exit.

And one deliberate non-action: if the relay **cannot** prove the process died, it **keeps** the agent-session ownership claim. That sounds backwards, but it is the safety property. That claim is what makes the next terminal you open **adopt the surviving pane** instead of starting a second agent on the same transcript. An honest "I can't verify this" keeps you at one agent; forgetting would take you to two.

---

## Root cause

**`PtyHandler.shutdown()` — `src/relay/pty-handler.ts:1939` (pre-change).**

```ts
const managed = this.ptys.get(id)
if (!managed) { return }
if (immediate) { … requestForceKill … } else { … requestGracefulKill … }
```

`pty.shutdown` is the only authoritative statement the relay ever receives that a tab has closed, and it **retired nothing**. It requested a kill and returned. Every retirement path in the relay keys on *proof of process death*, and there are exactly three:

| site | trigger |
| --- | --- |
| `pty-handler.ts:872` (`onExit`) | node-pty reported the child exited |
| `pty-handler.ts:1785` (`attach`) | an attach probed `isProcessAlive` and found the pid gone |
| `pty-handler.ts:2406` (`disposePtyForRelayShutdown`) | the whole daemon is going down |

Client disconnect retires nothing either (`relay-reconnect-listener.ts:120` → `dispatcher.ts:185` only close the writer), and the shipped grace is unlimited (`DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS = 0`, `src/shared/ssh-types.ts:7`), so with ≥1 live PTY nothing is ever armed.

So when the kill did not actually reap the pane shell — SIGTERM ignored by an interactive shell, or `forceKillPosixPtyProcessGroups` degrading to a root-pid kill when `getPosixPtyProcessGroups` returns `null` (`src/main/pty/posix-pty-process-groups.ts:99-108`) — **two advertisements survived the tab**:

1. **`src/relay/agent-hook-server.ts:301` (`applyEvent`).** The orphaned agent keeps POSTing to the relay's loopback hook listener with the closed pane's `ORCA_PANE_KEY`. `applyEvent` cached it in `lastStatusByPaneKey` and `forward`ed it to every connected client as an `agent.hook` notification — **with no check whatsoever that the relay still serves a PTY for that paneKey**. `replayCachedPayloadsForPanes` (`:200`) then re-published it on the next `agent_hook.requestReplay`, i.e. on every reconnect. The only eviction was `clearPaneState`, reachable solely through `notifyExitListener` — the exit that never came.

2. **`src/relay/pty-handler.ts:2114` (`listProcesses`).** This is what publishes `agentSessionOwners`, the host's "there is a live agent session here you can adopt". It iterated `this.ptys` and emitted the registry entry **with no liveness verification at all** — while `attach()` fourteen hundred lines earlier does exactly that probe and reaps ("*verify liveness because shells can exit without node-pty onExit*", `:1812`).

That is the loop @chanmuzi reported, and it needs no lost kill RPC to close: close → shell survives → orphan advertises → reopen resumes → two agents, one transcript.

## The fix

All hunks are relay-side. Per SSH-v3 P2 the host is the authoritative liveness source, so it has to **look**, and it must not advertise what it has not verified.

**1. `pty.shutdown` retires the pane surface (`pty-handler.ts`, `retired-pane-surfaces.ts`).** A new `RetiredPaneSurfaceRegistry` records paneKeys whose tab the client has said is gone. Retirement is deliberately **not** a liveness verdict — the vocabulary stays `live` / `unverifiable` / `exited` and this asserts none of them about the process. It records only that no client tab can own this pane any more, which is knowable without guessing *because the client stated it*. A new `setSurfaceRetiredListener` seam is kept separate from `PtyExitListener` for exactly that reason: retirement must never read as an exit. A PTY that later binds the same paneKey — a reopened pane, a revive, or an accepted `pty.attach` — clears the retirement.

**2. A retired pane cannot advertise (`agent-hook-server.ts`, `agent-hook-cached-pane-status.ts`, `relay-agent-hook-runtime.ts`).** `applyEvent` drops — does not cache, does not forward — a post from a retired pane, and drops the pane's stale cache with it. `replayCachedPayloadsForPanes` re-checks at replay time, because retirement can be recorded after the status was cached. The runtime routes the predicate to `ptyHandler.isPaneSurfaceRetired` and clears the cache eagerly on the retirement edge.

**3. The kill is verified, not assumed (`armShutdownReapSweep`).** A bounded, unref'd sweep (3 escalations, ~6s apart) re-probes `isProcessAlive`. Gone → run the full retirement even though node-pty never produced `onExit`. Still alive → re-issue the force kill, because *a SIGKILL that returned success is not proof of death*. POSIX only: on Windows ConPTY's kill is already force-final and re-closing the handle is the hazard `disposeManagedPty` guards against.

**4. `listProcesses` verifies before it advertises.** A PTY that is disposed, or whose pid probes dead, is reaped (shared `reapExitedPty`, now used by all three probes so they cannot drift) instead of being published with its `agentSessionOwners`.

### The deliberate non-fix, and why it is the safety property

**When the sweep exhausts its attempts, the agent-session ownership claim is retained, not released.** Releasing a claim the host cannot prove dead is precisely what authorises a reopened project to spawn a *second* agent: `reconcileAgentSessionOwnerListings` (`src/main/ipc/pty/pane/agent-session-owners.ts:105`) treats the relay's listing as authoritative and releases any claim missing from it, after which `ensure()` creates rather than adopts. Keeping the claim makes the next `pty.spawn` **adopt this PTY** — one process, one transcript. `unverifiable` is the honest verdict and it is also the safe one.

This is why the fix is *not* "withhold `agentSessionOwners` for a retired pane". That would have read as a fix and caused the corruption it was meant to prevent.

## Remote wire compatibility

Checked against `docs/reference/remote-wire-compatibility.md`. **No wire change**: no new RPC method, no new request or response field, no new stream opcode, no `RUNTIME_PROTOCOL_VERSION` bump. `pty.shutdown` params and result are byte-identical; `PtyProcessSummary` is unchanged. `isPaneSurfaceRetired` is a host-internal constructor option.

Two Rule-3 projections (*content the host stops publishing*), stated explicitly:

**Old client → new relay.**
- It stops receiving `agent.hook` notifications for a pane it asked the host to shut down. Previously those refreshed a live-agent record for a tab that no longer existed; now nothing arrives and the client's own record ages out via `AGENT_STATUS_STALE_AFTER_MS`. No client *requires* these frames: the desktop already clears its own records for a user-closed tab (`removeSleepingAgentSessionsForTab`, `src/renderer/src/store/terminals/terminal-tab-close.ts:154`), so nothing is stranded waiting for a final host hook. Strictly fewer false live-agent records; no path hangs on absence.
- It stops seeing `pty.listProcesses` rows whose process is **provably dead**. Old clients treat listing absence as an authoritative release — which is the correct verdict for a dead process, and already the outcome the moment `attach()` reaped the same entry. A *live* pane is never withheld, so no old client loses a claim it still needs.

**New client → old relay.** Identical to today. Nothing in this change asks the host for anything new or reads a new field, so a client on this build against a pre-fix relay gets exactly the pre-fix behaviour: orphan hook events still forwarded, dead rows still listed. The fix is a pure host-side narrowing with no client-side dependence, so there is no new-client-requires-new-host skew to negotiate.

**Not on the enforcement harness.** `tests/e2e/cross-version-wire/…` covers the terminal stream only, not the agent-hook channel or `pty.listProcesses`. Run anyway and green (5 passed) — it proves nothing here, and this section is the reasoning the doc asks for in its place.

## Relationship to #16989 (STA-5698)

**Adjacent, not overlapping, and not conflicting.** I read it before starting.

- #16989 is entirely **client-side** (`src/main/ipc/pty/…`); this PR is entirely **relay-side** (`src/relay/`). Zero file overlap.
- Different failure: #16989 covers a **replaced** relay — a young daemon truthfully answering "I never had that terminal" about a binding it could not have held — and suppresses the resume replay. Here the relay is the **same, long-lived** daemon that *did* hold the terminal, so #16989's `answeringRelayPredatesBinding` gate never fires: `uptimeMs` is larger than the binding age, so it returns `false` and the resume proceeds. It cannot cover this report.
- They compose cleanly. #16989 stops a resume the client should not replay; this stops the relay advertising a session it cannot verify. Neither depends on the other and either can land first.
- #16989 explicitly adds no wire surface, and neither does this — no contention with #16839 / #16901's competing identity approaches.

## Fix evidence

### Failing-first, full production revert

`src/relay/{pty-handler,agent-hook-server,relay-agent-hook-runtime,agent-hook-cached-pane-status}.ts` reverted, new tests kept:

```
 FAIL  agent-hook-retired-pane-suppression.test.ts > does not advertise an orphan agent whose tab was closed
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 FAIL  agent-hook-retired-pane-suppression.test.ts > does not replay a cached status for a pane retired after it was cached
AssertionError: expected 1 to be +0 // Object.is equality
 FAIL  agent-hook-retired-pane-suppression.test.ts > forwards again once the pane key is bound by a new PTY
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 FAIL  agent-hook-retired-pane-suppression.test.ts > RelayAgentHookRuntime wiring > routes hook admission through the PTY handler …
AssertionError: expected null not to be null
 FAIL  pty-handler-retired-pane-surface.test.ts > marks the pane surface retired as soon as its tab is closed
TypeError: handler.setSurfaceRetiredListener is not a function
 FAIL  pty-handler-retired-pane-surface.test.ts > retires the surface even when the shell survives the kill request
TypeError: handler.isPaneSurfaceRetired is not a function
 FAIL  pty-handler-retired-pane-surface.test.ts > re-issues the force kill instead of letting a detached shell outlive its tab
AssertionError: expected +0 to be undefined // Object.is equality
 FAIL  pty-handler-retired-pane-surface.test.ts > retires the relay session once the sweep proves the process is gone
AssertionError: expected [ { id: 'pty-1', …(4) } ] to deeply equal []
 FAIL  pty-handler-retired-pane-surface.test.ts > stops advertising an agent session whose process died without a node-pty exit
AssertionError: expected [ { id: 'pty-1', …(4) } ] to deeply equal []
 FAIL  pty-handler-retired-pane-surface.test.ts > restores the surface when a new PTY binds the same pane key
TypeError: handler.isPaneSurfaceRetired is not a function
 FAIL  pty-handler-retired-pane-surface.test.ts > shutting down a pane with no pane key retires nothing
TypeError: handler.setSurfaceRetiredListener is not a function
 Test Files  2 failed (2)
      Tests  11 failed | 2 passed (13)
```

**Honest note on that run.** Several of those are `TypeError`, not assertion failures — the retirement API does not exist on the unfixed relay, so the suite cannot express the pre-fix behaviour without it. A whole-file revert is therefore weak evidence. The ablation table below is the real proof, and one test — *"shutting down a pane with no pane key retires nothing"* — pins that behaviour is **unchanged** for a paneless PTY and by construction cannot fail before the change. I am not claiming failing-first for it.

Post-fix: **19 passed (19)**.

### Ablation table — every production hunk reverted individually

| # | Hunk | Result |
| --- | --- | --- |
| H1 | `applyEvent` retirement gate | **RED** — 3 failed / 16 passed |
| H2 | replay retirement gate | **RED** — 1 failed / 18 passed |
| H3 | `shutdown()` retires the surface | **RED** — 4 failed / 15 passed |
| H4 | `shutdown()` arms the reap sweep | **RED** — 2 failed / 17 passed |
| H5 | `listProcesses` liveness verification | **RED** — 1 failed / 18 passed |
| H6 | `wireAndStore` restores a rebound pane | **RED** — 1 failed / 18 passed |
| H7 | runtime routes the retirement predicate | **RED** — 1 failed / 18 passed |
| H8 | runtime clears the cache on retirement | **RED** — 1 failed / 18 passed |
| H9 | sweep reaps a proven-dead pid | **RED** — 1 failed / 18 passed |
| H10 | sweep re-issues the force kill | **RED** — 1 failed / 18 passed |
| H11 | `attach()` restores a reattached pane | **RED** — 1 failed / 18 passed |
| H12 | sweep skips the ConPTY re-close on Windows | **RED** — 1 failed / 18 passed |

No uncovered hunk. H7 was mutated to a permissive predicate (`() => false`) rather than deleted, since deletion only restores the default — a weak mutation would have made the table lie.

### Requested coverage

| requirement | test |
| --- | --- |
| a closed agent tab retires its relay session | *marks the pane surface retired as soon as its tab is closed*; *retires the relay session once the sweep proves the process is gone* |
| a detached shell does not outlive its tab | *re-issues the force kill instead of letting a detached shell outlive its tab* |
| a stale resumable-active advertisement cannot drive an auto-resume | *does not advertise an orphan agent whose tab was closed*; *does not replay a cached status for a pane retired after it was cached*; *stops advertising an agent session whose process died without a node-pty exit* |
| mixed version — old client / new relay | the two above are exactly what an old client stops receiving; *an embedder that supplies no retirement source keeps forwarding everything* pins the unchanged default (this is also the WSL relay's wiring, `wsl-agent-hook-relay.ts:67`) |
| mixed version — new client / old relay | no client change in this PR; `tests/e2e/cross-version-wire` green |

### Gates

- `pnpm tc` — exit 0
- `oxlint` (incl. the react-doctor config, via the commit hook) on all changed files — clean. **No `max-lines` disable added**: `agent-hook-server.ts` crossed 300 counted lines, so `replayCachedPayloadsForPanes`'s body and the cached-pane cap eviction were extracted into `agent-hook-cached-pane-status.ts` rather than suppressed.
- `pnpm exec oxfmt --write` on changed paths only
- `git diff --check` — clean
- `pnpm test src/relay` — **147 files, 1519 passed, 2 skipped, 0 failed**
- `src/relay` + `src/main/ipc/pty` + `src/main/providers` + `src/main/daemon` — **429 files, 4573 passed, 0 failed**
- `tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts` — 5 passed

## Identity-space findings — verified, deliberately left

Three findings landed mid-review. **This fix keys on neither incarnation identifier**, so none of them apply to it; I verified all three in the code and am reporting rather than fixing, so they can be filed separately.

**What this fix keys on, and why.** Retirement is keyed on **`paneKey`** (`ORCA_PANE_KEY`, `pty-handler.ts:1623`) and liveness on **`managed.pty.pid`**. Both are relay-local and host-owned: `paneKey` is the identity the agent-hook payload already carries (it is how `clearPaneState` has always worked), and the pid is what the host can probe directly. Neither `ptyIncarnation` nor `incarnationId` is read, compared, or used as a key anywhere in this diff. `listProcesses` still emits `incarnationId` exactly as before.

**Consequently there is no no-semantic-incarnation degradation to handle here.** A PTY with no semantic `incarnationId` — an old relay, a `legacy:` pin, a paired runtime — retires and reaps identically, because retirement never consults an incarnation. The one place this diff touches an incarnation-adjacent contract is `listProcesses` *omitting* a row for a provably dead PTY, and that is unambiguous in both directions of skew.

Verified and **not** fixed:

1. **`ptyIncarnation` ≠ `incarnationId`.** `SshPtyExitCallback` (`src/main/providers/ssh-pty-provider-contract.ts:34-40`) carries both — `ptyIncarnation: string` always present, `incarnationId?: PtyIncarnationId` optional — and `resolvePtyIncarnation` (`src/main/providers/ssh-pty-provider-output-state.ts:131-139`) synthesizes `legacy:${providerGeneration}:${serial}:${relayPtyId}` first-write-wins per `relayPtyId` when the wire omits one. A `legacy:` pin can never equal a real `incarnationId`.
2. **`findExactPendingExit` compares across that boundary** (`src/main/ssh/ssh-relay-session.ts:2530-2542`): it matches `exit.ptyIncarnation` (transport) against callers' `attachResult.incarnationId` (semantic — `:2433-2435` and `:2458`). Under a `legacy:` pin the exact match can never succeed, falling through to the coarser "any pending exit for this ptyId" clauses. Real, in adjacent territory, untouched here.
3. **`ptyIncarnationById` has two uncoordinated last-write-wins writers** (`src/main/ipc/pty/provider/ownership-state.ts:5`), with no generation fencing: renderer-driven spawn/reattach and connection-level bulk reattach-on-reconnect. A stale last write makes `isCurrentPtyExit` (`:7-10`) silently reject a real exit. Untouched here.

## What I did NOT verify

- **No live SSH reproduction.** I did not stand up a real host, close a tab, leave `claude` alive under `relay.js --detached`, and watch the advertisement stop. All evidence is unit-level against `PtyHandler` and a real `RelayAgentHookServer` over loopback HTTP.
- **No Electron/CDP run.** Nothing renders differently by design — the change is the *absence* of a notification.
- **Retirement is in-memory only.** A relay restart forgets every retirement. A pane closed before a restart whose shell survived would have its hooks forwarded again. Persisting it needs an on-disk ledger and is out of scope; in practice a closed tab is not in the client's serialized state, so `pty.revive` will not re-list it either.
- **Pid-recycling window widened.** The sweep re-issues a force kill on `managed.pty.pid` for up to ~24s. If node-pty missed the child's exit *and* the host recycled the pid inside that window, the sweep would signal an unrelated process group. The identical shape already exists in `armForceKillFallback`'s retry (+5.25s); this widens it. Note that a recycled pid normally implies the child was reaped, which implies `onExit` fired, which removes the entry and stops the sweep — so the exposure is confined to the missed-`onExit` case the feature exists for. Not measured on a real host.
- **The `SHUTDOWN_REAP_VERIFY_DELAY_MS = 6_000` / `SHUTDOWN_REAP_MAX_SWEEPS = 3` budget is reasoned, not tuned.** 6s sits just past the existing 5s armed fallback so the first sweep observes post-kill state; three escalations bound it at ~24s. I did not measure how often a real host needs more than one.
- **Not the whole of #12447.** Item 1 of the earlier triage — the lost `pty.kill` with no pending-kill journal (`src/main/ipc/pty/runtime/kill.ts`) — is untouched, as is `persistPtyBinding`'s unconditional tombstone delete. This PR closes the server-side advertisement loop, not the client-side lost kill.

Refs #12447. Adjacent to #16989 (STA-5698); neither blocks the other.
