### PR TITLE
perf(renderer): index unread completion tabs once per snapshot

### DIFF
--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
@@ -3,6 +3,7 @@ import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import {
   hasUnreadAgentCompletionForTerminalTab,
+  resetUnreadAgentCompletionTabIdsCacheForTest,
   resetTerminalTabActivityFlagsCacheForTest,
   resolveTerminalTabActivityStatus,
   resolveTerminalTabAttentionBadge,
@@ -41,6 +42,7 @@ const LIVE_PTY = { [TAB_ID]: ['pty-1'] }
 
 beforeEach(() => {
   resetTerminalTabActivityFlagsCacheForTest()
+  resetUnreadAgentCompletionTabIdsCacheForTest()
   vi.useFakeTimers()
   vi.setSystemTime(NOW)
 })
@@ -48,6 +50,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers()
   resetTerminalTabActivityFlagsCacheForTest()
+  resetUnreadAgentCompletionTabIdsCacheForTest()
 })
 
 describe('resolveTerminalTabActivityStatus', () => {
@@ -267,6 +270,7 @@ describe('hasUnreadAgentCompletionForTerminalTab', () => {
     expect(
       hasUnreadAgentCompletionForTerminalTab({ [`tab-2:${SECOND_LEAF_ID}`]: true }, TAB_ID)
     ).toBe(false)
+    expect(hasUnreadAgentCompletionForTerminalTab(undefined, TAB_ID)).toBe(false)
   })
 
   // Why: the param accepts boolean maps, so a cleared-to-`false` marker must not read as unread.
@@ -274,6 +278,57 @@ describe('hasUnreadAgentCompletionForTerminalTab', () => {
     expect(
       hasUnreadAgentCompletionForTerminalTab({ [`${TAB_ID}:${FIRST_LEAF_ID}`]: false }, TAB_ID)
     ).toBe(false)
+  })
+
+  it('preserves first-colon ownership for legacy and malformed pane keys', () => {
+    expect(hasUnreadAgentCompletionForTerminalTab({ [TAB_ID]: true }, TAB_ID)).toBe(true)
+    expect(hasUnreadAgentCompletionForTerminalTab({ [`${TAB_ID}:3`]: true }, TAB_ID)).toBe(true)
+    expect(
+      hasUnreadAgentCompletionForTerminalTab(
+        { [`${TAB_ID}:${FIRST_LEAF_ID}:suffix`]: true },
+        TAB_ID
+      )
+    ).toBe(true)
+    expect(
+      hasUnreadAgentCompletionForTerminalTab({ [`${TAB_ID}0:${SECOND_LEAF_ID}`]: true }, TAB_ID)
+    ).toBe(false)
+  })
+
+  it('changes only the owning tab when immutable marker snapshots add and clear unread', () => {
+    const before = { [`tab-2:${SECOND_LEAF_ID}`]: true }
+    const added = { ...before, [`${TAB_ID}:${FIRST_LEAF_ID}`]: true }
+    const cleared = { ...added, [`${TAB_ID}:${FIRST_LEAF_ID}`]: false }
+
+    expect(hasUnreadAgentCompletionForTerminalTab(before, TAB_ID)).toBe(false)
+    expect(hasUnreadAgentCompletionForTerminalTab(added, TAB_ID)).toBe(true)
+    expect(hasUnreadAgentCompletionForTerminalTab(cleared, TAB_ID)).toBe(false)
+    expect(hasUnreadAgentCompletionForTerminalTab(before, 'tab-2')).toBe(true)
+    expect(hasUnreadAgentCompletionForTerminalTab(added, 'tab-2')).toBe(true)
+    expect(hasUnreadAgentCompletionForTerminalTab(cleared, 'tab-2')).toBe(true)
+  })
+
+  it('indexes one immutable marker snapshot once across all mounted tab lookups', () => {
+    const ownKeys = vi.fn(Reflect.ownKeys)
+    let valueReads = 0
+    const markers: Record<string, true> = Object.fromEntries(
+      Array.from({ length: 1_000 }, (_, index) => [`owner-${index}:leaf`, true] as const)
+    )
+    const unread = new Proxy<Record<string, true>>(markers, {
+      ownKeys,
+      get: (target, property, receiver) => {
+        valueReads += 1
+        return Reflect.get(target, property, receiver)
+      }
+    })
+
+    for (let publication = 0; publication < 5; publication += 1) {
+      for (let tab = 0; tab < 500; tab += 1) {
+        expect(hasUnreadAgentCompletionForTerminalTab(unread, `absent-${tab}`)).toBe(false)
+      }
+    }
+
+    expect(ownKeys).toHaveBeenCalledTimes(1)
+    expect(valueReads).toBe(1_000)
   })
 })
 

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
@@ -256,29 +256,49 @@ export function terminalTabHasUnreadActivity({
   )
 }
 
+// Why: production writes replace this map; WeakMap supports retained snapshots without pinning them.
+let unreadAgentCompletionTabIdsBySnapshot = new WeakMap<
+  Record<string, boolean | undefined>,
+  ReadonlySet<string>
+>()
+
+function getUnreadAgentCompletionTabIds(
+  unreadAgentCompletionPanes: Record<string, boolean | undefined>
+): ReadonlySet<string> {
+  const cached = unreadAgentCompletionTabIdsBySnapshot.get(unreadAgentCompletionPanes)
+  if (cached) {
+    return cached
+  }
+
+  // Why: every mounted tab runs this selector per store write; index each immutable marker snapshot once.
+  const tabIds = new Set<string>()
+  for (const paneKey of Object.keys(unreadAgentCompletionPanes)) {
+    if (!unreadAgentCompletionPanes[paneKey]) {
+      continue
+    }
+    const separatorIndex = paneKey.indexOf(':')
+    tabIds.add(separatorIndex === -1 ? paneKey : paneKey.slice(0, separatorIndex))
+  }
+  unreadAgentCompletionTabIdsBySnapshot.set(unreadAgentCompletionPanes, tabIds)
+  return tabIds
+}
+
 /** Match pane-level unread completion markers to their owning terminal tab. */
 export function hasUnreadAgentCompletionForTerminalTab(
   unreadAgentCompletionPanes: Record<string, boolean | undefined> | undefined,
   tabId: string
 ): boolean {
-  for (const [paneKey, unread] of Object.entries(unreadAgentCompletionPanes ?? {})) {
-    // Why entries, not keys: the widened value type lets a cleared marker linger as `false`.
-    if (!unread) {
-      continue
-    }
-    // paneKey is `${tabId}:${leafId}` and tab ids never contain ":", so the
-    // prefix up to the first ":" is the owning tab id (see
-    // selectFloatingWorkspaceHasUnread). Prefix-match to keep legacy keys.
-    const separatorIndex = paneKey.indexOf(':')
-    const owningTabId = separatorIndex === -1 ? paneKey : paneKey.slice(0, separatorIndex)
-    if (owningTabId === tabId) {
-      return true
-    }
-  }
-  return false
+  return unreadAgentCompletionPanes
+    ? getUnreadAgentCompletionTabIds(unreadAgentCompletionPanes).has(tabId)
+    : false
 }
 
 /** Test-only: clear the memoized per-tab flag cache between cases. */
 export function resetTerminalTabActivityFlagsCacheForTest(): void {
   flagsCache = null
+}
+
+/** Test-only: clear the unread marker snapshot index between cases. */
+export function resetUnreadAgentCompletionTabIdsCacheForTest(): void {
+  unreadAgentCompletionTabIdsBySnapshot = new WeakMap()
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |

<!-- /orca-pr-loc -->

## ELI5

Every mounted terminal tab was rereading the entire unread-completion list whenever Zustand published any store update. With many tabs and markers, that made one harmless publication do the same long scan hundreds or thousands of times on the renderer thread.

This builds the list of owning tab IDs once for each immutable unread-map snapshot. Every tab then does one constant-time membership check. No notification, marker, tab, or feature is capped or disabled.

## User-visible problem

`SortableTab` stays mounted for every terminal and agent-session tab. Its selector called `hasUnreadAgentCompletionForTerminalTab`, which scanned all `U` pane markers for each of `T` tabs on every store publication—even when React ultimately rendered nothing. Accumulated sessions could therefore turn background status/title writes into synchronous O(T × U) input and status latency.

## Change

- Cache `ReadonlySet<tabId>` by `unreadAgentCompletionPanes` object identity in a `WeakMap`.
- Preserve truthy-marker filtering and the existing first-colon/no-colon ownership rule.
- Let old snapshots and their indexes be garbage-collected; retained palette snapshots can coexist safely.
- Reset the cache only in tests.

Production add, clear, close, hibernate, move, and purge paths already replace this map rather than mutating it in place; the test exercises add/clear through new snapshot identities.

## Deterministic before / after

Node 24.18.0, actual helper, mostly-absent lookups, three samples per case. Before uses `origin/main`; after uses a fresh marker-map identity for every sample so index construction is included.

| Mounted tabs | Pane markers | Before median | After cold median | Improvement |
| ---: | ---: | ---: | ---: | ---: |
| 100 | 1,000 | 9.46 ms | 0.15 ms | 63× |
| 100 | 10,000 | 128.29 ms | 1.39 ms | 92× |
| 500 | 5,000 | 273.84 ms | 0.70 ms | 391× |
| 1,000 | 10,000 | 1,245.73 ms | 1.30 ms | 958× |

The committed structural regression test is timing-independent: 2,500 tab lookups over one 1,000-marker snapshot caused 2,500 enumerations / 2,500,000 marker reads before and exactly 1 enumeration / 1,000 reads after.

Parity measurements at 1,000 lookups × 10,000 markers kept identical hit counts for absent, first match, last match, explicit `false`, and legacy no-colon keys. After times were 1.13–1.46 ms versus 1,110.50–1,330.56 ms before.

Low-cardinality guard: one tab with an early match did not regress cold construction—at 10,000 markers it measured 1.157 ms before and 0.999 ms after; an absent match measured 1.267 ms before and 1.012 ms after.

## Regression and compatibility proof

- Exact booleans remain unchanged for canonical, numeric legacy, no-colon, multi-colon, prefix-collision, falsy, missing, add, and clear cases.
- Adding or clearing one marker changes only its owning tab in the parity test.
- Duplicate tab IDs retain the prior existential behavior; the cache does not infer worktree or host ownership.
- Native, folder-workspace, WSL, direct-SSH, and paired/remote tab IDs remain opaque strings. There is no Git command, provider, process, RPC, stream, persisted-state, or remote-wire change.
- `WeakMap` avoids strong retention and supports multiple concurrently retained snapshots.

Electron CDP validation used an isolated profile and the intended branch identity. On two real rendered terminal tabs, adding an unread completion marker to the inactive tab visibly applied the amber unread treatment only there; the real clear action removed the store marker and the treatment from both tabs. The only console errors were the pre-existing exhausted GitHub API limit.

## Verification

- `pnpm tc`
- 78/78 related tests across terminal-tab status, SortableTab update-depth, Cmd+J live status, and recent tabs
- `pnpm run check:code-quality:changed` — 0 findings
- `pnpm run check:max-lines-ratchet`
- targeted `oxfmt`
- `git diff --check`
- independent review: no blocking correctness issue

## GitHub overlap and merge risk

Checked before editing. Merged PRs #13554 and #16173 cache/gate different unread projections; no active PR implements this per-tab index. Open PR #9318 is the only direct file overlap and still scans the marker map per tab, so this is not duplicate work.

- **Behavioral risk: low.** Pure renderer-derived cache; no source-of-truth or user-facing behavior changes.
- **Compatibility risk: low.** No platform, execution-host, Git, provider, or wire boundary is touched.
- **Textual/rebase risk: high.** #9318 rewrites the same status module and is currently stale/dirty. If it lands first, this must be rebased into its provider-aware resolver (likely indexing pane keys per tab, not only booleans) while retaining current false-marker semantics.
- **Backout:** revert this single commit; there is no migration or external state.
