### PR TITLE
fix(ssh): find the SFTP-visible home below a chrooted start directory

### DIFF
--- a/src/main/ssh/sftp-namespace-resolution.test.ts
+++ b/src/main/ssh/sftp-namespace-resolution.test.ts
@@ -270,6 +270,16 @@ describe('resolveSftpTransferPath', () => {
       expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('READDIR failed'))
     })
 
+    it('keeps the shell path when the session has no readdir', async () => {
+      const { sftp } = makeSftp({ startPath: '/' })
+      Reflect.deleteProperty(sftp, 'readdir')
+
+      const resolved = await resolveSftpTransferPath(sftp, `${SHELL_HOME}/${RELAY_DIR}`, mapping)
+
+      expect(resolved).toBe(`${SHELL_HOME}/${RELAY_DIR}`)
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('READDIR failed'))
+    })
+
     it('keeps the shell path when no reachable namespace carries the marker', async () => {
       const { sftp, readdirCalls } = makeSftp({
         startPath: '/',

--- a/src/main/ssh/sftp-namespace-resolution.test.ts
+++ b/src/main/ssh/sftp-namespace-resolution.test.ts
@@ -1,7 +1,7 @@
 // Why: picking the wrong SFTP path silently installs the relay somewhere the shell
 // will never launch it, so every discovery outcome needs a pinned decision.
 
-import type { SFTPWrapper } from 'ssh2'
+import type { FileEntryWithStats, SFTPWrapper } from 'ssh2'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   resolveSftpTransferPath,
@@ -35,13 +35,34 @@ const MARKER_STATS = {
   size: 0
 }
 
-function makeSftp(options: { startPath?: unknown; lstat?: (path: string) => LstatOutcome }): {
+type DirEntry = { filename: string; kind?: 'file' | 'link' }
+
+function entries(...listing: (string | DirEntry)[]): FileEntryWithStats[] {
+  return listing
+    .map((entry) => (typeof entry === 'string' ? { filename: entry } : entry))
+    .map(({ filename, kind }) => ({
+      filename,
+      longname: filename,
+      attrs: {
+        isDirectory: () => kind === undefined,
+        isSymbolicLink: () => kind === 'link'
+      }
+    })) as unknown as FileEntryWithStats[]
+}
+
+function makeSftp(options: {
+  startPath?: unknown
+  lstat?: (path: string) => LstatOutcome
+  readdir?: FileEntryWithStats[] | Error
+}): {
   sftp: SFTPWrapper
   realpathCalls: string[]
   lstatCalls: string[]
+  readdirCalls: string[]
 } {
   const realpathCalls: string[] = []
   const lstatCalls: string[] = []
+  const readdirCalls: string[] = []
   const sftp = {
     realpath: vi.fn((path: string, cb: (err: Error | null, resolved?: unknown) => void) => {
       realpathCalls.push(path)
@@ -59,9 +80,20 @@ function makeSftp(options: { startPath?: unknown; lstat?: (path: string) => Lsta
         return
       }
       cb('code' in outcome ? statusError(outcome.code) : new Error(outcome.message))
-    })
+    }),
+    readdir: vi.fn(
+      (path: string, cb: (err: Error | undefined, list?: FileEntryWithStats[]) => void) => {
+        readdirCalls.push(path)
+        const listing = options.readdir ?? []
+        if (listing instanceof Error) {
+          cb(listing)
+          return
+        }
+        cb(undefined, listing)
+      }
+    )
   }
-  return { sftp: sftp as unknown as SFTPWrapper, realpathCalls, lstatCalls }
+  return { sftp: sftp as unknown as SFTPWrapper, realpathCalls, lstatCalls, readdirCalls }
 }
 
 // The marker lives under the SFTP start directory but not under the shell path.
@@ -141,13 +173,124 @@ describe('resolveSftpTransferPath', () => {
     expect(resolved).toBe(`/homes/alice/${RELAY_DIR}/package.json`)
   })
 
+  // Why: Synology DSM opens SFTP on the shared-folder list, so the session's home sits
+  // below the start directory instead of at it, and the shell home is unreachable (#12868).
+  describe('when the start directory is an ancestor of the SFTP-visible home', () => {
+    it('redirects to the shell home suffix the chroot re-exposes', async () => {
+      const { sftp, readdirCalls } = makeSftp({
+        startPath: '/',
+        lstat: divergentLstat('/homes/alice')
+      })
+
+      const resolved = await resolveSftpTransferPath(sftp, `${SHELL_HOME}/${RELAY_DIR}`, mapping)
+
+      expect(resolved).toBe(`/homes/alice/${RELAY_DIR}`)
+      expect(readdirCalls).toEqual([])
+    })
+
+    it('redirects to a start-directory child that carries the marker', async () => {
+      const { sftp, readdirCalls } = makeSftp({
+        startPath: '/',
+        lstat: divergentLstat('/home'),
+        readdir: entries('Documents', 'docker', 'home', 'homes')
+      })
+
+      const resolved = await resolveSftpTransferPath(sftp, `${SHELL_HOME}/${RELAY_DIR}`, mapping)
+
+      expect(resolved).toBe(`/home/${RELAY_DIR}`)
+      expect(readdirCalls).toEqual(['/'])
+    })
+
+    it('probes no entry that cannot hold the marker', async () => {
+      const { sftp, lstatCalls } = makeSftp({
+        startPath: '/',
+        lstat: divergentLstat('/home'),
+        readdir: entries({ filename: 'notes.txt', kind: 'file' }, '..', 'a/b', 'home')
+      })
+
+      const resolved = await resolveSftpTransferPath(sftp, `${SHELL_HOME}/${RELAY_DIR}`, mapping)
+
+      expect(resolved).toBe(`/home/${RELAY_DIR}`)
+      expect(lstatCalls).not.toContain(`/notes.txt/${RELAY_DIR}/${MARKER}`)
+      expect(lstatCalls).not.toContain(`/../${RELAY_DIR}/${MARKER}`)
+      expect(lstatCalls).not.toContain(`/a/b/${RELAY_DIR}/${MARKER}`)
+    })
+
+    it('follows a symlinked share', async () => {
+      const { sftp } = makeSftp({
+        startPath: '/',
+        lstat: divergentLstat('/home'),
+        readdir: entries({ filename: 'home', kind: 'link' })
+      })
+
+      const resolved = await resolveSftpTransferPath(sftp, `${SHELL_HOME}/${RELAY_DIR}`, mapping)
+
+      expect(resolved).toBe(`/home/${RELAY_DIR}`)
+    })
+
+    it('stops scanning after a bounded number of entries', async () => {
+      const listing = Array.from({ length: 80 }, (_entry, index) => `share-${index}`)
+      const { sftp, lstatCalls } = makeSftp({
+        startPath: '/',
+        lstat: divergentLstat('/share-70'),
+        readdir: entries(...listing)
+      })
+
+      const resolved = await resolveSftpTransferPath(sftp, `${SHELL_HOME}/${RELAY_DIR}`, mapping)
+
+      expect(resolved).toBe(`${SHELL_HOME}/${RELAY_DIR}`)
+      expect(lstatCalls).toContain(`/share-63/${RELAY_DIR}/${MARKER}`)
+      expect(lstatCalls).not.toContain(`/share-64/${RELAY_DIR}/${MARKER}`)
+    })
+
+    // Why: a home the account cannot stat is common on DSM, where /homes is admin-only.
+    it('keeps searching past a candidate whose probe is inconclusive', async () => {
+      const { sftp } = makeSftp({
+        startPath: '/',
+        lstat: (path) => {
+          if (path === `/homes/alice/${RELAY_DIR}/${MARKER}`) {
+            return { code: 3 }
+          }
+          return path === `/home/${RELAY_DIR}/${MARKER}` ? 'present' : { code: 2 }
+        },
+        readdir: entries('home', 'homes')
+      })
+
+      const resolved = await resolveSftpTransferPath(sftp, `${SHELL_HOME}/${RELAY_DIR}`, mapping)
+
+      expect(resolved).toBe(`/home/${RELAY_DIR}`)
+    })
+
+    it('keeps the shell path when the start directory cannot be listed', async () => {
+      const { sftp } = makeSftp({ startPath: '/', readdir: new Error('permission denied') })
+
+      const resolved = await resolveSftpTransferPath(sftp, `${SHELL_HOME}/${RELAY_DIR}`, mapping)
+
+      expect(resolved).toBe(`${SHELL_HOME}/${RELAY_DIR}`)
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('READDIR failed'))
+    })
+
+    it('keeps the shell path when no reachable namespace carries the marker', async () => {
+      const { sftp, readdirCalls } = makeSftp({
+        startPath: '/',
+        readdir: entries('Documents', 'home', 'homes')
+      })
+
+      const resolved = await resolveSftpTransferPath(sftp, `${SHELL_HOME}/${RELAY_DIR}`, mapping)
+
+      expect(resolved).toBe(`${SHELL_HOME}/${RELAY_DIR}`)
+      expect(readdirCalls).toEqual(['/'])
+    })
+  })
+
   it('refuses an unrelated same-version directory that lacks our marker', async () => {
     const { sftp, lstatCalls } = makeSftp({ startPath: '/homes/alice' })
 
     const resolved = await resolveSftpTransferPath(sftp, `${SHELL_HOME}/${RELAY_DIR}`, mapping)
 
     expect(resolved).toBe(`${SHELL_HOME}/${RELAY_DIR}`)
-    expect(lstatCalls).toHaveLength(2)
+    expect(lstatCalls[0]).toBe(mapping.shellProbePath)
+    expect(lstatCalls).toContain(`/homes/alice/${RELAY_DIR}/${MARKER}`)
   })
 
   it('keeps the shell path when the marker is already visible there', async () => {

--- a/src/main/ssh/sftp-namespace-resolution.ts
+++ b/src/main/ssh/sftp-namespace-resolution.ts
@@ -2,9 +2,13 @@
 // different absolute namespaces for the same directory (e.g. Synology DSM's
 // /var/services/homes/alice shell home vs. /homes/alice SFTP start directory).
 //
+// The start directory is not always the home: a chrooted subsystem can open on an
+// ancestor of it — DSM lands on the shared-folder list, where that same home is
+// /homes/alice or /home — so discovery also searches below the start directory.
+//
 // See: docs/ssh-relay-sftp-namespace.md
 
-import type { SFTPWrapper } from 'ssh2'
+import type { FileEntryWithStats, SFTPWrapper } from 'ssh2'
 import { assertSafeRemotePathSegment, isWindowsRemoteHost } from './ssh-remote-platform'
 import type { RemoteHostPlatform } from './ssh-remote-platform'
 import { redactRelayInstallMarkerTokens } from './ssh-relay-install-marker'
@@ -19,6 +23,10 @@ export type SftpNamespacePathMapping = {
 // SSH_FX_NO_SUCH_FILE. The only status that definitively proves a path is absent;
 // permission denied, generic failure, and code-less errors are inconclusive.
 const SFTP_STATUS_NO_SUCH_FILE = 2
+
+// A start directory that is not the home is a share or export list, not a data
+// directory, so a bounded scan of it either finds the home or proves it absent.
+const MAX_SCANNED_START_DIRECTORY_ENTRIES = 64
 
 type MarkerProbe =
   | { kind: 'present' }
@@ -104,6 +112,49 @@ function joinSftpStartPath(startPath: string, homeRelativePath: string): string 
   return `${startPath.replace(/\/+$/, '')}/${homeRelativePath}`
 }
 
+// Each proper suffix of the shell home, longest first: /var/services/homes/alice
+// yields services/homes/alice, homes/alice, alice. One of them is where a chroot
+// that truncated the shell prefix re-exposes the home.
+function shellHomeSuffixes(shellHome: string): string[] {
+  const segments = shellHome.split('/').filter(Boolean)
+  return segments.slice(1).map((_segment, index) => segments.slice(index + 1).join('/'))
+}
+
+function isSafePosixPathSegment(segment: string): boolean {
+  if (segment.includes('\r') || segment.includes('\n')) {
+    return false
+  }
+  try {
+    assertSafeRemotePathSegment(segment, 'posix')
+    return true
+  } catch {
+    return false
+  }
+}
+
+function readdirSftp(
+  sftp: SFTPWrapper,
+  remotePath: string
+): Promise<FileEntryWithStats[] | undefined> {
+  return new Promise((resolve) => {
+    sftp.readdir(remotePath, (err, entries) => {
+      resolve(err ? undefined : entries)
+    })
+  })
+}
+
+// Only directories can hold the marker, so plain files cost no probe.
+function startDirectoryChildRoots(startPath: string, entries: FileEntryWithStats[]): string[] {
+  return entries
+    .filter(
+      (entry) =>
+        isSafePosixPathSegment(entry.filename) &&
+        (entry.attrs.isDirectory() || entry.attrs.isSymbolicLink())
+    )
+    .slice(0, MAX_SCANNED_START_DIRECTORY_ENTRIES)
+    .map((entry) => joinSftpStartPath(startPath, entry.filename))
+}
+
 function realpathSftp(sftp: SFTPWrapper, remotePath: string): Promise<string> {
   return new Promise((resolve, reject) => {
     sftp.realpath(remotePath, (err, resolved) => {
@@ -145,12 +196,37 @@ function logRetainedShellPath(operation: string, detail: string, shellAbsolutePa
   )
 }
 
+// Why: a candidate is adopted only on its own marker hit, so an inconclusive probe
+// must neither adopt it nor end the search; details are collected for one warning.
+async function findMarkedTransferPath(
+  sftp: SFTPWrapper,
+  namespaceRoots: string[],
+  mapping: SftpNamespacePathMapping,
+  inconclusive: string[]
+): Promise<string | null> {
+  for (const namespaceRoot of namespaceRoots) {
+    const probe = await probeMarkerPath(
+      sftp,
+      joinSftpStartPath(namespaceRoot, mapping.homeRelativeProbePath)
+    )
+    if (probe.kind === 'present') {
+      return joinSftpStartPath(namespaceRoot, mapping.homeRelativePath)
+    }
+    if (probe.kind === 'inconclusive') {
+      inconclusive.push(probe.detail)
+    }
+  }
+  return null
+}
+
 /**
  * Pick the path this SFTP session should transfer to.
  *
  * Returns `shellAbsolutePath` unless the session both fails to see the install
- * owner's marker there and does see it under its own start directory. Discovery
- * failures degrade to the shell path rather than inventing a namespace error.
+ * owner's marker there and does see it under the start directory, under a suffix
+ * of the shell home below it, or under one of the start directory's children.
+ * Discovery failures degrade to the shell path rather than inventing a namespace
+ * error.
  */
 export async function resolveSftpTransferPath(
   sftp: SFTPWrapper,
@@ -181,8 +257,7 @@ export async function resolveSftpTransferPath(
     return shellAbsolutePath
   }
 
-  const candidatePath = joinSftpStartPath(startPath, mapping.homeRelativePath)
-  if (candidatePath === shellAbsolutePath) {
+  if (joinSftpStartPath(startPath, mapping.homeRelativePath) === shellAbsolutePath) {
     return shellAbsolutePath
   }
 
@@ -194,18 +269,39 @@ export async function resolveSftpTransferPath(
     return shellAbsolutePath
   }
 
-  const candidateMarker = await probeMarkerPath(
-    sftp,
-    joinSftpStartPath(startPath, mapping.homeRelativeProbePath)
+  const inconclusive: string[] = []
+  const shellHome = shellAbsolutePath.slice(0, -(mapping.homeRelativePath.length + 1))
+  const suffixRoots = shellHomeSuffixes(shellHome).map((suffix) =>
+    joinSftpStartPath(startPath, suffix)
   )
-  if (candidateMarker.kind === 'present') {
-    console.log(
-      `[ssh-relay] SFTP namespace differs; transfer path: ${redactRelayInstallMarkerTokens(candidatePath)}`
-    )
-    return candidatePath
+  let transferPath = await findMarkedTransferPath(
+    sftp,
+    [startPath, ...suffixRoots],
+    mapping,
+    inconclusive
+  )
+  if (!transferPath) {
+    const entries = await readdirSftp(sftp, startPath)
+    if (entries) {
+      transferPath = await findMarkedTransferPath(
+        sftp,
+        startDirectoryChildRoots(startPath, entries),
+        mapping,
+        inconclusive
+      )
+    } else {
+      inconclusive.push('READDIR failed')
+    }
   }
-  if (candidateMarker.kind === 'inconclusive') {
-    logRetainedShellPath('LSTAT', candidateMarker.detail, shellAbsolutePath)
+
+  if (transferPath) {
+    console.log(
+      `[ssh-relay] SFTP namespace differs; transfer path: ${redactRelayInstallMarkerTokens(transferPath)}`
+    )
+    return transferPath
+  }
+  if (inconclusive.length > 0) {
+    logRetainedShellPath('search', inconclusive.join('; '), shellAbsolutePath)
   }
   return shellAbsolutePath
 }

--- a/src/main/ssh/sftp-namespace-resolution.ts
+++ b/src/main/ssh/sftp-namespace-resolution.ts
@@ -137,9 +137,13 @@ function readdirSftp(
   remotePath: string
 ): Promise<FileEntryWithStats[] | undefined> {
   return new Promise((resolve) => {
-    sftp.readdir(remotePath, (err, entries) => {
-      resolve(err ? undefined : entries)
-    })
+    try {
+      sftp.readdir(remotePath, (err, entries) => {
+        resolve(err ? undefined : entries)
+      })
+    } catch {
+      resolve(undefined)
+    }
   })
 }
 

--- a/src/main/ssh/ssh-relay-sftp-namespace-install.test.ts
+++ b/src/main/ssh/ssh-relay-sftp-namespace-install.test.ts
@@ -186,6 +186,9 @@ function makeConnection(capture: Capture, options: ConnectionOptions = {}): SshC
         capture.lstatCalls.push(path)
         cb(lstatPresent(path) ? null : Object.assign(new Error('No such file'), { code: 2 }))
       }),
+      readdir: vi.fn((_path: string, cb: (err: Error | undefined, list?: unknown[]) => void) => {
+        cb(undefined, [])
+      }),
       createWriteStream: vi.fn().mockImplementation((path: string) => {
         capture.writePaths.push(path)
         const ws = new EventEmitter()


### PR DESCRIPTION
## ELI5

On some NAS boxes, the SSH shell and the SFTP file transfer live in different directory trees. Orca used to upload the relay using the shell home path. SFTP does not see that path, so the upload failed with "No such file" and the host stayed stuck on Connecting. This change looks under the SFTP start directory for the same home — first as a suffix of the shell path, then as a child folder — and only uses a candidate if this install's own marker file is there.

## Goal

Stop Synology-style SFTP chroots from crashing relay install. A split namespace now remaps the upload to the SFTP-visible home instead of writing the shell path and dying.

## Problem it solves

- Adding a Synology DSM SSH host crashed the main process with `Error: No such file` during relay upload, and the target never left Connecting ([#12868](https://github.com/stablyai/orca/issues/12868)).
- Shell `$HOME` is `/var/services/homes/<user>`. SFTP opens on the shared-folder list (`/`), where that same directory is `/homes/<user>` or `/home`.
- The existing namespace redirect only tried "start directory *is* the home". It never searched *below* the start directory.

## What Changed

- After the shell marker is confirmed absent, discovery probes the SFTP start directory, then each proper suffix of the shell home under that start (`/homes/alice`), then a bounded list of child directories (`/home`).
- A candidate is used only when this install's marker is present there. An inconclusive probe (permission denied on `/homes`) does not stop the search.
- If listing the start directory throws or is missing, discovery keeps the shell path instead of throwing.

## Why

The marker already proves "this session created that directory". Extending the search with the same proof is enough. Inventing a new error type would still leave Connecting stuck.

## Linked Issue

Fixes #12868

Refs #15479 — same crash signature, different cause, and **not fixed here**. On that host the SFTP subsystem is a separate sandboxed filesystem rather than a different path into the same one, so the relay directory this install creates over the shell channel is never visible to SFTP and no amount of searching finds it. That report's actual ask, catching `SSH_FX_NO_SUCH_FILE` and degrading to a no-relay connection instead of an uncaught exception, is untouched by this diff.

## Visual Proof

N/A. No UI. The change is SSH relay path selection. Success is a completed Connect, not a screenshot.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Automated**

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/sftp-namespace-resolution.test.ts src/main/ssh/ssh-relay-sftp-namespace-install.test.ts src/main/ssh/ssh-connection-sftp-namespace.test.ts` — 81 pass
- `pnpm build` — pass
- Full `pnpm test` locally hit unrelated timeouts (git remote, UI hover, relay idle grace). Not attributed to this diff.

**Manual (macOS arm64 dev build → Synology DSM, linux-x64)**

Fresh install and reconnect-with-repair both remapped:

```
[ssh-relay] Remote dir: /var/services/homes/master/.orca-remote/relay-0.1.0+4b00379e0ee3
[ssh-relay] Uploading relay...
[ssh-relay] SFTP namespace differs; transfer path: /homes/master/.orca-remote/.upload-stages/slot-0/payload
[ssh-relay] Upload complete
[ssh-relay] Relay started successfully
```

Live path exercised: suffix search (`/var/services/homes/master` → `/homes/master`). Child-directory scan is covered by unit tests only; this NAS did not need it.

Windows SFTP is still skipped by the existing POSIX-prefix guard. Linux and macOS remotes that share one namespace are unchanged (start path matches shell home → no probes).

## AI Disclosure

Original patch is the author's. Local verification against the NAS, the `readdir` degrade follow-up, and this PR body used Cursor (Grok 4.6).

## Review

- **Security.** Redirect still requires this install's marker. Child names are filtered through the existing POSIX segment checks. Marker tokens stay redacted in logs.
- **Cross-platform.** POSIX SFTP only. Windows hosts skip mapping, same as before.
- **Remote SSH.** This is the SSH install path. Relay *launch* still uses the shell path over exec.
- **Performance.** Extra LSTATs on suffix segments, then at most 64 child probes, and only when the shell marker is absent.
- **Backwards compatible.** Failure still degrades to the old shell path.

Known leftover, not in this PR: `installRemoteOrcaCliLauncher` still calls `writeFile` without `sftpNamespace`, so the optional remote `orca` CLI install can fail with `No such file` after the relay is already up. Connection succeeds. Follow-up.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Author: add an X handle in a comment if you want the [@orca_build](https://x.com/orca_build) shout-out.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
