### PR TITLE
fix: arm first-work branch rename in headless orca serve

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1699,8 +1699,7 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
       providerSessionOnly,
       promptInteractionKey,
       restoredUnconfirmed,
-      observation,
-      isReplay
+      observation
     }) => {
       if (mainWindow?.isDestroyed()) {
         return
@@ -1721,9 +1720,6 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
           providerSessionOnly: true
         })
         return
-      }
-      if (!restoredUnconfirmed) {
-        maybeAutoRenameBranchOnFirstWorkFromHook({ paneKey, tabId, worktreeId, payload, isReplay })
       }
       const orchestration = runtime?.getAgentStatusOrchestrationContextForPaneKey(paneKey)
       const terminalHandle = runtime?.getAgentStatusTerminalHandleForPaneKey(paneKey)
@@ -3041,6 +3037,24 @@ void app.whenReady().then(async () => {
       receivedAt: enriched.receivedAt
     })
   })
+  agentHookServer.subscribeEnrichedStatus(
+    /** Arms first-work branch rename on the additive tap: it is store/runtime-only work, and headless serve never registers the main-window fanout. */
+    ({
+      paneKey,
+      tabId,
+      worktreeId,
+      payload,
+      providerSessionOnly,
+      restoredUnconfirmed,
+      isReplay
+    }) => {
+      // Why: mirrors the window fanout gates — session-identity refreshes carry no turn state, and restored rows are historical claims.
+      if (providerSessionOnly || restoredUnconfirmed) {
+        return
+      }
+      maybeAutoRenameBranchOnFirstWorkFromHook({ paneKey, tabId, worktreeId, payload, isReplay })
+    }
+  )
   runtimeService.onWorktreeLifecycle((event) => {
     emitPluginWorktreeLifecycle(event)
   })

--- a/src/main/startup/first-work-rename-headless-wiring.test.ts
+++ b/src/main/startup/first-work-rename-headless-wiring.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('first-work rename wiring', () => {
+  const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+
+  it('arms the rename before the serve early return so headless serve keeps it', () => {
+    const appReadyIndex = source.indexOf('app.whenReady().then(async () => {')
+    const renameIndex = source.indexOf(
+      'maybeAutoRenameBranchOnFirstWorkFromHook({ paneKey, tabId, worktreeId, payload, isReplay })',
+      appReadyIndex
+    )
+    const serveIndex = source.indexOf('if (serveOptions) {', appReadyIndex)
+
+    expect(appReadyIndex).toBeGreaterThanOrEqual(0)
+    expect(renameIndex).toBeGreaterThan(appReadyIndex)
+    expect(serveIndex).toBeGreaterThan(renameIndex)
+  })
+
+  it('subscribes through the additive tap, not the single-slot main-window fanout', () => {
+    const windowListenerIndex = source.indexOf('agentHookServer.setListener(\n')
+    const windowListenerEndIndex = source.indexOf(
+      'agentHookServer.setPaneStatusClearListener((clear)',
+      windowListenerIndex
+    )
+    const windowListener = source.slice(windowListenerIndex, windowListenerEndIndex)
+
+    expect(windowListenerIndex).toBeGreaterThanOrEqual(0)
+    expect(windowListenerEndIndex).toBeGreaterThan(windowListenerIndex)
+    expect(windowListener).not.toContain('maybeAutoRenameBranchOnFirstWorkFromHook')
+    expect(source).toContain('agentHookServer.subscribeEnrichedStatus(')
+  })
+
+  it('keeps the fanout gates that skip session-only refreshes and restored rows', () => {
+    const appReadyIndex = source.indexOf('app.whenReady().then(async () => {')
+    const renameIndex = source.indexOf(
+      'maybeAutoRenameBranchOnFirstWorkFromHook({ paneKey, tabId, worktreeId, payload, isReplay })',
+      appReadyIndex
+    )
+    const subscribeIndex = source.lastIndexOf(
+      'agentHookServer.subscribeEnrichedStatus(',
+      renameIndex
+    )
+    const subscription = source.slice(subscribeIndex, renameIndex)
+
+    expect(subscribeIndex).toBeGreaterThanOrEqual(0)
+    expect(subscription).toContain('if (providerSessionOnly || restoredUnconfirmed) {')
+  })
+})


### PR DESCRIPTION
## ELI5

When an agent starts its first turn, Orca renames the workspace and branch from `snipefish` to something that describes the work. That rename was wired into the callback that only exists while the desktop window is open, so on a headless `orca serve` box it never happened — workspaces there keep their creature name forever. This moves the rename onto the hook-server subscription that also fires with no window, so it works in both modes.

## What Changed

- `src/main/index.ts`: `maybeAutoRenameBranchOnFirstWorkFromHook` moves out of the `agentHookServer.setListener(...)` main-window fanout and onto `agentHookServer.subscribeEnrichedStatus(...)`, registered in shared `app.whenReady()` startup before the serve branch returns.
- The fanout's gates are preserved on the new subscription: `providerSessionOnly` (session-identity refresh, no turn state) and `restoredUnconfirmed` (historical claim, not fresh activity) still skip.
- `isReplay` is dropped from the window fanout destructure — it was only read by the rename call. The rename still ignores replays on its own (`subscribeEnrichedStatus` does not replay, and `maybeAutoRenameBranchOnFirstWork` returns early on `isReplay`).
- New test `src/main/startup/first-work-rename-headless-wiring.test.ts`, following the existing `src/main/startup/*-wiring.test.ts` pattern.

No behavior change on desktop: `emitEnrichedStatus` calls the window slot and the additive listeners from the same site with the same payload.

## Why

`agentHookServer.setListener(...)` is registered inside `openMainWindow()` and cleared again in `window.on('closed')`. In serve mode `app.whenReady()` returns inside `if (serveOptions) { … return }` before `openMainWindow()` is ever called, so the listener is never registered. `orca open` cannot rescue it either — on a serve host that path only calls `focusExistingWindow()`, which can focus a window but not create one, so it just returns `runtime_open_timeout`. The result is that first-work rename is unreachable by any route on a headless server.

`AgentHookServer` already has the correct seam, and its own comment names this exact case:

```ts
// Why: setListener is a single slot owned by the main-window fanout; the
// plugin event bus (and future consumers) need an additive subscription
// that also works in headless serve, where no window listener exists.
private enrichedStatusListeners = new Set<(payload: EnrichedAgentHookEventPayload) => void>()
```

The rename callback is store/runtime-only — it reads settings, repo, and worktree meta, and never touches `mainWindow` — so it belongs on that tap. The rest of the fanout (renderer sends, synthetic titles, `setPaneStatusClearListener`) is renderer-facing and correctly stays window-gated.

## Linked Issue

Fixes #17069

## Visual Proof

No renderer change, so there is no screenshot to take — but this **is** a behavior change, so here is a real before/after instead.

Both runs boot the built headless server (`out/main/index.js --serve --serve-port … --user-data-dir=<tmp>`) the same way `config/scripts/runtime-serve-terminal-smoke.mjs` does, add a throwaway repo, create a worktree named `snipefish` (auto-generated creature name, no upstream), launch `--agent claude --prompt "Investigate why the checkout page redirects twice before showing the cart…"`, and poll `worktree list`. **Same script, same flags, same agent, same prompt — only the build differs.**

**BEFORE** — `main`, headless serve:

```
[probe] initial displayName=snipefish
[probe] initial branch=refs/heads/snipefish
[probe] RESULT renamed=false
[probe] RESULT displayName=snipefish
[probe] RESULT branch=refs/heads/snipefish
[probe] RESULT auto-branch-rename log lines=0
```

The agent ran a full turn. The workspace kept its creature name, and the server logged nothing — every `stop`/`retry` path inside `runAutoRename` logs, so zero lines means it was never entered.

**AFTER** — this PR, headless serve:

```
[probe] initial displayName=snipefish
[probe] initial branch=refs/heads/snipefish
[probe] RESULT renamed=true
[probe] RESULT displayName=Investigate checkout double redirect
[probe] RESULT branch=refs/heads/investigate-checkout-double-redirect
[probe] RESULT auto-branch-rename log lines=1
[probe]   | [auto-branch-rename] renamed snipefish -> investigate-checkout-double-redirect; display "" -> "Investigate checkout double redirect"
```

| | `displayName` | branch | `[auto-branch-rename]` lines |
| --- | --- | --- | --- |
| **Before** (`main`) | `snipefish` | `refs/heads/snipefish` | 0 |
| **After** (this PR) | `Investigate checkout double redirect` | `refs/heads/investigate-checkout-double-redirect` | 1 |

Desktop is unaffected: the rename already worked there and still does, since `emitEnrichedStatus` feeds the window slot and the additive listeners from the same call site with the same payload.

## Testing

The headless before/after above is the primary verification — it was run against both builds before this PR was opened. Suites:

- `pnpm tc` — clean
- `oxlint` on the changed files — clean
- `vitest run src/main/startup` — 39 files, 289 tests pass
- `vitest run src/main/agent-hooks` — 75 files, 756 tests pass
- Full `vitest run` — 64,264 pass. 8 failures on my machine only, all pre-existing and environment-bound (`cross-version-wire` needs a prior-version artifact, `shell-startup`/`repro-13767`/`node-pty-fd-leak` are local zsh/macOS-fd tests, and one renderer at-scale timing assertion). None read `src/main/index.ts`.
- The new wiring test fails 3/3 with the change reverted and passes 3/3 with it, so it is a real regression guard rather than a restatement of the code.

Platforms actually tested: macOS (desktop + headless serve). The change is platform-neutral — no paths, shells, or process spawning involved.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Investigated and written with Claude Opus 5 in Claude Code. The root cause was found by bisecting the bundled `app.asar` on a live headless host, then confirmed against this source tree; the end-to-end probe above was written and run before opening the PR.

## Review

Reviewed against the checklist:

- **Cross-platform**: no platform-conditional code, no paths, no shell or process spawning. `subscribeEnrichedStatus` and `setListener` are both fed by `emitEnrichedStatus` on every OS.
- **SSH / remote / local**: the subscription reads `connectionId`-independent fields and hands the same event shape to the same orchestrator as before. `runAutoRename` keeps its existing SSH branch (`getSshGitProvider`, `provider.exec`) untouched, so remote worktrees route through the same provider they did before. Serve hosts are the case this fixes.
- **Agents / integrations**: provider-neutral. The gates keyed off `providerSessionOnly` and `restoredUnconfirmed` are unchanged, so Claude/Codex/Pi behave as before; nothing keys off `agentType`.
- **Performance**: one extra `Set` entry on a tap that already iterates for the plugin bus, and the callback returns on the first check for every event that is not `state === 'working'`. The in-flight/settled guards inside `maybeAutoRenameBranchOnFirstWork` still bound the work to one attempt per worktree.
- **UI quality**: no renderer change.
- **Security**: no new IPC surface, no new network or filesystem access, no token or credential handling.
- **Backwards compatibility**: desktop ordering is unchanged relative to the renderer send (both fire from `emitEnrichedStatus`), and no persisted shape changes.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

One adjacent gap this PR deliberately does not touch: `orca open` on a serve host reports `desktopWindowStatus: "openable"` and then times out, because serve-mode activation only focuses an existing window. That is worth its own issue — it is the reason a headless user cannot work around window-gated features at all.

## Author

X: [@ocs](https://x.com/ocs)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
