### PR TITLE
perf(markdown): update code highlighting incrementally

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@tiptap/extension-code-block": "^3.22.5",
     "@tiptap/extension-code-block-lowlight": "^3.22.5",
     "@tiptap/extension-details": "^3.22.5",
     "@tiptap/extension-image": "^3.22.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@tiptap/extension-code-block':
+        specifier: ^3.22.5
+        version: 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
       '@tiptap/extension-code-block-lowlight':
         specifier: ^3.22.5
         version: 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/extension-code-block@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(highlight.js@11.11.1)(lowlight@3.3.0)

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -3,7 +3,6 @@ import StarterKit from '@tiptap/starter-kit'
 import Link from '@tiptap/extension-link'
 import { Code } from '@tiptap/extension-code'
 import Image from '@tiptap/extension-image'
-import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import Placeholder from '@tiptap/extension-placeholder'
 import TaskItem from '@tiptap/extension-task-item'
 import { Table } from '@tiptap/extension-table'
@@ -34,6 +33,7 @@ import type { RichMarkdownEditorCodec } from './rich-markdown-source-transport'
 import { createRichMarkdownHtmlSuperscriptLink } from './rich-markdown-html-superscript-link'
 import type { RichMarkdownHtmlSuperscriptLinkContext } from './rich-markdown-html-superscript-link-context'
 import { RichMarkdownOrderedList } from './rich-markdown-ordered-list'
+import { RichMarkdownCodeBlockLowlight } from './rich-markdown-lowlight'
 import { RichMarkdownTaskList } from './rich-markdown-task-list'
 
 const lowlight = createLowlight(common)
@@ -75,7 +75,7 @@ export function createRichMarkdownExtensions({
       orderedList: false
     }),
     RichMarkdownCode,
-    CodeBlockLowlight.extend({
+    RichMarkdownCodeBlockLowlight.extend({
       addNodeView() {
         // Why: RichMarkdownCodeBlock never reads getPos, so it must not re-render
         // just because earlier edits shifted this block's document position.

--- a/src/renderer/src/components/editor/rich-markdown-lowlight.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-lowlight.test.ts
@@ -1,0 +1,467 @@
+// @vitest-environment happy-dom
+
+import { Editor, type JSONContent } from '@tiptap/core'
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
+import { TextSelection, type Plugin } from '@tiptap/pm/state'
+import type { Decoration, DecorationSet } from '@tiptap/pm/view'
+import StarterKit from '@tiptap/starter-kit'
+import { common, createLowlight } from 'lowlight'
+import { afterEach, describe, expect, it } from 'vitest'
+import { RichMarkdownCodeBlockLowlight } from './rich-markdown-lowlight'
+
+type Lowlight = ReturnType<typeof createLowlight>
+type Counters = { highlight: number; highlightAuto: number; listLanguages: number }
+type RuntimeKeyedPlugin = Plugin & { key?: string }
+type DecorationWithAttrs = Decoration & {
+  type: { attrs?: { class?: string } }
+}
+
+function observedLowlight(counters: Counters): Lowlight {
+  const base = createLowlight(common)
+  return {
+    ...base,
+    highlight: (...args) => {
+      counters.highlight += 1
+      return base.highlight(...args)
+    },
+    highlightAuto: (...args) => {
+      counters.highlightAuto += 1
+      return base.highlightAuto(...args)
+    },
+    listLanguages: () => {
+      counters.listLanguages += 1
+      return base.listLanguages()
+    }
+  }
+}
+
+function documentWithCodeBlocks(count = 3): JSONContent {
+  return {
+    type: 'doc',
+    content: Array.from({ length: count }, (_, index) => [
+      { type: 'paragraph', content: [{ type: 'text', text: `paragraph ${index}` }] },
+      {
+        type: 'codeBlock',
+        attrs: { language: index === 1 ? 'js' : index === 2 ? 'unknown' : 'typescript' },
+        content: [{ type: 'text', text: `const value${index}: number = ${index}` }]
+      }
+    ]).flat()
+  }
+}
+
+function createEditor({
+  incremental,
+  counters,
+  content = documentWithCodeBlocks(),
+  defaultLanguage = null
+}: {
+  incremental: boolean
+  counters: Counters
+  content?: JSONContent
+  defaultLanguage?: string | null
+}): Editor {
+  const extension = incremental ? RichMarkdownCodeBlockLowlight : CodeBlockLowlight
+  return new Editor({
+    element: document.createElement('div'),
+    extensions: [
+      StarterKit.configure({ codeBlock: false, trailingNode: false }),
+      extension.configure({ lowlight: observedLowlight(counters), defaultLanguage })
+    ],
+    content
+  })
+}
+
+function nodePositions(editor: Editor, name: string): number[] {
+  const positions: number[] = []
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === name) {
+      positions.push(pos)
+    }
+  })
+  return positions
+}
+
+function decorationSnapshot(editor: Editor, incremental: boolean): unknown[] {
+  const keyPrefix = incremental ? 'richMarkdownLowlight$' : 'lowlight$'
+  const plugin = editor.state.plugins.find((candidate) =>
+    (candidate as RuntimeKeyedPlugin).key?.startsWith(keyPrefix)
+  )
+  const decorations = plugin?.getState(editor.state) as DecorationSet | undefined
+  if (!decorations) {
+    const keys = editor.state.plugins.map((candidate) => (candidate as RuntimeKeyedPlugin).key)
+    throw new Error(`Missing ${keyPrefix} plugin: ${JSON.stringify(keys)}`)
+  }
+  return decorations.find().map((decoration) => {
+    const typed = decoration as DecorationWithAttrs
+    return [decoration.from, decoration.to, typed.type.attrs?.class]
+  })
+}
+
+function expectParity(stock: Editor, incremental: Editor): void {
+  expect(incremental.state.doc.toJSON()).toEqual(stock.state.doc.toJSON())
+  expect(decorationSnapshot(incremental, true)).toEqual(decorationSnapshot(stock, false))
+}
+
+function resetCounters(counters: Counters): void {
+  counters.highlight = 0
+  counters.highlightAuto = 0
+  counters.listLanguages = 0
+}
+
+describe('incremental rich markdown lowlight', () => {
+  const editors: Editor[] = []
+
+  afterEach(() => {
+    for (const editor of editors) {
+      editor.destroy()
+    }
+    editors.length = 0
+  })
+
+  function createPair(content?: JSONContent, defaultLanguage: string | null = null) {
+    const stockCounters = { highlight: 0, highlightAuto: 0, listLanguages: 0 }
+    const incrementalCounters = { highlight: 0, highlightAuto: 0, listLanguages: 0 }
+    const stock = createEditor({
+      incremental: false,
+      counters: stockCounters,
+      content,
+      defaultLanguage
+    })
+    const incremental = createEditor({
+      incremental: true,
+      counters: incrementalCounters,
+      content,
+      defaultLanguage
+    })
+    editors.push(stock, incremental)
+    return { stock, incremental, stockCounters, incrementalCounters }
+  }
+
+  it('matches stock decorations for named, aliased, and unknown languages', () => {
+    const { stock, incremental, stockCounters, incrementalCounters } = createPair()
+
+    expectParity(stock, incremental)
+    expect(stockCounters).toEqual({ highlight: 2, highlightAuto: 1, listLanguages: 3 })
+    expect(incrementalCounters).toEqual({ highlight: 2, highlightAuto: 1, listLanguages: 1 })
+  })
+
+  it('matches stock decorations when a default language is configured', () => {
+    const content = documentWithCodeBlocks(1)
+    const codeBlock = content.content?.[1]
+    if (!codeBlock?.attrs) {
+      throw new Error('Missing code block')
+    }
+    codeBlock.attrs.language = null
+    const { stock, incremental, stockCounters, incrementalCounters } = createPair(
+      content,
+      'typescript'
+    )
+
+    expectParity(stock, incremental)
+    expect(stockCounters.highlight).toBe(1)
+    expect(incrementalCounters.highlight).toBe(1)
+  })
+
+  it('maps decorations without highlighting after a prose edit', () => {
+    const { stock, incremental, stockCounters, incrementalCounters } = createPair()
+    resetCounters(stockCounters)
+    resetCounters(incrementalCounters)
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'paragraph')[0] + 1
+      editor.view.dispatch(editor.state.tr.insertText('x', pos))
+    }
+
+    expectParity(stock, incremental)
+    expect(stockCounters.highlight + stockCounters.highlightAuto).toBe(0)
+    expect(incrementalCounters.highlight + incrementalCounters.highlightAuto).toBe(0)
+  })
+
+  it('highlights only the edited code block', () => {
+    const { stock, incremental, stockCounters, incrementalCounters } = createPair()
+    resetCounters(stockCounters)
+    resetCounters(incrementalCounters)
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'codeBlock')[0] + 1
+      const tr = editor.state.tr.setSelection(TextSelection.create(editor.state.doc, pos))
+      editor.view.dispatch(tr.insertText('x'))
+    }
+
+    expectParity(stock, incremental)
+    expect(stockCounters.highlight + stockCounters.highlightAuto).toBe(3)
+    expect(incrementalCounters.highlight + incrementalCounters.highlightAuto).toBe(1)
+  })
+
+  it('highlights only the code blocks touched by a multi-step transaction', () => {
+    const { stock, incremental, stockCounters, incrementalCounters } = createPair()
+    resetCounters(stockCounters)
+    resetCounters(incrementalCounters)
+
+    for (const editor of [stock, incremental]) {
+      const [first, , third] = nodePositions(editor, 'codeBlock').map((pos) => pos + 1)
+      const tr = editor.state.tr.insertText('z', third).insertText('a', first)
+      tr.setSelection(TextSelection.create(tr.doc, first))
+      editor.view.dispatch(tr)
+    }
+
+    expectParity(stock, incremental)
+    expect(stockCounters.highlight + stockCounters.highlightAuto).toBe(3)
+    expect(incrementalCounters.highlight + incrementalCounters.highlightAuto).toBe(2)
+  })
+
+  it('falls back safely for a language attribute change', () => {
+    const { stock, incremental } = createPair()
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'codeBlock')[0]
+      const node = editor.state.doc.nodeAt(pos)
+      const tr = editor.state.tr.setNodeMarkup(pos, undefined, {
+        ...node?.attrs,
+        language: 'javascript'
+      })
+      tr.setSelection(TextSelection.create(tr.doc, pos + 1))
+      editor.view.dispatch(tr)
+    }
+
+    expectParity(stock, incremental)
+  })
+
+  it('preserves parity when code blocks are inserted and deleted', () => {
+    const { stock, incremental } = createPair()
+
+    for (const editor of [stock, incremental]) {
+      const end = editor.state.doc.content.size
+      const codeBlock = editor.schema.nodes.codeBlock.create(
+        { language: 'typescript' },
+        editor.schema.text('let inserted = true')
+      )
+      editor.view.dispatch(editor.state.tr.insert(end, codeBlock))
+    }
+    expectParity(stock, incremental)
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'codeBlock')[1]
+      const node = editor.state.doc.nodeAt(pos)
+      if (!node) {
+        throw new Error('Missing code block')
+      }
+      editor.view.dispatch(editor.state.tr.delete(pos, pos + node.nodeSize))
+    }
+    expectParity(stock, incremental)
+  })
+
+  it('preserves parity through undo and redo', () => {
+    const { stock, incremental } = createPair()
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'codeBlock')[0] + 1
+      const tr = editor.state.tr.setSelection(TextSelection.create(editor.state.doc, pos))
+      editor.view.dispatch(tr.insertText('undoable'))
+    }
+    expectParity(stock, incremental)
+
+    expect(stock.commands.undo()).toBe(true)
+    expect(incremental.commands.undo()).toBe(true)
+    expectParity(stock, incremental)
+
+    expect(stock.commands.redo()).toBe(true)
+    expect(incremental.commands.redo()).toBe(true)
+    expectParity(stock, incremental)
+  })
+
+  it('preserves parity when paragraphs and code blocks are converted', () => {
+    const { stock, incremental } = createPair()
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'paragraph')[0] + 1
+      editor.view.dispatch(
+        editor.state.tr.setSelection(TextSelection.create(editor.state.doc, pos))
+      )
+      expect(editor.commands.setCodeBlock({ language: 'typescript' })).toBe(true)
+    }
+    expectParity(stock, incremental)
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'codeBlock')[0] + 1
+      editor.view.dispatch(
+        editor.state.tr.setSelection(TextSelection.create(editor.state.doc, pos))
+      )
+      expect(editor.commands.setParagraph()).toBe(true)
+    }
+    expectParity(stock, incremental)
+  })
+
+  it('preserves parity for paste and deletion inside a code block', () => {
+    const { stock, incremental } = createPair()
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'codeBlock')[0] + 2
+      editor.view.dispatch(
+        editor.state.tr.setSelection(TextSelection.create(editor.state.doc, pos))
+      )
+      expect(editor.view.pasteText('pasted text')).toBe(true)
+    }
+    expectParity(stock, incremental)
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'codeBlock')[0] + 1
+      editor.view.dispatch(editor.state.tr.delete(pos, pos + 6))
+    }
+    expectParity(stock, incremental)
+  })
+
+  it('preserves parity when a code block is split and joined', () => {
+    const { stock, incremental } = createPair()
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'codeBlock')[0] + 8
+      editor.view.dispatch(editor.state.tr.split(pos))
+    }
+    expectParity(stock, incremental)
+
+    for (const editor of [stock, incremental]) {
+      const joinPos = nodePositions(editor, 'codeBlock')[1]
+      editor.view.dispatch(editor.state.tr.join(joinPos))
+    }
+    expectParity(stock, incremental)
+  })
+
+  it('preserves parity when a code block moves in one transaction', () => {
+    const { stock, incremental } = createPair()
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'codeBlock')[0]
+      const node = editor.state.doc.nodeAt(pos)
+      if (!node) {
+        throw new Error('Missing code block')
+      }
+      const tr = editor.state.tr.delete(pos, pos + node.nodeSize)
+      const insertedAt = tr.doc.content.size
+      tr.insert(insertedAt, node)
+      tr.setSelection(TextSelection.create(tr.doc, insertedAt + 1))
+      editor.view.dispatch(tr)
+    }
+
+    expectParity(stock, incremental)
+  })
+
+  it('preserves parity for code blocks nested in list items', () => {
+    const content: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'item' }] },
+                {
+                  type: 'codeBlock',
+                  attrs: { language: 'typescript' },
+                  content: [{ type: 'text', text: 'const nested = true' }]
+                }
+              ]
+            }
+          ]
+        },
+        { type: 'paragraph', content: [{ type: 'text', text: 'after' }] }
+      ]
+    }
+    const { stock, incremental } = createPair(content)
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'codeBlock')[0] + 1
+      const tr = editor.state.tr.setSelection(TextSelection.create(editor.state.doc, pos))
+      editor.view.dispatch(tr.insertText('x'))
+    }
+
+    expectParity(stock, incremental)
+  })
+
+  it('preserves parity after whole-document replacement', () => {
+    const { stock, incremental } = createPair()
+
+    expect(stock.commands.setContent(documentWithCodeBlocks(5))).toBe(true)
+    expect(incremental.commands.setContent(documentWithCodeBlocks(5))).toBe(true)
+
+    expectParity(stock, incremental)
+  })
+
+  it('does not highlight for selection-only transactions', () => {
+    const { stock, incremental, stockCounters, incrementalCounters } = createPair()
+    resetCounters(stockCounters)
+    resetCounters(incrementalCounters)
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'codeBlock')[0] + 1
+      editor.view.dispatch(
+        editor.state.tr.setSelection(TextSelection.create(editor.state.doc, pos))
+      )
+    }
+
+    expectParity(stock, incremental)
+    expect(stockCounters.highlight + stockCounters.highlightAuto).toBe(0)
+    expect(incrementalCounters.highlight + incrementalCounters.highlightAuto).toBe(0)
+  })
+
+  it('replaces the stock plugin without dropping the code-block paste handler', () => {
+    const counters = { highlight: 0, highlightAuto: 0, listLanguages: 0 }
+    const editor = createEditor({ incremental: true, counters })
+    editors.push(editor)
+    const keys = editor.state.plugins.map((plugin) => (plugin as RuntimeKeyedPlugin).key)
+
+    expect(RichMarkdownCodeBlockLowlight.options).toEqual(CodeBlockLowlight.options)
+    expect(keys.some((key) => key?.startsWith('richMarkdownLowlight$'))).toBe(true)
+    expect(keys.some((key) => key?.startsWith('lowlight$'))).toBe(false)
+    expect(keys.some((key) => key?.startsWith('codeBlockVSCodeHandler$'))).toBe(true)
+  })
+
+  it('preserves parity at adjacent code-block boundaries', () => {
+    const content: JSONContent = {
+      type: 'doc',
+      content: documentWithCodeBlocks(3).content?.filter((node) => node.type === 'codeBlock')
+    }
+    const { stock, incremental } = createPair(content)
+
+    for (const editor of [stock, incremental]) {
+      const firstPos = nodePositions(editor, 'codeBlock')[0]
+      const first = editor.state.doc.nodeAt(firstPos)
+      if (!first) {
+        throw new Error('Missing first code block')
+      }
+      editor.view.dispatch(editor.state.tr.insertText('tail', firstPos + first.nodeSize - 1))
+    }
+    expectParity(stock, incremental)
+
+    for (const editor of [stock, incremental]) {
+      const firstPos = nodePositions(editor, 'codeBlock')[0]
+      const first = editor.state.doc.nodeAt(firstPos)
+      if (!first) {
+        throw new Error('Missing first code block')
+      }
+      editor.view.dispatch(editor.state.tr.delete(firstPos, firstPos + first.nodeSize))
+    }
+    expectParity(stock, incremental)
+  })
+
+  it('rehighlights one of 533 code blocks after a local code edit', () => {
+    const { stock, incremental, stockCounters, incrementalCounters } = createPair(
+      documentWithCodeBlocks(533)
+    )
+    resetCounters(stockCounters)
+    resetCounters(incrementalCounters)
+
+    for (const editor of [stock, incremental]) {
+      const pos = nodePositions(editor, 'codeBlock')[0] + 1
+      const tr = editor.state.tr.setSelection(TextSelection.create(editor.state.doc, pos))
+      editor.view.dispatch(tr.insertText('x'))
+    }
+
+    expectParity(stock, incremental)
+    expect(stockCounters.highlight + stockCounters.highlightAuto).toBe(533)
+    expect(incrementalCounters.highlight + incrementalCounters.highlightAuto).toBe(1)
+    expect(incrementalCounters.listLanguages).toBe(0)
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-lowlight.ts
+++ b/src/renderer/src/components/editor/rich-markdown-lowlight.ts
@@ -1,0 +1,219 @@
+import { getChangedRanges } from '@tiptap/core'
+import { CodeBlock } from '@tiptap/extension-code-block'
+import CodeBlockLowlight, {
+  type CodeBlockLowlightOptions
+} from '@tiptap/extension-code-block-lowlight'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import { Plugin, PluginKey, type Transaction } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+import type { createLowlight } from 'lowlight'
+
+type Lowlight = ReturnType<typeof createLowlight>
+type HighlightNode = ReturnType<Lowlight['highlight']>['children'][number]
+type CodeBlockAt = { node: ProseMirrorNode; pos: number }
+type DocumentRange = { from: number; to: number }
+type HighlightSpan = { text: string; classes: string[] }
+
+function parseHighlightNodes(nodes: HighlightNode[], classes: string[] = []): HighlightSpan[] {
+  return nodes.flatMap((node) => {
+    if (node.type === 'text') {
+      return [{ text: node.value, classes }]
+    }
+    if (node.type !== 'element') {
+      return []
+    }
+
+    const className = node.properties.className
+    const ownClasses = Array.isArray(className)
+      ? className.map(String)
+      : typeof className === 'string'
+        ? [className]
+        : []
+    return parseHighlightNodes(node.children, [...classes, ...ownClasses])
+  })
+}
+
+function highlightBlock(
+  block: CodeBlockAt,
+  lowlight: Lowlight,
+  languages: ReadonlySet<string>,
+  defaultLanguage: string | null | undefined
+): Decoration[] {
+  const language = (block.node.attrs.language as string | null | undefined) || defaultLanguage
+  const highlighted =
+    language && (languages.has(language) || lowlight.registered(language))
+      ? lowlight.highlight(language, block.node.textContent)
+      : lowlight.highlightAuto(block.node.textContent)
+  const decorations: Decoration[] = []
+  let from = block.pos + 1
+
+  for (const span of parseHighlightNodes(highlighted.children)) {
+    const to = from + span.text.length
+    if (span.classes.length > 0) {
+      decorations.push(Decoration.inline(from, to, { class: span.classes.join(' ') }))
+    }
+    from = to
+  }
+
+  return decorations
+}
+
+function findAllCodeBlocks(doc: ProseMirrorNode, name: string): CodeBlockAt[] {
+  const blocks: CodeBlockAt[] = []
+  doc.descendants((node, pos) => {
+    if (node.type.name === name) {
+      blocks.push({ node, pos })
+      return false
+    }
+    return true
+  })
+  return blocks
+}
+
+function findCodeBlocksNearRanges(
+  doc: ProseMirrorNode,
+  name: string,
+  ranges: DocumentRange[]
+): CodeBlockAt[] {
+  const blocks = new Map<number, ProseMirrorNode>()
+  const addResolvedBlocks = (position: number): void => {
+    // Why: zero-width inserts and deletes have no nodesBetween span.
+    const $position = doc.resolve(Math.max(0, Math.min(doc.content.size, position)))
+    for (let depth = $position.depth; depth > 0; depth -= 1) {
+      const node = $position.node(depth)
+      if (node.type.name === name) {
+        blocks.set($position.before(depth), node)
+        break
+      }
+    }
+    if ($position.nodeBefore?.type.name === name) {
+      blocks.set($position.pos - $position.nodeBefore.nodeSize, $position.nodeBefore)
+    }
+    if ($position.nodeAfter?.type.name === name) {
+      blocks.set($position.pos, $position.nodeAfter)
+    }
+  }
+
+  for (const range of ranges) {
+    const from = Math.max(0, Math.min(doc.content.size, range.from))
+    const to = Math.max(from, Math.min(doc.content.size, range.to))
+    if (from < to) {
+      doc.nodesBetween(from, to, (node, pos) => {
+        if (node.type.name === name) {
+          blocks.set(pos, node)
+          return false
+        }
+        return true
+      })
+    }
+    addResolvedBlocks(from)
+    if (to !== from) {
+      addResolvedBlocks(to)
+    }
+  }
+  return [...blocks].map(([pos, node]) => ({ node, pos }))
+}
+
+function createDecorations(
+  doc: ProseMirrorNode,
+  name: string,
+  lowlight: Lowlight,
+  languages: ReadonlySet<string>,
+  defaultLanguage: string | null | undefined
+): DecorationSet {
+  return DecorationSet.create(
+    doc,
+    findAllCodeBlocks(doc, name).flatMap((block) =>
+      highlightBlock(block, lowlight, languages, defaultLanguage)
+    )
+  )
+}
+
+function updateDecorations(
+  transaction: Transaction,
+  decorationSet: DecorationSet,
+  name: string,
+  lowlight: Lowlight,
+  languages: ReadonlySet<string>,
+  defaultLanguage: string | null | undefined
+): DecorationSet {
+  if (!transaction.docChanged) {
+    return decorationSet
+  }
+
+  const changes = getChangedRanges(transaction)
+  if (changes.length === 0) {
+    // Why: attribute-only steps can change a code language without exposing a mapped range.
+    return createDecorations(transaction.doc, name, lowlight, languages, defaultLanguage)
+  }
+
+  // Why: mapped decorations stay valid outside code blocks touched by the transaction.
+  let next = decorationSet.map(transaction.mapping, transaction.doc)
+  const oldBlocks = findCodeBlocksNearRanges(
+    transaction.before,
+    name,
+    changes.map((change) => change.oldRange)
+  )
+  const staleDecorations = new Set<Decoration>()
+  for (const block of oldBlocks) {
+    const from = transaction.mapping.map(block.pos, -1)
+    const to = transaction.mapping.map(block.pos + block.node.nodeSize, 1)
+    for (const decoration of next.find(Math.min(from, to), Math.max(from, to))) {
+      staleDecorations.add(decoration)
+    }
+  }
+  if (staleDecorations.size > 0) {
+    next = next.remove([...staleDecorations])
+  }
+
+  const newBlocks = findCodeBlocksNearRanges(
+    transaction.doc,
+    name,
+    changes.map((change) => change.newRange)
+  )
+  return next.add(
+    transaction.doc,
+    newBlocks.flatMap((block) => highlightBlock(block, lowlight, languages, defaultLanguage))
+  )
+}
+
+function createRichMarkdownLowlightPlugin({
+  name,
+  lowlight,
+  defaultLanguage
+}: {
+  name: string
+  lowlight: Lowlight
+  defaultLanguage: string | null | undefined
+}): Plugin<DecorationSet> {
+  const languages = new Set(lowlight.listLanguages())
+  const key = new PluginKey<DecorationSet>('richMarkdownLowlight')
+  const plugin = new Plugin<DecorationSet>({
+    key,
+    state: {
+      init: (_, { doc }) => createDecorations(doc, name, lowlight, languages, defaultLanguage),
+      apply: (transaction, decorationSet) =>
+        updateDecorations(transaction, decorationSet, name, lowlight, languages, defaultLanguage)
+    },
+    props: {
+      decorations: (state) => key.getState(state)
+    }
+  })
+  return plugin
+}
+
+export const RichMarkdownCodeBlockLowlight = CodeBlock.extend<CodeBlockLowlightOptions>({
+  addOptions() {
+    return { ...CodeBlockLowlight.options }
+  },
+  addProseMirrorPlugins() {
+    return [
+      ...(this.parent?.() ?? []),
+      createRichMarkdownLowlightPlugin({
+        name: this.name,
+        lowlight: this.options.lowlight as Lowlight,
+        defaultLanguage: this.options.defaultLanguage
+      })
+    ]
+  }
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​467 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​467 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​225 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​223 |

<!-- /orca-pr-loc -->

## Summary

- map syntax-highlight decorations through unrelated document changes
- recompute only code blocks touched by transaction ranges, with a full rebuild when a change cannot be localized safely
- preserve existing code-block options, commands, node views, and paste behavior while adding stock-parity coverage

## Performance

On a 305 KB Markdown fixture with 533 code blocks, 15 real Electron keyboard samples measured keydown to the next animation frame:

- median: 79.5 ms to 22.7 ms (71% faster)
- p95: 114.5 ms to 39.7 ms (65% faster)

A deterministic test also verifies that a local code edit invokes highlighting for 1 block instead of all 533.

## Validation

- 18 stock-parity tests covering language handling, prose and code edits, insert/delete, undo/redo, conversions, paste, split/join, moves, nested blocks, full replacement, selection-only changes, adjacent boundaries, options, and paste-handler preservation
- 181 renderer-editor test files passed, 1,224 tests total
- full typecheck and post-rebase web typecheck passed
- changed-code quality gate passed with zero findings
- production Electron build passed
- Electron CDP check confirmed 533/533 rendered blocks highlighted; first and last blocks retained highlight spans; real typing and undo restored the document

Follow-up to #17008.

## ELI5

Typing in one code block used to make the editor recolor every code block in the document. The editor now carries unchanged colors forward and recolors only blocks touched by the edit. If it cannot prove which block changed, it safely falls back to recoloring everything.

## Before / After measurement

On the same 305 KB, 533-code-block fixture in Electron (15 keyboard samples), keydown-to-next-frame median fell from **79.5 ms to 22.7 ms** (-71%) and p95 fell from **114.5 ms to 39.7 ms** (-65%). The deterministic call-count test changes one local edit from **533 highlight calls to 1**.

## Regression Proof

- Eighteen stock-parity tests cover language handling, prose/code edits, insert/delete, undo/redo, conversions, paste, split/join, moves, nested blocks, full replacement, selection-only changes, adjacent boundaries, options, and paste-handler preservation.
- All 181 renderer-editor test files pass: 1,224 tests total.
- Electron CDP confirms 533/533 blocks remain highlighted, including the first and last; real typing and undo restore the expected document.
- Typecheck, changed-code quality, and production Electron build pass.

## No-user-regression signoff

No highlighting mode, language option, editor command, paste behavior, or rendered syntax is removed. Unchanged decorations are mapped through the editor transaction, touched blocks use the same highlighter, and ambiguous changes take the existing full-rebuild path. There is no persistence, IPC, remote-wire, SSH, filesystem, or platform-specific behavior change.

## Merge risk

**Medium-low.** This changes transaction-range bookkeeping in a latency-sensitive editor extension. The main risk is a missed affected range leaving stale decoration positions; boundary, structural-edit, undo/redo, and full-replacement parity cases exercise those paths, while the conservative full-rebuild fallback handles unlocalizable edits. The PR is isolated and independently revertible.