### PR TITLE
Fix inline agent mouse wheel scrolling

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -421,6 +421,7 @@ describe('terminal mouse wheel multiplier', () => {
     expect(shouldMultiplyTerminalMouseWheel(dispatched[0]!, target)).toBe(false)
   })
 
+  /** Verifies normal-buffer wheel input scrolls instead of reaching arrow-key fallback. */
   it('blocks wheel-to-arrow synthesis for normal buffers without mouse reporting', () => {
     const handlers: ((event: WheelEvent) => boolean)[] = []
     const scrollLines = vi.fn()
@@ -440,6 +441,7 @@ describe('terminal mouse wheel multiplier', () => {
     expect(scrollLines).toHaveBeenCalledWith(-1)
   })
 
+  /** Verifies alternate-buffer TUIs retain xterm's arrow-key fallback. */
   it('preserves wheel-to-arrow fallback for alternate buffers without mouse reporting', () => {
     const handlers: ((event: WheelEvent) => boolean)[] = []
     const terminal = {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -56,6 +56,7 @@ class TestWheelEvent extends Event {
   }
 }
 
+/** Creates the minimal terminal element state needed by wheel-routing tests. */
 function terminalElement(mouseReporting = true): HTMLElement {
   return {
     classList: {
@@ -64,6 +65,7 @@ function terminalElement(mouseReporting = true): HTMLElement {
   } as HTMLElement
 }
 
+/** Creates a wheel-event fixture with a vertical pixel delta by default. */
 function wheelEvent(
   init: Partial<WheelEventInit> & { wheelDelta?: number; wheelDeltaY?: number } = {}
 ): WheelEvent {
@@ -421,7 +423,6 @@ describe('terminal mouse wheel multiplier', () => {
     expect(shouldMultiplyTerminalMouseWheel(dispatched[0]!, target)).toBe(false)
   })
 
-  /** Verifies normal-buffer wheel input scrolls instead of reaching arrow-key fallback. */
   it('blocks wheel-to-arrow synthesis for normal buffers without mouse reporting', () => {
     const handlers: ((event: WheelEvent) => boolean)[] = []
     const scrollLines = vi.fn()
@@ -441,7 +442,6 @@ describe('terminal mouse wheel multiplier', () => {
     expect(scrollLines).toHaveBeenCalledWith(-1)
   })
 
-  /** Verifies alternate-buffer TUIs retain xterm's arrow-key fallback. */
   it('preserves wheel-to-arrow fallback for alternate buffers without mouse reporting', () => {
     const handlers: ((event: WheelEvent) => boolean)[] = []
     const terminal = {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -76,6 +76,11 @@ function wheelEvent(
   } as WheelEvent
 }
 
+/** Simulates xterm scrolling after its render dimensions have been disposed. */
+function throwDisposedRenderDimensions(): never {
+  throw new TypeError("Cannot read properties of undefined (reading 'dimensions')")
+}
+
 /** Verifies that normal-buffer wheel input scrolls terminal history directly. */
 function verifyNormalBufferWheelScroll(): void {
   const handlers: ((event: WheelEvent) => boolean)[] = []
@@ -96,6 +101,10 @@ function verifyNormalBufferWheelScroll(): void {
 
   expect(handlers[0]?.(wheelEvent({ deltaY: -16, deltaMode: DOM_DELTA_PIXEL }))).toBe(false)
   expect(scrollLines).toHaveBeenCalledWith(-1)
+
+  scrollLines.mockImplementation(throwDisposedRenderDimensions)
+  expect(handlers[0]?.(wheelEvent({ deltaY: -16, deltaMode: DOM_DELTA_PIXEL }))).toBe(false)
+  expect(scrollLines).toHaveBeenCalledTimes(2)
 }
 
 /** Verifies that alternate-buffer wheel input remains available to xterm's fallback. */

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -81,6 +81,7 @@ function verifyNormalBufferWheelScroll(): void {
   const handlers: ((event: WheelEvent) => boolean)[] = []
   const scrollLines = vi.fn()
   const terminal = {
+    /** Captures the normal-buffer wheel handler for direct invocation. */
     attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
       handlers.push(handler)
     },
@@ -100,6 +101,7 @@ function verifyNormalBufferWheelScroll(): void {
 function verifyAlternateBufferWheelFallback(): void {
   const handlers: ((event: WheelEvent) => boolean)[] = []
   const terminal = {
+    /** Captures the alternate-buffer wheel handler for direct invocation. */
     attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
       handlers.push(handler)
     },

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -76,6 +76,44 @@ function wheelEvent(
   } as WheelEvent
 }
 
+/** Verifies that normal-buffer wheel input scrolls terminal history directly. */
+function verifyNormalBufferWheelScroll(): void {
+  const handlers: ((event: WheelEvent) => boolean)[] = []
+  const scrollLines = vi.fn()
+  const terminal = {
+    attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
+      handlers.push(handler)
+    },
+    buffer: { active: { type: 'normal' as const } },
+    element: terminalElement(false),
+    modes: { mouseTrackingMode: 'none' as const },
+    rows: 24,
+    scrollLines
+  }
+  attachTerminalMouseWheelMultiplier(terminal)
+
+  expect(handlers[0]?.(wheelEvent({ deltaY: -16, deltaMode: DOM_DELTA_PIXEL }))).toBe(false)
+  expect(scrollLines).toHaveBeenCalledWith(-1)
+}
+
+/** Verifies that alternate-buffer wheel input remains available to xterm's fallback. */
+function verifyAlternateBufferWheelFallback(): void {
+  const handlers: ((event: WheelEvent) => boolean)[] = []
+  const terminal = {
+    attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
+      handlers.push(handler)
+    },
+    buffer: { active: { type: 'alternate' as const } },
+    element: terminalElement(false),
+    modes: { mouseTrackingMode: 'none' as const },
+    rows: 24,
+    scrollLines: vi.fn()
+  }
+  attachTerminalMouseWheelMultiplier(terminal)
+
+  expect(handlers[0]?.(wheelEvent())).toBe(true)
+}
+
 describe('terminal mouse wheel multiplier', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
@@ -423,41 +461,15 @@ describe('terminal mouse wheel multiplier', () => {
     expect(shouldMultiplyTerminalMouseWheel(dispatched[0]!, target)).toBe(false)
   })
 
-  it('blocks wheel-to-arrow synthesis for normal buffers without mouse reporting' /** Verifies that normal-buffer wheel input scrolls terminal history directly. */, () => {
-    const handlers: ((event: WheelEvent) => boolean)[] = []
-    const scrollLines = vi.fn()
-    const terminal = {
-      attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
-        handlers.push(handler)
-      },
-      buffer: { active: { type: 'normal' as const } },
-      element: terminalElement(false),
-      modes: { mouseTrackingMode: 'none' as const },
-      rows: 24,
-      scrollLines
-    }
-    attachTerminalMouseWheelMultiplier(terminal)
+  it(
+    'blocks wheel-to-arrow synthesis for normal buffers without mouse reporting',
+    verifyNormalBufferWheelScroll
+  )
 
-    expect(handlers[0]?.(wheelEvent({ deltaY: -16, deltaMode: DOM_DELTA_PIXEL }))).toBe(false)
-    expect(scrollLines).toHaveBeenCalledWith(-1)
-  })
-
-  it('preserves wheel-to-arrow fallback for alternate buffers without mouse reporting' /** Verifies that alternate-buffer wheel input remains available to xterm's fallback. */, () => {
-    const handlers: ((event: WheelEvent) => boolean)[] = []
-    const terminal = {
-      attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
-        handlers.push(handler)
-      },
-      buffer: { active: { type: 'alternate' as const } },
-      element: terminalElement(false),
-      modes: { mouseTrackingMode: 'none' as const },
-      rows: 24,
-      scrollLines: vi.fn()
-    }
-    attachTerminalMouseWheelMultiplier(terminal)
-
-    expect(handlers[0]?.(wheelEvent())).toBe(true)
-  })
+  it(
+    'preserves wheel-to-arrow fallback for alternate buffers without mouse reporting',
+    verifyAlternateBufferWheelFallback
+  )
 
   it('discards pending replay when mouse reporting turns off before drain', async () => {
     vi.stubGlobal('WheelEvent', TestWheelEvent)

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -80,11 +80,12 @@ function wheelEvent(
 function verifyNormalBufferWheelScroll(): void {
   const handlers: ((event: WheelEvent) => boolean)[] = []
   const scrollLines = vi.fn()
+  /** Captures the normal-buffer wheel handler for direct invocation. */
+  function captureNormalBufferWheelHandler(handler: (event: WheelEvent) => boolean): void {
+    handlers.push(handler)
+  }
   const terminal = {
-    /** Captures the normal-buffer wheel handler for direct invocation. */
-    attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
-      handlers.push(handler)
-    },
+    attachCustomWheelEventHandler: captureNormalBufferWheelHandler,
     buffer: { active: { type: 'normal' as const } },
     element: terminalElement(false),
     modes: { mouseTrackingMode: 'none' as const },
@@ -100,11 +101,12 @@ function verifyNormalBufferWheelScroll(): void {
 /** Verifies that alternate-buffer wheel input remains available to xterm's fallback. */
 function verifyAlternateBufferWheelFallback(): void {
   const handlers: ((event: WheelEvent) => boolean)[] = []
+  /** Captures the alternate-buffer wheel handler for direct invocation. */
+  function captureAlternateBufferWheelHandler(handler: (event: WheelEvent) => boolean): void {
+    handlers.push(handler)
+  }
   const terminal = {
-    /** Captures the alternate-buffer wheel handler for direct invocation. */
-    attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
-      handlers.push(handler)
-    },
+    attachCustomWheelEventHandler: captureAlternateBufferWheelHandler,
     buffer: { active: { type: 'alternate' as const } },
     element: terminalElement(false),
     modes: { mouseTrackingMode: 'none' as const },

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -395,7 +395,8 @@ describe('terminal mouse wheel multiplier', () => {
         buffer: { active: { type: 'alternate' } },
         element: target,
         modes: { mouseTrackingMode: 'any' },
-        rows: 24
+        rows: 24,
+        scrollLines: vi.fn()
       },
       { getTuiMouseWheelMultiplier: () => 1 }
     )
@@ -422,6 +423,7 @@ describe('terminal mouse wheel multiplier', () => {
 
   it('blocks wheel-to-arrow synthesis for normal buffers without mouse reporting', () => {
     const handlers: ((event: WheelEvent) => boolean)[] = []
+    const scrollLines = vi.fn()
     const terminal = {
       attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
         handlers.push(handler)
@@ -429,11 +431,13 @@ describe('terminal mouse wheel multiplier', () => {
       buffer: { active: { type: 'normal' as const } },
       element: terminalElement(false),
       modes: { mouseTrackingMode: 'none' as const },
-      rows: 24
+      rows: 24,
+      scrollLines
     }
     attachTerminalMouseWheelMultiplier(terminal)
 
-    expect(handlers[0]?.(wheelEvent())).toBe(false)
+    expect(handlers[0]?.(wheelEvent({ deltaY: -16, deltaMode: DOM_DELTA_PIXEL }))).toBe(false)
+    expect(scrollLines).toHaveBeenCalledWith(-1)
   })
 
   it('preserves wheel-to-arrow fallback for alternate buffers without mouse reporting', () => {
@@ -445,7 +449,8 @@ describe('terminal mouse wheel multiplier', () => {
       buffer: { active: { type: 'alternate' as const } },
       element: terminalElement(false),
       modes: { mouseTrackingMode: 'none' as const },
-      rows: 24
+      rows: 24,
+      scrollLines: vi.fn()
     }
     attachTerminalMouseWheelMultiplier(terminal)
 
@@ -469,7 +474,8 @@ describe('terminal mouse wheel multiplier', () => {
       buffer: { active: { type: 'alternate' as const } },
       element: target,
       modes: { mouseTrackingMode: 'any' as 'any' | 'none' },
-      rows: 24
+      rows: 24,
+      scrollLines: vi.fn()
     }
     attachTerminalMouseWheelMultiplier(terminal)
 
@@ -509,7 +515,8 @@ describe('terminal mouse wheel multiplier', () => {
         buffer: { active: { type: 'alternate' } },
         element: target,
         modes: { mouseTrackingMode: 'any' },
-        rows: 24
+        rows: 24,
+        scrollLines: vi.fn()
       },
       { getTuiMouseWheelMultiplier: () => 1 }
     )
@@ -563,7 +570,8 @@ describe('terminal mouse wheel multiplier', () => {
         buffer: { active: { type: 'alternate' } },
         element: target,
         modes: { mouseTrackingMode: 'any' },
-        rows: 24
+        rows: 24,
+        scrollLines: vi.fn()
       },
       { getTuiMouseWheelMultiplier: () => 1 }
     )
@@ -599,7 +607,8 @@ describe('terminal mouse wheel multiplier', () => {
         buffer: { active: { type: 'alternate' } },
         element: target,
         modes: { mouseTrackingMode: 'any' },
-        rows: 24
+        rows: 24,
+        scrollLines: vi.fn()
       },
       {
         getTuiMouseWheelMultiplier: () => 3

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -392,6 +392,7 @@ describe('terminal mouse wheel multiplier', () => {
         attachCustomWheelEventHandler: (handler) => {
           handlers.push(handler)
         },
+        buffer: { active: { type: 'alternate' } },
         element: target,
         modes: { mouseTrackingMode: 'any' },
         rows: 24
@@ -419,41 +420,36 @@ describe('terminal mouse wheel multiplier', () => {
     expect(shouldMultiplyTerminalMouseWheel(dispatched[0]!, target)).toBe(false)
   })
 
-  it('does not replay with a stale active mouse-reporting class', async () => {
-    vi.stubGlobal('WheelEvent', TestWheelEvent)
+  it('blocks wheel-to-arrow synthesis for normal buffers without mouse reporting', () => {
     const handlers: ((event: WheelEvent) => boolean)[] = []
-    const target = Object.assign(new EventTarget(), {
-      classList: {
-        contains: (className: string) => className === 'enable-mouse-events'
-      }
-    }) as unknown as EventTarget & HTMLElement
-    const dispatched: WheelEvent[] = []
-    target.addEventListener('wheel', (event) => dispatched.push(event as WheelEvent))
     const terminal = {
       attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
         handlers.push(handler)
       },
-      element: target,
+      buffer: { active: { type: 'normal' as const } },
+      element: terminalElement(false),
       modes: { mouseTrackingMode: 'none' as const },
       rows: 24
     }
     attachTerminalMouseWheelMultiplier(terminal)
 
-    const event = new TestWheelEvent('wheel', {
-      bubbles: true,
-      cancelable: true,
-      deltaMode: DOM_DELTA_PIXEL,
-      deltaY: 12
-    }) as WheelEvent
-    Object.defineProperty(event, 'wheelDeltaY', {
-      configurable: true,
-      value: -120
-    })
+    expect(handlers[0]?.(wheelEvent())).toBe(false)
+  })
 
-    expect(handlers[0]?.(event)).toBe(true)
-    await Promise.resolve()
+  it('preserves wheel-to-arrow fallback for alternate buffers without mouse reporting', () => {
+    const handlers: ((event: WheelEvent) => boolean)[] = []
+    const terminal = {
+      attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
+        handlers.push(handler)
+      },
+      buffer: { active: { type: 'alternate' as const } },
+      element: terminalElement(false),
+      modes: { mouseTrackingMode: 'none' as const },
+      rows: 24
+    }
+    attachTerminalMouseWheelMultiplier(terminal)
 
-    expect(dispatched).toHaveLength(0)
+    expect(handlers[0]?.(wheelEvent())).toBe(true)
   })
 
   it('discards pending replay when mouse reporting turns off before drain', async () => {
@@ -470,6 +466,7 @@ describe('terminal mouse wheel multiplier', () => {
       attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
         handlers.push(handler)
       },
+      buffer: { active: { type: 'alternate' as const } },
       element: target,
       modes: { mouseTrackingMode: 'any' as 'any' | 'none' },
       rows: 24
@@ -509,6 +506,7 @@ describe('terminal mouse wheel multiplier', () => {
         attachCustomWheelEventHandler: (handler) => {
           handlers.push(handler)
         },
+        buffer: { active: { type: 'alternate' } },
         element: target,
         modes: { mouseTrackingMode: 'any' },
         rows: 24
@@ -562,6 +560,7 @@ describe('terminal mouse wheel multiplier', () => {
         attachCustomWheelEventHandler: (handler) => {
           handlers.push(handler)
         },
+        buffer: { active: { type: 'alternate' } },
         element: target,
         modes: { mouseTrackingMode: 'any' },
         rows: 24
@@ -597,6 +596,7 @@ describe('terminal mouse wheel multiplier', () => {
         attachCustomWheelEventHandler: (handler) => {
           handlers.push(handler)
         },
+        buffer: { active: { type: 'alternate' } },
         element: target,
         modes: { mouseTrackingMode: 'any' },
         rows: 24

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -423,7 +423,7 @@ describe('terminal mouse wheel multiplier', () => {
     expect(shouldMultiplyTerminalMouseWheel(dispatched[0]!, target)).toBe(false)
   })
 
-  it('blocks wheel-to-arrow synthesis for normal buffers without mouse reporting', () => {
+  it('blocks wheel-to-arrow synthesis for normal buffers without mouse reporting' /** Verifies that normal-buffer wheel input scrolls terminal history directly. */, () => {
     const handlers: ((event: WheelEvent) => boolean)[] = []
     const scrollLines = vi.fn()
     const terminal = {
@@ -442,7 +442,7 @@ describe('terminal mouse wheel multiplier', () => {
     expect(scrollLines).toHaveBeenCalledWith(-1)
   })
 
-  it('preserves wheel-to-arrow fallback for alternate buffers without mouse reporting', () => {
+  it('preserves wheel-to-arrow fallback for alternate buffers without mouse reporting' /** Verifies that alternate-buffer wheel input remains available to xterm's fallback. */, () => {
     const handlers: ((event: WheelEvent) => boolean)[] = []
     const terminal = {
       attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
@@ -21,7 +21,10 @@ const XTERM_MOUSE_REPORTING_CLASS = 'enable-mouse-events'
 const REPLAYED_WHEEL_EVENT_PROPERTY = '__orcaReplayedTerminalWheelEvent'
 const DOM_DELTA_LINE = 1
 
-type TerminalWheelTarget = Pick<Terminal, 'attachCustomWheelEventHandler' | 'element' | 'rows'> & {
+type TerminalWheelTarget = Pick<
+  Terminal,
+  'attachCustomWheelEventHandler' | 'element' | 'rows' | 'scrollLines'
+> & {
   buffer: { active: Pick<Terminal['buffer']['active'], 'type'> }
   modes: Pick<Terminal['modes'], 'mouseTrackingMode'>
 }
@@ -184,15 +187,27 @@ function queueTerminalTuiWheelReports(
   })
 }
 
+/** Routes wheel input to scrollback or mouse-reporting TUIs based on the active buffer. */
 export function attachTerminalMouseWheelMultiplier(
   terminal: TerminalWheelTarget,
   options: TerminalMouseWheelMultiplierOptions = {}
 ): void {
   const replayState = createTerminalTuiMouseWheelReplayState()
+  const scrollbackDistance = createTerminalTuiMouseWheelDistanceState()
   terminal.attachCustomWheelEventHandler((event) => {
     if (terminal.modes.mouseTrackingMode === 'none') {
-      // Why: xterm can misclassify an inline agent buffer and synthesize arrow keys.
-      return terminal.buffer.active.type === 'alternate'
+      if (terminal.buffer.active.type === 'alternate' || event.deltaY === 0 || event.shiftKey) {
+        return true
+      }
+
+      const lineCount = resolveTerminalTuiMouseWheelReportCount(event, 1, scrollbackDistance, {
+        cellHeight: resolveTerminalWheelCellHeight(terminal),
+        rows: terminal.rows
+      })
+      if (lineCount > 0) {
+        terminal.scrollLines(resolveTerminalWheelDirection(event) * lineCount)
+      }
+      return false
     }
 
     if (!shouldMultiplyTerminalMouseWheel(event, terminal.element)) {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
@@ -6,6 +6,7 @@ import {
   resolveTerminalWheelDirection
 } from './pane-terminal-tui-wheel-reports'
 import type { TerminalTuiMouseWheelDistanceState } from './pane-terminal-tui-wheel-reports'
+import { safeTerminalScrollCall } from './terminal-scroll-buffer-snapshot'
 
 export {
   TERMINAL_TUI_MOUSE_WHEEL_MULTIPLIER,
@@ -206,7 +207,9 @@ export function attachTerminalMouseWheelMultiplier(
         rows: terminal.rows
       })
       if (lineCount > 0) {
-        terminal.scrollLines(resolveTerminalWheelDirection(event) * lineCount)
+        safeTerminalScrollCall(
+          terminal.scrollLines.bind(terminal, resolveTerminalWheelDirection(event) * lineCount)
+        )
       }
       return false
     }

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
@@ -22,6 +22,7 @@ const REPLAYED_WHEEL_EVENT_PROPERTY = '__orcaReplayedTerminalWheelEvent'
 const DOM_DELTA_LINE = 1
 
 type TerminalWheelTarget = Pick<Terminal, 'attachCustomWheelEventHandler' | 'element' | 'rows'> & {
+  buffer: { active: Pick<Terminal['buffer']['active'], 'type'> }
   modes: Pick<Terminal['modes'], 'mouseTrackingMode'>
 }
 
@@ -189,10 +190,12 @@ export function attachTerminalMouseWheelMultiplier(
 ): void {
   const replayState = createTerminalTuiMouseWheelReplayState()
   terminal.attachCustomWheelEventHandler((event) => {
-    if (
-      terminal.modes.mouseTrackingMode === 'none' ||
-      !shouldMultiplyTerminalMouseWheel(event, terminal.element)
-    ) {
+    if (terminal.modes.mouseTrackingMode === 'none') {
+      // Why: xterm can misclassify an inline agent buffer and synthesize arrow keys.
+      return terminal.buffer.active.type === 'alternate'
+    }
+
+    if (!shouldMultiplyTerminalMouseWheel(event, terminal.element)) {
       return true
     }
 

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
@@ -107,6 +107,7 @@ function resolveTerminalWheelCellHeight(terminal: TerminalWheelTarget): number |
   return rect.height / terminal.rows
 }
 
+/** Returns whether a mouse-reporting wheel event should use Orca's multiplier. */
 export function shouldMultiplyTerminalMouseWheel(
   event: WheelEvent,
   terminalElement: HTMLElement | null | undefined


### PR DESCRIPTION
## ELI5

When Codex runs inline, rolling the mouse wheel should move through the transcript. Orca now scrolls the terminal buffer directly instead of letting xterm turn the wheel into Up/Down keys that replace the current prompt with input history.

## What Changed

- Route normal-buffer wheel input through Terminal.scrollLines when mouse reporting is disabled.
- Keep xterm's wheel-to-arrow fallback for alternate-buffer TUIs.
- Carry fractional trackpad distance across events using the existing terminal wheel-distance calculation.
- Add regression coverage that verifies normal-buffer wheel input calls scrollLines and alternate-buffer input keeps the existing fallback.

## Why

The behavior tracked in #8563 is not Windows-only. It also occurs in an Orca Codex agent pane on macOS: scrolling upward changes the prompt history instead of moving through the transcript. Explicit normal-buffer scrolling prevents prompt-navigation escape sequences while preserving alternate-screen TUI behavior.

## Linked Issue

Fixes #8563

## Visual Proof

N/A — there is no static visual change; this changes how wheel input is routed. Local Electron/PTY validation exercised real wheel scrolling in the normal buffer and preserved mouse reports in an alternate-buffer TUI.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified locally on macOS:

- Headful Electron/PTY: a real wheel-up moved and pinned the normal-buffer viewport while output continued — passed
- Headful Electron/PTY: notched wheel ticks produced immediate alternate-buffer TUI mouse reports — passed
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts` — 62 tests passed
- `pnpm tc:web` — passed
- WebGL teardown regression: disposed xterm render dimensions do not abort normal-buffer wheel handling — passed
- `pnpm run check:code-quality:changed` — passed with zero findings

## AI Disclosure

OpenAI Codex assisted with investigation, implementation, tests, and PR preparation.

## Author

- GitHub: @wonjun3991
- X: N/A (no public X handle listed)

## Review

AI-assisted self-review completed:

- Cross-platform: renderer-only xterm behavior is platform-neutral; macOS was manually verified, with no platform-specific shortcut or path logic.
- Local/SSH/remote: wheel routing stays in the client renderer and changes no execution-host or wire behavior.
- Agents/integrations: fixes the Codex inline-agent repro while preserving alternate-buffer mouse-reporting behavior used by fullscreen TUIs; no provider or integration API changes.
- Performance: reuses the bounded wheel-distance accumulator and adds at most one guarded scroll call per normal-buffer wheel event.
- UI quality: interaction-only change with no static visual delta; normal scrollback and alternate-buffer behavior were both exercised in Electron.
- Security: no IPC, network, storage, credential, or privilege-boundary changes.
- Review feedback: both Greptile P1 findings were addressed, including the xterm WebGL teardown dimensions-error window.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows docs/reference/agent-skill-sharing-upstream-boundary.md and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Cross-platform: renderer behavior is platform-neutral and covers the macOS report while retaining Windows/Linux behavior.
- SSH/remote: no execution-host or wire behavior changes; wheel routing remains renderer-local.
- Mobile: no mobile code changes.
- Compatibility/performance: alternate-buffer TUI fallback is preserved; normal scrolling reuses the existing bounded wheel-distance calculation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass (focused local checks pass; CI will cover the full suite and build)
