### PR TITLE
fix(rate-limits): a failed shared-quota read is an Antigravity error, not an absent reading

### DIFF
--- a/src/main/rate-limits/antigravity-usage-mirror.test.ts
+++ b/src/main/rate-limits/antigravity-usage-mirror.test.ts
@@ -30,13 +30,15 @@ describe('deriveAntigravityRateLimits', () => {
     expect(antigravity.error).toBeNull()
   })
 
-  it('reports unavailable without quoting the Gemini failure', () => {
+  it('settles a failed quota read as an error without quoting the Gemini failure', () => {
     const antigravity = deriveAntigravityRateLimits(
       geminiSnapshot('error', 'Gemini project ID not found')
     )
 
     expect(antigravity.provider).toBe('antigravity')
-    expect(antigravity.status).toBe('unavailable')
+    // Why: the Gemini read is Antigravity's read of the shared quota, so its failure is a failed
+    // read, not an absent one — `unavailable` would discard the last good snapshot downstream.
+    expect(antigravity.status).toBe('error')
     expect(antigravity.error).not.toContain('Gemini project ID not found')
     expect(antigravity.error).toContain('Antigravity usage is not available')
     expect(antigravity.session).toBeNull()

--- a/src/main/rate-limits/antigravity-usage-mirror.test.ts
+++ b/src/main/rate-limits/antigravity-usage-mirror.test.ts
@@ -40,7 +40,11 @@ describe('deriveAntigravityRateLimits', () => {
     // read, not an absent one — `unavailable` would discard the last good snapshot downstream.
     expect(antigravity.status).toBe('error')
     expect(antigravity.error).not.toContain('Gemini project ID not found')
-    expect(antigravity.error).toContain('Antigravity usage is not available')
+    // Why: still Orca's own Antigravity wording — but this lane retains a reading, so it may not
+    // say the usage is unavailable. The no-sign-in lane below keeps that phrasing.
+    expect(antigravity.error).toContain('Antigravity usage')
+    expect(antigravity.error).toContain('shared Google Code Assist quota')
+    expect(antigravity.error).not.toContain('not available')
     expect(antigravity.session).toBeNull()
     expect(antigravity.weekly).toBeNull()
   })

--- a/src/main/rate-limits/antigravity-usage-mirror.ts
+++ b/src/main/rate-limits/antigravity-usage-mirror.ts
@@ -11,8 +11,10 @@ import type { ProviderRateLimits } from '../../shared/rate-limit-types'
 // implied, and a bespoke label would suppress the tooltip's "showing cached data" suffix.
 const ANTIGRAVITY_NO_SIGN_IN_REASON =
   'Antigravity usage is not available. Orca can only show shared Google Code Assist quota while a Gemini CLI sign-in is connected.'
+// Why: this lane now retains the last reading, so the tooltip prints this line above a live
+// meter — claiming the usage is unavailable would contradict the numbers beside it.
 const ANTIGRAVITY_QUOTA_UNREADABLE_REASON =
-  'Antigravity usage is not available. Orca reads it from the shared Google Code Assist quota, which could not be read right now.'
+  'Orca reads Antigravity usage from the shared Google Code Assist quota, which could not be read right now.'
 
 export function deriveAntigravityRateLimits(gemini: ProviderRateLimits): ProviderRateLimits {
   if (gemini.status === 'ok') {

--- a/src/main/rate-limits/antigravity-usage-mirror.ts
+++ b/src/main/rate-limits/antigravity-usage-mirror.ts
@@ -1,12 +1,16 @@
 import type { ProviderRateLimits } from '../../shared/rate-limit-types'
 
-// Why: the Antigravity CLI keeps its token in the OS keyring, not in the files the Gemini
-// fetcher reads, so Orca never actually queries Antigravity. Only a *successful* Gemini read
-// describes shared Google Code Assist quota; republishing a Gemini failure under the
-// Antigravity provider id surfaced "Refresh failed" for a request that was never attempted.
+// Why: Orca has no Antigravity endpoint — the Gemini read of shared Google Code Assist quota *is*
+// Antigravity's read, which is why a successful one is mirrored verbatim. #15876 stopped this row
+// quoting Gemini's raw error and blaming a sign-in that exists; both still hold. It also settled a
+// failed read as `unavailable`, taken as a copy choice but really a retention verdict —
+// `applyStalePolicy` discards on `unavailable`, retains on `error` — so one failure wiped this row
+// and spared Gemini's. One read cannot be Antigravity's when it succeeds and nobody's when it
+// fails, so a failed read settles `error` here too. That brings back the generic "Refresh failed"
+// label deliberately: the reason below names the shared quota, so no Antigravity request is
+// implied, and a bespoke label would suppress the tooltip's "showing cached data" suffix.
 const ANTIGRAVITY_NO_SIGN_IN_REASON =
   'Antigravity usage is not available. Orca can only show shared Google Code Assist quota while a Gemini CLI sign-in is connected.'
-// Why: a Gemini `error` means the sign-in exists and the quota read failed, so blaming a missing sign-in would misdirect the user.
 const ANTIGRAVITY_QUOTA_UNREADABLE_REASON =
   'Antigravity usage is not available. Orca reads it from the shared Google Code Assist quota, which could not be read right now.'
 
@@ -14,16 +18,16 @@ export function deriveAntigravityRateLimits(gemini: ProviderRateLimits): Provide
   if (gemini.status === 'ok') {
     return { ...gemini, provider: 'antigravity' }
   }
+  // Why: a Gemini `error` means the sign-in exists and the read failed; anything else means there
+  // was nothing to read, which is genuinely absent rather than failed.
+  const quotaReadFailed = gemini.status === 'error'
   return {
     provider: 'antigravity',
     session: null,
     weekly: null,
     // Why: reuse the Gemini timestamp so activation freshness checks don't force a refetch every cycle.
     updatedAt: gemini.updatedAt,
-    error:
-      gemini.status === 'unavailable'
-        ? ANTIGRAVITY_NO_SIGN_IN_REASON
-        : ANTIGRAVITY_QUOTA_UNREADABLE_REASON,
-    status: 'unavailable'
+    error: quotaReadFailed ? ANTIGRAVITY_QUOTA_UNREADABLE_REASON : ANTIGRAVITY_NO_SIGN_IN_REASON,
+    status: quotaReadFailed ? 'error' : 'unavailable'
   }
 }

--- a/src/main/rate-limits/gemini-oauth-sources.ts
+++ b/src/main/rate-limits/gemini-oauth-sources.ts
@@ -68,7 +68,9 @@ export async function readGeminiCredentials(): Promise<GeminiCredentials | null>
     ) {
       return parsed as GeminiCredentials
     }
-    return null
+    // A file that exists but does not match the credential contract is a failed
+    // read. Preserve that distinction so callers do not report it as signed out.
+    throw new Error('Gemini CLI credentials file is invalid')
   } catch (err) {
     if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
       return null

--- a/src/main/rate-limits/gemini-usage-fetcher.fallback.test.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.fallback.test.ts
@@ -153,6 +153,36 @@ describe('fetchGeminiRateLimits fallback oauth creds', () => {
     expect(result.weekly).toBeNull()
   })
 
+  it('reports a present but malformed oauth_creds.json as a failed read', async () => {
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (filePath.includes('auth.json')) {
+        return JSON.stringify({})
+      }
+      if (filePath.includes('oauth_creds.json')) {
+        return JSON.stringify({
+          access_token: 42,
+          refresh_token: 'refresh',
+          expiry_date: Date.now()
+        })
+      }
+      throw { code: 'ENOENT' }
+    })
+
+    const result = await fetchGeminiRateLimits(true)
+
+    expect(result.status).toBe('error')
+    expect(result.error).toContain('credentials file is invalid')
+  })
+
+  it('keeps an actually missing oauth_creds.json as absent', async () => {
+    readFileMock.mockRejectedValue({ code: 'ENOENT' })
+
+    const result = await fetchGeminiRateLimits(true)
+
+    expect(result.status).toBe('unavailable')
+    expect(result.error).toContain('credentials not found')
+  })
+
   it('returns error when loadCodeAssist cannot resolve a project for oauth_creds path', async () => {
     // Why: when the fallback (oauth_creds.json) path has no project embedded
     // and loadCodeAssist fails, we surface a clear "project ID not found"

--- a/src/main/rate-limits/service-antigravity-usage.test.ts
+++ b/src/main/rate-limits/service-antigravity-usage.test.ts
@@ -54,7 +54,7 @@ describe('RateLimitService Antigravity usage', () => {
     vi.mocked(fetchCodexRateLimits).mockResolvedValue(okProvider('codex', 20))
   })
 
-  it('does not republish a Gemini failure as an Antigravity refresh failure', async () => {
+  it('does not republish the Gemini failure text under the Antigravity provider', async () => {
     vi.mocked(fetchGeminiRateLimits).mockResolvedValue(
       errorProvider('gemini', 'Gemini project ID not found')
     )
@@ -63,7 +63,8 @@ describe('RateLimitService Antigravity usage', () => {
     await service.refresh()
 
     const state = service.getState()
-    expect(state.antigravity?.status).toBe('unavailable')
+    // Why: a failed shared-quota read is a failed Antigravity read; only the wording is Antigravity's.
+    expect(state.antigravity?.status).toBe('error')
     expect(state.antigravity?.error).not.toContain('Gemini project ID not found')
     expect(state.antigravity?.session).toBeNull()
     // Why: the real Gemini failure must still surface under its own provider.
@@ -83,7 +84,7 @@ describe('RateLimitService Antigravity usage', () => {
     expect(state.antigravity?.session?.usedPercent).toBe(42)
   })
 
-  it('never leaves a cached Antigravity snapshot in the error retry lane', async () => {
+  it('keeps the last shared-quota reading when the quota read fails, exactly as Gemini does', async () => {
     vi.mocked(fetchGeminiRateLimits).mockResolvedValueOnce(okProvider('gemini', 42, Date.now()))
     const service = new RateLimitService()
     await service.refresh()
@@ -93,8 +94,27 @@ describe('RateLimitService Antigravity usage', () => {
     )
     await service.refresh()
 
-    // Why: stale-retention would otherwise show Gemini numbers as "Refresh failed" Antigravity usage.
-    expect(service.getState().antigravity?.status).toBe('unavailable')
-    expect(service.getState().antigravity?.session).toBeNull()
+    // Why: one read backs both rows, so one failure must not wipe one row and spare the other.
+    const state = service.getState()
+    expect(state.antigravity?.status).toBe('error')
+    expect(state.antigravity?.session?.usedPercent).toBe(42)
+    expect(state.gemini?.status).toBe('error')
+    expect(state.gemini?.session?.usedPercent).toBe(42)
+  })
+
+  it('does not quote the Gemini failure while showing a retained Antigravity reading', async () => {
+    vi.mocked(fetchGeminiRateLimits).mockResolvedValueOnce(okProvider('gemini', 42, Date.now()))
+    const service = new RateLimitService()
+    await service.refresh()
+
+    vi.mocked(fetchGeminiRateLimits).mockResolvedValue(
+      errorProvider('gemini', 'Token refresh failed')
+    )
+    await service.refresh()
+
+    // Why: #15876's real protection — the Antigravity row owns its wording even in the failure lane.
+    const antigravity = service.getState().antigravity
+    expect(antigravity?.error).not.toContain('Token refresh failed')
+    expect(antigravity?.error).toContain('shared Google Code Assist quota')
   })
 })

--- a/src/main/rate-limits/service-antigravity-usage.test.ts
+++ b/src/main/rate-limits/service-antigravity-usage.test.ts
@@ -116,5 +116,10 @@ describe('RateLimitService Antigravity usage', () => {
     const antigravity = service.getState().antigravity
     expect(antigravity?.error).not.toContain('Token refresh failed')
     expect(antigravity?.error).toContain('shared Google Code Assist quota')
+    // Why: retention is what makes this lane new — the tooltip prints this reason under
+    // "Refresh failed — showing cached data" and directly above the retained meter, so a reason
+    // that calls the usage unavailable contradicts the numbers rendered next to it.
+    expect(antigravity?.session?.usedPercent).toBe(42)
+    expect(antigravity?.error).not.toContain('not available')
   })
 })

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -1767,7 +1767,8 @@ export class RateLimitService {
             status: 'error'
           } satisfies ProviderRateLimits)
 
-    // Why: Antigravity can only borrow a *successful* Gemini read; a Gemini failure is not an Antigravity failure.
+    // Why: the Gemini read of shared Code Assist quota IS Antigravity's read, so its failure is
+    // Antigravity's failed read too — see antigravity-usage-mirror.ts for why that settles `error`.
     const antigravity = deriveAntigravityRateLimits(gemini)
 
     const opencodeGo =


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​70 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​61 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

## Adjudication: the unreadable-response rule vs. the reverted Antigravity judgement

A stated rule (`unreadable-usage-response.ts`, on #17193) and a documented prior decision (#15876)
disagreed about the Antigravity usage mirror. This PR settles it. **Outcome: the prior decision was
made under an assumption that no longer holds.** It is changed deliberately; its tests are updated
in place, not deleted; and the reasoning is written into the file the next person meets.

### The previous author's reasoning (#15876, `636f428c25`)

Before #15876 the mirror was `{...gemini, provider: 'antigravity'}`. On a Gemini failure the
Antigravity row said **"Refresh failed"** and quoted Gemini's raw error (`Gemini project ID not
found`) — for a request Orca never sent, since Antigravity's token lives in the OS keyring and Orca
has no Antigravity endpoint. #15876 gave the row two Antigravity-owned reason strings and settled it
`unavailable`, pinned by `service-antigravity-usage.test.ts` — *"never leaves a cached Antigravity
snapshot in the error retry lane / Why: stale-retention would otherwise show Gemini numbers as
'Refresh failed' Antigravity usage."*

That reasoning is about **wording and blame**, and it is sound. It is preserved here in full.

### The assumption that no longer holds

`unavailable` was picked as a *label* choice. It is a **retention verdict**: `applyStalePolicy`
discards on `unavailable` and retains on `error`. Driven on `a1f198be0d`, one Gemini failure:

```
AFTER GOOD  gemini= {"s":"ok","sess":42}       antigrav= {"s":"ok","sess":42}
AFTER FAIL  gemini= {"s":"error","sess":42}    antigrav= {"s":"unavailable"}   ← 42% destroyed
```

The same read backs both rows. #15876's own second test blesses a successful Gemini read *as*
Antigravity's reading — so that read cannot be Antigravity's when it succeeds and nobody's when it
fails. That is exactly the shape the rule names: **a failed read reclassified as an absent one.**

### The asymmetry, and why it now has a stated reason

It no longer exists on a failed read — both rows retain, both settle `error`. It *is* retained,
with a reason, for the other Gemini verdict: `unavailable` (opt-in off) still maps to `unavailable`
on both, because nothing was read. Driven post-fix:

```
FAILREAD gemini= {"s":"error","u":42}          antig= {"s":"error","u":42}  + Antigravity wording
OPTOFF   gemini= {"s":"unavailable"}           antig= {"s":"unavailable"}   + Antigravity wording
```

### On the second harm — the hidden status surface

Driven, and it **does not apply to Antigravity**, uniquely: `isProviderConfigured` returns false for
`unavailable`, but `getVisibleUsageProvider` re-renders the row from the settings signal
(`antigravityUsageConfigured && geminiCliOAuthEnabled`), which is what makes the row exist at all.
The row survived either way. Only the destroyed-snapshot half was ever real here — reported rather
than overstated.

### "Refresh failed" comes back — deliberately

The label is status-derived. With a retained reading it reads *"Refresh failed — showing cached
data"* over the Antigravity reason line, which names the shared quota as the thing that failed, so
no Antigravity-specific request is implied. A bespoke provider label (the `usage-error-copy.ts`
`failureKind` mechanism, which already existed in Aug 2026) was considered and **declined**: it
would suppress the more useful "showing cached data" suffix. Stated in the file header.

### Verification

Failing-first, 1-to-1: the two new assertions were red on unmodified `main` before the fix; the two
prior-author status assertions went red only after it, and were then updated in place with their
new reasoning. Ablations run **serially, each mutation verified applied and reverted clean**, over
`src/main/rate-limits` + `src/renderer/src/components/status-bar` (89 files / 741 tests, green):

| Ablation | Red |
|---|---|
| A — delete the rule (`status` back to `'unavailable'`) | **3** |
| B — broaden the predicate to `true` (all non-ok → `error`) | **2** |
| C — leak `gemini.error` into the Antigravity reason | **5** |

Both halves are separately load-bearing, and #15876's message protection is still strongly pinned.

Read sites grepped, including the chip: `status-bar-provider-visibility.ts`, `usage-error-copy.ts`,
`usage-provider-settings-target.ts` (Antigravity's CTA points at `accounts-gemini`, consistent),
`StatusBar.tsx`. No new fetch churn: `deriveAntigravityRateLimits` only emits `error` when Gemini is
`error`, and Gemini already forces the same non-individually-refreshable `fetchAll()` lane.

**Gates:** `pnpm tc` all projects exit 0 · `check:code-quality:changed` exit 0 (native + type-aware
+ React Doctor, 0 findings across 3 files) · focused plugin configs with `--deny-warnings` exit 0
(oxlint proven non-vacuous with a control violation) · `git diff --check` clean · formatted with
`npx oxfmt --write <paths>`. No suppressions, no `max-lines` disable.

**Scope:** nothing here touches #17193. The conclusion is that Antigravity now *conforms* to the
rule, so the rule file needs no exception — but #17193's note that the rule "contradicts the
reverted antigravity judgement" is now resolved and its owner may want to drop it.
