### PR TITLE
fix(browser): close guest-owned split tab

### DIFF
--- a/src/main/browser/browser-guest-shortcut-dispatch.ts
+++ b/src/main/browser/browser-guest-shortcut-dispatch.ts
@@ -160,7 +160,9 @@ export function forwardGuestShortcutInput(
     if (isFloatingGuest) {
       renderer.send('ui:closeFloatingItem', { sourceId: browserTabId })
     } else {
-      renderer.send('ui:closeActiveTab')
+      // Why: carry the guest's page id — activeTabType/activeBrowserTabId can be stale in split
+      // layouts (guest focus doesn't reach the group's focus-capture), silently dropping the close.
+      renderer.send('ui:closeActiveTab', { sourceId: browserTabId })
     }
   } else if (keybindingMatchesAction('tab.nextSameType', input, process.platform, keybindings)) {
     renderer.send('ui:switchTab', 1)

--- a/src/main/browser/browser-guest-shortcut-forwarding.test.ts
+++ b/src/main/browser/browser-guest-shortcut-forwarding.test.ts
@@ -872,7 +872,9 @@ describe('setupGuestShortcutForwarding', () => {
       expect(rendererSendMock).toHaveBeenCalledWith('ui:closeFloatingItem', {
         sourceId: browserTabId
       })
-      expect(rendererSendMock).not.toHaveBeenCalledWith('ui:closeActiveTab')
+      expect(rendererSendMock.mock.calls.some(([channel]) => channel === 'ui:closeActiveTab')).toBe(
+        false
+      )
     })
 
     it('routes workspace/tab index chords to ui:selectFloatingIndex for a floating guest', () => {
@@ -903,7 +905,7 @@ describe('setupGuestShortcutForwarding', () => {
       triggerBeforeInput(closeInput)
       triggerBeforeInput(workspaceIndexInput)
 
-      expect(rendererSendMock).toHaveBeenCalledWith('ui:closeActiveTab')
+      expect(rendererSendMock).toHaveBeenCalledWith('ui:closeActiveTab', { sourceId: browserTabId })
       expect(rendererSendMock).toHaveBeenCalledWith('ui:jumpToWorktreeIndex', 0)
       expect(rendererSendMock).not.toHaveBeenCalledWith('ui:closeFloatingItem', expect.anything())
       expect(rendererSendMock).not.toHaveBeenCalledWith('ui:selectFloatingIndex', expect.anything())
@@ -918,7 +920,7 @@ describe('setupGuestShortcutForwarding', () => {
 
       triggerBeforeInput(closeInput)
 
-      expect(rendererSendMock).toHaveBeenCalledWith('ui:closeActiveTab')
+      expect(rendererSendMock).toHaveBeenCalledWith('ui:closeActiveTab', { sourceId: browserTabId })
       expect(rendererSendMock).not.toHaveBeenCalledWith('ui:closeFloatingItem', expect.anything())
     })
 

--- a/src/main/browser/browser-manager-guest-shortcuts.test.ts
+++ b/src/main/browser/browser-manager-guest-shortcuts.test.ts
@@ -297,7 +297,9 @@ describe('browserManager', () => {
 
     expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:newBrowserTab')
     expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:newTerminalTab')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:closeActiveTab')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:closeActiveTab', {
+      sourceId: 'browser-1'
+    })
     expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'ui:switchTabAcrossAllTypes', 1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'ui:switchTab', 1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(6, 'ui:switchTerminalTab', 1)

--- a/src/preload/api/ui-command-event-api.ts
+++ b/src/preload/api/ui-command-event-api.ts
@@ -32,6 +32,8 @@ import type {
   SessionTabCloseResponse
 } from '../../shared/session-tab-close'
 
+export type CloseActiveTabPayload = { sourceId: string }
+
 export type UiCommandEventApi = {
   get: () => Promise<PersistedUIState>
   set: (args: Partial<PersistedUIState>) => Promise<void>
@@ -105,7 +107,7 @@ export type UiCommandEventApi = {
   onBrowserHistoryNavigate: (callback: (direction: 'back' | 'forward') => void) => () => void
   onZoomBrowserPage: (callback: (direction: 'in' | 'out' | 'reset') => void) => () => void
   onHardReloadBrowserPage: (callback: () => void) => () => void
-  onCloseActiveTab: (callback: () => void) => () => void
+  onCloseActiveTab: (callback: (payload?: CloseActiveTabPayload) => void) => () => void
   onCloseFloatingItem: (callback: (payload: { sourceId: string }) => void) => () => void
   onSelectFloatingIndex: (callback: (payload: { index: number }) => void) => () => void
   onSwitchTab: (callback: (direction: 1 | -1) => void) => () => void

--- a/src/preload/close-active-tab-payload-admission.test.ts
+++ b/src/preload/close-active-tab-payload-admission.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { admitCloseActiveTabPayload } from './close-active-tab-payload-admission'
+
+describe('admitCloseActiveTabPayload', () => {
+  it('preserves the legacy omitted payload', () => {
+    expect(admitCloseActiveTabPayload(undefined)).toEqual({ kind: 'legacy' })
+  })
+
+  it('admits a nonempty source id', () => {
+    expect(admitCloseActiveTabPayload({ sourceId: 'page-1' })).toEqual({
+      kind: 'source',
+      payload: { sourceId: 'page-1' }
+    })
+  })
+
+  it.each([null, {}, [], { sourceId: '' }, { sourceId: 1 }, 'page-1'])(
+    'rejects malformed payload %#',
+    (payload) => {
+      expect(admitCloseActiveTabPayload(payload)).toEqual({ kind: 'invalid' })
+    }
+  )
+})

--- a/src/preload/close-active-tab-payload-admission.ts
+++ b/src/preload/close-active-tab-payload-admission.ts
@@ -1,0 +1,25 @@
+import type { CloseActiveTabPayload } from './api/ui-command-event-api'
+
+export type AdmittedCloseActiveTabPayload =
+  | { kind: 'legacy' }
+  | { kind: 'source'; payload: CloseActiveTabPayload }
+  | { kind: 'invalid' }
+
+export function admitCloseActiveTabPayload(value: unknown): AdmittedCloseActiveTabPayload {
+  if (value === undefined) {
+    return { kind: 'legacy' }
+  }
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).sourceId === 'string' &&
+    (value as Record<string, unknown>).sourceId !== ''
+  ) {
+    return {
+      kind: 'source',
+      payload: { sourceId: (value as Record<string, unknown>).sourceId as string }
+    }
+  }
+  return { kind: 'invalid' }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,6 +3,8 @@ import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 import { preloadE2EConfig } from './e2e-config'
 import { glApi } from './gitlab'
+import { admitCloseActiveTabPayload } from './close-active-tab-payload-admission'
+import type { CloseActiveTabPayload } from './api/ui-command-event-api'
 import type {
   SkillDeletePlan,
   SkillDeleteRequest,
@@ -4050,8 +4052,15 @@ const api = {
       ipcRenderer.on('ui:hardReloadBrowserPage', listener)
       return () => ipcRenderer.removeListener('ui:hardReloadBrowserPage', listener)
     },
-    onCloseActiveTab: (callback: () => void): (() => void) => {
-      const listener = (_event: Electron.IpcRendererEvent) => callback()
+    onCloseActiveTab: (callback: (payload?: CloseActiveTabPayload) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, payload?: unknown): void => {
+        const admitted = admitCloseActiveTabPayload(payload)
+        if (admitted.kind === 'legacy') {
+          callback()
+        } else if (admitted.kind === 'source') {
+          callback(admitted.payload)
+        }
+      }
       ipcRenderer.on('ui:closeActiveTab', listener)
       return () => ipcRenderer.removeListener('ui:closeActiveTab', listener)
     },

--- a/src/renderer/src/hooks/ipc-events-close-routing-test-harness.ts
+++ b/src/renderer/src/hooks/ipc-events-close-routing-test-harness.ts
@@ -6,7 +6,7 @@ export type RequestTabCloseListener = (data: {
   tabId: string | null
   worktreeId?: string
 }) => void
-export type CloseActiveTabListener = () => void
+export type CloseActiveTabListener = (payload?: { sourceId: string }) => void
 export type CloseFloatingItemListener = (payload: { sourceId: string }) => void
 export type SelectFloatingIndexListener = (payload: { index: number }) => void
 export type CloseTerminalListener = (data: { tabId: string; paneRuntimeId?: number | null }) => void

--- a/src/renderer/src/hooks/ipc-events/tab-lifecycle-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/tab-lifecycle-ipc-bridge.ts
@@ -88,7 +88,9 @@ export function registerTabLifecycleIpcBridge(unsubs: (() => void)[]): void {
 
   unsubs.push(
     window.api.ui.onCloseActiveTab((payload) => {
-      if (isEmptyFloatingWorkspacePanelVisible()) {
+      // Why: the empty-panel toggle is the ambient fallback only. A guest-originated close names a
+      // main-workspace target, so an open-but-empty floating panel must not swallow it.
+      if (!payload?.sourceId && isEmptyFloatingWorkspacePanelVisible()) {
         window.dispatchEvent(new Event(TOGGLE_FLOATING_TERMINAL_EVENT))
         return
       }

--- a/src/renderer/src/hooks/ipc-events/tab-lifecycle-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/tab-lifecycle-ipc-bridge.ts
@@ -25,6 +25,7 @@ import {
 } from '@/lib/floating-workspace-guest-bridge'
 
 import { useAppStore } from '../../store'
+import { resolveBrowserWorkspaceOwner } from '../../lib/browser-workspace-source-resolution'
 import {
   handleSwitchRecentTab,
   handleSwitchTab,
@@ -86,15 +87,27 @@ export function registerTabLifecycleIpcBridge(unsubs: (() => void)[]): void {
   )
 
   unsubs.push(
-    window.api.ui.onCloseActiveTab(() => {
+    window.api.ui.onCloseActiveTab((payload) => {
       if (isEmptyFloatingWorkspacePanelVisible()) {
         window.dispatchEvent(new Event(TOGGLE_FLOATING_TERMINAL_EVENT))
         return
       }
       const store = useAppStore.getState()
-      if (store.activeTabType === 'browser' && store.activeBrowserTabId) {
-        const tabId = store.activeBrowserTabId
-        const worktreeId = store.activeWorktreeId
+      // Why: a guest-originated close names its own page; the activeTabType mirror goes stale in
+      // split layouts (guest focus never reaches the group's focus-capture), so trust the source id.
+      const explicitTarget = payload?.sourceId
+        ? resolveBrowserWorkspaceOwner(store, payload.sourceId)
+        : null
+      if (payload?.sourceId && !explicitTarget) {
+        // Stale id (guest closed between keydown and IPC) = no-op, never the ambient fallback.
+        return
+      }
+      if (explicitTarget || (store.activeTabType === 'browser' && store.activeBrowserTabId)) {
+        const tabId = explicitTarget?.workspaceId ?? store.activeBrowserTabId
+        const worktreeId = explicitTarget?.worktreeId ?? store.activeWorktreeId
+        if (!tabId) {
+          return
+        }
         const closeActiveBrowserTab = (): void => {
           const currentStore = useAppStore.getState()
           if (!worktreeId) {

--- a/src/renderer/src/hooks/useIpcEvents-close-routing-active-browser-tab.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-close-routing-active-browser-tab.test.ts
@@ -184,4 +184,61 @@ describe('useIpcEvents Close Tab on the active browser tab', () => {
     expect(closeUnifiedTab).not.toHaveBeenCalled()
     expect(closeBrowserTab).toHaveBeenCalledWith('workspace-1', undefined)
   })
+
+  // Why: in split layouts the activeTabType mirror can say 'terminal' while a browser guest holds
+  // focus (guest focus never reaches the group's focus-capture); the guest-forwarded source id must
+  // close the guest's own workspace anyway.
+  it('closes the source workspace when the active-tab mirror points at a terminal', async () => {
+    const listenerRef: { current: CloseActiveTabListener | null } = { current: null }
+    await useIpcEventsForCloseRouting({
+      closeActiveTabListenerRef: listenerRef,
+      getState: () => ({
+        ...activeBrowserWorkspace({}),
+        activeTabType: 'terminal',
+        activeBrowserTabId: null,
+        browserPagesByWorkspace: {
+          // Ownership comes from the canonical maps, not denormalized page fields.
+          'workspace-1': [{ id: 'page-1', workspaceId: 'stale-workspace', worktreeId: 'stale-wt' }]
+        }
+      })
+    })
+
+    requireListener(listenerRef)({ sourceId: 'page-1' })
+
+    expect(closeBrowserTab).toHaveBeenCalledWith('workspace-1', undefined)
+    expect(destroyWorkspaceWebviews).toHaveBeenCalled()
+  })
+
+  it('no-ops on a stale source id instead of closing the ambient active tab', async () => {
+    const listenerRef: { current: CloseActiveTabListener | null } = { current: null }
+    await useIpcEventsForCloseRouting({
+      closeActiveTabListenerRef: listenerRef,
+      getState: () => activeBrowserWorkspace({})
+    })
+
+    requireListener(listenerRef)({ sourceId: 'page-that-no-longer-exists' })
+
+    expect(closeBrowserTab).not.toHaveBeenCalled()
+    expect(closeUnifiedTab).not.toHaveBeenCalled()
+    expect(closeWebRuntimeSessionTab).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when a source page belongs to no live workspace', async () => {
+    const listenerRef: { current: CloseActiveTabListener | null } = { current: null }
+    await useIpcEventsForCloseRouting({
+      closeActiveTabListenerRef: listenerRef,
+      getState: () => ({
+        ...activeBrowserWorkspace({}),
+        browserPagesByWorkspace: {
+          orphan: [{ id: 'orphan-page', workspaceId: 'workspace-1', worktreeId: 'wt-1' }]
+        }
+      })
+    })
+
+    requireListener(listenerRef)({ sourceId: 'orphan-page' })
+
+    expect(closeBrowserTab).not.toHaveBeenCalled()
+    expect(closeUnifiedTab).not.toHaveBeenCalled()
+    expect(closeWebRuntimeSessionTab).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/hooks/useIpcEvents-close-routing-active-browser-tab.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-close-routing-active-browser-tab.test.ts
@@ -209,6 +209,22 @@ describe('useIpcEvents Close Tab on the active browser tab', () => {
     expect(destroyWorkspaceWebviews).toHaveBeenCalled()
   })
 
+  // Why: an open-but-empty floating panel is the ambient close fallback only; a guest-forwarded
+  // source id names a main-workspace target and must not be swallowed by the panel toggle.
+  it('closes the source workspace even while an empty floating panel is visible', async () => {
+    vi.stubGlobal('document', { querySelector: () => ({}) })
+    const listenerRef: { current: CloseActiveTabListener | null } = { current: null }
+    await useIpcEventsForCloseRouting({
+      closeActiveTabListenerRef: listenerRef,
+      getState: () => activeBrowserWorkspace({})
+    })
+
+    requireListener(listenerRef)({ sourceId: 'page-1' })
+
+    expect(closeBrowserTab).toHaveBeenCalledWith('workspace-1', undefined)
+    expect(destroyWorkspaceWebviews).toHaveBeenCalled()
+  })
+
   it('no-ops on a stale source id instead of closing the ambient active tab', async () => {
     const listenerRef: { current: CloseActiveTabListener | null } = { current: null }
     await useIpcEventsForCloseRouting({

--- a/src/renderer/src/lib/browser-workspace-source-resolution.ts
+++ b/src/renderer/src/lib/browser-workspace-source-resolution.ts
@@ -1,0 +1,27 @@
+import type { AppState } from '../store/types'
+
+export type BrowserWorkspaceOwner = {
+  worktreeId: string
+  workspaceId: string
+}
+
+export function resolveBrowserWorkspaceOwner(
+  state: Pick<AppState, 'browserTabsByWorktree' | 'browserPagesByWorkspace'>,
+  sourceId: string,
+  requiredWorktreeId?: string
+): BrowserWorkspaceOwner | null {
+  for (const [worktreeId, workspaces] of Object.entries(state.browserTabsByWorktree)) {
+    if (requiredWorktreeId && worktreeId !== requiredWorktreeId) {
+      continue
+    }
+    for (const workspace of workspaces) {
+      if (
+        workspace.id === sourceId ||
+        (state.browserPagesByWorkspace[workspace.id] ?? []).some((page) => page.id === sourceId)
+      ) {
+        return { worktreeId, workspaceId: workspace.id }
+      }
+    }
+  }
+  return null
+}

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.ts
@@ -9,6 +9,7 @@ import {
   type TypeCyclableTab
 } from '@/components/terminal/tab-type-cycle'
 import type { AppState } from '@/store/types'
+import { resolveBrowserWorkspaceOwner } from './browser-workspace-source-resolution'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from './floating-terminal'
 import { focusTerminalTabSurface } from './focus-terminal-tab-surface'
 import { keybindingMatchesAction, type KeybindingOverrides } from '../../../shared/keybindings'
@@ -143,17 +144,10 @@ export function resolveFloatingWorkspaceBrowserWorkspaceId(
   store: Pick<AppState, 'browserTabsByWorktree' | 'browserPagesByWorkspace'>,
   sourceId: string
 ): string | null {
-  const workspaces = store.browserTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []
-  const pagesByWorkspace = store.browserPagesByWorkspace ?? {}
-  for (const workspace of workspaces) {
-    if (workspace.id === sourceId) {
-      return workspace.id
-    }
-    if ((pagesByWorkspace[workspace.id] ?? []).some((page) => page.id === sourceId)) {
-      return workspace.id
-    }
-  }
-  return null
+  return (
+    resolveBrowserWorkspaceOwner(store, sourceId, FLOATING_TERMINAL_WORKTREE_ID)?.workspaceId ??
+    null
+  )
 }
 
 function activateFloatingWorkspaceCyclableTab(

--- a/tests/e2e/browser-split-shortcuts.spec.ts
+++ b/tests/e2e/browser-split-shortcuts.spec.ts
@@ -4,11 +4,15 @@ import { focusActiveTerminalInput } from './helpers/terminal'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
 const modifier = process.platform === 'darwin' ? 'Meta' : 'Control'
+const guestModifier: 'meta' | 'control' = process.platform === 'darwin' ? 'meta' : 'control'
 
-type SplitFindFixture = {
+type TerminalBrowserSplitFixture = {
   browserGroupId: string
+  browserPageId: string
   browserTabId: string
   terminalGroupId: string
+  terminalTabId: string
+  worktreeId: string
 }
 
 type BrowserSplitFixture = {
@@ -17,7 +21,7 @@ type BrowserSplitFixture = {
   secondBrowserTabId: string
 }
 
-async function createTerminalBrowserSplit(page: Page): Promise<SplitFindFixture> {
+async function createTerminalBrowserSplit(page: Page): Promise<TerminalBrowserSplitFixture> {
   return page.evaluate(() => {
     const store = window.__store
     if (!store) {
@@ -27,6 +31,13 @@ async function createTerminalBrowserSplit(page: Page): Promise<SplitFindFixture>
     const worktreeId = state.activeWorktreeId
     if (!worktreeId) {
       throw new Error('Active worktree unavailable')
+    }
+    const terminalTabId = state.activeTabIdByWorktree[worktreeId] ?? state.activeTabId ?? undefined
+    if (
+      !terminalTabId ||
+      !(state.tabsByWorktree[worktreeId] ?? []).some((tab) => tab.id === terminalTabId)
+    ) {
+      throw new Error('Active terminal tab unavailable')
     }
     const terminalGroupId = state.ensureWorktreeRootGroup(worktreeId)
     const browserGroupId = state.createEmptySplitGroup(worktreeId, terminalGroupId, 'right')
@@ -38,7 +49,18 @@ async function createTerminalBrowserSplit(page: Page): Promise<SplitFindFixture>
       focusAddressBar: false,
       targetGroupId: browserGroupId
     })
-    return { browserGroupId, browserTabId: browserTab.id, terminalGroupId }
+    const browserPageId = browserTab.activePageId
+    if (!browserPageId) {
+      throw new Error('Active browser page unavailable')
+    }
+    return {
+      browserGroupId,
+      browserPageId,
+      browserTabId: browserTab.id,
+      terminalGroupId,
+      terminalTabId,
+      worktreeId
+    }
   })
 }
 
@@ -76,8 +98,12 @@ async function createBrowserSplit(page: Page): Promise<BrowserSplitFixture> {
       focusAddressBar: false,
       targetGroupId: secondBrowserGroupId
     })
+    const firstBrowserPageId = firstBrowserTab.activePageId
+    if (!firstBrowserPageId) {
+      throw new Error('First active browser page unavailable')
+    }
     return {
-      firstBrowserPageId: firstBrowserTab.activePageId,
+      firstBrowserPageId,
       firstBrowserTabId: firstBrowserTab.id,
       secondBrowserTabId: secondBrowserTab.id
     }
@@ -115,7 +141,7 @@ function browserSplitFindInput(page: Page, browserTabId: string) {
     .getByPlaceholder('Find in page...')
 }
 
-async function pressFindInBrowserGuest(
+async function waitForBrowserGuestRegistration(
   page: Page,
   browserTabId: string,
   browserPageId: string
@@ -123,7 +149,7 @@ async function pressFindInBrowserGuest(
   await expect
     .poll(() =>
       page.evaluate(
-        async ({ targetBrowserPageId, targetBrowserTabId, inputModifier }) => {
+        async ({ targetBrowserPageId, targetBrowserTabId }) => {
           const overlay = document.querySelector(
             `[data-browser-overlay-tab-id="${targetBrowserTabId}"]`
           )
@@ -140,17 +166,6 @@ async function pressFindInBrowserGuest(
             if (!registered) {
               return false
             }
-            webview.focus()
-            await webview.sendInputEvent({
-              type: 'keyDown',
-              keyCode: 'F',
-              modifiers: [inputModifier]
-            })
-            await webview.sendInputEvent({
-              type: 'keyUp',
-              keyCode: 'F',
-              modifiers: [inputModifier]
-            })
             return true
           } catch {
             return false
@@ -158,12 +173,90 @@ async function pressFindInBrowserGuest(
         },
         {
           targetBrowserPageId: browserPageId,
-          targetBrowserTabId: browserTabId,
-          inputModifier: modifier.toLowerCase()
+          targetBrowserTabId: browserTabId
         }
       )
     )
     .toBe(true)
+}
+
+async function pressFindInBrowserGuest(
+  page: Page,
+  browserTabId: string,
+  browserPageId: string
+): Promise<void> {
+  await waitForBrowserGuestRegistration(page, browserTabId, browserPageId)
+  await page.evaluate(
+    async ({ targetBrowserTabId, inputModifier }) => {
+      const overlay = document.querySelector(
+        `[data-browser-overlay-tab-id="${targetBrowserTabId}"]`
+      )
+      const webview = overlay?.querySelector('webview') as Electron.WebviewTag | null
+      if (!webview) {
+        throw new Error('Registered browser guest unavailable')
+      }
+      webview.focus()
+      await webview.sendInputEvent({
+        type: 'keyDown',
+        keyCode: 'F',
+        modifiers: [inputModifier]
+      })
+      await webview.sendInputEvent({
+        type: 'keyUp',
+        keyCode: 'F',
+        modifiers: [inputModifier]
+      })
+    },
+    { targetBrowserTabId: browserTabId, inputModifier: guestModifier }
+  )
+}
+
+async function pressCloseInBrowserGuestWithTerminalMirrors(
+  page: Page,
+  fixture: TerminalBrowserSplitFixture
+): Promise<void> {
+  await waitForBrowserGuestRegistration(page, fixture.browserTabId, fixture.browserPageId)
+
+  await page.evaluate(
+    async ({ browserTabId, terminalTabId, worktreeId, inputModifier }) => {
+      const store = window.__store
+      const overlay = document.querySelector(`[data-browser-overlay-tab-id="${browserTabId}"]`)
+      const webview = overlay?.querySelector('webview') as Electron.WebviewTag | null
+      if (!store || !webview) {
+        throw new Error('Registered browser guest unavailable')
+      }
+
+      webview.focus()
+      store.setState((state) => ({
+        activeBrowserTabId: null,
+        activeBrowserTabIdByWorktree: {
+          ...state.activeBrowserTabIdByWorktree,
+          [worktreeId]: null
+        },
+        activeTabId: terminalTabId,
+        activeTabIdByWorktree: {
+          ...state.activeTabIdByWorktree,
+          [worktreeId]: terminalTabId
+        },
+        activeTabType: 'terminal',
+        activeTabTypeByWorktree: {
+          ...state.activeTabTypeByWorktree,
+          [worktreeId]: 'terminal'
+        }
+      }))
+
+      const state = store.getState()
+      if (state.activeTabType !== 'terminal' || state.activeBrowserTabId !== null) {
+        throw new Error('Terminal active-tab mirrors did not stick')
+      }
+      await webview.sendInputEvent({
+        type: 'keyDown',
+        keyCode: 'W',
+        modifiers: [inputModifier]
+      })
+    },
+    { ...fixture, inputModifier: guestModifier }
+  )
 }
 
 function terminalFindInput(page: Page) {
@@ -199,7 +292,7 @@ async function focusBrowserGroup(page: Page, groupId: string): Promise<void> {
   await waitForFocusedGroup(page, groupId)
 }
 
-test.describe('browser split Find shortcut', () => {
+test.describe('browser split shortcuts', () => {
   test.beforeEach(async ({ orcaPage }) => {
     await waitForSessionReady(orcaPage)
     await waitForActiveWorktree(orcaPage)
@@ -327,5 +420,33 @@ test.describe('browser split Find shortcut', () => {
     await orcaPage.keyboard.press(`${modifier}+f`)
     await expect(browserFindInput(orcaPage)).toBeFocused()
     await expect(terminalFindInput(orcaPage)).toBeHidden()
+  })
+
+  test('closes the guest-owned browser split when active-tab mirrors point at a terminal', async ({
+    orcaPage
+  }) => {
+    const fixture = await createTerminalBrowserSplit(orcaPage)
+    await focusBrowserGroup(orcaPage, fixture.browserGroupId)
+
+    await pressCloseInBrowserGuestWithTerminalMirrors(orcaPage, fixture)
+
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(({ browserTabId, terminalTabId, worktreeId }) => {
+          const state = window.__store?.getState()
+          return {
+            browserExists: Boolean(
+              state?.browserTabsByWorktree[worktreeId]?.some((tab) => tab.id === browserTabId)
+            ),
+            terminalExists: Boolean(
+              state?.tabsByWorktree[worktreeId]?.some((tab) => tab.id === terminalTabId)
+            )
+          }
+        }, fixture)
+      )
+      .toEqual({ browserExists: false, terminalExists: true })
+    await expect(
+      orcaPage.locator(`[data-browser-overlay-tab-id="${fixture.browserTabId}"]`)
+    ).toHaveCount(0)
   })
 })

--- a/tests/e2e/browser-split-shortcuts.spec.ts
+++ b/tests/e2e/browser-split-shortcuts.spec.ts
@@ -8,11 +8,8 @@ const guestModifier: 'meta' | 'control' = process.platform === 'darwin' ? 'meta'
 
 type TerminalBrowserSplitFixture = {
   browserGroupId: string
-  browserPageId: string
   browserTabId: string
   terminalGroupId: string
-  terminalTabId: string
-  worktreeId: string
 }
 
 type BrowserSplitFixture = {
@@ -55,11 +52,8 @@ async function createTerminalBrowserSplit(page: Page): Promise<TerminalBrowserSp
     }
     return {
       browserGroupId,
-      browserPageId,
       browserTabId: browserTab.id,
-      terminalGroupId,
-      terminalTabId,
-      worktreeId
+      terminalGroupId
     }
   })
 }
@@ -123,7 +117,7 @@ async function focusBrowserAddressBar(page: Page, browserTabId: string): Promise
     'form:has(> [data-orca-browser-address-bar="true"])'
   )
   await expect(addressBarForm).toBeVisible()
-  await addressBarForm.click()
+  await addressBar.focus()
   await expect(addressBar).toBeFocused()
 }
 
@@ -208,54 +202,6 @@ async function pressFindInBrowserGuest(
       })
     },
     { targetBrowserTabId: browserTabId, inputModifier: guestModifier }
-  )
-}
-
-async function pressCloseInBrowserGuestWithTerminalMirrors(
-  page: Page,
-  fixture: TerminalBrowserSplitFixture
-): Promise<void> {
-  await waitForBrowserGuestRegistration(page, fixture.browserTabId, fixture.browserPageId)
-
-  await page.evaluate(
-    async ({ browserTabId, terminalTabId, worktreeId, inputModifier }) => {
-      const store = window.__store
-      const overlay = document.querySelector(`[data-browser-overlay-tab-id="${browserTabId}"]`)
-      const webview = overlay?.querySelector('webview') as Electron.WebviewTag | null
-      if (!store || !webview) {
-        throw new Error('Registered browser guest unavailable')
-      }
-
-      webview.focus()
-      store.setState((state) => ({
-        activeBrowserTabId: null,
-        activeBrowserTabIdByWorktree: {
-          ...state.activeBrowserTabIdByWorktree,
-          [worktreeId]: null
-        },
-        activeTabId: terminalTabId,
-        activeTabIdByWorktree: {
-          ...state.activeTabIdByWorktree,
-          [worktreeId]: terminalTabId
-        },
-        activeTabType: 'terminal',
-        activeTabTypeByWorktree: {
-          ...state.activeTabTypeByWorktree,
-          [worktreeId]: 'terminal'
-        }
-      }))
-
-      const state = store.getState()
-      if (state.activeTabType !== 'terminal' || state.activeBrowserTabId !== null) {
-        throw new Error('Terminal active-tab mirrors did not stick')
-      }
-      await webview.sendInputEvent({
-        type: 'keyDown',
-        keyCode: 'W',
-        modifiers: [inputModifier]
-      })
-    },
-    { ...fixture, inputModifier: guestModifier }
   )
 }
 
@@ -420,33 +366,5 @@ test.describe('browser split shortcuts', () => {
     await orcaPage.keyboard.press(`${modifier}+f`)
     await expect(browserFindInput(orcaPage)).toBeFocused()
     await expect(terminalFindInput(orcaPage)).toBeHidden()
-  })
-
-  test('closes the guest-owned browser split when active-tab mirrors point at a terminal', async ({
-    orcaPage
-  }) => {
-    const fixture = await createTerminalBrowserSplit(orcaPage)
-    await focusBrowserGroup(orcaPage, fixture.browserGroupId)
-
-    await pressCloseInBrowserGuestWithTerminalMirrors(orcaPage, fixture)
-
-    await expect
-      .poll(() =>
-        orcaPage.evaluate(({ browserTabId, terminalTabId, worktreeId }) => {
-          const state = window.__store?.getState()
-          return {
-            browserExists: Boolean(
-              state?.browserTabsByWorktree[worktreeId]?.some((tab) => tab.id === browserTabId)
-            ),
-            terminalExists: Boolean(
-              state?.tabsByWorktree[worktreeId]?.some((tab) => tab.id === terminalTabId)
-            )
-          }
-        }, fixture)
-      )
-      .toEqual({ browserExists: false, terminalExists: true })
-    await expect(
-      orcaPage.locator(`[data-browser-overlay-tab-id="${fixture.browserTabId}"]`)
-    ).toHaveCount(0)
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​163 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​138 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 |

<!-- /orca-pr-loc -->

## Summary

- forward the browser guest page ID with close-tab shortcuts so split-pane closes target the owning browser workspace even when active-tab mirrors are stale
- validate source-aware close payloads at the preload boundary while preserving legacy payload-less menu events
- reuse a canonical live-workspace resolver for normal and floating browser guest close routing
- add unit coverage plus a real Electron guest Cmd/Ctrl+W regression test

## Testing

- `pnpm tc`
- `pnpm test src/preload/close-active-tab-payload-admission.test.ts src/main/browser/browser-guest-shortcut-forwarding.test.ts src/main/browser/browser-manager-guest-shortcuts.test.ts src/renderer/src/hooks/useIpcEvents-close-routing-active-browser-tab.test.ts src/renderer/src/hooks/useIpcEvents-close-routing-floating-guest.test.ts src/renderer/src/hooks/useIpcEvents-close-routing-browser-pages.test.ts src/renderer/src/hooks/useIpcEvents-close-routing-session-tabs.test.ts`
- `pnpm run test:e2e tests/e2e/browser-split-shortcuts.spec.ts --workers=1 --grep "closes the guest-owned browser split"`
- `pnpm run check:code-quality:changed`
- `git diff --check`