### PR TITLE
feat(github): add My GitHub panel — sign in, browse, clone, and clean up your own repos

### DIFF
--- a/src/main/github-auth/api-request.ts
+++ b/src/main/github-auth/api-request.ts
@@ -1,0 +1,52 @@
+import { getMainHttpClient } from '../network/http-client'
+import { GITHUB_API_BASE_URL } from './github-auth-config'
+
+export type GitHubApiResult<T> =
+  | { ok: true; data: T }
+  // 'rejected' = GitHub answered 401/403 (bad or under-scoped token);
+  // 'unreachable' = network/5xx/parse failure — retrying the same token is fine.
+  | { ok: false; reason: 'rejected' | 'unreachable'; status?: number; message: string }
+
+export async function githubApiGet<T>(
+  token: string,
+  path: string,
+  timeoutMs = 15000
+): Promise<GitHubApiResult<T>> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await getMainHttpClient().fetch(`${GITHUB_API_BASE_URL}${path}`, {
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    })
+    if (response.status === 401 || response.status === 403) {
+      return {
+        ok: false,
+        reason: 'rejected',
+        status: response.status,
+        message: `${response.status}`
+      }
+    }
+    if (!response.ok) {
+      return {
+        ok: false,
+        reason: 'unreachable',
+        status: response.status,
+        message: `${response.status}`
+      }
+    }
+    return { ok: true, data: (await response.json()) as T }
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'unreachable',
+      message: error instanceof Error ? error.message : String(error)
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/src/main/github-auth/clone-repo.test.ts
+++ b/src/main/github-auth/clone-repo.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../shared/repo-types'
+
+const { lstatMock, cloneLocalRepoIntoDestinationMock, resolveGitHubTokenMock } = vi.hoisted(() => ({
+  lstatMock: vi.fn(),
+  cloneLocalRepoIntoDestinationMock: vi.fn(),
+  resolveGitHubTokenMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({ lstat: lstatMock }))
+vi.mock('../ipc/repos/repo-clone-lifecycle', () => ({
+  cloneLocalRepoIntoDestination: cloneLocalRepoIntoDestinationMock
+}))
+vi.mock('./connection', () => ({ resolveGitHubToken: resolveGitHubTokenMock }))
+
+import { cloneGitHubAccountRepo } from './clone-repo'
+
+const IS_WIN = process.platform === 'win32'
+const DESTINATION = IS_WIN ? 'C:\\Users\\dev\\orca\\projects' : '/Users/dev/orca/projects'
+const CLONE_PATH = IS_WIN ? `${DESTINATION}\\my-repo` : `${DESTINATION}/my-repo`
+const CLONE_URL = 'https://github.com/octo/my-repo'
+
+const mainWindowStub = {} as never
+const storeStub = {} as never
+
+const baseArgs = {
+  fullName: 'octo/my-repo',
+  cloneUrl: CLONE_URL,
+  isPrivate: false,
+  destination: DESTINATION
+}
+
+beforeEach(() => {
+  lstatMock.mockReset()
+  cloneLocalRepoIntoDestinationMock.mockReset()
+  resolveGitHubTokenMock.mockReset()
+})
+
+describe('cloneGitHubAccountRepo', () => {
+  it('clones when the target directory does not exist yet', async () => {
+    lstatMock.mockRejectedValue(Object.assign(new Error('gone'), { code: 'ENOENT' }))
+    const repo = { id: 'r1', path: CLONE_PATH } as Repo
+    cloneLocalRepoIntoDestinationMock.mockResolvedValue(repo)
+
+    const result = await cloneGitHubAccountRepo(mainWindowStub, storeStub, baseArgs)
+
+    expect(result).toEqual({ ok: true, repo })
+    expect(cloneLocalRepoIntoDestinationMock).toHaveBeenCalledWith(
+      mainWindowStub,
+      storeStub,
+      { url: CLONE_URL, destination: DESTINATION },
+      { extraGitConfig: undefined }
+    )
+  })
+
+  it('aborts with a clear error when a same-named directory already exists', async () => {
+    lstatMock.mockResolvedValue({ isDirectory: () => true })
+
+    const result = await cloneGitHubAccountRepo(mainWindowStub, storeStub, baseArgs)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain(CLONE_PATH)
+      expect(result.error).toContain('already exists')
+    }
+    expect(cloneLocalRepoIntoDestinationMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-GitHub clone URLs before touching the filesystem', async () => {
+    const result = await cloneGitHubAccountRepo(mainWindowStub, storeStub, {
+      ...baseArgs,
+      cloneUrl: 'https://example.com/octo/my-repo'
+    })
+
+    expect(result).toEqual({ ok: false, error: 'Invalid GitHub clone request.' })
+    expect(lstatMock).not.toHaveBeenCalled()
+    expect(cloneLocalRepoIntoDestinationMock).not.toHaveBeenCalled()
+  })
+
+  it('requires a connected account for private repositories', async () => {
+    lstatMock.mockRejectedValue(Object.assign(new Error('gone'), { code: 'ENOENT' }))
+    resolveGitHubTokenMock.mockReturnValue(null)
+
+    const result = await cloneGitHubAccountRepo(mainWindowStub, storeStub, {
+      ...baseArgs,
+      isPrivate: true
+    })
+
+    expect(result.ok).toBe(false)
+    expect(cloneLocalRepoIntoDestinationMock).not.toHaveBeenCalled()
+  })
+
+  it('passes a one-shot auth header for private clones, never embedding the token', async () => {
+    lstatMock.mockRejectedValue(Object.assign(new Error('gone'), { code: 'ENOENT' }))
+    resolveGitHubTokenMock.mockReturnValue('secret-token')
+    const repo = { id: 'r1', path: CLONE_PATH } as Repo
+    cloneLocalRepoIntoDestinationMock.mockResolvedValue(repo)
+
+    const result = await cloneGitHubAccountRepo(mainWindowStub, storeStub, {
+      ...baseArgs,
+      isPrivate: true
+    })
+
+    expect(result).toEqual({ ok: true, repo })
+    const options = cloneLocalRepoIntoDestinationMock.mock.calls[0][3] as {
+      extraGitConfig: string[]
+    }
+    expect(options.extraGitConfig).toHaveLength(1)
+    expect(options.extraGitConfig[0]).toMatch(/^http\.https:\/\/github\.com\/\.extraheader=/)
+    expect(options.extraGitConfig[0]).not.toContain('secret-token')
+  })
+})

--- a/src/main/github-auth/clone-repo.ts
+++ b/src/main/github-auth/clone-repo.ts
@@ -1,0 +1,75 @@
+import type { BrowserWindow } from 'electron'
+import { Buffer } from 'node:buffer'
+import { lstat } from 'node:fs/promises'
+import type { Store } from '../persistence'
+import type { GitHubCloneRepoArgs, GitHubCloneRepoResult } from '../../shared/github-account'
+import { cloneLocalRepoIntoDestination } from '../ipc/repos/repo-clone-lifecycle'
+import { deriveValidatedClonePath } from '../git/repo-clone-path'
+import { resolveGitHubToken } from './connection'
+
+const GITHUB_HTTPS_PREFIX = 'https://github.com/'
+
+// Why scoped to `http.https://github.com/`: git only sends the header to that
+// URL prefix, so a renderer-supplied clone URL pointing elsewhere can never
+// exfiltrate the account token.
+function buildCloneAuthConfig(token: string): string {
+  const basic = Buffer.from(`x-access-token:${token}`, 'utf-8').toString('base64')
+  return `http.${GITHUB_HTTPS_PREFIX}.extraheader=AUTHORIZATION: basic ${basic}`
+}
+
+// Why: the panel clones into a fixed default location, so a same-named
+// directory is leftover state — abort loudly instead of letting git fail with
+// a terse "not an empty directory" or silently reusing an empty one.
+async function getExistingCloneTargetError(
+  url: string,
+  destination: string
+): Promise<string | null> {
+  let clonePath: string
+  try {
+    clonePath = deriveValidatedClonePath({ url, destination })
+  } catch {
+    // Why: cloneLocalRepoIntoDestination re-derives and reports validation errors.
+    return null
+  }
+  try {
+    await lstat(clonePath)
+  } catch {
+    return null
+  }
+  return `Cannot clone: "${clonePath}" already exists. Remove it first — via the panel's Added menu if Orca manages it, or manually.`
+}
+
+export async function cloneGitHubAccountRepo(
+  mainWindow: BrowserWindow,
+  store: Store,
+  args: GitHubCloneRepoArgs
+): Promise<GitHubCloneRepoResult> {
+  const cloneUrl = args.cloneUrl.trim()
+  const destination = args.destination.trim()
+  if (!cloneUrl.startsWith(GITHUB_HTTPS_PREFIX) || !destination) {
+    return { ok: false, error: 'Invalid GitHub clone request.' }
+  }
+  const existingTargetError = await getExistingCloneTargetError(cloneUrl, destination)
+  if (existingTargetError) {
+    return { ok: false, error: existingTargetError }
+  }
+  let extraGitConfig: string[] | undefined
+  if (args.isPrivate) {
+    const token = resolveGitHubToken()
+    if (!token) {
+      return { ok: false, error: 'Connect a GitHub account before cloning private repositories.' }
+    }
+    extraGitConfig = [buildCloneAuthConfig(token)]
+  }
+  try {
+    const repo = await cloneLocalRepoIntoDestination(
+      mainWindow,
+      store,
+      { url: cloneUrl, destination },
+      { extraGitConfig }
+    )
+    return { ok: true, repo }
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) }
+  }
+}

--- a/src/main/github-auth/connection.ts
+++ b/src/main/github-auth/connection.ts
@@ -1,0 +1,143 @@
+import type {
+  GitHubAccountStatus,
+  GitHubConnectTokenResult,
+  GitHubDeviceFlowPollResult,
+  GitHubRepoListResult
+} from '../../shared/github-account'
+import {
+  clearStoredGitHubCredential,
+  getStoredGitHubMetadata,
+  hasStoredGitHubCredential,
+  loadStoredGitHubSecret,
+  saveGitHubCredential
+} from './credential-store'
+import { getEnvGitHubToken, getGitHubDeviceFlowClientId } from './github-auth-config'
+import { fetchGitHubViewer } from './viewer'
+import { listAccessibleGitHubRepos } from './repo-list'
+import { pollGitHubDeviceFlow, startGitHubDeviceFlow } from './device-flow'
+
+export async function connectGitHubWithToken(
+  rawToken: string,
+  authMethod: 'pat' | 'device-flow'
+): Promise<GitHubConnectTokenResult> {
+  const token = rawToken.trim()
+  if (!token) {
+    return { ok: false, error: 'Enter a personal access token.' }
+  }
+  const result = await fetchGitHubViewer(token)
+  if (!result.ok) {
+    // Why: calling a token invalid when the network is down sends people to
+    // regenerate a credential that was fine.
+    return {
+      ok: false,
+      error:
+        result.reason === 'rejected'
+          ? 'GitHub rejected this token. Check that it is valid and has the repo scope.'
+          : 'Could not reach GitHub. Check your connection, then try again.'
+    }
+  }
+  saveGitHubCredential({
+    token,
+    authMethod,
+    login: result.data.login,
+    name: result.data.name,
+    avatarUrl: result.data.avatarUrl
+  })
+  return { ok: true, login: result.data.login }
+}
+
+export function disconnectGitHub(): void {
+  clearStoredGitHubCredential()
+}
+
+// Reads env vars and plaintext metadata only — never decrypts — so the panel
+// can call it on every open without a keychain prompt.
+export function getGitHubAccountStatus(): GitHubAccountStatus {
+  const deviceFlowAvailable = getGitHubDeviceFlowClientId() !== null
+  if (getEnvGitHubToken()) {
+    return {
+      configured: true,
+      source: 'environment',
+      login: null,
+      name: null,
+      avatarUrl: null,
+      authMethod: null,
+      deviceFlowAvailable
+    }
+  }
+  if (hasStoredGitHubCredential()) {
+    const metadata = getStoredGitHubMetadata()
+    return {
+      configured: true,
+      source: 'stored',
+      login: metadata?.login ?? null,
+      name: metadata?.name ?? null,
+      avatarUrl: metadata?.avatarUrl ?? null,
+      authMethod: metadata?.authMethod ?? null,
+      deviceFlowAvailable
+    }
+  }
+  return {
+    configured: false,
+    source: 'none',
+    login: null,
+    name: null,
+    avatarUrl: null,
+    authMethod: null,
+    deviceFlowAvailable
+  }
+}
+
+// Resolves the token only when an operation needs it (repo list, clone); never
+// returns it across IPC.
+export function resolveGitHubToken(): string | null {
+  const envToken = getEnvGitHubToken()
+  if (envToken) {
+    return envToken
+  }
+  return loadStoredGitHubSecret({ force: true })?.token ?? null
+}
+
+export async function startGitHubAccountDeviceFlow() {
+  const clientId = getGitHubDeviceFlowClientId()
+  if (!clientId) {
+    return { ok: false as const, error: 'GitHub device sign-in is not configured in this build.' }
+  }
+  return startGitHubDeviceFlow(clientId)
+}
+
+export async function pollGitHubAccountDeviceFlow(
+  deviceCode: string
+): Promise<GitHubDeviceFlowPollResult> {
+  const clientId = getGitHubDeviceFlowClientId()
+  if (!clientId) {
+    return { status: 'error', error: 'GitHub device sign-in is not configured in this build.' }
+  }
+  const result = await pollGitHubDeviceFlow(clientId, deviceCode)
+  if (result.status !== 'authorized') {
+    return result
+  }
+  const connected = await connectGitHubWithToken(result.token, 'device-flow')
+  if (!connected.ok) {
+    return { status: 'error', error: connected.error }
+  }
+  return { status: 'connected', login: connected.login }
+}
+
+export async function listGitHubAccountRepos(): Promise<GitHubRepoListResult> {
+  const token = resolveGitHubToken()
+  if (!token) {
+    return { ok: false, error: 'Connect a GitHub account first.' }
+  }
+  const result = await listAccessibleGitHubRepos(token)
+  if (!result.ok) {
+    return {
+      ok: false,
+      error:
+        result.reason === 'rejected'
+          ? 'GitHub rejected the saved credential. Reconnect your account.'
+          : 'Could not reach GitHub. Check your connection, then try again.'
+    }
+  }
+  return { ok: true, repos: result.data }
+}

--- a/src/main/github-auth/credential-store.test.ts
+++ b/src/main/github-auth/credential-store.test.ts
@@ -1,0 +1,137 @@
+import { existsSync, mkdtempSync, statSync } from 'node:fs'
+import type * as Os from 'node:os'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+let tempHome = ''
+const decryptStringMock = vi.fn((value: Buffer) => value.toString('utf-8'))
+
+async function loadStore() {
+  vi.resetModules()
+  vi.doUnmock('node:fs')
+  const { setSecretStore } = await import('../../shared/secret-store')
+  setSecretStore({
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => Buffer.from(value),
+    decryptString: decryptStringMock,
+    describeProtectionGap: () => null
+  })
+  vi.doMock('node:os', async () => {
+    const actual = await vi.importActual<typeof Os>('node:os')
+    return { ...actual, homedir: () => tempHome }
+  })
+  return import('./credential-store')
+}
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), 'orca-github-store-'))
+  decryptStringMock.mockClear()
+})
+
+describe('GitHub credential store', () => {
+  it('persists plaintext metadata and an encrypted secret, then reads them back', async () => {
+    const store = await loadStore()
+    store.saveGitHubCredential({
+      token: 'secret-token',
+      authMethod: 'device-flow',
+      login: 'octocat',
+      name: 'The Octocat',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/1'
+    })
+
+    expect(store.hasStoredGitHubCredential()).toBe(true)
+    expect(store.getStoredGitHubMetadata()).toMatchObject({
+      authMethod: 'device-flow',
+      login: 'octocat',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/1'
+    })
+    expect(store.loadStoredGitHubSecret()).toMatchObject({
+      token: 'secret-token',
+      authMethod: 'device-flow'
+    })
+  })
+
+  // Why skipIf: Windows has no POSIX modes — chmod there is a documented no-op
+  // (see restrictCredentialFileToOwner), so the 0600 assertion is POSIX-only.
+  it.skipIf(process.platform === 'win32')('writes both credential files 0600', async () => {
+    const store = await loadStore()
+    store.saveGitHubCredential({
+      token: 'secret-token',
+      authMethod: 'pat',
+      login: 'octocat',
+      name: null,
+      avatarUrl: null
+    })
+
+    for (const file of ['github-credential.enc', 'github-credential.json']) {
+      expect(statSync(join(tempHome, '.orca', file)).mode & 0o777).toBe(0o600)
+    }
+  })
+
+  it('does not decrypt for metadata/status reads — only on a forced secret load', async () => {
+    const store = await loadStore()
+    store.saveGitHubCredential({
+      token: 'secret-token',
+      authMethod: 'pat',
+      login: 'octocat',
+      name: null,
+      avatarUrl: null
+    })
+
+    // Simulate a fresh session: caches cleared, files still on disk.
+    store._resetGitHubCredentialCache()
+
+    expect(store.getStoredGitHubMetadata()?.login).toBe('octocat')
+    expect(store.hasStoredGitHubCredential()).toBe(true)
+    expect(decryptStringMock).not.toHaveBeenCalled()
+
+    // Without force, the secret stays unread.
+    expect(store.loadStoredGitHubSecret()).toBeNull()
+    expect(decryptStringMock).not.toHaveBeenCalled()
+
+    // Forcing the load decrypts exactly once, then caches.
+    expect(store.loadStoredGitHubSecret({ force: true })).toMatchObject({ token: 'secret-token' })
+    expect(decryptStringMock).toHaveBeenCalledTimes(1)
+    expect(store.loadStoredGitHubSecret()).not.toBeNull()
+    expect(decryptStringMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects hand-edited metadata with an unknown auth method', async () => {
+    const store = await loadStore()
+    store.saveGitHubCredential({
+      token: 'secret-token',
+      authMethod: 'pat',
+      login: 'octocat',
+      name: null,
+      avatarUrl: null
+    })
+    const { writeFileSync } = await import('node:fs')
+    writeFileSync(
+      join(tempHome, '.orca', 'github-credential.json'),
+      JSON.stringify({ version: 1, authMethod: 'oauth-app', login: 'octocat' })
+    )
+    store._resetGitHubCredentialCache()
+
+    expect(store.getStoredGitHubMetadata()).toBeNull()
+    expect(store.hasStoredGitHubCredential()).toBe(false)
+  })
+
+  it('clears both files and in-memory state on disconnect', async () => {
+    const store = await loadStore()
+    store.saveGitHubCredential({
+      token: 'secret-token',
+      authMethod: 'pat',
+      login: 'octocat',
+      name: null,
+      avatarUrl: null
+    })
+
+    store.clearStoredGitHubCredential()
+
+    expect(store.hasStoredGitHubCredential()).toBe(false)
+    expect(store.getStoredGitHubMetadata()).toBeNull()
+    expect(existsSync(join(tempHome, '.orca', 'github-credential.enc'))).toBe(false)
+    expect(existsSync(join(tempHome, '.orca', 'github-credential.json'))).toBe(false)
+  })
+})

--- a/src/main/github-auth/credential-store.ts
+++ b/src/main/github-auth/credential-store.ts
@@ -1,0 +1,201 @@
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import {
+  CredentialDecryptionError,
+  credentialFileHasContent,
+  readStoredCredentialToken,
+  writeCredentialFileAtomic,
+  writeEncryptedCredential
+} from '../integration-credential-file'
+import type { GitHubAccountAuthMethod } from '../../shared/github-account'
+
+// Why: the secret stays encrypted via safeStorage while this metadata stays
+// plaintext, so status reads render the connected account without decrypting —
+// otherwise every panel open would trigger an OS keychain prompt.
+export type GitHubStoredMetadata = {
+  version: 1
+  authMethod: GitHubAccountAuthMethod
+  login: string | null
+  name: string | null
+  avatarUrl: string | null
+  updatedAt: string
+}
+
+export type GitHubStoredSecret = {
+  token: string | null
+  authMethod?: GitHubAccountAuthMethod
+}
+
+export type GitHubCredentialSaveInput = {
+  token: string
+  authMethod: GitHubAccountAuthMethod
+  login: string | null
+  name: string | null
+  avatarUrl: string | null
+}
+
+let cachedMetadata: GitHubStoredMetadata | null = null
+let metadataLoadedFromDisk = false
+let cachedSecret: GitHubStoredSecret | null = null
+let credentialError: string | null = null
+
+function getOrcaDir(): string {
+  return join(homedir(), '.orca')
+}
+
+function getMetadataPath(): string {
+  return join(getOrcaDir(), 'github-credential.json')
+}
+
+function getSecretPath(): string {
+  return join(getOrcaDir(), 'github-credential.enc')
+}
+
+function ensureOrcaDir(): void {
+  const dir = getOrcaDir()
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+}
+
+// Why: hand-edited or truncated JSON must not put a non-string into an auth
+// header, so every field is narrowed rather than trusted.
+function asOptionalString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+function readMetadataFromDisk(): GitHubStoredMetadata | null {
+  const path = getMetadataPath()
+  if (!existsSync(path)) {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<GitHubStoredMetadata>
+    if (parsed.authMethod !== 'device-flow' && parsed.authMethod !== 'pat') {
+      return null
+    }
+    return {
+      version: 1,
+      authMethod: parsed.authMethod,
+      login: asOptionalString(parsed.login),
+      name: asOptionalString(parsed.name),
+      avatarUrl: asOptionalString(parsed.avatarUrl),
+      updatedAt: asOptionalString(parsed.updatedAt) ?? ''
+    }
+  } catch {
+    return null
+  }
+}
+
+export function getStoredGitHubMetadata(): GitHubStoredMetadata | null {
+  if (!metadataLoadedFromDisk) {
+    cachedMetadata = readMetadataFromDisk()
+    metadataLoadedFromDisk = true
+  }
+  return cachedMetadata
+}
+
+// Cheap "is a credential saved?" check: metadata present and a non-empty secret
+// file. Never decrypts, so it is safe on every status poll.
+export function hasStoredGitHubCredential(): boolean {
+  return getStoredGitHubMetadata() !== null && credentialFileHasContent(getSecretPath())
+}
+
+export function getStoredGitHubCredentialError(): string | null {
+  return credentialError
+}
+
+// Cache-first; only touches the keychain when `force` is set and the secret is
+// not already in memory (mirrors Bitbucket's loadStoredBitbucketSecret).
+export function loadStoredGitHubSecret(
+  options: { force?: boolean } = {}
+): GitHubStoredSecret | null {
+  if (cachedSecret !== null) {
+    return cachedSecret
+  }
+  if (!options.force) {
+    return null
+  }
+  const path = getSecretPath()
+  if (!existsSync(path)) {
+    return null
+  }
+  try {
+    const raw = readStoredCredentialToken('GitHub', readFileSync(path))
+    if (!raw) {
+      return null
+    }
+    const parsed = JSON.parse(raw) as Partial<GitHubStoredSecret>
+    cachedSecret = {
+      token: asOptionalString(parsed.token),
+      ...(parsed.authMethod === 'device-flow' || parsed.authMethod === 'pat'
+        ? { authMethod: parsed.authMethod }
+        : {})
+    }
+    credentialError = null
+    return cachedSecret
+  } catch (error) {
+    if (error instanceof CredentialDecryptionError) {
+      credentialError = error.message
+      throw error
+    }
+    return null
+  }
+}
+
+export function saveGitHubCredential(input: GitHubCredentialSaveInput): void {
+  ensureOrcaDir()
+  const secret: GitHubStoredSecret = {
+    token: input.token,
+    authMethod: input.authMethod
+  }
+  writeEncryptedCredential('GitHub', getSecretPath(), JSON.stringify(secret))
+  const metadata: GitHubStoredMetadata = {
+    version: 1,
+    authMethod: input.authMethod,
+    login: input.login,
+    name: input.name,
+    avatarUrl: input.avatarUrl,
+    updatedAt: new Date().toISOString()
+  }
+  writeCredentialFileAtomic(
+    getMetadataPath(),
+    Buffer.from(JSON.stringify(metadata, null, 2), 'utf-8')
+  )
+  cachedMetadata = metadata
+  metadataLoadedFromDisk = true
+  cachedSecret = secret
+  credentialError = null
+}
+
+// Why: swallowing a non-ENOENT unlink failure would clear memory while the
+// files survive, so the credential silently returns on the next launch.
+export function clearStoredGitHubCredential(): void {
+  try {
+    for (const path of [getSecretPath(), getMetadataPath()]) {
+      try {
+        unlinkSync(path)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw error
+        }
+      }
+    }
+  } finally {
+    // Why: on a partial delete the caches must still be dropped, or the session
+    // keeps authenticating with a credential the user just disconnected.
+    cachedMetadata = null
+    metadataLoadedFromDisk = true
+    cachedSecret = null
+    credentialError = null
+  }
+}
+
+/** @internal - tests need a clean in-memory cache between cases. */
+export function _resetGitHubCredentialCache(): void {
+  cachedMetadata = null
+  metadataLoadedFromDisk = false
+  cachedSecret = null
+  credentialError = null
+}

--- a/src/main/github-auth/delete-cloned-repo-files.test.ts
+++ b/src/main/github-auth/delete-cloned-repo-files.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../shared/repo-types'
+import type { Store } from '../persistence'
+
+const { trashItemMock } = vi.hoisted(() => ({ trashItemMock: vi.fn() }))
+
+vi.mock('electron', () => ({
+  shell: { trashItem: trashItemMock }
+}))
+
+import { deleteGitHubClonedRepoFiles } from './delete-cloned-repo-files'
+
+const WORKSPACE_DIR = 'C:\\Users\\dev\\orca\\workspaces'
+const CLONE_PARENT = 'C:\\Users\\dev\\orca\\projects'
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: `${CLONE_PARENT}\\my-repo`,
+    displayName: 'my-repo',
+    badgeColor: '#000000',
+    addedAt: 1,
+    projectHostSetupMethod: 'cloned',
+    ...overrides
+  }
+}
+
+function makeStore(repo: Repo | undefined, settings?: { workspaceDir?: string }): Store {
+  return {
+    getRepo: vi.fn(() => repo),
+    getSettings: vi.fn(() => settings ?? { workspaceDir: WORKSPACE_DIR })
+  } as unknown as Store
+}
+
+beforeEach(() => {
+  trashItemMock.mockReset()
+  trashItemMock.mockResolvedValue(undefined)
+})
+
+describe('deleteGitHubClonedRepoFiles', () => {
+  it('trashes a local clone inside the default clone parent', async () => {
+    const repo = makeRepo()
+    const result = await deleteGitHubClonedRepoFiles(makeStore(repo), repo.id)
+
+    expect(result).toEqual({ ok: true })
+    expect(trashItemMock).toHaveBeenCalledWith(repo.path)
+  })
+
+  it('refuses when the project does not exist', async () => {
+    const result = await deleteGitHubClonedRepoFiles(makeStore(undefined), 'missing')
+
+    expect(result).toEqual({ ok: false, error: 'Project not found.' })
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses repos that were not cloned through Orca', async () => {
+    const repo = makeRepo({ projectHostSetupMethod: 'imported-existing-folder' })
+    const result = await deleteGitHubClonedRepoFiles(makeStore(repo), repo.id)
+
+    expect(result.ok).toBe(false)
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses remote repos even when the path string matches', async () => {
+    const repo = makeRepo({ connectionId: 'ssh:some-host' })
+    const result = await deleteGitHubClonedRepoFiles(makeStore(repo), repo.id)
+
+    expect(result).toEqual({ ok: false, error: 'Only local clones can be cleaned up here.' })
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses paths outside the clone parent', async () => {
+    const repo = makeRepo({ path: 'C:\\Users\\dev\\elsewhere\\my-repo' })
+    const result = await deleteGitHubClonedRepoFiles(makeStore(repo), repo.id)
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Repository files are outside the clone directory.'
+    })
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses clones made under the pre-projects default location', async () => {
+    const repo = makeRepo({ path: 'C:\\Users\\dev\\orca\\my-repo' })
+    const result = await deleteGitHubClonedRepoFiles(makeStore(repo), repo.id)
+
+    expect(result.ok).toBe(false)
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('trashes a clone under a POSIX workspace layout', async () => {
+    const repo = makeRepo({ path: '/Users/dev/orca/projects/my-repo' })
+    const store = makeStore(repo, { workspaceDir: '/Users/dev/orca/workspaces' })
+    const result = await deleteGitHubClonedRepoFiles(store, repo.id)
+
+    expect(result).toEqual({ ok: true })
+    expect(trashItemMock).toHaveBeenCalledWith('/Users/dev/orca/projects/my-repo')
+  })
+
+  it('refuses when no workspace directory is configured', async () => {
+    const repo = makeRepo()
+    const result = await deleteGitHubClonedRepoFiles(makeStore(repo, {}), repo.id)
+
+    expect(result.ok).toBe(false)
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('treats an already-deleted directory as success so the project can detach', async () => {
+    trashItemMock.mockRejectedValue(Object.assign(new Error('gone'), { code: 'ENOENT' }))
+    const repo = makeRepo()
+    const result = await deleteGitHubClonedRepoFiles(makeStore(repo), repo.id)
+
+    expect(result).toEqual({ ok: true })
+  })
+
+  it('surfaces other trash failures and keeps the project', async () => {
+    trashItemMock.mockRejectedValue(new Error('access denied'))
+    const repo = makeRepo()
+    const result = await deleteGitHubClonedRepoFiles(makeStore(repo), repo.id)
+
+    expect(result).toEqual({ ok: false, error: 'access denied' })
+  })
+})

--- a/src/main/github-auth/delete-cloned-repo-files.ts
+++ b/src/main/github-auth/delete-cloned-repo-files.ts
@@ -1,0 +1,42 @@
+import { shell } from 'electron'
+import type { Store } from '../persistence'
+import type { GitHubDeleteClonedRepoFilesResult } from '../../shared/github-account'
+import { getDefaultProjectsCloneParent } from '../../shared/clone-destination'
+import { relativePathInsideRoot } from '../../shared/cross-platform-path'
+import { isENOENT } from '../ipc/filesystem-path-containment'
+
+// Cleanup for the GitHub panel: trash the on-disk clone, then the caller drops
+// the project from Orca. The clone parent is recomputed here from settings —
+// never taken from the renderer — so this handler can only trash directories
+// Orca itself would clone into.
+export async function deleteGitHubClonedRepoFiles(
+  store: Store,
+  repoId: string
+): Promise<GitHubDeleteClonedRepoFilesResult> {
+  const repo = store.getRepo(repoId)
+  if (!repo) {
+    return { ok: false, error: 'Project not found.' }
+  }
+  if (repo.projectHostSetupMethod !== 'cloned') {
+    return { ok: false, error: 'Only repositories cloned through Orca can be cleaned up here.' }
+  }
+  const isLocal =
+    repo.connectionId == null && (!repo.executionHostId || repo.executionHostId === 'local')
+  if (!isLocal) {
+    return { ok: false, error: 'Only local clones can be cleaned up here.' }
+  }
+  const cloneParent = getDefaultProjectsCloneParent(store.getSettings().workspaceDir ?? '')
+  if (!cloneParent || relativePathInsideRoot(cloneParent, repo.path) === null) {
+    return { ok: false, error: 'Repository files are outside the clone directory.' }
+  }
+  try {
+    await shell.trashItem(repo.path)
+  } catch (error) {
+    // Files already gone (e.g. deleted externally): still let the project detach.
+    if (isENOENT(error)) {
+      return { ok: true }
+    }
+    return { ok: false, error: error instanceof Error ? error.message : String(error) }
+  }
+  return { ok: true }
+}

--- a/src/main/github-auth/device-flow.test.ts
+++ b/src/main/github-auth/device-flow.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { pollResultFromTokenPayload } from './device-flow'
+
+describe('pollResultFromTokenPayload', () => {
+  it('maps an access token to authorized', () => {
+    expect(pollResultFromTokenPayload({ access_token: 'tok', token_type: 'bearer' })).toEqual({
+      status: 'authorized',
+      token: 'tok'
+    })
+  })
+
+  it('keeps authorization_pending as pending', () => {
+    expect(pollResultFromTokenPayload({ error: 'authorization_pending' })).toEqual({
+      status: 'pending'
+    })
+  })
+
+  it('carries the requested backoff interval on slow_down', () => {
+    expect(pollResultFromTokenPayload({ error: 'slow_down', interval: 10 })).toEqual({
+      status: 'pending',
+      pollIntervalSeconds: 10
+    })
+  })
+
+  it('maps terminal RFC 8628 errors to user-readable states', () => {
+    expect(pollResultFromTokenPayload({ error: 'access_denied' })).toMatchObject({
+      status: 'error'
+    })
+    expect(pollResultFromTokenPayload({ error: 'expired_token' })).toMatchObject({
+      status: 'error'
+    })
+    expect(pollResultFromTokenPayload({ error: 'incorrect_device_code' })).toMatchObject({
+      status: 'error'
+    })
+  })
+
+  it('falls back to error_description for unknown errors', () => {
+    expect(
+      pollResultFromTokenPayload({ error: 'server_error', error_description: 'boom' })
+    ).toEqual({ status: 'error', error: 'boom' })
+  })
+})

--- a/src/main/github-auth/device-flow.ts
+++ b/src/main/github-auth/device-flow.ts
@@ -1,0 +1,130 @@
+import { getMainHttpClient } from '../network/http-client'
+import type {
+  GitHubDeviceFlowPollResult,
+  GitHubDeviceFlowStart,
+  GitHubDeviceFlowStartResult
+} from '../../shared/github-account'
+import { GITHUB_WEB_BASE_URL } from './github-auth-config'
+
+// GitHub's OAuth device authorization grant — the recommended sign-in for
+// desktop apps: no redirect URI, no client secret, no deep-link handler.
+const DEVICE_CODE_URL = `${GITHUB_WEB_BASE_URL}/login/device/code`
+const ACCESS_TOKEN_URL = `${GITHUB_WEB_BASE_URL}/login/oauth/access_token`
+const DEVICE_FLOW_GRANT = 'urn:ietf:params:oauth:grant-type:device_code'
+// `repo` covers private repository listing and HTTPS clone; `read:user` renders
+// the signed-in account header.
+const DEVICE_FLOW_SCOPE = 'repo read:user'
+
+async function postForm(
+  url: string,
+  body: Record<string, string>,
+  timeoutMs = 15000
+): Promise<{ ok: true; data: Record<string, unknown> } | { ok: false; error: string }> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await getMainHttpClient().fetch(url, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: new URLSearchParams(body).toString()
+    })
+    if (!response.ok) {
+      return { ok: false, error: `GitHub responded with ${response.status}` }
+    }
+    return { ok: true, data: (await response.json()) as Record<string, unknown> }
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function asPositiveNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null
+}
+
+export async function startGitHubDeviceFlow(
+  clientId: string
+): Promise<GitHubDeviceFlowStartResult> {
+  const result = await postForm(DEVICE_CODE_URL, { client_id: clientId, scope: DEVICE_FLOW_SCOPE })
+  if (!result.ok) {
+    return { ok: false, error: `Could not reach GitHub. ${result.error}` }
+  }
+  const deviceCode = asString(result.data.device_code)
+  const userCode = asString(result.data.user_code)
+  const verificationUri = asString(result.data.verification_uri)
+  if (!deviceCode || !userCode || !verificationUri) {
+    return { ok: false, error: 'GitHub returned an incomplete device flow response.' }
+  }
+  const flow: GitHubDeviceFlowStart = {
+    deviceCode,
+    userCode,
+    verificationUri,
+    expiresInSeconds: asPositiveNumber(result.data.expires_in) ?? 900,
+    pollIntervalSeconds: asPositiveNumber(result.data.interval) ?? 5
+  }
+  return { ok: true, flow }
+}
+
+export type GitHubDeviceFlowTokenPoll =
+  | { status: 'pending'; pollIntervalSeconds?: number }
+  | { status: 'authorized'; token: string }
+  | { status: 'error'; error: string }
+
+// Maps the RFC 8628 error vocabulary onto UI states; `slow_down` additionally
+// carries GitHub's requested interval so the poller can back off.
+export function pollResultFromTokenPayload(
+  payload: Record<string, unknown>
+): GitHubDeviceFlowTokenPoll {
+  const token = asString(payload.access_token)
+  if (token) {
+    return { status: 'authorized', token }
+  }
+  switch (asString(payload.error)) {
+    case 'authorization_pending':
+      return { status: 'pending' }
+    case 'slow_down': {
+      const interval = asPositiveNumber(payload.interval)
+      return interval === null
+        ? { status: 'pending' }
+        : { status: 'pending', pollIntervalSeconds: interval }
+    }
+    case 'access_denied':
+      return { status: 'error', error: 'Sign-in was declined on GitHub.' }
+    case 'expired_token':
+      return { status: 'error', error: 'The sign-in code expired. Start over to get a new one.' }
+    case 'incorrect_device_code':
+      return { status: 'error', error: 'The sign-in session is no longer valid. Start over.' }
+    case null:
+    default:
+      return {
+        status: 'error',
+        error: asString(payload.error_description) ?? 'GitHub sign-in failed. Try again.'
+      }
+  }
+}
+
+export async function pollGitHubDeviceFlow(
+  clientId: string,
+  deviceCode: string
+): Promise<GitHubDeviceFlowTokenPoll> {
+  const result = await postForm(ACCESS_TOKEN_URL, {
+    client_id: clientId,
+    device_code: deviceCode,
+    grant_type: DEVICE_FLOW_GRANT
+  })
+  if (!result.ok) {
+    return { status: 'error', error: `Could not reach GitHub. ${result.error}` }
+  }
+  return pollResultFromTokenPayload(result.data)
+}
+
+export type { GitHubDeviceFlowPollResult }

--- a/src/main/github-auth/github-auth-config.ts
+++ b/src/main/github-auth/github-auth-config.ts
@@ -1,0 +1,22 @@
+export const GITHUB_WEB_BASE_URL = 'https://github.com'
+export const GITHUB_API_BASE_URL = 'https://api.github.com'
+
+function envValue(name: string): string | null {
+  const value = process.env[name]?.trim() ?? ''
+  return value.length > 0 ? value : null
+}
+
+// Why an env override: a `ORCA_GITHUB_TOKEN` lets headless/CI hosts authenticate
+// without keychain access, mirroring Bitbucket's environment credential path.
+export function getEnvGitHubToken(): string | null {
+  return envValue('ORCA_GITHUB_TOKEN')
+}
+
+// Why env + no bundled default: Device Flow needs a first-party OAuth app
+// client id (its owner must enable "Device authorization flow"). Orca does not
+// ship one yet; `ORCA_GITHUB_CLIENT_ID` unblocks the flow for anyone who
+// registers their own OAuth app, and the panel hides device sign-in otherwise
+// (PAT sign-in still works).
+export function getGitHubDeviceFlowClientId(): string | null {
+  return envValue('ORCA_GITHUB_CLIENT_ID')
+}

--- a/src/main/github-auth/repo-list.test.ts
+++ b/src/main/github-auth/repo-list.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { mapRepoPayload } from './repo-list'
+
+const basePayload = {
+  id: 123,
+  name: 'orca',
+  full_name: 'acme/orca',
+  description: 'Workspace manager',
+  private: true,
+  fork: false,
+  html_url: 'https://github.com/acme/orca',
+  clone_url: 'https://github.com/acme/orca.git',
+  ssh_url: 'git@github.com:acme/orca.git',
+  default_branch: 'main',
+  language: 'TypeScript',
+  stargazers_count: 42,
+  pushed_at: '2026-08-20T10:00:00Z',
+  owner: { login: 'acme', avatar_url: 'https://avatars.githubusercontent.com/u/1' }
+}
+
+describe('mapRepoPayload', () => {
+  it('maps a full REST payload onto the panel shape', () => {
+    expect(mapRepoPayload(basePayload)).toEqual({
+      id: 123,
+      name: 'orca',
+      fullName: 'acme/orca',
+      description: 'Workspace manager',
+      isPrivate: true,
+      isFork: false,
+      htmlUrl: 'https://github.com/acme/orca',
+      cloneUrl: 'https://github.com/acme/orca.git',
+      sshUrl: 'git@github.com:acme/orca.git',
+      defaultBranch: 'main',
+      language: 'TypeScript',
+      stargazersCount: 42,
+      pushedAt: '2026-08-20T10:00:00Z',
+      ownerLogin: 'acme',
+      ownerAvatarUrl: 'https://avatars.githubusercontent.com/u/1'
+    })
+  })
+
+  it('drops entries too incomplete to clone or display', () => {
+    expect(mapRepoPayload({ ...basePayload, clone_url: null })).toBeNull()
+    expect(mapRepoPayload({ ...basePayload, full_name: 42 })).toBeNull()
+    expect(mapRepoPayload({ ...basePayload, owner: null })).toBeNull()
+    expect(mapRepoPayload({ ...basePayload, id: 'x' })).toBeNull()
+  })
+
+  it('defaults optional fields defensively', () => {
+    expect(
+      mapRepoPayload({
+        ...basePayload,
+        description: null,
+        language: null,
+        stargazers_count: undefined,
+        pushed_at: null,
+        private: undefined,
+        fork: undefined,
+        html_url: undefined,
+        ssh_url: undefined,
+        default_branch: undefined,
+        owner: { login: 'acme' }
+      })
+    ).toMatchObject({
+      description: null,
+      language: null,
+      stargazersCount: 0,
+      pushedAt: null,
+      isPrivate: false,
+      isFork: false,
+      htmlUrl: 'https://github.com/acme/orca',
+      sshUrl: 'git@github.com:acme/orca.git',
+      defaultBranch: 'main',
+      ownerAvatarUrl: null
+    })
+  })
+})

--- a/src/main/github-auth/repo-list.ts
+++ b/src/main/github-auth/repo-list.ts
@@ -1,0 +1,86 @@
+import type { GitHubAccountRepo } from '../../shared/github-account'
+import { githubApiGet, type GitHubApiResult } from './api-request'
+
+// Why a cap: `/user/repos` paginates at 100; three pages cover the recently
+// active set the panel is for, without unbounded fan-out on huge accounts.
+const MAX_REPO_PAGES = 3
+const PAGE_SIZE = 100
+
+type RepoPayload = {
+  id?: unknown
+  name?: unknown
+  full_name?: unknown
+  description?: unknown
+  private?: unknown
+  fork?: unknown
+  html_url?: unknown
+  clone_url?: unknown
+  ssh_url?: unknown
+  default_branch?: unknown
+  language?: unknown
+  stargazers_count?: unknown
+  pushed_at?: unknown
+  owner?: { login?: unknown; avatar_url?: unknown } | null
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+// Returns null for entries too incomplete to clone or display.
+export function mapRepoPayload(payload: RepoPayload): GitHubAccountRepo | null {
+  const id = typeof payload.id === 'number' ? payload.id : null
+  const name = asString(payload.name)
+  const fullName = asString(payload.full_name)
+  const cloneUrl = asString(payload.clone_url)
+  const ownerLogin = asString(payload.owner?.login)
+  if (id === null || !name || !fullName || !cloneUrl || !ownerLogin) {
+    return null
+  }
+  return {
+    id,
+    name,
+    fullName,
+    description: asString(payload.description),
+    isPrivate: payload.private === true,
+    isFork: payload.fork === true,
+    htmlUrl: asString(payload.html_url) ?? `https://github.com/${fullName}`,
+    cloneUrl,
+    sshUrl: asString(payload.ssh_url) ?? `git@github.com:${fullName}.git`,
+    defaultBranch: asString(payload.default_branch) ?? 'main',
+    language: asString(payload.language),
+    stargazersCount: typeof payload.stargazers_count === 'number' ? payload.stargazers_count : 0,
+    pushedAt: asString(payload.pushed_at),
+    ownerLogin,
+    ownerAvatarUrl: asString(payload.owner?.avatar_url)
+  }
+}
+
+// `sort=pushed` keeps the most recently active repositories first — the panel's
+// primary ordering — and the affiliation filter surfaces private repos the user
+// owns or can collaborate on.
+export async function listAccessibleGitHubRepos(
+  token: string
+): Promise<GitHubApiResult<GitHubAccountRepo[]>> {
+  const repos: GitHubAccountRepo[] = []
+  for (let page = 1; page <= MAX_REPO_PAGES; page += 1) {
+    const result = await githubApiGet<RepoPayload[]>(
+      token,
+      `/user/repos?per_page=${PAGE_SIZE}&page=${page}&sort=pushed&direction=desc&affiliation=owner,collaborator,organization_member`
+    )
+    if (!result.ok) {
+      return result
+    }
+    const entries = Array.isArray(result.data) ? result.data : []
+    for (const entry of entries) {
+      const mapped = mapRepoPayload(entry)
+      if (mapped) {
+        repos.push(mapped)
+      }
+    }
+    if (entries.length < PAGE_SIZE) {
+      break
+    }
+  }
+  return { ok: true, data: repos }
+}

--- a/src/main/github-auth/viewer.ts
+++ b/src/main/github-auth/viewer.ts
@@ -1,0 +1,36 @@
+import { githubApiGet, type GitHubApiResult } from './api-request'
+
+export type GitHubViewer = {
+  login: string | null
+  name: string | null
+  avatarUrl: string | null
+}
+
+type ViewerPayload = {
+  login?: unknown
+  name?: unknown
+  avatar_url?: unknown
+}
+
+function asOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+export function viewerFromPayload(payload: ViewerPayload): GitHubViewer {
+  return {
+    login: asOptionalString(payload.login),
+    name: asOptionalString(payload.name),
+    avatarUrl: asOptionalString(payload.avatar_url)
+  }
+}
+
+// Verifying against `/user` before persisting keeps the stored "connected
+// account" honest and lets the sign-in UI reject a dead token inline.
+export function fetchGitHubViewer(
+  token: string,
+  timeoutMs = 8000
+): Promise<GitHubApiResult<GitHubViewer>> {
+  return githubApiGet<ViewerPayload>(token, '/user', timeoutMs).then((result) =>
+    result.ok ? { ok: true, data: viewerFromPayload(result.data) } : result
+  )
+}

--- a/src/main/ipc/github-auth.ts
+++ b/src/main/ipc/github-auth.ts
@@ -1,0 +1,121 @@
+import type { BrowserWindow } from 'electron'
+import { ipcMain } from 'electron'
+import type { Store } from '../persistence'
+import type {
+  GitHubAccountStatus,
+  GitHubCloneRepoArgs,
+  GitHubCloneRepoResult,
+  GitHubConnectTokenResult,
+  GitHubDeleteClonedRepoFilesResult,
+  GitHubDeviceFlowPollResult,
+  GitHubDeviceFlowStartResult,
+  GitHubRepoListResult
+} from '../../shared/github-account'
+import {
+  connectGitHubWithToken,
+  disconnectGitHub,
+  getGitHubAccountStatus,
+  listGitHubAccountRepos,
+  pollGitHubAccountDeviceFlow,
+  startGitHubAccountDeviceFlow
+} from '../github-auth/connection'
+import { cloneGitHubAccountRepo } from '../github-auth/clone-repo'
+import { deleteGitHubClonedRepoFiles } from '../github-auth/delete-cloned-repo-files'
+import { _resetPreflightCache } from './preflight'
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+function normalizeCloneArgs(value: unknown): GitHubCloneRepoArgs | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const raw = value as Record<string, unknown>
+  const fullName = asString(raw.fullName)
+  const cloneUrl = asString(raw.cloneUrl)
+  const destination = asString(raw.destination)
+  if (!fullName || !cloneUrl || !destination) {
+    return null
+  }
+  return { fullName, cloneUrl, isPrivate: raw.isPrivate === true, destination }
+}
+
+// Auth-only handlers; registered once from register-core-handlers.
+export function registerGitHubAuthHandlers(): void {
+  ipcMain.handle('githubAuth:status', async (): Promise<GitHubAccountStatus> => {
+    return getGitHubAccountStatus()
+  })
+
+  ipcMain.handle(
+    'githubAuth:connectWithToken',
+    async (_event, args: unknown): Promise<GitHubConnectTokenResult> => {
+      const token = asString((args as Record<string, unknown> | null)?.token)
+      if (!token) {
+        return { ok: false, error: 'Enter a personal access token.' }
+      }
+      const result = await connectGitHubWithToken(token, 'pat')
+      if (result.ok) {
+        // Preflight caches source-control status per session; reset so the card
+        // reflects the new connection without a relaunch.
+        _resetPreflightCache()
+      }
+      return result
+    }
+  )
+
+  ipcMain.handle('githubAuth:startDeviceFlow', async (): Promise<GitHubDeviceFlowStartResult> => {
+    return startGitHubAccountDeviceFlow()
+  })
+
+  ipcMain.handle(
+    'githubAuth:pollDeviceFlow',
+    async (_event, args: unknown): Promise<GitHubDeviceFlowPollResult> => {
+      const deviceCode = asString((args as Record<string, unknown> | null)?.deviceCode)
+      if (!deviceCode) {
+        return { status: 'error', error: 'The sign-in session is no longer valid. Start over.' }
+      }
+      const result = await pollGitHubAccountDeviceFlow(deviceCode)
+      if (result.status === 'connected') {
+        _resetPreflightCache()
+      }
+      return result
+    }
+  )
+
+  ipcMain.handle('githubAuth:disconnect', async (): Promise<void> => {
+    disconnectGitHub()
+    _resetPreflightCache()
+  })
+
+  ipcMain.handle('githubAuth:listRepos', async (): Promise<GitHubRepoListResult> => {
+    return listGitHubAccountRepos()
+  })
+}
+
+// Clone needs the live main window for progress events and the repo store, so
+// it registers alongside the other repo handlers (re-registered on macOS
+// re-activation — callers must removeHandler first, as registerRepoHandlers does).
+export function registerGitHubAccountCloneHandlers(mainWindow: BrowserWindow, store: Store): void {
+  ipcMain.handle(
+    'githubAuth:cloneRepo',
+    async (_event, args: unknown): Promise<GitHubCloneRepoResult> => {
+      const input = normalizeCloneArgs(args)
+      if (!input) {
+        return { ok: false, error: 'Invalid GitHub clone request.' }
+      }
+      return cloneGitHubAccountRepo(mainWindow, store, input)
+    }
+  )
+
+  ipcMain.handle(
+    'githubAuth:deleteClonedRepoFiles',
+    async (_event, args: unknown): Promise<GitHubDeleteClonedRepoFilesResult> => {
+      const repoId = asString((args as Record<string, unknown> | null)?.repoId)
+      if (!repoId) {
+        return { ok: false, error: 'Invalid cleanup request.' }
+      }
+      return deleteGitHubClonedRepoFiles(store, repoId)
+    }
+  )
+}

--- a/src/main/ipc/register-core-handlers/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers/register-core-handlers.ts
@@ -15,6 +15,7 @@ import { registerHostedReviewHandlers } from '../hosted-review'
 import { registerLinearHandlers } from '../linear'
 import { registerJiraHandlers } from '../jira'
 import { registerBitbucketHandlers } from '../bitbucket'
+import { registerGitHubAuthHandlers } from '../github-auth'
 import { registerFeedbackHandlers } from '../feedback'
 import { registerCrashReportingHandlers } from '../crash-reporting'
 import { registerExportHandlers } from '../export'
@@ -155,6 +156,7 @@ export function registerCoreHandlers(
   registerLinearHandlers()
   registerJiraHandlers()
   registerBitbucketHandlers()
+  registerGitHubAuthHandlers()
   registerFeedbackHandlers()
   if (crashReports) {
     registerCrashReportingHandlers(crashReports)

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -11,6 +11,7 @@ import { registerRepoUpdateHandler } from './repos/repo-update-handler'
 import { registerSparsePresetHandlers } from './repos/sparse-preset-handlers'
 import { registerRepoFolderPickerHandlers } from './repos/repo-folder-picker-handlers'
 import { registerRepoCloneHandlers } from './repos/repo-clone-lifecycle'
+import { registerGitHubAccountCloneHandlers } from './github-auth'
 import { registerRepoGitUsernameHandler } from './repos/repo-git-username-handler'
 import { registerBaseRefQueryHandlers } from './repos/base-ref-query-handlers'
 
@@ -50,6 +51,8 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
   ipcMain.removeHandler('repos:clone')
   ipcMain.removeHandler('repos:cloneAbort')
   ipcMain.removeHandler('repos:cloneRemote')
+  ipcMain.removeHandler('githubAuth:cloneRepo')
+  ipcMain.removeHandler('githubAuth:deleteClonedRepoFiles')
   ipcMain.removeHandler('repos:isGitAvailable')
   ipcMain.removeHandler('repos:getDefaultCreateProjectParent')
   ipcMain.removeHandler('repos:getGitUsername')
@@ -73,6 +76,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
   registerSparsePresetHandlers(mainWindow, store)
   registerRepoFolderPickerHandlers(mainWindow)
   registerRepoCloneHandlers(mainWindow, store)
+  registerGitHubAccountCloneHandlers(mainWindow, store)
   registerRepoGitUsernameHandler(store)
   registerBaseRefQueryHandlers(store)
 }

--- a/src/main/ipc/repos/repo-clone-lifecycle.ts
+++ b/src/main/ipc/repos/repo-clone-lifecycle.ts
@@ -96,6 +96,190 @@ function settleCloneAbortCleanup(metadata: ActiveCloneMetadata): void {
   metadata.resolvePendingAbortCleanup = null
 }
 
+export type LocalCloneOptions = {
+  // Why: private GitHub clones authenticate with a one-shot
+  // `-c http.https://github.com/.extraheader=…` flag, so the token never lands
+  // in the remote URL, .git/config, or stderr's redacted-URL messages.
+  extraGitConfig?: string[]
+}
+
+// Why exported: the GitHub account panel's clone IPC reuses this full flow
+// (path lock, progress, abort, folder→git upgrade, store insert) so the two
+// entry points can never drift apart.
+export async function cloneLocalRepoIntoDestination(
+  mainWindow: BrowserWindow,
+  store: Store,
+  args: { url: string; destination: string },
+  options?: LocalCloneOptions
+): Promise<Repo> {
+  // Why: derive the repo folder name from the URL's last segment, matching default git clone behavior.
+  const clonePath = deriveValidatedClonePath(args)
+  const clonePathKey = getClonePathComparisonKey(clonePath)
+  return runWithClonePathLock(clonePathKey, async () => {
+    await pendingAbortCleanupByPath.get(clonePathKey)
+    const existingAfterPendingClone = store
+      .getRepos()
+      .find((r) => getClonePathComparisonKey(r.path) === clonePathKey)
+    if (existingAfterPendingClone && !isFolderRepo(existingAfterPendingClone)) {
+      // Why: clone_url always produces a git repo.
+      emitRepoAdded('clone_url', true, true)
+      return existingAfterPendingClone
+    }
+    // Why: gitSpawn cwd is args.destination, so it must exist before spawn (fresh installs may lack the defaulted parent).
+    await mkdir(args.destination, { recursive: true })
+    const claimedTarget = await claimCloneTarget(clonePath)
+
+    // Why: spawn (not execFile) avoids the maxBuffer limit — clone progress on stderr can exceed Node's 1 MB default.
+    // Why: --progress forces git to emit progress even when stderr isn't a TTY.
+    const cloneMetadataRef: { current: ActiveCloneMetadata | null } = { current: null }
+    let proc: Awaited<ReturnType<typeof gitSpawnAfterWindowsEnvironmentReady>>
+    const pendingController = new AbortController()
+    pendingLocalCloneControllers.add(pendingController)
+    const extraConfigArgs = (options?.extraGitConfig ?? []).flatMap((entry) => ['-c', entry])
+    try {
+      // Why: use the parent destination as cwd so the runner detects a WSL path and routes through wsl.exe.
+      // Why: '--' isolates the URL so a malicious URL can't be read as git flags (command injection).
+      proc = await gitSpawnAfterWindowsEnvironmentReady(
+        [...extraConfigArgs, 'clone', '--progress', '--', args.url, clonePath],
+        {
+          cwd: args.destination,
+          // Why: without this, an auth-needing clone pops Git Credential Manager's OAuth window on Windows, unclosable in a restricted env (issue #7652).
+          env: nonInteractiveGitEnv(),
+          signal: pendingController.signal,
+          stdio: ['ignore', 'ignore', 'pipe']
+        }
+      )
+    } catch (err) {
+      await cleanupClaimedCloneTarget(clonePath, claimedTarget)
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(`Clone failed: ${message}`)
+    } finally {
+      pendingLocalCloneControllers.delete(pendingController)
+    }
+    await new Promise<void>((resolve, reject) => {
+      const generation = nextCloneGeneration++
+      latestCloneGenerationByPath.set(clonePathKey, generation)
+      const metadata: ActiveCloneMetadata = {
+        path: clonePath,
+        pathKey: clonePathKey,
+        claimedTarget,
+        process: proc,
+        abortRequested: false,
+        generation,
+        pendingAbortCleanup: null,
+        resolvePendingAbortCleanup: null
+      }
+      cloneMetadataRef.current = metadata
+      activeClone = metadata
+
+      let stderrTail = ''
+      let settled = false
+      proc.stderr!.on('data', (chunk: Buffer) => {
+        const text = chunk.toString()
+        stderrTail = (stderrTail + text).slice(-4096)
+
+        // Why: git progress lines use \r to overwrite in-place; parse fragments the same as SSH clone.
+        emitCloneProgressFromText(mainWindow, text)
+      })
+
+      const finishClone = async (
+        code: number | null,
+        signal: NodeJS.Signals | null,
+        err?: Error
+      ) => {
+        if (settled) {
+          return
+        }
+        settled = true
+        // Why: only null activeClone if it still points to this proc; abort-and-retry may have reassigned it, stranding the new clone.
+        if (activeClone?.process === proc) {
+          activeClone = null
+        }
+
+        const cloneSucceeded = !err && code === 0 && !signal
+        if (!cloneSucceeded) {
+          // Why: only the process that created this target may remove it, and only after git reports failure.
+          await cleanupOwnedCloneTarget(metadata)
+        }
+        if (metadata.abortRequested && !cloneSucceeded) {
+          settleCloneAbortCleanup(metadata)
+        }
+        if (latestCloneGenerationByPath.get(metadata.pathKey) === metadata.generation) {
+          latestCloneGenerationByPath.delete(metadata.pathKey)
+        }
+
+        if (err) {
+          reject(new Error(`Clone failed: ${err.message}`))
+        } else if (signal === 'SIGTERM') {
+          reject(new Error('Clone aborted'))
+        } else if (code === 0) {
+          resolve()
+        } else {
+          reject(new Error(`Clone failed: ${getGitCloneFailureMessage(stderrTail, { clonePath })}`))
+        }
+      }
+
+      proc.on('error', (err) => {
+        void finishClone(null, null, err)
+      })
+
+      proc.on('close', (code, signal) => {
+        void finishClone(code, signal)
+      })
+    })
+
+    try {
+      // Why: check after clone (path didn't exist before); reuse+upgrade a folder repo clone landed into instead of duplicating.
+      const existing = store
+        .getRepos()
+        .find((r) => getClonePathComparisonKey(r.path) === clonePathKey)
+      if (existing) {
+        if (isFolderRepo(existing)) {
+          const updated = store.updateRepo(existing.id, {
+            kind: 'git',
+            projectHostSetupMethod: 'cloned'
+          })
+          if (updated) {
+            await prepareLocalWorktreeRootForRepo(store, updated)
+            invalidateAuthorizedRootsCache()
+            notifyReposChanged(mainWindow)
+            // Why: folder→git upgrade is a real new git repo provisioning event.
+            emitRepoAdded('clone_url', false, true)
+            return updated
+          }
+        }
+        emitRepoAdded('clone_url', true, true)
+        return existing
+      }
+
+      const detected = await detectRepoIconAndUpstream({ repoPath: clonePath, kind: 'git' })
+      const repo: Repo = {
+        id: randomUUID(),
+        path: clonePath,
+        displayName: getRepoName(clonePath),
+        badgeColor: DEFAULT_REPO_BADGE_COLOR,
+        ...detected,
+        addedAt: Date.now(),
+        kind: 'git',
+        externalWorktreeVisibilityLegacy: false,
+        projectHostSetupMethod: 'cloned'
+      }
+
+      store.addRepo(repo)
+      await prepareLocalWorktreeRootForRepo(store, repo)
+      invalidateAuthorizedRootsCache()
+      notifyReposChanged(mainWindow)
+      emitRepoAdded('clone_url', false, true)
+      return repo
+    } finally {
+      const metadata = cloneMetadataRef.current
+      if (metadata?.abortRequested) {
+        settleCloneAbortCleanup(metadata)
+      }
+    }
+  })
+}
+
 export function registerRepoCloneHandlers(mainWindow: BrowserWindow, store: Store): void {
   ipcMain.handle('repos:cloneAbort', async () => {
     for (const controller of pendingLocalCloneControllers) {
@@ -114,175 +298,8 @@ export function registerRepoCloneHandlers(mainWindow: BrowserWindow, store: Stor
 
   ipcMain.handle(
     'repos:clone',
-    async (_event, args: { url: string; destination: string }): Promise<Repo> => {
-      // Why: derive the repo folder name from the URL's last segment, matching default git clone behavior.
-      const clonePath = deriveValidatedClonePath(args)
-      const clonePathKey = getClonePathComparisonKey(clonePath)
-      return runWithClonePathLock(clonePathKey, async () => {
-        await pendingAbortCleanupByPath.get(clonePathKey)
-        const existingAfterPendingClone = store
-          .getRepos()
-          .find((r) => getClonePathComparisonKey(r.path) === clonePathKey)
-        if (existingAfterPendingClone && !isFolderRepo(existingAfterPendingClone)) {
-          // Why: clone_url always produces a git repo.
-          emitRepoAdded('clone_url', true, true)
-          return existingAfterPendingClone
-        }
-        // Why: gitSpawn cwd is args.destination, so it must exist before spawn (fresh installs may lack the defaulted parent).
-        await mkdir(args.destination, { recursive: true })
-        const claimedTarget = await claimCloneTarget(clonePath)
-
-        // Why: spawn (not execFile) avoids the maxBuffer limit — clone progress on stderr can exceed Node's 1 MB default.
-        // Why: --progress forces git to emit progress even when stderr isn't a TTY.
-        const cloneMetadataRef: { current: ActiveCloneMetadata | null } = { current: null }
-        let proc: Awaited<ReturnType<typeof gitSpawnAfterWindowsEnvironmentReady>>
-        const pendingController = new AbortController()
-        pendingLocalCloneControllers.add(pendingController)
-        try {
-          // Why: use the parent destination as cwd so the runner detects a WSL path and routes through wsl.exe.
-          // Why: '--' isolates the URL so a malicious URL can't be read as git flags (command injection).
-          proc = await gitSpawnAfterWindowsEnvironmentReady(
-            ['clone', '--progress', '--', args.url, clonePath],
-            {
-              cwd: args.destination,
-              // Why: without this, an auth-needing clone pops Git Credential Manager's OAuth window on Windows, unclosable in a restricted env (issue #7652).
-              env: nonInteractiveGitEnv(),
-              signal: pendingController.signal,
-              stdio: ['ignore', 'ignore', 'pipe']
-            }
-          )
-        } catch (err) {
-          await cleanupClaimedCloneTarget(clonePath, claimedTarget)
-          const message = err instanceof Error ? err.message : String(err)
-          throw new Error(`Clone failed: ${message}`)
-        } finally {
-          pendingLocalCloneControllers.delete(pendingController)
-        }
-        await new Promise<void>((resolve, reject) => {
-          const generation = nextCloneGeneration++
-          latestCloneGenerationByPath.set(clonePathKey, generation)
-          const metadata: ActiveCloneMetadata = {
-            path: clonePath,
-            pathKey: clonePathKey,
-            claimedTarget,
-            process: proc,
-            abortRequested: false,
-            generation,
-            pendingAbortCleanup: null,
-            resolvePendingAbortCleanup: null
-          }
-          cloneMetadataRef.current = metadata
-          activeClone = metadata
-
-          let stderrTail = ''
-          let settled = false
-          proc.stderr!.on('data', (chunk: Buffer) => {
-            const text = chunk.toString()
-            stderrTail = (stderrTail + text).slice(-4096)
-
-            // Why: git progress lines use \r to overwrite in-place; parse fragments the same as SSH clone.
-            emitCloneProgressFromText(mainWindow, text)
-          })
-
-          const finishClone = async (
-            code: number | null,
-            signal: NodeJS.Signals | null,
-            err?: Error
-          ) => {
-            if (settled) {
-              return
-            }
-            settled = true
-            // Why: only null activeClone if it still points to this proc; abort-and-retry may have reassigned it, stranding the new clone.
-            if (activeClone?.process === proc) {
-              activeClone = null
-            }
-
-            const cloneSucceeded = !err && code === 0 && !signal
-            if (!cloneSucceeded) {
-              // Why: only the process that created this target may remove it, and only after git reports failure.
-              await cleanupOwnedCloneTarget(metadata)
-            }
-            if (metadata.abortRequested && !cloneSucceeded) {
-              settleCloneAbortCleanup(metadata)
-            }
-            if (latestCloneGenerationByPath.get(metadata.pathKey) === metadata.generation) {
-              latestCloneGenerationByPath.delete(metadata.pathKey)
-            }
-
-            if (err) {
-              reject(new Error(`Clone failed: ${err.message}`))
-            } else if (signal === 'SIGTERM') {
-              reject(new Error('Clone aborted'))
-            } else if (code === 0) {
-              resolve()
-            } else {
-              reject(
-                new Error(`Clone failed: ${getGitCloneFailureMessage(stderrTail, { clonePath })}`)
-              )
-            }
-          }
-
-          proc.on('error', (err) => {
-            void finishClone(null, null, err)
-          })
-
-          proc.on('close', (code, signal) => {
-            void finishClone(code, signal)
-          })
-        })
-
-        try {
-          // Why: check after clone (path didn't exist before); reuse+upgrade a folder repo clone landed into instead of duplicating.
-          const existing = store
-            .getRepos()
-            .find((r) => getClonePathComparisonKey(r.path) === clonePathKey)
-          if (existing) {
-            if (isFolderRepo(existing)) {
-              const updated = store.updateRepo(existing.id, {
-                kind: 'git',
-                projectHostSetupMethod: 'cloned'
-              })
-              if (updated) {
-                await prepareLocalWorktreeRootForRepo(store, updated)
-                invalidateAuthorizedRootsCache()
-                notifyReposChanged(mainWindow)
-                // Why: folder→git upgrade is a real new git repo provisioning event.
-                emitRepoAdded('clone_url', false, true)
-                return updated
-              }
-            }
-            emitRepoAdded('clone_url', true, true)
-            return existing
-          }
-
-          const detected = await detectRepoIconAndUpstream({ repoPath: clonePath, kind: 'git' })
-          const repo: Repo = {
-            id: randomUUID(),
-            path: clonePath,
-            displayName: getRepoName(clonePath),
-            badgeColor: DEFAULT_REPO_BADGE_COLOR,
-            ...detected,
-            addedAt: Date.now(),
-            kind: 'git',
-            externalWorktreeVisibilityLegacy: false,
-            projectHostSetupMethod: 'cloned'
-          }
-
-          store.addRepo(repo)
-          await prepareLocalWorktreeRootForRepo(store, repo)
-          invalidateAuthorizedRootsCache()
-          notifyReposChanged(mainWindow)
-          emitRepoAdded('clone_url', false, true)
-          return repo
-        } finally {
-          const metadata = cloneMetadataRef.current
-          if (metadata?.abortRequested) {
-            settleCloneAbortCleanup(metadata)
-          }
-        }
-      })
-    }
+    async (_event, args: { url: string; destination: string }): Promise<Repo> =>
+      cloneLocalRepoIntoDestination(mainWindow, store, args)
   )
 
   ipcMain.handle(

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -97,7 +97,8 @@ const TopLevelViewSchema = z.enum([
   'space',
   'skills',
   'artifacts',
-  'mobile'
+  'mobile',
+  'github'
 ])
 const UiUpdateFields = z
   .object({

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -32,6 +32,7 @@ import type { GithubPullRequestApi } from './api/github-pull-request-api'
 import type { GithubWorkItemApi } from './api/github-work-item-api'
 import type { GitLabApi } from './api/gitlab-api'
 import type { BitbucketApi, HostedReviewApi } from './api/hosted-review-api'
+import type { GitHubAuthApi } from './api/github-auth-api'
 import type { JiraApi } from './api/jira-api'
 import type { LinearApi } from './api/linear-api'
 import type { MobileApi } from './api/mobile-api'
@@ -88,6 +89,7 @@ export type PreloadApi = {
   hostedReview: HostedReviewApi
   gl: GitLabApi
   bitbucket: BitbucketApi
+  githubAuth: GitHubAuthApi
   linear: LinearApi
   jira: JiraApi
   starNag: StarNagApi

--- a/src/preload/api/github-auth-api.ts
+++ b/src/preload/api/github-auth-api.ts
@@ -1,0 +1,21 @@
+import type {
+  GitHubAccountStatus,
+  GitHubCloneRepoArgs,
+  GitHubCloneRepoResult,
+  GitHubConnectTokenResult,
+  GitHubDeleteClonedRepoFilesResult,
+  GitHubDeviceFlowPollResult,
+  GitHubDeviceFlowStartResult,
+  GitHubRepoListResult
+} from '../../shared/github-account'
+
+export type GitHubAuthApi = {
+  status: () => Promise<GitHubAccountStatus>
+  connectWithToken: (args: { token: string }) => Promise<GitHubConnectTokenResult>
+  startDeviceFlow: () => Promise<GitHubDeviceFlowStartResult>
+  pollDeviceFlow: (args: { deviceCode: string }) => Promise<GitHubDeviceFlowPollResult>
+  disconnect: () => Promise<void>
+  listRepos: () => Promise<GitHubRepoListResult>
+  cloneRepo: (args: GitHubCloneRepoArgs) => Promise<GitHubCloneRepoResult>
+  deleteClonedRepoFiles: (args: { repoId: string }) => Promise<GitHubDeleteClonedRepoFilesResult>
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1872,6 +1872,28 @@ const api = {
     status: (): Promise<unknown> => ipcRenderer.invoke('bitbucket:status')
   },
 
+  githubAuth: {
+    status: (): Promise<unknown> => ipcRenderer.invoke('githubAuth:status'),
+
+    connectWithToken: (args: { token: string }): Promise<unknown> =>
+      ipcRenderer.invoke('githubAuth:connectWithToken', args),
+
+    startDeviceFlow: (): Promise<unknown> => ipcRenderer.invoke('githubAuth:startDeviceFlow'),
+
+    pollDeviceFlow: (args: { deviceCode: string }): Promise<unknown> =>
+      ipcRenderer.invoke('githubAuth:pollDeviceFlow', args),
+
+    disconnect: (): Promise<void> => ipcRenderer.invoke('githubAuth:disconnect'),
+
+    listRepos: (): Promise<unknown> => ipcRenderer.invoke('githubAuth:listRepos'),
+
+    cloneRepo: (args: unknown): Promise<unknown> =>
+      ipcRenderer.invoke('githubAuth:cloneRepo', args),
+
+    deleteClonedRepoFiles: (args: unknown): Promise<unknown> =>
+      ipcRenderer.invoke('githubAuth:deleteClonedRepoFiles', args)
+  },
+
   linear: {
     connect: (args: {
       apiKey: string

--- a/src/renderer/src/app-shell/AppWorkspaceShell.tsx
+++ b/src/renderer/src/app-shell/AppWorkspaceShell.tsx
@@ -22,6 +22,7 @@ const ActivityPrototypePage = lazy(() => import('../components/activity/Activity
 const Settings = lazy(() => import('../components/settings/Settings'))
 const SkillsPage = lazy(() => import('../components/skills/SkillsPage'))
 const ArtifactsPage = lazy(() => import('../components/artifacts/ArtifactsPage'))
+const GitHubPage = lazy(() => import('../components/github-panel/GitHubPage'))
 const WorkspaceSpacePage = lazy(() => import('../components/workspace-space/WorkspaceSpacePage'))
 const MobilePage = lazy(() => import('../components/mobile/MobilePage'))
 const Terminal = lazy(() => import('../components/Terminal'))
@@ -71,6 +72,7 @@ function ActivePage({ layout }: { layout: AppChromeLayout }): React.JSX.Element 
       {activeView === 'settings' ? <Settings /> : null}
       {activeView === 'skills' ? <SkillsPage /> : null}
       {activeView === 'artifacts' ? <ArtifactsPage /> : null}
+      {activeView === 'github' ? <GitHubPage /> : null}
       {activeView === 'tasks' ? <TaskPage /> : null}
       {activeView === 'automations' ? <AutomationsPage /> : null}
       {activeView === 'activity' ? <ActivityPrototypePage /> : null}
@@ -155,10 +157,11 @@ export function AppWorkspaceShell(props: {
               )
             ) : null}
             <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
-              {/* Why: automations/artifacts own their page headers; the stacked titlebar would be an empty 36px stripe. */}
+              {/* Why: automations/artifacts/github own their page headers; the stacked titlebar would be an empty 36px stripe. */}
               {layout.stackedSidebarOpen &&
               layout.activeView !== 'automations' &&
-              layout.activeView !== 'artifacts' ? (
+              layout.activeView !== 'artifacts' &&
+              layout.activeView !== 'github' ? (
                 <div className="titlebar">{titlebarMainStrip}</div>
               ) : null}
               <div className="relative flex flex-1 min-w-0 min-h-0 overflow-hidden">

--- a/src/renderer/src/components/github-panel/GitHubPage.tsx
+++ b/src/renderer/src/components/github-panel/GitHubPage.tsx
@@ -1,0 +1,96 @@
+import { useEffect } from 'react'
+import { Loader2 } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+import { useGitHubAccountStatus } from './useGitHubAccountStatus'
+import { GitHubSignInPanel } from './GitHubSignInPanel'
+import { GitHubRepoList } from './GitHubRepoList'
+
+export default function GitHubPage(): React.JSX.Element {
+  const closePage = useAppStore((state) => state.closeGithubPage)
+  const { status, loading, refresh, disconnect } = useGitHubAccountStatus()
+  const configured = status?.configured === true
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent): void {
+      if (event.key !== 'Escape' || event.defaultPrevented) {
+        return
+      }
+      const target = event.target
+      if (!(target instanceof HTMLElement)) {
+        return
+      }
+      if (target.dataset.escapeClearsValue === 'true') {
+        return
+      }
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLSelectElement ||
+        target.isContentEditable
+      ) {
+        event.preventDefault()
+        target.blur()
+        return
+      }
+      event.preventDefault()
+      closePage()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [closePage])
+
+  return (
+    <main className="relative flex h-full min-h-0 flex-1 flex-col bg-background pt-5 text-foreground md:pt-6">
+      <header
+        className="flex shrink-0 items-center gap-2 px-3 pb-3 md:px-5"
+        // Why: no stacked center titlebar on this page; keep the title clear of Windows/Linux window controls.
+        style={
+          {
+            paddingRight: 'max(0.75rem, var(--window-controls-width, 0px))'
+          } as React.CSSProperties
+        }
+      >
+        <h1 className="flex-1 truncate text-base font-semibold leading-8">
+          {translate('auto.components.github-panel.GitHubPage.title', 'My GitHub')}
+        </h1>
+        {configured ? (
+          <div className="flex items-center gap-2">
+            {status?.avatarUrl ? (
+              <img src={status.avatarUrl} alt="" className="size-5 rounded-full" />
+            ) : null}
+            <span className="text-[12px] text-muted-foreground">
+              {status?.login ??
+                (status?.source === 'environment'
+                  ? translate(
+                      'auto.components.github-panel.GitHubPage.envAccount',
+                      'via environment token'
+                    )
+                  : null)}
+            </span>
+            {status?.source === 'stored' ? (
+              <Button type="button" variant="ghost" size="sm" onClick={() => void disconnect()}>
+                {translate('auto.components.github-panel.GitHubPage.disconnect', 'Disconnect')}
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+      </header>
+
+      {loading ? (
+        <div className="flex flex-1 items-center justify-center gap-2 text-[13px] text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+          {translate('auto.components.github-panel.GitHubPage.loading', 'Loading…')}
+        </div>
+      ) : configured ? (
+        <GitHubRepoList />
+      ) : (
+        <GitHubSignInPanel
+          deviceFlowAvailable={status?.deviceFlowAvailable === true}
+          onConnected={refresh}
+        />
+      )}
+    </main>
+  )
+}

--- a/src/renderer/src/components/github-panel/GitHubRepoList.tsx
+++ b/src/renderer/src/components/github-panel/GitHubRepoList.tsx
@@ -1,0 +1,388 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Check, ChevronDown, GitFork, Loader2, Lock, RefreshCw, Search, Star } from 'lucide-react'
+import { toast } from 'sonner'
+import type { GitHubAccountRepo } from '../../../../shared/github-account'
+import type { Repo } from '../../../../shared/repo-types'
+import { useAppStore } from '@/store'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { useConfirmationDialog } from '@/components/confirmation-dialog-context'
+import { translate } from '@/i18n/i18n'
+import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
+import { isWindowsUserAgent } from '../terminal-pane/pane-helpers'
+import { getDefaultProjectsCloneParent } from '../sidebar/clone-defaults'
+import { findAddedGitHubRepo } from './github-added-repo-match'
+import { cloneGitHubRepoIntoProjects } from './github-repo-clone-action'
+import { isClonedRepoCleanupEligible } from './github-cloned-repo-cleanup-eligibility'
+
+// Why: the Recycle Bin is Windows-only vocabulary; macOS and Linux say Trash.
+const trashName = isWindowsUserAgent() ? 'Recycle Bin' : 'Trash'
+
+function filterRepos(repos: readonly GitHubAccountRepo[], query: string): GitHubAccountRepo[] {
+  const needle = query.trim().toLowerCase()
+  if (!needle) {
+    return [...repos]
+  }
+  return repos.filter(
+    (repo) =>
+      repo.fullName.toLowerCase().includes(needle) ||
+      (repo.description?.toLowerCase().includes(needle) ?? false)
+  )
+}
+
+function RepoRow({
+  item,
+  addedRepo,
+  cleanupEligible,
+  cloning,
+  progress,
+  onClone,
+  onRemove,
+  onCleanup
+}: {
+  item: GitHubAccountRepo
+  addedRepo: Repo | null
+  cleanupEligible: boolean
+  cloning: boolean
+  progress: { phase: string; percent: number } | null
+  onClone: (item: GitHubAccountRepo) => void
+  onRemove: (repo: Repo) => void
+  onCleanup: (repo: Repo) => void
+}): React.JSX.Element {
+  return (
+    <div className="flex items-center gap-3 px-4 py-2.5 hover:bg-muted/40">
+      {item.ownerAvatarUrl ? (
+        <img src={item.ownerAvatarUrl} alt="" className="size-7 shrink-0 rounded-full" />
+      ) : (
+        <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-[11px] font-semibold text-muted-foreground">
+          {item.ownerLogin.slice(0, 1).toUpperCase()}
+        </div>
+      )}
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="flex items-center gap-1.5">
+          <span className="truncate text-[13px] font-medium">{item.fullName}</span>
+          {item.isPrivate ? (
+            <Lock
+              className="size-3 shrink-0 text-muted-foreground"
+              aria-label={translate(
+                'auto.components.github-panel.GitHubRepoList.private',
+                'Private'
+              )}
+            />
+          ) : null}
+          {item.isFork ? (
+            <GitFork
+              className="size-3 shrink-0 text-muted-foreground"
+              aria-label={translate('auto.components.github-panel.GitHubRepoList.fork', 'Fork')}
+            />
+          ) : null}
+        </div>
+        {item.description ? (
+          <p className="truncate text-[12px] text-muted-foreground">{item.description}</p>
+        ) : null}
+        <div className="flex items-center gap-2 text-[11px] text-muted-foreground/80">
+          {item.language ? <span>{item.language}</span> : null}
+          {item.stargazersCount > 0 ? (
+            <span className="inline-flex items-center gap-0.5">
+              <Star className="size-3" />
+              {item.stargazersCount}
+            </span>
+          ) : null}
+          {item.pushedAt ? (
+            <span>
+              {translate('auto.components.github-panel.GitHubRepoList.pushed', 'pushed {{when}}', {
+                when: formatUiRelativeTimeFromDate(item.pushedAt)
+              })}
+            </span>
+          ) : null}
+        </div>
+      </div>
+      {addedRepo ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="shrink-0 gap-1 text-muted-foreground"
+              aria-label={translate(
+                'auto.components.github-panel.GitHubRepoList.addedActions',
+                'Added — project actions'
+              )}
+            >
+              <Check className="size-3.5" />
+              {translate('auto.components.github-panel.GitHubRepoList.added', 'Added')}
+              <ChevronDown className="size-3" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => onRemove(addedRepo)}>
+              {translate(
+                'auto.components.github-panel.GitHubRepoList.removeFromOrca',
+                'Remove from Orca'
+              )}
+            </DropdownMenuItem>
+            {cleanupEligible ? (
+              <DropdownMenuItem variant="destructive" onSelect={() => onCleanup(addedRepo)}>
+                {translate(
+                  'auto.components.github-panel.GitHubRepoList.cleanupFiles',
+                  'Remove and move files to {{trashName}}',
+                  { trashName }
+                )}
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          disabled={cloning}
+          onClick={() => onClone(item)}
+        >
+          {cloning ? (
+            <span className="inline-flex items-center gap-1.5">
+              <Loader2 className="size-3.5 animate-spin" />
+              {progress ? `${progress.percent}%` : null}
+            </span>
+          ) : (
+            translate('auto.components.github-panel.GitHubRepoList.clone', 'Clone')
+          )}
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export function GitHubRepoList(): React.JSX.Element {
+  const repos = useAppStore((state) => state.repos)
+  const workspaceDir = useAppStore((state) => state.settings?.workspaceDir)
+  const removeProject = useAppStore((state) => state.removeProject)
+  const confirm = useConfirmationDialog()
+  const [items, setItems] = useState<GitHubAccountRepo[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [query, setQuery] = useState('')
+  const [cloningId, setCloningId] = useState<number | null>(null)
+  const [progress, setProgress] = useState<{ phase: string; percent: number } | null>(null)
+
+  const load = useCallback(async (): Promise<void> => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await window.api.githubAuth.listRepos()
+      if (result?.ok) {
+        setItems(result.repos)
+      } else {
+        setError(
+          (result && !result.ok ? result.error : null) ??
+            translate(
+              'auto.components.github-panel.GitHubRepoList.loadFailed',
+              'Could not load repositories.'
+            )
+        )
+      }
+    } catch {
+      setError(
+        translate(
+          'auto.components.github-panel.GitHubRepoList.loadFailed',
+          'Could not load repositories.'
+        )
+      )
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  useEffect(() => {
+    if (cloningId === null) {
+      return
+    }
+    return window.api.repos.onCloneProgress(setProgress)
+  }, [cloningId])
+
+  const filtered = useMemo(() => filterRepos(items, query), [items, query])
+
+  const clone = useCallback(
+    async (item: GitHubAccountRepo): Promise<void> => {
+      const destination = workspaceDir ? getDefaultProjectsCloneParent(workspaceDir) : ''
+      if (!destination) {
+        toast.error(
+          translate(
+            'auto.components.github-panel.GitHubRepoList.noWorkspaceDir',
+            'Set a workspace directory in Settings first.'
+          )
+        )
+        return
+      }
+      setCloningId(item.id)
+      setProgress(null)
+      try {
+        const outcome = await cloneGitHubRepoIntoProjects(item, destination)
+        if (!outcome.ok) {
+          toast.error(outcome.error)
+          return
+        }
+        toast.success(
+          translate('auto.components.github-panel.GitHubRepoList.cloned', 'Repository cloned'),
+          { description: item.fullName }
+        )
+      } finally {
+        setCloningId(null)
+        setProgress(null)
+      }
+    },
+    [workspaceDir]
+  )
+
+  const removeFromOrca = useCallback(
+    (repo: Repo): void => {
+      void removeProject(repo.id, { errorFeedback: 'toast' })
+    },
+    [removeProject]
+  )
+
+  const cleanupFiles = useCallback(
+    async (repo: Repo): Promise<void> => {
+      const accepted = await confirm({
+        title: translate(
+          'auto.components.github-panel.GitHubRepoList.cleanupTitle',
+          'Remove project and delete files?'
+        ),
+        description: translate(
+          'auto.components.github-panel.GitHubRepoList.cleanupDescription',
+          '“{{path}}” will be moved to the {{trashName}}, and the project will be removed from Orca.',
+          { path: repo.path, trashName }
+        ),
+        confirmLabel: translate(
+          'auto.components.github-panel.GitHubRepoList.cleanupConfirm',
+          'Move to {{trashName}}',
+          { trashName }
+        ),
+        confirmVariant: 'destructive'
+      })
+      if (!accepted) {
+        return
+      }
+      const result = await window.api.githubAuth.deleteClonedRepoFiles({ repoId: repo.id })
+      if (!result?.ok) {
+        toast.error(
+          (result && !result.ok ? result.error : null) ??
+            translate(
+              'auto.components.github-panel.GitHubRepoList.cleanupFailed',
+              'Could not delete the repository files.'
+            )
+        )
+        return
+      }
+      toast.success(
+        translate(
+          'auto.components.github-panel.GitHubRepoList.cleanedUp',
+          'Repository files moved to the {{trashName}}',
+          { trashName }
+        ),
+        { description: repo.path }
+      )
+      await removeProject(repo.id, { errorFeedback: 'toast' })
+    },
+    [confirm, removeProject]
+  )
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center gap-2 px-3 pb-2 md:px-5">
+        <div className="relative max-w-sm flex-1">
+          <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/60" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={translate(
+              'auto.components.github-panel.GitHubRepoList.searchPlaceholder',
+              'Search repositories'
+            )}
+            aria-label={translate(
+              'auto.components.github-panel.GitHubRepoList.searchPlaceholder',
+              'Search repositories'
+            )}
+            className="h-8 pl-7 text-[13px]"
+          />
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label={translate('auto.components.github-panel.GitHubRepoList.refresh', 'Refresh')}
+          disabled={loading}
+          onClick={() => void load()}
+        >
+          <RefreshCw className={loading ? 'size-3.5 animate-spin' : 'size-3.5'} />
+        </Button>
+      </div>
+      {error ? (
+        <div className="mx-3 mb-2 flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-[12px] text-destructive md:mx-5">
+          <span>{error}</span>
+          <Button type="button" variant="ghost" size="sm" onClick={() => void load()}>
+            {translate('auto.components.github-panel.GitHubRepoList.retry', 'Retry')}
+          </Button>
+        </div>
+      ) : null}
+      <ScrollArea className="min-h-0 flex-1">
+        {loading && items.length === 0 ? (
+          <div className="flex items-center justify-center gap-2 py-16 text-[13px] text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" />
+            {translate(
+              'auto.components.github-panel.GitHubRepoList.loading',
+              'Loading repositories…'
+            )}
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="py-16 text-center text-[13px] text-muted-foreground">
+            {query
+              ? translate(
+                  'auto.components.github-panel.GitHubRepoList.noMatches',
+                  'No repositories match your search.'
+                )
+              : translate(
+                  'auto.components.github-panel.GitHubRepoList.empty',
+                  'No repositories found for this account.'
+                )}
+          </div>
+        ) : (
+          <div className="flex flex-col divide-y divide-border/60 pb-6">
+            {filtered.map((item) => {
+              const addedRepo = findAddedGitHubRepo(repos, item.fullName)
+              return (
+                <RepoRow
+                  key={item.id}
+                  item={item}
+                  addedRepo={addedRepo}
+                  cleanupEligible={
+                    addedRepo !== null && isClonedRepoCleanupEligible(addedRepo, workspaceDir)
+                  }
+                  cloning={cloningId === item.id}
+                  progress={cloningId === item.id ? progress : null}
+                  onClone={(target) => void clone(target)}
+                  onRemove={removeFromOrca}
+                  onCleanup={(target) => void cleanupFiles(target)}
+                />
+              )
+            })}
+          </div>
+        )}
+      </ScrollArea>
+    </div>
+  )
+}

--- a/src/renderer/src/components/github-panel/GitHubSignInPanel.tsx
+++ b/src/renderer/src/components/github-panel/GitHubSignInPanel.tsx
@@ -1,0 +1,298 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Check, Copy, Github, Loader2 } from 'lucide-react'
+import type { GitHubDeviceFlowStart } from '../../../../shared/github-account'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { translate } from '@/i18n/i18n'
+
+type DeviceFlowState =
+  | { phase: 'idle' }
+  | { phase: 'starting' }
+  | { phase: 'awaiting'; flow: GitHubDeviceFlowStart }
+  | { phase: 'error'; error: string }
+
+function DeviceFlowSection({
+  onConnected
+}: {
+  onConnected: () => Promise<void>
+}): React.JSX.Element {
+  const [state, setState] = useState<DeviceFlowState>({ phase: 'idle' })
+  const [copied, setCopied] = useState(false)
+  // Why: generation guard so a cancelled/superseded flow stops its poll loop.
+  const generationRef = useRef(0)
+
+  const cancel = useCallback((): void => {
+    generationRef.current += 1
+    setState({ phase: 'idle' })
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      generationRef.current += 1
+    }
+  }, [])
+
+  const start = useCallback(async (): Promise<void> => {
+    const generation = ++generationRef.current
+    setState({ phase: 'starting' })
+    const result = await window.api.githubAuth.startDeviceFlow()
+    if (generation !== generationRef.current) {
+      return
+    }
+    if (!result.ok) {
+      setState({ phase: 'error', error: result.error })
+      return
+    }
+    const flow = result.flow
+    setState({ phase: 'awaiting', flow })
+    void window.api.shell.openUrl(flow.verificationUri)
+
+    let intervalSeconds = flow.pollIntervalSeconds
+    const deadline = Date.now() + flow.expiresInSeconds * 1000
+    while (generation === generationRef.current) {
+      await new Promise((resolve) => setTimeout(resolve, intervalSeconds * 1000))
+      if (generation !== generationRef.current) {
+        return
+      }
+      if (Date.now() > deadline) {
+        setState({
+          phase: 'error',
+          error: translate(
+            'auto.components.github-panel.GitHubSignInPanel.codeExpired',
+            'The sign-in code expired. Start over to get a new one.'
+          )
+        })
+        return
+      }
+      const poll = await window.api.githubAuth.pollDeviceFlow({ deviceCode: flow.deviceCode })
+      if (generation !== generationRef.current) {
+        return
+      }
+      if (poll.status === 'pending') {
+        intervalSeconds = poll.pollIntervalSeconds ?? intervalSeconds
+        continue
+      }
+      if (poll.status === 'connected') {
+        setState({ phase: 'idle' })
+        await onConnected()
+        return
+      }
+      setState({ phase: 'error', error: poll.error })
+      return
+    }
+  }, [onConnected])
+
+  const copyCode = useCallback(async (code: string): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(code)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Clipboard unavailable; the code is visible for manual entry.
+    }
+  }, [])
+
+  if (state.phase === 'awaiting') {
+    const { flow } = state
+    return (
+      <div className="flex flex-col items-center gap-3 rounded-md border border-border bg-card p-4">
+        <p className="text-[13px] text-muted-foreground">
+          {translate(
+            'auto.components.github-panel.GitHubSignInPanel.enterCode',
+            'GitHub should have opened in your browser. Enter this code there:'
+          )}
+        </p>
+        <div className="flex items-center gap-2">
+          <code className="rounded-md bg-muted px-3 py-1.5 font-mono text-lg tracking-widest">
+            {flow.userCode}
+          </code>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={translate(
+              'auto.components.github-panel.GitHubSignInPanel.copyCode',
+              'Copy code'
+            )}
+            onClick={() => void copyCode(flow.userCode)}
+          >
+            {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+          </Button>
+        </div>
+        <div className="flex items-center gap-2 text-[12px] text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" />
+          {translate(
+            'auto.components.github-panel.GitHubSignInPanel.waiting',
+            'Waiting for authorization…'
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void window.api.shell.openUrl(flow.verificationUri)}
+          >
+            {translate(
+              'auto.components.github-panel.GitHubSignInPanel.openGithub',
+              'Open GitHub again'
+            )}
+          </Button>
+          <Button type="button" variant="ghost" size="sm" onClick={cancel}>
+            {translate('auto.components.github-panel.GitHubSignInPanel.cancel', 'Cancel')}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <Button
+        type="button"
+        onClick={() => void start()}
+        disabled={state.phase === 'starting'}
+        className="gap-2"
+      >
+        {state.phase === 'starting' ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : (
+          <Github className="size-4" />
+        )}
+        {translate('auto.components.github-panel.GitHubSignInPanel.signIn', 'Sign in with GitHub')}
+      </Button>
+      {state.phase === 'error' ? (
+        <p className="max-w-sm text-center text-[12px] text-destructive">{state.error}</p>
+      ) : null}
+    </div>
+  )
+}
+
+function PersonalAccessTokenSection({
+  onConnected
+}: {
+  onConnected: () => Promise<void>
+}): React.JSX.Element {
+  const [token, setToken] = useState('')
+  const [connecting, setConnecting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const connect = useCallback(async (): Promise<void> => {
+    if (!token.trim() || connecting) {
+      return
+    }
+    setConnecting(true)
+    setError(null)
+    try {
+      const result = await window.api.githubAuth.connectWithToken({ token: token.trim() })
+      if (!result.ok) {
+        setError(result.error)
+        return
+      }
+      setToken('')
+      await onConnected()
+    } catch {
+      setError(
+        translate(
+          'auto.components.github-panel.GitHubSignInPanel.connectFailed',
+          'Could not connect. Try again.'
+        )
+      )
+    } finally {
+      setConnecting(false)
+    }
+  }, [token, connecting, onConnected])
+
+  return (
+    <div className="flex w-full max-w-sm flex-col items-stretch gap-2">
+      <div className="flex items-center gap-2">
+        <Input
+          type="password"
+          value={token}
+          onChange={(event) => {
+            setToken(event.target.value)
+            setError(null)
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              void connect()
+            }
+          }}
+          placeholder={translate(
+            'auto.components.github-panel.GitHubSignInPanel.tokenPlaceholder',
+            'Personal access token'
+          )}
+          aria-label={translate(
+            'auto.components.github-panel.GitHubSignInPanel.tokenPlaceholder',
+            'Personal access token'
+          )}
+          className="h-8 text-[13px]"
+        />
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => void connect()}
+          disabled={!token.trim() || connecting}
+        >
+          {connecting ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            translate('auto.components.github-panel.GitHubSignInPanel.connect', 'Connect')
+          )}
+        </Button>
+      </div>
+      {error ? <p className="text-[12px] text-destructive">{error}</p> : null}
+      <button
+        type="button"
+        className="self-center text-[12px] text-muted-foreground underline-offset-2 hover:underline"
+        onClick={() =>
+          void window.api.shell.openUrl(
+            'https://github.com/settings/tokens/new?scopes=repo&description=Orca'
+          )
+        }
+      >
+        {translate(
+          'auto.components.github-panel.GitHubSignInPanel.createToken',
+          'Create a token with the repo scope on GitHub'
+        )}
+      </button>
+    </div>
+  )
+}
+
+export function GitHubSignInPanel({
+  deviceFlowAvailable,
+  onConnected
+}: {
+  deviceFlowAvailable: boolean
+  onConnected: () => Promise<void>
+}): React.JSX.Element {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-5 px-6 pb-16">
+      <Github className="size-10 text-muted-foreground/60" strokeWidth={1.5} />
+      <div className="flex flex-col items-center gap-1 text-center">
+        <h2 className="text-[15px] font-semibold">
+          {translate(
+            'auto.components.github-panel.GitHubSignInPanel.title',
+            'Connect your GitHub account'
+          )}
+        </h2>
+        <p className="max-w-md text-[13px] text-muted-foreground">
+          {translate(
+            'auto.components.github-panel.GitHubSignInPanel.subtitle',
+            'List your repositories, clone them locally, and add them as Orca projects.'
+          )}
+        </p>
+      </div>
+      {deviceFlowAvailable ? <DeviceFlowSection onConnected={onConnected} /> : null}
+      {deviceFlowAvailable ? (
+        <div className="flex w-full max-w-sm items-center gap-3 text-[11px] uppercase tracking-wide text-muted-foreground/70">
+          <div className="h-px flex-1 bg-border" />
+          {translate('auto.components.github-panel.GitHubSignInPanel.or', 'or')}
+          <div className="h-px flex-1 bg-border" />
+        </div>
+      ) : null}
+      <PersonalAccessTokenSection onConnected={onConnected} />
+    </div>
+  )
+}

--- a/src/renderer/src/components/github-panel/github-added-repo-match.test.ts
+++ b/src/renderer/src/components/github-panel/github-added-repo-match.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import { findAddedGitHubRepo } from './github-added-repo-match'
+
+function makeRepo(overrides: Partial<Repo>): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'Repo',
+    badgeColor: '#000',
+    addedAt: 1,
+    kind: 'git',
+    ...overrides
+  }
+}
+
+describe('findAddedGitHubRepo', () => {
+  it('matches a probed remote identity case-insensitively', () => {
+    const repos = [
+      makeRepo({
+        gitRemoteIdentity: {
+          canonicalKey: 'github.com/Acme/Orca',
+          remoteName: 'origin',
+          remoteUrl: 'git@github.com:Acme/Orca.git'
+        }
+      })
+    ]
+    expect(findAddedGitHubRepo(repos, 'acme/orca')?.id).toBe('repo-1')
+  })
+
+  it('matches the recorded upstream identity for forks', () => {
+    const repos = [makeRepo({ upstream: { owner: 'Acme', repo: 'Orca' } })]
+    expect(findAddedGitHubRepo(repos, 'acme/orca')?.id).toBe('repo-1')
+  })
+
+  it('returns null when nothing matches', () => {
+    const repos = [
+      makeRepo({
+        gitRemoteIdentity: {
+          canonicalKey: 'gitlab.com/acme/orca',
+          remoteName: 'origin',
+          remoteUrl: 'git@gitlab.com:acme/orca.git'
+        }
+      })
+    ]
+    expect(findAddedGitHubRepo(repos, 'acme/orca')).toBeNull()
+    expect(findAddedGitHubRepo([], 'acme/orca')).toBeNull()
+    expect(findAddedGitHubRepo(repos, '')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/github-panel/github-added-repo-match.ts
+++ b/src/renderer/src/components/github-panel/github-added-repo-match.ts
@@ -1,0 +1,22 @@
+import type { Repo } from '../../../../shared/repo-types'
+
+// Matches a GitHub `owner/repo` against projects already added to Orca, via the
+// probed remote identity (canonicalKey `github.com/owner/repo`) or the fork's
+// recorded upstream identity.
+export function findAddedGitHubRepo(repos: readonly Repo[], fullName: string): Repo | null {
+  const target = fullName.trim().toLowerCase()
+  if (!target) {
+    return null
+  }
+  for (const repo of repos) {
+    const key = repo.gitRemoteIdentity?.canonicalKey
+    if (key && key.toLowerCase() === `github.com/${target}`) {
+      return repo
+    }
+    const upstream = repo.upstream
+    if (upstream && `${upstream.owner}/${upstream.repo}`.toLowerCase() === target) {
+      return repo
+    }
+  }
+  return null
+}

--- a/src/renderer/src/components/github-panel/github-cloned-repo-cleanup-eligibility.ts
+++ b/src/renderer/src/components/github-panel/github-cloned-repo-cleanup-eligibility.ts
@@ -1,0 +1,23 @@
+import type { Repo } from '../../../../shared/repo-types'
+import { getDefaultProjectsCloneParent } from '../../../../shared/clone-destination'
+import { relativePathInsideRoot } from '../../../../shared/cross-platform-path'
+
+// File cleanup is offered only for repos Orca itself cloned locally into the
+// default clone parent; the main process re-checks the same rules before
+// trashing anything, this is purely which menu item to show.
+export function isClonedRepoCleanupEligible(
+  repo: Repo,
+  workspaceDir: string | null | undefined
+): boolean {
+  if (repo.projectHostSetupMethod !== 'cloned') {
+    return false
+  }
+  if (repo.connectionId != null || (repo.executionHostId && repo.executionHostId !== 'local')) {
+    return false
+  }
+  const cloneParent = getDefaultProjectsCloneParent(workspaceDir ?? '')
+  if (!cloneParent) {
+    return false
+  }
+  return relativePathInsideRoot(cloneParent, repo.path) !== null
+}

--- a/src/renderer/src/components/github-panel/github-repo-clone-action.ts
+++ b/src/renderer/src/components/github-panel/github-repo-clone-action.ts
@@ -1,0 +1,37 @@
+import { useAppStore } from '@/store'
+import type { GitHubAccountRepo } from '../../../../shared/github-account'
+import { upsertAddedRepoWithProjectHostSetup } from '../sidebar/add-repo-store-upsert'
+import { worktreeRefreshOptions } from '../sidebar/add-repo-runtime-owner'
+import { finishProjectAddWithDefaultCheckout } from '../sidebar/project-added-default-checkout'
+
+export type GitHubRepoCloneOutcome = { ok: true } | { ok: false; error: string }
+
+// Clones a GitHub repo through the authenticated account IPC, then runs the
+// same store upsert + worktree refresh + default-checkout reveal the Add
+// Project dialog uses, so the new project lands in the sidebar identically.
+export async function cloneGitHubRepoIntoProjects(
+  item: GitHubAccountRepo,
+  destination: string
+): Promise<GitHubRepoCloneOutcome> {
+  const result = await window.api.githubAuth.cloneRepo({
+    fullName: item.fullName,
+    cloneUrl: item.cloneUrl,
+    isPrivate: item.isPrivate,
+    destination
+  })
+  if (!result.ok) {
+    return { ok: false, error: result.error }
+  }
+  const { repo: ownedRepo } = upsertAddedRepoWithProjectHostSetup(result.repo, {})
+  await useAppStore.getState().fetchWorktrees(ownedRepo.id, worktreeRefreshOptions(null))
+  // Why: reveal handles the no-worktree fallback itself, so a failed refresh
+  // still finalizes the add instead of leaving the project half-visible.
+  await finishProjectAddWithDefaultCheckout({
+    repoId: ownedRepo.id,
+    source: 'clone_url',
+    closeModal: () => {},
+    setHideDefaultBranchWorkspace: (value) =>
+      useAppStore.getState().setHideDefaultBranchWorkspace(value)
+  })
+  return { ok: true }
+}

--- a/src/renderer/src/components/github-panel/useGitHubAccountStatus.ts
+++ b/src/renderer/src/components/github-panel/useGitHubAccountStatus.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { GitHubAccountStatus } from '../../../../shared/github-account'
+
+// Polls nothing by itself; the page triggers `refresh` after auth mutations.
+export function useGitHubAccountStatus(): {
+  status: GitHubAccountStatus | null
+  loading: boolean
+  refresh: () => Promise<void>
+  disconnect: () => Promise<void>
+} {
+  const [status, setStatus] = useState<GitHubAccountStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async (): Promise<void> => {
+    try {
+      const next = await window.api.githubAuth.status()
+      // Why: the web fallback proxy resolves `undefined` here; treat it as signed out.
+      setStatus(next ?? null)
+    } catch {
+      setStatus(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const disconnect = useCallback(async (): Promise<void> => {
+    await window.api.githubAuth.disconnect()
+    await refresh()
+  }, [refresh])
+
+  return { status, loading, refresh, disconnect }
+}

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -1,5 +1,14 @@
 import React from 'react'
-import { Bell, BookOpen, CalendarClock, EyeOff, Files, Search, Smartphone } from 'lucide-react'
+import {
+  Bell,
+  BookOpen,
+  CalendarClock,
+  EyeOff,
+  Files,
+  Github,
+  Search,
+  Smartphone
+} from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
@@ -63,6 +72,7 @@ const SidebarNav = React.memo(function SidebarNav() {
   useTranslation()
   const worktreePaletteShortcutCombos = useShortcutKeyComboDetails('worktree.palette')
   const openAutomationsPage = useAppStore((s) => s.openAutomationsPage)
+  const openGithubPage = useAppStore((s) => s.openGithubPage)
   const openActivityPage = useAppStore((s) => s.openActivityPage)
   const openMobilePage = useAppStore((s) => s.openMobilePage)
   const openArtifactsPage = useAppStore((s) => s.openArtifactsPage)
@@ -82,6 +92,7 @@ const SidebarNav = React.memo(function SidebarNav() {
   const showArtifactsButton = useAppStore((s) => shouldShowArtifactsButton(s.settings))
   const showSkillsButton = useAppStore((s) => shouldShowSkillsButton(s.settings))
   const automationsActive = activeView === 'automations'
+  const githubActive = activeView === 'github'
   const activityActive = activeView === 'activity'
   const mobileActive = activeView === 'mobile'
   const artifactsActive = activeView === 'artifacts'
@@ -137,6 +148,25 @@ const SidebarNav = React.memo(function SidebarNav() {
       </button>
       <SetupGuideSidebarEntry />
       <SidebarTaskNavButton />
+      <button
+        type="button"
+        onClick={openGithubPage}
+        aria-current={githubActive ? 'page' : undefined}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
+          githubActive
+            ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
+            : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'
+        )}
+      >
+        <Github
+          className={cn('size-4 shrink-0', !githubActive && 'text-worktree-sidebar-foreground/30')}
+          strokeWidth={githubActive ? 2.25 : 1.75}
+        />
+        <span className="flex-1">
+          {translate('auto.components.sidebar.SidebarNav.github', 'My GitHub')}
+        </span>
+      </button>
       {showArtifactsButton ? (
         <ContextMenu>
           <ContextMenuTrigger asChild>

--- a/src/renderer/src/components/sidebar/clone-defaults.test.ts
+++ b/src/renderer/src/components/sidebar/clone-defaults.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { getCloneDestinationAutoFill, getDefaultCloneParent } from './clone-defaults'
+import { getDefaultProjectsCloneParent } from '../../../../shared/clone-destination'
 
 describe('getDefaultCloneParent', () => {
   it('strips a POSIX workspaces suffix', () => {
@@ -42,6 +43,58 @@ describe('getDefaultCloneParent', () => {
 
   it('does not strip a similar-looking final segment', () => {
     expect(getDefaultCloneParent('/Users/mvanhorn/orca/project-workspaces')).toBe(
+      '/Users/mvanhorn/orca/project-workspaces'
+    )
+  })
+})
+
+describe('getDefaultProjectsCloneParent', () => {
+  it('maps a POSIX workspaces suffix to a sibling projects directory', () => {
+    expect(getDefaultProjectsCloneParent('/Users/mvanhorn/orca/workspaces')).toBe(
+      '/Users/mvanhorn/orca/projects'
+    )
+  })
+
+  it('maps a POSIX workspaces suffix with a trailing slash', () => {
+    expect(getDefaultProjectsCloneParent('/Users/mvanhorn/orca/workspaces/')).toBe(
+      '/Users/mvanhorn/orca/projects'
+    )
+  })
+
+  it('maps a Windows workspaces suffix keeping backslash separators', () => {
+    expect(getDefaultProjectsCloneParent('C:\\Users\\mvanhorn\\orca\\workspaces')).toBe(
+      'C:\\Users\\mvanhorn\\orca\\projects'
+    )
+  })
+
+  it('leaves input without a workspaces suffix unchanged', () => {
+    expect(getDefaultProjectsCloneParent('/Users/mvanhorn/projects')).toBe(
+      '/Users/mvanhorn/projects'
+    )
+  })
+
+  it('returns empty input unchanged', () => {
+    expect(getDefaultProjectsCloneParent('')).toBe('')
+  })
+
+  it('maps workspaces alone to a relative projects directory', () => {
+    expect(getDefaultProjectsCloneParent('workspaces')).toBe('projects')
+  })
+
+  it('maps an absolute root workspaces path to root-level projects', () => {
+    expect(getDefaultProjectsCloneParent('/workspaces')).toBe('/projects')
+  })
+
+  it('maps a Windows root workspaces path to drive-level projects', () => {
+    expect(getDefaultProjectsCloneParent('C:\\workspaces')).toBe('C:\\projects')
+  })
+
+  it('strips repeated trailing separators before matching the suffix', () => {
+    expect(getDefaultProjectsCloneParent('D:\\orca\\workspaces\\\\')).toBe('D:\\orca\\projects')
+  })
+
+  it('does not map a similar-looking final segment', () => {
+    expect(getDefaultProjectsCloneParent('/Users/mvanhorn/orca/project-workspaces')).toBe(
       '/Users/mvanhorn/orca/project-workspaces'
     )
   })

--- a/src/renderer/src/components/sidebar/clone-defaults.ts
+++ b/src/renderer/src/components/sidebar/clone-defaults.ts
@@ -1,30 +1,9 @@
-export function getDefaultCloneParent(workspaceDir: string): string {
-  if (!workspaceDir) {
-    return ''
-  }
+import { getDefaultCloneParent } from '../../../../shared/clone-destination'
 
-  const trimmed = workspaceDir.replace(/[\\/]+$/, '')
-  if (!trimmed) {
-    return workspaceDir
-  }
-
-  const separatorIndex = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
-  const lastSegment = separatorIndex === -1 ? trimmed : trimmed.slice(separatorIndex + 1)
-
-  if (lastSegment !== 'workspaces') {
-    return workspaceDir
-  }
-
-  // Why: default Orca worktrees live under "workspaces"; clones should sit beside that tree.
-  const parent = separatorIndex === -1 ? '' : trimmed.slice(0, separatorIndex)
-  if (parent === '' && trimmed.startsWith('/')) {
-    return '/'
-  }
-  if (/^[A-Za-z]:$/.test(parent)) {
-    return `${parent}${trimmed[separatorIndex]}`
-  }
-  return parent
-}
+export {
+  getDefaultCloneParent,
+  getDefaultProjectsCloneParent
+} from '../../../../shared/clone-destination'
 
 export function getCloneDestinationAutoFill({
   step,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5214,7 +5214,8 @@
           "fee535205b": "Tasks",
           "d599269755": "Hide from sidebar",
           "artifacts": "Artifacts",
-          "skills": "Skills"
+          "skills": "Skills",
+          "github": "My GitHub"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "Clear",
@@ -16425,6 +16426,54 @@
           "externalLinkTitle": "Open link to {{host}}?",
           "externalLinkConfirm": "Open link",
           "externalLinkCancel": "Cancel"
+        }
+      },
+      "github-panel": {
+        "GitHubPage": {
+          "title": "My GitHub",
+          "envAccount": "via environment token",
+          "disconnect": "Disconnect",
+          "loading": "Loading…"
+        },
+        "GitHubRepoList": {
+          "private": "Private",
+          "fork": "Fork",
+          "pushed": "pushed {{when}}",
+          "addedActions": "Added — project actions",
+          "added": "Added",
+          "removeFromOrca": "Remove from Orca",
+          "cleanupFiles": "Remove and move files to {{trashName}}",
+          "clone": "Clone",
+          "loadFailed": "Could not load repositories.",
+          "noWorkspaceDir": "Set a workspace directory in Settings first.",
+          "cloned": "Repository cloned",
+          "cleanupTitle": "Remove project and delete files?",
+          "cleanupDescription": "“{{path}}” will be moved to the {{trashName}}, and the project will be removed from Orca.",
+          "cleanupConfirm": "Move to {{trashName}}",
+          "cleanupFailed": "Could not delete the repository files.",
+          "cleanedUp": "Repository files moved to the {{trashName}}",
+          "searchPlaceholder": "Search repositories",
+          "refresh": "Refresh",
+          "retry": "Retry",
+          "loading": "Loading repositories…",
+          "noMatches": "No repositories match your search.",
+          "empty": "No repositories found for this account."
+        },
+        "GitHubSignInPanel": {
+          "codeExpired": "The sign-in code expired. Start over to get a new one.",
+          "enterCode": "GitHub should have opened in your browser. Enter this code there:",
+          "copyCode": "Copy code",
+          "waiting": "Waiting for authorization…",
+          "openGithub": "Open GitHub again",
+          "cancel": "Cancel",
+          "signIn": "Sign in with GitHub",
+          "connectFailed": "Could not connect. Try again.",
+          "tokenPlaceholder": "Personal access token",
+          "connect": "Connect",
+          "createToken": "Create a token with the repo scope on GitHub",
+          "title": "Connect your GitHub account",
+          "subtitle": "List your repositories, clone them locally, and add them as Orca projects.",
+          "or": "or"
         }
       }
     },

--- a/src/renderer/src/lib/right-sidebar-visibility.test.ts
+++ b/src/renderer/src/lib/right-sidebar-visibility.test.ts
@@ -38,7 +38,8 @@ describe('right sidebar visibility helpers', () => {
       'space',
       'skills',
       'artifacts',
-      'mobile'
+      'mobile',
+      'github'
     ]) {
       expect(canShowRightSidebarForView(view as AppState['activeView'])).toBe(false)
     }

--- a/src/renderer/src/lib/right-sidebar-visibility.ts
+++ b/src/renderer/src/lib/right-sidebar-visibility.ts
@@ -11,7 +11,8 @@ const RIGHT_SIDEBAR_SUPPRESSED_VIEWS = new Set<ActiveView>([
   'space',
   'skills',
   'artifacts',
-  'mobile'
+  'mobile',
+  'github'
 ])
 
 export function canShowRightSidebarForView(activeView: ActiveView): boolean {

--- a/src/renderer/src/lib/titlebar-worktree-history-controls.test.ts
+++ b/src/renderer/src/lib/titlebar-worktree-history-controls.test.ts
@@ -8,6 +8,7 @@ describe('shouldShowWorktreeHistoryControls', () => {
     expect(shouldShowWorktreeHistoryControls('automations')).toBe(true)
     expect(shouldShowWorktreeHistoryControls('artifacts')).toBe(true)
     expect(shouldShowWorktreeHistoryControls('skills')).toBe(true)
+    expect(shouldShowWorktreeHistoryControls('github')).toBe(true)
   })
 
   it('hides controls on full-page views outside the history stack', () => {

--- a/src/renderer/src/lib/titlebar-worktree-history-controls.ts
+++ b/src/renderer/src/lib/titlebar-worktree-history-controls.ts
@@ -6,6 +6,7 @@ export function shouldShowWorktreeHistoryControls(activeView: UISlice['activeVie
     activeView === 'tasks' ||
     activeView === 'automations' ||
     activeView === 'artifacts' ||
-    activeView === 'skills'
+    activeView === 'skills' ||
+    activeView === 'github'
   )
 }

--- a/src/renderer/src/lib/worktree-nav-view-history-replay.ts
+++ b/src/renderer/src/lib/worktree-nav-view-history-replay.ts
@@ -3,7 +3,12 @@ import type { WorktreeNavHistoryViewEntry } from '@/store/slices/worktree-nav-hi
 
 // Why: page entries replay via setActiveView (not open*Page) so back/forward doesn't mutate previousViewBefore* or duplicate history (see navigateToIndex).
 export function applyWorktreeNavViewEntry(entry: WorktreeNavHistoryViewEntry): void {
-  if (entry === 'automations' || entry === 'artifacts' || entry === 'skills') {
+  if (
+    entry === 'automations' ||
+    entry === 'artifacts' ||
+    entry === 'skills' ||
+    entry === 'github'
+  ) {
     useAppStore.getState().setActiveView(entry)
     return
   }

--- a/src/renderer/src/store/slices/ui-page-navigation.test.ts
+++ b/src/renderer/src/store/slices/ui-page-navigation.test.ts
@@ -677,6 +677,34 @@ describe('createUISlice space navigation', () => {
     expect(store.getState().worktreeNavHistoryIndex).toBe(0)
   })
 
+  it('records and rewinds GitHub visits on close', () => {
+    const store = createUIStore()
+    store.setState({ worktreesByRepo: { 'repo-1': [makeWorktree('a')] } })
+
+    store.getState().recordWorktreeVisit('a')
+    store.getState().openGithubPage()
+    expect(store.getState().worktreeNavHistory).toEqual(['a', 'github'])
+    expect(store.getState().worktreeNavHistoryIndex).toBe(1)
+
+    store.getState().closeGithubPage()
+    expect(store.getState().activeView).toBe('terminal')
+    expect(store.getState().worktreeNavHistoryIndex).toBe(0)
+  })
+
+  it('returns to the originating view after closing GitHub', () => {
+    const store = createUIStore()
+
+    store.getState().openTaskPage()
+    store.getState().openGithubPage()
+
+    expect(store.getState().activeView).toBe('github')
+    expect(store.getState().previousViewBeforeGithub).toBe('tasks')
+
+    store.getState().closeGithubPage()
+
+    expect(store.getState().activeView).toBe('tasks')
+  })
+
   it('records and rewinds Skills visits on close', () => {
     const store = createUIStore()
     store.setState({ worktreesByRepo: { 'repo-1': [makeWorktree('a')] } })

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -649,6 +649,7 @@ export type UISlice = {
     | 'skills'
     | 'artifacts'
     | 'mobile'
+    | 'github'
   previousViewBeforeSettings:
     | 'terminal'
     | 'tasks'
@@ -658,6 +659,7 @@ export type UISlice = {
     | 'skills'
     | 'artifacts'
     | 'mobile'
+    | 'github'
   previousViewBeforeActivity:
     | 'terminal'
     | 'settings'
@@ -667,6 +669,7 @@ export type UISlice = {
     | 'skills'
     | 'artifacts'
     | 'mobile'
+    | 'github'
   previousViewBeforeAutomations:
     | 'terminal'
     | 'settings'
@@ -676,6 +679,7 @@ export type UISlice = {
     | 'skills'
     | 'artifacts'
     | 'mobile'
+    | 'github'
   previousViewBeforeSpace:
     | 'terminal'
     | 'settings'
@@ -685,6 +689,7 @@ export type UISlice = {
     | 'skills'
     | 'artifacts'
     | 'mobile'
+    | 'github'
   previousViewBeforeSkills:
     | 'terminal'
     | 'settings'
@@ -694,6 +699,7 @@ export type UISlice = {
     | 'space'
     | 'artifacts'
     | 'mobile'
+    | 'github'
   previousViewBeforeMobile:
     | 'terminal'
     | 'settings'
@@ -703,6 +709,7 @@ export type UISlice = {
     | 'space'
     | 'skills'
     | 'artifacts'
+    | 'github'
   previousViewBeforeArtifacts:
     | 'terminal'
     | 'settings'
@@ -711,6 +718,17 @@ export type UISlice = {
     | 'automations'
     | 'space'
     | 'skills'
+    | 'mobile'
+    | 'github'
+  previousViewBeforeGithub:
+    | 'terminal'
+    | 'settings'
+    | 'tasks'
+    | 'activity'
+    | 'automations'
+    | 'space'
+    | 'skills'
+    | 'artifacts'
     | 'mobile'
   setActiveView: (view: UISlice['activeView']) => void
   taskPageData: {
@@ -801,6 +819,8 @@ export type UISlice = {
   clearPendingSkillsSharedView: () => void
   openArtifactsPage: () => void
   closeArtifactsPage: () => void
+  openGithubPage: () => void
+  closeGithubPage: () => void
   openMobilePage: () => void
   closeMobilePage: () => void
   setNewWorkspaceDraft: (draft: NonNullable<UISlice['newWorkspaceDraft']>) => void
@@ -1329,6 +1349,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   pendingSkillsSharedView: false,
   previousViewBeforeMobile: 'terminal',
   previousViewBeforeArtifacts: 'terminal',
+  previousViewBeforeGithub: 'terminal',
   setActiveView: (view) => set({ activeView: view }),
   taskPageData: {},
   taskResumeState: undefined,
@@ -1601,6 +1622,19 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     set((state) => ({
       activeView: state.previousViewBeforeArtifacts,
       worktreeNavHistoryIndex: rewindHistoryIndexPastView(state, 'artifacts')
+    })),
+  openGithubPage: () => {
+    get().recordViewVisit('github')
+    set((state) => ({
+      activeView: 'github',
+      previousViewBeforeGithub:
+        state.activeView === 'github' ? state.previousViewBeforeGithub : state.activeView
+    }))
+  },
+  closeGithubPage: () =>
+    set((state) => ({
+      activeView: state.previousViewBeforeGithub,
+      worktreeNavHistoryIndex: rewindHistoryIndexPastView(state, 'github')
     })),
   openMobilePage: () =>
     set((state) => ({

--- a/src/renderer/src/store/slices/worktree-nav-history-view-entries.test.ts
+++ b/src/renderer/src/store/slices/worktree-nav-history-view-entries.test.ts
@@ -48,7 +48,8 @@ const viewCases: { entry: WorktreeNavHistorySimpleViewEntry; label: string }[] =
   { entry: 'tasks', label: 'Tasks' },
   { entry: 'automations', label: 'Automations' },
   { entry: 'artifacts', label: 'Artifacts' },
-  { entry: 'skills', label: 'Skills' }
+  { entry: 'skills', label: 'Skills' },
+  { entry: 'github', label: 'GitHub' }
 ]
 
 function makeGitHubWorkItem(overrides: Partial<GitHubWorkItem> = {}): GitHubWorkItem {

--- a/src/renderer/src/store/slices/worktree-nav-history.ts
+++ b/src/renderer/src/store/slices/worktree-nav-history.ts
@@ -15,12 +15,18 @@ import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 const MAX_HISTORY = 50
 
 // Why: entries may be page sentinels, not just worktree IDs; names keep the "worktree" prefix for call-site stability.
-export type WorktreeNavHistorySimpleViewEntry = 'tasks' | 'automations' | 'artifacts' | 'skills'
+export type WorktreeNavHistorySimpleViewEntry =
+  | 'tasks'
+  | 'automations'
+  | 'artifacts'
+  | 'skills'
+  | 'github'
 const SIMPLE_VIEW_ENTRIES: readonly WorktreeNavHistorySimpleViewEntry[] = [
   'tasks',
   'automations',
   'artifacts',
-  'skills'
+  'skills',
+  'github'
 ]
 export type WorktreeNavHistoryTaskDetailEntry =
   | {

--- a/src/shared/clone-destination.ts
+++ b/src/shared/clone-destination.ts
@@ -1,0 +1,58 @@
+// Shared between renderer (clone autofill, GitHub panel) and main (cloned-repo
+// file cleanup), which is why this pure path logic cannot live under renderer/.
+
+export function getDefaultCloneParent(workspaceDir: string): string {
+  if (!workspaceDir) {
+    return ''
+  }
+
+  const trimmed = workspaceDir.replace(/[\\/]+$/, '')
+  if (!trimmed) {
+    return workspaceDir
+  }
+
+  const separatorIndex = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+  const lastSegment = separatorIndex === -1 ? trimmed : trimmed.slice(separatorIndex + 1)
+
+  if (lastSegment !== 'workspaces') {
+    return workspaceDir
+  }
+
+  // Why: default Orca worktrees live under "workspaces"; clones should sit beside that tree.
+  const parent = separatorIndex === -1 ? '' : trimmed.slice(0, separatorIndex)
+  if (parent === '' && trimmed.startsWith('/')) {
+    return '/'
+  }
+  if (/^[A-Za-z]:$/.test(parent)) {
+    return `${parent}${trimmed[separatorIndex]}`
+  }
+  return parent
+}
+
+// Variant for the GitHub account panel: clones land in a sibling "projects"
+// tree (`~/orca/projects/<repo>`) instead of directly beside "workspaces".
+// The sidebar clone flow intentionally keeps getDefaultCloneParent unchanged.
+export function getDefaultProjectsCloneParent(workspaceDir: string): string {
+  if (!workspaceDir) {
+    return ''
+  }
+
+  const trimmed = workspaceDir.replace(/[\\/]+$/, '')
+  if (!trimmed) {
+    return workspaceDir
+  }
+
+  const separatorIndex = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+  const lastSegment = separatorIndex === -1 ? trimmed : trimmed.slice(separatorIndex + 1)
+
+  if (lastSegment !== 'workspaces') {
+    return workspaceDir
+  }
+
+  const separator = separatorIndex === -1 ? '/' : trimmed[separatorIndex]
+  const parent = separatorIndex === -1 ? '' : trimmed.slice(0, separatorIndex)
+  if (parent === '') {
+    return trimmed.startsWith('/') ? '/projects' : 'projects'
+  }
+  return `${parent}${separator}projects`
+}

--- a/src/shared/github-account.ts
+++ b/src/shared/github-account.ts
@@ -1,0 +1,78 @@
+// Types for the GitHub account panel: in-app sign-in (device flow or PAT),
+// the authenticated user's repository list, and clone-into-Orca handoff.
+// The token itself never crosses IPC — only status metadata and results.
+
+import type { Repo } from './repo-types'
+
+export type GitHubAccountAuthMethod = 'device-flow' | 'pat'
+
+// Where the active credential comes from. Drives whether the UI offers
+// Disconnect, which is only meaningful for in-app `stored` credentials.
+export type GitHubAccountCredentialSource = 'environment' | 'stored' | 'none'
+
+// Deliberately excludes the token: it never crosses the IPC boundary back to
+// the renderer.
+export type GitHubAccountStatus = {
+  configured: boolean
+  source: GitHubAccountCredentialSource
+  login: string | null
+  name: string | null
+  avatarUrl: string | null
+  authMethod: GitHubAccountAuthMethod | null
+  /** True when an OAuth client id is configured, so the panel can offer device flow. */
+  deviceFlowAvailable: boolean
+}
+
+export type GitHubConnectTokenResult =
+  | { ok: true; login: string | null }
+  | { ok: false; error: string }
+
+export type GitHubDeviceFlowStart = {
+  deviceCode: string
+  userCode: string
+  verificationUri: string
+  expiresInSeconds: number
+  pollIntervalSeconds: number
+}
+
+export type GitHubDeviceFlowStartResult =
+  | { ok: true; flow: GitHubDeviceFlowStart }
+  | { ok: false; error: string }
+
+export type GitHubDeviceFlowPollResult =
+  | { status: 'pending'; pollIntervalSeconds?: number }
+  | { status: 'connected'; login: string | null }
+  | { status: 'error'; error: string }
+
+export type GitHubAccountRepo = {
+  id: number
+  name: string
+  fullName: string
+  description: string | null
+  isPrivate: boolean
+  isFork: boolean
+  htmlUrl: string
+  cloneUrl: string
+  sshUrl: string
+  defaultBranch: string
+  language: string | null
+  stargazersCount: number
+  pushedAt: string | null
+  ownerLogin: string
+  ownerAvatarUrl: string | null
+}
+
+export type GitHubRepoListResult =
+  | { ok: true; repos: GitHubAccountRepo[] }
+  | { ok: false; error: string }
+
+export type GitHubCloneRepoArgs = {
+  fullName: string
+  cloneUrl: string
+  isPrivate: boolean
+  destination: string
+}
+
+export type GitHubCloneRepoResult = { ok: true; repo: Repo } | { ok: false; error: string }
+
+export type GitHubDeleteClonedRepoFilesResult = { ok: true } | { ok: false; error: string }

--- a/src/shared/integration-credential-errors.ts
+++ b/src/shared/integration-credential-errors.ts
@@ -1,4 +1,4 @@
-export type IntegrationCredentialService = 'Linear' | 'Jira' | 'Bitbucket'
+export type IntegrationCredentialService = 'Linear' | 'Jira' | 'Bitbucket' | 'GitHub'
 
 export function credentialDecryptionMessage(service: IntegrationCredentialService): string {
   return `Could not decrypt saved ${service} credential. Approve Keychain access or reconnect ${service}.`
@@ -11,6 +11,7 @@ export function isIntegrationCredentialDecryptionError(error: unknown): boolean 
   return (
     message.includes(credentialDecryptionMessage('Linear')) ||
     message.includes(credentialDecryptionMessage('Jira')) ||
-    message.includes(credentialDecryptionMessage('Bitbucket'))
+    message.includes(credentialDecryptionMessage('Bitbucket')) ||
+    message.includes(credentialDecryptionMessage('GitHub'))
   )
 }

--- a/src/shared/top-level-view.ts
+++ b/src/shared/top-level-view.ts
@@ -11,7 +11,8 @@ const TOP_LEVEL_VIEW_LOOKUP: Record<TopLevelView, true> = {
   space: true,
   skills: true,
   artifacts: true,
-  mobile: true
+  mobile: true,
+  github: true
 }
 
 export function isTopLevelView(value: unknown): value is TopLevelView {

--- a/src/shared/ui-chrome-types.ts
+++ b/src/shared/ui-chrome-types.ts
@@ -116,3 +116,4 @@ export type TopLevelView =
   | 'skills'
   | 'artifacts'
   | 'mobile'
+  | 'github'


### PR DESCRIPTION
## ELI5

Adds a "My GitHub" panel to the sidebar (between Tasks and Automations) where you sign in to your own GitHub account with Device Flow (no PAT copy-paste), browse your own repos — recent and private included — and clone one straight into Orca's project management. Cloned repos land in `~/orca/projects/<repo>` and show up in the Projects panel, so existing multi-project/worktree management just works. A cleanup action removes the project and moves the files to the Trash/Recycle Bin when you're done.

## What Changed

- **Main: new `src/main/github-auth/` module** — Device Flow sign-in (`device-flow.ts`), encrypted token storage (`credential-store.ts`), account/repo listing (`viewer.ts`, `repo-list.ts`, `connection.ts`, `api-request.ts`), clone with same-name precheck that aborts with a clear error (`clone-repo.ts`), and guarded file cleanup (`delete-cloned-repo-files.ts`).
- **IPC + preload**: `githubAuth:*` handlers (`src/main/ipc/github-auth.ts`) and matching preload API. Tokens never cross IPC into the renderer — only account metadata and repo lists do.
- **Clone flow reuse, not duplication**: the existing local-clone IPC body in `repo-clone-lifecycle.ts` was extracted verbatim into an exported `cloneLocalRepoIntoDestination()`; the only behavioral addition is an optional `extraGitConfig` param. Private-repo clones authenticate via a one-shot `-c http.https://github.com/.extraheader=…` flag, so the token never lands in the remote URL, `.git/config`, or stderr. The sidebar clone flow is byte-for-byte the same as before.
- **Clone destination**: `getDefaultCloneParent` moved verbatim into `src/shared/clone-destination.ts`; the panel uses a new sibling variant `getDefaultProjectsCloneParent` (`~/orca/workspaces` → `~/orca/projects`). The original function's behavior is unchanged (covered by existing + moved tests).
- **Renderer**: `GitHubPage` / `GitHubSignInPanel` / `GitHubRepoList` under `src/renderer/src/components/github-panel/`, a "My GitHub" sidebar entry, and a new top-level view in the ui store. Rows show private/fork badges, pushed-at, language; "Added" rows get a dropdown with *Remove from Orca* and (only when eligible) *Remove and move files to Trash/Recycle Bin*.
- **i18n**: 41 new keys added to `en.json` via `sync:localization-catalog`; other locales fall back to English at runtime until translated.

## Why

Managing your own GitHub projects today means cloning in a terminal and re-adding the folder by hand. Signing in inside Orca removes that friction and feeds directly into the project/worktree management Orca already has. Design constraints followed: no changes to existing flows (purely additive), reuse of the existing clone lifecycle, and destructive actions gated behind main-process re-validation.

## Linked Issue

Implements #17180

## Visual Proof

Before: N/A — the panel and its sidebar entry are new; nothing existed to compare.

Signed-in repo list — private lock icons, fork icons, Clone buttons, one row already "Added":

![My GitHub panel: signed-in repo list](https://github.com/coconilu/orca/blob/fef40df976cf249505dcdc70cc30ef764c9d9ebb/after-repo-list.png?raw=true)

The "Added" dropdown on a cloned repo — *Remove from Orca* + *Remove and move files to Recycle Bin*; the cloned repo now appears in the Projects sidebar:

![Added row dropdown with cleanup action](https://github.com/coconilu/orca/blob/fef40df976cf249505dcdc70cc30ef764c9d9ebb/after-added-menu.png?raw=true)

Cleanup confirmation naming the exact path that would move to the Recycle Bin:

![Cleanup confirmation dialog](https://github.com/coconilu/orca/blob/fef40df976cf249505dcdc70cc30ef764c9d9ebb/after-cleanup-confirm.png?raw=true)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- Platform actually tested: **Windows 11** (dev instance): Device Flow sign-in, repo listing with private repos, clone into `~/orca/projects`, duplicate-name abort, cleanup dialog (cancelled — no deletion), removal from Orca. macOS/Linux were **not** run on real machines; platform-sensitive code uses existing cross-platform helpers (`shell.trashItem`, separator-agnostic path handling, Trash vs Recycle Bin label switched on the user agent).
- Automated: new tests for `clone-repo` (5), `credential-store` (5), `delete-cloned-repo-files` (10), `device-flow` (5), `repo-list` (3), `github-added-repo-match` (3), plus updated `clone-defaults` / `ui-page-navigation` / `repos-local-clone-lifecycle` suites — all green.
- `pnpm typecheck`: pass. `pnpm build`: pass. `pnpm lint` (incl. type-aware): clean on changed files.
- Full `pnpm test` on this Windows machine: 64,510 passed / 285 failed. A control run of a representative failing sample (6 files / 48 tests, spanning WSL, SSH, daemon, watcher areas this machine can't service) fails **identically on pristine `upstream/main`**, so those failures are pre-existing environment limitations, not regressions from this PR. None of the failing files are touched by this PR. CI on proper runners is the authoritative check.

## AI Disclosure

Pair-programmed with **Kimi Code (Moonshot AI)**. The human author directed the design (panel scope, clone location, safety guards, naming), reviewed the diff, and performed the acceptance testing above.

## Review

AI-assisted self-review summary:

- **Security**: tokens are stored encrypted via the existing credential-store approach and never cross IPC into the renderer; clone auth uses a one-shot `-c extraheader` so tokens can't leak into URLs, `.git/config`, or stderr; file deletion is re-validated in the main process (must be a `cloned` repo, local-only, path re-computed and confirmed inside the projects root — the renderer-supplied path is never trusted).
- **Cross-platform**: clone destination and cleanup-root checks are path-separator agnostic; `shell.trashItem` works on macOS/Windows/Linux; the Trash/Recycle Bin label follows the platform. No hardcoded `metaKey`, no shell-specific assumptions.
- **Remote SSH**: cleanup is refused for repos with a `connectionId` or non-local `executionHostId`; the panel clone only targets the local host. Nothing about remote execution changes.
- **Wire compatibility**: no RPC/stream changes a mixed-version pair could exchange — new IPC channels only exist between a matched preload/main pair.
- **Performance**: repo list is fetched on demand with the existing integration rate-limit patterns; no hot-path changes.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- Author X handle: [@Mr__Alpha](https://x.com/Mr__Alpha)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
