### PR TITLE
fix(cli): attribute account add from the WSL bridge to the caller's distro

### DIFF
--- a/src/cli/handlers/account-wsl-location.ts
+++ b/src/cli/handlers/account-wsl-location.ts
@@ -1,0 +1,13 @@
+import { parseWslUncPath } from '../../shared/wsl-paths'
+
+// Why: `orca-ide` in a distro re-enters Windows via the PowerShell bridge, so only
+// the bridged cwd's UNC form (or a forwarded WSL_DISTRO_NAME) still names the distro;
+// without it the account lands in the host lane and never shows under WSL (#17089).
+// A non-Windows CLI talks to a runtime with no WSL lane, so it never attributes one.
+export function getWslAccountTarget(cwd: string): { runtime: 'wsl'; wslDistro: string } | null {
+  const distro =
+    process.platform === 'win32'
+      ? process.env.WSL_DISTRO_NAME?.trim() || parseWslUncPath(cwd)?.distro
+      : undefined
+  return distro ? { runtime: 'wsl', wslDistro: distro } : null
+}

--- a/src/cli/handlers/account.test.ts
+++ b/src/cli/handlers/account.test.ts
@@ -97,14 +97,15 @@ describe('account CLI handlers', () => {
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
   const originalElectronRunAsNode = process.env.ELECTRON_RUN_AS_NODE
   const originalPathAlias = process.env.Path
+  const originalWslDistroName = process.env.WSL_DISTRO_NAME
   const callMock = vi.fn()
   const client = { call: callMock } as unknown as RuntimeClient
   let logSpy: ReturnType<typeof vi.spyOn>
 
-  function context(agent: string, json = false): HandlerContext {
+  function context(agent: string, json = false, cwd = process.cwd()): HandlerContext {
     return {
       client,
-      cwd: process.cwd(),
+      cwd,
       flags: new Map([['agent', agent]]),
       json,
       rawArgs: []
@@ -136,6 +137,9 @@ describe('account CLI handlers', () => {
     )
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     process.env.ELECTRON_RUN_AS_NODE = '1'
+    // Why: a test run inside a real distro carries WSL_DISTRO_NAME, which would
+    // leak WSL attribution into every faked-win32 add below.
+    delete process.env.WSL_DISTRO_NAME
   })
 
   afterEach(() => {
@@ -150,6 +154,11 @@ describe('account CLI handlers', () => {
       delete process.env.Path
     } else {
       process.env.Path = originalPathAlias
+    }
+    if (originalWslDistroName === undefined) {
+      delete process.env.WSL_DISTRO_NAME
+    } else {
+      process.env.WSL_DISTRO_NAME = originalWslDistroName
     }
   })
 
@@ -306,6 +315,62 @@ describe('account CLI handlers', () => {
         .digest('hex')
     })
     expect(existsSync(configDir)).toBe(false)
+  })
+
+  it('attributes a Claude account added through the WSL bridge to the cwd distro', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+    await ACCOUNT_HANDLERS['account add'](
+      context('claude', false, String.raw`\\wsl.localhost\Ubuntu-22.04\home\user\project`)
+    )
+
+    const configDir = spawnMock.mock.calls[0]?.[2].env.CLAUDE_CONFIG_DIR
+    expect(callMock).toHaveBeenCalledWith('accounts.addClaudeFromConfigDir', {
+      configDir,
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu-22.04'
+    })
+  })
+
+  it('attributes a Codex account added through the WSL bridge to the cwd distro', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+    await ACCOUNT_HANDLERS['account add'](
+      context('codex', false, String.raw`\\wsl$\Ubuntu\home\user`)
+    )
+
+    const sourceHome = spawnMock.mock.calls[0]?.[2].env.CODEX_HOME
+    expect(callMock).toHaveBeenCalledWith('accounts.addCodexFromHome', {
+      sourceHome,
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu'
+    })
+  })
+
+  it('prefers an interop-forwarded WSL_DISTRO_NAME over the bridged cwd distro', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    process.env.WSL_DISTRO_NAME = 'Debian'
+
+    await ACCOUNT_HANDLERS['account add'](
+      context('claude', false, String.raw`\\wsl.localhost\Ubuntu-22.04\home\user`)
+    )
+
+    expect(callMock).toHaveBeenCalledWith(
+      'accounts.addClaudeFromConfigDir',
+      expect.objectContaining({ runtime: 'wsl', wslDistro: 'Debian' })
+    )
+  })
+
+  it('keeps host attribution when the CLI itself runs inside a distro', async () => {
+    // Why: a Linux CLI talks to a Linux runtime whose accounts are host-lane;
+    // WSL_DISTRO_NAME there names the CLI's own environment, not a target lane.
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+    process.env.WSL_DISTRO_NAME = 'Ubuntu-22.04'
+
+    await ACCOUNT_HANDLERS['account add'](context('claude'))
+
+    const configDir = spawnMock.mock.calls[0]?.[2].env.CLAUDE_CONFIG_DIR
+    expect(callMock).toHaveBeenCalledWith('accounts.addClaudeFromConfigDir', { configDir })
   })
 
   it('waits for physical child close before removing interrupted login credentials', async () => {

--- a/src/cli/handlers/account.ts
+++ b/src/cli/handlers/account.ts
@@ -33,6 +33,7 @@ import {
   type InteractiveLoginSession,
   withInteractiveLoginCleanup
 } from './interactive-login-interruption'
+import { getWslAccountTarget } from './account-wsl-location'
 
 // Why: add returns just that provider's state; list returns the full snapshot.
 type AccountsListSnapshot = {
@@ -193,7 +194,7 @@ async function cleanupClaudeLoginArtifacts(
 }
 
 /** Logs into a Claude account in a temp config dir, then registers it with the local runtime. */
-async function addClaudeAccount({ client, json }: HandlerContext): Promise<void> {
+async function addClaudeAccount({ client, cwd, json }: HandlerContext): Promise<void> {
   const configDir = mkdtempSync(join(tmpdir(), 'orca-account-add-claude-'))
   const session: InteractiveLoginSession = {
     child: null,
@@ -224,6 +225,7 @@ async function addClaudeAccount({ client, json }: HandlerContext): Promise<void>
       session.registering = true
       return client.call<ClaudeRateLimitAccountsState>('accounts.addClaudeFromConfigDir', {
         configDir,
+        ...getWslAccountTarget(cwd),
         ...(process.platform === 'darwin'
           ? {
               previousLegacyCredentialsSha256: legacyCredentials
@@ -238,7 +240,7 @@ async function addClaudeAccount({ client, json }: HandlerContext): Promise<void>
 }
 
 /** Logs into a Codex account in a temp CODEX_HOME, then registers it with the local runtime. */
-async function addCodexAccount({ client, json }: HandlerContext): Promise<void> {
+async function addCodexAccount({ client, cwd, json }: HandlerContext): Promise<void> {
   const codexHome = mkdtempSync(join(tmpdir(), 'orca-account-add-codex-'))
   const session: InteractiveLoginSession = {
     child: null,
@@ -262,7 +264,8 @@ async function addCodexAccount({ client, json }: HandlerContext): Promise<void> 
       )
       session.registering = true
       return client.call<CodexRateLimitAccountsState>('accounts.addCodexFromHome', {
-        sourceHome: codexHome
+        sourceHome: codexHome,
+        ...getWslAccountTarget(cwd)
       })
     }
   )


### PR DESCRIPTION
## ELI5

Adding a Claude/Codex account from inside WSL (`orca-ide account add`) logged in fine, but the account landed in the **Windows** account list instead of the **WSL** one, so the WSL account manager kept saying "No managed Claude accounts". The CLI simply never told the runtime *which environment* the account was for. Now it does.

## What Changed

- New `src/cli/handlers/account-wsl-location.ts`: `getWslAccountTarget(cwd)` derives the WSL distro on Windows from an interop-forwarded `WSL_DISTRO_NAME` or from the bridged cwd's UNC form (`\\wsl.localhost\<distro>\…` via `ORCA_CLI_CWD`), mirroring the existing idiom in `src/cli/handlers/file.ts`. A non-Windows CLI never attributes WSL (its local runtime's accounts are host-lane by definition).
- `src/cli/handlers/account.ts`: both `accounts.addClaudeFromConfigDir` and `accounts.addCodexFromHome` now send `runtime: 'wsl'` + `wslDistro` when the add comes through the WSL bridge. (The helper lives in its own module to respect the 300-code-line `max-lines` cap on `account.ts`.)
- `src/cli/handlers/account.test.ts`: four new tests (Claude + Codex bridge attribution, `WSL_DISTRO_NAME` precedence, and host attribution when the CLI itself runs inside a distro), plus `WSL_DISTRO_NAME` env hygiene so the suite is stable when run inside a real distro.

## Why

`orca-ide` inside a distro re-enters Windows through the PowerShell bridge (`src/main/cli/wsl-cli-scripts.ts`), which only preserves `ORCA_CLI_CWD`. The account handlers ignored it and called the add RPCs with no `runtime`/`wslDistro` — those params already existed on `AddClaudeFromConfigDirParams`/`AddCodexFromHomeParams` but had no caller. Without a target, `ClaudeManagedAuthStorage.tryCreateWsl` (and the Codex twin) silently falls through to the host lane, and `provider-account-visibility.ts` then shows the account under the Windows location and hides it from the WSL view — exactly the symptom in the linked issue.

The whole downstream path (RPC schema → `OrcaRuntime` → account services → managed-auth storage) already accepts and honors the target, so the fix is purely to supply it. Both params are optional on the wire; an older runtime ignores them and degrades to today's behavior (no wire-compat break).

## Linked Issue

Fixes #17089

## Visual Proof

CLI-side attribution fix — no rendered UI change beyond the account now appearing in the correct list. Before/after of the WSL account manager (`Account location → WSL → Ubuntu-22.04 → Claude`) after a successful `orca-ide account add` from inside the distro:

**Before:** `No managed Claude accounts for WSL Ubuntu-22.04.` (account shows under the Windows location instead)

**After:** the added account is listed under the WSL Ubuntu-22.04 location.

I'm the reporter of #17089 and will attach a screen capture from my Windows + WSL Ubuntu-22.04 setup once a build with this change is available (my dev checkout here is Linux-side, where the bridge scenario can't be captured).

## Testing

- `vitest run src/cli/handlers/account.test.ts` — 31 passed (27 existing + 4 new; the new tests fail without the fix).
- `vitest run src/main/runtime/rpc/methods/accounts.test.ts` — 9 passed.
- `pnpm tc:cli` clean; `oxlint` (default + `oxlint-code-quality-native-plugins` + type-aware code-quality configs) clean on the changed files; `oxfmt` applied.
- Developed and tested on Linux (inside WSL). Not yet manually verified on a Windows host — the attribution payload and the receiving WSL lane are covered by unit tests on both sides (`service-wsl-accounts.test.ts` already covers the Codex WSL create path).

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Investigated and implemented with Claude Code (Fable 5); reviewed and driven by me (the issue reporter).

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: the distro name only feeds the existing `runWslProcess`/managed-auth ownership checks already exercised by the UI add path.
- Cross-platform: attribution is gated to `process.platform === 'win32'`; macOS/Linux payloads are byte-identical to before (see the darwin and linux tests).
- Backwards compatibility: params are optional and already declared in the RPC schema; old runtimes strip them and behave as today.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — ran the targeted lint/typecheck/tests above; full suite left to CI
