### PR TITLE
fix(terminal): complete OMP stale cwd recovery

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -6345,8 +6345,8 @@
         "https://github.com/stablyai/orca/issues/16457",
         "https://github.com/stablyai/orca/pull/17128"
       ],
-      "invariant": "A fresh local renderer terminal spawn may recover from a saved startup cwd whose directory no longer exists only by spawning at the selected workspace root and printing a generic in-terminal notice; existing directories — including ones outside the worktree (#7685) — spawn as requested, and reattach, SSH, remote-runtime, runtime/API, and mobile callers keep exact cwd semantics. A long-lived POSIX shell whose cwd inode was deleted and replaced may run an extension-enabled OMP launch from the live path named by its logical PWD only in a subshell; the parent shell cwd, OMP argv, status extension, and exit status remain unchanged, while a genuinely unavailable path fails visibly without invoking OMP. A usable current directory remains authoritative when PWD is unset instead of being remapped to a workspace fallback.",
-      "oracle": "The shared resolver falls back to the workspace root only when the injected existence probe reports the resolved cwd missing and the workspace root present, and never probes floating terminals or a cwd equal to the root. The renderer sends cwdFallback only for fresh local IPC spawns, main honors it only when connectionId and sessionId are absent, WSL UNC paths never engage the probe-based fallback, main returns fallback metadata only after an actual fallback, the IPC transport preserves that metadata, and the connection layer writes a generic notice that omits the missing path. In real interactive Bash and Zsh PTYs, unset PWD in a usable nested directory and require OMP to stay there rather than remap to ORCA_WORKTREE_PATH; then delete and recreate the active project path, require OMP to observe the replacement inode with byte-exact extension argv and its nonzero status preserved, require the parent shell to remain on the stale inode, and finally delete the replacement and require an actionable failure before the fake OMP binary runs again.",
+      "invariant": "A fresh local renderer terminal spawn may recover from a saved startup cwd whose directory no longer exists only by spawning at the selected workspace root and printing a generic in-terminal notice; existing directories — including ones outside the worktree (#7685) — spawn as requested, and reattach, SSH, remote-runtime, runtime/API, and mobile callers keep exact cwd semantics. A long-lived POSIX shell whose cwd inode was deleted and replaced may run a wrapped OMP command from the live path named by its logical PWD only in a subshell; the parent shell cwd, OMP argv, status extension, and exit status remain unchanged, while a genuinely unavailable path fails visibly without invoking OMP. A usable physical cwd remains authoritative when PWD is unset or names a removed logical symlink instead of being remapped to a workspace fallback.",
+      "oracle": "The shared resolver falls back to the workspace root only when the injected existence probe reports the resolved cwd missing and the workspace root present, and never probes floating terminals or a cwd equal to the root. The renderer sends cwdFallback only for fresh local IPC spawns, main honors it only when connectionId and sessionId are absent, WSL UNC paths never engage the probe-based fallback, main returns fallback metadata only after an actual fallback, the IPC transport preserves that metadata, and the connection layer writes a generic notice that omits the missing path. In real interactive Bash and Zsh PTYs, unset PWD and remove a logical symlink while the physical cwd stays usable, requiring OMP to remain there; then delete and recreate the active project path, require extension-enabled and extension-skipping invocations to observe the replacement inode with byte-exact argv and nonzero status preserved, require the parent shell to remain on the stale inode, unset PWD and require recovery through ORCA_WORKTREE_PATH, clear every logical fallback and require an actionable failure without invoking OMP, and finally delete the replacement and require the same for the missing PWD path.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-startup-cwd.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty-spawn-cwd-fallback.test.ts src/main/ipc/pty-wsl-cwd-validation.test.ts",
@@ -6410,6 +6410,10 @@
           "assertions": [
             "real Bash and Zsh PTYs rebind OMP to a recreated cwd inode without changing the parent shell",
             "an unset PWD with a usable cwd stays unset and does not remap OMP to ORCA_WORKTREE_PATH",
+            "a removed logical symlink does not invalidate its still-usable physical cwd",
+            "extension-skipping commands such as omp --version still recover the cwd without gaining extension argv",
+            "an unset PWD on a stale inode recovers through ORCA_WORKTREE_PATH",
+            "an unset PWD on a stale inode without a logical fallback fails visibly before invoking OMP",
             "extension argv and a nonzero OMP exit status survive the recovery subshell",
             "a subsequently missing logical cwd prints an actionable error and does not invoke OMP again"
           ]
@@ -6465,7 +6469,7 @@
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/pty/omp-shell-wrapper.node-pty.test.ts src/main/pty/omp-shell-wrapper-alias-safety.test.ts src/main/shell-wrapper-generated-file-snapshot.test.ts",
           "result": "passed",
           "durationSeconds": 3,
-          "summary": "3 test files passed; real Bash and Zsh PTYs covered unset-PWD authority, stale-inode recovery, parent-shell isolation, extension argv, exit status, missing-path visibility, alias safety, and generated local/daemon/relay parity."
+          "summary": "3 test files passed; real Bash and Zsh PTYs covered usable physical cwd authority, stale-inode recovery with set and unset PWD, extension-enabled and extension-skipping argv, parent-shell isolation, exit status, missing-path visibility, alias safety, and generated local/daemon/relay parity."
         }
       ],
       "runtimeBudget": {
@@ -6482,7 +6486,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "The spawn recovery adds at most two statSync probes on the fresh-local spawn path (the provider already stats the same paths during validation) and one bounded terminal write only when fallback actually occurs. Each extension-enabled OMP launch adds a constant number of shell filesystem predicates; only a detected stale/unusable cwd creates one short recovery subshell. No polling, retry, provider listing, hidden-pane work, startup awaits, extra OMP subprocesses, or render-loop work was added."
+        "evidence": "The spawn recovery adds at most two statSync probes on the fresh-local spawn path (the provider already stats the same paths during validation) and one bounded terminal write only when fallback actually occurs. Each wrapped OMP launch adds a constant number of shell filesystem predicates; only a detected stale/unusable cwd creates one short recovery subshell. No polling, retry, provider listing, hidden-pane work, startup awaits, extra OMP subprocesses, or render-loop work was added."
       },
       "promotionCriteria": [
         "Attach CI evidence for all declared test files.",

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
@@ -45,11 +45,14 @@ __orca_omp_should_skip_extension() {
   return 1
 }
 __orca_omp_cwd_is_usable() {
+  local __orca_physical_cwd
   [[ -x . ]] || return 1
-  if [[ -n "${PWD:-}" ]]; then
-    [[ -d "${PWD}" && "${PWD}" -ef . ]]
+  if [[ -n "${PWD:-}" && -d "${PWD:-}" ]]; then
+    [[ "${PWD}" -ef . ]]
   else
-    builtin pwd -P >/dev/null 2>&1
+    # Why compare the path: shell builtins can print a cached path for a deleted cwd.
+    __orca_physical_cwd="$(builtin pwd -P 2>/dev/null)" || return 1
+    [[ -d "$__orca_physical_cwd" && "$__orca_physical_cwd" -ef . ]]
   fi
 }
 __orca_omp_invoke() {
@@ -69,7 +72,7 @@ __orca_omp_invoke() {
 __orca_omp() {
   local __orca_use_extension=1
   __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
-  if [[ $__orca_use_extension -eq 1 ]] && ! __orca_omp_cwd_is_usable; then
+  if ! __orca_omp_cwd_is_usable; then
     local __orca_logical_cwd="${PWD:-${ORCA_WORKTREE_PATH:-${ORCA_ROOT_PATH:-}}}"
     # Why: a restored shell can retain the deleted directory inode after its path is recreated.
     (

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
@@ -83,11 +83,14 @@ __orca_deferred_init() {
       return 1
     }
     __orca_omp_cwd_is_usable() {
+      local __orca_physical_cwd
       [[ -x . ]] || return 1
-      if [[ -n "${PWD:-}" ]]; then
-        [[ -d "${PWD}" && "${PWD}" -ef . ]]
+      if [[ -n "${PWD:-}" && -d "${PWD:-}" ]]; then
+        [[ "${PWD}" -ef . ]]
       else
-        builtin pwd -P >/dev/null 2>&1
+        # Why compare the path: shell builtins can print a cached path for a deleted cwd.
+        __orca_physical_cwd="$(builtin pwd -P 2>/dev/null)" || return 1
+        [[ -d "$__orca_physical_cwd" && "$__orca_physical_cwd" -ef . ]]
       fi
     }
     __orca_omp_invoke() {
@@ -107,7 +110,7 @@ __orca_deferred_init() {
     __orca_omp() {
       local __orca_use_extension=1
       __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
-      if [[ $__orca_use_extension -eq 1 ]] && ! __orca_omp_cwd_is_usable; then
+      if ! __orca_omp_cwd_is_usable; then
         local __orca_logical_cwd="${PWD:-${ORCA_WORKTREE_PATH:-${ORCA_ROOT_PATH:-}}}"
         # Why: a restored shell can retain the deleted directory inode after its path is recreated.
         (

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
@@ -48,11 +48,14 @@ __orca_omp_should_skip_extension() {
   return 1
 }
 __orca_omp_cwd_is_usable() {
+  local __orca_physical_cwd
   [[ -x . ]] || return 1
-  if [[ -n "${PWD:-}" ]]; then
-    [[ -d "${PWD}" && "${PWD}" -ef . ]]
+  if [[ -n "${PWD:-}" && -d "${PWD:-}" ]]; then
+    [[ "${PWD}" -ef . ]]
   else
-    builtin pwd -P >/dev/null 2>&1
+    # Why compare the path: shell builtins can print a cached path for a deleted cwd.
+    __orca_physical_cwd="$(builtin pwd -P 2>/dev/null)" || return 1
+    [[ -d "$__orca_physical_cwd" && "$__orca_physical_cwd" -ef . ]]
   fi
 }
 __orca_omp_invoke() {
@@ -72,7 +75,7 @@ __orca_omp_invoke() {
 __orca_omp() {
   local __orca_use_extension=1
   __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
-  if [[ $__orca_use_extension -eq 1 ]] && ! __orca_omp_cwd_is_usable; then
+  if ! __orca_omp_cwd_is_usable; then
     local __orca_logical_cwd="${PWD:-${ORCA_WORKTREE_PATH:-${ORCA_ROOT_PATH:-}}}"
     # Why: a restored shell can retain the deleted directory inode after its path is recreated.
     (

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
@@ -83,11 +83,14 @@ __orca_deferred_init() {
       return 1
     }
     __orca_omp_cwd_is_usable() {
+      local __orca_physical_cwd
       [[ -x . ]] || return 1
-      if [[ -n "${PWD:-}" ]]; then
-        [[ -d "${PWD}" && "${PWD}" -ef . ]]
+      if [[ -n "${PWD:-}" && -d "${PWD:-}" ]]; then
+        [[ "${PWD}" -ef . ]]
       else
-        builtin pwd -P >/dev/null 2>&1
+        # Why compare the path: shell builtins can print a cached path for a deleted cwd.
+        __orca_physical_cwd="$(builtin pwd -P 2>/dev/null)" || return 1
+        [[ -d "$__orca_physical_cwd" && "$__orca_physical_cwd" -ef . ]]
       fi
     }
     __orca_omp_invoke() {
@@ -107,7 +110,7 @@ __orca_deferred_init() {
     __orca_omp() {
       local __orca_use_extension=1
       __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
-      if [[ $__orca_use_extension -eq 1 ]] && ! __orca_omp_cwd_is_usable; then
+      if ! __orca_omp_cwd_is_usable; then
         local __orca_logical_cwd="${PWD:-${ORCA_WORKTREE_PATH:-${ORCA_ROOT_PATH:-}}}"
         # Why: a restored shell can retain the deleted directory inode after its path is recreated.
         (

--- a/src/main/__fixtures__/shell-wrapper-snapshots/relay-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/relay-bash-rcfile.txt
@@ -37,11 +37,14 @@ __orca_omp_should_skip_extension() {
   return 1
 }
 __orca_omp_cwd_is_usable() {
+  local __orca_physical_cwd
   [[ -x . ]] || return 1
-  if [[ -n "${PWD:-}" ]]; then
-    [[ -d "${PWD}" && "${PWD}" -ef . ]]
+  if [[ -n "${PWD:-}" && -d "${PWD:-}" ]]; then
+    [[ "${PWD}" -ef . ]]
   else
-    builtin pwd -P >/dev/null 2>&1
+    # Why compare the path: shell builtins can print a cached path for a deleted cwd.
+    __orca_physical_cwd="$(builtin pwd -P 2>/dev/null)" || return 1
+    [[ -d "$__orca_physical_cwd" && "$__orca_physical_cwd" -ef . ]]
   fi
 }
 __orca_omp_invoke() {
@@ -61,7 +64,7 @@ __orca_omp_invoke() {
 __orca_omp() {
   local __orca_use_extension=1
   __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
-  if [[ $__orca_use_extension -eq 1 ]] && ! __orca_omp_cwd_is_usable; then
+  if ! __orca_omp_cwd_is_usable; then
     local __orca_logical_cwd="${PWD:-${ORCA_WORKTREE_PATH:-${ORCA_ROOT_PATH:-}}}"
     # Why: a restored shell can retain the deleted directory inode after its path is recreated.
     (

--- a/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshenv.txt
@@ -57,11 +57,14 @@ __orca_deferred_init() {
       return 1
     }
     __orca_omp_cwd_is_usable() {
+      local __orca_physical_cwd
       [[ -x . ]] || return 1
-      if [[ -n "${PWD:-}" ]]; then
-        [[ -d "${PWD}" && "${PWD}" -ef . ]]
+      if [[ -n "${PWD:-}" && -d "${PWD:-}" ]]; then
+        [[ "${PWD}" -ef . ]]
       else
-        builtin pwd -P >/dev/null 2>&1
+        # Why compare the path: shell builtins can print a cached path for a deleted cwd.
+        __orca_physical_cwd="$(builtin pwd -P 2>/dev/null)" || return 1
+        [[ -d "$__orca_physical_cwd" && "$__orca_physical_cwd" -ef . ]]
       fi
     }
     __orca_omp_invoke() {
@@ -81,7 +84,7 @@ __orca_deferred_init() {
     __orca_omp() {
       local __orca_use_extension=1
       __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
-      if [[ $__orca_use_extension -eq 1 ]] && ! __orca_omp_cwd_is_usable; then
+      if ! __orca_omp_cwd_is_usable; then
         local __orca_logical_cwd="${PWD:-${ORCA_WORKTREE_PATH:-${ORCA_ROOT_PATH:-}}}"
         # Why: a restored shell can retain the deleted directory inode after its path is recreated.
         (

--- a/src/main/pty/omp-shell-wrapper.node-pty.test.ts
+++ b/src/main/pty/omp-shell-wrapper.node-pty.test.ts
@@ -1,11 +1,13 @@
 import { spawnSync } from 'node:child_process'
 import {
   chmodSync,
+  existsSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
   realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -334,18 +336,82 @@ exit 0
     const homeDir = join(tempDir, 'home')
     const binDir = join(tempDir, 'bin')
     const extensionDir = join(tempDir, 'extensions')
+    const logicalProjectLink = join(tempDir, 'logical-project')
     mkdirSync(projectDir, { recursive: true })
     mkdirSync(homeDir)
     mkdirSync(binDir)
     mkdirSync(extensionDir)
+    symlinkSync(projectDir, logicalProjectLink)
     const expectedProjectDir = realpathSync(projectDir)
+    const expectedWorkspaceDir = realpathSync(workspaceDir)
     const statusExtension = join(extensionDir, 'orca-agent-status.ts')
     writeFileSync(statusExtension, 'export default {}')
     writeFakeOmp(binDir)
 
     const unsetPwdCaptureFile = join(tempDir, 'unset-pwd-capture')
+    const deletedLinkCaptureFile = join(tempDir, 'deleted-link-capture')
     const staleCaptureFile = join(tempDir, 'stale-cwd-capture')
+    const skipCaptureFile = join(tempDir, 'skip-capture')
+    const staleUnsetCaptureFile = join(tempDir, 'stale-unset-capture')
+    const noLogicalCaptureFile = join(tempDir, 'no-logical-capture')
     const resultFile = join(tempDir, 'stale-cwd-result')
+    const scenarioFile = join(tempDir, 'stale-cwd-scenario')
+    writeFileSync(
+      scenarioFile,
+      `ORCA_CAPTURE_FILE="$ORCA_UNSET_PWD_CAPTURE_FILE"
+unset PWD
+omp
+__orca_test_unset_status=$?
+if [[ -z "\${PWD+x}" ]]; then
+  __orca_test_pwd_state=unset
+else
+  __orca_test_pwd_state=set
+fi
+builtin cd -- "$ORCA_LOGICAL_PROJECT_LINK"
+/bin/rm -- "$ORCA_LOGICAL_PROJECT_LINK"
+ORCA_CAPTURE_FILE="$ORCA_DELETED_LINK_CAPTURE_FILE"
+omp
+__orca_test_deleted_link_status=$?
+builtin cd -P -- "$ORCA_STALE_PROJECT_DIR"
+ORCA_CAPTURE_FILE="$ORCA_STALE_CAPTURE_FILE"
+/bin/rm -rf -- "$ORCA_STALE_PROJECT_DIR"
+/bin/mkdir -p -- "$ORCA_STALE_PROJECT_DIR"
+omp
+__orca_test_first_status=$?
+ORCA_CAPTURE_FILE="$ORCA_SKIP_CAPTURE_FILE"
+omp --version
+__orca_test_skip_status=$?
+if [[ "$PWD" -ef . ]]; then
+  __orca_test_parent_state=live
+else
+  __orca_test_parent_state=stale
+fi
+unset PWD
+ORCA_CAPTURE_FILE="$ORCA_STALE_UNSET_CAPTURE_FILE"
+omp
+__orca_test_stale_unset_status=$?
+unset ORCA_WORKTREE_PATH ORCA_ROOT_PATH
+ORCA_CAPTURE_FILE="$ORCA_NO_LOGICAL_CAPTURE_FILE"
+omp
+__orca_test_no_logical_status=$?
+PWD="$ORCA_STALE_PROJECT_DIR"
+/bin/rm -rf -- "$ORCA_STALE_PROJECT_DIR"
+omp
+__orca_test_missing_status=$?
+{
+  echo "UNSET=$__orca_test_unset_status"
+  echo "PWD=$__orca_test_pwd_state"
+  echo "LINK=$__orca_test_deleted_link_status"
+  echo "FIRST=$__orca_test_first_status"
+  echo "SKIP=$__orca_test_skip_status"
+  echo "PARENT=$__orca_test_parent_state"
+  echo "STALE_UNSET=$__orca_test_stale_unset_status"
+  echo "NO_LOGICAL=$__orca_test_no_logical_status"
+  echo "MISSING=$__orca_test_missing_status"
+} > "$ORCA_RESULT_FILE"
+exit 0
+`
+    )
     const output = await runInteractivePosixPty({
       shell,
       cwd: projectDir,
@@ -355,47 +421,30 @@ ${getPosixOmpShellWrapper()}`,
         INPUTRC: '/dev/null',
         PROMPT_COMMAND: '',
         ORCA_STALE_PROJECT_DIR: projectDir,
+        ORCA_LOGICAL_PROJECT_LINK: logicalProjectLink,
         ORCA_UNSET_PWD_CAPTURE_FILE: unsetPwdCaptureFile,
+        ORCA_DELETED_LINK_CAPTURE_FILE: deletedLinkCaptureFile,
         ORCA_STALE_CAPTURE_FILE: staleCaptureFile,
+        ORCA_SKIP_CAPTURE_FILE: skipCaptureFile,
+        ORCA_STALE_UNSET_CAPTURE_FILE: staleUnsetCaptureFile,
+        ORCA_NO_LOGICAL_CAPTURE_FILE: noLogicalCaptureFile,
         ORCA_WORKTREE_PATH: workspaceDir,
         HOME: homeDir,
         PATH: `${binDir}:/usr/bin:/bin:/usr/sbin:/sbin`,
         ORCA_OMP_STATUS_EXTENSION: statusExtension,
         ORCA_CAPTURE_FILE: staleCaptureFile,
         ORCA_RESULT_FILE: resultFile,
+        ORCA_SCENARIO_FILE: scenarioFile,
         ORCA_TEST_FAKE_OMP_EXIT_CODE: '23',
         TERM: 'xterm-256color'
       },
-      input: `ORCA_CAPTURE_FILE="$ORCA_UNSET_PWD_CAPTURE_FILE"
-unset PWD
-omp
-__orca_test_unset_status=$?
-if [[ -z "\${PWD+x}" ]]; then
-  __orca_test_pwd_state=unset
-else
-  __orca_test_pwd_state=set
-fi
-builtin cd -P -- "$ORCA_STALE_PROJECT_DIR"
-ORCA_CAPTURE_FILE="$ORCA_STALE_CAPTURE_FILE"
-/bin/rm -rf -- "$ORCA_STALE_PROJECT_DIR"
-/bin/mkdir -p -- "$ORCA_STALE_PROJECT_DIR"
-omp
-__orca_test_first_status=$?
-if [[ "$PWD" -ef . ]]; then
-  __orca_test_parent_state=live
-else
-  __orca_test_parent_state=stale
-fi
-/bin/rm -rf -- "$ORCA_STALE_PROJECT_DIR"
-omp
-__orca_test_missing_status=$?
-printf 'UNSET=%s\nPWD=%s\nFIRST=%s\nPARENT=%s\nMISSING=%s\n' "$__orca_test_unset_status" "$__orca_test_pwd_state" "$__orca_test_first_status" "$__orca_test_parent_state" "$__orca_test_missing_status" > "$ORCA_RESULT_FILE"
-exit 0
-`
+      input: 'source "$ORCA_SCENARIO_FILE"\n'
     })
 
     const unsetPwdCapture = readFileSync(unsetPwdCaptureFile, 'utf8')
     expect(unsetPwdCapture).toContain(`CWD=${expectedProjectDir}`)
+    const deletedLinkCapture = readFileSync(deletedLinkCaptureFile, 'utf8')
+    expect(deletedLinkCapture).toContain(`CWD=${expectedProjectDir}`)
     const staleCapture = readFileSync(staleCaptureFile, 'utf8')
     expect(staleCapture).toContain(`CWD=${expectedProjectDir}`)
     expect(staleCapture.split('\n').filter((line) => line.startsWith('ARG'))).toEqual([
@@ -403,9 +452,17 @@ exit 0
       `ARG2=${statusExtension}`
     ])
     expect(staleCapture).not.toContain('--cwd')
+    const skipCapture = readFileSync(skipCaptureFile, 'utf8')
+    expect(skipCapture).toContain(`CWD=${expectedProjectDir}`)
+    expect(skipCapture).toContain('ARG1=--version')
+    expect(skipCapture).not.toContain('--extension')
+    const staleUnsetCapture = readFileSync(staleUnsetCaptureFile, 'utf8')
+    expect(staleUnsetCapture).toContain(`CWD=${expectedWorkspaceDir}`)
+    expect(existsSync(noLogicalCaptureFile)).toBe(false)
     expect(readFileSync(resultFile, 'utf8')).toBe(
-      'UNSET=23\nPWD=unset\nFIRST=23\nPARENT=stale\nMISSING=1\n'
+      'UNSET=23\nPWD=unset\nLINK=23\nFIRST=23\nSKIP=23\nPARENT=stale\nSTALE_UNSET=23\nNO_LOGICAL=1\nMISSING=1\n'
     )
+    expect(output).toContain('no terminal working directory is available')
     expect(output).toContain('Orca: OMP cannot access the terminal working directory')
   }
 

--- a/src/main/pty/omp-shell-wrapper.ts
+++ b/src/main/pty/omp-shell-wrapper.ts
@@ -52,11 +52,14 @@ __orca_omp_should_skip_extension() {
   return 1
 }
 __orca_omp_cwd_is_usable() {
+  local __orca_physical_cwd
   [[ -x . ]] || return 1
-  if [[ -n "\${PWD:-}" ]]; then
-    [[ -d "\${PWD}" && "\${PWD}" -ef . ]]
+  if [[ -n "\${PWD:-}" && -d "\${PWD:-}" ]]; then
+    [[ "\${PWD}" -ef . ]]
   else
-    builtin pwd -P >/dev/null 2>&1
+    # Why compare the path: shell builtins can print a cached path for a deleted cwd.
+    __orca_physical_cwd="$(builtin pwd -P 2>/dev/null)" || return 1
+    [[ -d "$__orca_physical_cwd" && "$__orca_physical_cwd" -ef . ]]
   fi
 }
 __orca_omp_invoke() {
@@ -76,7 +79,7 @@ __orca_omp_invoke() {
 __orca_omp() {
   local __orca_use_extension=1
   __orca_omp_should_skip_extension "\${1:-}" && __orca_use_extension=0
-  if [[ $__orca_use_extension -eq 1 ]] && ! __orca_omp_cwd_is_usable; then
+  if ! __orca_omp_cwd_is_usable; then
     local __orca_logical_cwd="\${PWD:-\${ORCA_WORKTREE_PATH:-\${ORCA_ROOT_PATH:-}}}"
     # Why: a restored shell can retain the deleted directory inode after its path is recreated.
     (


### PR DESCRIPTION
## ELI5

An Orca terminal can keep standing in an old folder object after the project path is deleted and recreated. The prompt still shows the familiar path, but OMP cannot determine its current directory and exits before doing any work.

Orca now checks the shell's real directory before every wrapped OMP command. If the path was replaced, OMP runs from the live replacement in a temporary subshell; the user's parent shell stays untouched. If only a logical symlink disappeared but the physical directory is still usable, Orca leaves it alone.

## What Changed

- Run stale-cwd validation and recovery for every wrapped POSIX OMP invocation, including commands such as `omp --version` that intentionally skip the status extension.
- Reject cached `pwd -P` output unless the path still exists and names the shell's current directory.
- Preserve a usable physical cwd when `PWD` is unset or names a removed logical symlink.
- Expand real Bash/Zsh PTY coverage and regenerate the byte-identical local, daemon/SSH, and relay wrapper fixtures.

## Why

The original recovery in #17128 left two real failure modes: extension-skipping commands bypassed recovery, and shell builtins could report a cached deleted path as though the cwd were usable. A narrow cwd predicate plus a recovery subshell closes those gaps without changing OMP argv, extension selection, exit status, or parent-shell state.

## Linked Issue

Fixes #16457

Follow-up to #17128.

## Visual Proof

N/A — this changes terminal cwd/process behavior, not product layout or visual design. The real rendered terminal flow is covered under Testing.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- Dedicated Orca Electron instance attached to this branch:
  - real `omp/18.0.10 --version` exited 0 from a replaced cwd while the parent shell remained on the stale inode
  - real OMP exited 0 after the logical symlink was removed while the physical cwd remained usable
  - stale cwd + unset `PWD` + no workspace/root fallback showed the actionable Orca error and returned 1 without starting OMP
  - visible terminal output and the main-owned PTY buffer snapshot agreed
- 10 focused test files: 151/151 tests passed.
- Bash 3.2 and Zsh 5.9 real-PTY wrapper tests: 20/20 passed.
- All six generated local/daemon/relay Bash/Zsh fixtures passed native syntax checks; the shared wrapper passed ShellCheck.
- `pnpm tc:node`
- `pnpm run check:code-quality:changed`
- `pnpm run check:max-lines-ratchet`
- `pnpm run check:reliability-gates`
- Full macOS, Windows, shell-contract, typecheck, static-analysis, and eight-shard test coverage is enforced by PR CI.

## AI Disclosure

## Review

- **Reliability invariant:** `terminal-session.startup-cwd-missing-dir-recovery` — recovery may rebind only the child OMP invocation; parent cwd/PWD, argv, extension behavior, and exit status remain authoritative.
- **Oracle:** real Bash/Zsh PTYs cover usable physical cwd authority, replaced inodes with set/unset `PWD`, skipped and extension-enabled argv, nonzero status propagation, parent-shell isolation, and visible failure without invocation when no recovery path exists.
- **Performance:** every wrapped OMP launch adds only a bounded group of shell filesystem predicates; a short subshell is created only after an unusable cwd is detected. No polling, retry, listener, timer, provider scan, render work, or extra OMP subprocess was added.
- **Compatibility:** no persisted state, protocol/wire payload, mobile-facing surface, dependency, or native PowerShell behavior changed. The POSIX wrapper executes on its owning local/daemon/SSH/relay host, and generated fixtures pin all six Bash/Zsh variants to the same source.
- **Readiness verdict:** no P0/P1/P2 candidate finding remains after fixes and verification. Findings-severity counsel is skipped as required when the candidate list is empty.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Residual execution gaps are explicit in the experimental reliability gate: no live Linux/WSL or SSH/relay stale-inode journey was run. Those topologies consume the same execution-host POSIX wrapper pinned by generated-file snapshots. Native Windows/PowerShell does not use this cwd predicate.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
