### PR TITLE
test(ipc): drop the ssh-pty-provider mock key that names no export

### DIFF
--- a/src/main/ipc/ssh-ipc-module-mocks.ts
+++ b/src/main/ipc/ssh-ipc-module-mocks.ts
@@ -177,8 +177,6 @@ export function createSshIpcMocks(): SshIpcMocks {
       }
     },
     sshPtyProvider: {
-      isSshPtyNotFoundError: (err: unknown) =>
-        (err instanceof Error ? err.message : String(err)).includes('not found'),
       SshPtyProvider: class MockSshPtyProvider {
         constructor(_targetId: unknown, _mux: unknown, _env: unknown, providerGeneration: number) {
           mockPtyProvider.providerGeneration = providerGeneration


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | 0 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

A test can say "pretend this function does X." If you misspell the function's name, nothing complains — the pretend version just sits there unused and the real function keeps running. The test still passes, so nobody notices.

#17222 built a guard that finds those misspellings. This PR fixes one the guard **cannot** see, because it lives in a shared mock object rather than inline in a test file.

## What was wrong

`src/main/providers/ssh-pty-provider.ts` exports exactly one symbol: `SshPtyProvider`.

The shared SSH IPC mock factory also declared `isSshPtyNotFoundError` on it. Nine suites mount that object:

```ts
vi.mock('../providers/ssh-pty-provider', () => mocks.sshPtyProvider)
```

Nobody ever read the key. Production imports `isSshPtyNotFoundError` from `ssh-pty-errors`, which no suite mocks — so the real classifier ran the whole time.

The stub was also **looser** than the real predicate:

| | predicate |
|---|---|
| stub | `String(err).includes('not found')` |
| real | `/PTY ".+" not found/i` |

Anyone reading the stub to work out which reattach verdict a test exercised would have got the wrong answer.

## Why the ratchet misses it

#17222's guard reads factory keys off an **object literal**. This factory returns an identifier (`mocks.sshPtyProvider`), which the guard deliberately drops whole rather than half-checking — a documented fail-open. This is that skip's first known occupant.

## Before / after

Test-only, so the effect is indirect. The class of bug now foreclosed: **a stub of the SSH PTY error classifier that silently disagrees with the real one.** That classifier drives a three-way verdict in `ssh-relay-session.handlePtyReattachFailure`:

- not not-found → **retain** (unverifiable; leave the remote PTY detached)
- not-found + identity mismatch → **ignore stale** (another pane owns it)
- not-found alone → **drop** (clear ownership, expire the lease, send `pty:exit`)

The third branch tells the renderer a remote process exited. A stub that widened "not found" would have made that branch look tested when it was not. Per `docs/reference/ssh-execution-boundary.md`, misreading `unverifiable` as `exited` orphans live remote work.

## Proof

Deadness — replaced the key with a getter that throws on any access:

| | result |
|---|---|
| dead key throws | **82/82 green** across all 9 consumers |
| same getter on sibling `SshPtyProvider` (positive control) | **19/21 red** |

The classification stays independently pinned after deletion:

| ablation | tests reddened |
|---|---|
| `isSshPtyNotFoundError` → always `false` | 5 |
| `isSshPtyNotFoundError` → always `true` | 25 |
| `isSshPtyIdentityMismatchError` → always `false` | 5 |

## Gates

- `pnpm tc` — **exit 0**, run in the foreground
- `src/main/ipc/` — 3375 passed, 1 skipped, **0 failed**
- `src/main/ipc/` + `src/main/ssh/` + `src/main/providers/` — 5916 passed, **0 failed**
- `oxlint`, code-quality native config, `oxfmt --check` — all clean

Based on `main` at `a1f198be0d96c7152997a1fd178ad4f201fa7e67`. Independent of #17222 — it fixes the complement of what that guard can reach.
