### PR TITLE
fix(browser): stop rewriting the engine user agent so Cloudflare challenges pass (STA-3905)

### DIFF
--- a/src/main/browser/browser-manager-auth-user-agent.test.ts
+++ b/src/main/browser/browser-manager-auth-user-agent.test.ts
@@ -51,7 +51,7 @@ import {
 import {
   createViewportGuestFactory,
   flushViewportOps,
-  GUEST_CLEAN_UA
+  GUEST_ELECTRON_UA
 } from './browser-manager-viewport-test-fixtures'
 
 const {
@@ -543,7 +543,7 @@ describe('browserManager', () => {
     )
     expect(uaWrites.length).toBeGreaterThan(0)
     for (const [, params] of uaWrites) {
-      expect((params as { userAgent: string }).userAgent).toBe(GUEST_CLEAN_UA)
+      expect((params as { userAgent: string }).userAgent).toBe(GUEST_ELECTRON_UA)
     }
   })
 })

--- a/src/main/browser/browser-manager-viewport-override.test.ts
+++ b/src/main/browser/browser-manager-viewport-override.test.ts
@@ -49,7 +49,6 @@ import {
 import {
   createViewportGuestFactory,
   flushViewportOps,
-  GUEST_CLEAN_UA,
   GUEST_ELECTRON_UA
 } from './browser-manager-viewport-test-fixtures'
 
@@ -207,7 +206,7 @@ describe('browserManager', () => {
         mobile: false
       })
       expect(debuggerSendCommand).toHaveBeenLastCalledWith('Emulation.setUserAgentOverride', {
-        userAgent: GUEST_CLEAN_UA
+        userAgent: GUEST_ELECTRON_UA
       })
 
       // Navigating to the auth host must move the standing override to the Firefox identity.
@@ -222,7 +221,7 @@ describe('browserManager', () => {
       debuggerSendCommand.mockClear()
       willRedirect({ preventDefault: vi.fn() }, 'https://example.com/', false, true)
       await flushViewportOps()
-      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_ELECTRON_UA })
     })
 
     // Why: not an ordering race — debugger.sendCommand dispatches in call order over one channel, so
@@ -241,8 +240,8 @@ describe('browserManager', () => {
     }
 
     // Why mobile: on the desktop branch the break is masked by coincidence — applyGoogleAuthUserAgent
-    // has already switched the WebContents UA to Firefox, and cleanElectronUserAgent passes a Firefox
-    // UA through untouched, so the stale-URL desktop path happens to emit Firefox anyway. The mobile
+    // has already switched the WebContents UA to Firefox and the desktop branch republishes its base
+    // UA untouched, so the stale-URL desktop path happens to emit Firefox anyway. The mobile
     // branch derives a Chrome-shaped iPhone UA from that same base and exposes the real defect.
     it('does not leave the Chrome preset UA standing when a mobile preset lands mid-navigation onto an auth host', async () => {
       const { guest, debuggerSendCommand } = makeGuest(4251, 'https://example.com/')
@@ -332,7 +331,7 @@ describe('browserManager', () => {
 
       // Without the fix the resuming preset re-reads getURL() as the auth host and clobbers the
       // navigation's correct write, stranding the Firefox UA on a non-auth page.
-      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_ELECTRON_UA })
     })
 
     it('falls back to the committed URL once a navigation commits or fails', async () => {
@@ -378,7 +377,7 @@ describe('browserManager', () => {
       await flushViewportOps()
 
       expect(guest.setUserAgent).toHaveBeenLastCalledWith(GUEST_ELECTRON_UA)
-      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_ELECTRON_UA })
 
       // A later preset must also resolve the committed, non-auth URL.
       debuggerSendCommand.mockClear()
@@ -457,7 +456,7 @@ describe('browserManager', () => {
       expect(guest.setUserAgent).not.toHaveBeenCalled()
       expect(debuggerSendCommand).not.toHaveBeenCalledWith(
         'Emulation.setUserAgentOverride',
-        expect.objectContaining({ userAgent: GUEST_CLEAN_UA })
+        expect.objectContaining({ userAgent: GUEST_ELECTRON_UA })
       )
     })
 
@@ -517,7 +516,7 @@ describe('browserManager', () => {
       didFailLoad(null, -3, 'Aborted', 'https://accounts.google.com/redirected', true)
       await flushViewportOps()
       expect(guest.setUserAgent).not.toHaveBeenCalled()
-      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_ELECTRON_UA })
     })
 
     it('preserves the auth identity when a viewport preset is cleared after a redirect', async () => {
@@ -592,7 +591,7 @@ describe('browserManager', () => {
       didStartNavigation(null, 'https://example.com/', false, true)
       await flushViewportOps()
 
-      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_ELECTRON_UA })
     })
 
     it('reapplies a preset when navigation starts during its final UA write', async () => {

--- a/src/main/browser/browser-manager-viewport-test-fixtures.ts
+++ b/src/main/browser/browser-manager-viewport-test-fixtures.ts
@@ -3,8 +3,6 @@ import type { BrowserManagerMocks } from './browser-manager-test-harness'
 
 export const GUEST_ELECTRON_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) orca/1.0.0 Chrome/134.0.0.0 Electron/30.0.0 Safari/537.36'
-export const GUEST_CLEAN_UA =
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36'
 
 // Why: viewport UA writes are queued on the per-tab chain, so draining it takes more than one
 // microtask hop; loop until the chain is empty rather than guessing a tick count.

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -48,7 +48,6 @@ import {
   type PageInitiatedTabBudget
 } from './browser-page-initiated-tab-budget'
 import { isNewBrowserTabPopupIntent } from './browser-popup-new-tab-intent'
-import { cleanElectronUserAgent } from './browser-session-ua'
 import { getBrowserSessionUserAgentMode } from './browser-session-user-agent-mode'
 import { googleAuthUserAgent, isGoogleAuthUrl } from './browser-google-auth-ua'
 import { buildViewportUserAgentOverride } from './browser-viewport-user-agent'
@@ -1273,7 +1272,7 @@ export class BrowserManager {
         // Why: the session UA is the profile's stable base identity. guest.getUserAgent() is not:
         // applyGoogleAuthUserAgent leaves it pinned to the Firefox auth UA once a guest switches to
         // the CDP override, so reading it back here would republish that identity on ordinary hosts.
-        baseUserAgent: cleanElectronUserAgent(baseUserAgent ?? guest.session.getUserAgent())
+        baseUserAgent: baseUserAgent ?? guest.session.getUserAgent()
       })
     )
   }

--- a/src/main/browser/browser-session-partition-policies.test.ts
+++ b/src/main/browser/browser-session-partition-policies.test.ts
@@ -5,7 +5,8 @@ const mocks = vi.hoisted(() => ({
   handleGuestWillDownload: vi.fn(),
   noticeDocPreviewDownloadBlocked: vi.fn(),
   clearBrowserWebAuthnAccessHandlers: vi.fn(),
-  installBrowserWebAuthnAccessHandlers: vi.fn()
+  installBrowserWebAuthnAccessHandlers: vi.fn(),
+  setupClientHintsOverride: vi.fn()
 }))
 
 type WillDownloadListener = (
@@ -82,8 +83,7 @@ vi.mock('./browser-media-access', () => ({
   requestSystemMediaAccess: async () => false
 }))
 vi.mock('./browser-session-ua', () => ({
-  cleanElectronUserAgent: (userAgent: string) => userAgent,
-  setupClientHintsOverride: vi.fn()
+  setupClientHintsOverride: mocks.setupClientHintsOverride
 }))
 vi.mock('./browser-session-user-agent-mode', () => ({
   setBrowserSessionUserAgentMode: vi.fn()
@@ -231,5 +231,34 @@ describe('partition permission policy', () => {
       displayMediaDecision = decision
     })
     expect(displayMediaDecision).toEqual({ video: undefined, audio: undefined })
+  })
+  // Why: stripping the engine tokens leaves a UA claiming Google Chrome that the engine cannot
+  // back — Electron emits no sec-ch-ua* client hints — and Cloudflare's managed challenge rejects
+  // exactly that combination. The untouched engine UA passes it (STA-3905).
+  it('leaves the engine user agent untouched on a clean-mode profile', async () => {
+    const install = await loadInstaller()
+    install(profileFor('orca-ua-clean'))
+    const sess = sessionsByPartition.get('orca-ua-clean')
+    if (!sess) {
+      throw new Error('Expected the clean-mode session')
+    }
+    expect(sess.setUserAgent).not.toHaveBeenCalled()
+  })
+
+  // Why: the auth-host Firefox switch lives inside the same installer, so dropping the UA rewrite
+  // must not take it down with it.
+  it('still installs the auth-host header switch for a clean-mode profile', async () => {
+    const install = await loadInstaller()
+    install(profileFor('orca-ua-hints'))
+    const sess = sessionsByPartition.get('orca-ua-hints')
+    expect(mocks.setupClientHintsOverride).toHaveBeenCalledWith(sess, 'Mozilla/5.0 Orca')
+  })
+
+  it('installs no header switch for a native-mode profile', async () => {
+    const install = await loadInstaller()
+    install({ ...profileFor('orca-ua-native'), userAgentMode: 'native' })
+    const sess = sessionsByPartition.get('orca-ua-native')
+    expect(sess?.setUserAgent).not.toHaveBeenCalled()
+    expect(mocks.setupClientHintsOverride).not.toHaveBeenCalledWith(sess, expect.anything())
   })
 })

--- a/src/main/browser/browser-session-partition-policies.ts
+++ b/src/main/browser/browser-session-partition-policies.ts
@@ -4,7 +4,7 @@ import type { BrowserSessionProfile } from '../../shared/browser-workspace-types
 import { browserManager } from './browser-manager'
 import { hasSystemMediaAccess, requestSystemMediaAccess } from './browser-media-access'
 import { isAutoGrantedBrowserSessionPermission } from './browser-session-permission-policy'
-import { cleanElectronUserAgent, setupClientHintsOverride } from './browser-session-ua'
+import { setupClientHintsOverride } from './browser-session-ua'
 import { setBrowserSessionUserAgentMode } from './browser-session-user-agent-mode'
 import {
   allowsBrowserWebAuthnPermission,
@@ -75,9 +75,9 @@ export function installBrowserSessionPartitionPolicies(
 
   browserManager.installCertificateRequestGuard(sess)
   if (profile.userAgentMode !== 'native' && typeof sess.getUserAgent === 'function') {
-    const cleanUA = cleanElectronUserAgent(sess.getUserAgent())
-    sess.setUserAgent(cleanUA)
-    setupClientHintsOverride(sess, cleanUA)
+    // Why the engine UA stands as-is: see setupClientHintsOverride's header. The switch still
+    // installs here because it owns the Google auth-host Firefox identity, which is unrelated.
+    setupClientHintsOverride(sess, sess.getUserAgent())
   }
   if (options?.permissions === 'deny') {
     sess.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false))
@@ -172,10 +172,7 @@ export function applyBrowserSessionUserAgentModes(profiles: BrowserSessionProfil
         continue
       }
 
-      // Why: the default Electron UA leaks "Electron/X.X.X" + app name, which trips Cloudflare Turnstile.
-      const cleanUA = cleanElectronUserAgent(sess.getUserAgent())
-      sess.setUserAgent(cleanUA)
-      setupClientHintsOverride(sess, cleanUA)
+      setupClientHintsOverride(sess, sess.getUserAgent())
     } catch {
       /* session not available yet (e.g. unit tests or pre-ready) */
     }

--- a/src/main/browser/browser-session-registry.persistence.test.ts
+++ b/src/main/browser/browser-session-registry.persistence.test.ts
@@ -119,7 +119,6 @@ function installModuleMocks(
     requestSystemMediaAccess: requestSystemMediaAccessMock
   }))
   vi.doMock('./browser-session-ua', () => ({
-    cleanElectronUserAgent: vi.fn((ua: string) => ua.replace(/\s*Electron\/\S+/, '')),
     setupClientHintsOverride: setupClientHintsOverrideMock
   }))
   // This suite models replay with an in-memory filesystem. The real file-backed SQLite merge has
@@ -234,7 +233,7 @@ describe('BrowserSessionRegistry persistence', () => {
     })
   })
 
-  it('keeps UA cleaning as the fallback for profiles without an override', async () => {
+  it('leaves the engine UA in place for profiles without an override', async () => {
     const fsState = createFsState()
     const { sessionFromPartitionMock, setupClientHintsOverrideMock } = installModuleMocks(fsState)
     const { browserSessionRegistry } = await import('./browser-session-registry')
@@ -242,8 +241,14 @@ describe('BrowserSessionRegistry persistence', () => {
     browserSessionRegistry.createProfile('isolated', 'Default identity')
 
     const profileSession = sessionFromPartitionMock.mock.results.at(-1)?.value
-    expect(profileSession.setUserAgent).toHaveBeenCalledWith('Mozilla/5.0 Orca')
-    expect(setupClientHintsOverrideMock).toHaveBeenCalledWith(profileSession, 'Mozilla/5.0 Orca')
+    // Why: a rewritten UA is what Cloudflare's managed challenge rejects (STA-3905); the engine's
+    // own identity stands, and only the auth-host header switch installs.
+    expect(profileSession.setUserAgent).not.toHaveBeenCalled()
+    // The Electron token now survives to the auth-host switch instead of being laundered out.
+    expect(setupClientHintsOverrideMock).toHaveBeenCalledWith(
+      profileSession,
+      'Mozilla/5.0 Electron/31 Orca'
+    )
   })
 
   it('leaves UA and client hints untouched for native-mode profiles', async () => {
@@ -379,7 +384,7 @@ describe('BrowserSessionRegistry persistence', () => {
   // Why: imports before Aug 2026 persisted a synthesized source-browser UA
   // (fork imports as a broken Chrome/1.x, Chrome imports as a valid version).
   // Neither may ever be applied again — the engine-derived UA is the only one.
-  it('ignores legacy persisted UAs, valid or broken, and applies the engine UA', async () => {
+  it('ignores legacy persisted UAs, valid or broken, and writes no UA at all', async () => {
     const importedPartition = 'persist:orca-browser-session-11111111-1111-4111-8111-111111111111'
     const brokenUa =
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/1.158.1 Safari/537.36'
@@ -415,9 +420,8 @@ describe('BrowserSessionRegistry persistence', () => {
     )
     expect(appliedUas).not.toContain(brokenUa)
     expect(appliedUas).not.toContain(validUa)
-    // Why: every non-native profile falls to Orca's own cleaned engine UA.
-    expect(appliedUas.length).toBeGreaterThan(0)
-    expect(appliedUas.every((ua) => ua === 'Mozilla/5.0 Orca')).toBe(true)
+    // Why: no profile writes a UA at all now, which subsumes "never replays a persisted one".
+    expect(appliedUas).toEqual([])
     expect(
       setupClientHintsOverrideMock.mock.calls.every(
         (c: unknown[]) => c[1] !== brokenUa && c[1] !== validUa

--- a/src/main/browser/browser-session-ua.ts
+++ b/src/main/browser/browser-session-ua.ts
@@ -8,25 +8,14 @@ import {
   stripClientHints
 } from './browser-google-auth-ua'
 
-// Why: Electron's default UA includes "Electron/X.X.X" and the app name
-// (e.g. "orca/1.2.3"), which Cloudflare Turnstile and other bot detectors
-// flag as non-human traffic. Strip those tokens so the webview's UA and
-// sec-ch-ua Client Hints look like standard Chrome.
-export function cleanElectronUserAgent(ua: string): string {
-  return (
-    ua
-      .replace(/\s+Electron\/\S+/, '')
-      // Why: \S+ matches any non-whitespace token (e.g. "orca/1.3.8-rc.0")
-      // including pre-release semver strings that [\d.]+ would miss.
-      .replace(/(\)\s+)\S+\s+(Chrome\/)/, '$1$2')
-  )
-}
-
-// Why: Electron emits sec-ch-ua brands like "Not A(Brand" without a
-// "Google Chrome" entry, which disagrees with the Chrome-shaped UA the session
-// presents. Rewrite the hint headers to the brand set Chrome ships for the same
-// engine version so the two surfaces tell one story. Also owns the Google
-// auth-host Firefox switch, which must install even for a non-Chrome-shaped UA.
+// Why the session UA is left alone (STA-3905): stripping "Electron/X" and the app name leaves a UA
+// claiming Google Chrome, and Chromium under Electron sends no sec-ch-ua* client hints at all — a
+// combination no real Chrome produces. Cloudflare's managed challenge rejects it ("There was a
+// problem with verification"), while the untouched engine UA passes. Measured on
+// dash.cloudflare.com/login: untouched 5/5 pass, every rewritten variant 12/12 fail.
+//
+// The brand rewrite below is kept for hosts that do send the hints, but its real job now is the
+// Google auth-host Firefox switch, which must install regardless of the UA shape.
 export function setupClientHintsOverride(
   sess: Session,
   ua: string,

--- a/src/main/browser/browser-viewport-user-agent.ts
+++ b/src/main/browser/browser-viewport-user-agent.ts
@@ -44,7 +44,8 @@ export function buildViewportUserAgentOverride(args: {
     return { userAgent: googleAuthUserAgent() }
   }
   if (!args.mobile) {
-    // Why: desktop presets still need the clean (non-Electron) UA so Cloudflare/Turnstile don't flag the session.
+    // Why: republish the session's own identity unchanged — a preset must not become a second place
+    // that reshapes the UA (STA-3905).
     return { userAgent: args.baseUserAgent }
   }
   const chromeMajor = extractChromeMajor(args.baseUserAgent)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​32 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 |

<!-- /orca-pr-loc -->

Fixes STA-3905 (the Cloudflare half only — Chrome extension support is a separate product decision and is not in this PR).

## ELI5

Orca's browser was telling websites "I am Google Chrome." It isn't — it's Electron, which is Chrome's engine wrapped in an app. Cloudflare checks that claim against things only real Chrome does, Orca failed those checks, and the "are you human?" box refused to pass.

This PR stops Orca from claiming to be something it isn't. It now says what it actually is, and Cloudflare lets it through.

## User-facing before/after

**Before:** sites protected by Cloudflare could not be used in Orca's browser at all — the verification widget on a login page showed **"There was a problem with verification. Please reload and try again."** and the Sign in button stayed disabled. There was no way past it, on any site using a real (risk-scored) Cloudflare challenge.

**After:** the challenge issues a token and the page proceeds normally.

| | Before | After |
|---|---|---|
| Session UA | `…(KHTML, like Gecko) Chrome/150.0.7871.47 Safari/537.36` | `…(KHTML, like Gecko) Orca/1.4.178 Chrome/150.0.7871.47 Electron/43.1.0 Safari/537.36` |
| `cf_challenge_response` | empty (0 chars) | issued (794 chars) |
| Widget | "There was a problem with verification." | no error |

## What was actually wrong

`cleanElectronUserAgent()` stripped `Electron/<version>` and the app token from the session UA. Its stated reason was that those tokens "Cloudflare Turnstile and other bot detectors flag as non-human traffic." **That premise is backwards** — the rewrite is what causes the failure.

Measured against `dash.cloudflare.com/login` (a real managed Turnstile on a login form — the same shape as the screenshot on the ticket), using a harness that loads the page under one treatment at a time with the real modules imported:

| Treatment | Result |
|---|---|
| Untouched Electron UA | **passes** 5/5 |
| `setUserAgent()` with an identical string (control) | **passes** 2/2 |
| CDP debugger attached, no UA change | passes |
| Anti-detection script injected, no UA change | passes |
| `cleanElectronUserAgent()` output (what Orca shipped) | **fails** 5/5 |
| Strip app token only, keep `Electron/x` | fails 3/3 |
| Strip `Electron/x` only, keep app token | fails 2/2 |
| Neutral app token, canonical Electron shape | fails 2/2 |

Only the engine's own unmodified UA passes. Every rewritten variant fails with the exact error from the ticket.

**Why the claim can't be backed:** Chromium under Electron sends **no `sec-ch-ua*` client hints at all**. Verified against a local HTTPS echo server — real Chrome sends `sec-ch-ua`, `sec-ch-ua-mobile`, and `sec-ch-ua-platform` on every secure request; Electron sends none, even after an `Accept-CH` response. A UA claiming `Chrome/150` with zero client hints is a combination no real Chrome produces.

This also means the existing `setupClientHintsOverride` brand rewrite has **never fired** for these headers — it only rewrites keys already present in the request, and they are never present. Injecting the three hints by hand does not rescue the clean UA either (tested: still fails), so chasing a complete Chrome impersonation is not a viable direction.

## The fix

Leave the session User-Agent alone. `setupClientHintsOverride` still installs, because it also owns the Google auth-host Firefox switch (STA-3811 / #12884), which is unrelated to the UA shape and must not regress. The viewport-preset path likewise republishes the session's own identity instead of a laundered copy.

This is the honest direction the ticket asked for: present accurately rather than disguise. Nothing here defeats or evades a bot check — it removes a false claim that was causing a legitimate user to fail a check they should pass.

## Trade-off to be aware of

Sites now see the app token and `Electron/<version>` in the UA again — i.e. Orca and its version are disclosed, where before they were stripped. That is a deliberate identity-disclosure trade, and it is exactly what the existing per-profile "Unmodified user agent" option (`--no-ua-spoof`) already did; this makes it the default. **No security or isolation boundary is relaxed** — partitions, permissions, downloads, and certificate handling are untouched.

## Tests

Failing-first, then ablated:

- `leaves the engine user agent untouched on a clean-mode profile` — red before the change for the right reason (`setUserAgent` called once), green after.
- Restoring the UA rewrite in the partition installer reds **3** tests.
- Restoring the laundering on the viewport base identity reds **6** tests.
- Full `src/main/browser` suite: 174 files / 1637 tests green.

Three pre-existing tests pinned the old behavior and were updated deliberately; the invariant they actually protect (a legacy persisted UA from a cookie import is never replayed onto a session) is preserved and now strengthened — no UA is written at all.

## Verification

`pnpm tc` exit 0 · `oxlint --deny-warnings` exit 0 · changed-code quality gate 0 findings · `git diff --check` clean.

End-to-end in the real app via `$electron` + CDP (dev instance, fresh profile), driving the actual URL bar to `dash.cloudflare.com/login`: before the change, no token and the error banner; after, a 794-char token and no error.

## Scope / what remains unproven

- Reproduced and fixed on **macOS**; not re-measured on Windows or Linux, though nothing in the change is platform-specific.
- Cloudflare's classifier is opaque. What is established is the input→output relation above, not *why* Cloudflare scores it that way.
- **Not all Cloudflare sites fail identically.** Dummy/testing sitekeys (e.g. the official Turnstile demo) pass in every arm. `nowsecure.nl`, a deliberately maximal anti-bot testbed, fails in *every* arm including bare Electron — so some hostile deployments remain out of reach and this PR does not claim otherwise.

## Separate finding, deliberately not fixed here

`anti-detection.ts` defines `navigator.webdriver` as an **own** property on `navigator` (`enumerable: false, configurable: false`), shadowing the genuine `Navigator.prototype` accessor. Measured: bare Electron and CDP-attached Electron both already report `navigator.webdriver === false` with no own property, so the override is unnecessary — and it flips `bot.sannysoft.com`'s WebDriver check from **passed** to **failed**. Its stated premise ("attaching the CDP debugger sets navigator.webdriver = true") is measurably false on Electron 43. The same script also leaves `Permissions.prototype.query` and `Notification.requestPermission` non-native to `toString()`.

These are real defects in the same subsystem, but they are **not** the cause of this bug (the arm with the script and no UA change passes), so folding them in would misrepresent this fix. Worth a follow-up.
