### PR TITLE
fix(agent-hooks): let a respawned pane's status come back on any provider

### DIFF
--- a/src/main/agent-hooks/server-live-pane-refence.test.ts
+++ b/src/main/agent-hooks/server-live-pane-refence.test.ts
@@ -215,6 +215,22 @@ describe("relay spool replay is fenced on the pane's current generation", () => 
     expect(promptOf(server)).toBe('offline agent finished')
   })
 
+  it('keeps the spool of a pane whose later launch minted no token', () => {
+    // Why this is the reachable shape and not a contrivance: `orca-runtime.ts` mints a launch
+    // token only when a `launchConfig` is present, so an ordinary relaunch into an
+    // already-tokened pane is untokened. Its posts are tokenless, its spool is tokenless, and
+    // the expectation the first launch armed is deliberately never cleared by a tokenless one.
+    const server = new AgentHookServer()
+    server.noteAgentPaneLaunchToken(PANE, 'token-a')
+    server.noteAgentPaneLaunchToken(PANE, undefined)
+
+    post(server, 'claude', 'UserPromptSubmit', '', 'untokened relaunch finished', {
+      isReplay: true
+    })
+
+    expect(promptOf(server)).toBe('untokened relaunch finished')
+  })
+
   it('does not clear the expectation when a tokenless shell respawns into the pane', () => {
     // Why: the expectation is only ever RAISED. A shell launched with no agent token is not
     // evidence about any generation, so it must not open the pane to the generation the last

--- a/src/main/agent-hooks/server-live-pane-refence.test.ts
+++ b/src/main/agent-hooks/server-live-pane-refence.test.ts
@@ -29,7 +29,10 @@ const BOUNDARIES: Record<
   { newTurn: string; sessionStart: string | null; followUp?: string; armable?: false }
 > = {
   claude: { newTurn: 'UserPromptSubmit', sessionStart: 'SessionStart' },
-  kimi: { newTurn: 'UserPromptSubmit', sessionStart: 'SessionStart' },
+  // Why null: Kimi's names are Claude-compatible, but `normalizeKimiEvent` has no SessionStart
+  // case and `KIMI_HOOK_EVENTS` does not subscribe to one, so no kimi session boundary can reach
+  // the fence. The spawn path is the only thing that re-fences a kimi pane.
+  kimi: { newTurn: 'UserPromptSubmit', sessionStart: null },
   codex: { newTurn: 'UserPromptSubmit', sessionStart: 'SessionStart' },
   gemini: { newTurn: 'BeforeAgent', sessionStart: null },
   antigravity: { newTurn: 'PreInvocation', sessionStart: null },
@@ -95,12 +98,11 @@ const SOURCES = (Object.keys(BOUNDARIES) as AgentHookSource[]).filter(
   (source) => BOUNDARIES[source].armable !== false
 )
 const WITH_SESSION_START = SOURCES.filter((source) => BOUNDARIES[source].sessionStart !== null)
-const WITHOUT_SESSION_START = SOURCES.filter((source) => BOUNDARIES[source].sessionStart === null)
 
 describe("a fenced live pane re-fences on each provider's own session boundary", () => {
-  // Why the whole matrix: the branch matched the literal `SessionStart`, which only claude,
-  // codex and opencode send. Every other source's replacement process was suppressed forever,
-  // with no user-reachable way to bring the pane's row back.
+  // Why the whole matrix: the branch matched the literal `SessionStart`, which only 5 of the 18
+  // sources send. Every other source's replacement process was suppressed forever, with no
+  // user-reachable way to bring the pane's row back.
   it.each(WITH_SESSION_START)('%s', (source) => {
     const server = new AgentHookServer()
     armFence(server, source, 'token-1')
@@ -134,9 +136,12 @@ describe("a fenced live pane re-fences on each provider's own session boundary",
 })
 
 describe('a fenced live pane re-fences on the spawn that replaced its process', () => {
-  // Why these sources need it: they emit no session boundary at all, so no event can ever tell
-  // the gate a new process owns the pane. Main's own spawn is the only proof available.
-  it.each(WITHOUT_SESSION_START)('%s', (source) => {
+  // Why every armable source and not only the ones with no session boundary: the spawn
+  // notification is provider-independent by construction, and it is what actually rescues the
+  // sources whose session boundary Orca never installs (cursor) or never normalizes (kimi).
+  // Scoping this to the no-boundary bucket left those two covered only by an event production
+  // never sends.
+  it.each(SOURCES)('%s', (source) => {
     const server = new AgentHookServer()
     armFence(server, source, 'token-1')
 
@@ -193,5 +198,47 @@ describe("relay spool replay is fenced on the pane's current generation", () => 
     post(server, 'claude', 'UserPromptSubmit', 'token-a', 'agent a late spool', { isReplay: true })
 
     expect(promptOf(server)).toBe('agent b offline')
+  })
+
+  it('keeps the spool of a poster whose process never received the token', () => {
+    // Why: every shell-side poster emits `${ORCA_AGENT_LAUNCH_TOKEN:-}`, so a process that never
+    // got the variable reports an EMPTY token, not an absent one. On the WSL and SSH launch paths
+    // the variable can be lost in transit (WSLENV passthrough, sshd's accepted env), so this is a
+    // real remote population — and before the spawn notification existed such a pane had no
+    // expectation at all and its spool landed. Rejecting it here would recreate, for that
+    // population, the exact silent frozen row this fence is supposed to prevent.
+    const server = new AgentHookServer()
+    server.noteAgentPaneLaunchToken(PANE, 'token-b')
+
+    post(server, 'claude', 'UserPromptSubmit', '', 'offline agent finished', { isReplay: true })
+
+    expect(promptOf(server)).toBe('offline agent finished')
+  })
+
+  it('does not clear the expectation when a tokenless shell respawns into the pane', () => {
+    // Why: the expectation is only ever RAISED. A shell launched with no agent token is not
+    // evidence about any generation, so it must not open the pane to the generation the last
+    // real launch replaced.
+    const server = new AgentHookServer()
+    post(server, 'claude', 'UserPromptSubmit', 'token-a', 'agent a')
+    server.noteAgentPaneLaunchToken(PANE, undefined)
+
+    post(server, 'claude', 'UserPromptSubmit', 'token-old', 'older generation spool', {
+      isReplay: true
+    })
+
+    expect(promptOf(server)).toBe('agent a')
+  })
+
+  it('admits the generation the standing expectation names after a tokenless respawn', () => {
+    // Positive control for the test above: the expectation survives, it does not reject
+    // everything. Same setup, a replay that names the generation the expectation stands for.
+    const server = new AgentHookServer()
+    post(server, 'claude', 'UserPromptSubmit', 'token-a', 'agent a')
+    server.noteAgentPaneLaunchToken(PANE, undefined)
+
+    post(server, 'claude', 'UserPromptSubmit', 'token-a', 'agent a offline', { isReplay: true })
+
+    expect(promptOf(server)).toBe('agent a offline')
   })
 })

--- a/src/main/agent-hooks/server-live-pane-refence.test.ts
+++ b/src/main/agent-hooks/server-live-pane-refence.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentHookSource } from '../../shared/agent-hook-relay'
+import { AgentHookServer, _internals } from './server'
+import { PANE } from './server.test-fixtures'
+
+const { trackMock, getCohortAtEmitMock } = vi.hoisted(() => ({
+  trackMock: vi.fn(),
+  getCohortAtEmitMock: vi.fn()
+}))
+vi.mock('../telemetry/client', () => ({ track: trackMock }))
+vi.mock('../telemetry/cohort-classifier', () => ({ getCohortAtEmit: getCohortAtEmitMock }))
+
+beforeEach(() => {
+  _internals.resetCachesForTests()
+  trackMock.mockReset()
+  getCohortAtEmitMock.mockReset()
+  getCohortAtEmitMock.mockReturnValue({ nth_repo_added: 2 })
+})
+
+/** Each source's new-turn boundary (arms the fence from a retired pane), its session-start
+ *  boundary if it has one, and a follow-up event that is neither. `sessionStart: null` names a
+ *  source that emits no session boundary at all — those are re-fenced by the spawn path, never by
+ *  an event. `armable: false` names a source no new-turn event can un-retire, so nothing can fence
+ *  its pane in the first place and nothing can strand it.
+ *  Why a Record over the source union: a new source fails typecheck here instead of silently
+ *  skipping coverage. */
+const BOUNDARIES: Record<
+  AgentHookSource,
+  { newTurn: string; sessionStart: string | null; followUp?: string; armable?: false }
+> = {
+  claude: { newTurn: 'UserPromptSubmit', sessionStart: 'SessionStart' },
+  kimi: { newTurn: 'UserPromptSubmit', sessionStart: 'SessionStart' },
+  codex: { newTurn: 'UserPromptSubmit', sessionStart: 'SessionStart' },
+  gemini: { newTurn: 'BeforeAgent', sessionStart: null },
+  antigravity: { newTurn: 'PreInvocation', sessionStart: null },
+  amp: { newTurn: 'agent.start', sessionStart: 'session.start' },
+  cursor: { newTurn: 'beforeSubmitPrompt', sessionStart: 'sessionStart' },
+  pi: { newTurn: 'before_agent_start', sessionStart: 'session_start' },
+  omp: { newTurn: 'before_agent_start', sessionStart: null },
+  'prime-agent': { newTurn: 'before_agent_start', sessionStart: 'session_start' },
+  droid: { newTurn: 'UserPromptSubmit', sessionStart: 'SessionStart' },
+  grok: { newTurn: 'user_prompt_submit', sessionStart: 'session_start' },
+  copilot: { newTurn: 'UserPromptSubmit', sessionStart: 'sessionStart' },
+  hermes: { newTurn: 'pre_llm_call', sessionStart: 'on_session_start' },
+  devin: { newTurn: 'UserPromptSubmit', sessionStart: 'SessionStart' },
+  opencode: { newTurn: 'SessionStart', sessionStart: 'SessionStart', followUp: 'SessionBusy' },
+  'mimo-code': { newTurn: 'MessagePart', sessionStart: null },
+  // Why armable: false — Command Code names no new-turn boundary either, so a retired pane of its
+  // never comes back and never mints a fence. Nothing here can strand it.
+  'command-code': { newTurn: 'PreToolUse', sessionStart: null, armable: false }
+}
+
+function post(
+  server: AgentHookServer,
+  source: AgentHookSource,
+  hookEventName: string,
+  launchToken: string,
+  prompt: string,
+  options: { isReplay?: boolean } = {}
+): void {
+  server.ingestRemote(
+    {
+      paneKey: PANE,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      source,
+      hookEventName,
+      launchToken,
+      ...(options.isReplay === true ? { isReplay: true } : {}),
+      ...(source === 'mimo-code' ? { hasExplicitPrompt: true } : {}),
+      payload: {
+        state: 'working',
+        prompt,
+        agentType: source,
+        ...(source === 'mimo-code' ? { role: 'user', text: prompt } : {})
+      }
+    },
+    'conn-1'
+  )
+}
+
+function promptOf(server: AgentHookServer): string | undefined {
+  return server.getStatusSnapshot().find((entry) => entry.paneKey === PANE)?.prompt
+}
+
+/** Retire the pane, then let a tokened new turn revive it — that revive is what mints the
+ *  launch-token fence this suite is about. */
+function armFence(server: AgentHookServer, source: AgentHookSource, token: string): void {
+  server.retirePaneAuthority(PANE)
+  post(server, source, BOUNDARIES[source].newTurn, token, 'first turn')
+  expect(promptOf(server)).toBe('first turn')
+}
+
+const SOURCES = (Object.keys(BOUNDARIES) as AgentHookSource[]).filter(
+  (source) => BOUNDARIES[source].armable !== false
+)
+const WITH_SESSION_START = SOURCES.filter((source) => BOUNDARIES[source].sessionStart !== null)
+const WITHOUT_SESSION_START = SOURCES.filter((source) => BOUNDARIES[source].sessionStart === null)
+
+describe("a fenced live pane re-fences on each provider's own session boundary", () => {
+  // Why the whole matrix: the branch matched the literal `SessionStart`, which only claude,
+  // codex and opencode send. Every other source's replacement process was suppressed forever,
+  // with no user-reachable way to bring the pane's row back.
+  it.each(WITH_SESSION_START)('%s', (source) => {
+    const server = new AgentHookServer()
+    armFence(server, source, 'token-1')
+
+    const sessionStart = BOUNDARIES[source].sessionStart as string
+    post(server, source, sessionStart, 'token-2', 'session start')
+    post(server, source, BOUNDARIES[source].newTurn, 'token-2', 'second turn')
+
+    expect(promptOf(server)).toBe('second turn')
+  })
+
+  it.each(WITH_SESSION_START)('%s still fences the token it replaced', (source) => {
+    const server = new AgentHookServer()
+    armFence(server, source, 'token-1')
+
+    post(server, source, BOUNDARIES[source].sessionStart as string, 'token-2', 'session start')
+    post(server, source, BOUNDARIES[source].newTurn, 'token-2', 'second turn')
+    // The process the fence replaced is still alive and still posting; it must not win the row.
+    // Why followUp and not the boundary: a boundary event IS the proof a process just started,
+    // so replaying one would be asking the gate to distrust its own evidence.
+    post(
+      server,
+      source,
+      BOUNDARIES[source].followUp ?? BOUNDARIES[source].newTurn,
+      'token-1',
+      'stale turn'
+    )
+
+    expect(promptOf(server)).toBe('second turn')
+  })
+})
+
+describe('a fenced live pane re-fences on the spawn that replaced its process', () => {
+  // Why these sources need it: they emit no session boundary at all, so no event can ever tell
+  // the gate a new process owns the pane. Main's own spawn is the only proof available.
+  it.each(WITHOUT_SESSION_START)('%s', (source) => {
+    const server = new AgentHookServer()
+    armFence(server, source, 'token-1')
+
+    server.noteAgentPaneLaunchToken(PANE, 'token-2')
+    post(server, source, BOUNDARIES[source].newTurn, 'token-2', 'second turn')
+
+    expect(promptOf(server)).toBe('second turn')
+  })
+
+  it('does not leave a tokenless respawn fenced to the process it replaced', () => {
+    const server = new AgentHookServer()
+    armFence(server, 'gemini', 'token-1')
+
+    // Why: nothing in a replacement PTY that carries no token can ever satisfy the old one, so
+    // keeping the fence would only ever admit the process the spawn replaced. (The tokenless
+    // poster itself is governed by the unmanaged-extension fence, which holds provisionally.)
+    server.noteAgentPaneLaunchToken(PANE, undefined)
+    post(server, 'gemini', 'BeforeAgent', 'token-2', 'second turn')
+
+    expect(promptOf(server)).toBe('second turn')
+  })
+
+  it('does not arm a fence on a pane that never had one', () => {
+    const server = new AgentHookServer()
+    server.noteAgentPaneLaunchToken(PANE, 'token-1')
+    // Why: arming here would start suppressing tokenless posters in panes no revive ever fenced.
+    post(server, 'gemini', 'BeforeAgent', '', 'tokenless turn')
+
+    expect(promptOf(server)).toBe('tokenless turn')
+  })
+})
+
+describe("relay spool replay is fenced on the pane's current generation", () => {
+  // Why: the replay fence compared against the last token main happened to observe. An agent
+  // launched over SSH whose connection dropped before its first live post had every spooled
+  // event — including its final one — discarded as if it were the stale generation.
+  it('accepts a replay from the generation the pane was last launched with', () => {
+    const server = new AgentHookServer()
+    post(server, 'claude', 'UserPromptSubmit', 'token-a', 'agent a')
+    expect(promptOf(server)).toBe('agent a')
+
+    server.noteAgentPaneLaunchToken(PANE, 'token-b')
+    post(server, 'claude', 'UserPromptSubmit', 'token-b', 'agent b offline', { isReplay: true })
+
+    expect(promptOf(server)).toBe('agent b offline')
+  })
+
+  it('still discards a replay from the generation that spawn replaced', () => {
+    const server = new AgentHookServer()
+    post(server, 'claude', 'UserPromptSubmit', 'token-a', 'agent a')
+    server.noteAgentPaneLaunchToken(PANE, 'token-b')
+    post(server, 'claude', 'UserPromptSubmit', 'token-b', 'agent b offline', { isReplay: true })
+
+    post(server, 'claude', 'UserPromptSubmit', 'token-a', 'agent a late spool', { isReplay: true })
+
+    expect(promptOf(server)).toBe('agent b offline')
+  })
+})

--- a/src/main/agent-hooks/server-unmanaged-status-extension.test.ts
+++ b/src/main/agent-hooks/server-unmanaged-status-extension.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentHookServer, _internals } from './server'
+import { buildBody, PANE } from './server.test-fixtures'
+
+// Why these exact bodies: measured against omp 17.0.5 with Orca's managed extension side-loaded
+// via `-e` alongside an unmanaged copy auto-discovered from the agent's extensions dir. Both post
+// the same pane key to /hook/omp from the same process; the managed copy always carries a
+// `launchToken` key (empty string when ORCA_AGENT_LAUNCH_TOKEN is unset), the unmanaged copy omits
+// the key entirely, and the unmanaged `agent_end` lands *first*.
+const LAUNCH_TOKEN = 'launch-token-abc'
+
+vi.mock('../telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('../telemetry/cohort-classifier', () => ({
+  getCohortAtEmit: () => ({ nth_repo_added: 2 })
+}))
+
+beforeEach(() => {
+  _internals.resetCachesForTests()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+type Post = { hookEventName: string; launchToken?: string }
+
+// Why structural: the server's enriched payload type is module-private; the assertions only
+// read the route and the projected state.
+type StatusEvent = { source?: string; payload: { state?: string } }
+
+function states(events: StatusEvent[]): (string | undefined)[] {
+  return events.map((event) => event.payload.state)
+}
+
+async function runOmpPosts(server: AgentHookServer, posts: Post[]): Promise<StatusEvent[]> {
+  const seen: StatusEvent[] = []
+  server.setListener((payload) => {
+    seen.push(payload)
+  })
+  const env = server.buildPtyEnv()
+  for (const post of posts) {
+    await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/omp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+      },
+      body: JSON.stringify(
+        buildBody(
+          { hook_event_name: post.hookEventName },
+          post.launchToken === undefined ? {} : { launchToken: post.launchToken }
+        )
+      )
+    })
+  }
+  return seen
+}
+
+describe('unmanaged OMP status extension', () => {
+  it('drops the unmanaged copy’s agent_end once a tokened poster owns the pane', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const seen = await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_end' },
+        { hookEventName: 'agent_end', launchToken: LAUNCH_TOKEN }
+      ])
+      expect(states(seen)).toEqual(['working', 'done'])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('reports the unmanaged extension once per pane and source', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    const reports: string[] = []
+    server.setUnmanagedStatusExtensionListener((report) => {
+      reports.push(`${report.source}:${report.paneKey}`)
+    })
+    try {
+      await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_end' },
+        { hookEventName: 'agent_end' }
+      ])
+      expect(reports).toEqual([`omp:${PANE}`])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('fails open when no post ever carries a launch token', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      // Why: a bare shell gets no ORCA_AGENT_LAUNCH_TOKEN, so the managed extension itself posts
+      // `launchToken: ''`. Gating that would strand the pane on 'working' with no user recovery.
+      const seen = await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: '' },
+        { hookEventName: 'agent_end', launchToken: '' }
+      ])
+      expect(states(seen)).toEqual(['working', 'done'])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('lets a relaunch with a different token take the pane back', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const seen = await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_start', launchToken: 'launch-token-second' },
+        { hookEventName: 'agent_end', launchToken: 'launch-token-second' }
+      ])
+      expect(states(seen)).toEqual(['working', 'working', 'done'])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('does not gate a different source that shares the pane', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    const seen: StatusEvent[] = []
+    server.setListener((payload) => {
+      seen.push(payload)
+    })
+    try {
+      const env = server.buildPtyEnv()
+      const post = async (pathname: string, body: unknown): Promise<void> => {
+        await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}${pathname}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(body)
+        })
+      }
+      await post(
+        '/hook/omp',
+        buildBody({ hook_event_name: 'agent_start' }, { launchToken: LAUNCH_TOKEN })
+      )
+      await post('/hook/claude', buildBody({ hook_event_name: 'UserPromptSubmit', prompt: 'go' }))
+      expect(seen.map((event) => event.source)).toEqual(['omp', 'claude'])
+    } finally {
+      await server.stop()
+    }
+  })
+})

--- a/src/main/agent-hooks/server-unmanaged-status-extension.test.ts
+++ b/src/main/agent-hooks/server-unmanaged-status-extension.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AgentHookServer, _internals } from './server'
+import { makePaneKey } from '../../shared/stable-pane-id'
 import { buildBody, PANE } from './server.test-fixtures'
 
 // Why these exact bodies: measured against omp 17.0.5 with Orca's managed extension side-loaded
@@ -32,11 +33,7 @@ function states(events: StatusEvent[]): (string | undefined)[] {
   return events.map((event) => event.payload.state)
 }
 
-async function runOmpPosts(server: AgentHookServer, posts: Post[]): Promise<StatusEvent[]> {
-  const seen: StatusEvent[] = []
-  server.setListener((payload) => {
-    seen.push(payload)
-  })
+async function postOmp(server: AgentHookServer, posts: Post[]): Promise<void> {
   const env = server.buildPtyEnv()
   for (const post of posts) {
     await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/omp`, {
@@ -53,6 +50,16 @@ async function runOmpPosts(server: AgentHookServer, posts: Post[]): Promise<Stat
       )
     })
   }
+}
+
+// Why it returns the live array: it keeps filling after the awaited posts, which is exactly
+// where a released hold has to show up. Installs the listener, so call it once per server.
+async function runOmpPosts(server: AgentHookServer, posts: Post[]): Promise<StatusEvent[]> {
+  const seen: StatusEvent[] = []
+  server.setListener((payload) => {
+    seen.push(payload)
+  })
+  await postOmp(server, posts)
   return seen
 }
 
@@ -73,6 +80,9 @@ describe('unmanaged OMP status extension', () => {
   })
 
   it('reports the unmanaged extension once per pane and source', async () => {
+    // Why a tokened post has to follow: a tokenless post on its own is only evidence that the
+    // token is missing. It becomes evidence of a *second* poster when the managed copy speaks
+    // over it on the same pane and source — one process cannot both send and omit the token.
     const server = new AgentHookServer()
     await server.start({ env: 'production' })
     const reports: string[] = []
@@ -83,7 +93,9 @@ describe('unmanaged OMP status extension', () => {
       await runOmpPosts(server, [
         { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
         { hookEventName: 'agent_end' },
-        { hookEventName: 'agent_end' }
+        { hookEventName: 'agent_end', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_end' },
+        { hookEventName: 'agent_end', launchToken: LAUNCH_TOKEN }
       ])
       expect(reports).toEqual([`omp:${PANE}`])
     } finally {
@@ -147,6 +159,140 @@ describe('unmanaged OMP status extension', () => {
       )
       await post('/hook/claude', buildBody({ hook_event_name: 'UserPromptSubmit', prompt: 'go' }))
       expect(seen.map((event) => event.source)).toEqual(['omp', 'claude'])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('delivers a held tokenless post once the tokened poster goes silent', async () => {
+    // Why this is the whole exit: "a tokened post was seen" proves a managed poster existed, not
+    // that one is live. Without a lapse the pane would claim work forever with no user recovery.
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    server._setUnmanagedExtensionConfirmationWindowMsForTests(40)
+    try {
+      const seen = await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_end' }
+      ])
+      expect(states(seen)).toEqual(['working'])
+      await vi.waitFor(() => {
+        expect(states(seen)).toEqual(['working', 'done'])
+      })
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('keeps holding while the tokened poster keeps posting', async () => {
+    // Why: the lapse must not become a back door. As long as the managed copy is live, every
+    // stale post is superseded, so the pane never settles early.
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    server._setUnmanagedExtensionConfirmationWindowMsForTests(40)
+    try {
+      const seen = await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_end' },
+        { hookEventName: 'tool_call', launchToken: LAUNCH_TOKEN }
+      ])
+      await new Promise((resolve) => setTimeout(resolve, 120))
+      expect(states(seen)).toEqual(['working', 'working'])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('does not report Orca’s own tokenless relaunch as a foreign extension', async () => {
+    // Why: Orca’s detached Codex account-switch restart respawns into the same pane key. Until it
+    // carried a launch token its posts were tokenless, and warning a user about “an extension Orca
+    // did not install” for something Orca launched is unactionable. Two posters are only proven
+    // when a tokened post interleaves with a held tokenless one — a relaunch never does.
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    server._setUnmanagedExtensionConfirmationWindowMsForTests(40)
+    const reports: string[] = []
+    server.setUnmanagedStatusExtensionListener((report) => {
+      reports.push(`${report.source}:${report.paneKey}`)
+    })
+    try {
+      await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_start' },
+        { hookEventName: 'agent_end' }
+      ])
+      expect(reports).toEqual([])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('reports per pane and source, which is what the renderer dedupe collapses to one toast', async () => {
+    // Why pin the fan-out shape: the one-shot property lives in the renderer's per-source
+    // dedupe, not here. This side must stay per-pane-and-source, or that dedupe is being fed
+    // something it was never sized for.
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    const reports: string[] = []
+    server.setUnmanagedStatusExtensionListener((report) => {
+      reports.push(`${report.source}:${report.paneKey}`)
+    })
+    const env = server.buildPtyEnv()
+    const paneKeys = Array.from({ length: 13 }, (_, index) =>
+      makePaneKey(
+        `tab-${index}`,
+        `${index.toString(16).padStart(8, '0')}-1111-4111-8111-111111111111`
+      )
+    )
+    const post = async (paneKey: string, hookEventName: string, launchToken?: string) => {
+      await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/omp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+        },
+        body: JSON.stringify(
+          buildBody(
+            { hook_event_name: hookEventName },
+            {
+              paneKey,
+              tabId: paneKey.split(':')[0],
+              ...(launchToken === undefined ? {} : { launchToken })
+            }
+          )
+        )
+      })
+    }
+    try {
+      for (const paneKey of paneKeys) {
+        await post(paneKey, 'agent_start', LAUNCH_TOKEN)
+        await post(paneKey, 'agent_end')
+        await post(paneKey, 'agent_end', LAUNCH_TOKEN)
+      }
+      expect(reports).toEqual(paneKeys.map((paneKey) => `omp:${paneKey}`))
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('drops a held post when the pane is retired, so a reused key cannot settle on it', async () => {
+    // Why the revive matters: retirement alone hides the released post behind the retired-pane
+    // gate. A pane key reused by a tokenless launch re-opens that gate, and a hold surviving
+    // teardown would then settle the *new* turn with the old turn's completion.
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    server._setUnmanagedExtensionConfirmationWindowMsForTests(40)
+    try {
+      const seen = await runOmpPosts(server, [
+        { hookEventName: 'agent_start', launchToken: LAUNCH_TOKEN },
+        { hookEventName: 'agent_end' }
+      ])
+      server.retirePaneAuthority(PANE)
+      // Why before_agent_start: that is omp's new-turn boundary, the one event that re-opens a
+      // retired pane. Anything else stays suppressed and would hide the held post either way.
+      await postOmp(server, [{ hookEventName: 'before_agent_start' }])
+      await new Promise((resolve) => setTimeout(resolve, 120))
+      expect(states(seen)).toEqual(['working', 'working'])
     } finally {
       await server.stop()
     }

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1232,7 +1232,7 @@ export class AgentHookServer {
       const tokenFence = this.restartedStatusLaunchTokenHashByPaneKey.get(ownerPaneKey)
       // Why: deferred retirement lets a new process start in a still-authorized pane, so
       // its tokened session boundary re-fences; prompts recur, so a stale process would win.
-      // Why the classifier, not a literal: `SessionStart` is how 3 of 18 sources spell it, so
+      // Why the classifier, not a literal: `SessionStart` is how 5 of 18 sources spell it, so
       // the rest could never re-fence and a pane Orca respawned stayed suppressed for the life
       // of the process. Same defect the retired branch below already fixed.
       // Why the literal survives as the fallback: an older relay omits `source` entirely.
@@ -2465,7 +2465,17 @@ export class AgentHookServer {
     if (envelope.isReplay === true) {
       const expectedLaunchTokenHash = this.hydratedLaunchTokenHashByPaneKey.get(paneKey)
       const actualLaunchTokenHash = launchTokenHash(envelope.launchToken)
-      if (expectedLaunchTokenHash && actualLaunchTokenHash !== expectedLaunchTokenHash) {
+      // Why a tokenless replay is admitted rather than rejected: this is the read-side of the
+      // same rule the spawn notification applies on the write side. A record carrying no token
+      // is not evidence about ANY generation, so treating it as evidence of the WRONG one would
+      // discard the whole spool of any agent whose process never received the token: the
+      // `${ORCA_AGENT_LAUNCH_TOKEN:-}` posters, and every WSL/SSH host where the env is lost in
+      // transit. That is the same silent, unrecoverable frozen row this fence exists to prevent.
+      if (
+        expectedLaunchTokenHash &&
+        actualLaunchTokenHash &&
+        actualLaunchTokenHash !== expectedLaunchTokenHash
+      ) {
         return
       }
     }

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -782,6 +782,10 @@ export class AgentHookServer {
     this.unmanagedExtensionFence.setDetectionListener(listener)
   }
 
+  _setUnmanagedExtensionConfirmationWindowMsForTests(windowMs: number): void {
+    this.unmanagedExtensionFence.setConfirmationWindowMsForTests(windowMs)
+  }
+
   setListener(listener: ((payload: EnrichedAgentHookEventPayload) => void) | null): void {
     this.onAgentStatus = listener
     if (!listener) {
@@ -1191,6 +1195,8 @@ export class AgentHookServer {
       isReplay?: boolean
       hasExplicitPrompt?: boolean
       launchToken?: string
+      /** Re-delivers this post if the unmanaged-extension fence holds it and nothing supersedes it. */
+      releaseIfUnconfirmed?: () => void
     }
   ): 'accept' | 'restart' | 'suppress' {
     const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
@@ -1202,13 +1208,19 @@ export class AgentHookServer {
       return 'suppress'
     }
     // Why: a second status extension loaded alongside Orca's own posts the same pane key from the
-    // same process, so only the launch token separates them. Fails open — the fence stays shut
-    // until a tokened post proves a managed poster is live, so a tokenless launch is never gated.
+    // same process, so only the launch token separates them. The hold is provisional in both
+    // directions — a tokenless launch is never gated until a tokened post owns the pane, and a
+    // held post is delivered anyway once the tokened poster goes silent, so no sequence of posts
+    // can strand a pane on 'working'.
     // Replays carry no live process and are fenced by hydratedLaunchTokenHashByPaneKey instead.
     if (event && event.isReplay !== true) {
       if (
-        this.unmanagedExtensionFence.classify(ownerPaneKey, event.source, event.launchToken) ===
-        'unmanaged'
+        this.unmanagedExtensionFence.classify(
+          ownerPaneKey,
+          event.source,
+          event.launchToken,
+          event.releaseIfUnconfirmed
+        ) === 'held'
       ) {
         return 'suppress'
       }
@@ -2176,6 +2188,47 @@ export class AgentHookServer {
     return { ...record, paneKey: stablePaneKey, tabId: parsePaneKey(stablePaneKey)?.tabId }
   }
 
+  /**
+   * Disposition + apply for one local hook post.
+   *
+   * Why re-entrant: the unmanaged-extension fence holds a tokenless post instead of dropping it,
+   * and delivers it through this same method once nothing supersedes it — so the hold cannot skip
+   * a gate, and a lapsed hold cannot bypass one that has closed in the meantime.
+   */
+  private routeLocalHookStatus(
+    source: AgentHookSource,
+    aliasedBody: unknown,
+    normalized: NormalizedLocalHook
+  ): void {
+    const event = normalized.event
+    if (!event) {
+      return
+    }
+    const statusDisposition = this.getAgentStatusDisposition(event.paneKey, {
+      source,
+      hookEventName: event.hookEventName,
+      isReplay: event.isReplay,
+      hasExplicitPrompt: event.hasExplicitPrompt,
+      launchToken: event.launchToken,
+      releaseIfUnconfirmed: () => {
+        this.routeLocalHookStatus(source, aliasedBody, normalized)
+      }
+    })
+    if (statusDisposition === 'suppress') {
+      return
+    }
+    const applied = statusDisposition === 'restart' ? { ...event, launchToken: undefined } : event
+    if (statusDisposition === 'restart') {
+      // Why: a retired pane accepting a new turn is a different agent session behind the
+      // same key — later observations must not be ordered against the retired one.
+      this.observations.rebind(applied.paneKey)
+    }
+    this.recordCurrentAuthorityObservation(applied)
+    const enriched = this.applyNormalizedStatus(applied, normalized.onAccepted)
+    this.scheduleAssistantMessageRetry(source, aliasedBody, enriched)
+    this.scheduleCodexSubagentPoll(source, aliasedBody, enriched)
+  }
+
   private normalizeLocalHookPayload(source: AgentHookSource, body: unknown): NormalizedLocalHook {
     if (source !== 'claude' || typeof body !== 'object' || body === null) {
       return { event: normalizeHookPayload(this.state, source, body, this.env) }
@@ -2411,7 +2464,12 @@ export class AgentHookServer {
       hookEventName,
       isReplay: envelope.isReplay === true,
       hasExplicitPrompt: envelope.hasExplicitPrompt === true,
-      launchToken: envelope.launchToken
+      launchToken: envelope.launchToken,
+      // Why re-enter rather than replay the tail: every gate below this point must be re-checked
+      // against the pane as it stands when the hold lapses, not as it stood when it was taken.
+      releaseIfUnconfirmed: () => {
+        this.ingestRemote(envelope, connectionId)
+      }
     })
     if (statusDisposition === 'suppress') {
       return
@@ -2655,31 +2713,11 @@ export class AgentHookServer {
         const hookBody = mergeAgentHookRequestHeaders(body, req.headers)
         trackEmptyPaneKeyHook(hookBody)
         const aliasedBody = this.normalizeHookBodyPaneKeyAlias(hookBody)
-        const normalized = this.normalizeLocalHookPayload(source, aliasedBody)
-        const statusDisposition = normalized.event
-          ? this.getAgentStatusDisposition(normalized.event.paneKey, {
-              source,
-              hookEventName: normalized.event.hookEventName,
-              isReplay: normalized.event.isReplay,
-              hasExplicitPrompt: normalized.event.hasExplicitPrompt,
-              launchToken: normalized.event.launchToken
-            })
-          : 'suppress'
-        if (normalized.event && statusDisposition !== 'suppress') {
-          const event =
-            statusDisposition === 'restart'
-              ? { ...normalized.event, launchToken: undefined }
-              : normalized.event
-          if (statusDisposition === 'restart') {
-            // Why: a retired pane accepting a new turn is a different agent session behind the
-            // same key — later observations must not be ordered against the retired one.
-            this.observations.rebind(event.paneKey)
-          }
-          this.recordCurrentAuthorityObservation(event)
-          const enriched = this.applyNormalizedStatus(event, normalized.onAccepted)
-          this.scheduleAssistantMessageRetry(source, aliasedBody, enriched)
-          this.scheduleCodexSubagentPoll(source, aliasedBody, enriched)
-        }
+        this.routeLocalHookStatus(
+          source,
+          aliasedBody,
+          this.normalizeLocalHookPayload(source, aliasedBody)
+        )
 
         res.writeHead(204)
         res.end()
@@ -2757,6 +2795,8 @@ export class AgentHookServer {
     this.closedAgentStatusTabIds.clear()
     this.closedAgentStatusPaneKeys.clear()
     this.restartedStatusLaunchTokenHashByPaneKey.clear()
+    // Why: a held tokenless post must not outlive the server that would deliver it.
+    this.unmanagedExtensionFence.dispose()
     this.retiredPaneFencesByKey.clear()
     this.connectionTimestampWatermarkById.clear()
     this.legacyPaneKeyAliases.clear()

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -55,6 +55,10 @@ import {
   readRequestBody
 } from '../../shared/agent-hook-listener/request-body'
 import { resolveHookSource } from '../../shared/agent-hook-listener/source-routing'
+import {
+  UnmanagedStatusExtensionFence,
+  type UnmanagedStatusExtensionReport
+} from './unmanaged-status-extension-fence'
 import type { AgentHookEventPayload } from '../../shared/agent-hook-listener/listener-event'
 import {
   canAcceptClaudeCompactCompletion,
@@ -746,6 +750,7 @@ export class AgentHookServer {
   private closedAgentStatusTabIds = new Set<string>()
   private closedAgentStatusPaneKeys = new Set<string>()
   private restartedStatusLaunchTokenHashByPaneKey = new Map<string, string>()
+  private unmanagedExtensionFence = new UnmanagedStatusExtensionFence()
   private connectionTimestampWatermarkById = new Map<string, number>()
   // Why: skip disk writes when the JSON exactly matches the last write; guards against re-firing trailing timers when nothing changed.
   private lastWrittenJson: string | null = null
@@ -764,6 +769,17 @@ export class AgentHookServer {
     listener: ((report: HookTransportInterferenceReport) => void) | null
   ): void {
     this.onTransportInterference = listener
+  }
+
+  /**
+   * Notified once per pane and source when a status extension Orca did not launch is posting.
+   * Why: the fence silently drops those posts, and the file is a user's own — Orca must never
+   * remove it, so the only honest remedy is telling the user which agent is affected.
+   */
+  setUnmanagedStatusExtensionListener(
+    listener: ((report: UnmanagedStatusExtensionReport) => void) | null
+  ): void {
+    this.unmanagedExtensionFence.setDetectionListener(listener)
   }
 
   setListener(listener: ((payload: EnrichedAgentHookEventPayload) => void) | null): void {
@@ -1184,6 +1200,18 @@ export class AgentHookServer {
     const tabId = parsePaneKey(ownerPaneKey)?.tabId
     if (tabId && this.closedAgentStatusTabIds.has(tabId)) {
       return 'suppress'
+    }
+    // Why: a second status extension loaded alongside Orca's own posts the same pane key from the
+    // same process, so only the launch token separates them. Fails open — the fence stays shut
+    // until a tokened post proves a managed poster is live, so a tokenless launch is never gated.
+    // Replays carry no live process and are fenced by hydratedLaunchTokenHashByPaneKey instead.
+    if (event && event.isReplay !== true) {
+      if (
+        this.unmanagedExtensionFence.classify(ownerPaneKey, event.source, event.launchToken) ===
+        'unmanaged'
+      ) {
+        return 'suppress'
+      }
     }
     if (!paneRetired) {
       const tokenFence = this.restartedStatusLaunchTokenHashByPaneKey.get(ownerPaneKey)
@@ -1961,6 +1989,10 @@ export class AgentHookServer {
 
   retirePaneAuthority(paneKey: string): void {
     const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
+    // Why: a reused pane key may relaunch without a launch token; keeping the old owner would
+    // gate the new process's own posts and strand the pane on 'working'.
+    this.unmanagedExtensionFence.forgetPane(paneKey)
+    this.unmanagedExtensionFence.forgetPane(ownerPaneKey)
     const paneKeys = new Set([paneKey, ownerPaneKey])
     const retiredAliases: RetiredPaneAlias[] = []
     let aliasChanged = false

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -47,7 +47,10 @@ import {
   normalizeClaudePromptId,
   warnOnHookEnvOrVersionMismatch
 } from '../../shared/agent-hook-listener/listener-limits'
-import { isNewTurnEvent } from '../../shared/agent-hook-listener/provider-event-routing'
+import {
+  isNewTurnEvent,
+  isSessionStartEvent
+} from '../../shared/agent-hook-listener/provider-event-routing'
 import { normalizeHookPayload } from '../../shared/agent-hook-listener'
 import { mergeAgentHookRequestHeaders } from '../../shared/agent-hook-listener/hook-envelope'
 import {
@@ -1228,12 +1231,17 @@ export class AgentHookServer {
     if (!paneRetired) {
       const tokenFence = this.restartedStatusLaunchTokenHashByPaneKey.get(ownerPaneKey)
       // Why: deferred retirement lets a new process start in a still-authorized pane, so
-      // its tokened SessionStart re-fences; prompts recur, so a stale process would win.
-      if (
-        event?.hookEventName === 'SessionStart' &&
-        event.isReplay !== true &&
-        tokenFence !== undefined
-      ) {
+      // its tokened session boundary re-fences; prompts recur, so a stale process would win.
+      // Why the classifier, not a literal: `SessionStart` is how 3 of 18 sources spell it, so
+      // the rest could never re-fence and a pane Orca respawned stayed suppressed for the life
+      // of the process. Same defect the retired branch below already fixed.
+      // Why the literal survives as the fallback: an older relay omits `source` entirely.
+      const startsNewSession =
+        event !== undefined &&
+        (event.source !== undefined
+          ? isSessionStartEvent(event.source, event.hookEventName)
+          : event.hookEventName === 'SessionStart')
+      if (event && startsNewSession && event.isReplay !== true && tokenFence !== undefined) {
         const startedLaunchToken = event.launchToken?.trim()
         if (startedLaunchToken) {
           this.restartedStatusLaunchTokenHashByPaneKey.set(
@@ -2077,6 +2085,40 @@ export class AgentHookServer {
   // lifts here instead of waiting for the agent to speak again — an agent re-attached
   // mid-turn or left idle would otherwise stay suppressed for the rest of its life
   // (STA-4114). A closed *tab* is a separate, stronger claim and is left standing.
+  /**
+   * Main just launched a PTY for this pane carrying this launch token, so the token names the
+   * pane's current agent lineage by construction — no provider has to say anything for it to
+   * be true.
+   *
+   * Why main and not a hook event: both token-keyed status gates could only learn about a new
+   * process from an event the provider might never send. The live-pane re-fence matched a raw
+   * `SessionStart`, and the spool-replay fence compares against the last token it happened to
+   * observe, which can be OLDER than the generation being replayed. Either way a pane Orca
+   * itself respawned went silent with no user-reachable recovery.
+   *
+   * Why the status fence is replaced and never armed here: arming one would fence panes that no
+   * revive ever fenced and start suppressing their tokenless posters.
+   *
+   * Why the replay expectation is only raised and never cleared: it exists to reject an older
+   * generation's spool, and a shell launched with no agent token is not evidence about any
+   * generation.
+   */
+  noteAgentPaneLaunchToken(paneKey: string, launchToken: string | undefined): void {
+    const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
+    const trimmed = launchToken?.trim()
+    const hash = trimmed ? createHash('sha256').update(trimmed).digest('hex') : null
+    if (this.restartedStatusLaunchTokenHashByPaneKey.has(ownerPaneKey)) {
+      if (hash) {
+        this.restartedStatusLaunchTokenHashByPaneKey.set(ownerPaneKey, hash)
+      } else {
+        this.restartedStatusLaunchTokenHashByPaneKey.delete(ownerPaneKey)
+      }
+    }
+    if (hash) {
+      this.hydratedLaunchTokenHashByPaneKey.set(ownerPaneKey, hash)
+    }
+  }
+
   restorePaneAuthority(paneKey: string): boolean {
     const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
     if (this.isClosedAgentStatusTabForPaneKey(ownerPaneKey)) {

--- a/src/main/agent-hooks/unmanaged-status-extension-fence.ts
+++ b/src/main/agent-hooks/unmanaged-status-extension-fence.ts
@@ -11,9 +11,31 @@ import type { AgentHookSource } from '../../shared/agent-hook-relay'
 // Orca's managed extension stamps ORCA_AGENT_LAUNCH_TOKEN into every post body; an unmanaged
 // copy predating that field cannot. That is the only reliable in-band discriminator, because
 // both copies share the process, the pane key, and the endpoint credentials.
+//
+// Why suppression is provisional, never permanent: "a tokened post was seen once" is evidence
+// that a managed poster *existed*, not that one is *live*. A managed poster that posts once and
+// then dies would otherwise gate every later post on that pane forever, and a pane stuck on
+// "working" is invisible and has no user recovery. So a tokenless post is HELD, not dropped:
+// a following tokened post discards it (and is the proof that two posters share the pane —
+// that is the only thing worth warning about), and silence past the confirmation window
+// re-opens the gate and delivers it. Every held post is therefore either superseded by the
+// managed poster or delivered; no sequence of posts can strand a pane.
 
 /** Panes tracked before the oldest owner is evicted; a lost owner only re-opens the gate. */
 const MAX_TRACKED_PANES = 512
+
+/**
+ * How long a held tokenless post waits for the managed poster to contradict it.
+ *
+ * Why this long: both copies run in one process off one hook event, so the managed copy's
+ * superseding post lands in the same millisecond band as the unmanaged one (the measured
+ * ordering was unmanaged-first by a hair). Even the deliberately-withheld `agent_end` is
+ * re-checked every 25–250ms until idle, and an auto-continuation posts `agent_start` as
+ * soon as it is scheduled. 30s is orders of magnitude above that and far below the 30min
+ * AGENT_STATUS_STALE_AFTER_MS at which Orca stops believing a "working" claim anyway, so a
+ * lapse means the managed poster is gone rather than merely quiet.
+ */
+export const UNMANAGED_POST_CONFIRMATION_WINDOW_MS = 30_000
 
 export type UnmanagedStatusExtensionReport = {
   paneKey: string
@@ -23,31 +45,50 @@ export type UnmanagedStatusExtensionReport = {
 export type StatusPostOrigin =
   /** Carries a launch token: this is the process Orca launched, and it now owns the pane. */
   | 'managed'
-  /** No token, and a token-carrying poster is already live on the same pane and source. */
-  | 'unmanaged'
+  /** No token while a token-carrying poster owns the pane: held pending confirmation. */
+  | 'held'
   /** No token and no established owner: indistinguishable from a normal tokenless launch. */
   | 'unattributed'
+
+type HeldPost = {
+  timer: ReturnType<typeof setTimeout>
+  release: () => void
+}
 
 /**
  * Tells Orca's own status extension apart from a second one loaded alongside it.
  *
- * Only ever classifies a *tokenless* post as unmanaged, and only once the same pane and source
- * have proven a token-carrying poster exists. A tokened post is never rejected, so a relaunch
- * always takes the pane back.
+ * Only ever holds a *tokenless* post, and only while a token-carrying poster owns the same pane
+ * and source. A tokened post is never rejected, so a relaunch always takes the pane back, and a
+ * held post is always resolved — superseded by the managed poster, or delivered when it goes
+ * silent for {@link UNMANAGED_POST_CONFIRMATION_WINDOW_MS}.
  */
 export class UnmanagedStatusExtensionFence {
   private ownerHashByPaneKey = new Map<string, Map<AgentHookSource, string>>()
   private reportedSourcesByPaneKey = new Map<string, Set<AgentHookSource>>()
+  private heldPostsByPaneKey = new Map<string, Map<AgentHookSource, HeldPost>>()
   private onDetected: ((report: UnmanagedStatusExtensionReport) => void) | null = null
+
+  constructor(private confirmationWindowMs: number = UNMANAGED_POST_CONFIRMATION_WINDOW_MS) {}
+
+  /** Test seam: the production window is far longer than any suite should wait on. */
+  setConfirmationWindowMsForTests(windowMs: number): void {
+    this.confirmationWindowMs = windowMs
+  }
 
   setDetectionListener(listener: ((report: UnmanagedStatusExtensionReport) => void) | null): void {
     this.onDetected = listener
   }
 
+  /**
+   * @param release re-delivers this post if the managed poster never contradicts it. Omitting it
+   *   makes the hold a plain drop, so callers that cannot replay must not gate on this fence.
+   */
   classify(
     paneKey: string,
     source: AgentHookSource | undefined,
-    launchToken: string | undefined
+    launchToken: string | undefined,
+    release?: () => void
   ): StatusPostOrigin {
     if (!source || paneKey.length === 0) {
       return 'unattributed'
@@ -55,27 +96,105 @@ export class UnmanagedStatusExtensionFence {
     const token = launchToken?.trim() ?? ''
     if (token.length > 0) {
       this.rememberOwner(paneKey, source, createHash('sha256').update(token).digest('hex'))
+      // Why here: a tokened post arriving while a tokenless one is held is the whole proof —
+      // two posters, one Orca launched and one it did not, interleaved on one pane.
+      if (this.discardHeldPost(paneKey, source)) {
+        this.reportOnce(paneKey, source)
+      }
       return 'managed'
     }
     if (!this.ownerHashByPaneKey.get(paneKey)?.has(source)) {
       return 'unattributed'
     }
-    const reported = this.reportedSourcesByPaneKey.get(paneKey)
-    if (!reported?.has(source)) {
-      if (reported) {
-        reported.add(source)
-      } else {
-        this.reportedSourcesByPaneKey.set(paneKey, new Set([source]))
-      }
-      this.onDetected?.({ paneKey, source })
+    if (!release) {
+      return 'unattributed'
     }
-    return 'unmanaged'
+    this.holdPost(paneKey, source, release)
+    return 'held'
   }
 
   /** Pane teardown: drop the owner so a key reused by a tokenless launch starts from an open gate. */
   forgetPane(paneKey: string): void {
     this.ownerHashByPaneKey.delete(paneKey)
     this.reportedSourcesByPaneKey.delete(paneKey)
+    this.discardPaneHolds(paneKey)
+  }
+
+  /** Server shutdown: a held post must not outlive the server that would deliver it. */
+  dispose(): void {
+    for (const held of this.heldPostsByPaneKey.values()) {
+      for (const entry of held.values()) {
+        clearTimeout(entry.timer)
+      }
+    }
+    this.heldPostsByPaneKey.clear()
+    this.ownerHashByPaneKey.clear()
+    this.reportedSourcesByPaneKey.clear()
+  }
+
+  private holdPost(paneKey: string, source: AgentHookSource, release: () => void): void {
+    // Why latest-only: an older held post describes a state the newer one already supersedes.
+    this.discardHeldPost(paneKey, source)
+    const timer = setTimeout(() => {
+      this.discardHeldPost(paneKey, source)
+      // Why before release: the replay re-enters classify, and a still-armed gate would hold it
+      // again forever. Dropping the owner is also the point — the managed poster proved absent.
+      this.forgetOwner(paneKey, source)
+      release()
+    }, this.confirmationWindowMs)
+    timer.unref?.()
+    const held = this.heldPostsByPaneKey.get(paneKey) ?? new Map<AgentHookSource, HeldPost>()
+    held.set(source, { timer, release })
+    this.heldPostsByPaneKey.set(paneKey, held)
+  }
+
+  private discardHeldPost(paneKey: string, source: AgentHookSource): boolean {
+    const held = this.heldPostsByPaneKey.get(paneKey)
+    const entry = held?.get(source)
+    if (!held || !entry) {
+      return false
+    }
+    clearTimeout(entry.timer)
+    held.delete(source)
+    if (held.size === 0) {
+      this.heldPostsByPaneKey.delete(paneKey)
+    }
+    return true
+  }
+
+  private discardPaneHolds(paneKey: string): void {
+    const held = this.heldPostsByPaneKey.get(paneKey)
+    if (!held) {
+      return
+    }
+    for (const entry of held.values()) {
+      clearTimeout(entry.timer)
+    }
+    this.heldPostsByPaneKey.delete(paneKey)
+  }
+
+  private reportOnce(paneKey: string, source: AgentHookSource): void {
+    const reported = this.reportedSourcesByPaneKey.get(paneKey)
+    if (reported?.has(source)) {
+      return
+    }
+    if (reported) {
+      reported.add(source)
+    } else {
+      this.reportedSourcesByPaneKey.set(paneKey, new Set([source]))
+    }
+    this.onDetected?.({ paneKey, source })
+  }
+
+  private forgetOwner(paneKey: string, source: AgentHookSource): void {
+    const sources = this.ownerHashByPaneKey.get(paneKey)
+    if (!sources) {
+      return
+    }
+    sources.delete(source)
+    if (sources.size === 0) {
+      this.ownerHashByPaneKey.delete(paneKey)
+    }
   }
 
   private rememberOwner(paneKey: string, source: AgentHookSource, hash: string): void {
@@ -92,6 +211,7 @@ export class UnmanagedStatusExtensionFence {
       }
       this.ownerHashByPaneKey.delete(oldest)
       this.reportedSourcesByPaneKey.delete(oldest)
+      this.discardPaneHolds(oldest)
     }
   }
 }

--- a/src/main/agent-hooks/unmanaged-status-extension-fence.ts
+++ b/src/main/agent-hooks/unmanaged-status-extension-fence.ts
@@ -1,0 +1,97 @@
+import { createHash } from 'node:crypto'
+import type { AgentHookSource } from '../../shared/agent-hook-relay'
+
+// Why: Pi/OMP auto-discover every extension file in the agent's extensions dir, and Orca
+// side-loads its managed copy with `-e` whenever a user-owned file already holds that name
+// (writeManagedExtension refuses to overwrite an unmarked file). Both copies then run in the
+// same process and post the same pane's status, but an unmanaged copy is frozen at whatever
+// Orca version produced it, so it can post a completion the managed copy deliberately withheld
+// and settle a pane that is still working.
+//
+// Orca's managed extension stamps ORCA_AGENT_LAUNCH_TOKEN into every post body; an unmanaged
+// copy predating that field cannot. That is the only reliable in-band discriminator, because
+// both copies share the process, the pane key, and the endpoint credentials.
+
+/** Panes tracked before the oldest owner is evicted; a lost owner only re-opens the gate. */
+const MAX_TRACKED_PANES = 512
+
+export type UnmanagedStatusExtensionReport = {
+  paneKey: string
+  source: AgentHookSource
+}
+
+export type StatusPostOrigin =
+  /** Carries a launch token: this is the process Orca launched, and it now owns the pane. */
+  | 'managed'
+  /** No token, and a token-carrying poster is already live on the same pane and source. */
+  | 'unmanaged'
+  /** No token and no established owner: indistinguishable from a normal tokenless launch. */
+  | 'unattributed'
+
+/**
+ * Tells Orca's own status extension apart from a second one loaded alongside it.
+ *
+ * Only ever classifies a *tokenless* post as unmanaged, and only once the same pane and source
+ * have proven a token-carrying poster exists. A tokened post is never rejected, so a relaunch
+ * always takes the pane back.
+ */
+export class UnmanagedStatusExtensionFence {
+  private ownerHashByPaneKey = new Map<string, Map<AgentHookSource, string>>()
+  private reportedSourcesByPaneKey = new Map<string, Set<AgentHookSource>>()
+  private onDetected: ((report: UnmanagedStatusExtensionReport) => void) | null = null
+
+  setDetectionListener(listener: ((report: UnmanagedStatusExtensionReport) => void) | null): void {
+    this.onDetected = listener
+  }
+
+  classify(
+    paneKey: string,
+    source: AgentHookSource | undefined,
+    launchToken: string | undefined
+  ): StatusPostOrigin {
+    if (!source || paneKey.length === 0) {
+      return 'unattributed'
+    }
+    const token = launchToken?.trim() ?? ''
+    if (token.length > 0) {
+      this.rememberOwner(paneKey, source, createHash('sha256').update(token).digest('hex'))
+      return 'managed'
+    }
+    if (!this.ownerHashByPaneKey.get(paneKey)?.has(source)) {
+      return 'unattributed'
+    }
+    const reported = this.reportedSourcesByPaneKey.get(paneKey)
+    if (!reported?.has(source)) {
+      if (reported) {
+        reported.add(source)
+      } else {
+        this.reportedSourcesByPaneKey.set(paneKey, new Set([source]))
+      }
+      this.onDetected?.({ paneKey, source })
+    }
+    return 'unmanaged'
+  }
+
+  /** Pane teardown: drop the owner so a key reused by a tokenless launch starts from an open gate. */
+  forgetPane(paneKey: string): void {
+    this.ownerHashByPaneKey.delete(paneKey)
+    this.reportedSourcesByPaneKey.delete(paneKey)
+  }
+
+  private rememberOwner(paneKey: string, source: AgentHookSource, hash: string): void {
+    // Why: re-insert so the Map's insertion order stays a usable LRU for the cap below.
+    const existing = this.ownerHashByPaneKey.get(paneKey)
+    this.ownerHashByPaneKey.delete(paneKey)
+    const sources = existing ?? new Map<AgentHookSource, string>()
+    sources.set(source, hash)
+    this.ownerHashByPaneKey.set(paneKey, sources)
+    while (this.ownerHashByPaneKey.size > MAX_TRACKED_PANES) {
+      const oldest = this.ownerHashByPaneKey.keys().next().value
+      if (oldest === undefined) {
+        break
+      }
+      this.ownerHashByPaneKey.delete(oldest)
+      this.reportedSourcesByPaneKey.delete(oldest)
+    }
+  }
+}

--- a/src/main/daemon/pty-subprocess/spawn-environment-pane-identity.test.ts
+++ b/src/main/daemon/pty-subprocess/spawn-environment-pane-identity.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { createDaemonPtyEnvironment } from './spawn-environment'
+import { PANE_IDENTITY_ENV_KEYS } from '../../../shared/pane-identity-env'
+import type { PtySubprocessOptions } from '../pty-subprocess'
+
+// Why: the daemon outlives Electron and inherits its own process.env, which names whichever pane
+// the daemon was started from. Pane identity that arrives by inheritance is always the wrong
+// pane's, and ORCA_AGENT_LAUNCH_TOKEN is Orca's proof of authorship — an inherited one lets a pane
+// satisfy a status fence a different pane set. Shared with the relay via PANE_IDENTITY_ENV_KEYS.
+function daemonOpts(env: Record<string, string> | undefined): PtySubprocessOptions {
+  return {
+    shell: '/bin/sh',
+    cwd: '/tmp',
+    cols: 80,
+    rows: 24,
+    ...(env ? { env } : {})
+  } as unknown as PtySubprocessOptions
+}
+
+describe('daemon pane identity env', () => {
+  const leaked = {
+    ORCA_PANE_KEY: 'daemon-own-tab:daemon-own-leaf',
+    ORCA_TAB_ID: 'daemon-own-tab',
+    ORCA_WORKTREE_ID: 'daemon-own-wt',
+    ORCA_AGENT_LAUNCH_TOKEN: 'daemon-own-launch-token'
+  }
+
+  function withInheritedPaneIdentity<T>(run: () => T): T {
+    const saved = new Map(Object.keys(leaked).map((key) => [key, process.env[key]]))
+    Object.assign(process.env, leaked)
+    try {
+      return run()
+    } finally {
+      for (const [key, value] of saved) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
+  }
+
+  it('drops every inherited pane identity key the spawn did not ask for', () => {
+    const env = withInheritedPaneIdentity(() => createDaemonPtyEnvironment(daemonOpts(undefined)))
+    for (const key of PANE_IDENTITY_ENV_KEYS) {
+      expect(`${key}=${env[key]}`).toBe(`${key}=undefined`)
+    }
+  })
+
+  it('keeps only the pane identity this spawn explicitly named', () => {
+    // Why a partial env: the spawn names the pane but not the token, which is exactly a
+    // non-agent pane. The named key must survive and the unnamed one must not be inherited.
+    const env = withInheritedPaneIdentity(() =>
+      createDaemonPtyEnvironment(daemonOpts({ ORCA_PANE_KEY: 'tab-1:leaf-1' }))
+    )
+    expect(env.ORCA_PANE_KEY).toBe('tab-1:leaf-1')
+    expect(`token=${env.ORCA_AGENT_LAUNCH_TOKEN}`).toBe('token=undefined')
+    expect(`tab=${env.ORCA_TAB_ID}`).toBe('tab=undefined')
+    expect(`wt=${env.ORCA_WORKTREE_ID}`).toBe('wt=undefined')
+  })
+})

--- a/src/main/daemon/pty-subprocess/spawn-environment.ts
+++ b/src/main/daemon/pty-subprocess/spawn-environment.ts
@@ -18,13 +18,8 @@ import {
 } from '../../../shared/windows-environment-expansion'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import type { PtySubprocessOptions } from '../pty-subprocess'
+import { removeUnspecifiedPaneIdentityEnv } from '../../../shared/pane-identity-env'
 
-const PANE_IDENTITY_ENV_KEYS = [
-  'ORCA_PANE_KEY',
-  'ORCA_TAB_ID',
-  'ORCA_WORKTREE_ID',
-  'ORCA_AGENT_LAUNCH_TOKEN'
-] as const
 const WINDOWS_PATH_ENV_KEY_RE = /^path$/i
 
 function composeGuardedDaemonGitConfigEnv(
@@ -55,17 +50,6 @@ function deleteRequestedDaemonEnvKeys(
   }
   if (deleteOrcaOwnedCodexHome) {
     delete env.CODEX_HOME
-  }
-}
-
-function removeUnspecifiedPaneIdentityEnv(
-  env: Record<string, string>,
-  explicitEnv: Record<string, string> | undefined
-): void {
-  for (const key of PANE_IDENTITY_ENV_KEYS) {
-    if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
-      delete env[key]
-    }
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1697,6 +1697,7 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
     // Why: detach the hook listener on close so the server never fires into destroyed webContents before reopen, and replay runs only on deliberate recreations.
     agentHookServer.setListener(null)
     agentHookServer.setPaneStatusClearListener(null)
+    agentHookServer.setUnmanagedStatusExtensionListener(null)
     setMigrationUnsupportedPtyListener(null)
     // Why: stop the spinner timer here — it would fire into destroyed webContents, and per-pane teardown may never run for restored-but-untorn panes.
     stopAllSyntheticTitleSpinners()
@@ -1801,6 +1802,19 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
     }
     mainWindow?.webContents.send('agentStatus:clear', clear)
     getDashboardPopoutWindow()?.webContents.send('agentStatus:clear', clear)
+  })
+  // Why: the fence drops those posts silently, and the extension file belongs to the user —
+  // Orca must not touch it, so surfacing is the whole remedy. Telemetry too, because the
+  // population carrying a stale copy is exactly the one that reports shipped fixes as broken.
+  agentHookServer.setUnmanagedStatusExtensionListener((report) => {
+    console.warn(
+      `[agent-hooks] ignoring status posts from an unmanaged ${report.source} extension on pane ${report.paneKey}; Orca did not launch it`
+    )
+    track('agent_hook_unmanaged_extension', { source: report.source })
+    if (mainWindow?.isDestroyed()) {
+      return
+    }
+    mainWindow?.webContents.send('agentStatus:unmanagedExtension', { source: report.source })
   })
   setMigrationUnsupportedPtyListener((event) => {
     if (mainWindow?.isDestroyed()) {

--- a/src/main/ipc/pty-ipc-mock-registry.ts
+++ b/src/main/ipc/pty-ipc-mock-registry.ts
@@ -40,6 +40,7 @@ export const setMigrationUnsupportedPtyMock: Mock = vi.fn()
 export const clearMigrationUnsupportedPtyMock: Mock = vi.fn()
 export const clearMigrationUnsupportedPtysForPaneKeyMock: Mock = vi.fn()
 export const clearPaneKeyAliasesForPtyMock: Mock = vi.fn()
+export const noteAgentPaneLaunchTokenMock: Mock = vi.fn()
 export const recordCodexPaneAccountMock: Mock = vi.fn()
 export const forgetCodexPaneAccountMock: Mock = vi.fn()
 export const getCodexPaneAccountMock: Mock = vi.fn()
@@ -122,7 +123,8 @@ export const agentHookServerModuleMock = () => ({
     buildPtyEnv: buildAgentHookEnvMock,
     clearPaneState: clearAgentHookPaneStateMock,
     registerPaneKeyAlias: registerPaneKeyAliasMock,
-    clearPaneKeyAliasesForPty: clearPaneKeyAliasesForPtyMock
+    clearPaneKeyAliasesForPty: clearPaneKeyAliasesForPtyMock,
+    noteAgentPaneLaunchToken: noteAgentPaneLaunchTokenMock
   }
 })
 

--- a/src/main/ipc/pty-ipc-suite-environment.ts
+++ b/src/main/ipc/pty-ipc-suite-environment.ts
@@ -37,6 +37,7 @@ import {
   clearMigrationUnsupportedPtyMock,
   clearMigrationUnsupportedPtysForPaneKeyMock,
   clearPaneKeyAliasesForPtyMock,
+  noteAgentPaneLaunchTokenMock,
   recordCodexPaneAccountMock,
   forgetCodexPaneAccountMock,
   getCodexPaneAccountMock,
@@ -161,6 +162,7 @@ export function createPtyIpcSuiteEnvironment(): PtyIpcSuiteEnvironment {
     clearMigrationUnsupportedPtyMock.mockReset()
     clearMigrationUnsupportedPtysForPaneKeyMock.mockReset()
     clearPaneKeyAliasesForPtyMock.mockReset()
+    noteAgentPaneLaunchTokenMock.mockReset()
     recordCodexPaneAccountMock.mockReset()
     forgetCodexPaneAccountMock.mockReset()
     getCodexPaneAccountMock.mockReset()

--- a/src/main/ipc/pty-restore-record-seeding.test.ts
+++ b/src/main/ipc/pty-restore-record-seeding.test.ts
@@ -5,7 +5,8 @@ import {
   registerPtyMock,
   setMigrationUnsupportedPtyMock,
   clearMigrationUnsupportedPtysForPaneKeyMock,
-  clearPaneKeyAliasesForPtyMock
+  clearPaneKeyAliasesForPtyMock,
+  noteAgentPaneLaunchTokenMock
 } from './pty-ipc-mock-registry'
 import { setupPtyIpcSuite } from './pty-ipc-test-harness'
 import { getDefaultWorkspaceSession } from '../../shared/constants'
@@ -407,6 +408,25 @@ describe('registerPtyHandlers', () => {
     const read = await runtime.readTerminal(created.handle)
     expect(read.tail).toContain('headless reattach history')
   })
+  it('tells the hook server which launch token this spawn put in the pane', async () => {
+    // Why this is wired at spawn and not inferred from a hook event: the pane's token-keyed
+    // status gates otherwise learn about a replacement process only from a session boundary,
+    // which several providers never send — so a respawned pane stayed suppressed for good.
+    registerPtyHandlers(mainWindow as never)
+    const leafId = '22222222-2222-4222-8222-222222222222'
+    const stablePaneKey = makePaneKey('tab-1', leafId)
+    await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId,
+      env: { ORCA_PANE_KEY: stablePaneKey, ORCA_AGENT_LAUNCH_TOKEN: 'launch-token-1' }
+    })
+
+    expect(noteAgentPaneLaunchTokenMock).toHaveBeenLastCalledWith(stablePaneKey, 'launch-token-1')
+  })
+
   it('upgrades legacy numeric pane keys when the spawn metadata proves the stable leaf', async () => {
     registerPtyHandlers(mainWindow as never)
     const leafId = '11111111-1111-4111-8111-111111111111'

--- a/src/main/ipc/pty/ipc/spawn-commit.ts
+++ b/src/main/ipc/pty/ipc/spawn-commit.ts
@@ -20,7 +20,8 @@ import { resolvePaneSpawnReservation } from '../pane/spawn-reservation'
 import { seedTerminalRestoreRecordsFromSpawnResult } from '../pane/agent-session-owners'
 import {
   admitProviderReattachLaunchIdentity,
-  admitRendererAgentLaunchAuthority
+  admitRendererAgentLaunchAuthority,
+  resolveSpawnedPaneLaunchToken
 } from '../pane/launch-authority'
 import type { PtyIpcSpawnState } from './spawn-state'
 import { persistPtyIpcSpawnCommit } from './spawn-commit-persist'
@@ -132,6 +133,23 @@ export async function commitPtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<PtySpawn
   }
   if (ctx.isClaudeLaunch && !ctx.stablePaneOwner) {
     markClaudePtySpawned(ctx.result.id)
+  }
+  // Why here: a fresh PTY for a pane is main's own proof that the pane's agent lineage moved on,
+  // and it is the only such proof for the sources that emit no session boundary. Without it the
+  // pane's token-keyed status gates keep answering for the process this spawn replaced.
+  // Why ctx.spawnEnv and not args.launchToken: the env is what the PTY's hook scripts will
+  // actually read and post, so it is the token the gates will be compared against.
+  // Why not on a reattach: rebinding a client to a running PTY starts no process.
+  const spawnedPaneLaunch = resolveSpawnedPaneLaunchToken({
+    validatedPaneKey: ctx.validatedPaneKey,
+    isReattach: ctx.result.isReattach === true,
+    spawnEnv: ctx.spawnEnv
+  })
+  if (spawnedPaneLaunch) {
+    agentHookServer.noteAgentPaneLaunchToken(
+      spawnedPaneLaunch.paneKey,
+      spawnedPaneLaunch.launchToken
+    )
   }
   // Why: record the paneKey mapping so clearProviderPtyState can clear the agent-hooks server's per-paneKey caches on exit.
   // Why: args.env is untrusted IPC JSON (type unenforced); bound the paneKey so malformed/oversized values can't pollute ptyPaneKey or clearPaneState.

--- a/src/main/ipc/pty/pane/launch-authority.test.ts
+++ b/src/main/ipc/pty/pane/launch-authority.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { admitProviderReattachLaunchIdentity } from './launch-authority'
+import {
+  admitProviderReattachLaunchIdentity,
+  resolveSpawnedPaneLaunchToken
+} from './launch-authority'
 
 describe('admitProviderReattachLaunchIdentity', () => {
   it('binds provider launch identity to a valid reattach incarnation', () => {
@@ -36,5 +39,63 @@ describe('admitProviderReattachLaunchIdentity', () => {
     expect(
       admitProviderReattachLaunchIdentity({ isReattach, launchAgent, incarnationId })
     ).toBeNull()
+  })
+})
+
+describe('resolveSpawnedPaneLaunchToken', () => {
+  it('reports the token this spawn puts into the pane', () => {
+    expect(
+      resolveSpawnedPaneLaunchToken({
+        validatedPaneKey: 'pane-1',
+        isReattach: false,
+        spawnEnv: { ORCA_AGENT_LAUNCH_TOKEN: 'token-2' }
+      })
+    ).toEqual({ paneKey: 'pane-1', launchToken: 'token-2' })
+  })
+
+  it('reports a respawn into a pane that already has an owner', () => {
+    // Why: that is the whole case — the pane whose previous process this spawn replaced is the
+    // one whose token-keyed status gates would otherwise keep answering for the old process.
+    expect(
+      resolveSpawnedPaneLaunchToken({
+        validatedPaneKey: 'pane-1',
+        isReattach: false,
+        spawnEnv: { ORCA_AGENT_LAUNCH_TOKEN: 'token-2', ORCA_PANE_KEY: 'pane-1' }
+      })
+    ).toEqual({ paneKey: 'pane-1', launchToken: 'token-2' })
+  })
+
+  it('reports a tokenless spawn as a token-free pane, not as no spawn', () => {
+    expect(
+      resolveSpawnedPaneLaunchToken({
+        validatedPaneKey: 'pane-1',
+        isReattach: false,
+        spawnEnv: { ORCA_PANE_KEY: 'pane-1' }
+      })
+    ).toEqual({ paneKey: 'pane-1', launchToken: undefined })
+    expect(
+      resolveSpawnedPaneLaunchToken({
+        validatedPaneKey: 'pane-1',
+        isReattach: false,
+        spawnEnv: { ORCA_AGENT_LAUNCH_TOKEN: '   ' }
+      })
+    ).toEqual({ paneKey: 'pane-1', launchToken: undefined })
+  })
+
+  it.each([
+    {
+      label: 'a reattach, which starts no process',
+      validatedPaneKey: 'pane-1',
+      isReattach: true,
+      spawnEnv: { ORCA_AGENT_LAUNCH_TOKEN: 'token-2' }
+    },
+    {
+      label: 'a spawn whose pane key never validated',
+      validatedPaneKey: null,
+      isReattach: false,
+      spawnEnv: { ORCA_AGENT_LAUNCH_TOKEN: 'token-2' }
+    }
+  ])('reports nothing for $label', ({ validatedPaneKey, isReattach, spawnEnv }) => {
+    expect(resolveSpawnedPaneLaunchToken({ validatedPaneKey, isReattach, spawnEnv })).toBeNull()
   })
 })

--- a/src/main/ipc/pty/pane/launch-authority.ts
+++ b/src/main/ipc/pty/pane/launch-authority.ts
@@ -30,6 +30,39 @@ export function admitRendererAgentLaunchAuthority(args: {
   return { launchToken: args.launchToken, launchAgent: args.launchAgent }
 }
 
+/**
+ * The pane and launch token a fresh PTY is about to carry, or null when this spawn starts no new
+ * process for a pane.
+ *
+ * Why separate from {@link admitRendererAgentLaunchAuthority}: that gate decides whether the
+ * renderer may claim *orchestration* authority, and deliberately refuses a pane that already has
+ * an owner. Re-fencing a pane's status is the opposite question — a respawn into an already-owned
+ * pane is exactly the case that must be reported, because that is the pane whose previous process
+ * the spawn replaced.
+ *
+ * Why spawnEnv and not the renderer's `launchToken` argument: the env is what this PTY's hook
+ * scripts will read and post, so it is the token the status gates will be compared against. A
+ * spawn with no token in its env reports `undefined`, which is a statement (this pane's new
+ * process has no token), not a missing value.
+ */
+export function resolveSpawnedPaneLaunchToken(args: {
+  validatedPaneKey: string | null
+  isReattach: boolean
+  spawnEnv: Record<string, string> | undefined
+}): { paneKey: string; launchToken: string | undefined } | null {
+  // Why a reattach is excluded: rebinding a client to a running PTY starts no process, so it is
+  // no evidence about which process owns the pane.
+  if (!args.validatedPaneKey || args.isReattach) {
+    return null
+  }
+  const launchToken = args.spawnEnv?.ORCA_AGENT_LAUNCH_TOKEN
+  return {
+    paneKey: args.validatedPaneKey,
+    launchToken:
+      typeof launchToken === 'string' && launchToken.trim().length > 0 ? launchToken : undefined
+  }
+}
+
 export function admitProviderReattachLaunchIdentity(args: {
   isReattach?: boolean
   launchAgent?: unknown

--- a/src/preload/api/agent-status-api.ts
+++ b/src/preload/api/agent-status-api.ts
@@ -17,6 +17,8 @@ export type AgentStatusApi = {
   inferInterrupt: (request: AgentInterruptInferenceRequest) => Promise<boolean>
   /** Guarded clear for an answered AskUserQuestion wait — the CLI emits no hook at answer time, so the renderer reports the submit keystroke. */
   inferQuestionAnswered: (request: AgentQuestionAnsweredInferenceRequest) => Promise<boolean>
+  /** Fires once per pane and source when a status extension Orca did not launch is posting. */
+  onUnmanagedExtension: (callback: (data: { source: string }) => void) => () => void
   /** Listen for PTYs on a legacy numeric pane key that have registry-backed UUID pane proof. */
   onMigrationUnsupported: (callback: (entry: MigrationUnsupportedPtyEntry) => void) => () => void
   onMigrationUnsupportedClear: (callback: (data: { ptyId: string }) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5175,6 +5175,13 @@ const api = {
       ipcRenderer.invoke('agentStatus:inferInterrupt', request),
     inferQuestionAnswered: (request: AgentQuestionAnsweredInferenceRequest): Promise<boolean> =>
       ipcRenderer.invoke('agentStatus:inferQuestionAnswered', request),
+    /** Fires once per pane and source when a status extension Orca did not launch is posting. */
+    onUnmanagedExtension: (callback: (data: { source: string }) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, data: { source: string }) =>
+        callback(data)
+      ipcRenderer.on('agentStatus:unmanagedExtension', listener)
+      return () => ipcRenderer.removeListener('agentStatus:unmanagedExtension', listener)
+    },
     onMigrationUnsupported: (
       callback: (entry: MigrationUnsupportedPtyEntry) => void
     ): (() => void) => {

--- a/src/relay/pty-handler-revive.test.ts
+++ b/src/relay/pty-handler-revive.test.ts
@@ -111,6 +111,57 @@ describe('PtyHandler', () => {
     expect(callArgs.env.ORCA_SHELL_FEATURES).not.toContain('identity')
   })
 
+  it('does not leak the relay process own pane identity into a spawned or revived pane', async () => {
+    // Why: the relay inherits process.env wholesale, and a relay is routinely started *from* an
+    // Orca agent pane — so that pane's identity quadruple rides into every pane the relay spawns.
+    // ORCA_AGENT_LAUNCH_TOKEN is the damaging member: it is Orca's proof of authorship, and an
+    // inherited one makes an unrelated remote pane claim the launch of the pane the relay was
+    // started from. The retired-pane fence is keyed on it, so one leaked token lets any pane on
+    // the relay pass a fence another pane set. The daemon path already scrubs exactly these four
+    // keys (removeUnspecifiedPaneIdentityEnv); this pins the same contract for the relay.
+    const leaked = {
+      ORCA_PANE_KEY: 'relay-own-tab:relay-own-leaf',
+      ORCA_TAB_ID: 'relay-own-tab',
+      ORCA_WORKTREE_ID: 'relay-own-wt',
+      ORCA_AGENT_LAUNCH_TOKEN: 'relay-own-launch-token'
+    }
+    const saved = new Map(Object.keys(leaked).map((key) => [key, process.env[key]]))
+    Object.assign(process.env, leaked)
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    try {
+      // A bare remote pane: the client names no pane identity at all.
+      await dispatcher.callRequest('pty.spawn', { cols: 90, rows: 30, cwd: '/tmp' })
+      const freshEnv = (mockPtySpawn.mock.calls[0][2] as { env: Record<string, string> }).env
+      for (const key of Object.keys(leaked)) {
+        expect(`${key}=${freshEnv[key]}`).toBe(`${key}=undefined`)
+      }
+
+      // And across revive, where no pane identity is ever re-supplied for the token.
+      const state = JSON.stringify([
+        { id: 'pty-9', pid: process.pid, cols: 80, rows: 24, cwd: '/tmp', paneKey: 'tab-9:1' }
+      ])
+      await handler.dispose({ waitForPhysicalExit: false })
+      mockPtySpawn.mockClear()
+      dispatcher = createMockDispatcher()
+      handler = new PtyHandler(dispatcher as unknown as RelayDispatcher)
+      await dispatcher.callRequest('pty.revive', { state })
+      const revivedEnv = (mockPtySpawn.mock.calls[0][2] as { env: Record<string, string> }).env
+      expect(revivedEnv.ORCA_PANE_KEY).toBe('tab-9:1')
+      expect(`token=${revivedEnv.ORCA_AGENT_LAUNCH_TOKEN}`).toBe('token=undefined')
+      expect(`tab=${revivedEnv.ORCA_TAB_ID}`).toBe('tab=undefined')
+      expect(`wt=${revivedEnv.ORCA_WORKTREE_ID}`).toBe('wt=undefined')
+    } finally {
+      killSpy.mockRestore()
+      for (const [key, value] of saved) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
+  })
+
   it('fences both revived worktree identity and cwd with rollback', async () => {
     const finishSiblingAdmission = vi.fn()
     const beginWorktreePtySpawn = vi.fn((operationPath: string) => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -4,6 +4,7 @@ import type * as NodePty from 'node-pty'
 import { existsSync } from 'node:fs'
 import { basename, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
+import { removeUnspecifiedPaneIdentityEnv } from '../shared/pane-identity-env'
 import { resolveWindowsGitBashShellPath } from '../main/git-bash'
 import { WINDOWS_GIT_BASH_SHELL } from '../shared/windows-terminal-shell'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
@@ -707,6 +708,12 @@ export class PtyHandler {
     // on, yet an inherited Orca HISTFILE must not scope a pane to someone else's
     // worktree on the disabled and revive paths either.
     dropInheritedOrcaHistFile(result)
+    // Why the same shape as the history drops above: a relay is routinely started *from* an Orca
+    // pane, so its process.env already names that pane. Pane identity that arrives by inheritance
+    // rather than from this spawn is always the wrong pane's — and ORCA_AGENT_LAUNCH_TOKEN is
+    // Orca's proof of authorship, so an inherited one lets any pane on this relay satisfy a status
+    // fence a different pane set. Shares the daemon's scrub so the two hosts cannot drift.
+    removeUnspecifiedPaneIdentityEnv(result, rendererEnv)
     // Why unconditionally: ORCA_HISTFILE is Orca-owned and minted below by
     // injectRelayHistoryEnv, which also runs only with isolation on. An
     // inherited one (the relay can be launched from an Orca pane) would

--- a/src/renderer/src/components/terminal-pane/codex-detached-pane-restart.test.ts
+++ b/src/renderer/src/components/terminal-pane/codex-detached-pane-restart.test.ts
@@ -138,6 +138,21 @@ describe('codex detached pane restart executor', () => {
     expect(blocksCodexPaneInput(state.codexRestartNoticeByPtyId[NEW_PTY])).toBe(false)
   })
 
+  it('stamps a launch token so its own respawn is not read as a poster Orca did not launch', async () => {
+    // Why: the launch token is Orca's only in-band proof of authorship, and every gate keyed on
+    // it — the retired-pane fence and the unmanaged-status-extension fence alike — reads a
+    // tokenless post as foreign. A relaunch into the same pane key that omitted the token made
+    // Orca warn the user about "an extension Orca did not install" for a process Orca launched.
+    seedQueuedRestart()
+
+    await sweepUnclaimedCodexPaneRestarts()
+
+    const env = vi.mocked(window.api.pty.spawn).mock.calls[0]?.[0]?.env
+    expect(env?.ORCA_AGENT_LAUNCH_TOKEN).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    )
+  })
+
   it('executes via the store subscription without a lifecycle timeout', async () => {
     const uninstall = installCodexDetachedPaneRestartExecutor()
     try {

--- a/src/renderer/src/components/terminal-pane/codex-detached-pane-restart.ts
+++ b/src/renderer/src/components/terminal-pane/codex-detached-pane-restart.ts
@@ -16,6 +16,7 @@ import { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
 import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
 import { hasRegisteredRuntimeTerminalTab } from '@/runtime/sync-runtime-graph'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 import { CODEX_ACCOUNT_RESTART_STARTUP } from '@/lib/codex-session-restart'
 import { isForeignMachineCodexPtyId } from '@/lib/codex-pane-selection-lane'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
@@ -157,7 +158,12 @@ function buildPaneIdentityEnv(
       : {}),
     ORCA_PANE_KEY: makePaneKey(tabId, leafId),
     ORCA_TAB_ID: tabId,
-    ORCA_WORKTREE_ID: worktreeId
+    ORCA_WORKTREE_ID: worktreeId,
+    // Why: the launch token is Orca's proof that it started this agent, and the mounted spawn
+    // path always mints one. Without it this respawn's hook posts are indistinguishable from a
+    // poster Orca never launched, so every gate keyed on the token — the retired-pane fence and
+    // the unmanaged-extension fence alike — reads Orca's own replacement as foreign.
+    ORCA_AGENT_LAUNCH_TOKEN: createBrowserUuid()
   }
 }
 

--- a/src/renderer/src/hooks/ipc-events/agent-status-listeners.ts
+++ b/src/renderer/src/hooks/ipc-events/agent-status-listeners.ts
@@ -8,6 +8,7 @@ import {
   rollbackLegacyWorkerTerminalSurfaceInStore
 } from '../legacy-worker-terminal-recovery-event'
 import { useAppStore } from '../../store'
+import { notifyUnmanagedStatusExtension } from './unmanaged-status-extension-notice'
 import { resolvePaneKey } from './agent-status-routing'
 import type { PendingAgentStatusEvent } from './agent-status-bridge-types'
 
@@ -90,6 +91,14 @@ export function registerAgentStatusListeners(args: {
   )
   if (unsubscribeAgentStatusClear) {
     unsubs.push(unsubscribeAgentStatusClear)
+  }
+  const unsubscribeUnmanagedExtension = window.api.agentStatus.onUnmanagedExtension?.(
+    ({ source }) => {
+      notifyUnmanagedStatusExtension(source)
+    }
+  )
+  if (unsubscribeUnmanagedExtension) {
+    unsubs.push(unsubscribeUnmanagedExtension)
   }
   const unsubscribeMigrationUnsupported = window.api.agentStatus.onMigrationUnsupported?.(
     (entry) => {

--- a/src/renderer/src/hooks/ipc-events/unmanaged-status-extension-notice.test.ts
+++ b/src/renderer/src/hooks/ipc-events/unmanaged-status-extension-notice.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import {
+  notifyUnmanagedStatusExtension,
+  resetUnmanagedStatusExtensionNotices
+} from './unmanaged-status-extension-notice'
+
+vi.mock('sonner', () => ({ toast: { warning: vi.fn() } }))
+
+beforeEach(() => {
+  resetUnmanagedStatusExtensionNotices()
+  vi.mocked(toast.warning).mockClear()
+})
+
+afterEach(() => {
+  resetUnmanagedStatusExtensionNotices()
+})
+
+describe('unmanaged status extension notice', () => {
+  it('raises one toast however many panes the main side reports', () => {
+    // Why this lives here and not in the fence: the main side reports per pane *and* source, so
+    // a user with 13 affected panes gets 13 detections. Collapsing them is this module's job.
+    for (let pane = 0; pane < 13; pane += 1) {
+      notifyUnmanagedStatusExtension('omp')
+    }
+    expect(toast.warning).toHaveBeenCalledTimes(1)
+  })
+
+  it('still warns once per agent, because the file lives in that agent’s own folder', () => {
+    notifyUnmanagedStatusExtension('omp')
+    notifyUnmanagedStatusExtension('pi')
+    notifyUnmanagedStatusExtension('omp')
+    expect(toast.warning).toHaveBeenCalledTimes(2)
+    expect(vi.mocked(toast.warning).mock.calls.map((call) => call[1]?.id)).toEqual([
+      'unmanaged-status-extension-omp',
+      'unmanaged-status-extension-pi'
+    ])
+  })
+
+  it('ignores an empty source rather than warning about an unnamed agent', () => {
+    notifyUnmanagedStatusExtension('')
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/ipc-events/unmanaged-status-extension-notice.ts
+++ b/src/renderer/src/hooks/ipc-events/unmanaged-status-extension-notice.ts
@@ -1,0 +1,51 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+
+// Why: the agent's own extension directory is the only place a second status extension can come
+// from, so naming the agent is enough for the user to find the file. Orca never touches it.
+const AGENT_LABEL_BY_SOURCE: Record<string, string> = {
+  omp: 'OMP',
+  pi: 'Pi',
+  'prime-agent': 'Prime'
+}
+
+const notifiedSources = new Set<string>()
+
+/** Reset between tests; the real notice is once-per-source for the life of the window. */
+export function resetUnmanagedStatusExtensionNotices(): void {
+  notifiedSources.clear()
+}
+
+/**
+ * Tell the user once per agent that a status extension Orca did not install is being ignored.
+ *
+ * Why a notice and not a fix: the file is the user's own, so Orca will not remove, move, or
+ * rewrite it. Without this the discrimination is invisible and reads as Orca ignoring their
+ * extension for no reason.
+ */
+export function notifyUnmanagedStatusExtension(source: string): void {
+  if (!source || notifiedSources.has(source)) {
+    return
+  }
+  notifiedSources.add(source)
+  const agent = AGENT_LABEL_BY_SOURCE[source] ?? source
+  toast.warning(
+    translate(
+      'auto.hooks.unmanagedStatusExtensionNotice.title',
+      'Ignoring status from an extension Orca did not install'
+    ),
+    {
+      id: `unmanaged-status-extension-${source}`,
+      description: translate(
+        'auto.hooks.unmanagedStatusExtensionNotice.description',
+        'A second copy of orca-agent-status.ts is running in your {{agent}} extensions folder. Orca is ignoring what it reports, because an older copy can mark a turn finished while the agent is still working. Orca has not changed the file — remove or rename it yourself if you no longer want it.',
+        { agent }
+      ),
+      duration: Infinity,
+      cancel: {
+        label: translate('auto.hooks.unmanagedStatusExtensionNotice.dismiss', 'Dismiss'),
+        onClick: () => {}
+      }
+    }
+  )
+}

--- a/src/renderer/src/hooks/useIpcEvents-lifecycle.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-lifecycle.test.ts
@@ -8,6 +8,7 @@ const EXPECTED_DIRECT_CALLBACK_METHODS = [
   'agentStatus.onMigrationUnsupported',
   'agentStatus.onMigrationUnsupportedClear',
   'agentStatus.onSet',
+  'agentStatus.onUnmanagedExtension',
   'automations.onChanged',
   'browser.onActivateView',
   'browser.onCertificateFailureChanged',
@@ -187,6 +188,7 @@ const EXPECTED_CALLBACK_REGISTRATION_SEQUENCE = [
   'ui.onTerminalZoom',
   'agentStatus.onSet',
   'agentStatus.onClear',
+  'agentStatus.onUnmanagedExtension',
   'agentStatus.onMigrationUnsupported',
   'agentStatus.onMigrationUnsupportedClear',
   'agentStatus.onLegacyWorkerTerminalRecovery',
@@ -411,6 +413,7 @@ describe('useIpcEvents App-lifetime lifecycle', () => {
       groupOrder([
         'agentStatus.onSet',
         'agentStatus.onClear',
+        'agentStatus.onUnmanagedExtension',
         'agentStatus.onMigrationUnsupported',
         'agentStatus.onMigrationUnsupportedClear',
         'agentStatus.onLegacyWorkerTerminalRecovery',
@@ -419,6 +422,7 @@ describe('useIpcEvents App-lifetime lifecycle', () => {
     ).toEqual([
       'agentStatus.onSet',
       'agentStatus.onClear',
+      'agentStatus.onUnmanagedExtension',
       'agentStatus.onMigrationUnsupported',
       'agentStatus.onMigrationUnsupportedClear',
       'agentStatus.onLegacyWorkerTerminalRecovery',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1107,6 +1107,11 @@
             "docPreviewLinkFailed": "Could not open this link in Orca Browser."
           }
         }
+      },
+      "unmanagedStatusExtensionNotice": {
+        "title": "Ignoring status from an extension Orca did not install",
+        "description": "A second copy of orca-agent-status.ts is running in your {{agent}} extensions folder. Orca is ignoring what it reports, because an older copy can mark a turn finished while the agent is still working. Orca has not changed the file — remove or rename it yourself if you no longer want it.",
+        "dismiss": "Dismiss"
       }
     },
     "components": {

--- a/src/renderer/src/web/preload-api/web-agent-status-api.ts
+++ b/src/renderer/src/web/preload-api/web-agent-status-api.ts
@@ -9,6 +9,7 @@ export function createWebAgentStatusApi(): Partial<PreloadApi> {
       getSnapshot: () => Promise.resolve([]),
       inferInterrupt: () => Promise.resolve(false),
       inferQuestionAnswered: () => Promise.resolve(false),
+      onUnmanagedExtension: () => noopUnsubscribe,
       onMigrationUnsupported: () => noopUnsubscribe,
       onMigrationUnsupportedClear: () => noopUnsubscribe,
       onLegacyWorkerTerminalRecovery: () => noopUnsubscribe,

--- a/src/shared/agent-hook-listener-extraction-characterization.test.ts
+++ b/src/shared/agent-hook-listener-extraction-characterization.test.ts
@@ -82,6 +82,12 @@ describe('agent hook extraction boundaries', () => {
     for (const source of ['devin', 'mimo-code', 'prime-agent', 'kimi', 'hermes'] as const) {
       expect(normalizeProviderState(source, 'UnknownEvent')).toBeNull()
     }
+    // Why kimi's SessionStart is called out by name: its event names are otherwise
+    // Claude-compatible, so `isSessionStartEvent` looks like it should ride with claude. It
+    // cannot — this returns null, the relay drops a null-normalizing event on both the live and
+    // spool paths, and `KIMI_HOOK_EVENTS` never subscribes to one. If this ever yields a payload,
+    // kimi has gained a session boundary and `isSessionStartEvent` must be taught to name it.
+    expect(normalizeProviderState('kimi', 'SessionStart')).toBeNull()
   })
 
   it('warns before tab rejection and caps version and environment warning keys independently', () => {

--- a/src/shared/agent-hook-listener/provider-event-routing.ts
+++ b/src/shared/agent-hook-listener/provider-event-routing.ts
@@ -88,17 +88,14 @@ export function isNewTurnEvent(source: AgentHookSource, eventName: unknown): boo
  * never order two processes that share a pane. A session boundary is emitted once per process,
  * which is what a launch-token fence needs before it hands the pane to a different token.
  *
- * Exported so the fence reuses this instead of matching a raw `SessionStart` literal — only
- * claude, codex and opencode spell it that way, and the other 15 sources were stranded by it.
+ * Exported so the fence reuses this instead of matching a raw `SessionStart` literal — only 5 of
+ * the 18 sources spell it that way, and the other 13 were stranded by it.
  */
 export function isSessionStartEvent(source: AgentHookSource, eventName: unknown): boolean {
   // Why: exhaustive switch so a new AgentHookSource fails typecheck here instead of silently
   // joining the half that can never re-fence.
   switch (source) {
-    // Why kimi rides with claude: Kimi Code emits Claude-compatible hook events, SessionStart
-    // included.
     case 'claude':
-    case 'kimi':
     case 'codex':
     case 'opencode':
     case 'droid':
@@ -106,6 +103,10 @@ export function isSessionStartEvent(source: AgentHookSource, eventName: unknown)
       return eventName === 'SessionStart'
     case 'copilot':
       return normalizeCopilotEventName(eventName) === 'SessionStart'
+    // Why cursor stays named here even though `CURSOR_EVENTS` deliberately does not subscribe to
+    // it (a process-boundary hook resets the submitted-turn prompt cache): `normalizeCursorEvent`
+    // does map it, so a hand-written hook config reaches this gate. An Orca-managed cursor pane is
+    // re-fenced by the spawn path instead.
     case 'cursor':
       return eventName === 'sessionStart'
     case 'amp':
@@ -124,6 +125,12 @@ export function isSessionStartEvent(source: AgentHookSource, eventName: unknown)
     // handling, and Command Code names no lifecycle event at all. Naming an event they do not
     // send would be a fence that never opens; their panes are re-fenced by the spawn path
     // instead, which needs no provider event.
+    // Why kimi is here despite emitting Claude-compatible names: `normalizeKimiEvent` has no
+    // SessionStart case, so the listener returns null for one and the relay drops it before it
+    // can reach any fence — and `KIMI_HOOK_EVENTS` does not subscribe to it either. Claiming
+    // the Claude spelling for kimi would be a branch no event can reach. Teaching Orca to read
+    // one would need a normalizer case AND a config entry, not a line here.
+    case 'kimi':
     case 'gemini':
     case 'antigravity':
     case 'mimo-code':

--- a/src/shared/agent-hook-listener/provider-event-routing.ts
+++ b/src/shared/agent-hook-listener/provider-event-routing.ts
@@ -81,6 +81,58 @@ export function isNewTurnEvent(source: AgentHookSource, eventName: unknown): boo
   }
 }
 
+/**
+ * The per-provider answer to "did a NEW agent process just start in this pane?".
+ *
+ * Deliberately not {@link isNewTurnEvent}: a turn boundary recurs inside one process, so it can
+ * never order two processes that share a pane. A session boundary is emitted once per process,
+ * which is what a launch-token fence needs before it hands the pane to a different token.
+ *
+ * Exported so the fence reuses this instead of matching a raw `SessionStart` literal — only
+ * claude, codex and opencode spell it that way, and the other 15 sources were stranded by it.
+ */
+export function isSessionStartEvent(source: AgentHookSource, eventName: unknown): boolean {
+  // Why: exhaustive switch so a new AgentHookSource fails typecheck here instead of silently
+  // joining the half that can never re-fence.
+  switch (source) {
+    // Why kimi rides with claude: Kimi Code emits Claude-compatible hook events, SessionStart
+    // included.
+    case 'claude':
+    case 'kimi':
+    case 'codex':
+    case 'opencode':
+    case 'droid':
+    case 'devin':
+      return eventName === 'SessionStart'
+    case 'copilot':
+      return normalizeCopilotEventName(eventName) === 'SessionStart'
+    case 'cursor':
+      return eventName === 'sessionStart'
+    case 'amp':
+      return eventName === 'session.start'
+    case 'pi':
+    case 'prime-agent':
+      return eventName === 'session_start'
+    case 'grok':
+      return isGrokEvent(eventName, 'session_start')
+    case 'hermes':
+      return eventName === 'on_session_start'
+    // Why false rather than a guess: these sources emit no session boundary this codebase has
+    // ever seen — Gemini CLI sends only BeforeAgent/AfterAgent/BeforeTool/AfterTool, Antigravity
+    // only PreInvocation/PostInvocation, mimo-code has no SessionStart (the OpenCode-family
+    // normalizer accepts it for `opencode` alone), omp is excluded from Pi's session_start
+    // handling, and Command Code names no lifecycle event at all. Naming an event they do not
+    // send would be a fence that never opens; their panes are re-fenced by the spawn path
+    // instead, which needs no provider event.
+    case 'gemini':
+    case 'antigravity':
+    case 'mimo-code':
+    case 'omp':
+    case 'command-code':
+      return false
+  }
+}
+
 export function hasExplicitUserPrompt(
   source: AgentHookSource,
   eventName: unknown,

--- a/src/shared/pane-identity-env-spawn-inventory.test.ts
+++ b/src/shared/pane-identity-env-spawn-inventory.test.ts
@@ -1,0 +1,179 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { glob } from 'tinyglobby'
+import {
+  blankStringContents,
+  blankStringContentsDesynced,
+  stripComments
+} from './source-scan/source-tree-scan'
+import { PANE_IDENTITY_ENV_KEYS } from './pane-identity-env'
+
+// Why this ratchet exists: 52 files name ORCA_AGENT_LAUNCH_TOKEN, but nothing stated the rule that
+// produces it. A spawn that reuses a pane key a previous launch already owned must stamp a launch
+// token, because the token is Orca's only in-band proof of authorship and the status fences read a
+// tokenless post as foreign. Two paths shipped without it — the detached-pane restart (#17243) and
+// the relay's revive — each found by accident. Adding a pane-identity env site now forces a
+// deliberate classification here instead of silently joining the broken half.
+type TokenBehavior =
+  /** Mints a fresh token: this spawn reuses or claims a pane key, so it must prove authorship. */
+  | 'mints-token'
+  /** Forwards a token it was handed; absence is the caller's decision, not this site's. */
+  | 'propagates-token'
+  /** Deliberately tokenless: a non-agent pane on a pane key no prior launch owned. */
+  | 'no-agent-launch'
+  /** Removes pane identity rather than authoring it (a scrub or an admission fence). */
+  | 'strips-identity'
+
+type Site = { path: string; behavior: TokenBehavior; marker: string }
+
+const INVENTORY: readonly Site[] = [
+  {
+    path: 'src/renderer/src/components/terminal-pane/codex-detached-pane-restart.ts',
+    behavior: 'mints-token',
+    marker: 'ORCA_AGENT_LAUNCH_TOKEN: createBrowserUuid()'
+  },
+  {
+    path: 'src/renderer/src/lib/adopt-agent-background-session-tab.ts',
+    behavior: 'mints-token',
+    marker: 'ORCA_AGENT_LAUNCH_TOKEN: launchToken'
+  },
+  {
+    path: 'src/renderer/src/components/terminal-pane/pty-connection/agent-idle-working-handlers.ts',
+    behavior: 'propagates-token',
+    marker: 'ORCA_AGENT_LAUNCH_TOKEN: session.launchToken'
+  },
+  {
+    path: 'src/renderer/src/components/terminal-pane/pty-connection/deferred-cold-restore-and-snapshot.ts',
+    behavior: 'propagates-token',
+    marker: 'ORCA_AGENT_LAUNCH_TOKEN: env.ORCA_AGENT_LAUNCH_TOKEN'
+  },
+  {
+    path: 'src/renderer/src/components/terminal-pane/pty-connection/cold-restore-resume-startup.ts',
+    behavior: 'mints-token',
+    marker: 'ORCA_AGENT_LAUNCH_TOKEN: coldRestoreLaunchToken'
+  },
+  {
+    // Why tokenless is correct: setup scripts and default tabs carry no launchConfig and land on
+    // freshly minted pane keys, so no fence can exist for them to fail.
+    path: 'src/renderer/src/lib/launch-worktree-background-terminals.ts',
+    behavior: 'no-agent-launch',
+    marker: 'ORCA_PANE_KEY: makePaneKey(tabId, leafId)'
+  },
+  {
+    // Mints only for a launchConfig spawn (an agent); a bare workspace terminal stays tokenless.
+    path: 'src/main/runtime/orca-runtime.ts',
+    behavior: 'mints-token',
+    marker: 'ORCA_AGENT_LAUNCH_TOKEN: launchToken'
+  },
+  {
+    path: 'src/main/ipc/pty/ipc/spawn-env.ts',
+    behavior: 'strips-identity',
+    marker: 'delete ctx.baseEnv.ORCA_AGENT_LAUNCH_TOKEN'
+  },
+  {
+    path: 'src/main/ipc/pty/provider/liveness.ts',
+    behavior: 'strips-identity',
+    marker: 'delete stripped.ORCA_AGENT_LAUNCH_TOKEN'
+  },
+  {
+    path: 'src/main/daemon/pty-subprocess/spawn-environment.ts',
+    behavior: 'strips-identity',
+    marker: 'removeUnspecifiedPaneIdentityEnv(env, opts.env)'
+  },
+  {
+    path: 'src/relay/pty-handler.ts',
+    behavior: 'strips-identity',
+    marker: 'removeUnspecifiedPaneIdentityEnv(result, rendererEnv)'
+  }
+]
+
+/** Names the var without authoring pane identity: hook-script emitters and passthrough allowlists. */
+const NON_AUTHORING = new Set([
+  'src/main/agent-hooks/hook-post-command.ts',
+  'src/main/agent-hooks/hook-stdin-contract.ts',
+  'src/main/agent-hooks/installer-utils.ts',
+  'src/main/amp/agent-status-plugin-source.ts',
+  'src/main/antigravity/hook-script.ts',
+  'src/main/command-code/command-code-managed-script.ts',
+  'src/main/copilot/copilot-managed-script.ts',
+  'src/main/cursor/hook-script.ts',
+  'src/main/cursor/hook-service.ts',
+  'src/main/devin/hook-service.ts',
+  'src/main/droid/hook-service.ts',
+  'src/main/gemini/hook-service.ts',
+  'src/main/grok/grok-hook-script.ts',
+  'src/main/hermes/hermes-managed-plugin-source.ts',
+  'src/main/kimi/hook-service.ts',
+  'src/main/opencode/status-plugin-post-source.ts',
+  'src/main/pi/agent-status-extension-source.ts',
+  'src/main/providers/local-pty-launch-helpers.ts',
+  'src/main/pty/wsl-orca-env.ts',
+  'src/main/ssh/ssh-remote-cli-host-passthrough.ts',
+  'src/main/ipc/pty/pane/launch-authority.ts',
+  'src/relay/remote-cli-env.ts',
+  'src/shared/orchestration-compatibility-evidence.ts',
+  'src/shared/pane-identity-env.ts'
+])
+
+describe('pane identity env spawn-site ratchet', () => {
+  it('classifies every file that names the launch token', async () => {
+    const files = await glob(['src/**/*.{ts,tsx}'], { ignore: ['**/*.test.*', '**/*.spec.*'] })
+    const found: string[] = []
+    for (const path of files) {
+      const raw = readFileSync(join(process.cwd(), path), 'utf8')
+      if (!raw.includes('ORCA_AGENT_LAUNCH_TOKEN')) {
+        continue
+      }
+      const decommented = stripComments(raw)
+      if (blankStringContentsDesynced(decommented)) {
+        throw new Error(`String scanner desynchronized while inventorying ${path}`)
+      }
+      // Why the decommented+blanked read: a mention inside a comment or an emitted shell snippet
+      // is not this file authoring pane identity.
+      if (!blankStringContents(decommented).includes('ORCA_AGENT_LAUNCH_TOKEN')) {
+        continue
+      }
+      found.push(path)
+    }
+    const classified = new Set([...INVENTORY.map((site) => site.path), ...NON_AUTHORING])
+    expect(found.filter((path) => !classified.has(path)).sort()).toEqual([])
+  })
+
+  it('pins the token decision each inventoried spawn site actually makes', () => {
+    for (const site of INVENTORY) {
+      const source = stripComments(readFileSync(join(process.cwd(), site.path), 'utf8'))
+      expect({
+        path: site.path,
+        behavior: site.behavior,
+        present: source.includes(site.marker)
+      }).toEqual({
+        path: site.path,
+        behavior: site.behavior,
+        present: true
+      })
+    }
+  })
+
+  it('keeps both PTY hosts scrubbing the same pane identity key set', () => {
+    // Why: the daemon and the relay each inherit a process env that names whichever pane their
+    // host was launched from. One host drifting from the shared key set is how the relay lost the
+    // launch token while the daemon kept it.
+    expect([...PANE_IDENTITY_ENV_KEYS]).toEqual([
+      'ORCA_PANE_KEY',
+      'ORCA_TAB_ID',
+      'ORCA_WORKTREE_ID',
+      'ORCA_AGENT_LAUNCH_TOKEN'
+    ])
+    for (const path of [
+      'src/main/daemon/pty-subprocess/spawn-environment.ts',
+      'src/relay/pty-handler.ts'
+    ]) {
+      const source = stripComments(readFileSync(join(process.cwd(), path), 'utf8'))
+      expect({ path, scrubs: source.includes('removeUnspecifiedPaneIdentityEnv(') }).toEqual({
+        path,
+        scrubs: true
+      })
+    }
+  })
+})

--- a/src/shared/pane-identity-env-spawn-inventory.test.ts
+++ b/src/shared/pane-identity-env-spawn-inventory.test.ts
@@ -9,12 +9,13 @@ import {
 } from './source-scan/source-tree-scan'
 import { PANE_IDENTITY_ENV_KEYS } from './pane-identity-env'
 
-// Why this ratchet exists: 52 files name ORCA_AGENT_LAUNCH_TOKEN, but nothing stated the rule that
-// produces it. A spawn that reuses a pane key a previous launch already owned must stamp a launch
-// token, because the token is Orca's only in-band proof of authorship and the status fences read a
-// tokenless post as foreign. Two paths shipped without it — the detached-pane restart (#17243) and
-// the relay's revive — each found by accident. Adding a pane-identity env site now forces a
-// deliberate classification here instead of silently joining the broken half.
+// Why this ratchet exists: 34 non-test source files name ORCA_AGENT_LAUNCH_TOKEN and 10 of them
+// actually author it, but nothing stated the rule that produces it. A spawn that reuses a pane
+// key a previous launch already owned must stamp a launch token, because the token is Orca's only
+// in-band proof of authorship and the status fences read a tokenless post as foreign. Two paths
+// shipped without it — the detached-pane restart (#17243) and the relay's revive — each found by
+// accident. Adding a pane-identity env site now forces a deliberate classification here instead
+// of silently joining the broken half.
 type TokenBehavior =
   /** Mints a fresh token: this spawn reuses or claims a pane key, so it must prove authorship. */
   | 'mints-token'

--- a/src/shared/pane-identity-env.ts
+++ b/src/shared/pane-identity-env.ts
@@ -1,0 +1,30 @@
+/**
+ * Pane identity that Orca stamps into a PTY's environment.
+ *
+ * Every one of these names a specific pane, so an *inherited* value is always wrong: it names
+ * whichever pane the host process was itself launched from. `ORCA_AGENT_LAUNCH_TOKEN` is the
+ * damaging member — it is Orca's only in-band proof that Orca launched an agent, and gates keyed
+ * on it (the retired-pane status fence, the unmanaged-status-extension fence) read a pane
+ * carrying someone else's token as that other pane's launch.
+ */
+export const PANE_IDENTITY_ENV_KEYS = [
+  'ORCA_PANE_KEY',
+  'ORCA_TAB_ID',
+  'ORCA_WORKTREE_ID',
+  'ORCA_AGENT_LAUNCH_TOKEN'
+] as const
+
+/**
+ * Drops every pane-identity key the spawn did not explicitly ask for, so none survives by
+ * inheritance from the host process. A key the caller named is left exactly as given.
+ */
+export function removeUnspecifiedPaneIdentityEnv(
+  env: Record<string, string>,
+  explicitEnv: Record<string, string> | undefined
+): void {
+  for (const key of PANE_IDENTITY_ENV_KEYS) {
+    if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
+      delete env[key]
+    }
+  }
+}

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -787,6 +787,10 @@ const agentHookUnattributedSchema = z
 // nothing derived from them may reach the wire.
 const agentHookTransportBlockedSchema = z.object({ count: z.number().int().nonnegative() }).strict()
 
+// Why: a status extension Orca did not install is posting for a pane. Source only — the pane key
+// and the file's own contents are user data and must not reach the wire.
+const agentHookUnmanagedExtensionSchema = z.object({ source: z.string() }).strict()
+
 // ── Onboarding ──────────────────────────────────────────────────────────
 // Closed enums only — no raw paths/repo names/URLs/error strings (measures activation, not repo debugging).
 // Why: event names still carry legacy seven-step payloads; keep validation backward-compatible for old rows.
@@ -1451,6 +1455,7 @@ export const eventSchemas = {
   agent_hook_install_failed: agentHookInstallFailedSchema,
   agent_hook_unattributed: agentHookUnattributedSchema,
   agent_hook_transport_blocked: agentHookTransportBlockedSchema,
+  agent_hook_unmanaged_extension: agentHookUnmanagedExtensionSchema,
 
   daemon_start_failed: daemonStartFailedSchema,
   main_thread_hang_detected: mainThreadHangDetectedSchema,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​333 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​331 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​176 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​166 |

<!-- /orca-pr-loc -->

Stacked on #17257 (`brennanb2025/pane-identity-env-leak`). Base it on that branch, not `main`.

## ELI5

Every agent Orca launches gets a secret sticker. When a pane's agent finishes but the shell stays open, Orca puts a lock on that pane saying "only the process holding sticker #1 may report status here" — that lock stops a leftover, orphaned agent from stealing the pane's row.

The lock could only be handed to a new process by one specific announcement: a hook event literally named `SessionStart`. Only 5 of the 18 agents call it that. Cursor says `sessionStart`, Amp says `session.start`, Pi says `session_start`, Copilot says `sessionStart`, Hermes says `on_session_start` — and Gemini, Antigravity and several others never say anything of the kind. So when Orca started a *new* agent in that pane, the new agent held sticker #2, could never announce itself in the one way the lock understood, and the lock kept turning it away — forever. The pane went quiet and there was nothing the user could do about it.

This teaches the lock every agent's own way of saying "I just started", and — for the handful that never say it at all — has Orca tell the lock directly at launch, since Orca is the one handing out the stickers.

There is a third door, on remote hosts. When the connection to an SSH or WSL agent drops, the relay saves everything the agent says and hands it over on reconnect. Orca checks each saved message's sticker against the pane's current one. But an agent whose process never *received* a sticker reports a blank one — and a blank sticker is not the wrong sticker, it is no evidence either way. Reading blank as wrong threw that agent's whole saved history away, including its final "done".

## What a person running Orca over SSH sees

**Before.** You have a remote pane where an agent finished a task. You start another agent in the same pane. The sidebar row for that pane never updates again — no spinner, no "done", no prompt text — for as long as the app stays open. The agent is running fine; the terminal shows its output. Only Orca's view of it is dead. Closing and reopening the tab is the only escape, and it loses the row's history. Which agents this hits depends on which provider you use, which is why it reads as random.

Same shape, second door: you launch an agent on a remote host and the SSH connection drops before its first status post lands. The relay dutifully spools everything the agent emits, including its final "done". On reconnect, main throws the entire spool away — it compares the replay against the last token it happened to see, which is the *previous* agent's. The pane stays showing the old agent's status, and since the new agent has already finished, nothing ever corrects it.

Third door, found while reviewing the second: your remote agent's hook scripts emit `launchToken=""` whenever the process did not receive `ORCA_AGENT_LAUNCH_TOKEN` — which happens whenever the variable is lost in transit, and both the WSL passthrough and an SSH host's accepted-env list can lose it. On reconnect the spool is compared against the pane's generation, an empty token is not that generation, and the whole spool is dropped. Identical symptom to the second door, different population.

**After.** All three panes come back. A replacement agent takes the row on its own session boundary; if its provider has no session boundary, the launch itself hands over the lock. A reconnecting relay's spool is measured against the generation the pane was actually launched with, and a spool that names no generation at all is admitted rather than read as the wrong one — so the offline agent's final status lands on every remote topology, not only the ones where the token survived the trip.

**Unchanged:** a genuinely stale process still cannot reclaim a pane, and a spool that names a *different* generation is still discarded. Every "still fences the token it replaced" case in the new suite pins the first, and "still discards a replay from the generation that spawn replaced" pins the second.

## The three gates

All three live in `src/main/agent-hooks/server.ts` (the original report cited `src/relay/server.ts:1206` / `:2338`; no such file exists on any branch — the line numbers map onto this file).

**1. Live-pane launch-token fence** (`getAgentStatusDisposition`, the `!paneRetired` branch). **Confirmed wrong.** The claim was "suppresses and can never re-fence, because re-fencing itself requires a token". Half right: re-fencing requires a token *and* a literal `SessionStart`. Measured across the source matrix — arm the fence, then post from a genuinely new process holding a fresh token — **11 of the 13 sources in that probe matrix were suppressed permanently**; only `claude` and `codex` recovered. (13 is the size of that probe, not the provider population: `AGENT_HOOK_SOURCES` has **18**, and the classifier covers all of them. Measured over all 18, five spell it `SessionStart` and thirteen do not.) The suppression is unbounded: `restartedStatusLaunchTokenHashByPaneKey` is only cleared by pane retirement or PTY-exit cleanup, and `restorePaneAuthority` — the escape hatch added for exactly this class of bug (STA-4114) — lifts the retirement tombstone but leaves this map untouched.

Forty lines below, the retired-pane branch carries the comment *"Why the classifier, not literals: only 5 of 18 sources name their boundary `UserPromptSubmit`/`SessionStart`; the rest stayed retired forever."* The same defect survived in the branch above it, where the consequence is worse: the retired branch fails **open** on an unknown provider by design, this one fails **closed**.

**2. Relay spool replay fence** (the `envelope.isReplay === true` gate). **Confirmed wrong, different mechanism.** It is not too strict about absence; it compares against the wrong generation. `hydratedLaunchTokenHashByPaneKey` is written by `recordCurrentAuthorityObservation` on every live tokened post, so "expected" is the last token main *observed*, which can be strictly older than the one being replayed. An agent launched over SSH that loses contact before its first live post has its whole spool discarded as stale — including its terminal status, so nothing ever repairs the row.

**3. The same replay fence read against a tokenless poster.** **Found by review of the fix for gate 2, reproduced before it was changed.** Supplying gate 2 with the pane's current generation at spawn time is correct, but it also *arms* an expectation on panes that never had one — and every shell-side poster emits `"launchToken":"${ORCA_AGENT_LAUNCH_TOKEN:-}"`, so a process that never received the variable reports an **empty** token, not an absent one. `launchTokenHash('')` is `null`, `null !== <hash>`, and the fence returned. Before this PR such a pane had no expectation at all — both pre-existing writers (`recordCurrentAuthorityObservation` and disk hydration) require a token — so its spool landed unconditionally. Reproduced with a differential probe against the real `AgentHookServer`: with the spawn notification, the tokenless replay leaves the row `undefined`; without it, the same replay lands. The fix is the read side of the rule the write side already argues — a record carrying no token is not evidence about any generation, so it is admitted rather than rejected as the wrong one. Every rejection that names a real, different token is untouched.

## Which way each fence fails

Both fail **closed and silently**: an early `return`, no telemetry, no user-visible signal, and no decay. Neither states anything about the pane's process. That is correct and preserved — retirement and this fence are authorship claims, not liveness verdicts, and nothing here asserts `live` / `unverifiable` / `exited` about a process or lets a boolean stand in for one. `RetiredPaneSurfaceRegistry`'s own doc comment makes the same commitment on the relay side.

## The fix, at the source

Deliberately no exemption to either gate; matching #17257's sibling commit *"Mint the token there: it is the contract every token-keyed gate depends on."*

- **`isSessionStartEvent(source, eventName)`** in `provider-event-routing.ts`, beside `isNewTurnEvent`. Exhaustive switch, so a new `AgentHookSource` fails typecheck instead of silently joining the half that can never re-fence. Not `isNewTurnEvent`: a turn boundary recurs inside one process and therefore cannot order two processes sharing a pane. Each name is taken from the provider's own normalizer — `kimi` was the one exception (its names are Claude-compatible, but `normalizeKimiEvent` has no `SessionStart` case and `KIMI_HOOK_EVENTS` never subscribes to one, so the branch was unreachable on every path) and it now returns `false` with a tripwire in the listener characterization suite that reddens the moment kimi gains one. `cursor` keeps its name: `normalizeCursorEvent` does map `sessionStart`, so a hand-written hook reaches the gate even though `CURSOR_EVENTS` deliberately does not subscribe to it.
- **`agentHookServer.noteAgentPaneLaunchToken(paneKey, launchToken)`**, called from `spawn-commit.ts` through a pure `resolveSpawnedPaneLaunchToken` helper. Gemini, Antigravity, mimo-code, omp and Command Code emit no session boundary at all, so no event can ever prove a new process owns their pane — main mints the tokens, so main reports them. This also supplies gate 2 with the pane's *current* generation instead of its last-observed one.
- The status fence is only **replaced**, never armed, here — arming would fence panes no revive ever fenced and start suppressing their tokenless posters. The replay expectation is only **raised**, never cleared, because it exists to reject an older generation and a tokenless shell is not evidence about any generation. **Both halves are now pinned**, and both directions ablate: adding an `else { delete }` to the tokenless arm reddens 1; dropping the `.has()` guard so the status fence arms unconditionally reddens 2. The second half was previously asserted only in prose and reddened nothing.
- **The read side of that same rule**, in the replay fence: reject only when the replay names a *different* generation, not when it names none. Deleting the whole fence still reddens 2, so the wrong-generation rejection is unchanged in strength.
- **Every armable source now gets spawn-path coverage**, not only the five with no session boundary. The spawn notification is provider-independent by construction, and it is what actually rescues the sources whose boundary Orca never installs (`cursor`) or never normalizes (`kimi`); scoping that suite to the no-boundary bucket left those two covered only by an event production never sends.

## The other five token gates

Of the files naming `ORCA_AGENT_LAUNCH_TOKEN`, the ones where the token's value or presence changes an outcome, beyond the two above:

- `unmanaged-status-extension-fence.ts` — was wrong the same way; already fixed on the parent stack. Verified here that its provisional hold is wired on **both** the local HTTP and the remote relay ingress (`releaseIfUnconfirmed` at both call sites), so a held remote post is released rather than dropped.
- **Degraded — `orca-runtime.ts`**: the runtime launch mints a token only when a `launchConfig` is present (`launchOpts.launchConfig ? (launchOpts.launchToken ?? randomUUID()) : undefined`). Every other launch runs untokened and each token-keyed gate quietly drops to its fail-open path. Worth promoting: it is the reason "tokenless" is a normal state rather than an edge case, and it is why the tokenless arm of `noteAgentPaneLaunchToken` clears the fence rather than leaving one nothing can satisfy.
- **Degraded — `wsl-orca-env.ts`**: the token reaches a WSL guest only via the `WSLENV` passthrough list, and nothing asserts the guest received it. A distro that drops it makes every guest hook post tokenless with no signal.
- **Degraded — `hook-stdin-contract.ts`**: the spool writer emits `"launchToken":""` when the env var is unset, so "this process has no token" and "the token was lost in transit" are the same bytes on disk. Those last two are exactly the population gate 3 was discarding: the same ambiguity that makes them degraded is what made reading an empty token as the wrong generation a data-loss bug rather than a strictness choice.

The remaining readers (`liveness.ts`, `spawn-env.ts`, `local-pty-launch-helpers.ts`, `spawn-environment.ts`, `remote-cli-env.ts`, `ssh-remote-cli-host-passthrough.ts`) are scrub or passthrough lists, not gates.

## Both worlds, and the wire

Under the pre-#17257 leak, a relay started from an Orca pane pushed its own launch token into every pane it spawned, so a wrong-but-present token satisfied gate 1 and made gate 2's mismatch look like ordinary staleness. That masked both defects rather than causing them — the strand needs only a token *change*, which a legitimate respawn produces on its own. With identity correct, both are plainly reachable, and gate 1's tokenless arm becomes ordinary rather than exotic.

**Wire compatibility.** No wire change: no new field, no new stream opcode, no change to what the host publishes. Combinations reasoned about: **new client + old relay** — the relay omits `source`, so the classifier falls through to the pre-existing `SessionStart` literal, which is exactly today's behaviour; **new client + new relay** — the classifier applies; **old client + new relay** — untouched, both gates are main-side only. The spawn notification is a main-process call, so it works identically for local, WSL and SSH panes and depends on no patched module reaching a relay.

## Verification

- `pnpm tc` — exit **0**, `0` × `error TS`, run in the **foreground**. Proven non-vacuous by planting `const wlPlanted: number = actualLaunchTokenHash` → exit **1** with 2 × `error TS` (TS2322, TS6133); restored → exit 0.
- `src/main/agent-hooks` + `src/shared/agent-hook-listener`: **92 files / 998 passed**, 6 skipped, 0 failed.
- `src/main/agent-hooks` + `src/shared/agent-hook-listener` + `src/main/ipc/pty`: **157 files / 1636 passed**, 12 skipped, 0 failed.
- `oxlint --deny-warnings` on every changed file: exit **0**, stdout retained and empty (so no config failure was smuggled onto stdout). Proven live by planting `const wlAny: any = paneKey` → exit **1** with `typescript(no-explicit-any)` printed to stdout.
- `oxfmt --check`: all formatted. Gates run directly, not through the changed-code quality gate.

**Ablations** — re-measured on this head, serial, one mutation at a time, each **verified applied** before the run (one mutation silently failed to apply and was caught by that check, not by its red count), tree asserted clean between runs. Scope: the three changed spec files plus `src/shared/agent-hook-listener*`, baseline **251/251 green across 18 files**.

| ablation | red |
|---|---|
| re-fence branch back to the `SessionStart` literal | 14 |
| `noteAgentPaneLaunchToken`'s status-fence block deleted | 17 |
| `noteAgentPaneLaunchToken`'s replay-generation line deleted | 2 |
| `resolveSpawnedPaneLaunchToken`'s reattach guard deleted | 1 |
| the `spawn-commit.ts` call deleted | 1 |
| `cursor` + `amp` zeroed in the classifier | 4 |
| the tokenless-replay admission reverted (gate 3's fix) | 2 |
| the whole replay fence deleted | 2 |
| replay expectation cleared on a tokenless respawn (`else { delete }`) | 1 |
| status fence armed unconditionally (`.has()` guard dropped) | 2 |
| `normalizeKimiEvent` taught a `SessionStart` case | 1 |

The first ablation reddens exactly 7 sources × 2 cases — amp, cursor, pi, prime-agent, grok, copilot, hermes — and leaves `claude`/`codex`/`droid`/`devin`/`opencode` green, because those five genuinely do spell it `SessionStart`. That is the positive control that the matrix is measuring the classifier and not the branch. `kimi` used to sit in the green half and its green was vacuous: it was filed as a `SessionStart` source, so the ablation could not distinguish it, and it never reached the spawn path that actually rescues it. The last row is that branch's replacement tripwire, and it reddens.

Gate 3 was **reproduced before it was fixed**: a probe with the spawn notification left the row `undefined`, the same probe without it landed the spool. The reverted-fix ablation reddens exactly the two tests that pin it and leaves "still discards a replay from the generation that spawn replaced" green, so the fix narrows the rejection to wrong-generation replays and does not loosen it further.

The second of those two names the shape a real pane reaches it by: `orca-runtime.ts` mints a launch token only when a `launchConfig` is present, so an ordinary relaunch into an already-tokened pane is **untokened** — its posts and its spool carry no token while the first launch's expectation still stands, and that expectation is deliberately never cleared by a tokenless launch. Verified host-independent: `src/relay/wsl-agent-hook-relay.ts` constructs the same `RelayAgentHookServer` that drains and replays the spool as the SSH relay does, so both remote topologies reach this fence through identical code.

