### PR TITLE
fix(browser): stop shadowing navigator.webdriver on the instance

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -689,6 +689,7 @@ jobs:
         run: >-
           pnpm exec vitest run --config config/vitest.config.ts
           config/scripts/rebuild-native-deps.test.mjs
+          src/main/browser/anti-detection-automation-surface.electron.test.ts
           src/main/browser/browser-client-page-renderer-lifecycle.electron.test.ts
           src/main/browser/browser-route-tcp-egress.electron.test.ts
           src/main/browser/browser-route-webrtc-egress.electron.test.ts

--- a/src/main/browser/anti-detection-automation-surface-fixture.ts
+++ b/src/main/browser/anti-detection-automation-surface-fixture.ts
@@ -1,0 +1,184 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ANTI_DETECTION_SCRIPT } from './anti-detection'
+import { runBrowserRouteEgressElectron } from './browser-route-egress-electron-launch'
+
+/** One reading of the automation surface a detector can see from inside a browser guest. */
+export type AutomationSurface = {
+  webdriverValue: unknown
+  /** Chrome keeps `webdriver` on Navigator.prototype; an own property is a tamper signal. */
+  webdriverOwnProperty: boolean
+  webdriverOnPrototype: boolean
+  pluginsLength: number
+  pluginsIsPluginArray: boolean
+  languagesLength: number
+  topFrameChrome: string
+  subframeChrome: string
+  /** bot.sannysoft.com: `navigator.webdriver || _.has(navigator, 'webdriver')`. */
+  sannysoftWebdriverFailed: boolean
+  /** bot.sannysoft.com: not a PluginArray, empty, or a first entry that is not a Plugin. */
+  sannysoftPluginsTypeFailed: boolean
+  /** bot.sannysoft.com: no window.chrome at all. */
+  sannysoftChromeFailed: boolean
+  /** bot.sannysoft.com: no navigator.languages entries. */
+  sannysoftLanguagesFailed: boolean
+}
+
+export type AntiDetectionAutomationSurfaceProbeResult = {
+  /** No debugger attached and no script: what the guest exposes on its own. */
+  native: AutomationSurface
+  /** webContents.debugger attached, nothing injected: isolates what CDP attachment alone changes. */
+  debuggerAttached: AutomationSurface
+  /** The production injection path: attach, then Page.addScriptToEvaluateOnNewDocument. */
+  scriptInjected: AutomationSurface
+}
+
+const MEASURE_SOURCE = `(() => {
+  const iframe = document.createElement('iframe')
+  iframe.srcdoc = 'subframe'
+  document.body.appendChild(iframe)
+  const subframeChrome = typeof iframe.contentWindow.chrome
+  iframe.remove()
+  const plugins = navigator.plugins
+  const webdriverOwnProperty = Object.prototype.hasOwnProperty.call(navigator, 'webdriver')
+  const pluginsIsPluginArray = plugins instanceof PluginArray
+  return {
+    webdriverValue: navigator.webdriver,
+    webdriverOwnProperty,
+    webdriverOnPrototype:
+      Object.getOwnPropertyDescriptor(Navigator.prototype, 'webdriver') !== undefined,
+    pluginsLength: plugins.length,
+    pluginsIsPluginArray,
+    languagesLength: (navigator.languages || []).length,
+    topFrameChrome: typeof window.chrome,
+    subframeChrome,
+    sannysoftWebdriverFailed: Boolean(navigator.webdriver) || webdriverOwnProperty,
+    sannysoftPluginsTypeFailed:
+      !pluginsIsPluginArray || plugins.length === 0 || String(plugins[0]) !== '[object Plugin]',
+    sannysoftChromeFailed: !window.chrome,
+    sannysoftLanguagesFailed: !navigator.languages || navigator.languages.length === 0
+  }
+})()`
+
+/**
+ * Reads the automation surface of a real Electron `<webview>` guest in three states, so a claim
+ * about what the engine exposes can be checked instead of assumed.
+ */
+export async function runAntiDetectionAutomationSurfaceProbe(): Promise<AntiDetectionAutomationSurfaceProbeResult> {
+  const root = mkdtempSync(join(tmpdir(), 'orca-anti-detection-surface-'))
+  try {
+    const guestPath = join(root, 'guest.html')
+    const hostPath = join(root, 'host.html')
+    const mainPath = join(root, 'main.cjs')
+    writeFileSync(guestPath, '<!doctype html><html><body>guest</body></html>')
+    writeFileSync(
+      hostPath,
+      `<!doctype html><html><body><webview id="guest" src="${pathToFileUrl(guestPath)}" partition="persist:orca-anti-detection-surface" style="width:320px;height:240px"></webview></body></html>`
+    )
+    writeFileSync(mainPath, probeElectronMain())
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({
+        hostPath,
+        measureSource: MEASURE_SOURCE,
+        resultPath: join(root, 'result.json'),
+        script: ANTI_DETECTION_SCRIPT
+      })
+    )
+    const parsed = await runBrowserRouteEgressElectron(root, mainPath)
+    return parsed as unknown as AntiDetectionAutomationSurfaceProbeResult
+  } finally {
+    rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  }
+}
+
+function pathToFileUrl(path: string): string {
+  return `file://${path.replace(/\\/g, '/').replace(/^([A-Za-z]:)/, '/$1')}`
+}
+
+function probeElectronMain(): string {
+  return `
+const { app, BrowserWindow, session } = require('electron')
+const { readFileSync, writeFileSync } = require('node:fs')
+
+const config = JSON.parse(readFileSync(process.argv[2], 'utf8'))
+const PARTITION = 'persist:orca-anti-detection-surface'
+
+function waitFor(predicate, label) {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + 10000
+    const tick = () => {
+      if (predicate()) return resolve()
+      if (Date.now() > deadline) return reject(new Error('timed out waiting for ' + label))
+      setTimeout(tick, 25)
+    }
+    tick()
+  })
+}
+
+function reload(guest) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('guest reload timed out')), 10000)
+    guest.once('did-finish-load', () => {
+      clearTimeout(timer)
+      resolve()
+    })
+    guest.reload()
+  })
+}
+
+async function run() {
+  await app.whenReady()
+  // Match the browser session policy: nothing is granted for this probe's partition.
+  const sess = session.fromPartition(PARTITION)
+  sess.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false))
+  sess.setPermissionCheckHandler(() => false)
+
+  const host = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+      webviewTag: true
+    }
+  })
+  let guest = null
+  host.webContents.on('will-attach-webview', (_event, webPreferences) => {
+    delete webPreferences.preload
+    webPreferences.contextIsolation = true
+    webPreferences.nodeIntegration = false
+    webPreferences.sandbox = true
+    webPreferences.partition = PARTITION
+  })
+  host.webContents.on('did-attach-webview', (_event, attached) => {
+    guest = attached
+  })
+  await host.loadFile(config.hostPath)
+  await waitFor(() => guest !== null && !guest.isLoading(), 'the guest webview to settle')
+
+  const out = {}
+  out.native = await guest.executeJavaScript(config.measureSource)
+
+  guest.debugger.attach('1.3')
+  await guest.debugger.sendCommand('Page.enable', {})
+  await reload(guest)
+  out.debuggerAttached = await guest.executeJavaScript(config.measureSource)
+
+  await guest.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {
+    source: config.script
+  })
+  await reload(guest)
+  out.scriptInjected = await guest.executeJavaScript(config.measureSource)
+
+  writeFileSync(config.resultPath, JSON.stringify(out))
+  app.exit(0)
+}
+
+run().catch((error) => {
+  writeFileSync(config.resultPath, JSON.stringify({ error: String((error && error.stack) || error) }))
+  app.exit(1)
+})
+`
+}

--- a/src/main/browser/anti-detection-automation-surface-fixture.ts
+++ b/src/main/browser/anti-detection-automation-surface-fixture.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { ANTI_DETECTION_SCRIPT } from './anti-detection'
 import { runBrowserRouteEgressElectron } from './browser-route-egress-electron-launch'
 
@@ -74,7 +75,7 @@ export async function runAntiDetectionAutomationSurfaceProbe(): Promise<AntiDete
     writeFileSync(guestPath, '<!doctype html><html><body>guest</body></html>')
     writeFileSync(
       hostPath,
-      `<!doctype html><html><body><webview id="guest" src="${pathToFileUrl(guestPath)}" partition="persist:orca-anti-detection-surface" style="width:320px;height:240px"></webview></body></html>`
+      `<!doctype html><html><body><webview id="guest" src="${pathToFileURL(guestPath).href}" partition="persist:orca-anti-detection-surface" style="width:320px;height:240px"></webview></body></html>`
     )
     writeFileSync(mainPath, probeElectronMain())
     writeFileSync(
@@ -91,10 +92,6 @@ export async function runAntiDetectionAutomationSurfaceProbe(): Promise<AntiDete
   } finally {
     rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
   }
-}
-
-function pathToFileUrl(path: string): string {
-  return `file://${path.replace(/\\/g, '/').replace(/^([A-Za-z]:)/, '/$1')}`
 }
 
 function probeElectronMain(): string {
@@ -115,6 +112,17 @@ function waitFor(predicate, label) {
     }
     tick()
   })
+}
+
+// Why the document and not guest.getURL(): a path the URL builder mis-encodes lands the guest on
+// chrome-error://chromewebdata, whose engine readings look exactly like a healthy guest's — and
+// whose requested URL still ends in guest.html. Only the loaded body proves what was measured.
+async function measure(guest, config, label) {
+  const loaded = await guest.executeJavaScript('[location.href, document.body && document.body.textContent]')
+  if (loaded[1] !== 'guest') {
+    throw new Error(label + ' measured ' + loaded[0] + ' instead of the guest document')
+  }
+  return guest.executeJavaScript(config.measureSource)
 }
 
 function reload(guest) {
@@ -164,18 +172,18 @@ async function run() {
   )
 
   const out = {}
-  out.native = await guest.executeJavaScript(config.measureSource)
+  out.native = await measure(guest, config, 'native')
 
   guest.debugger.attach('1.3')
   await guest.debugger.sendCommand('Page.enable', {})
   await reload(guest)
-  out.debuggerAttached = await guest.executeJavaScript(config.measureSource)
+  out.debuggerAttached = await measure(guest, config, 'debuggerAttached')
 
   await guest.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {
     source: config.script
   })
   await reload(guest)
-  out.scriptInjected = await guest.executeJavaScript(config.measureSource)
+  out.scriptInjected = await measure(guest, config, 'scriptInjected')
 
   writeFileSync(config.resultPath, JSON.stringify(out))
   app.exit(0)

--- a/src/main/browser/anti-detection-automation-surface-fixture.ts
+++ b/src/main/browser/anti-detection-automation-surface-fixture.ts
@@ -156,7 +156,12 @@ async function run() {
     guest = attached
   })
   await host.loadFile(config.hostPath)
-  await waitFor(() => guest !== null && !guest.isLoading(), 'the guest webview to settle')
+  // Why the URL and not just isLoading(): an attached guest reads as idle in the gap before its
+  // src starts loading, and measuring there would read an empty document instead of the guest.
+  await waitFor(
+    () => guest !== null && !guest.isLoading() && guest.getURL().endsWith('guest.html'),
+    'the guest webview to load its document'
+  )
 
   const out = {}
   out.native = await guest.executeJavaScript(config.measureSource)

--- a/src/main/browser/anti-detection-automation-surface.electron.test.ts
+++ b/src/main/browser/anti-detection-automation-surface.electron.test.ts
@@ -1,0 +1,58 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import {
+  runAntiDetectionAutomationSurfaceProbe,
+  type AntiDetectionAutomationSurfaceProbeResult
+} from './anti-detection-automation-surface-fixture'
+
+// Why one probe for the whole file: each run boots a full Electron stack and loads a real
+// <webview> guest three times. The assertions below read different rows of the same reading.
+let probe: AntiDetectionAutomationSurfaceProbeResult
+
+beforeAll(async () => {
+  probe = await runAntiDetectionAutomationSurfaceProbe()
+}, 120_000)
+
+describe('browser guest automation surface under Electron', () => {
+  it('reports navigator.webdriver as false without any injected override', () => {
+    expect(probe.native.webdriverValue).toBe(false)
+    expect(probe.native.webdriverOnPrototype).toBe(true)
+    expect(probe.native.webdriverOwnProperty).toBe(false)
+  })
+
+  // Why this is a premise pin, not a guard on our own code: it records what attaching
+  // webContents.debugger does to navigator.webdriver, which is the claim the injected override
+  // was written to answer. Nothing in src can falsify it; only an engine change can.
+  it('leaves navigator.webdriver false when the CDP debugger is attached', () => {
+    expect(probe.debuggerAttached.webdriverValue).toBe(false)
+    expect(probe.debuggerAttached.webdriverOwnProperty).toBe(false)
+  })
+
+  it('keeps webdriver off the navigator instance once the anti-detection script has run', () => {
+    expect(probe.scriptInjected.webdriverValue).toBe(false)
+    expect(probe.scriptInjected.webdriverOwnProperty).toBe(false)
+    expect(probe.scriptInjected.sannysoftWebdriverFailed).toBe(false)
+  })
+
+  // Why assert the engine and not our script: the plugins and languages fallbacks are guarded on
+  // an empty array. These readings are the reason those guards never open, so a platform where
+  // they would open fails here rather than silently swapping in a forged PluginArray.
+  it('already exposes the plugins, languages and chrome surface the script used to backfill', () => {
+    expect(probe.native.pluginsLength).toBeGreaterThan(0)
+    expect(probe.native.pluginsIsPluginArray).toBe(true)
+    expect(probe.native.languagesLength).toBeGreaterThan(0)
+    expect(probe.native.topFrameChrome).toBe('object')
+  })
+
+  // Why this one override still earns its place: Electron gives the top document a window.chrome
+  // but leaves subframes without one, and the script is what closes that gap.
+  it('gains window.chrome in subframes only once the script has run', () => {
+    expect(probe.native.subframeChrome).toBe('undefined')
+    expect(probe.scriptInjected.subframeChrome).toBe('object')
+  })
+
+  it('passes the plugins, chrome and languages checks bot.sannysoft.com runs', () => {
+    expect(probe.scriptInjected.sannysoftPluginsTypeFailed).toBe(false)
+    expect(probe.scriptInjected.sannysoftChromeFailed).toBe(false)
+    expect(probe.scriptInjected.sannysoftLanguagesFailed).toBe(false)
+  })
+})

--- a/src/main/browser/anti-detection.test.ts
+++ b/src/main/browser/anti-detection.test.ts
@@ -16,6 +16,9 @@ type AntiDetectionContext = {
   }
   navigator: {
     userAgent: string
+    webdriver: unknown
+    languages: string[]
+    plugins: { name: string }[]
     permissions: {
       query: (descriptor: { name: string }) => Promise<PermissionQueryResult>
     }
@@ -60,20 +63,64 @@ function createContext(args: {
     performance: { now: () => 0 },
     // Electron 43 exposes this native object before the anti-detection script runs.
     window: { chrome: {} },
-    navigator: {
+    // Why the prototype: engines keep webdriver on Navigator.prototype, so only a script that
+    // defines its own copy puts one on the instance — which is the shape detectors read.
+    navigator: Object.assign(Object.create({ webdriver: false }) as { webdriver: unknown }, {
       userAgent:
         args.userAgent ??
         'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36',
       plugins: [],
       languages: [],
       permissions: new Permissions()
-    },
+    }),
     Permissions,
     Notification
   } as AntiDetectionContext & Record<string, unknown>
 }
 
 describe('ANTI_DETECTION_SCRIPT', () => {
+  // Why an own property and not the value: engines already report webdriver as false, so a
+  // detector cannot learn anything from the value. It learns from where the property lives —
+  // bot.sannysoft.com fails a page when `_.has(navigator, 'webdriver')` is true.
+  it('leaves webdriver on the navigator prototype instead of shadowing it on the instance', () => {
+    const context = createContext({
+      nativeNotificationPermission: 'denied',
+      requestedNotificationPermission: 'denied'
+    })
+
+    runInNewContext(ANTI_DETECTION_SCRIPT, context)
+
+    expect(Object.hasOwn(context.navigator, 'webdriver')).toBe(false)
+    expect(context.navigator.webdriver).toBe(false)
+  })
+
+  // Why assert against a context that reports none: a real guest never does, so this is the only
+  // place the removed fallback could still fire. Forging entries would swap a real PluginArray for
+  // plain objects, which is a louder signal than the empty array it was meant to hide.
+  it('does not forge plugin entries when the engine reports none', () => {
+    const context = createContext({
+      nativeNotificationPermission: 'denied',
+      requestedNotificationPermission: 'denied'
+    })
+
+    runInNewContext(ANTI_DETECTION_SCRIPT, context)
+
+    expect(context.navigator.plugins).toHaveLength(0)
+    expect(Object.getOwnPropertyDescriptor(context.navigator, 'plugins')?.get).toBeUndefined()
+  })
+
+  it('does not forge languages when the engine reports none', () => {
+    const context = createContext({
+      nativeNotificationPermission: 'denied',
+      requestedNotificationPermission: 'denied'
+    })
+
+    runInNewContext(ANTI_DETECTION_SCRIPT, context)
+
+    expect(context.navigator.languages).toHaveLength(0)
+    expect(Object.getOwnPropertyDescriptor(context.navigator, 'languages')?.get).toBeUndefined()
+  })
+
   it('does not expose Chrome globals under a Firefox identity', () => {
     const context = createContext({
       nativeNotificationPermission: 'denied',

--- a/src/main/browser/anti-detection.ts
+++ b/src/main/browser/anti-detection.ts
@@ -1,21 +1,10 @@
-// Why: Cloudflare Turnstile and similar bot detectors probe multiple browser
-// APIs beyond navigator.webdriver. This script runs via
-// Page.addScriptToEvaluateOnNewDocument before any page JS to mask automation
-// signals that CDP debugger attachment and Electron's webview expose.
+// Why: Electron's browser guest diverges from Chrome on a few APIs that bot detectors read,
+// and this script closes those specific gaps. It runs via Page.addScriptToEvaluateOnNewDocument
+// before any page JS. Every override here has to earn its place against a measurement in
+// anti-detection-automation-surface.electron.test.ts: what Electron already reports matches Chrome
+// for navigator.webdriver, plugins and languages, so nothing masks those. Defining a property the
+// engine keeps on a prototype moves it onto the instance, which is itself what detectors look for.
 export const ANTI_DETECTION_SCRIPT = `(function() {
-  Object.defineProperty(navigator, 'webdriver', { get: () => false });
-  // Why: Electron webviews expose an empty plugins array. Real Chrome always
-  // has at least a few default plugins (PDF Viewer, etc.). An empty array is
-  // a strong automation signal.
-  if (navigator.plugins.length === 0) {
-    Object.defineProperty(navigator, 'plugins', {
-      get: () => [
-        { name: 'Chrome PDF Plugin', filename: 'internal-pdf-viewer' },
-        { name: 'Chrome PDF Viewer', filename: 'mhjfbmdgcfjbbpaeojofohoefgiehjai' },
-        { name: 'Native Client', filename: 'internal-nacl-plugin' }
-      ]
-    });
-  }
   // Why: auth hosts present Firefox, where Electron's native window.chrome is an identity mismatch.
   if (navigator.userAgent.includes('Firefox/')) {
     try {
@@ -151,11 +140,4 @@ export const ANTI_DETECTION_SCRIPT = `(function() {
       };
     }
   } catch {}
-  // Why: Electron webviews may have an empty languages array. Real Chrome
-  // always has at least one entry. An empty array is an automation signal.
-  if (!navigator.languages || navigator.languages.length === 0) {
-    Object.defineProperty(navigator, 'languages', {
-      get: () => ['en-US', 'en']
-    });
-  }
 })()`

--- a/src/main/browser/cdp-debugger-channel.ts
+++ b/src/main/browser/cdp-debugger-channel.ts
@@ -34,9 +34,9 @@ export class CdpDebuggerChannel {
     }
     this.attached = true
 
-    // Why: attaching the CDP debugger sets navigator.webdriver = true and
-    // exposes other automation signals that Cloudflare Turnstile checks.
-    // Inject before any page loads so challenges succeed.
+    // Why: Electron's guest diverges from Chrome on a few APIs Cloudflare Turnstile reads.
+    // Inject before any page loads so challenges succeed. Attaching the debugger is not itself
+    // one of those divergences — it leaves navigator.webdriver false, which is what Chrome reports.
     try {
       await this.webContents.debugger.sendCommand('Page.enable', {})
       await this.webContents.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​107 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​105 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​207 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​180 |

<!-- /orca-pr-loc -->

## ELI5

Orca's browser injects a small script into every page whose job is to make the built-in browser
look like ordinary Chrome. One line of that script rewrote `navigator.webdriver` — the flag a site
reads to ask "is a robot driving this?".

The line was pointless: the browser already answers `false` there, all by itself. And rewriting it
left a fingerprint. Sites don't only read the answer — they check *where the answer comes from*. In
a real browser `webdriver` is inherited from the prototype; the line put a personal copy directly
on `navigator`, and that copy is a thing only a script would have made.

So a line written to help Orca blend in was the single reason one detector called it a bot. It's
gone. Two neighbouring lines went with it for the same reason: they were repairing an empty plugin
list and an empty language list that the browser never actually has.

## User-facing before / after

**Before** — on [bot.sannysoft.com](https://bot.sannysoft.com), the Orca browser's **WebDriver**
row read `present (failed)`, in red. It failed that check *because of* Orca's own anti-detection
script; with the script switched off entirely, the same page passed.

**After** — the row reads `missing (passed)`. Orca reports what the engine actually reports.

Nothing else on that page changes: the other 55 rows read identically in all three arms.

## What was measured

A real Electron 43 `<webview>` guest, three states, one variable at a time
(`anti-detection-automation-surface.electron.test.ts` runs the first table on every CI run):

| | no debugger | debugger attached | debugger + injected script (before this PR) |
|---|---|---|---|
| `navigator.webdriver` | `false` | `false` | `false` |
| `webdriver` is an own property of `navigator` | no | no | **yes** |
| `navigator.plugins.length` | 5 | 5 | 5 |
| `navigator.plugins instanceof PluginArray` | yes | yes | yes |
| `navigator.languages.length` | 1 | 1 | 1 |
| top-frame `typeof window.chrome` | `object` | `object` | `object` |
| subframe `typeof window.chrome` | `undefined` | `undefined` | `object` |

And a live three-arm run against bot.sannysoft.com itself, scraping all 56 rows:

| row | no script | script before this PR | script after this PR |
|---|---|---|---|
| **WebDriver (New)** | passed — `missing (passed)` | **FAILED — `present (failed)`** | passed — `missing (passed)` |
| **HEADCHR_IFRAME** | **FAILED** | passed | passed |
| other 54 rows | identical | identical | identical |

## What this changes

**Removed** — three overrides whose stated premise is measurably false:

- `navigator.webdriver`. The engine reports `false` on its own, so the override moved no value; it
  only moved the property onto the instance, which is the thing the detector reads. Chrome 152
  driven over CDP reports the same `false`, so this is not an Electron quirk.
- the `navigator.plugins` fallback. The comment said Electron webviews expose an empty array; the
  guest reports five real `Plugin` entries in a real `PluginArray`, so the guard never opened. Run
  in the one context where it does open, the pre-PR script produces three plain objects whose first
  entry stringifies to `[object Object]` rather than `[object Plugin]` — which is precisely what
  fails the *Plugins is of type PluginArray* row on the same detector. The repair was a louder
  signal than the thing it repaired.
- the `navigator.languages` fallback, for the same reason: the list is never empty.

**Kept** — `if (!window.chrome) window.chrome = {}` plus the `csi`/`loadTimes` stubs. Electron gives
the top document a `window.chrome` but leaves subframes without one, and this branch is what closes
that gap. It is the HEADCHR_IFRAME row above: that check fails with no script and passes with it.
Chrome 152 still exposes both `csi` and `loadTimes`, so the stubs move Orca toward what a real
browser reports rather than away from it.

**Kept** — the Permissions/Notification override. Its premise holds: camera and microphone read
`denied` in the guest and `prompt` in Chrome, and the override closes that. Worth recording that it
leaves the same own-property residue on `PermissionStatus.state` that the `webdriver` line left on
`navigator` — measured, but no detector I ran reads it, and unlike `webdriver` this one is changing
a value that genuinely differs.

**Corrected** — the comment in `cdp-debugger-channel.ts` claiming that attaching the CDP debugger
sets `navigator.webdriver = true`. It does not, on either engine; `--enable-automation` is what
sets that flag, and nothing in this repo passes it.

## Proof

- Failing-first and 1-to-1. Restoring each removed line reddens exactly one test and no others:
  the `webdriver` line reddens the unit assertion *and* the Electron assertion (2 tests); the
  plugins line reddens 1; the languages line reddens 1. Deleting the *kept* `window.chrome` branch
  reddens 1 — which is how that branch earned the keep.
- Ablations were run one gate at a time, serially, each mutation asserting that the file actually
  changed before the suite ran, with the tree restored and hash-checked between runs.
- The removed plugins and languages guards are unreachable in a real guest, so no assertion about
  them can be falsified by the deletion alone; they are pinned instead against a forced
  empty-array context, where the pre-PR script does forge entries.

## What is not proven

- Whether Cloudflare Turnstile specifically reads any of this. Turnstile is opaque; the claim here
  is the measured input/output relation on bot.sannysoft.com and on the engine, not the reason
  behind either.
- Nothing outstanding on platforms: the probe passes on macOS locally, on Linux in the sharded test
  job, and on Windows in the `package (windows)` lane, which this PR adds it to. All three agree on
  the plugins, languages and `window.chrome` readings.
- `cross-version wire compatibility` is red here and red on unrelated PRs with a byte-identical
  assertion (`expected ... to not have property "terminalOwner"`). It is the known self-expiring
  baseline, not this change; `verify` fails only because it aggregates that lane.
- Detector sites change without notice. The committed test measures the engine and replicates
  sannysoft's published predicates offline; it does not depend on the site being reachable.
