### PR TITLE
Fix a skill install lock release moving a directory it no longer owns

### DIFF
--- a/src/main/skills/skill-install-lock-release-ownership.test.ts
+++ b/src/main/skills/skill-install-lock-release-ownership.test.ts
@@ -1,0 +1,236 @@
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, dirname, join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { acquireSkillInstallLock, skillInstallLockPath } from './skill-install-lock'
+
+const hooks: {
+  afterOpen: ((path: string) => Promise<void>) | null
+  afterRead: ((path: string) => Promise<void>) | null
+  afterReaddir: ((path: string) => Promise<void>) | null
+  openedPaths: string[]
+} = { afterOpen: null, afterRead: null, afterReaddir: null, openedPaths: [] }
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  const actualOpen = actual.open as (
+    path: string,
+    flags?: string,
+    mode?: number
+  ) => Promise<unknown>
+  const actualReadFile = actual.readFile as (path: string, options?: unknown) => Promise<unknown>
+  const actualReaddir = actual.readdir as (path: string, options?: unknown) => Promise<unknown>
+  const patched = {
+    ...actual,
+    open: async (path: string, flags?: string, mode?: number) => {
+      const handle = await actualOpen(path, flags, mode)
+      hooks.openedPaths.push(String(path))
+      await hooks.afterOpen?.(String(path))
+      return handle
+    },
+    readFile: async (path: string, options?: unknown) => {
+      const contents = await actualReadFile(path, options)
+      await hooks.afterRead?.(String(path))
+      return contents
+    },
+    readdir: async (path: string, options?: unknown) => {
+      const entries = await actualReaddir(path, options)
+      await hooks.afterReaddir?.(String(path))
+      return entries
+    }
+  }
+  return { ...patched, default: patched }
+})
+
+const roots: string[] = []
+
+afterEach(async () => {
+  hooks.afterOpen = null
+  hooks.afterRead = null
+  hooks.afterReaddir = null
+  hooks.openedPaths = []
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function makeLockPath(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-ownership-test-'))
+  roots.push(root)
+  return skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
+}
+
+async function ownerNames(path: string): Promise<string[]> {
+  return (await readdir(path)).filter((name) => name.endsWith('.owner'))
+}
+
+describe('skill install lock release ownership', () => {
+  it('leaves the contender that reclaimed the lock holding its own directory', async () => {
+    const lockPath = await makeLockPath()
+    const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 10_000 })
+    const contender = acquireSkillInstallLock({ path: lockPath, timeoutMs: 10_000 })
+    // Any reclaim signal published inside the live directory lets the contender take the lock
+    // before the release that published it has taken that directory away.
+    hooks.afterOpen = async (path) => {
+      if (dirname(path) !== lockPath || !path.endsWith('.released')) {
+        return
+      }
+      hooks.afterOpen = null
+      await contender
+    }
+
+    await release()
+    const releaseContender = await contender
+
+    await expect(ownerNames(lockPath)).resolves.toHaveLength(1)
+    await releaseContender()
+    await expect(readdir(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('never publishes a reclaim marker inside the live lock directory', async () => {
+    const lockPath = await makeLockPath()
+
+    const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 10_000 })
+    await release()
+
+    expect(
+      hooks.openedPaths.filter((path) => dirname(path) === lockPath && path.endsWith('.released'))
+    ).toEqual([])
+  })
+
+  it('leaves a republished directory alone when ownership changes after the release check', async () => {
+    const lockPath = await makeLockPath()
+    const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 10_000 })
+    const foreignToken = '99999999-9999-4999-8999-999999999999'
+    const foreignOwner = JSON.stringify({
+      token: foreignToken,
+      pid: 2_147_483_647,
+      createdAt: Date.now()
+    })
+    // Reclaim and republish in the window between the release's ownership check and its take-away.
+    hooks.afterRead = async (path) => {
+      if (dirname(path) !== lockPath || !path.endsWith('.owner')) {
+        return
+      }
+      hooks.afterRead = null
+      await rm(lockPath, { recursive: true })
+      await mkdir(lockPath, { mode: 0o700 })
+      await writeFile(join(lockPath, `${foreignToken}.owner`), foreignOwner, { mode: 0o600 })
+    }
+
+    await release()
+
+    await expect(readdir(lockPath)).resolves.toEqual([`${foreignToken}.owner`])
+    await expect(readFile(join(lockPath, `${foreignToken}.owner`), 'utf8')).resolves.toBe(
+      foreignOwner
+    )
+  })
+
+  it('leaves a republished working directory alone when ownership changes after the check', async () => {
+    const lockPath = await makeLockPath()
+    const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 10_000 })
+    const foreignToken = '88888888-8888-4888-8888-888888888888'
+    // Why: a new owner that already started work leaves entries beyond its owner record, which is
+    // exactly the shape the polluted-directory park path acts on.
+    hooks.afterRead = async (path) => {
+      if (dirname(path) !== lockPath || !path.endsWith('.owner')) {
+        return
+      }
+      hooks.afterRead = null
+      await rm(lockPath, { recursive: true })
+      await mkdir(lockPath, { mode: 0o700 })
+      await writeFile(
+        join(lockPath, `${foreignToken}.owner`),
+        JSON.stringify({ token: foreignToken, pid: 2_147_483_647, createdAt: Date.now() })
+      )
+      await writeFile(join(lockPath, 'in-progress-work'), 'preserve')
+    }
+
+    await release()
+
+    await expect(readdir(lockPath)).resolves.toEqual(
+      expect.arrayContaining([`${foreignToken}.owner`, 'in-progress-work'])
+    )
+  })
+
+  it('leaves a republished directory alone when ownership changes after every check', async () => {
+    const lockPath = await makeLockPath()
+    const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 10_000 })
+    const foreignToken = '77777777-7777-4777-8777-777777777777'
+    // Why: the take-away must carry its own ownership proof, so it has to survive a reclaim that
+    // lands after the release has finished looking at the directory.
+    hooks.afterReaddir = async (path) => {
+      if (path !== lockPath) {
+        return
+      }
+      hooks.afterReaddir = null
+      await rm(lockPath, { recursive: true })
+      await mkdir(lockPath, { mode: 0o700 })
+      await writeFile(
+        join(lockPath, `${foreignToken}.owner`),
+        JSON.stringify({ token: foreignToken, pid: 2_147_483_647, createdAt: Date.now() })
+      )
+    }
+
+    await release()
+
+    await expect(readdir(lockPath)).resolves.toEqual([`${foreignToken}.owner`])
+  })
+
+  it('parks a polluted lock directory aside so the canonical path stays usable', async () => {
+    const lockPath = await makeLockPath()
+    const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 10_000 })
+    await writeFile(join(lockPath, 'unexpected-entry'), 'preserve')
+
+    await release()
+
+    await expect(readdir(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    const parked = (await readdir(dirname(lockPath))).find((name) =>
+      name.startsWith(`${basename(lockPath)}.`)
+    )
+    expect(parked).toMatch(/\.released$/)
+    await expect(readdir(join(dirname(lockPath), parked ?? ''))).resolves.toEqual([
+      'unexpected-entry'
+    ])
+    const secondRelease = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 10_000 })
+    await secondRelease()
+  })
+
+  it('keeps contended acquisitions mutually exclusive', async () => {
+    const lockPath = await makeLockPath()
+    let held = 0
+    let overlaps = 0
+    let completed = 0
+
+    await Promise.all(
+      Array.from({ length: 8 }, async () => {
+        const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 30_000 })
+        held += 1
+        overlaps += held > 1 ? 1 : 0
+        await new Promise((resolve) => setTimeout(resolve, 1))
+        overlaps += held > 1 ? 1 : 0
+        held -= 1
+        completed += 1
+        await release()
+      })
+    )
+
+    expect(overlaps).toBe(0)
+    expect(completed).toBe(8)
+    await expect(readdir(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('reclaims a directory lock whose owning process is gone', async () => {
+    const lockPath = await makeLockPath()
+    const deadToken = '11111111-1111-4111-8111-111111111111'
+    await mkdir(lockPath, { recursive: true, mode: 0o700 })
+    await writeFile(
+      join(lockPath, `${deadToken}.owner`),
+      JSON.stringify({ token: deadToken, pid: 2_147_483_647, createdAt: Date.now() })
+    )
+
+    const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 10_000 })
+
+    await expect(ownerNames(lockPath)).resolves.toEqual([expect.not.stringContaining(deadToken)])
+    await release()
+    await expect(readdir(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+})

--- a/src/main/skills/skill-install-lock-release.ts
+++ b/src/main/skills/skill-install-lock-release.ts
@@ -86,8 +86,8 @@ export async function releaseOwnedSkillInstallLock(input: {
     return
   }
   await unlinkIfPresent(ownerPath)
-  // Why: rmdir is the only take-away that carries its own ownership proof. It succeeds solely on an
-  // empty directory, and a published lock directory always holds an owner record, so a directory
-  // this release no longer owns survives it untouched.
+  // Why: rmdir is the only take-away that carries its own ownership proof. Another active owner
+  // publishes its owner record before the directory, while an ownerless published directory is
+  // either unowned or kept nonempty by pollution, so a directory this release no longer owns stays.
   await removeDirectoryIfPresent(input.path, input.removeDirectory ?? rmdir)
 }

--- a/src/main/skills/skill-install-lock-release.ts
+++ b/src/main/skills/skill-install-lock-release.ts
@@ -1,5 +1,6 @@
-import { readdir, rmdir, unlink } from 'node:fs/promises'
+import { readdir, rename, rmdir, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
+import { readSkillInstallLockOwner } from './skill-install-lock-owner'
 
 const RELEASE_ENTRY_NAME = /^[a-f0-9-]{36}\.(?:owner|released)$/
 const LOCK_DIRECTORY_RMDIR_IGNORED_CODES = new Set(['ENOENT', 'ENOTEMPTY', 'EEXIST', 'EBUSY'])
@@ -50,4 +51,43 @@ export async function reclaimReleasedSkillInstallLock(path: string): Promise<voi
       throw error
     }
   })
+}
+
+async function readLockDirectoryEntries(path: string): Promise<string[]> {
+  return await readdir(path).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return []
+    }
+    throw error
+  })
+}
+
+export async function releaseOwnedSkillInstallLock(input: {
+  path: string
+  token: string
+  releasedPath: string
+  removeDirectory?: (path: string) => Promise<void>
+}): Promise<void> {
+  const ownerEntry = `${input.token}.owner`
+  const ownerPath = join(input.path, ownerEntry)
+  if ((await readSkillInstallLockOwner(ownerPath))?.token !== input.token) {
+    return
+  }
+  const entries = await readLockDirectoryEntries(input.path)
+  if (!entries.includes(ownerEntry)) {
+    return
+  }
+  if (entries.length > 1) {
+    // Why: our own owner record is still published here, and no reclaim path touches a directory
+    // whose owner is live, so this rename can only move the directory this release still owns.
+    // Parking it keeps the canonical path usable despite entries this release must not delete.
+    await rename(input.path, input.releasedPath)
+    await cleanupReleasedSkillInstallLock(input.releasedPath, input.token, input.removeDirectory)
+    return
+  }
+  await unlinkIfPresent(ownerPath)
+  // Why: rmdir is the only take-away that carries its own ownership proof. It succeeds solely on an
+  // empty directory, and a published lock directory always holds an owner record, so a directory
+  // this release no longer owns survives it untouched.
+  await removeDirectoryIfPresent(input.path, input.removeDirectory ?? rmdir)
 }

--- a/src/main/skills/skill-install-lock.test.ts
+++ b/src/main/skills/skill-install-lock.test.ts
@@ -51,7 +51,7 @@ describe('skill install lock', () => {
     await expect(readdir(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('reclaims a lock after its release deletion fails', async () => {
+  it('keeps a lock reclaimable after its release deletion fails', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-lock-test-'))
     roots.push(root)
     const lockPath = skillInstallLockPath(join(root, 'state'), join(root, 'skills', 'alpha'))
@@ -64,11 +64,10 @@ describe('skill install lock', () => {
     })
 
     await expect(release()).rejects.toThrow('injected-delete-failure')
-    await expect(readdir(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
-    expect(await readdir(dirname(lockPath))).toEqual(
-      expect.arrayContaining([expect.stringMatching(/\.lock\.[a-f0-9-]+\.released$/)])
-    )
-    const secondRelease = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
+    // Why: the release drops its own owner record before removing the directory, so a failed
+    // removal leaves an unowned directory that the next acquisition reclaims for itself.
+    await expect(readdir(lockPath)).resolves.toEqual([])
+    const secondRelease = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 5_000 })
     await secondRelease()
     await expect(readdir(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })

--- a/src/main/skills/skill-install-lock.ts
+++ b/src/main/skills/skill-install-lock.ts
@@ -18,8 +18,8 @@ import {
   type SkillInstallLockOwner
 } from './skill-install-lock-owner'
 import {
-  cleanupReleasedSkillInstallLock,
-  reclaimReleasedSkillInstallLock
+  reclaimReleasedSkillInstallLock,
+  releaseOwnedSkillInstallLock
 } from './skill-install-lock-release'
 import { skillInstallStateKey } from './skill-install-provenance'
 
@@ -70,7 +70,11 @@ async function removeStaleLegacyLock(path: string): Promise<void> {
   }
 }
 
-async function removeStaleLockDirectory(path: string, incompleteStaleMs = 0): Promise<void> {
+async function removeStaleLockDirectory(
+  path: string,
+  options: { incompleteStaleMs?: number; abandonedWhenEmpty?: boolean } = {}
+): Promise<void> {
+  const incompleteStaleMs = options.incompleteStaleMs ?? 0
   const lockStat = await stat(path).catch(() => null)
   if (!lockStat?.isDirectory()) {
     return
@@ -85,7 +89,10 @@ async function removeStaleLockDirectory(path: string, incompleteStaleMs = 0): Pr
       return match?.[1] ? [match[1]] : []
     })
   )
-  let mayRemoveDirectory = releasedTokens.size > 0
+  // Why: a lock directory is only ever published with its owner record inside, so an empty one is
+  // owned by nobody; a candidate directory is empty while it is still being built.
+  let mayRemoveDirectory =
+    releasedTokens.size > 0 || (options.abandonedWhenEmpty === true && entries.length === 0)
   for (const entry of entries) {
     const match = entry.isFile() ? OWNER_ENTRY_NAME.exec(entry.name) : null
     if (!match?.[1]) {
@@ -130,7 +137,7 @@ async function removeStaleLockDirectory(path: string, incompleteStaleMs = 0): Pr
 async function removeStaleLock(path: string): Promise<void> {
   const lockStat = await stat(path).catch(() => null)
   if (lockStat?.isDirectory()) {
-    await removeStaleLockDirectory(path)
+    await removeStaleLockDirectory(path, { abandonedWhenEmpty: true })
   } else if (lockStat?.isFile()) {
     await removeStaleLegacyLock(path)
   }
@@ -163,7 +170,7 @@ export async function reclaimDeadSkillInstallLocks(stateDirectory: string): Prom
     await (LEGACY_OWNER_NAME.test(lock.name)
       ? removeStaleLegacyLock(path)
       : CANDIDATE_LOCK_NAME.test(lock.name)
-        ? removeStaleLockDirectory(path, LOCK_STALE_MS)
+        ? removeStaleLockDirectory(path, { incompleteStaleMs: LOCK_STALE_MS })
         : RELEASED_LOCK_NAME.test(lock.name)
           ? reclaimReleasedSkillInstallLock(path)
           : removeStaleLock(path))
@@ -201,15 +208,6 @@ async function writeOwnerRecord(
   }
 }
 
-async function markReleased(path: string): Promise<void> {
-  const handle = await open(path, 'wx', 0o600)
-  try {
-    await handle.sync()
-  } finally {
-    await handle.close()
-  }
-}
-
 export async function acquireSkillInstallLock(input: {
   path: string
   timeoutMs?: number
@@ -227,7 +225,6 @@ export async function acquireSkillInstallLock(input: {
   const ownerRecord = JSON.stringify(owner)
   const candidatePath = `${input.path}.${owner.token}.candidate`
   const candidateOwnerPath = join(candidatePath, `${owner.token}.owner`)
-  const ownerPath = join(input.path, `${owner.token}.owner`)
   const releasedPath = `${input.path}.${owner.token}.released`
   await mkdir(candidatePath, { mode: 0o700 })
   activeLockTokens.add(owner.token)
@@ -270,19 +267,12 @@ export async function acquireSkillInstallLock(input: {
   return () => {
     releasePromise ??= (async () => {
       try {
-        if ((await readSkillInstallLockOwner(ownerPath))?.token !== owner.token) {
-          return
-        }
-        await markReleased(join(input.path, `${owner.token}.released`))
-        try {
-          await rename(input.path, releasedPath)
-        } catch (error) {
-          if ((await readSkillInstallLockOwner(ownerPath))?.token === owner.token) {
-            throw error
-          }
-          return
-        }
-        await cleanupReleasedSkillInstallLock(releasedPath, owner.token, input.removeLock)
+        await releaseOwnedSkillInstallLock({
+          path: input.path,
+          token: owner.token,
+          releasedPath,
+          removeDirectory: input.removeLock
+        })
       } finally {
         activeLockTokens.delete(owner.token)
       }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​241 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​235 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​30 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |

<!-- /orca-pr-loc -->

## ELI5

Two skill installs can run at once, so they take turns using a lock. When one
finished, it put up a "I'm done" note *before* it had actually packed up and
left. Someone else saw the note, moved into the room, and then the first one
came back and carried the room away — with the new occupant still inside.

Now the leaver never posts a note it has to come back for: it takes its own
name off the door and then removes the room only if the room is empty. A room
with someone else's name in it can't be empty, so it stays exactly where it is.

## What Changed

`release()` no longer publishes a `.released` marker inside the live lock
directory, and no longer renames that directory away in the common case.

- **The reclaim signal is gone from the live directory.** `markReleased()` opened
  `<lock>/<token>.released` with `wx` and *then* fsync'd it. The file was visible
  to every contender the instant `open()` returned — before the durability
  barrier, and long before the releaser had taken the directory away.
- **The take-away carries its own ownership proof.** The release now unlinks its
  own `<token>.owner` record (the name embeds the token, so it can only ever be
  its own) and then calls `rmdir`. `rmdir` succeeds *only* on an empty directory,
  and a published lock directory always contains its owner record — so a
  directory this release no longer owns survives the take-away untouched.
- **Parking a polluted directory is gated on still owning it.** The old
  unconditional `rename(lock, lock.<token>.released)` is now reached only when
  the same `readdir` that found foreign entries also found this release's own
  owner record — the state in which no reclaim path in the module can take the
  directory. That keeps the canonical path usable when a foreign writer has left
  entries behind, which is what the rename was really for.
- **An empty lock directory is now explicitly unowned.** `removeStaleLock` passes
  `abandonedWhenEmpty`, so a directory whose owner record is gone is reclaimed
  immediately instead of waiting on an mtime comparison. A *candidate* directory
  is empty while it is still being built, so it keeps the staleness window.

`releaseOwnedSkillInstallLock` lives in `skill-install-lock-release.ts` next to
the cleanup helpers it reuses; `skill-install-lock.ts` just calls it.

## Why

Two processes could hold the lock at once, and the loser found its own working
directory gone mid-operation.

`markReleased` published a reclaim signal at `open()`, before its `fsync`. A
contender's 50 ms retry tick could observe that marker, treat the directory as
abandoned, remove it, and publish its own directory at the same path. The
releaser's next syscall, `rename(lockPath, releasedPath)`, then operated on
*whatever was at that path now* — the new owner's directory — and moved it away.
In CI this surfaced as `ENOENT scandir` on the lock directory. In production it
means a skill install can lose its working directory part-way through.

**Why this closes the window rather than narrowing it.** Reordering the two
syscalls, or re-checking the owner file before the rename, would still leave a
check-then-act on a destructive operation. The fix removes the check-then-act
instead:

1. Nothing publishes a reclaim signal into a directory the releaser still holds,
   so no other actor in this module can make that directory reclaimable —
   `ownerIsReclaimable` is false for a live, active token, and the only other way
   in was the marker.
2. The destructive step is `rmdir`, which is atomic and self-verifying: it either
   finds an empty directory (nobody's) or fails with `ENOTEMPTY` (somebody's).
   There is no interval between deciding and acting.
3. The one remaining `rename` requires this release's own owner record to be
   present in the same `readdir`, which is exactly the state (1) makes
   untouchable by anyone else.

A pre-existing Orca build running concurrently against the same state directory
still publishes the old marker, and nothing a new client does can stop that
binary's own rename; the marker is still honoured on read so those releases stay
recoverable.

## Linked Issue

Fixes #

<!-- No issue filed: root-caused from a red CI shard on `main`. -->

## Visual Proof

`N/A` — main-process filesystem locking, no UI surface.

## Testing

**Deterministic reduction, failing-first 1-to-1** (`skill-install-lock-release-ownership.test.ts`,
`leaves the contender that reclaimed the lock holding its own directory`): a real
contender is let in at the moment the release publishes a reclaim signal.

- Before: fails with `ENOENT: no such file or directory, scandir '<lockdir>'` —
  CI's exact error class, syscall and path.
- After: passes; the contender still holds its own directory.

**Natural case, 8-way contention + fsync load** (`UV_THREADPOOL_SIZE=32`, six
concurrent 256 KB `fsync` loops, 192 rounds × 8 workers = 1536 acquisitions):

| | violations | mutual-exclusion overlaps |
| --- | --- | --- |
| before | **17** | **16** |
| after (run 1) | 0 | 0 |
| after (run 2) | 0 | 0 |

Every "before" violation is `ENOENT scandir` on the lock directory. Unloaded, and
under light load (64 × 8), it does not reproduce either way — this race needs
real contention, which is why it read as a flaky shard.

**Per-gate ablation** (20 tests across the three lock suites; each gate reverted
alone, baseline 0 failed):

| ablation | red |
| --- | --- |
| A — publish the reclaim marker inside the live directory | 4/20 |
| B — take the lock away with an unconditional `rename` | 2/20 |
| C — drop the re-check that our owner record is still there | 1/20 |
| D1 — park on every release, not just polluted directories | 2/20 |
| D2 — never park a polluted directory | 1/20 |
| E — drop the empty-lock-directory reclaim | 1/20 |
| A+C together | 5/20 |
| **delete the whole rule (main's release verbatim)** | **6/20** |

Only the full deletion reds the contention reduction: A, B and C are layered, and
each is separately pinned.

**Still true after the change:** mutual exclusion under contention (8-way test +
0 overlaps in 3072 loaded acquisitions), a crashed holder's lock is still
reclaimable (dead-pid directory, legacy file, and startup-scan cases), a release
whose directory removal fails leaves the lock reclaimable by the next acquirer,
and a polluted directory is still parked aside so the canonical path stays usable.

**Platforms.** macOS (locally, all of the above). Linux behaves as macOS: both
allow `rename` over an existing *empty* directory, so a contender can publish
straight over a released directory. Windows refuses that rename, so the contender
falls into the stale-lock sweep, which removes the empty directory
(`abandonedWhenEmpty`) and publishes on the next 50 ms tick — one extra tick, same
outcome. `rmdir` on a non-empty directory reports `ENOTEMPTY` on all three, and
`removeDirectoryIfPresent` also tolerates `EBUSY`, which is the Windows shape when
an indexer or AV holds a handle. All paths are built with `path.join`; no
separator assumptions. The release now performs one fewer `fsync` on every
platform.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`pnpm tc` (all projects), `oxlint`, `audit:code-quality:native --deny-warnings`,
`audit:code-quality:type-aware --deny-warnings`, `check-changed-code-quality.mjs`
(0 new findings across 4 files), max-lines ratchet, reliability gates, and
`git diff --check` all pass. `src/main/skills` suite: 601 passed / 43 skipped.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Backwards compatible on disk: directories left by an older build (`.released`
markers inside a lock directory, parked `*.released` directories, legacy owner
files) are still read and reclaimed by the unchanged sweep paths.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
