### PR TITLE
perf(worktrees): batch-prune stale local metadata

### DIFF
--- a/src/main/ipc/registered-worktree-roots-cache.ts
+++ b/src/main/ipc/registered-worktree-roots-cache.ts
@@ -7,6 +7,9 @@ import { isDescendantOrEqual, normalizeExistingPath } from './filesystem-path-co
 const registeredWorktreeRoots = new Set<string>()
 const registeredWorktreeRootsByRepo = new Map<string, Set<string>>()
 const registeredWorktreeRootRepoIds = new Set<string>()
+const registeredWorktreeRootsRevisionByRepo = new Map<string, number>()
+let registeredWorktreeRootsRevisionSequence = 0
+let registeredWorktreeRootsBaseRevision = 0
 let registeredWorktreeRootsDirty = true
 let registeredWorktreeRootsRefresh: Promise<void> | null = null
 const AUTHORIZED_ROOTS_REBUILD_CONCURRENCY = 8
@@ -17,6 +20,8 @@ export function invalidateAuthorizedRootsCache(): void {
   registeredWorktreeRoots.clear()
   registeredWorktreeRootsByRepo.clear()
   registeredWorktreeRootRepoIds.clear()
+  registeredWorktreeRootsBaseRevision = ++registeredWorktreeRootsRevisionSequence
+  registeredWorktreeRootsRevisionByRepo.clear()
 }
 
 export async function rebuildAuthorizedRootsCache(store: Store): Promise<void> {
@@ -55,6 +60,8 @@ export async function rebuildAuthorizedRootsCache(store: Store): Promise<void> {
     registeredWorktreeRootRepoIds.add(repoId)
   }
   registeredWorktreeRootsDirty = false
+  registeredWorktreeRootsBaseRevision = ++registeredWorktreeRootsRevisionSequence
+  registeredWorktreeRootsRevisionByRepo.clear()
 }
 
 async function mapWithConcurrency<T, R>(
@@ -87,6 +94,10 @@ export function registerWorktreeRootsForRepo(
     if (!localRepoIds.has(registeredRepoId)) {
       registeredWorktreeRootsByRepo.delete(registeredRepoId)
       registeredWorktreeRootRepoIds.delete(registeredRepoId)
+      registeredWorktreeRootsRevisionByRepo.set(
+        registeredRepoId,
+        ++registeredWorktreeRootsRevisionSequence
+      )
     }
   }
 
@@ -98,8 +109,13 @@ export function registerWorktreeRootsForRepo(
 
   registeredWorktreeRootsByRepo.set(repoId, new Set(worktreeRoots.map((root) => resolve(root))))
   registeredWorktreeRootRepoIds.add(repoId)
+  registeredWorktreeRootsRevisionByRepo.set(repoId, ++registeredWorktreeRootsRevisionSequence)
   refreshRegisteredWorktreeRoots()
   registeredWorktreeRootsDirty = !allLocalRepoRootsRegistered(localRepoIds)
+}
+
+export function getRegisteredWorktreeRootsRevision(repoId: string): number {
+  return registeredWorktreeRootsRevisionByRepo.get(repoId) ?? registeredWorktreeRootsBaseRevision
 }
 
 export async function ensureAuthorizedRootsCache(store: Store): Promise<void> {

--- a/src/main/ipc/worktrees-authoritative-local-metadata-pruning.test.ts
+++ b/src/main/ipc/worktrees-authoritative-local-metadata-pruning.test.ts
@@ -1,0 +1,611 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitWorktreeInfo } from '../../shared/worktree/types'
+import type { NativeLocalWorktreeMetadataScanExpectation } from '../persistence/tracking-repos/missing-local-worktree-metadata-pruning'
+import { notifyWorktreesChanged } from './worktree-remote'
+import {
+  listWorktreesMock,
+  pruneCleanupScanSnapshotsMock,
+  pruneSpaceAnalysisSnapshotsMock
+} from './worktrees-test-module-mocks'
+import { handlers, mainWindow, setupWorktreeHandlers, store } from './worktrees-test-harness'
+import { mockSelectedWslProjectRuntime } from './worktrees-test-fixtures'
+import { pruneMetadataMissingFromAuthoritativeLocalScan } from './worktrees/listing/authoritative-local-worktree-metadata-pruning'
+import { listDetectedWorktreesForCapturedRepo } from './worktrees/listing/detected-provider-listing'
+import { getLocalWorktreeScanGeneration } from '../local-worktree-scan-generation'
+import {
+  isRegisteredWorktreePath,
+  registerWorktreeRootsForRepo
+} from './registered-worktree-roots-cache'
+
+const localWorktreePathPresenceMock = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', async () =>
+  (await import('./worktrees-test-module-mocks')).electronModuleMock()
+)
+vi.mock('../git/worktree', async () =>
+  (await import('./worktrees-test-module-mocks')).gitWorktreeModuleMock()
+)
+vi.mock('../git/runner', async () =>
+  (await import('./worktrees-test-module-mocks')).gitRunnerModuleMock()
+)
+vi.mock('../git/repo', async () =>
+  (await import('./worktrees-test-module-mocks')).gitRepoModuleMock()
+)
+vi.mock('../git/git-username', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resolveLocalGitUsername: (await import('./worktrees-test-module-mocks'))
+    .resolveLocalGitUsernameMock
+}))
+vi.mock('../github/client', async () =>
+  (await import('./worktrees-test-module-mocks')).githubClientModuleMock()
+)
+vi.mock('../source-control/hosted-review', async () =>
+  (await import('./worktrees-test-module-mocks')).hostedReviewModuleMock()
+)
+vi.mock('../providers/ssh-git-dispatch', async () =>
+  (await import('./worktrees-test-module-mocks')).sshGitDispatchModuleMock()
+)
+vi.mock('../providers/ssh-filesystem-dispatch', async () =>
+  (await import('./worktrees-test-module-mocks')).sshFilesystemDispatchModuleMock()
+)
+vi.mock('./worktree-symlinks', async () =>
+  (await import('./worktrees-test-module-mocks')).worktreeSymlinksModuleMock()
+)
+vi.mock('./ssh', async () => (await import('./worktrees-test-module-mocks')).sshModuleMock())
+vi.mock('../ssh/ssh-target-registry', async () =>
+  (await import('./worktrees-test-module-mocks')).sshTargetRegistryModuleMock()
+)
+vi.mock('../hooks', async () => (await import('./worktrees-test-module-mocks')).hooksModuleMock())
+vi.mock('../setup-runner-script-text', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).setupRunnerScriptTextModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../worktree-runner-script', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).worktreeRunnerScriptModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../effective-hook-config', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).effectiveHookConfigModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../setup-hook-env-vars', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).setupHookEnvVarsModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('./worktree-logic', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).worktreeLogicModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../terminal-history-deletion', async () =>
+  (await import('./worktrees-test-module-mocks')).terminalHistoryDeletionModuleMock()
+)
+vi.mock('../ports/advertised-url-watcher', async () =>
+  (await import('./worktrees-test-module-mocks')).advertisedUrlWatcherModuleMock()
+)
+vi.mock('../workspace-cleanup-scan-snapshot', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceCleanupScanSnapshotModuleMock()
+)
+vi.mock('../workspace-space-analysis-snapshot', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceSpaceAnalysisSnapshotModuleMock()
+)
+vi.mock('../workspace-cleanup-removal-snapshot-prune', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceCleanupRemovalSnapshotPruneModuleMock()
+)
+vi.mock('../local-worktree-path-presence', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  localWorktreePathsExistOrAreUnverifiable: localWorktreePathPresenceMock
+}))
+vi.mock('../runtime/worktree-teardown', async () =>
+  (await import('./worktrees-test-module-mocks')).worktreeTeardownModuleMock()
+)
+vi.mock('./pty', async () => (await import('./worktrees-test-module-mocks')).ptyModuleMock())
+
+const REPO_ID = 'repo-1'
+const REPO_PATH = '/workspace/repo'
+const LOCAL_HOST_ID = 'local'
+
+function worktree(path: string, overrides: Partial<GitWorktreeInfo> = {}): GitWorktreeInfo {
+  return {
+    path,
+    head: path,
+    branch: `refs/heads/${path.split('/').at(-1) ?? 'main'}`,
+    isBare: false,
+    isMainWorktree: path === REPO_PATH,
+    ...overrides
+  }
+}
+
+function scanExpectation(
+  worktreeIds: readonly string[]
+): NativeLocalWorktreeMetadataScanExpectation {
+  const expectedRepo = {
+    id: REPO_ID,
+    path: REPO_PATH,
+    displayName: 'repo',
+    badgeColor: '#000',
+    addedAt: 0
+  }
+  return {
+    repo: {
+      id: REPO_ID,
+      path: REPO_PATH,
+      kind: 'git',
+      expectedRepo
+    },
+    routing: {
+      expectedProject: undefined,
+      expectedProjectUpdatedAt: undefined,
+      expectedSettings:
+        {} as NativeLocalWorktreeMetadataScanExpectation['routing']['expectedSettings']
+    },
+    metadata: worktreeIds.map((worktreeId) => ({
+      worktreeId,
+      expectedLegacy: {
+        expectedPresent: true,
+        expectedMeta: undefined,
+        expectedSerialized: undefined,
+        expectedInstanceId: undefined,
+        expectedHostId: LOCAL_HOST_ID
+      },
+      expectedAliases: []
+    }))
+  }
+}
+
+function listDetected(): Promise<unknown> {
+  return handlers['worktrees:listDetected'](null, { repoId: REPO_ID }) as Promise<unknown>
+}
+
+const localListingCalls = [
+  ['worktrees:listDetected', listDetected],
+  [
+    'worktrees:list',
+    () => handlers['worktrees:list'](null, { repoId: REPO_ID }) as Promise<unknown>
+  ],
+  ['worktrees:listAll', () => handlers['worktrees:listAll'](null, undefined) as Promise<unknown>]
+] as const
+
+describe('authoritative local worktree metadata pruning integration', () => {
+  beforeEach(() => {
+    setupWorktreeHandlers()
+    localWorktreePathPresenceMock.mockReset()
+    localWorktreePathPresenceMock.mockImplementation(
+      async (pathValues: readonly string[]) =>
+        new Map(pathValues.map((pathValue) => [pathValue, false]))
+    )
+  })
+
+  it('captures metadata expectations before starting the Git scan', async () => {
+    const order: string[] = []
+    store.captureNativeLocalWorktreeMetadataScanExpectation.mockImplementation(() => {
+      order.push('capture')
+      return scanExpectation([])
+    })
+    listWorktreesMock.mockImplementation(() => {
+      order.push('scan')
+      return Promise.resolve([worktree(REPO_PATH)])
+    })
+
+    await listDetected()
+
+    expect(order).toEqual(['capture', 'scan'])
+  })
+
+  it('prunes once for the fresh producer, while coalesced and cached callers do nothing', async () => {
+    const staleId = `${REPO_ID}::/workspace/stale`
+    const rows = [worktree(REPO_PATH), worktree('/workspace/live')]
+    store.captureNativeLocalWorktreeMetadataScanExpectation.mockReturnValue(
+      scanExpectation([staleId])
+    )
+    store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mockReturnValue([staleId])
+    listWorktreesMock.mockImplementation(async () => {
+      await Promise.resolve()
+      return rows
+    })
+
+    await Promise.all([listDetected(), listDetected(), listDetected()])
+    await listDetected()
+
+    expect(store.captureNativeLocalWorktreeMetadataScanExpectation).toHaveBeenCalledTimes(1)
+    expect(store.pruneSessionlessMissingLocalWorktreeMetadataForRepo).toHaveBeenCalledTimes(1)
+    const firstPruneCall = store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mock
+      .calls[0] as [unknown, readonly { worktreeId: string }[]] | undefined
+    expect(firstPruneCall?.[1].map(({ worktreeId }) => worktreeId)).toEqual([staleId])
+    expect(pruneCleanupScanSnapshotsMock).toHaveBeenCalledTimes(1)
+    expect(pruneCleanupScanSnapshotsMock).toHaveBeenCalledWith('/profile-a', [
+      { worktreeId: staleId, executionHostId: LOCAL_HOST_ID }
+    ])
+    expect(pruneSpaceAnalysisSnapshotsMock).toHaveBeenCalledTimes(1)
+    expect(pruneSpaceAnalysisSnapshotsMock).toHaveBeenCalledWith('/profile-a', [
+      { worktreeId: staleId, executionHostId: LOCAL_HOST_ID }
+    ])
+  })
+
+  it('does not prune when the authoritative scan is invalidated while in flight', async () => {
+    const staleId = `${REPO_ID}::/workspace/stale`
+    let resolveScan: (rows: GitWorktreeInfo[]) => void = () => {}
+    store.captureNativeLocalWorktreeMetadataScanExpectation.mockReturnValue(
+      scanExpectation([staleId])
+    )
+    store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mockReturnValue([staleId])
+    listWorktreesMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveScan = resolve as (rows: GitWorktreeInfo[]) => void
+        })
+    )
+
+    const pending = listDetected()
+    await Promise.resolve()
+    notifyWorktreesChanged(mainWindow as never, REPO_ID)
+    resolveScan([worktree(REPO_PATH), worktree('/workspace/live')])
+    await pending
+
+    expect(store.captureNativeLocalWorktreeMetadataScanExpectation).toHaveBeenCalledTimes(1)
+    expect(store.pruneSessionlessMissingLocalWorktreeMetadataForRepo).not.toHaveBeenCalled()
+    expect(pruneCleanupScanSnapshotsMock).not.toHaveBeenCalled()
+    expect(pruneSpaceAnalysisSnapshotsMock).not.toHaveBeenCalled()
+  })
+
+  it('does not prune when the completed scan is invalidated before its caller resumes', async () => {
+    const staleId = `${REPO_ID}::/workspace/stale`
+    let resolveScan: (rows: GitWorktreeInfo[]) => void = () => {}
+    store.captureNativeLocalWorktreeMetadataScanExpectation.mockReturnValue(
+      scanExpectation([staleId])
+    )
+    store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mockReturnValue([staleId])
+    listWorktreesMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveScan = resolve as (rows: GitWorktreeInfo[]) => void
+        })
+    )
+
+    const pending = listDetected()
+    await Promise.resolve()
+    resolveScan([worktree(REPO_PATH)])
+    queueMicrotask(() => notifyWorktreesChanged(mainWindow as never, REPO_ID))
+    await pending
+
+    expect(store.pruneSessionlessMissingLocalWorktreeMetadataForRepo).not.toHaveBeenCalled()
+  })
+
+  it.each(localListingCalls)(
+    'skips stale WSL root and lineage side effects after %s caller resumption',
+    async (_channel, listWorktrees) => {
+      const orphanId = `${REPO_ID}::/workspace/orphan`
+      let resolveScan: (rows: GitWorktreeInfo[]) => void = () => {}
+      mockSelectedWslProjectRuntime()
+      store.getAllWorktreeLineage.mockReturnValue({
+        [orphanId]: {
+          worktreeId: orphanId,
+          worktreeInstanceId: 'orphan-instance',
+          parentWorktreeId: `${REPO_ID}::${REPO_PATH}`,
+          parentWorktreeInstanceId: 'main-instance',
+          origin: 'manual',
+          capture: { source: 'manual-action', confidence: 'explicit' },
+          createdAt: 0
+        }
+      })
+      listWorktreesMock.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveScan = resolve as (rows: GitWorktreeInfo[]) => void
+          })
+      )
+
+      const pending = listWorktrees()
+      await Promise.resolve()
+      resolveScan([worktree(REPO_PATH)])
+      queueMicrotask(() => notifyWorktreesChanged(mainWindow as never, REPO_ID))
+      await pending
+
+      expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+      expect(isRegisteredWorktreePath(REPO_PATH)).toBe(false)
+    }
+  )
+
+  it('preserves WSL roots and lineage created while an older Git scan is pending', async () => {
+    const newPath = '/workspace/new-wsl-worktree'
+    const newId = `${REPO_ID}::${newPath}`
+    let resolveScan: (rows: GitWorktreeInfo[]) => void = () => {}
+    mockSelectedWslProjectRuntime()
+    listWorktreesMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveScan = resolve as (rows: GitWorktreeInfo[]) => void
+        })
+    )
+
+    const pending = listDetected()
+    await Promise.resolve()
+
+    resolveScan([worktree(REPO_PATH)])
+    queueMicrotask(() => {
+      registerWorktreeRootsForRepo(store as never, REPO_ID, [REPO_PATH, newPath])
+      store.setWorktreeMeta(newId, { hostId: LOCAL_HOST_ID, instanceId: 'new-instance' })
+      store.getAllWorktreeLineage.mockReturnValue({
+        [newId]: {
+          worktreeId: newId,
+          worktreeInstanceId: 'new-instance',
+          parentWorktreeId: `${REPO_ID}::${REPO_PATH}`,
+          parentWorktreeInstanceId: 'main-instance',
+          origin: 'manual',
+          capture: { source: 'manual-action', confidence: 'explicit' },
+          createdAt: 0
+        }
+      })
+    })
+    await pending
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(isRegisteredWorktreePath(newPath)).toBe(true)
+  })
+
+  it.each(['scan generation', 'caller request'] as const)(
+    'skips metadata, root, and lineage mutations when the %s is invalidated during path probes',
+    async (invalidation) => {
+      const staleId = `${REPO_ID}::/workspace/stale`
+      const orphanId = `${REPO_ID}::/workspace/orphan`
+      let callerCurrent = true
+      let resolvePresence: (presence: ReadonlyMap<string, boolean>) => void = () => {}
+      store.captureNativeLocalWorktreeMetadataScanExpectation.mockReturnValue(
+        scanExpectation([staleId])
+      )
+      store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mockReturnValue([staleId])
+      store.getAllWorktreeLineage.mockReturnValue({
+        [orphanId]: {
+          worktreeId: orphanId,
+          worktreeInstanceId: 'orphan-instance',
+          parentWorktreeId: `${REPO_ID}::${REPO_PATH}`,
+          parentWorktreeInstanceId: 'main-instance',
+          origin: 'manual',
+          capture: { source: 'manual-action', confidence: 'explicit' },
+          createdAt: 0
+        }
+      })
+      localWorktreePathPresenceMock.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolvePresence = resolve
+          })
+      )
+      listWorktreesMock.mockResolvedValue([worktree(REPO_PATH)])
+
+      const pending = listDetectedWorktreesForCapturedRepo(
+        store as never,
+        store.getRepo(REPO_ID) as never,
+        () => callerCurrent
+      )
+      await vi.waitFor(() => expect(localWorktreePathPresenceMock).toHaveBeenCalledTimes(1))
+      if (invalidation === 'scan generation') {
+        notifyWorktreesChanged(mainWindow as never, REPO_ID)
+      } else {
+        callerCurrent = false
+      }
+      resolvePresence(new Map([['/workspace/stale', false]]))
+      await pending
+
+      expect(store.pruneSessionlessMissingLocalWorktreeMetadataForRepo).not.toHaveBeenCalled()
+      expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+      expect(isRegisteredWorktreePath(REPO_PATH)).toBe(false)
+      expect(pruneCleanupScanSnapshotsMock).not.toHaveBeenCalled()
+      expect(pruneSpaceAnalysisSnapshotsMock).not.toHaveBeenCalled()
+    }
+  )
+
+  it('preserves roots and lineage created while an older path probe is pending', async () => {
+    const staleId = `${REPO_ID}::/workspace/stale`
+    const newPath = '/workspace/new-worktree'
+    const newId = `${REPO_ID}::${newPath}`
+    let resolvePresence: (presence: ReadonlyMap<string, boolean>) => void = () => {}
+    const metadata = new Map<string, { hostId: string; instanceId: string }>()
+    store.getWorktreeMeta.mockImplementation((worktreeId) => metadata.get(worktreeId))
+    store.captureNativeLocalWorktreeMetadataScanExpectation.mockReturnValue(
+      scanExpectation([staleId])
+    )
+    store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mockReturnValue([staleId])
+    localWorktreePathPresenceMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePresence = resolve
+        })
+    )
+    listWorktreesMock.mockResolvedValue([worktree(REPO_PATH)])
+
+    const pending = listDetected()
+    await vi.waitFor(() => expect(localWorktreePathPresenceMock).toHaveBeenCalledTimes(1))
+
+    registerWorktreeRootsForRepo(store as never, REPO_ID, [REPO_PATH, newPath])
+    const newMetadata = { hostId: LOCAL_HOST_ID, instanceId: 'new-instance' }
+    metadata.set(newId, newMetadata)
+    store.setWorktreeMeta(newId, newMetadata)
+    store.getAllWorktreeLineage.mockReturnValue({
+      [newId]: {
+        worktreeId: newId,
+        worktreeInstanceId: newMetadata.instanceId,
+        parentWorktreeId: `${REPO_ID}::${REPO_PATH}`,
+        parentWorktreeInstanceId: 'main-instance',
+        origin: 'manual',
+        capture: { source: 'manual-action', confidence: 'explicit' },
+        createdAt: 0
+      }
+    })
+    resolvePresence(new Map([['/workspace/stale', false]]))
+    await pending
+
+    expect(store.pruneSessionlessMissingLocalWorktreeMetadataForRepo).toHaveBeenCalledTimes(1)
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(isRegisteredWorktreePath(newPath)).toBe(true)
+  })
+
+  it('does not capture or prune on an initial WSL scan', async () => {
+    mockSelectedWslProjectRuntime()
+    listWorktreesMock.mockResolvedValue([worktree(REPO_PATH)])
+
+    await listDetected()
+
+    expect(listWorktreesMock).toHaveBeenCalledWith(REPO_PATH, { wslDistro: 'Ubuntu' })
+    expect(store.captureNativeLocalWorktreeMetadataScanExpectation).not.toHaveBeenCalled()
+    expect(store.pruneSessionlessMissingLocalWorktreeMetadataForRepo).not.toHaveBeenCalled()
+  })
+
+  it('does not let a native scan that changes to WSL routing become destructive', async () => {
+    const staleId = `${REPO_ID}::/workspace/stale`
+    const resolvers: ((rows: GitWorktreeInfo[]) => void)[] = []
+    store.captureNativeLocalWorktreeMetadataScanExpectation.mockReturnValue(
+      scanExpectation([staleId])
+    )
+    store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mockReturnValue([staleId])
+    listWorktreesMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve as (rows: GitWorktreeInfo[]) => void)
+        })
+    )
+
+    const nativePending = listDetected()
+    await Promise.resolve()
+    mockSelectedWslProjectRuntime()
+    const wslPending = listDetected()
+    await Promise.resolve()
+
+    resolvers[1]?.([worktree(REPO_PATH)])
+    await wslPending
+    resolvers[0]?.([worktree(REPO_PATH), worktree('/workspace/live')])
+    await nativePending
+
+    expect(store.captureNativeLocalWorktreeMetadataScanExpectation).toHaveBeenCalledTimes(1)
+    expect(store.pruneSessionlessMissingLocalWorktreeMetadataForRepo).not.toHaveBeenCalled()
+    expect(pruneCleanupScanSnapshotsMock).not.toHaveBeenCalled()
+    expect(pruneSpaceAnalysisSnapshotsMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['empty', [] as GitWorktreeInfo[]],
+    ['failed', new Error('git worktree list failed')]
+  ] as const)('does nothing for an %s authoritative scan', async (_label, result) => {
+    const staleId = `${REPO_ID}::/workspace/stale`
+    store.captureNativeLocalWorktreeMetadataScanExpectation.mockReturnValue(
+      scanExpectation([staleId])
+    )
+    store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mockReturnValue([staleId])
+    if (result instanceof Error) {
+      listWorktreesMock.mockRejectedValue(result)
+    } else {
+      listWorktreesMock.mockResolvedValue(result)
+    }
+
+    await listDetected()
+
+    expect(store.pruneSessionlessMissingLocalWorktreeMetadataForRepo).not.toHaveBeenCalled()
+    expect(pruneCleanupScanSnapshotsMock).not.toHaveBeenCalled()
+    expect(pruneSpaceAnalysisSnapshotsMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps prunable Git registrations live and does not probe their paths', async () => {
+    const staleId = `${REPO_ID}::/workspace/stale`
+    const liveId = `${REPO_ID}::/workspace/live`
+    const prunableId = `${REPO_ID}::/workspace/prunable`
+    store.captureNativeLocalWorktreeMetadataScanExpectation.mockReturnValue(
+      scanExpectation([staleId, liveId, prunableId])
+    )
+    store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mockReturnValue([staleId])
+    listWorktreesMock.mockResolvedValue([
+      worktree(REPO_PATH),
+      worktree('/workspace/live'),
+      worktree('/workspace/prunable', { prunable: true })
+    ])
+
+    await listDetected()
+
+    expect(store.pruneSessionlessMissingLocalWorktreeMetadataForRepo).toHaveBeenCalledTimes(1)
+    const missing = store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mock.calls[0]?.[1] as
+      | readonly { worktreeId: string }[]
+      | undefined
+    expect(missing?.map(({ worktreeId }) => worktreeId)).toEqual([staleId])
+    expect(missing?.map(({ worktreeId }) => worktreeId)).not.toContain(liveId)
+    expect(missing?.map(({ worktreeId }) => worktreeId)).not.toContain(prunableId)
+    expect(localWorktreePathPresenceMock).toHaveBeenCalledWith(['/workspace/stale'], {
+      signal: undefined
+    })
+  })
+
+  it('keeps the configured repo path live when Git reports a canonical spelling', async () => {
+    const configuredMainId = `${REPO_ID}::${REPO_PATH}`
+    const staleId = `${REPO_ID}::/workspace/stale`
+    store.captureNativeLocalWorktreeMetadataScanExpectation.mockReturnValue(
+      scanExpectation([configuredMainId, staleId])
+    )
+    store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mockReturnValue([staleId])
+    listWorktreesMock.mockResolvedValue([worktree('/canonical/workspace/repo')])
+
+    await listDetected()
+
+    const missing = store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mock.calls[0]?.[1] as
+      | readonly { worktreeId: string }[]
+      | undefined
+    expect(missing?.map(({ worktreeId }) => worktreeId)).toEqual([staleId])
+    expect(missing?.map(({ worktreeId }) => worktreeId)).not.toContain(configuredMainId)
+  })
+
+  it('keeps a linked worktree whose persisted symlink spelling still exists', async () => {
+    const aliasId = `${REPO_ID}::/workspace/alias/linked`
+    const staleId = `${REPO_ID}::/workspace/stale`
+    const scan = scanExpectation([aliasId, staleId])
+    const repo = scan.repo.expectedRepo!
+    const prune = vi.fn(
+      (
+        _scan: NativeLocalWorktreeMetadataScanExpectation,
+        _missing: readonly { worktreeId: string }[]
+      ) => [] as string[]
+    )
+
+    await pruneMetadataMissingFromAuthoritativeLocalScan({
+      store: {
+        getRepos: () => [repo],
+        pruneSessionlessMissingLocalWorktreeMetadataForRepo: prune
+      } as never,
+      repo,
+      gitWorktrees: [worktree('/workspace/real/linked')],
+      scan,
+      scanGeneration: getLocalWorktreeScanGeneration(REPO_ID),
+      pathsExistOrAreUnverifiable: async (pathValues) =>
+        new Map(pathValues.map((pathValue) => [pathValue, pathValue === '/workspace/alias/linked']))
+    })
+
+    expect(prune.mock.calls[0]?.[1].map(({ worktreeId }) => worktreeId)).toEqual([staleId])
+  })
+
+  it('does not rematerialize a removed lineage parent metadata row', async () => {
+    const staleId = `${REPO_ID}::/workspace/stale`
+    store.captureNativeLocalWorktreeMetadataScanExpectation.mockReturnValue(
+      scanExpectation([staleId])
+    )
+    store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mockReturnValue([staleId])
+    store.getAllWorktreeLineage.mockReturnValue({
+      [`${REPO_ID}::/workspace/live-child`]: {
+        worktreeId: `${REPO_ID}::/workspace/live-child`,
+        worktreeInstanceId: 'child-instance',
+        parentWorktreeId: staleId,
+        parentWorktreeInstanceId: 'stale-instance',
+        origin: 'manual',
+        capture: { source: 'manual-action', confidence: 'explicit' },
+        createdAt: 0
+      }
+    })
+    listWorktreesMock.mockResolvedValue([worktree(REPO_PATH), worktree('/workspace/live')])
+
+    await listDetected()
+
+    expect(store.pruneSessionlessMissingLocalWorktreeMetadataForRepo).toHaveBeenCalledTimes(1)
+    expect(store.setWorktreeMeta.mock.calls.some(([worktreeId]) => worktreeId === staleId)).toBe(
+      false
+    )
+  })
+})

--- a/src/main/ipc/worktrees-test-harness.ts
+++ b/src/main/ipc/worktrees-test-harness.ts
@@ -7,6 +7,7 @@ import { resetRetirementCollisionKeyCacheForTests } from '../worktree-name-retir
 import { resetSshProviderAuthorities } from '../ssh/ssh-provider-authority'
 import { createWorktreeRuntimeStub, type WorktreeRuntimeStub } from './worktrees-test-runtime-stub'
 import { handlers, mainWindow, store } from './worktrees-test-ipc-surface'
+import { configureMetadataPruningStoreMocks } from './worktrees-test-metadata-pruning-store'
 import {
   ORIGINAL_PLATFORM,
   setPlatform,
@@ -129,10 +130,12 @@ export function setupWorktreeHandlers(): WorktreeRuntimeStub {
     store.getWorktreeMeta,
     store.getWorktreeMetaForHost,
     store.getAllWorktreeMeta,
+    store.captureNativeLocalWorktreeMetadataScanExpectation,
     store.setWorktreeMeta,
     store.setWorktreeMetaForHost,
     store.getProjectHostSetups,
     store.removeWorktreeMeta,
+    store.pruneSessionlessMissingLocalWorktreeMetadataForRepo,
     store.removeWorkspaceSessionStateForWorktree,
     store.getAllWorktreeLineage,
     store.removeWorktreeLineage,
@@ -187,12 +190,13 @@ export function setupWorktreeHandlers(): WorktreeRuntimeStub {
   store.getRepo.mockReturnValue({ ...repo, worktreeBaseRef: null })
   store.getProjects.mockReturnValue([])
   store.getSparsePresets.mockReturnValue([])
-  store.getSettings.mockReturnValue({
+  const settings = {
     branchPrefix: 'none',
     nestWorkspaces: false,
     refreshLocalBaseRefOnWorktreeCreate: false,
     workspaceDir: '/workspace'
-  })
+  }
+  store.getSettings.mockReturnValue(settings)
   store.getWorktreeMeta.mockReturnValue(undefined)
   // Host-qualified accessors delegate by default so payload assertions stay on one spy;
   // host routing itself is covered by worktree-identity-persistence.test.ts.
@@ -200,6 +204,7 @@ export function setupWorktreeHandlers(): WorktreeRuntimeStub {
     store.getWorktreeMeta(args[0] as string)
   )
   store.getAllWorktreeMeta.mockReturnValue({})
+  configureMetadataPruningStoreMocks(store, settings)
   store.getRetiredWorktreeNameRegistry.mockReturnValue({ exhaustedTiers: 0, names: [] })
   resetRetirementCollisionKeyCacheForTests()
   store.setWorktreeMeta.mockReturnValue({})

--- a/src/main/ipc/worktrees-test-ipc-surface.ts
+++ b/src/main/ipc/worktrees-test-ipc-surface.ts
@@ -24,10 +24,12 @@ export type TestStore = {
   getWorktreeMeta: KeyedStoreMock
   getWorktreeMetaForHost: StoreMock
   getAllWorktreeMeta: StoreMock
+  captureNativeLocalWorktreeMetadataScanExpectation: StoreMock
   setWorktreeMeta: KeyedStoreWriteMock
   setWorktreeMetaForHost: StoreMock
   getProjectHostSetups: StoreMock
   removeWorktreeMeta: KeyedStoreMock
+  pruneSessionlessMissingLocalWorktreeMetadataForRepo: StoreMock
   removeWorkspaceSessionStateForWorktree: KeyedStoreMock
   getAllWorktreeLineage: StoreMock
   removeWorktreeLineage: KeyedStoreMock
@@ -58,10 +60,12 @@ export const store: TestStore = {
   getWorktreeMeta: vi.fn(),
   getWorktreeMetaForHost: vi.fn(),
   getAllWorktreeMeta: vi.fn(),
+  captureNativeLocalWorktreeMetadataScanExpectation: vi.fn(),
   setWorktreeMeta: vi.fn(),
   setWorktreeMetaForHost: vi.fn(),
   getProjectHostSetups: vi.fn(),
   removeWorktreeMeta: vi.fn(),
+  pruneSessionlessMissingLocalWorktreeMetadataForRepo: vi.fn(),
   removeWorkspaceSessionStateForWorktree: vi.fn(),
   getAllWorktreeLineage: vi.fn(),
   removeWorktreeLineage: vi.fn(),

--- a/src/main/ipc/worktrees-test-metadata-pruning-store.ts
+++ b/src/main/ipc/worktrees-test-metadata-pruning-store.ts
@@ -1,0 +1,35 @@
+import type { TestStore } from './worktrees-test-ipc-surface'
+
+export function configureMetadataPruningStoreMocks(
+  store: TestStore,
+  expectedSettings: unknown
+): void {
+  store.captureNativeLocalWorktreeMetadataScanExpectation.mockImplementation(
+    (...args: unknown[]) => {
+      const repo = args[0] as {
+        id: string
+        path: string
+        connectionId?: string | null
+        executionHostId?: string | null
+        kind?: string
+      }
+      return {
+        repo: {
+          id: repo.id,
+          path: repo.path,
+          connectionId: repo.connectionId,
+          executionHostId: repo.executionHostId,
+          kind: repo.kind === 'folder' ? 'folder' : 'git',
+          expectedRepo: repo
+        },
+        routing: {
+          expectedProject: undefined,
+          expectedProjectUpdatedAt: undefined,
+          expectedSettings
+        },
+        metadata: []
+      }
+    }
+  )
+  store.pruneSessionlessMissingLocalWorktreeMetadataForRepo.mockReturnValue([])
+}

--- a/src/main/ipc/worktrees-windows.test.ts
+++ b/src/main/ipc/worktrees-windows.test.ts
@@ -166,6 +166,7 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     getSettings: vi.fn(),
     getWorktreeMeta: vi.fn(),
     getAllWorktreeMeta: vi.fn(),
+    captureNativeLocalWorktreeMetadataScanExpectation: vi.fn(),
     setWorktreeMeta: vi.fn(),
     removeWorktreeMeta: vi.fn(),
     addRetiredWorktreeName: vi.fn(),
@@ -211,6 +212,7 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     store.getSettings.mockReset()
     store.getWorktreeMeta.mockReset()
     store.getAllWorktreeMeta.mockReset()
+    store.captureNativeLocalWorktreeMetadataScanExpectation.mockReset()
     store.setWorktreeMeta.mockReset()
     store.removeWorktreeMeta.mockReset()
     store.addRetiredWorktreeName.mockReset()
@@ -254,6 +256,20 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     resolveSetupRunnerShellMock.mockReturnValue(undefined)
     store.getWorktreeMeta.mockReturnValue(undefined)
     store.getAllWorktreeMeta.mockReturnValue({})
+    store.captureNativeLocalWorktreeMetadataScanExpectation.mockImplementation((repo) => ({
+      repo: {
+        id: repo.id,
+        path: repo.path,
+        kind: 'git',
+        expectedRepo: repo
+      },
+      routing: {
+        expectedProject: undefined,
+        expectedProjectUpdatedAt: undefined,
+        expectedSettings: store.getSettings()
+      },
+      metadata: []
+    }))
     store.getRetiredWorktreeNameRegistry.mockReturnValue({ exhaustedTiers: 0, names: [] })
     store.setWorktreeMeta.mockReturnValue({})
     resolveLocalGitUsernameMock.mockResolvedValue('')

--- a/src/main/ipc/worktrees/listing/authoritative-local-worktree-metadata-pruning.ts
+++ b/src/main/ipc/worktrees/listing/authoritative-local-worktree-metadata-pruning.ts
@@ -1,0 +1,141 @@
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
+import { isFolderRepo } from '../../../../shared/repo-kind'
+import type { Repo } from '../../../../shared/repo-types'
+import {
+  FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
+  splitWorktreeId
+} from '../../../../shared/worktree/id'
+import type { GitWorktreeInfo } from '../../../../shared/worktree/types'
+import { isWslUncPath } from '../../../../shared/wsl-paths'
+import type { Store } from '../../../persistence/loading-store/store'
+import type { NativeLocalWorktreeMetadataScanExpectation } from '../../../persistence/tracking-repos/missing-local-worktree-metadata-pruning'
+import { pruneWorkspaceCleanupScanSnapshots } from '../../../workspace-cleanup-scan-snapshot'
+import { pruneWorkspaceSpaceAnalysisSnapshots } from '../../../workspace-space-analysis-snapshot'
+import { isLocalWorktreeScanGenerationCurrent } from '../../../local-worktree-scan-generation'
+import { localWorktreePathsExistOrAreUnverifiable } from '../../../local-worktree-path-presence'
+import { worktreeRetentionPathComparisonKey } from '../../../worktree-retention-path-comparison'
+
+type AuthoritativeLocalMetadataPruneArgs = {
+  store: Store
+  repo: Repo
+  gitWorktrees: readonly GitWorktreeInfo[]
+  scan: NativeLocalWorktreeMetadataScanExpectation
+  scanGeneration: number
+  platform?: NodeJS.Platform
+  pathsExistOrAreUnverifiable?: (
+    pathValues: readonly string[],
+    options?: { signal?: AbortSignal }
+  ) => Promise<ReadonlyMap<string, boolean>>
+  isCallerCurrent?: () => boolean
+  signal?: AbortSignal
+}
+
+export type AuthoritativeLocalMetadataPruneResult = Readonly<{
+  removedWorktreeIds: readonly string[]
+  preservedMetadataCandidateIds: ReadonlySet<string>
+  scanGenerationCurrent: boolean
+}>
+
+export async function pruneMetadataMissingFromAuthoritativeLocalScan({
+  store,
+  repo,
+  gitWorktrees,
+  scan,
+  scanGeneration,
+  platform = process.platform,
+  pathsExistOrAreUnverifiable = localWorktreePathsExistOrAreUnverifiable,
+  isCallerCurrent = () => true,
+  signal
+}: AuthoritativeLocalMetadataPruneArgs): Promise<AuthoritativeLocalMetadataPruneResult> {
+  const capturedCandidateIds = scan.metadata.map(({ worktreeId }) => worktreeId)
+  const result = (
+    removedWorktreeIds: readonly string[],
+    scanGenerationCurrent: boolean
+  ): AuthoritativeLocalMetadataPruneResult => {
+    const removedIds = new Set(removedWorktreeIds)
+    return {
+      removedWorktreeIds,
+      preservedMetadataCandidateIds: new Set(
+        capturedCandidateIds.filter((worktreeId) => !removedIds.has(worktreeId))
+      ),
+      scanGenerationCurrent
+    }
+  }
+  const generationCurrent = () => isLocalWorktreeScanGenerationCurrent(repo.id, scanGeneration)
+  const repoOwners = store.getRepos().filter((candidate) => candidate.id === repo.id)
+  if (
+    !generationCurrent() ||
+    !isCallerCurrent() ||
+    gitWorktrees.length === 0 ||
+    repoOwners.length !== 1 ||
+    repo.id !== scan.repo.id ||
+    repo.path !== scan.repo.path ||
+    repo.connectionId ||
+    isFolderRepo(repo) ||
+    getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID ||
+    (platform === 'win32' &&
+      (isWslUncPath(repo.path) || gitWorktrees.some(({ path }) => isWslUncPath(path))))
+  ) {
+    return result([], generationCurrent())
+  }
+
+  const livePathKeys = new Set([
+    // Why: Git can canonicalize a symlinked main checkout differently from the configured path.
+    worktreeRetentionPathComparisonKey(repo.path, platform),
+    ...gitWorktrees.map((worktree) => worktreeRetentionPathComparisonKey(worktree.path, platform))
+  ])
+  const probeCandidates = scan.metadata.flatMap((metadata) => {
+    const { worktreeId } = metadata
+    const parsed = splitWorktreeId(worktreeId)
+    const nativeAbsolute = parsed
+      ? platform === 'win32'
+        ? isWindowsAbsolutePathLike(parsed.worktreePath)
+        : parsed.worktreePath.startsWith('/')
+      : false
+    if (
+      parsed?.repoId !== repo.id ||
+      !nativeAbsolute ||
+      isWslUncPath(parsed.worktreePath) ||
+      worktreeId.includes(FOLDER_WORKSPACE_INSTANCE_SEPARATOR) ||
+      livePathKeys.has(worktreeRetentionPathComparisonKey(parsed.worktreePath, platform))
+    ) {
+      return []
+    }
+    return [{ metadata, pathValue: parsed.worktreePath }]
+  })
+  const presenceByPath = await pathsExistOrAreUnverifiable(
+    probeCandidates.map(({ pathValue }) => pathValue),
+    { signal }
+  )
+  if (!generationCurrent() || !isCallerCurrent()) {
+    return result([], generationCurrent())
+  }
+  const missingMetadata = probeCandidates.flatMap(({ metadata, pathValue }) =>
+    presenceByPath.get(pathValue) === false ? [metadata] : []
+  )
+  if (missingMetadata.length === 0) {
+    return result([], generationCurrent())
+  }
+
+  if (!generationCurrent() || !isCallerCurrent()) {
+    return result([], generationCurrent())
+  }
+  const removedIds = store.pruneSessionlessMissingLocalWorktreeMetadataForRepo(
+    scan,
+    missingMetadata
+  )
+  if (removedIds.length > 0) {
+    const snapshotDirectory = store.getProfileStorageDirectory()
+    const targets: {
+      worktreeId: string
+      executionHostId: typeof LOCAL_EXECUTION_HOST_ID
+    }[] = removedIds.map((worktreeId) => ({
+      worktreeId,
+      executionHostId: LOCAL_EXECUTION_HOST_ID
+    }))
+    void pruneWorkspaceCleanupScanSnapshots(snapshotDirectory, targets)
+    void pruneWorkspaceSpaceAnalysisSnapshots(snapshotDirectory, targets)
+  }
+  return result(removedIds, generationCurrent())
+}

--- a/src/main/ipc/worktrees/listing/detected-provider-listing.ts
+++ b/src/main/ipc/worktrees/listing/detected-provider-listing.ts
@@ -4,7 +4,6 @@ import { getSshGitProvider } from '../../../providers/ssh-git-dispatch'
 import type { DetectedWorktreeListResult, GitWorktreeInfo } from '../../../../shared/worktree/types'
 import { isFolderRepo } from '../../../../shared/repo-kind'
 import { projectResolvedWorktreeLineage } from '../../../../shared/resolved-worktree-lineage'
-import { pruneLineageForMissingRepoWorktrees } from '../../../worktree-lineage-pruning'
 import type { DirectSshDetectedWorktreeRequest } from '../../../../shared/detected-worktree-provider-contract'
 import { isAdmissibleDirectSshAuthority } from '../../../../shared/ssh-retained-payload-admission'
 import type { ListDesktopLineageForHostArgs } from '../../../../shared/host-lineage-contract'
@@ -20,8 +19,10 @@ import {
 import { isFolderWorkspaceIdForRepo } from '../folder-workspace-model'
 import { hasConflictingStoredWorktreeOwner } from './worktree-host-ownership'
 import {
+  applyFreshDetectedWorktreeScanSideEffects,
   listDetectedGitWorktrees,
-  rememberLocalWorktreeRoots
+  type DetectedWorktreeMetadataPrune,
+  type DetectedWorktreeSideEffectToken
 } from './detected-worktree-scan-cache'
 import { loggedWorktreeListFailures, warnOnce } from './worktree-listing-diagnostics'
 import { readAllWorktreeMetaForHost } from '../../../persistence/host-qualified-worktree-meta'
@@ -48,6 +49,8 @@ export async function listDetectedWorktreesForCapturedRepo(
   try {
     let gitWorktrees: GitWorktreeInfo[]
     let freshScan = true
+    let sideEffectToken: DetectedWorktreeSideEffectToken | undefined
+    let metadataPrune: DetectedWorktreeMetadataPrune | undefined
     if (isFolderRepo(repo)) {
       if (!isCurrent()) {
         return null
@@ -97,6 +100,8 @@ export async function listDetectedWorktreesForCapturedRepo(
       const scan = await listDetectedGitWorktrees(store, repo)
       gitWorktrees = scan.gitWorktrees
       freshScan = scan.fresh
+      sideEffectToken = scan.sideEffectToken
+      metadataPrune = scan.metadataPrune
     }
     const aborted = abortedResult()
     if (aborted) {
@@ -115,8 +120,18 @@ export async function listDetectedWorktreesForCapturedRepo(
       }
     }
     if (freshScan) {
-      rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-      pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+      await applyFreshDetectedWorktreeScanSideEffects(store, repo, gitWorktrees, metadataPrune, {
+        isCurrent: () => isCurrent() && !providerAbort?.signal.aborted,
+        sideEffectToken,
+        signal: providerAbort?.signal
+      })
+      const aborted = abortedResult()
+      if (aborted) {
+        return aborted
+      }
+      if (!isCurrent()) {
+        return null
+      }
     }
     loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
     return {

--- a/src/main/ipc/worktrees/listing/detected-worktree-scan-cache.ts
+++ b/src/main/ipc/worktrees/listing/detected-worktree-scan-cache.ts
@@ -4,7 +4,19 @@ import type { Repo } from '../../../../shared/repo-types'
 import { getLocalProjectWorktreeGitOptions } from '../../../project-runtime-git-options'
 import { isFolderRepo } from '../../../../shared/repo-kind'
 import { listRepoWorktrees } from '../../../repo-worktrees'
-import { registerWorktreeRootsForRepo } from '../../registered-worktree-roots-cache'
+import {
+  getRegisteredWorktreeRootsRevision,
+  registerWorktreeRootsForRepo
+} from '../../registered-worktree-roots-cache'
+import type { NativeLocalWorktreeMetadataScanExpectation } from '../../../persistence/tracking-repos/missing-local-worktree-metadata-pruning'
+import {
+  bumpLocalWorktreeScanGeneration,
+  getLocalWorktreeScanGeneration,
+  isLocalWorktreeScanGenerationCurrent,
+  resetLocalWorktreeScanGenerationsForTests
+} from '../../../local-worktree-scan-generation'
+import { pruneLineageForMissingRepoWorktrees } from '../../../worktree-lineage-pruning'
+import { pruneMetadataMissingFromAuthoritativeLocalScan } from './authoritative-local-worktree-metadata-pruning'
 
 // Why: absorb renderer polling bursts while bounding external worktree-change lag to one short refresh window.
 export const DETECTED_WORKTREE_SCAN_CACHE_TTL_MS = 5_000
@@ -17,17 +29,31 @@ export type DetectedWorktreeScanCacheEntry = {
 export type DetectedWorktreeScan = {
   invalidated: boolean
   promise: Promise<GitWorktreeInfo[]>
+  sideEffectToken: DetectedWorktreeSideEffectToken
+  metadataPrune?: DetectedWorktreeMetadataPrune
 }
+
+export type DetectedWorktreeSideEffectToken = Readonly<{
+  generation: number
+  authorizedRootsRevision: number
+}>
+
+export type DetectedWorktreeMetadataPrune = Readonly<{
+  expectation: NativeLocalWorktreeMetadataScanExpectation
+}>
 
 export type DetectedWorktreeScanResult = {
   gitWorktrees: GitWorktreeInfo[]
   fresh: boolean
+  sideEffectToken?: DetectedWorktreeSideEffectToken
+  metadataPrune?: DetectedWorktreeMetadataPrune
 }
 
 export const detectedWorktreeScanCache = new Map<string, DetectedWorktreeScanCacheEntry>()
 export const detectedWorktreeScanInFlight = new Map<string, DetectedWorktreeScan>()
 
 export function invalidateDetectedWorktreeScanCache(repoId: string): void {
+  bumpLocalWorktreeScanGeneration(repoId)
   const keyPrefix = `${repoId}\0`
   for (const key of new Set([
     ...detectedWorktreeScanCache.keys(),
@@ -53,6 +79,7 @@ export function __resetDetectedWorktreeScanCacheForTests(): void {
   }
   detectedWorktreeScanCache.clear()
   detectedWorktreeScanInFlight.clear()
+  resetLocalWorktreeScanGenerationsForTests()
 }
 
 export function __getDetectedWorktreeScanCacheStatsForTests(): {
@@ -88,26 +115,109 @@ export async function listDetectedGitWorktrees(
     return { gitWorktrees: await inFlight.promise, fresh: false }
   }
 
+  // Why: capture before invoking Git because listing can mutate synchronously before its first await.
+  // WSL listings can use UNC paths while legacy metadata keeps Linux paths; v1 cannot prove
+  // those aliases equivalent, so only native-host scans carry destructive expectations.
+  const generation = getLocalWorktreeScanGeneration(repo.id)
+  const authorizedRootsRevision = getRegisteredWorktreeRootsRevision(repo.id)
+  const metadataPruneExpectation = localWorktreeGitOptions.wslDistro
+    ? undefined
+    : store.captureNativeLocalWorktreeMetadataScanExpectation(repo)
   const scan: DetectedWorktreeScan = {
     invalidated: false,
-    promise: listRepoWorktrees(repo, localWorktreeGitOptions)
+    promise: listRepoWorktrees(repo, localWorktreeGitOptions),
+    sideEffectToken: { generation, authorizedRootsRevision },
+    ...(metadataPruneExpectation
+      ? {
+          metadataPrune: {
+            expectation: metadataPruneExpectation
+          }
+        }
+      : {})
   }
   detectedWorktreeScanInFlight.set(cacheKey, scan)
   try {
     const gitWorktrees = await scan.promise
+    const routingUnchanged =
+      getDetectedWorktreeScanCacheKey(repo.id, getLocalProjectWorktreeGitOptions(store, repo)) ===
+      cacheKey
     // Why: a create/remove notification can invalidate mid-scan; don't let that stale scan repopulate the cache afterward.
-    if (!scan.invalidated) {
+    const generationCurrent = isLocalWorktreeScanGenerationCurrent(repo.id, generation)
+    if (!scan.invalidated && routingUnchanged && generationCurrent) {
       detectedWorktreeScanCache.set(cacheKey, {
         worktrees: gitWorktrees,
         expiresAt: Date.now() + DETECTED_WORKTREE_SCAN_CACHE_TTL_MS
       })
     }
-    return { gitWorktrees, fresh: !scan.invalidated }
+    const fresh = !scan.invalidated && routingUnchanged && generationCurrent
+    return {
+      gitWorktrees,
+      fresh,
+      ...(fresh ? { sideEffectToken: scan.sideEffectToken } : {}),
+      ...(fresh && scan.metadataPrune ? { metadataPrune: scan.metadataPrune } : {})
+    }
   } finally {
     if (detectedWorktreeScanInFlight.get(cacheKey) === scan) {
       detectedWorktreeScanInFlight.delete(cacheKey)
     }
   }
+}
+
+export async function applyFreshDetectedWorktreeScanSideEffects(
+  store: Store,
+  repo: Repo,
+  gitWorktrees: GitWorktreeInfo[],
+  metadataPrune?: DetectedWorktreeMetadataPrune,
+  options: {
+    isCurrent?: () => boolean
+    sideEffectToken?: DetectedWorktreeSideEffectToken
+    signal?: AbortSignal
+  } = {}
+): Promise<boolean> {
+  const { isCurrent = () => true, sideEffectToken, signal } = options
+  const generationCurrent = () =>
+    sideEffectToken === undefined ||
+    isLocalWorktreeScanGenerationCurrent(repo.id, sideEffectToken.generation)
+  if (!generationCurrent() || !isCurrent()) {
+    return false
+  }
+  let preservedMetadataCandidateIds: ReadonlySet<string> | undefined
+  if (metadataPrune) {
+    if (!sideEffectToken) {
+      return false
+    }
+    const pruneResult = await pruneMetadataMissingFromAuthoritativeLocalScan({
+      store,
+      repo,
+      gitWorktrees,
+      scan: metadataPrune.expectation,
+      scanGeneration: sideEffectToken.generation,
+      isCallerCurrent: isCurrent,
+      signal
+    })
+    if (!pruneResult.scanGenerationCurrent || !generationCurrent() || !isCurrent()) {
+      return false
+    }
+    preservedMetadataCandidateIds = pruneResult.preservedMetadataCandidateIds
+  }
+  if (!generationCurrent() || !isCurrent()) {
+    return false
+  }
+
+  if (
+    sideEffectToken &&
+    getRegisteredWorktreeRootsRevision(repo.id) !== sideEffectToken.authorizedRootsRevision
+  ) {
+    return false
+  }
+  rememberLocalWorktreeRoots(store, repo, gitWorktrees)
+  pruneLineageForMissingRepoWorktrees(
+    store,
+    repo,
+    gitWorktrees,
+    preservedMetadataCandidateIds ? { preservedMetadataCandidateIds } : undefined
+  )
+  return true
 }
 
 export function getDetectedWorktreeScanCacheKey(

--- a/src/main/ipc/worktrees/listing/register-worktree-catalog-handlers.ts
+++ b/src/main/ipc/worktrees/listing/register-worktree-catalog-handlers.ts
@@ -2,7 +2,6 @@ import { ipcMain } from 'electron'
 import { isFolderRepo } from '../../../../shared/repo-kind'
 import { getRepoExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
 import { getSshGitProvider } from '../../../providers/ssh-git-dispatch'
-import { pruneLineageForMissingRepoWorktrees } from '../../../worktree-lineage-pruning'
 import { EMPTY_RETIRED_NAME_REGISTRY } from '../../../../shared/worktree/retired-name-registry'
 import { getRetiredNameRegistryForRepo } from '../../../worktree-name-retirement'
 import {
@@ -13,8 +12,10 @@ import {
 } from './ssh-worktree-fallback'
 import { listVisibleFolderWorkspaces } from './folder-workspace-catalog'
 import {
+  applyFreshDetectedWorktreeScanSideEffects,
   listDetectedGitWorktrees,
-  rememberLocalWorktreeRoots
+  type DetectedWorktreeMetadataPrune,
+  type DetectedWorktreeSideEffectToken
 } from './detected-worktree-scan-cache'
 import {
   loggedUnavailableSshGitProviders,
@@ -88,6 +89,8 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
       try {
         let gitWorktrees
         let freshScan = true
+        let sideEffectToken: DetectedWorktreeSideEffectToken | undefined
+        let metadataPrune: DetectedWorktreeMetadataPrune | undefined
         if (isFolderRepo(repo)) {
           return listVisibleFolderWorkspaces(store, repo)
         } else if (repo.connectionId) {
@@ -116,10 +119,19 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
           const scan = await listDetectedGitWorktrees(store, repo)
           gitWorktrees = scan.gitWorktrees
           freshScan = scan.fresh
+          sideEffectToken = scan.sideEffectToken
+          metadataPrune = scan.metadataPrune
         }
         if (freshScan) {
-          rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-          pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+          await applyFreshDetectedWorktreeScanSideEffects(
+            store,
+            repo,
+            gitWorktrees,
+            metadataPrune,
+            {
+              sideEffectToken
+            }
+          )
         }
         loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
         const metadata = metadataForRepo(repo)
@@ -169,6 +181,8 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
     try {
       let gitWorktrees
       let freshScan = true
+      let sideEffectToken: DetectedWorktreeSideEffectToken | undefined
+      let metadataPrune: DetectedWorktreeMetadataPrune | undefined
       if (isFolderRepo(repo)) {
         return listVisibleFolderWorkspaces(store, repo)
       } else if (repo.connectionId) {
@@ -197,10 +211,13 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
         const scan = await listDetectedGitWorktrees(store, repo)
         gitWorktrees = scan.gitWorktrees
         freshScan = scan.fresh
+        sideEffectToken = scan.sideEffectToken
+        metadataPrune = scan.metadataPrune
       }
       if (freshScan) {
-        rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-        pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+        await applyFreshDetectedWorktreeScanSideEffects(store, repo, gitWorktrees, metadataPrune, {
+          sideEffectToken
+        })
       }
       loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
       const metadata = allMeta ?? readAllWorktreeMetaForHost(store, getRepoExecutionHostId(repo))

--- a/src/main/local-worktree-path-presence.test.ts
+++ b/src/main/local-worktree-path-presence.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { statMock } = vi.hoisted(() => ({
+  statMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({ stat: statMock }))
+
+import {
+  LOCAL_WORKTREE_PATH_PROBE_TIMEOUT_MS,
+  localWorktreePathExistsOrIsUnverifiable,
+  localWorktreePathsExistOrAreUnverifiable
+} from './local-worktree-path-presence'
+
+function fsError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(code), { code })
+}
+
+function installFakeAbortSignalTimeout(): AbortController[] {
+  const controllers: AbortController[] = []
+  vi.spyOn(AbortSignal, 'timeout').mockImplementation((timeoutMs) => {
+    const controller = new AbortController()
+    controllers.push(controller)
+    setTimeout(
+      () => controller.abort(new DOMException('The operation timed out.', 'TimeoutError')),
+      timeoutMs
+    )
+    return controller.signal
+  })
+  return controllers
+}
+
+describe('local worktree path presence', () => {
+  beforeEach(() => {
+    statMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('returns one result per distinct path and only treats ENOENT/ENOTDIR as missing', async () => {
+    statMock.mockImplementation(async (pathValue: string) => {
+      if (pathValue === '/missing') {
+        throw fsError('ENOENT')
+      }
+      if (pathValue === '/not-a-directory') {
+        throw fsError('ENOTDIR')
+      }
+      if (pathValue === '/permission-denied') {
+        throw fsError('EACCES')
+      }
+      return {}
+    })
+
+    const result = await localWorktreePathsExistOrAreUnverifiable([
+      '/present',
+      '/missing',
+      '/not-a-directory',
+      '/permission-denied',
+      '/present'
+    ])
+
+    expect([...result.entries()]).toEqual([
+      ['/present', true],
+      ['/missing', false],
+      ['/not-a-directory', false],
+      ['/permission-denied', true]
+    ])
+    expect(statMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('does not allocate a deadline when there are no paths to probe', async () => {
+    const timeout = vi.spyOn(AbortSignal, 'timeout')
+
+    await expect(localWorktreePathsExistOrAreUnverifiable([])).resolves.toEqual(new Map())
+
+    expect(timeout).not.toHaveBeenCalled()
+    expect(statMock).not.toHaveBeenCalled()
+  })
+
+  it('globally bounds stat calls across simultaneous bulk probes', async () => {
+    let active = 0
+    let maximumActive = 0
+    const pending: (() => void)[] = []
+    statMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          active += 1
+          maximumActive = Math.max(maximumActive, active)
+          pending.push(() => {
+            active -= 1
+            resolve({})
+          })
+        })
+    )
+
+    const first = localWorktreePathsExistOrAreUnverifiable([
+      '/first-1',
+      '/first-2',
+      '/first-3',
+      '/first-4'
+    ])
+    const second = localWorktreePathsExistOrAreUnverifiable([
+      '/second-1',
+      '/second-2',
+      '/second-3',
+      '/second-4'
+    ])
+
+    let resolved = 0
+    while (resolved < 8) {
+      while (pending.length === 0) {
+        await Promise.resolve()
+      }
+      pending.shift()?.()
+      resolved += 1
+      await Promise.resolve()
+    }
+
+    await Promise.all([first, second])
+
+    expect(maximumActive).toBe(2)
+    expect(statMock).toHaveBeenCalledTimes(8)
+  })
+
+  it('uses the same fail-closed classification for a single probe', async () => {
+    statMock.mockRejectedValueOnce(fsError('ENOENT'))
+    statMock.mockRejectedValueOnce(fsError('ENOTDIR'))
+    statMock.mockRejectedValueOnce(fsError('EIO'))
+
+    await expect(localWorktreePathExistsOrIsUnverifiable('/missing')).resolves.toBe(false)
+    await expect(localWorktreePathExistsOrIsUnverifiable('/parent-missing')).resolves.toBe(false)
+    await expect(localWorktreePathExistsOrIsUnverifiable('/unverifiable')).resolves.toBe(true)
+  })
+
+  it('settles timed-out batches without exceeding or leaking the global stat bound', async () => {
+    vi.useFakeTimers()
+    const timeoutControllers = installFakeAbortSignalTimeout()
+    const releaseStats: (() => void)[] = []
+    let returnMissing = false
+    statMock.mockImplementation(() =>
+      returnMissing
+        ? Promise.reject(fsError('ENOENT'))
+        : new Promise((resolve) => releaseStats.push(() => resolve({})))
+    )
+
+    try {
+      const firstPaths = ['/first-1', '/first-2', '/first-3', '/first-4']
+      const first = localWorktreePathsExistOrAreUnverifiable(firstPaths)
+      let firstSettled = false
+      void first.then(() => {
+        firstSettled = true
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(statMock).toHaveBeenCalledTimes(2)
+      await vi.advanceTimersByTimeAsync(LOCAL_WORKTREE_PATH_PROBE_TIMEOUT_MS - 1)
+      expect(firstSettled).toBe(false)
+      await vi.advanceTimersByTimeAsync(1)
+      await expect(first).resolves.toEqual(
+        new Map(firstPaths.map((pathValue) => [pathValue, true]))
+      )
+      expect(statMock).toHaveBeenCalledTimes(2)
+
+      const secondPaths = ['/second-1', '/second-2', '/second-3']
+      const second = localWorktreePathsExistOrAreUnverifiable(secondPaths)
+      await vi.advanceTimersByTimeAsync(LOCAL_WORKTREE_PATH_PROBE_TIMEOUT_MS)
+      await expect(second).resolves.toEqual(
+        new Map(secondPaths.map((pathValue) => [pathValue, true]))
+      )
+      expect(statMock).toHaveBeenCalledTimes(2)
+
+      returnMissing = true
+      releaseStats.splice(0).forEach((release) => release())
+      await vi.advanceTimersByTimeAsync(0)
+
+      await expect(localWorktreePathsExistOrAreUnverifiable(['/after-release'])).resolves.toEqual(
+        new Map([['/after-release', false]])
+      )
+      expect(statMock).toHaveBeenCalledTimes(3)
+    } finally {
+      timeoutControllers.forEach((controller) => controller.abort())
+      releaseStats.splice(0).forEach((release) => release())
+      await Promise.resolve()
+      await Promise.resolve()
+    }
+  })
+
+  it('settles promptly and fail closed when the caller aborts hung probes', async () => {
+    vi.useFakeTimers()
+    const timeoutControllers = installFakeAbortSignalTimeout()
+    const releaseStats: (() => void)[] = []
+    statMock.mockImplementation(
+      () => new Promise((resolve) => releaseStats.push(() => resolve({})))
+    )
+    const controller = new AbortController()
+    const paths = ['/abort-1', '/abort-2', '/abort-3']
+
+    try {
+      const result = localWorktreePathsExistOrAreUnverifiable(paths, {
+        signal: controller.signal
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(statMock).toHaveBeenCalledTimes(2)
+
+      controller.abort()
+
+      await expect(result).resolves.toEqual(new Map(paths.map((pathValue) => [pathValue, true])))
+      expect(vi.getTimerCount()).toBeGreaterThan(0)
+    } finally {
+      timeoutControllers.forEach((timeoutController) => timeoutController.abort())
+      releaseStats.splice(0).forEach((release) => release())
+      await Promise.resolve()
+      await Promise.resolve()
+    }
+  })
+})

--- a/src/main/local-worktree-path-presence.ts
+++ b/src/main/local-worktree-path-presence.ts
@@ -1,0 +1,72 @@
+import { stat } from 'node:fs/promises'
+import { mapWithConcurrency } from '../shared/map-with-concurrency'
+import { PrioritySemaphore } from '../shared/priority-semaphore'
+
+// Why: share one bound across polling callers so slow mounts cannot multiply libuv work.
+const LOCAL_WORKTREE_PATH_PROBE_CONCURRENCY = 2
+export const LOCAL_WORKTREE_PATH_PROBE_TIMEOUT_MS = 2_000
+const localWorktreePathProbeSemaphore = new PrioritySemaphore(LOCAL_WORKTREE_PATH_PROBE_CONCURRENCY)
+
+function probeDeadline(signal?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(LOCAL_WORKTREE_PATH_PROBE_TIMEOUT_MS)
+  return signal ? AbortSignal.any([signal, timeout]) : timeout
+}
+
+async function probeLocalWorktreePath(pathValue: string, signal: AbortSignal): Promise<boolean> {
+  let release: () => void
+  try {
+    release = await localWorktreePathProbeSemaphore.acquire(0, signal)
+  } catch {
+    return true
+  }
+  if (signal.aborted) {
+    release()
+    return true
+  }
+  const presence = stat(pathValue)
+    .then(
+      () => true,
+      (error) => {
+        const code = (error as NodeJS.ErrnoException | undefined)?.code
+        return code !== 'ENOENT' && code !== 'ENOTDIR'
+      }
+    )
+    .finally(release)
+  if (signal.aborted) {
+    return true
+  }
+  return new Promise((resolve) => {
+    const finish = (value: boolean): void => {
+      signal.removeEventListener('abort', onAbort)
+      resolve(value)
+    }
+    const onAbort = (): void => finish(true)
+    signal.addEventListener('abort', onAbort, { once: true })
+    void presence.then(finish)
+  })
+}
+
+/** A non-absence filesystem error cannot prove a native-local worktree disappeared. */
+export function localWorktreePathExistsOrIsUnverifiable(
+  pathValue: string,
+  options: { signal?: AbortSignal } = {}
+): Promise<boolean> {
+  return probeLocalWorktreePath(pathValue, probeDeadline(options.signal))
+}
+
+export async function localWorktreePathsExistOrAreUnverifiable(
+  pathValues: readonly string[],
+  options: { signal?: AbortSignal } = {}
+): Promise<ReadonlyMap<string, boolean>> {
+  const uniquePaths = [...new Set(pathValues)]
+  if (uniquePaths.length === 0) {
+    return new Map()
+  }
+  const signal = probeDeadline(options.signal)
+  const results = await mapWithConcurrency(
+    uniquePaths,
+    LOCAL_WORKTREE_PATH_PROBE_CONCURRENCY,
+    async (pathValue) => [pathValue, await probeLocalWorktreePath(pathValue, signal)] as const
+  )
+  return new Map(results)
+}

--- a/src/main/local-worktree-scan-generation.ts
+++ b/src/main/local-worktree-scan-generation.ts
@@ -1,0 +1,25 @@
+const generationByRepoId = new Map<string, number>()
+let generationSequence = 0
+
+export function getLocalWorktreeScanGeneration(repoId: string): number {
+  const existing = generationByRepoId.get(repoId)
+  if (existing !== undefined) {
+    return existing
+  }
+  const generation = ++generationSequence
+  generationByRepoId.set(repoId, generation)
+  return generation
+}
+
+export function bumpLocalWorktreeScanGeneration(repoId: string): void {
+  generationByRepoId.set(repoId, ++generationSequence)
+}
+
+export function isLocalWorktreeScanGenerationCurrent(repoId: string, generation: number): boolean {
+  return getLocalWorktreeScanGeneration(repoId) === generation
+}
+
+export function resetLocalWorktreeScanGenerationsForTests(): void {
+  generationSequence += 1
+  generationByRepoId.clear()
+}

--- a/src/main/persistence-initial-load.test.ts
+++ b/src/main/persistence-initial-load.test.ts
@@ -16,6 +16,10 @@ import {
   makeProjectHostSetup
 } from './persistence-test-harness'
 import { TEST_LEAF_1 } from './persistence-session-fixtures'
+import {
+  getLocalWorktreeScanGeneration,
+  isLocalWorktreeScanGenerationCurrent
+} from './local-worktree-scan-generation'
 
 // Stub the ~/.ssh/config parser so the SSH-import test drives the real Store with deterministic hosts, not the operator's actual ~/.ssh/config.
 const { loadUserSshConfigMock, sshConfigHostsToTargetsMock } = vi.hoisted(() => ({
@@ -304,12 +308,13 @@ describe('Store', () => {
 
   it('updates and persists a project Windows runtime preference', async () => {
     const project = makeProject({
-      id: 'project-1',
+      id: 'repo:r1',
       sourceRepoIds: ['r1'],
       localWindowsRuntimePreference: { kind: 'inherit-global' }
     })
     writeDataFile({
       ...getDefaultPersistedState(testState.dir),
+      repos: [makeRepo({ id: 'r1' })],
       projects: [project],
       projectHostSetups: [
         makeProjectHostSetup({
@@ -320,12 +325,14 @@ describe('Store', () => {
       ]
     })
     const store = await createStore()
+    const scanGeneration = getLocalWorktreeScanGeneration('r1')
 
-    const updated = store.updateProject('project-1', {
+    const updated = store.updateProject(project.id, {
       localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
     })
 
     expect(updated?.localWindowsRuntimePreference).toEqual({ kind: 'wsl', distro: 'Ubuntu' })
+    expect(isLocalWorktreeScanGenerationCurrent('r1', scanGeneration)).toBe(false)
     store.flush()
     const reloaded = await createStore()
     expect(reloaded.getProjects()[0]?.localWindowsRuntimePreference).toEqual({

--- a/src/main/persistence-repo-lifecycle.test.ts
+++ b/src/main/persistence-repo-lifecycle.test.ts
@@ -14,6 +14,10 @@ import {
   makeTerminalTab,
   makeWorktreeLineage
 } from './persistence-test-harness'
+import {
+  getLocalWorktreeScanGeneration,
+  isLocalWorktreeScanGenerationCurrent
+} from './local-worktree-scan-generation'
 
 // Stub the ~/.ssh/config parser so the SSH-import test drives the real Store with deterministic hosts, not the operator's actual ~/.ssh/config.
 const { loadUserSshConfigMock, sshConfigHostsToTargetsMock } = vi.hoisted(() => ({
@@ -77,6 +81,23 @@ describe('Store', () => {
     expect(fetched!.displayName).toBe('test')
     // No username has been resolved yet — hydration must not probe git/gh.
     expect(fetched!.gitUsername).toBe('')
+  })
+
+  it('invalidates local scans across add, remove, and same-id re-add', async () => {
+    const store = await createStore()
+    const repoId = 'scan-lifecycle'
+    const beforeAdd = getLocalWorktreeScanGeneration(repoId)
+
+    store.addRepo(makeRepo({ id: repoId }))
+    expect(isLocalWorktreeScanGenerationCurrent(repoId, beforeAdd)).toBe(false)
+
+    const beforeRemove = getLocalWorktreeScanGeneration(repoId)
+    store.removeProject(repoId)
+    expect(isLocalWorktreeScanGenerationCurrent(repoId, beforeRemove)).toBe(false)
+
+    const beforeReAdd = getLocalWorktreeScanGeneration(repoId)
+    store.addRepo(makeRepo({ id: repoId, path: '/replacement' }))
+    expect(isLocalWorktreeScanGenerationCurrent(repoId, beforeReAdd)).toBe(false)
   })
 
   it('setResolvedRepoGitUsername persists the enriched username for hydration', async () => {
@@ -368,6 +389,24 @@ describe('Store', () => {
   })
 
   // ── 6b. removeProjectForHost is host-scoped ───────────────────────────
+
+  it('invalidates local scans when one host registration is removed', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo({ id: 'shared', path: '/local/repo' }))
+    store.addRepo(
+      makeRepo({
+        id: 'shared',
+        path: '/remote/repo',
+        connectionId: 'ssh-old',
+        executionHostId: 'ssh:ssh-old'
+      })
+    )
+    const beforeRemove = getLocalWorktreeScanGeneration('shared')
+
+    store.removeProjectForHost('shared', 'ssh:ssh-old')
+
+    expect(isLocalWorktreeScanGenerationCurrent('shared', beforeRemove)).toBe(false)
+  })
 
   it('removeProjectForHost removes only the target host row for a shared repo id', async () => {
     const store = await createStore()

--- a/src/main/persistence-settings-update.test.ts
+++ b/src/main/persistence-settings-update.test.ts
@@ -14,6 +14,10 @@ import {
   makeRepo,
   makeTerminalTab
 } from './persistence-test-harness'
+import {
+  getLocalWorktreeScanGeneration,
+  isLocalWorktreeScanGenerationCurrent
+} from './local-worktree-scan-generation'
 
 // Stub the ~/.ssh/config parser so the SSH-import test drives the real Store with deterministic hosts, not the operator's actual ~/.ssh/config.
 const { loadUserSshConfigMock, sshConfigHostsToTargetsMock } = vi.hoisted(() => ({
@@ -225,6 +229,21 @@ describe('Store', () => {
     store.updateSettings({ theme: 'dark' })
 
     expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('invalidates local worktree scans when the global Windows runtime changes', async () => {
+    writeDataFile({ repos: [makeRepo()] })
+    const store = await createStore()
+    const generation = getLocalWorktreeScanGeneration('r1')
+
+    store.updateSettings({ theme: 'dark' })
+    expect(isLocalWorktreeScanGenerationCurrent('r1', generation)).toBe(true)
+
+    store.updateSettings({
+      localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+
+    expect(isLocalWorktreeScanGenerationCurrent('r1', generation)).toBe(false)
   })
 
   it('migrates missing terminal scrollback rows to the row default and writes back rows only', async () => {

--- a/src/main/persistence-update-repo.test.ts
+++ b/src/main/persistence-update-repo.test.ts
@@ -11,6 +11,10 @@ import {
   makeProject,
   makeProjectHostSetup
 } from './persistence-test-harness'
+import {
+  getLocalWorktreeScanGeneration,
+  isLocalWorktreeScanGenerationCurrent
+} from './local-worktree-scan-generation'
 
 // Stub the ~/.ssh/config parser so the SSH-import test drives the real Store with deterministic hosts, not the operator's actual ~/.ssh/config.
 const { loadUserSshConfigMock, sshConfigHostsToTargetsMock } = vi.hoisted(() => ({
@@ -73,6 +77,25 @@ describe('Store', () => {
     expect(updated).not.toBeNull()
     expect(updated!.displayName).toBe('renamed')
     expect(store.getRepo('r1')!.displayName).toBe('renamed')
+  })
+
+  it('invalidates local worktree scans across a git-folder-git update round trip', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo({ id: 'scan-round-trip', kind: 'git' }))
+
+    const initialGeneration = getLocalWorktreeScanGeneration('scan-round-trip')
+    expect(isLocalWorktreeScanGenerationCurrent('scan-round-trip', initialGeneration)).toBe(true)
+
+    const folder = store.updateRepo('scan-round-trip', { kind: 'folder' })
+    expect(folder?.kind).toBe('folder')
+    expect(isLocalWorktreeScanGenerationCurrent('scan-round-trip', initialGeneration)).toBe(false)
+
+    const folderGeneration = getLocalWorktreeScanGeneration('scan-round-trip')
+    expect(isLocalWorktreeScanGenerationCurrent('scan-round-trip', folderGeneration)).toBe(true)
+
+    const git = store.updateRepo('scan-round-trip', { kind: 'git' })
+    expect(git?.kind).toBe('git')
+    expect(isLocalWorktreeScanGenerationCurrent('scan-round-trip', folderGeneration)).toBe(false)
   })
 
   it('updateRepo targets one host when repo ids collide', async () => {

--- a/src/main/persistence/applying-settings/settings-update.ts
+++ b/src/main/persistence/applying-settings/settings-update.ts
@@ -41,6 +41,7 @@ import {
 
 export type SettingsMutationOperations = {
   state: PersistedState
+  bumpLocalWorktreeScanGeneration: (repoId: string) => void
   removeRetainedBlob: (
     slot: Parameters<ProtectedSecretPersistence['removeRetainedBlob']>[0]
   ) => void
@@ -241,6 +242,16 @@ export function updateSettings(
       ...sanitizedUpdates.notifications
     }),
     ...(mergedTelemetry !== undefined ? { telemetry: mergedTelemetry } : {})
+  }
+  if (
+    !Object.is(
+      previousSettings.localWindowsRuntimeDefault,
+      operations.state.settings.localWindowsRuntimeDefault
+    )
+  ) {
+    for (const repoId of new Set(operations.state.repos.map(({ id }) => id))) {
+      operations.bumpLocalWorktreeScanGeneration(repoId)
+    }
   }
   operations.scheduleSave()
   const changedUpdates = {} as Partial<GlobalSettings> & Record<string, unknown>

--- a/src/main/persistence/loading-store/metadata-lineage-batch-pruning.test.ts
+++ b/src/main/persistence/loading-store/metadata-lineage-batch-pruning.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultPersistedState } from '../../../shared/constants'
+import type { Repo } from '../../../shared/repo-types'
+import type { WorktreeMeta } from '../../../shared/worktree/meta-types'
+import type * as WriteSchedulingModule from './write-scheduling'
+import { MetadataLineageOperations } from './metadata-lineage-operations'
+
+const { scheduleSaveMock } = vi.hoisted(() => ({ scheduleSaveMock: vi.fn() }))
+
+vi.mock('./write-scheduling', async (importOriginal) => ({
+  ...(await importOriginal<typeof WriteSchedulingModule>()),
+  scheduleSave: scheduleSaveMock
+}))
+
+const REPO: Repo = {
+  id: 'repo-1',
+  path: '/workspace/repo',
+  displayName: 'repo',
+  badgeColor: '#000',
+  addedAt: 0
+}
+
+function makeMeta(worktreeId: string): WorktreeMeta {
+  return {
+    instanceId: `instance-${worktreeId}`,
+    hostId: 'local',
+    displayName: worktreeId,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+describe('MetadataLineageOperations batch metadata pruning', () => {
+  it('schedules one save for thousands of removals and none for a no-op retry', () => {
+    const state = getDefaultPersistedState('/home/test')
+    state.repos = [REPO]
+    const staleIds = Array.from(
+      { length: 2_709 },
+      (_, index) => `${REPO.id}::/workspace/stale-${index}`
+    )
+    for (const worktreeId of staleIds) {
+      state.worktreeMeta[worktreeId] = makeMeta(worktreeId)
+    }
+    const operations = new MetadataLineageOperations({ state } as never, {} as never, {} as never)
+    const scan = operations.captureNativeLocalWorktreeMetadataScanExpectation(REPO)
+
+    expect(
+      operations.pruneSessionlessMissingLocalWorktreeMetadataForRepo(scan, scan.metadata)
+    ).toHaveLength(staleIds.length)
+    expect(scheduleSaveMock).toHaveBeenCalledTimes(1)
+
+    expect(
+      operations.pruneSessionlessMissingLocalWorktreeMetadataForRepo(scan, scan.metadata)
+    ).toEqual([])
+    expect(scheduleSaveMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/persistence/loading-store/metadata-lineage-operations.ts
+++ b/src/main/persistence/loading-store/metadata-lineage-operations.ts
@@ -1,6 +1,7 @@
 import type { WorkspaceKey } from '../../../shared/folder-workspace-types'
 import type { WorkspaceLineage, WorktreeLineage } from '../../../shared/worktree/lineage-types'
 import type { WorktreeMeta } from '../../../shared/worktree/meta-types'
+import type { Repo } from '../../../shared/repo-types'
 import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../shared/execution-host'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
 import { hasWorktreeRemovalRepoOwnerOnOtherHost } from '../../worktree-removal-repo-owner'
@@ -28,6 +29,12 @@ import {
   setWorktreeMetaForHost as setWorktreeMetaForHostOperation
 } from './worktree-identity-metadata'
 import { mergeWorktreeMetaForWrite } from './worktree-meta-write-normalization'
+import {
+  captureNativeLocalWorktreeMetadataScanExpectation as captureNativeLocalWorktreeMetadataScanExpectationOperation,
+  pruneSessionlessMissingLocalWorktreeMetadataForRepo as pruneSessionlessMissingLocalWorktreeMetadataForRepoOperation,
+  type LocalWorktreeMetadataPruneExpectation,
+  type NativeLocalWorktreeMetadataScanExpectation
+} from '../tracking-repos/missing-local-worktree-metadata-pruning'
 
 type MetadataLineageOperationsRuntime = Pick<StoreRuntimeState, 'state'>
 
@@ -86,6 +93,15 @@ export class MetadataLineageOperations {
     return getAllWorktreeMetaForHostOperation(
       this[metadataLineageOperationsContext].runtime,
       executionHostId
+    )
+  }
+
+  captureNativeLocalWorktreeMetadataScanExpectation(
+    repo: Repo
+  ): NativeLocalWorktreeMetadataScanExpectation {
+    return captureNativeLocalWorktreeMetadataScanExpectationOperation(
+      this[metadataLineageOperationsContext].runtime.state,
+      repo
     )
   }
 
@@ -182,6 +198,21 @@ export class MetadataLineageOperations {
       )
     }
     scheduleSave(this[metadataLineageOperationsContext].scheduling)
+  }
+
+  pruneSessionlessMissingLocalWorktreeMetadataForRepo(
+    scan: NativeLocalWorktreeMetadataScanExpectation,
+    missingMetadata: readonly LocalWorktreeMetadataPruneExpectation[]
+  ): string[] {
+    const removed = pruneSessionlessMissingLocalWorktreeMetadataForRepoOperation(
+      this[metadataLineageOperationsContext].runtime.state,
+      scan,
+      missingMetadata
+    )
+    if (removed.length > 0) {
+      scheduleSave(this[metadataLineageOperationsContext].scheduling)
+    }
+    return removed
   }
 
   getWorktreeLineage(worktreeId: string): WorktreeLineage | undefined {

--- a/src/main/persistence/loading-store/profile-preferences.ts
+++ b/src/main/persistence/loading-store/profile-preferences.ts
@@ -17,6 +17,7 @@ import {
 import type { StoreRuntimeState } from './store-runtime-state'
 import type { WriteSchedulingOperations } from './write-scheduling'
 import { scheduleSave } from './write-scheduling'
+import { bumpLocalWorktreeScanGeneration } from '../../local-worktree-scan-generation'
 
 type ProfilePreferencesRuntime = Pick<
   StoreRuntimeState,
@@ -155,6 +156,7 @@ export function getSettingsMutationOperations(
 ): SettingsMutationOperations {
   return {
     state: owner[profilePreferencesContext].runtime.state,
+    bumpLocalWorktreeScanGeneration,
     removeRetainedBlob: (slot) =>
       owner[profilePreferencesContext].runtime.protectedSecrets.removeRetainedBlob(slot),
     scheduleSave: () => scheduleSave(owner[profilePreferencesContext].scheduling),

--- a/src/main/persistence/loading-store/project-collection-operations.ts
+++ b/src/main/persistence/loading-store/project-collection-operations.ts
@@ -28,6 +28,7 @@ import {
 } from './repo-lifecycle-operations'
 import { scheduleSave } from './write-scheduling'
 import { removeWorkspaceLineageForFolderParent } from './metadata-lineage-operations'
+import { bumpLocalWorktreeScanGeneration } from '../../local-worktree-scan-generation'
 
 type ProjectCollectionOperationsRuntime = Pick<
   StoreRuntimeState,
@@ -159,6 +160,7 @@ export function getProjectHostOperations(
     new ProjectHostPersistenceOperations({
       state: owner[projectCollectionOperationsContext].runtime.state,
       gitUsernameCache: owner[projectCollectionOperationsContext].runtime.gitUsernameCache,
+      bumpLocalWorktreeScanGeneration,
       hydrateRepo: (repo) => hydrateRepo(owner[projectCollectionOperationsContext].repos, repo),
       updateRepoBackedProjectHostSetup: (setup, repo, updates) =>
         updateRepoBackedProjectHostSetup(

--- a/src/main/persistence/loading-store/repo-lifecycle-operations.ts
+++ b/src/main/persistence/loading-store/repo-lifecycle-operations.ts
@@ -15,6 +15,7 @@ import { pruneWorktreeStateForRepo as pruneWorktreeStateForRepoOperation } from 
 import { hydrateRepo as hydrateRepoOperation } from '../tracking-repos/repo-hydration'
 import { RepoUpdatePersistenceOperations } from '../tracking-repos/repo-update-operations'
 import { ProjectHostSetupPersistenceOperations } from '../tracking-repos/project-host-setup-update'
+import { bumpLocalWorktreeScanGeneration } from '../../local-worktree-scan-generation'
 
 import type { StoreRuntimeState } from './store-runtime-state'
 import type { WriteSchedulingOperations } from './write-scheduling'
@@ -43,6 +44,7 @@ export class RepoLifecycleOperations {
   }
 
   addRepo(repo: Repo): void {
+    bumpLocalWorktreeScanGeneration(repo.id)
     getRepoOrderOperations(this).addRepo(repo)
   }
 
@@ -55,9 +57,15 @@ export class RepoLifecycleOperations {
   }
 
   removeProject(id: string): void {
+    const repoRemoved = this[repoLifecycleOperationsContext].runtime.state.repos.some(
+      (repo) => repo.id === id
+    )
     this[repoLifecycleOperationsContext].runtime.state.repos = this[
       repoLifecycleOperationsContext
     ].runtime.state.repos.filter((r) => r.id !== id)
+    if (repoRemoved) {
+      bumpLocalWorktreeScanGeneration(id)
+    }
     syncProjectHostSetupCompatibilityState(this)
     // Why: presets are repo-scoped and unreachable once the repo is gone, so drop them with it.
     delete this[repoLifecycleOperationsContext].runtime.state.sparsePresetsByRepo[id]
@@ -77,9 +85,15 @@ export class RepoLifecycleOperations {
   }
 
   removeProjectForHost(id: string, hostId: ExecutionHostId): void {
+    const repoRemoved = this[repoLifecycleOperationsContext].runtime.state.repos.some(
+      (repo) => repo.id === id && getRepoExecutionHostId(repo) === hostId
+    )
     this[repoLifecycleOperationsContext].runtime.state.repos = this[
       repoLifecycleOperationsContext
     ].runtime.state.repos.filter((r) => !(r.id === id && getRepoExecutionHostId(r) === hostId))
+    if (repoRemoved) {
+      bumpLocalWorktreeScanGeneration(id)
+    }
     const idStillPresent = this[repoLifecycleOperationsContext].runtime.state.repos.some(
       (r) => r.id === id
     )
@@ -204,6 +218,7 @@ export function getRepoUpdateOperations(
   owner[repoLifecycleOperationsContext].runtime.repoUpdateOperations ??=
     new RepoUpdatePersistenceOperations({
       state: owner[repoLifecycleOperationsContext].runtime.state,
+      bumpLocalWorktreeScanGeneration,
       syncProjectHostSetupCompatibilityState: () => syncProjectHostSetupCompatibilityState(owner),
       scheduleSave: () => scheduleSave(owner[repoLifecycleOperationsContext].scheduling),
       hydrateRepo: (repo) => hydrateRepo(owner, repo)

--- a/src/main/persistence/loading-store/worktree-identity-metadata.ts
+++ b/src/main/persistence/loading-store/worktree-identity-metadata.ts
@@ -36,11 +36,18 @@ function resolveAliasIdentityKey(state: PersistedState, alias: string): string |
 }
 
 /** Drop identity metadata no alias points at any more. */
-export function pruneUnreferencedWorktreeIdentityMeta(state: PersistedState): boolean {
+export function pruneUnreferencedWorktreeIdentityMeta(
+  state: PersistedState,
+  candidates?: ReadonlySet<string>
+): boolean {
   const referenced = new Set(Object.values(state.worktreeIdentityAliases ?? {}).flat())
   let changed = false
-  for (const identityKey of Object.keys(state.worktreeMetaByIdentity ?? {})) {
-    if (!referenced.has(identityKey)) {
+  const identityKeys = candidates ?? Object.keys(state.worktreeMetaByIdentity ?? {})
+  for (const identityKey of identityKeys) {
+    if (
+      Object.hasOwn(state.worktreeMetaByIdentity ?? {}, identityKey) &&
+      !referenced.has(identityKey)
+    ) {
       delete state.worktreeMetaByIdentity?.[identityKey]
       changed = true
     }

--- a/src/main/persistence/restoring-sessions/session-worktree-ownership.test.ts
+++ b/src/main/persistence/restoring-sessions/session-worktree-ownership.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultPersistedState, getDefaultWorkspaceSession } from '../../../shared/constants'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { worktreeWorkspaceKey } from '../../../shared/workspace-scope'
+import {
+  collectPersistedSessionWorktreeOwners,
+  collectWorkspaceSessionWorktreeOwners
+} from './session-worktree-ownership'
+
+const TARGET = 'repo-1::/workspace/target'
+const OTHER = 'repo-1::/workspace/other'
+
+function sessionWith(field: keyof WorkspaceSessionState, value: unknown): WorkspaceSessionState {
+  return { ...getDefaultWorkspaceSession(), [field]: value } as WorkspaceSessionState
+}
+
+function collected(session: WorkspaceSessionState): string[] {
+  return [...collectWorkspaceSessionWorktreeOwners(session, new Set([TARGET]))]
+}
+
+const OWNER_KEYED_FIELD_VALUES = [
+  ['tabsByWorktree', []],
+  ['openFilesByWorktree', []],
+  ['activeFileIdByWorktree', null],
+  ['browserTabsByWorktree', []],
+  ['activeBrowserTabIdByWorktree', null],
+  ['clientHostedBrowserPagesByWorktree', []],
+  ['activeTabTypeByWorktree', 'terminal'],
+  ['activeTabIdByWorktree', null],
+  ['unifiedTabs', []],
+  ['tabGroups', []],
+  ['tabGroupLayouts', { type: 'leaf', groupId: 'group-1' }],
+  ['activeGroupIdByWorktree', 'group-1'],
+  ['lastVisitedAtByWorktreeId', 0],
+  ['defaultTerminalTabsAppliedByWorktreeId', true]
+] as const satisfies readonly [keyof WorkspaceSessionState, unknown][]
+
+describe('workspace session worktree ownership', () => {
+  it.each(OWNER_KEYED_FIELD_VALUES)(
+    'treats a key in %s as ownership even when its bucket is empty or null',
+    (field, value) => {
+      expect(collected(sessionWith(field, { [TARGET]: value }))).toEqual([TARGET])
+    }
+  )
+
+  it.each([
+    ['active worktree', sessionWith('activeWorktreeId', TARGET)],
+    ['active workspace', sessionWith('activeWorkspaceKey', worktreeWorkspaceKey(TARGET))],
+    ['shutdown owner', sessionWith('activeWorktreeIdsOnShutdown', [TARGET])],
+    [
+      'host-qualified recency owner',
+      sessionWith('lastVisitedAtByWorktreeId', { [`ssh:builder|${TARGET}`]: 1 })
+    ]
+  ])('collects the %s', (_label, session) => {
+    expect(collected(session)).toEqual([TARGET])
+  })
+
+  it.each([
+    ['terminal tab', 'tabsByWorktree', { [OTHER]: [{ worktreeId: TARGET }] }],
+    ['open file', 'openFilesByWorktree', { [OTHER]: [{ worktreeId: TARGET }] }],
+    ['unified tab', 'unifiedTabs', { [OTHER]: [{ worktreeId: TARGET }] }],
+    ['tab group', 'tabGroups', { [OTHER]: [{ worktreeId: TARGET }] }],
+    ['browser workspace', 'browserTabsByWorktree', { [OTHER]: [{ worktreeId: TARGET }] }],
+    [
+      'browser workspace document',
+      'browserTabsByWorktree',
+      { [OTHER]: [{ worktreeId: OTHER, docLocation: { worktreeId: TARGET } }] }
+    ],
+    ['browser page', 'browserPagesByWorkspace', { page: [{ worktreeId: TARGET }] }],
+    [
+      'browser page document',
+      'browserPagesByWorkspace',
+      { page: [{ worktreeId: OTHER, docLocation: { worktreeId: TARGET } }] }
+    ],
+    [
+      'browser close intent',
+      'clientHostedBrowserCloseIntentsByEnvironment',
+      { environment: [{ worktreeId: TARGET }] }
+    ],
+    ['sleeping agent', 'sleepingAgentSessionsByPaneKey', { pane: { worktreeId: TARGET } }],
+    ['terminal tombstone', 'terminalSurfaceTombstonesByPaneKey', { pane: { worktreeId: TARGET } }],
+    [
+      'closed-terminal tombstone',
+      'closedTerminalTabTombstonesByTabId',
+      { tab: { worktreeId: TARGET } }
+    ]
+  ] as const)(
+    'collects a %s value even when its enclosing key names something else',
+    (_label, field, value) => {
+      expect(collected(sessionWith(field, value))).toEqual([TARGET])
+    }
+  )
+
+  it('collects ownership from every persisted host partition', () => {
+    const state = getDefaultPersistedState('/home/test')
+    state.workspaceSessionsByHostId = {
+      'ssh:builder': sessionWith('tabsByWorktree', { [TARGET]: [] }),
+      'runtime:environment': sessionWith('activeWorktreeIdsOnShutdown', [OTHER])
+    }
+
+    expect(
+      [...collectPersistedSessionWorktreeOwners(state, new Set([TARGET, OTHER]))].sort()
+    ).toEqual([OTHER, TARGET])
+  })
+
+  it('prefers an exact candidate id over workspace-key prefix parsing', () => {
+    const prefixedId = 'folder::/workspace/target'
+    const session = sessionWith('tabsByWorktree', { [prefixedId]: [] })
+
+    expect([...collectWorkspaceSessionWorktreeOwners(session, new Set([prefixedId]))]).toEqual([
+      prefixedId
+    ])
+  })
+
+  it('matches canonically equivalent Unicode worktree owners', () => {
+    const candidateId = 'repo-1::/workspace/Café'.normalize('NFC')
+    const ownerId = candidateId.normalize('NFD')
+    const session = sessionWith('activeWorktreeId', ownerId)
+
+    expect([...collectWorkspaceSessionWorktreeOwners(session, new Set([candidateId]))]).toEqual([
+      candidateId
+    ])
+  })
+
+  it('matches Windows worktree owners across drive case and slash spelling', () => {
+    const candidateId = 'repo-1::D:/Agentic/game2'
+    const session = sessionWith('activeWorktreeId', 'repo-1::d:\\agentic\\game2')
+
+    expect([...collectWorkspaceSessionWorktreeOwners(session, new Set([candidateId]))]).toEqual([
+      candidateId
+    ])
+  })
+
+  it('matches macOS /private/tmp session owners to /tmp metadata', () => {
+    const candidateId = 'repo-1::/private/tmp/orca/target'
+    const session = sessionWith('activeWorktreeId', 'repo-1::/tmp/orca/target')
+
+    expect([
+      ...collectWorkspaceSessionWorktreeOwners(session, new Set([candidateId]), 'darwin')
+    ]).toEqual([candidateId])
+  })
+
+  it('preserves every candidate that shares an owner comparison key', () => {
+    const nfcId = 'repo-1::/workspace/Café'.normalize('NFC')
+    const nfdId = nfcId.normalize('NFD')
+    const session = sessionWith('activeWorktreeId', nfcId)
+
+    expect(
+      [...collectWorkspaceSessionWorktreeOwners(session, new Set([nfcId, nfdId]))].sort()
+    ).toEqual([nfcId, nfdId].sort())
+  })
+
+  it('ignores fields whose keys cannot identify a worktree owner', () => {
+    const session = {
+      ...getDefaultWorkspaceSession(),
+      activeRepoId: TARGET,
+      activeTabId: TARGET,
+      terminalLayoutsByTabId: { [TARGET]: { root: null } },
+      remoteSessionIdsByTabId: { [TARGET]: TARGET },
+      terminalPtyIncarnationsByPaneKey: { [TARGET]: TARGET },
+      terminalTopologyRevisionByRepoId: { [TARGET]: 1 }
+    } as unknown as WorkspaceSessionState
+
+    expect(collected(session)).toEqual([])
+  })
+})

--- a/src/main/persistence/restoring-sessions/session-worktree-ownership.ts
+++ b/src/main/persistence/restoring-sessions/session-worktree-ownership.ts
@@ -1,0 +1,246 @@
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { parseWorkspaceKey } from '../../../shared/workspace-scope'
+import {
+  getWorktreeIdFromHostIdentity,
+  isWorktreeHostIdentity
+} from '../../../shared/worktree/host-qualified-identity'
+import { worktreeRetentionIdComparisonKey } from '../../worktree-retention-path-comparison'
+
+type WorkspaceSessionWorktreeReferenceKind =
+  | 'none'
+  | 'direct'
+  | 'owner-keyed'
+  | 'owner-keyed-row-arrays'
+  | 'owner-keyed-browser-row-arrays'
+  | 'worktree-id-array'
+  | 'row-record'
+  | 'row-arrays'
+  | 'browser-row-arrays'
+
+/** Every persisted session field must state how, if at all, it can name a worktree owner. */
+export const WORKSPACE_SESSION_WORKTREE_REFERENCE_KIND = {
+  activeRepoId: 'none',
+  activeWorkspaceKey: 'direct',
+  activeWorkspaceExecutionHostId: 'none',
+  activeWorktreeId: 'direct',
+  activeTabId: 'none',
+  tabsByWorktree: 'owner-keyed-row-arrays',
+  terminalLayoutsByTabId: 'none',
+  activeWorktreeIdsOnShutdown: 'worktree-id-array',
+  openFilesByWorktree: 'owner-keyed-row-arrays',
+  activeFileIdByWorktree: 'owner-keyed',
+  markdownFrontmatterVisible: 'none',
+  browserTabsByWorktree: 'owner-keyed-browser-row-arrays',
+  browserPagesByWorkspace: 'browser-row-arrays',
+  activeBrowserTabIdByWorktree: 'owner-keyed',
+  clientHostedBrowserPagesByWorktree: 'owner-keyed',
+  clientHostedBrowserCloseIntentsByEnvironment: 'row-arrays',
+  activeTabTypeByWorktree: 'owner-keyed',
+  browserUrlHistory: 'none',
+  activeTabIdByWorktree: 'owner-keyed',
+  unifiedTabs: 'owner-keyed-row-arrays',
+  tabGroups: 'owner-keyed-row-arrays',
+  tabGroupLayouts: 'owner-keyed',
+  activeGroupIdByWorktree: 'owner-keyed',
+  activeConnectionIdsAtShutdown: 'none',
+  remoteSessionIdsByTabId: 'none',
+  lastVisitedAtByWorktreeId: 'owner-keyed',
+  defaultTerminalTabsAppliedByWorktreeId: 'owner-keyed',
+  sleepingAgentSessionsByPaneKey: 'row-record',
+  terminalPtyIncarnationsByPaneKey: 'none',
+  terminalTopologyRevisionByRepoId: 'none',
+  terminalSurfaceTombstonesByPaneKey: 'row-record',
+  closedTerminalTabTombstonesByTabId: 'row-record'
+} as const satisfies Record<keyof WorkspaceSessionState, WorkspaceSessionWorktreeReferenceKind>
+
+type WorktreeRow = { worktreeId?: string | null }
+type BrowserWorktreeRow = WorktreeRow & {
+  docLocation?: { worktreeId?: string | null } | null
+}
+
+export type WorktreeOwnerCandidateCollector = Readonly<{
+  owners: Set<string>
+  addOwner: (ownerKey: string | null | undefined) => void
+}>
+
+export function getPersistedWorktreeOwnerId(ownerKey: string | null | undefined): string | null {
+  if (!ownerKey) {
+    return null
+  }
+  if (isWorktreeHostIdentity(ownerKey)) {
+    return getWorktreeIdFromHostIdentity(ownerKey) || null
+  }
+  const scope = parseWorkspaceKey(ownerKey)
+  if (scope?.type === 'folder') {
+    return null
+  }
+  return scope?.type === 'worktree' ? scope.worktreeId : ownerKey
+}
+
+export function createWorktreeOwnerCandidateCollector(
+  candidateIds: ReadonlySet<string>,
+  platform: NodeJS.Platform = process.platform,
+  owners: Set<string> = new Set<string>()
+): WorktreeOwnerCandidateCollector {
+  const candidateIdsByComparisonKey = new Map<string, string[]>()
+  for (const candidateId of candidateIds) {
+    const comparisonKey = worktreeRetentionIdComparisonKey(candidateId, platform)
+    if (!comparisonKey) {
+      continue
+    }
+    const matches = candidateIdsByComparisonKey.get(comparisonKey) ?? []
+    matches.push(candidateId)
+    candidateIdsByComparisonKey.set(comparisonKey, matches)
+  }
+  return {
+    owners,
+    addOwner: (ownerKey) => {
+      const worktreeId =
+        ownerKey && candidateIds.has(ownerKey) ? ownerKey : getPersistedWorktreeOwnerId(ownerKey)
+      if (!worktreeId) {
+        return
+      }
+      const comparisonKey = worktreeRetentionIdComparisonKey(worktreeId, platform)
+      const equivalentCandidates = comparisonKey
+        ? candidateIdsByComparisonKey.get(comparisonKey)
+        : undefined
+      if (equivalentCandidates) {
+        for (const candidateId of equivalentCandidates) {
+          owners.add(candidateId)
+        }
+      } else if (candidateIds.has(worktreeId)) {
+        owners.add(worktreeId)
+      }
+    }
+  }
+}
+
+function collectRecordKeys(
+  value: unknown,
+  add: (ownerKey: string | null | undefined) => void
+): void {
+  for (const ownerKey of Object.keys((value ?? {}) as Record<string, unknown>)) {
+    add(ownerKey)
+  }
+}
+
+function collectWorktreeRows(
+  rows: unknown,
+  add: (ownerKey: string | null | undefined) => void
+): void {
+  if (!Array.isArray(rows)) {
+    return
+  }
+  for (const row of rows as WorktreeRow[]) {
+    add(row?.worktreeId)
+  }
+}
+
+function collectBrowserRows(
+  rows: unknown,
+  add: (ownerKey: string | null | undefined) => void
+): void {
+  if (!Array.isArray(rows)) {
+    return
+  }
+  for (const row of rows as BrowserWorktreeRow[]) {
+    add(row?.worktreeId)
+    add(row?.docLocation?.worktreeId)
+  }
+}
+
+function collectSessionFieldOwners(
+  value: unknown,
+  kind: WorkspaceSessionWorktreeReferenceKind,
+  add: (ownerKey: string | null | undefined) => void
+): void {
+  switch (kind) {
+    case 'none':
+      return
+    case 'direct':
+      add(typeof value === 'string' ? value : null)
+      return
+    case 'owner-keyed':
+      collectRecordKeys(value, add)
+      return
+    case 'owner-keyed-row-arrays':
+    case 'owner-keyed-browser-row-arrays':
+      for (const [ownerKey, rows] of Object.entries((value ?? {}) as Record<string, unknown>)) {
+        add(ownerKey)
+        if (kind === 'owner-keyed-browser-row-arrays') {
+          collectBrowserRows(rows, add)
+        } else {
+          collectWorktreeRows(rows, add)
+        }
+      }
+      return
+    case 'worktree-id-array':
+      for (const ownerKey of (value ?? []) as string[]) {
+        add(ownerKey)
+      }
+      return
+    case 'row-record':
+      for (const row of Object.values((value ?? {}) as Record<string, WorktreeRow>)) {
+        add(row?.worktreeId)
+      }
+      return
+    case 'row-arrays':
+    case 'browser-row-arrays':
+      for (const rows of Object.values((value ?? {}) as Record<string, unknown>)) {
+        if (kind === 'browser-row-arrays') {
+          collectBrowserRows(rows, add)
+        } else {
+          collectWorktreeRows(rows, add)
+        }
+      }
+  }
+}
+
+export function collectWorkspaceSessionWorktreeOwners(
+  session: WorkspaceSessionState,
+  candidateIds: ReadonlySet<string>,
+  platform: NodeJS.Platform = process.platform,
+  owners: Set<string> = new Set<string>()
+): Set<string> {
+  const collector = createWorktreeOwnerCandidateCollector(candidateIds, platform, owners)
+  addWorkspaceSessionWorktreeOwners(session, collector)
+  return owners
+}
+
+function addWorkspaceSessionWorktreeOwners(
+  session: WorkspaceSessionState,
+  collector: WorktreeOwnerCandidateCollector
+): void {
+  for (const field of Object.keys(
+    WORKSPACE_SESSION_WORKTREE_REFERENCE_KIND
+  ) as (keyof WorkspaceSessionState)[]) {
+    collectSessionFieldOwners(
+      session[field],
+      WORKSPACE_SESSION_WORKTREE_REFERENCE_KIND[field],
+      collector.addOwner
+    )
+  }
+}
+
+export function addPersistedSessionWorktreeOwners(
+  state: Pick<PersistedState, 'workspaceSession' | 'workspaceSessionsByHostId'>,
+  collector: WorktreeOwnerCandidateCollector
+): void {
+  addWorkspaceSessionWorktreeOwners(state.workspaceSession, collector)
+  for (const session of Object.values(state.workspaceSessionsByHostId ?? {})) {
+    if (session) {
+      addWorkspaceSessionWorktreeOwners(session, collector)
+    }
+  }
+}
+
+export function collectPersistedSessionWorktreeOwners(
+  state: Pick<PersistedState, 'workspaceSession' | 'workspaceSessionsByHostId'>,
+  candidateIds: ReadonlySet<string>,
+  platform: NodeJS.Platform = process.platform
+): Set<string> {
+  const collector = createWorktreeOwnerCandidateCollector(candidateIds, platform)
+  addPersistedSessionWorktreeOwners(state, collector)
+  return collector.owners
+}

--- a/src/main/persistence/tracking-repos/local-worktree-metadata-batch-pruning.bench.test.ts
+++ b/src/main/persistence/tracking-repos/local-worktree-metadata-batch-pruning.bench.test.ts
@@ -1,0 +1,106 @@
+// Opt in: ORCA_LOCAL_METADATA_PRUNE_BENCH=1 pnpm test src/main/persistence/tracking-repos/local-worktree-metadata-batch-pruning.bench.test.ts
+import { performance } from 'node:perf_hooks'
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultPersistedState } from '../../../shared/constants'
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { Repo } from '../../../shared/repo-types'
+import type { WorktreeMeta } from '../../../shared/worktree/meta-types'
+import { removeWorkspaceSessionOwner } from '../restoring-sessions/session-owner-removal'
+import {
+  pruneUnreferencedWorktreeIdentityMeta,
+  removeWorktreeMetadataForHost
+} from '../loading-store/worktree-identity-metadata'
+import {
+  captureNativeLocalWorktreeMetadataScanExpectation,
+  pruneSessionlessMissingLocalWorktreeMetadataForRepo
+} from './missing-local-worktree-metadata-pruning'
+
+const describeBench = process.env.ORCA_LOCAL_METADATA_PRUNE_BENCH ? describe : describe.skip
+const ROW_COUNT = 2_709
+const REPO: Repo = {
+  id: 'repo-1',
+  path: '/workspace/repo',
+  displayName: 'repo',
+  badgeColor: '#000',
+  addedAt: 0
+}
+
+function makeMeta(index: number): WorktreeMeta {
+  return {
+    instanceId: `instance-${index}`,
+    hostId: 'local',
+    displayName: `stale-${index}`,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: index,
+    lastActivityAt: 0
+  }
+}
+
+function makeState(): { state: PersistedState; staleIds: string[] } {
+  const state = getDefaultPersistedState('/home/test')
+  state.repos = [REPO]
+  state.worktreeMetaByIdentity = {}
+  state.worktreeIdentityAliases = {}
+  const staleIds = Array.from(
+    { length: ROW_COUNT },
+    (_, index) => `${REPO.id}::/workspace/stale-${index}`
+  )
+  for (const [index, worktreeId] of staleIds.entries()) {
+    const meta = makeMeta(index)
+    const identityKey = `identity-${index}`
+    state.worktreeMeta[worktreeId] = meta
+    state.worktreeMetaByIdentity[identityKey] = meta
+    state.worktreeIdentityAliases[`local|${worktreeId}`] = [identityKey]
+  }
+  return { state, staleIds }
+}
+
+describeBench('authoritative local metadata batch pruning', () => {
+  it('measures the reported 2,709-row sequential and batch shapes', () => {
+    const legacy = makeState()
+    const batch = makeState()
+    const cloneSpy = vi.spyOn(globalThis, 'structuredClone')
+    const legacyStartedAt = performance.now()
+    for (const worktreeId of legacy.staleIds) {
+      removeWorktreeMetadataForHost(legacy.state, worktreeId, undefined)
+      delete legacy.state.worktreeMeta[worktreeId]
+      legacy.state.workspaceSession = removeWorkspaceSessionOwner(
+        legacy.state.workspaceSession,
+        worktreeId
+      )!
+    }
+    pruneUnreferencedWorktreeIdentityMeta(legacy.state)
+    const legacyMs = performance.now() - legacyStartedAt
+    const legacySessionClones = cloneSpy.mock.calls.length
+    cloneSpy.mockClear()
+
+    const batchStartedAt = performance.now()
+    const scan = captureNativeLocalWorktreeMetadataScanExpectation(batch.state, REPO)
+    const removed = pruneSessionlessMissingLocalWorktreeMetadataForRepo(
+      batch.state,
+      scan,
+      scan.metadata
+    )
+    const batchMs = performance.now() - batchStartedAt
+    const batchSessionClones = cloneSpy.mock.calls.length
+    cloneSpy.mockRestore()
+
+    expect(removed).toHaveLength(ROW_COUNT)
+    expect(Object.keys(legacy.state.worktreeMeta)).toHaveLength(0)
+    expect(Object.keys(batch.state.worktreeMeta)).toHaveLength(0)
+    expect(legacySessionClones).toBe(ROW_COUNT)
+    expect(batchSessionClones).toBe(0)
+
+    console.log(
+      `[bench] rows=${ROW_COUNT} metadata+session=${legacyMs.toFixed(2)}ms -> ${batchMs.toFixed(2)}ms; ` +
+        `gitScans=${ROW_COUNT} -> 1; sessionClones=${legacySessionClones} -> ${batchSessionClones}; ` +
+        `minimumSaveSchedules=${ROW_COUNT * 2} -> 1`
+    )
+  })
+})

--- a/src/main/persistence/tracking-repos/local-worktree-metadata-scan-expectation.test.ts
+++ b/src/main/persistence/tracking-repos/local-worktree-metadata-scan-expectation.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultPersistedState } from '../../../shared/constants'
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { Repo } from '../../../shared/repo-types'
+import type { WorktreeMeta } from '../../../shared/worktree/meta-types'
+import {
+  captureNativeLocalWorktreeMetadataScanExpectation,
+  pruneSessionlessMissingLocalWorktreeMetadataForRepo
+} from './missing-local-worktree-metadata-pruning'
+
+const REPO_ID = 'repo-1'
+const WORKTREE_ID = `${REPO_ID}::/workspace/stale`
+const LOCAL_ALIAS = `local|${WORKTREE_ID}`
+const IDENTITY_KEY = 'local-identity'
+
+function makeRepo(id = REPO_ID): Repo {
+  return {
+    id,
+    path: `/workspace/${id}`,
+    displayName: id,
+    badgeColor: '#000',
+    addedAt: 0
+  }
+}
+
+function makeMeta(worktreeId = WORKTREE_ID): WorktreeMeta {
+  return {
+    instanceId: `instance-${worktreeId}`,
+    hostId: 'local',
+    displayName: worktreeId,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+function makeState(): PersistedState {
+  const state = getDefaultPersistedState('/home/test')
+  state.repos = [makeRepo()]
+  return state
+}
+
+function makeCanonicalOnlyState(): {
+  state: PersistedState
+  meta: WorktreeMeta
+} {
+  const state = makeState()
+  const meta = makeMeta()
+  state.worktreeMetaByIdentity = { [IDENTITY_KEY]: meta }
+  state.worktreeIdentityAliases = { [LOCAL_ALIAS]: [IDENTITY_KEY] }
+  return { state, meta }
+}
+
+function pruneCaptured(state: PersistedState): string[] {
+  const scan = captureNativeLocalWorktreeMetadataScanExpectation(state, state.repos[0]!)
+  return pruneSessionlessMissingLocalWorktreeMetadataForRepo(state, scan, scan.metadata)
+}
+
+describe('local worktree metadata scan expectations', () => {
+  it('captures canonical-only local metadata and removes its orphaned identity row', () => {
+    const { state } = makeCanonicalOnlyState()
+
+    expect(pruneCaptured(state)).toEqual([WORKTREE_ID])
+    expect(state.worktreeMeta[WORKTREE_ID]).toBeUndefined()
+    expect(state.worktreeIdentityAliases?.[LOCAL_ALIAS]).toBeUndefined()
+    expect(state.worktreeMetaByIdentity?.[IDENTITY_KEY]).toBeUndefined()
+  })
+
+  it('removes equal legacy and canonical projections after a persistence round trip', () => {
+    const state = makeState()
+    const meta = makeMeta()
+    state.worktreeMeta[WORKTREE_ID] = structuredClone(meta)
+    state.worktreeMetaByIdentity = { [IDENTITY_KEY]: structuredClone(meta) }
+    state.worktreeIdentityAliases = { [LOCAL_ALIAS]: [IDENTITY_KEY] }
+
+    expect(pruneCaptured(state)).toEqual([WORKTREE_ID])
+    expect(state.worktreeMeta[WORKTREE_ID]).toBeUndefined()
+    expect(state.worktreeIdentityAliases[LOCAL_ALIAS]).toBeUndefined()
+    expect(state.worktreeMetaByIdentity[IDENTITY_KEY]).toBeUndefined()
+  })
+
+  it('does not sweep an unrelated unaliased canonical row during pruning', () => {
+    const { state, meta } = makeCanonicalOnlyState()
+    const unrelated = makeMeta(`${REPO_ID}::/workspace/unrelated`)
+    state.worktreeMetaByIdentity!.unrelated = unrelated
+
+    expect(pruneCaptured(state)).toEqual([WORKTREE_ID])
+    expect(state.worktreeMetaByIdentity).toEqual({ unrelated })
+    expect(state.worktreeMetaByIdentity?.[IDENTITY_KEY]).not.toBeDefined()
+    expect(meta).not.toBe(unrelated)
+  })
+
+  it('allocates expectations only for the scanned repository', () => {
+    const state = makeState()
+    const otherRepo = makeRepo('repo-2')
+    const otherId = `${otherRepo.id}::/workspace/other`
+    const canonicalId = `${REPO_ID}::/workspace/canonical`
+    const canonicalKey = 'canonical-key'
+    state.repos.push(otherRepo)
+    state.worktreeMeta[WORKTREE_ID] = makeMeta()
+    state.worktreeMeta[otherId] = makeMeta(otherId)
+    state.worktreeMetaByIdentity = {
+      [canonicalKey]: makeMeta(canonicalId),
+      'other-key': makeMeta(otherId)
+    }
+    state.worktreeIdentityAliases = {
+      [`local|${canonicalId}`]: [canonicalKey],
+      [`local|${otherId}`]: ['other-key']
+    }
+
+    const scan = captureNativeLocalWorktreeMetadataScanExpectation(state, state.repos[0]!)
+
+    expect(scan.metadata.map(({ worktreeId }) => worktreeId).sort()).toEqual(
+      [WORKTREE_ID, canonicalId].sort()
+    )
+  })
+
+  it('preserves metadata when an alias array is replaced with identical contents', () => {
+    const { state } = makeCanonicalOnlyState()
+    const scan = captureNativeLocalWorktreeMetadataScanExpectation(state, state.repos[0]!)
+    state.worktreeIdentityAliases![LOCAL_ALIAS] = [IDENTITY_KEY]
+
+    expect(pruneSessionlessMissingLocalWorktreeMetadataForRepo(state, scan, scan.metadata)).toEqual(
+      []
+    )
+    expect(state.worktreeMetaByIdentity?.[IDENTITY_KEY]).toBeDefined()
+  })
+
+  it('preserves metadata when the captured alias array is mutated in place', () => {
+    const { state } = makeCanonicalOnlyState()
+    const scan = captureNativeLocalWorktreeMetadataScanExpectation(state, state.repos[0]!)
+    state.worktreeIdentityAliases![LOCAL_ALIAS]!.push('new-identity')
+    state.worktreeMetaByIdentity!['new-identity'] = makeMeta()
+
+    expect(pruneSessionlessMissingLocalWorktreeMetadataForRepo(state, scan, scan.metadata)).toEqual(
+      []
+    )
+  })
+
+  it.each([
+    [
+      'replaced',
+      (state: PersistedState) => {
+        state.worktreeMetaByIdentity![IDENTITY_KEY] = {
+          ...state.worktreeMetaByIdentity![IDENTITY_KEY]!
+        }
+      }
+    ],
+    [
+      'host-mutated',
+      (state: PersistedState) => {
+        state.worktreeMetaByIdentity![IDENTITY_KEY]!.hostId = 'ssh:builder'
+      }
+    ],
+    [
+      'instance-mutated',
+      (state: PersistedState) => {
+        state.worktreeMetaByIdentity![IDENTITY_KEY]!.instanceId = 'new-instance'
+      }
+    ],
+    [
+      'content-mutated',
+      (state: PersistedState) => {
+        state.worktreeMetaByIdentity![IDENTITY_KEY]!.comment = 'new comment'
+      }
+    ]
+  ] as const)('preserves metadata when a canonical row is %s', (_label, mutate) => {
+    const { state } = makeCanonicalOnlyState()
+    const scan = captureNativeLocalWorktreeMetadataScanExpectation(state, state.repos[0]!)
+    mutate(state)
+
+    expect(pruneSessionlessMissingLocalWorktreeMetadataForRepo(state, scan, scan.metadata)).toEqual(
+      []
+    )
+  })
+
+  it.each([
+    [
+      'added',
+      (state: PersistedState) => {
+        state.worktreeIdentityAliases![`ssh:builder|${WORKTREE_ID}`] = [IDENTITY_KEY]
+      }
+    ],
+    [
+      'removed',
+      (state: PersistedState) => {
+        delete state.worktreeIdentityAliases![LOCAL_ALIAS]
+      }
+    ]
+  ] as const)('preserves metadata when an alias is %s during the scan', (_label, mutate) => {
+    const { state } = makeCanonicalOnlyState()
+    const scan = captureNativeLocalWorktreeMetadataScanExpectation(state, state.repos[0]!)
+    mutate(state)
+
+    expect(pruneSessionlessMissingLocalWorktreeMetadataForRepo(state, scan, scan.metadata)).toEqual(
+      []
+    )
+    expect(state.worktreeMetaByIdentity?.[IDENTITY_KEY]).toBeDefined()
+  })
+
+  it('preserves a legacy row created after a canonical-only scan capture', () => {
+    const { state } = makeCanonicalOnlyState()
+    const scan = captureNativeLocalWorktreeMetadataScanExpectation(state, state.repos[0]!)
+    state.worktreeMeta[WORKTREE_ID] = makeMeta()
+
+    expect(pruneSessionlessMissingLocalWorktreeMetadataForRepo(state, scan, scan.metadata)).toEqual(
+      []
+    )
+    expect(state.worktreeMeta[WORKTREE_ID]).toBeDefined()
+  })
+
+  it.each([WORKTREE_ID, `bogus|${WORKTREE_ID}`, `ssh:builder|${WORKTREE_ID}`])(
+    'preserves metadata with an unqualified or foreign alias: %s',
+    (alias) => {
+      const state = makeState()
+      state.worktreeMeta[WORKTREE_ID] = makeMeta()
+      state.worktreeMetaByIdentity = { [IDENTITY_KEY]: state.worktreeMeta[WORKTREE_ID]! }
+      state.worktreeIdentityAliases = { [alias]: [IDENTITY_KEY] }
+
+      expect(pruneCaptured(state)).toEqual([])
+      expect(state.worktreeMeta[WORKTREE_ID]).toBeDefined()
+    }
+  )
+
+  it('preserves an unqualified alias whose worktree path contains a pipe', () => {
+    const state = makeState()
+    const pipedId = `${REPO_ID}::/workspace/a|b`
+    state.worktreeMeta[pipedId] = makeMeta(pipedId)
+    state.worktreeMetaByIdentity = { [IDENTITY_KEY]: state.worktreeMeta[pipedId]! }
+    state.worktreeIdentityAliases = { [pipedId]: [IDENTITY_KEY] }
+
+    expect(pruneCaptured(state)).toEqual([])
+    expect(state.worktreeMeta[pipedId]).toBeDefined()
+    expect(state.worktreeIdentityAliases[pipedId]).toEqual([IDENTITY_KEY])
+  })
+})

--- a/src/main/persistence/tracking-repos/local-worktree-metadata-scan-expectation.ts
+++ b/src/main/persistence/tracking-repos/local-worktree-metadata-scan-expectation.ts
@@ -1,0 +1,243 @@
+import { isDeepStrictEqual } from 'node:util'
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import type { Project } from '../../../shared/project-types'
+import type { Repo } from '../../../shared/repo-types'
+import { getRepoKind } from '../../../shared/repo-kind'
+import { splitWorktreeId } from '../../../shared/worktree/id'
+import {
+  composeWorktreeHostIdentity,
+  getWorktreeIdFromHostIdentity,
+  isWorktreeHostIdentity
+} from '../../../shared/worktree/host-qualified-identity'
+import type { WorktreeMeta } from '../../../shared/worktree/meta-types'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
+
+type CapturedLocalRepoIdentity = Readonly<
+  Pick<Repo, 'id' | 'path' | 'connectionId' | 'executionHostId'> & {
+    kind: ReturnType<typeof getRepoKind>
+    expectedRepo: Repo | undefined
+  }
+>
+
+type CapturedLocalRoutingIdentity = Readonly<{
+  expectedProject: Project | undefined
+  expectedProjectUpdatedAt: number | undefined
+  expectedSettings: GlobalSettings
+}>
+
+type MetadataRowExpectation = Readonly<{
+  expectedPresent: boolean
+  expectedMeta: WorktreeMeta | undefined
+  expectedSerialized: string | null | undefined
+  expectedInstanceId: string | undefined
+  expectedHostId: WorktreeMeta['hostId']
+}>
+
+type MetadataAliasExpectation = Readonly<{
+  alias: string
+  expectedAlias: string[]
+  expectedIdentityKeys: readonly string[]
+  expectedIdentityRows: readonly (MetadataRowExpectation & { identityKey: string })[]
+}>
+
+export type LocalWorktreeMetadataPruneExpectation = Readonly<{
+  worktreeId: string
+  expectedLegacy: MetadataRowExpectation
+  expectedAliases: readonly MetadataAliasExpectation[]
+}>
+
+export type NativeLocalWorktreeMetadataScanExpectation = Readonly<{
+  repo: CapturedLocalRepoIdentity
+  routing: CapturedLocalRoutingIdentity
+  metadata: readonly LocalWorktreeMetadataPruneExpectation[]
+}>
+
+type MetadataAliasEntry = readonly [alias: string, identityKeys: string[]]
+
+function serializeMetadataRow(meta: WorktreeMeta | undefined): string | null | undefined {
+  if (!meta) {
+    return undefined
+  }
+  try {
+    return JSON.stringify(meta)
+  } catch {
+    return null
+  }
+}
+
+function captureRow(
+  record: Readonly<Record<string, WorktreeMeta>> | undefined,
+  key: string
+): MetadataRowExpectation {
+  const expectedPresent = Object.hasOwn(record ?? {}, key)
+  const expectedMeta = record?.[key]
+  return {
+    expectedPresent,
+    expectedMeta,
+    expectedSerialized: serializeMetadataRow(expectedMeta),
+    expectedInstanceId: expectedMeta?.instanceId,
+    expectedHostId: expectedMeta?.hostId
+  }
+}
+
+export function indexMetadataAliasesForWorktreeIds(
+  state: PersistedState,
+  worktreeIds: ReadonlySet<string>
+): Map<string, MetadataAliasEntry[]> {
+  const indexed = new Map<string, MetadataAliasEntry[]>()
+  for (const [alias, identityKeys] of Object.entries(state.worktreeIdentityAliases ?? {})) {
+    const matches = new Set<string>()
+    if (worktreeIds.has(alias)) {
+      matches.add(alias)
+    }
+    const separator = alias.indexOf('|')
+    const suffix = separator === -1 ? alias : alias.slice(separator + 1)
+    if (worktreeIds.has(suffix)) {
+      matches.add(suffix)
+    }
+    for (const worktreeId of matches) {
+      const entries = indexed.get(worktreeId) ?? []
+      entries.push([alias, identityKeys])
+      indexed.set(worktreeId, entries)
+    }
+  }
+  return indexed
+}
+
+export function captureNativeLocalWorktreeMetadataScanExpectation(
+  state: PersistedState,
+  repo: Repo
+): NativeLocalWorktreeMetadataScanExpectation {
+  const matchingRepos = state.repos.filter((entry) => entry.id === repo.id)
+  const expectedRepo = matchingRepos.length === 1 ? matchingRepos[0] : undefined
+  const expectedProject = state.projects.find((project) => project.sourceRepoIds.includes(repo.id))
+  const candidateIds = new Set<string>()
+  for (const [worktreeId, meta] of Object.entries(state.worktreeMeta)) {
+    if (
+      splitWorktreeId(worktreeId)?.repoId === repo.id &&
+      (!meta.hostId || meta.hostId === LOCAL_EXECUTION_HOST_ID)
+    ) {
+      candidateIds.add(worktreeId)
+    }
+  }
+  for (const alias of Object.keys(state.worktreeIdentityAliases ?? {})) {
+    if (!isWorktreeHostIdentity(alias)) {
+      continue
+    }
+    const worktreeId = getWorktreeIdFromHostIdentity(alias)
+    if (
+      alias === composeWorktreeHostIdentity(LOCAL_EXECUTION_HOST_ID, worktreeId) &&
+      splitWorktreeId(worktreeId)?.repoId === repo.id
+    ) {
+      candidateIds.add(worktreeId)
+    }
+  }
+  const aliasesByWorktreeId = indexMetadataAliasesForWorktreeIds(state, candidateIds)
+  return {
+    repo: {
+      id: repo.id,
+      path: repo.path,
+      connectionId: repo.connectionId,
+      executionHostId: repo.executionHostId,
+      kind: getRepoKind(repo),
+      expectedRepo
+    },
+    routing: {
+      expectedProject,
+      expectedProjectUpdatedAt: expectedProject?.updatedAt,
+      expectedSettings: state.settings
+    },
+    metadata: [...candidateIds].map((worktreeId) => ({
+      worktreeId,
+      expectedLegacy: captureRow(state.worktreeMeta, worktreeId),
+      expectedAliases: (aliasesByWorktreeId.get(worktreeId) ?? []).map(([alias, identityKeys]) => ({
+        alias,
+        expectedAlias: identityKeys,
+        expectedIdentityKeys: [...identityKeys],
+        expectedIdentityRows: identityKeys.map((identityKey) => ({
+          identityKey,
+          ...captureRow(state.worktreeMetaByIdentity, identityKey)
+        }))
+      }))
+    }))
+  }
+}
+
+function rowStillMatches(
+  record: Readonly<Record<string, WorktreeMeta>> | undefined,
+  key: string,
+  expected: MetadataRowExpectation
+): boolean {
+  const current = record?.[key]
+  return (
+    Object.hasOwn(record ?? {}, key) === expected.expectedPresent &&
+    current === expected.expectedMeta &&
+    expected.expectedSerialized !== null &&
+    serializeMetadataRow(current) === expected.expectedSerialized &&
+    current?.instanceId === expected.expectedInstanceId &&
+    current?.hostId === expected.expectedHostId
+  )
+}
+
+function aliasesStillMatch(
+  state: PersistedState,
+  expected: LocalWorktreeMetadataPruneExpectation,
+  currentAliases: readonly MetadataAliasEntry[]
+): boolean {
+  if (currentAliases.length !== expected.expectedAliases.length) {
+    return false
+  }
+  const currentByAlias = new Map(currentAliases)
+  return expected.expectedAliases.every((aliasExpectation) => {
+    const current = currentByAlias.get(aliasExpectation.alias)
+    return Boolean(
+      current &&
+      current === aliasExpectation.expectedAlias &&
+      current.length === aliasExpectation.expectedIdentityKeys.length &&
+      current.every((key, index) => key === aliasExpectation.expectedIdentityKeys[index]) &&
+      aliasExpectation.expectedIdentityRows.every(({ identityKey, ...row }) =>
+        rowStillMatches(state.worktreeMetaByIdentity, identityKey, row)
+      )
+    )
+  })
+}
+
+export function removeRevalidatedLocalWorktreeMetadata(
+  state: PersistedState,
+  expected: LocalWorktreeMetadataPruneExpectation,
+  currentAliases: readonly MetadataAliasEntry[],
+  removedIdentityKeys?: Set<string>
+): boolean {
+  if (
+    !rowStillMatches(state.worktreeMeta, expected.worktreeId, expected.expectedLegacy) ||
+    !aliasesStillMatch(state, expected, currentAliases)
+  ) {
+    return false
+  }
+  const localAlias = composeWorktreeHostIdentity(LOCAL_EXECUTION_HOST_ID, expected.worktreeId)
+  if (currentAliases.some(([alias]) => alias !== localAlias)) {
+    return false
+  }
+  const legacy = state.worktreeMeta[expected.worktreeId]
+  const identityKeys = state.worktreeIdentityAliases?.[localAlias]
+  if (identityKeys && identityKeys.length !== 1) {
+    return false
+  }
+  const canonical = identityKeys?.[0] ? state.worktreeMetaByIdentity?.[identityKeys[0]] : undefined
+  if (
+    (legacy?.hostId && legacy.hostId !== LOCAL_EXECUTION_HOST_ID) ||
+    (canonical?.hostId && canonical.hostId !== LOCAL_EXECUTION_HOST_ID) ||
+    (identityKeys && !canonical) ||
+    (legacy && canonical && !isDeepStrictEqual(legacy, canonical)) ||
+    (!legacy && !canonical)
+  ) {
+    return false
+  }
+  if (identityKeys?.[0]) {
+    removedIdentityKeys?.add(identityKeys[0])
+  }
+  delete state.worktreeMeta[expected.worktreeId]
+  delete state.worktreeIdentityAliases?.[localAlias]
+  return true
+}

--- a/src/main/persistence/tracking-repos/missing-local-worktree-metadata-pruning.test.ts
+++ b/src/main/persistence/tracking-repos/missing-local-worktree-metadata-pruning.test.ts
@@ -1,0 +1,477 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultPersistedState, getDefaultWorkspaceSession } from '../../../shared/constants'
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { Project } from '../../../shared/project-types'
+import type { Repo } from '../../../shared/repo-types'
+import { worktreeWorkspaceKey } from '../../../shared/workspace-scope'
+import type { WorktreeMeta } from '../../../shared/worktree/meta-types'
+import {
+  captureNativeLocalWorktreeMetadataScanExpectation,
+  pruneSessionlessMissingLocalWorktreeMetadataForRepo
+} from './missing-local-worktree-metadata-pruning'
+
+const REPO_ID = 'repo-1'
+const LIVE_ID = `${REPO_ID}::/workspace/live`
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: REPO_ID,
+    path: '/workspace/repo',
+    displayName: 'repo',
+    badgeColor: '#000',
+    addedAt: 0,
+    ...overrides
+  }
+}
+
+function makeMeta(worktreeId: string): WorktreeMeta {
+  return {
+    instanceId: `instance-${worktreeId}`,
+    hostId: 'local',
+    displayName: worktreeId,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+function makeState(repo = makeRepo()): PersistedState {
+  const state = getDefaultPersistedState('/home/test')
+  state.repos = [repo]
+  return state
+}
+
+function capture(state: PersistedState, repo = state.repos[0]!) {
+  return captureNativeLocalWorktreeMetadataScanExpectation(state, repo)
+}
+
+function pruneCaptured(
+  state: PersistedState,
+  scan: ReturnType<typeof capture>,
+  ids: readonly string[],
+  platform?: NodeJS.Platform
+): string[] {
+  const wanted = new Set(ids)
+  return pruneSessionlessMissingLocalWorktreeMetadataForRepo(
+    state,
+    scan,
+    scan.metadata.filter(({ worktreeId }) => wanted.has(worktreeId)),
+    platform
+  )
+}
+
+describe('pruneSessionlessMissingLocalWorktreeMetadataForRepo', () => {
+  it('removes 2,709 sessionless rows in one batch without cloning or changing session state', () => {
+    const state = makeState()
+    const staleIds = Array.from(
+      { length: 2_709 },
+      (_, index) => `${REPO_ID}::/workspace/stale-${index}`
+    )
+    const allIds = [LIVE_ID, ...staleIds]
+    state.worktreeMetaByIdentity = {}
+    state.worktreeIdentityAliases = {}
+    for (const [index, worktreeId] of allIds.entries()) {
+      const meta = makeMeta(worktreeId)
+      const identityKey = `identity-${index}`
+      state.worktreeMeta[worktreeId] = meta
+      state.worktreeMetaByIdentity[identityKey] = meta
+      state.worktreeIdentityAliases[`local|${worktreeId}`] = [identityKey]
+    }
+    state.worktreeLineageById[staleIds[0]!] = { worktreeId: staleIds[0] } as never
+    state.workspaceLineageByChildKey[worktreeWorkspaceKey(staleIds[0]!)] = {
+      childWorkspaceKey: worktreeWorkspaceKey(staleIds[0]!)
+    } as never
+    state.workspaceSession.terminalTopologyRevisionByRepoId = { [REPO_ID]: 7 }
+    const hostSession = {
+      ...getDefaultWorkspaceSession(),
+      terminalTopologyRevisionByRepoId: { [REPO_ID]: 11 }
+    }
+    state.workspaceSessionsByHostId = { 'runtime:mirror': hostSession }
+    const scan = capture(state)
+    const session = state.workspaceSession
+    const sessionSnapshot = structuredClone(session)
+    const hostSessionSnapshot = structuredClone(hostSession)
+    const cloneSpy = vi.spyOn(globalThis, 'structuredClone')
+
+    const removed = pruneCaptured(state, scan, staleIds)
+
+    expect(removed).toHaveLength(staleIds.length)
+    expect(cloneSpy).not.toHaveBeenCalled()
+    cloneSpy.mockRestore()
+    expect(Object.keys(state.worktreeMeta)).toEqual([LIVE_ID])
+    expect(Object.keys(state.worktreeMetaByIdentity ?? {})).toEqual(['identity-0'])
+    expect(Object.keys(state.worktreeIdentityAliases ?? {})).toEqual([`local|${LIVE_ID}`])
+    expect(state.worktreeLineageById[staleIds[0]!]).toBeUndefined()
+    expect(state.workspaceLineageByChildKey[worktreeWorkspaceKey(staleIds[0]!)]).toBeUndefined()
+    expect(state.workspaceSession).toBe(session)
+    expect(state.workspaceSession).toEqual(sessionSnapshot)
+    expect(state.workspaceSessionsByHostId?.['runtime:mirror']).toBe(hostSession)
+    expect(state.workspaceSessionsByHostId?.['runtime:mirror']).toEqual(hostSessionSnapshot)
+  })
+
+  it('fails closed when metadata is mutated or replaced after the scan starts', () => {
+    const inPlaceState = makeState()
+    const inPlaceId = `${REPO_ID}::/workspace/in-place`
+    inPlaceState.worktreeMeta[inPlaceId] = makeMeta(inPlaceId)
+    const inPlaceScan = capture(inPlaceState)
+    inPlaceState.worktreeMeta[inPlaceId]!.instanceId = 'replacement-instance'
+
+    expect(pruneCaptured(inPlaceState, inPlaceScan, [inPlaceId])).toEqual([])
+
+    const replacedState = makeState()
+    const replacedId = `${REPO_ID}::/workspace/replaced`
+    const original = makeMeta(replacedId)
+    replacedState.worktreeMeta[replacedId] = original
+    const replacedScan = capture(replacedState)
+    replacedState.worktreeMeta[replacedId] = { ...original }
+
+    expect(pruneCaptured(replacedState, replacedScan, [replacedId])).toEqual([])
+    expect(replacedState.worktreeMeta[replacedId]).not.toBe(original)
+  })
+
+  it('fails closed when an identical repo row is removed and re-added during the scan', () => {
+    const state = makeState()
+    const worktreeId = `${REPO_ID}::/workspace/re-added-repo`
+    state.worktreeMeta[worktreeId] = makeMeta(worktreeId)
+    const scan = capture(state)
+    const replacement = { ...state.repos[0]! }
+    state.repos.splice(0, 1, replacement)
+
+    expect(pruneCaptured(state, scan, [worktreeId])).toEqual([])
+    expect(state.repos[0]).toBe(replacement)
+    expect(state.worktreeMeta[worktreeId]).toBeDefined()
+  })
+
+  it('uses the effective Git kind when the raw legacy repo omitted kind', () => {
+    const state = makeState()
+    const worktreeId = `${REPO_ID}::/workspace/legacy-git-kind`
+    const rawRepo = state.repos[0]!
+    state.worktreeMeta[worktreeId] = makeMeta(worktreeId)
+    const scan = capture(state, { ...rawRepo, kind: 'git' })
+
+    expect(rawRepo.kind).toBeUndefined()
+    expect(pruneCaptured(state, scan, [worktreeId])).toEqual([worktreeId])
+  })
+
+  it.each([
+    'tabsByWorktree',
+    'browserTabsByWorktree',
+    'openFilesByWorktree',
+    'activeFileIdByWorktree',
+    'activeBrowserTabIdByWorktree',
+    'clientHostedBrowserPagesByWorktree',
+    'activeTabTypeByWorktree',
+    'activeTabIdByWorktree',
+    'unifiedTabs',
+    'tabGroups',
+    'tabGroupLayouts',
+    'activeGroupIdByWorktree',
+    'lastVisitedAtByWorktreeId',
+    'defaultTerminalTabsAppliedByWorktreeId'
+  ] as const)('preserves an owner named by workspaceSession.%s', (field) => {
+    const state = makeState()
+    const worktreeId = `${REPO_ID}::/workspace/${field}`
+    state.worktreeMeta[worktreeId] = makeMeta(worktreeId)
+    const scan = capture(state)
+    const ownerKey = field === 'lastVisitedAtByWorktreeId' ? `local|${worktreeId}` : worktreeId
+    ;(state.workspaceSession as unknown as Record<string, unknown>)[field] = {
+      [ownerKey]: []
+    }
+
+    expect(pruneCaptured(state, scan, [worktreeId])).toEqual([])
+    expect(state.worktreeMeta[worktreeId]).toBeDefined()
+  })
+
+  it('preserves scalar, nested, remote-partition, mobile, and relay recovery owners', () => {
+    const ownerMutations: ((state: PersistedState, worktreeId: string) => void)[] = [
+      (state, worktreeId) => {
+        state.workspaceSession.activeWorktreeId = worktreeId
+      },
+      (state, worktreeId) => {
+        state.workspaceSession.activeWorkspaceKey = worktreeWorkspaceKey(worktreeId)
+      },
+      (state, worktreeId) => {
+        state.workspaceSession.activeWorktreeIdsOnShutdown = [worktreeId]
+      },
+      (state, worktreeId) => {
+        state.ui.lastActiveWorktreeId = worktreeId
+      },
+      (state, worktreeId) => {
+        state.workspaceSession.sleepingAgentSessionsByPaneKey = {
+          pane: { worktreeId } as never
+        }
+      },
+      (state, worktreeId) => {
+        state.workspaceSession.terminalSurfaceTombstonesByPaneKey = {
+          pane: { worktreeId } as never
+        }
+      },
+      (state, worktreeId) => {
+        state.workspaceSession.closedTerminalTabTombstonesByTabId = {
+          tab: { worktreeId, closedAt: 1 }
+        }
+      },
+      (state, worktreeId) => {
+        state.workspaceSession.clientHostedBrowserCloseIntentsByEnvironment = {
+          runtime: [{ worktreeId, browserPageId: 'page', closedAt: 1 }]
+        }
+      },
+      (state, worktreeId) => {
+        state.workspaceSession.browserPagesByWorkspace = {
+          browser: [{ worktreeId } as never]
+        }
+      },
+      (state, worktreeId) => {
+        state.workspaceSessionsByHostId = {
+          'ssh:builder': {
+            ...getDefaultWorkspaceSession(),
+            lastVisitedAtByWorktreeId: { [worktreeId]: 1 }
+          }
+        }
+      },
+      (state, worktreeId) => {
+        state.mobileClientTabSelectionsByDeviceId = {
+          phone: { [worktreeId]: {} as never }
+        }
+      },
+      (state, worktreeId) => {
+        state.sshRemotePtyLeases = [
+          {
+            targetId: 'builder',
+            ptyId: 'pty',
+            worktreeId,
+            state: 'detached',
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ]
+      },
+      (state, worktreeId) => {
+        state.migrationUnsupportedPtyEntries = [
+          {
+            ptyId: 'pty',
+            worktreeId,
+            reason: 'legacy-numeric-pane-key',
+            source: 'local',
+            updatedAt: 1
+          }
+        ]
+      },
+      (state, worktreeId) => {
+        state.automations = [
+          {
+            enabled: true,
+            workspaceMode: 'existing',
+            workspaceId: worktreeId
+          } as never
+        ]
+      },
+      (state, worktreeId) => {
+        state.automationRuns = [{ status: 'dispatching', workspaceId: worktreeId } as never]
+      }
+    ]
+
+    for (const [index, mutate] of ownerMutations.entries()) {
+      const state = makeState()
+      const worktreeId = `${REPO_ID}::/workspace/owner-${index}`
+      state.worktreeMeta[worktreeId] = makeMeta(worktreeId)
+      const scan = capture(state)
+      mutate(state, worktreeId)
+      expect(pruneCaptured(state, scan, [worktreeId])).toEqual([])
+    }
+  })
+
+  it('preserves canonically equivalent session and top-level owners', () => {
+    const candidateId = `${REPO_ID}::/workspace/Café`.normalize('NFC')
+    const ownerId = candidateId.normalize('NFD')
+    const ownerMutations: ((state: PersistedState) => void)[] = [
+      (state) => {
+        state.workspaceSession.activeWorktreeId = ownerId
+      },
+      (state) => {
+        state.ui.lastActiveWorktreeId = ownerId
+      }
+    ]
+
+    for (const mutate of ownerMutations) {
+      const state = makeState()
+      state.worktreeMeta[candidateId] = makeMeta(candidateId)
+      const scan = capture(state)
+      mutate(state)
+
+      expect(pruneCaptured(state, scan, [candidateId])).toEqual([])
+      expect(state.worktreeMeta[candidateId]).toBeDefined()
+    }
+  })
+
+  it('removes a row on a later pass after its persisted owner is cleared', () => {
+    const state = makeState()
+    const worktreeId = `${REPO_ID}::/workspace/two-phase`
+    state.worktreeMeta[worktreeId] = makeMeta(worktreeId)
+    state.workspaceSession.lastVisitedAtByWorktreeId = { [worktreeId]: 1 }
+    const scan = capture(state)
+
+    expect(pruneCaptured(state, scan, [worktreeId])).toEqual([])
+    delete state.workspaceSession.lastVisitedAtByWorktreeId![worktreeId]
+    expect(pruneCaptured(state, scan, [worktreeId])).toEqual([worktreeId])
+  })
+
+  it('treats dotfile visibility and cleanup dismissals as non-owning preferences', () => {
+    const state = makeState()
+    const worktreeId = `${REPO_ID}::/workspace/non-owning-preferences`
+    state.worktreeMeta[worktreeId] = makeMeta(worktreeId)
+    const showDotfilesByWorktree = { [worktreeId]: true }
+    const workspaceCleanup = {
+      dismissals: {
+        [worktreeId]: {
+          worktreeId,
+          dismissedAt: 1,
+          fingerprint: 'fingerprint',
+          classifierVersion: 1
+        }
+      }
+    }
+    state.ui.showDotfilesByWorktree = showDotfilesByWorktree
+    state.ui.workspaceCleanup = workspaceCleanup
+    const scan = capture(state)
+
+    expect(pruneCaptured(state, scan, [worktreeId])).toEqual([worktreeId])
+    expect(state.ui.showDotfilesByWorktree).toBe(showDotfilesByWorktree)
+    expect(state.ui.workspaceCleanup).toBe(workspaceCleanup)
+  })
+
+  it('preserves foreign aliases, ambiguous local aliases, and divergent projections', () => {
+    const foreignState = makeState()
+    const foreignId = `${REPO_ID}::/workspace/foreign-alias`
+    const localMeta = makeMeta(foreignId)
+    const remoteMeta = { ...localMeta, hostId: 'ssh:builder' as const }
+    foreignState.worktreeMeta[foreignId] = localMeta
+    foreignState.worktreeMetaByIdentity = { local: localMeta, remote: remoteMeta }
+    foreignState.worktreeIdentityAliases = {
+      [`local|${foreignId}`]: ['local'],
+      [`ssh:builder|${foreignId}`]: ['remote']
+    }
+    const foreignScan = capture(foreignState)
+
+    expect(pruneCaptured(foreignState, foreignScan, [foreignId])).toEqual([])
+    expect(foreignState.worktreeMetaByIdentity).toEqual({ local: localMeta, remote: remoteMeta })
+
+    const ambiguousState = makeState()
+    const ambiguousId = `${REPO_ID}::/workspace/ambiguous`
+    const first = makeMeta(ambiguousId)
+    ambiguousState.worktreeMeta[ambiguousId] = first
+    ambiguousState.worktreeMetaByIdentity = { first, second: { ...first } }
+    ambiguousState.worktreeIdentityAliases = { [`local|${ambiguousId}`]: ['first', 'second'] }
+    expect(pruneCaptured(ambiguousState, capture(ambiguousState), [ambiguousId])).toEqual([])
+
+    const divergentState = makeState()
+    const divergentId = `${REPO_ID}::/workspace/divergent`
+    const legacy = makeMeta(divergentId)
+    const canonical = { ...legacy, comment: 'newer canonical comment' }
+    divergentState.worktreeMeta[divergentId] = legacy
+    divergentState.worktreeMetaByIdentity = { canonical }
+    divergentState.worktreeIdentityAliases = { [`local|${divergentId}`]: ['canonical'] }
+    const divergentScan = capture(divergentState)
+    expect(pruneCaptured(divergentState, divergentScan, [divergentId])).toEqual([])
+  })
+
+  it('fails closed for repo replacement, host collisions, remote, runtime, and folder repos', () => {
+    const mutations: ((state: PersistedState) => void)[] = [
+      (state) => {
+        state.repos[0] = makeRepo({ path: '/workspace/replacement' })
+      },
+      (state) => {
+        state.repos.push(makeRepo({ connectionId: 'builder', executionHostId: 'ssh:builder' }))
+      },
+      (state) => {
+        state.repos[0] = makeRepo({ connectionId: 'builder', executionHostId: 'ssh:builder' })
+      },
+      (state) => {
+        state.repos[0] = makeRepo({ executionHostId: 'runtime:environment' })
+      },
+      (state) => {
+        state.repos[0] = makeRepo({ kind: 'folder' })
+      }
+    ]
+    for (const mutate of mutations) {
+      const state = makeState()
+      const worktreeId = `${REPO_ID}::/workspace/stale`
+      state.worktreeMeta[worktreeId] = makeMeta(worktreeId)
+      const scan = capture(state)
+      mutate(state)
+      expect(pruneCaptured(state, scan, [worktreeId])).toEqual([])
+    }
+  })
+
+  it('fails closed when project runtime routing changes away and back during the scan', () => {
+    const state = makeState()
+    const worktreeId = `${REPO_ID}::/workspace/project-routing-race`
+    const project: Project = {
+      id: 'project-1',
+      displayName: 'project',
+      badgeColor: '#000',
+      localWindowsRuntimePreference: { kind: 'windows-host' },
+      sourceRepoIds: [REPO_ID],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    state.projects = [project]
+    state.worktreeMeta[worktreeId] = makeMeta(worktreeId)
+    const scan = capture(state)
+    project.localWindowsRuntimePreference = { kind: 'wsl', distro: 'Ubuntu' }
+    project.updatedAt += 1
+    project.localWindowsRuntimePreference = { kind: 'windows-host' }
+    project.updatedAt += 1
+
+    expect(pruneCaptured(state, scan, [worktreeId])).toEqual([])
+    expect(state.worktreeMeta[worktreeId]).toBeDefined()
+  })
+
+  it('fails closed when global runtime routing changes away and back during the scan', () => {
+    const state = makeState()
+    const worktreeId = `${REPO_ID}::/workspace/settings-routing-race`
+    const originalDefault = state.settings.localWindowsRuntimeDefault
+    state.worktreeMeta[worktreeId] = makeMeta(worktreeId)
+    const scan = capture(state)
+    state.settings = {
+      ...state.settings,
+      localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+    }
+    state.settings = {
+      ...state.settings,
+      localWindowsRuntimeDefault: originalDefault
+    }
+
+    expect(state.settings.localWindowsRuntimeDefault).toEqual(originalDefault)
+    expect(pruneCaptured(state, scan, [worktreeId])).toEqual([])
+    expect(state.worktreeMeta[worktreeId]).toBeDefined()
+  })
+
+  it('rejects malformed, folder-instance, WSL, and non-native Windows candidate paths', () => {
+    const state = makeState()
+    const foreignWindowsId = `${REPO_ID}::C:\\workspace\\stale`
+    const ids = [
+      `${REPO_ID}::relative/path`,
+      `${REPO_ID}::`,
+      `wrong::/workspace/stale`,
+      `${REPO_ID}::/workspace/folder::workspace:11111111-1111-4111-8111-111111111111`,
+      `${REPO_ID}::\\\\wsl.localhost\\Ubuntu\\home\\gone`,
+      `${REPO_ID}::/home/user/wsl-legacy`,
+      foreignWindowsId
+    ]
+    for (const worktreeId of ids) {
+      state.worktreeMeta[worktreeId] = makeMeta(worktreeId)
+    }
+    const scan = capture(state)
+
+    expect(pruneCaptured(state, scan, ids.slice(0, -2))).toEqual([])
+    expect(pruneCaptured(state, scan, [ids.at(-2)!], 'win32')).toEqual([])
+    expect(pruneCaptured(state, scan, [foreignWindowsId], 'linux')).toEqual([])
+  })
+})

--- a/src/main/persistence/tracking-repos/missing-local-worktree-metadata-pruning.ts
+++ b/src/main/persistence/tracking-repos/missing-local-worktree-metadata-pruning.ts
@@ -1,0 +1,153 @@
+import { isWindowsAbsolutePathLike } from '../../../shared/cross-platform-path'
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import { getRepoKind } from '../../../shared/repo-kind'
+import { worktreeWorkspaceKey } from '../../../shared/workspace-scope'
+import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR, splitWorktreeId } from '../../../shared/worktree/id'
+import { isWslUncPath } from '../../../shared/wsl-paths'
+import { isFinalAutomationRunStatus } from '../../../shared/automations-types'
+import { pruneUnreferencedWorktreeIdentityMeta } from '../loading-store/worktree-identity-metadata'
+import {
+  addPersistedSessionWorktreeOwners,
+  createWorktreeOwnerCandidateCollector
+} from '../restoring-sessions/session-worktree-ownership'
+import {
+  indexMetadataAliasesForWorktreeIds,
+  removeRevalidatedLocalWorktreeMetadata,
+  type LocalWorktreeMetadataPruneExpectation,
+  type NativeLocalWorktreeMetadataScanExpectation
+} from './local-worktree-metadata-scan-expectation'
+
+export { captureNativeLocalWorktreeMetadataScanExpectation } from './local-worktree-metadata-scan-expectation'
+export type {
+  LocalWorktreeMetadataPruneExpectation,
+  NativeLocalWorktreeMetadataScanExpectation
+} from './local-worktree-metadata-scan-expectation'
+
+function collectPersistedWorkspaceOwners(
+  state: PersistedState,
+  candidateIds: ReadonlySet<string>,
+  platform: NodeJS.Platform
+): Set<string> {
+  const collector = createWorktreeOwnerCandidateCollector(candidateIds, platform)
+  addPersistedSessionWorktreeOwners(state, collector)
+  const add = collector.addOwner
+  add(state.ui.lastActiveWorktreeId)
+  for (const selections of Object.values(state.mobileClientTabSelectionsByDeviceId ?? {})) {
+    for (const worktreeId of Object.keys(selections)) {
+      add(worktreeId)
+    }
+  }
+  for (const lease of state.sshRemotePtyLeases) {
+    add(lease.worktreeId)
+  }
+  for (const entry of state.migrationUnsupportedPtyEntries) {
+    add(entry.worktreeId)
+  }
+  for (const automation of state.automations) {
+    if (automation.enabled && automation.workspaceMode === 'existing') {
+      add(automation.workspaceId)
+    }
+  }
+  for (const run of state.automationRuns) {
+    if (!isFinalAutomationRunStatus(run.status)) {
+      add(run.workspaceId)
+    }
+  }
+  return collector.owners
+}
+
+function repoStillMatches(
+  state: PersistedState,
+  expected: NativeLocalWorktreeMetadataScanExpectation['repo']
+): boolean {
+  const owners = state.repos.filter((repo) => repo.id === expected.id)
+  const current = owners[0]
+  return Boolean(
+    owners.length === 1 &&
+    current &&
+    current === expected.expectedRepo &&
+    current.path === expected.path &&
+    current.connectionId === expected.connectionId &&
+    current.executionHostId === expected.executionHostId &&
+    getRepoKind(current) === expected.kind &&
+    expected.kind === 'git' &&
+    !current.connectionId &&
+    getRepoExecutionHostId(current) === LOCAL_EXECUTION_HOST_ID
+  )
+}
+
+function routingStillMatches(
+  state: PersistedState,
+  expected: NativeLocalWorktreeMetadataScanExpectation
+): boolean {
+  const currentProject = state.projects.find((project) =>
+    project.sourceRepoIds.includes(expected.repo.id)
+  )
+  return (
+    currentProject === expected.routing.expectedProject &&
+    currentProject?.updatedAt === expected.routing.expectedProjectUpdatedAt &&
+    state.settings === expected.routing.expectedSettings
+  )
+}
+
+function isValidCandidateId(
+  repoId: string,
+  worktreeId: string,
+  platform: NodeJS.Platform
+): boolean {
+  const parsed = splitWorktreeId(worktreeId)
+  return Boolean(
+    parsed?.repoId === repoId &&
+    parsed.worktreePath.length > 0 &&
+    !isWslUncPath(parsed.worktreePath) &&
+    (platform === 'win32'
+      ? isWindowsAbsolutePathLike(parsed.worktreePath)
+      : parsed.worktreePath.startsWith('/')) &&
+    !worktreeId.includes(FOLDER_WORKSPACE_INSTANCE_SEPARATOR)
+  )
+}
+
+export function pruneSessionlessMissingLocalWorktreeMetadataForRepo(
+  state: PersistedState,
+  scan: NativeLocalWorktreeMetadataScanExpectation,
+  missingMetadata: readonly LocalWorktreeMetadataPruneExpectation[],
+  platform = process.platform
+): string[] {
+  if (
+    missingMetadata.length === 0 ||
+    !repoStillMatches(state, scan.repo) ||
+    !routingStillMatches(state, scan)
+  ) {
+    return []
+  }
+
+  const candidateIds = new Set(missingMetadata.map(({ worktreeId }) => worktreeId))
+  const sessionOwners = collectPersistedWorkspaceOwners(state, candidateIds, platform)
+  const aliasesByWorktreeId = indexMetadataAliasesForWorktreeIds(state, candidateIds)
+  const removedIdentityKeys = new Set<string>()
+  const removedIds: string[] = []
+  for (const expectation of missingMetadata) {
+    const { worktreeId } = expectation
+    if (
+      !isValidCandidateId(scan.repo.id, worktreeId, platform) ||
+      sessionOwners.has(worktreeId) ||
+      !removeRevalidatedLocalWorktreeMetadata(
+        state,
+        expectation,
+        aliasesByWorktreeId.get(worktreeId) ?? [],
+        removedIdentityKeys
+      )
+    ) {
+      continue
+    }
+    delete state.worktreeLineageById[worktreeId]
+    delete state.workspaceLineageByChildKey[worktreeWorkspaceKey(worktreeId)]
+    removedIds.push(worktreeId)
+  }
+  if (removedIds.length > 0) {
+    // Why: a global sweep could delete unrelated unaliased rows from another repo or host.
+    pruneUnreferencedWorktreeIdentityMeta(state, removedIdentityKeys)
+  }
+  return removedIds
+}

--- a/src/main/persistence/tracking-repos/project-host-operations.ts
+++ b/src/main/persistence/tracking-repos/project-host-operations.ts
@@ -19,6 +19,7 @@ import { repoGitUsernameCacheKey } from './repo-hydration'
 export type ProjectHostMutationOperations = {
   state: PersistedState
   gitUsernameCache: Map<string, string>
+  bumpLocalWorktreeScanGeneration: (repoId: string) => void
   hydrateRepo: (repo: Repo) => Repo
   updateRepoBackedProjectHostSetup: (
     setup: ProjectHostSetup,
@@ -87,6 +88,9 @@ export class ProjectHostPersistenceOperations {
       return null
     }
     if ('localWindowsRuntimePreference' in updates) {
+      for (const repoId of project.sourceRepoIds) {
+        this.operations.bumpLocalWorktreeScanGeneration(repoId)
+      }
       if (updates.localWindowsRuntimePreference === undefined) {
         delete project.localWindowsRuntimePreference
       } else {

--- a/src/main/persistence/tracking-repos/repo-update-operations.ts
+++ b/src/main/persistence/tracking-repos/repo-update-operations.ts
@@ -9,6 +9,7 @@ import { sanitizeRepoUpdatesForPersistence } from './repo-sanitization'
 
 export type RepoUpdateMutationOperations = {
   state: PersistedState
+  bumpLocalWorktreeScanGeneration: (repoId: string) => void
   syncProjectHostSetupCompatibilityState: () => void
   scheduleSave: () => void
   hydrateRepo: (repo: Repo) => Repo
@@ -19,6 +20,10 @@ export class RepoUpdatePersistenceOperations {
 
   private get state(): PersistedState {
     return this.operations.state
+  }
+
+  private bumpLocalWorktreeScanGeneration(repoId: string): void {
+    this.operations.bumpLocalWorktreeScanGeneration(repoId)
   }
 
   private syncProjectHostSetupCompatibilityState(): void {
@@ -177,6 +182,7 @@ export class RepoUpdatePersistenceOperations {
       }
     }
     Object.assign(repo, sanitizedUpdates)
+    this.bumpLocalWorktreeScanGeneration(id)
     this.syncProjectHostSetupCompatibilityState()
     this.scheduleSave()
     return this.hydrateRepo(repo)

--- a/src/main/worktree-lineage-pruning.test.ts
+++ b/src/main/worktree-lineage-pruning.test.ts
@@ -57,6 +57,82 @@ function createStore(
 }
 
 describe('pruneLineageForMissingRepoWorktrees', () => {
+  it('keeps lineage stored under another spelling of a live worktree path', () => {
+    const parentId = 'repo-1::/repo'
+    const childId = 'repo-1::/repo/./child'
+    const edge = lineage(childId, parentId)
+    const worktreeLineageById = { [childId]: edge }
+    const workspaceLineageByChildKey = {
+      [worktreeWorkspaceKey(childId)]: workspaceLineage(childId, parentId)
+    }
+    const metaById = {
+      [parentId]: { instanceId: edge.parentWorktreeInstanceId } as WorktreeMeta
+    }
+    const store = createStore(worktreeLineageById, workspaceLineageByChildKey, metaById)
+
+    pruneLineageForMissingRepoWorktrees(
+      store as never,
+      repo,
+      [
+        { path: '/repo', head: 'a', branch: 'main', isBare: false, isMainWorktree: true },
+        { path: '/repo/child/', head: 'b', branch: 'child', isBare: false, isMainWorktree: false }
+      ],
+      { platform: 'linux' }
+    )
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(store.removeWorkspaceLineage).not.toHaveBeenCalled()
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+    expect(worktreeLineageById[childId]).toBe(edge)
+  })
+
+  it('keeps captured metadata lineage not removed after Git canonicalizes paths', () => {
+    const parentId = 'repo-1::/alias/parent'
+    const childId = 'repo-1::/alias/child'
+    const edge = lineage(childId, parentId)
+    const worktreeLineageById = { [childId]: edge }
+    const workspaceLineageByChildKey = {
+      [worktreeWorkspaceKey(childId)]: workspaceLineage(childId, parentId)
+    }
+    const metaById = {
+      [childId]: { instanceId: edge.worktreeInstanceId } as WorktreeMeta,
+      [parentId]: { instanceId: edge.parentWorktreeInstanceId } as WorktreeMeta
+    }
+    const store = createStore(worktreeLineageById, workspaceLineageByChildKey, metaById)
+
+    pruneLineageForMissingRepoWorktrees(
+      store as never,
+      repo,
+      [
+        {
+          path: '/canonical/parent',
+          head: 'a',
+          branch: 'parent',
+          isBare: false,
+          isMainWorktree: false
+        },
+        {
+          path: '/canonical/child',
+          head: 'b',
+          branch: 'child',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ],
+      {
+        platform: 'linux',
+        preservedMetadataCandidateIds: new Set([parentId, childId])
+      }
+    )
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(store.removeWorkspaceLineage).not.toHaveBeenCalled()
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+    expect(worktreeLineageById[childId]).toBe(edge)
+    expect(workspaceLineageByChildKey[worktreeWorkspaceKey(childId)]).toBeDefined()
+    expect(metaById[parentId].instanceId).toBe(edge.parentWorktreeInstanceId)
+  })
+
   it('refuses an empty scan when the repo still has registered lineage', () => {
     const parentId = 'repo-1::/repo/parent'
     const childId = 'repo-1::/repo/child'
@@ -78,7 +154,7 @@ describe('pruneLineageForMissingRepoWorktrees', () => {
     expect(workspaceLineageByChildKey[worktreeWorkspaceKey(childId)]).toBe(workspaceEdge)
   })
 
-  it('prunes missing children and rotates missing parents after a trusted non-empty scan', () => {
+  it('prunes and rotates missing IDs absent from preserved metadata candidates', () => {
     const liveParentId = 'repo-1::/repo/live-parent'
     const missingChildId = 'repo-1::/repo/missing-child'
     const liveChildId = 'repo-1::/repo/live-child'
@@ -99,25 +175,31 @@ describe('pruneLineageForMissingRepoWorktrees', () => {
     }
     const store = createStore(worktreeLineageById, workspaceLineageByChildKey, metaById)
 
-    pruneLineageForMissingRepoWorktrees(store as never, repo, [
-      {
-        path: '/repo/live-parent',
-        head: 'a',
-        branch: 'main',
-        isBare: false,
-        isMainWorktree: false
-      },
-      {
-        path: '/repo/live-child',
-        head: 'b',
-        branch: 'child',
-        isBare: false,
-        isMainWorktree: false
-      }
-    ])
+    pruneLineageForMissingRepoWorktrees(
+      store as never,
+      repo,
+      [
+        {
+          path: '/repo/live-parent',
+          head: 'a',
+          branch: 'main',
+          isBare: false,
+          isMainWorktree: false
+        },
+        {
+          path: '/repo/live-child',
+          head: 'b',
+          branch: 'child',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ],
+      { preservedMetadataCandidateIds: new Set([liveParentId, liveChildId]) }
+    )
 
     expect(store.removeWorktreeLineage).toHaveBeenCalledWith(missingChildId)
     expect(store.removeWorktreeLineage).not.toHaveBeenCalledWith(liveChildId)
+    expect(store.removeWorkspaceLineage).toHaveBeenCalledWith(worktreeWorkspaceKey(missingChildId))
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(missingParentId, {
       instanceId: expect.any(String)
     })
@@ -125,5 +207,26 @@ describe('pruneLineageForMissingRepoWorktrees', () => {
     expect(metaById[missingParentId].instanceId).not.toBe(
       missingParentEdge.parentWorktreeInstanceId
     )
+  })
+
+  it('does not rematerialize metadata already removed for a missing parent', () => {
+    const liveChildId = 'repo-1::/repo/live-child'
+    const removedParentId = 'repo-1::/repo/removed-parent'
+    const edge = lineage(liveChildId, removedParentId)
+    const worktreeLineageById = { [liveChildId]: edge }
+    const store = createStore(worktreeLineageById, {}, {})
+
+    pruneLineageForMissingRepoWorktrees(store as never, repo, [
+      {
+        path: '/repo/live-child',
+        head: 'child-head',
+        branch: 'child',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+    expect(worktreeLineageById[liveChildId]).toBe(edge)
   })
 })

--- a/src/main/worktree-lineage-pruning.ts
+++ b/src/main/worktree-lineage-pruning.ts
@@ -4,6 +4,8 @@ import type { WorkspaceLineage, WorktreeLineage } from '../shared/worktree/linea
 import type { GitWorktreeInfo } from '../shared/worktree/types'
 import { getRepoExecutionHostId } from '../shared/execution-host'
 import { isWorkspaceKey, parseWorkspaceKey, worktreeWorkspaceKey } from '../shared/workspace-scope'
+import { splitWorktreeId } from '../shared/worktree/id'
+import { worktreeRetentionPathComparisonKey } from './worktree-retention-path-comparison'
 import type { Store } from './persistence'
 
 function worktreeIdBelongsToRepo(worktreeId: string, repoPrefix: string): boolean {
@@ -37,8 +39,13 @@ function hasStoredRepoLineage(
 export function pruneLineageForMissingRepoWorktrees(
   store: Store,
   repo: Repo,
-  gitWorktrees: GitWorktreeInfo[]
+  gitWorktrees: GitWorktreeInfo[],
+  options: {
+    platform?: NodeJS.Platform
+    preservedMetadataCandidateIds?: ReadonlySet<string>
+  } = {}
 ): void {
+  const { platform = process.platform, preservedMetadataCandidateIds } = options
   if (
     typeof store.getAllWorktreeLineage !== 'function' ||
     typeof store.removeWorktreeLineage !== 'function'
@@ -56,6 +63,24 @@ export function pruneLineageForMissingRepoWorktrees(
     return
   }
   const liveIds = new Set(gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`))
+  const livePathKeys = new Set(
+    [repo.path, ...gitWorktrees.map(({ path }) => path)].map((pathValue) =>
+      worktreeRetentionPathComparisonKey(pathValue, platform)
+    )
+  )
+  const isLive = (worktreeId: string): boolean => {
+    if (liveIds.has(worktreeId) || preservedMetadataCandidateIds?.has(worktreeId)) {
+      return true
+    }
+    const worktreePath = splitWorktreeId(worktreeId)?.worktreePath
+    if (!worktreePath) {
+      return false
+    }
+    if (livePathKeys.has(worktreeRetentionPathComparisonKey(worktreePath, platform))) {
+      return true
+    }
+    return false
+  }
   const expectedHostId = getRepoExecutionHostId(repo)
   const repoOwners = store.getRepos().filter((candidate) => candidate.id === repo.id)
   const canMutateWorktree = (worktreeId: string): boolean => {
@@ -68,7 +93,7 @@ export function pruneLineageForMissingRepoWorktrees(
       childScope?.type === 'worktree' &&
       worktreeIdBelongsToRepo(childScope.worktreeId, repoPrefix) &&
       canMutateWorktree(childScope.worktreeId) &&
-      !liveIds.has(childScope.worktreeId) &&
+      !isLive(childScope.worktreeId) &&
       isWorkspaceKey(childWorkspaceKey)
     ) {
       store.removeWorkspaceLineage?.(childWorkspaceKey)
@@ -78,7 +103,7 @@ export function pruneLineageForMissingRepoWorktrees(
     if (
       worktreeIdBelongsToRepo(childId, repoPrefix) &&
       canMutateWorktree(childId) &&
-      !liveIds.has(childId)
+      !isLive(childId)
     ) {
       // Why: a proven-missing path must not transfer its lineage to a future checkout at that path.
       store.removeWorktreeLineage(childId)
@@ -87,10 +112,10 @@ export function pruneLineageForMissingRepoWorktrees(
     if (
       worktreeIdBelongsToRepo(lineage.parentWorktreeId, repoPrefix) &&
       canMutateWorktree(lineage.parentWorktreeId) &&
-      !liveIds.has(lineage.parentWorktreeId)
+      !isLive(lineage.parentWorktreeId)
     ) {
       const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
-      if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {
+      if (parentMeta?.instanceId === lineage.parentWorktreeInstanceId) {
         // Why: rotate a proven-missing parent's identity once so path reuse cannot validate old lineage.
         store.setWorktreeMeta(lineage.parentWorktreeId, { instanceId: randomUUID() })
       }

--- a/src/main/worktree-retention-path-comparison.ts
+++ b/src/main/worktree-retention-path-comparison.ts
@@ -1,0 +1,24 @@
+import { splitWorktreeId } from '../shared/worktree/id'
+import { worktreePathComparisonKey } from './ipc/worktree-path-comparison'
+
+/** Comparison keys used only to retain state; canonical equivalence must never select a delete target. */
+export function worktreeRetentionPathComparisonKey(
+  pathValue: string,
+  platform: NodeJS.Platform
+): string {
+  return worktreePathComparisonKey(pathValue.normalize('NFC'), platform)
+}
+
+export function worktreeRetentionIdComparisonKey(
+  worktreeId: string,
+  platform: NodeJS.Platform
+): string | null {
+  const parsed = splitWorktreeId(worktreeId)
+  if (!parsed?.repoId || !parsed.worktreePath) {
+    return null
+  }
+  return JSON.stringify([
+    parsed.repoId,
+    worktreeRetentionPathComparisonKey(parsed.worktreePath, platform)
+  ])
+}

--- a/src/shared/priority-semaphore.test.ts
+++ b/src/shared/priority-semaphore.test.ts
@@ -145,4 +145,19 @@ describe('PrioritySemaphore', () => {
     const r2 = await sem.acquire(0)
     r2()
   })
+
+  it('removes an aborted waiter without consuming the next permit', async () => {
+    const sem = new PrioritySemaphore(1)
+    const release = await sem.acquire(0)
+    const controller = new AbortController()
+    const reason = new Error('canceled')
+    const waiting = sem.acquire(0, controller.signal)
+
+    controller.abort(reason)
+    await expect(waiting).rejects.toBe(reason)
+    release()
+
+    const nextRelease = await sem.acquire(0)
+    nextRelease()
+  })
 })

--- a/src/shared/priority-semaphore.ts
+++ b/src/shared/priority-semaphore.ts
@@ -1,6 +1,8 @@
 type Waiter = {
   priority: number
   resolve: (release: () => void) => void
+  signal?: AbortSignal
+  onAbort?: () => void
 }
 
 export class PrioritySemaphore {
@@ -11,7 +13,10 @@ export class PrioritySemaphore {
     this.available = concurrency
   }
 
-  acquire(priority: number): Promise<() => void> {
+  acquire(priority: number, signal?: AbortSignal): Promise<() => void> {
+    if (signal?.aborted) {
+      return Promise.reject(signal.reason)
+    }
     if (this.available > 0) {
       this.available--
       let released = false
@@ -24,8 +29,20 @@ export class PrioritySemaphore {
       })
     }
 
-    return new Promise<() => void>((resolve) => {
-      this.waiters.push({ priority, resolve })
+    return new Promise<() => void>((resolve, reject) => {
+      const waiter: Waiter = { priority, resolve, signal }
+      if (signal) {
+        waiter.onAbort = () => {
+          const index = this.waiters.indexOf(waiter)
+          if (index === -1) {
+            return
+          }
+          this.waiters.splice(index, 1)
+          reject(signal.reason)
+        }
+        signal.addEventListener('abort', waiter.onAbort, { once: true })
+      }
+      this.waiters.push(waiter)
     })
   }
 
@@ -45,6 +62,9 @@ export class PrioritySemaphore {
     }
 
     const waiter = this.waiters.splice(bestIdx, 1)[0]
+    if (waiter.signal && waiter.onAbort) {
+      waiter.signal.removeEventListener('abort', waiter.onAbort)
+    }
     let released = false
     waiter.resolve(() => {
       if (released) {


### PR DESCRIPTION
## ELI5

Orca keeps a metadata card for each worktree so it can remember names, pins, links, and activity. Deleted worktrees could leave thousands of cards behind, and cleaning them one at a time repeatedly rescanned Git and copied session state. A fresh local Git inventory can now retire only the cards that are both missing and unused, in one batch.

This fixes the stale-metadata CPU amplifier from #15412. It does not claim to fix every independent source of high CPU described there.

## What Changed

- Capture a native-local metadata expectation before one asynchronous `git worktree list` scan.
- Let only the fresh producer of a successful, non-empty scan batch-prune missing metadata; cached, coalesced, failed, aborted, invalidated, or rerouted scans do nothing.
- Treat every Git-listed row, including `prunable` registrations, plus the configured repo path as live evidence.
- Probe only captured metadata paths absent from Git with asynchronous `fs/promises.stat`, using bounded workers and one process-wide two-probe semaphore. A two-second batch deadline and caller abort both settle as unverifiable; existing paths and non-absence errors also fail closed.
- Carry a common `{ generation, authorizedRootsRevision }` side-effect token for every local scan, including WSL, through all three listing callers. Recheck it after probes and immediately before mutation; repo updates, worktree notifications, runtime changes, or newer root publication fence the older observation.
- Revalidate metadata values and identities, local aliases, canonical rows, repo routing, and persisted ownership immediately before removal.
- Preserve every candidate referenced by any `WorkspaceSessionState` field or host partition, mobile selection, SSH lease, migration entry, active automation, or non-final automation run. Session state is neither cloned nor mutated.
- Remove qualifying legacy/canonical metadata, matching lineage, and cleanup/space-analysis sidecar rows in one batch with one scheduled save.
- Carry every captured candidate not removed into synchronous lineage pruning as protected, and skip both root and lineage side effects if generation or root authority changes while Git, probes, or the caller is pending.

## Why

The old cleanup shape could perform thousands of Git scans, session clones, and persistence schedules for one stale fleet. This keeps the authoritative Git observation singular and makes the persistence work linear while treating uncertainty as retention.

## Linked Issue

Fixes #15412

## Visual Proof

N/A — this changes main-process listing and persistence behavior only; there is no rendered UI or interaction change.

## Safety and provider boundary

The governing invariant is `agent-session.provider-ownership`: only the execution host that owns an authoritative observation may retire its metadata. Loss of contact is never proof of process death, and this path does not stop a PTY, agent, process, delete a directory, or delete a Git ref.

| Observation | Metadata pruning | Reason |
| --- | --- | --- |
| Fresh, successful, non-empty native-local scan; candidate is absent from Git and disk and sessionless | Allowed after synchronous revalidation | One authoritative native Git inventory plus bounded native path verification proves absence |
| Any Git-listed registration, including a `prunable` row | No | A temporarily unavailable removable or network volume must not turn registration into deletion evidence |
| Path exists or filesystem result is unverifiable | No | Symlink/canonical spellings, permissions, and non-absence errors fail closed |
| Cached, coalesced, failed, empty, aborted, invalidated, routing-generation-stale, or superseded-root scan | No | The observation is not fresh authoritative absence |
| Metadata, alias, repo, settings, or project routing changed during Git | No | Captured identity/value/generation checks reject the stale decision |
| Candidate has any persisted session/recovery owner | No | Session-bearing state stays with its existing teardown/recovery authority |
| WSL | No | v1 cannot prove Linux-path and UNC aliases equivalent |
| SSH or runtime-remote | No | The remote execution host owns the observation |
| Folder workspace | No | There is no Git worktree inventory to prove absence |
| Malformed, folder-instance, foreign-host, ambiguous, or wrong-platform identity | No | Candidate validation and alias ownership fail closed |

This is deliberately a native-local, sessionless v1. Remote/WSL/folder cleanup and broader terminal-manager or event-loop diagnostics remain out of scope. `ui.showDotfilesByWorktree` and cleanup dismissal preferences are not treated as live session ownership and remain under their existing cleanup paths.

## Performance evidence

Opt-in 2,709-row in-memory benchmark:

```text
metadata+session:     961.49ms -> 16.28ms
modeled Git scans:    2,709 -> 1
session clones:       2,709 -> 0
minimum save schedules: 5,418 -> 1
```

Command:

```bash
ORCA_LOCAL_METADATA_PRUNE_BENCH=1 pnpm exec vitest run \
  --config config/vitest.config.ts \
  src/main/persistence/tracking-repos/local-worktree-metadata-batch-pruning.bench.test.ts \
  --reporter=verbose
```

The wall times cover only modeled in-memory metadata/session work and vary by machine. They exclude filesystem-presence probes and do not claim end-to-end UI latency. A separate temporary real-Git measurement observed 2,709 `git worktree list` calls at 13.77s versus one call at 0.01s; those figures are illustrative, not a CI performance budget.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local verification:

- Changed-file Vitest suites: 239 passed; the opt-in benchmark was skipped in that run.
- Adjacent native/Windows/WSL/SSH/catalog and ownership suites: 148 passed.
- Focused timeout, semaphore, and authoritative-scan race suites: 33 passed.
- `pnpm tc:node` passed.
- `pnpm run check:code-quality:changed` passed with 0 findings across the changed files.
- `pnpm run check:reliability-gates` passed for 99 gates.
- `git diff --check` passed.
- The opt-in 2,709-row benchmark passed.

Full repository lint/build and the platform matrix are left to PR CI.

Coverage includes capture-before-Git ordering, fresh/coalesced/cached behavior, invalidation during Git and filesystem probes, hung-probe timeout, external abort, global two-probe accounting and permit reuse, all three listing-call continuation gaps, WSL setup/root-publication races, native-to-WSL route races, Git-folder-Git repo updates, repo/project/settings/metadata/alias races, persisted JSON projection equality, every persisted session ownership shape, host/provider isolation, Unicode/macOS/Windows path aliases, `prunable` retention, symlink spellings, filesystem-error retention, batch save/sidecar behavior, and lineage ordering without rematerialization.

No Electron validation was run because this has no UI change. No live physical Windows, WSL, SSH, runtime-remote, or folder-workspace journey was run; those boundaries have deterministic coverage and fail closed.

Residual gaps: Node cannot cancel an already-running `stat`, so two permanently wedged filesystem calls can retain the two global permits; current and later batches still settle at their own deadlines and preserve every candidate. Real Windows drive/UNC behavior remains covered by mocks rather than a physical host. Direct-SSH lineage pruning also retains a pre-existing concurrent-create setup gap; this diff does not change that behavior and never enables metadata pruning from an SSH observation.

Compatibility notes:

- No new Git command or option; the existing path remains Git 2.25 compatible.
- No public IPC/RPC shape, stream opcode, or remote-wire behavior changes.
- No provider-specific GitHub behavior was added.

## AI Disclosure

<!-- Internal contributor: intentionally left blank. -->

## Review

Primary risk is deleting metadata without enough authority. The implementation biases false negatives: any ambiguous ownership, changed state, path presence/error, unsupported provider, or stale scan preserves the row for a later scan. Sidecar pruning is best-effort and refetchable.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Reviewed for security, cross-platform behavior, SSH/remote ownership, mobile persisted owners, backwards compatibility, and performance.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
