### PR TITLE
Show remote host failure details in a submenu

### DIFF
--- a/src/renderer/src/components/status-bar/RuntimeHostStatusRow.test.tsx
+++ b/src/renderer/src/components/status-bar/RuntimeHostStatusRow.test.tsx
@@ -1,6 +1,41 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { RuntimeHostStatusRow } from './RuntimeHostStatusRow'
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenuItem: ({
+    children,
+    disabled,
+    onSelect
+  }: {
+    children: ReactNode
+    disabled?: boolean
+    onSelect?: (event: { preventDefault: () => void }) => void
+  }) => (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => onSelect?.({ preventDefault: () => undefined })}
+    >
+      {children}
+    </button>
+  ),
+  DropdownMenuSub: ({ children }: { children: ReactNode }) => (
+    <div data-slot="dropdown-menu-sub">{children}</div>
+  ),
+  DropdownMenuSubContent: ({ children }: { children: ReactNode }) => (
+    <div data-slot="dropdown-menu-sub-content">{children}</div>
+  ),
+  DropdownMenuSubTrigger: ({ children }: { children: ReactNode }) => (
+    <div data-slot="dropdown-menu-sub-trigger">{children}</div>
+  )
+}))
+
+afterEach(cleanup)
 
 describe('RuntimeHostStatusRow', () => {
   it('renders reconnecting diagnostics for remote hosts', () => {
@@ -67,5 +102,82 @@ describe('RuntimeHostStatusRow', () => {
     expect(markup).toContain('Dev Box')
     expect(markup).toContain('Connected')
     expect(markup).toContain('Disconnect')
+  })
+
+  it('keeps healthy rows free of a submenu trigger', () => {
+    const { container } = render(<RuntimeHostStatusRow label="Dev Box" state="connected" />)
+
+    expect(container.querySelector('[data-slot="dropdown-menu-sub-trigger"]')).toBeNull()
+  })
+
+  it('renders failing rows as submenu triggers', () => {
+    const { container } = render(
+      <RuntimeHostStatusRow label="Dev Box" state="disconnected" detail="Connection refused" />
+    )
+
+    expect(container.querySelector('[data-slot="dropdown-menu-sub-trigger"]')).not.toBeNull()
+  })
+
+  it('keeps the row action invokable for failing hosts', async () => {
+    const onConnect = vi.fn(async () => {})
+    render(
+      <RuntimeHostStatusRow
+        label="Dev Box"
+        state="disconnected"
+        detail="Connection refused"
+        onConnect={onConnect}
+      />
+    )
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Connect' })[0])
+
+    await waitFor(() => expect(onConnect).toHaveBeenCalledOnce())
+  })
+
+  it('renders a long raw error in full inside the submenu', () => {
+    const longError = `Invalid remote endpoint: ${'wss://relay.example.test/path/'.repeat(8)}`
+    const { container } = render(
+      <RuntimeHostStatusRow
+        label="Dev Box"
+        state="disconnected"
+        detail={longError}
+        diagnostics={{
+          state: 'closed',
+          pendingRequestCount: 0,
+          subscriptionCount: 0,
+          reconnectAttempt: 3,
+          lastConnectedAt: null,
+          lastClose: null,
+          lastError: longError
+        }}
+      />
+    )
+
+    const submenu = container.querySelector('[data-slot="dropdown-menu-sub-content"]')
+    expect(submenu).not.toBeNull()
+    expect(submenu?.textContent).toContain(longError)
+  })
+
+  it('shows the existing connection diagnostics in the submenu', () => {
+    const { container } = render(
+      <RuntimeHostStatusRow
+        label="Dev Box"
+        state="reconnecting"
+        detail="Connection refused"
+        diagnostics={{
+          state: 'reconnecting',
+          pendingRequestCount: 0,
+          subscriptionCount: 0,
+          reconnectAttempt: 2,
+          lastConnectedAt: Date.now() - 60_000,
+          lastClose: null,
+          lastError: 'Connection refused'
+        }}
+      />
+    )
+
+    const submenu = container.querySelector('[data-slot="dropdown-menu-sub-content"]')
+    expect(submenu?.textContent).toContain('Last connected')
+    expect(submenu?.textContent).toContain('Attempt 3')
   })
 })

--- a/src/renderer/src/components/status-bar/RuntimeHostStatusRow.test.tsx
+++ b/src/renderer/src/components/status-bar/RuntimeHostStatusRow.test.tsx
@@ -115,7 +115,9 @@ describe('RuntimeHostStatusRow', () => {
       <RuntimeHostStatusRow label="Dev Box" state="disconnected" detail="Connection refused" />
     )
 
-    expect(container.querySelector('[data-slot="dropdown-menu-sub-trigger"]')).not.toBeNull()
+    const trigger = container.querySelector('[data-slot="dropdown-menu-sub-trigger"]')
+    expect(trigger).not.toBeNull()
+    expect(trigger?.querySelector('button')).toBeNull()
   })
 
   it('keeps the row action invokable for failing hosts', async () => {

--- a/src/renderer/src/components/status-bar/RuntimeHostStatusRow.tsx
+++ b/src/renderer/src/components/status-bar/RuntimeHostStatusRow.tsx
@@ -1,11 +1,19 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
+import { formatUiRelativeTime } from '@/i18n/relative-time-format'
 import { useMountedRef } from '@/hooks/useMountedRef'
+import {
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger
+} from '@/components/ui/dropdown-menu'
 import {
   isConnectedRuntimeHostState,
   type RuntimeHostConnectionState
 } from '@/runtime/runtime-host-connection-state'
+import type { RemoteRuntimeSharedConnectionDiagnostics } from '../../../../shared/remote-runtime-shared-control-types'
 
 function runtimeStatusLabel(state: RuntimeHostConnectionState): string {
   switch (state) {
@@ -64,20 +72,64 @@ function runtimeActionLabel(state: RuntimeHostConnectionState): string | null {
   }
 }
 
+function runtimeFailureSummary(state: RuntimeHostConnectionState): string {
+  switch (state) {
+    case 'connected':
+      return translate(
+        'auto.components.status.bar.RuntimeHostStatusRow.previous_connection_closed',
+        'The previous connection closed'
+      )
+    case 'workspace-window-closed':
+      return translate(
+        'auto.components.status.bar.RuntimeHostStatusRow.workspace_window_closed',
+        'The workspace window is closed'
+      )
+    case 'checking':
+      return translate(
+        'auto.components.status.bar.RuntimeHostStatusRow.checking_host',
+        'Orca is checking whether this host is reachable'
+      )
+    case 'reconnecting':
+      return translate(
+        'auto.components.status.bar.RuntimeHostStatusRow.restoring_connection',
+        'Orca is trying to restore the connection'
+      )
+    case 'disconnected':
+      return translate(
+        'auto.components.status.bar.RuntimeHostStatusRow.host_unreachable',
+        'Orca isn’t reachable on this host'
+      )
+  }
+}
+
+function runtimeFailureExplanation(state: RuntimeHostConnectionState): string | null {
+  if (state === 'connected' || state === 'workspace-window-closed') {
+    return null
+  }
+  return translate(
+    'auto.components.status.bar.RuntimeHostStatusRow.contact_note',
+    'The host may still be running; only the Orca connection is unavailable.'
+  )
+}
+
 export function RuntimeHostStatusRow({
   label,
   state,
   detail,
+  diagnostics,
   onConnect,
   onDisconnect
 }: {
   label: string
   state: RuntimeHostConnectionState
   detail?: string
+  diagnostics?: RemoteRuntimeSharedConnectionDiagnostics | null
   onConnect?: () => Promise<void>
   onDisconnect?: () => Promise<void>
 }): React.JSX.Element {
   const [busy, setBusy] = useState(false)
+  const [submenuOpen, setSubmenuOpen] = useState(false)
+  const actionPointerActiveRef = useRef(false)
   const mountedRef = useMountedRef()
   const actionLabel = runtimeActionLabel(state)
 
@@ -96,9 +148,32 @@ export function RuntimeHostStatusRow({
     }
   }, [mountedRef, onConnect, onDisconnect, state])
 
-  return (
-    <div className="flex items-center gap-2.5 px-2 py-1.5">
-      <span className={`size-1.5 shrink-0 rounded-full ${runtimeDotColor(state)}`} />
+  const action = isConnectedRuntimeHostState(state) ? onDisconnect : onConnect
+  const lastConnectedLabel = diagnostics?.lastConnectedAt
+    ? translate(
+        'auto.components.status.bar.RuntimeHostStatusRow.last_connected',
+        'Last connected {{value0}}',
+        { value0: formatUiRelativeTime(diagnostics.lastConnectedAt - Date.now()) }
+      )
+    : null
+  const reconnectAttemptLabel =
+    diagnostics && state === 'reconnecting'
+      ? translate(
+          'auto.components.status.bar.RuntimeHostStatusRow.reconnect_attempt',
+          'Attempt {{value0}}',
+          { value0: String(diagnostics.reconnectAttempt + 1) }
+        )
+      : null
+  const diagnosticLabel = [lastConnectedLabel, reconnectAttemptLabel].filter(Boolean).join(' · ')
+  const rawDetail = diagnostics?.lastError ?? diagnostics?.lastClose?.reason ?? detail
+  const failureExplanation = runtimeFailureExplanation(state)
+
+  const rowContent = (
+    <>
+      <span
+        aria-hidden="true"
+        className={`size-1.5 shrink-0 rounded-full ${runtimeDotColor(state)}`}
+      />
       <div className="min-w-0 flex-1">
         <div className="truncate text-[12px] font-medium">{label}</div>
         <div className="flex min-w-0 items-center gap-1.5 text-[10px] text-muted-foreground">
@@ -115,25 +190,81 @@ export function RuntimeHostStatusRow({
             ) : null}
             <span className="truncate">{runtimeStatusLabel(state)}</span>
           </span>
-          {detail ? (
-            <>
-              <span aria-hidden="true">·</span>
-              <span className="truncate">{detail}</span>
-            </>
-          ) : null}
         </div>
       </div>
       {busy ? (
         <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
-      ) : actionLabel && (isConnectedRuntimeHostState(state) ? onDisconnect : onConnect) ? (
+      ) : actionLabel && action ? (
         <button
           type="button"
-          onClick={() => void handleAction()}
+          tabIndex={detail ? -1 : undefined}
+          onPointerEnter={() => {
+            actionPointerActiveRef.current = true
+            setSubmenuOpen(false)
+          }}
+          onPointerLeave={() => {
+            actionPointerActiveRef.current = false
+          }}
+          onPointerMove={(event) => event.stopPropagation()}
+          onPointerDown={(event) => {
+            event.stopPropagation()
+          }}
+          onClick={(event) => {
+            event.stopPropagation()
+            void handleAction()
+          }}
           className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent/70 hover:text-foreground"
         >
           {actionLabel}
         </button>
       ) : null}
-    </div>
+    </>
+  )
+
+  if (!detail) {
+    return <div className="flex items-center gap-2.5 px-2 py-1.5">{rowContent}</div>
+  }
+
+  return (
+    <DropdownMenuSub
+      open={submenuOpen}
+      onOpenChange={(open) => {
+        if (!open || !actionPointerActiveRef.current) {
+          setSubmenuOpen(open)
+        }
+      }}
+    >
+      <DropdownMenuSubTrigger className="gap-2.5 px-2 py-1.5">{rowContent}</DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="w-[min(18rem,calc(100vw-1rem))] p-1.5">
+        <div className="px-1.5 pt-0.5 pb-1.5">
+          <div className="text-[11px] font-semibold">{runtimeFailureSummary(state)}</div>
+          {failureExplanation ? (
+            <div className="mt-1 text-[11px] leading-4 text-muted-foreground">
+              {failureExplanation}
+            </div>
+          ) : null}
+        </div>
+        {rawDetail ? (
+          <div className="mx-1 mb-1.5 max-h-24 overflow-y-auto scrollbar-sleek whitespace-pre-wrap break-words rounded-md bg-muted px-2 py-1.5 font-mono text-[10px] leading-4 text-muted-foreground [overflow-wrap:anywhere]">
+            {rawDetail}
+          </div>
+        ) : null}
+        {diagnosticLabel ? (
+          <div className="px-1.5 pb-1.5 text-[10px] text-muted-foreground">{diagnosticLabel}</div>
+        ) : null}
+        {actionLabel && action ? (
+          <DropdownMenuItem
+            disabled={busy}
+            onSelect={(event) => {
+              event.preventDefault()
+              void handleAction()
+            }}
+          >
+            {busy ? <Loader2 className="size-3 animate-spin" /> : null}
+            {actionLabel}
+          </DropdownMenuItem>
+        ) : null}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
   )
 }

--- a/src/renderer/src/components/status-bar/RuntimeHostStatusRow.tsx
+++ b/src/renderer/src/components/status-bar/RuntimeHostStatusRow.tsx
@@ -200,28 +200,51 @@ export function RuntimeHostStatusRow({
   const actionButton = busy ? (
     <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
   ) : actionLabel && action ? (
-    <button
-      type="button"
-      tabIndex={detail ? -1 : undefined}
-      onPointerEnter={() => {
-        actionPointerActiveRef.current = true
-        setSubmenuOpen(false)
-      }}
-      onPointerLeave={() => {
-        actionPointerActiveRef.current = false
-      }}
-      onPointerMove={(event) => event.stopPropagation()}
-      onPointerDown={(event) => {
-        event.stopPropagation()
-      }}
-      onClick={(event) => {
-        event.stopPropagation()
-        void handleAction()
-      }}
-      className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent/70 hover:text-foreground"
-    >
-      {actionLabel}
-    </button>
+    detail ? (
+      <span
+        aria-hidden="true"
+        onPointerEnter={() => {
+          actionPointerActiveRef.current = true
+          setSubmenuOpen(false)
+        }}
+        onPointerLeave={() => {
+          actionPointerActiveRef.current = false
+        }}
+        onPointerMove={(event) => event.stopPropagation()}
+        onPointerDown={(event) => {
+          event.stopPropagation()
+        }}
+        onClick={(event) => {
+          event.stopPropagation()
+          void handleAction()
+        }}
+        className="shrink-0 cursor-pointer rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent/70 hover:text-foreground"
+      >
+        {actionLabel}
+      </span>
+    ) : (
+      <button
+        type="button"
+        onPointerEnter={() => {
+          actionPointerActiveRef.current = true
+          setSubmenuOpen(false)
+        }}
+        onPointerLeave={() => {
+          actionPointerActiveRef.current = false
+        }}
+        onPointerMove={(event) => event.stopPropagation()}
+        onPointerDown={(event) => {
+          event.stopPropagation()
+        }}
+        onClick={(event) => {
+          event.stopPropagation()
+          void handleAction()
+        }}
+        className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent/70 hover:text-foreground"
+      >
+        {actionLabel}
+      </button>
+    )
   ) : null
 
   if (!detail) {
@@ -242,12 +265,10 @@ export function RuntimeHostStatusRow({
         }
       }}
     >
-      <div className="flex items-center gap-2.5 px-2 py-1.5">
-        <DropdownMenuSubTrigger className="min-w-0 flex-1 px-0 py-0">
-          {rowDetails}
-        </DropdownMenuSubTrigger>
+      <DropdownMenuSubTrigger className="gap-2.5 px-2 py-1.5">
+        {rowDetails}
         {actionButton}
-      </div>
+      </DropdownMenuSubTrigger>
       <DropdownMenuSubContent className="w-[min(18rem,calc(100vw-1rem))] p-1.5">
         <div className="px-1.5 pt-0.5 pb-1.5">
           <div className="text-[11px] font-semibold">{runtimeFailureSummary(state)}</div>

--- a/src/renderer/src/components/status-bar/RuntimeHostStatusRow.tsx
+++ b/src/renderer/src/components/status-bar/RuntimeHostStatusRow.tsx
@@ -265,7 +265,7 @@ export function RuntimeHostStatusRow({
         }
       }}
     >
-      <DropdownMenuSubTrigger className="gap-2.5 px-2 py-1.5">
+      <DropdownMenuSubTrigger className="gap-2.5 px-2 py-1.5" hideChevron>
         {rowDetails}
         {actionButton}
       </DropdownMenuSubTrigger>

--- a/src/renderer/src/components/status-bar/RuntimeHostStatusRow.tsx
+++ b/src/renderer/src/components/status-bar/RuntimeHostStatusRow.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
-import { formatUiRelativeTime } from '@/i18n/relative-time-format'
+import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import {
   DropdownMenuItem,
@@ -153,7 +153,9 @@ export function RuntimeHostStatusRow({
     ? translate(
         'auto.components.status.bar.RuntimeHostStatusRow.last_connected',
         'Last connected {{value0}}',
-        { value0: formatUiRelativeTime(diagnostics.lastConnectedAt - Date.now()) }
+        {
+          value0: formatUiRelativeTimeFromDate(new Date(diagnostics.lastConnectedAt).toISOString())
+        }
       )
     : null
   const reconnectAttemptLabel =
@@ -168,7 +170,7 @@ export function RuntimeHostStatusRow({
   const rawDetail = diagnostics?.lastError ?? diagnostics?.lastClose?.reason ?? detail
   const failureExplanation = runtimeFailureExplanation(state)
 
-  const rowContent = (
+  const rowDetails = (
     <>
       <span
         aria-hidden="true"
@@ -192,37 +194,43 @@ export function RuntimeHostStatusRow({
           </span>
         </div>
       </div>
-      {busy ? (
-        <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
-      ) : actionLabel && action ? (
-        <button
-          type="button"
-          tabIndex={detail ? -1 : undefined}
-          onPointerEnter={() => {
-            actionPointerActiveRef.current = true
-            setSubmenuOpen(false)
-          }}
-          onPointerLeave={() => {
-            actionPointerActiveRef.current = false
-          }}
-          onPointerMove={(event) => event.stopPropagation()}
-          onPointerDown={(event) => {
-            event.stopPropagation()
-          }}
-          onClick={(event) => {
-            event.stopPropagation()
-            void handleAction()
-          }}
-          className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent/70 hover:text-foreground"
-        >
-          {actionLabel}
-        </button>
-      ) : null}
     </>
   )
 
+  const actionButton = busy ? (
+    <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
+  ) : actionLabel && action ? (
+    <button
+      type="button"
+      tabIndex={detail ? -1 : undefined}
+      onPointerEnter={() => {
+        actionPointerActiveRef.current = true
+        setSubmenuOpen(false)
+      }}
+      onPointerLeave={() => {
+        actionPointerActiveRef.current = false
+      }}
+      onPointerMove={(event) => event.stopPropagation()}
+      onPointerDown={(event) => {
+        event.stopPropagation()
+      }}
+      onClick={(event) => {
+        event.stopPropagation()
+        void handleAction()
+      }}
+      className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent/70 hover:text-foreground"
+    >
+      {actionLabel}
+    </button>
+  ) : null
+
   if (!detail) {
-    return <div className="flex items-center gap-2.5 px-2 py-1.5">{rowContent}</div>
+    return (
+      <div className="flex items-center gap-2.5 px-2 py-1.5">
+        {rowDetails}
+        {actionButton}
+      </div>
+    )
   }
 
   return (
@@ -234,7 +242,12 @@ export function RuntimeHostStatusRow({
         }
       }}
     >
-      <DropdownMenuSubTrigger className="gap-2.5 px-2 py-1.5">{rowContent}</DropdownMenuSubTrigger>
+      <div className="flex items-center gap-2.5 px-2 py-1.5">
+        <DropdownMenuSubTrigger className="min-w-0 flex-1 px-0 py-0">
+          {rowDetails}
+        </DropdownMenuSubTrigger>
+        {actionButton}
+      </div>
       <DropdownMenuSubContent className="w-[min(18rem,calc(100vw-1rem))] p-1.5">
         <div className="px-1.5 pt-0.5 pb-1.5">
           <div className="text-[11px] font-semibold">{runtimeFailureSummary(state)}</div>

--- a/src/renderer/src/components/status-bar/SshStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.tsx
@@ -260,6 +260,7 @@ export function SshStatusSegment({
             label={host.label}
             state={host.state}
             detail={runtimeHostConnectionDetail(host.remoteControl)}
+            diagnostics={host.remoteControl}
             onConnect={() => connectRuntimeHost(host.id)}
             onDisconnect={() => disconnectRuntimeHost(host.id)}
           />
@@ -279,6 +280,7 @@ export function SshStatusSegment({
             label={host.label}
             state={host.state}
             detail={runtimeHostConnectionDetail(host.remoteControl)}
+            diagnostics={host.remoteControl}
             onConnect={() => connectRuntimeHost(host.id)}
             onDisconnect={() => disconnectRuntimeHost(host.id)}
           />

--- a/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -178,9 +178,12 @@ function DropdownMenuSubTrigger({
   className,
   inset,
   children,
+  hideChevron,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
   inset?: boolean
+  // Why: collision-flipped submenus open leftward, where a right-pointing chevron misleads.
+  hideChevron?: boolean
 }) {
   return (
     <DropdownMenuPrimitive.SubTrigger
@@ -193,7 +196,7 @@ function DropdownMenuSubTrigger({
       {...props}
     >
       {children}
-      <ChevronRightIcon className="ml-auto size-4" />
+      {hideChevron ? null : <ChevronRightIcon className="ml-auto size-4" />}
     </DropdownMenuPrimitive.SubTrigger>
   )
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3901,6 +3901,16 @@
             "onDescription": "Keep this computer awake continuously",
             "autoDescription": "Stay awake while an agent is working",
             "offDescription": "Allow normal system sleep behavior"
+          },
+          "RuntimeHostStatusRow": {
+            "previous_connection_closed": "The previous connection closed",
+            "workspace_window_closed": "The workspace window is closed",
+            "checking_host": "Orca is checking whether this host is reachable",
+            "restoring_connection": "Orca is trying to restore the connection",
+            "host_unreachable": "Orca isn’t reachable on this host",
+            "contact_note": "The host may still be running; only the Orca connection is unavailable.",
+            "last_connected": "Last connected {{value0}}",
+            "reconnect_attempt": "Attempt {{value0}}"
           }
         }
       },


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​115 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​114 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​203 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​180 |

<!-- /orca-pr-loc -->

## Summary

- Move unbounded Remote Hosts failure detail into an adjacent submenu while leaving healthy rows unchanged.
- Show a plain-English summary, wrapped raw error or close reason, existing connection diagnostics, and the existing action in the submenu.
- Preserve the one-click pointer action in the row and rely on the menu primitive for focus return, dismissal, and viewport collision handling.

## Interaction

Pointer users can still select Connect, Reconnect, or Disconnect directly in one click. Keyboard users open a failed row with `→`, then activate the submenu action with Enter; `←` closes back to the failed row and Esc returns to the status trigger.

## Scope

Presentation only. This does not change connection state logic, reconnect behavior, or diagnostics semantics.

## Validation

- `pnpm test src/renderer/src/components/status-bar/RuntimeHostStatusRow.test.tsx` — 9 passed
- `pnpm tc` — passed
- changed-file `oxlint` — passed
- `git diff --check` — passed
- Electron/CDP — verified healthy and failed rows, one-click pointer action, keyboard focus flow, a wrapped 312-character error with no horizontal overflow, and narrow-viewport submenu collision handling