### PR TITLE
test(e2e): make the cold-hydration spec check its own captured snapshot

### DIFF
--- a/tests/e2e/ssh-cold-hydration-gap-tab-seeding.spec.ts
+++ b/tests/e2e/ssh-cold-hydration-gap-tab-seeding.spec.ts
@@ -101,6 +101,28 @@ function blockRemoteWorkspaceGet(target: DockerSshRelayTarget, snapshotPath: str
   return saved
 }
 
+/**
+ * Tab ids the relay actually persisted, or null when the bytes are not parseable JSON.
+ *
+ * The spec replays this capture verbatim, so bytes that carry no tab make every downstream count
+ * meaningless: an empty session places nothing, therefore reports nothing unplaced, therefore
+ * hydrates cleanly and replaces the worktree's tabs with none. That is indistinguishable from the
+ * regression this test exists to catch, so the capture has to be checked before it is trusted.
+ */
+function capturedSnapshotTabIds(saved: string): string[] | null {
+  try {
+    const parsed = JSON.parse(saved) as {
+      session?: { tabsByWorktreePath?: Record<string, { id?: unknown }[]> }
+    }
+    return Object.values(parsed.session?.tabsByWorktreePath ?? {})
+      .flat()
+      .map((tab) => tab?.id)
+      .filter((id): id is string => typeof id === 'string')
+  } catch {
+    return null
+  }
+}
+
 function unblockRemoteWorkspaceGet(
   target: DockerSshRelayTarget,
   snapshotPath: string,
@@ -174,6 +196,18 @@ test.describe('SSH cold hydration gap tab seeding', () => {
       app = null
 
       const saved = blockRemoteWorkspaceGet(target, snapshotPath)
+      // Precondition, not an expectation about the product: everything below reads the bytes this
+      // capture holds, so a capture that never recorded the baseline has to fail here and name
+      // itself rather than surface later as a tab count the product appears to have lost.
+      const capturedTabIds = capturedSnapshotTabIds(saved)
+      expect(
+        capturedTabIds,
+        `the captured host snapshot ${snapshotPath} is not parseable JSON, so replaying it proves nothing: ${JSON.stringify(saved.slice(0, 200))}`
+      ).not.toBeNull()
+      expect(
+        remote.tabIds.filter((id) => !(capturedTabIds ?? []).includes(id)),
+        `the captured host snapshot ${snapshotPath} holds ${capturedTabIds?.length ?? 0} tab(s) and is missing part of the ${BASELINE_TAB_COUNT}-tab baseline this test seeded, so the bytes it replays are not the workspace the assertions below describe`
+      ).toEqual([])
       const relaunch = await restart.launch()
       app = relaunch.app
       const page = relaunch.page


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Fixes the `ssh-cold-hydration-gap-tab-seeding` spec so it checks its own precondition instead of failing downstream.

## ELI5

This test captures a session snapshot, relaunches, replays the snapshot, and then checks that the tabs came back. If the capture happened to be **empty**, the test still sailed through the replay and only fell over much later, on `afterHydration=0` — which reads exactly like the product losing your tabs. It wasn't. The test just never looked at what it had captured.

Now it asserts the captured snapshot **before** the relaunch that replays it, so an empty or unparseable capture fails right there and names itself.

## Why the old failure was not a product bug

Traced through product code: an empty session **places nothing**, therefore **reports nothing unplaced**, therefore **marks hydrated** and replaces the worktree's tabs with none. That reproduces the observed `baseline=3 duringStall=3 afterHydration=0` exactly — and it is **correct behaviour for a genuinely empty host snapshot**.

## Before / after

| | Before | After |
|---|---|---|
| Capture is empty | Fails late on `afterHydration=0`, indistinguishable from a real tab-loss regression | Fails at the capture, naming the empty snapshot |
| Capture is good | Unchanged | Unchanged |

## What this is NOT

- **No assertion was weakened.** The `afterHydration` expectation is untouched.
- **No retry, no sleep, no timeout bump.** The fix is an added precondition, not a relaxed one.

## Context

This spec accounts for **1 of 29** failures on the `e2e / ssh docker watcher isolation` lane. The dominant failure on that lane (6 of 7) is a separate stale `connectDockerRemote` fork, fixed by #17017.

## Not verified

Docker is dead on the authoring machine (`docker ps` returns EOF; `docker desktop restart` fails with `context deadline exceeded`), so **nothing was run locally** — this rests on CI logs and source reading. `pnpm tc`, lint, the quality gate, and the ratchets are green.