### PR TITLE
fix(editor): route zoom gestures to PDF viewer

### DIFF
--- a/src/renderer/src/components/editor/PdfViewer.tsx
+++ b/src/renderer/src/components/editor/PdfViewer.tsx
@@ -328,7 +328,7 @@ export default function PdfViewer({
     applyPdfScalePreference(viewer, 'page-width', SCALE_BOUNDS)
   }, [])
 
-  usePdfZoomInput({
+  const setContainerRef = usePdfZoomInput({
     containerRef,
     filePath,
     keybindings,
@@ -383,7 +383,7 @@ export default function PdfViewer({
             carries positioning and background since all:revert nullifies classes. */}
         <div style={{ all: 'revert' }}>
           <div
-            ref={containerRef}
+            ref={setContainerRef}
             style={{
               position: 'absolute',
               inset: '0',

--- a/src/renderer/src/components/editor/PdfViewer.tsx
+++ b/src/renderer/src/components/editor/PdfViewer.tsx
@@ -28,6 +28,7 @@ import {
   clampPdfViewPosition,
   createPdfViewPositionRecorder
 } from './pdf-view-position'
+import { usePdfZoomInput } from './use-pdf-zoom-input'
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = workerUrl
 
@@ -327,6 +328,18 @@ export default function PdfViewer({
     applyPdfScalePreference(viewer, 'page-width', SCALE_BOUNDS)
   }, [])
 
+  usePdfZoomInput({
+    containerRef,
+    filePath,
+    keybindings,
+    scaleBounds: SCALE_BOUNDS,
+    scalePreferenceRef,
+    viewerRef: pdfViewerRef,
+    zoomIn,
+    zoomOut,
+    zoomReset
+  })
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent): void => {
       const platform = getShortcutPlatform()
@@ -334,22 +347,11 @@ export default function PdfViewer({
         e.preventDefault()
         e.stopPropagation()
         setFindOpen(true)
-        return
-      }
-      if (keybindingMatchesAction('zoom.in', e, platform, keybindings)) {
-        e.preventDefault()
-        zoomIn()
-      } else if (keybindingMatchesAction('zoom.out', e, platform, keybindings)) {
-        e.preventDefault()
-        zoomOut()
-      } else if (keybindingMatchesAction('zoom.reset', e, platform, keybindings)) {
-        e.preventDefault()
-        zoomReset()
       }
     }
     window.addEventListener('keydown', handleKeyDown, true)
     return () => window.removeEventListener('keydown', handleKeyDown, true)
-  }, [keybindings, zoomIn, zoomOut, zoomReset])
+  }, [keybindings])
 
   const zoomPercent = Math.round(scale * 100)
 

--- a/src/renderer/src/components/editor/pdf-scale-preference.test.ts
+++ b/src/renderer/src/components/editor/pdf-scale-preference.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
+  applyPdfWheelScale,
   applyPdfScalePreference,
   clampPdfScale,
+  getNextPdfWheelScale,
+  shouldHandlePdfZoomWheel,
   stepPdfScalePreference
 } from './pdf-scale-preference'
 
@@ -32,6 +35,79 @@ describe('applyPdfScalePreference', () => {
     const viewer = { currentScale: 1, currentScaleValue: 'auto' }
     applyPdfScalePreference(viewer, 99, BOUNDS)
     expect(viewer.currentScale).toBe(5)
+  })
+})
+
+describe('getNextPdfWheelScale', () => {
+  it('maps wheel direction to bounded PDF zoom', () => {
+    expect(getNextPdfWheelScale(1, -30, 0, BOUNDS)).toBeGreaterThan(1)
+    expect(getNextPdfWheelScale(1, 30, 0, BOUNDS)).toBeLessThan(1)
+    expect(getNextPdfWheelScale(BOUNDS.max, -30, 0, BOUNDS)).toBe(BOUNDS.max)
+    expect(getNextPdfWheelScale(BOUNDS.min, 30, 0, BOUNDS)).toBe(BOUNDS.min)
+  })
+})
+
+describe('applyPdfWheelScale', () => {
+  it('zooms around the pointer and returns the applied scale', () => {
+    const viewer = {
+      currentScale: 1,
+      updateScale: vi.fn(({ scaleFactor }: { scaleFactor: number }) => {
+        viewer.currentScale *= scaleFactor
+      })
+    }
+
+    const applied = applyPdfWheelScale(
+      viewer,
+      { clientX: 120, clientY: 240, deltaMode: 0, deltaY: -30 },
+      BOUNDS
+    )
+
+    expect(applied).toBeGreaterThan(1)
+    expect(viewer.updateScale).toHaveBeenCalledWith({
+      scaleFactor: applied,
+      origin: [120, 240]
+    })
+  })
+
+  it('does not update past a scale bound', () => {
+    const viewer = { currentScale: BOUNDS.max, updateScale: vi.fn() }
+    expect(
+      applyPdfWheelScale(viewer, { clientX: 0, clientY: 0, deltaMode: 0, deltaY: -30 }, BOUNDS)
+    ).toBe(BOUNDS.max)
+    expect(viewer.updateScale).not.toHaveBeenCalled()
+  })
+
+  it('seeds pdf.js before scaling its unknown internal scale', () => {
+    let internalScale = 0
+    const viewer = {
+      get currentScale(): number {
+        return internalScale || 1
+      },
+      set currentScale(scale: number) {
+        internalScale = scale
+      },
+      updateScale: vi.fn(({ scaleFactor }: { scaleFactor: number }) => {
+        internalScale = Math.max(0.1, internalScale * scaleFactor)
+      })
+    }
+
+    const applied = applyPdfWheelScale(
+      viewer,
+      { clientX: 0, clientY: 0, deltaMode: 0, deltaY: 30 },
+      BOUNDS
+    )
+
+    expect(applied).toBeGreaterThan(0.1)
+    expect(applied).toBeCloseTo(getNextPdfWheelScale(1, 30, 0, BOUNDS))
+  })
+})
+
+describe('shouldHandlePdfZoomWheel', () => {
+  it('supports Ctrl/pinch gestures everywhere and Command-wheel on macOS', () => {
+    expect(shouldHandlePdfZoomWheel({ ctrlKey: true, metaKey: false }, 'linux')).toBe(true)
+    expect(shouldHandlePdfZoomWheel({ ctrlKey: false, metaKey: true }, 'linux')).toBe(false)
+    expect(shouldHandlePdfZoomWheel({ ctrlKey: false, metaKey: true }, 'darwin')).toBe(true)
+    expect(shouldHandlePdfZoomWheel({ ctrlKey: true, metaKey: false }, 'darwin')).toBe(true)
   })
 })
 

--- a/src/renderer/src/components/editor/pdf-scale-preference.ts
+++ b/src/renderer/src/components/editor/pdf-scale-preference.ts
@@ -1,3 +1,5 @@
+import { getPinchZoomFactor } from './image-viewer-zoom'
+
 export type PdfScalePreference = 'page-width' | number
 
 export function clampPdfScale(scale: number, min: number, max: number): number {
@@ -28,4 +30,41 @@ export function stepPdfScalePreference(
       ? clampPdfScale(currentScale * bounds.step, bounds.min, bounds.max)
       : clampPdfScale(currentScale / bounds.step, bounds.min, bounds.max)
   return { scale: next, preference: next }
+}
+
+export function getNextPdfWheelScale(
+  currentScale: number,
+  deltaY: number,
+  deltaMode: number,
+  bounds: { min: number; max: number }
+): number {
+  return clampPdfScale(currentScale * getPinchZoomFactor(deltaY, deltaMode), bounds.min, bounds.max)
+}
+
+export function applyPdfWheelScale(
+  viewer: {
+    currentScale: number
+    updateScale: (options: { scaleFactor: number; origin: [number, number] }) => void
+  },
+  event: { clientX: number; clientY: number; deltaMode: number; deltaY: number },
+  bounds: { min: number; max: number }
+): number {
+  const currentScale = viewer.currentScale
+  const nextScale = getNextPdfWheelScale(currentScale, event.deltaY, event.deltaMode, bounds)
+  if (nextScale !== currentScale) {
+    // Why: pdf.js's getter masks its zero-valued unknown scale, so seed it before multiplication.
+    viewer.currentScale = currentScale
+    viewer.updateScale({
+      scaleFactor: nextScale / currentScale,
+      origin: [event.clientX, event.clientY]
+    })
+  }
+  return viewer.currentScale
+}
+
+export function shouldHandlePdfZoomWheel(
+  event: { ctrlKey: boolean; metaKey: boolean },
+  platform: NodeJS.Platform
+): boolean {
+  return event.ctrlKey || (platform === 'darwin' && event.metaKey)
 }

--- a/src/renderer/src/components/editor/use-pdf-zoom-input.test.ts
+++ b/src/renderer/src/components/editor/use-pdf-zoom-input.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+import { replacePdfZoomWheelTarget } from './use-pdf-zoom-input'
+
+describe('replacePdfZoomWheelTarget', () => {
+  it('moves the wheel listener when the PDF container is replaced', () => {
+    const first = document.createElement('div')
+    const second = document.createElement('div')
+    const firstAdd = vi.spyOn(first, 'addEventListener')
+    const firstRemove = vi.spyOn(first, 'removeEventListener')
+    const secondAdd = vi.spyOn(second, 'addEventListener')
+    const secondRemove = vi.spyOn(second, 'removeEventListener')
+    const handleWheel = vi.fn()
+
+    let current = replacePdfZoomWheelTarget(null, first, handleWheel)
+    expect(firstAdd).toHaveBeenCalledWith('wheel', handleWheel, { passive: false })
+
+    current = replacePdfZoomWheelTarget(current, second, handleWheel)
+    expect(firstRemove).toHaveBeenCalledWith('wheel', handleWheel)
+    expect(secondAdd).toHaveBeenCalledWith('wheel', handleWheel, { passive: false })
+
+    current = replacePdfZoomWheelTarget(current, null, handleWheel)
+    expect(secondRemove).toHaveBeenCalledWith('wheel', handleWheel)
+    expect(current).toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/use-pdf-zoom-input.ts
+++ b/src/renderer/src/components/editor/use-pdf-zoom-input.ts
@@ -18,6 +18,16 @@ type PdfWheelZoomViewer = {
   updateScale: (options: { scaleFactor: number; origin: [number, number] }) => void
 }
 
+export function replacePdfZoomWheelTarget(
+  current: HTMLDivElement | null,
+  next: HTMLDivElement | null,
+  handleWheel: (event: WheelEvent) => void
+): HTMLDivElement | null {
+  current?.removeEventListener('wheel', handleWheel)
+  next?.addEventListener('wheel', handleWheel, { passive: false })
+  return next
+}
+
 export function usePdfZoomInput({
   containerRef,
   filePath,
@@ -38,7 +48,7 @@ export function usePdfZoomInput({
   zoomIn: () => void
   zoomOut: () => void
   zoomReset: () => void
-}): void {
+}): (container: HTMLDivElement | null) => void {
   const applyZoomCommand = useCallback(
     (direction: PdfZoomDirection): void => {
       if (direction === 'in') {
@@ -69,12 +79,9 @@ export function usePdfZoomInput({
     [applyZoomCommand, isActiveZoomTarget]
   )
 
-  useEffect(() => {
-    const container = containerRef.current
-    if (!container) {
-      return
-    }
-    const handleWheel = (event: WheelEvent): void => {
+  const handleWheel = useCallback(
+    (event: WheelEvent): void => {
+      // Why: direct wheel input is pointer-owned like ImageViewer; active ownership applies to global commands.
       if (!shouldHandlePdfZoomWheel(event, getShortcutPlatform())) {
         return
       }
@@ -84,12 +91,17 @@ export function usePdfZoomInput({
       if (viewer) {
         scalePreferenceRef.current = applyPdfWheelScale(viewer, event, scaleBounds)
       }
-    }
-    // Why: Chromium exposes trackpad pinch as ctrl-wheel and requires a native
-    // non-passive listener to keep the gesture out of editor/app zoom.
-    container.addEventListener('wheel', handleWheel, { passive: false })
-    return () => container.removeEventListener('wheel', handleWheel)
-  }, [containerRef, scaleBounds, scalePreferenceRef, viewerRef])
+    },
+    [scaleBounds, scalePreferenceRef, viewerRef]
+  )
+
+  const setContainerRef = useCallback(
+    (container: HTMLDivElement | null): void => {
+      // Why: callback refs detach and reattach native listeners when error/recovery replaces the DOM node.
+      containerRef.current = replacePdfZoomWheelTarget(containerRef.current, container, handleWheel)
+    },
+    [containerRef, handleWheel]
+  )
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
@@ -111,4 +123,6 @@ export function usePdfZoomInput({
     window.addEventListener('keydown', handleKeyDown, true)
     return () => window.removeEventListener('keydown', handleKeyDown, true)
   }, [applyZoomCommand, isActiveZoomTarget, keybindings])
+
+  return setContainerRef
 }

--- a/src/renderer/src/components/editor/use-pdf-zoom-input.ts
+++ b/src/renderer/src/components/editor/use-pdf-zoom-input.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, type RefObject } from 'react'
+import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { useAppStore } from '@/store'
+import { keybindingMatchesAction, type KeybindingOverrides } from '../../../../shared/keybindings'
+import {
+  addPdfZoomCommandListener,
+  isActivePdfZoomTarget,
+  type PdfZoomDirection
+} from '@/lib/pdf-zoom-command'
+import {
+  applyPdfWheelScale,
+  shouldHandlePdfZoomWheel,
+  type PdfScalePreference
+} from './pdf-scale-preference'
+
+type PdfWheelZoomViewer = {
+  currentScale: number
+  updateScale: (options: { scaleFactor: number; origin: [number, number] }) => void
+}
+
+export function usePdfZoomInput({
+  containerRef,
+  filePath,
+  keybindings,
+  scaleBounds,
+  scalePreferenceRef,
+  viewerRef,
+  zoomIn,
+  zoomOut,
+  zoomReset
+}: {
+  containerRef: RefObject<HTMLDivElement | null>
+  filePath: string
+  keybindings: KeybindingOverrides | undefined
+  scaleBounds: { min: number; max: number }
+  scalePreferenceRef: RefObject<PdfScalePreference>
+  viewerRef: RefObject<PdfWheelZoomViewer | null>
+  zoomIn: () => void
+  zoomOut: () => void
+  zoomReset: () => void
+}): void {
+  const applyZoomCommand = useCallback(
+    (direction: PdfZoomDirection): void => {
+      if (direction === 'in') {
+        zoomIn()
+      } else if (direction === 'out') {
+        zoomOut()
+      } else {
+        zoomReset()
+      }
+    },
+    [zoomIn, zoomOut, zoomReset]
+  )
+
+  const isActiveZoomTarget = useCallback(
+    () => isActivePdfZoomTarget(containerRef.current, filePath, useAppStore.getState()),
+    [containerRef, filePath]
+  )
+
+  useEffect(
+    () =>
+      addPdfZoomCommandListener((direction) => {
+        if (!isActiveZoomTarget()) {
+          return false
+        }
+        applyZoomCommand(direction)
+        return true
+      }),
+    [applyZoomCommand, isActiveZoomTarget]
+  )
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) {
+      return
+    }
+    const handleWheel = (event: WheelEvent): void => {
+      if (!shouldHandlePdfZoomWheel(event, getShortcutPlatform())) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      const viewer = viewerRef.current
+      if (viewer) {
+        scalePreferenceRef.current = applyPdfWheelScale(viewer, event, scaleBounds)
+      }
+    }
+    // Why: Chromium exposes trackpad pinch as ctrl-wheel and requires a native
+    // non-passive listener to keep the gesture out of editor/app zoom.
+    container.addEventListener('wheel', handleWheel, { passive: false })
+    return () => container.removeEventListener('wheel', handleWheel)
+  }, [containerRef, scaleBounds, scalePreferenceRef, viewerRef])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      const platform = getShortcutPlatform()
+      if (!isActiveZoomTarget()) {
+        return
+      }
+      if (keybindingMatchesAction('zoom.in', event, platform, keybindings)) {
+        event.preventDefault()
+        applyZoomCommand('in')
+      } else if (keybindingMatchesAction('zoom.out', event, platform, keybindings)) {
+        event.preventDefault()
+        applyZoomCommand('out')
+      } else if (keybindingMatchesAction('zoom.reset', event, platform, keybindings)) {
+        event.preventDefault()
+        applyZoomCommand('reset')
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown, true)
+    return () => window.removeEventListener('keydown', handleKeyDown, true)
+  }, [applyZoomCommand, isActiveZoomTarget, keybindings])
+}

--- a/src/renderer/src/hooks/ipc-events/zoom-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/zoom-ipc-bridge.ts
@@ -5,11 +5,15 @@ import { dispatchZoomLevelChanged } from '@/lib/zoom-events'
 import { stepUIZoomLevel } from '../../../../shared/ui-zoom-level'
 import { useAppStore } from '../../store'
 import { resolveZoomTarget } from '../resolve-zoom-target'
+import { dispatchPdfZoomCommand } from '@/lib/pdf-zoom-command'
 
 export function registerZoomIpcBridge(unsubs: (() => void)[]): void {
   // Zoom handling for menu accelerators and keyboard fallback paths.
   unsubs.push(
     window.api.ui.onTerminalZoom((direction) => {
+      if (dispatchPdfZoomCommand(direction)) {
+        return
+      }
       const store = useAppStore.getState()
       const { activeView, activeTabType, editorFontZoomLevel, setEditorFontZoomLevel, settings } =
         store

--- a/src/renderer/src/lib/pdf-zoom-command.test.ts
+++ b/src/renderer/src/lib/pdf-zoom-command.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  addPdfZoomCommandListener,
+  dispatchPdfZoomCommand,
+  isActivePdfZoomTarget,
+  type PdfZoomTargetState
+} from './pdf-zoom-command'
+
+const STATE: PdfZoomTargetState = {
+  activeFileId: 'file-1',
+  activeGroupIdByWorktree: { 'worktree-1': 'group-1' },
+  activeWorktreeId: 'worktree-1',
+  openFiles: [{ id: 'file-1', filePath: '/repo/report.pdf' }]
+}
+
+function visible(element: HTMLElement): HTMLElement {
+  Object.defineProperty(element, 'clientHeight', { configurable: true, value: 600 })
+  return element
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+describe('isActivePdfZoomTarget', () => {
+  it('targets the PDF in the focused split group', () => {
+    const group = document.createElement('div')
+    group.dataset.tabGroupBodyId = 'group-1'
+    group.dataset.worktreeId = 'worktree-1'
+    const container = visible(document.createElement('div'))
+    group.append(container)
+    document.body.append(group)
+
+    expect(isActivePdfZoomTarget(container, '/repo/report.pdf', STATE)).toBe(true)
+    expect(
+      isActivePdfZoomTarget(container, '/repo/report.pdf', {
+        ...STATE,
+        activeGroupIdByWorktree: { 'worktree-1': 'group-2' }
+      })
+    ).toBe(false)
+    expect(isActivePdfZoomTarget(container, '/repo/other.pdf', STATE)).toBe(false)
+  })
+
+  it('uses the active file for the legacy single-pane editor', () => {
+    const container = visible(document.createElement('div'))
+    document.body.append(container)
+
+    expect(isActivePdfZoomTarget(container, '/repo/report.pdf', STATE)).toBe(true)
+    expect(isActivePdfZoomTarget(container, '/repo/other.pdf', STATE)).toBe(false)
+  })
+
+  it('ignores hidden PDF viewers', () => {
+    expect(isActivePdfZoomTarget(document.createElement('div'), '/repo/report.pdf', STATE)).toBe(
+      false
+    )
+  })
+})
+
+describe('PDF zoom command events', () => {
+  it('reports when the active PDF claims a command', () => {
+    const listener = vi.fn(() => true)
+    const remove = addPdfZoomCommandListener(listener)
+
+    expect(dispatchPdfZoomCommand('in')).toBe(true)
+    expect(listener).toHaveBeenCalledWith('in')
+
+    remove()
+    expect(dispatchPdfZoomCommand('out')).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/pdf-zoom-command.ts
+++ b/src/renderer/src/lib/pdf-zoom-command.ts
@@ -1,0 +1,59 @@
+export const PDF_ZOOM_COMMAND_EVENT = 'orca:pdf-zoom-command'
+
+export type PdfZoomDirection = 'in' | 'out' | 'reset'
+
+export type PdfZoomTargetState = {
+  activeFileId: string | null
+  activeGroupIdByWorktree: Record<string, string | undefined>
+  activeWorktreeId: string | null
+  openFiles: { id: string; filePath: string }[]
+}
+
+export function isActivePdfZoomTarget(
+  container: HTMLElement | null,
+  filePath: string,
+  state: PdfZoomTargetState
+): boolean {
+  if (!container || container.clientHeight === 0) {
+    return false
+  }
+
+  const activeFile = state.openFiles.find((file) => file.id === state.activeFileId)
+  if (activeFile?.filePath !== filePath) {
+    return false
+  }
+
+  const groupBody = container.closest<HTMLElement>('[data-tab-group-body-id]')
+  if (groupBody) {
+    const worktreeId = groupBody.dataset.worktreeId
+    return Boolean(
+      worktreeId &&
+      worktreeId === state.activeWorktreeId &&
+      groupBody.dataset.tabGroupBodyId === state.activeGroupIdByWorktree[worktreeId]
+    )
+  }
+
+  return true
+}
+
+export function dispatchPdfZoomCommand(direction: PdfZoomDirection): boolean {
+  const event = new CustomEvent<PdfZoomDirection>(PDF_ZOOM_COMMAND_EVENT, {
+    cancelable: true,
+    detail: direction
+  })
+  window.dispatchEvent(event)
+  return event.defaultPrevented
+}
+
+export function addPdfZoomCommandListener(
+  callback: (direction: PdfZoomDirection) => boolean
+): () => void {
+  const listener = (event: Event): void => {
+    const command = event as CustomEvent<PdfZoomDirection>
+    if (callback(command.detail)) {
+      command.preventDefault()
+    }
+  }
+  window.addEventListener(PDF_ZOOM_COMMAND_EVENT, listener)
+  return () => window.removeEventListener(PDF_ZOOM_COMMAND_EVENT, listener)
+}


### PR DESCRIPTION
## ELI5

Zoom gestures and shortcuts now zoom the PDF itself instead of changing Orca’s editor font size.

## What Changed

- Added cursor-centered Ctrl+scroll and trackpad-pinch zoom to the PDF viewer.
- Added Command+scroll support on macOS.
- Routed the configured zoom-in, zoom-out, and reset shortcuts to the active PDF.
- Preserved PDF zoom bounds and the current zoom preference across content reloads.
- Ensured hidden PDFs and PDFs in unfocused split panes do not receive zoom commands.
- Added regression coverage for pdf.js’s uninitialized scale, which previously caused the first gesture to jump to 10%.

## Why

Electron captures standard zoom commands before the PDF viewer receives them. Because an open PDF uses an editor tab, those commands were incorrectly routed to editor-font zoom, which has no visible effect on the document.

The PDF viewer now claims zoom input only when it is the active target and uses pdf.js’s existing scaling API with the pointer position as the zoom origin.

## Linked Issue

N/A

## Visual Proof

N/A, No visible UI changes are made, only hotkey behavior changed.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated with:

- Focused PDF scale, command-routing, and zoom-target tests
- Regression test for the pdf.js unknown-scale 10% jump
- Renderer web typecheck
- Changed-file lint and React Doctor profiles
- Max-lines ratchet
- Electron E2E-mode bundle build

Automated coverage includes Linux/Windows Ctrl modifiers, macOS Command-wheel, trackpad-style Ctrl-wheel events, scale bounds, pointer-origin scaling, hidden viewers, and focused split-pane ownership.

## AI Disclosure

OpenAI Codex (GPT-5.6 Sol) was used to implement this change. Code are manually reviewed and tested.

## Review

Review focus:

- First-gesture behavior when pdf.js has not initialized its private numeric scale
- Active PDF ownership across split panes and hidden worktrees
- Compatibility with customized global zoom keybindings

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: no new preload APIs, IPC channels, filesystem access, or remote commands.
- Cross-platform: supports Ctrl on Windows/Linux and Command on macOS while retaining Ctrl-based pinch events.
- SSH/remote: renderer-only behavior; no execution-host or wire-protocol changes.
- Mobile: no mobile code paths changed.
- Performance: wheel handling uses a scoped non-passive listener mounted only with the PDF viewer.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)