### PR TITLE
Fix same-target mobile notification navigation

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1147,6 +1147,109 @@
       "demotionRule": "Demote or quarantine if cancellation creates the shared install lock before transfer settlement, a split-SFTP transfer loses identity proof, recovery deletes a replacement/symlink/reparse/foreign stage, fixed-path work exceeds its eight-slot bound, cancellation leaks a local descriptor, or the focused gate flakes without a product or harness bug."
     },
     {
+      "id": "mobile-navigation.notification-input-lease-continuity",
+      "title": "Same-target mobile notification navigation preserves Native Chat input",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "mobile-runtime",
+      "layer": "shared-mobile-navigation-contract",
+      "surfaces": [
+        "iOS notification response",
+        "Android notification response",
+        "host-stack navigation",
+        "Native Chat terminal cache",
+        "Native Chat input lease"
+      ],
+      "platforms": ["ios", "android", "macos"],
+      "providers": ["provider-independent"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["provider-independent"],
+      "coverageNotes": "A deterministic macOS TypeScript/React harness drives the shared iOS/Android notification target builder through the production notification-opening hook, host-stack coordinator, and actual Native Chat input-lease hook. It covers exact same-target no-op behavior with session name/created/warning query state, cold start, different hosts and worktrees, stale, conflicting, percent-aliasing, or extra semantic identity, repeated taps, cancellation/disposal, and reconnect. Live iOS and Android notification delivery remain E2E gaps.",
+      "motivatingLinks": [
+        "https://linear.app/stably/issue/STA-5821",
+        "https://github.com/stablyai/orca/issues/16995"
+      ],
+      "invariant": "A notification tap whose host, nested route, and identifying params match the already-focused mobile session must be an identity-preserving no-op: it must add no listener, push, replace, dispatch, detach, or terminal-cache clear, and the exact acknowledged Native Chat input lease must remain sendable. Cold start, a different host or worktree, unknown or conflicting route identity, and canceled transitions must retain their existing transition and cleanup semantics.",
+      "oracle": "Build a notification navigation target from the same payload consumed by app/_layout.tsx, invoke it through useOpenNotificationRoute and useOpenHostStackRoute, and seed the root-layout-scoped Expo state with an active host/worktree session, an exact terminal-cache object, and an acknowledged input lease, then tap twice. Require zero route operations, listeners, detach callbacks, and cache clears; require the same cache object and lease readyRef, ready=true, null lock reason, and enabled composer gate. Separately drive cold, different-host, different-worktree, missing/stale/conflicting/percent-aliasing identity, extra semantic params that must be cleared, retarget-to-current settlement, cancellation, disposal, and reconnect states without sleeps, and require only genuine transitions to push and listen.",
+      "commands": [
+        "pnpm --dir mobile exec vitest run --root .. mobile/src/notifications/notification-route-coordination.test.ts mobile/src/navigation/host-stack-navigation.test.ts mobile/src/session/use-mobile-native-chat-input-lease.test.ts mobile/src/session/MobileNativeChatView.test.ts"
+      ],
+      "testFiles": [
+        "mobile/src/notifications/notification-route-coordination.test.ts",
+        "mobile/src/navigation/host-stack-navigation.test.ts",
+        "mobile/src/session/use-mobile-native-chat-input-lease.test.ts",
+        "mobile/src/session/MobileNativeChatView.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "mobile/src/notifications/notification-route-coordination.test.ts",
+          "assertions": [
+            "the production notification-opening hook carries repeated same-session taps with name/created/warning query state into the coordinator with zero route or detach work and preserves the exact terminal cache and input lease",
+            "different host/worktree and missing, stale, conflicting, or percent-aliasing identities still transition",
+            "cold-start coordination, cancellation/disposal, and post-reconnect same-route preservation remain deterministic"
+          ]
+        },
+        {
+          "file": "mobile/src/navigation/host-stack-navigation.test.ts",
+          "assertions": [
+            "cold and encoded host routes still mount then replace through the committed host stack",
+            "exact semantic targets no-op while an extra current taskSource filter still transitions so it can be cleared",
+            "canceled transitions and pending retargets that become current settle immediately with bounded listener and operation counts"
+          ]
+        },
+        {
+          "file": "mobile/src/session/use-mobile-native-chat-input-lease.test.ts",
+          "assertions": [
+            "an acknowledged terminal lease is ready and clears only on explicit lease loss or disconnect"
+          ]
+        },
+        {
+          "file": "mobile/src/session/MobileNativeChatView.test.ts",
+          "assertions": [
+            "the composer unlocks only after the input lease remains ready"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-28",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm --dir mobile exec vitest run --root .. mobile/src/notifications/notification-route-coordination.test.ts mobile/src/navigation/host-stack-navigation.test.ts mobile/src/session/use-mobile-native-chat-input-lease.test.ts mobile/src/session/MobileNativeChatView.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.25,
+          "summary": "35 deterministic tests passed. The byte-identical oracle failed 4/35 on latest main and again with only the identity decision removed: the shared owner performed route work for exact targets, did not settle a retarget that became current, and the notification push detached the route, cleared the exact terminal cache/input lease, and left the composer waiting."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 5,
+        "scope": "focused shared mobile navigation, lease, and composer contracts"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "Deterministic local runs use explicit navigation states and React updates with no sleeps, external services, or retry polling; CI and soak history are not yet available."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "The final byte-identical 35-test oracle failed 4 tests on latest main, passed all 35 with the focused-route identity no-op, failed the same 4 after removing only that decision, and passed all 35 after restoration."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Each deep-route request performs bounded focused-state inspection plus a small route-identity comparison. A same-target tap now creates zero listeners, route operations, cache work, remote calls, retries, timers, polling, or fanout; genuine transitions retain bounded listener and route-operation counts."
+      },
+      "promotionCriteria": [
+        "Collect 100 consecutive CI passes or 14 days of soak history.",
+        "Run real same-target and different-target notification taps on both iOS and Android with a paired host.",
+        "Exercise a paired remote host through disconnect/reconnect and preserve explicit host, worktree, terminal, and lease identities."
+      ],
+      "knownGaps": [
+        "No live iOS or Android notification-delivery run is registered yet.",
+        "No physical device run is registered.",
+        "No live paired remote, SSH-backed repository, or folder-workspace run is registered; the change is client-local and does not alter the remote wire or execution routing."
+      ],
+      "demotionRule": "Demote or quarantine if an exact same-target tap performs route work or loses cache/lease identity, a genuine target transition becomes a no-op, the focused contract flakes without a product defect, or navigation work grows beyond the focused-state/target-param bound."
+    },
+    {
       "id": "mobile-ui.drawer-close-continuity",
       "title": "Mobile drawers finish closing despite parent rerenders",
       "maturity": "experimental",

--- a/mobile/src/navigation/host-stack-navigation.test.ts
+++ b/mobile/src/navigation/host-stack-navigation.test.ts
@@ -34,6 +34,9 @@ function navigationHarness(initialState: HostStackNavigationState | undefined) {
     navigation,
     unsubscribe,
     listenerCount: () => stateListeners.size,
+    setStateWithoutNotification(nextState: HostStackNavigationState | undefined) {
+      state = nextState
+    },
     setState(nextState: HostStackNavigationState | undefined) {
       state = nextState
       for (const listener of stateListeners) {
@@ -59,6 +62,24 @@ function committedHostState(hostIdParam: string): HostStackNavigationState {
   }
 }
 
+function committedTargetState(
+  params: Readonly<Record<string, unknown>> = TARGET.params
+): HostStackNavigationState {
+  return {
+    index: 0,
+    routes: [
+      {
+        name: 'h',
+        state: {
+          key: '/h',
+          index: 0,
+          routes: [{ key: 'target', name: TARGET.name, params }]
+        }
+      }
+    ]
+  }
+}
+
 // The shape app/_layout.tsx sees: Expo Router mounts it as a screen of its own internal
 // navigator, so every route the host stack lives in sits one level below.
 function rootLayoutScopedState(inner: HostStackNavigationState): HostStackNavigationState {
@@ -66,6 +87,34 @@ function rootLayoutScopedState(inner: HostStackNavigationState): HostStackNaviga
 }
 
 describe('host stack navigation', () => {
+  it('completes an exact focused target without route work', () => {
+    const harness = navigationHarness(committedTargetState())
+    const push = vi.fn()
+
+    const controller = navigateToHostStackRoute(
+      harness.navigation,
+      { push, replace: vi.fn() },
+      'host/one',
+      TARGET
+    )
+
+    expect(push).not.toHaveBeenCalled()
+    expect(harness.listenerCount()).toBe(0)
+    expect(controller.isActive()).toBe(false)
+  })
+
+  it('transitions when the focused route has a semantic param the target clears', () => {
+    const harness = navigationHarness(
+      committedTargetState({ hostId: 'host/one', taskSource: 'linear' })
+    )
+    const push = vi.fn()
+
+    navigateToHostStackRoute(harness.navigation, { push, replace: vi.fn() }, 'host/one', TARGET)
+
+    expect(push).toHaveBeenCalledOnce()
+    expect(harness.listenerCount()).toBe(1)
+  })
+
   it('matches a host committed as the encoded segment it was pushed as', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
     const push = vi.fn()
@@ -216,6 +265,88 @@ describe('host stack navigation', () => {
     harness.setState(committedHostState('host/one'))
 
     expect(harness.navigation.dispatch).toHaveBeenCalledTimes(1)
+    expect(harness.navigation.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: OTHER_TARGET })
+    )
+  })
+
+  it('settles a pending retarget immediately when its new target is already focused', () => {
+    const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
+    const push = vi.fn()
+    const router = { push, replace: vi.fn() }
+    const pending = coordinateHostStackNavigation(
+      null,
+      harness.navigation,
+      router,
+      'host/one',
+      TARGET
+    )
+
+    harness.setStateWithoutNotification({
+      index: 0,
+      routes: [
+        {
+          name: 'h',
+          state: {
+            key: '/h',
+            index: 0,
+            routes: [{ key: 'session', name: OTHER_TARGET.name, params: OTHER_TARGET.params }]
+          }
+        }
+      ]
+    })
+    const retargeted = coordinateHostStackNavigation(
+      pending,
+      harness.navigation,
+      router,
+      'host/one',
+      OTHER_TARGET
+    )
+
+    expect(retargeted).toBe(pending)
+    expect(push).toHaveBeenCalledTimes(1)
+    expect(pending.controller.isActive()).toBe(false)
+    expect(harness.listenerCount()).toBe(0)
+
+    harness.setState(committedHostState('host/one'))
+    expect(harness.navigation.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('waits for a real state event before advancing a non-focused retarget', () => {
+    const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
+    const push = vi.fn()
+    const replace = vi.fn()
+    const router = { push, replace }
+    const pending = coordinateHostStackNavigation(
+      null,
+      harness.navigation,
+      router,
+      'host/one',
+      TARGET
+    )
+
+    harness.setStateWithoutNotification({
+      index: 0,
+      routes: [
+        {
+          name: 'h',
+          params: { hostId: 'host/one' },
+          state: {
+            key: '/h',
+            index: 0,
+            routes: [{ key: 'tasks', name: TARGET.name, params: TARGET.params }]
+          }
+        }
+      ]
+    })
+    coordinateHostStackNavigation(pending, harness.navigation, router, 'host/one', OTHER_TARGET)
+
+    expect(replace).not.toHaveBeenCalled()
+    expect(harness.navigation.dispatch).not.toHaveBeenCalled()
+    expect(pending.controller.isActive()).toBe(true)
+    expect(harness.listenerCount()).toBe(1)
+
+    harness.setState(committedHostState('host/one'))
     expect(harness.navigation.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ payload: OTHER_TARGET })
     )

--- a/mobile/src/navigation/host-stack-navigation.ts
+++ b/mobile/src/navigation/host-stack-navigation.ts
@@ -7,7 +7,7 @@ export type HostStackNavigationState = Readonly<{
 export type HostStackNavigationRoute = Readonly<{
   key?: string
   name: string
-  params?: Readonly<{ hostId?: unknown }>
+  params?: Readonly<Record<string, unknown>>
   state?: HostStackNavigationState
 }>
 
@@ -64,17 +64,17 @@ export function hostStackRouteHref(target: HostStackRouteTarget): HostStackRoute
   return { pathname: `/h/${target.name}`, params: target.params }
 }
 
-// Why: the host is pushed as an encoded segment, so the committed route may hold
-// either form — an id with `/`, `#`, or `%` must still match its own push.
-function hostParamMatches(param: unknown, expectedHostId: string): boolean {
+// Why: pushed host segments may commit encoded; ids with `/`, `#`, or `%` must
+// still match the host mount that their encoded path created.
+function pushedHostParamMatches(param: unknown, expected: string): boolean {
   if (typeof param !== 'string') {
     return false
   }
-  if (param === expectedHostId) {
+  if (param === expected) {
     return true
   }
   try {
-    return decodeURIComponent(param) === expectedHostId
+    return decodeURIComponent(param) === expected
   } catch {
     return false // Lone `%` — not our encoding.
   }
@@ -108,11 +108,53 @@ function mountedHostStack(
     !hostState?.key ||
     hostRoute?.name !== '[hostId]/index' ||
     !hostRoute.key ||
-    !hostParamMatches(hostRoute.params?.hostId, expectedHostId)
+    !pushedHostParamMatches(hostRoute.params?.hostId, expectedHostId)
   ) {
     return null
   }
   return { key: hostState.key, routeKey: hostRoute.key }
+}
+
+function focusedHostStackRouteMatches(
+  state: HostStackNavigationState,
+  hostId: string,
+  target: HostStackRouteTarget
+): boolean {
+  const hostContainer = focusedHostRoute(state)
+  const hostState = hostContainer?.state
+  const route = hostState?.routes[hostState.index]
+  if (
+    hostContainer?.params?.hostId !== undefined &&
+    !pushedHostParamMatches(hostContainer.params.hostId, hostId)
+  ) {
+    return false
+  }
+  if (route?.name !== target.name || route.params?.hostId !== hostId) {
+    return false
+  }
+  // Session query params also carry presentation and one-shot creation state; only
+  // the execution host and worktree identify the mounted session and its input lease.
+  if (target.name === '[hostId]/session/[worktreeId]') {
+    return (
+      target.params.hostId === hostId &&
+      typeof target.params.worktreeId === 'string' &&
+      route.params.worktreeId === target.params.worktreeId
+    )
+  }
+  const targetParams = Object.entries(target.params)
+  const routeParams = Object.entries(route.params)
+  return (
+    routeParams.length === targetParams.length &&
+    targetParams.every(([key, value]) => route.params?.[key] === value)
+  )
+}
+
+function completedHostStackNavigation(): HostStackNavigationController {
+  return {
+    cancel: () => {},
+    isActive: () => false,
+    retarget: () => {}
+  }
 }
 
 /** Opens a deep host route by mounting `/h/[hostId]` first and replacing it once
@@ -124,6 +166,11 @@ export function navigateToHostStackRoute(
   hostId: string,
   target: HostStackRouteTarget
 ): HostStackNavigationController {
+  const initialState = navigation.getState()
+  if (initialState && focusedHostStackRouteMatches(initialState, hostId, target)) {
+    return completedHostStackNavigation()
+  }
+
   let active = true
   let hostRouteSeen = false
   let selectedTarget = target
@@ -145,6 +192,10 @@ export function navigateToHostStackRoute(
     if (!state) {
       return
     }
+    if (focusedHostStackRouteMatches(state, hostId, selectedTarget)) {
+      dispose()
+      return
+    }
     const hostContainer = focusedHostRoute(state)
     if (hostContainer) {
       hostRouteSeen = true
@@ -154,7 +205,7 @@ export function navigateToHostStackRoute(
     }
     const hostStack = hostContainer && mountedHostStack(hostContainer, hostId)
     if (!hostStack) {
-      if (hostContainer && hostParamMatches(hostContainer.params?.hostId, hostId)) {
+      if (hostContainer && pushedHostParamMatches(hostContainer.params?.hostId, hostId)) {
         dispose()
         router.replace(hostStackRouteHref(selectedTarget))
       }
@@ -182,6 +233,10 @@ export function navigateToHostStackRoute(
     retarget: (nextTarget) => {
       if (active) {
         selectedTarget = nextTarget
+        const state = navigation.getState()
+        if (state && focusedHostStackRouteMatches(state, hostId, selectedTarget)) {
+          dispose()
+        }
       }
     }
   }

--- a/mobile/src/notifications/notification-route-coordination.test.ts
+++ b/mobile/src/notifications/notification-route-coordination.test.ts
@@ -1,5 +1,5 @@
 import { createElement } from 'react'
-import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { act, create } from 'react-test-renderer'
 import { readFileSync } from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
 import { getNotificationNavigationTarget } from './notification-routing'
@@ -20,6 +20,11 @@ vi.mock('expo-router', () => ({
 const rootLayoutSource = readFileSync(new URL('../../app/_layout.tsx', import.meta.url), 'utf8')
 const HOST_ID = 'host/one'
 const WORKTREE_ID = 'repo::/Users/me/orca/workspaces/feature'
+
+type TestRendererHandle = Readonly<{
+  unmount: () => void
+  update: (element: unknown) => void
+}>
 
 function navigationHarness(initialState: HostStackNavigationState | undefined) {
   const stateListeners = new Set<() => void>()
@@ -152,7 +157,7 @@ describe('notification route coordination', () => {
       return null
     }
 
-    let renderer: ReactTestRenderer | null = null
+    let renderer: TestRendererHandle | null = null
     await act(async () => {
       renderer = create(createElement(LeaseHarness))
     })
@@ -180,7 +185,7 @@ describe('notification route coordination', () => {
       return null
     }
 
-    let notificationRenderer: ReactTestRenderer | null = null
+    let notificationRenderer: TestRendererHandle | null = null
     await act(async () => {
       notificationRenderer = create(createElement(NotificationHookHarness))
     })
@@ -296,7 +301,7 @@ describe('notification route coordination', () => {
       return null
     }
 
-    let renderer: ReactTestRenderer | null = null
+    let renderer: TestRendererHandle | null = null
     await act(async () => {
       renderer = create(createElement(LeaseHarness, { connected: false }))
     })

--- a/mobile/src/notifications/notification-route-coordination.test.ts
+++ b/mobile/src/notifications/notification-route-coordination.test.ts
@@ -1,3 +1,5 @@
+import { createElement } from 'react'
+import { act, create } from 'react-test-renderer'
 import { readFileSync } from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
 import { getNotificationNavigationTarget } from './notification-routing'
@@ -6,8 +8,18 @@ import {
   navigateToHostStackRoute,
   type HostStackNavigationState
 } from '../navigation/host-stack-navigation'
+import { useMobileNativeChatInputLease } from '../session/use-mobile-native-chat-input-lease'
+import { useOpenNotificationRoute } from './use-open-notification-route'
+
+const navigationHooks = vi.hoisted(() => ({ navigation: null as unknown, router: null as unknown }))
+vi.mock('expo-router', () => ({
+  useNavigation: () => navigationHooks.navigation,
+  useRouter: () => navigationHooks.router
+}))
 
 const rootLayoutSource = readFileSync(new URL('../../app/_layout.tsx', import.meta.url), 'utf8')
+const HOST_ID = 'host/one'
+const WORKTREE_ID = 'repo::/Users/me/orca/workspaces/feature'
 
 function navigationHarness(initialState: HostStackNavigationState | undefined) {
   const stateListeners = new Set<() => void>()
@@ -22,6 +34,7 @@ function navigationHarness(initialState: HostStackNavigationState | undefined) {
   }
   return {
     navigation,
+    listenerCount: () => stateListeners.size,
     setState(nextState: HostStackNavigationState | undefined) {
       state = nextState
       for (const listener of stateListeners) {
@@ -35,6 +48,40 @@ function navigationHarness(initialState: HostStackNavigationState | undefined) {
 // own internal navigator — hence the extra `__root` level around the app's root stack.
 function rootLayoutScopedState(inner: HostStackNavigationState): HostStackNavigationState {
   return { key: 'internal', index: 0, routes: [{ key: '__root', name: '__root', state: inner }] }
+}
+
+function committedSessionState(
+  hostId = HOST_ID,
+  worktreeId = WORKTREE_ID,
+  hostContainerId?: string
+) {
+  return rootLayoutScopedState({
+    index: 1,
+    routes: [
+      { name: 'index' },
+      {
+        name: 'h',
+        params: hostContainerId === undefined ? undefined : { hostId: hostContainerId },
+        state: {
+          key: '/h',
+          index: 0,
+          routes: [
+            {
+              key: 'session',
+              name: '[hostId]/session/[worktreeId]',
+              params: {
+                hostId,
+                worktreeId,
+                name: 'Feature',
+                created: '1',
+                warning: 'Workspace creation used a fallback'
+              }
+            }
+          ]
+        }
+      }
+    ]
+  })
 }
 
 describe('notification route coordination', () => {
@@ -95,6 +142,183 @@ describe('notification route coordination', () => {
       source: 'host-index',
       payload: target!.sessionTarget
     })
+  })
+
+  it('keeps the exact cache and input lease sendable across repeated same-session taps', async () => {
+    type Lease = ReturnType<typeof useMobileNativeChatInputLease>
+    let lease: Lease | null = null
+    function LeaseHarness(): null {
+      lease = useMobileNativeChatInputLease({ activeHandle: 'terminal-1', connected: true })
+      return null
+    }
+
+    let renderer: ReturnType<typeof create> | null = null
+    await act(async () => {
+      renderer = create(createElement(LeaseHarness))
+    })
+    act(() => lease?.markReady('terminal-1'))
+
+    const readyRef = lease!.readyRef
+    const cachedTerminal = { handle: 'terminal-1' }
+    const terminalCache = new Map([['terminal-1', cachedTerminal]])
+    const clearTerminalCache = vi.fn(() => {
+      terminalCache.clear()
+      lease?.clear()
+    })
+    const detach = vi.fn(() => act(clearTerminalCache))
+    const harness = navigationHarness(
+      committedSessionState(HOST_ID, WORKTREE_ID, encodeURIComponent(HOST_ID))
+    )
+    const router = { push: vi.fn(detach), replace: vi.fn(detach) }
+    const target = getNotificationNavigationTarget({ hostId: HOST_ID, worktreeId: WORKTREE_ID })!
+    navigationHooks.navigation = harness.navigation
+    navigationHooks.router = router
+
+    let openNotificationRoute: ReturnType<typeof useOpenNotificationRoute> | null = null
+    function NotificationHookHarness(): null {
+      openNotificationRoute = useOpenNotificationRoute()
+      return null
+    }
+
+    let notificationRenderer: ReturnType<typeof create> | null = null
+    await act(async () => {
+      notificationRenderer = create(createElement(NotificationHookHarness))
+    })
+
+    act(() => openNotificationRoute?.(target))
+    act(() => openNotificationRoute?.(target))
+
+    expect.soft(router.push).not.toHaveBeenCalled()
+    expect.soft(router.replace).not.toHaveBeenCalled()
+    expect.soft(harness.navigation.dispatch).not.toHaveBeenCalled()
+    expect.soft(harness.listenerCount()).toBe(0)
+    expect.soft(detach).not.toHaveBeenCalled()
+    expect.soft(clearTerminalCache).not.toHaveBeenCalled()
+    expect.soft(terminalCache.get('terminal-1')).toBe(cachedTerminal)
+    expect.soft(lease!.readyRef).toBe(readyRef)
+    expect.soft(lease!.ready).toBe(true)
+    expect.soft(lease!.lockReason).toBeNull()
+    expect.soft(lease!.lockReason !== null).toBe(false)
+
+    act(() => notificationRenderer?.unmount())
+    act(() => renderer?.unmount())
+  })
+
+  it.each([
+    ['different worktree', HOST_ID, 'repo::/Users/me/orca/workspaces/other'],
+    ['different host', 'host/two', WORKTREE_ID]
+  ])('transitions for a %s notification', (_label, hostId, worktreeId) => {
+    const harness = navigationHarness(committedSessionState())
+    const push = vi.fn()
+    const target = getNotificationNavigationTarget({ hostId, worktreeId })!
+
+    navigateToHostStackRoute(
+      harness.navigation,
+      { push, replace: vi.fn() },
+      target.hostId,
+      target.sessionTarget!
+    )
+
+    expect(push).toHaveBeenCalledOnce()
+    expect(harness.listenerCount()).toBe(1)
+  })
+
+  it.each([
+    ['missing worktree identity', committedSessionState(HOST_ID, '')],
+    ['stale worktree identity', committedSessionState(HOST_ID, `${WORKTREE_ID}-stale`)],
+    ['conflicting outer host identity', committedSessionState(HOST_ID, WORKTREE_ID, 'host/two')]
+  ])('transitions when the focused route has %s', (_label, state) => {
+    const harness = navigationHarness(state)
+    const push = vi.fn()
+    const target = getNotificationNavigationTarget({ hostId: HOST_ID, worktreeId: WORKTREE_ID })!
+
+    navigateToHostStackRoute(
+      harness.navigation,
+      { push, replace: vi.fn() },
+      target.hostId,
+      target.sessionTarget!
+    )
+
+    expect(push).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    [HOST_ID, 'repo::/tmp/a%2Fb', HOST_ID, 'repo::/tmp/a/b'],
+    [HOST_ID, 'repo::/tmp/%41', HOST_ID, 'repo::/tmp/A'],
+    ['host%2Fone', WORKTREE_ID, 'host/one', WORKTREE_ID]
+  ])(
+    'transitions when distinct raw identities only look equal after decoding',
+    (focusedHostId, focusedWorktreeId, targetHostId, targetWorktreeId) => {
+      const harness = navigationHarness(committedSessionState(focusedHostId, focusedWorktreeId))
+      const push = vi.fn()
+      const target = getNotificationNavigationTarget({
+        hostId: targetHostId,
+        worktreeId: targetWorktreeId
+      })!
+
+      navigateToHostStackRoute(
+        harness.navigation,
+        { push, replace: vi.fn() },
+        target.hostId,
+        target.sessionTarget!
+      )
+
+      expect(push).toHaveBeenCalledOnce()
+      expect(harness.listenerCount()).toBe(1)
+    }
+  )
+
+  it('disposes a canceled notification transition before a later host commit', () => {
+    const harness = navigationHarness(
+      rootLayoutScopedState({ index: 0, routes: [{ name: 'index' }] })
+    )
+    const target = getNotificationNavigationTarget({ hostId: HOST_ID, worktreeId: WORKTREE_ID })!
+    const controller = navigateToHostStackRoute(
+      harness.navigation,
+      { push: vi.fn(), replace: vi.fn() },
+      target.hostId,
+      target.sessionTarget!
+    )
+
+    controller.cancel()
+    harness.setState(committedSessionState())
+
+    expect(controller.isActive()).toBe(false)
+    expect(harness.listenerCount()).toBe(0)
+    expect(harness.navigation.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('preserves a re-established lease when the same route is reconstructed after reconnect', async () => {
+    type Lease = ReturnType<typeof useMobileNativeChatInputLease>
+    let lease: Lease | null = null
+    function LeaseHarness({ connected }: { connected: boolean }): null {
+      lease = useMobileNativeChatInputLease({ activeHandle: 'terminal-1', connected })
+      return null
+    }
+
+    let renderer: ReturnType<typeof create> | null = null
+    await act(async () => {
+      renderer = create(createElement(LeaseHarness, { connected: false }))
+    })
+    await act(async () => {
+      renderer?.update(createElement(LeaseHarness, { connected: true }))
+    })
+    act(() => lease?.markReady('terminal-1'))
+    const readyRef = lease!.readyRef
+    const harness = navigationHarness(committedSessionState())
+    const target = getNotificationNavigationTarget({ hostId: HOST_ID, worktreeId: WORKTREE_ID })!
+
+    navigateToHostStackRoute(
+      harness.navigation,
+      { push: vi.fn(() => act(() => lease?.clear())), replace: vi.fn() },
+      target.hostId,
+      target.sessionTarget!
+    )
+
+    expect.soft(lease!.readyRef).toBe(readyRef)
+    expect.soft(lease!.ready).toBe(true)
+    expect.soft(lease!.lockReason).toBeNull()
+    act(() => renderer?.unmount())
   })
 
   it('leaves a host-only notification as a shallow push with nothing to coordinate', () => {

--- a/mobile/src/notifications/notification-route-coordination.test.ts
+++ b/mobile/src/notifications/notification-route-coordination.test.ts
@@ -1,5 +1,5 @@
 import { createElement } from 'react'
-import { act, create } from 'react-test-renderer'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { readFileSync } from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
 import { getNotificationNavigationTarget } from './notification-routing'
@@ -152,7 +152,7 @@ describe('notification route coordination', () => {
       return null
     }
 
-    let renderer: ReturnType<typeof create> | null = null
+    let renderer: ReactTestRenderer | null = null
     await act(async () => {
       renderer = create(createElement(LeaseHarness))
     })
@@ -180,7 +180,7 @@ describe('notification route coordination', () => {
       return null
     }
 
-    let notificationRenderer: ReturnType<typeof create> | null = null
+    let notificationRenderer: ReactTestRenderer | null = null
     await act(async () => {
       notificationRenderer = create(createElement(NotificationHookHarness))
     })
@@ -296,7 +296,7 @@ describe('notification route coordination', () => {
       return null
     }
 
-    let renderer: ReturnType<typeof create> | null = null
+    let renderer: ReactTestRenderer | null = null
     await act(async () => {
       renderer = create(createElement(LeaseHarness, { connected: false }))
     })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​360 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​360 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​166 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​158 |

<!-- /orca-pr-loc -->

## ELI5

Tapping an agent-completion notification for the Native Chat already on screen should leave that chat alone. Previously Orca navigated away and back, discarded the terminal input lease, and left Send disabled. Exact same-host/worktree notification navigation is now a no-op, while cold starts and genuinely different destinations still navigate.

## What Changed

- Compare the focused host-stack route with the requested notification destination before starting navigation.
- Treat a Native Chat session's raw host and worktree IDs as identity; presentation and one-shot query state do not force a remount.
- Preserve meaningful semantic parameters for other host-stack routes.
- Settle pending retargets that become current without reordering genuine transitions.
- Add deterministic notification-entry, route lifecycle, lease continuity, reconnect, and identity regression coverage.
- Register the invariant in the reliability gate manifest.

## Why

The shared host-stack navigation owner was performing route work for an already-focused destination. That detach cleared the terminal cache and acknowledged input lease, while the same-identity remount did not necessarily reacquire it. Preventing the invalid transition fixes the cause without chat retries, polling, Send-button exceptions, or broader lease lifecycle changes.

## Linked Issue

Fixes #16995

Linear: [STA-5821](https://linear.app/stably/issue/STA-5821/bug-mobile-notification-tap-locks-chat-composer-in-the-current)

## Visual Proof

N/A — the fix prevents an invisible same-route detach/remount. The isolated iOS simulator validated paired Native Chat lease/sendability and a real agent completion, but two bounded attempts did not produce an iOS notification banner or notification-center entry, so this PR does not claim a physical notification-tap E2E pass.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

```bash
pnpm --dir mobile exec vitest run --root .. \
  mobile/src/notifications/notification-route-coordination.test.ts \
  mobile/src/navigation/host-stack-navigation.test.ts \
  mobile/src/session/use-mobile-native-chat-input-lease.test.ts \
  mobile/src/session/MobileNativeChatView.test.ts \
  mobile/src/tasks/mobile-task-navigation.test.ts
pnpm --dir mobile typecheck
pnpm --dir mobile lint
pnpm run check:reliability-gates
pnpm run check:code-quality:changed
git diff --check
```

Results: 41/41 tests passed; typecheck, lint, all 100 reliability gates, changed-code quality, and diff checks passed.

The byte-identical focused 35-test oracle failed 4 tests on current-main behavior, passed 35/35 with the fix, failed the same 4 with the identity/retarget decisions disabled, and passed 35/35 after restoration.

## AI Disclosure

## Review

Fresh design, performance, and adversarial reviews were clean. Earlier review findings addressed raw percent-encoding aliases, use of the production notification hook, semantic Tasks parameters, session query identity, retarget-to-current settlement, and genuine retarget ordering.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Downside: an exact same-session tap intentionally preserves current scroll/focus and does not replay one-shot route metadata. A future notification that must target a specific response or terminal within a worktree should add that identity explicitly.

This is client-local shared iOS/Android navigation logic. It changes no RPC, remote-wire, execution ownership, filesystem, Git, SSH, WSL, provider, or platform-specific behavior. Live Android, physical-device notification delivery, and live paired-host reconnect remain explicit reliability-gate gaps.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (focused mobile equivalents pass; full CI will cover the repository-wide matrix)
