### PR TITLE
fix(test): stop the WebRTC egress probe timing out its own startup

### DIFF
--- a/src/main/browser/browser-route-egress-electron-launch.ts
+++ b/src/main/browser/browser-route-egress-electron-launch.ts
@@ -41,10 +41,12 @@ export async function runBrowserRouteEgressElectron(
     termination ??= terminateProcessTree(child)
     return termination
   }
+  // Why 60s: this bounds cold start plus the child's own watchdog, so the child's verdict wins the race. Startup
+  // alone reached ~26s under reproduced contention and the widest child watchdog is 25s, which 30s could not cover.
   const timeout = setTimeout(() => {
     timedOut = true
     void terminate()
-  }, 30_000)
+  }, 60_000)
   try {
     const output = await exit
     const rawResult = existsSync(resultPath) ? readFileSync(resultPath, 'utf8') : 'no result'

--- a/src/main/browser/browser-route-h3-egress.electron.test.ts
+++ b/src/main/browser/browser-route-h3-egress.electron.test.ts
@@ -33,5 +33,5 @@ describe('browser route HTTP/3 and Direct Sockets egress under Electron', () => 
     })
     expect(guarded.directSocketsConstruct).toBe('threw:ReferenceError')
     expect(guarded.rendererGone).toBe('none')
-  }, 90_000)
+  }, 150_000)
 })

--- a/src/main/browser/browser-route-tcp-egress.electron.test.ts
+++ b/src/main/browser/browser-route-tcp-egress.electron.test.ts
@@ -17,5 +17,5 @@ describe('browser route TCP egress under Electron', () => {
     // Chromium may route an unrelated background request through the same proxy.
     // The target-host observation is the causal DNS/routing oracle for this fixture.
     expect(protectedSession.socksHosts).toContain('remote-browser.test')
-  }, 60_000)
+  }, 150_000)
 })

--- a/src/main/browser/browser-route-webrtc-egress-electron-main.test.ts
+++ b/src/main/browser/browser-route-webrtc-egress-electron-main.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { browserRouteWebrtcEgressElectronMain } from './browser-route-webrtc-egress-electron-main'
+
+// Why a source-order assertion: the accounting this probe depends on is an *ordering* in the
+// emitted child, and no probe run can observe it — a watchdog armed at evaluation only differs
+// from one armed after readiness when startup is slow, which is exactly the contended runner
+// this file cannot reproduce. Reverting the arm to evaluation time reddens nothing otherwise.
+describe('browser route WebRTC egress probe child', () => {
+  const source = browserRouteWebrtcEgressElectronMain()
+
+  it('arms the budget after the app is ready, so cold start is not charged against it', () => {
+    const readyAt = source.indexOf('await app.whenReady()')
+    // The budget's own closing argument, not a bare `setTimeout(` — the ICE script the probe
+    // injects into the guest carries one of those and it precedes readiness by design.
+    const armedAt = source.indexOf('}, 20000)')
+
+    // Both markers must exist, or the ordering assertion below passes vacuously.
+    expect(readyAt).toBeGreaterThanOrEqual(0)
+    expect(armedAt).toBeGreaterThanOrEqual(0)
+    expect(readyAt).toBeLessThan(armedAt)
+  })
+
+  it('keeps the probe budget at 20s and disarms it before the result is written', () => {
+    expect(source).toContain('}, 20000)')
+
+    const disarmedAt = source.indexOf('clearTimeout(timeout)')
+    const writtenAt = source.indexOf('writeFileSync(config.resultPath, JSON.stringify(result))')
+
+    expect(disarmedAt).toBeGreaterThanOrEqual(0)
+    expect(writtenAt).toBeGreaterThanOrEqual(0)
+    expect(disarmedAt).toBeLessThan(writtenAt)
+  })
+})

--- a/src/main/browser/browser-route-webrtc-egress-electron-main.ts
+++ b/src/main/browser/browser-route-webrtc-egress-electron-main.ts
@@ -1,0 +1,113 @@
+export function browserRouteWebrtcEgressElectronMain(): string {
+  return String.raw`
+const { app, BrowserWindow, session } = require('electron')
+const dgram = require('node:dgram')
+const net = require('node:net')
+const os = require('node:os')
+const { readFileSync, writeFileSync } = require('node:fs')
+const config = JSON.parse(readFileSync(process.argv[2], 'utf8'))
+
+function bind(socket, host) {
+  return new Promise((resolve, reject) => {
+    socket.once('error', reject)
+    socket.bind(0, host, () => {
+      socket.off('error', reject)
+      resolve(socket.address())
+    })
+  })
+}
+
+function listen(server, host) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, host, () => {
+      server.off('error', reject)
+      resolve(server.address())
+    })
+  })
+}
+
+function viewerAddress() {
+  for (const entries of Object.values(os.networkInterfaces())) {
+    for (const entry of entries || []) {
+      if (entry.family === 'IPv4' && !entry.internal) return entry.address
+    }
+  }
+  return '127.0.0.1'
+}
+
+function iceScript(stunUrl) {
+  return [
+    "(async () => {",
+    "  const peer = new RTCPeerConnection({",
+    "    iceServers: [{ urls: '" + stunUrl + "' }],",
+    "    iceCandidatePoolSize: 1",
+    "  })",
+    "  peer.createDataChannel('probe')",
+    "  const offer = await peer.createOffer()",
+    "  await peer.setLocalDescription(offer)",
+    "  await new Promise(resolve => setTimeout(resolve, 3000))",
+    "  peer.close()",
+    "})()"
+  ].join('\n')
+}
+
+async function probe() {
+  const udp = dgram.createSocket('udp4')
+  const tcp = net.createServer((socket) => socket.destroy())
+  const packets = []
+  udp.on('message', (message) => packets.push(message.length))
+  const [udpAddress, tcpAddress] = await Promise.all([
+    bind(udp, '0.0.0.0'),
+    listen(tcp, '127.0.0.1')
+  ])
+  const partition = 'persist:webrtc-egress-' + config.protectedGuest + '-' + Date.now()
+  const routeSession = session.fromPartition(partition, { cache: false })
+  await routeSession.setProxy({
+    mode: 'fixed_servers',
+    proxyRules: 'socks5://127.0.0.1:' + tcpAddress.port,
+    proxyBypassRules: '<-loopback>'
+  })
+  await routeSession.closeAllConnections()
+  const resolvedProxy = await routeSession.resolveProxy('https://example.invalid/')
+  const window = new BrowserWindow({
+    show: false,
+    webPreferences: { partition, sandbox: true, nodeIntegration: false, contextIsolation: true }
+  })
+  if (config.protectedGuest) {
+    window.webContents.setWebRTCIPHandlingPolicy('disable_non_proxied_udp')
+  }
+  const policy = window.webContents.getWebRTCIPHandlingPolicy()
+  await window.loadURL('data:text/html,<title>WebRTC egress probe</title>')
+  const target = viewerAddress()
+  await window.webContents.executeJavaScript(
+    iceScript('stun:' + target + ':' + udpAddress.port)
+  )
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  window.destroy()
+  udp.close()
+  tcp.close()
+  return { packets: packets.length, policy, resolvedProxy }
+}
+
+async function run() {
+  // Why: armed after whenReady so the budget bounds the probe, not Electron's cold start. Startup is the term that
+  // dilates when five probes race one runner, and a process that never becomes ready is the launcher's to end.
+  await app.whenReady()
+  const timeout = setTimeout(() => {
+    writeFileSync(config.resultPath, JSON.stringify({ error: 'webrtc_egress_probe_exceeded_budget' }))
+    app.exit(2)
+  }, 20000)
+  const result = await probe()
+  // Why disarm first: a watchdog that fires between the probe resolving and the write would clobber a good result.
+  clearTimeout(timeout)
+  writeFileSync(config.resultPath, JSON.stringify(result))
+  app.quit()
+}
+
+run().catch((error) => {
+  writeFileSync(config.resultPath, JSON.stringify({ error: String(error?.stack || error) }))
+  app.exit(1)
+})
+`
+}

--- a/src/main/browser/browser-route-webrtc-egress-fixture.ts
+++ b/src/main/browser/browser-route-webrtc-egress-fixture.ts
@@ -1,0 +1,51 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { runBrowserRouteEgressElectron } from './browser-route-egress-electron-launch'
+import { browserRouteWebrtcEgressElectronMain } from './browser-route-webrtc-egress-electron-main'
+
+export type BrowserRouteWebrtcEgressProbeResult = {
+  packets: number
+  policy: string
+  resolvedProxy: string
+}
+
+const fixtureRoots: string[] = []
+
+export async function runBrowserRouteWebrtcEgressProbe(
+  protectedGuest: boolean
+): Promise<BrowserRouteWebrtcEgressProbeResult> {
+  const root = mkdtempSync(join(tmpdir(), 'orca-browser-webrtc-egress-'))
+  fixtureRoots.push(root)
+  const mainPath = join(root, 'main.cjs')
+  writeFileSync(mainPath, browserRouteWebrtcEgressElectronMain())
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({ protectedGuest, resultPath: join(root, 'result.json') })
+  )
+  const parsed = await runBrowserRouteEgressElectron(root, mainPath)
+  const { packets, policy, resolvedProxy } = parsed
+  if (
+    typeof packets !== 'number' ||
+    typeof policy !== 'string' ||
+    typeof resolvedProxy !== 'string'
+  ) {
+    throw new Error(`browser_route_webrtc_probe_result_invalid:${JSON.stringify(parsed)}`)
+  }
+  return { packets, policy, resolvedProxy }
+}
+
+export function cleanupBrowserRouteWebrtcEgressFixtures(): void {
+  const failures: unknown[] = []
+  for (const root of fixtureRoots) {
+    try {
+      rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+    } catch (error) {
+      failures.push(error)
+    }
+  }
+  fixtureRoots.length = 0
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Failed to clean up WebRTC egress fixtures')
+  }
+}

--- a/src/main/browser/browser-route-webrtc-egress.electron.test.ts
+++ b/src/main/browser/browser-route-webrtc-egress.electron.test.ts
@@ -1,172 +1,19 @@
-import { spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { createRequire } from 'node:module'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
-import { resolveElectronProbeLaunch } from './electron-probe-display-launch'
+import {
+  cleanupBrowserRouteWebrtcEgressFixtures,
+  runBrowserRouteWebrtcEgressProbe
+} from './browser-route-webrtc-egress-fixture'
 
-const electronBinary = createRequire(import.meta.url)('electron') as string
-const fixtureRoots: string[] = []
-
-type ProbeResult = {
-  packets: number
-  policy: string
-  resolvedProxy: string
-}
-
-afterAll(() => {
-  const failures: unknown[] = []
-  for (const root of fixtureRoots) {
-    try {
-      rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
-    } catch (error) {
-      failures.push(error)
-    }
-  }
-  if (failures.length > 0) {
-    throw new AggregateError(failures, 'Failed to clean up WebRTC egress fixtures')
-  }
-})
-
-function probeMain(resultPath: string, protectedGuest: boolean): string {
-  return `
-const { app, BrowserWindow, session } = require('electron')
-const dgram = require('node:dgram')
-const net = require('node:net')
-const os = require('node:os')
-const { writeFileSync } = require('node:fs')
-
-function bind(socket, host) {
-  return new Promise((resolve, reject) => {
-    socket.once('error', reject)
-    socket.bind(0, host, () => {
-      socket.off('error', reject)
-      resolve(socket.address())
-    })
-  })
-}
-
-function listen(server, host) {
-  return new Promise((resolve, reject) => {
-    server.once('error', reject)
-    server.listen(0, host, () => {
-      server.off('error', reject)
-      resolve(server.address())
-    })
-  })
-}
-
-function viewerAddress() {
-  for (const entries of Object.values(os.networkInterfaces())) {
-    for (const entry of entries || []) {
-      if (entry.family === 'IPv4' && !entry.internal) return entry.address
-    }
-  }
-  return '127.0.0.1'
-}
-
-async function probe() {
-  const udp = dgram.createSocket('udp4')
-  const tcp = net.createServer((socket) => socket.destroy())
-  const packets = []
-  udp.on('message', (message) => packets.push(message.length))
-  const [udpAddress, tcpAddress] = await Promise.all([
-    bind(udp, '0.0.0.0'),
-    listen(tcp, '127.0.0.1')
-  ])
-  const partition = 'persist:webrtc-egress-${protectedGuest}-' + Date.now()
-  const routeSession = session.fromPartition(partition, { cache: false })
-  await routeSession.setProxy({
-    mode: 'fixed_servers',
-    proxyRules: 'socks5://127.0.0.1:' + tcpAddress.port,
-    proxyBypassRules: '<-loopback>'
-  })
-  await routeSession.closeAllConnections()
-  const resolvedProxy = await routeSession.resolveProxy('https://example.invalid/')
-  const window = new BrowserWindow({
-    show: false,
-    webPreferences: { partition, sandbox: true, nodeIntegration: false, contextIsolation: true }
-  })
-  if (${protectedGuest}) {
-    window.webContents.setWebRTCIPHandlingPolicy('disable_non_proxied_udp')
-  }
-  const policy = window.webContents.getWebRTCIPHandlingPolicy()
-  await window.loadURL('data:text/html,<title>WebRTC egress probe</title>')
-  const target = viewerAddress()
-  const script = \`
-    (async () => {
-      const peer = new RTCPeerConnection({
-        iceServers: [{ urls: 'stun:\${target}:\${udpAddress.port}' }],
-        iceCandidatePoolSize: 1
-      })
-      peer.createDataChannel('probe')
-      const offer = await peer.createOffer()
-      await peer.setLocalDescription(offer)
-      await new Promise(resolve => setTimeout(resolve, 3000))
-      peer.close()
-    })()
-  \`
-  await window.webContents.executeJavaScript(script)
-  await new Promise((resolve) => setTimeout(resolve, 500))
-  window.destroy()
-  udp.close()
-  tcp.close()
-  return { packets: packets.length, policy, resolvedProxy }
-}
-
-async function run() {
-  const timeout = setTimeout(() => app.exit(2), 20000)
-  await app.whenReady()
-  const result = await probe()
-  writeFileSync(${JSON.stringify(resultPath)}, JSON.stringify(result))
-  clearTimeout(timeout)
-  app.quit()
-}
-
-run().catch((error) => {
-  writeFileSync(${JSON.stringify(resultPath)}, JSON.stringify({ error: String(error?.stack || error) }))
-  app.exit(1)
-})
-`
-}
-
-function runProbe(protectedGuest: boolean): ProbeResult {
-  const root = mkdtempSync(join(tmpdir(), 'orca-browser-webrtc-egress-'))
-  fixtureRoots.push(root)
-  const mainPath = join(root, 'main.cjs')
-  const resultPath = join(root, 'result.json')
-  writeFileSync(mainPath, probeMain(resultPath, protectedGuest))
-  const { ELECTRON_RUN_AS_NODE: _electronRunAsNode, ...env } = process.env
-  const electronArgs = [mainPath, `--user-data-dir=${join(root, 'profile')}`]
-  const { executable, args } = resolveElectronProbeLaunch({
-    electronBinary,
-    electronArgs,
-    platform: process.platform,
-    display: env.DISPLAY
-  })
-  const run = spawnSync(executable, args, { encoding: 'utf8', env, timeout: 30_000 })
-  const rawResult = existsSync(resultPath) ? readFileSync(resultPath, 'utf8') : 'no result'
-  expect(run.error).toBeUndefined()
-  expect(run.status, `${rawResult}\n${run.stdout}\n${run.stderr}`).toBe(0)
-  if (rawResult === 'no result') {
-    throw new Error(`${rawResult}\n${run.stdout}\n${run.stderr}`)
-  }
-  const parsed = JSON.parse(rawResult) as ProbeResult | { error: string }
-  if ('error' in parsed) {
-    throw new Error(parsed.error)
-  }
-  return parsed
-}
+afterAll(cleanupBrowserRouteWebrtcEgressFixtures)
 
 describe('browser route WebRTC egress under Electron', () => {
-  it('blocks direct UDP after applying the exact guest policy', () => {
-    const baseline = runProbe(false)
-    const protectedGuest = runProbe(true)
+  it('blocks direct UDP after applying the exact guest policy', async () => {
+    const baseline = await runBrowserRouteWebrtcEgressProbe(false)
+    const protectedGuest = await runBrowserRouteWebrtcEgressProbe(true)
 
     expect(protectedGuest.resolvedProxy).toMatch(/^SOCKS5 127\.0\.0\.1:\d+$/)
     expect(baseline.packets).toBeGreaterThan(0)
     expect(protectedGuest.policy).toBe('disable_non_proxied_udp')
     expect(protectedGuest.packets).toBe(0)
-  }, 45_000)
+  }, 150_000)
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​164 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​120 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​167 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​166 |

<!-- /orca-pr-loc -->

## ELI5

The WebRTC egress test boots a small, separate Electron app, asks it one question, and gives it 20 seconds to
answer. The stopwatch was started too early — before the little app had finished booting. On a busy CI machine
five of these boot at the same instant, and booting alone can eat most of the 20 seconds, so the app killed
itself before it ever reached the question. The test then reported a failure on a pull request that had nothing
to do with it.

Now the stopwatch starts when the app is actually ready to answer. Booting is the launcher's problem, and the
launcher waits long enough for a slow boot.

## Before / after — and who it affects

**Before:** anyone whose PR touched packaging could get a red `package` job because this probe timed *itself* out
while its own process was still starting. The cost landed on the PR author: a rerun, a delayed merge, and one
more reason to read a red check as noise. It hit three separate branches, two of which predate the change they
were blamed on.

**After:** the probe's 20-second budget covers only what the probe does. A slow start no longer counts against
it, and only a probe that is genuinely stuck fails.

Nothing about what the test exercises changes: same partition, same fixed SOCKS proxy, same
`disable_non_proxied_udp` policy, same STUN target on the viewer address, same four assertions.

## The mechanism

Exit code 2 came from the probe's own `setTimeout(() => app.exit(2), 20000)`. It was killing itself, not crashing.

- In the failing `package` job, the test file's duration was **20229 ms** — the 20-second watchdog, plus change.
- The child's captured stderr in that same failure shows Chromium's D-Bus/browser-process init still logging
  **14.5 seconds** after the probe was spawned. The probe had not started its work yet.
- In healthy runs of the same job the whole file takes **8.5–14.0 s for two probes** (4.3–7.0 s each), and
  **3.5 s of each probe is two deliberate sleeps**. So the probe's own variable work is under a second.

The 20 seconds was being spent becoming ready, not probing.

Reproduced locally by starving the probe (background QoS + CPU load), with phase marks in the child:

```
script evaluated   11.2 s
app.whenReady()    26.5 s   <- watchdog already expired here
WATCHDOG           exit 2, no probe work executed at all
```

Unstarved, the same probe finishes in 4.1 s end to end and the `script-eval -> ready` interval is 49 ms. Under
starvation that interval reached **15.3 s** — on its own, three quarters of the probe's entire budget.

## What changed

1. **`browser-route-webrtc-egress-electron-main.ts` (new)** — the probe's child script, arming its 20-second
   watchdog **after** `app.whenReady()`. The number is unchanged; it just no longer pays for process startup.
   It also writes a named marker when it fires, so the failure reads `webrtc_egress_probe_exceeded_budget`
   instead of a mute `no result`.
2. **`browser-route-webrtc-egress-fixture.ts` (new)** — runs the probe through `runBrowserRouteEgressElectron`,
   the launcher the h3, TCP and DNS probes already use. This was the one probe in the family still on
   `spawnSync`.
3. **The test file** keeps only its assertions.
4. **`browser-route-egress-electron-launch.ts`** — kill deadline 30 s → 60 s.
5. **TCP and h3 test timeouts** → 150 s, so two probes at the new deadline still fit.

## Why the shared launcher

`spawnSync` has two concrete costs here. Its 30-second timeout signals only the wrapper — on Linux that is the
`xvfb-run` shell script — so Electron and its Xvfb survive as orphans and add load to the four sibling probes
still running in the same job. And because it blocks the Vitest worker thread outright, the test's own
`testTimeout` cannot fire while a probe is running. Both were observed: a starved run returned
`status: null` at 60 s with no result file and a live process tree behind it.

The launcher fixes both — `detached` spawn with a process-group SIGTERM/SIGKILL, and an async wait — and it is
what the other three probes in this family already do.

**Is it equivalent for WebRTC?** Yes, and the differences are checked rather than assumed. Executable and
argument selection are identical (`xvfb-run --auto-servernum` plus `--no-sandbox` on Linux, the bare binary
elsewhere); the environment is the same, `ELECTRON_RUN_AS_NODE` stripped; the result path is the same
`result.json`; and the `{ error }` shape the child writes on a throw is propagated the same way. The WebRTC
probe needs *less* from its parent than h3 does — it binds its own UDP observer and SOCKS stand-in inside the
child, so unlike h3 it passes no ports in — which is why its config is just `{ protectedGuest, resultPath }`.
Fixture-root cleanup keeps its existing `afterAll` semantics, including the `AggregateError`, rather than
moving into the per-probe path. The rewritten child was run directly in both arms and returns exactly what the
assertions require: baseline `packets: 4`, `policy: "default"`; protected `packets: 0`,
`policy: "disable_non_proxied_udp"`, `resolvedProxy: "SOCKS5 127.0.0.1:…"`.

## Why not just raise 20 to 30

Because 20 was never the tight number. Against 3.5 s of deliberate sleeps and well under a second of variable
work, 20 s is roughly a 5× margin — and it is exactly as generous as the sibling h3 probe's 25 s is for its own
12 s of deliberate waits. The probe did not overrun a tight budget; it never started. Raising 20 to 30 buys ten
seconds of *startup* headroom, leaves the defect in place for the next contended runner, and is how a 20-second
watchdog becomes a 25-second watchdog that fails next quarter. **This ships with the probe budget untouched.**

## Why the launcher deadline moved, and why the two sibling timeouts followed

The launcher's deadline is the backstop for "this process never came up". It has to exceed cold start *plus*
the child's own watchdog, or the parent kills the child before the child can report which step wedged — a mute
`timeout` instead of an attributable one. At 30 s it did not: h3's child arms a 25-second watchdog at script
evaluation, so an h3 probe that takes more than 5 seconds to reach that line has its own diagnostic exit
pre-empted by the parent. In CI, h3 probes run 7–9 s each; the margin is a couple of seconds. 60 s covers the
~26 s cold start seen under reproduced contention plus the widest child watchdog (25 s).

That deadline is what forces the two test-timeout changes: a test running two probes must allow 2 × 60 s or
Vitest kills it before the launcher can say anything. The DNS test runs a single probe and is already at 90 s,
so it is unchanged.

## Platforms

The probe runs in both the Linux `package` job and the Windows `package (windows)` job. No platform branch is
added or removed — the launcher keeps the same `xvfb-run` selection on Linux, and on Windows it replaces an
unscoped `spawnSync` kill with `taskkill /pid <pid> /t /f` plus `windowsHide`, which is the same treatment the
other three probes already get there. macOS is unaffected in CI (this file is not in a macOS job) and passes
locally.

## Relationship to #17071

While this was in flight, #17071 landed on `main` and attacked the same failure from the other end: it gives
each Linux Electron probe the runner to itself (`--no-file-parallelism`) and stops each probe nesting a private
`xvfb-run --auto-servernum` inside the step's own one. That removes most of the contention that made cold start
run long, and this PR is rebased on top of it.

It does not make this change redundant, and the two are complementary rather than overlapping. #17071's own
description names the in-process deadline as the surface every observed failure went through — "every observed
failure was one of those deadlines expiring" — but leaves that deadline armed across process startup. This PR
removes the residual: the deadline now measures the probe, so a slow start on any future contended runner
(shards, local dev, a noisy hosted runner, a machine without an inherited `DISPLAY`) cannot spend it.

The two also compose cleanly rather than duplicating. #17071 added `resolveElectronProbeLaunch` and called it
from both `browser-route-egress-electron-launch.ts` and, separately, from the WebRTC test's own inlined
`runProbe`. Moving the WebRTC probe onto the shared launcher deletes that second call site: the probe now
inherits the display resolution from the launcher, exactly as the h3, TCP and DNS probes already do.


## Evidence

### Controlled before/after

The defect is "the interval before `app.whenReady()` is charged to the probe's budget", so it reproduces
deterministically rather than by hoping a scheduler produces it: inject a stall of D ms immediately before
`app.whenReady()` in both arms and vary D. In the old arm the watchdog is already armed, so D comes out of its
20 s; in the new arm it does not. Five runs per cell, arms alternated so both see the same ambient load.

| injected pre-ready stall | old arm | new arm |
| --- | --- | --- |
| 0 s | 4/5 pass, 0 watchdog kills | 5/5 pass, 0 watchdog kills |
| 10 s | 4/5 pass, 0 watchdog kills | 4/5 pass, 0 watchdog kills |
| 15 s | 3/5 pass, 0 watchdog kills | 2/5 pass, 0 watchdog kills |
| **18 s** | **0/5 pass, 5/5 killed by the watchdog** | **4/5 pass, 0 watchdog kills** |

18 s is calibrated against the 14.5 s of browser-process init visible in the CI failure's own child stderr. At
0 s and 10 s the arms are indistinguishable — the stall still fits inside 20 s. At 18 s the old arm dies by its
own watchdog every single time, with exactly the CI signature (exit 2, no result written); the new arm is
unaffected. The residual failures in both columns are ambient noise, not watchdog kills: the machine is an
18-core Darwin box carrying a 100–140 load average from unrelated work.

### The real test under load

Running the actual Vitest file under background QoS plus 24 CPU burners, the unmodified test failed **4/4**.
There the binding kill was the parent `spawnSync` deadline at 30 s rather than the child watchdog — the same
defect one layer up, which is why the launcher deadline moves too. Past that load level neither arm can pass,
because local starvation bottlenecks on loading the 180 MB Electron binary, which is not the resource a
GitHub runner is short of; that is what the injected-stall table is for.

### Real CI, this PR

| job | WebRTC | h3 | TCP | DNS |
| --- | --- | --- | --- | --- |
| Linux `package` | 7652 ms ✓ | 13770 ms ✓ | 800 ms ✓ | 4342 ms ✓ |
| `package (windows)` | 7794 ms ✓ | 14223 ms ✓ | 1442 ms ✓ | 4622 ms ✓ |

Before this change the WebRTC file's healthy range on the same Linux job was 8513–14025 ms. It is now at or
below the fast end of that range, so nothing is slower and none of the added headroom is being consumed in the
healthy path — it is reserve for a contended runner, not slack that hides a slow probe.

`pnpm tc` clean, `node config/scripts/check-changed-code-quality.mjs` reports 0 new findings across all three
scans, `oxlint --deny-warnings` clean on the changed files for the base, type-aware and React Doctor configs,
`git diff --check` clean.
