### PR TITLE
fix(cli): resolve --workspace-status by column name

### DIFF
--- a/skill-guides/orca-cli.md
+++ b/skill-guides/orca-cli.md
@@ -115,7 +115,7 @@ ORCA worktree create --name child-task --agent codex --prompt "hi" --json
 ORCA worktree create --name independent-task --no-parent --json
 ORCA worktree set --worktree id:<repoId>::<worktreePath> --display-name "My Task" --json
 ORCA worktree set --worktree active --comment "reproduced bug; testing fix" --json
-ORCA worktree set --worktree active --workspace-status in-review --json
+ORCA worktree set --worktree active --workspace-status "In review" --json
 ORCA worktree rm --worktree id:<repoId>::<worktreePath> --force --json
 ```
 
@@ -166,7 +166,7 @@ ORCA worktree set --worktree active --comment "fix implemented; running integrat
 
 Update after meaningful state changes such as repro, fix, validation, handoff, or blocker. Keep comments short/current; failures are best-effort unless Orca state was requested.
 
-Card status uses `--workspace-status <id>`; defaults are `todo`, `in-progress`, `in-review`, `completed`.
+Card status uses `--workspace-status <column>`: pass the board column name (`--workspace-status "Human review"`) or its configured id. An unknown value is rejected and the error lists the available columns.
 
 ## Terminals
 

--- a/src/cli/index-worktree-set.test.ts
+++ b/src/cli/index-worktree-set.test.ts
@@ -391,4 +391,34 @@ describe('orca cli worktree awareness', () => {
       noParent: false
     })
   })
+  it('passes a board column name through worktree.set for the host to resolve', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_set_status_name', {
+        worktree: {
+          ...buildWorktree('/tmp/repo/child', 'feature/child'),
+          workspaceStatus: 'status-5-2'
+        }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      [
+        'worktree',
+        'set',
+        '--worktree',
+        'id:repo::/tmp/repo/child',
+        '--workspace-status',
+        'Human review',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenCalledWith(
+      'worktree.set',
+      expect.objectContaining({ workspaceStatus: 'Human review' })
+    )
+  })
 })

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -137,7 +137,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['worktree', 'set'],
     summary: 'Update Orca metadata for a worktree',
     usage:
-      'orca worktree set --worktree <selector> [--display-name <name>] [--issue <number|null>] [--linear-issue <identifier-or-url|null>] [--comment <text>] [--workspace-status <id>] [--parent-worktree <selector>|--no-parent] [--json]',
+      'orca worktree set --worktree <selector> [--display-name <name>] [--issue <number|null>] [--linear-issue <identifier-or-url|null>] [--comment <text>] [--workspace-status <column>] [--parent-worktree <selector>|--no-parent] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'worktree',
@@ -150,7 +150,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'no-parent'
     ],
     notes: [
-      'Workspace status ids match the board columns (defaults: todo, in-progress, in-review, completed); custom statuses use their configured id.',
+      'Pass the board column name, e.g. --workspace-status "Human review"; its configured id also works. An unknown value is rejected with the available columns listed.',
       'Pass --linear-issue null to clear the Linear issue link.'
     ],
     examples: [

--- a/src/main/runtime/rpc/methods/workspace-status-resolution.ts
+++ b/src/main/runtime/rpc/methods/workspace-status-resolution.ts
@@ -1,0 +1,24 @@
+import { InvalidArgumentError } from '../core'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { WorkspaceStatus } from '../../../../shared/worktree/types'
+import {
+  normalizeWorkspaceStatuses,
+  resolveWorkspaceStatusInput
+} from '../../../../shared/workspace-statuses'
+
+// Why: the board catalog lives in main-side UI state, so CLI and remote callers can
+// only send a name; resolve it here rather than persisting an unmatched id silently.
+export function resolveRpcWorkspaceStatus(
+  runtime: OrcaRuntimeService,
+  value: string | undefined
+): WorkspaceStatus | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  const statuses = normalizeWorkspaceStatuses(runtime.getUIState().workspaceStatuses)
+  const resolved = resolveWorkspaceStatusInput(value, statuses)
+  if (!resolved.ok) {
+    throw new InvalidArgumentError(resolved.message)
+  }
+  return resolved.status
+}

--- a/src/main/runtime/rpc/methods/workspace-status-resolution.ts
+++ b/src/main/runtime/rpc/methods/workspace-status-resolution.ts
@@ -6,8 +6,7 @@ import {
   resolveWorkspaceStatusInput
 } from '../../../../shared/workspace-statuses'
 
-// Why: the board catalog lives in main-side UI state, so CLI and remote callers can
-// only send a name; resolve it here rather than persisting an unmatched id silently.
+// Why: the board catalog lives in main-side UI state, so only the host can resolve a name.
 export function resolveRpcWorkspaceStatus(
   runtime: OrcaRuntimeService,
   value: string | undefined

--- a/src/main/runtime/rpc/methods/worktree-workspace-status.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-workspace-status.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RpcDispatcher } from '../dispatcher'
+import type { RpcRequest } from '../core'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { WORKTREE_METHODS } from './worktree'
+
+const repo = {
+  id: 'repo-1',
+  path: '/workspace/repo',
+  displayName: 'repo',
+  badgeColor: '#000',
+  addedAt: 1,
+  kind: 'git' as const,
+  executionHostId: 'ssh:ssh-target-1' as const
+}
+
+function makeRequest(method: string, params?: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+const passthroughDedupe = <T>(_repo: string, _id: string | undefined, run: () => Promise<T>) =>
+  run()
+
+describe('worktree RPC workspace status resolution', () => {
+  const board = [
+    { id: 'todo', label: 'Todo' },
+    { id: 'status-5-2', label: 'QA' }
+  ]
+
+  function makeRuntime(overrides: Record<string, unknown> = {}): OrcaRuntimeService {
+    return {
+      getRuntimeId: () => 'test-runtime',
+      dedupeWorktreeCreate: passthroughDedupe,
+      showRepo: vi.fn().mockResolvedValue(repo),
+      getUIState: vi.fn(() => ({ workspaceStatuses: board })),
+      createManagedWorktree: vi.fn().mockResolvedValue({ worktree: { id: 'wt-1' } }),
+      updateManagedWorktreeMeta: vi.fn().mockResolvedValue({ id: 'wt-1' }),
+      ...overrides
+    } as unknown as OrcaRuntimeService
+  }
+
+  it('sets a renamed column by its name', async () => {
+    const runtime = makeRuntime()
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('worktree.set', { worktree: 'id:wt-1', workspaceStatus: 'QA' })
+    )
+
+    expect(response).toMatchObject({ ok: true })
+    expect(runtime.updateManagedWorktreeMeta).toHaveBeenCalledWith(
+      'id:wt-1',
+      expect.objectContaining({ workspaceStatus: 'status-5-2' })
+    )
+  })
+
+  it('creates a workspace in a renamed column by its name', async () => {
+    const runtime = makeRuntime()
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    await dispatcher.dispatch(
+      makeRequest('worktree.create', { repo: 'repo-1', name: 'feature', workspaceStatus: 'qa' })
+    )
+
+    expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceStatus: 'status-5-2' })
+    )
+  })
+
+  it('rejects an unknown workspace status instead of storing it', async () => {
+    const runtime = makeRuntime()
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('worktree.set', { worktree: 'id:wt-1', workspaceStatus: 'nope' })
+    )
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: { code: 'invalid_argument', message: expect.stringContaining('status-5-2 (QA)') }
+    })
+    expect(runtime.updateManagedWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('leaves the workspace status alone when the caller omits it', async () => {
+    const runtime = makeRuntime()
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('worktree.set', { worktree: 'id:wt-1', comment: 'hi' })
+    )
+
+    expect(response).toMatchObject({ ok: true })
+    expect(runtime.updateManagedWorktreeMeta).toHaveBeenCalledWith(
+      'id:wt-1',
+      expect.objectContaining({ workspaceStatus: undefined })
+    )
+  })
+})

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -81,6 +81,7 @@ describe('worktree RPC methods', () => {
       getRuntimeId: () => 'test-runtime',
       dedupeWorktreeCreate: passthroughDedupe,
       showRepo: vi.fn().mockResolvedValue(repo),
+      getUIState: vi.fn(() => ({})),
       createManagedWorktree: vi.fn().mockResolvedValue({ worktree: { id: 'wt-1' } })
     } as unknown as OrcaRuntimeService
     const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -7,6 +7,7 @@ import { buildCliWorkspaceProvenance } from '../../../../shared/cli-workspace-pr
 import { defineMethod, type RpcMethod } from '../core'
 import { buildManagedWorktreeCreateArgs } from './worktree-create-args'
 import { resolvePairedCallerHostId } from './paired-caller-host-id'
+import { resolveRpcWorkspaceStatus } from './workspace-status-resolution'
 import { resolveRuntimeNavigationTarget } from '../../../../shared/runtime-navigation'
 import { resolveRpcWorkspaceCreatorProvenance } from '../workspace-creator-context'
 import { WorktreeCreate, WorktreePrefetchCreateBase } from './worktree-create-schemas'
@@ -80,6 +81,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
       // worktree instead of spawning a duplicate. No key (desktop/CLI) runs plainly.
       context.runtime.dedupeWorktreeCreate(params.repo, params.clientMutationId, async () => {
         const { runtime } = context
+        const workspaceStatus = resolveRpcWorkspaceStatus(runtime, params.workspaceStatus)
         const repo = await runtime.showRepo(params.repo)
         const automationProvenance = resolveAutomationWorkspaceProvenance({
           authority: runtime,
@@ -92,7 +94,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
         try {
           const result = await runtime.createManagedWorktree(
             buildManagedWorktreeCreateArgs(
-              params,
+              { ...params, workspaceStatus },
               {
                 automationProvenance,
                 cliProvenance: buildCliWorkspaceProvenance(params.cliProvenanceRequest, {
@@ -157,7 +159,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
         sparseBaseRef: params.sparseBaseRef,
         sparsePresetId: params.sparsePresetId,
         baseRef: params.baseRef,
-        workspaceStatus: params.workspaceStatus,
+        workspaceStatus: resolveRpcWorkspaceStatus(runtime, params.workspaceStatus),
         pushTarget: params.pushTarget,
         diffComments: params.diffComments,
         mobileDiffReview: params.mobileDiffReview,

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -21,10 +21,7 @@ import {
   selectColdParkedTerminalTabs
 } from './terminal-hidden-view-parking'
 import type { ParkVerdictFlipRecord } from './terminal-park-verdict-flip-telemetry'
-import {
-  haveSameTerminalTabIds,
-  useTerminalParkVerdictPin
-} from './use-terminal-park-verdict-pin'
+import { haveSameTerminalTabIds, useTerminalParkVerdictPin } from './use-terminal-park-verdict-pin'
 import { withholdUnparkableTerminalTabs } from './terminal-cold-park-withheld-tabs'
 import { getTerminalParkingPolicyOverrides } from './terminal-parking-e2e-overrides'
 import {

--- a/src/shared/workspace-statuses.test.ts
+++ b/src/shared/workspace-statuses.test.ts
@@ -6,7 +6,8 @@ import {
   clampWorkspaceBoardColumnWidth,
   cloneDefaultWorkspaceStatuses,
   normalizePersistedWorkspaceStatuses,
-  normalizeWorkspaceStatuses
+  normalizeWorkspaceStatuses,
+  resolveWorkspaceStatusInput
 } from './workspace-statuses'
 
 describe('workspace status visuals', () => {
@@ -296,5 +297,73 @@ describe('workspace status visuals', () => {
     expect(clampWorkspaceBoardColumnWidth(100)).toBe(WORKSPACE_BOARD_COLUMN_WIDTH_MIN)
     expect(clampWorkspaceBoardColumnWidth(321.6)).toBe(322)
     expect(clampWorkspaceBoardColumnWidth(900)).toBe(WORKSPACE_BOARD_COLUMN_WIDTH_MAX)
+  })
+})
+
+describe('workspace status input resolution', () => {
+  const renamedBoard = [
+    { id: 'todo', label: 'Todo' },
+    { id: 'status-5-2', label: 'QA' },
+    { id: 'status-6', label: 'Human review' }
+  ]
+
+  it('resolves a status id', () => {
+    expect(resolveWorkspaceStatusInput('status-5-2', renamedBoard)).toEqual({
+      ok: true,
+      status: 'status-5-2'
+    })
+  })
+
+  it.each(['qa', 'QA', ' qa ', 'Human review', 'human-review', 'HUMAN-REVIEW'])(
+    'resolves the column named %s by label',
+    (input) => {
+      const resolved = resolveWorkspaceStatusInput(input, renamedBoard)
+
+      expect(resolved.ok).toBe(true)
+      expect(resolved).toHaveProperty('status')
+    }
+  )
+
+  it('resolves a renamed column by its label rather than its stale id', () => {
+    expect(resolveWorkspaceStatusInput('qa', renamedBoard)).toEqual({
+      ok: true,
+      status: 'status-5-2'
+    })
+  })
+
+  it('prefers an exact id over another column whose label slugs the same', () => {
+    const statuses = [
+      { id: 'qa', label: 'Quality' },
+      { id: 'qa-2', label: 'QA' }
+    ]
+
+    expect(resolveWorkspaceStatusInput('qa', statuses)).toEqual({ ok: true, status: 'qa' })
+  })
+
+  it('refuses a label that matches more than one column', () => {
+    const statuses = [
+      { id: 'first', label: 'QA' },
+      { id: 'second', label: 'QA!' }
+    ]
+
+    const resolved = resolveWorkspaceStatusInput('qa', statuses)
+
+    expect(resolved.ok).toBe(false)
+    expect(resolved).toHaveProperty('message', expect.stringContaining('first (QA)'))
+    expect(resolved).toHaveProperty('message', expect.stringContaining('second (QA!)'))
+  })
+
+  it('refuses an unknown status and lists every column', () => {
+    const resolved = resolveWorkspaceStatusInput('nope', renamedBoard)
+
+    expect(resolved.ok).toBe(false)
+    expect(resolved).toHaveProperty(
+      'message',
+      expect.stringContaining('todo (Todo), status-5-2 (QA), status-6 (Human review)')
+    )
+  })
+
+  it.each(['', '   '])('refuses a blank status', (input) => {
+    expect(resolveWorkspaceStatusInput(input, renamedBoard).ok).toBe(false)
   })
 })

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -67,7 +67,7 @@ function sanitizeWorkspaceStatusLabel(value: unknown, fallback: string): string 
   return trimmed ? trimmed.slice(0, MAX_STATUS_LABEL_LENGTH) : fallback
 }
 
-function slugWorkspaceStatusLabel(label: string): string {
+export function slugWorkspaceStatusLabel(label: string): string {
   const slug = label
     .trim()
     .toLowerCase()
@@ -242,6 +242,49 @@ export function clampWorkspaceBoardColumnWidth(value: unknown): number {
     WORKSPACE_BOARD_COLUMN_WIDTH_MAX,
     Math.max(WORKSPACE_BOARD_COLUMN_WIDTH_MIN, Math.round(value))
   )
+}
+
+export type WorkspaceStatusResolution =
+  | { ok: true; status: WorkspaceStatus }
+  | { ok: false; message: string }
+
+function describeWorkspaceStatuses(statuses: readonly WorkspaceStatusDefinition[]): string {
+  return statuses.map((status) => `${status.id} (${status.label})`).join(', ')
+}
+
+// Why: a column keeps the id slugged from its label at creation time, so a renamed
+// column's id no longer resembles its name; accept the name as an alias for it.
+export function resolveWorkspaceStatusInput(
+  value: string,
+  statuses: readonly WorkspaceStatusDefinition[]
+): WorkspaceStatusResolution {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return {
+      ok: false,
+      message: `Workspace status is empty. Available: ${describeWorkspaceStatuses(statuses)}.`
+    }
+  }
+  const byId = statuses.find((status) => status.id === trimmed)
+  if (byId) {
+    return { ok: true, status: byId.id }
+  }
+  const slug = slugWorkspaceStatusLabel(trimmed)
+  const byLabel = statuses.filter((status) => slugWorkspaceStatusLabel(status.label) === slug)
+  const [onlyMatch] = byLabel
+  if (onlyMatch && byLabel.length === 1) {
+    return { ok: true, status: onlyMatch.id }
+  }
+  if (byLabel.length > 1) {
+    return {
+      ok: false,
+      message: `Workspace status "${trimmed}" matches more than one column: ${describeWorkspaceStatuses(byLabel)}. Pass the id instead.`
+    }
+  }
+  return {
+    ok: false,
+    message: `Unknown workspace status "${trimmed}". Available: ${describeWorkspaceStatuses(statuses)}.`
+  }
 }
 
 export function isWorkspaceStatusId(

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -252,8 +252,7 @@ function describeWorkspaceStatuses(statuses: readonly WorkspaceStatusDefinition[
   return statuses.map((status) => `${status.id} (${status.label})`).join(', ')
 }
 
-// Why: a column keeps the id slugged from its label at creation time, so a renamed
-// column's id no longer resembles its name; accept the name as an alias for it.
+// Why: a column's id is slugged from its label only at creation, so a rename leaves it stale.
 export function resolveWorkspaceStatusInput(
   value: string,
   statuses: readonly WorkspaceStatusDefinition[]
@@ -265,9 +264,8 @@ export function resolveWorkspaceStatusInput(
       message: `Workspace status is empty. Available: ${describeWorkspaceStatuses(statuses)}.`
     }
   }
-  const byId = statuses.find((status) => status.id === trimmed)
-  if (byId) {
-    return { ok: true, status: byId.id }
+  if (isWorkspaceStatusId(trimmed, statuses)) {
+    return { ok: true, status: trimmed }
   }
   const slug = slugWorkspaceStatusLabel(trimmed)
   const byLabel = statuses.filter((status) => slugWorkspaceStatusLabel(status.label) === slug)


### PR DESCRIPTION
#17119 

Instead of requiring a data-migration and changing the persisted workspaceStatus, I went resolving the label when calling form the CLI.

This has breaking changes: If a user submits a workspaceStatus that does not resolve to either an id or a label, Orca now throws, rather than silently accepting the invalid input.