### PR TITLE
fix(macos): disclaim TCC responsibility at PTY spawn instead of relying on login(1)

### DIFF
--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/binding.gyp b/binding.gyp
-index 5f63978b07ab50aaf7523219a2170ec737a6b5db..bbd9e06136e8922f40b5779e35d4fc835f1479ab 100644
+index 5f63978..837360b 100644
 --- a/binding.gyp
 +++ b/binding.gyp
 @@ -1,13 +1,18 @@
@@ -8,7 +8,7 @@ index 5f63978b07ab50aaf7523219a2170ec737a6b5db..bbd9e06136e8922f40b5779e35d4fc83
      'dependencies': [
 -      "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except",
 +      "<!(node -p \"require.resolve('node-addon-api/node_addon_api.gyp')\"):node_addon_api_except",
-     ],
++    ],
 +    # Orca: GCC 9 (Ubuntu 20.04 floor) accepts C++20 as gnu++2a, but rejects
 +    # the newer gnu++20 spelling emitted by Node 24's gyp flags.
 +    'cflags_cc!': [
@@ -16,7 +16,7 @@ index 5f63978b07ab50aaf7523219a2170ec737a6b5db..bbd9e06136e8922f40b5779e35d4fc83
 +    ],
 +    'cflags_cc': [
 +      '-std=gnu++2a'
-+    ],
+     ],
      'conditions': [
        ['OS=="win"', {
 -        'msvs_configuration_attributes': {
@@ -25,7 +25,7 @@ index 5f63978b07ab50aaf7523219a2170ec737a6b5db..bbd9e06136e8922f40b5779e35d4fc83
          'msvs_settings': {
              'VCCLCompilerTool': {
                'AdditionalOptions': [
-@@ -42,32 +39,6 @@
+@@ -42,32 +47,6 @@
              '-lshlwapi'
            ],
          },
@@ -58,7 +58,7 @@ index 5f63978b07ab50aaf7523219a2170ec737a6b5db..bbd9e06136e8922f40b5779e35d4fc83
        ]
      }, { # OS!="win"
        'targets': [
-@@ -88,6 +85,16 @@
+@@ -88,6 +67,16 @@
                'libraries!': [
                  '-lutil'
                ]
@@ -76,7 +76,7 @@ index 5f63978b07ab50aaf7523219a2170ec737a6b5db..bbd9e06136e8922f40b5779e35d4fc83
            ]
          }
 diff --git a/deps/winpty/src/winpty.gyp b/deps/winpty/src/winpty.gyp
-index 1ac5758bedd8cf54f32280dea4e4aeb5afdee30d..e619813759c6f14694838bdfbd0ea5f8360130ef 100644
+index 1ac5758..e619813 100644
 --- a/deps/winpty/src/winpty.gyp
 +++ b/deps/winpty/src/winpty.gyp
 @@ -10,7 +10,7 @@
@@ -118,7 +118,7 @@ index 1ac5758bedd8cf54f32280dea4e4aeb5afdee30d..e619813759c6f14694838bdfbd0ea5f8
                  # Specify this setting here to override a setting from somewhere
                  # else, such as node's common.gypi.
 diff --git a/lib/conpty_console_list_agent.js b/lib/conpty_console_list_agent.js
-index 8c4fca9022a6d6f015bca87f61625cde2278f428..0a01730616488119aa21ef441cf3c441e02a974c 100644
+index 8c4fca9..0a01730 100644
 --- a/lib/conpty_console_list_agent.js
 +++ b/lib/conpty_console_list_agent.js
 @@ -10,7 +10,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
@@ -139,7 +139,7 @@ index 8c4fca9022a6d6f015bca87f61625cde2278f428..0a01730616488119aa21ef441cf3c441
  //# sourceMappingURL=conpty_console_list_agent.js.map
 \ No newline at end of file
 diff --git a/lib/unixTerminal.js b/lib/unixTerminal.js
-index 1ec12f796a822c78fba9ad7f6448c3987e325c23..cec8b67aef02f8199e5606a0d257088bf1865877 100644
+index 1ec12f7..526a2c3 100644
 --- a/lib/unixTerminal.js
 +++ b/lib/unixTerminal.js
 @@ -28,8 +28,12 @@ var native = utils_1.loadNativeModule('pty');
@@ -157,8 +157,29 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..cec8b67aef02f8199e5606a0d257088b
  var DEFAULT_FILE = 'sh';
  var DEFAULT_NAME = 'xterm';
  var DESTROY_SOCKET_TIMEOUT_MS = 200;
+@@ -127,6 +131,8 @@ var UnixTerminal = /** @class */ (function (_super) {
+         _this._pid = term.pid;
+         _this._fd = term.fd;
+         _this._pty = term.pty;
++        // Orca (STA-3631): absent on unpatched builds, so readers treat undefined as "unknown".
++        _this._tccDisclaim = term.tccDisclaim;
+         _this._file = file;
+         _this._name = name;
+         _this._readable = true;
+@@ -166,6 +172,11 @@ var UnixTerminal = /** @class */ (function (_super) {
+         enumerable: false,
+         configurable: true
+     });
++    Object.defineProperty(UnixTerminal.prototype, "tccDisclaim", {
++        get: function () { return this._tccDisclaim; },
++        enumerable: false,
++        configurable: true
++    });
+     /**
+      * openpty
+      */
 diff --git a/src/conpty_console_list_agent.ts b/src/conpty_console_list_agent.ts
-index 181ccabbbe9c4948a9725fb1db907a68e9de01fc..67f31facf85562b67adbfbd04ce28ddd8eeb4a79 100644
+index 181ccab..67f31fa 100644
 --- a/src/conpty_console_list_agent.ts
 +++ b/src/conpty_console_list_agent.ts
 @@ -10,6 +10,12 @@ import { loadNativeModule } from './utils';
@@ -176,7 +197,7 @@ index 181ccabbbe9c4948a9725fb1db907a68e9de01fc..67f31facf85562b67adbfbd04ce28ddd
  process.send!({ consoleProcessList });
  process.exit(0);
 diff --git a/src/unix/pty.cc b/src/unix/pty.cc
-index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d15c4dd44 100644
+index 7b4b9e1..9193e6a 100644
 --- a/src/unix/pty.cc
 +++ b/src/unix/pty.cc
 @@ -23,7 +23,9 @@
@@ -189,7 +210,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  #include <thread>
  
  #include <sys/types.h>
-@@ -47,6 +49,25 @@
+@@ -47,6 +49,68 @@
  #include <termios.h>
  #endif
  
@@ -212,10 +233,53 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 +#  endif
 +#endif
 +
++/* Orca (STA-3631): macOS 26 no longer breaks TCC responsibility inheritance at
++ * an intermediate login(1) session, so every terminal child is attributed to the
++ * app bundle. Disclaim responsibility on the spawn attributes instead — the same
++ * mechanism Terminal.app and iTerm2 rely on. Resolved at runtime because the
++ * symbol is SPI and absent from the public SDK headers. */
++#if defined(__APPLE__)
++#include <dlfcn.h>
++#include <spawn.h>
++
++/* Verdict codes surfaced to JS; keep in sync with lib/unixTerminal.js. */
++#define ORCA_TCC_DISCLAIM_UNKNOWN 0
++#define ORCA_TCC_DISCLAIM_APPLIED 1
++#define ORCA_TCC_DISCLAIM_UNSUPPORTED 2
++#define ORCA_TCC_DISCLAIM_FAILED 3
++
++typedef int (*orca_tcc_setdisclaim_fn)(posix_spawnattr_t*, int);
++
++static orca_tcc_setdisclaim_fn
++orca_tcc_resolve_setdisclaim(void) {
++  static orca_tcc_setdisclaim_fn resolved = NULL;
++  static bool attempted = false;
++  if (!attempted) {
++    attempted = true;
++    resolved = (orca_tcc_setdisclaim_fn)dlsym(
++        RTLD_DEFAULT, "responsibility_spawnattrs_setdisclaim");
++  }
++  return resolved;
++}
++
++/* Returns one of the ORCA_TCC_DISCLAIM_* verdicts. Never reports APPLIED unless
++ * the SPI both resolved and returned success, so callers can say "unknown"
++ * rather than assume isolation that may not exist. */
++static int
++orca_tcc_apply_disclaim(posix_spawnattr_t* attrs) {
++  orca_tcc_setdisclaim_fn setdisclaim = orca_tcc_resolve_setdisclaim();
++  if (setdisclaim == NULL) {
++    return ORCA_TCC_DISCLAIM_UNSUPPORTED;
++  }
++  return setdisclaim(attrs, 1) == 0 ? ORCA_TCC_DISCLAIM_APPLIED
++                                    : ORCA_TCC_DISCLAIM_FAILED;
++}
++#endif
++
  /* Some platforms name VWERASE and VDISCARD differently */
  #if !defined(VWERASE) && defined(VWERSE)
  #define VWERASE	VWERSE
-@@ -237,13 +258,23 @@ pty_getproc(int, char *);
+@@ -237,13 +301,24 @@ pty_getproc(int, char *);
  #endif
  
  #if defined(__APPLE__) || defined(__OpenBSD__)
@@ -236,11 +300,12 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
                  int* master,
                  pid_t* pid,
 -                int* err);
-+                pty_spawn_error* err);
++                pty_spawn_error* err,
++                int* tcc_disclaim);
  #endif
  
  struct DelBuf {
-@@ -367,10 +398,11 @@ Napi::Value PtyFork(const Napi::CallbackInfo& info) {
+@@ -367,10 +442,13 @@ Napi::Value PtyFork(const Napi::CallbackInfo& info) {
      argv[i + 3] = strdup(arg.c_str());
    }
  
@@ -249,14 +314,26 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 -  if (err != 0) {
 -    throw Napi::Error::New(napiEnv, "posix_spawnp failed.");
 +  pty_spawn_error spawn_error = { NULL, 0, "", "" };
-+  pty_posix_spawn(argv, env, term, &winp, &master, &pid, &spawn_error);
++  int tcc_disclaim = ORCA_TCC_DISCLAIM_UNKNOWN;
++  pty_posix_spawn(argv, env, term, &winp, &master, &pid, &spawn_error,
++                  &tcc_disclaim);
 +  if (spawn_error.errnum != 0) {
 +    std::string spawn_message = pty_format_spawn_error(spawn_error);
 +    throw Napi::Error::New(napiEnv, spawn_message);
    }
    if (pty_nonblock(master) == -1) {
      throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
-@@ -684,15 +716,73 @@ pty_getproc(int fd, char *tty) {
+@@ -452,6 +530,9 @@ Napi::Value PtyFork(const Napi::CallbackInfo& info) {
+   obj.Set("fd", Napi::Number::New(napiEnv, master));
+   obj.Set("pid", Napi::Number::New(napiEnv, pid));
+   obj.Set("pty", Napi::String::New(napiEnv, ptsname(master)));
++#if defined(__APPLE__)
++  obj.Set("tccDisclaim", Napi::Number::New(napiEnv, tcc_disclaim));
++#endif
+ 
+   // Set up process exit callback.
+   Napi::Function cb = info[10].As<Napi::Function>();
+@@ -684,15 +765,74 @@ pty_getproc(int fd, char *tty) {
  #endif
  
  #if defined(__APPLE__)
@@ -320,7 +397,8 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
                  pid_t* pid,
 -                int* err) {
 -  int low_fds[3];
-+                pty_spawn_error* err) {
++                pty_spawn_error* err,
++                int* tcc_disclaim) {
 +  int low_fds[3] = {-1, -1, -1};
    size_t count = 0;
 +  int res = -1;
@@ -332,25 +410,25 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  
    for (; count < 3; count++) {
      low_fds[count] = posix_openpt(O_RDWR);
-@@ -706,80 +796,118 @@ pty_posix_spawn(char** argv, char** env,
+@@ -706,80 +846,122 @@ pty_posix_spawn(char** argv, char** env,
                POSIX_SPAWN_SETSID;
    *master = posix_openpt(O_RDWR);
    if (*master == -1) {
 -    return;
 +    pty_set_spawn_error(err, "posix_openpt", errno);
 +    goto done;
++  }
++
++  res = grantpt(*master);
++  if (res == -1) {
++    pty_set_spawn_error(err, "grantpt", errno);
++    goto done;
    }
  
 -  int res = grantpt(*master) || unlockpt(*master);
-+  res = grantpt(*master);
++  res = unlockpt(*master);
    if (res == -1) {
 -    return;
-+    pty_set_spawn_error(err, "grantpt", errno);
-+    goto done;
-+  }
-+
-+  res = unlockpt(*master);
-+  if (res == -1) {
 +    pty_set_spawn_error(err, "unlockpt", errno);
 +    goto done;
    }
@@ -411,14 +489,18 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 +  res = posix_spawnattr_init(&attrs);
 +  if (res != 0) {
 +    pty_set_spawn_error(err, "posix_spawnattr_init", res);
-+    goto done;
-+  }
+     goto done;
+   }
 +  attrs_initialized = true;
 +  res = posix_spawnattr_setflags(&attrs, flags);
 +  if (res != 0) {
 +    pty_set_spawn_error(err, "posix_spawnattr_setflags", res);
-     goto done;
-   }
++    goto done;
++  }
++
++  /* Orca (STA-3631): a failed disclaim is reported, never fatal — a shell with
++   * collapsed attribution still beats no shell. */
++  *tcc_disclaim = orca_tcc_apply_disclaim(&attrs);
  
    sigset_t signal_set;
    /* Reset all signal the child to their default behavior */
@@ -475,8 +557,37 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
    }
  }
  #endif
+diff --git a/src/unixTerminal.ts b/src/unixTerminal.ts
+index 98733dc..6077b46 100644
+--- a/src/unixTerminal.ts
++++ b/src/unixTerminal.ts
+@@ -26,6 +26,7 @@ const DESTROY_SOCKET_TIMEOUT_MS = 200;
+ export class UnixTerminal extends Terminal {
+   protected _fd: number;
+   protected _pty: string;
++  protected _tccDisclaim: number | undefined;
+ 
+   protected _file: string;
+   protected _name: string;
+@@ -147,6 +148,8 @@ export class UnixTerminal extends Terminal {
+     this._pid = term.pid;
+     this._fd = term.fd;
+     this._pty = term.pty;
++    // Orca (STA-3631): absent on unpatched builds, so readers treat undefined as "unknown".
++    this._tccDisclaim = term.tccDisclaim;
+ 
+     this._file = file;
+     this._name = name;
+@@ -172,6 +175,7 @@ export class UnixTerminal extends Terminal {
+ 
+   /* Accessors */
+   get fd(): number { return this._fd; }
++  get tccDisclaim(): number | undefined { return this._tccDisclaim; }
+   get ptsName(): string { return this._pty; }
+ 
+   /**
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d644c26141df516929703aa6e129df4b2..ec6bf3932c65b89c013ff133dc6bf46a6a4082ce 100644
+index 7b286d3..ec6bf39 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
 @@ -18,6 +18,7 @@

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,7 +115,7 @@ patchedDependencies:
   '@xterm/addon-webgl@0.20.0-beta.286': 2c301a06ad9caa635d746147dcb2b1c69aa026904f65e1183564f08a0e601b91
   '@xterm/xterm@6.1.0-beta.287': 46796c152f3b73e28238f44499eaf5a867a863809bc7b470b159526a41e354f7
   lint-staged@16.4.0: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
-  node-pty@1.1.0: 9a2eedbf2448b8ff1387a8a740ee5e4e968bf8484d7d80e12a3f6a2dc26b0e17
+  node-pty@1.1.0: e09d7ecc093abdce946aab18c025faa1ae4ab4b329be1d6be4829090740cd4ba
 
 importers:
 
@@ -156,7 +156,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=9a2eedbf2448b8ff1387a8a740ee5e4e968bf8484d7d80e12a3f6a2dc26b0e17)
+        version: 1.1.0(patch_hash=e09d7ecc093abdce946aab18c025faa1ae4ab4b329be1d6be4829090740cd4ba)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12152,7 +12152,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=9a2eedbf2448b8ff1387a8a740ee5e4e968bf8484d7d80e12a3f6a2dc26b0e17):
+  node-pty@1.1.0(patch_hash=e09d7ecc093abdce946aab18c025faa1ae4ab4b329be1d6be4829090740cd4ba):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -298,7 +298,10 @@ async function main(): Promise<void> {
         ...(process.platform === 'darwin'
           ? {
               onMacosTccSpawnStrategy: (strategy) =>
-                daemonLog.log('macos-tcc-pty-spawn', { strategy })
+                daemonLog.log('macos-tcc-pty-spawn', {
+                  wrapper: strategy.wrapper,
+                  attribution: strategy.attribution
+                })
             }
           : {})
       }),

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -130,7 +130,10 @@ describe('createPtySubprocess', () => {
         name: 'xterm-256color'
       })
     )
-    expect(onMacosTccSpawnStrategy).toHaveBeenCalledWith('direct')
+    expect(onMacosTccSpawnStrategy).toHaveBeenCalledWith({
+      wrapper: 'direct',
+      attribution: 'unknown'
+    })
   })
 
   it('does not spawn after cancellation wins during async cwd validation', async () => {

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -4,6 +4,7 @@ import { TerminalAttachCanceledError } from './daemon-errors'
 import { createDaemonPtyEnvironment } from './pty-subprocess/spawn-environment'
 import { createPtyShellLaunchPlan } from './pty-subprocess/shell-launch-plan'
 import { spawnNativeDaemonPty, type SpawnedDaemonPty } from './pty-subprocess/native-pty-spawn'
+import type { MacosTccSpawnStrategy } from '../providers/macos-tcc-spawn-attribution'
 import {
   formatPtySpawnError,
   preflightPtySpawn,
@@ -33,7 +34,7 @@ export type PtySubprocessOptions = {
   isCanceled?: () => boolean
   /** Aborts in-progress cwd validation; `isCanceled` is only polled between steps. */
   cancelSignal?: AbortSignal
-  onMacosTccSpawnStrategy?: (strategy: 'wrapped' | 'direct') => void
+  onMacosTccSpawnStrategy?: (strategy: MacosTccSpawnStrategy) => void
 }
 
 export async function checkPtySpawnHealth(): Promise<void> {

--- a/src/main/daemon/pty-subprocess/native-pty-spawn-tcc-attribution.test.ts
+++ b/src/main/daemon/pty-subprocess/native-pty-spawn-tcc-attribution.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const spawnMock = vi.fn()
+vi.mock('node-pty', () => ({ spawn: (...a: unknown[]) => spawnMock(...a) }))
+vi.mock('../../windows/windows-pty-job', () => ({ assignHostProcessToKillOnCloseJob: vi.fn() }))
+
+import { spawnNativeDaemonPty } from './native-pty-spawn'
+import type { MacosTccSpawnStrategy } from '../../providers/macos-tcc-spawn-attribution'
+
+const realPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true })
+}
+
+function spawnedPty(extra: Record<string, unknown> = {}) {
+  return { pid: 4242, onData: vi.fn(), onExit: vi.fn(), write: vi.fn(), kill: vi.fn(), ...extra }
+}
+
+function run(onMacosTccSpawnStrategy: (strategy: MacosTccSpawnStrategy) => void) {
+  spawnNativeDaemonPty({
+    shellPath: '/bin/zsh',
+    shellArgs: ['-l'],
+    spawnCwd: '/tmp',
+    env: { SHELL: '/bin/zsh' },
+    cols: 80,
+    rows: 24,
+    windowsFallbackAttempts: [],
+    onMacosTccSpawnStrategy
+  })
+}
+
+beforeEach(() => spawnMock.mockReset())
+afterEach(() => {
+  if (realPlatform) {
+    Object.defineProperty(process, 'platform', realPlatform)
+  }
+})
+
+describe('spawnNativeDaemonPty macOS TCC attribution reporting', () => {
+  // Why: the verdict must come off the process node-pty actually returned, not
+  // from the argv we asked for — `wrapped` never implied isolation (STA-3631).
+  it('reports the disclaim verdict carried by the spawned process', () => {
+    setPlatform('darwin')
+    spawnMock.mockReturnValue(spawnedPty({ tccDisclaim: 1 }))
+    const onMacosTccSpawnStrategy = vi.fn()
+    run(onMacosTccSpawnStrategy)
+    expect(onMacosTccSpawnStrategy).toHaveBeenCalledWith(
+      expect.objectContaining({ attribution: 'disclaimed' })
+    )
+  })
+
+  it('reports unknown when the spawned process carries no verdict', () => {
+    setPlatform('darwin')
+    spawnMock.mockReturnValue(spawnedPty())
+    const onMacosTccSpawnStrategy = vi.fn()
+    run(onMacosTccSpawnStrategy)
+    expect(onMacosTccSpawnStrategy).toHaveBeenCalledWith(
+      expect.objectContaining({ attribution: 'unknown' })
+    )
+  })
+
+  it('reports not-disclaimed when the native spawn could not apply the attribute', () => {
+    setPlatform('darwin')
+    spawnMock.mockReturnValue(spawnedPty({ tccDisclaim: 2 }))
+    const onMacosTccSpawnStrategy = vi.fn()
+    run(onMacosTccSpawnStrategy)
+    expect(onMacosTccSpawnStrategy).toHaveBeenCalledWith(
+      expect.objectContaining({ attribution: 'not-disclaimed' })
+    )
+  })
+
+  // Why: the wrapper decision and the disclaim verdict are independent facts.
+  it('keeps the wrapper verdict separate from the attribution verdict', () => {
+    setPlatform('darwin')
+    spawnMock.mockReturnValue(spawnedPty({ tccDisclaim: 1 }))
+    const onMacosTccSpawnStrategy = vi.fn()
+    run(onMacosTccSpawnStrategy)
+    expect(onMacosTccSpawnStrategy).toHaveBeenCalledWith({
+      wrapper: 'direct',
+      attribution: 'disclaimed'
+    })
+  })
+})

--- a/src/main/daemon/pty-subprocess/native-pty-spawn.ts
+++ b/src/main/daemon/pty-subprocess/native-pty-spawn.ts
@@ -3,6 +3,10 @@ import {
   hostReportsChildExitStatus,
   wrapShellSpawnForMacosTccAttribution
 } from '../../providers/macos-tcc-login-shell'
+import {
+  readMacosTccAttribution,
+  type MacosTccSpawnStrategy
+} from '../../providers/macos-tcc-spawn-attribution'
 import type { WindowsShellSpawnAttempt } from '../../providers/windows-shell-fallback-chain'
 import { assignHostProcessToKillOnCloseJob } from '../../windows/windows-pty-job'
 
@@ -24,7 +28,7 @@ export function spawnNativeDaemonPty(args: {
   cols: number
   rows: number
   windowsFallbackAttempts: WindowsShellSpawnAttempt[]
-  onMacosTccSpawnStrategy?: (strategy: 'wrapped' | 'direct') => void
+  onMacosTccSpawnStrategy?: (strategy: MacosTccSpawnStrategy) => void
 }): SpawnedDaemonPty {
   let reportsChildExitStatus = true
   const spawnAt = (shellPath: string, shellArgs: string[], cwd: string): pty.IPty => {
@@ -43,7 +47,12 @@ export function spawnNativeDaemonPty(args: {
       ...(process.platform === 'win32' ? { useConptyDll: true } : {})
     })
     reportsChildExitStatus = hostReportsChildExitStatus(wrapped.file)
-    args.onMacosTccSpawnStrategy?.(wrapped.file === shellPath ? 'direct' : 'wrapped')
+    // Why: the wrapper and the disclaim are independent — login(1) stopped isolating
+    // attribution on macOS 26, so report what each one actually achieved (STA-3631).
+    args.onMacosTccSpawnStrategy?.({
+      wrapper: wrapped.file === shellPath ? 'direct' : 'wrapped',
+      attribution: readMacosTccAttribution(proc)
+    })
     return proc
   }
 

--- a/src/main/providers/macos-tcc-spawn-attribution.test.ts
+++ b/src/main/providers/macos-tcc-spawn-attribution.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { readMacosTccAttribution } from './macos-tcc-spawn-attribution'
+
+const realPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function withPlatform<T>(value: NodeJS.Platform, run: () => T): T {
+  Object.defineProperty(process, 'platform', { value, configurable: true })
+  return run()
+}
+
+afterEach(() => {
+  if (realPlatform) {
+    Object.defineProperty(process, 'platform', realPlatform)
+  }
+})
+
+describe('readMacosTccAttribution', () => {
+  it('reports disclaimed only when the native spawn says the attribute applied', () => {
+    expect(withPlatform('darwin', () => readMacosTccAttribution({ tccDisclaim: 1 }))).toBe(
+      'disclaimed'
+    )
+  })
+
+  it('reports not-disclaimed when the SPI was missing or the call failed', () => {
+    expect(withPlatform('darwin', () => readMacosTccAttribution({ tccDisclaim: 2 }))).toBe(
+      'not-disclaimed'
+    )
+    expect(withPlatform('darwin', () => readMacosTccAttribution({ tccDisclaim: 3 }))).toBe(
+      'not-disclaimed'
+    )
+  })
+
+  // Why: an unpatched node-pty reports nothing; silence must never read as success (STA-3631).
+  it('reports unknown when node-pty reports no verdict at all', () => {
+    expect(withPlatform('darwin', () => readMacosTccAttribution({}))).toBe('unknown')
+    expect(withPlatform('darwin', () => readMacosTccAttribution(undefined))).toBe('unknown')
+    expect(withPlatform('darwin', () => readMacosTccAttribution(null))).toBe('unknown')
+  })
+
+  it('reports unknown for a non-numeric or unrecognized verdict', () => {
+    expect(withPlatform('darwin', () => readMacosTccAttribution({ tccDisclaim: '1' }))).toBe(
+      'unknown'
+    )
+    expect(withPlatform('darwin', () => readMacosTccAttribution({ tccDisclaim: 0 }))).toBe(
+      'unknown'
+    )
+    expect(withPlatform('darwin', () => readMacosTccAttribution({ tccDisclaim: 99 }))).toBe(
+      'unknown'
+    )
+  })
+
+  // Why: disclaiming is a darwin spawn attribute; other hosts have nothing to claim either way.
+  it('never claims disclaimed off macOS even if a verdict is present', () => {
+    expect(withPlatform('linux', () => readMacosTccAttribution({ tccDisclaim: 1 }))).toBe('unknown')
+    expect(withPlatform('win32', () => readMacosTccAttribution({ tccDisclaim: 1 }))).toBe('unknown')
+  })
+})

--- a/src/main/providers/macos-tcc-spawn-attribution.ts
+++ b/src/main/providers/macos-tcc-spawn-attribution.ts
@@ -1,0 +1,54 @@
+/**
+ * Spawn-time TCC responsibility disclaiming (STA-3631).
+ *
+ * macOS 26 no longer breaks TCC responsibility inheritance at an intermediate
+ * `login(1)` session, so every child of a wrapped pane is still attributed to
+ * Orca's bundle. The patched node-pty darwin spawn path calls
+ * `responsibility_spawnattrs_setdisclaim` and reports whether it took effect;
+ * this module turns that report into a verdict the spawn site can log honestly.
+ */
+
+/** Verdict codes emitted by the patched node-pty darwin spawn path. Keep in sync
+ *  with ORCA_TCC_DISCLAIM_* in config/patches/node-pty@1.1.0.patch. */
+const DISCLAIM_APPLIED = 1
+const DISCLAIM_UNSUPPORTED = 2
+const DISCLAIM_FAILED = 3
+
+/**
+ * Whether this spawn's children get their own TCC identity.
+ *
+ * `unknown` is the honest default: an unpatched node-pty reports nothing, and
+ * `wrapped` never implied isolation on macOS 26 — neither may this.
+ */
+export type MacosTccAttribution = 'disclaimed' | 'not-disclaimed' | 'unknown'
+
+/** How a pane shell's argv was built, paired with what that actually bought. */
+export type MacosTccSpawnStrategy = {
+  wrapper: 'wrapped' | 'direct'
+  attribution: MacosTccAttribution
+}
+
+/**
+ * Read the disclaim verdict off a spawned node-pty process.
+ *
+ * Reports `disclaimed` only on a positive report from the native spawn; a
+ * missing, non-numeric, or unrecognized value stays `unknown` so a node-pty
+ * without the patch can never be mistaken for an isolated one.
+ */
+export function readMacosTccAttribution(ptyProcess: unknown): MacosTccAttribution {
+  if (process.platform !== 'darwin') {
+    return 'unknown'
+  }
+  // Why: every non-verdict — absent, wrong type, unrecognized code — funnels through
+  // the same default, so an unpatched node-pty can never read as isolated.
+  const reported = (ptyProcess as { tccDisclaim?: unknown } | null | undefined)?.tccDisclaim
+  switch (reported) {
+    case DISCLAIM_APPLIED:
+      return 'disclaimed'
+    case DISCLAIM_UNSUPPORTED:
+    case DISCLAIM_FAILED:
+      return 'not-disclaimed'
+    default:
+      return 'unknown'
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​145 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​144 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​215 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​37 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​178 |

<!-- /orca-pr-loc -->

Fixes STA-3631. Same defect as STA-3297.

## ELI5

macOS decides "who is asking" when a program wants to read another app's data. Today, when Orca opens a terminal, macOS decides the asker is **Orca** — not the command you actually ran. Orca has been trying to prevent that by starting each pane through `/usr/bin/login`, which used to create a clean break in that chain.

On macOS 26 (Tahoe) that break stopped working, and macOS 26 also refuses to *remember* your answer for this kind of request. So the dialog comes back on every single command. Clicking "Don't Allow" never sticks, because there is nothing to stick to.

This PR stops asking `login` to do the job and instead tells macOS directly, at the moment the shell is created: *don't hold Orca responsible for this process.* That is the same mechanism Terminal.app and iTerm2 use, and macOS 26 still honours it.

## User-facing before / after

**Before**, on macOS 26: every command an agent ran could pop "Orca would like to access data from other apps" — the 1Password CLI, `rg` sweeps, anything touching another app's container. Clicking "Don't Allow" never made it stop, because Tahoe never wrote the decision down. Agent-heavy sessions meant clicking dialogs all day.

**After**, for panes running on your own machine: terminal children are no longer attributed to Orca's bundle. Each tool asks as itself, so macOS can attach your answer to that tool instead of throwing it away. And when Orca *cannot* tell whether that worked, it now records `unknown` instead of claiming success.

**What still needs a signed build to confirm:** whether the end-user consent then *persists* — that is, whether the dialog actually stops coming back. TCC keys grants off signed bundle identity, so a development build cannot demonstrate the consent-persistence half either way. What is proven below is the attribution half: who macOS holds responsible.

## What changed

- **`config/patches/node-pty@1.1.0.patch`** — `pty_posix_spawn` (the darwin path) now calls `responsibility_spawnattrs_setdisclaim(attrs, 1)` on the spawn attributes, and reports back whether it took effect. The symbol is SPI and absent from the public SDK, so it is resolved with `dlsym(RTLD_DEFAULT, …)` once per process. A missing symbol or a failed call is reported, never fatal — a shell with collapsed attribution still beats no shell.
- **`src/main/providers/macos-tcc-spawn-attribution.ts`** (new) — turns the native verdict into `disclaimed` / `not-disclaimed` / `unknown`.
- **`native-pty-spawn.ts`** — `onMacosTccSpawnStrategy` now reports two independent facts: `wrapper` (`wrapped`/`direct`) and `attribution`. Previously it reported only `wrapped`, which on macOS 26 no longer implied isolation.
- **Scope: local panes only.** The disclaim rides a pnpm patch, and panes hosted on an SSH remote spawn from a stock `node-pty` the relay installs on that host. Details and the byte-level verification are in *Scope: local panes only* below.
- The `login(1)` wrapper is **kept**. Disclaiming survives its setuid exec (measured below), so the two compose. Nothing is removed until the replacement is shown to cover what it covered.

## Scope: local panes only. SSH-hosted panes are not covered.

**This fix does not reach an SSH remote.** Stated plainly because the PR title says "at PTY spawn" and that reads as if it covers every pane. It does not.

The disclaim ships as a **pnpm patch** (`config/patches/node-pty@1.1.0.patch`), and `pnpm.patchedDependencies` only rewrites the *app's own* `node_modules`. A relay-hosted pane spawns from a **different node-pty**, installed on the remote host:

- `installNativeDeps` (`src/main/ssh/ssh-relay-deploy.ts:1008-1013`) runs plain `npm install node-pty@1.1.0` **on the remote**, against the public registry. On POSIX hosts there is **no patch step at all** — the only post-install patch in that function is `windowsNodePtyPatchCommand`, which is Windows-only and applies the unrelated console-list agent fix.
- The relay resolves the module from its own deployed tree, not the app's — the `moduleEntry` constant, `join(__dirname, 'node_modules', 'node-pty', 'lib', 'index.js')` (`src/relay/pty-handler.ts:532` at this PR head).
- `src/relay/` contains **zero** references to `wrapShellSpawnForMacosTccAttribution`, `readMacosTccAttribution`, `/usr/bin/login`, or TCC of any kind. The relay spawns bare, at both of its spawn sites: `pty.spawn(shell, shellLaunch.args, …)` (`:1690`) and `ptyMod.spawn(shell, shellLaunch.args, …)` (`:2396`).

> Line numbers above are resolved at this PR's head, `de52c6a5`. An earlier revision cited
> `:540` / `:1698` / `:2401`, which are that file's positions on a different branch.
> `src/relay/pty-handler.ts` is untouched by this PR, so these will drift again on any restack —
> the stable references are the `moduleEntry` constant and the two `*.spawn(shell, shellLaunch.args, …)`
> call sites.

**Verified against a real deployment, not just by reading the installer.** A macOS host with a relay already deployed at `~/.orca-remote/relay-<version>/node_modules/node-pty` was compared byte-for-byte against the stock `node-pty@1.1.0` registry tarball:

| tree | `lib/unixTerminal.js` sha256 | `lib/` diff vs registry | `prebuilds/darwin-arm64/` diff vs registry |
|---|---|---|---|
| stock registry tarball | `a62e3a60…60473` | — | — |
| **deployed relay** | `a62e3a60…60473` | **identical** | **identical** |
| app, `main`'s patch (pre-PR) | `67bcdb6e…d90f71` | differs | — |
| app, **this PR's patch** | `2330a12c…24a83` | differs | — |

Each `app` row is the stock `node-pty@1.1.0` tarball with the corresponding
`config/patches/node-pty@1.1.0.patch` applied to a pristine tree. An earlier revision of this
table quoted `67bcdb6e…d90f71` as "app (pnpm-patched)"; that is `main`'s **pre-PR** value, measured
against a `node_modules` predating the disclaim hunk. This PR's patch also touches
`lib/unixTerminal.js` (it adds the `_tccDisclaim` field and its accessor), so the post-PR value is
`2330a12c…24a83`. Neither value changes the conclusion — the deployed relay matches the *stock*
row, not either app row.

Tarball identity, so the comparison is against the right artifact: sha256
`c7517f19083ddcb05f276904680eb2b11a6b5ecab778b8e4e5685a6d645b3f60`, integrity
`sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==`,
identical to `pnpm-lock.yaml`.

The deployed relay's darwin native prebuild also contains no `responsibility_spawnattrs_setdisclaim` symbol or string. It is the unmodified registry package.

**Consequence.** On a macOS SSH remote, pane children get **no disclaim** — and no `login(1)` wrapper either, since the relay never had one. Nothing about remote attribution changes in this PR, in either direction. What was *measured* here is the delivery boundary; what a macOS SSH remote is actually attributed to (the relay is a child of the remote's `sshd`, not of Orca's bundle, so it is not the same chain the ELI5 describes) would need a second macOS host and was **not measured**. The honest claim is therefore the narrow one: **this PR fixes local panes and leaves remote panes exactly as they were.**

### Correction: the obvious remedy does not work on the platform that has the problem

An earlier revision of this section named two ways to close the remote gap and listed the cheap one
first: teach `installNativeDeps` to apply a POSIX patch the way it already applies the Windows one.
**That option is inert on macOS**, which is the only platform with the symptom. Measured here, not
inferred:

`node-pty@1.1.0`'s install script is `node scripts/prebuild.js || node-gyp rebuild`. `prebuild.js`
exits **0** when `prebuilds/<platform>-<arch>` exists, which short-circuits `node-gyp` entirely.
The stock tarball ships exactly four prebuild directories:

| directory | present in the stock tarball? | consequence for a remote host |
|---|---|---|
| `prebuilds/darwin-arm64` | **yes** (`pty.node` + `spawn-helper`) | macOS arm64 **never compiles** |
| `prebuilds/darwin-x64` | **yes** (`pty.node` + `spawn-helper`) | macOS x64 **never compiles** |
| `prebuilds/win32-arm64` | yes | Windows never compiles |
| `prebuilds/win32-x64` | yes | Windows never compiles |
| `prebuilds/linux-*` | **no — none at all** | Linux **always** compiles from source |

Confirmed on the relay already deployed on this machine: `~/.orca-remote/relay-<version>/node_modules/node-pty`
has `prebuilds/` but **no `build/` directory at all** — that host never ran `node-gyp`. And node-pty's
own loader order is `build/Release` → `build/Debug` → `prebuilds/<platform>-<arch>`, so with no `build/`
the binary actually loaded is the stock prebuilt `pty.node`.

The disclaim lives in `src/unix/pty.cc`. A source patch only takes effect if the host compiles:

- **Linux remotes** would pick it up — they always rebuild. But Linux has no TCC, so there is nothing
  to fix there.
- **macOS remotes** would not — they never rebuild. The one platform that needs the disclaim is
  exactly the one that will not build it.

Forcing a macOS rebuild means setting `npm_config_build_from_source=true` on the remote install
(`prebuild.js` honours it by deleting the prebuilds and exiting 1). Nothing in the repo sets that on
the relay install path today, and doing so would require **Xcode Command Line Tools on every macOS SSH
host** and push macOS into the same degraded-mode toolchain path Linux hosts already hit. So the
POSIX-patch option is not the cheap one it looks like.

That leaves two shapes worth considering, neither in scope here:

- **Ship a patched prebuilt node-pty with the relay.** The hook already exists — `TODO(#1693)` at
  `ssh-relay-deploy.ts:950` ("ship per-platform tarballs with node-pty prebuilt from CI to skip remote
  npm install") — and `RELAY_ARTIFACTS` already carries a per-platform native binary for a comparable
  reason (`windows-process-tree.node`, marked `optional` precisely because only a Windows build machine
  can compile it). node-pty is N-API, so Node-ABI drift is not the blocker it would otherwise be.
  Largest option: a CI build job, per-arch `pty.node` + `spawn-helper` artifacts, hash-manifest and
  install-path changes. Multi-PR.
- **Move the disclaim out of node-pty into a spawn shim.** `responsibility_spawnattrs_setdisclaim`
  acts on a `posix_spawnattr_t` that only node-pty's `pty_posix_spawn` owns, so this concretely means a
  small native helper that sets the disclaim and then `exec`s the shell — the structural slot
  `/usr/bin/login` occupies today. Works on a prebuild-only host with no node-pty rebuild. Evidence
  item 2 below shows the disclaim survives the setuid `login(1)` exec, which is encouraging but is not
  the same test as surviving a helper's own exec; that would need verifying first.

**Both should be gated on a cheaper measurement first:** whether a macOS SSH remote has the symptom at
all. The relay is a child of the remote host's `sshd`, not of Orca's bundle, so it is not the
attribution chain this PR's ELI5 describes. That is not measured here, and it is cheaper than any
remedy above.

Recorded so the next person does not re-derive it.

## Runtime gating

Linux and Windows are untouched: the native change is inside `#if defined(__APPLE__)`, and `readMacosTccAttribution` returns `unknown` off darwin. Older macOS is covered by the `dlsym` resolution — if the SPI is absent the spawn proceeds exactly as before and the verdict reports `not-disclaimed`, never a false success.

## The honest verdict: this stops claiming an outcome it cannot observe

This is a behaviour change *and* a reporting change, and the reporting change is the one that keeps the next regression from hiding.

Before, the spawn site emitted a single value — `wrapped` or `direct` — and `wrapped` was read as "attribution is isolated". That was an **inference about an outcome the code never observed**. It was true on macOS 15 and silently false from macOS 26 onward, which is exactly how this regression crossed an OS release without surfacing.

Now the spawn site reports two independent facts:

- **`wrapper`** — how the argv was built (`wrapped` / `direct`). Observable, and all it ever claims.
- **`attribution`** — what the spawn actually achieved (`disclaimed` / `not-disclaimed` / `unknown`), read back from the native spawn.

`disclaimed` is emitted **only** on a positive report from the native code. Absent, non-numeric, or unrecognized — an unpatched node-pty, an older macOS, a relay-hosted pane — all funnel to `unknown`. Silence can no longer read as success. If the SPI stops working on some future macOS, the log says `unknown`/`not-disclaimed` instead of continuing to imply an isolation that is no longer there.

## Evidence (macOS 26.5.1, build 25F80)

All measurements are dialog-free. `kTCCServiceDeveloperTool` preflights record the responsible identity without prompting; **no permission dialog was triggered at any point**. Oracle is the TCC unified log (`log show --predicate 'subsystem == "com.apple.TCC"'`), no `sudo` required.

**1. The wrapper is active and ineffective.** 4,905 of 16,599 TCC records in one 45-minute window named Orca as responsible, with `binary_path` pointing at ordinary terminal children — `/bin/sh`, `/usr/bin/env`, `/bin/bash`, `rg`, `tsc`, `glab` — while `ps` confirmed the panes were wrapped in `/usr/bin/login -flpq …`.

**2. Matched control through the same setuid `login(1)` hop**, two identical freshly-compiled binaries, seconds apart:

| arm | `responsible` |
|---|---|
| plain (today's behaviour) | `identifier=com.stablyai.orca, responsible_path=/Applications/Orca.app/Contents/MacOS/Orca` |
| `setdisclaim` applied | *(no `responsible` block — the process is its own principal)* |

That is the ticket's central claim reproduced with a control, and it also shows the disclaim survives the setuid exec.

**3. End-to-end through the shipped patch.** After `pnpm install --frozen-lockfile` applied this patch and rebuilt node-pty from source, a `pty.spawn` of a fresh binary reported `tccDisclaim=1` and produced a TCC record with **no `responsible` block**.

**4. Ablation.** Removing only `*tcc_disclaim = orca_tcc_apply_disclaim(&attrs);` and rebuilding flipped the same spawn back to `responsible={identifier=com.stablyai.orca, …}`, and the reported verdict from `1` to `0`. Restored and rebuilt after.

## Tests

9 new unit tests. Each gate was ablated alone and confirmed red (failure counts vs a 0-failure baseline):

| gate | ablation | result |
|---|---|---|
| darwin platform guard | deleted | 1 red |
| `APPLIED` → `disclaimed` | deleted | 3 red |
| `UNSUPPORTED`/`FAILED` → `not-disclaimed` | deleted | 2 red |
| honest default (`unknown` → `disclaimed`) | inverted | 3 red |
| spawn site reads the real process | replaced with a literal | 3 red |

A sixth candidate guard — an explicit `typeof reported !== 'number'` early return — reddened **0** and was removed rather than shipped as an unpinned rule.

**That zero was re-verified, because a 0-red can also mean the mutation silently never applied.** Both directions were checked with the guard region dumped after each edit:

| step | file changed? | tests |
|---|---|---|
| PR as shipped (guard absent) — baseline | — | 5 passed, 0 failed |
| guard **inserted** | yes (`diff` exit 1, `+3` lines, region dumped showing the guard present) | 5 passed, 0 failed |
| guard **deleted** — the ablation | yes (`diff` exit 1, `-3` lines, region dumped showing it gone) | 5 passed, **0 red** |
| tree restored | byte-identical to PR as shipped | — |

And because "0 red" alone only proves *unpinned*, not *inert*, the two variants were differentially executed over 28 inputs — `1`/`2`/`3`, `0`, `-1`, `99`, `NaN`, `±Infinity`, strings, booleans, `null`, `undefined`, `Symbol`, `{}`, `[]`, `[1]`, `new Number(1)`, `Object(1)`, `1n`, `2n`, and a `valueOf`-coercing object — with **0 divergences**. `switch` compares with `===`, so no non-number can ever reach `case 1/2/3`; the guard was a second spelling of the `default` arm. The rule it expressed is still pinned — `readMacosTccAttribution({ tccDisclaim: '1' })` → `unknown` is an existing assertion. Removal is safe.

The vendored patch was verified to be a pure superset: applying the old and new patch files to pristine `node-pty@1.1.0` trees and diffing the results yields only the disclaim change, nothing lost.

## Gates

`pnpm tc` clean · `oxlint` clean · native + type-aware plugin checks with `--deny-warnings` clean · `node config/scripts/check-changed-code-quality.mjs` → 0 new findings · formatted with `npx oxfmt --write` on changed files only.

`git diff --check` reports trailing whitespace only inside `config/patches/node-pty@1.1.0.patch`. Those are unified-diff blank *context* lines, which are a single space by format. The file already had 31 of them at `HEAD` and trips the same check on its own; this change adds 5 more inside its own hunks. No source file trips it.

## Not addressed here

The ticket's closing note about the signing TeamID change (`2DC432GLL2` → `6CX3WHS9HZ`) invalidating existing grants is a separate issue and is untouched by this PR.


