### PR TITLE
perf(markdown): skip closed-search update renders

### DIFF
--- a/src/renderer/src/components/editor/useRichMarkdownSearch.test.tsx
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import type { Editor } from '@tiptap/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useRichMarkdownSearch } from './useRichMarkdownSearch'
+
+function createEditor(): { editor: Editor; emitUpdate: () => void } {
+  const updateListeners = new Set<() => void>()
+  const transaction = {
+    setMeta: vi.fn().mockReturnThis()
+  }
+  const editor = {
+    commands: { focus: vi.fn() },
+    off: vi.fn((event: string, listener: () => void) => {
+      if (event === 'update') {
+        updateListeners.delete(listener)
+      }
+    }),
+    on: vi.fn((event: string, listener: () => void) => {
+      if (event === 'update') {
+        updateListeners.add(listener)
+      }
+    }),
+    registerPlugin: vi.fn(),
+    state: { doc: {}, tr: transaction },
+    unregisterPlugin: vi.fn(),
+    view: { dispatch: vi.fn() }
+  } as unknown as Editor
+  return {
+    editor,
+    emitUpdate: () => updateListeners.forEach((listener) => listener())
+  }
+}
+
+describe('useRichMarkdownSearch', () => {
+  it('rerenders for editor updates only while search is open', () => {
+    const { editor, emitUpdate } = createEditor()
+    const rootRef = { current: document.createElement('div') }
+    const scrollContainerRef = { current: document.createElement('div') }
+    let renderCount = 0
+    const hook = renderHook(() => {
+      renderCount += 1
+      return useRichMarkdownSearch({ editor, rootRef, scrollContainerRef })
+    })
+
+    const closedRenderCount = renderCount
+    act(emitUpdate)
+
+    expect(renderCount).toBe(closedRenderCount)
+    expect(editor.on).not.toHaveBeenCalledWith('update', expect.any(Function))
+
+    act(() => hook.result.current.openSearch())
+
+    const openRenderCount = renderCount
+    expect(editor.on).toHaveBeenCalledWith('update', expect.any(Function))
+    act(emitUpdate)
+    expect(renderCount).toBe(openRenderCount + 1)
+
+    act(() => hook.result.current.searchActions.closeSearch())
+
+    const reclosedRenderCount = renderCount
+    act(emitUpdate)
+    expect(renderCount).toBe(reclosedRenderCount)
+    expect(editor.off).toHaveBeenCalledWith('update', expect.any(Function))
+  })
+})

--- a/src/renderer/src/components/editor/useRichMarkdownSearch.test.tsx
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.test.tsx
@@ -35,6 +35,7 @@ function createEditor(): { editor: Editor; emitUpdate: () => void } {
 
 describe('useRichMarkdownSearch', () => {
   it('rerenders for editor updates only while search is open', () => {
+    const closedUpdateCount = 100
     const { editor, emitUpdate } = createEditor()
     const rootRef = { current: document.createElement('div') }
     const scrollContainerRef = { current: document.createElement('div') }
@@ -45,9 +46,11 @@ describe('useRichMarkdownSearch', () => {
     })
 
     const closedRenderCount = renderCount
-    act(emitUpdate)
+    for (let index = 0; index < closedUpdateCount; index += 1) {
+      act(emitUpdate)
+    }
 
-    expect(renderCount).toBe(closedRenderCount)
+    expect(renderCount - closedRenderCount).toBe(0)
     expect(editor.on).not.toHaveBeenCalledWith('update', expect.any(Function))
 
     act(() => hook.result.current.openSearch())
@@ -55,13 +58,15 @@ describe('useRichMarkdownSearch', () => {
     const openRenderCount = renderCount
     expect(editor.on).toHaveBeenCalledWith('update', expect.any(Function))
     act(emitUpdate)
-    expect(renderCount).toBe(openRenderCount + 1)
+    expect(renderCount - openRenderCount).toBe(1)
 
     act(() => hook.result.current.searchActions.closeSearch())
 
     const reclosedRenderCount = renderCount
-    act(emitUpdate)
-    expect(renderCount).toBe(reclosedRenderCount)
+    for (let index = 0; index < closedUpdateCount; index += 1) {
+      act(emitUpdate)
+    }
+    expect(renderCount - reclosedRenderCount).toBe(0)
     expect(editor.off).toHaveBeenCalledWith('update', expect.any(Function))
   })
 })

--- a/src/renderer/src/components/editor/useRichMarkdownSearch.ts
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.ts
@@ -234,7 +234,7 @@ export function useRichMarkdownSearch({
   }, [editor])
 
   useEffect(() => {
-    if (!editor) {
+    if (!editor || !isSearchOpen) {
       return
     }
 
@@ -242,7 +242,7 @@ export function useRichMarkdownSearch({
     return () => {
       editor.off('update', handleEditorUpdate)
     }
-  }, [editor, handleEditorUpdate])
+  }, [editor, handleEditorUpdate, isSearchOpen])
 
   useEffect(() => {
     if (!isSearchOpen) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | 0 |

<!-- /orca-pr-loc -->

## ELI5

The rich editor used to wake React up after every document edit even when Find/Replace was closed. Those renders could not show search results because the search UI was hidden. Orca now listens for editor updates only while Find/Replace is open, while opening it still searches the editor's current document.

## What changed

- Subscribe to TipTap/ProseMirror `update` events only while rich-markdown search is open.
- Unsubscribe again on close and preserve the existing live recomputation path while open.
- Strengthen the hook regression to flush 100 closed updates individually, one open update, and 100 reclosed updates.

## Before / after measurement

Deterministic React hook render counts, with every editor update flushed in a separate `act()`:

| Scenario | Before | After |
|---|---:|---:|
| 100 updates, search closed | 100 extra renders | 0 |
| 1 update, search open | 1 extra render | 1 |
| 100 updates, search closed again | 100 extra renders | 0 |

The same strengthened test was run against the pre-fix subscription and failed with **received 100** at the closed-search zero-render assertion; the patched code passes with **0**.

## Regression proof

- `pnpm test src/renderer/src/components/editor/useRichMarkdownSearch.test.tsx src/renderer/src/components/editor/rich-markdown-search.test.ts` — 2 files / 4 tests passed.
- `pnpm tc:web` — passed.
- `pnpm run check:code-quality:changed` — 0 findings across 2 changed files.
- `git diff --check` and commit hooks — passed.
- Electron: opened a 305 KB rich document, typed with search closed, opened Find, observed a live query update from “No results” to “1/1” after editing, closed Find, and typed again; zero console errors.

## No-user-regression signoff

**Sign-off: no search, replace, editor, shortcut, cursor, or document-size behavior is removed.** Find/Replace still recomputes against the current ProseMirror document when opened, updates once per editor transaction while visible, and detaches only when its results cannot be displayed. The 300 KB rich-editing limit is unchanged.

## Merge risk

**Risk: low.** The change only scopes an existing external-editor subscription to the UI state that consumes it. The main risk is stale results across close/reopen; reopening changes `isSearchOpen`, which recomputes matches from the current document, while the deterministic lifecycle test covers closed, open, and reclosed event handling.