### PR TITLE
Fix authorization for coalesced worktree scans

### DIFF
--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -19,6 +19,7 @@ import {
 import { isDescendantOrEqual, validateGitRelativeFilePath } from './filesystem-path-containment'
 import {
   invalidateAuthorizedRootsCache,
+  registerWorktreeRootsForRepo,
   rebuildAuthorizedRootsCache,
   resolveRegisteredWorktreePath
 } from './registered-worktree-roots-cache'
@@ -141,6 +142,57 @@ describe('filesystem auth worktree roots', () => {
 
     expect(listRepoWorktrees).toHaveBeenCalledTimes(repos.length)
     expect(maxActive).toBeLessThanOrEqual(8)
+  })
+
+  it('preserves roots registered while an older full rebuild is pending', async () => {
+    let resolveScan: (worktrees: GitWorktreeInfo[]) => void = () => {}
+    vi.mocked(listRepoWorktrees).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveScan = resolve
+        })
+    )
+    const store = makeStore()
+    const pendingRebuild = rebuildAuthorizedRootsCache(store)
+    await vi.waitFor(() => expect(listRepoWorktrees).toHaveBeenCalledTimes(1))
+
+    registerWorktreeRootsForRepo(store, repo.id, [repo.path, '/linked/new-worktree'])
+    resolveScan([])
+    await pendingRebuild
+
+    await expect(resolveRegisteredWorktreePath('/linked/new-worktree', store)).resolves.toBe(
+      resolve('/linked/new-worktree')
+    )
+  })
+
+  it('does not restore roots from a rebuild invalidated while pending', async () => {
+    let resolveScan: (worktrees: GitWorktreeInfo[]) => void = () => {}
+    vi.mocked(listRepoWorktrees).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveScan = resolve
+        })
+    )
+    const store = makeStore()
+    const pendingRebuild = rebuildAuthorizedRootsCache(store)
+    await vi.waitFor(() => expect(listRepoWorktrees).toHaveBeenCalledTimes(1))
+
+    invalidateAuthorizedRootsCache()
+    resolveScan([
+      {
+        path: '/linked/stale-worktree',
+        head: '',
+        branch: 'refs/heads/stale',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    await pendingRebuild
+
+    vi.mocked(listRepoWorktrees).mockResolvedValue([])
+    await expect(resolveRegisteredWorktreePath('/linked/stale-worktree', store)).rejects.toThrow(
+      'Access denied: unknown repository or worktree path'
+    )
   })
 })
 

--- a/src/main/ipc/registered-worktree-roots-cache.ts
+++ b/src/main/ipc/registered-worktree-roots-cache.ts
@@ -9,9 +9,11 @@ const registeredWorktreeRootsByRepo = new Map<string, Set<string>>()
 const registeredWorktreeRootRepoIds = new Set<string>()
 let registeredWorktreeRootsDirty = true
 let registeredWorktreeRootsRefresh: Promise<void> | null = null
+let registeredWorktreeRootsRevision = 0
 const AUTHORIZED_ROOTS_REBUILD_CONCURRENCY = 8
 
 export function invalidateAuthorizedRootsCache(): void {
+  registeredWorktreeRootsRevision += 1
   registeredWorktreeRootsDirty = true
   // Why: dirty roots can't be trusted for auth short-circuits; fresh worktrees:list seeds safe per-repo roots before a full rebuild.
   registeredWorktreeRoots.clear()
@@ -20,6 +22,7 @@ export function invalidateAuthorizedRootsCache(): void {
 }
 
 export async function rebuildAuthorizedRootsCache(store: Store): Promise<void> {
+  const revisionAtStart = registeredWorktreeRootsRevision
   // Why: bounded parallelism keeps the Windows speedup without one git process per repo.
   // Why no realpath here: canonicalizing every root on invalidation would trigger macOS TCC prompts; handlers still canonicalize the target before any operation.
   const repos = getLocalRepos(store)
@@ -42,6 +45,11 @@ export async function rebuildAuthorizedRootsCache(store: Store): Promise<void> {
     }
   )
 
+  // Why: a newer targeted registration or invalidation must win over this older full scan.
+  if (registeredWorktreeRootsRevision !== revisionAtStart) {
+    return
+  }
+
   registeredWorktreeRoots.clear()
   registeredWorktreeRootsByRepo.clear()
   registeredWorktreeRootRepoIds.clear()
@@ -54,6 +62,7 @@ export async function rebuildAuthorizedRootsCache(store: Store): Promise<void> {
     registeredWorktreeRootsByRepo.set(repoId, normalizedRoots)
     registeredWorktreeRootRepoIds.add(repoId)
   }
+  registeredWorktreeRootsRevision += 1
   registeredWorktreeRootsDirty = false
 }
 
@@ -82,6 +91,7 @@ export function registerWorktreeRootsForRepo(
   repoId: string,
   worktreeRoots: string[]
 ): void {
+  registeredWorktreeRootsRevision += 1
   const localRepoIds = new Set(getLocalRepos(store).map((repo) => repo.id))
   for (const registeredRepoId of registeredWorktreeRootsByRepo.keys()) {
     if (!localRepoIds.has(registeredRepoId)) {

--- a/src/main/ipc/worktrees-detected-scan-cache.test.ts
+++ b/src/main/ipc/worktrees-detected-scan-cache.test.ts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolve } from 'node:path'
+import type { Repo } from '../../shared/repo-types'
 import type { GitWorktreeInfo, Worktree } from '../../shared/worktree/types'
 import { notifyWorktreesChanged } from './worktree-remote'
-import { resolveRegisteredWorktreePath } from './registered-worktree-roots-cache'
+import {
+  isRegisteredWorktreePath,
+  resolveRegisteredWorktreePath
+} from './registered-worktree-roots-cache'
+import { listDetectedWorktreesForCapturedRepo } from './worktrees/listing/detected-provider-listing'
 import { __getDetectedWorktreeScanCacheStatsForTests } from './worktrees/listing/detected-worktree-scan-cache'
 import { setPlatform, listWorktreesMock } from './worktrees-test-module-mocks'
 import { handlers, mainWindow, setupWorktreeHandlers, store } from './worktrees-test-harness'
@@ -182,6 +187,48 @@ describe('registerWorktreeHandlers', () => {
       handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
     ])
 
+    expect(listWorktreesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('registers roots when the current caller joins a scan whose starter becomes stale', async () => {
+    let resolveScan: (worktrees: GitWorktreeInfo[]) => void = () => {}
+    listWorktreesMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveScan = resolve as (worktrees: GitWorktreeInfo[]) => void
+        })
+    )
+    const repo = (store.getRepos() as Repo[])[0]
+    let starterIsCurrent = true
+
+    const staleList = listDetectedWorktreesForCapturedRepo(
+      store as never,
+      repo,
+      () => starterIsCurrent
+    )
+    await Promise.resolve()
+    const currentList = listDetectedWorktreesForCapturedRepo(store as never, repo, () => true)
+    starterIsCurrent = false
+    resolveScan([
+      {
+        path: '/workspace/repo',
+        head: 'main-head',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      },
+      {
+        path: '/workspace/new-worktree',
+        head: 'feature-head',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await expect(staleList).resolves.toBeNull()
+    await expect(currentList).resolves.toMatchObject({ authoritative: true })
+    expect(isRegisteredWorktreePath(resolve('/workspace/new-worktree'))).toBe(true)
     expect(listWorktreesMock).toHaveBeenCalledTimes(1)
   })
 

--- a/src/main/ipc/worktrees-detected-scan-cache.test.ts
+++ b/src/main/ipc/worktrees-detected-scan-cache.test.ts
@@ -4,6 +4,7 @@ import type { Repo } from '../../shared/repo-types'
 import type { GitWorktreeInfo, Worktree } from '../../shared/worktree/types'
 import { notifyWorktreesChanged } from './worktree-remote'
 import {
+  invalidateAuthorizedRootsCache,
   isRegisteredWorktreePath,
   resolveRegisteredWorktreePath
 } from './registered-worktree-roots-cache'
@@ -164,6 +165,35 @@ describe('registerWorktreeHandlers', () => {
     const second = await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
 
     expect(first).toEqual(second)
+    expect(listWorktreesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-registers roots when authorization is invalidated before a cached listing', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: 'main-head',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      },
+      {
+        path: '/workspace/new-worktree',
+        head: 'feature-head',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+    expect(isRegisteredWorktreePath(resolve('/workspace/new-worktree'))).toBe(true)
+    invalidateAuthorizedRootsCache()
+    expect(isRegisteredWorktreePath(resolve('/workspace/new-worktree'))).toBe(false)
+
+    await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+
+    expect(isRegisteredWorktreePath(resolve('/workspace/new-worktree'))).toBe(true)
     expect(listWorktreesMock).toHaveBeenCalledTimes(1)
   })
 
@@ -495,6 +525,7 @@ describe('registerWorktreeHandlers', () => {
     await pendingList
 
     expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(isRegisteredWorktreePath(resolve('/workspace/repo'))).toBe(false)
     expect(listWorktreesMock).toHaveBeenCalledTimes(1)
   })
 

--- a/src/main/ipc/worktrees/listing/detected-provider-listing.ts
+++ b/src/main/ipc/worktrees/listing/detected-provider-listing.ts
@@ -48,6 +48,7 @@ export async function listDetectedWorktreesForCapturedRepo(
   try {
     let gitWorktrees: GitWorktreeInfo[]
     let freshScan = true
+    let safeToAuthorize = true
     if (isFolderRepo(repo)) {
       if (!isCurrent()) {
         return null
@@ -97,6 +98,7 @@ export async function listDetectedWorktreesForCapturedRepo(
       const scan = await listDetectedGitWorktrees(store, repo)
       gitWorktrees = scan.gitWorktrees
       freshScan = scan.fresh
+      safeToAuthorize = scan.safeToAuthorize
     }
     const aborted = abortedResult()
     if (aborted) {
@@ -114,8 +116,10 @@ export async function listDetectedWorktreesForCapturedRepo(
         worktrees: []
       }
     }
-    if (freshScan) {
+    if (safeToAuthorize) {
       rememberLocalWorktreeRoots(store, repo, gitWorktrees)
+    }
+    if (freshScan) {
       pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
     }
     loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)

--- a/src/main/ipc/worktrees/listing/detected-worktree-scan-cache.ts
+++ b/src/main/ipc/worktrees/listing/detected-worktree-scan-cache.ts
@@ -85,7 +85,9 @@ export async function listDetectedGitWorktrees(
 
   const inFlight = detectedWorktreeScanInFlight.get(cacheKey)
   if (inFlight) {
-    return { gitWorktrees: await inFlight.promise, fresh: false }
+    const gitWorktrees = await inFlight.promise
+    // A current follower must register roots when the caller that started the live scan went stale.
+    return { gitWorktrees, fresh: !inFlight.invalidated }
   }
 
   const scan: DetectedWorktreeScan = {

--- a/src/main/ipc/worktrees/listing/detected-worktree-scan-cache.ts
+++ b/src/main/ipc/worktrees/listing/detected-worktree-scan-cache.ts
@@ -22,6 +22,7 @@ export type DetectedWorktreeScan = {
 export type DetectedWorktreeScanResult = {
   gitWorktrees: GitWorktreeInfo[]
   fresh: boolean
+  safeToAuthorize: boolean
 }
 
 export const detectedWorktreeScanCache = new Map<string, DetectedWorktreeScanCacheEntry>()
@@ -73,21 +74,26 @@ export async function listDetectedGitWorktrees(
   if (repo.connectionId || isFolderRepo(repo)) {
     return {
       gitWorktrees: await listRepoWorktrees(repo, localWorktreeGitOptions),
-      fresh: true
+      fresh: true,
+      safeToAuthorize: true
     }
   }
 
   const cacheKey = getDetectedWorktreeScanCacheKey(repo.id, localWorktreeGitOptions)
   const cached = detectedWorktreeScanCache.get(cacheKey)
   if (cached && cached.expiresAt > Date.now()) {
-    return { gitWorktrees: cached.worktrees, fresh: false }
+    return { gitWorktrees: cached.worktrees, fresh: false, safeToAuthorize: true }
   }
 
   const inFlight = detectedWorktreeScanInFlight.get(cacheKey)
   if (inFlight) {
     const gitWorktrees = await inFlight.promise
     // A current follower must register roots when the caller that started the live scan went stale.
-    return { gitWorktrees, fresh: !inFlight.invalidated }
+    return {
+      gitWorktrees,
+      fresh: !inFlight.invalidated,
+      safeToAuthorize: !inFlight.invalidated
+    }
   }
 
   const scan: DetectedWorktreeScan = {
@@ -104,7 +110,11 @@ export async function listDetectedGitWorktrees(
         expiresAt: Date.now() + DETECTED_WORKTREE_SCAN_CACHE_TTL_MS
       })
     }
-    return { gitWorktrees, fresh: !scan.invalidated }
+    return {
+      gitWorktrees,
+      fresh: !scan.invalidated,
+      safeToAuthorize: !scan.invalidated
+    }
   } finally {
     if (detectedWorktreeScanInFlight.get(cacheKey) === scan) {
       detectedWorktreeScanInFlight.delete(cacheKey)

--- a/src/main/ipc/worktrees/listing/register-worktree-catalog-handlers.ts
+++ b/src/main/ipc/worktrees/listing/register-worktree-catalog-handlers.ts
@@ -88,6 +88,7 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
       try {
         let gitWorktrees
         let freshScan = true
+        let safeToAuthorize = true
         if (isFolderRepo(repo)) {
           return listVisibleFolderWorkspaces(store, repo)
         } else if (repo.connectionId) {
@@ -116,9 +117,12 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
           const scan = await listDetectedGitWorktrees(store, repo)
           gitWorktrees = scan.gitWorktrees
           freshScan = scan.fresh
+          safeToAuthorize = scan.safeToAuthorize
+        }
+        if (safeToAuthorize) {
+          rememberLocalWorktreeRoots(store, repo, gitWorktrees)
         }
         if (freshScan) {
-          rememberLocalWorktreeRoots(store, repo, gitWorktrees)
           pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
         }
         loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
@@ -169,6 +173,7 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
     try {
       let gitWorktrees
       let freshScan = true
+      let safeToAuthorize = true
       if (isFolderRepo(repo)) {
         return listVisibleFolderWorkspaces(store, repo)
       } else if (repo.connectionId) {
@@ -197,9 +202,12 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
         const scan = await listDetectedGitWorktrees(store, repo)
         gitWorktrees = scan.gitWorktrees
         freshScan = scan.fresh
+        safeToAuthorize = scan.safeToAuthorize
+      }
+      if (safeToAuthorize) {
+        rememberLocalWorktreeRoots(store, repo, gitWorktrees)
       }
       if (freshScan) {
-        rememberLocalWorktreeRoots(store, repo, gitWorktrees)
         pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
       }
       loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​130 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |

<!-- /orca-pr-loc -->

## Summary
- treat callers joining a live detected-worktree scan as fresh when that scan remains valid
- let a current follower register authorized worktree roots when the scan starter becomes stale
- add a deterministic regression test for the stale-starter/current-follower interleaving

## Why
The Windows golden source-control test selected and displayed a linked worktree, then Git status and filesystem reads rejected it as unregistered. The first renderer refresh had started the shared scan but became stale; the current follower received the same live result marked non-fresh and therefore skipped root registration.

## Validation
- regression test fails without the fix and passes with it
- focused worktree/filesystem tests: 63 passed, 1 platform skip
- pnpm tc:node
- changed-code quality gate

The equivalent commit is already backported to the 1.4.192 ad-hoc release branch for non-signing golden validation.