### PR TITLE
fix(windows): give Orca's own durable deletions the rm retry policy

### DIFF
--- a/src/cli/handlers/account.ts
+++ b/src/cli/handlers/account.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { delimiter, join } from 'node:path'
 import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
@@ -249,7 +249,7 @@ async function addCodexAccount({ client, json }: HandlerContext): Promise<void> 
   const result = await withInteractiveLoginCleanup(
     session,
     async () => {
-      rmSync(codexHome, { recursive: true, force: true })
+      removeTreeSync(codexHome)
     },
     async () => {
       // Why: plain OAuth binds a loopback callback the user's browser cannot reach

--- a/src/main/browser/browser-client-download-relay.ts
+++ b/src/main/browser/browser-client-download-relay.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto'
-import { mkdirSync, rmSync } from 'node:fs'
-import { open, rm, stat } from 'node:fs/promises'
+import { mkdirSync } from 'node:fs'
+import { open, stat } from 'node:fs/promises'
 import path from 'node:path'
+import { removeTree, removeTreeSync } from '../../shared/windows-transient-lock-removal'
 
 import {
   BROWSER_CLIENT_FILE_CHANNEL_CHUNK_MAX_BYTES,
@@ -54,7 +55,7 @@ const nodeRelayFilesystem: RelayFilesystem = {
     mkdirSync(directory, { recursive: true, mode: 0o700 })
   },
   removeDirectorySync: (directory) => {
-    rmSync(directory, { recursive: true, force: true })
+    removeTreeSync(directory)
   },
   readChunks: async function* (filePath, chunkBytes) {
     const handle = await open(filePath, 'r')
@@ -73,7 +74,7 @@ const nodeRelayFilesystem: RelayFilesystem = {
   },
   size: async (filePath) => (await stat(filePath)).size,
   removeDirectory: async (directory) => {
-    await rm(directory, { recursive: true, force: true })
+    await removeTree(directory)
   }
 }
 

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -12,10 +12,10 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
-  rmSync,
   unlinkSync
 } from 'node:fs'
 import { readFile } from 'node:fs/promises'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 import { DatabaseSync } from 'node:sqlite'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -1424,7 +1424,7 @@ async function importCookiesFromFirefox(
       }
     }
   } catch {
-    rmSync(tmpDir, { recursive: true, force: true })
+    removeTreeSync(tmpDir)
     return {
       ok: false,
       reason: 'Could not copy Firefox cookies database. Try closing Firefox first.'
@@ -1463,7 +1463,7 @@ async function importCookiesFromFirefox(
 
     diag(`  Firefox source has ${rows.length} cookies`)
     if (rows.length === 0) {
-      rmSync(tmpDir, { recursive: true, force: true })
+      removeTreeSync(tmpDir)
       return { ok: false, reason: 'No cookies found in Firefox.' }
     }
 
@@ -1498,7 +1498,7 @@ async function importCookiesFromFirefox(
       })
     }
 
-    rmSync(tmpDir, { recursive: true, force: true })
+    removeTreeSync(tmpDir)
 
     if (validated.length === 0) {
       return { ok: false, reason: 'No valid cookies found in Firefox.' }
@@ -1512,7 +1512,7 @@ async function importCookiesFromFirefox(
       options
     )
   } catch (err) {
-    rmSync(tmpDir, { recursive: true, force: true })
+    removeTreeSync(tmpDir)
     diag(`  Firefox import failed: ${String(err)}`)
     return {
       ok: false,

--- a/src/main/claude-accounts/claude-login-session.ts
+++ b/src/main/claude-accounts/claude-login-session.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { toWindowsWslPath } from '../wsl'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 import { runWslProcess } from '../wsl/wsl-runner'
 import type { CapturedClaudeAuth } from './claude-auth-capture'
 import type { ClaudeCommandConfig, ClaudeCommandOptions } from './claude-command-process'
@@ -138,5 +139,6 @@ async function removeTemporaryClaudeConfigDir(config: ClaudeCommandConfig): Prom
     }
     return
   }
-  rmSync(config.windowsPath, { recursive: true, force: true })
+  // This branch is the Windows one by construction, and the directory holds login material.
+  removeTreeSync(config.windowsPath)
 }

--- a/src/main/codex/codex-home-paths.ts
+++ b/src/main/codex/codex-home-paths.ts
@@ -5,7 +5,6 @@ import {
   readFileSync,
   readlinkSync,
   rmdirSync,
-  rmSync,
   statSync,
   symlinkSync,
   unlinkSync
@@ -18,6 +17,7 @@ import {
   targetIsOwnedFallbackCopy
 } from './codex-managed-home-resource-copy-marker'
 import { observe, observeResolvedPathEntry } from './codex-path-observation'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 
 const CODEX_GLOBAL_INSTRUCTIONS_ENTRY = 'AGENTS.md'
 
@@ -151,7 +151,7 @@ function linkSystemCodexResource(
         return
       }
     }
-    rmSync(targetPath, { recursive: true, force: true })
+    removeTreeSync(targetPath)
   }
 
   if (preferCopy) {
@@ -189,7 +189,9 @@ function copySystemCodexResourceAsOwnedFallback(
   symlinkError?: unknown
 ): void {
   try {
-    rmSync(targetPath, { recursive: true, force: true })
+    // Why the shared policy: the copy below is errorOnExist, so a target Windows
+    // still holds leaves Codex running against the stale mirrored resource.
+    removeTreeSync(targetPath)
     cpSync(sourcePath, targetPath, {
       recursive: true,
       force: false,
@@ -203,7 +205,7 @@ function copySystemCodexResourceAsOwnedFallback(
     // Why: an unmarked copy cannot be refreshed or safely removed later.
     // Roll it back instead of stranding stale instructions in the runtime home.
     try {
-      rmSync(targetPath, { recursive: true, force: true })
+      removeTreeSync(targetPath)
     } catch (cleanupError) {
       console.warn(
         '[codex-home] Failed to remove incomplete resource copy:',
@@ -270,7 +272,7 @@ function removeCopiedResourceIfOwned(
   if (!targetIsOwnedFallbackCopy(targetPath, managedHomePath, entryName, sourcePath)) {
     return
   }
-  rmSync(targetPath, { recursive: true, force: true })
+  removeTreeSync(targetPath)
   clearCopiedResourceMarker(managedHomePath, entryName)
 }
 

--- a/src/main/codex/codex-managed-home-resource-copy-marker.ts
+++ b/src/main/codex/codex-managed-home-resource-copy-marker.ts
@@ -1,5 +1,6 @@
-import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 
 /**
  * Ownership markers for system Codex resources a managed home had to copy.
@@ -45,10 +46,7 @@ function readCopiedResourceSourcePath(managedHomePath: string, entryName: string
 export function clearCopiedResourceMarker(managedHomePath: string, entryName: string): void {
   // Why: a malformed marker directory must not block Codex launch or prevent
   // an owned resource from being repaired.
-  rmSync(getResourceCopyMarkerPath(managedHomePath, entryName), {
-    recursive: true,
-    force: true
-  })
+  removeTreeSync(getResourceCopyMarkerPath(managedHomePath, entryName))
 }
 
 export function targetIsOwnedFallbackCopy(

--- a/src/main/computer/desktop-script-provider-client.ts
+++ b/src/main/computer/desktop-script-provider-client.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type {
@@ -20,6 +20,7 @@ import {
 } from './desktop-script-action'
 import { validateComputerProviderActionParams } from './computer-provider-action-validation'
 import { execBridge, mapBridgeError } from './desktop-script-provider-bridge'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 import {
   optionalNumberParam,
   optionalStringParam,
@@ -222,7 +223,8 @@ export class DesktopScriptProviderClient {
       }
       return response
     } finally {
-      await rm(operationDirectory, { force: true, recursive: true })
+      // This provider runs on Linux and Windows only, so the retry policy is live here.
+      await removeTree(operationDirectory)
     }
   }
 

--- a/src/main/daemon/daemon-host-relocation.ts
+++ b/src/main/daemon/daemon-host-relocation.ts
@@ -11,6 +11,7 @@ import {
 } from 'node:fs'
 import { dirname, join, win32 as winPath } from 'node:path'
 import { getAppEnvironment } from '../../shared/app-environment'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 import type { ProcessLivenessVerdict } from './daemon-incarnation-evidence-types'
 import { parseDaemonPidFile } from './daemon-pid-file-parse'
 import { quarantineCorruptDaemonPidRecord } from './daemon-pid-record-quarantine'
@@ -272,7 +273,7 @@ export function materializeRelocatedDaemonHost(): RelocatedDaemonHost | null {
   const staging = join(root, `${version}.staging-${randomBytes(6).toString('hex')}`)
   try {
     mkdirSync(root, { recursive: true })
-    rmSync(staging, { recursive: true, force: true })
+    removeTreeSync(staging)
     executeManifest(buildDaemonHostManifest(sources), staging)
     // Marker written LAST so an interrupted copy leaves a marker-less staging dir the next launch discards.
     const marker: MaterializeMarker = {
@@ -281,12 +282,13 @@ export function materializeRelocatedDaemonHost(): RelocatedDaemonHost | null {
       entryRelPath: sources.entryRelPath
     }
     writeFileSync(join(staging, MARKER_NAME), JSON.stringify(marker))
-    // Replace any stale/partial dest, then publish the staging dir atomically.
-    rmSync(dest, { recursive: true, force: true })
+    // Replace any stale/partial dest, then publish the staging dir atomically. The retry policy is
+    // load-bearing: a dest Windows still holds makes the rename below fail and relocation give up.
+    removeTreeSync(dest)
     renameSync(staging, dest)
   } catch {
     try {
-      rmSync(staging, { recursive: true, force: true })
+      removeTreeSync(staging)
     } catch {
       // Best-effort staging cleanup.
     }

--- a/src/main/emulator/serve-sim-runtime-materializer.ts
+++ b/src/main/emulator/serve-sim-runtime-materializer.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process'
 import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 
 export type ServeSimRuntimeMaterializerOptions = {
   bundledPackageDir: string
@@ -67,8 +68,10 @@ export function materializeServeSimRuntime(
   try {
     mkdirSync(targetRootDir, { recursive: true })
     pruneStaleServeSimRuntimes(targetRootDir, version)
-    rmSync(stagingDir, { recursive: true, force: true })
-    rmSync(targetDir, { recursive: true, force: true })
+    removeTreeSync(stagingDir)
+    // Why the shared policy: a half-materialized targetDir Windows still holds can never be renamed
+    // over, so serve-sim stays permanently unavailable on that machine.
+    removeTreeSync(targetDir)
     cpSync(bundledPackageDir, stagingDir, { recursive: true })
     for (const relativePath of EXECUTABLE_RELATIVE_PATHS) {
       const executablePath = join(stagingDir, relativePath)
@@ -89,6 +92,7 @@ export function materializeServeSimRuntime(
   } catch {
     return null
   } finally {
-    rmSync(stagingDir, { recursive: true, force: true })
+    // A throw here would escape a function whose contract is `string | null`.
+    removeTreeSync(stagingDir)
   }
 }

--- a/src/main/hermes/hook-service.ts
+++ b/src/main/hermes/hook-service.ts
@@ -1,7 +1,7 @@
-import { rmSync } from 'node:fs'
 import type { SFTPWrapper } from 'ssh2'
 
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 import {
   readTextFileRemote,
   writeTextFileRemoteAtomic
@@ -152,7 +152,8 @@ export class HermesHookService {
     }
     const pluginDir = getPluginDir()
     if (getPluginFilesState(pluginDir).managed) {
-      rmSync(pluginDir, { recursive: true, force: true })
+      // A throw here skips the config rewrite below, leaving the hook enabled after the user removed it.
+      removeTreeSync(pluginDir)
     }
     writeConfigFile(configPath, disablePlugin(parsed.config))
     return this.getStatus()

--- a/src/main/internal-durable-deletion-retry-policy.test.ts
+++ b/src/main/internal-durable-deletion-retry-policy.test.ts
@@ -1,0 +1,268 @@
+import { readFileSync } from 'node:fs'
+import type * as nodeFsPromises from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { findRawRecursiveRemovals } from '../shared/raw-recursive-removal-scan'
+import { readSourceRegionBody } from '../shared/source-region-body'
+import {
+  WINDOWS_RM_MAX_RETRIES,
+  transientLockRemovalOptions
+} from '../shared/windows-transient-lock-removal'
+import { deleteRelayPath } from '../relay/fs-path-mutation-requests'
+
+/** Records the options every recursive removal hands Node, without performing the removal. */
+const recorded = vi.hoisted(() => ({ rmCalls: [] as [string, unknown][] }))
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof nodeFsPromises>()
+  return {
+    ...actual,
+    rm: (path: string, options: unknown) => {
+      recorded.rmCalls.push([path, options])
+      return Promise.resolve()
+    }
+  }
+})
+
+/**
+ * The sibling guard covers deletions a person asked for. This one covers Orca's own durable state:
+ * removals whose failure is silent at the time and only shows up later — as a directory a rename
+ * can never be published over, as a completed operation reporting failure because its scratch
+ * cleanup threw, or as state Orca can no longer find in order to reclaim it.
+ *
+ * Still deliberately not every recursive removal in `src/`. The disposable temp trees that sit in
+ * `.catch(() => {})` or a `try { … } catch { /* best-effort *\/ }` are genuinely harmless, and the
+ * darwin-only computer-use provider paths can never reach a Windows retry.
+ */
+const REPO_ROOT = join(__dirname, '..', '..')
+
+/** A removal of Orca's own state, named by the region of the file that performs it. */
+type InternalDurableDeletion = { file: string; region: string; breaks: string }
+
+/** A failed removal blocks the rename or copy that was supposed to replace it. */
+const BLOCKS_ITS_OWN_REPLACEMENT: InternalDurableDeletion[] = [
+  {
+    file: 'src/main/daemon/daemon-host-relocation.ts',
+    region: 'export function materializeRelocatedDaemonHost',
+    breaks: 'the daemon host never publishes over its stale copy'
+  },
+  {
+    file: 'src/main/emulator/serve-sim-runtime-materializer.ts',
+    region: 'export function materializeServeSimRuntime',
+    breaks: 'a half-materialized serve-sim runtime can never be replaced'
+  },
+  {
+    file: 'src/main/plugins/plugin-install-staging.ts',
+    region: 'export async function installStagedPluginTree',
+    breaks: 'a corrupted immutable plugin version stays unrepairable'
+  },
+  {
+    file: 'src/main/codex/codex-home-paths.ts',
+    region: 'function copySystemCodexResourceAsOwnedFallback',
+    breaks: 'Codex keeps launching against a stale mirrored resource'
+  },
+  {
+    file: 'src/main/codex/codex-managed-home-resource-copy-marker.ts',
+    region: 'export function clearCopiedResourceMarker',
+    breaks: 'an ownership marker outlives the copy it describes'
+  }
+]
+
+/** A failed removal turns a result the caller already earned into a rejection. */
+const REPORTS_A_FALSE_FAILURE: InternalDurableDeletion[] = [
+  {
+    file: 'src/main/native-chat/agent-session-journal/journal-epoch-replacement.ts',
+    region: 'export async function replaceJournalEpoch',
+    breaks: 'a published journal epoch reports failure'
+  },
+  {
+    file: 'src/main/plugins/plugin-marketplace-fetch.ts',
+    region: 'export async function fetchPluginMarketplace',
+    breaks: 'a successful marketplace fetch reports failure'
+  },
+  {
+    file: 'src/main/skills/skill-bundle-creation.ts',
+    region: 'async function createSkillBundleArchiveUnobserved',
+    breaks: 'a written skill bundle archive reports failure'
+  },
+  {
+    file: 'src/main/skills/skill-package-creation.ts',
+    region: 'async function createSkillPackageArchiveUnobserved',
+    breaks: 'a written skill package archive reports failure'
+  },
+  {
+    file: 'src/main/skills/skill-package-extraction.ts',
+    region: 'export async function extractSkillPackageArchive',
+    breaks: 'a rollback replaces the failure the caller needed to see'
+  },
+  {
+    file: 'src/main/skills/skill-bundle-extraction.ts',
+    region: 'export async function extractSkillBundleArchive',
+    breaks: 'a rollback replaces the failure the caller needed to see'
+  },
+  {
+    file: 'src/main/plugins/plugin-marketplace-installer.ts',
+    region: 'async preview',
+    breaks: 'a successful marketplace preview reports failure'
+  },
+  {
+    file: 'src/main/computer/desktop-script-provider-client.ts',
+    region: 'private async callBridge',
+    breaks: 'a successful computer-use bridge call reports failure'
+  },
+  {
+    file: 'src/main/skills/skill-package-download.ts',
+    region: 'async function downloadSkillPackageGrantUnobserved',
+    breaks: 'a rollback replaces the digest mismatch the caller needed to see'
+  },
+  {
+    file: 'src/main/plugins/plugin-install.ts',
+    region: 'export async function installPluginFromGit',
+    breaks: 'an installed plugin reports failure'
+  },
+  {
+    file: 'src/main/plugins/plugin-install.ts',
+    region: 'export async function installPluginFromMarketplace',
+    breaks: 'a marketplace-installed plugin reports failure'
+  },
+  {
+    file: 'src/main/browser/browser-cookie-import.ts',
+    region: 'async function importCookiesFromFirefox',
+    breaks: "a finished Firefox cookie import reports 'could not import'"
+  }
+]
+
+/** A failed removal strands state Orca can no longer find in order to reclaim it. */
+const STRANDS_RECLAIMABLE_STATE: InternalDurableDeletion[] = [
+  {
+    file: 'src/main/skills/skill-share-preparation-service.ts',
+    region: 'async release',
+    breaks: 'a released share preparation is unreachable and never reclaimed'
+  },
+  {
+    file: 'src/main/skills/skill-upload-staging-ownership.ts',
+    region: 'private async cleanupAbandonedOwners',
+    breaks: "one dead owner's directory blocks every skill upload"
+  },
+  {
+    file: 'src/main/skills/skill-package-download.ts',
+    region: 'async function prepareTemporaryRoot',
+    breaks: "one dead process's leftover directory blocks every skill download"
+  },
+  {
+    file: 'src/main/hermes/hook-service.ts',
+    region: 'remove(): AgentHookInstallStatus',
+    breaks: 'the Hermes hook stays enabled after the user removed it'
+  },
+  {
+    file: 'src/main/orcad/electron-serve-browser-process.ts',
+    region: 'async stop',
+    breaks: "the stopped sidecar's profile directory is never reclaimed"
+  },
+  {
+    file: 'src/main/browser/browser-client-download-relay.ts',
+    region: 'const nodeRelayFilesystem',
+    breaks: "a client-hosted page's downloaded bytes are never removed"
+  }
+]
+
+const INTERNAL_DURABLE_DELETIONS = [
+  ...BLOCKS_ITS_OWN_REPLACEMENT,
+  ...REPORTS_A_FALSE_FAILURE,
+  ...STRANDS_RECLAIMABLE_STATE
+]
+
+/** The body of `region` in `source`, or a failed expectation naming the region that moved. */
+function readRegion(source: string, region: string): string {
+  const body = readSourceRegionBody(source, region)
+  expect(body, `region "${region}" is gone; re-point this guard at its new name`).not.toBeNull()
+  return body ?? ''
+}
+
+describe('internal durable removals carry the Windows removal policy', () => {
+  it.each(INTERNAL_DURABLE_DELETIONS)(
+    'removes through the retrying helper, or else $breaks ($file)',
+    ({ file, region }) => {
+      const body = readRegion(readFileSync(join(REPO_ROOT, file), 'utf8'), region)
+      expect(
+        findRawRecursiveRemovals(body),
+        `on Windows a raw recursive rm throws on a transiently held handle, and here that is silent until later. Use removeTree/removeTreeSync from src/shared/windows-transient-lock-removal.ts`
+      ).toEqual([])
+    }
+  )
+
+  it('every named region reads back a real body', () => {
+    // Without this, every assertion above passes for a region that matched nothing.
+    for (const { file, region } of INTERNAL_DURABLE_DELETIONS) {
+      const body = readRegion(readFileSync(join(REPO_ROOT, file), 'utf8'), region)
+      expect(body.length, `${file}#${region}`).toBeGreaterThan(60)
+      expect(body, `${file}#${region}`).toMatch(/removeTree(Sync)?\(/)
+    }
+  })
+
+  it('the scan still reports a region that forgot the retries', () => {
+    // Positive control: the guard above is only meaningful if this shape reddens it.
+    expect(
+      findRawRecursiveRemovals(
+        'async function publish(p) {\n  await rm(p, { recursive: true, force: true })\n}'
+      )
+    ).toEqual([2])
+  })
+
+  it('counts a spread of the shared policy as carrying the retries', () => {
+    // The two conditionally-recursive deletes below spread the policy instead of calling removeTree.
+    expect(
+      findRawRecursiveRemovals(
+        'const r = () => rm(p, { ...transientLockRemovalOptions(), recursive: !!recursive })'
+      )
+    ).toEqual([])
+  })
+})
+
+describe('the file-explorer delete reaching a relay host', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    recorded.rmCalls.length = 0
+  })
+
+  const fenceless = {
+    runWithRemovalFence: async (_path: string, remove: () => Promise<void>) => {
+      await remove()
+    }
+  } as unknown as Parameters<typeof deleteRelayPath>[1]
+
+  it('hands Node the retry count on Windows', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' })
+
+    await deleteRelayPath({ targetPath: REPO_ROOT, recursive: true }, fenceless)
+
+    expect(recorded.rmCalls.at(-1)?.[1]).toEqual({
+      recursive: true,
+      force: true,
+      maxRetries: WINDOWS_RM_MAX_RETRIES,
+      retryDelay: expect.any(Number)
+    })
+  })
+
+  it('keeps a non-recursive delete non-recursive', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' })
+
+    await deleteRelayPath({ targetPath: join(REPO_ROOT, 'package.json') }, fenceless)
+
+    expect(recorded.rmCalls.at(-1)?.[1]).toEqual(
+      expect.objectContaining({ recursive: false, maxRetries: WINDOWS_RM_MAX_RETRIES })
+    )
+  })
+
+  it('leaves the call unchanged on macOS and Linux', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'darwin' })
+
+    await deleteRelayPath({ targetPath: REPO_ROOT, recursive: true }, fenceless)
+
+    expect(recorded.rmCalls.at(-1)?.[1]).toEqual({ recursive: true, force: true })
+  })
+
+  it('leaves the shared policy untouched on non-Windows', () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    expect(transientLockRemovalOptions()).toEqual({ recursive: true, force: true })
+  })
+})

--- a/src/main/native-chat/agent-session-journal/journal-epoch-replacement.ts
+++ b/src/main/native-chat/agent-session-journal/journal-epoch-replacement.ts
@@ -1,6 +1,7 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp } from 'node:fs/promises'
 import { join } from 'node:path'
 import { copyFileDurable } from '../../durable-file-write'
+import { removeTree } from '../../../shared/windows-transient-lock-removal'
 import type {
   AgentJournalItemBody,
   AgentJournalItemIdentity,
@@ -87,7 +88,8 @@ export async function replaceJournalEpoch(input: {
     })
     await publishPreparedFile(stagingDir, input.journalDir, JOURNAL_LOG_FILE)
   } finally {
-    await rm(stagingDir, { recursive: true, force: true })
+    // The epoch is published by now; a scratch removal must not turn that into a rejection.
+    await removeTree(stagingDir)
   }
 }
 

--- a/src/main/orcad/electron-serve-browser-process.ts
+++ b/src/main/orcad/electron-serve-browser-process.ts
@@ -1,10 +1,11 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp } from 'node:fs/promises'
 import { createServer, type AddressInfo } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { z } from 'zod'
 import { BrowserError } from '../browser/browser-error'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 import type {
   RuntimeBrowserCommandHost,
   RuntimeBrowserCommands
@@ -185,7 +186,8 @@ export class ElectronServeBrowserProcess {
       }
     }
     if (sidecarDataPath) {
-      await rm(sidecarDataPath, { recursive: true, force: true })
+      // The sidecar was only just SIGKILLed, which is exactly when Windows still holds its profile.
+      await removeTree(sidecarDataPath)
     }
   }
 

--- a/src/main/plugins/plugin-install-staging.ts
+++ b/src/main/plugins/plugin-install-staging.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { cp, mkdir, rm } from 'node:fs/promises'
+import { cp, mkdir } from 'node:fs/promises'
 import { join, relative, resolve, sep } from 'node:path'
 import {
   PLUGIN_MANIFEST_FILENAME,
@@ -9,6 +9,7 @@ import {
   type PluginManifest
 } from '../../shared/plugins/plugin-manifest'
 import { fingerprintPluginConsent } from '../../shared/plugins/plugin-consent-fingerprint'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 import type {
   PluginInstallSource,
   PluginLockEntry
@@ -151,13 +152,15 @@ export async function installStagedPluginTree(input: {
     if (!existingHash.ok || existingHash.hash !== sourceInspection.contentHash) {
       // Why: bundled resources are release-index verified above, so they can
       // safely restore a damaged immutable install instead of staying broken.
-      await rm(versionDir, { recursive: true, force: true })
+      // Repair is the only path that may delete an immutable version dir, so a
+      // removal that gives up leaves the plugin broken and unrepairable.
+      await removeTree(versionDir)
     }
   }
   if (!existsSync(versionDir)) {
     const stagedVersionDir = `${versionDir}.staging`
     try {
-      await rm(stagedVersionDir, { recursive: true, force: true })
+      await removeTree(stagedVersionDir)
       await mkdir(pluginDir, { recursive: true })
       // Source trees can change while copying. Hashing the destination closes
       // that race before the immutable directory becomes current.
@@ -197,7 +200,8 @@ export async function installStagedPluginTree(input: {
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error.message : String(error) }
     } finally {
-      await rm(stagedVersionDir, { recursive: true, force: true })
+      // A leftover `.staging` is what the copy above collides with next time.
+      await removeTree(stagedVersionDir)
     }
   } else {
     // Never repoint at an existing hash directory without proving its bytes;

--- a/src/main/plugins/plugin-install.ts
+++ b/src/main/plugins/plugin-install.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, realpath, rm } from 'node:fs/promises'
+import { mkdtemp, readdir, realpath } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { removeTree } from '../../shared/windows-transient-lock-removal'
@@ -140,7 +140,7 @@ export async function installPluginFromGit(input: {
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error.message : String(error) }
     } finally {
-      await rm(stagingDir, { recursive: true, force: true })
+      await removeTree(stagingDir)
     }
   })
 }
@@ -189,7 +189,7 @@ export async function installPluginFromMarketplace(input: {
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error.message : String(error) }
     } finally {
-      await rm(stagingDir, { recursive: true, force: true })
+      await removeTree(stagingDir)
     }
   })
 }

--- a/src/main/plugins/plugin-marketplace-fetch.ts
+++ b/src/main/plugins/plugin-marketplace-fetch.ts
@@ -1,5 +1,5 @@
 import { createReadStream } from 'node:fs'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -8,6 +8,7 @@ import {
   type PluginMarketplace
 } from '../../shared/plugins/plugin-marketplace'
 import { checkoutPluginGitSource } from './plugin-git-repository'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 import type { PluginMarketplaceRegisteredSource } from './plugin-marketplace-store'
 
 const MARKETPLACE_INDEX_MAX_BYTES = 16 * 1024 * 1024
@@ -33,7 +34,7 @@ export async function fetchPluginMarketplace(
     const marketplace = await readPluginMarketplaceIndex(stagingDirectory)
     return { marketplaceCommit, marketplace }
   } finally {
-    await rm(stagingDirectory, { recursive: true, force: true })
+    await removeTree(stagingDirectory)
   }
 }
 

--- a/src/main/plugins/plugin-marketplace-installer.ts
+++ b/src/main/plugins/plugin-marketplace-installer.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { PluginManifest } from '../../shared/plugins/plugin-manifest'
 import { getUserPluginsDir } from './plugin-discovery'
 import { checkoutPluginGitSource } from './plugin-git-repository'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 import {
   installPluginFromMarketplace,
   readPluginLockfile,
@@ -93,7 +94,7 @@ export class PluginMarketplaceInstaller {
         ...(listing.blockedByKillList ? { blockedByKillList: listing.blockedByKillList } : {})
       }
     } finally {
-      await rm(stagingDirectory, { recursive: true, force: true })
+      await removeTree(stagingDirectory)
     }
   }
 

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -20,6 +20,7 @@ import {
 import { homedir, tmpdir } from 'node:os'
 import { basename, dirname, extname, join } from 'node:path'
 import type { SearchOptions, SearchResult } from '../../shared/code-search-types'
+import { transientLockRemovalOptions } from '../../shared/windows-transient-lock-removal'
 import type { DirEntry, FsChangeEvent, MarkdownDocument } from '../../shared/filesystem-entry-types'
 import type { GitWorktreeInfo, Worktree } from '../../shared/worktree/types'
 import {
@@ -2122,7 +2123,8 @@ export class RuntimeFileCommands {
       preserveSymlink: true
     })
     // Why: a non-local runtime has no client Trash; this delete is permanent, so the renderer confirms before calling.
-    await rm(targetPath, { recursive: recursive === true, force: true })
+    // The retry policy is spread rather than removeTree'd because this delete is only recursive on request.
+    await rm(targetPath, { ...transientLockRemovalOptions(), recursive: recursive === true })
     return { ok: true }
   }
 

--- a/src/main/skills/skill-bundle-creation.ts
+++ b/src/main/skills/skill-bundle-creation.ts
@@ -18,6 +18,7 @@ import {
   validateSkillPackageName
 } from '../../shared/skill-package-manifest'
 import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 import { renameSkillPathWithWindowsRetry } from './skill-filesystem-retry'
 import { extractSkillBundleArchive } from './skill-bundle-extraction'
 import {
@@ -236,7 +237,7 @@ async function createSkillBundleArchiveUnobserved(
     await renameSkillPathWithWindowsRetry(temporaryArchive, input.archivePath)
     return { pluginManifest, manifest, archivePath: input.archivePath, ...archiveIdentity }
   } finally {
-    await rm(workDirectory, { recursive: true, force: true })
+    await removeTree(workDirectory)
     await rm(temporaryArchive, { force: true }).catch(() => undefined)
   }
 }

--- a/src/main/skills/skill-bundle-extraction.ts
+++ b/src/main/skills/skill-bundle-extraction.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdir, open, readFile, rm } from 'node:fs/promises'
+import { mkdir, open, readFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import {
   AGENT_PLUGIN_MANIFEST_PATH,
@@ -15,6 +15,7 @@ import {
 } from '../../shared/skill-package-manifest'
 import { SKILL_INSTALL_CANCELLED_FAILURE } from '../../shared/skill-install-failure'
 import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 import { observeSkillPackage } from './skill-package-identity'
 import {
   openSkillTarGzip,
@@ -256,7 +257,8 @@ export async function extractSkillBundleArchive(input: {
     archive.abort(failure)
     await archive.archiveIdentity.catch(() => undefined)
     if (destinationCreated) {
-      await rm(input.destinationDirectory, { recursive: true, force: true })
+      // Rolling back must not replace the failure the caller needs to see.
+      await removeTree(input.destinationDirectory)
     }
     throw failure
   }

--- a/src/main/skills/skill-package-creation.ts
+++ b/src/main/skills/skill-package-creation.ts
@@ -9,6 +9,7 @@ import {
   type SkillPackageManifestV1
 } from '../../shared/skill-package-manifest'
 import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 import { renameSkillPathWithWindowsRetry } from './skill-filesystem-retry'
 import { startSkillPhaseOperation } from './skill-operation-observability'
 import {
@@ -129,7 +130,7 @@ async function createSkillPackageArchiveUnobserved(
     await renameSkillPathWithWindowsRetry(temporaryArchive, input.archivePath)
     return { manifest, archivePath: input.archivePath, ...archiveIdentity }
   } finally {
-    await rm(workDirectory, { recursive: true, force: true })
+    await removeTree(workDirectory)
     await rm(temporaryArchive, { force: true }).catch(() => undefined)
   }
 }

--- a/src/main/skills/skill-package-download.ts
+++ b/src/main/skills/skill-package-download.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID, timingSafeEqual } from 'node:crypto'
-import { chmod, mkdir, mkdtemp, open, readdir, rm } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, open, readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import {
   SKILL_PACKAGE_CONTENT_TYPE,
@@ -11,6 +11,7 @@ import {
   throwIfSkillDownloadUnavailable
 } from './skill-package-download-availability'
 import { startSkillPhaseOperation } from './skill-operation-observability'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
 const MAX_REDIRECTS = 3
@@ -146,7 +147,8 @@ async function prepareTemporaryRoot(path: string): Promise<string> {
             : null
           const pid = Number(match?.[1])
           if (match && Number.isSafeInteger(pid) && !processIsAlive(pid)) {
-            await rm(join(path, entry.name), { recursive: true, force: true })
+            // A dead process's leftover directory must not fail this process's download.
+            await removeTree(join(path, entry.name))
           }
         })
       )
@@ -269,10 +271,10 @@ async function downloadSkillPackageGrantUnobserved(
         archivePath,
         archiveSha256,
         compressedBytes,
-        cleanup: () => rm(temporaryDirectory, { recursive: true, force: true })
+        cleanup: () => removeTree(temporaryDirectory)
       }
     } catch (error) {
-      await rm(temporaryDirectory, { recursive: true, force: true })
+      await removeTree(temporaryDirectory)
       throw error
     }
   } finally {

--- a/src/main/skills/skill-package-extraction.ts
+++ b/src/main/skills/skill-package-extraction.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdir, open, readFile, rm } from 'node:fs/promises'
+import { mkdir, open, readFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import {
   SKILL_PACKAGE_MAX_MANIFEST_BYTES,
@@ -8,6 +8,7 @@ import {
   type SkillPackageManifestV1
 } from '../../shared/skill-package-manifest'
 import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 import type { ObservedSkillPackage } from './skill-package-identity'
 import {
   openSkillTarGzip,
@@ -227,7 +228,8 @@ export async function extractSkillPackageArchive(input: {
     archive.abort(failure)
     await archive.archiveIdentity.catch(() => undefined)
     if (destinationCreated) {
-      await rm(input.destinationDirectory, { recursive: true, force: true })
+      // Rolling back must not replace the failure the caller needs to see.
+      await removeTree(input.destinationDirectory)
     }
     throw failure
   }

--- a/src/main/skills/skill-share-preparation-service.ts
+++ b/src/main/skills/skill-share-preparation-service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { mkdir, realpath, rm } from 'node:fs/promises'
+import { mkdir, realpath } from 'node:fs/promises'
 import { join } from 'node:path'
 import type {
   SkillSharePreview,
@@ -11,6 +11,7 @@ import type { SkillCloudVersion } from '../../shared/skill-cloud-contract'
 import { createSkillBundleArchive, type CreatedSkillBundle } from './skill-bundle-creation'
 import type { SkillCloudService } from './skill-cloud-service'
 import { readSkillInstallReceipt } from './skill-install-provenance'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 
 const PREPARATION_TTL_MS = 30 * 60 * 1000
 const MAX_PREPARATIONS = 8
@@ -141,7 +142,7 @@ export class SkillSharePreparationService {
       this.preparations.set(preparationId, value)
       return preview(preparationId, value)
     } catch (error) {
-      await rm(directory, { recursive: true, force: true })
+      await removeTree(directory)
       throw error
     } finally {
       this.preparingCount -= 1
@@ -216,7 +217,8 @@ export class SkillSharePreparationService {
     const preparation = this.preparations.get(preparationId)
     preparation?.controller?.abort()
     this.preparations.delete(preparationId)
-    await rm(join(this.root, preparationId), { recursive: true, force: true })
+    // The map entry is already gone, so a removal that gives up strands this directory for good.
+    await removeTree(join(this.root, preparationId))
   }
 
   async dispose(): Promise<void> {
@@ -224,7 +226,7 @@ export class SkillSharePreparationService {
       preparation.controller?.abort()
     }
     this.preparations.clear()
-    await rm(this.root, { recursive: true, force: true })
+    await removeTree(this.root)
   }
 
   private async prune(): Promise<void> {
@@ -240,7 +242,8 @@ export class SkillSharePreparationService {
         if (this.options.initializeRoot) {
           await this.options.initializeRoot()
         } else {
-          await rm(this.root, { recursive: true, force: true })
+          // mkdir below succeeds on a surviving root, so a failed wipe silently keeps last session's work.
+          await removeTree(this.root)
           await mkdir(this.root, { recursive: true, mode: 0o700 })
         }
       })()

--- a/src/main/skills/skill-upload-staging-ownership.ts
+++ b/src/main/skills/skill-upload-staging-ownership.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
-import { lstat, mkdir, opendir, rm } from 'node:fs/promises'
+import { lstat, mkdir, opendir } from 'node:fs/promises'
 import { join } from 'node:path'
+import { removeTree } from '../../shared/windows-transient-lock-removal'
 
 const OWNER_DIRECTORY_PREFIX = 'owner-'
 const OWNER_DIRECTORY_PATTERN =
@@ -36,7 +37,7 @@ export class SkillUploadStagingOwnership {
   }
 
   async remove(): Promise<void> {
-    await rm(this.directory, { recursive: true, force: true })
+    await removeTree(this.directory)
   }
 
   private async cleanupAbandonedOwners(): Promise<void> {
@@ -55,7 +56,8 @@ export class SkillUploadStagingOwnership {
         const candidate = join(this.root, entry.name)
         const stats = await lstat(candidate).catch(() => null)
         if (stats?.isDirectory() && !stats.isSymbolicLink()) {
-          await rm(candidate, { recursive: true, force: true })
+          // This sweep gates initialize(), so one locked orphan would block every upload.
+          await removeTree(candidate)
         }
       }
     } finally {

--- a/src/main/user-facing-deletion-retry-policy.test.ts
+++ b/src/main/user-facing-deletion-retry-policy.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { findRawRecursiveRemovals } from '../shared/raw-recursive-removal-scan'
+import { readSourceRegionBody } from '../shared/source-region-body'
 import {
   WINDOWS_RM_MAX_RETRIES,
   transientLockRemovalOptions
@@ -80,28 +81,36 @@ const USER_FACING_DELETIONS: UserFacingDeletion[] = [
     file: 'src/cli/handlers/account.ts',
     region: 'async function cleanupClaudeLoginArtifacts',
     deletes: "a removed account's config directory"
+  },
+  {
+    file: 'src/cli/handlers/account.ts',
+    region: 'async function addCodexAccount',
+    deletes: 'the temporary CODEX_HOME an interrupted login left behind'
+  },
+  {
+    file: 'src/main/claude-accounts/claude-login-session.ts',
+    region: 'async function removeTemporaryClaudeConfigDir',
+    deletes: 'the temporary Claude config directory a login wrote into'
+  },
+  // Both halves of one gesture: the file explorer's confirmed permanent delete. The renderer routes
+  // it to the runtime host, and a relay host serves it from the other side of the wire.
+  {
+    file: 'src/main/runtime/orca-runtime-files.ts',
+    region: 'async deleteFileExplorerPath',
+    deletes: 'a file or folder the user deleted from the file explorer'
+  },
+  {
+    file: 'src/relay/fs-path-mutation-requests.ts',
+    region: 'export async function deleteRelayPath',
+    deletes: 'that same file explorer delete, on a relay host'
   }
 ]
 
-/** The body of `region` in `source`, from its signature to the brace that closes it. */
+/** The body of `region` in `source`, or a failed expectation naming the region that moved. */
 function readRegion(source: string, region: string): string {
-  const start = source.indexOf(region)
-  expect(start, `region "${region}" is gone; re-point this guard at its new name`).toBeGreaterThan(
-    -1
-  )
-  const open = source.indexOf('{', start)
-  let depth = 0
-  for (let i = open; i < source.length; i += 1) {
-    if (source[i] === '{') {
-      depth += 1
-    } else if (source[i] === '}') {
-      depth -= 1
-      if (depth === 0) {
-        return source.slice(start, i + 1)
-      }
-    }
-  }
-  throw new Error(`region "${region}" never closes`)
+  const body = readSourceRegionBody(source, region)
+  expect(body, `region "${region}" is gone; re-point this guard at its new name`).not.toBeNull()
+  return body ?? ''
 }
 
 describe('user-facing deletions carry the Windows removal policy', () => {
@@ -121,14 +130,15 @@ describe('user-facing deletions carry the Windows removal policy', () => {
     }
   )
 
-  it('the region reader returns a real body rather than an empty string', () => {
-    // Without this every assertion above passes for a region that matched nothing.
-    const body = readRegion(
-      readFileSync(join(REPO_ROOT, 'src/main/speech/model-manager.ts'), 'utf8'),
-      'async deleteModel'
-    )
-    expect(body).toContain('removeTree')
-    expect(body.length).toBeGreaterThan(100)
+  it('every named region reads back a real body', () => {
+    // Without this, every assertion above passes for a region whose body was read short — which a
+    // signature like `): Promise<{ ok: true }> {` did until the reader learned to skip return types.
+    for (const { file, region } of USER_FACING_DELETIONS) {
+      const body = readRegion(readFileSync(join(REPO_ROOT, file), 'utf8'), region)
+      expect(body.length, `${file}#${region}`).toBeGreaterThan(100)
+      // `removeTree` is passed by reference in one region, so match the name rather than a call.
+      expect(body, `${file}#${region}`).toMatch(/removeTree(Sync)?\b|transientLockRemovalOptions\(/)
+    }
   })
 
   it('the scan still reports a region that forgot the retries', () => {

--- a/src/relay/fs-path-mutation-requests.ts
+++ b/src/relay/fs-path-mutation-requests.ts
@@ -1,6 +1,7 @@
 import { writeFile, stat, lstat, mkdir, rename, cp, rm } from 'node:fs/promises'
 import { expandTilde } from './context'
 import { assertNoClobberRenameDestinationAvailable } from '../shared/filesystem-rename-collision'
+import { transientLockRemovalOptions } from '../shared/windows-transient-lock-removal'
 import type { RelayFilesystemWatchRegistry } from './relay-filesystem-watch-registry'
 
 export async function writeRelayFile(params: Record<string, unknown>) {
@@ -29,7 +30,7 @@ export async function deleteRelayPath(
   if (stats.isDirectory() && !recursive) {
     throw new Error('Cannot delete directory without recursive flag')
   }
-  const remove = () => rm(targetPath, { recursive: !!recursive, force: true })
+  const remove = () => rm(targetPath, { ...transientLockRemovalOptions(), recursive: !!recursive })
   if (stats.isDirectory()) {
     // Why: forced orphan cleanup bypasses git.removeWorktree but must hold
     // the same relay-wide watcher fence through recursive deletion.

--- a/src/shared/raw-recursive-removal-scan.ts
+++ b/src/shared/raw-recursive-removal-scan.ts
@@ -61,7 +61,8 @@ export function findRawRecursiveRemovals(source: string): number[] {
     if (!args.includes('recursive')) {
       continue
     }
-    if (args.includes('maxRetries')) {
+    // The shared policy helper *is* the retry count, so a call spreading it is not an offender.
+    if (args.includes('maxRetries') || args.includes('transientLockRemovalOptions')) {
       continue
     }
     offenders.push(source.slice(0, match.index).split('\n').length)

--- a/src/shared/source-region-body.ts
+++ b/src/shared/source-region-body.ts
@@ -1,0 +1,53 @@
+// Why: the removal-policy guards assert over one named region of a file rather than the whole
+// file, so both need the same answer to "where does this region's body end?". Reading it wrong is
+// silent — a truncated body has nothing in it to flag, so the guard passes for the wrong reason.
+
+/**
+ * The text of `region` in `source`, from the start of its signature to the brace that closes its
+ * body.
+ *
+ * The body's opening brace is the first `{` outside both the argument list and the return type, so
+ * neither an inline object parameter (`f(input: { a: string })`) nor an object return type
+ * (`: Promise<{ ok: true }>`) ends the region on the signature. Getting either wrong is silent: the
+ * caller gets a body with nothing in it to flag. Returns `null` when the region is absent.
+ */
+export function readSourceRegionBody(source: string, region: string): string | null {
+  const start = source.indexOf(region)
+  if (start === -1) {
+    return null
+  }
+  let parens = 0
+  let angles = 0
+  let open = -1
+  for (let i = start; i < source.length; i += 1) {
+    const char = source[i]
+    if (char === '(') {
+      parens += 1
+    } else if (char === ')') {
+      parens -= 1
+    } else if (parens === 0 && char === '<') {
+      angles += 1
+    } else if (parens === 0 && char === '>') {
+      // Clamped so the `>` of an arrow signature cannot drive the depth negative.
+      angles = Math.max(0, angles - 1)
+    } else if (char === '{' && parens === 0 && angles === 0) {
+      open = i
+      break
+    }
+  }
+  if (open === -1) {
+    return null
+  }
+  let depth = 0
+  for (let i = open; i < source.length; i += 1) {
+    if (source[i] === '{') {
+      depth += 1
+    } else if (source[i] === '}') {
+      depth -= 1
+      if (depth === 0) {
+        return source.slice(start, i + 1)
+      }
+    }
+  }
+  return null
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​304 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​26 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​278 |
| Prod | 27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​162 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​70 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 |

<!-- /orca-pr-loc -->

Stacked on #17245 — review that first. Uses the `removeTree`/`removeTreeSync` helper #17227 introduced; adds no second copy of the retry constants.

## ELI5

On Windows a folder cannot be deleted while any program still holds a file inside it open — antivirus, the search indexer, or a program that only just exited. The hold lasts a few milliseconds. Node has a built-in "wait and try again" setting for exactly this, and this repo already settled on 8 attempts.

#17245 put the deletions a **person** asked for onto that setting. This PR does the tier below: the deletions **Orca** does to its own bookkeeping. Nobody is watching those, so when one fails nothing is reported — and the damage shows up later, as a folder that can never be replaced, an operation that reports failure after it already succeeded, or state Orca can no longer find in order to clean up.

## User-facing before/after

Two of these turned out to be plainly user-facing and were filed as internal in the earlier triage:

| | Before | After |
| :-- | :-- | :-- |
| Delete a file or folder in the file explorer, on a paired runtime or over a relay | The confirm dialog says the delete is permanent, then it fails with `EPERM` on a handle that was about to be released. | The delete retries past the transient hold. |
| Log in to a Codex or Claude account and interrupt it | The temporary home the login wrote OAuth material into survives in `%TEMP%`. | Removed. |

And the internal ones, by what a person eventually notices:

| | Before | After |
| :-- | :-- | :-- |
| Launch after an app update | The relocated daemon host cannot be published over its stale copy, so relocation gives up and retries every launch. | The stale copy goes and the new host lands. |
| Open the mobile simulator | A half-materialized serve-sim runtime can never be renamed over. Serve-sim stays unavailable on that machine. | Materialization completes. |
| Reinstall a plugin whose files got damaged | Repair is the only path allowed to delete an immutable version directory. If it gives up, every reinstall afterwards fails the hash check instead. | The damaged version is replaced. |
| Install a plugin or create a skill bundle | The install lands, then the scratch cleanup in `finally` throws over it and the operation is reported as failed. | Reported as what it was. |
| A skill install fails for a real reason | The rollback runs between the failure and the `throw`, so `EPERM` replaces the message that said what actually went wrong. | The real failure survives. |
| Turn off Hermes agent hooks | The plugin directory removal throws before the config rewrite that disables the plugin, so the hook stays on. | Off. |
| Download a skill, or upload one | One dead process's leftover directory fails the sweep that gates every download and every upload. | The orphan is cleared. |
| Import cookies from Firefox | Every exit from the read path removes the copied profile first, so a held copy turns a finished import into "Could not import cookies from Firefox." | Imported. |
| Share a skill | `release()` drops the map entry before removing the directory. Nothing else knows the id, so a failed removal strands the content permanently. | Reclaimed. |

macOS and Linux are unchanged: `transientLockRemovalOptions()` returns plain `{ recursive, force }` off `win32`.

## Census, re-derived

Re-derived from the tree at this stack's merge-base with `main` (`a1f198be0d`). #17245's
census originally read 84 sites in 50 files with 10 converted; the correct figures are **99 in
61** and **11**, and #17245's body now carries them. The 15-site gap was almost entirely an
undercount of test-support files living in `src/`.

**This PR's own headline was also wrong.** It said "45 sites" under *what is left*. 45 is what
this PR **converts**; what is left is **43**. Corrected throughout below.

| | Sites | Files |
| :-- | --: | --: |
| Shipped app (`src/`, non-test) at `a1f198be0d` | **99** | 61 |
| — converted by #17245 (user-facing) | 11 | 7 |
| — **converted here** | **45** | **25** |
| — **left** | **43** | **33** |

Derived by censusing three trees with the same scanner and differencing per file, so a site
that vanished because a file was deleted rather than converted would show up as a file-level
drop rather than a conversion. 11 + 45 + 43 = 99, and the tree at this branch's head censuses
to 43 directly.

Counted twice by two independent methods — the repo's regex scanner
(`raw-recursive-removal-scan.ts`) and an oxc AST walk over `ObjectExpression` property keys —
which agree on the site set byte-for-byte, not merely on the total. Positive control: a raw
`rm(p, { recursive: true, force: true })` planted in a file that had none moved both methods
99 → 100; a companion carrying `maxRetries: 8` moved neither.

One classification is also wrong in #17245, and is corrected there too.
`desktop-script-provider-client.ts` was filed under "platform-gated to macOS, a Windows retry
is provably dead code". It is the **opposite**: `desktopScriptPlatform()` returns `'linux'` or
`'windows'` and `null` on darwin (`src/main/computer/desktop-script-provider-paths.ts:6-14`),
and the client is built through `requiredPlatform()`, so that path runs on Linux and Windows
**only**. It is converted here. The other three macOS-gated sites check out —
`macos-computer-use-permission-status.ts` returns early off darwin, and
`macos-native-provider-client.ts` / `macos-native-provider-transport.ts` are only constructed
from `computer-provider-lifecycle.ts` under `platform === 'darwin'` — and are left alone.

## What is deliberately left, and why

**43** sites, argued rather than assumed. The four buckets are exact, not approximate:
3 + 19 + 20 + 1 = 43.

- **3 macOS-only** — `macos-computer-use-permission-status.ts` (early `platform !== 'darwin'` return), `macos-native-provider-client.ts` and `macos-native-provider-transport.ts` (only constructed under `platform === 'darwin'`). A Windows retry there compiles to a literal no-op.
- **19 test-support living in `src/`** (14 files) — harnesses, fixtures and probes. #17227 already covers the Windows CI lane's own teardowns.
- **20 genuinely disposable scratch** — already in `.catch(() => {})` or a `try { … } catch { /* best-effort */ }`, removing a `mkdtemp` directory whose loss costs disk and nothing else: the parcel-watcher canary, `repo-clone-path`, `create-github-pull-request`, `pet-bundle-import`'s `.tmp` staging, `repo-creation-handlers`, `local-downloaded-folder-promotion`, `legacy-terminal-shim-dir`'s atomic-write temp, `plugin-install-publication`'s historical-version prune (self-healing on the next install), and `speech-model-download-cleanup` (whose durable twin, `deleteModel`, #17245 already converted).
- **`filesystem-download-folder.ts:40`** — leaks a transfer tree, but already `console.warn`s with the path, which is the visibility that failure needs.

**No blanket lint rule is proposed.** #17245's finding holds and this round reinforces it: the populations interleave inside single functions. `daemon-host-relocation.ts` has a durable `rmSync(dest)` four lines from a best-effort staging cleanup, and `serve-sim-runtime-materializer.ts` has all three tiers inside one function.

## Refactor

#17245's `readRegion` took the first `{` after the region name as the start of the body. Any region whose signature carries an object parameter (`f(input: { a: string })`) or an object return type (`: Promise<{ ok: true }>`) therefore scanned a body of `{ ok: true }` — nothing in it to flag, so the gate passed for the wrong reason. This was found by ablation: reverting `orca-runtime-files.ts` reddened **0 of 38**.

The corrected reader is `src/shared/source-region-body.ts`, tracking paren depth and angle depth so neither ends the signature early. Both guards import it, and both now assert every named region reads back a real body rather than checking one region.

`raw-recursive-removal-scan.ts` also learns that a call spreading `transientLockRemovalOptions()` is not an offender — two deletes here are only conditionally recursive, so they spread the policy instead of calling `removeTree`.

## Tests

`src/main/internal-durable-deletion-retry-policy.test.ts` — 26 tests: a ratchet over 22 named internal-durable regions grouped by consequence, a vacuity control asserting every region reads back a real body, a positive control that the scan still reddens a region that forgot the retries, a control that a policy spread is *not* an offender, and behavioural tests that `deleteRelayPath` hands Node `maxRetries: 8` on `win32`, keeps a non-recursive delete non-recursive, and is unchanged on darwin.

`src/main/user-facing-deletion-retry-policy.test.ts` grows from 14 to 22 tests: 4 new regions, and its vacuity control widened to every region.

**Ablation.** Every changed production file reverted one at a time, serially, mutation verified applied by blob hash, tree asserted clean between runs. Baseline 48/48 green.

| Reverted file | Gates reddened |
| :-- | --: |
| `relay/fs-path-mutation-requests.ts` | 4 |
| `skills/skill-package-download.ts` | 3 |
| `plugins/plugin-install.ts` | 3 |
| `shared/raw-recursive-removal-scan.ts` | 3 |
| each of the other 19 changed files | 2 |

`orca-runtime-files.ts` reddened **0** on the first attempt. That was not an inert change — it was the vacuous region read described above. After the reader was fixed it reddens 2.

## Verification

- `pnpm tc` — **exit 0, 0 `error TS`**, run in the foreground and the exit code read directly. Proven non-vacuous: a planted `const x: number = "s"` gave exit 1 and 2 `error TS`.
- `vitest` over every touched module: **8059 passed / 8125** (browser, runtime file explorer, shared) and **6592 passed / 6648** (skills, plugins, codex, daemon, emulator, hermes, orcad, computer, native-chat, relay), plus **1220 passed / 1220** (cli, claude-accounts, both guards). 0 failed.
  - Honest note: attempt 1 of the second batch had **1** failure — `native-chat/agent-session-wire/structured-tui-transcript-catchup.test.ts`, a `vi.waitFor` on a filesystem watcher under a 712-file parallel run. It passed 3/3 in isolation and the batch was green on attempt 2. The change cannot affect it: off `win32` the converted calls are byte-identical, which an existing test asserts.
- `oxlint` on all 29 changed files — exit 0, no diagnostics. Proven non-vacuous: a planted `debugger` + unused binding gave exit 1 and 2 errors. (The first run of this looked clean but had actually printed `No files found to lint` at exit 1 — an unquoted `$VAR` file list collapses to one argv in zsh.)
- `oxfmt --check` — clean on all 29.
- The changed-code quality gate is not reported here; it brace-slices oxlint stdout, which Node 26 pollutes with a package-manager warning. That is the defect #17201 fixes, so the scans above were run directly.

