### PR TITLE
fix(remote): preserve standing host reconnect intent

### DIFF
--- a/src/main/ipc/runtime-environment-browser-client-host-handler.test.ts
+++ b/src/main/ipc/runtime-environment-browser-client-host-handler.test.ts
@@ -94,7 +94,12 @@ describe('runtime environment browser client host handler', () => {
     await expect(
       prepare(null, { selector: 'environment-a', expectedPairingRevision: 7 })
     ).resolves.toEqual({ kind: 'client', browserHostClientId: 'browser-client-a' })
-    expect(getRuntimeEnvironmentStatusMock).toHaveBeenCalledWith('/profile', 'environment-a')
+    expect(getRuntimeEnvironmentStatusMock).toHaveBeenCalledWith(
+      '/profile',
+      'environment-a',
+      undefined,
+      { observeOnly: true }
+    )
     expect(startHostMock).toHaveBeenCalledWith({
       environment: expect.objectContaining({ id: 'environment-a', pairingRevision: 7 }),
       authorityRuntimeId: 'runtime-a'

--- a/src/main/ipc/runtime-environment-browser-client-host-handler.ts
+++ b/src/main/ipc/runtime-environment-browser-client-host-handler.ts
@@ -32,7 +32,9 @@ export function registerRuntimeEnvironmentBrowserClientHostHandler(options: {
         resolveEnvironment: (selector) => resolveEnvironment(userDataPath, selector),
         getStatus: async (environmentId) => {
           requireConnected(environmentId)
-          const status = await getRuntimeEnvironmentStatus(userDataPath, environmentId)
+          const status = await getRuntimeEnvironmentStatus(userDataPath, environmentId, undefined, {
+            observeOnly: true
+          })
           requireConnected(environmentId)
           return status
         },

--- a/src/main/ipc/runtime-environment-capability-evidence.test.ts
+++ b/src/main/ipc/runtime-environment-capability-evidence.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PairingOffer } from '../../shared/pairing'
+import {
+  advanceRuntimeEnvironmentCapabilityIncarnation,
+  applyRuntimeEnvironmentCapabilityVerdict,
+  captureRuntimeEnvironmentCapabilityEvidence,
+  getAcceptedRuntimeEnvironmentCapabilityOutcome,
+  isRuntimeEnvironmentCapabilityOutcomeCurrent,
+  isRuntimeEnvironmentCapabilityPaused,
+  resetRuntimeEnvironmentCapabilityEvidence,
+  runtimeEnvironmentCapabilityOutcome
+} from './runtime-environment-capability-evidence'
+
+beforeEach(resetRuntimeEnvironmentCapabilityEvidence)
+
+describe('runtime environment capability evidence', () => {
+  it('accepts evidence by dispatch order instead of completion order', () => {
+    const older = captureRuntimeEnvironmentCapabilityEvidence('env', pairing())
+    const newer = captureRuntimeEnvironmentCapabilityEvidence('env', pairing())
+    const pause = vi.fn()
+
+    expect(
+      applyRuntimeEnvironmentCapabilityVerdict({
+        evidence: newer,
+        verdict: 'capable',
+        runtimeId: 'runtime-new'
+      })
+    ).toBe(true)
+    expect(
+      applyRuntimeEnvironmentCapabilityVerdict({
+        evidence: older,
+        verdict: 'absent',
+        runtimeId: 'runtime-old',
+        onAbsent: pause
+      })
+    ).toBe(false)
+
+    expect(pause).not.toHaveBeenCalled()
+    expect(isRuntimeEnvironmentCapabilityPaused('env')).toBe(false)
+  })
+
+  it('rejects every pre-invalidation completion, including a same-pairing cycle', () => {
+    const evidence = captureRuntimeEnvironmentCapabilityEvidence('env', pairing())
+    advanceRuntimeEnvironmentCapabilityIncarnation('env')
+
+    expect(
+      applyRuntimeEnvironmentCapabilityVerdict({
+        evidence,
+        verdict: 'capable',
+        runtimeId: 'runtime-old'
+      })
+    ).toBe(false)
+    expect(
+      isRuntimeEnvironmentCapabilityOutcomeCurrent(
+        runtimeEnvironmentCapabilityOutcome(evidence, 'capable')
+      )
+    ).toBe(false)
+  })
+
+  it('invalidates cached outcomes symmetrically on contradictory evidence', () => {
+    const supportedEvidence = captureRuntimeEnvironmentCapabilityEvidence('env', pairing())
+    applyRuntimeEnvironmentCapabilityVerdict({
+      evidence: supportedEvidence,
+      verdict: 'capable',
+      runtimeId: 'runtime'
+    })
+    const supported = runtimeEnvironmentCapabilityOutcome(supportedEvidence, 'capable')
+    const absentEvidence = captureRuntimeEnvironmentCapabilityEvidence('env', pairing())
+    applyRuntimeEnvironmentCapabilityVerdict({
+      evidence: absentEvidence,
+      verdict: 'absent',
+      runtimeId: 'runtime'
+    })
+
+    expect(isRuntimeEnvironmentCapabilityOutcomeCurrent(supported)).toBe(false)
+    expect(isRuntimeEnvironmentCapabilityPaused('env')).toBe(true)
+    expect(
+      getAcceptedRuntimeEnvironmentCapabilityOutcome('env', pairing(), 'runtime')
+    ).toMatchObject({
+      kind: 'unsupported'
+    })
+
+    const recoveredEvidence = captureRuntimeEnvironmentCapabilityEvidence('env', pairing())
+    applyRuntimeEnvironmentCapabilityVerdict({
+      evidence: recoveredEvidence,
+      verdict: 'capable',
+      runtimeId: 'runtime'
+    })
+    expect(
+      isRuntimeEnvironmentCapabilityOutcomeCurrent(
+        runtimeEnvironmentCapabilityOutcome(absentEvidence, 'absent')
+      )
+    ).toBe(false)
+    expect(
+      getAcceptedRuntimeEnvironmentCapabilityOutcome('env', pairing(), 'runtime')
+    ).toMatchObject({
+      kind: 'supported'
+    })
+  })
+
+  it('does not reuse accepted evidence across runtime identities', () => {
+    const evidence = captureRuntimeEnvironmentCapabilityEvidence('env', pairing())
+    applyRuntimeEnvironmentCapabilityVerdict({
+      evidence,
+      verdict: 'capable',
+      runtimeId: 'runtime-a'
+    })
+
+    expect(
+      getAcceptedRuntimeEnvironmentCapabilityOutcome('env', pairing(), 'runtime-a')
+    ).toMatchObject({
+      kind: 'supported'
+    })
+    expect(getAcceptedRuntimeEnvironmentCapabilityOutcome('env', pairing(), 'runtime-b')).toBeNull()
+  })
+})
+
+function pairing(): PairingOffer {
+  return {
+    v: 2,
+    endpoint: 'ws://host',
+    deviceToken: 'token',
+    publicKeyB64: 'key'
+  }
+}

--- a/src/main/ipc/runtime-environment-capability-evidence.test.ts
+++ b/src/main/ipc/runtime-environment-capability-evidence.test.ts
@@ -39,6 +39,22 @@ describe('runtime environment capability evidence', () => {
     expect(isRuntimeEnvironmentCapabilityPaused('env')).toBe(false)
   })
 
+  it('rejects an older same-verdict outcome from a different runtime identity', () => {
+    const older = captureRuntimeEnvironmentCapabilityEvidence('env', pairing())
+    const newer = captureRuntimeEnvironmentCapabilityEvidence('env', pairing())
+    applyRuntimeEnvironmentCapabilityVerdict({
+      evidence: newer,
+      verdict: 'capable',
+      runtimeId: 'runtime-new'
+    })
+
+    expect(
+      isRuntimeEnvironmentCapabilityOutcomeCurrent(
+        runtimeEnvironmentCapabilityOutcome(older, 'capable', 'runtime-old')
+      )
+    ).toBe(false)
+  })
+
   it('rejects every pre-invalidation completion, including a same-pairing cycle', () => {
     const evidence = captureRuntimeEnvironmentCapabilityEvidence('env', pairing())
     advanceRuntimeEnvironmentCapabilityIncarnation('env')
@@ -52,7 +68,7 @@ describe('runtime environment capability evidence', () => {
     ).toBe(false)
     expect(
       isRuntimeEnvironmentCapabilityOutcomeCurrent(
-        runtimeEnvironmentCapabilityOutcome(evidence, 'capable')
+        runtimeEnvironmentCapabilityOutcome(evidence, 'capable', 'runtime-old')
       )
     ).toBe(false)
   })
@@ -64,7 +80,7 @@ describe('runtime environment capability evidence', () => {
       verdict: 'capable',
       runtimeId: 'runtime'
     })
-    const supported = runtimeEnvironmentCapabilityOutcome(supportedEvidence, 'capable')
+    const supported = runtimeEnvironmentCapabilityOutcome(supportedEvidence, 'capable', 'runtime')
     const absentEvidence = captureRuntimeEnvironmentCapabilityEvidence('env', pairing())
     applyRuntimeEnvironmentCapabilityVerdict({
       evidence: absentEvidence,
@@ -88,7 +104,7 @@ describe('runtime environment capability evidence', () => {
     })
     expect(
       isRuntimeEnvironmentCapabilityOutcomeCurrent(
-        runtimeEnvironmentCapabilityOutcome(absentEvidence, 'absent')
+        runtimeEnvironmentCapabilityOutcome(absentEvidence, 'absent', 'runtime')
       )
     ).toBe(false)
     expect(

--- a/src/main/ipc/runtime-environment-capability-evidence.ts
+++ b/src/main/ipc/runtime-environment-capability-evidence.ts
@@ -1,0 +1,142 @@
+import type { PairingOffer } from '../../shared/pairing'
+
+export type RuntimeEnvironmentCapabilityVerdict = 'capable' | 'absent'
+
+export type RuntimeEnvironmentCapabilityEvidence = {
+  environmentId: string
+  pairingKey: string
+  epoch: number
+  sequence: number
+}
+
+export type RuntimeEnvironmentCapabilityOutcome =
+  | { kind: 'supported'; evidence: RuntimeEnvironmentCapabilityEvidence }
+  | { kind: 'unsupported'; evidence: RuntimeEnvironmentCapabilityEvidence }
+  | { kind: 'stale_incarnation' }
+
+type AcceptedEvidence = {
+  evidence: RuntimeEnvironmentCapabilityEvidence
+  verdict: RuntimeEnvironmentCapabilityVerdict
+  runtimeId: string
+}
+
+type EvidenceState = {
+  epoch: number
+  nextSequence: number
+  accepted: AcceptedEvidence | null
+}
+
+const evidenceByEnvironment = new Map<string, EvidenceState>()
+
+export function resetRuntimeEnvironmentCapabilityEvidence(): void {
+  evidenceByEnvironment.clear()
+}
+
+function stateFor(environmentId: string): EvidenceState {
+  let state = evidenceByEnvironment.get(environmentId)
+  if (!state) {
+    state = { epoch: 0, nextSequence: 0, accepted: null }
+    evidenceByEnvironment.set(environmentId, state)
+  }
+  return state
+}
+
+export function captureRuntimeEnvironmentCapabilityEvidence(
+  environmentId: string,
+  pairing: PairingOffer
+): RuntimeEnvironmentCapabilityEvidence {
+  const state = stateFor(environmentId)
+  return {
+    environmentId,
+    pairingKey: pairingKey(pairing),
+    epoch: state.epoch,
+    sequence: ++state.nextSequence
+  }
+}
+
+export function advanceRuntimeEnvironmentCapabilityIncarnation(environmentId: string): void {
+  const state = stateFor(environmentId)
+  state.epoch += 1
+  state.accepted = null
+}
+
+export function applyRuntimeEnvironmentCapabilityVerdict(args: {
+  evidence: RuntimeEnvironmentCapabilityEvidence
+  verdict: RuntimeEnvironmentCapabilityVerdict
+  runtimeId: string
+  onCapable?: () => void
+  onAbsent?: () => void
+}): boolean {
+  const state = stateFor(args.evidence.environmentId)
+  if (
+    args.evidence.epoch !== state.epoch ||
+    (state.accepted !== null && args.evidence.sequence <= state.accepted.evidence.sequence)
+  ) {
+    return false
+  }
+  state.accepted = {
+    evidence: args.evidence,
+    verdict: args.verdict,
+    runtimeId: args.runtimeId
+  }
+  if (args.verdict === 'capable') {
+    args.onCapable?.()
+  } else {
+    args.onAbsent?.()
+  }
+  return true
+}
+
+export function runtimeEnvironmentCapabilityOutcome(
+  evidence: RuntimeEnvironmentCapabilityEvidence,
+  verdict: RuntimeEnvironmentCapabilityVerdict
+): RuntimeEnvironmentCapabilityOutcome {
+  return {
+    kind: verdict === 'capable' ? 'supported' : 'unsupported',
+    evidence
+  }
+}
+
+export function getAcceptedRuntimeEnvironmentCapabilityOutcome(
+  environmentId: string,
+  pairing: PairingOffer,
+  runtimeId: string | null
+): RuntimeEnvironmentCapabilityOutcome | null {
+  const accepted = stateFor(environmentId).accepted
+  if (
+    !accepted ||
+    accepted.evidence.pairingKey !== pairingKey(pairing) ||
+    (runtimeId !== null && accepted.runtimeId !== runtimeId)
+  ) {
+    return null
+  }
+  return runtimeEnvironmentCapabilityOutcome(accepted.evidence, accepted.verdict)
+}
+
+export function isRuntimeEnvironmentCapabilityOutcomeCurrent(
+  outcome: RuntimeEnvironmentCapabilityOutcome
+): boolean {
+  if (outcome.kind === 'stale_incarnation') {
+    return false
+  }
+  const state = stateFor(outcome.evidence.environmentId)
+  if (outcome.evidence.epoch !== state.epoch) {
+    return false
+  }
+  const accepted = state.accepted
+  if (!accepted || accepted.evidence.sequence <= outcome.evidence.sequence) {
+    return true
+  }
+  return (
+    (outcome.kind === 'supported' && accepted.verdict === 'capable') ||
+    (outcome.kind === 'unsupported' && accepted.verdict === 'absent')
+  )
+}
+
+export function isRuntimeEnvironmentCapabilityPaused(environmentId: string): boolean {
+  return stateFor(environmentId).accepted?.verdict === 'absent'
+}
+
+function pairingKey(pairing: PairingOffer): string {
+  return [pairing.endpoint, pairing.deviceToken, pairing.publicKeyB64].join('\0')
+}

--- a/src/main/ipc/runtime-environment-capability-evidence.ts
+++ b/src/main/ipc/runtime-environment-capability-evidence.ts
@@ -32,6 +32,10 @@ export function resetRuntimeEnvironmentCapabilityEvidence(): void {
   evidenceByEnvironment.clear()
 }
 
+export function clearRuntimeEnvironmentCapabilityEvidence(environmentId: string): void {
+  evidenceByEnvironment.delete(environmentId)
+}
+
 function stateFor(environmentId: string): EvidenceState {
   let state = evidenceByEnvironment.get(environmentId)
   if (!state) {

--- a/src/main/ipc/runtime-environment-capability-evidence.ts
+++ b/src/main/ipc/runtime-environment-capability-evidence.ts
@@ -10,8 +10,8 @@ export type RuntimeEnvironmentCapabilityEvidence = {
 }
 
 export type RuntimeEnvironmentCapabilityOutcome =
-  | { kind: 'supported'; evidence: RuntimeEnvironmentCapabilityEvidence }
-  | { kind: 'unsupported'; evidence: RuntimeEnvironmentCapabilityEvidence }
+  | { kind: 'supported'; evidence: RuntimeEnvironmentCapabilityEvidence; runtimeId: string }
+  | { kind: 'unsupported'; evidence: RuntimeEnvironmentCapabilityEvidence; runtimeId: string }
   | { kind: 'stale_incarnation' }
 
 type AcceptedEvidence = {
@@ -89,11 +89,13 @@ export function applyRuntimeEnvironmentCapabilityVerdict(args: {
 
 export function runtimeEnvironmentCapabilityOutcome(
   evidence: RuntimeEnvironmentCapabilityEvidence,
-  verdict: RuntimeEnvironmentCapabilityVerdict
+  verdict: RuntimeEnvironmentCapabilityVerdict,
+  runtimeId: string
 ): RuntimeEnvironmentCapabilityOutcome {
   return {
     kind: verdict === 'capable' ? 'supported' : 'unsupported',
-    evidence
+    evidence,
+    runtimeId
   }
 }
 
@@ -110,7 +112,11 @@ export function getAcceptedRuntimeEnvironmentCapabilityOutcome(
   ) {
     return null
   }
-  return runtimeEnvironmentCapabilityOutcome(accepted.evidence, accepted.verdict)
+  return runtimeEnvironmentCapabilityOutcome(
+    accepted.evidence,
+    accepted.verdict,
+    accepted.runtimeId
+  )
 }
 
 export function isRuntimeEnvironmentCapabilityOutcomeCurrent(
@@ -128,8 +134,9 @@ export function isRuntimeEnvironmentCapabilityOutcomeCurrent(
     return true
   }
   return (
-    (outcome.kind === 'supported' && accepted.verdict === 'capable') ||
-    (outcome.kind === 'unsupported' && accepted.verdict === 'absent')
+    ((outcome.kind === 'supported' && accepted.verdict === 'capable') ||
+      (outcome.kind === 'unsupported' && accepted.verdict === 'absent')) &&
+    accepted.runtimeId === outcome.runtimeId
   )
 }
 

--- a/src/main/ipc/runtime-environment-connectivity-handlers.ts
+++ b/src/main/ipc/runtime-environment-connectivity-handlers.ts
@@ -17,14 +17,20 @@ import type { Store } from '../persistence'
 import { clearBrowserRoutePartitionStorageForEnvironment } from '../browser/browser-route-partition-storage-runtime'
 import { retireBrowserRoutePartitionStorageForEnvironment } from '../browser/browser-route-partition-storage-retirement'
 import { verifyAndAddRuntimeEnvironmentFromPairingCode } from './runtime-environment-pairing-verification'
-import { closeRemoteRuntimeRequestConnection } from './runtime-environment-request-connections'
+import {
+  closeRemoteRuntimeRequestConnection,
+  retryRemoteRuntimeSharedControlConnectionNow
+} from './runtime-environment-request-connections'
+import {
+  clearRuntimeEnvironmentManualDisconnect,
+  isRuntimeEnvironmentManuallyDisconnected,
+  markRuntimeEnvironmentManuallyDisconnected
+} from './runtime-environment-manual-disconnect'
 import {
   callRuntimeEnvironment,
   clearSharedControlSupport,
   getRuntimeEnvironmentStatus
 } from './runtime-environment-transport-routing'
-
-const manuallyDisconnectedEnvironmentIds = new Set<string>()
 
 function manuallyDisconnectedResponse(
   environment: ReturnType<typeof resolveEnvironment>
@@ -40,9 +46,7 @@ function manuallyDisconnectedResponse(
   }
 }
 
-export function isRuntimeEnvironmentManuallyDisconnected(environmentId: string): boolean {
-  return manuallyDisconnectedEnvironmentIds.has(environmentId)
-}
+export { isRuntimeEnvironmentManuallyDisconnected }
 
 type ConnectivityHandlerOptions = {
   store: Store
@@ -65,7 +69,7 @@ export function registerRuntimeEnvironmentConnectivityHandlers({
       args: { name: string; pairingCode: string }
     ): { environment: PublicKnownRuntimeEnvironment } => {
       const environment = addEnvironmentFromPairingCode(getUserDataPath(), args)
-      manuallyDisconnectedEnvironmentIds.delete(environment.id)
+      clearRuntimeEnvironmentManualDisconnect(environment.id)
       return { environment: redactRuntimeEnvironment(environment) }
     }
   )
@@ -74,7 +78,7 @@ export function registerRuntimeEnvironmentConnectivityHandlers({
     async (_event, args: { name: string; pairingCode: string; allowLoopback?: boolean }) => {
       const result = await verifyAndAddRuntimeEnvironmentFromPairingCode(getUserDataPath(), args)
       if (result.ok) {
-        manuallyDisconnectedEnvironmentIds.delete(result.environment.id)
+        clearRuntimeEnvironmentManualDisconnect(result.environment.id)
       }
       return result
     }
@@ -90,7 +94,7 @@ export function registerRuntimeEnvironmentConnectivityHandlers({
         throw new Error('Choose another Active Server in Advanced before removing this server.')
       }
       const removed = removeEnvironment(getUserDataPath(), args.selector)
-      manuallyDisconnectedEnvironmentIds.delete(removed.id)
+      clearRuntimeEnvironmentManualDisconnect(removed.id)
       const retiring = Promise.resolve(invalidateTransport(removed.id))
       closeLegacySelectorTransport(args.selector, removed.id)
       // Why: removal is an explicit lifecycle decision, so its client-hosted browser storage goes
@@ -112,7 +116,7 @@ export function registerRuntimeEnvironmentConnectivityHandlers({
     'runtimeEnvironments:disconnect',
     (_event, args: { selector: string }): { disconnected: PublicKnownRuntimeEnvironment } => {
       const environment = resolveEnvironment(getUserDataPath(), args.selector)
-      manuallyDisconnectedEnvironmentIds.add(environment.id)
+      markRuntimeEnvironmentManuallyDisconnected(environment.id)
       invalidateTransport(environment.id)
       closeLegacySelectorTransport(args.selector, environment.id)
       return { disconnected: redactRuntimeEnvironment(environment) }
@@ -125,8 +129,17 @@ export function registerRuntimeEnvironmentConnectivityHandlers({
       args: { selector: string; timeoutMs?: number }
     ): Promise<RuntimeRpcResponse<RuntimeStatus>> => {
       const environment = resolveEnvironment(getUserDataPath(), args.selector)
-      manuallyDisconnectedEnvironmentIds.delete(environment.id)
+      clearRuntimeEnvironmentManualDisconnect(environment.id)
       return getRuntimeEnvironmentStatus(getUserDataPath(), environment.id, args.timeoutMs)
+    }
+  )
+  ipcMain.handle(
+    'runtimeEnvironments:retryControlConnection',
+    (_event, args: { selector: string }): void => {
+      const environment = resolveEnvironment(getUserDataPath(), args.selector)
+      if (!isRuntimeEnvironmentManuallyDisconnected(environment.id)) {
+        retryRemoteRuntimeSharedControlConnectionNow(environment.id)
+      }
     }
   )
 }
@@ -149,7 +162,7 @@ function registerPassiveStatusHandler(getUserDataPath: () => string): void {
     'runtimeEnvironments:getStatus',
     async (
       _event,
-      args: { selector: string; timeoutMs?: number }
+      args: { selector: string; timeoutMs?: number; observeOnly?: true }
     ): Promise<RuntimeRpcResponse<RuntimeStatus>> => {
       const environment = resolveEnvironment(getUserDataPath(), args.selector)
       if (isRuntimeEnvironmentManuallyDisconnected(environment.id)) {
@@ -158,7 +171,8 @@ function registerPassiveStatusHandler(getUserDataPath: () => string): void {
       const response = await getRuntimeEnvironmentStatus(
         getUserDataPath(),
         environment.id,
-        args.timeoutMs
+        args.timeoutMs,
+        args.observeOnly ? { observeOnly: true } : undefined
       )
       return isRuntimeEnvironmentManuallyDisconnected(environment.id)
         ? manuallyDisconnectedResponse(environment)

--- a/src/main/ipc/runtime-environment-connectivity-handlers.ts
+++ b/src/main/ipc/runtime-environment-connectivity-handlers.ts
@@ -17,6 +17,7 @@ import type { Store } from '../persistence'
 import { clearBrowserRoutePartitionStorageForEnvironment } from '../browser/browser-route-partition-storage-runtime'
 import { retireBrowserRoutePartitionStorageForEnvironment } from '../browser/browser-route-partition-storage-retirement'
 import { verifyAndAddRuntimeEnvironmentFromPairingCode } from './runtime-environment-pairing-verification'
+import { clearRuntimeEnvironmentCapabilityEvidence } from './runtime-environment-capability-evidence'
 import {
   closeRemoteRuntimeRequestConnection,
   retryRemoteRuntimeSharedControlConnectionNow
@@ -94,6 +95,7 @@ export function registerRuntimeEnvironmentConnectivityHandlers({
         throw new Error('Choose another Active Server in Advanced before removing this server.')
       }
       const removed = removeEnvironment(getUserDataPath(), args.selector)
+      clearRuntimeEnvironmentCapabilityEvidence(removed.id)
       clearRuntimeEnvironmentManualDisconnect(removed.id)
       const retiring = Promise.resolve(invalidateTransport(removed.id))
       closeLegacySelectorTransport(args.selector, removed.id)

--- a/src/main/ipc/runtime-environment-federated-read-routing.test.ts
+++ b/src/main/ipc/runtime-environment-federated-read-routing.test.ts
@@ -23,7 +23,10 @@ vi.mock('../../shared/remote-runtime-client', () => ({
 vi.mock('./runtime-environment-request-connections', () => ({
   sendRemoteRuntimeConnectionRequest: vi.fn(),
   sendRemoteRuntimeSharedControlRequest: sendRemoteRuntimeSharedControlRequestMock,
-  reconnectRemoteRuntimeSharedControlConnection: vi.fn()
+  reconnectRemoteRuntimeSharedControlConnection: vi.fn(),
+  retryRemoteRuntimeSharedControlConnectionNow: vi.fn(),
+  ensureRemoteRuntimeSharedControlConnection: vi.fn(),
+  pauseRemoteRuntimeSharedControlRetry: vi.fn()
 }))
 
 import {

--- a/src/main/ipc/runtime-environment-handler-channels.ts
+++ b/src/main/ipc/runtime-environment-handler-channels.ts
@@ -6,6 +6,7 @@ export const RUNTIME_ENVIRONMENT_HANDLER_CHANNELS = [
   'runtimeEnvironments:remove',
   'runtimeEnvironments:disconnect',
   'runtimeEnvironments:connect',
+  'runtimeEnvironments:retryControlConnection',
   'runtimeEnvironments:prepareBrowserClientHostPlacement',
   'runtimeEnvironments:getStatus',
   'runtimeEnvironments:call',

--- a/src/main/ipc/runtime-environment-manual-disconnect.ts
+++ b/src/main/ipc/runtime-environment-manual-disconnect.ts
@@ -1,0 +1,13 @@
+const manuallyDisconnectedEnvironmentIds = new Set<string>()
+
+export function markRuntimeEnvironmentManuallyDisconnected(environmentId: string): void {
+  manuallyDisconnectedEnvironmentIds.add(environmentId)
+}
+
+export function clearRuntimeEnvironmentManualDisconnect(environmentId: string): void {
+  manuallyDisconnectedEnvironmentIds.delete(environmentId)
+}
+
+export function isRuntimeEnvironmentManuallyDisconnected(environmentId: string): boolean {
+  return manuallyDisconnectedEnvironmentIds.has(environmentId)
+}

--- a/src/main/ipc/runtime-environment-request-connections.test.ts
+++ b/src/main/ipc/runtime-environment-request-connections.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { vi } from 'vitest'
+import {
+  closeSharedControlTestServers,
+  createSharedControlTestServer
+} from '../../shared/remote-runtime-shared-control-test-server'
+import {
+  applyRuntimeEnvironmentCapabilityVerdict,
+  captureRuntimeEnvironmentCapabilityEvidence,
+  resetRuntimeEnvironmentCapabilityEvidence
+} from './runtime-environment-capability-evidence'
+import {
+  clearRuntimeEnvironmentManualDisconnect,
+  markRuntimeEnvironmentManuallyDisconnected
+} from './runtime-environment-manual-disconnect'
+import {
+  closeRemoteRuntimeRequestConnection,
+  ensureRemoteRuntimeSharedControlConnection,
+  getRemoteRuntimeSharedControlDiagnostics,
+  pauseRemoteRuntimeSharedControlRetry,
+  reconnectRemoteRuntimeSharedControlConnection,
+  sendRemoteRuntimeSharedControlRequest,
+  subscribeRemoteRuntimeSharedControlRequest
+} from './runtime-environment-request-connections'
+
+const ENVIRONMENT_ID = 'standing-intent-test'
+
+afterEach(async () => {
+  closeRemoteRuntimeRequestConnection(ENVIRONMENT_ID)
+  clearRuntimeEnvironmentManualDisconnect(ENVIRONMENT_ID)
+  resetRuntimeEnvironmentCapabilityEvidence()
+  await closeSharedControlTestServers()
+})
+
+describe('runtime environment shared-control connection cache', () => {
+  it('ensures once and resumes a paused standing connection from capable evidence', async () => {
+    const server = await createSharedControlTestServer()
+    ensureRemoteRuntimeSharedControlConnection(ENVIRONMENT_ID, server.pairing)
+    ensureRemoteRuntimeSharedControlConnection(ENVIRONMENT_ID, server.pairing)
+    reconnectRemoteRuntimeSharedControlConnection(ENVIRONMENT_ID)
+    await waitFor(() => server.connectionCount() === 1)
+
+    server.closeClients()
+    await waitFor(
+      () => getRemoteRuntimeSharedControlDiagnostics(ENVIRONMENT_ID)?.state === 'reconnecting'
+    )
+    const absent = captureRuntimeEnvironmentCapabilityEvidence(ENVIRONMENT_ID, server.pairing)
+    applyRuntimeEnvironmentCapabilityVerdict({
+      evidence: absent,
+      verdict: 'absent',
+      runtimeId: 'runtime-test',
+      onAbsent: () => pauseRemoteRuntimeSharedControlRetry(ENVIRONMENT_ID)
+    })
+    expect(getRemoteRuntimeSharedControlDiagnostics(ENVIRONMENT_ID)?.state).toBe('closed')
+    await delay(400)
+    expect(server.connectionCount()).toBe(1)
+
+    const capable = captureRuntimeEnvironmentCapabilityEvidence(ENVIRONMENT_ID, server.pairing)
+    applyRuntimeEnvironmentCapabilityVerdict({
+      evidence: capable,
+      verdict: 'capable',
+      runtimeId: 'runtime-test',
+      onCapable: () => {
+        ensureRemoteRuntimeSharedControlConnection(ENVIRONMENT_ID, server.pairing)
+        reconnectRemoteRuntimeSharedControlConnection(ENVIRONMENT_ID)
+      }
+    })
+    await waitFor(() => server.connectionCount() === 2)
+  })
+
+  it('blocks standing creation while manual intent is disconnected', async () => {
+    const server = await createSharedControlTestServer()
+    markRuntimeEnvironmentManuallyDisconnected(ENVIRONMENT_ID)
+
+    ensureRemoteRuntimeSharedControlConnection(ENVIRONMENT_ID, server.pairing)
+    reconnectRemoteRuntimeSharedControlConnection(ENVIRONMENT_ID)
+    await delay(50)
+
+    expect(server.connectionCount()).toBe(0)
+    expect(getRemoteRuntimeSharedControlDiagnostics(ENVIRONMENT_ID)).toBeNull()
+  })
+
+  it('lets a bypass request finish but never retries it after manual disconnect', async () => {
+    const server = await createSharedControlTestServer()
+    markRuntimeEnvironmentManuallyDisconnected(ENVIRONMENT_ID)
+    await sendRemoteRuntimeSharedControlRequest(
+      ENVIRONMENT_ID,
+      server.pairing,
+      'repo.list',
+      undefined,
+      1_000
+    )
+
+    server.closeClients()
+    await waitFor(
+      () => getRemoteRuntimeSharedControlDiagnostics(ENVIRONMENT_ID)?.state === 'closed'
+    )
+    await delay(400)
+
+    expect(server.connectionCount()).toBe(1)
+    expect(getRemoteRuntimeSharedControlDiagnostics(ENVIRONMENT_ID)?.state).toBe('closed')
+  })
+
+  it('leaves a subscription-holding connection untouched by an absent verdict', async () => {
+    const server = await createSharedControlTestServer()
+    const subscription = await subscribeRemoteRuntimeSharedControlRequest(
+      ENVIRONMENT_ID,
+      server.pairing,
+      'session.tabs.subscribeAll',
+      undefined,
+      1_000,
+      { onResponse: vi.fn(), onError: vi.fn(), onClose: vi.fn() }
+    )
+    server.closeClients()
+    await waitFor(
+      () => getRemoteRuntimeSharedControlDiagnostics(ENVIRONMENT_ID)?.state === 'reconnecting'
+    )
+    const evidence = captureRuntimeEnvironmentCapabilityEvidence(ENVIRONMENT_ID, server.pairing)
+
+    applyRuntimeEnvironmentCapabilityVerdict({
+      evidence,
+      verdict: 'absent',
+      runtimeId: 'runtime-test',
+      onAbsent: () => pauseRemoteRuntimeSharedControlRetry(ENVIRONMENT_ID)
+    })
+
+    expect(getRemoteRuntimeSharedControlDiagnostics(ENVIRONMENT_ID)?.state).toBe('reconnecting')
+    await waitFor(() => server.connectionCount() === 2)
+    subscription.close()
+  })
+})
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const startedAt = Date.now()
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error('Timed out waiting for cached shared-control connection')
+    }
+    await delay(10)
+  }
+}
+
+const delay = (timeoutMs: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, timeoutMs))

--- a/src/main/ipc/runtime-environment-request-connections.test.ts
+++ b/src/main/ipc/runtime-environment-request-connections.test.ts
@@ -1,5 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
-import { vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   closeSharedControlTestServers,
   createSharedControlTestServer

--- a/src/main/ipc/runtime-environment-request-connections.ts
+++ b/src/main/ipc/runtime-environment-request-connections.ts
@@ -10,6 +10,8 @@ import type {
   RemoteRuntimeSharedConnectionDiagnostics,
   RemoteRuntimeSharedSubscription
 } from '../../shared/remote-runtime-shared-control-types'
+import { isRuntimeEnvironmentCapabilityPaused } from './runtime-environment-capability-evidence'
+import { isRuntimeEnvironmentManuallyDisconnected } from './runtime-environment-manual-disconnect'
 
 type CachedRuntimeConnection = {
   pairingKey: string
@@ -110,6 +112,23 @@ export function reconnectRemoteRuntimeSharedControlConnection(environmentId: str
   sharedControlConnections.get(environmentId)?.connection.reconnectNow()
 }
 
+export function retryRemoteRuntimeSharedControlConnectionNow(environmentId: string): void {
+  sharedControlConnections.get(environmentId)?.connection.retryNow()
+}
+
+export function pauseRemoteRuntimeSharedControlRetry(environmentId: string): void {
+  sharedControlConnections.get(environmentId)?.connection.pauseStandingRetry()
+}
+
+export function ensureRemoteRuntimeSharedControlConnection(
+  environmentId: string,
+  pairing: PairingOffer
+): void {
+  if (!isRuntimeEnvironmentManuallyDisconnected(environmentId)) {
+    getSharedControlConnection(environmentId, pairing)
+  }
+}
+
 export function retryRemoteRuntimeSharedControlConnectionsNow(): void {
   for (const { connection } of sharedControlConnections.values()) {
     connection.retryNow()
@@ -128,7 +147,9 @@ function getSharedControlConnection(
       pairingKey,
       connection: new RemoteRuntimeSharedControlConnection(pairing, {
         environmentId,
-        clientCapabilities: ELECTRON_REMOTE_RUNTIME_CLIENT_CAPABILITIES
+        clientCapabilities: ELECTRON_REMOTE_RUNTIME_CLIENT_CAPABILITIES,
+        isManuallyDisconnected: () => isRuntimeEnvironmentManuallyDisconnected(environmentId),
+        isCapabilityPaused: () => isRuntimeEnvironmentCapabilityPaused(environmentId)
       })
     }
     sharedControlConnections.set(environmentId, cached)

--- a/src/main/ipc/runtime-environment-shared-control-support.ts
+++ b/src/main/ipc/runtime-environment-shared-control-support.ts
@@ -9,11 +9,25 @@ import type {
   KnownRuntimeEnvironment
 } from '../../shared/runtime-environments'
 import type { RuntimeStatus } from '../../shared/runtime-types'
+import {
+  applyRuntimeEnvironmentCapabilityVerdict,
+  captureRuntimeEnvironmentCapabilityEvidence,
+  getAcceptedRuntimeEnvironmentCapabilityOutcome,
+  isRuntimeEnvironmentCapabilityOutcomeCurrent,
+  runtimeEnvironmentCapabilityOutcome,
+  resetRuntimeEnvironmentCapabilityEvidence,
+  type RuntimeEnvironmentCapabilityOutcome
+} from './runtime-environment-capability-evidence'
+import { pauseRemoteRuntimeSharedControlRetry } from './runtime-environment-request-connections'
 
-const sharedControlSupport = new Map<string, { cacheKey: string; check: Promise<boolean> }>()
+const sharedControlSupport = new Map<
+  string,
+  { cacheKey: string; check: Promise<RuntimeEnvironmentCapabilityOutcome> }
+>()
 
 export function resetSharedControlSupport(): void {
   sharedControlSupport.clear()
+  resetRuntimeEnvironmentCapabilityEvidence()
 }
 
 export function clearSharedControlSupport(environmentId: string): void {
@@ -25,13 +39,29 @@ export async function supportsSharedControl(
   environment: KnownRuntimeEnvironment,
   pairing: ReturnType<typeof getPreferredPairingOffer>,
   timeoutMs: number
-): Promise<boolean> {
+): Promise<RuntimeEnvironmentCapabilityOutcome> {
+  const accepted = getAcceptedRuntimeEnvironmentCapabilityOutcome(
+    environment.id,
+    pairing,
+    environment.runtimeId
+  )
+  if (accepted) {
+    return accepted
+  }
   const cacheKey = getSharedControlSupportCacheKey(environment, pairing)
   const cached = sharedControlSupport.get(environment.id)
   if (cached?.cacheKey === cacheKey) {
-    return cached.check
+    const outcome = await cached.check
+    if (isRuntimeEnvironmentCapabilityOutcomeCurrent(outcome)) {
+      return outcome
+    }
+    if (sharedControlSupport.get(environment.id)?.check === cached.check) {
+      sharedControlSupport.delete(environment.id)
+    }
+    return { kind: 'stale_incarnation' }
   }
   let resolvedCacheKey = cacheKey
+  const evidence = captureRuntimeEnvironmentCapabilityEvidence(environment.id, pairing)
   const check = (async () => {
     const response = await sendRemoteRuntimeRequest<RuntimeStatus>(
       pairing,
@@ -43,27 +73,39 @@ export async function supportsSharedControl(
       ELECTRON_REMOTE_RUNTIME_CLIENT_CAPABILITIES
     )
     if (response.ok === true) {
+      const verdict = response.result.capabilities?.includes(
+        REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY
+      )
+        ? 'capable'
+        : 'absent'
+      const acceptedEvidence = applyRuntimeEnvironmentCapabilityVerdict({
+        evidence,
+        verdict,
+        runtimeId: response._meta.runtimeId,
+        onAbsent: () => pauseRemoteRuntimeSharedControlRetry(environment.id)
+      })
+      if (!acceptedEvidence) {
+        return { kind: 'stale_incarnation' } as const
+      }
       markEnvironmentUsed(userDataPath, environment.id, { runtimeId: response._meta.runtimeId })
       resolvedCacheKey = getSharedControlSupportCacheKey(
         environment,
         pairing,
         response._meta.runtimeId
       )
-      return (
-        response.result.capabilities?.includes(REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY) === true
-      )
+      return runtimeEnvironmentCapabilityOutcome(evidence, verdict)
     }
-    return false
+    return runtimeEnvironmentCapabilityOutcome(evidence, 'absent')
   })()
   // Why: support belongs to the saved pairing/runtime identity, not its mutable display name.
   sharedControlSupport.set(environment.id, { cacheKey, check })
   try {
-    const supported = await check
+    const outcome = await check
     const cachedAfterCheck = sharedControlSupport.get(environment.id)
     if (cachedAfterCheck?.check === check && cachedAfterCheck.cacheKey !== resolvedCacheKey) {
       sharedControlSupport.set(environment.id, { cacheKey: resolvedCacheKey, check })
     }
-    return supported
+    return outcome
   } catch (error) {
     if (sharedControlSupport.get(environment.id)?.check === check) {
       sharedControlSupport.delete(environment.id)

--- a/src/main/ipc/runtime-environment-shared-control-support.ts
+++ b/src/main/ipc/runtime-environment-shared-control-support.ts
@@ -93,9 +93,13 @@ export async function supportsSharedControl(
         pairing,
         response._meta.runtimeId
       )
-      return runtimeEnvironmentCapabilityOutcome(evidence, verdict)
+      return runtimeEnvironmentCapabilityOutcome(evidence, verdict, response._meta.runtimeId)
     }
-    return runtimeEnvironmentCapabilityOutcome(evidence, 'absent')
+    return runtimeEnvironmentCapabilityOutcome(
+      evidence,
+      'absent',
+      environment.runtimeId ?? 'unknown-runtime'
+    )
   })()
   // Why: support belongs to the saved pairing/runtime identity, not its mutable display name.
   sharedControlSupport.set(environment.id, { cacheKey, check })

--- a/src/main/ipc/runtime-environment-status-diagnostics.ts
+++ b/src/main/ipc/runtime-environment-status-diagnostics.ts
@@ -1,4 +1,5 @@
 import type { RuntimeRpcResponse } from '../../shared/runtime-rpc-envelope'
+import { REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY } from '../../shared/protocol-version'
 import { getRemoteRuntimeSharedControlDiagnostics } from './runtime-environment-request-connections'
 
 export function attachRemoteControlDiagnostics<TResult extends object>(
@@ -10,6 +11,10 @@ export function attachRemoteControlDiagnostics<TResult extends object>(
     return response
   }
   if (response.ok) {
+    const capabilities = (response.result as { capabilities?: readonly string[] }).capabilities
+    if (!capabilities?.includes(REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY)) {
+      return response
+    }
     return { ...response, result: { ...(response.result as object), remoteControl } as TResult }
   }
   return {

--- a/src/main/ipc/runtime-environment-support-routing.test.ts
+++ b/src/main/ipc/runtime-environment-support-routing.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { KnownRuntimeEnvironment } from '../../shared/runtime-environments'
+import {
+  advanceRuntimeEnvironmentCapabilityIncarnation,
+  applyRuntimeEnvironmentCapabilityVerdict,
+  captureRuntimeEnvironmentCapabilityEvidence,
+  resetRuntimeEnvironmentCapabilityEvidence,
+  runtimeEnvironmentCapabilityOutcome
+} from './runtime-environment-capability-evidence'
+
+const { supportsMock, clearSupportMock, resolveEnvironmentMock } = vi.hoisted(() => ({
+  supportsMock: vi.fn(),
+  clearSupportMock: vi.fn(),
+  resolveEnvironmentMock: vi.fn()
+}))
+
+vi.mock('./runtime-environment-shared-control-support', () => ({
+  supportsSharedControl: supportsMock,
+  clearSharedControlSupport: clearSupportMock
+}))
+vi.mock('../../shared/runtime-environment-store', async (importOriginal) => ({
+  ...(await importOriginal()),
+  resolveEnvironment: resolveEnvironmentMock
+}))
+
+import {
+  routeRuntimeEnvironmentCallBySupport,
+  routeRuntimeEnvironmentSubscriptionBySupport
+} from './runtime-environment-support-routing'
+
+beforeEach(() => {
+  resetRuntimeEnvironmentCapabilityEvidence()
+  supportsMock.mockReset()
+  clearSupportMock.mockReset()
+  resolveEnvironmentMock.mockReset()
+  resolveEnvironmentMock.mockReturnValue(environment())
+})
+
+describe('runtime environment support routing', () => {
+  it('re-probes an unpinned stale call exactly once and succeeds', async () => {
+    supportsMock
+      .mockResolvedValueOnce({ kind: 'stale_incarnation' })
+      .mockResolvedValueOnce(acceptedOutcome('capable'))
+    const supported = vi.fn().mockResolvedValue(success())
+    const unsupported = vi.fn()
+
+    await expect(
+      routeRuntimeEnvironmentCallBySupport({
+        userDataPath: '/profile',
+        initialEnvironment: environment(),
+        method: 'repo.list',
+        timeoutMs: 100,
+        supported,
+        unsupported,
+        markUsed: vi.fn()
+      })
+    ).resolves.toMatchObject({ ok: true })
+
+    expect(supportsMock).toHaveBeenCalledTimes(2)
+    expect(clearSupportMock).toHaveBeenCalledOnce()
+    expect(supported).toHaveBeenCalledOnce()
+    expect(unsupported).not.toHaveBeenCalled()
+  })
+
+  it('fails a pinned stale call before probing or creating against the replacement', async () => {
+    supportsMock.mockResolvedValueOnce({ kind: 'stale_incarnation' })
+    resolveEnvironmentMock.mockReturnValue(environment({ pairingRevision: 2 }))
+    const supported = vi.fn()
+    const unsupported = vi.fn()
+
+    const result = await routeRuntimeEnvironmentCallBySupport({
+      userDataPath: '/profile',
+      initialEnvironment: environment({ pairingRevision: 1 }),
+      expectedPairingRevision: 1,
+      method: 'repo.list',
+      timeoutMs: 100,
+      supported,
+      unsupported,
+      markUsed: vi.fn()
+    })
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'runtime_environment_changed' } })
+    expect(supportsMock).toHaveBeenCalledOnce()
+    expect(supported).not.toHaveBeenCalled()
+    expect(unsupported).not.toHaveBeenCalled()
+  })
+
+  it('delivers a response but suppresses identity writes after response-time invalidation', async () => {
+    supportsMock.mockResolvedValue(acceptedOutcome('absent'))
+    const pending = deferred<ReturnType<typeof success>>()
+    const unsupported = vi.fn().mockReturnValue(pending.promise)
+    const markUsed = vi.fn()
+    const routed = routeRuntimeEnvironmentCallBySupport({
+      userDataPath: '/profile',
+      initialEnvironment: environment(),
+      method: 'repo.list',
+      timeoutMs: 100,
+      supported: vi.fn(),
+      unsupported,
+      markUsed
+    })
+    await vi.waitFor(() => expect(unsupported).toHaveBeenCalledOnce())
+    advanceRuntimeEnvironmentCapabilityIncarnation('env')
+    pending.resolve(success())
+
+    await expect(routed).resolves.toMatchObject({ ok: true })
+    expect(markUsed).not.toHaveBeenCalled()
+  })
+
+  it('fails a stale subscription before either factory is touched', async () => {
+    const outcome = acceptedOutcome('capable')
+    supportsMock.mockImplementation(async () => {
+      advanceRuntimeEnvironmentCapabilityIncarnation('env')
+      return outcome
+    })
+    const supported = vi.fn()
+    const unsupported = vi.fn()
+
+    await expect(
+      routeRuntimeEnvironmentSubscriptionBySupport({
+        userDataPath: '/profile',
+        environment: environment(),
+        timeoutMs: 100,
+        isCurrent: () => true,
+        supported,
+        unsupported
+      })
+    ).rejects.toThrow('Runtime environment pairing changed')
+    expect(supported).not.toHaveBeenCalled()
+    expect(unsupported).not.toHaveBeenCalled()
+  })
+})
+
+function acceptedOutcome(verdict: 'capable' | 'absent') {
+  const environmentId = 'env'
+  const pairing = {
+    v: 2 as const,
+    endpoint: 'ws://host',
+    deviceToken: 'token',
+    publicKeyB64: 'key'
+  }
+  const evidence = captureRuntimeEnvironmentCapabilityEvidence(environmentId, pairing)
+  applyRuntimeEnvironmentCapabilityVerdict({ evidence, verdict, runtimeId: 'runtime' })
+  return runtimeEnvironmentCapabilityOutcome(evidence, verdict)
+}
+
+function environment(overrides: Partial<KnownRuntimeEnvironment> = {}): KnownRuntimeEnvironment {
+  return {
+    id: 'env',
+    name: 'Environment',
+    createdAt: 1,
+    updatedAt: 1,
+    pairingRevision: 1,
+    lastUsedAt: null,
+    runtimeId: 'runtime',
+    endpoints: [
+      {
+        id: 'ws',
+        kind: 'websocket',
+        label: 'WebSocket',
+        endpoint: 'ws://host',
+        deviceToken: 'token',
+        publicKeyB64: 'key'
+      }
+    ],
+    preferredEndpointId: 'ws',
+    ...overrides
+  }
+}
+
+function success() {
+  return { id: 'repo.list', ok: true as const, result: {}, _meta: { runtimeId: 'runtime' } }
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {}
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}

--- a/src/main/ipc/runtime-environment-support-routing.test.ts
+++ b/src/main/ipc/runtime-environment-support-routing.test.ts
@@ -141,7 +141,7 @@ function acceptedOutcome(verdict: 'capable' | 'absent') {
   }
   const evidence = captureRuntimeEnvironmentCapabilityEvidence(environmentId, pairing)
   applyRuntimeEnvironmentCapabilityVerdict({ evidence, verdict, runtimeId: 'runtime' })
-  return runtimeEnvironmentCapabilityOutcome(evidence, verdict)
+  return runtimeEnvironmentCapabilityOutcome(evidence, verdict, 'runtime')
 }
 
 function environment(overrides: Partial<KnownRuntimeEnvironment> = {}): KnownRuntimeEnvironment {

--- a/src/main/ipc/runtime-environment-support-routing.ts
+++ b/src/main/ipc/runtime-environment-support-routing.ts
@@ -1,0 +1,286 @@
+import { waitForPromiseWithSignal } from '../../shared/abort-signal-reason'
+import type { PairingOffer } from '../../shared/pairing'
+import type { RuntimeRpcResponse } from '../../shared/runtime-rpc-envelope'
+import type { RuntimeOrchestrationEnvelope } from '../../shared/runtime-rpc-envelope'
+import type { KnownRuntimeEnvironment } from '../../shared/runtime-environments'
+import { getPreferredPairingOffer } from '../../shared/runtime-environments'
+import { markEnvironmentUsed, resolveEnvironment } from '../../shared/runtime-environment-store'
+import { ELECTRON_REMOTE_RUNTIME_CLIENT_CAPABILITIES } from '../../shared/protocol-version'
+import {
+  subscribeRemoteRuntimeRequest,
+  type RemoteRuntimeSubscription
+} from '../../shared/remote-runtime-client'
+import { withRemoteRuntimeTailscaleHint } from '../../shared/remote-runtime-tailscale-hint'
+import {
+  isRuntimeEnvironmentCapabilityOutcomeCurrent,
+  type RuntimeEnvironmentCapabilityOutcome
+} from './runtime-environment-capability-evidence'
+import { runtimeEnvironmentRevisionFailure } from './runtime-environment-revision-guard'
+import {
+  clearSharedControlSupport,
+  supportsSharedControl
+} from './runtime-environment-shared-control-support'
+import {
+  sendRemoteRuntimeRequestAbortable,
+  sendRemoteRuntimeSharedControlRequestAbortable
+} from './runtime-environment-abortable-requests'
+import { subscribeRemoteRuntimeSharedControlRequest } from './runtime-environment-request-connections'
+
+type SupportRoute = {
+  environment: KnownRuntimeEnvironment
+  pairing: PairingOffer
+  outcome: Exclude<RuntimeEnvironmentCapabilityOutcome, { kind: 'stale_incarnation' }>
+}
+
+type SubscriptionCallbacks = {
+  onEvent: (
+    payload:
+      | { type: 'response'; response: RuntimeRpcResponse<unknown> }
+      | { type: 'binary'; bytes: Uint8Array<ArrayBufferLike> }
+      | { type: 'error'; code: string; message: string }
+      | { type: 'close' }
+  ) => void
+  onClose: () => void
+}
+
+export function shouldRouteCallBySupport(method: string): boolean {
+  // Snapshot recovery must stay available while shared-control streams reconnect after a restart.
+  return (
+    method !== 'status.get' && method !== 'session.tabs.list' && method !== 'session.tabs.listAll'
+  )
+}
+
+export function shouldRouteSubscriptionBySupport(method: string): boolean {
+  if (method === 'browser.screencast' || method === 'terminal.multiplex') {
+    return false
+  }
+  return (
+    method === 'runtime.clientEvents.subscribe' ||
+    method === 'session.tabs.subscribe' ||
+    method === 'session.tabs.subscribeAll' ||
+    method === 'accounts.subscribe' ||
+    method === 'notifications.subscribe' ||
+    method === 'files.watch'
+  )
+}
+
+export function executeSupportRoutedCall(args: {
+  userDataPath: string
+  environment: KnownRuntimeEnvironment
+  method: string
+  params: unknown
+  timeoutMs: number
+  expectedPairingRevision?: number
+  envelope?: RuntimeOrchestrationEnvelope
+  signal?: AbortSignal
+}): Promise<RuntimeRpcResponse<unknown>> {
+  return routeRuntimeEnvironmentCallBySupport({
+    userDataPath: args.userDataPath,
+    initialEnvironment: args.environment,
+    method: args.method,
+    timeoutMs: args.timeoutMs,
+    expectedPairingRevision: args.expectedPairingRevision,
+    signal: args.signal,
+    supported: (route) =>
+      sendRemoteRuntimeSharedControlRequestAbortable(
+        route.environment.id,
+        route.pairing,
+        args.method,
+        args.params,
+        args.timeoutMs,
+        args.envelope,
+        args.signal
+      ),
+    unsupported: (route) =>
+      sendRemoteRuntimeRequestAbortable(
+        route.pairing,
+        args.method,
+        args.params,
+        args.timeoutMs,
+        args.envelope,
+        args.signal,
+        ELECTRON_REMOTE_RUNTIME_CLIENT_CAPABILITIES
+      ),
+    markUsed: (environmentId, response) => {
+      if (response.ok) {
+        markEnvironmentUsed(args.userDataPath, environmentId, {
+          runtimeId: response._meta.runtimeId
+        })
+      }
+    }
+  })
+}
+
+export async function subscribeSupportRoutedRuntimeEnvironment(args: {
+  userDataPath: string
+  environment: KnownRuntimeEnvironment
+  method: string
+  params: unknown
+  timeoutMs: number
+  callbacks: SubscriptionCallbacks
+  isCurrent: () => boolean
+}): Promise<RemoteRuntimeSubscription> {
+  let markedUsed = false
+  let supportOutcome: SupportRoute['outcome'] | null = null
+  const callbacks = subscriptionCallbacks(args, () => {
+    if (
+      markedUsed ||
+      !args.isCurrent() ||
+      (supportOutcome && !isRuntimeEnvironmentCapabilityOutcomeCurrent(supportOutcome))
+    ) {
+      return false
+    }
+    markedUsed = true
+    return true
+  })
+  const routed = await routeRuntimeEnvironmentSubscriptionBySupport({
+    userDataPath: args.userDataPath,
+    environment: args.environment,
+    timeoutMs: args.timeoutMs,
+    isCurrent: args.isCurrent,
+    supported: (route) => {
+      supportOutcome = route.outcome
+      return subscribeRemoteRuntimeSharedControlRequest(
+        args.environment.id,
+        route.pairing,
+        args.method,
+        args.params,
+        args.timeoutMs,
+        callbacks
+      )
+    },
+    unsupported: (route) => {
+      supportOutcome = route.outcome
+      return subscribeRemoteRuntimeRequest(
+        route.pairing,
+        args.method,
+        args.params,
+        args.timeoutMs,
+        callbacks,
+        { clientCapabilities: ELECTRON_REMOTE_RUNTIME_CLIENT_CAPABILITIES }
+      )
+    }
+  })
+  return routed.subscription
+}
+
+export async function routeRuntimeEnvironmentCallBySupport(args: {
+  userDataPath: string
+  initialEnvironment: KnownRuntimeEnvironment
+  method: string
+  timeoutMs: number
+  expectedPairingRevision?: number
+  signal?: AbortSignal
+  supported: (route: SupportRoute) => Promise<RuntimeRpcResponse<unknown>>
+  unsupported: (route: SupportRoute) => Promise<RuntimeRpcResponse<unknown>>
+  markUsed: (environmentId: string, response: RuntimeRpcResponse<unknown>) => void
+}): Promise<RuntimeRpcResponse<unknown>> {
+  let environment = args.initialEnvironment
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const revisionFailure = runtimeEnvironmentRevisionFailure(
+      environment,
+      args.expectedPairingRevision,
+      args.method
+    )
+    if (revisionFailure) {
+      return revisionFailure
+    }
+    const pairing = getPreferredPairingOffer(environment)
+    const outcome = await waitForPromiseWithSignal(
+      supportsSharedControl(args.userDataPath, environment, pairing, args.timeoutMs),
+      args.signal
+    )
+    if (
+      outcome.kind !== 'stale_incarnation' &&
+      isRuntimeEnvironmentCapabilityOutcomeCurrent(outcome)
+    ) {
+      const route = { environment, pairing, outcome }
+      const response = await (outcome.kind === 'supported'
+        ? args.supported(route)
+        : args.unsupported(route))
+      if (isRuntimeEnvironmentCapabilityOutcomeCurrent(outcome)) {
+        args.markUsed(environment.id, response)
+      }
+      return response
+    }
+    clearSharedControlSupport(environment.id)
+    environment = resolveEnvironment(args.userDataPath, environment.id)
+  }
+  return runtimeEnvironmentChangedFailure(environment, args.method)
+}
+
+export async function routeRuntimeEnvironmentSubscriptionBySupport<TSubscription>(args: {
+  userDataPath: string
+  environment: KnownRuntimeEnvironment
+  timeoutMs: number
+  isCurrent: () => boolean
+  supported: (route: SupportRoute) => Promise<TSubscription>
+  unsupported: (route: SupportRoute) => Promise<TSubscription>
+}): Promise<{ subscription: TSubscription; outcome: SupportRoute['outcome'] }> {
+  const pairing = getPreferredPairingOffer(args.environment)
+  const outcome = await supportsSharedControl(
+    args.userDataPath,
+    args.environment,
+    pairing,
+    args.timeoutMs
+  )
+  if (
+    outcome.kind === 'stale_incarnation' ||
+    !args.isCurrent() ||
+    !isRuntimeEnvironmentCapabilityOutcomeCurrent(outcome)
+  ) {
+    throw new Error('Runtime environment pairing changed; refresh and try again')
+  }
+  const route = { environment: args.environment, pairing, outcome }
+  const subscription = await (outcome.kind === 'supported'
+    ? args.supported(route)
+    : args.unsupported(route))
+  return { subscription, outcome }
+}
+
+function runtimeEnvironmentChangedFailure(
+  environment: KnownRuntimeEnvironment,
+  method: string
+): RuntimeRpcResponse<never> {
+  return {
+    id: method,
+    ok: false,
+    error: {
+      code: 'runtime_environment_changed',
+      message: 'Runtime environment pairing changed; refresh and try again'
+    },
+    _meta: { runtimeId: environment.runtimeId }
+  }
+}
+
+function subscriptionCallbacks(
+  args: Pick<
+    Parameters<typeof subscribeSupportRoutedRuntimeEnvironment>[0],
+    'userDataPath' | 'environment' | 'callbacks'
+  >,
+  shouldMarkUsed: () => boolean
+) {
+  const pairing = getPreferredPairingOffer(args.environment)
+  return {
+    onResponse: (response: RuntimeRpcResponse<unknown>) => {
+      if (response.ok && shouldMarkUsed()) {
+        markEnvironmentUsed(args.userDataPath, args.environment.id, {
+          runtimeId: response._meta.runtimeId
+        })
+      }
+      args.callbacks.onEvent({ type: 'response' as const, response })
+    },
+    onBinary: (bytes: Uint8Array<ArrayBufferLike>) =>
+      args.callbacks.onEvent({ type: 'binary' as const, bytes }),
+    onError: (error: { code: string; message: string }) =>
+      args.callbacks.onEvent({
+        type: 'error' as const,
+        code: error.code,
+        message: withRemoteRuntimeTailscaleHint(error.message, pairing.endpoint)
+      }),
+    onClose: () => {
+      args.callbacks.onEvent({ type: 'close' as const })
+      args.callbacks.onClose()
+    }
+  }
+}

--- a/src/main/ipc/runtime-environment-support-routing.ts
+++ b/src/main/ipc/runtime-environment-support-routing.ts
@@ -1,7 +1,9 @@
 import { waitForPromiseWithSignal } from '../../shared/abort-signal-reason'
 import type { PairingOffer } from '../../shared/pairing'
-import type { RuntimeRpcResponse } from '../../shared/runtime-rpc-envelope'
-import type { RuntimeOrchestrationEnvelope } from '../../shared/runtime-rpc-envelope'
+import type {
+  RuntimeOrchestrationEnvelope,
+  RuntimeRpcResponse
+} from '../../shared/runtime-rpc-envelope'
 import type { KnownRuntimeEnvironment } from '../../shared/runtime-environments'
 import { getPreferredPairingOffer } from '../../shared/runtime-environments'
 import { markEnvironmentUsed, resolveEnvironment } from '../../shared/runtime-environment-store'

--- a/src/main/ipc/runtime-environment-transport-routing.ts
+++ b/src/main/ipc/runtime-environment-transport-routing.ts
@@ -1,6 +1,8 @@
-import { waitForPromiseWithSignal } from '../../shared/abort-signal-reason'
 import { getPreferredPairingOffer } from '../../shared/runtime-environments'
-import { ELECTRON_REMOTE_RUNTIME_CLIENT_CAPABILITIES } from '../../shared/protocol-version'
+import {
+  ELECTRON_REMOTE_RUNTIME_CLIENT_CAPABILITIES,
+  REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY
+} from '../../shared/protocol-version'
 import { resolveEnvironment, markEnvironmentUsed } from '../../shared/runtime-environment-store'
 import { isOrchestrationMutation } from '../../shared/orchestration-rpc-contract'
 import type {
@@ -16,22 +18,32 @@ import {
 import { withRemoteRuntimeTailscaleHint } from '../../shared/remote-runtime-tailscale-hint'
 import { enqueueRuntimeCall } from './runtime-environment-call-queue'
 import {
-  reconnectRemoteRuntimeSharedControlConnection,
-  subscribeRemoteRuntimeSharedControlRequest
+  ensureRemoteRuntimeSharedControlConnection,
+  pauseRemoteRuntimeSharedControlRetry,
+  reconnectRemoteRuntimeSharedControlConnection
 } from './runtime-environment-request-connections'
 import {
   sendRemoteRuntimeConnectionRequestAbortable,
-  sendRemoteRuntimeRequestAbortable,
-  sendRemoteRuntimeSharedControlRequestAbortable
+  sendRemoteRuntimeRequestAbortable
 } from './runtime-environment-abortable-requests'
 import { attachRemoteControlDiagnostics } from './runtime-environment-status-diagnostics'
+import {
+  applyRuntimeEnvironmentCapabilityVerdict,
+  captureRuntimeEnvironmentCapabilityEvidence
+} from './runtime-environment-capability-evidence'
+import { isRuntimeEnvironmentManuallyDisconnected } from './runtime-environment-manual-disconnect'
 import { runtimeEnvironmentRevisionFailure } from './runtime-environment-revision-guard'
 import { withTailscaleHintForResponse } from './runtime-environment-tailscale-response'
 import {
   clearSharedControlSupport,
-  resetSharedControlSupport,
-  supportsSharedControl
+  resetSharedControlSupport
 } from './runtime-environment-shared-control-support'
+import {
+  executeSupportRoutedCall,
+  shouldRouteCallBySupport,
+  shouldRouteSubscriptionBySupport,
+  subscribeSupportRoutedRuntimeEnvironment
+} from './runtime-environment-support-routing'
 
 const DEFAULT_REMOTE_RUNTIME_TIMEOUT_MS = 15_000
 
@@ -40,10 +52,12 @@ export { clearSharedControlSupport, resetSharedControlSupport }
 export async function getRuntimeEnvironmentStatus(
   userDataPath: string,
   selector: string,
-  timeoutMs?: number
+  timeoutMs?: number,
+  options?: { observeOnly?: true }
 ): Promise<RuntimeRpcResponse<RuntimeStatus>> {
   const environment = resolveEnvironment(userDataPath, selector)
   const pairing = getPreferredPairingOffer(environment)
+  const evidence = captureRuntimeEnvironmentCapabilityEvidence(environment.id, pairing)
   let response: RuntimeRpcResponse<RuntimeStatus>
   try {
     response = await sendRemoteRuntimeRequest<RuntimeStatus>(
@@ -75,11 +89,27 @@ export async function getRuntimeEnvironmentStatus(
     )
   }
   if (response.ok === true) {
-    markEnvironmentUsed(userDataPath, environment.id, {
+    const verdict = response.result.capabilities?.includes(REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY)
+      ? 'capable'
+      : 'absent'
+    const accepted = applyRuntimeEnvironmentCapabilityVerdict({
+      evidence,
+      verdict,
       runtimeId: response._meta.runtimeId,
-      pairedDeviceId: response.result.pairedDeviceId
+      onCapable: () => {
+        if (!options?.observeOnly && !isRuntimeEnvironmentManuallyDisconnected(environment.id)) {
+          ensureRemoteRuntimeSharedControlConnection(environment.id, pairing)
+          reconnectRemoteRuntimeSharedControlConnection(environment.id)
+        }
+      },
+      onAbsent: () => pauseRemoteRuntimeSharedControlRetry(environment.id)
     })
-    reconnectRemoteRuntimeSharedControlConnection(environment.id)
+    if (accepted && !options?.observeOnly) {
+      markEnvironmentUsed(userDataPath, environment.id, {
+        runtimeId: response._meta.runtimeId,
+        pairedDeviceId: response.result.pairedDeviceId
+      })
+    }
   }
   return attachRemoteControlDiagnostics(
     withTailscaleHintForResponse(response, pairing.endpoint),
@@ -147,25 +177,17 @@ export async function callRuntimeEnvironment(
           markEnvironmentUsedFromResponse(userDataPath, currentEnvironment.id, response)
           return response
         }
-        if (
-          method !== 'status.get' &&
-          !shouldUseOneShotRequest(method) &&
-          (await waitForPromiseWithSignal(
-            supportsSharedControl(userDataPath, currentEnvironment, pairing, effectiveTimeoutMs),
-            options?.signal
-          ))
-        ) {
-          const response = await sendRemoteRuntimeSharedControlRequestAbortable(
-            currentEnvironment.id,
-            pairing,
+        if (shouldRouteCallBySupport(method)) {
+          return executeSupportRoutedCall({
+            userDataPath,
+            environment: currentEnvironment,
             method,
             params,
-            effectiveTimeoutMs,
-            sharedControlEnvelope,
-            options?.signal
-          )
-          markEnvironmentUsedFromResponse(userDataPath, currentEnvironment.id, response)
-          return response
+            timeoutMs: effectiveTimeoutMs,
+            expectedPairingRevision: expectedEnvironmentPairingRevision,
+            envelope: sharedControlEnvelope,
+            signal: options?.signal
+          })
         }
         // Why: startup/control-plane RPCs use the proven one-shot path so repo
         // hydration cannot be coupled to a stale terminal-control connection.
@@ -206,14 +228,15 @@ export async function subscribeRuntimeEnvironment(
         | { type: 'close' }
     ) => void
     onClose: () => void
-  }
+  },
+  isCurrent: () => boolean = () => true
 ): Promise<RemoteRuntimeSubscription> {
   const environment = resolveEnvironment(userDataPath, selector)
   const pairing = getPreferredPairingOffer(environment)
   const effectiveTimeoutMs = timeoutMs ?? DEFAULT_REMOTE_RUNTIME_TIMEOUT_MS
   let markedUsed = false
   const markUsedOnce = (runtimeId: string): void => {
-    if (markedUsed) {
+    if (markedUsed || !isCurrent()) {
       return
     }
     markedUsed = true
@@ -242,19 +265,16 @@ export async function subscribeRuntimeEnvironment(
   // Why: an initial-connect failure rejects (mid-stream drops go through
   // onError above), so the hint is applied to the thrown error here too.
   try {
-    if (
-      shouldUseSharedControlSubscription(method) &&
-      !shouldKeepDedicatedSubscriptionSocket(method) &&
-      (await supportsSharedControl(userDataPath, environment, pairing, effectiveTimeoutMs))
-    ) {
-      return await subscribeRemoteRuntimeSharedControlRequest(
-        environment.id,
-        pairing,
+    if (shouldRouteSubscriptionBySupport(method)) {
+      return await subscribeSupportRoutedRuntimeEnvironment({
+        userDataPath,
+        environment,
         method,
         params,
-        effectiveTimeoutMs,
-        callbacksWithMarkUsed
-      )
+        timeoutMs: effectiveTimeoutMs,
+        callbacks,
+        isCurrent
+      })
     }
     return await subscribeRemoteRuntimeRequest(
       pairing,
@@ -294,24 +314,4 @@ function shouldUseSharedControlEnvelope(
   return envelope && method.startsWith('orchestration.') && !isOrchestrationMutation(method, params)
     ? envelope
     : undefined
-}
-
-function shouldUseOneShotRequest(method: string): boolean {
-  // Why: snapshot recovery must remain available while a retained shared-control stream is reconnecting after a HUB restart.
-  return method === 'session.tabs.list' || method === 'session.tabs.listAll'
-}
-
-function shouldKeepDedicatedSubscriptionSocket(method: string): boolean {
-  return method === 'browser.screencast' || method === 'terminal.multiplex'
-}
-
-function shouldUseSharedControlSubscription(method: string): boolean {
-  return (
-    method === 'runtime.clientEvents.subscribe' ||
-    method === 'session.tabs.subscribe' ||
-    method === 'session.tabs.subscribeAll' ||
-    method === 'accounts.subscribe' ||
-    method === 'notifications.subscribe' ||
-    method === 'files.watch'
-  )
 }

--- a/src/main/ipc/runtime-environments-call-routing.test.ts
+++ b/src/main/ipc/runtime-environments-call-routing.test.ts
@@ -65,6 +65,9 @@ vi.mock('./runtime-environment-request-connections', () => ({
   getRemoteRuntimeSharedControlDiagnostics: getRemoteRuntimeSharedControlDiagnosticsMock,
   reconnectRemoteRuntimeSharedControlConnection: reconnectRemoteRuntimeSharedControlConnectionMock,
   retryRemoteRuntimeSharedControlConnectionsNow: retryRemoteRuntimeSharedControlConnectionsNowMock,
+  retryRemoteRuntimeSharedControlConnectionNow: vi.fn(),
+  ensureRemoteRuntimeSharedControlConnection: vi.fn(),
+  pauseRemoteRuntimeSharedControlRetry: vi.fn(),
   closeRemoteRuntimeRequestConnection: closeRemoteRuntimeRequestConnectionMock
 }))
 

--- a/src/main/ipc/runtime-environments-capability-cache.test.ts
+++ b/src/main/ipc/runtime-environments-capability-cache.test.ts
@@ -58,6 +58,9 @@ vi.mock('./runtime-environment-request-connections', () => ({
   getRemoteRuntimeSharedControlDiagnostics: getRemoteRuntimeSharedControlDiagnosticsMock,
   reconnectRemoteRuntimeSharedControlConnection: reconnectRemoteRuntimeSharedControlConnectionMock,
   retryRemoteRuntimeSharedControlConnectionsNow: retryRemoteRuntimeSharedControlConnectionsNowMock,
+  retryRemoteRuntimeSharedControlConnectionNow: vi.fn(),
+  ensureRemoteRuntimeSharedControlConnection: vi.fn(),
+  pauseRemoteRuntimeSharedControlRetry: vi.fn(),
   closeRemoteRuntimeRequestConnection: closeRemoteRuntimeRequestConnectionMock
 }))
 
@@ -234,7 +237,6 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     await call(null, { selector: 'desk', method: 'repo.list' })
 
     expect(sendRemoteRuntimeRequestMock.mock.calls.map((call) => call[1])).toEqual([
-      'status.get',
       'status.get',
       'status.get'
     ])

--- a/src/main/ipc/runtime-environments-pairing.test.ts
+++ b/src/main/ipc/runtime-environments-pairing.test.ts
@@ -23,6 +23,7 @@ const {
   getRemoteRuntimeSharedControlDiagnosticsMock,
   reconnectRemoteRuntimeSharedControlConnectionMock,
   retryRemoteRuntimeSharedControlConnectionsNowMock,
+  retryRemoteRuntimeSharedControlConnectionNowMock,
   closeRemoteRuntimeRequestConnectionMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
@@ -38,6 +39,7 @@ const {
   getRemoteRuntimeSharedControlDiagnosticsMock: vi.fn(),
   reconnectRemoteRuntimeSharedControlConnectionMock: vi.fn(),
   retryRemoteRuntimeSharedControlConnectionsNowMock: vi.fn(),
+  retryRemoteRuntimeSharedControlConnectionNowMock: vi.fn(),
   closeRemoteRuntimeRequestConnectionMock: vi.fn()
 }))
 
@@ -63,6 +65,9 @@ vi.mock('./runtime-environment-request-connections', () => ({
   getRemoteRuntimeSharedControlDiagnostics: getRemoteRuntimeSharedControlDiagnosticsMock,
   reconnectRemoteRuntimeSharedControlConnection: reconnectRemoteRuntimeSharedControlConnectionMock,
   retryRemoteRuntimeSharedControlConnectionsNow: retryRemoteRuntimeSharedControlConnectionsNowMock,
+  retryRemoteRuntimeSharedControlConnectionNow: retryRemoteRuntimeSharedControlConnectionNowMock,
+  ensureRemoteRuntimeSharedControlConnection: vi.fn(),
+  pauseRemoteRuntimeSharedControlRetry: vi.fn(),
   closeRemoteRuntimeRequestConnection: closeRemoteRuntimeRequestConnectionMock
 }))
 
@@ -115,6 +120,7 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     getRemoteRuntimeSharedControlDiagnosticsMock.mockReturnValue(null)
     reconnectRemoteRuntimeSharedControlConnectionMock.mockReset()
     retryRemoteRuntimeSharedControlConnectionsNowMock.mockReset()
+    retryRemoteRuntimeSharedControlConnectionNowMock.mockReset()
     closeRemoteRuntimeRequestConnectionMock.mockReset()
   })
 
@@ -133,6 +139,7 @@ describe('registerRuntimeEnvironmentHandlers', () => {
       'runtimeEnvironments:remove',
       'runtimeEnvironments:disconnect',
       'runtimeEnvironments:connect',
+      'runtimeEnvironments:retryControlConnection',
       'runtimeEnvironments:prepareBrowserClientHostPlacement',
       'runtimeEnvironments:retryConnectionsNow',
       'runtimeEnvironments:getStatus',
@@ -156,6 +163,7 @@ describe('registerRuntimeEnvironmentHandlers', () => {
       'runtimeEnvironments:remove',
       'runtimeEnvironments:disconnect',
       'runtimeEnvironments:connect',
+      'runtimeEnvironments:retryControlConnection',
       'runtimeEnvironments:prepareBrowserClientHostPlacement',
       'runtimeEnvironments:getStatus',
       'runtimeEnvironments:call',
@@ -173,6 +181,29 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     await retryConnectionsNow(null, undefined)
 
     expect(retryRemoteRuntimeSharedControlConnectionsNowMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries one control connection without reversing manual disconnect intent', async () => {
+    registerRuntimeEnvironmentHandlers(store as never)
+    const add = handler<{ name: string; pairingCode: string }, { environment: { id: string } }>(
+      'runtimeEnvironments:addFromPairingCode'
+    )
+    const added = await add(null, { name: 'desk', pairingCode: pairingCode() })
+    const retry = handler<{ selector: string }, void>('runtimeEnvironments:retryControlConnection')
+
+    await retry(null, { selector: 'desk' })
+    expect(retryRemoteRuntimeSharedControlConnectionNowMock).toHaveBeenCalledWith(
+      added.environment.id
+    )
+    expect(sendRemoteRuntimeRequestMock).not.toHaveBeenCalled()
+
+    const disconnect = handler<{ selector: string }, unknown>('runtimeEnvironments:disconnect')
+    await disconnect(null, { selector: 'desk' })
+    retryRemoteRuntimeSharedControlConnectionNowMock.mockClear()
+    await retry(null, { selector: 'desk' })
+
+    expect(retryRemoteRuntimeSharedControlConnectionNowMock).not.toHaveBeenCalled()
+    expect(sendRemoteRuntimeRequestMock).not.toHaveBeenCalled()
   })
 
   it('stores, resolves, lists, and removes environments under Electron userData', async () => {

--- a/src/main/ipc/runtime-environments-status-diagnostics.test.ts
+++ b/src/main/ipc/runtime-environments-status-diagnostics.test.ts
@@ -2,7 +2,10 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ELECTRON_REMOTE_RUNTIME_CLIENT_CAPABILITIES } from '../../shared/protocol-version'
+import {
+  ELECTRON_REMOTE_RUNTIME_CLIENT_CAPABILITIES,
+  REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY
+} from '../../shared/protocol-version'
 
 const {
   handleMock,
@@ -17,6 +20,8 @@ const {
   subscribeRemoteRuntimeSharedControlRequestMock,
   getRemoteRuntimeSharedControlDiagnosticsMock,
   reconnectRemoteRuntimeSharedControlConnectionMock,
+  ensureRemoteRuntimeSharedControlConnectionMock,
+  pauseRemoteRuntimeSharedControlRetryMock,
   retryRemoteRuntimeSharedControlConnectionsNowMock,
   closeRemoteRuntimeRequestConnectionMock
 } = vi.hoisted(() => ({
@@ -32,6 +37,8 @@ const {
   subscribeRemoteRuntimeSharedControlRequestMock: vi.fn(),
   getRemoteRuntimeSharedControlDiagnosticsMock: vi.fn(),
   reconnectRemoteRuntimeSharedControlConnectionMock: vi.fn(),
+  ensureRemoteRuntimeSharedControlConnectionMock: vi.fn(),
+  pauseRemoteRuntimeSharedControlRetryMock: vi.fn(),
   retryRemoteRuntimeSharedControlConnectionsNowMock: vi.fn(),
   closeRemoteRuntimeRequestConnectionMock: vi.fn()
 }))
@@ -58,6 +65,9 @@ vi.mock('./runtime-environment-request-connections', () => ({
   getRemoteRuntimeSharedControlDiagnostics: getRemoteRuntimeSharedControlDiagnosticsMock,
   reconnectRemoteRuntimeSharedControlConnection: reconnectRemoteRuntimeSharedControlConnectionMock,
   retryRemoteRuntimeSharedControlConnectionsNow: retryRemoteRuntimeSharedControlConnectionsNowMock,
+  retryRemoteRuntimeSharedControlConnectionNow: vi.fn(),
+  ensureRemoteRuntimeSharedControlConnection: ensureRemoteRuntimeSharedControlConnectionMock,
+  pauseRemoteRuntimeSharedControlRetry: pauseRemoteRuntimeSharedControlRetryMock,
   closeRemoteRuntimeRequestConnection: closeRemoteRuntimeRequestConnectionMock
 }))
 
@@ -97,6 +107,8 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     getRemoteRuntimeSharedControlDiagnosticsMock.mockReset()
     getRemoteRuntimeSharedControlDiagnosticsMock.mockReturnValue(null)
     reconnectRemoteRuntimeSharedControlConnectionMock.mockReset()
+    ensureRemoteRuntimeSharedControlConnectionMock.mockReset()
+    pauseRemoteRuntimeSharedControlRetryMock.mockReset()
     retryRemoteRuntimeSharedControlConnectionsNowMock.mockReset()
     closeRemoteRuntimeRequestConnectionMock.mockReset()
   })
@@ -110,7 +122,11 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     sendRemoteRuntimeRequestMock.mockResolvedValue({
       id: 'rpc-1',
       ok: true,
-      result: { runtimeId: 'runtime-remote', graphStatus: 'ready' },
+      result: {
+        runtimeId: 'runtime-remote',
+        graphStatus: 'ready',
+        capabilities: [REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY]
+      },
       _meta: { runtimeId: 'runtime-remote' }
     })
 
@@ -140,6 +156,10 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     expect(reconnectRemoteRuntimeSharedControlConnectionMock).toHaveBeenCalledWith(
       added.environment.id
     )
+    expect(ensureRemoteRuntimeSharedControlConnectionMock).toHaveBeenCalledWith(
+      added.environment.id,
+      expect.objectContaining({ endpoint: 'ws://127.0.0.1:6768' })
+    )
 
     const resolve = handler<{ selector: string }, { id: string; runtimeId: string | null }>(
       'runtimeEnvironments:resolve'
@@ -148,6 +168,77 @@ describe('registerRuntimeEnvironmentHandlers', () => {
       id: added.environment.id,
       runtimeId: 'runtime-remote'
     })
+  })
+
+  it('observes diagnostics without ensuring, refreshing, or marking the environment used', async () => {
+    registerRuntimeEnvironmentHandlers(store as never)
+    getRemoteRuntimeSharedControlDiagnosticsMock.mockReturnValue({
+      state: 'reconnecting',
+      pendingRequestCount: 0,
+      subscriptionCount: 0,
+      reconnectAttempt: 2,
+      lastConnectedAt: null,
+      lastClose: null,
+      lastError: 'offline'
+    })
+    sendRemoteRuntimeRequestMock.mockResolvedValue({
+      id: 'status',
+      ok: true,
+      result: {
+        runtimeId: 'runtime-remote',
+        graphStatus: 'ready',
+        capabilities: [REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY]
+      },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const add = handler<{ name: string; pairingCode: string }, { environment: { id: string } }>(
+      'runtimeEnvironments:addFromPairingCode'
+    )
+    const added = await add(null, { name: 'desk', pairingCode: pairingCode() })
+    const getStatus = handler<
+      { selector: string; observeOnly?: true },
+      { ok: true; result: { remoteControl: { state: string } } }
+    >('runtimeEnvironments:getStatus')
+
+    await expect(getStatus(null, { selector: 'desk', observeOnly: true })).resolves.toMatchObject({
+      result: { remoteControl: { state: 'reconnecting' } }
+    })
+    expect(ensureRemoteRuntimeSharedControlConnectionMock).not.toHaveBeenCalled()
+    expect(reconnectRemoteRuntimeSharedControlConnectionMock).not.toHaveBeenCalled()
+    const resolve = handler<{ selector: string }, { runtimeId: string | null }>(
+      'runtimeEnvironments:resolve'
+    )
+    expect((await resolve(null, { selector: added.environment.id })).runtimeId).toBeNull()
+  })
+
+  it('strips diagnostics from successful capability-less status results', async () => {
+    registerRuntimeEnvironmentHandlers(store as never)
+    getRemoteRuntimeSharedControlDiagnosticsMock.mockReturnValue({
+      state: 'reconnecting',
+      pendingRequestCount: 0,
+      subscriptionCount: 0,
+      reconnectAttempt: 1,
+      lastConnectedAt: null,
+      lastClose: null,
+      lastError: null
+    })
+    sendRemoteRuntimeRequestMock.mockResolvedValue({
+      id: 'status',
+      ok: true,
+      result: { runtimeId: 'runtime-legacy', graphStatus: 'ready', capabilities: [] },
+      _meta: { runtimeId: 'runtime-legacy' }
+    })
+    const add = handler<{ name: string; pairingCode: string }, unknown>(
+      'runtimeEnvironments:addFromPairingCode'
+    )
+    await add(null, { name: 'desk', pairingCode: pairingCode() })
+    const getStatus = handler<{ selector: string }, { result: { remoteControl?: unknown } }>(
+      'runtimeEnvironments:getStatus'
+    )
+
+    const result = await getStatus(null, { selector: 'desk' })
+    expect(result.result.remoteControl).toBeUndefined()
+    expect(pauseRemoteRuntimeSharedControlRetryMock).toHaveBeenCalledOnce()
   })
 
   it('attaches shared-control diagnostics to saved remote runtime status', async () => {
@@ -164,7 +255,11 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     sendRemoteRuntimeRequestMock.mockResolvedValue({
       id: 'rpc-status',
       ok: true,
-      result: { runtimeId: 'runtime-remote', graphStatus: 'ready' },
+      result: {
+        runtimeId: 'runtime-remote',
+        graphStatus: 'ready',
+        capabilities: [REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY]
+      },
       _meta: { runtimeId: 'runtime-remote' }
     })
 

--- a/src/main/ipc/runtime-environments-subscription-lifecycle.test.ts
+++ b/src/main/ipc/runtime-environments-subscription-lifecycle.test.ts
@@ -59,6 +59,9 @@ vi.mock('./runtime-environment-request-connections', () => ({
   getRemoteRuntimeSharedControlDiagnostics: getRemoteRuntimeSharedControlDiagnosticsMock,
   reconnectRemoteRuntimeSharedControlConnection: reconnectRemoteRuntimeSharedControlConnectionMock,
   retryRemoteRuntimeSharedControlConnectionsNow: retryRemoteRuntimeSharedControlConnectionsNowMock,
+  retryRemoteRuntimeSharedControlConnectionNow: vi.fn(),
+  ensureRemoteRuntimeSharedControlConnection: vi.fn(),
+  pauseRemoteRuntimeSharedControlRetry: vi.fn(),
   closeRemoteRuntimeRequestConnection: closeRemoteRuntimeRequestConnectionMock
 }))
 

--- a/src/main/ipc/runtime-environments-subscription-routing.test.ts
+++ b/src/main/ipc/runtime-environments-subscription-routing.test.ts
@@ -61,6 +61,9 @@ vi.mock('./runtime-environment-request-connections', () => ({
   getRemoteRuntimeSharedControlDiagnostics: getRemoteRuntimeSharedControlDiagnosticsMock,
   reconnectRemoteRuntimeSharedControlConnection: reconnectRemoteRuntimeSharedControlConnectionMock,
   retryRemoteRuntimeSharedControlConnectionsNow: retryRemoteRuntimeSharedControlConnectionsNowMock,
+  retryRemoteRuntimeSharedControlConnectionNow: vi.fn(),
+  ensureRemoteRuntimeSharedControlConnection: vi.fn(),
+  pauseRemoteRuntimeSharedControlRetry: vi.fn(),
   closeRemoteRuntimeRequestConnection: closeRemoteRuntimeRequestConnectionMock
 }))
 

--- a/src/main/ipc/runtime-environments-subscription-teardown.test.ts
+++ b/src/main/ipc/runtime-environments-subscription-teardown.test.ts
@@ -59,6 +59,9 @@ vi.mock('./runtime-environment-request-connections', () => ({
   getRemoteRuntimeSharedControlDiagnostics: getRemoteRuntimeSharedControlDiagnosticsMock,
   reconnectRemoteRuntimeSharedControlConnection: reconnectRemoteRuntimeSharedControlConnectionMock,
   retryRemoteRuntimeSharedControlConnectionsNow: retryRemoteRuntimeSharedControlConnectionsNowMock,
+  retryRemoteRuntimeSharedControlConnectionNow: vi.fn(),
+  ensureRemoteRuntimeSharedControlConnection: vi.fn(),
+  pauseRemoteRuntimeSharedControlRetry: vi.fn(),
   closeRemoteRuntimeRequestConnection: closeRemoteRuntimeRequestConnectionMock
 }))
 vi.mock('../browser/paired-runtime-browser-client-host-runtime', () => ({

--- a/src/main/ipc/runtime-environments.ts
+++ b/src/main/ipc/runtime-environments.ts
@@ -22,6 +22,7 @@ import {
 import { RUNTIME_ENVIRONMENT_HANDLER_CHANNELS } from './runtime-environment-handler-channels'
 import { retirePairedRuntimeBrowserClientHostEnvironment } from '../browser/paired-runtime-browser-client-host-runtime'
 import { registerRuntimeEnvironmentBrowserClientHostHandler } from './runtime-environment-browser-client-host-handler'
+import { advanceRuntimeEnvironmentCapabilityIncarnation } from './runtime-environment-capability-evidence'
 
 type RetainedRemoteRuntimeSubscription = RemoteRuntimeSubscription & {
   environmentId: string
@@ -60,6 +61,7 @@ function closeSubscriptionsForEnvironment(environmentId: string): void {
 /** Returns once the environment's client-hosted browser pages have been released. */
 export function invalidateRuntimeEnvironmentTransport(environmentId: string): Promise<void> {
   // Why: a same-id re-pair must retire every transport that still authenticates as the old peer.
+  advanceRuntimeEnvironmentCapabilityIncarnation(environmentId)
   advanceRuntimeEnvironmentTransportGeneration(environmentId)
   closeRemoteRuntimeRequestConnection(environmentId)
   clearSharedControlSupport(environmentId)
@@ -196,7 +198,8 @@ export function registerRuntimeEnvironmentHandlers(store: Store): void {
               retained?.removeDestroyedListener()
               remoteRuntimeSubscriptions.delete(subscriptionId)
             }
-          }
+          },
+          transportIsCurrent
         )
       } catch (error) {
         removeDestroyedListener()

--- a/src/preload/api/runtime-api.ts
+++ b/src/preload/api/runtime-api.ts
@@ -98,7 +98,9 @@ export type RuntimeApi = {
     getStatus: (args: {
       selector: string
       timeoutMs?: number
+      observeOnly?: true
     }) => Promise<RuntimeRpcResponse<RuntimeStatus>>
+    retryControlConnection?: (args: { selector: string }) => Promise<void>
     prepareBrowserClientHostPlacement: (
       args: BrowserClientHostPlacementPreparationRequest
     ) => Promise<BrowserPageCreationPlacement>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4802,8 +4802,11 @@ const api = {
     getStatus: (args: {
       selector: string
       timeoutMs?: number
+      observeOnly?: true
     }): Promise<RuntimeRpcResponse<RuntimeStatus>> =>
       ipcRenderer.invoke('runtimeEnvironments:getStatus', args),
+    retryControlConnection: (args: { selector: string }): Promise<void> =>
+      ipcRenderer.invoke('runtimeEnvironments:retryControlConnection', args),
     prepareBrowserClientHostPlacement: (args) =>
       ipcRenderer.invoke('runtimeEnvironments:prepareBrowserClientHostPlacement', args),
     retryConnectionsNow: (): Promise<void> =>

--- a/src/renderer/src/components/status-bar/remote-host-connection-status.test.ts
+++ b/src/renderer/src/components/status-bar/remote-host-connection-status.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import type { RemoteRuntimeSharedConnectionDiagnostics } from '../../../../shared/remote-runtime-shared-control-types'
+import { runtimeHostConnectionDetail } from './remote-host-connection-status'
+
+describe('runtimeHostConnectionDetail', () => {
+  it('suppresses stale failures while a handshake is in flight', () => {
+    expect(runtimeHostConnectionDetail(diagnostics('awaiting_ready', 0, 'old failure'))).toBe(
+      undefined
+    )
+    expect(
+      runtimeHostConnectionDetail(diagnostics('awaiting_authenticated', 0, 'old failure'))
+    ).toBe(undefined)
+  })
+
+  it('shows the upcoming reconnect attempt ahead of stale failures', () => {
+    expect(runtimeHostConnectionDetail(diagnostics('reconnecting', 1, 'old failure'))).toBe(
+      'Attempt 2'
+    )
+    expect(runtimeHostConnectionDetail(diagnostics('reconnecting', 2, 'old failure'))).toBe(
+      'Attempt 3'
+    )
+  })
+
+  it('keeps settled connection errors visible', () => {
+    expect(runtimeHostConnectionDetail(diagnostics('closed', 0, 'socket closed'))).toBe(
+      'socket closed'
+    )
+  })
+})
+
+function diagnostics(
+  state: RemoteRuntimeSharedConnectionDiagnostics['state'],
+  reconnectAttempt: number,
+  lastError: string | null
+): RemoteRuntimeSharedConnectionDiagnostics {
+  return {
+    state,
+    reconnectAttempt,
+    lastError,
+    pendingRequestCount: 0,
+    subscriptionCount: 0,
+    lastConnectedAt: null,
+    lastClose: null
+  }
+}

--- a/src/renderer/src/components/status-bar/remote-host-connection-status.ts
+++ b/src/renderer/src/components/status-bar/remote-host-connection-status.ts
@@ -51,6 +51,19 @@ export function runtimeHostConnectionDetail(
   if (!remoteControl) {
     return undefined
   }
+  if (
+    remoteControl.state === 'awaiting_ready' ||
+    remoteControl.state === 'awaiting_authenticated'
+  ) {
+    return undefined
+  }
+  if (remoteControl.state === 'reconnecting') {
+    return translate(
+      'auto.components.status.bar.SshStatusSegment.runtime_reconnect_attempt',
+      'Attempt {{value0}}',
+      { value0: String(remoteControl.reconnectAttempt + 1) }
+    )
+  }
   if (remoteControl.lastError) {
     return remoteControl.lastError
   }
@@ -59,13 +72,6 @@ export function runtimeHostConnectionDetail(
       'auto.components.status.bar.SshStatusSegment.runtime_last_close_reason',
       'Closed: {{value0}}',
       { value0: remoteControl.lastClose.reason }
-    )
-  }
-  if (remoteControl.state === 'reconnecting') {
-    return translate(
-      'auto.components.status.bar.SshStatusSegment.runtime_reconnect_attempt',
-      'Attempt {{value0}}',
-      { value0: String(remoteControl.reconnectAttempt + 1) }
     )
   }
   // Why: pending-request / subscription counts are internal RPC plumbing (e.g. a

--- a/src/renderer/src/store/slices/runtime-status-recheck.test.ts
+++ b/src/renderer/src/store/slices/runtime-status-recheck.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { create } from 'zustand'
+import { toast } from 'sonner'
+import { REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY } from '../../../../shared/protocol-version'
+import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
+import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import {
+  clearRuntimeEnvironmentConnectionGenerationsForTests,
+  createRuntimeStatusSlice,
+  setRuntimeEnvironmentConnectionGenerationForTests,
+  type RuntimeStatusSlice
+} from './runtime-status'
+import { clearRuntimeStatusRechecksForTests } from './runtime-status-recheck'
+
+vi.mock('sonner', () => ({ toast: { warning: vi.fn(), dismiss: vi.fn() } }))
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  clearRuntimeStatusRechecksForTests()
+  clearRuntimeEnvironmentConnectionGenerationsForTests()
+  vi.mocked(toast.warning).mockReset()
+})
+
+afterEach(() => {
+  clearRuntimeStatusRechecksForTests()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('runtime status recheck', () => {
+  it('publishes an observe-only ready result through the setter', async () => {
+    const getStatus = vi.fn().mockResolvedValue(response(status('ready')))
+    const store = createStore(getStatus)
+
+    store.getState().setRuntimeEnvironmentStatus('env-a', {
+      status: status('awaiting_ready'),
+      checkedAt: 1
+    })
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect(getStatus).toHaveBeenCalledWith({
+      selector: 'env-a',
+      timeoutMs: 10_000,
+      observeOnly: true
+    })
+    expect(
+      store.getState().runtimeStatusByEnvironmentId.get('env-a')?.status?.remoteControl
+    ).toMatchObject({
+      state: 'ready'
+    })
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(getStatus).toHaveBeenCalledOnce()
+  })
+
+  it('continues indefinitely on the capped ladder, including unchanged publishes', async () => {
+    const getStatus = vi.fn().mockResolvedValue(response(status('reconnecting')))
+    const store = createStore(getStatus)
+    store.getState().setRuntimeEnvironmentStatus('env-a', {
+      status: status('reconnecting'),
+      checkedAt: 1
+    })
+
+    await vi.advanceTimersByTimeAsync(3_000 + 6_000 + 12_000 + 30_000 + 60_000 + 60_000)
+
+    expect(getStatus).toHaveBeenCalledTimes(6)
+    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.checkedAt).toBe(1)
+  })
+
+  it('cancels on removal, capability loss, and null without probing again', async () => {
+    const getStatus = vi.fn()
+    const store = createStore(getStatus)
+    store.getState().setRuntimeEnvironmentStatus('env-a', {
+      status: status('awaiting_authenticated'),
+      checkedAt: 1
+    })
+    store.getState().setRuntimeEnvironmentStatus('env-a', {
+      status: { ...status('awaiting_authenticated'), capabilities: [] },
+      checkedAt: 2
+    })
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(getStatus).not.toHaveBeenCalled()
+
+    store.getState().setRuntimeEnvironmentStatus('env-a', {
+      status: status('awaiting_ready'),
+      checkedAt: 3
+    })
+    store.getState().setRuntimeEnvironments([])
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(getStatus).not.toHaveBeenCalled()
+  })
+
+  it('cancels an armed probe when the connection generation changes', async () => {
+    const getStatus = vi.fn()
+    const store = createStore(getStatus)
+    store.getState().setRuntimeEnvironmentStatus('env-a', {
+      status: status('awaiting_ready'),
+      checkedAt: 1
+    })
+
+    setRuntimeEnvironmentConnectionGenerationForTests('env-a', 2)
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect(getStatus).not.toHaveBeenCalled()
+  })
+
+  it('restarts the ladder for a newly published connection generation', async () => {
+    const getStatus = vi.fn().mockResolvedValue(response(status('ready', 'rt-next')))
+    const store = createStore(getStatus)
+    store.getState().setRuntimeEnvironmentStatus('env-a', {
+      status: status('awaiting_ready'),
+      checkedAt: 1
+    })
+    store.getState().setRuntimeEnvironmentStatus('env-a', {
+      status: status('awaiting_ready', 'rt-next'),
+      checkedAt: 2
+    })
+
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect(getStatus).toHaveBeenCalledOnce()
+    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.status?.runtimeId).toBe(
+      'rt-next'
+    )
+  })
+
+  it('discards an in-flight result after a ready publish bumps the epoch', async () => {
+    const pending = deferred<ReturnType<typeof response>>()
+    const getStatus = vi.fn().mockReturnValue(pending.promise)
+    const store = createStore(getStatus)
+    store.getState().setRuntimeEnvironmentStatus('env-a', {
+      status: status('awaiting_ready'),
+      checkedAt: 1
+    })
+    await vi.advanceTimersByTimeAsync(3_000)
+    store.getState().setRuntimeEnvironmentStatus('env-a', {
+      status: status('ready'),
+      checkedAt: 2
+    })
+
+    pending.resolve(response(status('reconnecting')))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(
+      store.getState().runtimeStatusByEnvironmentId.get('env-a')?.status?.remoteControl
+    ).toMatchObject({
+      state: 'ready'
+    })
+  })
+
+  it('keeps setter side effects when a recheck discovers disconnection', async () => {
+    const getStatus = vi.fn().mockResolvedValue({
+      id: 'status.get',
+      ok: false,
+      error: { code: 'runtime_unavailable', message: 'offline' },
+      _meta: { runtimeId: 'rt' }
+    })
+    const store = createStore(getStatus)
+    store.getState().setRuntimeEnvironmentStatus('env-a', {
+      status: status('awaiting_ready'),
+      checkedAt: 1
+    })
+
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.status).toBeNull()
+    expect(toast.warning).toHaveBeenCalledOnce()
+  })
+})
+
+function createStore(getStatus: ReturnType<typeof vi.fn>) {
+  vi.stubGlobal('window', {
+    api: { runtimeEnvironments: { getStatus, list: vi.fn() } }
+  })
+  const store = create<RuntimeStatusSlice>()((...args) => ({
+    ...createRuntimeStatusSlice(...(args as unknown as Parameters<typeof createRuntimeStatusSlice>))
+  }))
+  store.getState().setRuntimeEnvironments([environment()])
+  return store
+}
+
+function status(
+  controlState: NonNullable<RuntimeStatus['remoteControl']>['state'],
+  runtimeId = 'rt'
+): RuntimeStatus {
+  return {
+    runtimeId,
+    rendererGraphEpoch: 1,
+    graphStatus: 'ready',
+    authoritativeWindowId: null,
+    liveTabCount: 0,
+    liveLeafCount: 0,
+    capabilities: [REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY],
+    remoteControl: {
+      state: controlState,
+      pendingRequestCount: 0,
+      subscriptionCount: 0,
+      reconnectAttempt: 1,
+      lastConnectedAt: null,
+      lastClose: null,
+      lastError: null
+    }
+  } as RuntimeStatus
+}
+
+function response(result: RuntimeStatus) {
+  return { id: 'status.get', ok: true as const, result, _meta: { runtimeId: result.runtimeId } }
+}
+
+function environment(): PublicKnownRuntimeEnvironment {
+  return {
+    id: 'env-a',
+    name: 'Dev Box',
+    createdAt: 1,
+    updatedAt: 1,
+    lastUsedAt: null,
+    runtimeId: 'rt',
+    endpoints: [{ id: 'ws', kind: 'websocket', label: 'WebSocket', endpoint: 'ws://x' }],
+    preferredEndpointId: 'ws'
+  }
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {}
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}

--- a/src/renderer/src/store/slices/runtime-status-recheck.ts
+++ b/src/renderer/src/store/slices/runtime-status-recheck.ts
@@ -1,0 +1,138 @@
+import { REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY } from '../../../../shared/protocol-version'
+import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import { unwrapRuntimeRpcResult } from '@/runtime/runtime-rpc-client'
+
+const RECHECK_DELAYS_MS = [3_000, 6_000, 12_000, 30_000, 60_000]
+
+type RecheckState = {
+  epoch: number
+  attempt: number
+  timer: ReturnType<typeof setTimeout> | null
+  inFlight: boolean
+  connectionGeneration: number
+  environmentExists: () => boolean
+  getConnectionGeneration: () => number
+  publish: (status: RuntimeStatus | null) => void
+}
+
+const rechecks = new Map<string, RecheckState>()
+
+export function reconcileRuntimeStatusRecheck(args: {
+  environmentId: string
+  status: RuntimeStatus | null
+  connectionGeneration: number
+  environmentExists: () => boolean
+  getConnectionGeneration: () => number
+  publish: (status: RuntimeStatus | null) => void
+}): void {
+  if (!shouldRecheck(args.status)) {
+    cancelRuntimeStatusRecheck(args.environmentId)
+    return
+  }
+  let state = rechecks.get(args.environmentId)
+  if (state && state.connectionGeneration !== args.connectionGeneration) {
+    cancelRuntimeStatusRecheck(args.environmentId)
+    state = undefined
+  }
+  if (!state) {
+    state = {
+      epoch: 0,
+      attempt: 0,
+      timer: null,
+      inFlight: false,
+      connectionGeneration: args.connectionGeneration,
+      environmentExists: args.environmentExists,
+      getConnectionGeneration: args.getConnectionGeneration,
+      publish: args.publish
+    }
+    rechecks.set(args.environmentId, state)
+  } else {
+    state.connectionGeneration = args.connectionGeneration
+    state.environmentExists = args.environmentExists
+    state.getConnectionGeneration = args.getConnectionGeneration
+    state.publish = args.publish
+  }
+  armRuntimeStatusRecheck(args.environmentId, state)
+}
+
+export function cancelRuntimeStatusRecheck(environmentId: string): void {
+  const state = rechecks.get(environmentId)
+  if (!state) {
+    return
+  }
+  state.epoch += 1
+  if (state.timer) {
+    clearTimeout(state.timer)
+  }
+  rechecks.delete(environmentId)
+}
+
+export function cancelRuntimeStatusRechecks(environmentIds: Iterable<string>): void {
+  for (const environmentId of environmentIds) {
+    cancelRuntimeStatusRecheck(environmentId)
+  }
+}
+
+export function clearRuntimeStatusRechecksForTests(): void {
+  cancelRuntimeStatusRechecks([...rechecks.keys()])
+}
+
+function shouldRecheck(status: RuntimeStatus | null): boolean {
+  return Boolean(
+    status?.capabilities?.includes(REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY) &&
+    status.remoteControl &&
+    status.remoteControl.state !== 'ready'
+  )
+}
+
+function armRuntimeStatusRecheck(environmentId: string, state: RecheckState): void {
+  if (state.timer || state.inFlight) {
+    return
+  }
+  const delay = RECHECK_DELAYS_MS[Math.min(state.attempt, RECHECK_DELAYS_MS.length - 1)]
+  const generation = state.connectionGeneration
+  state.attempt += 1
+  state.timer = setTimeout(
+    () => void fireRuntimeStatusRecheck(environmentId, state, generation),
+    delay
+  )
+}
+
+async function fireRuntimeStatusRecheck(
+  environmentId: string,
+  state: RecheckState,
+  generation: number
+): Promise<void> {
+  state.timer = null
+  const epoch = state.epoch
+  if (
+    rechecks.get(environmentId) !== state ||
+    !state.environmentExists() ||
+    state.getConnectionGeneration() !== generation
+  ) {
+    cancelRuntimeStatusRecheck(environmentId)
+    return
+  }
+  state.inFlight = true
+  let status: RuntimeStatus | null = null
+  try {
+    const response = await window.api.runtimeEnvironments.getStatus({
+      selector: environmentId,
+      timeoutMs: 10_000,
+      observeOnly: true
+    })
+    status = unwrapRuntimeRpcResult<RuntimeStatus>(response)
+  } catch {
+    status = null
+  }
+  state.inFlight = false
+  if (
+    rechecks.get(environmentId) !== state ||
+    state.epoch !== epoch ||
+    !state.environmentExists() ||
+    state.getConnectionGeneration() !== generation
+  ) {
+    return
+  }
+  state.publish(status)
+}

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -21,6 +21,7 @@ import {
   ensureBrowserClientHostForRestartedRuntime,
   ensureBrowserClientHostsForRestoredPages
 } from '@/runtime/restored-client-hosted-browser-host-attach'
+import * as runtimeStatusRecheck from './runtime-status-recheck'
 
 /** Live status for one saved runtime environment, as last observed by the
  * renderer. `status === null` records a probe that failed or timed out so the
@@ -97,8 +98,10 @@ export function getRuntimeEnvironmentConnectionGeneration(environmentId: string)
   return connectionGenerationByEnvironment.get(environmentId) ?? 0
 }
 
-export const clearRuntimeEnvironmentConnectionGenerationsForTests = (): void =>
+export const clearRuntimeEnvironmentConnectionGenerationsForTests = (): void => {
+  runtimeStatusRecheck.cancelRuntimeStatusRechecks(connectionGenerationByEnvironment.keys())
   connectionGenerationByEnvironment.clear()
+}
 
 export const setRuntimeEnvironmentConnectionGenerationForTests = (
   environmentId: string,
@@ -147,6 +150,7 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
     const removedIds = get()
       .runtimeEnvironments.map((environment) => environment.id)
       .filter((id) => !nextIds.has(id))
+    runtimeStatusRecheck.cancelRuntimeStatusRechecks([...removedIds, ...replacedEnvironmentIds])
     set((s) => {
       const keep = new Set(environments.map((environment) => environment.id))
       const nextStatuses = new Map(s.runtimeStatusByEnvironmentId)
@@ -283,6 +287,19 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
         ...(environmentsChanged ? { runtimeEnvironments } : {})
       }
     })
+    runtimeStatusRecheck.reconcileRuntimeStatusRecheck({
+      environmentId,
+      status: status.status,
+      connectionGeneration: getRuntimeEnvironmentConnectionGeneration(environmentId),
+      environmentExists: () =>
+        get().runtimeEnvironments.some((environment) => environment.id === environmentId),
+      getConnectionGeneration: () => getRuntimeEnvironmentConnectionGeneration(environmentId),
+      publish: (nextStatus) =>
+        get().setRuntimeEnvironmentStatus(environmentId, {
+          status: nextStatus,
+          checkedAt: Date.now()
+        })
+    })
     if (runtimeRestarted) {
       void ensureBrowserClientHostForRestartedRuntime(get(), environmentId)
     }
@@ -296,6 +313,7 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
   },
 
   clearRuntimeEnvironmentStatus: (environmentId) => {
+    runtimeStatusRecheck.cancelRuntimeStatusRecheck(environmentId)
     dismissRuntimeDisconnectedToast(environmentId)
     set((s) => {
       advanceRuntimeEnvironmentConnectionGeneration(environmentId)
@@ -312,6 +330,7 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
     const keep = new Set(environmentIds)
     for (const id of get().runtimeStatusByEnvironmentId.keys()) {
       if (!keep.has(id)) {
+        runtimeStatusRecheck.cancelRuntimeStatusRecheck(id)
         dismissRuntimeDisconnectedToast(id)
       }
     }

--- a/src/renderer/src/web/preload-api/web-runtime-environments-api.ts
+++ b/src/renderer/src/web/preload-api/web-runtime-environments-api.ts
@@ -182,6 +182,7 @@ export function createRuntimeEnvironmentsApi(): NonNullable<
     },
     getStatus: ({ selector, timeoutMs }) =>
       callEnvironmentEnvelope<RuntimeStatus>(selector, 'status.get', undefined, timeoutMs),
+    retryControlConnection: () => Promise.resolve(),
     prepareBrowserClientHostPlacement: async () => ({ kind: 'server' }),
     call: ({ selector, method, params, timeoutMs }) =>
       callEnvironmentEnvelope(selector, method, params, timeoutMs),

--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -1,16 +1,5 @@
 import path from 'node:path'
-import type { AddressInfo } from 'node:net'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { WebSocketServer, type WebSocket } from 'ws'
-import {
-  decrypt,
-  deriveSharedKey,
-  encrypt,
-  generateKeyPair,
-  publicKeyFromBase64,
-  publicKeyToBase64
-} from './e2ee-crypto'
-import { encodePairingOffer, parsePairingCode, type PairingOffer } from './pairing'
 import {
   REMOTE_RUNTIME_MAX_PENDING_RPC_BYTES,
   retainedRemoteRuntimeJsonStringBytes,
@@ -21,31 +10,14 @@ import { remoteRuntimeClientCapabilities } from './remote-runtime-client-capabil
 import { RemoteRuntimeSharedControlConnection } from './remote-runtime-shared-control-connection'
 import * as sharedControlProtocol from './remote-runtime-shared-control-protocol'
 import { isRuntimeSubscriptionReplayResponse } from './runtime-subscription-replay'
+import {
+  closeSharedControlTestServers,
+  createSharedControlTestServer as createServer
+} from './remote-runtime-shared-control-test-server'
 
 const TEST_PROJECT_PATH = path.join('tmp', 'project')
-type TestServer = {
-  pairing: PairingOffer
-  requests: { id: string; method: string; params?: unknown }[]
-  auths: unknown[]
-  connectionCount: () => number
-  flushDelayedResponses: () => void
-}
 
-const servers: WebSocketServer[] = []
-
-afterEach(async () => {
-  await Promise.all(
-    servers.splice(0).map(
-      (server) =>
-        new Promise<void>((resolve) => {
-          for (const client of server.clients) {
-            client.close()
-          }
-          server.close(() => resolve())
-        })
-    )
-  )
-})
+afterEach(closeSharedControlTestServers)
 
 describe('RemoteRuntimeSharedControlConnection', () => {
   it('routes multiple one-shot RPCs over one authenticated WebSocket', async () => {
@@ -695,7 +667,7 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     })
   })
 
-  it('rejects pending requests and records close diagnostics when the socket closes', async () => {
+  it('rejects pending requests and schedules standing recovery when the socket closes', async () => {
     const server = await createServer({ closeBeforeResponse: true })
     const connection = new RemoteRuntimeSharedControlConnection(server.pairing)
 
@@ -703,7 +675,7 @@ describe('RemoteRuntimeSharedControlConnection', () => {
       'Remote Orca runtime closed the connection'
     )
     expect(connection.getDiagnostics()).toMatchObject({
-      state: 'closed',
+      state: 'reconnecting',
       pendingRequestCount: 0,
       lastClose: { code: 4001, reason: 'test close' }
     })
@@ -711,207 +683,3 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     connection.close()
   })
 })
-
-async function createServer(
-  options: {
-    delaySubscriptionReady?: boolean
-    sendKeepaliveBeforeResponse?: boolean
-    keepaliveDelayMs?: number
-    responseDelayMs?: number
-    sendBinaryAfterAuth?: boolean
-    sendUnknownResponseBeforeResponse?: boolean
-    closeAfterFirstStreamingResponse?: boolean
-    closeBeforeResponse?: boolean
-    suppressReadyFrame?: boolean
-    suppressReadyFrameCount?: number
-    // Why: half-open simulation — the socket stays open but never answers
-    // protocol pings, like a wedged tunnel that swallows frames silently.
-    disableAutoPong?: boolean
-    delayedMethods?: string[]
-    silentMethods?: string[]
-  } = {}
-): Promise<TestServer> {
-  const serverKeyPair = generateKeyPair()
-  const requests: TestServer['requests'] = []
-  const auths: unknown[] = []
-  const delayedResponses: (() => void)[] = []
-  let connectionCount = 0
-  let closedAfterFirstStreamingResponse = false
-  const wss = new WebSocketServer({ port: 0, autoPong: options.disableAutoPong !== true })
-  servers.push(wss)
-
-  wss.on('connection', (ws) => {
-    connectionCount += 1
-    let sharedKey: Uint8Array | null = null
-    let authenticated = false
-    ws.on('message', (data, isBinary) => {
-      if (isBinary) {
-        return
-      }
-      const frame = data.toString()
-      if (!sharedKey) {
-        const hello = JSON.parse(frame) as { publicKeyB64: string }
-        sharedKey = deriveSharedKey(
-          serverKeyPair.secretKey,
-          publicKeyFromBase64(hello.publicKeyB64)
-        )
-        if (
-          options.suppressReadyFrame ||
-          connectionCount <= (options.suppressReadyFrameCount ?? 0)
-        ) {
-          return
-        }
-        ws.send(JSON.stringify({ type: 'e2ee_ready' }))
-        return
-      }
-      const plaintext = decrypt(frame, sharedKey)
-      if (!plaintext) {
-        return
-      }
-      if (!authenticated) {
-        auths.push(JSON.parse(plaintext))
-        authenticated = true
-        sendEncrypted(ws, sharedKey, { type: 'e2ee_authenticated' })
-        if (options.sendBinaryAfterAuth) {
-          ws.send(Buffer.from([1, 2, 3]), { binary: true })
-        }
-        return
-      }
-      handleRequest(
-        ws,
-        sharedKey,
-        requests,
-        JSON.parse(plaintext),
-        {
-          ...options,
-          closeAfterStreamingResponse: () => {
-            if (!options.closeAfterFirstStreamingResponse || closedAfterFirstStreamingResponse) {
-              return false
-            }
-            closedAfterFirstStreamingResponse = true
-            return true
-          }
-        },
-        delayedResponses
-      )
-    })
-  })
-
-  await new Promise<void>((resolve) => wss.once('listening', resolve))
-  const address = wss.address() as AddressInfo
-  const pairing = parsePairingCode(
-    encodePairingOffer({
-      v: 2,
-      endpoint: `ws://127.0.0.1:${address.port}`,
-      deviceToken: 'device-token',
-      publicKeyB64: publicKeyToBase64(serverKeyPair.publicKey)
-    })
-  )
-  if (!pairing) {
-    throw new Error('Failed to create test pairing')
-  }
-  return {
-    pairing,
-    requests,
-    auths,
-    connectionCount: () => connectionCount,
-    flushDelayedResponses: () => delayedResponses.splice(0).forEach((send) => send())
-  }
-}
-
-function handleRequest(
-  ws: WebSocket,
-  sharedKey: Uint8Array,
-  requests: TestServer['requests'],
-  request: { id: string; method: string; params?: unknown },
-  options: {
-    delaySubscriptionReady?: boolean
-    sendKeepaliveBeforeResponse?: boolean
-    keepaliveDelayMs?: number
-    responseDelayMs?: number
-    sendUnknownResponseBeforeResponse?: boolean
-    closeAfterStreamingResponse?: () => boolean
-    closeBeforeResponse?: boolean
-    delayedMethods?: string[]
-    silentMethods?: string[]
-  },
-  delayedResponses: (() => void)[]
-): void {
-  requests.push(request)
-  // Why: keepalives are armed by an unrelated long-poll and keep flowing even
-  // while a method is deliberately silent — emit them before the silent return.
-  if (options.sendKeepaliveBeforeResponse && options.keepaliveDelayMs !== undefined) {
-    const timer = setInterval(
-      () => sendEncrypted(ws, sharedKey, { _keepalive: true }),
-      options.keepaliveDelayMs
-    )
-    ws.once('close', () => clearInterval(timer))
-  }
-  if (options.silentMethods?.includes(request.method)) {
-    return
-  }
-  if (options.closeBeforeResponse) {
-    ws.close(4001, 'test close')
-    return
-  }
-  const streaming = isStreamingMethod(request.method)
-  const result = streaming
-    ? { type: 'ready', subscriptionId: `${request.method}:subscription` }
-    : { method: request.method }
-  const sendResponse = (): void => {
-    if (options.sendUnknownResponseBeforeResponse) {
-      sendEncrypted(ws, sharedKey, {
-        id: 'unknown-response-id',
-        ok: true,
-        result: { method: 'unknown' },
-        _meta: { runtimeId: 'runtime-test' }
-      })
-    }
-    sendEncrypted(ws, sharedKey, {
-      id: request.id,
-      ok: true,
-      result,
-      streaming: streaming ? true : undefined,
-      _meta: { runtimeId: 'runtime-test' }
-    })
-  }
-  const closeAfterResponse = streaming && options.closeAfterStreamingResponse?.() === true
-  // Delayed/periodic keepalives are handled by the interval above; here we only
-  // cover the immediate single-keepalive-before-response case.
-  if (options.sendKeepaliveBeforeResponse && options.keepaliveDelayMs === undefined) {
-    sendEncrypted(ws, sharedKey, { _keepalive: true })
-  }
-  if (options.delaySubscriptionReady && streaming) {
-    delayedResponses.push(sendResponse)
-    return
-  }
-  if (options.delayedMethods?.includes(request.method)) {
-    delayedResponses.push(sendResponse)
-    return
-  }
-  if (options.responseDelayMs !== undefined) {
-    setTimeout(() => {
-      sendResponse()
-      if (closeAfterResponse) {
-        setTimeout(() => ws.close(), 0)
-      }
-    }, options.responseDelayMs)
-    return
-  }
-  sendResponse()
-  if (closeAfterResponse) {
-    setTimeout(() => ws.close(), 0)
-  }
-}
-
-function isStreamingMethod(method: string): boolean {
-  return (
-    method.endsWith('.subscribe') ||
-    method === 'session.tabs.subscribeAll' ||
-    method === 'files.watch'
-  )
-}
-
-function sendEncrypted(ws: WebSocket, sharedKey: Uint8Array, message: unknown): void {
-  ws.send(encrypt(JSON.stringify(message), sharedKey))
-}

--- a/src/shared/remote-runtime-shared-control-connection.ts
+++ b/src/shared/remote-runtime-shared-control-connection.ts
@@ -1,4 +1,4 @@
-import WebSocket from 'ws'
+import type WebSocket from 'ws'
 import type { PairingOffer } from './pairing'
 import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
 import { remoteRuntimeClientCapabilities } from './remote-runtime-client-capabilities'
@@ -30,9 +30,11 @@ export class RemoteRuntimeSharedControlConnection {
   private readonly reconnect = new SharedControlReconnectScheduler()
   private readonly readyStableReset: SharedControlReadyStableResetTimer
   private intentionallyClosed = false
-  private lastConnectedAt: number | null = null
-  private lastClose: { code: number; reason: string } | null = null
-  private lastError: string | null = null
+  private readonly diag = {
+    lastConnectedAt: null as number | null,
+    lastClose: null as { code: number; reason: string } | null,
+    lastError: null as string | null
+  }
   private readonly pendingRequests = new Map<string, PendingRequest>()
   private readonly subscriptions = new Map<string, LogicalSubscription>()
   private readonly retiredRequestIds = new SharedControlRetiredRequestIds()
@@ -99,6 +101,12 @@ export class RemoteRuntimeSharedControlConnection {
 
   readonly retryNow = (): boolean => this.reconnect.retryNow()
 
+  pauseStandingRetry(): void {
+    if (this.subscriptions.size === 0) {
+      this.reconnect.clear()
+    }
+  }
+
   getDiagnostics(): SharedControlTypes.RemoteRuntimeSharedConnectionDiagnostics {
     return sharedControlState.buildSharedControlDiagnostics({
       state: this.state,
@@ -106,9 +114,7 @@ export class RemoteRuntimeSharedControlConnection {
       pendingRequestCount: this.pendingRequests.size,
       subscriptionCount: this.subscriptions.size,
       reconnectAttempt: this.reconnect.attemptCount,
-      lastConnectedAt: this.lastConnectedAt,
-      lastClose: this.lastClose,
-      lastError: this.lastError
+      diag: this.diag
     })
   }
 
@@ -134,15 +140,7 @@ export class RemoteRuntimeSharedControlConnection {
       readyWaiters: this.readyWaiters,
       timeoutMs,
       signal,
-      open: () => {
-        if (
-          !this.ws ||
-          this.ws.readyState === WebSocket.CLOSED ||
-          this.ws.readyState === WebSocket.CLOSING
-        ) {
-          this.open()
-        }
-      }
+      open: () => sharedControlReady.openIfSocketClosed(this.ws, () => this.open())
     })
   }
 
@@ -168,7 +166,7 @@ export class RemoteRuntimeSharedControlConnection {
       getCurrentSocket: () => this.ws,
       onClose: (close, error) => {
         if (this.socketGeneration.isCurrent(socketGeneration)) {
-          this.lastClose = close
+          this.diag.lastClose = close
         }
         this.handleSocketClosed(error, socketGeneration)
       },
@@ -210,11 +208,11 @@ export class RemoteRuntimeSharedControlConnection {
       handleSocketClosed: (error) => this.handleSocketClosed(error, socketGeneration),
       sendEncrypted: (payload) => this.sendEncrypted(payload),
       markReady: () => {
-        this.lastConnectedAt = Date.now()
+        this.diag.lastConnectedAt = Date.now()
         // Why cleared here: these describe the attempt that just succeeded's predecessor.
         // Left set, a recovered host reads "Connected" next to a stale failure forever.
-        this.lastError = null
-        this.lastClose = null
+        this.diag.lastError = null
+        this.diag.lastClose = null
         this.readyStableReset.schedule({
           getState: () => this.state,
           getSocket: () => this.ws,
@@ -267,7 +265,6 @@ export class RemoteRuntimeSharedControlConnection {
       deviceToken: this.pairing.deviceToken,
       send: (payload) => this.sendEncrypted(payload)
     })
-    this.reconnect.clearWhenIdle(this.subscriptions.size === 0 && this.state === 'closed')
   }
 
   private sendEncrypted(payload: unknown): boolean {
@@ -291,10 +288,14 @@ export class RemoteRuntimeSharedControlConnection {
     ) {
       return
     }
-    this.lastError = error.message
-    if (this.subscriptions.size > 0 && !this.intentionallyClosed) {
-      this.reconnect.scheduleWithDefaultBackoff(this.intentionallyClosed, () => this.open())
-    }
+    this.diag.lastError = error.message
+    this.reconnect.scheduleAfterSocketClose({
+      intentionallyClosed: this.intentionallyClosed,
+      manuallyDisconnected: this.options.isManuallyDisconnected?.() ?? false,
+      capabilityPaused: this.options.isCapabilityPaused?.() ?? false,
+      subscriptionCount: this.subscriptions.size,
+      open: () => this.open()
+    })
   }
 
   private closeSocket(error?: Error, preserveReadyWaitersAndPendingRequests = false): void {
@@ -304,7 +305,7 @@ export class RemoteRuntimeSharedControlConnection {
       pendingRequests: this.pendingRequests,
       subscriptions: this.subscriptions,
       readyWaiters: this.readyWaiters,
-      lastClose: this.lastClose,
+      lastClose: this.diag.lastClose,
       socketCleanup: this.socketCleanup,
       ws: this.ws,
       error,

--- a/src/shared/remote-runtime-shared-control-ready.ts
+++ b/src/shared/remote-runtime-shared-control-ready.ts
@@ -16,6 +16,12 @@ export function isSharedControlReady(args: {
   return args.state === 'ready' && args.ws?.readyState === WebSocket.OPEN && !!args.sharedKey
 }
 
+export function openIfSocketClosed(ws: WebSocket | null, open: () => void): void {
+  if (!ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+    open()
+  }
+}
+
 export function waitForSharedControlReadyWithTimeout(args: {
   readyWaiters: SharedControlReadyWaiter[]
   timeoutMs: number

--- a/src/shared/remote-runtime-shared-control-reconnect.ts
+++ b/src/shared/remote-runtime-shared-control-reconnect.ts
@@ -1,5 +1,8 @@
 import { scheduleSharedControlReconnect } from './remote-runtime-shared-control-state'
 
+const ACTIVE_RECONNECT_DELAYS_MS = [250, 500, 1000, 2000, 4000, 8000, 15_000, 30_000]
+const IDLE_RECONNECT_DELAYS_MS = [...ACTIVE_RECONNECT_DELAYS_MS, 60_000, 120_000, 300_000]
+
 export class SharedControlReconnectScheduler {
   private timer: ReturnType<typeof setTimeout> | null = null
   private attempt = 0
@@ -40,9 +43,34 @@ export class SharedControlReconnectScheduler {
   scheduleWithDefaultBackoff(intentionallyClosed: boolean, open: () => void): void {
     this.schedule({
       intentionallyClosed,
-      delaysMs: [250, 500, 1000, 2000, 4000, 8000, 15_000, 30_000],
+      delaysMs: ACTIVE_RECONNECT_DELAYS_MS,
       open
     })
+  }
+
+  scheduleWithIdleBackoff(intentionallyClosed: boolean, open: () => void): void {
+    this.schedule({ intentionallyClosed, delaysMs: IDLE_RECONNECT_DELAYS_MS, open })
+  }
+
+  scheduleAfterSocketClose(args: {
+    intentionallyClosed: boolean
+    manuallyDisconnected: boolean
+    capabilityPaused: boolean
+    subscriptionCount: number
+    open: () => void
+  }): void {
+    if (
+      args.intentionallyClosed ||
+      args.manuallyDisconnected ||
+      (args.subscriptionCount === 0 && args.capabilityPaused)
+    ) {
+      return
+    }
+    if (args.subscriptionCount > 0) {
+      this.scheduleWithDefaultBackoff(args.intentionallyClosed, args.open)
+      return
+    }
+    this.scheduleWithIdleBackoff(args.intentionallyClosed, args.open)
   }
 
   // Why: OS resume / browser online should advance an already-scheduled reconnect, not start a new one.
@@ -64,12 +92,6 @@ export class SharedControlReconnectScheduler {
       this.timer = null
     }
     this.pendingOpen = null
-  }
-
-  clearWhenIdle(isIdle: boolean): void {
-    if (isIdle) {
-      this.clear()
-    }
   }
 
   resetAttempt(): void {

--- a/src/shared/remote-runtime-shared-control-standing-intent.test.ts
+++ b/src/shared/remote-runtime-shared-control-standing-intent.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RemoteRuntimeClientError } from './remote-runtime-client-error'
+import { RemoteRuntimeSharedControlConnection } from './remote-runtime-shared-control-connection'
+import { SharedControlReconnectScheduler } from './remote-runtime-shared-control-reconnect'
+import type { SharedControlLogicalSubscription } from './remote-runtime-shared-control-types'
+import {
+  closeSharedControlTestServers,
+  createSharedControlTestServer
+} from './remote-runtime-shared-control-test-server'
+
+afterEach(async () => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  await closeSharedControlTestServers()
+})
+
+describe('shared-control standing intent', () => {
+  it('reconnects an idle established connection after the socket drops', async () => {
+    const server = await createSharedControlTestServer()
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing)
+    await connection.request('worktree.ps', undefined, 1_000)
+
+    server.closeClients()
+
+    await waitFor(() => connection.getDiagnostics().state === 'reconnecting')
+    await waitFor(() => server.connectionCount() >= 2, 2_000)
+    await expect(connection.request('repo.list', undefined, 1_000)).resolves.toMatchObject({
+      ok: true
+    })
+    connection.close()
+  })
+
+  it('keeps recovery armed when the last subscription closes', async () => {
+    const server = await createSharedControlTestServer()
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing)
+    const subscription = await connection.subscribe(
+      'session.tabs.subscribeAll',
+      {},
+      1_000,
+      callbacks()
+    )
+
+    server.closeClients()
+    await waitFor(() => connection.getDiagnostics().state === 'reconnecting')
+    subscription.close()
+
+    expect(connection.getDiagnostics()).toMatchObject({
+      state: 'reconnecting',
+      subscriptionCount: 0
+    })
+    await waitFor(() => server.connectionCount() >= 2, 2_000)
+    connection.close()
+  })
+
+  it('selects the 5-minute idle ceiling and preserves the 30-second active ceiling', () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const timerSpy = vi.spyOn(globalThis, 'setTimeout')
+    const idle = testConnection()
+    setReconnectAttempt(idle, 100)
+    closeCurrentGeneration(idle)
+    expect(timerSpy).toHaveBeenLastCalledWith(expect.any(Function), 300_000)
+    idle.close()
+
+    const active = testConnection()
+    addLogicalSubscription(active)
+    setReconnectAttempt(active, 100)
+    closeCurrentGeneration(active)
+    expect(timerSpy).toHaveBeenLastCalledWith(expect.any(Function), 30_000)
+    active.close()
+  })
+
+  it('retries indefinitely at the idle ceiling with bounded jitter', () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(1)
+    const timerSpy = vi.spyOn(globalThis, 'setTimeout')
+    const scheduler = new SharedControlReconnectScheduler()
+    ;(scheduler as unknown as { attempt: number }).attempt = 100
+    let opens = 0
+    const open = (): void => {
+      opens += 1
+      scheduler.scheduleWithIdleBackoff(false, open)
+    }
+
+    scheduler.scheduleWithIdleBackoff(false, open)
+    expect(timerSpy).toHaveBeenLastCalledWith(expect.any(Function), 360_000)
+    vi.advanceTimersByTime(360_000 * 4)
+
+    expect(opens).toBe(4)
+    expect(scheduler.attemptCount).toBe(105)
+    scheduler.clear()
+  })
+
+  it.each([
+    { manual: false, paused: false, subscriptions: 0, scheduled: true },
+    { manual: false, paused: false, subscriptions: 1, scheduled: true },
+    { manual: false, paused: true, subscriptions: 0, scheduled: false },
+    { manual: false, paused: true, subscriptions: 1, scheduled: true },
+    { manual: true, paused: false, subscriptions: 0, scheduled: false },
+    { manual: true, paused: false, subscriptions: 1, scheduled: false },
+    { manual: true, paused: true, subscriptions: 0, scheduled: false },
+    { manual: true, paused: true, subscriptions: 1, scheduled: false }
+  ])(
+    'applies the intent/capability truth table: $manual/$paused/$subscriptions',
+    ({ manual, paused, subscriptions, scheduled }) => {
+      vi.useFakeTimers()
+      const connection = testConnection({ manual, paused })
+      if (subscriptions > 0) {
+        addLogicalSubscription(connection)
+      }
+
+      closeCurrentGeneration(connection)
+
+      expect(connection.getDiagnostics().state === 'reconnecting').toBe(scheduled)
+      connection.close()
+    }
+  )
+
+  it('advances an armed idle retry without recreating cleared work', () => {
+    vi.useFakeTimers()
+    const connection = testConnection()
+    const open = replaceOpen(connection)
+    closeCurrentGeneration(connection)
+
+    expect(connection.retryNow()).toBe(true)
+    expect(open).toHaveBeenCalledOnce()
+    expect(connection.retryNow()).toBe(false)
+    connection.close()
+  })
+
+  it('clears an armed idle retry on close and ignores a late socket close', () => {
+    vi.useFakeTimers()
+    const connection = testConnection()
+    const open = replaceOpen(connection)
+    const generation = currentGeneration(connection)
+    invokeSocketClose(connection, generation)
+    connection.close()
+
+    vi.runAllTimers()
+    invokeSocketClose(connection, generation)
+
+    expect(open).not.toHaveBeenCalled()
+    expect(connection.getDiagnostics().state).toBe('closed')
+  })
+})
+
+function testConnection(options?: {
+  manual?: boolean
+  paused?: boolean
+}): RemoteRuntimeSharedControlConnection {
+  return new RemoteRuntimeSharedControlConnection(
+    {
+      v: 2,
+      endpoint: 'ws://127.0.0.1:1',
+      deviceToken: 'token',
+      publicKeyB64: Buffer.from(new Uint8Array(32).fill(1)).toString('base64')
+    },
+    {
+      isManuallyDisconnected: () => options?.manual ?? false,
+      isCapabilityPaused: () => options?.paused ?? false
+    }
+  )
+}
+
+function callbacks() {
+  return {
+    onResponse: vi.fn(),
+    onError: vi.fn(),
+    onClose: vi.fn()
+  }
+}
+
+function addLogicalSubscription(connection: RemoteRuntimeSharedControlConnection): void {
+  const subscription: SharedControlLogicalSubscription = {
+    requestId: 'subscription-1',
+    method: 'files.watch',
+    params: {},
+    retainedParamsBytes: 2,
+    callbacks: callbacks(),
+    sent: false,
+    closed: false,
+    closeAfterReady: false,
+    remoteSubscriptionId: null
+  }
+  unsafeConnection(connection).subscriptions.set(subscription.requestId, subscription)
+}
+
+function currentGeneration(connection: RemoteRuntimeSharedControlConnection): number {
+  return unsafeConnection(connection).socketGeneration.begin()
+}
+
+function closeCurrentGeneration(connection: RemoteRuntimeSharedControlConnection): void {
+  invokeSocketClose(connection, currentGeneration(connection))
+}
+
+function invokeSocketClose(
+  connection: RemoteRuntimeSharedControlConnection,
+  generation: number
+): void {
+  unsafeConnection(connection).handleSocketClosed(
+    new RemoteRuntimeClientError('runtime_unavailable', 'test close'),
+    generation
+  )
+}
+
+function setReconnectAttempt(
+  connection: RemoteRuntimeSharedControlConnection,
+  attempt: number
+): void {
+  unsafeConnection(connection).reconnect.attempt = attempt
+}
+
+function replaceOpen(connection: RemoteRuntimeSharedControlConnection): ReturnType<typeof vi.fn> {
+  const open = vi.fn()
+  unsafeConnection(connection).open = open
+  return open
+}
+
+function unsafeConnection(connection: RemoteRuntimeSharedControlConnection): {
+  open: () => void
+  handleSocketClosed: (error: RemoteRuntimeClientError, generation: number) => void
+  socketGeneration: { begin: () => number }
+  subscriptions: Map<string, SharedControlLogicalSubscription>
+  reconnect: { attempt: number }
+} {
+  return connection as never
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const startedAt = Date.now()
+  while (!predicate()) {
+    if (Date.now() - startedAt >= timeoutMs) {
+      throw new Error('Timed out waiting for shared-control state')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}

--- a/src/shared/remote-runtime-shared-control-state.ts
+++ b/src/shared/remote-runtime-shared-control-state.ts
@@ -19,18 +19,17 @@ export function buildSharedControlDiagnostics(args: {
   pendingRequestCount: number
   subscriptionCount: number
   reconnectAttempt: number
-  lastConnectedAt: number | null
-  lastClose: { code: number; reason: string } | null
-  lastError: string | null
+  diag: Pick<
+    RemoteRuntimeSharedConnectionDiagnostics,
+    'lastConnectedAt' | 'lastClose' | 'lastError'
+  >
 }): RemoteRuntimeSharedConnectionDiagnostics {
   return {
     state: args.reconnecting ? 'reconnecting' : args.state,
     pendingRequestCount: args.pendingRequestCount,
     subscriptionCount: args.subscriptionCount,
     reconnectAttempt: args.reconnectAttempt,
-    lastConnectedAt: args.lastConnectedAt,
-    lastClose: args.lastClose,
-    lastError: args.lastError
+    ...args.diag
   }
 }
 

--- a/src/shared/remote-runtime-shared-control-test-server.ts
+++ b/src/shared/remote-runtime-shared-control-test-server.ts
@@ -1,0 +1,227 @@
+import type { AddressInfo } from 'node:net'
+import { WebSocketServer, type WebSocket } from 'ws'
+import {
+  decrypt,
+  deriveSharedKey,
+  encrypt,
+  generateKeyPair,
+  publicKeyFromBase64,
+  publicKeyToBase64
+} from './e2ee-crypto'
+import { encodePairingOffer, parsePairingCode, type PairingOffer } from './pairing'
+
+export type SharedControlTestServer = {
+  pairing: PairingOffer
+  requests: { id: string; method: string; params?: unknown }[]
+  auths: unknown[]
+  connectionCount: () => number
+  flushDelayedResponses: () => void
+  closeClients: () => void
+}
+
+type ServerOptions = {
+  delaySubscriptionReady?: boolean
+  sendKeepaliveBeforeResponse?: boolean
+  keepaliveDelayMs?: number
+  responseDelayMs?: number
+  sendBinaryAfterAuth?: boolean
+  sendUnknownResponseBeforeResponse?: boolean
+  closeAfterFirstStreamingResponse?: boolean
+  closeBeforeResponse?: boolean
+  suppressReadyFrame?: boolean
+  suppressReadyFrameCount?: number
+  disableAutoPong?: boolean
+  delayedMethods?: string[]
+  silentMethods?: string[]
+}
+
+const servers: WebSocketServer[] = []
+
+export async function closeSharedControlTestServers(): Promise<void> {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          for (const client of server.clients) {
+            client.close()
+          }
+          server.close(() => resolve())
+        })
+    )
+  )
+}
+
+export async function createSharedControlTestServer(
+  options: ServerOptions = {}
+): Promise<SharedControlTestServer> {
+  const serverKeyPair = generateKeyPair()
+  const requests: SharedControlTestServer['requests'] = []
+  const auths: unknown[] = []
+  const delayedResponses: (() => void)[] = []
+  let connectionCount = 0
+  let closedAfterFirstStreamingResponse = false
+  const wss = new WebSocketServer({ port: 0, autoPong: options.disableAutoPong !== true })
+  servers.push(wss)
+
+  wss.on('connection', (ws) => {
+    connectionCount += 1
+    let sharedKey: Uint8Array | null = null
+    let authenticated = false
+    ws.on('message', (data, isBinary) => {
+      if (isBinary) {
+        return
+      }
+      const frame = data.toString()
+      if (!sharedKey) {
+        const hello = JSON.parse(frame) as { publicKeyB64: string }
+        sharedKey = deriveSharedKey(
+          serverKeyPair.secretKey,
+          publicKeyFromBase64(hello.publicKeyB64)
+        )
+        if (
+          options.suppressReadyFrame ||
+          connectionCount <= (options.suppressReadyFrameCount ?? 0)
+        ) {
+          return
+        }
+        ws.send(JSON.stringify({ type: 'e2ee_ready' }))
+        return
+      }
+      const plaintext = decrypt(frame, sharedKey)
+      if (!plaintext) {
+        return
+      }
+      if (!authenticated) {
+        auths.push(JSON.parse(plaintext))
+        authenticated = true
+        sendEncrypted(ws, sharedKey, { type: 'e2ee_authenticated' })
+        if (options.sendBinaryAfterAuth) {
+          ws.send(Buffer.from([1, 2, 3]), { binary: true })
+        }
+        return
+      }
+      handleRequest(
+        ws,
+        sharedKey,
+        requests,
+        JSON.parse(plaintext),
+        {
+          ...options,
+          closeAfterStreamingResponse: () => {
+            if (!options.closeAfterFirstStreamingResponse || closedAfterFirstStreamingResponse) {
+              return false
+            }
+            closedAfterFirstStreamingResponse = true
+            return true
+          }
+        },
+        delayedResponses
+      )
+    })
+  })
+
+  await new Promise<void>((resolve) => wss.once('listening', resolve))
+  const address = wss.address() as AddressInfo
+  const pairing = parsePairingCode(
+    encodePairingOffer({
+      v: 2,
+      endpoint: `ws://127.0.0.1:${address.port}`,
+      deviceToken: 'device-token',
+      publicKeyB64: publicKeyToBase64(serverKeyPair.publicKey)
+    })
+  )
+  if (!pairing) {
+    throw new Error('Failed to create test pairing')
+  }
+  return {
+    pairing,
+    requests,
+    auths,
+    connectionCount: () => connectionCount,
+    flushDelayedResponses: () => delayedResponses.splice(0).forEach((send) => send()),
+    closeClients: () => wss.clients.forEach((client) => client.close(4001, 'test close'))
+  }
+}
+
+function handleRequest(
+  ws: WebSocket,
+  sharedKey: Uint8Array,
+  requests: SharedControlTestServer['requests'],
+  request: { id: string; method: string; params?: unknown },
+  options: ServerOptions & { closeAfterStreamingResponse?: () => boolean },
+  delayedResponses: (() => void)[]
+): void {
+  requests.push(request)
+  if (options.sendKeepaliveBeforeResponse && options.keepaliveDelayMs !== undefined) {
+    const timer = setInterval(
+      () => sendEncrypted(ws, sharedKey, { _keepalive: true }),
+      options.keepaliveDelayMs
+    )
+    ws.once('close', () => clearInterval(timer))
+  }
+  if (options.silentMethods?.includes(request.method)) {
+    return
+  }
+  if (options.closeBeforeResponse) {
+    ws.close(4001, 'test close')
+    return
+  }
+  const streaming = isStreamingMethod(request.method)
+  const result = streaming
+    ? { type: 'ready', subscriptionId: `${request.method}:subscription` }
+    : { method: request.method }
+  const sendResponse = (): void => {
+    if (options.sendUnknownResponseBeforeResponse) {
+      sendEncrypted(ws, sharedKey, {
+        id: 'unknown-response-id',
+        ok: true,
+        result: { method: 'unknown' },
+        _meta: { runtimeId: 'runtime-test' }
+      })
+    }
+    sendEncrypted(ws, sharedKey, {
+      id: request.id,
+      ok: true,
+      result,
+      streaming: streaming ? true : undefined,
+      _meta: { runtimeId: 'runtime-test' }
+    })
+  }
+  const closeAfterResponse = streaming && options.closeAfterStreamingResponse?.() === true
+  if (options.sendKeepaliveBeforeResponse && options.keepaliveDelayMs === undefined) {
+    sendEncrypted(ws, sharedKey, { _keepalive: true })
+  }
+  if (options.delaySubscriptionReady && streaming) {
+    delayedResponses.push(sendResponse)
+    return
+  }
+  if (options.delayedMethods?.includes(request.method)) {
+    delayedResponses.push(sendResponse)
+    return
+  }
+  if (options.responseDelayMs !== undefined) {
+    setTimeout(() => {
+      sendResponse()
+      if (closeAfterResponse) {
+        setTimeout(() => ws.close(), 0)
+      }
+    }, options.responseDelayMs)
+    return
+  }
+  sendResponse()
+  if (closeAfterResponse) {
+    setTimeout(() => ws.close(), 0)
+  }
+}
+
+function isStreamingMethod(method: string): boolean {
+  return (
+    method.endsWith('.subscribe') ||
+    method === 'session.tabs.subscribeAll' ||
+    method === 'files.watch'
+  )
+}
+
+function sendEncrypted(ws: WebSocket, sharedKey: Uint8Array, message: unknown): void {
+  ws.send(encrypt(JSON.stringify(message), sharedKey))
+}

--- a/src/shared/remote-runtime-shared-control-types.ts
+++ b/src/shared/remote-runtime-shared-control-types.ts
@@ -75,6 +75,8 @@ export type RemoteRuntimeSharedConnectionDiagnostics = {
 export type RemoteRuntimeSharedControlConnectionOptions = {
   environmentId?: string
   clientCapabilities?: readonly RuntimeCapability[]
+  isManuallyDisconnected?: () => boolean
+  isCapabilityPaused?: () => boolean
   reconnectStableResetMs?: number
   liveness?: RemoteRuntimeSocketLivenessOptions
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1138 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​246 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​892 |
| Prod | 23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1108 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​134 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​974 |

<!-- /orca-pr-loc -->

## Summary

- Keep an existing remote shared-control connection recovering for as long as saved-host intent stands, including when it has no logical subscriptions.
- Preserve the active retry ladder and its 30-second ceiling; add an idle ladder that reaches a 300-second ceiling. Both use the existing one-sided 0–20% jitter and retry indefinitely at the ceiling with no attempt cap.
- Make manual disconnect and capability evidence process-owned inputs to the retry gate. Disconnect remains authoritative even when direct main-process callers recreate a cached connection.
- Ensure successful default status probes create/resume capable shared-control connections, while capability absence pauses only idle connections. Subscription-holding connections are immune.
- Add incarnation- and sequence-fenced capability routing so stale probes cannot select a retired transport, overwrite runtime identity, or revive an invalidated pairing.
- Add a renderer-owned observe-only status recheck ladder (`3s, 6s, 12s, 30s, 60s`, then indefinitely at 60s) so a published Checking/Reconnecting state converges without repeatedly resetting the handshake it observes.
- Prioritize Attempt N during reconnect and suppress stale failure copy while authentication/readiness is in flight.
- Add the per-environment retry-now IPC and preload seam without changing the status-row component owned by the separate in-flight UI PR.

## Risk accounting

- **Invisible retry loops:** deliberate and rate-bounded at the idle ceiling. Disconnect and Remove synchronously invalidate the capability incarnation, close/delete the cached connection, and clear its timer. Real-connection teardown tests prove an armed idle timer cannot fire after close, including a late socket-close callback; handler tests prove both lifecycle paths close the environment cache.
- **Intentional disconnect regression:** `intentionallyClosed` retains its original timer-clearing and schedule-veto semantics. A separate process-owned manual-disconnect predicate vetoes both idle and active scheduling, including bypass-created connections. The full manual/capability/subscription truth table and the bypass path are tested.
- **Stuck Checking:** only successful snapshots with non-ready shared-control diagnostics arm the observe-only rechecker. It keeps one timer or in-flight request per environment per window, validates catalog membership and connection generation at arm/fire/settlement boundaries, and cancels on Ready, unreachable/null, capability loss, missing diagnostics, removal, or re-pair. Observe-only probes never ensure, refresh, or mark an environment used; the only permitted mutation is a sequence-fenced idle pause after accepted capability loss. A reachable host that never becomes ready costs at most one status read per minute per open window.
- **Thundering herd:** the shipped one-sided jitter remains in both ladders, and idle hosts spread to at least 300-second base spacing. The active profile is unchanged.
- **Bypass callers:** direct main-process RPCs to a manually disconnected environment retain current behavior, but any resulting idle connection is unable to arm a standing retry. Tightening bypass RPC admission remains outside this change.
- **Relocation risk:** the connection-file budget relief is limited to grouped diagnostics state and the socket-open predicate extraction. The incumbent connection test changes only the deliberate `closed` to `reconnecting` expectation; its shared WebSocket harness is reused from one named test-support module. No max-lines disable or baseline entry was added.

## Compatibility and lifecycle boundaries

- No host/server or remote-wire change: no RPC parameter sent to a paired host, frame, opcode, capability, or published host payload changes. The new observe-only and retry-now values are renderer-to-main desktop IPC only; the web implementation remains a pure-read/no-op seam.
- SSH/relay execution ownership and the `live` / `unverifiable` / `exited` vocabulary are untouched. Loss of shared control is not used as evidence that remote work exited.
- The change is timers, WebSockets, and environment-local state only; it introduces no path, shell, Git, platform, worktree, or folder-workspace assumption.
- Capability absence never closes or notifies subscription holders. Existing subscription retry/replay behavior remains unchanged.

## Historical protection verification

- Shared-control suites covering the behaviors introduced or protected by #5341, #9774, #8255, #11513/#11656, and #7718 pass: active subscription replay, capped active retry, resume/online retry-now semantics, ready-waiter and pending-request preservation during refresh, liveness recovery, socket-generation fencing, keepalive refresh, subscription cleanup, and the SSH/relay import boundary.
- The targeted query/reply and remote-terminal regression suites associated with #7329, #9993, #12112, #13137/#13309, #15559, and #15578 pass (145 assertions). No reply withholding or deferral scheduler was added.

## Follow-ups and known limitations

- **Follow-up:** wire the Reconnecting-row **Retry now** affordance through the new IPC after the separate in-flight PR that owns `RuntimeHostStatusRow.tsx` lands. This PR intentionally does not touch that file.
- **Follow-up:** subscription recovery across full transport retirement is a pre-existing cross-window lifecycle gap and remains out of scope. This PR does not claim broader subscription recovery.
- **Known limitation:** a catalog row with no status entry can still show Checking until an existing hydration or user-triggered probe publishes a status. The new healer is intentionally publication-gated and does not add background polling for a host that was already down at boot.

## Verification

- `pnpm tc`
- bare `oxlint` on all changed TypeScript/TSX files
- shared-control matrix: 9 files, 62 tests passed
- main routing/diagnostics matrix: 12 files, 81 tests passed
- renderer/status-bar matrix: 48 files, 357 tests passed
- historical terminal regression matrix: 10 files, 145 tests passed
- `git diff --check`
- protected-file check: `RuntimeHostStatusRow.tsx` has no diff

Rendered Electron validation was not applicable: no rendered component was changed, and the row-owned affordance is explicitly deferred. The copy derivation and store behavior are covered by focused unit tests.
