### PR TITLE
fix(rate-limits): don't report a connected Codex account as unconfigured when its usage read fails

### DIFF
--- a/src/main/rate-limits/codex-fetcher-backend.test.ts
+++ b/src/main/rate-limits/codex-fetcher-backend.test.ts
@@ -137,6 +137,36 @@ describe('Codex backend rate-limit requests', () => {
     expect(ptySpawnMock).not.toHaveBeenCalled()
   })
 
+  // STA-3445: the WSL path publishes the backend reading directly, so a payload whose only
+  // readable field is `plan_type` published two null windows as a success -- the same
+  // last-good-snapshot overwrite the RPC probe was fixed for, through a second door.
+  it('does not publish a backend payload with no readable window as a successful reading', async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({
+        tokens: { access_token: 'access-token', account_id: 'account-id' }
+      })
+    )
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        plan_type: 'plus',
+        rate_limit: {
+          primary_window: { used_percent: 'lots', limit_window_seconds: 3_600 },
+          secondary_window: null
+        }
+      })
+    } as Response)
+
+    const limits = await fetchCodexRateLimits({
+      codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex',
+      allowPtyFallback: false
+    })
+
+    expect(limits.status).not.toBe('ok')
+    expect(limits.session).toBeNull()
+    expect(limits.weekly).toBeNull()
+  })
+
   it('aborts callers while sharing one stalled backend auth read', async () => {
     let resolveRead!: (content: string) => void
     readFileMock.mockImplementation(

--- a/src/main/rate-limits/codex-fetcher-signed-in-probe-failure.test.ts
+++ b/src/main/rate-limits/codex-fetcher-signed-in-probe-failure.test.ts
@@ -1,0 +1,142 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { childSpawnMock, readFileMock, resolveCodexCommandMock, ptySpawnMock } = vi.hoisted(() => ({
+  childSpawnMock: vi.fn(),
+  readFileMock: vi.fn(),
+  resolveCodexCommandMock: vi.fn(),
+  ptySpawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  spawn: childSpawnMock
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: readFileMock
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveCodexCommand: resolveCodexCommandMock
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: ptySpawnMock
+}))
+
+vi.mock('./codex-auth-presence', () => ({
+  probeCodexAuthPresence: vi.fn(() => 'present')
+}))
+
+import { fetchCodexRateLimits } from './codex-fetcher'
+import { probeCodexAuthPresence } from './codex-auth-presence'
+
+function makeDisposable() {
+  return { dispose: vi.fn() }
+}
+
+function makeRpcChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    stdin: EventEmitter & { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+    kill: ReturnType<typeof vi.fn>
+    exitCode: number | null
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  const exitNow = (): void => {
+    child.exitCode = 0
+    child.emit('exit', 0, null)
+    child.emit('close', 0, null)
+  }
+  child.stdin = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn(exitNow) })
+  child.exitCode = null
+  child.kill = vi.fn(() => {
+    exitNow()
+    return true
+  })
+  return child
+}
+
+function makePtyTerm() {
+  return {
+    onData: vi.fn(() => makeDisposable()),
+    onExit: vi.fn(() => makeDisposable()),
+    write: vi.fn(),
+    kill: vi.fn()
+  }
+}
+
+function spawnEnoent(): NodeJS.ErrnoException {
+  const error: NodeJS.ErrnoException = new Error('spawn codex ENOENT')
+  error.code = 'ENOENT'
+  return error
+}
+
+// STA-3445: `unavailable` is the UI's "provider not set up" signal — it hides the
+// chip and feeds the status bar's "Connect an account" empty-state CTA. The auth
+// gate runs before either probe spawns, so every failure below is reported about
+// a Codex sign-in Orca already proved exists on disk.
+describe('fetchCodexRateLimits with a proven Codex sign-in', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    resolveCodexCommandMock.mockReturnValue('codex')
+    vi.mocked(probeCodexAuthPresence).mockResolvedValue('present')
+    readFileMock.mockRejectedValue(new Error('no auth fixture'))
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('reports an unrunnable RPC probe as a failed reading, not an unconfigured provider', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+
+    const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+    await vi.advanceTimersByTimeAsync(0)
+    rpcChild.emit('error', spawnEnoent())
+    await vi.advanceTimersByTimeAsync(0)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      provider: 'codex',
+      status: 'error',
+      error: 'Codex CLI not found'
+    })
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+
+  it('reports an unrunnable PTY fallback as a failed reading, not an unconfigured provider', async () => {
+    childSpawnMock.mockImplementation(() => {
+      throw new Error('rpc unavailable')
+    })
+    ptySpawnMock.mockImplementation(() => {
+      throw spawnEnoent()
+    })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(0)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      provider: 'codex',
+      status: 'error',
+      error: 'Codex CLI not found'
+    })
+  })
+
+  it('still reports a genuinely signed-out Codex as unavailable', async () => {
+    vi.mocked(probeCodexAuthPresence).mockResolvedValue('absent')
+    ptySpawnMock.mockReturnValue(makePtyTerm())
+
+    await expect(fetchCodexRateLimits()).resolves.toMatchObject({
+      provider: 'codex',
+      status: 'unavailable',
+      error: 'Codex not signed in'
+    })
+    expect(childSpawnMock).not.toHaveBeenCalled()
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -176,7 +176,10 @@ async function fetchWslBackend(
     if (options.signal?.aborted) {
       return abortedCodexRateLimitResult()
     }
-    return result
+    // Why (STA-3445): this is the one path that publishes the backend reading as-is, so the
+    // no-window rule the RPC and PTY probes apply has to hold here too. Falling through to
+    // those probes beats overwriting the account's last real usage with two nulls.
+    return result && (result.session || result.weekly)
       ? supplementCodexRateLimitResetCredits(result, fetchCodexResetCredits, options)
       : null
   } catch {

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -207,7 +207,20 @@ export async function fetchCodexRateLimits(
       'error'
     )
   }
+  return withSignedInCodexStatus(await readSignedInCodexRateLimits(options))
+}
 
+// Why: `unavailable` is the UI's "provider is not set up" signal — it hides the
+// chip and feeds the status bar's "Connect an account" empty state. Everything
+// below the auth gate ran against a Codex sign-in Orca already found on disk, so
+// a probe that could not run is a failed reading, never an absent account.
+function withSignedInCodexStatus(limits: ProviderRateLimits): ProviderRateLimits {
+  return limits.status === 'unavailable' ? { ...limits, status: 'error' } : limits
+}
+
+async function readSignedInCodexRateLimits(
+  options?: FetchCodexRateLimitsOptions
+): Promise<ProviderRateLimits> {
   if (options?.codexHomePath && parseWslUncPath(options.codexHomePath)) {
     const backendResult = await fetchWslBackend(options)
     if (backendResult) {

--- a/src/main/rate-limits/codex-rate-limit-fetch-result.ts
+++ b/src/main/rate-limits/codex-rate-limit-fetch-result.ts
@@ -1,12 +1,21 @@
 import type { ProviderRateLimits } from '../../shared/rate-limit-types'
 
-export function abortedCodexRateLimitResult(): ProviderRateLimits {
+/** A Codex reading that produced no window, carrying why. Never `ok`: an empty reading
+ *  settled as success is what the stale policy writes over the last real usage. */
+export function failedCodexRateLimitReading(
+  error: string,
+  status: 'error' | 'unavailable' = 'error'
+): ProviderRateLimits {
   return {
     provider: 'codex',
     session: null,
     weekly: null,
     updatedAt: Date.now(),
-    error: 'Rate-limit fetch aborted',
-    status: 'error'
+    error,
+    status
   }
+}
+
+export function abortedCodexRateLimitResult(): ProviderRateLimits {
+  return failedCodexRateLimitReading('Rate-limit fetch aborted')
 }

--- a/src/main/rate-limits/codex-rate-limit-window-classification.ts
+++ b/src/main/rate-limits/codex-rate-limit-window-classification.ts
@@ -15,6 +15,28 @@ export type CodexRateLimitWindowsSnapshot = {
   secondary?: CodexRateWindowSnapshot | null
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isReadableRateLimitWindow(value: unknown): boolean {
+  return (
+    value == null ||
+    (isRecord(value) && typeof value.usedPercent === 'number' && Number.isFinite(value.usedPercent))
+  )
+}
+
+export function isReadableCodexRateLimitWindowsSnapshot(
+  value: unknown
+): value is CodexRateLimitWindowsSnapshot | null | undefined {
+  return (
+    value == null ||
+    (isRecord(value) &&
+      isReadableRateLimitWindow(value.primary) &&
+      isReadableRateLimitWindow(value.secondary))
+  )
+}
+
 type MappableCodexRateWindowSnapshot = CodexRateWindowSnapshot & { usedPercent: number }
 type CodexRateLimitWindowKind = 'session' | 'weekly' | null
 

--- a/src/main/rate-limits/codex-rate-limit-window-classification.ts
+++ b/src/main/rate-limits/codex-rate-limit-window-classification.ts
@@ -21,20 +21,29 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isReadableRateLimitWindow(value: unknown): boolean {
   return (
-    value == null ||
-    (isRecord(value) && typeof value.usedPercent === 'number' && Number.isFinite(value.usedPercent))
+    isRecord(value) && typeof value.usedPercent === 'number' && Number.isFinite(value.usedPercent)
   )
 }
 
+/**
+ * False only for a wrapper that carries windows but none this build can read — the shape it
+ * must not classify, because classifying it yields the same two nulls a real empty answer does.
+ *
+ * Why not "every window must read": one window Orca does not recognise beside one it does is a
+ * readable answer. Rejecting it would discard live usage the day the app-server grows a window
+ * shape, which is the harm this gate exists to prevent, pointed the other way.
+ */
 export function isReadableCodexRateLimitWindowsSnapshot(
   value: unknown
 ): value is CodexRateLimitWindowsSnapshot | null | undefined {
-  return (
-    value == null ||
-    (isRecord(value) &&
-      isReadableRateLimitWindow(value.primary) &&
-      isReadableRateLimitWindow(value.secondary))
-  )
+  if (value == null) {
+    return true
+  }
+  if (!isRecord(value)) {
+    return false
+  }
+  const windows = [value.primary, value.secondary]
+  return windows.some(isReadableRateLimitWindow) || windows.every((window) => window == null)
 }
 
 type MappableCodexRateWindowSnapshot = CodexRateWindowSnapshot & { usedPercent: number }

--- a/src/main/rate-limits/codex-rpc-malformed-result.test.ts
+++ b/src/main/rate-limits/codex-rpc-malformed-result.test.ts
@@ -81,10 +81,16 @@ describe('readCodexRateLimitsViaRpc with an unreadable result', () => {
     })
   })
 
+  // STA-3445: the shape gate rejects a window Orca cannot read, but a response that claims
+  // no window at all reaches the same settle with the same two nulls -- and the stale policy
+  // cannot tell them apart, so it writes both over the account's last real usage. Apply the
+  // rule the PTY probe already uses: a reading with no window is not a successful reading.
   it.each([
     ['an empty object', {}],
-    ['an explicit null rateLimits', { rateLimits: null }]
-  ])('still accepts %s as a real answer with no windows', async (_label, result) => {
+    ['an explicit null rateLimits', { rateLimits: null }],
+    ['an empty rateLimits object', { rateLimits: {} }],
+    ['windows that are all null', { rateLimits: { primary: null, secondary: null } }]
+  ])('does not settle %s as a successful empty reading', async (_label, result) => {
     const pending = readRateLimits(result)
     await vi.advanceTimersByTimeAsync(1)
     await vi.advanceTimersByTimeAsync(1)
@@ -93,8 +99,22 @@ describe('readCodexRateLimitsViaRpc with an unreadable result', () => {
       provider: 'codex',
       session: null,
       weekly: null,
+      status: 'error'
+    })
+  })
+
+  it('still settles ok when at least one window reads', async () => {
+    const pending = readRateLimits({
+      rateLimits: { primary: { usedPercent: 42, windowDurationMins: 300 } }
+    })
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(pending).resolves.toMatchObject({
+      provider: 'codex',
       status: 'ok',
-      error: null
+      error: null,
+      session: { usedPercent: 42 }
     })
   })
 })

--- a/src/main/rate-limits/codex-rpc-malformed-result.test.ts
+++ b/src/main/rate-limits/codex-rpc-malformed-result.test.ts
@@ -61,7 +61,12 @@ describe('readCodexRateLimitsViaRpc with an unreadable result', () => {
     ['no result and no error', undefined],
     ['a null result', null],
     ['a scalar result', 42],
-    ['an array result', []]
+    ['an array result', []],
+    ['a scalar rateLimits field', { rateLimits: 42 }],
+    ['an array rateLimits field', { rateLimits: [] }],
+    ['a scalar primary window', { rateLimits: { primary: 42 } }],
+    ['a primary window without usage', { rateLimits: { primary: {} } }],
+    ['a primary window with non-numeric usage', { rateLimits: { primary: { usedPercent: '5' } } }]
   ])('does not report %s as a successful empty reading', async (_label, result) => {
     const pending = readRateLimits(result)
     await vi.advanceTimersByTimeAsync(1)

--- a/src/main/rate-limits/codex-rpc-malformed-result.test.ts
+++ b/src/main/rate-limits/codex-rpc-malformed-result.test.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  readCodexRateLimitsViaRpc,
+  type CodexRpcRateLimitChild
+} from './codex-rpc-rate-limit-probe'
+
+function makeRpcChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    stdin: EventEmitter & { write: ReturnType<typeof vi.fn> }
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.stdin = Object.assign(new EventEmitter(), { write: vi.fn() })
+  return child
+}
+
+function readRateLimits(result: unknown): Promise<{ status: string; error: string | null }> {
+  const child = makeRpcChild()
+  child.stdin.write.mockImplementation((line: string) => {
+    const msg = JSON.parse(line) as { id?: number; method?: string }
+    if (msg.method === 'initialize') {
+      setTimeout(() => {
+        child.stdout.emit(
+          'data',
+          Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} })}\n`)
+        )
+      }, 0)
+    }
+    if (msg.method === 'account/rateLimits/read') {
+      setTimeout(() => {
+        child.stdout.emit(
+          'data',
+          Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result })}\n`)
+        )
+      }, 0)
+    }
+  })
+  return readCodexRateLimitsViaRpc({
+    child: child as unknown as CodexRpcRateLimitChild,
+    codexCommand: 'codex',
+    initTimeoutMs: 1_000,
+    rpcTimeoutMs: 1_000,
+    terminate: () => Promise.resolve()
+  })
+}
+
+// STA-3445: `message.result` arrives from JSON.parse as `unknown` and was cast
+// straight to the expected wrapper. Every unreadable shape then classified into
+// two null windows and settled as a successful, empty reading — which the stale
+// policy treats as fresh data and writes over the last real snapshot.
+describe('readCodexRateLimitsViaRpc with an unreadable result', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  it.each([
+    ['no result and no error', undefined],
+    ['a null result', null],
+    ['a scalar result', 42],
+    ['an array result', []]
+  ])('does not report %s as a successful empty reading', async (_label, result) => {
+    const pending = readRateLimits(result)
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(pending).resolves.toMatchObject({
+      provider: 'codex',
+      session: null,
+      weekly: null,
+      status: 'error',
+      error: 'Codex returned an unreadable usage response'
+    })
+  })
+
+  it.each([
+    ['an empty object', {}],
+    ['an explicit null rateLimits', { rateLimits: null }]
+  ])('still accepts %s as a real answer with no windows', async (_label, result) => {
+    const pending = readRateLimits(result)
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(pending).resolves.toMatchObject({
+      provider: 'codex',
+      session: null,
+      weekly: null,
+      status: 'ok',
+      error: null
+    })
+  })
+})

--- a/src/main/rate-limits/codex-rpc-malformed-result.test.ts
+++ b/src/main/rate-limits/codex-rpc-malformed-result.test.ts
@@ -103,6 +103,26 @@ describe('readCodexRateLimitsViaRpc with an unreadable result', () => {
     })
   })
 
+  // STA-3445: rejecting the whole response because ONE window is unrecognised throws away a
+  // real reading -- the same harm from the other direction, and the one an app-server that
+  // grows a new window shape would trigger on every refresh.
+  it('still reads a window it understands next to one it does not', async () => {
+    const pending = readRateLimits({
+      rateLimits: {
+        primary: { usedPercent: 42, windowDurationMins: 300 },
+        secondary: 'a shape this build does not know'
+      }
+    })
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(pending).resolves.toMatchObject({
+      status: 'ok',
+      error: null,
+      session: { usedPercent: 42 }
+    })
+  })
+
   it('still settles ok when at least one window reads', async () => {
     const pending = readRateLimits({
       rateLimits: { primary: { usedPercent: 42, windowDurationMins: 300 } }

--- a/src/main/rate-limits/codex-rpc-rate-limit-probe.ts
+++ b/src/main/rate-limits/codex-rpc-rate-limit-probe.ts
@@ -14,7 +14,10 @@ import {
   type CodexRateLimitWindowsSnapshot
 } from './codex-rate-limit-window-classification'
 import type { CodexRateLimitFetchOptions } from './codex-rate-limit-fetch-options'
-import { abortedCodexRateLimitResult } from './codex-rate-limit-fetch-result'
+import {
+  abortedCodexRateLimitResult,
+  failedCodexRateLimitReading
+} from './codex-rate-limit-fetch-result'
 import { mapCodexRateLimitWindow } from './codex-rate-limit-window-mapper'
 import {
   mapRpcRateLimitResetCredits,
@@ -142,17 +145,7 @@ export function readCodexRateLimitsViaRpc(
         clearTimeout(timeout)
       }
       timeout = setTimeout(() => {
-        settle(
-          {
-            provider: 'codex',
-            session: null,
-            weekly: null,
-            updatedAt: Date.now(),
-            error: 'RPC timeout',
-            status: 'error'
-          },
-          { kill: true }
-        )
+        settle(failedCodexRateLimitReading('RPC timeout'), { kill: true })
       }, deadlineMs)
     }
     armRpcDeadline(options.initTimeoutMs)
@@ -178,18 +171,14 @@ export function readCodexRateLimitsViaRpc(
       const isEnoent = (error as NodeJS.ErrnoException).code === 'ENOENT'
       const isBareCommand = codexCommand === 'codex'
       settle(
-        {
-          provider: 'codex',
-          session: null,
-          weekly: null,
-          updatedAt: Date.now(),
-          error: isEnoent
+        failedCodexRateLimitReading(
+          isEnoent
             ? isBareCommand
               ? 'Codex CLI not found'
               : 'Codex CLI found but could not run — Node.js may not be in your PATH'
             : withMacTailscaleDnsHint(error.message, stderr),
-          status: isEnoent && isBareCommand ? 'unavailable' : 'error'
-        },
+          isEnoent && isBareCommand ? 'unavailable' : 'error'
+        ),
         { kill: true }
       )
     }
@@ -203,14 +192,7 @@ export function readCodexRateLimitsViaRpc(
     }
 
     function onClose(code: number | null, signal: NodeJS.Signals | null): void {
-      settle({
-        provider: 'codex',
-        session: null,
-        weekly: null,
-        updatedAt: Date.now(),
-        error: describeCodexRpcExit(code, signal, stderr),
-        status: 'error'
-      })
+      settle(failedCodexRateLimitReading(describeCodexRpcExit(code, signal, stderr)))
     }
 
     let rateLimitsId: number | null = null
@@ -245,14 +227,7 @@ export function readCodexRateLimitsViaRpc(
           }
           if (message.error) {
             settle(
-              {
-                provider: 'codex',
-                session: null,
-                weekly: null,
-                updatedAt: Date.now(),
-                error: withMacTailscaleDnsHint(message.error.message, stderr),
-                status: 'error'
-              },
+              failedCodexRateLimitReading(withMacTailscaleDnsHint(message.error.message, stderr)),
               { kill: true }
             )
             return
@@ -263,20 +238,22 @@ export function readCodexRateLimitsViaRpc(
             // one Orca could not understand. Classifying it anyway would settle
             // two null windows as a successful reading, and the stale policy
             // would write that over the account's last real usage (STA-3445).
-            settle(
-              {
-                provider: 'codex',
-                session: null,
-                weekly: null,
-                updatedAt: Date.now(),
-                error: 'Codex returned an unreadable usage response',
-                status: 'error'
-              },
-              { kill: true }
-            )
+            settle(failedCodexRateLimitReading('Codex returned an unreadable usage response'), {
+              kill: true
+            })
             return
           }
           const classified = classifyCodexRateLimitWindows(wrapper.rateLimits)
+          if (!classified.session && !classified.weekly) {
+            // Why (STA-3445): the gate above rejects a window Orca cannot read, but a response
+            // claiming no window at all lands on the same two nulls -- and the stale policy
+            // cannot tell those apart, so it writes both over the last real usage. Apply the
+            // rule the PTY probe already uses: no window is not a successful reading.
+            settle(failedCodexRateLimitReading('Codex returned no readable usage windows'), {
+              kill: true
+            })
+            return
+          }
           const credits = mapRpcRateLimitResetCredits(wrapper.rateLimitResetCredits)
           settle(
             {

--- a/src/main/rate-limits/codex-rpc-rate-limit-probe.ts
+++ b/src/main/rate-limits/codex-rpc-rate-limit-probe.ts
@@ -10,6 +10,7 @@ import {
   classifyCodexRateLimitWindows,
   CODEX_SESSION_WINDOW_MINUTES,
   CODEX_WEEKLY_WINDOW_MINUTES,
+  isReadableCodexRateLimitWindowsSnapshot,
   type CodexRateLimitWindowsSnapshot
 } from './codex-rate-limit-window-classification'
 import type { CodexRateLimitFetchOptions } from './codex-rate-limit-fetch-options'
@@ -37,9 +38,15 @@ type RpcRateLimitsResponse = {
 // a claim, not a fact. Only a plain object can carry the wrapper's fields; each
 // field inside is validated separately by its own mapper.
 function readRpcRateLimitsResult(result: unknown): RpcRateLimitsResponse | null {
-  return result && typeof result === 'object' && !Array.isArray(result)
-    ? (result as RpcRateLimitsResponse)
-    : null
+  if (
+    !result ||
+    typeof result !== 'object' ||
+    Array.isArray(result) ||
+    !isReadableCodexRateLimitWindowsSnapshot((result as RpcRateLimitsResponse).rateLimits)
+  ) {
+    return null
+  }
+  return result as RpcRateLimitsResponse
 }
 
 type RpcDataStream = {

--- a/src/main/rate-limits/codex-rpc-rate-limit-probe.ts
+++ b/src/main/rate-limits/codex-rpc-rate-limit-probe.ts
@@ -33,6 +33,15 @@ type RpcRateLimitsResponse = {
   rateLimitResetCredits?: RpcRateLimitResetCredits
 }
 
+// Why: `result` crosses the app-server boundary as parsed JSON, so its shape is
+// a claim, not a fact. Only a plain object can carry the wrapper's fields; each
+// field inside is validated separately by its own mapper.
+function readRpcRateLimitsResult(result: unknown): RpcRateLimitsResponse | null {
+  return result && typeof result === 'object' && !Array.isArray(result)
+    ? (result as RpcRateLimitsResponse)
+    : null
+}
+
 type RpcDataStream = {
   on(event: 'data', listener: (chunk: Buffer) => void): unknown
   off(event: 'data', listener: (chunk: Buffer) => void): unknown
@@ -241,9 +250,27 @@ export function readCodexRateLimitsViaRpc(
             )
             return
           }
-          const wrapper = message.result as RpcRateLimitsResponse | undefined
-          const classified = classifyCodexRateLimitWindows(wrapper?.rateLimits)
-          const credits = mapRpcRateLimitResetCredits(wrapper?.rateLimitResetCredits)
+          const wrapper = readRpcRateLimitsResult(message.result)
+          if (!wrapper) {
+            // Why: a response carrying neither an error nor a readable result is
+            // one Orca could not understand. Classifying it anyway would settle
+            // two null windows as a successful reading, and the stale policy
+            // would write that over the account's last real usage (STA-3445).
+            settle(
+              {
+                provider: 'codex',
+                session: null,
+                weekly: null,
+                updatedAt: Date.now(),
+                error: 'Codex returned an unreadable usage response',
+                status: 'error'
+              },
+              { kill: true }
+            )
+            return
+          }
+          const classified = classifyCodexRateLimitWindows(wrapper.rateLimits)
+          const credits = mapRpcRateLimitResetCredits(wrapper.rateLimitResetCredits)
           settle(
             {
               provider: 'codex',

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -519,3 +519,45 @@ describe('isUsageEmptyState', () => {
     ).toBe(true)
   })
 })
+
+// STA-3445: the reporter's Codex account was connected (Settings resolved its
+// ~/.codex identity) while the status bar still offered "Configure usage
+// tracking". A system-default account persists no managed-account row, so the
+// usage snapshot is its only durable signal here.
+describe('a system-default Codex account whose usage probe failed', () => {
+  function withCodex(codex: ProviderRateLimits): Parameters<typeof isUsageEmptyState>[0] {
+    return {
+      claude: provider('unavailable', { provider: 'claude' }),
+      codex,
+      gemini: provider('unavailable'),
+      opencodeGo: provider('unavailable', { provider: 'opencode-go' }),
+      kimi: provider('unavailable', { provider: 'kimi' }),
+      antigravity: provider('unavailable', { provider: 'antigravity' }),
+      minimax: provider('unavailable', { provider: 'minimax' }),
+      grok: provider('unavailable', { provider: 'grok' })
+    }
+  }
+
+  const failedReading = provider('error', {
+    provider: 'codex',
+    error: 'Codex CLI not found'
+  })
+
+  it('keeps the Codex chip visible instead of hiding a connected account', () => {
+    expect(isProviderConfigured(failedReading)).toBe(true)
+    expect(getVisibleUsageProvider('codex', failedReading, usageSettings())).toBe(failedReading)
+  })
+
+  it('does not offer the connect-an-account CTA to a signed-in user', () => {
+    expect(isUsageEmptyState(withCodex(failedReading), usageSettings())).toBe(false)
+  })
+
+  it('still offers the CTA when Codex really is signed out', () => {
+    expect(
+      isUsageEmptyState(
+        withCodex(provider('unavailable', { provider: 'codex', error: 'Codex not signed in' })),
+        usageSettings()
+      )
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​354 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​354 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​43 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 |

<!-- /orca-pr-loc -->

Fixes STA-3445.

## ELI5

Orca's bottom-left corner said **"Configure usage tracking"** — the message a
brand-new user sees when they have not connected any AI account yet. But the
reporter *had* connected Codex, and Orca's own Settings pane proved it: it was
showing their ChatGPT email, read live out of `~/.codex/auth.json`.

The two screens disagreed because they were answering different questions with
the same word. Settings asked *"is an account connected?"*. The status bar asked
*"did the usage reading succeed?"* — and when it did not, Orca filed that
failure under `unavailable`, which is the same code it uses for "the user never
set this up". So a reading that failed came back out the other side as a
confident statement about the user's account.

## User-facing before / after

**Before:** your Codex usage showed as unavailable — in fact the status bar
offered to help you *connect an account you had already connected* — whenever
Orca could not run the `codex` binary to take the reading. There was nothing to
click, nothing to retry, and no hint that anything had failed.

**After:** Orca separates "you are not signed in to Codex" from "I could not
read your Codex usage". A connected account is never described as unconfigured,
so the "Connect an account" prompt no longer appears for someone who is already
signed in. When the reading genuinely fails, the Codex chip stays and says
*Refresh failed — Codex CLI not found*, and the next poll retries. If Codex
really is signed out, the setup prompt still appears exactly as before.

A second, quieter case is fixed too: if the Codex app-server answered with
something Orca could not parse, Orca recorded it as a **successful** reading of
zero, threw away your last real usage numbers, and left a blank chip with no
error. That now reports as a failed read, so your previous numbers survive and
Orca can fall back to its other probe.

## What was actually wrong

**It is usage-fetch, not account-detection.** Account detection works — the same
`~/.codex/auth.json` that Settings renders is what `probeCodexAuthPresence`
reads, and the reporter's screenshot shows the resolved email, which only
renders on `authKind: 'oauth'`.

**The point where a failure becomes a value** is the `unavailable` status, in
two places, both of which sit *downstream of the auth gate* in
`fetchCodexRateLimits` — they are only reachable once `authPresence === 'present'`
has already proven a Codex sign-in exists on disk:

| Site | Failure | Reported as |
| --- | --- | --- |
| `codex-rpc-rate-limit-probe.ts` `onError` | spawn `codex` → `ENOENT` | `unavailable` "Codex CLI not found" |
| `codex-fetcher.ts` PTY `catch` | PTY spawn → `ENOENT` | `unavailable` "Codex CLI not found" |

`isProviderConfigured()` reads `unavailable` as "this provider is not set up",
which hides the chip and — because a **system-default** Codex account persists no
managed-account row, so the usage snapshot is its only durable signal —
makes `isUsageEmptyState()` render `StatusBarUsageEmptyCta` ("Configure usage
tracking" / "Connect an account").

The fix states the invariant once, where it is true, instead of patching each
arm: everything below the auth gate ran against a proven sign-in, so nothing
down there may claim the account is absent.

The repo already had this exact rule for the gate's own indeterminate answers
("does not report an indeterminate timeout/unavailable probe as signed out",
`codex-fetcher.test.ts`). This extends it past the gate.

### Second defect: a cast without a check

`codex-rpc-rate-limit-probe.ts` cast the JSON-RPC `result` — `unknown`, straight
off the wire — to its expected wrapper, then classified it. Measured on the base
commit, **every** unreadable shape settled as a success:

| `result` | Before | After |
| --- | --- | --- |
| omitted (no `result`, no `error`) | `ok`, `error: null`, no windows | `error` |
| `null` | `ok`, `error: null`, no windows | `error` |
| `42` | `ok`, `error: null`, no windows | `error` |
| `[]` | `ok`, `error: null`, no windows | `error` |
| `{}` | `ok`, no windows | `ok` (unchanged) |
| `{ rateLimits: null }` | `ok`, no windows | `ok` (unchanged) |

`ok` is the worst possible verdict here: `applyStalePolicy` treats it as fresh
data and **discards the last good snapshot**, so one unreadable response wipes
real usage and leaves a silent blank chip forever. `{}` and an explicit
`rateLimits: null` remain valid "no windows recorded" answers — the check is
only that the payload is an object at all.

## Tests

Failing-first, one test per producer, each failing on the assertion itself:

| Test | Base | Fixed |
| --- | --- | --- |
| RPC probe `ENOENT` → failed reading | `status: "unavailable"` | pass |
| PTY fallback `ENOENT` → failed reading | `status: "unavailable"` | pass |
| genuinely signed-out Codex stays `unavailable` | pass (control) | pass |
| 4 × unreadable RPC `result` → not a success | `status: "ok"` | pass |
| 2 × `{}` / `rateLimits: null` still `ok` | pass (control) | pass |

Read-site pins in `status-bar-provider-visibility.test.ts` assert the
user-visible consequence at the surface that renders the CTA: a failed Codex
reading keeps the chip visible and suppresses the empty-state prompt, while a
genuinely signed-out Codex still shows it.

### Ablation

Scope: `src/main/rate-limits/ src/renderer/src/components/status-bar/` — 752
tests. Each mutation was diffed against the original to confirm it applied
before the count was trusted.

| Ablation | Result |
| --- | --- |
| baseline (both fixes) | 752 passed |
| A1 delete the signed-in fence | **2 failed** |
| A2 fence body → `return limits` | **2 failed** |
| A3 invert the fence (`error` → `unavailable`) | **19 failed** |
| B1 result reader always accepts | **2 failed** |
| B2 remove the unreadable-result guard | **4 failed** |

B1 reddens 2 rather than 4 because `!wrapper` still catches `null`/omitted; it
ablates only the type half of the reader.

Regression sweep across every consumer (`rate-limits`, `codex-accounts`,
`codex`, `ipc`, store slices, status-bar, stats, shared): **14,675 passed**.

## What is not proven

No live Codex account was available, so nothing here was observed end-to-end in
a running app. What is proven is the seam: the control flow that makes both
`unavailable` arms reachable only with a verified sign-in, the response-parser
behaviour measured shape-by-shape on the base commit, and the renderer helper
that turns those statuses into the CTA. What is *not* proven is that this exact
path is what the reporter hit — the screenshot fixes the symptom (the empty-state
CTA with a resolved Codex identity in Settings) and rules out account-detection,
but it cannot name which spawn failed on their machine.

One honesty gap remains and is deliberately **not** fixed here: when the `codex`
CLI is also missing from Orca's PATH detection, `isStatusBarItemAvailable()`
hides the Codex chip, so after this change the status bar says *nothing* rather
than something false. Removing the false claim is the fix; giving that case its
own "usage unreadable" affordance is a separate design change.

## Gates

`pnpm tc` clean · `oxlint --deny-warnings` clean · changed-code quality gate
0 new findings across 5 files (code quality, type-aware, React Doctor) ·
`git diff --check` clean · formatted with `npx oxfmt --write` on changed files
only. No suppressions, no `max-lines` disable.
