### PR TITLE
fix(runtime): add authenticated Windows loopback fallback

### DIFF
--- a/src/cli/runtime/transport.test.ts
+++ b/src/cli/runtime/transport.test.ts
@@ -5,7 +5,8 @@ import { createServer, type Socket } from 'node:net'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { RuntimeMetadata } from '../../shared/runtime-bootstrap'
 import { MAX_TIMER_DELAY_MS } from '../../shared/timer-delay'
-import { sendRequest } from './transport'
+import { mapRuntimeConnectError, sendRequest, shouldUseLocalTcpFallback } from './transport'
+import { RuntimeClientError } from './types'
 
 const servers = new Set<ReturnType<typeof createServer>>()
 const sockets = new Set<Socket>()
@@ -45,6 +46,61 @@ describe('runtime transport timeout validation', () => {
       )
     }
   )
+})
+
+describe('runtime transport connection errors', () => {
+  it.each(['EPERM', 'EACCES'] as const)(
+    'preserves %s instead of recommending a restart',
+    (code) => {
+      const failure = mapRuntimeConnectError(
+        Object.assign(new Error('denied'), { code, errno: -4048, syscall: 'connect' }),
+        'named-pipe'
+      )
+
+      expect(failure).toBeInstanceOf(RuntimeClientError)
+      expect(failure).toMatchObject({
+        code: 'runtime_permission_denied',
+        data: {
+          transportKind: 'named-pipe',
+          osErrorCode: code,
+          osErrorNumber: -4048,
+          syscall: 'connect'
+        }
+      })
+      expect(failure.message).not.toContain('Restart Orca and try again')
+    }
+  )
+
+  it('keeps a missing endpoint in the generic unavailable class', () => {
+    const failure = mapRuntimeConnectError(
+      Object.assign(new Error('missing'), { code: 'ENOENT', syscall: 'connect' }),
+      'named-pipe'
+    )
+
+    expect(failure).toMatchObject({ code: 'runtime_unavailable' })
+  })
+})
+
+describe('local TCP fallback admission', () => {
+  const denied = new RuntimeClientError('runtime_permission_denied', 'denied')
+
+  it('admits only a loopback fallback after named-pipe permission denial', () => {
+    expect(shouldUseLocalTcpFallback(denied, 'named-pipe', 'tcp://127.0.0.1:54321')).toBe(true)
+  })
+
+  it.each([
+    [
+      new RuntimeClientError('runtime_unavailable', 'missing'),
+      'named-pipe',
+      'tcp://127.0.0.1:54321'
+    ],
+    [denied, 'unix', 'tcp://127.0.0.1:54321'],
+    [denied, 'named-pipe', 'tcp://0.0.0.0:54321'],
+    [denied, 'named-pipe', 'tcp://127.0.0.1:0'],
+    [denied, 'named-pipe', undefined]
+  ] as const)('rejects a non-permission or non-loopback fallback', (error, kind, endpoint) => {
+    expect(shouldUseLocalTcpFallback(error, kind, endpoint)).toBe(false)
+  })
 })
 
 // Why: these tests create Unix domain socket servers in temp directories.

--- a/src/cli/runtime/transport.ts
+++ b/src/cli/runtime/transport.ts
@@ -19,18 +19,36 @@ export async function sendRequest<TResult>(
       `Runtime request timeout must be an integer between 0 and ${MAX_TIMER_DELAY_MS}ms.`
     )
   }
-  return await new Promise((resolve, reject) => {
-    const transport = findTransport(metadata, 'unix', 'named-pipe')
-    if (!transport) {
-      reject(
-        new RuntimeClientError(
-          'runtime_unavailable',
-          'No compatible transport found in Orca runtime metadata.'
-        )
-      )
-      return
+  const primary = findTransport(metadata, 'unix', 'named-pipe')
+  if (!primary) {
+    throw new RuntimeClientError(
+      'runtime_unavailable',
+      'No compatible transport found in Orca runtime metadata.'
+    )
+  }
+  try {
+    return await sendRequestUsingTransport(metadata, primary, method, params, timeoutMs, envelope)
+  } catch (error) {
+    const fallback = findTransport(metadata, 'local-tcp')
+    if (!shouldUseLocalTcpFallback(error, primary.kind, fallback?.endpoint)) {
+      throw error
     }
-    const socket = createConnection(transport.endpoint)
+    return await sendRequestUsingTransport(metadata, fallback!, method, params, timeoutMs, envelope)
+  }
+}
+
+function sendRequestUsingTransport<TResult>(
+  metadata: RuntimeMetadata,
+  transport: RuntimeMetadata['transports'][number],
+  method: string,
+  params: unknown,
+  timeoutMs: number,
+  envelope?: RuntimeOrchestrationEnvelope
+): Promise<RuntimeRpcResponse<TResult>> {
+  return new Promise((resolve, reject) => {
+    const endpoint = resolveLocalTransportEndpoint(transport)
+    const socket =
+      typeof endpoint === 'string' ? createConnection(endpoint) : createConnection(endpoint)
     let buffer = ''
     let settled = false
     const requestId = randomUUID()
@@ -66,13 +84,16 @@ export async function sendRequest<TResult>(
     }
 
     socket.setEncoding('utf8')
-    socket.once('error', () => {
+    socket.once('error', (error: NodeJS.ErrnoException) => {
       finish({
         ok: false,
-        error: new RuntimeClientError(
-          'runtime_unavailable',
-          'Could not connect to the running Orca app. Restart Orca and try again.'
-        )
+        error:
+          transport.kind === 'local-tcp'
+            ? new RuntimeClientError(
+                'runtime_unavailable',
+                'Could not connect to the running Orca app. Restart Orca and try again.'
+              )
+            : mapRuntimeConnectError(error, transport.kind)
       })
     })
     // Why: a clean peer close (FIN, no 'error') before a terminal frame never
@@ -195,4 +216,56 @@ export async function sendRequest<TResult>(
       )
     })
   })
+}
+
+export function mapRuntimeConnectError(
+  error: NodeJS.ErrnoException,
+  transportKind: 'unix' | 'named-pipe'
+): RuntimeClientError {
+  const permissionDenied = error.code === 'EPERM' || error.code === 'EACCES'
+  return new RuntimeClientError(
+    permissionDenied ? 'runtime_permission_denied' : 'runtime_unavailable',
+    permissionDenied
+      ? 'Permission denied while connecting to the Orca runtime transport. Restarting Orca will not change this transport permission.'
+      : 'Could not connect to the running Orca app. Restart Orca and try again.',
+    {
+      transportKind,
+      ...(error.code ? { osErrorCode: error.code } : {}),
+      ...(typeof error.errno === 'number' ? { osErrorNumber: error.errno } : {}),
+      ...(error.syscall ? { syscall: error.syscall } : {})
+    }
+  )
+}
+
+export function shouldUseLocalTcpFallback(
+  error: unknown,
+  primaryKind: RuntimeMetadata['transports'][number]['kind'],
+  fallbackEndpoint: string | undefined
+): boolean {
+  const endpointMatch = fallbackEndpoint
+    ? /^tcp:\/\/127\.0\.0\.1:(\d+)$/.exec(fallbackEndpoint)
+    : null
+  const port = endpointMatch ? Number(endpointMatch[1]) : 0
+  return (
+    primaryKind === 'named-pipe' &&
+    error instanceof RuntimeClientError &&
+    error.code === 'runtime_permission_denied' &&
+    Number.isInteger(port) &&
+    port >= 1 &&
+    port <= 65535
+  )
+}
+
+function resolveLocalTransportEndpoint(
+  transport: RuntimeMetadata['transports'][number]
+): string | { host: '127.0.0.1'; port: number } {
+  if (transport.kind !== 'local-tcp') {
+    return transport.endpoint
+  }
+  const match = /^tcp:\/\/127\.0\.0\.1:(\d+)$/.exec(transport.endpoint)
+  const port = match ? Number(match[1]) : 0
+  if (!match || !Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new RuntimeClientError('runtime_unavailable', 'Invalid local TCP runtime endpoint.')
+  }
+  return { host: '127.0.0.1', port }
 }

--- a/src/cli/runtime/transport.ts
+++ b/src/cli/runtime/transport.ts
@@ -88,12 +88,12 @@ function sendRequestUsingTransport<TResult>(
       finish({
         ok: false,
         error:
-          transport.kind === 'local-tcp'
-            ? new RuntimeClientError(
+          transport.kind === 'named-pipe' || transport.kind === 'unix'
+            ? mapRuntimeConnectError(error, transport.kind)
+            : new RuntimeClientError(
                 'runtime_unavailable',
                 'Could not connect to the running Orca app. Restart Orca and try again.'
               )
-            : mapRuntimeConnectError(error, transport.kind)
       })
     })
     // Why: a clean peer close (FIN, no 'error') before a terminal frame never

--- a/src/main/runtime/rpc/unix-socket-transport.test.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.test.ts
@@ -75,3 +75,16 @@ describe('UnixSocketTransport', () => {
     expect(socket.writes).toHaveLength(1)
   })
 })
+
+describe('loopback TCP transport', () => {
+  it('binds an OS-assigned port only on IPv4 loopback', async () => {
+    const transport = new UnixSocketTransport({
+      endpoint: { host: '127.0.0.1', port: 0 },
+      kind: 'local-tcp'
+    })
+
+    await transport.start()
+    expect(transport.resolvedEndpoint).toMatch(/^tcp:\/\/127\.0\.0\.1:\d+$/)
+    await transport.stop()
+  })
+})

--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -1,5 +1,5 @@
-// Why: this is the original Unix socket / named pipe transport extracted from
-// runtime-rpc.ts. It preserves the exact same behavior: newline-delimited JSON,
+// Why: local Unix, named-pipe, and loopback TCP endpoints share one authenticated
+// newline-delimited RPC lifecycle instead of drifting across fallback transports:
 // 30s idle timeout, 1MB max message, 32 max connections, chmod 0o600 on Unix.
 // It also owns the keepalive timer and per-connection abort signal so the
 // server-side handler can cancel long-poll dispatches when the client goes
@@ -14,8 +14,8 @@ const MAX_RUNTIME_RPC_CONNECTIONS = 32
 const DEFAULT_KEEPALIVE_INTERVAL_MS = 10_000
 
 export type UnixSocketTransportOptions = {
-  endpoint: string
-  kind: 'unix' | 'named-pipe'
+  endpoint: string | { host: '127.0.0.1'; port: number }
+  kind: 'unix' | 'named-pipe' | 'local-tcp'
   // Why: how often to write `{"_keepalive":true}\n` frames while a dispatch
   // is pending. Each write resets both the server-side idle timer and, once
   // the client honours them, the client-side idle timer. Tests override this
@@ -30,8 +30,8 @@ type MessageHandler = (
 ) => void
 
 export class UnixSocketTransport implements RpcTransport {
-  private readonly endpoint: string
-  private readonly kind: 'unix' | 'named-pipe'
+  private readonly endpoint: string | { host: '127.0.0.1'; port: number }
+  private readonly kind: 'unix' | 'named-pipe' | 'local-tcp'
   private readonly keepaliveIntervalMs: number
   private server: Server | null = null
   private messageHandler: MessageHandler | null = null
@@ -47,12 +47,23 @@ export class UnixSocketTransport implements RpcTransport {
     this.messageHandler = handler
   }
 
+  get resolvedEndpoint(): string {
+    if (this.kind !== 'local-tcp') {
+      return String(this.endpoint)
+    }
+    const address = this.server?.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Loopback TCP transport is not listening.')
+    }
+    return `tcp://127.0.0.1:${address.port}`
+  }
+
   async start(): Promise<void> {
     if (this.server) {
       return
     }
 
-    if (this.kind === 'unix' && existsSync(this.endpoint)) {
+    if (this.kind === 'unix' && typeof this.endpoint === 'string' && existsSync(this.endpoint)) {
       rmSync(this.endpoint, { force: true })
     }
 
@@ -63,13 +74,17 @@ export class UnixSocketTransport implements RpcTransport {
 
     await new Promise<void>((resolve, reject) => {
       server.once('error', reject)
-      server.listen(this.endpoint, () => {
+      const listenTarget =
+        this.kind === 'local-tcp' && typeof this.endpoint !== 'string'
+          ? this.endpoint
+          : String(this.endpoint)
+      server.listen(listenTarget, () => {
         server.off('error', reject)
         resolve()
       })
     })
 
-    if (this.kind === 'unix') {
+    if (this.kind === 'unix' && typeof this.endpoint === 'string') {
       chmodSync(this.endpoint, 0o600)
     }
 
@@ -97,7 +112,7 @@ export class UnixSocketTransport implements RpcTransport {
       socket.destroy()
     }
     await closePromise
-    if (this.kind === 'unix' && existsSync(this.endpoint)) {
+    if (this.kind === 'unix' && typeof this.endpoint === 'string' && existsSync(this.endpoint)) {
       rmSync(this.endpoint, { force: true })
     }
   }

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -1177,32 +1177,47 @@ export class OrcaRuntimeRpcServer {
       keepaliveIntervalMs: this.keepaliveIntervalMs
     })
 
-    // Why: the `.catch` guarantees reply() always fires so a throw can't strand the client or leak the AbortController.
-    socketTransport.onMessage((msg, reply, context) => {
-      void this.handleMessage(msg, context)
-        .then((response) => {
-          reply(JSON.stringify(response))
-        })
-        .catch((error) => {
-          const message = error instanceof Error ? error.message : String(error)
-          // Why: best-effort id recovery so the client can correlate the error frame to its pending request.
-          let id = 'unknown'
-          try {
-            const parsed = JSON.parse(msg) as { id?: unknown }
-            if (typeof parsed.id === 'string' && parsed.id.length > 0) {
-              id = parsed.id
+    const attachLocalHandler = (transport: UnixSocketTransport): void => {
+      transport.onMessage((msg, reply, context) => {
+        void this.handleMessage(msg, context)
+          .then((response) => reply(JSON.stringify(response)))
+          .catch((error) => {
+            const message = error instanceof Error ? error.message : String(error)
+            let id = 'unknown'
+            try {
+              const parsed = JSON.parse(msg) as { id?: unknown }
+              if (typeof parsed.id === 'string' && parsed.id.length > 0) {
+                id = parsed.id
+              }
+            } catch {
+              // Best-effort id recovery.
             }
-          } catch {
-            // ignore — fall through with id='unknown'
-          }
-          reply(JSON.stringify(this.buildError(id, 'internal_error', message)))
-        })
-    })
+            reply(JSON.stringify(this.buildError(id, 'internal_error', message)))
+          })
+      })
+    }
+    attachLocalHandler(socketTransport)
 
     await socketTransport.start()
 
     const activeTransports: RpcTransport[] = [socketTransport]
     const transportsMeta: RuntimeTransportMetadata[] = [transportMeta]
+
+    if (this.platform === 'win32') {
+      const tcpTransport = new UnixSocketTransport({
+        endpoint: { host: '127.0.0.1', port: 0 },
+        kind: 'local-tcp',
+        keepaliveIntervalMs: this.keepaliveIntervalMs
+      })
+      attachLocalHandler(tcpTransport)
+      try {
+        await tcpTransport.start()
+        activeTransports.push(tcpTransport)
+        transportsMeta.push({ kind: 'local-tcp', endpoint: tcpTransport.resolvedEndpoint })
+      } catch (error) {
+        console.error('[runtime] Failed to start local TCP fallback transport:', error)
+      }
+    }
 
     // Why: WebSocket uses per-device tokens + E2EE (tweetnacl) instead of TLS since React Native can't pin self-signed certs.
     if (this.enableWebSocket) {

--- a/src/shared/runtime-bootstrap.ts
+++ b/src/shared/runtime-bootstrap.ts
@@ -13,6 +13,10 @@ export type RuntimeTransportMetadata =
       kind: 'websocket'
       endpoint: string
     }
+  | {
+      kind: 'local-tcp'
+      endpoint: string
+    }
 
 export type RuntimeMetadata = {
   runtimeId: string


### PR DESCRIPTION
## Summary

- publish an authenticated OS-assigned IPv4 loopback RPC fallback on Windows while retaining the named pipe as primary
- retry only after named-pipe `EPERM`/`EACCES`; reject non-loopback or invalid endpoints
- preserve runtime ID/auth-token response validation and narrow CLI error mapping for current main

## Why a new PR

This supersedes stacked PR #16623 with the same contract rebased directly onto current `main`. The prior PR remains useful history but targets the diagnostics branch rather than `main`.

## Verification

- current-main head: `394dc4b796`
- `pnpm run typecheck:cli`: pass
- `pnpm run typecheck:node`: pass
- focused Vitest: 15 passed, 2 existing Windows Unix-socket skips
- `git diff --check`: pass
- independent Claude review: GO after closing the CLI type narrowing blocker
- packaged Surface artifact: Orca 1.4.192, SHA-256 `788A16072277F60CDD146C609577729180D06D6CD29D83928B9065F77F3225BA`

## Live Windows evidence

The installed Surface build published `named-pipe`, `local-tcp` (`127.0.0.1`, OS-assigned port), and `websocket` metadata for runtime `18f8820e-8eb5-4651-941e-d133895ca05a`. From the restricted Codex shell, `orca status --json` returned `state=ready`, `reachable=true`, and the same response runtime ID. Terminal, orchestration task/run, and computer-use read-only queries succeeded. Existing terminal daemon and Herdr/WezTerm processes were preserved.

## Security boundary

The fallback remains Windows-only, loopback-only, permission-error-only, and uses the existing per-runtime random auth token. Transport acceptance is not treated as cross-agent ACK or completion.

## Separate axes

Crashpad `CreateFile` warnings on Windows CLI invocation remain a separate unresolved console-producer issue. Surface Paseo is retired and is not a fallback dependency.
