### PR TITLE
fix(startup): open the window before asking the OS keyring about stored secrets

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,6 +38,7 @@ import { setSecretStore } from '../shared/secret-store'
 import { ElectronSecretStore } from './host/electron-secret-store'
 import { reportSecretProtectionGap } from './host/secret-protection-report'
 import { initSessionParseCachePersistence } from './ai-vault/session-parse-cache-persistence'
+import { deferUntilFirstWindowShown } from './window/defer-until-first-window-shown'
 import { ensureActiveOrcaProfile, initOrcaProfilePaths } from './orca-profiles/profile-index-store'
 import { getOrcaCloudAuthConfig } from './orca-profiles/profile-cloud-auth-config'
 import { getProfileUserDataPath } from './orca-profiles/profile-storage-paths'
@@ -2342,9 +2343,15 @@ void app.whenReady().then(async () => {
   // Why this early: the first window stamps the hosting id into its renderer's argv, so the durable
   // read has to have happened by then or the renderer and the browser-host lease disagree.
   initializeBrowserClientHostId(activeOrcaProfile.profileDirectory)
+  // Why deferred: the load decrypts every populated protected slot, and each decrypt probes the
+  // OS keyring — on Linux a blocking D-Bus round trip that a locked keyring never answers, run
+  // here with no window on screen to explain the wait (STA-5782). Serve is excluded: it opens no
+  // window, so deferring would move the block past the point clients can already pair.
+  const deferKeyringProbe = process.platform === 'linux' && !isServeMode
   store = new Store({
     dataFile: activeOrcaProfile.dataFile,
-    storageAuthority: isServeMode ? 'runtime' : 'desktop'
+    storageAuthority: isServeMode ? 'runtime' : 'desktop',
+    deferKeyringProbe
   })
   // Why here and not at install time: the report remembers what it last said, and that
   // state lives beside the profile data file, which does not exist until now.
@@ -2444,6 +2451,20 @@ void app.whenReady().then(async () => {
     }
   } catch {
     console.warn('[proxy] Failed to apply network proxy settings')
+  }
+  if (deferKeyringProbe) {
+    const deferredSecretStore = store
+    deferUntilFirstWindowShown(() => {
+      const hydration = deferredSecretStore.hydrateDeferredProtectedSecrets()
+      // Why re-apply here and not via onSettingsChanged: the proxy is applied once at startup
+      // from settings, not from a listener, so a deferred load leaves it on the environment
+      // fallback for the rest of the session.
+      if ('httpProxyUrl' in hydration.settingsUpdates) {
+        void applyElectronProxySettings(deferredSecretStore.getSettings()).catch(() => {
+          console.warn('[proxy] Failed to apply network proxy settings after secret hydration')
+        })
+      }
+    })
   }
   // Why: the preview session is protocol-scoped, so the handler must exist before any preview webview attaches.
   installDocPreviewProtocolHandler()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,6 +39,7 @@ import { ElectronSecretStore } from './host/electron-secret-store'
 import { reportSecretProtectionGap } from './host/secret-protection-report'
 import { initSessionParseCachePersistence } from './ai-vault/session-parse-cache-persistence'
 import { deferUntilFirstWindowShown } from './window/defer-until-first-window-shown'
+import { shouldDeferKeyringProbe } from './startup/keyring-probe-deferral'
 import { ensureActiveOrcaProfile, initOrcaProfilePaths } from './orca-profiles/profile-index-store'
 import { getOrcaCloudAuthConfig } from './orca-profiles/profile-cloud-auth-config'
 import { getProfileUserDataPath } from './orca-profiles/profile-storage-paths'
@@ -2347,7 +2348,7 @@ void app.whenReady().then(async () => {
   // OS keyring — on Linux a blocking D-Bus round trip that a locked keyring never answers, run
   // here with no window on screen to explain the wait (STA-5782). Serve is excluded: it opens no
   // window, so deferring would move the block past the point clients can already pair.
-  const deferKeyringProbe = process.platform === 'linux' && !isServeMode
+  const deferKeyringProbe = shouldDeferKeyringProbe({ platform: process.platform, isServeMode })
   store = new Store({
     dataFile: activeOrcaProfile.dataFile,
     storageAuthority: isServeMode ? 'runtime' : 'desktop',

--- a/src/main/persistence/loading-store/deferred-secret-hydration.test.ts
+++ b/src/main/persistence/loading-store/deferred-secret-hydration.test.ts
@@ -1,0 +1,229 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { _resetSecretStoreForTests, setSecretStore } from '../../../shared/secret-store'
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import { dataFile, testState, writeDataFile } from '../../persistence-test-harness'
+import { installFakeAppEnvironment } from '../../../../config/scripts/vitest-host-ports-setup'
+import { initDataPath } from './user-data-path'
+import { Store } from './store'
+
+vi.mock('electron', () => ({ app: { getPath: () => testState.dir } }))
+vi.mock('../../telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('../../telemetry/cohort-classifier', () => ({ getCohortAtEmit: () => ({}) }))
+vi.mock('../../ssh/ssh-config-parser', () => ({
+  loadUserSshConfig: vi.fn(() => ({ hosts: [] })),
+  sshConfigHostsToTargets: vi.fn(() => [])
+}))
+
+/**
+ * How long the fake keyring blocks the calling thread. Models the real hazard: on a locked
+ * Linux keyring, `safeStorage.isEncryptionAvailable()` accepts the call and does not return —
+ * a fast failure would not reproduce it. Bounded so a regression fails the suite instead of
+ * wedging the worker, since a synchronous spin cannot be interrupted by a test timeout.
+ */
+const KEYRING_BLOCK_MS = 2_000
+/** Generous enough to absorb loaded-CI jitter, far below one blocking probe. */
+const NON_BLOCKING_CEILING_MS = 1_000
+
+const PROXY_URL = 'http://proxy.example:8080'
+const KAGI_LINK = 'https://kagi.com/search?token=abcdef0123456789'
+const OWNER_LEASE = '11111111-2222-4333-8444-555555555555'
+const COOKIE = 'auth=opencode-session-value'
+
+function seal(plaintext: string): string {
+  return Buffer.from(`encrypted:${plaintext}`, 'utf-8').toString('base64')
+}
+
+let probes = 0
+
+function installBlockingKeyring(): void {
+  setSecretStore({
+    isEncryptionAvailable: () => {
+      probes += 1
+      // Why a real thread block and not a counter alone: this is what a locked keyring does to
+      // the main process, and it is the only thing that makes a pre-window probe fatal.
+      // Why only the first call: OSCrypt resolves the backend once, so the block lands on
+      // whichever call happens first — which is the whole question this file is about.
+      if (probes === 1) {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, KEYRING_BLOCK_MS)
+      }
+      return true
+    },
+    encryptString: (plainText) => Buffer.from(`encrypted:${plainText}`, 'utf-8'),
+    decryptString: (cipher) => {
+      const decoded = cipher.toString('utf-8')
+      if (!decoded.startsWith('encrypted:')) {
+        throw new Error('invalid ciphertext')
+      }
+      return decoded.slice('encrypted:'.length)
+    },
+    describeProtectionGap: () => null
+  })
+}
+
+function writeProfileWithEverySecretSlot(): void {
+  writeDataFile({
+    settings: { httpProxyUrl: seal(PROXY_URL), opencodeSessionCookie: seal(COOKIE) },
+    ui: { browserKagiSessionLink: seal(KAGI_LINK) },
+    sshPtyConsumerRecoveries: [
+      {
+        targetId: 'target-1',
+        clientInstanceId: 'client-1',
+        serverBuildId: 'build-1',
+        clientGeneration: 1,
+        ownerGeneration: 1,
+        ownerLease: seal(OWNER_LEASE)
+      }
+    ]
+  })
+}
+
+function createStore(options: { deferKeyringProbe?: boolean } = {}): Store {
+  installFakeAppEnvironment({ getPath: () => testState.dir })
+  initDataPath()
+  return new Store({ dataFile: dataFile(), ...options })
+}
+
+describe('deferred protected-secret hydration', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-deferred-secret-'))
+    probes = 0
+    installBlockingKeyring()
+  })
+
+  afterEach(() => {
+    _resetSecretStoreForTests()
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('never touches the keyring while loading a profile that has populated secret slots', () => {
+    // Why this is the regression (STA-5782): the Store constructor runs ~1000 lines before the
+    // first window exists, so one blocking probe here is a window that never appears.
+    writeProfileWithEverySecretSlot()
+
+    const startedAt = performance.now()
+    const store = createStore({ deferKeyringProbe: true })
+    const elapsedMs = performance.now() - startedAt
+
+    expect(probes).toBe(0)
+    expect(elapsedMs).toBeLessThan(NON_BLOCKING_CEILING_MS)
+    // Withheld, not read: a deferred load exposes nothing, exactly as an unavailable keyring does.
+    expect(store.getSettings().httpProxyUrl).toBe('')
+    expect(store.getSettings().opencodeSessionCookie).toBe('')
+    store.freezeWrites()
+  })
+
+  it('restores every deferred slot once hydration runs', () => {
+    writeProfileWithEverySecretSlot()
+    const store = createStore({ deferKeyringProbe: true })
+
+    const result = store.hydrateDeferredProtectedSecrets()
+
+    expect(result.hydrated).toBe(true)
+    expect(probes).toBeGreaterThan(0)
+    expect(store.getSettings().httpProxyUrl).toBe(PROXY_URL)
+    expect(store.getSettings().opencodeSessionCookie).toBe(COOKIE)
+    expect(store.getUI().browserKagiSessionLink).toBe(KAGI_LINK)
+    expect(store.getSshPtyConsumerRecovery('target-1')?.ownerLease).toBe(OWNER_LEASE)
+    store.freezeWrites()
+  })
+
+  it('tells settings and UI listeners the real values so startup work can re-run against them', () => {
+    writeProfileWithEverySecretSlot()
+    const store = createStore({ deferKeyringProbe: true })
+    const seen: Partial<GlobalSettings>[] = []
+    const seenUi: (string | null | undefined)[] = []
+    store.onSettingsChanged((updates) => void seen.push(updates))
+    store.onUIChanged((ui) => void seenUi.push(ui.browserKagiSessionLink))
+
+    const result = store.hydrateDeferredProtectedSecrets()
+
+    expect(result.settingsUpdates.httpProxyUrl).toBe(PROXY_URL)
+    expect(seen.map((updates) => updates.httpProxyUrl)).toEqual([PROXY_URL])
+    expect(result.uiChanged).toBe(true)
+    expect(seenUi).toEqual([KAGI_LINK])
+    store.freezeWrites()
+  })
+
+  it('keeps the stored ciphertext byte-for-byte when a save lands before hydration', () => {
+    // Why: a withheld read is not an empty value. Writing the profile back with the slots blank
+    // would destroy secrets the user still has, which no failed probe justifies.
+    writeProfileWithEverySecretSlot()
+    const before = JSON.parse(readFileSync(dataFile(), 'utf-8')) as {
+      settings: { httpProxyUrl: string }
+    }
+    const store = createStore({ deferKeyringProbe: true })
+
+    store.updateSettings({ terminalFontSize: 15 })
+    store.flushOrThrow()
+
+    const after = JSON.parse(readFileSync(dataFile(), 'utf-8')) as {
+      settings: { httpProxyUrl: string; opencodeSessionCookie: string }
+      ui: { browserKagiSessionLink: string }
+      sshPtyConsumerRecoveries: { ownerLease: string }[]
+    }
+    expect(after.settings.httpProxyUrl).toBe(before.settings.httpProxyUrl)
+    expect(after.settings.opencodeSessionCookie).toBe(seal(COOKIE))
+    expect(after.ui.browserKagiSessionLink).toBe(seal(KAGI_LINK))
+    expect(after.sshPtyConsumerRecoveries.at(0)?.ownerLease).toBe(seal(OWNER_LEASE))
+    store.freezeWrites()
+  })
+
+  it('persists the clear when hydration finds an unusable secret, with no explicit flush', async () => {
+    // Why without a flush: hydration runs long after startup, so nothing else is guaranteed to
+    // save. Dropping the retained blob in memory only would resurrect the bad value next launch.
+    writeDataFile({ settings: { httpProxyUrl: seal('!!! not a url !!!') } })
+    const store = createStore({ deferKeyringProbe: true })
+    // Why flush first: load-time migrations schedule their own save, and a hydration that
+    // scheduled nothing would still reach disk on the back of it.
+    store.flushOrThrow()
+    expect(
+      (JSON.parse(readFileSync(dataFile(), 'utf-8')) as { settings: { httpProxyUrl: string } })
+        .settings.httpProxyUrl
+    ).toBe(seal('!!! not a url !!!'))
+
+    const result = store.hydrateDeferredProtectedSecrets()
+    expect(result.needsSave).toBe(true)
+    await vi.waitFor(
+      async () => {
+        await store.waitForPendingWrite()
+        const saved = JSON.parse(readFileSync(dataFile(), 'utf-8')) as {
+          settings: { httpProxyUrl: string }
+        }
+        expect(saved.settings.httpProxyUrl).toBe('')
+      },
+      { timeout: 10_000, interval: 100 }
+    )
+    store.freezeWrites()
+  })
+
+  it('probes inline when the host opens no window, so nothing pairs against a stalled main thread', () => {
+    // Why pinned: headless serve advertises readiness with no window to defer behind, and an
+    // earlier deferral moved this block to after clients could already connect (STA-5765).
+    writeProfileWithEverySecretSlot()
+
+    const store = createStore()
+
+    expect(probes).toBeGreaterThan(0)
+    expect(store.getSettings().httpProxyUrl).toBe(PROXY_URL)
+    expect(store.hydrateDeferredProtectedSecrets().hydrated).toBe(false)
+    store.freezeWrites()
+  })
+
+  it('reports nothing to hydrate when the load already probed', () => {
+    writeProfileWithEverySecretSlot()
+    const store = createStore()
+
+    const result = store.hydrateDeferredProtectedSecrets()
+
+    expect(result).toEqual({
+      hydrated: false,
+      settingsUpdates: {},
+      uiChanged: false,
+      needsSave: false
+    })
+    store.freezeWrites()
+  })
+})

--- a/src/main/persistence/loading-store/deferred-secret-hydration.test.ts
+++ b/src/main/persistence/loading-store/deferred-secret-hydration.test.ts
@@ -245,6 +245,42 @@ describe('deferred protected-secret hydration', () => {
     store.freezeWrites()
   })
 
+  it('keeps a secret written while the window was up instead of reverting it on hydration', async () => {
+    // Why this is reachable: the whole point of the deferral is that the window paints first, so
+    // there is a real interval in which the app is on screen and every protected slot still reads
+    // as empty. A write in that interval is the user's current intent; the retained ciphertext is
+    // the value they replaced. Hydrating over it silently restores the old proxy — and a proxy is
+    // where traffic goes, so a silent revert sends it somewhere the user has stopped choosing.
+    writeProfileWithEverySecretSlot()
+    const store = createStore({ deferKeyringProbe: true })
+    const seen: Partial<GlobalSettings>[] = []
+    store.onSettingsChanged((updates) => void seen.push(updates))
+
+    store.updateSettings({
+      httpProxyUrl: 'http://replacement.example:9090',
+      opencodeSessionCookie: 'auth=replacement-session-value'
+    })
+    store.updateUI({ browserKagiSessionLink: 'https://kagi.com/search?token=99998888aaaabbbb' })
+    const result = store.hydrateDeferredProtectedSecrets()
+
+    expect(store.getSettings().httpProxyUrl).toBe('http://replacement.example:9090')
+    expect(store.getSettings().opencodeSessionCookie).toBe('auth=replacement-session-value')
+    expect(store.getUI().browserKagiSessionLink).toBe(
+      'https://kagi.com/search?token=99998888aaaabbbb'
+    )
+    // Why the listener census too: a revert announced to listeners re-runs startup work — the
+    // proxy re-apply in index.ts above all — against the value the user just discarded.
+    expect(seen.map((updates) => updates.httpProxyUrl)).not.toContain(PROXY_URL)
+    expect(seen.map((updates) => updates.opencodeSessionCookie)).not.toContain(COOKIE)
+    expect(result.settingsUpdates.httpProxyUrl).toBeUndefined()
+    expect(result.settingsUpdates.opencodeSessionCookie).toBeUndefined()
+    // Why an untouched slot in the same run: the guard must be per slot, not a blanket bail that
+    // would strand every secret the user did not happen to overwrite.
+    expect(store.getSshPtyConsumerRecovery('target-1')?.ownerLease).toBe(OWNER_LEASE)
+    await store.waitForPendingWrite()
+    store.freezeWrites()
+  })
+
   it('probes inline when the host opens no window, so nothing pairs against a stalled main thread', () => {
     // Why pinned: headless serve advertises readiness with no window to defer behind, and an
     // earlier deferral moved this block to after clients could already connect (STA-5765).

--- a/src/main/persistence/loading-store/deferred-secret-hydration.test.ts
+++ b/src/main/persistence/loading-store/deferred-secret-hydration.test.ts
@@ -37,6 +37,7 @@ function seal(plaintext: string): string {
 }
 
 let probes = 0
+let encryptions = 0
 
 function installBlockingKeyring(): void {
   setSecretStore({
@@ -51,13 +52,16 @@ function installBlockingKeyring(): void {
       }
       return true
     },
-    encryptString: (plainText) => Buffer.from(`encrypted:${plainText}`, 'utf-8'),
+    // Why a nonce: a real keyring seals with a fresh IV, so re-encrypting a value yields
+    // different bytes. Without that, a save that decrypted and re-encrypted a secret would be
+    // indistinguishable from one that preserved the stored ciphertext untouched.
+    encryptString: (plainText) => Buffer.from(`encrypted:${plainText}#${++encryptions}`, 'utf-8'),
     decryptString: (cipher) => {
       const decoded = cipher.toString('utf-8')
       if (!decoded.startsWith('encrypted:')) {
         throw new Error('invalid ciphertext')
       }
-      return decoded.slice('encrypted:'.length)
+      return decoded.slice('encrypted:'.length).replace(/#\d+$/, '')
     },
     describeProtectionGap: () => null
   })
@@ -90,6 +94,7 @@ describe('deferred protected-secret hydration', () => {
   beforeEach(() => {
     testState.dir = mkdtempSync(join(tmpdir(), 'orca-deferred-secret-'))
     probes = 0
+    encryptions = 0
     installBlockingKeyring()
   })
 
@@ -193,6 +198,47 @@ describe('deferred protected-secret hydration', () => {
           settings: { httpProxyUrl: string }
         }
         expect(saved.settings.httpProxyUrl).toBe('')
+      },
+      { timeout: 10_000, interval: 100 }
+    )
+    store.freezeWrites()
+  })
+
+  it('persists the drop when hydration finds an unusable SSH owner lease', async () => {
+    // Why: the lease decodes to a value normalization rejects, so hydration drops the record.
+    // Dropping it in memory only would resurrect it next launch and re-present a lease the
+    // relay will refuse, so the drop has to reach disk on hydration's own save.
+    writeDataFile({
+      sshPtyConsumerRecoveries: [
+        {
+          targetId: 'target-1',
+          clientInstanceId: 'client-1',
+          serverBuildId: 'build-1',
+          clientGeneration: 1,
+          ownerGeneration: 1,
+          ownerLease: seal('')
+        }
+      ]
+    })
+    const store = createStore({ deferKeyringProbe: true })
+    // Why flush first: load-time migrations schedule their own save, and a hydration that
+    // scheduled nothing would still reach disk on the back of it.
+    store.flushOrThrow()
+    expect(
+      (JSON.parse(readFileSync(dataFile(), 'utf-8')) as { sshPtyConsumerRecoveries: unknown[] })
+        .sshPtyConsumerRecoveries
+    ).toHaveLength(1)
+
+    const result = store.hydrateDeferredProtectedSecrets()
+
+    expect(result.needsSave).toBe(true)
+    await vi.waitFor(
+      async () => {
+        await store.waitForPendingWrite()
+        const saved = JSON.parse(readFileSync(dataFile(), 'utf-8')) as {
+          sshPtyConsumerRecoveries: unknown[]
+        }
+        expect(saved.sshPtyConsumerRecoveries).toEqual([])
       },
       { timeout: 10_000, interval: 100 }
     )

--- a/src/main/persistence/loading-store/deferred-secret-hydration.ts
+++ b/src/main/persistence/loading-store/deferred-secret-hydration.ts
@@ -1,0 +1,89 @@
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import type { SshPtyConsumerRecovery } from '../../../shared/ssh-types'
+import { PROTECTED_SECRET_SLOT } from '../../protected-secret-persistence'
+import {
+  decodeBrowserKagiSessionLink,
+  decodeHttpProxyUrl,
+  decodeOpencodeSessionCookie,
+  decodeSshPtyOwnerLease
+} from './protected-secret-decoding'
+import type { StoreRuntimeState } from './store-runtime-state'
+
+type DeferredSecretHydrationRuntime = Pick<StoreRuntimeState, 'protectedSecrets' | 'state'>
+
+export type DeferredSecretHydrationResult = {
+  /** False when the load already probed the keyring, so there is nothing left to finish. */
+  hydrated: boolean
+  settingsUpdates: Partial<GlobalSettings>
+  uiChanged: boolean
+  /** True when a slot was dropped as unusable, which only reaches disk on the next save. */
+  needsSave: boolean
+}
+
+const NOTHING_DEFERRED: DeferredSecretHydrationResult = {
+  hydrated: false,
+  settingsUpdates: {},
+  uiChanged: false,
+  needsSave: false
+}
+
+/**
+ * Finish the protected slots a deferred load left sealed, now that blocking the main thread
+ * no longer blocks a window from appearing.
+ *
+ * Why re-read from the retained ciphertext rather than from state: a deferred load exposes
+ * nothing, exactly as it does when the keyring is genuinely unavailable, so state holds the
+ * withheld value and the ciphertext lives only in the retention map.
+ */
+export function hydrateDeferredProtectedSecrets(
+  runtime: DeferredSecretHydrationRuntime
+): DeferredSecretHydrationResult {
+  const secrets = runtime.protectedSecrets
+  if (!secrets.isKeyringProbeDeferred()) {
+    return NOTHING_DEFERRED
+  }
+  secrets.resumeKeyringProbe()
+
+  const settingsUpdates: Partial<GlobalSettings> = {}
+  let needsSave = false
+  let uiChanged = false
+
+  const cookieBlob = secrets.retainedBlob(PROTECTED_SECRET_SLOT.opencodeSessionCookie)
+  if (cookieBlob) {
+    const cookie = decodeOpencodeSessionCookie(secrets, cookieBlob)
+    if (cookie !== runtime.state.settings.opencodeSessionCookie) {
+      runtime.state.settings.opencodeSessionCookie = cookie
+      settingsUpdates.opencodeSessionCookie = cookie
+    }
+  }
+
+  const proxyBlob = secrets.retainedBlob(PROTECTED_SECRET_SLOT.httpProxyUrl)
+  if (proxyBlob) {
+    const proxy = decodeHttpProxyUrl(secrets, proxyBlob)
+    needsSave ||= proxy.cleared
+    if (proxy.value !== (runtime.state.settings.httpProxyUrl ?? '')) {
+      runtime.state.settings.httpProxyUrl = proxy.value
+      settingsUpdates.httpProxyUrl = proxy.value
+    }
+  }
+
+  const kagiBlob = secrets.retainedBlob(PROTECTED_SECRET_SLOT.browserKagiSessionLink)
+  if (kagiBlob) {
+    const link = decodeBrowserKagiSessionLink(secrets, kagiBlob)
+    if (link !== (runtime.state.ui.browserKagiSessionLink ?? '')) {
+      runtime.state.ui.browserKagiSessionLink = link
+      uiChanged = true
+    }
+  }
+
+  const recoveries = runtime.state.sshPtyConsumerRecoveries
+  if (recoveries && recoveries.length > 0) {
+    const decoded = recoveries
+      .map((record) => decodeSshPtyOwnerLease(secrets, record))
+      .filter((record): record is SshPtyConsumerRecovery => record !== null)
+    needsSave ||= decoded.length !== recoveries.length
+    runtime.state.sshPtyConsumerRecoveries = decoded
+  }
+
+  return { hydrated: true, settingsUpdates, uiChanged, needsSave }
+}

--- a/src/main/persistence/loading-store/deferred-secret-hydration.ts
+++ b/src/main/persistence/loading-store/deferred-secret-hydration.ts
@@ -48,8 +48,11 @@ export function hydrateDeferredProtectedSecrets(
   let needsSave = false
   let uiChanged = false
 
+  // Why each slot is claimed only while still withheld: the deferred load left it at '', so a
+  // non-empty value now is a write that landed after the window came up and before hydration ran.
+  // Overwriting it from the retained ciphertext would silently revert the user's own change.
   const cookieBlob = secrets.retainedBlob(PROTECTED_SECRET_SLOT.opencodeSessionCookie)
-  if (cookieBlob) {
+  if (cookieBlob && !runtime.state.settings.opencodeSessionCookie) {
     const cookie = decodeOpencodeSessionCookie(secrets, cookieBlob)
     if (cookie !== runtime.state.settings.opencodeSessionCookie) {
       runtime.state.settings.opencodeSessionCookie = cookie
@@ -58,7 +61,7 @@ export function hydrateDeferredProtectedSecrets(
   }
 
   const proxyBlob = secrets.retainedBlob(PROTECTED_SECRET_SLOT.httpProxyUrl)
-  if (proxyBlob) {
+  if (proxyBlob && !(runtime.state.settings.httpProxyUrl ?? '')) {
     const proxy = decodeHttpProxyUrl(secrets, proxyBlob)
     needsSave ||= proxy.cleared
     if (proxy.value !== (runtime.state.settings.httpProxyUrl ?? '')) {
@@ -68,7 +71,7 @@ export function hydrateDeferredProtectedSecrets(
   }
 
   const kagiBlob = secrets.retainedBlob(PROTECTED_SECRET_SLOT.browserKagiSessionLink)
-  if (kagiBlob) {
+  if (kagiBlob && !(runtime.state.ui.browserKagiSessionLink ?? '')) {
     const link = decodeBrowserKagiSessionLink(secrets, kagiBlob)
     if (link !== (runtime.state.ui.browserKagiSessionLink ?? '')) {
       runtime.state.ui.browserKagiSessionLink = link

--- a/src/main/persistence/loading-store/loaded-state-parsing.ts
+++ b/src/main/persistence/loading-store/loaded-state-parsing.ts
@@ -1,7 +1,5 @@
 import { readFileSync, existsSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { normalizeProxyUrl } from '../../../shared/network-proxy'
-import { normalizeKagiSessionLink } from '../../../shared/browser-url'
 import type { PersistedState } from '../../../shared/persisted-state-types'
 import type { SshPtyConsumerRecovery } from '../../../shared/ssh-types'
 import { getDefaultPersistedState } from '../../../shared/constants'
@@ -14,13 +12,11 @@ import {
   logStartupDiagnostic
 } from '../../startup/startup-diagnostics'
 import {
-  PROTECTED_SECRET_SLOT,
-  sshPtyOwnerLeaseSecretSlot
-} from '../../protected-secret-persistence'
-import {
-  isLegacyOpenCodeSessionCookie,
-  isLegacySshPtyOwnerLease
-} from '../leasing-ssh-ptys/secret-validation'
+  decodeBrowserKagiSessionLink,
+  decodeHttpProxyUrl,
+  decodeOpencodeSessionCookie,
+  decodeSshPtyOwnerLease
+} from './protected-secret-decoding'
 import { readGithubCacheSnapshot } from './user-data-path'
 import {
   gcStaleWorktreeMeta,
@@ -94,43 +90,24 @@ export class LoadedStateParsingOperations {
         logPersistenceStartupMilestone('persistence-json-parse-done')
 
         // Why: secrets are stored encrypted via safeStorage; decrypt at the load boundary so the app sees plaintext.
+        const secrets = this.runtime.protectedSecrets
         if (parsed.settings?.opencodeSessionCookie) {
-          parsed.settings.opencodeSessionCookie = this.runtime.protectedSecrets.decrypt(
-            PROTECTED_SECRET_SLOT.opencodeSessionCookie,
-            parsed.settings.opencodeSessionCookie,
-            isLegacyOpenCodeSessionCookie
+          parsed.settings.opencodeSessionCookie = decodeOpencodeSessionCookie(
+            secrets,
+            parsed.settings.opencodeSessionCookie
           )
         }
         if (parsed.settings?.httpProxyUrl) {
-          const decryptedProxy = this.runtime.protectedSecrets.decryptWithStatus(
-            PROTECTED_SECRET_SLOT.httpProxyUrl,
-            parsed.settings.httpProxyUrl,
-            (value) => normalizeProxyUrl(value).ok
-          )
-          // Why (STA-3442): after a keychain reset decrypt returns raw ciphertext; a non-URL
-          // value must not masquerade as a configured proxy (silent DIRECT fallback) or
-          // re-persist as garbage. Plaintext URLs still pass, preserving the upgrade path.
-          if (
-            decryptedProxy.status === 'unavailable' ||
-            (decryptedProxy.status === 'failed' && !decryptedProxy.plaintext)
-          ) {
-            parsed.settings.httpProxyUrl = ''
-          } else if (normalizeProxyUrl(decryptedProxy.plaintext).ok) {
-            parsed.settings.httpProxyUrl = decryptedProxy.plaintext
-          } else {
-            console.warn(
-              '[persistence] httpProxyUrl could not be decrypted — clearing the stored proxy URL. Re-enter it in Settings > Advanced > Network.'
-            )
-            parsed.settings.httpProxyUrl = ''
-            this.runtime.protectedSecrets.removeRetainedBlob(PROTECTED_SECRET_SLOT.httpProxyUrl)
+          const decodedProxy = decodeHttpProxyUrl(secrets, parsed.settings.httpProxyUrl)
+          parsed.settings.httpProxyUrl = decodedProxy.value
+          if (decodedProxy.cleared) {
             this.runtime.loadNeedsSave = true
           }
         }
         if (parsed.ui?.browserKagiSessionLink) {
-          parsed.ui.browserKagiSessionLink = this.runtime.protectedSecrets.decrypt(
-            PROTECTED_SECRET_SLOT.browserKagiSessionLink,
-            parsed.ui.browserKagiSessionLink,
-            (value) => normalizeKagiSessionLink(value) !== null
+          parsed.ui.browserKagiSessionLink = decodeBrowserKagiSessionLink(
+            secrets,
+            parsed.ui.browserKagiSessionLink
           )
         }
         parsed.sshPtyConsumerRecoveries = (
@@ -140,23 +117,7 @@ export class LoadedStateParsingOperations {
             normalizeSshPtyConsumerRecovery(record, ENCRYPTED_SSH_PTY_OWNER_LEASE_MAX_LENGTH)
           )
           .filter((record): record is SshPtyConsumerRecovery => record !== null)
-          .map((record) => {
-            const slot = sshPtyOwnerLeaseSecretSlot(record.targetId)
-            const decrypted = this.runtime.protectedSecrets.decryptWithStatus(
-              slot,
-              record.ownerLease,
-              isLegacySshPtyOwnerLease
-            )
-            const normalized =
-              decrypted.status === 'unavailable' ||
-              (decrypted.status === 'failed' && !decrypted.plaintext)
-                ? record
-                : normalizeSshPtyConsumerRecovery({ ...record, ownerLease: decrypted.plaintext })
-            if (!normalized) {
-              this.runtime.protectedSecrets.removeRetainedBlob(slot)
-            }
-            return normalized
-          })
+          .map((record) => decodeSshPtyOwnerLease(secrets, record))
           .filter((record): record is SshPtyConsumerRecovery => record !== null)
 
         const terminalSettings = prepareLoadedTerminalSettings(parsed, () => {

--- a/src/main/persistence/loading-store/protected-secret-decoding.ts
+++ b/src/main/persistence/loading-store/protected-secret-decoding.ts
@@ -1,0 +1,93 @@
+import { normalizeProxyUrl } from '../../../shared/network-proxy'
+import { normalizeKagiSessionLink } from '../../../shared/browser-url'
+import type { SshPtyConsumerRecovery } from '../../../shared/ssh-types'
+import {
+  PROTECTED_SECRET_SLOT,
+  sshPtyOwnerLeaseSecretSlot,
+  type ProtectedSecretPersistence
+} from '../../protected-secret-persistence'
+import {
+  isLegacyOpenCodeSessionCookie,
+  isLegacySshPtyOwnerLease
+} from '../leasing-ssh-ptys/secret-validation'
+import { normalizeSshPtyConsumerRecovery } from '../leasing-ssh-ptys/ssh-normalization'
+
+/**
+ * The per-slot decode rules, shared by the load boundary and the deferred hydration that
+ * finishes the slots the load skipped. Why shared and not duplicated: the two paths must
+ * agree on what an undecryptable value means, and a second copy would drift silently.
+ */
+export type ProtectedSecretDecoder = Pick<
+  ProtectedSecretPersistence,
+  'decrypt' | 'decryptWithStatus' | 'removeRetainedBlob'
+>
+
+export function decodeOpencodeSessionCookie(
+  secrets: ProtectedSecretDecoder,
+  ciphertext: string
+): string {
+  return secrets.decrypt(
+    PROTECTED_SECRET_SLOT.opencodeSessionCookie,
+    ciphertext,
+    isLegacyOpenCodeSessionCookie
+  )
+}
+
+export function decodeBrowserKagiSessionLink(
+  secrets: ProtectedSecretDecoder,
+  ciphertext: string
+): string {
+  return secrets.decrypt(
+    PROTECTED_SECRET_SLOT.browserKagiSessionLink,
+    ciphertext,
+    (value) => normalizeKagiSessionLink(value) !== null
+  )
+}
+
+/** `cleared` means the retained ciphertext was dropped, so the caller must persist the clear. */
+export function decodeHttpProxyUrl(
+  secrets: ProtectedSecretDecoder,
+  ciphertext: string
+): { value: string; cleared: boolean } {
+  const decrypted = secrets.decryptWithStatus(
+    PROTECTED_SECRET_SLOT.httpProxyUrl,
+    ciphertext,
+    (value) => normalizeProxyUrl(value).ok
+  )
+  // Why (STA-3442): after a keychain reset decrypt returns raw ciphertext; a non-URL
+  // value must not masquerade as a configured proxy (silent DIRECT fallback) or
+  // re-persist as garbage. Plaintext URLs still pass, preserving the upgrade path.
+  if (
+    decrypted.status === 'unavailable' ||
+    (decrypted.status === 'failed' && !decrypted.plaintext)
+  ) {
+    return { value: '', cleared: false }
+  }
+  if (normalizeProxyUrl(decrypted.plaintext).ok) {
+    return { value: decrypted.plaintext, cleared: false }
+  }
+  console.warn(
+    '[persistence] httpProxyUrl could not be decrypted — clearing the stored proxy URL. Re-enter it in Settings > Advanced > Network.'
+  )
+  secrets.removeRetainedBlob(PROTECTED_SECRET_SLOT.httpProxyUrl)
+  return { value: '', cleared: true }
+}
+
+/** Null drops the record entirely; the caller must filter it out of the recovery list. */
+export function decodeSshPtyOwnerLease(
+  secrets: ProtectedSecretDecoder,
+  record: SshPtyConsumerRecovery
+): SshPtyConsumerRecovery | null {
+  const slot = sshPtyOwnerLeaseSecretSlot(record.targetId)
+  const decrypted = secrets.decryptWithStatus(slot, record.ownerLease, isLegacySshPtyOwnerLease)
+  // Why the record unchanged on 'unavailable': the lease stays sealed, and replacing it with
+  // the empty plaintext would discard a live owner claim we can still re-read later.
+  const normalized =
+    decrypted.status === 'unavailable' || (decrypted.status === 'failed' && !decrypted.plaintext)
+      ? record
+      : normalizeSshPtyConsumerRecovery({ ...record, ownerLease: decrypted.plaintext })
+  if (!normalized) {
+    secrets.removeRetainedBlob(slot)
+  }
+  return normalized
+}

--- a/src/main/persistence/loading-store/store-runtime-state.ts
+++ b/src/main/persistence/loading-store/store-runtime-state.ts
@@ -23,6 +23,13 @@ import type {
 export type StoreRuntimeOptions = {
   dataFile?: string
   storageAuthority?: AutomationStorageAuthority
+  /**
+   * Load without asking the OS keyring, leaving every protected slot sealed until
+   * `Store.hydrateDeferredProtectedSecrets()` runs. Only for hosts that open a window: the
+   * probe is a blocking D-Bus round trip on Linux, and the load runs before the first window
+   * exists (STA-5782).
+   */
+  deferKeyringProbe?: boolean
 }
 
 /** Mutable coordination state shared only with this Store's private collaborators. */
@@ -72,6 +79,9 @@ export class StoreRuntimeState {
   constructor(options: StoreRuntimeOptions = {}) {
     this.dataFile = options.dataFile ?? getDataFile()
     this.storageAuthority = options.storageAuthority ?? 'desktop'
+    if (options.deferKeyringProbe) {
+      this.protectedSecrets.deferKeyringProbe()
+    }
     this.staleTempCleanup = removeStaleDurableWriteTempFiles(this.dataFile, {
       minimumAgeMs: STALE_DURABLE_WRITE_TEMP_AGE_MS
     })

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -9,6 +9,11 @@ import { registerPersistedPaneKeyAlias } from '../restoring-sessions/pane-alias-
 import { normalizePersistedPaneIdentityState } from '../restoring-sessions/workspace-pane-normalization'
 import { StoreRuntimeState, type StoreRuntimeOptions } from './store-runtime-state'
 import {
+  hydrateDeferredProtectedSecrets,
+  type DeferredSecretHydrationResult
+} from './deferred-secret-hydration'
+import { notifySettingsChanged, notifyUIChanged } from './profile-preferences'
+import {
   createStoreDomains,
   installStoreDomainContexts,
   STORE_DOMAIN_OPERATION_CLASSES,
@@ -85,6 +90,27 @@ export class Store {
 
   getProfileStorageDirectory(): string {
     return dirname(this.runtime.dataFile)
+  }
+
+  /**
+   * Decrypt the protected slots a `deferKeyringProbe` load left sealed, then tell listeners.
+   *
+   * Returns what changed so the caller can re-run the startup work that read the withheld
+   * values — the persisted proxy above all, which is applied from settings before any window
+   * exists and would otherwise stay unset for the whole session.
+   */
+  hydrateDeferredProtectedSecrets(): DeferredSecretHydrationResult {
+    const result = hydrateDeferredProtectedSecrets(this.runtime)
+    if (Object.keys(result.settingsUpdates).length > 0) {
+      notifySettingsChanged(this, result.settingsUpdates)
+    }
+    if (result.uiChanged) {
+      notifyUIChanged(this)
+    }
+    if (result.needsSave) {
+      scheduleSave(this.domains.scheduling)
+    }
+    return result
   }
 
   freezeWrites(): void {

--- a/src/main/protected-secret-persistence.ts
+++ b/src/main/protected-secret-persistence.ts
@@ -33,6 +33,33 @@ type ProtectedSecretEncryption = {
 export class ProtectedSecretPersistence {
   private readonly retainedBlobs = new Map<string, string>()
   private readonly sealedSlots = new Set<string>()
+  private keyringProbeDeferred = false
+
+  /**
+   * Answer "keyring unavailable" without asking the keyring, until {@link resumeKeyringProbe}.
+   *
+   * Why: on Linux `isEncryptionAvailable()` is a synchronous, blocking D-Bus round trip to
+   * `org.freedesktop.secrets`, and a keyring that is present but locked with no unlock prompter
+   * never replies. Run from the store load that precedes the first window, it holds the main
+   * thread with nothing on screen (STA-5782). Deferring reuses the existing unavailable path,
+   * which retains every ciphertext rather than clearing it.
+   */
+  deferKeyringProbe(): void {
+    this.keyringProbeDeferred = true
+  }
+
+  resumeKeyringProbe(): void {
+    this.keyringProbeDeferred = false
+  }
+
+  isKeyringProbeDeferred(): boolean {
+    return this.keyringProbeDeferred
+  }
+
+  /** The ciphertext held for a slot whose plaintext was withheld; '' when nothing is retained. */
+  retainedBlob(slot: string): string {
+    return this.retainedBlobs.get(slot) ?? ''
+  }
 
   removeRetainedBlob(slot: string): void {
     this.retainedBlobs.delete(slot)
@@ -129,6 +156,9 @@ export class ProtectedSecretPersistence {
   }
 
   private encryptionAvailable(): boolean {
+    if (this.keyringProbeDeferred) {
+      return false
+    }
     // Why getSecretStore() sits outside the try: an uninstalled store is a startup bug,
     // not a keyring failure. Swallowing it would degrade to an empty blob and report
     // 'unavailable' — the silent-wrong-state outcome the port throws to prevent. Only

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -304,6 +304,47 @@ describe('startup ordering', () => {
     expect(signalHandlers).toBeLessThan(serveReady)
   })
 
+  it('defers the profile load keyring probe and finishes it once a window has painted', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const decision = source.indexOf('const deferKeyringProbe = shouldDeferKeyringProbe(')
+    // Why the two-space indent is part of the anchor: it is the only thing that separates the live
+    // `whenReady` body from the same block relocated into a nested helper nothing calls. A bare
+    // substring match accepts the relocated copy, and every assertion below then passes against
+    // code that never runs.
+    const arming = source.indexOf(
+      '\n  if (deferKeyringProbe) {\n    const deferredSecretStore = store\n    deferUntilFirstWindowShown('
+    )
+    // Why bound both: an unresolved indexOf is -1, and the slices below would run from the top of
+    // the file or to its end.
+    expect(decision).toBeGreaterThanOrEqual(0)
+    expect(arming).toBeGreaterThan(decision)
+
+    // Why the whole host argument: reading `isServeMode` here is the serve exclusion (STA-5765).
+    // A headless host opens no window to defer behind, so dropping it would park the probe past
+    // `printServeReady`, where a client can already pair against a stalled main thread.
+    expect(source).toContain('shouldDeferKeyringProbe({ platform: process.platform, isServeMode })')
+
+    const beforeArming = source.slice(decision, arming)
+    // Why: the decision is inert unless the load actually receives it.
+    expect(beforeArming).toContain('    deferKeyringProbe\n  })')
+    // Why: a `return` planted above the arming leaves every substring assertion intact while the
+    // deferred secrets are never hydrated at all. Nothing else returns at this indent inside
+    // `whenReady`, so any occurrence here is the regression.
+    expect(beforeArming).not.toContain('\n  return')
+
+    const armingBlock = source.slice(arming, source.indexOf('\n  }\n', arming))
+    expect(armingBlock).toContain('deferredSecretStore.hydrateDeferredProtectedSecrets()')
+    // Why the proxy re-apply belongs to this contract: the proxy is applied once from settings
+    // before any window exists, so without it a deferred load leaves the session on the
+    // environment fallback for the rest of the session.
+    expect(armingBlock).toContain("if ('httpProxyUrl' in hydration.settingsUpdates) {")
+    expect(armingBlock).toContain('applyElectronProxySettings(deferredSecretStore.getSettings())')
+
+    // Why the count: a second arming site would run the blocking probe twice, the second time
+    // while the user is already interacting with the window.
+    expect(source.split('deferUntilFirstWindowShown(')).toHaveLength(2)
+  })
+
   it('starts the automation scheduler before headless serve reports ready', () => {
     const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
     const serveStart = source.indexOf('if (serveOptions) {')

--- a/src/main/startup/keyring-probe-deferral.test.ts
+++ b/src/main/startup/keyring-probe-deferral.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { shouldDeferKeyringProbe } from './keyring-probe-deferral'
+
+describe('shouldDeferKeyringProbe', () => {
+  it('defers on Linux desktop, the only host where the probe can block forever', () => {
+    expect(shouldDeferKeyringProbe({ platform: 'linux', isServeMode: false })).toBe(true)
+  })
+
+  it('never defers in serve mode, which advertises readiness with no window to defer behind', () => {
+    // Why pinned separately from the platform gate: this is the regression a reviewer caught on
+    // the sibling leg (STA-5765) — deferring here moves the block past the point clients pair.
+    expect(shouldDeferKeyringProbe({ platform: 'linux', isServeMode: true })).toBe(false)
+  })
+
+  it('never defers on macOS or Windows, whose keychains answer promptly', () => {
+    // Why both listed: a platform gate that accidentally widened to every desktop would withhold
+    // secrets for the whole pre-window startup on hosts that never had the hazard.
+    expect(shouldDeferKeyringProbe({ platform: 'darwin', isServeMode: false })).toBe(false)
+    expect(shouldDeferKeyringProbe({ platform: 'win32', isServeMode: false })).toBe(false)
+  })
+
+  it('never defers on a non-Linux serve host either', () => {
+    expect(shouldDeferKeyringProbe({ platform: 'darwin', isServeMode: true })).toBe(false)
+  })
+})

--- a/src/main/startup/keyring-probe-deferral.ts
+++ b/src/main/startup/keyring-probe-deferral.ts
@@ -1,0 +1,21 @@
+/** The host facts that decide whether the profile load may skip the OS keyring probe. */
+export type KeyringProbeDeferralHost = {
+  platform: NodeJS.Platform
+  isServeMode: boolean
+}
+
+/**
+ * Whether the profile load may answer "keyring unavailable" without asking the keyring,
+ * leaving every protected slot sealed until the first window has painted (STA-5782).
+ *
+ * Linux only: `safeStorage.isEncryptionAvailable()` is a blocking D-Bus round trip there, and a
+ * keyring that is present but locked with no unlock prompter accepts the call and never replies.
+ * macOS and Windows answer promptly, so deferring would only widen the window in which secrets
+ * are withheld for no gain.
+ *
+ * Never in serve mode: a headless host opens no window to defer behind, so the probe would land
+ * after `printServeReady`, and a client could pair against a main thread already stalled on it.
+ */
+export function shouldDeferKeyringProbe(host: KeyringProbeDeferralHost): boolean {
+  return host.platform === 'linux' && !host.isServeMode
+}

--- a/src/main/window/defer-until-first-window-shown.test.ts
+++ b/src/main/window/defer-until-first-window-shown.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type Listener = (...args: unknown[]) => void
+
+const appListeners = new Map<string, Listener[]>()
+
+vi.mock('electron', () => ({
+  app: {
+    once: (event: string, listener: Listener) => {
+      const existing = appListeners.get(event) ?? []
+      existing.push(listener)
+      appListeners.set(event, existing)
+    }
+  }
+}))
+
+const { deferUntilFirstWindowShown, FIRST_WINDOW_SHOWN_FALLBACK_MS } =
+  await import('./defer-until-first-window-shown')
+
+/** Stands in for the BrowserWindow the app creates first. */
+function createWindow(): { reveal: () => void } {
+  const revealListeners: Listener[] = []
+  const window = {
+    once: (event: string, listener: Listener) => {
+      if (event === 'ready-to-show') {
+        revealListeners.push(listener)
+      }
+    }
+  }
+  appListeners
+    .get('browser-window-created')
+    ?.splice(0)
+    .forEach((listener) => listener({}, window))
+  return { reveal: () => revealListeners.splice(0).forEach((listener) => listener()) }
+}
+
+describe('deferUntilFirstWindowShown', () => {
+  let runs: number
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    appListeners.clear()
+    runs = 0
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const arm = (): void => deferUntilFirstWindowShown(() => void (runs += 1))
+
+  /** Runs an already-queued setImmediate; the 1ms is slack, not a delay under test. */
+  const drain = (): void => void vi.advanceTimersByTime(1)
+
+  it('does not run while the first window is still being created', () => {
+    arm()
+    createWindow()
+    // Why drain: creation alone must arm nothing. Asserting before the queue drains would also
+    // pass if the task were merely queued off `browser-window-created`, which still lands before
+    // the window paints.
+    drain()
+    expect(runs).toBe(0)
+  })
+
+  it('runs once the window is ready to show', () => {
+    arm()
+    const window = createWindow()
+    window.reveal()
+    // Why: the reveal handler must return before a blocking task runs, or the paint it is
+    // waiting on is the thing being blocked.
+    expect(runs).toBe(0)
+    drain()
+    expect(runs).toBe(1)
+  })
+
+  it('still runs when ready-to-show never fires, so a failed reveal is not silent', () => {
+    arm()
+    createWindow()
+    // Why bracket the wait instead of flushing every timer: an unbounded flush passes for any
+    // fallback delay, including one long enough to never arrive in a real session.
+    vi.advanceTimersByTime(FIRST_WINDOW_SHOWN_FALLBACK_MS - 1_000)
+    drain()
+    expect(runs).toBe(0)
+    vi.advanceTimersByTime(1_100)
+    drain()
+    expect(runs).toBe(1)
+  })
+
+  it('runs once when the window reveals and the fallback would also have elapsed', () => {
+    arm()
+    const window = createWindow()
+    window.reveal()
+    drain()
+    expect(vi.getTimerCount()).toBe(0)
+    vi.advanceTimersByTime(FIRST_WINDOW_SHOWN_FALLBACK_MS * 2)
+    drain()
+    expect(runs).toBe(1)
+  })
+
+  it('does not run again when the window reveals after the fallback already ran', () => {
+    // Why this order and not the reverse: a GPU that presents late reveals the window after the
+    // fallback has run, and a second blocking task would freeze the main thread exactly as the
+    // user starts interacting.
+    arm()
+    const window = createWindow()
+    vi.advanceTimersByTime(FIRST_WINDOW_SHOWN_FALLBACK_MS + 100)
+    drain()
+    expect(runs).toBe(1)
+    window.reveal()
+    drain()
+    expect(runs).toBe(1)
+  })
+})

--- a/src/main/window/defer-until-first-window-shown.test.ts
+++ b/src/main/window/defer-until-first-window-shown.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 type Listener = (...args: unknown[]) => void
@@ -95,6 +97,30 @@ describe('deferUntilFirstWindowShown', () => {
     vi.advanceTimersByTime(FIRST_WINDOW_SHOWN_FALLBACK_MS * 2)
     drain()
     expect(runs).toBe(1)
+  })
+
+  it('fires within the window-reveal fallback, so the task cannot trail an on-screen app', () => {
+    // Why read the peer constant instead of restating it: the deadline that matters is the one
+    // `main-window-state-lifecycle.ts` uses to reveal the window when `ready-to-show` never fires
+    // (#8421). A fallback later than that leaves the app interactive with the task still pending —
+    // for the keyring deferral, interactive with every protected secret still withheld.
+    // Why source text and not an import: that module pulls in electron and the e2e config at
+    // module scope, which this file's `electron` stub does not satisfy.
+    const revealSource = readFileSync(
+      join(process.cwd(), 'src/main/window/main-window-state-lifecycle.ts'),
+      'utf8'
+    )
+    const declaration = /export const INITIAL_REVEAL_FALLBACK_MS = ([\d_]+)/.exec(revealSource)
+    // Why assert the match: a rename would make the number `NaN`, and every comparison below
+    // would then pass vacuously.
+    expect(declaration).not.toBeNull()
+    const revealFallbackMs = Number(declaration![1].replaceAll('_', ''))
+    expect(revealFallbackMs).toBeGreaterThan(0)
+
+    expect(FIRST_WINDOW_SHOWN_FALLBACK_MS).toBeGreaterThan(revealFallbackMs)
+    // Why a ceiling and not just an ordering: 15s (the updater deferral's constant) sits 5s past
+    // the reveal, and being merely "after" the reveal is what made that gap invisible.
+    expect(FIRST_WINDOW_SHOWN_FALLBACK_MS).toBeLessThanOrEqual(revealFallbackMs + 2_000)
   })
 
   it('does not run again when the window reveals after the fallback already ran', () => {

--- a/src/main/window/defer-until-first-window-shown.ts
+++ b/src/main/window/defer-until-first-window-shown.ts
@@ -1,0 +1,41 @@
+import { app, type BrowserWindow } from 'electron'
+
+/** Matches the updater deferral in attach-main-window-services.ts. */
+export const FIRST_WINDOW_SHOWN_FALLBACK_MS = 15_000
+
+/**
+ * Run `task` exactly once, after the first window has painted — never on the pre-window
+ * startup path, where blocking the main thread means nothing appears at all.
+ *
+ * Why a fallback timer as well as the window event: `ready-to-show` never fires when window
+ * creation itself fails (a GPU or driver fault), and a task armed only on the happy path
+ * would then never run. The timer is unref'd so it cannot hold the process alive.
+ *
+ * Not for headless hosts: with no window, the fallback is the only path, which moves the task
+ * to after readiness has already been advertised.
+ */
+export function deferUntilFirstWindowShown(
+  task: () => void,
+  options: { fallbackMs?: number } = {}
+): void {
+  let done = false
+  let fallback: ReturnType<typeof setTimeout> | null = null
+  const runOnce = (): void => {
+    if (done) {
+      return
+    }
+    done = true
+    if (fallback) {
+      clearTimeout(fallback)
+      fallback = null
+    }
+    task()
+  }
+  fallback = setTimeout(runOnce, options.fallbackMs ?? FIRST_WINDOW_SHOWN_FALLBACK_MS)
+  fallback.unref?.()
+  app.once('browser-window-created', (_event: unknown, window: BrowserWindow) => {
+    // Why setImmediate: the reveal handler must return before a blocking task runs, or the
+    // paint it is waiting on is the thing being blocked.
+    window.once('ready-to-show', () => setImmediate(runOnce))
+  })
+}

--- a/src/main/window/defer-until-first-window-shown.ts
+++ b/src/main/window/defer-until-first-window-shown.ts
@@ -1,7 +1,12 @@
 import { app, type BrowserWindow } from 'electron'
 
-/** Matches the updater deferral in attach-main-window-services.ts. */
-export const FIRST_WINDOW_SHOWN_FALLBACK_MS = 15_000
+/**
+ * Just past `main-window-state-lifecycle.ts`'s `INITIAL_REVEAL_FALLBACK_MS`, on the same reasoning
+ * as `TRAY_CREATE_FALLBACK_MS`: when `ready-to-show` never fires the window is still revealed on
+ * that timer, so a later deadline leaves the app on screen and interactive with the deferred task
+ * unrun. The updater deferral's 15s is safe to be late; withheld secrets are not.
+ */
+export const FIRST_WINDOW_SHOWN_FALLBACK_MS = 12_000
 
 /**
  * Run `task` exactly once, after the first window has painted — never on the pre-window

--- a/src/main/window/main-window-state-lifecycle.ts
+++ b/src/main/window/main-window-state-lifecycle.ts
@@ -11,6 +11,13 @@ export type MainWindowStateLifecycle = {
   resumeBoundsPersistence: () => void
 }
 
+/**
+ * When `ready-to-show` never fires — a GPU or driver fault on Windows/Linux — the window is
+ * revealed on this timer anyway (#8421). Work deferred behind the first window must therefore
+ * land at or just after this deadline, or the app is interactive with that work still pending.
+ */
+export const INITIAL_REVEAL_FALLBACK_MS = 10_000
+
 export function installMainWindowStateLifecycle(args: {
   mainWindow: BrowserWindow
   revealOnDidFinishLoad: boolean
@@ -35,7 +42,7 @@ export function installMainWindowStateLifecycle(args: {
           // Why: GPU/driver failures on Windows/Linux can prevent ready-to-show forever, hiding the only app window (#8421).
           initialRevealFallbackTimer = null
           revealInitialWindow()
-        }, 10_000)
+        }, INITIAL_REVEAL_FALLBACK_MS)
       : null
   initialRevealFallbackTimer?.unref?.()
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​516 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​516 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​365 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​57 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​308 |

<!-- /orca-pr-loc -->

Fixes [STA-5782](https://linear.app/stably/issue/STA-5782/locked-linux-keyring-blocks-startup-via-the-store-load-boundary-pre).

**This is the second of two legs. [#16912](https://github.com/stablyai/orca/pull/16912) covers the first** (the diagnostic-report probe, STA-5765). The two are independent and neither alone fixes a real profile — measured below.

## ELI5

Before Orca can draw its window it loads your profile. If that profile has any saved secret in it, the loader stops and asks the operating system's keyring "can I unseal this?" On Linux that question travels over D-Bus, and a keyring that is present but **locked with no unlock prompt** accepts the question and never answers. So Orca sits there with no window, looking like it failed to launch.

This change stops asking that question until after the window is on screen. Nothing is thrown away while we wait: the sealed secrets stay sealed on disk exactly as they were, and the moment the window paints we ask the keyring and fill them in.

## User-facing before / after

**Who is affected:** any profile with at least one populated protected slot — `settings.httpProxyUrl`, `settings.opencodeSessionCookie`, `ui.browserKagiSessionLink`, or an SSH owner lease in `sshPtyConsumerRecoveries`. A profile with all four empty never reaches the probe, which is why #16912's own timing looked fine.

| | Before | After |
| --- | --- | --- |
| Linux desktop, locked/unresponsive keyring, secret slot populated | no window for 76 s | window in ~1 s |
| Linux desktop, healthy keyring | unchanged | unchanged |
| macOS / Windows | unchanged | unchanged (the deferral is behind `process.platform === 'linux'`) |
| `serve` / headless | probe runs inline before the RPC listener and `printServeReady` | **identical** — serve is explicitly excluded |

**Honest limitation:** this moves the block past first paint; it does not remove it. When the deferred probe finally runs against an unresponsive keyring the main thread still blocks, so the window paints and then stops responding. That is strictly better than no window (the user can see the app, and the OS reports it as running) but it is not a cure. Bounding the probe itself needs D-Bus liveness machinery the repo does not have today — that is the remaining work on STA-5782's option 1.

## What changed

- `ProtectedSecretPersistence` can be told to answer "keyring unavailable" **without asking the keyring**. That reuses the existing unavailable path, which already retains every ciphertext rather than clearing it — no new "withheld" semantics were invented.
- `new Store({ deferKeyringProbe })` arms that on Linux desktop only.
- `Store.hydrateDeferredProtectedSecrets()` finishes the job after the window paints, decoding from the retained ciphertext and notifying settings/UI listeners.
- The per-slot decode rules moved to `protected-secret-decoding.ts` so the load boundary and the hydration share one implementation and cannot drift.
- `deferUntilFirstWindowShown()` is the `ready-to-show` + `setImmediate` + unref'd-15s-fallback shape already shipped by `attach-main-window-services.ts:203-206`.
- `index.ts` re-applies the persisted proxy after hydration, because the proxy is applied once from settings at startup rather than from a `onSettingsChanged` listener.

**Never auto-clears user data.** A withheld read is not an empty value: while deferred, a save writes the retained ciphertext back byte-for-byte (`degraded` path in `state-serialization-secret-handling.ts`). There is a test asserting exactly that.

## Failing-first proof

Both new test files, run against `origin/main` production code with the tests kept:

```
× never touches the keyring while loading a profile that has populated secret slots 2018ms
  AssertionError: expected 4 to be +0            <- four blocking keyring probes during Store construction
× restores every deferred slot once hydration runs
  TypeError: store.hydrateDeferredProtectedSecrets is not a function
× tells settings and UI listeners the real values so startup work can re-run against them
× persists the clear when hydration finds an unusable secret, with no explicit flush
  AssertionError: expected '' to be 'ZW5jcnlwdGVkOiEhISBub3QgYSB1cmwgISEh'
× probes inline when the host opens no window, so nothing pairs against a stalled main thread
× reports nothing to hydrate when the load already probed
FAIL src/main/window/defer-until-first-window-shown.test.ts
  Error: Cannot find module '.../defer-until-first-window-shown'

Test Files  2 failed (2)
     Tests  6 failed | 1 passed (7)
```

After the fix:

```
Test Files  2 passed (2)
     Tests  12 passed (12)
```

Parent suites (behaviour-preserving extraction): `persistence-protected-secret-fail-closed`, `persistence-protected-secret-write-race`, `persistence-proxy-secret-recovery`, `persistence-loading-store-write-risks`, `persistence-loading-store-extraction`, `persistence-ui-state`, `persistence-single-serialize`, `persistence-async-write-syscalls` — **102 passed**.

### On modelling the hazard

`secret-tool` and `secretstorage` fail **fast** on a locked collection; only Chromium hangs, on libsecret's prompt path. So a test that models a fast failure does not model the bug. The unit test's fake keyring **blocks the calling thread** (`Atomics.wait`, 2 s, on the first call only — OSCrypt resolves the backend once). It is bounded on purpose: a synchronous spin cannot be interrupted by a vitest timeout, so an unbounded block would wedge the worker instead of failing. The real unbounded hang is covered by the live Linux trials below, not by the unit test.

## Ablation table

Each production hunk reverted individually; tests unchanged.

| # | Hunk | Ablation | Result |
| --- | --- | --- | --- |
| A1 | `protected-secret-persistence.ts` deferral guard in `encryptionAvailable()` | delete `if (this.keyringProbeDeferred) return false` | **FAILS** — `never touches the keyring…` (expected 4 to be 0) |
| A2 | `store-runtime-state.ts` arms the deferral | delete `protectedSecrets.deferKeyringProbe()` | **FAILS** — `never touches the keyring…`, `restores every deferred slot…` |
| A3 | `protected-secret-persistence.ts` `retainedBlob()` | return `''` | **FAILS** — `restores every deferred slot…`, listeners, persist-the-clear |
| A4 | `deferred-secret-hydration.ts` `resumeKeyringProbe()` | delete | **FAILS** — `restores every deferred slot…` |
| A5 | `deferred-secret-hydration.ts` decode + apply body | early-return `NOTHING_DEFERRED` | **FAILS** — `restores every deferred slot…` |
| A6 | `store.ts` `notifySettingsChanged` | delete | **FAILS** — `tells settings and UI listeners…` |
| A7 | `store.ts` `scheduleSave` on `needsSave` | delete | **FAILS** — `persists the clear…` |
| A8 | `store.ts` `notifyUIChanged` | delete | **FAILS** — `tells settings and UI listeners…` |
| A9 | `defer-until-first-window-shown.ts` `ready-to-show` arming | replace with a dead lambda | **FAILS** — `runs once the window is ready to show` |
| A10 | `defer-until-first-window-shown.ts` fallback timer | delete | **FAILS** — `still runs when ready-to-show never fires…`, `does not run again…` |
| — | `protected-secret-decoding.ts` + `loaded-state-parsing.ts` call sites | — | **Structural.** A behaviour-preserving extraction has no behaviour to ablate; pinned by the 102 parent tests above. |
| — | `index.ts` wiring | — | **Structural.** `index.ts` has top-level side effects and runs inside `app.whenReady()`, so vitest cannot import it. Covered by the live trials below. |

A7 initially reported as uncovered: the assertion was riding on a save the constructor had already scheduled. The test now flushes first, so only hydration's own `scheduleSave` can reach disk.

## Measured on Linux

Ubuntu 24.04 (x86_64), private session bus, `XDG_CURRENT_DESKTOP=GNOME`, fault-injected Secret Service that claims `org.freedesktop.secrets` and **accepts every method call without ever replying**. Time to first **mapped** window (`xwininfo … IsViewable`, not mere window existence).

**Secret slot populated: `settings.httpProxyUrl`**, holding a real `gnome_libsecret` blob produced by `safeStorage.encryptString('http://proxy.example:8080')` on the same box. Every build's `out/main/index.js` was grepped for its patch markers before the run.

| Build | Keyring | Time to mapped window |
| --- | --- | --- |
| neither leg (control) | hanging | **76 134 ms** |
| #16912 only | hanging | **76 120 ms** (no benefit — `Store` runs first) |
| both legs | hanging | **1 080 ms** first launch; 4 717 / 4 761 / 4 773 ms on repeats |
| both legs | fast-failing keyring (no hazard) | 4 780 / 4 769 ms |

The repeat figure rises to ~4.7 s only because the profile accumulates state across launches — the **same binary** on a non-hanging bus is 4 769–4 780 ms, so the residual is profile-load cost, not the keyring.

### `serve` still works

| Build | Keyring | Result |
| --- | --- | --- |
| both legs | fast-failing | `Orca server ready`, socket bound, **1 013 ms** |
| both legs | hanging | never advertises readiness, **no socket bound** — the pre-fix property is preserved, so no client can pair against a stalled main thread |

That second row is the regression #16912's reviewer caught, and it is pinned by a unit test as well (`probes inline when the host opens no window…`).

## Not verified

- **macOS and Windows at runtime.** Unit tests only. The deferral is gated on `process.platform === 'linux'`, so both platforms keep today's inline behaviour by construction, but I did not launch the app on either.
- **A packaged build.** The Linux trials used an `electron-vite` dev build run through `./node_modules/.bin/electron .`. Dev-mode results cannot catch packaged-build regressions.
- **A literally locked GNOME collection.** I built one (private `XDG_DATA_HOME`, `login` aliased default, daemon restarted without `--unlock`, `is_locked() == True`) and `safeStorage.isEncryptionAvailable()` returned `false` in **38 ms** — a fast failure, not the hang. So the numbers above come from the hanging-service rig, which reproduces "accepts and never replies" but is a fault injection, not a locked collection.
- **The main-thread block after first paint.** Stated above as a known limitation, not measured for how long the UI stays frozen.
- **Real-world proxy latency during the deferral window.** Between load and hydration the Electron session falls back to environment proxy settings; I reasoned about this from `applyElectronProxySettings` rather than measuring it.

## Coordination with #16912

No conflict. `git merge-tree --write-tree HEAD pr16912` returns a clean tree, and the merged `src/main/index.ts` carries both changes intact (`deferKeyringProbe` on the `Store` call, `scheduleSecretProtectionGapReport` right after). The two hunks are adjacent but disjoint. Both legs were applied together for the measurements above.
