### PR TITLE
fix(worktree): keep the PR branch name when the push target is unresolved

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -924,10 +924,20 @@ function isAllowedPushTargetRemoteConflict(
   branchName: string,
   args: SelectedReviewBranchInput
 ): boolean {
+  // Why absent is allowed: a fork PR whose push target cannot be resolved — the
+  // fork was deleted, or its metadata is inaccessible — still knows the review
+  // number and the head ref. Requiring a push target here made that PR take a
+  // `-N` suffix, which is the behaviour #536 set out to remove ("forked PRs where
+  // users would otherwise expect `gh pr checkout`-style behavior"). A push target
+  // naming a *different* branch is still rejected. This only decides whether the
+  // caller looks the review up; the conflict is cleared solely by that lookup
+  // confirming the branch owns the selected review.
+  const pushTargetMatches =
+    args.pushTarget === undefined || args.pushTarget.branchName === branchName
   return (
     conflictKind === 'remote' &&
     isSelectedReviewBranchOverride(args, branchName) &&
-    args.pushTarget?.branchName === branchName
+    pushTargetMatches
   )
 }
 

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -919,6 +919,7 @@ function isMatchingSelectedGitHubPr(
   )
 }
 
+/** Remote conflict is checkable against the selected review: an absent push target still qualifies. */
 function isAllowedPushTargetRemoteConflict(
   conflictKind: 'local' | 'remote' | null,
   branchName: string,

--- a/src/main/ipc/worktrees-pr-branch-suffix.test.ts
+++ b/src/main/ipc/worktrees-pr-branch-suffix.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  listWorktreesMock,
+  addWorktreeMock,
+  getBranchConflictKindMock,
+  getPRForBranchMock,
+  computeWorktreePathMock
+} from './worktrees-test-module-mocks'
+import { handlers, setupWorktreeHandlers, store } from './worktrees-test-harness'
+
+vi.mock('electron', async () =>
+  (await import('./worktrees-test-module-mocks')).electronModuleMock()
+)
+vi.mock('../git/worktree', async () =>
+  (await import('./worktrees-test-module-mocks')).gitWorktreeModuleMock()
+)
+vi.mock('../git/runner', async () =>
+  (await import('./worktrees-test-module-mocks')).gitRunnerModuleMock()
+)
+vi.mock('../git/repo', async () =>
+  (await import('./worktrees-test-module-mocks')).gitRepoModuleMock()
+)
+vi.mock('../git/git-username', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resolveLocalGitUsername: (await import('./worktrees-test-module-mocks'))
+    .resolveLocalGitUsernameMock
+}))
+vi.mock('../github/client', async () =>
+  (await import('./worktrees-test-module-mocks')).githubClientModuleMock()
+)
+vi.mock('../source-control/hosted-review', async () =>
+  (await import('./worktrees-test-module-mocks')).hostedReviewModuleMock()
+)
+vi.mock('../providers/ssh-git-dispatch', async () =>
+  (await import('./worktrees-test-module-mocks')).sshGitDispatchModuleMock()
+)
+vi.mock('../providers/ssh-filesystem-dispatch', async () =>
+  (await import('./worktrees-test-module-mocks')).sshFilesystemDispatchModuleMock()
+)
+vi.mock('./worktree-symlinks', async () =>
+  (await import('./worktrees-test-module-mocks')).worktreeSymlinksModuleMock()
+)
+vi.mock('./ssh', async () => (await import('./worktrees-test-module-mocks')).sshModuleMock())
+vi.mock('../ssh/ssh-target-registry', async () =>
+  (await import('./worktrees-test-module-mocks')).sshTargetRegistryModuleMock()
+)
+vi.mock('../hooks', async () => (await import('./worktrees-test-module-mocks')).hooksModuleMock())
+vi.mock('../setup-runner-script-text', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).setupRunnerScriptTextModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../worktree-runner-script', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).worktreeRunnerScriptModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../effective-hook-config', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).effectiveHookConfigModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../setup-hook-env-vars', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).setupHookEnvVarsModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('./worktree-logic', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).worktreeLogicModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../terminal-history-deletion', async () =>
+  (await import('./worktrees-test-module-mocks')).terminalHistoryDeletionModuleMock()
+)
+vi.mock('../ports/advertised-url-watcher', async () =>
+  (await import('./worktrees-test-module-mocks')).advertisedUrlWatcherModuleMock()
+)
+vi.mock('../workspace-cleanup-scan-snapshot', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceCleanupScanSnapshotModuleMock()
+)
+vi.mock('../workspace-space-analysis-snapshot', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceSpaceAnalysisSnapshotModuleMock()
+)
+vi.mock('../workspace-cleanup-removal-snapshot-prune', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceCleanupRemovalSnapshotPruneModuleMock()
+)
+vi.mock('../runtime/worktree-teardown', async () =>
+  (await import('./worktrees-test-module-mocks')).worktreeTeardownModuleMock()
+)
+vi.mock('./pty', async () => (await import('./worktrees-test-module-mocks')).ptyModuleMock())
+
+describe('worktree create for a selected PR branch', () => {
+  beforeEach(() => {
+    setupWorktreeHandlers()
+    store.getRepo.mockReturnValue({
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0
+    })
+    // Report back whatever was created, so the flow finds the worktree under
+    // whichever name the conflict path settled on.
+    listWorktreesMock.mockImplementation(async () =>
+      addWorktreeMock.mock.calls.map((call: unknown[]) => ({
+        path: call[1] as string,
+        head: 'abc123',
+        branch: `refs/heads/${call[2] as string}`,
+        isBare: false,
+        isMainWorktree: false
+      }))
+    )
+    computeWorktreePathMock.mockImplementation(
+      (_repoPath: string, name: string) => `/workspace/${name}`
+    )
+    // Only the PR's own branch carries PR #42; suffixed siblings carry nothing.
+    getPRForBranchMock.mockImplementation(async (_repoPath: string, branch: string) =>
+      branch === 'feature/fix'
+        ? {
+            number: 42,
+            title: 'Selected PR',
+            state: 'open',
+            url: 'https://example.com/pr/42',
+            checksStatus: 'success',
+            updatedAt: '2026-06-16T00:00:00.000Z',
+            mergeable: 'UNKNOWN'
+          }
+        : null
+    )
+  })
+
+  it('keeps the PR branch name when a push target names it', async () => {
+    getBranchConflictKindMock.mockResolvedValueOnce('remote')
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'fix-title',
+      baseBranch: 'abc123',
+      branchNameOverride: 'feature/fix',
+      linkedPR: 42,
+      pushTarget: { remoteName: 'origin', branchName: 'feature/fix' }
+    })
+
+    expect(addWorktreeMock.mock.calls.map((call: unknown[]) => call[2])).toEqual(['feature/fix'])
+  })
+
+  it('keeps the PR branch name when the push target could not be resolved', async () => {
+    // A fork PR with deleted or inaccessible fork metadata reaches create with no
+    // push target. The review number and head ref still identify the branch, so it
+    // must not be renamed to `feature/fix-2`.
+    getBranchConflictKindMock.mockResolvedValueOnce('remote')
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'fix-title',
+      baseBranch: 'abc123',
+      branchNameOverride: 'feature/fix',
+      linkedPR: 42
+    })
+
+    expect(addWorktreeMock.mock.calls.map((call: unknown[]) => call[2])).toEqual(['feature/fix'])
+  })
+
+  it('still suffixes when the branch does not own the selected PR', async () => {
+    getBranchConflictKindMock.mockResolvedValueOnce('remote')
+    getPRForBranchMock.mockResolvedValue(null)
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'fix-title',
+      baseBranch: 'abc123',
+      branchNameOverride: 'feature/fix',
+      linkedPR: 42
+    })
+
+    expect(addWorktreeMock.mock.calls.map((call: unknown[]) => call[2])).toEqual(['feature/fix-2'])
+  })
+})

--- a/src/main/runtime/selected-review-branch.test.ts
+++ b/src/main/runtime/selected-review-branch.test.ts
@@ -137,13 +137,14 @@ describe('isAllowedPushTargetRemoteConflict', () => {
     ).toBe(false)
   })
 
-  it('requires a push target', () => {
+  it('allows a selected review branch with no push target', () => {
+    // A fork PR whose push target could not be resolved still names its review.
     expect(
       isAllowedPushTargetRemoteConflict('remote', 'feat', {
         linkedGitLabMR: 12,
         branchNameOverride: 'feat'
       })
-    ).toBe(false)
+    ).toBe(true)
   })
 })
 

--- a/src/main/runtime/selected-review-branch.ts
+++ b/src/main/runtime/selected-review-branch.ts
@@ -64,6 +64,7 @@ export function isMatchingSelectedGitHubPr(
   )
 }
 
+/** Remote conflict is checkable against the selected review: an absent push target still qualifies. */
 export function isAllowedPushTargetRemoteConflict(
   conflictKind: 'local' | 'remote' | null,
   branchName: string,

--- a/src/main/runtime/selected-review-branch.ts
+++ b/src/main/runtime/selected-review-branch.ts
@@ -69,10 +69,20 @@ export function isAllowedPushTargetRemoteConflict(
   branchName: string,
   args: SelectedReviewBranchInput
 ): boolean {
+  // Why absent is allowed: a fork PR whose push target cannot be resolved — the
+  // fork was deleted, or its metadata is inaccessible — still knows the review
+  // number and the head ref. Requiring a push target here made that PR take a
+  // `-N` suffix, which is the behaviour #536 set out to remove ("forked PRs where
+  // users would otherwise expect `gh pr checkout`-style behavior"). A push target
+  // naming a *different* branch is still rejected. This only decides whether the
+  // caller looks the review up; the conflict is cleared solely by that lookup
+  // confirming the branch owns the selected review.
+  const pushTargetMatches =
+    args.pushTarget === undefined || args.pushTarget.branchName === branchName
   return (
     conflictKind === 'remote' &&
     isSelectedReviewBranchOverride(args, branchName) &&
-    args.pushTarget?.branchName === branchName
+    pushTargetMatches
   )
 }
 


### PR DESCRIPTION
## ELI5

Open a worktree for someone's pull request and Orca sometimes names the branch `their-branch-2` instead of `their-branch`. This makes it use the real name.

## What Changed

`isAllowedPushTargetRemoteConflict` required a push target before it would check a remote branch-name conflict against the selected review. It now also allows the case where there is **no** push target at all. A push target naming a *different* branch is still rejected.

Both copies of the helper are updated: `src/main/ipc/worktree-remote.ts` keeps a private duplicate used by the local and SSH create paths, and `src/main/runtime/selected-review-branch.ts` exports the one the runtime flow uses. Changing only one would have fixed only some of the three call sites.

## Why

Checking out a PR sets `branchNameOverride` to the head ref and resolves a push target. For a fork PR that resolution is explicitly allowed to come back empty:

```ts
catch {
  // Why: deleted/inaccessible fork metadata can prevent push-target
  // discovery, but GitHub still exposes the PR head ref for checkout.
  pushTarget = undefined
}
```

With `pushTarget` undefined the gate closed, the review was never looked up, and the branch fell through to the `-N` suffix retry — even though the PR number and head ref were both known.

That is the behaviour #536 set out to remove. Its problem statement is *"rejects branch names that already map to a PR … especially for forked PRs where users would otherwise expect `gh pr checkout`-style behavior"*, and its acceptance criteria include *"works for same-repo PRs and forked PRs"*.

**The safety did not live in the push target.** The gate only decides whether the review is looked up; the conflict is cleared solely by `isMatchingSelectedGitHubPr` (or `matchesSelected` for GitLab / Bitbucket / Azure DevOps / Gitea) confirming the branch owns the selected review. A branch that does not own it still gets the suffix — covered by a test here.

These two helpers are duplicated between the two files with identical bodies. I changed both rather than deduplicating, to keep this PR behavioural-only; removing the duplication is worth doing as its own change.

## Linked Issue

Refs #16646 — this fixes the PR-checkout half. The orphaned-prefix half is #16699. Neither closes the issue alone, so no closing keyword here.

## Visual Proof

`N/A` — no UI change. The user-visible effect is the created branch and folder name, asserted directly by the tests below.

## Testing

Windows 11 (10.0.26200), Node 24, `pnpm test` / `pnpm tc:node` / `pnpm build`.

New `src/main/ipc/worktrees-pr-branch-suffix.test.ts` drives the real `worktrees:create` handler:

| case | before | after |
|---|---|---|
| push target names the branch | `feature/fix` | `feature/fix` |
| **push target unresolved** | **`feature/fix-2`** | **`feature/fix`** |
| branch does not own the selected PR | `feature/fix-2` | `feature/fix-2` |

I confirmed the middle test fails without the source change (`git stash` on the two source files, re-run: exactly that one test fails, the other two pass), so it targets this defect rather than passing incidentally.

Full affected set: 13 files, 1388 tests, all passing — including `orca-runtime.test.ts`, the SSH fork push-target suite, the WSL routing suite and `repo.test.ts`.

One characterization test changed: `selected-review-branch.test.ts` had `requires a push target` asserting the old gate. That file is headed `// characterization: current behavior`, so it records behaviour rather than intent; it now reads `allows a selected review branch with no push target`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Opus 5 (Claude Code). I ran and read every test, traced all three call sites by hand, and verified the duplicate helpers are byte-identical after whitespace normalisation before deciding to change both.

## Review

The judgement call worth a second opinion: allowing an absent push target. The alternative reading is that an unknown push target should stay conservative and take a suffix. I went the other way because the review lookup still has to confirm ownership before anything is cleared, and #536 names the suffix as the thing to remove for fork PRs.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security** — no widening. The confirmation step (`isMatchingSelectedGitHubPr` / `matchesSelected`) is untouched; only the decision to run it changed. A branch that does not own the selected review still conflicts.
- **Cross-platform** — no platform-dependent code; pure argument logic. Verified on Windows.
- **Remote SSH** — `createRemoteWorktree` uses the same gate followed by `getSelectedHostedReviewForBranch(...).matchesSelected`. Same shape, same guarantee; the SSH fork push-target suite passes.
- **Git providers** — the non-GitHub path compares both provider and review number, so GitLab, Bitbucket, Azure DevOps and Gitea are covered identically.
- **Mobile / backwards compatibility / performance** — no wire, schema or IPC change; no extra git or network calls (the lookup already ran whenever the gate opened).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

`pnpm tc:node`, `pnpm build`, the affected test set and `oxlint` on the changed files all pass locally. `pnpm run check:code-quality:changed` could not run on this machine — it fails with `spawnSync pnpm.cmd EINVAL` before reaching my files, a Windows-only defect in that script rather than a finding about this change. `oxlint` invoked directly on the four files is clean.
