### PR TITLE
perf(ssh): cache legacy worktree clean fallback

### DIFF
--- a/src/main/providers/ssh-git-provider-worktree.test.ts
+++ b/src/main/providers/ssh-git-provider-worktree.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { SshGitProvider } from './ssh-git-provider'
-import { createMockMux, type MockMultiplexer } from './ssh-git-provider-test-harness'
+import {
+  createMockMux,
+  waitForRequestCount,
+  type MockMultiplexer
+} from './ssh-git-provider-test-harness'
+
+function methodNotFound(method: string): Error & { code: number } {
+  return Object.assign(new Error(`Method not found: ${method}`), { code: -32601 })
+}
+
+const CLEAN_STATUS = { entries: [], conflictOperation: 'unknown' }
 
 describe('SshGitProvider', () => {
   let mux: MockMultiplexer
@@ -67,6 +77,40 @@ describe('SshGitProvider', () => {
     expect(result).toEqual(cleanResult)
   })
 
+  it('keeps supported clean checks on the preferred relay RPC', async () => {
+    let resolveProbe!: (result: { clean: boolean }) => void
+    let resolveRemaining!: (result: { clean: boolean }) => void
+    const probe = new Promise<{ clean: boolean }>((resolve) => {
+      resolveProbe = resolve
+    })
+    const remaining = new Promise<{ clean: boolean }>((resolve) => {
+      resolveRemaining = resolve
+    })
+    let preferredRequestCount = 0
+    mux.request.mockImplementation((method) => {
+      expect(method).toBe('git.worktreeIsClean')
+      preferredRequestCount += 1
+      return preferredRequestCount === 1 ? probe : remaining
+    })
+    const checks = Array.from({ length: 10 }, (_, index) =>
+      provider.worktreeIsClean(`/repo/worktree-${index}`)
+    )
+
+    await waitForRequestCount(mux.request, 1)
+    expect(mux.request).toHaveBeenCalledOnce()
+    resolveProbe({ clean: true })
+    await waitForRequestCount(mux.request, 10)
+    expect(mux.request).toHaveBeenCalledTimes(10)
+    resolveRemaining({ clean: true })
+    await expect(Promise.all(checks)).resolves.toEqual(
+      Array.from({ length: 10 }, () => ({ clean: true }))
+    )
+    expect(
+      mux.request.mock.calls.filter(([method]) => method === 'git.worktreeIsClean')
+    ).toHaveLength(10)
+    expect(mux.request.mock.calls.some(([method]) => method === 'git.status')).toBe(false)
+  })
+
   it('worktreeIsClean can ignore untracked files', async () => {
     const cleanResult = { clean: true }
     mux.request.mockResolvedValue(cleanResult)
@@ -113,10 +157,7 @@ describe('SshGitProvider', () => {
   })
 
   it('worktreeIsClean falls back to git.status for old relays', async () => {
-    const methodNotFound = Object.assign(new Error('Method not found: git.worktreeIsClean'), {
-      code: -32601
-    })
-    mux.request.mockRejectedValueOnce(methodNotFound).mockResolvedValueOnce({
+    mux.request.mockRejectedValueOnce(methodNotFound('git.worktreeIsClean')).mockResolvedValueOnce({
       entries: [{ path: 'scratch.txt', status: 'untracked', area: 'untracked' }],
       conflictOperation: 'unknown'
     })
@@ -140,26 +181,180 @@ describe('SshGitProvider', () => {
     }
   })
 
-  it('worktreeIsClean filters untracked entries in old-relay fallback', async () => {
-    const methodNotFound = Object.assign(new Error('Method not found: git.worktreeIsClean'), {
-      code: -32601
+  it('probes an old relay once across sequential clean checks', async () => {
+    mux.request.mockImplementation(async (method) => {
+      if (method === 'git.worktreeIsClean') {
+        throw methodNotFound(method)
+      }
+      return CLEAN_STATUS
     })
-    mux.request.mockRejectedValueOnce(methodNotFound).mockResolvedValueOnce({
-      entries: [{ path: 'scratch.txt', status: 'untracked', area: 'untracked' }],
-      conflictOperation: 'unknown'
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const worktreePaths = Array.from({ length: 10 }, (_, index) => `/repo/worktree-${index}`)
+
+    try {
+      for (const worktreePath of worktreePaths) {
+        await expect(provider.worktreeIsClean(worktreePath)).resolves.toEqual({ clean: true })
+      }
+
+      expect(
+        mux.request.mock.calls.filter(([method]) => method === 'git.worktreeIsClean')
+      ).toHaveLength(1)
+      expect(mux.request.mock.calls.filter(([method]) => method === 'git.status')).toHaveLength(10)
+      expect(mux.request).toHaveBeenCalledTimes(11)
+      expect(warnSpy).toHaveBeenCalledOnce()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('shares one old-relay probe across concurrent clean checks', async () => {
+    let rejectProbe!: (error: Error) => void
+    const probe = new Promise((_resolve, reject) => {
+      rejectProbe = reject
+    })
+    mux.request.mockImplementation((method) => {
+      if (method === 'git.worktreeIsClean') {
+        return probe
+      }
+      return Promise.resolve(CLEAN_STATUS)
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const checks = Array.from({ length: 10 }, (_, index) =>
+      provider.worktreeIsClean(`/repo/worktree-${index}`)
+    )
+
+    try {
+      await waitForRequestCount(mux.request, 1)
+      rejectProbe(methodNotFound('git.worktreeIsClean'))
+      await expect(Promise.all(checks)).resolves.toEqual(
+        Array.from({ length: 10 }, () => ({ clean: true }))
+      )
+
+      expect(
+        mux.request.mock.calls.filter(([method]) => method === 'git.worktreeIsClean')
+      ).toHaveLength(1)
+      expect(mux.request.mock.calls.filter(([method]) => method === 'git.status')).toHaveLength(10)
+      expect(mux.request).toHaveBeenCalledTimes(11)
+      expect(warnSpy).toHaveBeenCalledOnce()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('retries the preferred clean RPC after a transport failure', async () => {
+    const transportError = Object.assign(new Error('Method not found: git.worktreeIsClean'), {
+      code: -32602
+    })
+    mux.request.mockRejectedValueOnce(transportError).mockResolvedValueOnce({ clean: true })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      await expect(provider.worktreeIsClean('/repo/first')).rejects.toBe(transportError)
+      await expect(provider.worktreeIsClean('/repo/second')).resolves.toEqual({ clean: true })
+      expect(mux.request.mock.calls.map(([method]) => method)).toEqual([
+        'git.worktreeIsClean',
+        'git.worktreeIsClean'
+      ])
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('lets concurrent waiters retry after a transient probe failure', async () => {
+    const transportError = new Error('connection closed')
+    let rejectProbe!: (error: Error) => void
+    let resolveRetries!: (result: { clean: boolean }) => void
+    const probe = new Promise((_resolve, reject) => {
+      rejectProbe = reject
+    })
+    const retries = new Promise<{ clean: boolean }>((resolve) => {
+      resolveRetries = resolve
+    })
+    let preferredRequestCount = 0
+    mux.request.mockImplementation((method) => {
+      expect(method).toBe('git.worktreeIsClean')
+      preferredRequestCount += 1
+      return preferredRequestCount === 1 ? probe : retries
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const checks = Array.from({ length: 3 }, (_, index) =>
+      provider.worktreeIsClean(`/repo/worktree-${index}`)
+    )
+    const settledChecks = Promise.allSettled(checks)
+
+    try {
+      await waitForRequestCount(mux.request, 1)
+      rejectProbe(transportError)
+      await waitForRequestCount(mux.request, 3)
+      resolveRetries({ clean: true })
+
+      const results = await settledChecks
+      expect(results[0]).toEqual({ status: 'rejected', reason: transportError })
+      expect(results.slice(1)).toEqual([
+        { status: 'fulfilled', value: { clean: true } },
+        { status: 'fulfilled', value: { clean: true } }
+      ])
+      await expect(provider.worktreeIsClean('/repo/later')).resolves.toEqual({ clean: true })
+      expect(mux.request).toHaveBeenCalledTimes(4)
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('re-probes clean support after the provider is replaced', async () => {
+    mux.request.mockImplementation(async (method) => {
+      if (method === 'git.worktreeIsClean') {
+        throw methodNotFound(method)
+      }
+      return CLEAN_STATUS
     })
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     try {
+      await expect(provider.worktreeIsClean('/repo/first')).resolves.toEqual({ clean: true })
+      const replacement = new SshGitProvider('conn-1', mux as never)
+      await expect(replacement.worktreeIsClean('/repo/second')).resolves.toEqual({ clean: true })
+
+      expect(
+        mux.request.mock.calls.filter(([method]) => method === 'git.worktreeIsClean')
+      ).toHaveLength(2)
+      expect(warnSpy).toHaveBeenCalledTimes(2)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('worktreeIsClean filters untracked entries in old-relay fallback', async () => {
+    mux.request.mockImplementation(async (method) => {
+      if (method === 'git.worktreeIsClean') {
+        throw methodNotFound(method)
+      }
+      return {
+        entries: [{ path: 'scratch.txt', status: 'untracked', area: 'untracked' }],
+        conflictOperation: 'unknown'
+      }
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      await expect(provider.worktreeIsClean('/home/user/feat')).resolves.toEqual({
+        clean: false,
+        stdout: 'untracked untracked: scratch.txt'
+      })
       await expect(
         provider.worktreeIsClean('/home/user/feat', { includeUntracked: false })
       ).resolves.toEqual({ clean: true })
       expect(mux.request).toHaveBeenNthCalledWith(
-        2,
+        3,
         'git.status',
         { worktreePath: '/home/user/feat' },
         { signal: expect.any(AbortSignal) }
       )
+      expect(
+        mux.request.mock.calls.filter(([method]) => method === 'git.worktreeIsClean')
+      ).toHaveLength(1)
     } finally {
       warnSpy.mockRestore()
     }
@@ -183,11 +378,7 @@ describe('SshGitProvider', () => {
   })
 
   it('forceDeletePreservedBranch maps old relays to the reconnect message', async () => {
-    const methodNotFound = Object.assign(
-      new Error('Method not found: git.forceDeletePreservedBranch'),
-      { code: -32601 }
-    )
-    mux.request.mockRejectedValueOnce(methodNotFound)
+    mux.request.mockRejectedValueOnce(methodNotFound('git.forceDeletePreservedBranch'))
 
     await expect(
       provider.forceDeletePreservedBranch('/home/user/repo', 'you/fix-auth', 'abc123')

--- a/src/main/providers/ssh-git-worktree-provider.ts
+++ b/src/main/providers/ssh-git-worktree-provider.ts
@@ -1,8 +1,11 @@
 import type { GitStatusResult } from '../../shared/git-status-types'
 import type { RemoveWorktreeResult } from '../../shared/worktree/create-types'
 import type { GitWorktreeInfo } from '../../shared/worktree/types'
+import { CapabilityProbeCache } from '../../shared/capability-probe-cache'
 import { isJsonRpcMethodNotFoundError } from './ssh-git-relay-errors'
 import { SshGitReviewHeadProvider } from './ssh-git-review-head-provider'
+
+const WORKTREE_IS_CLEAN_CAPABILITY = 'git.worktreeIsClean' as const
 
 function formatStatusEntriesForCleanCheck(entries: GitStatusResult['entries']): string | undefined {
   if (entries.length === 0) {
@@ -20,6 +23,10 @@ function filterUntrackedPorcelainStatus(stdout: string | undefined): string | un
 
 export class SshGitWorktreeProvider extends SshGitReviewHeadProvider {
   private loggedWorktreeIsCleanFallback = false
+  // Why: reconnect replaces this provider, so an upgraded relay is naturally re-probed.
+  private readonly worktreeIsCleanCapabilityCache = new CapabilityProbeCache<
+    typeof WORKTREE_IS_CLEAN_CAPABILITY
+  >(Number.POSITIVE_INFINITY)
 
   async listWorktrees(
     repoPath: string,
@@ -67,37 +74,39 @@ export class SshGitWorktreeProvider extends SshGitReviewHeadProvider {
     worktreePath: string,
     options: { includeUntracked?: boolean } = {}
   ): Promise<{ clean: boolean; stdout?: string }> {
-    try {
-      const result = (await this.mux.request('git.worktreeIsClean', {
-        worktreePath,
-        ...(options.includeUntracked === false ? { includeUntracked: false } : {})
-      })) as { clean: boolean; stdout?: string }
-      if (options.includeUntracked === false) {
-        if (!result.clean && result.stdout === undefined) {
-          return result
+    return this.worktreeIsCleanCapabilityCache.runWithFallback(
+      WORKTREE_IS_CLEAN_CAPABILITY,
+      async () => {
+        const result = (await this.mux.request('git.worktreeIsClean', {
+          worktreePath,
+          ...(options.includeUntracked === false ? { includeUntracked: false } : {})
+        })) as { clean: boolean; stdout?: string }
+        if (options.includeUntracked === false) {
+          if (!result.clean && result.stdout === undefined) {
+            return result
+          }
+          const trackedStdout = filterUntrackedPorcelainStatus(result.stdout)
+          return { clean: !trackedStdout, ...(trackedStdout ? { stdout: trackedStdout } : {}) }
         }
-        const trackedStdout = filterUntrackedPorcelainStatus(result.stdout)
-        return { clean: !trackedStdout, ...(trackedStdout ? { stdout: trackedStdout } : {}) }
-      }
-      return result
-    } catch (error) {
-      if (!isJsonRpcMethodNotFoundError(error)) {
-        throw error
-      }
-      if (!this.loggedWorktreeIsCleanFallback) {
-        this.loggedWorktreeIsCleanFallback = true
-        console.warn(
-          '[ssh-git] Relay does not implement git.worktreeIsClean; falling back to git.status clean check'
-        )
-      }
-      const status = await this.getStatus(worktreePath)
-      const entries =
-        options.includeUntracked === false
-          ? status.entries.filter((entry) => entry.area !== 'untracked')
-          : status.entries
-      const clean = entries.length === 0
-      return { clean, stdout: formatStatusEntriesForCleanCheck(entries) }
-    }
+        return result
+      },
+      async () => {
+        if (!this.loggedWorktreeIsCleanFallback) {
+          this.loggedWorktreeIsCleanFallback = true
+          console.warn(
+            '[ssh-git] Relay does not implement git.worktreeIsClean; falling back to git.status clean check'
+          )
+        }
+        const status = await this.getStatus(worktreePath)
+        const entries =
+          options.includeUntracked === false
+            ? status.entries.filter((entry) => entry.area !== 'untracked')
+            : status.entries
+        const clean = entries.length === 0
+        return { clean, stdout: formatStatusEntriesForCleanCheck(entries) }
+      },
+      isJsonRpcMethodNotFoundError
+    )
   }
 
   async refreshLocalBaseRefForWorktreeCreate(args: {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​208 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​191 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​30 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

## Summary

- remember an exact `-32601` response for `git.worktreeIsClean` for the lifetime of one SSH Git provider
- share the first capability probe across concurrent callers
- keep running the existing remote `git.status` fallback for every clean check
- naturally re-probe after reconnect, when `ssh-relay-session` creates a replacement provider

## ELI5

An old relay does not know Orca's small “is this worktree clean?” shortcut. Orca used to ask for that shortcut every time, receive “method not found,” and then perform the real status check anyway. This change remembers “that shortcut is absent on this connection,” so later checks go straight to the same authoritative remote status check.

## Measurement proof

The deterministic red harness runs 10 clean checks against an old-relay mock:

- before, sequential: `10` unsupported shortcut RPCs + `10` status RPCs = `20`
- after, sequential: `1` unsupported probe + `10` status RPCs = `11` (**45% fewer**)
- before, concurrent across 10 worktrees: `20` RPCs
- after, concurrent across 10 worktrees: `11` RPCs because callers share the probe
- each later 10-check batch on that connection: `10` status RPCs instead of `20` (**50% fewer**)

The original code failed both red assertions with `10` preferred calls where `1` was expected. The green tests assert the complete `11`-RPC budget. This proof intentionally counts transport work rather than claiming a stable wall-clock result across different SSH networks.

Modern-relay guardrail: a deferred cold-probe test proves only one caller waits on capability discovery, then all nine waiting clean checks launch their own preferred RPC before any of them resolves. No supported result is cached across worktrees.

## Regression proof

- focused worktree-provider suite: 20/20 passed
- provider + shared capability-cache + relay worktree suites: 15 files, 134 tests passed
- `pnpm tc:node`
- `pnpm run check:code-quality:changed` — 0 findings in all three scans
- targeted `oxfmt --check`
- `git diff --check`
- independent review by two audit agents: no actionable correctness findings

Coverage includes sequential and concurrent old relays, current relays, warning once, cached `includeUntracked: false` filtering, provider replacement, numeric non-`-32601` errors, and concurrent transport failures.

## No-user-regression signoff

- [x] no clean check is skipped, delayed by a timer, or capped
- [x] old relays still run remote `git.status` on every call
- [x] current relays still run `git.worktreeIsClean` on every call
- [x] only numeric JSON-RPC `-32601` enables fallback; transport and generic errors still surface
- [x] untracked-file filtering and dirty-output formatting are unchanged
- [x] reconnect/provider replacement forgets the old capability verdict and probes again
- [x] no local fallback can answer for a remote repository

## Compatibility

No wire shape, RPC method, parameter, relay handler, or published content changes. This only changes how a new client reacts after an old relay returns the already-supported structured `-32601` error. The cache is scoped to the provider/relay connection, so mixed versions remain safe and a newly deployed relay is discovered on reconnect.

No Git command changes (Git 2.25 compatibility is unaffected), no process or filesystem changes, and no impact to native, WSL, or non-SSH providers. SSH folder workspaces and SSH git worktrees retain the same execution-host-owned status fallback.

## GitHub pointers checked

No direct issue or open PR covers repeated `git.worktreeIsClean` probing. #14555, #15297, and #10408 are related capability/cache-scoping precedents, but none touch this provider or RPC and this PR does not close them.

## Merge risk

**Low.** The change reuses the existing, tested `CapabilityProbeCache`; the only cached verdict is a structured method-absence response, and the cache dies with the SSH provider. The full fallback body and all returned clean/dirty semantics remain unchanged.
