### PR TITLE
fix(win32): ensure DACL allows renderer bootstrap in packaged installs

### DIFF
--- a/config/nsis/daemon-host-uninstall.nsh
+++ b/config/nsis/daemon-host-uninstall.nsh
@@ -27,6 +27,9 @@
 ; or protected DACL inheritance), Chromium renderer and GPU processes fail to
 ; start with STATUS_BREAKPOINT since their AppContainer cannot read the binaries.
 !macro customInstall
-  nsExec::Exec 'icacls "$INSTDIR" /grant *S-1-15-2-2:(OI)(CI)(RX)'
+  nsExec::Exec '"$SYSDIR\icacls.exe" "$INSTDIR" /grant *S-1-15-2-2:(OI)(CI)(RX)'
   Pop $0
+  ${If} $0 != "0"
+    DetailPrint "Failed to grant restricted AppContainer read access: $0"
+  ${EndIf}
 !macroend

--- a/config/nsis/daemon-host-uninstall.nsh
+++ b/config/nsis/daemon-host-uninstall.nsh
@@ -31,5 +31,8 @@
   Pop $0
   ${If} $0 != "0"
     DetailPrint "Failed to grant restricted AppContainer read access: $0"
+    ${IfNot} ${Silent}
+      MessageBox MB_OK|MB_ICONEXCLAMATION "Orca was installed, but Windows could not finish configuring access to its files (error $0). Orca may not start; retry the installer or contact support."
+    ${EndIf}
   ${EndIf}
 !macroend

--- a/config/nsis/daemon-host-uninstall.nsh
+++ b/config/nsis/daemon-host-uninstall.nsh
@@ -21,3 +21,11 @@
     RMDir /r "$LOCALAPPDATA\Orca\daemon-host"
   ${endIf}
 !macroend
+
+; Why: ensure the install directory carries an explicit read/execute grant for
+; ALL RESTRICTED APPLICATION PACKAGES. When missing (e.g. from custom unpacking
+; or protected DACL inheritance), Chromium renderer and GPU processes fail to
+; start with STATUS_BREAKPOINT since their AppContainer cannot read the binaries.
+!macro customInstall
+  nsExec::Exec 'icacls "$INSTDIR" /grant *S-1-15-2-2:(OI)(CI)(RX)'
+!macroend

--- a/config/nsis/daemon-host-uninstall.nsh
+++ b/config/nsis/daemon-host-uninstall.nsh
@@ -28,4 +28,5 @@
 ; start with STATUS_BREAKPOINT since their AppContainer cannot read the binaries.
 !macro customInstall
   nsExec::Exec 'icacls "$INSTDIR" /grant *S-1-15-2-2:(OI)(CI)(RX)'
+  Pop $0
 !macroend

--- a/config/nsis/daemon-host-uninstall.test.ts
+++ b/config/nsis/daemon-host-uninstall.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('daemon-host-uninstall.nsh', () => {
+  it('implements an idempotent DACL repair without aggressive sweeping flags', () => {
+    const source = readFileSync(join(__dirname, 'daemon-host-uninstall.nsh'), 'utf-8')
+    
+    // Must contain the well-known S-1-15-2-2 SID to fix the DACL cluster
+    expect(source).toContain('icacls "$INSTDIR" /grant *S-1-15-2-2:(OI)(CI)(RX)')
+    
+    // Must NOT contain sweeping or destructive flags
+    expect(source).not.toMatch(/\/T\b/i)
+    expect(source).not.toMatch(/\/reset\b/i)
+    expect(source).not.toMatch(/\(F\)|\(M\)|\(W\)/)
+    expect(source).not.toMatch(/ALL APPLICATION PACKAGES/i) // No English principal name
+  })
+})

--- a/config/scripts/nsis-daemon-host-uninstall.test.ts
+++ b/config/scripts/nsis-daemon-host-uninstall.test.ts
@@ -11,7 +11,11 @@ describe('daemon-host-uninstall.nsh', () => {
       'nsExec::Exec \'"$SYSDIR\\icacls.exe" "$INSTDIR" /grant *S-1-15-2-2:(OI)(CI)(RX)\''
     )
     expect(installMacro).toMatch(/nsExec::Exec[\s\S]*?Pop \$0/)
-    expect(installMacro).toMatch(/\$\{If\} \$0 != "0"[\s\S]*?DetailPrint[\s\S]*?\$\{EndIf\}/)
+    expect(installMacro).toMatch(/\$\{If\} \$0 != "0"[\s\S]*?DetailPrint/)
+    expect(installMacro).toMatch(
+      /\$\{IfNot\} \$\{Silent\}[\s\S]*?MessageBox MB_OK\|MB_ICONEXCLAMATION[\s\S]*?\$\{EndIf\}/
+    )
+    expect(installMacro).not.toMatch(/\b(?:Abort|Quit|SetErrorLevel)\b/)
     expect(installMacro).not.toMatch(/\/T\b|\/reset\b|\(F\)|\(M\)|\(W\)/i)
     expect(installMacro).not.toMatch(/ALL APPLICATION PACKAGES/i)
   })

--- a/config/scripts/nsis-daemon-host-uninstall.test.ts
+++ b/config/scripts/nsis-daemon-host-uninstall.test.ts
@@ -3,16 +3,16 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 describe('daemon-host-uninstall.nsh', () => {
-  it('implements an idempotent DACL repair without aggressive sweeping flags', () => {
+  it('uses the system icacls with a bounded least-privilege grant', () => {
     const source = readFileSync(join(__dirname, '../nsis/daemon-host-uninstall.nsh'), 'utf-8')
-    
-    // Must contain the well-known S-1-15-2-2 SID to fix the DACL cluster
-    expect(source).toContain('icacls "$INSTDIR" /grant *S-1-15-2-2:(OI)(CI)(RX)')
-    
-    // Must NOT contain sweeping or destructive flags
-    expect(source).not.toMatch(/\/T\b/i)
-    expect(source).not.toMatch(/\/reset\b/i)
-    expect(source).not.toMatch(/\(F\)|\(M\)|\(W\)/)
-    expect(source).not.toMatch(/ALL APPLICATION PACKAGES/i) // No English principal name
+    const installMacro = source.match(/!macro customInstall[\s\S]*?!macroend/)?.[0]
+
+    expect(installMacro).toContain(
+      'nsExec::Exec \'"$SYSDIR\\icacls.exe" "$INSTDIR" /grant *S-1-15-2-2:(OI)(CI)(RX)\''
+    )
+    expect(installMacro).toMatch(/nsExec::Exec[\s\S]*?Pop \$0/)
+    expect(installMacro).toMatch(/\$\{If\} \$0 != "0"[\s\S]*?DetailPrint[\s\S]*?\$\{EndIf\}/)
+    expect(installMacro).not.toMatch(/\/T\b|\/reset\b|\(F\)|\(M\)|\(W\)/i)
+    expect(installMacro).not.toMatch(/ALL APPLICATION PACKAGES/i)
   })
 })

--- a/config/scripts/nsis-daemon-host-uninstall.test.ts
+++ b/config/scripts/nsis-daemon-host-uninstall.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 describe('daemon-host-uninstall.nsh', () => {
   it('implements an idempotent DACL repair without aggressive sweeping flags', () => {
-    const source = readFileSync(join(__dirname, 'daemon-host-uninstall.nsh'), 'utf-8')
+    const source = readFileSync(join(__dirname, '../nsis/daemon-host-uninstall.nsh'), 'utf-8')
     
     // Must contain the well-known S-1-15-2-2 SID to fix the DACL cluster
     expect(source).toContain('icacls "$INSTDIR" /grant *S-1-15-2-2:(OI)(CI)(RX)')


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 |

<!-- /orca-pr-loc -->

## Description

Fix the reproduced **poisoned install-DACL** crash cluster on Windows. The NSIS install/update hook grants the locale-independent `ALL RESTRICTED APPLICATION PACKAGES` SID (`S-1-15-2-2`) inheritable read/execute access on `$INSTDIR`.

This PR is intentionally narrow. It fixes the field reports where an orphan `S-1-15-2-*` ACE exists without a well-known package grant and sandboxed Chromium children die with `STATUS_BREAKPOINT` (`0x80000003`). It does **not** claim to fix the separate clean-DACL `STATUS_DLL_NOT_FOUND` / renderer `launch-failed/49` cluster.

## Implementation

- Reuse the existing electron-builder NSIS include and add `customInstall`.
- Run `"$SYSDIR\icacls.exe" "$INSTDIR" /grant *S-1-15-2-2:(OI)(CI)(RX)` after install/update extraction; the absolute system path prevents installer-token PATH hijacking.
- Consume and check the `nsExec::Exec` result with `Pop $0`. Nonzero results are written to installer details; interactive installs show a warning, while silent updates never block on UI. The failure stays non-fatal because electron-builder has already removed the old version and has no rollback at `customInstall`.
- Avoid `/T`: `(OI)(CI)` lets extracted children inherit the root ACE without an O(N) filesystem walk.
- Avoid `/reset`, ACE removal, full/modify/write permissions, and localized principal names.
- Keep the regression test under `config/scripts/`, where the standard Vitest configuration discovers it.

## Clear fix evidence

**Before:** on a disposable packaged install on awin, adding orphan SID `S-1-15-2-9999:(OI)(CI)(RX)` while removing the well-known package grant reproduced sandboxed renderer/GPU bootstrap failure with `STATUS_BREAKPOINT` (`-2147483645` / `0x80000003`).

**After:** running the rebuilt installer over that poisoned disposable install added:

```text
APPLICATION PACKAGE AUTHORITY\ALL RESTRICTED APPLICATION PACKAGES:(OI)(CI)(RX)
```

The grant was present alongside the synthetic orphan ACE; existing SYSTEM, Administrators, and user full-control ACEs remained. Re-running the installer remained idempotent. Disposable file/ACL mutations were confined to the test install tree.

Focused verification:

```text
npx vitest run config/scripts/nsis-daemon-host-uninstall.test.ts
# 1 file passed; 1 test passed
```

GitHub typecheck passed on the PR. The test-discovery review finding was fixed in `e740c585ea45` by moving the test under the standard `config/scripts/**/*.test.ts` include.

## ELI5

Windows launches Orca’s renderer in a locked sandbox. A malformed install-folder permission list can let ordinary users read Orca while accidentally blocking that sandbox from reading Orca’s own DLLs. The installer now adds one read-only permission for Windows’ restricted app sandboxes, so the renderer can start without granting it write access.

## Trade-offs

- Every Windows install/update launches one windowless `icacls` process. It updates one directory descriptor; it does not recursively scan the install tree.
- If a user intentionally disables inheritance on a specific child DLL, the root `(OI)(CI)` grant cannot repair that protected child. electron-builder normally extracts inheriting files, so recursive mutation would add broad cost and risk for a non-field shape.
- If AppLocker/AV/enterprise policy blocks `icacls`, installation continues and the grant may remain absent. Failing the entire application install would be a worse regression; the existing crash DACL diagnostic still records the condition.
- Access is read/execute only. No write, modify, full-control, reset, or ACE removal is introduced.

## Adversarial, security, and performance review

**4 fresh adversarial loops until clean.**

1. Found the regression test was outside standard Vitest discovery. Moved it to `config/scripts/` and balanced the new `nsExec` result stack.
2. Clean on SID syntax, quoting, least privilege, install/update lifecycle, failure behavior, discovery, and no recursive/destructive flags.
3. After external security review found bare executable search and unchecked failure reporting, pinned `icacls.exe` to `$SYSDIR`, checked the result, and added non-fatal diagnostic logging.
4. After adding an interactive-only warning with a `${Silent}` guard and tests rejecting `Abort`, `Quit`, and `SetErrorLevel`, **clean**: no remaining security, rollback, silent-update, quoting, privilege, stack, or test finding.

Independent security review verified that `$INSTDIR` is not a command-injection path because `nsExec` does not invoke `cmd.exe` and valid Windows paths cannot contain quote/NUL. The executable path is now pinned to the Windows system directory.

Independent performance review: **clean**. The no-`/T` inheritance design changes one root DACL instead of walking thousands of files, is idempotent across updates, runs windowless, and retains no resources.

## Current verification

```text
pnpm test config/scripts/nsis-daemon-host-uninstall.test.ts
# 1 file passed; 1 test passed

pnpm run check:code-quality:changed
# 0 new code-quality, type-aware, or React Doctor findings
```

The branch is rebased onto current `main`. GitHub typecheck, static analysis, all eight test shards, root guard, verification, and Greptile checks passed before the final failure-warning hardening; the current head reruns the same checks.
