### PR TITLE
refactor(daemon): collapse three listener-registration helpers into one

### DIFF
--- a/src/main/daemon/add-removable-listener.test.ts
+++ b/src/main/daemon/add-removable-listener.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { addRemovableListener } from './add-removable-listener'
+
+describe('addRemovableListener', () => {
+  it('removes only its own listener and leaves the order of the rest intact', () => {
+    const first = (): void => {}
+    const second = (): void => {}
+    const third = (): void => {}
+    const listeners = [first]
+    addRemovableListener(listeners, second)
+    const removeThird = addRemovableListener(listeners, third)
+
+    expect(listeners).toEqual([first, second, third])
+    removeThird()
+    expect(listeners).toEqual([first, second])
+  })
+
+  it('is a no-op on a second call rather than dropping the last listener', () => {
+    const kept = (): void => {}
+    const listeners: (() => void)[] = []
+    const remove = addRemovableListener(listeners, () => {})
+    remove()
+    addRemovableListener(listeners, kept)
+
+    // A second unsubscribe finds indexOf === -1; an unguarded splice(-1, 1) would evict `kept`.
+    remove()
+    expect(listeners).toEqual([kept])
+  })
+})

--- a/src/main/daemon/add-removable-listener.ts
+++ b/src/main/daemon/add-removable-listener.ts
@@ -1,7 +1,8 @@
-// The registration half of combineUnsubscribes, shared so the daemon provider, its adapter
-// fanout and the adapter base don't each repeat it. Why the guard: these unsubscribes get
-// called twice (dispose, then the caller's own cleanup) and splice(-1, 1) would drop the
-// last listener rather than none.
+// The one registration path for the daemon's listener arrays: push, and hand back a disposer
+// that removes exactly that entry. Why the guard: these disposers get called twice (dispose,
+// then the caller's own cleanup) and an unguarded splice(-1, 1) would drop the last listener
+// rather than none. The only site that does not use this is DegradedDaemonPtyProvider.onReplay,
+// which needs a once-only latch over a downstream fan-out as well; see the comment there.
 export function addRemovableListener<T>(listeners: T[], listener: NoInfer<T>): () => void {
   listeners.push(listener)
   return () => {

--- a/src/main/daemon/add-removable-listener.ts
+++ b/src/main/daemon/add-removable-listener.ts
@@ -1,0 +1,13 @@
+// The registration half of combineUnsubscribes, shared so the daemon provider, its adapter
+// fanout and the adapter base don't each repeat it. Why the guard: these unsubscribes get
+// called twice (dispose, then the caller's own cleanup) and splice(-1, 1) would drop the
+// last listener rather than none.
+export function addRemovableListener<T>(listeners: T[], listener: NoInfer<T>): () => void {
+  listeners.push(listener)
+  return () => {
+    const index = listeners.indexOf(listener)
+    if (index !== -1) {
+      listeners.splice(index, 1)
+    }
+  }
+}

--- a/src/main/daemon/daemon-client-listener-registry.test.ts
+++ b/src/main/daemon/daemon-client-listener-registry.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { DaemonClientListeners } from './daemon-client-listener-registry'
+
+describe('DaemonClientListeners', () => {
+  it('drops only the listener that asked, and a repeat disposal evicts nobody', () => {
+    const listeners = new DaemonClientListeners<() => void>()
+    const seen: string[] = []
+    const disposeFirst = listeners.add(() => seen.push('first'))
+    listeners.add(() => seen.push('second'))
+
+    disposeFirst()
+    listeners.each((listener) => listener())
+    expect(seen).toEqual(['second'])
+
+    disposeFirst()
+    listeners.each((listener) => listener())
+    expect(seen).toEqual(['second', 'second'])
+  })
+
+  it('gives the same function registered twice two independent disposers', () => {
+    const listeners = new DaemonClientListeners<() => void>()
+    let calls = 0
+    const listener = (): void => {
+      calls += 1
+    }
+    const disposeOne = listeners.add(listener)
+    listeners.add(listener)
+
+    disposeOne()
+    listeners.each((each) => each())
+    expect(calls).toBe(1)
+  })
+})

--- a/src/main/daemon/daemon-client-listener-registry.ts
+++ b/src/main/daemon/daemon-client-listener-registry.ts
@@ -1,16 +1,12 @@
+import { addRemovableListener } from './add-removable-listener'
+
 // Why: unsubscribe is by listener identity, so re-registering the same function
 // twice yields two entries and each returned disposer drops only one of them.
 export class DaemonClientListeners<T> {
   private listeners: T[] = []
 
   add(listener: T): () => void {
-    this.listeners.push(listener)
-    return () => {
-      const idx = this.listeners.indexOf(listener)
-      if (idx !== -1) {
-        this.listeners.splice(idx, 1)
-      }
-    }
+    return addRemovableListener(this.listeners, listener)
   }
 
   each(visit: (listener: T) => void): void {

--- a/src/main/daemon/daemon-pty-adapter-subscription-fanout.ts
+++ b/src/main/daemon/daemon-pty-adapter-subscription-fanout.ts
@@ -1,4 +1,5 @@
 import type { PtyBackgroundStreamEvent } from '../providers/types'
+import { addRemovableListener } from './add-removable-listener'
 import { combineUnsubscribes } from './combine-unsubscribes'
 import type { DaemonPtyAdapter } from './daemon-pty-adapter'
 import type { DaemonPtyRouterDataEvent, DaemonPtyRouterExitEvent } from './daemon-pty-router-events'
@@ -34,13 +35,7 @@ export class DaemonPtyAdapterSubscriptionFanout {
   }
 
   onData(callback: (payload: DaemonPtyRouterDataEvent) => void): () => void {
-    this.dataListeners.push(callback)
-    return () => {
-      const index = this.dataListeners.indexOf(callback)
-      if (index !== -1) {
-        this.dataListeners.splice(index, 1)
-      }
-    }
+    return addRemovableListener(this.dataListeners, callback)
   }
 
   onBackgroundStreamEvent(callback: (payload: PtyBackgroundStreamEvent) => void): () => void {
@@ -60,13 +55,7 @@ export class DaemonPtyAdapterSubscriptionFanout {
   }
 
   onExit(callback: (payload: DaemonPtyRouterExitEvent) => void): () => void {
-    this.exitListeners.push(callback)
-    return () => {
-      const index = this.exitListeners.indexOf(callback)
-      if (index !== -1) {
-        this.exitListeners.splice(index, 1)
-      }
-    }
+    return addRemovableListener(this.exitListeners, callback)
   }
 
   dispose(): void {

--- a/src/main/daemon/daemon-pty-connection-lifecycle.ts
+++ b/src/main/daemon/daemon-pty-connection-lifecycle.ts
@@ -10,7 +10,7 @@ import {
 } from './daemon-endpoint-incarnation'
 import type { DaemonEndpointIdentity } from './daemon-hello-protocol'
 import type { DaemonEvidenceSource, ExactDaemonIncarnation } from './daemon-incarnation-evidence'
-import { notifyDaemonAuditListeners } from './daemon-listener-registry'
+import { notifyDaemonAuditListeners } from './notify-daemon-audit-listeners'
 import { DaemonPtyEventSubscriptions } from './daemon-pty-event-subscriptions'
 import { parseDaemonPidFile, type ParsedDaemonPid } from './daemon-pid-file-parse'
 

--- a/src/main/daemon/daemon-pty-event-subscriptions.ts
+++ b/src/main/daemon/daemon-pty-event-subscriptions.ts
@@ -1,4 +1,5 @@
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
+import { addRemovableListener } from './add-removable-listener'
 import { DaemonPtySessionInventory } from './daemon-pty-session-inventory'
 import { CLEAN_DISCONNECT_PROTOCOL_VERSION } from './types'
 import type { PtyBackgroundStreamEvent } from '../providers/types'
@@ -13,23 +14,11 @@ export abstract class DaemonPtyEventSubscriptions extends DaemonPtySessionInvent
       seq?: number
     }) => void
   ): () => void {
-    this.dataListeners.push(callback)
-    return () => {
-      const idx = this.dataListeners.indexOf(callback)
-      if (idx !== -1) {
-        this.dataListeners.splice(idx, 1)
-      }
-    }
+    return addRemovableListener(this.dataListeners, callback)
   }
 
   onBackgroundStreamEvent(callback: (payload: PtyBackgroundStreamEvent) => void): () => void {
-    this.backgroundStreamListeners.push(callback)
-    return () => {
-      const idx = this.backgroundStreamListeners.indexOf(callback)
-      if (idx !== -1) {
-        this.backgroundStreamListeners.splice(idx, 1)
-      }
-    }
+    return addRemovableListener(this.backgroundStreamListeners, callback)
   }
 
   onReplay(_callback: (payload: { id: string; data: string }) => void): () => void {
@@ -39,23 +28,11 @@ export abstract class DaemonPtyEventSubscriptions extends DaemonPtySessionInvent
   onExit(
     callback: (payload: { id: string; code: number; incarnationId?: PtyIncarnationId }) => void
   ): () => void {
-    this.exitListeners.push(callback)
-    return () => {
-      const idx = this.exitListeners.indexOf(callback)
-      if (idx !== -1) {
-        this.exitListeners.splice(idx, 1)
-      }
-    }
+    return addRemovableListener(this.exitListeners, callback)
   }
 
   onWriteUnavailable(callback: (payload: { id: string }) => void): () => void {
-    this.writeUnavailableListeners.push(callback)
-    return () => {
-      const idx = this.writeUnavailableListeners.indexOf(callback)
-      if (idx !== -1) {
-        this.writeUnavailableListeners.splice(idx, 1)
-      }
-    }
+    return addRemovableListener(this.writeUnavailableListeners, callback)
   }
 
   protected emitWriteUnavailable(id: string): void {

--- a/src/main/daemon/daemon-pty-runtime-state-listener-disposal.test.ts
+++ b/src/main/daemon/daemon-pty-runtime-state-listener-disposal.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import type { DaemonAuditObservation } from './daemon-audit-classifier'
+import { notifyDaemonAuditListeners } from './notify-daemon-audit-listeners'
+import { DaemonPtyRuntimeState, type DaemonIdentityChangeEvent } from './daemon-pty-runtime-state'
+
+// Reaches the protected arrays through the real notifier, so the assertions observe the
+// registration state the adapter actually publishes from rather than a stand-in list.
+class RuntimeStateProbe extends DaemonPtyRuntimeState {
+  protected observeAuditFailure(): void {}
+
+  fireIdentityChange(event: DaemonIdentityChangeEvent): void {
+    notifyDaemonAuditListeners(this.identityChangeListeners, event)
+  }
+
+  fireAuditObservation(observation: DaemonAuditObservation): void {
+    notifyDaemonAuditListeners(this.auditObservationListeners, observation)
+  }
+}
+
+const identity = { pid: 1, startedAtMs: 2, launchNonce: 'n' }
+const identityEvent: DaemonIdentityChangeEvent = { previous: identity, current: identity }
+const observation = {
+  state: 'present',
+  reason: 'authenticated_inventory'
+} as DaemonAuditObservation
+
+const newProbe = (): RuntimeStateProbe =>
+  new RuntimeStateProbe({ socketPath: '/tmp/probe.sock', tokenPath: '/tmp/probe.token' })
+
+describe('DaemonPtyRuntimeState listener disposal', () => {
+  it('unsubscribes only the identity listener that asked, and repeats are a no-op', () => {
+    const probe = newProbe()
+    const seen: string[] = []
+    const unsubscribeFirst = probe.onDaemonIdentityChanged(() => seen.push('first'))
+    probe.onDaemonIdentityChanged(() => seen.push('second'))
+
+    unsubscribeFirst()
+    probe.fireIdentityChange(identityEvent)
+    expect(seen).toEqual(['second'])
+
+    // A repeat unsubscribe finds indexOf === -1; an unguarded splice would evict 'second'.
+    unsubscribeFirst()
+    probe.fireIdentityChange(identityEvent)
+    expect(seen).toEqual(['second', 'second'])
+  })
+
+  it('unsubscribes only the audit listener that asked, and repeats are a no-op', () => {
+    const probe = newProbe()
+    const seen: string[] = []
+    const unsubscribeFirst = probe.onAuditEligibilityObservation(() => seen.push('first'))
+    probe.onAuditEligibilityObservation(() => seen.push('second'))
+
+    unsubscribeFirst()
+    probe.fireAuditObservation(observation)
+    expect(seen).toEqual(['second'])
+
+    unsubscribeFirst()
+    probe.fireAuditObservation(observation)
+    expect(seen).toEqual(['second', 'second'])
+  })
+})

--- a/src/main/daemon/daemon-pty-runtime-state.ts
+++ b/src/main/daemon/daemon-pty-runtime-state.ts
@@ -1,3 +1,4 @@
+import { addRemovableListener } from './add-removable-listener'
 import { DaemonClient } from './client'
 import { createDaemonAuditEligibilityTracker } from './daemon-audit-eligibility-event'
 import type {
@@ -10,7 +11,6 @@ import { SNAPSHOT_SERIALIZER_FIDELITY_DAEMON_PROTOCOL_VERSION } from './daemon-p
 import type { DaemonEndpointIdentity } from './daemon-hello-protocol'
 import type { DaemonEvidenceSource, ExactDaemonIncarnation } from './daemon-incarnation-evidence'
 import { readDaemonPidRecord } from './daemon-endpoint-incarnation'
-import { removeDaemonListener } from './daemon-listener-registry'
 import type { ParsedDaemonPid } from './daemon-pid-file-parse'
 import {
   AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION,
@@ -235,15 +235,13 @@ export abstract class DaemonPtyRuntimeState {
   }
 
   onDaemonIdentityChanged(listener: (event: DaemonIdentityChangeEvent) => void): () => void {
-    this.identityChangeListeners.push(listener)
-    return () => removeDaemonListener(this.identityChangeListeners, listener)
+    return addRemovableListener(this.identityChangeListeners, listener)
   }
 
   onAuditEligibilityObservation(
     listener: (observation: DaemonAuditObservation) => void
   ): () => void {
-    this.auditObservationListeners.push(listener)
-    return () => removeDaemonListener(this.auditObservationListeners, listener)
+    return addRemovableListener(this.auditObservationListeners, listener)
   }
 
   supportsAgentSessionClaims(): boolean {

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -1,4 +1,5 @@
 import type { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { addRemovableListener } from './add-removable-listener'
 import { combineUnsubscribes } from './combine-unsubscribes'
 import { shutdownDegradedFallbackSessions } from './degraded-daemon-fallback-shutdown'
 import { inspectPtyProviderProcess } from '../providers/pty-process-inspection'
@@ -222,13 +223,7 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
   }
 
   onData(callback: (payload: PtyDataEvent) => void): () => void {
-    this.dataListeners.push(callback)
-    return () => {
-      const idx = this.dataListeners.indexOf(callback)
-      if (idx !== -1) {
-        this.dataListeners.splice(idx, 1)
-      }
-    }
+    return addRemovableListener(this.dataListeners, callback)
   }
 
   onBackgroundStreamEvent(callback: (payload: PtyBackgroundStreamEvent) => void): () => void {
@@ -265,13 +260,7 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
   }
 
   onExit(callback: (payload: { id: string; code: number }) => void): () => void {
-    this.exitListeners.push(callback)
-    return () => {
-      const idx = this.exitListeners.indexOf(callback)
-      if (idx !== -1) {
-        this.exitListeners.splice(idx, 1)
-      }
-    }
+    return addRemovableListener(this.exitListeners, callback)
   }
 
   ackColdRestore(sessionId: string): void {

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -241,6 +241,9 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     )
   }
 
+  // Why not addRemovableListener: this disposer also runs a downstream fan-out, so it needs a
+  // once-only latch. The shared helper's indexOf guard makes the removal idempotent but would
+  // still re-run `unsubscribes` after disposeProviderOnly() has already drained the array.
   onReplay(callback: (payload: { id: string; data: string }) => void): () => void {
     const unsubscribes = this.allProviders().map((provider) => provider.onReplay(callback))
     let active = true

--- a/src/main/daemon/notify-daemon-audit-listeners.ts
+++ b/src/main/daemon/notify-daemon-audit-listeners.ts
@@ -1,10 +1,3 @@
-export function removeDaemonListener<T>(listeners: T[], listener: T): void {
-  const index = listeners.indexOf(listener)
-  if (index !== -1) {
-    listeners.splice(index, 1)
-  }
-}
-
 export function notifyDaemonAuditListeners<T>(
   listeners: readonly ((value: T) => void)[],
   value: T


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​123 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​123 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​76 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​41 |

<!-- /orca-pr-loc -->

## ELI5

The daemon had **three** separate pieces of code doing the same small job: "put this callback on a
list, and hand back a function that takes it off again." One was a plain function that did only
the *taking off* half. One was a little class. And eight call sites just wrote the whole thing out
by hand.

This PR makes that job have **one** implementation. The class calls it, the hand-written copies
call it, and the take-off-only function is deleted because nothing needs it any more.

Nothing about how Orca behaves changes.

## User-facing before/after

**None — there is no user-visible change.** No UI, no behavior, no wire format, no timing, no
change to what the daemon reports about a session.

What it unblocks: `src/main/daemon/degraded-daemon-pty-provider.ts` sits at **297 counted lines**
on `main` against a 300-line `max-lines` limit. Three open PRs each add a couple of counted lines
to it. Each one passes lint alone; **merged together they land at 304 and lint fails.** No merge
ordering fixes that — the file is only over in the union. This PR takes it to 286 alone, and 293
in that union, so the siblings (and the next few) fit with room to spare.

## What was already there, and what this changes

Before this PR, `src/main/daemon/` had three owners of the register-and-unsubscribe idiom:

| | What it was | Sites |
| --- | --- | ---: |
| `daemon-listener-registry.ts` → `removeDaemonListener` | the *removal* half only; callers still wrote the `push` and the closure themselves | 2 |
| `daemon-client-listener-registry.ts` → `DaemonClientListeners.add` | push + disposer, over an array the class owns | 2 |
| written out by hand at the call site | no helper at all | 8 |

Counting the one deliberate exception below, that is **13 registration entry points across three
shapes**. After this PR, **12 of the 13 resolve to a single implementation**:

- `add-removable-listener.ts` → `addRemovableListener` is that implementation, called directly at
  10 sites.
- `DaemonClientListeners.add` **delegates** to it. The class stays — it also owns its array and
  the `each()` iteration — but no longer carries a second copy of the logic. Its two users in
  `client.ts` are unchanged.
- `removeDaemonListener` is **deleted**. Its only two callers were the last two hand-written
  registrations, in `daemon-pty-runtime-state.ts` (`onDaemonIdentityChanged` at :237 and
  `onAuditEligibilityObservation` at :242), which now call the shared helper directly. With it
  gone, `daemon-listener-registry.ts` held one unrelated function, so the file is renamed
  `notify-daemon-audit-listeners.ts` after what it actually contains.

**The one site that stays different, and why.** `DegradedDaemonPtyProvider.onReplay` keeps its
hand-rolled `trackedUnsubscribe`. Its disposer does two things: remove itself from
`this.unsubscribers`, *and* run a downstream fan-out of provider unsubscribes. The shared helper's
`indexOf` guard makes the removal idempotent, but it would still let that fan-out re-run after
`disposeProviderOnly()` has already drained the array — so this site needs a once-only latch, not
just a guarded splice. **That reason is now written in the code**, at the call site and in the
helper's own comment, rather than living only in a PR description.

## Semantics

The two newly converted sites were checked block by block against what they replaced:

- **Idempotence.** `removeDaemonListener` guarded on `indexOf !== -1`; so does the shared helper.
  A repeat unsubscribe is a no-op in both, and in particular does not evict a later listener the
  way an unguarded `splice(-1, 1)` would.
- **Ordering.** Registration pushes at call time in both; disposal removes by identity, leaving
  the relative order of the remaining listeners intact.
- **No guard was lost.** The one difference worth naming: the old form read
  `this.identityChangeListeners` *at disposal time* (inside the returned arrow), while the helper
  captures the array reference *at registration time*. Those differ only if the field is
  reassigned. It never is — both arrays are cleared with `.length = 0`
  (`daemon-pty-event-subscriptions.ts:63-64`) and are never re-pointed anywhere in `src/`. The
  same check clears `DaemonClientListeners`, whose `private listeners` is likewise never
  reassigned.

`probePtyLiveness`, `inspectProcess` and the `live` / `unverifiable` / `exited` verdict surfaces
are not touched by this diff.

## Verification

Every gate below ran in the foreground on this branch **rebased onto `origin/main` @
`2214d29f15`**, with `pnpm install --frozen-lockfile` under main's pinned toolchain (pnpm 12.0.0,
oxlint 1.80.0, oxfmt 0.65.0). Main's toolchain moved after this branch was cut, so nothing here is
measured at the branch's original base.

| Gate | Result |
| --- | --- |
| `pnpm tc`, incremental state cleared first | exit 0, 0 `error TS` |
| same, with a mismatched listener planted at a converted site | exit 1, `TS2345` — the checker is live and `NoInfer<T>` still pins the type |
| `pnpm lint` (full suite) | exit 0; the log shows the max-lines ratchet, reliability gates and localization checks all ran |
| `oxfmt --check src/` | exit 0 |
| `vitest run src/main/daemon src/main/providers` | 2477 passed, 0 failed |

**The disposers at the two converted sites had no test at all.** Ablating either one to
`return () => {}` left the entire `src/main/daemon` suite green (1700 passed). The same was true
of `DaemonClientListeners.add`. Two new test files close that, and each was confirmed to fail
against its own ablation — one element mutated at a time, with the mutation verified present in
the file before the run:

| Ablation | Result |
| --- | --- |
| `addRemovableListener` guard → unguarded `splice(indexOf(...), 1)` | 3 red |
| `onDaemonIdentityChanged` disposer → no-op | 1 red, the identity test |
| `onAuditEligibilityObservation` disposer → no-op | 1 red, the audit test |
| `DaemonClientListeners.add` disposer → no-op | 2 red |

**Merged-tree line-count proof.** The three open siblings that touch the overflowing file and
still merge cleanly with `main` are #16827 (+3 counted lines), #17058 (+2) and #17085 (+2).
Measured with the pinned oxlint on real merged trees:

- `main` alone → **297**
- `main` + those three siblings, **without** this PR → **304**, `oxlint` on that file exits **1**:
  `max-lines: File has too many lines (304). Maximum allowed is 300.`
- `main` + those three siblings + this PR → **293**, `oxlint` exits **0**

Same command, same tree; only this commit differs. No `max-lines` suppression was added — the
ratchet still reports its 87 pre-existing grandfathered entries, unchanged.

#16277 and #17007 also touch that file but currently conflict with `main`, so they could not be
included in the union measurement.

## Merge note

Merging this after #17058 produces one trivial conflict: both insert an import immediately after
line 1 of `degraded-daemon-pty-provider.ts`. Both lines are wanted; keep both.
