### PR TITLE
fix(agent-hooks): ignore status posts from an extension Orca did not launch

### DIFF
--- a/src/main/agent-hooks/server-unmanaged-status-extension.test.ts
+++ b/src/main/agent-hooks/server-unmanaged-status-extension.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AgentHookServer, _internals } from './server'
+import { MAX_TRACKED_PANES } from './unmanaged-status-extension-fence'
 import { makePaneKey } from '../../shared/stable-pane-id'
 import { buildBody, PANE } from './server.test-fixtures'
 
@@ -27,10 +28,48 @@ type Post = { hookEventName: string; launchToken?: string }
 
 // Why structural: the server's enriched payload type is module-private; the assertions only
 // read the route and the projected state.
-type StatusEvent = { source?: string; payload: { state?: string } }
+type StatusEvent = { source?: string; paneKey?: string; payload: { state?: string } }
 
 function states(events: StatusEvent[]): (string | undefined)[] {
   return events.map((event) => event.payload.state)
+}
+
+function statesOn(events: StatusEvent[], paneKey: string): (string | undefined)[] {
+  return states(events.filter((event) => event.paneKey === paneKey))
+}
+
+// Distinct panes that only exist to age PANE out of the fence's owner LRU.
+function fillerPaneKey(index: number): string {
+  return makePaneKey(
+    `tab-${index}`,
+    `${index.toString(16).padStart(8, '0')}-1111-4111-8111-111111111111`
+  )
+}
+
+async function postPane(
+  server: AgentHookServer,
+  paneKey: string,
+  hookEventName: string,
+  launchToken?: string
+): Promise<void> {
+  const env = server.buildPtyEnv()
+  await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/omp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+    },
+    body: JSON.stringify(
+      buildBody(
+        { hook_event_name: hookEventName },
+        {
+          paneKey,
+          tabId: paneKey.split(':')[0],
+          ...(launchToken === undefined ? {} : { launchToken })
+        }
+      )
+    )
+  })
 }
 
 async function postOmp(server: AgentHookServer, posts: Post[]): Promise<void> {
@@ -237,43 +276,44 @@ describe('unmanaged OMP status extension', () => {
     server.setUnmanagedStatusExtensionListener((report) => {
       reports.push(`${report.source}:${report.paneKey}`)
     })
-    const env = server.buildPtyEnv()
-    const paneKeys = Array.from({ length: 13 }, (_, index) =>
-      makePaneKey(
-        `tab-${index}`,
-        `${index.toString(16).padStart(8, '0')}-1111-4111-8111-111111111111`
-      )
-    )
-    const post = async (paneKey: string, hookEventName: string, launchToken?: string) => {
-      await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/omp`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
-        },
-        body: JSON.stringify(
-          buildBody(
-            { hook_event_name: hookEventName },
-            {
-              paneKey,
-              tabId: paneKey.split(':')[0],
-              ...(launchToken === undefined ? {} : { launchToken })
-            }
-          )
-        )
-      })
-    }
+    const paneKeys = Array.from({ length: 13 }, (_, index) => fillerPaneKey(index))
     try {
       for (const paneKey of paneKeys) {
-        await post(paneKey, 'agent_start', LAUNCH_TOKEN)
-        await post(paneKey, 'agent_end')
-        await post(paneKey, 'agent_end', LAUNCH_TOKEN)
+        await postPane(server, paneKey, 'agent_start', LAUNCH_TOKEN)
+        await postPane(server, paneKey, 'agent_end')
+        await postPane(server, paneKey, 'agent_end', LAUNCH_TOKEN)
       }
       expect(reports).toEqual(paneKeys.map((paneKey) => `omp:${paneKey}`))
     } finally {
       await server.stop()
     }
   })
+
+  it('releases a held post when the owner LRU evicts its pane, rather than destroying it', async () => {
+    // Why this is a third way to strand a pane: eviction is not a delivery event, so a held post
+    // dropped with the owner has nothing left to resolve it. Measured against a control — the
+    // same sequence behind MAX_TRACKED_PANES filler panes stranded on ['working'] where ten
+    // filler panes delivered ['working', 'done'].
+    // Why no window seam here: at the shipped 30s the lapse cannot fire inside this test, so the
+    // delivery below can only have come from the eviction itself.
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const seen = await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_end' }
+      ])
+      expect(statesOn(seen, PANE)).toEqual(['working'])
+      for (let index = 0; index < MAX_TRACKED_PANES; index += 1) {
+        await postPane(server, fillerPaneKey(index), 'agent_start', LAUNCH_TOKEN)
+      }
+      await vi.waitFor(() => {
+        expect(statesOn(seen, PANE)).toEqual(['working', 'done'])
+      })
+    } finally {
+      await server.stop()
+    }
+  }, 30_000)
 
   it('drops a held post when the pane is retired, so a reused key cannot settle on it', async () => {
     // Why the revive matters: retirement alone hides the released post behind the retired-pane

--- a/src/main/agent-hooks/server-unmanaged-status-extension.test.ts
+++ b/src/main/agent-hooks/server-unmanaged-status-extension.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentHookServer, _internals } from './server'
+import { buildBody, PANE } from './server.test-fixtures'
+
+// Why these exact bodies: measured against omp 17.0.5 with Orca's managed extension side-loaded
+// via `-e` alongside an unmanaged copy auto-discovered from the agent's extensions dir. Both post
+// the same pane key to /hook/omp from the same process; the managed copy always carries a
+// `launchToken` key (empty string when ORCA_AGENT_LAUNCH_TOKEN is unset), the unmanaged copy omits
+// the key entirely, and the unmanaged `agent_end` lands *first*.
+const LAUNCH_TOKEN = 'launch-token-abc'
+
+vi.mock('../telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('../telemetry/cohort-classifier', () => ({
+  getCohortAtEmit: () => ({ nth_repo_added: 2 })
+}))
+
+beforeEach(() => {
+  _internals.resetCachesForTests()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+type Post = { hookEventName: string; launchToken?: string }
+
+// Why structural: the server's enriched payload type is module-private; the assertions only
+// read the route and the projected state.
+type StatusEvent = { source?: string; payload: { state?: string } }
+
+function states(events: StatusEvent[]): (string | undefined)[] {
+  return events.map((event) => event.payload.state)
+}
+
+async function runOmpPosts(server: AgentHookServer, posts: Post[]): Promise<StatusEvent[]> {
+  const seen: StatusEvent[] = []
+  server.setListener((payload) => {
+    seen.push(payload)
+  })
+  const env = server.buildPtyEnv()
+  for (const post of posts) {
+    await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/omp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+      },
+      body: JSON.stringify(
+        buildBody(
+          { hook_event_name: post.hookEventName },
+          post.launchToken === undefined ? {} : { launchToken: post.launchToken }
+        )
+      )
+    })
+  }
+  return seen
+}
+
+describe('unmanaged OMP status extension', () => {
+  it('drops the unmanaged copy’s agent_end once a tokened poster owns the pane', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const seen = await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_end' },
+        { hookEventName: 'agent_end', launchToken: LAUNCH_TOKEN }
+      ])
+      expect(states(seen)).toEqual(['working', 'done'])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('reports the unmanaged extension once per pane and source', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    const reports: string[] = []
+    server.setUnmanagedStatusExtensionListener((report) => {
+      reports.push(`${report.source}:${report.paneKey}`)
+    })
+    try {
+      await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_end' },
+        { hookEventName: 'agent_end' }
+      ])
+      expect(reports).toEqual([`omp:${PANE}`])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('fails open when no post ever carries a launch token', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      // Why: a bare shell gets no ORCA_AGENT_LAUNCH_TOKEN, so the managed extension itself posts
+      // `launchToken: ''`. Gating that would strand the pane on 'working' with no user recovery.
+      const seen = await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: '' },
+        { hookEventName: 'agent_end', launchToken: '' }
+      ])
+      expect(states(seen)).toEqual(['working', 'done'])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('lets a relaunch with a different token take the pane back', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const seen = await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_start', launchToken: 'launch-token-second' },
+        { hookEventName: 'agent_end', launchToken: 'launch-token-second' }
+      ])
+      expect(states(seen)).toEqual(['working', 'working', 'done'])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('does not gate a different source that shares the pane', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    const seen: StatusEvent[] = []
+    server.setListener((payload) => {
+      seen.push(payload)
+    })
+    try {
+      const env = server.buildPtyEnv()
+      const post = async (pathname: string, body: unknown): Promise<void> => {
+        await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}${pathname}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(body)
+        })
+      }
+      await post(
+        '/hook/omp',
+        buildBody({ hook_event_name: 'agent_start' }, { launchToken: LAUNCH_TOKEN })
+      )
+      await post('/hook/claude', buildBody({ hook_event_name: 'UserPromptSubmit', prompt: 'go' }))
+      expect(seen.map((event) => event.source)).toEqual(['omp', 'claude'])
+    } finally {
+      await server.stop()
+    }
+  })
+})

--- a/src/main/agent-hooks/server-unmanaged-status-extension.test.ts
+++ b/src/main/agent-hooks/server-unmanaged-status-extension.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AgentHookServer, _internals } from './server'
+import { makePaneKey } from '../../shared/stable-pane-id'
 import { buildBody, PANE } from './server.test-fixtures'
 
 // Why these exact bodies: measured against omp 17.0.5 with Orca's managed extension side-loaded
@@ -32,11 +33,7 @@ function states(events: StatusEvent[]): (string | undefined)[] {
   return events.map((event) => event.payload.state)
 }
 
-async function runOmpPosts(server: AgentHookServer, posts: Post[]): Promise<StatusEvent[]> {
-  const seen: StatusEvent[] = []
-  server.setListener((payload) => {
-    seen.push(payload)
-  })
+async function postOmp(server: AgentHookServer, posts: Post[]): Promise<void> {
   const env = server.buildPtyEnv()
   for (const post of posts) {
     await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/omp`, {
@@ -53,6 +50,16 @@ async function runOmpPosts(server: AgentHookServer, posts: Post[]): Promise<Stat
       )
     })
   }
+}
+
+// Why it returns the live array: it keeps filling after the awaited posts, which is exactly
+// where a released hold has to show up. Installs the listener, so call it once per server.
+async function runOmpPosts(server: AgentHookServer, posts: Post[]): Promise<StatusEvent[]> {
+  const seen: StatusEvent[] = []
+  server.setListener((payload) => {
+    seen.push(payload)
+  })
+  await postOmp(server, posts)
   return seen
 }
 
@@ -73,6 +80,9 @@ describe('unmanaged OMP status extension', () => {
   })
 
   it('reports the unmanaged extension once per pane and source', async () => {
+    // Why a tokened post has to follow: a tokenless post on its own is only evidence that the
+    // token is missing. It becomes evidence of a *second* poster when the managed copy speaks
+    // over it on the same pane and source — one process cannot both send and omit the token.
     const server = new AgentHookServer()
     await server.start({ env: 'production' })
     const reports: string[] = []
@@ -83,7 +93,9 @@ describe('unmanaged OMP status extension', () => {
       await runOmpPosts(server, [
         { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
         { hookEventName: 'agent_end' },
-        { hookEventName: 'agent_end' }
+        { hookEventName: 'agent_end', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_end' },
+        { hookEventName: 'agent_end', launchToken: LAUNCH_TOKEN }
       ])
       expect(reports).toEqual([`omp:${PANE}`])
     } finally {
@@ -147,6 +159,140 @@ describe('unmanaged OMP status extension', () => {
       )
       await post('/hook/claude', buildBody({ hook_event_name: 'UserPromptSubmit', prompt: 'go' }))
       expect(seen.map((event) => event.source)).toEqual(['omp', 'claude'])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('delivers a held tokenless post once the tokened poster goes silent', async () => {
+    // Why this is the whole exit: "a tokened post was seen" proves a managed poster existed, not
+    // that one is live. Without a lapse the pane would claim work forever with no user recovery.
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    server._setUnmanagedExtensionConfirmationWindowMsForTests(40)
+    try {
+      const seen = await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_end' }
+      ])
+      expect(states(seen)).toEqual(['working'])
+      await vi.waitFor(() => {
+        expect(states(seen)).toEqual(['working', 'done'])
+      })
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('keeps holding while the tokened poster keeps posting', async () => {
+    // Why: the lapse must not become a back door. As long as the managed copy is live, every
+    // stale post is superseded, so the pane never settles early.
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    server._setUnmanagedExtensionConfirmationWindowMsForTests(40)
+    try {
+      const seen = await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_end' },
+        { hookEventName: 'tool_call', launchToken: LAUNCH_TOKEN }
+      ])
+      await new Promise((resolve) => setTimeout(resolve, 120))
+      expect(states(seen)).toEqual(['working', 'working'])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('does not report Orca’s own tokenless relaunch as a foreign extension', async () => {
+    // Why: Orca’s detached Codex account-switch restart respawns into the same pane key. Until it
+    // carried a launch token its posts were tokenless, and warning a user about “an extension Orca
+    // did not install” for something Orca launched is unactionable. Two posters are only proven
+    // when a tokened post interleaves with a held tokenless one — a relaunch never does.
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    server._setUnmanagedExtensionConfirmationWindowMsForTests(40)
+    const reports: string[] = []
+    server.setUnmanagedStatusExtensionListener((report) => {
+      reports.push(`${report.source}:${report.paneKey}`)
+    })
+    try {
+      await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_start' },
+        { hookEventName: 'agent_end' }
+      ])
+      expect(reports).toEqual([])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('reports per pane and source, which is what the renderer dedupe collapses to one toast', async () => {
+    // Why pin the fan-out shape: the one-shot property lives in the renderer's per-source
+    // dedupe, not here. This side must stay per-pane-and-source, or that dedupe is being fed
+    // something it was never sized for.
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    const reports: string[] = []
+    server.setUnmanagedStatusExtensionListener((report) => {
+      reports.push(`${report.source}:${report.paneKey}`)
+    })
+    const env = server.buildPtyEnv()
+    const paneKeys = Array.from({ length: 13 }, (_, index) =>
+      makePaneKey(
+        `tab-${index}`,
+        `${index.toString(16).padStart(8, '0')}-1111-4111-8111-111111111111`
+      )
+    )
+    const post = async (paneKey: string, hookEventName: string, launchToken?: string) => {
+      await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/omp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+        },
+        body: JSON.stringify(
+          buildBody(
+            { hook_event_name: hookEventName },
+            {
+              paneKey,
+              tabId: paneKey.split(':')[0],
+              ...(launchToken === undefined ? {} : { launchToken })
+            }
+          )
+        )
+      })
+    }
+    try {
+      for (const paneKey of paneKeys) {
+        await post(paneKey, 'agent_start', LAUNCH_TOKEN)
+        await post(paneKey, 'agent_end')
+        await post(paneKey, 'agent_end', LAUNCH_TOKEN)
+      }
+      expect(reports).toEqual(paneKeys.map((paneKey) => `omp:${paneKey}`))
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('drops a held post when the pane is retired, so a reused key cannot settle on it', async () => {
+    // Why the revive matters: retirement alone hides the released post behind the retired-pane
+    // gate. A pane key reused by a tokenless launch re-opens that gate, and a hold surviving
+    // teardown would then settle the *new* turn with the old turn's completion.
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    server._setUnmanagedExtensionConfirmationWindowMsForTests(40)
+    try {
+      const seen = await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_end' }
+      ])
+      server.retirePaneAuthority(PANE)
+      // Why before_agent_start: that is omp's new-turn boundary, the one event that re-opens a
+      // retired pane. Anything else stays suppressed and would hide the held post either way.
+      await postOmp(server, [{ hookEventName: 'before_agent_start' }])
+      await new Promise((resolve) => setTimeout(resolve, 120))
+      expect(states(seen)).toEqual(['working', 'working'])
     } finally {
       await server.stop()
     }

--- a/src/main/agent-hooks/server-unmanaged-status-extension.test.ts
+++ b/src/main/agent-hooks/server-unmanaged-status-extension.test.ts
@@ -337,4 +337,21 @@ describe('unmanaged OMP status extension', () => {
       await server.stop()
     }
   })
+
+  it('stops holding when the server stops, so a hold cannot land on a torn-down server', async () => {
+    // Why the pane snapshot rather than the listener: stop() nulls the status listener before it
+    // reaches the fence and clears the pane's row, so a hold that outlives teardown does not call
+    // back — it re-enters the routing path and writes a fresh row onto a server that is gone.
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    server._setUnmanagedExtensionConfirmationWindowMsForTests(40)
+    const seen = await runOmpPosts(server, [
+      { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+      { hookEventName: 'agent_end' }
+    ])
+    expect(states(seen)).toEqual(['working'])
+    server.stop()
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    expect(server.getStatusSnapshotForPane(PANE)).toEqual([])
+  })
 })

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -782,6 +782,10 @@ export class AgentHookServer {
     this.unmanagedExtensionFence.setDetectionListener(listener)
   }
 
+  _setUnmanagedExtensionConfirmationWindowMsForTests(windowMs: number): void {
+    this.unmanagedExtensionFence.setConfirmationWindowMsForTests(windowMs)
+  }
+
   setListener(listener: ((payload: EnrichedAgentHookEventPayload) => void) | null): void {
     this.onAgentStatus = listener
     if (!listener) {
@@ -1191,6 +1195,8 @@ export class AgentHookServer {
       isReplay?: boolean
       hasExplicitPrompt?: boolean
       launchToken?: string
+      /** Re-delivers this post if the unmanaged-extension fence holds it and nothing supersedes it. */
+      releaseIfUnconfirmed?: () => void
     }
   ): 'accept' | 'restart' | 'suppress' {
     const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
@@ -1202,13 +1208,19 @@ export class AgentHookServer {
       return 'suppress'
     }
     // Why: a second status extension loaded alongside Orca's own posts the same pane key from the
-    // same process, so only the launch token separates them. Fails open — the fence stays shut
-    // until a tokened post proves a managed poster is live, so a tokenless launch is never gated.
+    // same process, so only the launch token separates them. The hold is provisional in both
+    // directions — a tokenless launch is never gated until a tokened post owns the pane, and a
+    // held post is delivered anyway once the tokened poster goes silent, so no sequence of posts
+    // can strand a pane on 'working'.
     // Replays carry no live process and are fenced by hydratedLaunchTokenHashByPaneKey instead.
     if (event && event.isReplay !== true) {
       if (
-        this.unmanagedExtensionFence.classify(ownerPaneKey, event.source, event.launchToken) ===
-        'unmanaged'
+        this.unmanagedExtensionFence.classify(
+          ownerPaneKey,
+          event.source,
+          event.launchToken,
+          event.releaseIfUnconfirmed
+        ) === 'held'
       ) {
         return 'suppress'
       }
@@ -2176,6 +2188,47 @@ export class AgentHookServer {
     return { ...record, paneKey: stablePaneKey, tabId: parsePaneKey(stablePaneKey)?.tabId }
   }
 
+  /**
+   * Disposition + apply for one local hook post.
+   *
+   * Why re-entrant: the unmanaged-extension fence holds a tokenless post instead of dropping it,
+   * and delivers it through this same method once nothing supersedes it — so the hold cannot skip
+   * a gate, and a lapsed hold cannot bypass one that has closed in the meantime.
+   */
+  private routeLocalHookStatus(
+    source: AgentHookSource,
+    aliasedBody: unknown,
+    normalized: NormalizedLocalHook
+  ): void {
+    const event = normalized.event
+    if (!event) {
+      return
+    }
+    const statusDisposition = this.getAgentStatusDisposition(event.paneKey, {
+      source,
+      hookEventName: event.hookEventName,
+      isReplay: event.isReplay,
+      hasExplicitPrompt: event.hasExplicitPrompt,
+      launchToken: event.launchToken,
+      releaseIfUnconfirmed: () => {
+        this.routeLocalHookStatus(source, aliasedBody, normalized)
+      }
+    })
+    if (statusDisposition === 'suppress') {
+      return
+    }
+    const applied = statusDisposition === 'restart' ? { ...event, launchToken: undefined } : event
+    if (statusDisposition === 'restart') {
+      // Why: a retired pane accepting a new turn is a different agent session behind the
+      // same key — later observations must not be ordered against the retired one.
+      this.observations.rebind(applied.paneKey)
+    }
+    this.recordCurrentAuthorityObservation(applied)
+    const enriched = this.applyNormalizedStatus(applied, normalized.onAccepted)
+    this.scheduleAssistantMessageRetry(source, aliasedBody, enriched)
+    this.scheduleCodexSubagentPoll(source, aliasedBody, enriched)
+  }
+
   private normalizeLocalHookPayload(source: AgentHookSource, body: unknown): NormalizedLocalHook {
     if (source !== 'claude' || typeof body !== 'object' || body === null) {
       return { event: normalizeHookPayload(this.state, source, body, this.env) }
@@ -2411,7 +2464,12 @@ export class AgentHookServer {
       hookEventName,
       isReplay: envelope.isReplay === true,
       hasExplicitPrompt: envelope.hasExplicitPrompt === true,
-      launchToken: envelope.launchToken
+      launchToken: envelope.launchToken,
+      // Why re-enter rather than replay the tail: every gate below this point must be re-checked
+      // against the pane as it stands when the hold lapses, not as it stood when it was taken.
+      releaseIfUnconfirmed: () => {
+        this.ingestRemote(envelope, connectionId)
+      }
     })
     if (statusDisposition === 'suppress') {
       return
@@ -2655,31 +2713,11 @@ export class AgentHookServer {
         const hookBody = mergeAgentHookRequestHeaders(body, req.headers)
         trackEmptyPaneKeyHook(hookBody)
         const aliasedBody = this.normalizeHookBodyPaneKeyAlias(hookBody)
-        const normalized = this.normalizeLocalHookPayload(source, aliasedBody)
-        const statusDisposition = normalized.event
-          ? this.getAgentStatusDisposition(normalized.event.paneKey, {
-              source,
-              hookEventName: normalized.event.hookEventName,
-              isReplay: normalized.event.isReplay,
-              hasExplicitPrompt: normalized.event.hasExplicitPrompt,
-              launchToken: normalized.event.launchToken
-            })
-          : 'suppress'
-        if (normalized.event && statusDisposition !== 'suppress') {
-          const event =
-            statusDisposition === 'restart'
-              ? { ...normalized.event, launchToken: undefined }
-              : normalized.event
-          if (statusDisposition === 'restart') {
-            // Why: a retired pane accepting a new turn is a different agent session behind the
-            // same key — later observations must not be ordered against the retired one.
-            this.observations.rebind(event.paneKey)
-          }
-          this.recordCurrentAuthorityObservation(event)
-          const enriched = this.applyNormalizedStatus(event, normalized.onAccepted)
-          this.scheduleAssistantMessageRetry(source, aliasedBody, enriched)
-          this.scheduleCodexSubagentPoll(source, aliasedBody, enriched)
-        }
+        this.routeLocalHookStatus(
+          source,
+          aliasedBody,
+          this.normalizeLocalHookPayload(source, aliasedBody)
+        )
 
         res.writeHead(204)
         res.end()
@@ -2757,6 +2795,8 @@ export class AgentHookServer {
     this.closedAgentStatusTabIds.clear()
     this.closedAgentStatusPaneKeys.clear()
     this.restartedStatusLaunchTokenHashByPaneKey.clear()
+    // Why: a held tokenless post must not outlive the server that would deliver it.
+    this.unmanagedExtensionFence.dispose()
     this.retiredPaneFencesByKey.clear()
     this.connectionTimestampWatermarkById.clear()
     this.legacyPaneKeyAliases.clear()

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -55,6 +55,10 @@ import {
   readRequestBody
 } from '../../shared/agent-hook-listener/request-body'
 import { resolveHookSource } from '../../shared/agent-hook-listener/source-routing'
+import {
+  UnmanagedStatusExtensionFence,
+  type UnmanagedStatusExtensionReport
+} from './unmanaged-status-extension-fence'
 import type { AgentHookEventPayload } from '../../shared/agent-hook-listener/listener-event'
 import {
   canAcceptClaudeCompactCompletion,
@@ -746,6 +750,7 @@ export class AgentHookServer {
   private closedAgentStatusTabIds = new Set<string>()
   private closedAgentStatusPaneKeys = new Set<string>()
   private restartedStatusLaunchTokenHashByPaneKey = new Map<string, string>()
+  private unmanagedExtensionFence = new UnmanagedStatusExtensionFence()
   private connectionTimestampWatermarkById = new Map<string, number>()
   // Why: skip disk writes when the JSON exactly matches the last write; guards against re-firing trailing timers when nothing changed.
   private lastWrittenJson: string | null = null
@@ -764,6 +769,17 @@ export class AgentHookServer {
     listener: ((report: HookTransportInterferenceReport) => void) | null
   ): void {
     this.onTransportInterference = listener
+  }
+
+  /**
+   * Notified once per pane and source when a status extension Orca did not launch is posting.
+   * Why: the fence silently drops those posts, and the file is a user's own — Orca must never
+   * remove it, so the only honest remedy is telling the user which agent is affected.
+   */
+  setUnmanagedStatusExtensionListener(
+    listener: ((report: UnmanagedStatusExtensionReport) => void) | null
+  ): void {
+    this.unmanagedExtensionFence.setDetectionListener(listener)
   }
 
   setListener(listener: ((payload: EnrichedAgentHookEventPayload) => void) | null): void {
@@ -1184,6 +1200,18 @@ export class AgentHookServer {
     const tabId = parsePaneKey(ownerPaneKey)?.tabId
     if (tabId && this.closedAgentStatusTabIds.has(tabId)) {
       return 'suppress'
+    }
+    // Why: a second status extension loaded alongside Orca's own posts the same pane key from the
+    // same process, so only the launch token separates them. Fails open — the fence stays shut
+    // until a tokened post proves a managed poster is live, so a tokenless launch is never gated.
+    // Replays carry no live process and are fenced by hydratedLaunchTokenHashByPaneKey instead.
+    if (event && event.isReplay !== true) {
+      if (
+        this.unmanagedExtensionFence.classify(ownerPaneKey, event.source, event.launchToken) ===
+        'unmanaged'
+      ) {
+        return 'suppress'
+      }
     }
     if (!paneRetired) {
       const tokenFence = this.restartedStatusLaunchTokenHashByPaneKey.get(ownerPaneKey)
@@ -1961,6 +1989,10 @@ export class AgentHookServer {
 
   retirePaneAuthority(paneKey: string): void {
     const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
+    // Why: a reused pane key may relaunch without a launch token; keeping the old owner would
+    // gate the new process's own posts and strand the pane on 'working'.
+    this.unmanagedExtensionFence.forgetPane(paneKey)
+    this.unmanagedExtensionFence.forgetPane(ownerPaneKey)
     const paneKeys = new Set([paneKey, ownerPaneKey])
     const retiredAliases: RetiredPaneAlias[] = []
     let aliasChanged = false

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1210,8 +1210,8 @@ export class AgentHookServer {
     // Why: a second status extension loaded alongside Orca's own posts the same pane key from the
     // same process, so only the launch token separates them. The hold is provisional in both
     // directions — a tokenless launch is never gated until a tokened post owns the pane, and a
-    // held post is delivered anyway once the tokened poster goes silent, so no sequence of posts
-    // can strand a pane on 'working'.
+    // held post is delivered anyway once the tokened poster goes silent or its owner is evicted,
+    // so no sequence of posts can strand a pane on 'working'.
     // Replays carry no live process and are fenced by hydratedLaunchTokenHashByPaneKey instead.
     if (event && event.isReplay !== true) {
       if (

--- a/src/main/agent-hooks/unmanaged-status-extension-fence.test.ts
+++ b/src/main/agent-hooks/unmanaged-status-extension-fence.test.ts
@@ -47,4 +47,42 @@ describe('unmanaged-extension fence hold window', () => {
     expect(UNMANAGED_POST_CONFIRMATION_WINDOW_MS).toBeGreaterThan(1_000)
     expect(UNMANAGED_POST_CONFIRMATION_WINDOW_MS).toBeLessThan(AGENT_STATUS_STALE_AFTER_MS)
   })
+
+  it('cancels a held post when the fence is disposed, so it cannot fire after teardown', () => {
+    // Why: dispose() is the only removal path with no delivery and no pane retirement behind it.
+    // Leaving the timer armed lets a post land on a torn-down server, which nothing else catches.
+    const fence = new UnmanagedStatusExtensionFence()
+    const released: string[] = []
+    expect(fence.classify(PANE, 'omp', LAUNCH_TOKEN)).toBe('managed')
+    expect(
+      fence.classify(PANE, 'omp', undefined, () => {
+        released.push('agent_end')
+      })
+    ).toBe('held')
+    fence.dispose()
+    vi.advanceTimersByTime(UNMANAGED_POST_CONFIRMATION_WINDOW_MS * 2)
+    expect(released).toEqual([])
+  })
+
+  it('holds only the newest tokenless post, and never replays the one it superseded', () => {
+    // Why this shape is real: one stale extension posts a whole turn tokenless, so a second
+    // tokenless post arrives inside the first one's window. Without the supersede, the older
+    // post's timer stays armed and wins the race — the pane resolves on the stale earlier state.
+    const fence = new UnmanagedStatusExtensionFence()
+    const released: string[] = []
+    expect(fence.classify(PANE, 'omp', LAUNCH_TOKEN)).toBe('managed')
+    expect(
+      fence.classify(PANE, 'omp', undefined, () => {
+        released.push('first')
+      })
+    ).toBe('held')
+    vi.advanceTimersByTime(UNMANAGED_POST_CONFIRMATION_WINDOW_MS / 2)
+    expect(
+      fence.classify(PANE, 'omp', undefined, () => {
+        released.push('second')
+      })
+    ).toBe('held')
+    vi.advanceTimersByTime(UNMANAGED_POST_CONFIRMATION_WINDOW_MS * 2)
+    expect(released).toEqual(['second'])
+  })
 })

--- a/src/main/agent-hooks/unmanaged-status-extension-fence.test.ts
+++ b/src/main/agent-hooks/unmanaged-status-extension-fence.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  UNMANAGED_POST_CONFIRMATION_WINDOW_MS,
+  UnmanagedStatusExtensionFence
+} from './unmanaged-status-extension-fence'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../shared/agent-status-types'
+import { makePaneKey } from '../../shared/stable-pane-id'
+
+const PANE = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
+const LAUNCH_TOKEN = 'launch-token-abc'
+
+describe('unmanaged-extension fence hold window', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('holds for the shipped window by default, not for whatever a seam last set', () => {
+    // Why this test exists: every other window test runs on the 40ms seam, so the shipped
+    // constant had no reader at all — an edit to it, or to the constructor default, stayed green.
+    // Fake timers keep that real 30s bounded to nothing.
+    const fence = new UnmanagedStatusExtensionFence()
+    const released: string[] = []
+    try {
+      expect(fence.classify(PANE, 'omp', LAUNCH_TOKEN)).toBe('managed')
+      expect(
+        fence.classify(PANE, 'omp', undefined, () => {
+          released.push('agent_end')
+        })
+      ).toBe('held')
+      vi.advanceTimersByTime(UNMANAGED_POST_CONFIRMATION_WINDOW_MS - 1)
+      expect(released).toEqual([])
+      vi.advanceTimersByTime(1)
+      expect(released).toEqual(['agent_end'])
+    } finally {
+      fence.dispose()
+    }
+  })
+
+  it('keeps the window between the supersede band and the point Orca stops believing “working”', () => {
+    // Why bounds rather than the literal: the value is only justified by two other numbers.
+    // Under a second it would race the managed copy's own superseding post; at or past the stale
+    // cutoff the hold would outlive the claim it exists to protect.
+    expect(UNMANAGED_POST_CONFIRMATION_WINDOW_MS).toBeGreaterThan(1_000)
+    expect(UNMANAGED_POST_CONFIRMATION_WINDOW_MS).toBeLessThan(AGENT_STATUS_STALE_AFTER_MS)
+  })
+})

--- a/src/main/agent-hooks/unmanaged-status-extension-fence.ts
+++ b/src/main/agent-hooks/unmanaged-status-extension-fence.ts
@@ -11,9 +11,31 @@ import type { AgentHookSource } from '../../shared/agent-hook-relay'
 // Orca's managed extension stamps ORCA_AGENT_LAUNCH_TOKEN into every post body; an unmanaged
 // copy predating that field cannot. That is the only reliable in-band discriminator, because
 // both copies share the process, the pane key, and the endpoint credentials.
+//
+// Why suppression is provisional, never permanent: "a tokened post was seen once" is evidence
+// that a managed poster *existed*, not that one is *live*. A managed poster that posts once and
+// then dies would otherwise gate every later post on that pane forever, and a pane stuck on
+// "working" is invisible and has no user recovery. So a tokenless post is HELD, not dropped:
+// a following tokened post discards it (and is the proof that two posters share the pane —
+// that is the only thing worth warning about), and silence past the confirmation window
+// re-opens the gate and delivers it. Every held post is therefore either superseded by the
+// managed poster or delivered; no sequence of posts can strand a pane.
 
 /** Panes tracked before the oldest owner is evicted; a lost owner only re-opens the gate. */
 const MAX_TRACKED_PANES = 512
+
+/**
+ * How long a held tokenless post waits for the managed poster to contradict it.
+ *
+ * Why this long: both copies run in one process off one hook event, so the managed copy's
+ * superseding post lands in the same millisecond band as the unmanaged one (the measured
+ * ordering was unmanaged-first by a hair). Even the deliberately-withheld `agent_end` is
+ * re-checked every 25–250ms until idle, and an auto-continuation posts `agent_start` as
+ * soon as it is scheduled. 30s is orders of magnitude above that and far below the 30min
+ * AGENT_STATUS_STALE_AFTER_MS at which Orca stops believing a "working" claim anyway, so a
+ * lapse means the managed poster is gone rather than merely quiet.
+ */
+export const UNMANAGED_POST_CONFIRMATION_WINDOW_MS = 30_000
 
 export type UnmanagedStatusExtensionReport = {
   paneKey: string
@@ -23,31 +45,50 @@ export type UnmanagedStatusExtensionReport = {
 export type StatusPostOrigin =
   /** Carries a launch token: this is the process Orca launched, and it now owns the pane. */
   | 'managed'
-  /** No token, and a token-carrying poster is already live on the same pane and source. */
-  | 'unmanaged'
+  /** No token while a token-carrying poster owns the pane: held pending confirmation. */
+  | 'held'
   /** No token and no established owner: indistinguishable from a normal tokenless launch. */
   | 'unattributed'
+
+type HeldPost = {
+  timer: ReturnType<typeof setTimeout>
+  release: () => void
+}
 
 /**
  * Tells Orca's own status extension apart from a second one loaded alongside it.
  *
- * Only ever classifies a *tokenless* post as unmanaged, and only once the same pane and source
- * have proven a token-carrying poster exists. A tokened post is never rejected, so a relaunch
- * always takes the pane back.
+ * Only ever holds a *tokenless* post, and only while a token-carrying poster owns the same pane
+ * and source. A tokened post is never rejected, so a relaunch always takes the pane back, and a
+ * held post is always resolved — superseded by the managed poster, or delivered when it goes
+ * silent for {@link UNMANAGED_POST_CONFIRMATION_WINDOW_MS}.
  */
 export class UnmanagedStatusExtensionFence {
   private ownerHashByPaneKey = new Map<string, Map<AgentHookSource, string>>()
   private reportedSourcesByPaneKey = new Map<string, Set<AgentHookSource>>()
+  private heldPostsByPaneKey = new Map<string, Map<AgentHookSource, HeldPost>>()
   private onDetected: ((report: UnmanagedStatusExtensionReport) => void) | null = null
+
+  constructor(private confirmationWindowMs: number = UNMANAGED_POST_CONFIRMATION_WINDOW_MS) {}
+
+  /** Test seam: the production window is far longer than any suite should wait on. */
+  setConfirmationWindowMsForTests(windowMs: number): void {
+    this.confirmationWindowMs = windowMs
+  }
 
   setDetectionListener(listener: ((report: UnmanagedStatusExtensionReport) => void) | null): void {
     this.onDetected = listener
   }
 
+  /**
+   * @param release re-delivers this post if the managed poster never contradicts it. Omitting it
+   *   makes the hold a plain drop, so callers that cannot replay must not gate on this fence.
+   */
   classify(
     paneKey: string,
     source: AgentHookSource | undefined,
-    launchToken: string | undefined
+    launchToken: string | undefined,
+    release?: () => void
   ): StatusPostOrigin {
     if (!source || paneKey.length === 0) {
       return 'unattributed'
@@ -55,27 +96,105 @@ export class UnmanagedStatusExtensionFence {
     const token = launchToken?.trim() ?? ''
     if (token.length > 0) {
       this.rememberOwner(paneKey, source, createHash('sha256').update(token).digest('hex'))
+      // Why here: a tokened post arriving while a tokenless one is held is the whole proof —
+      // two posters, one Orca launched and one it did not, interleaved on one pane.
+      if (this.discardHeldPost(paneKey, source)) {
+        this.reportOnce(paneKey, source)
+      }
       return 'managed'
     }
     if (!this.ownerHashByPaneKey.get(paneKey)?.has(source)) {
       return 'unattributed'
     }
-    const reported = this.reportedSourcesByPaneKey.get(paneKey)
-    if (!reported?.has(source)) {
-      if (reported) {
-        reported.add(source)
-      } else {
-        this.reportedSourcesByPaneKey.set(paneKey, new Set([source]))
-      }
-      this.onDetected?.({ paneKey, source })
+    if (!release) {
+      return 'unattributed'
     }
-    return 'unmanaged'
+    this.holdPost(paneKey, source, release)
+    return 'held'
   }
 
   /** Pane teardown: drop the owner so a key reused by a tokenless launch starts from an open gate. */
   forgetPane(paneKey: string): void {
     this.ownerHashByPaneKey.delete(paneKey)
     this.reportedSourcesByPaneKey.delete(paneKey)
+    this.discardPaneHolds(paneKey)
+  }
+
+  /** Server shutdown: a held post must not outlive the server that would deliver it. */
+  dispose(): void {
+    for (const held of this.heldPostsByPaneKey.values()) {
+      for (const entry of held.values()) {
+        clearTimeout(entry.timer)
+      }
+    }
+    this.heldPostsByPaneKey.clear()
+    this.ownerHashByPaneKey.clear()
+    this.reportedSourcesByPaneKey.clear()
+  }
+
+  private holdPost(paneKey: string, source: AgentHookSource, release: () => void): void {
+    // Why latest-only: an older held post describes a state the newer one already supersedes.
+    this.discardHeldPost(paneKey, source)
+    const timer = setTimeout(() => {
+      this.discardHeldPost(paneKey, source)
+      // Why before release: the replay re-enters classify, and a still-armed gate would hold it
+      // again forever. Dropping the owner is also the point — the managed poster proved absent.
+      this.forgetOwner(paneKey, source)
+      release()
+    }, this.confirmationWindowMs)
+    timer.unref?.()
+    const held = this.heldPostsByPaneKey.get(paneKey) ?? new Map<AgentHookSource, HeldPost>()
+    held.set(source, { timer, release })
+    this.heldPostsByPaneKey.set(paneKey, held)
+  }
+
+  private discardHeldPost(paneKey: string, source: AgentHookSource): boolean {
+    const held = this.heldPostsByPaneKey.get(paneKey)
+    const entry = held?.get(source)
+    if (!held || !entry) {
+      return false
+    }
+    clearTimeout(entry.timer)
+    held.delete(source)
+    if (held.size === 0) {
+      this.heldPostsByPaneKey.delete(paneKey)
+    }
+    return true
+  }
+
+  private discardPaneHolds(paneKey: string): void {
+    const held = this.heldPostsByPaneKey.get(paneKey)
+    if (!held) {
+      return
+    }
+    for (const entry of held.values()) {
+      clearTimeout(entry.timer)
+    }
+    this.heldPostsByPaneKey.delete(paneKey)
+  }
+
+  private reportOnce(paneKey: string, source: AgentHookSource): void {
+    const reported = this.reportedSourcesByPaneKey.get(paneKey)
+    if (reported?.has(source)) {
+      return
+    }
+    if (reported) {
+      reported.add(source)
+    } else {
+      this.reportedSourcesByPaneKey.set(paneKey, new Set([source]))
+    }
+    this.onDetected?.({ paneKey, source })
+  }
+
+  private forgetOwner(paneKey: string, source: AgentHookSource): void {
+    const sources = this.ownerHashByPaneKey.get(paneKey)
+    if (!sources) {
+      return
+    }
+    sources.delete(source)
+    if (sources.size === 0) {
+      this.ownerHashByPaneKey.delete(paneKey)
+    }
   }
 
   private rememberOwner(paneKey: string, source: AgentHookSource, hash: string): void {
@@ -92,6 +211,7 @@ export class UnmanagedStatusExtensionFence {
       }
       this.ownerHashByPaneKey.delete(oldest)
       this.reportedSourcesByPaneKey.delete(oldest)
+      this.discardPaneHolds(oldest)
     }
   }
 }

--- a/src/main/agent-hooks/unmanaged-status-extension-fence.ts
+++ b/src/main/agent-hooks/unmanaged-status-extension-fence.ts
@@ -1,0 +1,97 @@
+import { createHash } from 'node:crypto'
+import type { AgentHookSource } from '../../shared/agent-hook-relay'
+
+// Why: Pi/OMP auto-discover every extension file in the agent's extensions dir, and Orca
+// side-loads its managed copy with `-e` whenever a user-owned file already holds that name
+// (writeManagedExtension refuses to overwrite an unmarked file). Both copies then run in the
+// same process and post the same pane's status, but an unmanaged copy is frozen at whatever
+// Orca version produced it, so it can post a completion the managed copy deliberately withheld
+// and settle a pane that is still working.
+//
+// Orca's managed extension stamps ORCA_AGENT_LAUNCH_TOKEN into every post body; an unmanaged
+// copy predating that field cannot. That is the only reliable in-band discriminator, because
+// both copies share the process, the pane key, and the endpoint credentials.
+
+/** Panes tracked before the oldest owner is evicted; a lost owner only re-opens the gate. */
+const MAX_TRACKED_PANES = 512
+
+export type UnmanagedStatusExtensionReport = {
+  paneKey: string
+  source: AgentHookSource
+}
+
+export type StatusPostOrigin =
+  /** Carries a launch token: this is the process Orca launched, and it now owns the pane. */
+  | 'managed'
+  /** No token, and a token-carrying poster is already live on the same pane and source. */
+  | 'unmanaged'
+  /** No token and no established owner: indistinguishable from a normal tokenless launch. */
+  | 'unattributed'
+
+/**
+ * Tells Orca's own status extension apart from a second one loaded alongside it.
+ *
+ * Only ever classifies a *tokenless* post as unmanaged, and only once the same pane and source
+ * have proven a token-carrying poster exists. A tokened post is never rejected, so a relaunch
+ * always takes the pane back.
+ */
+export class UnmanagedStatusExtensionFence {
+  private ownerHashByPaneKey = new Map<string, Map<AgentHookSource, string>>()
+  private reportedSourcesByPaneKey = new Map<string, Set<AgentHookSource>>()
+  private onDetected: ((report: UnmanagedStatusExtensionReport) => void) | null = null
+
+  setDetectionListener(listener: ((report: UnmanagedStatusExtensionReport) => void) | null): void {
+    this.onDetected = listener
+  }
+
+  classify(
+    paneKey: string,
+    source: AgentHookSource | undefined,
+    launchToken: string | undefined
+  ): StatusPostOrigin {
+    if (!source || paneKey.length === 0) {
+      return 'unattributed'
+    }
+    const token = launchToken?.trim() ?? ''
+    if (token.length > 0) {
+      this.rememberOwner(paneKey, source, createHash('sha256').update(token).digest('hex'))
+      return 'managed'
+    }
+    if (!this.ownerHashByPaneKey.get(paneKey)?.has(source)) {
+      return 'unattributed'
+    }
+    const reported = this.reportedSourcesByPaneKey.get(paneKey)
+    if (!reported?.has(source)) {
+      if (reported) {
+        reported.add(source)
+      } else {
+        this.reportedSourcesByPaneKey.set(paneKey, new Set([source]))
+      }
+      this.onDetected?.({ paneKey, source })
+    }
+    return 'unmanaged'
+  }
+
+  /** Pane teardown: drop the owner so a key reused by a tokenless launch starts from an open gate. */
+  forgetPane(paneKey: string): void {
+    this.ownerHashByPaneKey.delete(paneKey)
+    this.reportedSourcesByPaneKey.delete(paneKey)
+  }
+
+  private rememberOwner(paneKey: string, source: AgentHookSource, hash: string): void {
+    // Why: re-insert so the Map's insertion order stays a usable LRU for the cap below.
+    const existing = this.ownerHashByPaneKey.get(paneKey)
+    this.ownerHashByPaneKey.delete(paneKey)
+    const sources = existing ?? new Map<AgentHookSource, string>()
+    sources.set(source, hash)
+    this.ownerHashByPaneKey.set(paneKey, sources)
+    while (this.ownerHashByPaneKey.size > MAX_TRACKED_PANES) {
+      const oldest = this.ownerHashByPaneKey.keys().next().value
+      if (oldest === undefined) {
+        break
+      }
+      this.ownerHashByPaneKey.delete(oldest)
+      this.reportedSourcesByPaneKey.delete(oldest)
+    }
+  }
+}

--- a/src/main/agent-hooks/unmanaged-status-extension-fence.ts
+++ b/src/main/agent-hooks/unmanaged-status-extension-fence.ts
@@ -64,8 +64,9 @@ type HeldPost = {
  * and source. A tokened post is never rejected, so a relaunch always takes the pane back, and a
  * held post is always resolved — superseded by the managed poster, delivered when it goes silent
  * for {@link UNMANAGED_POST_CONFIRMATION_WINDOW_MS}, or delivered when the owner is evicted by
- * {@link MAX_TRACKED_PANES}. Only pane retirement ends a hold without delivering it, and that
- * closes the pane's row along with it.
+ * {@link MAX_TRACKED_PANES}. Two paths end a hold without delivering it, and neither can leave a
+ * pane claiming finished work: pane retirement closes the pane's row in the same step, and server
+ * teardown is app quit, after which the row comes back explicitly unconfirmed — see {@link dispose}.
  */
 export class UnmanagedStatusExtensionFence {
   private ownerHashByPaneKey = new Map<string, Map<AgentHookSource, string>>()
@@ -124,7 +125,13 @@ export class UnmanagedStatusExtensionFence {
     this.discardPaneHolds(paneKey)
   }
 
-  /** Server shutdown: a held post must not outlive the server that would deliver it. */
+  /**
+   * Server shutdown: a held post must not outlive the server that would deliver it. Dropping it
+   * cannot strand the pane, because nothing held here is what the next launch reads. What survives is
+   * the pane's persisted status row, and hydrate re-stamps every non-`done` row `restoredUnconfirmed`
+   * (`server.ts`), which `isFreshNonDoneAgentStatus` refuses to read as live work until a live post
+   * replaces it.
+   */
   dispose(): void {
     for (const held of this.heldPostsByPaneKey.values()) {
       for (const entry of held.values()) {

--- a/src/main/agent-hooks/unmanaged-status-extension-fence.ts
+++ b/src/main/agent-hooks/unmanaged-status-extension-fence.ts
@@ -18,11 +18,13 @@ import type { AgentHookSource } from '../../shared/agent-hook-relay'
 // "working" is invisible and has no user recovery. So a tokenless post is HELD, not dropped:
 // a following tokened post discards it (and is the proof that two posters share the pane —
 // that is the only thing worth warning about), and silence past the confirmation window
-// re-opens the gate and delivers it. Every held post is therefore either superseded by the
-// managed poster or delivered; no sequence of posts can strand a pane.
+// re-opens the gate and delivers it. Anything else that removes an owner — including the LRU
+// eviction below — releases the hold with it, because eviction is not a delivery event.
+// A held post is therefore superseded, delivered, or dropped with the turn it described when
+// the pane itself is retired; only that last case ends a hold without a post reaching the pane.
 
-/** Panes tracked before the oldest owner is evicted; a lost owner only re-opens the gate. */
-const MAX_TRACKED_PANES = 512
+/** Panes tracked before the oldest owner is evicted; eviction re-opens that pane's gate. */
+export const MAX_TRACKED_PANES = 512
 
 /**
  * How long a held tokenless post waits for the managed poster to contradict it.
@@ -60,8 +62,10 @@ type HeldPost = {
  *
  * Only ever holds a *tokenless* post, and only while a token-carrying poster owns the same pane
  * and source. A tokened post is never rejected, so a relaunch always takes the pane back, and a
- * held post is always resolved — superseded by the managed poster, or delivered when it goes
- * silent for {@link UNMANAGED_POST_CONFIRMATION_WINDOW_MS}.
+ * held post is always resolved — superseded by the managed poster, delivered when it goes silent
+ * for {@link UNMANAGED_POST_CONFIRMATION_WINDOW_MS}, or delivered when the owner is evicted by
+ * {@link MAX_TRACKED_PANES}. Only pane retirement ends a hold without delivering it, and that
+ * closes the pane's row along with it.
  */
 export class UnmanagedStatusExtensionFence {
   private ownerHashByPaneKey = new Map<string, Map<AgentHookSource, string>>()
@@ -162,15 +166,24 @@ export class UnmanagedStatusExtensionFence {
     return true
   }
 
-  private discardPaneHolds(paneKey: string): void {
+  /** Removes every hold on a pane and hands back their releases, so a caller can resolve them. */
+  private takePaneHolds(paneKey: string): (() => void)[] {
     const held = this.heldPostsByPaneKey.get(paneKey)
     if (!held) {
-      return
+      return []
     }
+    const releases: (() => void)[] = []
     for (const entry of held.values()) {
       clearTimeout(entry.timer)
+      releases.push(entry.release)
     }
     this.heldPostsByPaneKey.delete(paneKey)
+    return releases
+  }
+
+  /** Retirement only: the held post describes the turn that just ended, so it must not be replayed. */
+  private discardPaneHolds(paneKey: string): void {
+    this.takePaneHolds(paneKey)
   }
 
   private reportOnce(paneKey: string, source: AgentHookSource): void {
@@ -204,6 +217,7 @@ export class UnmanagedStatusExtensionFence {
     const sources = existing ?? new Map<AgentHookSource, string>()
     sources.set(source, hash)
     this.ownerHashByPaneKey.set(paneKey, sources)
+    const stranded: (() => void)[] = []
     while (this.ownerHashByPaneKey.size > MAX_TRACKED_PANES) {
       const oldest = this.ownerHashByPaneKey.keys().next().value
       if (oldest === undefined) {
@@ -211,7 +225,13 @@ export class UnmanagedStatusExtensionFence {
       }
       this.ownerHashByPaneKey.delete(oldest)
       this.reportedSourcesByPaneKey.delete(oldest)
-      this.discardPaneHolds(oldest)
+      // Why release, not discard: eviction is not a delivery event, so a post destroyed with it
+      // has nothing left to resolve it. Losing the owner is the lapse case — the gate re-opens.
+      stranded.push(...this.takePaneHolds(oldest))
+    }
+    // Why after the loop: a release re-enters classify, which must not run mid-eviction.
+    for (const release of stranded) {
+      release()
     }
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1697,6 +1697,7 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
     // Why: detach the hook listener on close so the server never fires into destroyed webContents before reopen, and replay runs only on deliberate recreations.
     agentHookServer.setListener(null)
     agentHookServer.setPaneStatusClearListener(null)
+    agentHookServer.setUnmanagedStatusExtensionListener(null)
     setMigrationUnsupportedPtyListener(null)
     // Why: stop the spinner timer here — it would fire into destroyed webContents, and per-pane teardown may never run for restored-but-untorn panes.
     stopAllSyntheticTitleSpinners()
@@ -1801,6 +1802,19 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
     }
     mainWindow?.webContents.send('agentStatus:clear', clear)
     getDashboardPopoutWindow()?.webContents.send('agentStatus:clear', clear)
+  })
+  // Why: the fence drops those posts silently, and the extension file belongs to the user —
+  // Orca must not touch it, so surfacing is the whole remedy. Telemetry too, because the
+  // population carrying a stale copy is exactly the one that reports shipped fixes as broken.
+  agentHookServer.setUnmanagedStatusExtensionListener((report) => {
+    console.warn(
+      `[agent-hooks] ignoring status posts from an unmanaged ${report.source} extension on pane ${report.paneKey}; Orca did not launch it`
+    )
+    track('agent_hook_unmanaged_extension', { source: report.source })
+    if (mainWindow?.isDestroyed()) {
+      return
+    }
+    mainWindow?.webContents.send('agentStatus:unmanagedExtension', { source: report.source })
   })
   setMigrationUnsupportedPtyListener((event) => {
     if (mainWindow?.isDestroyed()) {

--- a/src/preload/api/agent-status-api.ts
+++ b/src/preload/api/agent-status-api.ts
@@ -17,6 +17,8 @@ export type AgentStatusApi = {
   inferInterrupt: (request: AgentInterruptInferenceRequest) => Promise<boolean>
   /** Guarded clear for an answered AskUserQuestion wait — the CLI emits no hook at answer time, so the renderer reports the submit keystroke. */
   inferQuestionAnswered: (request: AgentQuestionAnsweredInferenceRequest) => Promise<boolean>
+  /** Fires once per pane and source when a status extension Orca did not launch is posting. */
+  onUnmanagedExtension: (callback: (data: { source: string }) => void) => () => void
   /** Listen for PTYs on a legacy numeric pane key that have registry-backed UUID pane proof. */
   onMigrationUnsupported: (callback: (entry: MigrationUnsupportedPtyEntry) => void) => () => void
   onMigrationUnsupportedClear: (callback: (data: { ptyId: string }) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5184,6 +5184,13 @@ const api = {
       ipcRenderer.invoke('agentStatus:inferInterrupt', request),
     inferQuestionAnswered: (request: AgentQuestionAnsweredInferenceRequest): Promise<boolean> =>
       ipcRenderer.invoke('agentStatus:inferQuestionAnswered', request),
+    /** Fires once per pane and source when a status extension Orca did not launch is posting. */
+    onUnmanagedExtension: (callback: (data: { source: string }) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, data: { source: string }) =>
+        callback(data)
+      ipcRenderer.on('agentStatus:unmanagedExtension', listener)
+      return () => ipcRenderer.removeListener('agentStatus:unmanagedExtension', listener)
+    },
     onMigrationUnsupported: (
       callback: (entry: MigrationUnsupportedPtyEntry) => void
     ): (() => void) => {

--- a/src/renderer/src/components/terminal-pane/codex-detached-pane-restart.test.ts
+++ b/src/renderer/src/components/terminal-pane/codex-detached-pane-restart.test.ts
@@ -138,6 +138,21 @@ describe('codex detached pane restart executor', () => {
     expect(blocksCodexPaneInput(state.codexRestartNoticeByPtyId[NEW_PTY])).toBe(false)
   })
 
+  it('stamps a launch token so its own respawn is not read as a poster Orca did not launch', async () => {
+    // Why: the launch token is Orca's only in-band proof of authorship, and every gate keyed on
+    // it — the retired-pane fence and the unmanaged-status-extension fence alike — reads a
+    // tokenless post as foreign. A relaunch into the same pane key that omitted the token made
+    // Orca warn the user about "an extension Orca did not install" for a process Orca launched.
+    seedQueuedRestart()
+
+    await sweepUnclaimedCodexPaneRestarts()
+
+    const env = vi.mocked(window.api.pty.spawn).mock.calls[0]?.[0]?.env
+    expect(env?.ORCA_AGENT_LAUNCH_TOKEN).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    )
+  })
+
   it('executes via the store subscription without a lifecycle timeout', async () => {
     const uninstall = installCodexDetachedPaneRestartExecutor()
     try {

--- a/src/renderer/src/components/terminal-pane/codex-detached-pane-restart.ts
+++ b/src/renderer/src/components/terminal-pane/codex-detached-pane-restart.ts
@@ -16,6 +16,7 @@ import { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
 import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
 import { hasRegisteredRuntimeTerminalTab } from '@/runtime/sync-runtime-graph'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 import { CODEX_ACCOUNT_RESTART_STARTUP } from '@/lib/codex-session-restart'
 import { isForeignMachineCodexPtyId } from '@/lib/codex-pane-selection-lane'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
@@ -157,7 +158,12 @@ function buildPaneIdentityEnv(
       : {}),
     ORCA_PANE_KEY: makePaneKey(tabId, leafId),
     ORCA_TAB_ID: tabId,
-    ORCA_WORKTREE_ID: worktreeId
+    ORCA_WORKTREE_ID: worktreeId,
+    // Why: the launch token is Orca's proof that it started this agent, and the mounted spawn
+    // path always mints one. Without it this respawn's hook posts are indistinguishable from a
+    // poster Orca never launched, so every gate keyed on the token — the retired-pane fence and
+    // the unmanaged-extension fence alike — reads Orca's own replacement as foreign.
+    ORCA_AGENT_LAUNCH_TOKEN: createBrowserUuid()
   }
 }
 

--- a/src/renderer/src/hooks/ipc-events/agent-status-listeners.ts
+++ b/src/renderer/src/hooks/ipc-events/agent-status-listeners.ts
@@ -8,6 +8,7 @@ import {
   rollbackLegacyWorkerTerminalSurfaceInStore
 } from '../legacy-worker-terminal-recovery-event'
 import { useAppStore } from '../../store'
+import { notifyUnmanagedStatusExtension } from './unmanaged-status-extension-notice'
 import { resolvePaneKey } from './agent-status-routing'
 import type { PendingAgentStatusEvent } from './agent-status-bridge-types'
 
@@ -90,6 +91,14 @@ export function registerAgentStatusListeners(args: {
   )
   if (unsubscribeAgentStatusClear) {
     unsubs.push(unsubscribeAgentStatusClear)
+  }
+  const unsubscribeUnmanagedExtension = window.api.agentStatus.onUnmanagedExtension?.(
+    ({ source }) => {
+      notifyUnmanagedStatusExtension(source)
+    }
+  )
+  if (unsubscribeUnmanagedExtension) {
+    unsubs.push(unsubscribeUnmanagedExtension)
   }
   const unsubscribeMigrationUnsupported = window.api.agentStatus.onMigrationUnsupported?.(
     (entry) => {

--- a/src/renderer/src/hooks/ipc-events/unmanaged-status-extension-notice.test.ts
+++ b/src/renderer/src/hooks/ipc-events/unmanaged-status-extension-notice.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import {
+  notifyUnmanagedStatusExtension,
+  resetUnmanagedStatusExtensionNotices
+} from './unmanaged-status-extension-notice'
+
+vi.mock('sonner', () => ({ toast: { warning: vi.fn() } }))
+
+beforeEach(() => {
+  resetUnmanagedStatusExtensionNotices()
+  vi.mocked(toast.warning).mockClear()
+})
+
+afterEach(() => {
+  resetUnmanagedStatusExtensionNotices()
+})
+
+describe('unmanaged status extension notice', () => {
+  it('raises one toast however many panes the main side reports', () => {
+    // Why this lives here and not in the fence: the main side reports per pane *and* source, so
+    // a user with 13 affected panes gets 13 detections. Collapsing them is this module's job.
+    for (let pane = 0; pane < 13; pane += 1) {
+      notifyUnmanagedStatusExtension('omp')
+    }
+    expect(toast.warning).toHaveBeenCalledTimes(1)
+  })
+
+  it('still warns once per agent, because the file lives in that agent’s own folder', () => {
+    notifyUnmanagedStatusExtension('omp')
+    notifyUnmanagedStatusExtension('pi')
+    notifyUnmanagedStatusExtension('omp')
+    expect(toast.warning).toHaveBeenCalledTimes(2)
+    expect(vi.mocked(toast.warning).mock.calls.map((call) => call[1]?.id)).toEqual([
+      'unmanaged-status-extension-omp',
+      'unmanaged-status-extension-pi'
+    ])
+  })
+
+  it('ignores an empty source rather than warning about an unnamed agent', () => {
+    notifyUnmanagedStatusExtension('')
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/ipc-events/unmanaged-status-extension-notice.ts
+++ b/src/renderer/src/hooks/ipc-events/unmanaged-status-extension-notice.ts
@@ -1,0 +1,51 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+
+// Why: the agent's own extension directory is the only place a second status extension can come
+// from, so naming the agent is enough for the user to find the file. Orca never touches it.
+const AGENT_LABEL_BY_SOURCE: Record<string, string> = {
+  omp: 'OMP',
+  pi: 'Pi',
+  'prime-agent': 'Prime'
+}
+
+const notifiedSources = new Set<string>()
+
+/** Reset between tests; the real notice is once-per-source for the life of the window. */
+export function resetUnmanagedStatusExtensionNotices(): void {
+  notifiedSources.clear()
+}
+
+/**
+ * Tell the user once per agent that a status extension Orca did not install is being ignored.
+ *
+ * Why a notice and not a fix: the file is the user's own, so Orca will not remove, move, or
+ * rewrite it. Without this the discrimination is invisible and reads as Orca ignoring their
+ * extension for no reason.
+ */
+export function notifyUnmanagedStatusExtension(source: string): void {
+  if (!source || notifiedSources.has(source)) {
+    return
+  }
+  notifiedSources.add(source)
+  const agent = AGENT_LABEL_BY_SOURCE[source] ?? source
+  toast.warning(
+    translate(
+      'auto.hooks.unmanagedStatusExtensionNotice.title',
+      'Ignoring status from an extension Orca did not install'
+    ),
+    {
+      id: `unmanaged-status-extension-${source}`,
+      description: translate(
+        'auto.hooks.unmanagedStatusExtensionNotice.description',
+        'A second copy of orca-agent-status.ts is running in your {{agent}} extensions folder. Orca is ignoring what it reports, because an older copy can mark a turn finished while the agent is still working. Orca has not changed the file — remove or rename it yourself if you no longer want it.',
+        { agent }
+      ),
+      duration: Infinity,
+      cancel: {
+        label: translate('auto.hooks.unmanagedStatusExtensionNotice.dismiss', 'Dismiss'),
+        onClick: () => {}
+      }
+    }
+  )
+}

--- a/src/renderer/src/hooks/useIpcEvents-lifecycle.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-lifecycle.test.ts
@@ -8,6 +8,7 @@ const EXPECTED_DIRECT_CALLBACK_METHODS = [
   'agentStatus.onMigrationUnsupported',
   'agentStatus.onMigrationUnsupportedClear',
   'agentStatus.onSet',
+  'agentStatus.onUnmanagedExtension',
   'automations.onChanged',
   'browser.onActivateView',
   'browser.onCertificateFailureChanged',
@@ -187,6 +188,7 @@ const EXPECTED_CALLBACK_REGISTRATION_SEQUENCE = [
   'ui.onTerminalZoom',
   'agentStatus.onSet',
   'agentStatus.onClear',
+  'agentStatus.onUnmanagedExtension',
   'agentStatus.onMigrationUnsupported',
   'agentStatus.onMigrationUnsupportedClear',
   'agentStatus.onLegacyWorkerTerminalRecovery',
@@ -411,6 +413,7 @@ describe('useIpcEvents App-lifetime lifecycle', () => {
       groupOrder([
         'agentStatus.onSet',
         'agentStatus.onClear',
+        'agentStatus.onUnmanagedExtension',
         'agentStatus.onMigrationUnsupported',
         'agentStatus.onMigrationUnsupportedClear',
         'agentStatus.onLegacyWorkerTerminalRecovery',
@@ -419,6 +422,7 @@ describe('useIpcEvents App-lifetime lifecycle', () => {
     ).toEqual([
       'agentStatus.onSet',
       'agentStatus.onClear',
+      'agentStatus.onUnmanagedExtension',
       'agentStatus.onMigrationUnsupported',
       'agentStatus.onMigrationUnsupportedClear',
       'agentStatus.onLegacyWorkerTerminalRecovery',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1107,6 +1107,11 @@
             "docPreviewLinkFailed": "Could not open this link in Orca Browser."
           }
         }
+      },
+      "unmanagedStatusExtensionNotice": {
+        "title": "Ignoring status from an extension Orca did not install",
+        "description": "A second copy of orca-agent-status.ts is running in your {{agent}} extensions folder. Orca is ignoring what it reports, because an older copy can mark a turn finished while the agent is still working. Orca has not changed the file — remove or rename it yourself if you no longer want it.",
+        "dismiss": "Dismiss"
       }
     },
     "components": {

--- a/src/renderer/src/web/preload-api/web-agent-status-api.ts
+++ b/src/renderer/src/web/preload-api/web-agent-status-api.ts
@@ -9,6 +9,7 @@ export function createWebAgentStatusApi(): Partial<PreloadApi> {
       getSnapshot: () => Promise.resolve([]),
       inferInterrupt: () => Promise.resolve(false),
       inferQuestionAnswered: () => Promise.resolve(false),
+      onUnmanagedExtension: () => noopUnsubscribe,
       onMigrationUnsupported: () => noopUnsubscribe,
       onMigrationUnsupportedClear: () => noopUnsubscribe,
       onLegacyWorkerTerminalRecovery: () => noopUnsubscribe,

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -787,6 +787,10 @@ const agentHookUnattributedSchema = z
 // nothing derived from them may reach the wire.
 const agentHookTransportBlockedSchema = z.object({ count: z.number().int().nonnegative() }).strict()
 
+// Why: a status extension Orca did not install is posting for a pane. Source only — the pane key
+// and the file's own contents are user data and must not reach the wire.
+const agentHookUnmanagedExtensionSchema = z.object({ source: z.string() }).strict()
+
 // ── Onboarding ──────────────────────────────────────────────────────────
 // Closed enums only — no raw paths/repo names/URLs/error strings (measures activation, not repo debugging).
 // Why: event names still carry legacy seven-step payloads; keep validation backward-compatible for old rows.
@@ -1451,6 +1455,7 @@ export const eventSchemas = {
   agent_hook_install_failed: agentHookInstallFailedSchema,
   agent_hook_unattributed: agentHookUnattributedSchema,
   agent_hook_transport_blocked: agentHookTransportBlockedSchema,
+  agent_hook_unmanaged_extension: agentHookUnmanagedExtensionSchema,
 
   daemon_start_failed: daemonStartFailedSchema,
   main_thread_hang_detected: mainThreadHangDetectedSchema,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​453 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​453 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​443 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​416 |

<!-- /orca-pr-loc -->

## ELI5

Orca's OMP/Pi status extension lives in the agent's own extensions folder, and OMP loads **every** file it finds there. If a copy of `orca-agent-status.ts` is already sitting in that folder that Orca didn't write, Orca deliberately refuses to overwrite it — it's the user's file — and side-loads its own managed copy with `-e` instead.

So both run. In the same process. Posting the same pane's status to the same endpoint.

That's fine while the two agree. It stops being fine the moment Orca ships a fix to the extension, because the old copy doesn't have it. The old copy posts `agent_end` unconditionally; a current one can withhold it (for example while OMP has an automatic continuation scheduled). The old copy's post lands first, the pane settles, and the user — who just installed the fix — watches their pane go quiet mid-turn and concludes the fix didn't work.

Orca can tell the two apart, because Orca stamps a launch token into every process it starts and the old copy predates that field. But "I once saw a post with a token" is not the same as "the copy with the token is still alive". So the discrimination is written as a **delay, not a veto**: a post without a token is *held*, and it is delivered anyway unless the copy with the token speaks up and contradicts it.

## Before / after, for a user

| | Before this PR | After |
| :--- | :--- | :--- |
| Stale extension settles a pane mid-turn | Pane goes quiet while the agent is still working | Stale post is held; the managed copy's own post wins |
| The managed copy stops posting (crash, exit) | — | Pane settles ~30s later instead of hanging |
| Orca's own Codex account-switch restart | — | Unchanged; it now carries a launch token |
| Warning toast | — | One toast per agent, only when two posters are actually proven |

## What was measured

Against the shipped `omp 17.0.5` binary, in a temp `PI_CODING_AGENT_DIR` (nothing in `~` was read, written, moved, or removed):

- **Both copies load.** One auto-discovered from `<agentDir>/extensions/`, one passed with `-e`. Load-time markers from both landed. `omp --help` documents `--no-extensions` as "Disable extension discovery (explicit -e paths still work)", which is the same statement from the other side.
- **Both reach the hook server** on the same `paneKey`, through `/hook/omp`, in one turn: `before_agent_start`, `agent_start`, `agent_end` from each.
- **The unmanaged copy's `agent_end` lands first.** It won the race in the captured ordering.
- **The launch token separates them.** The managed copy sends `launchToken`; the unmanaged copy omits the field entirely.

### Correction to an earlier claim in this description

An earlier revision said the discrimination turns on *absent* vs *present-but-empty*: with `ORCA_AGENT_LAUNCH_TOKEN` unset the managed copy still sends `launchToken: ''`, while an unmanaged copy omits the key.

That is true **on the wire** and false **at the gate**. `readEnvelopeString` (`src/shared/agent-hook-listener/hook-envelope.ts:89-96`) trims the value and returns `undefined` for anything empty, so by the time the fence is called the two cases are already the same value. Nothing in this PR can rely on that distinction, and nothing in it does — the gate reads "non-empty token" vs "no usable token", which is the only fact that survives parsing. Recovering the distinction would need a wire/parse change, which is not in scope here.

## What the review loops found, and how each is fixed

### 1. Armed, then died — the pane stranded on "working" forever

The original fence dropped tokenless posts permanently once a tokened poster had been seen on a pane. Measured with the identical post sequence (`agent_start` with a token, then a tokenless `agent_end`, then silence):

| Build | Outcome |
| :--- | :--- |
| `main` (`a1f198be0d`) | pane settles to `done` — 1 check passed |
| this PR at `2c2415735d` | pane strands on `working`, no TTL at all — 1 check failed |

So the first cut traded a pane that settles *too early* for one that **never settles**. That is not the better failure: a pane wrongly stuck on "working" is invisible, permanent, and has no user recovery. The claim in the earlier description that it "fails open in every other direction" was **wrong**, and this is the direction it was wrong about.

**The fix: suppression is provisional.** A tokenless post on an owned pane is *held*, not dropped.

- A following **tokened** post discards the held post. That is also the only real proof that two posters share the pane — one process cannot both send and omit the token — so that is when the warning fires.
- **Silence** past `UNMANAGED_POST_CONFIRMATION_WINDOW_MS` (30s) re-opens the gate, forgets the owner, and delivers the held post through the same gates it would have passed originally.

Every held post is therefore either superseded by the managed poster or delivered — but that only became true of *every* removal path in defect 3 below. This line, as originally written, asserted an invariant the PR did not hold; see there for what falsified it.

#### The shipped window had no committed reader

Every window test ran on the 40ms test seam, so `UNMANAGED_POST_CONFIRMATION_WINDOW_MS` had **zero readers** — the 30s that actually ships was untested, and an edit to the constant or to the constructor default that wires it would have left every test green.

Closed by **exercising the real constant** rather than only asserting the wiring, because fake timers make that free. `unmanaged-status-extension-fence.test.ts` (new) drives a **default-constructed** fence and advances to `UNMANAGED_POST_CONFIRMATION_WINDOW_MS - 1` (no release), then `+1` (release). That is a real reader of the shipped value *and* a wiring assertion, in ~150ms of wall clock rather than 30s. A second check pins the value between the two bounds that justify it — above the sub-second band in which the managed copy supersedes, below the real `AGENT_STATUS_STALE_AFTER_MS` rather than a copy of it.

The two are separately load-bearing, which the ablations show: unwiring the constructor default reddens only the first, changing the constant's value reddens only the second.

Why 30s: both copies run in one process off one hook event, so the managed copy's superseding post lands in the same millisecond band as the unmanaged one. Even the deliberately-withheld `agent_end` is re-checked every 25–250ms until idle, and an auto-continuation posts `agent_start` as soon as it is scheduled. 30s is orders of magnitude above that, and far below the 30-minute `AGENT_STATUS_STALE_AFTER_MS` at which Orca stops believing a "working" claim anyway — so a lapse means the managed poster is *gone*, not merely quiet. Verified end-to-end against the real constant with no test seam: the pane settles at 33s.

The property this PR exists for is kept: while the managed copy is alive and posting, every stale post is superseded, so a stale extension still cannot settle a pane that is genuinely still working.

### 2. Orca's own relaunch posted without a token, and got warned about

`codex-detached-pane-restart.ts` — Orca's driver for an accepted Codex account-switch restart on an unmounted pane — kill-and-respawns Codex into the **same pane key** via `buildPaneIdentityEnv`, which set `ORCA_PANE_KEY` / `ORCA_TAB_ID` / `ORCA_WORKTREE_ID` but **not** `ORCA_AGENT_LAUNCH_TOKEN`. Codex's hook script posts `launchToken=${ORCA_AGENT_LAUNCH_TOKEN}`, so the replacement posted tokenless into a pane the previous (tokened) Codex had already armed. Result: Orca suppressed its own replacement's status and toasted the user about "an extension Orca did not install" — for a process Orca launched. Unactionable, and worse than the bug it was guarding.

**This is a gap in the token contract, not in the fence.** The launch token is Orca's only in-band proof of authorship, and *every* gate keyed on it reads a tokenless post as foreign — the retired-pane fence (`restartedStatusLaunchTokenHashByPaneKey`) as much as this one. Teaching one fence to recognise one relaunch path would leave the other gates wrong and would need a new exemption for every future path. So the fix is at the source: that path now mints a launch token, like every other Orca agent spawn.

Surveyed all four renderer `pty.spawn` call sites; this was the only one that named a `launchAgent` and shipped no token. `launch-worktree-background-terminals.ts` also omits it but launches no agent, so it arms nothing.

Note that fix 1 independently removes the *toast* here (a relaunch never produces the interleaved tokened post that confirmation requires), but it would still have left ~30s of suppressed status on Orca's own process. Both halves are needed.

### 3. The owner cap destroyed a held post instead of releasing it

The fence tracks at most `MAX_TRACKED_PANES` (512) pane owners and evicts the least-recently-tokened one. That eviction called `discardPaneHolds`, which cleared the pane's hold timer and dropped the entry **without calling its release** — so the held post was destroyed with nothing left to resolve it, and the pane claimed `working` permanently.

Measured against a control: two arms, one variable, identical hold window and identical waits, with the filler loop asserted to finish *inside* the window so the lapse could not be the discriminator.

| Arm | Filler panes | Outcome |
| :--- | ---: | :--- |
| A | 512 (crosses the cap) | **strands** on `['working']` |
| B | 10 (control) | delivers `['working', 'done']` |

Swapping in a releasing variant flips arm A to `['working', 'done']`. The shipped suite stayed **10/10 green either way** — nothing pinned it.

**The fix: eviction resolves the hold instead of destroying it.** Eviction is not a delivery event, so it is treated exactly as the lapse is — the owner is forgotten, the gate re-opens, and the held post is released down the same re-entrant path. The releases run *after* the eviction loop, because a release re-enters `classify` and must not mutate the owner map mid-iteration.

**Every path that can remove a held post, enumerated.** This is the third mechanism to break one invariant, so the check is exhaustive rather than incremental:

| Removal path | Releases? | Verdict |
| :--- | :--- | :--- |
| A tokened post supersedes it (`classify`) | no | correct — the managed post is delivered in its place |
| A newer tokenless post replaces it (`holdPost`, latest-only) | no | correct — the replacement still resolves, and carries the newer state. **Now pinned** (row P) — it reddened 0 before, and no test reached it at all |
| The confirmation window lapses (timer) | **yes** | correct |
| The pane is retired (`forgetPane`) | no | **deliberate** — the post describes the turn that just ended, and retirement closes the pane's row in the same step. Pinned; reddens if collapsed into a release |
| The owner LRU evicts the pane (`rememberOwner`) | **yes, now** | **this defect** |
| Server teardown (`dispose`) | no | app quit only — one production caller, `index.ts`. Nothing held here is what the next launch reads: what survives is the pane's persisted status row, and hydrate re-stamps every non-`done` row `restoredUnconfirmed` (`server.ts:3321-3323`), which `isFreshNonDoneAgentStatus` refuses to read as live work. See the correction below. **Now pinned** (rows N and O) — the reasoning was right and nothing tested it |

So the invariant now holds on every path: **no reachable sequence of posts can leave a pane permanently claiming work that has finished.**

#### Correction to the explanation of the last row

The invariant is confirmed. The reason given for the teardown row was not, and this is the third revision of this description to assert something false about its own invariant while landing on the right conclusion — which is exactly how a wrong explanation survives review.

Two things were wrong. The sentence above it said the *single* path that ends a hold without delivering it retires the pane's row; there are **two** — pane retirement and server teardown. And teardown was said to be safe because what persists "is re-read on the next launch as a *replay*, which this fence does not gate at all". A replay is a different thing in this code (`isReplay`, fenced by `hydratedLaunchTokenHashByPaneKey`), and "the fence does not gate it" explains only why the fence is irrelevant — not why the pane is safe.

The mechanism that actually makes it safe is a restore path keyed on `restoredUnconfirmed`:

- At quit the held post is dropped. The pane's persisted row is whatever the managed poster last said — typically `working`.
- On the next launch, hydrate stamps that row: `if (entry.payload.state !== 'done') entry.restoredUnconfirmed = true` (`src/main/agent-hooks/server.ts:3321-3323`; the field is declared at `:142-143` and is deliberately **not** persisted — it is stripped on write at `:3449` so hydrate always re-stamps it).
- Every freshness gate then discounts that row rather than treating it as live work: `isFreshNonDoneAgentStatus` (`src/shared/agent-status-types.ts:252-263`), `isExplicitAgentStatusFresh` (`src/renderer/src/lib/pane-agent-evidence.ts:17-25`), and the sidebar, tab-bar and palette readers that call them.
- The flag clears only when a live event replaces the entry (`server.ts:1641-1645`), or the row is retired by the ended-process / hydrated-authority machinery.

So a hold lost at quit cannot produce a standing "working" claim, because the row that comes back is explicitly marked as not-live-truth until something live confirms it. The code comment asserted the old, wrong reason too; both it and the class doc's "only pane retirement" line are corrected in `b1cd969660`. **No behaviour changed** — comment text only, verified by stripping comments from both revisions of the file and diffing the remainder (identical), with `src/main/agent-hooks` + `src/shared/agent-hook-listener` at **952 checks, 0 red** (6 skipped, 92 files), `pnpm tc` **exit 0 / 0 `error TS`** run cold after clearing the build cache, `oxlint` **exit 0** with stdout retained and empty, and `oxfmt --check` reporting the file correctly formatted.

### 4. Three live paths that nothing protected — coverage, not behaviour

Three more pieces of this change reddened **0 of 775** in `src/main/agent-hooks` — the whole
suite passed with each of them removed:

- `dispose()` clearing the held posts' timers,
- that path's only call site, `this.unmanagedExtensionFence.dispose()` in `stop()`,
- and `holdPost`'s latest-only supersede, the `discardHeldPost` that drops an older hold
  before installing a newer one.

**A 0-red is a question, not an answer**, so each was classified against a whole-function
control before anything was written. Controls first, then the verdicts:

| Control | Red | What it establishes |
| :--- | ---: | :--- |
| `dispose()` throws unconditionally | **200/775** | the function is reached, and often |
| `dispose()` throws only when a hold is outstanding | **1/775** | the *state* it protects is reached too — once |
| the `stop()` call removed **and** `dispose()` throws | **1/775** (from 200) | `stop()` is the route for 199 of those 200 reaches |
| `holdPost` returns immediately (never holds) | **5/775** | the hold machinery is exercised |
| `holdPost` throws on a **second** hold for the same pane and source | **0/775** | that path is never reached at all |

| Path | Which kind of zero | Fix |
| :--- | :--- | :--- |
| `dispose()` clears held timers | **unprotected.** Reached by 200 tests, and once with a hold outstanding, yet no assertion depended on the timer being cleared | pinned |
| `stop()` disposes the fence | **unprotected.** Executed by 199 tests, and nothing asserted its effect | pinned |
| `holdPost` latest-only supersede | **unreachable in this population — reachable in production.** No test posts a second tokenless post inside the first one's window; one stale extension posting a whole turn tokenless does exactly that | pinned by a test that reaches it |

None of the three is unreachable *code*, so none warrants a tripwire or a deletion: the
remedy in every case is a test that reaches the path and fails if it changes.

The `stop()` pin needed the right observable. `stop()` sets `this.onAgentStatus = null`
**before** it reaches the fence, so a hold that outlives teardown never calls back — a
listener-based assertion would have passed either way and been vacuous. What it does instead
is re-enter the routing path and write a fresh row for a pane whose row `stop()` just
cleared, so the pin reads `getStatusSnapshotForPane(PANE)` and requires it to stay empty.

With the three pins in place the same three mutations redden **2 / 1 / 1 of 778**. The
dispose mutation reddens two because both new teardown pins depend on that one clearTimeout.

## Blast radius

**Orca does still write to that directory today** — `installManagedExtensions` writes `<sourceAgentDir>/extensions/orca-agent-status.ts` on every OMP/Pi launch, where `sourceAgentDir` defaults to `~/.omp/agent`. But it writes **only** when the file already there carries the `@orca-managed-pi-extension` marker. An unmarked file is treated as user-owned, is never replaced, and Orca falls back to `userData/omp-managed-status-extension/`.

That means the condition is **permanent once it exists**. It does not heal on upgrade. Every subsequent Orca release side-loads a second extension alongside the stale one, and each release widens the behavioural gap between them.

How a marker-less copy gets there:

- **Not from a current Orca write** — every managed write is marked.
- **Not from an older Orca write either.** Before the managed-extension change, Orca wrote extensions into a per-source **overlay** under `userData/…-agent-overlays/`, not into `~/.<agent>/agent/extensions`. The legacy overlay migration that copies that state home explicitly **skips** the three managed extension filenames.
- So the realistic sources are **hand-installed or hand-copied files**: `omp install` / `omp plugin link`, a copy out of an overlay or another machine, or a user editing the managed file and dropping the marker line — that last one silently converts Orca's own extension into a permanently-stale one.

Verdict: **not everyone who upgraded**, but not a closed set either. This is pre-existing. It is not caused by the OMP settle work, but it can mask it.

## What changed

- `src/main/agent-hooks/unmanaged-status-extension-fence.ts` — the classifier. Holds instead of drops, discards a held post when a tokened post supersedes it, reports only on that confirmation, and releases the held post when the window lapses **or when the owner LRU evicts its pane**. `MAX_TRACKED_PANES` is exported so the eviction test names the boundary instead of hard-coding 512.
- `src/main/agent-hooks/server.ts` — threads a re-delivery thunk into `getAgentStatusDisposition`, which is the single choke point both the local HTTP path and the relay `ingestRemote` path already funnel through. The local path is now a re-entrant `routeLocalHookStatus`, so a released hold re-runs **every** gate against the pane as it stands at release time rather than replaying a stale decision. `stop()` disposes held timers.
- `src/renderer/src/components/terminal-pane/codex-detached-pane-restart.ts` — mints `ORCA_AGENT_LAUNCH_TOKEN` for the respawn.
- `src/main/agent-hooks/unmanaged-status-extension-fence.test.ts`, `server-unmanaged-status-extension.test.ts` — **tests only.** Three pins for the teardown and supersede paths that reddened 0 of 775 (see finding 4).
- `src/main/agent-hooks/unmanaged-status-extension-fence.ts` (`b1cd969660`) — **comment only.** The class doc named pane retirement as the only path that ends a hold without delivering it; server teardown does too, and `dispose()` now states the reason it is safe (the `restoredUnconfirmed` restore path) instead of the replay claim that was wrong.

Orca **does not delete, move, rename, or rewrite the user's file**, and this PR adds no code that could. Detection and discrimination only.

## Surfacing

A quiet filter would leave someone staring at their own extension being ignored for no stated reason. So the drop is announced, once per pane and source, and only once two posters are actually proven:

- `console.warn` in main naming the source and pane, plus `agent_hook_unmanaged_extension` telemetry carrying the **source only** — the pane key and the file's contents are user data.
- A one-shot renderer toast, title *"Ignoring status from an extension Orca did not install"*.

The one-shot property lives in the renderer's per-source dedupe, not in the fence: main reports per pane **and** source, so 13 affected panes produce 13 detections that the renderer collapses to 1 toast. Both halves are now pinned by tests (they previously had none), and both redden under ablation.

## Verification

Every number below was observed in the foreground, on this head, after the branch was refreshed onto `main`. The rebase pulled in `main`'s pnpm 12 and oxlint/oxfmt upgrades, so every gate was re-run from a clean install rather than carried over.

- **`pnpm tc`: exit 0, 0 `error TS`**, run cold — `node_modules/.tmp` removed and every `*.tsbuildinfo` deleted first, because it is incremental and a warm cache has returned exit 0 on a tree that does not typecheck. Proven non-vacuous the same cold way: planting `const orcaTcProbe2f45: number = 'not a number'` in the fence gives exit 1 and 2 `error TS` naming that file at line 245.
- **`oxlint` 1.80.0** on the two changed test files: exit 0, stdout **and** stderr retained and both empty. Proven non-vacuous: planting a `debugger` gives exit 1 and `eslint(no-debugger)` naming line 54; removing it returns exit 0. (Run directly, retaining **stdout** — oxlint writes configuration failures there, and the changed-code quality gate brace-slices that stdout, which Node 26 pollutes with an engine warning.) Versions read from `origin/main` at the rebase target rather than a worktree: pnpm **12.0.0**, oxlint **^1.80.0**, oxfmt **^0.65.0**; installed binaries report 12.0.0 / 1.80.0 / 0.65.0.
- **`oxfmt`** on the two changed test files, plus the repo's own staged-file hook (`oxlint`, react-doctor, `oxfmt --write`) running clean at commit time.
- All three defects proven **failing-first against a control**, not by reasoning about the failure direction:
  - Defect 1, identical probe: `main` **1 check, 0 red**; the first cut **1 check, 1 red** (`['working']`, no `done`).
  - Defect 2, relaunch env: at the first cut `ORCA_AGENT_LAUNCH_TOKEN` is `undefined` — **1 red**. Relaunch toast probe: **1 red** then, passes now.
  - Defect 3, two arms differing only in pane count: 512 filler panes **1 red** (`['working']`), 10 filler panes **0 red** (`['working', 'done']`), with the filler loop asserted to finish inside the hold window so the lapse was not the discriminator.
- Suites: `server-unmanaged-status-extension.test.ts` **12 checks, 0 red**; `unmanaged-status-extension-fence.test.ts` **4 checks, 0 red** — 16 together in 1.7s.
- Sweeps: `src/main/agent-hooks` → **778 checks, 0 red** (6 skipped, 77 files). `src/main/agent-hooks` + `src/shared/agent-hook-listener` → **961 checks, 0 red** (6 skipped, 92 files).
- Branch currency measured with the compare API, not the mergeable label: before this round `diverged`, ahead 4 / **behind 18**, while GitHub reported `MERGEABLE` — the label is not a currency signal. After the refresh onto `main` (`0a995cc30d`): **`ahead`, ahead 5, `behind_by` 0**. CI re-earned on that base: **19 pass, 7 skipping, 0 failed** — all eight `test / tests node 24` shards, `static analysis`, `package` and `package (windows)` included.

### Ablations

Gate level, one mutation at a time, each verified applied by diff before the run (an edit that silently misses reads as 0-red), tree restored and asserted clean between runs, run serially.

**Rows J–M re-measured on this head.** Rows A–I were measured at the previous head `574b7cbf97` and are reproduced here unchanged; they have not been re-run since the rebase.

| # | Mutation | Red |
| :--- | :--- | ---: |
| A | delete `release()` on lapse | 1 |
| B | report on the first tokenless post instead of on confirmation | 1 |
| C | keep the owner armed across the lapse | 1 |
| D | drop the launch token from Orca's relaunch env | 1 |
| E | **positive control** — delete the fence gate entirely | 5 |
| F | a tokened post no longer supersedes the held post | 2 |
| G | pane retirement no longer drops the held post | 1 |
| H | remove the renderer per-source dedupe | 2 |
| I | collapse main-side reporting from per-pane to per-source | 1 |
| **J** | **eviction destroys the held post instead of releasing it** | **1** |
| **K** | **the constructor default stops reading the shipped constant** | **1** |
| **L** | **the shipped constant's value is changed** | **1** |
| **M** | **pane retirement releases instead of dropping** | **1** |
| **N** | **`dispose()` stops clearing the held posts' timers** | **2** |
| **O** | **`stop()` stops disposing the fence** | **1** |
| **P** | **`holdPost` stops superseding the older hold** | **1** |

**Rows N–P are new in this round**, each measured on the rebased head against a 778-check population; all three reddened **0 of 775** before their pins existed. Each of J–M reddens exactly its own gate and nothing else, which is what separates them: J and M are the two halves of "which removal paths release"; K and L are the two halves of "which edits to the shipped window get caught". J also reddens **only** the new test — the ten shipped tests stayed green under it, which is why the defect survived two rounds.

G reddened **0** on its first run in the previous round: the retired-pane gate suppressed the released post anyway, so the test named a line it did not exercise. It was rewritten to revive the pane through omp's real new-turn boundary (`before_agent_start`) — a reused pane key settling on the *previous* turn's completion — and now reddens 1.

## Outstanding

**The toast's rendered appearance still has not been checked.** This change alters only *when* it fires, not its copy, styling, or markup, so no rendered-UI claim is made here. The `$electron` skill is present and well-formed in this worktree (`.claude/skills/electron/SKILL.md`), unlike the lane that wrote the first revision, where it returned `Unknown skill`.



