### PR TITLE
fix(windows): give user-facing deletions the repo's rm retry policy

### DIFF
--- a/src/cli/handlers/account.ts
+++ b/src/cli/handlers/account.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { delimiter, join } from 'node:path'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 import type { CommandHandler, HandlerContext } from '../dispatch'
 import { printResult } from '../format'
 import { RuntimeClientError } from '../runtime-client'
@@ -183,7 +184,7 @@ async function cleanupClaudeLoginArtifacts(
     }
   }
   try {
-    rmSync(configDir, { recursive: true, force: true })
+    removeTreeSync(configDir)
   } catch (error) {
     errors.push(error)
   }

--- a/src/main/browser/browser-route-partition-storage-dependencies.ts
+++ b/src/main/browser/browser-route-partition-storage-dependencies.ts
@@ -1,5 +1,5 @@
 import { session } from 'electron'
-import { rm } from 'node:fs/promises'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 import {
   releaseBrowserRoutePartitionStorage,
   type BrowserRoutePartitionStorageDependencies
@@ -24,7 +24,7 @@ export function browserRoutePartitionStorageDependencies(
       browserSessionRegistry.clearRoutePartitionPolicies(partition)
     },
     // Why: force ignores an already-absent directory, keeping the sweep idempotent.
-    removePartitionDirectory: (directory) => rm(directory, { recursive: true, force: true })
+    removePartitionDirectory: removeTree
   }
 }
 

--- a/src/main/claude-accounts/claude-managed-auth-storage.ts
+++ b/src/main/claude-accounts/claude-managed-auth-storage.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join, relative, resolve, sep } from 'node:path'
 import { parseWslUncPath } from '../../shared/wsl-paths'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 import { toWindowsWslPath } from '../wsl'
 import { runWslProcess } from '../wsl/wsl-runner'
 import {
@@ -141,7 +142,7 @@ export class ClaudeManagedAuthStorage {
   async remove(accountId: string, candidatePath: string): Promise<void> {
     try {
       const managedAuthPath = await this.assertOwned(candidatePath, accountId)
-      rmSync(resolve(managedAuthPath, '..'), { recursive: true, force: true })
+      removeTreeSync(resolve(managedAuthPath, '..'))
     } catch (error) {
       console.warn('[claude-accounts] Refusing to remove untrusted managed auth:', error)
     }

--- a/src/main/ipc/pet.ts
+++ b/src/main/ipc/pet.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, dialog, ipcMain } from 'electron'
 import { copyFile, mkdir, readFile, rm, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 import { basename, extname, join, normalize, sep } from 'node:path'
 import { z } from 'zod'
 import type { CustomPet } from '../../shared/pet-types'
@@ -136,7 +137,7 @@ export function registerPetHandlers(): void {
           return
         }
         try {
-          await rm(target, { recursive: true, force: true })
+          await removeTree(target)
         } catch (error) {
           console.warn('[pet-overlay] pet:delete (bundle) failed', error)
         }

--- a/src/main/plugins/plugin-install.ts
+++ b/src/main/plugins/plugin-install.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readdir, realpath, rm } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 import {
   PLUGIN_MANIFEST_FILENAME,
@@ -315,5 +316,5 @@ async function removeResolvedPluginDirectory(rootDir: string, pluginKey: string)
   ) {
     throw new Error(`refusing to remove plugin path outside ${rootReal}`)
   }
-  await rm(resolve(rootDir, pluginKey), { recursive: true, force: true })
+  await removeTree(resolve(rootDir, pluginKey))
 }

--- a/src/main/skills/skill-install-filesystem.ts
+++ b/src/main/skills/skill-install-filesystem.ts
@@ -1,7 +1,8 @@
 import type { Dirent, Stats } from 'node:fs'
-import { lstat, readdir, realpath, rm, stat } from 'node:fs/promises'
+import { lstat, readdir, realpath, stat } from 'node:fs/promises'
 import type { SkillPackageManifestV1 } from '../../shared/skill-package-manifest'
 import { renameSkillPathWithWindowsRetry } from './skill-filesystem-retry'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 import { runSkillCandidateTasks } from './skill-candidate-concurrency'
 import {
   SKILL_PACKAGE_OBSERVATION_LIMITS,
@@ -63,7 +64,9 @@ export const nativeSkillInstallFilesystem: SkillInstallFilesystem = {
         : undefined
     ),
   rename: renameSkillPathWithWindowsRetry,
-  remove: (path) => rm(path, { recursive: true, force: true }),
+  // Why the shared policy: deleting an installed skill is a user action, and the rename above
+  // already concedes Windows holds these paths open a moment longer than the call expects.
+  remove: removeTree,
   // Why the bounded pool rather than `Promise.all`: a delete plan enumerates
   // every discovery root, and unbounded fan-out here is the same burst of
   // filesystem-metadata work discovery already learned to cap.

--- a/src/main/speech/model-manager.ts
+++ b/src/main/speech/model-manager.ts
@@ -2,6 +2,7 @@ import { app } from 'electron'
 import { existsSync, mkdirSync, rmSync, statSync } from 'node:fs'
 import { rename, rm } from 'node:fs/promises'
 import { join, relative, resolve } from 'node:path'
+import { removeTree, removeTreeSync } from '../../shared/windows-transient-lock-removal'
 import type {
   SpeechModelManifest,
   SpeechModelState,
@@ -172,8 +173,9 @@ export class ModelManager extends SpeechModelDownloadTransport {
 
     const stagingDir = `${modelDir}.partial`
     const legacyArchivePath = join(this.modelsDir, `${modelId}.tar.bz2`)
-    // Why: resuming an unverified file left by a crashed process could preserve corrupt bytes.
-    rmSync(stagingDir, { recursive: true, force: true })
+    // Why: resuming an unverified file left by a crashed process could preserve corrupt bytes,
+    // so a Windows handle still on the last attempt's staging dir must not decide this quietly.
+    removeTreeSync(stagingDir)
     try {
       rmSync(legacyArchivePath, { force: true })
     } catch {
@@ -205,7 +207,9 @@ export class ModelManager extends SpeechModelDownloadTransport {
         return
       }
 
-      await rm(modelDir, { recursive: true, force: true })
+      // Why the shared policy: the rename below cannot land while Windows still holds a handle
+      // on the model being replaced, and the user already waited out the whole download.
+      await removeTree(modelDir)
       await rename(stagingDir, modelDir)
       this.updateState(modelId, 'ready')
     } catch (err) {
@@ -244,15 +248,15 @@ export class ModelManager extends SpeechModelDownloadTransport {
     this.cancelDownload(modelId)
     const modelDir = this.getModelDir(modelId)
     if (existsSync(modelDir)) {
-      await rm(modelDir, { recursive: true, force: true })
+      await removeTree(modelDir)
     }
-    await rm(`${modelDir}.partial`, { recursive: true, force: true })
+    await removeTree(`${modelDir}.partial`)
     await rm(join(this.modelsDir, `${modelId}.tar.bz2`), { force: true })
     // Why: also delete the pre-migration copy, or the next launch re-migrates it and resurrects the model.
     if (this.migrationSourceDir) {
       const sourceModelDir = this.getSafeModelDir(modelId, this.migrationSourceDir)
       if (existsSync(sourceModelDir)) {
-        await rm(sourceModelDir, { recursive: true, force: true })
+        await removeTree(sourceModelDir)
       }
     }
     this.modelStates.delete(modelId)

--- a/src/main/user-facing-deletion-retry-policy.test.ts
+++ b/src/main/user-facing-deletion-retry-policy.test.ts
@@ -1,0 +1,193 @@
+import { mkdtempSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
+import type * as nodeFsPromises from 'node:fs/promises'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { findRawRecursiveRemovals } from '../shared/raw-recursive-removal-scan'
+import {
+  WINDOWS_RM_MAX_RETRIES,
+  transientLockRemovalOptions
+} from '../shared/windows-transient-lock-removal'
+import { nativeSkillInstallFilesystem } from './skills/skill-install-filesystem'
+
+/** Records the options every recursive removal hands Node, while still performing the removal. */
+const recorded = vi.hoisted(() => ({ rmCalls: [] as [string, unknown][] }))
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof nodeFsPromises>()
+  return {
+    ...actual,
+    rm: (path: string, options: unknown) => {
+      recorded.rmCalls.push([path, options])
+      return actual.rm(path, options as Parameters<typeof actual.rm>[1])
+    }
+  }
+})
+
+/**
+ * Deleting a workspace, a skill, a plugin, a downloaded speech model or a signed-in account is a
+ * removal the user asked for and will notice. On Windows any of those trees can still be held open
+ * by an indexer, antivirus or a just-exited child, so a bare
+ * `rm(dir, { recursive: true, force: true })` throws EPERM and the delete silently does not happen
+ * while the UI reports success. The holds are transient, which is what `maxRetries` absorbs.
+ *
+ * This guard is deliberately scoped to the user-facing population rather than to every recursive
+ * removal in the repo: the internal staging and scratch directories are best-effort by design, and
+ * the macOS-only provider paths can never benefit from a Windows retry at all.
+ */
+const REPO_ROOT = join(__dirname, '..', '..')
+
+/** A deletion the user asked for, named by the region of the file that performs it. */
+type UserFacingDeletion = { file: string; region: string; deletes: string }
+
+const USER_FACING_DELETIONS: UserFacingDeletion[] = [
+  {
+    file: 'src/main/skills/skill-install-filesystem.ts',
+    region: 'export const nativeSkillInstallFilesystem',
+    deletes: 'an installed skill'
+  },
+  {
+    file: 'src/main/plugins/plugin-install.ts',
+    region: 'async function removeResolvedPluginDirectory',
+    deletes: 'an installed plugin'
+  },
+  {
+    file: 'src/main/speech/model-manager.ts',
+    region: 'async deleteModel',
+    deletes: 'a downloaded speech model'
+  },
+  {
+    file: 'src/main/speech/model-manager.ts',
+    region: 'async downloadModel',
+    deletes: 'the model a finished download replaces'
+  },
+  {
+    file: 'src/main/claude-accounts/claude-managed-auth-storage.ts',
+    region: 'async remove',
+    deletes: "a signed-in account's managed auth"
+  },
+  {
+    file: 'src/main/browser/browser-route-partition-storage-dependencies.ts',
+    region: 'export function browserRoutePartitionStorageDependencies',
+    deletes: "the user's browsing data for a route partition"
+  },
+  {
+    file: 'src/main/ipc/pet.ts',
+    region: "'pet:delete'",
+    deletes: 'a pet bundle the user imported'
+  },
+  {
+    file: 'src/cli/handlers/account.ts',
+    region: 'async function cleanupClaudeLoginArtifacts',
+    deletes: "a removed account's config directory"
+  }
+]
+
+/** The body of `region` in `source`, from its signature to the brace that closes it. */
+function readRegion(source: string, region: string): string {
+  const start = source.indexOf(region)
+  expect(start, `region "${region}" is gone; re-point this guard at its new name`).toBeGreaterThan(
+    -1
+  )
+  const open = source.indexOf('{', start)
+  let depth = 0
+  for (let i = open; i < source.length; i += 1) {
+    if (source[i] === '{') {
+      depth += 1
+    } else if (source[i] === '}') {
+      depth -= 1
+      if (depth === 0) {
+        return source.slice(start, i + 1)
+      }
+    }
+  }
+  throw new Error(`region "${region}" never closes`)
+}
+
+describe('user-facing deletions carry the Windows removal policy', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it.each(USER_FACING_DELETIONS)(
+    'removes $deletes through the retrying helper ($file)',
+    ({ file, region }) => {
+      const body = readRegion(readFileSync(join(REPO_ROOT, file), 'utf8'), region)
+      expect(
+        findRawRecursiveRemovals(body),
+        `this deletes ${file} content the user asked to remove; on Windows a raw recursive rm throws EPERM on a transiently held handle. Use removeTree/removeTreeSync from src/shared/windows-transient-lock-removal.ts`
+      ).toEqual([])
+    }
+  )
+
+  it('the region reader returns a real body rather than an empty string', () => {
+    // Without this every assertion above passes for a region that matched nothing.
+    const body = readRegion(
+      readFileSync(join(REPO_ROOT, 'src/main/speech/model-manager.ts'), 'utf8'),
+      'async deleteModel'
+    )
+    expect(body).toContain('removeTree')
+    expect(body.length).toBeGreaterThan(100)
+  })
+
+  it('the scan still reports a region that forgot the retries', () => {
+    // Positive control: the guard above is only meaningful if this shape reddens it.
+    expect(
+      findRawRecursiveRemovals(
+        'async remove(p) {\n  await rm(p, { recursive: true, force: true })\n}'
+      )
+    ).toEqual([2])
+  })
+
+  it("hands Node the retry count on Windows and leaves other platforms' calls untouched", () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' })
+    expect(transientLockRemovalOptions()).toEqual({
+      recursive: true,
+      force: true,
+      maxRetries: WINDOWS_RM_MAX_RETRIES,
+      retryDelay: expect.any(Number)
+    })
+    vi.stubGlobal('process', { ...process, platform: 'darwin' })
+    expect(transientLockRemovalOptions()).toEqual({ recursive: true, force: true })
+  })
+})
+
+describe('the skill delete primitive', () => {
+  const roots: string[] = []
+  afterEach(async () => {
+    vi.unstubAllGlobals()
+    recorded.rmCalls.length = 0
+    await Promise.all(roots.splice(0).map((dir) => rm(dir, transientLockRemovalOptions())))
+  })
+
+  it('passes the retry policy to Node when deleting an installed skill on Windows', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' })
+
+    await nativeSkillInstallFilesystem.remove(join(tmpdir(), 'orca-absent-skill'))
+
+    expect(recorded.rmCalls.at(-1)?.[1]).toEqual(
+      expect.objectContaining({ recursive: true, maxRetries: WINDOWS_RM_MAX_RETRIES })
+    )
+  })
+
+  it('leaves the call unchanged on macOS and Linux', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'darwin' })
+
+    await nativeSkillInstallFilesystem.remove(join(tmpdir(), 'orca-absent-skill'))
+
+    expect(recorded.rmCalls.at(-1)?.[1]).toEqual({ recursive: true, force: true })
+  })
+
+  it('still actually removes the tree', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'skill-delete-'))
+    roots.push(root)
+    const skillDir = join(root, 'my-skill')
+    mkdirSync(join(skillDir, 'nested'), { recursive: true })
+    writeFileSync(join(skillDir, 'nested', 'SKILL.md'), '# skill')
+
+    await nativeSkillInstallFilesystem.remove(skillDir)
+
+    expect(existsSync(skillDir)).toBe(false)
+  })
+})

--- a/src/shared/raw-recursive-removal-scan.ts
+++ b/src/shared/raw-recursive-removal-scan.ts
@@ -1,0 +1,70 @@
+// Why: two guards need the same answer to "is this a recursive removal that forgot the retries?" —
+// the Windows CI lane's teardowns and the product paths that delete something a user created. One
+// scanner so a spelling either guard cannot see is a gap in neither rather than a gap in one.
+
+/** `node:fs` and `node:fs/promises`, spelled with or without the `node:` prefix. */
+const FS_SPECIFIER = String.raw`['"](?:node:)?fs(?:/promises)?['"]`
+/** The `{ … }` clause of an fs import or require, which is where a rename would be declared. */
+const FS_BINDING_CLAUSE = new RegExp(
+  String.raw`\{([^}]*)\}\s*(?:from\s*${FS_SPECIFIER}|=\s*(?:await\s+import|require)\(\s*${FS_SPECIFIER})`,
+  'g'
+)
+/** `rm as removeDir` or `rmSync: dropTree` — the two ways a binding gets a local name. */
+const RENAMED_REMOVAL = /\brm(?:Sync)?\s*(?:as|:)\s*([A-Za-z0-9_$]+)/g
+
+/**
+ * The local names a recursive removal can be called by in `source`.
+ *
+ * Namespaced spellings are covered by the optional `<identifier>.` prefix in the matcher rather
+ * than by listing names, so `fsp.rm` and `fsPromises.rm` are caught without anyone having to teach
+ * the rule that spelling first. Renames are the one form that prefix cannot see, so they are read
+ * out of the import clause.
+ */
+function collectRemovalNames(source: string): string[] {
+  const names = new Set(['rmSync', 'rm'])
+  for (const clause of source.matchAll(FS_BINDING_CLAUSE)) {
+    for (const rename of clause[1].matchAll(RENAMED_REMOVAL)) {
+      names.add(rename[1])
+    }
+  }
+  return [...names]
+}
+
+/**
+ * The 1-based line of every recursive removal in `source` that hands Node no retry count.
+ *
+ * Renames are read out of `source`'s own import clauses, so pass a whole file rather than a
+ * fragment when the call and its import live together.
+ */
+export function findRawRecursiveRemovals(source: string): number[] {
+  const offenders: number[] = []
+  const call = new RegExp(
+    String.raw`(?<![\w$.])(?:[\w$]+\.)?(?:${collectRemovalNames(source).join('|')})\s*\(`,
+    'g'
+  )
+  let match: RegExpExecArray | null
+  while ((match = call.exec(source)) !== null) {
+    // Read to the call's closing paren so multi-line option objects are covered.
+    let depth = 0
+    let end = match.index + match[0].length - 1
+    for (; end < source.length; end += 1) {
+      if (source[end] === '(') {
+        depth += 1
+      } else if (source[end] === ')') {
+        depth -= 1
+        if (depth === 0) {
+          break
+        }
+      }
+    }
+    const args = source.slice(match.index, end + 1)
+    if (!args.includes('recursive')) {
+      continue
+    }
+    if (args.includes('maxRetries')) {
+      continue
+    }
+    offenders.push(source.slice(0, match.index).split('\n').length)
+  }
+  return offenders
+}

--- a/src/shared/windows-lane-tree-removal-boundary.test.ts
+++ b/src/shared/windows-lane-tree-removal-boundary.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { findRawRecursiveRemovals } from './raw-recursive-removal-scan'
 
 /**
  * The Windows CI lane runs a fixed list of specs on `windows-2022`, and every one of them removes
@@ -29,68 +30,6 @@ function readWindowsLaneSpecs(): string[] {
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => /^(src|tests|config)\/.+\.(test|spec)\.(ts|tsx|mjs)$/.test(line))
-}
-
-/** `node:fs` and `node:fs/promises`, spelled with or without the `node:` prefix. */
-const FS_SPECIFIER = String.raw`['"](?:node:)?fs(?:/promises)?['"]`
-/** The `{ … }` clause of an fs import or require, which is where a rename would be declared. */
-const FS_BINDING_CLAUSE = new RegExp(
-  String.raw`\{([^}]*)\}\s*(?:from\s*${FS_SPECIFIER}|=\s*(?:await\s+import|require)\(\s*${FS_SPECIFIER})`,
-  'g'
-)
-/** `rm as removeDir` or `rmSync: dropTree` — the two ways a binding gets a local name. */
-const RENAMED_REMOVAL = /\brm(?:Sync)?\s*(?:as|:)\s*([A-Za-z0-9_$]+)/g
-
-/**
- * The local names a recursive removal can be called by in `source`.
- *
- * Namespaced spellings are covered by the optional `<identifier>.` prefix in the matcher rather
- * than by listing names, so `fsp.rm` and `fsPromises.rm` are caught without anyone having to teach
- * the rule that spelling first. Renames are the one form that prefix cannot see, so they are read
- * out of the import clause.
- */
-function collectRemovalNames(source: string): string[] {
-  const names = new Set(['rmSync', 'rm'])
-  for (const clause of source.matchAll(FS_BINDING_CLAUSE)) {
-    for (const rename of clause[1].matchAll(RENAMED_REMOVAL)) {
-      names.add(rename[1])
-    }
-  }
-  return [...names]
-}
-
-/** Every recursive removal that does not go through the retrying helper. */
-function findRawRecursiveRemovals(source: string): number[] {
-  const offenders: number[] = []
-  const call = new RegExp(
-    String.raw`(?<![\w$.])(?:[\w$]+\.)?(?:${collectRemovalNames(source).join('|')})\s*\(`,
-    'g'
-  )
-  let match: RegExpExecArray | null
-  while ((match = call.exec(source)) !== null) {
-    // Read to the call's closing paren so multi-line option objects are covered.
-    let depth = 0
-    let end = match.index + match[0].length - 1
-    for (; end < source.length; end += 1) {
-      if (source[end] === '(') {
-        depth += 1
-      } else if (source[end] === ')') {
-        depth -= 1
-        if (depth === 0) {
-          break
-        }
-      }
-    }
-    const args = source.slice(match.index, end + 1)
-    if (!args.includes('recursive')) {
-      continue
-    }
-    if (args.includes('maxRetries')) {
-      continue
-    }
-    offenders.push(source.slice(0, match.index).split('\n').length)
-  }
-  return offenders
 }
 
 describe('windows lane tree removal', () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​194 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​62 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​132 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 |

<!-- /orca-pr-loc -->

Stacked on #17227 — review that first. This PR uses the `removeTree`/`removeTreeSync` helper that PR introduces, rather than adding a third copy of the retry constants.

## ELI5

On Windows, a folder cannot be deleted while any program still has a file inside it open — antivirus, the search indexer, or a program that only just exited. That hold usually lasts a few milliseconds. Node has a built-in "wait and try again" setting for exactly this, and this repo already decided the answer is 8 retries.

The problem is that the retry setting only got used in a handful of places. Everywhere else, the delete just gives up the first time it's told "no". When that happens in a spot where the app already told the user "deleted", the thing is still on disk.

This PR finds the deletes where that actually hurts a person — the ones removing something they made or asked to remove — and puts them all on the shared retry policy.

## User-facing before/after

A Windows user, with the speech model download as the clearest case:

| | Before | After |
| :-- | :-- | :-- |
| Delete a downloaded speech model | The model row disappears from the list, but the multi-GB folder is still on disk. Disk space never comes back. On the next launch the model is re-discovered and reappears in the list, undeleted. | The delete retries past the transient hold and the folder actually goes. |
| Download a model you already have | The download completes, then fails at the final step with `EPERM` because the old model folder could not be cleared to make room. All the downloaded bytes are discarded. | The replace retries and the new model lands. |
| Delete an installed skill or plugin | Reported as removed; the directory survives, so it is still discovered and listed after a restart. | Removed. |
| Sign out of a Claude account | The managed auth directory survives. The failure is only `console.warn`'d, so nothing surfaces. | Removed. |
| Clear a browser route partition | Browsing data for that partition stays on disk. | Removed. |
| Delete an imported pet bundle | Reported as deleted; the bundle directory survives. | Removed. |

macOS and Linux are unchanged: `transientLockRemovalOptions()` returns plain `{ recursive, force }` off `win32`, and there is a test asserting that.

## What this does not do

It deliberately does **not** rewrite every recursive removal. I censused them first (numbers below) and only the user-facing set is converted. The internal staging/scratch removals are best-effort by design — they sit in `finally` blocks and `.catch(() => {})` — and three genuinely macOS-only provider paths can never benefit from a Windows retry at all. (A fourth was misfiled under that heading; see the correction below.)

## Census

**Re-derived after review. The first published version of this table was wrong — it said 84
sites in 50 files and 10 converted. The correct figures are 99 in 61 and 11.** They are
corrected in place below rather than footnoted, because a number in a PR body becomes the
next person's premise.

Across all tracked JS/TS at this stack's merge-base with `main` (`a1f198be0d`), recursive
removals that hand Node no retry count:

| Population | Sites | Files |
| :-- | --: | --: |
| All no-retry recursive removals | **1,649** | 1,037 |
| — under `*.test.*` or `__tests__/` | 1,365 | 844 |
| — under `tests/` (e2e specs, helpers, tooling) | 116 | 92 |
| — build/CI scripts under `config/` | 69 | 40 |
| — **shipped app (`src/`, non-test)** | **99** | **61** |

**Axis enumerated: the call site** — one `CallExpression` whose callee resolves to `fs.rm` /
`fs.rmSync` (namespaced, or renamed through its own import clause), whose options carry
`recursive` and neither `maxRetries` nor a spread of the shared policy helper. Not the file,
not the import.

Counted twice by two different methods over the same file list: the repo's own regex scanner
(`raw-recursive-removal-scan.ts`, which reads the call's argument text) and an independent
oxc AST walk (which reads `ObjectExpression` property keys). The two agree on the site set
byte-for-byte, not merely on the total — 0 rows in either direction.

**Positive control.** A raw `rm(p, { recursive: true, force: true })` planted in a file that
previously had none moved both methods 99 → 100 and 61 → 62. A companion planted with
`maxRetries: 8` moved neither. Reverted, both methods return to 99/61 and the tree is clean.

**What this census cannot see:** a removal reached through a wrapper this repo does not name
(`shell.rm -rf`, a spawned `rimraf`, a `fs-extra` re-export); a call whose options object is
built elsewhere and passed by variable; and, by construction, anything outside tracked JS/TS.

Triage of the 99 shipped-app sites:

| Class | Sites | Meaning |
| :-- | --: | :-- |
| **User-facing** | **11** | Removes something the user created or asked to remove. Converted here, across 7 files. |
| Internal, durable | 45 | Orca's own state that must actually go or something breaks later. Converted by #17252 — which also found two of them to be plainly user-facing, and one to be misfiled below. |
| Internal, disposable | 20 | Temp scratch already inside `.catch(() => {})` or a best-effort `try`/`catch`; a failed removal costs disk and nothing else. |
| Test-support living in `src/` | 19 | Fixtures/probes/harnesses, e.g. `watcher-aliased-root-fixture.ts`, `*-test-harness.ts`. |
| Platform-gated to macOS | 3 | A Windows retry is provably dead code there. |
| Visible on failure | 1 | `filesystem-download-folder.ts` leaks a transfer tree but already `console.warn`s the path. |

**Correction: the macOS-gated class is 3, not 4.** `computer/desktop-script-provider-client.ts`
was filed here on its directory neighbours' names. It is the **inverse**:
`desktopScriptPlatform()` returns `'linux'` or `'windows'` and `null` on darwin
(`src/main/computer/desktop-script-provider-paths.ts:6-14`), and the client is constructed
through `requiredPlatform()`, so that path runs on **Linux and Windows only** — exactly where
the retry is worth having. #17252 converts it. The other three check out:
`macos-computer-use-permission-status.ts` returns early on `process.platform !== 'darwin'`, and
`macos-native-provider-client.ts` / `macos-native-provider-transport.ts` are only reached from
`computer-provider-lifecycle.ts` under `platform === 'darwin'`.

## Tests

`src/main/user-facing-deletion-retry-policy.test.ts` — 14 tests:

- A ratchet over the **named user-facing deletion regions** (7 regions across 7 files), asserting no raw recursive removal survives in any of them.
- A vacuity control (the region reader must return a real body) and a positive control (the scan must still flag a region that forgot the retries).
- A behavioural pair on the skill delete primitive: on `win32` the call reaches Node with `maxRetries: 8`; on `darwin` the options are unchanged.
- A real-filesystem test that the skill delete still actually removes the tree.

Each of the 7 converted files was reverted one at a time, serially, with the mutation verified applied and the tree asserted clean between runs:

| Reverted file | Gates reddened |
| :-- | --: |
| `skills/skill-install-filesystem.ts` | 2 |
| `plugins/plugin-install.ts` | 1 |
| `speech/model-manager.ts` | 3 |
| `ipc/pet.ts` | 1 |
| `claude-accounts/claude-managed-auth-storage.ts` | 1 |
| `browser/browser-route-partition-storage-dependencies.ts` | 1 |
| `cli/handlers/account.ts` | 1 |

Baseline 14/14 green.

## Refactor

#17227's boundary test grew a source scanner for "is this a recursive removal that forgot the retries?". This PR needs the same answer for a different population, so the scanner moves to `src/shared/raw-recursive-removal-scan.ts` and both guards import it. No second copy.

## Verification

- `pnpm tc` — exit 0, 0 `error TS` (run in the foreground).
- `vitest` over every touched module (`speech`, `plugins`, `ipc/pet`, `cli/handlers/account`, `skills`, `claude-accounts`, `shared`): **7412 passed, 109 skipped, 0 failed** across 761 files.
- `oxlint` on the 10 changed files: 0 warnings, 0 errors (167 rules); `oxfmt --check` clean.

