### PR TITLE
test(e2e): stop reading a missing worktree row as an empty tab list

### DIFF
--- a/tests/e2e/helpers/worktree-tab-settlement.ts
+++ b/tests/e2e/helpers/worktree-tab-settlement.ts
@@ -1,0 +1,75 @@
+/**
+ * Reading a worktree's tab row without turning "no row yet" into "no tabs".
+ *
+ * `tabsByWorktree` has no entry for a worktree the client has not placed yet. A cold launch, a
+ * stalled host snapshot and a profile that has never held the workspace all sit in that state for
+ * a while. Reading it as an empty array makes an unanswered question look like a confident answer,
+ * and a settle loop then agrees with itself about a tab set it never actually saw.
+ */
+
+/** Either the client has a row for this worktree, or it does not. Those are different facts. */
+export type WorktreeTabObservation = { present: false } | { present: true; tabIds: string[] }
+
+/** What `page.evaluate` hands back: the row's tab ids, or `null` for "no row". */
+export type WorktreeTabRow = string[] | null
+
+export function toWorktreeTabObservation(row: WorktreeTabRow): WorktreeTabObservation {
+  return row === null ? { present: false } : { present: true, tabIds: row }
+}
+
+export function describeWorktreeTabObservation(observation: WorktreeTabObservation): string {
+  return observation.present ? `tabs=[${observation.tabIds.join(' ')}]` : 'no worktree row'
+}
+
+/**
+ * A stable key per observation. `absent` can never collide with a present-but-empty row, which is
+ * the collision that let the settle loop below count an unanswered read as an agreement.
+ */
+export function worktreeTabObservationKey(observation: WorktreeTabObservation): string {
+  return observation.present ? `present:${observation.tabIds.join(' ')}` : 'absent'
+}
+
+export type WorktreeTabSettleOptions = {
+  /**
+   * Whether a missing row can end the wait. `true` for a workspace the client is expected to hold
+   * — there the absence is the thing still loading, never the answer. `false` where "this client
+   * holds nothing for that worktree" is itself a legitimate resting state.
+   */
+  requirePresentRow: boolean
+}
+
+export type WorktreeTabSettleTracker = {
+  /** Feeds one poll in and returns how many consecutive agreeing observations have accrued. */
+  observe(observation: WorktreeTabObservation): number
+  /** The most recent observation. */
+  latest(): WorktreeTabObservation
+}
+
+export function createWorktreeTabSettleTracker(
+  options: WorktreeTabSettleOptions
+): WorktreeTabSettleTracker {
+  // Why null and not '': every observation has a key, so no first poll can agree with the seed.
+  let previousKey: string | null = null
+  let agreements = 0
+  let latest: WorktreeTabObservation = { present: false }
+
+  return {
+    observe(observation) {
+      latest = observation
+      const key = worktreeTabObservationKey(observation)
+      if (options.requirePresentRow && !observation.present) {
+        // Not an answer, so it cannot accrue agreement — but it is still what we last saw, so a
+        // row that appears next poll reads as a change rather than as more of the same.
+        previousKey = key
+        agreements = 0
+        return 0
+      }
+      agreements = key === previousKey ? agreements + 1 : 0
+      previousKey = key
+      return agreements
+    },
+    latest() {
+      return latest
+    }
+  }
+}

--- a/tests/e2e/helpers/worktree-tab-settlement.unit.test.ts
+++ b/tests/e2e/helpers/worktree-tab-settlement.unit.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createWorktreeTabSettleTracker,
+  toWorktreeTabObservation,
+  worktreeTabObservationKey,
+  type WorktreeTabObservation
+} from './worktree-tab-settlement'
+
+/** The settle loop calls the tracker once per poll and stops at three agreements. */
+const AGREEMENTS_TO_SETTLE = 3
+
+const ABSENT: WorktreeTabObservation = { present: false }
+const EMPTY: WorktreeTabObservation = { present: true, tabIds: [] }
+const THREE: WorktreeTabObservation = { present: true, tabIds: ['a', 'b', 'c'] }
+
+function agreementsFor(
+  observations: WorktreeTabObservation[],
+  requirePresentRow: boolean
+): number[] {
+  const tracker = createWorktreeTabSettleTracker({ requirePresentRow })
+  return observations.map((observation) => tracker.observe(observation))
+}
+
+describe('worktree tab observations', () => {
+  it('does not turn a missing row into an empty one', () => {
+    expect(toWorktreeTabObservation(null)).toEqual({ present: false })
+    expect(toWorktreeTabObservation([])).toEqual({ present: true, tabIds: [] })
+  })
+
+  it('keys a missing row apart from a row holding no tabs', () => {
+    expect(worktreeTabObservationKey(ABSENT)).not.toBe(worktreeTabObservationKey(EMPTY))
+  })
+
+  it('gives every observation a non-empty key, so no seed value can collide with one', () => {
+    for (const observation of [ABSENT, EMPTY, THREE]) {
+      expect(worktreeTabObservationKey(observation)).not.toBe('')
+    }
+  })
+})
+
+describe('worktree tab settle tracker', () => {
+  it('never settles on a missing row when the row is required', () => {
+    // Four polls of nothing. The old helper answered "zero tabs" after three of these.
+    expect(agreementsFor([ABSENT, ABSENT, ABSENT, ABSENT], true)).toEqual([0, 0, 0, 0])
+  })
+
+  it('settles on a row that holds no tabs when a missing row is a legitimate rest', () => {
+    expect(agreementsFor([ABSENT, ABSENT, ABSENT, ABSENT], false)).toEqual([0, 1, 2, 3])
+  })
+
+  it('charges the first poll nothing, so three agreements mean three agreeing polls', () => {
+    // The seed used to be '', which is what an empty tab list serialised to — so an empty
+    // workspace was handed one agreement for free and settled a whole poll early.
+    const [first] = agreementsFor([EMPTY, EMPTY, EMPTY, EMPTY], true)
+    expect(first).toBe(0)
+    expect(agreementsFor([EMPTY, EMPTY, EMPTY, EMPTY], true)).toEqual([0, 1, 2, 3])
+  })
+
+  it('treats a row appearing as a change, not as more of the same', () => {
+    // Collapse absent into empty and this reads as four agreeing polls of "no tabs".
+    expect(agreementsFor([ABSENT, EMPTY, EMPTY, EMPTY], false)).toEqual([0, 0, 1, 2])
+  })
+
+  it('needs the same three agreements once the row is populated', () => {
+    const agreements = agreementsFor([ABSENT, THREE, THREE, THREE, THREE], true)
+    expect(agreements).toEqual([0, 0, 1, 2, 3])
+    expect(agreements.filter((count) => count >= AGREEMENTS_TO_SETTLE)).toHaveLength(1)
+  })
+
+  it('reports the observation it settled on', () => {
+    const tracker = createWorktreeTabSettleTracker({ requirePresentRow: true })
+    tracker.observe(ABSENT)
+    expect(tracker.latest()).toEqual(ABSENT)
+    tracker.observe(THREE)
+    expect(tracker.latest()).toEqual(THREE)
+  })
+})

--- a/tests/e2e/ssh-cold-hydration-gap-tab-seeding.spec.ts
+++ b/tests/e2e/ssh-cold-hydration-gap-tab-seeding.spec.ts
@@ -13,6 +13,12 @@ import {
 } from './helpers/docker-ssh-relay-target'
 import { connectDockerSshRelayTarget } from './helpers/docker-ssh-relay-connection'
 import { createRestartSession } from './helpers/orca-restart'
+import {
+  createWorktreeTabSettleTracker,
+  describeWorktreeTabObservation,
+  toWorktreeTabObservation,
+  type WorktreeTabObservation
+} from './helpers/worktree-tab-settlement'
 
 const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
 const BASELINE_TAB_COUNT = 3
@@ -21,10 +27,22 @@ const REMOTE_SNAPSHOT_DIR = '/root/.orca/sessions'
 
 test.use({ seedTestRepo: false })
 
-async function readWorktreeTabIds(page: Page, worktreeId: string): Promise<string[]> {
-  return page.evaluate(
-    (id) => (window.__store?.getState().tabsByWorktree[id] ?? []).map((tab) => tab.id),
-    worktreeId
+/**
+ * Reads the worktree's tab row, or reports that there is no row.
+ *
+ * `null` and `[]` are different answers here: the client has not placed this workspace yet versus
+ * it has and the workspace holds nothing. Collapsing them is what let the settle loop below call
+ * a cold launch "zero tabs".
+ */
+async function readWorktreeTabs(page: Page, worktreeId: string): Promise<WorktreeTabObservation> {
+  return toWorktreeTabObservation(
+    await page.evaluate((id) => {
+      const tabsByWorktree = window.__store?.getState().tabsByWorktree
+      if (!tabsByWorktree || !Object.hasOwn(tabsByWorktree, id)) {
+        return null
+      }
+      return tabsByWorktree[id].map((tab) => tab.id)
+    }, worktreeId)
   )
 }
 
@@ -42,24 +60,37 @@ async function readTargetSyncPhase(page: Page, targetId: string): Promise<string
   )
 }
 
-/** Poll until the worktree's tabs stop changing, so a late seed cannot slip past the sample. */
-async function waitForSettledTabIds(page: Page, worktreeId: string): Promise<string[]> {
-  let latest: string[] = []
-  let previousKey = ''
-  let agreements = 0
+/**
+ * Poll until the worktree's tabs stop changing, so a late seed cannot slip past the sample.
+ *
+ * `requirePresentRow` says whether a missing row may end the wait. Where the client is expected to
+ * hold this workspace, it may not: the absence is the thing still loading.
+ */
+async function waitForSettledTabs(
+  page: Page,
+  worktreeId: string,
+  options: { requirePresentRow: boolean }
+): Promise<WorktreeTabObservation> {
+  const tracker = createWorktreeTabSettleTracker(options)
   await expect
-    .poll(
-      async () => {
-        latest = await readWorktreeTabIds(page, worktreeId)
-        const key = latest.join()
-        agreements = key === previousKey ? agreements + 1 : 0
-        previousKey = key
-        return agreements
-      },
-      { timeout: 60_000, intervals: [1_000], message: 'the tab set never stopped changing' }
-    )
+    .poll(async () => tracker.observe(await readWorktreeTabs(page, worktreeId)), {
+      timeout: 60_000,
+      intervals: [1_000],
+      message: options.requirePresentRow
+        ? 'the worktree never held a settled tab row'
+        : 'the tab set never stopped changing'
+    })
     .toBeGreaterThanOrEqual(3)
-  return latest
+  return tracker.latest()
+}
+
+/** The settled tab ids, for a call site that has already established the row must be there. */
+async function waitForSettledTabIds(page: Page, worktreeId: string): Promise<string[]> {
+  const settled = await waitForSettledTabs(page, worktreeId, { requirePresentRow: true })
+  if (!settled.present) {
+    throw new Error(`the worktree row for ${worktreeId} never arrived`)
+  }
+  return settled.tabIds
 }
 
 function findRemoteSnapshotPath(target: DockerSshRelayTarget): string | null {
@@ -127,8 +158,10 @@ async function connectAndSeedTabs(
   await expect.poll(() => waitForActiveWorktree(page), { timeout: 30_000 }).toBe(remote.worktreeId)
   await waitForActiveTerminalManager(page, 60_000)
   await waitForActivePanePtyId(page, 60_000)
-  while ((await readWorktreeTabIds(page, remote.worktreeId)).length < BASELINE_TAB_COUNT) {
+  let seeded = await readWorktreeTabs(page, remote.worktreeId)
+  while (!seeded.present || seeded.tabIds.length < BASELINE_TAB_COUNT) {
     await createRemoteTerminalTab(page, remote.worktreeId)
+    seeded = await readWorktreeTabs(page, remote.worktreeId)
   }
   return { ...remote, tabIds: await waitForSettledTabIds(page, remote.worktreeId) }
 }
@@ -262,13 +295,18 @@ test.describe('SSH cold hydration gap tab seeding', () => {
           message: 'the fresh client never reported the unplaced snapshot as a conflict'
         })
         .toBe('conflict')
-      const rejoinedTabIds = await waitForSettledTabIds(freshLaunch.page, rejoined.worktreeId)
+      // Why not requirePresentRow: a client that never held this workspace legitimately has no row
+      // at all, and the fix under test is that it must not conjure one.
+      const rejoinedTabs = await waitForSettledTabs(freshLaunch.page, rejoined.worktreeId, {
+        requirePresentRow: false
+      })
+      const rejoinedTabIds = rejoinedTabs.present ? rejoinedTabs.tabIds : []
       const hydrated = await isTargetHydrated(freshLaunch.page, rejoined.targetId)
       // Re-read after settling: a conflict verdict that a later apply flips back would re-authorise
       // seeding, so the phase has to still hold once the tab set has stopped moving.
       const settledPhase = await readTargetSyncPhase(freshLaunch.page, rejoined.targetId)
       console.log(
-        `[unplaced-host-tabs] hydrated=${hydrated} phase=${settledPhase} tabs=${rejoinedTabIds.length}`
+        `[unplaced-host-tabs] hydrated=${hydrated} phase=${settledPhase} ${describeWorktreeTabObservation(rejoinedTabs)}`
       )
 
       // STA-3593. The host listed three tabs on paths this client cannot place. Adoption still
@@ -288,9 +326,9 @@ test.describe('SSH cold hydration gap tab seeding', () => {
         'the unplaced verdict has to survive settling, or authority is re-authorised to seed'
       ).toBe('conflict')
       expect(
-        rejoinedTabIds.length,
-        `authority stays unverifiable, so no tab may be seeded: got ${rejoinedTabIds.length}`
-      ).toBe(0)
+        rejoinedTabIds,
+        `authority stays unverifiable, so no tab may be seeded: ${describeWorktreeTabObservation(rejoinedTabs)}`
+      ).toEqual([])
     } finally {
       if (freshApp) {
         await fresh.close(freshApp)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​216 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​26 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​190 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

The test asks the app "which tabs does this workspace have?" and waits until the answer stops changing. But there are two different ways to get "none": the app has a list for that workspace and the list is empty, or the app **has no list for that workspace yet** because it is still loading. The helper treated those as the same answer, wrote both down as `[]`, and then agreed with itself.

It also started out believing it had already seen `[]` before the first poll, so an empty workspace got one agreement handed to it for free and the wait ended a whole second early.

This PR makes "no row yet" and "a row with nothing in it" two different answers, and lets each caller say which one it means.

## What the user sees

Nothing — this is test infrastructure. What it changes is what CI tells you:

| | Before | After |
|---|---|---|
| Cold launch where the worktree row lands late | the helper reports `tabs changed inside the stall window: baseline=3 duringStall=0` and the spec fails, blaming tab seeding | the helper keeps waiting for the row and, if it never arrives, fails with `the worktree never held a settled tab row` |
| A client that legitimately holds no row | indistinguishable from the case above | stated explicitly at the call site, and printed as `no worktree row` rather than `tabs=0` |

## The coercion

```ts
// before
(id) => (window.__store?.getState().tabsByWorktree[id] ?? []).map((tab) => tab.id)
```

`tabsByWorktree` has no entry for a worktree the client has not placed yet. `?? []` turns that into a confident empty answer.

The settle loop then compounded it:

```ts
let previousKey = ''            // ← what an empty tab list serialises to
...
const key = latest.join()       // ← '' for both "absent" and "empty"
agreements = key === previousKey ? agreements + 1 : 0
```

The first poll of an empty (or absent) workspace already "agreed" with the seed. Traces from the convicting lane match exactly: **4 polls / 3.01 s** when the row was populated, **3 polls / 2.01 s** when it was not — one poll and one second short.

## The fix

`tests/e2e/helpers/worktree-tab-settlement.ts`:

- `WorktreeTabObservation` is `{ present: false }` or `{ present: true; tabIds }`. The `page.evaluate` returns `null` when `Object.hasOwn(tabsByWorktree, id)` is false, and `toWorktreeTabObservation` is the only place that maps it.
- `worktreeTabObservationKey` namespaces the present case (`present:…`), so `absent` can never collide with an empty row.
- `createWorktreeTabSettleTracker({ requirePresentRow })` seeds from `null`, and under `requirePresentRow` a missing row can never accrue agreement — the absence is the thing still loading, not the answer.

Call sites now state their intent: the restored workspace and the freshly seeded one require a row; the client that has never held this workspace does not, because there the absent row **is** the assertion.

## Proof

`tests/e2e/helpers/worktree-tab-settlement.unit.test.ts` — 9 tests, and it runs in the ordinary unit shard (`tests/e2e/**/*.unit.test.ts` is in `config/vitest.config.ts`), not only in the Docker-gated SSH lane.

Ablations, one mutation at a time, mutation verified applied, tree restored between runs, run serially:

| Ablation | Failing tests (of 9) |
|---|---|
| `toWorktreeTabObservation` maps `null` back to `{ present: true, tabIds: [] }` | 1 |
| seed `previousKey` with `''` instead of `null` | **0** |
| drop the `requirePresentRow` branch from the tracker | 1 |
| `worktreeTabObservationKey` returns the bare `join()` (`''` for absent) | 3 |

The `''` seed ablates to 0 red, and that is a real finding rather than a gap I am hiding: the key namespacing already makes `''` unreachable as an observation key, so the seed is belt-and-braces. `gives every observation a non-empty key, so no seed value can collide with one` pins the assumption the seed rests on, and it is one of the three that the key ablation reds.

The two ablations that matter for the brief — collapsing absent into empty at the reader, and collapsing them at the key — both go red. A test that passes with those collapsed would pin nothing.

Local gates: `pnpm tc` exit 0, 0 `error TS` (foreground). `oxlint` on the three changed files exit 0. `tests/e2e/helpers`: 12 files, 56 tests, 0 failed.

The Docker-SSH spec itself only runs in the targeted `e2e` lane (the shards set no `ORCA_E2E_SSH_DOCKER`), so the helper's unit coverage is what guards this on every PR.
