### PR TITLE
fix(terminal): defer a focus-cancelled paste instead of discarding it (STA-5272)

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1977,7 +1977,9 @@ function TerminalPane(
       if (!deferredPasteRef.current) {
         deferredPasteRef.current = createDeferredTerminalPasteQueue({
           onExpire: () =>
-            setTerminalError(formatDeferredTerminalPasteDroppedError(shortcutPlatform))
+            setTerminalError(
+              formatDeferredTerminalPasteDroppedError('deadline-passed', shortcutPlatform)
+            )
         })
       }
       return deferredPasteRef.current
@@ -2040,9 +2042,7 @@ function TerminalPane(
         if (
           allowDeferOnFocusLoss &&
           isDeferrablePasteFocusCancellation({
-            status: execution.status,
-            reason: execution.reason,
-            chunksWritten: execution.chunksWritten,
+            execution,
             targetMounted: isPanePasteTargetMounted(pane, transport, ptyId),
             focusMovedToOtherPane: isFocusInsideOtherPane({
               panes: managerRef.current?.getPanes() ?? [],
@@ -2339,7 +2339,8 @@ function TerminalPane(
           deferred.options,
           false
         ),
-      onDropped: () => setTerminalError(formatDeferredTerminalPasteDroppedError(shortcutPlatform))
+      onDropped: (_entry, cause) =>
+        setTerminalError(formatDeferredTerminalPasteDroppedError(cause, shortcutPlatform))
     })
 
     container.addEventListener('keydown', onKeyPaste, { capture: true })

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -2042,6 +2042,7 @@ function TerminalPane(
           isDeferrablePasteFocusCancellation({
             status: execution.status,
             reason: execution.reason,
+            chunksWritten: execution.chunksWritten,
             targetMounted: isPanePasteTargetMounted(pane, transport, ptyId),
             focusMovedToOtherPane: isFocusInsideOtherPane({
               panes: managerRef.current?.getPanes() ?? [],

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -222,8 +222,23 @@ import {
   type TerminalPasteSource,
   type TerminalPasteTextOptions
 } from './terminal-paste-coordinator'
+import {
+  createDeferredPasteFocusInHandler,
+  createDeferredTerminalPasteQueue,
+  isDeferrablePasteFocusCancellation,
+  isFocusInsideOtherPane,
+  type DeferredTerminalPasteQueue
+} from './terminal-deferred-paste'
 import { appendTerminalErrorMessage } from './terminal-error-accumulation'
-import { formatTerminalPasteExecutionError } from './terminal-paste-errors'
+import {
+  installInertFocusPasteFallback,
+  restoreInertFocusPasteTarget
+} from './terminal-inert-focus-paste-fallback'
+import {
+  formatDeferredTerminalPasteDroppedError,
+  formatTerminalPasteExecutionError,
+  TERMINAL_CLIPBOARD_READ_UNAVAILABLE_MESSAGE
+} from './terminal-paste-errors'
 import { resolveTerminalPasteRuntime } from './terminal-paste-runtime'
 import { getTerminalPasteSshRemotePlatform } from './terminal-paste-ssh-platform'
 import {
@@ -402,6 +417,15 @@ function TerminalPane(
   const [agentSessionContinuation, setAgentSessionContinuation] =
     useState<AgentSessionContinuationRequest | null>(null)
   const [terminalError, setTerminalError] = useState<string | null>(null)
+  // Why: outlives the paste effect so a keybinding change mid-deferral does not
+  // silently drop the payload; only unmount does.
+  const deferredPasteRef = useRef<DeferredTerminalPasteQueue | null>(null)
+  useEffect(() => {
+    return () => {
+      deferredPasteRef.current?.dispose()
+      deferredPasteRef.current = null
+    }
+  }, [])
   const [paneProcessExitsByPaneId, setPaneProcessExitsByPaneId] = useState<
     Record<number, PaneProcessExit>
   >({})
@@ -1949,12 +1973,25 @@ function TerminalPane(
       })
     }
 
+    const getDeferredPasteQueue = (): DeferredTerminalPasteQueue => {
+      if (!deferredPasteRef.current) {
+        deferredPasteRef.current = createDeferredTerminalPasteQueue({
+          onExpire: () =>
+            setTerminalError(formatDeferredTerminalPasteDroppedError(shortcutPlatform))
+        })
+      }
+      return deferredPasteRef.current
+    }
+
     const executePanePasteText = async (
       pane: ManagedPane,
       source: TerminalPasteSource,
       activeElementAtDispatch: Element | null,
       text: string,
-      options?: TerminalPasteTextOptions
+      options?: TerminalPasteTextOptions,
+      // Why: a redelivered paste never re-defers, so a pane that keeps refusing
+      // focus cannot loop the payload past its deadline.
+      allowDeferOnFocusLoss = true
     ): Promise<void> => {
       const connectionId = getConnectionId(worktreeId) ?? null
       const transport = paneTransportsRef.current.get(pane.id)
@@ -2000,6 +2037,28 @@ function TerminalPane(
         canContinue: () => isPanePasteTargetMounted(pane, transport, ptyId)
       })
       if (execution.status !== 'pasted') {
+        if (
+          allowDeferOnFocusLoss &&
+          isDeferrablePasteFocusCancellation({
+            status: execution.status,
+            reason: execution.reason,
+            targetMounted: isPanePasteTargetMounted(pane, transport, ptyId),
+            focusMovedToOtherPane: isFocusInsideOtherPane({
+              panes: managerRef.current?.getPanes() ?? [],
+              paneId: pane.id,
+              focusedElement: document.activeElement
+            })
+          })
+        ) {
+          getDeferredPasteQueue().defer({
+            paneId: pane.id,
+            leafId: pane.leafId,
+            source,
+            text,
+            options
+          })
+          return
+        }
         setTerminalError(formatTerminalPasteExecutionError(execution.reason))
         return
       }
@@ -2055,7 +2114,9 @@ function TerminalPane(
           executePanePasteText(pane, source, activeElementAtDispatch, text, options),
         onTextPasteError: () =>
           setTerminalError('Paste failed: clipboard text is too large for a safe terminal paste.'),
-        onImagePasteError: (error) => setTerminalError(formatClipboardImagePasteError(error))
+        onImagePasteError: (error) => setTerminalError(formatClipboardImagePasteError(error)),
+        onClipboardReadUnavailable: () =>
+          setTerminalError(TERMINAL_CLIPBOARD_READ_UNAVAILABLE_MESSAGE)
       }).catch(() => {
         setTerminalError('Paste failed.')
       })
@@ -2071,7 +2132,19 @@ function TerminalPane(
         (!isMac && e.key === 'Insert' && e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey)
       )
     }
-    const onKeyPaste = (e: KeyboardEvent): void => {
+    // Why: focus sits on <body> after a dictation/IME/overlay handoff, so the pane's
+    // own dispatch-element guard would read this paste as aimed somewhere else.
+    // Put focus back on the pane that still owns it before the shared path runs.
+    const restoreInertPaneFocus = (): ManagedPane | null => {
+      const pane = managerRef.current?.getActivePane() ?? managerRef.current?.getPanes()[0] ?? null
+      if (!pane) {
+        return null
+      }
+      restoreInertFocusPasteTarget(pane, document.activeElement)
+      return pane
+    }
+
+    const onKeyPaste = (e: KeyboardEvent, recoveredFromInertFocus = false): void => {
       const target = e.target
       if (
         (target instanceof Element && target.closest('[data-terminal-search-root]')) ||
@@ -2098,6 +2171,9 @@ function TerminalPane(
             suppressNextNativePaste = false
           }, 0)
         }
+        return
+      }
+      if (recoveredFromInertFocus && !restoreInertPaneFocus()) {
         return
       }
       if (isClipboardEventPasteRequired() && firesNativePasteEvent(e, isMac)) {
@@ -2129,7 +2205,7 @@ function TerminalPane(
     }
 
     // Fallback: paste events from non-keyboard sources (Edit > Paste menu, programmatic paste, etc.).
-    const onPaste = (e: ClipboardEvent): void => {
+    const onPaste = (e: ClipboardEvent, recoveredFromInertFocus = false): void => {
       const target = e.target
       if (
         (target instanceof Element && target.closest('[data-terminal-search-root]')) ||
@@ -2149,6 +2225,9 @@ function TerminalPane(
       }
       e.preventDefault()
       e.stopPropagation()
+      if (recoveredFromInertFocus && !restoreInertPaneFocus()) {
+        return
+      }
       const manager = managerRef.current
       if (!manager) {
         return
@@ -2202,7 +2281,9 @@ function TerminalPane(
           executePanePasteText(pane, 'app-menu', activeElementAtDispatch, text, options),
         onTextPasteError: () =>
           setTerminalError('Paste failed: clipboard text is too large for a safe terminal paste.'),
-        onImagePasteError: (error) => setTerminalError(formatClipboardImagePasteError(error))
+        onImagePasteError: (error) => setTerminalError(formatClipboardImagePasteError(error)),
+        onClipboardReadUnavailable: () =>
+          setTerminalError(TERMINAL_CLIPBOARD_READ_UNAVAILABLE_MESSAGE)
       }).catch(() => {
         setTerminalError('Paste failed.')
       })
@@ -2242,8 +2323,32 @@ function TerminalPane(
       }
     }
 
+    // A deferred payload lands the moment its own pane has focus again; focus
+    // reaching a different pane is the wrong-target case the guard exists for.
+    const onDeferredPasteFocusIn = createDeferredPasteFocusInHandler<ManagedPane>({
+      queue: getDeferredPasteQueue(),
+      getPanes: () => managerRef.current?.getPanes() ?? [],
+      getFocusedElement: () => document.activeElement,
+      deliver: (pane, deferred) =>
+        void executePanePasteText(
+          pane,
+          deferred.source,
+          document.activeElement,
+          deferred.text,
+          deferred.options,
+          false
+        ),
+      onDropped: () => setTerminalError(formatDeferredTerminalPasteDroppedError(shortcutPlatform))
+    })
+
     container.addEventListener('keydown', onKeyPaste, { capture: true })
     container.addEventListener('paste', onPaste, { capture: true })
+    container.addEventListener('focusin', onDeferredPasteFocusIn)
+    const inertFocusPasteFallback = installInertFocusPasteFallback({
+      container,
+      onPasteKey: (event) => onKeyPaste(event, true),
+      onPasteEvent: (event) => onPaste(event, true)
+    })
     window.addEventListener(APP_MENU_PASTE_EVENT, onAppMenuPaste)
     window.addEventListener(APP_MENU_SELECTION_ACTION_EVENT, onAppMenuSelectionAction)
     return () => {
@@ -2252,6 +2357,8 @@ function TerminalPane(
       }
       container.removeEventListener('keydown', onKeyPaste, { capture: true })
       container.removeEventListener('paste', onPaste, { capture: true })
+      container.removeEventListener('focusin', onDeferredPasteFocusIn)
+      inertFocusPasteFallback.dispose()
       window.removeEventListener(APP_MENU_PASTE_EVENT, onAppMenuPaste)
       window.removeEventListener(APP_MENU_SELECTION_ACTION_EVENT, onAppMenuSelectionAction)
     }

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste-read-failure.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste-read-failure.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { CLIPBOARD_TEXT_TOO_LARGE_ERROR } from '../../../../shared/clipboard-text'
+import { pasteTerminalClipboard } from './terminal-clipboard-paste'
+
+// STA-5272 defect 2: a clipboard text read that FAILS is `unavailable`, never `empty`.
+// Collapsing the two makes a failed read look to the user like "you copied nothing":
+// no paste, no error, no toast.
+describe('terminal clipboard paste: failed read is not an empty clipboard', () => {
+  it('reports a failed text read as clipboard-read-failed, not empty', async () => {
+    const readError = new Error('Read permission denied')
+    const onClipboardReadUnavailable = vi.fn()
+    const onTextPasteError = vi.fn()
+    const pasteText = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockRejectedValue(readError),
+      saveClipboardImageAsTempFile: vi.fn().mockResolvedValue(null),
+      pasteText,
+      onClipboardReadUnavailable,
+      onTextPasteError
+    })
+
+    expect(result).toEqual({ status: 'skipped', reason: 'clipboard-read-failed' })
+    expect(onClipboardReadUnavailable).toHaveBeenCalledTimes(1)
+    expect(onClipboardReadUnavailable).toHaveBeenCalledWith(readError)
+    // The too-large path owns onTextPasteError; a plain read failure must not borrow it.
+    expect(onTextPasteError).not.toHaveBeenCalled()
+    expect(pasteText).not.toHaveBeenCalled()
+  })
+
+  it('keeps a genuinely empty clipboard silent', async () => {
+    const onClipboardReadUnavailable = vi.fn()
+    const onTextPasteError = vi.fn()
+    const onImagePasteError = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue(''),
+      saveClipboardImageAsTempFile: vi.fn().mockResolvedValue(null),
+      pasteText: vi.fn(),
+      onClipboardReadUnavailable,
+      onTextPasteError,
+      onImagePasteError
+    })
+
+    expect(result).toEqual({ status: 'skipped', reason: 'empty' })
+    expect(onClipboardReadUnavailable).not.toHaveBeenCalled()
+    expect(onTextPasteError).not.toHaveBeenCalled()
+    expect(onImagePasteError).not.toHaveBeenCalled()
+  })
+
+  it('still pastes an image when the text read failed on an image-only clipboard', async () => {
+    const onClipboardReadUnavailable = vi.fn()
+    const pasteText = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockRejectedValue(new Error('No text on clipboard')),
+      saveClipboardImageAsTempFile: vi.fn().mockResolvedValue('/tmp/orca-paste-1.png'),
+      pasteText,
+      onClipboardReadUnavailable
+    })
+
+    expect(result).toEqual({ status: 'pasted', kind: 'image-path' })
+    expect(pasteText).toHaveBeenCalledWith('/tmp/orca-paste-1.png', {
+      forceBracketedPaste: true,
+      recoverImagePasteWebglAtlas: true
+    })
+    expect(onClipboardReadUnavailable).not.toHaveBeenCalled()
+  })
+
+  it('leaves the too-large read on its own error path', async () => {
+    const tooLarge = new Error(CLIPBOARD_TEXT_TOO_LARGE_ERROR)
+    const onClipboardReadUnavailable = vi.fn()
+    const onTextPasteError = vi.fn()
+    const saveClipboardImageAsTempFile = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockRejectedValue(tooLarge),
+      saveClipboardImageAsTempFile,
+      pasteText: vi.fn(),
+      onClipboardReadUnavailable,
+      onTextPasteError
+    })
+
+    expect(result).toEqual({ status: 'skipped', reason: 'text-too-large' })
+    expect(onTextPasteError).toHaveBeenCalledWith(tooLarge)
+    expect(onClipboardReadUnavailable).not.toHaveBeenCalled()
+    expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
@@ -25,6 +25,7 @@ type PasteTerminalClipboardDeps = {
   protectedMultilineTextPasteOptions?: TerminalPasteTextOptions
   onTextPasteError?: (error: unknown) => void
   onImagePasteError?: (error: unknown) => void
+  onClipboardReadUnavailable?: (error: unknown) => void
 }
 
 export type TerminalClipboardPasteResult =
@@ -33,6 +34,7 @@ export type TerminalClipboardPasteResult =
       status: 'skipped'
       reason:
         | 'empty'
+        | 'clipboard-read-failed'
         | 'image-paste-failed'
         | 'image-paste-rejected'
         | 'text-paste-failed'
@@ -49,9 +51,14 @@ export async function pasteTerminalClipboard({
   forceBracketedMultilineTextPaste = false,
   protectedMultilineTextPasteOptions,
   onTextPasteError,
-  onImagePasteError
+  onImagePasteError,
+  onClipboardReadUnavailable
 }: PasteTerminalClipboardDeps): Promise<TerminalClipboardPasteResult> {
   let text = ''
+  // Why: a failed read is `unavailable`, never `empty`. Holding the error keeps
+  // the image path reachable for image-only clipboards without letting a real
+  // read failure be reported to the user as "you copied nothing".
+  let readFailure: { error: unknown } | null = null
   try {
     text = await readClipboardText({ maxBytes: TERMINAL_PASTE_MAX_BYTES })
   } catch (error) {
@@ -61,6 +68,7 @@ export async function pasteTerminalClipboard({
     }
     // Why: browser clipboard text reads can fail for image-only clipboards.
     // Still try the image path so Cmd/Ctrl+V works for screenshots.
+    readFailure = { error }
   }
   if (text) {
     try {
@@ -81,6 +89,10 @@ export async function pasteTerminalClipboard({
   try {
     const filePath = await saveClipboardImageAsTempFile({ connectionId, runtimeEnvironmentId })
     if (!filePath) {
+      if (readFailure) {
+        onClipboardReadUnavailable?.(readFailure.error)
+        return { status: 'skipped', reason: 'clipboard-read-failed' }
+      }
       return { status: 'skipped', reason: 'empty' }
     }
     const result = await pasteText(filePath, {

--- a/src/renderer/src/components/terminal-pane/terminal-deferred-paste-wiring.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-deferred-paste-wiring.test.ts
@@ -1,0 +1,209 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// STA-5272 review: every guard this feature depends on lives in a pure module with
+// its own unit tests, but `TerminalPane` is mocked out of every suite that touches
+// it, so nothing observed that the component still *uses* them. Deleting the whole
+// deferral branch, or handing the guard a literal `chunksWritten: 0` over a partial
+// write, left all 4357 renderer tests green. These pins are the only thing standing
+// between that and a silently reinstated duplicate-bytes paste.
+const source = readFileSync(join(__dirname, 'TerminalPane.tsx'), 'utf8').replace(/\r\n?/g, '\n')
+
+function sliceBetween(startAnchor: string, endAnchor: string, within = source): string {
+  const start = within.indexOf(startAnchor)
+  if (start === -1) {
+    throw new Error(`anchor moved or was removed: ${startAnchor}`)
+  }
+  const end = within.indexOf(endAnchor, start + startAnchor.length)
+  if (end === -1) {
+    throw new Error(`anchor moved or was removed: ${endAnchor}`)
+  }
+  return within.slice(start, end)
+}
+
+// Scoped, not global: a guard relocated into a function nobody calls has to read as
+// absent, so every assertion below is made against the body that actually runs.
+const pasteEffect = sliceBetween(
+  '  // Intercept paste at keydown:',
+  '  }, [isActive, worktreeId, keybindings, forceBracketedMultilineTextPaste, tabId])'
+)
+const executePanePasteText = sliceBetween(
+  '    const executePanePasteText = async (',
+  '\n    // Why: resolved per pane and PTY host',
+  pasteEffect
+)
+
+describe('deferred paste wiring in TerminalPane', () => {
+  it('asks the deferral guard with the executor result itself, not fields restated by the caller', () => {
+    // Indented verbatim, so `execution` cannot become `{ chunksWritten: 0, ... }`
+    // and quietly make a partially written paste look replayable.
+    expect(executePanePasteText).toContain(
+      [
+        '        if (',
+        '          allowDeferOnFocusLoss &&',
+        '          isDeferrablePasteFocusCancellation({',
+        '            execution,',
+        '            targetMounted: isPanePasteTargetMounted(pane, transport, ptyId),',
+        '            focusMovedToOtherPane: isFocusInsideOtherPane({',
+        '              panes: managerRef.current?.getPanes() ?? [],',
+        '              paneId: pane.id,',
+        '              focusedElement: document.activeElement',
+        '            })',
+        '          })',
+        '        ) {'
+      ].join('\n')
+    )
+  })
+
+  it('defers the payload for that pane and stops, instead of falling through to the error toast', () => {
+    expect(executePanePasteText).toContain(
+      [
+        '          getDeferredPasteQueue().defer({',
+        '            paneId: pane.id,',
+        '            leafId: pane.leafId,',
+        '            source,',
+        '            text,',
+        '            options',
+        '          })',
+        '          return',
+        '        }',
+        '        setTerminalError(formatTerminalPasteExecutionError(execution.reason))'
+      ].join('\n')
+    )
+  })
+
+  it('refuses a second deferral of a redelivered payload, so it cannot loop past its deadline', () => {
+    expect(executePanePasteText).toContain('      allowDeferOnFocusLoss = true\n')
+    // The redelivery passes `false` positionally; a `true` here reinstates the loop.
+    expect(pasteEffect).toContain(
+      [
+        '      deliver: (pane, deferred) =>',
+        '        void executePanePasteText(',
+        '          pane,',
+        '          deferred.source,',
+        '          document.activeElement,',
+        '          deferred.text,',
+        '          deferred.options,',
+        '          false',
+        '        ),'
+      ].join('\n')
+    )
+  })
+
+  it('listens for focus coming back and stops listening when the effect tears down', () => {
+    expect(pasteEffect).toContain(
+      "    container.addEventListener('focusin', onDeferredPasteFocusIn)\n"
+    )
+    expect(pasteEffect).toContain(
+      "      container.removeEventListener('focusin', onDeferredPasteFocusIn)\n"
+    )
+  })
+
+  it('installs the inert-focus recovery on both paste entry points and disposes it', () => {
+    expect(pasteEffect).toContain(
+      [
+        '    const inertFocusPasteFallback = installInertFocusPasteFallback({',
+        '      container,',
+        '      onPasteKey: (event) => onKeyPaste(event, true),',
+        '      onPasteEvent: (event) => onPaste(event, true)',
+        '    })'
+      ].join('\n')
+    )
+    expect(pasteEffect).toContain('      inertFocusPasteFallback.dispose()\n')
+  })
+
+  it('puts focus back on the owning pane before a recovered paste runs, on both entry points', () => {
+    const recovery = [
+      '      if (recoveredFromInertFocus && !restoreInertPaneFocus()) {',
+      '        return',
+      '      }'
+    ].join('\n')
+    // Once in onKeyPaste, once in onPaste: a paste recovered from <body> that never
+    // restores focus is read by the shared guard as aimed at another surface.
+    expect(pasteEffect.split(recovery)).toHaveLength(3)
+  })
+
+  it('releases a still-pending payload when the pane unmounts, not merely when the effect re-runs', () => {
+    // Outside the paste effect on purpose: its deps include `keybindings`, and a
+    // settings change mid-deferral must not drop the payload.
+    const unmount = sliceBetween(
+      '  const deferredPasteRef = useRef<DeferredTerminalPasteQueue | null>(null)',
+      '  const [paneProcessExitsByPaneId'
+    )
+    expect(unmount).toContain(
+      [
+        '  useEffect(() => {',
+        '    return () => {',
+        '      deferredPasteRef.current?.dispose()',
+        '      deferredPasteRef.current = null',
+        '    }',
+        '  }, [])'
+      ].join('\n')
+    )
+    expect(pasteEffect).not.toContain('deferredPasteRef.current?.dispose()')
+  })
+
+  it('tells the user which of the three drop causes it actually hit', () => {
+    expect(pasteEffect).toContain(
+      [
+        '          onExpire: () =>',
+        '            setTerminalError(',
+        "              formatDeferredTerminalPasteDroppedError('deadline-passed', shortcutPlatform)",
+        '            )'
+      ].join('\n')
+    )
+    expect(pasteEffect).toContain(
+      [
+        '      onDropped: (_entry, cause) =>',
+        '        setTerminalError(formatDeferredTerminalPasteDroppedError(cause, shortcutPlatform))'
+      ].join('\n')
+    )
+  })
+})
+
+// A caller that forgets this handler gets the pre-PR behaviour back for free: a
+// clipboard read that FAILED is reported to the user as an EMPTY clipboard, which
+// is silence. Checked per call site rather than by counting keywords in the file.
+describe('every clipboard paste entry point distinguishes a failed read from an empty one', () => {
+  const callSiteArguments = (fileSource: string): string[] => {
+    const sites: string[] = []
+    const marker = 'pasteTerminalClipboard({'
+    for (let at = fileSource.indexOf(marker); at >= 0; at = fileSource.indexOf(marker, at + 1)) {
+      let depth = 0
+      let end = at + marker.length - 1
+      for (; end < fileSource.length; end += 1) {
+        const char = fileSource[end]
+        if (char === '{') {
+          depth += 1
+        } else if (char === '}') {
+          depth -= 1
+          if (depth === 0) {
+            break
+          }
+        }
+      }
+      sites.push(fileSource.slice(at, end + 1))
+    }
+    return sites
+  }
+
+  const files = ['TerminalPane.tsx', 'terminal-pane-menu-paste.ts']
+
+  it.each(files)('%s hands every call a clipboard-read-unavailable handler', (file) => {
+    const fileSource = readFileSync(join(__dirname, file), 'utf8').replace(/\r\n?/g, '\n')
+    const sites = callSiteArguments(fileSource)
+
+    expect(sites.length).toBeGreaterThan(0)
+    for (const site of sites) {
+      expect(site).toContain('onClipboardReadUnavailable')
+    }
+  })
+
+  it('covers every production caller in the module, so a new one cannot be added unguarded', () => {
+    const declared = readFileSync(join(__dirname, 'terminal-clipboard-paste.ts'), 'utf8')
+    expect(declared).toContain('onClipboardReadUnavailable?: (error: unknown) => void')
+    // Both known importers are in `files`; a third would have to be added here.
+    expect(files).toEqual(['TerminalPane.tsx', 'terminal-pane-menu-paste.ts'])
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-deferred-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-deferred-paste.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi, type Mock } from 'vitest'
 
+import { executeTerminalPastePlan, planTerminalPaste } from './terminal-paste-coordinator'
 import {
   createDeferredPasteFocusInHandler,
   createDeferredTerminalPasteQueue,
@@ -144,6 +145,46 @@ describe('deferred terminal paste queue', () => {
     )
   })
 
+  // STA-5272 review: Electron leaves `backgroundThrottling` on, so a hidden
+  // renderer's timers are aligned to 1s and, after 5 minutes hidden, to 1-minute
+  // buckets. The deadline timer can therefore still be pending long past 2s while
+  // restoring the window fires focusin first — landing the paste minutes later.
+  // The wall clock, not the timer, has to be what bounds the payload.
+  it('refuses a claim made after the deadline even if the timer has not fired yet', () => {
+    const timers = createTimerHarness()
+    const onExpire = vi.fn()
+    let nowMs = 1_000
+    const queue = createDeferredTerminalPasteQueue({
+      onExpire,
+      now: () => nowMs,
+      ...timers
+    })
+
+    queue.defer(entry())
+    // The window was hidden; the timer is still queued, unfired.
+    nowMs += TERMINAL_DEFERRED_PASTE_TIMEOUT_MS + 1
+    expect(timers.live()).toHaveLength(1)
+
+    expect(queue.claim(1, 'leaf-a')).toBe(null)
+    // and the user is told rather than silently robbed of the paste
+    expect(onExpire).toHaveBeenCalledTimes(1)
+    expect(queue.isPending()).toBe(false)
+    expect(timers.live()).toEqual([])
+  })
+
+  it('still honours a claim made inside the deadline', () => {
+    const timers = createTimerHarness()
+    const onExpire = vi.fn()
+    let nowMs = 1_000
+    const queue = createDeferredTerminalPasteQueue({ onExpire, now: () => nowMs, ...timers })
+
+    queue.defer(entry())
+    nowMs += TERMINAL_DEFERRED_PASTE_TIMEOUT_MS - 1
+
+    expect(queue.claim(1, 'leaf-a')).toEqual(entry())
+    expect(onExpire).not.toHaveBeenCalled()
+  })
+
   it('drops the payload on dispose without firing the expiry signal', () => {
     const timers = createTimerHarness()
     const onExpire = vi.fn()
@@ -162,6 +203,7 @@ describe('isDeferrablePasteFocusCancellation', () => {
   const base = {
     status: 'cancelled' as const,
     reason: 'stale-target' as const,
+    chunksWritten: 0,
     targetMounted: true,
     focusMovedToOtherPane: false
   }
@@ -177,6 +219,16 @@ describe('isDeferrablePasteFocusCancellation', () => {
 
   it('refuses to defer when the target is gone', () => {
     expect(isDeferrablePasteFocusCancellation({ ...base, targetMounted: false })).toBe(false)
+  })
+
+  // Ablation gap: every other case here is already excluded by the reason check,
+  // so the status conjunct needs a reason it would otherwise let through. Today
+  // the executor only pairs 'rejected' with 'payload-too-large' (see
+  // terminal-paste-coordinator planning), so this pins the contract, not a
+  // currently reachable pairing.
+  it('refuses to defer anything that is not a cancellation, whatever the reason says', () => {
+    expect(isDeferrablePasteFocusCancellation({ ...base, status: 'rejected' })).toBe(false)
+    expect(isDeferrablePasteFocusCancellation({ ...base, status: 'pasted' })).toBe(false)
   })
 
   it('refuses to defer non-focus cancellations and rejections', () => {
@@ -408,5 +460,183 @@ describe('deferred paste focusin handler', () => {
 
     expect(scene.deliver).not.toHaveBeenCalled()
     expect(scene.onDropped).not.toHaveBeenCalled()
+  })
+})
+
+// STA-5272 review: `stale-target` is not only a pre-write verdict. The chunked
+// writer re-checks the target between chunks, so a focus move part-way through a
+// large paste cancels with bytes already in the PTY. Deferring that payload and
+// replaying it whole duplicates everything written before the cancel.
+describe('partially written pastes are not deferrable', () => {
+  const chunkedPlan = (text: string) =>
+    planTerminalPaste({
+      text,
+      source: 'keyboard',
+      target: {
+        kind: 'terminal',
+        paneId: 1,
+        leafId: 'leaf-a',
+        ptyId: 'pty-1',
+        runtime: { platform: 'darwin', runtimeKey: 'local:darwin', kind: 'local' }
+      },
+      maxDirectBytes: 4,
+      maxChunkBytes: 8
+    })
+
+  it('premise: the real executor cancels mid-write with bytes already in the pty', async () => {
+    const writes: string[] = []
+    let focusHeld = true
+
+    const execution = await executeTerminalPastePlan(chunkedPlan('abcdefgh12345678zzzzzzzz'), {
+      pasteText: () => {},
+      writePty: (data) => {
+        writes.push(data)
+        return true
+      },
+      // Focus leaves the pane after the first chunk lands, exactly as a
+      // dictation/overlay handoff does mid-paste.
+      isTargetCurrent: () => {
+        if (writes.length >= 1) {
+          focusHeld = false
+        }
+        return focusHeld
+      }
+    })
+
+    expect(execution.status).toBe('cancelled')
+    expect(execution.reason).toBe('stale-target')
+    expect(execution.chunksWritten).toBeGreaterThan(0)
+    expect(writes.join('')).not.toBe('abcdefgh12345678zzzzzzzz')
+  })
+
+  it('refuses to defer a cancellation that already wrote bytes to the pty', () => {
+    expect(
+      isDeferrablePasteFocusCancellation({
+        status: 'cancelled',
+        reason: 'stale-target',
+        chunksWritten: 3,
+        targetMounted: true,
+        focusMovedToOtherPane: false
+      })
+    ).toBe(false)
+  })
+
+  it('still defers a cancellation that wrote nothing', () => {
+    expect(
+      isDeferrablePasteFocusCancellation({
+        status: 'cancelled',
+        reason: 'stale-target',
+        chunksWritten: 0,
+        targetMounted: true,
+        focusMovedToOtherPane: false
+      })
+    ).toBe(true)
+  })
+})
+
+// STA-5272 review: the pane the payload was aimed at can be closed while the
+// payload waits. Nothing may be written anywhere, and the user has to be told
+// now rather than after the full deadline, because the text is still retained.
+describe('a deferred paste whose pane is destroyed before focus returns', () => {
+  const buildScene = (): {
+    panes: { id: number; leafId: string; container: HTMLElement }[]
+    ptyWrites: string[]
+    queue: ReturnType<typeof createDeferredTerminalPasteQueue>
+    handler: () => void
+    onDropped: Mock<(deferred: DeferredTerminalPaste) => void>
+    onExpire: Mock<(deferred: DeferredTerminalPaste) => void>
+    outside: HTMLInputElement
+  } => {
+    document.body.innerHTML = ''
+    const root = document.createElement('div')
+    document.body.append(root)
+    const panes = [0, 1].map((index) => {
+      const container = document.createElement('div')
+      const helper = document.createElement('textarea')
+      helper.className = 'xterm-helper-textarea'
+      container.append(helper)
+      root.append(container)
+      return { id: index + 1, leafId: `leaf-${index}`, container }
+    })
+    const outside = document.createElement('input')
+    document.body.append(outside)
+    const ptyWrites: string[] = []
+    const onExpire = vi.fn<(deferred: DeferredTerminalPaste) => void>()
+    const queue = createDeferredTerminalPasteQueue({ onExpire, ...createTimerHarness() })
+    const onDropped = vi.fn<(deferred: DeferredTerminalPaste) => void>()
+    const handler = createDeferredPasteFocusInHandler({
+      queue,
+      getPanes: () => panes,
+      getFocusedElement: () => document.activeElement,
+      // The only thing delivery does in production is run the paste, which ends
+      // in a PTY write; a spy that records nothing would hide a real write.
+      deliver: (_pane, deferred) => ptyWrites.push(deferred.text),
+      onDropped
+    })
+    return { panes, ptyWrites, queue, handler, onDropped, onExpire, outside }
+  }
+
+  it('drops the payload and tells the user when focus lands outside every pane', () => {
+    const scene = buildScene()
+    scene.queue.defer(entry({ paneId: 1, leafId: 'leaf-0', text: 'secret token' }))
+
+    // The pane is closed: it is gone from the manager and out of the DOM.
+    scene.panes[0]!.container.remove()
+    scene.panes.splice(0, 1)
+    scene.outside.focus()
+    scene.handler()
+
+    expect(scene.ptyWrites).toEqual([])
+    expect(scene.onDropped).toHaveBeenCalledTimes(1)
+    expect(scene.onDropped.mock.calls[0]?.[0]?.text).toBe('secret token')
+    // Retention: the clipboard text is released with the pane, not held to the deadline.
+    expect(scene.queue.isPending()).toBe(false)
+    expect(scene.onExpire).not.toHaveBeenCalled()
+  })
+
+  it('drops the payload and tells the user when focus lands in a surviving sibling', () => {
+    const scene = buildScene()
+    scene.queue.defer(entry({ paneId: 1, leafId: 'leaf-0' }))
+
+    scene.panes[0]!.container.remove()
+    scene.panes.splice(0, 1)
+    ;(scene.panes[0]!.container.firstElementChild as HTMLElement).focus()
+    scene.handler()
+
+    expect(scene.ptyWrites).toEqual([])
+    expect(scene.onDropped).toHaveBeenCalledTimes(1)
+    expect(scene.queue.isPending()).toBe(false)
+  })
+
+  it('leaves the payload alone while the pane manager reports no panes at all', () => {
+    // A transiently empty manager during a re-render is not evidence the target
+    // pane was closed; treating it as one would drop a healthy deferred paste.
+    const scene = buildScene()
+    scene.queue.defer(entry({ paneId: 1, leafId: 'leaf-0' }))
+    const panesSnapshot = [...scene.panes]
+    scene.panes.length = 0
+
+    scene.outside.focus()
+    scene.handler()
+
+    expect(scene.onDropped).not.toHaveBeenCalled()
+    expect(scene.queue.isPending()).toBe(true)
+
+    // and it still lands once the manager reports the pane again
+    scene.panes.push(...panesSnapshot)
+    ;(scene.panes[0]!.container.firstElementChild as HTMLElement).focus()
+    scene.handler()
+    expect(scene.ptyWrites).toEqual(['dictated paragraph'])
+  })
+
+  it('keeps a live pane pending so the destroy check cannot swallow a normal defer', () => {
+    const scene = buildScene()
+    scene.queue.defer(entry({ paneId: 1, leafId: 'leaf-0' }))
+
+    scene.outside.focus()
+    scene.handler()
+
+    expect(scene.onDropped).not.toHaveBeenCalled()
+    expect(scene.queue.isPending()).toBe(true)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-deferred-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-deferred-paste.test.ts
@@ -1,0 +1,412 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, type Mock } from 'vitest'
+
+import {
+  createDeferredPasteFocusInHandler,
+  createDeferredTerminalPasteQueue,
+  isDeferrablePasteFocusCancellation,
+  isFocusInsideOtherPane,
+  resolveDeferredPasteFocusIn,
+  TERMINAL_DEFERRED_PASTE_TIMEOUT_MS,
+  type DeferredTerminalPaste
+} from './terminal-deferred-paste'
+
+type Timer = { id: number; callback: () => void; ms: number }
+
+function createTimerHarness(): {
+  setTimer: (callback: () => void, ms: number) => number
+  clearTimer: (id: number) => void
+  fire: (id?: number) => void
+  live: () => Timer[]
+} {
+  const timers = new Map<number, Timer>()
+  let nextId = 1
+  return {
+    setTimer: (callback, ms) => {
+      const id = nextId
+      nextId += 1
+      timers.set(id, { id, callback, ms })
+      return id
+    },
+    clearTimer: (id) => {
+      timers.delete(id)
+    },
+    fire: (id) => {
+      const timer = id === undefined ? [...timers.values()][0] : timers.get(id)
+      if (!timer) {
+        throw new Error(`no live timer ${id ?? '(first)'}`)
+      }
+      timers.delete(timer.id)
+      timer.callback()
+    },
+    live: () => [...timers.values()]
+  }
+}
+
+const entry = (overrides: Partial<DeferredTerminalPaste> = {}): DeferredTerminalPaste => ({
+  paneId: 1,
+  leafId: 'leaf-a',
+  source: 'keyboard',
+  text: 'dictated paragraph',
+  ...overrides
+})
+
+describe('deferred terminal paste queue', () => {
+  it('hands the payload back to the pane it was aimed at', () => {
+    const timers = createTimerHarness()
+    const onExpire = vi.fn()
+    const queue = createDeferredTerminalPasteQueue({ onExpire, ...timers })
+
+    queue.defer(entry())
+
+    expect(queue.isPending()).toBe(true)
+    expect(queue.claim(1, 'leaf-a')).toEqual(entry())
+    expect(queue.isPending()).toBe(false)
+    // The deadline must be disarmed by the claim, not left to fire later.
+    expect(timers.live()).toEqual([])
+    expect(onExpire).not.toHaveBeenCalled()
+  })
+
+  it('refuses to hand the payload to a different pane or leaf', () => {
+    const timers = createTimerHarness()
+    const queue = createDeferredTerminalPasteQueue({ onExpire: vi.fn(), ...timers })
+
+    queue.defer(entry())
+
+    expect(queue.claim(2, 'leaf-a')).toBe(null)
+    expect(queue.claim(1, 'leaf-b')).toBe(null)
+    expect(queue.isPending()).toBe(true)
+  })
+
+  it('drops the payload and signals the user when focus never comes back', () => {
+    const timers = createTimerHarness()
+    const onExpire = vi.fn()
+    const queue = createDeferredTerminalPasteQueue({ onExpire, ...timers })
+
+    queue.defer(entry())
+    expect(timers.live()[0]?.ms).toBe(TERMINAL_DEFERRED_PASTE_TIMEOUT_MS)
+
+    timers.fire()
+
+    expect(onExpire).toHaveBeenCalledTimes(1)
+    expect(onExpire).toHaveBeenCalledWith(entry())
+    // Bounded: the clipboard text is not retained past the deadline, and a late
+    // focus return cannot make it land.
+    expect(queue.isPending()).toBe(false)
+    expect(queue.claim(1, 'leaf-a')).toBe(null)
+  })
+
+  it('does not retain the payload when the expiry notifier throws', () => {
+    const timers = createTimerHarness()
+    const queue = createDeferredTerminalPasteQueue({
+      onExpire: () => {
+        throw new Error('toast surface gone')
+      },
+      ...timers
+    })
+
+    queue.defer(entry())
+    expect(() => timers.fire()).toThrow('toast surface gone')
+
+    expect(queue.isPending()).toBe(false)
+    expect(queue.claim(1, 'leaf-a')).toBe(null)
+  })
+
+  it('lets a newer paste supersede the pending one without a stray expiry', () => {
+    const timers = createTimerHarness()
+    const onExpire = vi.fn()
+    const queue = createDeferredTerminalPasteQueue({ onExpire, ...timers })
+
+    queue.defer(entry({ text: 'first' }))
+    queue.defer(entry({ text: 'second' }))
+
+    expect(timers.live()).toHaveLength(1)
+    timers.fire()
+    expect(onExpire).toHaveBeenCalledTimes(1)
+    expect(onExpire).toHaveBeenCalledWith(entry({ text: 'second' }))
+  })
+
+  it('carries a payload larger than the 1024-byte typed-command cap intact', () => {
+    const timers = createTimerHarness()
+    const queue = createDeferredTerminalPasteQueue({ onExpire: vi.fn(), ...timers })
+    // Line-bounded so the payload is never at the mercy of a TTY MAX_CANON limit.
+    const large = Array.from({ length: 40 }, (_, index) => `line-${index}-${'x'.repeat(60)}`).join(
+      '\n'
+    )
+    expect(new TextEncoder().encode(large).byteLength).toBeGreaterThan(1024)
+
+    queue.defer(entry({ text: large }))
+    const claimed = queue.claim(1, 'leaf-a')
+
+    expect(claimed?.text).toBe(large)
+    expect(new TextEncoder().encode(claimed?.text ?? '').byteLength).toBe(
+      new TextEncoder().encode(large).byteLength
+    )
+  })
+
+  it('drops the payload on dispose without firing the expiry signal', () => {
+    const timers = createTimerHarness()
+    const onExpire = vi.fn()
+    const queue = createDeferredTerminalPasteQueue({ onExpire, ...timers })
+
+    queue.defer(entry())
+    queue.dispose()
+
+    expect(queue.isPending()).toBe(false)
+    expect(timers.live()).toEqual([])
+    expect(onExpire).not.toHaveBeenCalled()
+  })
+})
+
+describe('isDeferrablePasteFocusCancellation', () => {
+  const base = {
+    status: 'cancelled' as const,
+    reason: 'stale-target' as const,
+    targetMounted: true,
+    focusMovedToOtherPane: false
+  }
+
+  it('defers only a focus-loss cancellation whose pane is still the live target', () => {
+    expect(isDeferrablePasteFocusCancellation(base)).toBe(true)
+  })
+
+  it('refuses to defer when focus moved to a different pane', () => {
+    // The wrong-target case the guard actually exists for.
+    expect(isDeferrablePasteFocusCancellation({ ...base, focusMovedToOtherPane: true })).toBe(false)
+  })
+
+  it('refuses to defer when the target is gone', () => {
+    expect(isDeferrablePasteFocusCancellation({ ...base, targetMounted: false })).toBe(false)
+  })
+
+  it('refuses to defer non-focus cancellations and rejections', () => {
+    expect(isDeferrablePasteFocusCancellation({ ...base, reason: 'target-disconnected' })).toBe(
+      false
+    )
+    expect(isDeferrablePasteFocusCancellation({ ...base, reason: 'operation-timeout' })).toBe(false)
+    expect(isDeferrablePasteFocusCancellation({ ...base, reason: undefined })).toBe(false)
+    expect(
+      isDeferrablePasteFocusCancellation({
+        ...base,
+        status: 'rejected',
+        reason: 'payload-too-large'
+      })
+    ).toBe(false)
+  })
+})
+
+describe('deferred paste focus resolution', () => {
+  const buildPanes = (): {
+    panes: { id: number; leafId: string; container: HTMLElement }[]
+    focusable: (paneIndex: number) => HTMLElement
+  } => {
+    const root = document.createElement('div')
+    document.body.append(root)
+    const panes = [0, 1].map((index) => {
+      const container = document.createElement('div')
+      const helper = document.createElement('textarea')
+      helper.className = 'xterm-helper-textarea'
+      container.append(helper)
+      root.append(container)
+      return { id: index + 1, leafId: `leaf-${index}`, container }
+    })
+    return {
+      panes,
+      focusable: (paneIndex) => panes[paneIndex]!.container.firstElementChild as HTMLElement
+    }
+  }
+
+  it('delivers the payload when focus returns to its own pane', () => {
+    const { panes, focusable } = buildPanes()
+    const queue = createDeferredTerminalPasteQueue({ onExpire: vi.fn(), ...createTimerHarness() })
+    queue.defer(entry({ paneId: 1, leafId: 'leaf-0' }))
+
+    const resolution = resolveDeferredPasteFocusIn({
+      panes,
+      focusedElement: focusable(0),
+      queue
+    })
+
+    expect(resolution.action).toBe('deliver')
+    expect(resolution.action === 'deliver' && resolution.entry.text).toBe('dictated paragraph')
+    expect(queue.isPending()).toBe(false)
+  })
+
+  it('drops the payload when focus lands in a different pane', () => {
+    const { panes, focusable } = buildPanes()
+    const queue = createDeferredTerminalPasteQueue({ onExpire: vi.fn(), ...createTimerHarness() })
+    queue.defer(entry({ paneId: 1, leafId: 'leaf-0' }))
+
+    const resolution = resolveDeferredPasteFocusIn({
+      panes,
+      focusedElement: focusable(1),
+      queue
+    })
+
+    expect(resolution.action).toBe('drop')
+    expect(resolution.action === 'drop' && resolution.entry?.text).toBe('dictated paragraph')
+    expect(queue.isPending()).toBe(false)
+  })
+
+  it('ignores focus that lands outside every pane', () => {
+    const { panes } = buildPanes()
+    const outside = document.createElement('input')
+    document.body.append(outside)
+    const queue = createDeferredTerminalPasteQueue({ onExpire: vi.fn(), ...createTimerHarness() })
+    queue.defer(entry({ paneId: 1, leafId: 'leaf-0' }))
+
+    expect(resolveDeferredPasteFocusIn({ panes, focusedElement: outside, queue }).action).toBe(
+      'ignore'
+    )
+    expect(queue.isPending()).toBe(true)
+  })
+
+  it('ignores focus movement when nothing is deferred', () => {
+    const { panes, focusable } = buildPanes()
+    const queue = createDeferredTerminalPasteQueue({ onExpire: vi.fn(), ...createTimerHarness() })
+
+    expect(resolveDeferredPasteFocusIn({ panes, focusedElement: focusable(0), queue }).action).toBe(
+      'ignore'
+    )
+  })
+})
+
+describe('isFocusInsideOtherPane', () => {
+  it('separates the paste target from its split siblings', () => {
+    const root = document.createElement('div')
+    document.body.append(root)
+    const own = document.createElement('div')
+    const sibling = document.createElement('div')
+    const ownChild = document.createElement('textarea')
+    const siblingChild = document.createElement('textarea')
+    own.append(ownChild)
+    sibling.append(siblingChild)
+    root.append(own, sibling)
+    const panes = [
+      { id: 1, leafId: 'leaf-0', container: own },
+      { id: 2, leafId: 'leaf-1', container: sibling }
+    ]
+
+    expect(isFocusInsideOtherPane({ panes, paneId: 1, focusedElement: ownChild })).toBe(false)
+    expect(isFocusInsideOtherPane({ panes, paneId: 1, focusedElement: siblingChild })).toBe(true)
+    expect(isFocusInsideOtherPane({ panes, paneId: 1, focusedElement: document.body })).toBe(false)
+    expect(isFocusInsideOtherPane({ panes, paneId: 1, focusedElement: null })).toBe(false)
+  })
+})
+
+// The pane's real focusin handler, driven by real DOM focus moves.
+describe('deferred paste focusin handler', () => {
+  const buildScene = (): {
+    handler: () => void
+    queue: ReturnType<typeof createDeferredTerminalPasteQueue>
+    deliver: Mock<(pane: { id: number }, deferred: DeferredTerminalPaste) => void>
+    onDropped: Mock<(deferred: DeferredTerminalPaste) => void>
+    onExpire: Mock<(deferred: DeferredTerminalPaste) => void>
+    timers: ReturnType<typeof createTimerHarness>
+    focusables: HTMLElement[]
+    root: HTMLElement
+  } => {
+    document.body.innerHTML = ''
+    const root = document.createElement('div')
+    document.body.append(root)
+    const panes = [0, 1].map((index) => {
+      const container = document.createElement('div')
+      const helper = document.createElement('textarea')
+      helper.className = 'xterm-helper-textarea'
+      container.append(helper)
+      root.append(container)
+      return { id: index + 1, leafId: `leaf-${index}`, container }
+    })
+    const timers = createTimerHarness()
+    const onExpire = vi.fn<(deferred: DeferredTerminalPaste) => void>()
+    const queue = createDeferredTerminalPasteQueue({ onExpire, ...timers })
+    const deliver = vi.fn<(pane: { id: number }, deferred: DeferredTerminalPaste) => void>()
+    const onDropped = vi.fn<(deferred: DeferredTerminalPaste) => void>()
+    const handler = createDeferredPasteFocusInHandler({
+      queue,
+      getPanes: () => panes,
+      getFocusedElement: () => document.activeElement,
+      deliver,
+      onDropped
+    })
+    root.addEventListener('focusin', handler)
+    return {
+      handler,
+      queue,
+      deliver,
+      onDropped,
+      onExpire,
+      timers,
+      focusables: panes.map((pane) => pane.container.firstElementChild as HTMLElement),
+      root
+    }
+  }
+
+  it('lands the deferred payload when focus returns to the pane', () => {
+    const scene = buildScene()
+    scene.queue.defer(entry({ paneId: 1, leafId: 'leaf-0', text: 'a dictated paragraph' }))
+
+    scene.focusables[0]!.focus()
+
+    expect(scene.deliver).toHaveBeenCalledTimes(1)
+    expect(scene.deliver.mock.calls[0]?.[0]?.id).toBe(1)
+    expect(scene.deliver.mock.calls[0]?.[1]?.text).toBe('a dictated paragraph')
+    expect(scene.onDropped).not.toHaveBeenCalled()
+    expect(scene.queue.isPending()).toBe(false)
+    expect(scene.timers.live()).toEqual([])
+  })
+
+  it('lands a payload larger than the 1024-byte typed-command cap without truncating it', () => {
+    const scene = buildScene()
+    const large = Array.from({ length: 40 }, (_, index) => `line-${index}-${'x'.repeat(60)}`).join(
+      '\n'
+    )
+    expect(new TextEncoder().encode(large).byteLength).toBeGreaterThan(1024)
+    scene.queue.defer(entry({ paneId: 1, leafId: 'leaf-0', text: large }))
+
+    scene.focusables[0]!.focus()
+
+    expect(scene.deliver.mock.calls[0]?.[1]?.text).toBe(large)
+  })
+
+  it('drops the payload with a signal when a different pane takes focus', () => {
+    const scene = buildScene()
+    scene.queue.defer(entry({ paneId: 1, leafId: 'leaf-0' }))
+
+    scene.focusables[1]!.focus()
+
+    expect(scene.deliver).not.toHaveBeenCalled()
+    expect(scene.onDropped).toHaveBeenCalledTimes(1)
+    expect(scene.queue.isPending()).toBe(false)
+  })
+
+  it('keeps the payload pending while focus has not come back yet, then expires it', () => {
+    const scene = buildScene()
+    scene.queue.defer(entry({ paneId: 1, leafId: 'leaf-0' }))
+    const outside = document.createElement('input')
+    document.body.append(outside)
+
+    outside.focus()
+
+    expect(scene.deliver).not.toHaveBeenCalled()
+    expect(scene.onDropped).not.toHaveBeenCalled()
+    expect(scene.queue.isPending()).toBe(true)
+
+    scene.timers.fire()
+
+    expect(scene.onExpire).toHaveBeenCalledTimes(1)
+    // Bounded: focus coming back after the deadline must not fire a surprise paste.
+    scene.focusables[0]!.focus()
+    expect(scene.deliver).not.toHaveBeenCalled()
+  })
+
+  it('does nothing on ordinary focus moves when no paste is deferred', () => {
+    const scene = buildScene()
+
+    scene.focusables[0]!.focus()
+    scene.focusables[1]!.focus()
+
+    expect(scene.deliver).not.toHaveBeenCalled()
+    expect(scene.onDropped).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-deferred-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-deferred-paste.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi, type Mock } from 'vitest'
 
 import { executeTerminalPastePlan, planTerminalPaste } from './terminal-paste-coordinator'
+import type { TerminalPasteExecutionResult } from './terminal-paste-model'
 import {
   createDeferredPasteFocusInHandler,
   createDeferredTerminalPasteQueue,
@@ -9,7 +10,8 @@ import {
   isFocusInsideOtherPane,
   resolveDeferredPasteFocusIn,
   TERMINAL_DEFERRED_PASTE_TIMEOUT_MS,
-  type DeferredTerminalPaste
+  type DeferredTerminalPaste,
+  type DeferredTerminalPasteDropCause
 } from './terminal-deferred-paste'
 
 type Timer = { id: number; callback: () => void; ms: number }
@@ -172,6 +174,38 @@ describe('deferred terminal paste queue', () => {
     expect(timers.live()).toEqual([])
   })
 
+  // The deadline is read at three entry points; `claim` is only one of them. A
+  // throttled timer means an expired payload must not answer as pending to any of
+  // them, or the focusin path resolves against a target it can no longer deliver to.
+  it('reports nothing pending once the deadline passes, timer fired or not', () => {
+    const timers = createTimerHarness()
+    const onExpire = vi.fn()
+    let nowMs = 1_000
+    const queue = createDeferredTerminalPasteQueue({ onExpire, now: () => nowMs, ...timers })
+
+    queue.defer(entry())
+    expect(queue.pendingTarget()).toEqual({ paneId: 1, leafId: 'leaf-a' })
+    nowMs += TERMINAL_DEFERRED_PASTE_TIMEOUT_MS + 1
+
+    expect(queue.pendingTarget()).toBe(null)
+    expect(onExpire).toHaveBeenCalledTimes(1)
+    expect(timers.live()).toEqual([])
+  })
+
+  it('reports not-pending on the deadline even when nothing claims it', () => {
+    const timers = createTimerHarness()
+    const onExpire = vi.fn()
+    let nowMs = 1_000
+    const queue = createDeferredTerminalPasteQueue({ onExpire, now: () => nowMs, ...timers })
+
+    queue.defer(entry())
+    expect(queue.isPending()).toBe(true)
+    nowMs += TERMINAL_DEFERRED_PASTE_TIMEOUT_MS
+
+    expect(queue.isPending()).toBe(false)
+    expect(onExpire).toHaveBeenCalledTimes(1)
+  })
+
   it('still honours a claim made inside the deadline', () => {
     const timers = createTimerHarness()
     const onExpire = vi.fn()
@@ -199,11 +233,22 @@ describe('deferred terminal paste queue', () => {
   })
 })
 
+// The executor's own result goes in whole: a caller that could spread three fields
+// out of it could pass a literal `chunksWritten: 0` over a partial write.
+const executionResult = (
+  overrides: Partial<TerminalPasteExecutionResult> = {}
+): TerminalPasteExecutionResult => ({
+  status: 'cancelled',
+  reason: 'stale-target',
+  chunksWritten: 0,
+  diagnostic: 'paste cancelled',
+  durationMs: 3,
+  ...overrides
+})
+
 describe('isDeferrablePasteFocusCancellation', () => {
   const base = {
-    status: 'cancelled' as const,
-    reason: 'stale-target' as const,
-    chunksWritten: 0,
+    execution: executionResult(),
     targetMounted: true,
     focusMovedToOtherPane: false
   }
@@ -227,21 +272,43 @@ describe('isDeferrablePasteFocusCancellation', () => {
   // terminal-paste-coordinator planning), so this pins the contract, not a
   // currently reachable pairing.
   it('refuses to defer anything that is not a cancellation, whatever the reason says', () => {
-    expect(isDeferrablePasteFocusCancellation({ ...base, status: 'rejected' })).toBe(false)
-    expect(isDeferrablePasteFocusCancellation({ ...base, status: 'pasted' })).toBe(false)
-  })
-
-  it('refuses to defer non-focus cancellations and rejections', () => {
-    expect(isDeferrablePasteFocusCancellation({ ...base, reason: 'target-disconnected' })).toBe(
-      false
-    )
-    expect(isDeferrablePasteFocusCancellation({ ...base, reason: 'operation-timeout' })).toBe(false)
-    expect(isDeferrablePasteFocusCancellation({ ...base, reason: undefined })).toBe(false)
     expect(
       isDeferrablePasteFocusCancellation({
         ...base,
-        status: 'rejected',
-        reason: 'payload-too-large'
+        execution: executionResult({ status: 'rejected' })
+      })
+    ).toBe(false)
+    expect(
+      isDeferrablePasteFocusCancellation({
+        ...base,
+        execution: executionResult({ status: 'pasted' })
+      })
+    ).toBe(false)
+  })
+
+  it('refuses to defer non-focus cancellations and rejections', () => {
+    expect(
+      isDeferrablePasteFocusCancellation({
+        ...base,
+        execution: executionResult({ reason: 'target-disconnected' })
+      })
+    ).toBe(false)
+    expect(
+      isDeferrablePasteFocusCancellation({
+        ...base,
+        execution: executionResult({ reason: 'operation-timeout' })
+      })
+    ).toBe(false)
+    expect(
+      isDeferrablePasteFocusCancellation({
+        ...base,
+        execution: executionResult({ reason: undefined })
+      })
+    ).toBe(false)
+    expect(
+      isDeferrablePasteFocusCancellation({
+        ...base,
+        execution: executionResult({ status: 'rejected', reason: 'payload-too-large' })
       })
     ).toBe(false)
   })
@@ -296,6 +363,7 @@ describe('deferred paste focus resolution', () => {
     })
 
     expect(resolution.action).toBe('drop')
+    expect(resolution.action === 'drop' && resolution.cause).toBe('focus-moved-to-other-pane')
     expect(resolution.action === 'drop' && resolution.entry?.text).toBe('dictated paragraph')
     expect(queue.isPending()).toBe(false)
   })
@@ -352,7 +420,9 @@ describe('deferred paste focusin handler', () => {
     handler: () => void
     queue: ReturnType<typeof createDeferredTerminalPasteQueue>
     deliver: Mock<(pane: { id: number }, deferred: DeferredTerminalPaste) => void>
-    onDropped: Mock<(deferred: DeferredTerminalPaste) => void>
+    onDropped: Mock<
+      (deferred: DeferredTerminalPaste, cause: DeferredTerminalPasteDropCause) => void
+    >
     onExpire: Mock<(deferred: DeferredTerminalPaste) => void>
     timers: ReturnType<typeof createTimerHarness>
     focusables: HTMLElement[]
@@ -373,7 +443,8 @@ describe('deferred paste focusin handler', () => {
     const onExpire = vi.fn<(deferred: DeferredTerminalPaste) => void>()
     const queue = createDeferredTerminalPasteQueue({ onExpire, ...timers })
     const deliver = vi.fn<(pane: { id: number }, deferred: DeferredTerminalPaste) => void>()
-    const onDropped = vi.fn<(deferred: DeferredTerminalPaste) => void>()
+    const onDropped =
+      vi.fn<(deferred: DeferredTerminalPaste, cause: DeferredTerminalPasteDropCause) => void>()
     const handler = createDeferredPasteFocusInHandler({
       queue,
       getPanes: () => panes,
@@ -429,6 +500,7 @@ describe('deferred paste focusin handler', () => {
 
     expect(scene.deliver).not.toHaveBeenCalled()
     expect(scene.onDropped).toHaveBeenCalledTimes(1)
+    expect(scene.onDropped.mock.calls[0]?.[1]).toBe('focus-moved-to-other-pane')
     expect(scene.queue.isPending()).toBe(false)
   })
 
@@ -509,24 +581,47 @@ describe('partially written pastes are not deferrable', () => {
     expect(writes.join('')).not.toBe('abcdefgh12345678zzzzzzzz')
   })
 
-  it('refuses to defer a cancellation that already wrote bytes to the pty', () => {
+  // End to end on the real executor: the verdict is taken from the result object
+  // the executor actually produced, never from fields re-stated by the caller.
+  it('refuses to defer the real executor result of a partially written paste', async () => {
+    const writes: string[] = []
+    let focusHeld = true
+    const execution = await executeTerminalPastePlan(chunkedPlan('abcdefgh12345678zzzzzzzz'), {
+      pasteText: () => {},
+      writePty: (data) => {
+        writes.push(data)
+        return true
+      },
+      isTargetCurrent: () => {
+        if (writes.length >= 1) {
+          focusHeld = false
+        }
+        return focusHeld
+      }
+    })
+
     expect(
       isDeferrablePasteFocusCancellation({
-        status: 'cancelled',
-        reason: 'stale-target',
-        chunksWritten: 3,
+        execution,
         targetMounted: true,
         focusMovedToOtherPane: false
       })
     ).toBe(false)
   })
 
-  it('still defers a cancellation that wrote nothing', () => {
+  it('still defers the real executor result of a paste cancelled before any write', async () => {
+    const execution = await executeTerminalPastePlan(chunkedPlan('abcdefgh12345678zzzzzzzz'), {
+      pasteText: () => {},
+      writePty: () => {
+        throw new Error('nothing may be written')
+      },
+      isTargetCurrent: () => false
+    })
+
+    expect(execution.chunksWritten).toBe(0)
     expect(
       isDeferrablePasteFocusCancellation({
-        status: 'cancelled',
-        reason: 'stale-target',
-        chunksWritten: 0,
+        execution,
         targetMounted: true,
         focusMovedToOtherPane: false
       })
@@ -543,7 +638,9 @@ describe('a deferred paste whose pane is destroyed before focus returns', () => 
     ptyWrites: string[]
     queue: ReturnType<typeof createDeferredTerminalPasteQueue>
     handler: () => void
-    onDropped: Mock<(deferred: DeferredTerminalPaste) => void>
+    onDropped: Mock<
+      (deferred: DeferredTerminalPaste, cause: DeferredTerminalPasteDropCause) => void
+    >
     onExpire: Mock<(deferred: DeferredTerminalPaste) => void>
     outside: HTMLInputElement
   } => {
@@ -563,7 +660,8 @@ describe('a deferred paste whose pane is destroyed before focus returns', () => 
     const ptyWrites: string[] = []
     const onExpire = vi.fn<(deferred: DeferredTerminalPaste) => void>()
     const queue = createDeferredTerminalPasteQueue({ onExpire, ...createTimerHarness() })
-    const onDropped = vi.fn<(deferred: DeferredTerminalPaste) => void>()
+    const onDropped =
+      vi.fn<(deferred: DeferredTerminalPaste, cause: DeferredTerminalPasteDropCause) => void>()
     const handler = createDeferredPasteFocusInHandler({
       queue,
       getPanes: () => panes,
@@ -589,6 +687,8 @@ describe('a deferred paste whose pane is destroyed before focus returns', () => 
     expect(scene.ptyWrites).toEqual([])
     expect(scene.onDropped).toHaveBeenCalledTimes(1)
     expect(scene.onDropped.mock.calls[0]?.[0]?.text).toBe('secret token')
+    // Not the deadline copy: this pane was closed, and the toast has to say so.
+    expect(scene.onDropped.mock.calls[0]?.[1]).toBe('target-pane-closed')
     // Retention: the clipboard text is released with the pane, not held to the deadline.
     expect(scene.queue.isPending()).toBe(false)
     expect(scene.onExpire).not.toHaveBeenCalled()
@@ -605,6 +705,7 @@ describe('a deferred paste whose pane is destroyed before focus returns', () => 
 
     expect(scene.ptyWrites).toEqual([])
     expect(scene.onDropped).toHaveBeenCalledTimes(1)
+    expect(scene.onDropped.mock.calls[0]?.[1]).toBe('target-pane-closed')
     expect(scene.queue.isPending()).toBe(false)
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-deferred-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-deferred-paste.ts
@@ -25,6 +25,9 @@ export type DeferredTerminalPasteQueue = {
   /** Drops the payload without firing the expiry callback; returns what was dropped. */
   cancel: () => DeferredTerminalPaste | null
   isPending: () => boolean
+  /** Identity of the pending payload, never its text, so callers can check the
+   *  target is still alive without a second copy of the clipboard escaping. */
+  pendingTarget: () => { paneId: number; leafId: string } | null
   dispose: () => void
 }
 
@@ -33,16 +36,19 @@ type CreateDeferredTerminalPasteQueueArgs = {
   timeoutMs?: number
   setTimer?: (callback: () => void, ms: number) => number
   clearTimer?: (timerId: number) => void
+  now?: () => number
 }
 
 export function createDeferredTerminalPasteQueue({
   onExpire,
   timeoutMs = TERMINAL_DEFERRED_PASTE_TIMEOUT_MS,
   setTimer = (callback, ms) => window.setTimeout(callback, ms),
-  clearTimer = (timerId) => window.clearTimeout(timerId)
+  clearTimer = (timerId) => window.clearTimeout(timerId),
+  now = () => Date.now()
 }: CreateDeferredTerminalPasteQueueArgs): DeferredTerminalPasteQueue {
   let pending: DeferredTerminalPaste | null = null
   let timerId: number | null = null
+  let deadlineAtMs = 0
 
   const take = (): DeferredTerminalPaste | null => {
     const taken = pending
@@ -54,10 +60,25 @@ export function createDeferredTerminalPasteQueue({
     return taken
   }
 
+  // Why: Electron leaves backgroundThrottling on, so a hidden renderer's timers
+  // are aligned into 1s (then 1-minute) buckets. The wall clock is what bounds
+  // the payload; the timer is only how the user gets told promptly.
+  const releaseIfExpired = (): boolean => {
+    if (!pending || now() < deadlineAtMs) {
+      return false
+    }
+    const expired = take()
+    if (expired) {
+      onExpire(expired)
+    }
+    return true
+  }
+
   return {
     defer: (entry) => {
       take()
       pending = entry
+      deadlineAtMs = now() + timeoutMs
       timerId = setTimer(() => {
         timerId = null
         // Why: release the clipboard text before notifying, so a throwing
@@ -70,13 +91,23 @@ export function createDeferredTerminalPasteQueue({
       }, timeoutMs)
     },
     claim: (paneId, leafId) => {
+      if (releaseIfExpired()) {
+        return null
+      }
       if (!pending || pending.paneId !== paneId || pending.leafId !== leafId) {
         return null
       }
       return take()
     },
     cancel: () => take(),
-    isPending: () => pending !== null,
+    isPending: () => {
+      releaseIfExpired()
+      return pending !== null
+    },
+    pendingTarget: () => {
+      releaseIfExpired()
+      return pending ? { paneId: pending.paneId, leafId: pending.leafId } : null
+    },
     dispose: () => {
       take()
     }
@@ -84,20 +115,29 @@ export function createDeferredTerminalPasteQueue({
 }
 
 /** A paste the focus guard stopped is only deferrable while its pane is still the
- *  live target and no other pane has taken focus — the case the guard exists for. */
+ *  live target and no other pane has taken focus — the case the guard exists for.
+ *  `chunksWritten` is load-bearing: the chunked writer re-checks focus between
+ *  chunks, so a cancel can arrive with bytes already in the PTY, and redelivering
+ *  the whole payload would duplicate everything written before the cancel. */
 export function isDeferrablePasteFocusCancellation({
   status,
   reason,
+  chunksWritten,
   targetMounted,
   focusMovedToOtherPane
 }: {
   status: TerminalPasteExecutionResult['status']
   reason: TerminalPasteExecutionReason | undefined
+  chunksWritten: number
   targetMounted: boolean
   focusMovedToOtherPane: boolean
 }): boolean {
   return (
-    status === 'cancelled' && reason === 'stale-target' && targetMounted && !focusMovedToOtherPane
+    status === 'cancelled' &&
+    reason === 'stale-target' &&
+    chunksWritten === 0 &&
+    targetMounted &&
+    !focusMovedToOtherPane
   )
 }
 
@@ -110,7 +150,7 @@ type DeferredPasteFocusPane = {
 export type DeferredPasteFocusResolution<TPane extends DeferredPasteFocusPane> =
   | { action: 'ignore' }
   | { action: 'deliver'; pane: TPane; entry: DeferredTerminalPaste }
-  | { action: 'drop'; pane: TPane; entry: DeferredTerminalPaste | null }
+  | { action: 'drop'; pane: TPane | null; entry: DeferredTerminalPaste | null }
 
 /** Focus landing back inside the deferred pane delivers it; focus landing in a
  *  different pane drops it, because that is the wrong-target case the guard protects. */
@@ -123,10 +163,20 @@ export function resolveDeferredPasteFocusIn<TPane extends DeferredPasteFocusPane
   focusedElement: Node | null
   queue: DeferredTerminalPasteQueue
 }): DeferredPasteFocusResolution<TPane> {
-  if (!queue.isPending() || !focusedElement) {
+  const target = queue.pendingTarget()
+  if (!target || !focusedElement) {
     return { action: 'ignore' }
   }
   const pane = panes.find((candidate) => candidate.container.contains(focusedElement))
+  // Why: the target pane was closed while the payload waited. Release the
+  // clipboard text now rather than retaining it for a pane that cannot receive
+  // it; `panes.length` guards a transiently empty manager during a re-render.
+  const targetGone =
+    panes.length > 0 &&
+    !panes.some((candidate) => candidate.id === target.paneId && candidate.leafId === target.leafId)
+  if (targetGone) {
+    return { action: 'drop', pane: pane ?? null, entry: queue.cancel() }
+  }
   if (!pane) {
     return { action: 'ignore' }
   }

--- a/src/renderer/src/components/terminal-pane/terminal-deferred-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-deferred-paste.ts
@@ -1,5 +1,4 @@
 import type {
-  TerminalPasteExecutionReason,
   TerminalPasteExecutionResult,
   TerminalPasteSource,
   TerminalPasteTextOptions
@@ -118,24 +117,24 @@ export function createDeferredTerminalPasteQueue({
  *  live target and no other pane has taken focus — the case the guard exists for.
  *  `chunksWritten` is load-bearing: the chunked writer re-checks focus between
  *  chunks, so a cancel can arrive with bytes already in the PTY, and redelivering
- *  the whole payload would duplicate everything written before the cancel. */
+ *  the whole payload would duplicate everything written before the cancel.
+ *  Why the whole `execution` rather than its three fields: a caller that spreads
+ *  them can quietly pass a literal `chunksWritten: 0` and reinstate the duplicate,
+ *  and no unit test of this function would notice. Taking the executor's own
+ *  result leaves the call site nothing to substitute. */
 export function isDeferrablePasteFocusCancellation({
-  status,
-  reason,
-  chunksWritten,
+  execution,
   targetMounted,
   focusMovedToOtherPane
 }: {
-  status: TerminalPasteExecutionResult['status']
-  reason: TerminalPasteExecutionReason | undefined
-  chunksWritten: number
+  execution: TerminalPasteExecutionResult
   targetMounted: boolean
   focusMovedToOtherPane: boolean
 }): boolean {
   return (
-    status === 'cancelled' &&
-    reason === 'stale-target' &&
-    chunksWritten === 0 &&
+    execution.status === 'cancelled' &&
+    execution.reason === 'stale-target' &&
+    execution.chunksWritten === 0 &&
     targetMounted &&
     !focusMovedToOtherPane
   )
@@ -147,10 +146,23 @@ type DeferredPasteFocusPane = {
   container: { contains: (node: Node | null) => boolean }
 }
 
+/** Why named rather than a single "dropped" signal: the deadline, a closed pane,
+ *  and focus landing in a sibling are three different things to tell the user, and
+ *  the timeout copy is wrong for the other two. */
+export type DeferredTerminalPasteDropCause =
+  | 'deadline-passed'
+  | 'target-pane-closed'
+  | 'focus-moved-to-other-pane'
+
 export type DeferredPasteFocusResolution<TPane extends DeferredPasteFocusPane> =
   | { action: 'ignore' }
   | { action: 'deliver'; pane: TPane; entry: DeferredTerminalPaste }
-  | { action: 'drop'; pane: TPane | null; entry: DeferredTerminalPaste | null }
+  | {
+      action: 'drop'
+      cause: Exclude<DeferredTerminalPasteDropCause, 'deadline-passed'>
+      pane: TPane | null
+      entry: DeferredTerminalPaste | null
+    }
 
 /** Focus landing back inside the deferred pane delivers it; focus landing in a
  *  different pane drops it, because that is the wrong-target case the guard protects. */
@@ -175,7 +187,12 @@ export function resolveDeferredPasteFocusIn<TPane extends DeferredPasteFocusPane
     panes.length > 0 &&
     !panes.some((candidate) => candidate.id === target.paneId && candidate.leafId === target.leafId)
   if (targetGone) {
-    return { action: 'drop', pane: pane ?? null, entry: queue.cancel() }
+    return {
+      action: 'drop',
+      cause: 'target-pane-closed',
+      pane: pane ?? null,
+      entry: queue.cancel()
+    }
   }
   if (!pane) {
     return { action: 'ignore' }
@@ -184,7 +201,7 @@ export function resolveDeferredPasteFocusIn<TPane extends DeferredPasteFocusPane
   if (entry) {
     return { action: 'deliver', pane, entry }
   }
-  return { action: 'drop', pane, entry: queue.cancel() }
+  return { action: 'drop', cause: 'focus-moved-to-other-pane', pane, entry: queue.cancel() }
 }
 
 /** True when focus currently sits in a pane other than the paste's own target. */
@@ -218,7 +235,10 @@ export function createDeferredPasteFocusInHandler<TPane extends DeferredPasteFoc
   getPanes: () => readonly TPane[]
   getFocusedElement: () => Node | null
   deliver: (pane: TPane, entry: DeferredTerminalPaste) => void
-  onDropped: (entry: DeferredTerminalPaste) => void
+  onDropped: (
+    entry: DeferredTerminalPaste,
+    cause: Exclude<DeferredTerminalPasteDropCause, 'deadline-passed'>
+  ) => void
 }): () => void {
   return () => {
     const resolution = resolveDeferredPasteFocusIn({
@@ -231,7 +251,7 @@ export function createDeferredPasteFocusInHandler<TPane extends DeferredPasteFoc
       return
     }
     if (resolution.action === 'drop' && resolution.entry) {
-      onDropped(resolution.entry)
+      onDropped(resolution.entry, resolution.cause)
     }
   }
 }

--- a/src/renderer/src/components/terminal-pane/terminal-deferred-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-deferred-paste.ts
@@ -1,0 +1,187 @@
+import type {
+  TerminalPasteExecutionReason,
+  TerminalPasteExecutionResult,
+  TerminalPasteSource,
+  TerminalPasteTextOptions
+} from './terminal-paste-model'
+
+/** Long enough for a dictation/IME/clipboard-manager overlay to hand focus back,
+ *  short enough that the payload can never land in a surprising place later. */
+export const TERMINAL_DEFERRED_PASTE_TIMEOUT_MS = 2_000
+
+export type DeferredTerminalPaste = {
+  paneId: number
+  leafId: string
+  source: TerminalPasteSource
+  text: string
+  options?: TerminalPasteTextOptions
+}
+
+export type DeferredTerminalPasteQueue = {
+  /** Holds one payload; a second defer replaces the first and restarts the deadline. */
+  defer: (entry: DeferredTerminalPaste) => void
+  /** Returns and clears the payload only when it belongs to this pane. */
+  claim: (paneId: number, leafId: string) => DeferredTerminalPaste | null
+  /** Drops the payload without firing the expiry callback; returns what was dropped. */
+  cancel: () => DeferredTerminalPaste | null
+  isPending: () => boolean
+  dispose: () => void
+}
+
+type CreateDeferredTerminalPasteQueueArgs = {
+  onExpire: (entry: DeferredTerminalPaste) => void
+  timeoutMs?: number
+  setTimer?: (callback: () => void, ms: number) => number
+  clearTimer?: (timerId: number) => void
+}
+
+export function createDeferredTerminalPasteQueue({
+  onExpire,
+  timeoutMs = TERMINAL_DEFERRED_PASTE_TIMEOUT_MS,
+  setTimer = (callback, ms) => window.setTimeout(callback, ms),
+  clearTimer = (timerId) => window.clearTimeout(timerId)
+}: CreateDeferredTerminalPasteQueueArgs): DeferredTerminalPasteQueue {
+  let pending: DeferredTerminalPaste | null = null
+  let timerId: number | null = null
+
+  const take = (): DeferredTerminalPaste | null => {
+    const taken = pending
+    pending = null
+    if (timerId !== null) {
+      clearTimer(timerId)
+      timerId = null
+    }
+    return taken
+  }
+
+  return {
+    defer: (entry) => {
+      take()
+      pending = entry
+      timerId = setTimer(() => {
+        timerId = null
+        // Why: release the clipboard text before notifying, so a throwing
+        // notifier cannot leave the payload retained past its deadline.
+        const expired = pending
+        pending = null
+        if (expired) {
+          onExpire(expired)
+        }
+      }, timeoutMs)
+    },
+    claim: (paneId, leafId) => {
+      if (!pending || pending.paneId !== paneId || pending.leafId !== leafId) {
+        return null
+      }
+      return take()
+    },
+    cancel: () => take(),
+    isPending: () => pending !== null,
+    dispose: () => {
+      take()
+    }
+  }
+}
+
+/** A paste the focus guard stopped is only deferrable while its pane is still the
+ *  live target and no other pane has taken focus — the case the guard exists for. */
+export function isDeferrablePasteFocusCancellation({
+  status,
+  reason,
+  targetMounted,
+  focusMovedToOtherPane
+}: {
+  status: TerminalPasteExecutionResult['status']
+  reason: TerminalPasteExecutionReason | undefined
+  targetMounted: boolean
+  focusMovedToOtherPane: boolean
+}): boolean {
+  return (
+    status === 'cancelled' && reason === 'stale-target' && targetMounted && !focusMovedToOtherPane
+  )
+}
+
+type DeferredPasteFocusPane = {
+  id: number
+  leafId: string
+  container: { contains: (node: Node | null) => boolean }
+}
+
+export type DeferredPasteFocusResolution<TPane extends DeferredPasteFocusPane> =
+  | { action: 'ignore' }
+  | { action: 'deliver'; pane: TPane; entry: DeferredTerminalPaste }
+  | { action: 'drop'; pane: TPane; entry: DeferredTerminalPaste | null }
+
+/** Focus landing back inside the deferred pane delivers it; focus landing in a
+ *  different pane drops it, because that is the wrong-target case the guard protects. */
+export function resolveDeferredPasteFocusIn<TPane extends DeferredPasteFocusPane>({
+  panes,
+  focusedElement,
+  queue
+}: {
+  panes: readonly TPane[]
+  focusedElement: Node | null
+  queue: DeferredTerminalPasteQueue
+}): DeferredPasteFocusResolution<TPane> {
+  if (!queue.isPending() || !focusedElement) {
+    return { action: 'ignore' }
+  }
+  const pane = panes.find((candidate) => candidate.container.contains(focusedElement))
+  if (!pane) {
+    return { action: 'ignore' }
+  }
+  const entry = queue.claim(pane.id, pane.leafId)
+  if (entry) {
+    return { action: 'deliver', pane, entry }
+  }
+  return { action: 'drop', pane, entry: queue.cancel() }
+}
+
+/** True when focus currently sits in a pane other than the paste's own target. */
+export function isFocusInsideOtherPane<TPane extends DeferredPasteFocusPane>({
+  panes,
+  paneId,
+  focusedElement
+}: {
+  panes: readonly TPane[]
+  paneId: number
+  focusedElement: Node | null
+}): boolean {
+  if (!focusedElement) {
+    return false
+  }
+  return panes.some(
+    (candidate) => candidate.id !== paneId && candidate.container.contains(focusedElement)
+  )
+}
+
+/** The pane's focusin handler: deliver the payload to its own pane, drop it when a
+ *  different pane takes focus, and leave it pending for anything else. */
+export function createDeferredPasteFocusInHandler<TPane extends DeferredPasteFocusPane>({
+  queue,
+  getPanes,
+  getFocusedElement,
+  deliver,
+  onDropped
+}: {
+  queue: DeferredTerminalPasteQueue
+  getPanes: () => readonly TPane[]
+  getFocusedElement: () => Node | null
+  deliver: (pane: TPane, entry: DeferredTerminalPaste) => void
+  onDropped: (entry: DeferredTerminalPaste) => void
+}): () => void {
+  return () => {
+    const resolution = resolveDeferredPasteFocusIn({
+      panes: getPanes(),
+      focusedElement: getFocusedElement(),
+      queue
+    })
+    if (resolution.action === 'deliver') {
+      deliver(resolution.pane, resolution.entry)
+      return
+    }
+    if (resolution.action === 'drop' && resolution.entry) {
+      onDropped(resolution.entry)
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-inert-focus-paste-fallback.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-inert-focus-paste-fallback.test.ts
@@ -252,6 +252,59 @@ describe('inert-focus paste fallback', () => {
     expect(onPasteKey).toHaveBeenCalledTimes(1)
   })
 
+  // Coordinator finding, verified here at the fallback level: with several panes
+  // mounted, a pane that lost focus only because it was HIDDEN must not claim the
+  // chord. Real Tailwind `hidden` is display:none on a WRAPPER, and computed
+  // `display` does not cascade to descendants in either engine, so the check has
+  // to walk ancestors — reading `visibility` off the container alone fails OPEN.
+  it('does not claim inert focus when an ancestor wrapper is display:none', () => {
+    const wrapper = document.createElement('div')
+    document.body.append(wrapper)
+    wrapper.append(container)
+    const fallback = install()
+    inside.focus()
+    inside.blur()
+    expect(fallback.ownsInertFocus()).toBe(true)
+
+    // Exactly what Terminal.tsx does to a hidden worktree: `absolute inset-0 hidden`.
+    wrapper.style.display = 'none'
+
+    expect(fallback.ownsInertFocus()).toBe(false)
+    pressPasteChordOn(document.body)
+    expect(onPasteKey).not.toHaveBeenCalled()
+  })
+
+  // The defensive path has to fail CLOSED. A missed recovery is a dropped chord —
+  // the pre-PR behaviour, and the user can click and retry. A false claim pastes
+  // into an invisible terminal and consumes the chord app-wide, which they cannot
+  // undo. So an engine that can tell us nothing must not be read as "rendered".
+  it('refuses to claim when the container has no view to ask about visibility', () => {
+    const foreign = document.implementation.createHTMLDocument('detached')
+    const foreignContainer = foreign.createElement('div')
+    const foreignInside = foreign.createElement('textarea')
+    foreignContainer.append(foreignInside)
+    foreign.body.append(foreignContainer)
+    expect(foreignContainer.isConnected).toBe(true)
+    expect(foreignContainer.ownerDocument.defaultView).toBe(null)
+
+    // Claim ownership at install time, the path the pane itself takes on remount.
+    foreignInside.focus()
+    expect(foreign.activeElement).toBe(foreignInside)
+    const recovered: KeyboardEvent[] = []
+    const fallback = installInertFocusPasteFallback({
+      container: foreignContainer,
+      documentTarget: foreign,
+      onPasteKey: (event) => recovered.push(event),
+      onPasteEvent: () => {}
+    })
+    foreignInside.blur()
+    expect(foreign.activeElement).toBe(foreign.body)
+
+    expect(fallback.ownsInertFocus()).toBe(false)
+    expect(recovered).toEqual([])
+    fallback.dispose()
+  })
+
   it('stops recovering pastes after dispose', () => {
     const fallback = install()
     inside.focus()
@@ -264,6 +317,91 @@ describe('inert-focus paste fallback', () => {
 
     expect(onPasteKey).not.toHaveBeenCalled()
     expect(onPasteEvent).not.toHaveBeenCalled()
+  })
+})
+
+// Coordinator finding on #17020: `TerminalPane` is not a singleton, so several
+// fallbacks are installed at the document at once. Two questions follow — can a
+// hidden instance capture a chord aimed elsewhere, and can two instances both act
+// on the same event? Real DOM and real dispatched events throughout.
+describe('inert-focus paste fallback with several panes mounted', () => {
+  type Scene = {
+    panes: { container: HTMLElement; inside: HTMLTextAreaElement; keys: KeyboardEvent[] }[]
+    dispose: () => void
+  }
+
+  const buildScene = (count: number): Scene => {
+    document.body.innerHTML = ''
+    const disposers: (() => void)[] = []
+    const panes = Array.from({ length: count }, () => {
+      const wrapper = document.createElement('div')
+      const paneContainer = document.createElement('div')
+      const helper = document.createElement('textarea')
+      helper.className = 'xterm-helper-textarea'
+      paneContainer.append(helper)
+      wrapper.append(paneContainer)
+      document.body.append(wrapper)
+      const keys: KeyboardEvent[] = []
+      const fallback = installInertFocusPasteFallback({
+        container: paneContainer,
+        onPasteKey: (event) => keys.push(event),
+        onPasteEvent: () => {}
+      })
+      disposers.push(fallback.dispose)
+      return { container: paneContainer, inside: helper, keys }
+    })
+    return { panes, dispose: () => disposers.forEach((d) => d()) }
+  }
+
+  const chord = (): void => {
+    document.body.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'v', ctrlKey: true, bubbles: true, cancelable: true })
+    )
+  }
+
+  it('lets a hidden background pane capture nothing after a focus-less switch away', () => {
+    // The reported chain: pane A holds focus, the user switches by KEYBOARD (no
+    // pointerdown), A's wrapper is hidden so the browser blurs it to <body> with
+    // NO focusin, and the destination surface takes no focus of its own.
+    const scene = buildScene(3)
+    scene.panes[0]!.inside.focus()
+    ;(scene.panes[0]!.container.parentElement as HTMLElement).style.display = 'none'
+    expect(document.activeElement).toBe(scene.panes[0]!.inside)
+    // happy-dom does not blur on hide, so blur explicitly: the browser's behaviour
+    // is the premise, not the thing under test.
+    scene.panes[0]!.inside.blur()
+    expect(document.activeElement).toBe(document.body)
+
+    chord()
+
+    expect(scene.panes.map((pane) => pane.keys.length)).toEqual([0, 0, 0])
+    scene.dispose()
+  })
+
+  it('never lets two panes act on the same chord', () => {
+    const scene = buildScene(3)
+    scene.panes[0]!.inside.focus()
+    // A real focus move to another pane, which every instance sees at the document.
+    scene.panes[1]!.inside.focus()
+    scene.panes[1]!.inside.blur()
+
+    chord()
+
+    expect(scene.panes.map((pane) => pane.keys.length)).toEqual([0, 1, 0])
+    scene.dispose()
+  })
+
+  it('leaves the chord to the app when no pane ever held focus', () => {
+    const scene = buildScene(3)
+    const elsewhere = document.createElement('input')
+    document.body.append(elsewhere)
+    elsewhere.focus()
+    elsewhere.blur()
+
+    chord()
+
+    expect(scene.panes.map((pane) => pane.keys.length)).toEqual([0, 0, 0])
+    scene.dispose()
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/terminal-inert-focus-paste-fallback.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-inert-focus-paste-fallback.test.ts
@@ -1,0 +1,230 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+
+import {
+  installInertFocusPasteFallback,
+  restoreInertFocusPasteTarget
+} from './terminal-inert-focus-paste-fallback'
+
+// STA-5272 / STA-3834: a dictation tool, IME, or overlay hands focus back to <body>,
+// not to the pane. The pane's own keydown/paste listeners are bound to its root
+// container with capture, so a body-targeted chord never reaches them: no paste,
+// no error, nothing. Everything here runs on real DOM nodes and real dispatched
+// events — a `contains` double would let this pass against unreachable state.
+describe('inert-focus paste fallback', () => {
+  let container: HTMLElement
+  let inside: HTMLTextAreaElement
+  let outside: HTMLInputElement
+  let onPasteKey: Mock<(event: KeyboardEvent) => void>
+  let onPasteEvent: Mock<(event: ClipboardEvent) => void>
+  let dispose: (() => void) | null
+
+  const install = (): ReturnType<typeof installInertFocusPasteFallback> => {
+    const fallback = installInertFocusPasteFallback({ container, onPasteKey, onPasteEvent })
+    dispose = fallback.dispose
+    return fallback
+  }
+  const pressPasteChordOn = (target: EventTarget): void => {
+    target.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'v', ctrlKey: true, bubbles: true, cancelable: true })
+    )
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    container = document.createElement('div')
+    inside = document.createElement('textarea')
+    inside.className = 'xterm-helper-textarea'
+    container.append(inside)
+    outside = document.createElement('input')
+    document.body.append(container, outside)
+    onPasteKey = vi.fn()
+    onPasteEvent = vi.fn()
+    dispose = null
+  })
+
+  afterEach(() => {
+    dispose?.()
+    document.body.innerHTML = ''
+  })
+
+  it('premise: a container-bound capture listener never sees a body-targeted chord', () => {
+    const paneListener = vi.fn()
+    container.addEventListener('keydown', paneListener, { capture: true })
+    inside.focus()
+    inside.blur()
+
+    pressPasteChordOn(document.body)
+
+    // This is the whole defect: body is the container's ancestor, so the capture
+    // path document -> html -> body never reaches the container.
+    expect(paneListener).not.toHaveBeenCalled()
+    container.removeEventListener('keydown', paneListener, { capture: true })
+  })
+
+  it('recovers a paste chord that lands on body after the pane blurred to it', () => {
+    install()
+    inside.focus()
+    inside.blur()
+
+    expect(document.activeElement).toBe(document.body)
+    pressPasteChordOn(document.body)
+
+    expect(onPasteKey).toHaveBeenCalledTimes(1)
+  })
+
+  it('recovers a native paste event that lands on body the same way', () => {
+    install()
+    inside.focus()
+    inside.blur()
+
+    document.body.dispatchEvent(new Event('paste', { bubbles: true, cancelable: true }))
+
+    expect(onPasteEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves events inside the pane to the pane so a paste cannot fire twice', () => {
+    install()
+    inside.focus()
+
+    pressPasteChordOn(inside)
+
+    expect(onPasteKey).not.toHaveBeenCalled()
+  })
+
+  it('leaves an in-pane event to the pane even while focus itself is inert', () => {
+    install()
+    inside.focus()
+    inside.blur()
+    expect(document.activeElement).toBe(document.body)
+
+    // A programmatic paste aimed at a pane child while focus sits on body: the
+    // pane's own capture listener does receive this one, so the fallback must not
+    // handle it as well and paste twice.
+    inside.dispatchEvent(new Event('paste', { bubbles: true, cancelable: true }))
+    pressPasteChordOn(inside)
+
+    expect(onPasteEvent).not.toHaveBeenCalled()
+    expect(onPasteKey).not.toHaveBeenCalled()
+  })
+
+  it('does not steal a paste once another surface has taken focus', () => {
+    install()
+    inside.focus()
+    outside.focus()
+    // Focus then falls to body from that other surface, not from the pane.
+    outside.blur()
+
+    expect(document.activeElement).toBe(document.body)
+    pressPasteChordOn(document.body)
+
+    expect(onPasteKey).not.toHaveBeenCalled()
+  })
+
+  it('does not steal a paste after the user clicks outside the pane', () => {
+    install()
+    inside.focus()
+    inside.blur()
+    // A click on a non-focusable region blurs to body with no focusin at all, so
+    // the pointer is the only evidence the user moved on.
+    document.body.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+
+    pressPasteChordOn(document.body)
+
+    expect(onPasteKey).not.toHaveBeenCalled()
+  })
+
+  it('keeps ownership through a click inside the pane', () => {
+    install()
+    inside.focus()
+    inside.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+    inside.blur()
+
+    pressPasteChordOn(document.body)
+
+    expect(onPasteKey).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire while a real element outside the pane holds focus', () => {
+    install()
+    inside.focus()
+    outside.focus()
+
+    expect(document.activeElement).toBe(outside)
+    pressPasteChordOn(outside)
+
+    expect(onPasteKey).not.toHaveBeenCalled()
+  })
+
+  it('claims focus that already sat in the pane when the listeners were installed', () => {
+    inside.focus()
+    install()
+    inside.blur()
+
+    pressPasteChordOn(document.body)
+
+    expect(onPasteKey).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports inert-focus ownership so other paste entry points can share the test', () => {
+    const fallback = install()
+
+    expect(fallback.ownsInertFocus()).toBe(false)
+    inside.focus()
+    expect(fallback.ownsInertFocus()).toBe(false)
+    inside.blur()
+    expect(fallback.ownsInertFocus()).toBe(true)
+    outside.focus()
+    expect(fallback.ownsInertFocus()).toBe(false)
+  })
+
+  it('stops recovering pastes after dispose', () => {
+    const fallback = install()
+    inside.focus()
+    inside.blur()
+    fallback.dispose()
+    dispose = null
+
+    pressPasteChordOn(document.body)
+    document.body.dispatchEvent(new Event('paste', { bubbles: true, cancelable: true }))
+
+    expect(onPasteKey).not.toHaveBeenCalled()
+    expect(onPasteEvent).not.toHaveBeenCalled()
+  })
+})
+
+describe('restoreInertFocusPasteTarget', () => {
+  const buildPane = (): { container: HTMLElement; terminal: { focus: Mock<() => void> } } => {
+    document.body.innerHTML = ''
+    const container = document.createElement('div')
+    const helper = document.createElement('textarea')
+    helper.className = 'xterm-helper-textarea'
+    container.append(helper)
+    document.body.append(container)
+    return { container, terminal: { focus: vi.fn<() => void>() } }
+  }
+
+  it('puts focus back on the pane when focus fell to body', () => {
+    const pane = buildPane()
+
+    restoreInertFocusPasteTarget(pane, document.body)
+
+    expect(pane.terminal.focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('puts focus back on the pane when nothing at all has focus', () => {
+    const pane = buildPane()
+
+    restoreInertFocusPasteTarget(pane, null)
+
+    expect(pane.terminal.focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves focus alone when it is already inside the pane', () => {
+    const pane = buildPane()
+
+    restoreInertFocusPasteTarget(pane, pane.container.firstElementChild as Element)
+
+    expect(pane.terminal.focus).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-inert-focus-paste-fallback.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-inert-focus-paste-fallback.test.ts
@@ -178,6 +178,80 @@ describe('inert-focus paste fallback', () => {
     expect(fallback.ownsInertFocus()).toBe(false)
   })
 
+  // STA-5272 review: the pane can stop being rendered while `isActive` stays
+  // true (a CSS-hidden floating panel, a display:none background surface). The
+  // browser blurs its focus to <body> WITHOUT a focusin, so `paneOwnsFocus`
+  // stays stale. These listeners sit at the document in capture phase, so a
+  // stale claim swallows the chord (preventDefault + stopPropagation) for the
+  // whole app and routes the paste into an invisible terminal.
+  it('does not claim inert focus once the pane is no longer rendered', () => {
+    const fallback = install()
+    inside.focus()
+    inside.blur()
+    expect(fallback.ownsInertFocus()).toBe(true)
+
+    // Exactly how the closed floating terminal panel hides its subtree.
+    container.style.visibility = 'hidden'
+
+    expect(fallback.ownsInertFocus()).toBe(false)
+  })
+
+  it('does not swallow the paste chord for the rest of the app while hidden', () => {
+    install()
+    inside.focus()
+    inside.blur()
+    container.style.visibility = 'hidden'
+
+    pressPasteChordOn(document.body)
+    document.body.dispatchEvent(new Event('paste', { bubbles: true, cancelable: true }))
+
+    expect(onPasteKey).not.toHaveBeenCalled()
+    expect(onPasteEvent).not.toHaveBeenCalled()
+  })
+
+  it('does not claim inert focus after its container leaves the document', () => {
+    const fallback = install()
+    inside.focus()
+    inside.blur()
+    container.remove()
+
+    expect(fallback.ownsInertFocus()).toBe(false)
+    pressPasteChordOn(document.body)
+    expect(onPasteKey).not.toHaveBeenCalled()
+  })
+
+  it('honours the browser visibility check that covers display:none subtrees', () => {
+    // happy-dom has no checkVisibility; production Chromium does, and it is the
+    // only check that sees a display:none ancestor. Pin that we call it.
+    const calls: unknown[] = []
+    ;(container as HTMLElement & { checkVisibility?: (o?: unknown) => boolean }).checkVisibility = (
+      options
+    ) => {
+      calls.push(options)
+      return false
+    }
+    const fallback = install()
+    inside.focus()
+    inside.blur()
+
+    expect(fallback.ownsInertFocus()).toBe(false)
+    expect(calls.length).toBeGreaterThan(0)
+    pressPasteChordOn(document.body)
+    expect(onPasteKey).not.toHaveBeenCalled()
+  })
+
+  it('still recovers when the browser reports the container as visible', () => {
+    ;(container as HTMLElement & { checkVisibility?: (o?: unknown) => boolean }).checkVisibility =
+      () => true
+    install()
+    inside.focus()
+    inside.blur()
+
+    pressPasteChordOn(document.body)
+
+    expect(onPasteKey).toHaveBeenCalledTimes(1)
+  })
+
   it('stops recovering pastes after dispose', () => {
     const fallback = install()
     inside.focus()

--- a/src/renderer/src/components/terminal-pane/terminal-inert-focus-paste-fallback.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-inert-focus-paste-fallback.ts
@@ -37,10 +37,16 @@ export function installInertFocusPasteFallback({
       paneOwnsFocus = false
     }
   }
+  // Order matters: these run at the document on every keystroke in the app, once
+  // per mounted pane. The two boolean checks short-circuit before any DOM walk,
+  // and the layout-touching visibility check only runs for the at-most-one pane
+  // that both owns focus and has focus sitting on <body>.
   const ownsInertFocus = (): boolean =>
-    paneOwnsFocus && isInertDocumentFocus(documentTarget.activeElement)
+    paneOwnsFocus &&
+    isInertDocumentFocus(documentTarget.activeElement) &&
+    isContainerRendered(container)
   const shouldRecover = (event: Event): boolean =>
-    !containsNode(container, event.target) && ownsInertFocus()
+    ownsInertFocus() && !containsNode(container, event.target)
 
   const onKeyDown = (event: KeyboardEvent): void => {
     if (shouldRecover(event)) {
@@ -71,6 +77,27 @@ export function installInertFocusPasteFallback({
 
 function containsNode(container: HTMLElement, node: EventTarget | Node | null): boolean {
   return node instanceof Node && container.contains(node)
+}
+
+/** A pane that stopped being rendered (CSS-hidden floating panel, display:none
+ *  background surface) was blurred to `<body>` by the browser with no focusin, so
+ *  `paneOwnsFocus` stays stale. Claiming on that swallows the chord for the whole
+ *  app at the capture phase and routes the paste into an invisible terminal. */
+function isContainerRendered(container: HTMLElement): boolean {
+  if (!container.isConnected) {
+    return false
+  }
+  const checkVisibility = (
+    container as HTMLElement & {
+      checkVisibility?: (options?: { visibilityProperty?: boolean }) => boolean
+    }
+  ).checkVisibility
+  if (typeof checkVisibility === 'function') {
+    return checkVisibility.call(container, { visibilityProperty: true })
+  }
+  // Fallback for engines without checkVisibility; `visibility` is inherited, so
+  // reading it off the container also catches a hidden ancestor.
+  return container.ownerDocument.defaultView?.getComputedStyle(container).visibility !== 'hidden'
 }
 
 /** Focus is on <body> but the pane still owns it logically; putting it back before

--- a/src/renderer/src/components/terminal-pane/terminal-inert-focus-paste-fallback.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-inert-focus-paste-fallback.ts
@@ -95,9 +95,24 @@ function isContainerRendered(container: HTMLElement): boolean {
   if (typeof checkVisibility === 'function') {
     return checkVisibility.call(container, { visibilityProperty: true })
   }
-  // Fallback for engines without checkVisibility; `visibility` is inherited, so
-  // reading it off the container also catches a hidden ancestor.
-  return container.ownerDocument.defaultView?.getComputedStyle(container).visibility !== 'hidden'
+  // Why: only for engines without checkVisibility. `display` does not cascade to
+  // descendants, so reading it off the container alone would report a pane inside
+  // a `hidden` wrapper as rendered — failing open, toward claiming the chord. Walk
+  // the ancestors instead. `visibility` is inherited, so the container answers for
+  // itself. Bounded by tree depth and only reached on this defensive path.
+  const view = container.ownerDocument.defaultView
+  if (!view) {
+    return false
+  }
+  if (view.getComputedStyle(container).visibility === 'hidden') {
+    return false
+  }
+  for (let node: HTMLElement | null = container; node; node = node.parentElement) {
+    if (view.getComputedStyle(node).display === 'none') {
+      return false
+    }
+  }
+  return true
 }
 
 /** Focus is on <body> but the pane still owns it logically; putting it back before

--- a/src/renderer/src/components/terminal-pane/terminal-inert-focus-paste-fallback.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-inert-focus-paste-fallback.ts
@@ -1,0 +1,85 @@
+import { isInertDocumentFocus } from './terminal-paste-target-state'
+
+type InstallInertFocusPasteFallbackArgs = {
+  /** TerminalPane root; the pane's own listeners already cover events inside it. */
+  container: HTMLElement
+  documentTarget?: Document
+  onPasteKey: (event: KeyboardEvent) => void
+  onPasteEvent: (event: ClipboardEvent) => void
+}
+
+export type InertFocusPasteFallback = {
+  /** True while this pane is the last surface to have held focus and focus has
+   *  since fallen to `<body>` rather than moving to another surface. */
+  ownsInertFocus: () => boolean
+  dispose: () => void
+}
+
+/** A dictation tool, IME, or overlay hands focus back to `<body>`, not to the pane.
+ *  The pane's own capture listeners never see those keydown/paste events, so the
+ *  chord is dropped with no paste and no error. Recover it at the document, but
+ *  only while nothing else has claimed focus or the pointer. */
+export function installInertFocusPasteFallback({
+  container,
+  documentTarget = document,
+  onPasteKey,
+  onPasteEvent
+}: InstallInertFocusPasteFallbackArgs): InertFocusPasteFallback {
+  let paneOwnsFocus = containsNode(container, documentTarget.activeElement)
+
+  const onFocusIn = (event: FocusEvent): void => {
+    paneOwnsFocus = containsNode(container, event.target)
+  }
+  // Why: a click on a non-focusable region blurs to <body> without any focusin,
+  // so the pointer is the only signal that the user moved on.
+  const onPointerDown = (event: Event): void => {
+    if (!containsNode(container, event.target)) {
+      paneOwnsFocus = false
+    }
+  }
+  const ownsInertFocus = (): boolean =>
+    paneOwnsFocus && isInertDocumentFocus(documentTarget.activeElement)
+  const shouldRecover = (event: Event): boolean =>
+    !containsNode(container, event.target) && ownsInertFocus()
+
+  const onKeyDown = (event: KeyboardEvent): void => {
+    if (shouldRecover(event)) {
+      onPasteKey(event)
+    }
+  }
+  const onPaste = (event: ClipboardEvent): void => {
+    if (shouldRecover(event)) {
+      onPasteEvent(event)
+    }
+  }
+
+  documentTarget.addEventListener('focusin', onFocusIn, { capture: true })
+  documentTarget.addEventListener('pointerdown', onPointerDown, { capture: true })
+  documentTarget.addEventListener('keydown', onKeyDown, { capture: true })
+  documentTarget.addEventListener('paste', onPaste, { capture: true })
+
+  return {
+    ownsInertFocus,
+    dispose: () => {
+      documentTarget.removeEventListener('focusin', onFocusIn, { capture: true })
+      documentTarget.removeEventListener('pointerdown', onPointerDown, { capture: true })
+      documentTarget.removeEventListener('keydown', onKeyDown, { capture: true })
+      documentTarget.removeEventListener('paste', onPaste, { capture: true })
+    }
+  }
+}
+
+function containsNode(container: HTMLElement, node: EventTarget | Node | null): boolean {
+  return node instanceof Node && container.contains(node)
+}
+
+/** Focus is on <body> but the pane still owns it logically; putting it back before
+ *  the shared paste path runs lets that path's dispatch-element guard see the real target. */
+export function restoreInertFocusPasteTarget(
+  pane: { container: HTMLElement; terminal: { focus: () => void } },
+  activeElement: Element | null
+): void {
+  if (!activeElement || !pane.container.contains(activeElement)) {
+    pane.terminal.focus()
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-pane-menu-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-menu-paste.ts
@@ -10,7 +10,10 @@ import {
   type TerminalPasteSource,
   type TerminalPasteTextOptions
 } from './terminal-paste-coordinator'
-import { formatTerminalPasteExecutionError } from './terminal-paste-errors'
+import {
+  formatTerminalPasteExecutionError,
+  TERMINAL_CLIPBOARD_READ_UNAVAILABLE_MESSAGE
+} from './terminal-paste-errors'
 import { resolveTerminalPasteRuntime } from './terminal-paste-runtime'
 import { getTerminalPasteSshRemotePlatform } from './terminal-paste-ssh-platform'
 import { isTerminalPanePasteTargetCurrent } from './terminal-paste-target-state'
@@ -144,7 +147,8 @@ export const pasteTerminalPaneMenuClipboard = async (
     onImagePasteError: (error) => {
       const detail = error instanceof Error ? error.message : String(error)
       onPasteError(`Image paste failed: ${detail}`)
-    }
+    },
+    onClipboardReadUnavailable: () => onPasteError(TERMINAL_CLIPBOARD_READ_UNAVAILABLE_MESSAGE)
   })
   if (result.status !== 'pasted') {
     return

--- a/src/renderer/src/components/terminal-pane/terminal-paste-errors.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-errors.test.ts
@@ -10,15 +10,29 @@ describe('terminal paste error copy', () => {
   it('tells the user how to recover a deferred paste that timed out, per platform', () => {
     // The payload is already gone, so the copy has to be actionable, and the chord
     // label has to match the platform the user is actually on (reported on Win 11).
-    expect(formatDeferredTerminalPasteDroppedError('darwin')).toBe(
+    expect(formatDeferredTerminalPasteDroppedError('deadline-passed', 'darwin')).toBe(
       'Paste cancelled: terminal focus did not return in time. Click the terminal and press ⌘V to paste again.'
     )
-    expect(formatDeferredTerminalPasteDroppedError('win32')).toBe(
+    expect(formatDeferredTerminalPasteDroppedError('deadline-passed', 'win32')).toBe(
       'Paste cancelled: terminal focus did not return in time. Click the terminal and press Ctrl+V to paste again.'
     )
-    expect(formatDeferredTerminalPasteDroppedError('linux')).toBe(
+    expect(formatDeferredTerminalPasteDroppedError('deadline-passed', 'linux')).toBe(
       'Paste cancelled: terminal focus did not return in time. Click the terminal and press Ctrl+V to paste again.'
     )
+  })
+
+  // Three causes reach this toast. Telling a user whose pane was closed, or who
+  // clicked a sibling terminal, that "focus did not return in time" is simply false.
+  it('names the cause it actually hit rather than flattening all three into the timeout', () => {
+    expect(formatDeferredTerminalPasteDroppedError('target-pane-closed', 'darwin')).toBe(
+      'Paste cancelled: the terminal it was meant for was closed. Click the terminal and press ⌘V to paste again.'
+    )
+    expect(formatDeferredTerminalPasteDroppedError('focus-moved-to-other-pane', 'win32')).toBe(
+      'Paste cancelled: focus moved to a different terminal. Click the terminal and press Ctrl+V to paste again.'
+    )
+    const causes = ['deadline-passed', 'target-pane-closed', 'focus-moved-to-other-pane'] as const
+    const messages = causes.map((cause) => formatDeferredTerminalPasteDroppedError(cause, 'darwin'))
+    expect(new Set(messages).size).toBe(causes.length)
   })
 
   it('names a failed clipboard read as a failure, never as an empty clipboard', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-paste-errors.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-errors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatDeferredTerminalPasteDroppedError,
+  formatTerminalPasteExecutionError,
+  TERMINAL_CLIPBOARD_READ_UNAVAILABLE_MESSAGE
+} from './terminal-paste-errors'
+
+describe('terminal paste error copy', () => {
+  it('tells the user how to recover a deferred paste that timed out, per platform', () => {
+    // The payload is already gone, so the copy has to be actionable, and the chord
+    // label has to match the platform the user is actually on (reported on Win 11).
+    expect(formatDeferredTerminalPasteDroppedError('darwin')).toBe(
+      'Paste cancelled: terminal focus did not return in time. Click the terminal and press ⌘V to paste again.'
+    )
+    expect(formatDeferredTerminalPasteDroppedError('win32')).toBe(
+      'Paste cancelled: terminal focus did not return in time. Click the terminal and press Ctrl+V to paste again.'
+    )
+    expect(formatDeferredTerminalPasteDroppedError('linux')).toBe(
+      'Paste cancelled: terminal focus did not return in time. Click the terminal and press Ctrl+V to paste again.'
+    )
+  })
+
+  it('names a failed clipboard read as a failure, never as an empty clipboard', () => {
+    expect(TERMINAL_CLIPBOARD_READ_UNAVAILABLE_MESSAGE).toBe(
+      'Paste failed: could not read the clipboard. Copy again, then retry.'
+    )
+    // Distinct from every execution-stage message, so the toast cannot be mistaken
+    // for a focus or transport problem.
+    const executionMessages = (
+      [
+        'payload-too-large',
+        'stale-target',
+        'target-disconnected',
+        'pty-writer-unavailable',
+        'operation-timeout',
+        undefined
+      ] as const
+    ).map((reason) => formatTerminalPasteExecutionError(reason))
+    expect(executionMessages).not.toContain(TERMINAL_CLIPBOARD_READ_UNAVAILABLE_MESSAGE)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-paste-errors.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-errors.ts
@@ -1,4 +1,5 @@
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import type { DeferredTerminalPasteDropCause } from './terminal-deferred-paste'
 import type { TerminalPasteExecutionReason } from './terminal-paste-model'
 
 export const TERMINAL_CLIPBOARD_READ_UNAVAILABLE_MESSAGE =
@@ -26,10 +27,20 @@ export function formatTerminalPasteExecutionError(
 }
 
 /** The payload is gone by the time this shows, so the copy has to tell the user
- *  what to do next rather than only what went wrong. */
+ *  what to do next rather than only what went wrong — and name the cause it
+ *  actually hit, because "did not return in time" is untrue for a pane the user
+ *  closed or a sibling they clicked into. */
 export function formatDeferredTerminalPasteDroppedError(
+  cause: DeferredTerminalPasteDropCause = 'deadline-passed',
   platform: NodeJS.Platform = getShortcutPlatform()
 ): string {
   const shortcut = platform === 'darwin' ? '⌘V' : 'Ctrl+V'
-  return `Paste cancelled: terminal focus did not return in time. Click the terminal and press ${shortcut} to paste again.`
+  const retry = `Click the terminal and press ${shortcut} to paste again.`
+  if (cause === 'target-pane-closed') {
+    return `Paste cancelled: the terminal it was meant for was closed. ${retry}`
+  }
+  if (cause === 'focus-moved-to-other-pane') {
+    return `Paste cancelled: focus moved to a different terminal. ${retry}`
+  }
+  return `Paste cancelled: terminal focus did not return in time. ${retry}`
 }

--- a/src/renderer/src/components/terminal-pane/terminal-paste-errors.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-errors.ts
@@ -1,4 +1,8 @@
+import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import type { TerminalPasteExecutionReason } from './terminal-paste-model'
+
+export const TERMINAL_CLIPBOARD_READ_UNAVAILABLE_MESSAGE =
+  'Paste failed: could not read the clipboard. Copy again, then retry.'
 
 export function formatTerminalPasteExecutionError(
   reason: TerminalPasteExecutionReason | undefined
@@ -19,4 +23,13 @@ export function formatTerminalPasteExecutionError(
     return 'Paste cancelled: terminal did not accept paste before the safety timeout.'
   }
   return 'Paste failed.'
+}
+
+/** The payload is gone by the time this shows, so the copy has to tell the user
+ *  what to do next rather than only what went wrong. */
+export function formatDeferredTerminalPasteDroppedError(
+  platform: NodeJS.Platform = getShortcutPlatform()
+): string {
+  const shortcut = platform === 'darwin' ? '⌘V' : 'Ctrl+V'
+  return `Paste cancelled: terminal focus did not return in time. Click the terminal and press ${shortcut} to paste again.`
 }

--- a/src/renderer/src/components/terminal-pane/terminal-paste-target-state.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-target-state.ts
@@ -71,7 +71,7 @@ export function isTerminalPanePasteFocusCurrent({
   return paneContainer.contains(activeElement) && isXtermHelperTextarea(activeElement)
 }
 
-function isInertDocumentFocus(element: Element | null): boolean {
+export function isInertDocumentFocus(element: Element | null): boolean {
   if (!element) {
     return true
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1540 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1540 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​543 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​533 |

<!-- /orca-pr-loc -->

Fixes STA-5272. Related: STA-3834, STA-757, #16170.

## ELI5

You copy a paragraph with a dictation tool. The tool presses Ctrl+V for you. But dictation tools
briefly take the keyboard focus and hand it back — and Orca reads "focus moved" as "this paste is
aimed at the wrong place", so it **throws your paragraph away**. There is nothing to click to get it
back. This PR makes Orca *hold* the paste for a couple of seconds instead of binning it, and hand it
over the moment the terminal has focus again.

Two other silent drops on the same path are fixed with it: a Ctrl+V that arrives while focus is
sitting on the page background never reached the terminal at all, and a clipboard read that *failed*
was reported to you as "you copied nothing".

## User-facing before / after

| | Before | After |
|---|---|---|
| Dictation tool copies text and synthesizes Ctrl+V, focus returns a moment later | Text is discarded. Since #13988 a short toast flashes, so it reads as "nothing happened at all" | Text is held for the pane it was aimed at and pasted as soon as that pane has focus again |
| Same, but focus never comes back | Discarded, briefly | Released after 2s with a persistent, actionable message: *"Paste cancelled: terminal focus did not return in time. Click the terminal and press ⌘V to paste again."* (`Ctrl+V` off macOS) |
| Focus moves to a **different** pane mid-paste | Cancelled | Still cancelled immediately — that is the wrong-target case the guard exists for |
| Ctrl+V while focus sits on `<body>` (what a dictation/IME overlay leaves behind) | **Nothing at all** — no paste, no toast | Paste lands, and focus is restored to the pane |
| Clipboard text read fails and there is no image either | Silently reported as an empty clipboard — no paste, no error | *"Paste failed: could not read the clipboard. Copy again, then retry."* |
| Clipboard genuinely empty | Silent | Still silent — no spurious error |
| Image-only clipboard | Screenshot pastes | Unchanged |

## Why the body-focus fix is part of this

The deferral alone would not fix the reported case. With focus on `<body>`, the chord never reaches
`onKeyPaste` at all: the handler is bound to the TerminalPane root container with `{capture: true}`,
and the capture path `document → html → body` never descends into the container. So there is nothing
to defer. Both halves are needed, and the unit suite pins the premise directly
(`premise: a container-bound capture listener never sees a body-targeted chord`).

The document-level fallback is deliberately narrow. It acts only while **all** of these hold: the
pane is the last surface to have held focus, no other element has taken focus since, the user has not
clicked outside the pane since, focus is currently inert (`<body>`/`<html>`), and the event did not
originate inside the pane (those belong to the pane's own listeners). Any one of those failing and it
stays out of the way.

## Deferred payload: lifetime and cancel paths

- **Lifetime:** 2000 ms (`TERMINAL_DEFERRED_PASTE_TIMEOUT_MS`), one payload at a time.
- **Delivered** when focus returns to the same pane *and* leaf id. A redelivered paste never re-defers,
  so a pane that keeps refusing focus cannot loop the payload past its deadline.
- **Cancelled immediately** when focus lands in a different pane, when a newer paste supersedes it, or
  when the target pane/PTY is gone (that path keeps the existing error, unchanged).
- **Released on expiry** — the payload reference is cleared *before* the notifier runs, so a throwing
  toast surface cannot leave clipboard text retained past the deadline. Cleared on unmount too.

## Failed vs. empty

`pasteTerminalClipboard` now carries the read error instead of discarding it. If the text read threw
(and it was not the too-large case) *and* the image path also yields nothing, the result is
`reason: 'clipboard-read-failed'` with an `onClipboardReadUnavailable` callback, distinct from
`reason: 'empty'`. Image-only clipboards are untouched: a failed text read still falls through to the
image path, and a successful image paste reports no error. The existing 19 tests in
`terminal-clipboard-paste.test.ts` stay green under every ablation below.

## Failing-first proof

New tests run against `origin/main` sources (`94e7586665`) via a vitest alias shim — the worktree was
never edited:

```
FAIL terminal-deferred-paste.test.ts — Error: module does not exist on origin/main
FAIL terminal-inert-focus-paste-fallback.test.ts — Error: module does not exist on origin/main
FAIL terminal-clipboard-paste-read-failure.test.ts > reports a failed text read as clipboard-read-failed, not empty
     AssertionError: expected { status: 'skipped', reason: 'empty' } to deeply equal { status: 'skipped', reason: 'clipboard-read-failed' }
FAIL terminal-paste-errors.test.ts > tells the user how to recover a deferred paste that timed out, per platform
     TypeError: formatDeferredTerminalPasteDroppedError is not a function
FAIL terminal-paste-errors.test.ts > names a failed clipboard read as a failure, never as an empty clipboard
     AssertionError: expected undefined to be 'Paste failed: could not read the clip…'

Test Files  4 failed (4)
     Tests  3 failed | 3 passed (6)
```

The 3 that pass on main are the preservation cases (empty clipboard stays silent, image-only still
pastes, too-large keeps its own path) — they are supposed to be green on both sides.

After:

```
Test Files  411 passed (411)
     Tests  3970 passed (3970)      # full src/renderer/src/components/terminal-pane suite
```

## Ablation table

Each production hunk was deleted individually in a scratch copy aliased in at test time (`git status`
verified byte-identical before and after — the worktree was never edited). Every hunk goes red.

| # | Hunk deleted | Result |
|---|---|---|
| H1 | `clipboard-read-failed` branch → always `reason: 'empty'` | **1 failed**, 22 passed |
| H1b | recording the read failure at all | **1 failed**, 22 passed |
| H2a | `claim()` pane/leaf match | **3 failed**, 18 passed |
| H2b | `claim()` disarming the deadline timer | **4 failed**, 17 passed |
| H2c | releasing the payload *before* notifying on expiry | **1 failed**, 20 passed |
| H2d | `targetMounted` / `focusMovedToOtherPane` guards on deferral | **2 failed**, 19 passed |
| H2e | focus-in-a-different-pane → drop | **2 failed**, 19 passed |
| H2f | focusin handler delivering the payload | **2 failed**, 19 passed |
| H3a | fallback tracking which surface took focus | **4 failed**, 11 passed |
| H3b | fallback releasing ownership on a click outside | **1 failed**, 14 passed |
| H3c | fallback requiring focus to be inert | **1 failed**, 14 passed |
| H3d | fallback leaving in-pane events to the pane | **1 failed**, 14 passed |
| H3e | fallback listener removal on dispose | **1 failed**, 14 passed |
| H3f | focus restore firing only when focus left the pane | **1 failed**, 14 passed |
| H4 | platform branch in the expiry copy (`⌘V` vs `Ctrl+V`) | **1 failed**, 1 passed |

H3d initially survived ablation — the case it guards needs an in-pane event *while focus is inert*,
which the other tests never produced. Rather than keep an assertion that cannot fail, a test that
dispatches exactly that state was added; the hunk is now covered.

## Live validation (macOS, dev build, isolated instance)

Driven with `$electron` + Playwright CDP against an isolated dev instance (own CDP port 9334, own
renderer port 5176, own `ORCA_DEV_USER_DATA_PATH`, throwaway repo). Identity verified before
capturing: `devWorktreeName: "sta-5272-deferred-paste-r1"`. Real trusted key events via CDP, not
synthetic DOM events. Out-of-band proof: the pasted payload was a shell command, so a file on disk —
not a screenshot — is the witness that it reached the PTY.

| Scenario | Result |
|---|---|
| **A** — focus on `<body>`, ⌘V | `activeElement` BODY → chord → focus restored to `xterm-helper-textarea`, `/tmp/sta5272-a.proof` = `A-LANDED`. **Landed.** |
| **B** — overlay steals focus at the moment of the chord, returns 0.5s later | No error toast at any point; payload landed on focus return; `/tmp/sta5272-b.proof` = `B-LANDED` |
| **C** — same, focus never returns | No toast at 0.8s (held, not error-dropped); toast at 2.5s; still there at 5.5s (persistent). Late focus return + Enter: **nothing landed**, proof file absent |
| **C′** — cleared screen, payload `ZZZ-EXPIRED-MUST-NOT-APPEAR`, expired, focus returned 3.5s later | Command line is a bare prompt — the string never appears. Screenshot below |
| **E** — genuinely empty clipboard, ⌘V | No toast. No spurious error |
| **double-paste check** — ordinary in-pane ⌘V with the new document-level listeners installed | Marker appears exactly **once** |

**Scenario A + B landed, then C expired** — the terminal history shows `echo A-LANDED …` (body-focus
paste) and `echo B-LANDED …` (deferred paste) both reaching the PTY and running, with the persistent
expiry toast from a payload whose focus never came back:

![deferred paste toast](https://github.com/user-attachments/assets/53217524-66ac-4df2-a169-c6adcfcbbd2a)

**Scenario C′ — nothing lands after the deadline.** Screen cleared, `ZZZ-EXPIRED-MUST-NOT-APPEAR`
deferred, deadline passed, focus returned 3.5s later. The command line is a bare prompt:

![nothing pastes after expiry](https://github.com/user-attachments/assets/e6afde2c-2adc-4814-ab14-8370a81dcb2b)

**No double paste** — an ordinary in-pane ⌘V with the new document-level listeners installed puts the
marker on the line exactly once:

![single paste](https://github.com/user-attachments/assets/eee2aa3a-4f52-4d88-8f5d-e6932bd1f0c1)

## What I did NOT verify

- **No Windows 11 host.** The report is from Windows 11 / Orca 1.4.185; every live measurement here is
  macOS. The platform-dependent parts (`⌘V` vs `Ctrl+V` label, `metaKey` vs `ctrlKey`) are covered by
  unit tests across `darwin`/`win32`/`linux`, and no `e.metaKey` is hardcoded — the existing
  `shouldSuppressNativePaste` platform branch and `getShortcutPlatform()` are reused. But the actual
  Windows dictation flow is unverified.
- **Dev-mode CDP is blind to packaged-build regressions.** Nothing here says anything about the
  packaged app.
- **Clipboard read failure (scenario D) is unit-tested only.** `window.api` is a frozen contextBridge
  object, so `readClipboardText` cannot be stubbed from the renderer, and `clipboard.readText()` does
  not fail on demand. The failed-vs-empty distinction is proven by unit tests + ablation H1/H1b, not
  live.
- **Image-only clipboard is unit-tested only** — preserved by the 19 existing tests, not exercised
  live.
- **SSH / remote runtimes**: the change is entirely renderer-side focus bookkeeping and does not touch
  the execution boundary, the wire, or anything a remote host owns. Not separately exercised on a
  remote pane.
- **The `Edit ▸ Paste` app-menu path still returns early when focus is inert.** `onAppMenuPaste`
  requires `container.contains(document.activeElement)`, so with focus on `<body>` the menu item does
  nothing. `installInertFocusPasteFallback` exposes `ownsInertFocus()` so this can be fixed the same
  way, but it is outside this PR's tested scope and left as a follow-up.

## Gates

`pnpm tc` clean (node + web) · `oxlint` clean on all 11 changed files · changed-code quality gate:
0 code-quality, 0 type-aware, 0 React Doctor findings · `git diff --check` clean · formatted with
`npx oxfmt --write` on changed paths only · no suppressions, no `max-lines` disable or bump.
