### PR TITLE
perf(markdown): skip unmatched list tokenizer scans

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,7 @@
     "@tiptap/extension-details": "^3.22.5",
     "@tiptap/extension-image": "^3.22.5",
     "@tiptap/extension-link": "^3.22.5",
+    "@tiptap/extension-list": "^3.22.5",
     "@tiptap/extension-mathematics": "3.22.5",
     "@tiptap/extension-placeholder": "^3.22.5",
     "@tiptap/extension-table": "3.22.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       '@tiptap/extension-link':
         specifier: ^3.22.5
         version: 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-list':
+        specifier: ^3.22.5
+        version: 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
       '@tiptap/extension-mathematics':
         specifier: 3.22.5
         version: 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(katex@0.16.45)

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -33,6 +33,7 @@ import { createRichMarkdownAnnotationHighlightExtension } from './rich-markdown-
 import type { RichMarkdownEditorCodec } from './rich-markdown-source-transport'
 import { createRichMarkdownHtmlSuperscriptLink } from './rich-markdown-html-superscript-link'
 import type { RichMarkdownHtmlSuperscriptLinkContext } from './rich-markdown-html-superscript-link-context'
+import { RichMarkdownOrderedList } from './rich-markdown-ordered-list'
 import { RichMarkdownTaskList } from './rich-markdown-task-list'
 
 const lowlight = createLowlight(common)
@@ -70,7 +71,8 @@ export function createRichMarkdownExtensions({
     StarterKit.configure({
       link: false,
       code: false,
-      codeBlock: false
+      codeBlock: false,
+      orderedList: false
     }),
     RichMarkdownCode,
     CodeBlockLowlight.extend({
@@ -195,6 +197,7 @@ export function createRichMarkdownExtensions({
     }).configure({
       allowBase64: true
     }),
+    RichMarkdownOrderedList,
     RichMarkdownTaskList,
     TaskItem.configure({
       nested: true

--- a/src/renderer/src/components/editor/rich-markdown-list-tokenizers.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-list-tokenizers.test.ts
@@ -1,0 +1,62 @@
+import type { MarkdownLexerConfiguration, MarkdownTokenizer } from '@tiptap/core'
+import { OrderedList } from '@tiptap/extension-list'
+import TaskList from '@tiptap/extension-task-list'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RichMarkdownOrderedList } from './rich-markdown-ordered-list'
+import { RichMarkdownTaskList } from './rich-markdown-task-list'
+
+const lexer: MarkdownLexerConfiguration = {
+  inlineTokens: (src) => [{ type: 'text', raw: src, text: src }],
+  blockTokens: (src) => [{ type: 'paragraph', raw: src, text: src }]
+}
+
+function getTokenizer(extension: typeof OrderedList | typeof TaskList): MarkdownTokenizer {
+  return extension.config.markdownTokenizer as MarkdownTokenizer
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('rich markdown list tokenizers', () => {
+  it.each([
+    ['ordered', RichMarkdownOrderedList, OrderedList],
+    ['task', RichMarkdownTaskList, TaskList]
+  ] as const)('skips the %s base tokenizer for nonmatching source', (_name, guarded, base) => {
+    const baseTokenizer = getTokenizer(base)
+    const tokenize = vi.spyOn(baseTokenizer, 'tokenize')
+    const source = `# Heading\n\n${'Paragraph content.\n'.repeat(10_000)}`
+
+    expect(getTokenizer(guarded).tokenize(source, [], lexer)).toBeUndefined()
+    expect(tokenize).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['ordered', RichMarkdownOrderedList, OrderedList, '3. third\n4. fourth\n'],
+    ['task', RichMarkdownTaskList, TaskList, '- [x] done\n- [ ] todo\n']
+  ] as const)(
+    'calls the %s base tokenizer once for matching source',
+    (_name, guarded, base, source) => {
+      const tokenize = vi.spyOn(getTokenizer(base), 'tokenize')
+
+      expect(getTokenizer(guarded).tokenize(source, [], lexer)).toBeTruthy()
+      expect(tokenize).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('preserves nested ordered-list tokens', () => {
+    const source = '3. parent\n   1. child\n   2. child two\n4. sibling\n'
+
+    expect(getTokenizer(RichMarkdownOrderedList).tokenize(source, [], lexer)).toEqual(
+      getTokenizer(OrderedList).tokenize(source, [], lexer)
+    )
+  })
+
+  it('preserves nested task-list tokens', () => {
+    const source = '- [ ] parent\n  - [x] child\n- [x] sibling\n'
+
+    expect(getTokenizer(RichMarkdownTaskList).tokenize(source, [], lexer)).toEqual(
+      getTokenizer(TaskList).tokenize(source, [], lexer)
+    )
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-ordered-list.ts
+++ b/src/renderer/src/components/editor/rich-markdown-ordered-list.ts
@@ -1,0 +1,17 @@
+import type { MarkdownTokenizer } from '@tiptap/core'
+import { OrderedList } from '@tiptap/extension-list'
+
+const baseTokenizer = OrderedList.config.markdownTokenizer as MarkdownTokenizer
+
+export const RichMarkdownOrderedList = OrderedList.extend({
+  markdownTokenizer: {
+    ...baseTokenizer,
+    tokenize(src, tokens, lexer) {
+      // Why: the base tokenizer scans the full remaining source before rejecting a non-list.
+      if (typeof baseTokenizer.start === 'function' && baseTokenizer.start(src) !== 0) {
+        return undefined
+      }
+      return baseTokenizer.tokenize(src, tokens, lexer)
+    }
+  }
+})

--- a/src/renderer/src/components/editor/rich-markdown-task-list.ts
+++ b/src/renderer/src/components/editor/rich-markdown-task-list.ts
@@ -27,6 +27,10 @@ export const RichMarkdownTaskList = TaskList.extend({
   markdownTokenizer: {
     ...baseTokenizer,
     tokenize(src, tokens, lexer) {
+      // Why: the base tokenizer scans the full remaining source before rejecting a non-list.
+      if (typeof baseTokenizer.start === 'function' && baseTokenizer.start(src) !== 0) {
+        return undefined
+      }
       const token = baseTokenizer.tokenize(src, tokens, lexer)
       if (token) {
         normalizeTaskListToken(token, lexer)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 |

<!-- /orca-pr-loc -->

## ELI5

Large Markdown documents were repeatedly splitting the entire remaining file just to decide that ordinary text was not an ordered or task list. This adds a cheap exact-match check first, so the expensive tokenizer only runs when a list actually starts at the current position.

## What Changed

- Guard ordered-list and task-list tokenizers with their existing start predicates.
- Replace the starter-kit ordered-list registration with an equivalent guarded extension.
- Add focused coverage for nonmatching fast paths, matching inputs, and nested-list token parity.

## Why

The list tokenizers scan the full remaining source before rejecting non-list content. Repeating that work at each block boundary makes rich-editor startup approximately quadratic for large documents. Reusing the tokenizer-owned start predicate removes the redundant scans without changing matching syntax or rendered output.

## Linked Issue

Follow-up performance work for #17008.

## Visual Proof

N/A — there is no visual or interaction change. The same 305 KB fixture rendered the same 533 headings, bullet lists, tables, and syntax-highlighted code blocks before and after.

## Testing

Measured in the built Electron app on macOS with the same profile and 305 KB fixture (533 code blocks):

| Rich-open metric | Baseline | After | Change |
| --- | ---: | ---: | ---: |
| Cold elapsed time | 2,039 ms | 1,053 ms | -48% |
| Warm elapsed time, median of 3 | 1,425 ms | 679 ms | -52% |
| Warm primary long task, median of 3 | 1,306 ms | 570 ms | -56% |

- [x] Manually tested through the real Source → Rich Editor surface with Electron CDP.
- [x] Verified all 533 code blocks remain highlighted, including the first and last blocks.
- [x] Added tokenizer fast-path and nested-token parity tests.
- [x] `pnpm test` on 5 editor suites: 93 tests passed.
- [x] `pnpm tc`.
- [x] `pnpm run check:code-quality:changed`.
- [x] `pnpm run build:electron-vite`.
- [x] Frozen-lockfile install validation.

## Review

No IPC, remote wire, filesystem, SSH, mobile, or platform-specific behavior changes. Matching list inputs still execute the original tokenizer.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why, including ELI5.
- [x] Visual proof is N/A because rendered behavior is unchanged.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered and not affected.
- [ ] Full `pnpm lint`, full `pnpm test`, and full `pnpm build` left to CI; targeted local checks are listed above.

## Regression Proof

- The 305 KB Electron fixture renders the same 533 code blocks and the same first/last-block highlighting before and after.
- Focused tests cover both rejected non-list inputs and accepted ordered/task/nested-list inputs.
- Five editor suites pass: 93 tests total, alongside typecheck, changed-code quality, and the production Electron build.

## No-user-regression signoff

No user-visible behavior is removed or delayed. Inputs that can start a list still run the original tokenizer; only inputs that cannot match skip its full-source scan. Markdown syntax, rendered output, editor commands, document limits, settings, persistence, IPC, remote, SSH, and platform behavior are unchanged.

## Merge risk

**Low.** The production change is a narrow guard around existing tokenizer entry points. The main risk is an incomplete start predicate rejecting valid list syntax; matching-input, nested-list, and rendered-fixture parity tests cover that boundary. There is no data migration or wire change, and the change is independently revertible.