### PR TITLE
perf(worktrees): resolve watcher targets concurrently

### DIFF
--- a/src/main/ipc/worktree-base-directory-watch-targets.test.ts
+++ b/src/main/ipc/worktree-base-directory-watch-targets.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { join, sep } from 'node:path'
+import type { GlobalSettings } from '../../shared/global-settings-types'
+import type { Repo } from '../../shared/repo-types'
+
+const { getSshFilesystemProviderMock, readFileMock, realpathMock, statMock } = vi.hoisted(() => ({
+  getSshFilesystemProviderMock: vi.fn(),
+  readFileMock: vi.fn(),
+  realpathMock: vi.fn(),
+  statMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: readFileMock,
+  realpath: realpathMock,
+  stat: statMock
+}))
+
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: getSshFilesystemProviderMock
+}))
+
+import {
+  buildWorktreeBaseDirectoryWatchTargets,
+  clearWorktreeBaseDirectoryWatchTargetWarnings,
+  WORKTREE_BASE_TARGET_RESOLUTION_CONCURRENCY
+} from './worktree-base-directory-watch-targets'
+
+const absolutePath = (...parts: string[]): string => join(sep, ...parts)
+const WORKTREE_ROOT = absolutePath('workspace', 'worktrees')
+const PROJECT_ROOT = absolutePath('workspace', 'projects')
+const localDirectoryStat = { isDirectory: () => true }
+const remoteDirectoryStat = { type: 'directory', size: 0, mtime: 0 }
+const settings = {
+  workspaceDir: WORKTREE_ROOT,
+  nestWorkspaces: true
+} as GlobalSettings
+
+function makeRepo(index: number, overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: `repo-${index}`,
+    path: join(PROJECT_ROOT, `project-${index}`),
+    displayName: `Project ${index}`,
+    badgeColor: '#000000',
+    addedAt: index,
+    ...overrides
+  } as Repo
+}
+
+function makeStore(repos: Repo[]) {
+  return {
+    getSettings: () => settings,
+    getRepos: () => repos
+  }
+}
+
+function makeRemoteProvider() {
+  return {
+    stat: vi.fn(async () => remoteDirectoryStat),
+    realpath: vi.fn(async (path: string) => path),
+    readFile: vi.fn(async () => ({ content: '', isBinary: false }))
+  }
+}
+
+describe('worktree base directory watch target resolution', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    statMock.mockReset().mockResolvedValue(localDirectoryStat)
+    realpathMock.mockReset().mockImplementation(async (path: string) => path)
+    readFileMock.mockReset().mockResolvedValue('')
+    getSshFilesystemProviderMock.mockReset().mockReturnValue(undefined)
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    clearWorktreeBaseDirectoryWatchTargetWarnings()
+    warnSpy.mockRestore()
+  })
+
+  it('bounds resolution concurrency and starts one successor per released slot', async () => {
+    const repos = Array.from(
+      { length: WORKTREE_BASE_TARGET_RESOLUTION_CONCURRENCY + 4 },
+      (_, index) => makeRepo(index)
+    )
+    const gates = repos.map(() => Promise.withResolvers<void>())
+    let startedRootStats = 0
+    let activeRootStats = 0
+    let peakRootStats = 0
+    statMock.mockImplementation(async (path: string) => {
+      if (path === WORKTREE_ROOT) {
+        const gate = gates[startedRootStats++]
+        activeRootStats++
+        peakRootStats = Math.max(peakRootStats, activeRootStats)
+        await gate.promise
+        activeRootStats--
+      }
+      return localDirectoryStat
+    })
+
+    const resultPromise = buildWorktreeBaseDirectoryWatchTargets(makeStore(repos) as never)
+    await vi.waitFor(() => {
+      expect(startedRootStats).toBe(WORKTREE_BASE_TARGET_RESOLUTION_CONCURRENCY)
+    })
+    expect(peakRootStats).toBe(WORKTREE_BASE_TARGET_RESOLUTION_CONCURRENCY)
+
+    gates[0].resolve()
+    await vi.waitFor(() => {
+      expect(startedRootStats).toBe(WORKTREE_BASE_TARGET_RESOLUTION_CONCURRENCY + 1)
+    })
+    expect(peakRootStats).toBe(WORKTREE_BASE_TARGET_RESOLUTION_CONCURRENCY)
+
+    for (const gate of gates) {
+      gate.resolve()
+    }
+    await resultPromise
+    expect(startedRootStats).toBe(repos.length)
+    expect(peakRootStats).toBe(WORKTREE_BASE_TARGET_RESOLUTION_CONCURRENCY)
+  })
+
+  it('merges targets and shared repo membership in store order after reverse completion', async () => {
+    const repos = Array.from({ length: 4 }, (_, index) => makeRepo(index))
+    const gates = repos.map(() => Promise.withResolvers<void>())
+    const gitStatStarted = new Set<number>()
+    const completionOrder: number[] = []
+    statMock.mockImplementation(async (path: string) => {
+      const index = repos.findIndex((repo) => path === join(repo.path, '.git'))
+      if (index !== -1) {
+        gitStatStarted.add(index)
+        await gates[index].promise
+        completionOrder.push(index)
+      }
+      return localDirectoryStat
+    })
+
+    const resultPromise = buildWorktreeBaseDirectoryWatchTargets(makeStore(repos) as never)
+    await vi.waitFor(() => expect(gitStatStarted.size).toBe(repos.length))
+    for (let index = repos.length - 1; index >= 0; index--) {
+      gates[index].resolve()
+      await vi.waitFor(() => expect(completionOrder).toContain(index))
+    }
+    const targets = await resultPromise
+
+    expect(completionOrder).toEqual([3, 2, 1, 0])
+    expect([...targets.values()].map((target) => [target.kind, target.path])).toEqual([
+      ['base', WORKTREE_ROOT],
+      ...repos.map((repo) => ['git-common', join(repo.path, '.git')])
+    ])
+    expect([...([...targets.values()][0]?.repos.keys() ?? [])]).toEqual(
+      repos.map((repo) => repo.id)
+    )
+  })
+
+  it('isolates missing paths to the affected repo', async () => {
+    const missing = Object.assign(new Error('missing'), { code: 'ENOENT' })
+    const goodBefore = makeRepo(0, { worktreeBasePath: absolutePath('worktrees', 'before') })
+    const unavailable = makeRepo(1, { worktreeBasePath: absolutePath('worktrees', 'missing') })
+    const goodAfter = makeRepo(2, { worktreeBasePath: absolutePath('worktrees', 'after') })
+    statMock.mockImplementation(async (path: string) => {
+      if (path === unavailable.worktreeBasePath || path === join(unavailable.path, '.git')) {
+        throw missing
+      }
+      return localDirectoryStat
+    })
+
+    const targets = await buildWorktreeBaseDirectoryWatchTargets(
+      makeStore([goodBefore, unavailable, goodAfter]) as never
+    )
+    const repoIds = [...targets.values()].flatMap((target) => [...target.repos.keys()])
+
+    expect(repoIds).toContain(goodBefore.id)
+    expect(repoIds).not.toContain(unavailable.id)
+    expect(repoIds).toContain(goodAfter.id)
+  })
+
+  it('keeps identical SSH paths isolated by connection and provider', async () => {
+    const providerA = makeRemoteProvider()
+    const providerB = makeRemoteProvider()
+    getSshFilesystemProviderMock.mockImplementation((connectionId: string) =>
+      connectionId === 'ssh-a' ? providerA : connectionId === 'ssh-b' ? providerB : undefined
+    )
+    const sharedPath = '/srv/project'
+    const repos = [
+      makeRepo(0, { path: sharedPath, connectionId: 'ssh-a' }),
+      makeRepo(1, { path: sharedPath, connectionId: 'ssh-b' })
+    ]
+
+    const targets = await buildWorktreeBaseDirectoryWatchTargets(makeStore(repos) as never)
+
+    expect(providerA.stat).toHaveBeenCalledTimes(2)
+    expect(providerA.realpath).toHaveBeenCalledTimes(2)
+    expect(providerB.stat).toHaveBeenCalledTimes(2)
+    expect(providerB.realpath).toHaveBeenCalledTimes(2)
+    expect([...targets.values()].map((target) => target.connectionId)).toEqual([
+      'ssh-a',
+      'ssh-a',
+      'ssh-b',
+      'ssh-b'
+    ])
+    expect(new Set(targets.keys()).size).toBe(4)
+  })
+
+  it('skips folder workspaces, unavailable SSH providers, and WSL UNC roots', async () => {
+    const folder = makeRepo(0, { kind: 'folder' })
+    const unavailableSsh = makeRepo(1, { connectionId: 'missing', path: '/srv/missing' })
+    const wslPath = '\\\\wsl.localhost\\Ubuntu\\home\\alice\\project'
+    const wsl = makeRepo(2, { path: wslPath, worktreeBasePath: wslPath })
+
+    const targets = await buildWorktreeBaseDirectoryWatchTargets(
+      makeStore([folder, unavailableSsh, wsl]) as never
+    )
+
+    expect(targets.size).toBe(0)
+    expect(statMock).not.toHaveBeenCalled()
+    expect(getSshFilesystemProviderMock).toHaveBeenCalledWith('missing')
+  })
+
+  it('does not publish ordered partial targets when a repo resolver rejects unexpectedly', async () => {
+    const completed = makeRepo(0)
+    const broken = makeRepo(1)
+    Object.defineProperty(broken, 'path', {
+      get: () => {
+        throw new Error('unexpected resolver failure')
+      }
+    })
+
+    await expect(
+      buildWorktreeBaseDirectoryWatchTargets(makeStore([completed, broken]) as never)
+    ).rejects.toThrow('unexpected resolver failure')
+    expect(statMock).toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/worktree-base-directory-watch-targets.ts
+++ b/src/main/ipc/worktree-base-directory-watch-targets.ts
@@ -15,6 +15,7 @@ import {
   resolveRuntimePath
 } from '../../shared/cross-platform-path'
 import { isWslUncPath } from '../../shared/wsl-paths'
+import { mapWithConcurrency } from '../../shared/map-with-concurrency'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
   computeWorkspaceRoot,
@@ -31,6 +32,9 @@ import type {
 
 const missingRootWarnings = new Set<string>()
 const skippedWslWarnings = new Set<string>()
+
+// Why: match existing worktree probe caps while bounding aggregate SSH filesystem RPC pressure.
+export const WORKTREE_BASE_TARGET_RESOLUTION_CONCURRENCY = 8
 
 function normalizeWatchKey(pathValue: string): string {
   return normalizeRuntimePathForComparison(normalize(pathValue))
@@ -177,21 +181,51 @@ async function maybeAddBaseTarget(
   }
 }
 
+async function resolveRepoTargets(
+  repo: Repo,
+  settings: GlobalSettings
+): Promise<Map<string, WorktreeBaseWatchTarget>> {
+  const targets = new Map<string, WorktreeBaseWatchTarget>()
+  if (isFolderRepo(repo)) {
+    return targets
+  }
+  const executionHostId = getRepoExecutionHostId(repo)
+  if (executionHostId === LOCAL_EXECUTION_HOST_ID) {
+    await maybeAddBaseTarget(targets, repo, settings)
+  } else if (repo.connectionId) {
+    await maybeAddBaseTarget(targets, repo, settings, repo.connectionId)
+  }
+  return targets
+}
+
+function mergeRepoTargets(
+  targets: Map<string, WorktreeBaseWatchTarget>,
+  repoTargets: Map<string, WorktreeBaseWatchTarget>
+): void {
+  for (const [key, target] of repoTargets) {
+    const existing = targets.get(key)
+    if (!existing) {
+      targets.set(key, target)
+      continue
+    }
+    for (const [repoId, config] of target.repos) {
+      existing.repos.set(repoId, config)
+    }
+  }
+}
+
 export async function buildWorktreeBaseDirectoryWatchTargets(
   store: Store
 ): Promise<Map<string, WorktreeBaseWatchTarget>> {
   const settings = store.getSettings()
+  const resolvedRepoTargets = await mapWithConcurrency(
+    store.getRepos(),
+    WORKTREE_BASE_TARGET_RESOLUTION_CONCURRENCY,
+    (repo) => resolveRepoTargets(repo, settings)
+  )
   const targets = new Map<string, WorktreeBaseWatchTarget>()
-  for (const repo of store.getRepos()) {
-    if (isFolderRepo(repo)) {
-      continue
-    }
-    const executionHostId = getRepoExecutionHostId(repo)
-    if (executionHostId === LOCAL_EXECUTION_HOST_ID) {
-      await maybeAddBaseTarget(targets, repo, settings)
-    } else if (repo.connectionId) {
-      await maybeAddBaseTarget(targets, repo, settings, repo.connectionId)
-    }
+  for (const repoTargets of resolvedRepoTargets) {
+    mergeRepoTargets(targets, repoTargets)
   }
   return targets
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​232 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​232 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |

<!-- /orca-pr-loc -->

## ELI5

Orca used to prepare repository watcher targets one repository at a time. If each repository needed a few filesystem or SSH round trips, every later repository waited in line. This prepares up to eight repositories at once, then merges their results back in the original store order.

## What changed

- Reused the existing `mapWithConcurrency` primitive with a cap of 8.
- Resolved each repository into a private target map, so partial concurrent results are never published.
- Merged those maps in store order, preserving target order and shared-target repository order.
- Kept folder-workspace, WSL, local, and SSH routing behavior unchanged.

## Before / after measurement

Controlled async-I/O benchmark on Node v24.18.0, five runs per case, reporting the median. Each repository performs the ordinary four sequential provider operations represented by this path (base `stat` + `realpath`, Git common-dir `stat` + `realpath`), with each operation delayed 5 ms.

| Repositories | Before: serial | After: cap 8 | Provider calls |
|---:|---:|---:|---:|
| 20 | 482.3 ms | 71.7 ms | 80 → 80 |
| 100 | 2411.7 ms | 314.3 ms | 400 → 400 |

The cap of 8 matches existing filesystem-probe caps in this subsystem. A higher cap improved the synthetic latency further, but would increase aggregate SSH/provider pressure.

## Regression proof

- `pnpm test src/main/ipc/worktree-base-directory-watch-targets.test.ts src/main/ipc/worktree-base-directory-watcher.test.ts src/main/ipc/worktree-base-directory-event-filter.test.ts` — 40 tests passed.
- `pnpm tc:node` — passed.
- `pnpm run check:code-quality:changed` — passed with 0 new findings.
- `git diff --check` — passed.

The focused tests prove:

- peak resolution concurrency never exceeds 8;
- a released slot starts exactly one successor;
- reverse completion still produces store-ordered targets and membership;
- one unavailable repository does not erase neighboring targets;
- identical SSH paths remain isolated by connection/provider;
- folder workspaces, unavailable SSH providers, and WSL UNC roots keep their existing behavior;
- an unexpected resolver rejection never publishes an ordered partial target map.

## No-user-regression signoff

**Sign-off: no user-facing behavior is intentionally changed.** No watcher, polling path, repository type, or cursor/animation behavior is disabled. Successful resolutions make the same provider calls in the same per-repository order and return the same ordered target map; only independent repositories overlap in time.

## Merge risk

**Runtime risk: low.** The change is confined to target-map construction, uses an existing bounded-concurrency primitive, and has ordering/failure/isolation coverage. The main risk is extra simultaneous pressure on slow SSH providers; the explicit cap of 8 bounds it.

**Integration note:** #16176 also touches this file as part of a much larger incremental-watcher rewrite and is currently based 334 commits behind `main`, so the two PRs may need a small textual reconciliation if that older rewrite is revived.
