### PR TITLE
Show friendly model names in compact agent rows

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+/**
+ * Why a render test: the change is a WIRING one. The formatter is unit-tested on its own;
+ * these assert the combined label actually reaches the row, that the now-redundant raw
+ * model chip is gone, and that child-row activation still targets the parent pane.
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+import { CompactAgentRow } from './worktree-card-compact-agent-row'
+
+vi.mock('@/components/dashboard/use-agent-row-conversation-name', () => ({
+  useAgentRowConversationName: () => null
+}))
+vi.mock('./CacheTimer', () => ({
+  default: () => null,
+  usePromptCacheCountdownForPane: () => null
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+function agentRow(overrides: {
+  model?: string
+  prompt?: string
+  displayName?: string
+  agentType?: string
+  rowSource?: 'subagent'
+  paneKey?: string
+  activationPaneKey?: string
+}): DashboardAgentRow {
+  const paneKey = overrides.paneKey ?? 'pane-1'
+  return {
+    paneKey,
+    entry: {
+      state: 'working',
+      prompt: overrides.prompt ?? '',
+      updatedAt: 1,
+      stateStartedAt: 1,
+      agentType: overrides.agentType ?? 'codex',
+      model: overrides.model,
+      paneKey,
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      stateHistory: [],
+      ...(overrides.displayName
+        ? {
+            orchestration: {
+              taskId: 'task-1',
+              dispatchId: 'ctx-1',
+              displayName: overrides.displayName
+            }
+          }
+        : {})
+    },
+    tab: { id: 'tab-1' },
+    agentType: overrides.agentType ?? 'codex',
+    rowSource: overrides.rowSource,
+    state: 'working',
+    startedAt: 1,
+    ...(overrides.activationPaneKey ? { activationPaneKey: overrides.activationPaneKey } : {})
+  } as unknown as DashboardAgentRow
+}
+
+function renderRow(
+  agent: DashboardAgentRow,
+  onActivate = vi.fn()
+): { onActivate: typeof onActivate } {
+  render(<CompactAgentRow agent={agent} now={2} onActivate={onActivate} />)
+  return { onActivate }
+}
+
+describe('CompactAgentRow model label', () => {
+  it('names a Sol parent before its generated feature', () => {
+    renderRow(agentRow({ model: 'gpt-5.6-sol', prompt: 'Inspect scraper pipeline' }))
+    expect(screen.getByText('Sol: Inspect scraper pipeline')).toBeTruthy()
+    // The trailing raw-model chip is redundant once the label names the model.
+    expect(screen.queryByText('gpt-5.6-sol')).toBeNull()
+    // The tooltip carries the full combined label, which the row itself truncates.
+    const row = document.querySelector('.compact-agent-row')
+    expect(row?.getAttribute('title')).toContain('Sol: Inspect scraper pipeline')
+  })
+
+  it('names a Fable parent the same way', () => {
+    renderRow(agentRow({ model: 'claude-fable-5', prompt: 'Rework the replay gate' }))
+    expect(screen.getByText('Fable: Rework the replay gate')).toBeTruthy()
+    expect(screen.queryByText('claude-fable-5')).toBeNull()
+  })
+
+  it('names a native Terra child from its description', () => {
+    renderRow(
+      agentRow({
+        model: 'gpt-5.6-terra',
+        prompt: 'Map backend API layer',
+        rowSource: 'subagent',
+        agentType: 'api-mapper'
+      })
+    )
+    expect(screen.getByText('Terra: Map backend API layer')).toBeTruthy()
+  })
+
+  it('names a native Claude child from its description', () => {
+    renderRow(
+      agentRow({
+        model: 'claude-sonnet-5',
+        prompt: 'Survey the test suite',
+        rowSource: 'subagent',
+        agentType: 'test-surveyor'
+      })
+    )
+    expect(screen.getByText('Sonnet: Survey the test suite')).toBeTruthy()
+  })
+
+  it('keeps an unknown model readable rather than dropping it', () => {
+    renderRow(agentRow({ model: 'mystery-model-1', prompt: 'Do the thing' }))
+    expect(screen.getByText('mystery-model-1: Do the thing')).toBeTruthy()
+  })
+
+  it('leaves a row without a model exactly as it was', () => {
+    renderRow(agentRow({ prompt: 'Inspect scraper pipeline' }))
+    expect(screen.getByText('Inspect scraper pipeline')).toBeTruthy()
+  })
+
+  it('does not double-prefix an orchestration displayName that is already formatted', () => {
+    renderRow(
+      agentRow({
+        model: 'gpt-5.6-terra',
+        prompt: 'You are working inside Orca, a multi-agent IDE. === TASK === Inspect pipeline',
+        displayName: 'Terra (medium): Inspect scraper pipeline'
+      })
+    )
+    expect(screen.getByText('Terra (medium): Inspect scraper pipeline')).toBeTruthy()
+    expect(screen.queryByText(/Terra: Terra/u)).toBeNull()
+  })
+
+  it('still activates the parent pane from a child row', () => {
+    const { onActivate } = renderRow(
+      agentRow({
+        model: 'gpt-5.6-luna',
+        prompt: 'Check the migration',
+        rowSource: 'subagent',
+        paneKey: 'pane-1 subagent:abc',
+        activationPaneKey: 'pane-parent'
+      })
+    )
+    fireEvent.click(screen.getByText('Luna: Check the migration'))
+    expect(onActivate).toHaveBeenCalledWith('tab-1', 'pane-parent')
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils'
 import { getAgentDotState } from './worktree-card-agent-summary'
 import { translate } from '@/i18n/i18n'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
+import { formatAgentRowLabel, labelNamesModel } from '@/lib/agent-row-model-label'
 import { formatAgentToolPreview } from '@/lib/agent-row-tool-preview'
 import { useAgentRowConversationName } from '@/components/dashboard/use-agent-row-conversation-name'
 import { lastEnteredDoneAt } from '@/components/dashboard/agent-finished-timestamp'
@@ -33,8 +34,12 @@ function getCompactAgentPrimary(
   agent: DashboardAgentRowData,
   conversationName: string | null
 ): string {
+  // Why: name the model first, then the feature ("Sol: Inspect scraper pipeline"). The
+  // feature name keeps Orca's existing precedence — orchestration label, subagent
+  // description, generated conversation name, then the state label.
   const prompt = conversationName ?? getAgentRowPrimaryText(agent.entry)
-  return prompt || agentStateLabel(getAgentDotState(agent))
+  const feature = prompt || agentStateLabel(getAgentDotState(agent))
+  return formatAgentRowLabel({ model: agent.entry.model, feature })
 }
 
 export function getCompactAgentSecondary(agent: DashboardAgentRowData): string {
@@ -129,6 +134,9 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
     dotState === 'monitoring' ? (primary === secondary ? '' : primary) : secondary
   const rowTitle = `${leadingText}${trailingText ? ` - ${trailingText}` : ''}`
   const model = agent.entry.model?.trim() ?? ''
+  // Why: the combined primary already names the model, so the trailing raw-model chip
+  // would only repeat it. Keep the chip for rows whose label could not name it.
+  const showModelChip = model !== '' && !labelNamesModel(primary, model)
   const shortTime = getCompactAgentTime(agent, now)
   const cacheTimer = usePromptCacheCountdownForPane(agent.paneKey, cacheTimerActive)
 
@@ -219,7 +227,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
           </span>
         )}
       </span>
-      {model && (
+      {showModelChip && (
         <span
           className={cn(
             'min-w-0 max-w-24 truncate font-mono text-[10px]',

--- a/src/renderer/src/lib/agent-row-model-label.test.ts
+++ b/src/renderer/src/lib/agent-row-model-label.test.ts
@@ -96,4 +96,11 @@ describe('labelNamesModel', () => {
     expect(labelNamesModel('Inspect scraper pipeline', undefined)).toBe(false)
     expect(labelNamesModel('Inspect scraper pipeline', '')).toBe(false)
   })
+
+  it('accepts a lowercase caller prefix that isAlreadyPrefixed preserved verbatim', () => {
+    const feature = 'terra: Inspect scraper pipeline'
+    const label = formatAgentRowLabel({ model: 'gpt-5.6-terra', feature })
+    expect(label).toBe(feature)
+    expect(labelNamesModel(label, 'gpt-5.6-terra')).toBe(true)
+  })
 })

--- a/src/renderer/src/lib/agent-row-model-label.test.ts
+++ b/src/renderer/src/lib/agent-row-model-label.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { formatAgentRowLabel, friendlyModel, labelNamesModel } from './agent-row-model-label'
+
+describe('friendlyModel', () => {
+  it('names the models Orca actually launches', () => {
+    expect(friendlyModel('gpt-5.6-sol')).toBe('Sol')
+    expect(friendlyModel('gpt-5.6-terra')).toBe('Terra')
+    expect(friendlyModel('gpt-5.6-luna')).toBe('Luna')
+    expect(friendlyModel('claude-fable-5')).toBe('Fable')
+    expect(friendlyModel('claude-opus-5')).toBe('Opus')
+    expect(friendlyModel('claude-sonnet-5')).toBe('Sonnet')
+    expect(friendlyModel('claude-haiku-4-5-20251001')).toBe('Haiku')
+  })
+
+  it('falls back to the raw id rather than guessing', () => {
+    expect(friendlyModel('gpt-oss-120b-medium')).toBe('gpt-oss-120b-medium')
+    expect(friendlyModel('some-future-model')).toBe('some-future-model')
+    // A substring inside another word is not a match.
+    expect(friendlyModel('solar-preview')).toBe('solar-preview')
+    expect(friendlyModel(undefined)).toBe('')
+    expect(friendlyModel('   ')).toBe('')
+  })
+})
+
+describe('formatAgentRowLabel', () => {
+  it('renders a supervised parent as "Sol: feature"', () => {
+    expect(formatAgentRowLabel({ model: 'gpt-5.6-sol', feature: 'Inspect scraper pipeline' })).toBe(
+      'Sol: Inspect scraper pipeline'
+    )
+  })
+
+  it('renders a Fable parent the same way', () => {
+    expect(
+      formatAgentRowLabel({ model: 'claude-fable-5', feature: 'Rework the replay gate' })
+    ).toBe('Fable: Rework the replay gate')
+  })
+
+  it('renders a native child from its description', () => {
+    expect(formatAgentRowLabel({ model: 'gpt-5.6-terra', feature: 'Map backend API layer' })).toBe(
+      'Terra: Map backend API layer'
+    )
+    expect(
+      formatAgentRowLabel({ model: 'claude-sonnet-5', feature: 'Survey the test suite' })
+    ).toBe('Sonnet: Survey the test suite')
+  })
+
+  it('shows effort only when a caller supplies an authoritative one', () => {
+    expect(
+      formatAgentRowLabel({ model: 'gpt-5.6-terra', effort: 'medium', feature: 'Fix flake' })
+    ).toBe('Terra (medium): Fix flake')
+    expect(formatAgentRowLabel({ model: 'gpt-5.6-terra', feature: 'Fix flake' })).toBe(
+      'Terra: Fix flake'
+    )
+  })
+
+  it('keeps an unknown model readable instead of dropping it', () => {
+    expect(formatAgentRowLabel({ model: 'mystery-model-1', feature: 'Do the thing' })).toBe(
+      'mystery-model-1: Do the thing'
+    )
+  })
+
+  it('leaves the feature untouched when there is no model', () => {
+    expect(formatAgentRowLabel({ feature: 'Inspect scraper pipeline' })).toBe(
+      'Inspect scraper pipeline'
+    )
+    expect(formatAgentRowLabel({ model: '', feature: 'Inspect scraper pipeline' })).toBe(
+      'Inspect scraper pipeline'
+    )
+  })
+
+  it('never double-prefixes a displayName the caller already formatted', () => {
+    expect(
+      formatAgentRowLabel({
+        model: 'gpt-5.6-terra',
+        feature: 'Terra (medium): Inspect scraper pipeline'
+      })
+    ).toBe('Terra (medium): Inspect scraper pipeline')
+    expect(
+      formatAgentRowLabel({ model: 'gpt-5.6-terra', feature: 'Terra: Inspect scraper pipeline' })
+    ).toBe('Terra: Inspect scraper pipeline')
+    // Even when the caller named a different model, adding a second prefix is worse.
+    expect(
+      formatAgentRowLabel({ model: 'gpt-5.6-terra', feature: 'Sonnet: Inspect scraper pipeline' })
+    ).toBe('Sonnet: Inspect scraper pipeline')
+  })
+
+  it('degrades to the model alone when there is no feature name yet', () => {
+    expect(formatAgentRowLabel({ model: 'gpt-5.6-sol', feature: '' })).toBe('Sol')
+  })
+})
+
+describe('labelNamesModel', () => {
+  it('reports whether the row still needs its separate model chip', () => {
+    expect(labelNamesModel('Sol: Inspect scraper pipeline', 'gpt-5.6-sol')).toBe(true)
+    expect(labelNamesModel('mystery-model-1: Do the thing', 'mystery-model-1')).toBe(true)
+    expect(labelNamesModel('Inspect scraper pipeline', undefined)).toBe(false)
+    expect(labelNamesModel('Inspect scraper pipeline', '')).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/agent-row-model-label.ts
+++ b/src/renderer/src/lib/agent-row-model-label.ts
@@ -63,8 +63,10 @@ export function formatAgentRowLabel(args: {
 }
 
 /** True when the combined label already names the model, so the row can drop its
- *  separate raw-model chip instead of saying it twice. */
+ *  separate raw-model chip instead of saying it twice. Case-insensitive to stay symmetric
+ *  with isAlreadyPrefixed: a caller label like `terra: …` is preserved verbatim there, so
+ *  a case-sensitive test here would leave the redundant chip on exactly those rows. */
 export function labelNamesModel(label: string, model: string | undefined): boolean {
   const name = friendlyModel(model)
-  return name !== '' && label.startsWith(name)
+  return name !== '' && label.toLowerCase().startsWith(name.toLowerCase())
 }

--- a/src/renderer/src/lib/agent-row-model-label.ts
+++ b/src/renderer/src/lib/agent-row-model-label.ts
@@ -1,0 +1,70 @@
+// Why: sidebar rows previously showed a folded lifecycle preamble on the left and a raw
+// model id on the right ("You are working in the Ass…            gpt-5.6-sol"). Naming the
+// model up front and following it with the feature reads as one thought and costs no width.
+
+/** Friendly names we recognise inside provider model ids. Deliberately tiny: this is a
+ *  presentation nicety, not a model registry, and anything unknown keeps its raw id. */
+const FRIENDLY_NAMES = ['Sol', 'Terra', 'Luna', 'Fable', 'Opus', 'Sonnet', 'Haiku'] as const
+
+/** Token boundary so `claude-haiku-4-5-20251001` matches Haiku while `solar-preview` does
+ *  not match Sol. */
+function matchesToken(modelLower: string, nameLower: string): boolean {
+  const index = modelLower.indexOf(nameLower)
+  if (index === -1) {
+    return false
+  }
+  const before = index === 0 ? '' : modelLower[index - 1]
+  const after = modelLower[index + nameLower.length] ?? ''
+  return !/[a-z0-9]/.test(before) && !/[a-z0-9]/.test(after)
+}
+
+/** `gpt-5.6-sol` -> `Sol`, `claude-fable-5` -> `Fable`, unknown ids unchanged. */
+export function friendlyModel(model: string | undefined): string {
+  const raw = model?.trim() ?? ''
+  if (!raw) {
+    return ''
+  }
+  const lower = raw.toLowerCase()
+  for (const name of FRIENDLY_NAMES) {
+    if (matchesToken(lower, name.toLowerCase())) {
+      return name
+    }
+  }
+  return raw
+}
+
+/** True when a feature name is already `Terra: …` / `Terra (medium): …`, so orchestration
+ *  callers that format their own displayName are never double-prefixed. Any known name
+ *  counts — `Terra: Sonnet: fix` would be worse than leaving the caller's label alone. */
+function isAlreadyPrefixed(feature: string): boolean {
+  return FRIENDLY_NAMES.some((name) =>
+    new RegExp(`^${name}\\s*(\\([^)]*\\))?\\s*:`, 'i').test(feature)
+  )
+}
+
+/**
+ * Combine model, optional authoritative effort and feature name into one row label.
+ * Effort is only ever rendered when a caller already knows it — nothing here infers it
+ * from the model id.
+ */
+export function formatAgentRowLabel(args: {
+  model?: string
+  effort?: string
+  feature: string
+}): string {
+  const feature = args.feature.trim()
+  const name = friendlyModel(args.model)
+  if (!name || isAlreadyPrefixed(feature)) {
+    return feature
+  }
+  const effort = args.effort?.trim()
+  const prefix = effort ? `${name} (${effort})` : name
+  return feature ? `${prefix}: ${feature}` : prefix
+}
+
+/** True when the combined label already names the model, so the row can drop its
+ *  separate raw-model chip instead of saying it twice. */
+export function labelNamesModel(label: string, model: string | undefined): boolean {
+  const name = friendlyModel(model)
+  return name !== '' && label.startsWith(name)
+}


### PR DESCRIPTION
## ELI5

A sidebar agent row used to show a truncated prompt on the left and a raw model id like `gpt-5.6-sol` on the right. Now it shows `Sol: Inspect scraper pipeline` in one label, so the same width tells you both who is working and what they are working on.

## What Changed

Compact worktree agent rows combine the provider model with the existing conversation/task name:

- `gpt-5.6-sol` + task → `Sol: Inspect scraper pipeline`
- `gpt-5.6-terra` child → `Terra: Map backend API layer`
- Claude models render the same way as Fable / Opus / Sonnet / Haiku

The separate raw-model chip is removed **only** when the combined primary label already names the model. Rows with an unrecognised model keep the id inline (`mystery-model-1: Do the thing`), rows with no model are byte-for-byte unchanged, and a label already prefixed by an orchestration `displayName` (`Terra (medium): …`) is left alone rather than double-prefixed.

Four files, one new 47-line helper and a 10-line wiring change:

- `src/renderer/src/lib/agent-row-model-label.ts` (new)
- `src/renderer/src/lib/agent-row-model-label.test.ts` (new)
- `src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx` (+10/−2)
- `src/renderer/src/components/sidebar/worktree-card-compact-agent-row.test.tsx` (new)

## Why

The current layout spends scarce sidebar width on both a prompt/title preview and a raw model id. Combining them gives the two useful facts in one readable label, and the friendly name is what people actually say out loud. The model list is a small ordered array matched on token boundaries rather than a registry, so an unknown model degrades to its raw id instead of disappearing.

## Linked Issue

No existing issue — this is a small unsolicited presentation improvement. Happy to open one first if you would prefer the tracked path.

## Visual Proof

Real sidebar row, rendered by this branch in a running Orca dev instance (isolated `orca-dev` profile):

```
before   ● [icon] You are working in the …          gpt-5.6-sol   1m
after    ● [icon] Sol: orca-visual-check - OK                     1m
```

Verified in the live DOM: friendly prefix visible, feature text visible, raw `gpt-5.6-sol` chip gone, status dot / agent icon / elapsed time all preserved, and the row `title` attribute still carries the full untruncated label for the truncated case.

## Testing

- 44 focused agent-row tests pass — 11 new formatter tests, 8 new render/wiring tests, and 25 pre-existing (`agent-row-primary-text`, `agent-row-tool-preview`) with no regressions.
- `pnpm typecheck` — exit 0.
- `pnpm lint` — exit 0.
- `node config/scripts/check-changed-code-quality.mjs` — 0 new findings on each of code quality, type-aware, and React Doctor.
- `pnpm test` — 64,139 passed. 17 failures in 8 files (`agent-hooks`, `ssh-connection-host-key-store-wiring`, `remote-browser-socks-server`, `pty-subprocess-wsl-launch`, `local-pty-provider-windows-shell-launch`, `configure-process`, `pty-handler-revive`, `pty-handler-spawn-environment`). All 17 reproduce identically on the unmodified base commit `94e758666` on this host, so they are pre-existing/environmental (Linux/WSL host running Windows-shell and PTY/SSH suites), not caused by this change.
- Platform tested: Linux (WSL2), rendered on the Windows desktop via WSLg. Not tested on macOS or over SSH — the change is pure renderer string formatting with no platform, path, or shortcut surface.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Authored with Claude Opus 5 via Claude Code, reviewed by the contributor before submission.

## Review

Two small notes for a reviewer:

1. `friendlyModel` matches on token boundaries, so `gpt-5.6-sol` → `Sol` but a hypothetical `solaris-1` would not match `Sol`.
2. The chip is removed via `labelNamesModel`, which checks the rendered label rather than re-deriving the model, so the chip can never disappear while the label fails to name the model.

**Observed follow-up, deliberately not in this PR:** Codex `spawn_agent` children did not appear as Orca native child rows, because their lifecycle metadata did not populate `AgentStatusEntry.subagents`. Claude-spawned children (fed by the SubagentStart/SubagentStop hooks) render correctly. That looks like an independent main-process/hook integration gap rather than a renderer one, and when that metadata does arrive these rows will render `Luna: …` with no further work, since `buildSubagentChildRows` already maps `subagent.model` and `subagent.description` into the same shape. Happy to file it separately.

## Agent skill upstream boundary

- [x] Not applicable — this change touches only renderer presentation code and copies no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Presentation only: no orchestration semantics, no agent-status transport changes, no protocol or state changes. No new dependencies. No hot-path work — one small string derivation per rendered row. No security, cross-platform, SSH/remote, mobile, or backwards-compatibility surface: rows without a model, or with an unrecognised one, render exactly as before.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after included as a textual diff of the live row; a PNG of the running app is available if you would like it attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (N/A — renderer string formatting only)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` run locally (see Testing for the pre-existing failures); `pnpm build` left to CI
