### PR TITLE
fix(test): stop Windows teardown failing a passed rebuild-native-deps test

### DIFF
--- a/config/scripts/rebuild-native-deps.test.mjs
+++ b/config/scripts/rebuild-native-deps.test.mjs
@@ -46,7 +46,7 @@ describe('rebuild-native-deps Electron install fallback', () => {
         'download attempted\n'
       )
     } finally {
-      rmSync(projectDir, { recursive: true, force: true })
+      removeTempProject(projectDir)
     }
   })
 
@@ -70,7 +70,7 @@ describe('rebuild-native-deps Electron install fallback', () => {
         'Continuing postinstall because Electron binary installation failed'
       )
     } finally {
-      rmSync(projectDir, { recursive: true, force: true })
+      removeTempProject(projectDir)
     }
   })
 
@@ -91,7 +91,7 @@ describe('rebuild-native-deps Electron install fallback', () => {
         'Continuing postinstall because Electron binary installation failed'
       )
     } finally {
-      rmSync(projectDir, { recursive: true, force: true })
+      removeTempProject(projectDir)
     }
   })
 
@@ -121,7 +121,7 @@ describe('rebuild-native-deps Electron install fallback', () => {
         'partial cleared\ndownload attempted\n'
       )
     } finally {
-      rmSync(projectDir, { recursive: true, force: true })
+      removeTempProject(projectDir)
     }
   })
 })
@@ -154,7 +154,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         )
         expect(existsSync(rebuildLogPath)).toBe(false)
       } finally {
-        rmSync(projectDir, { recursive: true, force: true })
+        removeTempProject(projectDir)
       }
     }
   )
@@ -179,7 +179,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
       expect(readFileSync(join(runtimeDir, 'conpty.dll'), 'utf8')).toBe('conpty.dll x64')
       expect(readFileSync(join(runtimeDir, 'OpenConsole.exe'), 'utf8')).toBe('OpenConsole.exe x64')
     } finally {
-      rmSync(projectDir, { recursive: true, force: true })
+      removeTempProject(projectDir)
     }
   })
 
@@ -207,7 +207,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         const rebuildCall = JSON.parse(readFileSync(rebuildLogPath, 'utf8').trim())
         expect(rebuildCall.onlyModules).toEqual(['windows-native-registry'])
       } finally {
-        rmSync(projectDir, { recursive: true, force: true })
+        removeTempProject(projectDir)
       }
     }
   )
@@ -237,7 +237,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         const rebuildCall = JSON.parse(readFileSync(rebuildLogPath, 'utf8').trim())
         expect(rebuildCall.onlyModules).toEqual(['node-pty'])
       } finally {
-        rmSync(projectDir, { recursive: true, force: true })
+        removeTempProject(projectDir)
       }
     }
   )
@@ -268,7 +268,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         expect(rebuildCall.ignoreModules).toEqual(['cpu-features'])
         expect(rebuildCall.force).toBe(true)
       } finally {
-        rmSync(projectDir, { recursive: true, force: true })
+        removeTempProject(projectDir)
       }
     }
   )
@@ -296,7 +296,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         )
         expect(existsSync(rebuildLogPath)).toBe(false)
       } finally {
-        rmSync(projectDir, { recursive: true, force: true })
+        removeTempProject(projectDir)
       }
     }
   )
@@ -326,11 +326,30 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         expect(rebuildCall.onlyModules).toEqual(['node-pty'])
         expect(rebuildCall.force).toBe(true)
       } finally {
-        rmSync(projectDir, { recursive: true, force: true })
+        removeTempProject(projectDir)
       }
     }
   )
 })
+
+// Why: Windows can still hold handles on a tree a just-exited child wrote, so these are the codes
+// `rm` surfaces while the release is pending rather than real teardown bugs.
+const TRANSIENT_WINDOWS_REMOVAL_CODES = new Set(['EBUSY', 'EMFILE', 'ENFILE', 'ENOTEMPTY', 'EPERM'])
+
+/** Removes a fixture tree without letting Windows teardown flakiness fail a test that already passed. */
+function removeTempProject(projectDir) {
+  try {
+    rmSync(projectDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  } catch (error) {
+    // Why: anything the retries cannot explain away is still a real failure worth surfacing.
+    if (process.platform !== 'win32' || !TRANSIENT_WINDOWS_REMOVAL_CODES.has(error?.code)) {
+      throw error
+    }
+    console.warn(
+      `rebuild-native-deps test left ${projectDir} behind after retries (${error.code}); remove it manually.`
+    )
+  }
+}
 
 function mkTempProject() {
   const projectDir = mkdtempSync(join(tmpdir(), 'orca-rebuild-native-deps-'))


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## What this fixes

`package (windows)` went red intermittently across unrelated pull requests (seen on #16955 and #17077).
The failure is not in an assertion — it is an `rmSync` **EPERM** thrown from a `finally` block in
`config/scripts/rebuild-native-deps.test.mjs` *after every assertion in that test has already passed*.

## ELI5

Each test here makes a scratch folder, runs a small program inside it, checks the result, then deletes
the folder.

On Windows, the moment a program exits is not the moment Windows lets go of its files. Antivirus,
the indexer, or the just-exited child can still be holding the folder for a fraction of a second.
Delete it in that window and Windows says "operation not permitted".

So the test *passed*, then the cleanup line threw, and the whole Windows job went red — on pull requests
that had never touched this code.

The fix is to ask twice: wait a moment and retry the delete, which is what the rest of the repo already
does. And if the retries genuinely lose, say so out loud instead of failing a test that had already
succeeded.

## Why this file

The `package (windows)` job runs a hardcoded file list, so its inputs hash identically across runs —
the variation had to be inside a test. Of that list, `config/scripts/rebuild-native-deps.test.mjs` is the
only file that imports nothing but Node builtins, and it has eleven
`finally { rmSync(projectDir, { recursive: true, force: true }) }` blocks, none with retry options.
`force: true` only suppresses `ENOENT`; it does nothing for `EPERM`. Four runs at the same head gave
1 fail / 3 pass.

## What changed

The eleven duplicated cleanup lines now go through one helper:

```js
function removeTempProject(projectDir) {
  try {
    rmSync(projectDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
  } catch (error) {
    if (process.platform !== 'win32' || !TRANSIENT_WINDOWS_REMOVAL_CODES.has(error?.code)) {
      throw error
    }
    console.warn(`rebuild-native-deps test left ${projectDir} behind after retries (${error.code}); remove it manually.`)
  }
}
```

`maxRetries` / `retryDelay` is the idiom already used across the repo for exactly this — including
`browser-client-page-renderer-lifecycle.electron.test.ts`, which runs in this very job — and it is what
`src/main/host-tree-removal.ts` applies in product code. Node retries `EBUSY`, `EMFILE`, `ENFILE`,
`ENOTEMPTY` and `EPERM` on that option, which is the whole failure class here.

## This is not a blanket swallow

The `catch` is deliberately narrow, and it is in *teardown* only — no assertion is retried or wrapped:

| platform | error | result |
| --- | --- | --- |
| win32 | `EPERM` / `EBUSY` / `ENOTEMPTY` / `EMFILE` / `ENFILE` | warning naming the leftover directory |
| win32 | anything else (e.g. `ENOSPC`, no `code`) | **throws** |
| macOS / Linux | anything, including `EPERM` | **throws** |

So a cleanup failure that leaves real garbage behind is still visible — it names the directory in the
job log — but it can no longer fail a test whose assertions passed. A genuine teardown bug still fails
the suite.

## Verification

- `config/scripts/rebuild-native-deps.test.mjs` passes locally (8 passed, 3 win32-only skipped).
- The `catch` branch table above was checked case by case against the guard condition.
- `pnpm tc`, `oxlint`, `node config/scripts/check-changed-code-quality.mjs` and `git diff --check` are
  clean.

The EPERM itself cannot be reproduced on macOS — it is a Windows handle-release race — so the evidence
here is the mechanism plus the observed 1-in-4 rate at a fixed head, not a local repro.

## Before / after

This is a developer-facing change, so the "user" is us.

**Before:** an unrelated pull request could go red on `package (windows)` for a reason that had nothing
to do with it. That costs a rerun, and every one of those teaches the team that a red check might just
be noise.

**After:** it doesn't. No product code changes, and no test assertion was weakened, skipped, or retried.
