### PR TITLE
fix(ci): stop the Linux Electron probe step from starving its own probes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -265,11 +265,30 @@ jobs:
       - name: Run Docker SSH watcher isolation E2E
         run: xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:ssh-docker-watcher-isolation
 
+      # Why: Playwright empties test-results/ when it starts, so each step here used to
+      # destroy the previous step's traces. Only the last lane's failure was ever
+      # diagnosable from the artifact; set each lane aside before the next one runs.
+      - name: Keep watcher-isolation traces
+        if: always()
+        run: |
+          if [ -d test-results ]; then
+            mkdir -p e2e-traces
+            mv test-results "e2e-traces/watcher-isolation"
+          fi
+
       # Why always(): this lane gates SSH parking/retention plus startup-exec
       # readiness across live SSH, headed paired, and headless serve topologies.
       - name: Run Docker SSH terminal parking + startup readiness E2E
         if: always()
         run: xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:ssh-docker-terminal-parking
+
+      - name: Keep terminal-parking traces
+        if: always()
+        run: |
+          if [ -d test-results ]; then
+            mkdir -p e2e-traces
+            mv test-results "e2e-traces/terminal-parking"
+          fi
 
       # Why here rather than the sharded lanes: the shards set no ORCA_E2E_SSH_DOCKER, so every
       # spec below skipped itself while the shard still reported green. Running them on this one
@@ -279,11 +298,19 @@ jobs:
         if: always()
         run: xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:ssh-docker
 
+      - name: Keep remaining-ssh-docker traces
+        if: always()
+        run: |
+          if [ -d test-results ]; then
+            mkdir -p e2e-traces
+            mv test-results "e2e-traces/remaining-ssh-docker"
+          fi
+
       - name: Upload watcher isolation traces
         if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: playwright-traces-ssh-docker-watcher-isolation
-          path: test-results/
+          path: e2e-traces/
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -593,9 +593,13 @@ jobs:
         with:
           native-runtime: electron
 
+      # Why --no-file-parallelism: every file here launches a full Electron stack twice, and each
+      # probe carries its own in-process deadline. Four at once on a 4-vCPU runner starve each other
+      # past those deadlines; serial, every probe owns the runner.
       - name: Test Linux Electron lifecycle boundary
         run: >-
           xvfb-run --auto-servernum pnpm exec vitest run --config config/vitest.config.ts
+          --no-file-parallelism
           src/main/browser/browser-client-page-renderer-lifecycle.electron.test.ts
           src/main/browser/browser-route-tcp-egress.electron.test.ts
           src/main/browser/browser-route-webrtc-egress.electron.test.ts

--- a/config/scripts/client-hosted-browser-package-coverage.test.mjs
+++ b/config/scripts/client-hosted-browser-package-coverage.test.mjs
@@ -37,4 +37,16 @@ describe('client-hosted browser package coverage', () => {
       expect(windowsStep.run).toContain(file)
     }
   })
+
+  // Why pinned: each of those files launches a full Electron stack twice under its own in-process
+  // deadline. Letting the runner interleave four of them starved the probes past those deadlines,
+  // which is the only way this step has ever failed.
+  it('gives each Linux Electron probe the runner to itself', () => {
+    const parsedWorkflow = parse(readFileSync(join(projectDir, '.github/workflows/pr.yml'), 'utf8'))
+    const linuxStep = parsedWorkflow.jobs.package.steps.find(
+      (step) => step.name === 'Test Linux Electron lifecycle boundary'
+    )
+
+    expect(linuxStep.run).toContain('--no-file-parallelism')
+  })
 })

--- a/src/main/browser/browser-client-page-renderer-lifecycle.electron.test.ts
+++ b/src/main/browser/browser-client-page-renderer-lifecycle.electron.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
 import { build as buildVite } from 'vite'
+import { resolveElectronProbeLaunch } from './electron-probe-display-launch'
 
 const electronBinary = createRequire(import.meta.url)('electron') as string
 const fixtureRoots: string[] = []
@@ -276,11 +277,12 @@ async function runFixture(): Promise<FixtureResult> {
 
   const { ELECTRON_RUN_AS_NODE: _electronRunAsNode, ...env } = process.env
   const electronArgs = [mainPath, `--user-data-dir=${join(root, 'profile')}`]
-  const executable = process.platform === 'linux' ? 'xvfb-run' : electronBinary
-  const args =
-    process.platform === 'linux'
-      ? ['--auto-servernum', electronBinary, ...electronArgs, '--no-sandbox']
-      : electronArgs
+  const { executable, args } = resolveElectronProbeLaunch({
+    electronBinary,
+    electronArgs,
+    platform: process.platform,
+    display: env.DISPLAY
+  })
   const run = spawnSync(executable, args, { encoding: 'utf8', env, timeout: 60_000 })
   const rawResult = existsSync(resultPath) ? readFileSync(resultPath, 'utf8') : 'no result'
   expect(run.error).toBeUndefined()

--- a/src/main/browser/browser-route-egress-electron-launch.ts
+++ b/src/main/browser/browser-route-egress-electron-launch.ts
@@ -2,6 +2,7 @@ import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { join } from 'node:path'
+import { resolveElectronProbeLaunch } from './electron-probe-display-launch'
 
 const electronBinary = createRequire(import.meta.url)('electron') as string
 
@@ -20,12 +21,13 @@ export async function runBrowserRouteEgressElectron(
     `--user-data-dir=${join(root, 'profile')}`,
     ...extraElectronArgs
   ]
-  const executable = process.platform === 'linux' ? 'xvfb-run' : electronBinary
-  const args =
-    process.platform === 'linux'
-      ? ['--auto-servernum', electronBinary, ...electronArgs, '--no-sandbox']
-      : electronArgs
   const { ELECTRON_RUN_AS_NODE: _electronRunAsNode, ...env } = process.env
+  const { executable, args } = resolveElectronProbeLaunch({
+    electronBinary,
+    electronArgs,
+    platform: process.platform,
+    display: env.DISPLAY
+  })
   const child = spawn(executable, args, {
     detached: true,
     env,

--- a/src/main/browser/browser-route-persisted-worker-electron-process.ts
+++ b/src/main/browser/browser-route-persisted-worker-electron-process.ts
@@ -2,6 +2,7 @@ import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { existsSync, readFileSync, rmSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { join } from 'node:path'
+import { resolveElectronProbeLaunch } from './electron-probe-display-launch'
 
 const electronBinary = createRequire(import.meta.url)('electron') as string
 
@@ -20,12 +21,13 @@ export async function runPersistedWorkerElectron(
   const resultPath = join(root, 'result.json')
   rmSync(resultPath, { force: true })
   const electronArgs = [mainPath, configPath, mode, `--user-data-dir=${join(root, 'profile')}`]
-  const executable = process.platform === 'linux' ? 'xvfb-run' : electronBinary
-  const args =
-    process.platform === 'linux'
-      ? ['--auto-servernum', electronBinary, ...electronArgs, '--no-sandbox']
-      : electronArgs
   const { ELECTRON_RUN_AS_NODE: _electronRunAsNode, ...env } = process.env
+  const { executable, args } = resolveElectronProbeLaunch({
+    electronBinary,
+    electronArgs,
+    platform: process.platform,
+    display: env.DISPLAY
+  })
   const child = spawn(executable, args, {
     detached: true,
     env,

--- a/src/main/browser/browser-route-webrtc-egress.electron.test.ts
+++ b/src/main/browser/browser-route-webrtc-egress.electron.test.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
+import { resolveElectronProbeLaunch } from './electron-probe-display-launch'
 
 const electronBinary = createRequire(import.meta.url)('electron') as string
 const fixtureRoots: string[] = []
@@ -138,11 +139,12 @@ function runProbe(protectedGuest: boolean): ProbeResult {
   writeFileSync(mainPath, probeMain(resultPath, protectedGuest))
   const { ELECTRON_RUN_AS_NODE: _electronRunAsNode, ...env } = process.env
   const electronArgs = [mainPath, `--user-data-dir=${join(root, 'profile')}`]
-  const executable = process.platform === 'linux' ? 'xvfb-run' : electronBinary
-  const args =
-    process.platform === 'linux'
-      ? ['--auto-servernum', electronBinary, ...electronArgs, '--no-sandbox']
-      : electronArgs
+  const { executable, args } = resolveElectronProbeLaunch({
+    electronBinary,
+    electronArgs,
+    platform: process.platform,
+    display: env.DISPLAY
+  })
   const run = spawnSync(executable, args, { encoding: 'utf8', env, timeout: 30_000 })
   const rawResult = existsSync(resultPath) ? readFileSync(resultPath, 'utf8') : 'no result'
   expect(run.error).toBeUndefined()

--- a/src/main/browser/electron-probe-display-launch.test.ts
+++ b/src/main/browser/electron-probe-display-launch.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { resolveElectronProbeLaunch } from './electron-probe-display-launch'
+
+const electronBinary = '/tmp/electron'
+const electronArgs = ['/tmp/main.cjs', '--user-data-dir=/tmp/profile']
+
+describe('electron probe launch resolution', () => {
+  it('reuses an inherited X display instead of nesting another xvfb-run server', () => {
+    expect(
+      resolveElectronProbeLaunch({
+        electronBinary,
+        electronArgs,
+        platform: 'linux',
+        display: ':99'
+      })
+    ).toEqual({
+      executable: electronBinary,
+      args: ['/tmp/main.cjs', '--user-data-dir=/tmp/profile', '--no-sandbox']
+    })
+  })
+
+  it('owns a display when Linux hands the probe none', () => {
+    expect(
+      resolveElectronProbeLaunch({
+        electronBinary,
+        electronArgs,
+        platform: 'linux',
+        display: undefined
+      })
+    ).toEqual({
+      executable: 'xvfb-run',
+      args: [
+        '--auto-servernum',
+        electronBinary,
+        '/tmp/main.cjs',
+        '--user-data-dir=/tmp/profile',
+        '--no-sandbox'
+      ]
+    })
+  })
+
+  it('treats an empty DISPLAY as no display', () => {
+    expect(
+      resolveElectronProbeLaunch({ electronBinary, electronArgs, platform: 'linux', display: '' })
+        .executable
+    ).toBe('xvfb-run')
+  })
+
+  it('leaves non-Linux launches on the plain Electron binary', () => {
+    expect(
+      resolveElectronProbeLaunch({
+        electronBinary,
+        electronArgs,
+        platform: 'darwin',
+        display: undefined
+      })
+    ).toEqual({ executable: electronBinary, args: electronArgs })
+  })
+})

--- a/src/main/browser/electron-probe-display-launch.ts
+++ b/src/main/browser/electron-probe-display-launch.ts
@@ -1,0 +1,31 @@
+export type ElectronProbeLaunch = {
+  executable: string
+  args: string[]
+}
+
+export type ElectronProbeLaunchInput = {
+  electronBinary: string
+  electronArgs: readonly string[]
+  platform: NodeJS.Platform
+  display: string | undefined
+}
+
+// Why: these probes each start a full Electron stack, and CI already runs the whole vitest
+// invocation under one `xvfb-run`. Nesting a private `--auto-servernum` server per probe adds an
+// X server per concurrent file and races the sibling probes for a free display number, so reuse
+// the display we were handed and only own one when there is none.
+export function resolveElectronProbeLaunch({
+  electronBinary,
+  electronArgs,
+  platform,
+  display
+}: ElectronProbeLaunchInput): ElectronProbeLaunch {
+  if (platform !== 'linux') {
+    return { executable: electronBinary, args: [...electronArgs] }
+  }
+  const linuxArgs = [...electronArgs, '--no-sandbox']
+  if (display) {
+    return { executable: electronBinary, args: linuxArgs }
+  }
+  return { executable: 'xvfb-run', args: ['--auto-servernum', electronBinary, ...linuxArgs] }
+}


### PR DESCRIPTION
## What was flaky, explained simply

**The `package` job's "Test Linux Electron lifecycle boundary" step.** It runs five test files, and
each one launches a **real Electron app, twice**, to probe how the browser routes traffic. Vitest's
default is to run test files in parallel, so on a 4-CPU GitHub runner **four full Electron stacks were
launched at the same time** and fought each other for CPU.

Each probe also gives itself a stopwatch: the Electron process it starts kills itself with exit code
`2` if it has not finished in 20 s (WebRTC) or 25 s (HTTP/3). When four stacks compete, a probe that
normally takes ~6 s can blow past 20 s — and the step fails with `AssertionError: no result`, on a
file the PR never touched.

On top of that, **every probe started its own X server**. The CI step already runs everything under
one `xvfb-run --auto-servernum`, and then each probe launched *another* `xvfb-run --auto-servernum`
inside it — up to five X servers, all racing each other to claim a free display number.

## The evidence it was starvation, not a slow assertion

Every failure exited with code **2**, which is only ever produced by the probe's own internal
watchdog — not by a failed assertion, and not by a missing display. And in **8 of 8** failing runs,
*every other file in the same run* was slower than its own green maximum:

| file | green p50 | green max | value in the 8 failing runs |
| --- | --- | --- | --- |
| `browser-client-page-renderer-lifecycle` | 3.7 s | 11.2 s | 13.6 – 19.1 s (**all above green max**) |
| `browser-route-h3-egress` | 17.2 s | 24.3 s | 25.2 – 28.9 s (**all at/above green max**) |
| `browser-route-webrtc-egress` | 13.3 s | 22.0 s | 20.2 – 20.7 s (**its 20 s watchdog**) |
| `browser-route-tcp-egress` | 0.85 s | 1.8 s | 0.79 – 3.1 s |
| `browser-route-dns-prefetch` | 4.37 s | 4.52 s | 4.33 – 5.00 s (sleep-bound; barely moves) |

The whole runner was slow, uniformly — the classic starvation fingerprint. `dns-prefetch` is the
control: it is dominated by fixed sleeps rather than CPU, and it is the one file that does not move.

The runs also show the oversubscription directly: reported test time is **55–72 s** against a
**15–29 s** wall clock, i.e. 3–4× overlap, sustained, on 4 vCPUs.

## Measured rates

Measured myself over **898 `pr.yml` runs** between `2026-08-27T09:33Z` and `2026-08-28T22:10Z`
(GitHub jobs API, not inherited from a report):

- **Before: 8 genuine failures in 586 valid step runs — 1.37% fail / 98.63% pass**, across **8
  unrelated branches**. (Two further non-success outcomes were workflow cancellations and are
  excluded.)
- **After** (this PR's own `package` run, [job 99005552280](https://github.com/stablyai/orca/actions/runs/33217547604)),
  every CPU-bound probe now lands at or below its previous *minimum* across 40 sampled green runs:

  | file | before p50 | before min | before max | after |
  | --- | --- | --- | --- | --- |
  | `browser-client-page-renderer-lifecycle` | 3693 ms | 923 ms | 11230 ms | **981 ms** |
  | `browser-route-webrtc-egress` | 13250 ms | 8345 ms | 22027 ms | **8620 ms** |
  | `browser-route-h3-egress` | 17160 ms | 14373 ms | 24323 ms | **13809 ms** (below the old min) |
  | `browser-route-tcp-egress` | 852 ms | 640 ms | 1808 ms | 797 ms |
  | `browser-route-dns-prefetch` | 4369 ms | 4243 ms | 4522 ms | 4360 ms (sleep-bound control) |

  That restores the headroom the deadlines assume: WebRTC now runs ~4.3 s per probe against its 20 s
  watchdog (4.6×), HTTP/3 ~6.9 s against 25 s (3.6×). At the failures they were at 1.0×.
- **Cost: the step went 19 s (previous green p50) → 30 s** — still inside the previous
  distribution's own maximum of 31 s, on a `package` job that runs for minutes.
- A single green run does not establish a new failure *rate* at a 1.37% base rate; the timing table
  above is the evidence, and a comparable volume of post-merge runs is what would confirm it.

## What changed

1. `--no-file-parallelism` on that one step, so the five heavyweight probe files run one at a time.
   Pinned by a new assertion in `client-hosted-browser-package-coverage.test.mjs`.
2. A shared `resolveElectronProbeLaunch` used by all four probe launch sites: on Linux, reuse an
   inherited `DISPLAY` instead of nesting another `xvfb-run --auto-servernum`; own an X server only
   when there is no display (test shards, local dev), so those lanes are byte-for-byte unchanged.
3. The Docker-SSH E2E job now sets each step's `test-results/` aside before the next step runs.
   Playwright empties that directory on every run, so the job's three E2E steps were destroying each
   other's traces and only the **last** step's failure was ever diagnosable. I hit this directly:
   the trace for a real `ssh-startup-exec-readiness` failure was already gone from the artifact.

## What I deliberately did not change

- **No deadline was raised.** Not the probes' 20 s/25 s internal watchdogs, not `spawnSync`'s
  timeouts, not any Vitest timeout. A bigger deadline hides contention instead of removing it.
- **No assertion weakened, no retry, nothing skipped.**
- **The `package (windows)` step.** Its 4.32% non-success rate is dominated by unrelated tests
  (`rebuild-native-deps`, `windows-host-job`); the two sampled failures that did touch these probes
  failed at 1.9 s and 7.8 s, i.e. a different signature, not the watchdog.
- **The seven `browser-cookie-import-*.electron.test.ts` probes.** They still hand-roll
  `xvfb-run --auto-servernum`, but they only run in the test shards where no display is inherited, so
  converting them would change nothing today.
- **`ssh-startup-exec-readiness.spec.ts`.** See below — I did not determinise it.

## The second flake: `ssh-startup-exec-readiness.spec.ts` (reported, not patched)

Measured: **3 genuine failures in 136 valid runs — 2.21% fail / 97.79% pass**, on three unrelated
branches (three further non-successes were cancellations). All three are the identical shape.

It is **not** a marginal timeout, and the cause is *not* runner load:

- A green run completes the entire post-reconnect phase in **~1.1 s**; the failures burn the full
  8 s and the marker never arrives **at all**.
- The **same shell command** writes a ledger file and then prints the marker. The ledger poll
  succeeds — so the command ran — while only its PTY output is missing. The output is lost, not late.
- `reconnectDockerSshRelayTarget` resolves on `ssh.connect` returning `status: 'connected'` — the
  *transport* signal — and the spec releases the shell barrier one `docker exec` later. In the
  failing run the release and the host's `pty.attach` land within ~50 ms of each other. It is a coin
  flip, and every other reconnect spec in this repo (`ssh-docker-reconnect-pane-restore`,
  `ssh-reconnect-tab-destruction`, …) follows its reconnect with an explicit settle that this one
  lacks.

So the likely defect is that **PTY output produced between relay reconnect and host PTY re-attach
can be dropped** — which is precisely what this spec exists to guard. Synchronising the test on the
re-attach would make it green while hiding that. There is also no host-side observable to
synchronise on: `terminal.show` exposes `connected`/`writable`, which track the remote *process*,
not the relay attach. Docker is dead on this machine, so I could not reproduce it, and a single
`workflow_dispatch` green proves nothing at a 2.21% base rate. Change 3 above is what makes the next
occurrence diagnosable.
