### PR TITLE
fix(pty): stop a relay leaking its own pane identity into every pane it spawns

### DIFF
--- a/src/main/daemon/pty-subprocess/spawn-environment-pane-identity.test.ts
+++ b/src/main/daemon/pty-subprocess/spawn-environment-pane-identity.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { createDaemonPtyEnvironment } from './spawn-environment'
+import { PANE_IDENTITY_ENV_KEYS } from '../../../shared/pane-identity-env'
+import type { PtySubprocessOptions } from '../pty-subprocess'
+
+// Why: the daemon outlives Electron and inherits its own process.env, which names whichever pane
+// the daemon was started from. Pane identity that arrives by inheritance is always the wrong
+// pane's, and ORCA_AGENT_LAUNCH_TOKEN is Orca's proof of authorship — an inherited one lets a pane
+// satisfy a status fence a different pane set. Shared with the relay via PANE_IDENTITY_ENV_KEYS.
+function daemonOpts(env: Record<string, string> | undefined): PtySubprocessOptions {
+  return {
+    shell: '/bin/sh',
+    cwd: '/tmp',
+    cols: 80,
+    rows: 24,
+    ...(env ? { env } : {})
+  } as unknown as PtySubprocessOptions
+}
+
+describe('daemon pane identity env', () => {
+  const leaked = {
+    ORCA_PANE_KEY: 'daemon-own-tab:daemon-own-leaf',
+    ORCA_TAB_ID: 'daemon-own-tab',
+    ORCA_WORKTREE_ID: 'daemon-own-wt',
+    ORCA_AGENT_LAUNCH_TOKEN: 'daemon-own-launch-token'
+  }
+
+  function withInheritedPaneIdentity<T>(run: () => T): T {
+    const saved = new Map(Object.keys(leaked).map((key) => [key, process.env[key]]))
+    Object.assign(process.env, leaked)
+    try {
+      return run()
+    } finally {
+      for (const [key, value] of saved) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
+  }
+
+  it('drops every inherited pane identity key the spawn did not ask for', () => {
+    const env = withInheritedPaneIdentity(() => createDaemonPtyEnvironment(daemonOpts(undefined)))
+    for (const key of PANE_IDENTITY_ENV_KEYS) {
+      expect(`${key}=${env[key]}`).toBe(`${key}=undefined`)
+    }
+  })
+
+  it('keeps only the pane identity this spawn explicitly named', () => {
+    // Why a partial env: the spawn names the pane but not the token, which is exactly a
+    // non-agent pane. The named key must survive and the unnamed one must not be inherited.
+    const env = withInheritedPaneIdentity(() =>
+      createDaemonPtyEnvironment(daemonOpts({ ORCA_PANE_KEY: 'tab-1:leaf-1' }))
+    )
+    expect(env.ORCA_PANE_KEY).toBe('tab-1:leaf-1')
+    expect(`token=${env.ORCA_AGENT_LAUNCH_TOKEN}`).toBe('token=undefined')
+    expect(`tab=${env.ORCA_TAB_ID}`).toBe('tab=undefined')
+    expect(`wt=${env.ORCA_WORKTREE_ID}`).toBe('wt=undefined')
+  })
+})

--- a/src/main/daemon/pty-subprocess/spawn-environment.ts
+++ b/src/main/daemon/pty-subprocess/spawn-environment.ts
@@ -18,13 +18,8 @@ import {
 } from '../../../shared/windows-environment-expansion'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import type { PtySubprocessOptions } from '../pty-subprocess'
+import { removeUnspecifiedPaneIdentityEnv } from '../../../shared/pane-identity-env'
 
-const PANE_IDENTITY_ENV_KEYS = [
-  'ORCA_PANE_KEY',
-  'ORCA_TAB_ID',
-  'ORCA_WORKTREE_ID',
-  'ORCA_AGENT_LAUNCH_TOKEN'
-] as const
 const WINDOWS_PATH_ENV_KEY_RE = /^path$/i
 
 function composeGuardedDaemonGitConfigEnv(
@@ -55,17 +50,6 @@ function deleteRequestedDaemonEnvKeys(
   }
   if (deleteOrcaOwnedCodexHome) {
     delete env.CODEX_HOME
-  }
-}
-
-function removeUnspecifiedPaneIdentityEnv(
-  env: Record<string, string>,
-  explicitEnv: Record<string, string> | undefined
-): void {
-  for (const key of PANE_IDENTITY_ENV_KEYS) {
-    if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
-      delete env[key]
-    }
   }
 }
 

--- a/src/relay/pty-handler-revive.test.ts
+++ b/src/relay/pty-handler-revive.test.ts
@@ -111,6 +111,57 @@ describe('PtyHandler', () => {
     expect(callArgs.env.ORCA_SHELL_FEATURES).not.toContain('identity')
   })
 
+  it('does not leak the relay process own pane identity into a spawned or revived pane', async () => {
+    // Why: the relay inherits process.env wholesale, and a relay is routinely started *from* an
+    // Orca agent pane — so that pane's identity quadruple rides into every pane the relay spawns.
+    // ORCA_AGENT_LAUNCH_TOKEN is the damaging member: it is Orca's proof of authorship, and an
+    // inherited one makes an unrelated remote pane claim the launch of the pane the relay was
+    // started from. The retired-pane fence is keyed on it, so one leaked token lets any pane on
+    // the relay pass a fence another pane set. The daemon path already scrubs exactly these four
+    // keys (removeUnspecifiedPaneIdentityEnv); this pins the same contract for the relay.
+    const leaked = {
+      ORCA_PANE_KEY: 'relay-own-tab:relay-own-leaf',
+      ORCA_TAB_ID: 'relay-own-tab',
+      ORCA_WORKTREE_ID: 'relay-own-wt',
+      ORCA_AGENT_LAUNCH_TOKEN: 'relay-own-launch-token'
+    }
+    const saved = new Map(Object.keys(leaked).map((key) => [key, process.env[key]]))
+    Object.assign(process.env, leaked)
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    try {
+      // A bare remote pane: the client names no pane identity at all.
+      await dispatcher.callRequest('pty.spawn', { cols: 90, rows: 30, cwd: '/tmp' })
+      const freshEnv = (mockPtySpawn.mock.calls[0][2] as { env: Record<string, string> }).env
+      for (const key of Object.keys(leaked)) {
+        expect(`${key}=${freshEnv[key]}`).toBe(`${key}=undefined`)
+      }
+
+      // And across revive, where no pane identity is ever re-supplied for the token.
+      const state = JSON.stringify([
+        { id: 'pty-9', pid: process.pid, cols: 80, rows: 24, cwd: '/tmp', paneKey: 'tab-9:1' }
+      ])
+      await handler.dispose({ waitForPhysicalExit: false })
+      mockPtySpawn.mockClear()
+      dispatcher = createMockDispatcher()
+      handler = new PtyHandler(dispatcher as unknown as RelayDispatcher)
+      await dispatcher.callRequest('pty.revive', { state })
+      const revivedEnv = (mockPtySpawn.mock.calls[0][2] as { env: Record<string, string> }).env
+      expect(revivedEnv.ORCA_PANE_KEY).toBe('tab-9:1')
+      expect(`token=${revivedEnv.ORCA_AGENT_LAUNCH_TOKEN}`).toBe('token=undefined')
+      expect(`tab=${revivedEnv.ORCA_TAB_ID}`).toBe('tab=undefined')
+      expect(`wt=${revivedEnv.ORCA_WORKTREE_ID}`).toBe('wt=undefined')
+    } finally {
+      killSpy.mockRestore()
+      for (const [key, value] of saved) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
+  })
+
   it('fences both revived worktree identity and cwd with rollback', async () => {
     const finishSiblingAdmission = vi.fn()
     const beginWorktreePtySpawn = vi.fn((operationPath: string) => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -4,6 +4,7 @@ import type * as NodePty from 'node-pty'
 import { existsSync } from 'node:fs'
 import { basename, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
+import { removeUnspecifiedPaneIdentityEnv } from '../shared/pane-identity-env'
 import { resolveWindowsGitBashShellPath } from '../main/git-bash'
 import { WINDOWS_GIT_BASH_SHELL } from '../shared/windows-terminal-shell'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
@@ -707,6 +708,12 @@ export class PtyHandler {
     // on, yet an inherited Orca HISTFILE must not scope a pane to someone else's
     // worktree on the disabled and revive paths either.
     dropInheritedOrcaHistFile(result)
+    // Why the same shape as the history drops above: a relay is routinely started *from* an Orca
+    // pane, so its process.env already names that pane. Pane identity that arrives by inheritance
+    // rather than from this spawn is always the wrong pane's — and ORCA_AGENT_LAUNCH_TOKEN is
+    // Orca's proof of authorship, so an inherited one lets any pane on this relay satisfy a status
+    // fence a different pane set. Shares the daemon's scrub so the two hosts cannot drift.
+    removeUnspecifiedPaneIdentityEnv(result, rendererEnv)
     // Why unconditionally: ORCA_HISTFILE is Orca-owned and minted below by
     // injectRelayHistoryEnv, which also runs only with isolation on. An
     // inherited one (the relay can be launched from an Orca pane) would

--- a/src/shared/pane-identity-env-spawn-inventory.test.ts
+++ b/src/shared/pane-identity-env-spawn-inventory.test.ts
@@ -1,0 +1,179 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { glob } from 'tinyglobby'
+import {
+  blankStringContents,
+  blankStringContentsDesynced,
+  stripComments
+} from './source-scan/source-tree-scan'
+import { PANE_IDENTITY_ENV_KEYS } from './pane-identity-env'
+
+// Why this ratchet exists: 52 files name ORCA_AGENT_LAUNCH_TOKEN, but nothing stated the rule that
+// produces it. A spawn that reuses a pane key a previous launch already owned must stamp a launch
+// token, because the token is Orca's only in-band proof of authorship and the status fences read a
+// tokenless post as foreign. Two paths shipped without it — the detached-pane restart (#17243) and
+// the relay's revive — each found by accident. Adding a pane-identity env site now forces a
+// deliberate classification here instead of silently joining the broken half.
+type TokenBehavior =
+  /** Mints a fresh token: this spawn reuses or claims a pane key, so it must prove authorship. */
+  | 'mints-token'
+  /** Forwards a token it was handed; absence is the caller's decision, not this site's. */
+  | 'propagates-token'
+  /** Deliberately tokenless: a non-agent pane on a pane key no prior launch owned. */
+  | 'no-agent-launch'
+  /** Removes pane identity rather than authoring it (a scrub or an admission fence). */
+  | 'strips-identity'
+
+type Site = { path: string; behavior: TokenBehavior; marker: string }
+
+const INVENTORY: readonly Site[] = [
+  {
+    path: 'src/renderer/src/components/terminal-pane/codex-detached-pane-restart.ts',
+    behavior: 'mints-token',
+    marker: 'ORCA_AGENT_LAUNCH_TOKEN: createBrowserUuid()'
+  },
+  {
+    path: 'src/renderer/src/lib/adopt-agent-background-session-tab.ts',
+    behavior: 'mints-token',
+    marker: 'ORCA_AGENT_LAUNCH_TOKEN: launchToken'
+  },
+  {
+    path: 'src/renderer/src/components/terminal-pane/pty-connection/agent-idle-working-handlers.ts',
+    behavior: 'propagates-token',
+    marker: 'ORCA_AGENT_LAUNCH_TOKEN: session.launchToken'
+  },
+  {
+    path: 'src/renderer/src/components/terminal-pane/pty-connection/deferred-cold-restore-and-snapshot.ts',
+    behavior: 'propagates-token',
+    marker: 'ORCA_AGENT_LAUNCH_TOKEN: env.ORCA_AGENT_LAUNCH_TOKEN'
+  },
+  {
+    path: 'src/renderer/src/components/terminal-pane/pty-connection/cold-restore-resume-startup.ts',
+    behavior: 'mints-token',
+    marker: 'ORCA_AGENT_LAUNCH_TOKEN: coldRestoreLaunchToken'
+  },
+  {
+    // Why tokenless is correct: setup scripts and default tabs carry no launchConfig and land on
+    // freshly minted pane keys, so no fence can exist for them to fail.
+    path: 'src/renderer/src/lib/launch-worktree-background-terminals.ts',
+    behavior: 'no-agent-launch',
+    marker: 'ORCA_PANE_KEY: makePaneKey(tabId, leafId)'
+  },
+  {
+    // Mints only for a launchConfig spawn (an agent); a bare workspace terminal stays tokenless.
+    path: 'src/main/runtime/orca-runtime.ts',
+    behavior: 'mints-token',
+    marker: 'ORCA_AGENT_LAUNCH_TOKEN: launchToken'
+  },
+  {
+    path: 'src/main/ipc/pty/ipc/spawn-env.ts',
+    behavior: 'strips-identity',
+    marker: 'delete ctx.baseEnv.ORCA_AGENT_LAUNCH_TOKEN'
+  },
+  {
+    path: 'src/main/ipc/pty/provider/liveness.ts',
+    behavior: 'strips-identity',
+    marker: 'delete stripped.ORCA_AGENT_LAUNCH_TOKEN'
+  },
+  {
+    path: 'src/main/daemon/pty-subprocess/spawn-environment.ts',
+    behavior: 'strips-identity',
+    marker: 'removeUnspecifiedPaneIdentityEnv(env, opts.env)'
+  },
+  {
+    path: 'src/relay/pty-handler.ts',
+    behavior: 'strips-identity',
+    marker: 'removeUnspecifiedPaneIdentityEnv(result, rendererEnv)'
+  }
+]
+
+/** Names the var without authoring pane identity: hook-script emitters and passthrough allowlists. */
+const NON_AUTHORING = new Set([
+  'src/main/agent-hooks/hook-post-command.ts',
+  'src/main/agent-hooks/hook-stdin-contract.ts',
+  'src/main/agent-hooks/installer-utils.ts',
+  'src/main/amp/agent-status-plugin-source.ts',
+  'src/main/antigravity/hook-script.ts',
+  'src/main/command-code/command-code-managed-script.ts',
+  'src/main/copilot/copilot-managed-script.ts',
+  'src/main/cursor/hook-script.ts',
+  'src/main/cursor/hook-service.ts',
+  'src/main/devin/hook-service.ts',
+  'src/main/droid/hook-service.ts',
+  'src/main/gemini/hook-service.ts',
+  'src/main/grok/grok-hook-script.ts',
+  'src/main/hermes/hermes-managed-plugin-source.ts',
+  'src/main/kimi/hook-service.ts',
+  'src/main/opencode/status-plugin-post-source.ts',
+  'src/main/pi/agent-status-extension-source.ts',
+  'src/main/providers/local-pty-launch-helpers.ts',
+  'src/main/pty/wsl-orca-env.ts',
+  'src/main/ssh/ssh-remote-cli-host-passthrough.ts',
+  'src/main/ipc/pty/pane/launch-authority.ts',
+  'src/relay/remote-cli-env.ts',
+  'src/shared/orchestration-compatibility-evidence.ts',
+  'src/shared/pane-identity-env.ts'
+])
+
+describe('pane identity env spawn-site ratchet', () => {
+  it('classifies every file that names the launch token', async () => {
+    const files = await glob(['src/**/*.{ts,tsx}'], { ignore: ['**/*.test.*', '**/*.spec.*'] })
+    const found: string[] = []
+    for (const path of files) {
+      const raw = readFileSync(join(process.cwd(), path), 'utf8')
+      if (!raw.includes('ORCA_AGENT_LAUNCH_TOKEN')) {
+        continue
+      }
+      const decommented = stripComments(raw)
+      if (blankStringContentsDesynced(decommented)) {
+        throw new Error(`String scanner desynchronized while inventorying ${path}`)
+      }
+      // Why the decommented+blanked read: a mention inside a comment or an emitted shell snippet
+      // is not this file authoring pane identity.
+      if (!blankStringContents(decommented).includes('ORCA_AGENT_LAUNCH_TOKEN')) {
+        continue
+      }
+      found.push(path)
+    }
+    const classified = new Set([...INVENTORY.map((site) => site.path), ...NON_AUTHORING])
+    expect(found.filter((path) => !classified.has(path)).sort()).toEqual([])
+  })
+
+  it('pins the token decision each inventoried spawn site actually makes', () => {
+    for (const site of INVENTORY) {
+      const source = stripComments(readFileSync(join(process.cwd(), site.path), 'utf8'))
+      expect({
+        path: site.path,
+        behavior: site.behavior,
+        present: source.includes(site.marker)
+      }).toEqual({
+        path: site.path,
+        behavior: site.behavior,
+        present: true
+      })
+    }
+  })
+
+  it('keeps both PTY hosts scrubbing the same pane identity key set', () => {
+    // Why: the daemon and the relay each inherit a process env that names whichever pane their
+    // host was launched from. One host drifting from the shared key set is how the relay lost the
+    // launch token while the daemon kept it.
+    expect([...PANE_IDENTITY_ENV_KEYS]).toEqual([
+      'ORCA_PANE_KEY',
+      'ORCA_TAB_ID',
+      'ORCA_WORKTREE_ID',
+      'ORCA_AGENT_LAUNCH_TOKEN'
+    ])
+    for (const path of [
+      'src/main/daemon/pty-subprocess/spawn-environment.ts',
+      'src/relay/pty-handler.ts'
+    ]) {
+      const source = stripComments(readFileSync(join(process.cwd(), path), 'utf8'))
+      expect({ path, scrubs: source.includes('removeUnspecifiedPaneIdentityEnv(') }).toEqual({
+        path,
+        scrubs: true
+      })
+    }
+  })
+})

--- a/src/shared/pane-identity-env-spawn-inventory.test.ts
+++ b/src/shared/pane-identity-env-spawn-inventory.test.ts
@@ -9,12 +9,13 @@ import {
 } from './source-scan/source-tree-scan'
 import { PANE_IDENTITY_ENV_KEYS } from './pane-identity-env'
 
-// Why this ratchet exists: 52 files name ORCA_AGENT_LAUNCH_TOKEN, but nothing stated the rule that
-// produces it. A spawn that reuses a pane key a previous launch already owned must stamp a launch
-// token, because the token is Orca's only in-band proof of authorship and the status fences read a
-// tokenless post as foreign. Two paths shipped without it — the detached-pane restart (#17243) and
-// the relay's revive — each found by accident. Adding a pane-identity env site now forces a
-// deliberate classification here instead of silently joining the broken half.
+// Why this ratchet exists: 34 non-test source files name ORCA_AGENT_LAUNCH_TOKEN and 10 of them
+// actually author it, but nothing stated the rule that produces it. A spawn that reuses a pane
+// key a previous launch already owned must stamp a launch token, because the token is Orca's only
+// in-band proof of authorship and the status fences read a tokenless post as foreign. Two paths
+// shipped without it — the detached-pane restart (#17243) and the relay's revive — each found by
+// accident. Adding a pane-identity env site now forces a deliberate classification here instead
+// of silently joining the broken half.
 type TokenBehavior =
   /** Mints a fresh token: this spawn reuses or claims a pane key, so it must prove authorship. */
   | 'mints-token'

--- a/src/shared/pane-identity-env.ts
+++ b/src/shared/pane-identity-env.ts
@@ -1,0 +1,30 @@
+/**
+ * Pane identity that Orca stamps into a PTY's environment.
+ *
+ * Every one of these names a specific pane, so an *inherited* value is always wrong: it names
+ * whichever pane the host process was itself launched from. `ORCA_AGENT_LAUNCH_TOKEN` is the
+ * damaging member — it is Orca's only in-band proof that Orca launched an agent, and gates keyed
+ * on it (the retired-pane status fence, the unmanaged-status-extension fence) read a pane
+ * carrying someone else's token as that other pane's launch.
+ */
+export const PANE_IDENTITY_ENV_KEYS = [
+  'ORCA_PANE_KEY',
+  'ORCA_TAB_ID',
+  'ORCA_WORKTREE_ID',
+  'ORCA_AGENT_LAUNCH_TOKEN'
+] as const
+
+/**
+ * Drops every pane-identity key the spawn did not explicitly ask for, so none survives by
+ * inheritance from the host process. A key the caller named is left exactly as given.
+ */
+export function removeUnspecifiedPaneIdentityEnv(
+  env: Record<string, string>,
+  explicitEnv: Record<string, string> | undefined
+): void {
+  for (const key of PANE_IDENTITY_ENV_KEYS) {
+    if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
+      delete env[key]
+    }
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​293 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​293 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |

<!-- /orca-pr-loc -->

Stacked on #17243. Base: `fix/unmanaged-omp-status-extension`.

## What broke

The relay builds every PTY's environment from its own `process.env`, stripping only build-mode keys:

```ts
// src/relay/pty-handler.ts — buildSpawnEnv()
...stripInheritedBuildModeEnv(process.env),
```

A relay is routinely started **from an Orca pane**. So that pane's identity quadruple —
`ORCA_PANE_KEY`, `ORCA_TAB_ID`, `ORCA_WORKTREE_ID`, `ORCA_AGENT_LAUNCH_TOKEN` — was already sitting in the
relay's `process.env` and rode into **every pane the relay spawned**, fresh or revived.

`ORCA_AGENT_LAUNCH_TOKEN` is the damaging member. It is Orca's only in-band proof of authorship, and the
retired-pane status fence is keyed on it. **One leaked token let any pane on the relay satisfy a fence a
different pane had set.**

The daemon PTY host already scrubbed exactly these four keys. The relay never did.

## The fix

Hoist the daemon's existing scrub into `src/shared/pane-identity-env.ts` and give the relay the same call,
rather than writing a second copy that can drift again:

```ts
removeUnspecifiedPaneIdentityEnv(result, rendererEnv)
```

A key the spawn **explicitly named** is left exactly as given; only keys arriving by *inheritance* are
dropped. Both the spawn and revive paths funnel through `buildSpawnEnv`, so the single insertion covers
both.

## ELI5

Think of each terminal pane as a person wearing a name badge.

The relay is the receptionist who prints badges for everyone who walks in. But the receptionist was
*themself* hired through the same door, and never took **their own** badge off — so every badge they
printed came out with **their** name already on it.

Most of the badge is harmless: a wrong desk number. But one line on it is the signature proving "Orca
personally hired this person," and everyone downstream trusts that signature. So every pane the relay
created walked around holding **someone else's signature**, and could open a door that had been locked
specifically for that other person.

This makes the receptionist take their own badge off before printing anyone else's.

## What a user could actually have seen

**Setup:** you run Orca over SSH, and you start the relay from inside an Orca agent pane — the normal way.
You're already in Orca, you open a terminal, you bring the remote host up from there. That pane had an
agent in it, so it carries a launch token.

**Before**

1. Your agent pane finishes and is retired. Orca sets the retired-pane fence on it, keyed to that pane's
   launch token — "ignore further status posts from this launch."
2. You open a brand-new, unrelated remote pane on that relay. It inherits the retired pane's token.
3. That new pane now presents the *retired* pane's proof of authorship. It matches the fence.
4. The new pane's agent status is **silently suppressed** — the sidebar shows nothing, or shows the dead
   agent's last state. You restart the pane and it stays wrong, because the token is re-inherited on every
   spawn. Every pane on that relay shares one identity.

There is no error message. It reads as "remote agent status is just flaky over SSH."

**After**

Each remote pane is spawned with only the identity that spawn was actually given. It carries no token it
did not earn, does not match another pane's fence, and reports its own status.

## Ratchet

34 non-test source files name `ORCA_AGENT_LAUNCH_TOKEN` and 10 actually author it, but nothing stated the
rule that produces it. Two paths shipped without it — the detached-pane restart (#17243) and this one —
and **each was found by accident**. `src/shared/pane-identity-env-spawn-inventory.test.ts` now forces every
pane-identity env site to be classified deliberately as one of `mints-token` / `propagates-token` /
`no-agent-launch` / `strips-identity`, so a new site cannot silently join the broken half.

## Verification

`pnpm tc` **exit 0**, 0 `error TS` lines, run in the foreground. Gate proven non-vacuous: planting
`const __tcProbe: number = "not-a-number"` gives **exit 1 / TS2322**.

Blast-radius suite (`src/relay src/main/daemon src/shared src/main/ipc/pty src/main/providers src/main/pty`):
**1,056 files / 11,291 tests**. The single red is `remote-runtime-shared-control-connection.test.ts` (E2EE
handshake) — it references none of the changed files, is a real socket-server test, and passes **28/28 in
isolation** on a quiet machine. Not attributable to this PR.

`oxlint` and `oxfmt --check` both exit 0.

### Both scrubs are pinned

Deleting the daemon's scrub reddened **0 tests** before this work — the behaviour this fix copies was itself
entirely unpinned. Ablations run serially, by **deleting the branch** (not `true &&`), with the file hash
compared before/after and the tree restored and verified clean between runs:

| Ablation | Reds | Which |
|---|---|---|
| baseline | 0 / 23 pass | — |
| delete **relay** scrub | **3** | 1 behavioural + 2 ratchet |
| delete **daemon** scrub | **4** | **2 behavioural** + 2 ratchet |

The daemon ablation reddens two *behavioural* tests, not just the source-text ratchet — the 0-red hole is
closed, and each host fails when its own scrub is removed.

## Surface

There are **three** user-pane PTY spawn hosts:

1. **Local / main** — `src/main/ipc/pty/ipc/spawn-env.ts` validates the pane key against the spawn's own
   tab+leaf and deletes all four on mismatch. Already correct.
2. **Daemon** — `spawn-environment.ts`. Already correct; now shares the hoisted module.
3. **Relay** — `pty-handler.ts`. **Was the only one with no scrub at all.** Fixed here.

The scrub runs *after* the env augmenters; neither production augmenter writes a pane-identity key, so it
cannot delete a legitimately-authored value.

## SSH / wire compatibility

No new field and no new stream opcode, so nothing here needs capability negotiation. But scrubbing an env
var changes what the **host** publishes, which reaches old clients with no wire change:

- **New client ↔ new relay** — identity the renderer explicitly names survives; only inherited identity is
  dropped.
- **Old client ↔ new relay** — a client that names the keys keeps them; one that does not now gets panes
  carrying no token where they previously carried the relay's leaked one. The leaked value was always the
  wrong pane's, so nothing correct breaks.
- **New client ↔ old relay** — the leak persists. **The fix lives on the execution host, so it only takes
  effect once the remote relay is upgraded; a client-side update alone changes nothing.**

The fix is pure TypeScript (`Object.hasOwn` + `delete`) and depends on no patched module, so unlike a
node-pty patch it does reach a relay running stock node-pty. No process-liveness verdict is introduced, so
`live` / `unverifiable` / `exited` are untouched.

## Scope: what this does *not* fix

Two status-fence defects in `src/main/agent-hooks/server.ts` are **not** resolved here and need separate
work — they are fence semantics, while this PR is env construction in the PTY hosts:

- **Retired-pane token fence** (`:1246` here; `:1206` on `main`). A tokenless process in a fenced,
  non-retired pane is permanently suppressed, because the only re-fence path requires a token. Note this PR
  makes it *more* reachable: pre-fix every pane on a relay shared the one leaked token, so posts
  accidentally matched whatever fence was set — the leak was **masking** this gate.
- **Relay spool replay fence** (`:2423` here; `:2338` on `main`). This PR removes a source of false matches
  feeding it, but the gate still fails open when no hydrated hash exists.

## Related

**#10188** is the same shape of bug (inherited env markers leaking into spawned PTYs) and touches
`src/relay/pty-handler.ts` and the daemon PTY subprocess as well. Different key set, so not a duplicate, but
a textual conflict is likely for whichever lands second.
