### PR TITLE
test: drive the Git contract tests, and ban vi.mock keys that name no real export

### DIFF
--- a/src/main/github/project-view/mutations.test.ts
+++ b/src/main/github/project-view/mutations.test.ts
@@ -28,14 +28,12 @@ vi.mock('./internals', () => ({
     stdout: ''
   }),
   ghExecFileAsync: ghExecFileAsyncMock,
-  rateLimitGuard: () => ({ blocked: false }),
-  noteRateLimitSpend: vi.fn(),
+
   repositoryRateLimitGuard: repositoryRateLimitGuardMock,
   noteRepositoryRateLimitSpend: noteRepositoryRateLimitSpendMock,
   projectHostAuthenticationError: projectHostAuthenticationErrorMock,
   projectGhExecOptions: (host?: string) => ({ host: host ?? 'github.com' }),
-  classifyProjectError: (stderr: string) => ({ type: 'unknown', message: stderr }),
-  rateLimitedError: () => ({ type: 'rate_limited', message: 'rate limited' }),
+
   runGraphql: runGraphqlMock,
   runRest: runRestMock,
   validateSlugArgs: (owner: string, repo: string) =>

--- a/src/main/ipc/register-core-handlers/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers/register-core-handlers.test.ts
@@ -140,7 +140,7 @@ vi.mock('electron', () => ({
   }
 }))
 
-vi.mock('../../shared/runtime-environment-store', () => ({
+vi.mock('../../../shared/runtime-environment-store', () => ({
   listEnvironments: listEnvironmentsMock
 }))
 

--- a/src/main/ipc/repos-add-linked-worktree.test.ts
+++ b/src/main/ipc/repos-add-linked-worktree.test.ts
@@ -52,7 +52,7 @@ vi.mock('../git/repo', () => ({
   searchBaseRefs: vi.fn().mockResolvedValue([])
 }))
 
-vi.mock('../repo-detection', () => ({
+vi.mock('../repo-icon-autodetect', () => ({
   detectRepoIconAndUpstream: detectRepoIconAndUpstreamMock
 }))
 

--- a/src/main/ipc/repos-remote-client-events.test.ts
+++ b/src/main/ipc/repos-remote-client-events.test.ts
@@ -30,9 +30,7 @@ vi.mock('../git/repo', () => ({
   isGitRepo: vi.fn().mockReturnValue(true),
   getRepoName: vi.fn().mockImplementation((path: string) => path.split('/').pop()),
   getBaseRefDefault: vi.fn().mockResolvedValue('origin/main'),
-  searchBaseRefs: vi.fn().mockResolvedValue([]),
-  BASE_REF_SEARCH_ARGS: ['for-each-ref'],
-  filterBaseRefSearchOutput: vi.fn().mockReturnValue([])
+  searchBaseRefs: vi.fn().mockResolvedValue([])
 }))
 
 vi.mock('./registered-worktree-roots-cache', () => ({ invalidateAuthorizedRootsCache: vi.fn() }))

--- a/src/main/ipc/repos-sparse-presets.test.ts
+++ b/src/main/ipc/repos-sparse-presets.test.ts
@@ -37,9 +37,7 @@ vi.mock('../git/repo', () => ({
   isGitRepo: vi.fn().mockReturnValue(true),
   getRepoName: vi.fn().mockImplementation((path: string) => path.split('/').pop()),
   getBaseRefDefault: vi.fn().mockResolvedValue('origin/main'),
-  searchBaseRefs: vi.fn().mockResolvedValue([]),
-  BASE_REF_SEARCH_ARGS: ['for-each-ref'],
-  filterBaseRefSearchOutput: vi.fn().mockReturnValue([])
+  searchBaseRefs: vi.fn().mockResolvedValue([])
 }))
 
 vi.mock('./registered-worktree-roots-cache', () => ({

--- a/src/main/orca-profiles/profile-cloud-org-members-service.test.ts
+++ b/src/main/orca-profiles/profile-cloud-org-members-service.test.ts
@@ -28,7 +28,6 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('./profile-cloud-session-refresh', () => ({
-  runWithFreshOrcaCloudSessionMock,
   runWithFreshOrcaCloudSession: runWithFreshOrcaCloudSessionMock
 }))
 

--- a/src/main/runtime/runtime-git-api-contract.test.ts
+++ b/src/main/runtime/runtime-git-api-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { GlobalSettings } from '../../shared/global-settings-types'
+import type { RpcContext } from './rpc/core'
 import { GIT_METHODS } from './rpc/methods/git'
 import { RuntimeGitCommands } from './orca-runtime-git'
 
@@ -41,8 +42,26 @@ const RPC_TO_RUNTIME_COMMAND = {
   'git.remoteCommitUrl': 'getRuntimeGitRemoteCommitUrl'
 } as const satisfies Record<string, keyof RuntimeGitCommands>
 
+/**
+ * Records which runtime command a handler reaches for. A Proxy rather than a stub
+ * of {@link RuntimeGitCommands} so a handler that calls a command nobody mapped is
+ * recorded instead of throwing.
+ */
+function createCommandRecorder(): { calls: string[]; runtime: RpcContext['runtime'] } {
+  const calls: string[] = []
+  const runtime = new Proxy(
+    {},
+    {
+      get: (_target, property) => () => {
+        calls.push(String(property))
+      }
+    }
+  ) as unknown as RpcContext['runtime']
+  return { calls, runtime }
+}
+
 describe('runtime Git API contract', () => {
-  it('keeps every registered Git RPC paired with one public runtime command', () => {
+  it('keeps the registered Git RPC set and the runtime command map in step', () => {
     const commands = new RuntimeGitCommands({
       resolveRuntimeGitTarget: async () => {
         throw new Error('not called')
@@ -54,6 +73,20 @@ describe('runtime Git API contract', () => {
     expect(registeredMethods).toEqual(Object.keys(RPC_TO_RUNTIME_COMMAND).sort())
     for (const commandName of Object.values(RPC_TO_RUNTIME_COMMAND)) {
       expect(commands[commandName]).toBeTypeOf('function')
+    }
+  })
+
+  // Why this drives the handlers instead of reading the map: the map is a hand-kept
+  // declaration of intent, and asserting only that its values name real methods leaves
+  // every routing in it unverified -- `git.unstage` calling `stageRuntimeGitPath` passed.
+  it('routes every registered Git RPC to the runtime command the map names', async () => {
+    for (const method of GIT_METHODS) {
+      const expected = RPC_TO_RUNTIME_COMMAND[method.name as keyof typeof RPC_TO_RUNTIME_COMMAND]
+      const { calls, runtime } = createCommandRecorder()
+
+      await method.handler({}, { runtime } as RpcContext)
+
+      expect(calls, method.name).toEqual([expected])
     }
   })
 })

--- a/src/main/ssh/ssh-relay-orphan-abandon-paths.test.ts
+++ b/src/main/ssh/ssh-relay-orphan-abandon-paths.test.ts
@@ -78,8 +78,7 @@ vi.mock('../ipc/pty', () => ({
   deletePtyOwnership: vi.fn(),
   setPtyOwnership: vi.fn(),
   restorePtyIncarnation: vi.fn(),
-  isCurrentPtyExit: vi.fn(() => true),
-  answerStartupTerminalColorQueriesForPty: vi.fn((_id: string, data: string) => data)
+  isCurrentPtyExit: vi.fn(() => true)
 }))
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({
   registerSshFilesystemProvider: vi.fn(),

--- a/src/main/ssh/ssh-relay-session-data-delivery.test.ts
+++ b/src/main/ssh/ssh-relay-session-data-delivery.test.ts
@@ -65,8 +65,6 @@ vi.mock('../agent-hooks/remote-managed-hook-installers', () => ({
 }))
 
 vi.mock('../providers/ssh-pty-provider', () => ({
-  isSshPtyNotFoundError: vi.fn().mockReturnValue(false),
-  isSshPtyIdentityMismatchError: vi.fn().mockReturnValue(false),
   SshPtyProvider: class MockSshPtyProvider {
     onData = vi.fn().mockImplementation((handler) => {
       ptyDataHandlerRef.current = handler

--- a/src/main/ssh/ssh-relay-session-incarnation.test.ts
+++ b/src/main/ssh/ssh-relay-session-incarnation.test.ts
@@ -76,8 +76,7 @@ vi.mock('../ipc/pty', () => ({
   deletePtyOwnership: vi.fn(),
   setPtyOwnership: vi.fn(),
   restorePtyIncarnation: vi.fn(),
-  isCurrentPtyExit: vi.fn(() => true),
-  answerStartupTerminalColorQueriesForPty: vi.fn((_id: string, data: string) => data)
+  isCurrentPtyExit: vi.fn(() => true)
 }))
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({
   registerSshFilesystemProvider: vi.fn(),

--- a/src/main/ssh/ssh-relay-session-managed-hooks.test.ts
+++ b/src/main/ssh/ssh-relay-session-managed-hooks.test.ts
@@ -31,8 +31,6 @@ vi.mock('./ssh-channel-multiplexer', () => ({
   }
 }))
 vi.mock('../providers/ssh-pty-provider', () => ({
-  isSshPtyNotFoundError: vi.fn(() => false),
-  isSshPtyIdentityMismatchError: vi.fn(() => false),
   SshPtyProvider: class MockSshPtyProvider {
     onData = vi.fn().mockReturnValue(() => {})
     onReplay = vi.fn().mockReturnValue(() => {})

--- a/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
+++ b/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
@@ -81,8 +81,6 @@ vi.mock('../agent-hooks/remote-managed-hook-installers', () => ({
   installRemoteManagedAgentHooks: vi.fn()
 }))
 vi.mock('../providers/ssh-pty-provider', () => ({
-  isSshPtyNotFoundError: (error: unknown) => String(error).includes('not found'),
-  isSshPtyIdentityMismatchError: (error: unknown) => String(error).includes('identity mismatch'),
   SshPtyProvider: class MockSshPtyProvider {
     onData = vi.fn().mockReturnValue(() => {})
     onReplay = vi.fn().mockReturnValue(() => {})
@@ -110,8 +108,7 @@ vi.mock('../ipc/pty', () => ({
   deletePtyOwnership: vi.fn(),
   setPtyOwnership: vi.fn(),
   restorePtyIncarnation: vi.fn(),
-  isCurrentPtyExit: vi.fn(() => true),
-  answerStartupTerminalColorQueriesForPty: vi.fn((_id: string, data: string) => data)
+  isCurrentPtyExit: vi.fn(() => true)
 }))
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({
   registerSshFilesystemProvider: vi.fn(),

--- a/src/main/ssh/ssh-relay-session-recovery-durability.test.ts
+++ b/src/main/ssh/ssh-relay-session-recovery-durability.test.ts
@@ -53,8 +53,6 @@ vi.mock('../agent-hooks/remote-managed-hook-installers', () => ({
 }))
 
 vi.mock('../providers/ssh-pty-provider', () => ({
-  isSshPtyNotFoundError: vi.fn().mockReturnValue(false),
-  isSshPtyIdentityMismatchError: vi.fn().mockReturnValue(false),
   SshPtyProvider: class MockSshPtyProvider {
     onData = vi.fn().mockReturnValue(() => {})
     onReplay = vi.fn().mockReturnValue(() => {})

--- a/src/main/ssh/ssh-relay-session-recovery-races.test.ts
+++ b/src/main/ssh/ssh-relay-session-recovery-races.test.ts
@@ -63,8 +63,6 @@ vi.mock('./ssh-channel-multiplexer', () => ({
   }
 }))
 vi.mock('../providers/ssh-pty-provider', () => ({
-  isSshPtyNotFoundError: vi.fn().mockReturnValue(false),
-  isSshPtyIdentityMismatchError: vi.fn().mockReturnValue(false),
   SshPtyProvider: class MockSshPtyProvider {
     onData = vi.fn().mockImplementation((handler) => {
       ptyDataHandlerRef.current = handler

--- a/src/main/ssh/ssh-relay-session-relay-loss.test.ts
+++ b/src/main/ssh/ssh-relay-session-relay-loss.test.ts
@@ -86,8 +86,6 @@ vi.mock('./ssh-channel-multiplexer', () => ({
 }))
 
 vi.mock('../providers/ssh-pty-provider', () => ({
-  isSshPtyNotFoundError: () => false,
-  isSshPtyIdentityMismatchError: () => false,
   SshPtyProvider: class MockSshPtyProvider {
     onData = vi.fn().mockReturnValue(() => {})
     onReplay = vi.fn().mockReturnValue(() => {})

--- a/src/main/ssh/ssh-relay-session-terminal-error.test.ts
+++ b/src/main/ssh/ssh-relay-session-terminal-error.test.ts
@@ -40,8 +40,6 @@ vi.mock('./ssh-channel-multiplexer', () => {
 })
 
 vi.mock('../providers/ssh-pty-provider', () => ({
-  isSshPtyNotFoundError: (err: unknown) =>
-    (err instanceof Error ? err.message : String(err)).includes('not found'),
   SshPtyProvider: class MockSshPtyProvider {
     onData = vi.fn().mockReturnValue(() => {})
     onReplay = vi.fn().mockReturnValue(() => {})

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -61,10 +61,6 @@ vi.mock('./ssh-channel-multiplexer', () => {
 })
 
 vi.mock('../providers/ssh-pty-provider', () => ({
-  isSshPtyNotFoundError: (err: unknown) =>
-    (err instanceof Error ? err.message : String(err)).includes('not found'),
-  isSshPtyIdentityMismatchError: (err: unknown) =>
-    (err instanceof Error ? err.message : String(err)).includes('identity mismatch'),
   SshPtyProvider: class MockSshPtyProvider {
     onData = vi.fn().mockReturnValue(() => {})
     onReplay = vi.fn().mockReturnValue(() => {})

--- a/src/renderer/src/components/browser-cookie-import-google-disclosure.test.tsx
+++ b/src/renderer/src/components/browser-cookie-import-google-disclosure.test.tsx
@@ -16,7 +16,7 @@ vi.mock('@/components/ui/dropdown-menu', () => dropdownMenuStubs())
 vi.mock('../ui/dropdown-menu', () => dropdownMenuStubs())
 vi.mock('@/components/ui/popover', () => popoverStubs())
 vi.mock('@/store', () => ({ useAppStore: appStoreStub() }))
-vi.mock('../../store', () => ({ useAppStore: appStoreStub() }))
+vi.mock('../store', () => ({ useAppStore: appStoreStub() }))
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 import { BrowserCookieImportDisclosure } from './BrowserCookieImportDisclosure'

--- a/src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts
+++ b/src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts
@@ -61,7 +61,7 @@ let transportFactoryQueue: unknown[] = []
 
 vi.mock('@/runtime/sync-runtime-graph', () => ({ scheduleRuntimeGraphSync: vi.fn() }))
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery: vi.fn()
+  scheduleImagePasteWebglAtlasRecovery: vi.fn()
 }))
 vi.mock('@/lib/codex-stale-pane-sweep', () => ({ notifyCodexPaneBoundForStaleSweep: vi.fn() }))
 vi.mock('sonner', () => ({ toast: { info: vi.fn() } }))

--- a/src/renderer/src/components/terminal-pane/pty-connection-agent-session-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-agent-session-resume.test.ts
@@ -22,14 +22,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -51,7 +51,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-cold-restore-agent-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-cold-restore-agent-resume.test.ts
@@ -21,14 +21,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -50,7 +50,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-cold-restore-repaint.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-cold-restore-repaint.test.ts
@@ -29,14 +29,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -58,7 +58,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-cold-restore-resume-command.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-cold-restore-resume-command.test.ts
@@ -22,14 +22,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -51,7 +51,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-command-finished-cleanup.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-command-finished-cleanup.test.ts
@@ -30,14 +30,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -59,7 +59,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-daemon-snapshot-replay.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-daemon-snapshot-replay.test.ts
@@ -28,14 +28,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -57,7 +57,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-deferred-reattach-live-output.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-deferred-reattach-live-output.test.ts
@@ -22,14 +22,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -51,7 +51,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-deferred-ssh-passphrase.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-deferred-ssh-passphrase.test.ts
@@ -22,14 +22,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -51,7 +51,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-reattach-retry.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-reattach-retry.test.ts
@@ -22,14 +22,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -51,7 +51,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-spawn-retry.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-spawn-retry.test.ts
@@ -18,14 +18,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -47,7 +47,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-foreground-agent-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-foreground-agent-routing.test.ts
@@ -29,14 +29,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -58,7 +58,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-foreground-agent-sampling.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-foreground-agent-sampling.test.ts
@@ -30,14 +30,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -59,7 +59,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-foreground-routing-confirmation.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-foreground-routing-confirmation.test.ts
@@ -28,14 +28,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -57,7 +57,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-foreground-write-path.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-foreground-write-path.test.ts
@@ -22,14 +22,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -51,7 +51,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts
@@ -20,14 +20,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -49,7 +49,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-hibernation-wake.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hibernation-wake.test.ts
@@ -19,14 +19,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -48,7 +48,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-hidden-atlas-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hidden-atlas-recovery.test.ts
@@ -19,14 +19,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -48,7 +48,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({
@@ -130,7 +130,7 @@ function createDeps(overrides: Record<string, unknown> = {}) {
 
 function expectNoGlobalAtlasRecovery(): void {
   // Why: the removed output path requested recovery 200ms before its global reset ran.
-  expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
+  expect(scheduleImagePasteWebglAtlasRecovery).not.toHaveBeenCalled()
   expect(resetAndRefreshAllTerminalWebglAtlases).not.toHaveBeenCalled()
 }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection-hidden-backlog-reconciliation.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hidden-backlog-reconciliation.test.ts
@@ -19,14 +19,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -48,7 +48,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-hidden-backlog-snapshot.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hidden-backlog-snapshot.test.ts
@@ -29,7 +29,7 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
@@ -37,7 +37,7 @@ const {
   presentPaneViewportPreservingSynchronizedOutput
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -65,7 +65,7 @@ vi.mock('@/lib/pane-manager/pane-webgl-renderer', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-hidden-codex-queries.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hidden-codex-queries.test.ts
@@ -26,14 +26,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -55,7 +55,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-hidden-delivery-gate.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hidden-delivery-gate.test.ts
@@ -19,14 +19,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -48,7 +48,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-hidden-output-restore.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hidden-output-restore.test.ts
@@ -20,14 +20,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -49,7 +49,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-hidden-query-snapshot-restore.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hidden-query-snapshot-restore.test.ts
@@ -18,14 +18,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -47,7 +47,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-hidden-snapshot-live-overlap.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hidden-snapshot-live-overlap.test.ts
@@ -18,14 +18,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -47,7 +47,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-hidden-snapshot-resize-signals.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hidden-snapshot-resize-signals.test.ts
@@ -18,14 +18,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -47,7 +47,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-hidden-tui-snapshot-replay.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hidden-tui-snapshot-replay.test.ts
@@ -18,14 +18,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -47,7 +47,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-hook-completion-bell-arbitration.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hook-completion-bell-arbitration.test.ts
@@ -26,14 +26,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -55,7 +55,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-hook-completion-side-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hook-completion-side-effects.test.ts
@@ -31,14 +31,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -60,7 +60,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-hook-idle-arbitration.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hook-idle-arbitration.test.ts
@@ -22,14 +22,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -51,7 +51,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-interrupt-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-interrupt-inference.test.ts
@@ -20,14 +20,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -49,7 +49,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-main-side-effect-authority.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-main-side-effect-authority.test.ts
@@ -24,14 +24,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -53,7 +53,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-mode-2031-subscriptions.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-mode-2031-subscriptions.test.ts
@@ -18,14 +18,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -47,7 +47,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-notification-settings-gating.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-notification-settings-gating.test.ts
@@ -21,14 +21,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -50,7 +50,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-parked-ssh-snapshot.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-parked-ssh-snapshot.test.ts
@@ -27,14 +27,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -56,7 +56,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
@@ -22,14 +22,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -51,7 +51,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-queued-startup-consume.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-queued-startup-consume.test.ts
@@ -17,14 +17,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -43,7 +43,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
   resetAndRefreshAllTerminalWebglAtlases
 }))
 
-vi.mock('./terminal-webgl-atlas-recovery', () => ({ scheduleTerminalWebglAtlasRecovery }))
+vi.mock('./terminal-webgl-atlas-recovery', () => ({ scheduleImagePasteWebglAtlasRecovery }))
 
 vi.mock('@/store', () => ({
   useAppStore: {

--- a/src/renderer/src/components/terminal-pane/pty-connection-reattach-binding.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-reattach-binding.test.ts
@@ -21,14 +21,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -50,7 +50,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-reattach-mode-reset.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-reattach-mode-reset.test.ts
@@ -38,14 +38,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -67,7 +67,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-remote-runtime-attach.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-remote-runtime-attach.test.ts
@@ -25,14 +25,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -54,7 +54,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-renderer-risk-repaint.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-renderer-risk-repaint.test.ts
@@ -19,14 +19,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -48,7 +48,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({
@@ -130,7 +130,7 @@ function createDeps(overrides: Record<string, unknown> = {}) {
 
 function expectNoGlobalAtlasRecovery(): void {
   // Why: the removed output path requested recovery 200ms before its global reset ran.
-  expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
+  expect(scheduleImagePasteWebglAtlasRecovery).not.toHaveBeenCalled()
   expect(resetAndRefreshAllTerminalWebglAtlases).not.toHaveBeenCalled()
 }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection-replay-payload-handling.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-replay-payload-handling.test.ts
@@ -36,14 +36,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -65,7 +65,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-restored-baseline-shortfall.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-restored-baseline-shortfall.test.ts
@@ -18,14 +18,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -45,7 +45,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-runtime-owner-spawn-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-runtime-owner-spawn-routing.test.ts
@@ -21,14 +21,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -50,7 +50,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-session-liveness.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-session-liveness.test.ts
@@ -23,14 +23,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -52,7 +52,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-setup-split-spawn.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-setup-split-spawn.test.ts
@@ -20,14 +20,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -49,7 +49,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-sleeping-resume-banner.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-sleeping-resume-banner.test.ts
@@ -20,14 +20,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -49,7 +49,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-ssh-startup-draft-delivery.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-ssh-startup-draft-delivery.test.ts
@@ -23,14 +23,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -52,7 +52,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-stalled-hidden-restore.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-stalled-hidden-restore.test.ts
@@ -20,14 +20,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -49,7 +49,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-startup-command-delivery.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-startup-command-delivery.test.ts
@@ -22,14 +22,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -51,7 +51,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-task-complete-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-task-complete-dispatch.test.ts
@@ -27,14 +27,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -56,7 +56,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-terminal-input-gating.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-terminal-input-gating.test.ts
@@ -25,14 +25,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -54,7 +54,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-typed-agent-identity.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-typed-agent-identity.test.ts
@@ -24,14 +24,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -53,7 +53,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-visibility-resume-size.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-visibility-resume-size.test.ts
@@ -19,14 +19,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -48,7 +48,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection-windows-cjk-repaint.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-windows-cjk-repaint.test.ts
@@ -22,14 +22,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -51,7 +51,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({
@@ -133,7 +133,7 @@ function createDeps(overrides: Record<string, unknown> = {}) {
 
 function expectNoGlobalAtlasRecovery(): void {
   // Why: the removed output path requested recovery 200ms before its global reset ran.
-  expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
+  expect(scheduleImagePasteWebglAtlasRecovery).not.toHaveBeenCalled()
   expect(resetAndRefreshAllTerminalWebglAtlases).not.toHaveBeenCalled()
 }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection-windows-keyboard-reset.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-windows-keyboard-reset.test.ts
@@ -26,14 +26,14 @@ import {
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
-  scheduleTerminalWebglAtlasRecovery,
+  scheduleImagePasteWebglAtlasRecovery,
   scheduleRuntimeGraphSync,
   shouldSeedCacheTimerOnInitialTitle,
   toastInfo,
   notifyCodexPaneBoundForStaleSweep
 } = vi.hoisted(() => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
-  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleImagePasteWebglAtlasRecovery: vi.fn(),
   scheduleRuntimeGraphSync: vi.fn(),
   shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
   toastInfo: vi.fn(),
@@ -55,7 +55,7 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
 }))
 
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
+  scheduleImagePasteWebglAtlasRecovery
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/runtime/runtime-git-client-api-contract.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client-api-contract.test.ts
@@ -47,4 +47,16 @@ describe('runtime Git client API contract', () => {
       expect(exported[functionName]).toBeTypeOf('function')
     }
   })
+
+  // Why the declared name and not just the type: the facade is a wall of
+  // `export const x = xImplementation` aliases with interchangeable signatures, so a
+  // swap is invisible to both `tc` and a name-plus-typeof check. Pointing
+  // `unstageRuntimeGitPath` at `stageRuntimeGitPathImplementation` stayed green across
+  // the whole renderer suite (27,021 tests).
+  it('binds every facade export to the implementation of the same name', () => {
+    const exported: Record<string, unknown> = { ...runtimeGitClient }
+    for (const functionName of PUBLIC_RUNTIME_GIT_CLIENT_FUNCTIONS) {
+      expect((exported[functionName] as { name?: string }).name, functionName).toBe(functionName)
+    }
+  })
 })

--- a/src/shared/dead-mock-key-ban.test.ts
+++ b/src/shared/dead-mock-key-ban.test.ts
@@ -1,0 +1,208 @@
+import { resolve } from 'node:path'
+import { beforeAll, describe, expect, it } from 'vitest'
+import type { parseAst as ParseAstFn } from 'vite' with { 'resolution-mode': 'import' }
+import type { AstNode, ParseProgram } from './source-scan/module-export-names'
+import { readExportedNames, resolveRelativeModule } from './source-scan/module-export-names'
+import { scanSourceTree } from './source-scan/source-tree-scan'
+
+// Dynamic import: vite is ESM-only and this file typechecks under tsconfig.tc.cli.json's node16/CJS.
+let parseAst: typeof ParseAstFn
+
+beforeAll(async () => {
+  ;({ parseAst } = await import('vite'))
+})
+
+/**
+ * Ban `vi.mock` factory keys that name nothing the mocked module exports.
+ *
+ * A key that matches no export is not a stub -- it is a comment. The module
+ * registry serves it to nobody, production keeps calling the real function, and
+ * the suite goes green for a reason its author did not intend. Nothing else
+ * catches this: it typechecks (a factory is a plain object literal), it does not
+ * warn at runtime, and the tell only shows if you make the key throw and notice
+ * that nothing happens.
+ *
+ * It found 83 such keys across 73 suites on the commit that introduced it,
+ * in seven clusters. The two largest were symbols that had been renamed or moved
+ * out of the mocked module, leaving eight SSH-relay suites and 56 terminal-pane
+ * suites each carrying a stub that had never once been reached.
+ */
+
+type MockCall = { specifier: string; keys: string[] }
+
+/** Unwraps a factory to the object literal it yields, or null if not statically known. */
+function factoryObject(node: AstNode | undefined): AstNode | null {
+  let current: AstNode | undefined = node
+  if (current?.type === 'ArrowFunctionExpression' || current?.type === 'FunctionExpression') {
+    // A concise arrow body is one node; a block body is a statement list.
+    current = Array.isArray(current.body) ? undefined : current.body
+    if (current?.type === 'BlockStatement') {
+      const statements = Array.isArray(current.body) ? current.body : []
+      current = statements.findLast((statement) => statement.type === 'ReturnStatement')?.argument
+    }
+  }
+  const TRANSPARENT = [
+    'TSAsExpression',
+    'ParenthesizedExpression',
+    'AwaitExpression',
+    'TSSatisfiesExpression'
+  ]
+  while (current && TRANSPARENT.includes(current.type)) {
+    current = current.expression ?? current.argument
+  }
+  return current?.type === 'ObjectExpression' ? current : null
+}
+
+/**
+ * Every statically readable `vi.mock`/`vi.doMock` in a file.
+ *
+ * A factory whose keys cannot all be read -- a computed key, or a returned
+ * identifier -- is dropped whole rather than half-checked, so the guard never
+ * accuses a key it did not actually see.
+ */
+function readMockCalls(program: { body: AstNode[] }): MockCall[] {
+  const calls: MockCall[] = []
+  const stack: unknown[] = [program]
+  while (stack.length > 0) {
+    const node = stack.pop()
+    if (!node || typeof node !== 'object') {
+      continue
+    }
+    if (Array.isArray(node)) {
+      stack.push(...node)
+      continue
+    }
+    const candidate = node as AstNode
+    const callee = candidate.callee
+    if (
+      candidate.type === 'CallExpression' &&
+      callee?.type === 'MemberExpression' &&
+      callee.object?.name === 'vi' &&
+      (callee.property?.name === 'mock' || callee.property?.name === 'doMock')
+    ) {
+      calls.push(...readMockCall(candidate))
+    }
+    stack.push(...Object.values(candidate as Record<string, unknown>))
+  }
+  return calls
+}
+
+function readMockCall(call: AstNode): MockCall[] {
+  const args = call.arguments ?? []
+  const target = args[0]
+  // `vi.mock(import('./x'), ...)` names its module through an import expression.
+  const specifier = target?.type === 'Literal' ? target.value : target?.source?.value
+  const object = factoryObject(args[1])
+  if (typeof specifier !== 'string' || !object) {
+    return []
+  }
+  const keys: string[] = []
+  for (const property of object.properties ?? []) {
+    // A spread carries the real module's exports through; its own keys are not ours to judge.
+    if (property.type === 'SpreadElement') {
+      continue
+    }
+    const key = property.computed ? undefined : (property.key?.name ?? property.key?.value)
+    if (typeof key !== 'string') {
+      return []
+    }
+    keys.push(key)
+  }
+  return [{ specifier, keys }]
+}
+
+describe('dead vi.mock factory keys', () => {
+  const repoRoot = resolve(__dirname, '..', '..')
+  const offenders: string[] = []
+  const phantomPaths: string[] = []
+  const unparseable: string[] = []
+  let filesScanned = 0
+  let mockCallsSeen = 0
+  let mockCallsChecked = 0
+
+  beforeAll(() => {
+    const scanned = scanSourceTree(resolve(repoRoot, 'src'), { includeTests: true })
+    filesScanned = scanned.length
+    // One pass to hold every file's text, so a mocked module is readable whether or
+    // not the walk has reached it yet.
+    const sources = new Map(scanned.map((file) => [file.path, file.source]))
+    const parse: ParseProgram = (file) =>
+      parseAst(sources.get(file) ?? '', {
+        lang: file.endsWith('.tsx') ? 'tsx' : 'ts'
+      }) as unknown as { body: AstNode[] }
+    const exportCache = new Map<string, ReturnType<typeof readExportedNames>>()
+    const exportsOf = (file: string): ReturnType<typeof readExportedNames> => {
+      const cached = exportCache.get(file)
+      if (cached) {
+        return cached
+      }
+      const read = readExportedNames(file, parse)
+      exportCache.set(file, read)
+      return read
+    }
+
+    for (const file of scanned) {
+      if (!/vi\.(?:mock|doMock)\s*\(/.test(file.source)) {
+        continue
+      }
+      let program: { body: AstNode[] }
+      try {
+        program = parse(file.path)
+      } catch {
+        // Fail closed: a file the guard cannot read is not a file the guard cleared.
+        unparseable.push(file.relativePath)
+        continue
+      }
+      for (const call of readMockCalls(program)) {
+        mockCallsSeen += 1
+        const target = resolveRelativeModule(file.path, call.specifier)
+        if (!target) {
+          // A relative path that resolves to nothing is the same bug one level up:
+          // the whole factory is dead, not just a key. `?asset`-style specifiers are
+          // resolved by a bundler plugin, not by the filesystem, so they are exempt.
+          if (call.specifier.startsWith('.') && !call.specifier.includes('?')) {
+            phantomPaths.push(`${file.relativePath}: vi.mock('${call.specifier}')`)
+          }
+          continue
+        }
+        const { names, complete } = exportsOf(target)
+        if (!complete) {
+          continue
+        }
+        mockCallsChecked += 1
+        for (const key of call.keys.filter((name) => !names.has(name))) {
+          offenders.push(`${file.relativePath}: vi.mock('${call.specifier}') key '${key}'`)
+        }
+      }
+    }
+  })
+
+  it('scans a plausible amount of the tree', () => {
+    // Counting what the filter saw, not just what it reported: a broken walk or a
+    // regressed AST shape would make every assertion below vacuously green.
+    expect(filesScanned).toBeGreaterThan(5000)
+    expect(mockCallsSeen).toBeGreaterThan(2000)
+    expect(mockCallsChecked).toBeGreaterThan(1000)
+  })
+
+  it('parses every file that mocks a module', () => {
+    expect(unparseable).toEqual([])
+  })
+
+  it('mocks no relative path that resolves to no module', () => {
+    expect(
+      phantomPaths,
+      'This vi.mock names a relative path with no module behind it, so the whole factory is ' +
+        'inert and the real module loads. Correct the path.'
+    ).toEqual([])
+  })
+
+  it('has no factory key that the mocked module does not export', () => {
+    expect(
+      offenders,
+      'This vi.mock key matches no export of that module, so the mock never applies and the ' +
+        'real implementation runs. Point it at the module that actually exports the symbol, ' +
+        'fix the name, or delete the key.'
+    ).toEqual([])
+  })
+})

--- a/src/shared/source-scan/module-export-names.ts
+++ b/src/shared/source-scan/module-export-names.ts
@@ -1,0 +1,145 @@
+import { existsSync, statSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+
+/**
+ * The set of names a module actually exports, read from its source.
+ *
+ * Why source and not a dynamic import: the modules a test mocks are the ones
+ * with side effects at import time -- Electron handles, native bindings, a
+ * relay socket -- so importing them to enumerate their exports is exactly what
+ * the mock existed to avoid.
+ */
+
+export type AstNode = {
+  type: string
+  name?: string
+  value?: unknown
+  computed?: boolean
+  declaration?: AstNode
+  declarations?: { id?: { name?: string } }[]
+  specifiers?: { exported?: { name?: string; value?: string } }[]
+  exported?: { name?: string } | null
+  source?: { value?: string }
+  id?: { name?: string }
+  key?: { name?: string; value?: unknown }
+  properties?: AstNode[]
+  arguments?: AstNode[]
+  callee?: AstNode
+  object?: AstNode
+  property?: AstNode
+  expression?: AstNode
+  argument?: AstNode
+  /** An array on a Program or BlockStatement, a single node on a concise arrow body. */
+  body?: AstNode | AstNode[]
+}
+
+export type ParseProgram = (filePath: string) => { body: AstNode[] }
+
+/** Extensions tried for a relative specifier, in resolution order. */
+const CANDIDATE_SUFFIXES = ['.ts', '.tsx', '/index.ts', '/index.tsx']
+
+/**
+ * A relative specifier resolved to a file in the tree, or null.
+ *
+ * Bare specifiers return null on purpose: a package's exports are not ours to
+ * read, and guessing at them would be the wrong kind of confident.
+ */
+export function resolveRelativeModule(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith('.')) {
+    return null
+  }
+  // A `.js` specifier is the TS `node16` spelling of a `.ts` file on disk.
+  const base = resolve(dirname(fromFile), specifier.replace(/\.js$/, ''))
+  if (existsSync(base) && statSync(base).isFile()) {
+    return base
+  }
+  return CANDIDATE_SUFFIXES.map((suffix) => base + suffix).find((path) => existsSync(path)) ?? null
+}
+
+export type ModuleExports = {
+  names: Set<string>
+  /**
+   * False when some export could not be enumerated -- an unparseable file, a
+   * destructured `export const`, or an `export *` through a package. Callers
+   * must skip an incomplete module rather than report its keys as unknown,
+   * because a partial set turns every real export it missed into a false
+   * accusation.
+   */
+  complete: boolean
+}
+
+function collectDeclarationNames(declaration: AstNode, into: ModuleExports): void {
+  if (declaration.type === 'VariableDeclaration') {
+    for (const declarator of declaration.declarations ?? []) {
+      if (declarator.id?.name) {
+        into.names.add(declarator.id.name)
+      } else {
+        into.complete = false
+      }
+    }
+    return
+  }
+  if (declaration.id?.name) {
+    into.names.add(declaration.id.name)
+    return
+  }
+  into.complete = false
+}
+
+/** Follows `export * from './x'` so a barrel reports what it really re-exports. */
+export function readExportedNames(
+  file: string,
+  parse: ParseProgram,
+  seen = new Set<string>()
+): ModuleExports {
+  if (seen.has(file)) {
+    return { names: new Set(), complete: true }
+  }
+  seen.add(file)
+  let program: { body: AstNode[] }
+  try {
+    program = parse(file)
+  } catch {
+    return { names: new Set(), complete: false }
+  }
+  const result: ModuleExports = { names: new Set(), complete: true }
+  for (const statement of program.body) {
+    if (statement.type === 'ExportDefaultDeclaration') {
+      result.names.add('default')
+      continue
+    }
+    if (statement.type === 'ExportNamedDeclaration') {
+      if (statement.declaration) {
+        collectDeclarationNames(statement.declaration, result)
+      }
+      for (const specifier of statement.specifiers ?? []) {
+        const name = specifier.exported?.name ?? specifier.exported?.value
+        if (name) {
+          result.names.add(name)
+        } else {
+          result.complete = false
+        }
+      }
+      continue
+    }
+    if (statement.type !== 'ExportAllDeclaration') {
+      continue
+    }
+    // `export * as ns from '...'` contributes one name, not the target's set.
+    if (statement.exported?.name) {
+      result.names.add(statement.exported.name)
+      continue
+    }
+    const target = resolveRelativeModule(file, statement.source?.value ?? '')
+    if (!target) {
+      result.complete = false
+      continue
+    }
+    const reExported = readExportedNames(target, parse, seen)
+    for (const name of reExported.names) {
+      result.names.add(name)
+    }
+    result.complete &&= reExported.complete
+  }
+  return result
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 76 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​433 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​208 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​225 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​145 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​145 |

<!-- /orca-pr-loc -->

## ELI5

Tests fake out modules with `vi.mock('./thing', () => ({ doStuff: fake }))`. Vitest matches those keys by name against what `./thing` really exports. If the name doesn't match — the function moved, got renamed, or never existed — the fake is quietly ignored. The test still passes, but it's passing with the *real* code running, not the fake. Nothing tells you: it typechecks fine, there's no runtime warning.

This PR adds a test that reads every `vi.mock` in the repo and checks each key against that module's actual exports. It found **86 fakes that had never once been used**, across 73 test files.

It also strengthens two Git contract tests that were checking *names* instead of *behaviour*.

## User-facing before/after

**This is a test-only PR — no shipped code changes, so the user-facing effect is indirect.** What changes is the class of bug that can now reach a release.

| | Before | After |
|---|---|---|
| A Git RPC wired to the wrong runtime command | Green. `git.unstage` calling the *stage* implementation passed the whole main suite, and typecheck is blind because the signatures are identical. | Red, naming the method and both commands. |
| A renderer Git facade export aliased to the wrong implementation | Green. `unstageRuntimeGitPath` pointing at `stageRuntimeGitPathImplementation` passed the whole renderer suite. | Red, naming the export. |
| A `vi.mock` key that names nothing the module exports | Green forever. The suite silently exercises production code it believed it had stubbed. | Red, naming the file, module, and key. |

Concretely: "un-stage a file actually stages it" is a bug a user would hit immediately, and every test that claimed to cover that routing would still have been green. That's now caught.

## What the guards do

**1. Git RPC contract** — the old test compared two name sets. It never called anything. Now all 35 handlers run against a `Proxy` runtime that records which command each one actually reaches, and that is compared to the map.

**2. Renderer Git facade** — the facade is a wall of `export const x = xImplementation` aliases with interchangeable signatures, so a swap is invisible to both `tc` and a `typeof` check. Now every export's `Function.name` must equal its export name.

**3. Dead-mock-key ban** (`src/shared/dead-mock-key-ban.test.ts`) — parses every `vi.mock` factory with the same oxc parser the bundler uses, resolves the mocked module, and compares keys to its real exports (following `export *`). It also flags a relative path with no module behind it at all.

## What it convicted

| Count | Key | Mocked on | Really lives in |
|---|---|---|---|
| 56 | `scheduleTerminalWebglAtlasRecovery` | `terminal-webgl-atlas-recovery` | nowhere — renamed to `scheduleImagePasteWebglAtlasRecovery` |
| 8 | `isSshPtyNotFoundError` | `ssh-pty-provider` | `ssh-pty-errors` |
| 7 | `isSshPtyIdentityMismatchError` | `ssh-pty-provider` | `ssh-pty-errors` |
| 3 | `answerStartupTerminalColorQueriesForPty` | `ipc/pty` | nowhere in `src/` |
| 4 | `BASE_REF_SEARCH_ARGS`, `filterBaseRefSearchOutput` | `git/repo` | nowhere in `src/` |
| 2 | `classifyProjectError`, `rateLimitedError` | `project-view/internals` | `project-view/project-error-classification` |
| 2 | `noteRateLimitSpend`, `rateLimitGuard` | `project-view/internals` | `github/rate-limit` |
| 1 | `runWithFreshOrcaCloudSessionMock` | `profile-cloud-session-refresh` | typo — stray `Mock` suffix |
| 3 | *(whole factory)* | `../repo-detection`, `../../shared/runtime-environment-store`, `../../store` | paths with no module behind them |

The webgl cluster is the sharpest case: `terminal-webgl-atlas-recovery`'s own test **already asserted** the module must not export `scheduleTerminalWebglAtlasRecovery`. 56 suites went on mocking that name anyway. Both facts sat in the repo; nothing connected them.

## How each fix was chosen

- **Renamed symbol** → repointed at the real export.
- **Exists nowhere** → key deleted.
- **Lives in a different module** → key deleted, not moved. Deleting is behaviour-preserving by construction: the real implementation was already the one running. Moving it would *activate* a stub for the first time, and several of those stubs return a constant `false` where the real predicate is a regex — a behaviour change that needs a human decision, not a mechanical sweep. Flagged below.
- **Wrong path** → path corrected; all three suites pass with the mock now live.

## Verification

Every claim here was re-proven on this branch, not inherited.

**Failing-first, one mutation at a time, mutation verified applied, restored between runs, run serially:**

| Ablation | Result |
|---|---|
| `git.unstage` → `stageRuntimeGitPath` | guard **red**, names both commands. Old set-only test still **passed** — the vacuity reproduced. |
| same sabotage under `pnpm tc:node` | **exit 0, 0 errors** — typecheck confirmed blind |
| facade `unstageRuntimeGitPath` → `stageRuntimeGitPathImplementation` | guard **red**, names the export |
| reintroduce the original dead mock key | **red** |
| a brand-new dead key in an untouched file | **red** |
| a near-miss typo of a *real* export (`isGitRepoo`) | **red** — second ablation shape |
| point the tree walk at an empty subtree | **red** — vacuity guard has teeth |
| revert one phantom path | **red** |
| remove the `?asset` exemption | **red** on 8 asset mocks — the exemption is load-bearing |

**The dead-mock tell** — every convicted key was rewritten as a throwing getter and the affected suites re-run. All stayed green, which is the proof they were never reached:

| Cluster | Suites | Tests green with the mock throwing |
|---|---|---|
| `scheduleTerminalWebglAtlasRecovery` | 56 | 634 |
| `isSshPtyNotFoundError` | 8 | 100 |
| `isSshPtyIdentityMismatchError` | 7 | 96 |
| others | 12 | 78 |

**Positive control:** the same throwing-getter mutation applied to a key that *is* a real export and *is* reached (`SshPtyProvider`) went **red**. The tell discriminates; it isn't just always-green.

**Coverage, measured rather than assumed** — 17,252 files walked, 10,556 `vi.mock` calls seen, 3,646 fully checked. The rest are skipped for stated reasons: 3,880 bare/aliased specifiers, 3,019 factories whose keys aren't statically readable, 11 unresolvable paths. The guard asserts these counts so a broken walk can't make it vacuously green.

**Gates:** `pnpm tc` **exit 0, 0 errors** (foreground). All 74 modified suites: **74 files / 791 tests passing**. `oxlint` clean on all 75 changed files, default and react-doctor configs.

## Known limitations, stated rather than hidden

- **Aliased and bare specifiers aren't checked** (3,880 calls, ~37%). `vi.mock('@/store', ...)` resolves through the vite alias config, which this guard doesn't read. That's the obvious next widening.
- **The incomplete-export skip is currently inert.** Ablating it reddens nothing, because zero mocked modules in the tree presently have an unenumerable export set. It's kept as a correctness valve for the first `export * from '<package>'`, not because it's load-bearing today. Called out so nobody reads its green as proof.
- **`src/main/ipc/ssh-ipc-module-mocks.ts` builds mock factories indirectly**, as object literals consumed by 10 suites. A static per-file scan can't follow that, and it carries the same dead `isSshPtyNotFoundError` key (line ~180). Not fixed here.

## Follow-ups for a human, not a sweep

Three deleted keys look like *intended* stubs that never took effect. Deleting them preserved today's behaviour, but someone should decide whether the intent should be restored:

1. **`runWithFreshOrcaCloudSessionMock`** — a stray duplicate beside the correct `runWithFreshOrcaCloudSession` key, which is live. Almost certainly harmless.
2. **The SSH error predicates.** Several suites stubbed them to a constant `false`, or to `String(e).includes('not found')`. The real `isSshPtyNotFoundError` is a regex over `PTY ".+" not found`. Any suite that *meant* to force that predicate has never been doing so — its assertions pass under the real implementation, which may or may not be what it intended to test.
3. **`classifyProjectError` / `rateLimitedError` / `noteRateLimitSpend` / `rateLimitGuard`** — mocked on `./internals` but exported by `project-error-classification` and `github/rate-limit`. Note `rateLimitGuard` sits beside a live `repositoryRateLimitGuard`, so these read as superseded names rather than active intent.
