### PR TITLE
perf(terminals): drop disposed queued inspections

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-queued-inspection-disposal.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-queued-inspection-disposal.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createAgentCompletionCoordinator } from './agent-completion-coordinator'
+import {
+  createDeferred,
+  flushAsyncTicks,
+  processResult,
+  useAgentCompletionCoordinatorLifecycle
+} from './agent-completion-coordinator-test-harness'
+import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
+
+describe('agent completion coordinator queued inspections', () => {
+  useAgentCompletionCoordinatorLifecycle()
+
+  it('drops inspections queued by a disposed coordinator before starting live work', async () => {
+    const blockers = Array.from({ length: 4 }, () =>
+      createDeferred<RuntimeTerminalProcessInspection>()
+    )
+    const blockerInspectors = blockers.map((inspection) => vi.fn(() => inspection.promise))
+    const blockerCoordinators = blockerInspectors.map((inspectProcess, index) =>
+      createAgentCompletionCoordinator({
+        paneKey: `tab-1:blocked-${index}`,
+        getPtyId: () => `pty-blocked-${index}`,
+        getSettings: () => null,
+        inspectProcess,
+        dispatchCompletion: vi.fn(),
+        isLive: () => true
+      })
+    )
+
+    blockerCoordinators.forEach((coordinator) => coordinator.startProcessTracking())
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(
+      blockerInspectors.every((inspectProcess) => inspectProcess.mock.calls.length === 1)
+    ).toBe(true)
+
+    const staleInspectProcesses = Array.from({ length: 8 }, () =>
+      vi.fn(async () => processResult(null, false))
+    )
+    const staleCoordinators = staleInspectProcesses.map((inspectProcess, index) =>
+      createAgentCompletionCoordinator({
+        paneKey: `tab-1:stale-${index}`,
+        getPtyId: () => `pty-stale-${index}`,
+        getSettings: () => null,
+        inspectProcess,
+        dispatchCompletion: vi.fn(),
+        isLive: () => true
+      })
+    )
+    const liveInspectProcess = vi.fn(async () => processResult(null, false))
+    const liveCoordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:live',
+      getPtyId: () => 'pty-live',
+      getSettings: () => null,
+      inspectProcess: liveInspectProcess,
+      dispatchCompletion: vi.fn(),
+      isLive: () => true
+    })
+
+    for (const [index, coordinator] of staleCoordinators.entries()) {
+      coordinator.observeTitle(`Codex working ${index}`)
+      coordinator.observeTitle(`~/stale-${index}`)
+    }
+    liveCoordinator.observeTitle('Codex working')
+    liveCoordinator.observeTitle('~/live')
+    staleCoordinators.forEach((coordinator) => coordinator.dispose())
+
+    blockers.forEach((inspection) => inspection.resolve(processResult(null, false)))
+    await flushAsyncTicks()
+    // Existing 100ms pump admits live work after blockers release.
+    await vi.advanceTimersByTimeAsync(100)
+    await flushAsyncTicks()
+
+    expect(
+      staleInspectProcesses.every((inspectProcess) => inspectProcess.mock.calls.length === 0)
+    ).toBe(true)
+    expect(liveInspectProcess).toHaveBeenCalledTimes(1)
+
+    blockerCoordinators.forEach((coordinator) => coordinator.dispose())
+    liveCoordinator.dispose()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
@@ -146,6 +146,7 @@ export function createAgentCompletionProcessMonitor({
     const pendingTitleIdAtRequest = priority === 'pending-title' ? pendingTitle.get()?.id : null
     enqueueAgentProcessInspection({
       priority,
+      canRun: () => !state.disposed,
       run: async () => {
         let inspectedRecognizedAgent = false
         let inspectionSucceeded = false

--- a/src/renderer/src/components/terminal-pane/agent-process-inspection-queue.ts
+++ b/src/renderer/src/components/terminal-pane/agent-process-inspection-queue.ts
@@ -2,6 +2,7 @@ export type InspectionPriority = 'cadence' | 'pending-title'
 
 type InspectionTask = {
   priority: InspectionPriority
+  canRun: () => boolean
   run: () => Promise<void>
 }
 
@@ -37,6 +38,16 @@ function scheduleInspectionPump(delayMs = 0): void {
 }
 
 function pumpInspectionQueue(): void {
+  // Drop disposed tasks before slot/rate accounting.
+  for (let index = inspectionQueue.length - 1; index >= 0; index -= 1) {
+    const task = inspectionQueue[index]
+    if (task && !task.canRun()) {
+      inspectionQueue.splice(index, 1)
+    }
+  }
+  if (inspectionQueue.length === 0) {
+    return
+  }
   const now = Date.now()
   if (!canStartInspection(now)) {
     scheduleInspectionPump(100)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

Orca limits process checks so many terminal panes cannot overwhelm Windows process scans or remote hosts. A pane that closed while waiting still kept its place in that shared line, so dead work could run before a live pane. The queue now removes closed-pane checks before they consume a slot or the per-second start budget.

## What changed

- Added a required start-validity predicate to queued agent process inspections.
- Drop tasks whose coordinator was disposed while waiting, before concurrency or rate accounting.
- Keep inspections that already started unchanged.
- Added a coordinator-level regression with four occupied slots, eight disposed high-priority tasks, and one live task.

## Before / after measurement

Deterministic fake-clock queue oracle with the existing 4-concurrent / 8-starts-per-second limits:

| Outcome after releasing four blockers | Before | After |
|---|---:|---:|
| Disposed host inspections started | 8 | 0 |
| Live inspection start time | 1,100 ms | 100 ms |

Before the patch, four disposed tasks started at 100 ms, four more at 1,000 ms, and the live pane waited until 1,100 ms. After the patch, all eight disposed tasks are removed before accounting and the live pane starts in the next 100 ms pump window.

The checked-in regression fails against the unpatched queue at the stale-call assertion and passes with this change.

## Regression proof

- `pnpm test src/renderer/src/components/terminal-pane/agent-completion-coordinator-queued-inspection-disposal.test.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator-process-cadence.test.ts` — 2 files / 16 tests passed.
- `pnpm test src/renderer/src/components/terminal-pane/agent-completion` — 12 files / 109 tests passed.
- `pnpm tc:web` — passed.
- `pnpm run check:code-quality:changed` — 0 findings across 3 changed files.
- Commit hooks, formatting, and `git diff --check` — passed.

## No-user-regression signoff

**Sign-off: no terminal feature, polling cadence, completion behavior, process-inspection result, or liveness verdict is intentionally changed.** Only work owned by an already-disposed renderer coordinator is skipped before it starts. Live and already-started inspections keep the same priority, concurrency, rate, and result handling.

This is renderer-side queue cleanup shared by local, daemon, WSL, direct SSH, and relay-backed terminals. It adds no RPC fields, opcodes, provider-specific behavior, or wire changes, and does not reinterpret connection loss as process exit. Folder workspaces and git worktrees use the same unchanged path.

## Merge risk

**Risk: low.** The predicate reads the coordinator lifecycle flag already used to suppress results and future polls. The main risk is dropping a task too early; the regression disposes only after tasks are queued, while the related coordinator suite covers active polling and completion behavior. Already-started host inspections remain uncancelled as a deliberate residual limitation.