### PR TITLE
Pin pnpm and rebalance scheduled E2E

### DIFF
--- a/.github/workflows/adhoc-mac-build.yml
+++ b/.github/workflows/adhoc-mac-build.yml
@@ -173,6 +173,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/daemon-relocation-spike.yml
+++ b/.github/workflows/daemon-relocation-spike.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Install dependencies

--- a/.github/workflows/daily-mac-build.yml
+++ b/.github/workflows/daily-mac-build.yml
@@ -147,6 +147,7 @@ jobs:
         if: steps.freshness.outputs.should_build == 'true'
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/dev-channel-win-build.yml
+++ b/.github/workflows/dev-channel-win-build.yml
@@ -193,6 +193,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,33 +81,37 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Last-week scheduled runs averaged ~24 runner-minutes per shard;
-          # shards 4 and 9 repeatedly hit the 30-minute cap. Twelve-way
-          # Playwright sharding targets ~20 minutes without changing coverage.
-          - shard: '1/12'
-            shard_name: 1-of-12
-          - shard: '2/12'
-            shard_name: 2-of-12
-          - shard: '3/12'
-            shard_name: 3-of-12
-          - shard: '4/12'
-            shard_name: 4-of-12
-          - shard: '5/12'
-            shard_name: 5-of-12
-          - shard: '6/12'
-            shard_name: 6-of-12
-          - shard: '7/12'
-            shard_name: 7-of-12
-          - shard: '8/12'
-            shard_name: 8-of-12
-          - shard: '9/12'
-            shard_name: 9-of-12
-          - shard: '10/12'
-            shard_name: 10-of-12
-          - shard: '11/12'
-            shard_name: 11-of-12
-          - shard: '12/12'
-            shard_name: 12-of-12
+          # Fourteen scheduled runs averaged 24.6 minutes per shard; shards 4
+          # and 9 repeatedly hit the 30-minute cap. A 12-way trial still left
+          # one 30-minute shard, so 14 gives the suite enough failure headroom.
+          - shard: '1/14'
+            shard_name: 1-of-14
+          - shard: '2/14'
+            shard_name: 2-of-14
+          - shard: '3/14'
+            shard_name: 3-of-14
+          - shard: '4/14'
+            shard_name: 4-of-14
+          - shard: '5/14'
+            shard_name: 5-of-14
+          - shard: '6/14'
+            shard_name: 6-of-14
+          - shard: '7/14'
+            shard_name: 7-of-14
+          - shard: '8/14'
+            shard_name: 8-of-14
+          - shard: '9/14'
+            shard_name: 9-of-14
+          - shard: '10/14'
+            shard_name: 10-of-14
+          - shard: '11/14'
+            shard_name: 11-of-14
+          - shard: '12/14'
+            shard_name: 12-of-14
+          - shard: '13/14'
+            shard_name: 13-of-14
+          - shard: '14/14'
+            shard_name: 14-of-14
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,26 +81,33 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - shard: '1/10'
-            shard_name: 1-of-10
-          - shard: '2/10'
-            shard_name: 2-of-10
-          - shard: '3/10'
-            shard_name: 3-of-10
-          - shard: '4/10'
-            shard_name: 4-of-10
-          - shard: '5/10'
-            shard_name: 5-of-10
-          - shard: '6/10'
-            shard_name: 6-of-10
-          - shard: '7/10'
-            shard_name: 7-of-10
-          - shard: '8/10'
-            shard_name: 8-of-10
-          - shard: '9/10'
-            shard_name: 9-of-10
-          - shard: '10/10'
-            shard_name: 10-of-10
+          # Last-week scheduled runs averaged ~24 runner-minutes per shard;
+          # shards 4 and 9 repeatedly hit the 30-minute cap. Twelve-way
+          # Playwright sharding targets ~20 minutes without changing coverage.
+          - shard: '1/12'
+            shard_name: 1-of-12
+          - shard: '2/12'
+            shard_name: 2-of-12
+          - shard: '3/12'
+            shard_name: 3-of-12
+          - shard: '4/12'
+            shard_name: 4-of-12
+          - shard: '5/12'
+            shard_name: 5-of-12
+          - shard: '6/12'
+            shard_name: 6-of-12
+          - shard: '7/12'
+            shard_name: 7-of-12
+          - shard: '8/12'
+            shard_name: 8-of-12
+          - shard: '9/12'
+            shard_name: 9-of-12
+          - shard: '10/12'
+            shard_name: 10-of-12
+          - shard: '11/12'
+            shard_name: 11-of-12
+          - shard: '12/12'
+            shard_name: 12-of-12
 
     steps:
       - name: Checkout
@@ -108,18 +115,10 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      # Why: pnpm install used to rebuild native modules here; the composite
-      # action restores them from cache and only compiles on a miss. The
-      # toolchain is still required for that miss path, and for paired Quick
-      # Open coverage which exercises the resource-bounded host search.
-      - name: Install native build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential fonts-noto-cjk python3 ripgrep zsh
-
-      # Why: Electron on Linux needs an X display even when the app
-      # suppresses mainWindow.show() via ORCA_E2E_HEADLESS. xvfb provides a
-      # virtual framebuffer so Chromium can initialize without a real display.
-      - name: Install xvfb
-        run: sudo apt-get install -y xvfb
+      # Native cache misses need the compiler, Electron needs Xvfb, and paired
+      # Quick Open needs ripgrep. Install them in one apt transaction per shard.
+      - name: Install native build and headless UI tools
+        run: sudo apt-get update && sudo apt-get install -y build-essential fonts-noto-cjk python3 ripgrep xvfb zsh
 
       - uses: ./.github/actions/install-node-dependencies
         with:

--- a/.github/workflows/golden-e2e-experiment.yml
+++ b/.github/workflows/golden-e2e-experiment.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       # Why: Linux golden E2E uses the same native install path as PR/release CI,

--- a/.github/workflows/hourly-mac-build.yml
+++ b/.github/workflows/hourly-mac-build.yml
@@ -137,6 +137,7 @@ jobs:
         if: steps.freshness.outputs.should_build == 'true'
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/linux-wayland-gpu-sandbox.yml
+++ b/.github/workflows/linux-wayland-gpu-sandbox.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       # Why: mirrors pr.yml so native module rebuilds do not use pnpm's

--- a/.github/workflows/mobile-android-release.yml
+++ b/.github/workflows/mobile-android-release.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Install dependencies

--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Install dependencies

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       # Why: the mobile typecheck imports shared types from ../src/shared, and

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -866,6 +866,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       # Why: Linux terminal golden E2E uses the same native install path as
@@ -1081,6 +1082,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       # Why: keep the non-blocking evidence lane on the same Linux native
@@ -1195,6 +1197,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/release-mac-build.yml
+++ b/.github/workflows/release-mac-build.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/terminal-ime-e2e.yml
+++ b/.github/workflows/terminal-ime-e2e.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Use external node-gyp to avoid pnpm bundled copy

--- a/.github/workflows/terminal-perf.yml
+++ b/.github/workflows/terminal-perf.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       # Why: this scheduled/manual workflow uses the same native install path as

--- a/.github/workflows/win-crash-survival-e2e.yml
+++ b/.github/workflows/win-crash-survival-e2e.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/win-update-e2e.yml
+++ b/.github/workflows/win-update-e2e.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       # Why: the harness only needs its runtime deps (the Playwright Electron

--- a/.github/workflows/win-update-survival-e2e.yml
+++ b/.github/workflows/win-update-survival-e2e.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Install dependencies

--- a/.github/workflows/windows-signing-rehearsal.yml
+++ b/.github/workflows/windows-signing-rehearsal.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/windows-terminal-restart-e2e.yml
+++ b/.github/workflows/windows-terminal-restart-e2e.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
+          version: 10.24.0
           run_install: false
 
       - name: Setup Node.js

--- a/config/scripts/pr-e2e-gate-contract.test.mjs
+++ b/config/scripts/pr-e2e-gate-contract.test.mjs
@@ -139,9 +139,9 @@ describe('PR E2E gate contract', () => {
     expect(e2eWorkflow.jobs['changed-e2e'].if).toBe("inputs.test_files != ''")
     expect(e2eWorkflow.jobs['changed-e2e'].strategy).toBeUndefined()
     expect(e2eWorkflow.jobs.e2e.strategy.matrix.include).toEqual(
-      Array.from({ length: 12 }, (_, index) => ({
-        shard: `${index + 1}/12`,
-        shard_name: `${index + 1}-of-12`
+      Array.from({ length: 14 }, (_, index) => ({
+        shard: `${index + 1}/14`,
+        shard_name: `${index + 1}-of-14`
       }))
     )
     const changedRun = e2eWorkflow.jobs['changed-e2e'].steps.find(

--- a/config/scripts/pr-e2e-gate-contract.test.mjs
+++ b/config/scripts/pr-e2e-gate-contract.test.mjs
@@ -138,6 +138,12 @@ describe('PR E2E gate contract', () => {
     expect(e2eWorkflow.jobs.e2e.if).toBe("inputs.test_files == ''")
     expect(e2eWorkflow.jobs['changed-e2e'].if).toBe("inputs.test_files != ''")
     expect(e2eWorkflow.jobs['changed-e2e'].strategy).toBeUndefined()
+    expect(e2eWorkflow.jobs.e2e.strategy.matrix.include).toEqual(
+      Array.from({ length: 12 }, (_, index) => ({
+        shard: `${index + 1}/12`,
+        shard_name: `${index + 1}-of-12`
+      }))
+    )
     const changedRun = e2eWorkflow.jobs['changed-e2e'].steps.find(
       (step) => step.name === 'Run changed E2E specs'
     )

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -232,6 +232,23 @@ describe('PR workflow parallelism', () => {
     expect(steps[requestedNodeIndex].with.cache).toBe('pnpm')
   })
 
+  it('pins every direct pnpm setup to the repository package-manager version', () => {
+    const packageManagerVersion = /^pnpm@([^+]+)/.exec(packageJson.packageManager)?.[1]
+    const directSetups = globSync('.github/workflows/*.yml').flatMap((workflowPath) => {
+      const parsed = parse(readFileSync(workflowPath, 'utf8'))
+      return Object.values(parsed.jobs ?? {}).flatMap((job) =>
+        (job.steps ?? [])
+          .filter((step) => step.uses === 'pnpm/action-setup@v6')
+          .map((step) => ({ workflowPath, step }))
+      )
+    })
+
+    expect(directSetups.length).toBeGreaterThan(0)
+    for (const { workflowPath, step } of directSetups) {
+      expect(step.with?.version, workflowPath).toBe(packageManagerVersion)
+    }
+  })
+
   it('restores Electron downloads before preparing the package runtime', () => {
     const steps = workflow.jobs.package.steps
     const cacheIndex = steps.findIndex((step) => step.name === 'Cache electron-builder downloads')


### PR DESCRIPTION
## Summary

- Pin every direct `pnpm/action-setup@v6` caller to the repository-supported pnpm 10.24.0.
- Add a workflow contract that keeps direct setup actions equal to `package.json#packageManager`.
- Rebalance scheduled Playwright from 10 to 14 shards without changing test coverage or per-run worker count.
- Install E2E native/headless apt dependencies in one transaction per shard.

## Why pnpm 10

The repository still declares pnpm 10.24.0. pnpm 11/12 require a real configuration migration (`package.json#pnpm`, build allowlists, environment-variable semantics), so silently running those versions in CI is incorrect. Explicit pinning removes the observed install-11-then-downgrade path without broadening scope.

## Playwright evidence

Analyzed 14 scheduled full-suite runs from the last week. Mean shard durations were:

`1 25.5m, 2 24.3m, 3 24.3m, 4 27.8m, 5 25.4m, 6 18.3m, 7 26.8m, 8 21.1m, 9 30.0m, 10 22.0m`.

A full 12-way trial still left one shard at the 30-minute cap. The final 14-way validation run `33246201299` completed every shard without a timeout; the slowest shard finished in 26m39s. Product E2E failures remain visible and unchanged.

## Testing

- Focused workflow contracts: 75 passed.
- Full 14-shard workflow dispatch: no timeout/cancellation from shard overload.
- Changed-code quality: 0 new findings.
- `git diff --check`: clean.
- `actionlint` reported only pre-existing custom-runner-label and shellcheck warnings; no errors in the changed expressions.