### PR TITLE
test: stabilize process and transcript liveness checks

### DIFF
--- a/src/main/native-chat/transcript-watch-liveness.test.ts
+++ b/src/main/native-chat/transcript-watch-liveness.test.ts
@@ -60,7 +60,8 @@ function claudeLine(uuid: string, role: 'user' | 'assistant', text: string): str
   })}\n`
 }
 
-async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+// fs.watch and filesystem mutations use the platform clock; poll observable callbacks to a deadline.
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
   const start = Date.now()
   while (!predicate()) {
     if (Date.now() - start > timeoutMs) {
@@ -166,13 +167,14 @@ describe('native chat transcript watcher liveness', () => {
       onReplace: replacements,
       onAppend: () => {},
       debounceMs: 0,
-      reconciliationIntervalMs: 20
+      reconciliationIntervalMs: 10_000
     })
     await waitFor(() => snapshots.mock.calls.length === 1)
 
     await writeFile(filePath, prefixAfter + stableTail)
     const future = new Date(Date.now() + 10_000)
     await utimes(filePath, future, future)
+    watchCallbacks[0]!('change', 'transcript.jsonl')
     await waitFor(() =>
       replacements.mock.calls.flat(2).some((message) => message.id === 'prefix-new')
     )

--- a/src/main/windows/windows-host-job.win32.test.ts
+++ b/src/main/windows/windows-host-job.win32.test.ts
@@ -30,6 +30,18 @@ function isAlive(pid: number): boolean {
   }
 }
 
+// Job-object teardown is external to fake timers; poll the real process table to a deadline.
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) {
+      return true
+    }
+    await sleep(50)
+  }
+  return !isAlive(pid)
+}
+
 describeOnWindows('host job reaps the tree when the host dies', () => {
   let dir: string
 
@@ -83,11 +95,13 @@ describeOnWindows('host job reaps the tree when the host dies', () => {
     // Force-kill only the host: no tree kill, nothing given a chance to unwind.
     // This is the daemon-crash shape.
     process.kill(host.pid!, 'SIGKILL')
-    await sleep(3_000)
-
     try {
-      expect(isAlive(shellPid)).toBe(false)
-      expect(isAlive(grandchildPid)).toBe(false)
+      const [shellExited, grandchildExited] = await Promise.all([
+        waitForProcessExit(shellPid, 15_000),
+        waitForProcessExit(grandchildPid, 15_000)
+      ])
+      expect(shellExited).toBe(true)
+      expect(grandchildExited).toBe(true)
     } finally {
       for (const pid of [shellPid, grandchildPid]) {
         try {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Two correct tests intermittently failed because they sampled asynchronous operating-system work too early or mutated a watched file in two racing steps. They now wait for the actual bounded outcome and drive one deterministic watcher event.

## What Changed

- Poll Windows job-object descendants for up to 15 seconds after the host is force-killed instead of sampling once after a fixed 3-second sleep.
- Keep the hard failure if either process survives the deadline; cleanup still runs in `finally`.
- Make the same-size transcript rewrite fixture finish both filesystem mutations before scheduling one watcher drain.
- Give real filesystem watcher assertions a 5-second condition deadline under loaded CI.

## Why

CI showed the Windows process-tree assertion failing on four unrelated branches and the transcript watcher suite failing on three unrelated branches. Both failures were timing races in the tests, not weakened product contracts.

## Linked Issue

Fixes #17016

## Visual Proof

N/A — test-only reliability changes; no UI or interaction change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Executed:
- `pnpm test src/main/updater.startup-scheduling.test.ts src/main/native-chat/transcript-watch-liveness.test.ts src/main/windows/windows-host-job.win32.test.ts` — 17 passed, 1 Windows-only test skipped on macOS.
- Transcript watcher suite: 30 additional concurrent stress runs, all passed.
- `pnpm tc:node`.
- `pnpm run check:code-quality:changed` — 0 new findings.
- Windows process-tree behavior is exercised by PR CI on Windows.

## AI Disclosure


## Review

Test-only. The Windows deadline remains bounded and fails closed; no retry or skip was added. The transcript fixture still covers same-size prefix replacement with an unchanged trailing boundary.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No production, wire, SSH, folder-workspace, mobile, or provider behavior changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (targeted tests, node typecheck, changed-code quality, and CI used instead)