### PR TITLE
Bump mobile app.json to 0.0.47

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -75,7 +75,7 @@
       "allowBackup": false,
       "permissions": ["RECORD_AUDIO", "MODIFY_AUDIO_SETTINGS"],
       "package": "com.stably.orca.mobile",
-      "versionCode": 13
+      "versionCode": 15
     },
     "plugins": [
       "expo-router",

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.44",
+    "version": "0.0.47",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | 0 |

<!-- /orca-pr-loc -->

## Summary
Bump `mobile/app.json` to the `0.0.47` release values.

- `expo.version`: `0.0.44` → `0.0.47`
- `expo.android.versionCode`: `13` → `15`

## Why both fields

`app.json` on main had drifted behind what actually shipped: main said `0.0.44` / versionCode `13`, while the `mobile-android-v0.0.46` tag shipped `0.0.46` / versionCode `14`. The release bump lived only on the release side-branch and was never merged back.

`versionCode` is **not** CI-owned, despite what the release runbook says. `mobile/scripts/prepare-android-release.mjs` hard-fails if you try to pass it as a workflow input:

```
Android versionCode changes must be committed in mobile/app.json before release
```

It also requires the release tag version to match the committed `expo.version` exactly, and `MOBILE_ANDROID_BUMP_PATCH_VERSION` is rejected outright. So an Android `0.0.47` release cut from main as-is would have carried versionCode `13` — **below** the `14` already on users' devices — and Android would refuse the upgrade. `15` clears the shipped `14`.

`expo.ios.buildNumber` is left alone: the iOS side genuinely is CI-resolved, via fastlane's `latest_testflight_build_number` against App Store Connect.

## Context
The iOS `0.0.47` build (build 1) is already on TestFlight from [run 33224233767](https://github.com/stablyai/orca/actions/runs/33224233767).

## Verification
- `node -e` round-trip parses clean: `version=0.0.47 buildNumber=1 versionCode=15`
- Diff is two lines, no formatter reflow.