### PR TITLE
fix(test): stop a leaked real timer from failing the updater scheduling test

### DIFF
--- a/src/main/updater.startup-scheduling.test.ts
+++ b/src/main/updater.startup-scheduling.test.ts
@@ -27,7 +27,12 @@ vi.mock('./local-builds/local-build-feed-server', () => moduleFactories.localBui
 
 describe('updater', () => {
   beforeEach(() => {
+    // Why: resetUpdaterMocks() uninstalls fake timers, which discards every timer the previous test
+    // armed; re-faking here keeps this test's timers discardable too. On real timers a stale
+    // `vi.resetModules()`-orphaned updater instance survived to re-arm its 24h check inside a later
+    // fake-timer test, adding a phantom checkForUpdates at fake offset 24h.
     resetUpdaterMocks()
+    vi.useFakeTimers()
   })
 
   it('does not load or configure electron-updater during dev setup', async () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## What this fixes

`test / tests node 24 6/8` intermittently failed at `src/main/updater.startup-scheduling.test.ts:243` —
*"reschedules the next automatic check 24 hours after finding an available update"* — with
`expected checkForUpdates called 1 time, got 2`. Because `verify` is only an aggregator, that red
surfaced on pull requests that had nothing to do with the updater.

## ELI5

The updater sets kitchen timers. Some tests in this file use a real stopwatch, others use a pretend one
they can fast-forward.

Between tests we throw away the updater and build a fresh one — but throwing away the updater does not
un-set the timers it already started. A real 1-second timer set by an early test kept ticking, and went
off in the middle of a much later test that had switched to the pretend stopwatch. The dead updater woke
up, said "time to schedule tomorrow's update check", and set that new timer on the *pretend* clock.

So when the later test fast-forwarded 24 hours to prove it schedules exactly one check, it saw two: its
own, plus the ghost from the test that had already finished.

The fix is to put every test in this file on the pretend clock. Uninstalling a fake clock discards its
pending timers outright, so nothing a test starts can survive into the next one.

## The mechanism, concretely

- `resetUpdaterMocks()` runs `vi.resetModules()` + `vi.useRealTimers()`. Neither cancels a timer already
  armed by the module instance being orphaned.
- The real-timer tests near the top of the file arm the updater's 1 s silent-settle timer
  (`UPDATE_CHECK_SILENT_SETTLE_DELAY_MS`) and its 45 s stall timer.
- When the stale silent-settle timer fires, `settleSilentUpdateCheck` → `completeSilentUpdateCheck`
  reaches `scheduleAutomaticUpdateCheck(AUTO_UPDATE_CHECK_INTERVAL_MS)`. By then `setTimeout` is the
  faked global, so the 24 h check lands on the *current* test's fake clock.
- `autoUpdaterMock` is shared across the file, so that phantom check increments the count the live test
  asserts on. A local repro caught the extra call at fake-clock offset exactly `86400.000 s` — a delay
  the test itself never arms.

## Proof

A scratch file reduced the file to just the two tests involved and held the fake-timer test at fake
offset 0 for 1.5 s of real time, so the stale timer's arrival is not a wall-clock race:

| scenario | result |
| --- | --- |
| real-timer test present, no fix | **3/3 fail**, `expected 1 times, but got 2 times` |
| real-timer test removed, no fix | 3/3 pass |
| real-timer test present, fix applied | 3/3 pass |

After the fix, the real file: **0 failures in 40 runs**, and **0 failures in 15 runs with
`--sequence.shuffle`**, which checks the leak was not just relocated into a different test. All nine
sibling suites that share `updater-test-harness.ts` still pass.

(The natural race does not reproduce on this machine — 0/40 before the fix too. It needs CI's slower
node 24 runner, which is why the deterministic reduction above is the evidence rather than a raw
repeat count.)

## Scope

The `beforeEach` fake-timer install is scoped to this one file rather than to the shared
`resetUpdaterMocks()` helper: doing it in the helper hangs six tests in
`updater.nudge-campaign.test.ts`, which depend on real timers.

The line-243 assertion is untouched — it is catching a genuine cross-test leak, and loosening it would
hide the bug.

## Before / after

This is a developer-facing change, so the "user" is us.

**Before:** an unrelated pull request could go red on `verify` for a reason that had nothing to do with
it. That costs a rerun, and every one of those teaches the team that a red check might just be noise.

**After:** it doesn't. No product behaviour changes; `updater.ts` is not modified.
