### PR TITLE
perf(startup): skip disabled diagnostic serialization

### DIFF
--- a/src/main/persistence-loading-store-extraction.test.ts
+++ b/src/main/persistence-loading-store-extraction.test.ts
@@ -2,14 +2,22 @@ import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'v
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { getDefaultWorkspaceSession } from '../shared/constants'
+import { getDefaultPersistedState, getDefaultWorkspaceSession } from '../shared/constants'
 import type { PersistedState } from '../shared/persisted-state-types'
+import type * as StartupDiagnosticsModule from './startup/startup-diagnostics'
 import type { Store as PersistenceStore } from './persistence/loading-store/store'
-import { createStore, dataFile, makeRepo, testState } from './persistence-test-harness'
+import {
+  createStore,
+  dataFile,
+  makeRepo,
+  testState,
+  writeDataFile
+} from './persistence-test-harness'
 
-const { trackMock, getCohortAtEmitMock } = vi.hoisted(() => ({
+const { trackMock, getCohortAtEmitMock, logStartupDiagnosticMock } = vi.hoisted(() => ({
   trackMock: vi.fn(),
-  getCohortAtEmitMock: vi.fn(() => ({ nth_repo_added: 2 }))
+  getCohortAtEmitMock: vi.fn(() => ({ nth_repo_added: 2 })),
+  logStartupDiagnosticMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -33,6 +41,10 @@ vi.mock('./ssh/ssh-config-parser', () => ({
   loadUserSshConfig: vi.fn(() => ({ hosts: [] })),
   sshConfigHostsToTargets: vi.fn(() => [])
 }))
+vi.mock('./startup/startup-diagnostics', async (importOriginal) => {
+  const actual = await importOriginal<typeof StartupDiagnosticsModule>()
+  return { ...actual, logStartupDiagnostic: logStartupDiagnosticMock }
+})
 
 describe('loading Store extraction seams', () => {
   beforeEach(() => {
@@ -40,7 +52,68 @@ describe('loading Store extraction seams', () => {
   })
 
   afterEach(() => {
+    vi.unstubAllEnvs()
+    logStartupDiagnosticMock.mockReset()
     rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('does not serialize the workspace session when startup diagnostics are disabled', () => {
+    const sentinel = 'startup-diagnostics-workspace-session-sentinel-disabled'
+    vi.stubEnv('ORCA_STARTUP_DIAGNOSTICS', '')
+    const state = getDefaultPersistedState(testState.dir)
+    state.workspaceSession = { ...state.workspaceSession, activeTabId: sentinel }
+    writeDataFile(state)
+
+    const stringifySpy = vi.spyOn(JSON, 'stringify')
+    const store = createStore()
+    store.freezeWrites()
+
+    const workspaceSessionStringifyCalls = stringifySpy.mock.calls.filter(
+      ([value]) =>
+        value &&
+        typeof value === 'object' &&
+        (value as { activeTabId?: unknown }).activeTabId === sentinel
+    )
+    stringifySpy.mockRestore()
+
+    expect(store.getWorkspaceSession().activeTabId).toBe(sentinel)
+    expect(workspaceSessionStringifyCalls).toHaveLength(0)
+    expect(
+      logStartupDiagnosticMock.mock.calls.some(([event]) => event === 'persistence-load-done')
+    ).toBe(false)
+  })
+
+  it('reports the unchanged workspace-session byte count when startup diagnostics are enabled', () => {
+    const sentinel = 'startup-diagnostics-workspace-session-sentinel-enabled'
+    vi.stubEnv('ORCA_STARTUP_DIAGNOSTICS', '1')
+    const state = getDefaultPersistedState(testState.dir)
+    state.workspaceSession = { ...state.workspaceSession, activeTabId: sentinel }
+    writeDataFile(state)
+
+    const stringifySpy = vi.spyOn(JSON, 'stringify')
+    const store = createStore()
+    store.freezeWrites()
+
+    const workspaceSessionStringifyCalls = stringifySpy.mock.calls.filter(
+      ([value]) =>
+        value &&
+        typeof value === 'object' &&
+        (value as { activeTabId?: unknown }).activeTabId === sentinel
+    )
+    stringifySpy.mockRestore()
+
+    expect(store.getWorkspaceSession().activeTabId).toBe(sentinel)
+    expect(workspaceSessionStringifyCalls).toHaveLength(1)
+    const loadDoneCall = logStartupDiagnosticMock.mock.calls.find(
+      ([event]) => event === 'persistence-load-done'
+    )
+    expect(loadDoneCall).toBeDefined()
+    const details = loadDoneCall?.[1] as Record<string, unknown> | undefined
+    expect(details).toEqual({
+      t: expect.any(Number),
+      repos: state.repos.length,
+      workspaceSessionBytes: Buffer.byteLength(JSON.stringify(store.getWorkspaceSession()))
+    })
   })
 
   it('accepts the first JSON-parseable backup even when an older backup has richer state', async () => {

--- a/src/main/persistence/loading-store/loaded-state-parsing.ts
+++ b/src/main/persistence/loading-store/loaded-state-parsing.ts
@@ -42,13 +42,17 @@ import { prepareLoadedTerminalSettings } from './prepare-loaded-terminal-setting
 import { prepareLoadedProfileSettings } from './prepare-loaded-profile-settings'
 import { normalizeLoadedProfileState } from './normalize-loaded-profile-state'
 
+type PersistenceStartupDetails = Record<string, unknown> | (() => Record<string, unknown>)
+
 function logPersistenceStartupMilestone(
   event: string,
-  details: Record<string, unknown> = {}
+  details: PersistenceStartupDetails = {}
 ): void {
-  if (isStartupDiagnosticsEnabled()) {
-    logStartupDiagnostic(event, { t: Math.round(performance.now()), ...details })
+  if (!isStartupDiagnosticsEnabled()) {
+    return
   }
+  const resolvedDetails = typeof details === 'function' ? details() : details
+  logStartupDiagnostic(event, { t: Math.round(performance.now()), ...resolvedDetails })
 }
 
 import type { StoreRuntimeState } from './store-runtime-state'
@@ -279,10 +283,10 @@ export class LoadedStateParsingOperations {
       migrated.githubCache = readGithubCacheSnapshot(this.runtime.dataFile) ?? migrated.githubCache
     }
 
-    logPersistenceStartupMilestone('persistence-load-done', {
+    logPersistenceStartupMilestone('persistence-load-done', () => ({
       repos: migrated.repos.length,
       workspaceSessionBytes: Buffer.byteLength(JSON.stringify(migrated.workspaceSession))
-    })
+    }))
     return migrated
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5

Orca was calculating the byte size of the entire saved workspace session during every startup, even though that number is only used by an opt-in startup diagnostic. This makes the expensive calculation wait inside the diagnostic gate, so ordinary startups no longer pay for disabled logging.

## What changed

- Let persistence startup milestones accept either ready details or a lazy details callback.
- Return before evaluating that callback when startup diagnostics are disabled.
- Supply the final persistence-load details lazily, leaving all enabled milestones unchanged.

## Before / after measurement

Measured against the same persisted session shape:

| Workspace session | Before | After with diagnostics disabled |
|---|---:|---:|
| Real ~2.02 MB session | ~2.2 ms redundant stringify | 0 session stringify calls |
| 10× session fixture | ~22.6 ms redundant stringify | 0 session stringify calls |

When diagnostics are enabled, the session is still serialized exactly once and publishes the same `{ t, repos, workspaceSessionBytes }` details.

## Regression proof

- `pnpm test src/main/persistence-loading-store-extraction.test.ts` — 9 tests passed.
- `pnpm tc:node` — passed.
- `pnpm run check:code-quality:changed` — 0 findings across 2 changed files.
- `git diff --check` — passed.

The focused assertions use a sentinel workspace session and prove zero matching `JSON.stringify` calls while diagnostics are disabled, exactly one while enabled, the exact diagnostic shape, and preservation of the loaded session value.

## No-user-regression signoff

**Sign-off: no user-facing behavior changes.** Persistence parsing, migrations, saved state, and startup ordering are untouched. Opt-in diagnostics retain the same event name, payload fields, byte calculation, and post-serialization timestamp placement.

## Merge risk

**Risk: low.** The production change is a small lazy-argument seam around an existing environment gate. The main risk would be accidentally skipping details when diagnostics are enabled; the enabled-path call count and exact-payload test cover that directly.