### PR TITLE
perf(editor): skip unchanged review-note reflows

### DIFF
--- a/src/renderer/src/components/diff-comments/DiffCommentCard.resize.test.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.resize.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { act, cleanup, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DiffCommentCard } from './DiffCommentCard'
 
@@ -44,6 +44,7 @@ describe('DiffCommentCard content resize', () => {
 
   afterEach(() => {
     cleanup()
+    vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
 
@@ -100,5 +101,53 @@ describe('DiffCommentCard content resize', () => {
 
     expect(constructObserver).not.toHaveBeenCalled()
     expect(onContentResize).not.toHaveBeenCalled()
+  })
+
+  it('requests rail reflow only when the editing textarea height changes', () => {
+    const onContentResize = vi.fn()
+    let scrollHeight = 60
+    vi.spyOn(HTMLTextAreaElement.prototype, 'scrollHeight', 'get').mockImplementation(
+      () => scrollHeight
+    )
+    const view = render(
+      <DiffCommentCard
+        lineNumber={26}
+        body="A saved note"
+        onContentResize={onContentResize}
+        onSubmitEdit={async () => true}
+      />
+    )
+
+    fireEvent.click(view.getByRole('button', { name: 'Edit note' }))
+    expect(onContentResize).toHaveBeenCalledOnce()
+
+    const textarea = view.getByRole('textbox')
+    expect(textarea.style.height).toBe('60px')
+    fireEvent.change(textarea, { target: { value: 'A saved note!' } })
+    expect(onContentResize).toHaveBeenCalledOnce()
+
+    for (let index = 0; index < 50; index++) {
+      fireEvent.change(textarea, { target: { value: `A saved note! ${index}` } })
+    }
+    expect(textarea.style.height).toBe('60px')
+    expect(onContentResize).toHaveBeenCalledOnce()
+
+    scrollHeight = 400
+    fireEvent.change(textarea, { target: { value: 'A much taller saved note' } })
+    expect(textarea.style.height).toBe('240px')
+    expect(onContentResize).toHaveBeenCalledTimes(2)
+
+    scrollHeight = 480
+    fireEvent.change(textarea, { target: { value: 'A still taller saved note' } })
+    expect(textarea.style.height).toBe('240px')
+    expect(onContentResize).toHaveBeenCalledTimes(2)
+
+    scrollHeight = 80
+    fireEvent.change(textarea, { target: { value: 'A shorter saved note' } })
+    expect(textarea.style.height).toBe('80px')
+    expect(onContentResize).toHaveBeenCalledTimes(3)
+
+    fireEvent.click(view.getByRole('button', { name: 'Cancel' }))
+    expect(onContentResize).toHaveBeenCalledTimes(4)
   })
 })

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -35,6 +35,13 @@ type Props = {
   headerActions?: ReactNode
 }
 
+function resizeDiffCommentTextarea(textarea: HTMLTextAreaElement): boolean {
+  const previousHeight = textarea.style.height
+  textarea.style.height = 'auto'
+  textarea.style.height = `${Math.min(textarea.scrollHeight, 240)}px`
+  return textarea.style.height !== previousHeight
+}
+
 export function DiffCommentCard({
   lineNumber,
   startLine,
@@ -116,8 +123,7 @@ export function DiffCommentCard({
     if (!el) {
       return
     }
-    el.style.height = 'auto'
-    el.style.height = `${Math.min(el.scrollHeight, 240)}px`
+    resizeDiffCommentTextarea(el)
     el.focus()
     el.setSelectionRange(el.value.length, el.value.length)
     onContentResizeRef.current?.()
@@ -281,10 +287,10 @@ export function DiffCommentCard({
               value={draft}
               onChange={(e) => {
                 setDraft(e.target.value)
-                const el = e.currentTarget
-                el.style.height = 'auto'
-                el.style.height = `${Math.min(el.scrollHeight, 240)}px`
-                onContentResizeRef.current?.()
+                // Why: rich-review layout measures every note; skip it when this card stayed put.
+                if (resizeDiffCommentTextarea(e.currentTarget)) {
+                  onContentResizeRef.current?.()
+                }
               }}
               onKeyDown={(e) => {
                 if (e.key === 'Escape') {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​50 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## Summary

- keep auto-growing the review-note textarea on every edit
- notify parent geometry consumers only when the textarea's clamped inline height actually changes
- cover stable-height input, the existing 240 px cap, shrink, and close reflow behavior

Fixes #16400

## ELI5

Each keypress still asks the textarea how tall it needs to be. Before this change, it also rang a bell saying “the card moved” even when the answer was the same height as before. In the rich Markdown review rail, that bell makes Orca rebuild note anchors and measure every rendered note. Now the bell rings only when the card can actually have moved.

## Measurement proof

Deterministic red/green regression harness:

- before: after one real height change, 50 same-height edits raised the callback total from `2` to `52` (expected `2`)
- after: same-height edits add `0` callbacks; the tightened final test also proves real growth, repeated input above the existing 240 px cap, shrink, and close notifications

Rendered Electron proof on this branch with 24 seeded Markdown review notes (19 had renderable anchors in the viewport document):

- 50 edits that stayed at `73px`: `0` downstream `getBoundingClientRect()` calls, `0` note-position changes, textarea focus retained
- real growth from `73px` to `240px`: the rail still ran its geometry pass (`19` note-card reads plus the container read), and the next stacked note moved by exactly `167px`
- both edited note bodies saved and rendered visibly; console errors: `0`

This does not claim to remove the textarea's own required style writes or `scrollHeight` read. It removes the expensive downstream parent notification when final card geometry is unchanged.

## Regression proof

- `pnpm test src/renderer/src/components/diff-comments` — 5 files, 22 tests passed
- rich Markdown review layout/range/annotation suites — 3 files, 17 tests passed
- `pnpm tc:web`
- `pnpm run check:code-quality:changed` — 0 findings in all three scans
- `pnpm exec oxfmt --check ...` — 2 files formatted
- `git diff --check`
- isolated Electron/CDP validation described above, including save and actual downstream reflow

## No-user-regression signoff

- [x] no review feature is disabled, delayed, debounced, or capped
- [x] no note-count or content limit is added
- [x] textarea auto-grow still runs on every edit
- [x] opening, real growth, capped-height shrink, save/cancel close, and rendered-size observation still trigger geometry updates
- [x] saving edited note content still works in the rendered app

## Compatibility

Renderer-only DOM behavior: no IPC/RPC, remote wire, Git command, process, filesystem, or persistence changes. Local, folder-workspace, git-worktree, WSL, and SSH flows use the same renderer behavior. The height comparison is platform-independent and retains the existing 240 px clamp.

## Merge risk

**Low.** `DiffCommentCard` is shared by rich Markdown and Monaco review cards, but its `onContentResize` consumers are geometry updates. Actual geometry changes still notify, and Monaco's existing `ResizeObserver` path is untouched. The focused unit test and real rich-rail Electron measurement cover the optimized and retained paths.
