### PR TITLE
fix(mobile): bulk stage reviewed files

### DIFF
--- a/mobile/src/components/MobileDiffReviewDrawers.tsx
+++ b/mobile/src/components/MobileDiffReviewDrawers.tsx
@@ -270,7 +270,7 @@ function CompletionDrawer({ controller }: Props) {
       <View style={styles.drawerButtonRow}>
         <Pressable
           style={({ pressed }) => [styles.secondaryButton, pressed && styles.buttonPressed]}
-          disabled={controller.reviewedUnstagedCount === 0}
+          disabled={controller.reviewedUnstagedCount === 0 || controller.busyAction !== null}
           onPress={() => void controller.stageReviewedFiles()}
           accessibilityRole="button"
           accessibilityLabel="Stage reviewed files"

--- a/mobile/src/session/use-mobile-diff-review-git-actions.test.ts
+++ b/mobile/src/session/use-mobile-diff-review-git-actions.test.ts
@@ -1,5 +1,5 @@
 import { createElement } from 'react'
-import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { act, create } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import type { RpcResponse } from '../transport/types'
@@ -10,6 +10,10 @@ const haptics = vi.hoisted(() => ({ triggerError: vi.fn(), triggerSuccess: vi.fn
 vi.mock('../platform/haptics', () => haptics)
 
 type GitActions = ReturnType<typeof useMobileDiffReviewGitActions>
+type MountedHarness = {
+  unmount: () => void
+  update: (element: ReturnType<typeof createElement>) => void
+}
 
 function success(): RpcResponse {
   return { id: 'rpc', ok: true, result: { ok: true }, _meta: { runtimeId: 'runtime' } }
@@ -59,7 +63,7 @@ function createGenerationClient(sendRequest: ReturnType<typeof vi.fn>) {
 }
 
 describe('useMobileDiffReviewGitActions', () => {
-  let renderer: ReactTestRenderer | null = null
+  let renderer: MountedHarness | null = null
   let actions: GitActions | null = null
   let client: RpcClient
   let queue: MobileDiffReviewQueueItem[]

--- a/mobile/src/session/use-mobile-diff-review-git-actions.test.ts
+++ b/mobile/src/session/use-mobile-diff-review-git-actions.test.ts
@@ -1,0 +1,312 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcResponse } from '../transport/types'
+import type { MobileDiffReviewQueueItem } from './mobile-diff-review-queue'
+import { useMobileDiffReviewGitActions } from './use-mobile-diff-review-git-actions'
+
+const haptics = vi.hoisted(() => ({ triggerError: vi.fn(), triggerSuccess: vi.fn() }))
+vi.mock('../platform/haptics', () => haptics)
+
+type GitActions = ReturnType<typeof useMobileDiffReviewGitActions>
+
+function success(): RpcResponse {
+  return { id: 'rpc', ok: true, result: { ok: true }, _meta: { runtimeId: 'runtime' } }
+}
+
+function failure(code: string, message: string): RpcResponse {
+  return { id: 'rpc', ok: false, error: { code, message }, _meta: { runtimeId: 'runtime' } }
+}
+
+function reviewedFile(filePath: string): MobileDiffReviewQueueItem {
+  return {
+    key: `unstaged\0unstaged\0\0${filePath}`,
+    scope: 'unstaged',
+    area: 'unstaged',
+    filePath,
+    status: 'modified',
+    title: filePath,
+    subtitle: 'Unstaged',
+    canStage: true,
+    canUnstage: false,
+    canDiscard: true,
+    isGeneratedOrLockFile: false,
+    diffIdentity: `diff-${filePath}`,
+    noteCount: 0,
+    unsentNoteCount: 0,
+    staleNoteCount: 0,
+    reviewedAt: 1,
+    isReviewed: true,
+    changedSinceReview: false
+  }
+}
+
+function createGenerationClient(sendRequest: ReturnType<typeof vi.fn>) {
+  const logicalGeneration = 1
+  let lastConnectedAt = 100
+  const client = {
+    sendRequest,
+    getGeneration: () => logicalGeneration,
+    getLastConnectedAt: () => lastConnectedAt
+  } as unknown as RpcClient
+  return {
+    client,
+    advanceConnection: () => {
+      lastConnectedAt += 1
+    }
+  }
+}
+
+describe('useMobileDiffReviewGitActions', () => {
+  let renderer: ReactTestRenderer | null = null
+  let actions: GitActions | null = null
+  let client: RpcClient
+  let queue: MobileDiffReviewQueueItem[]
+  let setActionError: ReturnType<typeof vi.fn>
+  let setBusyAction: ReturnType<typeof vi.fn>
+  let loadReviewData: ReturnType<typeof vi.fn>
+
+  function Harness(): null {
+    actions = useMobileDiffReviewGitActions({
+      client,
+      connState: 'connected',
+      worktreeId: 'wt-1',
+      queue,
+      setActionError,
+      setBusyAction,
+      loadReviewData
+    })
+    return null
+  }
+
+  async function mount(): Promise<void> {
+    await act(async () => {
+      renderer = create(createElement(Harness))
+    })
+  }
+
+  async function rerender(): Promise<void> {
+    await act(async () => {
+      renderer?.update(createElement(Harness))
+    })
+  }
+
+  async function stageReviewedFiles(): Promise<void> {
+    await act(async () => {
+      await actions?.stageReviewedFiles()
+    })
+  }
+
+  beforeEach(() => {
+    queue = []
+    setActionError = vi.fn()
+    setBusyAction = vi.fn()
+    loadReviewData = vi.fn().mockResolvedValue(undefined)
+    haptics.triggerError.mockReset()
+    haptics.triggerSuccess.mockReset()
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    actions = null
+  })
+
+  it('stages 100 reviewed files with one bulk RPC', async () => {
+    const paths = Array.from({ length: 100 }, (_, index) => `src/reviewed-${index}.ts`)
+    queue = [
+      ...paths.map(reviewedFile),
+      { ...reviewedFile('src/unreviewed.ts'), isReviewed: false },
+      { ...reviewedFile('src/already-staged.ts'), scope: 'staged', area: 'staged' },
+      { ...reviewedFile('src/conflicted.ts'), canStage: false }
+    ]
+    const sendRequest = vi.fn().mockResolvedValue(success())
+    client = createGenerationClient(sendRequest).client
+    await mount()
+
+    await stageReviewedFiles()
+
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(sendRequest).toHaveBeenCalledWith('git.bulkStage', {
+      worktree: 'id:wt-1',
+      filePaths: paths
+    })
+    expect(setBusyAction.mock.calls).toEqual([['stage-reviewed'], [null]])
+    expect(setActionError).toHaveBeenLastCalledWith('100 reviewed files staged')
+    expect(haptics.triggerSuccess).toHaveBeenCalledTimes(1)
+    expect(haptics.triggerError).not.toHaveBeenCalled()
+    expect(loadReviewData).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores repeated staging while the bulk mutation is in flight', async () => {
+    queue = [reviewedFile('src/a.ts')]
+    let resolveBulk!: (response: RpcResponse) => void
+    const sendRequest = vi.fn(
+      () =>
+        new Promise<RpcResponse>((resolve) => {
+          resolveBulk = resolve
+        })
+    )
+    client = createGenerationClient(sendRequest).client
+    await mount()
+
+    let first: Promise<void> | undefined
+    let second: Promise<void> | undefined
+    await act(async () => {
+      first = actions?.stageReviewedFiles()
+      second = actions?.stageReviewedFiles()
+      await Promise.resolve()
+    })
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+
+    resolveBulk(success())
+    await act(async () => {
+      await Promise.all([first, second])
+    })
+    expect(haptics.triggerSuccess).toHaveBeenCalledTimes(1)
+    expect(loadReviewData).toHaveBeenCalledTimes(1)
+    expect(setBusyAction.mock.calls).toEqual([['stage-reviewed'], [null]])
+  })
+
+  it('falls back only after exact method_not_found and preserves the partial summary', async () => {
+    queue = [reviewedFile('src/a.ts'), reviewedFile('src/b.ts')]
+    const sendRequest = vi.fn(async (method: string, params: { filePath?: string }) => {
+      if (method === 'git.bulkStage') {
+        return failure('method_not_found', 'legacy desktop')
+      }
+      return params.filePath === 'src/a.ts' ? success() : failure('git_failed', 'blocked')
+    })
+    client = createGenerationClient(sendRequest).client
+    await mount()
+
+    await stageReviewedFiles()
+
+    expect(sendRequest.mock.calls).toEqual([
+      ['git.bulkStage', { worktree: 'id:wt-1', filePaths: ['src/a.ts', 'src/b.ts'] }],
+      ['git.stage', { worktree: 'id:wt-1', filePath: 'src/a.ts' }],
+      ['git.stage', { worktree: 'id:wt-1', filePath: 'src/b.ts' }]
+    ])
+    expect(setActionError).toHaveBeenLastCalledWith('1 staged, 1 failed')
+    expect(haptics.triggerSuccess).toHaveBeenCalledTimes(1)
+    expect(haptics.triggerError).not.toHaveBeenCalled()
+    expect(loadReviewData).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches an old host only for the current connection generation', async () => {
+    queue = [reviewedFile('src/a.ts')]
+    let bulkSupported = false
+    const sendRequest = vi.fn(async (method: string) => {
+      if (method === 'git.bulkStage' && !bulkSupported) {
+        return failure('method_not_found', 'legacy desktop')
+      }
+      return success()
+    })
+    const generationClient = createGenerationClient(sendRequest)
+    client = generationClient.client
+    await mount()
+
+    await stageReviewedFiles()
+    sendRequest.mockClear()
+    await stageReviewedFiles()
+    expect(sendRequest.mock.calls.map(([method]) => method)).toEqual(['git.stage'])
+
+    bulkSupported = true
+    generationClient.advanceConnection()
+    sendRequest.mockClear()
+    await stageReviewedFiles()
+    expect(sendRequest.mock.calls.map(([method]) => method)).toEqual(['git.bulkStage'])
+  })
+
+  it('does not cache a stale method_not_found response for a new generation', async () => {
+    queue = [reviewedFile('src/a.ts')]
+    let resolveBulk!: (response: RpcResponse) => void
+    let firstBulk = true
+    const sendRequest = vi.fn((method: string) => {
+      if (method === 'git.bulkStage' && firstBulk) {
+        firstBulk = false
+        return new Promise<RpcResponse>((resolve) => {
+          resolveBulk = resolve
+        })
+      }
+      return Promise.resolve(success())
+    })
+    const generationClient = createGenerationClient(sendRequest)
+    client = generationClient.client
+    await mount()
+
+    let pending: Promise<void> | undefined
+    await act(async () => {
+      pending = actions?.stageReviewedFiles()
+      await Promise.resolve()
+    })
+    generationClient.advanceConnection()
+    resolveBulk(failure('method_not_found', 'legacy desktop'))
+    await act(async () => {
+      await pending
+    })
+
+    sendRequest.mockClear()
+    await stageReviewedFiles()
+    expect(sendRequest.mock.calls.map(([method]) => method)).toEqual(['git.bulkStage'])
+  })
+
+  it('does not let an old client capability result poison its replacement', async () => {
+    queue = [reviewedFile('src/a.ts')]
+    const oldSendRequest = vi.fn(async (method: string) =>
+      method === 'git.bulkStage' ? failure('method_not_found', 'legacy desktop') : success()
+    )
+    client = createGenerationClient(oldSendRequest).client
+    await mount()
+    await stageReviewedFiles()
+
+    const replacementSendRequest = vi.fn().mockResolvedValue(success())
+    client = createGenerationClient(replacementSendRequest).client
+    await rerender()
+    await stageReviewedFiles()
+
+    expect(replacementSendRequest).toHaveBeenCalledTimes(1)
+    expect(replacementSendRequest).toHaveBeenCalledWith('git.bulkStage', {
+      worktree: 'id:wt-1',
+      filePaths: ['src/a.ts']
+    })
+  })
+
+  it.each(['forbidden', 'runtime_error'])(
+    'refreshes after a %s bulk failure without per-file fanout',
+    async (code) => {
+      queue = [reviewedFile('src/a.ts'), reviewedFile('src/b.ts')]
+      const sendRequest = vi.fn().mockResolvedValue(failure(code, 'Unknown method: git.bulkStage'))
+      client = createGenerationClient(sendRequest).client
+      await mount()
+
+      await stageReviewedFiles()
+
+      expect(sendRequest).toHaveBeenCalledTimes(1)
+      expect(sendRequest).toHaveBeenCalledWith('git.bulkStage', {
+        worktree: 'id:wt-1',
+        filePaths: ['src/a.ts', 'src/b.ts']
+      })
+      expect(setActionError).toHaveBeenLastCalledWith('Unknown method: git.bulkStage')
+      expect(setBusyAction).toHaveBeenLastCalledWith(null)
+      expect(haptics.triggerError).toHaveBeenCalledTimes(1)
+      expect(haptics.triggerSuccess).not.toHaveBeenCalled()
+      expect(loadReviewData).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('refreshes after a rejected bulk request without retrying individual files', async () => {
+    queue = [reviewedFile('src/a.ts'), reviewedFile('src/b.ts')]
+    const sendRequest = vi.fn().mockRejectedValue(new Error('delivery unknown'))
+    client = createGenerationClient(sendRequest).client
+    await mount()
+
+    await stageReviewedFiles()
+
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(setActionError).toHaveBeenLastCalledWith('delivery unknown')
+    expect(setBusyAction).toHaveBeenLastCalledWith(null)
+    expect(haptics.triggerError).toHaveBeenCalledTimes(1)
+    expect(loadReviewData).toHaveBeenCalledTimes(1)
+  })
+})

--- a/mobile/src/session/use-mobile-diff-review-git-actions.ts
+++ b/mobile/src/session/use-mobile-diff-review-git-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback, type Dispatch, type SetStateAction } from 'react'
+import { useCallback, useRef, type Dispatch, type SetStateAction } from 'react'
 import type { ConnectionState } from '../transport/types'
 import type { RpcClient } from '../transport/rpc-client'
 import { triggerError, triggerSuccess } from '../platform/haptics'
@@ -16,9 +16,63 @@ type GitActionsInput = {
   loadReviewData: () => Promise<void>
 }
 
+type BulkStageGenerationClient = RpcClient & {
+  getGeneration?: () => number
+}
+
+type StageReviewedResult = { staged: number; failed: number }
+
+// Why: reconnecting can replace an upgraded host behind the same logical client.
+const unsupportedBulkStageGeneration = new WeakMap<RpcClient, string>()
+
+function readBulkStageGeneration(client: RpcClient): string {
+  const generationClient = client as BulkStageGenerationClient
+  return `${generationClient.getGeneration?.() ?? 0}:${generationClient.getLastConnectedAt() ?? 0}`
+}
+
+async function stageReviewedFilePaths(
+  client: RpcClient,
+  worktreeId: string,
+  filePaths: readonly string[]
+): Promise<StageReviewedResult> {
+  const generation = readBulkStageGeneration(client)
+  if (unsupportedBulkStageGeneration.get(client) !== generation) {
+    const response = await client.sendRequest('git.bulkStage', {
+      worktree: `id:${worktreeId}`,
+      filePaths
+    })
+    if (response.ok) {
+      return { staged: filePaths.length, failed: 0 }
+    }
+    // Why: any other failure may follow a partial bulk mutation, so status must be refreshed.
+    if (response.error.code !== 'method_not_found') {
+      throw new Error(response.error.message || 'Source control action failed')
+    }
+    if (readBulkStageGeneration(client) === generation) {
+      unsupportedBulkStageGeneration.set(client, generation)
+    }
+  }
+
+  let staged = 0
+  let failed = 0
+  for (const filePath of filePaths) {
+    const response = await client.sendRequest('git.stage', {
+      worktree: `id:${worktreeId}`,
+      filePath
+    })
+    if (response.ok) {
+      staged += 1
+    } else {
+      failed += 1
+    }
+  }
+  return { staged, failed }
+}
+
 export function useMobileDiffReviewGitActions(input: GitActionsInput) {
   const { client, connState, worktreeId, queue, setActionError, setBusyAction, loadReviewData } =
     input
+  const stageReviewedInFlightRef = useRef(false)
 
   const runGitMutation = useCallback(
     async (method: GitMutationMethod, item: MobileDiffReviewQueueItem) => {
@@ -49,6 +103,9 @@ export function useMobileDiffReviewGitActions(input: GitActionsInput) {
   )
 
   const stageReviewedFiles = useCallback(async () => {
+    if (stageReviewedInFlightRef.current) {
+      return
+    }
     if (!client || connState !== 'connected') {
       setActionError('Waiting for desktop...')
       return
@@ -59,29 +116,32 @@ export function useMobileDiffReviewGitActions(input: GitActionsInput) {
     if (files.length === 0) {
       return
     }
+    stageReviewedInFlightRef.current = true
     setBusyAction('stage-reviewed')
     setActionError(null)
-    let staged = 0
-    let failed = 0
-    for (const item of files) {
-      const response = await client.sendRequest('git.stage', {
-        worktree: `id:${worktreeId}`,
-        filePath: item.filePath
-      })
-      if (response.ok) {
-        staged += 1
-      } else {
-        failed += 1
+    try {
+      const { staged, failed } = await stageReviewedFilePaths(
+        client,
+        worktreeId,
+        files.map((item) => item.filePath)
+      )
+      triggerSuccess()
+      setActionError(
+        failed > 0
+          ? `${staged} staged, ${failed} failed`
+          : `${mobileReviewCountLabel(staged, 'reviewed file', 'reviewed files')} staged`
+      )
+    } catch (err) {
+      triggerError()
+      setActionError(err instanceof Error ? err.message : 'Source control action failed')
+    } finally {
+      try {
+        await loadReviewData()
+      } finally {
+        stageReviewedInFlightRef.current = false
+        setBusyAction(null)
       }
     }
-    setBusyAction(null)
-    triggerSuccess()
-    setActionError(
-      failed > 0
-        ? `${staged} staged, ${failed} failed`
-        : `${mobileReviewCountLabel(staged, 'reviewed file', 'reviewed files')} staged`
-    )
-    await loadReviewData()
   }, [client, connState, loadReviewData, queue, setActionError, setBusyAction, worktreeId])
 
   return { runGitMutation, stageReviewedFiles }

--- a/src/main/providers/ssh-git-provider-staging.test.ts
+++ b/src/main/providers/ssh-git-provider-staging.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it, beforeEach } from 'vitest'
+import { JsonRpcErrorCode } from '../ssh/relay-protocol'
 import { SshGitProvider } from './ssh-git-provider'
-import { createMockMux, type MockMultiplexer } from './ssh-git-provider-test-harness'
+import {
+  createMockMux,
+  waitForRequestCount,
+  type MockMultiplexer
+} from './ssh-git-provider-test-harness'
+
+function methodNotFoundError(): Error & { code: number } {
+  return Object.assign(new Error('Method not found: git.bulkStage'), {
+    code: JsonRpcErrorCode.MethodNotFound
+  })
+}
 
 describe('SshGitProvider', () => {
   let mux: MockMultiplexer
@@ -46,6 +57,77 @@ describe('SshGitProvider', () => {
       worktreePath: '/home/user/repo',
       filePaths: ['a.ts', 'b.ts']
     })
+  })
+
+  it('falls back sequentially on an old relay and caches that connection capability', async () => {
+    mux.request.mockImplementation(async (method: string) => {
+      if (method === 'git.bulkStage') {
+        throw methodNotFoundError()
+      }
+    })
+
+    await provider.bulkStageFiles('/home/user/repo', ['a.ts', 'b.ts'])
+    await provider.bulkStageFiles('/home/user/repo', ['c.ts'])
+
+    expect(mux.request.mock.calls).toEqual([
+      ['git.bulkStage', { worktreePath: '/home/user/repo', filePaths: ['a.ts', 'b.ts'] }],
+      ['git.stage', { worktreePath: '/home/user/repo', filePath: 'a.ts' }],
+      ['git.stage', { worktreePath: '/home/user/repo', filePath: 'b.ts' }],
+      ['git.stage', { worktreePath: '/home/user/repo', filePath: 'c.ts' }]
+    ])
+  })
+
+  it('does not fall back after a generic bulk-stage failure', async () => {
+    const failure = Object.assign(new Error('relay failed'), { code: -32_000 })
+    mux.request.mockRejectedValue(failure)
+
+    await expect(provider.bulkStageFiles('/home/user/repo', ['a.ts', 'b.ts'])).rejects.toBe(failure)
+
+    expect(mux.request).toHaveBeenCalledTimes(1)
+    expect(mux.request).toHaveBeenCalledWith('git.bulkStage', {
+      worktreePath: '/home/user/repo',
+      filePaths: ['a.ts', 'b.ts']
+    })
+  })
+
+  it('re-probes bulk staging after the SSH provider is replaced', async () => {
+    mux.request.mockRejectedValueOnce(methodNotFoundError())
+    await provider.bulkStageFiles('/home/user/repo', ['a.ts'])
+
+    mux.request.mockReset().mockResolvedValue(undefined)
+    provider = new SshGitProvider('conn-2', mux as never)
+    await provider.bulkStageFiles('/home/user/repo', ['b.ts'])
+
+    expect(mux.request).toHaveBeenCalledTimes(1)
+    expect(mux.request).toHaveBeenCalledWith('git.bulkStage', {
+      worktreePath: '/home/user/repo',
+      filePaths: ['b.ts']
+    })
+  })
+
+  it('shares an old-relay capability probe across concurrent bulk-stage calls', async () => {
+    let rejectBulk!: (error: Error) => void
+    mux.request.mockImplementation((method: string) => {
+      if (method !== 'git.bulkStage') {
+        return Promise.resolve(undefined)
+      }
+      return new Promise((_, reject) => {
+        rejectBulk = reject
+      })
+    })
+
+    const first = provider.bulkStageFiles('/home/user/repo', ['a.ts'])
+    const second = provider.bulkStageFiles('/home/user/repo', ['b.ts'])
+    await waitForRequestCount(mux.request, 1)
+    expect(mux.request).toHaveBeenCalledTimes(1)
+
+    rejectBulk(methodNotFoundError())
+    await Promise.all([first, second])
+    expect(mux.request.mock.calls).toEqual([
+      ['git.bulkStage', { worktreePath: '/home/user/repo', filePaths: ['a.ts'] }],
+      ['git.stage', { worktreePath: '/home/user/repo', filePath: 'a.ts' }],
+      ['git.stage', { worktreePath: '/home/user/repo', filePath: 'b.ts' }]
+    ])
   })
 
   it('bulkUnstageFiles sends git.bulkUnstage request', async () => {

--- a/src/main/providers/ssh-git-working-tree-provider.ts
+++ b/src/main/providers/ssh-git-working-tree-provider.ts
@@ -4,9 +4,18 @@ import type {
 } from '../../shared/git-diff-compare-types'
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
 import type { GitConflictOperation } from '../../shared/git-status-types'
+import { CapabilityProbeCache } from '../../shared/capability-probe-cache'
 import { SshGitNoninteractiveProvider } from './ssh-git-noninteractive-provider'
+import { isJsonRpcMethodNotFoundError } from './ssh-git-relay-errors'
+
+type SshGitRelayCapability = 'bulk-stage'
 
 export class SshGitWorkingTreeProvider extends SshGitNoninteractiveProvider {
+  // Why: reconnecting constructs a new provider, which is the relay capability boundary.
+  private readonly relayCapabilities = new CapabilityProbeCache<SshGitRelayCapability>(
+    Number.POSITIVE_INFINITY
+  )
+
   async checkIgnoredPaths(worktreePath: string, relativePaths: string[]): Promise<string[]> {
     return (await this.mux.request('git.checkIgnored', {
       worktreePath,
@@ -51,7 +60,18 @@ export class SshGitWorkingTreeProvider extends SshGitNoninteractiveProvider {
 
   async bulkStageFiles(worktreePath: string, filePaths: string[]): Promise<void> {
     await this.runWithGitReadInvalidation(async () => {
-      await this.mux.request('git.bulkStage', { worktreePath, filePaths })
+      await this.relayCapabilities.runWithFallback(
+        'bulk-stage',
+        async () => {
+          await this.mux.request('git.bulkStage', { worktreePath, filePaths })
+        },
+        async () => {
+          for (const filePath of filePaths) {
+            await this.mux.request('git.stage', { worktreePath, filePath })
+          }
+        },
+        isJsonRpcMethodNotFoundError
+      )
     })
   }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​399 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​398 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​80 |

<!-- /orca-pr-loc -->

## ELI5

`Stage Reviewed Files` used to ask the desktop to stage every reviewed file one at a time. This sends the reviewed file list once and lets Orca's existing bulk staging path do the work in one bounded operation.

## What changed

- Mobile filters to reviewed, unstaged, stageable files and sends one `git.bulkStage` mutation.
- Duplicate submissions are blocked both in the hook and by disabling the drawer action while a mutation or authoritative refresh is active.
- An older desktop falls back to sequential `git.stage` calls only after the exact `method_not_found` response. Unsupported capability state is scoped to the client and current logical/physical connection identity, so replacement connections probe again.
- An older SSH relay falls back at the SSH provider boundary only after exact JSON-RPC `-32601`. The provider caches that result for its connection and deduplicates concurrent capability probes.
- Generic, rejected, or otherwise ambiguous bulk failures never fan out into per-file mutations because the bulk call may have partially applied. Mobile reports the failure and refreshes authoritative review status.

## Measurement

For 100 reviewed files on a current host:

| Work | Before | After |
| --- | ---: | ---: |
| Mobile mutation RPCs | 100 | 1 |
| Target resolutions | 100 | 1 |
| Git invocations for realistic native paths | 100 | 1 |
| SSH relay mutation calls on a current relay | 100 | 1 |

An old relay pays one exact unsupported probe, then retains the existing sequential staging behavior for compatibility; later calls skip the unsupported bulk probe for that SSH connection.

## Compatibility signoff

- No new RPC method, stream opcode, or wire payload shape; this reuses the existing optional `git.bulkStage` method.
- Folder workspaces retain `id:<worktreeId>` routing and do not assume a Git worktree.
- SSH execution remains host-owned, with no local process or filesystem substitution.
- Existing Windows/WSL command-line chunking remains in the host bulk implementation.
- Git 2.25 compatibility is unchanged; no Git command or option was added.
- Review behavior remains provider-neutral for GitHub, GitLab, and other supported providers.
- Merge risk: **medium**. The change is narrow but touches a mobile mutation path and mixed-version SSH fallback behavior.

## Validation

- [x] New mobile hook suite: 9/9
- [x] SSH provider staging suite: 11/11
- [x] Focused host/allowlist/SSH/command-budget suite: 40/40
- [x] Full mobile suite: 480 files; 3,872 passed; 3 skipped
- [x] Mobile typecheck
- [x] Node typecheck
- [x] Changed-code quality: 0 findings across 5 files
- [x] Formatting and `git diff --check`

Electron CDP validation is not applicable because the rendered behavior changed only in the React Native mobile surface.
