### PR TITLE
fix(terminal): a recycled PTY id must not replay the dead shell's bytes

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
@@ -24,6 +24,9 @@ const RECYCLED_PTY_ID = 'ssh:target@@pty-2'
 // and the one the fresh spawn just got handed.
 const PRIOR_INCARNATION_ID = 'incarnation-before-the-relay-restarted'
 const FRESH_INCARNATION_ID = 'incarnation-of-the-shell-now-attaching'
+const WARN_PTY_ID = 'pty-pre-handler-lost-handler-warn'
+// One more than the buffered-data pty cap, so admitting them all evicts `WARN_PTY_ID`'s buffer.
+const WARN_EVICTION_PTY_IDS = Array.from({ length: 64 }, (_, index) => `pty-warn-evict-${index}`)
 
 describe('pre-handler PTY buffer', () => {
   afterEach(() => {
@@ -34,6 +37,10 @@ describe('pre-handler PTY buffer', () => {
       clearPreHandlerPtyState(ptyId)
     }
     clearPreHandlerPtyState(RECYCLED_PTY_ID)
+    clearPreHandlerPtyState(WARN_PTY_ID)
+    for (const ptyId of WARN_EVICTION_PTY_IDS) {
+      clearPreHandlerPtyState(ptyId)
+    }
   })
 
   it('does not rescan historical chunks while buffering small startup output', () => {
@@ -362,6 +369,62 @@ describe('pre-handler PTY buffer', () => {
     bufferPreHandlerPtyExit(RECYCLED_PTY_ID, 5, PRIOR_INCARNATION_ID)
     discardPreHandlerPtyExitFromForeignIncarnation(RECYCLED_PTY_ID, 42)
     expect(hasPreHandlerPtyExit(RECYCLED_PTY_ID)).toBe(true)
+  })
+
+  // Why these three: the lost-handler diagnostic is latched so a buffer already over the threshold
+  // does not warn on every chunk. The latch describes ONE buffering episode, but a pty id is reused
+  // over time and its byte count falls as well as rises, so every way the count comes back down has
+  // to re-arm it or the replacement PTY's own accumulation goes unreported.
+  it('warns again once the spawn fence drops the prior owner below the threshold', () => {
+    const warn = vi.fn()
+    const originalWarn = console.warn
+    console.warn = warn
+
+    try {
+      bufferPreHandlerPtyData(WARN_PTY_ID, 'a'.repeat(70 * 1_024))
+      const fence = currentPreHandlerPtySequence()
+      bufferPreHandlerPtyData(WARN_PTY_ID, 'b'.repeat(1_024))
+      discardPreHandlerPtyStateFromPriorIncarnation(WARN_PTY_ID, fence)
+      bufferPreHandlerPtyData(WARN_PTY_ID, 'c'.repeat(70 * 1_024))
+    } finally {
+      console.warn = originalWarn
+    }
+
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+
+  it('warns again after the byte cap trims the buffer back under the threshold', () => {
+    const warn = vi.fn()
+    const originalWarn = console.warn
+    console.warn = warn
+
+    try {
+      bufferPreHandlerPtyData(WARN_PTY_ID, 'a'.repeat(500 * 1_024))
+      bufferPreHandlerPtyData(WARN_PTY_ID, 'b'.repeat(20 * 1_024))
+      bufferPreHandlerPtyData(WARN_PTY_ID, 'c'.repeat(70 * 1_024))
+    } finally {
+      console.warn = originalWarn
+    }
+
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+
+  it('warns again for an id whose buffer was evicted at the pty cap', () => {
+    const warn = vi.fn()
+    const originalWarn = console.warn
+    console.warn = warn
+
+    try {
+      bufferPreHandlerPtyData(WARN_PTY_ID, 'a'.repeat(70 * 1_024))
+      for (const ptyId of WARN_EVICTION_PTY_IDS) {
+        bufferPreHandlerPtyData(ptyId, 'x')
+      }
+      bufferPreHandlerPtyData(WARN_PTY_ID, 'c'.repeat(70 * 1_024))
+    } finally {
+      console.warn = originalWarn
+    }
+
+    expect(warn).toHaveBeenCalledTimes(2)
   })
 
   it('re-admits exits for a recycled id whose prior incarnation was consumed', () => {

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
@@ -233,6 +233,22 @@ describe('pre-handler PTY buffer', () => {
     expect(data).toHaveBeenCalledWith('startup bytes', undefined)
   })
 
+  // A buffer can hold both owners' bytes: the dead shell's output is still queued when our own
+  // first chunk arrives while the spawn reply is in flight. Dating the buffer by its newest chunk
+  // makes that one chunk of ours vouch for all of them, and the new terminal opens showing the
+  // dead PTY's output above its own.
+  it("keeps only our own bytes when a recycled id's buffer holds both owners' output", () => {
+    bufferPreHandlerPtyData(RECYCLED_PTY_ID, 'output from the dead shell')
+    const fence = currentPreHandlerPtySequence()
+    bufferPreHandlerPtyData(RECYCLED_PTY_ID, 'our startup bytes')
+
+    discardPreHandlerPtyStateFromPriorIncarnation(RECYCLED_PTY_ID, fence)
+
+    const seen: string[] = []
+    drainPreHandlerPtyData(RECYCLED_PTY_ID, (data) => seen.push(data))
+    expect(seen).toEqual(['our startup bytes'])
+  })
+
   // The case the sequence fence structurally cannot reach: the stale exit is recorded AFTER the
   // renderer asked for a fresh PTY, so it is newer than the fence and passes it. Only the
   // incarnation says the exit describes a lifetime of the id that ended before this one began.

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
@@ -14,6 +14,8 @@ type BufferedPreHandlerPtyState = {
   chunks: BufferedPreHandlerPtyData[]
   head: number
   bytes: number
+  /** Whether the lost-handler diagnostic has already fired for this buffer's current climb. */
+  warnedLostHandler: boolean
 }
 
 type BufferedPreHandlerPtyExit = {
@@ -46,7 +48,6 @@ const PRE_HANDLER_PTY_EXIT_MAX_INCARNATIONS_PER_PTY = 4
 // data. Sustained accumulation means a pane lost its data handler (the
 // frozen-pane detach/attach race) — leave a breadcrumb for trace capture.
 const PRE_HANDLER_PTY_DATA_WARN_BYTES = 64 * 1024
-const warnedLostHandlerPtyIds = new Set<string>()
 
 // Why: pty ids are NOT unique over time — a redeployed SSH relay renumbers from pty-1, so a fresh
 // spawn can be handed an id whose previous incarnation left buffered state here. A monotonic
@@ -61,6 +62,20 @@ function nextPreHandlerPtySequence(): number {
 
 export function currentPreHandlerPtySequence(): number {
   return preHandlerPtySequence
+}
+
+/** The only writer of `state.bytes`, so the warn latch can never describe a count it no longer has.
+ *
+ *  Why one place: the latch exists to keep one climb past the threshold from warning on every chunk,
+ *  and it is scoped to a buffer, not to a pty id — ids are recycled, and the count comes back down
+ *  three different ways (the spawn fence dropping a prior owner's chunks, the byte cap trimming the
+ *  head, the buffer being dropped outright). Re-arming at each of those separately is how the
+ *  replacement PTY ends up accumulating in silence, so the descent re-arms here instead. */
+function setPreHandlerPtyBytes(state: BufferedPreHandlerPtyState, bytes: number): void {
+  state.bytes = bytes
+  if (bytes <= PRE_HANDLER_PTY_DATA_WARN_BYTES) {
+    state.warnedLostHandler = false
+  }
 }
 
 /** Map preserves insertion order, so the first key is the least recently admitted id. */
@@ -136,12 +151,14 @@ function retainPreHandlerPtyChunks(
   }
   if (kept.length === 0) {
     preHandlerPtyData.delete(ptyId)
-    warnedLostHandlerPtyIds.delete(ptyId)
     return
   }
   state.chunks = kept
   state.head = 0
-  state.bytes = kept.reduce((total, chunk) => total + chunk.bytes, 0)
+  setPreHandlerPtyBytes(
+    state,
+    kept.reduce((total, chunk) => total + chunk.bytes, 0)
+  )
 }
 
 export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyDataMeta): void {
@@ -159,7 +176,7 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
       : meta
   let state = preHandlerPtyData.get(ptyId)
   if (!state) {
-    state = { chunks: [], head: 0, bytes: 0 }
+    state = { chunks: [], head: 0, bytes: 0, warnedLostHandler: false }
     preHandlerPtyData.set(ptyId, state)
   }
   state.chunks.push({
@@ -168,11 +185,11 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
     sequence: nextPreHandlerPtySequence(),
     ...(bufferedMeta ? { meta: bufferedMeta } : {})
   })
-  state.bytes += chunk.bytes
+  setPreHandlerPtyBytes(state, state.bytes + chunk.bytes)
   // Why: a missing handler can accumulate many small chunks; a stored total
   // and head index keep that failure path linear instead of rescanning/shifting.
   while (state.bytes > PRE_HANDLER_PTY_DATA_MAX_BYTES && state.head < state.chunks.length - 1) {
-    state.bytes -= state.chunks[state.head].bytes
+    setPreHandlerPtyBytes(state, state.bytes - state.chunks[state.head].bytes)
     state.chunks[state.head] = { ...state.chunks[state.head], data: '', bytes: 0 }
     state.head += 1
   }
@@ -180,8 +197,8 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
     state.chunks.splice(0, state.head)
     state.head = 0
   }
-  if (state.bytes > PRE_HANDLER_PTY_DATA_WARN_BYTES && !warnedLostHandlerPtyIds.has(ptyId)) {
-    warnedLostHandlerPtyIds.add(ptyId)
+  if (state.bytes > PRE_HANDLER_PTY_DATA_WARN_BYTES && !state.warnedLostHandler) {
+    state.warnedLostHandler = true
     console.warn(
       `[pty] ${ptyId}: ${state.bytes} bytes buffered with no registered data handler; ` +
         'the owning pane may have lost its handler to a detach/attach race'
@@ -194,7 +211,6 @@ export function drainPreHandlerPtyData(
   handler: (data: string, meta?: PtyDataMeta) => void
 ): void {
   const state = preHandlerPtyData.get(ptyId)
-  warnedLostHandlerPtyIds.delete(ptyId)
   if (!state) {
     return
   }
@@ -380,5 +396,4 @@ export function clearPreHandlerPtyState(ptyId: string): void {
     clearTimeout(discardTimer)
   }
   discardedPreHandlerPtyStates.delete(ptyId)
-  warnedLostHandlerPtyIds.delete(ptyId)
 }

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
@@ -5,6 +5,8 @@ import type { PtyDataMeta } from './pty-dispatcher'
 type BufferedPreHandlerPtyData = {
   data: string
   bytes: number
+  /** Dates this chunk, so the fence can drop a prior incarnation's bytes without taking ours. */
+  sequence: number
   meta?: PtyDataMeta
 }
 
@@ -12,8 +14,6 @@ type BufferedPreHandlerPtyState = {
   chunks: BufferedPreHandlerPtyData[]
   head: number
   bytes: number
-  /** Sequence of the newest chunk, used to fence state left by a prior incarnation of a reused id. */
-  sequence: number
 }
 
 type BufferedPreHandlerPtyExit = {
@@ -121,6 +121,29 @@ function retainPreHandlerPtyExits(
   preHandlerPtyExit.set(ptyId, kept)
 }
 
+function retainPreHandlerPtyChunks(
+  ptyId: string,
+  keep: (chunk: BufferedPreHandlerPtyData) => boolean
+): void {
+  const state = preHandlerPtyData.get(ptyId)
+  if (!state) {
+    return
+  }
+  // Slots below `head` are already-released placeholders, so they are dropped either way.
+  const kept = state.chunks.slice(state.head).filter(keep)
+  if (kept.length === state.chunks.length - state.head) {
+    return
+  }
+  if (kept.length === 0) {
+    preHandlerPtyData.delete(ptyId)
+    warnedLostHandlerPtyIds.delete(ptyId)
+    return
+  }
+  state.chunks = kept
+  state.head = 0
+  state.bytes = kept.reduce((total, chunk) => total + chunk.bytes, 0)
+}
+
 export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyDataMeta): void {
   if (discardedPreHandlerPtyStates.has(ptyId)) {
     return
@@ -136,13 +159,13 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
       : meta
   let state = preHandlerPtyData.get(ptyId)
   if (!state) {
-    state = { chunks: [], head: 0, bytes: 0, sequence: 0 }
+    state = { chunks: [], head: 0, bytes: 0 }
     preHandlerPtyData.set(ptyId, state)
   }
-  state.sequence = nextPreHandlerPtySequence()
   state.chunks.push({
     data: chunk.data,
     bytes: chunk.bytes,
+    sequence: nextPreHandlerPtySequence(),
     ...(bufferedMeta ? { meta: bufferedMeta } : {})
   })
   state.bytes += chunk.bytes
@@ -150,7 +173,7 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
   // and head index keep that failure path linear instead of rescanning/shifting.
   while (state.bytes > PRE_HANDLER_PTY_DATA_MAX_BYTES && state.head < state.chunks.length - 1) {
     state.bytes -= state.chunks[state.head].bytes
-    state.chunks[state.head] = { data: '', bytes: 0 }
+    state.chunks[state.head] = { ...state.chunks[state.head], data: '', bytes: 0 }
     state.head += 1
   }
   if (state.head > 0 && state.head * 2 >= state.chunks.length) {
@@ -232,6 +255,8 @@ export function bufferPreHandlerPtyExit(
  *  was recorded when this PTY did not yet exist and cannot describe it. Bytes and exits recorded
  *  after the fence are kept: that is the real pre-attach race (a shell that dies instantly, or
  *  writes before the pane registers its handler) and losing it would blank a legitimate pane.
+ *  Bytes are judged one chunk at a time, because a buffer can hold both owners' output: our first
+ *  chunk arriving while the spawn reply is still in flight must not carry the dead PTY's along.
  *
  *  Still needed alongside `discardPreHandlerPtyExitFromForeignIncarnation`, which supersedes it
  *  wherever both sides name an incarnation. Two cases have none to compare and rest on the fence
@@ -243,11 +268,7 @@ export function discardPreHandlerPtyStateFromPriorIncarnation(
   fenceSequence: number
 ): void {
   retainPreHandlerPtyExits(ptyId, (exit) => exit.sequence > fenceSequence)
-  const data = preHandlerPtyData.get(ptyId)
-  if (data && data.sequence <= fenceSequence) {
-    preHandlerPtyData.delete(ptyId)
-    warnedLostHandlerPtyIds.delete(ptyId)
-  }
+  retainPreHandlerPtyChunks(ptyId, (chunk) => chunk.sequence > fenceSequence)
   // Why: the id now names a different, live PTY, so a prior incarnation's consumed/discarded marks
   // must not suppress this one's own exit — the same admission boundary a same-id reattach gets.
   clearConsumedPreHandlerPtyExit(ptyId)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 |

<!-- /orca-pr-loc -->

## ELI5

When you open a terminal over SSH, output can arrive a split second before the
terminal is ready to draw it, so Orca parks those first bytes in a small holding
area filed under the terminal's id.

The catch: those ids are not unique forever. If the remote helper restarts it
starts numbering again at `pty-1`, so a brand-new terminal can be handed the same
id a dead one used to have — and inherit whatever that dead one left in the
holding area.

Orca already knew this and stamped every parked record with a counter, so a new
terminal could say "that was filed before I even asked for a shell, it isn't
mine." But for output bytes the stamp was kept on the *folder*, not on each
sheet of paper in it, and the folder took the date of its newest sheet. So the
moment the new terminal's own first bytes landed, the folder looked new — and the
dead shell's bytes rode in on that. This files the date on each sheet instead.

## Before / after

- **Before:** after the SSH relay restarted, a newly opened remote terminal could
  come up with the previous, already-dead shell's output printed above its own
  prompt. It only happened when the new shell also wrote before its pane attached
  — which is precisely the race the buffer exists to cover — so it looked random.
- **After:** the new terminal shows only its own output. Bytes recorded after the
  spawn request still replay, so the genuine pre-attach race (a shell that writes
  or dies instantly) is untouched.
- **Who it affects:** anyone using SSH remote terminals across a relay restart or
  reconnect — the same recycled-id hazard that `#16970` fenced for exit codes.

## Not a relocation

`#16970` fenced *exit* records; the pane-never-binds failure it fixed is gone and
stays gone. This closes the byte half of the same fence, which `#16970`'s own doc
comment describes as per-record ("bytes recorded after the fence are kept") while
the code judged the whole buffer at once. Nothing about where a failure is
reported changes; what changes is which chunks survive the discard.

## How this was found

While diagnosing `tests/e2e/ssh-lost-kill-tab-resurrection.spec.ts`, the
second-largest failure source in the `e2e / ssh docker watcher isolation` lane.
That spec's 12 failures are **already fixed on `main` by `#16970`** and are not
what this PR addresses — see the investigation summary below. This is a separate,
latent defect in the module that investigation landed in.

## Evidence

New test in `pty-pre-handler-buffer.test.ts` fails on `main` and passes here:

```
AssertionError: expected [ 'output from the dead shell', …(1) ]
                to deeply equal [ 'our startup bytes' ]
 Tests  1 failed | 20 passed (21)      # source reverted
 Tests  21 passed (21)                 # with this change
```

## Gates

Run from a worktree at `fb6c2800ee` (machine load avg 6.6 / 9.5 / 14.4):

- `pnpm tc` (all projects) — pass
- `oxlint` on changed files — clean
- `audit:code-quality:native` and `:type-aware` config, changed files, `--deny-warnings` — clean
- `node config/scripts/check-changed-code-quality.mjs` — 0 new findings (code quality, type-aware, React Doctor)
- `check-max-lines-ratchet.mjs` / `check-reliability-gates.mjs` — pass; no suppression added
- `npx oxfmt --write` on the two changed files only; `git diff --check` clean
- `vitest src/renderer/src/components/terminal-pane/` — 407 files, 3933 tests, all pass

X / Twitter: `@BrennanKB5`
