### PR TITLE
Improve discriminated union contracts across TypeScript state models

### DIFF
--- a/mobile/src/files/file-tree.test.ts
+++ b/mobile/src/files/file-tree.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import {
   flattenDirectoryCache,
   getMobileFileKind,
   isMarkdownPath,
   shouldIncludeMobileFileExplorerEntry,
   type DirectoryCache,
+  type DirectoryState,
+  type InlineStatusNode,
   type MobileDirEntry
 } from './file-tree'
 
@@ -13,6 +15,14 @@ function entry(name: string, isDirectory = false, isSymlink = false): MobileDirE
 }
 
 describe('file-tree', () => {
+  it('ties directory and inline payloads to their states', () => {
+    expectTypeOf<Extract<DirectoryState, { loading: true }>['error']>().toEqualTypeOf<undefined>()
+    expectTypeOf<Extract<DirectoryState, { error: string }>['loading']>().toEqualTypeOf<
+      false | undefined
+    >()
+    expectTypeOf<Extract<InlineStatusNode, { kind: 'error' }>['message']>().toEqualTypeOf<string>()
+  })
+
   it('flattens cached directories lazily with directories before files', () => {
     const cache: DirectoryCache = {
       '': { entries: [entry('zeta.txt'), entry('src', true), entry('readme.md')] },

--- a/mobile/src/files/file-tree.ts
+++ b/mobile/src/files/file-tree.ts
@@ -21,9 +21,11 @@ export type TreeNode = {
 
 export type DirectoryState = {
   entries: MobileDirEntry[]
-  loading?: boolean
-  error?: string
-}
+} & (
+  | { loading: true; error?: never }
+  | { loading?: false; error: string }
+  | { loading?: false; error?: never }
+)
 
 export type DirectoryCache = Record<string, DirectoryState | undefined>
 
@@ -31,9 +33,7 @@ export type InlineStatusNode = {
   id: string
   relativePath: string
   depth: number
-  kind: 'loading' | 'error'
-  message?: string
-}
+} & ({ kind: 'loading'; message?: never } | { kind: 'error'; message: string })
 
 export type FileExplorerRow = TreeNode | InlineStatusNode
 

--- a/mobile/src/tasks/github-pr-file-diff.test.ts
+++ b/mobile/src/tasks/github-pr-file-diff.test.ts
@@ -1,11 +1,27 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import {
   highlightMobileDiffLines,
   resolveMobileSyntaxLanguage
 } from '../session/mobile-file-syntax'
-import { buildGitHubPrFileDiffLines, buildGitHubPrFileDiffPreview } from './github-pr-file-diff'
+import {
+  buildGitHubPrFileDiffLines,
+  buildGitHubPrFileDiffPreview,
+  type GitHubPrFileDiffLine
+} from './github-pr-file-diff'
 
 describe('buildGitHubPrFileDiffLines', () => {
+  it('ties line numbers to each diff side', () => {
+    expectTypeOf<
+      Extract<GitHubPrFileDiffLine, { kind: 'context' }>['oldLineNumber']
+    >().toEqualTypeOf<number>()
+    expectTypeOf<
+      Extract<GitHubPrFileDiffLine, { kind: 'added' }>['oldLineNumber']
+    >().toEqualTypeOf<undefined>()
+    expectTypeOf<
+      Extract<GitHubPrFileDiffLine, { kind: 'removed' }>['newLineNumber']
+    >().toEqualTypeOf<undefined>()
+  })
+
   it('preserves context and marks added and removed lines', () => {
     expect(buildGitHubPrFileDiffLines('one\ntwo\nthree\n', 'one\ntoo\nthree\n')).toEqual([
       {

--- a/mobile/src/tasks/github-pr-file-diff.ts
+++ b/mobile/src/tasks/github-pr-file-diff.ts
@@ -1,10 +1,11 @@
 export type GitHubPrFileDiffLine = {
   key: string
-  kind: 'context' | 'added' | 'removed'
-  oldLineNumber?: number
-  newLineNumber?: number
   text: string
-}
+} & (
+  | { kind: 'context'; oldLineNumber: number; newLineNumber: number }
+  | { kind: 'added'; oldLineNumber?: never; newLineNumber: number }
+  | { kind: 'removed'; oldLineNumber: number; newLineNumber?: never }
+)
 
 export type GitHubPrFileDiffPreview = {
   lines: GitHubPrFileDiffLine[]

--- a/src/cli/emulator-permissions-args.ts
+++ b/src/cli/emulator-permissions-args.ts
@@ -1,11 +1,9 @@
 import { getOptionalStringFlag, getRequiredStringFlag } from './flags'
 import { RuntimeClientError } from './runtime-client'
 
-export type EmulatorPermissionRequest = {
-  op: 'grant' | 'revoke' | 'reset'
-  packageName?: string
-  permission?: string
-}
+export type EmulatorPermissionRequest =
+  | { op: 'grant' | 'revoke'; packageName: string; permission: string }
+  | { op: 'reset'; packageName?: never; permission?: never }
 
 export function parseEmulatorPermissionRequest(
   flags: Map<string, string | boolean>

--- a/src/cli/handlers/emulator.test.ts
+++ b/src/cli/handlers/emulator.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 
 const { callMock, remoteMock } = vi.hoisted(() => ({
   callMock: vi.fn(),
@@ -27,8 +27,18 @@ vi.mock('../runtime-client', async () => {
 
 import { main } from '../index'
 import { okFixture, queueFixtures } from '../test-fixtures'
+import type { EmulatorPermissionRequest } from '../emulator-permissions-args'
 
 describe('orca emulator CLI handlers', () => {
+  it('ties permission arguments to grant and revoke operations', () => {
+    expectTypeOf<
+      Extract<EmulatorPermissionRequest, { op: 'grant' | 'revoke' }>['packageName']
+    >().toEqualTypeOf<string>()
+    expectTypeOf<
+      Extract<EmulatorPermissionRequest, { op: 'reset' }>['packageName']
+    >().toEqualTypeOf<undefined>()
+  })
+
   const originalWorkspaceId = process.env.ORCA_WORKSPACE_ID
   const originalWorktreeId = process.env.ORCA_WORKTREE_ID
 

--- a/src/main/automations/headless-dispatch.ts
+++ b/src/main/automations/headless-dispatch.ts
@@ -3,6 +3,7 @@ import type {
   AutomationRun,
   AutomationRunOutputSnapshot
 } from '../../shared/automations-types'
+import type { AutomationRunCompletionObservation } from './run-completion-watcher'
 import type { AutomationRunTargetResult } from './run-target-resolution'
 
 const MAX_HEADLESS_OUTPUT_SNAPSHOT_CHARS = 256 * 1024
@@ -13,11 +14,7 @@ export type HeadlessAutomationDispatchLaunch = {
   terminalSessionId: string | null
   terminalPaneKey?: string | null
   terminalPtyId?: string | null
-  completion?: Promise<{
-    status: 'completed' | 'dispatch_failed'
-    outputSnapshot?: AutomationRunOutputSnapshot | null
-    error?: string | null
-  }>
+  completion?: Promise<AutomationRunCompletionObservation>
 }
 
 export type HeadlessAutomationDispatcher = (request: {

--- a/src/main/automations/retained-run-reconciliation.test.ts
+++ b/src/main/automations/retained-run-reconciliation.test.ts
@@ -164,7 +164,7 @@ describe('reconciling retained runs against a graph that has not published yet',
     await vi.advanceTimersByTimeAsync(5_000)
     expect(surface.observedHandles).toEqual(['handle-1'])
 
-    surface.settleObservation({ status: 'completed', error: null })
+    surface.settleObservation({ status: 'completed' })
     await vi.advanceTimersByTimeAsync(0)
     expect(readRun(store, automation.id, retained.id).status).toBe('completed')
     service.stop()

--- a/src/main/automations/run-completion-watcher.test.ts
+++ b/src/main/automations/run-completion-watcher.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -92,6 +92,15 @@ function createObserver(
 }
 
 describe('authority-owned automation run completion', () => {
+  it('requires errors only for failed observations', () => {
+    expectTypeOf<
+      Extract<AutomationRunCompletionObservation, { status: 'dispatch_failed' }>['error']
+    >().toEqualTypeOf<string>()
+    expectTypeOf<
+      Extract<AutomationRunCompletionObservation, { status: 'completed' }>['error']
+    >().toEqualTypeOf<undefined>()
+  })
+
   beforeEach(() => {
     testState.dir = mkdtempSync(join(tmpdir(), 'orca-automation-completion-'))
     ipcHandlers.clear()
@@ -108,7 +117,7 @@ describe('authority-owned automation run completion', () => {
       // Why: a dispatcher without a completion promise is exactly the case that
       // used to strand a run at 'dispatched' for the process lifetime.
       headlessDispatcher: async () => ({ ...LAUNCH_TARGET }),
-      terminalObserver: createObserver(async () => ({ status: 'completed', error: null }))
+      terminalObserver: createObserver(async () => ({ status: 'completed' }))
     })
 
     const run = await service.runNow(automation.id)
@@ -227,7 +236,7 @@ describe('authority-owned automation run completion', () => {
 
     await vi.waitFor(() => expect(resolveObservation).not.toBeNull())
     expect(readRun(store, automation.id, run.id).status).toBe('dispatched')
-    resolveObservation!({ status: 'completed', error: null })
+    resolveObservation!({ status: 'completed' })
     await vi.waitFor(() => {
       expect(readRun(store, automation.id, run.id).status).toBe('completed')
     })

--- a/src/main/automations/run-completion-watcher.ts
+++ b/src/main/automations/run-completion-watcher.ts
@@ -7,10 +7,8 @@ import {
 import { RetainedRunReconciler } from './retained-run-reconciliation'
 
 export type AutomationRunCompletionObservation = {
-  status: 'completed' | 'dispatch_failed'
   outputSnapshot?: AutomationRunOutputSnapshot | null
-  error?: string | null
-}
+} & ({ status: 'completed'; error?: never } | { status: 'dispatch_failed'; error: string })
 
 /** The owning authority's view of a dispatched run's own terminal session. */
 export type AutomationRunTerminalObserver = {

--- a/src/main/automations/runtime-terminal-run-observer.ts
+++ b/src/main/automations/runtime-terminal-run-observer.ts
@@ -121,7 +121,7 @@ async function buildObservation(
 ): Promise<AutomationRunCompletionObservation> {
   const outputSnapshot = await readTerminalSnapshot(runtime, handle)
   if (wait.satisfied) {
-    return { status: 'completed', outputSnapshot, error: null }
+    return { status: 'completed', outputSnapshot }
   }
   return {
     status: 'dispatch_failed',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2886,8 +2886,7 @@ void app.whenReady().then(async () => {
             if (wait.satisfied) {
               return {
                 status: 'completed' as const,
-                outputSnapshot: snapshotBuffer.snapshot(),
-                error: null
+                outputSnapshot: snapshotBuffer.snapshot()
               }
             }
             return {

--- a/src/main/ipc/ephemeral-vm-recipe-context.ts
+++ b/src/main/ipc/ephemeral-vm-recipe-context.ts
@@ -4,22 +4,20 @@ import type { EphemeralVmRecipeDoctorResult } from '../../shared/ephemeral-vm-re
 import { listEphemeralVmRuntimes } from '../../shared/ephemeral-vm-runtime-store'
 import type { EphemeralVmRuntimeRecord } from '../../shared/ephemeral-vm-runtimes'
 import { isFolderRepo, isGitRepoKind } from '../../shared/repo-kind'
-import type { OrcaVmRecipe } from '../../shared/orca-yaml-hook-types'
+import type { OrcaHooks, OrcaVmRecipe } from '../../shared/orca-yaml-hook-types'
 
 export type EphemeralVmRecipeListResult = {
-  status: 'ok' | 'error'
   repoPath: string | null
   recipes: OrcaVmRecipe[]
-  diagnostics: NonNullable<ReturnType<typeof loadHooks>>['environmentRecipeDiagnostics']
-  message?: string
-}
+  diagnostics: NonNullable<OrcaHooks['environmentRecipeDiagnostics']>
+} & ({ status: 'ok'; message?: never } | { status: 'error'; message: string })
 
 export type EphemeralVmRecipeCatalogEntry = {
   repoId: string
   repoName: string
   repoPath: string
   recipes: OrcaVmRecipe[]
-  diagnostics: NonNullable<ReturnType<typeof loadHooks>>['environmentRecipeDiagnostics']
+  diagnostics: NonNullable<OrcaHooks['environmentRecipeDiagnostics']>
 }
 
 export type RecipeRepoResult =

--- a/src/main/ipc/ephemeral-vm.test.ts
+++ b/src/main/ipc/ephemeral-vm.test.ts
@@ -1,10 +1,11 @@
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { encodePairingOffer, PAIRING_OFFER_VERSION } from '../../shared/pairing'
 import { listEnvironments } from '../../shared/runtime-environment-store'
 import { upsertEphemeralVmRuntime } from '../../shared/ephemeral-vm-runtime-store'
+import type { EphemeralVmRecipeListResult } from './ephemeral-vm-recipe-context'
 
 const handlers = new Map<string, (_event: unknown, args: never) => unknown>()
 const {
@@ -103,6 +104,15 @@ function pluginServiceWithRecipes(
 }
 
 describe('registerEphemeralVmHandlers', () => {
+  it('requires recipe errors only for failed listings', () => {
+    expectTypeOf<
+      Extract<EphemeralVmRecipeListResult, { status: 'error' }>['message']
+    >().toEqualTypeOf<string>()
+    expectTypeOf<
+      Extract<EphemeralVmRecipeListResult, { status: 'ok' }>['message']
+    >().toEqualTypeOf<undefined>()
+  })
+
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
 
   beforeEach(() => {

--- a/src/main/skills/skill-install-destinations.test.ts
+++ b/src/main/skills/skill-install-destinations.test.ts
@@ -1,9 +1,12 @@
 import { mkdir, mkdtemp, realpath, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, expectTypeOf, it } from 'vitest'
 import type { SkillInstallRequest } from '../../shared/skill-install-contract'
-import { resolveSkillInstallDestination } from './skill-install-destinations'
+import {
+  resolveSkillInstallDestination,
+  type ResolvedSkillInstallDestination
+} from './skill-install-destinations'
 
 const roots: string[] = []
 
@@ -34,6 +37,15 @@ async function fixture() {
 }
 
 describe('resolveSkillInstallDestination', () => {
+  it('requires a workspace directory only for workspace destinations', () => {
+    expectTypeOf<
+      Extract<ResolvedSkillInstallDestination, { scope: 'workspace' }>['workspaceDirectory']
+    >().toEqualTypeOf<string>()
+    expectTypeOf<
+      Extract<ResolvedSkillInstallDestination, { scope: 'global' }>['workspaceDirectory']
+    >().toEqualTypeOf<undefined>()
+  })
+
   it('derives global paths from host-owned home and environment identity', async () => {
     const { authority } = await fixture()
     await expect(

--- a/src/main/skills/skill-install-destinations.ts
+++ b/src/main/skills/skill-install-destinations.ts
@@ -17,12 +17,13 @@ export type SkillInstallDestinationAuthority = {
 }
 
 export type ResolvedSkillInstallDestination = {
-  scope: 'global' | 'workspace'
   homeDirectory: string
-  workspaceDirectory?: string
   destinationIdentity: string
   wslDistro?: string
-}
+} & (
+  | { scope: 'global'; workspaceDirectory?: never }
+  | { scope: 'workspace'; workspaceDirectory: string }
+)
 
 async function requireDirectory(path: string, category: string): Promise<string> {
   const stat = await lstat(path).catch(() => null)

--- a/src/preload/api/ephemeral-vm-api.ts
+++ b/src/preload/api/ephemeral-vm-api.ts
@@ -5,13 +5,13 @@ import type { EphemeralVmRecipeResultWarning } from '../../shared/ephemeral-vm-r
 import type { EphemeralVmRuntimeRecord } from '../../shared/ephemeral-vm-runtimes'
 
 export type EphemeralVmApi = {
-  listRecipes: (args: { repoId: string }) => Promise<{
-    status: 'ok' | 'error'
-    repoPath: string | null
-    recipes: OrcaHooks['environmentRecipes']
-    diagnostics: NonNullable<OrcaHooks['environmentRecipeDiagnostics']>
-    message?: string
-  }>
+  listRecipes: (args: { repoId: string }) => Promise<
+    {
+      repoPath: string | null
+      recipes: OrcaHooks['environmentRecipes']
+      diagnostics: NonNullable<OrcaHooks['environmentRecipeDiagnostics']>
+    } & ({ status: 'ok'; message?: never } | { status: 'error'; message: string })
+  >
   listRecipeCatalog: () => Promise<
     {
       repoId: string

--- a/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
-import type { PluginPanelActionOutcome } from '../../../../shared/plugins/plugin-panel-bridge'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
+import type {
+  PluginPanelActionOutcome,
+  PluginPanelActionResultMessage
+} from '../../../../shared/plugins/plugin-panel-bridge'
 import {
   createPanelMessageBudget,
   type PanelMessageBudget
@@ -42,6 +45,15 @@ function createHandler(
 }
 
 describe('createPanelBridgeMessageHandler', () => {
+  it('ties result payloads to success and failure', () => {
+    expectTypeOf<
+      Extract<PluginPanelActionResultMessage, { ok: false }>['error']
+    >().toEqualTypeOf<string>()
+    expectTypeOf<
+      Extract<PluginPanelActionResultMessage, { ok: true }>['error']
+    >().toEqualTypeOf<undefined>()
+  })
+
   it('relays a valid request and posts the success result back into the panel', async () => {
     const panelWindow = createFakePanelWindow()
     const { handler, callPanelAction } = createHandler(panelWindow)

--- a/src/renderer/src/components/right-sidebar/source-control/sync/git-history-panel-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/sync/git-history-panel-state.test.ts
@@ -1,0 +1,17 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type { GitHistoryResult } from '../../../../../../shared/git-history'
+import type { GitHistoryPanelState } from './git-history-panel'
+
+describe('GitHistoryPanelState', () => {
+  it('ties retained history and errors to panel status', () => {
+    expectTypeOf<
+      Extract<GitHistoryPanelState, { status: 'refreshing' | 'ready' }>['result']
+    >().toEqualTypeOf<GitHistoryResult>()
+    expectTypeOf<
+      Extract<GitHistoryPanelState, { status: 'idle' | 'loading' }>['result']
+    >().toEqualTypeOf<undefined>()
+    expectTypeOf<
+      Extract<GitHistoryPanelState, { status: 'error' }>['error']
+    >().toEqualTypeOf<string>()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control/sync/git-history-panel.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/sync/git-history-panel.tsx
@@ -20,8 +20,8 @@ import type { SourceControlRowOpenEvent } from '../listing/split-open'
 import { translate } from '@/i18n/i18n'
 
 export type GitHistoryPanelState =
-  | { status: 'idle' | 'loading'; result?: GitHistoryResult; error?: string }
-  | { status: 'refreshing' | 'ready'; result: GitHistoryResult; error?: string }
+  | { status: 'idle' | 'loading'; result?: never; error?: never }
+  | { status: 'refreshing' | 'ready'; result: GitHistoryResult; error?: never }
   | { status: 'error'; result?: GitHistoryResult; error: string }
 
 const DEFAULT_GIT_HISTORY_PANEL_HEIGHT = 256

--- a/src/renderer/src/components/settings/McpConfigFileRow.tsx
+++ b/src/renderer/src/components/settings/McpConfigFileRow.tsx
@@ -1,12 +1,23 @@
 import { AlertCircle, CheckCircle2 } from 'lucide-react'
-import type { McpConfigInspection } from '../../../../shared/mcp-config'
+import type {
+  McpConfigCandidate,
+  McpConfigInspection,
+  McpServerSummary
+} from '../../../../shared/mcp-config'
 import { Button } from '../ui/button'
 import { translate } from '@/i18n/i18n'
 
-export type LoadedMcpConfigInspection = McpConfigInspection & {
-  absolutePath: string
-  readError?: string
-}
+export type LoadedMcpConfigInspection =
+  | (McpConfigInspection & { absolutePath: string; readError?: never })
+  | {
+      candidate: McpConfigCandidate
+      servers: McpServerSummary[]
+      status: 'invalid'
+      exists: false
+      error?: never
+      absolutePath: string
+      readError: string
+    }
 
 type McpConfigFileRowProps = {
   config: LoadedMcpConfigInspection

--- a/src/renderer/src/components/settings/mcp-config-inspection.ts
+++ b/src/renderer/src/components/settings/mcp-config-inspection.ts
@@ -61,7 +61,8 @@ export async function loadMcpConfigInspections(
       )
       if (parentDirReadError) {
         return {
-          ...inspectMcpConfigContent(candidate, null),
+          candidate,
+          servers: [],
           exists: false,
           status: 'invalid',
           absolutePath,
@@ -82,7 +83,8 @@ export async function loadMcpConfigInspections(
           return { ...inspectMcpConfigContent(candidate, null), absolutePath }
         }
         return {
-          ...inspectMcpConfigContent(candidate, null),
+          candidate,
+          servers: [],
           exists: false,
           status: 'invalid',
           absolutePath,

--- a/src/shared/git-fork-sync.test.ts
+++ b/src/shared/git-fork-sync.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import {
   syncForkDefaultBranch,
   validateGitForkSyncExpectedUpstream,
+  type GitForkSyncResult,
   type GitForkSyncRunner
 } from './git-fork-sync'
 
@@ -60,6 +61,15 @@ function flattenedCommands(calls: string[][]): string {
 }
 
 describe('syncForkDefaultBranch', () => {
+  it('requires a reason only when synchronization is blocked', () => {
+    expectTypeOf<
+      Extract<GitForkSyncResult, { status: 'blocked' }>['reason']
+    >().toMatchTypeOf<string>()
+    expectTypeOf<
+      Extract<GitForkSyncResult, { status: 'up-to-date' | 'synced' }>['reason']
+    >().toEqualTypeOf<undefined>()
+  })
+
   it('pushes the upstream default branch when the fork is only behind', async () => {
     const { runGit, calls } = createRunner({ aheadBehind: '0\t3\n' })
 

--- a/src/shared/git-fork-sync.ts
+++ b/src/shared/git-fork-sync.ts
@@ -11,14 +11,15 @@ export type GitForkSyncBlockedReason =
   | 'diverged'
 
 export type GitForkSyncResult = {
-  status: 'up-to-date' | 'synced' | 'blocked'
-  reason?: GitForkSyncBlockedReason
   originRemote: string
   upstreamRemote: string
   branchName?: string
   ahead: number
   behind: number
-}
+} & (
+  | { status: 'up-to-date' | 'synced'; reason?: never }
+  | { status: 'blocked'; reason: GitForkSyncBlockedReason }
+)
 
 export type GitForkSyncExpectedUpstream = {
   owner: string

--- a/src/shared/mcp-config.test.ts
+++ b/src/shared/mcp-config.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import {
   canInspectLocalMcpConfigRoot,
   getMcpConfigCandidateParentDir,
@@ -7,7 +7,8 @@ import {
   maskMcpEnv,
   MCP_CONFIG_CANDIDATES,
   MCP_STARTER_CONFIG,
-  selectExistingMcpConfigCandidates
+  selectExistingMcpConfigCandidates,
+  type McpConfigInspection
 } from './mcp-config'
 import {
   MCP_CONFIG_INSPECTION_MAX_BYTES,
@@ -22,6 +23,18 @@ afterEach(() => {
 })
 
 describe('mcp-config', () => {
+  it('ties existence and errors to inspection status', () => {
+    expectTypeOf<
+      Extract<McpConfigInspection, { status: 'invalid' }>['error']
+    >().toEqualTypeOf<string>()
+    expectTypeOf<
+      Extract<McpConfigInspection, { status: 'valid' }>['error']
+    >().toEqualTypeOf<undefined>()
+    expectTypeOf<
+      Extract<McpConfigInspection, { status: 'missing' }>['exists']
+    >().toEqualTypeOf<false>()
+  })
+
   const workspaceCandidate = MCP_CONFIG_CANDIDATES[0]
 
   it('reports missing configs', () => {

--- a/src/shared/mcp-config.ts
+++ b/src/shared/mcp-config.ts
@@ -36,11 +36,12 @@ export type McpServerSummary = {
 
 export type McpConfigInspection = {
   candidate: McpConfigCandidate
-  exists: boolean
-  status: 'missing' | 'valid' | 'invalid'
   servers: McpServerSummary[]
-  error?: string
-}
+} & (
+  | { status: 'missing'; exists: false; error?: never }
+  | { status: 'valid'; exists: true; error?: never }
+  | { status: 'invalid'; exists: true; error: string }
+)
 
 export const MCP_CONFIG_CANDIDATES: McpConfigCandidate[] = [
   {

--- a/src/shared/plugins/plugin-panel-bridge.ts
+++ b/src/shared/plugins/plugin-panel-bridge.ts
@@ -65,11 +65,10 @@ export type PluginPanelActionErrorCode =
 export type PluginPanelActionResultMessage = {
   type: typeof PANEL_ACTION_RESULT_TYPE
   requestId: string
-  ok: boolean
-  value?: unknown
-  errorCode?: PluginPanelActionErrorCode
-  error?: string
-}
+} & (
+  | { ok: true; value: unknown; errorCode?: never; error?: never }
+  | { ok: false; value?: never; errorCode: PluginPanelActionErrorCode; error: string }
+)
 
 /** Outcome of executing a panel action in main (wire shape of
  *  `plugins:panelAction` / `plugins.panelAction`). */

--- a/src/shared/project-group-types.ts
+++ b/src/shared/project-group-types.ts
@@ -46,10 +46,10 @@ export type ProjectGroupImportMode = 'group' | 'separate'
 
 export type ProjectGroupImportProjectResult = {
   path: string
-  projectId?: string
-  status: 'imported' | 'already-known' | 'failed'
-  error?: string
-}
+} & (
+  | { status: 'imported' | 'already-known'; projectId: string; error?: never }
+  | { status: 'failed'; projectId?: never; error: string }
+)
 
 export type ProjectGroupImportResult = {
   group?: ProjectGroup

--- a/src/shared/project-groups.test.ts
+++ b/src/shared/project-groups.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import {
   clearMissingProjectGroupMemberships,
   createProjectGroup,
@@ -9,6 +9,7 @@ import {
   normalizeProjectGroups
 } from './project-groups'
 import type { Repo } from './repo-types'
+import type { ProjectGroupImportProjectResult } from './project-group-types'
 
 function repo(overrides: Partial<Repo>): Repo {
   return {
@@ -23,6 +24,21 @@ function repo(overrides: Partial<Repo>): Repo {
 }
 
 describe('project-groups', () => {
+  it('ties project ids and errors to import outcomes', () => {
+    expectTypeOf<
+      Extract<
+        ProjectGroupImportProjectResult,
+        { status: 'imported' | 'already-known' }
+      >['projectId']
+    >().toEqualTypeOf<string>()
+    expectTypeOf<
+      Extract<ProjectGroupImportProjectResult, { status: 'failed' }>['error']
+    >().toEqualTypeOf<string>()
+    expectTypeOf<
+      Extract<ProjectGroupImportProjectResult, { status: 'failed' }>['projectId']
+    >().toEqualTypeOf<undefined>()
+  })
+
   it('creates a durable project group with normalized defaults', () => {
     const group = createProjectGroup({
       name: '  Platform  ',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​152 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​135 |
| Prod | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​67 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## ELI5

Makes invalid combinations of TypeScript state fields impossible to construct while preserving the same runtime payloads and behavior.

## What Changed

- AST-scanned all 19,096 tracked `.ts`/`.tsx` files (there are no tracked `.mts`/`.cts` files), then manually reviewed the high-signal state, result, argument, and props candidates.
- Converted mutually exclusive payloads to discriminated unions across mobile file/diff state, emulator permission arguments, automation completion, ephemeral VM recipes, Git history state, MCP inspection, skill destinations, Git fork sync, plugin panel results, and project import results.
- Used `?: never` where callers legitimately read a field across variants, preserving current access ergonomics while rejecting invalid object construction.
- Reused the canonical automation completion observation in the headless dispatcher instead of maintaining a weaker duplicate shape.
- Added focused `expectTypeOf` contract tests for every changed union family.

## Why

The previous object types allowed combinations that runtime producers never emit: successful outcomes with errors, failed outcomes without errors, reset operations with permission payloads, loading states with errors, and diff rows with line numbers from the wrong side. Encoding those invariants in TypeScript moves these failures to compile time without adding runtime branches or changing wire content.

Optional properties that are independently absent were intentionally left alone; this is not a blanket conversion.

## Linked Issue

N/A — this codebase-wide maintenance audit was requested directly and has no linked issue.

## Visual Proof

N/A — type contracts and equivalent internal object construction only; no visual or interaction change.

## Testing

- [ ] I manually tested these changes locally — no interactive behavior changed.
- [x] Automated tests added/updated.

Verified on macOS:

- `pnpm tc` — passed.
- `cd mobile && pnpm typecheck` — passed.
- Focused root tests — 11 files, 159 tests passed.
- Focused mobile tests — 2 files, 16 tests passed.
- Full mobile suite — 479 files, 3,865 passed, 3 skipped.
- Full root suite — 7,043 files passed and 43 skipped; one unrelated 130,000-leaf persistence test exceeded the 30s timeout under full-suite load. Its isolated rerun passed all 7 tests in 20.14s.
- `pnpm run check:code-quality:changed` — 0 new standard, type-aware, or React Doctor findings across the changed files.
- `pnpm build` — passed, including typecheck, relay/CLI/Electron/web builds, and native macOS builds.
- `git diff --check` — passed.

## Review

Runtime JSON and remote wire content are unchanged. The only removed values were internal `error: null` properties on successful automation observations; persistence still receives the same normalized `error: null`. MCP unreadable-file objects are constructed explicitly with the same values previously produced by spreading the missing inspection.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer source or related assets changed.

## Notes

- Cross-platform/SSH: no path, process, shortcut, provider, or execution-host behavior changed.
- Remote compatibility: no field, value, decoder, opcode, or published content changed.
- Performance: compile-time-only modeling; no new work on runtime hot paths.

## Checklist

- [x] This PR is focused on one concern.
- [x] I explained what changed and why (including ELI5).
- [x] Visual proof is N/A because there is no UI change.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and compatibility impact considered.
- [x] Typecheck, changed-code quality, focused tests, mobile full suite, isolated root retry, and full build pass; CI will rerun the root suite.