### PR TITLE
fix(mobile-sync): make the published group->tab invariant true for terminals

### DIFF
--- a/src/renderer/src/runtime/sync-runtime-graph-published-group-references.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-published-group-references.test.ts
@@ -631,4 +631,53 @@ describe('buildMobileSessionTabSnapshots published group references', () => {
     expect(danglingGroupRefs(snapshot)).toEqual([])
     expect(snapshot?.activeGroupId).toBeNull()
   })
+  // Why the groups-empty arm: with no host groups the projection returns the legacy nav order, which
+  // is built from every terminal tab rather than the filtered publishable set, so the per-tab guard
+  // in the order loop is the only thing holding a web mirror back on this path.
+  it('keeps a web-mirrored terminal out of the legacy nav order projection', () => {
+    const mirroredLeafId = '33333333-3333-4333-8333-333333333333'
+    const state = makeState({
+      groupsByWorktree: { 'wt-1': [] } as unknown as AppState['groupsByWorktree'],
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'web-terminal-term-host',
+            groupId: null,
+            contentType: 'terminal',
+            entityId: 'web-terminal-term-host',
+            title: 'Mirrored'
+          }
+        ]
+      } as unknown as AppState['unifiedTabsByWorktree'],
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'web-terminal-term-host',
+            worktreeId: 'wt-1',
+            ptyId: 'remote:pty-host',
+            title: 'Mirrored',
+            defaultTitle: 'Mirrored',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      } as unknown as AppState['tabsByWorktree'],
+      terminalLayoutsByTabId: {
+        'web-terminal-term-host': {
+          root: { type: 'leaf', leafId: mirroredLeafId },
+          activeLeafId: mirroredLeafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [mirroredLeafId]: 'remote:pty-host' }
+        }
+      } as unknown as AppState['terminalLayoutsByTabId']
+    })
+
+    const snapshot = buildMobileSessionTabSnapshots(state)[0]
+
+    // The persisted layout resolves a leaf, so without the guard this publishes a surface row.
+    expect(snapshot?.tabs).toEqual([])
+    expect(danglingTabRefs(snapshot)).toEqual([])
+  })
 })

--- a/src/renderer/src/runtime/sync-runtime-graph-published-group-references.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-published-group-references.test.ts
@@ -249,6 +249,185 @@ describe('buildMobileSessionTabSnapshots published group references', () => {
     expect(snapshot?.activeGroupId).toBe('group-right')
   })
 
+  // Why this arm and not just the mounted one above: a terminal occupies its group under the parent
+  // tab id but publishes one row per pane, so a terminal with no live pane and no persisted layout
+  // publishes none at all. `createTerminalTab` seeds exactly that — `emptyLayoutSnapshot()` — until
+  // TerminalPane mounts, so this is the ordinary new-tab window, not a corrupt fixture.
+  it('keeps a terminal that publishes no surface rows out of its published group', () => {
+    const state = makeState({
+      activeGroupIdByWorktree: { 'wt-1': 'group-1' },
+      groupsByWorktree: {
+        'wt-1': [
+          {
+            id: 'group-1',
+            activeTabId: 'term-unmounted',
+            tabOrder: ['term-unmounted', 'term-mounted'],
+            recentTabIds: ['term-unmounted', 'term-mounted']
+          }
+        ]
+      } as unknown as AppState['groupsByWorktree'],
+      layoutByWorktree: {
+        'wt-1': { type: 'leaf', groupId: 'group-1' }
+      } as unknown as AppState['layoutByWorktree'],
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'term-unmounted',
+            groupId: 'group-1',
+            contentType: 'terminal',
+            entityId: 'term-unmounted',
+            title: 'Terminal'
+          },
+          {
+            id: 'term-mounted',
+            groupId: 'group-1',
+            contentType: 'terminal',
+            entityId: 'term-mounted',
+            title: 'Terminal'
+          }
+        ]
+      } as unknown as AppState['unifiedTabsByWorktree'],
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'term-unmounted',
+            worktreeId: 'wt-1',
+            ptyId: null,
+            title: 'Terminal',
+            defaultTitle: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          },
+          {
+            id: 'term-mounted',
+            worktreeId: 'wt-1',
+            ptyId: 'pty-mounted',
+            title: 'Terminal',
+            defaultTitle: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 1,
+            createdAt: 2
+          }
+        ]
+      } as unknown as AppState['tabsByWorktree'],
+      terminalLayoutsByTabId: {
+        // What `createTerminalTab` writes before the pane mounts: a layout with no leaf at all.
+        'term-unmounted': { root: null, activeLeafId: null, expandedLeafId: null },
+        'term-mounted': {
+          root: { type: 'leaf', leafId: mountedLeafId },
+          activeLeafId: mountedLeafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [mountedLeafId]: 'pty-mounted' }
+        }
+      } as unknown as AppState['terminalLayoutsByTabId']
+    } as unknown as Parameters<typeof makeState>[0])
+
+    const snapshot = buildMobileSessionTabSnapshots(state)[0]
+
+    // The presence half: its neighbour publishes, so a projection that had stopped emitting terminal
+    // rows fails here rather than passing on emptiness.
+    expect(snapshot?.tabs.map((tab) => tab.id)).toEqual([`term-mounted::${mountedLeafId}`])
+    expect(snapshot?.tabGroups).toMatchObject([{ id: 'group-1', tabOrder: ['term-mounted'] }])
+    expect(danglingTabRefs(snapshot)).toEqual([])
+    expect(danglingGroupRefs(snapshot)).toEqual([])
+  })
+
+  // The same terminal alone in its group: holding it back empties the group, so the group and the
+  // pane the layout gave it have to go with it rather than leaving the client an empty split.
+  it('drops a group whose only terminal publishes no surface rows', () => {
+    const state = makeState({
+      activeGroupIdByWorktree: { 'wt-1': 'group-empty' },
+      groupsByWorktree: {
+        'wt-1': [
+          {
+            id: 'group-empty',
+            activeTabId: 'term-unmounted',
+            tabOrder: ['term-unmounted'],
+            recentTabIds: ['term-unmounted']
+          },
+          {
+            id: 'group-right',
+            activeTabId: 'term-mounted',
+            tabOrder: ['term-mounted'],
+            recentTabIds: ['term-mounted']
+          }
+        ]
+      } as unknown as AppState['groupsByWorktree'],
+      layoutByWorktree: {
+        'wt-1': {
+          type: 'split',
+          direction: 'horizontal',
+          first: { type: 'leaf', groupId: 'group-empty' },
+          second: { type: 'leaf', groupId: 'group-right' }
+        }
+      } as unknown as AppState['layoutByWorktree'],
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'term-unmounted',
+            groupId: 'group-empty',
+            contentType: 'terminal',
+            entityId: 'term-unmounted',
+            title: 'Terminal'
+          },
+          {
+            id: 'term-mounted',
+            groupId: 'group-right',
+            contentType: 'terminal',
+            entityId: 'term-mounted',
+            title: 'Terminal'
+          }
+        ]
+      } as unknown as AppState['unifiedTabsByWorktree'],
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'term-unmounted',
+            worktreeId: 'wt-1',
+            ptyId: null,
+            title: 'Terminal',
+            defaultTitle: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          },
+          {
+            id: 'term-mounted',
+            worktreeId: 'wt-1',
+            ptyId: 'pty-mounted',
+            title: 'Terminal',
+            defaultTitle: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 1,
+            createdAt: 2
+          }
+        ]
+      } as unknown as AppState['tabsByWorktree'],
+      terminalLayoutsByTabId: {
+        'term-unmounted': { root: null, activeLeafId: null, expandedLeafId: null },
+        'term-mounted': {
+          root: { type: 'leaf', leafId: mountedLeafId },
+          activeLeafId: mountedLeafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [mountedLeafId]: 'pty-mounted' }
+        }
+      } as unknown as AppState['terminalLayoutsByTabId']
+    } as unknown as Parameters<typeof makeState>[0])
+
+    const snapshot = buildMobileSessionTabSnapshots(state)[0]
+
+    expect(snapshot?.tabGroups?.map((group) => group.id)).toEqual(['group-right'])
+    expect(collectLayoutGroupIds(snapshot?.tabGroupLayout)).toEqual(['group-right'])
+    expect(snapshot?.activeGroupId).toBe('group-right')
+    expect(danglingTabRefs(snapshot)).toEqual([])
+    expect(danglingGroupRefs(snapshot)).toEqual([])
+  })
+
   // Why this arm: the mirrored-tab guard is applied twice — once choosing which terminals the group
   // projection may name, once emitting rows. Ablating the projection copy alone leaves the emit copy
   // holding the tab list, so without this the projection's copy is unpinned and its removal is

--- a/src/renderer/src/runtime/sync-runtime-graph-published-group-references.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-published-group-references.test.ts
@@ -4,7 +4,8 @@ import { makeState } from './sync-runtime-graph-test-harness'
 import {
   collectLayoutGroupIds,
   danglingGroupRefs,
-  danglingTabRefs
+  danglingTabRefs,
+  unplacedPublishedGroupIds
 } from './sync-runtime-graph-published-reference-invariants'
 import type { AppState } from '../store/types'
 
@@ -424,6 +425,7 @@ describe('buildMobileSessionTabSnapshots published group references', () => {
     expect(snapshot?.tabGroups?.map((group) => group.id)).toEqual(['group-right'])
     expect(collectLayoutGroupIds(snapshot?.tabGroupLayout)).toEqual(['group-right'])
     expect(snapshot?.activeGroupId).toBe('group-right')
+    expect(unplacedPublishedGroupIds(snapshot)).toEqual([])
     expect(danglingTabRefs(snapshot)).toEqual([])
     expect(danglingGroupRefs(snapshot)).toEqual([])
   })
@@ -512,6 +514,72 @@ describe('buildMobileSessionTabSnapshots published group references', () => {
     const snapshot = buildMobileSessionTabSnapshots(state)[0]
 
     expect(snapshot?.tabs.map((tab) => tab.id)).toEqual([`term-mounted::${mountedLeafId}`])
+    expect(danglingTabRefs(snapshot)).toEqual([])
+    expect(danglingGroupRefs(snapshot)).toEqual([])
+  })
+
+  // Why this arm: the fallback that rescues editor tabs the group projection missed takes their
+  // `groupId` on faith and mints a published group for it. A group id that is not one of the host's
+  // is one the host layout cannot place, so the tab would arrive in a group with no pane. Hydration
+  // (`adoptGrouplessTabs`) is what keeps that groupId live today, which is why this is a fixture and
+  // not a report — but the projection must not be the thing that invents the id either.
+  it('does not mint a published group for an editor tab whose group does not exist', () => {
+    const state = makeState({
+      activeGroupIdByWorktree: { 'wt-1': 'group-1' },
+      groupsByWorktree: {
+        'wt-1': [{ id: 'group-1', activeTabId: 'ed-1', tabOrder: ['ed-1'], recentTabIds: [] }]
+      } as unknown as AppState['groupsByWorktree'],
+      layoutByWorktree: {
+        'wt-1': { type: 'leaf', groupId: 'group-1' }
+      } as unknown as AppState['layoutByWorktree'],
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'ed-1',
+            groupId: 'group-1',
+            contentType: 'editor',
+            entityId: '/repo/a.ts',
+            title: 'a.ts'
+          },
+          {
+            id: 'ed-stranded',
+            groupId: 'group-never-published',
+            contentType: 'editor',
+            entityId: '/repo/b.ts',
+            title: 'b.ts'
+          }
+        ]
+      } as unknown as AppState['unifiedTabsByWorktree'],
+      openFiles: [
+        {
+          id: '/repo/a.ts',
+          filePath: '/repo/a.ts',
+          relativePath: 'a.ts',
+          worktreeId: 'wt-1',
+          language: 'typescript',
+          mode: 'edit',
+          isDirty: false
+        },
+        {
+          id: '/repo/b.ts',
+          filePath: '/repo/b.ts',
+          relativePath: 'b.ts',
+          worktreeId: 'wt-1',
+          language: 'typescript',
+          mode: 'edit',
+          isDirty: false
+        }
+      ]
+    } as unknown as Parameters<typeof makeState>[0])
+
+    const snapshot = buildMobileSessionTabSnapshots(state)[0]
+
+    // The tab still publishes — the repair is where it lands, not whether it survives.
+    expect(snapshot?.tabs.map((tab) => tab.id)).toEqual(['ed-1', 'ed-stranded'])
+    expect(snapshot?.tabGroups).toMatchObject([
+      { id: 'group-1', tabOrder: ['ed-1', 'ed-stranded'] }
+    ])
+    expect(unplacedPublishedGroupIds(snapshot)).toEqual([])
     expect(danglingTabRefs(snapshot)).toEqual([])
     expect(danglingGroupRefs(snapshot)).toEqual([])
   })

--- a/src/renderer/src/runtime/sync-runtime-graph-published-group-references.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-published-group-references.test.ts
@@ -1,40 +1,21 @@
 import { describe, expect, it } from 'vitest'
 import { buildMobileSessionTabSnapshots } from './sync-runtime-graph'
 import { makeState } from './sync-runtime-graph-test-harness'
-import type { RuntimeMobileSessionTabsSnapshot } from '../../../shared/runtime-session-contracts'
+import {
+  collectLayoutGroupIds,
+  danglingGroupRefs,
+  danglingTabRefs
+} from './sync-runtime-graph-published-reference-invariants'
 import type { AppState } from '../store/types'
 
 // The invariant these share: the mobile snapshot may not publish an id that names something it did
 // not publish. Held-back tabs already drag their group out of `tabGroups`; these pin that the
 // snapshot's own `activeGroupId` and `tabGroupLayout` follow the group out rather than pointing at
-// a group the phone was never sent.
-
-function collectLayoutGroupIds(node: unknown, into: string[] = []): string[] {
-  if (!node || typeof node !== 'object') {
-    return into
-  }
-  const candidate = node as { type?: string; groupId?: string; first?: unknown; second?: unknown }
-  if (candidate.type === 'leaf' && candidate.groupId) {
-    into.push(candidate.groupId)
-    return into
-  }
-  collectLayoutGroupIds(candidate.first, into)
-  collectLayoutGroupIds(candidate.second, into)
-  return into
-}
-
-/** Published ids that name a tab group the snapshot never published — empty is the invariant. */
-function danglingGroupRefs(
-  snapshot: RuntimeMobileSessionTabsSnapshot | undefined
-): (string | null)[] {
-  const publishedGroupIds = new Set((snapshot?.tabGroups ?? []).map((group) => group.id))
-  return [
-    snapshot?.activeGroupId ?? null,
-    ...collectLayoutGroupIds(snapshot?.tabGroupLayout)
-  ].filter((groupId) => groupId !== null && !publishedGroupIds.has(groupId))
-}
+// a group the phone was never sent, and that every tab a group names is one the client can resolve.
 
 describe('buildMobileSessionTabSnapshots published group references', () => {
+  const mountedLeafId = '22222222-2222-4222-8222-222222222222'
+
   // Why groups get their own fixture: 'omits a browser tab located by a workspace document from
   // mobile snapshots' (in sync-runtime-graph-editor-diff-tabs.test.ts) drives the same document
   // through the legacy nav order, where the per-tab guard is the only thing holding it back. With
@@ -43,6 +24,7 @@ describe('buildMobileSessionTabSnapshots published group references', () => {
   it('keeps a workspace document out of published tab groups as well as the tab list', () => {
     const docWorkspaceId = 'browser-doc'
     const urlWorkspaceId = 'browser-url'
+    const rightLeafId = '11111111-1111-4111-8111-111111111111'
     const state = makeState({
       // The document's group is the active one: if it survived anywhere, this is where it shows.
       activeGroupIdByWorktree: { 'wt-1': 'group-left' },
@@ -57,8 +39,8 @@ describe('buildMobileSessionTabSnapshots published group references', () => {
           {
             id: 'group-right',
             activeTabId: 'unified-url',
-            tabOrder: ['unified-url'],
-            recentTabIds: ['unified-url']
+            tabOrder: ['unified-url', 'term-right'],
+            recentTabIds: ['unified-url', 'term-right']
           }
         ]
       } as unknown as AppState['groupsByWorktree'],
@@ -85,9 +67,41 @@ describe('buildMobileSessionTabSnapshots published group references', () => {
             contentType: 'browser',
             entityId: urlWorkspaceId,
             title: 'Example'
+          },
+          // A terminal's unified tab is self-backed (`id === entityId === the terminal tab id`),
+          // which is what puts the parent id — not a surface id — into the group's tabOrder.
+          {
+            id: 'term-right',
+            groupId: 'group-right',
+            contentType: 'terminal',
+            entityId: 'term-right',
+            title: 'Terminal'
           }
         ]
       } as unknown as AppState['unifiedTabsByWorktree'],
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'term-right',
+            worktreeId: 'wt-1',
+            ptyId: 'pty-right',
+            title: 'Terminal',
+            defaultTitle: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      } as unknown as AppState['tabsByWorktree'],
+      terminalLayoutsByTabId: {
+        'term-right': {
+          root: { type: 'leaf', leafId: rightLeafId },
+          activeLeafId: rightLeafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [rightLeafId]: 'pty-right' }
+        }
+      } as unknown as AppState['terminalLayoutsByTabId'],
       browserTabsByWorktree: {
         'wt-1': [
           {
@@ -131,17 +145,17 @@ describe('buildMobileSessionTabSnapshots published group references', () => {
 
     // The presence half: the grouped URL tab beside it does publish, so a projection that had
     // stopped emitting browser tabs — or groups — fails here rather than passing on emptiness.
-    expect(snapshot?.tabs).toMatchObject([{ type: 'browser', browserWorkspaceId: urlWorkspaceId }])
-    expect(snapshot?.tabGroups).toMatchObject([{ id: 'group-right', tabOrder: ['unified-url'] }])
-    // Mechanical rather than by name: nothing a group points at may be missing from the tab list,
-    // whatever the reason it was held back.
-    const publishedTabIds = new Set(snapshot?.tabs.map((tab) => tab.id) ?? [])
-    for (const group of snapshot?.tabGroups ?? []) {
-      expect(group.tabOrder.filter((tabId) => !publishedTabIds.has(tabId))).toEqual([])
-      expect((group.recentTabIds ?? []).filter((tabId) => !publishedTabIds.has(tabId))).toEqual([])
-      expect(group.activeTabId === null || publishedTabIds.has(group.activeTabId)).toBe(true)
-    }
-    expect(snapshot?.activeTabId === null || publishedTabIds.has(snapshot.activeTabId)).toBe(true)
+    expect(snapshot?.tabs).toMatchObject([
+      { type: 'browser', browserWorkspaceId: urlWorkspaceId },
+      { type: 'terminal', id: `term-right::${rightLeafId}`, parentTabId: 'term-right' }
+    ])
+    expect(snapshot?.tabGroups).toMatchObject([
+      { id: 'group-right', tabOrder: ['unified-url', 'term-right'] }
+    ])
+    // Mechanical rather than by name: nothing a group points at may be unresolvable in the tab list,
+    // whatever the reason it was held back. The terminal is why this resolves through `parentTabId`
+    // rather than by id — 'term-right' is published as 'term-right::<leafId>'.
+    expect(danglingTabRefs(snapshot)).toEqual([])
     // The same claim one level up: the snapshot's own active-group pointer may not name a group the
     // phone was never sent. 'group-left' is the held-back one, so a pass-through of the desktop's
     // active group fails here.
@@ -233,6 +247,94 @@ describe('buildMobileSessionTabSnapshots published group references', () => {
     expect(danglingGroupRefs(snapshot)).toEqual([])
     // The display choice, by name: focus lands on the group the phone actually has.
     expect(snapshot?.activeGroupId).toBe('group-right')
+  })
+
+  // Why this arm: the mirrored-tab guard is applied twice — once choosing which terminals the group
+  // projection may name, once emitting rows. Ablating the projection copy alone leaves the emit copy
+  // holding the tab list, so without this the projection's copy is unpinned and its removal is
+  // invisible: the group would name a tab the client is never sent a row for.
+  it('keeps a web-only mirrored terminal out of its published group', () => {
+    const mirroredLeafId = '33333333-3333-4333-8333-333333333333'
+    const state = makeState({
+      activeGroupIdByWorktree: { 'wt-1': 'group-1' },
+      groupsByWorktree: {
+        'wt-1': [
+          {
+            id: 'group-1',
+            activeTabId: 'web-terminal-host%3A%3Aleaf',
+            tabOrder: ['web-terminal-host%3A%3Aleaf', 'term-mounted'],
+            recentTabIds: ['web-terminal-host%3A%3Aleaf', 'term-mounted']
+          }
+        ]
+      } as unknown as AppState['groupsByWorktree'],
+      layoutByWorktree: {
+        'wt-1': { type: 'leaf', groupId: 'group-1' }
+      } as unknown as AppState['layoutByWorktree'],
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'web-terminal-host%3A%3Aleaf',
+            groupId: 'group-1',
+            contentType: 'terminal',
+            entityId: 'web-terminal-host%3A%3Aleaf',
+            title: 'Mirrored'
+          },
+          {
+            id: 'term-mounted',
+            groupId: 'group-1',
+            contentType: 'terminal',
+            entityId: 'term-mounted',
+            title: 'Terminal'
+          }
+        ]
+      } as unknown as AppState['unifiedTabsByWorktree'],
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'web-terminal-host%3A%3Aleaf',
+            worktreeId: 'wt-1',
+            ptyId: null,
+            title: 'Mirrored',
+            defaultTitle: 'Mirrored',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          },
+          {
+            id: 'term-mounted',
+            worktreeId: 'wt-1',
+            ptyId: 'pty-mounted',
+            title: 'Terminal',
+            defaultTitle: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 1,
+            createdAt: 2
+          }
+        ]
+      } as unknown as AppState['tabsByWorktree'],
+      terminalLayoutsByTabId: {
+        // A persisted leaf, so it is the mirror guard holding this back and not the empty-layout one.
+        'web-terminal-host%3A%3Aleaf': {
+          root: { type: 'leaf', leafId: mirroredLeafId },
+          activeLeafId: mirroredLeafId,
+          expandedLeafId: null
+        },
+        'term-mounted': {
+          root: { type: 'leaf', leafId: mountedLeafId },
+          activeLeafId: mountedLeafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [mountedLeafId]: 'pty-mounted' }
+        }
+      } as unknown as AppState['terminalLayoutsByTabId']
+    } as unknown as Parameters<typeof makeState>[0])
+
+    const snapshot = buildMobileSessionTabSnapshots(state)[0]
+
+    expect(snapshot?.tabs.map((tab) => tab.id)).toEqual([`term-mounted::${mountedLeafId}`])
+    expect(danglingTabRefs(snapshot)).toEqual([])
+    expect(danglingGroupRefs(snapshot)).toEqual([])
   })
 
   it('does not recover unsupported combined diff tabs through split-group fallback', () => {

--- a/src/renderer/src/runtime/sync-runtime-graph-published-reference-invariants.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-published-reference-invariants.ts
@@ -50,6 +50,25 @@ export function danglingGroupRefs(
   ].filter((groupId) => groupId !== null && !publishedGroupIds.has(groupId))
 }
 
+/**
+ * Published groups the published layout gives no pane — empty is the invariant.
+ *
+ * Not the mirror of `danglingGroupRefs`: a group is content and the layout is placement, so this
+ * only holds because the host layout spans every group (`layoutSpanningGroups` at hydration). It is
+ * here to catch the publisher minting a group id of its own that no layout could ever place.
+ */
+export function unplacedPublishedGroupIds(
+  snapshot: RuntimeMobileSessionTabsSnapshot | undefined
+): string[] {
+  if (!snapshot?.tabGroupLayout) {
+    return []
+  }
+  const placed = new Set(collectLayoutGroupIds(snapshot.tabGroupLayout))
+  return (snapshot.tabGroups ?? [])
+    .map((group) => group.id)
+    .filter((groupId) => !placed.has(groupId))
+}
+
 /** Published ids that name a tab the client cannot resolve in `tabs` — empty is the invariant. */
 export function danglingTabRefs(
   snapshot: RuntimeMobileSessionTabsSnapshot | undefined

--- a/src/renderer/src/runtime/sync-runtime-graph-published-reference-invariants.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-published-reference-invariants.ts
@@ -1,0 +1,63 @@
+import type { RuntimeMobileSessionTabsSnapshot } from '../../../shared/runtime-session-contracts'
+
+/**
+ * What "published" means for every id the mobile snapshot cross-references.
+ *
+ * Group ids resolve by equality. Tab ids do not: a terminal occupies its group under the parent
+ * tab id while publishing one row per pane, so `tabGroups[].tabOrder` names `term-a` and `tabs[]`
+ * carries `term-a::<leafId>`. Both are the published identity of the same tab — the client's
+ * `buildHostToLocalTabIdMap` keys terminals by surface id *and* `parentTabId` for exactly that
+ * reason — so the rule is that a group may only name a tab the client can resolve, not one whose
+ * id appears verbatim in `tabs`.
+ */
+
+export function collectLayoutGroupIds(node: unknown, into: string[] = []): string[] {
+  if (!node || typeof node !== 'object') {
+    return into
+  }
+  const candidate = node as { type?: string; groupId?: string; first?: unknown; second?: unknown }
+  if (candidate.type === 'leaf' && candidate.groupId) {
+    into.push(candidate.groupId)
+    return into
+  }
+  collectLayoutGroupIds(candidate.first, into)
+  collectLayoutGroupIds(candidate.second, into)
+  return into
+}
+
+/** Every tab id the client can resolve from this snapshot: row ids, plus terminal parent tab ids. */
+function resolvablePublishedTabIds(
+  snapshot: RuntimeMobileSessionTabsSnapshot | undefined
+): Set<string> {
+  const resolvable = new Set<string>()
+  for (const tab of snapshot?.tabs ?? []) {
+    resolvable.add(tab.id)
+    if (tab.type === 'terminal') {
+      resolvable.add(tab.parentTabId)
+    }
+  }
+  return resolvable
+}
+
+/** Published ids that name a tab group the snapshot never published — empty is the invariant. */
+export function danglingGroupRefs(
+  snapshot: RuntimeMobileSessionTabsSnapshot | undefined
+): (string | null)[] {
+  const publishedGroupIds = new Set((snapshot?.tabGroups ?? []).map((group) => group.id))
+  return [
+    snapshot?.activeGroupId ?? null,
+    ...collectLayoutGroupIds(snapshot?.tabGroupLayout)
+  ].filter((groupId) => groupId !== null && !publishedGroupIds.has(groupId))
+}
+
+/** Published ids that name a tab the client cannot resolve in `tabs` — empty is the invariant. */
+export function danglingTabRefs(
+  snapshot: RuntimeMobileSessionTabsSnapshot | undefined
+): (string | null)[] {
+  const resolvable = resolvablePublishedTabIds(snapshot)
+  const referenced: (string | null)[] = [snapshot?.activeTabId ?? null]
+  for (const group of snapshot?.tabGroups ?? []) {
+    referenced.push(...group.tabOrder, ...(group.recentTabIds ?? []), group.activeTabId)
+  }
+  return referenced.filter((tabId) => tabId !== null && !resolvable.has(tabId))
+}

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -1305,10 +1305,7 @@ export function buildMobileSessionTabSnapshots(
       return file ? isMobilePublishableOpenFile(file) : false
     })
     const publishableTerminalIds = [...terminalTabByIdForWorktree.values()]
-      .filter(
-        (terminal) =>
-          !isWebOnlyMirroredTerminalTab(terminal, inputs.terminalLayoutByTabId.get(terminal.id))
-      )
+      .filter((terminal) => isMobilePublishableTerminalTab(inputs, terminal))
       .map((terminal) => terminal.id)
     const groupProjection = buildMobileSessionGroupProjection(inputs, {
       terminalIds: publishableTerminalIds,
@@ -1915,6 +1912,25 @@ function buildMobileLaunchDraftsByPaneKey(args: {
     draftsByPaneKey.set(makePaneKey(terminal.id, ownerLeafId), draft)
   }
   return draftsByPaneKey ?? EMPTY_NARROWED_BY_KEY
+}
+
+/**
+ * Why a second guard beside the mirrored-tab one: a terminal occupies its group under the parent tab
+ * id but publishes one row per pane, so one with no live pane and no persisted layout publishes no
+ * rows at all. Leaving it in the group would name a tab the client has no row to resolve it to.
+ */
+function isMobilePublishableTerminalTab(
+  inputs: MobileSessionWorktreeInputs,
+  terminal: NonNullable<AppState['tabsByWorktree'][string]>[number]
+): boolean {
+  const savedLayout = inputs.terminalLayoutByTabId.get(terminal.id)
+  if (isWebOnlyMirroredTerminalTab(terminal, savedLayout)) {
+    return false
+  }
+  return (
+    getRuntimeLeafIdsForTerminal(inputs.mountedSurfaceCaptureByTabId.get(terminal.id), savedLayout)
+      .length > 0
+  )
 }
 
 function buildMobileTerminalSurfaceTabs(

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -1521,8 +1521,14 @@ function appendFallbackEditorTabsToGroups(
   const fallbackTabIdSet = new Set(fallbackTabs.map((tab) => tab.tabId))
 
   for (const fallback of fallbackTabs) {
+    // Why the membership test on the tab's own group: a groupId naming no host group is one the host
+    // layout can never place, so minting a published group for it lands the tab in a pane-less group.
+    const strandedGroupId =
+      fallback.groupId !== null &&
+      !groupIndexById.has(fallback.groupId) &&
+      !sourceGroupsById.has(fallback.groupId)
     const targetGroupId =
-      fallback.groupId ??
+      (strandedGroupId ? null : fallback.groupId) ??
       (activeGroupId && (groupIndexById.has(activeGroupId) || sourceGroupsById.has(activeGroupId))
         ? activeGroupId
         : firstTargetGroupId)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​438 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​40 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​398 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​109 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​104 |

<!-- /orca-pr-loc -->

## ELI5

Your phone mirrors the desktop's tabs. Tabs live in groups, and the mirror publishes both:
the groups, and the tabs themselves. A group is allowed to say "I contain tab X" only if
tab X actually got published — otherwise the phone is holding a pointer to nothing.

Two ways that was broken. First, the *check* for it was written for editor and browser tabs
and did not know that terminals use two different ids on purpose, so adding a terminal to the
fixture made the check fail on perfectly correct data. Second, a terminal that has never been
opened on screen publishes no rows at all, yet still sat inside its group — a real dangling
pointer.

This fixes the check to match the rule terminals actually follow, holds row-less terminals
out of the groups, and stops one code path from inventing a group id the host never had.

## User-facing before / after

**Nothing changes on the phone, and that is deliberate.** The RN app has no read site for
`tabGroups`, `tabGroupLayout` or `activeGroupId` — they appear under `mobile/` only in mock
fixtures — and the two real consumers (`web-session-tabs-sync.ts` and
`local-structured-session-tabs-sync.ts`) already dropped or filtered out the bad references
locally. So:

- **Before:** the host published a group naming a terminal it had published no rows for. Every
  current client repaired that itself, so nobody saw a broken tab.
- **After:** the host does not publish it. Same screen, one less thing each client has to
  repair, and a published snapshot that now satisfies its own invariant — which is what the
  next client to read these fields will rely on.

Stacked on #17100 (`brennanb2025/sta-5724-published-active-group-id`) — that PR introduces the invariant file this one corrects, so basing on `main` would have meant re-creating it. **Base this on #17100, not `main`.**

While fixing STA-5724, an audit of the mobile session snapshot for the same shape — a published reference to something not published — reported three more instances. All three reproduce; one turns out to be a defect in the *test*, one is a real dangling reference, and one is unreachable and guarded anyway.

## 1. The group→tab invariant was pinned to a rule the system never had

The assertion read "no group may name a tab absent from `tabs`". Add an ordinary mounted terminal to the fixture and it fails:

```
AssertionError: expected [ 'term-right' ] to deeply equal []
```

Terminals use two id namespaces on purpose. A terminal occupies its group under the **parent tab id** (`tabGroups[].tabOrder: ['term-a']`) but publishes one row **per pane** (`tabs[].id: 'term-a::<leafId>'`, each carrying `parentTabId`). The old rule held only because both fixtures were browser/editor-only.

**The true rule is resolvability, not equality:** a group may only name a tab id the client can resolve in `tabs` — as a row id, or as a terminal row's `parentTabId`. That is not a guess: the client's `buildHostToLocalTabIdMap` (`web-session-tabs-sync.ts:2115`) keys terminals by surface id **and** `parentTabId` for exactly this reason.

Commit 1 moves the invariants into `sync-runtime-graph-published-reference-invariants.ts`, states the rule there, and puts a terminal in the fixture so the case is covered instead of avoided.

It also pins a guard that was silently unpinned: the web-only-mirrored-terminal check runs **twice** — once choosing which terminals the group projection may name, once emitting rows — and deleting the projection copy left the entire `src/renderer/src/runtime/` suite green (measured on the pre-commit-1 tree `f4a86821db`: 1146 tests across 151 files), because no fixture had a mirrored terminal inside a group.

## 2. An unmounted terminal occupies a group while publishing zero rows — real

`getRuntimeLeafIdsForTerminal` returns `[]` with no live pane and no persisted layout, and that is exactly what `createTerminalTab` seeds: `emptyLayoutSnapshot()` (`root: null`) until `TerminalPane` mounts. Observed snapshot:

```
tabs:          []
tabGroups:     [{ id: 'group-1', tabOrder: ['term-a'], activeTabId: 'term-a' }]
tabGroupLayout: { type: 'leaf', groupId: 'group-1' }
activeGroupId: 'group-1'
```

Off the active worktree nothing mounts, so this is not only the new-tab window — it lasts until the user goes there.

Commit 2 holds such a terminal out of the group projection. Existing machinery does the rest: an emptied group leaves `tabGroups`, its layout leaf is pruned with it, `resolvePublishedActiveGroupId` (from #17100) moves the pointer.

## 3. `tabGroups` holding a group `tabGroupLayout` never places — refuted as a live bug, guarded where it could be minted

Reproducible, but only from a host state where `layoutByWorktree` does not span `groupsByWorktree`, and I could not reach that:

- hydration repairs it — `layoutSpanningGroups` + `adoptGrouplessTabs` (`tabs-hydration.ts:204`, `tab-group-reference-repair.ts`);
- `createEmptySplitGroup` places the new group; `closeEmptyGroup` deletes the layout entry when its last leaf goes;
- given a spanning host layout the projection is self-consistent, because `tabGroupLayout` is that layout pruned to the published groups.

And if it did occur it would be **faithful mirroring**, not an invented reference: the desktop renders panes from the layout too (`getEffectiveLayoutForWorktree`), so an unplaced group is invisible on both sides. Repairing it in the publisher would make the client show something the desktop does not.

There is one line that can mint such a group **in the publisher itself**: the fallback rescuing editor tabs the projection missed takes each tab's `groupId` on faith, so a `groupId` naming no host group gets a published `tabGroups` entry that pruning can never place. Commit 3 resolves such a tab into a group that did publish. Labelled as hardening for a latent path, not a live fix.

## What an older client does

Nothing changes for it, by construction.

| Field | Old client, before | Old client, after |
| --- | --- | --- |
| group `tabOrder` naming a row-less terminal | already dropped — `hostToLocalTabId` has no key for it (`buildMirroredHostGroups`, `web-session-tabs-sync.ts:2244`) | host no longer sends it |
| group left empty by that drop | already skipped (`if (tabOrder.length === 0) continue`) | host no longer sends the group |
| whole worktree emptied by it | `nextGroups` returns `null` before groups are read (`nextUnifiedTabs.length === 0`) | unchanged |
| `activeGroupId` / `tabGroupLayout` for a dropped group | already re-derived — `nextGroups[0]` fallback, `pruneTabGroupLayout` | host sends the value the client computed |

No wire-format change; only what the host publishes. The RN app has **no read site** for `tabGroups`, `tabGroupLayout` or `activeGroupId` — they appear under `mobile/` only in mock fixtures. Real consumers are `web-session-tabs-sync.ts` and `local-structured-session-tabs-sync.ts`, and the latter filters group membership to `agent-session` ids, so terminals never reach it. **Nothing here is user-visible on the phone**; it is a correctness fix at the publisher.

## Failing-first

| Claim | Change | Before | After |
| --- | --- | --- | --- |
| terminals resolve by `parentTabId` | terminal added to the browser-doc fixture, old rule kept | `expected [ 'term-right' ] to deeply equal []` | green |
| row-less terminal must leave its group | new arm | `expected [{id:'group-1', …}] to match object [{id:'group-1', tabOrder:['term-mounted']}]` | green |
| a group emptied by it must leave with its pane | new arm | `expected [ 'group-empty', 'group-right' ] to deeply equal [ 'group-right' ]` | green |
| no minted group id | new arm | `expected […, { id: 'group-never-published' }] to match object […]` | green |

## Per-gate ablation

Measured at head `81ae7a5465` against `sync-runtime-graph-published-group-references.test.ts`
(baseline **7/7 green**), except the one row that is explicitly measured on the pre-commit-1
tree (`f4a86821db`) and says so. Each gate deleted on its own, everything else intact.

| Ablation | Result |
| --- | --- |
| leaf-count half of `isMobilePublishableTerminalTab` | **red** — 2 arms |
| leaf-count half, *and* the by-name assertions removed so only `danglingTabRefs` is left | **red** — `expected [ 'term-unmounted', …(2) ] to deeply equal []` |
| mirrored-tab half of the same predicate, **before** commit 1's new arm | **green across 1146 tests / 151 files** in `src/renderer/src/runtime/` — the second copy in the emit loop was covering it |
| mirrored-tab half, **after** | **red** — `expected [ 'web-terminal-host%3A%3Aleaf', …(2) ] to deeply equal []` |
| `parentTabId` acceptance in the invariant | **red** — 4 arms |
| stranded-group guard | **red** |
| stranded-group guard, with only `unplacedPublishedGroupIds` asserted | **red** — `expected [ 'group-never-published' ] to deeply equal []` |
| `danglingTabRefs` body emptied, on the current fixtures | **green** — stated plainly: a "must be empty" assertion cannot be falsified by removing its inputs. It is falsified by the production ablations above, which is the pin that matters. |

## Gates

`pnpm tc` clean. `oxlint` clean, no suppressions added (`sync-runtime-graph.ts` carries a pre-existing `max-lines` disable from before this branch; none added, none needed). `node config/scripts/check-changed-code-quality.mjs` — 0 new findings, all three lanes. `git diff --check` clean. `npx oxfmt --check` on the three changed files clean. Tests: `src/renderer/src/runtime`, `src/main/runtime`, `src/renderer/src/store`, `src/renderer/src/lib`, `src/renderer/src/web`, `src/renderer/src/hooks`, `src/shared`, `src/renderer/src/components/terminal-pane` — 12,020 + 8,889 + 3,936 passing, 0 failures. Each of the three commits verified green on its own.

