### PR TITLE
fix(cmd-j): index folder-workspace tabs so they are reachable from the palette

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -142,6 +142,11 @@ import {
 import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
 import { buildSidebarHostOptions } from '@/components/sidebar/sidebar-host-options'
 import { getPaletteHostBadge } from '@/components/cmd-j/palette-host-badge'
+import {
+  collectFolderWorkspaceHostLabels,
+  collectPaletteTabIndexWorkspaces,
+  excludePaletteFolderWorkspaces
+} from '@/components/cmd-j/palette-folder-workspace-tab-index'
 import { getWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
 import { getRepoHostIdentity } from '@/store/slices/repo-host-identity'
 import type { Repo } from '../../../shared/repo-types'
@@ -746,6 +751,7 @@ function WorktreeJumpPaletteContent({
   const revealSidebarRow = useAppStore((s) => s.revealSidebarRow)
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
   const allWorktrees = useAllWorktrees()
+  const folderWorkspaces = useAppStore((s) => s.folderWorkspaces)
   const repos = useAppStore((s) => s.repos)
   const projectGroups = useAppStore((s) => s.projectGroups)
   const projects = useAppStore((s) => s.projects)
@@ -1095,15 +1101,23 @@ function WorktreeJumpPaletteContent({
     return hasQuery && filterPredicate ? scope.filter(filterPredicate.matchesWorktree) : scope
   }, [allWorktrees, filterPredicate, hasQuery, switchableWorktreesForRows])
 
-  // Why: browser-tab search is cross-worktree, so sort all worktrees once (including archived).
+  // Why unfiltered and ungated: tab ownership is decided against every workspace that
+  // exists, not the subset the current filter renders.
+  const paletteTabIndexOwnershipWorkspaces = useMemo(
+    () => collectPaletteTabIndexWorkspaces(allWorktrees, folderWorkspaces),
+    [allWorktrees, folderWorkspaces]
+  )
+
+  // Why: tab search is cross-workspace, so sort every workspace once (including archived
+  // ones, and folder workspaces alongside worktrees so both kinds interleave by attention).
   // Gated on paletteStatusInputsActive so the closed-but-mounted palette skips the sort entirely.
-  const browserSortedWorktrees = useMemo(() => {
+  const paletteTabIndexWorkspaces = useMemo(() => {
     if (!paletteStatusInputsActive) {
       return EMPTY_SORTED_WORKTREES
     }
     const scope = filterPredicate
-      ? allWorktrees.filter(filterPredicate.matchesWorktree)
-      : allWorktrees
+      ? paletteTabIndexOwnershipWorkspaces.filter(filterPredicate.matchesWorktree)
+      : paletteTabIndexOwnershipWorkspaces
     return sortWorktreesSmart(
       scope,
       tabsByWorktree,
@@ -1116,7 +1130,7 @@ function WorktreeJumpPaletteContent({
     )
   }, [
     paletteStatusInputsActive,
-    allWorktrees,
+    paletteTabIndexOwnershipWorkspaces,
     filterPredicate,
     tabsByWorktree,
     repoMap,
@@ -1127,6 +1141,13 @@ function WorktreeJumpPaletteContent({
     terminalLayoutsByTabId
   ])
 
+  // Why derived, not a second sort: worktree rows, browser pages and simulator tabs have no
+  // folder-workspace path yet, so they read the worktree-only view of the same ordering.
+  const browserSortedWorktrees = useMemo(
+    () => excludePaletteFolderWorkspaces(paletteTabIndexWorkspaces),
+    [paletteTabIndexWorkspaces]
+  )
+
   // Why: derive typed-query sort from browserSortedWorktrees (P2-a) — both call sortWorktreesSmart
   // with the same deps, so filtering the superset avoids a redundant sort.
   const sortedWorktrees = useMemo(
@@ -1135,9 +1156,10 @@ function WorktreeJumpPaletteContent({
   )
 
   // Why browser search includes archived worktrees, so its host-qualified metadata index must too.
+  // Folder workspaces ride along so an open-tab row can resolve the workspace it belongs to.
   const paletteWorktreeIndex = useMemo(
-    () => buildPaletteWorktreeIndex(browserSortedWorktrees),
-    [browserSortedWorktrees]
+    () => buildPaletteWorktreeIndex(paletteTabIndexWorkspaces),
+    [paletteTabIndexWorkspaces]
   )
 
   const resolveWorktree = useCallback(
@@ -1149,9 +1171,12 @@ function WorktreeJumpPaletteContent({
   const worktreeOrder = useMemo(
     () =>
       new Map(
-        browserSortedWorktrees.map((worktree, index) => [getWorktreeHostIdentity(worktree), index])
+        paletteTabIndexWorkspaces.map((worktree, index) => [
+          getWorktreeHostIdentity(worktree),
+          index
+        ])
       ),
-    [browserSortedWorktrees]
+    [paletteTabIndexWorkspaces]
   )
 
   const checksReviewByWorktree = useMemo(
@@ -1179,8 +1204,16 @@ function WorktreeJumpPaletteContent({
         labels.set(getWorktreeHostIdentity(worktree), badge.label)
       }
     }
+    // Folder workspaces carry their own host stamp instead of inheriting a repo's.
+    for (const [identity, label] of collectFolderWorkspaceHostLabels(
+      folderWorkspaces,
+      hostOptions,
+      hostFilterActive
+    )) {
+      labels.set(identity, label)
+    }
     return labels
-  }, [allWorktrees, hostFilterActive, hostOptions, resolveRepoForWorktree])
+  }, [allWorktrees, folderWorkspaces, hostFilterActive, hostOptions, resolveRepoForWorktree])
 
   // Why keyed on the unsorted list: normalized documents depend only on text
   // inputs, so re-sorting for recency re-ranks without re-normalizing anything.
@@ -1312,8 +1345,10 @@ function WorktreeJumpPaletteContent({
       return EMPTY_WORKSPACE_TAB_ENTRIES
     }
     return buildSearchableWorkspaceTabs({
-      worktrees: browserSortedWorktrees,
-      ownershipWorktrees: allWorktrees,
+      // Why the combined list: a folder workspace's tabs live in the same tab maps as a
+      // worktree's, so leaving them out made every one of them unreachable from Cmd+J.
+      worktrees: paletteTabIndexWorkspaces,
+      ownershipWorktrees: paletteTabIndexOwnershipWorkspaces,
       repoMap,
       repoMapByHostIdentity: repoByHostIdentity,
       worktreeOrder,
@@ -1349,8 +1384,8 @@ function WorktreeJumpPaletteContent({
     activeWorktreeId,
     activeWorkspaceExecutionHostId,
     agentStatusByPaneKey,
-    allWorktrees,
-    browserSortedWorktrees,
+    paletteTabIndexOwnershipWorkspaces,
+    paletteTabIndexWorkspaces,
     groupsByWorktree,
     openFiles,
     repoByHostIdentity,
@@ -2670,17 +2705,21 @@ function WorktreeJumpPaletteContent({
     (result: WorkspaceTabPaletteSearchResult) => {
       const activation = activateWorkspaceTabPaletteResult(result)
       if (activation.status === 'failed') {
-        toast.error(
-          activation.reason === 'missing-worktree'
-            ? translate(
-                'auto.components.WorktreeJumpPalette.2c38630a01',
-                'Workspace no longer exists'
-              )
-            : translate(
-                'auto.components.WorktreeJumpPalette.workspaceTabMissing',
-                'Tab no longer exists'
-              )
-        )
+        // A declined activation already explained itself (a folder workspace whose path is
+        // gone or whose host is unreachable), so a second toast would only contradict it.
+        if (activation.reason !== 'activation-declined') {
+          toast.error(
+            activation.reason === 'missing-worktree'
+              ? translate(
+                  'auto.components.WorktreeJumpPalette.2c38630a01',
+                  'Workspace no longer exists'
+                )
+              : translate(
+                  'auto.components.WorktreeJumpPalette.workspaceTabMissing',
+                  'Tab no longer exists'
+                )
+          )
+        }
         return
       }
 
@@ -3545,6 +3584,13 @@ function WorktreeJumpPaletteContent({
                   ? resolveRepoForWorktree(workspaceTabWorktree)
                   : undefined
                 const workspaceTabRepoName = workspaceTabRepo?.displayName ?? result.repoName
+                // Why only without a repo badge: a folder workspace hangs off a project group,
+                // so the host label is what tells a remote tab apart from a local one.
+                const workspaceTabHostLabel =
+                  !workspaceTabRepoName && workspaceTabWorktree
+                    ? (hostLabelByWorktreeId.get(getWorktreeHostIdentity(workspaceTabWorktree)) ??
+                      null)
+                    : null
                 const workspaceTabFallback =
                   result.contentType === 'terminal' && result.occupantAgent ? (
                     <span
@@ -3620,6 +3666,14 @@ function WorktreeJumpPaletteContent({
                                   matchRanges={result.repoRanges}
                                 />
                               </span>
+                            </span>
+                          )}
+                          {workspaceTabHostLabel && (
+                            <span
+                              data-slot="palette-open-tab-host"
+                              className="inline-block max-w-[180px] truncate rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground"
+                            >
+                              {workspaceTabHostLabel}
                             </span>
                           )}
                           <PaletteRowShortcutBadge

--- a/src/renderer/src/components/cmd-j/palette-folder-workspace-tab-index.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-folder-workspace-tab-index.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from 'vitest'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { Tab, TabGroup } from '../../../../shared/tab-types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
+import {
+  buildSearchableWorkspaceTabs,
+  searchWorkspaceTabs
+} from '@/lib/workspace-tab-palette-search'
+import { sortWorktreesSmart } from '../sidebar/smart-sort'
+import type { SidebarHostOption } from '../sidebar/sidebar-host-options'
+import {
+  collectFolderWorkspaceHostLabels,
+  collectPaletteTabIndexWorkspaces,
+  excludePaletteFolderWorkspaces
+} from './palette-folder-workspace-tab-index'
+
+const WORKSPACE_KEY = 'folder:fw-1'
+
+function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'fw-1',
+    projectGroupId: 'group-tasks',
+    name: 'Tasks',
+    folderPath: '/tmp/tasks',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides
+  }
+}
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-1',
+    repoId: 'repo-1',
+    path: '/tmp/wt-1',
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'Palette Worktree',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+function makeUnifiedTab(overrides: Partial<Tab> = {}): Tab {
+  return {
+    id: 'unified-terminal-1',
+    entityId: 'terminal-1',
+    groupId: 'group-1',
+    worktreeId: WORKSPACE_KEY,
+    contentType: 'terminal',
+    label: 'ORCA-42 payment retries',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0,
+    ...overrides
+  }
+}
+
+function makeTerminalTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: 'terminal-1',
+    ptyId: 'pty-1',
+    worktreeId: WORKSPACE_KEY,
+    title: 'zsh',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0,
+    ...overrides
+  }
+}
+
+function makeGroup(overrides: Partial<TabGroup> = {}): TabGroup {
+  return {
+    id: 'group-1',
+    worktreeId: WORKSPACE_KEY,
+    activeTabId: 'unified-terminal-1',
+    tabOrder: ['unified-terminal-1'],
+    ...overrides
+  }
+}
+
+function buildEntries(
+  workspaces: readonly Worktree[],
+  overrides: Partial<Parameters<typeof buildSearchableWorkspaceTabs>[0]> = {}
+) {
+  return buildSearchableWorkspaceTabs({
+    worktrees: workspaces,
+    ownershipWorktrees: workspaces,
+    repoMap: new Map(),
+    worktreeOrder: new Map(
+      workspaces.map((workspace, index) => [getWorktreeHostIdentity(workspace), index])
+    ),
+    unifiedTabsByWorktree: { [WORKSPACE_KEY]: [makeUnifiedTab()] },
+    tabsByWorktree: { [WORKSPACE_KEY]: [makeTerminalTab()] },
+    openFiles: [],
+    agentStatusByPaneKey: {},
+    retainedAgentsByPaneKey: {},
+    sleepingAgentSessionsByPaneKey: {},
+    activeGroupIdByWorktree: {},
+    groupsByWorktree: { [WORKSPACE_KEY]: [makeGroup()] },
+    activeWorktreeId: null,
+    activeTabType: 'terminal',
+    activeTabId: null,
+    activeTabIdByWorktree: {},
+    activeFileId: null,
+    activeFileIdByWorktree: {},
+    activeTabTypeByWorktree: {},
+    generatedTitlesEnabled: true,
+    ...overrides
+  })
+}
+
+const LOCAL_HOST: SidebarHostOption = {
+  id: 'local',
+  label: 'This computer',
+  detail: '',
+  kind: 'local',
+  health: 'local',
+  presence: 'local'
+}
+
+const SSH_HOST: SidebarHostOption = {
+  id: 'ssh:remote-1',
+  label: 'build-box',
+  detail: '',
+  kind: 'ssh',
+  health: 'available',
+  presence: 'configured'
+}
+
+describe('collectPaletteTabIndexWorkspaces', () => {
+  it('adapts folder workspaces into the worktree shape the tab index walks', () => {
+    const workspaces = collectPaletteTabIndexWorkspaces(
+      [makeWorktree()],
+      [makeFolderWorkspace({ connectionId: 'remote-1' })]
+    )
+
+    expect(workspaces.map((workspace) => workspace.id)).toEqual(['wt-1', WORKSPACE_KEY])
+    expect(workspaces[1]?.displayName).toBe('Tasks')
+    expect(workspaces[1]?.hostId).toBe('ssh:remote-1')
+  })
+
+  it('keeps folder-workspace ids out of the worktree id space', () => {
+    // Why: palette rows key on the workspace id, so a collision would let one row
+    // resolve — and activate — the other workspace.
+    const workspaces = collectPaletteTabIndexWorkspaces(
+      [makeWorktree({ id: 'fw-1' })],
+      [makeFolderWorkspace()]
+    )
+
+    expect(new Set(workspaces.map((workspace) => workspace.id)).size).toBe(workspaces.length)
+  })
+
+  it('returns the same array when there is no folder workspace to exclude', () => {
+    const worktrees = [makeWorktree()]
+    expect(excludePaletteFolderWorkspaces(worktrees)).toBe(worktrees)
+  })
+
+  it('drops folder workspaces for the indexes that only understand worktrees', () => {
+    const workspaces = collectPaletteTabIndexWorkspaces([makeWorktree()], [makeFolderWorkspace()])
+    expect(excludePaletteFolderWorkspaces(workspaces).map((workspace) => workspace.id)).toEqual([
+      'wt-1'
+    ])
+  })
+})
+
+describe('folder-workspace tabs in the Cmd+J tab index', () => {
+  it('finds a folder-workspace tab by its title', () => {
+    const workspaces = collectPaletteTabIndexWorkspaces([], [makeFolderWorkspace()])
+    const results = searchWorkspaceTabs(buildEntries(workspaces), 'ORCA-42')
+
+    expect(results.map((result) => result.worktreeId)).toEqual([WORKSPACE_KEY])
+    expect(results[0]?.title).toBe('ORCA-42 payment retries')
+    expect(results[0]?.worktreeName).toBe('Tasks')
+  })
+
+  it('stamps the SSH host so the row activates on the host it was indexed from', () => {
+    const workspaces = collectPaletteTabIndexWorkspaces(
+      [],
+      [makeFolderWorkspace({ connectionId: 'remote-1' })]
+    )
+    const [result] = searchWorkspaceTabs(buildEntries(workspaces), '')
+
+    expect(result?.executionHostId).toBe('ssh:remote-1')
+  })
+
+  it('keeps a remote folder workspace indexed while its host is unreachable', () => {
+    // Why: losing contact with a host says nothing about the workspace existing —
+    // dropping the rows would make the tabs unreachable exactly when they are needed.
+    const workspaces = collectPaletteTabIndexWorkspaces(
+      [],
+      [makeFolderWorkspace({ connectionId: 'remote-1' })]
+    )
+    const results = searchWorkspaceTabs(buildEntries(workspaces), 'ORCA-42')
+
+    expect(results).toHaveLength(1)
+    expect(
+      collectFolderWorkspaceHostLabels(
+        [makeFolderWorkspace({ connectionId: 'remote-1' })],
+        [LOCAL_HOST, { ...SSH_HOST, health: 'disconnected' }],
+        true
+      ).get(`ssh:remote-1|${WORKSPACE_KEY}`)
+    ).toBe('build-box')
+  })
+
+  it('orders folder workspaces among worktrees instead of after them', () => {
+    const worktree = makeWorktree({ sortOrder: 1 })
+    const folderWorkspace = makeFolderWorkspace({ sortOrder: 2 })
+    // Cold start (no live PTY) ranks by persisted sortOrder, so the folder workspace leads.
+    const sorted = sortWorktreesSmart(
+      collectPaletteTabIndexWorkspaces([worktree], [folderWorkspace]),
+      {},
+      new Map(),
+      {},
+      {},
+      {}
+    )
+
+    expect(sorted.map((workspace) => workspace.id)).toEqual([WORKSPACE_KEY, 'wt-1'])
+
+    const entries = buildEntries(sorted, {
+      unifiedTabsByWorktree: {
+        [WORKSPACE_KEY]: [makeUnifiedTab()],
+        'wt-1': [
+          makeUnifiedTab({
+            id: 'unified-terminal-2',
+            worktreeId: 'wt-1',
+            label: 'ORCA-42 shell'
+          })
+        ]
+      },
+      tabsByWorktree: {
+        [WORKSPACE_KEY]: [makeTerminalTab()],
+        'wt-1': [makeTerminalTab({ worktreeId: 'wt-1' })]
+      },
+      groupsByWorktree: {
+        [WORKSPACE_KEY]: [makeGroup()],
+        'wt-1': [
+          makeGroup({
+            worktreeId: 'wt-1',
+            activeTabId: 'unified-terminal-2',
+            tabOrder: ['unified-terminal-2']
+          })
+        ]
+      }
+    })
+
+    expect(searchWorkspaceTabs(entries, 'ORCA-42').map((result) => result.worktreeId)).toEqual([
+      WORKSPACE_KEY,
+      'wt-1'
+    ])
+  })
+})
+
+describe('collectFolderWorkspaceHostLabels', () => {
+  it('labels a remote folder workspace by its own host stamp', () => {
+    const labels = collectFolderWorkspaceHostLabels(
+      [makeFolderWorkspace({ executionHostId: 'ssh:remote-1' })],
+      [LOCAL_HOST, SSH_HOST],
+      false
+    )
+
+    expect(labels.get(`ssh:remote-1|${WORKSPACE_KEY}`)).toBe('build-box')
+  })
+
+  it('leaves local folder workspaces unlabelled when no remote host is live', () => {
+    const labels = collectFolderWorkspaceHostLabels([makeFolderWorkspace()], [LOCAL_HOST], false)
+
+    expect(labels.size).toBe(0)
+  })
+})

--- a/src/renderer/src/components/cmd-j/palette-folder-workspace-tab-index.ts
+++ b/src/renderer/src/components/cmd-j/palette-folder-workspace-tab-index.ts
@@ -1,0 +1,57 @@
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
+import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import type { SidebarHostOption } from '../sidebar/sidebar-host-options'
+import { getPaletteHostBadge } from './palette-host-badge'
+
+/**
+ * Folder workspaces are a store collection of their own, so every Cmd+J index built
+ * by walking `worktrees` misses their tabs entirely. Adapting them to the worktree
+ * shape lets a single sort interleave both workspace kinds instead of appending
+ * folder rows after every worktree row.
+ */
+export function collectPaletteTabIndexWorkspaces(
+  worktrees: readonly Worktree[],
+  folderWorkspaces: readonly FolderWorkspace[]
+): Worktree[] {
+  return [...worktrees, ...folderWorkspaces.map(folderWorkspaceToWorktree)]
+}
+
+export function isPaletteFolderWorkspace(workspace: Pick<Worktree, 'id'>): boolean {
+  return parseWorkspaceKey(workspace.id)?.type === 'folder'
+}
+
+/**
+ * Worktree-only view of the combined list, for the indexes that have no folder path yet.
+ * Returns the input untouched when it holds no folder workspace, so consumers memoizing on
+ * identity don't re-run for a user who has none.
+ */
+export function excludePaletteFolderWorkspaces(
+  workspaces: readonly Worktree[]
+): readonly Worktree[] {
+  return workspaces.some(isPaletteFolderWorkspace)
+    ? workspaces.filter((workspace) => !isPaletteFolderWorkspace(workspace))
+    : workspaces
+}
+
+/**
+ * Host label per folder workspace, keyed by host identity. A folder workspace hangs off
+ * a project group rather than a repo, so its rows have no repo badge — on a remote host
+ * the label is the only thing on the row that says where the tab actually runs.
+ */
+export function collectFolderWorkspaceHostLabels(
+  folderWorkspaces: readonly FolderWorkspace[],
+  hostOptions: readonly SidebarHostOption[],
+  alwaysShowHostLabel: boolean
+): Map<string, string> {
+  const labels = new Map<string, string>()
+  for (const folderWorkspace of folderWorkspaces) {
+    const badge = getPaletteHostBadge(folderWorkspace, hostOptions, alwaysShowHostLabel)
+    if (badge) {
+      labels.set(getWorktreeHostIdentity(folderWorkspaceToWorktree(folderWorkspace)), badge.label)
+    }
+  }
+  return labels
+}

--- a/src/renderer/src/components/worktree-jump-palette-folder-workspace-tabs.test.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-folder-workspace-tabs.test.tsx
@@ -1,0 +1,293 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ReactI18Next from 'react-i18next'
+import type { FolderWorkspace } from '../../../shared/folder-workspace-types'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+import WorktreeJumpPalette from './WorktreeJumpPalette'
+import {
+  makeGroup,
+  makeRepo,
+  makeTerminalTab,
+  makeUnifiedTab,
+  makeWorktree
+} from './worktree-jump-palette-test-fixtures'
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18Next>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (_key: string, fallback?: string) => fallback ?? _key
+    })
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    message: vi.fn()
+  }
+}))
+
+vi.mock('@/hooks/useSettingsNavigationMetadata', () => ({
+  useSettingsNavigationMetadata: () => []
+}))
+
+vi.mock('@/components/sidebar/StatusIndicator', () => ({
+  default: () => <span data-status-indicator="true" />
+}))
+
+vi.mock('@/components/repo/RepoBadgeLabel', () => ({
+  RepoBadgeMark: () => <span data-repo-badge-mark="true" />
+}))
+
+// Why stubbed: activation reaches into the whole workspace-reveal path; the palette's own
+// contract is which result it hands over, so assert on that.
+const { activateWorkspaceTabPaletteResult } = vi.hoisted(() => ({
+  activateWorkspaceTabPaletteResult: vi.fn((_result: unknown) => ({ status: 'activated' }) as const)
+}))
+vi.mock('@/lib/workspace-tab-palette-activation', () => ({
+  activateWorkspaceTabPaletteResult: (result: unknown) => activateWorkspaceTabPaletteResult(result)
+}))
+
+vi.mock('@/components/ui/command', async () => {
+  const React = await import('react')
+  return {
+    Command: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    CommandGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    CommandDialog: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+      open ? <div data-command-dialog="true">{children}</div> : null,
+    CommandInput: ({
+      value,
+      onValueChange
+    }: {
+      value?: string
+      onValueChange?: (next: string) => void
+    }) => {
+      setCommandQuery = onValueChange ?? null
+      return <input data-command-input="true" value={value} onChange={() => {}} />
+    },
+    CommandList: React.forwardRef(function CommandList(
+      { children }: { children: React.ReactNode },
+      ref: React.ForwardedRef<HTMLDivElement>
+    ) {
+      return (
+        <div ref={ref} data-command-list="true">
+          {children}
+        </div>
+      )
+    }),
+    CommandEmpty: ({ children }: { children: React.ReactNode }) => (
+      <div data-command-empty="true">{children}</div>
+    ),
+    CommandItem: ({
+      children,
+      onSelect,
+      value
+    }: {
+      children: React.ReactNode
+      onSelect?: (value: string) => void
+      value?: string
+    }) => (
+      <button data-command-item={value ?? ''} onClick={() => onSelect?.(value ?? '')} type="button">
+        {children}
+      </button>
+    )
+  }
+})
+
+const initialAppState = useAppStore.getInitialState()
+const WORKSPACE_KEY = 'folder:fw-tasks'
+let testRoot: Root
+let testContainer: HTMLDivElement
+let setCommandQuery: ((next: string) => void) | null = null
+
+function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'fw-tasks',
+    projectGroupId: 'group-tasks',
+    name: 'Tasks',
+    folderPath: '/tmp/tasks',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides
+  }
+}
+
+/** One worktree with a tab plus one folder workspace holding the ticket tab. */
+function makeFolderWorkspaceTabState(
+  folderWorkspace: FolderWorkspace,
+  overrides: Partial<AppState> = {}
+): Partial<AppState> {
+  return {
+    worktreesByRepo: { 'repo-1': [makeWorktree('wt-alpha', 'Alpha workspace')] },
+    folderWorkspaces: [folderWorkspace],
+    showSleepingWorkspaces: true,
+    ptyIdsByTabId: {
+      'term-alpha': ['pty-term-alpha'],
+      'term-tasks': ['pty-term-tasks']
+    },
+    tabsByWorktree: {
+      'wt-alpha': [makeTerminalTab('term-alpha', 'wt-alpha', 'Alpha chat')],
+      [WORKSPACE_KEY]: [makeTerminalTab('term-tasks', WORKSPACE_KEY, 'zsh')]
+    },
+    unifiedTabsByWorktree: {
+      'wt-alpha': [makeUnifiedTab('tab-alpha', 'wt-alpha', 'term-alpha', 'Alpha chat')],
+      [WORKSPACE_KEY]: [
+        makeUnifiedTab('tab-tasks', WORKSPACE_KEY, 'term-tasks', 'ORCA-42 payment retries')
+      ]
+    },
+    groupsByWorktree: {
+      'wt-alpha': [makeGroup('wt-alpha', ['tab-alpha'])],
+      [WORKSPACE_KEY]: [makeGroup(WORKSPACE_KEY, ['tab-tasks'])]
+    },
+    activeGroupIdByWorktree: {
+      'wt-alpha': 'group-wt-alpha',
+      [WORKSPACE_KEY]: `group-${WORKSPACE_KEY}`
+    },
+    ...overrides
+  }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function renderPalette(overrides: Partial<AppState>): Promise<void> {
+  useAppStore.setState({
+    activeModal: 'worktree-palette',
+    activeWorktreeId: null,
+    repos: [makeRepo()],
+    tabsByWorktree: {},
+    browserTabsByWorktree: {},
+    browserPagesByWorkspace: {},
+    unifiedTabsByWorktree: {},
+    hideDefaultBranchWorkspace: false,
+    hideAutomationGeneratedWorkspaces: false,
+    alwaysShowDefaultBranchWorkspace: true,
+    lastVisitedAtByWorktreeId: {},
+    ...overrides
+  } as Partial<AppState>)
+
+  await act(async () => {
+    testRoot.render(<WorktreeJumpPalette />)
+  })
+  await flushEffects()
+}
+
+async function search(query: string): Promise<void> {
+  await act(async () => {
+    setCommandQuery?.(query)
+  })
+  await flushEffects()
+}
+
+function getTabRow(tabId: string): HTMLElement | null {
+  return testContainer.querySelector<HTMLElement>(`[data-command-item="workspace-tab:${tabId}"]`)
+}
+
+function getTabRowIds(): string[] {
+  return [...testContainer.querySelectorAll<HTMLElement>('[data-command-item^="workspace-tab:"]')]
+    .map((node) => node.dataset.commandItem ?? '')
+    .map((id) => id.replace('workspace-tab:', ''))
+}
+
+describe('WorktreeJumpPalette folder-workspace tabs', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    setCommandQuery = null
+    activateWorkspaceTabPaletteResult.mockClear()
+    useAppStore.setState(initialAppState, true)
+    testContainer = document.createElement('div')
+    document.body.appendChild(testContainer)
+    testRoot = createRoot(testContainer)
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      testRoot.unmount()
+    })
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+  })
+
+  it('finds a folder-workspace tab by its title', async () => {
+    await renderPalette(makeFolderWorkspaceTabState(makeFolderWorkspace()))
+    await search('ORCA-42')
+
+    expect(getTabRowIds()).toEqual(['tab-tasks'])
+    expect(getTabRow('tab-tasks')?.textContent).toContain('Tasks')
+  })
+
+  it('hands the folder workspace key to activation when the row is chosen', async () => {
+    await renderPalette(makeFolderWorkspaceTabState(makeFolderWorkspace()))
+    await search('ORCA-42')
+
+    await act(async () => {
+      getTabRow('tab-tasks')?.click()
+    })
+    await flushEffects()
+
+    expect(activateWorkspaceTabPaletteResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tabId: 'tab-tasks',
+        entityId: 'term-tasks',
+        worktreeId: WORKSPACE_KEY,
+        contentType: 'terminal'
+      })
+    )
+  })
+
+  it('labels a remote folder-workspace tab with its host', async () => {
+    await renderPalette(
+      makeFolderWorkspaceTabState(makeFolderWorkspace({ connectionId: 'remote-1' }), {
+        sshTargetLabels: new Map([['remote-1', 'build-box']]),
+        sshConnectionStates: new Map([['remote-1', { targetId: 'remote-1', status: 'connected' }]])
+      } as Partial<AppState>)
+    )
+    await search('ORCA-42')
+
+    const hostChip = getTabRow('tab-tasks')?.querySelector('[data-slot="palette-open-tab-host"]')
+    expect(hostChip?.textContent).toBe('build-box')
+  })
+
+  it('ranks folder-workspace and worktree tabs in one list', async () => {
+    // Why identical titles: with the match rank tied, position decides — and the busier
+    // folder workspace can only outrank the worktree if one sort ordered both kinds.
+    await renderPalette(
+      makeFolderWorkspaceTabState(makeFolderWorkspace({ lastActivityAt: 5_000 }), {
+        worktreesByRepo: {
+          'repo-1': [makeWorktree('wt-alpha', 'Alpha workspace', { lastActivityAt: 1_000 })]
+        },
+        unifiedTabsByWorktree: {
+          'wt-alpha': [
+            makeUnifiedTab('tab-alpha', 'wt-alpha', 'term-alpha', 'ORCA-42 payment retries')
+          ],
+          [WORKSPACE_KEY]: [
+            makeUnifiedTab('tab-tasks', WORKSPACE_KEY, 'term-tasks', 'ORCA-42 payment retries')
+          ]
+        }
+      })
+    )
+    await search('ORCA-42')
+
+    expect(getTabRowIds()).toEqual(['tab-tasks', 'tab-alpha'])
+  })
+})

--- a/src/renderer/src/lib/workspace-tab-palette-activation.test.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-activation.test.ts
@@ -60,7 +60,7 @@ const mocks = vi.hoisted(() => {
   }
   return {
     store,
-    activateAndRevealWorktree: vi.fn(),
+    activateAndRevealWorkspace: vi.fn(),
     activateWebRuntimeSessionTab: vi.fn(),
     focusTerminalTabSurface: vi.fn(),
     getRuntimeEnvironmentIdForWorktree: vi.fn(),
@@ -88,7 +88,7 @@ vi.mock('@/runtime/web-runtime-session', () => ({
 }))
 
 vi.mock('./worktree-activation', () => ({
-  activateAndRevealWorktree: mocks.activateAndRevealWorktree
+  activateAndRevealWorkspace: mocks.activateAndRevealWorkspace
 }))
 
 import { activateWorkspaceTabPaletteResult } from './workspace-tab-palette-activation'
@@ -165,7 +165,7 @@ describe('activateWorkspaceTabPaletteResult', () => {
         .flat()
         .find((worktree) => worktree.id === worktreeId)
     )
-    mocks.activateAndRevealWorktree.mockReturnValue(true)
+    mocks.activateAndRevealWorkspace.mockReturnValue(true)
     mocks.getRuntimeEnvironmentIdForWorktree.mockReturnValue('runtime-1')
     mocks.isWebRuntimeSessionActive.mockReturnValue(false)
   })
@@ -173,7 +173,7 @@ describe('activateWorkspaceTabPaletteResult', () => {
   it('activates terminal tabs and focuses the terminal surface', () => {
     expect(activateWorkspaceTabPaletteResult(makeResult())).toEqual({ status: 'activated' })
 
-    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('wt-1')
     expect(mocks.store.focusGroup).toHaveBeenCalledWith('wt-1', 'group-1')
     expect(mocks.store.activateTab).toHaveBeenCalledWith('unified-terminal-1')
     expect(mocks.store.setActiveTab).toHaveBeenCalledWith('terminal-1')
@@ -189,7 +189,7 @@ describe('activateWorkspaceTabPaletteResult', () => {
     })
 
     expect(mocks.store.getKnownWorktreeById).toHaveBeenCalledWith('wt-1', executionHostId)
-    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1', { executionHostId })
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('wt-1', { executionHostId })
   })
 
   it('activates tabs in known folder or detected workspaces', () => {
@@ -197,7 +197,7 @@ describe('activateWorkspaceTabPaletteResult', () => {
     mocks.store.getKnownWorktreeById.mockReturnValue({ id: 'wt-1', repoId: 'repo-1' })
 
     expect(activateWorkspaceTabPaletteResult(makeResult())).toEqual({ status: 'activated' })
-    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('wt-1')
   })
 
   it('uses the web-runtime terminal activation path when active', () => {
@@ -316,7 +316,7 @@ describe('activateWorkspaceTabPaletteResult', () => {
       status: 'failed',
       reason: 'missing-group'
     })
-    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    expect(mocks.activateAndRevealWorkspace).not.toHaveBeenCalled()
     expect(mocks.store.focusGroup).not.toHaveBeenCalled()
 
     resetStore()
@@ -361,6 +361,84 @@ describe('activateWorkspaceTabPaletteResult', () => {
     expect(activateWorkspaceTabPaletteResult(makeResult())).toEqual({
       status: 'failed',
       reason: 'missing-worktree'
+    })
+  })
+
+  describe('folder workspaces', () => {
+    const workspaceKey = 'folder:fw-1'
+
+    function seedFolderWorkspaceTab(hostId?: string): void {
+      mocks.store.worktreesByRepo = {}
+      mocks.store.groupsByWorktree = {
+        [workspaceKey]: [
+          {
+            id: 'group-1',
+            worktreeId: workspaceKey,
+            activeTabId: 'unified-terminal-1',
+            tabOrder: ['unified-terminal-1']
+          }
+        ]
+      }
+      mocks.store.unifiedTabsByWorktree = {
+        [workspaceKey]: [
+          {
+            id: 'unified-terminal-1',
+            entityId: 'terminal-1',
+            groupId: 'group-1',
+            worktreeId: workspaceKey,
+            contentType: 'terminal',
+            label: 'Terminal',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 0
+          }
+        ]
+      }
+      mocks.store.getKnownWorktreeById.mockReturnValue({
+        id: workspaceKey,
+        repoId: 'folder-workspace:group-1',
+        path: '/tmp/tasks',
+        ...(hostId ? { hostId } : {})
+      })
+    }
+
+    it('activates a folder-workspace tab through the scope-aware helper', () => {
+      seedFolderWorkspaceTab()
+
+      expect(activateWorkspaceTabPaletteResult(makeResult({ worktreeId: workspaceKey }))).toEqual({
+        status: 'activated'
+      })
+
+      expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith(workspaceKey)
+      expect(mocks.store.focusGroup).toHaveBeenCalledWith(workspaceKey, 'group-1')
+      expect(mocks.store.setActiveTab).toHaveBeenCalledWith('terminal-1')
+      expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1')
+    })
+
+    it('scopes an SSH folder workspace to the host the row was indexed on', () => {
+      const executionHostId = 'ssh:remote-1' as const
+      seedFolderWorkspaceTab(executionHostId)
+
+      expect(
+        activateWorkspaceTabPaletteResult(makeResult({ worktreeId: workspaceKey, executionHostId }))
+      ).toEqual({ status: 'activated' })
+
+      expect(mocks.store.getKnownWorktreeById).toHaveBeenCalledWith(workspaceKey, executionHostId)
+      expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith(workspaceKey, {
+        executionHostId
+      })
+    })
+
+    it('reports a declined activation apart from a vanished workspace', () => {
+      seedFolderWorkspaceTab()
+      mocks.activateAndRevealWorkspace.mockReturnValue(false)
+
+      expect(activateWorkspaceTabPaletteResult(makeResult({ worktreeId: workspaceKey }))).toEqual({
+        status: 'failed',
+        reason: 'activation-declined'
+      })
+      expect(mocks.store.focusGroup).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/renderer/src/lib/workspace-tab-palette-activation.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-activation.ts
@@ -7,7 +7,7 @@ import {
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 import type { ExecutionHostId } from '../../../shared/execution-host'
-import { activateAndRevealWorktree } from './worktree-activation'
+import { activateAndRevealWorkspace } from './worktree-activation'
 import type { WorkspaceTabPaletteSearchResult } from './workspace-tab-palette-search'
 
 export type WorkspaceTabPaletteActivationFailure =
@@ -15,6 +15,8 @@ export type WorkspaceTabPaletteActivationFailure =
   | 'missing-group'
   | 'missing-tab'
   | 'missing-file'
+  /** The workspace still exists but declined to open — it reported why itself. */
+  | 'activation-declined'
 
 export type WorkspaceTabPaletteActivationResult =
   | { status: 'activated' }
@@ -85,11 +87,13 @@ export function activateWorkspaceTabPaletteResult(
 
   const executionHostId =
     result.executionHostId ?? initialState.getKnownWorktreeById(result.worktreeId)?.hostId
+  // Why activateAndRevealWorkspace: a `folder:` id needs the folder branch, which owns the
+  // path-status gate that blocks a missing or disconnected folder (#10716).
   const activated = executionHostId
-    ? activateAndRevealWorktree(result.worktreeId, { executionHostId })
-    : activateAndRevealWorktree(result.worktreeId)
+    ? activateAndRevealWorkspace(result.worktreeId, { executionHostId })
+    : activateAndRevealWorkspace(result.worktreeId)
   if (!activated) {
-    return { status: 'failed', reason: 'missing-worktree' }
+    return { status: 'failed', reason: 'activation-declined' }
   }
 
   const state = useAppStore.getState()


### PR DESCRIPTION
## The bug

Every tab in every folder workspace is unreachable from Cmd+J. Searching an agent tab by its exact title returns no result, with the tab open and visible in the sidebar.

I hit this with a folder workspace named "Tasks" holding ~11 agent tabs, one per ticket. Typing a ticket id into the palette found nothing.

## Why

The palette builds its open-tab index by walking worktrees only:

```ts
buildSearchableWorkspaceTabs({ worktrees: browserSortedWorktrees, ownershipWorktrees: allWorktrees, ... })
```

`browserSortedWorktrees` derives from `allWorktrees`, and folder workspaces are a store collection of their own. `folderWorkspace` appears zero times in `WorktreeJumpPalette.tsx`, so no folder workspace's tabs ever enter the index. The `workspace-tab` result type and its activation path already work — only the data source was missing.

## The change

- Fold folder workspaces into the same index through the existing `folderWorkspaceToWorktree` adapter, rather than building a parallel index.
- Sort both workspace kinds in one pass, so the new rows interleave by attention instead of trailing the worktree rows. Worktree rows, browser pages and simulator tabs keep reading the worktree-only view of that same ordering, so their behaviour is unchanged.
- Route selection through `activateAndRevealWorkspace`, which dispatches a `folder:` id to the folder branch that owns the path-status gate. A declined activation now reports itself apart from a vanished workspace, so the palette stops stacking a contradictory toast on top of the one that branch already shows.
- Folder workspaces hang off a project group rather than a repo, so their rows carry no repo badge. On a remote host the row carries the host label — the only thing that says where the tab actually runs.

New logic lives in `palette-folder-workspace-tab-index.ts` rather than growing `WorktreeJumpPalette.tsx`.

## Notes

- `palette-activation-focus-routing.test.ts` pins the #9939 routing at the source level; selection still passes through the scoped helper before any fallback.
- Remote folder workspaces stay in the index when contact with their host is lost — losing contact is not evidence the workspace is gone.
- Ids are namespaced so a folder workspace and a worktree cannot collide in `buildPaletteListEntryRenderKeys`.

## Verification

`pnpm run tc` (all three targets), full `pnpm lint`, and the whole suite: **64,245 passing**. The only failures are the 4 in `src/main/rate-limits/codex-fetcher-pty-settle.test.ts`, which I confirmed also fail on a clean `main` at `94e7586665c2` — untouched by this PR.

New tests cover: a folder-workspace tab appearing by title, selection activating the workspace and focusing the tab, a remote folder workspace carrying its host badge, both kinds interleaving in one sort, and no id collisions between the two sources.