### PR TITLE
test(persistence): pin the migration-unsupported replay as unreachable

### DIFF
--- a/src/main/persistence-migration-unsupported-replay-guard.test.ts
+++ b/src/main/persistence-migration-unsupported-replay-guard.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { installFakeAppEnvironment } from '../../config/scripts/vitest-host-ports-setup'
+import type { PersistedState } from '../shared/persisted-state-types'
+import { Store } from './persistence/loading-store/store'
+
+vi.mock('./telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('./telemetry/cohort-classifier', () => ({
+  getCohortAtEmit: () => ({ nth_repo_added: 2 })
+}))
+
+function writeProfile(dir: string, state: Record<string, unknown>): string {
+  const dataFile = join(dir, 'orca-data.json')
+  writeFileSync(dataFile, JSON.stringify(state), 'utf-8')
+  return dataFile
+}
+
+/** A profile carrying restart-required rows an older build wrote. */
+function profileWithMigrationUnsupportedRows(ptyId: string): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    migrationUnsupportedPtyEntries: [
+      {
+        ptyId,
+        tabId: 'tab-later',
+        paneKey: 'tab-later:1',
+        reason: 'legacy-numeric-pane-key',
+        source: 'local',
+        updatedAt: 1
+      }
+    ]
+  }
+}
+
+describe('Store migration-unsupported replay ownership', () => {
+  let dirs: string[] = []
+
+  beforeEach(() => {
+    dirs = []
+    installFakeAppEnvironment({ getPath: () => tmpdir() })
+  })
+
+  afterEach(() => {
+    for (const dir of dirs) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  function makeDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-migration-replay-guard-'))
+    dirs.push(dir)
+    return dir
+  }
+
+  // Why this is a tripwire and not a regression test: `Store` hands the
+  // migration-unsupported singleton a listener that closes over this store, and never
+  // detaches it, so a later store's constructor replays through the earlier store's
+  // closure — the exact defect fixed for pane-key aliases in #17262. It is harmless
+  // only because `normalizePersistedPaneIdentityState` retires these rows into aliases
+  // and returns no entries to replay, leaving the loop unreachable. Re-emitting them
+  // without first detaching (see the alias listener's clear) reddens this.
+  it('does not write a later store’s migration-unsupported rows into an earlier store’s profile', () => {
+    const earlierFile = writeProfile(makeDir(), { schemaVersion: 1 })
+    const earlier = new Store({ dataFile: earlierFile })
+
+    const laterFile = writeProfile(makeDir(), profileWithMigrationUnsupportedRows('pty-later'))
+    new Store({ dataFile: laterFile })
+
+    earlier.flush()
+    const earlierState = JSON.parse(readFileSync(earlierFile, 'utf-8')) as PersistedState
+    expect(earlierState.migrationUnsupportedPtyEntries ?? []).toEqual([])
+  })
+})

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -70,6 +70,10 @@ export class Store {
     for (const entry of normalized.legacyPaneKeyAliasEntries) {
       registerPersistedPaneKeyAlias(entry)
     }
+    // Why this single-slot registration needs no detach above the replay loops: normalization
+    // retires these rows into aliases and returns none, so the loop that would fire a previous
+    // Store's listener is unreachable. persistence-migration-unsupported-replay-guard.test.ts
+    // reddens if that stops being true.
     setMigrationUnsupportedPtyPersistenceListener((entries) => {
       this.state.migrationUnsupportedPtyEntries = entries
       scheduleSave(this.domains.scheduling)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​75 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​75 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5

When Orca opens a profile it builds a `Store`. The `Store` hands a long-lived
background object a callback — "if these rows change, save them for me" — and that
object only has room for **one** callback at a time.

Handing over a second one silently throws the first away. If the handover happens
*after* the new `Store` has already replayed its saved rows, the replay goes through
the **old** `Store`'s callback and writes the new profile's rows into the old
profile's file. That is the bug fixed for pane-key aliases in #17262.

There are two such handovers in the same constructor. This PR is about the second
one, which was reported as the same defect. **It is the same shape but it is not a
live defect**, and this PR proves why rather than patching it: the rows it would
replay are retired into aliases during normalization, so the list is always empty and
the loop that would fire the stale callback never runs.

Rather than add a guard line that guards nothing, this pins the condition that makes
it safe. The day someone re-enables those rows, CI says so.

Deleting the dead loop instead was considered and measured, not skipped — see
[Why not just delete the dead loop?](#why-not-just-delete-the-dead-loop) below. Short
version: the loop is the only thing that still writes into that subsystem, so deleting
it strands the rest of it and removes the one warning anyone would get if the path
came back.

## User-facing before/after

**None. No user-visible change.** This PR adds one test and one comment; it changes no
shipped behaviour, no timing, and no output. Calling it anything more would be
inflating it.

## Verdict on the report: the report was wrong

The reported location is also wrong. There is no `src/main/store.ts`. The listener is
`src/main/persistence/loading-store/store.ts:73` — line 73 of a different file.

On the substance, it is genuinely the same *shape*: a single-slot registration on a
module singleton, made from a constructor, never detached. It is not the same
*defect*, because its firing path is unreachable:

- `normalizeWorkspaceSessionPaneIdentities` builds `migrationUnsupportedEntries` as
  `const [] ` and never pushes (`workspace-pane-normalization.ts:40`, carrying an
  explicit `Why always empty` comment).
- `normalizePersistedPaneIdentityState` does the same for
  `mergedMigrationUnsupportedEntries` (`:206`), returning it at both of its exits
  (`:234` and `:241` — I said "all three" in an earlier revision; there are two).
- So the constructor's replay loop (`store.ts:67`) never iterates, and the stale
  listener is never invoked.
- There are **two** such loops, not one. `workspace-session-snapshot-publication.ts:46`
  iterates the same always-empty array out of `normalizeWorkspaceSessionPaneIdentities`
  on every session write. The same fact retires both.

Measured rather than read. Two `Store`s, the later one loading a profile that really
does carry a restart-required row:

| | rows in file | rows after normalization | singleton received | leaked into earlier store |
|---|---|---|---|---|
| shipped code | 1 | **0** | 0 | **0** |
| replay re-enabled | 1 | 1 | 1 | **1** |

The row survives loading; normalization is what discards it.

**The 0 is load-bearing, not vacuous.** The same harness, same run, asserting on the
*alias* listener instead — the #17262 defect, still live on `main` — leaks **3** rows.
So the probe detects cross-store contamination through exactly this path; the
migration listener simply produces none.

This independently confirms what #17262's author found when they dropped this very
line from their branch for reddening nothing. An unpinned guard line is worse than no
line, so this PR does not add one.

## Why not just delete the dead loop?

This was raised in review and it should have been on the table from the first draft: if the
loop provably cannot run, deleting it is simpler than pinning it, and the tripwire stops being
necessary at all. I measured it rather than argued it. **The answer is to keep both the loop
and the tripwire**, and the reasoning is below rather than in a commit message, because "we
considered deleting it" is the part a future reader needs.

**Deleting reddens nothing — which is the expected result, not a green light.** Each mutation
applied serially, verified present in the file, tree restored and re-verified between runs,
over `src/main/persistence` + `src/main/agent-hooks` (baseline **130 files, 1463 passed,
6 skipped, 0 failed**):

| ablation | reddened |
|---|---|
| `store.ts:67` loop deleted, with its now-unused import | **0 / 1463** |
| `workspace-session-snapshot-publication.ts:46` loop deleted, with its import | **0 / 1463** |
| both deleted | **0 / 1463** |

The rig is not blind to this path. Seeding `mergedMigrationUnsupportedEntries` from
`state.migrationUnsupportedPtyEntries` — making the replay reachable — reddens **2 of 1463** in
the same scope: this PR's tripwire, on the exact cross-store leak, plus an unrelated clearing
assertion in `persistence-pane-identity-migration.test.ts`. A 0 from a rig that can produce a 2
on demand is a measurement, not a shrug.

**What deleting actually costs.** These two loops are the *only* production writers to
`migration-unsupported-pty-state`'s map: `setMigrationUnsupportedPty` has exactly two non-test
call sites in `src/main`, and they are these. Everything else in that module reads a snapshot
or clears, and every clear early-returns on an empty map. So deleting them does not remove
three lines of scaffolding — it removes the last producer of a subsystem that otherwise stays
wired: the `agentStatus:getMigrationUnsupportedSnapshot` IPC handler
(`ipc/agent-hooks.ts:97-100`), the renderer store slice that consumes it, the three clear paths
hung off pty spawn and teardown, and the persisted `migrationUnsupportedPtyEntries` field would
all remain with nothing left that could ever fill them. That is not a smaller codebase, it is a
stranded one. The honest version of that deletion is a subsystem removal touching a persisted
field and a renderer IPC surface — a different PR, and one that deserves to be deliberate
rather than a side effect of tidying a loop.

**And the loop is a consumer, not debris.** The array is empty because the *producer* was
switched off — legacy numeric pane keys are bridged as aliases now — and the field was
deliberately kept so old rows still get cleared; `workspace-pane-normalization.ts:38-39` says
exactly that. The loop is the standing consumer for a producer that is currently off. Delete
it, and on the day someone turns the producer back on, persisted restart-required rows are
silently never rehydrated into the runtime: a quiet behavioural gap, with no test to catch it,
because the test that would have caught it was deleted alongside the loop. Keep it, and turning
the producer back on reddens CI immediately, at the line, with arm B below already showing what
the fix is.

**The tripwire is not redundant with coverage that already exists.** I checked, because if it
were, deletion would win.
`persistence-loading-store-extraction.test.ts` already carries `keeps the last constructed
Store as the global pane-migration listener owner`, which builds two `Store`s and calls
`setMigrationUnsupportedPty` directly. Under the reachability mutation above **that test stays
green**: it drives the singleton *after* both constructors have returned, when the newest store
correctly owns the listener. It cannot see a leak that happens *during* the second
constructor — which is precisely the #17262 shape. Measured, not assumed.

**The trade, stated plainly.** Deleting buys six lines and costs the only warning anyone would
get if this path came back, while stranding a subsystem. The tripwire costs those six dead
lines plus 75 test lines, and buys a failure that fires exactly when the dead path stops being
dead. At that price the tripwire wins.

## The guard, and the placement check

The new test is a tripwire, and it pins **ownership**, not emptiness. Four arms, run
serially, one mutation at a time, each mutation verified present in the file, tree
restored and re-verified green between runs:

| arm | replay reachable | detach line | placement | result |
|---|---|---|---|---|
| shipped | no | — | — | **pass** |
| A | yes | none | — | **FAIL** |
| B | yes | yes | top of constructor | pass |
| C | yes | yes | below the replay loops | **FAIL** |

A→B is what makes this a guard rather than a restatement: with the replay reachable,
the detach line is exactly what flips the test. C reproduces #17262's placement
finding on this listener — above the replay loops or it does nothing.

## Sweep: every single-slot listener without a detach

**Axis enumerated: the registration call site, not the slot.** The defect needs a
registrant whose lifetime is shorter than the singleton it registers on, so the slot
alone tells you nothing.

Built on the oxc AST (a regex pass was discarded — it spanned function boundaries,
inventing `if` and `listener` as setters while swallowing real ones).

| | |
|---|---|
| Files parsed | 18,543 (0 parse failures) |
| Single-slot setters (any type) | 164 |
| Nullable, callback-shaped | 77 |
| Prod registration call sites | 31 distinct enclosing contexts |
| Registered from a **constructor** | **3** |

Two census bugs were caught by controls before I trusted a number, both of which had
dropped a known instance:

1. A `: void {` single-line-signature match missed
   `setMigrationUnsupportedPtyPersistenceListener` — the subject of this PR — because
   its signature wraps.
2. Requiring `=>` in the parameter type missed
   `setPaneKeyAliasPersistenceListener` — the #17262 site — because its parameter is a
   named type alias.

The final census carries a positive control (all four known setters must appear) and a
negative control (the regex-era false positives must not).

The three constructor sites:

| site | receiver | verdict |
|---|---|---|
| `store.ts:73` migration listener | module singleton | same shape, **unreachable** — this PR |
| `store.ts:77` alias listener | module singleton (`agentHookServer`) | **the real one**, fixed by #17262 |
| `relay-runtime-services.ts:56` `setWorktreeRemovalCoordinator` | `new PtyHandler` built two lines above | **not the shape** — no prior listener to orphan |

Beyond constructors, the repeating-lifetime registrants all already detach, several by
exactly the #17262 method. `bindProviderListeners`
(`src/main/ipc/pty/provider/bind-listeners.ts:19`) calls the four previous unsubscribes
at the top of the function before re-registering, with a module comment naming the
macOS re-activation path that motivated it. The one transitive hit —
`mobile-socket-wiring.ts:92 attachTransport`, reached from a constructor — registers on
the transport it was handed and returns a detach.

### There IS a repeating registrant in the shipped app — and it is already disciplined

Worth stating plainly, because it is the thing that would make this class user-facing:
`registerPtyHandlers` genuinely re-runs in the shipped app. macOS app re-activation
builds a new `BrowserWindow` and calls it again, so every listener it installs on a
process-lifetime object is installed a second time with a live predecessor.

That path does not have the defect, because it already applies exactly the discipline
#17262 arrived at — neutralise the previous owner at the **top**, before anything can
fire through it (`register-handlers.ts:74-81`):

```ts
resetRendererDeliveryAccountingForLifecycleReset()
clearRendererDispatcherReadyWatchdog()
setResetRendererDeliveryAccountingForLifecycleReset(() => {})
setInvalidatePendingPtyDrainPriority(() => {})
setInvalidatePendingPtyDrainPolicy(() => {})
setRebindProviderListeners(() => {})
```

with `clearDidFinishLoadHandler()` before `setDidFinishLoadHandler(...)` (`:168`) and the
four provider unsubscribes called at the top of `bindProviderListeners` (`:19`). The
one un-detached registration on that path, `setPtyController`
(`ipc/pty/runtime/controller.ts:37`), is a pure newest-window-wins replacement with no
replay between registration and use, so there is no window for a stale closure to run.

**So: no live instance of the defect anywhere, including on the one lifetime that
actually repeats.**

### What this census cannot see

- **Setters with more than one statement.** The scan requires a body that is exactly
  one assignment, which is what makes "assigns without detaching" decidable. 932
  multi-statement single-assignment setters are excluded; that is an upper bound on the
  blind spot, not a count of misses.
- **Direct assignment with no setter function** (`obj.onFoo = fn`).
- **Indirection deeper than one level.** I resolved registrar-called-from-constructor
  one hop (1 hit, classified above); a registration two helpers below a constructor
  reads as its immediate enclosing function.
- **Multi-listener registries** (Set/array), excluded by definition — they do not
  silently orphan.
- **Dynamic or computed setter names.**

## Why no repo-wide ratchet

I looked at turning the census into a gate and concluded it would need suppressions,
so I am not proposing it. The discriminating property is *receiver lifetime* — module
singleton versus freshly constructed — and that is not decidable from a source walk
without cross-module binding resolution. A naive version flags
`relay-runtime-services.ts:56`, which is correct code, and that is a suppression on day
one. The narrow, exact guard is the reachability pin in this PR.

## Proof

**Suite** — `src/main/persistence` + `src/main/agent-hooks`, `--no-file-parallelism`:
**130 files passed, 1463 passed, 6 skipped, 0 failed.**

**Typecheck** — `pnpm tc`, foreground, exit code observed directly: **0**. Proven
non-vacuous: planting `const plantedTypeError: number = 'not a number'` in the new file
gave **exit 1**, `TS2322` at line 37; removing it returned exit 0.

**Lint** — `npx oxlint` on both changed files, stdout retained: **exit 0**. Gate proven
live: a probe file with a duplicate key reported `eslint(no-dupe-keys)` and **exit 1**.
`npx oxfmt --check`: clean, 2 files.

**CI** — run `33269986368`, **attempt 1**: **27 checks total — 19 pass, 0 red, 8 skipping.**
`verify` passed. Neither known-false red applied: `cross-version wire compatibility` was
skipped rather than run, and no updater flake surfaced on `test / tests node 24 6/8`.

## Relationship to #17262

**Independent — not stacked.** Branched from `main` at `a1f198be0d`, re-resolved by
`ls-remote` immediately before pushing. It touches a different listener and a different
file, so the two cannot conflict, and this test passes with or without #17262. I have
not merged, approved, or closed anything.

