### PR TITLE
feat(keybindings): make Close Others / To The Right / To The Left bindable (#16614)

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -179,6 +179,7 @@ import { matchesRecentTabSwitcherChord } from '../../../shared/window-shortcut-p
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
 import { useContextualTour } from './contextual-tours/use-contextual-tour'
 import { openTabBarEntry, type TabCreateEntryArgs } from './tab-bar/tab-create-entry-action'
+import { resolveTabCloseScopeTargets } from './tab-bar/tab-close-scope-targets'
 import { closeTerminalTab } from './terminal/terminal-tab-actions'
 import { translate } from '@/i18n/i18n'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
@@ -2286,6 +2287,34 @@ function Terminal(): React.JSX.Element | null {
         return
       }
 
+      // Scoped closes around the focused tab — unbound by default, assignable in Settings (#16614).
+      // Why: mirror the tab context menu by walking the active strip's visible order.
+      const closeScope = matchShortcut('tab.closeOthers')
+        ? ('others' as const)
+        : matchShortcut('tab.closeToRight')
+          ? ('right' as const)
+          : matchShortcut('tab.closeToLeft')
+            ? ('left' as const)
+            : null
+      if (!e.repeat && closeScope !== null) {
+        // Why: the floating panel owns its own strip; a chord fired there must not close main-window tabs.
+        if (isEventTargetInsideFloatingWorkspacePanel(e.target) || floatingWorkspaceFocused) {
+          return
+        }
+        e.preventDefault()
+        notifyTerminalCapture(
+          closeScope === 'others'
+            ? 'tab.closeOthers'
+            : closeScope === 'right'
+              ? 'tab.closeToRight'
+              : 'tab.closeToLeft'
+        )
+        closeTabBarTabs(
+          resolveTabCloseScopeTargets(useAppStore.getState(), activeWorktreeId, closeScope)
+        )
+        return
+      }
+
       // Ctrl+Tab - quick-toggle to the previously focused tab in this group.
       if (
         matchesRecentTabSwitcherChord(e, shortcutPlatform, keybindings, {
@@ -2374,6 +2403,7 @@ function Terminal(): React.JSX.Element | null {
     closeBrowserTab,
     handleCloseFile,
     handleCloseAllFiles,
+    closeTabBarTabs,
     keybindings,
     mobileEmulatorEnabled,
     terminalShortcutPolicy

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
@@ -306,6 +306,38 @@ describe('EditorFileTabContextMenu close-all shortcut', () => {
     expect(labels.some((label) => label.includes('Close Tabs To The Left'))).toBe(true)
   })
 
+  it('renders assigned shortcuts next to the scoped close items (#16614)', async () => {
+    shortcutLabelMock.mockImplementation((actionId: string) => {
+      switch (actionId) {
+        case 'tab.closeOthers':
+          return '⌘⌥⇧W'
+        case 'tab.closeToRight':
+          return '⌘⌥⇧]'
+        case 'tab.closeToLeft':
+          return '⌘⌥⇧['
+        default:
+          return null
+      }
+    })
+
+    const tree = expandNode(await renderMenu())
+    const menuItems = findElementsByType(tree, 'DropdownMenuItem')
+    const shortcutExpectations: [string, string][] = [
+      ['Close Others', '⌘⌥⇧W'],
+      ['Close Tabs To The Right', '⌘⌥⇧]'],
+      ['Close Tabs To The Left', '⌘⌥⇧[']
+    ]
+
+    for (const [label, expectedLabel] of shortcutExpectations) {
+      const item = menuItems.find((candidate) =>
+        extractText(candidate.props.children).includes(label)
+      )
+      const shortcut = findElementsByType(item, 'DropdownMenuShortcut')
+      expect(shortcut).toHaveLength(1)
+      expect(extractText(shortcut[0].props.children)).toBe(expectedLabel)
+    }
+  })
+
   it('hides the shortcut chip when close-all is unassigned', async () => {
     shortcutLabelMock.mockReturnValue(null)
 

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
@@ -105,6 +105,9 @@ export function EditorFileTabContextMenu({
   const renameShortcut = useOptionalShortcutLabel('tab.rename')
   const closeShortcut = useOptionalShortcutLabel('tab.close')
   const closeAllShortcut = useOptionalShortcutLabel('tab.closeAll')
+  const closeOthersShortcut = useOptionalShortcutLabel('tab.closeOthers')
+  const closeToRightShortcut = useOptionalShortcutLabel('tab.closeToRight')
+  const closeToLeftShortcut = useOptionalShortcutLabel('tab.closeToLeft')
 
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange} modal={false}>
@@ -161,6 +164,9 @@ export function EditorFileTabContextMenu({
         <DropdownMenuItem onSelect={onCloseOthers} disabled={tabCount <= 1}>
           <CopyX className="size-3.5" />
           {translate('components.tab.bar.EditorFileTabContextMenu.closeOthers', 'Close Others')}
+          {closeOthersShortcut ? (
+            <DropdownMenuShortcut>{closeOthersShortcut}</DropdownMenuShortcut>
+          ) : null}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={onCloseAll}>
           <ListX className="size-3.5" />
@@ -178,6 +184,9 @@ export function EditorFileTabContextMenu({
             'auto.components.tab.bar.EditorFileTabContextMenu.e5ff31ccaf',
             'Close Tabs To The Right'
           )}
+          {closeToRightShortcut ? (
+            <DropdownMenuShortcut>{closeToRightShortcut}</DropdownMenuShortcut>
+          ) : null}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={onCloseToLeft} disabled={!hasTabsToLeft}>
           <PanelLeftClose className="size-3.5" />
@@ -185,6 +194,9 @@ export function EditorFileTabContextMenu({
             'components.tab.bar.EditorFileTabContextMenu.closeTabsToLeft',
             'Close Tabs To The Left'
           )}
+          {closeToLeftShortcut ? (
+            <DropdownMenuShortcut>{closeToLeftShortcut}</DropdownMenuShortcut>
+          ) : null}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         {canShowMarkdownPreview ? (

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
@@ -146,6 +146,9 @@ export function SortableTabContextMenu({
   const splitDownShortcut = formatShortcutLabel('terminal.splitDown', keybindings)
 
   const closeShortcut = useOptionalShortcutLabel('tab.close')
+  const closeOthersShortcut = useOptionalShortcutLabel('tab.closeOthers')
+  const closeToRightShortcut = useOptionalShortcutLabel('tab.closeToRight')
+  const closeToLeftShortcut = useOptionalShortcutLabel('tab.closeToLeft')
   const renameShortcut = useOptionalShortcutLabel('tab.rename')
 
   return (
@@ -209,6 +212,9 @@ export function SortableTabContextMenu({
         <DropdownMenuItem onSelect={() => onCloseOthers(tab.id)} disabled={tabCount <= 1}>
           <ListX className="size-3.5" />
           {translate('auto.components.tab.bar.SortableTabContextMenu.8d16f9cd30', 'Close Others')}
+          {closeOthersShortcut ? (
+            <DropdownMenuShortcut>{closeOthersShortcut}</DropdownMenuShortcut>
+          ) : null}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={() => onCloseToRight(tab.id)} disabled={!hasTabsToRight}>
           <PanelRightClose className="size-3.5" />
@@ -216,6 +222,9 @@ export function SortableTabContextMenu({
             'auto.components.tab.bar.SortableTabContextMenu.c1ee099c7e',
             'Close Tabs To The Right'
           )}
+          {closeToRightShortcut ? (
+            <DropdownMenuShortcut>{closeToRightShortcut}</DropdownMenuShortcut>
+          ) : null}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={() => onCloseToLeft(tab.id)} disabled={!hasTabsToLeft}>
           <PanelLeftClose className="size-3.5" />
@@ -223,6 +232,9 @@ export function SortableTabContextMenu({
             'components.tab.bar.SortableTabContextMenu.closeTabsToLeft',
             'Close Tabs To The Left'
           )}
+          {closeToLeftShortcut ? (
+            <DropdownMenuShortcut>{closeToLeftShortcut}</DropdownMenuShortcut>
+          ) : null}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={onRenameOpen}>

--- a/src/renderer/src/components/tab-bar/group-tab-order.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.ts
@@ -219,3 +219,24 @@ export function getActiveTabNavOrder(
   }
   return result
 }
+
+/**
+ * The active group's unified tab id, but only when it is present in `order`.
+ *
+ * Split layouts can open the same entity twice, so the unified id is the only way to tell
+ * which copy is focused. Returning null when it isn't in the visible order keeps callers on
+ * backing-id matching during hydration races, instead of colliding the two id domains.
+ */
+export function getActiveGroupTabIdInNavOrder(
+  state: Pick<AppState, 'activeGroupIdByWorktree' | 'groupsByWorktree'>,
+  worktreeId: string,
+  order: readonly VisibleTabRef[]
+): string | null {
+  const activeGroupId = state.activeGroupIdByWorktree[worktreeId]
+  const group = activeGroupId
+    ? (state.groupsByWorktree[worktreeId] ?? []).find((candidate) => candidate.id === activeGroupId)
+    : undefined
+  return group?.activeTabId && order.some((entry) => entry.tabId === group.activeTabId)
+    ? group.activeTabId
+    : null
+}

--- a/src/renderer/src/components/tab-bar/tab-close-scope-targets.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-close-scope-targets.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import type { Tab, TabGroup } from '../../../../shared/tab-types'
+import type { AppState } from '../../store/types'
+import { resolveTabCloseScopeTargets } from './tab-close-scope-targets'
+
+type ScopeState = Parameters<typeof resolveTabCloseScopeTargets>[0]
+
+function terminalTab(id: string, groupId: string, entityId: string, sortOrder: number): Tab {
+  return {
+    id,
+    entityId,
+    groupId,
+    worktreeId: 'wt',
+    contentType: 'terminal',
+    label: entityId,
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: sortOrder
+  }
+}
+
+function editorTab(id: string, groupId: string, entityId: string, sortOrder: number): Tab {
+  return {
+    id,
+    entityId,
+    groupId,
+    worktreeId: 'wt',
+    contentType: 'editor',
+    label: entityId,
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: sortOrder
+  }
+}
+
+function makeState(overrides: Partial<ScopeState>): ScopeState {
+  return {
+    activeGroupIdByWorktree: {},
+    groupsByWorktree: {},
+    unifiedTabsByWorktree: {},
+    tabBarOrderByWorktree: {},
+    tabsByWorktree: {},
+    openFiles: [],
+    browserTabsByWorktree: {},
+    activeTabType: 'terminal',
+    activeTabId: null,
+    activeFileId: null,
+    activeBrowserTabId: null,
+    ...overrides
+  } as ScopeState
+}
+
+const THREE_TERMINALS = {
+  tabsByWorktree: {
+    wt: [{ id: 'term-1' }, { id: 'term-2' }, { id: 'term-3' }]
+  } as unknown as AppState['tabsByWorktree']
+}
+
+describe('resolveTabCloseScopeTargets', () => {
+  describe('with a split-group layout', () => {
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-t1',
+      // Drag-reordered: the strip shows term-2 first, so term-1 is no longer leftmost.
+      tabOrder: ['tab-t2', 'tab-t1', 'tab-t3']
+    }
+    const tabs: Tab[] = [
+      terminalTab('tab-t1', 'g1', 'term-1', 0),
+      terminalTab('tab-t2', 'g1', 'term-2', 1),
+      terminalTab('tab-t3', 'g1', 'term-3', 2)
+    ]
+    const state = makeState({
+      ...THREE_TERMINALS,
+      activeGroupIdByWorktree: { wt: 'g1' },
+      groupsByWorktree: { wt: [group] },
+      unifiedTabsByWorktree: { wt: tabs },
+      // Stale legacy order: it must not decide what gets closed.
+      tabBarOrderByWorktree: { wt: ['term-1', 'term-2', 'term-3'] },
+      activeTabId: 'term-1'
+    })
+
+    it('targets every sibling for a close-others', () => {
+      expect(resolveTabCloseScopeTargets(state, 'wt', 'others')).toEqual(['term-2', 'term-3'])
+    })
+
+    it('walks the drag-reordered strip order for directional closes', () => {
+      // The stale legacy order would leave nothing to the left of term-1.
+      expect(resolveTabCloseScopeTargets(state, 'wt', 'left')).toEqual(['term-2'])
+      expect(resolveTabCloseScopeTargets(state, 'wt', 'right')).toEqual(['term-3'])
+    })
+  })
+
+  it('disambiguates split copies of one file by the active group tab id', () => {
+    const activeGroup: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-e1',
+      tabOrder: ['tab-e1', 'tab-t1']
+    }
+    const otherGroup: TabGroup = {
+      id: 'g2',
+      worktreeId: 'wt',
+      activeTabId: 'tab-e2',
+      tabOrder: ['tab-e2', 'tab-t2']
+    }
+    const state = makeState({
+      activeGroupIdByWorktree: { wt: 'g1' },
+      groupsByWorktree: { wt: [activeGroup, otherGroup] },
+      unifiedTabsByWorktree: {
+        wt: [
+          editorTab('tab-e1', 'g1', '/repo/file.md', 0),
+          terminalTab('tab-t1', 'g1', 'term-1', 1),
+          editorTab('tab-e2', 'g2', '/repo/file.md', 2),
+          terminalTab('tab-t2', 'g2', 'term-2', 3)
+        ]
+      },
+      tabsByWorktree: {
+        wt: [{ id: 'term-1' }, { id: 'term-2' }]
+      } as unknown as AppState['tabsByWorktree'],
+      openFiles: [{ id: '/repo/file.md', worktreeId: 'wt' }] as unknown as AppState['openFiles'],
+      activeTabType: 'editor',
+      activeFileId: '/repo/file.md'
+    })
+
+    // The other group's terminal is never a target: only the active strip is in scope.
+    expect(resolveTabCloseScopeTargets(state, 'wt', 'others')).toEqual(['term-1'])
+  })
+
+  it('falls back to the legacy worktree order when no group has hydrated', () => {
+    const state = makeState({
+      ...THREE_TERMINALS,
+      tabBarOrderByWorktree: { wt: ['term-1', 'term-2', 'term-3'] },
+      activeTabId: 'term-2'
+    })
+
+    expect(resolveTabCloseScopeTargets(state, 'wt', 'left')).toEqual(['term-1'])
+    expect(resolveTabCloseScopeTargets(state, 'wt', 'right')).toEqual(['term-3'])
+    expect(resolveTabCloseScopeTargets(state, 'wt', 'others')).toEqual(['term-1', 'term-3'])
+  })
+
+  it('closes nothing when the focused tab is not in the visible order', () => {
+    const state = makeState({
+      ...THREE_TERMINALS,
+      tabBarOrderByWorktree: { wt: ['term-1', 'term-2', 'term-3'] },
+      activeTabId: 'term-gone'
+    })
+
+    expect(resolveTabCloseScopeTargets(state, 'wt', 'others')).toEqual([])
+    expect(resolveTabCloseScopeTargets(state, 'wt', 'right')).toEqual([])
+  })
+})

--- a/src/renderer/src/components/tab-bar/tab-close-scope-targets.ts
+++ b/src/renderer/src/components/tab-bar/tab-close-scope-targets.ts
@@ -1,0 +1,49 @@
+import { getActiveEntityIdForTabType, type TabCycleType } from '../terminal/tab-type-cycle'
+import { getActiveGroupTabIdInNavOrder, getActiveTabNavOrder } from './group-tab-order'
+
+export type TabCloseScope = 'others' | 'right' | 'left'
+
+type TabCloseScopeState = Parameters<typeof getActiveTabNavOrder>[0] & {
+  activeTabType: TabCycleType
+  activeTabId: string | null
+  activeFileId: string | null
+  activeBrowserTabId: string | null
+}
+
+/**
+ * The visible tab ids a scoped close should target, relative to the focused tab.
+ *
+ * Walks the same order the active tab strip renders (`getActiveTabNavOrder`), so the
+ * keyboard actions close exactly what the "Close Others / To The Right / To The Left"
+ * context-menu items would in the surface the user is looking at. Ids stay in the
+ * visible-id domain the bulk-close paths take (entity id for terminals, browsers and
+ * editor files; unified tab id for simulators); pinned and dirty handling belongs to
+ * those paths, not here. Returns [] when the focused tab isn't in the visible order.
+ */
+export function resolveTabCloseScopeTargets(
+  state: TabCloseScopeState,
+  worktreeId: string,
+  scope: TabCloseScope
+): string[] {
+  const order = getActiveTabNavOrder(state, worktreeId)
+  const groupTabIdInNav = getActiveGroupTabIdInNavOrder(state, worktreeId, order)
+  const activeEntityId = getActiveEntityIdForTabType(
+    state.activeTabType,
+    state.activeTabId,
+    state.activeFileId,
+    state.activeBrowserTabId
+  )
+  const focusedIndex = groupTabIdInNav
+    ? order.findIndex((entry) => entry.tabId === groupTabIdInNav)
+    : order.findIndex((entry) => entry.type === state.activeTabType && entry.id === activeEntityId)
+  if (focusedIndex === -1) {
+    return []
+  }
+  const targets =
+    scope === 'others'
+      ? order.filter((_, index) => index !== focusedIndex)
+      : scope === 'right'
+        ? order.slice(focusedIndex + 1)
+        : order.slice(0, focusedIndex)
+  return targets.map((entry) => entry.id)
+}

--- a/src/renderer/src/hooks/ipc-tab-switch.test.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.test.ts
@@ -11,7 +11,10 @@ vi.mock('../store', () => ({
   }
 }))
 
-vi.mock('@/components/tab-bar/group-tab-order', () => ({
+// Only the nav order is stubbed; the active-group resolver keeps its real behaviour so the
+// split-layout disambiguation these tests cover still runs.
+vi.mock(import('@/components/tab-bar/group-tab-order'), async (importOriginal) => ({
+  ...(await importOriginal()),
   getActiveTabNavOrder: getActiveTabNavOrderMock
 }))
 

--- a/src/renderer/src/hooks/ipc-tab-switch.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.ts
@@ -1,5 +1,8 @@
 import { useAppStore } from '../store'
-import { getActiveTabNavOrder } from '@/components/tab-bar/group-tab-order'
+import {
+  getActiveGroupTabIdInNavOrder,
+  getActiveTabNavOrder
+} from '@/components/tab-bar/group-tab-order'
 import {
   getActiveEntityIdForTabType,
   getNextTabAcrossAllTypes,
@@ -35,20 +38,10 @@ function resolveCycleContext(): CycleContext | null {
   if (allTabIds.length <= 1) {
     return null
   }
-  const activeGroupId = store.activeGroupIdByWorktree[worktreeId]
-  const group = activeGroupId
-    ? (store.groupsByWorktree[worktreeId] ?? []).find((candidate) => candidate.id === activeGroupId)
-    : undefined
   // Why: prefer the active group's unified tab id so split layouts disambiguate
-  // which copy of a same-entity tab is focused. Match strictly against `tabId`
-  // in that path; only fall back to backing-id matching when the group path
-  // doesn't apply (no group, or its activeTabId isn't in the visible nav —
-  // e.g. hydration races). Keeping the two domains in separate branches
-  // prevents a backing id from colliding with an unrelated tab's `tabId`.
-  const groupTabIdInNav =
-    group?.activeTabId && allTabIds.some((entry) => entry.tabId === group.activeTabId)
-      ? group.activeTabId
-      : null
+  // which copy of a same-entity tab is focused; callers fall back to backing-id
+  // matching when it resolves to null.
+  const groupTabIdInNav = getActiveGroupTabIdInNavOrder(store, worktreeId, allTabIds)
   return { store, worktreeId, allTabIds, groupTabIdInNav }
 }
 

--- a/src/shared/keybindings-unassigned-actions.test.ts
+++ b/src/shared/keybindings-unassigned-actions.test.ts
@@ -215,6 +215,39 @@ describe('keybindings', () => {
     )
   })
 
+  it('keeps the scoped tab closes unassigned beside the bound close actions (#16614)', () => {
+    const platforms: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
+    const scopedCloses: readonly KeybindingActionId[] = [
+      'tab.closeOthers',
+      'tab.closeToRight',
+      'tab.closeToLeft'
+    ]
+
+    for (const actionId of scopedCloses) {
+      for (const platform of platforms) {
+        expect(getEffectiveKeybindingsForAction(actionId, platform)).toEqual([])
+      }
+      const definition = getKeybindingDefinition(actionId)
+      expect(definition?.group).toBe('Tabs')
+      expect(definition?.scope).toBe('tabs')
+      expect(definition?.searchKeywords).toEqual(expect.arrayContaining(['close', 'tabs']))
+    }
+
+    expect(getKeybindingDefinition('tab.closeOthers')?.title).toBe('Close other tabs')
+    expect(getKeybindingDefinition('tab.closeToRight')?.title).toBe('Close tabs to the right')
+    expect(getKeybindingDefinition('tab.closeToLeft')?.title).toBe('Close tabs to the left')
+
+    // The bound close actions keep their chords; the scoped ones only match once assigned.
+    expect(getEffectiveKeybindingsForAction('tab.close', 'darwin')).toEqual(['Mod+W'])
+    const chord = { key: 'w', code: 'KeyW', control: false, meta: true, alt: true, shift: true }
+    expect(keybindingMatchesAction('tab.closeOthers', chord, 'darwin')).toBe(false)
+    expect(
+      keybindingMatchesAction('tab.closeOthers', chord, 'darwin', {
+        'tab.closeOthers': ['Mod+Alt+Shift+W']
+      })
+    ).toBe(true)
+  })
+
   it('leaves floating workspace minimize unassigned because floating terminal toggle owns show and hide', () => {
     const platforms: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
     const minimizeAction = 'floatingWorkspace.minimize' as KeybindingActionId

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -67,6 +67,9 @@ export type KeybindingActionId =
   | 'tab.openMarkdown'
   | 'tab.close'
   | 'tab.closeAll'
+  | 'tab.closeOthers'
+  | 'tab.closeToRight'
+  | 'tab.closeToLeft'
   | 'tab.rename'
   | 'tab.reopenClosed'
   | 'tab.nextSameType'
@@ -633,6 +636,31 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'tabs',
     searchKeywords: ['shortcut', 'close', 'all', 'tabs', 'files', 'editors'],
     defaultBindings: platformBindings(['Mod+Alt+W'])
+  },
+  {
+    id: 'tab.closeOthers',
+    title: 'Close other tabs',
+    group: 'Tabs',
+    scope: 'tabs',
+    searchKeywords: ['shortcut', 'close', 'others', 'tabs', 'siblings'],
+    // Why: unbound by default — every free Mod+W variant is already taken by close/close-all.
+    defaultBindings: platformBindings([])
+  },
+  {
+    id: 'tab.closeToRight',
+    title: 'Close tabs to the right',
+    group: 'Tabs',
+    scope: 'tabs',
+    searchKeywords: ['shortcut', 'close', 'right', 'tabs', 'trailing'],
+    defaultBindings: platformBindings([])
+  },
+  {
+    id: 'tab.closeToLeft',
+    title: 'Close tabs to the left',
+    group: 'Tabs',
+    scope: 'tabs',
+    searchKeywords: ['shortcut', 'close', 'left', 'tabs', 'leading'],
+    defaultBindings: platformBindings([])
   },
   {
     id: 'tab.rename',


### PR DESCRIPTION
## ELI5

The tab right-click menu can already "Close Others", "Close Tabs To The Right" and "Close Tabs To The Left", but you could not put those on a keyboard shortcut. Now you can assign them in Settings → Shortcuts, and once assigned the chord shows up in the menu next to the item — the same way `Close ⌘W` does today.

## What Changed

- **Registry** (`src/shared/keybindings.ts`): adds `tab.closeOthers`, `tab.closeToRight` and `tab.closeToLeft` to the `Tabs` group, scope `tabs`. All three ship **unbound** — every free `Mod+W` variant is already taken by `tab.close` / `tab.closeAll`, and the issue asks for "no default binding (or a sensible one if desired)". Settings → Shortcuts picks them up automatically, since `groupDefinitions` enumerates `KEYBINDING_DEFINITIONS`.
- **New module** `src/renderer/src/components/tab-bar/tab-close-scope-targets.ts`: a pure `resolveTabCloseScopeTargets(state, worktreeId, scope)` that returns the visible tab ids a scoped close should target, relative to the focused tab.
- **Handler** (`Terminal.tsx`): the three chords are matched in the existing workspace key listener, right after `tab.closeAll`, and routed through `closeTabBarTabs` — the same bulk-close path the context menu items use.
- **Menus**: `SortableTabContextMenu` and `EditorFileTabContextMenu` now render the assigned chord next to each scoped close via `useOptionalShortcutLabel`, so nothing appears while the action is unbound.
- **Dedupe**: the active-group tab resolution that `ipc-tab-switch.ts` used inline is extracted to `getActiveGroupTabIdInNavOrder` in `group-tab-order.ts` and shared with the new module rather than copied.

## Why

Fixes the exact gap the issue describes: `commands.closeOthers` / `closeToRight` / `closeToLeft` already existed in `TabGroupPanel` and `Terminal.tsx`, but there was no action id, so `~/.orca/keybindings.json` rejected them with "Unknown keybinding action".

Three decisions worth reviewing:

1. **Targets come from `getActiveTabNavOrder`, not `tabBarOrderByWorktree`.** That is the order the active tab strip actually renders — the active split group when a layout has hydrated, the legacy worktree order as fallback. Using the legacy order directly would close the wrong tabs after a drag-reorder (the same class of bug `getActiveTabNavOrder` was introduced for in STA-3475), and in a split layout it would reach across into sibling groups, which is not what the menu item does.
2. **Closing reuses `closeTabBarTabs` instead of a new path.** Pinned-tab skipping, the dirty-file save/confirm queue, web-runtime session tabs and browser-guest teardown all keep working unchanged — the new code only decides *which* ids, never *how* they close.
3. **A chord fired inside the floating workspace panel is ignored.** That panel owns its own tab strip and its own owned-action list; without the guard, a scoped close pressed there would silently close main-window tabs. This mirrors the guard `tab.close` already has.

## Linked Issue

Fixes #16614

## Visual Proof

The only rendered change is a shortcut chip in the tab context menu, and it is invisible until the user assigns a chord (`useOptionalShortcutLabel` returns `null` while unbound), so **before/after is identical on a default install**. After assigning e.g. `⌘⌥⇧W` to "Close other tabs":

```
before                          after
─────────────────────────       ─────────────────────────
 Close              ⌘W           Close              ⌘W
 Close Others                    Close Others    ⌘⌥⇧W
 Close Tabs To The Right         Close Tabs To The Right
 Close Tabs To The Left          Close Tabs To The Left
```

That rendering is asserted by a test rather than a screenshot — see `EditorFileTabContextMenu.test.tsx` → "renders assigned shortcuts next to the scoped close items", which drives the real menu tree and checks each item carries exactly one `DropdownMenuShortcut` with its own label, plus the existing "hides the shortcut chip when close-all is unassigned" case for the unbound state.

I did not launch a dev instance to capture video: this machine is running Orca as the primary editor and a second instance sharing `~/.orca` and the terminal daemon would have disturbed the live session. Happy to attach a recording if a maintainer would rather have one.

## Testing

Automated:

- `src/renderer/src/components/tab-bar/tab-close-scope-targets.test.ts` (new, 5 cases): close-others / left / right against a **drag-reordered** group order (the stale legacy order would give a different answer for both directions); split layouts where the same file is open in two groups, asserting the sibling group is never a target; the legacy no-group-hydrated fallback; and the "focused tab not in the visible order" case closing nothing.
- `src/shared/keybindings-unassigned-actions.test.ts`: the three actions are unbound on darwin/linux/win32, carry the right group/scope/title/keywords, do not match a chord until assigned, and `tab.close` keeps `Mod+W`.
- `src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx`: the chip test described above.
- `src/renderer/src/hooks/ipc-tab-switch.test.ts`: its module mock now uses `importOriginal` so the extracted resolver runs for real instead of being stubbed away.

Local runs (macOS, node via pnpm):

- `pnpm test` — 64243 passed / 264 skipped. One unrelated failure, `src/main/startup/run-electron-vite-dev.test.ts` → "rebuilds the copied Electron app when Chromium resources are missing", a `waitFor` timeout under full-suite load; it passes in isolation both with this branch and on a clean checkout.
- `pnpm tc:web`, `pnpm tc:node` — clean.
- `oxlint` (base, `oxlint-code-quality-native-plugins`, `--type-aware oxlint-code-quality-type-aware --deny-warnings`) and `oxfmt --check` on every touched file — clean.
- Gates: `check:max-lines-ratchet`, `check:reliability-gates`, `check:runtime-electron-ratchet`, `verify:localization-catalog`, `verify:localization-extraction`, `verify:localization-coverage` — all pass.

Manual: not exercised in the running app, for the reason given under Visual Proof.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5, via Claude Code, was used to write the implementation and tests. I reviewed the diff and ran the full test/typecheck/lint suite locally.

## Review

Cross-cutting concerns considered:

- **Cross-platform**: no new platform branches. Matching goes through `keybindingMatchesAction`, which already resolves `Mod` per platform, and the menu chip comes from `useOptionalShortcutLabel`, which formats `⌘`/`Ctrl+` per platform. Defaults are empty on all three platforms, so nothing new can collide with an OS or shell chord.
- **SSH / remote**: no execution-boundary change. Terminal tabs still close through `closeTabBarTabs`, which routes web-runtime session tabs to their authoritative host (`closeWebRuntimeSessionTab`) exactly as the context-menu path does.
- **Remote wire**: nothing added to RPC params, stream frames, or published content — this is renderer-local keybinding plumbing.
- **Folder workspaces**: the resolver is keyed by `worktreeId` the same way `getActiveTabNavOrder` already is, with no git-worktree assumption.
- **Backwards compatibility**: three new action ids and no change to existing ones. An existing `keybindings.json` is unaffected; a user who had hand-written `tab.closeOthers` and been rejected will now have it honoured.
- **Performance**: three extra `keybindingMatchesAction` calls per keydown, all short-circuiting on an empty binding list until the user assigns one.
- **Known gap**: `BrowserTab.tsx` renders its own close menu and shows **no** shortcut chips at all today — not even `⌘W` on "Close". I left it alone rather than adding chips only for the scoped closes, which would have read as inconsistent inside that one menu. Happy to bring all of them over in this PR if that is preferred.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
