### PR TITLE
perf(automations): narrow status observer updates

### DIFF
--- a/src/renderer/src/hooks/automation-agent-status-entry-change.test.ts
+++ b/src/renderer/src/hooks/automation-agent-status-entry-change.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import {
+  selectAutomationAgentStatusEntryChange,
+  UNCHANGED_AUTOMATION_AGENT_STATUS_ENTRY
+} from './automation-agent-status-entry-change'
+
+function makeEntry(paneKey: string): AgentStatusEntry {
+  return {
+    paneKey,
+    state: 'working',
+    prompt: 'turn',
+    updatedAt: 1,
+    stateStartedAt: 1,
+    stateHistory: []
+  }
+}
+
+describe('selectAutomationAgentStatusEntryChange', () => {
+  it('reads only the target and skips an unchanged entry', () => {
+    const targetPaneKey = 'target-tab:leaf'
+    const targetEntry = makeEntry(targetPaneKey)
+    const entries = Object.fromEntries(
+      Array.from({ length: 499 }, (_, index) => {
+        const paneKey = `other-tab:${index}`
+        return [paneKey, makeEntry(paneKey)]
+      })
+    )
+    entries[targetPaneKey] = targetEntry
+    let enumerations = 0
+    const measuredEntries = new Proxy(entries, {
+      ownKeys: (target) => {
+        enumerations += 1
+        return Reflect.ownKeys(target)
+      }
+    })
+
+    expect(selectAutomationAgentStatusEntryChange(measuredEntries, targetPaneKey, undefined)).toBe(
+      targetEntry
+    )
+    expect(
+      selectAutomationAgentStatusEntryChange(measuredEntries, targetPaneKey, targetEntry)
+    ).toBe(UNCHANGED_AUTOMATION_AGENT_STATUS_ENTRY)
+    expect(enumerations).toBe(0)
+  })
+
+  it('reports removal and ignores inherited or non-enumerable entries', () => {
+    const targetPaneKey = 'target-tab:leaf'
+    const previousEntry = makeEntry(targetPaneKey)
+    const inheritedEntries = Object.create({ [targetPaneKey]: previousEntry }) as Record<
+      string,
+      AgentStatusEntry
+    >
+    const nonEnumerableEntries = Object.defineProperty({}, targetPaneKey, {
+      value: previousEntry
+    }) as Record<string, AgentStatusEntry>
+
+    expect(selectAutomationAgentStatusEntryChange({}, targetPaneKey, previousEntry)).toBeUndefined()
+    expect(selectAutomationAgentStatusEntryChange(inheritedEntries, targetPaneKey, undefined)).toBe(
+      UNCHANGED_AUTOMATION_AGENT_STATUS_ENTRY
+    )
+    expect(
+      selectAutomationAgentStatusEntryChange(nonEnumerableEntries, targetPaneKey, undefined)
+    ).toBe(UNCHANGED_AUTOMATION_AGENT_STATUS_ENTRY)
+  })
+})

--- a/src/renderer/src/hooks/automation-agent-status-entry-change.ts
+++ b/src/renderer/src/hooks/automation-agent-status-entry-change.ts
@@ -1,0 +1,15 @@
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+
+export const UNCHANGED_AUTOMATION_AGENT_STATUS_ENTRY = Symbol('unchanged-agent-status-entry')
+
+export function selectAutomationAgentStatusEntryChange(
+  entries: Readonly<Record<string, AgentStatusEntry>>,
+  targetPaneKey: string,
+  previousEntry: AgentStatusEntry | undefined
+): AgentStatusEntry | undefined | typeof UNCHANGED_AUTOMATION_AGENT_STATUS_ENTRY {
+  const entry = Object.prototype.propertyIsEnumerable.call(entries, targetPaneKey)
+    ? entries[targetPaneKey]
+    : undefined
+  // Why: status writes replace entries; unchanged identity proves an unrelated publication.
+  return entry === previousEntry ? UNCHANGED_AUTOMATION_AGENT_STATUS_ENTRY : entry
+}

--- a/src/renderer/src/hooks/automation-dispatch-observer-test-probe.ts
+++ b/src/renderer/src/hooks/automation-dispatch-observer-test-probe.ts
@@ -1,0 +1,30 @@
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+
+const TARGET_PANE_KEY = 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d'
+
+export function countUnchangedObserverHistoryReads(
+  state: { agentStatusByPaneKey: Record<string, AgentStatusEntry> },
+  subscriber: (() => void) | null
+): number {
+  if (!subscriber) {
+    throw new Error('agent status observer was not registered')
+  }
+  let historyReads = 0
+  state.agentStatusByPaneKey = {
+    [TARGET_PANE_KEY]: {
+      paneKey: TARGET_PANE_KEY,
+      state: 'working',
+      prompt: 'turn',
+      updatedAt: Date.now() + 1,
+      stateStartedAt: Date.now() + 1,
+      get stateHistory() {
+        historyReads += 1
+        return []
+      }
+    }
+  }
+  subscriber()
+  historyReads = 0
+  subscriber()
+  return historyReads
+}

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -1,6 +1,7 @@
 import type * as ReactModule from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AUTOMATIONS_CHANGED_EVENT } from '@/lib/automations-changed-window-event'
+import { countUnchangedObserverHistoryReads } from './automation-dispatch-observer-test-probe'
 
 const mockDispatchEvent = vi.fn()
 
@@ -620,10 +621,11 @@ describe('useAutomationDispatchEvents setup launch', () => {
     await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
   })
 
-  it('persists assistant output from a batched working→done→working transition', async () => {
+  it('skips unchanged status and persists batched working→done→working output', async () => {
     const paneKey = 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d'
 
     await registerAndDispatch()
+    expect(countUnchangedObserverHistoryReads(state, latestStoreSubscriber)).toBe(0)
     const transitionStartedAt = Date.now() + 1
     state.agentStatusByPaneKey = {
       [paneKey]: {

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -32,8 +32,12 @@ import {
   toSshExecutionHostId
 } from '../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
-import type { AgentStateHistoryEntry } from '../../../shared/agent-status-types'
+import type { AgentStateHistoryEntry, AgentStatusEntry } from '../../../shared/agent-status-types'
 import { resolveFolderWorkspaceHost } from '../../../shared/folder-workspace-execution-host'
+import {
+  selectAutomationAgentStatusEntryChange,
+  UNCHANGED_AUTOMATION_AGENT_STATUS_ENTRY
+} from './automation-agent-status-entry-change'
 
 const activeReuseDispatchTabIds = new Set<string>()
 
@@ -450,56 +454,63 @@ export function useAutomationDispatchEvents(): void {
           ): void => {
             let sawWorkingAfterStart = false
             let observedStateHistory: AgentStateHistoryEntry[] = []
+            let observedEntry: AgentStatusEntry | undefined
             const checkCurrentStatus = (): void => {
-              const { agentStatusByPaneKey } = useAppStore.getState()
-              for (const [paneKey, entry] of Object.entries(agentStatusByPaneKey)) {
-                if (paneKey !== targetPaneKey || entry.updatedAt < startedAfter) {
+              const entryChange = selectAutomationAgentStatusEntryChange(
+                useAppStore.getState().agentStatusByPaneKey,
+                targetPaneKey,
+                observedEntry
+              )
+              if (entryChange === UNCHANGED_AUTOMATION_AGENT_STATUS_ENTRY) {
+                return
+              }
+              const entry = entryChange
+              observedEntry = entry
+              if (!entry || entry.updatedAt < startedAfter) {
+                return
+              }
+              const historyOverlap = getAgentStateHistoryOverlap(
+                observedStateHistory,
+                entry.stateHistory
+              )
+              // Why: sawWorkingAfterStart stays monotonic — a recreated entry
+              // (transport loss, PTY exit, cap eviction) arrives with an empty
+              // stateHistory, so clearing it here would strand reuseSession runs
+              // with nothing left to re-derive the working edge from.
+              for (const historicalState of entry.stateHistory.slice(historyOverlap)) {
+                if (historicalState.startedAt < startedAfter) {
                   continue
                 }
-                const historyOverlap = getAgentStateHistoryOverlap(
-                  observedStateHistory,
-                  entry.stateHistory
-                )
-                // Why: sawWorkingAfterStart stays monotonic — a recreated entry
-                // (transport loss, PTY exit, cap eviction) arrives with an empty
-                // stateHistory, so clearing it here would strand reuseSession runs
-                // with nothing left to re-derive the working edge from.
-                for (const historicalState of entry.stateHistory.slice(historyOverlap)) {
-                  if (historicalState.startedAt < startedAfter) {
-                    continue
-                  }
-                  if (historicalState.state === 'working') {
-                    sawWorkingAfterStart = true
-                  }
-                  if (
-                    historicalState.state === 'done' &&
-                    (!options?.requireWorkingAfterStart || sawWorkingAfterStart)
-                  ) {
-                    // Why: this `done` already rolled out of the live entry, so its output
-                    // survives only in the entry-level completed slot.
-                    latestAssistantMessage =
-                      entry.lastCompletedAssistantMessage?.trim() || latestAssistantMessage
-                    handleAgentDone()
-                    return
-                  }
-                }
-                observedStateHistory = [...entry.stateHistory]
-                if (entry.state === 'working') {
+                if (historicalState.state === 'working') {
                   sawWorkingAfterStart = true
                 }
                 if (
-                  entry.state === 'done' &&
-                  // Why: a session-boundary done is the agent CONNECTING (Claude SessionStart
-                  // fires at launch, before the argv prompt submits) — completing here would
-                  // close the tab and record an empty run result.
-                  entry.sessionBoundary !== true &&
+                  historicalState.state === 'done' &&
                   (!options?.requireWorkingAfterStart || sawWorkingAfterStart)
                 ) {
+                  // Why: this `done` already rolled out of the live entry, so its output
+                  // survives only in the entry-level completed slot.
                   latestAssistantMessage =
-                    entry.lastAssistantMessage?.trim() || latestAssistantMessage
+                    entry.lastCompletedAssistantMessage?.trim() || latestAssistantMessage
                   handleAgentDone()
                   return
                 }
+              }
+              observedStateHistory = [...entry.stateHistory]
+              if (entry.state === 'working') {
+                sawWorkingAfterStart = true
+              }
+              if (
+                entry.state === 'done' &&
+                // Why: a session-boundary done is the agent CONNECTING (Claude SessionStart
+                // fires at launch, before the argv prompt submits) — completing here would
+                // close the tab and record an empty run result.
+                entry.sessionBoundary !== true &&
+                (!options?.requireWorkingAfterStart || sawWorkingAfterStart)
+              ) {
+                latestAssistantMessage =
+                  entry.lastAssistantMessage?.trim() || latestAssistantMessage
+                handleAgentDone()
               }
             }
             // Why: Codex/Claude completion normally arrives through the global


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​39 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 |

<!-- /orca-pr-loc -->

## ELI5

Every running automation has a watcher waiting for its one agent pane to finish. The watcher already knew the exact pane, but every app-state update made it open every agent-status drawer and inspect the labels again. This change opens only the known drawer, then ignores publications where that entry is the same object.

## User-visible symptom and wasted resource

The old bare Zustand listener ran synchronously for every top-level store publication. Each active automation run installed one listener, and each listener materialized Object.entries for the entire live-status map before filtering to one exact pane.

The cost therefore scaled as store publications x overlapping automation observers x live status rows. The normal stale or unprovable row cap is 500; genuinely rooted live panes can make the map larger. This creates avoidable renderer main-thread work during status-heavy sessions and overlapping scheduled runs.

## Before and after measurement

A production-shaped V8 callback microbenchmark at 500 incrementally-built rows measured the unchanged callback selection path:

- Before: 37.909 microseconds per callback
- After: 0.020 microseconds per callback
- Selection-path speedup: about 1,883x

At the documented stress rate of roughly 160 unrelated publications per second, the removed enumeration alone is about 6.1 ms of renderer work per wall-second for one observer, or about 61 ms for ten overlapping observers, before history processing.

Deterministic operation proof:

- 50 callbacks x 500 rows: 25,000 row visits before versus 50 targeted entry checks after.
- The committed 500-row Proxy test asserts zero full-map enumeration.
- The hook integration probe resets a stateHistory getter after the first callback and proves the unchanged second callback performs zero history reads.
- Restoring the baseline scan makes the equivalent regression assertion fail with one enumeration instead of zero.

## Change

- Select the exact own enumerable target entry in O(1), preserving Object.entries key semantics.
- Remember the previously observed entry identity and return before history overlap or completion logic when the target did not change.
- Keep removal distinct from unchanged absence with an explicit sentinel.

## Correctness and compatibility signoff

All production status writers were audited: hook updates, remote mirrors, pane transfer, removal, purge, and provider-session paths replace entry objects rather than mutating them in place. Deletion records undefined, so a later recreated entry is processed. Existing monotonic working evidence, batched history overlap, session-boundary done handling, assistant output capture, and duplicate finalization behavior are unchanged.

This is renderer-local. It changes no IPC or remote wire payload, SSH or WSL routing, folder-workspace behavior, process handling, Git command, provider behavior, persistence schema, or rendered UI. No Electron visual run is applicable.

## Regression coverage and verification

- 57 focused observer and agent-status tests passed across 5 files.
- Full pnpm tc passed.
- Direct oxlint on all changed files passed.
- Changed-code quality: zero findings, including type-aware checks and React Doctor.
- Max-lines ratchet passed with no new bypass.
- Formatting and git diff --check passed.
- Fresh independent read-only review found no blocker.

## Overlap and merge risk

No open PR implements this lookup or identity gate. Open PR #17155 is a stacked file-split refactor that moves the unchanged observer into automation-dispatch-completion.ts, so textual conflict risk is high if it lands first. Semantic adaptation is small: transplant this selector call and tests into the extracted completion module. The related remote-observer lifecycle branch changes cleanup timing, not this hot path.