### PR TITLE
fix(persistence): take hook-server alias ownership before replay, not after

### DIFF
--- a/src/main/persistence-store-listener-ownership.test.ts
+++ b/src/main/persistence-store-listener-ownership.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { installFakeAppEnvironment } from '../../config/scripts/vitest-host-ports-setup'
+import type { PersistedState } from '../shared/persisted-state-types'
+import { makeBalancedLegacyPaneLayout } from './persistence-session-fixtures'
+import { Store } from './persistence/loading-store/store'
+
+vi.mock('./telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('./telemetry/cohort-classifier', () => ({
+  getCohortAtEmit: () => ({ nth_repo_added: 2 })
+}))
+
+function writeProfile(dir: string, state: Record<string, unknown>): string {
+  const dataFile = join(dir, 'orca-data.json')
+  writeFileSync(dataFile, JSON.stringify(state), 'utf-8')
+  return dataFile
+}
+
+function legacySplitLayoutProfile(tabId: string, ptyId: string): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    workspaceSession: {
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: tabId,
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: tabId,
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        [tabId]: {
+          root: makeBalancedLegacyPaneLayout(0, 2),
+          activeLeafId: 'pane:1',
+          expandedLeafId: null
+        }
+      }
+    }
+  }
+}
+
+function readProfile(dataFile: string): PersistedState {
+  return JSON.parse(readFileSync(dataFile, 'utf-8')) as PersistedState
+}
+
+describe('Store hook-server listener ownership', () => {
+  let dirs: string[] = []
+
+  beforeEach(() => {
+    dirs = []
+    installFakeAppEnvironment({ getPath: () => tmpdir() })
+  })
+
+  afterEach(() => {
+    for (const dir of dirs) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  function makeDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-listener-ownership-'))
+    dirs.push(dir)
+    return dir
+  }
+
+  it('does not write a later store’s hydrated aliases into an earlier store’s profile', () => {
+    const earlierFile = writeProfile(makeDir(), { schemaVersion: 1 })
+    const earlier = new Store({ dataFile: earlierFile })
+
+    // Why: the later store replays its own legacy layout; the earlier store must not observe it.
+    const laterFile = writeProfile(makeDir(), legacySplitLayoutProfile('tab-later', 'pty-later'))
+    new Store({ dataFile: laterFile })
+
+    earlier.flush()
+    const earlierAliases = readProfile(earlierFile).legacyPaneKeyAliasEntries ?? []
+    expect(earlierAliases).toEqual([])
+  })
+
+  it('still persists a store’s own hydrated aliases after it takes ownership', () => {
+    const dataFile = writeProfile(makeDir(), legacySplitLayoutProfile('tab-own', 'pty-own'))
+    const store = new Store({ dataFile })
+
+    store.flush()
+    const aliases = readProfile(dataFile).legacyPaneKeyAliasEntries ?? []
+    expect(aliases.some((entry) => entry.legacyPaneKey === 'tab-own:1')).toBe(true)
+  })
+})

--- a/src/main/persistence-store-listener-ownership.test.ts
+++ b/src/main/persistence-store-listener-ownership.test.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { installFakeAppEnvironment } from '../../config/scripts/vitest-host-ports-setup'
 import type { PersistedState } from '../shared/persisted-state-types'
+import { makePaneKey } from '../shared/stable-pane-id'
+import { agentHookServer } from './agent-hooks/server'
 import { makeBalancedLegacyPaneLayout } from './persistence-session-fixtures'
 import { Store } from './persistence/loading-store/store'
 
@@ -54,6 +56,9 @@ function readProfile(dataFile: string): PersistedState {
   return JSON.parse(readFileSync(dataFile, 'utf-8')) as PersistedState
 }
 
+const RUNTIME_PANE_KEY = makePaneKey('tab-own', '9f0e1d2c-3b4a-4c5d-8e6f-7a8b9c0d1e2f')
+const RUNTIME_UPDATED_AT = 1_700_000_000_000
+
 describe('Store hook-server listener ownership', () => {
   let dirs: string[] = []
 
@@ -87,12 +92,29 @@ describe('Store hook-server listener ownership', () => {
     expect(earlierAliases).toEqual([])
   })
 
-  it('still persists a store’s own hydrated aliases after it takes ownership', () => {
+  it('persists an alias the hook server registers after the store takes ownership', () => {
     const dataFile = writeProfile(makeDir(), legacySplitLayoutProfile('tab-own', 'pty-own'))
     const store = new Store({ dataFile })
 
+    // Why: hydrated rows reach `state` through normalization alone, so asserting on those watches
+    // nothing. Only the listener the constructor re-installs can carry a post-construction alias to
+    // disk — that is what the detach above must hand over rather than destroy.
+    agentHookServer.registerPaneKeyAlias(
+      'tab-own:7',
+      RUNTIME_PANE_KEY,
+      'pty-runtime',
+      RUNTIME_UPDATED_AT
+    )
+
     store.flush()
     const aliases = readProfile(dataFile).legacyPaneKeyAliasEntries ?? []
+    expect(aliases).toContainEqual({
+      legacyPaneKey: 'tab-own:7',
+      stablePaneKey: RUNTIME_PANE_KEY,
+      ptyId: 'pty-runtime',
+      updatedAt: RUNTIME_UPDATED_AT
+    })
+    // The listener replaces the whole persisted list, so the hydrated rows must survive the replace.
     expect(aliases.some((entry) => entry.legacyPaneKey === 'tab-own:1')).toBe(true)
   })
 })

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -54,6 +54,11 @@ export class Store {
     this.domains = createStoreDomains(this.runtime)
     installStoreDomainContexts(this, this.domains)
     this.runtime.flushOrThrow = () => this.flushOrThrow()
+    // Why: the hook server still holds a previous Store's alias listener, which closes over that
+    // store's state and scheduler. Detach before any replay below — normalization registers aliases
+    // too — so hydration cannot write this store's rows into the dead one, rebuilding that store's
+    // whole persisted alias list once per entry.
+    agentHookServer.setPaneKeyAliasPersistenceListener(null)
     const loaded = this.domains.loader.load()
     const normalized = normalizePersistedPaneIdentityState(loaded)
     this.state = normalized.state


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​120 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​120 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5

Orca's hook server is one shared object that lives as long as the process. When a
profile store is built, it hands that server a callback so the server can say
"your pane bookmarks changed, save them."

The store handed the callback over and never took it back. So if a second store
was ever built, the hook server was still holding the **first** store's callback,
and the second store's startup replay went through it. Two things followed:

1. The first store's profile got the second store's bookmarks written into it —
   on disk, in a different folder.
2. Every bookmark replayed rebuilt that entire bookmark list from scratch.

This moves the hand-over to the **start** of the constructor, so a store takes
ownership before it replays anything. Newest store owns the server.

## User-facing before/after

**None — this is a CI-reliability and test-correctness fix.** No shipped behaviour
changes, and the product is not affected.

Why it cannot bite a real user: the app builds exactly one `Store` per process
(`src/main/index.ts:2432` is the only assignment to that variable; the daemon has
its own single one at `src/main/orcad/orcad-entry.ts:158`). With one store there
is no previous listener to inherit, so both the cross-store write and the rebuild
cost are unreachable in production.

What changes is for whoever is waiting on a green check:

| 130k-leaf migration test | Before | After |
|---|---|---|
| Solo (3 runs each) | 7,689 / 7,512 / 7,573 ms | **832 / 837 / 845 ms** |
| Under 36 CPU hogs on 18 cores | **29,872 ms** | **1,997 ms** |
| Headroom vs the 30,000 ms `testTimeout` | **1.004×** | **~15×** |

The contended number was reproduced, not inferred. 29,872 ms clears the repo-wide
cap by **128 ms** — that test was one busy CI box away from a red nobody could
explain. Note the *after* run sat at a **higher** loadavg (61.5 vs 46.7) and was
still 15× faster.

## What was actually wrong

`Store`'s constructor ended with:

```ts
agentHookServer.setPaneKeyAliasPersistenceListener((entries) => {
  this.state.legacyPaneKeyAliasEntries = entries   // <- captures THIS store
  scheduleSave(this.domains.scheduling)            // <- and THIS store's scheduler
})
```

`agentHookServer` is a module singleton and nothing ever cleared that listener, so
the listener outlived the store that installed it. This is not only a cost
problem: a later store's replay wrote **its** alias rows into an **earlier**
store's `state` and scheduled a disk write for it. The new test demonstrates that
directly — pre-fix, the earlier store's profile file on disk contains three alias
rows belonging to a store pointed at a different directory.

The fix detaches the listener at the top of the constructor. It has to sit above
`normalizePersistedPaneIdentityState`, not merely above the explicit hydration
loop: normalization registers aliases itself, via
`normalizeWorkspaceSessionPaneIdentities -> registerLegacyPaneKeyAliasesForTab`.
Placing the clear below normalization removed exactly half the notifications
(260,011 -> 130,008) and left the test at 4.25s; placing it above took it to 0.

## How far the leak actually reaches

**Axis enumerated: runtime, not source.** I instrumented the singleton itself to
record every test file in which it received an alias listener and how much work
followed, then ran all 6,926 test files. That axis is mechanism-independent, so it
catches direct `new Store(...)`, the shared `persistence-test-harness.createStore()`
factory, and transitive imports alike.

| | |
|---|---|
| Test files that construct a `Store` | **64** |
| `Store`s constructed suite-wide | **950** (median 11/file, max 57) |
| Files with any singleton notification | **5** |
| Total leaked notifications outside the known file | **11**, rebuilding **19** entries |
| The one known file, pre-fix, alone | **260,011** notifications, **265,721,359** entries |

**So: the leak is in 64 files; the symptom is in one.** Every other file builds
stores and then does essentially no alias work, so it inherits the defect and pays
nothing. Nothing else is near the timeout from this cause. This PR is therefore a
recurrence guard, not a broad speedup — it makes the class impossible rather than
relying on 64 files never growing alias work.

Worth recording that the obvious static enumeration is wrong: `grep "new Store("`
over test files finds **30**, undercounting by 2.1×, because it misses every
consumer of the `createStore()` harness.

## Corrections to earlier numbers

- The waste is **~266M** rebuilt entries (260,011 notifications × ~1,022 avg list
  length), not the ~133M previously stated. The estimate assumed one notification
  per registration; there are two, because normalization and the hydration loop
  each register the full set.
- `30,000 ms` is the repo-wide `testTimeout` (`config/vitest.config.ts:37`), not a
  per-test budget. It is line **37**, not 34.

## Fixture unchanged

The 130,000 leaves are load-bearing and were not touched. V8's spread-argument
limit on this repo's Node 26 sits at 124,000 OK / 125,000 `RangeError`, so a
smaller fixture would pass forever while testing nothing.

## Proof

Every ablation below deletes or moves lines rather than disabling them, was verified
applied with `git diff` before its run, ran serially, and had the tree restored to clean
between runs. Population throughout: `src/main/persistence` + `src/main/agent-hooks`,
**1,470 tests** (1,464 pass, 6 skipped).

**The fix — two ablation shapes, both red.**

| Shape | Mutation | Test 1 |
|---|---|---|
| Deletion | remove `setPaneKeyAliasPersistenceListener(null)` | **fail** — `expected [ { ptyId: 'pty-later', …(3) }, …(2) ] to deeply equal []` |
| Relocation | keep the line, move it one statement *below* `normalizePersistedPaneIdentityState` | **fail** |

The relocation arm is the one that carries weight. It proves the test pins the
*placement* above normalization rather than the line's mere presence — normalization
registers the full alias set itself, so a detach sitting below it is already too late.
Deletion alone could not tell those two apart.

**The preservation test — it was vacuous, and is now pinned.** The second test originally
asserted that a store's hydrated aliases reach its own profile. They do — but via
`normalizePersistedPaneIdentityState`, which assigns `state.legacyPaneKeyAliasEntries`
directly (`workspace-pane-normalization.ts:248`) *before* the listener is installed at
all. So deleting the alias listener install outright reddened **0 of 1,470**. The test
named a behaviour it could not detect.

It now asserts on an alias registered on the hook server **after** construction.
`store.ts:83` is the only writer of `state.legacyPaneKeyAliasEntries` after load, so such
a row can reach disk only through the listener:

| Shape | Mutation | Before | After |
|---|---|---|---|
| Whole block | delete the `setPaneKeyAliasPersistenceListener((entries) => …)` install | pass | **fail** |
| Single element | delete only `this.state.legacyPaneKeyAliasEntries = entries` | pass | **fail** |
| Corruption | rewrite that write as `entries.map((e) => ({ …e, updatedAt: 0 }))` | pass | **fail** |
| Discriminating control | delete only `scheduleSave(…)` inside the listener | pass | pass |

The corruption row matters on its own: it removes nothing, so it is the class of mutation
a clamped or coalescing reader can survive under deletion while still being wrong. The
last row is deliberate. The test watches the state write specifically, not the
block's existence — without it, a test that reddens on any edit to the block would look
identical. It also records an honest gap: the `scheduleSave` inside the listener stays
unpinned. That line is pre-existing rather than added here, and pinning it means
asserting on a debounced disk write, which is a different test. Reported, not fixed.

Same population, same mutation (listener install deleted): **0 of 1,470 → 1 of 1,470**.
The corrected test also reddens when run alone under `-t`, so it does not lean on the
first test's leftover singleton state.

## Why the original ablation missed it

The ablation axis was *“remove the fix.”* A preservation control is by construction
insensitive to that axis — staying green is its job. I read that green as evidence it was
watching something; it was only evidence that it was not watching the fix. Along that one
axis those two states are indistinguishable, so a fully empty test and a fully healthy one
produce the same reading.

A preservation test needs its own axis: **remove the thing being preserved.** That
mutation was never run here, and it was the one that returned zero. The general rule this
should have followed: a test's ablation must target what the *test* claims, not what the
*PR* changed.

**A second guard line was dropped for being unpinned.** My first draft also cleared
`setMigrationUnsupportedPtyPersistenceListener`. Deleting that line on its own
reddened **nothing** — because `normalizePersistedPaneIdentityState` initialises
`mergedMigrationUnsupportedEntries` to `[]` and never pushes to it (those rows are
deliberately converted to aliases and retired), so the loop it guarded never
iterates. An unpinned line is worse than no line, so it is not in this PR.

**Suite** — the figures below are from the pre-correction commit; the test-only follow-up
was re-verified against the 1,470-test scope above (green), not by re-running all 6,927
files. `src/`, 6,927 files: **3 failed, 64,532 passed, 246 skipped**.
All three failures are pre-existing timing flakes, established by differential
rather than assertion. Run solo 3× with the fix: 2 / 0 / 1 test failures. Run solo
3× on clean `main` without it: 0 / 2 / 0. `filesystem-watcher-real.test.ts` failed
in the baseline run too, and `codex-tui-resume-real-binary` failed in the baseline
but passed here — the family alternates in both directions.

**Typecheck** — `pnpm tc`, foreground, exit code read directly from `$?`: **exit 0**.
Proven non-vacuous: planting `const plantedTypeError: number = 'not a number'` in the test
file gave **exit 1** with `persistence-store-listener-ownership.test.ts(61,7): error
TS2322`; removing it returned exit 0.

**Lint/format** — `npx oxlint` on both changed files: exit 0, with stdout retained (it is
where oxlint reports configuration failures). Gate proven live in place: planting a
duplicate object key in the test file reported
`persistence-store-listener-ownership.test.ts:61:23: error eslint(no-dupe-keys)` and exit
1; removing it returned exit 0. `npx oxfmt --check` on both files: `All matched files use
the correct format.`

## Relationship to #17256

Independent — this branches off `main` and touches different files, so the two
cannot conflict. #17256 clears the listener in one test file's `afterEach`; this
removes the need for that teardown anywhere, and reaches ~0.85s versus its
~1.00s. If both land, #17256's `afterEach` becomes redundant but harmless. I have
not touched, merged, or closed it — that call is yours.

