### PR TITLE
fix(git): stop cutting a failed fetch/pull/push down to git's closing line

### DIFF
--- a/src/renderer/src/lib/git-remote-failure-cause.test.ts
+++ b/src/renderer/src/lib/git-remote-failure-cause.test.ts
@@ -10,17 +10,52 @@ import { resolveRemoteOperationErrorMessage } from './source-control-remote-erro
 const execFileAsync = promisify(execFile)
 
 /**
- * Real `git push`/`git fetch` failures, not stubs: a fake GIT_SSH_COMMAND makes the
- * transport fail the way a missing key does, so git itself writes the two-part stderr
- * (cause first, generic "and the repository exists." advice last) this suite is about.
- * No network — the fake ssh never connects.
+ * The bytes OpenSSH itself writes ahead of a `publickey` denial when the configured identity
+ * is missing, transcribed from a live `git push` to github.com (OpenSSH 9.x, macOS). The
+ * denial is never the first line: ssh names the unreadable key file — under the user's home
+ * directory — before it gets there.
  */
-async function runFailingGitRemoteOperation(subcommand: 'push' | 'fetch'): Promise<Error> {
+const REAL_SSH_MISSING_IDENTITY_STDERR = [
+  'Warning: Identity file /Users/example/.ssh/id_ed25519 not accessible: No such file or directory.',
+  "Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.",
+  'git@github.com: Permission denied (publickey).'
+]
+
+/**
+ * Likewise for a changed host key, transcribed from a live `git push` against a deliberately
+ * wrong pinned key. ssh's verdict is last; everything before it is a banner, a fingerprint,
+ * and two lines naming a local `known_hosts` path.
+ */
+const REAL_SSH_HOST_KEY_CHANGED_STDERR = [
+  '@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@',
+  '@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @',
+  '@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@',
+  'IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!',
+  'Someone could be eavesdropping on you right now (man-in-the-middle attack)!',
+  'It is also possible that a host key has just been changed.',
+  'The fingerprint for the ED25519 key sent by the remote host is',
+  'SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.',
+  'Please contact your system administrator.',
+  'Add correct host key in /Users/example/.ssh/known_hosts to get rid of this message.',
+  'Offending ED25519 key in /Users/example/.ssh/known_hosts:1',
+  'Host key for github.com has changed and you have requested strict checking.',
+  'Host key verification failed.'
+]
+
+/**
+ * Real `git push`/`git fetch` failures, not stubs: a fake GIT_SSH_COMMAND replays what a real
+ * ssh wrote, so git itself writes the two-part stderr (cause first, generic "and the repository
+ * exists." advice last) this suite is about. No network — the fake ssh never connects.
+ */
+async function runFailingGitRemoteOperation(
+  subcommand: 'push' | 'fetch',
+  sshStderr: readonly string[] = ['git@github.com: Permission denied (publickey).']
+): Promise<Error> {
   const dir = mkdtempSync(join(tmpdir(), 'orca-git-remote-failure-'))
   const ssh = join(dir, 'fake-ssh.sh')
   writeFileSync(
     ssh,
-    '#!/bin/sh\necho "git@github.com: Permission denied (publickey)." >&2\nexit 255\n'
+    `#!/bin/sh\ncat >&2 <<'ORCA_SSH_STDERR'\n${sshStderr.join('\n')}\nORCA_SSH_STDERR\nexit 255\n`
   )
   chmodSync(ssh, 0o755)
   const git = (args: string[]): Promise<unknown> => execFileAsync('git', args, { cwd: dir })
@@ -92,6 +127,36 @@ describe('a failing git remote operation keeps its cause', () => {
     )
     expect(toast).toContain(`${CAUSE}. Check your remote access`)
     expect(toast).not.toContain('..')
+  })
+
+  describe('what real ssh prints ahead of its verdict is not the verdict', () => {
+    it('surfaces the denial, not the unreadable-identity warning naming a home path', async () => {
+      const failure = await runFailingGitRemoteOperation('push', REAL_SSH_MISSING_IDENTITY_STDERR)
+      const toast = resolveRemoteOperationErrorMessage(
+        asRendererSeesIt('git:push', normalizeGitErrorMessage(failure, 'push')),
+        { isPush: true }
+      )
+
+      expect(toast).toBe(
+        `Push failed. git@github.com: ${CAUSE}. Check your remote access and try again.`
+      )
+      // A file-permissions warning is not the reason the push failed, and it carries the
+      // user's home directory into a toast.
+      expect(toast).not.toContain('Identity file')
+      expect(toast).not.toContain('/Users/example')
+    })
+
+    it('surfaces the host-key verdict, not the banner or the known_hosts path', async () => {
+      const failure = await runFailingGitRemoteOperation('fetch', REAL_SSH_HOST_KEY_CHANGED_STDERR)
+      const toast = resolveRemoteOperationErrorMessage(
+        asRendererSeesIt('git:fetch', normalizeGitErrorMessage(failure, 'fetch')),
+        { isFetch: true }
+      )
+
+      expect(toast).toBe('Fetch failed. Host key verification failed.')
+      expect(toast).not.toContain('@@@')
+      expect(toast).not.toContain('/Users/example')
+    })
   })
 
   it('does not leave the user reading only git’s closing advice', () => {

--- a/src/renderer/src/lib/git-remote-failure-cause.test.ts
+++ b/src/renderer/src/lib/git-remote-failure-cause.test.ts
@@ -1,0 +1,105 @@
+import { execFile } from 'node:child_process'
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { normalizeGitErrorMessage } from '../../../shared/git-remote-error'
+import { resolveRemoteOperationErrorMessage } from './source-control-remote-error'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * Real `git push`/`git fetch` failures, not stubs: a fake GIT_SSH_COMMAND makes the
+ * transport fail the way a missing key does, so git itself writes the two-part stderr
+ * (cause first, generic "and the repository exists." advice last) this suite is about.
+ * No network — the fake ssh never connects.
+ */
+async function runFailingGitRemoteOperation(subcommand: 'push' | 'fetch'): Promise<Error> {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-git-remote-failure-'))
+  const ssh = join(dir, 'fake-ssh.sh')
+  writeFileSync(
+    ssh,
+    '#!/bin/sh\necho "git@github.com: Permission denied (publickey)." >&2\nexit 255\n'
+  )
+  chmodSync(ssh, 0o755)
+  const git = (args: string[]): Promise<unknown> => execFileAsync('git', args, { cwd: dir })
+  await git(['init', '-q'])
+  await git(['config', 'user.email', 'test@example.com'])
+  await git(['config', 'user.name', 'Test'])
+  writeFileSync(join(dir, 'a.txt'), 'hi\n')
+  await git(['add', 'a.txt'])
+  await git(['-c', 'commit.gpgsign=false', 'commit', '-qm', 'init'])
+  await git(['remote', 'add', 'origin', 'git@github.com:acme/repo.git'])
+  const args =
+    subcommand === 'push' ? ['push', '--set-upstream', 'origin', 'HEAD'] : ['fetch', '--prune']
+  try {
+    await execFileAsync('git', args, {
+      cwd: dir,
+      env: { ...process.env, GIT_SSH_COMMAND: ssh, GIT_TERMINAL_PROMPT: '0' }
+    })
+  } catch (error) {
+    return error as Error
+  }
+  throw new Error(`git ${subcommand} unexpectedly succeeded`)
+}
+
+/** Electron rewraps every rejected `ipcMain.handle` before the renderer reads it. */
+function asRendererSeesIt(channel: string, message: string): Error {
+  return new Error(`Error invoking remote method '${channel}': Error: ${message}`)
+}
+
+const CAUSE = 'Permission denied (publickey)'
+const GENERIC_TAIL = 'and the repository exists.'
+
+describe('a failing git remote operation keeps its cause', () => {
+  let pushFailure: Error
+  let fetchFailure: Error
+
+  beforeAll(async () => {
+    ;[pushFailure, fetchFailure] = await Promise.all([
+      runFailingGitRemoteOperation('push'),
+      runFailingGitRemoteOperation('fetch')
+    ])
+  }, 60_000)
+
+  it('git really did print the cause first and the generic advice last', () => {
+    const stderr = (pushFailure as Error & { stderr?: string }).stderr ?? ''
+    expect(stderr).toContain(CAUSE)
+    expect(stderr.trimEnd().endsWith(GENERIC_TAIL)).toBe(true)
+  })
+
+  it.each([
+    ['push', 'git:push', { isPush: true }],
+    ['fetch', 'git:fetch', { isFetch: true }],
+    ['pull', 'git:pull', undefined]
+  ] as const)('surfaces the cause to the %s toast', (operation, channel, options) => {
+    const failure = operation === 'fetch' ? fetchFailure : pushFailure
+    const produced = normalizeGitErrorMessage(failure, operation)
+
+    // The producer must not decide which half of git's output the user needs.
+    expect(produced).toContain(CAUSE)
+
+    const toast = resolveRemoteOperationErrorMessage(asRendererSeesIt(channel, produced), options)
+    expect(toast).toContain(CAUSE)
+    expect(toast).not.toContain('Error invoking remote method')
+  })
+
+  it('reads as one sentence when git’s own line already ends in a period', () => {
+    const toast = resolveRemoteOperationErrorMessage(
+      asRendererSeesIt('git:push', normalizeGitErrorMessage(pushFailure, 'push')),
+      { isPush: true }
+    )
+    expect(toast).toContain(`${CAUSE}. Check your remote access`)
+    expect(toast).not.toContain('..')
+  })
+
+  it('does not leave the user reading only git’s closing advice', () => {
+    const toast = resolveRemoteOperationErrorMessage(
+      asRendererSeesIt('git:push', normalizeGitErrorMessage(pushFailure, 'push')),
+      { isPush: true }
+    )
+    expect(toast).not.toBe(`Push failed. ${GENERIC_TAIL} Check your remote access and try again.`)
+    expect(toast).not.toBe('Push failed. Check your connection and try again.')
+  })
+})

--- a/src/renderer/src/lib/git-remote-failure-cause.test.ts
+++ b/src/renderer/src/lib/git-remote-failure-cause.test.ts
@@ -43,6 +43,29 @@ const REAL_SSH_HOST_KEY_CHANGED_STDERR = [
 ]
 
 /**
+ * What a current OpenSSH writes when a configured identity is missing, captured verbatim from
+ * OpenSSH_10.2p1 against a real sshd. Note it is *not* `Warning:`-prefixed — the `Warning: Identity
+ * file …` wording above belongs to older releases — so no prefix tells advisories apart from verdicts.
+ */
+const REAL_SSH_NO_SUCH_IDENTITY = [
+  'no such identity: /Users/example/.ssh/id_ed25519: No such file or directory\r'
+]
+
+/**
+ * Likewise for a private key with loose permissions: seven lines, the last of which names the key
+ * under the user's home and is neither `Warning:`-prefixed nor a verdict.
+ */
+const REAL_SSH_UNPROTECTED_KEY = [
+  '@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\r',
+  '@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @\r',
+  '@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\r',
+  "Permissions 0644 for '/Users/example/.ssh/id_ed25519' are too open.\r",
+  'It is required that your private key files are NOT accessible by others.\r',
+  'This private key will be ignored.\r',
+  'Load key "/Users/example/.ssh/id_ed25519": bad permissions\r'
+]
+
+/**
  * Real `git push`/`git fetch` failures, not stubs: a fake GIT_SSH_COMMAND replays what a real
  * ssh wrote, so git itself writes the two-part stderr (cause first, generic "and the repository
  * exists." advice last) this suite is about. No network — the fake ssh never connects.
@@ -77,6 +100,40 @@ async function runFailingGitRemoteOperation(
     return error as Error
   }
   throw new Error(`git ${subcommand} unexpectedly succeeded`)
+}
+
+/**
+ * The other half of the matrix: a transport that *works*. The fake ssh writes the same real advisory
+ * and then executes the git service it was handed, against a real local repo — so the connection is
+ * made, the ref advertisement arrives, and the failure that follows is git's own.
+ */
+async function runGitFailureOverWorkingTransport(sshStderr: readonly string[]): Promise<Error> {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-git-transport-ok-'))
+  const ssh = join(dir, 'fake-ssh.sh')
+  writeFileSync(
+    ssh,
+    `#!/bin/sh\ncat >&2 <<'ORCA_SSH_STDERR'\n${sshStderr.join('\n')}\nORCA_SSH_STDERR\nfor orca_last; do :; done\nexec /bin/sh -c "$orca_last"\n`
+  )
+  chmodSync(ssh, 0o755)
+  const git = (args: string[], cwd: string): Promise<unknown> => execFileAsync('git', args, { cwd })
+  await git(['init', '-q', '--bare', 'remote.git'], dir)
+  await git(['init', '-q', 'work'], dir)
+  const work = join(dir, 'work')
+  await git(['config', 'user.email', 'test@example.com'], work)
+  await git(['config', 'user.name', 'Test'], work)
+  writeFileSync(join(work, 'a.txt'), 'hi\n')
+  await git(['add', 'a.txt'], work)
+  await git(['-c', 'commit.gpgsign=false', 'commit', '-qm', 'init'], work)
+  await git(['remote', 'add', 'origin', `git@github.com:${join(dir, 'remote.git')}`], work)
+  const env = { ...process.env, GIT_SSH_COMMAND: ssh, GIT_TERMINAL_PROMPT: '0' }
+  // Proves the transport works: this one has to succeed through the same fake ssh.
+  await execFileAsync('git', ['push', '-q', 'origin', 'HEAD:refs/heads/main'], { cwd: work, env })
+  try {
+    await execFileAsync('git', ['fetch', 'origin', 'refs/heads/does-not-exist'], { cwd: work, env })
+  } catch (error) {
+    return error as Error
+  }
+  throw new Error('git fetch unexpectedly succeeded')
 }
 
 /** Electron rewraps every rejected `ipcMain.handle` before the renderer reads it. */
@@ -155,6 +212,78 @@ describe('a failing git remote operation keeps its cause', () => {
 
       expect(toast).toBe('Fetch failed. Host key verification failed.')
       expect(toast).not.toContain('@@@')
+      expect(toast).not.toContain('/Users/example')
+    })
+  })
+
+  describe('when the transport worked, the failure git names is git’s own', () => {
+    const GIT_VERDICT = "couldn't find remote ref refs/heads/does-not-exist"
+
+    it.each([
+      ['a missing identity file', REAL_SSH_NO_SUCH_IDENTITY],
+      ['a key with loose permissions', REAL_SSH_UNPROTECTED_KEY]
+    ] as const)(
+      'shows it, not what ssh said on the way past (%s)',
+      async (_case, advisory) => {
+        const failure = await runGitFailureOverWorkingTransport(advisory)
+        const produced = normalizeGitErrorMessage(failure, 'fetch')
+
+        // The producer still hands on everything, so the log keeps the advisory too.
+        expect(produced).toContain('/Users/example')
+
+        for (const [channel, options] of [
+          ['git:fetch', { isFetch: true }],
+          ['git:push', { isPush: true }],
+          ['git:pull', undefined]
+        ] as const) {
+          const toast = resolveRemoteOperationErrorMessage(
+            asRendererSeesIt(channel, produced),
+            options
+          )
+
+          expect(toast).toContain(GIT_VERDICT)
+          // ssh's advisories are the only lines here that name the user's home, and none of them
+          // is the reason the fetch failed.
+          expect(toast).not.toContain('/Users/example')
+        }
+      },
+      60_000
+    )
+
+    it('is not a matter of recognising ssh: git’s own progress line loses too', () => {
+      // Real `git pull` output over a working transport. `From …` and `* branch … -> FETCH_HEAD`
+      // are git's, printed on a non-tty, and sit between the advisory and the verdict.
+      const produced = [
+        'no such identity: /Users/example/.ssh/id_ed25519: No such file or directory\r',
+        'From ssh://git@github.com/acme/repo',
+        ' * branch            main       -> FETCH_HEAD',
+        'fatal: refusing to merge unrelated histories'
+      ].join('\n')
+
+      expect(resolveRemoteOperationErrorMessage(asRendererSeesIt('git:pull', produced))).toBe(
+        'refusing to merge unrelated histories'
+      )
+    })
+
+    it('keeps the advisory out of the fallback that runs when no line stood out', () => {
+      // Captured from a real `git fetch` whose remote-ref directory was not writable: no `fatal:`
+      // and no `remote:` line at all, so the scan finds no candidate and the raw fallback runs.
+      // Every line but the last names a path; two of them are under the user's home.
+      const produced = [
+        'no such identity: /Users/example/.ssh/id_ed25519: No such file or directory\r',
+        "error: cannot lock ref 'refs/remotes/origin/newbr': Unable to create " +
+          "'/Users/example/repo/.git/refs/remotes/origin/newbr.lock': Permission denied",
+        'From ssh://git@github.com/acme/repo',
+        ' ! [new branch]      newbr      -> origin/newbr  (unable to update local ref)'
+      ].join('\n')
+
+      const toast = resolveRemoteOperationErrorMessage(asRendererSeesIt('git:fetch', produced), {
+        isFetch: true
+      })
+
+      expect(toast).toBe(
+        'Fetch failed. ! [new branch]      newbr      -> origin/newbr  (unable to update local ref)'
+      )
       expect(toast).not.toContain('/Users/example')
     })
   })

--- a/src/renderer/src/lib/source-control-remote-error.test.ts
+++ b/src/renderer/src/lib/source-control-remote-error.test.ts
@@ -2,10 +2,76 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { resolveRemoteOperationErrorMessage } from './source-control-remote-error'
 
+// Why: an exec rejection whose stderr was empty reaches the renderer with an empty `message`.
+// Built by assignment because `new Error('')` is the very thing the lint rule forbids writing.
+function withMessage(message: string): Error {
+  const error = new Error('replaced below')
+  error.message = message
+  return error
+}
+
 describe('source-control remote error formatting', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
+
+  describe('a toast that says nothing is worse than a generic one', () => {
+    // Why: the producer elides the middle of an oversized blob with this marker. It is Orca's own
+    // bookkeeping, so a toast reading "[…]" tells the user only that something was cut.
+    const ELIDED = `${'remote: policy note\n'.repeat(3)}[\u2026]\nfatal: Could not read from remote repository.`
+
+    it('never shows the truncation marker as the reason', () => {
+      expect(resolveRemoteOperationErrorMessage(new Error(ELIDED), { isPush: true })).toBe(
+        'Push failed. Could not read from remote repository. Check your remote access and try again.'
+      )
+      expect(resolveRemoteOperationErrorMessage(new Error(ELIDED), undefined)).toBe(
+        'Could not read from remote repository.'
+      )
+    })
+
+    it.each([
+      [undefined, 'Remote operation failed'],
+      [{ isFetch: true }, 'Fetch failed. Check your connection and try again.'],
+      [{ isFastForward: true }, 'Fast-forward failed. Check your connection and try again.'],
+      [{ isRebase: true }, 'Rebase failed. Check your connection and try again.']
+    ] as const)('falls back to words when there is no detail at all (%#)', (options, expected) => {
+      // Absent must not become empty: an error carrying nothing, and Electron's wrapper around one.
+      expect(resolveRemoteOperationErrorMessage(withMessage(''), options)).toBe(expected)
+      expect(
+        resolveRemoteOperationErrorMessage(
+          new Error("Error invoking remote method 'git:fetch': Error: "),
+          options
+        )
+      ).toBe(expected)
+    })
+
+    it('does not let a bare remote: line blank out a toast that had something to say', () => {
+      // An empty `remote:` payload used to latch as the detail, so the readable line below it
+      // never reached the user.
+      const toast = resolveRemoteOperationErrorMessage(
+        new Error('remote: \nConnection closed by 140.82.114.4 port 22'),
+        { isFetch: true }
+      )
+
+      expect(toast).toContain('Connection closed by 140.82.114.4 port 22')
+      expect(toast).not.toBe('Fetch failed. ')
+    })
+  })
+
+  it.each([
+    [{ isFetch: true }, 'Fetch failed. Connection closed by 140.82.114.4 port 22'],
+    [{ isFastForward: true }, 'Fast-forward failed. Connection closed by 140.82.114.4 port 22'],
+    [{ isRebase: true }, 'Rebase failed. Connection closed by 140.82.114.4 port 22']
+  ] as const)(
+    'keeps Electron\u2019s IPC wrapper out of the no-line-stood-out fallback (%#)',
+    (options, expected) => {
+      const error = new Error(
+        "Error invoking remote method 'git:fetch': Error: Connection closed by 140.82.114.4 port 22"
+      )
+
+      expect(resolveRemoteOperationErrorMessage(error, options)).toBe(expected)
+    }
+  )
 
   it('prefers fatal detail over an earlier remote detail for publish failures', () => {
     const error = new Error('remote: protected branch\r\nfatal: Authentication failed\r\n')

--- a/src/renderer/src/lib/source-control-remote-error.test.ts
+++ b/src/renderer/src/lib/source-control-remote-error.test.ts
@@ -69,7 +69,7 @@ describe('source-control remote error formatting', () => {
     )
 
     expect(resolveRemoteOperationErrorMessage(protectedError, { isPush: true })).toBe(
-      'Push failed. error: GH006 protected branch update failed.. Check your remote access and try again.'
+      'Push failed. error: GH006 protected branch update failed. Check your remote access and try again.'
     )
     expect(resolveRemoteOperationErrorMessage(preReceiveError, { isPush: true })).toBe(
       'Push failed. pre-receive hook declined. Check your remote access and try again.'

--- a/src/renderer/src/lib/source-control-remote-error.ts
+++ b/src/renderer/src/lib/source-control-remote-error.ts
@@ -34,6 +34,14 @@ function withoutTrailingPeriod(detail: string): string {
 const IPC_INVOKE_PREFIX = /^Error invoking remote method '[^']*': (?:\w*Error: )?/
 /** Node's execFile rejection preamble names the argv Orca ran, so such a line is never git's own reason. */
 const COMMAND_PREAMBLE_LINE = /Command failed:/
+/**
+ * The one `fatal:` that diagnoses nothing: it says git never got to talk to the remote, and hands the
+ * question upstream to whatever did the talking. Every other `fatal:` is git's own finding, reached
+ * over a transport that worked, so nothing ssh printed before it can outrank it. Kept to this single
+ * verdict deliberately: it is the only one where ssh is guaranteed to have stated its own reason last
+ * (a denial, a refused connection, a host-key failure), so deferring cannot surface a bare advisory.
+ */
+const GIT_DEFERS_TO_TRANSPORT = /^Could not read from remote repository/i
 
 // Why: a detail is either something to show or nothing at all. An empty string is neither — it
 // survives every `??` below and reaches the user as a blank toast, which says less than a generic one.
@@ -51,11 +59,14 @@ function extractPublishFailureDetail(message: string): string | null {
       continue
     }
     if (line.startsWith('fatal:')) {
-      // Why: git states the transport's own reason first, then wraps it in a generic `fatal:`
-      // line ("Could not read from remote repository."). The earlier line is the actionable one.
+      // Why: whose finding this is, not where it sits. git defers to the transport only when its own
+      // verdict is the "never delivered" wrapper; then the reason is the transport's last word above.
+      // Otherwise git reached the remote and diagnosed the failure itself, and ssh's preamble is noise
+      // that carries identity-file and known_hosts paths out of the user's home.
+      const verdict = line.slice('fatal:'.length).trim()
       return (
-        causeBeforeFatal ??
-        emptyToNull(truncateDetail(stripCredentialsFromMessage(line.slice('fatal:'.length).trim())))
+        (GIT_DEFERS_TO_TRANSPORT.test(verdict) ? causeBeforeFatal : null) ??
+        emptyToNull(truncateDetail(stripCredentialsFromMessage(verdict)))
       )
     }
     if (line.startsWith('remote:')) {
@@ -71,10 +82,9 @@ function extractPublishFailureDetail(message: string): string | null {
     // names Orca's argv rather than anything git reported, and the elision marker is our own
     // truncation bookkeeping — showing it as the reason tells the user nothing at all.
     if (!COMMAND_PREAMBLE_LINE.test(line) && line !== GIT_FAILURE_DETAIL_ELISION_MARKER) {
-      // Why: the *last* such line, not the first. Real ssh prints its own preamble ahead of the
-      // denial — `Warning: Identity file <home path> not accessible`, `Warning: Permanently
-      // added …` — so keeping the first hides `Permission denied (publickey)` behind noise and
-      // puts a home-directory path in the toast. The line nearest git's verdict is the cause.
+      // Why: the *last* such line, not the first — within the transport's own output. ssh states its
+      // verdict as it gives up, after every advisory it had to offer (`no such identity: <home
+      // path>`, `Load key "<home path>": bad permissions`, the changed-host-key banner).
       causeBeforeFatal = truncateDetail(stripCredentialsFromMessage(line))
     }
   }
@@ -103,12 +113,20 @@ function* iterateRemoteErrorLines(message: string): Generator<string> {
   }
 }
 
-// Why: the last resort when no line stood out. Electron's `Error invoking remote method …` wrapper is
-// Orca's own framing, never git's, so it is stripped here the same way the line scan strips it.
+// Why: the last resort when no line stood out — and still a line, never the blob. git's closing
+// diagnostic is last; everything above it can be ssh's preamble, which names files under the user's
+// home. Electron's `Error invoking remote method …` wrapper is Orca's own framing, never git's, so it
+// is stripped here the same way the line scan strips it.
 function rawMessageDetail(message: string): string | null {
-  return emptyToNull(
-    truncateDetail(stripCredentialsFromMessage(message.replace(IPC_INVOKE_PREFIX, '')).trim())
-  )
+  const scrubbed = stripCredentialsFromMessage(message.replace(IPC_INVOKE_PREFIX, ''))
+  let lastDiagnostic = ''
+  for (const rawLine of iterateRemoteErrorLines(scrubbed)) {
+    const line = rawLine.trim()
+    if (line && line !== GIT_FAILURE_DETAIL_ELISION_MARKER) {
+      lastDiagnostic = line
+    }
+  }
+  return emptyToNull(truncateDetail(lastDiagnostic))
 }
 
 function resolveSubmodulePushFailureMessage(

--- a/src/renderer/src/lib/source-control-remote-error.ts
+++ b/src/renderer/src/lib/source-control-remote-error.ts
@@ -23,21 +23,45 @@ function truncateDetail(detail: string): string {
   return `${detail.slice(0, REMOTE_OPERATION_DETAIL_MAX_LENGTH).trimEnd()}...`
 }
 
+// Why: git's own lines usually end in a period, and the "…. Check your remote access" templates below
+// append their own — without this the toast reads "Permission denied (publickey)..".
+function withoutTrailingPeriod(detail: string): string {
+  return detail.endsWith('.') ? detail.slice(0, -1) : detail
+}
+
+/** Electron wraps every rejected `ipcMain.handle` before the renderer sees it, on the first line only. */
+const IPC_INVOKE_PREFIX = /^Error invoking remote method '[^']*': (?:\w*Error: )?/
+/** Node's execFile rejection preamble names the argv Orca ran, so such a line is never git's own reason. */
+const COMMAND_PREAMBLE_LINE = /Command failed:/
+
 function extractPublishFailureDetail(message: string): string | null {
   let remoteDetail: string | null = null
+  let causeBeforeFatal: string | null = null
 
   for (const rawLine of iterateRemoteErrorLines(message)) {
-    const line = rawLine.trim()
+    const line = rawLine.trim().replace(IPC_INVOKE_PREFIX, '')
     if (!line) {
       continue
     }
     if (line.startsWith('fatal:')) {
-      return truncateDetail(stripCredentialsFromMessage(line.slice('fatal:'.length).trim()))
+      // Why: git states the transport's own reason first, then wraps it in a generic `fatal:`
+      // line ("Could not read from remote repository."). The earlier line is the actionable one.
+      return (
+        causeBeforeFatal ??
+        truncateDetail(stripCredentialsFromMessage(line.slice('fatal:'.length).trim()))
+      )
     }
-    if (remoteDetail === null && line.startsWith('remote:')) {
-      remoteDetail = truncateDetail(
+    if (line.startsWith('remote:')) {
+      remoteDetail ??= truncateDetail(
         stripCredentialsFromMessage(line.slice('remote:'.length).trim())
       )
+      continue
+    }
+    // Why: only git's own local transport lines count as the cause. `remote:` is server chatter
+    // (progress, policy notes) that git's `fatal:` verdict should still outrank, and a wrapper
+    // preamble names Orca's argv rather than anything git reported.
+    if (!COMMAND_PREAMBLE_LINE.test(line)) {
+      causeBeforeFatal ??= truncateDetail(stripCredentialsFromMessage(line))
     }
   }
 
@@ -254,7 +278,7 @@ export function resolveRemoteOperationErrorMessage(
     // keeps the toast human-readable while preserving the actionable fatal reason.
     const detail = extractPublishFailureDetail(error.message)
     if (detail) {
-      return `Publish Branch failed. ${detail}. Check your remote access and try again.`
+      return `Publish Branch failed. ${withoutTrailingPeriod(detail)}. Check your remote access and try again.`
     }
 
     return 'Publish Branch failed. Check your remote access and try again.'
@@ -266,7 +290,7 @@ export function resolveRemoteOperationErrorMessage(
     // auth / protected-branch reasons stay actionable.
     const detail = extractPublishFailureDetail(error.message)
     if (detail) {
-      return `Sync failed. ${detail}. Check your remote access and try again.`
+      return `Sync failed. ${withoutTrailingPeriod(detail)}. Check your remote access and try again.`
     }
     return 'Sync failed. Check your connection and try again.'
   }
@@ -274,7 +298,7 @@ export function resolveRemoteOperationErrorMessage(
   if (options?.isForcePush) {
     const detail = extractPublishFailureDetail(error.message)
     if (detail) {
-      return `Force Push failed. ${detail}. Check your remote access and try again.`
+      return `Force Push failed. ${withoutTrailingPeriod(detail)}. Check your remote access and try again.`
     }
     return 'Force Push failed. Check your connection and try again.'
   }
@@ -284,7 +308,7 @@ export function resolveRemoteOperationErrorMessage(
     // connection message for auth errors, protected branches, etc.
     const detail = extractPublishFailureDetail(error.message)
     if (detail) {
-      return `Push failed. ${detail}. Check your remote access and try again.`
+      return `Push failed. ${withoutTrailingPeriod(detail)}. Check your remote access and try again.`
     }
     return 'Push failed. Check your connection and try again.'
   }
@@ -310,7 +334,12 @@ export function resolveRemoteOperationErrorMessage(
     return `Rebase failed. ${detail}`
   }
 
-  return error.message
+  // Why: unlabeled callers (Pull) share the toast's one-line budget, and git output reaching here is
+  // multi-line, so pick the same actionable line the labeled operations do instead of dumping the blob.
+  return (
+    extractPublishFailureDetail(error.message) ??
+    truncateDetail(stripCredentialsFromMessage(error.message.replace(IPC_INVOKE_PREFIX, '')))
+  )
 }
 
 export { isNonFastForwardRemoteError }

--- a/src/renderer/src/lib/source-control-remote-error.ts
+++ b/src/renderer/src/lib/source-control-remote-error.ts
@@ -1,5 +1,6 @@
 import {
   formatSubmodulePushFailureDetail,
+  GIT_FAILURE_DETAIL_ELISION_MARKER,
   stripCredentialsFromMessage
 } from '../../../shared/git-remote-error'
 import {
@@ -34,6 +35,12 @@ const IPC_INVOKE_PREFIX = /^Error invoking remote method '[^']*': (?:\w*Error: )
 /** Node's execFile rejection preamble names the argv Orca ran, so such a line is never git's own reason. */
 const COMMAND_PREAMBLE_LINE = /Command failed:/
 
+// Why: a detail is either something to show or nothing at all. An empty string is neither — it
+// survives every `??` below and reaches the user as a blank toast, which says less than a generic one.
+function emptyToNull(detail: string): string | null {
+  return detail.length > 0 ? detail : null
+}
+
 function extractPublishFailureDetail(message: string): string | null {
   let remoteDetail: string | null = null
   let causeBeforeFatal: string | null = null
@@ -48,20 +55,27 @@ function extractPublishFailureDetail(message: string): string | null {
       // line ("Could not read from remote repository."). The earlier line is the actionable one.
       return (
         causeBeforeFatal ??
-        truncateDetail(stripCredentialsFromMessage(line.slice('fatal:'.length).trim()))
+        emptyToNull(truncateDetail(stripCredentialsFromMessage(line.slice('fatal:'.length).trim())))
       )
     }
     if (line.startsWith('remote:')) {
-      remoteDetail ??= truncateDetail(
-        stripCredentialsFromMessage(line.slice('remote:'.length).trim())
+      // Why: a bare `remote:` with nothing after it is not a detail — `??=` would latch the empty
+      // string and every `?? fallback` below would then keep it, blanking the toast.
+      remoteDetail ??= emptyToNull(
+        truncateDetail(stripCredentialsFromMessage(line.slice('remote:'.length).trim()))
       )
       continue
     }
     // Why: only git's own local transport lines count as the cause. `remote:` is server chatter
-    // (progress, policy notes) that git's `fatal:` verdict should still outrank, and a wrapper
-    // preamble names Orca's argv rather than anything git reported.
-    if (!COMMAND_PREAMBLE_LINE.test(line)) {
-      causeBeforeFatal ??= truncateDetail(stripCredentialsFromMessage(line))
+    // (progress, policy notes) that git's `fatal:` verdict should still outrank, a wrapper preamble
+    // names Orca's argv rather than anything git reported, and the elision marker is our own
+    // truncation bookkeeping — showing it as the reason tells the user nothing at all.
+    if (!COMMAND_PREAMBLE_LINE.test(line) && line !== GIT_FAILURE_DETAIL_ELISION_MARKER) {
+      // Why: the *last* such line, not the first. Real ssh prints its own preamble ahead of the
+      // denial — `Warning: Identity file <home path> not accessible`, `Warning: Permanently
+      // added …` — so keeping the first hides `Permission denied (publickey)` behind noise and
+      // puts a home-directory path in the toast. The line nearest git's verdict is the cause.
+      causeBeforeFatal = truncateDetail(stripCredentialsFromMessage(line))
     }
   }
 
@@ -87,6 +101,14 @@ function* iterateRemoteErrorLines(message: string): Generator<string> {
   if (lineStart <= message.length) {
     yield message.slice(lineStart)
   }
+}
+
+// Why: the last resort when no line stood out. Electron's `Error invoking remote method …` wrapper is
+// Orca's own framing, never git's, so it is stripped here the same way the line scan strips it.
+function rawMessageDetail(message: string): string | null {
+  return emptyToNull(
+    truncateDetail(stripCredentialsFromMessage(message.replace(IPC_INVOKE_PREFIX, '')).trim())
+  )
 }
 
 function resolveSubmodulePushFailureMessage(
@@ -314,31 +336,30 @@ export function resolveRemoteOperationErrorMessage(
   }
 
   if (options?.isFetch) {
-    const detail =
-      extractPublishFailureDetail(error.message) ??
-      truncateDetail(stripCredentialsFromMessage(error.message))
-    return `Fetch failed. ${detail}`
+    const detail = extractPublishFailureDetail(error.message) ?? rawMessageDetail(error.message)
+    return detail ? `Fetch failed. ${detail}` : 'Fetch failed. Check your connection and try again.'
   }
 
   if (options?.isFastForward) {
-    const detail =
-      extractPublishFailureDetail(error.message) ??
-      truncateDetail(stripCredentialsFromMessage(error.message))
-    return `Fast-forward failed. ${detail}`
+    const detail = extractPublishFailureDetail(error.message) ?? rawMessageDetail(error.message)
+    return detail
+      ? `Fast-forward failed. ${detail}`
+      : 'Fast-forward failed. Check your connection and try again.'
   }
 
   if (options?.isRebase) {
-    const detail =
-      extractPublishFailureDetail(error.message) ??
-      truncateDetail(stripCredentialsFromMessage(error.message))
-    return `Rebase failed. ${detail}`
+    const detail = extractPublishFailureDetail(error.message) ?? rawMessageDetail(error.message)
+    return detail
+      ? `Rebase failed. ${detail}`
+      : 'Rebase failed. Check your connection and try again.'
   }
 
   // Why: unlabeled callers (Pull) share the toast's one-line budget, and git output reaching here is
   // multi-line, so pick the same actionable line the labeled operations do instead of dumping the blob.
   return (
     extractPublishFailureDetail(error.message) ??
-    truncateDetail(stripCredentialsFromMessage(error.message.replace(IPC_INVOKE_PREFIX, '')))
+    rawMessageDetail(error.message) ??
+    REMOTE_OPERATION_FAILED_MESSAGE
   )
 }
 

--- a/src/shared/git-remote-error.test.ts
+++ b/src/shared/git-remote-error.test.ts
@@ -60,8 +60,17 @@ describe('normalizeGitErrorMessage', () => {
       ].join('\n')
     )
 
-    expect(normalizeGitErrorMessage(error, 'push')).toBe(
-      "error: failed to push some refs to 'origin'"
+    const message = normalizeGitErrorMessage(error, 'push')
+
+    // Not routed through the pre-push-hook branch, which keeps the `Command failed:` argv line.
+    expect(message).not.toContain('Command failed:')
+    // The server's reason survives alongside git's closing line instead of being cut down to it.
+    expect(message).toBe(
+      [
+        'remote: pre-receive hook declined',
+        'remote: eslint failed in hosted checks',
+        "error: failed to push some refs to 'origin'"
+      ].join('\n')
     )
   })
 
@@ -79,13 +88,22 @@ describe('normalizeGitErrorMessage', () => {
     )
   })
 
-  it('uses the tail diagnostic from newline-heavy failures without line-array splitting', () => {
+  it('bounds a newline-heavy failure from both ends without line-array splitting', () => {
     const splitSpy = vi.spyOn(String.prototype, 'split')
     const error = new Error(
       `Command failed: git fetch\r\n${'remote: progress update\r\n'.repeat(10_000)}remote side closed connection\r\n`
     )
 
-    expect(normalizeGitErrorMessage(error, 'fetch')).toBe('remote side closed connection')
+    const message = normalizeGitErrorMessage(error, 'fetch')
+
+    // Both ends survive the cap: whatever git said first, and its closing diagnostic.
+    expect(message.startsWith('remote: progress update')).toBe(true)
+    expect(message.endsWith('remote side closed connection')).toBe(true)
+    expect(message).toContain('[\u2026]')
+    // The argv line is not part of git's output and must not reach the renderer.
+    expect(message).not.toContain('Command failed:')
+    // Bounded so a multi-megabyte hook transcript cannot ride the IPC reply.
+    expect(message.length).toBeLessThanOrEqual(4_100)
 
     const usedLineSplit = splitSpy.mock.calls.some(
       ([separator]) =>

--- a/src/shared/git-remote-error.test.ts
+++ b/src/shared/git-remote-error.test.ts
@@ -88,6 +88,22 @@ describe('normalizeGitErrorMessage', () => {
     )
   })
 
+  it('says something when git said nothing, instead of handing on Orca\u2019s argv', () => {
+    const error = new Error(
+      'Command failed: git -C /Users/example/repo fetch --prune\n'
+    ) as Error & {
+      stderr: string
+    }
+    error.stderr = ''
+
+    const message = normalizeGitErrorMessage(error, 'fetch')
+
+    expect(message).toBe('Git remote operation failed.')
+    // The argv is Orca's, not git's, and it names a local path.
+    expect(message).not.toContain('Command failed:')
+    expect(message).not.toContain('/Users/example')
+  })
+
   it('bounds a newline-heavy failure from both ends without line-array splitting', () => {
     const splitSpy = vi.spyOn(String.prototype, 'split')
     const error = new Error(

--- a/src/shared/git-remote-error.ts
+++ b/src/shared/git-remote-error.ts
@@ -51,6 +51,8 @@ const COMMAND_FAILED_PREAMBLE_PATTERN = /^Command failed:[^\n]*\n/
 // one line, so the cause (first) and git's verdict (last) both cross IPC. Sliced, never line-split.
 const MAX_GIT_FAILURE_DETAIL_LENGTH = 4_000
 const GIT_FAILURE_DETAIL_HEAD_LENGTH = 3_000
+// Why: shared with the display layer, which must never show the marker as if it were a git diagnostic.
+export const GIT_FAILURE_DETAIL_ELISION_MARKER = '[…]'
 
 function readGitFailureDetail(error: Error): string {
   const { stderr } = error as { stderr?: unknown }
@@ -60,12 +62,18 @@ function readGitFailureDetail(error: Error): string {
       : error.message.replace(COMMAND_FAILED_PREAMBLE_PATTERN, '')
   // No line selection here: git prints the cause first and generic advice last, so keeping only one
   // line discards whichever half the caller needed. The display layer picks the line it can fit.
+  //
+  // Careful — this blob still carries local paths and env. Real ssh puts
+  // `Warning: Identity file <home path> not accessible` ahead of the denial, and a server hook can
+  // echo anything. Credential scrubbing is not path scrubbing and a toast character cap is not
+  // redaction, so whatever renders this must pick a line rather than dump the blob; see
+  // extractPublishFailureDetail in src/renderer/src/lib/source-control-remote-error.ts.
   const detail = stripCredentialsFromMessage(text).trim()
   if (detail.length <= MAX_GIT_FAILURE_DETAIL_LENGTH) {
     return detail
   }
   const tailLength = MAX_GIT_FAILURE_DETAIL_LENGTH - GIT_FAILURE_DETAIL_HEAD_LENGTH
-  return `${detail.slice(0, GIT_FAILURE_DETAIL_HEAD_LENGTH).trimEnd()}\n[…]\n${detail.slice(-tailLength).trimStart()}`
+  return `${detail.slice(0, GIT_FAILURE_DETAIL_HEAD_LENGTH).trimEnd()}\n${GIT_FAILURE_DETAIL_ELISION_MARKER}\n${detail.slice(-tailLength).trimStart()}`
 }
 
 // Why: Git 2.27+ refuses divergent pulls when no pull.rebase/pull.ff policy is set; detected so callers can retry as merge.
@@ -110,9 +118,11 @@ export function isExecKilledError(error: unknown): boolean {
 
 export type GitRemoteOperation = 'push' | 'pull' | 'fetch' | 'upstream'
 
+const GIT_REMOTE_OPERATION_FAILED_MESSAGE = 'Git remote operation failed.'
+
 export function normalizeGitErrorMessage(error: unknown, operation?: GitRemoteOperation): string {
   if (!(error instanceof Error)) {
-    return 'Git remote operation failed.'
+    return GIT_REMOTE_OPERATION_FAILED_MESSAGE
   }
 
   // Why: scrub credentials up-front so every downstream branch operates on already-redacted text.
@@ -168,8 +178,9 @@ export function normalizeGitErrorMessage(error: unknown, operation?: GitRemoteOp
   }
 
   // Fallthrough: nothing above recognized this failure, so hand the whole credential-scrubbed
-  // git output on rather than guessing which line mattered.
-  return readGitFailureDetail(error) || raw.trim()
+  // git output on rather than guessing which line mattered. When git itself said nothing, say that
+  // — an empty string renders as a blank toast, and all `raw` holds here is Orca's own argv.
+  return readGitFailureDetail(error) || GIT_REMOTE_OPERATION_FAILED_MESSAGE
 }
 
 // Why: require a `fatal:` prefix so wrapped command text or hook/progress output can't spuriously match and mask real failures.

--- a/src/shared/git-remote-error.ts
+++ b/src/shared/git-remote-error.ts
@@ -42,36 +42,30 @@ export function formatSubmodulePushFailureDetail(message: string): string | null
   return `${subject} could not be pushed. Resolve the submodule push error, then try again.`
 }
 
-function extractTailLine(message: string): string {
-  // Why: last non-empty stderr line is the diagnostic; the full blob risks leaking local paths/env to the UI.
-  for (const rawLine of iterateLinesFromEnd(message)) {
-    const line = rawLine.trim()
-    if (line.length > 0) {
-      return line
-    }
+// Why: Node's execFile rejection prefixes `.message` with the argv it ran; `.stderr` is git's own bytes.
+// Mirrors extractExecError in src/main/git/exec-error.ts, which this module cannot import — the renderer
+// and the relay both bundle src/shared.
+const COMMAND_FAILED_PREAMBLE_PATTERN = /^Command failed:[^\n]*\n/
+
+// Why: a server-side hook or a progress-heavy transfer can emit megabytes; keep both ends rather than
+// one line, so the cause (first) and git's verdict (last) both cross IPC. Sliced, never line-split.
+const MAX_GIT_FAILURE_DETAIL_LENGTH = 4_000
+const GIT_FAILURE_DETAIL_HEAD_LENGTH = 3_000
+
+function readGitFailureDetail(error: Error): string {
+  const { stderr } = error as { stderr?: unknown }
+  const text =
+    typeof stderr === 'string' && stderr.trim().length > 0
+      ? stderr
+      : error.message.replace(COMMAND_FAILED_PREAMBLE_PATTERN, '')
+  // No line selection here: git prints the cause first and generic advice last, so keeping only one
+  // line discards whichever half the caller needed. The display layer picks the line it can fit.
+  const detail = stripCredentialsFromMessage(text).trim()
+  if (detail.length <= MAX_GIT_FAILURE_DETAIL_LENGTH) {
+    return detail
   }
-  return message
-}
-
-function* iterateLinesFromEnd(value: string): Generator<string> {
-  let lineEnd = value.length
-  let index = value.length - 1
-
-  while (index >= 0) {
-    const code = value.charCodeAt(index)
-    if (code !== 10 && code !== 13) {
-      index--
-      continue
-    }
-
-    const delimiterStart =
-      code === 10 && index > 0 && value.charCodeAt(index - 1) === 13 ? index - 1 : index
-    yield value.slice(index + 1, lineEnd)
-    lineEnd = delimiterStart
-    index = delimiterStart - 1
-  }
-
-  yield value.slice(0, lineEnd)
+  const tailLength = MAX_GIT_FAILURE_DETAIL_LENGTH - GIT_FAILURE_DETAIL_HEAD_LENGTH
+  return `${detail.slice(0, GIT_FAILURE_DETAIL_HEAD_LENGTH).trimEnd()}\n[…]\n${detail.slice(-tailLength).trimStart()}`
 }
 
 // Why: Git 2.27+ refuses divergent pulls when no pull.rebase/pull.ff policy is set; detected so callers can retry as merge.
@@ -173,8 +167,9 @@ export function normalizeGitErrorMessage(error: unknown, operation?: GitRemoteOp
     return 'Pull would overwrite untracked files. Move, remove, or add them before pulling.'
   }
 
-  // Fallthrough: raw was already credential-scrubbed at top, so just extract the tail stderr line.
-  return extractTailLine(raw)
+  // Fallthrough: nothing above recognized this failure, so hand the whole credential-scrubbed
+  // git output on rather than guessing which line mattered.
+  return readGitFailureDetail(error) || raw.trim()
 }
 
 // Why: require a `fatal:` prefix so wrapped command text or hook/progress output can't spuriously match and mask real failures.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​404 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​399 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​129 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​55 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 |

<!-- /orca-pr-loc -->

## ELI5

When a `git push` fails over SSH, the reason and the advice are at opposite ends of the output — and neither end is the first line, because **ssh gets to talk before git does**:

```
Warning: Identity file /Users/you/.ssh/id_ed25519 not accessible: No such file or directory.
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
git@github.com: Permission denied (publickey).      <-- the reason
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.                          <-- the advice
```

Orca's main process was keeping **only the last line**, so the one sentence that made it across was `and the repository exists.` — and because that sentence has no `fatal:` or `remote:` prefix, the renderer's detail extractor found nothing to show and fell back to a generic message. A credentials failure told the user to check their **connection**.

This keeps the whole thing and lets the UI pick the useful line. "The useful line" is decided by **whose finding it is**, not by where it sits.

git's `fatal:` line is normally its own verdict, and it wins. There is exactly one `fatal:` that diagnoses nothing — `Could not read from remote repository.` — and it means git never got to talk to the remote. Only then is the reason upstream, and only then does the line above it win. That is what makes both halves of the matrix come out right: when the transport failed, the toast shows ssh's verdict; when the transport worked, it shows git's.

## User-facing before / after

Measured end-to-end on **real bytes**. The stderr below is transcribed from a live `git push` to github.com through the **real ssh binary** with a missing identity file; the committed test replays those bytes through a real `git push`, so git itself still writes the wrapper.

| Surface | On `main` | After |
| --- | --- | --- |
| Push toast | `Push failed. Check your connection and try again.` | `Push failed. git@github.com: Permission denied (publickey). Check your remote access and try again.` |
| Fetch toast | `Fetch failed. Error invoking remote method 'git:fetch': Error: and the repository exists.` | `Fetch failed. git@github.com: Permission denied (publickey).` |
| Pull toast | `Error invoking remote method 'git:pull': Error: and the repository exists.` | `git@github.com: Permission denied (publickey).` |

A second real-ssh case, a changed host key, exercises the same selection — thirteen lines of banner, fingerprint and two `known_hosts` paths, ending in ssh's verdict:

| Surface | On `main` | After |
| --- | --- | --- |
| Fetch toast | `Fetch failed. Error invoking remote method 'git:fetch': Error: and the repository exists.` | `Fetch failed. Host key verification failed.` |

## What changed

**Producer — `src/shared/git-remote-error.ts`.** `normalizeGitErrorMessage`'s fallthrough called `extractTailLine`, which kept only the last non-empty stderr line. The fallthrough now returns git's whole credential-scrubbed output.

Three details that mattered:

- It reads the rejection's **`.stderr`**, not `.message`. Node's `execFile` prefixes `.message` with `Command failed: <argv>`; that argv line is Orca's, not git's, and would otherwise become the "first line". (Same rule as `extractExecError` in `src/main/git/exec-error.ts`, which `src/shared` cannot import — the renderer and the relay both bundle it.)
- The result is **bounded at 4KB, from both ends** (3KB head + 1KB tail with an elision marker), so a multi-megabyte server-side hook transcript cannot ride the IPC reply. Sliced, never line-split — the existing no-line-array-split guard still holds.
- When git said **nothing at all**, the fallthrough says so rather than handing on `raw`, which at that point holds only Orca's own argv — including any local path in it.

`extractTailLine` carried a comment: *"the full blob risks leaking local paths/env to the UI."* That warning is still live, so it is restored on the producer, where it now reads as the reason the display layer must **select a line** rather than dump the blob. Credential scrubbing is not path scrubbing, and a 200-character toast cap is not redaction.

**Display — `src/renderer/src/lib/source-control-remote-error.ts`.** With the full text arriving, the toast needed to pick the right line:

- Prefer the transport's own reason **only over the one `fatal:` line that defers to it** — `Could not read from remote repository.` Against any other `fatal:`, git's own verdict wins. Within the deferring case, take the candidate **nearest git's verdict**: ssh emits its advisories first and its verdict last, so keeping the first candidate surfaces a home-directory path and buries `Permission denied (publickey)`. `remote:` server chatter and wrapper preambles are excluded from the candidate set entirely.
- The no-line-stood-out fallback picks **a line too, never the blob**. It used to hand on the whole (now multi-line) message truncated to 200 characters, which is the one place ssh's preamble could still reach a toast whole.
- The elision marker is Orca's own truncation bookkeeping, never a diagnostic, so it can never be chosen as the reason.
- An empty detail is not a detail. A blank toast says less than a generic one, so every path that had no line to show now falls back to words: `Fetch failed. Check your connection and try again.` and its Fast-forward / Rebase siblings, and `Remote operation failed` for the unlabeled Pull path.
- Strip Electron's `Error invoking remote method '…': Error:` prefix. The line scan already did; the Fetch, Fast-forward and Rebase fallbacks did not, and leaked it whenever no single line stood out.
- Give the unlabeled **Pull** path the same one-line treatment the labeled operations get; it previously returned `error.message` raw, which is now multi-line.
- Drop a trailing period before the `". Check your remote access"` templates, so the toast reads `publickey).` and not `publickey)..`.

**Which surface needs one line, and how the full text is reached.** The toast is the compact surface — 200 characters, `truncateDetail`. The full stderr is not lost: `withGitSpan` → `withSpan` calls `span.fail(err)` on the **raw** execFile rejection, and `formatError` writes `err.message` (the complete stderr) into the span's Failure cause, redacted, in the diagnostics sink. That was already true before this change and is unaffected by it.

**Correction — this change *does* widen what reaches a display surface.** An earlier revision said "nothing here widens what reaches a display surface: the candidate lines are the same set, only the choice among them changed, and the fallbacks now strip strictly more than they did." Both supporting clauses are false, and the headline they support is false with them.

- **The candidate set is larger, not the same.** On `main` `extractPublishFailureDetail` could only ever return a `fatal:` line or a `remote:` line — no other line was reachable as a detail at all. `causeBeforeFatal` adds every remaining non-empty line that is not a wrapper preamble and not the elision marker, which is precisely the set the producer's own comment warns about: ssh's advisories, and the home-directory paths inside them. Upstream of that, `main`'s producer handed the display layer **one line**; this one hands it up to 4KB of git's whole stderr. Two independent widenings, one at each layer.
- **The fallbacks do not strip *strictly* more.** They strip *differently*. `rawMessageDetail` takes the **last** diagnostic line; `main`'s Fetch / Fast-forward / Rebase fallback was `truncateDetail(stripCredentialsFromMessage(error.message))` — the **first 200 characters** of the message. On any message longer than that, the new fallback surfaces text the old one never reached. What is true, and narrower, is that it strips more in three named respects — the IPC preamble, the elision marker, and line-instead-of-blob — and that the unlabeled Pull path went from raw `error.message` to a single line, which is a large reduction. Those are the claims worth making; "strictly more" is not a relation that holds.

The widening is deliberate and is what makes the rule work at all — you cannot prefer git's verdict over ssh's preamble if only one line ever arrives. It also has a measured cost, in the section below.

## Round four: the rule, not another case

The previous round's rule was "the last line before `fatal:`". It is wrong whenever the **transport succeeds and the failure is git-side**, because then there is no transport verdict for the position to find — only ssh's advisories — and one of those becomes the toast.

### Reproduced first, on a fully real stack

Real OpenSSH 10.2p1 client, a real `sshd` started on `127.0.0.1:2233` from a temp directory (its own host key, its own `authorized_keys`; nothing under `~` was read or written), a real bare repo, a real `git`. Two `IdentityFile` entries: one missing, one that authenticates. The push succeeds through the same command, which is what makes it a transport-succeeds case; the fetch then asks for a ref that is not there.

```
no such identity: /Users/example/.ssh/id_ed25519: No such file or directory\r
fatal: couldn't find remote ref refs/heads/does-not-exist
fatal: the remote end hung up unexpectedly
```

The committed test replays those bytes through a fake `GIT_SSH_COMMAND` that **executes the git service it is handed** rather than failing, so git still writes its own half. Its `.stderr` was compared to the live capture and is **byte-identical**.

### Measured differentially against `main`

Same bytes, same three surfaces, on `main` (`de851d5ca7`) and on the previous head (`c3f4126af5`):

| Surface | `main` | Previous head | Now |
| --- | --- | --- | --- |
| Fetch | `Fetch failed. Error invoking remote method 'git:fetch': Error: fatal: the remote end hung up unexpectedly` | `Fetch failed. no such identity: /Users/example/.ssh/id_ed25519: No such file or directory` | `Fetch failed. couldn't find remote ref refs/heads/does-not-exist` |
| Push | `Push failed. Check your connection and try again.` | `Push failed. no such identity: /Users/example/.ssh/id_ed25519: No such file or directory. Check your remote access and try again.` | `Push failed. couldn't find remote ref refs/heads/does-not-exist. Check your remote access and try again.` |
| Pull | `Error invoking remote method 'git:fetch': Error: fatal: the remote end hung up unexpectedly` | `no such identity: /Users/example/.ssh/id_ed25519: No such file or directory` | `couldn't find remote ref refs/heads/does-not-exist` |

`main` puts **no** home-directory path on any of the three. So this was a regression this PR introduced, not a gap it failed to close — which is only visible by measuring against `main`, and is why it is recorded that way here.

### The cases the rule has to distinguish

Every row measured on the same real stack, not constructed:

| # | Transport | Failure | Real stderr shape | Right detail |
| :--- | :--- | :--- | :--- | :--- |
| 1 | fails | transport (credentials) | advisory, `…@…: Permission denied (publickey).`, `fatal: Could not read…`, blank, 2-line advice | ssh's denial |
| 2 | fails | transport (host key) | 13-line banner incl. **two** home paths, `Host key verification failed.`, same `fatal:` wrapper | `Host key verification failed.` |
| 3 | **succeeds** | git-side | advisory, `fatal: couldn't find remote ref …`, `fatal: the remote end hung up unexpectedly` | git's first `fatal:` |
| 4 | succeeds | git-side, with git's own non-`fatal:` lines in between (`From …`, ` * branch … -> FETCH_HEAD`) | as above plus two git lines | git's `fatal:` |
| 5 | succeeds | server-side, `remote:`-prefixed | `remote: …`, `fatal: …` | git's `fatal:` (existing gate G5) |
| 6 | either | no `fatal:` and no `remote:` at all | advisory, `error: cannot lock ref …<home path>…`, `From …`, ` ! [new branch] … (unable to update local ref)` | git's last line |

Rows 3, 4 and 6 are the ones the position rule got wrong. Row 4 also **falsifies the previous round's stated mitigation**: it said git suppresses local progress on a non-tty, so nothing could sit between the cause and the `fatal:`. `From …` and ` * branch … -> FETCH_HEAD` are not progress — they are printed on a non-tty, they were captured that way here, and under the position rule ` * branch            main       -> FETCH_HEAD` became the toast for a `refusing to merge unrelated histories` pull.

### Why not filter ssh's advisories instead

That is the obvious fourth special case, and it does not work. The same capture run produced three advisory shapes, each naming a path, none sharing a prefix:

```
no such identity: /Users/example/.ssh/id_ed25519: No such file or directory
Load key "/Users/example/.ssh/id_ed25519": bad permissions
Add correct host key in /Users/example/.ssh/known_hosts to get rid of this message.
```

The `Warning: Identity file … not accessible` wording this PR was originally built on is an **older** OpenSSH's phrasing; 10.2 does not emit it at all. A `^Warning:` filter would have caught the fixture and none of the real lines. And row 4 shows the problem is not ssh in the first place — git's own progress-adjacent lines lose to a position rule too.

### The rule

**git's `fatal:` line is the reason, unless it is the one `fatal:` that diagnoses nothing.**

`Could not read from remote repository.` says only that git never reached the remote; the reason belongs to whatever was doing the talking, and it is that transport's **last word** — which is where ssh always puts its verdict, after every advisory it had to offer. Every other `fatal:` was reached over a transport that worked, so it is git's own finding and nothing printed before it can outrank it.

The wrapper set is deliberately **one** verdict. `The remote end hung up unexpectedly` was the obvious second candidate and is not included: no fixture pins it (its ablation reddens 0/46), and including it would re-open the leak for a shape where ssh's last word could be a bare advisory. Excluding it costs a less specific — but still correct, and still git's — verdict on a mid-stream hangup, which is what `main` shows today.

Position still decides *within* the transport's own output. That part of round three stands; it is what rows 1 and 2 need, and both are re-confirmed green.

## Proof

Failing-first, ablated at the gate level, one mutation at a time, each mutation verified applied on disk before the run, tree restored and re-verified by hash between runs, ablations serial. Suite = **46** tests across the three suites. Baseline 0/46.

The four new tests were run against the previous head's production file with the new tests in place: **4 red, and the other 42 unaffected.**

**The whole table below was re-measured on this head.** The previous round's numbers were quoted against a 42-test suite and are not reproduced, because three of them have moved and one has gone to zero — a stale ablation table is worse than none.

| Gate | Ablation | Red |
| --- | --- | --- |
| **PC** | positive control: tag every extracted detail so no expected string can match | 10/46 |
| **N** | **display: drop the deferral gate — the round-three rule, i.e. the defect** | **3/46** |
| O | display: treat *every* `fatal:` as a deferral wrapper | 3/46 |
| P | display: treat *no* `fatal:` as a deferral wrapper | 6/46 |
| Q | display: raw fallback dumps the blob again | 1/46 |
| A1 | display: keep the *first* cause candidate (the round-two defect) | 2/46 |
| A2 | display: let the elision marker count as a cause | 1/46 |
| A3a | display: drop the unlabeled (Pull) never-blank fallback | 1/46 |
| A3c | display: let an empty extracted detail count as a detail | 2/46 |
| A4 | display: stop stripping the IPC preamble in the raw fallback | 7/46 |
| A5 | producer: hand on Orca's argv instead of saying git reported nothing | 1/46 |
| G1 | producer: restore last-line truncation (the original defect) | 11/46 |
| G2 | producer: read `.message` verbatim instead of `.stderr` | 3/46 |
| G3 | producer: drop the head+tail size cap | 1/46 |
| G4 | display: drop the cause preference entirely | 6/46 |
| G5 | display: let `remote:` lines count as the cause | 3/46 |
| G7 | display: stop stripping the IPC preamble in the line scan | 3/46 |
| G8 | display: pull fallthrough back to raw `error.message` | 6/46 |
| G9 | display: drop the doubled-period polish | 4/46 |

`N` and `O` redden the same three: the two transport-succeeds cases and the progress-line case. `P` reddens six — the two the earlier rounds fixed, plus four that depend on the preference existing at all. So the deferral test is load-bearing in **both** directions, which is what distinguishes a rule from a special case.

### Three ablations reddened nothing. Which kind of nothing:

| Gate | Ablation | Red | Which meaning |
| --- | --- | --- | --- |
| G6 | display: let a wrapper preamble count as the cause | 0/46 | **clamped.** The one fixture with a `Command failed:` line before a `fatal:` has `fatal: Authentication failed` — not a deferral wrapper — so the new gate answers first and the preamble guard is never consulted. It is still correct for a `Command failed:` line ahead of the wrapper `fatal:`; no fixture has that shape. Reported rather than removed. |
| P2 | display: drop the `^` anchor on the deferral test | 0/46 | **unreachable in this population.** No git verdict embeds the wrapper phrase mid-line. The anchor narrows the rule and is kept as a guard, not as pinned behaviour. |
| P3 | display: add `The remote end hung up unexpectedly` to the wrapper set | 0/46 | **unprotected either way** — nothing distinguishes the two sets. This is the reason it is *excluded*: an unpinned second wrapper would re-open the leak for a shape where ssh's last word is a bare advisory, and no fixture would catch it. |

None of the three is a vacuous test.

**Re-measured after refreshing onto `main`.** `main` moved 17 commits under this branch, including a pnpm major upgrade and new oxlint/oxfmt pins, so every number below was observed on the rebased head from a clean `pnpm install --frozen-lockfile`, in the foreground, rather than carried over. Branch currency read from the compare API rather than the mergeable label: before the refresh `diverged`, ahead 3 / **behind 17**; after, **`ahead`, ahead 3, `behind_by` 0**. CI re-earned on the current base: **19 pass, 7 skipping, 0 failed** — all eight `test / tests node 24` shards, `static analysis`, `package` and `package (windows)` included.

**Regression:** `src/main/git` + `src/relay` + `src/shared` → **915 files / 9809 passed**, 72 skipped, **1 failed**. `src/renderer/src/lib` + source-control components → **482 files / 4602 passed**, 1 skipped, 0 failed.

The one red is not attributable: `src/shared/remote-runtime-subscription-request.test.ts > fails the subscription on a duplicate nested response id` opens a real WebSocket and failed with `remote_runtime_unavailable` under a full-tree run; the same file run in isolation on the same tree is **10 passed**. It touches nothing this PR changes.

**Typecheck:** `pnpm tc` run in the foreground **cold** — `node_modules/.tmp` removed and every `*.tsbuildinfo` deleted first, because it is incremental and a warm cache has returned exit 0 on a tree that does not typecheck. **Exit 0, `error TS` count 0.** Proved non-vacuous the same cold way: planting `const orcaTcProbe2f45: number = 'not a number'` in `src/shared/git-remote-error.ts` gives exit **1** and 6 `error TS` lines, `TS2322` naming that file at line 198; restoring gives exit 0.

**Lint / format:** versions read from `origin/main` at the rebase target, not from a worktree — pnpm **12.0.0**, oxlint **^1.80.0**, oxfmt **^0.65.0**; the installed binaries report pnpm 12.0.0, oxlint 1.80.0, oxfmt 0.65.0, tsc 7.0.2. `oxlint` on all five changed files: exit **0**, stdout **and** stderr retained and both empty (oxlint writes configuration failures to stdout). `oxlint --config config/oxlint-react-doctor.json` on the same five: exit **0**, both streams empty — the exit code read directly, not through a pipe. `oxfmt --check`: "All matched files use the correct format", **5 files**, so the scan is not silently empty. Liveness proved by planting a `debugger` in `source-control-remote-error.ts`: exit **1**, `eslint(no-debugger)` naming line 49; removing it returns exit 0. Run directly rather than through the changed-code quality gate, which is broken on this machine.

## Cross-version note (measured, not assumed)

The relay path (`src/relay/git-handler.ts`) attaches `.stderr` the same way, so SSH and remote hosts get the same fix. No wire-schema change — the field is the same `string`. But a **new relay host** now publishes multi-line text to **old clients**, so the baseline display code was run against the new host message on the real-ssh bytes above:

- old client, push: **improves** — `Push failed. Could not read from remote repository.. Check your remote access and try again.` instead of the generic connection message. (Doubled period: old clients lack the polish.)
- old client, fetch: **improves** — `Fetch failed. Could not read from remote repository.`
- old client, **pull**: **regresses** — the old un-optioned path returns `error.message` raw, so the toast shows the whole multi-line blob, **including the `Warning: Identity file <home path>` line**. This is a path leak to old clients, not merely cosmetic; the previous description of it as cosmetic was wrong. It is bounded to pull on old clients and no data is lost, but it is a real disclosure and it is worth a decision rather than a footnote. New clients are covered by G8.

## Known limitation: a measured 8-surface regression against `main`

An earlier revision framed this as an assumption that no capture had falsified: *"when git says `Could not read from remote repository.`, ssh's last line before it is ssh's verdict and not a bare advisory."* The assumption is right; the framing understated it. Where it does not hold, the result is a **regression against `main` on every one of the eight display surfaces** — not a hypothetical, and not merely cosmetic.

The shape is a transport that fails **without stating a verdict**, so the line above git's wrapper is a bare advisory:

```
no such identity: /Users/example/.ssh/id_ed25519: No such file or directory
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Measured by running those exact bytes through both complete pipelines — `main`'s producer and display (`0a995cc30d`), and this head's — on the same `execFile` rejection, for every option shape `resolveRemoteOperationErrorMessage` branches on:

| Surface | `main` | This head |
| --- | --- | --- |
| Publish Branch | `Publish Branch failed. Check your remote access and try again.` | `Publish Branch failed. no such identity: /Users/example/.ssh/id_ed25519: No such file or directory. Check your remote access and try again.` |
| Sync | `Sync failed. Check your connection and try again.` | `Sync failed. no such identity: /Users/example/.ssh/id_ed25519: No such file or directory. Check your remote access and try again.` |
| Force Push | `Force Push failed. Check your connection and try again.` | `Force Push failed. no such identity: /Users/example/.ssh/id_ed25519: No such file or directory. Check your remote access and try again.` |
| Push | `Push failed. Check your connection and try again.` | `Push failed. no such identity: /Users/example/.ssh/id_ed25519: No such file or directory. Check your remote access and try again.` |
| Fetch | `Fetch failed. and the repository exists.` | `Fetch failed. no such identity: /Users/example/.ssh/id_ed25519: No such file or directory` |
| Fast-forward | `Fast-forward failed. and the repository exists.` | `Fast-forward failed. no such identity: /Users/example/.ssh/id_ed25519: No such file or directory` |
| Rebase | `Rebase failed. and the repository exists.` | `Rebase failed. no such identity: /Users/example/.ssh/id_ed25519: No such file or directory` |
| Pull (unlabeled) | `and the repository exists.` | `no such identity: /Users/example/.ssh/id_ed25519: No such file or directory` |

**8 of 8 surfaces put a home-directory path in the toast on this head. 0 of 8 do on `main`.** That is the cost of the widening described above, and it is the same class of disclosure the module's own comment warns about — `main`'s last-line truncation was accidentally protective here, because git's advice block, not ssh's preamble, is what ends the blob.

### Why nobody has hit it, and exactly what that depends on

The protection is the **SSH client's**, not git's and not Orca's: ssh prints its give-up verdict *after* every advisory it had to offer, so the line above the wrapper is a verdict and never an advisory. Measured directly against a real client on this machine — **OpenSSH_10.2p1, LibreSSL 3.3.6**, with **git 2.50.1** — with `IdentitiesOnly=yes` and a missing identity file, so an advisory is in play in every run:

| Real failure | What ssh actually printed above git's `fatal:` wrapper |
| --- | --- |
| authentication failure against `github.com` | `git@github.com: Permission denied (publickey).` — the `no such identity: <path>` advisory *is* printed, but above the verdict, not last |
| port with nothing listening (`127.0.0.1:2`) | `ssh: connect to host 127.0.0.1 port 2: Connection refused` — no advisory printed at all |
| unresolvable host | `ssh: Could not resolve hostname …` — no advisory printed at all |

So the advisory-last shape does not occur with a stock OpenSSH client: either ssh states a verdict after its advisories, or it fails before it has any advisory to state. **The reachability argument is therefore a client-version argument, and the version it was measured on is OpenSSH 10.2p1.**

What makes it reachable is a client that does not follow that convention. Orca sets `GIT_SSH_COMMAND='ssh -o BatchMode=yes'` only when the caller has not already set one (`src/main/git/command-runner/git-process-env.ts:66` and `git-ssh-policy-env.ts:127` both defer to an existing value; the relay does the same with `??=` at `src/relay/relay-command-env.ts:181`). A user's own SSH wrapper that forwards ssh's advisories but swallows its verdict, or a non-OpenSSH client, is outside Orca's control and produces exactly this shape.

### Decision: documented, not fixed

Fixing it would mean recognising "a bare advisory" as a class the deferral must refuse. The **Why not filter ssh's advisories instead** section above already measured why that does not work: the same capture run produced three advisory shapes naming a path, sharing no prefix, and the `Warning: Identity file …` wording the earlier rounds were built on is an older OpenSSH's phrasing that 10.2 does not emit at all. So the only fix available at this layer is a heuristic this PR has already shown to be unreliable, applied to a shape no stock client produces — which would trade a measured, bounded exposure for an unmeasured pattern-matching rule on every surface.

It is therefore **documented rather than fixed**, with the condition named rather than implied: the guarantee holds for OpenSSH, and does not hold for an arbitrary `GIT_SSH_COMMAND`. If that trade is not acceptable, the sound fix is not advisory-matching but **path redaction on the chosen detail** — credential scrubbing is not path scrubbing, as the producer comment already says — and that is real scope for its own change, covering every surface at once rather than this one shape.

The rule matches git's English phrasing, as the existing `fatal:` / `remote:` / `non-fast-forward` checks in this module already do. Windows and WSL emit the same shapes, so the same selection applies there.

The previous round's stated limitation — that local progress output could win — is **superseded**: it is not hypothetical and it is not progress. `From …` and ` * branch … -> FETCH_HEAD` are printed on a non-tty and did win under the position rule; they are row 4 above and are pinned.
