### PR TITLE
fix(browser): accept an empty --value in cookie set and --pass in set credentials

### DIFF
--- a/src/cli/browser-cookie-credentials-empty-value.test.ts
+++ b/src/cli/browser-cookie-credentials-empty-value.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.fn()
+
+vi.mock('./runtime-client', () => {
+  class RuntimeClient {
+    call = callMock
+    getCliStatus = vi.fn()
+    openOrca = vi.fn()
+  }
+
+  class RuntimeClientError extends Error {
+    readonly code: string
+
+    constructor(code: string, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+
+  class RuntimeRpcFailureError extends RuntimeClientError {
+    readonly response: unknown
+
+    constructor(response: unknown) {
+      super('runtime_error', 'runtime_error')
+      this.response = response
+    }
+  }
+
+  return {
+    RuntimeClient,
+    RuntimeClientError,
+    RuntimeRpcFailureError
+  }
+})
+
+import { main } from './index'
+import { okFixture, queueFixtures } from './test-fixtures'
+
+// Why: CookieSet.value and SetCredentials.pass accept any string, empty included,
+// while name and user require a non-empty one.
+describe('orca cli cookie set and set credentials preserve an empty value', () => {
+  beforeEach(() => {
+    callMock.mockReset()
+    process.exitCode = undefined
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('passes an empty --value through to browser.cookie.set', async () => {
+    queueFixtures(callMock, okFixture('req_cookie_set', { success: true }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['cookie', 'set', '--name', 'sid', '--value', '', '--worktree', 'all', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.cookie.set', {
+      name: 'sid',
+      value: '',
+      worktree: undefined
+    })
+  })
+
+  it('passes an empty --pass through to browser.setCredentials', async () => {
+    queueFixtures(callMock, okFixture('req_set_credentials', { success: true }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['set', 'credentials', '--user', 'token', '--pass', '', '--worktree', 'all', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.setCredentials', {
+      user: 'token',
+      pass: '',
+      worktree: undefined
+    })
+  })
+
+  it('still rejects an empty --name before RPC dispatch', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      ['cookie', 'set', '--name', '', '--value', 'x', '--worktree', 'all'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain('Missing required --name')
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
+  it('still rejects a missing --pass before RPC dispatch', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      ['set', 'credentials', '--user', 'token', '--worktree', 'all'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain('Missing required --pass')
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+})

--- a/src/cli/handlers/browser-cookie.ts
+++ b/src/cli/handlers/browser-cookie.ts
@@ -5,7 +5,11 @@ import type {
 } from '../../shared/runtime-types'
 import type { CommandHandler } from '../dispatch'
 import { printResult } from '../format'
-import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
+import {
+  getOptionalStringFlag,
+  getRequiredStringFlag,
+  getRequiredStringFlagAllowingEmpty
+} from '../flags'
 import { RuntimeClientError } from '../runtime-client'
 import { getBrowserCommandTarget } from '../selectors'
 
@@ -41,7 +45,8 @@ export const BROWSER_COOKIE_HANDLERS: Record<string, CommandHandler> = {
   },
   'cookie set': async ({ flags, client, cwd, json }) => {
     const name = getRequiredStringFlag(flags, 'name')
-    const value = getRequiredStringFlag(flags, 'value')
+    // CookieSet.value accepts '' (clearing a cookie's value is a real operation).
+    const value = getRequiredStringFlagAllowingEmpty(flags, 'value')
     const params: Record<string, unknown> = { name, value }
     const domain = getOptionalStringFlag(flags, 'domain')
     const path = getOptionalStringFlag(flags, 'path')

--- a/src/cli/handlers/browser-env.ts
+++ b/src/cli/handlers/browser-env.ts
@@ -5,7 +5,8 @@ import {
   getOptionalStringFlag,
   getRequiredFiniteNumber,
   getRequiredPositiveNumber,
-  getRequiredStringFlag
+  getRequiredStringFlag,
+  getRequiredStringFlagAllowingEmpty
 } from '../flags'
 import { RuntimeClientError } from '../runtime-client'
 import { getBrowserCommandTarget } from '../selectors'
@@ -70,7 +71,8 @@ export const BROWSER_ENV_HANDLERS: Record<string, CommandHandler> = {
   },
   'set credentials': async ({ flags, client, cwd, json }) => {
     const user = getRequiredStringFlag(flags, 'user')
-    const pass = getRequiredStringFlag(flags, 'pass')
+    // SetCredentials.pass accepts '' (empty passwords are legal in HTTP basic auth).
+    const pass = getRequiredStringFlagAllowingEmpty(flags, 'pass')
     const target = await getBrowserCommandTarget(flags, cwd, client)
     const result = await client.call<unknown>('browser.setCredentials', {
       user,


### PR DESCRIPTION
## ELI5
Setting a cookie to "nothing" and using a blank password are both real things the browser runtime already allows. The CLI was saying "you forgot to type something" and refusing. This teaches both commands that an empty value is a real value.

## What Changed
`cookie set` reads `--value` and `set credentials` reads `--pass` with `getRequiredStringFlagAllowingEmpty` instead of `getRequiredStringFlag`, so an explicit empty string is forwarded to the RPC. `--name` and `--user` still require a non-empty string, matching the schemas.

## Why
The server contract is deliberately asymmetric — `CookieSet.value` and `SetCredentials.pass` accept any string while `name` and `user` require a non-empty one (`browser-schemas.ts`). The CLI was stricter than the schema on the two fields where empty is meaningful. Clearing a cookie's value and token-only HTTP basic auth (empty password) were impossible from the CLI. Mirrors #15863 (storage set) and #16030 (fill/select), tracked separately per the note on #15810.

## Linked Issue
Fixes #17225

## Visual Proof
N/A — CLI arg-parsing behavior, covered by tests.

## Testing
New `src/cli/browser-cookie-credentials-empty-value.test.ts`: asserts `--value ""` reaches `browser.cookie.set` and `--pass ""` reaches `browser.setCredentials`, and that empty `--name` / missing `--pass` are still rejected before dispatch. The two empty-value cases fail without the fix and pass with it. `browser.test.ts` (33) still passes. oxlint + oxfmt clean, `tc:cli` passes.

## AI Disclosure
Written with AI assistance (Claude, model claude-fable-5). I reviewed the diff and test before submission.

## Review
Same two-line helper swap as the merged storage fix and #16030, applied to the last two fields in this family. Server contract unchanged. CLI only becomes less restrictive on existing params.

## Checklist
- [x] Small and focused, linked issue, tests added, lint/format/typecheck pass locally