### PR TITLE
fix(wsl): resolve Linux Git metadata paths on Windows

### DIFF
--- a/src/main/git/git-metadata-path.test.ts
+++ b/src/main/git/git-metadata-path.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { resolveGitMetadataPath } from './git-metadata-path'
+
+describe('resolveGitMetadataPath', () => {
+  it('maps a WSL drive mount without requiring a distro', () => {
+    expect(
+      resolveGitMetadataPath(
+        String.raw`C:\Users\me\repo`,
+        '/mnt/c/Users/me/repo/.git/worktrees/feature',
+        { platform: 'win32' }
+      )
+    ).toBe(String.raw`C:\Users\me\repo\.git\worktrees\feature`)
+  })
+
+  it('maps an absolute distro path with the runtime distro', () => {
+    expect(
+      resolveGitMetadataPath(String.raw`C:\Users\me\repo`, '/home/me/repo/.git/worktrees/feature', {
+        platform: 'win32',
+        wslDistro: 'Ubuntu'
+      })
+    ).toBe(String.raw`\\wsl.localhost\Ubuntu\home\me\repo\.git\worktrees\feature`)
+  })
+
+  it('prefers the distro encoded by a WSL UNC base path', () => {
+    expect(
+      resolveGitMetadataPath(
+        String.raw`\\wsl.localhost\Debian\home\me\repo`,
+        '/home/me/repo/.git/worktrees/feature',
+        { platform: 'win32', wslDistro: 'Ubuntu' }
+      )
+    ).toBe(String.raw`\\wsl.localhost\Debian\home\me\repo\.git\worktrees\feature`)
+  })
+
+  it('rejects an untranslatable POSIX absolute path on native Windows', () => {
+    expect(
+      resolveGitMetadataPath(String.raw`C:\Users\me\repo`, '/home/me/repo/.git', {
+        platform: 'win32'
+      })
+    ).toBeNull()
+  })
+
+  it.each([
+    ['/var/lib/git/worktrees/feature', '/var/lib/git/worktrees/feature', 'linux'],
+    [String.raw`D:\repo\.git`, String.raw`D:\repo\.git`, 'win32'],
+    [String.raw`\\server\share\repo\.git`, String.raw`\\server\share\repo\.git`, 'win32']
+  ] as const)('preserves an absolute metadata path %s', (metadataPath, expected, platform) => {
+    expect(resolveGitMetadataPath('/repo', metadataPath, { platform })).toBe(expected)
+  })
+
+  it.each(['', '   ', '\t'])('rejects an empty metadata path', (metadataPath) => {
+    expect(resolveGitMetadataPath('/repo', metadataPath, { platform: 'linux' })).toBeNull()
+  })
+
+  it('resolves relative paths using the base path flavor', () => {
+    expect(
+      resolveGitMetadataPath('/repo/worktree', '../.git/worktrees/feature', {
+        platform: 'linux'
+      })
+    ).toBe('/repo/.git/worktrees/feature')
+    expect(
+      resolveGitMetadataPath(String.raw`C:\repo\worktree`, String.raw`..\.git\worktrees\feature`, {
+        platform: 'win32'
+      })
+    ).toBe(String.raw`C:\repo\.git\worktrees\feature`)
+  })
+})

--- a/src/main/git/git-metadata-path.ts
+++ b/src/main/git/git-metadata-path.ts
@@ -1,0 +1,43 @@
+import { posix, win32 } from 'node:path'
+import { parseWslUncPath, toWindowsWslDrivePath, toWindowsWslPath } from '../../shared/wsl-paths'
+
+export type GitMetadataPathOptions = {
+  platform?: NodeJS.Platform
+  wslDistro?: string
+}
+
+export function resolveGitMetadataPath(
+  basePath: string,
+  rawPath: string,
+  options: GitMetadataPathOptions = {}
+): string | null {
+  const value = rawPath.trim()
+  const platform = options.platform ?? process.platform
+  if (!value) {
+    return null
+  }
+  if (isWindowsDriveOrUncPath(value)) {
+    return value
+  }
+  if (!value.startsWith('/')) {
+    return pathOperations(platform).resolve(basePath, value)
+  }
+  if (platform !== 'win32') {
+    return value
+  }
+
+  const drivePath = toWindowsWslDrivePath(value)
+  if (drivePath) {
+    return drivePath
+  }
+  const distro = parseWslUncPath(basePath)?.distro ?? options.wslDistro?.trim()
+  return distro ? toWindowsWslPath(value, distro) : null
+}
+
+function isWindowsDriveOrUncPath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || /^[/\\]{2}[^/\\]+[/\\][^/\\]+/.test(value)
+}
+
+function pathOperations(platform: NodeJS.Platform): typeof posix {
+  return platform === 'win32' ? win32 : posix
+}

--- a/src/main/git/repo-git-marker-scan.ts
+++ b/src/main/git/repo-git-marker-scan.ts
@@ -1,8 +1,7 @@
 import { readFileSync, realpathSync, statSync } from 'node:fs'
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { dirname, isAbsolute, join, relative } from 'node:path'
 import { normalizeRuntimePathSeparators } from '../../shared/cross-platform-path'
-import { parseWslUncPath } from '../../shared/wsl-paths'
-import { toWindowsWslPath } from '../wsl'
+import { resolveGitMetadataPath } from './git-metadata-path'
 
 export type GitMarkerScanResult =
   | { status: 'valid'; rootPath: string }
@@ -134,18 +133,6 @@ function parseGitdirFile(basePath: string, content: string): string | null {
     return null
   }
   return resolveGitMetadataPath(basePath, match[1])
-}
-
-function resolveGitMetadataPath(basePath: string, rawPath: string): string | null {
-  const value = rawPath.trim()
-  if (!value) {
-    return null
-  }
-  const baseWsl = parseWslUncPath(basePath)
-  if (baseWsl && value.startsWith('/')) {
-    return toWindowsWslPath(value, baseWsl.distro)
-  }
-  return isAbsolute(value) ? value : resolve(basePath, value)
 }
 
 function hasValidGitDirectorySync(gitDir: string): boolean {

--- a/src/main/git/source-control/file-diff.ts
+++ b/src/main/git/source-control/file-diff.ts
@@ -76,7 +76,7 @@ async function loadDiffThroughSettledCache(
   // lands entirely inside that window would otherwise leave the fence covering only the git read.
   const readGeneration = settledDiffCache.beginRead()
   // A staged diff compares HEAD to the index, so the working tree is not one of its inputs.
-  const stamp = await readWorktreeDiffStamp(worktreePath, filePath, !staged)
+  const stamp = await readWorktreeDiffStamp(worktreePath, filePath, !staged, options)
   const cached = settledDiffCache.get(readKey, stamp)
   if (cached) {
     return cached

--- a/src/main/git/source-control/git-conflict-operation.ts
+++ b/src/main/git/source-control/git-conflict-operation.ts
@@ -1,5 +1,5 @@
 import { access } from 'node:fs/promises'
-import * as path from 'node:path'
+import { posix, win32 } from 'node:path'
 import type { GitConflictOperation } from '../../../shared/git-status-types'
 import type { GitRuntimeOptions } from '../git-runtime-options'
 import { gitOptionsForWorktree } from '../git-runtime-options'
@@ -9,12 +9,19 @@ import { resolveGitDir } from './resolve-git-dir'
 
 // Why: the git-status → existsSync race can miss a transient HEAD; fall back to 'unknown' for one poll cycle.
 // Why: detect rebase from rebase-merge/ or rebase-apply/ dirs (persist all steps), not REBASE_HEAD (partial, lingers → stale badge).
-export async function detectConflictOperation(worktreePath: string): Promise<GitConflictOperation> {
-  const gitDir = await resolveGitDir(worktreePath)
-  const mergeHead = path.join(gitDir, 'MERGE_HEAD')
-  const cherryPickHead = path.join(gitDir, 'CHERRY_PICK_HEAD')
-  const rebaseMergeDir = path.join(gitDir, 'rebase-merge')
-  const rebaseApplyDir = path.join(gitDir, 'rebase-apply')
+export async function detectConflictOperation(
+  worktreePath: string,
+  options: Pick<GitRuntimeOptions, 'wslDistro'> = {}
+): Promise<GitConflictOperation> {
+  const gitDir = await resolveGitDir(worktreePath, options)
+  if (!gitDir) {
+    return 'unknown'
+  }
+  const pathOperations = process.platform === 'win32' ? win32 : posix
+  const mergeHead = pathOperations.join(gitDir, 'MERGE_HEAD')
+  const cherryPickHead = pathOperations.join(gitDir, 'CHERRY_PICK_HEAD')
+  const rebaseMergeDir = pathOperations.join(gitDir, 'rebase-merge')
+  const rebaseApplyDir = pathOperations.join(gitDir, 'rebase-apply')
 
   // Why async and concurrent: this runs on every status poll, and on a WSL/UNC git dir each
   // probe is a 9p round trip — four of them synchronously blocked the Electron main thread.

--- a/src/main/git/source-control/resolve-git-dir.test.ts
+++ b/src/main/git/source-control/resolve-git-dir.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { readFileMock } = vi.hoisted(() => ({ readFileMock: vi.fn() }))
+
+vi.mock('node:fs/promises', () => ({ readFile: readFileMock }))
+
+import { resolveGitDir } from './resolve-git-dir'
+
+describe('resolveGitDir', () => {
+  beforeEach(() => {
+    readFileMock.mockReset()
+  })
+
+  it('resolves a relative linked-worktree marker', async () => {
+    readFileMock.mockResolvedValue('gitdir: ../main/.git/worktrees/feature\n')
+
+    await expect(resolveGitDir('/repo/feature')).resolves.toBe('/repo/main/.git/worktrees/feature')
+  })
+
+  it('does not treat an empty gitdir marker as a metadata directory', async () => {
+    readFileMock.mockResolvedValue('gitdir:   \n')
+
+    await expect(resolveGitDir('/repo/feature')).resolves.toBeNull()
+  })
+
+  it('uses the .git directory when the marker cannot be read', async () => {
+    readFileMock.mockRejectedValue(Object.assign(new Error('EISDIR'), { code: 'EISDIR' }))
+
+    await expect(resolveGitDir('/repo')).resolves.toBe('/repo/.git')
+  })
+})

--- a/src/main/git/source-control/resolve-git-dir.ts
+++ b/src/main/git/source-control/resolve-git-dir.ts
@@ -1,14 +1,20 @@
 import { readFile } from 'node:fs/promises'
 import * as path from 'node:path'
+import type { GitRuntimeOptions } from '../git-runtime-options'
+import { resolveGitMetadataPath } from '../git-metadata-path'
 
-export async function resolveGitDir(worktreePath: string): Promise<string> {
+export async function resolveGitDir(
+  worktreePath: string,
+  options: Pick<GitRuntimeOptions, 'wslDistro'> = {}
+): Promise<string | null> {
   const dotGitPath = path.join(worktreePath, '.git')
 
   try {
     const dotGitContents = await readFile(dotGitPath, 'utf-8')
-    const match = dotGitContents.match(/^gitdir:\s*(.+)\s*$/m)
+    const firstLine = dotGitContents.split(/\r?\n/, 1)[0] ?? ''
+    const match = firstLine.match(/^gitdir:\s*(.*?)\s*$/i)
     if (match) {
-      return path.resolve(worktreePath, match[1])
+      return resolveGitMetadataPath(worktreePath, match[1], options)
     }
   } catch {
     // `.git` is likely a directory in a non-worktree checkout.

--- a/src/main/git/source-control/status-read.ts
+++ b/src/main/git/source-control/status-read.ts
@@ -109,7 +109,7 @@ async function runGetStatus(
   const limit = resolveGitStatusLimit(options.limit)
 
   // Why: detectConflictOperation and git status are independent, so run them concurrently to save I/O latency.
-  const conflictPromise = detectConflictOperation(worktreePath)
+  const conflictPromise = detectConflictOperation(worktreePath, options)
   // Why: core.quotePath=false keeps non-ASCII paths as raw UTF-8, not octal escapes, so entry.path is readable and lookups match.
   const statusArgs = [
     '-c',

--- a/src/main/git/source-control/worktree-diff-stamp.ts
+++ b/src/main/git/source-control/worktree-diff-stamp.ts
@@ -1,5 +1,7 @@
 import { readFile, stat } from 'node:fs/promises'
 import * as path from 'node:path'
+import type { GitRuntimeOptions } from '../git-runtime-options'
+import { resolveGitMetadataPath } from '../git-metadata-path'
 import { resolveGitDir } from './resolve-git-dir'
 
 /**
@@ -68,13 +70,17 @@ export function isDiffStampClockSkewed(stamp: WorktreeDiffStamp): boolean {
 export async function readWorktreeDiffStamp(
   worktreePath: string,
   filePath: string,
-  includeWorkingTree: boolean
+  includeWorkingTree: boolean,
+  options: Pick<GitRuntimeOptions, 'wslDistro'> = {}
 ): Promise<WorktreeDiffStamp | null> {
   const capturedAtMs = Date.now()
   try {
-    const gitDir = await resolveGitDir(worktreePath)
+    const gitDir = await resolveGitDir(worktreePath, options)
+    if (!gitDir) {
+      return null
+    }
     const [head, index, gitmodules, workingTree] = await Promise.all([
-      readHeadComponent(gitDir),
+      readHeadComponent(gitDir, options),
       // Over-invalidates on purpose: git run outside Orca (a terminal `git status`/`git add`)
       // can refresh a stat-dirty index and rewrite this file without changing a single blob,
       // which costs one re-read. That is the safe direction — do not "fix" it by dropping the
@@ -115,7 +121,10 @@ export async function readWorktreeDiffStamp(
  * branch — does this fall back to the coarser stamps of the files a packed tip
  * moves, and the recorded "no loose ref" marker still catches the ref appearing.
  */
-async function readHeadComponent(gitDir: string): Promise<StampComponent | null> {
+async function readHeadComponent(
+  gitDir: string,
+  options: Pick<GitRuntimeOptions, 'wslDistro'>
+): Promise<StampComponent | null> {
   const [head, commonDirEntry] = await Promise.all([
     readTrimmedFile(path.join(gitDir, 'HEAD')),
     readTrimmedFile(path.join(gitDir, 'commondir'))
@@ -123,7 +132,12 @@ async function readHeadComponent(gitDir: string): Promise<StampComponent | null>
   if (!head) {
     return null
   }
-  const commonDir = commonDirEntry ? path.resolve(gitDir, commonDirEntry) : gitDir
+  const commonDir = commonDirEntry
+    ? resolveGitMetadataPath(gitDir, commonDirEntry, options)
+    : gitDir
+  if (!commonDir) {
+    return null
+  }
   const refName = head.match(/^ref:\s*(.+?)\s*$/)?.[1]
   if (!refName || !isSafeRefName(refName)) {
     // Detached HEAD already holds the object id; an unrecognized HEAD is covered by its own text.

--- a/src/main/git/status-conflict-operations.test.ts
+++ b/src/main/git/status-conflict-operations.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as BoundedFileReader from '../../shared/node-bounded-file-reader'
 import {
   createBoundedFileReaderModuleMock,
@@ -55,6 +55,18 @@ vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) =>
 )
 
 import { abortMerge, abortRebase, detectConflictOperation } from './status'
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+afterEach(() => {
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+})
+
+function useWindowsPlatform(): void {
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+}
 
 describe('abortMerge', () => {
   beforeEach(() => {
@@ -139,6 +151,44 @@ describe('detectConflictOperation', () => {
 
     expect(accessMock).toHaveBeenCalledTimes(4)
     expect(peakConcurrent).toBe(4)
+  })
+
+  it.each([
+    {
+      name: 'native drive',
+      worktreePath: String.raw`C:\worktrees\feature`,
+      gitDir: '/mnt/c/repo/.git/worktrees/feature',
+      options: {},
+      expectedGitDir: String.raw`C:\repo\.git\worktrees\feature`
+    },
+    {
+      name: 'WSL UNC',
+      worktreePath: String.raw`C:\worktrees\feature`,
+      gitDir: '/home/me/repo/.git/worktrees/feature',
+      options: { wslDistro: 'Ubuntu' },
+      expectedGitDir: String.raw`\\wsl.localhost\Ubuntu\home\me\repo\.git\worktrees\feature`
+    }
+  ])('targets all conflict probes at the resolved $name gitdir', async (fixture) => {
+    useWindowsPlatform()
+    readFileMock.mockResolvedValue(`gitdir: ${fixture.gitDir}\n`)
+    accessMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+
+    await detectConflictOperation(fixture.worktreePath, fixture.options)
+
+    expect(accessMock.mock.calls.map(([target]) => target)).toEqual([
+      `${fixture.expectedGitDir}\\MERGE_HEAD`,
+      `${fixture.expectedGitDir}\\CHERRY_PICK_HEAD`,
+      `${fixture.expectedGitDir}\\rebase-merge`,
+      `${fixture.expectedGitDir}\\rebase-apply`
+    ])
+  })
+
+  it('skips probes when a Windows gitdir cannot be translated', async () => {
+    useWindowsPlatform()
+    readFileMock.mockResolvedValue('gitdir: /home/me/repo/.git/worktrees/feature\n')
+
+    await expect(detectConflictOperation(String.raw`C:\worktrees\feature`)).resolves.toBe('unknown')
+    expect(accessMock).not.toHaveBeenCalled()
   })
 
   it('reads as unknown when the git dir cannot be reached at all', async () => {

--- a/src/main/git/status-diff-settled-cache.test.ts
+++ b/src/main/git/status-diff-settled-cache.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as path from 'node:path'
 import type * as BoundedFileReader from '../../shared/node-bounded-file-reader'
 import { createBoundedFileReaderModuleMock, createGitRunnerModuleMock } from './status-test-harness'
 
@@ -147,6 +148,35 @@ describe('settled diff cache', () => {
     expect(blobReadCount()).toBe(spawnsAfterFirst)
     expect(second).toEqual(first)
     expect(settledDiffCache.stats().hits).toBe(1)
+  })
+
+  it('caches a WSL diff through distro-required gitdir and absolute commondir paths', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      const worktreePath = String.raw`C:\workspace\feature`
+      const gitDir = String.raw`\\wsl.localhost\Ubuntu\home\me\repo\.git\worktrees\feature`
+      const commonGitDir = String.raw`\\wsl.localhost\Ubuntu\home\me\repo\.git`
+      files.clear()
+      writeFile(path.join(worktreePath, '.git'), 'gitdir: /home/me/repo/.git/worktrees/feature\n')
+      writeFile(path.join(gitDir, 'HEAD'), 'ref: refs/heads/main\n')
+      writeFile(path.join(gitDir, 'commondir'), '/home/me/repo/.git\n')
+      writeFile(path.join(commonGitDir, 'refs/heads/main'), `${'a'.repeat(40)}\n`)
+      writeFile(path.join(gitDir, 'index'), 'index-bytes')
+      writeFile(path.join(worktreePath, FILE), 'working-tree-content')
+
+      await getDiff(worktreePath, FILE, false, false, { wslDistro: 'Ubuntu' })
+      const spawnsAfterFirst = blobReadCount()
+      await getDiff(worktreePath, FILE, false, false, { wslDistro: 'Ubuntu' })
+
+      expect(blobReadCount()).toBe(spawnsAfterFirst)
+      expect(settledDiffCache.stats().hits).toBe(1)
+      expect(readFileMock).toHaveBeenCalledWith(path.join(commonGitDir, 'refs/heads/main'), 'utf-8')
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
   })
 
   // The four invalidation axes, one per diff input. Each proves the stale result is

--- a/src/main/git/worktree-list-porcelain.test.ts
+++ b/src/main/git/worktree-list-porcelain.test.ts
@@ -116,7 +116,7 @@ describe('listWorktrees', () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout:
         'worktree /mnt/c/Users/me/repo\nHEAD abc123\nbranch refs/heads/main\nsparse\n\n' +
-        'worktree /mnt/c/Users/me/repo-feature\nHEAD def456\nbranch refs/heads/feature/test\nsparse\n\n'
+        'worktree /mnt/c/Users/me/repo-feature\nHEAD def456\nbranch refs/heads/feature/test\n\n'
     })
     translateWslOutputPathsMock.mockImplementation((output: string) =>
       output
@@ -138,7 +138,6 @@ describe('listWorktrees', () => {
         head: 'def456',
         branch: 'refs/heads/feature/test',
         isBare: false,
-        isSparse: true,
         isMainWorktree: false
       }
     ])
@@ -152,6 +151,9 @@ describe('listWorktrees', () => {
       'C:\\Users\\me\\repo',
       { wslDistro: 'Ubuntu' }
     )
+    expect(resolveGitDirMock).toHaveBeenCalledWith('C:\\Users\\me\\repo-feature', {
+      wslDistro: 'Ubuntu'
+    })
   })
 
   it('returns no worktrees when the repo path is gone', async () => {
@@ -243,11 +245,61 @@ describe('listWorktrees', () => {
         isMainWorktree: false
       }
     ])
-    expect(resolveGitDirMock).toHaveBeenCalledWith(featureWorktreePath)
+    expect(resolveGitDirMock).toHaveBeenCalledWith(featureWorktreePath, {})
     // Why: the detection path must not spawn a git subprocess per worktree —
     // the perf regression in #1131 came from `git sparse-checkout list` firing
     // on every poll.
     expect(getGitCalls()).toEqual(['git worktree list --porcelain -z'])
+  })
+
+  it('translates an absolute WSL commondir before reading sparse config', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      const worktreePath = String.raw`C:\Users\me\repo-feature`
+      const gitDir = String.raw`C:\repo\.git\worktrees\feature`
+      gitExecFileAsyncMock.mockResolvedValueOnce({
+        stdout:
+          'worktree /mnt/c/Users/me/repo-feature\n' +
+          'HEAD def456\nbranch refs/heads/feature/test\n\n'
+      })
+      translateWslOutputPathsMock.mockImplementation((output: string) =>
+        output.replace('/mnt/c/Users/me/repo-feature', worktreePath)
+      )
+      resolveGitDirMock.mockResolvedValue(gitDir)
+      statMock.mockResolvedValue({ isFile: () => true, size: 32 })
+      readFileMock.mockImplementation(async (filePath: string) => {
+        const normalized = String(filePath).replaceAll('\\', '/')
+        if (normalized.endsWith('/commondir')) {
+          return '/mnt/c/repo/.git\n'
+        }
+        if (normalized === 'C:/repo/.git/config') {
+          return '[core]\nsparseCheckout = true\n'
+        }
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      })
+
+      const worktrees = await listWorktrees(String.raw`C:\Users\me\repo`, {
+        wslDistro: 'Ubuntu'
+      })
+
+      expect(worktrees).toEqual([
+        {
+          path: worktreePath,
+          head: 'def456',
+          branch: 'refs/heads/feature/test',
+          isBare: false,
+          isSparse: true,
+          isMainWorktree: true
+        }
+      ])
+      expect(readFileMock).toHaveBeenCalledWith(String.raw`C:\repo\.git/config`, 'utf-8')
+      expect(readFileMock).not.toHaveBeenCalledWith('/mnt/c/repo/.git/config', 'utf-8')
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
   })
 
   it('bounds concurrent sparse-checkout filesystem probes', async () => {

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: this file keeps git worktree create/remove behavior together so local cleanup and creation invariants stay in one place. */
 import { readFile, stat } from 'node:fs/promises'
-import { isAbsolute, join, posix, resolve, win32 } from 'node:path'
+import { join, posix, win32 } from 'node:path'
 import {
   branchHasNoUnmergedChangesWithLazyTargetRefresh,
   getBranchCleanupTargetRefs
@@ -32,6 +32,7 @@ import {
   isUnsupportedWorktreeListZError
 } from '../../shared/git-worktree-command-capabilities'
 import { withLocalGitCapabilityCacheForExecution } from './git-capability-state'
+import { resolveGitMetadataPath } from './git-metadata-path'
 import { gitExecFileAsync, translateWslOutputPaths } from './runner'
 import { resolveGitDir, runWithGitReadCacheInvalidation } from './status'
 import { hasWorktreeBaseCommitRef, probeWorktreeBaseRefPresence } from './worktree-base-ref-probe'
@@ -815,7 +816,7 @@ async function listWorktreesUnshared(
 ): Promise<GitWorktreeInfo[]> {
   try {
     const worktrees = await readTranslatedWorktreeGraph(repoPath, options)
-    return annotateSparseCheckoutStatus(worktrees)
+    return annotateSparseCheckoutStatus(worktrees, options)
   } catch (err) {
     if (getErrorCode(err) === 'ENOENT') {
       try {
@@ -844,11 +845,12 @@ export async function listWorktreesStrict(
     const translatedPath = translateWorktreePath(worktree.path, repoPath, options)
     return translatedPath === worktree.path ? worktree : { ...worktree, path: translatedPath }
   })
-  return annotateSparseCheckoutStatus(worktrees)
+  return annotateSparseCheckoutStatus(worktrees, options)
 }
 
 async function annotateSparseCheckoutStatus(
-  worktrees: GitWorktreeInfo[]
+  worktrees: GitWorktreeInfo[],
+  options: GitWorktreeExecOptions
 ): Promise<GitWorktreeInfo[]> {
   const annotated = [...worktrees]
   let nextIndex = 0
@@ -861,7 +863,7 @@ async function annotateSparseCheckoutStatus(
       if (!worktree || worktree.isBare || worktree.isSparse) {
         continue
       }
-      const isSparse = await detectSparseCheckout(worktree.path)
+      const isSparse = await detectSparseCheckout(worktree.path, options)
       if (isSparse) {
         annotated[index] = { ...worktree, isSparse }
       }
@@ -1558,11 +1560,17 @@ function translateWorktreePath(
   return translated.startsWith(prefix) ? translated.slice(prefix.length) : worktreePath
 }
 
-async function detectSparseCheckout(worktreePath: string): Promise<boolean> {
+async function detectSparseCheckout(
+  worktreePath: string,
+  options: GitWorktreeExecOptions
+): Promise<boolean> {
   // Why: fs.stat the per-worktree gitdir's sparse-checkout pattern file instead of a per-poll `git sparse-checkout list` subprocess that regressed responsiveness (PR #1290);
   // this is the cheap fast-path gate before the enabled check below.
   try {
-    const gitDir = await resolveGitDir(worktreePath)
+    const gitDir = await resolveGitDir(worktreePath, options)
+    if (!gitDir) {
+      return false
+    }
     const stats = await stat(join(gitDir, 'info', 'sparse-checkout'))
     if (!stats.isFile() || stats.size === 0) {
       return false
@@ -1575,8 +1583,8 @@ async function detectSparseCheckout(worktreePath: string): Promise<boolean> {
     // sparse and show a misleading "files are not on disk" badge. This runs only for the rare
     // worktree that still has a non-empty pattern file, so it does not reintroduce the per-poll
     // subprocess fan-out PR #1290 removed, and it reads git's config files directly (no
-    // subprocess) so it stays cheap and needs no exec options.
-    return await isSparseCheckoutEnabled(gitDir)
+    // subprocess) so it stays cheap.
+    return await isSparseCheckoutEnabled(gitDir, options)
   } catch {
     return false
   }
@@ -1585,11 +1593,14 @@ async function detectSparseCheckout(worktreePath: string): Promise<boolean> {
 // Resolve the shared common gitdir for a (possibly linked) worktree gitdir. A linked worktree's
 // gitdir holds a `commondir` file pointing at the repo's main `.git`; the main worktree's gitdir
 // is itself the common dir.
-async function resolveGitCommonDir(gitDir: string): Promise<string> {
+async function resolveGitCommonDir(
+  gitDir: string,
+  options: GitWorktreeExecOptions
+): Promise<string | null> {
   try {
     const raw = (await readFile(join(gitDir, 'commondir'), 'utf-8')).trim()
     if (raw.length > 0) {
-      return isAbsolute(raw) ? raw : resolve(gitDir, raw)
+      return resolveGitMetadataPath(gitDir, raw, options)
     }
   } catch {
     // No `commondir` file: this gitdir is already the common dir.
@@ -1600,8 +1611,14 @@ async function resolveGitCommonDir(gitDir: string): Promise<string> {
 // Whether core.sparseCheckout is actually enabled for this worktree. The value can live in the
 // shared repo config or, when extensions.worktreeConfig is on, in the worktree-local
 // `config.worktree`; later files override earlier ones, matching git's config precedence.
-async function isSparseCheckoutEnabled(gitDir: string): Promise<boolean> {
-  const commonDir = await resolveGitCommonDir(gitDir)
+async function isSparseCheckoutEnabled(
+  gitDir: string,
+  options: GitWorktreeExecOptions
+): Promise<boolean> {
+  const commonDir = await resolveGitCommonDir(gitDir, options)
+  if (!commonDir) {
+    return false
+  }
   const sharedConfig = await readGitConfigText(join(commonDir, 'config'))
   const sharedFlag = parseCoreSparseCheckoutFlag(sharedConfig)
   // Git reads `config.worktree` only while extensions.worktreeConfig is on; without that gate a

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1350,7 +1350,12 @@ export function registerFilesystemHandlers(
         return provider.detectConflictOperation(args.worktreePath)
       }
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
-      return detectConflictOperation(worktreePath)
+      const gitOptions = getLocalGitOptionsForRegisteredWorktree(
+        store,
+        args.worktreePath,
+        worktreePath
+      )
+      return detectConflictOperation(worktreePath, gitOptions)
     }
   )
 

--- a/src/main/runtime/runtime-git-execution-host-ownership.test.ts
+++ b/src/main/runtime/runtime-git-execution-host-ownership.test.ts
@@ -10,6 +10,7 @@ import { SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE } from '../providers/ssh-git-dispa
 const mocks = vi.hoisted(() => ({
   getSshGitProvider: vi.fn(),
   getStatus: vi.fn(),
+  detectConflictOperation: vi.fn(),
   gitFetch: vi.fn(),
   stageFile: vi.fn()
 }))
@@ -22,6 +23,7 @@ vi.mock('../providers/ssh-git-dispatch', async () => ({
 vi.mock('../git/status', async () => ({
   ...(await vi.importActual<typeof GitStatusModule>('../git/status')),
   getStatus: mocks.getStatus,
+  detectConflictOperation: mocks.detectConflictOperation,
   stageFile: mocks.stageFile
 }))
 
@@ -47,6 +49,7 @@ describe('runtime Git execution-host ownership', () => {
   beforeEach(() => {
     mocks.getSshGitProvider.mockReset().mockReturnValue(undefined)
     mocks.getStatus.mockReset()
+    mocks.detectConflictOperation.mockReset()
     mocks.gitFetch.mockReset()
     mocks.stageFile.mockReset()
   })
@@ -66,5 +69,27 @@ describe('runtime Git execution-host ownership', () => {
     expect(mocks.getStatus).not.toHaveBeenCalled()
     expect(mocks.gitFetch).not.toHaveBeenCalled()
     expect(mocks.stageFile).not.toHaveBeenCalled()
+  })
+
+  it('passes the local WSL runtime through conflict detection', async () => {
+    mocks.detectConflictOperation.mockResolvedValue('unknown')
+    const worktree = {
+      id: 'wt-1',
+      repoId: 'repo-1',
+      path: String.raw`C:\workspace\feature`
+    } as unknown as ResolvedRuntimeGitWorktree
+    const commands = new RuntimeGitCommands({
+      resolveRuntimeGitTarget: async () => ({
+        worktree,
+        localGitOptions: { wslDistro: 'Ubuntu' }
+      }),
+      getRuntimeSettings: () => ({}) as GlobalSettings
+    })
+
+    await commands.getRuntimeGitConflictOperation('id:wt-1')
+
+    expect(mocks.detectConflictOperation).toHaveBeenCalledWith(worktree.path, {
+      wslDistro: 'Ubuntu'
+    })
   })
 })

--- a/src/main/runtime/runtime-git-status-commands.ts
+++ b/src/main/runtime/runtime-git-status-commands.ts
@@ -108,7 +108,7 @@ export class RuntimeGitStatusCommands {
       }
       return provider.detectConflictOperation(target.worktree.path)
     }
-    return detectConflictOperation(target.worktree.path)
+    return detectConflictOperation(target.worktree.path, localGitOptionsForTarget(target))
   }
 
   async checkoutRuntimeGitBranch(

--- a/src/shared/wsl-paths.test.ts
+++ b/src/shared/wsl-paths.test.ts
@@ -4,6 +4,7 @@ import {
   isWslUncPath,
   parseWslUncPath,
   resolveWslRepoWorktreeBasePath,
+  toWindowsWslDrivePath,
   toWindowsWslPath
 } from './wsl-paths'
 
@@ -32,6 +33,15 @@ describe('wsl path helpers', () => {
     ['/mnt/C/Repo', '\\\\wsl.localhost\\Ubuntu\\mnt\\C\\Repo']
   ])('converts %s without folding case-sensitive Linux paths', (linuxPath, expected) => {
     expect(toWindowsWslPath(linuxPath, 'Ubuntu')).toBe(expected)
+  })
+
+  it('converts a drvfs path without requiring a distro', () => {
+    expect(toWindowsWslDrivePath('/mnt/c/Users/me/repo')).toBe('C:\\Users\\me\\repo')
+  })
+
+  it('rejects paths outside a lowercase drvfs mount', () => {
+    expect(toWindowsWslDrivePath('/home/me/repo')).toBeNull()
+    expect(toWindowsWslDrivePath('/mnt/C/Users/me/repo')).toBeNull()
   })
 })
 

--- a/src/shared/wsl-paths.ts
+++ b/src/shared/wsl-paths.ts
@@ -47,14 +47,22 @@ export function toLinuxPath(windowsPath: string): string {
   return `/mnt/${driveLetter}/${rest}`
 }
 
-/** Convert an absolute Linux path in a known WSL distro to its Windows form. */
-export function toWindowsWslPath(linuxPath: string, distro: string): string {
+/** Convert a WSL drvfs mount to its native Windows drive path. */
+export function toWindowsWslDrivePath(linuxPath: string): string | null {
   const mntMatch = linuxPath.match(/^\/mnt\/([a-z])(\/.*)?$/)
   if (mntMatch) {
     const rest = (mntMatch[2] || '').replace(/\//g, '\\')
     return `${mntMatch[1].toUpperCase()}:${rest || '\\'}`
   }
+  return null
+}
 
+/** Convert an absolute Linux path in a known WSL distro to its Windows form. */
+export function toWindowsWslPath(linuxPath: string, distro: string): string {
+  const drivePath = toWindowsWslDrivePath(linuxPath)
+  if (drivePath) {
+    return drivePath
+  }
   return `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​268 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​264 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​136 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​49 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 |

<!-- /orca-pr-loc -->

## ELI5

Git can write Linux paths into its small metadata pointer files even when Orca is running on Windows. Orca was asking Windows to open those Linux-looking strings directly, producing paths such as `C:\mnt\c\...` that do not exist. This translates the metadata path onto the correct Windows drive or WSL UNC share before any filesystem probe.

This addresses the path-correctness item in #9284. It intentionally does **not** claim to solve that issue's separate login-shell or DrvFs latency concerns, so #9284 should remain open.

## What changed

- Added one shared `resolveGitMetadataPath` path resolver and reused it for synchronous repository-marker scanning plus async source-control metadata reads.
- Converts `/mnt/<drive>/...` without a distro lookup.
- Converts other absolute Linux paths with the selected WSL distro, preferring a distro already encoded by a WSL UNC base path.
- Propagates local WSL runtime options through status, IPC, runtime conflict detection, diff-cache stamps, and sparse-checkout annotation.
- Applies the same translation to absolute `commondir` entries, not only `.git` pointers.
- Fails conservatively (`null` / `unknown` / no cache / no sparse annotation) when a Windows path cannot be translated.

## Before / after measurement

Deterministic Windows path fixtures:

| Metadata pointer | Before (`path.win32.resolve`) | After |
|---|---|---|
| `/mnt/c/repo/.git/worktrees/feature` | `C:\mnt\c\repo\.git\worktrees\feature` | `C:\repo\.git\worktrees\feature` |
| `/home/me/repo/.git/worktrees/feature` with distro `Ubuntu` | `C:\home\me\repo\.git\worktrees\feature` | `\\wsl.localhost\Ubuntu\home\me\repo\.git\worktrees\feature` |

For conflict detection, the same fixture changes correctly targeted probes from **0/4 to 4/4** (`MERGE_HEAD`, `CHERRY_PICK_HEAD`, `rebase-merge`, `rebase-apply`) with no extra probes. The diff-cache integration fixture now proves one cache hit and zero additional Git blob spawns on the second unchanged read through both a distro-required `.git` pointer and an absolute Linux `commondir`.

This is functional path evidence, not a Windows latency claim.

## Regression proof

- 10 focused test files / 150 tests passed, covering metadata resolution, repo detection, status/conflict state, WSL diff stamping, sparse checkout, runtime host ownership, and existing WSL path helpers.
- `pnpm tc:node` — passed.
- `pnpm run check:code-quality:changed` — passed with 0 findings across 18 changed files.
- Pre-commit plain `oxlint`, React Doctor config, formatting, and `git diff --check` — passed.
- Independent review found the absolute-`commondir` gap before commit; that path now has direct diff-cache and sparse-checkout regressions.

## No-user-regression signoff

**Sign-off: no feature or execution route is removed.** Native drive/UNC paths and non-Windows absolute paths are preserved, relative pointers retain the host's path flavor, WSL UNC bases retain their own distro, and SSH conflict checks still stay on the SSH provider. Folder workspaces and the remote wire contract are unchanged. Untranslatable Windows/Linux combinations fail closed rather than probing a fabricated path.

## Merge risk

**Risk: low-to-medium.** The patch touches several callers because they all consumed the same Git metadata contract, but the conversion itself is centralized and has table-driven path coverage plus end-to-end caller assertions. The remaining risk is an unusual hand-authored Git pointer syntax; conservative `null` handling avoids turning ambiguity into a false filesystem verdict.
