### PR TITLE
feat: add local Paperclip task source

### DIFF
--- a/src/main/ipc/paperclip.ts
+++ b/src/main/ipc/paperclip.ts
@@ -1,0 +1,74 @@
+import { ipcMain } from 'electron'
+import type { PaperclipLaunchAdmissionRequest } from '../../shared/paperclip-types'
+import {
+  connect,
+  disconnect,
+  getIssue,
+  getLaunchAdmission,
+  getStatus,
+  listIssues,
+  testConnection
+} from '../paperclip/client'
+
+export function registerPaperclipHandlers(): void {
+  ipcMain.handle(
+    'paperclip:connectLocalTrusted',
+    async (_event, args: { origin?: string; companyId?: string; projectId?: string }) => {
+      if (
+        typeof args?.origin !== 'string' ||
+        typeof args?.companyId !== 'string' ||
+        typeof args?.projectId !== 'string'
+      ) {
+        return { ok: false, error: 'Paperclip connection details are required.' }
+      }
+      // No credential or credential handle crosses IPC. Authenticated deployments
+      // need a separate main-process credential-capture design.
+      return connect({
+        origin: args.origin,
+        companyId: args.companyId,
+        projectId: args.projectId
+      })
+    }
+  )
+  ipcMain.handle('paperclip:disconnect', () => disconnect())
+  ipcMain.handle('paperclip:status', () => getStatus())
+  ipcMain.handle('paperclip:testConnection', () => testConnection())
+  ipcMain.handle('paperclip:listIssues', (_event, args?: { query?: string }) =>
+    listIssues(typeof args?.query === 'string' ? args.query : undefined)
+  )
+  ipcMain.handle('paperclip:getIssue', (_event, args: { issueId?: string }) => {
+    const issueId = normalizeId(args?.issueId)
+    if (!issueId) {
+      throw new Error('A Paperclip issue ID is required.')
+    }
+    return getIssue(issueId)
+  })
+  ipcMain.handle(
+    'paperclip:getLaunchAdmission',
+    (_event, args: PaperclipLaunchAdmissionRequest) => {
+      const request = normalizeAdmissionRequest(args)
+      if (!request) {
+        throw new Error('A Paperclip issue ID is required.')
+      }
+      return getLaunchAdmission(request)
+    }
+  )
+}
+
+function normalizeAdmissionRequest(value: unknown): PaperclipLaunchAdmissionRequest | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const args = value as Record<string, unknown>
+  const issueId = normalizeId(args.issueId)
+  const connectionId = normalizeId(args.connectionId)
+  const companyId = normalizeId(args.companyId)
+  const projectId = normalizeId(args.projectId)
+  return issueId && connectionId && companyId && projectId
+    ? { issueId, connectionId, companyId, projectId }
+    : null
+}
+
+function normalizeId(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}

--- a/src/main/ipc/register-core-handlers/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers/register-core-handlers.test.ts
@@ -48,6 +48,7 @@ const {
   registerAppHandlersMock,
   registerLinearHandlersMock,
   registerJiraHandlersMock,
+  registerPaperclipHandlersMock,
   registerBitbucketHandlersMock,
   registerGitLabHandlersMock,
   registerHostedReviewHandlersMock,
@@ -114,6 +115,7 @@ const {
   registerAppHandlersMock: vi.fn(),
   registerLinearHandlersMock: vi.fn(),
   registerJiraHandlersMock: vi.fn(),
+  registerPaperclipHandlersMock: vi.fn(),
   registerBitbucketHandlersMock: vi.fn(),
   registerGitLabHandlersMock: vi.fn(),
   registerHostedReviewHandlersMock: vi.fn(),
@@ -371,6 +373,10 @@ vi.mock('../jira', () => ({
   registerJiraHandlers: registerJiraHandlersMock
 }))
 
+vi.mock('../paperclip', () => ({
+  registerPaperclipHandlers: registerPaperclipHandlersMock
+}))
+
 vi.mock('../bitbucket', () => ({
   registerBitbucketHandlers: registerBitbucketHandlersMock
 }))
@@ -521,6 +527,7 @@ describe('registerCoreHandlers', () => {
     expect(registerGitHubHandlersMock).toHaveBeenCalledWith(store, stats)
     expect(registerLinearHandlersMock).toHaveBeenCalled()
     expect(registerJiraHandlersMock).toHaveBeenCalled()
+    expect(registerPaperclipHandlersMock).toHaveBeenCalled()
     expect(registerBitbucketHandlersMock).toHaveBeenCalled()
     expect(registerGitLabHandlersMock).toHaveBeenCalledWith(store)
     expect(registerHostedReviewHandlersMock).toHaveBeenCalledWith(store, stats)

--- a/src/main/ipc/register-core-handlers/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers/register-core-handlers.ts
@@ -14,6 +14,7 @@ import { registerGitLabHandlers } from '../gitlab'
 import { registerHostedReviewHandlers } from '../hosted-review'
 import { registerLinearHandlers } from '../linear'
 import { registerJiraHandlers } from '../jira'
+import { registerPaperclipHandlers } from '../paperclip'
 import { registerBitbucketHandlers } from '../bitbucket'
 import { registerFeedbackHandlers } from '../feedback'
 import { registerCrashReportingHandlers } from '../crash-reporting'
@@ -154,6 +155,7 @@ export function registerCoreHandlers(
   registerHostedReviewHandlers(store, stats)
   registerLinearHandlers()
   registerJiraHandlers()
+  registerPaperclipHandlers()
   registerBitbucketHandlers()
   registerFeedbackHandlers()
   if (crashReports) {

--- a/src/main/ipc/repos/folder-workspace-handlers.ts
+++ b/src/main/ipc/repos/folder-workspace-handlers.ts
@@ -17,6 +17,10 @@ import {
   FolderWorkspaceUpdateArgs,
   parseProjectGroupIpcArgs
 } from './repo-ipc-arg-schemas'
+import {
+  assertNoPaperclipRuntimeLink,
+  withPaperclipWorkspaceAdmission
+} from '../../paperclip/paperclip-workspace-admission'
 
 export function registerFolderWorkspaceHandlers(mainWindow: BrowserWindow, store: Store): void {
   ipcMain.handle('folderWorkspaces:list', (): FolderWorkspace[] => store.getFolderWorkspaces())
@@ -58,9 +62,16 @@ export function registerFolderWorkspaceHandlers(mainWindow: BrowserWindow, store
         { getSshFilesystemProvider }
       )
       assertFolderWorkspacePathUsable(status)
-      const workspace = store.createFolderWorkspace({
-        ...args,
-        creatorProvenance: { kind: 'host' }
+      const workspace = await withPaperclipWorkspaceAdmission({
+        linkedWorkItem: args.linkedTask,
+        linkedTaskSourceContext: args.linkedTaskSourceContext,
+        store,
+        localTarget: !(args.connectionId ?? group.connectionId),
+        create: () =>
+          store.createFolderWorkspace({
+            ...args,
+            creatorProvenance: { kind: 'host' }
+          })
       })
       notifyReposChanged(mainWindow)
       return workspace
@@ -75,6 +86,7 @@ export function registerFolderWorkspaceHandlers(mainWindow: BrowserWindow, store
         rawArgs,
         'invalid_folder_workspace_update_args'
       )
+      assertNoPaperclipRuntimeLink(args.updates.linkedTask, args.updates.linkedTaskSourceContext)
       if (
         typeof args.updates.folderPath === 'string' &&
         args.updates.folderPath.trim().length > 0

--- a/src/main/ipc/worktrees/create/register-worktree-create-handlers.ts
+++ b/src/main/ipc/worktrees/create/register-worktree-create-handlers.ts
@@ -27,6 +27,10 @@ import type { CreateWorktreeArgsWithSystemProvenance } from '../ipc-context-sche
 import { createFolderWorkspace } from './folder-workspace-creation'
 import { findExactRepoOwner, isCapturedRepoCurrent } from '../listing/worktree-host-ownership'
 import type { WorktreeIpcContext } from '../worktree-ipc-context'
+import {
+  assertNoPaperclipRuntimeLink,
+  withPaperclipWorkspaceAdmission
+} from '../../../paperclip/paperclip-workspace-admission'
 
 export function registerWorktreeCreateHandlers(context: WorktreeIpcContext): void {
   const { mainWindow, store, runtime, options } = context
@@ -59,11 +63,18 @@ export function registerWorktreeCreateHandlers(context: WorktreeIpcContext): voi
         let result: CreateWorktreeResult
         try {
           // Why: wrap only the helpers; the pre-validation throws above are IPC-shape bugs, not the git/filesystem failures the funnel tracks.
-          result = isFolderRepo(repo)
-            ? createFolderWorkspace(createArgs, repo, store)
-            : repo.connectionId
-              ? await createRemoteWorktree(createArgs, repo, store, mainWindow)
-              : await createLocalWorktree(createArgs, repo, store, mainWindow, runtime)
+          result = await withPaperclipWorkspaceAdmission({
+            linkedWorkItem: createArgs.linkedWorkItem,
+            linkedTaskSourceContext: createArgs.linkedTaskSourceContext,
+            store,
+            localTarget: !repo.connectionId,
+            create: () =>
+              isFolderRepo(repo)
+                ? createFolderWorkspace(createArgs, repo, store)
+                : repo.connectionId
+                  ? createRemoteWorktree(createArgs, repo, store, mainWindow)
+                  : createLocalWorktree(createArgs, repo, store, mainWindow, runtime)
+          })
         } catch (error) {
           releaseAutomationWorkspaceProvenanceRequest(args.automationProvenanceRequest)
           track('workspace_create_failed', {
@@ -105,6 +116,7 @@ export function registerWorktreeCreateHandlers(context: WorktreeIpcContext): voi
     'worktrees:adoptProvisionedRoot',
     async (_event, rawArgs: AdoptProvisionedRootArgs): Promise<CreateWorktreeResult> => {
       const args = normalizeLinkedWorkItemFields(rawArgs)
+      assertNoPaperclipRuntimeLink(args.linkedWorkItem, args.linkedTaskSourceContext)
       return withWorktreeSpan({ stage: 'create' }, async () => {
         const repo = findExactRepoOwner(store, args.repoId, args.executionHostId)
         if (!repo || isFolderRepo(repo)) {

--- a/src/main/ipc/worktrees/metadata/register-worktree-metadata-handlers.ts
+++ b/src/main/ipc/worktrees/metadata/register-worktree-metadata-handlers.ts
@@ -14,6 +14,7 @@ import { readBranchRenameFailureOutputForDisplay } from '../../../agent-hooks/br
 import { normalizeLinkedWorkItemFields } from '../ipc-context-schemas'
 import { listDesktopLineageForHost } from './host-lineage-listing'
 import type { WorktreeIpcContext } from '../worktree-ipc-context'
+import { assertNoPaperclipRuntimeLink } from '../../../paperclip/paperclip-workspace-admission'
 
 export function registerWorktreeMetadataHandlers(context: WorktreeIpcContext): void {
   const { mainWindow, store, runtime } = context
@@ -35,6 +36,10 @@ export function registerWorktreeMetadataHandlers(context: WorktreeIpcContext): v
         throw new Error('Invalid execution host identity.')
       }
       const validatedUpdates = normalizeLinkedWorkItemFields(args.updates)
+      assertNoPaperclipRuntimeLink(
+        validatedUpdates.linkedWorkItem,
+        validatedUpdates.linkedTaskSourceContext
+      )
       const updates =
         validatedUpdates.displayName !== undefined
           ? {

--- a/src/main/paperclip/client.ts
+++ b/src/main/paperclip/client.ts
@@ -1,0 +1,233 @@
+import type {
+  PaperclipCompany,
+  PaperclipConnectArgs,
+  PaperclipConnectionIdentity,
+  PaperclipConnectionStatus,
+  PaperclipConnectionSummary,
+  PaperclipIssue,
+  PaperclipLaunchAdmission,
+  PaperclipLaunchAdmissionRequest,
+  PaperclipProject
+} from '../../shared/paperclip-types'
+import {
+  clearPaperclipConnection,
+  getPaperclipConnection,
+  savePaperclipConnection
+} from './paperclip-connection-store'
+import { createPaperclipOriginPolicy, type PaperclipOriginPolicy } from './paperclip-origin-policy'
+import { PaperclipApiError, paperclipRequest } from './paperclip-request'
+import { parsePaperclipIssue } from './paperclip-response'
+import {
+  decidePaperclipLaunchAdmission,
+  reducePaperclipActiveRunResponse
+} from './paperclip-launch-admission'
+import { createPaperclipConnectionId } from './paperclip-connection-id'
+
+export async function getStatus(): Promise<PaperclipConnectionStatus> {
+  const stored = getPaperclipConnection()
+  if (!stored) {
+    return { connected: false, connection: null }
+  }
+  const policy = createPaperclipOriginPolicy(stored.origin)
+  const companies = parseCompanies(await paperclipRequest({ policy, segments: ['companies'] }))
+  const company = companies.find((item) => item.id === stored.companyId)
+  if (!company) {
+    throw new Error('The bound Paperclip company is unavailable.')
+  }
+  const projects = parseProjects(
+    await paperclipRequest({ policy, segments: ['companies', company.id, 'projects'] }),
+    company.id
+  )
+  const project = projects.find((item) => item.id === stored.projectId)
+  if (!project) {
+    throw new Error('The bound Paperclip project is unavailable.')
+  }
+  return {
+    connected: true,
+    connection: { ...stored, companyName: company.name, projectName: project.name }
+  }
+}
+
+export async function connect(
+  args: PaperclipConnectArgs
+): Promise<{ ok: true; connection: PaperclipConnectionSummary } | { ok: false; error: string }> {
+  try {
+    const policy = createPaperclipOriginPolicy(args.origin)
+    const companies = parseCompanies(await paperclipRequest({ policy, segments: ['companies'] }))
+    const company = companies.find((item) => item.id === args.companyId)
+    if (!company) {
+      throw new Error('The selected Paperclip company is unavailable.')
+    }
+    const projects = parseProjects(
+      await paperclipRequest({
+        policy,
+        segments: ['companies', company.id, 'projects']
+      }),
+      company.id
+    )
+    const project = projects.find((item) => item.id === args.projectId)
+    if (!project) {
+      throw new Error('The selected Paperclip project is unavailable.')
+    }
+    const connection: PaperclipConnectionSummary = {
+      id: createPaperclipConnectionId(policy.origin, company.id, project.id),
+      origin: policy.origin,
+      companyId: company.id,
+      companyName: company.name,
+      projectId: project.id,
+      projectName: project.name
+    }
+    savePaperclipConnection({
+      id: connection.id,
+      origin: connection.origin,
+      companyId: connection.companyId,
+      projectId: connection.projectId
+    })
+    return { ok: true, connection }
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : 'Connection failed.' }
+  }
+}
+
+export function disconnect(): void {
+  clearPaperclipConnection()
+}
+
+export async function testConnection(): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const client = getClient()
+    const projects = parseProjects(
+      await paperclipRequest({
+        ...client,
+        segments: ['companies', client.connection.companyId, 'projects']
+      }),
+      client.connection.companyId
+    )
+    if (!projects.some((project) => project.id === client.connection.projectId)) {
+      throw new Error('The bound Paperclip project is unavailable.')
+    }
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : 'Connection failed.' }
+  }
+}
+
+export async function listIssues(query?: string): Promise<PaperclipIssue[]> {
+  const client = getClient()
+  const value = await paperclipRequest({
+    ...client,
+    segments: ['companies', client.connection.companyId, 'issues'],
+    query: { projectId: client.connection.projectId, q: query?.trim() || undefined }
+  })
+  if (!Array.isArray(value)) {
+    throw new Error('Paperclip returned an invalid issue list.')
+  }
+  return value.map((issue) =>
+    parsePaperclipIssue(issue, {
+      companyId: client.connection.companyId,
+      projectId: client.connection.projectId
+    })
+  )
+}
+
+export async function getIssue(issueId: string): Promise<PaperclipIssue> {
+  const client = getClient()
+  return parsePaperclipIssue(await paperclipRequest({ ...client, segments: ['issues', issueId] }), {
+    companyId: client.connection.companyId,
+    projectId: client.connection.projectId
+  })
+}
+
+export async function getLaunchAdmission(
+  expected: PaperclipLaunchAdmissionRequest
+): Promise<PaperclipLaunchAdmission> {
+  const client = getClient()
+  if (!isPaperclipConnectionMatch(client.connection, expected)) {
+    return { allowed: false, reason: 'unknown_run_state' }
+  }
+  const issue = await getIssue(expected.issueId)
+  let activeRun
+  try {
+    const body = await paperclipRequest({
+      ...client,
+      segments: ['issues', expected.issueId, 'active-run']
+    })
+    activeRun = reducePaperclipActiveRunResponse({
+      body,
+      expectedIssueId: issue.id,
+      expectedCompanyId: client.connection.companyId
+    })
+  } catch (error) {
+    activeRun = {
+      state: 'unknown' as const,
+      reason:
+        error instanceof PaperclipApiError && (error.status === 401 || error.status === 403)
+          ? ('unauthorized' as const)
+          : error instanceof PaperclipApiError && error.status === 404
+            ? ('unsupported' as const)
+            : ('unavailable' as const)
+    }
+  }
+  return decidePaperclipLaunchAdmission({ activeRun, issue })
+}
+
+export function isPaperclipConnectionMatch(
+  connection: PaperclipConnectionIdentity,
+  expected: PaperclipLaunchAdmissionRequest
+): boolean {
+  return (
+    connection.id === expected.connectionId &&
+    connection.companyId === expected.companyId &&
+    connection.projectId === expected.projectId
+  )
+}
+
+function getClient(): {
+  connection: PaperclipConnectionIdentity
+  policy: PaperclipOriginPolicy
+} {
+  const connection = getPaperclipConnection()
+  if (!connection) {
+    throw new Error('Not connected to Paperclip.')
+  }
+  return {
+    connection,
+    policy: createPaperclipOriginPolicy(connection.origin)
+  }
+}
+
+function parseCompanies(value: unknown): PaperclipCompany[] {
+  if (!Array.isArray(value)) {
+    throw new Error('Paperclip returned an invalid company list.')
+  }
+  return value.map((item) => {
+    if (!item || typeof item !== 'object') {
+      throw new Error('Paperclip returned an invalid company.')
+    }
+    const record = item as Record<string, unknown>
+    if (typeof record.id !== 'string' || typeof record.name !== 'string') {
+      throw new Error('Paperclip returned an invalid company.')
+    }
+    return { id: record.id, name: record.name }
+  })
+}
+
+function parseProjects(value: unknown, companyId: string): PaperclipProject[] {
+  if (!Array.isArray(value)) {
+    throw new Error('Paperclip returned an invalid project list.')
+  }
+  return value.map((item) => {
+    if (!item || typeof item !== 'object') {
+      throw new Error('Paperclip returned an invalid project.')
+    }
+    const record = item as Record<string, unknown>
+    if (
+      typeof record.id !== 'string' ||
+      typeof record.name !== 'string' ||
+      record.companyId !== companyId
+    ) {
+      throw new Error('Paperclip project is missing or outside the bound company scope.')
+    }
+    return { id: record.id, name: record.name, companyId }
+  })
+}

--- a/src/main/paperclip/paperclip-connection-id.ts
+++ b/src/main/paperclip/paperclip-connection-id.ts
@@ -1,0 +1,12 @@
+import { createHash } from 'node:crypto'
+
+export function createPaperclipConnectionId(
+  origin: string,
+  companyId: string,
+  projectId: string
+): string {
+  return createHash('sha256')
+    .update(`${origin}\0${companyId}\0${projectId}`)
+    .digest('hex')
+    .slice(0, 24)
+}

--- a/src/main/paperclip/paperclip-connection-match.test.ts
+++ b/src/main/paperclip/paperclip-connection-match.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { isPaperclipConnectionMatch } from './client'
+
+const connection = {
+  id: 'connection-1',
+  origin: 'http://127.0.0.1:3101',
+  companyId: 'company-1',
+  companyName: 'Company',
+  projectId: 'project-1',
+  projectName: 'Project'
+}
+
+describe('Paperclip admission connection binding', () => {
+  it('requires immutable connection, company, and project identity', () => {
+    const request = {
+      issueId: 'issue-1',
+      connectionId: 'connection-1',
+      companyId: 'company-1',
+      projectId: 'project-1'
+    }
+    expect(isPaperclipConnectionMatch(connection, request)).toBe(true)
+    expect(isPaperclipConnectionMatch(connection, { ...request, connectionId: 'other' })).toBe(
+      false
+    )
+    expect(isPaperclipConnectionMatch(connection, { ...request, companyId: 'other' })).toBe(false)
+    expect(isPaperclipConnectionMatch(connection, { ...request, projectId: 'other' })).toBe(false)
+  })
+})

--- a/src/main/paperclip/paperclip-connection-store.test.ts
+++ b/src/main/paperclip/paperclip-connection-store.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { createPaperclipConnectionId } from './paperclip-connection-id'
+import { normalizePaperclipConnection } from './paperclip-connection-store'
+
+describe('Paperclip persisted connection boundary', () => {
+  const origin = 'http://127.0.0.1:3100'
+  const companyId = 'company-1'
+  const projectId = 'project-1'
+  const id = createPaperclipConnectionId(origin, companyId, projectId)
+
+  it('reconstructs only canonical identity fields', () => {
+    expect(
+      normalizePaperclipConnection({
+        id,
+        origin,
+        companyId,
+        projectId,
+        companyName: 'mutable label',
+        projectName: 'mutable label',
+        token: 'must-not-cross'
+      })
+    ).toEqual({ id, origin, companyId, projectId })
+  })
+
+  it('fails closed when origin and derived identity disagree', () => {
+    expect(
+      normalizePaperclipConnection({
+        id,
+        origin: 'http://127.0.0.2:3100',
+        companyId,
+        projectId
+      })
+    ).toBeNull()
+  })
+})

--- a/src/main/paperclip/paperclip-connection-store.ts
+++ b/src/main/paperclip/paperclip-connection-store.ts
@@ -1,0 +1,73 @@
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import type { PaperclipConnectionIdentity } from '../../shared/paperclip-types'
+import { createPaperclipConnectionId } from './paperclip-connection-id'
+import { parsePaperclipOrigin } from './paperclip-origin-policy'
+
+let cachedConnection: PaperclipConnectionIdentity | null | undefined
+const filePath = (): string => join(homedir(), '.orca', 'paperclip-connection.json')
+
+export function getPaperclipConnection(): PaperclipConnectionIdentity | null {
+  if (cachedConnection !== undefined) {
+    return cachedConnection
+  }
+  try {
+    cachedConnection = normalizePaperclipConnection(JSON.parse(readFileSync(filePath(), 'utf8')))
+  } catch {
+    cachedConnection = null
+  }
+  return cachedConnection
+}
+
+export function savePaperclipConnection(connection: PaperclipConnectionIdentity): void {
+  mkdirSync(join(homedir(), '.orca'), { recursive: true })
+  cachedConnection = normalizePaperclipConnection(connection)
+  if (!cachedConnection) {
+    throw new Error('Cannot persist an invalid Paperclip connection.')
+  }
+  writeFileSync(filePath(), JSON.stringify(cachedConnection, null, 2), {
+    encoding: 'utf8',
+    mode: 0o600
+  })
+}
+
+export function clearPaperclipConnection(): void {
+  cachedConnection = null
+  if (existsSync(filePath())) {
+    unlinkSync(filePath())
+  }
+}
+
+export function normalizePaperclipConnection(value: unknown): PaperclipConnectionIdentity | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const item = value as Record<string, unknown>
+  if (
+    !['id', 'origin', 'companyId', 'projectId'].every(
+      (key) => typeof item[key] === 'string' && (item[key] as string).trim().length > 0
+    )
+  ) {
+    return null
+  }
+  try {
+    const origin = parsePaperclipOrigin(item.origin as string).origin
+    const id = createPaperclipConnectionId(
+      origin,
+      item.companyId as string,
+      item.projectId as string
+    )
+    if (item.id !== id) {
+      return null
+    }
+    return {
+      id,
+      origin,
+      companyId: item.companyId as string,
+      projectId: item.projectId as string
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/main/paperclip/paperclip-launch-admission.test.ts
+++ b/src/main/paperclip/paperclip-launch-admission.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decidePaperclipLaunchAdmission,
+  reducePaperclipActiveRunResponse,
+  type PaperclipActiveRunObservation,
+  type PaperclipIssueClaimEvidence
+} from './paperclip-launch-admission'
+
+const unclaimedIssue: PaperclipIssueClaimEvidence = {
+  status: 'todo',
+  checkoutRunId: null,
+  executionRunId: null,
+  executionLockedAt: null
+}
+
+describe('Paperclip active-run presence reduction', () => {
+  it('retains only presence and drops session-derived canary content', () => {
+    const observation = reducePaperclipActiveRunResponse({
+      expectedIssueId: 'issue-1',
+      expectedCompanyId: 'company-1',
+      body: {
+        id: 'run-1',
+        issueId: 'issue-1',
+        companyId: 'company-1',
+        status: 'running',
+        currentStatusMessage: 'CANARY_STATUS_TEXT',
+        lastAssistantSnippet: 'CANARY_ASSISTANT_TEXT',
+        currentToolName: 'CANARY_TOOL',
+        outputSilence: { excerpt: 'CANARY_OUTPUT' }
+      }
+    })
+
+    expect(observation).toEqual({ state: 'present' })
+    expect(JSON.stringify(observation)).not.toContain('CANARY')
+    expect(JSON.stringify(observation)).not.toContain('run-1')
+  })
+
+  it('accepts null as an authoritative absence', () => {
+    expect(
+      reducePaperclipActiveRunResponse({
+        expectedIssueId: 'issue-1',
+        expectedCompanyId: 'company-1',
+        body: null
+      })
+    ).toEqual({ state: 'absent' })
+  })
+
+  it('fails closed for mismatched or malformed run objects', () => {
+    for (const body of [
+      { id: 'run-1', issueId: 'issue-2', status: 'running' },
+      { id: 'run-1', issueId: 'issue-1', companyId: 'company-2', status: 'running' },
+      { id: 'run-1', issueId: 'issue-1', status: 'finished' },
+      { issueId: 'issue-1', status: 'running' },
+      'running'
+    ]) {
+      expect(
+        reducePaperclipActiveRunResponse({
+          expectedIssueId: 'issue-1',
+          expectedCompanyId: 'company-1',
+          body
+        })
+      ).toEqual({ state: 'unknown', reason: 'invalid' })
+    }
+  })
+})
+
+describe('Paperclip launch admission', () => {
+  it('blocks an active run and every unknown active-run state', () => {
+    expect(
+      decidePaperclipLaunchAdmission({ activeRun: { state: 'present' }, issue: unclaimedIssue })
+    ).toEqual({ allowed: false, reason: 'active_run' })
+
+    for (const reason of [
+      'unavailable',
+      'unauthorized',
+      'unsupported',
+      'invalid',
+      'stale'
+    ] as const) {
+      const activeRun: PaperclipActiveRunObservation = { state: 'unknown', reason }
+      expect(decidePaperclipLaunchAdmission({ activeRun, issue: unclaimedIssue })).toEqual({
+        allowed: false,
+        reason: 'unknown_run_state'
+      })
+    }
+  })
+
+  it.each([
+    { status: 'in_progress' },
+    { checkoutRunId: 'checkout-1' },
+    { executionRunId: 'execution-1' },
+    { executionLockedAt: '2026-08-29T12:00:00.000Z' }
+  ])('blocks null active-run with remaining claim evidence: %o', (claim) => {
+    expect(
+      decidePaperclipLaunchAdmission({
+        activeRun: { state: 'absent' },
+        issue: { ...unclaimedIssue, ...claim }
+      })
+    ).toEqual({ allowed: false, reason: 'claim_markers' })
+  })
+
+  it('permits only explicit non-exclusive confirmation when no claim evidence exists', () => {
+    expect(
+      decidePaperclipLaunchAdmission({ activeRun: { state: 'absent' }, issue: unclaimedIssue })
+    ).toEqual({ allowed: true, requiresNonExclusiveConfirmation: true })
+  })
+})

--- a/src/main/paperclip/paperclip-launch-admission.ts
+++ b/src/main/paperclip/paperclip-launch-admission.ts
@@ -1,0 +1,67 @@
+export type PaperclipIssueClaimEvidence = {
+  status: string | null
+  checkoutRunId: string | null
+  executionRunId: string | null
+  executionLockedAt: string | null
+}
+
+export type PaperclipActiveRunObservation =
+  | { state: 'present' }
+  | { state: 'absent' }
+  | {
+      state: 'unknown'
+      reason: 'unavailable' | 'unauthorized' | 'unsupported' | 'invalid' | 'stale'
+    }
+
+import type { PaperclipLaunchAdmission } from '../../shared/paperclip-types'
+
+export function reducePaperclipActiveRunResponse(input: {
+  body: unknown
+  expectedIssueId: string
+  expectedCompanyId: string
+}): PaperclipActiveRunObservation {
+  if (input.body === null) {
+    return { state: 'absent' }
+  }
+  if (!input.body || typeof input.body !== 'object' || Array.isArray(input.body)) {
+    return { state: 'unknown', reason: 'invalid' }
+  }
+  const run = input.body as Record<string, unknown>
+  if (
+    typeof run.id !== 'string' ||
+    run.id.trim().length === 0 ||
+    run.issueId !== input.expectedIssueId ||
+    (run.status !== 'queued' && run.status !== 'running') ||
+    (run.companyId !== undefined && run.companyId !== input.expectedCompanyId)
+  ) {
+    return { state: 'unknown', reason: 'invalid' }
+  }
+
+  // Presence is the only retained fact. Session-derived fields must die here.
+  return { state: 'present' }
+}
+
+export function decidePaperclipLaunchAdmission(input: {
+  activeRun: PaperclipActiveRunObservation
+  issue: PaperclipIssueClaimEvidence
+}): PaperclipLaunchAdmission {
+  if (input.activeRun.state === 'present') {
+    return { allowed: false, reason: 'active_run' }
+  }
+  if (input.activeRun.state === 'unknown') {
+    return { allowed: false, reason: 'unknown_run_state' }
+  }
+  if (
+    input.issue.status === 'in_progress' ||
+    hasValue(input.issue.checkoutRunId) ||
+    hasValue(input.issue.executionRunId) ||
+    hasValue(input.issue.executionLockedAt)
+  ) {
+    return { allowed: false, reason: 'claim_markers' }
+  }
+  return { allowed: true, requiresNonExclusiveConfirmation: true }
+}
+
+function hasValue(value: string | null): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}

--- a/src/main/paperclip/paperclip-origin-policy.test.ts
+++ b/src/main/paperclip/paperclip-origin-policy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPaperclipApiUrl,
+  createPaperclipOriginPolicy,
+  parsePaperclipOrigin
+} from './paperclip-origin-policy'
+
+describe('Paperclip local origin policy', () => {
+  it.each(['http://127.0.0.1:3101', 'http://127.8.9.10', 'http://[::1]:3101'])(
+    'accepts literal loopback HTTP: %s',
+    (origin) => expect(parsePaperclipOrigin(origin).origin).toBe(origin)
+  )
+
+  it.each([
+    'http://localhost:3101',
+    'https://127.0.0.1:3101',
+    'http://10.0.0.1:3101',
+    'http://169.254.169.254',
+    'http://user:secret@127.0.0.1:3101',
+    'http://127.0.0.1:3101/api',
+    'http://127.0.0.1:3101/?company=1'
+  ])('rejects non-literal or widened input: %s', (origin) => {
+    expect(() => parsePaperclipOrigin(origin)).toThrow()
+  })
+
+  it('constructs encoded API paths locally', () => {
+    const policy = createPaperclipOriginPolicy('http://127.0.0.1:3101')
+    expect(buildPaperclipApiUrl(policy, ['issues', 'issue/1', 'active-run'])).toBe(
+      'http://127.0.0.1:3101/api/issues/issue%2F1/active-run'
+    )
+  })
+})

--- a/src/main/paperclip/paperclip-origin-policy.ts
+++ b/src/main/paperclip/paperclip-origin-policy.ts
@@ -1,0 +1,55 @@
+export type PaperclipOriginPolicy = { origin: string }
+
+export function parsePaperclipOrigin(input: string): URL {
+  let url: URL
+  try {
+    url = new URL(input.trim())
+  } catch {
+    throw new Error('Enter an absolute local Paperclip HTTP origin.')
+  }
+  if (
+    url.protocol !== 'http:' ||
+    url.username ||
+    url.password ||
+    url.pathname !== '/' ||
+    url.search ||
+    url.hash ||
+    !isLiteralLoopbackHost(url.hostname)
+  ) {
+    throw new Error(
+      'Paperclip must use a literal loopback HTTP origin with no path or credentials.'
+    )
+  }
+  return url
+}
+
+export function createPaperclipOriginPolicy(origin: string): PaperclipOriginPolicy {
+  return { origin: parsePaperclipOrigin(origin).origin }
+}
+
+export function buildPaperclipApiUrl(
+  policy: PaperclipOriginPolicy,
+  segments: readonly string[],
+  query?: Readonly<Record<string, string | number | undefined>>
+): string {
+  const url = new URL(`/api/${segments.map(encodeURIComponent).join('/')}`, policy.origin)
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value))
+    }
+  }
+  return url.toString()
+}
+
+function isLiteralLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+  if (normalized === '::1') {
+    return true
+  }
+  const octets = normalized.split('.').map(Number)
+  return (
+    octets.length === 4 &&
+    octets.every((octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255) &&
+    octets[0] === 127
+  )
+}

--- a/src/main/paperclip/paperclip-request.test.ts
+++ b/src/main/paperclip/paperclip-request.test.ts
@@ -1,0 +1,57 @@
+import { createServer, type RequestListener } from 'node:http'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createPaperclipOriginPolicy } from './paperclip-origin-policy'
+import { paperclipRequest } from './paperclip-request'
+
+const servers: ReturnType<typeof createServer>[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve())))
+  )
+})
+
+async function serve(
+  handler: RequestListener
+): Promise<ReturnType<typeof createPaperclipOriginPolicy>> {
+  const server = createServer(handler)
+  servers.push(server)
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Missing test server address')
+  }
+  return createPaperclipOriginPolicy(`http://127.0.0.1:${address.port}`)
+}
+
+describe('Paperclip HTTP request bounds', () => {
+  it('enforces an absolute deadline even while bytes keep arriving', async () => {
+    const policy = await serve((_request, response) => {
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.write('[')
+      const interval = setInterval(() => response.write(' '), 5)
+      response.on('close', () => clearInterval(interval))
+    })
+    await expect(
+      paperclipRequest({ policy, segments: ['issues'], deadlineMs: 40 })
+    ).rejects.toThrow('timed out')
+  })
+
+  it('rejects redirects immediately without reading their body', async () => {
+    const policy = await serve((_request, response) => {
+      response.writeHead(302, { Location: 'http://127.0.0.1:9/escape' })
+      response.write('never-ending')
+    })
+    await expect(
+      paperclipRequest({ policy, segments: ['issues'], deadlineMs: 500 })
+    ).rejects.toThrow('redirects are not allowed')
+  })
+
+  it('rejects responses larger than two MiB', async () => {
+    const policy = await serve((_request, response) => {
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(Buffer.alloc(2 * 1024 * 1024 + 1, 32))
+    })
+    await expect(paperclipRequest({ policy, segments: ['issues'] })).rejects.toThrow('size limit')
+  })
+})

--- a/src/main/paperclip/paperclip-request.ts
+++ b/src/main/paperclip/paperclip-request.ts
@@ -1,0 +1,95 @@
+import { request } from 'node:http'
+import { buildPaperclipApiUrl, type PaperclipOriginPolicy } from './paperclip-origin-policy'
+
+const REQUEST_TIMEOUT_MS = 15_000
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+
+export class PaperclipApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number | null
+  ) {
+    super(message)
+  }
+}
+
+export async function paperclipRequest(input: {
+  policy: PaperclipOriginPolicy
+  segments: readonly string[]
+  query?: Readonly<Record<string, string | number | undefined>>
+  deadlineMs?: number
+}): Promise<unknown> {
+  const url = buildPaperclipApiUrl(input.policy, input.segments, input.query)
+  return new Promise((resolve, reject) => {
+    const req = request(
+      url,
+      {
+        method: 'GET',
+        headers: { Accept: 'application/json', 'User-Agent': 'Orca' },
+        agent: false
+      },
+      (response) => {
+        const status = response.statusCode ?? 0
+        if (status >= 300 && status < 400) {
+          response.destroy()
+          reject(new PaperclipApiError('Paperclip redirects are not allowed.', status))
+          return
+        }
+        const chunks: Buffer[] = []
+        let total = 0
+        response.on('data', (chunk: Buffer) => {
+          total += chunk.byteLength
+          if (total > MAX_RESPONSE_BYTES) {
+            response.destroy(
+              new PaperclipApiError(
+                'Paperclip response exceeded the size limit.',
+                response.statusCode ?? null
+              )
+            )
+            return
+          }
+          chunks.push(chunk)
+        })
+        response.on('error', reject)
+        response.on('end', () => {
+          const text = Buffer.concat(chunks).toString('utf8')
+          if (status < 200 || status >= 300) {
+            reject(new PaperclipApiError(readPaperclipError(text, status), status))
+            return
+          }
+          if (status === 204 || text.trim().length === 0) {
+            resolve(null)
+            return
+          }
+          try {
+            resolve(JSON.parse(text) as unknown)
+          } catch {
+            reject(new PaperclipApiError('Paperclip returned invalid JSON.', status))
+          }
+        })
+      }
+    )
+    const deadline = setTimeout(
+      () => req.destroy(new PaperclipApiError('Paperclip request timed out.', null)),
+      input.deadlineMs ?? REQUEST_TIMEOUT_MS
+    )
+    req.once('close', () => clearTimeout(deadline))
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+function readPaperclipError(text: string, status: number): string {
+  try {
+    const value = JSON.parse(text) as { error?: unknown; message?: unknown }
+    if (typeof value.error === 'string' && value.error.trim()) {
+      return value.error
+    }
+    if (typeof value.message === 'string' && value.message.trim()) {
+      return value.message
+    }
+  } catch {
+    // Fall through to a bounded generic status message.
+  }
+  return `Paperclip request failed (${status}).`
+}

--- a/src/main/paperclip/paperclip-response.test.ts
+++ b/src/main/paperclip/paperclip-response.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { parsePaperclipIssue } from './paperclip-response'
+
+const issue = {
+  id: 'issue-1',
+  identifier: 'PAP-1',
+  companyId: 'company-1',
+  projectId: 'project-1',
+  title: 'Integrate Orca',
+  description: null,
+  status: 'todo',
+  priority: 'high'
+}
+
+describe('Paperclip response scope', () => {
+  it('accepts an issue inside the bound company and project', () => {
+    expect(
+      parsePaperclipIssue(issue, { companyId: 'company-1', projectId: 'project-1' })
+    ).toMatchObject({ id: 'issue-1', identifier: 'PAP-1' })
+  })
+
+  it.each([
+    { ...issue, companyId: 'company-2' },
+    { ...issue, projectId: 'project-2' },
+    { ...issue, companyId: undefined },
+    { ...issue, projectId: undefined }
+  ])('rejects missing or mismatched provider scope', (value) => {
+    expect(() =>
+      parsePaperclipIssue(value, { companyId: 'company-1', projectId: 'project-1' })
+    ).toThrow(/scope/)
+  })
+})

--- a/src/main/paperclip/paperclip-response.ts
+++ b/src/main/paperclip/paperclip-response.ts
@@ -1,0 +1,42 @@
+import type { PaperclipIssue } from '../../shared/paperclip-types'
+
+export function parsePaperclipIssue(
+  value: unknown,
+  scope: { companyId: string; projectId?: string }
+): PaperclipIssue {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Paperclip returned an invalid issue.')
+  }
+  const issue = value as Record<string, unknown>
+  const projectId = nullableString(issue.projectId)
+  if (
+    !nonEmpty(issue.id) ||
+    !nonEmpty(issue.identifier) ||
+    !nonEmpty(issue.title) ||
+    issue.companyId !== scope.companyId ||
+    (scope.projectId !== undefined && projectId !== scope.projectId)
+  ) {
+    throw new Error('Paperclip issue is missing or outside the bound connection scope.')
+  }
+  return {
+    id: issue.id,
+    identifier: issue.identifier,
+    companyId: scope.companyId,
+    projectId,
+    title: issue.title,
+    description: nullableString(issue.description),
+    status: typeof issue.status === 'string' ? issue.status : 'unknown',
+    priority: nullableString(issue.priority),
+    checkoutRunId: nullableString(issue.checkoutRunId),
+    executionRunId: nullableString(issue.executionRunId),
+    executionLockedAt: nullableString(issue.executionLockedAt)
+  }
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null
+}

--- a/src/main/paperclip/paperclip-workspace-admission.test.ts
+++ b/src/main/paperclip/paperclip-workspace-admission.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkspaceLinkedItem } from '../../shared/worktree/types'
+
+const { getLaunchAdmission } = vi.hoisted(() => ({ getLaunchAdmission: vi.fn() }))
+vi.mock('./client', () => ({ getLaunchAdmission }))
+
+import {
+  assertNoPaperclipRuntimeLink,
+  withPaperclipWorkspaceAdmission
+} from './paperclip-workspace-admission'
+
+const linkedWorkItem: WorkspaceLinkedItem = {
+  provider: 'paperclip',
+  type: 'issue',
+  number: 0,
+  title: 'Paperclip issue',
+  url: 'http://127.0.0.1:3100/issues/issue-1',
+  paperclipIssueId: 'issue-1',
+  paperclipIdentifier: 'PAP-1',
+  paperclipConnectionId: 'connection-1',
+  paperclipCompanyId: 'company-1',
+  paperclipProjectId: 'project-1'
+}
+const linkedTaskSourceContext = {
+  kind: 'task-source' as const,
+  provider: 'paperclip' as const,
+  projectId: 'project-1',
+  hostId: 'local' as const,
+  providerIdentity: {
+    provider: 'paperclip' as const,
+    connectionId: 'connection-1',
+    companyId: 'company-1',
+    projectId: 'project-1'
+  }
+}
+
+const emptyStore = () => ({ getAllWorktreeMeta: () => ({}), getFolderWorkspaces: () => [] })
+
+describe('Paperclip workspace mutation boundary', () => {
+  beforeEach(() => {
+    getLaunchAdmission.mockReset()
+    getLaunchAdmission.mockResolvedValue({
+      allowed: true,
+      requiresNonExclusiveConfirmation: true
+    })
+  })
+
+  it('performs a fresh admission immediately before local creation', async () => {
+    const create = vi.fn(() => 'created')
+    await expect(
+      withPaperclipWorkspaceAdmission({
+        linkedWorkItem,
+        linkedTaskSourceContext,
+        store: emptyStore(),
+        localTarget: true,
+        create
+      })
+    ).resolves.toBe('created')
+    expect(getLaunchAdmission).toHaveBeenCalledWith({
+      issueId: 'issue-1',
+      connectionId: 'connection-1',
+      companyId: 'company-1',
+      projectId: 'project-1'
+    })
+    expect(create).toHaveBeenCalledOnce()
+  })
+
+  it('rejects nonlocal targets before admission or mutation', async () => {
+    const create = vi.fn()
+    await expect(
+      withPaperclipWorkspaceAdmission({
+        linkedWorkItem,
+        linkedTaskSourceContext,
+        store: emptyStore(),
+        localTarget: false,
+        create
+      })
+    ).rejects.toThrow('only on the local Orca runtime')
+    expect(getLaunchAdmission).not.toHaveBeenCalled()
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it('rejects existing and concurrent duplicate workspace creation', async () => {
+    const existingStore = {
+      getAllWorktreeMeta: () => ({ existing: { linkedWorkItem } }),
+      getFolderWorkspaces: () => []
+    }
+    await expect(
+      withPaperclipWorkspaceAdmission({
+        linkedWorkItem,
+        linkedTaskSourceContext,
+        store: existingStore,
+        localTarget: true,
+        create: vi.fn()
+      })
+    ).rejects.toThrow('already linked')
+
+    let finish!: () => void
+    const first = withPaperclipWorkspaceAdmission({
+      linkedWorkItem,
+      linkedTaskSourceContext,
+      store: emptyStore(),
+      localTarget: true,
+      create: () => new Promise<void>((resolve) => (finish = resolve))
+    })
+    await vi.waitFor(() => expect(getLaunchAdmission).toHaveBeenCalledOnce())
+    await expect(
+      withPaperclipWorkspaceAdmission({
+        linkedWorkItem,
+        linkedTaskSourceContext,
+        store: emptyStore(),
+        localTarget: true,
+        create: vi.fn()
+      })
+    ).rejects.toThrow('already linked')
+    finish()
+    await first
+  })
+
+  it('rejects Paperclip linkage on runtime RPC boundaries', () => {
+    expect(() => assertNoPaperclipRuntimeLink(linkedWorkItem, linkedTaskSourceContext)).toThrow(
+      'runtime RPC'
+    )
+    expect(() => assertNoPaperclipRuntimeLink(null, linkedTaskSourceContext)).toThrow('runtime RPC')
+  })
+
+  it('requires the Paperclip item and context pair before local creation', async () => {
+    await expect(
+      withPaperclipWorkspaceAdmission({
+        linkedWorkItem,
+        linkedTaskSourceContext: null,
+        store: emptyStore(),
+        localTarget: true,
+        create: vi.fn()
+      })
+    ).rejects.toThrow('matching linked item and source context')
+  })
+})

--- a/src/main/paperclip/paperclip-workspace-admission.ts
+++ b/src/main/paperclip/paperclip-workspace-admission.ts
@@ -1,0 +1,108 @@
+import type { WorkspaceLinkedItem } from '../../shared/worktree/types'
+import type { TaskSourceContext } from '../../shared/task-source-context'
+import { isWorkspaceLinkedItemSourceContextMatch } from '../../shared/workspace-linked-item-source-context'
+import { getLaunchAdmission } from './client'
+
+const pendingPaperclipIssues = new Set<string>()
+
+type PaperclipWorkspaceStore = {
+  getAllWorktreeMeta: () => Readonly<
+    Record<string, { linkedWorkItem?: WorkspaceLinkedItem | null }>
+  >
+  getFolderWorkspaces: () => readonly { linkedTask?: WorkspaceLinkedItem | null }[]
+}
+
+export async function withPaperclipWorkspaceAdmission<T>(input: {
+  linkedWorkItem: WorkspaceLinkedItem | null | undefined
+  linkedTaskSourceContext: TaskSourceContext | null | undefined
+  store: PaperclipWorkspaceStore
+  localTarget: boolean
+  create: () => Promise<T> | T
+}): Promise<T> {
+  const request = getPaperclipAdmissionRequest(input.linkedWorkItem, input.linkedTaskSourceContext)
+  if (!request) {
+    return input.create()
+  }
+  if (!input.localTarget) {
+    throw new Error('Paperclip-linked workspaces are available only on the local Orca runtime.')
+  }
+  const key = [request.connectionId, request.companyId, request.projectId, request.issueId].join(
+    '\0'
+  )
+  if (pendingPaperclipIssues.has(key) || hasExistingPaperclipWorkspace(input.store, request)) {
+    throw new Error('An Orca workspace is already linked to this Paperclip issue.')
+  }
+  pendingPaperclipIssues.add(key)
+  try {
+    const admission = await getLaunchAdmission(request)
+    if (!admission.allowed) {
+      throw new Error('Paperclip run state changed. Workspace creation stopped.')
+    }
+    return await input.create()
+  } finally {
+    pendingPaperclipIssues.delete(key)
+  }
+}
+
+export function assertNoPaperclipRuntimeLink(
+  linkedWorkItem: WorkspaceLinkedItem | null | undefined,
+  linkedTaskSourceContext?: TaskSourceContext | null
+): void {
+  if (
+    linkedWorkItem?.provider === 'paperclip' ||
+    linkedTaskSourceContext?.provider === 'paperclip'
+  ) {
+    throw new Error('Paperclip-linked workspaces are not supported over runtime RPC.')
+  }
+}
+
+function getPaperclipAdmissionRequest(
+  linkedWorkItem: WorkspaceLinkedItem | null | undefined,
+  linkedTaskSourceContext: TaskSourceContext | null | undefined
+): {
+  issueId: string
+  connectionId: string
+  companyId: string
+  projectId: string
+} | null {
+  const hasPaperclipItem = linkedWorkItem?.provider === 'paperclip'
+  const hasPaperclipContext = linkedTaskSourceContext?.provider === 'paperclip'
+  if (!hasPaperclipItem && !hasPaperclipContext) {
+    return null
+  }
+  if (
+    !hasPaperclipItem ||
+    !hasPaperclipContext ||
+    !isWorkspaceLinkedItemSourceContextMatch(linkedWorkItem, linkedTaskSourceContext)
+  ) {
+    throw new Error(
+      'Paperclip workspace creation requires matching linked item and source context.'
+    )
+  }
+  const issueId = linkedWorkItem.paperclipIssueId?.trim()
+  const connectionId = linkedWorkItem.paperclipConnectionId?.trim()
+  const companyId = linkedWorkItem.paperclipCompanyId?.trim()
+  const projectId = linkedWorkItem.paperclipProjectId?.trim()
+  if (!issueId || !connectionId || !companyId || !projectId) {
+    throw new Error('The linked Paperclip scope is missing.')
+  }
+  return { issueId, connectionId, companyId, projectId }
+}
+
+function hasExistingPaperclipWorkspace(
+  store: PaperclipWorkspaceStore,
+  request: { issueId: string; connectionId: string; companyId: string; projectId: string }
+): boolean {
+  const items = [
+    ...Object.values(store.getAllWorktreeMeta()).map((meta) => meta.linkedWorkItem),
+    ...store.getFolderWorkspaces().map((workspace) => workspace.linkedTask)
+  ]
+  return items.some(
+    (item) =>
+      item?.provider === 'paperclip' &&
+      item.paperclipIssueId === request.issueId &&
+      item.paperclipConnectionId === request.connectionId &&
+      item.paperclipCompanyId === request.companyId &&
+      item.paperclipProjectId === request.projectId
+  )
+}

--- a/src/main/persistence-settings-ui-defaults.test.ts
+++ b/src/main/persistence-settings-ui-defaults.test.ts
@@ -92,7 +92,13 @@ describe('Store', () => {
     expect(settings.rightSidebarOpenByDefault).toBe(true)
     expect(settings.showTasksButton).toBe(true)
     expect(settings.showAutomationsButton).toBe(true)
-    expect(settings.visibleTaskProviders).toEqual(['github', 'gitlab', 'linear', 'jira'])
+    expect(settings.visibleTaskProviders).toEqual([
+      'github',
+      'gitlab',
+      'linear',
+      'jira',
+      'paperclip'
+    ])
     expect(settings.openInApplications).toEqual([
       { id: 'vscode', label: 'VS Code', command: 'code' }
     ])

--- a/src/main/persistence-source-control-ai-migration.test.ts
+++ b/src/main/persistence-source-control-ai-migration.test.ts
@@ -106,7 +106,13 @@ describe('Store', () => {
     expect(store.getSettings().showTasksButton).toBe(true)
     expect(store.getSettings().showAutomationsButton).toBe(true)
     expect(store.getSettings().combinedDiffFileTreeVisibleByDefault).toBe(false)
-    expect(store.getSettings().visibleTaskProviders).toEqual(['github', 'gitlab', 'linear', 'jira'])
+    expect(store.getSettings().visibleTaskProviders).toEqual([
+      'github',
+      'gitlab',
+      'linear',
+      'jira',
+      'paperclip'
+    ])
     expect(store.getSettings().experimentalActivity).toBe(false)
     expect(store.getSettings().experimentalActivityDefaultedOffForAllUsers).toBe(true)
     expect(store.getSettings().experimentalTerminalAttention).toBe(false)

--- a/src/main/runtime/rpc/methods/folder-workspace.ts
+++ b/src/main/runtime/rpc/methods/folder-workspace.ts
@@ -7,6 +7,7 @@ import { WorkspaceLinkedItemSchema } from '../../../../shared/workspace-linked-i
 import { isWorkspaceLinkedItemSourceContextMatch } from '../../../../shared/workspace-linked-item-source-context'
 import { resolveRpcWorkspaceCreatorProvenance } from '../workspace-creator-context'
 import { DiffCommentSchema } from '../../../../shared/diff-comment-schema'
+import { assertNoPaperclipRuntimeLink } from '../../../paperclip/paperclip-workspace-admission'
 
 const FolderWorkspaceLinkedTask = WorkspaceLinkedItemSchema.nullable()
 
@@ -97,19 +98,31 @@ export const FOLDER_WORKSPACE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'folderWorkspace.create',
     params: FolderWorkspaceCreate,
-    handler: async (params, context) => ({
-      folderWorkspace: await context.runtime.createFolderWorkspace({
-        ...params,
-        creatorProvenance: resolveRpcWorkspaceCreatorProvenance(context)
-      })
-    })
+    handler: async (params, context) => {
+      assertNoPaperclipRuntimeLink(params.linkedTask, params.linkedTaskSourceContext)
+      return {
+        folderWorkspace: await context.runtime.createFolderWorkspace({
+          ...params,
+          creatorProvenance: resolveRpcWorkspaceCreatorProvenance(context)
+        })
+      }
+    }
   }),
   defineMethod({
     name: 'folderWorkspace.update',
     params: FolderWorkspaceUpdate,
-    handler: async (params, { runtime }) => ({
-      folderWorkspace: await runtime.updateFolderWorkspace(params.folderWorkspaceId, params.updates)
-    })
+    handler: async (params, { runtime }) => {
+      assertNoPaperclipRuntimeLink(
+        params.updates.linkedTask,
+        params.updates.linkedTaskSourceContext
+      )
+      return {
+        folderWorkspace: await runtime.updateFolderWorkspace(
+          params.folderWorkspaceId,
+          params.updates
+        )
+      }
+    }
   }),
   defineMethod({
     name: 'folderWorkspace.delete',

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -147,6 +147,35 @@ describe('worktree RPC methods', () => {
     })
   })
 
+  it('rejects Paperclip linkage at the runtime mutation boundary', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      dedupeWorktreeCreate: passthroughDedupe,
+      showRepo: vi.fn().mockResolvedValue(repo),
+      createManagedWorktree: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const response = await new RpcDispatcher({ runtime, methods: WORKTREE_METHODS }).dispatch(
+      makeRequest('worktree.create', {
+        repo: 'repo-1',
+        name: 'paperclip-task',
+        linkedWorkItem: {
+          provider: 'paperclip',
+          type: 'issue',
+          number: 0,
+          title: 'Paperclip issue',
+          url: 'http://127.0.0.1:3100/issues/issue-1',
+          paperclipIssueId: 'issue-1',
+          paperclipConnectionId: 'connection-1',
+          paperclipCompanyId: 'company-1',
+          paperclipProjectId: 'project-1'
+        }
+      })
+    )
+    expect(response).toMatchObject({ ok: false })
+    expect(runtime.showRepo).not.toHaveBeenCalled()
+    expect(runtime.createManagedWorktree).not.toHaveBeenCalled()
+  })
+
   it('mints automation provenance from a valid dispatch request on worktree creation', async () => {
     const dispatchToken = createAutomationDispatchToken('automation-1', 'run-1')
     const runtime = {

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -22,6 +22,7 @@ import {
   WorktreeTeardownMissingTerminalsParams
 } from './worktree-schemas'
 import { WORKTREE_CATALOG_METHODS } from './worktree-catalog-methods'
+import { assertNoPaperclipRuntimeLink } from '../../../paperclip/paperclip-workspace-admission'
 
 export const WORKTREE_METHODS: RpcMethod[] = [
   ...WORKTREE_CATALOG_METHODS,
@@ -79,6 +80,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
       // the same clientMutationId; dedupe so the host returns the in-flight/created
       // worktree instead of spawning a duplicate. No key (desktop/CLI) runs plainly.
       context.runtime.dedupeWorktreeCreate(params.repo, params.clientMutationId, async () => {
+        assertNoPaperclipRuntimeLink(params.linkedWorkItem, params.linkedTaskSourceContext)
         const { runtime } = context
         const repo = await runtime.showRepo(params.repo)
         const automationProvenance = resolveAutomationWorkspaceProvenance({
@@ -130,46 +132,49 @@ export const WORKTREE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'worktree.set',
     params: WorktreeSet,
-    handler: async (params, { runtime }) => ({
-      worktree: await runtime.updateManagedWorktreeMeta(params.worktree, {
-        displayName: params.displayName,
-        linkedIssue: params.linkedIssue,
-        linkedPR: params.linkedPR,
-        linkedLinearIssue: params.linkedLinearIssue,
-        linkedLinearIssueWorkspaceId: params.linkedLinearIssueWorkspaceId,
-        linkedLinearIssueOrganizationUrlKey: params.linkedLinearIssueOrganizationUrlKey,
-        linkedGitLabMR: params.linkedGitLabMR,
-        linkedGitLabIssue: params.linkedGitLabIssue,
-        linkedBitbucketPR: params.linkedBitbucketPR,
-        linkedAzureDevOpsPR: params.linkedAzureDevOpsPR,
-        linkedGiteaPR: params.linkedGiteaPR,
-        linkedWorkItem: params.linkedWorkItem,
-        linkedTaskSourceContext: params.linkedTaskSourceContext,
-        comment: params.comment,
-        isArchived: params.isArchived,
-        isUnread: params.isUnread,
-        isPinned: params.isPinned,
-        sortOrder: params.sortOrder,
-        manualOrder: params.manualOrder,
-        lastActivityAt: params.lastActivityAt,
-        createdAt: params.createdAt,
-        sparseDirectories: params.sparseDirectories,
-        sparseBaseRef: params.sparseBaseRef,
-        sparsePresetId: params.sparsePresetId,
-        baseRef: params.baseRef,
-        workspaceStatus: params.workspaceStatus,
-        pushTarget: params.pushTarget,
-        diffComments: params.diffComments,
-        mobileDiffReview: params.mobileDiffReview,
-        lineage:
-          params.parentWorktree || params.noParent === true
-            ? {
-                parentWorktree: params.parentWorktree,
-                noParent: params.noParent === true
-              }
-            : undefined
-      } as Parameters<typeof runtime.updateManagedWorktreeMeta>[1])
-    })
+    handler: async (params, { runtime }) => {
+      assertNoPaperclipRuntimeLink(params.linkedWorkItem, params.linkedTaskSourceContext)
+      return {
+        worktree: await runtime.updateManagedWorktreeMeta(params.worktree, {
+          displayName: params.displayName,
+          linkedIssue: params.linkedIssue,
+          linkedPR: params.linkedPR,
+          linkedLinearIssue: params.linkedLinearIssue,
+          linkedLinearIssueWorkspaceId: params.linkedLinearIssueWorkspaceId,
+          linkedLinearIssueOrganizationUrlKey: params.linkedLinearIssueOrganizationUrlKey,
+          linkedGitLabMR: params.linkedGitLabMR,
+          linkedGitLabIssue: params.linkedGitLabIssue,
+          linkedBitbucketPR: params.linkedBitbucketPR,
+          linkedAzureDevOpsPR: params.linkedAzureDevOpsPR,
+          linkedGiteaPR: params.linkedGiteaPR,
+          linkedWorkItem: params.linkedWorkItem,
+          linkedTaskSourceContext: params.linkedTaskSourceContext,
+          comment: params.comment,
+          isArchived: params.isArchived,
+          isUnread: params.isUnread,
+          isPinned: params.isPinned,
+          sortOrder: params.sortOrder,
+          manualOrder: params.manualOrder,
+          lastActivityAt: params.lastActivityAt,
+          createdAt: params.createdAt,
+          sparseDirectories: params.sparseDirectories,
+          sparseBaseRef: params.sparseBaseRef,
+          sparsePresetId: params.sparsePresetId,
+          baseRef: params.baseRef,
+          workspaceStatus: params.workspaceStatus,
+          pushTarget: params.pushTarget,
+          diffComments: params.diffComments,
+          mobileDiffReview: params.mobileDiffReview,
+          lineage:
+            params.parentWorktree || params.noParent === true
+              ? {
+                  parentWorktree: params.parentWorktree,
+                  noParent: params.noParent === true
+                }
+              : undefined
+        } as Parameters<typeof runtime.updateManagedWorktreeMeta>[1])
+      }
+    }
   }),
   defineMethod({
     name: 'worktree.persistSortOrder',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -33,6 +33,7 @@ import type { GithubWorkItemApi } from './api/github-work-item-api'
 import type { GitLabApi } from './api/gitlab-api'
 import type { BitbucketApi, HostedReviewApi } from './api/hosted-review-api'
 import type { JiraApi } from './api/jira-api'
+import type { PaperclipApi } from './api/paperclip-api'
 import type { LinearApi } from './api/linear-api'
 import type { MobileApi } from './api/mobile-api'
 import type { NativeChatApi } from './api/native-chat-api'
@@ -90,6 +91,7 @@ export type PreloadApi = {
   bitbucket: BitbucketApi
   linear: LinearApi
   jira: JiraApi
+  paperclip: PaperclipApi
   starNag: StarNagApi
   telemetryTrack: TelemetryApi['telemetryTrack']
   telemetrySetOptIn: TelemetryApi['telemetrySetOptIn']

--- a/src/preload/api/paperclip-api.ts
+++ b/src/preload/api/paperclip-api.ts
@@ -1,0 +1,21 @@
+import type {
+  PaperclipConnectionStatus,
+  PaperclipConnectionSummary,
+  PaperclipIssue,
+  PaperclipLaunchAdmission,
+  PaperclipLaunchAdmissionRequest
+} from '../../shared/paperclip-types'
+
+export type PaperclipApi = {
+  connectLocalTrusted: (args: {
+    origin: string
+    companyId: string
+    projectId: string
+  }) => Promise<{ ok: true; connection: PaperclipConnectionSummary } | { ok: false; error: string }>
+  disconnect: () => Promise<void>
+  status: () => Promise<PaperclipConnectionStatus>
+  testConnection: () => Promise<{ ok: true } | { ok: false; error: string }>
+  listIssues: (args?: { query?: string }) => Promise<PaperclipIssue[]>
+  getIssue: (args: { issueId: string }) => Promise<PaperclipIssue>
+  getLaunchAdmission: (args: PaperclipLaunchAdmissionRequest) => Promise<PaperclipLaunchAdmission>
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2120,6 +2120,16 @@ const api = {
     }): Promise<JiraProjectStatusOrder> => ipcRenderer.invoke('jira:getProjectStatusOrder', args)
   },
 
+  paperclip: {
+    connectLocalTrusted: (args) => ipcRenderer.invoke('paperclip:connectLocalTrusted', args),
+    disconnect: () => ipcRenderer.invoke('paperclip:disconnect'),
+    status: () => ipcRenderer.invoke('paperclip:status'),
+    testConnection: () => ipcRenderer.invoke('paperclip:testConnection'),
+    listIssues: (args) => ipcRenderer.invoke('paperclip:listIssues', args),
+    getIssue: (args) => ipcRenderer.invoke('paperclip:getIssue', args),
+    getLaunchAdmission: (args) => ipcRenderer.invoke('paperclip:getLaunchAdmission', args)
+  },
+
   starNag: {
     onShow: (
       callback: (payload?: { mode?: 'gh' | 'web'; surface?: 'card' | 'toast' }) => void

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -36,6 +36,7 @@ import { saveLinearIssueView } from './linear-issue-view-storage'
 import type { GitHubAssignableUser } from '../../../shared/github/pull-request-types'
 import type { GitHubWorkItem } from '../../../shared/github/work-item-types'
 import type { GitLabWorkItem } from '../../../shared/gitlab-types'
+import type { PaperclipIssue } from '../../../shared/paperclip-types'
 
 import type { LinearIssue } from '../../../shared/linear/issue-types'
 import type {
@@ -195,6 +196,13 @@ export default function TaskPage(): React.JSX.Element {
     jiraStatusReady,
     linearConnected,
     jiraConnected,
+    paperclipStatus,
+    paperclipIssues,
+    paperclipIssuesLoading,
+    paperclipError,
+    loadPaperclipIssues,
+    getPaperclipLaunchAdmission,
+    paperclipConnected,
     submitShortcutLabel,
     eligibleRepos
   } = useTaskPageStoreBindings()
@@ -243,6 +251,7 @@ export default function TaskPage(): React.JSX.Element {
     preflightStatusCurrent,
     preflightStatus,
     linearConnected,
+    paperclipConnected,
     updateSettings,
     pageData
   })
@@ -3093,6 +3102,86 @@ export default function TaskPage(): React.JSX.Element {
     jiraConnectOpen,
     setJiraConnectOpen
   }
+  const handleUsePaperclipIssue = async (issue: PaperclipIssue): Promise<void> => {
+    const connection = paperclipStatus.connection
+    if (!connection) {
+      return
+    }
+    const admission = await getPaperclipLaunchAdmission({
+      issueId: issue.id,
+      connectionId: connection.id,
+      companyId: connection.companyId,
+      projectId: connection.projectId
+    })
+    if (!admission.allowed) {
+      toast.error(
+        admission.reason === 'active_run'
+          ? translate(
+              'auto.components.TaskPage.paperclipActiveRun',
+              'Paperclip already has an active run for this issue.'
+            )
+          : admission.reason === 'claim_markers'
+            ? translate(
+                'auto.components.TaskPage.paperclipClaimMarkers',
+                'This Paperclip issue still has active claim markers.'
+              )
+            : translate(
+                'auto.components.TaskPage.paperclipUnknownRun',
+                'Paperclip run state could not be verified. Launch is blocked.'
+              )
+      )
+      return
+    }
+    if (
+      !window.confirm(
+        translate(
+          'auto.components.TaskPage.paperclipNonExclusiveConfirm',
+          'Orca cannot reserve this Paperclip issue. Start a non-exclusive workspace anyway?'
+        )
+      )
+    ) {
+      return
+    }
+    const issueUrl = `${connection.origin}/issues/${encodeURIComponent(issue.id)}`
+    openModal('new-workspace-composer', {
+      linkedWorkItem: {
+        provider: 'paperclip',
+        type: 'issue',
+        number: 0,
+        title: issue.title,
+        url: issueUrl,
+        paperclipIssueId: issue.id,
+        paperclipIdentifier: issue.identifier,
+        paperclipConnectionId: connection.id,
+        paperclipCompanyId: connection.companyId,
+        paperclipProjectId: connection.projectId
+      },
+      taskSourceContext: {
+        kind: 'task-source',
+        provider: 'paperclip',
+        projectId: primaryRepo?.id ?? connection.projectId,
+        hostId: 'local',
+        accountLabel: connection.projectName,
+        providerIdentity: {
+          provider: 'paperclip',
+          connectionId: connection.id,
+          companyId: connection.companyId,
+          projectId: connection.projectId
+        }
+      },
+      prefilledName: `${issue.identifier}-${issue.title}`,
+      ...(primaryRepo ? { initialRepoId: primaryRepo.id } : {}),
+      telemetrySource: 'sidebar'
+    })
+  }
+  const paperclipList = {
+    connected: paperclipConnected,
+    issues: paperclipIssues,
+    loading: paperclipIssuesLoading,
+    error: paperclipError,
+    onLoad: loadPaperclipIssues,
+    onUse: (issue: PaperclipIssue) => void handleUsePaperclipIssue(issue)
+  }
 
   return (
     <TaskPageLayout
@@ -3116,6 +3205,7 @@ export default function TaskPage(): React.JSX.Element {
       primaryRepo={primaryRepo}
       gitlabList={gitlabList}
       jiraList={jiraList}
+      paperclipList={paperclipList}
       linearViews={linearViews}
       newGithubIssue={newGithubIssue}
       newLinearProject={newLinearProject}

--- a/src/renderer/src/components/automations/automation-source-display.ts
+++ b/src/renderer/src/components/automations/automation-source-display.ts
@@ -41,6 +41,8 @@ function getProviderLabel(provider: TaskSourceContext['provider']): string {
       return 'Linear'
     case 'jira':
       return 'Jira'
+    case 'paperclip':
+      return 'Paperclip'
   }
 }
 
@@ -58,6 +60,8 @@ function getSourceIdentityLabel(sourceContext: TaskSourceContext): string | null
         return identity.workspaceName ?? identity.workspaceId ?? null
       case 'jira':
         return identity.siteUrl ?? identity.siteId ?? null
+      case 'paperclip':
+        return identity.projectId ?? identity.companyId ?? null
     }
   }
   return sourceContext.accountLabel ?? sourceContext.repoId ?? null

--- a/src/renderer/src/components/automations/automation-target-availability.ts
+++ b/src/renderer/src/components/automations/automation-target-availability.ts
@@ -11,6 +11,7 @@ import {
 import type { AutomationHostTarget } from './automation-host-client'
 import type { SshConnectionState } from '../../../../shared/ssh-types'
 import type { TaskSourceContext } from '../../../../shared/task-source-context'
+import { getTaskProviderDisplayName } from '@/components/task-provider-display-name'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
 import type { ProjectHostSetup } from '../../../../shared/project-types'
 import type { Repo } from '../../../../shared/repo-types'
@@ -198,7 +199,7 @@ function getAutomationSourceAvailability(
   if (!availability) {
     return null
   }
-  const providerLabel = getAutomationSourceProviderLabel(sourceContext.provider)
+  const providerLabel = getTaskProviderDisplayName(sourceContext.provider)
   switch (availability.reason) {
     case undefined:
       break
@@ -250,19 +251,6 @@ function getAutomationSourceAvailability(
     )
   }
   return null
-}
-
-function getAutomationSourceProviderLabel(provider: TaskSourceContext['provider']): string {
-  switch (provider) {
-    case 'github':
-      return 'GitHub'
-    case 'gitlab':
-      return 'GitLab'
-    case 'linear':
-      return 'Linear'
-    case 'jira':
-      return 'Jira'
-  }
 }
 
 export function getRuntimeAutomationAvailability(

--- a/src/renderer/src/components/settings/IntegrationsPane.tsx
+++ b/src/renderer/src/components/settings/IntegrationsPane.tsx
@@ -6,6 +6,7 @@ import {
   GitLabIntegrationCard
 } from './source-control-integration-cards'
 import { JiraIntegrationCard, LinearIntegrationCard } from './task-tracker-integration-cards'
+import { PaperclipIntegrationCard } from './paperclip-integration-card'
 import { useIntegrationProviderStatusRefresh } from './use-integration-provider-status-refresh'
 import { translate } from '@/i18n/i18n'
 export { getIntegrationsPaneSearchEntries } from './integrations-search'
@@ -51,6 +52,7 @@ export function IntegrationsPane(): React.JSX.Element {
         <div className="space-y-3">
           <LinearIntegrationCard />
           <JiraIntegrationCard />
+          <PaperclipIntegrationCard />
         </div>
       </section>
     </div>

--- a/src/renderer/src/components/settings/TasksPane.test.tsx
+++ b/src/renderer/src/components/settings/TasksPane.test.tsx
@@ -137,7 +137,8 @@ describe('TasksPane', () => {
         skillChecking: false,
         visible: true
       },
-      jira: { connected: false, checking: false, visible: false }
+      jira: { connected: false, checking: false, visible: false },
+      paperclip: { connected: false, checking: false, visible: false }
     }
   })
 

--- a/src/renderer/src/components/settings/TasksPane.tsx
+++ b/src/renderer/src/components/settings/TasksPane.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Github, Gitlab } from 'lucide-react'
+import { Github, Gitlab, Paperclip } from 'lucide-react'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { TaskProvider } from '../../../../shared/task-providers'
 import {
@@ -22,7 +22,8 @@ import {
 } from './task-source-setup-state'
 import {
   JIRA_INTEGRATION_SECTION_ID,
-  LINEAR_INTEGRATION_SECTION_ID
+  LINEAR_INTEGRATION_SECTION_ID,
+  PAPERCLIP_INTEGRATION_SECTION_ID
 } from './task-provider-integration-section-ids'
 import { getTasksPaneSearchKeywords } from './tasks-search'
 import { useIntegrationProviderStatusRefresh } from './use-integration-provider-status-refresh'
@@ -89,6 +90,18 @@ const PROVIDER_META: Record<
       )
     },
     Icon: ({ className }) => <JiraIcon className={className} />
+  },
+  paperclip: {
+    get label() {
+      return translate('auto.components.settings.TasksPane.paperclip', 'Paperclip')
+    },
+    get description() {
+      return translate(
+        'auto.components.settings.TasksPane.paperclipDescription',
+        'Connect a Paperclip project and browse its issues in Tasks.'
+      )
+    },
+    Icon: ({ className }) => <Paperclip className={className} />
   }
 }
 
@@ -227,6 +240,17 @@ export function TasksPane({ settings, updateSettings }: TasksPaneProps): React.J
                     onConnected={() => void checkJiraConnection()}
                     onOpenIntegrations={() => openIntegrations(JIRA_INTEGRATION_SECTION_ID)}
                   />
+                ) : provider === 'paperclip' ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => openIntegrations(PAPERCLIP_INTEGRATION_SECTION_ID)}
+                  >
+                    {translate(
+                      'auto.components.settings.TasksPane.paperclipSetup',
+                      'Open Paperclip integration'
+                    )}
+                  </Button>
                 ) : (
                   <CodeHostSetupSteps
                     providerLabel={meta.label}

--- a/src/renderer/src/components/settings/paperclip-integration-card.tsx
+++ b/src/renderer/src/components/settings/paperclip-integration-card.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react'
+import { CheckCircle2, LoaderCircle, Paperclip, Unlink } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useAppStore } from '@/store'
+import { IntegrationCardDetails, IntegrationCardShell } from './integration-card-shell'
+import { PAPERCLIP_INTEGRATION_SECTION_ID } from './task-provider-integration-section-ids'
+import { translate } from '@/i18n/i18n'
+
+export function PaperclipIntegrationCard(): React.JSX.Element {
+  const status = useAppStore((state) => state.paperclipStatus)
+  const checked = useAppStore((state) => state.paperclipStatusChecked)
+  const connect = useAppStore((state) => state.connectLocalPaperclip)
+  const disconnect = useAppStore((state) => state.disconnectPaperclip)
+  const testConnection = useAppStore((state) => state.testPaperclipConnection)
+  const [origin, setOrigin] = useState('http://127.0.0.1:3100')
+  const [companyId, setCompanyId] = useState('')
+  const [projectId, setProjectId] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const connection = status.connection
+
+  const handleConnect = async (): Promise<void> => {
+    setBusy(true)
+    setMessage(null)
+    const result = await connect({ origin, companyId, projectId })
+    setBusy(false)
+    setMessage(result.ok ? 'Connected.' : result.error)
+  }
+
+  const handleTest = async (): Promise<void> => {
+    setBusy(true)
+    const result = await testConnection()
+    setBusy(false)
+    setMessage(result.ok ? 'Connection verified.' : result.error)
+  }
+
+  return (
+    <IntegrationCardShell
+      settingsSectionId={PAPERCLIP_INTEGRATION_SECTION_ID}
+      icon={<Paperclip className="size-5" />}
+      name="Paperclip"
+      description={
+        connection
+          ? `${connection.companyName} · ${connection.projectName}`
+          : translate(
+              'auto.components.settings.paperclip.description',
+              'Browse Paperclip issues and start linked Orca workspaces.'
+            )
+      }
+      checking={!checked}
+      statusTone={connection ? 'connected' : 'attention'}
+      statusLabel={connection ? 'Connected' : 'Not connected'}
+    >
+      <IntegrationCardDetails>
+        {connection ? (
+          <div className="space-y-3">
+            <div className="text-xs text-muted-foreground">
+              <p>{connection.origin}</p>
+              <p>
+                {connection.companyName} · {connection.projectName}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" disabled={busy} onClick={() => void handleTest()}>
+                {busy ? <LoaderCircle className="mr-1.5 size-3.5 animate-spin" /> : null}
+                {translate('auto.components.settings.paperclip.test', 'Test')}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => void disconnect()}>
+                <Unlink className="mr-1.5 size-3.5" />
+                {translate('auto.components.settings.paperclip.disconnect', 'Disconnect')}
+              </Button>
+            </div>
+          </div>
+        ) : checked ? (
+          <div className="space-y-3">
+            <p className="text-xs text-muted-foreground">
+              {translate(
+                'auto.components.settings.paperclip.localOnly',
+                'Initial support is limited to Paperclip’s local-trusted loopback server. Authenticated and remote-only servers stay disabled so credentials never cross renderer or runtime boundaries.'
+              )}
+            </p>
+            <div className="grid gap-2 sm:grid-cols-3">
+              <Input
+                aria-label={translate(
+                  'auto.components.settings.paperclip.origin',
+                  'Paperclip origin'
+                )}
+                value={origin}
+                onChange={(e) => setOrigin(e.target.value)}
+              />
+              <Input
+                aria-label={translate(
+                  'auto.components.settings.paperclip.companyId',
+                  'Paperclip company ID'
+                )}
+                placeholder={translate(
+                  'auto.components.settings.paperclip.companyIdPlaceholder',
+                  'Company ID'
+                )}
+                value={companyId}
+                onChange={(e) => setCompanyId(e.target.value)}
+              />
+              <Input
+                aria-label={translate(
+                  'auto.components.settings.paperclip.projectId',
+                  'Paperclip project ID'
+                )}
+                placeholder={translate(
+                  'auto.components.settings.paperclip.projectIdPlaceholder',
+                  'Project ID'
+                )}
+                value={projectId}
+                onChange={(e) => setProjectId(e.target.value)}
+              />
+            </div>
+            <Button
+              size="sm"
+              disabled={busy || !companyId.trim() || !projectId.trim()}
+              onClick={() => void handleConnect()}
+            >
+              {busy ? <LoaderCircle className="mr-1.5 size-3.5 animate-spin" /> : null}
+              {translate('auto.components.settings.paperclip.connect', 'Connect local Paperclip')}
+            </Button>
+          </div>
+        ) : null}
+        {message ? (
+          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            {message.endsWith('verified.') || message === 'Connected.' ? (
+              <CheckCircle2 className="size-3.5 text-status-success" />
+            ) : null}
+            {message}
+          </p>
+        ) : null}
+      </IntegrationCardDetails>
+    </IntegrationCardShell>
+  )
+}

--- a/src/renderer/src/components/settings/task-provider-integration-section-ids.ts
+++ b/src/renderer/src/components/settings/task-provider-integration-section-ids.ts
@@ -1,2 +1,3 @@
 export const LINEAR_INTEGRATION_SECTION_ID = 'integrations-linear'
 export const JIRA_INTEGRATION_SECTION_ID = 'integrations-jira'
+export const PAPERCLIP_INTEGRATION_SECTION_ID = 'integrations-paperclip'

--- a/src/renderer/src/components/settings/task-source-setup-state.test.ts
+++ b/src/renderer/src/components/settings/task-source-setup-state.test.ts
@@ -11,7 +11,7 @@ import {
   type TaskProviderReadiness
 } from './task-source-setup-state'
 
-const ORDER: readonly TaskProvider[] = ['github', 'gitlab', 'linear', 'jira']
+const ORDER: readonly TaskProvider[] = ['github', 'gitlab', 'linear', 'jira', 'paperclip']
 
 function buildReadiness(
   overrides: Partial<Record<TaskProvider, Partial<TaskProviderReadiness>>> = {}
@@ -26,7 +26,8 @@ function buildReadiness(
       skillChecking: false,
       visible: true
     },
-    jira: { connected: true, checking: false, visible: true }
+    jira: { connected: true, checking: false, visible: true },
+    paperclip: { connected: true, checking: false, visible: true }
   }
   for (const provider of ORDER) {
     Object.assign(base[provider], overrides[provider])

--- a/src/renderer/src/components/settings/use-integration-provider-status-refresh.ts
+++ b/src/renderer/src/components/settings/use-integration-provider-status-refresh.ts
@@ -11,8 +11,10 @@ export function useIntegrationProviderStatusRefresh(): void {
   const linearStatusContextKey = useAppStore((s) => s.linearStatusContextKey)
   const jiraStatusChecked = useAppStore((s) => s.jiraStatusChecked)
   const jiraStatusContextKey = useAppStore((s) => s.jiraStatusContextKey)
+  const paperclipStatusChecked = useAppStore((s) => s.paperclipStatusChecked)
   const checkLinearConnection = useAppStore((s) => s.checkLinearConnection)
   const checkJiraConnection = useAppStore((s) => s.checkJiraConnection)
+  const checkPaperclipConnection = useAppStore((s) => s.checkPaperclipConnection)
   const refreshPreflightStatus = useAppStore((s) => s.refreshPreflightStatus)
   const expectedPreflightContextKey = useAppStore((s) =>
     localPreflightContextKey(getLocalPreflightContext(s))
@@ -29,18 +31,23 @@ export function useIntegrationProviderStatusRefresh(): void {
     if (!jiraStatusCurrent || !jiraStatusChecked) {
       void checkJiraConnection()
     }
+    if (!paperclipStatusChecked) {
+      void checkPaperclipConnection()
+    }
     if (!preflightStatusCurrent || !preflightStatusChecked) {
       void refreshPreflightStatus()
     }
   }, [
     checkJiraConnection,
     checkLinearConnection,
+    checkPaperclipConnection,
     jiraStatusChecked,
     jiraStatusCurrent,
     jiraStatusContextKey,
     linearStatusChecked,
     linearStatusCurrent,
     linearStatusContextKey,
+    paperclipStatusChecked,
     expectedPreflightContextKey,
     preflightStatusChecked,
     preflightStatusContextKey,

--- a/src/renderer/src/components/settings/use-task-source-provider-readiness.test.tsx
+++ b/src/renderer/src/components/settings/use-task-source-provider-readiness.test.tsx
@@ -45,7 +45,7 @@ vi.mock('@/hooks/useInstalledAgentSkills', () => ({
   useInstalledAgentSkillNames: () => mocks.skill
 }))
 
-const ALL_PROVIDERS: readonly TaskProvider[] = ['github', 'gitlab', 'linear', 'jira']
+const ALL_PROVIDERS: readonly TaskProvider[] = ['github', 'gitlab', 'linear', 'jira', 'paperclip']
 
 let root: Root | null = null
 let container: HTMLDivElement | null = null

--- a/src/renderer/src/components/settings/use-task-source-provider-readiness.ts
+++ b/src/renderer/src/components/settings/use-task-source-provider-readiness.ts
@@ -27,6 +27,8 @@ export function useTaskSourceProviderReadiness(
   const jiraStatus = useAppStore((s) => s.jiraStatus)
   const jiraStatusChecked = useAppStore((s) => s.jiraStatusChecked)
   const jiraStatusContextKey = useAppStore((s) => s.jiraStatusContextKey)
+  const paperclipStatus = useAppStore((s) => s.paperclipStatus) ?? { connected: false }
+  const paperclipStatusChecked = useAppStore((s) => s.paperclipStatusChecked)
   const linearConnected = useLinearProviderConnected()
   const linearStatusChecked = useAppStore((s) => s.linearStatusChecked)
   const linearStatusContextKey = useAppStore((s) => s.linearStatusContextKey)
@@ -89,6 +91,11 @@ export function useTaskSourceProviderReadiness(
         connected: jiraConnected,
         checking: jiraChecking,
         visible: visible.has('jira')
+      },
+      paperclip: {
+        connected: paperclipStatus.connected,
+        checking: !paperclipStatusChecked,
+        visible: visible.has('paperclip')
       }
     }
   }, [
@@ -101,6 +108,8 @@ export function useTaskSourceProviderReadiness(
     linearSkillInstalled,
     linearSkillLoading,
     linearSkillSettled,
+    paperclipStatus.connected,
+    paperclipStatusChecked,
     reviewChecking,
     reviewUnavailable,
     visibleProvidersKey

--- a/src/renderer/src/components/task-page-list-chrome-visibility.ts
+++ b/src/renderer/src/components/task-page-list-chrome-visibility.ts
@@ -30,5 +30,7 @@ export function shouldHideTaskPageListChrome({
       return hasJiraDetail
     case 'linear':
       return hasLinearIssueDetail || hasLinearProjectContext || hasLinearViewContext
+    case 'paperclip':
+      return false
   }
 }

--- a/src/renderer/src/components/task-page-localized-options.tsx
+++ b/src/renderer/src/components/task-page-localized-options.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Github, Gitlab, LayoutGrid, List } from 'lucide-react'
+import { Github, Gitlab, LayoutGrid, List, Paperclip } from 'lucide-react'
 
 import { JiraIcon } from '@/components/icons/JiraIcon'
 import { createLocalizedCatalog } from '@/i18n/localized-catalog'
@@ -131,6 +131,11 @@ export const getSourceOptions = createLocalizedCatalog((): SourceOption[] => [
     id: 'jira',
     label: translate('auto.components.TaskPage.9cd11ba218', 'Jira'),
     Icon: ({ className }) => <JiraIcon className={className} />
+  },
+  {
+    id: 'paperclip',
+    label: translate('auto.components.TaskPage.paperclip', 'Paperclip'),
+    Icon: ({ className }) => <Paperclip className={className} />
   }
 ])
 

--- a/src/renderer/src/components/task-page/hooks/use-task-page-store-bindings.ts
+++ b/src/renderer/src/components/task-page/hooks/use-task-page-store-bindings.ts
@@ -72,6 +72,13 @@ export function useTaskPageStoreBindings() {
   const searchJiraIssues = useAppStore((s) => s.searchJiraIssues)
   const listJiraIssues = useAppStore((s) => s.listJiraIssues)
   const checkJiraConnection = useAppStore((s) => s.checkJiraConnection)
+  const paperclipStatus = useAppStore((s) => s.paperclipStatus)
+  const paperclipStatusChecked = useAppStore((s) => s.paperclipStatusChecked)
+  const paperclipIssues = useAppStore((s) => s.paperclipIssues)
+  const paperclipIssuesLoading = useAppStore((s) => s.paperclipIssuesLoading)
+  const paperclipError = useAppStore((s) => s.paperclipError)
+  const loadPaperclipIssues = useAppStore((s) => s.loadPaperclipIssues)
+  const getPaperclipLaunchAdmission = useAppStore((s) => s.getPaperclipLaunchAdmission)
   const providerRuntimeContextKey = getProviderRuntimeContextKey(settings)
   const providerRuntimeContextKeyRef = useRef(providerRuntimeContextKey)
   useLayoutEffect(() => {
@@ -84,6 +91,7 @@ export function useTaskPageStoreBindings() {
   const jiraStatusReady = jiraStatusCurrent && jiraStatusChecked
   const linearConnected = linearStatusCurrent && linearStatus.connected
   const jiraConnected = jiraStatusCurrent && jiraStatus.connected
+  const paperclipConnected = paperclipStatusChecked && paperclipStatus.connected
   const submitShortcutLabel = getScreenSubmitShortcutLabel()
   const eligibleRepos = useMemo(() => getTaskEligibleRepos(repos), [repos])
 
@@ -147,6 +155,13 @@ export function useTaskPageStoreBindings() {
     searchJiraIssues,
     listJiraIssues,
     checkJiraConnection,
+    paperclipStatus,
+    paperclipStatusChecked,
+    paperclipIssues,
+    paperclipIssuesLoading,
+    paperclipError,
+    loadPaperclipIssues,
+    getPaperclipLaunchAdmission,
     providerRuntimeContextKey,
     providerRuntimeContextKeyRef,
     linearStatusCurrent,
@@ -156,6 +171,7 @@ export function useTaskPageStoreBindings() {
     jiraStatusReady,
     linearConnected,
     jiraConnected,
+    paperclipConnected,
     submitShortcutLabel,
     eligibleRepos
   }

--- a/src/renderer/src/components/task-page/hooks/use-task-page-visible-sources.ts
+++ b/src/renderer/src/components/task-page/hooks/use-task-page-visible-sources.ts
@@ -30,6 +30,7 @@ export function useTaskPageVisibleSources({
   preflightStatusCurrent,
   preflightStatus,
   linearConnected,
+  paperclipConnected,
   updateSettings,
   pageData
 }: {
@@ -37,6 +38,7 @@ export function useTaskPageVisibleSources({
   preflightStatusCurrent: boolean
   preflightStatus: PreflightStatus | null
   linearConnected: boolean
+  paperclipConnected: boolean
   updateSettings: (updates: Partial<GlobalSettings>) => Promise<void>
   pageData: { taskSource?: TaskProvider }
 }) {
@@ -51,13 +53,15 @@ export function useTaskPageVisibleSources({
         preferredVisibleTaskProviders,
         {
           gitlabInstalled: preflightStatusCurrent && preflightStatus?.glab?.installed === true,
-          linearConnected: linearConnected === true
+          linearConnected: linearConnected === true,
+          paperclipConnected: paperclipConnected === true
         },
         defaultTaskSource
       ),
     [
       defaultTaskSource,
       linearConnected,
+      paperclipConnected,
       preferredVisibleTaskProviders,
       preflightStatusCurrent,
       preflightStatus?.glab?.installed

--- a/src/renderer/src/components/task-page/paperclip/paperclip-issue-list.tsx
+++ b/src/renderer/src/components/task-page/paperclip/paperclip-issue-list.tsx
@@ -1,0 +1,78 @@
+import { useEffect } from 'react'
+import { LoaderCircle, Paperclip } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { PaperclipIssue } from '../../../../../shared/paperclip-types'
+import { translate } from '@/i18n/i18n'
+
+export function PaperclipIssueList({
+  connected,
+  issues,
+  loading,
+  error,
+  onLoad,
+  onUse
+}: {
+  connected: boolean
+  issues: readonly PaperclipIssue[]
+  loading: boolean
+  error: string | null
+  onLoad: () => void
+  onUse: (issue: PaperclipIssue) => void
+}): React.JSX.Element {
+  useEffect(() => {
+    if (connected) {
+      onLoad()
+    }
+  }, [connected, onLoad])
+
+  if (!connected) {
+    return (
+      <div className="m-auto max-w-md rounded-lg border border-border/60 bg-muted/20 p-6 text-center">
+        <Paperclip className="mx-auto mb-3 size-6 text-muted-foreground" />
+        <p className="text-sm font-medium">
+          {translate(
+            'auto.components.paperclipIssueList.connect',
+            'Connect Paperclip in Settings → Integrations.'
+          )}
+        </p>
+      </div>
+    )
+  }
+  if (loading && issues.length === 0) {
+    return <LoaderCircle className="m-auto size-5 animate-spin text-muted-foreground" />
+  }
+  return (
+    <div className="scrollbar-sleek mt-3 min-h-0 flex-1 overflow-auto rounded-md border border-border/50">
+      {error ? (
+        <p className="border-b border-border/50 p-3 text-xs text-destructive">{error}</p>
+      ) : null}
+      {issues.map((issue) => (
+        <article
+          key={issue.id}
+          className="flex items-start gap-3 border-b border-border/40 p-3 last:border-b-0"
+        >
+          <div className="min-w-0 flex-1">
+            <p className="text-xs text-muted-foreground">
+              {issue.identifier} · {issue.status}
+            </p>
+            <h3 className="truncate text-sm font-medium">{issue.title}</h3>
+            {issue.description ? (
+              <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{issue.description}</p>
+            ) : null}
+          </div>
+          <Button size="sm" variant="outline" onClick={() => onUse(issue)}>
+            {translate('auto.components.paperclipIssueList.use', 'Use in workspace')}
+          </Button>
+        </article>
+      ))}
+      {!loading && issues.length === 0 ? (
+        <p className="p-6 text-center text-sm text-muted-foreground">
+          {translate(
+            'auto.components.paperclipIssueList.empty',
+            'No issues in this Paperclip project.'
+          )}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/task-page/task-page-layout.tsx
+++ b/src/renderer/src/components/task-page/task-page-layout.tsx
@@ -43,6 +43,8 @@ import {
   JiraIssueListHost,
   type JiraIssueListHostProps
 } from '@/components/task-page/jira/jira-issue-list-host'
+import { PaperclipIssueList } from '@/components/task-page/paperclip/paperclip-issue-list'
+import type { PaperclipIssue } from '../../../../shared/paperclip-types'
 import {
   NewGithubIssueDialog,
   type NewGithubIssueDialogProps
@@ -92,6 +94,7 @@ export function TaskPageLayout({
   primaryRepo,
   gitlabList,
   jiraList,
+  paperclipList,
   linearViews,
   newGithubIssue,
   newLinearProject,
@@ -119,6 +122,14 @@ export function TaskPageLayout({
   primaryRepo: Repo | null
   gitlabList: GitlabWorkItemListProps
   jiraList: JiraIssueListHostProps
+  paperclipList: {
+    connected: boolean
+    issues: readonly PaperclipIssue[]
+    loading: boolean
+    error: string | null
+    onLoad: () => void
+    onUse: (issue: PaperclipIssue) => void
+  }
   linearViews: LinearViewsHostProps
   newGithubIssue: NewGithubIssueDialogProps
   newLinearProject: NewLinearProjectDialogProps
@@ -170,6 +181,8 @@ export function TaskPageLayout({
             <JiraIssueListHost {...jiraList} />
           ) : taskSource === 'linear' ? (
             <LinearViewsHost {...linearViews} />
+          ) : taskSource === 'paperclip' ? (
+            <PaperclipIssueList {...paperclipList} />
           ) : null}
         </div>
       </div>

--- a/src/renderer/src/components/task-provider-display-name.ts
+++ b/src/renderer/src/components/task-provider-display-name.ts
@@ -1,0 +1,16 @@
+import type { TaskProvider } from '../../../shared/task-providers'
+
+export function getTaskProviderDisplayName(provider: TaskProvider): string {
+  switch (provider) {
+    case 'github':
+      return 'GitHub'
+    case 'gitlab':
+      return 'GitLab'
+    case 'linear':
+      return 'Linear'
+    case 'jira':
+      return 'Jira'
+    case 'paperclip':
+      return 'Paperclip'
+  }
+}

--- a/src/renderer/src/components/task-provider-identity-label.ts
+++ b/src/renderer/src/components/task-provider-identity-label.ts
@@ -1,0 +1,23 @@
+import type { TaskProviderIdentity } from '../../../shared/task-provider-identity'
+
+export function getTaskProviderIdentityLabel(
+  identity: TaskProviderIdentity | null | undefined
+): string | null {
+  if (!identity) {
+    return null
+  }
+  switch (identity.provider) {
+    case 'github':
+      return `${identity.owner}/${identity.repo}`
+    case 'gitlab':
+      return identity.namespace && identity.project
+        ? `${identity.namespace}/${identity.project}`
+        : (identity.projectId ?? null)
+    case 'linear':
+      return identity.workspaceName ?? identity.workspaceId ?? null
+    case 'jira':
+      return identity.siteUrl ?? identity.siteId ?? null
+    case 'paperclip':
+      return identity.projectId ?? identity.companyId ?? null
+  }
+}

--- a/src/renderer/src/components/task-source-context-summary.ts
+++ b/src/renderer/src/components/task-source-context-summary.ts
@@ -4,7 +4,8 @@ import type { ExecutionHostScope } from '../../../shared/execution-host'
 import type { ExecutionHostHealth } from '../../../shared/execution-host-registry'
 import type { SshConnectionStatus } from '../../../shared/ssh-types'
 import type { TaskProvider } from '../../../shared/task-providers'
-import type { TaskProviderIdentity, TaskSourceContext } from '../../../shared/task-source-context'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import { getTaskProviderIdentityLabel } from './task-provider-identity-label'
 
 export type TaskSourceContextSummary = {
   label: string
@@ -45,6 +46,7 @@ export function getTaskSourceContextSummary(args: {
   selectedRepoCount?: number
   linearWorkspaceName?: string | null
   jiraSiteName?: string | null
+  paperclipProjectName?: string | null
 }): TaskSourceContextSummary {
   switch (args.provider) {
     case 'github':
@@ -60,6 +62,13 @@ export function getTaskSourceContextSummary(args: {
     case 'jira':
       return getAccountBackedTaskSourceSummary(args.providerLabel, {
         accountLabel: args.jiraSiteName,
+        accountHostId: args.accountHostId,
+        hostLabelById: args.hostLabelById,
+        hostAvailability: args.hostAvailability
+      })
+    case 'paperclip':
+      return getAccountBackedTaskSourceSummary(args.providerLabel, {
+        accountLabel: args.paperclipProjectName,
         accountHostId: args.accountHostId,
         hostLabelById: args.hostLabelById,
         hostAvailability: args.hostAvailability
@@ -117,7 +126,7 @@ function getRepoBackedTaskSourceSummary(args: {
   const unavailableHosts = getUnavailableHosts(args.hostAvailability ?? [], args.hostLabelById)
   const availabilityLabel = getAvailabilityLabel(unavailableHosts)
   const identityLabels = uniqueLabels(
-    contexts.map((context) => getProviderIdentityLabel(context.providerIdentity))
+    contexts.map((context) => getTaskProviderIdentityLabel(context.providerIdentity))
   )
   const accountLabels = uniqueLabels(contexts.map((context) => context.accountLabel))
   const repoCount = args.selectedRepoCount ?? contexts.length
@@ -178,26 +187,6 @@ function getAccountBackedTaskSourceSummary(
       .filter((part): part is string => Boolean(part))
       .join(' · '),
     title: titleParts.join(' · ')
-  }
-}
-
-function getProviderIdentityLabel(
-  identity: TaskProviderIdentity | null | undefined
-): string | null {
-  if (!identity) {
-    return null
-  }
-  switch (identity.provider) {
-    case 'github':
-      return `${identity.owner}/${identity.repo}`
-    case 'gitlab':
-      return identity.namespace && identity.project
-        ? `${identity.namespace}/${identity.project}`
-        : (identity.projectId ?? null)
-    case 'linear':
-      return identity.workspaceName ?? identity.workspaceId ?? null
-    case 'jira':
-      return identity.siteUrl ?? identity.siteId ?? null
   }
 }
 

--- a/src/renderer/src/hooks/composer-state/composer-submit-orchestration.ts
+++ b/src/renderer/src/hooks/composer-state/composer-submit-orchestration.ts
@@ -104,6 +104,8 @@ export function useComposerSubmitOrchestration(
     prepareFullSubmit: fullSubmitPreparation.prepareFullSubmit,
     resolvedInitialWorkspaceStatus: target.initialTargetState.resolvedInitialWorkspaceStatus,
     selectedRepoIsGit: target.runtimeTargetSelection.selectedRepoIsGit,
+    selectedRepoIsRemote: target.runtimeTargetSelection.selectedRepoIsRemote,
+    selectedRepoSettings: target.runtimeTargetSelection.selectedRepoSettings,
     setSidebarOpen: target.composerTargetStore.setSidebarOpen,
     sparseEnabled: target.asyncComposerState.sparseEnabled,
     taskSourceContext: target.sourceContextState.taskSourceContext,

--- a/src/renderer/src/hooks/composer-state/derived-model.ts
+++ b/src/renderer/src/hooks/composer-state/derived-model.ts
@@ -16,7 +16,7 @@ export type ComposerDerivedModel = {
   currentYamlHooks: OrcaHooks | null
   setupConfig: SetupConfig | null
   setupPolicy: SetupRunPolicy
-  linkedWorkItemProvider: 'github' | 'gitlab' | 'linear' | 'jira' | null
+  linkedWorkItemProvider: 'github' | 'gitlab' | 'linear' | 'jira' | 'paperclip' | null
   willApplyIssueCommandAsPrompt: boolean
   shouldWaitForIssueAutomationCheck: boolean
   requiresExplicitSetupChoice: boolean

--- a/src/renderer/src/hooks/composer-state/folder-submit-orchestration.ts
+++ b/src/renderer/src/hooks/composer-state/folder-submit-orchestration.ts
@@ -47,6 +47,7 @@ import {
   getWorkspaceCreateErrorToastMessage
 } from '@/lib/workspace-create-error-format'
 import { toast } from 'sonner'
+import { assertPaperclipSubmitAdmission } from './paperclip-submit-admission'
 
 export function useFolderSubmitOrchestration(input: FolderSubmitOrchestrationInput) {
   const {
@@ -111,6 +112,10 @@ export function useFolderSubmitOrchestration(input: FolderSubmitOrchestrationInp
           agent && submitLinkedWorkItem
             ? resolveFolderWorkspaceLaunchDraft(submitLinkedWorkItem, note)
             : null
+        await assertPaperclipSubmitAdmission(
+          submitLinkedWorkItem,
+          !folderTargetIsRemote && !folderTargetRuntimeEnvironmentId
+        )
         const folderWorkspaceCreated = await submitFolderWorkspaceCreate({
           projectGroup: selectedProjectGroup,
           name: smartGitHubMetadata?.workspaceName ?? name,

--- a/src/renderer/src/hooks/composer-state/full-creation-execution.test.ts
+++ b/src/renderer/src/hooks/composer-state/full-creation-execution.test.ts
@@ -80,6 +80,8 @@ describe('useFullCreationExecution cancellation', () => {
         .mockResolvedValue(prepared),
       resolvedInitialWorkspaceStatus: undefined,
       selectedRepoIsGit: true,
+      selectedRepoIsRemote: false,
+      selectedRepoSettings: null,
       setSidebarOpen: vi.fn<FullCreationExecutionInput['setSidebarOpen']>(),
       sparseEnabled: false,
       taskSourceContext: null,

--- a/src/renderer/src/hooks/composer-state/full-creation-execution.ts
+++ b/src/renderer/src/hooks/composer-state/full-creation-execution.ts
@@ -18,6 +18,8 @@ export type FullCreationExecutionInput = Pick<
   | 'prepareFullSubmit'
   | 'resolvedInitialWorkspaceStatus'
   | 'selectedRepoIsGit'
+  | 'selectedRepoIsRemote'
+  | 'selectedRepoSettings'
   | 'setSidebarOpen'
   | 'sparseEnabled'
   | 'taskSourceContext'
@@ -35,6 +37,8 @@ import { createBrowserUuid } from '@/lib/browser-uuid'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { seedNativeChatAppliedSessionOptions } from '@/components/native-chat/native-chat-session-option-cache'
 import { queueWorkspaceActivationTerminalFocus } from '@/lib/workspace-activation-terminal-focus'
+import { assertPaperclipSubmitAdmission } from './paperclip-submit-admission'
+import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 
 export function useFullCreationExecution(input: FullCreationExecutionInput) {
   const {
@@ -54,6 +58,8 @@ export function useFullCreationExecution(input: FullCreationExecutionInput) {
     prepareFullSubmit,
     resolvedInitialWorkspaceStatus,
     selectedRepoIsGit,
+    selectedRepoIsRemote,
+    selectedRepoSettings,
     setSidebarOpen,
     sparseEnabled,
     taskSourceContext,
@@ -119,6 +125,11 @@ export function useFullCreationExecution(input: FullCreationExecutionInput) {
       if (isSubmissionCancelled()) {
         return
       }
+
+      await assertPaperclipSubmitAdmission(
+        submitLinkedWorkItem,
+        !selectedRepoIsRemote && getActiveRuntimeTarget(selectedRepoSettings).kind === 'local'
+      )
 
       const result = await createWorktree(
         repoId,
@@ -260,6 +271,8 @@ export function useFullCreationExecution(input: FullCreationExecutionInput) {
       prepareFullSubmit,
       resolvedInitialWorkspaceStatus,
       selectedRepoIsGit,
+      selectedRepoIsRemote,
+      selectedRepoSettings,
       setSidebarOpen,
       sparseEnabled,
       taskSourceContext,

--- a/src/renderer/src/hooks/composer-state/paperclip-submit-admission.test.ts
+++ b/src/renderer/src/hooks/composer-state/paperclip-submit-admission.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { assertPaperclipSubmitAdmission } from './paperclip-submit-admission'
+
+const getLaunchAdmission = vi.fn()
+const paperclipScope = {
+  paperclipIssueId: 'issue-1',
+  paperclipConnectionId: 'connection-1',
+  paperclipCompanyId: 'company-1',
+  paperclipProjectId: 'project-1'
+}
+
+beforeEach(() => {
+  getLaunchAdmission.mockReset()
+  Object.assign(window, { api: { paperclip: { getLaunchAdmission } } })
+})
+
+describe('Paperclip submit admission', () => {
+  it('does nothing for non-Paperclip work items', async () => {
+    await assertPaperclipSubmitAdmission({
+      provider: 'jira',
+      type: 'issue',
+      number: 1,
+      title: 'Jira',
+      url: 'https://jira.example/1'
+    })
+    expect(getLaunchAdmission).not.toHaveBeenCalled()
+  })
+
+  it('rejects Paperclip linkage before admission when the target runtime is not local', async () => {
+    await expect(
+      assertPaperclipSubmitAdmission(
+        {
+          provider: 'paperclip',
+          type: 'issue',
+          number: 0,
+          title: 'Paperclip',
+          url: 'http://127.0.0.1:3101/issues/1',
+          ...paperclipScope
+        },
+        false
+      )
+    ).rejects.toThrow('available only on the local Orca runtime')
+    expect(getLaunchAdmission).not.toHaveBeenCalled()
+  })
+
+  it('performs a fresh read and permits a clean Paperclip issue', async () => {
+    getLaunchAdmission.mockResolvedValue({ allowed: true, requiresNonExclusiveConfirmation: true })
+    await assertPaperclipSubmitAdmission({
+      provider: 'paperclip',
+      type: 'issue',
+      number: 0,
+      title: 'Paperclip',
+      url: 'http://127.0.0.1:3101/issues/1',
+      ...paperclipScope
+    })
+    expect(getLaunchAdmission).toHaveBeenCalledWith({
+      issueId: 'issue-1',
+      connectionId: 'connection-1',
+      companyId: 'company-1',
+      projectId: 'project-1'
+    })
+  })
+
+  it.each(['active_run', 'claim_markers', 'unknown_run_state'] as const)(
+    'fails closed for %s',
+    async (reason) => {
+      getLaunchAdmission.mockResolvedValue({ allowed: false, reason })
+      await expect(
+        assertPaperclipSubmitAdmission({
+          provider: 'paperclip',
+          type: 'issue',
+          number: 0,
+          title: 'Paperclip',
+          url: 'http://127.0.0.1:3101/issues/1',
+          ...paperclipScope
+        })
+      ).rejects.toThrow(/stopped/)
+    }
+  )
+})

--- a/src/renderer/src/hooks/composer-state/paperclip-submit-admission.ts
+++ b/src/renderer/src/hooks/composer-state/paperclip-submit-admission.ts
@@ -1,0 +1,36 @@
+import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
+
+export async function assertPaperclipSubmitAdmission(
+  linkedWorkItem: LinkedWorkItemSummary | null | undefined,
+  targetIsLocal = true
+): Promise<void> {
+  if (linkedWorkItem?.provider !== 'paperclip') {
+    return
+  }
+  if (!targetIsLocal) {
+    throw new Error('Paperclip-linked workspaces are available only on the local Orca runtime.')
+  }
+  const issueId = linkedWorkItem.paperclipIssueId?.trim()
+  const connectionId = linkedWorkItem.paperclipConnectionId?.trim()
+  const companyId = linkedWorkItem.paperclipCompanyId?.trim()
+  const projectId = linkedWorkItem.paperclipProjectId?.trim()
+  if (!issueId || !connectionId || !companyId || !projectId) {
+    throw new Error('The linked Paperclip scope is missing.')
+  }
+  const admission = await window.api.paperclip.getLaunchAdmission({
+    issueId,
+    connectionId,
+    companyId,
+    projectId
+  })
+  if (admission.allowed) {
+    return
+  }
+  if (admission.reason === 'active_run') {
+    throw new Error('Paperclip started an active run for this issue. Workspace creation stopped.')
+  }
+  if (admission.reason === 'claim_markers') {
+    throw new Error('Paperclip claim markers changed. Workspace creation stopped.')
+  }
+  throw new Error('Paperclip run state is unknown. Workspace creation stopped.')
+}

--- a/src/renderer/src/hooks/composer-state/quick-creation-execution.ts
+++ b/src/renderer/src/hooks/composer-state/quick-creation-execution.ts
@@ -43,6 +43,7 @@ import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { runBackgroundWorktreeCreation } from '@/lib/worktree-creation-flow'
 import { translate } from '@/i18n/i18n'
 import { resolveQuickCreateLinkedWorkItemPrompt } from '@/lib/linked-work-item-context'
+import { assertPaperclipSubmitAdmission } from './paperclip-submit-admission'
 import { buildQuickComposerStartup } from './quick-startup-plan'
 import { buildQuickCreationRequest } from './quick-creation-request'
 import type { PendingSmartGitHubSubmitResolution } from './source-selection-decisions'
@@ -191,6 +192,11 @@ export function useQuickCreationExecution(input: QuickCreationExecutionInput) {
           ...(selectedRecipe?.checkoutMode ? { checkoutMode: selectedRecipe.checkoutMode } : {})
         }
       }
+
+      await assertPaperclipSubmitAdmission(
+        submitLinkedWorkItem,
+        !selectedRepoIsRemote && getActiveRuntimeTarget(selectedRepoSettings).kind === 'local'
+      )
 
       const request = buildQuickCreationRequest({
         repoId,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2210,7 +2210,12 @@
         "linearModeHasWorktreeTooltip": "Linear tickets linked to an Orca workspace",
         "linearEmptyHasWorktree": "No Linear tickets are linked to an Orca workspace yet. Start work from a Linear issue to see it here.",
         "linearOpenAttachedWorkspace": "Open workspace attached to {{value0}}",
-        "linearWorktreesColumn": "Workspaces"
+        "linearWorktreesColumn": "Workspaces",
+        "paperclip": "Paperclip",
+        "paperclipActiveRun": "Paperclip already has an active run for this issue.",
+        "paperclipClaimMarkers": "This Paperclip issue still has active claim markers.",
+        "paperclipUnknownRun": "Paperclip run state could not be verified. Launch is blocked.",
+        "paperclipNonExclusiveConfirm": "Orca cannot reserve this Paperclip issue. Start a non-exclusive workspace anyway?"
       },
       "Terminal": {
         "73768427cf": "Close",
@@ -8335,7 +8340,10 @@
           "integrationsHint": "Credentials for all providers also live under",
           "integrationsLink": "Integrations",
           "skillHint": ". After Linear is connected, usage examples stay under Settings → Linear.",
-          "incompleteBannerBodyWithLinear": "Hide providers you do not use, or expand a card and finish its steps. For Linear: API access, the agent skill, and Show in Tasks."
+          "incompleteBannerBodyWithLinear": "Hide providers you do not use, or expand a card and finish its steps. For Linear: API access, the agent skill, and Show in Tasks.",
+          "paperclip": "Paperclip",
+          "paperclipDescription": "Connect a Paperclip project and browse its issues in Tasks.",
+          "paperclipSetup": "Open Paperclip integration"
         },
         "TerminalAppearanceSection": {
           "a14a427ae4": "Thickness of the pane divider line.",
@@ -11506,6 +11514,18 @@
         },
         "NativeChatSupportedAgents": {
           "label": "Supported agents:"
+        },
+        "paperclip": {
+          "description": "Browse Paperclip issues and start linked Orca workspaces.",
+          "test": "Test",
+          "disconnect": "Disconnect",
+          "localOnly": "Initial support is limited to Paperclip’s local-trusted loopback server. Authenticated and remote-only servers stay disabled so credentials never cross renderer or runtime boundaries.",
+          "origin": "Paperclip origin",
+          "companyId": "Paperclip company ID",
+          "companyIdPlaceholder": "Company ID",
+          "projectId": "Paperclip project ID",
+          "projectIdPlaceholder": "Project ID",
+          "connect": "Connect local Paperclip"
         }
       },
       "right": {
@@ -16426,6 +16446,11 @@
           "externalLinkConfirm": "Open link",
           "externalLinkCancel": "Cancel"
         }
+      },
+      "paperclipIssueList": {
+        "connect": "Connect Paperclip in Settings → Integrations.",
+        "use": "Use in workspace",
+        "empty": "No issues in this Paperclip project."
       }
     },
     "i18n": {

--- a/src/renderer/src/lib/pending-worktree-creation.ts
+++ b/src/renderer/src/lib/pending-worktree-creation.ts
@@ -138,10 +138,11 @@ export function findPendingLinkedWorkItemCreationId(
   pendingCreations: Readonly<Record<string, PendingWorktreeCreation>>,
   request: Pick<
     WorktreeCreationRequest,
-    'repoId' | 'linkedIssue' | 'linkedPR' | 'workspaceRunContext'
+    'repoId' | 'linkedIssue' | 'linkedPR' | 'linkedWorkItem' | 'workspaceRunContext'
   >
 ): string | null {
-  if (request.linkedIssue == null && request.linkedPR == null) {
+  const paperclip = request.linkedWorkItem?.provider === 'paperclip' ? request.linkedWorkItem : null
+  if (request.linkedIssue == null && request.linkedPR == null && !paperclip) {
     return null
   }
   const hostId = request.workspaceRunContext?.hostId ?? null
@@ -151,6 +152,13 @@ export function findPendingLinkedWorkItemCreationId(
       pending.repoId === request.repoId &&
       pending.linkedIssue === request.linkedIssue &&
       pending.linkedPR === request.linkedPR &&
+      (paperclip
+        ? pending.linkedWorkItem?.provider === 'paperclip' &&
+          pending.linkedWorkItem.paperclipIssueId === paperclip.paperclipIssueId &&
+          pending.linkedWorkItem.paperclipConnectionId === paperclip.paperclipConnectionId &&
+          pending.linkedWorkItem.paperclipCompanyId === paperclip.paperclipCompanyId &&
+          pending.linkedWorkItem.paperclipProjectId === paperclip.paperclipProjectId
+        : true) &&
       (pending.workspaceRunContext?.hostId ?? null) === hostId
     )
   })

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -13,6 +13,7 @@ import { createHostedReviewSlice } from './slices/hosted-review'
 import { createLinearSlice } from './slices/linear'
 import { createPreflightSlice } from './slices/preflight'
 import { createJiraSlice } from './slices/jira'
+import { createPaperclipSlice } from './slices/paperclip'
 import { createEditorSlice } from './slices/editor'
 import { createStatsSlice } from './slices/stats'
 import { createMemorySlice } from './slices/memory'
@@ -77,6 +78,7 @@ export const useAppStore = create<AppState>()(
       ...createLinearSlice(...a),
       ...createPreflightSlice(...a),
       ...createJiraSlice(...a),
+      ...createPaperclipSlice(...a),
       ...createEditorSlice(...a),
       ...createStatsSlice(...a),
       ...createMemorySlice(...a),

--- a/src/renderer/src/store/slices/paperclip.ts
+++ b/src/renderer/src/store/slices/paperclip.ts
@@ -1,0 +1,82 @@
+import type { StateCreator } from 'zustand'
+import type {
+  PaperclipConnectArgs,
+  PaperclipConnectionStatus,
+  PaperclipIssue,
+  PaperclipLaunchAdmission,
+  PaperclipLaunchAdmissionRequest
+} from '../../../../shared/paperclip-types'
+import type { AppState } from '../types'
+
+export type PaperclipSlice = {
+  paperclipStatus: PaperclipConnectionStatus
+  paperclipStatusChecked: boolean
+  paperclipIssues: PaperclipIssue[]
+  paperclipIssuesLoading: boolean
+  paperclipError: string | null
+  checkPaperclipConnection: () => Promise<void>
+  connectLocalPaperclip: (
+    args: Pick<PaperclipConnectArgs, 'origin' | 'companyId' | 'projectId'>
+  ) => Promise<{ ok: true } | { ok: false; error: string }>
+  disconnectPaperclip: () => Promise<void>
+  testPaperclipConnection: () => Promise<{ ok: true } | { ok: false; error: string }>
+  loadPaperclipIssues: (query?: string) => Promise<void>
+  getPaperclipLaunchAdmission: (
+    request: PaperclipLaunchAdmissionRequest
+  ) => Promise<PaperclipLaunchAdmission>
+}
+
+export const createPaperclipSlice: StateCreator<AppState, [], [], PaperclipSlice> = (set) => ({
+  paperclipStatus: { connected: false, connection: null },
+  paperclipStatusChecked: false,
+  paperclipIssues: [],
+  paperclipIssuesLoading: false,
+  paperclipError: null,
+  checkPaperclipConnection: async () => {
+    try {
+      const status = await window.api.paperclip.status()
+      set({ paperclipStatus: status, paperclipStatusChecked: true, paperclipError: null })
+    } catch (error) {
+      set({
+        paperclipStatus: { connected: false, connection: null },
+        paperclipStatusChecked: true,
+        paperclipError: error instanceof Error ? error.message : 'Paperclip status failed.'
+      })
+    }
+  },
+  connectLocalPaperclip: async (args) => {
+    const result = await window.api.paperclip.connectLocalTrusted(args)
+    if (!result.ok) {
+      return result
+    }
+    set({
+      paperclipStatus: { connected: true, connection: result.connection },
+      paperclipStatusChecked: true,
+      paperclipError: null
+    })
+    return { ok: true }
+  },
+  disconnectPaperclip: async () => {
+    await window.api.paperclip.disconnect()
+    set({
+      paperclipStatus: { connected: false, connection: null },
+      paperclipStatusChecked: true,
+      paperclipIssues: [],
+      paperclipError: null
+    })
+  },
+  testPaperclipConnection: () => window.api.paperclip.testConnection(),
+  loadPaperclipIssues: async (query) => {
+    set({ paperclipIssuesLoading: true, paperclipError: null })
+    try {
+      const issues = await window.api.paperclip.listIssues(query ? { query } : undefined)
+      set({ paperclipIssues: issues, paperclipIssuesLoading: false })
+    } catch (error) {
+      set({
+        paperclipIssuesLoading: false,
+        paperclipError: error instanceof Error ? error.message : 'Paperclip issue loading failed.'
+      })
+    }
+  },
+  getPaperclipLaunchAdmission: (request) => window.api.paperclip.getLaunchAdmission(request)
+})

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -17,6 +17,7 @@ import { createHostedReviewSlice } from './hosted-review'
 import { createLinearSlice } from './linear'
 import { createPreflightSlice } from './preflight'
 import { createJiraSlice } from './jira'
+import { createPaperclipSlice } from './paperclip'
 import { createEditorSlice } from './editor'
 import { createStatsSlice } from './stats'
 import { createMemorySlice } from './memory'
@@ -74,6 +75,7 @@ export function createTestStore() {
     ...createLinearSlice(...a),
     ...createPreflightSlice(...a),
     ...createJiraSlice(...a),
+    ...createPaperclipSlice(...a),
     ...createEditorSlice(...a),
     ...createStatsSlice(...a),
     ...createMemorySlice(...a),

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -745,7 +745,7 @@ export type UISlice = {
     note: string
     attachments: string[]
     linkedWorkItem: {
-      provider?: 'github' | 'gitlab' | 'linear' | 'jira'
+      provider?: 'github' | 'gitlab' | 'linear' | 'jira' | 'paperclip'
       type: 'issue' | 'pr' | 'mr'
       number: number
       title: string
@@ -753,6 +753,11 @@ export type UISlice = {
       linearIdentifier?: string
       linearBranchName?: string
       jiraIdentifier?: string
+      paperclipIssueId?: string
+      paperclipIdentifier?: string
+      paperclipConnectionId?: string
+      paperclipCompanyId?: string
+      paperclipProjectId?: string
       repoId?: string
     } | null
     /** Preserve where provider data came from, separately from the host chosen to run the workspace. */

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -11,6 +11,7 @@ import type { HostedReviewSlice } from './slices/hosted-review'
 import type { LinearSlice } from './slices/linear'
 import type { PreflightSlice } from './slices/preflight'
 import type { JiraSlice } from './slices/jira'
+import type { PaperclipSlice } from './slices/paperclip'
 import type { EditorSlice } from './slices/editor'
 import type { StatsSlice } from './slices/stats'
 import type { MemorySlice } from './slices/memory'
@@ -57,6 +58,7 @@ export type AppState = RepoSlice &
   LinearSlice &
   PreflightSlice &
   JiraSlice &
+  PaperclipSlice &
   EditorSlice &
   StatsSlice &
   MemorySlice &

--- a/src/renderer/src/web/web-preload-api-composition.test.ts
+++ b/src/renderer/src/web/web-preload-api-composition.test.ts
@@ -46,6 +46,7 @@ describe('web preload API composition', () => {
       'gl',
       'hostedReview',
       'linear',
+      'paperclip',
       'hooks',
       'stats',
       'memory',
@@ -81,6 +82,20 @@ describe('web preload API composition', () => {
     expect(Object.keys(globals.window.api.projects)).toEqual([])
     expect(Reflect.get(globals.window.api.projects, 'then')).toBeUndefined()
     expect(Object.keys(globals.window.electron)).toEqual([])
+    await expect(globals.window.api.paperclip.status()).resolves.toEqual({
+      connected: false,
+      connection: null
+    })
+    await expect(
+      globals.window.api.paperclip.connectLocalTrusted({
+        origin: 'http://127.0.0.1:3101',
+        companyId: 'company-1',
+        projectId: 'project-1'
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error: 'Paperclip is available only in the local Orca desktop app.'
+    })
   })
 
   it('snapshots E2E config before runtime storage initialization', async () => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1,5 +1,6 @@
 import type { PreloadApi } from '../../../preload/api-types'
 import type { StatsSummary } from '../../../shared/process-stats-types'
+import type { PaperclipApi } from '../../../preload/api/paperclip-api'
 import { createWebE2EApi } from './preload-api/web-e2e-api'
 import {
   createAccountsApi,
@@ -89,6 +90,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
     gl: createGitLabApi(),
     hostedReview: createRuntimeNamespaceApi('hostedReview'),
     linear: createRuntimeNamespaceApi('linear'),
+    paperclip: createUnavailablePaperclipApi(),
     hooks: createHooksApi(),
     stats: {
       getSummary: async () =>
@@ -137,5 +139,21 @@ function createWebPreloadApi(): Partial<PreloadApi> {
     ...createWebAgentStatusApi(),
     ...createWebMobileApi(),
     ...createWebTelemetryApi()
+  }
+}
+
+function createUnavailablePaperclipApi(): PaperclipApi {
+  const message = 'Paperclip is available only in the local Orca desktop app.'
+  const unsupported = (): never => {
+    throw new Error(message)
+  }
+  return {
+    connectLocalTrusted: async () => ({ ok: false, error: message }),
+    disconnect: async () => unsupported(),
+    status: async () => ({ connected: false, connection: null }),
+    testConnection: async () => ({ ok: false, error: message }),
+    listIssues: async () => unsupported(),
+    getIssue: async () => unsupported(),
+    getLaunchAdmission: async () => unsupported()
   }
 }

--- a/src/shared/new-workspace/workspace-source.test.ts
+++ b/src/shared/new-workspace/workspace-source.test.ts
@@ -61,6 +61,22 @@ describe('workspace source policy', () => {
         url: 'https://acme.atlassian.net/browse/FUS-1'
       })
     ).toBe(true)
+    const paperclip = {
+      provider: 'paperclip' as const,
+      type: 'issue' as const,
+      number: 0,
+      title: 'Local Paperclip task',
+      url: 'http://127.0.0.1:3100/issues/issue-1',
+      paperclipIssueId: 'issue-1',
+      paperclipConnectionId: 'connection-1',
+      paperclipCompanyId: 'company-1',
+      paperclipProjectId: 'project-1'
+    }
+    expect(shouldPreserveWorkspaceSourceOnRepoChange(paperclip)).toBe(true)
+    expect(buildWorkspaceSourceSelection({ linkedWorkItem: paperclip })).toMatchObject({
+      kind: 'paperclip',
+      label: 'Local Paperclip task'
+    })
     // Why: Jira items picked from smart search may arrive without an explicit
     // provider; preservation must still hold via URL/identifier inference.
     expect(

--- a/src/shared/new-workspace/workspace-source.ts
+++ b/src/shared/new-workspace/workspace-source.ts
@@ -37,6 +37,11 @@ export type JiraWorkspaceSource = WorkspaceSourceLinkedItem & {
   type: 'issue'
 }
 
+export type PaperclipWorkspaceSource = WorkspaceSourceLinkedItem & {
+  provider: 'paperclip'
+  type: 'issue'
+}
+
 export type WorkspaceSourceItemLike = Omit<WorkspaceSourceLinkedItem, 'provider'> & {
   provider?: WorkspaceSourceProvider
 }
@@ -49,6 +54,7 @@ export type WorkspaceSourceSelectionKind =
   | 'branch'
   | 'linear'
   | 'jira'
+  | 'paperclip'
 
 export type WorkspaceSourceSelection = {
   kind: WorkspaceSourceSelectionKind
@@ -198,17 +204,22 @@ export function buildWorkspaceSourceSelection(args: {
       ? 'linear'
       : provider === 'jira'
         ? 'jira'
-        : provider === 'gitlab'
-          ? linkedWorkItem.type === 'mr'
-            ? 'gitlab-mr'
-            : 'gitlab-issue'
-          : linkedWorkItem.type === 'pr'
-            ? 'github-pr'
-            : 'github-issue'
+        : provider === 'paperclip'
+          ? 'paperclip'
+          : provider === 'gitlab'
+            ? linkedWorkItem.type === 'mr'
+              ? 'gitlab-mr'
+              : 'gitlab-issue'
+            : linkedWorkItem.type === 'pr'
+              ? 'github-pr'
+              : 'github-issue'
   return {
     kind,
     label:
-      provider === 'linear' || provider === 'jira' || linkedWorkItem.number === 0
+      provider === 'linear' ||
+      provider === 'jira' ||
+      provider === 'paperclip' ||
+      linkedWorkItem.number === 0
         ? linkedWorkItem.title
         : `#${linkedWorkItem.number} ${linkedWorkItem.title}`,
     url: linkedWorkItem.url
@@ -222,5 +233,5 @@ export function shouldPreserveWorkspaceSourceOnRepoChange(
     return false
   }
   const provider = getWorkspaceSourceProvider(item)
-  return provider === 'linear' || provider === 'jira'
+  return provider === 'linear' || provider === 'jira' || provider === 'paperclip'
 }

--- a/src/shared/paperclip-types.ts
+++ b/src/shared/paperclip-types.ts
@@ -1,0 +1,50 @@
+export type PaperclipConnectionIdentity = {
+  id: string
+  origin: string
+  companyId: string
+  projectId: string
+}
+
+export type PaperclipConnectionSummary = PaperclipConnectionIdentity & {
+  companyName: string
+  projectName: string
+}
+
+export type PaperclipConnectionStatus = {
+  connected: boolean
+  connection: PaperclipConnectionSummary | null
+}
+
+export type PaperclipConnectArgs = {
+  origin: string
+  companyId: string
+  projectId: string
+}
+
+export type PaperclipCompany = { id: string; name: string }
+export type PaperclipProject = { id: string; companyId: string; name: string }
+
+export type PaperclipIssue = {
+  id: string
+  identifier: string
+  companyId: string
+  projectId: string | null
+  title: string
+  description: string | null
+  status: string
+  priority: string | null
+  checkoutRunId: string | null
+  executionRunId: string | null
+  executionLockedAt: string | null
+}
+
+export type PaperclipLaunchAdmission =
+  | { allowed: false; reason: 'active_run' | 'unknown_run_state' | 'claim_markers' }
+  | { allowed: true; requiresNonExclusiveConfirmation: true }
+
+export type PaperclipLaunchAdmissionRequest = {
+  issueId: string
+  connectionId: string
+  companyId: string
+  projectId: string
+}

--- a/src/shared/task-provider-identity.test.ts
+++ b/src/shared/task-provider-identity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  areTaskProviderIdentitiesEqual,
+  isStoredTaskProviderIdentity,
+  normalizeTaskProviderIdentity,
+  taskProviderIdentityCachePart
+} from './task-provider-identity'
+
+describe('Paperclip task provider identity', () => {
+  const identity = {
+    provider: 'paperclip' as const,
+    connectionId: 'connection-1',
+    companyId: 'company-1',
+    projectId: 'project-1'
+  }
+
+  it('normalizes bounded connection and provider scope without an origin', () => {
+    expect(
+      normalizeTaskProviderIdentity('paperclip', {
+        ...identity,
+        connectionId: ' connection-1 ',
+        companyName: 'ignored display label'
+      })
+    ).toEqual(identity)
+  })
+
+  it('rejects malformed stored scope fields', () => {
+    expect(isStoredTaskProviderIdentity('paperclip', identity)).toBe(true)
+    expect(
+      isStoredTaskProviderIdentity('paperclip', { ...identity, companyId: ['company-1'] })
+    ).toBe(false)
+  })
+
+  it('separates connection, company, and project cache authorities', () => {
+    expect(taskProviderIdentityCachePart(identity)).toBe('connection-1/company-1/project-1')
+    expect(areTaskProviderIdentitiesEqual(identity, { ...identity, companyId: 'company-2' })).toBe(
+      false
+    )
+    expect(areTaskProviderIdentitiesEqual(identity, { ...identity, projectId: 'project-2' })).toBe(
+      false
+    )
+  })
+})

--- a/src/shared/task-provider-identity.ts
+++ b/src/shared/task-provider-identity.ts
@@ -29,11 +29,19 @@ export type JiraTaskProviderIdentity = {
   projectKey?: string | null
 }
 
+export type PaperclipTaskProviderIdentity = {
+  provider: 'paperclip'
+  connectionId?: string | null
+  companyId?: string | null
+  projectId?: string | null
+}
+
 export type TaskProviderIdentity =
   | GitHubTaskProviderIdentity
   | GitLabTaskProviderIdentity
   | LinearTaskProviderIdentity
   | JiraTaskProviderIdentity
+  | PaperclipTaskProviderIdentity
 
 export function normalizeTaskProviderIdentity(
   provider: TaskProvider,
@@ -79,6 +87,13 @@ export function normalizeTaskProviderIdentity(
         siteUrl: normalizeNonEmptyString(raw.siteUrl),
         projectKey: normalizeNonEmptyString(raw.projectKey)
       }
+    case 'paperclip':
+      return {
+        provider,
+        connectionId: normalizeNonEmptyString(raw.connectionId),
+        companyId: normalizeNonEmptyString(raw.companyId),
+        projectId: normalizeNonEmptyString(raw.projectId)
+      }
   }
 }
 
@@ -112,6 +127,10 @@ export function isStoredTaskProviderIdentity(provider: TaskProvider, identity: u
       )
     case 'jira':
       return ['siteId', 'siteUrl', 'projectKey'].every((key) => isNullableOptionalString(raw[key]))
+    case 'paperclip':
+      return ['connectionId', 'companyId', 'projectId'].every((key) =>
+        isNullableOptionalString(raw[key])
+      )
   }
 }
 
@@ -119,7 +138,8 @@ const TASK_PROVIDER_IDENTITY_FIELDS: Record<TaskProvider, readonly string[]> = {
   github: ['owner', 'repo', 'host'],
   gitlab: ['projectId', 'namespace', 'project', 'webUrl'],
   linear: ['workspaceId', 'workspaceName', 'teamId', 'teamKey'],
-  jira: ['siteId', 'siteUrl', 'projectKey']
+  jira: ['siteId', 'siteUrl', 'projectKey'],
+  paperclip: ['connectionId', 'companyId', 'projectId']
 }
 
 export function areTaskProviderIdentitiesEqual(
@@ -157,6 +177,10 @@ export function taskProviderIdentityCachePart(
       return [identity.workspaceId, identity.teamId ?? identity.teamKey].filter(Boolean).join('/')
     case 'jira':
       return [identity.siteId ?? identity.siteUrl, identity.projectKey].filter(Boolean).join('/')
+    case 'paperclip':
+      return [identity.connectionId, identity.companyId, identity.projectId]
+        .filter(Boolean)
+        .join('/')
   }
 }
 

--- a/src/shared/task-providers.test.ts
+++ b/src/shared/task-providers.test.ts
@@ -16,7 +16,13 @@ describe('task providers', () => {
   })
 
   it('falls back to all providers when none are visible', () => {
-    expect(normalizeVisibleTaskProviders([])).toEqual(['github', 'gitlab', 'linear', 'jira'])
+    expect(normalizeVisibleTaskProviders([])).toEqual([
+      'github',
+      'gitlab',
+      'linear',
+      'jira',
+      'paperclip'
+    ])
   })
 
   it('restores a valid saved default when provider settings drifted', () => {
@@ -115,5 +121,21 @@ describe('task providers', () => {
         linearConnected: false
       })
     ).toEqual(['github'])
+  })
+
+  it('shows Paperclip only after its local desktop connection is ready', () => {
+    expect(
+      filterAvailableTaskProviders(['github', 'paperclip'], {
+        gitlabInstalled: false,
+        linearConnected: false
+      })
+    ).toEqual(['github'])
+    expect(
+      filterAvailableTaskProviders(['github', 'paperclip'], {
+        gitlabInstalled: false,
+        linearConnected: false,
+        paperclipConnected: true
+      })
+    ).toEqual(['github', 'paperclip'])
   })
 })

--- a/src/shared/task-providers.ts
+++ b/src/shared/task-providers.ts
@@ -1,6 +1,12 @@
-export type TaskProvider = 'github' | 'gitlab' | 'linear' | 'jira'
+export type TaskProvider = 'github' | 'gitlab' | 'linear' | 'jira' | 'paperclip'
 
-export const TASK_PROVIDERS: readonly TaskProvider[] = ['github', 'gitlab', 'linear', 'jira']
+export const TASK_PROVIDERS: readonly TaskProvider[] = [
+  'github',
+  'gitlab',
+  'linear',
+  'jira',
+  'paperclip'
+]
 
 const TASK_PROVIDER_SET = new Set<TaskProvider>(TASK_PROVIDERS)
 
@@ -55,6 +61,7 @@ export function normalizeVisibleTaskProviders(value: unknown): TaskProvider[] {
 export type TaskProviderAvailability = {
   gitlabInstalled: boolean
   linearConnected: boolean
+  paperclipConnected?: boolean
 }
 
 export function filterAvailableTaskProviders(
@@ -104,6 +111,9 @@ function isTaskProviderAvailable(
   // when disconnected would remove the entry point for first-time setup.
   if (provider === 'jira') {
     return true
+  }
+  if (provider === 'paperclip') {
+    return availability.paperclipConnected === true
   }
   return availability.linearConnected
 }

--- a/src/shared/task-source-context.test.ts
+++ b/src/shared/task-source-context.test.ts
@@ -117,7 +117,7 @@ describe('task source context', () => {
     expect(local).not.toBe(enterpriseRepo)
   })
 
-  it('serializes provider identities for GitLab, Linear, and Jira cache scopes', () => {
+  it('serializes provider identities for GitLab, Linear, Jira, and Paperclip cache scopes', () => {
     const base = {
       projectId: 'project-1',
       hostId: LOCAL_EXECUTION_HOST_ID,
@@ -149,6 +149,51 @@ describe('task source context', () => {
         }
       })
     ).toContain(encodeURIComponent('https://example.atlassian.net/OPS'))
+    expect(
+      getTaskSourceCacheScope({
+        ...base,
+        provider: 'paperclip',
+        providerIdentity: {
+          provider: 'paperclip',
+          connectionId: 'connection-1',
+          companyId: 'company-1',
+          projectId: 'paperclip-project-1'
+        }
+      })
+    ).toContain(encodeURIComponent('connection-1/company-1/paperclip-project-1'))
+  })
+
+  it('round-trips a Paperclip source without credential or origin fields', () => {
+    const context = normalizeStoredTaskSourceContext({
+      kind: 'task-source',
+      provider: 'paperclip',
+      projectId: 'orca-project-1',
+      hostId: 'local',
+      providerIdentity: {
+        provider: 'paperclip',
+        connectionId: 'connection-1',
+        companyId: 'company-1',
+        projectId: 'paperclip-project-1'
+      }
+    })
+
+    expect(context).toEqual({
+      kind: 'task-source',
+      provider: 'paperclip',
+      projectId: 'orca-project-1',
+      hostId: 'local',
+      projectHostSetupId: null,
+      repoId: null,
+      providerIdentity: {
+        provider: 'paperclip',
+        connectionId: 'connection-1',
+        companyId: 'company-1',
+        projectId: 'paperclip-project-1'
+      },
+      accountLabel: null
+    })
+    expect(JSON.stringify(context)).not.toContain('apiOrigin')
+    expect(JSON.stringify(context)).not.toContain('token')
   })
 
   it('drops provider identities that do not match the source provider', () => {

--- a/src/shared/task-source-context.ts
+++ b/src/shared/task-source-context.ts
@@ -22,6 +22,7 @@ export type {
   GitLabTaskProviderIdentity,
   JiraTaskProviderIdentity,
   LinearTaskProviderIdentity,
+  PaperclipTaskProviderIdentity,
   TaskProviderIdentity
 } from './task-provider-identity'
 export type { TaskProvider } from './task-providers'
@@ -208,6 +209,7 @@ function normalizeTaskProvider(value: unknown): TaskProvider | null {
     case 'gitlab':
     case 'linear':
     case 'jira':
+    case 'paperclip':
       return value
     default:
       return null

--- a/src/shared/workspace-linked-item-equality.test.ts
+++ b/src/shared/workspace-linked-item-equality.test.ts
@@ -44,4 +44,30 @@ describe('areWorkspaceLinkedItemsEqual', () => {
     )
     expect(areWorkspaceLinkedItemsEqual(item, { ...item, repoId: 'repo-2' })).toBe(false)
   })
+
+  it('compares immutable Paperclip issue and scope fields', () => {
+    const paperclip: WorkspaceLinkedItem = {
+      provider: 'paperclip',
+      type: 'issue',
+      number: 0,
+      title: 'PAP-12 Connect Paperclip',
+      url: 'https://paperclip.example/acme/issues/PAP-12',
+      paperclipIssueId: 'issue-12',
+      paperclipIdentifier: 'PAP-12',
+      paperclipConnectionId: 'connection-1',
+      paperclipCompanyId: 'company-1',
+      paperclipProjectId: 'project-1'
+    }
+
+    expect(areWorkspaceLinkedItemsEqual(paperclip, { ...paperclip })).toBe(true)
+    expect(
+      areWorkspaceLinkedItemsEqual(paperclip, { ...paperclip, paperclipIssueId: 'issue-13' })
+    ).toBe(false)
+    expect(
+      areWorkspaceLinkedItemsEqual(paperclip, {
+        ...paperclip,
+        paperclipConnectionId: 'connection-2'
+      })
+    ).toBe(false)
+  })
 })

--- a/src/shared/workspace-linked-item-source-context.test.ts
+++ b/src/shared/workspace-linked-item-source-context.test.ts
@@ -110,4 +110,47 @@ describe('workspace linked-item source context', () => {
       )
     ).toBe(true)
   })
+
+  it('requires Paperclip connection, company, and project scope to agree', () => {
+    const item: WorkspaceLinkedItem = {
+      provider: 'paperclip',
+      type: 'issue',
+      number: 0,
+      title: 'PAP-12 Connect Paperclip',
+      url: 'https://paperclip.example/acme/issues/PAP-12',
+      paperclipIssueId: 'issue-12',
+      paperclipIdentifier: 'PAP-12',
+      paperclipConnectionId: 'connection-1',
+      paperclipCompanyId: 'company-1',
+      paperclipProjectId: 'project-1'
+    }
+    const context: TaskSourceContext = {
+      kind: 'task-source',
+      provider: 'paperclip',
+      projectId: 'orca-project-1',
+      hostId: 'local',
+      providerIdentity: {
+        provider: 'paperclip',
+        connectionId: 'connection-1',
+        companyId: 'company-1',
+        projectId: 'project-1'
+      }
+    }
+
+    expect(isWorkspaceLinkedItemSourceContextMatch(item, context)).toBe(true)
+    expect(
+      isWorkspaceLinkedItemSourceContextMatch({ ...item, paperclipCompanyId: 'company-2' }, context)
+    ).toBe(false)
+    expect(
+      isWorkspaceLinkedItemSourceContextMatch(item, {
+        ...context,
+        providerIdentity: {
+          provider: 'paperclip',
+          connectionId: 'connection-1',
+          companyId: 'company-2',
+          projectId: 'project-1'
+        }
+      })
+    ).toBe(false)
+  })
 })

--- a/src/shared/workspace-linked-item-source-context.ts
+++ b/src/shared/workspace-linked-item-source-context.ts
@@ -37,7 +37,23 @@ export function isWorkspaceLinkedItemSourceContextMatch(
     return false
   }
   if (itemProvider !== 'jira') {
-    return true
+    if (itemProvider !== 'paperclip') {
+      return true
+    }
+    const identity = context.providerIdentity
+    return (
+      item.type === 'issue' &&
+      item.number === 0 &&
+      identity?.provider === 'paperclip' &&
+      !!identity.connectionId &&
+      !!identity.companyId &&
+      !!identity.projectId &&
+      !!item.paperclipIssueId &&
+      !!item.paperclipIdentifier &&
+      item.paperclipConnectionId === identity.connectionId &&
+      item.paperclipCompanyId === identity.companyId &&
+      item.paperclipProjectId === identity.projectId
+    )
   }
   const identity = context.providerIdentity
   const itemUrl = parseJiraIssueUrl(item.url)

--- a/src/shared/workspace-linked-item.ts
+++ b/src/shared/workspace-linked-item.ts
@@ -18,6 +18,11 @@ export function areWorkspaceLinkedItemsEqual(
     a.url === b.url &&
     (a.linearIdentifier ?? null) === (b.linearIdentifier ?? null) &&
     (a.jiraIdentifier ?? null) === (b.jiraIdentifier ?? null) &&
+    (a.paperclipIssueId ?? null) === (b.paperclipIssueId ?? null) &&
+    (a.paperclipIdentifier ?? null) === (b.paperclipIdentifier ?? null) &&
+    (a.paperclipConnectionId ?? null) === (b.paperclipConnectionId ?? null) &&
+    (a.paperclipCompanyId ?? null) === (b.paperclipCompanyId ?? null) &&
+    (a.paperclipProjectId ?? null) === (b.paperclipProjectId ?? null) &&
     (a.repoId ?? null) === (b.repoId ?? null)
   )
 }
@@ -31,7 +36,8 @@ export function normalizeWorkspaceLinkedItem(value: unknown): WorkspaceLinkedIte
     raw.provider !== 'github' &&
     raw.provider !== 'gitlab' &&
     raw.provider !== 'linear' &&
-    raw.provider !== 'jira'
+    raw.provider !== 'jira' &&
+    raw.provider !== 'paperclip'
   ) {
     return null
   }
@@ -59,6 +65,21 @@ export function normalizeWorkspaceLinkedItem(value: unknown): WorkspaceLinkedIte
       : {}),
     ...(typeof raw.jiraIdentifier === 'string' && raw.jiraIdentifier.trim().length > 0
       ? { jiraIdentifier: raw.jiraIdentifier.trim() }
+      : {}),
+    ...(typeof raw.paperclipIssueId === 'string' && raw.paperclipIssueId.trim().length > 0
+      ? { paperclipIssueId: raw.paperclipIssueId.trim() }
+      : {}),
+    ...(typeof raw.paperclipIdentifier === 'string' && raw.paperclipIdentifier.trim().length > 0
+      ? { paperclipIdentifier: raw.paperclipIdentifier.trim() }
+      : {}),
+    ...(typeof raw.paperclipConnectionId === 'string' && raw.paperclipConnectionId.trim().length > 0
+      ? { paperclipConnectionId: raw.paperclipConnectionId.trim() }
+      : {}),
+    ...(typeof raw.paperclipCompanyId === 'string' && raw.paperclipCompanyId.trim().length > 0
+      ? { paperclipCompanyId: raw.paperclipCompanyId.trim() }
+      : {}),
+    ...(typeof raw.paperclipProjectId === 'string' && raw.paperclipProjectId.trim().length > 0
+      ? { paperclipProjectId: raw.paperclipProjectId.trim() }
       : {}),
     ...(typeof raw.repoId === 'string' && raw.repoId.trim().length > 0
       ? { repoId: raw.repoId.trim() }

--- a/src/shared/workspace-name.ts
+++ b/src/shared/workspace-name.ts
@@ -47,9 +47,10 @@ export type WorkspaceIntentWorkItem = {
   type: 'issue' | 'pr' | 'mr'
   number: number
   title: string
-  provider?: 'github' | 'gitlab' | 'linear' | 'jira'
+  provider?: 'github' | 'gitlab' | 'linear' | 'jira' | 'paperclip'
   linearIdentifier?: string
   jiraIdentifier?: string
+  paperclipIdentifier?: string
 }
 
 export type WorkspaceIntentName = {

--- a/src/shared/worktree/types.ts
+++ b/src/shared/worktree/types.ts
@@ -8,13 +8,18 @@ import type { BuiltInWorktreeVisibilitySourceId } from '../repo-types'
 import type { WorktreeIdentity } from './identity'
 
 export type WorkspaceLinkedItem = {
-  provider: 'github' | 'gitlab' | 'linear' | 'jira'
+  provider: 'github' | 'gitlab' | 'linear' | 'jira' | 'paperclip'
   type: 'issue' | 'pr' | 'mr'
   number: number
   title: string
   url: string
   linearIdentifier?: string
   jiraIdentifier?: string
+  paperclipIssueId?: string
+  paperclipIdentifier?: string
+  paperclipConnectionId?: string
+  paperclipCompanyId?: string
+  paperclipProjectId?: string
   repoId?: string
 }
 


### PR DESCRIPTION
## ELI5

Adds Paperclip beside Linear and Jira in Orca’s Tasks area. A user running Paperclip locally can connect a company/project, browse issues, and open a linked Orca workspace without letting Orca claim or modify the Paperclip issue.

## What Changed

- Added `paperclip` to Orca’s provider identity, task-source context, linked-item, settings, and Tasks UI flows.
- Added a main-process, read-only Paperclip client for unauthenticated local-trusted servers.
- Added issue listing and workspace-composer linkage for Paperclip tasks.
- Added an authoritative main-process launch boundary that:
  - allows only literal loopback HTTP (`127/8` or `[::1]`);
  - performs a fresh issue plus active-run admission immediately before mutation;
  - requires matching immutable item/source identity;
  - blocks active, ambiguous, duplicate, concurrent, retry, remote, SSH, runtime, and context-only bypasses.
- Added explicit unsupported behavior for the web client and remote runtime RPC paths.
- Persists only canonical connection identity; display labels are refetched.

## Why

Paperclip already works from Orca terminals through its CLI, but it cannot be browsed or linked through Orca’s native task-manager UI like Linear and Jira. This PR provides that ergonomic bridge while keeping Paperclip as task authority and Orca as workspace authority.

The first slice is intentionally local-only and read-only. It does not add credentials, Paperclip writes, checkout/release, status changes, heartbeats, lifecycle supervision, background polling, or remote transport.

## Linked Issue

Fixes #17197

## Visual Proof

Pending before/after capture. This PR remains draft until visual validation is attached.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated on macOS arm64:

- Focused Paperclip/touched-boundary suite: 20 files, 148 tests passed.
- `pnpm tc` passed.
- `pnpm lint` passed, including type-aware, reliability, localization, max-lines, and runtime-boundary audits.
- `pnpm build` passed for desktop, web projection, relay targets, CLI, and native macOS helpers.
- `git diff --check` passed.

A full parallel `pnpm test` run was attempted but stopped after widespread unrelated subsystem timeouts under severe local resource contention made it non-diagnostic. The focused boundary suite was rerun in isolation and passed. Electron visual validation was not available in the implementation session because its required validation skill was unavailable; visual proof remains a draft-PR follow-up.

## AI Disclosure

Implemented with OpenAI Codex. The plan/architecture and final consequential diff received independent AI review; both final verdicts were PASS after the authoritative mutation-boundary findings were corrected.

## Review

Please focus on:

- whether a local-only first slice fits Orca’s task-source direction;
- the main-process admission/duplicate boundary;
- the explicit decision not to advertise or transport Paperclip over runtime RPC;
- whether company/project onboarding should remain ID-based in this first PR or gain discovery UI before readiness.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: no credential surface; literal loopback only; direct `node:http` with no proxy agent, redirects disabled, absolute deadline, and 2 MiB response cap.
- Cross-platform: shared TypeScript paths are platform-neutral; build passed all relay targets. Runtime/SSH/mobile linkage is deliberately rejected for this MVP.
- Backwards compatibility: existing providers retain their explicit behavior; web preload returns a controlled unavailable Paperclip status instead of an undefined namespace.
- Performance: no background polling; provider reads occur only for status/list/detail/admission actions.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
