### PR TITLE
fix(workspaces): prevent Create from hanging on selected PR

### DIFF
--- a/src/main/github/pr-head-tracking-ref.test.ts
+++ b/src/main/github/pr-head-tracking-ref.test.ts
@@ -30,7 +30,22 @@ describe('fetchPrHeadTrackingRef', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['fetch', 'origin', '+refs/heads/feature/x:refs/remotes/origin/feature/x'],
-      { cwd: '/repo' }
+      { cwd: '/repo', timeout: REVIEW_HEAD_FETCH_TIMEOUT_MS }
+    )
+  })
+
+  it('keeps WSL routing while bounding the remote-tracking fetch', async () => {
+    await fetchPrHeadTrackingRef(
+      { path: '/repo', connectionId: null },
+      null,
+      'origin',
+      'feature/x',
+      { localGitExecOptions: { cwd: '/repo', wslDistro: 'Ubuntu' } }
+    )
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['fetch', 'origin', '+refs/heads/feature/x:refs/remotes/origin/feature/x'],
+      { cwd: '/repo', wslDistro: 'Ubuntu', timeout: REVIEW_HEAD_FETCH_TIMEOUT_MS }
     )
   })
 

--- a/src/main/github/pr-head-tracking-ref.ts
+++ b/src/main/github/pr-head-tracking-ref.ts
@@ -24,10 +24,11 @@ export async function fetchPrHeadTrackingRef(
 ): Promise<void> {
   const ref = `refs/remotes/${remote}/${branch}`
   if (!repo.connectionId) {
-    await gitExecFileAsync(
-      ['fetch', remote, `+refs/heads/${branch}:${ref}`],
-      options.localGitExecOptions ?? { cwd: repo.path }
-    )
+    const localGitExecOptions = options.localGitExecOptions ?? { cwd: repo.path }
+    await gitExecFileAsync(['fetch', remote, `+refs/heads/${branch}:${ref}`], {
+      ...localGitExecOptions,
+      timeout: REVIEW_HEAD_FETCH_TIMEOUT_MS
+    })
     return
   }
   if (!sshGitProvider) {

--- a/src/main/ipc/worktrees-ssh-pr-head-fetch.test.ts
+++ b/src/main/ipc/worktrees-ssh-pr-head-fetch.test.ts
@@ -302,7 +302,7 @@ describe('registerWorktreeHandlers', () => {
         'origin',
         '+refs/heads/feat/onboarding-model-choice-782:refs/remotes/origin/feat/onboarding-model-choice-782'
       ],
-      { cwd: '/workspace/repo' }
+      { cwd: '/workspace/repo', timeout: REVIEW_HEAD_FETCH_TIMEOUT_MS }
     )
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       [

--- a/src/main/ipc/worktrees-wsl-runtime-routing.test.ts
+++ b/src/main/ipc/worktrees-wsl-runtime-routing.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { REVIEW_HEAD_FETCH_TIMEOUT_MS } from '../../shared/review-head-tracking-ref'
 import {
   setPlatform,
   listWorktreesMock,
@@ -283,7 +284,11 @@ describe('registerWorktreeHandlers', () => {
         'origin',
         '+refs/heads/feature/add-feature:refs/remotes/origin/feature/add-feature'
       ],
-      { cwd: '/workspace/repo', wslDistro: 'Ubuntu' }
+      {
+        cwd: '/workspace/repo',
+        wslDistro: 'Ubuntu',
+        timeout: REVIEW_HEAD_FETCH_TIMEOUT_MS
+      }
     )
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['rev-parse', '--verify', 'origin/feature/add-feature'],

--- a/src/renderer/src/hooks/composer-state/github-provider-selection.ts
+++ b/src/renderer/src/hooks/composer-state/github-provider-selection.ts
@@ -42,7 +42,10 @@ import { resolveGitHubPrStartPointForRepo } from '@/lib/github-pr-start-point'
 import { getForkPushWarning } from '../fork-push-warning'
 import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
-import type { SmartGitHubPrStartPointSelection } from './source-selection-decisions'
+import {
+  resolveGitHubPrStartPointSelection,
+  type SmartGitHubPrStartPointSelection
+} from './source-selection-decisions'
 
 export function useGitHubProviderSelection(input: GitHubProviderSelectionInput) {
   const {
@@ -129,22 +132,23 @@ export function useGitHubProviderSelection(input: GitHubProviderSelectionInput) 
         { repos: [runRepo], settings },
         runRepo.id
       )
-      const resolvePrBase = resolveGitHubPrStartPointForRepo({
-        repoId: runRepo.id,
-        prNumber: identity.number,
-        settings: itemRepoSettings,
-        ...(normalizedItem.branchName ? { headRefName: normalizedItem.branchName } : {}),
-        ...(normalizedItem.baseRefName ? { baseRefName: normalizedItem.baseRefName } : {}),
-        ...(normalizedItem.isCrossRepository !== undefined
-          ? { isCrossRepository: normalizedItem.isCrossRepository }
-          : {})
-      })
+      const resolvePrBase = resolveGitHubPrStartPointSelection(startPointSelection, () =>
+        resolveGitHubPrStartPointForRepo({
+          repoId: runRepo.id,
+          prNumber: identity.number,
+          settings: itemRepoSettings,
+          ...(normalizedItem.branchName ? { headRefName: normalizedItem.branchName } : {}),
+          ...(normalizedItem.baseRefName ? { baseRefName: normalizedItem.baseRefName } : {}),
+          ...(normalizedItem.isCrossRepository !== undefined
+            ? { isCrossRepository: normalizedItem.isCrossRepository }
+            : {})
+        })
+      )
       void resolvePrBase
         .then((result) => {
           if (smartGitHubPrStartPointSelectionRef.current !== startPointSelection) {
             return
           }
-          startPointSelection.resolved = result
           handleBaseBranchPrSelect(
             result.baseBranch,
             normalizedItem,

--- a/src/renderer/src/hooks/composer-state/github-submit-resolution.ts
+++ b/src/renderer/src/hooks/composer-state/github-submit-resolution.ts
@@ -48,7 +48,10 @@ import {
 } from '@/lib/github-work-item-source-lookup'
 import type { GitHubWorkItem } from '../../../../shared/github/work-item-types'
 import type { PendingSmartGitHubSubmitResolution } from './source-selection-decisions'
-import { getGitHubLinkedWorkItemIdentity } from './source-selection-decisions'
+import {
+  getGitHubLinkedWorkItemIdentity,
+  resolveGitHubPrStartPointSelection
+} from './source-selection-decisions'
 
 export function useGitHubSubmitResolution(input: GitHubSubmitResolutionInput) {
   const {
@@ -97,26 +100,27 @@ export function useGitHubSubmitResolution(input: GitHubSubmitResolutionInput) {
           startPointSelection?.repoId === selectedRepo.id &&
           startPointIdentity.number === linkedWorkItemIdentity.number
         ) {
-          const selectedPrStartPoint =
-            startPointSelection.resolved ??
-            (await resolveGitHubPrStartPointForRepo({
-              repoId: selectedRepo.id,
-              prNumber: startPointIdentity.number,
-              settings: getSettingsForRepoRuntimeOwner(
-                { repos: [selectedRepo], settings },
-                selectedRepo.id
-              ),
-              ...(startPointSelection.item.branchName
-                ? { headRefName: startPointSelection.item.branchName }
-                : {}),
-              ...(startPointSelection.item.baseRefName
-                ? { baseRefName: startPointSelection.item.baseRefName }
-                : {}),
-              ...(startPointSelection.item.isCrossRepository !== undefined
-                ? { isCrossRepository: startPointSelection.item.isCrossRepository }
-                : {})
-            }))
-          startPointSelection.resolved = selectedPrStartPoint
+          const selectedPrStartPoint = await resolveGitHubPrStartPointSelection(
+            startPointSelection,
+            () =>
+              resolveGitHubPrStartPointForRepo({
+                repoId: selectedRepo.id,
+                prNumber: startPointIdentity.number,
+                settings: getSettingsForRepoRuntimeOwner(
+                  { repos: [selectedRepo], settings },
+                  selectedRepo.id
+                ),
+                ...(startPointSelection.item.branchName
+                  ? { headRefName: startPointSelection.item.branchName }
+                  : {}),
+                ...(startPointSelection.item.baseRefName
+                  ? { baseRefName: startPointSelection.item.baseRefName }
+                  : {}),
+                ...(startPointSelection.item.isCrossRepository !== undefined
+                  ? { isCrossRepository: startPointSelection.item.isCrossRepository }
+                  : {})
+              })
+          )
           const smartGitHubMetadata = getSmartGitHubSubmitResolution(startPointSelection.item)
           const resolution: Exclude<PendingSmartGitHubSubmitResolution, { kind: 'none' }> = {
             ...smartGitHubMetadata,

--- a/src/renderer/src/hooks/composer-state/source-selection-decisions.test.ts
+++ b/src/renderer/src/hooks/composer-state/source-selection-decisions.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GitHubPrStartPoint } from '../../../../shared/worktree/types'
+import {
+  resolveGitHubPrStartPointSelection,
+  type SmartGitHubPrStartPointSelection
+} from './source-selection-decisions'
+
+function selection(): SmartGitHubPrStartPointSelection {
+  return {
+    repoId: 'repo-1',
+    item: {
+      id: 'pr-17128',
+      type: 'pr',
+      number: 17128,
+      title: 'Fix terminal recovery',
+      state: 'merged',
+      url: 'https://github.com/stablyai/orca/pull/17128',
+      labels: [],
+      updatedAt: '2026-08-29T09:27:45.000Z',
+      author: 'octocat',
+      repoId: 'repo-1'
+    }
+  }
+}
+
+describe('resolveGitHubPrStartPointSelection', () => {
+  it('returns the completed selection without resolving again', async () => {
+    const target = selection()
+    target.resolved = { baseBranch: 'cached-head' }
+    const resolve = vi.fn<() => Promise<GitHubPrStartPoint>>()
+
+    await expect(resolveGitHubPrStartPointSelection(target, resolve)).resolves.toEqual({
+      baseBranch: 'cached-head'
+    })
+    expect(resolve).not.toHaveBeenCalled()
+  })
+
+  it('shares an in-flight selection resolution with submit', async () => {
+    let release!: (value: GitHubPrStartPoint) => void
+    const pending = new Promise<GitHubPrStartPoint>((resolve) => {
+      release = resolve
+    })
+    const resolve = vi.fn(() => pending)
+    const target = selection()
+
+    const eager = resolveGitHubPrStartPointSelection(target, resolve)
+    const submit = resolveGitHubPrStartPointSelection(target, resolve)
+    release({ baseBranch: 'resolved-head' })
+
+    await expect(Promise.all([eager, submit])).resolves.toEqual([
+      { baseBranch: 'resolved-head' },
+      { baseBranch: 'resolved-head' }
+    ])
+    expect(resolve).toHaveBeenCalledTimes(1)
+    expect(target).toMatchObject({ resolved: { baseBranch: 'resolved-head' } })
+    expect(target.pendingResolution).toBeUndefined()
+  })
+
+  it('clears a failed pending resolution so create can retry', async () => {
+    const resolve = vi
+      .fn<() => Promise<GitHubPrStartPoint>>()
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockResolvedValueOnce({ baseBranch: 'retry-head' })
+    const target = selection()
+
+    await expect(resolveGitHubPrStartPointSelection(target, resolve)).rejects.toThrow(
+      'fetch failed'
+    )
+    await expect(resolveGitHubPrStartPointSelection(target, resolve)).resolves.toEqual({
+      baseBranch: 'retry-head'
+    })
+
+    expect(resolve).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/hooks/composer-state/source-selection-decisions.ts
+++ b/src/renderer/src/hooks/composer-state/source-selection-decisions.ts
@@ -22,6 +22,36 @@ export type SmartGitHubPrStartPointSelection = {
   repoId: string
   item: GitHubWorkItem
   resolved?: GitHubPrStartPoint
+  pendingResolution?: Promise<GitHubPrStartPoint>
+}
+
+export function resolveGitHubPrStartPointSelection(
+  selection: SmartGitHubPrStartPointSelection,
+  resolve: () => Promise<GitHubPrStartPoint>
+): Promise<GitHubPrStartPoint> {
+  if (selection.resolved) {
+    return Promise.resolve(selection.resolved)
+  }
+  if (selection.pendingResolution) {
+    return selection.pendingResolution
+  }
+
+  const pendingResolution = resolve()
+  selection.pendingResolution = pendingResolution
+  void pendingResolution.then(
+    (result) => {
+      if (selection.pendingResolution === pendingResolution) {
+        selection.resolved = result
+        selection.pendingResolution = undefined
+      }
+    },
+    () => {
+      if (selection.pendingResolution === pendingResolution) {
+        selection.pendingResolution = undefined
+      }
+    }
+  )
+  return pendingResolution
 }
 
 export function getGitHubLinkedWorkItemIdentity(

--- a/tests/e2e/worktree.spec.ts
+++ b/tests/e2e/worktree.spec.ts
@@ -406,12 +406,12 @@ test.describe('Create Workspace', () => {
     }
   })
 
-  test('names the workspace after the PR title when the pasted URL suggestion is selected', async ({
+  test('reuses pending PR resolution when creating from a pasted URL suggestion', async ({
     electronApp,
     orcaPage
   }) => {
     const title = `E2E selected URL resolution ${Date.now()}`
-    const url = 'https://github.com/stablyai/orca/pull/2050'
+    const url = 'https://github.com/stablyai/orca/pull/17128'
     const linkedWorkspacePattern = new RegExp(title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
 
     try {
@@ -440,17 +440,29 @@ test.describe('Create Workspace', () => {
             })
           )
           ipcMain.removeHandler('worktrees:resolvePrBase')
-          // Why: the fixture repo has no remote and its default branch name
-          // depends on the host's git init.defaultBranch (main vs master), so
-          // resolve the PR base to HEAD, which always exists regardless.
-          ipcMain.handle('worktrees:resolvePrBase', () => ({ baseBranch: 'HEAD' }))
+          const fixture = globalThis as unknown as {
+            __smartResolvePrBaseCount?: number
+            __releaseSmartResolvePrBase?: () => void
+          }
+          fixture.__smartResolvePrBaseCount = 0
+          ipcMain.handle('worktrees:resolvePrBase', () => {
+            fixture.__smartResolvePrBaseCount = (fixture.__smartResolvePrBaseCount ?? 0) + 1
+            if (fixture.__smartResolvePrBaseCount > 1) {
+              return new Promise(() => {})
+            }
+            return new Promise<{ baseBranch: string }>((resolve) => {
+              fixture.__releaseSmartResolvePrBase = () => resolve({ baseBranch: 'HEAD' })
+            })
+          })
         },
         { title, url }
       )
 
       const nameInput = dialog.getByPlaceholder(/Type a name/i)
       await expect(nameInput).toBeVisible()
-      await nameInput.fill(url)
+      await orcaPage.evaluate((text) => window.api.ui.writeClipboardText(text), url)
+      await nameInput.focus()
+      await orcaPage.keyboard.press(process.platform === 'darwin' ? 'Meta+V' : 'Control+V')
 
       // Why: this is the regression PR #4900 missed — selecting the resolved
       // suggestion row (instead of submitting the raw URL) must not leave the
@@ -459,17 +471,41 @@ test.describe('Create Workspace', () => {
       const suggestion = orcaPage.getByRole('option', { name: linkedWorkspacePattern })
       await expect(suggestion).toBeVisible()
       await suggestion.click()
+      await expect
+        .poll(() =>
+          electronApp.evaluate(
+            () =>
+              (globalThis as unknown as { __smartResolvePrBaseCount?: number })
+                .__smartResolvePrBaseCount ?? 0
+          )
+        )
+        .toBe(1)
 
       const createButton = dialog.getByRole('button', { name: /Create (Workspace|Worktree)/i })
       await expect(createButton).toBeEnabled()
       await createButton.click()
+      await electronApp.evaluate(() => {
+        const release = (globalThis as unknown as { __releaseSmartResolvePrBase?: () => void })
+          .__releaseSmartResolvePrBase
+        if (!release) {
+          throw new Error('PR base resolution was not held')
+        }
+        release()
+      })
 
       await expect(dialog).toBeHidden({ timeout: 15_000 })
       await expect(orcaPage.getByRole('option', { name: linkedWorkspacePattern })).toBeVisible({
         timeout: 10_000
       })
       await expect(orcaPage.getByRole('option', { name: /https-github/i })).toHaveCount(0)
-      await expect(orcaPage.getByText('Linked PR #2050')).toBeVisible()
+      await expect(orcaPage.getByText('Linked PR #17128')).toBeVisible()
+      expect(
+        await electronApp.evaluate(
+          () =>
+            (globalThis as unknown as { __smartResolvePrBaseCount?: number })
+              .__smartResolvePrBaseCount ?? 0
+        )
+      ).toBe(1)
     } finally {
       await orcaPage
         .evaluate(() => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​142 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​76 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​37 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 |

<!-- /orca-pr-loc -->

## ELI5

Selecting a pull request starts figuring out which Git commit Orca should use. If Create was clicked before that finished, Orca started the same work again and could wait forever. Create now shares the resolution already in progress, and the underlying same-repository fetch has a timeout.

## What Changed

- Reuse a selected PR's in-flight start-point resolution during submit.
- Cache successful resolution and clear failed pending state so a later Create can retry.
- Bound local and WSL same-repository PR branch fetches with the existing 60-second review-head timeout.
- Add deterministic unit, local/WSL integration, and Electron E2E coverage using `https://github.com/stablyai/orca/pull/17128`.

## Why

The exact production sequence was: paste PR #17128 into Smart selection, select it, then immediately click Create. Selection eagerly started `worktrees:resolvePrBase`; submit started a second resolver before the first populated `resolved`. The duplicate Git fetch could remain blocked/unbounded while the dialog kept its creating spinner.

This is newly observed on latest stable, but source history does not support it being introduced by `v1.4.190`: the four affected implementation blobs are identical in `v1.4.187`, `v1.4.188`, and `v1.4.190`. The duplicate-resolution race first shipped in `v1.4.107`; PR #17128 was created after `v1.4.190` and newly exercised the old same-repository path. The later composer split preserved the behavior and is not in `v1.4.190`.

## Linked Issue

N/A — direct production regression report. PR #17128 is the reproduction input, not the issue fixed by this PR.

## Visual Proof

**Before:** the deterministic pre-fix Electron run remained in the Create dialog spinner beyond its 15-second assertion timeout. Because the failure is temporal, a still frame adds no evidence beyond the red regression test.

**After:** exact public PR URL selected and created through the rendered Orca surface; the resulting workspace visibly carries `Linked PR #17128`.

![Create Workspace completed with Linked PR #17128](https://github.com/user-attachments/assets/4e677a7d-9dce-4853-a577-f1a1e0785313)

## Testing

- [x] Manually tested on macOS in Electron via Playwright CDP: clipboard-pasted the exact URL, selected the resolved PR, clicked Create immediately, observed the dialog close, and observed `Linked PR #17128`.
- [x] Automated tests added/updated.

Commands/results:

- `pnpm tc` — passed.
- `pnpm run check:code-quality:changed` — zero new findings across nine changed files.
- Focused unit and integration suites — 92 checks passed, including local, WSL, SSH routing, PR fallback, retry, and in-flight coalescing.
- `pnpm run test:e2e tests/e2e/worktree.spec.ts --grep 'reuses pending PR resolution'` — passed against a rebuilt Electron app. The test makes any second resolver never settle and asserts the resolver count stays exactly one.
- `git diff --check` and focused `oxfmt --check` — passed.

Readiness checklist result: PASS with zero P0/P1/P2 candidates. No RPC/wire, persistence, dependency, mobile-facing, or provider-generic contract changed. SSH remains UI-bounded by its existing 30-second multiplexer timeout; local/WSL now use the existing 60-second Git fetch timeout.

## AI Disclosure

## Review

## Agent skill upstream boundary

- [x] Not applicable; no agent-skill source or registry content changed.

## Notes

Security, cross-platform behavior, SSH/remote behavior, mobile/backward compatibility, performance, and retry/stuck-state behavior were reviewed under the readiness checklist. In-flight coalescing reduces resolver and Git subprocess fanout from two calls to one for this interaction.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before behavior and after visual proof are documented; the before failure is pinned by the deterministic red test
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered
- [x] Local typecheck, changed-code lint/React checks, focused tests, and Electron build/E2E pass; CI will cover the full repository gates
