### PR TITLE
Make worktree palette hint rows keyboard-clickable

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -42,7 +42,6 @@ import {
   CommandEmpty,
   CommandItem
 } from '@/components/ui/command'
-import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { parseGitHubIssueOrPRNumber, parseGitHubIssueOrPRLink } from '@/lib/github-links'
 import { getLinkedWorkItemSuggestedName, getLinkedWorkItemWorkspaceName } from '@/lib/new-workspace'
@@ -3262,30 +3261,23 @@ function WorktreeJumpPaletteContent({
               }
 
               if (entry.type === 'hint') {
-                // Why: plain div (not CommandItem) so cmdk can't select it; arrow keys skip it via selectableItems.
                 return (
-                  <div
+                  <CommandItem
                     key={renderKey}
-                    className="mx-0.5 mt-1 flex items-center gap-2 px-3 py-1.5 text-[12px] text-muted-foreground"
+                    value={renderKey}
+                    onSelect={entry.onSeeMore}
+                    className={cn(
+                      JUMP_PALETTE_ITEM_CLASSNAME,
+                      'mt-1 min-h-0 gap-2 py-1.5 text-[12px] text-muted-foreground'
+                    )}
                   >
                     <span className="truncate">{entry.label}</span>
                     {entry.onSeeMore ? (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="xs"
-                        className="h-6 shrink-0 px-2 text-xs font-medium text-foreground hover:bg-accent"
-                        onClick={(event) => {
-                          event.preventDefault()
-                          event.stopPropagation()
-                          entry.onSeeMore?.()
-                          inputRef.current?.focus()
-                        }}
-                      >
+                      <span className="h-6 shrink-0 rounded-md border border-input bg-background px-2 text-xs font-medium leading-6 text-foreground">
                         {translate('worktreeJumpPalette.seeMore', 'See more')}
-                      </Button>
+                      </span>
                     ) : null}
-                  </div>
+                  </CommandItem>
                 )
               }
 

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -8,6 +8,7 @@ import React, {
   useRef,
   useState
 } from 'react'
+import { flushSync } from 'react-dom'
 import { useShallow } from 'zustand/react/shallow'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -3265,7 +3266,17 @@ function WorktreeJumpPaletteContent({
                   <CommandItem
                     key={renderKey}
                     value={renderKey}
-                    onSelect={entry.onSeeMore}
+                    onSelect={() => {
+                      const previousIndex = selectionItemIds.indexOf(renderKey)
+                      flushSync(() => entry.onSeeMore?.())
+                      const expandedItemId = Array.from(
+                        listRef.current?.querySelectorAll<HTMLElement>('[cmdk-item]') ?? []
+                      )[previousIndex]?.getAttribute('data-value')
+                      if (expandedItemId) {
+                        setSelectedItemId(expandedItemId)
+                      }
+                      inputRef.current?.focus()
+                    }}
                     className={cn(
                       JUMP_PALETTE_ITEM_CLASSNAME,
                       'mt-1 min-h-0 gap-2 py-1.5 text-[12px] text-muted-foreground'

--- a/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
@@ -82,8 +82,16 @@ vi.mock('@/components/ui/command', async () => {
     CommandEmpty: ({ children }: { children: React.ReactNode }) => (
       <div data-command-empty="true">{children}</div>
     ),
-    CommandItem: ({ children, value }: { children: React.ReactNode; value?: string }) => (
-      <button data-command-item={value ?? ''} type="button">
+    CommandItem: ({
+      children,
+      value,
+      onSelect
+    }: {
+      children: React.ReactNode
+      value?: string
+      onSelect?: () => void
+    }) => (
+      <button data-command-item={value ?? ''} type="button" onClick={onSelect}>
         {children}
       </button>
     )
@@ -540,7 +548,7 @@ describe('WorktreeJumpPalette interleaved primary sections', () => {
     await flushEffects()
 
     // After expanding by 20: 30 worktrees are rendered, 5 more
-    const renderedItems = testContainer.querySelectorAll('[data-command-item]')
+    const renderedItems = testContainer.querySelectorAll('[data-command-item^="worktree:"]')
     expect(renderedItems).toHaveLength(30)
     expect(testContainer.textContent).toContain('5 more')
 
@@ -553,7 +561,7 @@ describe('WorktreeJumpPalette interleaved primary sections', () => {
     })
     await flushEffects()
 
-    const renderedItemsAll = testContainer.querySelectorAll('[data-command-item]')
+    const renderedItemsAll = testContainer.querySelectorAll('[data-command-item^="worktree:"]')
     expect(renderedItemsAll).toHaveLength(35)
     expect(testContainer.textContent).not.toContain('more')
   })

--- a/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
@@ -57,18 +57,33 @@ vi.mock('@/components/ui/command', async () => {
   return {
     Command: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     CommandGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    CommandDialog: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
-      open ? <div data-command-dialog="true">{children}</div> : null,
-    CommandInput: ({
-      value,
-      onValueChange
+    CommandDialog: ({
+      children,
+      open,
+      commandProps
     }: {
-      value?: string
-      onValueChange?: (next: string) => void
-    }) => {
+      children: React.ReactNode
+      open?: boolean
+      commandProps?: { value?: string }
+    }) =>
+      open ? (
+        <div data-command-dialog="true" data-command-value={commandProps?.value ?? ''}>
+          {children}
+        </div>
+      ) : null,
+    CommandInput: React.forwardRef(function CommandInput(
+      {
+        value,
+        onValueChange
+      }: {
+        value?: string
+        onValueChange?: (next: string) => void
+      },
+      ref: React.ForwardedRef<HTMLInputElement>
+    ) {
       setCommandQuery = onValueChange ?? null
-      return <input data-command-input="true" value={value} onChange={() => {}} />
-    },
+      return <input ref={ref} data-command-input="true" value={value} onChange={() => {}} />
+    }),
     CommandList: React.forwardRef(function CommandList(
       { children }: { children: React.ReactNode },
       ref: React.ForwardedRef<HTMLDivElement>
@@ -91,7 +106,13 @@ vi.mock('@/components/ui/command', async () => {
       value?: string
       onSelect?: () => void
     }) => (
-      <button data-command-item={value ?? ''} type="button" onClick={onSelect}>
+      <button
+        cmdk-item=""
+        data-value={value ?? ''}
+        data-command-item={value ?? ''}
+        type="button"
+        onClick={onSelect}
+      >
         {children}
       </button>
     )
@@ -541,6 +562,13 @@ describe('WorktreeJumpPalette interleaved primary sections', () => {
       btn.textContent?.includes('See more')
     )
     expect(seeMoreBtn).toBeDefined()
+    const initialItemIds = Array.from(testContainer.querySelectorAll('[cmdk-item]')).map((item) =>
+      item.getAttribute('data-value')
+    )
+    const seeMoreIndex = initialItemIds.indexOf('__hint_worktree_overflow__')
+    expect(seeMoreIndex).toBeGreaterThan(0)
+    const input = testContainer.querySelector<HTMLInputElement>('[data-command-input="true"]')
+    input?.focus()
 
     await act(async () => {
       seeMoreBtn?.click()
@@ -551,6 +579,17 @@ describe('WorktreeJumpPalette interleaved primary sections', () => {
     const renderedItems = testContainer.querySelectorAll('[data-command-item^="worktree:"]')
     expect(renderedItems).toHaveLength(30)
     expect(testContainer.textContent).toContain('5 more')
+    const firstRevealedItemId = Array.from(testContainer.querySelectorAll('[cmdk-item]'))[
+      seeMoreIndex
+    ]?.getAttribute('data-value')
+    expect(firstRevealedItemId).toMatch(/^worktree:/)
+    expect(firstRevealedItemId).not.toBe(initialItemIds[0])
+    expect(
+      testContainer
+        .querySelector('[data-command-dialog="true"]')
+        ?.getAttribute('data-command-value')
+    ).toBe(firstRevealedItemId)
+    expect(document.activeElement).toBe(input)
 
     // Click again: 30 + 20 = 50 (all 35 fit), hint disappears
     const seeMoreBtn2 = Array.from(testContainer.querySelectorAll('button')).find((btn) =>

--- a/src/renderer/src/lib/worktree-palette-create-action.test.ts
+++ b/src/renderer/src/lib/worktree-palette-create-action.test.ts
@@ -182,7 +182,7 @@ describe('worktree-palette-create-action', () => {
     })
   })
 
-  it('derives selection ids from rendered entries while skipping headers and hints', () => {
+  it('derives selection ids from rendered entries while skipping headers', () => {
     expect(
       getWorktreePaletteSelectionItemIds([
         { id: '__header_worktrees__', type: 'section-header' },
@@ -198,6 +198,7 @@ describe('worktree-palette-create-action', () => {
     ).toEqual([
       'worktree:one',
       CREATE_WORKTREE_ITEM_ID,
+      '__hint_worktree_cap__',
       'settings:ai-provider-accounts',
       'quick-action:new-terminal',
       'browser-page:one'

--- a/src/renderer/src/lib/worktree-palette-create-action.ts
+++ b/src/renderer/src/lib/worktree-palette-create-action.ts
@@ -66,7 +66,8 @@ const SELECTABLE_ENTRY_TYPES = [
   'browser-page',
   'workspace-tab',
   'simulator-tab',
-  'project-target'
+  'project-target',
+  'hint'
 ] as const
 
 type WorktreePaletteSelectableEntryType = (typeof SELECTABLE_ENTRY_TYPES)[number]
@@ -85,7 +86,7 @@ export function getWorktreePaletteSelectionItemIds<
   T extends WorktreePaletteSelectionCandidateEntry
 >(entries: readonly T[], renderKeys: readonly string[] = []): string[] {
   // Why: keyboard focus should mirror rendered order, including synthetic
-  // action rows, while skipping headers and explanatory hint rows.
+  // action rows, while skipping only section headers.
   // Why renderKeys wins: rows render under de-duplicated keys, so naming the bare
   // id here would leave a duplicate row absent from the list the `includes` check
   // above consults — arrowing onto it would snap the highlight back to the top.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## Problem
Hint rows (like "5 more" indicators) in the worktree jump palette were not keyboard-accessible. Users navigating with arrow keys couldn't select or interact with them.

## Solution
Converted hint rows from plain `<div>` elements to `<CommandItem>` components so they participate in keyboard navigation. The "See more" action is now triggered via keyboard selection (Enter) or click. Added `hint` to the selectable entry types list.

## Visual Proof
N/A — keyboard interaction change only, no visual changes.

## Testing
- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

Updated tests in `worktree-jump-palette-interleaved-sections.test.tsx` and `worktree-palette-create-action.test.ts` to verify hint rows are now included in selection navigation.

## Checklist
- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)