### PR TITLE
fix(accounts): notify the renderer when the active account changes outside it

### DIFF
--- a/src/main/claude-accounts/claude-account-registration.ts
+++ b/src/main/claude-accounts/claude-account-registration.ts
@@ -185,7 +185,7 @@ export class ClaudeAccountRegistration {
       claudeManagedAccounts: [...previousSettings.claudeManagedAccounts, account],
       activeClaudeManagedAccountId: selection.host,
       activeClaudeManagedAccountIdsByRuntime: selection
-    })
+    }, { notifyListeners: true })
     this.dependencies.runtimeAuth.clearLastWrittenCredentialsJson(accountId)
     this.dependencies.rateLimits.evictInactiveClaudeCache(accountId)
     return this.dependencies.selection.snapshot()

--- a/src/main/claude-accounts/claude-account-selection.ts
+++ b/src/main/claude-accounts/claude-account-selection.ts
@@ -50,7 +50,8 @@ export class ClaudeAccountSelection {
           activeClaudeManagedAccountIdsByRuntime: nextSelection
         }, { notifyListeners: true })
         await this.syncRuntimeAuth(target)
-        this.store.updateSettings({ claudeManagedAccounts: nextAccounts })
+        // Why: an external removal must also broadcast the roster, or the renderer keeps the removed account until an unrelated refetch.
+        this.store.updateSettings({ claudeManagedAccounts: nextAccounts }, { notifyListeners: true })
       } else {
         this.store.updateSettings({
           claudeManagedAccounts: nextAccounts,

--- a/src/main/claude-accounts/claude-account-selection.ts
+++ b/src/main/claude-accounts/claude-account-selection.ts
@@ -48,7 +48,7 @@ export class ClaudeAccountSelection {
         this.store.updateSettings({
           activeClaudeManagedAccountId: nextActiveId,
           activeClaudeManagedAccountIdsByRuntime: nextSelection
-        })
+        }, { notifyListeners: true })
         await this.syncRuntimeAuth(target)
         this.store.updateSettings({ claudeManagedAccounts: nextAccounts })
       } else {
@@ -56,7 +56,7 @@ export class ClaudeAccountSelection {
           claudeManagedAccounts: nextAccounts,
           activeClaudeManagedAccountId: nextActiveId,
           activeClaudeManagedAccountIdsByRuntime: nextSelection
-        })
+        }, { notifyListeners: true })
         await this.syncRuntimeAuth(target)
       }
       await this.removeManagedAuth(accountId, account.managedAuthPath)
@@ -103,7 +103,7 @@ export class ClaudeAccountSelection {
       activeClaudeManagedAccountId:
         effectiveTarget?.runtime === 'wsl' ? nextSelection.host : accountId,
       activeClaudeManagedAccountIdsByRuntime: nextSelection
-    })
+    }, { notifyListeners: true })
     try {
       await this.syncRuntimeAuth(effectiveTarget)
       await this.rateLimits.refreshForClaudeAccountChange(outgoingAccountId, effectiveTarget)
@@ -141,7 +141,7 @@ export class ClaudeAccountSelection {
       claudeManagedAccounts: settings.claudeManagedAccounts,
       activeClaudeManagedAccountId: settings.activeClaudeManagedAccountId,
       activeClaudeManagedAccountIdsByRuntime: settings.activeClaudeManagedAccountIdsByRuntime
-    })
+    }, { notifyListeners: true })
   }
 
   async syncRuntimeAuth(
@@ -170,7 +170,7 @@ export class ClaudeAccountSelection {
       this.store.updateSettings({
         activeClaudeManagedAccountId: nextSelection.host,
         activeClaudeManagedAccountIdsByRuntime: nextSelection
-      })
+      }, { notifyListeners: true })
     }
   }
 }

--- a/src/main/claude-accounts/claude-account-service-account-selection.test.ts
+++ b/src/main/claude-accounts/claude-account-service-account-selection.test.ts
@@ -188,6 +188,11 @@ describe('ClaudeAccountService credential capture', () => {
     expect(rateLimits.refreshForClaudeAccountChange).toHaveBeenCalledWith('account-1', {
       runtime: 'host'
     })
+    // Why: mobile/CLI-initiated switches have no renderer-side refetch, so the write must broadcast.
+    expect(store.updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ activeClaudeManagedAccountId: 'account-2' }),
+      { notifyListeners: true }
+    )
   })
 
   it('restores the previous selection when a Claude account switch fails', async () => {

--- a/src/main/claude-accounts/claude-account-service-account-selection.test.ts
+++ b/src/main/claude-accounts/claude-account-service-account-selection.test.ts
@@ -106,6 +106,12 @@ describe('ClaudeAccountService credential capture', () => {
       claudeManagedAccounts: [],
       activeClaudeManagedAccountId: null
     })
+    // Why: an external removal must broadcast the roster write too, or the renderer
+    // keeps the removed account in its settings cache until an unrelated refetch.
+    expect(store.updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ claudeManagedAccounts: [] }),
+      { notifyListeners: true }
+    )
   })
 
   it('switches the active Claude account while PTYs are live', async () => {

--- a/src/main/codex-accounts/codex-account-registration.ts
+++ b/src/main/codex-accounts/codex-account-registration.ts
@@ -124,7 +124,7 @@ export class CodexAccountRegistration {
       codexManagedAccounts: updatedAccounts,
       activeCodexManagedAccountId: activeSelection.host,
       activeCodexManagedAccountIdsByRuntime: activeSelection
-    })
+    }, { notifyListeners: true })
     this.dependencies.configMirror.safeSyncToManagedHomes()
     this.dependencies.runtimeHome.clearLastWrittenAuthJson(accountId)
     this.dependencies.runtimeHome.syncForCurrentSelection(accountTarget)
@@ -178,7 +178,7 @@ export class CodexAccountRegistration {
         account.id,
         targetSelection
       )
-    })
+    }, { notifyListeners: true })
     try {
       this.dependencies.configMirror.safeSyncToManagedHomes()
       this.dependencies.runtimeHome.clearLastWrittenAuthJson(account.id)
@@ -193,7 +193,7 @@ export class CodexAccountRegistration {
         codexManagedAccounts: settings.codexManagedAccounts,
         activeCodexManagedAccountId: settings.activeCodexManagedAccountId,
         activeCodexManagedAccountIdsByRuntime: settings.activeCodexManagedAccountIdsByRuntime
-      })
+      }, { notifyListeners: true })
       // Why: a failed post-write step must restore both persisted selection and
       // the runtime home it drives before the new managed home is removed.
       try {

--- a/src/main/codex-accounts/codex-account-selection.ts
+++ b/src/main/codex-accounts/codex-account-selection.ts
@@ -76,7 +76,7 @@ export class CodexAccountSelection {
       codexManagedAccounts: nextAccounts,
       activeCodexManagedAccountId: nextActiveId,
       activeCodexManagedAccountIdsByRuntime: nextSelection
-    })
+    }, { notifyListeners: true })
     this.dependencies.runtimeHome.syncForCurrentSelection()
     if (account.managedHomeRuntime === 'host' && nextSelection.host === null) {
       this.dependencies.lifecycle.onHostSystemDefaultSelected?.()
@@ -127,7 +127,7 @@ export class CodexAccountSelection {
       activeCodexManagedAccountId:
         effectiveTarget?.runtime === 'wsl' ? nextSelection.host : accountId,
       activeCodexManagedAccountIdsByRuntime: nextSelection
-    })
+    }, { notifyListeners: true })
     this.dependencies.configMirror.safeSyncToManagedHomes()
     this.dependencies.runtimeHome.syncForCurrentSelection(effectiveTarget)
     if (
@@ -157,7 +157,7 @@ export class CodexAccountSelection {
     this.dependencies.store.updateSettings({
       activeCodexManagedAccountId: nextSelection.host,
       activeCodexManagedAccountIdsByRuntime: nextSelection
-    })
+    }, { notifyListeners: true })
     if (selection.host !== null && nextSelection.host === null) {
       this.dependencies.lifecycle.onHostSystemDefaultSelected?.()
     }


### PR DESCRIPTION
## ELI5

If you switch your Claude account from your phone, the desktop app keeps showing the old account as active — and paints the incoming usage numbers under the old account's name — even though the new account is really the one being used. This makes the desktop broadcast the change, so its display follows reality.

## What Changed

- Pass `{ notifyListeners: true }` on every settings write that changes the active managed-account selection:
  - `claude-account-selection.ts` — select, deselect-on-removal, rollback restore, and selection normalization
  - `claude-account-registration.ts` — the select-after-add write
  - `codex-accounts/service.ts` — the six equivalent Codex selection-state writes (same pattern, same symptom)
- Regression assertion in `claude-account-service-account-selection.test.ts`: a live switch must broadcast the settings change.

No new IPC/RPC surface: `Store.updateSettings` already supports the option, the `settings:changed` broadcast already exists, and the renderer already merges it into the app store (`settings-sidebar-ipc-bridge.ts`) — the status bar derives the active-account label and its roster sync key from those settings.

## Why

Selection mutations can originate outside the desktop renderer: the paired mobile app (`accounts.selectClaude` RPC) and `orca account add` both land in the same services. Today those writes skip `notifyListeners` (the store default is no-notify), and the desktop UI stays consistent only because the renderer refetches settings after mutations it initiated itself. A comment in `runtime-provider-accounts-client.ts` documents the gap: "they have no push channel here; the pane refetches after each mutation."

Result: consumption moves to the new account (main-process measurement resolves credentials per fetch and is correct), but the desktop keeps displaying the old account and attributes the fresh numbers to it. Broadcasting on the write is the minimal fix; main-side `onSettingsChanged` listeners are all keyed to specific settings keys, so the extra notification is low-risk.

## Linked Issue

Fixes #17261

## Visual Proof

N/A — the change is an internal settings broadcast. The user-visible effect is the status-bar account label following a switch made outside the desktop renderer; I have not yet re-run the live phone-switch scenario on a build carrying this patch (the regression test asserts the broadcast), and I'm happy to record it on request.

## Testing

- [ ] I manually tested these changes locally (targeted suites only — no live phone-switch rerun on a patched build yet)
- [x] Automated tests added/updated, or explained why not below

On Windows 11:

- `pnpm exec vitest run src/main/claude-accounts src/main/codex-accounts` — 465 passed; 5 pre-existing failures in WSL-environment tests that shell out to the machine's real `wsl.exe` (fail identically on a clean checkout of `main`, verified by stash/run/pop)
- `pnpm tc:node` — exit 0
- `oxlint` on the four changed files — 0 findings
- Full `pnpm test`/`pnpm build` not run locally (native module rebuild hits the known MAX_PATH limitation on this checkout); CI covers them

Platforms tested: Windows. The change is platform-independent (settings write flag only).

## AI Disclosure

Diagnosed and implemented with AI assistance (Claude Code); the flow trace, fix, and test were reviewed and verified locally by me.

## Review

Review notes by contract area:

- **Cross-platform**: no path or platform logic touched; a settings-write flag only.
- **SSH/remote & wire compat**: no RPC/stream change; `settings:changed` is a local Electron IPC broadcast. Remote-scope meter attribution (#16466) is a different mechanism and intentionally untouched.
- **Agents/integrations**: no agent-facing behavior change; credentials materialization order is unchanged.
- **Performance**: at most a handful of extra `settings:changed` broadcasts per account mutation; listeners are key-gated.
- **UI**: the status bar and accounts pane consume the existing settings-merge path; no component changes.
- **Security**: no credential handling changes; the broadcast carries the same settings keys the renderer already reads.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The one desktop surface still on one-shot reads is the Accounts pane while it is already open during an external switch; covering it would be a keyed refetch and can follow separately if wanted. Codex sites are included because the pattern and symptom are identical (`activeCodexManagedAccountId` writes).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

X: @EnricoPin
