### PR TITLE
Change artifact link button wording

### DIFF
--- a/src/renderer/src/components/artifacts/ArtifactPublishButton.test.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactPublishButton.test.tsx
@@ -97,7 +97,7 @@ describe('ArtifactPublishButton', () => {
     await user.click(screen.getByRole('button', { name: 'Share as artifact' }))
     expect(mocks.publish).not.toHaveBeenCalled()
 
-    await user.click(await screen.findByRole('button', { name: 'Share public link' }))
+    await user.click(await screen.findByRole('button', { name: 'Generate link' }))
     await waitFor(() => expect(mocks.publish).toHaveBeenCalledWith(createRequest))
     expect(screen.getByText('https://example.com')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Update shared content' })).toBeInTheDocument()
@@ -108,7 +108,7 @@ describe('ArtifactPublishButton', () => {
     mocks.state.orcaProfileAuthStatus = { configured: true, state: 'local' }
     render(<ArtifactPublishButton sourceKey="/repo/report.md" createRequest={vi.fn()} />)
 
-    expect(await screen.findByRole('button', { name: 'Share public link' })).toBeDisabled()
+    expect(await screen.findByRole('button', { name: 'Generate link' })).toBeDisabled()
     await user.click(screen.getByRole('button', { name: 'Sign in' }))
 
     expect(mocks.connect).toHaveBeenCalledOnce()
@@ -121,7 +121,7 @@ describe('ArtifactPublishButton', () => {
     render(<ArtifactPublishButton sourceKey="/repo/report.md" createRequest={vi.fn()} />)
 
     await user.click(screen.getByRole('button', { name: 'Share as artifact' }))
-    expect(await screen.findByRole('button', { name: 'Share public link' })).toBeDisabled()
+    expect(await screen.findByRole('button', { name: 'Generate link' })).toBeDisabled()
     await user.click(screen.getByRole('button', { name: 'Open Artifacts settings' }))
 
     expect(mocks.openSettingsTarget).toHaveBeenCalledWith({ pane: 'artifacts', repoId: null })

--- a/src/renderer/src/components/artifacts/ArtifactPublishButton.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactPublishButton.tsx
@@ -284,7 +284,7 @@ export function ArtifactPublishButton({
                 ? translate('auto.components.artifacts.ArtifactPublishButton.sharing', 'Sharing…')
                 : translate(
                     'auto.components.artifacts.ArtifactPublishButton.sharePublicLink',
-                    'Share public link'
+                    'Generate link'
                   )}
             </Button>
           )}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16240,7 +16240,7 @@
           "publishingOffDescription": "Learn about public links and enable sharing in Settings.",
           "openSettings": "Open Artifacts settings",
           "sharing": "Sharing…",
-          "sharePublicLink": "Share public link",
+          "sharePublicLink": "Generate link",
           "publishedDescription": "Anyone with this link can view the shared file.",
           "checkingLink": "Checking for an existing link…",
           "checkFailed": "Could not check for an existing link.",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | 0 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | 0 |

<!-- /orca-pr-loc -->

Changes the artifact publishing action from "Share public link" to "Generate link".