### PR TITLE
Prime native cache before E2E fanout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,9 +55,13 @@ jobs:
         env:
           VITE_EXPOSE_STORE: 'true'
         run: |
-          npx electron-vite build --mode e2e
-          pnpm run build:web-from-renderer
-          pnpm run build:relay
+          status=0
+          pnpm run build:relay &
+          relay_pid=$!
+          npx electron-vite build --mode e2e || status=1
+          pnpm run build:web-from-renderer || status=1
+          wait "$relay_pid" || status=1
+          exit "$status"
 
       - name: Upload E2E build output
         uses: actions/upload-artifact@v7
@@ -71,9 +75,29 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  # Build Electron-native dependencies once per workflow. Consumer shards restore
+  # this immutable cache instead of compiling the same ABI concurrently.
+  prepare-native-cache:
+    name: prepare Electron native cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install native build tools
+        run: sudo apt-get update && sudo apt-get install -y build-essential python3
+
+      - uses: ./.github/actions/install-node-dependencies
+        with:
+          native-runtime: electron
+
   e2e:
     name: e2e ${{ matrix.shard_name }}
-    needs: build
+    needs: [build, prepare-native-cache]
     if: inputs.test_files == ''
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -159,7 +183,7 @@ jobs:
 
   changed-e2e:
     name: changed e2e specs
-    needs: build
+    needs: [build, prepare-native-cache]
     if: inputs.test_files != ''
     runs-on: ubuntu-latest
     # Why 45: pr.yml now maps SSH source edits onto Docker-backed specs, so this lane can
@@ -227,8 +251,7 @@ jobs:
 
   ssh-docker-watcher-isolation:
     name: ssh docker watcher isolation
-    needs: build
-    # Why ssh_source_changed first: this lane used to trigger on SSH source only as a side
+    needs: [build, prepare-native-cache]
     # effect of one route listing a startup-readiness spec — pruning that spec would have
     # silently retired the whole lane. The signal is now derived from the SSH routes directly.
     # The two spec clauses stay for their honest purpose: changed-e2e hands these specs to this

--- a/config/scripts/release-cut-token-permissions.test.mjs
+++ b/config/scripts/release-cut-token-permissions.test.mjs
@@ -8,6 +8,7 @@ const EXPECTED_MATRIX = {
   '.github/workflows/e2e.yml#build': { contents: 'read' },
   '.github/workflows/e2e.yml#changed-e2e': { contents: 'read' },
   '.github/workflows/e2e.yml#e2e': { contents: 'read' },
+  '.github/workflows/e2e.yml#prepare-native-cache': { contents: 'read' },
   '.github/workflows/e2e.yml#ssh-docker-watcher-isolation': { contents: 'read' },
   '.github/workflows/homebrew-bump.yml#bump-cask': { contents: 'read' },
   '.github/workflows/release-mac-build.yml#build-mac': { contents: 'write' },

--- a/config/scripts/release-e2e-dispatch-contract.test.mjs
+++ b/config/scripts/release-e2e-dispatch-contract.test.mjs
@@ -46,6 +46,28 @@ describe('release E2E dispatch contract', () => {
     expect(refInput.required).toBe(false)
   })
 
+  it('overlaps the relay bundle with the Electron build', () => {
+    const buildStep = e2eWorkflow.jobs.build.steps.find((step) => step.name === 'Build E2E outputs')
+
+    expect(buildStep.run).toContain('pnpm run build:relay &')
+    expect(buildStep.run).toContain('relay_pid=$!')
+    expect(buildStep.run).toContain('wait "$relay_pid"')
+    expect(buildStep.run).toContain('pnpm run build:web-from-renderer')
+  })
+
+  it('primes the Electron native cache before every E2E consumer', () => {
+    const primer = e2eWorkflow.jobs['prepare-native-cache']
+    expect(primer.steps).toBeDefined()
+    expect(
+      primer.steps.find((step) => step.uses === './.github/actions/install-node-dependencies').with
+    ).toEqual({
+      'native-runtime': 'electron'
+    })
+    for (const jobName of ['e2e', 'changed-e2e', 'ssh-docker-watcher-isolation']) {
+      expect(e2eWorkflow.jobs[jobName].needs, jobName).toEqual(['build', 'prepare-native-cache'])
+    }
+  })
+
   it('includes the paired-runtime web client in the shared E2E build artifact', () => {
     const buildStep = e2eWorkflow.jobs.build.steps.find((step) => step.name === 'Build E2E outputs')
 
@@ -71,7 +93,7 @@ describe('release E2E dispatch contract', () => {
       const downloadStep = job.steps.find((step) => step.name === 'Download E2E build output')
       const runStep = job.steps.find((step) => step.name === runStepName)
 
-      expect(job.needs).toBe('build')
+      expect(job.needs).toEqual(['build', 'prepare-native-cache'])
       expect(downloadStep.with.name).toBe('e2e-build-out')
       expect(downloadStep.with.path).toBe('out/')
       expect(runStep.run).toContain('ORCA_RELAY_PATH="$GITHUB_WORKSPACE/out/relay"')


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

## Summary

- Add a single Electron native-cache primer job to the reusable E2E workflow.
- Run the primer concurrently with the E2E app build.
- Make full E2E, changed E2E, and Docker-SSH consumers wait for both build artifacts and the prepared native cache.
- Build the independent relay bundle concurrently with the Electron/Web output build.

## Why

Every E2E consumer currently runs the shared install action with `native-runtime: electron`. On a cold cache, all 14 shards can compile the same Electron ABI concurrently. The primer owns that cold build once; consumers restore the immutable cache afterward. On warm caches, the primer overlaps the existing app build, so it should not extend the critical path.

The relay bundle writes `out/relay` independently from Electron/Web outputs. It now runs in the background while those outputs build and is explicitly awaited with failure propagation.

## Testing

- E2E workflow contracts: 62 passed.
- `actionlint .github/workflows/e2e.yml`: passed.
- `git diff --check`: clean.

This PR changes workflow orchestration only; no product behavior.