### PR TITLE
Keep project ring positions stable across Agent Map repacks

### DIFF
--- a/src/renderer/src/components/dashboard-popout/agent-map-layout.test.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-layout.test.ts
@@ -406,6 +406,33 @@ describe('agent map layout', () => {
     expect(updated.layout.topologyKey).not.toBe(initial.layout.topologyKey)
   })
 
+  it('keeps unaffected project ring positions stable across a full repack', () => {
+    const cards = [
+      card({ paneKey: 'a', repoId: 'repo-a', repoName: 'Repo A', worktreeId: 'wt-a' }),
+      card({ paneKey: 'b', repoId: 'repo-b', repoName: 'Repo B', worktreeId: 'wt-b' }),
+      card({ paneKey: 'c', repoId: 'repo-c', repoName: 'Repo C', worktreeId: 'wt-c' })
+    ]
+    const initial = updateAgentMapLayout(null, cards, NOW)
+    const initialPositions = new Map(
+      initial.layout.projects.map((project) => [project.id, { x: project.x, y: project.y }])
+    )
+
+    // A brand new project (repo-d) spawns its first agent elsewhere — none of
+    // the existing projects changed and none of them should move.
+    const updated = updateAgentMapLayout(
+      initial.cache,
+      [...cards, card({ paneKey: 'd', repoId: 'repo-d', repoName: 'Repo D', worktreeId: 'wt-d' })],
+      NOW
+    )
+
+    expect(updated.cache).not.toBe(initial.cache)
+    expect(updated.cache.packingGeneration).toBe(2)
+    for (const projectId of ['repo-a', 'repo-b', 'repo-c']) {
+      const updatedProject = updated.layout.projects.find((project) => project.id === projectId)!
+      expect({ x: updatedProject.x, y: updatedProject.y }).toEqual(initialPositions.get(projectId))
+    }
+  })
+
   it('keeps positions stable across routine status and duration updates', () => {
     const initialCards = [
       card({ paneKey: 'a', worktreeId: 'wt-a' }),

--- a/src/renderer/src/components/dashboard-popout/agent-map-layout.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-layout.ts
@@ -1,26 +1,16 @@
 import type * as DashboardSnapshotTypes from '../../../../shared/dashboard-snapshot'
-import { placeAgentMapAgents } from './agent-map-agent-placement'
-import { layoutAgentMapLineage } from './agent-map-lineage-layout'
 import { refreshAgentMapMetadata } from './agent-map-layout-metadata'
-import {
-  agentMapDurationMinutes,
-  agentMapNodeStatus,
-  agentMapQuietCount,
-  emptyAgentMapStatusCounts,
-  type AgentMapNodeStatus,
-  type AgentMapStatusCounts
-} from './agent-map-node-metadata'
+import { buildLocalWorktree, type LocalWorktree } from './agent-map-local-worktree'
+import type { AgentMapNodeStatus, AgentMapStatusCounts } from './agent-map-node-metadata'
 import { placeAgentMapProjects } from './agent-map-project-placement'
 import { selectAgentMapSpawnParentContainer } from './agent-map-spawn-clustering'
 import {
   agentMapCardTopologyIdentity,
   agentMapWorkspaceIdentity,
   agentMapWorkspaceTopologyIdentity,
-  agentMapWorktreeIdentity,
-  agentMapWorktreeIdentityFromParts
+  agentMapWorktreeIdentity
 } from './agent-map-workspace-identity'
 import { layoutAgentMapWorktreeLineage } from './agent-map-worktree-lineage-layout'
-import { agentMapWorktreeHost } from './agent-map-worktree-host'
 
 type DashboardCard = DashboardSnapshotTypes.DashboardCard
 type DashboardWorkspace = DashboardSnapshotTypes.DashboardWorkspace
@@ -100,7 +90,6 @@ export type AgentMapLayoutCache = {
   packingGeneration: number
 }
 
-type LocalWorktree = Omit<AgentMapWorktreeRing, 'x' | 'y'> & { x: number; y: number }
 type LocalProject = Omit<AgentMapProjectRing, 'x' | 'y' | 'worktrees'> & {
   x: number
   y: number
@@ -137,63 +126,6 @@ export function shouldAggregateAgentMapWorktree(
   )
 }
 
-function worktreeRadius(agentCount: number): number {
-  return Math.max(
-    52,
-    24 + Math.ceil(Math.sqrt(Math.max(1, agentCount))) * (AGENT_MAP_AGENT_RADIUS + 8)
-  )
-}
-
-function buildLocalWorktree(
-  id: string,
-  cards: DashboardCard[],
-  now: number,
-  workspace?: DashboardWorkspace
-): LocalWorktree {
-  const lineageLayout = layoutAgentMapLineage(cards, AGENT_MAP_AGENT_RADIUS)
-  const contentRadius = lineageLayout?.radius ?? worktreeRadius(cards.length)
-  const radius = contentRadius + RING_CONTENT_OFFSET
-  const statusCounts = emptyAgentMapStatusCounts()
-  for (const card of cards) {
-    statusCounts[agentMapNodeStatus(card)] += 1
-  }
-  const host = agentMapWorktreeHost(cards, workspace)
-  const executionHostId = host.executionHostId
-  const parentWorktreeId = workspace?.parentWorktreeId ?? cards[0]?.parentWorktreeId
-  return {
-    id,
-    parentId: parentWorktreeId
-      ? agentMapWorktreeIdentityFromParts(parentWorktreeId, executionHostId)
-      : undefined,
-    worktreeId: workspace?.worktreeId ?? cards[0]?.worktreeId ?? id,
-    ...host,
-    name: workspace?.worktreeName ?? cards[0]?.worktreeName ?? id,
-    workspaceKind: workspace?.workspaceKind ?? cards[0]?.workspaceKind ?? 'worktree',
-    x: 0,
-    y: 0,
-    radius,
-    agents: (
-      lineageLayout?.agents.map(({ card, x, y }) => ({
-        card,
-        x,
-        y,
-        radius: AGENT_MAP_AGENT_RADIUS,
-        durationMinutes: agentMapDurationMinutes(card, now),
-        status: agentMapNodeStatus(card)
-      })) ??
-      placeAgentMapAgents({
-        worktreeId: id,
-        cards,
-        radius: contentRadius,
-        agentRadius: AGENT_MAP_AGENT_RADIUS,
-        now
-      })
-    ).map((agent) => ({ ...agent, y: agent.y + RING_CONTENT_OFFSET })),
-    statusCounts,
-    quiet: agentMapQuietCount(statusCounts) === cards.length
-  }
-}
-
 function buildLocalProject(
   id: string,
   cards: DashboardCard[],
@@ -223,7 +155,14 @@ function buildLocalProject(
     [...byWorktree.entries()]
       .sort(([a], [b]) => compareStable(a, b))
       .map(([worktreeId, worktreeCards]) => ({
-        ...buildLocalWorktree(worktreeId, worktreeCards, now, workspacesById.get(worktreeId)),
+        ...buildLocalWorktree(
+          worktreeId,
+          worktreeCards,
+          now,
+          AGENT_MAP_AGENT_RADIUS,
+          RING_CONTENT_OFFSET,
+          workspacesById.get(worktreeId)
+        ),
         clusterParentId: selectAgentMapSpawnParentContainer(
           worktreeCards,
           cardsByPaneKey,
@@ -260,12 +199,19 @@ function buildLocalProject(
 export function deriveAgentMapLayout(
   cards: DashboardCard[],
   now: number,
-  workspaces: DashboardWorkspace[] = []
+  workspaces: DashboardWorkspace[] = [],
+  previousLayout: AgentMapLayout | null = null
 ): AgentMapLayout {
   const topologyKey = agentMapTopologyKey(cards, workspaces)
   if (cards.length === 0 && workspaces.length === 0) {
     return { projects: [], width: 900, height: 560, topologyKey }
   }
+  const previousPositions =
+    previousLayout && previousLayout.projects.length > 0
+      ? new Map(
+          previousLayout.projects.map((project) => [project.id, { x: project.x, y: project.y }])
+        )
+      : undefined
   const byProject = new Map<string, { cards: DashboardCard[]; workspaces: DashboardWorkspace[] }>()
   for (const card of cards) {
     const current = byProject.get(card.repoId) ?? { cards: [], workspaces: [] }
@@ -283,7 +229,7 @@ export function deriveAgentMapLayout(
     .map(([projectId, project]) =>
       buildLocalProject(projectId, project.cards, project.workspaces, cardsByPaneKey, now)
     )
-  const framed = placeAgentMapProjects(localProjects, 900, 560, WORLD_MARGIN)
+  const framed = placeAgentMapProjects(localProjects, 900, 560, WORLD_MARGIN, previousPositions)
   const projects = framed.projects.map((project): AgentMapProjectRing => {
     return {
       ...project,
@@ -310,7 +256,7 @@ export function updateAgentMapLayout(
 ): { cache: AgentMapLayoutCache; layout: AgentMapLayout } {
   const topologyKey = agentMapTopologyKey(cards, workspaces)
   if (!cache || cache.topologyKey !== topologyKey) {
-    const geometry = deriveAgentMapLayout(cards, now, workspaces)
+    const geometry = deriveAgentMapLayout(cards, now, workspaces, cache?.geometry ?? null)
     return {
       cache: {
         topologyKey,

--- a/src/renderer/src/components/dashboard-popout/agent-map-local-worktree.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-local-worktree.ts
@@ -1,0 +1,73 @@
+import type * as DashboardSnapshotTypes from '../../../../shared/dashboard-snapshot'
+import { placeAgentMapAgents } from './agent-map-agent-placement'
+import { layoutAgentMapLineage } from './agent-map-lineage-layout'
+import {
+  agentMapDurationMinutes,
+  agentMapNodeStatus,
+  agentMapQuietCount,
+  emptyAgentMapStatusCounts
+} from './agent-map-node-metadata'
+import { agentMapWorktreeIdentityFromParts } from './agent-map-workspace-identity'
+import { agentMapWorktreeHost } from './agent-map-worktree-host'
+import type { AgentMapWorktreeRing } from './agent-map-layout'
+
+type DashboardCard = DashboardSnapshotTypes.DashboardCard
+type DashboardWorkspace = DashboardSnapshotTypes.DashboardWorkspace
+
+export type LocalWorktree = Omit<AgentMapWorktreeRing, 'x' | 'y'> & { x: number; y: number }
+
+function worktreeRadius(agentCount: number, agentRadius: number): number {
+  return Math.max(52, 24 + Math.ceil(Math.sqrt(Math.max(1, agentCount))) * (agentRadius + 8))
+}
+
+export function buildLocalWorktree(
+  id: string,
+  cards: DashboardCard[],
+  now: number,
+  agentRadius: number,
+  ringContentOffset: number,
+  workspace?: DashboardWorkspace
+): LocalWorktree {
+  const lineageLayout = layoutAgentMapLineage(cards, agentRadius)
+  const contentRadius = lineageLayout?.radius ?? worktreeRadius(cards.length, agentRadius)
+  const radius = contentRadius + ringContentOffset
+  const statusCounts = emptyAgentMapStatusCounts()
+  for (const card of cards) {
+    statusCounts[agentMapNodeStatus(card)] += 1
+  }
+  const host = agentMapWorktreeHost(cards, workspace)
+  const executionHostId = host.executionHostId
+  const parentWorktreeId = workspace?.parentWorktreeId ?? cards[0]?.parentWorktreeId
+  return {
+    id,
+    parentId: parentWorktreeId
+      ? agentMapWorktreeIdentityFromParts(parentWorktreeId, executionHostId)
+      : undefined,
+    worktreeId: workspace?.worktreeId ?? cards[0]?.worktreeId ?? id,
+    ...host,
+    name: workspace?.worktreeName ?? cards[0]?.worktreeName ?? id,
+    workspaceKind: workspace?.workspaceKind ?? cards[0]?.workspaceKind ?? 'worktree',
+    x: 0,
+    y: 0,
+    radius,
+    agents: (
+      lineageLayout?.agents.map(({ card, x, y }) => ({
+        card,
+        x,
+        y,
+        radius: agentRadius,
+        durationMinutes: agentMapDurationMinutes(card, now),
+        status: agentMapNodeStatus(card)
+      })) ??
+      placeAgentMapAgents({
+        worktreeId: id,
+        cards,
+        radius: contentRadius,
+        agentRadius,
+        now
+      })
+    ).map((agent) => ({ ...agent, y: agent.y + ringContentOffset })),
+    statusCounts,
+    quiet: agentMapQuietCount(statusCounts) === cards.length
+  }
+}

--- a/src/renderer/src/components/dashboard-popout/agent-map-project-placement.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-project-placement.ts
@@ -10,12 +10,28 @@ type ProjectCircle = {
   clusterParentId?: string
 }
 
-function placeUnlinkedProjects<T extends ProjectCircle>(projects: T[]): T[] {
+// Projects are placed left-to-right in stable id order. A project that already
+// had a position keeps it (so unrelated projects never jump when some other
+// project's own size changes); the cursor only pushes a project forward when
+// its previous slot would now overlap the project placed just before it —
+// i.e. when its own membership, or an earlier project's growth, genuinely
+// requires it to move.
+function placeUnlinkedProjects<T extends ProjectCircle>(
+  projects: T[],
+  previousPositions?: ReadonlyMap<string, { x: number; y: number }>
+): T[] {
+  // Every project sits on the same row (y is otherwise always 0), so any
+  // previously-anchored project's y already carries the frame's vertical
+  // centering — reuse it for brand-new projects too instead of 0, or the
+  // whole row would jump back to an unoffset y once anchoring skips re-centering below.
+  const rowY = previousPositions?.values().next().value?.y ?? 0
   let cursorX = 0
   return projects.map((project) => {
-    const positioned = { ...project, x: cursorX + project.radius, y: 0 }
-    cursorX += project.radius * 2 + PROJECT_GAP
-    return positioned
+    const previous = previousPositions?.get(project.id)
+    const x =
+      previous && previous.x - project.radius >= cursorX ? previous.x : cursorX + project.radius
+    cursorX = x + project.radius + PROJECT_GAP
+    return { ...project, x, y: previousPositions ? rowY : 0 }
   })
 }
 
@@ -23,11 +39,16 @@ export function placeAgentMapProjects<T extends ProjectCircle>(
   projects: T[],
   minimumWidth: number,
   minimumHeight: number,
-  worldMargin: number
+  worldMargin: number,
+  previousPositions?: ReadonlyMap<string, { x: number; y: number }>
 ): { projects: T[]; width: number; height: number } {
+  // ponytail: cross-project spawn clusters (clusterParentId) still fully
+  // repack via layoutAgentMapWorktreeLineage on every change — rare path
+  // (an agent in one repo spawning a worktree in another repo); upgrade to
+  // anchored placement here too if that turns out to churn in practice.
   const positioned = projects.some((project) => project.clusterParentId)
     ? layoutAgentMapWorktreeLineage(projects)
-    : placeUnlinkedProjects(projects)
+    : placeUnlinkedProjects(projects, previousPositions)
   const left = Math.min(...positioned.map((project) => project.x - project.radius))
   const right = Math.max(...positioned.map((project) => project.x + project.radius))
   const top = Math.min(...positioned.map((project) => project.y - project.radius))
@@ -36,8 +57,14 @@ export function placeAgentMapProjects<T extends ProjectCircle>(
   const naturalHeight = bottom - top + worldMargin * 2
   const width = Math.max(minimumWidth, naturalWidth)
   const height = Math.max(minimumHeight, naturalHeight)
-  const offsetX = worldMargin - left + (width - naturalWidth) / 2
-  const offsetY = worldMargin - top + (height - naturalHeight) / 2
+  // Anchored projects already carry absolute coordinates from the previous
+  // frame — re-centering the whole frame here (e.g. because the total content
+  // width crossed the minimum-width padding threshold) would drag every
+  // ring sideways even though nothing about it changed. Only the very first
+  // layout (no previous positions to anchor to) gets centered within the
+  // minimum canvas size.
+  const offsetX = previousPositions ? 0 : worldMargin - left + (width - naturalWidth) / 2
+  const offsetY = previousPositions ? 0 : worldMargin - top + (height - naturalHeight) / 2
   return {
     projects: positioned.map((project) => ({
       ...project,

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
@@ -201,6 +201,21 @@ describe('buildDashboardSnapshot', () => {
     expect(card.unseen).toBe(true)
   })
 
+  it('publishes a card for an agent running on the repo primary/main checkout', () => {
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        worktreesByRepo: { r1: [{ ...worktree(), isMainWorktree: true }] },
+        agentStatusByPaneKey: {
+          [PANE_KEY]: entry({ state: 'working', lastAssistantMessage: 'Working on it now' })
+        }
+      }),
+      NOW
+    )
+    expect(snapshot.cards).toHaveLength(1)
+    expect(snapshot.cards[0].worktreeId).toBe('w1')
+    expect(snapshot.workspaces).toEqual([expect.objectContaining({ worktreeId: 'w1' })])
+  })
+
   it('keeps monitoring in the working bucket with a passive dot state', () => {
     const snapshot = buildDashboardSnapshot(
       baseState({


### PR DESCRIPTION
## Summary
- Project rings on the Agent Dashboard's map view were fully repacked left-to-right from x=0 on every topology change anywhere on the board, so one project growing/shrinking or a new project appearing shifted every other project's ring, even unrelated ones.
- Anchors each project ring to its previous frame position when repacking, only advancing a ring past its old slot when it would now overlap the ring placed immediately before it.
- Skips the frame re-centering step when anchoring so the whole canvas doesn't pan when total content size crosses the minimum-canvas padding threshold.

Also traced a reported case where an agent running on a repo's primary/main checkout (not a separate worktree) doesn't get a ring — found no exclusion for `isMainWorktree` anywhere in `collectActiveDashboardWorkspaces` → `buildDashboardSnapshot` → the map layout/placement/identity pipeline. Added a regression test confirming a main-checkout-only repo already produces a card and workspace on this code path. If the ring is still missing live, the gap is likely upstream of this pipeline (how a terminal/agent session gets associated with `worktreeId` in the first place), not here.

## Test plan
- `pnpm vitest run` on touched files and direct siblings — 70/70 passing
- `pnpm run typecheck:web` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>