### PR TITLE
perf(terminal): bound stalled setup-split grid polling

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.test.ts
@@ -115,6 +115,30 @@ describe('waitForStableStartupGrid', () => {
     expect(onSettled).toHaveBeenCalledWith({ cols: 88, rows: 50 })
   })
 
+  it('stops polling at the default cap when the external split gate never opens', () => {
+    const scheduler = createFrameScheduler()
+    const onSettled = vi.fn()
+    const measure = vi.fn(() => ({ cols: 88, rows: 50 }))
+
+    waitForStableStartupGrid({
+      isAlive: () => true,
+      isReadyToSettle: () => false,
+      measure,
+      onSettled,
+      requestFrame: scheduler.requestFrame,
+      cancelFrame: scheduler.cancelFrame
+    })
+
+    expect(scheduler.run(119)).toBe(119)
+    expect(scheduler.pending()).toBe(1)
+    expect(onSettled).not.toHaveBeenCalled()
+
+    expect(scheduler.run(10)).toBe(1)
+    expect(scheduler.pending()).toBe(0)
+    expect(measure).toHaveBeenCalledTimes(120)
+    expect(onSettled).toHaveBeenCalledWith({ cols: 88, rows: 50 })
+  })
+
   it('uses the latest usable grid at the frame cap when dimensions keep changing', () => {
     const scheduler = createFrameScheduler()
     const onSettled = vi.fn()

--- a/src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.ts
@@ -13,6 +13,7 @@ export type TerminalStartupGridSettleOptions = {
   minFrames?: number
   stableFrames?: number
   maxFrames?: number
+  maxReadinessWaitFrames?: number
 }
 
 export type TerminalStartupGridSettleHandle = {
@@ -22,6 +23,8 @@ export type TerminalStartupGridSettleHandle = {
 const DEFAULT_MIN_FRAMES = 6
 const DEFAULT_STABLE_FRAMES = 2
 const DEFAULT_MAX_FRAMES = 12
+// Why: ten settle windows tolerate slow split layout without permitting permanent polling.
+const DEFAULT_MAX_READINESS_WAIT_FRAMES = DEFAULT_MAX_FRAMES * 10
 
 function usableDimensions(
   dimensions: TerminalStartupGridDimensions | null
@@ -42,6 +45,10 @@ export function waitForStableStartupGrid(
   const minFrames = Math.max(1, options.minFrames ?? DEFAULT_MIN_FRAMES)
   const stableFrames = Math.max(1, options.stableFrames ?? DEFAULT_STABLE_FRAMES)
   const maxFrames = Math.max(minFrames, options.maxFrames ?? DEFAULT_MAX_FRAMES)
+  const maxReadinessWaitFrames = Math.max(
+    1,
+    options.maxReadinessWaitFrames ?? DEFAULT_MAX_READINESS_WAIT_FRAMES
+  )
   let frame = 0
   let stableFrameCount = 0
   let previous: TerminalStartupGridDimensions | null = null
@@ -50,6 +57,7 @@ export function waitForStableStartupGrid(
   let pendingFrame: number | null = null
   let cancelled = false
   let readyFrame = 0
+  let latestReadinessWaitUsable: TerminalStartupGridDimensions | null = null
   const usesReadinessGate = options.isReadyToSettle !== undefined
 
   const settle = (dimensions: TerminalStartupGridDimensions | null): void => {
@@ -73,6 +81,13 @@ export function waitForStableStartupGrid(
     const measured = options.measure()
     const readyToSettle = options.isReadyToSettle?.() ?? true
     if (!readyToSettle) {
+      if (usableDimensions(measured)) {
+        latestReadinessWaitUsable = measured
+      }
+      if (frame >= maxReadinessWaitFrames) {
+        settle(latestReadinessWaitUsable)
+        return
+      }
       previous = null
       stableFrameCount = 0
       observedGridChange = false


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 |

<!-- /orca-pr-loc -->

## ELI5

When Orca opens a terminal beside a setup-command split, it waits for the new split's geometry before starting the terminal. If that geometry gate never became ready, Orca kept asking Chromium to measure the pane every rendered frame forever. The terminal never connected, and the layout-reading loop could keep burning renderer CPU.

This gives that gate a generous but finite budget. If it is still closed after 120 rendered frames, Orca connects with the latest usable grid and lets the existing post-spawn size reconciliation handle any later resize.

## What changed

- Add a separate 120-frame readiness-wait cap, ten times the normal 12-frame settle window.
- Retain the latest usable measurement while the external gate is closed and settle with it at the cap.
- Keep ungated startup and the existing ready-frame stability/minimum/maximum behavior unchanged.

## Measurement proof

The regression uses a deterministic frame scheduler, so it counts layout work instead of relying on machine timing.

- **Before (recorded red run):** with a five-frame test budget, the old loop consumed all 100 simulated frames, left another frame queued, and never called the settle callback (`expected 5, received 100`).
- **After:** the production-default test waits through frame 119, settles exactly on frame 120, performs exactly 120 measurements, and leaves zero queued work.
- **Complexity:** a permanently closed gate changes from unbounded layout reads over pane lifetime to at most 120 reads for that startup.

This is intentionally a rendered-frame work bound, not a wall-clock promise. Chromium may throttle or pause `requestAnimationFrame` while the window is hidden; that hidden state also does not sustain the foreground layout-reading loop this fixes.

## Regression proof

- `pnpm test` across 7 related setup-split/startup files: **88/88 passed**.
- Final focused rerun: startup-grid settle + setup-split spawn, **16/16 passed**.
- `pnpm tc:web`: passed.
- `pnpm run check:code-quality:changed`: zero code-quality, type-aware, or React Doctor findings across both files.
- `pnpm exec oxfmt --check ...`: passed for both changed files.
- Independent read-only review found no correctness regression in cap, cancellation, readiness-toggle, or caller semantics.

The pre-existing healthy-gate test still holds through eight pre-ready frames and then settles on the correct post-split `88x50` grid. The new test locks the permanently closed gate's exact default boundary.

## Electron validation

Validated in this branch's own Electron dev instance over CDP:

- queued the real startup-command + vertical setup-split flow;
- visibly observed `MAIN_STARTUP_READY` in the primary pane and `SETUP_SPLIT_READY` in the setup pane;
- confirmed two distinct PTY IDs mapped to the two split leaves;
- observed zero console errors.

No visual artifact is attached because this changes failure-path scheduling, not styling or layout.

## No-user-regression signoff

- No feature is disabled, reduced, or made opt-in.
- Ungated terminal startups never consult the new cap.
- Healthy setup-split gates that open within 120 rendered frames keep the exact prior wait/stability behavior.
- Only a gate that stays closed for the full budget falls back; the caller immediately performs its normal `safeFit`, and existing post-spawn reconciliation remains authoritative for later geometry changes.
- No IPC/RPC, remote-wire, Git, filesystem-path, keyboard, provider, SSH execution-ownership, or folder-workspace contract changes.

## Merge risk

**Low.** Two files, one internal optional limit, and one deterministic regression test. The residual risk is a genuinely healthy setup split needing more than 120 rendered frames; the 10x readiness window plus the existing post-spawn reconcile limit the consequence to connecting with the latest usable grid instead of waiting indefinitely.

Addresses root cause #2 in #15241 without closing the broader issue.

## AI disclosure

Developed and reviewed with OpenAI Codex assistance.
