### PR TITLE
Recover unreachable main windows after display changes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -262,6 +262,10 @@ import {
 import { createMacAppActivationHandler } from './window/macos-app-activation'
 import { focusExistingMainWindow } from './window/focus-existing-window'
 import { notifyMainWindowBecameVisible } from './window/main-window-visibility'
+import {
+  deferMainWindowBoundsRecovery,
+  isMainWindowReachable
+} from './window/main-window-reachability'
 import { CodexAccountService } from './codex-accounts/service'
 import { CodexRuntimeHomeService } from './codex-accounts/runtime-home-service'
 import { markCodexProjectTrusted } from './agent-trust-presets'
@@ -774,6 +778,7 @@ startMainThreadChurnProbe({ extraStats: () => ({ diffCache: settledDiffCache.sta
 function focusExistingWindow(): void {
   focusExistingMainWindow({
     app,
+    ensureWindowReachable: deferMainWindowBoundsRecovery,
     getWindow: () => mainWindow,
     openWindow: openMainWindow,
     warn: console.warn
@@ -803,6 +808,7 @@ skillShareDeepLinks.capture(process.argv)
 
 const handleMacAppActivation = createMacAppActivationHandler({
   getWindow: () => mainWindow,
+  isWindowReachable: isMainWindowReachable,
   requestActivation: requestDesktopActivation
 })
 
@@ -1390,11 +1396,7 @@ async function prepareCodexSessionResumeForLaunch(args: {
 // Why: restore the window the close handler may have hidden to tray, or reopen it (dock-reactivation style) if fully torn down.
 function showMainWindowFromTray(): void {
   if (mainWindow && !mainWindow.isDestroyed()) {
-    if (mainWindow.isMinimized()) {
-      mainWindow.restore()
-    }
-    mainWindow.show()
-    mainWindow.focus()
+    focusExistingWindow()
     return
   }
   if (!isQuittingForUpdate()) {

--- a/src/main/window/createMainWindow-bounds-restoration.test.ts
+++ b/src/main/window/createMainWindow-bounds-restoration.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', async () =>
+  (await import('./createMainWindow-test-harness')).electronModuleMock()
+)
+vi.mock('@electron-toolkit/utils', async () =>
+  (await import('./createMainWindow-test-harness')).electronToolkitUtilsMock()
+)
+vi.mock('./macos-tahoe-release', async () =>
+  (await import('./createMainWindow-test-harness')).macosTahoeReleaseMock()
+)
+vi.mock('../app-icon', async () => (await import('./createMainWindow-test-harness')).appIconMock())
+vi.mock('../browser/browser-manager', async () =>
+  (await import('./createMainWindow-test-harness')).browserManagerMock()
+)
+
+import { createMainWindow } from './createMainWindow'
+import { resetExpectedTeardownStateForTest } from '../crash-reporting/expected-teardown-state'
+import { browserWindowMock, resetMainWindowMocks } from './createMainWindow-test-harness'
+
+function installBrowserWindowFixture(): void {
+  const webContents = {
+    on: vi.fn(),
+    setZoomLevel: vi.fn(),
+    setBackgroundThrottling: vi.fn(),
+    invalidate: vi.fn(),
+    setWindowOpenHandler: vi.fn(),
+    send: vi.fn()
+  }
+  browserWindowMock.mockImplementation(function () {
+    return {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => false),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      setWindowButtonPosition: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+  })
+}
+
+function createStore(windowBounds: Electron.Rectangle) {
+  return {
+    getUI: () => ({ windowBounds }) as never,
+    getSettings: () => ({ windowBackgroundBlur: false }) as never,
+    updateUI: vi.fn()
+  }
+}
+
+describe('main window bounds restoration', () => {
+  beforeEach(() => {
+    resetMainWindowMocks()
+    resetExpectedTeardownStateForTest()
+    installBrowserWindowFixture()
+  })
+
+  it('restores an intentionally side-parked window with a grabbable titlebar slice', () => {
+    const windowBounds = { x: -1110, y: 0, width: 1200, height: 800 }
+
+    createMainWindow(createStore(windowBounds) as never)
+
+    expect(browserWindowMock).toHaveBeenCalledWith(expect.objectContaining(windowBounds))
+  })
+
+  it('discards a saved window with only a titlebar sliver visible', () => {
+    createMainWindow(createStore({ x: -1180, y: 0, width: 1200, height: 800 }) as never)
+
+    expect(browserWindowMock).toHaveBeenCalledWith(expect.not.objectContaining({ x: -1180, y: 0 }))
+  })
+})

--- a/src/main/window/createMainWindow-renderer-crash-recovery.test.ts
+++ b/src/main/window/createMainWindow-renderer-crash-recovery.test.ts
@@ -70,7 +70,9 @@ describe('createMainWindow', () => {
       isDestroyed: vi.fn(() => false),
       isMaximized: vi.fn(() => true),
       isFullScreen: vi.fn(() => false),
+      getBounds: vi.fn(() => ({ x: 0, y: 0, width: 1200, height: 800 })),
       getSize: vi.fn(() => [1200, 800]),
+      setBounds: vi.fn(),
       setSize: vi.fn(),
       maximize: vi.fn(),
       show: vi.fn(),
@@ -116,7 +118,9 @@ describe('createMainWindow', () => {
       isDestroyed: vi.fn(() => false),
       isMaximized: vi.fn(() => true),
       isFullScreen: vi.fn(() => false),
+      getBounds: vi.fn(() => ({ x: 0, y: 0, width: 1200, height: 800 })),
       getSize: vi.fn(() => [1200, 800]),
+      setBounds: vi.fn(),
       setSize: vi.fn(),
       maximize: vi.fn(),
       show: vi.fn(),
@@ -370,7 +374,9 @@ describe('createMainWindow', () => {
       isDestroyed: vi.fn(() => false),
       isMaximized: vi.fn(() => true),
       isFullScreen: vi.fn(() => false),
+      getBounds: vi.fn(() => ({ x: 0, y: 0, width: 1200, height: 800 })),
       getSize: vi.fn(() => [1200, 800]),
+      setBounds: vi.fn(),
       setSize: vi.fn(),
       maximize: vi.fn(),
       show: vi.fn(),
@@ -406,6 +412,38 @@ describe('createMainWindow', () => {
     expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(2)
     expect(browserWindowInstance.loadURL).not.toHaveBeenCalled()
 
+    consoleError.mockRestore()
+  })
+
+  it('recovers offscreen bounds before reloading after renderer loss', () => {
+    vi.useFakeTimers()
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { browserWindowInstance, windowHandlers } = createRendererRecoveryWindowHarness()
+    browserWindowInstance.isMaximized.mockReturnValue(false)
+    browserWindowInstance.getBounds.mockReturnValue({
+      x: 5000,
+      y: -3000,
+      width: 1200,
+      height: 800
+    })
+
+    createMainWindow(null)
+    windowHandlers['render-process-gone']?.(
+      {} as never,
+      { reason: 'crashed', exitCode: 5 } as Electron.RenderProcessGoneDetails
+    )
+    vi.advanceTimersByTime(250)
+
+    expect(browserWindowInstance.setBounds).toHaveBeenCalledWith({
+      x: 240,
+      y: 0,
+      width: 1200,
+      height: 800
+    })
+    expect(browserWindowInstance.setBounds.mock.invocationCallOrder[0]).toBeLessThan(
+      browserWindowInstance.loadFile.mock.invocationCallOrder.at(-1) ?? 0
+    )
     consoleError.mockRestore()
   })
 

--- a/src/main/window/createMainWindow-renderer-crash-recovery.test.ts
+++ b/src/main/window/createMainWindow-renderer-crash-recovery.test.ts
@@ -67,6 +67,7 @@ describe('createMainWindow', () => {
       on: vi.fn((event, handler) => {
         windowHandlers[event] = handler
       }),
+      removeListener: vi.fn(),
       isDestroyed: vi.fn(() => false),
       isMaximized: vi.fn(() => true),
       isFullScreen: vi.fn(() => false),

--- a/src/main/window/createMainWindow-startup-reveal.test.ts
+++ b/src/main/window/createMainWindow-startup-reveal.test.ts
@@ -49,6 +49,7 @@ describe('createMainWindow', () => {
       on: vi.fn((event, handler) => {
         windowHandlers[event] = handler
       }),
+      removeListener: vi.fn(),
       isDestroyed: vi.fn(() => false),
       isMaximized: vi.fn(() => false),
       isFullScreen: vi.fn(() => false),

--- a/src/main/window/createMainWindow-system-resume-relay.test.ts
+++ b/src/main/window/createMainWindow-system-resume-relay.test.ts
@@ -48,6 +48,7 @@ describe('createMainWindow', () => {
         on: vi.fn((event: string, handler: (...args: any[]) => void) => {
           windowHandlers[event] = handler
         }),
+        removeListener: vi.fn(),
         isDestroyed: vi.fn(() => false),
         // Why: maximized keeps forceRepaint from scheduling its size-nudge timer.
         isMaximized: vi.fn(() => true),

--- a/src/main/window/createMainWindow-test-harness.ts
+++ b/src/main/window/createMainWindow-test-harness.ts
@@ -53,8 +53,17 @@ export type ElectronModuleMock = {
   nativeTheme: { shouldUseDarkColors: boolean }
   powerMonitor: { on: MainWindowSpy; removeListener: MainWindowSpy }
   screen: {
-    getPrimaryDisplay: () => { workAreaSize: { width: number; height: number } }
-    getDisplayMatching: () => { scaleFactor: number }
+    getPrimaryDisplay: () => {
+      workArea: { x: number; y: number; width: number; height: number }
+      workAreaSize: { width: number; height: number }
+    }
+    getAllDisplays: () => { workArea: { x: number; y: number; width: number; height: number } }[]
+    getDisplayMatching: () => {
+      scaleFactor: number
+      workArea: { x: number; y: number; width: number; height: number }
+    }
+    on: MainWindowSpy
+    removeListener: MainWindowSpy
   }
   shell: { openExternal: MainWindowSpy }
 }
@@ -78,8 +87,17 @@ export function electronModuleMock(): ElectronModuleMock {
     nativeTheme: { shouldUseDarkColors: false },
     powerMonitor: { on: powerMonitorOnMock, removeListener: powerMonitorRemoveListenerMock },
     screen: {
-      getPrimaryDisplay: () => ({ workAreaSize: { width: 1440, height: 900 } }),
-      getDisplayMatching: () => ({ scaleFactor: 2 })
+      getPrimaryDisplay: () => ({
+        workArea: { x: 0, y: 0, width: 1440, height: 900 },
+        workAreaSize: { width: 1440, height: 900 }
+      }),
+      getAllDisplays: () => [{ workArea: { x: 0, y: 0, width: 1440, height: 900 } }],
+      getDisplayMatching: () => ({
+        scaleFactor: 2,
+        workArea: { x: 0, y: 0, width: 1440, height: 900 }
+      }),
+      on: vi.fn(),
+      removeListener: vi.fn()
     },
     shell: { openExternal: openExternalMock }
   }

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -473,7 +473,9 @@ describe('createMainWindow', () => {
       isDestroyed: vi.fn(() => false),
       isMaximized: vi.fn(() => false),
       isFullScreen: vi.fn(() => false),
+      getBounds: vi.fn(() => ({ x: 0, y: 0, width: 1200, height: 800 })),
       getSize: vi.fn(() => windowSize),
+      setBounds: vi.fn(),
       setSize: vi.fn((width: number, height: number) => {
         windowSize = [width, height]
       }),
@@ -490,12 +492,16 @@ describe('createMainWindow', () => {
 
     expect(webContents.setBackgroundThrottling).toHaveBeenCalledWith(true)
     expect(webContents.setBackgroundThrottling).not.toHaveBeenCalledWith(false)
-    expect(windowHandlers.get('restore')).toHaveLength(1)
-    expect(windowHandlers.get('show')).toHaveLength(1)
+    expect(windowHandlers.get('restore')?.length).toBeGreaterThanOrEqual(1)
+    expect(windowHandlers.get('show')?.length).toBeGreaterThanOrEqual(1)
     expect(windowHandlers.get('focus')).toHaveLength(1)
 
-    windowHandlers.get('show')?.[0]?.()
-    windowHandlers.get('restore')?.[0]?.()
+    for (const handler of windowHandlers.get('show') ?? []) {
+      handler()
+    }
+    for (const handler of windowHandlers.get('restore') ?? []) {
+      handler()
+    }
 
     expect(webContents.invalidate).toHaveBeenCalledTimes(2)
     // Why: the size nudge must never run inside the show/restore dispatch itself.

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -16,7 +16,10 @@ import {
 } from './main-window-close-lifecycle'
 import type { CreateMainWindowOptions } from './main-window-contracts'
 import { installMainWindowFocusLifecycle } from './main-window-focus-lifecycle'
-import { installMainWindowReachabilityLifecycle } from './main-window-reachability'
+import {
+  installMainWindowReachabilityLifecycle,
+  mainWindowBoundsHaveReachableTitlebar
+} from './main-window-reachability'
 import { installMainWindowShortcutRouting } from './main-window-shortcut-routing'
 import { installMainWindowStateLifecycle } from './main-window-state-lifecycle'
 import {
@@ -29,7 +32,6 @@ import {
   TRAFFIC_LIGHT_X
 } from './main-window-visual-lifecycle'
 import { installMainWindowWebviewSecurity } from './main-window-webview-security'
-import { rectHasVisibleAreaOnAnyDisplay } from './window-bounds-validation'
 import { installWindowsPathRegistryChangeListener } from '../pty/windows-path-registry-change'
 
 export { WINDOW_QUIT_RENDERER_ACK_TIMEOUT_MS }
@@ -47,12 +49,12 @@ export function createMainWindow(
   opts?: CreateMainWindowOptions
 ): BrowserWindow {
   const rawSavedBounds = store?.getUI().windowBounds
-  // Why: reject min-size or substantially off-screen bounds so the titlebar stays reachable after display changes.
+  // Why: reject undersized or unreachable bounds while preserving intentionally parked windows.
   const savedBounds =
     rawSavedBounds &&
     rawSavedBounds.width > MIN_WIDTH &&
     rawSavedBounds.height > MIN_HEIGHT &&
-    rectHasVisibleAreaOnAnyDisplay(rawSavedBounds, MIN_WIDTH / 2, MIN_HEIGHT / 2)
+    mainWindowBoundsHaveReachableTitlebar(rawSavedBounds)
       ? rawSavedBounds
       : undefined
   if (rawSavedBounds && !savedBounds) {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -16,6 +16,7 @@ import {
 } from './main-window-close-lifecycle'
 import type { CreateMainWindowOptions } from './main-window-contracts'
 import { installMainWindowFocusLifecycle } from './main-window-focus-lifecycle'
+import { installMainWindowReachabilityLifecycle } from './main-window-reachability'
 import { installMainWindowShortcutRouting } from './main-window-shortcut-routing'
 import { installMainWindowStateLifecycle } from './main-window-state-lifecycle'
 import {
@@ -167,6 +168,7 @@ export function createMainWindow(
     savedMaximized,
     store
   })
+  const disposeReachability = installMainWindowReachabilityLifecycle(mainWindow)
   installMainWindowWebviewSecurity(mainWindow)
   const focus = installMainWindowFocusLifecycle({
     isWindowClosing: state.isWindowClosing,
@@ -192,6 +194,7 @@ export function createMainWindow(
     focus.dispose()
     browserManager.setDictationShortcutForwardingPredicate(null)
     powerMonitor.removeListener('resume', onSystemResume)
+    disposeReachability()
     clearTrustedUIRendererWebContentsId(rendererWebContentsId)
     state.dispose()
   })

--- a/src/main/window/focus-existing-window.test.ts
+++ b/src/main/window/focus-existing-window.test.ts
@@ -127,6 +127,24 @@ describe('focusExistingMainWindow', () => {
     expect(timer.scheduledMs()).toEqual([])
   })
 
+  it('recovers window placement before revealing it', () => {
+    const window = makeFakeWindow()
+    const ensureWindowReachable = vi.fn()
+
+    focusExistingMainWindow({
+      app: makeFakeApp(),
+      ensureWindowReachable,
+      getWindow: () => window,
+      openWindow: vi.fn(),
+      platform: 'darwin'
+    })
+
+    expect(ensureWindowReachable).toHaveBeenCalledWith(window)
+    expect(ensureWindowReachable.mock.invocationCallOrder[0]).toBeLessThan(
+      window.calls.show.mock.invocationCallOrder[0]
+    )
+  })
+
   it('waits for normal startup when no window exists before app readiness', () => {
     const openWindow = vi.fn()
 

--- a/src/main/window/focus-existing-window.ts
+++ b/src/main/window/focus-existing-window.ts
@@ -6,6 +6,7 @@ export type FocusExistingMainWindowResult = 'focused' | 'opened' | 'pending'
 
 export type FocusExistingMainWindowOptions = {
   app: Pick<App, 'focus' | 'isReady'>
+  ensureWindowReachable?: (window: BrowserWindow) => void
   getWindow: () => BrowserWindow | null
   openWindow: () => BrowserWindow
   platform?: NodeJS.Platform
@@ -70,8 +71,10 @@ function activateWindow(
   window: BrowserWindow,
   app: Pick<App, 'focus'>,
   platform: NodeJS.Platform,
-  setTimer: FocusTimer
+  setTimer: FocusTimer,
+  ensureWindowReachable?: (window: BrowserWindow) => void
 ): void {
+  ensureWindowReachable?.(window)
   safelyFocusApp(app)
   safelyRevealWindow(window)
   if (platform === 'win32') {
@@ -93,7 +96,10 @@ const REOPEN_MAX_ATTEMPTS = 3
 const REOPEN_RETRY_DELAY_MS = 300
 
 function openWindowWithRetry(
-  opts: Pick<FocusExistingMainWindowOptions, 'app' | 'getWindow' | 'openWindow' | 'warn'>,
+  opts: Pick<
+    FocusExistingMainWindowOptions,
+    'app' | 'ensureWindowReachable' | 'getWindow' | 'openWindow' | 'warn'
+  >,
   platform: NodeJS.Platform,
   setTimer: FocusTimer,
   attempt: number
@@ -117,7 +123,7 @@ function openWindowWithRetry(
           ? existing
           : openWindowWithRetry(opts, platform, setTimer, attempt + 1)
       if (window) {
-        activateWindow(window, opts.app, platform, setTimer)
+        activateWindow(window, opts.app, platform, setTimer, opts.ensureWindowReachable)
       }
     }, REOPEN_RETRY_DELAY_MS)
     return null
@@ -143,6 +149,6 @@ export function focusExistingMainWindow(
     openedWindow = true
   }
 
-  activateWindow(window, opts.app, platform, setTimer)
+  activateWindow(window, opts.app, platform, setTimer, opts.ensureWindowReachable)
   return openedWindow ? 'opened' : 'focused'
 }

--- a/src/main/window/macos-app-activation.test.ts
+++ b/src/main/window/macos-app-activation.test.ts
@@ -2,9 +2,10 @@ import type { BrowserWindow } from 'electron'
 import { describe, expect, it, vi } from 'vitest'
 import { createMacAppActivationHandler } from './macos-app-activation'
 
-function makeWindow(destroyed = false): BrowserWindow {
+function makeWindow(options: { destroyed?: boolean; visible?: boolean } = {}): BrowserWindow {
   return {
-    isDestroyed: vi.fn(() => destroyed)
+    isDestroyed: vi.fn(() => options.destroyed ?? false),
+    isVisible: vi.fn(() => options.visible ?? true)
   } as unknown as BrowserWindow
 }
 
@@ -13,6 +14,7 @@ describe('createMacAppActivationHandler', () => {
     const requestActivation = vi.fn()
     const handler = createMacAppActivationHandler({
       getWindow: () => makeWindow(),
+      isWindowReachable: () => true,
       requestActivation
     })
 
@@ -21,12 +23,13 @@ describe('createMacAppActivationHandler', () => {
     expect(requestActivation).not.toHaveBeenCalled()
   })
 
-  it.each([null, makeWindow(true)])(
+  it.each([null, makeWindow({ destroyed: true })])(
     'requests desktop activation for a missing or destroyed window',
     (window) => {
       const requestActivation = vi.fn()
       const handler = createMacAppActivationHandler({
         getWindow: () => window,
+        isWindowReachable: () => true,
         requestActivation
       })
 
@@ -35,4 +38,20 @@ describe('createMacAppActivationHandler', () => {
       expect(requestActivation).toHaveBeenCalledTimes(1)
     }
   )
+
+  it.each([
+    ['hidden', makeWindow({ visible: false }), true],
+    ['offscreen', makeWindow(), false]
+  ])('requests desktop activation for a live %s window', (_label, window, reachable) => {
+    const requestActivation = vi.fn()
+    const handler = createMacAppActivationHandler({
+      getWindow: () => window as BrowserWindow,
+      isWindowReachable: () => reachable as boolean,
+      requestActivation
+    })
+
+    handler()
+
+    expect(requestActivation).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/main/window/macos-app-activation.ts
+++ b/src/main/window/macos-app-activation.ts
@@ -2,12 +2,18 @@ import type { BrowserWindow } from 'electron'
 
 export function createMacAppActivationHandler(options: {
   getWindow: () => BrowserWindow | null
+  isWindowReachable: (window: BrowserWindow) => boolean
   requestActivation: () => void
 }): () => void {
   return () => {
     const window = options.getWindow()
     // Why: re-focusing an existing macOS window can race its scene-backed Space transition.
-    if (!window || window.isDestroyed()) {
+    if (
+      !window ||
+      window.isDestroyed() ||
+      !window.isVisible() ||
+      !options.isWindowReachable(window)
+    ) {
       options.requestActivation()
     }
   }

--- a/src/main/window/main-window-focus-lifecycle.ts
+++ b/src/main/window/main-window-focus-lifecycle.ts
@@ -21,6 +21,7 @@ import {
   retireBrowserClientPageRenderer
 } from '../browser/browser-client-page-renderer-runtime'
 import { registerRendererDocumentNavigation } from './renderer-document-navigation'
+import { recoverMainWindowBounds } from './main-window-reachability'
 
 export type MainWindowFocusLifecycle = {
   dispose: () => void
@@ -197,6 +198,7 @@ export function installMainWindowFocusLifecycle(args: {
       // Why: a transient renderer/Network Service loss can blank Chromium; reload the app document once to recover.
       // Why: mark this in-place reload so the did-finish-load orphan sweep spares live PTYs until session restore (#5787).
       opts?.onBeforeRecoveryReload?.(mainWindow.webContents.id)
+      recoverMainWindowBounds(mainWindow)
       reloadMainWindow()
     }, 250)
   }

--- a/src/main/window/main-window-reachability.test.ts
+++ b/src/main/window/main-window-reachability.test.ts
@@ -63,6 +63,9 @@ function makeWindow(bounds: Rectangle): BrowserWindow & {
       eventListeners.add(listener)
       listeners.set(event, eventListeners)
     }),
+    removeListener: vi.fn((event: string, listener: () => void) =>
+      listeners.get(event)?.delete(listener)
+    ),
     setBounds
   } as unknown as BrowserWindow & {
     emitWindow: (event: string) => void
@@ -89,9 +92,21 @@ describe('main window reachability', () => {
     vi.useRealTimers()
   })
 
-  it('recognizes a main window with a reachable titlebar area', () => {
-    expect(isMainWindowReachable(makeWindow({ x: -900, y: 0, width: 1200, height: 800 }))).toBe(
-      true
+  it('preserves a side-parked window with a grabbable titlebar slice', () => {
+    const window = makeWindow({ x: -1110, y: 0, width: 1200, height: 800 })
+
+    expect(isMainWindowReachable(window)).toBe(true)
+    expect(recoverMainWindowBounds(window)).toBe(false)
+    expect(window.setBounds).not.toHaveBeenCalled()
+  })
+
+  it('preserves a top-parked window with a grabbable titlebar slice', () => {
+    expect(isMainWindowReachable(makeWindow({ x: 0, y: -20, width: 1200, height: 800 }))).toBe(true)
+  })
+
+  it('rejects a barely peeking titlebar that cannot be grabbed', () => {
+    expect(isMainWindowReachable(makeWindow({ x: -1180, y: 0, width: 1200, height: 800 }))).toBe(
+      false
     )
   })
 
@@ -146,6 +161,7 @@ describe('main window reachability', () => {
 
       dispose()
       electronMock.screen.emit(event)
+      window.emitWindow('show')
       vi.runAllTimers()
       expect(window.setBounds).toHaveBeenCalledTimes(1)
     }

--- a/src/main/window/main-window-reachability.test.ts
+++ b/src/main/window/main-window-reachability.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BrowserWindow, Rectangle } from 'electron'
+
+const electronMock = vi.hoisted(() => {
+  const listeners = new Map<string, Set<() => void>>()
+  const screen = {
+    emit: (event: string) => {
+      for (const listener of listeners.get(event) ?? []) {
+        listener()
+      }
+    },
+    on: (event: string, listener: () => void) => {
+      const eventListeners = listeners.get(event) ?? new Set()
+      eventListeners.add(listener)
+      listeners.set(event, eventListeners)
+    },
+    removeAllListeners: () => listeners.clear(),
+    removeListener: (event: string, listener: () => void) => listeners.get(event)?.delete(listener),
+    getAllDisplays: vi.fn(),
+    getDisplayMatching: vi.fn(),
+    getPrimaryDisplay: vi.fn()
+  } as unknown as {
+    emit: (event: string) => void
+    on: (event: string, listener: () => void) => void
+    removeAllListeners: () => void
+    removeListener: (event: string, listener: () => void) => void
+    getAllDisplays: ReturnType<typeof vi.fn>
+    getDisplayMatching: ReturnType<typeof vi.fn>
+    getPrimaryDisplay: ReturnType<typeof vi.fn>
+  }
+  return { screen }
+})
+
+vi.mock('electron', () => ({ screen: electronMock.screen }))
+
+import {
+  installMainWindowReachabilityLifecycle,
+  isMainWindowReachable,
+  recoverMainWindowBounds
+} from './main-window-reachability'
+
+function makeWindow(bounds: Rectangle): BrowserWindow & {
+  emitWindow: (event: string) => void
+  setBounds: ReturnType<typeof vi.fn>
+} {
+  const listeners = new Map<string, Set<() => void>>()
+  let currentBounds = bounds
+  const setBounds = vi.fn((nextBounds: Rectangle) => {
+    currentBounds = nextBounds
+  })
+  return {
+    emitWindow: (event) => {
+      for (const listener of listeners.get(event) ?? []) {
+        listener()
+      }
+    },
+    getBounds: vi.fn(() => currentBounds),
+    isDestroyed: vi.fn(() => false),
+    isFullScreen: vi.fn(() => false),
+    isMaximized: vi.fn(() => false),
+    on: vi.fn((event: string, listener: () => void) => {
+      const eventListeners = listeners.get(event) ?? new Set()
+      eventListeners.add(listener)
+      listeners.set(event, eventListeners)
+    }),
+    setBounds
+  } as unknown as BrowserWindow & {
+    emitWindow: (event: string) => void
+    setBounds: ReturnType<typeof vi.fn>
+  }
+}
+
+describe('main window reachability', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    electronMock.screen.removeAllListeners()
+    electronMock.screen.getAllDisplays.mockReturnValue([
+      { workArea: { x: 0, y: 0, width: 1440, height: 900 } }
+    ])
+    electronMock.screen.getPrimaryDisplay.mockReturnValue({
+      workArea: { x: 0, y: 0, width: 1440, height: 900 }
+    })
+    electronMock.screen.getDisplayMatching.mockReturnValue({
+      workArea: { x: 0, y: 0, width: 1440, height: 900 }
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('recognizes a main window with a reachable titlebar area', () => {
+    expect(isMainWindowReachable(makeWindow({ x: -900, y: 0, width: 1200, height: 800 }))).toBe(
+      true
+    )
+  })
+
+  it('rejects a bottom slice whose titlebar is above an attached display', () => {
+    expect(isMainWindowReachable(makeWindow({ x: 0, y: -600, width: 1200, height: 800 }))).toBe(
+      false
+    )
+  })
+
+  it.each(['isMaximized', 'isFullScreen'] as const)(
+    'leaves native %s placement to the operating system',
+    (state) => {
+      const window = makeWindow({ x: 5000, y: -3000, width: 1200, height: 800 })
+      vi.mocked(window[state]).mockReturnValue(true)
+
+      expect(isMainWindowReachable(window)).toBe(true)
+    }
+  )
+
+  it('clamps an unreachable window into its matching display work area', () => {
+    electronMock.screen.getDisplayMatching.mockReturnValue({
+      workArea: { x: 1440, y: -900, width: 1920, height: 900 }
+    })
+    const bounds = { x: 5000, y: -3000, width: 1200, height: 800 }
+    const window = makeWindow(bounds)
+
+    expect(recoverMainWindowBounds(window)).toBe(true)
+    expect(electronMock.screen.getDisplayMatching).toHaveBeenCalledWith(bounds)
+    expect(window.setBounds).toHaveBeenCalledWith({ x: 2160, y: -900, width: 1200, height: 800 })
+  })
+
+  it('falls back to the primary work area when display matching fails', () => {
+    electronMock.screen.getDisplayMatching.mockImplementation(() => {
+      throw new Error('display topology is unsettled')
+    })
+    const window = makeWindow({ x: 5000, y: -3000, width: 1200, height: 800 })
+
+    expect(recoverMainWindowBounds(window)).toBe(true)
+    expect(window.setBounds).toHaveBeenCalledWith({ x: 240, y: 0, width: 1200, height: 800 })
+  })
+
+  it.each(['display-added', 'display-removed', 'display-metrics-changed'])(
+    'recovers after %s and releases display listeners on close',
+    (event) => {
+      const window = makeWindow({ x: 5000, y: -3000, width: 1200, height: 800 })
+      const dispose = installMainWindowReachabilityLifecycle(window)
+
+      electronMock.screen.emit(event)
+      expect(window.setBounds).not.toHaveBeenCalled()
+      vi.runAllTimers()
+      expect(window.setBounds).toHaveBeenCalledTimes(1)
+
+      dispose()
+      electronMock.screen.emit(event)
+      vi.runAllTimers()
+      expect(window.setBounds).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('coalesces normal-state window events on a fresh event-loop turn', () => {
+    const window = makeWindow({ x: 5000, y: -3000, width: 1200, height: 800 })
+    installMainWindowReachabilityLifecycle(window)
+
+    for (const event of ['show', 'restore', 'unmaximize', 'leave-full-screen']) {
+      window.emitWindow(event)
+    }
+    expect(window.setBounds).not.toHaveBeenCalled()
+
+    vi.runAllTimers()
+    expect(window.setBounds).toHaveBeenCalledTimes(1)
+
+    window.emitWindow('show')
+    vi.runAllTimers()
+    expect(window.setBounds).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['isMaximized', 'isFullScreen'] as const)('does not alter native %s state', (state) => {
+    const window = makeWindow({ x: 5000, y: -3000, width: 1200, height: 800 })
+    vi.mocked(window[state]).mockReturnValue(true)
+
+    expect(recoverMainWindowBounds(window)).toBe(false)
+    expect(window.setBounds).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/window/main-window-reachability.ts
+++ b/src/main/window/main-window-reachability.ts
@@ -1,24 +1,39 @@
 import { screen, type BrowserWindow, type Rectangle } from 'electron'
 import { deferAppKitSceneMutation } from '../appkit-scene-mutation'
-import { MIN_WIDTH, TITLEBAR_CSS_CENTER } from './main-window-visual-lifecycle'
+import { TITLEBAR_CSS_CENTER } from './main-window-visual-lifecycle'
 
 const pendingRecoveries = new WeakSet<BrowserWindow>()
+const MIN_REACHABLE_TITLEBAR_WIDTH = 60
+const MIN_REACHABLE_TITLEBAR_HEIGHT = 16
+
+export function mainWindowBoundsHaveReachableTitlebar(bounds: Rectangle): boolean {
+  if (bounds.width <= 0 || bounds.height <= 0) {
+    return false
+  }
+  const titlebarHeight = Math.min(bounds.height, TITLEBAR_CSS_CENTER * 2)
+  try {
+    return screen.getAllDisplays().some((display) => {
+      const area = display.workArea
+      const visibleWidth = Math.max(
+        0,
+        Math.min(bounds.x + bounds.width, area.x + area.width) - Math.max(bounds.x, area.x)
+      )
+      const visibleTitlebarHeight = Math.max(
+        0,
+        Math.min(bounds.y + titlebarHeight, area.y + area.height) - Math.max(bounds.y, area.y)
+      )
+      return (
+        visibleWidth >= Math.min(MIN_REACHABLE_TITLEBAR_WIDTH, bounds.width) &&
+        visibleTitlebarHeight >= Math.min(MIN_REACHABLE_TITLEBAR_HEIGHT, titlebarHeight)
+      )
+    })
+  } catch {
+    return false
+  }
+}
 
 function hasReachableTitlebar(window: BrowserWindow): boolean {
-  const bounds = window.getBounds()
-  return screen.getAllDisplays().some((display) => {
-    const area = display.workArea
-    const visibleWidth = Math.max(
-      0,
-      Math.min(bounds.x + bounds.width, area.x + area.width) - Math.max(bounds.x, area.x)
-    )
-    const visibleTitlebarHeight = Math.max(
-      0,
-      Math.min(bounds.y + TITLEBAR_CSS_CENTER * 2, area.y + area.height) -
-        Math.max(bounds.y, area.y)
-    )
-    return visibleWidth >= MIN_WIDTH / 2 && visibleTitlebarHeight >= TITLEBAR_CSS_CENTER
-  })
+  return mainWindowBoundsHaveReachableTitlebar(window.getBounds())
 }
 
 function getRecoveryWorkArea(bounds: Rectangle): Rectangle {
@@ -95,5 +110,9 @@ export function installMainWindowReachabilityLifecycle(window: BrowserWindow): (
     screen.removeListener('display-added', recover)
     screen.removeListener('display-removed', recover)
     screen.removeListener('display-metrics-changed', recover)
+    window.removeListener('show', recover)
+    window.removeListener('restore', recover)
+    window.removeListener('unmaximize', recover)
+    window.removeListener('leave-full-screen', recover)
   }
 }

--- a/src/main/window/main-window-reachability.ts
+++ b/src/main/window/main-window-reachability.ts
@@ -1,0 +1,99 @@
+import { screen, type BrowserWindow, type Rectangle } from 'electron'
+import { deferAppKitSceneMutation } from '../appkit-scene-mutation'
+import { MIN_WIDTH, TITLEBAR_CSS_CENTER } from './main-window-visual-lifecycle'
+
+const pendingRecoveries = new WeakSet<BrowserWindow>()
+
+function hasReachableTitlebar(window: BrowserWindow): boolean {
+  const bounds = window.getBounds()
+  return screen.getAllDisplays().some((display) => {
+    const area = display.workArea
+    const visibleWidth = Math.max(
+      0,
+      Math.min(bounds.x + bounds.width, area.x + area.width) - Math.max(bounds.x, area.x)
+    )
+    const visibleTitlebarHeight = Math.max(
+      0,
+      Math.min(bounds.y + TITLEBAR_CSS_CENTER * 2, area.y + area.height) -
+        Math.max(bounds.y, area.y)
+    )
+    return visibleWidth >= MIN_WIDTH / 2 && visibleTitlebarHeight >= TITLEBAR_CSS_CENTER
+  })
+}
+
+function getRecoveryWorkArea(bounds: Rectangle): Rectangle {
+  try {
+    return screen.getDisplayMatching(bounds).workArea
+  } catch {
+    return screen.getPrimaryDisplay().workArea
+  }
+}
+
+export function isMainWindowReachable(window: BrowserWindow): boolean {
+  if (window.isDestroyed()) {
+    return false
+  }
+  try {
+    if (window.isFullScreen() || window.isMaximized()) {
+      return true
+    }
+    return hasReachableTitlebar(window)
+  } catch {
+    return false
+  }
+}
+
+export function recoverMainWindowBounds(window: BrowserWindow): boolean {
+  if (window.isDestroyed() || window.isFullScreen() || window.isMaximized()) {
+    return false
+  }
+  try {
+    const current = window.getBounds()
+    if (hasReachableTitlebar(window)) {
+      return false
+    }
+    const workArea = getRecoveryWorkArea(current)
+    const width = Math.min(current.width, workArea.width)
+    const height = Math.min(current.height, workArea.height)
+    window.setBounds({
+      x: Math.min(Math.max(current.x, workArea.x), workArea.x + workArea.width - width),
+      y: Math.min(Math.max(current.y, workArea.y), workArea.y + workArea.height - height),
+      width,
+      height
+    })
+    return true
+  } catch (error) {
+    console.warn('[window] Failed to recover main window bounds', error)
+    return false
+  }
+}
+
+export function deferMainWindowBoundsRecovery(window: BrowserWindow): void {
+  if (window.isDestroyed() || pendingRecoveries.has(window)) {
+    return
+  }
+  pendingRecoveries.add(window)
+  deferAppKitSceneMutation(() => {
+    pendingRecoveries.delete(window)
+    recoverMainWindowBounds(window)
+  })
+}
+
+export function installMainWindowReachabilityLifecycle(window: BrowserWindow): () => void {
+  const recover = (): void => {
+    deferMainWindowBoundsRecovery(window)
+  }
+  screen.on('display-added', recover)
+  screen.on('display-removed', recover)
+  screen.on('display-metrics-changed', recover)
+  window.on('show', recover)
+  window.on('restore', recover)
+  window.on('unmaximize', recover)
+  window.on('leave-full-screen', recover)
+
+  return () => {
+    screen.removeListener('display-added', recover)
+    screen.removeListener('display-removed', recover)
+    screen.removeListener('display-metrics-changed', recover)
+  }
+}

--- a/src/renderer/src/lib/serve-desktop-promotion-session-continuity.test.ts
+++ b/src/renderer/src/lib/serve-desktop-promotion-session-continuity.test.ts
@@ -57,6 +57,7 @@ afterEach(() => {
 function createFakeWindow(): BrowserWindow {
   return {
     isDestroyed: () => false,
+    isVisible: () => true,
     isMinimized: () => false,
     isAlwaysOnTop: () => false,
     restore: vi.fn(),
@@ -130,6 +131,7 @@ function bootHeadlessServeOwner(): {
     },
     dockActivate: createMacAppActivationHandler({
       getWindow: () => mainWindow,
+      isWindowReachable: () => true,
       requestActivation: () => requestDesktopActivation(DESKTOP_RELAUNCH_ARGV)
     }),
     settle: (options) => settleServeDesktopActivation(gate, options)

--- a/tests/e2e/main-window-display-recovery.spec.ts
+++ b/tests/e2e/main-window-display-recovery.spec.ts
@@ -1,0 +1,117 @@
+import { execFileSync } from 'node:child_process'
+import { expect, test } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+type NativeWindowBounds = { position: [number, number]; size: [number, number] }
+
+function readNativeWindowBounds(processId: number): NativeWindowBounds {
+  const output = execFileSync(
+    '/usr/bin/osascript',
+    [
+      '-e',
+      'tell application "System Events"',
+      '-e',
+      `set matches to every application process whose unix id is ${processId}`,
+      '-e',
+      'if (count of matches) is not 1 then error "expected one application process"',
+      '-e',
+      'tell item 1 of matches',
+      '-e',
+      'if (count of windows) is not 1 then error "expected one native window"',
+      '-e',
+      'set windowPosition to position of window 1',
+      '-e',
+      'set windowSize to size of window 1',
+      '-e',
+      'return {item 1 of windowPosition, item 2 of windowPosition, item 1 of windowSize, item 2 of windowSize}',
+      '-e',
+      'end tell',
+      '-e',
+      'end tell'
+    ],
+    { encoding: 'utf8' }
+  )
+  const [x, y, width, height] = output.split(',').map((value) => Number(value.trim()))
+  return { position: [x, y], size: [width, height] }
+}
+
+test.describe('Main window display recovery', () => {
+  test.skip(process.platform !== 'darwin', 'Accessibility report is macOS-specific')
+
+  test('display metrics recover an offscreen live main window @headful', async ({
+    electronApp,
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+
+    const result = await electronApp.evaluate(({ BrowserWindow, screen }) => {
+      const windows = BrowserWindow.getAllWindows().filter((window) => !window.isDestroyed())
+      if (windows.length !== 1) {
+        throw new Error(`expected one BrowserWindow, found ${windows.length}`)
+      }
+      const window = windows[0]
+      if (window.isMaximized()) {
+        window.unmaximize()
+      }
+      if (window.isFullScreen()) {
+        throw new Error('expected a normal test window, found fullscreen')
+      }
+      const displays = screen.getAllDisplays()
+      const right = Math.max(...displays.map((display) => display.bounds.x + display.bounds.width))
+      const bottom = Math.max(
+        ...displays.map((display) => display.bounds.y + display.bounds.height)
+      )
+      const offscreenBounds = { x: right + 1000, y: bottom + 1000, width: 900, height: 700 }
+      window.setBounds(offscreenBounds)
+      screen.emit('display-metrics-changed', {} as Electron.Event, screen.getPrimaryDisplay(), [
+        'workArea'
+      ])
+
+      return {
+        processId: process.pid,
+        windowIdBefore: window.id,
+        visible: window.isVisible()
+      }
+    })
+
+    await expect
+      .poll(() =>
+        electronApp.evaluate(({ BrowserWindow, screen }) => {
+          const window = BrowserWindow.getAllWindows()[0]
+          const bounds = window.getBounds()
+          const reachable = screen
+            .getAllDisplays()
+            .some(({ workArea: area }) =>
+              Boolean(
+                bounds.x >= area.x &&
+                bounds.y >= area.y &&
+                bounds.x + bounds.width <= area.x + area.width &&
+                bounds.y + bounds.height <= area.y + area.height
+              )
+            )
+          return { bounds, reachable, windowIdAfter: window.id }
+        })
+      )
+      .toMatchObject({ reachable: true, windowIdAfter: result.windowIdBefore })
+    expect(result.visible).toBe(true)
+    expect(result.processId).toBe(electronApp.process().pid)
+
+    const recovered = await electronApp.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows()[0].getBounds()
+    )
+    await expect
+      .poll(() => {
+        try {
+          return readNativeWindowBounds(result.processId)
+        } catch {
+          return null
+        }
+      })
+      .toEqual({
+        position: [recovered.x, recovered.y],
+        size: [recovered.width, recovered.height]
+      })
+    expect(await orcaPage.locator('body').isVisible()).toBe(true)
+    await orcaPage.screenshot({ path: testInfo.outputPath('main-window-display-recovered.png') })
+  })
+})

--- a/tests/e2e/main-window-display-recovery.spec.ts
+++ b/tests/e2e/main-window-display-recovery.spec.ts
@@ -63,6 +63,25 @@ test.describe('Main window display recovery', () => {
       )
       const offscreenBounds = { x: right + 1000, y: bottom + 1000, width: 900, height: 700 }
       window.setBounds(offscreenBounds)
+      const candidateBounds = window.getBounds()
+      const candidateOverlapsDisplay = displays.some(({ workArea: area }) => {
+        const overlapWidth = Math.max(
+          0,
+          Math.min(candidateBounds.x + candidateBounds.width, area.x + area.width) -
+            Math.max(candidateBounds.x, area.x)
+        )
+        const overlapHeight = Math.max(
+          0,
+          Math.min(candidateBounds.y + candidateBounds.height, area.y + area.height) -
+            Math.max(candidateBounds.y, area.y)
+        )
+        return overlapWidth > 0 && overlapHeight > 0
+      })
+      if (candidateOverlapsDisplay) {
+        throw new Error(
+          `expected offscreen candidate bounds, got ${JSON.stringify(candidateBounds)}`
+        )
+      }
       screen.emit('display-metrics-changed', {} as Electron.Event, screen.getPrimaryDisplay(), [
         'workArea'
       ])

--- a/tests/e2e/main-window-display-recovery.spec.ts
+++ b/tests/e2e/main-window-display-recovery.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from './helpers/orca-app'
 import { waitForSessionReady } from './helpers/store'
 
 type NativeWindowBounds = { position: [number, number]; size: [number, number] }
+type DisplayWorkArea = { x: number; y: number; width: number; height: number }
 
 function readNativeWindowBounds(processId: number): NativeWindowBounds {
   const output = execFileSync(
@@ -64,22 +65,22 @@ test.describe('Main window display recovery', () => {
       const offscreenBounds = { x: right + 1000, y: bottom + 1000, width: 900, height: 700 }
       window.setBounds(offscreenBounds)
       const candidateBounds = window.getBounds()
-      const candidateOverlapsDisplay = displays.some(({ workArea: area }) => {
-        const overlapWidth = Math.max(
+      const candidateHasReachableTitlebar = displays.some(({ workArea: area }) => {
+        const visibleWidth = Math.max(
           0,
           Math.min(candidateBounds.x + candidateBounds.width, area.x + area.width) -
             Math.max(candidateBounds.x, area.x)
         )
-        const overlapHeight = Math.max(
+        const visibleTitlebarHeight = Math.max(
           0,
-          Math.min(candidateBounds.y + candidateBounds.height, area.y + area.height) -
+          Math.min(candidateBounds.y + 36, area.y + area.height) -
             Math.max(candidateBounds.y, area.y)
         )
-        return overlapWidth > 0 && overlapHeight > 0
+        return visibleWidth >= 60 && visibleTitlebarHeight >= 16
       })
-      if (candidateOverlapsDisplay) {
+      if (candidateHasReachableTitlebar) {
         throw new Error(
-          `expected offscreen candidate bounds, got ${JSON.stringify(candidateBounds)}`
+          `expected unreachable candidate bounds, got ${JSON.stringify(candidateBounds)}`
         )
       }
       screen.emit('display-metrics-changed', {} as Electron.Event, screen.getPrimaryDisplay(), [
@@ -89,7 +90,8 @@ test.describe('Main window display recovery', () => {
       return {
         processId: process.pid,
         windowIdBefore: window.id,
-        visible: window.isVisible()
+        visible: window.isVisible(),
+        displayWorkAreas: displays.map(({ workArea }) => workArea as DisplayWorkArea)
       }
     })
 
@@ -115,21 +117,28 @@ test.describe('Main window display recovery', () => {
     expect(result.visible).toBe(true)
     expect(result.processId).toBe(electronApp.process().pid)
 
-    const recovered = await electronApp.evaluate(({ BrowserWindow }) =>
-      BrowserWindow.getAllWindows()[0].getBounds()
-    )
     await expect
       .poll(() => {
         try {
-          return readNativeWindowBounds(result.processId)
+          const native = readNativeWindowBounds(result.processId)
+          const [x, y] = native.position
+          const [width, height] = native.size
+          return result.displayWorkAreas.some((area) => {
+            const overlapWidth = Math.max(
+              0,
+              Math.min(x + width, area.x + area.width) - Math.max(x, area.x)
+            )
+            const overlapHeight = Math.max(
+              0,
+              Math.min(y + height, area.y + area.height) - Math.max(y, area.y)
+            )
+            return overlapWidth > 0 && overlapHeight > 0
+          })
         } catch {
-          return null
+          return false
         }
       })
-      .toEqual({
-        position: [recovered.x, recovered.y],
-        size: [recovered.width, recovered.height]
-      })
+      .toBe(true)
     expect(await orcaPage.locator('body').isVisible()).toBe(true)
     await orcaPage.screenshot({ path: testInfo.outputPath('main-window-display-recovered.png') })
   })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​508 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​501 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​174 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​157 |

<!-- /orca-pr-loc -->

## ELI5

A display change can leave Orca's live main window outside every connected screen. Orca still sees a valid BrowserWindow, so Dock, tray, and second-instance activation previously focused an unreachable window instead of recovering it. This keeps the same window and sessions alive while moving only an unreachable normal window back into a usable display work area.

## What Changed

- Define main-window reachability by a usable portion of Orca's draggable titlebar.
- Reconcile bounds after display add/remove/metrics changes and normal-state restore/show transitions.
- Route Dock, tray, second-instance, and renderer-recovery activation through the lifecycle owner.
- Clamp to Electron's matching display, preserving position where possible; use primary only if display matching fails.
- Preserve fullscreen/maximized ownership, hidden state, BrowserWindow identity, daemon lifecycle, PTYs, workspaces, and update/quit semantics.
- Add deterministic unit coverage and a macOS headful Electron/Accessibility E2E oracle.

## Why

Latest main was deterministically red when a live normal BrowserWindow was moved outside all display bounds and a display-topology event fired. The main PID and BrowserWindow ID survived, but activation left the content unreachable.

Ordinary renderer crashes are not the proven cause: existing bounded reload recovery works, including PTY input after two forced renderer crashes. The exact field trigger behind STA-5835 remains unconfirmed, so this PR fixes the proven reachability invariant without broadening into daemon restarts or unconditional window recreation.

## Linked Issue

Related to #17025 and STA-5835. This intentionally does not auto-close the field issue.

## Visual Proof

Baseline with the recovery wiring disabled: the isolated window remained outside every display with the same main PID and BrowserWindow ID, and the oracle reported reachable false. A truthful visible screenshot is unavailable for that state because the window is outside the visible desktop by definition.

Candidate after the identical fault injection:

![Recovered Orca main window in isolated E2E profile](https://github.com/user-attachments/assets/dbd80843-9ea7-4877-8b8c-6add7deddfe1)

The screenshot contains only the generated E2E repository/profile. PID-scoped macOS Accessibility bounds exactly matched Electron's recovered bounds.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Passed locally on macOS:

- pnpm tc
- pnpm run check:code-quality:changed
- 445 passed / 8 skipped across the focused main-window, startup-activation, and session-continuity suite
- Headful display-recovery E2E: same BrowserWindow ID and main PID, visible renderer, matching Accessibility bounds
- Existing forced-renderer-crash E2E: terminal input survives two renderer crashes and recovery reloads
- Electron E2E build

Not exercised locally: Windows/Linux display servers, physical monitor disconnect, GPU-process failure, renderer hang, or the exact field-only CGWindowList/Accessibility disappearance.

## Review

The lifecycle boundary, product behavior, and regression surface received independent review during the investigation. The final matching-display policy was rechecked with focused unit tests, the broader main-window suite, typecheck, changed-code quality, and the headful oracle.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no upstream skill-installer source.

## Notes

The recovery is event-driven and window-owned. It does not add polling, scattered timers, daemon restarts, RPC/wire changes, or workspace-specific behavior.

The tradeoff is that an unreachable normal window may be repositioned after a topology event or explicit activation. Reachable windows are left untouched, and hidden/fullscreen/maximized state is not forcibly revealed or recreated.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why, including ELI5
- [x] Visual proof attached with the baseline limitation explained
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, folder-workspace, and backwards-compatibility impact considered
- [ ] Full repository lint/test/build suite; scoped local gates passed and CI will cover the full matrix
