### PR TITLE
feat(i18n): localize Agent Dashboard to Korean

### DIFF
--- a/config/scripts/locale-ko-key-overrides.json
+++ b/config/scripts/locale-ko-key-overrides.json
@@ -5032,5 +5032,50 @@
   },
   "auto.components.right.sidebar.AiVaultPanel.noAgentsSelected": {
     "ko": "선택된 에이전트가 없습니다"
+  },
+  "dashboardPopout.title": {
+    "ko": "에이전트"
+  },
+  "dashboardPopout.total": {
+    "ko": "총 {{count}}개"
+  },
+  "dashboardPopout.close": {
+    "ko": "대시보드 닫기"
+  },
+  "dashboardPopout.placeholder.title": {
+    "ko": "에이전트 대시보드"
+  },
+  "dashboardPopout.placeholder.description": {
+    "ko": "모든 에이전트를 한눈에 볼 수 있는 곳입니다. 보드는 곧 제공됩니다."
+  },
+  "dashboardPopout.recoverableError.title": {
+    "ko": "Orca 대시보드에서 오류가 발생했습니다."
+  },
+  "dashboardPopout.recoverableError.description": {
+    "ko": "대시보드 렌더링을 완료하지 못했습니다. 다시 시도해 다시 마운트하거나 다시 열어 보세요."
+  },
+  "dashboardPopout.bucket.attention": {
+    "ko": "확인 필요"
+  },
+  "dashboardPopout.bucket.working": {
+    "ko": "작업 중"
+  },
+  "dashboardPopout.bucket.idle": {
+    "ko": "유휴"
+  },
+  "dashboardPopout.bucket.empty": {
+    "ko": "없음"
+  },
+  "dashboardPopout.card.you": {
+    "ko": "나"
+  },
+  "dashboardPopout.terminal.closed": {
+    "ko": "실시간 터미널이 없습니다 — 이 에이전트의 창이 닫혔습니다."
+  },
+  "dashboardPopout.terminal.focusWorktree": {
+    "ko": "워크트리 열기"
+  },
+  "dashboardPopout.terminal.close": {
+    "ko": "닫기"
   }
 }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14798,24 +14798,24 @@
       "agentCount": "에이전트 {{count}}개"
     },
     "placeholder": {
-      "title": "Agent dashboard",
-      "description": "This is where all your agents will show up at a glance. The board is coming soon."
+      "title": "에이전트 대시보드",
+      "description": "모든 에이전트를 한눈에 볼 수 있는 곳입니다. 보드는 곧 제공됩니다."
     },
     "recoverableError": {
-      "title": "Orca dashboard hit an error.",
-      "description": "The dashboard could not finish rendering. Retry to remount it, or reopen it."
+      "title": "Orca 대시보드에서 오류가 발생했습니다.",
+      "description": "대시보드 렌더링을 완료하지 못했습니다. 다시 시도해 다시 마운트하거나 다시 열어 보세요."
     },
     "bucket": {
-      "attention": "Needs You",
-      "working": "Working",
-      "idle": "Idle",
-      "empty": "None",
+      "attention": "확인 필요",
+      "working": "작업 중",
+      "idle": "유휴",
+      "empty": "없음",
       "done": "완료"
     },
-    "title": "Agents",
-    "total": "{{count}} total",
+    "title": "에이전트",
+    "total": "총 {{count}}개",
     "card": {
-      "you": "You",
+      "you": "나",
       "time": {
         "justNow": "방금",
         "minutes": "{{count}}분",
@@ -14832,11 +14832,11 @@
       "subagents_other": "서브에이전트 {{count}}개"
     },
     "terminal": {
-      "closed": "No live terminal — this agent's pane has closed.",
-      "focusWorktree": "Open worktree",
-      "close": "Close"
+      "closed": "실시간 터미널이 없습니다 — 이 에이전트의 창이 닫혔습니다.",
+      "focusWorktree": "워크트리 열기",
+      "close": "닫기"
     },
-    "close": "Close dashboard",
+    "close": "대시보드 닫기",
     "settingsTooltip": "보드 설정",
     "filters": {
       "remove": "{{label}} 필터 제거",


### PR DESCRIPTION
## ELI5

The Agent Dashboard shows agents as a kanban board (columns like "Needs You", "Working", "Idle"). When the app language is set to Korean, most of the UI is Korean but these column headers and a handful of other labels were still shown in English — only "Done" (완료) had been translated. This PR fills in the missing Korean so the whole Agent Dashboard reads naturally in Korean.

## What Changed

Added Korean translations for 15 `dashboardPopout.*` keys (Agent Dashboard) that were falling back to English:

| Key | English | Korean |
|---|---|---|
| `bucket.attention` | Needs You | 확인 필요 |
| `bucket.working` | Working | 작업 중 |
| `bucket.idle` | Idle | 유휴 |
| `bucket.empty` | None | 없음 |
| `title` | Agents | 에이전트 |
| `total` | {{count}} total | 총 {{count}}개 |
| `close` | Close dashboard | 대시보드 닫기 |
| `placeholder.title` | Agent dashboard | 에이전트 대시보드 |
| `placeholder.description` | This is where all your agents will show up… | 모든 에이전트를 한눈에 볼 수 있는 곳입니다… |
| `recoverableError.title` | Orca dashboard hit an error. | Orca 대시보드에서 오류가 발생했습니다. |
| `recoverableError.description` | The dashboard could not finish rendering… | 대시보드 렌더링을 완료하지 못했습니다… |
| `card.you` | You | 나 |
| `terminal.closed` | No live terminal — this agent's pane has closed. | 실시간 터미널이 없습니다 — 이 에이전트의 창이 닫혔습니다. |
| `terminal.focusWorktree` | Open worktree | 워크트리 열기 |
| `terminal.close` | Close | 닫기 |

Changed strictly two files, consistent with existing Korean i18n PRs:

- `config/scripts/locale-ko-key-overrides.json` — durable translation source (survives catalog regeneration).
- `src/renderer/src/i18n/locales/ko.json` — generated catalog, kept in sync with the override.

Proper nouns / acronyms (SSH, WSL) were intentionally left untranslated. `bucket.done` was already "완료" and is unchanged.

## Why

These strings are rendered via `translate('dashboardPopout.*', …)` across the Agent Dashboard:
`AgentKanbanBoard.tsx` (column headers, board title/count, close), `AgentKanbanCard.tsx` (the "You" message badge), `AgentDashboardSidebarEntry.tsx` (sidebar bucket labels), `AgentTerminalDialog.tsx` / `AgentTerminalPreview.tsx` (terminal preview), and `popout.tsx` (error boundary).

`ko.json` held English values for these keys, so i18next fell back to English under the Korean locale. Adding the Korean values (and registering them in the override source) resolves the fallback durably.

## Linked Issue

Fixes #17120

## Visual Proof

Agent Dashboard under the **Korean** locale. Before, the surrounding UI is Korean but the board title, column headers, and empty-state are English — only "완료" (Done) was translated. After, the whole board reads in Korean.

| Before (Korean locale) | After (this PR) |
|---|---|
| `Agents` · `0 total` — `NEEDS YOU` / `WORKING` / **완료** / `IDLE` — `None` | `에이전트` · `총 0개` — `확인 필요` / `작업 중` / `완료` / `유휴` — `없음` |
| <img width="2692" height="1756" alt="image" src="https://github.com/user-attachments/assets/385d5093-c142-494b-86b9-739125c797e1" /> | <img width="1920" height="1376" alt="image" src="https://github.com/user-attachments/assets/08016ed4-ca8e-4779-8938-e0c19792162a" /> |

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verification:
- `pnpm test src/renderer/src/i18n/ko-ui-semantic-mistranslations.test.ts config/scripts/locale-ko-key-overrides.test.mjs config/scripts/locale-generic-ui-terms.test.mjs config/scripts/locale-translation-policy-ko-round5.test.mjs` → all pass.
- `pnpm verify:localization-catalog`, `verify:localization-extraction`, `verify:localization-coverage` → no errors.
- No new tests added: this is a data-only locale change; the existing locale policy/consistency tests cover it.
- Platform: locale strings are platform-independent (macOS verified).

## AI Disclosure

Claude (Opus 4.8) was used to locate the untranslated keys, draft the Korean translations, and wire them through the repo's locale override + catalog workflow. Translations were reviewed by the author (native Korean speaker).

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, or docs touched.

## Notes

Security / cross-platform / SSH / mobile / performance: no impact — data-only Korean locale strings, no code paths changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm test` and localization verifiers pass (lint/typecheck/build covered by CI)
