### PR TITLE
fix(rate-limits): never publish a usage reply Orca could not read as a successful reading

### DIFF
--- a/config/tsconfig.node.json
+++ b/config/tsconfig.node.json
@@ -6,6 +6,7 @@
     "./scripts/vitest-host-ports-setup.ts",
     "../src/main/**/*",
     "../src/renderer/src/lib/skill-freshness-display-status.ts",
+    "../src/renderer/src/components/status-bar/status-bar-provider-visibility.ts",
     "../src/preload/**/*",
     "../src/shared/**/*",
     "../src/relay/**/*",

--- a/src/main/rate-limits/claude-oauth-empty-usage-reading.test.ts
+++ b/src/main/rate-limits/claude-oauth-empty-usage-reading.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchClaudeRateLimits } from './claude-fetcher'
+import { primeClaudeFetcherMocks, restorePlatform } from './claude-fetcher-test-harness'
+import { fetchViaPty } from './claude-pty'
+import { readActiveClaudeKeychainCredentialsStrict } from '../claude-accounts/keychain'
+import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
+
+const { netFetchMock, readFileMock, resolveProxyMock, setProxyMock, appGetPathMock } = vi.hoisted(
+  () => ({
+    netFetchMock: vi.fn(),
+    readFileMock: vi.fn(),
+    resolveProxyMock: vi.fn(),
+    setProxyMock: vi.fn(),
+    appGetPathMock: vi.fn()
+  })
+)
+
+vi.mock('node:fs/promises', () => ({
+  readFile: readFileMock
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: appGetPathMock },
+  net: { fetch: netFetchMock },
+  session: {
+    defaultSession: { resolveProxy: resolveProxyMock, setProxy: setProxyMock }
+  }
+}))
+
+vi.mock('./claude-pty', () => ({
+  fetchViaPty: vi.fn()
+}))
+
+vi.mock('../claude-accounts/keychain', () => ({
+  deleteActiveClaudeKeychainCredentialsStrict: vi.fn(),
+  readActiveClaudeKeychainCredentials: vi.fn(),
+  readActiveClaudeKeychainCredentialsStrict: vi.fn(),
+  readManagedClaudeKeychainCredentials: vi.fn(),
+  writeActiveClaudeKeychainCredentials: vi.fn(),
+  writeManagedClaudeKeychainCredentials: vi.fn()
+}))
+
+const CONFIG_DIR = '/Users/test/.claude'
+const authPreparation: ClaudeRuntimeAuthPreparation = {
+  configDir: CONFIG_DIR,
+  envPatch: { CLAUDE_CONFIG_DIR: CONFIG_DIR },
+  stripAuthEnv: false,
+  provenance: 'system'
+}
+
+function primeOAuthToken(): void {
+  vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValueOnce(
+    JSON.stringify({
+      claudeAiOauth: { accessToken: 'oauth-token', expiresAt: Date.now() + 60_000 }
+    })
+  )
+}
+
+// Why: the stale policy treats `ok` as fresh and writes it over the last good snapshot, so a
+// 200 Orca could not read a window out of must never settle as a successful reading.
+describe('Claude OAuth usage readings that carry no window', () => {
+  beforeEach(() => {
+    primeClaudeFetcherMocks({
+      netFetchMock,
+      readFileMock,
+      resolveProxyMock,
+      setProxyMock,
+      appGetPathMock
+    })
+    vi.mocked(fetchViaPty).mockResolvedValue({
+      provider: 'claude',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: 'CLI exited before /usage rendered',
+      status: 'error'
+    })
+  })
+
+  afterEach(() => {
+    restorePlatform()
+  })
+
+  const unreadableBodies: [string, string][] = [
+    ['a JSON array', '[]'],
+    ['a bare string', '"nope"'],
+    ['a bare number', '7'],
+    ['an error envelope', '{"error":{"type":"overloaded_error","message":"Overloaded"}}'],
+    ['an object with no usage key', '{"detail":"Not Found"}'],
+    ['a malformed five_hour field', '{"five_hour":"eighty percent"}']
+  ]
+
+  for (const [label, body] of unreadableBodies) {
+    it(`does not report ${label} as a successful usage reading`, async () => {
+      primeOAuthToken()
+      netFetchMock.mockResolvedValueOnce(new Response(body, { status: 200 }))
+
+      const limits = await fetchClaudeRateLimits({ authPreparation })
+
+      expect(limits.status).not.toBe('ok')
+      expect(limits.session).toBeNull()
+      expect(limits.weekly).toBeNull()
+      expect(limits.error).toBeTruthy()
+    })
+  }
+
+  it('still reports a readable window as a successful reading', async () => {
+    primeOAuthToken()
+    netFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ five_hour: { utilization: 36 } }), { status: 200 })
+    )
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      status: 'ok',
+      session: { usedPercent: 36 }
+    })
+  })
+
+  // Why: an unreadable body is a failed read, not a missing account — the CLI can still answer.
+  it('falls back to the CLI read when the OAuth body carries no window', async () => {
+    primeOAuthToken()
+    netFetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }))
+    vi.mocked(fetchViaPty).mockResolvedValueOnce({
+      provider: 'claude',
+      session: { usedPercent: 12, windowMinutes: 300, resetsAt: null, resetDescription: null },
+      weekly: null,
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok'
+    })
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      status: 'ok',
+      session: { usedPercent: 12 }
+    })
+    expect(fetchViaPty).toHaveBeenCalled()
+  })
+})

--- a/src/main/rate-limits/claude-oauth-empty-usage-reading.test.ts
+++ b/src/main/rate-limits/claude-oauth-empty-usage-reading.test.ts
@@ -87,7 +87,8 @@ describe('Claude OAuth usage readings that carry no window', () => {
     ['a bare number', '7'],
     ['an error envelope', '{"error":{"type":"overloaded_error","message":"Overloaded"}}'],
     ['an object with no usage key', '{"detail":"Not Found"}'],
-    ['a malformed five_hour field', '{"five_hour":"eighty percent"}']
+    ['a malformed five_hour field', '{"five_hour":"eighty percent"}'],
+    ['a JSON null body', 'null']
   ]
 
   for (const [label, body] of unreadableBodies) {
@@ -101,6 +102,32 @@ describe('Claude OAuth usage readings that carry no window', () => {
       expect(limits.session).toBeNull()
       expect(limits.weekly).toBeNull()
       expect(limits.error).toBeTruthy()
+    })
+  }
+
+  // Why: a throw from field access is not a classification. Reading `five_hour` off a JSON `null`
+  // raises a TypeError, which the classifier files as `unknown` — the one failure kind
+  // `getProviderUsageErrorMessage` has no copy for, so it hands the engine's own words to the
+  // user. The CLI fallback is made to fail here because it otherwise answers first and hides
+  // which verdict the OAuth read reached.
+  const shapeCheckedBodies: [string, string][] = [
+    ['a JSON null body', 'null'],
+    ['a JSON array body', '[]'],
+    ['a bare string body', '"nope"'],
+    ['a bare number body', '7'],
+    ['an object with no usage key', '{"detail":"Not Found"}']
+  ]
+
+  for (const [label, body] of shapeCheckedBodies) {
+    it(`classifies ${label} as a failed read in Orca's own words`, async () => {
+      primeOAuthToken()
+      netFetchMock.mockResolvedValueOnce(new Response(body, { status: 200 }))
+      vi.mocked(fetchViaPty).mockRejectedValueOnce(new Error('CLI unavailable'))
+
+      const limits = await fetchClaudeRateLimits({ authPreparation })
+
+      expect(limits.usageMetadata?.failureKind).toBe('parse')
+      expect(limits.error).not.toMatch(/Cannot read propert/i)
     })
   }
 

--- a/src/main/rate-limits/claude-oauth-empty-usage-reading.test.ts
+++ b/src/main/rate-limits/claude-oauth-empty-usage-reading.test.ts
@@ -131,6 +131,34 @@ describe('Claude OAuth usage readings that carry no window', () => {
     })
   }
 
+  // Why: both bodies settle the same verdict, so only the words tell them apart — and the words
+  // are what reaches the tooltip. Without this, the clause that separates "a field I could not
+  // read" from "no window here" is unpinned: neutering it leaves every test in this file green.
+  const namedReadings: [string, string, string][] = [
+    [
+      'an object with no usage key',
+      '{"detail":"Not Found"}',
+      'Claude usage response contained no usage window'
+    ],
+    [
+      'a malformed five_hour field',
+      '{"five_hour":"eighty percent"}',
+      'Claude usage response had a usage field Orca could not read'
+    ]
+  ]
+
+  for (const [label, body, message] of namedReadings) {
+    it(`says which failed read ${label} was`, async () => {
+      primeOAuthToken()
+      netFetchMock.mockResolvedValueOnce(new Response(body, { status: 200 }))
+      vi.mocked(fetchViaPty).mockRejectedValueOnce(new Error('CLI unavailable'))
+
+      const limits = await fetchClaudeRateLimits({ authPreparation })
+
+      expect(limits.error).toContain(message)
+    })
+  }
+
   it('still reports a readable window as a successful reading', async () => {
     primeOAuthToken()
     netFetchMock.mockResolvedValueOnce(

--- a/src/main/rate-limits/claude-oauth-usage-error.ts
+++ b/src/main/rate-limits/claude-oauth-usage-error.ts
@@ -1,6 +1,13 @@
 // Why: a corrupt/hostile Retry-After must not gate usage refreshes for days.
 const MAX_RETRY_AFTER_MS = 24 * 60 * 60 * 1000
 
+/**
+ * The OAuth usage endpoint answered 200 but the body was not a usage reading. Distinct from
+ * OAuthUsageError (which carries an HTTP status) so the classifier can route it to the same
+ * retry-and-preserve path as a JSON parse failure instead of a successful empty reading.
+ */
+export class OAuthUsageUnreadableError extends Error {}
+
 export class OAuthUsageError extends Error {
   constructor(
     message: string,

--- a/src/main/rate-limits/claude-oauth-usage-request.ts
+++ b/src/main/rate-limits/claude-oauth-usage-request.ts
@@ -3,6 +3,7 @@ import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limi
 import { ensureElectronProxyFromEnvironment } from '../network/proxy-settings'
 import { createOAuthUsageError, OAuthUsageUnreadableError } from './claude-oauth-usage-error'
 import { mapClaudeUsageWindow, type ClaudeUsageWindowInput } from './claude-usage-window'
+import { isReadableUsageBody } from './unreadable-usage-response'
 import { abortedClaudeRateLimitResult } from './claude-usage-result'
 
 const OAUTH_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
@@ -103,13 +104,17 @@ export async function fetchClaudeOAuthUsage(
       throw await createOAuthUsageError(response)
     }
 
-    const data = (await response.json()) as OAuthUsageResponse
+    const data: unknown = await response.json()
     if (signal?.aborted) {
       return abortedClaudeRateLimitResult()
     }
-    const session = mapClaudeUsageWindow(data.five_hour, 300)
-    const weekly = mapClaudeUsageWindow(data.seven_day, 10080)
-    const fableWeekly = mapFableWeeklyWindow(data)
+    if (!isReadableUsageBody(data)) {
+      throw new OAuthUsageUnreadableError(describeUnreadableUsageResponse(data))
+    }
+    const body = data as OAuthUsageResponse
+    const session = mapClaudeUsageWindow(body.five_hour, 300)
+    const weekly = mapClaudeUsageWindow(body.seven_day, 10080)
+    const fableWeekly = mapFableWeeklyWindow(body)
     if (!session && !weekly && !fableWeekly) {
       throw new OAuthUsageUnreadableError(describeUnreadableUsageResponse(data))
     }

--- a/src/main/rate-limits/claude-oauth-usage-request.ts
+++ b/src/main/rate-limits/claude-oauth-usage-request.ts
@@ -3,7 +3,7 @@ import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limi
 import { ensureElectronProxyFromEnvironment } from '../network/proxy-settings'
 import { createOAuthUsageError, OAuthUsageUnreadableError } from './claude-oauth-usage-error'
 import { mapClaudeUsageWindow, type ClaudeUsageWindowInput } from './claude-usage-window'
-import { isReadableUsageBody } from './unreadable-usage-response'
+import { isReadableUsageBody, namesReadableUsageField } from './unreadable-usage-response'
 import { abortedClaudeRateLimitResult } from './claude-usage-result'
 
 const OAUTH_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
@@ -70,7 +70,7 @@ function describeUnreadableUsageResponse(data: unknown): string {
   if (typeof data !== 'object' || data === null || Array.isArray(data)) {
     return 'Claude usage response was not a usage reading'
   }
-  return USAGE_RESPONSE_KEYS.some((key) => key in data)
+  return namesReadableUsageField(data, USAGE_RESPONSE_KEYS)
     ? 'Claude usage response had a usage field Orca could not read'
     : 'Claude usage response contained no usage window'
 }

--- a/src/main/rate-limits/claude-oauth-usage-request.ts
+++ b/src/main/rate-limits/claude-oauth-usage-request.ts
@@ -1,7 +1,7 @@
 import { net, session } from 'electron'
 import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
 import { ensureElectronProxyFromEnvironment } from '../network/proxy-settings'
-import { createOAuthUsageError } from './claude-oauth-usage-error'
+import { createOAuthUsageError, OAuthUsageUnreadableError } from './claude-oauth-usage-error'
 import { mapClaudeUsageWindow, type ClaudeUsageWindowInput } from './claude-usage-window'
 import { abortedClaudeRateLimitResult } from './claude-usage-result'
 
@@ -52,6 +52,28 @@ function mapFableWeeklyWindow(data: OAuthUsageResponse): RateLimitWindow | null 
   )
 }
 
+const USAGE_RESPONSE_KEYS = [
+  'five_hour',
+  'seven_day',
+  'fable_weekly',
+  'fable_seven_day',
+  'seven_day_fable',
+  'limits'
+] as const
+
+// Why: an unreadable 200 maps to the same nulls a genuinely empty account would, and the stale
+// policy writes an `ok` straight over the last real usage — so no-window is never a success here.
+// The first two shapes are provably unreadable; the third is the case Orca cannot tell apart from
+// an account that truly has no window, and a failed read is the only non-destructive reading of it.
+function describeUnreadableUsageResponse(data: unknown): string {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    return 'Claude usage response was not a usage reading'
+  }
+  return USAGE_RESPONSE_KEYS.some((key) => key in data)
+    ? 'Claude usage response had a usage field Orca could not read'
+    : 'Claude usage response contained no usage window'
+}
+
 export async function fetchClaudeOAuthUsage(
   token: string,
   signal?: AbortSignal
@@ -85,11 +107,17 @@ export async function fetchClaudeOAuthUsage(
     if (signal?.aborted) {
       return abortedClaudeRateLimitResult()
     }
+    const session = mapClaudeUsageWindow(data.five_hour, 300)
+    const weekly = mapClaudeUsageWindow(data.seven_day, 10080)
+    const fableWeekly = mapFableWeeklyWindow(data)
+    if (!session && !weekly && !fableWeekly) {
+      throw new OAuthUsageUnreadableError(describeUnreadableUsageResponse(data))
+    }
     return {
       provider: 'claude',
-      session: mapClaudeUsageWindow(data.five_hour, 300),
-      weekly: mapClaudeUsageWindow(data.seven_day, 10080),
-      fableWeekly: mapFableWeeklyWindow(data),
+      session,
+      weekly,
+      fableWeekly,
       updatedAt: Date.now(),
       error: null,
       status: 'ok'

--- a/src/main/rate-limits/claude-usage-error-classification.test.ts
+++ b/src/main/rate-limits/claude-usage-error-classification.test.ts
@@ -3,9 +3,23 @@ import {
   classifyClaudeCredentialAbsence,
   classifyClaudeOAuthUsageError
 } from './claude-usage-error-classification'
-import { OAuthUsageError } from './claude-oauth-usage-error'
+import { OAuthUsageError, OAuthUsageUnreadableError } from './claude-oauth-usage-error'
 
 describe('classifyClaudeOAuthUsageError', () => {
+  // Why: a 200 that yielded no window is a read failure, not a usage answer. 'parse' is the kind
+  // the status-bar copy reads to keep the internal diagnostic out of the tooltip, and the CLI
+  // fallback is what can still produce a real reading.
+  it('classifies an unreadable usage body as a parse failure that may retry via the CLI', () => {
+    expect(
+      classifyClaudeOAuthUsageError(new OAuthUsageUnreadableError('no usage window'))
+    ).toMatchObject({
+      failureKind: 'parse',
+      shouldAttemptCliFallback: true,
+      shouldAttemptDelegatedRefresh: false,
+      terminal: false
+    })
+  })
+
   it('treats OAuth unauthorized as stale-token repair/fallback', () => {
     expect(
       classifyClaudeOAuthUsageError(new OAuthUsageError('Invalid OAuth token', 401, true))

--- a/src/main/rate-limits/claude-usage-error-classification.ts
+++ b/src/main/rate-limits/claude-usage-error-classification.ts
@@ -1,5 +1,5 @@
 import type { UsageRateLimitFailureKind } from '../../shared/rate-limit-types'
-import { OAuthUsageError } from './claude-oauth-usage-error'
+import { OAuthUsageError, OAuthUsageUnreadableError } from './claude-oauth-usage-error'
 
 export type ClaudeUsageErrorClassification = {
   failureKind: UsageRateLimitFailureKind
@@ -27,7 +27,9 @@ export function classifyClaudeOAuthUsageError(error: unknown): ClaudeUsageErrorC
     return terminal('usage-unavailable')
   }
 
-  if (error instanceof SyntaxError) {
+  // Why: a 200 whose body yielded no window is a failed read like malformed JSON — retry via the
+  // CLI and keep the last good snapshot, never publish it as a successful empty reading.
+  if (error instanceof SyntaxError || error instanceof OAuthUsageUnreadableError) {
     return fallbackOnly('parse')
   }
 

--- a/src/main/rate-limits/gemini-unreadable-quota-response.test.ts
+++ b/src/main/rate-limits/gemini-unreadable-quota-response.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { authJsonGoogle, makeResponse } from './gemini-usage-fetcher.test-fixtures'
+
+const { readFileMock, extractCredsMock, netFetchMock } = vi.hoisted(() => ({
+  readFileMock: vi.fn(),
+  extractCredsMock: vi.fn(),
+  netFetchMock: vi.fn()
+}))
+
+vi.mock('./gemini-cli-oauth-extractor', () => ({
+  extractOAuthClientCredentials: extractCredsMock
+}))
+vi.mock('node:fs/promises', () => ({
+  readFile: readFileMock,
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  rename: vi.fn().mockResolvedValue(undefined)
+}))
+vi.mock('electron', () => ({ net: { fetch: netFetchMock } }))
+
+import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
+
+const USABLE_BUCKET = {
+  remainingFraction: 0.4,
+  resetTime: '2026-04-24T18:00:00.000Z',
+  modelId: 'gemini-2.5-pro'
+}
+
+function respondToQuotaWith(body: unknown): void {
+  netFetchMock.mockImplementation((url: string) => {
+    if (url.includes('retrieveUserQuota')) {
+      return Promise.resolve(makeResponse(body))
+    }
+    if (url.includes('loadCodeAssist')) {
+      return Promise.resolve(makeResponse({ cloudaicompanionProject: 'proj-123' }))
+    }
+    return Promise.resolve(makeResponse({}, 404))
+  })
+}
+
+// Why: `ok` is what the stale policy writes over the account's last real usage, so a quota body
+// Orca could not read must not settle as one. An envelope that really carries zero buckets is a
+// different fact and stays `ok`.
+describe('Gemini quota responses that yield no bucket', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-24T12:00:00.000Z'))
+    readFileMock.mockReset()
+    extractCredsMock.mockReset()
+    netFetchMock.mockReset()
+    extractCredsMock.mockResolvedValue(null)
+    readFileMock.mockImplementation(async (p: string) => {
+      if (p.includes('auth.json')) {
+        return JSON.stringify(authJsonGoogle)
+      }
+      throw { code: 'ENOENT' }
+    })
+  })
+
+  const unreadableBodies: [string, unknown][] = [
+    ['an HTTP-200 error envelope', { error: { code: 429, message: 'quota exceeded' } }],
+    ['a renamed buckets field', { quotaBuckets: [USABLE_BUCKET] }],
+    ['a bare string', 'nope'],
+    ['a null body', null],
+    ['an envelope whose every bucket is malformed', [{ remainingFraction: 'lots' }]]
+  ]
+
+  for (const [label, body] of unreadableBodies) {
+    it(`does not report ${label} as a successful quota reading`, async () => {
+      respondToQuotaWith(body)
+
+      const result = await fetchGeminiRateLimits(true)
+
+      expect(result.status).toBe('error')
+      expect(result.error).toBeTruthy()
+      expect(result.session).toBeNull()
+    })
+  }
+
+  const emptyEnvelopes: [string, unknown][] = [
+    ['a bare empty array', []],
+    ['a wrapped empty bucket list', { buckets: [] }]
+  ]
+
+  for (const [label, body] of emptyEnvelopes) {
+    it(`still reports ${label} as a genuinely empty reading`, async () => {
+      respondToQuotaWith(body)
+
+      const result = await fetchGeminiRateLimits(true)
+
+      expect(result.status).toBe('ok')
+      expect(result.buckets).toEqual([])
+    })
+  }
+
+  it('still reports a readable bucket as a successful reading', async () => {
+    respondToQuotaWith([USABLE_BUCKET])
+
+    const result = await fetchGeminiRateLimits(true)
+
+    expect(result.status).toBe('ok')
+    expect(result.buckets).toHaveLength(1)
+    expect(result.session?.usedPercent).toBe(60)
+  })
+})

--- a/src/main/rate-limits/gemini-usage-fetcher.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.ts
@@ -31,14 +31,21 @@ function isQuotaBucket(o: unknown): o is QuotaBucket {
   )
 }
 
-function parseQuotaResponse(data: unknown): QuotaBucket[] {
-  let rawBuckets: unknown[] = []
+// Why: an unreadable 200 (error envelope, renamed field, drifted bucket shape) used to collapse to
+// the same empty list a genuinely bucket-less account produces, and the stale policy writes an `ok`
+// over the account's last real quota. Only a recognised envelope that really lists zero buckets is
+// an empty reading; anything else is a failed one. `null` means "could not read".
+function parseQuotaResponse(data: unknown): QuotaBucket[] | null {
+  let rawBuckets: unknown[]
   if (Array.isArray(data)) {
     rawBuckets = data
   } else if (data && typeof data === 'object' && 'buckets' in data && Array.isArray(data.buckets)) {
     rawBuckets = data.buckets
+  } else {
+    return null
   }
-  return rawBuckets.filter((b) => isQuotaBucket(b))
+  const buckets = rawBuckets.filter((b) => isQuotaBucket(b))
+  return rawBuckets.length > 0 && buckets.length === 0 ? null : buckets
 }
 
 async function fetchQuota(accessToken: string, projectId: string): Promise<ProviderRateLimits> {
@@ -64,8 +71,19 @@ async function fetchQuota(accessToken: string, projectId: string): Promise<Provi
       }
     }
     const data = (await res.json()) as unknown
+    const parsed = parseQuotaResponse(data)
+    if (!parsed) {
+      return {
+        provider: 'gemini',
+        session: null,
+        weekly: null,
+        updatedAt: Date.now(),
+        error: 'Gemini quota response could not be read',
+        status: 'error'
+      }
+    }
     const buckets = deduplicateBuckets(
-      parseQuotaResponse(data).map((b) => ({ ...buildRateLimitBucket(b), modelId: b.modelId }))
+      parsed.map((b) => ({ ...buildRateLimitBucket(b), modelId: b.modelId }))
     )
     return {
       provider: 'gemini',

--- a/src/main/rate-limits/grok-fetcher.test.ts
+++ b/src/main/rate-limits/grok-fetcher.test.ts
@@ -224,9 +224,12 @@ describe('fetchGrokRateLimits', () => {
     expect(netFetchMock).toHaveBeenCalledTimes(1)
   })
 
-  it('returns unavailable when billing response has no config', async () => {
+  // A recognisable billing view with no credit carrier is the plan-has-no-credits answer. `{}` used
+  // to stand in for it and no longer can: a body naming no billing field is a read that failed, and
+  // grok-unreadable-billing-response.test.ts owns that case.
+  it('returns unavailable when a billing view carries no credit config', async () => {
     authState.file = freshAuthJson()
-    netFetchMock.mockResolvedValueOnce(jsonResponse({}))
+    netFetchMock.mockResolvedValueOnce(jsonResponse({ subscriptionTier: 'Enterprise' }))
 
     const result = await fetchGrokRateLimits()
     expect(result.status).toBe('unavailable')

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -212,10 +212,12 @@ async function fetchBillingData(
     }
   }
   const data: unknown = await res.json()
-  return {
-    kind: 'data',
-    data: typeof data === 'object' && data !== null ? (data as GrokBillingResponse) : {}
+  // Why: coercing an unreadable body to {} sent it down the "this plan has no credits" road, and
+  // that answer is 'unavailable' — which discards the last good snapshot and hides the chip.
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    return { kind: 'result', result: result('error', 'Grok billing response could not be read') }
   }
+  return { kind: 'data', data: data as GrokBillingResponse }
 }
 
 type GrokMonthlyFallbackOutcome =

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -10,6 +10,7 @@ import {
   type GrokAuthReadResult,
   type GrokAuthSession
 } from './grok-auth'
+import { isReadableUsageBody } from './unreadable-usage-response'
 
 // Why: billing URL and headers must match Grok CLI or xAI rejects the request.
 const GROK_CLI_PROXY_BASE =
@@ -150,14 +151,27 @@ function grokRequestHeaders(session: GrokAuthSession): Record<string, string> {
   return headers
 }
 
-function resolveBillingConfig(data: GrokBillingResponse): GrokBillingConfig | null {
-  if (data.config) {
-    return data.config
+type GrokBillingConfigResolution =
+  | { kind: 'config'; config: GrokBillingConfig }
+  // Why: no config carrier at all is the documented "this plan has no weekly credits" answer.
+  | { kind: 'absent' }
+  | { kind: 'unreadable'; reason: string }
+
+// Why: a present carrier of the wrong type is a failed read, not an absent one — the old
+// truthiness test handed `[]`/`"invalid"` to the mappers, which produce no window, and the
+// windowless road answers `unavailable`: it discards the last good snapshot and hides the chip.
+function resolveBillingConfig(data: GrokBillingResponse): GrokBillingConfigResolution {
+  if (data.config !== undefined && data.config !== null) {
+    return isReadableUsageBody(data.config)
+      ? { kind: 'config', config: data.config }
+      : { kind: 'unreadable', reason: 'Grok billing config was not a billing reading' }
   }
-  if (typeof data.creditUsagePercent === 'number') {
-    return data
+  if (data.creditUsagePercent !== undefined && data.creditUsagePercent !== null) {
+    return typeof data.creditUsagePercent === 'number'
+      ? { kind: 'config', config: data }
+      : { kind: 'unreadable', reason: 'Grok credit usage was not a number' }
   }
-  return null
+  return { kind: 'absent' }
 }
 
 function billingUsageResult(
@@ -236,7 +250,11 @@ async function fetchMonthlyUsageFallback(
   if (outcome.kind === 'result') {
     return outcome
   }
-  const config = outcome.data.config ?? outcome.data
+  const resolution = resolveBillingConfig(outcome.data)
+  if (resolution.kind === 'unreadable') {
+    return { kind: 'result', result: result('error', resolution.reason) }
+  }
+  const config = resolution.kind === 'config' ? resolution.config : outcome.data
   return { kind: 'window', window: mapMonthlyUsage(config) }
 }
 
@@ -268,13 +286,17 @@ export async function fetchGrokRateLimits(
     if (outcome.kind === 'result') {
       return outcome.result
     }
-    const config = resolveBillingConfig(outcome.data)
+    const resolution = resolveBillingConfig(outcome.data)
+    if (resolution.kind === 'unreadable') {
+      return result('error', resolution.reason)
+    }
     // Why: a 200 without credit usage means the plan has no weekly credits —
     // 'unavailable' hides the bar (like Claude on API-key billing); 'error'
     // would paint a permanent alert for a signed-in account that has no quota.
-    if (!config) {
+    if (resolution.kind === 'absent') {
       return result('unavailable', 'Grok billing response did not include config')
     }
+    const config = resolution.config
     const weekly = mapWeeklyCredits(config)
     if (weekly) {
       return billingUsageResult({ weekly }, config, session)

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -10,7 +10,7 @@ import {
   type GrokAuthReadResult,
   type GrokAuthSession
 } from './grok-auth'
-import { isReadableUsageBody } from './unreadable-usage-response'
+import { isReadableUsageBody, namesReadableUsageField } from './unreadable-usage-response'
 
 // Why: billing URL and headers must match Grok CLI or xAI rejects the request.
 const GROK_CLI_PROXY_BASE =
@@ -151,9 +151,27 @@ function grokRequestHeaders(session: GrokAuthSession): Record<string, string> {
   return headers
 }
 
+// Why: the fields a billing view is made of. A 200 naming none of them is a read that failed,
+// not a plan without credits — see clause 4 in unreadable-usage-response.ts.
+const BILLING_RESPONSE_KEYS = [
+  'config',
+  'creditUsagePercent',
+  'currentPeriod',
+  'billingPeriodStart',
+  'billingPeriodEnd',
+  'subscriptionTier',
+  'monthlyLimit',
+  'used',
+  'onDemandCap',
+  'onDemandUsed',
+  'prepaidBalance',
+  'isUnifiedBillingUser'
+] as const
+
 type GrokBillingConfigResolution =
   | { kind: 'config'; config: GrokBillingConfig }
-  // Why: no config carrier at all is the documented "this plan has no weekly credits" answer.
+  // Why: a recognisable billing view with no credit carrier is the documented "this plan has no
+  // weekly credits" answer. A body that names no billing field at all is not that — it is clause 4.
   | { kind: 'absent' }
   | { kind: 'unreadable'; reason: string }
 
@@ -170,6 +188,12 @@ function resolveBillingConfig(data: GrokBillingResponse): GrokBillingConfigResol
     return typeof data.creditUsagePercent === 'number'
       ? { kind: 'config', config: data }
       : { kind: 'unreadable', reason: 'Grok credit usage was not a number' }
+  }
+  // Both billing views resolve here, so the clause is stated once rather than at each fetch: an
+  // error envelope and a drifted schema reach this line as readable objects, and calling either
+  // absent publishes `unavailable`, which discards the last good snapshot and hides the chip.
+  if (!namesReadableUsageField(data, BILLING_RESPONSE_KEYS)) {
+    return { kind: 'unreadable', reason: 'Grok billing response was not a billing reading' }
   }
   return { kind: 'absent' }
 }

--- a/src/main/rate-limits/grok-unreadable-billing-response.test.ts
+++ b/src/main/rate-limits/grok-unreadable-billing-response.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const netFetchMock = vi.hoisted(() => vi.fn())
+const authState = vi.hoisted<{ file: string | null }>(() => ({ file: null }))
+
+vi.mock('electron', () => ({ net: { fetch: netFetchMock } }))
+vi.mock('node:fs', () => ({
+  existsSync: () => authState.file !== null,
+  readFileSync: () => {
+    if (authState.file === null) {
+      throw new Error('ENOENT')
+    }
+    return authState.file
+  }
+}))
+vi.mock('node:os', () => ({ homedir: () => '/home/test' }))
+
+import { fetchGrokRateLimits } from './grok-fetcher'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return { ok: status >= 200 && status < 300, status, json: async () => body } as Response
+}
+
+function freshAuthJson(): string {
+  return JSON.stringify({
+    'https://auth.x.ai::client': {
+      key: 'access-token',
+      user_id: 'user-1',
+      email: 'dev@example.com',
+      expires_at: '2099-01-01T00:00:00.000Z'
+    }
+  })
+}
+
+// Why: `unavailable` is the "provider is not set up" signal — the stale policy discards the last
+// good snapshot for it and the status bar hides the chip. That is only honest about a billing view
+// Orca could actually read; a body that is not an object at all is a failed read.
+describe('Grok billing responses Orca cannot read', () => {
+  beforeEach(() => {
+    netFetchMock.mockReset()
+    authState.file = freshAuthJson()
+  })
+
+  const unreadableBodies: [string, unknown][] = [
+    ['a JSON array', []],
+    ['a bare string', 'nope'],
+    ['a bare number', 7],
+    ['a null body', null]
+  ]
+
+  for (const [label, body] of unreadableBodies) {
+    it(`reports ${label} as a failed reading, not an unconfigured account`, async () => {
+      netFetchMock.mockResolvedValue(jsonResponse(body))
+
+      const result = await fetchGrokRateLimits()
+
+      expect(result.status).toBe('error')
+      expect(result.error).toBeTruthy()
+    })
+  }
+
+  // Why: an object with no credit fields is the documented "this plan has no weekly credits"
+  // answer — a genuine empty reading, and it must keep behaving like one.
+  it('still reports a readable billing view with no credits as unavailable', async () => {
+    netFetchMock.mockResolvedValue(jsonResponse({}))
+
+    await expect(fetchGrokRateLimits()).resolves.toMatchObject({ status: 'unavailable' })
+  })
+})

--- a/src/main/rate-limits/grok-unreadable-billing-response.test.ts
+++ b/src/main/rate-limits/grok-unreadable-billing-response.test.ts
@@ -97,12 +97,53 @@ describe('Grok billing responses Orca cannot read', () => {
     expect(isProviderConfigured(result)).toBe(true)
   })
 
+  // Why: a 200 that carries none of the fields a billing view is made of — an error envelope, a
+  // renamed schema — is a read Orca failed, not an account with nothing to report. Settling it as
+  // absent publishes `unavailable`, the one verdict that discards the last good snapshot *and*
+  // hides the chip. Claude's usage reader already draws this line; this provider did not.
+  const unrecognisedBodies: [string, unknown][] = [
+    ['an HTTP-200 error envelope', { error: 'rate limited' }],
+    ['an HTTP-200 error code envelope', { code: 429, msg: 'too many requests' }],
+    ['a drifted billing schema', { credits: { weekly: { usedPercent: 41 } } }],
+    ['a body that says nothing at all', {}]
+  ]
+
+  for (const [label, body] of unrecognisedBodies) {
+    it(`reports ${label} as a failed reading that keeps the chip visible`, async () => {
+      netFetchMock.mockResolvedValue(jsonResponse(body))
+
+      const result = await fetchGrokRateLimits()
+
+      expect(result.status).toBe('error')
+      expect(isProviderConfigured(result)).toBe(true)
+    })
+  }
+
+  // Why: the monthly fallback reads the second billing view through the same resolver, so the
+  // clause has to hold there too — the first view answering readably must not launder the second.
+  it('reports an unrecognised body in the monthly fallback view as a failed reading', async () => {
+    netFetchMock.mockImplementation((url: string) =>
+      Promise.resolve(
+        jsonResponse(
+          url.includes('format=credits')
+            ? { config: { isUnifiedBillingUser: true } }
+            : { error: 'rate limited' }
+        )
+      )
+    )
+
+    const result = await fetchGrokRateLimits()
+
+    expect(result.status).toBe('error')
+    expect(isProviderConfigured(result)).toBe(true)
+  })
+
   // Why: an object with no credit fields is the documented "this plan has no weekly credits"
   // answer — a genuine empty reading, and it must keep behaving like one. An explicit `null`
   // carrier is an absent field, not a wrong-typed one, so it stays on that same road.
   const genuinelyEmptyBodies: [string, unknown][] = [
-    ['no credit fields', {}],
-    ['an explicitly null config', { config: null }]
+    ['an explicitly null config', { config: null }],
+    ['a tier with no credit fields', { subscriptionTier: 'Enterprise' }]
   ]
 
   for (const [label, body] of genuinelyEmptyBodies) {

--- a/src/main/rate-limits/grok-unreadable-billing-response.test.ts
+++ b/src/main/rate-limits/grok-unreadable-billing-response.test.ts
@@ -16,6 +16,7 @@ vi.mock('node:fs', () => ({
 vi.mock('node:os', () => ({ homedir: () => '/home/test' }))
 
 import { fetchGrokRateLimits } from './grok-fetcher'
+import { isProviderConfigured } from '../../renderer/src/components/status-bar/status-bar-provider-visibility'
 
 function jsonResponse(body: unknown, status = 200): Response {
   return { ok: status >= 200 && status < 300, status, json: async () => body } as Response
@@ -59,11 +60,65 @@ describe('Grok billing responses Orca cannot read', () => {
     })
   }
 
-  // Why: an object with no credit fields is the documented "this plan has no weekly credits"
-  // answer — a genuine empty reading, and it must keep behaving like one.
-  it('still reports a readable billing view with no credits as unavailable', async () => {
-    netFetchMock.mockResolvedValue(jsonResponse({}))
+  // Why: `unavailable` does two things at once — the stale policy discards the previous snapshot
+  // and `isProviderConfigured` hides the chip. A read that failed may reach neither, so the chip
+  // read site is asserted here rather than assumed from the status alone.
+  const wrongTypedCarriers: [string, unknown][] = [
+    ['an array config', { config: [] }],
+    ['a string config', { config: 'invalid' }],
+    ['a number config', { config: 7 }],
+    ['a boolean config', { config: true }],
+    ['a string creditUsagePercent', { creditUsagePercent: '42' }]
+  ]
 
-    await expect(fetchGrokRateLimits()).resolves.toMatchObject({ status: 'unavailable' })
+  for (const [label, body] of wrongTypedCarriers) {
+    it(`reports ${label} as a failed reading that keeps the chip visible`, async () => {
+      netFetchMock.mockResolvedValue(jsonResponse(body))
+
+      const result = await fetchGrokRateLimits()
+
+      expect(result.status).toBe('error')
+      expect(isProviderConfigured(result)).toBe(true)
+    })
+  }
+
+  // Why: the monthly fallback reads a second billing view, and it was mapping the same
+  // wrong-typed carrier straight to "no monthly window", which lands on the same `unavailable`.
+  it('reports a wrong-typed carrier in the monthly fallback view as a failed reading', async () => {
+    netFetchMock.mockImplementation((url: string) =>
+      Promise.resolve(
+        jsonResponse(url.includes('format=credits') ? { config: {} } : { config: 'invalid' })
+      )
+    )
+
+    const result = await fetchGrokRateLimits()
+
+    expect(result.status).toBe('error')
+    expect(isProviderConfigured(result)).toBe(true)
+  })
+
+  // Why: an object with no credit fields is the documented "this plan has no weekly credits"
+  // answer — a genuine empty reading, and it must keep behaving like one. An explicit `null`
+  // carrier is an absent field, not a wrong-typed one, so it stays on that same road.
+  const genuinelyEmptyBodies: [string, unknown][] = [
+    ['no credit fields', {}],
+    ['an explicitly null config', { config: null }]
+  ]
+
+  for (const [label, body] of genuinelyEmptyBodies) {
+    it(`still reports a readable billing view with ${label} as unavailable`, async () => {
+      netFetchMock.mockResolvedValue(jsonResponse(body))
+
+      await expect(fetchGrokRateLimits()).resolves.toMatchObject({ status: 'unavailable' })
+    })
+  }
+
+  it('still reports a readable weekly credit reading as a successful one', async () => {
+    netFetchMock.mockResolvedValue(jsonResponse({ config: { creditUsagePercent: 41 } }))
+
+    await expect(fetchGrokRateLimits()).resolves.toMatchObject({
+      status: 'ok',
+      weekly: { usedPercent: 41 }
+    })
   })
 })

--- a/src/main/rate-limits/kimi-fetcher.test.ts
+++ b/src/main/rate-limits/kimi-fetcher.test.ts
@@ -34,6 +34,7 @@ vi.mock('node:fs/promises', () => ({
 vi.mock('node:os', () => ({ homedir: () => '/home/test' }))
 
 import { fetchKimiRateLimits } from './kimi-fetcher'
+import { isProviderConfigured } from '../../renderer/src/components/status-bar/status-bar-provider-visibility'
 
 function jsonResponse(body: unknown, status = 200): Response {
   return {
@@ -105,6 +106,28 @@ describe('fetchKimiRateLimits', () => {
     const [, init] = netFetchMock.mock.calls[0]
     expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tok-abc')
   })
+
+  // Why: Kimi coerces an unreadable body to `{}` and leans entirely on the windowless verdict
+  // being `error`. That coupling is what keeps it off the destructive road (`unavailable` would
+  // discard the last good snapshot and hide the chip), so it is pinned rather than assumed.
+  const unreadableBodies: [string, unknown][] = [
+    ['a JSON null body', null],
+    ['a JSON array body', []],
+    ['a bare string body', 'nope'],
+    ['an error envelope', { error: { code: 500, message: 'internal' } }]
+  ]
+
+  for (const [label, body] of unreadableBodies) {
+    it(`reports ${label} as a failed reading that keeps the chip visible`, async () => {
+      fsState.credentials = freshCredentials()
+      netFetchMock.mockResolvedValueOnce(jsonResponse(body))
+
+      const result = await fetchKimiRateLimits()
+
+      expect(result.status).toBe('error')
+      expect(isProviderConfigured(result)).toBe(true)
+    })
+  }
 
   it('surfaces an error when the usage request fails', async () => {
     fsState.credentials = freshCredentials()

--- a/src/main/rate-limits/minimax-fetcher.ts
+++ b/src/main/rate-limits/minimax-fetcher.ts
@@ -11,6 +11,7 @@ import {
   redactMiniMaxSecret,
   type MiniMaxFetchResponse
 } from './minimax-request-context'
+import { isReadableUsageBody } from './unreadable-usage-response'
 
 export {
   extractMiniMaxCookieValue,
@@ -242,16 +243,26 @@ export async function fetchMiniMaxRateLimits(
     if (httpError) {
       return httpError
     }
-    let payload: MiniMaxUsageResponse
+    let body: unknown
     try {
-      payload = (await fetchResult.response.json()) as MiniMaxUsageResponse
+      body = await fetchResult.response.json()
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Invalid MiniMax usage response'
       return makeError(redactMiniMaxSecret(message), 'parse')
     }
+    // Why: reading `base_resp` off a JSON `null` throws, and the catch-all below files that
+    // TypeError as a network failure and puts its text in the tooltip. See
+    // unreadable-usage-response.ts — proving the shape first is the classification.
+    if (!isReadableUsageBody(body)) {
+      return makeError('MiniMax usage response was not a usage reading', 'parse')
+    }
+    const payload = body as MiniMaxUsageResponse
     const payloadError = handleMiniMaxPayloadError(fetchResult, payload)
     if (payloadError) {
       return payloadError
+    }
+    if (payload.model_remains !== undefined && !Array.isArray(payload.model_remains)) {
+      return makeError('MiniMax usage response model list could not be read', 'parse')
     }
     const snapshots = (payload.model_remains ?? [])
       .map(parseUsageItem)

--- a/src/main/rate-limits/minimax-unreadable-usage-response.test.ts
+++ b/src/main/rate-limits/minimax-unreadable-usage-response.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const netFetchMock = vi.hoisted(() => vi.fn())
+const sessionFromPartitionMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    clearStorageData: vi.fn(() => Promise.resolve()),
+    cookies: { set: vi.fn(() => Promise.resolve()) },
+    fetch: netFetchMock
+  }))
+)
+
+vi.mock('electron', () => ({
+  net: { fetch: netFetchMock },
+  session: { fromPartition: sessionFromPartitionMock }
+}))
+
+import { fetchMiniMaxRateLimits } from './minimax-fetcher'
+import { isProviderConfigured } from '../../renderer/src/components/status-bar/status-bar-provider-visibility'
+
+const FULL_COOKIE =
+  '_token=eyJh.eyJ.payload; _twpid=tw.123; minimax_group_id_v2=12345; platform_cookie_consent=3'
+
+function makeResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as Response
+}
+
+// Why: MiniMax reads `base_resp` and `model_remains` straight off the decoded body. On a JSON
+// `null` that access throws, and the catch-all files the internal TypeError as a network failure
+// whose message reaches the tooltip verbatim. See unreadable-usage-response.ts.
+describe('MiniMax usage responses Orca cannot read', () => {
+  const unreadableBodies: [string, unknown][] = [
+    ['a JSON null body', null],
+    ['a JSON array body', []],
+    ['a bare string body', 'nope'],
+    ['a bare number body', 7],
+    ['a non-array model_remains', { base_resp: { status_code: 0 }, model_remains: 'none' }]
+  ]
+
+  for (const [label, body] of unreadableBodies) {
+    it(`classifies ${label} as a failed read in Orca's own words`, async () => {
+      netFetchMock.mockReset()
+      netFetchMock.mockResolvedValueOnce(makeResponse(body))
+
+      const result = await fetchMiniMaxRateLimits({ cookie: FULL_COOKIE })
+
+      expect(result.status).toBe('error')
+      expect(result.usageMetadata?.failureKind).toBe('parse')
+      expect(result.error).not.toMatch(/Cannot read propert/i)
+      expect(isProviderConfigured(result)).toBe(true)
+    })
+  }
+})

--- a/src/main/rate-limits/service-grok-unreadable-billing-retention.test.ts
+++ b/src/main/rate-limits/service-grok-unreadable-billing-retention.test.ts
@@ -94,7 +94,9 @@ describe('RateLimitService with an unreadable Grok billing read', () => {
     await service.refresh()
     expect(service.getState().grok?.weekly?.usedPercent).toBe(41)
 
-    respondToBillingWith({})
+    // A billing view Orca recognises, carrying no credit field — not `{}`, which names no billing
+    // field at all and is therefore a failed read rather than a plan without credits.
+    respondToBillingWith({ subscriptionTier: 'Enterprise' })
     await service.refresh()
 
     const grok = service.getState().grok

--- a/src/main/rate-limits/service-grok-unreadable-billing-retention.test.ts
+++ b/src/main/rate-limits/service-grok-unreadable-billing-retention.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RateLimitService } from './service'
+import { fetchClaudeRateLimits } from './claude-fetcher'
+import { fetchCodexRateLimits } from './codex-fetcher'
+import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
+import { fetchKimiRateLimits } from './kimi-fetcher'
+import { fetchMiniMaxRateLimits } from './minimax-fetcher'
+import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
+import { okProvider } from './rate-limit-service-test-harness'
+import { isProviderConfigured } from '../../renderer/src/components/status-bar/status-bar-provider-visibility'
+
+const netFetchMock = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({ net: { fetch: netFetchMock } }))
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn().mockRejectedValue({ code: 'ENOENT' }),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  rename: vi.fn().mockResolvedValue(undefined)
+}))
+vi.mock('./claude-fetcher', () => ({
+  fetchClaudeRateLimits: vi.fn(),
+  fetchManagedAccountUsage: vi.fn()
+}))
+vi.mock('./codex-fetcher', () => ({
+  consumeCodexRateLimitResetCredit: vi.fn(),
+  fetchCodexRateLimits: vi.fn()
+}))
+vi.mock('./gemini-usage-fetcher', () => ({ fetchGeminiRateLimits: vi.fn() }))
+vi.mock('./kimi-fetcher', () => ({ fetchKimiRateLimits: vi.fn() }))
+vi.mock('./opencode-go-usage-fetcher', () => ({ fetchOpenCodeGoRateLimits: vi.fn() }))
+vi.mock('./minimax-fetcher', () => ({ fetchMiniMaxRateLimits: vi.fn() }))
+vi.mock('../minimax/minimax-cookie-store', () => ({ hasMiniMaxSessionCookie: vi.fn(() => false) }))
+// Why: only the Grok fetcher is real here — the point is what the live billing read publishes.
+vi.mock('./grok-auth', () => ({
+  isGrokAccessTokenFresh: () => true,
+  readGrokAuthSession: () => ({
+    status: 'ok',
+    session: {
+      accessToken: 'access-token',
+      userId: 'user-1',
+      email: 'dev@example.com',
+      teamId: null,
+      expiresAtMs: null,
+      oidcClientId: null
+    }
+  })
+}))
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as Response
+}
+
+function respondToBillingWith(body: unknown): void {
+  netFetchMock.mockImplementation(() => Promise.resolve(jsonResponse(body)))
+}
+
+// Why: `unavailable` is destructive twice over — `applyStalePolicy` returns it verbatim, dropping
+// the previous snapshot, and `isProviderConfigured` then hides the chip that would have told the
+// user anything was wrong. Both halves are asserted here against the real fetcher.
+describe('RateLimitService with an unreadable Grok billing read', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 7))
+    vi.mocked(fetchCodexRateLimits).mockResolvedValue(okProvider('codex', 20))
+    vi.mocked(fetchGeminiRateLimits).mockResolvedValue(okProvider('gemini', 5))
+    vi.mocked(fetchKimiRateLimits).mockResolvedValue(okProvider('kimi', 5))
+    vi.mocked(fetchOpenCodeGoRateLimits).mockResolvedValue(okProvider('opencode-go', 5))
+    vi.mocked(fetchMiniMaxRateLimits).mockResolvedValue(okProvider('minimax', 5))
+    netFetchMock.mockReset()
+  })
+
+  it('keeps the last good Grok reading and the chip when the next billing body cannot be read', async () => {
+    const service = new RateLimitService()
+
+    respondToBillingWith({ config: { creditUsagePercent: 41 } })
+    await service.refresh()
+    expect(service.getState().grok?.weekly?.usedPercent).toBe(41)
+
+    respondToBillingWith({ config: 'invalid' })
+    await service.refresh()
+
+    const grok = service.getState().grok
+    expect(grok?.status).toBe('error')
+    expect(grok?.weekly?.usedPercent).toBe(41)
+    expect(isProviderConfigured(grok)).toBe(true)
+  })
+
+  // Why: the retention above must not come from making every windowless answer non-destructive —
+  // a signed-in account that genuinely has no weekly credits still reads as unconfigured.
+  it('still discards the snapshot and hides the chip when the plan genuinely has no credits', async () => {
+    const service = new RateLimitService()
+
+    respondToBillingWith({ config: { creditUsagePercent: 41 } })
+    await service.refresh()
+    expect(service.getState().grok?.weekly?.usedPercent).toBe(41)
+
+    respondToBillingWith({})
+    await service.refresh()
+
+    const grok = service.getState().grok
+    expect(grok?.status).toBe('unavailable')
+    expect(grok?.weekly).toBeNull()
+    expect(isProviderConfigured(grok)).toBe(false)
+  })
+})

--- a/src/main/rate-limits/service-unreadable-usage-overwrite.test.ts
+++ b/src/main/rate-limits/service-unreadable-usage-overwrite.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RateLimitService } from './service'
+import { fetchClaudeRateLimits } from './claude-fetcher'
+import { fetchCodexRateLimits } from './codex-fetcher'
+import { okProvider } from './rate-limit-service-test-harness'
+import { fetchKimiRateLimits } from './kimi-fetcher'
+import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
+import { fetchMiniMaxRateLimits } from './minimax-fetcher'
+import { fetchGrokRateLimits } from './grok-fetcher'
+import { makeResponse } from './gemini-usage-fetcher.test-fixtures'
+
+const { readFileMock, netFetchMock } = vi.hoisted(() => ({
+  readFileMock: vi.fn(),
+  netFetchMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({ net: { fetch: netFetchMock } }))
+vi.mock('node:fs/promises', () => ({
+  readFile: readFileMock,
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  rename: vi.fn().mockResolvedValue(undefined)
+}))
+vi.mock('./gemini-cli-oauth-extractor', () => ({
+  extractOAuthClientCredentials: vi.fn().mockResolvedValue(null)
+}))
+
+vi.mock('./claude-fetcher', () => ({
+  fetchClaudeRateLimits: vi.fn(),
+  fetchManagedAccountUsage: vi.fn()
+}))
+vi.mock('./codex-fetcher', () => ({
+  consumeCodexRateLimitResetCredit: vi.fn(),
+  fetchCodexRateLimits: vi.fn()
+}))
+vi.mock('./kimi-fetcher', () => ({ fetchKimiRateLimits: vi.fn() }))
+vi.mock('./opencode-go-usage-fetcher', () => ({ fetchOpenCodeGoRateLimits: vi.fn() }))
+vi.mock('./minimax-fetcher', () => ({ fetchMiniMaxRateLimits: vi.fn() }))
+vi.mock('./grok-fetcher', () => ({ fetchGrokRateLimits: vi.fn() }))
+vi.mock('./grok-auth', () => ({ readGrokAuthSession: vi.fn(() => ({ status: 'missing' })) }))
+vi.mock('../minimax/minimax-cookie-store', () => ({
+  hasMiniMaxSessionCookie: vi.fn(() => false)
+}))
+
+const FRESH_AUTH_JSON = {
+  google: {
+    type: 'oauth',
+    access: 'auth-json-access-token',
+    expires: new Date('2999-01-01T00:00:00.000Z').getTime(),
+    refresh: 'refresh-token-abc|proj-123|managed-456'
+  }
+}
+
+const READABLE_BUCKET = {
+  remainingFraction: 0.4,
+  resetTime: '2999-01-01T00:00:00.000Z',
+  modelId: 'gemini-2.5-pro'
+}
+
+function respondToQuotaWith(body: unknown): void {
+  netFetchMock.mockImplementation((url: string) => {
+    if (url.includes('retrieveUserQuota')) {
+      return Promise.resolve(makeResponse(body))
+    }
+    if (url.includes('loadCodeAssist')) {
+      return Promise.resolve(makeResponse({ cloudaicompanionProject: 'proj-123' }))
+    }
+    return Promise.resolve(makeResponse({}, 404))
+  })
+}
+
+// Why: this is the damage the empty-success shape does. The stale policy treats `ok` as fresh and
+// returns it verbatim, so an unreadable quota read published as `ok` replaces the account's last
+// real usage; published as `error` it keeps the previous snapshot on screen.
+describe('RateLimitService with an unreadable Gemini quota read', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 7))
+    vi.mocked(fetchCodexRateLimits).mockResolvedValue(okProvider('codex', 20))
+    vi.mocked(fetchKimiRateLimits).mockResolvedValue(okProvider('kimi', 5))
+    vi.mocked(fetchOpenCodeGoRateLimits).mockResolvedValue(okProvider('opencode-go', 5))
+    vi.mocked(fetchMiniMaxRateLimits).mockResolvedValue(okProvider('minimax', 5))
+    vi.mocked(fetchGrokRateLimits).mockResolvedValue(okProvider('grok', 5))
+    netFetchMock.mockReset()
+    readFileMock.mockReset()
+    readFileMock.mockImplementation(async (p: string) => {
+      if (p.includes('auth.json')) {
+        return JSON.stringify(FRESH_AUTH_JSON)
+      }
+      throw { code: 'ENOENT' }
+    })
+  })
+
+  it('keeps the last good Gemini reading when the next quota body cannot be read', async () => {
+    const service = new RateLimitService()
+    service.setGeminiCliOAuthEnabledResolver(() => true)
+
+    respondToQuotaWith([READABLE_BUCKET])
+    await service.refresh()
+    expect(service.getState().gemini?.buckets).toHaveLength(1)
+
+    respondToQuotaWith({ error: { code: 500, message: 'internal' } })
+    await service.refresh()
+
+    const gemini = service.getState().gemini
+    expect(gemini?.status).toBe('error')
+    expect(gemini?.buckets).toHaveLength(1)
+    expect(gemini?.session?.usedPercent).toBe(60)
+  })
+})

--- a/src/main/rate-limits/service-unreadable-usage-overwrite.test.ts
+++ b/src/main/rate-limits/service-unreadable-usage-overwrite.test.ts
@@ -106,4 +106,24 @@ describe('RateLimitService with an unreadable Gemini quota read', () => {
     expect(gemini?.buckets).toHaveLength(1)
     expect(gemini?.session?.usedPercent).toBe(60)
   })
+
+  // Why: the mirror is the one place in this class where the blanking is deliberate — see
+  // service-antigravity-usage.test.ts, "never leaves a cached Antigravity snapshot in the error
+  // retry lane". Pinned here so the asymmetry with Gemini's own retention stays visible: Gemini
+  // keeps its last good snapshot through the same failure, Antigravity does not.
+  it('drops the mirrored Antigravity reading when the Gemini read fails, unlike Gemini itself', async () => {
+    const service = new RateLimitService()
+    service.setGeminiCliOAuthEnabledResolver(() => true)
+
+    respondToQuotaWith([READABLE_BUCKET])
+    await service.refresh()
+    expect(service.getState().antigravity?.buckets).toHaveLength(1)
+
+    respondToQuotaWith({ error: { code: 500, message: 'internal' } })
+    await service.refresh()
+
+    expect(service.getState().antigravity?.status).toBe('unavailable')
+    expect(service.getState().antigravity?.session).toBeNull()
+    expect(service.getState().gemini?.session?.usedPercent).toBe(60)
+  })
 })

--- a/src/main/rate-limits/unreadable-usage-response.ts
+++ b/src/main/rate-limits/unreadable-usage-response.ts
@@ -1,0 +1,16 @@
+/**
+ * The rule every provider that reads a usage reply off the wire has to express.
+ *
+ * 1. Prove the body is a readable object before reading a field off it. A throw from field
+ *    access is not a classification — it escapes as an internal `TypeError`, lands in whatever
+ *    catch-all the caller has, and puts the engine's own words in the user's tooltip.
+ * 2. A recognised field carrying the wrong type is a failed read, not an absent one. Absence can
+ *    mean the account genuinely has nothing to report; a present-but-unusable value never can.
+ * 3. A failed read settles `error`. It is the only non-destructive verdict: `ok` overwrites the
+ *    last good snapshot (`applyStalePolicy` returns fresh verbatim) and `unavailable` discards it
+ *    *and* hides the chip (`isProviderConfigured`), which is the surface that would have shown
+ *    the user something was wrong.
+ */
+export function isReadableUsageBody(data: unknown): data is Record<string, unknown> {
+  return typeof data === 'object' && data !== null && !Array.isArray(data)
+}

--- a/src/main/rate-limits/unreadable-usage-response.ts
+++ b/src/main/rate-limits/unreadable-usage-response.ts
@@ -10,7 +10,16 @@
  *    last good snapshot (`applyStalePolicy` returns fresh verbatim) and `unavailable` discards it
  *    *and* hides the chip (`isProviderConfigured`), which is the surface that would have shown
  *    the user something was wrong.
+ * 4. A body naming none of the fields the reading is made of is a failed read, not an empty one.
+ *    An HTTP-200 error envelope and a renamed schema both parse; neither is evidence that the
+ *    account has nothing to report, and clause 3 says the verdict Orca cannot support is the
+ *    destructive one. Clauses 1-3 were prose every provider re-expressed by hand, and this is the
+ *    clause that got dropped each time — so it ships as the check itself.
  */
 export function isReadableUsageBody(data: unknown): data is Record<string, unknown> {
   return typeof data === 'object' && data !== null && !Array.isArray(data)
+}
+
+export function namesReadableUsageField(body: object, fields: readonly string[]): boolean {
+  return fields.some((field) => field in body)
 }

--- a/src/renderer/src/components/status-bar/usage-error-copy.test.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.test.ts
@@ -4,7 +4,7 @@ vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string) => fallback
 }))
 
-import { getProviderDisplayName } from './usage-error-copy'
+import { getProviderDisplayName, getProviderUsageErrorMessage } from './usage-error-copy'
 
 describe('getProviderDisplayName', () => {
   it('returns the Antigravity brand name', () => {
@@ -28,5 +28,36 @@ describe('getProviderDisplayName', () => {
     // Why: provider id is a closed union, but TypeScript may not enforce
     // exhaustiveness on dynamic callers. Fallback keeps logging safe.
     expect(getProviderDisplayName('unknown-provider' as never)).toBe('unknown-provider')
+  })
+})
+
+describe('getProviderUsageErrorMessage', () => {
+  // Why: a body Orca could not read is classified 'parse'. That is the field the copy switch
+  // reads, and it is what keeps the internal diagnostic out of the user-facing tooltip.
+  it('replaces an unreadable Claude usage body with user-facing copy', () => {
+    expect(
+      getProviderUsageErrorMessage({
+        provider: 'claude',
+        session: null,
+        weekly: null,
+        updatedAt: 0,
+        error: 'Claude usage response contained no usage window',
+        status: 'error',
+        usageMetadata: { failureKind: 'parse' }
+      })
+    ).toBe('Claude usage is unavailable right now.')
+  })
+
+  it('surfaces the raw reason when the failure was never classified', () => {
+    expect(
+      getProviderUsageErrorMessage({
+        provider: 'claude',
+        session: null,
+        weekly: null,
+        updatedAt: 0,
+        error: 'Claude usage response contained no usage window',
+        status: 'error'
+      })
+    ).toBe('Claude usage response contained no usage window')
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​825 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​821 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​170 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​145 |

<!-- /orca-pr-loc -->

## ELI5

Orca asks each AI provider "how much of my quota have I used?" Sometimes the provider answers
"200 OK" but the answer inside is not usable — an error envelope, a renamed field, a body that
isn't even an object. Orca used to read that as **"the answer is: nothing"** and file it as a
successful reading. And because a successful reading is treated as the freshest thing Orca knows,
it **replaced the real numbers you were looking at a minute ago** with a blank.

This teaches three provider paths to tell "there is nothing to report" apart from "I could not
read the report", and to only overwrite your usage with the first one.

## User-facing before / after

| | Before | After |
|---|---|---|
| Claude usage endpoint returns a body Orca can't read | The bar goes blank. Your last real 5-hour/weekly numbers are gone. | Orca says the refresh failed, retries via the Claude CLI, and **your last good numbers stay on screen**. |
| Gemini quota endpoint returns an HTTP-200 error envelope or a drifted schema | The Gemini bar goes blank and reads "No usage data" — the same thing it shows an account that genuinely has no quota. | Orca reports a failed read and **keeps the last good buckets**. An envelope that really lists zero buckets still reads as a genuine empty. |
| Grok billing view returns something that isn't a JSON object | The Grok chip **disappears entirely** — `unavailable` is the "you haven't set this up" verdict, and it discards the last good snapshot. | Orca reports a failed read; the chip stays and keeps its last good value. A readable billing view with no credits still reads as "no quota", as before. |

## Why this shape

This is the class behind the three doors closed for Codex in #17167: an unsuccessful or empty
answer presented as a successful one, then persisted over good data. `applyStalePolicy` returns
`fresh` verbatim when `status === 'ok'`, and discards the previous snapshot when
`status === 'unavailable'` — so both verdicts are destructive, and neither may be reached by a
read that failed.

Several providers already had the right rule and are untouched here — `codex-pty-rate-limit-probe`
and `claude-pty` gate on `session || weekly`, `kimi-fetcher` and `minimax-fetcher` refuse to
publish a windowless reading, `opencode-go-usage-fetcher` only settles `ok` behind a successful
parse, and `service.ts`'s live-Claude ingest drops a post with no window. The three paths changed
here are the ones that were written to the older pattern.

Shared cause, so one PR: each is a wire read whose derived value (the windows/buckets) was never
checked before the verdict was chosen.

## What changed

- **`claude-oauth-usage-request.ts`** — a 200 that yields no session, weekly *or* Fable window now
  throws `OAuthUsageUnreadableError` instead of returning two nulls as `ok`. The classifier routes
  it to `parse`, the same lane a malformed-JSON body already took: the CLI fallback still runs, and
  a real failure keeps the last good snapshot.
- **`gemini-usage-fetcher.ts`** — `parseQuotaResponse` now distinguishes three cases instead of
  collapsing them to one empty list: a recognised envelope listing zero buckets (genuine empty,
  still `ok`), a recognised envelope whose every entry is malformed (failed read), and a body with
  no recognised envelope at all (failed read).
- **`grok-fetcher.ts`** — a billing body that is not a JSON object is no longer coerced to `{}` and
  sent down the "this plan has no credits" road, which answers `unavailable`.

## Known limit, stated rather than papered over

For Claude, an object carrying **none** of the recognised usage keys (`{}`, an error envelope) is
the one shape Orca genuinely cannot tell apart from an account that truly has no window — the
response has no envelope marker to check. This picks the non-destructive reading of it and says so
in the code comment. Distinguishing it would need either a documented "no limits" marker from the
usage API or a second signal (plan/subscription state) fetched alongside.

## Tests

Failing-first, one gate each; every gate ablated **individually and serially** through a
checksum-verified harness that aborts if the substitution misses.

| Gate | Ablation | Reds |
|---|---|---|
| G1 Claude no-window throw | delete the throw | 7 / 466 |
| G2 unreadable → `parse` classification | drop the `OAuthUsageUnreadableError` arm | 1 / 467 |
| G3 Gemini unrecognised envelope | return `[]` instead of `null` | 5 / 466 |
| G4 Gemini all-entries-malformed | return `buckets` unconditionally | 1 / 466 |
| G5 Gemini failed-read verdict | flip `error` → `ok` | 6 / 466 |
| G6 Grok non-object body | restore the `{}` coercion | 4 / 466 |
| G7 `parse` tooltip copy (render site) | drop `case 'parse'` | 1 / 298 |

G2 reddened **0/466** on its first measurement — the fallback lane is identical for `unknown`, so
only the user-facing copy differs. Pinned at the classifier and at the render site
(`getProviderUsageErrorMessage`) rather than left unpinned.

`service-unreadable-usage-overwrite.test.ts` drives the real Gemini fetcher through the real
`RateLimitService` end to end: a good read, then an unreadable one, asserting the good buckets
survive. It reddens on G3 and G5.

## Verification

`pnpm tc` clean; `oxlint`, the native and type-aware code-quality plugin configs and React Doctor
all clean with `--deny-warnings`; `check-changed-code-quality.mjs` reports 0 new findings across 11
changed files; max-lines ratchet unchanged (no suppressions added); `git diff --check` clean.
`src/main/rate-limits` + `src/renderer/src/components/status-bar`: 766 passing.


---

## Round 2 — the rule, not three more instances

Two of the four review threads said the defect this PR fixes was still reachable one level in: a
Claude success body of `null` threw out of the field access before the new unreadable handling
could run, and a Grok `config` carrying the wrong type still reached `unavailable`, which is
destructive twice over. Both reproduced by driving. Rather than patch the two inputs, the rule is
now stated once in **`src/main/rate-limits/unreadable-usage-response.ts`** and every provider that
reads a usage reply expresses it:

1. **Prove the body is a readable object before reading a field off it.** A throw from field access
   is not a classification — it escapes as an internal `TypeError`, lands in a catch-all, and puts
   the engine's own words in the user's tooltip.
2. **A recognised field carrying the wrong type is a failed read, not an absent one.** Absence can
   mean the account genuinely has nothing to report; a present-but-unusable value never can.
3. **A failed read settles `error`.** It is the only non-destructive verdict: `ok` overwrites the
   last good snapshot and `unavailable` discards it *and* hides the chip (`isProviderConfigured`).

### Where each provider expresses it

| Provider | Status under the rule | Change |
|---|---|---|
| `claude-oauth-usage-request` | clause 1 was open | shape-check before mapping; the `OAuthUsageResponse` cast moved behind the guard so the compiler enforces the order |
| `grok-fetcher` | clauses 2 and 3 were open | `resolveBillingConfig` returns `config` / `absent` / `unreadable`; unreadable settles `error`. The monthly fallback view reads through the same resolver |
| `minimax-fetcher` | clause 1 was open — **found by re-asking the question, not reported** | shape-check the body; reject a non-array `model_remains` |
| `gemini-usage-fetcher` | passes | unchanged |
| `kimi-fetcher` | passes — but only because its windowless verdict is `error`; that coupling is now pinned | tests only |
| `opencode-go-usage-fetcher` | passes — its only `unavailable` is decided before any wire read | unchanged |

### Both harms, not one

Grok's `unavailable` discards the snapshot **and** hides the chip.
`service-grok-unreadable-billing-retention.test.ts` drives the real fetcher through the real
`RateLimitService` and asserts both: the last good weekly reading survives, and
`isProviderConfigured` still returns `true`. Its companion asserts the genuine no-credits account
still discards and still hides, so the retention does not come from making every windowless answer
non-destructive.

### Failing-first (13 red against `e43115a509`, prod reverted, tests kept)

| Test | Red before |
|---|---|
| Claude — JSON `null` classified `parse`, message is Orca's | 1 |
| Grok — array / string / number / boolean `config`, string `creditUsagePercent` | 5 |
| Grok — wrong-typed carrier in the monthly fallback view | 1 |
| Grok — service keeps the last good reading and the chip | 1 |
| MiniMax — `null` / array / string / number body, non-array `model_remains` | 5 |
| Kimi — non-object bodies keep the chip | 0 (a pin, not a fix — Kimi already satisfied the rule) |

### Ablations (one gate at a time, serially, each mutation byte-verified; 791 tests)

| Gate | Ablation | Reds |
|---|---|---|
| H1 Claude shape check | delete the guard | 1 / 791 |
| H2 Grok wrong-typed `config` arm | accept the carrier unconditionally | 6 / 791 |
| H3 Grok wrong-typed `creditUsagePercent` arm | accept the body unconditionally | 1 / 791 |
| H4 Grok monthly-fallback unreadable arm | drop it | 1 / 791 |
| H5 Grok unreadable **verdict** | `error` → `unavailable` | 6 / 791 |
| H6 MiniMax shape check | delete the guard | 4 / 791 |
| H7 MiniMax `model_remains` array guard | delete it | 1 / 791 |
| H8 the shared predicate itself | `isReadableUsageBody` returns `true` | 11 / 791 |

### The one case the rule does not decide

A Grok billing 200 with **no** config carrier at all (`{}`, an object-shaped error envelope, a
renamed field) stays `unavailable`. That verdict is the documented "this plan has no weekly
credits" answer, present on the merge-base `51ed7d4f678d` and pinned by an existing test; there is
no envelope marker in the billing view to tell it from a drifted schema. This is the same known
limit already stated for Claude's `{}` — except Claude picks the non-destructive reading of the
ambiguity and Grok picks the destructive one, because for Grok a signed-in account with no quota is
a real, tested state that `error` would paint a permanent alert on. Deciding it needs a documented
marker from the billing API or a second signal, not a guess here.
