### PR TITLE
fix(remote): stop painting a disconnected host as connected

### DIFF
--- a/src/renderer/src/runtime/runtime-host-connection-state.test.ts
+++ b/src/renderer/src/runtime/runtime-host-connection-state.test.ts
@@ -78,6 +78,46 @@ describe('runtime host connection state', () => {
     ).toBe('reconnecting')
   })
 
+  function remoteControl(
+    overrides: Partial<NonNullable<RuntimeStatus['remoteControl']>>
+  ): NonNullable<RuntimeStatus['remoteControl']> {
+    return {
+      state: 'ready',
+      pendingRequestCount: 0,
+      subscriptionCount: 0,
+      reconnectAttempt: 0,
+      lastConnectedAt: null,
+      lastClose: null,
+      lastError: null,
+      ...overrides
+    }
+  }
+
+  it('reports a cleanly closed control channel as disconnected even with no error', () => {
+    // Why: a clean close (server restart, host sleep, network blip) leaves lastError null.
+    // Requiring an error string to call it disconnected paints a dead host green.
+    expect(
+      runtimeHostConnectionState({
+        hasStatusEntry: true,
+        status: { ...makeStatus(), remoteControl: remoteControl({ state: 'closed' }) }
+      })
+    ).toBe('disconnected')
+  })
+
+  it('does not call a half-open handshake connected', () => {
+    // Why: the socket is up but the runtime has not completed ready/auth, so nothing
+    // can run there yet. Green here is the same lie as a closed channel reading connected.
+    for (const state of ['awaiting_ready', 'awaiting_authenticated'] as const) {
+      expect(
+        runtimeHostConnectionState({
+          hasStatusEntry: true,
+          status: { ...makeStatus(), remoteControl: remoteControl({ state }) }
+        }),
+        state
+      ).toBe('checking')
+    }
+  })
+
   it('does not hide a closed control channel behind workspace-window diagnostics', () => {
     expect(
       runtimeHostConnectionState({

--- a/src/renderer/src/runtime/runtime-host-connection-state.ts
+++ b/src/renderer/src/runtime/runtime-host-connection-state.ts
@@ -31,8 +31,14 @@ export function runtimeHostConnectionState({
   if (!status) {
     return 'disconnected'
   }
-  if (remoteControl?.state === 'closed' && remoteControl.lastError) {
+  // Why no lastError requirement: a clean close (server restart, host sleep, network
+  // blip) leaves lastError null, and demanding an error string painted those hosts green.
+  if (remoteControl?.state === 'closed') {
     return 'disconnected'
+  }
+  // Why: the socket is up but ready/auth has not completed, so nothing can run there yet.
+  if (remoteControl && remoteControl.state !== 'ready') {
+    return 'checking'
   }
   // Why: reachable but graph-less — the transport is fine, so this is not a network
   // disconnect, but calling it "Connected" hides that nothing will run there.

--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -317,6 +317,11 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     )
     expect(onError).toHaveBeenCalledTimes(1)
     expect(onClose).not.toHaveBeenCalled()
+    expect(connection.getDiagnostics()).toMatchObject({
+      state: 'ready',
+      lastError: null,
+      lastClose: null
+    })
 
     connection.close()
   })

--- a/src/shared/remote-runtime-shared-control-connection.ts
+++ b/src/shared/remote-runtime-shared-control-connection.ts
@@ -211,6 +211,10 @@ export class RemoteRuntimeSharedControlConnection {
       sendEncrypted: (payload) => this.sendEncrypted(payload),
       markReady: () => {
         this.lastConnectedAt = Date.now()
+        // Why cleared here: these describe the attempt that just succeeded's predecessor.
+        // Left set, a recovered host reads "Connected" next to a stale failure forever.
+        this.lastError = null
+        this.lastClose = null
         this.readyStableReset.schedule({
           getState: () => this.state,
           getSocket: () => this.ws,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

## What this fixes

A remote host row could show a green dot and the word **"Connected"** while the host was not connected, and could keep showing a stale error long after the host recovered. Both were visible in the wild: the `Windows high spec` runtime was verifiably `state: ready, reachable: true` while the panel still read `Connected · Could not connect to the remote Orca runtime.`

**1. A disconnected host read as connected.** `runtimeHostConnectionState` only reported `disconnected` when `remoteControl.state === 'closed' && remoteControl.lastError`. A clean close — server restart, host sleep, network blip — leaves `lastError` null, so it fell through to `connected`. Same for a half-open handshake still in `awaiting_ready` / `awaiting_authenticated`, where the socket is up but nothing can run yet.

Now: `closed` → `disconnected` regardless of whether an error string happened to be captured, and `awaiting_*` → `checking`.

**2. Stale failure text beside "Connected".** `lastError` was assigned on the error path and never cleared. `markReady()` set `lastConnectedAt` but left the old error in the diagnostics, and the status row renders it unconditionally — so a host that failed once and recovered showed the failure forever.

Now: `markReady()` clears `lastError` and `lastClose`. This matches what the SSH lane already does (`runtime-environment-ssh-state.ts` sets `lastError = null` on success), which is exactly why only Remote Server rows showed stale text and SSH Host rows did not.

## Tests

Both assertions fail before the change:

```
× reports a cleanly closed control channel as disconnected even with no error
  AssertionError: expected 'connected' to be 'disconnected'
× does not call a half-open handshake connected
  AssertionError: awaiting_ready: expected 'connected' to be 'checking'
```

`pnpm tc` clean, `oxlint` clean on changed files, 36 tests pass across the two affected suites.

## Follow-ups (deliberately not in this PR)

1. **Idle connections never reconnect.** `remote-runtime-shared-control-connection.ts` only schedules a retry when `subscriptions.size > 0`, so a host with nothing actively watching it drops and stays dead until the user manually Disconnects and Connects. That is the root cause of the recurring outage this PR only makes *visible*. A reviewed plan exists; it lands separately.
2. **Retry policy is unsettled.** Whether reconnection should continue indefinitely at a ceiling or stop after a bounded number of attempts is an open decision. Orca has rate caps (15s web lane, 30s shared-control) but no attempt cap anywhere.
3. **The two host lanes should converge.** Remote Server and SSH Host each have their own row component, their own status/colour/action mappings, and their own reconnect implementation. That duplication is what allowed this bug to exist in one lane and not the other. Unifying them behind one connection-state model is the real architectural fix and wants its own design pass.

## Scope

Renderer + shared only. No wire changes, no server changes, no SSH-lane changes.
