### PR TITLE
fix(terminal): bound producer pause so a lost renderer ACK cannot wedge a PTY

### DIFF
--- a/src/main/ipc/pty-producer-flow-control.test.ts
+++ b/src/main/ipc/pty-producer-flow-control.test.ts
@@ -218,18 +218,6 @@ describe('PtyProducerFlowController', () => {
       expect(resumeProducer).toHaveBeenCalledWith('pty-2')
     })
 
-    it('reports the exceeded ceiling for diagnostics', () => {
-      const onPauseCeilingExceeded = vi.fn<(id: string, heldMs: number) => void>()
-      const observed = new PtyProducerFlowController(
-        { pauseProducer, resumeProducer },
-        { onPauseCeilingExceeded }
-      )
-      observed.update('pty-1', HIGH + 1)
-      vi.advanceTimersByTime(PRODUCER_PAUSE_MAX_HOLD_MS)
-      expect(onPauseCeilingExceeded).toHaveBeenCalledTimes(1)
-      expect(onPauseCeilingExceeded).toHaveBeenCalledWith('pty-1', PRODUCER_PAUSE_MAX_HOLD_MS)
-    })
-
     it('keeps bookkeeping consistent when the ceiling resume throws', () => {
       resumeProducer.mockImplementation(() => {
         throw new Error('provider gone')

--- a/src/main/ipc/pty-producer-flow-control.test.ts
+++ b/src/main/ipc/pty-producer-flow-control.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   PRODUCER_FLOW_HIGH_WATERMARK_CHARS,
   PRODUCER_FLOW_LOW_WATERMARK_CHARS,
+  PRODUCER_PAUSE_MAX_HOLD_MS,
   PRODUCER_PAUSE_REASSERT_INTERVAL_MS,
   PtyProducerFlowController
 } from './pty-producer-flow-control'
@@ -133,5 +134,109 @@ describe('PtyProducerFlowController', () => {
     expect(resumeProducer).toHaveBeenCalledTimes(1)
     expect(controller.isPaused('pty-1')).toBe(false)
     expect(controller.isPaused('pty-2')).toBe(true)
+  })
+
+  // A provider without its own failsafe (LocalPtyProvider) would otherwise keep
+  // the child blocked on write forever once renderer ACKs stop arriving.
+  describe('pause ceiling', () => {
+    it('resumes a pty held past the ceiling with no further reports', () => {
+      controller.update('pty-1', HIGH + 1)
+      expect(controller.isPaused('pty-1')).toBe(true)
+
+      vi.advanceTimersByTime(PRODUCER_PAUSE_MAX_HOLD_MS - 1)
+      expect(resumeProducer).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(1)
+      expect(resumeProducer).toHaveBeenCalledTimes(1)
+      expect(resumeProducer).toHaveBeenCalledWith('pty-1')
+      expect(controller.isPaused('pty-1')).toBe(false)
+    })
+
+    it('does not extend the ceiling when a re-assert re-pauses the same span', () => {
+      controller.update('pty-1', HIGH + 1)
+      // Re-assert fires at the failsafe interval, before the ceiling.
+      vi.advanceTimersByTime(PRODUCER_PAUSE_REASSERT_INTERVAL_MS)
+      controller.update('pty-1', HIGH * 4)
+      expect(pauseProducer).toHaveBeenCalledTimes(2)
+
+      // The ceiling still expires measured from the original pause.
+      vi.advanceTimersByTime(PRODUCER_PAUSE_MAX_HOLD_MS - PRODUCER_PAUSE_REASSERT_INTERVAL_MS)
+      expect(resumeProducer).toHaveBeenCalledTimes(1)
+      expect(controller.isPaused('pty-1')).toBe(false)
+    })
+
+    it('re-pauses a still-flooded pty after the ceiling released it', () => {
+      controller.update('pty-1', HIGH + 1)
+      vi.advanceTimersByTime(PRODUCER_PAUSE_MAX_HOLD_MS)
+      expect(controller.isPaused('pty-1')).toBe(false)
+
+      controller.update('pty-1', HIGH + 1)
+      expect(pauseProducer).toHaveBeenCalledTimes(2)
+      expect(controller.isPaused('pty-1')).toBe(true)
+    })
+
+    it('does not resume twice when pending drains before the ceiling', () => {
+      controller.update('pty-1', HIGH + 1)
+      controller.update('pty-1', LOW - 1)
+      expect(resumeProducer).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(PRODUCER_PAUSE_MAX_HOLD_MS * 2)
+      expect(resumeProducer).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not resume after release cancelled the ceiling', () => {
+      controller.update('pty-1', HIGH + 1)
+      controller.release('pty-1')
+      expect(resumeProducer).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(PRODUCER_PAUSE_MAX_HOLD_MS * 2)
+      expect(resumeProducer).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not resume after releaseAll cancelled the ceiling', () => {
+      controller.update('pty-1', HIGH + 1)
+      controller.update('pty-2', HIGH + 1)
+      controller.releaseAll()
+      expect(resumeProducer).toHaveBeenCalledTimes(2)
+
+      vi.advanceTimersByTime(PRODUCER_PAUSE_MAX_HOLD_MS * 2)
+      expect(resumeProducer).toHaveBeenCalledTimes(2)
+    })
+
+    it('bounds each pty on its own ceiling', () => {
+      controller.update('pty-1', HIGH + 1)
+      vi.advanceTimersByTime(PRODUCER_PAUSE_MAX_HOLD_MS / 2)
+      controller.update('pty-2', HIGH + 1)
+
+      vi.advanceTimersByTime(PRODUCER_PAUSE_MAX_HOLD_MS / 2)
+      expect(resumeProducer).toHaveBeenCalledTimes(1)
+      expect(resumeProducer).toHaveBeenCalledWith('pty-1')
+      expect(controller.isPaused('pty-2')).toBe(true)
+
+      vi.advanceTimersByTime(PRODUCER_PAUSE_MAX_HOLD_MS / 2)
+      expect(resumeProducer).toHaveBeenCalledTimes(2)
+      expect(resumeProducer).toHaveBeenCalledWith('pty-2')
+    })
+
+    it('reports the exceeded ceiling for diagnostics', () => {
+      const onPauseCeilingExceeded = vi.fn<(id: string, heldMs: number) => void>()
+      const observed = new PtyProducerFlowController(
+        { pauseProducer, resumeProducer },
+        { onPauseCeilingExceeded }
+      )
+      observed.update('pty-1', HIGH + 1)
+      vi.advanceTimersByTime(PRODUCER_PAUSE_MAX_HOLD_MS)
+      expect(onPauseCeilingExceeded).toHaveBeenCalledTimes(1)
+      expect(onPauseCeilingExceeded).toHaveBeenCalledWith('pty-1', PRODUCER_PAUSE_MAX_HOLD_MS)
+    })
+
+    it('keeps bookkeeping consistent when the ceiling resume throws', () => {
+      resumeProducer.mockImplementation(() => {
+        throw new Error('provider gone')
+      })
+      controller.update('pty-1', HIGH + 1)
+      expect(() => vi.advanceTimersByTime(PRODUCER_PAUSE_MAX_HOLD_MS)).not.toThrow()
+      expect(controller.isPaused('pty-1')).toBe(false)
+    })
   })
 })

--- a/src/main/ipc/pty-producer-flow-control.ts
+++ b/src/main/ipc/pty-producer-flow-control.ts
@@ -29,7 +29,6 @@ export class PtyProducerFlowController {
   private lowWatermarkChars: number
   private reassertIntervalMs: number
   private maxPauseHoldMs: number
-  private onPauseCeilingExceeded?: (id: string, heldMs: number) => void
   private pausedAtByPty = new Map<string, number>()
   private pauseCeilingTimerByPty = new Map<string, ReturnType<typeof setTimeout>>()
 
@@ -40,7 +39,6 @@ export class PtyProducerFlowController {
       lowWatermarkChars?: number
       reassertIntervalMs?: number
       maxPauseHoldMs?: number
-      onPauseCeilingExceeded?: (id: string, heldMs: number) => void
     } = {}
   ) {
     this.transport = transport
@@ -48,7 +46,6 @@ export class PtyProducerFlowController {
     this.lowWatermarkChars = opts.lowWatermarkChars ?? PRODUCER_FLOW_LOW_WATERMARK_CHARS
     this.reassertIntervalMs = opts.reassertIntervalMs ?? PRODUCER_PAUSE_REASSERT_INTERVAL_MS
     this.maxPauseHoldMs = opts.maxPauseHoldMs ?? PRODUCER_PAUSE_MAX_HOLD_MS
-    this.onPauseCeilingExceeded = opts.onPauseCeilingExceeded
   }
 
   /** Reports the current pending chars for a PTY. Fires pause exactly once at
@@ -105,7 +102,6 @@ export class PtyProducerFlowController {
 
   private armPauseCeiling(id: string): void {
     this.clearPauseCeiling(id)
-    const pausedAt = Date.now()
     const timer = setTimeout(() => {
       this.pauseCeilingTimerByPty.delete(id)
       // Why unconditional: pending is still above LOW here by construction, so
@@ -115,7 +111,6 @@ export class PtyProducerFlowController {
         return
       }
       this.safeResume(id)
-      this.onPauseCeilingExceeded?.(id, Date.now() - pausedAt)
     }, this.maxPauseHoldMs)
     // Why unref: a pending resume timer must never hold the process open at exit.
     timer.unref?.()

--- a/src/main/ipc/pty-producer-flow-control.ts
+++ b/src/main/ipc/pty-producer-flow-control.ts
@@ -11,6 +11,12 @@ export const PRODUCER_FLOW_LOW_WATERMARK_CHARS = 32 * 1024
 // pending is still above HIGH after that window, the pause must be re-asserted
 // or a sustained flood would run unthrottled after the first failsafe fires.
 export const PRODUCER_PAUSE_REASSERT_INTERVAL_MS = 5_000
+// Why: resume is driven by renderer ACKs draining pending below LOW. If those
+// ACKs stop (wedged/lost renderer), pending never drains and a provider without
+// its own failsafe — LocalPtyProvider is a bare node-pty pause() — leaves the
+// child blocked on write for good, freezing a live agent TUI. Cap one continuous
+// paused span; a still-flooded pending re-pauses on the next report.
+export const PRODUCER_PAUSE_MAX_HOLD_MS = 10_000
 
 export type ProducerFlowControlTransport = {
   pauseProducer: (id: string) => void
@@ -22,7 +28,10 @@ export class PtyProducerFlowController {
   private highWatermarkChars: number
   private lowWatermarkChars: number
   private reassertIntervalMs: number
+  private maxPauseHoldMs: number
+  private onPauseCeilingExceeded?: (id: string, heldMs: number) => void
   private pausedAtByPty = new Map<string, number>()
+  private pauseCeilingTimerByPty = new Map<string, ReturnType<typeof setTimeout>>()
 
   constructor(
     transport: ProducerFlowControlTransport,
@@ -30,12 +39,16 @@ export class PtyProducerFlowController {
       highWatermarkChars?: number
       lowWatermarkChars?: number
       reassertIntervalMs?: number
+      maxPauseHoldMs?: number
+      onPauseCeilingExceeded?: (id: string, heldMs: number) => void
     } = {}
   ) {
     this.transport = transport
     this.highWatermarkChars = opts.highWatermarkChars ?? PRODUCER_FLOW_HIGH_WATERMARK_CHARS
     this.lowWatermarkChars = opts.lowWatermarkChars ?? PRODUCER_FLOW_LOW_WATERMARK_CHARS
     this.reassertIntervalMs = opts.reassertIntervalMs ?? PRODUCER_PAUSE_REASSERT_INTERVAL_MS
+    this.maxPauseHoldMs = opts.maxPauseHoldMs ?? PRODUCER_PAUSE_MAX_HOLD_MS
+    this.onPauseCeilingExceeded = opts.onPauseCeilingExceeded
   }
 
   /** Reports the current pending chars for a PTY. Fires pause exactly once at
@@ -46,12 +59,14 @@ export class PtyProducerFlowController {
     if (pausedAt === undefined) {
       if (pendingChars > this.highWatermarkChars) {
         this.pausedAtByPty.set(id, Date.now())
+        this.armPauseCeiling(id)
         this.safePause(id)
       }
       return
     }
     if (pendingChars < this.lowWatermarkChars) {
       this.pausedAtByPty.delete(id)
+      this.clearPauseCeiling(id)
       this.safeResume(id)
       return
     }
@@ -59,6 +74,8 @@ export class PtyProducerFlowController {
       pendingChars > this.highWatermarkChars &&
       Date.now() - pausedAt >= this.reassertIntervalMs
     ) {
+      // Why no re-arm: the ceiling bounds one continuous paused span, so a
+      // re-assert must not extend it or a sustained flood would never release.
       this.pausedAtByPty.set(id, Date.now())
       this.safePause(id)
     }
@@ -67,6 +84,7 @@ export class PtyProducerFlowController {
   /** Resumes a PTY if it was paused. For teardown paths (exit, kill) where
    *  the pending bookkeeping is being dropped rather than drained. */
   release(id: string): void {
+    this.clearPauseCeiling(id)
     if (this.pausedAtByPty.delete(id)) {
       this.safeResume(id)
     }
@@ -83,6 +101,34 @@ export class PtyProducerFlowController {
 
   isPaused(id: string): boolean {
     return this.pausedAtByPty.has(id)
+  }
+
+  private armPauseCeiling(id: string): void {
+    this.clearPauseCeiling(id)
+    const pausedAt = Date.now()
+    const timer = setTimeout(() => {
+      this.pauseCeilingTimerByPty.delete(id)
+      // Why unconditional: pending is still above LOW here by construction, so
+      // only the ceiling can break the deadlock. Dropping the bookkeeping lets
+      // the next report re-pause if the flood is real.
+      if (!this.pausedAtByPty.delete(id)) {
+        return
+      }
+      this.safeResume(id)
+      this.onPauseCeilingExceeded?.(id, Date.now() - pausedAt)
+    }, this.maxPauseHoldMs)
+    // Why unref: a pending resume timer must never hold the process open at exit.
+    timer.unref?.()
+    this.pauseCeilingTimerByPty.set(id, timer)
+  }
+
+  private clearPauseCeiling(id: string): void {
+    const timer = this.pauseCeilingTimerByPty.get(id)
+    if (timer === undefined) {
+      return
+    }
+    clearTimeout(timer)
+    this.pauseCeilingTimerByPty.delete(id)
   }
 
   // Why swallow: pause/resume are optimizations riding the terminal data


### PR DESCRIPTION
## ELI5

When a terminal pane produces output faster than the UI can draw it, Orca tells the OS to stop reading that terminal so the program inside blocks and stops flooding. It undoes that once the backlog drains. The problem: "the backlog drained" is only ever learned from the renderer sending an acknowledgement. If those acknowledgements stop arriving, nothing ever says "you can resume", and the program stays frozen mid-sentence. This adds a 10-second ceiling on how long one of those pauses can be held, so a stuck agent always gets un-stuck by itself.

## What Changed

`PtyProducerFlowController` now bounds a single continuous paused span:

- New `PRODUCER_PAUSE_MAX_HOLD_MS = 10_000`. When a PTY is paused, a timer is armed; if the span reaches the ceiling, the pause is released unconditionally and the bookkeeping dropped.
- The ceiling measures from the **first** pause of a span. A re-assert (`PRODUCER_PAUSE_REASSERT_INTERVAL_MS`) deliberately does **not** re-arm it, or a sustained flood would extend the span forever and reintroduce the same unbounded hold.
- Cleared on every exit path already in the class: drain below LOW, `release()`, `releaseAll()`.
- Timer is `unref()`d so a pending resume never holds the process open at exit.

No call sites changed. Sustained backpressure behavior is unchanged: pending still above HIGH re-pauses on the very next report, so this removes only the *unbounded* hold, not the throttling.

## Why

Resume is entirely ACK-driven. `updateProducerFlowControl` is only ever invoked from a data/flush/ACK event, and it computes `pendingChars` from `session.pendingData`, which shrinks only when the renderer acknowledges. So the resume edge depends on a signal that can stop arriving (wedged renderer, dropped push channel, lifecycle reset mid-flight). Once it does, `update` either stops being called or keeps reporting a value above LOW, and the pause is held with no upper bound.

How much that hurts depends on the provider, and the two live providers disagree:

- **Daemon path** — `SessionProducerPause` arms `PRODUCER_PAUSE_FAILSAFE_MS = 5_000` and auto-resumes. Its comment states the invariant directly: *"a lost resume must never wedge a shell."* A held pause degrades to a 5s stutter.
- **Local path** — `LocalPtyProvider.pauseProducer` is `ptyProcesses.get(id)?.pause()` with no failsafe. Nothing ever resumes it. The child stays blocked on `write()` indefinitely.

That asymmetry is the bug. The daemon already treats "a lost resume must never wedge a shell" as a hard invariant; the main-side controller is the layer that can hold a pause across *any* provider, so the same guarantee belongs here rather than being re-implemented per provider.

Why this matters more for agent panes than for a shell: a full-screen TUI runs the tty in raw mode, where a full buffer returns `EAGAIN` and the writer blocks. A cooked-mode shell silently discards instead, so it never wedges. On macOS, Node's stdout-to-TTY writes are synchronous, so a blocked write stalls the agent's whole event loop — the spinner freezes on one frame and input stops being read, while the process is alive and `S+`. That is why this presents as "the agent is frozen" rather than "output is slow".

Consistent with the existing `releaseAll()` comment on this class — *"a local PTY left paused here would stay wedged forever"* — which already identifies the wedge; this generalizes that safety net from window-destroyed to any unbounded hold.

10s is chosen to sit clearly above the daemon's 5s failsafe so the daemon's own recovery always wins on that path and this stays a genuine last resort, while remaining short enough that a user reads it as a hitch rather than a hang.

## Linked Issue

Refs #12523 — the narrower match. Its diagnosis names this exact layer as root-cause stage 3: "main-process delivery window (`rendererInFlightChars` saturated at 1 MB, `ackGatedFlushSkipCount` > 100)". This PR bounds how long that saturated window can hold the producer paused. It does **not** claim to fix #12523's headline symptom: #12523 is bounded-but-large echo *latency* under a flood that still drains, whereas this is an unbounded *wedge* where the resume edge never arrives at all. #12523 also notes "keeping the in-flight delivery window small alone did not fix it" — agreed, and this PR does not propose that as a latency fix; it only removes the infinite hold.

Refs #12283 — Pi agent pane appears frozen at 'working' with no streamed output during long responses.

Refs #11178 — daemon busy-waits on `EAGAIN` writing to `/dev/ptmx` when the agent stops draining its PTY; same mechanism observed from the provider side.

### Honest status of the #12283 link

I linked #12283 on 2026-08-29 because its reported symptom matched. On 2026-09-03 the reporter re-attributed that Windows first-tool freeze to a different mechanism — #18446, a DEC 2026 synchronized-output frame not upgraded to the interactive render path — and explicitly called it "distinct from the dense-SGR backlog in #12523". So I no longer expect this PR to resolve #12283. Its "eventually recovers" detail is in fact evidence *against* this path: a hold that clears on its own looks like the daemon's 5s failsafe already firing, which is the behaviour this ceiling is a backstop for, not the failure it prevents. I keep the reference because an unbounded pause on the local provider produces the same visible symptom, but this PR should not be read as #12283's fix.

### Relationship to the other open fixes in this area

#12624 and #12525 are both open against the dense-SGR echo-latency symptom and change the renderer write/scheduler path. This PR is neither a duplicate nor a competitor: it lives in `PtyProducerFlowController` on the main side and changes only the *lifetime* of a producer pause, so it is composable with whichever of those lands. #15319 addresses the provider-side `EAGAIN` retry loop from #11178; a pause ceiling is orthogonal to write-retry pacing.

## Visual Proof

`N/A` — no UI surface. The change is internal PTY flow-control timing; there is no visual or interaction change to capture, only the absence of a freeze.

## Testing

`pnpm test src/main/ipc/pty-producer-flow-control.test.ts` — 17 passed (10 pre-existing, unmodified; 7 new). Verified the 10 original assertions still pass unchanged, so hysteresis, re-assert, per-PTY isolation, and throw-safety are not regressed.

New cases in a `pause ceiling` describe block:

- resumes a PTY held past the ceiling with no further reports (the wedge itself)
- ceiling is not extended by a re-assert within the same span
- a still-flooded PTY re-pauses after the ceiling released it (throttling preserved)
- no double resume when pending drains normally before the ceiling
- no late resume after `release()` / `releaseAll()` already cancelled it
- each PTY bounded on its own independent ceiling
- bookkeeping stays consistent when the ceiling's resume throws

Typecheck clean on the changed file under `--strict`.

Platforms: logic is platform-agnostic (`setTimeout` + existing transport calls) and I did not touch any platform-guarded path. The provider gap it protects is most consequential on the local (non-daemon) provider on all three OSes. The diagnosis behind it was done on macOS against 1.4.192, whose panes are daemon-hosted; the patch itself has only been exercised by the unit tests above, on no platform end-to-end. I have not reproduced the wedge on Windows or Linux. The fix is derived from the ACK-driven resume path plus the provider asymmetry, both platform-independent.

SSH/remote: `SshPtyProvider.pauseProducer` routes to the relay's own pause path; this only bounds how long main holds the pause, adding an upper bound where there was none. No wire format, RPC param, or stream opcode is touched, so there is no mixed-version concern.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

To be explicit about the unchecked box: I verified this at the unit level (17 tests, fake timers) and by typecheck, not by building the app and reproducing a live wedge. I could not get the wedge to occur on demand — my own panes are daemon-hosted, where the 5s failsafe masks it, which is exactly why the local-provider gap is easy to miss. A reviewer who can reach the local (non-daemon) provider path is better placed to confirm the end-to-end recovery.

## AI Disclosure

This PR was produced end-to-end by an AI coding agent (an Anthropic Claude model, accessed through a gateway under the alias `claude-ultimate`; I can't verify which exact published version that maps to, so I won't name one). That covers the investigation, the root-cause analysis, the patch, the tests, and this PR description.

It has **not** had a line-by-line human review before submission. The human in the loop asked for the fix and approved sending it, but is relying on your review rather than vouching for the diff independently. Treat the reasoning in *Why* as a claim to check, not as a verified account.

What was actually verified, mechanically: the 17 unit tests pass, the 10 pre-existing tests still pass unmodified, and the changed file typechecks under `--strict`. What was **not** verified: any live wedge or its recovery in a running build (see *Testing*).

The root cause was established by reading this repository's source. The constants and the provider asymmetry were additionally cross-checked against the shipped 1.4.192 bundle to confirm the behavior is live in a release build and not just on `main`.

## Review

Summary from the agent that wrote the patch, per the contributor guide. Unreviewed by a human — verify rather than trust.

Cross-platform: no platform branch touched; `setTimeout`/`clearTimeout`/`unref` only. `unref?.()` is optional-called so a non-Node timer shape cannot throw.

SSH/remote/local: all three providers reach this class through the same `ProducerFlowControlTransport`. The ceiling only adds an upper bound to a pause each provider already receives. No wire compatibility surface.

Agent/integration neutrality: no agent-specific logic. The class never learns which agent occupies a PTY, and nothing keys off agent identity.

Performance: one `setTimeout` per *paused* PTY — paused is already the rare path, and the timer is cleared on all three exit paths, so steady state adds no timers and no work in the data path. Map entries are removed with their timers, so no unbounded growth. Worst case for a genuinely sustained flood is one extra pause/resume pair per 10s per PTY, which is cheaper than the 5s daemon re-assert already in place.

Security: no new input, IPC surface, or privileged call; no data logged.

Backwards compatibility: additive. New exported constant, two new optional constructor options; existing construction sites compile and behave identically. Behavior changes only in the state that was previously a wedge.

Risk: the deliberate trade-off is that releasing a still-flooded PTY lets it produce again, so a real flood re-fills pending and re-pauses. That is the intended failure mode — a bounded stutter under flood is strictly better than an unbounded freeze, and it matches the reasoning the daemon failsafe already encodes.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

One adjacent thing I deliberately left out of scope:

1. `LocalPtyProvider.pauseProducer` could grow its own failsafe mirroring `SessionProducerPause`, giving defense in depth at the provider layer. I put the bound in the controller instead because it covers every provider at once and keeps the invariant in the layer that owns the hold. Happy to add the provider-level one too if you'd prefer it there.

Author: not on X.


