### PR TITLE
test(persistence): stop a leaked hook-server listener from making the 130k-leaf migration test load-decided

### DIFF
--- a/src/main/persistence-pane-identity-migration.test.ts
+++ b/src/main/persistence-pane-identity-migration.test.ts
@@ -59,7 +59,12 @@ describe('Store', () => {
     getCohortAtEmitMock.mockReturnValue({ nth_repo_added: 2 })
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Why: Store installs an alias-persistence listener on the module-singleton hook server and never
+    // removes it, so a listener left behind here makes the next test's load rebuild the entire
+    // persisted alias list once per registered alias.
+    const { agentHookServer } = await import('./agent-hooks/server')
+    agentHookServer.setPaneKeyAliasPersistenceListener(null)
     rmSync(testState.dir, { recursive: true, force: true })
   })
   it('hydrates split-pane legacy numeric agent status rows onto the matching remapped leaves', async () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

A test in this file pretends a user restarts Orca with a terminal tab split into 130,000 panes, and checks that Orca can rebuild all their pane bookmarks without falling over.

Rebuilding those bookmarks should take about a second. It was taking eight to nineteen, and on a busy machine more than thirty — at which point the test runner gives up and calls it a failure, even though nothing is actually broken.

The reason turned out to have nothing to do with 130,000 panes. Orca's hook server is a single shared object, and when a test builds a profile store, that store hands the hook server a callback and never takes it back. The next test in the file inherits that leftover callback. So for every single one of the 130,001 bookmarks it registers, the hook server stops and rebuilds its entire bookmark list from scratch — about a thousand items each time. Roughly 133 million pieces of pointless bookkeeping.

This change makes each test hand the callback back when it's done. Same 130,000 panes, same checks, ~19× less work.

## User-facing before/after

**None — this is a CI-reliability fix, not a product fix.** Being honest about that: no user behaviour changes, and no shipped code is touched. The entire diff is six lines in one test file.

The leaked-listener effect is test-only by construction: the main process constructs `Store` exactly once (`src/main/index.ts:2432`), so in a real Orca there is never a listener from a *previous* store to inherit. A user with a huge legacy split layout is not paying this cost today.

What changes is for whoever is waiting on a green check:

| | Before | After |
|---|---|---|
| Test, no contention | 7,795–19,152 ms | **1,003 ms** |
| Test, loaded machine (loadavg 69, 18 cores) | 28,006 ms → **33,631 ms, FAILED** | **2,334 ms** |
| Headroom against the repo-wide 30 s cap | 1.1–3.8× | **~13× at the worst load measured** |

Before this, an unrelated PR could go red here purely because it happened to run while the CI box was busy. #17240 — which touches no persistence code at all — is the case that prompted this.

## What was actually wrong

`Store`'s constructor ends with:

```ts
agentHookServer.setPaneKeyAliasPersistenceListener((entries) => { ... })   // store.ts:77
```

`agentHookServer` is a module singleton, and nothing ever clears that listener. Every alias registration ends in:

```ts
this.paneKeyAliasPersistenceListener?.(this.getPersistedPaneKeyAliases())   // server.ts:1771
```

With no listener, the optional call short-circuits and the argument is never evaluated — free. With a listener left over from an earlier test's store, `getPersistedPaneKeyAliases()` runs on every registration, doing `Array.from(map.entries()).flatMap(...)` over up to `PANE_KEY_ALIASES_MAX = 1024` entries. 130,001 registrations × ~1024 ≈ 133M allocations.

The fix clears the listener in `afterEach`.

## Why the fixture was not shrunk

The 130,000 leaves are load-bearing. The test exists (from `30af757a30`, "fix: load large legacy pane alias migrations") to prove that alias rows are appended with a `for…of` loop rather than `push(...entries)`, which blows V8's spread-argument limit. Measured on this repo's Node 26:

```
124,000 → OK
125,000 → RangeError: Maximum call stack size exceeded
```

130,000 is only ~4% above the threshold, and the effective limit *falls* as the call stack deepens. Shrinking the fixture would have quietly disarmed the assertion. Raising the timeout was also rejected — it would have papered over a 20× waste rather than removing it, and the repo has already been bitten by a budget sized to just clear the number of the day.

## Proof the coverage is unchanged

Run serially, one mutation at a time, mutation verified applied via `git diff`, tree restored and re-verified green between runs.

**Gate ablation** — revert the fix's target guard in `workspace-pane-normalization.ts`:
```diff
-      for (const entry of tabAliasEntries) {
-        legacyPaneKeyAliasEntries.push(entry)
-      }
+      legacyPaneKeyAliasEntries.push(...tabAliasEntries)
```
→ **1 failed, 6 passed.** `RangeError: Maximum call stack size exceeded`, on exactly the large-layout test. The gate still reddens post-fix.

**Positive control** — disable the fallback-alias branch in `pane-identity-migration.ts` so one alias row goes missing:
→ **2 failed, 5 passed.** `expected [ …(130000) ] to have a length of 130001 but got 130000`. The content assertions genuinely execute; the test is not vacuous.

**Restored tree** → 7 passed, 7 tests, 1.05 s.

## Verification

- `pnpm tc` — **exit 0**, run in the foreground. Proven non-vacuous: planting `const planted: number = 'not a number'` in the changed file produced `error TS2322` at `persistence-pane-identity-migration.test.ts(68,11)` and **exit 1**; removing it returned exit 0.
- `npx vitest run --config config/vitest.config.ts src/main/persistence src/main/agent-hooks` — **129 files, 1462 passed, 6 skipped, 0 failed.**
- `npx oxlint src/main/persistence-pane-identity-migration.test.ts` — exit 0, clean. Gate proven live: a probe file with `no-dupe-keys` reported 2 errors and exit 1.
- `npx oxfmt --check` — clean.
- Contention reproduced locally with 36 CPU hogs on an 18-core machine; the pre-fix timeout was reproduced directly (33,631 ms > 30,000 ms), not inferred.
