### PR TITLE
fix(relay): report when a remote's node-pty has no native job control

### DIFF
--- a/src/main/ssh/relay-pty-job-control-capability.test.ts
+++ b/src/main/ssh/relay-pty-job-control-capability.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  describeRelayPtyJobControlSupport,
+  readRelayPtyJobControlSupport,
+  relayPtyJobControlProbeJs,
+  RELAY_PTY_JOB_CONTROL_MARKER
+} from './relay-pty-job-control-capability'
+
+describe('relay pty job-control capability', () => {
+  it('reads a present verdict', () => {
+    expect(
+      readRelayPtyJobControlSupport(`ORCA-NPTY-PROBE-OK\n${RELAY_PTY_JOB_CONTROL_MARKER}present\n`)
+    ).toBe('present')
+  })
+
+  it('reads an absent verdict', () => {
+    expect(
+      readRelayPtyJobControlSupport(`${RELAY_PTY_JOB_CONTROL_MARKER}absent\r\nORCA-NPTY-PROBE-OK\n`)
+    ).toBe('absent')
+  })
+
+  it('reads a probe that could not look as unknown, not absent', () => {
+    expect(
+      readRelayPtyJobControlSupport(`ORCA-NPTY-PROBE-OK\n${RELAY_PTY_JOB_CONTROL_MARKER}unknown\n`)
+    ).toBe('unknown')
+  })
+
+  it('reads output with no marker at all as unknown, not absent', () => {
+    // An older relay, a probe that never ran, or stdout the host truncated.
+    expect(readRelayPtyJobControlSupport('ORCA-NPTY-PROBE-OK\n')).toBe('unknown')
+    expect(readRelayPtyJobControlSupport('')).toBe('unknown')
+  })
+
+  it('reads an unrecognised verdict as unknown, not absent', () => {
+    expect(readRelayPtyJobControlSupport(`${RELAY_PTY_JOB_CONTROL_MARKER}maybe`)).toBe('unknown')
+  })
+
+  it('probes all three job symbols and falls back to unknown when the look throws', () => {
+    const js = relayPtyJobControlProbeJs('"conpty"')
+    expect(js).toContain('assignCurrentProcessToJob')
+    expect(js).toContain('terminateJob')
+    expect(js).toContain('listJobProcessIds')
+    expect(js).toContain('catch{jc="unknown"}')
+  })
+
+  it('never calls an unanswered probe an absence in the operator line', () => {
+    expect(describeRelayPtyJobControlSupport('unknown')).toContain('not a confirmed absence')
+    expect(describeRelayPtyJobControlSupport('unknown')).not.toContain(': absent')
+    expect(describeRelayPtyJobControlSupport('absent')).toContain('absent')
+    expect(describeRelayPtyJobControlSupport('present')).toContain('present')
+  })
+})

--- a/src/main/ssh/relay-pty-job-control-capability.test.ts
+++ b/src/main/ssh/relay-pty-job-control-capability.test.ts
@@ -4,8 +4,42 @@ import {
   describeRelayPtyJobControlSupport,
   readRelayPtyJobControlSupport,
   relayPtyJobControlProbeJs,
-  RELAY_PTY_JOB_CONTROL_MARKER
+  RELAY_PTY_JOB_CONTROL_MARKER,
+  type RelayPtyJobControlSupport
 } from './relay-pty-job-control-capability'
+
+// Restated rather than imported: importing the module's own list would assert it against itself.
+const JOB_CONTROL_SYMBOLS = ['assignCurrentProcessToJob', 'terminateJob', 'listJobProcessIds']
+
+/**
+ * Execute the snippet the remote actually runs, the way the browser-bridge specs
+ * execute their injected JS. Grepping its source pins the characters; only running
+ * it pins the verdict, and the verdict is the whole contract.
+ */
+function runProbeSnippet(nodePtyUtils: unknown): {
+  support: RelayPtyJobControlSupport
+  printed: string[]
+} {
+  const printed: string[] = []
+  const requireStub = (name: string): unknown => {
+    if (name !== 'node-pty/lib/utils') {
+      throw new Error(`unexpected require(${name})`)
+    }
+    return nodePtyUtils
+  }
+  new Function('require', 'console', relayPtyJobControlProbeJs('"conpty"'))(requireStub, {
+    log: (line: string) => printed.push(line)
+  })
+  return { support: readRelayPtyJobControlSupport(printed.join('\n')), printed }
+}
+
+function utilsLoading(module: unknown): unknown {
+  return { loadNativeModule: () => ({ module }) }
+}
+
+function nativeWith(symbols: readonly string[]): Record<string, unknown> {
+  return Object.fromEntries(symbols.map((symbol) => [symbol, () => true]))
+}
 
 describe('relay pty job-control capability', () => {
   it('reads a present verdict', () => {
@@ -36,12 +70,48 @@ describe('relay pty job-control capability', () => {
     expect(readRelayPtyJobControlSupport(`${RELAY_PTY_JOB_CONTROL_MARKER}maybe`)).toBe('unknown')
   })
 
-  it('probes all three job symbols and falls back to unknown when the look throws', () => {
+  it('prints present when the remote module exposes all three job symbols', () => {
+    const { support, printed } = runProbeSnippet(utilsLoading(nativeWith(JOB_CONTROL_SYMBOLS)))
+    expect(support).toBe('present')
+    expect(printed).toEqual([`${RELAY_PTY_JOB_CONTROL_MARKER}present`])
+  })
+
+  it('prints absent for the stock registry module', () => {
+    expect(runProbeSnippet(utilsLoading(nativeWith(['spawn', 'resize']))).support).toBe('absent')
+  })
+
+  it('prints absent when only some of the three symbols are there', () => {
+    // Every symbol is required: a partial module cannot terminate a tree by job object.
+    expect(runProbeSnippet(utilsLoading(nativeWith(JOB_CONTROL_SYMBOLS.slice(1)))).support).toBe(
+      'absent'
+    )
+  })
+
+  it('prints unknown when the native load throws', () => {
+    const utils = {
+      loadNativeModule: () => {
+        throw new Error('Failed to load native module: conpty.node')
+      }
+    }
+    expect(runProbeSnippet(utils).support).toBe('unknown')
+  })
+
+  it('prints unknown when node-pty has no loadNativeModule to call', () => {
+    // A node-pty whose internals moved is a probe that could not look, not an absence.
+    expect(runProbeSnippet({}).support).toBe('unknown')
+  })
+
+  it('prints unknown, not absent, when the loader hands back no module', () => {
+    expect(runProbeSnippet({ loadNativeModule: () => ({}) }).support).toBe('unknown')
+    expect(runProbeSnippet(utilsLoading(null)).support).toBe('unknown')
+    expect(runProbeSnippet(utilsLoading(undefined)).support).toBe('unknown')
+  })
+
+  it('names all three job symbols in the snippet it ships to the remote', () => {
     const js = relayPtyJobControlProbeJs('"conpty"')
-    expect(js).toContain('assignCurrentProcessToJob')
-    expect(js).toContain('terminateJob')
-    expect(js).toContain('listJobProcessIds')
-    expect(js).toContain('catch{jc="unknown"}')
+    for (const symbol of JOB_CONTROL_SYMBOLS) {
+      expect(js).toContain(symbol)
+    }
   })
 
   it('never calls an unanswered probe an absence in the operator line', () => {

--- a/src/main/ssh/relay-pty-job-control-capability.ts
+++ b/src/main/ssh/relay-pty-job-control-capability.ts
@@ -32,7 +32,8 @@ export function relayPtyJobControlProbeJs(nativeModuleNameExpr: string): string 
   // Why "unknown" on throw: a probe that could not look is not evidence of absence.
   return (
     `let jc="unknown";try{const n=require("node-pty/lib/utils").loadNativeModule(${nativeModuleNameExpr}).module;` +
-    `jc=${symbols}.every(s=>n&&typeof n[s]==="function")?"present":"absent"}catch{jc="unknown"}` +
+    // Why the `if`: a loader that hands back no module never let us look, so leave the verdict unanswered.
+    `if(n){jc=${symbols}.every(s=>typeof n[s]==="function")?"present":"absent"}}catch{jc="unknown"}` +
     `console.log(${JSON.stringify(RELAY_PTY_JOB_CONTROL_MARKER)}+jc);`
   )
 }

--- a/src/main/ssh/relay-pty-job-control-capability.ts
+++ b/src/main/ssh/relay-pty-job-control-capability.ts
@@ -1,0 +1,70 @@
+/**
+ * Whether a deployed relay's node-pty exposes native job-object control.
+ *
+ * `assignCurrentProcessToJob`, `terminateJob` and `listJobProcessIds` are added
+ * by Orca's local pnpm patch of node-pty, and only in its Windows ConPTY
+ * sources. A relay installs the stock registry package over SSH, so on every
+ * remote the symbols are absent — and nothing said so. `windows-pty-job.ts`
+ * feature-detects them and silently takes its `null` branch, which makes a
+ * remote that never had the capability look exactly like one where it works.
+ *
+ * This reports the fact and nothing more. It does not restore the capability,
+ * no code path branches on it, and an absence is not an error: PTY teardown
+ * keeps using the portable best-effort path it already uses today.
+ */
+export type RelayPtyJobControlSupport = 'present' | 'absent' | 'unknown'
+
+/** Emitted on its own stdout line by the native-deps probe. */
+export const RELAY_PTY_JOB_CONTROL_MARKER = 'ORCA-PTY-JOB-CONTROL:'
+
+const JOB_CONTROL_SYMBOLS = ['assignCurrentProcessToJob', 'terminateJob', 'listJobProcessIds']
+
+/**
+ * JS appended to the native-deps probe that feature-detects the three symbols
+ * on the module the deps check already loaded.
+ *
+ * `nativeModuleNameExpr` is the same expression the deps check uses, so this
+ * re-reads a module node-pty has already cached rather than paying a second
+ * native load.
+ */
+export function relayPtyJobControlProbeJs(nativeModuleNameExpr: string): string {
+  const symbols = JSON.stringify(JOB_CONTROL_SYMBOLS)
+  // Why "unknown" on throw: a probe that could not look is not evidence of absence.
+  return (
+    `let jc="unknown";try{const n=require("node-pty/lib/utils").loadNativeModule(${nativeModuleNameExpr}).module;` +
+    `jc=${symbols}.every(s=>n&&typeof n[s]==="function")?"present":"absent"}catch{jc="unknown"}` +
+    `console.log(${JSON.stringify(RELAY_PTY_JOB_CONTROL_MARKER)}+jc);`
+  )
+}
+
+/**
+ * Read the probe's verdict out of its stdout.
+ *
+ * No marker means no answer — a relay whose probe never ran, whose deps are
+ * missing, or that predates the marker entirely. That is `unknown`, never
+ * `absent`: reporting an unanswered probe as a confirmed absence is the same
+ * lie this probe exists to remove.
+ */
+export function readRelayPtyJobControlSupport(probeOutput: string): RelayPtyJobControlSupport {
+  const line = probeOutput
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith(RELAY_PTY_JOB_CONTROL_MARKER))
+  if (!line) {
+    return 'unknown'
+  }
+  const verdict = line.slice(RELAY_PTY_JOB_CONTROL_MARKER.length).trim()
+  return verdict === 'present' || verdict === 'absent' ? verdict : 'unknown'
+}
+
+/** The one line an operator sees in the deploy log. */
+export function describeRelayPtyJobControlSupport(support: RelayPtyJobControlSupport): string {
+  switch (support) {
+    case 'present':
+      return '[ssh-relay] Remote node-pty job control: present (this relay can terminate a PTY process tree by job object)'
+    case 'absent':
+      return '[ssh-relay] Remote node-pty job control: absent (expected: the symbols are Windows-only and come from a local-only node-pty patch; remote PTY teardown keeps using the portable path)'
+    case 'unknown':
+      return '[ssh-relay] Remote node-pty job control: unknown (the probe did not answer, so this is not a confirmed absence)'
+  }
+}

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -77,6 +77,12 @@ import {
 import { detectRemoteHostPlatform } from './ssh-remote-platform-detection'
 import { powerShellCommand, powerShellLiteral, powerShellNativeArg } from './ssh-remote-powershell'
 import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
+import {
+  describeRelayPtyJobControlSupport,
+  readRelayPtyJobControlSupport,
+  relayPtyJobControlProbeJs,
+  type RelayPtyJobControlSupport
+} from './relay-pty-job-control-capability'
 import { isSshSessionLimitError } from './ssh-session-limit-error'
 import {
   isWindowsRelayPipePath,
@@ -101,6 +107,11 @@ export type RelayDeployResult = {
   nodePath?: string
   sockPath?: string
   credentialFile?: string
+  /**
+   * Whether this remote's node-pty exposes native job control. Reporting only —
+   * nothing branches on it, and `unknown` means the probe never answered.
+   */
+  ptyJobControl: RelayPtyJobControlSupport
 }
 
 class RelayDirectoryGcConflictError extends Error {
@@ -398,6 +409,8 @@ async function deployAndLaunchRelayAttempt(
   let ownsInstallLock = false
   let launchGcClaimToken: string | undefined
   let launchNamespace: RelayInstallNamespace | undefined
+  // Reporting only. Stays 'unknown' on every path that never asked the remote.
+  let ptyJobControl: RelayPtyJobControlSupport = 'unknown'
   if (alreadyInstalled) {
     const launchFence = await repairInstalledNativeDeps(
       conn,
@@ -411,6 +424,7 @@ async function deployAndLaunchRelayAttempt(
     ownsInstallLock = launchFence.ownsInstallLock
     launchGcClaimToken = launchFence.gcClaimToken
     launchNamespace = launchFence.sftpNamespace
+    ptyJobControl = launchFence.ptyJobControl
     deploySignal?.throwIfAborted()
   } else {
     await execHostCommand(
@@ -511,7 +525,7 @@ async function deployAndLaunchRelayAttempt(
 
           onProgress?.('Installing native dependencies...')
           console.log('[ssh-relay] Installing native dependencies...')
-          await installNativeDeps(
+          ptyJobControl = await installNativeDeps(
             conn,
             remoteRelayDir,
             platform,
@@ -574,6 +588,7 @@ async function deployAndLaunchRelayAttempt(
     }
   }
   console.log('[ssh-relay] Relay started successfully')
+  console.log(describeRelayPtyJobControlSupport(ptyJobControl))
 
   void execHostCommand(
     conn,
@@ -596,6 +611,7 @@ async function deployAndLaunchRelayAttempt(
     hostPlatform,
     remoteHome,
     remoteRelayDir,
+    ptyJobControl,
     nodePath: launched.nodePath,
     sockPath: launched.sockPath,
     credentialFile: launched.credentialFile
@@ -714,12 +730,17 @@ const RELAY_NATIVE_DEP_SCRIPT_ALLOWLIST = Object.fromEntries(
   Object.entries(RELAY_NATIVE_DEPS).map(([name, version]) => [`${name}@${version}`, true])
 )
 
+const NODE_PTY_NATIVE_MODULE_EXPR =
+  'process.platform==="win32"&&Number(require("os").release().split(".")[2])>=18309?"conpty":"pty"'
+
 function nativeDepsProbeJs(successToken: string): string {
   // Why: node-pty's Windows wrapper defers conpty.node until first spawn, so require("node-pty") alone can't prove the binding is healthy.
   const loadNodePty =
-    'require("node-pty"); require("node-pty/lib/utils").loadNativeModule(process.platform==="win32"&&Number(require("os").release().split(".")[2])>=18309?"conpty":"pty");' +
+    `require("node-pty"); require("node-pty/lib/utils").loadNativeModule(${NODE_PTY_NATIVE_MODULE_EXPR});` +
     `if(process.platform==="win32"){require("./${NODE_PTY_CONSOLE_LIST_PATCH_FILENAME}").assertPatchedNodePtyConsoleListAgent(process.cwd())}`
-  return `(()=>{const missing=[];try{${loadNodePty}}catch{missing.push("node-pty")}try{require("@parcel/watcher")}catch{missing.push("@parcel/watcher")}if(missing.length){console.log("${NATIVE_DEPS_MISSING_PREFIX}"+missing.join(","));process.exitCode=1}else{console.log(${JSON.stringify(successToken)})}})()`
+  // Why report only on the healthy branch: without a loadable node-pty there is nothing to look at, and a guess would read as a confirmed absence.
+  const jobControl = relayPtyJobControlProbeJs(NODE_PTY_NATIVE_MODULE_EXPR)
+  return `(()=>{const missing=[];try{${loadNodePty}}catch{missing.push("node-pty")}try{require("@parcel/watcher")}catch{missing.push("@parcel/watcher")}if(missing.length){console.log("${NATIVE_DEPS_MISSING_PREFIX}"+missing.join(","));process.exitCode=1}else{${jobControl}console.log(${JSON.stringify(successToken)})}})()`
 }
 
 function missingNativeDepsFromProbe(output: string): RelayNativeDepName[] {
@@ -739,7 +760,11 @@ async function probeRequiredNativeDeps(
   hostPlatform: RemoteHostPlatform,
   nodePath: string,
   signal?: AbortSignal
-): Promise<{ available: boolean; missing: RelayNativeDepName[] }> {
+): Promise<{
+  available: boolean
+  missing: RelayNativeDepName[]
+  ptyJobControl: RelayPtyJobControlSupport
+}> {
   const escapedNode = shellEscape(nodePath)
   const probeJs = nativeDepsProbeJs('ORCA-NATIVE-DEPS-OK')
   try {
@@ -758,10 +783,15 @@ async function probeRequiredNativeDeps(
         )
     const probe = await execHostCommand(conn, hostPlatform, command, { signal })
     const available = probe.includes('ORCA-NATIVE-DEPS-OK')
-    return { available, missing: available ? [] : missingNativeDepsFromProbe(probe) }
+    return {
+      available,
+      missing: available ? [] : missingNativeDepsFromProbe(probe),
+      ptyJobControl: readRelayPtyJobControlSupport(probe)
+    }
   } catch {
     signal?.throwIfAborted()
-    return { available: false, missing: [...RELAY_NATIVE_DEP_NAMES] }
+    // A probe that never ran says nothing about job control; never downgrade that to a confirmed absence.
+    return { available: false, missing: [...RELAY_NATIVE_DEP_NAMES], ptyJobControl: 'unknown' }
   }
 }
 
@@ -777,6 +807,7 @@ async function repairInstalledNativeDeps(
   ownsInstallLock: boolean
   gcClaimToken?: string
   sftpNamespace?: RelayInstallNamespace
+  ptyJobControl: RelayPtyJobControlSupport
 }> {
   const initialProbe = await probeRequiredNativeDeps(
     conn,
@@ -813,10 +844,11 @@ async function repairInstalledNativeDeps(
   if (initialProbe.available) {
     // Why: even a healthy reconnect stays fenced until launch liveness is observable, or cross-version GC can rename after this probe.
     if (lockResult !== 'acquired') {
-      return { ownsInstallLock: false, gcClaimToken }
+      return { ownsInstallLock: false, gcClaimToken, ptyJobControl: initialProbe.ptyJobControl }
     }
     try {
       return {
+        ptyJobControl: initialProbe.ptyJobControl,
         ownsInstallLock: true,
         sftpNamespace: await createRelayLaunchNamespace(
           conn,
@@ -831,7 +863,10 @@ async function repairInstalledNativeDeps(
       console.warn(
         `[ssh-relay] Launch namespace marker is unconfirmed at ${remoteDir}; deferring lock ownership to stale recovery`
       )
-      return { ownsInstallLock: !isUnconfirmedSshCommandTermination(err) }
+      return {
+        ownsInstallLock: !isUnconfirmedSshCommandTermination(err),
+        ptyJobControl: initialProbe.ptyJobControl
+      }
     }
   }
 
@@ -841,12 +876,13 @@ async function repairInstalledNativeDeps(
     console.warn(
       `[ssh-relay] Native-deps repair lock is ${lockResult} at ${remoteDir}; launching degraded`
     )
-    return { ownsInstallLock: false, gcClaimToken }
+    return { ownsInstallLock: false, gcClaimToken, ptyJobControl: initialProbe.ptyJobControl }
   }
   try {
     // Why: older complete relay dirs predate @parcel/watcher; re-probe under the lock so only one reconnect mutates the dir.
     const probe = await probeRequiredNativeDeps(conn, remoteDir, hostPlatform, nodePath, signal)
     let repairNamespace: RelayInstallNamespace | undefined
+    let ptyJobControl = probe.ptyJobControl
     if (!probe.available) {
       // Why: only stamp ownership once the locked recheck proves this connection is the one about to write.
       repairNamespace = await createRelayLaunchNamespace(
@@ -856,7 +892,7 @@ async function repairInstalledNativeDeps(
         homeRelativeRelayDir,
         signal
       )
-      await installNativeDeps(
+      ptyJobControl = await installNativeDeps(
         conn,
         remoteDir,
         platform,
@@ -868,7 +904,7 @@ async function repairInstalledNativeDeps(
       )
       await finalizeInstall(conn, remoteDir, hostPlatform, { signal, releaseLock: false })
     }
-    return { ownsInstallLock: true, sftpNamespace: repairNamespace }
+    return { ownsInstallLock: true, sftpNamespace: repairNamespace, ptyJobControl }
   } catch (err) {
     const terminationUnconfirmed = isUnconfirmedSshCommandTermination(err)
     // Why: hold a confirmed-failure lock through degraded launch so GC can't move the relay before liveness is visible.
@@ -878,7 +914,8 @@ async function repairInstalledNativeDeps(
         err instanceof Error ? err.message : String(err)
       }`
     )
-    return { ownsInstallLock: !terminationUnconfirmed }
+    // The repair aborted mid-flight, so the last verdict is stale: say so rather than publish it.
+    return { ownsInstallLock: !terminationUnconfirmed, ptyJobControl: 'unknown' }
   }
 }
 
@@ -948,6 +985,18 @@ async function acquireRelayLaunchGcFence(
 
 // Why: node-pty and @parcel/watcher are native addons esbuild can't bundle; install them on the remote against its Node/OS.
 // TODO(#1693): ship per-platform tarballs with node-pty prebuilt from CI to skip remote npm install.
+// Scope, measured 2026-08-28 — do not re-derive it:
+//   - The only thing a prebuilt would ADD over the registry package is the three job-object symbols
+//     (assignCurrentProcessToJob / terminateJob / listJobProcessIds) from
+//     config/patches/node-pty@1.1.0.patch. `npm pack` + `strings` on both stock win32 prebuilds find
+//     0 occurrences, against 5 in the locally patched conpty.cc.
+//   - Those symbols live only in src/win/conpty.cc, so the payoff is Windows-only. Linux and macOS
+//     remotes could never gain anything from a prebuilt on this axis.
+//   - Shipping Linux prebuilts is a NET NEGATIVE: the patch's unix hunk is a glibc back-compat shim
+//     that remote node-gyp compilation already makes unnecessary, and a binary built on a newer
+//     runner reintroduces the #9902 glibc hazard (docs/reference/linux-glibc-compatibility.md).
+//   - Decision: do not ship prebuilts. Remotes have no native job control, and the probe below
+//     reports that honestly instead of leaving it indistinguishable from a working one.
 async function installNativeDeps(
   conn: SshConnection,
   remoteDir: string,
@@ -957,7 +1006,7 @@ async function installNativeDeps(
   signal?: AbortSignal,
   resetDeps: RelayNativeDepName[] = [],
   namespace?: RelayInstallNamespace
-): Promise<void> {
+): Promise<RelayPtyJobControlSupport> {
   const writeRelayPackageJson = async (deps: Record<string, string>): Promise<void> => {
     await writeRelayFile(
       conn,
@@ -1068,7 +1117,8 @@ async function installNativeDeps(
           nodePath,
           signal
         )
-        return
+        // No node-pty means nothing to look at, and this path never probed for the symbols.
+        return 'unknown'
       }
     }
     throw err
@@ -1106,6 +1156,7 @@ async function installNativeDeps(
       `[ssh-relay][NPTY-MISSING] native deps installed but require() failed at ${remoteDir} (${platform}). stdout=${probe.output.trim().slice(-200)} stderr=${probe.stderr.trim().slice(-500)}`
     )
   }
+  return probe.ptyJobControl
 }
 
 function resetNativeDepsCommand(
@@ -1283,6 +1334,7 @@ async function probeInstalledNativeDeps(
   missing: RelayNativeDepName[]
   output: string
   stderr: string
+  ptyJobControl: RelayPtyJobControlSupport
 }> {
   // require() catches unloadable installs (wrong arch, missing prebuild, skipped lifecycle script) that require.resolve() and test -d miss.
   const PROBE_OK = 'ORCA-NPTY-PROBE-OK'
@@ -1321,7 +1373,8 @@ async function probeInstalledNativeDeps(
     available: probeOutput.includes(PROBE_OK),
     missing: probeOutput.includes(PROBE_OK) ? [] : missingNativeDepsFromProbe(probeOutput),
     output: probeOutput,
-    stderr: remoteStderr
+    stderr: remoteStderr,
+    ptyJobControl: readRelayPtyJobControlSupport(probeOutput)
   }
 }
 

--- a/src/main/ssh/ssh-relay-pty-job-control-report.test.ts
+++ b/src/main/ssh/ssh-relay-pty-job-control-report.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as RelayInstallMarkerModule from './ssh-relay-install-marker'
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => '/mock/app' }
+}))
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+  readFileSync: vi.fn().mockReturnValue('0.1.0+testhash')
+}))
+
+vi.mock('./relay-protocol', () => ({
+  RELAY_VERSION: '0.1.0',
+  RELAY_REMOTE_DIR: '.orca-remote',
+  parseUnameToRelayPlatform: vi.fn().mockReturnValue('linux-x64'),
+  RELAY_SENTINEL: 'ORCA-RELAY v0.1.0 READY\n',
+  RELAY_SENTINEL_TIMEOUT_MS: 10_000
+}))
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  uploadDirectory: vi.fn().mockResolvedValue(undefined),
+  waitForSentinel: vi.fn().mockResolvedValue({
+    write: vi.fn(),
+    onData: vi.fn(),
+    onClose: vi.fn()
+  }),
+  isUnconfirmedSshCommandTermination: (error: unknown) =>
+    error instanceof Error &&
+    (error as Error & { sshChannelCloseConfirmed?: boolean }).sshChannelCloseConfirmed === false,
+  execCommand: vi.fn()
+}))
+
+vi.mock('./ssh-remote-node-resolution', () => ({
+  resolveRemoteNodePath: vi.fn().mockResolvedValue('/usr/bin/node')
+}))
+
+vi.mock('./ssh-relay-install-marker', async (importOriginal) => ({
+  ...(await importOriginal<typeof RelayInstallMarkerModule>()),
+  createRelayInstallMarkerFileName: () => '.sftp-namespace-00000000000000000000000000000000'
+}))
+
+vi.mock('./ssh-relay-versioned-install', () => ({
+  readLocalFullVersion: vi.fn().mockReturnValue('0.1.0+testhash'),
+  computeRemoteRelayDir: (home: string, v: string) => `${home}/.orca-remote/relay-${v}`,
+  isRelayAlreadyInstalled: vi.fn().mockResolvedValue(false),
+  finalizeInstall: vi.fn().mockResolvedValue(undefined),
+  abandonInstall: vi.fn().mockResolvedValue(undefined),
+  gcOldRelayVersions: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-relay-install-lock', () => ({
+  acquireInstallLock: vi.fn().mockResolvedValue(undefined),
+  RELAY_INSTALL_LOCK_NAME: '.install-lock'
+}))
+
+vi.mock('./ssh-relay-repair-lock', () => ({
+  tryAcquireRelayRepairLock: vi.fn().mockResolvedValue('acquired')
+}))
+
+vi.mock('./ssh-relay-gc-claim', () => ({
+  releaseRelayGcClaimWithRetry: vi.fn().mockResolvedValue('released'),
+  tryAcquireRelayGcClaim: vi.fn().mockResolvedValue('launch-token'),
+  waitForRelayGcClaimRelease: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-connection-utils', () => ({
+  shellEscape: (s: string) => `'${s}'`
+}))
+
+import { deployAndLaunchRelay } from './ssh-relay-deploy'
+import { execCommand } from './ssh-relay-deploy-helpers'
+import { parseUnameToRelayPlatform } from './relay-protocol'
+import { isRelayAlreadyInstalled } from './ssh-relay-versioned-install'
+import { tryAcquireRelayRepairLock } from './ssh-relay-repair-lock'
+import {
+  makeExecResponses,
+  makeMockConnection,
+  type ExecResponse,
+  type SftpWriteCapture
+} from './ssh-relay-native-deps-install-fixture'
+
+/**
+ * The three job-object symbols never reach a remote: they come from Orca's
+ * local node-pty patch, and the relay installs the stock registry package.
+ * Before this probe the deploy log for such a host was byte-identical to one
+ * where job control works, so nothing an operator could read told them apart.
+ *
+ * These specs pin the report, not a behaviour change: a relay without the
+ * symbols still deploys, still launches, and still tears PTYs down the same way.
+ */
+describe('relay pty job-control reporting', () => {
+  const sftpCapture: SftpWriteCapture = {
+    paths: [],
+    contents: {},
+    execCallCountAtWrite: {}
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(execCommand).mockReset().mockResolvedValue('')
+    vi.mocked(parseUnameToRelayPlatform).mockReturnValue('linux-x64')
+    vi.mocked(isRelayAlreadyInstalled).mockResolvedValue(false)
+    vi.mocked(tryAcquireRelayRepairLock).mockResolvedValue('acquired')
+    sftpCapture.paths.length = 0
+  })
+
+  function feed(execResponses: ExecResponse[]): void {
+    const mockExec = vi.mocked(execCommand)
+    for (const response of execResponses) {
+      if (typeof response === 'string') {
+        mockExec.mockResolvedValueOnce(response)
+      } else {
+        mockExec.mockRejectedValueOnce(new Error(response.reject))
+      }
+    }
+  }
+
+  async function deployWithProbeStdout(
+    probeStdoutOverride: string
+  ): Promise<{ support: string | undefined; log: string[] }> {
+    const logged: string[] = []
+    const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logged.push(args.map(String).join(' '))
+    })
+    try {
+      const conn = makeMockConnection(sftpCapture)
+      feed(makeExecResponses({ npmInstall: 'ok', probeStdoutOverride }))
+      const result = await deployAndLaunchRelay(conn)
+      return { support: result.ptyJobControl, log: logged }
+    } finally {
+      spy.mockRestore()
+    }
+  }
+
+  function jobControlLine(log: string[]): string {
+    return log.find((line) => line.includes('Remote node-pty job control')) ?? ''
+  }
+
+  it('asks the remote for all three job symbols in the native-deps probe', async () => {
+    const { support } = await deployWithProbeStdout(
+      'ORCA-NPTY-PROBE-OK\nORCA-PTY-JOB-CONTROL:present\n'
+    )
+    expect(support).toBe('present')
+    const probeCommand =
+      vi
+        .mocked(execCommand)
+        .mock.calls.map(([, command]) => command)
+        .find((command) => command.includes('ORCA-NPTY-PROBE-OK')) ?? ''
+    expect(probeCommand).toContain('ORCA-PTY-JOB-CONTROL:')
+    expect(probeCommand).toContain('assignCurrentProcessToJob')
+    expect(probeCommand).toContain('terminateJob')
+    expect(probeCommand).toContain('listJobProcessIds')
+  })
+
+  it('reports present when the remote node-pty exposes the symbols', async () => {
+    const { support, log } = await deployWithProbeStdout(
+      'ORCA-NPTY-PROBE-OK\nORCA-PTY-JOB-CONTROL:present\n'
+    )
+    expect(support).toBe('present')
+    expect(jobControlLine(log)).toContain('present')
+  })
+
+  it('reports absent when the remote node-pty is the stock package', async () => {
+    const { support, log } = await deployWithProbeStdout(
+      'ORCA-NPTY-PROBE-OK\nORCA-PTY-JOB-CONTROL:absent\n'
+    )
+    expect(support).toBe('absent')
+    // The operator has to be able to tell this apart from a working relay.
+    expect(jobControlLine(log)).toContain('absent')
+    expect(jobControlLine(log)).not.toContain('unknown')
+  })
+
+  it('reports unknown, not absent, when the probe could not look', async () => {
+    const { support, log } = await deployWithProbeStdout(
+      'ORCA-NPTY-PROBE-OK\nORCA-PTY-JOB-CONTROL:unknown\n'
+    )
+    expect(support).toBe('unknown')
+    expect(jobControlLine(log)).toContain('not a confirmed absence')
+  })
+
+  it('reports unknown, not absent, for a relay whose probe answers nothing', async () => {
+    // An older relay predating the marker answers the deps probe and says nothing else.
+    const { support, log } = await deployWithProbeStdout('ORCA-NPTY-PROBE-OK\n')
+    expect(support).toBe('unknown')
+    expect(jobControlLine(log)).toContain('not a confirmed absence')
+  })
+
+  async function deployReconnectWithHealthProbe(
+    healthProbe: ExecResponse
+  ): Promise<string | undefined> {
+    vi.mocked(isRelayAlreadyInstalled).mockResolvedValue(true)
+    vi.mocked(tryAcquireRelayRepairLock).mockResolvedValue('busy')
+    const conn = makeMockConnection(sftpCapture)
+    feed([
+      '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
+      '/home/u',
+      healthProbe,
+      'DEAD',
+      '', // publish the per-launch credential
+      'READY'
+    ])
+    const result = await deployAndLaunchRelay(conn)
+    return result.ptyJobControl
+  }
+
+  it('reports unknown when the probe command itself fails on a reconnect', async () => {
+    await expect(
+      deployReconnectWithHealthProbe({ reject: 'cd: no such file or directory' })
+    ).resolves.toBe('unknown')
+  })
+
+  it('reports unknown, not the pre-repair verdict, when a repair aborts mid-flight', async () => {
+    // The repair mutated the dir and then failed, so the verdict measured before it is stale.
+    vi.mocked(isRelayAlreadyInstalled).mockResolvedValue(true)
+    const conn = makeMockConnection(sftpCapture)
+    const brokenWithVerdict =
+      'ORCA-NATIVE-DEPS-MISSING:@parcel/watcher\nMISSING\nORCA-PTY-JOB-CONTROL:absent'
+    feed([
+      '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
+      '/home/u',
+      brokenWithVerdict, // health probe before the lock
+      brokenWithVerdict, // re-probe under the lock
+      '', // SFTP-namespace install-owner marker (repair)
+      { reject: 'npm ERR! network ETIMEDOUT' },
+      'DEAD',
+      '', // publish the per-launch credential
+      'READY'
+    ])
+
+    const result = await deployAndLaunchRelay(conn)
+
+    expect(result.ptyJobControl).toBe('unknown')
+  })
+
+  it('still reports a real absence on that same reconnect path', async () => {
+    // Control for the case above: the path is not hardwired to 'unknown'.
+    await expect(
+      deployReconnectWithHealthProbe('ORCA-NATIVE-DEPS-OK\nORCA-PTY-JOB-CONTROL:absent\n')
+    ).resolves.toBe('absent')
+  })
+})

--- a/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
+++ b/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
@@ -256,7 +256,8 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
     vi.mocked(deployAndLaunchRelay).mockResolvedValue({
       transport: relay.transport,
       serverBuildId: 'test-relay-build',
-      platform: 'linux-x64'
+      platform: 'linux-x64',
+      ptyJobControl: 'unknown'
     })
     const events: CapturedStatus[] = []
     captureAgentStatuses(events)
@@ -310,7 +311,8 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
     vi.mocked(deployAndLaunchRelay).mockResolvedValue({
       transport: relay.transport,
       serverBuildId: 'test-relay-build',
-      platform: 'linux-x64'
+      platform: 'linux-x64',
+      ptyJobControl: 'unknown'
     })
     const events: CapturedStatus[] = []
     captureAgentStatuses(events)
@@ -346,7 +348,8 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
     vi.mocked(deployAndLaunchRelay).mockResolvedValue({
       transport: relay.transport,
       serverBuildId: 'test-relay-build',
-      platform: 'linux-x64'
+      platform: 'linux-x64',
+      ptyJobControl: 'unknown'
     })
     const events: CapturedStatus[] = []
     captureAgentStatuses(events)
@@ -418,12 +421,14 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
       .mockResolvedValueOnce({
         transport: initialRelay.transport,
         serverBuildId: 'test-relay-build',
-        platform: 'linux-x64'
+        platform: 'linux-x64',
+        ptyJobControl: 'unknown'
       })
       .mockResolvedValueOnce({
         transport: relay.transport,
         serverBuildId: 'test-relay-build',
-        platform: 'linux-x64'
+        platform: 'linux-x64',
+        ptyJobControl: 'unknown'
       })
     const clearListener = vi.fn()
     agentHookServer.setPaneStatusClearListener(clearListener)
@@ -465,7 +470,8 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
     vi.mocked(deployAndLaunchRelay).mockResolvedValue({
       transport: relay.transport,
       serverBuildId: 'test-relay-build',
-      platform: 'linux-x64'
+      platform: 'linux-x64',
+      ptyJobControl: 'unknown'
     })
     const events: CapturedStatus[] = []
     captureAgentStatuses(events)
@@ -493,7 +499,8 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
     vi.mocked(deployAndLaunchRelay).mockResolvedValue({
       transport: relay.transport,
       serverBuildId: 'test-relay-build',
-      platform: 'linux-x64'
+      platform: 'linux-x64',
+      ptyJobControl: 'unknown'
     })
     const events: CapturedStatus[] = []
     captureAgentStatuses(events)
@@ -524,7 +531,8 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
     vi.mocked(deployAndLaunchRelay).mockResolvedValue({
       transport: relay.transport,
       serverBuildId: 'test-relay-build',
-      platform: 'linux-x64'
+      platform: 'linux-x64',
+      ptyJobControl: 'unknown'
     })
 
     session = createSession('conn-explicit-prompt')
@@ -584,7 +592,8 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
     vi.mocked(deployAndLaunchRelay).mockResolvedValue({
       transport: relay.transport,
       serverBuildId: 'test-relay-build',
-      platform: 'linux-x64'
+      platform: 'linux-x64',
+      ptyJobControl: 'unknown'
     })
     const ingestSpy = vi.spyOn(agentHookServer, 'ingestRemote')
 
@@ -643,7 +652,8 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
     vi.mocked(deployAndLaunchRelay).mockResolvedValue({
       transport: relay.transport,
       serverBuildId: 'test-relay-build',
-      platform: 'linux-x64'
+      platform: 'linux-x64',
+      ptyJobControl: 'unknown'
     })
 
     session = createSession('conn-live-telemetry')
@@ -691,7 +701,8 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
     vi.mocked(deployAndLaunchRelay).mockResolvedValue({
       transport: relay.transport,
       serverBuildId: 'test-relay-build',
-      platform: 'linux-x64'
+      platform: 'linux-x64',
+      ptyJobControl: 'unknown'
     })
 
     session = createSession('conn-replay-marker')

--- a/src/main/ssh/ssh-relay-session-data-delivery.test.ts
+++ b/src/main/ssh/ssh-relay-session-data-delivery.test.ts
@@ -283,7 +283,8 @@ describe('SshRelaySession data delivery', () => {
     vi.mocked(deployAndLaunchRelay).mockResolvedValue({
       transport: { write: vi.fn(), onData: vi.fn(), onClose: vi.fn() },
       platform: 'linux-x64',
-      serverBuildId: 'test-relay-build'
+      serverBuildId: 'test-relay-build',
+      ptyJobControl: 'unknown'
     })
     const first = new SshRelaySession('recovery-target', getMainWindow, mockStore, mockPortForward)
 
@@ -323,7 +324,8 @@ describe('SshRelaySession data delivery', () => {
     vi.mocked(deployAndLaunchRelay).mockResolvedValue({
       transport: { write: vi.fn(), onData: vi.fn(), onClose: vi.fn() },
       platform: 'linux-x64',
-      serverBuildId: 'test-relay-build'
+      serverBuildId: 'test-relay-build',
+      ptyJobControl: 'unknown'
     })
 
     const session = new SshRelaySession(targetId, getMainWindow, mockStore, mockPortForward)
@@ -353,7 +355,8 @@ describe('SshRelaySession data delivery', () => {
     vi.mocked(deployAndLaunchRelay).mockResolvedValue({
       transport: { write: vi.fn(), onData: vi.fn(), onClose: vi.fn() },
       platform: 'linux-x64',
-      serverBuildId: 'test-relay-build'
+      serverBuildId: 'test-relay-build',
+      ptyJobControl: 'unknown'
     })
     vi.mocked(getSshPtyAcceptedSourceCheckpoints).mockReturnValue([
       {

--- a/src/main/ssh/ssh-relay-session-recovery-durability.test.ts
+++ b/src/main/ssh/ssh-relay-session-recovery-durability.test.ts
@@ -119,7 +119,8 @@ describe('SshRelaySession consumer recovery durability', () => {
     vi.mocked(deployAndLaunchRelay).mockResolvedValue({
       transport: { write: vi.fn(), onData: vi.fn(), onClose: vi.fn() },
       platform: 'linux-x64',
-      serverBuildId: 'test-relay-build'
+      serverBuildId: 'test-relay-build',
+      ptyJobControl: 'unknown'
     })
   })
 

--- a/src/main/ssh/ssh-relay-session-terminal-error.test.ts
+++ b/src/main/ssh/ssh-relay-session-terminal-error.test.ts
@@ -133,7 +133,8 @@ function mockDeploySuccess(): void {
   }
   vi.mocked(deployAndLaunchRelay).mockResolvedValue({
     transport: mockTransport,
-    platform: 'linux-x64'
+    platform: 'linux-x64',
+    ptyJobControl: 'unknown'
   })
 }
 

--- a/src/main/ssh/ssh-relay-session-test-fixtures.ts
+++ b/src/main/ssh/ssh-relay-session-test-fixtures.ts
@@ -55,6 +55,7 @@ export function mockDeploySuccess(): void {
       onData: vi.fn(),
       onClose: vi.fn()
     },
-    platform: 'linux-x64'
+    platform: 'linux-x64',
+    ptyJobControl: 'unknown'
   })
 }

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -278,6 +278,7 @@ describe('SshRelaySession', () => {
         onClose: vi.fn()
       },
       platform: 'win32-x64',
+      ptyJobControl: 'unknown',
       hostPlatform: getRemoteHostPlatform('win32-x64'),
       remoteHome: 'C:/Users/me',
       remoteRelayDir: 'C:/Users/me/.orca-remote/relay-v1',
@@ -379,6 +380,7 @@ describe('SshRelaySession', () => {
         onClose: vi.fn()
       },
       platform: 'win32-x64',
+      ptyJobControl: 'unknown',
       hostPlatform: getRemoteHostPlatform('win32-x64'),
       remoteHome: 'C:/Users/me',
       remoteRelayDir: 'C:/Users/me/.orca-remote/relay-v1',
@@ -783,7 +785,8 @@ describe('SshRelaySession', () => {
         resolveFirst = () =>
           resolve({
             transport: { write: vi.fn(), onData: vi.fn(), onClose: vi.fn() },
-            platform: 'linux-x64' as const
+            platform: 'linux-x64' as const,
+            ptyJobControl: 'unknown'
           })
       })
     )


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​401 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​384 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​141 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​125 |

<!-- /orca-pr-loc -->

## ELI5

Orca can kill a terminal's *whole* process tree on Windows by putting it in a job object. That
ability comes from three functions Orca adds to `node-pty` with a **local patch**
(`config/patches/node-pty@1.1.0.patch:786-788`).

When you connect to a **remote host over SSH**, the relay installs `node-pty` straight from npm.
Patches don't travel over SSH, so the three functions are **not there** — on any remote, ever.

The code already handles that: it feature-detects the symbols and quietly falls back to the older
best-effort teardown. The problem was the *quietly*. A relay that never had the capability produced
a deploy log **byte-identical** to one where it works. Nothing anyone could read said which.

This PR makes the deploy say so out loud. **It does not restore the capability** — remotes still
have no native job control, and nothing about teardown changes.

## What an operator sees

**Before** — nothing. The relay deploy log ended at:

```
[ssh-relay] Relay started successfully
```

…whether the remote had job control or not.

**After** — one extra line, always:

```
[ssh-relay] Relay started successfully
[ssh-relay] Remote node-pty job control: absent (expected: the symbols are Windows-only and come from a local-only node-pty patch; remote PTY teardown keeps using the portable path)
```

and the two other states it can report:

```
[ssh-relay] Remote node-pty job control: present (this relay can terminate a PTY process tree by job object)
[ssh-relay] Remote node-pty job control: unknown (the probe did not answer, so this is not a confirmed absence)
```

`unknown` is a first-class answer, never collapsed into `absent`. A probe that could not look is not
evidence of absence — that is the exact bug this exists to remove, and putting it back in a new place
would be no better than leaving the old one.

## Why merge this

The teardown fallback already works. What is missing is any way to **know which teardown you got**.

Today, if a user reports "I killed a terminal on my remote host and its child processes kept
running", there is **nothing in any log that distinguishes the two explanations**: the capability
was absent and the portable path ran, or the capability was present and something failed. Both
produce a byte-identical relay deploy log. Triage starts from zero every time, and the first hour
goes into re-establishing a fact the machine already knew at deploy time.

That is the same defect this whole batch is about, in diagnostic form: **an absent signal being
read as an answer.** Here nobody was even coercing it — there was simply no signal at all, so the
engineer supplies one from memory, and the thing they have to remember is obscure: patches do not
travel over SSH, so three Windows-only symbols added by a local `node-pty` patch are never present
on a remote. That is an invariant most people will not have in their heads at 2am.

**Honest limitation, stated up front:** with today's deploy, this line will say `absent` on every
remote, every time. A constant carries little information on its own. Its value is that the
invariant becomes **readable at the point of use** rather than something you have to know — and
that the moment it stops being constant, the log says so. If the relay ever ships the patched
`node-pty`, this line is what proves the capability arrived, and it is what catches the regression
if it silently stops arriving.

**What it costs to merge:** 141 production lines in a new module, one `console.log` at deploy time,
no behaviour change, no wire change, and no new failure mode — an absence is not an error and
nothing branches on the verdict.

**What it costs not to merge:** every future remote-teardown report is diagnosed by inference
instead of evidence.

## What it does

- `nativeDepsProbeJs` — the probe the deploy **already runs** on every connect — now also feature-detects
  the three symbols on the native module it has *already loaded*, and prints one extra stdout line.
  **No new SSH round trip and no new native load.**
- The verdict is parsed into `present` / `absent` / `unknown` and carried out on
  `RelayDeployResult.ptyJobControl`, which every construction site must state (it is required, not
  optional, so no site can silently omit it and have the omission read as a verdict).
- `TODO(#1693)` records the measured scope so nobody repeats the ruled-out work.

## This is not a wire change

Per `docs/reference/remote-wire-compatibility.md`:

- **Not Rule 1** — no new field on an RPC param or stream frame. `RelayDeployResult` is an in-process
  type on the client.
- **Not Rule 2** — no new stream opcode, so nothing to capability-negotiate.
- **Not Rule 3** — the host publishes nothing new. The probe is a **client-driven `node -e` run over an
  SSH exec channel** against the remote's own `node_modules`. An old relay is not asked anything it
  cannot answer, and no client is made to depend on a field an old host lacks.

The one contract it does borrow is the `agentWait` tri-state from that same doc: **absent ≠ unknown**.
A relay whose probe answers nothing — older install, probe that never ran, truncated stdout, a deploy
branch that skipped the probe — reads `unknown`, never `absent`.

## Failing-first proof

Run A, pre-fix (`ssh-relay-deploy.ts` reverted to `main`; the capability module kept so imports resolve):

```
× asks the remote for all three job symbols in the native-deps probe
× reports present when the remote node-pty exposes the symbols
× reports absent when the remote node-pty is the stock package
× reports unknown, not absent, when the probe could not look
× reports unknown, not absent, for a relay whose probe answers nothing
× reports unknown when the probe command itself fails on a reconnect
× reports unknown, not the pre-repair verdict, when a repair aborts mid-flight
× still reports a real absence on that same reconnect path
Test Files  1 failed | 1 passed (2)
Tests  8 failed | 7 passed (15)
```

Run B, post-fix:

```
Test Files  2 passed (2)
Tests  15 passed (15)
```

## Ablation table

Every production hunk reverted **individually**, tests re-run each time. No hunk is jointly pinned:
each one is red on its own.

| # | Production hunk ablated | Tests that go red |
|---|---|---|
| H1 | `nativeDepsProbeJs` stops embedding `relayPtyJobControlProbeJs` | asks the remote for all three job symbols in the native-deps probe |
| H2 | `probeInstalledNativeDeps` stops parsing the marker | asks the remote for all three job symbols…; reports present…; reports absent… |
| H3 | `probeRequiredNativeDeps` stops parsing the marker | still reports a real absence on that same reconnect path |
| H4 | `probeRequiredNativeDeps` catch reports `absent` instead of `unknown` | reports unknown when the probe command itself fails on a reconnect |
| H5 | `installNativeDeps` drops the post-install verdict | asks the remote…; reports present…; reports absent… |
| H6 | repair catch republishes the stale pre-repair verdict | reports unknown, not the pre-repair verdict, when a repair aborts mid-flight |
| H7 | deploy attempt stops carrying the verdict out of the repair fence | still reports a real absence on that same reconnect path |
| H8 | deploy attempt stops carrying the fresh-install verdict | asks the remote…; reports present…; reports absent… |
| H9 | operator log line removed | reports present…; reports absent…; reports unknown ×2 |
| H10 | `RelayDeployResult` stops exposing the verdict | asks the remote…; reports present…; reports absent…; still reports a real absence… |
| H11 | parser reads a missing marker as `absent` | reads output with no marker at all as unknown, not absent; reports unknown, not absent, for a relay whose probe answers nothing |
| H12 | parser reads an unrecognised verdict as `absent` | reads a probe that could not look…; reads an unrecognised verdict…; reports unknown, not absent, when the probe could not look |
| H13 | remote snippet reports a failed look as `absent` | probes all three job symbols and falls back to unknown when the look throws |
| H14 | operator line for `unknown` reuses the `absent` wording | never calls an unanswered probe an absence in the operator line; reports unknown, not absent ×2 |

H3 and H7 both redden the same single test, but each is red **on its own** — they are not a
jointly-pinned pair.

## Coverage

The four required cases, each asserted on what a **consumer** reads (the deploy result a caller gets
*and* the operator line in the deploy log):

| Case | Reported |
|---|---|
| Symbols present on the remote | `present` |
| Symbols absent (the stock registry package — every real remote today) | `absent` |
| Probe ran but could not look (native module threw) | `unknown` |
| Relay whose probe answers nothing at all (older install / no marker) | `unknown` |

Plus two more that were easy to get wrong: a probe **command** that fails outright on a reconnect
(`unknown`), and a repair that aborts mid-flight after measuring (`unknown`, not the now-stale
pre-repair verdict). The reconnect path carries a **control** — the same path reporting a real
`absent` — so the `unknown` result there is not a hardwired constant.

## What this does NOT do

- **It does not restore native job control on any remote.** Remotes still have none. This only reports it.
- **It ships no prebuilts** and does not touch `config/patches/node-pty@1.1.0.patch`. `TODO(#1693)` now
  records why: the only thing a prebuilt would add is these Windows-only symbols, and shipping Linux
  prebuilts would reintroduce the #9902 glibc hazard for zero gain.
- **It changes no behaviour.** The feature-detect branch stays exactly as it was. An absence is not an
  error, not a warning (`console.log`, not `console.warn`), and not a startup gate. No code path
  branches on the verdict.
- **It is not a liveness verdict.** `live` / `unverifiable` / `exited` is about processes; this is a
  capability, with its own separate words.

## Gates

- `pnpm tc` — clean (both projects)
- `src/main/ssh/` suite — 1781 passed, 14 skipped, 0 failed
- `oxlint` clean; changed-code quality gate (code quality + type-aware + React Doctor) — 0 findings
- `check:max-lines-ratchet` — OK, no new bypasses; the new logic lives in its own module rather than
  growing `ssh-relay-deploy.ts`
- `git diff --check` clean; only changed files formatted with `npx oxfmt --write`
- No `node:child_process` import added

