### PR TITLE
fix(preload): enforce the bridge contract the renderer already trusts

### DIFF
--- a/src/preload/app-restart-checkpoint-routing.test.ts
+++ b/src/preload/app-restart-checkpoint-routing.test.ts
@@ -92,6 +92,20 @@ describe('native preload destructive app actions', () => {
     })
   }
 
+  // Why: the lazy-chunk recovery reload joins this member through `?.()`, so leaving
+  // it off the bridge reads as "checkpoint fine" and reloads over unsaved buffers.
+  it('exposes the durable checkpoint join the recovery reload refuses on', async () => {
+    const api = await loadApi()
+    invoke.mockImplementation(async (channel: string) =>
+      channel === 'app:await-before-unload-checkpoint' ? { ok: false } : undefined
+    )
+
+    expect(typeof api.app.awaitBeforeUnloadCheckpoint).toBe('function')
+    await expect(api.app.awaitBeforeUnloadCheckpoint()).rejects.toThrow(
+      'Failed to persist renderer state before unload.'
+    )
+  })
+
   it('preserves both macOS keyboard preload adapters', async () => {
     const api = await loadApi()
     invoke.mockResolvedValue(undefined)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -589,6 +589,7 @@ const api = {
         throw new Error('Failed to stage renderer state before unload.')
       }
     },
+    awaitBeforeUnloadCheckpoint,
     awaitFirstWindowStartupServices: (): Promise<void> =>
       ipcRenderer.invoke('app:awaitFirstWindowStartupServices'),
     prepareTerminalStartupRestoration: (): Promise<void> =>
@@ -5308,6 +5309,9 @@ const api = {
     }
   }
 }
+
+/** The bridge object the renderer receives; checked against PreloadApi in preload-api-implementation-completeness.ts. */
+export type PreloadApiImplementation = typeof api
 
 // Expose Electron APIs via contextBridge when context-isolated, otherwise attach to the DOM global.
 if (process.contextIsolated) {

--- a/src/preload/preload-api-implementation-completeness.ts
+++ b/src/preload/preload-api-implementation-completeness.ts
@@ -1,0 +1,31 @@
+import type { PreloadApi } from './api-types'
+import type { PreloadApiImplementation } from './index'
+
+/**
+ * Compile-time proof that the preload bridge implements every member the
+ * renderer is allowed to call.
+ *
+ * Why this is not redundant with the annotations in index.ts: `api` is handed to
+ * `contextBridge.exposeInMainWorld`, which takes `any`, and the renderer types
+ * every call as `PreloadApi` (api-types.ts). Nothing compared the two, so a
+ * member declared in `PreloadApi` and never implemented reached the renderer as
+ * `undefined` — and callers guard with `?.()`, which turns the absence into a
+ * confident default rather than a failure.
+ *
+ * Names only, deliberately: `ipcRenderer.invoke` returns `Promise<unknown>`, so
+ * full assignability reports pre-existing return-type widenings that the call
+ * sites already cast. Presence is the half that fails silently.
+ */
+type AssertNoMissingMembers<Missing extends never> = Missing
+
+type UnimplementedGroups = Exclude<keyof PreloadApi, keyof PreloadApiImplementation>
+
+type UnimplementedMembers = {
+  [Group in keyof PreloadApi & keyof PreloadApiImplementation]: Exclude<
+    keyof PreloadApi[Group],
+    keyof PreloadApiImplementation[Group]
+  >
+}[keyof PreloadApi & keyof PreloadApiImplementation]
+
+export type PreloadApiGroupsAreImplemented = AssertNoMissingMembers<UnimplementedGroups>
+export type PreloadApiMembersAreImplemented = AssertNoMissingMembers<UnimplementedMembers>

--- a/src/preload/preload-api-implementation-completeness.ts
+++ b/src/preload/preload-api-implementation-completeness.ts
@@ -20,12 +20,28 @@ type AssertNoMissingMembers<Missing extends never> = Missing
 
 type UnimplementedGroups = Exclude<keyof PreloadApi, keyof PreloadApiImplementation>
 
-type UnimplementedMembers = {
-  [Group in keyof PreloadApi & keyof PreloadApiImplementation]: Exclude<
-    keyof PreloadApi[Group],
-    keyof PreloadApiImplementation[Group]
-  >
-}[keyof PreloadApi & keyof PreloadApiImplementation]
+type ObjectMembers<T> = T extends object
+  ? T extends (...args: never[]) => unknown
+    ? never
+    : T
+  : never
+
+/** Recurses through nested API records while treating callable leaves as terminals. */
+type UnimplementedMembers<Expected, Actual, Prefix extends string = ''> =
+  | `${Prefix}${Extract<Exclude<keyof Expected, keyof Actual>, string>}`
+  | {
+      [Key in keyof Expected & keyof Actual]: ObjectMembers<Expected[Key]> extends never
+        ? never
+        : ObjectMembers<Actual[Key]> extends never
+          ? `${Prefix}${Extract<Key, string>}`
+          : UnimplementedMembers<
+              ObjectMembers<Expected[Key]>,
+              ObjectMembers<Actual[Key]>,
+              `${Prefix}${Extract<Key, string>}.`
+            >
+    }[keyof Expected & keyof Actual]
 
 export type PreloadApiGroupsAreImplemented = AssertNoMissingMembers<UnimplementedGroups>
-export type PreloadApiMembersAreImplemented = AssertNoMissingMembers<UnimplementedMembers>
+export type PreloadApiMembersAreImplemented = AssertNoMissingMembers<
+  UnimplementedMembers<PreloadApi, PreloadApiImplementation>
+>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 |

<!-- /orca-pr-loc -->

## What this is

An audit of the main→renderer preload hop, plus the one live defect the audit turned up and a compile-time rule so the next one is a build error.

Base: `main` @ `51ed7d4f678de68b38eef14c79b473b84a6e55bc`. Touches no PR in the current batch.

## The extent, counted

**Receive side** — `ipcRenderer.on` registrations in `src/preload` (non-test): **183**

| | count |
|---|---|
| carry no payload (pure signal) | 38 |
| carry a payload | **145** |
| &nbsp;&nbsp;→ runtime-validated | **2** (`ssh:state-changed`, `ssh:detected-ports-changed`) |
| &nbsp;&nbsp;→ single field coerced to the safe side | 2 (`window:close-requested`, `ui:editableContextPaste`) |
| &nbsp;&nbsp;→ forwarded verbatim | **141** |

**Send side** — `webContents.send` in `src/main` (non-test): **135** sites, 105 distinct channels, and **0** carry a `satisfies` or `as` annotation. (The `satisfies WindowCloseRequestPayload` in the original finding is added by an in-flight PR; it is not on `main`.)

For contrast, the opposite direction — renderer→main, where the untrusted side is the sender — has **65** zod `parse`/`safeParse` sites in `src/main/ipc`.

## Where the enforcement actually leaks

The premise was that the annotations are droppable. Measured, with `tsc` as the instrument:

- **Drifting the two ends apart is caught.** Rename `code`→`exitCode` on the `pty:exit` listener only: `tsc` exit **1**, `TS2741 Property 'code' is missing`. The listener param is checked against the callback param by the `callback(data)` call itself. So the 89 duplicated inline literals are *not* the hole.
- **Deleting the annotation is silent.** Same site, annotation removed: `tsc` exit **0**, zero errors. The repo sets `"noImplicitAny": false` (`@electron-toolkit/tsconfig`, overriding `strict`), so the payload becomes `any` and flows into a typed callback unchecked.

The larger leak is one level up. `PreloadApi` declares **83** API groups. `const api = {…}` is handed to `contextBridge.exposeInMainWorld`, which takes `any`; only **20 of 83** groups carry a per-block `satisfies PreloadApi['x']`. The renderer declares `window.api: PreloadApi` and types every call against it. Nothing ever compared the implementation to the contract.

Adding `satisfies PreloadApi` to the object yields 125 errors — 123 are mechanical `Promise<unknown>` widenings from `ipcRenderer.invoke` that call sites already cast, and **one is real**.

## The real one

`app.awaitBeforeUnloadCheckpoint` is declared **required** on `AppApi`, implemented by the web shim (`web-app-api.ts:34`), and joined by the lazy-chunk recovery reload:

```ts
awaitCheckpoint: () => Promise<void> = () =>
  window.api?.app?.awaitBeforeUnloadCheckpoint?.() ?? Promise.resolve()
```

On desktop the member was never exposed — the function exists in `index.ts` but only as a module-local used by `relaunch`/`restart`/`reload`. So the optional chain fell through to `Promise.resolve()`: the reload never joined the durable write, never threw, and never returned `'checkpoint-refused'`. That path's own comment reads *"Never reload over editor buffers that could not be backed up."*

This is the failure mode the contract is supposed to prevent, in its purest form: **an absent answer became a confident default.**

No regression risk from fixing it — `pendingCheckpoint` initialises to `{ ok: true }`, so a reload with nothing staged still proceeds. It now refuses only when staging actually failed, matching `relaunch`/`restart`.

## What I chose, and what I did not

**Chosen: a structural guarantee.** A type-level completeness check comparing `typeof api` to `PreloadApi`, on **member names only**. It costs nothing at runtime, covers all 83 groups at once, and turns the next omission into a build error.

**Deliberately not chosen: runtime validation of the 141 pass-through payloads.** Arguments, not assertions:

1. **No trust boundary.** Main is the trusted process; the renderer is the sandboxed one, and that direction *is* already validated (65 zod sites). Validating main's own output buys no security.
2. **No version skew.** Preload and main ship in one binary from one commit. There is no older peer across this hop, so the wire-compatibility rules do not bite here. The two payloads that *do* carry off-box data — the SSH ones — are already admitted correctly, and are the only two that need to be.
3. **Cost lands on hot paths.** `pty:data`, `pty:replay`, `emulator:videoStreamFrame` and `terminalPreview:data` fire per output chunk or per frame.
4. **Most decisively: for most of these there is no safe rejection.** A rejected `pty:exit` has no honest fallback — ignoring a real exit leaves a dead pane reading live, which is the same defect wearing a different hat. Validation is only justified where "unknown" has a real representation. That is true for the close/quit payloads (unknown ⇒ prompt) and it is already being handled; it is not true for most of the rest.

**Left unenforced on purpose:** payload *shape* for the 141. This PR enforces that the member exists, not that its argument is well-formed. Shape drift is already caught by the compiler (ablation above); member absence was not, and was the half that shipped a bug.

## Failing-first

| # | State | Gate | Result |
|---|---|---|---|
| 1 | pristine `main` | `tsc` | 0 errors — defect invisible |
| 2 | + check, no fix | `tsc` | **1 error**, `Type '"awaitBeforeUnloadCheckpoint"' does not satisfy the constraint 'never'` |
| 3 | + check + fix | `tsc` | 0 errors |
| 4 | + test, no fix | vitest | **1 failed \| 5 passed** — `expected 'undefined' to be 'function'` |
| 5 | + test + fix | vitest | 6 passed |
| 6 | **rule deleted**, defect present | `tsc` | **0 errors** — confirms the check is load-bearing |
| 7 | groups arm: rename `platform` group | `tsc` | **1 error** naming `"platform"` — second arm is not dead |

Every mutation was applied by a checksum-verified harness that aborts on a missed substitution; one substitution did silently miss and was caught rather than read as a 0-red result.

## Gates

`pnpm tc` (all projects) ✅ · `oxlint --deny-warnings` ✅ · native + type-aware code-quality plugins `--deny-warnings` ✅ · `node config/scripts/check-changed-code-quality.mjs` → *0 new findings across 3 changed files* ✅ · `check:max-lines-ratchet` ✅ (no disable added) · `git diff --check` ✅ · `src/preload` suite 67/67 · renderer lazy-chunk suites 7/7. Formatted with `npx oxfmt --write` on changed paths only.
