### PR TITLE
test(e2e): wait for the host snapshot to hold the baseline before capturing it

### DIFF
--- a/tests/e2e/ssh-cold-hydration-gap-tab-seeding.spec.ts
+++ b/tests/e2e/ssh-cold-hydration-gap-tab-seeding.spec.ts
@@ -70,17 +70,57 @@ function findRemoteSnapshotPath(target: DockerSshRelayTarget): string | null {
   return listing.split('\n').find((line) => line.endsWith('.json')) ?? null
 }
 
-async function waitForUploadedRemoteSnapshot(target: DockerSshRelayTarget): Promise<string> {
+/** Tab ids the relay has actually committed, or null while no readable snapshot exists yet. */
+function readPersistedRemoteSnapshotTabIds(
+  target: DockerSshRelayTarget,
+  snapshotPath: string
+): string[] | null {
+  try {
+    const parsed = JSON.parse(
+      execDockerSshRelayTargetControlCommand(target, `cat ${snapshotPath}`)
+    ) as {
+      session?: { tabsByWorktreePath?: Record<string, { id?: unknown }[]> }
+    }
+    return Object.values(parsed.session?.tabsByWorktreePath ?? {})
+      .flat()
+      .map((tab) => tab?.id)
+      .filter((id): id is string => typeof id === 'string')
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Wait until the host snapshot actually holds every seeded tab, not merely until a file exists.
+ *
+ * Why content and not existence: the upload is a detached chain hung off the local session write
+ * (`use-app-session-persistence.ts`), so no barrier the test can await proves it landed, and the
+ * relay rewrites the file atomically — a short capture is a stale revision, never a torn one.
+ * Capturing on existence replays a revision that predates the baseline, and the client then
+ * applies that empty session as an authoritative replace, which is indistinguishable from the
+ * tab loss this spec exists to catch.
+ */
+async function waitForRemoteSnapshotHoldingTabs(
+  target: DockerSshRelayTarget,
+  tabIds: readonly string[]
+): Promise<string> {
   let snapshotPath: string | null = null
+  let persistedTabIds: string[] | null = null
   await expect
     .poll(
       () => {
         snapshotPath = findRemoteSnapshotPath(target)
-        return snapshotPath
+        persistedTabIds = snapshotPath
+          ? readPersistedRemoteSnapshotTabIds(target, snapshotPath)
+          : null
+        return tabIds.every((id) => persistedTabIds?.includes(id) === true)
       },
-      { timeout: 60_000, message: 'the relay never persisted a workspace snapshot' }
+      {
+        timeout: 60_000,
+        message: `the relay never persisted a snapshot holding the ${tabIds.length}-tab baseline`
+      }
     )
-    .not.toBeNull()
+    .toBe(true)
   return snapshotPath!
 }
 
@@ -168,7 +208,7 @@ test.describe('SSH cold hydration gap tab seeding', () => {
       await waitForSessionReady(firstLaunch.page)
       const remote = await connectAndSeedTabs(firstLaunch.page, target)
       expect(remote.tabIds).toHaveLength(BASELINE_TAB_COUNT)
-      const snapshotPath = await waitForUploadedRemoteSnapshot(target)
+      const snapshotPath = await waitForRemoteSnapshotHoldingTabs(target, remote.tabIds)
       await flushSessionBeforeQuit(firstLaunch.page, remote.targetId)
       await restart.close(app)
       app = null
@@ -237,7 +277,7 @@ test.describe('SSH cold hydration gap tab seeding', () => {
       await waitForSessionReady(firstLaunch.page)
       const remote = await connectAndSeedTabs(firstLaunch.page, target)
       expect(remote.tabIds).toHaveLength(BASELINE_TAB_COUNT)
-      await waitForUploadedRemoteSnapshot(target)
+      await waitForRemoteSnapshotHoldingTabs(target, remote.tabIds)
       await flushSessionBeforeQuit(firstLaunch.page, remote.targetId)
       await seeding.close(seedingApp)
       seedingApp = null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Fixes the `ssh-cold-hydration-gap-tab-seeding` spec so it captures the host snapshot only once that snapshot actually holds the tabs it is about to replay.

## ELI5

The test seeds three terminal tabs on a remote host, saves the copy of the workspace the host wrote down, quits, relaunches, and checks the three tabs come back. The catch: it only waited for the host's file to **exist**, never for the host to have finished writing the three tabs into it. When it grabbed the file too early it replayed a copy from **before** the tabs existed — an empty workspace — and the app then did exactly the right thing with an empty authoritative workspace: it replaced the tabs with none. The test reported `afterHydration=0` and looked like the product had lost your tabs. It hadn't. The test handed it nothing.

Now the test waits until the host's file actually lists all three tabs before capturing it.

## The mechanism

- The remote upload is **detached**: `use-app-session-persistence.ts` fires it off the local session write as `void localWrite.then(() => setForConnectedTargets(...))`. Nothing the spec can await proves it landed.
- The spec's pre-capture barrier, `flushSessionBeforeQuit`, waits on `window.api.session.get()` — the **local** write only.
- `waitForUploadedRemoteSnapshot` polled `ls`, i.e. **existence**, never contents.
- So closing the app could cut off the final upload, leaving the host file at a revision that predates the three-tab baseline.
- The relay writes that file atomically (`writeFileSync` to `.tmp` + `renameSync`, `workspace-session-handler.ts`), so a short capture is always a **stale revision**, never a torn one. That rules out a partial-write race and leaves exactly one cause.
- Replaying an empty session then places nothing, so nothing is reported unplaced, so the target hydrates cleanly and the replace-scoped apply writes zero tabs. That is correct behaviour for a genuinely empty host snapshot.

## This is not a deadline extension

Nothing was stuck. The upload is a real in-flight operation the spec waited **zero** time for. The new wait reuses the existing 60 s `expect.poll` budget — no timeout was raised, no retry added, no assertion weakened. The `afterHydration` expectation is untouched.

## Before / after

Who this affects: anyone whose pull request runs the `e2e / ssh docker watcher isolation` lane.

| | Before | After |
|---|---|---|
| Host snapshot lands before quit | Passes | Passes, unchanged |
| Final upload cut off by the quit | Fails late on `afterHydration=0`, reading as a product tab-loss regression, and costs a rerun | Waits for the snapshot to hold the baseline, then proceeds |
| Snapshot never holds the baseline | — | Fails at the capture, naming the missing baseline |

Both tests in the file used the existence-only barrier, so both get the content barrier.

## Measured rate

`e2e / ssh docker watcher isolation`, all attempts enumerated via `filter=all` (not just the latest, which hides runs re-run to green), 2026-08-27T00:00Z → 2026-08-29T08:40Z, 388 job records / 32 failures:

| spec | failures |
|---|---|
| `ssh-pi-compatible-agent-title` | 16 |
| `ssh-lost-kill-tab-resurrection` | 12 |
| `ssh-cold-hydration-gap-tab-seeding` | 5 |
| `ssh-startup-exec-readiness` | 2 |
| `ssh-port-forward-lifecycle` | 2 |

Four of the five cold-hydration failures are this signature (`:158`, `baseline=3 duringStall=3 afterHydration=0`, ~1.1 m each), the most recent at 2026-08-29T07:08Z. The fifth is an older revision of the spec.

## The 30 s multiplexer-timeout lead is refuted

`ssh-channel-multiplexer.ts` does carry a 30 s `REQUEST_TIMEOUT_MS`, but it is not what happens here. A timed-out `workspace.get` resolves `snapshot` to null, which takes the `phase: 'offline'` early return in `remote-workspace-target-sync.ts` — no apply, no replace, tabs stay at 3. The observed failure requires a **successful** apply of an **empty** snapshot. The absent timeout log line is consistent with that: no timeout occurred.

## Not verified locally

Docker is unavailable on the authoring machine, so neither Docker-SSH spec was run here; this rests on the CI record and on source reading. `pnpm tc` (all projects), `oxlint`, both focused plugin audits with `--deny-warnings`, `node config/scripts/check-changed-code-quality.mjs` (0 new findings across 1 file), the `pr-e2e-gate-contract` suite (37 passed), and `git diff --check` are all green. Local load average was 6–9 during those runs.

## Supersedes

#17031 diagnosed the same mechanism but asserted the capture **after** taking it, which renames the failure without removing it. This waits for the precondition instead, so the run passes. #17031 can be closed.
