### PR TITLE
refactor(pty): say what the liveness vocabulary actually fixes, and dedupe the observation status

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration-federation-control.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-control.ts
@@ -6,6 +6,7 @@ import { OrchestrationError } from '../../orchestration/orchestration-error'
 import type { RemoteDispatchAttachmentRow } from '../../orchestration/types'
 import { defineMethod, type RpcMethod } from '../core'
 import { OptionalFiniteNumber, requiredString } from '../schemas'
+import type { WorkerTerminalObservationStatus } from './orchestration-worker-observation'
 import { readExactWorkerOutput } from './orchestration-worker-output'
 import { describeUnconfirmedAgentStop } from '../../../../shared/pty-liveness-verdict'
 
@@ -215,7 +216,7 @@ async function inspectRemoteAttachment(
 ): Promise<{
   terminal: Awaited<ReturnType<OrcaRuntimeService['showTerminal']>> | null
   exact: boolean
-  status: 'unattached' | 'missing' | 'identity_changed' | 'live' | 'exited' | 'unverifiable'
+  status: WorkerTerminalObservationStatus
   /** Set with `unverifiable`; names what we lost contact with. */
   reason?: string
   /** Set only on a proven-exact attachment parked on a prompt that needs a human. */

--- a/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
@@ -8,6 +8,19 @@ import type {
   WorkerDispatchRow
 } from '../../orchestration/types'
 
+/**
+ * What a terminal observation can conclude. The last three are the fixed
+ * `live` / `unverifiable` / `exited` verdict vocabulary; the first three say the
+ * question was never reached, and must never collapse into `exited`.
+ */
+export type WorkerTerminalObservationStatus =
+  | 'unattached'
+  | 'missing'
+  | 'identity_changed'
+  | 'live'
+  | 'exited'
+  | 'unverifiable'
+
 export async function inspectWorkerTerminal(
   runtime: OrcaRuntimeService,
   db: OrchestrationDb,
@@ -15,7 +28,7 @@ export async function inspectWorkerTerminal(
 ): Promise<{
   terminal: Awaited<ReturnType<OrcaRuntimeService['showTerminal']>> | null
   exact: boolean
-  status: 'unattached' | 'missing' | 'identity_changed' | 'live' | 'exited' | 'unverifiable'
+  status: WorkerTerminalObservationStatus
   /** Set with `unverifiable`; names what we lost contact with. */
   reason?: string
   /** Set only on a proven-exact worker parked on a prompt that needs a human. */

--- a/src/shared/pty-liveness-verdict.ts
+++ b/src/shared/pty-liveness-verdict.ts
@@ -1,10 +1,19 @@
 /**
- * The one vocabulary Orca uses to talk about whether a PTY is live.
+ * `live` / `unverifiable` / `exited` for a PTY — the fixed verdict vocabulary of
+ * docs/reference/ssh-execution-boundary.md.
  *
  * `exited` requires positive evidence of absence from the owning host. Losing
  * contact with that host — an unregistered SSH provider, a dropped relay, an
  * inventory that only enumerates registered providers — is `unverifiable`, never
  * a death certificate and never a successful stop.
+ *
+ * What that doc fixes is the three spellings, "whatever the field is named" — not
+ * one type and not one discriminant. `PtyProcessInspectionEvidence` spells the
+ * same three under `verdict`, answering a different question (does this shell
+ * have children) with different payloads, and ships them across the relay wire
+ * inside `processEvidence`. Keep the shapes separate: renaming that discriminant
+ * reads as malformed evidence on the far side of a version skew, which is worse
+ * than the field being absent, and the arms are not interchangeable anyway.
  */
 export type PtyLivenessVerdict =
   | { status: 'exited' }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

## ELI5

Two places in Orca describe whether a terminal is alive using the same three words, but store them
under differently-named fields. Five separate reviews looked at that and concluded it was
copy-and-paste that ought to be merged into one. Someone went and enumerated every place this
vocabulary actually appears: there are **six** different shapes, not two, and they differ in real ways
— different numbers of options, different data attached, and some of them travel between machines
where a rename would break older clients.

So the answer is: don't merge them. What was actually wrong was a comment claiming one of them was
"the one vocabulary Orca uses". This PR fixes that comment, writes down why the shapes stay separate
so the next reviewer doesn't file it a sixth time, and separately removes one list of options that
genuinely was duplicated.

## User-facing before / after

| | Before | After |
|---|---|---|
| Anything you do in the app | — | **No change.** This is a comment correction plus one duplicated type removed |
| A reviewer reading that file | The comment invited the conclusion that two types should be merged — five separate reviews reached it, and acting on it would have been a wire-breaking rename | The comment says what is true, and the reasoning is recorded next to it |

## When it bites

Nobody in the app. It bites reviewers, repeatedly — which is the thing this closes.


## Summary

Five independent lanes flagged today that `src/shared/pty-liveness-verdict.ts` calls itself *"the one
vocabulary Orca uses to talk about whether a PTY is live"* while #16926's `PtyChildProcessesEvidence`
spells the same three values under `verdict` instead of `status`.

**I did the enumeration and the answer is: do not rename either one.** The header comment is the
defect, not the second type. This PR fixes the comment, records why the shapes stay separate so the
next lane does not re-file it, and separately dedupes one union that genuinely *was* copy-pasted.

## What the inventory actually found — six shapes, not two

| # | Shape | Discriminant | Arms | Payloads | Crosses a version boundary? |
|---|---|---|---|---|---|
| 1 | `PtyLivenessVerdict` | `status` | 3 | `live` carries **`ptyIds: string[]`** | No — main-process only |
| 2 | `PtyChildProcessesEvidence` (#16926) | `verdict` | 3 | `live`/`exited` carry nothing | **Yes** — relay + daemon |
| 3 | `PtyForegroundProcessEvidence` (#16926) | `verdict` | **2** (`observed`/`unverifiable`) | — | **Yes** — same field |
| 4 | `inspectWorkerTerminal` / `inspectRemoteAttachment` status | `status` | **6** | flat | **Yes** — federation RPC + CLI |
| 5 | `PtyPresenceObservation` (#16932) | `status` | 3 | `unverifiable` carries `reason` | No |
| 6 | `classifyWorkerTerminalProcessIncarnation` | *(bare string union)* | 3 | none | No |

Shape 4 is six-valued, not three: `unattached | missing | identity_changed | live | exited | unverifiable`.
Shape 3 does not even share the arm names. So "two parallel unions over the same three values" describes
one pair out of six, and the discriminant field name is the only thing they have in common.

## Why the rename is wrong

**1. `docs/reference/ssh-execution-boundary.md` does not ask for it.** Line 14 fixes the vocabulary as the
three *values*; line 55 pins them explicitly **"whatever the field is named"**. Both `{status}` and
`{verdict}` already comply. The rename buys nothing the contract asks for.

**2. The two types never meet, and answer different questions.** Their consumer sets are disjoint —
`PtyLivenessVerdict` lives in PTY teardown / orchestration liveness (`orca-runtime.ts`,
`unstopped-pty-verification.ts`, `worktree-teardown.ts`); `PtyChildProcessesEvidence` lives in agent-completion
detection (`pty-process-probes.ts`, `local-pty-process-evidence.ts`, `agent-completion-process-monitor.ts`).
*"Does this shell have child processes"* is not *"is this PTY live."* Giving them one field name would
suggest an interchangeability that does not exist.

**3. They cannot become one type anyway.** `PtyLivenessVerdict`'s `live` arm **requires** `ptyIds: string[]`;
the evidence `live` arm carries nothing. Merging means making `ptyIds` optional, which forces every reader in
`unstopped-pty-verification.ts` to handle absence — a behavior change. Per the brief I stopped rather than
decide that.

**4. Renaming #2's discriminant is a wire break in both directions.** This is the decisive one.
`PtyChildProcessesEvidence` ships inside `processEvidence` on the relay's `inspectProcess` result, across two
independently-versioned boundaries (the relay on the SSH host, and `orcad`, which already version-gates this
call at `COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION`).

`normalizeChildrenEvidence` reads `evidence.verdict`. Rename it and:

- **new client ← old host**: host sends `{verdict:'exited'}`, reader looks for `status`, falls through to
  `{verdict:'unverifiable', reason:'malformed…'}`;
- **old client ← new host**: exactly symmetric.

Then `agent-completion-process-monitor.ts` refuses (`children.verdict !== 'exited'`), re-arms, and **agent
completion never dispatches on that pane again.**

That is strictly worse than the field not existing: when `processEvidence` is *absent*,
`readPtyProcessInspectionEvidence` takes the legacy-field branch and produces a working answer. The rename
converts a working mixed-version pair into a permanently broken one. Per
`docs/reference/remote-wire-compatibility.md` that is a Rule 1 violation (the reader would require a key old
hosts never send) and Rule 3 (changing what the host publishes). **Category: wire migration, not a rename.**

A dual-publish `{verdict, status}` migration would be safe — but it *adds* a third spelling and must be kept
until the version floor moves, which is the exact failure mode this refactor was meant to prevent.

## What this PR does change

**1. `src/shared/pty-liveness-verdict.ts` — the header comment.** Restate the invariant the way the boundary
doc states it, name `PtyProcessInspectionEvidence` as the deliberate sibling, and say why renaming its
discriminant is unsafe. This is the actual defect: the false claim is what five lanes each tripped over.

**2. The six-valued observation status — a real copy-paste.** It was declared **verbatim** in both
`orchestration-worker-observation.ts:18` and `orchestration-federation-control.ts:218`. Extracted once as
`WorkerTerminalObservationStatus` and imported. Type-only; no value changes.

The two functions' verdict logic is spelled differently, so I ran a 12-combination differential over
`(verdict, connected)` rather than reasoning about it: **0 divergences.** I did not unify the functions — only
the type.

## Behavior, tests, gates

**No behavior change.** Every gate is exactly as conservative; no arm added, removed, or respelled.

**Zero test files touched** — that is the proof this is a refactor. 8 affected suites, **74/74 green**, no
assertion edited to accommodate anything. I added no tests: nothing changed, and inventing pins for unchanged
behavior would be worse than not.

- `pnpm tc` exit 0 · `oxlint` + react-doctor clean · `oxfmt --write` on the 3 changed files only · `git diff --check` clean
- No `max-lines` disable or bump, no suppressions, no `node:child_process` import

## Sequencing

Main-based, and `git merge-tree` is **conflict-free against all four in-flight heads** — #16932 `2fdd4435c1`
(which edits the same file), #16953 `c90e2df0c3`, #17024 `4490961bc1`, and the stack tip #17003 `5dfbe98858`.
I pushed to none of them.

**Draft for one reason: merge after #16926.** The new comment names `PtyProcessInspectionEvidence`, which
arrives with #16926. It is prose, so nothing fails to compile either way — but merged first, the comment would
point at a type that does not exist yet. The type extraction (change 2) has no such dependency.

## Open question I declined to answer

Merging shapes #1 and #2 into one type requires making `ptyIds` optional on the `live` arm and updating every
reader in `unstopped-pty-verification.ts` to handle its absence. That is a behavior decision, not a refactor,
so I stopped and am reporting it instead.

