### PR TITLE
feat(mobile): edit multiple direct host addresses

### DIFF
--- a/mobile/app/h/[hostId]/edit.tsx
+++ b/mobile/app/h/[hostId]/edit.tsx
@@ -13,10 +13,15 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { ChevronLeft } from 'lucide-react-native'
+import { HostAddressFields } from '../../../src/components/HostAddressFields'
 import { colors, radii, spacing, typography } from '../../../src/theme/mobile-theme'
 import { loadHosts, updateHostNameAndEndpoint } from '../../../src/transport/host-store'
 import { displayHostEndpoint } from '../../../src/transport/host-endpoint'
-import { resolveHostEndpointEdit } from '../../../src/transport/host-endpoint-edit'
+import {
+  resolveHostEndpointEdit,
+  sameHostEndpointAuthority
+} from '../../../src/transport/host-endpoint-edit'
+import { isTailscaleEndpoint } from '../../../../src/shared/remote-runtime-tailscale-hint'
 import { useForceReconnect, usePrimeHosts } from '../../../src/transport/client-context'
 import type { HostProfile } from '../../../src/transport/types'
 
@@ -31,6 +36,7 @@ export default function EditHostScreen() {
   const [loadError, setLoadError] = useState<string | null>(null)
   const [name, setName] = useState('')
   const [address, setAddress] = useState('')
+  const [alternateAddress, setAlternateAddress] = useState('')
   const [saveError, setSaveError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   // Why: setSaving is async, so a second trigger before the re-render could
@@ -53,6 +59,10 @@ export default function EditHostScreen() {
       setHost(found)
       setName(found.name)
       setAddress(displayHostEndpoint(found.endpoint))
+      const alternate = found.endpoints?.find(
+        ({ kind, url }) => kind !== 'relay' && !sameHostEndpointAuthority(url, found.endpoint)
+      )
+      setAlternateAddress(alternate ? displayHostEndpoint(alternate.url) : '')
       setLoadError(null)
     } catch (err) {
       setLoadError(err instanceof Error ? err.message : 'Failed to load host.')
@@ -68,16 +78,46 @@ export default function EditHostScreen() {
     () => (host ? resolveHostEndpointEdit(host.endpoint, address) : null),
     [address, host]
   )
+  const storedAlternateEndpoint = useMemo(
+    () =>
+      host?.endpoints?.find(
+        ({ kind, url }) => kind !== 'relay' && !sameHostEndpointAuthority(url, host.endpoint)
+      )?.url,
+    [host]
+  )
+  const alternateEndpointEdit = useMemo(() => {
+    if (!host || !alternateAddress.trim()) {
+      return null
+    }
+    return resolveHostEndpointEdit(storedAlternateEndpoint ?? host.endpoint, alternateAddress)
+  }, [alternateAddress, host, storedAlternateEndpoint])
 
   const nameTrimmed = name.trim()
   const nameChanged = host != null && nameTrimmed.length > 0 && nameTrimmed !== host.name
   const endpointChanged = endpointEdit?.kind === 'changed'
+  const alternateEndpoint =
+    alternateEndpointEdit && alternateEndpointEdit.kind !== 'invalid'
+      ? alternateEndpointEdit.endpoint
+      : null
+  const alternateChanged =
+    (storedAlternateEndpoint == null && alternateEndpoint != null) ||
+    (storedAlternateEndpoint != null &&
+      (alternateEndpoint == null ||
+        !sameHostEndpointAuthority(storedAlternateEndpoint, alternateEndpoint)))
+  const duplicateAddresses =
+    endpointEdit != null &&
+    endpointEdit.kind !== 'invalid' &&
+    alternateEndpoint != null &&
+    sameHostEndpointAuthority(endpointEdit.endpoint, alternateEndpoint)
+  const addressesChanged = endpointChanged || alternateChanged
   const canSave =
     host != null &&
     endpointEdit != null &&
     nameTrimmed.length > 0 &&
     endpointEdit.kind !== 'invalid' &&
-    (nameChanged || endpointChanged) &&
+    alternateEndpointEdit?.kind !== 'invalid' &&
+    !duplicateAddresses &&
+    (nameChanged || addressesChanged) &&
     !saving
 
   async function handleSave() {
@@ -93,13 +133,43 @@ export default function EditHostScreen() {
       setSaveError(endpointEdit.error)
       return
     }
+    if (alternateEndpointEdit?.kind === 'invalid') {
+      setSaveError(alternateEndpointEdit.error)
+      return
+    }
+    if (duplicateAddresses) {
+      setSaveError('Use a different alternate address.')
+      return
+    }
 
     const willRename = nextName !== host.name
     const nextEndpoint = endpointEdit.kind === 'changed' ? endpointEdit.endpoint : undefined
-    if (!willRename && nextEndpoint === undefined) {
+    if (!willRename && !addressesChanged) {
       router.back()
       return
     }
+    const resolvedPrimaryEndpoint = nextEndpoint ?? host.endpoint
+    const directEndpoints = [
+      {
+        id: 'direct-primary',
+        kind: isTailscaleEndpoint(resolvedPrimaryEndpoint)
+          ? ('tailscale' as const)
+          : ('lan' as const),
+        url: resolvedPrimaryEndpoint
+      },
+      ...(alternateEndpoint
+        ? [
+            {
+              id: 'direct-alternate-1',
+              kind: isTailscaleEndpoint(alternateEndpoint)
+                ? ('tailscale' as const)
+                : ('lan' as const),
+              url: alternateEndpoint
+            }
+          ]
+        : [])
+    ]
+    const relayEndpoints = host.endpoints?.filter(({ kind }) => kind === 'relay') ?? []
 
     savingRef.current = true
     setSaving(true)
@@ -110,7 +180,16 @@ export default function EditHostScreen() {
       // other, and a host removed mid-edit throws instead of no-oping.
       await updateHostNameAndEndpoint(host.id, {
         ...(willRename ? { name: nextName } : {}),
-        ...(nextEndpoint !== undefined ? { endpoint: nextEndpoint } : {})
+        ...(nextEndpoint !== undefined ? { endpoint: nextEndpoint } : {}),
+        ...(addressesChanged
+          ? {
+              routing: {
+                endpoints: [...directEndpoints, ...relayEndpoints],
+                ...(host.relayHostId ? { relayHostId: host.relayHostId } : {}),
+                ...(host.relay ? { relay: host.relay } : {})
+              }
+            }
+          : {})
       })
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : 'Failed to save host.')
@@ -133,7 +212,7 @@ export default function EditHostScreen() {
     setSaving(false)
     router.back()
 
-    if (nextEndpoint !== undefined) {
+    if (addressesChanged) {
       // Why: reconnect is a follow-on side effect of a save that already
       // committed — its failure or a hang must not be reported as a save
       // failure or block navigating back.
@@ -192,9 +271,8 @@ export default function EditHostScreen() {
             keyboardShouldPersistTaps="handled"
           >
             <Text style={styles.help}>
-              Change the display name or connection address. Address edits only switch where this
-              phone connects — they do not re-pair. Use this when the same desktop is reachable at a
-              different IP (for example home LAN vs Tailscale).
+              Add LAN and Tailscale addresses for the same desktop. Orca uses the first address that
+              connects.
             </Text>
 
             <Text style={styles.label}>Name</Text>
@@ -213,40 +291,24 @@ export default function EditHostScreen() {
               returnKeyType="next"
             />
 
-            <Text style={styles.label}>Address</Text>
-            <TextInput
-              style={styles.input}
-              accessibilityLabel="Address"
-              value={address}
-              onChangeText={(value) => {
+            <HostAddressFields
+              address={address}
+              alternateAddress={alternateAddress}
+              alternateEndpoint={alternateEndpoint}
+              alternateEndpointEdit={alternateEndpointEdit}
+              canSave={canSave}
+              duplicateAddresses={duplicateAddresses}
+              endpointEdit={endpointEdit!}
+              onAddressChange={(value) => {
                 setAddress(value)
                 setSaveError(null)
               }}
-              placeholder="192.168.1.10:6768"
-              placeholderTextColor={colors.textMuted}
-              autoCapitalize="none"
-              autoCorrect={false}
-              autoComplete="off"
-              keyboardType="url"
-              returnKeyType="done"
-              onSubmitEditing={() => {
-                if (canSave) {
-                  void handleSave()
-                }
+              onAlternateAddressChange={(value) => {
+                setAlternateAddress(value)
+                setSaveError(null)
               }}
+              onSubmit={() => void handleSave()}
             />
-            <Text style={styles.hint}>
-              Accepts IP, host:port, or ws:// / wss://. Missing port defaults to the current port
-              (or 6768).
-            </Text>
-
-            {endpointEdit == null ? null : endpointEdit.kind !== 'invalid' ? (
-              <Text style={styles.preview} numberOfLines={2}>
-                Connects to {endpointEdit.endpoint}
-              </Text>
-            ) : address.trim().length > 0 ? (
-              <Text style={styles.previewError}>{endpointEdit.error}</Text>
-            ) : null}
 
             {saveError ? <Text style={styles.errorText}>{saveError}</Text> : null}
           </ScrollView>
@@ -327,22 +389,6 @@ const styles = StyleSheet.create({
     fontSize: typography.bodySize,
     paddingHorizontal: spacing.md,
     paddingVertical: Platform.OS === 'ios' ? 12 : 10
-  },
-  hint: {
-    color: colors.textMuted,
-    fontSize: typography.metaSize,
-    lineHeight: 16
-  },
-  preview: {
-    marginTop: spacing.sm,
-    color: colors.textSecondary,
-    fontSize: typography.metaSize,
-    fontFamily: Platform.OS === 'ios' ? 'Menlo' : typography.monoFamily
-  },
-  previewError: {
-    marginTop: spacing.sm,
-    color: colors.statusRed,
-    fontSize: typography.bodySize
   },
   errorText: {
     color: colors.statusRed,

--- a/mobile/src/components/HostAddressFields.tsx
+++ b/mobile/src/components/HostAddressFields.tsx
@@ -1,0 +1,103 @@
+import { Platform, StyleSheet, Text, TextInput, View } from 'react-native'
+import { colors, radii, spacing, typography } from '../theme/mobile-theme'
+import type { HostEndpointEditResolution } from '../transport/host-endpoint-edit'
+
+type Props = {
+  address: string
+  alternateAddress: string
+  alternateEndpoint: string | null
+  alternateEndpointEdit: HostEndpointEditResolution | null
+  canSave: boolean
+  duplicateAddresses: boolean
+  endpointEdit: HostEndpointEditResolution
+  onAddressChange: (value: string) => void
+  onAlternateAddressChange: (value: string) => void
+  onSubmit: () => void
+}
+
+export function HostAddressFields(props: Props) {
+  return (
+    <View style={styles.fields}>
+      <Text style={styles.label}>Address</Text>
+      <TextInput
+        style={styles.input}
+        accessibilityLabel="Address"
+        value={props.address}
+        onChangeText={props.onAddressChange}
+        placeholder="192.168.1.10:6768"
+        placeholderTextColor={colors.textMuted}
+        autoCapitalize="none"
+        autoCorrect={false}
+        autoComplete="off"
+        keyboardType="url"
+        returnKeyType="next"
+      />
+      <Text style={styles.hint}>
+        Accepts IP, host:port, or ws:// / wss://. Missing port uses the current port or 6768.
+      </Text>
+      {props.endpointEdit.kind !== 'invalid' ? (
+        <Text style={styles.preview} numberOfLines={2}>
+          Primary: {props.endpointEdit.endpoint}
+        </Text>
+      ) : props.address.trim() ? (
+        <Text style={styles.previewError}>{props.endpointEdit.error}</Text>
+      ) : null}
+
+      <Text style={styles.label}>Alternate address</Text>
+      <TextInput
+        style={styles.input}
+        accessibilityLabel="Alternate address"
+        value={props.alternateAddress}
+        onChangeText={props.onAlternateAddressChange}
+        placeholder="100.64.0.10:6768"
+        placeholderTextColor={colors.textMuted}
+        autoCapitalize="none"
+        autoCorrect={false}
+        autoComplete="off"
+        keyboardType="url"
+        returnKeyType="done"
+        onSubmitEditing={() => props.canSave && props.onSubmit()}
+      />
+      <Text style={styles.hint}>Optional. Use a different LAN or Tailscale address.</Text>
+      {props.alternateEndpointEdit?.kind === 'invalid' ? (
+        <Text style={styles.previewError}>{props.alternateEndpointEdit.error}</Text>
+      ) : props.duplicateAddresses ? (
+        <Text style={styles.previewError}>Use a different alternate address.</Text>
+      ) : props.alternateEndpoint ? (
+        <Text style={styles.preview} numberOfLines={2}>
+          Alternate: {props.alternateEndpoint}
+        </Text>
+      ) : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  fields: { gap: spacing.sm },
+  label: {
+    color: colors.textSecondary,
+    fontSize: typography.metaSize,
+    fontWeight: '500',
+    marginTop: spacing.sm,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4
+  },
+  input: {
+    backgroundColor: colors.bgPanel,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    borderRadius: radii.row,
+    color: colors.textPrimary,
+    fontSize: typography.bodySize,
+    paddingHorizontal: spacing.md,
+    paddingVertical: Platform.OS === 'ios' ? 12 : 10
+  },
+  hint: { color: colors.textMuted, fontSize: typography.metaSize, lineHeight: 16 },
+  preview: {
+    marginTop: spacing.sm,
+    color: colors.textSecondary,
+    fontSize: typography.metaSize,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : typography.monoFamily
+  },
+  previewError: { marginTop: spacing.sm, color: colors.statusRed, fontSize: typography.bodySize }
+})

--- a/mobile/src/host-edit-route-accessibility.test.ts
+++ b/mobile/src/host-edit-route-accessibility.test.ts
@@ -76,12 +76,16 @@ describe('edit host route accessibility', () => {
     vi.restoreAllMocks()
   })
 
-  it('exposes stable accessible names for both editable fields', async () => {
+  it('exposes stable accessible names for every editable field', async () => {
     const renderer = await renderEditHostRoute()
 
     const inputs = renderer.root.findAllByType('TextInput')
-    expect(inputs).toHaveLength(2)
-    expect(inputs.map((input) => input.props.accessibilityLabel)).toEqual(['Name', 'Address'])
+    expect(inputs).toHaveLength(3)
+    expect(inputs.map((input) => input.props.accessibilityLabel)).toEqual([
+      'Name',
+      'Address',
+      'Alternate address'
+    ])
 
     act(() => renderer.unmount())
   })

--- a/mobile/src/host-edit-save-flow.test.ts
+++ b/mobile/src/host-edit-save-flow.test.ts
@@ -70,7 +70,7 @@ async function renderEditHostRoute(): Promise<ReactTestRenderer> {
 
 function setFieldValue(
   renderer: ReactTestRenderer,
-  accessibilityLabel: 'Name' | 'Address',
+  accessibilityLabel: 'Name' | 'Address' | 'Alternate address',
   value: string
 ): void {
   const input = renderer.root
@@ -137,7 +137,7 @@ describe('edit host handleSave', () => {
     setFieldValue(renderer, 'Address', '  wss://%64esk.example.com:443  ')
     setFieldValue(renderer, 'Name', 'Home Desk')
 
-    expect(findText(renderer, `Connects to ${storedEndpoint}`)).toBe(true)
+    expect(findText(renderer, `Primary: ${storedEndpoint}`)).toBe(true)
     await pressSave(renderer)
 
     expect(dependencies.updateHostNameAndEndpoint).toHaveBeenCalledWith('host-1', {
@@ -155,7 +155,10 @@ describe('edit host handleSave', () => {
     await pressSave(renderer)
 
     expect(dependencies.updateHostNameAndEndpoint).toHaveBeenCalledWith('host-1', {
-      endpoint: 'ws://192.168.1.20:6768'
+      endpoint: 'ws://192.168.1.20:6768',
+      routing: {
+        endpoints: [{ id: 'direct-primary', kind: 'lan', url: 'ws://192.168.1.20:6768' }]
+      }
     })
     expect(dependencies.forceReconnectHost).toHaveBeenCalledWith('host-1')
     expect(dependencies.back).toHaveBeenCalledTimes(1)
@@ -172,10 +175,46 @@ describe('edit host handleSave', () => {
     expect(dependencies.updateHostNameAndEndpoint).toHaveBeenCalledTimes(1)
     expect(dependencies.updateHostNameAndEndpoint).toHaveBeenCalledWith('host-1', {
       name: 'Home Desk',
-      endpoint: 'ws://192.168.1.20:6768'
+      endpoint: 'ws://192.168.1.20:6768',
+      routing: {
+        endpoints: [{ id: 'direct-primary', kind: 'lan', url: 'ws://192.168.1.20:6768' }]
+      }
     })
     expect(dependencies.forceReconnectHost).toHaveBeenCalledWith('host-1')
     expect(dependencies.back).toHaveBeenCalledTimes(1)
+
+    act(() => renderer.unmount())
+  })
+
+  it('persists LAN and Tailscale addresses with existing relay routing', async () => {
+    dependencies.loadHosts.mockResolvedValueOnce([
+      {
+        ...HOST_FIXTURE,
+        relayHostId: 'relay-host-id-1',
+        relay: { relayHostId: 'relay-host-id-1' },
+        endpoints: [{ id: 'relay-primary', kind: 'relay', url: 'wss://relay.example' }]
+      }
+    ])
+    const renderer = await renderEditHostRoute()
+    setFieldValue(renderer, 'Alternate address', '100.86.153.122:6768')
+    await pressSave(renderer)
+
+    expect(dependencies.updateHostNameAndEndpoint).toHaveBeenCalledWith('host-1', {
+      routing: {
+        endpoints: [
+          { id: 'direct-primary', kind: 'lan', url: 'ws://192.168.1.10:6768' },
+          {
+            id: 'direct-alternate-1',
+            kind: 'tailscale',
+            url: 'ws://100.86.153.122:6768'
+          },
+          { id: 'relay-primary', kind: 'relay', url: 'wss://relay.example' }
+        ],
+        relayHostId: 'relay-host-id-1',
+        relay: { relayHostId: 'relay-host-id-1' }
+      }
+    })
+    expect(dependencies.forceReconnectHost).toHaveBeenCalledWith('host-1')
 
     act(() => renderer.unmount())
   })

--- a/mobile/src/transport/host-endpoint-edit.ts
+++ b/mobile/src/transport/host-endpoint-edit.ts
@@ -30,9 +30,9 @@ export function resolveHostEndpointEdit(
 
   const normalizedDisplay = normalizeHostEndpoint(displayedEndpoint, options)
   if (
-    sameEndpointAuthority(normalizedInput.endpoint, storedEndpoint) ||
+    sameHostEndpointAuthority(normalizedInput.endpoint, storedEndpoint) ||
     (normalizedDisplay.ok &&
-      sameEndpointAuthority(normalizedInput.endpoint, normalizedDisplay.endpoint))
+      sameHostEndpointAuthority(normalizedInput.endpoint, normalizedDisplay.endpoint))
   ) {
     return { kind: 'unchanged', endpoint: storedEndpoint }
   }
@@ -43,7 +43,7 @@ export function resolveHostEndpointEdit(
   }
 }
 
-function sameEndpointAuthority(left: string, right: string): boolean {
+export function sameHostEndpointAuthority(left: string, right: string): boolean {
   try {
     return new URL(left).origin === new URL(right).origin
   } catch {

--- a/mobile/src/transport/host-store-endpoint.test.ts
+++ b/mobile/src/transport/host-store-endpoint.test.ts
@@ -84,6 +84,35 @@ describe('updateHostNameAndEndpoint', () => {
     )
   })
 
+  it('persists primary and alternate direct endpoints', async () => {
+    vi.mocked(AsyncStorage.getItem).mockImplementation(async (key) =>
+      key === 'orca:hosts' ? JSON.stringify(stored) : '[]'
+    )
+
+    await updateHostNameAndEndpoint('host-1', {
+      routing: {
+        endpoints: [
+          { id: 'direct-primary', kind: 'lan', url: 'ws://192.168.1.10:6768' },
+          { id: 'direct-alternate-1', kind: 'tailscale', url: 'ws://100.64.0.5:6768' }
+        ]
+      }
+    })
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'orca:mobile-relay:host-overlays:v2',
+      JSON.stringify([
+        {
+          v: 2,
+          hostId: 'host-1',
+          endpoints: [
+            { id: 'direct-primary', kind: 'lan', url: 'ws://192.168.1.10:6768' },
+            { id: 'direct-alternate-1', kind: 'tailscale', url: 'ws://100.64.0.5:6768' }
+          ]
+        }
+      ])
+    )
+  })
+
   it('throws and writes nothing when the host is missing', async () => {
     vi.mocked(AsyncStorage.getItem).mockResolvedValue('[]')
 

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -15,7 +15,9 @@ import {
   loadMobileRelayHostOverlayState,
   removeMobileRelayHostOverlay,
   removeMobileRelayHostOverlays,
-  saveMobileRelayHostOverlay
+  saveHostRouting,
+  saveMobileRelayHostOverlay,
+  type HostRoutingUpdate
 } from './mobile-relay-host-overlay-store'
 import { scheduleOrphanedMobileRelayCleanup } from './mobile-relay-orphan-cleanup'
 import {
@@ -30,6 +32,7 @@ import {
   toStoredHostProfile,
   writeStoredHostProfiles
 } from './host-metadata-store'
+import { updateStoredHostProfile } from './stored-host-profile-update'
 
 async function commitDeviceToken(hostId: string, token: string): Promise<void> {
   markHostCredentialWrite(hostId)
@@ -300,33 +303,27 @@ export async function retryPendingHostCredentialCleanup(): Promise<{
 // Why: single mutation pass commits name + endpoint atomically so a mid-save failure can't persist one without the other.
 export async function updateHostNameAndEndpoint(
   hostId: string,
-  updates: { name?: string; endpoint?: string }
+  updates: { name?: string; endpoint?: string; routing?: HostRoutingUpdate }
 ): Promise<void> {
-  await mutateStoredHosts((hosts) => {
-    const index = hosts.findIndex((host) => host.id === hostId)
-    if (index === -1) {
-      throw new Error('Host not found')
-    }
-    const next = hosts.slice()
-    next[index] = {
-      ...next[index]!,
+  await mutateStoredHosts((hosts) =>
+    updateStoredHostProfile(hosts, hostId, {
       ...(updates.name !== undefined ? { name: updates.name } : {}),
       ...(updates.endpoint !== undefined ? { endpoint: updates.endpoint } : {})
-    }
-    return next
-  })
+    })
+  )
+  if (updates.routing) {
+    await saveHostRouting(hostId, updates.routing)
+    hostListLoads.dropSharedHostListLoad()
+  }
 }
 
 export async function updateLastConnected(hostId: string): Promise<void> {
   try {
     await mutateStoredHosts((hosts) => {
-      const index = hosts.findIndex((h) => h.id === hostId)
-      if (index === -1) {
+      if (!hosts.some(({ id }) => id === hostId)) {
         return hosts
       }
-      const next = hosts.slice()
-      next[index] = { ...next[index]!, lastConnected: Date.now() }
-      return next
+      return updateStoredHostProfile(hosts, hostId, { lastConnected: Date.now() })
     })
   } catch {
     // Why: best-effort timestamp fired with void; swallow so unreadable storage doesn't reject.

--- a/mobile/src/transport/mobile-relay-host-overlay-store.ts
+++ b/mobile/src/transport/mobile-relay-host-overlay-store.ts
@@ -4,6 +4,8 @@ import {
   type MobileRelayHostOverlay
 } from './mobile-relay-host-overlay'
 
+export type HostRoutingUpdate = Pick<MobileRelayHostOverlay, 'endpoints' | 'relayHostId' | 'relay'>
+
 const OVERLAY_STORAGE_KEY = 'orca:mobile-relay:host-overlays:v2'
 let overlayMutation: Promise<void> = Promise.resolve()
 
@@ -74,6 +76,10 @@ export async function loadMobileRelayHostOverlayState(
     }
   }
   return { overlays: active, orphanHostIds }
+}
+
+export function saveHostRouting(hostId: string, routing: HostRoutingUpdate): Promise<void> {
+  return saveMobileRelayHostOverlay({ v: 2, hostId, ...routing })
 }
 
 export async function saveMobileRelayHostOverlay(overlay: MobileRelayHostOverlay): Promise<void> {

--- a/mobile/src/transport/stored-host-profile-update.ts
+++ b/mobile/src/transport/stored-host-profile-update.ts
@@ -1,0 +1,17 @@
+import type { StoredHostProfile } from './types'
+
+type StoredHostUpdates = { name?: string; endpoint?: string; lastConnected?: number }
+
+export function updateStoredHostProfile(
+  hosts: StoredHostProfile[],
+  hostId: string,
+  updates: StoredHostUpdates
+): StoredHostProfile[] {
+  const index = hosts.findIndex((host) => host.id === hostId)
+  if (index === -1) {
+    throw new Error('Host not found')
+  }
+  const next = hosts.slice()
+  next[index] = { ...next[index]!, ...updates }
+  return next
+}


### PR DESCRIPTION
## Summary
- add optional alternate address to Edit host
- persist LAN/Tailscale direct endpoints in the relay host overlay
- preserve relay routing metadata and reconnect after address changes

## Verification
- `cd mobile && pnpm typecheck`
- `cd mobile && pnpm lint`
- `cd mobile && pnpm test` (479 files, 3865 passed, 3 skipped)
- Android release APK built and upgraded in place on Android 16
- Edit host displays existing LAN and Tailscale addresses on device