### PR TITLE
Explain broken npx shim skill update failures

### DIFF
--- a/src/main/skills/skill-update-run.test.ts
+++ b/src/main/skills/skill-update-run.test.ts
@@ -1,4 +1,7 @@
 import { EventEmitter } from 'node:events'
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import type { SkillUpdateRun } from '../../shared/skill-freshness'
 import {
@@ -43,6 +46,17 @@ function makeRunner(
 
 async function flush(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve))
+}
+
+async function waitForSettled(runner: SkillUpdateRunner): Promise<SkillUpdateRun> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    const run = runner.getState()
+    if (run.state !== 'running') {
+      return run
+    }
+  }
+  throw new Error('Timed out waiting for skill update runner to settle')
 }
 
 describe('SkillUpdateRunner', () => {
@@ -152,6 +166,81 @@ describe('SkillUpdateRunner', () => {
     const run = runner.getState()
     expect(run.state === 'error' && run.message).toBe('spawn ENOENT')
     expect(rescan).toHaveBeenCalledTimes(1)
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'explains asdf shim failures with the resolved npx path',
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), 'orca-skill-update-shim-'))
+      const badDir = join(root, 'bad-shim')
+      const npx = join(badDir, 'npx')
+      mkdirSync(badDir, { recursive: true })
+      writeFileSync(
+        npx,
+        [
+          '#!/bin/sh',
+          "echo 'No version is set for command npx' >&2",
+          "echo 'nodejs 22.22.2' >&2",
+          'exit 126'
+        ].join('\n')
+      )
+      chmodSync(npx, 0o755)
+      const previousPath = process.env.PATH
+      process.env.PATH = [badDir, previousPath].filter(Boolean).join(delimiter)
+
+      try {
+        const runner = new SkillUpdateRunner({
+          now: () => 1000,
+          rescanOutdatedNames: async () => ['orca-cli']
+        })
+
+        expect(runner.start(['orca-cli'])).toEqual({ started: true })
+        const run = await waitForSettled(runner)
+
+        expect(run.state).toBe('error')
+        expect(run.state === 'error' && run.output).toContain('No version is set for command npx')
+        expect(run.state === 'error' && run.message).toContain(`npx failed at ${npx}`)
+        expect(run.state === 'error' && run.message).toContain(
+          'Install the Node.js version configured for asdf/mise'
+        )
+        expect(run.state === 'error' && run.message).toContain('skills update exited with code 126')
+      } finally {
+        if (previousPath === undefined) {
+          delete process.env.PATH
+        } else {
+          process.env.PATH = previousPath
+        }
+      }
+    }
+  )
+
+  it('keeps unrelated exit 126 failures generic', async () => {
+    const { runner, child } = makeRunner({ rescanOutdatedNames: async () => ['orca-cli'] })
+    runner.start(['orca-cli'])
+    child.stderr.emit('data', Buffer.from('inner skills command failed after starting'))
+    child.emit('close', 126)
+    await flush()
+
+    const run = runner.getState()
+    expect(run.state).toBe('error')
+    expect(run.state === 'error' && run.message).toBe('skills update exited with code 126')
+  })
+
+  it('does not apply POSIX shim guidance on Windows', async () => {
+    const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    try {
+      const { runner, child } = makeRunner({ rescanOutdatedNames: async () => ['orca-cli'] })
+      runner.start(['orca-cli'])
+      child.stderr.emit('data', Buffer.from('No version is set for command npx'))
+      child.emit('close', 126)
+      await flush()
+
+      const run = runner.getState()
+      expect(run.state).toBe('error')
+      expect(run.state === 'error' && run.message).toBe('skills update exited with code 126')
+    } finally {
+      platform.mockRestore()
+    }
   })
 
   it('refuses a new run until the cancelled process tree is actually dead', async () => {

--- a/src/main/skills/skill-update-run.ts
+++ b/src/main/skills/skill-update-run.ts
@@ -27,6 +27,15 @@ const OUTPUT_FLUSH_MS = 100
 // while a slow-but-healthy sweep is still working.
 export const CANCEL_RELEASE_TIMEOUT_MS = 12_000
 
+const VERSION_MANAGER_SHIM_EXIT_CODES = new Set([126, 127])
+const VERSION_MANAGER_SHIM_FAILURE_PATTERNS = [
+  /\bNo version is set for command npx\b/i,
+  /\bNo preset version installed for command npx\b/i,
+  /\bversion\s+['"]?[^'"\s]+['"]?\s+is not installed\b/i,
+  /\basdf\b[\s\S]*\bnot installed\b/i,
+  /\bmise\b[\s\S]*\bnot installed\b/i
+]
+
 export type SkillUpdateRunnerDeps = {
   spawnProcess?: typeof spawn
   resolveCommand?: (commandName: string) => string
@@ -45,6 +54,39 @@ function stripAnsi(value: string): string {
 
 function clampOutput(value: string): string {
   return value.length <= MAX_OUTPUT_CHARS ? value : value.slice(value.length - MAX_OUTPUT_CHARS)
+}
+
+function versionManagerShimDetail(output: string): string | null {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+  return (
+    lines.find((line) => VERSION_MANAGER_SHIM_FAILURE_PATTERNS.some((p) => p.test(line))) ?? null
+  )
+}
+
+function skillUpdateExitMessage(
+  npxCommand: string,
+  code: number | null,
+  output: string,
+  platform: NodeJS.Platform
+): string {
+  const base = `skills update exited with code ${code}`
+  if (platform === 'win32' || code === null || !VERSION_MANAGER_SHIM_EXIT_CODES.has(code)) {
+    return base
+  }
+
+  const detail = versionManagerShimDetail(output)
+  if (!detail) {
+    return base
+  }
+
+  return (
+    `npx failed at ${npxCommand}: ${detail}. ` +
+    'Install the Node.js version configured for asdf/mise, or move a working npx ahead of that shim on PATH. ' +
+    `(${base})`
+  )
 }
 
 /**
@@ -176,10 +218,11 @@ export class SkillUpdateRunner {
     })
     child.on('close', (code) => {
       drain()
+      const output = this.run.state === 'running' ? this.run.output : ''
       this.settle(
         token,
         canonicalNames,
-        code === 0 ? null : `skills update exited with code ${code}`
+        code === 0 ? null : skillUpdateExitMessage(npxCommand, code, output, process.platform)
       )
     })
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​89 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​89 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |

<!-- /orca-pr-loc -->

Fixes STA-3896.

## What Broke

When skill update resolved `npx` to a broken asdf/mise shim, the real `skills update` child exited with code 126 before it could run. Orca already captured the useful shim stderr in the update log, but the main dialog message collapsed every non-zero close into `skills update exited with code 126`, so the visible failure gave no actionable cause.

## Live Reproduction

I reproduced this on a real isolated Orca dev instance from this worktree with:

- isolated `ORCA_DEV_USER_DATA_PATH`
- CDP on `127.0.0.1:9333`
- renderer on `127.0.0.1:5175`
- `--use-mock-keychain`
- `/@fs` proof that this renderer served files from this worktree and rejected an outside path
- a throwaway PATH fixture with `.tmp/sta-3896-live-repro/bad-shim/npx` first on PATH

Before the fix, clicking the real skill update surface for stale `orca-cli` showed:

```text
Update failed
Updated 0 of 1 skills
orca-cli
Still out of date after the update ran.
The update didn't finish
skills update exited with code 126
```

The expanded log already contained:

```text
No version is set for command npx
Consider adding one of the following versions in your config file at /Users/brennanbenson/orca/workspaces/orca/sta-3896-skill-update-shim/.tmp/sta-3896-live-repro/home/.tool-versions
nodejs 22.22.2
```

After the fix, the same live rig and same broken shim still failed the update, but the visible dialog now reads:

```text
npx failed at /Users/brennanbenson/orca/workspaces/orca/sta-3896-skill-update-shim/.tmp/sta-3896-live-repro/bad-shim/npx: No version is set for command npx. Install the Node.js version configured for asdf/mise, or move a working npx ahead of that shim on PATH. (skills update exited with code 126)
```

Screenshots are saved locally under `.tmp/sta-3896-live-repro/evidence/`:

- `before2-failure-dialog.png`
- `before2-failure-log.png`
- `after-failure-dialog.png`

## Scope

This is presentation-only. I deliberately did not change `resolveCliCommand`, because falling through version-manager shims would change global CLI resolution behavior for every caller, including agents, Git-adjacent paths, provider flows, folder workspaces, and remote/runtime code; STA-3896 only requires making the already-captured cause legible in the skill update failure.

## Cross-Platform Behavior

The shim guidance only applies on non-Windows platforms, only for exit code 126 or 127, and only when the captured output matches a version-manager shim failure signature. Windows behavior is excluded by design because Windows uses `npx.cmd` and has no asdf/mise POSIX shim path here; unrelated non-zero exits, including unrelated 126 exits, keep the generic message.

## Regression Proof

The regression test uses a real temporary executable `npx` shim first on PATH and lets `SkillUpdateRunner` use its default command resolution and spawn behavior; it does not mock the resolver or child process for the positive shim case.

With only the test present and the source fix reverted:

```text
FAIL  src/main/skills/skill-update-run.test.ts > SkillUpdateRunner > explains asdf shim failures with the resolved npx path
AssertionError: expected 'skills update exited with code 126' to contain 'npx failed at /var/folders/1y/_t14pyz…'

Expected: "npx failed at /var/folders/1y/_t14pyzd3qqdml33sfq8b34w0000gn/T/orca-skill-update-shim-lpqBG1/bad-shim/npx"
Received: "skills update exited with code 126"

Test Files  1 failed (1)
Tests  1 failed | 21 passed (22)
RED_EXIT=1
```

After restoring the source fix:

```text
Test Files  1 passed (1)
Tests  22 passed (22)
GREEN_EXIT=0
```

## Verification

All final checks passed under Node 24 via `PATH=/opt/homebrew/opt/node@24/bin:$PATH`.

```text
pnpm tc
TC_EXIT=0
```

```text
pnpm test src/main/skills/skill-update-run.test.ts
Test Files  1 passed (1)
Tests  22 passed (22)
```

```text
pnpm run check:code-quality:changed
code quality: 0 new finding(s) across 2 changed file(s).
type-aware code quality: 0 new finding(s) across 2 changed file(s).
React Doctor: 0 new finding(s) across 2 changed file(s).
Changed-code quality gate passed since 94e7586665c2.
```
