### PR TITLE
fix(settings): always render the per-agent Environment field

### DIFF
--- a/src/renderer/src/components/settings/AgentCatalogRow.test.tsx
+++ b/src/renderer/src/components/settings/AgentCatalogRow.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { describe, expect, it, vi } from 'vitest'
+import { AgentCatalogRow, type AgentCatalogRowProps } from './AgentCatalogRow'
+
+function makeProps(overrides: Partial<AgentCatalogRowProps> = {}): AgentCatalogRowProps {
+  return {
+    agentId: 'claude',
+    label: 'Claude',
+    homepageUrl: 'https://code.claude.com/docs',
+    defaultCmd: 'claude',
+    defaultArgs: '',
+    // Why: Claude ships no default env, which is the case that used to hide
+    // the Environment field entirely.
+    defaultEnv: {},
+    isDetected: true,
+    isEnabled: true,
+    isDefault: true,
+    cmdOverride: undefined,
+    argsOverride: '',
+    envOverride: {},
+    onSetDefault: vi.fn(),
+    onSetEnabled: vi.fn(),
+    onSaveOverride: vi.fn(),
+    onSaveArgs: vi.fn(),
+    onSaveEnv: vi.fn(),
+    ...overrides
+  }
+}
+
+function render(props: AgentCatalogRowProps): HTMLDivElement {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    createRoot(container).render(<AgentCatalogRow {...props} />)
+  })
+  return container
+}
+
+// Why: the row auto-expands when an override already exists (cmdOpen seeds from
+// hasOverrides), so clicking unconditionally would collapse it instead.
+function expandOverrides(container: HTMLElement): void {
+  const toggle = Array.from(container.querySelectorAll('button')).find((entry) =>
+    /command override/i.test(entry.getAttribute('aria-label') ?? entry.textContent ?? '')
+  )
+  expect(toggle, 'command override toggle should exist').toBeTruthy()
+  const isCollapsed = /expand/i.test(
+    toggle?.getAttribute('aria-label') ?? toggle?.textContent ?? ''
+  )
+  if (!isCollapsed) {
+    return
+  }
+  act(() => {
+    toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+describe('AgentCatalogRow', () => {
+  it('renders the Environment field for an agent with no default env and no override', () => {
+    const container = render(makeProps())
+    expandOverrides(container)
+    expect(container.textContent).toContain('Environment')
+  })
+
+  it('still renders the Environment field when an override already exists', () => {
+    const container = render(makeProps({ envOverride: { OTEL_METRICS_EXPORTER: 'otlp' } }))
+    expandOverrides(container)
+    expect(container.textContent).toContain('Environment')
+  })
+})

--- a/src/renderer/src/components/settings/AgentCatalogRow.tsx
+++ b/src/renderer/src/components/settings/AgentCatalogRow.tsx
@@ -216,16 +216,14 @@ export function AgentCatalogRow({
               onSaveArgs={onSaveArgs}
             />
           </div>
-          {(defaultEnvSummary || envSummary) && (
-            <div className="mt-2">
-              <AgentDefaultEnvInput
-                key={`${agentId}:${envSummary}`}
-                defaultEnv={defaultEnv}
-                envOverride={envOverride}
-                onSaveEnv={onSaveEnv}
-              />
-            </div>
-          )}
+          <div className="mt-2">
+            <AgentDefaultEnvInput
+              key={`${agentId}:${envSummary}`}
+              defaultEnv={defaultEnv}
+              envOverride={envOverride}
+              onSaveEnv={onSaveEnv}
+            />
+          </div>
           {sessionSourceHome && (
             <div className="mt-2">
               <AgentSessionSourceHomeInput


### PR DESCRIPTION
## ELI5

The Environment box in Settings → Agents only showed up if the agent already had an
environment set. Nothing shipped one, so it never showed up, so you could never set one.
This makes it always show.

## What Changed

`AgentCatalogRow` renders `AgentDefaultEnvInput` unconditionally inside the expanded
command-override section, the same way `AgentDefaultArgsInput` already is. The
`{(defaultEnvSummary || envSummary) && …}` wrapper is removed.

`defaultEnvSummary` is still used on line 102 to seed `cmdOpen`, so nothing is orphaned
and typecheck stays clean.

Adds `AgentCatalogRow.test.tsx` covering both the empty and populated cases.

## Why

`agentDefaultEnv` is the only supported way to give a spawned agent environment variables
— `worktree create` and `terminal create` have no env flag, and the CLI exposes no
settings surface. Gating the editor on the value already existing makes it unreachable for
every agent that ships no default, which is all of them except `goose`.

The row's own helper text advertises the control (*"…edit the default launch arguments or
environment for this agent"*), so the UI promises something it does not render.

We hit this configuring OTLP telemetry for Claude sessions and had to hand-edit
`profiles/local-default/orca-data.json` with the app quit to break the loop. Once any
value exists the field appears and works correctly — only the render condition was wrong.

## Linked Issue

Fixes #17177

## Visual Proof

Settings → Agents → Installed, with no environment set for any agent.

**Before** — 1.4.192 as shipped. The Claude row ends at Arguments, and the helper text
underneath still promises "…edit the default launch arguments **or environment** for this
agent". There is no way to set one.

![before](https://github.com/user-attachments/assets/7679e0b2-deeb-4120-a74d-0a7d5d479c25)

**After** — this branch, same profile, still no environment set anywhere. Claude, Claude
Agent Teams and Kiro each render an **Environment** field with a "No default environment"
placeholder.

![after](https://github.com/user-attachments/assets/0ba4dbc7-a24f-4c89-9d80-e64ecb4846f0)

## Testing

Built from `v1.4.191` and re-based on `main` for this PR; the diff against `main` is only
the gate removal.

- `pnpm run typecheck` — clean
- `vitest src/renderer/src/components/settings/` — **162 files, 1070 tests, all passing**
- New test with the fix — 2 passed
- New test with the fix reverted — **1 failed**, on exactly the empty-env case
  (`expected 'ClaudeclaudeEnabledDisabledDefaultCom…' to contain 'Environment'`), so it
  discriminates rather than passing vacuously

Platform tested: macOS (Apple Silicon), local dev build.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

On the screenshots: I drove this through the accessibility tree rather than by hand, and
the dev build reports `Computer Use is unavailable — Orca Computer Use.app was not found`,
so I could not script a reliable window capture. The tree output above is from the real
running builds, before and after. I will attach proper before/after images before marking
this ready for review — happy to be told if the tree evidence is sufficient instead.


