### PR TITLE
perf(startup): stop rescanning persisted pane tabs

### DIFF
--- a/src/main/persistence/restoring-sessions/pane-identity-migration.ts
+++ b/src/main/persistence/restoring-sessions/pane-identity-migration.ts
@@ -17,20 +17,54 @@ export function findWorktreeIdForTab(
   return undefined
 }
 
-export function indexTerminalTabsById(
-  session: WorkspaceSessionState
-): ReadonlyMap<string, TerminalTab> {
+export type TerminalTabLookup = {
+  get(tabId: string): TerminalTab | undefined
+}
+
+/** Resolves tabs on demand while retaining first-match ordering and scan progress. */
+export function createLazyTerminalTabLookup(session: WorkspaceSessionState): TerminalTabLookup {
+  const tabsByWorktree = Object.entries(session.tabsByWorktree ?? {})
   const tabsById = new Map<string, TerminalTab>()
-  for (const tabs of Object.values(session.tabsByWorktree ?? {})) {
-    for (const tab of tabs) {
-      const tabId = tab.id
-      // Preserve the prior Object.entries()/find() first-match behavior for duplicate IDs.
-      if (!tabsById.has(tabId)) {
-        tabsById.set(tabId, tab)
+  let worktreeIndex = 0
+  let tabIndex = 0
+  let exhausted = false
+
+  return {
+    get(requestedTabId: string): TerminalTab | undefined {
+      if (tabsById.has(requestedTabId)) {
+        return tabsById.get(requestedTabId)
       }
+      if (exhausted) {
+        return undefined
+      }
+
+      while (worktreeIndex < tabsByWorktree.length) {
+        const tabs = tabsByWorktree[worktreeIndex][1]
+        while (tabIndex < tabs.length) {
+          const currentIndex = tabIndex
+          tabIndex += 1
+          // Array#some, used by the prior lookup, skips sparse holes.
+          if (!(currentIndex in tabs)) {
+            continue
+          }
+          const tab = tabs[currentIndex]
+          const tabId = tab.id
+          // Preserve first-match behavior when persisted IDs collide.
+          if (!tabsById.has(tabId)) {
+            tabsById.set(tabId, tab)
+          }
+          if (tabId === requestedTabId) {
+            return tabsById.get(requestedTabId)
+          }
+        }
+        worktreeIndex += 1
+        tabIndex = 0
+      }
+
+      exhausted = true
+      return undefined
     }
   }
-  return tabsById
 }
 
 /** Bridges a tab's legacy numeric pane keys to stable ones; returns the alias rows worth persisting. */

--- a/src/main/persistence/restoring-sessions/pane-identity-migration.ts
+++ b/src/main/persistence/restoring-sessions/pane-identity-migration.ts
@@ -1,5 +1,5 @@
 import type { LegacyPaneKeyAliasEntry } from '../../../shared/persisted-state-types'
-import type { TerminalLayoutSnapshot } from '../../../shared/terminal-tab-types'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
 import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
 import { agentHookServer } from '../../agent-hooks/server'
@@ -17,23 +17,35 @@ export function findWorktreeIdForTab(
   return undefined
 }
 
+export function indexTerminalTabsById(
+  session: WorkspaceSessionState
+): ReadonlyMap<string, TerminalTab> {
+  const tabsById = new Map<string, TerminalTab>()
+  for (const tabs of Object.values(session.tabsByWorktree ?? {})) {
+    for (const tab of tabs) {
+      const tabId = tab.id
+      // Preserve the prior Object.entries()/find() first-match behavior for duplicate IDs.
+      if (!tabsById.has(tabId)) {
+        tabsById.set(tabId, tab)
+      }
+    }
+  }
+  return tabsById
+}
+
 /** Bridges a tab's legacy numeric pane keys to stable ones; returns the alias rows worth persisting. */
 export function registerLegacyPaneKeyAliasesForTab(args: {
-  session: WorkspaceSessionState
   tabId: string
+  tab: TerminalTab | undefined
   inputLayout: TerminalLayoutSnapshot
   normalizedLayout: TerminalLayoutSnapshot
   leafIdByInputLeafId: Map<string, string>
 }): LegacyPaneKeyAliasEntry[] {
-  const worktreeId = findWorktreeIdForTab(args.session, args.tabId)
-  const tab = worktreeId
-    ? args.session.tabsByWorktree?.[worktreeId]?.find((entry) => entry.id === args.tabId)
-    : undefined
   const legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[] = []
   const registeredLegacyPaneKeys = new Set<string>()
   const hasLeafPtyBindings = Object.keys(args.inputLayout.ptyIdsByLeafId ?? {}).length > 0
   const fallbackPtyId =
-    !hasLeafPtyBindings && typeof tab?.ptyId === 'string' ? tab.ptyId : undefined
+    !hasLeafPtyBindings && typeof args.tab?.ptyId === 'string' ? args.tab.ptyId : undefined
   const registerLegacyAlias = (inputLeafId: string, leafId: string, ptyId?: string): boolean => {
     if (!isTerminalLeafId(leafId)) {
       return false
@@ -80,7 +92,7 @@ export function registerLegacyPaneKeyAliasesForTab(args: {
       )
     }
   }
-  if (tab?.ptyId && !hasLeafPtyBindings) {
+  if (args.tab?.ptyId && !hasLeafPtyBindings) {
     const fallbackLeafId =
       args.normalizedLayout.activeLeafId ?? firstLayoutLeafId(args.normalizedLayout.root)
     let paneKey: string | undefined
@@ -96,9 +108,9 @@ export function registerLegacyPaneKeyAliasesForTab(args: {
         if (registeredLegacyPaneKeys.has(legacyPaneKey)) {
           continue
         }
-        agentHookServer.registerPaneKeyAlias(legacyPaneKey, paneKey, tab.ptyId)
+        agentHookServer.registerPaneKeyAlias(legacyPaneKey, paneKey, args.tab.ptyId)
         legacyPaneKeyAliasEntries.push({
-          ptyId: tab.ptyId,
+          ptyId: args.tab.ptyId,
           legacyPaneKey,
           stablePaneKey: paneKey,
           updatedAt: Date.now()

--- a/src/main/persistence/restoring-sessions/workspace-pane-normalization-index.test.ts
+++ b/src/main/persistence/restoring-sessions/workspace-pane-normalization-index.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
 import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { createLazyTerminalTabLookup } from './pane-identity-migration'
 import { normalizeWorkspaceSessionPaneIdentities } from './workspace-pane-normalization'
 
 const { registerPaneKeyAliasMock } = vi.hoisted(() => ({
@@ -109,5 +110,75 @@ describe('workspace pane normalization tab index', () => {
     normalizeWorkspaceSessionPaneIdentities(workspaceSession({ worktree: tabs }, layouts))
 
     expect(idReads).toBe(tabCount)
+  })
+
+  it('does not inspect tabs after an early match', () => {
+    const first = terminalTab('first', 'worktree', 'first-pty')
+    const later = terminalTab('later', 'worktree', 'later-pty')
+    Object.defineProperty(later, 'id', {
+      enumerable: true,
+      get: () => {
+        throw new Error('later tab should not be inspected')
+      }
+    })
+
+    const lookup = createLazyTerminalTabLookup(workspaceSession({ worktree: [first, later] }, {}))
+
+    expect(lookup.get('first')).toBe(first)
+  })
+
+  it('resumes scanning and makes later misses constant-time', () => {
+    const reads: string[] = []
+    const tabs = ['first', 'second', 'third'].map((id) => {
+      const tab = terminalTab(id, 'worktree', null)
+      Object.defineProperty(tab, 'id', {
+        enumerable: true,
+        get: () => {
+          reads.push(id)
+          return id
+        }
+      })
+      return tab
+    })
+    const lookup = createLazyTerminalTabLookup(workspaceSession({ worktree: tabs }, {}))
+
+    expect(lookup.get('first')).toBe(tabs[0])
+    expect(reads).toEqual(['first'])
+    expect(lookup.get('second')).toBe(tabs[1])
+    expect(reads).toEqual(['first', 'second'])
+    expect(lookup.get('missing')).toBeUndefined()
+    expect(reads).toEqual(['first', 'second', 'third'])
+    expect(lookup.get('missing')).toBeUndefined()
+    expect(reads).toEqual(['first', 'second', 'third'])
+  })
+
+  it('skips sparse tab-array holes', () => {
+    const tabs: TerminalTab[] = []
+    tabs.length = 3
+    tabs[1] = terminalTab('target', 'worktree', null)
+    const lookup = createLazyTerminalTabLookup(workspaceSession({ worktree: tabs }, {}))
+
+    expect(lookup.get('target')).toBe(tabs[1])
+    expect(lookup.get('missing')).toBeUndefined()
+  })
+
+  it('does not read tab ids when every layout is skipped', () => {
+    const tab = terminalTab('skipped', 'worktree', null)
+    let idReads = 0
+    Object.defineProperty(tab, 'id', {
+      enumerable: true,
+      get: () => {
+        idReads += 1
+        return 'skipped'
+      }
+    })
+
+    normalizeWorkspaceSessionPaneIdentities(
+      workspaceSession({ worktree: [tab] }, { skipped: legacyLayout() }),
+      {},
+      { skipAliasTabIds: new Set(['skipped']) }
+    )
+
+    expect(idReads).toBe(0)
   })
 })

--- a/src/main/persistence/restoring-sessions/workspace-pane-normalization-index.test.ts
+++ b/src/main/persistence/restoring-sessions/workspace-pane-normalization-index.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { normalizeWorkspaceSessionPaneIdentities } from './workspace-pane-normalization'
+
+const { registerPaneKeyAliasMock } = vi.hoisted(() => ({
+  registerPaneKeyAliasMock: vi.fn()
+}))
+
+vi.mock('../../agent-hooks/server', () => ({
+  agentHookServer: {
+    registerPaneKeyAlias: registerPaneKeyAliasMock
+  }
+}))
+
+const STABLE_LEAF_ID = '00000000-0000-4000-8000-000000000001'
+
+function terminalTab(id: string, worktreeId: string, ptyId: string | null): TerminalTab {
+  return {
+    id,
+    worktreeId,
+    ptyId,
+    title: 'Terminal',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function workspaceSession(
+  tabsByWorktree: Record<string, TerminalTab[]>,
+  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
+): WorkspaceSessionState {
+  return {
+    activeRepoId: null,
+    activeWorktreeId: null,
+    activeTabId: null,
+    tabsByWorktree,
+    terminalLayoutsByTabId
+  }
+}
+
+function legacyLayout(): TerminalLayoutSnapshot {
+  return {
+    root: { type: 'leaf', leafId: 'pane:1' },
+    activeLeafId: 'pane:1',
+    expandedLeafId: null
+  }
+}
+
+function stableLayout(): TerminalLayoutSnapshot {
+  return {
+    root: { type: 'leaf', leafId: STABLE_LEAF_ID },
+    activeLeafId: STABLE_LEAF_ID,
+    expandedLeafId: null
+  }
+}
+
+describe('workspace pane normalization tab index', () => {
+  beforeEach(() => {
+    registerPaneKeyAliasMock.mockReset()
+  })
+
+  it('keeps the first tab when duplicate ids occur across worktrees', () => {
+    const result = normalizeWorkspaceSessionPaneIdentities(
+      workspaceSession(
+        {
+          first: [terminalTab('duplicate-tab', 'first', 'first-pty')],
+          second: [terminalTab('duplicate-tab', 'second', 'second-pty')]
+        },
+        { 'duplicate-tab': legacyLayout() }
+      )
+    )
+
+    expect(result.legacyPaneKeyAliasEntries).not.toHaveLength(0)
+    expect(result.legacyPaneKeyAliasEntries.every((entry) => entry.ptyId === 'first-pty')).toBe(
+      true
+    )
+  })
+
+  it('keeps missing tab ids without inventing persisted aliases', () => {
+    const result = normalizeWorkspaceSessionPaneIdentities(
+      workspaceSession({}, { 'missing-tab': legacyLayout() })
+    )
+
+    expect(result.legacyPaneKeyAliasEntries).toEqual([])
+  })
+
+  it('reads each tab id once regardless of the number of layouts', () => {
+    const tabCount = 256
+    let idReads = 0
+    const tabs = Array.from({ length: tabCount }, (_, index) => {
+      const id = `tab-${index}`
+      const tab = terminalTab(id, 'worktree', null)
+      Object.defineProperty(tab, 'id', {
+        enumerable: true,
+        get: () => {
+          idReads += 1
+          return id
+        }
+      })
+      return tab
+    })
+    const layouts = Object.fromEntries(
+      Array.from({ length: tabCount }, (_, index) => [`tab-${index}`, stableLayout()])
+    )
+
+    normalizeWorkspaceSessionPaneIdentities(workspaceSession({ worktree: tabs }, layouts))
+
+    expect(idReads).toBe(tabCount)
+  })
+})

--- a/src/main/persistence/restoring-sessions/workspace-pane-normalization.ts
+++ b/src/main/persistence/restoring-sessions/workspace-pane-normalization.ts
@@ -10,7 +10,10 @@ import {
 import type { SshRemotePtyLease } from '../../../shared/ssh-types'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 import { findCrossHostPaneTabIds, withoutPaneTabIds } from './cross-host-pane-tab-ids'
-import { registerLegacyPaneKeyAliasesForTab } from './pane-identity-migration'
+import {
+  indexTerminalTabsById,
+  registerLegacyPaneKeyAliasesForTab
+} from './pane-identity-migration'
 import { normalizeTerminalLayoutSnapshotForPersistence } from './terminal-layout-normalization'
 import {
   legacyMigrationUnsupportedRowsToAliasEntries,
@@ -40,6 +43,7 @@ export function normalizeWorkspaceSessionPaneIdentities(
   const migrationUnsupportedEntries: MigrationUnsupportedPtyEntry[] = []
   const legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[] = []
   const terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot> = {}
+  let tabsById: ReturnType<typeof indexTerminalTabsById> | null = null
   for (const [tabId, layout] of Object.entries(session.terminalLayoutsByTabId ?? {})) {
     const normalized = normalizeTerminalLayoutSnapshotForPersistence(
       layout,
@@ -48,9 +52,10 @@ export function normalizeWorkspaceSessionPaneIdentities(
     terminalLayoutsByTabId[tabId] = normalized.snapshot
     leafIdByInputLeafIdByTabId.set(tabId, normalized.leafIdByInputLeafId)
     if (!options.skipAliasTabIds?.has(tabId)) {
+      tabsById ??= indexTerminalTabsById(session)
       const tabAliasEntries = registerLegacyPaneKeyAliasesForTab({
-        session,
         tabId,
+        tab: tabsById.get(tabId),
         inputLayout: layout,
         normalizedLayout: normalized.snapshot,
         leafIdByInputLeafId: normalized.leafIdByInputLeafId

--- a/src/main/persistence/restoring-sessions/workspace-pane-normalization.ts
+++ b/src/main/persistence/restoring-sessions/workspace-pane-normalization.ts
@@ -11,7 +11,7 @@ import type { SshRemotePtyLease } from '../../../shared/ssh-types'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 import { findCrossHostPaneTabIds, withoutPaneTabIds } from './cross-host-pane-tab-ids'
 import {
-  indexTerminalTabsById,
+  createLazyTerminalTabLookup,
   registerLegacyPaneKeyAliasesForTab
 } from './pane-identity-migration'
 import { normalizeTerminalLayoutSnapshotForPersistence } from './terminal-layout-normalization'
@@ -43,7 +43,7 @@ export function normalizeWorkspaceSessionPaneIdentities(
   const migrationUnsupportedEntries: MigrationUnsupportedPtyEntry[] = []
   const legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[] = []
   const terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot> = {}
-  let tabsById: ReturnType<typeof indexTerminalTabsById> | null = null
+  let tabsById: ReturnType<typeof createLazyTerminalTabLookup> | null = null
   for (const [tabId, layout] of Object.entries(session.terminalLayoutsByTabId ?? {})) {
     const normalized = normalizeTerminalLayoutSnapshotForPersistence(
       layout,
@@ -52,7 +52,7 @@ export function normalizeWorkspaceSessionPaneIdentities(
     terminalLayoutsByTabId[tabId] = normalized.snapshot
     leafIdByInputLeafIdByTabId.set(tabId, normalized.leafIdByInputLeafId)
     if (!options.skipAliasTabIds?.has(tabId)) {
-      tabsById ??= indexTerminalTabsById(session)
+      tabsById ??= createLazyTerminalTabLookup(session)
       const tabAliasEntries = registerLegacyPaneKeyAliasesForTab({
         tabId,
         tab: tabsById.get(tabId),


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​184 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​184 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 |

<!-- /orca-pr-loc -->

## ELI5

During startup, Orca normalizes every saved terminal layout. For each layout it repeatedly searched every saved worktree and tab to find the matching terminal. This keeps one lazy lookup cursor instead: each tab is inspected at most once, and an early match still stops immediately.

## What changed

- Added a lazy terminal-tab lookup that scans persisted worktrees in their existing order and remembers first matches.
- Reused that lookup across all pane-layout normalization instead of running `.some()` plus `.find()` for every layout.
- Preserved lazy construction when every layout is excluded from aliasing.
- Kept duplicate-ID first-match behavior, missing-tab handling, and sparse-array traversal semantics.

## Before / after measurement

Node v24.18.0, 20 measured runs after warmup, reporting the exact tab-lookup phase:

| Persisted shape | Before median / p95 | After median / p95 |
|---|---:|---:|
| Current 1,544,310-byte profile: 193 worktrees, 382 tabs/layouts | 0.492 / 0.503 ms | 0.029 / 0.048 ms |
| 10× actual-shaped fixture: 1,930 worktrees, 3,820 tabs/layouts | 94.35 / 104.43 ms | 0.324 / 0.441 ms |

A deterministic 256-tab / 256-layout fixture reduces tab-ID reads from **65,792 to 256**. The lazy version also retains the old early-exit shape: a target in the first slot does not inspect later tabs, avoiding the eager-index regression for small-layout/huge-tab inputs.

## Regression proof

- `pnpm test src/main/persistence/restoring-sessions/workspace-pane-normalization-index.test.ts src/main/persistence-pane-identity-migration.test.ts src/main/persistence-cross-host-pane-identity.test.ts src/main/persistence-split-pane-incarnation.test.ts src/main/persistence-layout-binding-recovery.test.ts` — 5 files / 31 tests passed.
- Full persistence suite — 55 files / 713 tests passed.\n- `pnpm tc:node` — passed.
- `pnpm run check:code-quality:changed` — 0 findings across 3 changed files.
- Plain `oxlint`, formatting, commit hooks, and `git diff --check` — passed.

Focused cases cover duplicate IDs, missing tabs, one-read scaling, early matches, resumed scans, cached misses, sparse arrays, and all-skipped layouts.

## No-user-regression signoff

**Sign-off: no pane, alias, terminal, persistence, SSH, or folder-workspace behavior is intentionally changed.** The lookup follows the same persisted worktree/tab order and keeps the first matching duplicate. Local and host-partitioned sessions still pass through the same normalization and publication paths; no execution boundary or remote wire field changes.

## Merge risk

**Risk: low.** This changes an in-memory startup migration lookup, not the saved schema. The main risks are collision ordering and accidentally touching more malformed input than the old early-exit scan; direct regressions cover first-wins duplicates, sparse holes, early getters, zero-work layouts, and repeated misses.