### PR TITLE
fix(e2e): drop the pi-title spec's stale private Docker-SSH connect fork

### DIFF
--- a/tests/e2e/ssh-pi-compatible-agent-title.spec.ts
+++ b/tests/e2e/ssh-pi-compatible-agent-title.spec.ts
@@ -7,20 +7,14 @@ import {
   waitForActiveTerminalManager,
   waitForTerminalOutput
 } from './helpers/terminal'
+import { connectDockerSshRelayTarget } from './helpers/docker-ssh-relay-connection'
 import {
   cleanupDockerSshRelayTarget,
-  DOCKER_SSH_RELAY_REMOTE_REPO_PATH,
   startDockerSshRelayTarget,
   type DockerSshRelayTarget
 } from './helpers/docker-ssh-relay-target'
 
 const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
-
-type ConnectedDockerRemote = {
-  targetId: string
-  repoId: string
-  worktreeId: string
-}
 
 type RuntimeTerminalStatus = {
   isRunningAgent: boolean
@@ -31,73 +25,6 @@ type RuntimeTerminalSummary = {
   handle: string
   ptyId: string | null
   title: string | null
-}
-
-async function connectDockerRemote(
-  page: Page,
-  target: DockerSshRelayTarget
-): Promise<ConnectedDockerRemote> {
-  return await page.evaluate(
-    async ({ target, remotePath }) => {
-      const store = window.__store
-      if (!store) {
-        throw new Error('Store unavailable')
-      }
-      const credentialUnsub = window.api.ssh.onCredentialRequest((request) => {
-        void window.api.ssh.submitCredential({ requestId: request.requestId, value: null })
-      })
-      try {
-        const { target: createdTarget, repoReadoptions } = await window.api.ssh.addTarget({
-          target: {
-            label: `Docker SSH Pi-Compatible Agent ${Date.now()}`,
-            host: '127.0.0.1',
-            port: target.port,
-            username: 'root',
-            identityFile: target.identityFile,
-            identitiesOnly: true,
-            relayGracePeriodSeconds: 1
-          }
-        })
-        store.getState().recordSshRepoReadoptions(repoReadoptions)
-        const state = await window.api.ssh.connect({ targetId: createdTarget.id })
-        if (!state || state.status !== 'connected') {
-          throw new Error(`SSH target did not connect: ${JSON.stringify(state)}`)
-        }
-        store.getState().setSshConnectionState(createdTarget.id, state)
-        const labels = new Map(store.getState().sshTargetLabels)
-        labels.set(createdTarget.id, createdTarget.label)
-        store.getState().setSshTargetLabels(labels)
-
-        const result = await window.api.repos.addRemote({
-          connectionId: createdTarget.id,
-          remotePath,
-          displayName: 'Docker SSH Pi-Compatible Agent'
-        })
-        if ('error' in result) {
-          throw new Error(result.error)
-        }
-        await store.getState().fetchRepos()
-        await store.getState().fetchWorktrees(result.repo.id)
-        const worktree = (store.getState().worktreesByRepo[result.repo.id] ?? [])[0]
-        if (!worktree) {
-          throw new Error(`No remote worktree found for ${result.repo.path}`)
-        }
-        store.getState().setActiveWorktree(worktree.id)
-        if ((store.getState().tabsByWorktree[worktree.id] ?? []).length === 0) {
-          store.getState().createTab(worktree.id)
-        }
-        store.getState().setActiveTabType('terminal')
-        return {
-          targetId: createdTarget.id,
-          repoId: result.repo.id,
-          worktreeId: worktree.id
-        }
-      } finally {
-        credentialUnsub()
-      }
-    },
-    { target, remotePath: DOCKER_SSH_RELAY_REMOTE_REPO_PATH }
-  )
 }
 
 async function emitOscTitle(page: Page, ptyId: string, title: string): Promise<void> {
@@ -153,7 +80,7 @@ test.describe('Docker SSH Pi-compatible agent titles', () => {
       target = startDockerSshRelayTarget(testInfo)
       await waitForSessionReady(orcaPage)
       await waitForActiveWorktree(orcaPage)
-      const remote = await connectDockerRemote(orcaPage, target)
+      const remote = await connectDockerSshRelayTarget(orcaPage, target)
       await ensureTerminalVisible(orcaPage, 45_000)
       await waitForActiveTerminalManager(orcaPage, 60_000)
       const ptyId = await waitForActivePanePtyId(orcaPage, 60_000)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​75 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​73 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## What this does

Deletes a stale private `connectDockerRemote` fork from
`tests/e2e/ssh-pi-compatible-agent-title.spec.ts` and calls the shared
`connectDockerSshRelayTarget` helper instead. **One test file, +2/-75.** No production code, no
helper change, no new assertion, and nothing weakened.

> **Scope change (2026-08-28):** this PR previously also added a 60s retry loop to the shared
> helper. That half has been removed — see [Why the retry loop is gone](#why-the-retry-loop-is-gone).
> Please do not re-add it here.

## The defect

`ssh-pi-compatible-agent-title.spec.ts` (last touched 2026-07-11) kept a private copy of the connect
sequence:

```ts
await store.getState().fetchRepos()
await store.getState().fetchWorktrees(result.repo.id)          // no options
const worktree = (store.getState().worktreesByRepo[result.repo.id] ?? [])[0]
if (!worktree) {
  throw new Error(`No remote worktree found for ${result.repo.path}`)
}
```

`a40183389b` (#11003, 2026-07-28) gave `fetchWorktrees` a host-qualified authority gate. With no
`directSshAuthority` passed, it depends on `getCurrentDirectSshAuthority` resolving at that instant
(`direct-ssh-authority.ts:21-43` returns `null` unless `status === 'connected'` with a complete
epoch/generation); when it returns `null`, `fetch-worktrees.ts:70-77` short-circuits to `false` and
writes no authoritative rows. The listing is empty, `[0]` is `undefined`, and setup throws
`No remote worktree found for /tmp/orca-docker-relay-perf-repo` before the spec reaches a single
title assertion.

The same commit updated `tests/e2e/helpers/docker-ssh-relay-connection.ts` (+80) to pass
`directSshAuthority` explicitly — making that short-circuit structurally unreachable there — but
touched this spec **zero** times. The fork rotted silently, and
[the Docker-SSH specs had no CI lane at all until #16746](https://github.com/stablyai/orca/pull/16746),
so nothing caught it for four weeks.

### Differential that pins it

Across 5 lane runs (~130 SSH connects):

| Source | Guard errors |
| --- | --- |
| Shared helper (`connectDockerSshRelayTarget`), 26 connects/run | **0** |
| The private fork, 1 connect/run | **3** × `No remote worktree found` |

The fork's message has no `:` suffix, so it is distinguishable from the shared helper's. It accounts
for **6 of 7** failures on the `e2e / ssh docker watcher isolation` lane.

## The fix is a faithful swap

Every helper default matches what the fork passed explicitly:

| Fork | Shared helper |
| --- | --- |
| `relayGracePeriodSeconds: 1` | `options.relayGracePeriodSeconds ?? 1` |
| `remotePath: DOCKER_SSH_RELAY_REMOTE_REPO_PATH` | same default when `viaProxyJump` is false |
| seeds a tab when the worktree has none | `seedInitialTab ?? true` |
| `port: target.port` | `viaProxyJump ? 22 : target.port` |
| `host: '127.0.0.1'` (hardcoded) | `target.host` — correct under `ORCA_E2E_SSH_TARGET_HOST` |
| `worktreesByRepo[repoId][0]` | `.find(c => c.hostId === executionHostId)` — host-qualified |

The three OMP/Pi title assertions are byte-identical; `git diff -U0` shows exactly two added lines
(the import and the call).

## Why the retry loop is gone

The removed half added a 60s `waitForLiveAuthority` retry loop to the **shared** helper, justified
by a "~0.5s post-deploy transport bounce". **That premise was refuted**
([review, point 1](https://github.com/stablyai/orca/pull/17017#issuecomment-5455900028)): the
`[ssh] Reconnecting … failed handshakes 0/9` line is the spec's own `finally` calling
`cleanupDockerSshRelayTarget` → `docker rm -f` (`docker-ssh-relay-target.ts:287`), which deletes the
container the transport is connected to. In run
[33175867485](https://github.com/stablyai/orca/actions/runs/33175867485) the Playwright trace dates
the spec's throw **~0.1s earlier** than the drop, and the gap is not fixed at 0.5s — across passing
runs it is 1.4s / 3.4s / 12s / 27s, tracking each spec's body length. `failed handshakes 0/9` means
the transport was healthy until it was deleted. There is no product-side drop.

Three further reasons it should not ride along:

1. **It fixes nothing measurable.** A fork-deletion-only branch (helper untouched) was run on the
   lane four times; the pi-title spec passed in **all four**.
2. **CI structurally cannot exercise it.** `selectPrE2eSpecs` seeds only from
   `/^tests\/e2e\/.*\.spec\.ts$/` and every route requires `^src/`, so a `tests/e2e/helpers/` edit
   routes **zero** specs and skips the Docker-SSH lane. The helper has **24 consumer files**; a
   helper-only diff validates none of them.
3. **It can erase the error it exists to produce.** `tests/playwright.config.ts:22` sets a 120s
   default; `ssh-startup-exec-readiness.spec.ts:32` sets `test.setTimeout(150_000)` with no
   `test.slow()`. A full 60s burn there replaces the named
   `No remote worktree found for X: <reason>` with an opaque test timeout, and
   `tests/playwright.config.ts:34` sets `retries: 0` deliberately so first-failure traces stay the
   only reliable artifact.

**No retry, sleep, or timeout was added anywhere as compensation.**

## Validation

Docker is dead on the reviewing machine, so the lane was exercised only through
`workflow_dispatch` — the sole way to reach it (a PR diff of one Docker-gated spec routes to a
sharded lane that sets no `ORCA_E2E_SSH_DOCKER` and self-skips).

Fork-deletion-only branch, `e2e / ssh docker watcher isolation`:

| Run | Lane | pi-title spec |
| --- | --- | --- |
| [33185192081](https://github.com/stablyai/orca/actions/runs/33185192081) | success | ✓ `74:7` (24.1s) — 18 passed |
| [33185197126](https://github.com/stablyai/orca/actions/runs/33185197126) | success | ✓ `74:7` (24.5s) — 18 passed |
| [33185202362](https://github.com/stablyai/orca/actions/runs/33185202362) | failure | ✓ `74:7` (24.5s) — 17 passed, 1 failed |
| [33185207547](https://github.com/stablyai/orca/actions/runs/33185207547) | success | ✓ `74:7` (24.0s) — 18 passed |

**3 of 4 lanes green; the pi-title spec passed 4 of 4.** The single red was
`ssh-cold-hydration-gap-tab-seeding.spec.ts:158` (`baseline=3 duringStall=3 afterHydration=0`) — a
separate known issue that #17031 covers and that this branch deliberately does not include.

Baseline for comparison: the lane measured **22 pass / 7 fail (76%)** across 29 decided runs since
#16746, with pi-title accounting for 6 of the 7 failures.

This PR's head `e8a9988b6f`, same lane, four more `workflow_dispatch` runs:

| Run | Lane | pi-title spec | Suite |
| --- | --- | --- | --- |
| [33197732254](https://github.com/stablyai/orca/actions/runs/33197732254) | **success** | ✓ `74:7` (24.8s) | 2 + 5 + 18 passed, 0 failed |
| [33197734527](https://github.com/stablyai/orca/actions/runs/33197734527) | **success** | ✓ `74:7` (23.5s) | 2 + 5 + 18 passed, 0 failed |
| [33197737144](https://github.com/stablyai/orca/actions/runs/33197737144) | **success** | ✓ `74:7` (24.8s) | 2 + 5 + 18 passed, 0 failed |
| [33197738900](https://github.com/stablyai/orca/actions/runs/33197738900) | **success** | ✓ `74:7` (25.2s) | 2 + 5 + 18 passed, 0 failed |

**4 of 4 green.** Combined with the probe branch: **8 lane runs, 7 green, pi-title 8 of 8** — against
a 76% pre-fix baseline where pi-title alone was 6 of 7 failures. The one red across all eight was
the cold-hydration spec #17031 covers.

### Gates

`pnpm tc` exit 0 · `oxlint` + type-aware + React Doctor changed-code gate: **0 new findings** ·
`oxfmt --check` clean · `git diff --check` clean · `typecheck:e2e` error count **208 → 208**
(red on `main` for unrelated reasons; this file contributes none — measured in both directions).
No suppressions, no `max-lines` disable or bump.

## Known gap this PR does NOT fix

`ssh_source_changed` is false for a test-only diff, and the Docker-SSH lane's `if` names only
`ssh-startup-exec-readiness.spec.ts` and `paired-startup-exec-readiness.spec.ts` by hand. So
**this PR's own `e2e / ssh docker watcher isolation` check will show as skipping** — the lane it
fixes does not run on it. Fixing the gate means a new `docker_ssh_spec_changed` signal through
`pr-e2e-source-routing.mjs` → `pr.yml` → `e2e.yml` plus an update to `pr-e2e-gate-contract.test.mjs`:
a separate defect for a separate PR.

`tests/e2e/ssh-localhost.spec.ts:213` has the **identical** pre-#11003 fork shape — same latent
defect, different lane. Also out of scope here.

## Unblocks

#16336, #16901, #16915 and #16926 are each red on this lane and nothing else. Once this lands they
each need `gh pr update-branch` (or a new commit) — a `gh run rerun` stays pinned to the original
merge base and cannot pick this up.
