### PR TITLE
fix(updater): stop the update scheduler when the app quits

### DIFF
--- a/src/main/updater-test-harness.ts
+++ b/src/main/updater-test-harness.ts
@@ -227,6 +227,10 @@ export function createUpdaterMocks(): UpdaterMocks {
 
   /** Shared `beforeEach` body: fresh module registry plus every mock back to its default. */
   const resetUpdaterMocks = () => {
+    // Why first: the outgoing instance owns real timers this registry reset cannot reach — a 45s
+    // stall guard among them. Left armed, it fires into whatever clock the next test installs and
+    // schedules an update check the next test never asked for.
+    appMock.emit('will-quit')
     vi.resetModules()
     autoUpdaterMock.reset()
     nativeUpdaterMock.on.mockReset()

--- a/src/main/updater.retired-instance-scheduling.test.ts
+++ b/src/main/updater.retired-instance-scheduling.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as UpdaterModule from './updater'
+
+const { appMock, autoUpdaterMock, fetchChangelogMock, moduleFactories, resetUpdaterMocks } =
+  await vi.hoisted(async () => (await import('./updater-test-harness')).createUpdaterMocks())
+
+vi.mock('electron', () => moduleFactories.electron())
+vi.mock('electron-updater', () => moduleFactories.electronUpdater())
+vi.mock('./electron-updater-loader', () => moduleFactories.electronUpdaterLoader())
+vi.mock('@electron-toolkit/utils', () => moduleFactories.electronToolkitUtils())
+vi.mock('./ipc/pty', () => moduleFactories.ipcPty())
+vi.mock('./linux-update-package-type', () => moduleFactories.linuxUpdatePackageType())
+vi.mock('./updater-lifecycle-diagnostics', () => moduleFactories.updaterLifecycleDiagnostics())
+vi.mock('./updater-changelog', () => moduleFactories.updaterChangelog())
+vi.mock('./updater-nudge', () => moduleFactories.updaterNudge())
+vi.mock('./update-install-exit-watchdog', () => moduleFactories.updateInstallExitWatchdog())
+vi.mock('./updater-prerelease-feed', () => moduleFactories.updaterPrereleaseFeed())
+vi.mock('./local-builds/local-build-switch', () => moduleFactories.localBuildSwitch())
+vi.mock('./local-builds/local-build-feed-server', () => moduleFactories.localBuildFeedServer())
+
+/** The 45s stall guard plus the 1h retry it arms — the whole window a retired guard can reach into. */
+const PAST_STALL_AND_RETRY_MS = 45_000 + 60 * 60 * 1000
+
+/** Starts a background check that never settles, so the stall guard stays armed. */
+async function launchStalledCheck(): Promise<typeof UpdaterModule> {
+  autoUpdaterMock.checkForUpdates.mockImplementation(() => new Promise(() => {}))
+  const updater = await import('./updater')
+  updater.setupAutoUpdater({ webContents: { send: vi.fn() } } as never, {
+    getLastUpdateCheckAt: () => Date.now() - 25 * 60 * 60 * 1000
+  })
+  await vi.advanceTimersByTimeAsync(0)
+  expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+  // Reset so anything counted below can only be a check the retired guard drove.
+  autoUpdaterMock.checkForUpdates.mockReset().mockResolvedValue(null)
+  return updater
+}
+
+describe('updater scheduling teardown', () => {
+  beforeEach(() => {
+    resetUpdaterMocks()
+  })
+
+  it('stops the stall guard from arming a retry once scheduling is stopped', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-03T12:00:00Z'))
+
+    const updater = await launchStalledCheck()
+    updater.stopAutoUpdaterScheduling()
+
+    await vi.advanceTimersByTimeAsync(PAST_STALL_AND_RETRY_MS)
+
+    expect(
+      autoUpdaterMock.checkForUpdates,
+      'a stopped updater still ran a check off its stall guard'
+    ).not.toHaveBeenCalled()
+  })
+
+  it('stops scheduling when the app says it is quitting', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-03T12:00:00Z'))
+
+    await launchStalledCheck()
+    appMock.emit('will-quit')
+
+    await vi.advanceTimersByTimeAsync(PAST_STALL_AND_RETRY_MS)
+
+    expect(
+      autoUpdaterMock.checkForUpdates,
+      'the updater kept checking for updates while the app was quitting'
+    ).not.toHaveBeenCalled()
+  })
+
+  it('leaves no armed timer behind', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-03T12:00:00Z'))
+
+    await launchStalledCheck()
+    expect(vi.getTimerCount(), 'the fixture armed nothing to tear down').toBeGreaterThan(0)
+
+    const { stopAutoUpdaterScheduling } = await import('./updater')
+    stopAutoUpdaterScheduling()
+
+    expect(vi.getTimerCount(), 'a stopped updater still owns armed timers').toBe(0)
+  })
+
+  it('does not re-arm the daily check from a result that lands after the stop', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-03T12:00:00Z'))
+
+    // The changelog fetch is the real in-flight tail: 'update-available' has already been handled,
+    // and the daily reschedule only happens once this resolves.
+    const changelogResolvers: ((value: string | null) => void)[] = []
+    fetchChangelogMock.mockImplementation(
+      () =>
+        new Promise<string | null>((resolve) => {
+          changelogResolvers.push(resolve)
+        })
+    )
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+
+    const updater = await import('./updater')
+    updater.setupAutoUpdater({ webContents: { send: vi.fn() } } as never, {
+      getLastUpdateCheckAt: () => Date.now() - 25 * 60 * 60 * 1000
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+
+    updater.stopAutoUpdaterScheduling()
+    for (const resolve of changelogResolvers) {
+      resolve(null)
+    }
+    await vi.advanceTimersByTimeAsync(0)
+    autoUpdaterMock.checkForUpdates.mockReset().mockResolvedValue(null)
+
+    await vi.advanceTimersByTimeAsync(25 * 60 * 60 * 1000)
+
+    expect(
+      autoUpdaterMock.checkForUpdates,
+      'a result that landed after the stop re-armed the daily check'
+    ).not.toHaveBeenCalled()
+  })
+
+  it('arms nothing when a window focus asks for a check after the stop', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-03T12:00:00Z'))
+
+    const updater = await import('./updater')
+    updater.setupAutoUpdater({ webContents: { send: vi.fn() } } as never, {
+      // A live closure, so every focus after the stop still reads as overdue.
+      getLastUpdateCheckAt: () => Date.now() - 25 * 60 * 60 * 1000
+    })
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+
+    updater.stopAutoUpdaterScheduling()
+    expect(vi.getTimerCount()).toBe(0)
+
+    // The focus and resume handlers outlive the stop, and both route to a background check.
+    appMock.emit('browser-window-focus')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(vi.getTimerCount(), 'a post-stop check re-armed the updater timers').toBe(0)
+  })
+
+  it('the shared reset retires the outgoing instance', () => {
+    // The reset cannot reach the timers the outgoing module armed on the real clock, so it has to
+    // ask that instance to stand down. The two tests above prove what standing down does.
+    const seen: string[] = []
+    appMock.on('will-quit', () => {
+      seen.push('will-quit')
+    })
+
+    resetUpdaterMocks()
+
+    expect(seen, 'the shared reset left the outgoing updater scheduling').toEqual(['will-quit'])
+  })
+})

--- a/src/main/updater.retired-instance-scheduling.test.ts
+++ b/src/main/updater.retired-instance-scheduling.test.ts
@@ -40,6 +40,24 @@ describe('updater scheduling teardown', () => {
     resetUpdaterMocks()
   })
 
+  it('arms a retry off the stall guard while the updater is still running', async () => {
+    // Why this sits ahead of the stop tests: every one of them asserts that nothing happened, and
+    // nothing happens just as reliably in an updater that never schedules at all. Without this,
+    // the whole file passes on a build where scheduling is stopped from the first line — so it
+    // would stop reporting the loss of the behaviour it is named for.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-03T12:00:00Z'))
+
+    await launchStalledCheck()
+
+    await vi.advanceTimersByTimeAsync(PAST_STALL_AND_RETRY_MS)
+
+    expect(
+      autoUpdaterMock.checkForUpdates,
+      'a running updater never retried the check its stall guard gave up on'
+    ).toHaveBeenCalled()
+  })
+
   it('stops the stall guard from arming a retry once scheduling is stopped', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-04-03T12:00:00Z'))

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -149,6 +149,8 @@ let _getLastUpdateCheckAt: (() => number | null) | null = null
 let backgroundCheckLaunchPending = false
 // Why: a promoted background check can emit an error event before its promise catch runs; keep the promotion attached to that launch.
 let backgroundCheckPromotedToUserInitiated = false
+// Why: nothing could stop the updater once armed, so a retired instance kept re-arming checks off a clock it no longer owned.
+let updaterSchedulingStopped = false
 let updateCheckStallTimer: ReturnType<typeof setTimeout> | null = null
 let updateCheckSilentSettleTimer: ReturnType<typeof setTimeout> | null = null
 let updateCheckAttemptSequence = 0
@@ -477,6 +479,9 @@ function clearUpdateAvailableEventPending(attemptId: number | null): void {
 
 function armUpdateCheckStallTimer(attemptId: number): void {
   clearUpdateCheckStallTimer()
+  if (updaterSchedulingStopped) {
+    return
+  }
   updateCheckStallTimer = setTimeout(() => {
     updateCheckStallTimer = null
     if (!isActiveUpdateCheckAttempt(attemptId)) {
@@ -597,6 +602,9 @@ function handleSettledUpdateCheckPromise(attemptId: number): void {
     return
   }
   clearUpdateCheckSilentSettleTimer()
+  if (updaterSchedulingStopped) {
+    return
+  }
   // Why: electron-updater can resolve before the terminal event arrives; grace-period it, then unstick checks that resolved without one.
   updateCheckSilentSettleTimer = setTimeout(() => {
     updateCheckSilentSettleTimer = null
@@ -1243,6 +1251,9 @@ export function installRemoteServerUpdate(runtimeId: string): RemoteServerUpdate
 let consecutiveAutomaticRetrySchedules = 0
 
 function scheduleAutomaticUpdateCheck(delayMs: number): void {
+  if (updaterSchedulingStopped) {
+    return
+  }
   let effectiveDelayMs = delayMs
   // All retry-cadence callers pass exactly this constant, so keying backoff on it keeps one choke point instead of threading a flag through every schedule site.
   if (delayMs === AUTO_UPDATE_RETRY_INTERVAL_MS) {
@@ -2160,6 +2171,30 @@ export function dismissAvailableUpdate(): void {
   sendStatus({ state: 'idle' })
 }
 
+/**
+ * Stop every timer the updater schedules work from.
+ *
+ * Why this exists: `setupAutoUpdater` arms a daily check, a nudge poll, a 45-second stall guard
+ * and a 1-second settle grace, and nothing could cancel them. A stall guard that outlives its
+ * updater still fires, still finds `backgroundCheckLaunchPending`, and still arms an hourly retry
+ * — a check nobody asked for, driven by an instance that has already been retired.
+ *
+ * The install timers are deliberately left alone: a quit that is handing off to an installer
+ * still needs them.
+ */
+export function stopAutoUpdaterScheduling(): void {
+  updaterSchedulingStopped = true
+  clearUpdateCheckTimers()
+  if (autoUpdateCheckTimer) {
+    clearTimeout(autoUpdateCheckTimer)
+    autoUpdateCheckTimer = null
+  }
+  if (nudgeCheckTimer) {
+    clearTimeout(nudgeCheckTimer)
+    nudgeCheckTimer = null
+  }
+}
+
 export function setupAutoUpdater(
   mainWindow: BrowserWindow,
   opts?: {
@@ -2175,6 +2210,7 @@ export function setupAutoUpdater(
   }
 ): void {
   mainWindowRef = mainWindow
+  updaterSchedulingStopped = false
   onBeforeQuitCleanup = opts?.onBeforeQuit ?? null
   persistLastUpdateCheckAt = opts?.setLastUpdateCheckAt ?? null
   _getLastUpdateCheckAt = opts?.getLastUpdateCheckAt ?? null
@@ -2303,6 +2339,9 @@ export function setupAutoUpdater(
 
   powerMonitor.on('resume', checkDailyOnWake)
   app.on('browser-window-focus', checkDailyOnWake)
+  // Why: a background check launched while the app is tearing down cannot finish, and its stall
+  // guard outlives the process it was scheduled for.
+  app.on('will-quit', stopAutoUpdaterScheduling)
 
   const lastUpdateCheckAt = opts?.getLastUpdateCheckAt?.() ?? null
   const msSinceLastCheck =


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​181 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​181 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |

<!-- /orca-pr-loc -->

## ELI5

Orca sets a few kitchen timers when it starts looking for an update: "check again tomorrow", "look for a nudge in half an hour", and "if this check hasn't answered in 45 seconds, assume it's stuck and try again in an hour". Until now there was no way to turn those timers off. If the thing that set them went away, the timers kept ticking anyway — and when the 45-second one went off, it cheerfully booked another update check for an updater that had already been retired.

This PR adds an off switch and pulls it when the app is quitting.

## What the user sees

| | Before | After |
|---|---|---|
| Quitting Orca | The updater can still launch a background check on the way out, and a 45-second stall guard can book an hourly retry for a process that is shutting down | Update scheduling stops when the app announces it is quitting |
| Installing an update | unchanged — the quit-and-install timers are deliberately untouched | unchanged |
| CI | `updater.startup-scheduling.test.ts` fails intermittently on shard 6/8 with `expected "vi.fn()" to be called 1 times, but got 2 times` | the leaked timer cannot reach a later test's clock |

## The failure

```
FAIL  src/main/updater.startup-scheduling.test.ts > updater > reschedules the next automatic check 24 hours after finding an available update
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
 ❯ src/main/updater.startup-scheduling.test.ts:243:45
```

Reproduced identically on three unrelated branches on 2026-08-29: runs `33255231751`, `33255357119`, `33256696552`. All three already contain #17130.

## Mechanism

`beginUpdateCheckAttempt()` arms a 45-second stall guard. When it fires it checks `backgroundCheckLaunchPending`, and if the check never got as far as `checking-for-update` it calls `scheduleAutomaticUpdateCheck(AUTO_UPDATE_RETRY_INTERVAL_MS)` — one hour.

Nothing can cancel that guard. `updater.startup-scheduling.test.ts` runs four tests on **real** timers before the fake-timer ones, and one of them (`deduplicates rapid focus-triggered daily checks`) deliberately hands `checkForUpdates` a promise that never settles. That test's stall guard is still armed on the real clock when the test ends. `vi.resetModules()` makes the module unreachable but does not clear its timers.

Roughly 45 real seconds later the guard fires. By then a later test has `vi.useFakeTimers()` installed, so the `setTimeout` the retired instance reaches for is the **fake** one — and its one-hour retry is booked on the current test's clock. `reschedules the next automatic check 24 hours after finding an available update` then sweeps 23 hours and runs it, calling the shared `autoUpdaterMock.checkForUpdates` a second time.

That also explains why #17130 could not help: it widened the margin at the 24-hour boundary (checkpoint moved from 23 h 59 m to 23 h), but the extra check lands about **one hour** into the sweep. Both the old and new checkpoints are far past it.

Why it is CI-only: locally the file finishes in ~1.4 s, so the 45-second guard fires long after the suite is done. On CI each test re-imports the whole updater graph after `vi.resetModules()`, and the file stays alive well past 45 seconds.

## The fix

- `stopAutoUpdaterScheduling()` clears the daily check, the nudge poll, the stall guard and the settle grace, and latches a flag so a result that lands afterwards cannot re-arm any of them.
- `setupAutoUpdater` registers it on `will-quit` and clears the flag, so a background check started while the app is tearing down cannot outlive it.
- `pendingQuitAndInstallTimer` is deliberately **not** cleared — a quit that is handing off to an installer still needs it.
- The shared test harness emits `will-quit` before `vi.resetModules()`, so each test retires the previous instance instead of leaving it armed.

## Proof

`src/main/updater.retired-instance-scheduling.test.ts`, 6 tests. Every gate ablated one at a time, mutation verified applied, tree restored between runs, run serially:

| Ablation | Failing tests |
|---|---|
| drop `app.on('will-quit', stopAutoUpdaterScheduling)` | 1 |
| drop the `updaterSchedulingStopped` guard in `scheduleAutomaticUpdateCheck` | 1 |
| drop `clearUpdateCheckTimers()` from `stopAutoUpdaterScheduling` | 1 |
| drop the guard in `armUpdateCheckStallTimer` | 1 |
| drop the guard in `handleSettledUpdateCheckPromise` | 1 |
| drop `appMock.emit('will-quit')` from the shared harness | 1 |

Two of these first ablated to **0 red** because the flag and the timer-clearing each covered the other; the tests were sharpened (a direct `vi.getTimerCount()` assertion, and a result that lands after the stop) until each half was pinned on its own.

Local gates: `pnpm tc` exit 0, 0 `error TS` (run in the foreground). `oxlint` on the changed files exit 0, including the native-plugin, type-aware and React Doctor configs. `src/main/updater*` + adjacent update suites: 26 files, 336 tests, 0 failed. Shard 6/8 locally before the change: 884 files, 0 failed — the flake does not reproduce on a warm local checkout, which is consistent with the 45-second mechanism above.
