### PR TITLE
test: read the vi.mock factories that hand back a shared mock module, and report dead keys by mock shape

### DIFF
--- a/src/main/daemon/daemon-init-dependency-mocks.ts
+++ b/src/main/daemon/daemon-init-dependency-mocks.ts
@@ -33,7 +33,6 @@ export function createDaemonInitModuleFactories(state: DaemonInitMockState) {
     getProcessStartedAtMsMock,
     parseDaemonPidFileMock,
     replaceDaemonPidFileMock,
-    getDaemonCommandLineMock,
     unlinkOwnedDaemonPidFileMock,
     daemonClientMock,
     spawnerInstances,
@@ -174,7 +173,6 @@ export function createDaemonInitModuleFactories(state: DaemonInitMockState) {
       healthCheckDaemon: healthCheckDaemonMock
     }),
     daemonPidIdentity: () => ({
-      getDaemonCommandLine: getDaemonCommandLineMock,
       getDaemonLaunchIdentity: getDaemonLaunchIdentityMock
     }),
     daemonTccAttribution: () => ({

--- a/src/main/daemon/daemon-init-mock-types.ts
+++ b/src/main/daemon/daemon-init-mock-types.ts
@@ -122,7 +122,6 @@ export type DaemonInitMockState = {
     (...args: unknown[]) => { pid: number; startedAtMs: number | null } | null
   >
   replaceDaemonPidFileMock: Mock<(...args: unknown[]) => boolean>
-  getDaemonCommandLineMock: Mock<(pid: number) => Promise<string | null>>
   unlinkOwnedDaemonPidFileMock: Mock<(...args: unknown[]) => boolean>
   launchedStartedAtMs: { current: number }
   readLaunchedDaemonIdentity: () => LaunchedDaemonIdentity | null

--- a/src/main/daemon/daemon-init-test-harness.ts
+++ b/src/main/daemon/daemon-init-test-harness.ts
@@ -81,7 +81,6 @@ function createDaemonInitMockState(): DaemonInitMockState {
     (): { pid: number; startedAtMs: number | null } | null => null
   )
   const replaceDaemonPidFileMock = vi.fn(() => true)
-  const getDaemonCommandLineMock = vi.fn(async (_pid: number): Promise<string | null> => null)
   const unlinkOwnedDaemonPidFileMock = vi.fn(() => true)
   const launchedStartedAtMs = { current: 1_000_000 }
 
@@ -176,7 +175,6 @@ function createDaemonInitMockState(): DaemonInitMockState {
     getProcessStartedAtMsMock,
     parseDaemonPidFileMock,
     replaceDaemonPidFileMock,
-    getDaemonCommandLineMock,
     unlinkOwnedDaemonPidFileMock,
     launchedStartedAtMs,
     readLaunchedDaemonIdentity,

--- a/src/main/ipc/ssh-ipc-module-mocks.ts
+++ b/src/main/ipc/ssh-ipc-module-mocks.ts
@@ -200,8 +200,7 @@ export function createSshIpcMocks(): SshIpcMocks {
       setPtyOwnership: vi.fn(),
       getSshPtyProvider: vi.fn(),
       getPtyIdsForConnection: vi.fn().mockReturnValue([]),
-      isCurrentPtyExit: vi.fn().mockReturnValue(true),
-      isRendererPtyOutputPaused: vi.fn().mockReturnValue(false)
+      isCurrentPtyExit: vi.fn().mockReturnValue(true)
     },
     sshFilesystemDispatch: {
       registerSshFilesystemProvider: vi.fn(),

--- a/src/main/ipc/ssh-ipc-module-mocks.ts
+++ b/src/main/ipc/ssh-ipc-module-mocks.ts
@@ -177,8 +177,6 @@ export function createSshIpcMocks(): SshIpcMocks {
       }
     },
     sshPtyProvider: {
-      isSshPtyNotFoundError: (err: unknown) =>
-        (err instanceof Error ? err.message : String(err)).includes('not found'),
       SshPtyProvider: class MockSshPtyProvider {
         constructor(_targetId: unknown, _mux: unknown, _env: unknown, providerGeneration: number) {
           mockPtyProvider.providerGeneration = providerGeneration

--- a/src/renderer/src/components/browser-cookie-import-google-disclosure.test.tsx
+++ b/src/renderer/src/components/browser-cookie-import-google-disclosure.test.tsx
@@ -13,7 +13,7 @@ const DISCLOSURE_TITLE = "Google logins aren't imported"
 const DISCLOSURE_DESCRIPTION = 'Sign in to Google directly in Orca.'
 
 vi.mock('@/components/ui/dropdown-menu', () => dropdownMenuStubs())
-vi.mock('../ui/dropdown-menu', () => dropdownMenuStubs())
+vi.mock('./ui/dropdown-menu', () => dropdownMenuStubs())
 vi.mock('@/components/ui/popover', () => popoverStubs())
 vi.mock('@/store', () => ({ useAppStore: appStoreStub() }))
 vi.mock('../store', () => ({ useAppStore: appStoreStub() }))

--- a/src/shared/dead-mock-key-ban.test.ts
+++ b/src/shared/dead-mock-key-ban.test.ts
@@ -3,6 +3,8 @@ import { beforeAll, describe, expect, it } from 'vitest'
 import type { parseAst as ParseAstFn } from 'vite' with { 'resolution-mode': 'import' }
 import type { AstNode, ParseProgram } from './source-scan/module-export-names'
 import { readExportedNames, resolveRelativeModule } from './source-scan/module-export-names'
+import type { MockShape } from './source-scan/mock-factory-reader'
+import { createMockReaderContext, readMockFactory } from './source-scan/mock-factory-reader'
 import { scanSourceTree } from './source-scan/source-tree-scan'
 
 // Dynamic import: vite is ESM-only and this file typechecks under tsconfig.tc.cli.json's node16/CJS.
@@ -26,40 +28,28 @@ beforeAll(async () => {
  * in seven clusters. The two largest were symbols that had been renamed or moved
  * out of the mocked module, leaving eight SSH-relay suites and 56 terminal-pane
  * suites each carrying a stub that had never once been reached.
- */
-
-type MockCall = { specifier: string; keys: string[] }
-
-/** Unwraps a factory to the object literal it yields, or null if not statically known. */
-function factoryObject(node: AstNode | undefined): AstNode | null {
-  let current: AstNode | undefined = node
-  if (current?.type === 'ArrowFunctionExpression' || current?.type === 'FunctionExpression') {
-    // A concise arrow body is one node; a block body is a statement list.
-    current = Array.isArray(current.body) ? undefined : current.body
-    if (current?.type === 'BlockStatement') {
-      const statements = Array.isArray(current.body) ? current.body : []
-      current = statements.findLast((statement) => statement.type === 'ReturnStatement')?.argument
-    }
-  }
-  const TRANSPARENT = [
-    'TSAsExpression',
-    'ParenthesizedExpression',
-    'AwaitExpression',
-    'TSSatisfiesExpression'
-  ]
-  while (current && TRANSPARENT.includes(current.type)) {
-    current = current.expression ?? current.argument
-  }
-  return current?.type === 'ObjectExpression' ? current : null
-}
-
-/**
- * Every statically readable `vi.mock`/`vi.doMock` in a file.
  *
- * A factory whose keys cannot all be read -- a computed key, or a returned
- * identifier -- is dropped whole rather than half-checked, so the guard never
- * accuses a key it did not actually see.
+ * Two things decide whether one of these is noise or a bug, and the guard reports
+ * them apart:
+ *
+ * - A **wholesale** factory replaces the module outright, so a name it does not
+ *   list resolves to `undefined` and production throws on first use. The dead key
+ *   is inert -- a comment that reads like a stub.
+ * - A **partial** factory spreads the genuine module in, so a name it does not
+ *   list still resolves to the real export. There, a dead key means the suite has
+ *   been exercising production code it believes it stubbed, and the green is
+ *   telling you nothing. That is the shape worth waking someone for.
+ *
+ * Reading the factory is the hard half. Most of the tree does not write an object
+ * literal inline: it hands back a shared mock module (`() => mocks.sshPtyProvider`,
+ * `async () => (await import('./m')).xMock(await importOriginal())`). An
+ * object-literal-only reader skips 29% of the `vi.mock` calls in the tree, and the
+ * one dead key that was hiding a real call lived in exactly that gap.
  */
+
+type MockCall = { specifier: string; factory: AstNode | undefined }
+
+/** Every `vi.mock`/`vi.doMock` in a file, paired with the factory expression it was given. */
 function readMockCalls(program: { body: AstNode[] }): MockCall[] {
   const calls: MockCall[] = []
   const stack: unknown[] = [program]
@@ -92,33 +82,26 @@ function readMockCall(call: AstNode): MockCall[] {
   const target = args[0]
   // `vi.mock(import('./x'), ...)` names its module through an import expression.
   const specifier = target?.type === 'Literal' ? target.value : target?.source?.value
-  const object = factoryObject(args[1])
-  if (typeof specifier !== 'string' || !object) {
+  if (typeof specifier !== 'string' || args.length < 2) {
     return []
   }
-  const keys: string[] = []
-  for (const property of object.properties ?? []) {
-    // A spread carries the real module's exports through; its own keys are not ours to judge.
-    if (property.type === 'SpreadElement') {
-      continue
-    }
-    const key = property.computed ? undefined : (property.key?.name ?? property.key?.value)
-    if (typeof key !== 'string') {
-      return []
-    }
-    keys.push(key)
-  }
-  return [{ specifier, keys }]
+  return [{ specifier, factory: args[1] }]
 }
 
 describe('dead vi.mock factory keys', () => {
   const repoRoot = resolve(__dirname, '..', '..')
-  const offenders: string[] = []
+  /** Dead keys in a factory that spreads the real module: the real export answers instead. */
+  const leakingOffenders: string[] = []
+  /** Dead keys in a factory that replaces the module outright: inert, but a lie in the fixture. */
+  const inertOffenders: string[] = []
   const phantomPaths: string[] = []
   const unparseable: string[] = []
   let filesScanned = 0
   let mockCallsSeen = 0
   let mockCallsChecked = 0
+  let partialMocksSeen = 0
+  let partialMocksChecked = 0
+  let factoriesUnreadable = 0
 
   beforeAll(() => {
     const scanned = scanSourceTree(resolve(repoRoot, 'src'), { includeTests: true })
@@ -130,6 +113,7 @@ describe('dead vi.mock factory keys', () => {
       parseAst(sources.get(file) ?? '', {
         lang: file.endsWith('.tsx') ? 'tsx' : 'ts'
       }) as unknown as { body: AstNode[] }
+    const readerContext = createMockReaderContext(parse)
     const exportCache = new Map<string, ReturnType<typeof readExportedNames>>()
     const exportsOf = (file: string): ReturnType<typeof readExportedNames> => {
       const cached = exportCache.get(file)
@@ -155,6 +139,15 @@ describe('dead vi.mock factory keys', () => {
       }
       for (const call of readMockCalls(program)) {
         mockCallsSeen += 1
+        const reading = readMockFactory(call.factory, file.path, readerContext)
+        if (!reading) {
+          factoriesUnreadable += 1
+          continue
+        }
+        const shape: MockShape = reading.shape
+        if (shape === 'partial') {
+          partialMocksSeen += 1
+        }
         const target = resolveRelativeModule(file.path, call.specifier)
         if (!target) {
           // A relative path that resolves to nothing is the same bug one level up:
@@ -170,8 +163,16 @@ describe('dead vi.mock factory keys', () => {
           continue
         }
         mockCallsChecked += 1
-        for (const key of call.keys.filter((name) => !names.has(name))) {
-          offenders.push(`${file.relativePath}: vi.mock('${call.specifier}') key '${key}'`)
+        if (shape === 'partial') {
+          partialMocksChecked += 1
+        }
+        const dead = reading.keys.filter((name) => !names.has(name))
+        const site = `${file.relativePath}: vi.mock('${call.specifier}')`
+        for (const key of dead) {
+          // An unresolved spread could be the real module, so `unknown` is graded
+          // with `partial`: the guard does not get to assume the safe answer.
+          const into = shape === 'wholesale' ? inertOffenders : leakingOffenders
+          into.push(`${site} key '${key}'`)
         }
       }
     }
@@ -183,6 +184,20 @@ describe('dead vi.mock factory keys', () => {
     expect(filesScanned).toBeGreaterThan(5000)
     expect(mockCallsSeen).toBeGreaterThan(2000)
     expect(mockCallsChecked).toBeGreaterThan(1000)
+  })
+
+  it('reads all but a handful of the factories it finds', () => {
+    // The reader resolves 10514 of 10556 factories today. A regression that made it
+    // give up would empty the offender lists without failing anything else, so the
+    // rate is asserted rather than assumed.
+    expect(factoriesUnreadable).toBeLessThan(mockCallsSeen / 20)
+  })
+
+  it('reaches the partial mocks, where a dead key is dangerous rather than inert', () => {
+    // The population that matters. If this floor ever collapses, the assertion below
+    // it is green because nothing was looked at, not because nothing was wrong.
+    expect(partialMocksSeen).toBeGreaterThan(800)
+    expect(partialMocksChecked).toBeGreaterThan(300)
   })
 
   it('parses every file that mocks a module', () => {
@@ -197,12 +212,22 @@ describe('dead vi.mock factory keys', () => {
     ).toEqual([])
   })
 
+  it('has no dead factory key in a mock that spreads the real module', () => {
+    expect(
+      leakingOffenders,
+      'This vi.mock spreads the real module and then names a key it does not export, so the ' +
+        'genuine export is what the code under test received. Whatever this suite believes it ' +
+        'stubbed, it did not: treat its green as unproven until the key is corrected.'
+    ).toEqual([])
+  })
+
   it('has no factory key that the mocked module does not export', () => {
     expect(
-      offenders,
-      'This vi.mock key matches no export of that module, so the mock never applies and the ' +
-        'real implementation runs. Point it at the module that actually exports the symbol, ' +
-        'fix the name, or delete the key.'
+      inertOffenders,
+      'This vi.mock key matches no export of that module. The factory replaces the module ' +
+        'outright, so nothing reads the key and no test is wrong because of it -- but it reads ' +
+        'as a stub that is doing something. Fix the name, point it at the module that exports ' +
+        'the symbol, or delete the key.'
     ).toEqual([])
   })
 })

--- a/src/shared/source-scan/mock-factory-reader.test.ts
+++ b/src/shared/source-scan/mock-factory-reader.test.ts
@@ -1,0 +1,174 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import type { parseAst as ParseAstFn } from 'vite' with { 'resolution-mode': 'import' }
+import type { AstNode, ParseProgram } from './module-export-names'
+import { createMockReaderContext, readMockFactory } from './mock-factory-reader'
+import type { MockFactoryReading } from './mock-factory-reader'
+
+let parseAst: typeof ParseAstFn
+
+beforeAll(async () => {
+  ;({ parseAst } = await import('vite'))
+})
+
+/**
+ * The reader decides whether a `vi.mock` key is checked at all, so a regression
+ * here is silent: the guard reports an empty list and everyone reads that as
+ * clean. Each case below is a factory shape that actually appears in the tree,
+ * plus the shapes that must fail closed rather than be guessed at.
+ */
+
+let workspace: string | null = null
+
+afterEach(() => {
+  if (workspace) {
+    rmSync(workspace, { recursive: true, force: true })
+    workspace = null
+  }
+})
+
+/** Reads the first `vi.mock` factory in `entry`, with `files` on disk beside it. */
+function read(files: Record<string, string>, entry = 'suite.test.ts'): MockFactoryReading | null {
+  workspace = mkdtempSync(join(tmpdir(), 'mock-factory-'))
+  for (const [name, source] of Object.entries(files)) {
+    writeFileSync(join(workspace, name), source)
+  }
+  const parse: ParseProgram = (file) =>
+    parseAst(readFileSync(file, 'utf8'), {
+      lang: file.endsWith('.tsx') ? 'tsx' : 'ts'
+    }) as unknown as { body: AstNode[] }
+  const entryPath = join(workspace, entry)
+  const program = parse(entryPath)
+  let factory: AstNode | undefined
+  const stack: unknown[] = [program]
+  while (stack.length > 0 && !factory) {
+    const node = stack.pop()
+    if (!node || typeof node !== 'object') {
+      continue
+    }
+    if (Array.isArray(node)) {
+      stack.push(...node)
+      continue
+    }
+    const candidate = node as AstNode
+    if (
+      candidate.type === 'CallExpression' &&
+      candidate.callee?.type === 'MemberExpression' &&
+      candidate.callee.object?.name === 'vi' &&
+      candidate.callee.property?.name === 'mock'
+    ) {
+      factory = candidate.arguments?.[1]
+      break
+    }
+    stack.push(...Object.values(candidate as Record<string, unknown>))
+  }
+  return readMockFactory(factory, entryPath, createMockReaderContext(parse))
+}
+
+describe('readMockFactory', () => {
+  it('reads an inline object literal', () => {
+    expect(read({ 'suite.test.ts': `vi.mock('./x', () => ({ a: 1, b: 2 }))` })).toEqual({
+      keys: ['a', 'b'],
+      shape: 'wholesale'
+    })
+  })
+
+  it('reads a factory that hands back a property of a shared mock module', () => {
+    // The shape that hid the one dead key a real call was reaching through: the
+    // factory returns an identifier, so an object-literal-only reader sees nothing.
+    const reading = read({
+      'mocks.ts': [
+        `export function createMocks() {`,
+        `  const state = { helper: 1 }`,
+        `  const modules = { provider: { Live: class {}, gone: () => false } }`,
+        `  return { ...state, ...modules }`,
+        `}`
+      ].join('\n'),
+      'suite.test.ts': [
+        `const mocks = await vi.hoisted(async () => {`,
+        `  const { createMocks } = await import('./mocks')`,
+        `  return createMocks()`,
+        `})`,
+        `vi.mock('./provider', () => mocks.provider)`
+      ].join('\n')
+    })
+    expect(reading).toEqual({ keys: ['Live', 'gone'], shape: 'wholesale' })
+  })
+
+  it('reads a factory that calls an imported builder', () => {
+    expect(
+      read({
+        'registry.ts': `export const ptyMock = () => ({ spawn: 1 })`,
+        'suite.test.ts': `vi.mock('./pty', async () => (await import('./registry')).ptyMock())`
+      })
+    ).toEqual({ keys: ['spawn'], shape: 'wholesale' })
+  })
+
+  it('reads a factory built through a then-callback', () => {
+    expect(
+      read({
+        'registry.ts': `export const wslMock = () => ({ runWsl: 1 })`,
+        'suite.test.ts': `vi.mock('./wsl', () => import('./registry').then((m) => m.wslMock()))`
+      })
+    ).toEqual({ keys: ['runWsl'], shape: 'wholesale' })
+  })
+
+  it('calls a spread of importOriginal partial, not wholesale', () => {
+    // The distinction the guard reports on: here an unlisted name still resolves
+    // to the genuine export, so a dead key means production ran.
+    expect(
+      read({
+        'suite.test.ts': `vi.mock('./x', async (importOriginal) => ({ ...(await importOriginal()), a: 1 }))`
+      })
+    ).toEqual({ keys: ['a'], shape: 'partial' })
+  })
+
+  it('carries partial through a builder that spreads its argument', () => {
+    expect(
+      read({
+        'registry.ts': `export function build(actual) { return { ...actual, sampled: 1 } }`,
+        'suite.test.ts': [
+          `vi.mock('./x', async (importOriginal) => {`,
+          `  const { build } = await import('./registry')`,
+          `  return build(await importOriginal())`,
+          `})`
+        ].join('\n')
+      })
+    ).toEqual({ keys: ['sampled'], shape: 'partial' })
+  })
+
+  it('calls a spread of vi.importActual partial', () => {
+    expect(
+      read({
+        'suite.test.ts': `vi.mock('./x', async () => ({ ...(await vi.importActual('./x')), a: 1 }))`
+      })
+    ).toEqual({ keys: ['a'], shape: 'partial' })
+  })
+
+  it('reports an unreadable spread as unknown rather than assuming wholesale', () => {
+    // Grading this `wholesale` would let a real partial mock be reported as noise.
+    expect(read({ 'suite.test.ts': `vi.mock('./x', () => ({ ...whatever, a: 1 }))` })).toEqual({
+      keys: ['a'],
+      shape: 'unknown'
+    })
+  })
+
+  it('gives up on a computed key rather than naming a key it did not read', () => {
+    expect(read({ 'suite.test.ts': `vi.mock('./x', () => ({ [name]: 1 }))` })).toBeNull()
+  })
+
+  it('gives up when the factory returns an identifier it cannot resolve', () => {
+    expect(read({ 'suite.test.ts': `vi.mock('./x', () => somethingElse)` })).toBeNull()
+  })
+
+  it('gives up on a builder whose result depends on which branch returned', () => {
+    expect(
+      read({
+        'registry.ts': `export function build(flag) { if (flag) { return { a: 1 } } return { b: 2 } }`,
+        'suite.test.ts': `vi.mock('./x', async () => (await import('./registry')).build(true))`
+      })
+    ).toBeNull()
+  })
+})

--- a/src/shared/source-scan/mock-factory-reader.ts
+++ b/src/shared/source-scan/mock-factory-reader.ts
@@ -1,0 +1,287 @@
+import type { AstNode } from './module-export-names'
+import { resolveRelativeModule } from './module-export-names'
+import type { Env, MockReaderContext, Value } from './mock-factory-scope'
+import {
+  MAX_DEPTH,
+  UNKNOWN,
+  collectBindings,
+  moduleEnv,
+  newEnv,
+  returnedExpression,
+  statementsOf,
+  unwrap
+} from './mock-factory-scope'
+
+export type { MockReaderContext } from './mock-factory-scope'
+export { createMockReaderContext } from './mock-factory-scope'
+
+/**
+ * The keys a `vi.mock` factory declares, and whether the real module shows through.
+ *
+ * The literal form -- `vi.mock('./x', () => ({ a, b }))` -- is one read. The rest
+ * of the tree does not use it: the common shape hands the factory a shared mock
+ * module (`() => mocks.sshPtyProvider`, `async () => (await import('./m')).xMock()`),
+ * and a reader that only understands object literals sees none of those keys. The
+ * one dead key that was hiding a real call lived in exactly that blind spot.
+ *
+ * So this walks the expression back to the object literal it yields, across
+ * modules and through calls, binding the factory's `importOriginal` parameter to
+ * the genuine module so a spread of it is recognisable. Every step that cannot be
+ * read statically collapses to `unknown`, and an unknown anywhere drops the whole
+ * factory: the guard must never name a key it did not actually resolve.
+ */
+
+/** `partial` means a spread of the genuine module, so an unlisted name still resolves to production. */
+export type MockShape = 'wholesale' | 'partial' | 'unknown'
+
+export type MockFactoryReading = { keys: string[]; shape: MockShape }
+
+function lookupExport(file: string, name: string, ctx: MockReaderContext): Value {
+  const key = `${file}#${name}`
+  if (ctx.resolving.has(key)) {
+    return UNKNOWN
+  }
+  const env = moduleEnv(file, ctx)
+  if (!env) {
+    return UNKNOWN
+  }
+  ctx.resolving.add(key)
+  try {
+    const direct = lookupLocal(name, env, ctx)
+    if (direct.kind !== 'unknown') {
+      return direct
+    }
+    for (const specifier of env.starExports) {
+      const target = resolveRelativeModule(file, specifier)
+      const reExported = target ? lookupExport(target, name, ctx) : UNKNOWN
+      if (reExported.kind !== 'unknown') {
+        return reExported
+      }
+    }
+    return UNKNOWN
+  } finally {
+    ctx.resolving.delete(key)
+  }
+}
+
+function lookupLocal(name: string, env: Env, ctx: MockReaderContext): Value {
+  for (let scope: Env | null = env; scope; scope = scope.parent) {
+    const bound = scope.values.get(name)
+    if (bound) {
+      return bound
+    }
+    const node = scope.nodes.get(name)
+    if (node) {
+      return evaluate(node, scope, ctx)
+    }
+    const imported = scope.imports.get(name)
+    if (imported) {
+      const target = resolveRelativeModule(scope.file, imported.specifier)
+      if (!target) {
+        return UNKNOWN
+      }
+      return imported.imported === '*'
+        ? { kind: 'namespace', file: target }
+        : lookupExport(target, imported.imported, ctx)
+    }
+  }
+  return UNKNOWN
+}
+
+function importedNamespace(node: AstNode, env: Env): Value {
+  const source = node.source?.value ?? (node.arguments?.[0]?.value as string | undefined)
+  if (typeof source !== 'string') {
+    return UNKNOWN
+  }
+  const target = resolveRelativeModule(env.file, source)
+  return target ? { kind: 'namespace', file: target } : UNKNOWN
+}
+
+/** True for `vi.importActual` / `vi.requireActual` and their bare-imported spellings. */
+function isActualModuleCallee(callee: AstNode | undefined): boolean {
+  const name =
+    callee?.type === 'MemberExpression' ? callee.property?.name : (callee?.name ?? undefined)
+  return name === 'importActual' || name === 'requireActual'
+}
+
+function evaluateCall(node: AstNode, env: Env, ctx: MockReaderContext): Value {
+  const callee = node.callee
+  if (isActualModuleCallee(callee)) {
+    return { kind: 'real' }
+  }
+  // `vi.hoisted(() => ...)` is a pass-through: the value it yields is the binding.
+  if (
+    callee?.type === 'MemberExpression' &&
+    callee.object?.name === 'vi' &&
+    callee.property?.name === 'hoisted'
+  ) {
+    return applyFunction(evaluate(node.arguments?.[0], env, ctx), [], ctx)
+  }
+  // `(await import('./m')).f()` and `import('./m').then((m) => m.f())` both land here.
+  if (callee?.type === 'MemberExpression' && callee.property?.name === 'then') {
+    const settled = evaluate(callee.object as AstNode, env, ctx)
+    return applyFunction(evaluate(node.arguments?.[0] as AstNode, env, ctx), [settled], ctx)
+  }
+  const target = evaluate(callee as AstNode, env, ctx)
+  if (target.kind === 'realFactory') {
+    return { kind: 'real' }
+  }
+  const args = (node.arguments ?? []).map((argument) => evaluate(argument, env, ctx))
+  return applyFunction(target, args, ctx)
+}
+
+function applyFunction(target: Value, args: Value[], ctx: MockReaderContext): Value {
+  if (target.kind !== 'function') {
+    return UNKNOWN
+  }
+  const child = newEnv(target.env.file, target.env)
+  const parameters = target.node.params ?? []
+  parameters.forEach((parameter, index) => {
+    if (parameter.type === 'Identifier' && parameter.name) {
+      child.values.set(parameter.name, args[index] ?? UNKNOWN)
+    }
+  })
+  const body = Array.isArray(target.node.body) ? undefined : target.node.body
+  if (body?.type === 'BlockStatement') {
+    collectBindings(statementsOf(body.body), child)
+  }
+  const returned = returnedExpression(target.node)
+  return returned ? evaluate(returned, child, ctx) : UNKNOWN
+}
+
+function evaluateMember(node: AstNode, env: Env, ctx: MockReaderContext): Value {
+  const name = node.computed ? undefined : node.property?.name
+  if (!name) {
+    return UNKNOWN
+  }
+  const object = evaluate(node.object as AstNode, env, ctx)
+  if (object.kind === 'namespace') {
+    return lookupExport(object.file, name, ctx)
+  }
+  return object.kind === 'object' ? propertyOf(object, name, ctx) : UNKNOWN
+}
+
+/** A property of a resolved object literal, following spreads so a merged shape reads. */
+function propertyOf(
+  object: { kind: 'object'; node: AstNode; env: Env },
+  name: string,
+  ctx: MockReaderContext
+): Value {
+  const properties = (object.node.properties ?? []).toReversed()
+  for (const property of properties) {
+    if (property.type === 'SpreadElement') {
+      const source = evaluate(property.argument as AstNode, object.env, ctx)
+      const found = source.kind === 'object' ? propertyOf(source, name, ctx) : UNKNOWN
+      if (found.kind !== 'unknown') {
+        return found
+      }
+      continue
+    }
+    const key = property.computed ? undefined : (property.key?.name ?? property.key?.value)
+    if (key === name) {
+      return evaluate(property.value as AstNode, object.env, ctx)
+    }
+  }
+  return UNKNOWN
+}
+
+function evaluate(node: AstNode | undefined, env: Env, ctx: MockReaderContext): Value {
+  const current = unwrap(node)
+  if (!current || ctx.depth > MAX_DEPTH) {
+    return UNKNOWN
+  }
+  ctx.depth += 1
+  try {
+    switch (current.type) {
+      case 'ObjectExpression':
+        return { kind: 'object', node: current, env }
+      case 'ArrowFunctionExpression':
+      case 'FunctionExpression':
+      case 'FunctionDeclaration':
+        return { kind: 'function', node: current, env }
+      case 'Identifier':
+        return current.name ? lookupLocal(current.name, env, ctx) : UNKNOWN
+      case 'MemberExpression':
+        return evaluateMember(current, env, ctx)
+      case 'ImportExpression':
+        return importedNamespace(current, env)
+      case 'CallExpression':
+        return evaluateCall(current, env, ctx)
+      default:
+        return UNKNOWN
+    }
+  } finally {
+    ctx.depth -= 1
+  }
+}
+
+/** Every declared key of a resolved object, plus whether the genuine module spreads in. */
+function readObjectKeys(
+  object: { kind: 'object'; node: AstNode; env: Env },
+  ctx: MockReaderContext,
+  seen: Set<AstNode>
+): MockFactoryReading | null {
+  if (seen.has(object.node)) {
+    return null
+  }
+  seen.add(object.node)
+  const keys: string[] = []
+  let shape: MockShape = 'wholesale'
+  for (const property of object.node.properties ?? []) {
+    if (property.type !== 'SpreadElement') {
+      const key = property.computed ? undefined : (property.key?.name ?? property.key?.value)
+      if (typeof key !== 'string') {
+        return null
+      }
+      keys.push(key)
+      continue
+    }
+    const source = evaluate(property.argument as AstNode, object.env, ctx)
+    if (source.kind === 'real') {
+      shape = 'partial'
+      continue
+    }
+    if (source.kind !== 'object') {
+      // An unreadable spread could be the real module, so the shape is not settled;
+      // the named keys are still the named keys.
+      shape = shape === 'partial' ? 'partial' : 'unknown'
+      continue
+    }
+    const nested = readObjectKeys(source, ctx, seen)
+    if (!nested) {
+      return null
+    }
+    keys.push(...nested.keys)
+    shape = nested.shape === 'partial' || shape === 'partial' ? 'partial' : shape
+  }
+  return { keys, shape }
+}
+
+/**
+ * The keys a `vi.mock` factory declares for `file`, or null when it cannot be read.
+ *
+ * `importOriginal` is bound before evaluation so the partial form -- the one where
+ * a dead key is dangerous rather than merely inert -- resolves to `partial`.
+ */
+export function readMockFactory(
+  factory: AstNode | undefined,
+  file: string,
+  ctx: MockReaderContext
+): MockFactoryReading | null {
+  const env = moduleEnv(file, ctx)
+  if (!env) {
+    return null
+  }
+  const node = unwrap(factory)
+  if (!node) {
+    return null
+  }
+  const isFunction =
+    node.type === 'ArrowFunctionExpression' ||
+    node.type === 'FunctionExpression' ||
+    node.type === 'FunctionDeclaration'
+  const value = isFunction
+    ? applyFunction({ kind: 'function', node, env }, [{ kind: 'realFactory' }], ctx)
+    : evaluate(node, env, ctx)
+  return value.kind === 'object' ? readObjectKeys(value, ctx, new Set()) : null
+}

--- a/src/shared/source-scan/mock-factory-scope.ts
+++ b/src/shared/source-scan/mock-factory-scope.ts
@@ -1,0 +1,214 @@
+import type { AstNode, ParseProgram } from './module-export-names'
+
+/**
+ * What a name means inside a `vi.mock` factory, and where to look it up.
+ *
+ * Reading a factory means walking back through the bindings between it and the
+ * object literal it yields -- imports, `vi.hoisted` results, destructured shared
+ * mock modules, function parameters. This is the scope machinery that walk needs;
+ * `mock-factory-reader` is the walk itself.
+ */
+
+export type Value =
+  | { kind: 'object'; node: AstNode; env: Env }
+  | { kind: 'function'; node: AstNode; env: Env }
+  | { kind: 'namespace'; file: string }
+  /** The genuine module, from `importOriginal()` / `vi.importActual()`. */
+  | { kind: 'real' }
+  /** `importOriginal` itself: calling it yields the genuine module. */
+  | { kind: 'realFactory' }
+  | { kind: 'unknown' }
+
+export type ImportRef = { specifier: string; imported: string }
+
+export type Env = {
+  file: string
+  nodes: Map<string, AstNode>
+  imports: Map<string, ImportRef>
+  values: Map<string, Value>
+  starExports: string[]
+  parent: Env | null
+}
+
+export type MockReaderContext = {
+  parse: ParseProgram
+  moduleEnvs: Map<string, Env | null>
+  resolving: Set<string>
+  depth: number
+}
+
+export const UNKNOWN: Value = { kind: 'unknown' }
+export const MAX_DEPTH = 24
+
+const TRANSPARENT = new Set([
+  'TSAsExpression',
+  'TSSatisfiesExpression',
+  'TSNonNullExpression',
+  'TSInstantiationExpression',
+  'ParenthesizedExpression',
+  'AwaitExpression'
+])
+
+export function createMockReaderContext(parse: ParseProgram): MockReaderContext {
+  return { parse, moduleEnvs: new Map(), resolving: new Set(), depth: 0 }
+}
+
+export function unwrap(node: AstNode | undefined): AstNode | undefined {
+  let current = node
+  while (current && TRANSPARENT.has(current.type)) {
+    current = current.expression ?? current.argument
+  }
+  return current
+}
+
+export function statementsOf(node: AstNode | AstNode[] | undefined): AstNode[] {
+  return Array.isArray(node) ? node : []
+}
+
+/**
+ * The single expression a function yields, or undefined.
+ *
+ * More than one `return` means the answer depends on arguments this reader does
+ * not evaluate, so the function is treated as unreadable rather than guessed at.
+ */
+export function returnedExpression(fn: AstNode): AstNode | undefined {
+  const body = Array.isArray(fn.body) ? undefined : fn.body
+  if (body?.type !== 'BlockStatement') {
+    return unwrap(body)
+  }
+  const returns: AstNode[] = []
+  const stack: unknown[] = [statementsOf(body.body)]
+  while (stack.length > 0) {
+    const node = stack.pop()
+    if (!node || typeof node !== 'object') {
+      continue
+    }
+    if (Array.isArray(node)) {
+      stack.push(...node)
+      continue
+    }
+    const candidate = node as AstNode
+    // A nested function's `return` is its own, not this one's.
+    if (candidate.type === 'ArrowFunctionExpression' || candidate.type === 'FunctionExpression') {
+      continue
+    }
+    if (candidate.type === 'ReturnStatement') {
+      returns.push(candidate)
+      continue
+    }
+    stack.push(...Object.values(candidate as Record<string, unknown>))
+  }
+  return returns.length === 1 ? unwrap(returns[0]?.argument) : undefined
+}
+
+export function newEnv(file: string, parent: Env | null): Env {
+  return { file, nodes: new Map(), imports: new Map(), values: new Map(), starExports: [], parent }
+}
+
+export function bindImport(statement: AstNode, env: Env): void {
+  const specifier = statement.source?.value
+  if (typeof specifier !== 'string') {
+    return
+  }
+  for (const entry of statement.specifiers ?? []) {
+    const node = entry as unknown as AstNode
+    const local = node.local?.name ?? node.exported?.name
+    if (!local) {
+      continue
+    }
+    const imported =
+      node.type === 'ImportDefaultSpecifier'
+        ? 'default'
+        : node.type === 'ImportNamespaceSpecifier'
+          ? '*'
+          : (node.imported?.name ?? node.imported?.value ?? node.local?.name)
+    if (typeof imported === 'string') {
+      env.imports.set(local, { specifier, imported })
+    }
+  }
+}
+
+/**
+ * `const x = e` and `const { a, b: c } = e`, the latter as a member read of `e`.
+ *
+ * The destructured form is how a test reaches a shared mock module
+ * (`const { createSshIpcMocks } = await import('./m')`), so skipping it would
+ * leave the guard blind to every factory built that way.
+ */
+export function bindDeclarator(id: AstNode | undefined, init: AstNode | undefined, env: Env): void {
+  if (!id || !init) {
+    return
+  }
+  if (id.type === 'Identifier' && id.name) {
+    env.nodes.set(id.name, init)
+    return
+  }
+  if (id.type !== 'ObjectPattern') {
+    return
+  }
+  for (const property of id.properties ?? []) {
+    const key = property.computed ? undefined : (property.key?.name ?? property.key?.value)
+    const local = (property.value as AstNode | undefined)?.name
+    if (typeof key !== 'string' || !local) {
+      continue
+    }
+    env.nodes.set(local, {
+      type: 'MemberExpression',
+      object: init,
+      property: { type: 'Identifier', name: key },
+      computed: false
+    })
+  }
+}
+
+/** Top-level or block-level `const`/`function`/`import` bindings, by name. */
+export function collectBindings(statements: AstNode[], env: Env): void {
+  for (const statement of statements) {
+    if (statement.type === 'ImportDeclaration') {
+      bindImport(statement, env)
+      continue
+    }
+    if (statement.type === 'ExportAllDeclaration' && !statement.exported?.name) {
+      const specifier = statement.source?.value
+      if (typeof specifier === 'string') {
+        env.starExports.push(specifier)
+      }
+      continue
+    }
+    if (statement.type === 'ExportNamedDeclaration' && statement.source?.value) {
+      bindImport(statement, env)
+      continue
+    }
+    const declared = statement.type === 'ExportNamedDeclaration' ? statement.declaration : statement
+    if (!declared) {
+      continue
+    }
+    if (declared.type === 'VariableDeclaration') {
+      for (const declarator of declared.declarations ?? []) {
+        const entry = declarator as { id?: AstNode; init?: AstNode }
+        bindDeclarator(entry.id, entry.init, env)
+      }
+      continue
+    }
+    if (declared.type === 'FunctionDeclaration' && declared.id?.name) {
+      env.nodes.set(declared.id.name, declared)
+    }
+  }
+}
+
+export function moduleEnv(file: string, ctx: MockReaderContext): Env | null {
+  const cached = ctx.moduleEnvs.get(file)
+  if (cached !== undefined) {
+    return cached
+  }
+  let env: Env | null = null
+  try {
+    const program = ctx.parse(file)
+    env = newEnv(file, null)
+    collectBindings(program.body, env)
+  } catch {
+    env = null
+  }
+  ctx.moduleEnvs.set(file, env)
+  return env
+}

--- a/src/shared/source-scan/module-export-names.ts
+++ b/src/shared/source-scan/module-export-names.ts
@@ -16,8 +16,13 @@ export type AstNode = {
   value?: unknown
   computed?: boolean
   declaration?: AstNode
-  declarations?: { id?: { name?: string } }[]
-  specifiers?: { exported?: { name?: string; value?: string } }[]
+  declarations?: { id?: { name?: string }; init?: AstNode }[]
+  specifiers?: {
+    type?: string
+    exported?: { name?: string; value?: string }
+    local?: { name?: string }
+    imported?: { name?: string; value?: string }
+  }[]
   exported?: { name?: string } | null
   source?: { value?: string }
   id?: { name?: string }
@@ -31,6 +36,10 @@ export type AstNode = {
   argument?: AstNode
   /** An array on a Program or BlockStatement, a single node on a concise arrow body. */
   body?: AstNode | AstNode[]
+  params?: AstNode[]
+  local?: { name?: string }
+  imported?: { name?: string; value?: string }
+  init?: AstNode
 }
 
 export type ParseProgram = (filePath: string) => { body: AstNode[] }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​253 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​54 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​199 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​513 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​502 |

<!-- /orca-pr-loc -->

Stacked on #17222 (`brennanb2025/contract-guards-dead-mock-ratchet`). Also carries the two-line deletion from #17232, which fixes one of the clusters this guard now convicts; that PR may land independently.

## ELI5

When a test wants to isolate the thing it is testing, it swaps a real module for a fake one — `vi.mock('../ssh-pty-provider', () => ({ ... }))`. The fake lists the names the test expects to be used.

Names in that list go stale. Someone renames or deletes the real function; the fake keeps listing the old name. Nobody notices, because a fake nobody calls never complains.

A guard for those stale names already exists, but it could only read a fake written as a plain object right there inside the `vi.mock(...)` call. Plenty of fakes aren't written that way — they're built by a helper, pulled from a shared mock file, or awaited. The guard skipped every one of those: **3,019 of the 10,556 in `src/`**, close to three in ten.

This PR teaches the reader to follow those indirections back to the object they eventually hand over, so it reads **10,514** of them instead of 7,537.

It also learned that a stale name means two different things depending on how the fake is built, and that the two deserve different messages:

- The fake **replaces** the whole module. A stale name is dead weight — a stub that reads like it does something and doesn't. Annoying, not dangerous.
- The fake **spreads the real module in** and overrides a few names. A stale name here means the override never landed, so the test has been calling the real production code while believing it was stubbed. Its green tells you nothing about the code it claims to cover.

## User-facing before/after

**Nothing a user can see changes.** No feature, no bug fix, no shipped code — the guard runs in CI and nowhere else. The effect on the product is indirect and one step removed, and worth stating plainly rather than dressed up.

What it buys is narrower than "catches bugs": it closes a hole through which *a test that proves nothing* could keep passing. The class it now detects is a suite that believes it stubbed a module and has silently been running the real one — the kind of thing that lets a genuine regression land green.

| | Before | After |
|---|---:|---:|
| `vi.mock` factories the guard can read | 7,537 (71.4%) | **10,514 (99.6%)** |
| Factories skipped whole, unchecked | 3,019 | **42** |
| Keys checked against a resolvable module | 1,000+ | **5,941** |
| Partial/spread mocks recognised as partial | 212 | **1,296** |

That the gap was real is not hypothetical: `isSshPtyNotFoundError` was stale across nine SSH IPC suites (#17232) and sat squarely inside it — it had to be found by hand, because the old reader could not open those factories. The wider reader convicts all nine on its own.

**Being honest about severity, though.** The three sites this PR newly convicts are all the low-consequence kind — a module-private daemon helper mocked by name, a `ipc/pty` name that exists nowhere in the repo, and a `vi.mock` path pointing one directory off. Inert stubs, not tests secretly running production code. And the sweep of all 583 spread-mocks whose exports can be enumerated found **zero** dead keys, so there is no dangerous instance outstanding today.

So the value here is a floor, not a rescue: the ~30% of mock factories that were previously invisible are now watched, and the day someone's override quietly stops landing, CI says so instead of going green.

## What was blind

#17222's guard reads a `vi.mock` factory only when it is an inline object literal. That is **7,537 of the 10,556 `vi.mock` calls in `src/`**. The other **3,019** hand back a shared mock module and were skipped whole:

```ts
vi.mock('../providers/ssh-pty-provider', () => mocks.sshPtyProvider)
vi.mock('../pwsh', () => import('./pty-ipc-mock-registry').then((m) => m.pwshModuleMock()))
vi.mock('@/lib/agent-status', async (importOriginal) =>
  buildAgentStatusModuleMock(await importOriginal()))
```

The one dead key known to have been hiding a real call — `isSshPtyNotFoundError` across nine SSH IPC suites, #17232 — sat in exactly that gap and was found by hand.

## The reader

`mock-factory-reader` walks the factory expression back to the object literal it yields: through `vi.hoisted`, `await import`, destructured imports, a call to an imported builder, and `.then` callbacks, binding the factory's `importOriginal` parameter to the genuine module on the way in.

| | before | after |
|---|---:|---:|
| factories read | 7,537 (71.4%) | **10,514 (99.6%)** |
| unreadable | 3,019 | **42** |
| keys checked against a resolvable module | 1,000+ | **5,941** |
| partial/spread mocks recognised | 212 | **1,296** |

Any step that cannot be read statically collapses to `unknown`, and an unknown anywhere drops the factory rather than half-checking it, so the guard still never names a key it did not resolve.

## Shape, reported apart

Reading `importOriginal` is also what lets the guard say which dead keys matter.

- **Wholesale** — the factory replaces the module. An unlisted name resolves to `undefined` and production throws. The dead key is inert: a comment that reads like a stub.
- **Partial** — the factory spreads the real module in. An unlisted name resolves to the **genuine export**, so the suite has been exercising production code it believed it stubbed, and its green means nothing.

These are now two assertions with two messages. A guard that reports them identically teaches people to ignore both.

## The sweep

**1,296 partial/spread mocks exist. 583 of them name a module whose exports can be enumerated. None carries a dead key.** So the 86 keys the first version convicted really were all noise, and this confirms it by measurement rather than by inspection.

## Three new convictions

The wider read caught three sites the literal-only version could not see. Each was confirmed dead by making the key throw on any access, paired with the same getter on a live sibling as a positive control:

| n | site | tell | control |
|---:|---|---|---|
| 10 | `getDaemonCommandLine` on `daemon-pid-identity` — a module-private helper that is not exported at all, mocked beside the exported function that calls it | 80/80 green | `getDaemonLaunchIdentity` → **17/80 red** |
| 9 | `isRendererPtyOutputPaused` on `ipc/pty` — a name that exists nowhere in the repo outside the mock | 82/82 green | `registerSshPtyProvider` → **51/82 red** |
| 1 | `vi.mock('../ui/dropdown-menu')` in the cookie-import disclosure suite — one directory off, so the factory was inert and the real module loaded | — | — |

## Coverage is asserted, not assumed

A reader that quietly stopped resolving would empty the offender lists without failing anything, so the unreadable-factory rate and the count of partial mocks reached both carry floors. Ablating the reader one gate at a time:

| ablation | reader unit tests | ratchet |
|---|---|---|
| remove `vi.hoisted` pass-through | 1/11 red | coverage floor red |
| remove destructured binding | 2/11 red | `reads all but a handful of the factories` red |
| unbind `importOriginal` | 2/11 red | `reaches the partial mocks` red |
| remove `.then` callback | 1/11 red | `reads all but a handful of the factories` red |
| last-return instead of single-return | 1/11 red | green (fail-closed rule, no offender today) |
| grade unreadable spread `wholesale` | 1/11 red | green (fail-closed rule, no offender today) |

Verified against the known instance both ways: with #17232's fix reverted the guard convicts all nine sites; with it applied it convicts none.

## Gates

- `pnpm tc` — **exit 0**, 0 `error TS`
- `oxlint` (native, type-aware, react-doctor) on all 10 changed files — clean
- `src/main/daemon` + `src/main/ipc/ssh*` + the disclosure suite — **168 files, 1,888 tests, 0 failures**
- new guard suites — 18 tests green; full ratchet run 7.4s

