### PR TITLE
perf(markdown): cache repeated syntax highlighting

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -35,8 +35,9 @@ import type { RichMarkdownHtmlSuperscriptLinkContext } from './rich-markdown-htm
 import { RichMarkdownOrderedList } from './rich-markdown-ordered-list'
 import { RichMarkdownCodeBlockLowlight } from './rich-markdown-lowlight'
 import { RichMarkdownTaskList } from './rich-markdown-task-list'
+import { createCachedLowlight } from './rich-markdown-lowlight-cache'
 
-const lowlight = createLowlight(common)
+const lowlight = createCachedLowlight(createLowlight(common))
 
 const RichMarkdownLink = Link.extend({
   // Why: link's priority must stay below code's default 100 so Markdown

--- a/src/renderer/src/components/editor/rich-markdown-lowlight-cache.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-lowlight-cache.test.ts
@@ -1,0 +1,117 @@
+import { common, createLowlight } from 'lowlight'
+import { describe, expect, it, vi } from 'vitest'
+import { createCachedLowlight } from './rich-markdown-lowlight-cache'
+
+const CODE = 'export function handler(input: string): string { return input.trim() }'
+
+describe('createCachedLowlight', () => {
+  it('reuses one exact-language result across 533 identical code blocks', () => {
+    const lowlight = createLowlight(common)
+    const highlight = vi.spyOn(lowlight, 'highlight')
+    const cached = createCachedLowlight(lowlight)
+
+    for (let index = 0; index < 533; index += 1) {
+      cached.highlight('typescript', CODE)
+    }
+
+    expect(highlight).toHaveBeenCalledOnce()
+  })
+
+  it('matches lowlight for exact-language and automatic highlighting', () => {
+    const stock = createLowlight(common)
+    const cached = createCachedLowlight(createLowlight(common))
+
+    expect(cached.highlight('typescript', CODE, { prefix: 'syntax-' })).toEqual(
+      stock.highlight('typescript', CODE, { prefix: 'syntax-' })
+    )
+    expect(
+      cached.highlightAuto(CODE, {
+        prefix: 'syntax-',
+        subset: ['javascript', 'typescript']
+      })
+    ).toEqual(
+      stock.highlightAuto(CODE, {
+        prefix: 'syntax-',
+        subset: ['javascript', 'typescript']
+      })
+    )
+  })
+
+  it('preserves language registration', () => {
+    const cached = createCachedLowlight(createLowlight())
+
+    cached.register('typescript', common.typescript)
+
+    expect(cached.listLanguages()).toEqual(['typescript'])
+    expect(cached.registered('typescript')).toBe(true)
+    expect(cached.highlight('typescript', CODE).children).not.toHaveLength(0)
+  })
+
+  it('keys explicit language, automatic mode, and supported options independently', () => {
+    const lowlight = createLowlight(common)
+    const highlight = vi.spyOn(lowlight, 'highlight')
+    const highlightAuto = vi.spyOn(lowlight, 'highlightAuto')
+    const cached = createCachedLowlight(lowlight)
+
+    cached.highlight('typescript', CODE, { prefix: 'first-' })
+    cached.highlight('typescript', CODE, { prefix: 'second-' })
+    cached.highlight('typescript', CODE, { prefix: 'first-' })
+    cached.highlightAuto(CODE, { subset: ['typescript'] })
+    cached.highlightAuto(CODE, { subset: ['javascript'] })
+    cached.highlightAuto(CODE, { subset: ['typescript'] })
+
+    expect(highlight).toHaveBeenCalledTimes(2)
+    expect(highlightAuto).toHaveBeenCalledTimes(2)
+  })
+
+  it('preserves registration APIs and invalidates results after registry changes', () => {
+    const lowlight = createLowlight(common)
+    const reference = createLowlight(common)
+    const highlight = vi.spyOn(lowlight, 'highlight')
+    const cached = createCachedLowlight(lowlight)
+
+    cached.highlight('javascript', CODE)
+    cached.highlight('javascript', CODE)
+    cached.registerAlias('javascript', 'cached-js')
+    reference.registerAlias('javascript', 'cached-js')
+
+    expect(cached.registered('cached-js')).toBe(true)
+    expect(cached.highlight('cached-js', CODE)).toEqual(reference.highlight('cached-js', CODE))
+    cached.highlight('javascript', CODE)
+    expect(highlight).toHaveBeenCalledTimes(3)
+  })
+
+  it('evicts least-recently-used results by entry count', () => {
+    const lowlight = createLowlight(common)
+    const highlight = vi.spyOn(lowlight, 'highlight')
+    const cached = createCachedLowlight(lowlight, {
+      maxEntries: 2,
+      maxSourceCharacters: 100
+    })
+
+    cached.highlight('typescript', 'first')
+    cached.highlight('typescript', 'second')
+    cached.highlight('typescript', 'first')
+    cached.highlight('typescript', 'third')
+    cached.highlight('typescript', 'second')
+
+    expect(highlight).toHaveBeenCalledTimes(4)
+  })
+
+  it('bounds retained source text and does not retain oversized blocks', () => {
+    const lowlight = createLowlight(common)
+    const highlight = vi.spyOn(lowlight, 'highlight')
+    const cached = createCachedLowlight(lowlight, {
+      maxEntries: 10,
+      maxSourceCharacters: 5
+    })
+
+    cached.highlight('typescript', '123')
+    cached.highlight('typescript', '456')
+    cached.highlight('typescript', '123')
+    cached.highlight('typescript', '123456')
+    cached.highlight('typescript', '123456')
+
+    expect(highlight).toHaveBeenCalledTimes(5)
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-lowlight-cache.ts
+++ b/src/renderer/src/components/editor/rich-markdown-lowlight-cache.ts
@@ -1,0 +1,127 @@
+import type { AutoOptions, createLowlight, LanguageFn, Options } from 'lowlight'
+
+type Lowlight = ReturnType<typeof createLowlight>
+type HighlightResult = ReturnType<Lowlight['highlight']>
+
+type HighlightCacheEntry = {
+  result: HighlightResult
+  sourceCharacters: number
+}
+
+type HighlightCacheLimits = {
+  maxEntries: number
+  maxSourceCharacters: number
+}
+
+// Source text bounds retained HASTs; the entry cap also covers empty and tiny blocks.
+const DEFAULT_CACHE_LIMITS: HighlightCacheLimits = {
+  maxEntries: 256,
+  maxSourceCharacters: 128 * 1024
+}
+
+function prefixKey(options: Readonly<Options> | null | undefined): string | null {
+  return options?.prefix ?? null
+}
+
+function highlightKey(
+  language: string,
+  value: string,
+  options: Readonly<Options> | null | undefined
+): string {
+  return JSON.stringify(['language', language, prefixKey(options), value])
+}
+
+function highlightAutoKey(
+  value: string,
+  options: Readonly<AutoOptions> | null | undefined
+): string {
+  return JSON.stringify(['auto', prefixKey(options), options?.subset ?? null, value])
+}
+
+export function createCachedLowlight(
+  lowlight: Lowlight,
+  limits: HighlightCacheLimits = DEFAULT_CACHE_LIMITS
+): Lowlight {
+  const cache = new Map<string, HighlightCacheEntry>()
+  let retainedSourceCharacters = 0
+
+  const clear = (): void => {
+    cache.clear()
+    retainedSourceCharacters = 0
+  }
+
+  const getOrHighlight = (
+    createKey: () => string,
+    sourceCharacters: number,
+    highlight: () => HighlightResult
+  ): HighlightResult => {
+    if (
+      limits.maxEntries <= 0 ||
+      limits.maxSourceCharacters <= 0 ||
+      sourceCharacters > limits.maxSourceCharacters
+    ) {
+      return highlight()
+    }
+
+    const key = createKey()
+    const cached = cache.get(key)
+    if (cached) {
+      cache.delete(key)
+      cache.set(key, cached)
+      return cached.result
+    }
+    const result = highlight()
+    cache.set(key, { result, sourceCharacters })
+    retainedSourceCharacters += sourceCharacters
+    while (
+      cache.size > limits.maxEntries ||
+      retainedSourceCharacters > limits.maxSourceCharacters
+    ) {
+      const oldest = cache.entries().next()
+      if (oldest.done) {
+        break
+      }
+      retainedSourceCharacters -= oldest.value[1].sourceCharacters
+      cache.delete(oldest.value[0])
+    }
+    return result
+  }
+
+  const register = ((
+    grammarsOrName: Readonly<Record<string, LanguageFn>> | string,
+    grammar?: LanguageFn
+  ): undefined => {
+    clear()
+    return typeof grammarsOrName === 'string'
+      ? lowlight.register(grammarsOrName, grammar as LanguageFn)
+      : lowlight.register(grammarsOrName)
+  }) as Lowlight['register']
+
+  const registerAlias = ((
+    aliasesOrName: Readonly<Record<string, readonly string[] | string>> | string,
+    alias?: readonly string[] | string
+  ): undefined => {
+    clear()
+    return typeof aliasesOrName === 'string'
+      ? lowlight.registerAlias(aliasesOrName, alias as readonly string[] | string)
+      : lowlight.registerAlias(aliasesOrName)
+  }) as Lowlight['registerAlias']
+
+  return {
+    ...lowlight,
+    highlight: (language, value, options) =>
+      getOrHighlight(
+        () => highlightKey(language, value, options),
+        value.length,
+        () => lowlight.highlight(language, value, options)
+      ),
+    highlightAuto: (value, options) =>
+      getOrHighlight(
+        () => highlightAutoKey(value, options),
+        value.length,
+        () => lowlight.highlightAuto(value, options)
+      ),
+    register,
+    registerAlias
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​117 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​117 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​129 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​128 |

<!-- /orca-pr-loc -->

## Summary

- reuse exact lowlight results for repeated rich-Markdown code blocks
- keep language, automatic detection, prefix, and subset modes isolated
- invalidate on registry changes and bound retention by both entry count and source characters
- leave the rich-Markdown size limit and rendered behavior unchanged

## Performance

Measured in the rendered Electron app with a 305 KB Markdown fixture containing 533 identical TypeScript fences, across 9 open cycles:

| | Median open | Longest-task median |
| --- | ---: | ---: |
| Before | 2,029.2 ms | 1,819 ms |
| After | 1,867.5 ms | 1,662 ms |
| Change | -161.7 ms (-8.0%) | -157 ms (-8.6%) |

The deterministic test reduces underlying highlight calls from 533 to 1. Both Electron paths rendered all 533 code blocks and the same 4,797 syntax-highlight spans.

## Verification

- pnpm test src/renderer/src/components/editor/rich-markdown-lowlight-cache.test.ts
- 56 broader rich-Markdown tests
- pnpm tc:web
- pnpm run check:code-quality:changed
- Electron CDP validation of the 305 KB fixture with zero console errors

## ELI5

When a document repeats the same code snippet hundreds of times, the editor was doing the exact same coloring work hundreds of times. A small bounded cache now reuses the first identical result while keeping different languages and highlighting settings separate.

## Before / After measurement

On the same 305 KB fixture with 533 identical TypeScript fences across nine Electron open cycles, median open time fell from **2,029.2 ms to 1,867.5 ms** (-8.0%) and longest-task median fell from **1,819 ms to 1,662 ms** (-8.6%). The deterministic test reduces underlying highlighter calls from **533 to 1**.

## Regression Proof

- Before and after both render all 533 code blocks and exactly 4,797 syntax-highlight spans.
- Focused cache tests plus 56 broader rich-Markdown tests pass.
- Electron CDP validation reports zero console errors.
- Web typecheck and changed-code quality checks pass; the full PR check suite is green.

## No-user-regression signoff

No highlighting language, automatic-detection mode, prefix, subset, document-size limit, or rendered output changes. Cache identity includes all inputs that affect highlighting, registry changes invalidate retained results, and entry-count plus source-character budgets bound memory. There is no persistence, IPC, remote-wire, SSH, filesystem, or platform-specific behavior change.

## Merge risk

**Low to medium.** The cache sits on a shared rich-Markdown highlighting path, so incorrect identity or invalidation could reuse stale syntax trees. Mode-isolation, registry-invalidation, eviction, and rendered-span parity tests cover those failure modes. Retention is bounded, there is no migration, and the PR is independently revertible.