### PR TITLE
Fix lost session-tab changes during initial census

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -8519,6 +8519,7 @@
         "remote terminal reveal and input",
         "paired host relaunch with preserved daemon PTYs",
         "paired host session inventory publication authority",
+        "paired host session inventory subscription linearizability",
         "manual server disconnect"
       ],
       "platforms": ["macos", "linux", "windows"],
@@ -8537,7 +8538,7 @@
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-cold-park-pre-gate-loop.react185.test.tsx src/renderer/src/components/terminal-pane/use-parked-terminal-watcher-synchronization.react185.test.tsx src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts --maxWorkers=1",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/terminal-multiplex-initial-snapshot-buffering.test.ts src/main/runtime/rpc/terminal-multiplex-snapshot-serialization.test.ts src/main/runtime/rpc/terminal-multiplex-pty-wait-capacity.test.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.test.ts src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.test.ts src/renderer/src/components/terminal-pane/pty-connection-hidden-output-restore.test.ts src/renderer/src/components/terminal-pane/pty-connection-parked-ssh-snapshot.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-activation-inventory-fallback.test.ts src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.test.ts src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.test.ts src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.test.ts src/renderer/src/components/terminal-pane/terminal-parked-watcher-reconciliation.test.ts src/renderer/src/components/terminal-pane/terminal-parked-watcher-partial-reconciliation.test.ts src/renderer/src/components/terminal-pane/terminal-parking-e2e-overrides.test.ts src/renderer/src/runtime/remote-runtime-terminal-stall-recovery.test.ts src/renderer/src/runtime/runtime-client-events.test.ts src/renderer/src/web/web-preload-api-runtime-environment.test.ts src/main/ipc/runtime-environments-pairing.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/terminal-subscriber-driven-daemon-attach.test.ts",
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/session-tabs-inventory-publication.test.ts src/main/runtime/rpc/methods/session-tabs.test.ts src/renderer/src/runtime/host-session-mirror-empty-inventory-settle.test.ts src/main/daemon/terminal-host-agent-session.test.ts tests/e2e/session-tabs-empty-inventory-daemon-oracle.unit.test.ts --maxWorkers=1",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/session-tabs-inventory-publication.test.ts src/main/runtime/rpc/methods/session-tabs-inventory-census-race.test.ts src/main/runtime/rpc/methods/session-tabs.test.ts src/renderer/src/runtime/host-session-mirror-empty-inventory-settle.test.ts src/main/daemon/terminal-host-agent-session.test.ts tests/e2e/session-tabs-empty-inventory-daemon-oracle.unit.test.ts --maxWorkers=1",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-shared-control-connection.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/remote-runtime-terminal-parse-backpressure.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty-ipc-hidden-delivery-gate.test.ts",
@@ -8571,6 +8572,7 @@
         "src/main/runtime/rpc/terminal-subscribe-buffer.test.ts",
         "src/main/runtime/terminal-subscriber-driven-daemon-attach.test.ts",
         "src/main/runtime/session-tabs-inventory-publication.test.ts",
+        "src/main/runtime/rpc/methods/session-tabs-inventory-census-race.test.ts",
         "src/main/runtime/rpc/methods/session-tabs.test.ts",
         "src/renderer/src/runtime/host-session-mirror-empty-inventory-settle.test.ts",
         "src/main/daemon/terminal-host-agent-session.test.ts",
@@ -8657,6 +8659,18 @@
         {
           "file": "src/main/runtime/terminal-subscriber-driven-daemon-attach.test.ts",
           "assertions": ["retries an existing subscriber when provider inventory becomes ready"]
+        },
+        {
+          "file": "src/main/runtime/rpc/methods/session-tabs-inventory-census-race.test.ts",
+          "assertions": [
+            "pre-boundary creation and removal are subsumed by the census exactly once",
+            "post-boundary creation and removal replay after the initial snapshot in sequence order",
+            "create/remove/recreate transitions are preserved without collapse",
+            "projected PTY state already visible in the census is deduplicated while later projected state is delivered",
+            "coalesced delivery uses its scheduling watermark across every subscriber",
+            "initialization churn is memory-bounded and repeated structural overflow fails after bounded recollection",
+            "initialization clears buffered transitions on cancellation"
+          ]
         },
         {
           "file": "tests/e2e/session-tabs-empty-inventory-daemon-oracle.unit.test.ts",

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3171,6 +3171,8 @@ export class OrcaRuntimeService {
   private headlessGraphFallbackAvailable = false
   private pendingHeadlessPromotionWindowId: number | null = null
   private rendererGeneration: string | null = null
+  private mobileSessionTabsChangeSequence = 0
+  private pendingMobileSessionTabsChangeSequenceByWorktree = new Map<string, number>()
   private readonly graphReloadLifecycle = new RuntimeGraphReloadLifecycle({
     timeoutMs: RUNTIME_GRAPH_RELOAD_TIMEOUT_MS,
     onSettled: ({ revision, windowId, outcome, durationMs }) => {
@@ -3248,7 +3250,7 @@ export class OrcaRuntimeService {
     }
   >()
   private mobileSessionTabListeners = new Set<{
-    listener: (snapshot: RuntimeMobileSessionTabsResult) => void
+    listener: (snapshot: RuntimeMobileSessionTabsResult, changeSequence: number) => void
     clientNavigationId?: string
   }>()
   // Why: one watermark per repo replaces per-closed-pane fences while preserving stale-write safety.
@@ -3264,7 +3266,7 @@ export class OrcaRuntimeService {
   // second. Emit reads the latest snapshot, so only the freshest version ships.
   private readonly mobileSessionTabsNotifyCoalescer: MobileSessionTabsNotifyCoalescer =
     createMobileSessionTabsNotifyCoalescer((worktreeId) =>
-      this.notifyMobileSessionTabsChangedNow(worktreeId)
+      this.flushScheduledMobileSessionTabsChanged(worktreeId)
     )
   private readonly mobileSessionTabsAgentStatusHeartbeat: MobileSessionTabsAgentStatusHeartbeat =
     createMobileSessionTabsAgentStatusHeartbeat(
@@ -6766,7 +6768,7 @@ export class OrcaRuntimeService {
         ...next,
         snapshotVersion: snapshot.snapshotVersion + 1
       })
-      this.mobileSessionTabsNotifyCoalescer.schedule(worktreeId)
+      this.scheduleMobileSessionTabsChanged(worktreeId)
       return
     }
   }
@@ -6954,7 +6956,7 @@ export class OrcaRuntimeService {
       return
     }
     for (const worktreeId of worktreeIds) {
-      this.notifyMobileSessionTabsChangedNow(worktreeId)
+      this.notifyMobileSessionTabsChangedNow(worktreeId, ++this.mobileSessionTabsChangeSequence)
     }
   }
 
@@ -7361,7 +7363,7 @@ export class OrcaRuntimeService {
     }
     for (const worktreeId of changedMobileWorktrees) {
       if (this.mobileSessionTabsByWorktree.has(worktreeId)) {
-        this.mobileSessionTabsNotifyCoalescer.schedule(worktreeId)
+        this.scheduleMobileSessionTabsChanged(worktreeId)
       }
     }
     // Why: only the authoritative window grants inventory authority; headless qualifies because it becomes authoritative before its next sync.
@@ -7488,12 +7490,21 @@ export class OrcaRuntimeService {
   async listAllMobileSessionTabs(
     clientNavigationId?: string
   ): Promise<RuntimeMobileSessionTabsResult[]> {
-    return (await this.collectAllMobileSessionTabs(clientNavigationId)).snapshots
+    return (await this.listAllMobileSessionTabsWithChangeSequence(clientNavigationId)).snapshots
+  }
+
+  async listAllMobileSessionTabsWithChangeSequence(clientNavigationId?: string): Promise<{
+    snapshots: RuntimeMobileSessionTabsResult[]
+    changeSequence: number
+  }> {
+    const inventory = await this.collectAllMobileSessionTabs(clientNavigationId)
+    return { snapshots: inventory.snapshots, changeSequence: inventory.changeSequence }
   }
 
   private async collectAllMobileSessionTabs(clientNavigationId?: string): Promise<{
     snapshots: RuntimeMobileSessionTabsResult[]
     ptyInventory: PtyControllerInventory | null
+    changeSequence: number
   }> {
     for (const worktreeId of this.getKnownWorkspaceSessionWorktreeIds()) {
       this.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(worktreeId, {
@@ -7504,21 +7515,32 @@ export class OrcaRuntimeService {
     this.hydrateHeadlessMobileSessionTabsFromWorkspaceSession()
     const ptyInventory = await this.refreshMobileSessionPtyInventory()
     this.restoreLivePairedRendererSessionOwnedMobileTerminals(null)
-    return {
-      snapshots: [...this.mobileSessionTabsByWorktree.values()].map((snapshot) =>
-        this.projectMobileSessionTabsForClient(
-          this.toMobileSessionTabsResult(snapshot),
-          clientNavigationId
-        )
-      ),
-      ptyInventory
-    }
+    const snapshots = [...this.mobileSessionTabsByWorktree.values()].map((snapshot) =>
+      this.projectMobileSessionTabsForClient(
+        this.toMobileSessionTabsResult(snapshot),
+        clientNavigationId
+      )
+    )
+    return { snapshots, ptyInventory, changeSequence: this.mobileSessionTabsChangeSequence }
   }
 
   async listAllMobileSessionTabsInventory(
     clientNavigationId?: string,
     signal?: AbortSignal
   ): Promise<{ snapshots: RuntimeMobileSessionTabsResult[]; authoritative?: true }> {
+    const { snapshots, authoritative } =
+      await this.listAllMobileSessionTabsInventoryWithChangeSequence(clientNavigationId, signal)
+    return { snapshots, ...(authoritative ? { authoritative } : {}) }
+  }
+
+  async listAllMobileSessionTabsInventoryWithChangeSequence(
+    clientNavigationId?: string,
+    signal?: AbortSignal
+  ): Promise<{
+    snapshots: RuntimeMobileSessionTabsResult[]
+    authoritative?: true
+    changeSequence: number
+  }> {
     this.assertSessionTabsInventoryRequestActive(signal)
     const primedPublicationEpoch = this.getAuthoritativeSessionTabsInventoryEpoch()
     const primed = await this.collectAllMobileSessionTabs(clientNavigationId)
@@ -7552,17 +7574,26 @@ export class OrcaRuntimeService {
     inventory: {
       snapshots: RuntimeMobileSessionTabsResult[]
       ptyInventory: PtyControllerInventory | null
+      changeSequence: number
     },
     clientNavigationId?: string,
     signal?: AbortSignal
-  ): Promise<{ snapshots: RuntimeMobileSessionTabsResult[]; authoritative?: true }> {
+  ): Promise<{
+    snapshots: RuntimeMobileSessionTabsResult[]
+    authoritative?: true
+    changeSequence: number
+  }> {
     if (this.isCompleteSessionTabsPtyCensus(inventory.ptyInventory)) {
-      return { snapshots: inventory.snapshots, authoritative: true }
+      return {
+        snapshots: inventory.snapshots,
+        authoritative: true,
+        changeSequence: inventory.changeSequence
+      }
     }
     const retried = await this.collectAllMobileSessionTabs(clientNavigationId)
     this.assertSessionTabsInventoryRequestActive(signal)
     // Why: the retry ran outside the epoch fence, so it never claims authority.
-    return { snapshots: retried.snapshots }
+    return { snapshots: retried.snapshots, changeSequence: retried.changeSequence }
   }
 
   supportsAuthoritativeSessionTabsInventory(): boolean {
@@ -8599,7 +8630,7 @@ export class OrcaRuntimeService {
     }
     // Why: title/status flips several times a second under spinner-in-title
     // agents. Coalesce the emit instead of fanning out every version.
-    this.mobileSessionTabsNotifyCoalescer.schedule(worktreeId)
+    this.scheduleMobileSessionTabsChanged(worktreeId)
   }
 
   /** Republish the workspace snapshot after a pane's hook status changed.
@@ -9326,9 +9357,11 @@ export class OrcaRuntimeService {
       return
     }
     const result = this.toMobileSessionTabsResult(snapshot)
+    const changeSequence = ++this.mobileSessionTabsChangeSequence
     for (const subscription of this.mobileSessionTabListeners) {
       subscription.listener(
-        this.projectMobileSessionTabsForClient(result, subscription.clientNavigationId)
+        this.projectMobileSessionTabsForClient(result, subscription.clientNavigationId),
+        changeSequence
       )
     }
   }
@@ -11246,7 +11279,7 @@ export class OrcaRuntimeService {
   }
 
   onMobileSessionTabsChanged(
-    listener: (snapshot: RuntimeMobileSessionTabsResult) => void,
+    listener: (snapshot: RuntimeMobileSessionTabsResult, changeSequence: number) => void,
     clientNavigationId?: string
   ): () => void {
     // Why: a notify coalesced before this subscriber existed is already folded
@@ -30078,9 +30111,11 @@ export class OrcaRuntimeService {
     }
     this.mobileSessionTabsByWorktree.set(worktreeId, next)
     const result = this.toMobileSessionTabsResult(next)
+    const changeSequence = ++this.mobileSessionTabsChangeSequence
     for (const subscription of this.mobileSessionTabListeners) {
       subscription.listener(
-        this.projectMobileSessionTabsForClient(result, subscription.clientNavigationId)
+        this.projectMobileSessionTabsForClient(result, subscription.clientNavigationId),
+        changeSequence
       )
     }
     const created = result.tabs.find((candidate) => candidate.id === tab.id)
@@ -34289,7 +34324,7 @@ export class OrcaRuntimeService {
           this.mobileSessionTabsAgentStatusHeartbeat.removeWorktree(worktreeId)
           this.acceptedRendererMobileSnapshotByWorktree.delete(worktreeId)
           // Why: drop any pending coalesced notify so a stale snapshot can't land after the removed frame.
-          this.mobileSessionTabsNotifyCoalescer.cancel(worktreeId)
+          this.cancelScheduledMobileSessionTabsChanged(worktreeId)
           this.notifyMobileSessionTabsRemoved(worktreeId)
         }
       }
@@ -34531,9 +34566,11 @@ export class OrcaRuntimeService {
       activeTabType: null,
       tabs: []
     }
+    const changeSequence = ++this.mobileSessionTabsChangeSequence
     for (const subscription of this.mobileSessionTabListeners) {
       subscription.listener(
-        this.clientSessionTabSelections.project(removed, subscription.clientNavigationId)
+        this.clientSessionTabSelections.project(removed, subscription.clientNavigationId),
+        changeSequence
       )
     }
     this.clientSessionTabSelections.forgetWorktree(worktreeId)
@@ -34575,11 +34612,33 @@ export class OrcaRuntimeService {
       }
     }
     // Why: structural changes must propagate promptly; cancel any pending coalesced notify since this immediate emit supersedes it.
-    this.mobileSessionTabsNotifyCoalescer.cancel(worktreeId)
-    this.notifyMobileSessionTabsChangedNow(worktreeId)
+    this.cancelScheduledMobileSessionTabsChanged(worktreeId)
+    this.notifyMobileSessionTabsChangedNow(worktreeId, ++this.mobileSessionTabsChangeSequence)
   }
 
-  private notifyMobileSessionTabsChangedNow(worktreeId: string): void {
+  private scheduleMobileSessionTabsChanged(worktreeId: string): void {
+    this.pendingMobileSessionTabsChangeSequenceByWorktree.set(
+      worktreeId,
+      ++this.mobileSessionTabsChangeSequence
+    )
+    this.mobileSessionTabsNotifyCoalescer.schedule(worktreeId)
+  }
+
+  private cancelScheduledMobileSessionTabsChanged(worktreeId: string): void {
+    this.mobileSessionTabsNotifyCoalescer.cancel(worktreeId)
+    this.pendingMobileSessionTabsChangeSequenceByWorktree.delete(worktreeId)
+  }
+
+  private flushScheduledMobileSessionTabsChanged(worktreeId: string): void {
+    const changeSequence = this.pendingMobileSessionTabsChangeSequenceByWorktree.get(worktreeId)
+    if (changeSequence === undefined) {
+      return
+    }
+    this.pendingMobileSessionTabsChangeSequenceByWorktree.delete(worktreeId)
+    this.notifyMobileSessionTabsChangedNow(worktreeId, changeSequence)
+  }
+
+  private notifyMobileSessionTabsChangedNow(worktreeId: string, changeSequence: number): void {
     if (this.mobileSessionTabListeners.size === 0) {
       return
     }
@@ -34591,7 +34650,8 @@ export class OrcaRuntimeService {
     const result = this.toMobileSessionTabsResult(snapshot)
     for (const subscription of this.mobileSessionTabListeners) {
       subscription.listener(
-        this.projectMobileSessionTabsForClient(result, subscription.clientNavigationId)
+        this.projectMobileSessionTabsForClient(result, subscription.clientNavigationId),
+        changeSequence
       )
     }
   }
@@ -34602,9 +34662,11 @@ export class OrcaRuntimeService {
     }
     for (const snapshot of this.mobileSessionTabsByWorktree.values()) {
       const result = this.toMobileSessionTabsResult(snapshot)
+      const changeSequence = ++this.mobileSessionTabsChangeSequence
       for (const subscription of this.mobileSessionTabListeners) {
         subscription.listener(
-          this.projectMobileSessionTabsForClient(result, subscription.clientNavigationId)
+          this.projectMobileSessionTabsForClient(result, subscription.clientNavigationId),
+          changeSequence
         )
       }
     }
@@ -34640,9 +34702,13 @@ export class OrcaRuntimeService {
     clientNavigationId: string,
     follow = false
   ): void {
+    const changeSequence = ++this.mobileSessionTabsChangeSequence
     for (const subscription of this.mobileSessionTabListeners) {
       if (subscription.clientNavigationId === clientNavigationId) {
-        subscription.listener(follow ? { ...projected, navigationIntent: 'follow' } : projected)
+        subscription.listener(
+          follow ? { ...projected, navigationIntent: 'follow' } : projected,
+          changeSequence
+        )
       }
     }
   }

--- a/src/main/runtime/rpc/methods/session-tabs-inventory-census-race.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-inventory-census-race.test.ts
@@ -1,0 +1,897 @@
+import { describe, expect, it, vi } from 'vitest'
+import { SESSION_TABS_AUTHORITATIVE_INVENTORY_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+import type { RuntimeMobileSessionTabsSnapshot } from '../../../../shared/runtime-session-contracts'
+import type { RuntimeMobileSessionTabsResult } from '../../../../shared/runtime-types'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import { subscribeSessionTabsInventory } from './session-tabs-inventory'
+
+const runningBaselineOracle = process.env.ORCA_TEST_BASELINE_SESSION_TABS_CENSUS_ORACLE === '1'
+
+type Inventory = {
+  snapshots: RuntimeMobileSessionTabsResult[]
+  authoritative: true
+  changeSequence: number
+}
+
+function deferredInventory(): {
+  promise: Promise<Inventory>
+  resolve: (inventory: Inventory) => void
+} {
+  let resolve!: (inventory: Inventory) => void
+  return {
+    promise: new Promise<Inventory>((settle) => {
+      resolve = settle
+    }),
+    resolve
+  }
+}
+
+function snapshot(
+  snapshotVersion: number,
+  tabs: RuntimeMobileSessionTabsResult['tabs'],
+  options: { publicationEpoch?: string; removed?: true } = {}
+): RuntimeMobileSessionTabsResult {
+  return {
+    worktree: 'wt-census-race',
+    publicationEpoch: options.publicationEpoch ?? 'epoch-current',
+    snapshotVersion,
+    ...(options.removed ? { removed: true as const } : {}),
+    activeGroupId: null,
+    activeTabId: null,
+    activeTabType: null,
+    tabs
+  }
+}
+
+function terminalTab(id: string): RuntimeMobileSessionTabsResult['tabs'][number] {
+  return {
+    id,
+    type: 'terminal',
+    title: id,
+    parentTabId: `parent-${id}`,
+    leafId: `leaf-${id}`,
+    ptyId: `pty-${id}`,
+    status: 'ready',
+    terminal: `term-${id}`,
+    isActive: false
+  }
+}
+
+type RuntimeInventoryInternals = {
+  refreshMobileSessionPtyInventory: () => Promise<PtyInventory>
+  mobileSessionTabsNotifyCoalescer: { flushAll: () => void }
+  mobileSessionTabListeners: Set<unknown>
+  mobileSessionTabsByWorktree: Map<string, RuntimeMobileSessionTabsSnapshot>
+  emitMobileSessionTabsSnapshot: (snapshot: RuntimeMobileSessionTabsSnapshot) => void
+  emitMobileSessionTabsSnapshotToClient: (
+    snapshot: RuntimeMobileSessionTabsResult,
+    clientNavigationId: string,
+    follow?: boolean
+  ) => void
+}
+
+type PtyInventory = {
+  livePtyIds: Set<string>
+  allLivePtyIds: Set<string>
+  terminalIdentityByPtyId: Map<string, never>
+  queriedHostIds: Set<string>
+}
+
+function completePtyInventory(): PtyInventory {
+  return {
+    livePtyIds: new Set(),
+    allLivePtyIds: new Set(),
+    terminalIdentityByPtyId: new Map<string, never>(),
+    queriedHostIds: new Set(['local'])
+  }
+}
+
+function runtimeSnapshot(
+  worktree: string,
+  snapshotVersion: number
+): RuntimeMobileSessionTabsSnapshot {
+  return {
+    worktree,
+    publicationEpoch: 'epoch-current',
+    snapshotVersion,
+    activeGroupId: null,
+    activeTabId: null,
+    activeTabType: null,
+    tabs: []
+  }
+}
+
+function deferredPtyInventory(): {
+  promise: Promise<PtyInventory>
+  resolve: (inventory: PtyInventory) => void
+} {
+  let resolve!: (inventory: PtyInventory) => void
+  return {
+    promise: new Promise<PtyInventory>((settle) => {
+      resolve = settle
+    }),
+    resolve
+  }
+}
+
+function createRuntimeHarness(initialSnapshots: RuntimeMobileSessionTabsSnapshot[] = []) {
+  const runtime = new OrcaRuntimeService()
+  runtime.syncWindowGraph(0, { tabs: [], leaves: [], mobileSessionTabs: initialSnapshots })
+  const census = deferredPtyInventory()
+  const internals = runtime as unknown as RuntimeInventoryInternals
+  vi.spyOn(internals, 'refreshMobileSessionPtyInventory').mockReturnValue(census.promise)
+  const emit = vi.fn<(event: unknown) => void>()
+  const pending = subscribeSessionTabsInventory(
+    {
+      runtime,
+      connectionId: 'conn-runtime-census-race',
+      requestId: 'req-runtime-census-race',
+      pairedDeviceId: 'paired-runtime-census-race',
+      clientCapabilities: [SESSION_TABS_AUTHORITATIVE_INVENTORY_RUNTIME_CAPABILITY]
+    },
+    emit
+  )
+  return {
+    census,
+    emit,
+    internals,
+    pending,
+    publish: (snapshots: RuntimeMobileSessionTabsSnapshot[], flush = true): void => {
+      runtime.syncWindowGraph(0, { tabs: [], leaves: [], mobileSessionTabs: snapshots })
+      if (flush) {
+        internals.mobileSessionTabsNotifyCoalescer.flushAll()
+      }
+    },
+    runtime
+  }
+}
+
+function createHarness() {
+  const census = deferredInventory()
+  const emit = vi.fn<(event: unknown) => void>()
+  const unsubscribe = vi.fn<() => void>()
+  const cleanup = vi.fn<() => void>()
+  let changeSequence = 0
+  let listener:
+    | ((value: RuntimeMobileSessionTabsResult, changeSequence: number) => void)
+    | undefined
+  const runtime = {
+    supportsAuthoritativeSessionTabsInventory: vi.fn(() => true),
+    listAllMobileSessionTabsInventory: vi.fn(() => census.promise),
+    listAllMobileSessionTabsInventoryWithChangeSequence: vi.fn(async () => {
+      return await census.promise
+    }),
+    onMobileSessionTabsChanged: vi.fn(
+      (nextListener: (value: RuntimeMobileSessionTabsResult, changeSequence: number) => void) => {
+        listener = nextListener
+        return unsubscribe
+      }
+    ),
+    registerSubscriptionCleanup: vi.fn((_id: string, nextCleanup: () => void) =>
+      cleanup.mockImplementation(nextCleanup)
+    ),
+    cleanupSubscription: vi.fn()
+  } as unknown as OrcaRuntimeService
+
+  return {
+    census,
+    cleanup,
+    context: {
+      runtime,
+      connectionId: 'conn-census-race',
+      requestId: 'req-census-race',
+      clientCapabilities: [SESSION_TABS_AUTHORITATIVE_INVENTORY_RUNTIME_CAPABILITY]
+    },
+    emit,
+    deliver: (value: RuntimeMobileSessionTabsResult, sequence: number) =>
+      listener?.(value, sequence),
+    publish: (value: RuntimeMobileSessionTabsResult) => listener?.(value, ++changeSequence),
+    unsubscribe
+  }
+}
+
+describe.skipIf(runningBaselineOracle)('real runtime session tabs census boundary', () => {
+  it('subsumes a delivered change already captured by the census', async () => {
+    const harness = createRuntimeHarness()
+    const created = runtimeSnapshot('wt-census-race', 1)
+
+    harness.publish([created])
+    harness.census.resolve(completePtyInventory())
+    await harness.pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      expect.objectContaining({
+        type: 'snapshots',
+        authoritative: true,
+        snapshots: [expect.objectContaining({ worktree: created.worktree, snapshotVersion: 1 })]
+      })
+    ])
+  })
+
+  it('subsumes a removal that precedes the final census snapshot', async () => {
+    const existing = runtimeSnapshot('wt-census-race', 1)
+    const harness = createRuntimeHarness([existing])
+
+    harness.publish([])
+    harness.census.resolve(completePtyInventory())
+    await harness.pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [], authoritative: true }
+    ])
+  })
+
+  it('subsumes creation and removal at the census release edge', async () => {
+    const created = runtimeSnapshot('wt-created', 1)
+    const creation = createRuntimeHarness()
+    creation.census.resolve(completePtyInventory())
+    creation.publish([created])
+
+    const existing = runtimeSnapshot('wt-removed', 1)
+    const removal = createRuntimeHarness([existing])
+    removal.census.resolve(completePtyInventory())
+    removal.publish([])
+
+    await Promise.all([creation.pending, removal.pending])
+
+    expect(creation.emit).toHaveBeenCalledOnce()
+    expect(creation.emit.mock.calls[0]?.[0]).toMatchObject({
+      type: 'snapshots',
+      snapshots: [expect.objectContaining({ worktree: created.worktree })]
+    })
+    expect(removal.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [], authoritative: true }
+    ])
+  })
+
+  it('does not replay a delayed pre-boundary change after initialization', async () => {
+    const harness = createRuntimeHarness()
+    const created = runtimeSnapshot('wt-census-race', 1)
+
+    harness.publish([created], false)
+    harness.census.resolve(completePtyInventory())
+    await harness.pending
+    harness.internals.mobileSessionTabsNotifyCoalescer.flushAll()
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      expect.objectContaining({
+        type: 'snapshots',
+        authoritative: true,
+        snapshots: [expect.objectContaining({ worktree: created.worktree, snapshotVersion: 1 })]
+      })
+    ])
+  })
+
+  it('delivers a creation after the effective snapshot boundary', async () => {
+    const harness = createRuntimeHarness()
+    const created = runtimeSnapshot('wt-census-race', 1)
+
+    harness.census.resolve(completePtyInventory())
+    queueMicrotask(() => harness.publish([created]))
+    await harness.pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [], authoritative: true },
+      expect.objectContaining({
+        type: 'updated',
+        worktree: created.worktree,
+        snapshotVersion: created.snapshotVersion
+      })
+    ])
+  })
+
+  it('delivers a removal after the effective snapshot boundary', async () => {
+    const existing = runtimeSnapshot('wt-census-race', 1)
+    const harness = createRuntimeHarness([existing])
+
+    harness.census.resolve(completePtyInventory())
+    queueMicrotask(() => harness.publish([]))
+    await harness.pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      expect.objectContaining({
+        type: 'snapshots',
+        authoritative: true,
+        snapshots: [expect.objectContaining({ worktree: existing.worktree, snapshotVersion: 1 })]
+      }),
+      expect.objectContaining({
+        type: 'updated',
+        worktree: existing.worktree,
+        removed: true,
+        tabs: []
+      })
+    ])
+  })
+
+  it('coalesces ordinary same-structure churn and replays worktrees in sequence order', async () => {
+    const harness = createRuntimeHarness()
+    const worktreeB1 = runtimeSnapshot('wt-b', 1)
+    const worktreeA = runtimeSnapshot('wt-a', 1)
+    const worktreeB2 = runtimeSnapshot('wt-b', 2)
+
+    harness.census.resolve(completePtyInventory())
+    queueMicrotask(() => {
+      harness.publish([worktreeB1])
+      harness.publish([worktreeB1, worktreeA])
+      harness.publish([worktreeB2, worktreeA])
+    })
+    await harness.pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [], authoritative: true },
+      expect.objectContaining({ type: 'updated', worktree: 'wt-a', snapshotVersion: 1 }),
+      expect.objectContaining({ type: 'updated', worktree: 'wt-b', snapshotVersion: 2 })
+    ])
+  })
+
+  it('replays create, remove, and recreate transitions without collapsing them', async () => {
+    const harness = createRuntimeHarness()
+    const created = runtimeSnapshot('wt-census-race', 1)
+    const recreated = runtimeSnapshot('wt-census-race', 2)
+
+    harness.census.resolve(completePtyInventory())
+    queueMicrotask(() => {
+      harness.publish([created])
+      harness.publish([])
+      harness.publish([recreated])
+    })
+    await harness.pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [], authoritative: true },
+      expect.objectContaining({ type: 'updated', worktree: created.worktree, snapshotVersion: 1 }),
+      expect.objectContaining({ type: 'updated', worktree: created.worktree, removed: true }),
+      expect.objectContaining({ type: 'updated', worktree: recreated.worktree, snapshotVersion: 2 })
+    ])
+  })
+
+  it('cancels a stale coalesced callback before removal and later recreation', async () => {
+    const initial = runtimeSnapshot('wt-census-race', 1)
+    const harness = createRuntimeHarness([initial])
+    const pending = runtimeSnapshot('wt-census-race', 2)
+    const recreated = runtimeSnapshot('wt-census-race', 3)
+
+    harness.census.resolve(completePtyInventory())
+    await harness.pending
+    harness.publish([pending], false)
+    harness.publish([])
+    harness.internals.mobileSessionTabsNotifyCoalescer.flushAll()
+    harness.publish([recreated])
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      expect.objectContaining({
+        type: 'snapshots',
+        snapshots: [expect.objectContaining({ snapshotVersion: initial.snapshotVersion })]
+      }),
+      expect.objectContaining({ type: 'updated', worktree: initial.worktree, removed: true }),
+      expect.objectContaining({
+        type: 'updated',
+        worktree: recreated.worktree,
+        snapshotVersion: recreated.snapshotVersion
+      })
+    ])
+  })
+
+  it('keeps a newer immediate change when an older coalesced callback arrives last', async () => {
+    const harness = createRuntimeHarness()
+    const scheduled = runtimeSnapshot('wt-census-race', 1)
+    const immediate = runtimeSnapshot('wt-census-race', 2)
+
+    harness.publish([scheduled], false)
+    harness.census.resolve(completePtyInventory())
+    queueMicrotask(() => {
+      harness.internals.mobileSessionTabsByWorktree.set(immediate.worktree, immediate)
+      harness.internals.emitMobileSessionTabsSnapshot(immediate)
+      harness.internals.mobileSessionTabsNotifyCoalescer.flushAll()
+    })
+    await harness.pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      expect.objectContaining({
+        type: 'snapshots',
+        snapshots: [expect.objectContaining({ snapshotVersion: scheduled.snapshotVersion })]
+      }),
+      expect.objectContaining({
+        type: 'updated',
+        worktree: immediate.worktree,
+        snapshotVersion: immediate.snapshotVersion
+      })
+    ])
+  })
+
+  it('preserves caller-only follow intent when a later shared snapshot is buffered', async () => {
+    const runtime = new OrcaRuntimeService()
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [], mobileSessionTabs: [] })
+    const census = deferredInventory()
+    vi.spyOn(runtime, 'listAllMobileSessionTabsInventoryWithChangeSequence').mockImplementation(
+      () => census.promise
+    )
+    const callerEmit = vi.fn<(event: unknown) => void>()
+    const bystanderEmit = vi.fn<(event: unknown) => void>()
+    const callerPending = subscribeSessionTabsInventory(
+      {
+        runtime,
+        connectionId: 'conn-caller',
+        requestId: 'req-caller',
+        pairedDeviceId: 'device-caller'
+      },
+      callerEmit
+    )
+    const bystanderPending = subscribeSessionTabsInventory(
+      {
+        runtime,
+        connectionId: 'conn-bystander',
+        requestId: 'req-bystander',
+        pairedDeviceId: 'device-bystander'
+      },
+      bystanderEmit
+    )
+    const followed = snapshot(1, [terminalTab('followed')])
+    const latest = snapshot(2, [terminalTab('latest')])
+    const internals = runtime as unknown as RuntimeInventoryInternals
+
+    census.resolve({ snapshots: [], authoritative: true, changeSequence: 0 })
+    queueMicrotask(() => {
+      internals.emitMobileSessionTabsSnapshotToClient(followed, 'device-caller', true)
+      const latestRuntimeSnapshot = latest as RuntimeMobileSessionTabsSnapshot
+      internals.mobileSessionTabsByWorktree.set(latest.worktree, latestRuntimeSnapshot)
+      internals.emitMobileSessionTabsSnapshot(latestRuntimeSnapshot)
+    })
+    await Promise.all([callerPending, bystanderPending])
+
+    expect(callerEmit).toHaveBeenCalledTimes(3)
+    expect(callerEmit.mock.calls[1]?.[0]).toMatchObject({
+      type: 'updated',
+      worktree: followed.worktree,
+      snapshotVersion: followed.snapshotVersion,
+      navigationIntent: 'follow',
+      tabs: [expect.objectContaining({ id: 'followed' })]
+    })
+    expect(callerEmit.mock.calls[2]?.[0]).toMatchObject({
+      type: 'updated',
+      worktree: latest.worktree,
+      snapshotVersion: latest.snapshotVersion,
+      tabs: [expect.objectContaining({ id: 'latest' })]
+    })
+    expect(callerEmit.mock.calls[2]?.[0]).not.toHaveProperty('navigationIntent')
+    expect(bystanderEmit).toHaveBeenCalledTimes(2)
+    expect(bystanderEmit.mock.calls[1]?.[0]).toMatchObject({
+      type: 'updated',
+      worktree: latest.worktree,
+      snapshotVersion: latest.snapshotVersion,
+      tabs: [expect.objectContaining({ id: 'latest' })]
+    })
+    expect(bystanderEmit.mock.calls[1]?.[0]).not.toHaveProperty('navigationIntent')
+  })
+
+  it('subsumes pre-boundary follow intent into the census selection', async () => {
+    const runtime = new OrcaRuntimeService()
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [], mobileSessionTabs: [] })
+    const census = deferredInventory()
+    vi.spyOn(runtime, 'listAllMobileSessionTabsInventoryWithChangeSequence').mockImplementation(
+      () => census.promise
+    )
+    const emit = vi.fn<(event: unknown) => void>()
+    const pending = subscribeSessionTabsInventory(
+      {
+        runtime,
+        connectionId: 'conn-follow-before',
+        requestId: 'req-follow-before',
+        pairedDeviceId: 'device-follow-before'
+      },
+      emit
+    )
+    const selected = snapshot(1, [terminalTab('selected')])
+    const internals = runtime as unknown as RuntimeInventoryInternals
+
+    internals.emitMobileSessionTabsSnapshotToClient(selected, 'device-follow-before', true)
+    census.resolve({ snapshots: [selected], authoritative: true, changeSequence: 1 })
+    await pending
+
+    expect(emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [selected] }
+    ])
+  })
+
+  it('uses one change sequence across subscribers without duplicate fanout', async () => {
+    const runtime = new OrcaRuntimeService()
+    const created = runtimeSnapshot('wt-census-race', 1)
+    const first: number[] = []
+    const second: number[] = []
+    const unsubscribeFirst = runtime.onMobileSessionTabsChanged((_snapshot, sequence) =>
+      first.push(sequence)
+    )
+    const unsubscribeSecond = runtime.onMobileSessionTabsChanged((_snapshot, sequence) =>
+      second.push(sequence)
+    )
+
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [], mobileSessionTabs: [created] })
+    ;(runtime as unknown as RuntimeInventoryInternals).mobileSessionTabsNotifyCoalescer.flushAll()
+
+    expect(first).toEqual([expect.any(Number)])
+    expect(second).toEqual(first)
+    unsubscribeFirst()
+    unsubscribeSecond()
+  })
+
+  it('aborts the census and removes the real runtime listener on disconnect', async () => {
+    const runtime = new OrcaRuntimeService()
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [], mobileSessionTabs: [] })
+    const census = deferredPtyInventory()
+    const internals = runtime as unknown as RuntimeInventoryInternals
+    vi.spyOn(internals, 'refreshMobileSessionPtyInventory').mockReturnValue(census.promise)
+    const controller = new AbortController()
+    const pending = subscribeSessionTabsInventory(
+      {
+        runtime,
+        connectionId: 'conn-abort',
+        requestId: 'req-abort',
+        signal: controller.signal
+      },
+      vi.fn()
+    )
+
+    controller.abort()
+    census.resolve(completePtyInventory())
+
+    await expect(pending).rejects.toThrow('client_disconnected')
+    expect(internals.mobileSessionTabListeners).toHaveLength(0)
+  })
+})
+
+describe('session tabs inventory census boundary', () => {
+  it('subsumes a change that precedes the final census snapshot', async () => {
+    const harness = createHarness()
+    const prior = snapshot(1, [terminalTab('prior')], { publicationEpoch: 'epoch-prior' })
+    const current = snapshot(1, [terminalTab('current')])
+    const pending = subscribeSessionTabsInventory(harness.context, harness.emit)
+
+    await Promise.resolve()
+    harness.publish(prior)
+    harness.census.resolve({ snapshots: [current], authoritative: true, changeSequence: 1 })
+    await pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [current], authoritative: true }
+    ])
+  })
+
+  it('subsumes a creation captured at the census boundary exactly once', async () => {
+    const harness = createHarness()
+    const created = snapshot(2, [terminalTab('created')])
+    const pending = subscribeSessionTabsInventory(harness.context, harness.emit)
+
+    await Promise.resolve()
+    harness.publish(created)
+    harness.census.resolve({ snapshots: [created], authoritative: true, changeSequence: 1 })
+    await pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [created], authoritative: true }
+    ])
+  })
+
+  it('delivers a creation after the census boundary as the next ordered update', async () => {
+    const harness = createHarness()
+    const created = snapshot(2, [terminalTab('created')])
+    const pending = subscribeSessionTabsInventory(harness.context, harness.emit)
+
+    await Promise.resolve()
+    harness.census.resolve({ snapshots: [], authoritative: true, changeSequence: 0 })
+    queueMicrotask(() => harness.publish(created))
+    await pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [], authoritative: true },
+      { type: 'updated', ...created }
+    ])
+  })
+
+  it('delivers a removal after the census boundary as the next ordered update', async () => {
+    const harness = createHarness()
+    const existing = snapshot(1, [terminalTab('existing')])
+    const removed = snapshot(0, [], { publicationEpoch: 'removed:epoch', removed: true })
+    const pending = subscribeSessionTabsInventory(harness.context, harness.emit)
+
+    await Promise.resolve()
+    harness.census.resolve({ snapshots: [existing], authoritative: true, changeSequence: 0 })
+    queueMicrotask(() => harness.publish(removed))
+    await pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [existing], authoritative: true },
+      { type: 'updated', ...removed }
+    ])
+  })
+
+  it('delivers ordinary changes after initialization without duplication', async () => {
+    const harness = createHarness()
+    const created = snapshot(2, [terminalTab('created')])
+    const pending = subscribeSessionTabsInventory(harness.context, harness.emit)
+
+    await Promise.resolve()
+    harness.census.resolve({ snapshots: [], authoritative: true, changeSequence: 0 })
+    await pending
+    harness.publish(created)
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [], authoritative: true },
+      { type: 'updated', ...created }
+    ])
+  })
+
+  it('drops a delayed callback already covered by the census watermark', async () => {
+    const harness = createHarness()
+    const included = snapshot(2, [terminalTab('included')])
+    const pending = subscribeSessionTabsInventory(harness.context, harness.emit)
+
+    await Promise.resolve()
+    harness.census.resolve({ snapshots: [included], authoritative: true, changeSequence: 1 })
+    await pending
+    harness.deliver(included, 1)
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [included], authoritative: true }
+    ])
+  })
+
+  it('deduplicates a post-watermark notification already projected by the census', async () => {
+    const harness = createHarness()
+    const included = snapshot(2, [terminalTab('included')])
+    const pending = subscribeSessionTabsInventory(harness.context, harness.emit)
+
+    await Promise.resolve()
+    harness.census.resolve({ snapshots: [included], authoritative: true, changeSequence: 0 })
+    await pending
+    harness.deliver(included, 1)
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [included], authoritative: true }
+    ])
+  })
+
+  it('delivers a post-boundary projected-state change without a new snapshot revision', async () => {
+    const harness = createHarness()
+    const pendingTab = {
+      ...terminalTab('derived'),
+      status: 'pending-handle' as const,
+      terminal: null
+    }
+    const initial = snapshot(2, [pendingTab])
+    const ready = snapshot(2, [terminalTab('derived')])
+    const pending = subscribeSessionTabsInventory(harness.context, harness.emit)
+
+    await Promise.resolve()
+    harness.census.resolve({ snapshots: [initial], authoritative: true, changeSequence: 0 })
+    await pending
+    harness.deliver(ready, 1)
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [initial], authoritative: true },
+      { type: 'updated', ...ready }
+    ])
+  })
+
+  it('replays buffered follow intent before the later ordinary snapshot', async () => {
+    const harness = createHarness()
+    const followed = {
+      ...snapshot(1, [terminalTab('followed')]),
+      navigationIntent: 'follow' as const
+    }
+    const latest = snapshot(2, [terminalTab('latest')])
+    const pending = subscribeSessionTabsInventory(harness.context, harness.emit)
+
+    await Promise.resolve()
+    harness.census.resolve({ snapshots: [], authoritative: true, changeSequence: 0 })
+    queueMicrotask(() => {
+      harness.publish(followed)
+      harness.publish(latest)
+    })
+    await pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [], authoritative: true },
+      { type: 'updated', ...followed },
+      { type: 'updated', ...latest }
+    ])
+  })
+
+  it('bounds non-structural initialization churn to the latest projected state', async () => {
+    const harness = createHarness()
+    const pending = subscribeSessionTabsInventory(harness.context, harness.emit)
+
+    await Promise.resolve()
+    harness.census.resolve({ snapshots: [], authoritative: true, changeSequence: 0 })
+    queueMicrotask(() => {
+      for (let version = 1; version <= 1_000; version += 1) {
+        harness.publish(snapshot(version, [terminalTab('stable')]))
+      }
+    })
+    await pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [], authoritative: true },
+      { type: 'updated', ...snapshot(1_000, [terminalTab('stable')]) }
+    ])
+  })
+
+  it('bounds alternating selection churn to the latest projected state', async () => {
+    const harness = createHarness()
+    const pending = subscribeSessionTabsInventory(harness.context, harness.emit)
+
+    await Promise.resolve()
+    harness.census.resolve({ snapshots: [], authoritative: true, changeSequence: 0 })
+    queueMicrotask(() => {
+      for (let version = 1; version <= 1_000; version += 1) {
+        const selected = version % 2 === 0
+        harness.publish({
+          ...snapshot(version, [{ ...terminalTab('stable'), isActive: selected }]),
+          activeTabId: selected ? 'stable' : null,
+          activeTabType: selected ? 'terminal' : null
+        })
+      }
+    })
+    await pending
+
+    expect(harness.emit).toHaveBeenCalledTimes(2)
+    expect(harness.emit.mock.calls[1]?.[0]).toMatchObject({
+      type: 'updated',
+      snapshotVersion: 1_000,
+      activeTabId: 'stable'
+    })
+  })
+
+  it('bounds repeated follow intent to the latest caller request', async () => {
+    const harness = createHarness()
+    const pending = subscribeSessionTabsInventory(harness.context, harness.emit)
+
+    await Promise.resolve()
+    harness.census.resolve({ snapshots: [], authoritative: true, changeSequence: 0 })
+    queueMicrotask(() => {
+      for (let version = 1; version <= 1_000; version += 1) {
+        harness.publish({
+          ...snapshot(version, [terminalTab(`followed-${version}`)]),
+          navigationIntent: 'follow'
+        })
+      }
+    })
+    await pending
+
+    expect(harness.emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [], authoritative: true },
+      {
+        type: 'updated',
+        ...snapshot(1_000, [terminalTab('followed-1000')]),
+        navigationIntent: 'follow'
+      }
+    ])
+  })
+
+  it('restarts the census when structural churn fills the bounded buffer', async () => {
+    const firstCensus = deferredInventory()
+    const secondCensus = deferredInventory()
+    const emit = vi.fn<(event: unknown) => void>()
+    let listener:
+      | ((value: RuntimeMobileSessionTabsResult, changeSequence: number) => void)
+      | undefined
+    const collect = vi
+      .fn()
+      .mockImplementationOnce(() => firstCensus.promise)
+      .mockImplementationOnce(() => secondCensus.promise)
+    const runtime = {
+      supportsAuthoritativeSessionTabsInventory: vi.fn(() => true),
+      listAllMobileSessionTabsInventoryWithChangeSequence: collect,
+      onMobileSessionTabsChanged: vi.fn(
+        (nextListener: (value: RuntimeMobileSessionTabsResult, sequence: number) => void) => {
+          listener = nextListener
+          return vi.fn()
+        }
+      ),
+      registerSubscriptionCleanup: vi.fn(),
+      cleanupSubscription: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const pending = subscribeSessionTabsInventory(
+      {
+        runtime,
+        connectionId: 'conn-structural-churn',
+        requestId: 'req-structural-churn'
+      },
+      emit
+    )
+
+    await Promise.resolve()
+    for (let sequence = 1; sequence <= 300; sequence += 1) {
+      listener?.(snapshot(sequence, sequence % 2 === 0 ? [terminalTab('stable')] : []), sequence)
+    }
+    firstCensus.resolve({ snapshots: [], authoritative: true, changeSequence: 0 })
+    await vi.waitFor(() => expect(collect).toHaveBeenCalledTimes(2))
+    const settled = snapshot(300, [terminalTab('stable')])
+    secondCensus.resolve({ snapshots: [settled], authoritative: true, changeSequence: 300 })
+    await pending
+
+    expect(emit.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'snapshots', snapshots: [settled] }
+    ])
+  })
+
+  it('fails before publication after repeated structural buffer overflow', async () => {
+    const censuses = [deferredInventory(), deferredInventory(), deferredInventory()]
+    const emit = vi.fn<(event: unknown) => void>()
+    const unsubscribe = vi.fn()
+    let cleanup = vi.fn()
+    let listener:
+      | ((value: RuntimeMobileSessionTabsResult, changeSequence: number) => void)
+      | undefined
+    const collect = vi.fn((..._args: unknown[]) => {
+      const census = censuses[collect.mock.calls.length - 1]
+      if (!census) {
+        throw new Error('unexpected extra census')
+      }
+      return census.promise
+    })
+    const runtime = {
+      supportsAuthoritativeSessionTabsInventory: vi.fn(() => true),
+      listAllMobileSessionTabsInventoryWithChangeSequence: collect,
+      onMobileSessionTabsChanged: vi.fn(
+        (nextListener: (value: RuntimeMobileSessionTabsResult, sequence: number) => void) => {
+          listener = nextListener
+          return unsubscribe
+        }
+      ),
+      registerSubscriptionCleanup: vi.fn((_id: string, nextCleanup: () => void) => {
+        cleanup = vi.fn(nextCleanup)
+      }),
+      cleanupSubscription: vi.fn(() => cleanup())
+    } as unknown as OrcaRuntimeService
+    const pending = subscribeSessionTabsInventory(
+      {
+        runtime,
+        connectionId: 'conn-sustained-structural-churn',
+        requestId: 'req-sustained-structural-churn'
+      },
+      emit
+    )
+    let changeSequence = 0
+    const overflowBuffer = (): void => {
+      for (let index = 0; index <= 256; index += 1) {
+        changeSequence += 1
+        listener?.(
+          snapshot(changeSequence, index % 2 === 0 ? [terminalTab('alternating')] : []),
+          changeSequence
+        )
+      }
+    }
+
+    await Promise.resolve()
+    for (let censusIndex = 0; censusIndex < censuses.length; censusIndex += 1) {
+      overflowBuffer()
+      censuses[censusIndex]?.resolve({
+        snapshots: [],
+        authoritative: true,
+        changeSequence
+      })
+      if (censusIndex < censuses.length - 1) {
+        await vi.waitFor(() => expect(collect).toHaveBeenCalledTimes(censusIndex + 2))
+      }
+    }
+
+    await expect(pending).rejects.toThrow('session_tabs_inventory_unstable')
+    expect(collect).toHaveBeenCalledTimes(3)
+    expect(unsubscribe).toHaveBeenCalledOnce()
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('drops buffered work and removes the listener when disposed during census', async () => {
+    const harness = createHarness()
+    const pending = subscribeSessionTabsInventory(harness.context, harness.emit)
+
+    await Promise.resolve()
+    harness.cleanup()
+    harness.publish(snapshot(2, [terminalTab('late')]))
+    harness.census.resolve({ snapshots: [], authoritative: true, changeSequence: 0 })
+    await pending
+
+    expect(harness.emit).not.toHaveBeenCalled()
+    expect(harness.unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/runtime/rpc/methods/session-tabs-inventory-rpc.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-inventory-rpc.test.ts
@@ -194,22 +194,27 @@ describe('session tabs inventory RPC methods', () => {
     let resolveInventory!: (value: {
       snapshots: RuntimeMobileSessionTabsResult[]
       authoritative: true
+      changeSequence: number
     }) => void
-    const listeners: ((snapshot: RuntimeMobileSessionTabsResult) => void)[] = []
+    const listeners: ((
+      snapshot: RuntimeMobileSessionTabsResult,
+      changeSequence: number
+    ) => void)[] = []
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       supportsAuthoritativeSessionTabsInventory: vi.fn(() => true),
-      listAllMobileSessionTabsInventory: vi.fn(
+      listAllMobileSessionTabsInventoryWithChangeSequence: vi.fn(
         () =>
           new Promise<{
             snapshots: RuntimeMobileSessionTabsResult[]
             authoritative: true
+            changeSequence: number
           }>((resolve) => {
             resolveInventory = resolve
           })
       ),
       onMobileSessionTabsChanged: vi.fn(
-        (listener: (snapshot: RuntimeMobileSessionTabsResult) => void) => {
+        (listener: (snapshot: RuntimeMobileSessionTabsResult, changeSequence: number) => void) => {
           listeners.push(listener)
           return vi.fn()
         }
@@ -229,15 +234,18 @@ describe('session tabs inventory RPC methods', () => {
       }
     )
     await Promise.resolve()
-    listeners[0]?.({
-      worktree: 'wt-authoritative',
-      publicationEpoch: 'epoch-before-reload',
-      snapshotVersion: 2,
-      activeGroupId: null,
-      activeTabId: null,
-      activeTabType: null,
-      tabs: []
-    })
+    listeners[0]?.(
+      {
+        worktree: 'wt-authoritative',
+        publicationEpoch: 'epoch-before-reload',
+        snapshotVersion: 2,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: null,
+        tabs: []
+      },
+      1
+    )
     expect(messages).toEqual([])
 
     resolveInventory({
@@ -252,18 +260,22 @@ describe('session tabs inventory RPC methods', () => {
           tabs: []
         }
       ],
-      authoritative: true
+      authoritative: true,
+      changeSequence: 1
     })
     await pending
-    listeners[0]?.({
-      worktree: 'wt-authoritative',
-      publicationEpoch: 'epoch-after-reload',
-      snapshotVersion: 2,
-      activeGroupId: null,
-      activeTabId: null,
-      activeTabType: null,
-      tabs: []
-    })
+    listeners[0]?.(
+      {
+        worktree: 'wt-authoritative',
+        publicationEpoch: 'epoch-after-reload',
+        snapshotVersion: 2,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: null,
+        tabs: []
+      },
+      2
+    )
 
     expect(messages.map((message) => JSON.parse(message).result)).toEqual([
       {
@@ -287,19 +299,26 @@ describe('session tabs inventory RPC methods', () => {
   })
 
   it('lets authoritative empty inventory win over prior-epoch updates', async () => {
-    let resolveInventory!: (value: { snapshots: []; authoritative: true }) => void
-    const listeners: ((snapshot: RuntimeMobileSessionTabsResult) => void)[] = []
+    let resolveInventory!: (value: {
+      snapshots: []
+      authoritative: true
+      changeSequence: number
+    }) => void
+    const listeners: ((
+      snapshot: RuntimeMobileSessionTabsResult,
+      changeSequence: number
+    ) => void)[] = []
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       supportsAuthoritativeSessionTabsInventory: vi.fn(() => true),
-      listAllMobileSessionTabsInventory: vi.fn(
+      listAllMobileSessionTabsInventoryWithChangeSequence: vi.fn(
         () =>
-          new Promise<{ snapshots: []; authoritative: true }>((resolve) => {
+          new Promise<{ snapshots: []; authoritative: true; changeSequence: number }>((resolve) => {
             resolveInventory = resolve
           })
       ),
       onMobileSessionTabsChanged: vi.fn(
-        (listener: (snapshot: RuntimeMobileSessionTabsResult) => void) => {
+        (listener: (snapshot: RuntimeMobileSessionTabsResult, changeSequence: number) => void) => {
           listeners.push(listener)
           return vi.fn()
         }
@@ -328,10 +347,10 @@ describe('session tabs inventory RPC methods', () => {
       }
     )
     await Promise.resolve()
-    listeners[0]?.(snapshot(2))
-    listeners[0]?.(snapshot(3))
+    listeners[0]?.(snapshot(2), 1)
+    listeners[0]?.(snapshot(3), 2)
 
-    resolveInventory({ snapshots: [], authoritative: true })
+    resolveInventory({ snapshots: [], authoritative: true, changeSequence: 2 })
     await pending
 
     expect(messages.map((message) => JSON.parse(message).result)).toEqual([

--- a/src/main/runtime/rpc/methods/session-tabs-inventory.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-inventory.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from 'node:util'
 import { SESSION_TABS_AUTHORITATIVE_INVENTORY_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
 import type { RuntimeMobileSessionTabsResult } from '../../../../shared/runtime-types'
 import type { RpcContext } from '../core'
@@ -8,6 +9,11 @@ type SessionTabsInventory = {
   snapshots: RuntimeMobileSessionTabsResult[]
   authoritative?: true
 }
+
+type SessionTabsChange = RuntimeMobileSessionTabsResult & { removed?: true }
+
+const MAX_BUFFERED_CENSUS_CHANGES = 256
+const MAX_CENSUS_COLLECTION_ATTEMPTS = 3
 
 function clientUnderstandsAuthoritativeInventory(context: RpcContext): boolean {
   return (
@@ -42,14 +48,33 @@ function projectInventory(
   }
 }
 
-export async function listSessionTabsInventory(context: RpcContext): Promise<SessionTabsInventory> {
+async function collectSessionTabsInventory(
+  context: RpcContext,
+  includeChangeSequence = false
+): Promise<{
+  inventory: SessionTabsInventory
+  changeSequence: number
+}> {
   const { runtime, pairedDeviceId, signal } = context
   // Why: a failed census degrades inside the runtime to the same scan without
   // the authoritative label, so no client ever pays a second full collection.
-  const inventory = runtime.supportsAuthoritativeSessionTabsInventory()
-    ? await runtime.listAllMobileSessionTabsInventory(pairedDeviceId, signal)
-    : { snapshots: await runtime.listAllMobileSessionTabs(pairedDeviceId) }
-  return projectInventory(inventory, context)
+  if (!includeChangeSequence) {
+    const inventory = runtime.supportsAuthoritativeSessionTabsInventory()
+      ? await runtime.listAllMobileSessionTabsInventory(pairedDeviceId, signal)
+      : { snapshots: await runtime.listAllMobileSessionTabs(pairedDeviceId) }
+    return { inventory: projectInventory(inventory, context), changeSequence: 0 }
+  }
+  const collected = runtime.supportsAuthoritativeSessionTabsInventory()
+    ? await runtime.listAllMobileSessionTabsInventoryWithChangeSequence(pairedDeviceId, signal)
+    : await runtime.listAllMobileSessionTabsWithChangeSequence(pairedDeviceId)
+  return {
+    inventory: projectInventory(collected, context),
+    changeSequence: collected.changeSequence
+  }
+}
+
+export async function listSessionTabsInventory(context: RpcContext): Promise<SessionTabsInventory> {
+  return (await collectSessionTabsInventory(context)).inventory
 }
 
 export async function subscribeSessionTabsInventory(
@@ -67,15 +92,117 @@ export async function subscribeSessionTabsInventory(
   context.signal?.addEventListener('abort', abortInventory, { once: true })
   let initialized = false
   let closed = false
-  const unsubscribe = runtime.onMobileSessionTabsChanged((snapshot) => {
-    if (!initialized) {
-      // Why: the final authoritative scan subsumes these; replaying a prior epoch afterward resurrects stale host state.
+  const bufferedChanges: { snapshot: SessionTabsChange; changeSequence: number }[] = []
+  const bufferedOrdinaryChangeByWorktree = new Map<
+    string,
+    { index: number; membershipKey: string; changeSequence: number }
+  >()
+  const bufferedNavigationIntentByWorktree = new Map<
+    string,
+    { index: number; changeSequence: number }
+  >()
+  const publishedSnapshotsByWorktree = new Map<string, SessionTabsChange>()
+  const deliveredChangeSequenceByWorktree = new Map<string, number>()
+  let censusChangeSequence: number | undefined
+  let censusInvalidated = false
+  const projectChange = (snapshot: SessionTabsChange): SessionTabsChange =>
+    projectSessionTabsForClient(
+      snapshot,
+      context.clientKind,
+      context.clientCapabilities
+    ) as SessionTabsChange
+  const withoutNavigationIntent = (snapshot: SessionTabsChange): SessionTabsChange => {
+    if (snapshot.navigationIntent === undefined) {
+      return snapshot
+    }
+    const { navigationIntent: _navigationIntent, ...state } = snapshot
+    return state as SessionTabsChange
+  }
+  const membershipKey = (snapshot: SessionTabsChange): string =>
+    JSON.stringify({
+      removed: snapshot.removed === true,
+      tabs: snapshot.tabs.map((tab) => ({
+        type: tab.type,
+        id: tab.id
+      }))
+    })
+  const clearBufferedChanges = (): void => {
+    bufferedChanges.length = 0
+    bufferedOrdinaryChangeByWorktree.clear()
+    bufferedNavigationIntentByWorktree.clear()
+  }
+  const reserveBufferedChange = (): void => {
+    if (bufferedChanges.length < MAX_BUFFERED_CENSUS_CHANGES) {
+      return
+    }
+    clearBufferedChanges()
+    censusInvalidated = true
+  }
+  const bufferChange = (snapshot: SessionTabsChange, changeSequence: number): void => {
+    if (snapshot.navigationIntent !== undefined) {
+      const previous = bufferedNavigationIntentByWorktree.get(snapshot.worktree)
+      if (previous) {
+        if (changeSequence > previous.changeSequence) {
+          bufferedChanges[previous.index] = { snapshot, changeSequence }
+          previous.changeSequence = changeSequence
+        }
+        return
+      }
+      reserveBufferedChange()
+      const index = bufferedChanges.push({ snapshot, changeSequence }) - 1
+      bufferedNavigationIntentByWorktree.set(snapshot.worktree, { index, changeSequence })
+      return
+    }
+    const nextMembershipKey = membershipKey(snapshot)
+    const previous = bufferedOrdinaryChangeByWorktree.get(snapshot.worktree)
+    if (previous?.membershipKey === nextMembershipKey) {
+      if (changeSequence > previous.changeSequence) {
+        bufferedChanges[previous.index] = { snapshot, changeSequence }
+        previous.changeSequence = changeSequence
+      }
+      return
+    }
+    reserveBufferedChange()
+    const index = bufferedChanges.push({ snapshot, changeSequence }) - 1
+    bufferedOrdinaryChangeByWorktree.set(snapshot.worktree, {
+      index,
+      membershipKey: nextMembershipKey,
+      changeSequence
+    })
+  }
+  const publishChange = (snapshot: SessionTabsChange, changeSequence: number): void => {
+    const projected = projectChange(snapshot)
+    const state = withoutNavigationIntent(projected)
+    const published = publishedSnapshotsByWorktree.get(snapshot.worktree)
+    if (projected.navigationIntent === undefined && isDeepStrictEqual(published, state)) {
+      deliveredChangeSequenceByWorktree.set(snapshot.worktree, changeSequence)
       return
     }
     emit({
       type: 'updated',
-      ...projectSessionTabsForClient(snapshot, context.clientKind, context.clientCapabilities)
+      ...projected
     })
+    if (projected.removed === true) {
+      publishedSnapshotsByWorktree.delete(snapshot.worktree)
+      deliveredChangeSequenceByWorktree.delete(snapshot.worktree)
+    } else {
+      publishedSnapshotsByWorktree.set(snapshot.worktree, state)
+      deliveredChangeSequenceByWorktree.set(snapshot.worktree, changeSequence)
+    }
+  }
+  const unsubscribe = runtime.onMobileSessionTabsChanged((runtimeSnapshot, changeSequence) => {
+    const snapshot = runtimeSnapshot as SessionTabsChange
+    if (!initialized) {
+      bufferChange(snapshot, changeSequence)
+      return
+    }
+    if (
+      changeSequence <= (censusChangeSequence ?? 0) ||
+      changeSequence <= (deliveredChangeSequenceByWorktree.get(snapshot.worktree) ?? 0)
+    ) {
+      return
+    }
+    publishChange(snapshot, changeSequence)
   }, pairedDeviceId)
   runtime.registerSubscriptionCleanup(
     subscriptionId,
@@ -83,6 +210,9 @@ export async function subscribeSessionTabsInventory(
       closed = true
       inventoryController.abort()
       unsubscribe()
+      clearBufferedChanges()
+      publishedSnapshotsByWorktree.clear()
+      deliveredChangeSequenceByWorktree.clear()
       if (initialized) {
         emit({ type: 'end' })
       }
@@ -93,18 +223,53 @@ export async function subscribeSessionTabsInventory(
     context.signal?.removeEventListener('abort', abortInventory)
     return
   }
-  const inventory = await listSessionTabsInventory({
-    ...context,
-    signal: inventoryController.signal
-  })
-    .catch((error) => {
-      runtime.cleanupSubscription(subscriptionId)
-      throw error
-    })
-    .finally(() => context.signal?.removeEventListener('abort', abortInventory))
+  let collected: Awaited<ReturnType<typeof collectSessionTabsInventory>> | undefined
+  try {
+    for (let attempt = 1; !collected; attempt += 1) {
+      censusInvalidated = false
+      const candidate = await collectSessionTabsInventory(
+        { ...context, signal: inventoryController.signal },
+        true
+      )
+      if (closed) {
+        return
+      }
+      if (censusInvalidated) {
+        clearBufferedChanges()
+        if (attempt === MAX_CENSUS_COLLECTION_ATTEMPTS) {
+          throw new Error('session_tabs_inventory_unstable')
+        }
+      } else {
+        collected = candidate
+      }
+    }
+  } catch (error) {
+    runtime.cleanupSubscription(subscriptionId)
+    throw error
+  } finally {
+    context.signal?.removeEventListener('abort', abortInventory)
+  }
   if (closed) {
     return
   }
+  const { inventory, changeSequence } = collected
+  censusChangeSequence = changeSequence
   emit({ type: 'snapshots', ...inventory })
+  for (const snapshot of inventory.snapshots) {
+    publishedSnapshotsByWorktree.set(snapshot.worktree, withoutNavigationIntent(snapshot))
+  }
+  bufferedChanges.sort((left, right) => left.changeSequence - right.changeSequence)
+  for (const buffered of bufferedChanges) {
+    if (closed) {
+      break
+    }
+    if (buffered.changeSequence > changeSequence) {
+      publishChange(buffered.snapshot, buffered.changeSequence)
+    }
+  }
+  clearBufferedChanges()
+  if (closed) {
+    return
+  }
   initialized = true
 }

--- a/src/main/runtime/rpc/methods/session-tabs.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs.test.ts
@@ -628,34 +628,41 @@ describe('session tab RPC methods', () => {
 
   it('streams all known session tab snapshots and later updates', async () => {
     const unsubscribe = vi.fn()
-    const listeners: ((snapshot: unknown) => void)[] = []
+    const listeners: ((snapshot: unknown, changeSequence: number) => void)[] = []
+    const snapshots = [
+      {
+        worktree: 'wt-1',
+        publicationEpoch: 'epoch-1',
+        snapshotVersion: 1,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: null,
+        tabs: []
+      },
+      {
+        worktree: 'wt-2',
+        publicationEpoch: 'epoch-2',
+        snapshotVersion: 1,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: null,
+        tabs: []
+      }
+    ]
     const runtime = {
       getRuntimeId: () => 'test-runtime',
-      listAllMobileSessionTabs: vi.fn(() => [
-        {
-          worktree: 'wt-1',
-          publicationEpoch: 'epoch-1',
-          snapshotVersion: 1,
-          activeGroupId: null,
-          activeTabId: null,
-          activeTabType: null,
-          tabs: []
-        },
-        {
-          worktree: 'wt-2',
-          publicationEpoch: 'epoch-2',
-          snapshotVersion: 1,
-          activeGroupId: null,
-          activeTabId: null,
-          activeTabType: null,
-          tabs: []
-        }
-      ]),
+      listAllMobileSessionTabs: vi.fn(() => snapshots),
+      listAllMobileSessionTabsWithChangeSequence: vi.fn(() => ({
+        snapshots,
+        changeSequence: 0
+      })),
       supportsAuthoritativeSessionTabsInventory: vi.fn(() => false),
-      onMobileSessionTabsChanged: vi.fn((listener: (snapshot: unknown) => void) => {
-        listeners.push(listener)
-        return unsubscribe
-      }),
+      onMobileSessionTabsChanged: vi.fn(
+        (listener: (snapshot: unknown, changeSequence: number) => void) => {
+          listeners.push(listener)
+          return unsubscribe
+        }
+      ),
       registerSubscriptionCleanup: vi.fn()
     } as unknown as OrcaRuntimeService
     const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
@@ -666,15 +673,18 @@ describe('session tab RPC methods', () => {
       (message) => messages.push(message),
       { connectionId: 'conn-1' }
     )
-    listeners[0]?.({
-      worktree: 'wt-1',
-      publicationEpoch: 'epoch-3',
-      snapshotVersion: 2,
-      activeGroupId: null,
-      activeTabId: null,
-      activeTabType: null,
-      tabs: []
-    })
+    listeners[0]?.(
+      {
+        worktree: 'wt-1',
+        publicationEpoch: 'epoch-3',
+        snapshotVersion: 2,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: null,
+        tabs: []
+      },
+      1
+    )
 
     expect(runtime.registerSubscriptionCleanup).toHaveBeenCalledWith(
       'session.tabs:conn-1:*:req-1',
@@ -698,6 +708,10 @@ describe('session tab RPC methods', () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       listAllMobileSessionTabs: vi.fn(() => []),
+      listAllMobileSessionTabsWithChangeSequence: vi.fn(() => ({
+        snapshots: [],
+        changeSequence: 0
+      })),
       supportsAuthoritativeSessionTabsInventory: vi.fn(() => false),
       onMobileSessionTabsChanged: vi.fn(() => vi.fn()),
       registerSubscriptionCleanup: vi.fn()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​994 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​64 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​930 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​293 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​48 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​245 |

<!-- /orca-pr-loc -->

## ELI5

When a client first connects to an Orca host, the host sends an initial list of session tabs. A tab created or removed while that list was being prepared could fall into a gap: it was absent from the list, and its change notification was discarded. This PR makes the initial list and concurrent tab changes one ordered handoff, so the client converges to the host's actual tabs.

## What Changed

- Assign a host-local monotonic sequence to logical session-tab notifications.
- Capture the sequence watermark with the initial census.
- Buffer and reconcile changes received while the census is in progress.
- Preserve ordered create/remove/recreate membership transitions.
- Coalesce ordinary same-membership churn and repeated caller-only follow requests.
- Suppress projected payloads already represented by the census while delivering later PTY projection changes.
- Bound initialization buffering to 256 records and census collection to three attempts; fail before publishing partial state if sustained structural churn prevents a stable boundary.
- Add a deterministic controlled-promise regression suite and register the invariant in the reliability gate.

No wire field/opcode or renderer retry/polling behavior is added.

## Why

The existing listener is installed before the asynchronous census resolves, but callbacks are discarded while `initialized` is false. Latest `main` deterministically loses a post-boundary creation and removal. Fixing the subscription/runtime authority keeps the snapshot and concurrent changes linearizable without spreading recovery logic into consumers.

## Linked Issue

- [STA-5733](https://linear.app/stably/issue/STA-5733/p2continuous-buffer-session-tabs-change-events-during-initial-census)
- Related merged PR: #16546

## Visual Proof

N/A — this is a main-runtime ordering fix with no visual design change.

## Testing

- Actual latest-`main` source, controlled boundary oracle: 2 expected failures (post-boundary create/remove lost), 3 controls passed.
- Candidate deterministic race suite: 29/29 passed.
- Focused inventory/RPC suites: 66/66 passed.
- Reliability slice: 98/98 passed.
- Fresh independent review adjacent runtime/fanout/PTY suites: 78/78 passed.
- `pnpm tc` and `pnpm tc:node` passed.
- Changed-code quality, max-lines ratchet, reliability manifest, and `git diff --check` passed.
- Rebuilt headless `orca serve` focused terminal-create E2E: 1/1 passed on macOS.

Known validation gap: the headed paired host-relaunch journey stalled in transport recovery (`connecting`, then cleanup `tab_not_found`) before reaching a census assertion. A supplemental paired Cmd-J journey mirrored the host inventory but later failed active-tab visibility. No live Windows, Linux, or SSH E2E was run; the change is host-local, adds no platform-specific behavior, and does not alter wire bytes.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure


## Review

A fresh independent subagent reviewed the exact rebased diff and reported CLEAN: no validated correctness, design, performance, cleanup, fanout, mixed-version, SSH/folder-workspace, or cross-platform regression. Earlier delegated design, adversarial, and performance review rounds also reached a clean final round.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The bounded failure policy is deliberate: after 256 buffered structural transitions repeatedly invalidate three census attempts, the subscription rejects with `session_tabs_inventory_unstable` rather than publishing an inventory known to be incomplete.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
