### PR TITLE
test(windows): give the Windows lane's teardowns the repo's rm retry policy

### DIFF
--- a/config/scripts/rebuild-native-deps.test.mjs
+++ b/config/scripts/rebuild-native-deps.test.mjs
@@ -6,13 +6,13 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
-  rmSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { removeTreeSync } from '../../src/shared/windows-transient-lock-removal.ts'
 
 const sourceScriptPath = fileURLToPath(new URL('./rebuild-native-deps.mjs', import.meta.url))
 const sourceInstallScriptPath = fileURLToPath(
@@ -46,7 +46,7 @@ describe('rebuild-native-deps Electron install fallback', () => {
         'download attempted\n'
       )
     } finally {
-      rmSync(projectDir, { recursive: true, force: true })
+      removeTreeSync(projectDir)
     }
   })
 
@@ -70,7 +70,7 @@ describe('rebuild-native-deps Electron install fallback', () => {
         'Continuing postinstall because Electron binary installation failed'
       )
     } finally {
-      rmSync(projectDir, { recursive: true, force: true })
+      removeTreeSync(projectDir)
     }
   })
 
@@ -91,7 +91,7 @@ describe('rebuild-native-deps Electron install fallback', () => {
         'Continuing postinstall because Electron binary installation failed'
       )
     } finally {
-      rmSync(projectDir, { recursive: true, force: true })
+      removeTreeSync(projectDir)
     }
   })
 
@@ -121,7 +121,7 @@ describe('rebuild-native-deps Electron install fallback', () => {
         'partial cleared\ndownload attempted\n'
       )
     } finally {
-      rmSync(projectDir, { recursive: true, force: true })
+      removeTreeSync(projectDir)
     }
   })
 })
@@ -154,7 +154,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         )
         expect(existsSync(rebuildLogPath)).toBe(false)
       } finally {
-        rmSync(projectDir, { recursive: true, force: true })
+        removeTreeSync(projectDir)
       }
     }
   )
@@ -179,7 +179,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
       expect(readFileSync(join(runtimeDir, 'conpty.dll'), 'utf8')).toBe('conpty.dll x64')
       expect(readFileSync(join(runtimeDir, 'OpenConsole.exe'), 'utf8')).toBe('OpenConsole.exe x64')
     } finally {
-      rmSync(projectDir, { recursive: true, force: true })
+      removeTreeSync(projectDir)
     }
   })
 
@@ -207,7 +207,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         const rebuildCall = JSON.parse(readFileSync(rebuildLogPath, 'utf8').trim())
         expect(rebuildCall.onlyModules).toEqual(['windows-native-registry'])
       } finally {
-        rmSync(projectDir, { recursive: true, force: true })
+        removeTreeSync(projectDir)
       }
     }
   )
@@ -237,7 +237,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         const rebuildCall = JSON.parse(readFileSync(rebuildLogPath, 'utf8').trim())
         expect(rebuildCall.onlyModules).toEqual(['node-pty'])
       } finally {
-        rmSync(projectDir, { recursive: true, force: true })
+        removeTreeSync(projectDir)
       }
     }
   )
@@ -268,7 +268,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         expect(rebuildCall.ignoreModules).toEqual(['cpu-features'])
         expect(rebuildCall.force).toBe(true)
       } finally {
-        rmSync(projectDir, { recursive: true, force: true })
+        removeTreeSync(projectDir)
       }
     }
   )
@@ -296,7 +296,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         )
         expect(existsSync(rebuildLogPath)).toBe(false)
       } finally {
-        rmSync(projectDir, { recursive: true, force: true })
+        removeTreeSync(projectDir)
       }
     }
   )
@@ -326,7 +326,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         expect(rebuildCall.onlyModules).toEqual(['node-pty'])
         expect(rebuildCall.force).toBe(true)
       } finally {
-        rmSync(projectDir, { recursive: true, force: true })
+        removeTreeSync(projectDir)
       }
     }
   )

--- a/src/main/agent-hooks/windows-hook-payload-delivery.test.ts
+++ b/src/main/agent-hooks/windows-hook-payload-delivery.test.ts
@@ -7,7 +7,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { spawn } from 'node:child_process'
 import { createServer, type Server } from 'node:http'
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type * as osModule from 'node:os'
@@ -33,6 +33,7 @@ vi.mock('os', async (importOriginal) => {
 import { ClaudeHookService } from '../claude/hook-service'
 import { getConfigPath, getWindowsManagedLifecycleHook } from '../claude/hook-settings'
 import { findGitBash } from './windows-git-bash-path.test-fixture'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 
 const PANE_KEY = 'tab-1:leaf-1'
 const HOOK_TOKEN = 'payload-delivery-token'
@@ -149,7 +150,7 @@ describe.skipIf(process.platform !== 'win32')('Windows managed hook payload deli
     server = null
     homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
     if (home) {
-      rmSync(home, { recursive: true, force: true })
+      removeTreeSync(home)
       home = ''
     }
   })

--- a/src/main/cli/wsl-cli-powershell-boundary.test.ts
+++ b/src/main/cli/wsl-cli-powershell-boundary.test.ts
@@ -1,9 +1,10 @@
 import { spawnSync } from 'node:child_process'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { buildWslBridgeScript, buildWslLauncher } from './wsl-cli-scripts'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 
 const FORWARDED_ARGS = [
   'terminal',
@@ -113,7 +114,7 @@ describe('WSL CLI PowerShell boundary', () => {
         expect(exitResult.error).toBeUndefined()
         expect(exitResult.status).toBe(23)
       } finally {
-        await rm(root, { recursive: true, force: true })
+        await removeTree(root)
       }
     }
   )

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -63,13 +63,13 @@ import {
   ManagedCodexHomeTemporarilyUnavailableError
 } from './host-codex-managed-home-ownership'
 import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
+import {
+  WINDOWS_RM_MAX_RETRIES,
+  WINDOWS_RM_RETRY_DELAY_MS
+} from '../../shared/windows-transient-lock-removal'
 
 const LOGIN_TIMEOUT_MS = 120_000
 const MAX_LOGIN_OUTPUT_CHARS = 4_000
-// Why: mirrors the Windows rm retry policy in local-worktree-filesystem — a
-// just-terminated codex login can briefly keep handles inside a managed home.
-const WINDOWS_RM_MAX_RETRIES = 8
-const WINDOWS_RM_RETRY_DELAY_MS = 150
 const WINDOWS_LOGIN_AUTH_POLL_INTERVAL_MS = 500
 const WINDOWS_LOGIN_POST_AUTH_EXIT_GRACE_MS = 5_000
 const WINDOWS_LOGIN_TREE_KILL_TIMEOUT_MS = 5_000
@@ -205,6 +205,8 @@ function removeManagedHomeTreeSync(targetPath: string): void {
   // Why: codex login descendants can briefly keep Windows handles on files in
   // the managed home (e.g. log/codex-login.log); bounded retries absorb the
   // transient lock instead of failing with ENOTEMPTY and orphaning the home.
+  // Why unconditional, unlike transientLockRemovalOptions(): a WSL-hosted managed home is removed
+  // by this host process, so the lock this absorbs is not gated on the host being Windows.
   rmSync(targetPath, {
     recursive: true,
     force: true,

--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -20,6 +20,7 @@ vi.mock('os', async () => {
 import { CursorHookService } from './hook-service'
 import { POSIX_HOOK_STDIN_READER } from '../agent-hooks/hook-stdin-contract'
 import { CURSOR_EVENTS, type CursorEvent } from './hook-events'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 
 const CURSOR_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'cursor-hook.cmd' : 'cursor-hook.sh'
 const WINDOWS_POWERSHELL_LAUNCHER =
@@ -89,7 +90,7 @@ describe('CursorHookService', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
-    rmSync(homeDir, { recursive: true, force: true })
+    removeTreeSync(homeDir)
   })
 
   it('installs Cursor Agent hooks with the documented top-level command schema', () => {
@@ -155,7 +156,7 @@ describe('CursorHookService', () => {
           expect(command).toMatch(WINDOWS_POWERSHELL_LAUNCHER)
         }
       } finally {
-        rmSync(spaceHome, { recursive: true, force: true })
+        removeTreeSync(spaceHome)
       }
     }
   )

--- a/src/main/host-tree-removal.ts
+++ b/src/main/host-tree-removal.ts
@@ -2,33 +2,17 @@
 // generations) hits the same Windows stickiness — AV/indexers/late handle releases surface transient
 // EBUSY/ENOTEMPTY/EPERM on a tree Node just emptied. One helper so no call site forgets the retries.
 
-import type { RmOptions } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { win32 } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
+import { transientLockRemovalOptions } from '../shared/windows-transient-lock-removal'
 
 const WINDOWS_REMOVE_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000]
-const WINDOWS_RM_MAX_RETRIES = 8
-const WINDOWS_RM_RETRY_DELAY_MS = 150
 
 export function toHostRemovalPath(targetPath: string): string {
   // Why: Git for Windows can fail long recursive deletes even after Orca has
   // proven the worktree target; Node's host deletion should use Win32 long paths.
   return process.platform === 'win32' ? win32.toNamespacedPath(targetPath) : targetPath
-}
-
-function getHostRemovalOptions(): RmOptions {
-  const base = { recursive: true, force: true }
-  if (process.platform !== 'win32') {
-    return base
-  }
-  return {
-    ...base,
-    // Why: large Windows trees commonly surface transient ENOTEMPTY/EPERM while
-    // Node walks and removes nested directories.
-    maxRetries: WINDOWS_RM_MAX_RETRIES,
-    retryDelay: WINDOWS_RM_RETRY_DELAY_MS
-  }
 }
 
 function isTransientWindowsRemovalError(error: unknown): boolean {
@@ -47,7 +31,9 @@ function isTransientWindowsRemovalError(error: unknown): boolean {
 export async function removeHostTree(targetPath: string): Promise<void> {
   const removalPath = toHostRemovalPath(targetPath)
   const retryDelays = process.platform === 'win32' ? WINDOWS_REMOVE_RETRY_DELAYS_MS : []
-  const rmOptions = getHostRemovalOptions()
+  // Why: large Windows trees commonly surface transient ENOTEMPTY/EPERM while Node walks and
+  // removes nested directories; Node's own retries absorb that before the loop below has to.
+  const rmOptions = transientLockRemovalOptions()
   let attempt = 0
 
   while (true) {

--- a/src/main/orca-profiles/profile-index-store.test.ts
+++ b/src/main/orca-profiles/profile-index-store.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { installFakeAppEnvironment } from '../../../config/scripts/vitest-host-ports-setup'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
@@ -10,6 +10,7 @@ import {
   ORCA_PROFILE_INDEX_SCHEMA_VERSION,
   type OrcaProfileIndex
 } from '../../shared/orca-profiles'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 
 const testState = { dir: '' }
 
@@ -35,7 +36,7 @@ describe('profile index store', () => {
   })
 
   afterEach(() => {
-    rmSync(testState.dir, { recursive: true, force: true })
+    removeTreeSync(testState.dir)
   })
 
   it('creates the default local profile and copies legacy state without deleting it', async () => {

--- a/src/main/runtime/repo-worktree-admin-fingerprint.test.ts
+++ b/src/main/runtime/repo-worktree-admin-fingerprint.test.ts
@@ -4,12 +4,13 @@
 // Windows path resolution, CRLF in `HEAD`/`gitdir`/`commondir`, and whether `worktree move`/`lock`
 // and deleting a live checkout behave as they do on POSIX. The Linux shards cannot reach any of it.
 import { execFile } from 'node:child_process'
-import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { readRepoWorktreeAdminFingerprint } from './repo-worktree-admin-fingerprint'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 
 const execFileAsync = promisify(execFile)
 
@@ -43,7 +44,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await rm(scratchDir, { recursive: true, force: true })
+  await removeTree(scratchDir)
 })
 
 describe('readRepoWorktreeAdminFingerprint', () => {
@@ -71,7 +72,7 @@ describe('readRepoWorktreeAdminFingerprint', () => {
   it('changes when a worktree directory is deleted outside Git', async () => {
     // The admin dir is untouched by `rm -rf`, but the row's `prunable` flag flips.
     const before = await fingerprint()
-    await rm(worktreePath, { recursive: true, force: true })
+    await removeTree(worktreePath)
     expect(await fingerprint()).not.toBe(before)
   })
 

--- a/src/main/windows/windows-host-job.win32.test.ts
+++ b/src/main/windows/windows-host-job.win32.test.ts
@@ -1,8 +1,9 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawn } from 'node:child_process'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 
 /**
  * The second half of the two-job design.
@@ -50,7 +51,7 @@ describeOnWindows('host job reaps the tree when the host dies', () => {
   })
 
   afterAll(() => {
-    rmSync(dir, { recursive: true, force: true })
+    removeTreeSync(dir)
   })
 
   it('kills a pty and its detached grandchild when the host is force-killed', async () => {

--- a/src/shared/child-process/windows-command-line.win32.test.ts
+++ b/src/shared/child-process/windows-command-line.win32.test.ts
@@ -7,6 +7,7 @@ import {
   WINDOWS_ARGUMENT_CORPUS,
   WINDOWS_ARGUMENT_CORPUS_ENV
 } from './__fixtures__/windows-argument-corpus'
+import { removeTreeSync } from '../windows-transient-lock-removal'
 
 /**
  * The other half of the encoding proof: the unit test checks the bytes against
@@ -37,7 +38,7 @@ describeOnWindows('Windows .cmd argument round-trip', () => {
   })
 
   afterAll(() => {
-    rmSync(dir, { recursive: true, force: true })
+    removeTreeSync(dir)
   })
 
   function decode(stdout: string): string[] {

--- a/src/shared/secure-file-fsync-flags.test.ts
+++ b/src/shared/secure-file-fsync-flags.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs'
 import type * as NodeFs from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -28,13 +28,14 @@ import {
   fsyncFileSync,
   writeDurableSecureJsonFile
 } from './secure-file'
+import { removeTreeSync } from './windows-transient-lock-removal'
 
 const createdPaths: string[] = []
 
 afterEach(() => {
   openedPaths.length = 0
   for (const path of createdPaths.splice(0)) {
-    rmSync(path, { recursive: true, force: true })
+    removeTreeSync(path)
   }
 })
 

--- a/src/shared/windows-lane-tree-removal-boundary.test.ts
+++ b/src/shared/windows-lane-tree-removal-boundary.test.ts
@@ -31,10 +31,41 @@ function readWindowsLaneSpecs(): string[] {
     .filter((line) => /^(src|tests|config)\/.+\.(test|spec)\.(ts|tsx|mjs)$/.test(line))
 }
 
+/** `node:fs` and `node:fs/promises`, spelled with or without the `node:` prefix. */
+const FS_SPECIFIER = String.raw`['"](?:node:)?fs(?:/promises)?['"]`
+/** The `{ … }` clause of an fs import or require, which is where a rename would be declared. */
+const FS_BINDING_CLAUSE = new RegExp(
+  String.raw`\{([^}]*)\}\s*(?:from\s*${FS_SPECIFIER}|=\s*(?:await\s+import|require)\(\s*${FS_SPECIFIER})`,
+  'g'
+)
+/** `rm as removeDir` or `rmSync: dropTree` — the two ways a binding gets a local name. */
+const RENAMED_REMOVAL = /\brm(?:Sync)?\s*(?:as|:)\s*([A-Za-z0-9_$]+)/g
+
+/**
+ * The local names a recursive removal can be called by in `source`.
+ *
+ * Namespaced spellings are covered by the optional `<identifier>.` prefix in the matcher rather
+ * than by listing names, so `fsp.rm` and `fsPromises.rm` are caught without anyone having to teach
+ * the rule that spelling first. Renames are the one form that prefix cannot see, so they are read
+ * out of the import clause.
+ */
+function collectRemovalNames(source: string): string[] {
+  const names = new Set(['rmSync', 'rm'])
+  for (const clause of source.matchAll(FS_BINDING_CLAUSE)) {
+    for (const rename of clause[1].matchAll(RENAMED_REMOVAL)) {
+      names.add(rename[1])
+    }
+  }
+  return [...names]
+}
+
 /** Every recursive removal that does not go through the retrying helper. */
 function findRawRecursiveRemovals(source: string): number[] {
   const offenders: number[] = []
-  const call = /(?<![\w$.])(?:fs\.)?rm(?:Sync)?\(/g
+  const call = new RegExp(
+    String.raw`(?<![\w$.])(?:[\w$]+\.)?(?:${collectRemovalNames(source).join('|')})\s*\(`,
+    'g'
+  )
   let match: RegExpExecArray | null
   while ((match = call.exec(source)) !== null) {
     // Read to the call's closing paren so multi-line option objects are covered.
@@ -81,6 +112,48 @@ describe('windows lane tree removal', () => {
     ).toEqual([])
     // A single-file removal is not this rule's business.
     expect(findRawRecursiveRemovals('rmSync(file, { force: true })')).toEqual([])
+  })
+
+  it('detects the removal whatever the import spelled it', () => {
+    // Why: a rule that only reads one import style stops catching violations the moment someone
+    // writes the next one differently — and the guard goes on reporting zero offenders.
+    const spellings: [string, string][] = [
+      ['bare named import', "import { rmSync } from 'node:fs'\nrmSync(DIR"],
+      ['fs namespace', "import * as fs from 'node:fs'\nfs.rmSync(DIR"],
+      ['fsp namespace', "import * as fsp from 'node:fs/promises'\nawait fsp.rm(DIR"],
+      [
+        'fsPromises namespace',
+        "import * as fsPromises from 'node:fs/promises'\nawait fsPromises.rm(DIR"
+      ],
+      ['nodeFs namespace', "import * as nodeFs from 'node:fs'\nnodeFs.rmSync(DIR"],
+      ['unprefixed fs specifier', "import * as fs from 'fs'\nfs.rmSync(DIR"],
+      [
+        'renamed named import',
+        "import { rm as removeDir } from 'node:fs/promises'\nawait removeDir(DIR"
+      ],
+      ['renamed require', "const { rmSync: dropTree } = require('node:fs')\ndropTree(DIR"]
+    ]
+
+    for (const [label, prelude] of spellings) {
+      const source = `${prelude}, { recursive: true, force: true })`
+      expect(findRawRecursiveRemovals(source), `${label} slipped past the scan`).toEqual([2])
+    }
+  })
+
+  it('still exempts the retrying spellings and single-file removals', () => {
+    // The widened matcher must not start reporting the calls the rule is asking people to write.
+    expect(
+      findRawRecursiveRemovals(
+        "import * as fsp from 'node:fs/promises'\nawait fsp.rm(dir, { recursive: true, maxRetries: 8 })"
+      )
+    ).toEqual([])
+    expect(
+      findRawRecursiveRemovals(
+        "import { rm as removeDir } from 'node:fs/promises'\nawait removeDir(file, { force: true })"
+      )
+    ).toEqual([])
+    // `rm` inside a longer identifier is not a removal call.
+    expect(findRawRecursiveRemovals('confirmRemoval(dir, { recursive: true })')).toEqual([])
   })
 
   it('removes trees through the retrying helper, never a raw recursive rm', () => {

--- a/src/shared/windows-lane-tree-removal-boundary.test.ts
+++ b/src/shared/windows-lane-tree-removal-boundary.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The Windows CI lane runs a fixed list of specs on `windows-2022`, and every one of them removes
+ * a temporary tree when it is done. On Windows those removals race a handle the OS has not
+ * released yet — a just-exited child, an indexer, a dlopen'd native module — so a raw
+ * `rmSync(dir, { recursive: true, force: true })` throws EPERM after the test's assertions have
+ * all passed, and the lane reports a green test as a failure.
+ *
+ * `removeTree`/`removeTreeSync` carry the repo's `maxRetries: 8` policy. This keeps the lane on
+ * them: a new spec that hand-rolls the removal fails here rather than intermittently on Windows.
+ */
+const REPO_ROOT = join(__dirname, '..', '..')
+const WORKFLOW_PATH = join(REPO_ROOT, '.github', 'workflows', 'pr.yml')
+const WINDOWS_STEP_NAME = 'Test Windows-specific boundaries'
+
+/** The spec paths the `package (windows)` job passes to vitest, read from the workflow itself. */
+function readWindowsLaneSpecs(): string[] {
+  const workflow = readFileSync(WORKFLOW_PATH, 'utf8')
+  const stepIndex = workflow.indexOf(`- name: ${WINDOWS_STEP_NAME}`)
+  expect(stepIndex, `${WORKFLOW_PATH} no longer has a "${WINDOWS_STEP_NAME}" step`).toBeGreaterThan(
+    -1
+  )
+  const nextStepIndex = workflow.indexOf('\n      - name:', stepIndex + 1)
+  const step = workflow.slice(stepIndex, nextStepIndex === -1 ? undefined : nextStepIndex)
+  return step
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => /^(src|tests|config)\/.+\.(test|spec)\.(ts|tsx|mjs)$/.test(line))
+}
+
+/** Every recursive removal that does not go through the retrying helper. */
+function findRawRecursiveRemovals(source: string): number[] {
+  const offenders: number[] = []
+  const call = /(?<![\w$.])(?:fs\.)?rm(?:Sync)?\(/g
+  let match: RegExpExecArray | null
+  while ((match = call.exec(source)) !== null) {
+    // Read to the call's closing paren so multi-line option objects are covered.
+    let depth = 0
+    let end = match.index + match[0].length - 1
+    for (; end < source.length; end += 1) {
+      if (source[end] === '(') {
+        depth += 1
+      } else if (source[end] === ')') {
+        depth -= 1
+        if (depth === 0) {
+          break
+        }
+      }
+    }
+    const args = source.slice(match.index, end + 1)
+    if (!args.includes('recursive')) {
+      continue
+    }
+    if (args.includes('maxRetries')) {
+      continue
+    }
+    offenders.push(source.slice(0, match.index).split('\n').length)
+  }
+  return offenders
+}
+
+describe('windows lane tree removal', () => {
+  const specs = readWindowsLaneSpecs()
+
+  it('reads a non-trivial spec list out of the workflow', () => {
+    // A parser that silently matched nothing would make every assertion below vacuous.
+    expect(specs.length).toBeGreaterThan(10)
+    expect(specs).toContain('config/scripts/rebuild-native-deps.test.mjs')
+  })
+
+  it('actually detects a raw recursive removal', () => {
+    // Without this the scan below passes for any reason at all, including not scanning.
+    expect(findRawRecursiveRemovals('rmSync(dir, { recursive: true, force: true })')).toEqual([1])
+    expect(
+      findRawRecursiveRemovals(
+        'await rm(dir, {\n  recursive: true,\n  force: true,\n  maxRetries: 8\n})'
+      )
+    ).toEqual([])
+    // A single-file removal is not this rule's business.
+    expect(findRawRecursiveRemovals('rmSync(file, { force: true })')).toEqual([])
+  })
+
+  it('removes trees through the retrying helper, never a raw recursive rm', () => {
+    const offenders = specs.flatMap((spec) => {
+      const source = readFileSync(join(REPO_ROOT, spec), 'utf8')
+      return findRawRecursiveRemovals(source).map((line) => `${spec}:${line}`)
+    })
+
+    expect(
+      offenders,
+      'these teardowns can throw EPERM on Windows after their assertions have passed; use removeTree/removeTreeSync from src/shared/windows-transient-lock-removal.ts'
+    ).toEqual([])
+  })
+})

--- a/src/shared/windows-transient-lock-removal.test.ts
+++ b/src/shared/windows-transient-lock-removal.test.ts
@@ -1,6 +1,6 @@
-import { readFileSync, readdirSync, statSync } from 'node:fs'
-import { join, relative } from 'node:path'
+import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { scanSourceTree, stripComments } from './source-scan/source-tree-scan'
 import {
   WINDOWS_RM_MAX_RETRIES,
   WINDOWS_RM_RETRY_DELAY_MS,
@@ -12,33 +12,19 @@ function withPlatform(platform: NodeJS.Platform): void {
 }
 
 const SOURCE_ROOT = join(__dirname, '..')
-const OWNING_MODULE = join('shared', 'windows-transient-lock-removal.ts')
-const IGNORED_DIRECTORIES = new Set(['node_modules', 'dist', 'out', 'build', '.git'])
+const OWNING_MODULE = 'shared/windows-transient-lock-removal.ts'
 /** A `const WINDOWS_RM_… =` line, i.e. a file stating the policy rather than importing it. */
 const POLICY_DECLARATION =
   /^\s*(?:export\s+)?const\s+WINDOWS_RM_(?:MAX_RETRIES|RETRY_DELAY_MS)\s*=/m
 
-function collectSourceFiles(root: string): string[] {
-  const found: string[] = []
-  for (const entry of readdirSync(root)) {
-    if (IGNORED_DIRECTORIES.has(entry)) {
-      continue
-    }
-    const path = join(root, entry)
-    if (statSync(path).isDirectory()) {
-      found.push(...collectSourceFiles(path))
-    } else if (/\.tsx?$/.test(entry)) {
-      found.push(path)
-    }
-  }
-  return found
-}
-
 /** Every file that declares the retry policy instead of importing it. */
 function findPolicyDeclarations(): string[] {
-  return collectSourceFiles(SOURCE_ROOT)
-    .filter((path) => POLICY_DECLARATION.test(readFileSync(path, 'utf8')))
-    .map((path) => relative(SOURCE_ROOT, path))
+  return scanSourceTree(SOURCE_ROOT, { includeTests: true })
+    .filter(
+      (file) =>
+        POLICY_DECLARATION.test(file.source) && POLICY_DECLARATION.test(stripComments(file.source))
+    )
+    .map((file) => file.relativePath)
     .sort()
 }
 

--- a/src/shared/windows-transient-lock-removal.test.ts
+++ b/src/shared/windows-transient-lock-removal.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   WINDOWS_RM_MAX_RETRIES,
@@ -7,6 +9,37 @@ import {
 
 function withPlatform(platform: NodeJS.Platform): void {
   vi.stubGlobal('process', { ...process, platform })
+}
+
+const SOURCE_ROOT = join(__dirname, '..')
+const OWNING_MODULE = join('shared', 'windows-transient-lock-removal.ts')
+const IGNORED_DIRECTORIES = new Set(['node_modules', 'dist', 'out', 'build', '.git'])
+/** A `const WINDOWS_RM_… =` line, i.e. a file stating the policy rather than importing it. */
+const POLICY_DECLARATION =
+  /^\s*(?:export\s+)?const\s+WINDOWS_RM_(?:MAX_RETRIES|RETRY_DELAY_MS)\s*=/m
+
+function collectSourceFiles(root: string): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(root)) {
+    if (IGNORED_DIRECTORIES.has(entry)) {
+      continue
+    }
+    const path = join(root, entry)
+    if (statSync(path).isDirectory()) {
+      found.push(...collectSourceFiles(path))
+    } else if (/\.tsx?$/.test(entry)) {
+      found.push(path)
+    }
+  }
+  return found
+}
+
+/** Every file that declares the retry policy instead of importing it. */
+function findPolicyDeclarations(): string[] {
+  return collectSourceFiles(SOURCE_ROOT)
+    .filter((path) => POLICY_DECLARATION.test(readFileSync(path, 'utf8')))
+    .map((path) => relative(SOURCE_ROOT, path))
+    .sort()
 }
 
 describe('transient lock removal options', () => {
@@ -36,5 +69,23 @@ describe('transient lock removal options', () => {
       expect(transientLockRemovalOptions()).toEqual({ recursive: true, force: true })
       vi.unstubAllGlobals()
     }
+  })
+
+  it('actually detects a file that states the policy', () => {
+    // Without this the scan below passes for any reason at all, including not scanning.
+    expect(POLICY_DECLARATION.test('const WINDOWS_RM_MAX_RETRIES = 8')).toBe(true)
+    expect(POLICY_DECLARATION.test('  export const WINDOWS_RM_RETRY_DELAY_MS = 150')).toBe(true)
+    // Importing the policy is the thing this rule is asking for, not a violation of it.
+    expect(POLICY_DECLARATION.test('import { WINDOWS_RM_MAX_RETRIES } from x')).toBe(false)
+    expect(POLICY_DECLARATION.test('    retryDelay: WINDOWS_RM_RETRY_DELAY_MS')).toBe(false)
+  })
+
+  it('is the only file that states the policy', () => {
+    // Why a ratchet: a second copy is how "8 attempts" becomes 8 in one file and 4 in another,
+    // and nothing fails until a Windows lane goes red for a reason nobody can place.
+    expect(
+      findPolicyDeclarations(),
+      'declare the retry policy once, in src/shared/windows-transient-lock-removal.ts, and import it'
+    ).toEqual([OWNING_MODULE])
   })
 })

--- a/src/shared/windows-transient-lock-removal.test.ts
+++ b/src/shared/windows-transient-lock-removal.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  WINDOWS_RM_MAX_RETRIES,
+  WINDOWS_RM_RETRY_DELAY_MS,
+  transientLockRemovalOptions
+} from './windows-transient-lock-removal'
+
+function withPlatform(platform: NodeJS.Platform): void {
+  vi.stubGlobal('process', { ...process, platform })
+}
+
+describe('transient lock removal options', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('retries on Windows, where a late handle release is the whole problem', () => {
+    withPlatform('win32')
+
+    expect(transientLockRemovalOptions()).toEqual({
+      recursive: true,
+      force: true,
+      maxRetries: WINDOWS_RM_MAX_RETRIES,
+      retryDelay: WINDOWS_RM_RETRY_DELAY_MS
+    })
+  })
+
+  it('matches the repo policy of eight attempts', () => {
+    // Same number src/main/host-tree-removal.ts and codex-accounts/service.ts already use.
+    expect(WINDOWS_RM_MAX_RETRIES).toBe(8)
+  })
+
+  it('asks for no retries where removal is not raced by the OS', () => {
+    for (const platform of ['darwin', 'linux'] as const) {
+      withPlatform(platform)
+      expect(transientLockRemovalOptions()).toEqual({ recursive: true, force: true })
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/src/shared/windows-transient-lock-removal.ts
+++ b/src/shared/windows-transient-lock-removal.ts
@@ -1,0 +1,31 @@
+// Why: Windows releases handles late. Antivirus, the search indexer, a just-exited child and a
+// freshly dlopen'd DLL all keep a tree Node has just emptied locked for a few milliseconds, which
+// surfaces as EBUSY/ENOTEMPTY/EPERM. Node's own `maxRetries` absorbs exactly that, and the repo
+// already settled on 8 attempts — but only product code was using it, so test teardown kept
+// failing tests whose assertions had already passed.
+
+import type { RmOptions } from 'node:fs'
+import { rmSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+
+export const WINDOWS_RM_MAX_RETRIES = 8
+export const WINDOWS_RM_RETRY_DELAY_MS = 150
+
+/** `rm`/`rmSync` options for a recursive removal that must survive a late handle release. */
+export function transientLockRemovalOptions(): RmOptions {
+  const base = { recursive: true, force: true }
+  if (process.platform !== 'win32') {
+    return base
+  }
+  return { ...base, maxRetries: WINDOWS_RM_MAX_RETRIES, retryDelay: WINDOWS_RM_RETRY_DELAY_MS }
+}
+
+/** Recursively remove a directory, retrying the transient Windows locks. */
+export function removeTreeSync(targetPath: string): void {
+  rmSync(targetPath, transientLockRemovalOptions())
+}
+
+/** Recursively remove a directory, retrying the transient Windows locks. */
+export async function removeTree(targetPath: string): Promise<void> {
+  await rm(targetPath, transientLockRemovalOptions())
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​284 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​255 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /orca-pr-loc -->

## ELI5

When a test finishes it deletes the temporary folder it was working in. On Windows the folder is often still "in use" for a fraction of a second after the test is done — an antivirus scan, the search indexer, a child process that just exited, or a native `.dll` the OS has not finished unloading. Delete it right then and Windows says *operation not permitted*.

Node has a built-in answer: ask it to retry the delete a few times. Orca's product code already does this and already picked the number — **8**. Its tests did not, so a test whose checks had **all passed** was reported as a failure because tidying up lost a race.

This teaches the Windows CI lane to tidy up the way the rest of the codebase already does.

## What the user sees

Nothing at runtime — the product paths already retried. What changes is that `package (windows)` stops reporting passing tests as failures.

| | Before | After |
|---|---|---|
| A Windows spec that loads a native module and then deletes its temp dir | `EPERM: operation not permitted` from the `finally`, after every assertion passed | the delete retries up to 8 times, 150 ms apart |
| A new spec added to the Windows lane | free to hand-roll `rmSync(dir, { recursive: true, force: true })` and reintroduce the flake | fails a boundary test on the PR that adds it, on every platform |

## The failure

`package (windows)`, `config/scripts/rebuild-native-deps.test.mjs`, test **`rebuilds a loadable ConPTY native that lacks Orca job ownership`** (win32-only).

The last assertion is line 238 and it **passed**. The throw comes from line 240:

```js
      } finally {
        rmSync(projectDir, { recursive: true, force: true })   // maxRetries defaults to 0
      }
```

That test exists to rebuild node-pty and load the ConPTY native — the same job log carries `node-pty's conpty native is missing listJobProcessIds … Resolved from: ../prebuilds/win32-x64/`, so a real `dlopen` is live in the run. A DLL Windows has just mapped keeps a handle on the directory it came from, and `maxRetries: 0` gives that handle no time to go away.

## The convention it was ignoring

```
src/main/host-tree-removal.ts:11      const WINDOWS_RM_MAX_RETRIES = 8
src/main/codex-accounts/service.ts:71 const WINDOWS_RM_MAX_RETRIES = 8
```

Two copies, both in product code, neither reachable from a test.

## The fix

- `src/shared/windows-transient-lock-removal.ts` — one home for the policy, exposing `removeTree` / `removeTreeSync` and the options behind them. Retries are win32-only; POSIX gets the plain options it had.
- All **21** raw recursive removals in the Windows CI lane move onto it, across 9 files.
- `src/shared/windows-lane-tree-removal-boundary.test.ts` reads the lane's spec list out of the `Test Windows-specific boundaries` step in `.github/workflows/pr.yml` — so the gate follows the lane rather than a hand-kept copy of it — and fails on any recursive removal that carries no `maxRetries`.

## Census

The task asked how many other teardowns ignore the convention. Across `src`, `tests` and `config`:

**1,633 recursive directory removals in 1,028 files pass no `maxRetries`** — **1,368** in tests and fixtures, **265** in product code.

This PR changes only the 21 in the Windows lane. The 265 product-code sites are the ones that matter beyond CI hygiene: a test leaking a temp directory is untidy, a product path that cannot delete a user's directory is a bug. That is a separate change, and worth deciding as a shape question (shared helper plus a lint rule that makes the raw call the exception) rather than as a sweep.

## Proof

Ablations, one at a time, mutation verified applied, tree restored between runs, run serially. Suite: `windows-transient-lock-removal.test.ts` + `windows-lane-tree-removal-boundary.test.ts`, 6 tests.

| Ablation | Failing tests |
|---|---|
| revert the convicted teardown at `rebuild-native-deps.test.mjs` line 240 to the raw `rmSync` | 1 |
| drop the win32 branch from `transientLockRemovalOptions()` | 1 |
| blind the boundary scanner so it reports nothing | 1 |

The third ablation first came back **0 red** — the boundary test passed because the scanner found nothing, which is indistinguishable from finding nothing wrong. `actually detects a raw recursive removal` was added to pin the detector against a synthetic source, and the scanner-blinding ablation then reds.

**Honest limit:** the EPERM itself is a `win32`-only teardown failure and I could not reproduce it on macOS — `it.skipIf(process.platform !== 'win32')` skips the convicted test here. What is proved failing-first is the gate: the boundary test reds on the exact line that threw in CI, and it runs on every platform. The EPERM itself is settled by CI on `package (windows)`.

Local gates: `pnpm tc` exit 0, 0 `error TS` (foreground). `oxlint` on all 12 changed files exit 0, including the native-plugin and type-aware code-quality configs. The 11 touched/affected test files: 9 passed, 2 skipped, 47 tests passed, 0 failed.
