### PR TITLE
perf(browser): release popup origin bar contents

### DIFF
--- a/src/main/browser/popup-origin-bar-window.test.ts
+++ b/src/main/browser/popup-origin-bar-window.test.ts
@@ -285,6 +285,7 @@ describe('openPopupWithOriginBar', () => {
   it('closes the window when the popup content is destroyed, without re-closing the contents', () => {
     const adopted = createFakeWebContents()
     openPopupWithOriginBar({ webContents: adopted as never }, 'https://example.com/')
+    const { bar } = lastViews()
 
     adopted.emit('destroyed')
 
@@ -292,6 +293,7 @@ describe('openPopupWithOriginBar', () => {
     // The window's closed handler must not call close() on already-destroyed
     // contents — that throws in real Electron.
     expect(adopted.close).not.toHaveBeenCalled()
+    expect(bar.webContents.close).toHaveBeenCalledTimes(1)
   })
 
   it('re-asserts the origin when the popup finishes loading', () => {
@@ -326,11 +328,54 @@ describe('openPopupWithOriginBar', () => {
     const adopted = createFakeWebContents()
     const onClosed = vi.fn()
     const popup = openPopupWithOriginBar({ webContents: adopted as never }, 'https://example.com/')
+    const { bar } = lastViews()
     popup.onClosed(onClosed)
 
     popup.close()
 
     expect(adopted.close).toHaveBeenCalledTimes(1)
+    expect(bar.webContents.close).toHaveBeenCalledTimes(1)
     expect(onClosed).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases every origin bar across repeated popup lifecycles', () => {
+    const cycleCount = 25
+    const originBars: FakeWebContents[] = []
+
+    for (let cycle = 0; cycle < cycleCount; cycle += 1) {
+      const popup = openPopupWithOriginBar({}, `https://example.com/${cycle}`)
+      originBars.push(lastViews().bar.webContents)
+      popup.close()
+    }
+
+    expect(originBars.filter((contents) => contents.close.mock.calls.length === 1)).toHaveLength(
+      cycleCount
+    )
+  })
+
+  it('tolerates an origin bar destroyed before its window closes', () => {
+    const adopted = createFakeWebContents()
+    const onClosed = vi.fn()
+    const popup = openPopupWithOriginBar({ webContents: adopted as never }, 'https://example.com/')
+    popup.onClosed(onClosed)
+    const { bar } = lastViews()
+    const barWebContents = bar.webContents
+    barWebContents.emit('destroyed')
+    Object.defineProperty(bar, 'webContents', { get: () => undefined })
+
+    expect(() => popup.close()).not.toThrow()
+    expect(adopted.close).toHaveBeenCalledTimes(1)
+    expect(barWebContents.close).not.toHaveBeenCalled()
+    expect(onClosed).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes both child contents when popup preparation fails', () => {
+    const adopted = createFakeWebContents()
+
+    openPopupWithOriginBar({ webContents: adopted as never }, 'https://example.com/', () => false)
+
+    expect(adopted.close).toHaveBeenCalledTimes(1)
+    expect(lastViews().bar.webContents.close).toHaveBeenCalledTimes(1)
+    expect(lastWindow().close).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/browser/popup-origin-bar-window.ts
+++ b/src/main/browser/popup-origin-bar-window.ts
@@ -92,7 +92,8 @@ function clampPopupContentSize(options: PopupChildWindowOptions): {
 // caller's popup bookkeeping cannot leak an entry for a window that no longer exists.
 function closeUnpreparedPopup(
   window: BaseWindow,
-  contentWebContents: Electron.WebContents
+  contentWebContents: Electron.WebContents,
+  originBarWebContents: Electron.WebContents
 ): PopupOriginBarWindow {
   const closedListeners: (() => void)[] = []
   let closed = false
@@ -104,6 +105,9 @@ function closeUnpreparedPopup(
   })
   if (!contentWebContents.isDestroyed()) {
     contentWebContents.close()
+  }
+  if (!originBarWebContents.isDestroyed()) {
+    originBarWebContents.close()
   }
   if (!window.isDestroyed()) {
     window.close()
@@ -159,6 +163,7 @@ export function openPopupWithOriginBar(
   const originBarView = new WebContentsView({
     webPreferences: { contextIsolation: true, nodeIntegration: false, sandbox: true }
   })
+  const originBarWebContents = originBarView.webContents
   const contentView = new WebContentsView({
     // Why: Electron rejects an explicitly undefined webContents; omitting it
     // lets WebContentsView create contents for Cmd/Ctrl-click popups.
@@ -188,7 +193,7 @@ export function openPopupWithOriginBar(
 
   const contentWebContents = contentView.webContents
   if (prepareContent && !prepareContent(contentWebContents)) {
-    return closeUnpreparedPopup(window, contentWebContents)
+    return closeUnpreparedPopup(window, contentWebContents, originBarWebContents)
   }
   let currentUrl = initialUrl
   const renderOrigin = (): void => {
@@ -202,15 +207,15 @@ export function openPopupWithOriginBar(
     }
     // Why: textContent + JSON encoding — the URL is attacker-controlled and
     // must never be interpolated into the bar's markup.
-    void originBarView.webContents
+    void originBarWebContents
       .executeJavaScript(
         `document.body.classList.toggle('insecure', ${insecure ? 'true' : 'false'});` +
           `document.getElementById('origin').textContent = ${JSON.stringify(label)};`
       )
       .catch(() => {})
   }
-  originBarView.webContents.once('did-finish-load', renderOrigin)
-  void originBarView.webContents.loadURL(
+  originBarWebContents.once('did-finish-load', renderOrigin)
+  void originBarWebContents.loadURL(
     `data:text/html;charset=utf-8,${encodeURIComponent(ORIGIN_BAR_HTML)}`
   )
 
@@ -252,6 +257,10 @@ export function openPopupWithOriginBar(
       // Why: close() (not destroy) so the page's unload handlers run — OAuth
       // pages often notify the opener from unload.
       contentWebContents.close()
+    }
+    // Why: BaseWindow does not destroy child WebContentsView contents when it closes.
+    if (!originBarWebContents.isDestroyed()) {
+      originBarWebContents.close()
     }
     for (const listener of closedListeners) {
       listener()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

## ELI5

Each browser popup contains two mini browser pages: the site itself and Orca's origin strip above it. Electron closes the outer `BaseWindow` but deliberately leaves both child pages alive. Orca already closed the site page, but forgot the origin strip, so every popup could leave one hidden `WebContents` behind. This closes both children.

## What Changed

- Close the origin-bar `WebContents` after the popup content during normal window teardown.
- Close it on content self-destruction and fail-closed popup preparation paths too.
- Cache the bar contents while valid, because Electron's getter becomes empty after independent destruction.
- Cover normal close, content self-destruction, preparation failure, an already-destroyed bar, and 25 repeated popup lifecycles.

## Why

Electron 43's documented [`BaseWindow` resource-management contract](https://github.com/electron/electron/blob/v43.1.0/docs/api/base-window.md#resource-management) says closing the window does not destroy child `WebContentsView.webContents`; applications must close each child explicitly. Leaving the Orca-controlled bar alive accumulates renderer-side WebContents resources as users open OAuth/SSO and other browser popups.

## Linked Issue

N/A — found during the performance audit. An overlap search found no open issue or PR owning this lifecycle leak; the similarly worded popup issues found were unrelated.

## Visual Proof

N/A — popup appearance and interaction are intentionally unchanged. The invisible cleanup was verified through the rendered Electron surface and CDP target lifecycle:

- Baseline: 2 targets (`Orca` page + opener webview).
- Visible popup open: 4 targets; the added targets were the 500×400 popup content and the 500×34 origin strip displaying `http://127.0.0.1:8899`.
- Clicked the visible **Close popup** button: returned to the exact same 2 baseline target IDs, with neither popup target stranded.

## Measurement Proof

Deterministic red/green tests against the production boundary:

| Lifecycle | Before | After |
| --- | ---: | ---: |
| Normal close | 0/1 origin bars closed | 1/1 |
| `prepareContent` failure | 0/1 origin bars closed | 1/1 |
| 25 repeated popup cycles | 0/25 origin bars closed | 25/25 |

The old implementation failed both one-cycle assertions with “expected once, received zero.”

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated
- `pnpm test src/main/browser/popup-origin-bar-window.test.ts` — 19/19 passed
- `pnpm tc:node` — passed
- `pnpm run check:code-quality:changed` — 0 findings across 2 changed files
- `git diff --check` — clean
- Electron 43.1.0 on macOS via Playwright CDP — intended worktree/branch identity confirmed; popup opened and closed through its real rendered controls

Linux/Windows were not manually exercised. The changed path uses only Electron lifecycle APIs with no platform branch; CI covers the platform matrix.

## No-user-regression signoff

- Popup content still receives `close()` first, preserving its unload/opener notification semantics.
- The isolated Orca data-URL bar closes second; no popup layout, navigation, title, session, or origin-display behavior changes.
- Destroyed-content guards remain in place, including the Electron edge where a destroyed view's getter becomes empty.
- No IPC, remote wire, SSH execution, Git, filesystem path, workspace-kind, or provider behavior changes.

## Review

Independent lifecycle review found no merge blocker after the cached-WebContents guard was added. The implementation matches Electron's explicit ownership contract.

## Merge Risk

Low. This is a two-file ownership fix localized to popup teardown. The main risk is changing close ordering; the implementation deliberately retains the existing graceful content close first and only then releases Orca's origin strip. Automated coverage exercises every reachable teardown path.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Targeted tests, node typecheck, and changed-code quality pass; full platform/package coverage is delegated to CI
