### PR TITLE
fix(native-chat): drain the reaped child's journal writes before an attach reports

### DIFF
--- a/src/main/native-chat/agent-session-wire/structured-agent-session-attach-drain.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-attach-drain.test.ts
@@ -1,0 +1,155 @@
+// The exit-side half of the attach's journal barrier.
+//
+// A takeover reaps the superseded provider child from inside `adapter.acquire`,
+// and the reap journals what it saw — for Codex, the tombstone that ends the
+// turn-lifecycle row. The sink is unbound by then, so those writes only buffer;
+// rebinding re-queues them. The page the attach reports has to be read AFTER
+// they land, or it still shows a turn this same attach just ended.
+
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { AgentSessionRecordStore } from '../../runtime/agent-session-record-store'
+import type { StructuredAgentSessionAdapter } from './structured-agent-session-adapter'
+import type { DeferredStructuredAgentSessionEventSink } from './structured-agent-session-event-sink'
+import { StructuredAgentSessionHost } from './structured-agent-session-host'
+import {
+  HOST_TEST_NOW as NOW,
+  HOST_TEST_SESSION as SESSION,
+  HOST_TEST_THREAD as THREAD,
+  hostTestAttachParams,
+  resetHostTestOperationIds
+} from './structured-agent-session-host-test-data'
+
+const CALLER = { callerKey: 'client-1' }
+
+let root: string
+let store: AgentSessionRecordStore
+let host: StructuredAgentSessionHost
+let acquire: Mock<StructuredAgentSessionAdapter['acquire']>
+/** Opened by the test that gates the replacement journal; released unconditionally
+ *  so a failed assertion fails fast instead of stalling teardown on the gate. */
+let releaseGate: (() => void) | null = null
+
+beforeEach(async () => {
+  releaseGate = null
+  root = await mkdtemp(join(tmpdir(), 'orca-attach-drain-'))
+  resetHostTestOperationIds()
+  acquire = vi.fn(async ({ fence, spawnToken }) => ({
+    process: { hostId: 'local', pid: 4242, processStartTimeMs: NOW, spawnToken },
+    link: {
+      linkId: `link-${fence}`,
+      handle: { provider: 'codex' as const, threadId: THREAD },
+      origin: store.getRecord(SESSION)?.providerHandleChain.length
+        ? ('resumed' as const)
+        : ('created' as const),
+      mintedAtFence: fence,
+      observedAt: NOW
+    }
+  }))
+  store = await AgentSessionRecordStore.open({ directory: join(root, 'store'), hostId: 'local' })
+  host = new StructuredAgentSessionHost({
+    store,
+    adapter: {
+      acquire,
+      releaseAcquisition: vi.fn(async () => true),
+      dispatch: vi.fn(),
+      cancelTurn: vi.fn(),
+      answerPrompt: vi.fn(),
+      setOption: vi.fn()
+    },
+    journalRoot: root,
+    claimKeyId: 'key-1',
+    mintSpawnToken: () => 'spawn-a',
+    now: () => NOW
+  })
+})
+
+afterEach(async () => {
+  releaseGate?.()
+  await host.flushAllStreamedEvents()
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('attach journal barrier', () => {
+  it('drains what the reaped child wrote during acquire before reporting the page', async () => {
+    expect(await host.attach(CALLER, hostTestAttachParams(null))).toMatchObject({ ok: true })
+    const released = await store.evictProvenDeadOwner({
+      sessionId: SESSION,
+      expectedFence: store.getRecord(SESSION)?.lease.runtimeFence ?? 1,
+      probe: { outcome: 'pid-absent' },
+      now: NOW
+    })
+    // Stands in for closing the superseded child: journaled from inside
+    // `acquire`, while the sink is unbound and the write is only buffered.
+    acquire.mockImplementationOnce(async (input) => {
+      input.events?.appendItem(
+        { provider: 'orca', clientMessageId: 'reaped-child-write' },
+        { kind: 'status', text: 'reaped child write' }
+      )
+      return {
+        process: {
+          hostId: 'local',
+          pid: 4242,
+          processStartTimeMs: NOW,
+          spawnToken: input.spawnToken
+        },
+        link: {
+          linkId: 'resumed-link',
+          handle: { provider: 'codex' as const, threadId: THREAD },
+          origin: 'resumed' as const,
+          mintedAtFence: input.fence,
+          observedAt: NOW
+        }
+      }
+    })
+
+    const sink = (
+      host as unknown as {
+        runtimeState: {
+          eventSinkFor: (sessionId: string) => DeferredStructuredAgentSessionEventSink
+        }
+      }
+    ).runtimeState.eventSinkFor(SESSION)
+    const appendGate = Promise.withResolvers<void>()
+    releaseGate = appendGate.resolve
+    const bind = sink.bind.bind(sink)
+    let bound = 0
+    // Gate the replacement journal the instant the sink is re-pointed at it, so
+    // the buffered write cannot land until this test lets it.
+    sink.bind = (target) => {
+      bound += 1
+      const append = target.journal.appendItem.bind(target.journal)
+      vi.spyOn(target.journal, 'appendItem').mockImplementationOnce(async (...args) => {
+        await appendGate.promise
+        return append(...args)
+      })
+      bind(target)
+    }
+
+    let settled = false
+    const replacement = host.attach(CALLER, hostTestAttachParams(released.lease.runtimeFence))
+    void replacement.then(() => {
+      settled = true
+    })
+    await vi.waitFor(() => expect(bound).toBe(1))
+    // All that is left after the bind is one store write and a page read, so an
+    // attach that did not wait for the reaped child's write settles here. One
+    // that does wait is parked on the drain until the gate opens below.
+    await expect(
+      vi.waitFor(() => expect(settled).toBe(true), { timeout: 1_000, interval: 5 })
+    ).rejects.toThrow()
+
+    appendGate.resolve()
+    const attached = await replacement
+    expect(attached).toMatchObject({ ok: true })
+    if (!attached.ok) {
+      throw new Error('attach refused')
+    }
+    const statuses = attached.value.page.items.flatMap((item) =>
+      item.body.kind === 'status' ? [item.body.text] : []
+    )
+    expect(statuses).toContain('reaped child write')
+  })
+})

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-attach-flow.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-attach-flow.ts
@@ -47,7 +47,7 @@ export type AttachFlowInput = {
   /** Registers the opened journal and fans out to subscribers before the caller
    *  sees the result, so no client can send against a session the host has not
    *  finished publishing. */
-  onAttached: (attached: AttachedJournal) => void
+  onAttached: (attached: AttachedJournal) => Promise<void> | void
   /** Handed to the adapter so it can journal what the provider streams. The
    *  host owns it and binds it to the journal inside `onAttached`. */
   eventSink?: StructuredAgentSessionEventSink
@@ -171,7 +171,7 @@ export async function performAttach(
       journalRoot: input.journalRoot,
       adapter: input.adapter
     })
-    input.onAttached(attached)
+    await input.onAttached(attached)
     await store.recordOperationOutcome({
       callerKey: input.callerKey,
       operationId: params.envelope.clientOperationId,

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-attach-orchestration.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-attach-orchestration.ts
@@ -58,7 +58,7 @@ export function attachStructuredAgentSession(
         eventSink.close()
         context.runtimeState.discardEventSink(sessionId)
       },
-      onAttached: (attached) => {
+      onAttached: async (attached) => {
         const fence = context.deps.store.getRecord(sessionId)?.lease.runtimeFence ?? 0
         const previousFence = context.sessions.get(sessionId)?.fence
         context.sessions.set(sessionId, {
@@ -79,6 +79,10 @@ export function attachStructuredAgentSession(
           fence,
           publish: () => context.subscribers.publish(sessionId, attached.journal)
         })
+        // Why: binding re-queues what the reaped child buffered — including the
+        // tombstone ending its turn. The page this attach returns must not still
+        // report a turn this same attach just ended.
+        await eventSink.drained()
       }
     })
     // Why: a failed attach that left no session behind must not strand a bound sink; the runtime

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host-handoff.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host-handoff.ts
@@ -220,6 +220,9 @@ async function acquireNativeHandoffOwner(
     fence: proved.lease.runtimeFence,
     publish: () => host.subscribers.publish(input.sessionId, session.journal)
   })
+  // Why: same rule as the attach path — the snapshot below must not fan out the
+  // reaped child's turn as still running.
+  await eventSink.drained()
   host.subscribers.snapshot(input.sessionId, session.journal, proved.lease.runtimeFence)
   return proved
 }

--- a/src/main/runtime/structured-agent-session-integration.test.ts
+++ b/src/main/runtime/structured-agent-session-integration.test.ts
@@ -605,8 +605,18 @@ describe('a structured codex session over agentSession.*', () => {
         current: { model: 'gpt-live', effort: 'high' }
       }
     })
-    // The journal belongs to the session, not to the process that just died.
+    // The journal belongs to the session, not to the process that just died —
+    // and the takeover reaped the old child, so the page it hands back must
+    // already show that turn ended rather than still running.
     expect(resumed.page.items.map(textOf)).toContain('Two files.')
+    expect(resumed.page.items.map((item) => item.body?.kind)).toEqual([
+      'message',
+      'message',
+      'tool-call',
+      'approval',
+      'status',
+      'message'
+    ])
 
     // ── page history ────────────────────────────────────────────────────────
     const tail = await historyPage('tail', { limit: 2 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​166 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​165 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

## The failure

`structured-agent-session-integration.test.ts` intermittently reported **seven** journal rows where
six were expected, on `test / tests node 24 2/8`:

```
- Expected            + Received
  [                     [
    "message",            "message",
                        + "status",      ← the extra element
    "message",            "message",
```

The extra element is the Codex **turn-lifecycle** row — `legacy:codex:<session>:turn-lifecycle:turn-1`,
body text `"Codex is working…"` — still present in history after the takeover that should have ended it.

## Mechanism

`turn/started` journals a `turn-lifecycle` status row; the matching tombstone is written when the
provider child is closed. On a takeover (`agentSession.ensure`), that close happens **inside
`adapter.acquire`** — at which point the attach has already called `eventSink.unbind()`, so the
tombstone is only *buffered* on the deferred sink.

`eventSink.bind()` in `onAttached` re-queues the buffered writes onto the sink's async chain, but
nothing awaited that chain. The attach then read its hydration page, published the new fence and
released the session lock while the tombstone was still in flight. Whether a reader saw the stale
row came down to an unrelated race between the tombstone's journal write and the attach's own
`store.recordOperationOutcome` write.

The attach already establishes the symmetric barrier on the way *in*
(`beforeJournalOpen: unbind() + await drained()`). The barrier on the way *out* was missing.

This is not cosmetic. The stale row is what `activeStructuredAgentSessionTurnId()` reads, so a
session whose child was just reaped could hydrate as "Codex is working…" — and in the main process
`isTurnActive` uses the same signal to gate eviction.

## Fix

Await the rebound sink before the attach reports: `performAttach` now awaits `onAttached`, and the
orchestration drains the sink after `bind()`. The same rule is applied to the handoff restart path,
which binds and then immediately fans out a snapshot.

## Not the PR it failed on

All the implicated files are byte-identical to `main`, and the same failure occurred independently on
**#17115** (an unrelated Windows PowerShell polling PR). Rate across enumerated attempts: **2 / 85**.

## Verification

Ablation, 12 runs per arm (local load 10–15):

| arm | pin result |
|---|---|
| baseline (fix in place) | 12/12 green |
| flow drops `await onAttached` | **0/12** green |
| orchestration drops `await eventSink.drained()` | **0/12** green |
| restored | 12/12 green |

The failure was also reproduced byte-for-byte against the CI diff by delaying the
tombstone 150ms on pristine `main` — extra `"status"` at index 1, row
`legacy:codex:<session>:turn-lifecycle%3Aturn-1`, text `"Codex is working…"` —
and that same probe passes with the fix.

Gates: `pnpm tc` (all projects) clean; `oxlint`, both `--deny-warnings` plugin
audits, the max-lines ratchet and `check-changed-code-quality.mjs` all clean;
`git diff --check` clean; formatted with `npx oxfmt --write` on changed paths only.
