### PR TITLE
fix(terminal): stop leaking the Git credential guard into terminals Orca chose not to guard

### DIFF
--- a/src/main/daemon/pty-subprocess-git-credential-guard.test.ts
+++ b/src/main/daemon/pty-subprocess-git-credential-guard.test.ts
@@ -75,7 +75,14 @@ vi.mock('../providers/windows-pty-job-membership', () => ({
 }))
 
 import { createPtySubprocess } from './pty-subprocess'
-import { TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV } from '../../shared/terminal-git-credential-guard'
+import {
+  restoreGitCredentialGuardEnv,
+  takeGitCredentialGuardEnv
+} from '../../shared/git-credential-guard-env-test-harness'
+import {
+  applyTerminalGitCredentialPromptGuard,
+  TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV
+} from '../../shared/terminal-git-credential-guard'
 import { mockPtyProcess, useDaemonPtySubprocessEnv } from './pty-subprocess-test-harness'
 
 describe('createPtySubprocess', () => {
@@ -221,5 +228,84 @@ describe('createPtySubprocess', () => {
     expect(spawnEnv.GCM_INTERACTIVE).toBe('never')
     expect(Object.values(spawnEnv)).toContain('credential.interactive')
     expect(Object.values(spawnEnv)).toContain('credential.guiPrompt')
+  })
+  it('strips a guard the daemon inherited when the pane must not be guarded', async () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    // A daemon forked from a guarded agent pane: build its inherited env with the
+    // real guard so the double carries every variable the guard actually sets.
+    const inherited: Record<string, string> = {
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'core.quotePath',
+      GIT_CONFIG_VALUE_0: 'false'
+    }
+    applyTerminalGitCredentialPromptGuard(inherited, {
+      launchCommand: 'claude',
+      platform: process.platform
+    })
+    const saved = takeGitCredentialGuardEnv(inherited)
+
+    try {
+      await createPtySubprocess({
+        sessionId: 'inherited-guard-unguarded-pane',
+        cols: 80,
+        rows: 24,
+        env: { SHELL: '/bin/bash' }
+      })
+
+      const spawnEnv = spawnMock.mock.calls.at(-1)?.[2]?.env as Record<string, string>
+      expect(spawnEnv.GIT_TERMINAL_PROMPT).toBeUndefined()
+      expect(spawnEnv.GCM_INTERACTIVE).toBeUndefined()
+      expect(spawnEnv.GIT_ASKPASS).toBeUndefined()
+      expect(spawnEnv.SSH_ASKPASS).toBeUndefined()
+      // The caller's own entry survives; only Orca's appended pair is removed.
+      expect(spawnEnv.GIT_CONFIG_COUNT).toBe('1')
+      expect(spawnEnv.GIT_CONFIG_KEY_0).toBe('core.quotePath')
+      expect(spawnEnv.GIT_CONFIG_VALUE_0).toBe('false')
+      expect(spawnEnv.GIT_CONFIG_KEY_1).toBeUndefined()
+      expect(Object.values(spawnEnv)).not.toContain('credential.interactive')
+      expect(Object.values(spawnEnv)).not.toContain('credential.guiPrompt')
+    } finally {
+      restoreGitCredentialGuardEnv(saved)
+    }
+  })
+
+  it('gives a guarded daemon pane what its children need to undo the guard', async () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const saved = takeGitCredentialGuardEnv({
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'core.quotePath',
+      GIT_CONFIG_VALUE_0: 'false'
+    })
+
+    try {
+      await createPtySubprocess({
+        sessionId: 'guarded-daemon-pane-provenance',
+        cols: 80,
+        rows: 24,
+        env: { SHELL: '/bin/bash', [TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV]: 'guard' }
+      })
+
+      const paneEnv = spawnMock.mock.calls.at(-1)?.[2]?.env as Record<string, string>
+      expect(paneEnv.GIT_TERMINAL_PROMPT).toBe('0')
+      expect(paneEnv.GIT_CONFIG_COUNT).toBe('3')
+
+      // A plain shell launched from inside that guarded pane.
+      const child = { ...paneEnv }
+      expect(
+        applyTerminalGitCredentialPromptGuard(child, {
+          launchCommand: '/bin/zsh',
+          platform: process.platform
+        })
+      ).toBe(false)
+      expect(child.GIT_TERMINAL_PROMPT).toBeUndefined()
+      expect(child.GCM_INTERACTIVE).toBeUndefined()
+      expect(child.GIT_CONFIG_COUNT).toBe('1')
+      expect(child.GIT_CONFIG_KEY_0).toBe('core.quotePath')
+      expect(child.GIT_CONFIG_KEY_1).toBeUndefined()
+    } finally {
+      restoreGitCredentialGuardEnv(saved)
+    }
   })
 })

--- a/src/main/daemon/pty-subprocess-git-credential-guard.test.ts
+++ b/src/main/daemon/pty-subprocess-git-credential-guard.test.ts
@@ -308,4 +308,62 @@ describe('createPtySubprocess', () => {
       restoreGitCredentialGuardEnv(saved)
     }
   })
+  it('does not double the guard when the daemon inherited one and the request carries its own', async () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    // Orca was launched from a guarded agent pane, so the daemon it forked
+    // inherits that pane's guard AND that pane's provenance marker.
+    const inherited: Record<string, string> = {
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'core.quotePath',
+      GIT_CONFIG_VALUE_0: 'false',
+      GIT_TERMINAL_PROMPT: '1',
+      GCM_INTERACTIVE: 'auto'
+    }
+    applyTerminalGitCredentialPromptGuard(inherited, {
+      launchCommand: 'claude',
+      platform: process.platform
+    })
+    const saved = takeGitCredentialGuardEnv(inherited)
+
+    try {
+      // Exactly what main puts on the wire for a guarded pane it defers to the daemon.
+      const requested: Record<string, string> = {}
+      applyTerminalGitCredentialPromptGuard(requested, {
+        launchCommand: 'claude',
+        platform: process.platform,
+        deferGitConfigGuardToHost: true
+      })
+      await createPtySubprocess({
+        sessionId: 'inherited-and-requested-guard',
+        cols: 80,
+        rows: 24,
+        env: { SHELL: '/bin/bash', ...requested }
+      })
+
+      const paneEnv = spawnMock.mock.calls.at(-1)?.[2]?.env as Record<string, string>
+      // One caller entry plus one guard pair — not two guard pairs.
+      expect(paneEnv.GIT_CONFIG_COUNT).toBe('3')
+      expect(paneEnv.GIT_CONFIG_KEY_1).toBe('credential.interactive')
+      expect(paneEnv.GIT_CONFIG_KEY_2).toBe('credential.guiPrompt')
+      expect(paneEnv.GIT_CONFIG_KEY_3).toBeUndefined()
+
+      // And the pane's own marker still describes the user's real pre-guard env,
+      // so a plain shell launched inside it lands exactly back on those values.
+      const child = { ...paneEnv }
+      expect(
+        applyTerminalGitCredentialPromptGuard(child, {
+          launchCommand: '/bin/zsh',
+          platform: process.platform
+        })
+      ).toBe(false)
+      expect(child.GIT_TERMINAL_PROMPT).toBe('1')
+      expect(child.GCM_INTERACTIVE).toBe('auto')
+      expect(child.GIT_CONFIG_COUNT).toBe('1')
+      expect(child.GIT_CONFIG_KEY_0).toBe('core.quotePath')
+      expect(Object.values(child)).not.toContain('credential.interactive')
+    } finally {
+      restoreGitCredentialGuardEnv(saved)
+    }
+  })
 })

--- a/src/main/daemon/pty-subprocess/spawn-environment.ts
+++ b/src/main/daemon/pty-subprocess/spawn-environment.ts
@@ -11,6 +11,11 @@ import {
   gitCredentialPromptGuardEnv,
   mergeGitConfigEnvProtocol
 } from '../../../shared/git-credential-prompt-env'
+import {
+  captureGitCredentialGuardPreGuardState,
+  recordGitCredentialGuardProvenance,
+  restoreUnguardedGitCredentialEnv
+} from '../../../shared/git-credential-guard-provenance'
 import { TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV } from '../../../shared/terminal-git-credential-guard'
 import {
   expandWindowsEnvironmentVariables,
@@ -34,11 +39,19 @@ function composeGuardedDaemonGitConfigEnv(
 ): void {
   const policy = explicitEnv?.[TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV]
   delete env[TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV]
+  // Why: the daemon forks from Electron and can be launched from a guarded pane, so
+  // its inherited env may already carry the guard; undo it before deciding afresh.
+  restoreUnguardedGitCredentialEnv(env)
   if (policy !== 'guard' && launchAgent === undefined) {
     return
   }
   // Why: the daemon can outlive Electron, so its process.env is the authoritative inherited config; append only the guard.
+  const preGuard = captureGitCredentialGuardPreGuardState(env)
   Object.assign(env, gitCredentialPromptGuardEnv(env, process.platform))
+  recordGitCredentialGuardProvenance(env, preGuard, {
+    appendedConfig: true,
+    forwardToWsl: process.platform === 'win32'
+  })
 }
 
 function deleteRequestedDaemonEnvKeys(

--- a/src/main/daemon/pty-subprocess/spawn-environment.ts
+++ b/src/main/daemon/pty-subprocess/spawn-environment.ts
@@ -39,9 +39,6 @@ function composeGuardedDaemonGitConfigEnv(
 ): void {
   const policy = explicitEnv?.[TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV]
   delete env[TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV]
-  // Why: the daemon forks from Electron and can be launched from a guarded pane, so
-  // its inherited env may already carry the guard; undo it before deciding afresh.
-  restoreUnguardedGitCredentialEnv(env)
   if (policy !== 'guard' && launchAgent === undefined) {
     return
   }
@@ -145,8 +142,19 @@ function removeInheritedDevAgentHookEndpoint(
 }
 
 export function createDaemonPtyEnvironment(opts: PtySubprocessOptions): Record<string, string> {
+  // Why: a marker only describes the environment it was stamped into. The daemon
+  // forks from Electron and can be launched from a guarded pane, and the request
+  // carries its own marker for the scalars main wrote on the wire — undo them on
+  // their own side, or the request's marker lands on top of the inherited one and
+  // the guard it was meant to explain survives the merge unexplained.
+  const inheritedEnv = stripInheritedBuildModeEnv(process.env) as Record<string, string>
+  restoreUnguardedGitCredentialEnv(inheritedEnv)
+  const requestedEnv = opts.env ? { ...opts.env } : undefined
+  if (requestedEnv) {
+    restoreUnguardedGitCredentialEnv(requestedEnv)
+  }
   const env: Record<string, string> = {
-    ...mergeGitConfigEnvProtocol(stripInheritedBuildModeEnv(process.env), opts.env),
+    ...mergeGitConfigEnvProtocol(inheritedEnv, requestedEnv),
     TERM: 'xterm-256color',
     COLORTERM: 'truecolor',
     TERM_PROGRAM: 'Orca',

--- a/src/relay/pty-handler-revive.test.ts
+++ b/src/relay/pty-handler-revive.test.ts
@@ -35,6 +35,11 @@ vi.mock('../main/shell-prompt-readiness-probe', () => ({
   createShellPromptReadinessProbe: mockCreateShellPromptReadinessProbe
 }))
 
+import {
+  restoreGitCredentialGuardEnv,
+  takeGitCredentialGuardEnv
+} from '../shared/git-credential-guard-env-test-harness'
+import { applyTerminalGitCredentialPromptGuard } from '../shared/terminal-git-credential-guard'
 import { MAX_RELAY_PTY_SESSIONS, PtyHandler } from './pty-handler'
 import type { RelayDispatcher } from './dispatcher'
 import {
@@ -647,5 +652,80 @@ describe('PtyHandler', () => {
       expect(mockPtySpawn).toHaveBeenCalledTimes(2)
       expect(mockPtySpawn.mock.calls.map(([shell]) => shell)).not.toContain('nc.exe')
     })
+  })
+  it('revive strips a guard the relay inherited for an unguarded pane', async () => {
+    const cleared = takeGitCredentialGuardEnv()
+    try {
+      await dispatcher.callRequest('pty.spawn', {})
+      const state = (await dispatcher.callRequest('pty.serialize', { ids: ['pty-1'] })) as string
+      expect(JSON.parse(state)[0]?.gitCredentialPromptGuarded).toBe(false)
+
+      handler.dispose()
+      mockPtySpawn.mockClear()
+      dispatcher = createMockDispatcher()
+      handler = new PtyHandler(dispatcher as unknown as RelayDispatcher)
+
+      // The relay process was restarted from a guarded agent pane.
+      const inherited: Record<string, string> = {}
+      applyTerminalGitCredentialPromptGuard(inherited, {
+        launchCommand: 'claude',
+        platform: process.platform
+      })
+      Object.assign(process.env, inherited)
+
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      try {
+        await dispatcher.callRequest('pty.revive', { state })
+      } finally {
+        killSpy.mockRestore()
+      }
+
+      const revivedEnv = mockPtySpawn.mock.calls[0]?.[2]?.env as Record<string, string>
+      expect(revivedEnv.GIT_TERMINAL_PROMPT).toBeUndefined()
+      expect(revivedEnv.GCM_INTERACTIVE).toBeUndefined()
+      expect(revivedEnv.GIT_CONFIG_COUNT).toBeUndefined()
+      expect(Object.values(revivedEnv)).not.toContain('credential.interactive')
+      expect(Object.values(revivedEnv)).not.toContain('credential.guiPrompt')
+    } finally {
+      restoreGitCredentialGuardEnv(cleared)
+    }
+  })
+
+  it('gives a revived guarded pane what its children need to undo the guard', async () => {
+    const cleared = takeGitCredentialGuardEnv()
+    try {
+      await dispatcher.callRequest('pty.spawn', { command: 'claude' })
+      const state = (await dispatcher.callRequest('pty.serialize', { ids: ['pty-1'] })) as string
+
+      handler.dispose()
+      mockPtySpawn.mockClear()
+      dispatcher = createMockDispatcher()
+      handler = new PtyHandler(dispatcher as unknown as RelayDispatcher)
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      try {
+        await dispatcher.callRequest('pty.revive', { state })
+      } finally {
+        killSpy.mockRestore()
+      }
+
+      const revivedEnv = mockPtySpawn.mock.calls[0]?.[2]?.env as Record<string, string>
+      expect(revivedEnv.GIT_TERMINAL_PROMPT).toBe('0')
+
+      // A plain shell launched from inside that revived guarded pane.
+      const child = { ...revivedEnv }
+      expect(
+        applyTerminalGitCredentialPromptGuard(child, {
+          launchCommand: '/bin/zsh',
+          platform: process.platform
+        })
+      ).toBe(false)
+      expect(child.GIT_TERMINAL_PROMPT).toBeUndefined()
+      expect(child.GCM_INTERACTIVE).toBeUndefined()
+      expect(child.GIT_CONFIG_COUNT).toBeUndefined()
+      expect(Object.values(child)).not.toContain('credential.interactive')
+      expect(Object.values(child)).not.toContain('credential.guiPrompt')
+    } finally {
+      restoreGitCredentialGuardEnv(cleared)
+    }
   })
 })

--- a/src/relay/pty-handler-spawn-environment.test.ts
+++ b/src/relay/pty-handler-spawn-environment.test.ts
@@ -41,6 +41,11 @@ vi.mock('../main/shell-prompt-readiness-probe', () => ({
   createShellPromptReadinessProbe: mockCreateShellPromptReadinessProbe
 }))
 
+import {
+  restoreGitCredentialGuardEnv,
+  takeGitCredentialGuardEnv
+} from '../shared/git-credential-guard-env-test-harness'
+import { applyTerminalGitCredentialPromptGuard } from '../shared/terminal-git-credential-guard'
 import { PtyHandler } from './pty-handler'
 import type { RelayDispatcher } from './dispatcher'
 import {
@@ -754,4 +759,37 @@ describe('PtyHandler', () => {
       rmSync(homeDir, { recursive: true, force: true })
     }
   )
+  it('strips a guard the relay inherited when the SSH pane must not be guarded', async () => {
+    // A relay server started from a guarded agent pane: build its inherited env
+    // with the real guard so every variable the guard sets is present.
+    const inherited: Record<string, string> = {
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'core.quotePath',
+      GIT_CONFIG_VALUE_0: 'false'
+    }
+    applyTerminalGitCredentialPromptGuard(inherited, {
+      launchCommand: 'claude',
+      platform: process.platform
+    })
+    const saved = takeGitCredentialGuardEnv(inherited)
+
+    try {
+      await dispatcher.callRequest('pty.spawn', {})
+
+      const spawnEnv = mockPtySpawn.mock.calls[0]?.[2]?.env as Record<string, string>
+      expect(spawnEnv.GIT_TERMINAL_PROMPT).toBeUndefined()
+      expect(spawnEnv.GCM_INTERACTIVE).toBeUndefined()
+      expect(spawnEnv.GIT_ASKPASS).toBeUndefined()
+      expect(spawnEnv.SSH_ASKPASS).toBeUndefined()
+      expect(spawnEnv.GIT_CONFIG_COUNT).toBe('1')
+      expect(spawnEnv.GIT_CONFIG_KEY_0).toBe('core.quotePath')
+      expect(spawnEnv.GIT_CONFIG_KEY_1).toBeUndefined()
+      expect(Object.values(spawnEnv)).not.toContain('credential.interactive')
+      expect(Object.values(spawnEnv)).not.toContain('credential.guiPrompt')
+      const state = (await dispatcher.callRequest('pty.serialize', { ids: ['pty-1'] })) as string
+      expect(JSON.parse(state)[0]?.gitCredentialPromptGuarded).toBe(false)
+    } finally {
+      restoreGitCredentialGuardEnv(saved)
+    }
+  })
 })

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -41,6 +41,11 @@ import {
   createShellPromptReadinessProbe,
   type ShellPromptReadinessProbe
 } from '../main/shell-prompt-readiness-probe'
+import {
+  captureGitCredentialGuardPreGuardState,
+  recordGitCredentialGuardProvenance,
+  restoreUnguardedGitCredentialEnv
+} from '../shared/git-credential-guard-provenance'
 import { applyTerminalGitCredentialPromptGuard } from '../shared/terminal-git-credential-guard'
 import {
   gitCredentialPromptGuardEnv,
@@ -2385,8 +2390,16 @@ export class PtyHandler {
     }
     // Why: revive lacks the original launch command, so reuse the fresh-spawn guard decision (legacy defaults to unguarded).
     const gitCredentialPromptGuarded = entry.gitCredentialPromptGuarded === true
+    // Why: the relay server inherits its own env, so a relay launched from a guarded
+    // pane leaks the guard into revived user panes unless it is undone first.
+    restoreUnguardedGitCredentialEnv(spawnEnv)
     if (gitCredentialPromptGuarded) {
+      const preGuard = captureGitCredentialGuardPreGuardState(spawnEnv)
       Object.assign(spawnEnv, gitCredentialPromptGuardEnv(spawnEnv, process.platform))
+      recordGitCredentialGuardProvenance(spawnEnv, preGuard, {
+        appendedConfig: true,
+        forwardToWsl: process.platform === 'win32'
+      })
     }
     const shellLaunch = getRelayShellLaunchConfig(shell, spawnEnv, process.platform, {
       terminalWindowsWslDistro

--- a/src/shared/git-credential-guard-env-test-harness.ts
+++ b/src/shared/git-credential-guard-env-test-harness.ts
@@ -1,0 +1,39 @@
+// Includes the setup-sequencing keys: they turn an ordinary pane into an "agent
+// launch" for the guard's own decision, so a suite asserting on that decision
+// must own them too.
+const GIT_CREDENTIAL_GUARD_ENV_RE =
+  /^(?:GIT_TERMINAL_PROMPT|GCM_INTERACTIVE|GIT_ASKPASS|SSH_ASKPASS|WSLENV|ORCA_SEQUENCED_STARTUP_COMMAND|ORCA_SEQUENCED_STARTUP_SCRIPT|ORCA_INTERNAL_TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE|GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+))$/
+
+export type SavedGitCredentialGuardEnv = Record<string, string | undefined>
+
+/**
+ * Orca's own agent panes export the credential guard, so a suite that asserts on
+ * inherited guard state must own this slice of `process.env` rather than read the
+ * pane the tests happen to run in.
+ */
+export function takeGitCredentialGuardEnv(
+  seed: Record<string, string> = {}
+): SavedGitCredentialGuardEnv {
+  const saved: SavedGitCredentialGuardEnv = {}
+  for (const key of Object.keys(process.env)) {
+    if (GIT_CREDENTIAL_GUARD_ENV_RE.test(key)) {
+      saved[key] = process.env[key]
+      delete process.env[key]
+    }
+  }
+  Object.assign(process.env, seed)
+  return saved
+}
+
+export function restoreGitCredentialGuardEnv(saved: SavedGitCredentialGuardEnv): void {
+  for (const key of Object.keys(process.env)) {
+    if (GIT_CREDENTIAL_GUARD_ENV_RE.test(key)) {
+      delete process.env[key]
+    }
+  }
+  for (const [key, value] of Object.entries(saved)) {
+    if (value !== undefined) {
+      process.env[key] = value
+    }
+  }
+}

--- a/src/shared/git-credential-guard-provenance.test.ts
+++ b/src/shared/git-credential-guard-provenance.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import {
+  captureGitCredentialGuardPreGuardState,
+  recordGitCredentialGuardProvenance,
+  restoreUnguardedGitCredentialEnv,
+  TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE_ENV as MARKER
+} from './git-credential-guard-provenance'
+
+/** An env carrying the guard, marked with the provenance `raw` describes. */
+function guardedEnv(raw: string): Record<string, string> {
+  return {
+    GIT_TERMINAL_PROMPT: '0',
+    GCM_INTERACTIVE: 'never',
+    GIT_ASKPASS: '',
+    SSH_ASKPASS: '',
+    GIT_CONFIG_COUNT: '2',
+    GIT_CONFIG_KEY_0: 'credential.interactive',
+    GIT_CONFIG_VALUE_0: 'false',
+    GIT_CONFIG_KEY_1: 'credential.guiPrompt',
+    GIT_CONFIG_VALUE_1: 'false',
+    [MARKER]: raw
+  }
+}
+
+const INTACT_GUARD = {
+  GIT_TERMINAL_PROMPT: '0',
+  GCM_INTERACTIVE: 'never',
+  GIT_ASKPASS: '',
+  SSH_ASKPASS: '',
+  GIT_CONFIG_COUNT: '2',
+  GIT_CONFIG_KEY_0: 'credential.interactive',
+  GIT_CONFIG_VALUE_0: 'false',
+  GIT_CONFIG_KEY_1: 'credential.guiPrompt',
+  GIT_CONFIG_VALUE_1: 'false'
+}
+
+describe('restoreUnguardedGitCredentialEnv marker handling', () => {
+  it('leaves everything alone when there is no marker at all', () => {
+    const env = { ...INTACT_GUARD }
+    expect(restoreUnguardedGitCredentialEnv(env)).toBe(false)
+    expect(env).toEqual(INTACT_GUARD)
+  })
+
+  // A marker Orca cannot read cannot tell it which values are Orca's, so the
+  // arm it falls to must be "change nothing" — never "clear the user's Git env".
+  it.each([
+    ['truncated json', '{"v":1,"env":{"GIT_TERMINAL_PROM'],
+    ['not json at all', 'guard'],
+    ['a json non-object', '"guard"'],
+    ['a future marker version', '{"v":2,"env":{"GIT_TERMINAL_PROMPT":"1"},"configBase":0}'],
+    ['a missing version', '{"env":{"GIT_TERMINAL_PROMPT":"1"},"configBase":0}'],
+    ['a non-object env', '{"v":1,"env":"GIT_TERMINAL_PROMPT","configBase":0}']
+  ])('leaves the guard intact for %s', (_label, raw) => {
+    const env = guardedEnv(raw)
+    expect(restoreUnguardedGitCredentialEnv(env)).toBe(false)
+    expect(env).toEqual(INTACT_GUARD)
+  })
+
+  it('drops an unreadable marker so it cannot be mistaken for provenance later', () => {
+    const env = guardedEnv('{"v":1,"env":{')
+    restoreUnguardedGitCredentialEnv(env)
+    expect(Object.hasOwn(env, MARKER)).toBe(false)
+  })
+
+  it('ignores a marker whose recorded values are not strings or null', () => {
+    const env = guardedEnv(
+      '{"v":1,"env":{"GIT_TERMINAL_PROMPT":7,"GCM_INTERACTIVE":null},"configBase":null}'
+    )
+    expect(restoreUnguardedGitCredentialEnv(env)).toBe(true)
+    // 7 is not a recorded value, so the key is not Orca's to restore.
+    expect(env.GIT_TERMINAL_PROMPT).toBe('0')
+    expect(env.GCM_INTERACTIVE).toBeUndefined()
+  })
+
+  it('ignores a configBase that is not a safe integer', () => {
+    for (const base of ['"0"', '0.5', '1e400', 'true']) {
+      const env = guardedEnv(`{"v":1,"env":{},"configBase":${base}}`)
+      restoreUnguardedGitCredentialEnv(env)
+      expect(env.GIT_CONFIG_COUNT).toBe('2')
+      expect(env.GIT_CONFIG_KEY_0).toBe('credential.interactive')
+    }
+  })
+
+  // A marker that names no config base did not append config, so nothing indexed
+  // in this environment is Orca's — including a pair that looks exactly like ours.
+  it('never removes indexed config when the marker claims no config base', () => {
+    const env = guardedEnv('{"v":1,"env":{"GIT_TERMINAL_PROMPT":null},"configBase":null}')
+    expect(restoreUnguardedGitCredentialEnv(env)).toBe(true)
+    expect(env.GIT_TERMINAL_PROMPT).toBeUndefined()
+    expect(env.GIT_CONFIG_COUNT).toBe('2')
+    expect(env.GIT_CONFIG_KEY_0).toBe('credential.interactive')
+    expect(env.GIT_CONFIG_VALUE_0).toBe('false')
+    expect(env.GIT_CONFIG_KEY_1).toBe('credential.guiPrompt')
+  })
+
+  it('round-trips a capture through a record and back to the captured values', () => {
+    const original = {
+      GIT_TERMINAL_PROMPT: '1',
+      GIT_ASKPASS: '/usr/local/bin/ask',
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'http.proxy',
+      GIT_CONFIG_VALUE_0: 'http://proxy.invalid'
+    }
+    const env: Record<string, string> = { ...original }
+    const pre = captureGitCredentialGuardPreGuardState(env)
+    Object.assign(env, {
+      GIT_TERMINAL_PROMPT: '0',
+      GCM_INTERACTIVE: 'never',
+      SSH_ASKPASS: '',
+      GIT_CONFIG_COUNT: '3',
+      GIT_CONFIG_KEY_1: 'credential.interactive',
+      GIT_CONFIG_VALUE_1: 'false',
+      GIT_CONFIG_KEY_2: 'credential.guiPrompt',
+      GIT_CONFIG_VALUE_2: 'false'
+    })
+    recordGitCredentialGuardProvenance(env, pre, { appendedConfig: true, forwardToWsl: false })
+
+    expect(restoreUnguardedGitCredentialEnv(env)).toBe(true)
+    expect(env).toEqual(original)
+  })
+})

--- a/src/shared/git-credential-guard-provenance.test.ts
+++ b/src/shared/git-credential-guard-provenance.test.ts
@@ -98,6 +98,26 @@ describe('restoreUnguardedGitCredentialEnv marker handling', () => {
     expect(env.GIT_CONFIG_KEY_1).toBe('credential.guiPrompt')
   })
 
+  // The guard forwards only its scalars and the indexed-config protocol into
+  // WSLENV -- never the askpass names. Removing a name the guard never added
+  // strips the user's own WSL forwarding, which is the leak's mirror image.
+  it('keeps a WSLENV name the guard never forwards, even when it appeared after the guard', () => {
+    const saved = takeGitCredentialGuardEnv()
+    try {
+      const env: Record<string, string> = { WSLENV: 'MY_VAR/u' }
+      const pre = captureGitCredentialGuardPreGuardState(env)
+      Object.assign(env, gitCredentialPromptGuardEnv(env, 'win32') as Record<string, string>)
+      recordGitCredentialGuardProvenance(env, pre, { appendedConfig: true, forwardToWsl: true })
+      // The user forwards their own askpass into WSL from inside the guarded pane.
+      env.WSLENV = `${env.WSLENV}:GIT_ASKPASS/p`
+
+      expect(restoreUnguardedGitCredentialEnv(env)).toBe(true)
+      expect(env.WSLENV).toBe('MY_VAR/u:GIT_ASKPASS/p')
+    } finally {
+      restoreGitCredentialGuardEnv(saved)
+    }
+  })
+
   // A marker that names no config base did not append config, so nothing indexed
   // in this environment is Orca's — including a pair that looks exactly like ours.
   it('never removes indexed config when the marker claims no config base', () => {

--- a/src/shared/git-credential-guard-provenance.test.ts
+++ b/src/shared/git-credential-guard-provenance.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
+  restoreGitCredentialGuardEnv,
+  takeGitCredentialGuardEnv
+} from './git-credential-guard-env-test-harness'
+import { gitCredentialPromptGuardEnv } from './git-credential-prompt-env'
+import {
   captureGitCredentialGuardPreGuardState,
   recordGitCredentialGuardProvenance,
   restoreUnguardedGitCredentialEnv,
@@ -118,4 +123,35 @@ describe('restoreUnguardedGitCredentialEnv marker handling', () => {
     expect(restoreUnguardedGitCredentialEnv(env)).toBe(true)
     expect(env).toEqual(original)
   })
+  // The coupling ratchet. `guardOwnedValue` and SCALAR_KEYS mirror, by hand and in
+  // another file, what gitCredentialPromptGuardEnv writes. Nothing else enforces
+  // that: a guard key this module does not know is simply left in the child, which
+  // is the leak. Asserting guard-then-restore is the identity catches both a value
+  // that drifts and a key that is added.
+  it.each(['linux', 'darwin', 'win32'] as const)(
+    'undoes every key the real guard writes on %s',
+    (platform) => {
+      const saved = takeGitCredentialGuardEnv()
+      try {
+        const original = { PATH: '/usr/bin', HOME: '/home/u' }
+        const env: Record<string, string> = { ...original }
+        const pre = captureGitCredentialGuardPreGuardState(env)
+        const guarded = gitCredentialPromptGuardEnv(env, platform) as Record<string, string>
+        // Liveness: without this the marker alone would satisfy the round trip and
+        // a guard that stopped writing anything would still pass.
+        const touched = Object.keys(guarded).filter((key) => guarded[key] !== env[key])
+        expect(touched.length).toBeGreaterThan(0)
+        Object.assign(env, guarded)
+        recordGitCredentialGuardProvenance(env, pre, {
+          appendedConfig: true,
+          forwardToWsl: platform === 'win32'
+        })
+
+        expect(restoreUnguardedGitCredentialEnv(env)).toBe(true)
+        expect(env).toEqual(original)
+      } finally {
+        restoreGitCredentialGuardEnv(saved)
+      }
+    }
+  )
 })

--- a/src/shared/git-credential-guard-provenance.test.ts
+++ b/src/shared/git-credential-guard-provenance.test.ts
@@ -86,6 +86,18 @@ describe('restoreUnguardedGitCredentialEnv marker handling', () => {
     }
   })
 
+  // A negative base is not a position the guard can ever have appended at, but it
+  // still satisfies Number.isSafeInteger. Left unvalidated it makes index 0 look
+  // guard-owned and deletes a pair the user configured themselves.
+  it('ignores a negative configBase instead of treating index 0 as a guard slot', () => {
+    const env = guardedEnv('{"v":1,"env":{},"configBase":-1}')
+    restoreUnguardedGitCredentialEnv(env)
+    expect(env.GIT_CONFIG_COUNT).toBe('2')
+    expect(env.GIT_CONFIG_KEY_0).toBe('credential.interactive')
+    expect(env.GIT_CONFIG_VALUE_0).toBe('false')
+    expect(env.GIT_CONFIG_KEY_1).toBe('credential.guiPrompt')
+  })
+
   // A marker that names no config base did not append config, so nothing indexed
   // in this environment is Orca's — including a pair that looks exactly like ours.
   it('never removes indexed config when the marker claims no config base', () => {

--- a/src/shared/git-credential-guard-provenance.ts
+++ b/src/shared/git-credential-guard-provenance.ts
@@ -1,0 +1,211 @@
+import { readValidGitConfigEnvCount } from './git-credential-prompt-env'
+import { addWslEnvKeys } from './wsl-env'
+
+/**
+ * Marks a terminal environment whose Git credential guard Orca applied, and
+ * carries the pre-guard values so a child terminal the guard declines to guard
+ * can undo exactly Orca's changes and nothing the user set themselves.
+ */
+export const TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE_ENV =
+  'ORCA_INTERNAL_TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE'
+
+const GUARD_CONFIG_KEYS = new Set(['credential.interactive', 'credential.guiPrompt'])
+const GIT_CONFIG_PROTOCOL_KEY_RE = /^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/
+const GIT_CONFIG_INDEXED_KEY_RE = /^GIT_CONFIG_(?:KEY|VALUE)_\d+$/
+const SCALAR_KEYS = [
+  'GIT_TERMINAL_PROMPT',
+  'GCM_INTERACTIVE',
+  'GIT_ASKPASS',
+  'SSH_ASKPASS'
+] as const
+
+/** Pre-guard values; `null` records that the variable was absent. */
+type RestoreState = {
+  v: 1
+  env: Record<string, string | null>
+  /** Index the guard appended its credential pair at, or null when it appended none. */
+  configBase: number | null
+}
+
+export type GitCredentialGuardPreGuardState = {
+  env: Record<string, string | null>
+  configBase: number | null
+}
+
+function snapshot(env: Record<string, string>, key: string): string | null {
+  return Object.hasOwn(env, key) ? (env[key] as string) : null
+}
+
+/** Capture the values the guard is about to overwrite. Must run before the guard. */
+export function captureGitCredentialGuardPreGuardState(
+  env: Record<string, string>
+): GitCredentialGuardPreGuardState {
+  const captured: Record<string, string | null> = {}
+  for (const key of [...SCALAR_KEYS, 'WSLENV', 'GIT_CONFIG_COUNT']) {
+    captured[key] = snapshot(env, key)
+  }
+  return { env: captured, configBase: readValidGitConfigEnvCount(env) }
+}
+
+/** Stamp a guarded environment with what Orca changed, so a child can undo it. */
+export function recordGitCredentialGuardProvenance(
+  env: Record<string, string>,
+  pre: GitCredentialGuardPreGuardState,
+  opts: { appendedConfig: boolean; forwardToWsl: boolean }
+): void {
+  const state: RestoreState = {
+    v: 1,
+    env: { ...pre.env },
+    configBase: opts.appendedConfig ? pre.configBase : null
+  }
+  env[TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE_ENV] = JSON.stringify(state)
+  if (opts.forwardToWsl) {
+    // Why: the guard's own variables cross into WSL via WSLENV, so their provenance must cross too.
+    addWslEnvKeys(env, [TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE_ENV])
+  }
+}
+
+function readRestoreState(raw: string): RestoreState | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    return null
+  }
+  const candidate = parsed as Partial<RestoreState>
+  if (candidate.v !== 1 || typeof candidate.env !== 'object' || candidate.env === null) {
+    return null
+  }
+  const entries = Object.entries(candidate.env).filter(
+    ([, value]) => typeof value === 'string' || value === null
+  ) as [string, string | null][]
+  const configBase = candidate.configBase
+  return {
+    v: 1,
+    env: Object.fromEntries(entries),
+    configBase:
+      typeof configBase === 'number' && Number.isSafeInteger(configBase) ? configBase : null
+  }
+}
+
+/** The value the guard writes for a key, given what was there before it ran. */
+function guardOwnedValue(key: string, prior: string | null): string | null {
+  if (key === 'GIT_TERMINAL_PROMPT') {
+    return '0'
+  }
+  if (key === 'GCM_INTERACTIVE') {
+    return 'never'
+  }
+  if (key === 'GIT_ASKPASS' || key === 'SSH_ASKPASS') {
+    return prior ?? ''
+  }
+  return null
+}
+
+function restoreScalars(env: Record<string, string>, state: RestoreState): void {
+  for (const key of SCALAR_KEYS) {
+    if (!Object.hasOwn(state.env, key)) {
+      continue
+    }
+    const prior = state.env[key] ?? null
+    // Why: anything that no longer holds the guard's value was set after the guard ran; leave it.
+    if (env[key] !== guardOwnedValue(key, prior)) {
+      continue
+    }
+    if (prior === null) {
+      delete env[key]
+    } else {
+      env[key] = prior
+    }
+  }
+}
+
+function restoreIndexedConfig(env: Record<string, string>, state: RestoreState): void {
+  const base = state.configBase
+  if (base === null) {
+    return
+  }
+  const count = readValidGitConfigEnvCount(env)
+  if (count === null) {
+    // Why: the indexed protocol is positional, so a partial strip corrupts it. Leave an ambiguous set intact.
+    return
+  }
+  const kept: [string, string][] = []
+  for (let index = 0; index < count; index++) {
+    const key = env[`GIT_CONFIG_KEY_${index}`] as string
+    const value = env[`GIT_CONFIG_VALUE_${index}`] as string
+    if (index >= base && GUARD_CONFIG_KEYS.has(key) && value === 'false') {
+      continue
+    }
+    kept.push([key, value])
+  }
+  for (const key of Object.keys(env)) {
+    if (GIT_CONFIG_INDEXED_KEY_RE.test(key)) {
+      delete env[key]
+    }
+  }
+  kept.forEach(([key, value], index) => {
+    env[`GIT_CONFIG_KEY_${index}`] = key
+    env[`GIT_CONFIG_VALUE_${index}`] = value
+  })
+  if (kept.length === 0 && (state.env.GIT_CONFIG_COUNT ?? null) === null) {
+    delete env.GIT_CONFIG_COUNT
+    return
+  }
+  env.GIT_CONFIG_COUNT = String(kept.length)
+}
+
+function restoreWslEnv(env: Record<string, string>, state: RestoreState): void {
+  if (!Object.hasOwn(state.env, 'WSLENV') || env.WSLENV === undefined) {
+    return
+  }
+  const prior = state.env.WSLENV ?? null
+  const priorNames = new Set(
+    (prior ?? '')
+      .split(':')
+      .filter(Boolean)
+      .map((t) => t.split('/')[0])
+  )
+  const kept = env.WSLENV.split(':')
+    .filter(Boolean)
+    .filter((token) => {
+      const name = token.split('/')[0] ?? ''
+      if (priorNames.has(name)) {
+        return true
+      }
+      return !(
+        name === TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE_ENV ||
+        (SCALAR_KEYS as readonly string[]).includes(name) ||
+        GIT_CONFIG_PROTOCOL_KEY_RE.test(name)
+      )
+    })
+  if (kept.length === 0 && prior === null) {
+    delete env.WSLENV
+    return
+  }
+  env.WSLENV = kept.join(':')
+}
+
+/**
+ * Undo an inherited Orca credential guard. Returns whether a guard was found.
+ * Environments with no Orca marker are left untouched, so a user's own
+ * `GIT_TERMINAL_PROMPT=0` survives.
+ */
+export function restoreUnguardedGitCredentialEnv(env: Record<string, string>): boolean {
+  const raw = env[TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE_ENV]
+  if (raw === undefined) {
+    return false
+  }
+  delete env[TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE_ENV]
+  const state = readRestoreState(raw)
+  if (!state) {
+    return false
+  }
+  restoreScalars(env, state)
+  restoreIndexedConfig(env, state)
+  restoreWslEnv(env, state)
+  return true
+}

--- a/src/shared/git-credential-guard-provenance.ts
+++ b/src/shared/git-credential-guard-provenance.ts
@@ -1,4 +1,7 @@
-import { readValidGitConfigEnvCount } from './git-credential-prompt-env'
+import {
+  GIT_CREDENTIAL_GUARD_CONFIG_ENTRIES,
+  readValidGitConfigEnvCount
+} from './git-credential-prompt-env'
 import { addWslEnvKeys } from './wsl-env'
 
 /**
@@ -9,7 +12,8 @@ import { addWslEnvKeys } from './wsl-env'
 export const TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE_ENV =
   'ORCA_INTERNAL_TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE'
 
-const GUARD_CONFIG_KEYS = new Set(['credential.interactive', 'credential.guiPrompt'])
+const GUARD_CONFIG_VALUES = new Map<string, string>(GIT_CREDENTIAL_GUARD_CONFIG_ENTRIES)
+const GUARD_CONFIG_SLOT_COUNT = GIT_CREDENTIAL_GUARD_CONFIG_ENTRIES.length
 const GIT_CONFIG_PROTOCOL_KEY_RE = /^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/
 const GIT_CONFIG_INDEXED_KEY_RE = /^GIT_CONFIG_(?:KEY|VALUE)_\d+$/
 const SCALAR_KEYS = [
@@ -137,7 +141,10 @@ function restoreIndexedConfig(env: Record<string, string>, state: RestoreState):
   for (let index = 0; index < count; index++) {
     const key = env[`GIT_CONFIG_KEY_${index}`] as string
     const value = env[`GIT_CONFIG_VALUE_${index}`] as string
-    if (index >= base && GUARD_CONFIG_KEYS.has(key) && value === 'false') {
+    // Why: only the slots the guard appended; an identical-looking entry past them
+    // was added inside the guarded pane and is the caller's to keep.
+    const isGuardSlot = index >= base && index < base + GUARD_CONFIG_SLOT_COUNT
+    if (isGuardSlot && GUARD_CONFIG_VALUES.get(key) === value) {
       continue
     }
     kept.push([key, value])

--- a/src/shared/git-credential-guard-provenance.ts
+++ b/src/shared/git-credential-guard-provenance.ts
@@ -1,5 +1,6 @@
 import {
   GIT_CREDENTIAL_GUARD_CONFIG_ENTRIES,
+  GIT_CREDENTIAL_GUARD_WSLENV_SCALAR_KEYS,
   readValidGitConfigEnvCount
 } from './git-credential-prompt-env'
 import { addWslEnvKeys } from './wsl-env'
@@ -187,9 +188,11 @@ function restoreWslEnv(env: Record<string, string>, state: RestoreState): void {
       if (priorNames.has(name)) {
         return true
       }
+      // Why: the guard never forwards the askpass names, so a WSLENV token it
+      // never added is the user's even when it postdates the pre-guard snapshot.
       return !(
         name === TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE_ENV ||
-        (SCALAR_KEYS as readonly string[]).includes(name) ||
+        (GIT_CREDENTIAL_GUARD_WSLENV_SCALAR_KEYS as readonly string[]).includes(name) ||
         GIT_CONFIG_PROTOCOL_KEY_RE.test(name)
       )
     })

--- a/src/shared/git-credential-guard-provenance.ts
+++ b/src/shared/git-credential-guard-provenance.ts
@@ -90,8 +90,12 @@ function readRestoreState(raw: string): RestoreState | null {
   return {
     v: 1,
     env: Object.fromEntries(entries),
+    // Why: a negative base is a position the guard cannot have appended at, and
+    // would make slot 0 look guard-owned and delete a pair the user set.
     configBase:
-      typeof configBase === 'number' && Number.isSafeInteger(configBase) ? configBase : null
+      typeof configBase === 'number' && Number.isSafeInteger(configBase) && configBase >= 0
+        ? configBase
+        : null
   }
 }
 

--- a/src/shared/git-credential-prompt-env.ts
+++ b/src/shared/git-credential-prompt-env.ts
@@ -79,6 +79,17 @@ export function appendGitConfigEnv(
 }
 
 /**
+ * The indexed config the guard appends, in append order. Provenance reads it to
+ * bound removal to the slots the guard itself owns.
+ */
+// Why: keep the helper so cached credentials continue to work; disable
+// only its interactive fallback.
+export const GIT_CREDENTIAL_GUARD_CONFIG_ENTRIES = [
+  ['credential.interactive', 'false'],
+  ['credential.guiPrompt', 'false']
+] as const satisfies readonly (readonly [key: string, value: string])[]
+
+/**
  * Disable interactive Git credential UI while preserving cached credentials
  * and caller-provided askpass programs.
  */
@@ -95,12 +106,7 @@ export function gitCredentialPromptGuardEnv(
       // Why: GCM can ignore terminal/askpass guards and open its own GUI.
       GCM_INTERACTIVE: 'never'
     },
-    // Why: keep the helper so cached credentials continue to work; disable
-    // only its interactive fallback.
-    [
-      ['credential.interactive', 'false'],
-      ['credential.guiPrompt', 'false']
-    ]
+    GIT_CREDENTIAL_GUARD_CONFIG_ENTRIES
   )
   if (platform === 'win32') {
     // Why: wsl.exe imports only variables registered in WSLENV. Indexed Git

--- a/src/shared/git-credential-prompt-env.ts
+++ b/src/shared/git-credential-prompt-env.ts
@@ -90,6 +90,15 @@ export const GIT_CREDENTIAL_GUARD_CONFIG_ENTRIES = [
 ] as const satisfies readonly (readonly [key: string, value: string])[]
 
 /**
+ * The scalar guard variables the guard forwards into WSL. Provenance reads it so
+ * restoration removes exactly the names the guard adds to WSLENV and no others.
+ */
+export const GIT_CREDENTIAL_GUARD_WSLENV_SCALAR_KEYS = [
+  'GIT_TERMINAL_PROMPT',
+  'GCM_INTERACTIVE'
+] as const
+
+/**
  * Disable interactive Git credential UI while preserving cached credentials
  * and caller-provided askpass programs.
  */
@@ -115,7 +124,7 @@ export function gitCredentialPromptGuardEnv(
       readValidGitConfigEnvCount(next) === null
         ? []
         : Object.keys(next).filter((key) => GIT_CONFIG_WSLENV_KEY_RE.test(key))
-    addWslEnvKeys(next, ['GIT_TERMINAL_PROMPT', 'GCM_INTERACTIVE', ...configKeys])
+    addWslEnvKeys(next, [...GIT_CREDENTIAL_GUARD_WSLENV_SCALAR_KEYS, ...configKeys])
   }
   return next
 }

--- a/src/shared/terminal-git-credential-guard-inheritance.test.ts
+++ b/src/shared/terminal-git-credential-guard-inheritance.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest'
+import { TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE_ENV } from './git-credential-guard-provenance'
+import {
+  applyTerminalGitCredentialPromptGuard,
+  TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV
+} from './terminal-git-credential-guard'
+
+/** Env a guarded agent pane exports to everything it launches. */
+function guardedParentEnv(
+  platform: NodeJS.Platform,
+  seed: Record<string, string> = {}
+): Record<string, string> {
+  const env: Record<string, string> = { PATH: '/usr/bin', ...seed }
+  expect(applyTerminalGitCredentialPromptGuard(env, { launchCommand: 'claude', platform })).toBe(
+    true
+  )
+  return env
+}
+
+function spawnChild(
+  parentEnv: Record<string, string>,
+  opts: Parameters<typeof applyTerminalGitCredentialPromptGuard>[1]
+): { env: Record<string, string>; guarded: boolean } {
+  const env = { ...parentEnv }
+  return { env, guarded: applyTerminalGitCredentialPromptGuard(env, opts) }
+}
+
+describe('guard env inherited by a terminal the guard declines to guard', () => {
+  it('does not leave GIT_TERMINAL_PROMPT=0 in an ordinary user terminal', () => {
+    for (const platform of ['win32', 'darwin', 'linux'] as const) {
+      const { env, guarded } = spawnChild(guardedParentEnv(platform), {
+        launchCommand: '/bin/zsh',
+        platform
+      })
+
+      expect(guarded).toBe(false)
+      expect(env.GIT_TERMINAL_PROMPT).toBeUndefined()
+      expect(env.GCM_INTERACTIVE).toBeUndefined()
+      expect(env.GIT_ASKPASS).toBeUndefined()
+      expect(env.SSH_ASKPASS).toBeUndefined()
+    }
+  })
+
+  it('removes the whole indexed Git config protocol coherently', () => {
+    const { env } = spawnChild(guardedParentEnv('linux'), {
+      launchCommand: '/bin/zsh',
+      platform: 'linux'
+    })
+
+    expect(env.GIT_CONFIG_COUNT).toBeUndefined()
+    expect(Object.keys(env).filter((key) => key.startsWith('GIT_CONFIG_'))).toEqual([])
+  })
+
+  it('keeps a caller indexed config entry the guard appended after', () => {
+    const parent = guardedParentEnv('linux', {
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'http.proxy',
+      GIT_CONFIG_VALUE_0: 'http://proxy.invalid'
+    })
+    expect(parent.GIT_CONFIG_COUNT).toBe('3')
+
+    const { env } = spawnChild(parent, { launchCommand: '/bin/zsh', platform: 'linux' })
+
+    expect(env.GIT_CONFIG_COUNT).toBe('1')
+    expect(env.GIT_CONFIG_KEY_0).toBe('http.proxy')
+    expect(env.GIT_CONFIG_VALUE_0).toBe('http://proxy.invalid')
+    expect(env.GIT_CONFIG_KEY_1).toBeUndefined()
+    expect(env.GIT_CONFIG_VALUE_1).toBeUndefined()
+  })
+
+  it('restores the user values the guard overwrote', () => {
+    const parent = guardedParentEnv('linux', {
+      GIT_TERMINAL_PROMPT: '1',
+      GCM_INTERACTIVE: 'auto',
+      GIT_ASKPASS: '/usr/local/bin/user-askpass'
+    })
+
+    const { env } = spawnChild(parent, { launchCommand: '/bin/zsh', platform: 'linux' })
+
+    expect(env.GIT_TERMINAL_PROMPT).toBe('1')
+    expect(env.GCM_INTERACTIVE).toBe('auto')
+    expect(env.GIT_ASKPASS).toBe('/usr/local/bin/user-askpass')
+  })
+
+  it('unwinds only the WSLENV tokens the guard added', () => {
+    const parent = guardedParentEnv('win32', { WSLENV: 'CALLER_VALUE/p' })
+    expect((parent.WSLENV ?? '').split(':')).toContain('GIT_TERMINAL_PROMPT')
+
+    const { env } = spawnChild(parent, { launchCommand: '/bin/zsh', platform: 'win32' })
+
+    expect(env.WSLENV).toBe('CALLER_VALUE/p')
+  })
+
+  it('leaves a guarded child fully guarded', () => {
+    const { env, guarded } = spawnChild(guardedParentEnv('linux'), {
+      launchCommand: 'claude',
+      platform: 'linux'
+    })
+
+    expect(guarded).toBe(true)
+    expect(env.GIT_TERMINAL_PROMPT).toBe('0')
+    expect(env.GCM_INTERACTIVE).toBe('never')
+    expect(env.GIT_CONFIG_COUNT).toBe('2')
+    expect(env.GIT_CONFIG_KEY_0).toBe('credential.interactive')
+    expect(env.GIT_CONFIG_KEY_1).toBe('credential.guiPrompt')
+  })
+
+  it('leaves a user terminal with no inherited guard untouched', () => {
+    const original = {
+      PATH: '/usr/bin',
+      GIT_TERMINAL_PROMPT: '0',
+      GIT_ASKPASS: '/usr/local/bin/user-askpass',
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'credential.interactive',
+      GIT_CONFIG_VALUE_0: 'false'
+    }
+    const env = { ...original }
+
+    expect(
+      applyTerminalGitCredentialPromptGuard(env, {
+        launchCommand: '/bin/zsh',
+        platform: 'linux'
+      })
+    ).toBe(false)
+    expect(env).toEqual(original)
+  })
+  it('forwards the provenance marker into WSL beside the guard variables it explains', () => {
+    const names = (guardedParentEnv('win32').WSLENV ?? '')
+      .split(':')
+      .map((token) => token.split('/')[0])
+
+    expect(names).toContain('GIT_TERMINAL_PROMPT')
+    expect(names).toContain(TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE_ENV)
+  })
+
+  it('carries provenance across a detached-host wire', () => {
+    const wire: Record<string, string> = { PATH: '/usr/bin', GIT_TERMINAL_PROMPT: '1' }
+    expect(
+      applyTerminalGitCredentialPromptGuard(wire, {
+        launchCommand: 'claude',
+        platform: 'linux',
+        deferGitConfigGuardToHost: true
+      })
+    ).toBe(true)
+    expect(wire.GIT_TERMINAL_PROMPT).toBe('0')
+
+    const child = { ...wire }
+    // The host consumes the policy marker before the shell ever sees it.
+    delete child[TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV]
+
+    expect(
+      applyTerminalGitCredentialPromptGuard(child, {
+        launchCommand: '/bin/zsh',
+        platform: 'linux'
+      })
+    ).toBe(false)
+    expect(child.GIT_TERMINAL_PROMPT).toBe('1')
+    expect(child[TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE_ENV]).toBeUndefined()
+  })
+
+  it('leaves an indexed config protocol that turned ambiguous fully intact', () => {
+    const parent = guardedParentEnv('linux')
+    // Something after the guard corrupted the positional protocol.
+    parent.GIT_CONFIG_COUNT = '5'
+
+    const { env } = spawnChild(parent, { launchCommand: '/bin/zsh', platform: 'linux' })
+
+    expect(env.GIT_CONFIG_COUNT).toBe('5')
+    expect(env.GIT_CONFIG_KEY_0).toBe('credential.interactive')
+    expect(env.GIT_CONFIG_VALUE_0).toBe('false')
+    expect(env.GIT_CONFIG_KEY_1).toBe('credential.guiPrompt')
+    expect(env.GIT_CONFIG_VALUE_1).toBe('false')
+  })
+
+  it('does not grow the config protocol as guarded panes nest', () => {
+    let env = guardedParentEnv('linux')
+    for (let depth = 0; depth < 3; depth++) {
+      const next = { ...env }
+      expect(
+        applyTerminalGitCredentialPromptGuard(next, { launchCommand: 'claude', platform: 'linux' })
+      ).toBe(true)
+      env = next
+    }
+
+    expect(env.GIT_CONFIG_COUNT).toBe('2')
+  })
+})

--- a/src/shared/terminal-git-credential-guard-inheritance.test.ts
+++ b/src/shared/terminal-git-credential-guard-inheritance.test.ts
@@ -68,6 +68,35 @@ describe('guard env inherited by a terminal the guard declines to guard', () => 
     expect(env.GIT_CONFIG_VALUE_1).toBeUndefined()
   })
 
+  it('keeps indexed config entries appended after the guard, identical-looking or not', () => {
+    const parent = guardedParentEnv('linux', {
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'http.proxy',
+      GIT_CONFIG_VALUE_0: 'http://proxy.invalid'
+    })
+    expect(parent.GIT_CONFIG_COUNT).toBe('3')
+    // Hardening the user appended inside the guarded pane, after Orca's own pair.
+    Object.assign(parent, {
+      GIT_CONFIG_KEY_3: 'credential.interactive',
+      GIT_CONFIG_VALUE_3: 'false',
+      GIT_CONFIG_KEY_4: 'credential.guiPrompt',
+      GIT_CONFIG_VALUE_4: 'false',
+      GIT_CONFIG_COUNT: '5'
+    })
+
+    const { env } = spawnChild(parent, { launchCommand: '/bin/zsh', platform: 'linux' })
+
+    expect(env.GIT_CONFIG_COUNT).toBe('3')
+    expect(env.GIT_CONFIG_KEY_0).toBe('http.proxy')
+    expect(env.GIT_CONFIG_VALUE_0).toBe('http://proxy.invalid')
+    expect(env.GIT_CONFIG_KEY_1).toBe('credential.interactive')
+    expect(env.GIT_CONFIG_VALUE_1).toBe('false')
+    expect(env.GIT_CONFIG_KEY_2).toBe('credential.guiPrompt')
+    expect(env.GIT_CONFIG_VALUE_2).toBe('false')
+    expect(env.GIT_CONFIG_KEY_3).toBeUndefined()
+    expect(env.GIT_CONFIG_VALUE_3).toBeUndefined()
+  })
+
   it('restores the user values the guard overwrote', () => {
     const parent = guardedParentEnv('linux', {
       GIT_TERMINAL_PROMPT: '1',

--- a/src/shared/terminal-git-credential-guard-inheritance.test.ts
+++ b/src/shared/terminal-git-credential-guard-inheritance.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import {
+  restoreGitCredentialGuardEnv,
+  takeGitCredentialGuardEnv
+} from './git-credential-guard-env-test-harness'
 import { TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE_ENV } from './git-credential-guard-provenance'
 import {
   applyTerminalGitCredentialPromptGuard,
@@ -212,5 +216,88 @@ describe('guard env inherited by a terminal the guard declines to guard', () => 
     }
 
     expect(env.GIT_CONFIG_COUNT).toBe('2')
+  })
+  it('keeps a guard variable the pane itself re-exported', () => {
+    const parent = guardedParentEnv('linux')
+    // The pane's own shell rc re-enabled prompting after Orca guarded the pane.
+    parent.GIT_TERMINAL_PROMPT = '1'
+    parent.GCM_INTERACTIVE = 'auto'
+
+    const { env } = spawnChild(parent, { launchCommand: '/bin/zsh', platform: 'linux' })
+
+    expect(env.GIT_TERMINAL_PROMPT).toBe('1')
+    expect(env.GCM_INTERACTIVE).toBe('auto')
+  })
+
+  it('keeps a guard config slot whose value the pane overrode', () => {
+    const parent = guardedParentEnv('linux')
+    // Someone inside the pane flipped Orca's own entry back on.
+    parent.GIT_CONFIG_VALUE_0 = 'true'
+
+    const { env } = spawnChild(parent, { launchCommand: '/bin/zsh', platform: 'linux' })
+
+    expect(env.GIT_CONFIG_COUNT).toBe('1')
+    expect(env.GIT_CONFIG_KEY_0).toBe('credential.interactive')
+    expect(env.GIT_CONFIG_VALUE_0).toBe('true')
+  })
+
+  it("keeps the caller's own WSLENV token for a guard variable, flags and all", () => {
+    const saved = takeGitCredentialGuardEnv()
+    try {
+      const parent = guardedParentEnv('win32', { WSLENV: 'GIT_ASKPASS/p' })
+
+      const { env } = spawnChild(parent, { launchCommand: '/bin/zsh', platform: 'win32' })
+
+      expect(env.WSLENV).toBe('GIT_ASKPASS/p')
+    } finally {
+      restoreGitCredentialGuardEnv(saved)
+    }
+  })
+
+  it('removes WSLENV rather than leaving an empty one behind', () => {
+    const saved = takeGitCredentialGuardEnv()
+    try {
+      const parent = guardedParentEnv('win32')
+      expect(parent.WSLENV).toBeTruthy()
+
+      const { env } = spawnChild(parent, { launchCommand: '/bin/zsh', platform: 'win32' })
+
+      expect(Object.hasOwn(env, 'WSLENV')).toBe(false)
+    } finally {
+      restoreGitCredentialGuardEnv(saved)
+    }
+  })
+
+  it('never lets a detached-host marker remove indexed config the host owns', () => {
+    const wire: Record<string, string> = { PATH: '/usr/bin' }
+    expect(
+      applyTerminalGitCredentialPromptGuard(wire, {
+        launchCommand: 'claude',
+        platform: 'linux',
+        deferGitConfigGuardToHost: true
+      })
+    ).toBe(true)
+
+    // The host's own environment already hardens Git the same way Orca does.
+    const host: Record<string, string> = {
+      ...wire,
+      GIT_CONFIG_COUNT: '2',
+      GIT_CONFIG_KEY_0: 'credential.interactive',
+      GIT_CONFIG_VALUE_0: 'false',
+      GIT_CONFIG_KEY_1: 'credential.guiPrompt',
+      GIT_CONFIG_VALUE_1: 'false'
+    }
+    delete host[TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV]
+
+    expect(
+      applyTerminalGitCredentialPromptGuard(host, {
+        launchCommand: '/bin/zsh',
+        platform: 'linux'
+      })
+    ).toBe(false)
+    expect(host.GIT_CONFIG_COUNT).toBe('2')
+    expect(host.GIT_CONFIG_KEY_0).toBe('credential.interactive')
+    expect(host.GIT_CONFIG_VALUE_0).toBe('false')
+    expect(host.GIT_CONFIG_KEY_1).toBe('credential.guiPrompt')
   })
 })

--- a/src/shared/terminal-git-credential-guard.ts
+++ b/src/shared/terminal-git-credential-guard.ts
@@ -1,4 +1,9 @@
 import { recognizeAgentProcessFromCommandLine } from './agent-process-recognition'
+import {
+  captureGitCredentialGuardPreGuardState,
+  recordGitCredentialGuardProvenance,
+  restoreUnguardedGitCredentialEnv
+} from './git-credential-guard-provenance'
 import { gitCredentialPromptGuardEnv } from './git-credential-prompt-env'
 
 const GIT_CONFIG_PROTOCOL_KEY_RE = /^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/
@@ -20,6 +25,12 @@ export function applyTerminalGitCredentialPromptGuard(
   const explicitlyGuarded = env[TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV] === 'guard'
   delete env[TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV]
 
+  // Why: guard variables are inherited by every child, so undo an inherited Orca
+  // guard before deciding afresh. Otherwise a terminal this call declines to guard
+  // keeps the parent's GIT_TERMINAL_PROMPT=0 and Git fails instead of prompting.
+  restoreUnguardedGitCredentialEnv(env)
+  const platform = opts.platform ?? process.platform
+
   const shouldGuard =
     opts.isUnattended === true ||
     Boolean(
@@ -29,9 +40,14 @@ export function applyTerminalGitCredentialPromptGuard(
     return false
   }
 
-  const guarded = gitCredentialPromptGuardEnv(env, opts.platform ?? process.platform)
+  const preGuard = captureGitCredentialGuardPreGuardState(env)
+  const guarded = gitCredentialPromptGuardEnv(env, platform)
   if (!opts.deferGitConfigGuardToHost) {
     Object.assign(env, guarded)
+    recordGitCredentialGuardProvenance(env, preGuard, {
+      appendedConfig: true,
+      forwardToWsl: platform === 'win32'
+    })
     return true
   }
 
@@ -50,5 +66,9 @@ export function applyTerminalGitCredentialPromptGuard(
     }
     env[key] = value
   }
+  recordGitCredentialGuardProvenance(env, preGuard, {
+    appendedConfig: false,
+    forwardToWsl: false
+  })
   return true
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​755 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​754 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​342 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​333 |

<!-- /orca-pr-loc -->

## ELI5

Orca deliberately turns off Git's "please type your username/password" prompt in
**agent** terminals, so an unattended agent can never hang forever on an invisible
prompt. It does that with a handful of environment variables.

Environment variables are inherited by every program a terminal starts. So when
`applyTerminalGitCredentialPromptGuard` looked at a new terminal and decided *"this
one is a person, do not guard it"* — it returned right there, without removing the
guard variables the terminal had **inherited from its parent**. The decision was
right; the effect was never applied.

Result: a plain shell opened underneath a guarded agent pane silently kept
`GIT_TERMINAL_PROMPT=0`.

## What you'd actually see

**Before:** in an ordinary terminal that happens to sit under a guarded pane, an
HTTPS `git push` / `git fetch` / `git clone` that needs credentials does **not**
prompt. It fails immediately:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

Nothing in the UI explains why, and there is no way to work around what you cannot
see. Cached credentials keep working, so it shows up as *intermittent* auth failure
rather than an obvious misconfiguration.

**After:** the same terminal prompts normally:

```
Username for 'https://github.com':
```

**When you'd hit it:** any terminal that inherits a guarded environment — a shell
launched from inside an agent pane, an Orca process started from one, or a daemon /
SSH relay whose own process environment carries the guard.

## The crux: telling Orca's guard apart from your own setting

If you genuinely exported `GIT_TERMINAL_PROMPT=0` yourself, deleting it would be its
own bug. On `main` this was **not distinguishable**: the existing
`ORCA_INTERNAL_TERMINAL_GIT_CREDENTIAL_GUARD_POLICY` marker is deleted on every path
before the shell ever starts, so a guarded pane exports the guard values with no
Orca provenance at all.

So this PR adds the lever. When the guard is applied it stamps
`ORCA_INTERNAL_TERMINAL_GIT_CREDENTIAL_GUARD_RESTORE` — a small JSON record of the
values that were there **before** the guard ran. An unguarded terminal undoes exactly
those and nothing else, and a variable that no longer holds the guard's own value is
left alone. **No marker → nothing is touched**, so a user's own export survives, and a
pane guarded by an older host behaves exactly as it does today.

## Guard variables handled (the full set from `gitCredentialPromptGuardEnv`)

| Variable | Guard writes | Undo |
| --- | --- | --- |
| `GIT_TERMINAL_PROMPT` | `0` | restore prior value, or delete |
| `GCM_INTERACTIVE` | `never` | restore prior value, or delete |
| `GIT_ASKPASS` | prior, else `''` | delete only when the guard blanked it |
| `SSH_ASKPASS` | prior, else `''` | delete only when the guard blanked it |
| `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n` | appends `credential.interactive=false`, `credential.guiPrompt=false` | remove Orca's pair **at or above the recorded append base**, renumber the rest, rewrite `COUNT` |
| `WSLENV` | registers the guard keys for WSL | remove only tokens the guard added |

The indexed protocol is positional, so a partial strip corrupts it. Orca's pair is
removed *and the remainder renumbered* as one operation; if the protocol is already
ambiguous (`readValidGitConfigEnvCount` returns `null`) it is left **completely
intact** rather than half-stripped. Both are tested.

`WSLENV` also carries the new provenance marker, so a variable stripped on the
Windows side is stripped in the guest too rather than arriving guarded.

## Where it is applied

| Path | Site |
| --- | --- |
| Local | `applyTerminalGitCredentialPromptGuard` (via `main/ipc/pty/host-env/assembly.ts`) |
| Detached-host wire | same function, `deferGitConfigGuardToHost` arm |
| Persistent daemon | `composeGuardedDaemonGitConfigEnv` in `daemon/pty-subprocess/spawn-environment.ts` |
| SSH relay, fresh spawn | `relay/pty-handler.ts` (via the shared function) |
| SSH relay, revive | `relay/pty-handler.ts` revive block |

`relay/agent-exec-handler.ts` always passes `isUnattended: true`, so it is always
guarded and needs no change.

The fix is *restore-then-decide*, which also makes the guard idempotent — see the
bonus fix below.

## Failing-first proof

New suite `src/shared/terminal-git-credential-guard-inheritance.test.ts`.

**On `main` (`65dd06a8701d`) — 6 of 7 fail:**

```
Tests  6 failed | 1 passed (7)

× does not leave GIT_TERMINAL_PROMPT=0 in an ordinary user terminal
    expected "0" to be undefined
× removes the whole indexed Git config protocol coherently
× keeps a caller indexed config entry the guard appended after
× restores the user values the guard overwrote
    expected "0" to be "1"
× unwinds only the WSLENV tokens the guard added
    expected 'CALLER_VALUE/p:GIT_TERMINAL_PROMPT:GC…' to be 'CALLER_VALUE/p'
× leaves a guarded child fully guarded
    expected "4" to be "2"
✓ leaves a user terminal with no inherited guard untouched
```

The one that passes on `main` is the *preservation* case — a user's own
`GIT_TERMINAL_PROMPT=0` with no Orca marker must not be touched. It passes before
and after, which is the point.

**After the fix — 11 pass**, and the pre-existing guard suite is unchanged
(`src/main/ipc/terminal-git-credential-guard.test.ts`, 10/10, including
"leaves ordinary user terminals unchanged on every platform").

### Real Git behaviour, under a real PTY

Same binary (git 2.50.1), same repo, same clean environment, only the inherited
guard differs:

```
=== A) unguarded pane (no guard env) -> git PROMPTS on the tty ===
Username for 'https://github.com':

=== B) unguarded pane that INHERITED the guard -> NO prompt, hard failure ===
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

## Bonus fix: the guard was not idempotent

`leaves a guarded child fully guarded` fails on `main` with `GIT_CONFIG_COUNT=4`.
A guarded pane nested under a guarded pane appended Orca's credential pair **again**,
so `GIT_CONFIG_COUNT` grew by 2 per nesting level without bound. Restore-then-decide
fixes that too; pinned by `does not grow the config protocol as guarded panes nest`
(3 levels deep, still `2`).

## Ablation table

Each production hunk deleted individually, then the covering suites re-run. Source
files were checksummed before and after the sweep and verified byte-identical.

| Hunk | Ablated | Result |
| --- | --- | --- |
| H1 | `terminal-git-credential-guard.ts` — restore-first | FAILS (12) |
| H2 | `terminal-git-credential-guard.ts` — record, local arm | FAILS (8) |
| H3 | `terminal-git-credential-guard.ts` — record, defer arm | FAILS (1) |
| H4 | `spawn-environment.ts` — daemon restore-first | FAILS (1) |
| H5 | `spawn-environment.ts` — daemon record | FAILS (1) |
| H6 | `pty-handler.ts` — relay revive restore-first | FAILS (1) |
| H7 | `pty-handler.ts` — relay revive record | FAILS (1) |
| H8 | `git-credential-guard-provenance.ts` — `restoreScalars` | FAILS (9) |
| H9 | `git-credential-guard-provenance.ts` — `restoreIndexedConfig` | FAILS (8) |
| H10 | `git-credential-guard-provenance.ts` — `restoreWslEnv` | FAILS (1) |
| H11 | `git-credential-guard-provenance.ts` — WSLENV marker forwarding | FAILS (1) |
| H12 | `git-credential-guard-provenance.ts` — ambiguous-protocol bail | FAILS (1) |

Every hunk is pinned; no hunk is unpinned or excused.

## Relationship to #16909

Found while reviewing #16909, and this is the **second of two causes** of the same
user-visible symptom. #16909 stops ordinary terminals from *looking* like agent
launches; this PR stops terminals correctly identified as ordinary from *keeping*
the guard they inherited. Neither subsumes the other.

`git merge-tree` against #16909 head `02cacf64e0` is conflict-free, and I checked the
merged blobs rather than trusting the exit code: `spawn-environment.ts` and
`pty-handler.ts` both contain #16909's `removeUnspecifiedPtyChildScopedEnv` calls
*and* this PR's restore/record calls. Nothing #16909 adds is weakened or removed.

## Testing

- `src/shared/terminal-git-credential-guard-inheritance.test.ts` — 11 new
- `src/main/daemon/pty-subprocess-git-credential-guard.test.ts` — +2 (daemon inherit-strip, daemon child round-trip)
- `src/relay/pty-handler-spawn-environment.test.ts` — +1 (relay fresh spawn)
- `src/relay/pty-handler-revive.test.ts` — +2 (revive inherit-strip, revive child round-trip)
- Parent suites `src/relay src/main/daemon src/shared src/main/ipc` — **12,679 passed**, 82 skipped, 0 failed
- `pnpm tc` and `pnpm tc:web` — both exit 0
- `oxlint` clean on changed files; changed-code quality gate: 0 findings (code quality, type-aware, React Doctor)
- `git diff --check` clean; no `node:child_process` imports added

Test doubles for inherited environments are built by calling the **real**
`applyTerminalGitCredentialPromptGuard`, not by hand-writing an env dict, so they
cannot omit a variable the guard actually sets.

`src/shared/git-credential-guard-env-test-harness.ts` gives those suites ownership of
the credential-guard slice of `process.env`. This is needed because Orca's own agent
panes export the guard — a suite that reads ambient `process.env` is really reading
the pane the tests happen to run in.

## What I did NOT verify

- **No packaged-build or live-app run.** Everything is unit-level plus a direct
  `node-pty` reproduction of Git's behaviour. No `$electron` validation (this change
  has no UI surface).
- **macOS only.** Windows, WSL and Linux behaviour is covered by tests that pass an
  explicit `platform`, not by running on those hosts. The `WSLENV` handling in
  particular has never been exercised against a real `wsl.exe`.
- **No real SSH relay.** The relay spawn and revive paths are covered through the
  relay's own mocked-PTY suites, not against a live remote host.
- **Mixed-version hosts are safe but unfixed.** A pane guarded by an *older* host
  carries no provenance marker, so its children still inherit the guard — the
  behaviour on `main` today. It is deliberately conservative rather than guessing,
  because stripping a user's own setting is the worse failure.
- **Ambiguous indexed config is left intact**, meaning `credential.interactive=false`
  can survive into an unguarded terminal if the protocol was already corrupt. Chosen
  over a partial strip, which would break Git outright.
- **One pre-existing failure on `main` is untouched by this PR:**
  `pty-handler-spawn-environment.test.ts > leaves an ordinary Windows SSH user
  terminal unchanged` fails on pristine `65dd06a8701d` when the suite is run from a
  setup-gated pane (`ORCA_SEQUENCED_STARTUP_COMMAND` in the environment). That is
  exactly the bug #16909 fixes. I verified it fails with my changes stashed, and I
  did not modify that test.
