### PR TITLE
refactor: remove redundant control flow

### DIFF
--- a/src/cli/handlers/automation-handler-flags.ts
+++ b/src/cli/handlers/automation-handler-flags.ts
@@ -165,56 +165,36 @@ export function getScheduleFlag(
   return { rrule, dtstart: Date.now() }
 }
 
-export function getEnabledFlag(flags: Map<string, string | boolean>): boolean | undefined {
-  const enabledFlag = flags.get('enabled')
-  const disabledFlag = flags.get('disabled')
-  if (typeof enabledFlag === 'string') {
-    throw new RuntimeClientError('invalid_argument', '--enabled does not take a value')
+function getAutomationBooleanChoice(
+  flags: Map<string, string | boolean>,
+  trueFlagName: string,
+  falseFlagName: string
+): boolean | undefined {
+  const trueFlag = flags.get(trueFlagName)
+  const falseFlag = flags.get(falseFlagName)
+  if (typeof trueFlag === 'string') {
+    throw new RuntimeClientError('invalid_argument', `--${trueFlagName} does not take a value`)
   }
-  if (typeof disabledFlag === 'string') {
-    throw new RuntimeClientError('invalid_argument', '--disabled does not take a value')
+  if (typeof falseFlag === 'string') {
+    throw new RuntimeClientError('invalid_argument', `--${falseFlagName} does not take a value`)
   }
-  const enabled = enabledFlag === true
-  const disabled = disabledFlag === true
+  const enabled = trueFlag === true
+  const disabled = falseFlag === true
   if (enabled && disabled) {
     throw new RuntimeClientError(
       'invalid_argument',
-      'Use either --enabled or --disabled, not both.'
+      `Use either --${trueFlagName} or --${falseFlagName}, not both.`
     )
   }
-  if (enabled) {
-    return true
-  }
-  if (disabled) {
-    return false
-  }
-  return undefined
+  return enabled ? true : disabled ? false : undefined
+}
+
+export function getEnabledFlag(flags: Map<string, string | boolean>): boolean | undefined {
+  return getAutomationBooleanChoice(flags, 'enabled', 'disabled')
 }
 
 export function getReuseSessionFlag(flags: Map<string, string | boolean>): boolean | undefined {
-  const reuseFlag = flags.get('reuse-session')
-  const freshFlag = flags.get('fresh-session')
-  if (typeof reuseFlag === 'string') {
-    throw new RuntimeClientError('invalid_argument', '--reuse-session does not take a value')
-  }
-  if (typeof freshFlag === 'string') {
-    throw new RuntimeClientError('invalid_argument', '--fresh-session does not take a value')
-  }
-  const reuse = reuseFlag === true
-  const fresh = freshFlag === true
-  if (reuse && fresh) {
-    throw new RuntimeClientError(
-      'invalid_argument',
-      'Use either --reuse-session or --fresh-session, not both.'
-    )
-  }
-  if (reuse) {
-    return true
-  }
-  if (fresh) {
-    return false
-  }
-  return undefined
+  return getAutomationBooleanChoice(flags, 'reuse-session', 'fresh-session')
 }
 
 export function getPrecheckFlag(

--- a/src/cli/handlers/automations.ts
+++ b/src/cli/handlers/automations.ts
@@ -64,27 +64,9 @@ async function resolveDefaultTarget(
   cwd: string,
   client: Parameters<CommandHandler>[0]['client']
 ): Promise<{ repo?: string; workspace?: string; runContext?: WorkspaceRunContext }> {
-  assertWorkspaceTargetFlagsCompatible(flags)
-  const repo = getOptionalStringFlag(flags, 'repo')
-  if (repo && getOptionalStringFlag(flags, 'workspace')) {
-    throw new RuntimeClientError('invalid_argument', 'Use either --repo or --workspace, not both.')
-  }
-  if (hasWorkspaceProjectTarget(flags) && getOptionalStringFlag(flags, 'workspace')) {
-    throw new RuntimeClientError(
-      'invalid_argument',
-      'Use either --workspace or project target flags, not both.'
-    )
-  }
-  const projectTarget = await resolveProjectCreateTarget(flags, client)
-  if (projectTarget) {
-    return {
-      repo: projectTarget.repoSelector,
-      runContext: buildAutomationRunContextFromSetup(projectTarget.setup)
-    }
-  }
-  const workspace = await getOptionalWorktreeSelector(flags, 'workspace', cwd, client)
-  if (repo || workspace) {
-    return { repo, workspace }
+  const target = await getExplicitTarget(flags, cwd, client)
+  if (target.repo || target.workspace || target.runContext) {
+    return target
   }
   if (client.isRemote) {
     return {}

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1318,15 +1318,12 @@ async function deleteBranchAfterWorktreeRemoval(
   try {
     // Why: also drop the now-orphaned branch so delete-worktree leaves none; `-d` (not `-D`) preserves
     // unmerged work, and forceBranchDelete opts into `-D` for failed-creation rollback.
-    const branchDeleteResult = await deleteLocalBranchAfterWorktreeRemoval(
+    await deleteLocalBranchAfterWorktreeRemoval(
       repoPath,
       branchName,
       options.forceBranchDelete === true,
       options
     )
-    if (branchDeleteResult === 'checked-out') {
-      return {}
-    }
     return {}
   } catch (error) {
     if (!options.forceBranchDelete && branchHead) {
@@ -1363,14 +1360,14 @@ async function deleteLocalBranchAfterWorktreeRemoval(
   branchName: string,
   forceBranchDelete: boolean,
   options: GitWorktreeExecOptions = {}
-): Promise<'deleted' | 'checked-out'> {
+): Promise<void> {
   const deleteFlag = forceBranchDelete ? '-D' : '-d'
   try {
     await gitExecFileAsync(
       ['branch', deleteFlag, '--', branchName],
       gitExecOptions(repoPath, options)
     )
-    return 'deleted'
+    return
   } catch (error) {
     if (!isBranchCheckedOutInWorktreeError(error)) {
       throw error
@@ -1382,7 +1379,7 @@ async function deleteLocalBranchAfterWorktreeRemoval(
     await gitExecFileAsync(['worktree', 'prune'], gitExecOptions(repoPath, options))
   } catch (error) {
     console.warn(`[git] Failed to prune worktrees before deleting branch "${branchName}"`, error)
-    return 'checked-out'
+    return
   }
 
   try {
@@ -1390,10 +1387,9 @@ async function deleteLocalBranchAfterWorktreeRemoval(
       ['branch', deleteFlag, '--', branchName],
       gitExecOptions(repoPath, options)
     )
-    return 'deleted'
   } catch (error) {
     if (isBranchCheckedOutInWorktreeError(error)) {
-      return 'checked-out'
+      return
     }
     throw error
   }

--- a/src/preload/doc-preview-link-interception.ts
+++ b/src/preload/doc-preview-link-interception.ts
@@ -130,10 +130,7 @@ export function handleDocPreviewLinkClick(
 }
 
 export function handleDocPreviewLinkAuxClick(event: MouseEvent): void {
-  if (!event.isTrusted || event.button !== 1) {
-    return
-  }
-  if (!findClickedAnchor(event)) {
+  if (!event.isTrusted || event.button !== 1 || !findClickedAnchor(event)) {
     return
   }
   // Why swallowed rather than routed: a middle click asks for a background tab, and honouring it

--- a/src/relay/git-handler-worktree-remove.ts
+++ b/src/relay/git-handler-worktree-remove.ts
@@ -88,11 +88,11 @@ async function deleteRelayBranchAfterWorktreeRemoval(
   repoPath: string,
   branchName: string,
   forceBranchDelete: boolean
-): Promise<'deleted' | 'checked-out'> {
+): Promise<void> {
   const deleteFlag = forceBranchDelete ? '-D' : '-d'
   try {
     await git(['branch', deleteFlag, '--', branchName], repoPath)
-    return 'deleted'
+    return
   } catch (error) {
     if (!isBranchCheckedOutInWorktreeError(error)) {
       throw error
@@ -108,15 +108,14 @@ async function deleteRelayBranchAfterWorktreeRemoval(
       `relay removeWorktree: failed to prune worktrees before deleting branch "${branchName}"`,
       error
     )
-    return 'checked-out'
+    return
   }
 
   try {
     await git(['branch', deleteFlag, '--', branchName], repoPath)
-    return 'deleted'
   } catch (error) {
     if (isBranchCheckedOutInWorktreeError(error)) {
-      return 'checked-out'
+      return
     }
     throw error
   }
@@ -187,15 +186,7 @@ export async function removeWorktreeOp(
   // after the last PR review worktree is gone.
   try {
     // Why: use `-d` (not `-D`) to mirror the local removeWorktree fix.
-    const branchDeleteResult = await deleteRelayBranchAfterWorktreeRemoval(
-      git,
-      repoPath,
-      branchName,
-      forceBranchDelete
-    )
-    if (branchDeleteResult === 'checked-out') {
-      return {}
-    }
+    await deleteRelayBranchAfterWorktreeRemoval(git, repoPath, branchName, forceBranchDelete)
     return {}
   } catch (error) {
     if (!forceBranchDelete && branchHead) {

--- a/src/renderer/src/components/terminal/tab-type-cycle.ts
+++ b/src/renderer/src/components/terminal/tab-type-cycle.ts
@@ -30,9 +30,6 @@ export function getActiveEntityIdForTabType(
   if (activeTabType === 'browser') {
     return activeBrowserTabId
   }
-  if (activeTabType === 'simulator') {
-    return activeTabId
-  }
   return activeTabId
 }
 

--- a/src/renderer/src/lib/activity-thread-display.ts
+++ b/src/renderer/src/lib/activity-thread-display.ts
@@ -147,10 +147,7 @@ function isMislabeledUserPrompt(text: string, entry: Pick<AgentStatusEntry, 'pro
   }
   // Why: some hooks echo the live user prompt into assistant preview fields
   // between turns; never surface that as the agent's latest reply.
-  if (trimmed === entry.prompt.trim()) {
-    return true
-  }
-  return false
+  return trimmed === entry.prompt.trim()
 }
 
 /** Latest agent activity line — tool step while working, assistant reply otherwise. */

--- a/src/renderer/src/lib/run-quick-command-in-new-tab.ts
+++ b/src/renderer/src/lib/run-quick-command-in-new-tab.ts
@@ -71,9 +71,6 @@ export function runQuickCommandInNewTab({
       }
       return { tabId: result.tabId }
     }
-    if (result) {
-      return null
-    }
     return null
   }
 

--- a/src/renderer/src/store/slices/terminal-tab-title-batch.ts
+++ b/src/renderer/src/store/slices/terminal-tab-title-batch.ts
@@ -1,9 +1,9 @@
 import { deriveGeneratedTabTitle } from '../../../../shared/agent-tab-title'
 import { isDecorativeAgentTitleFrameChange } from '../../../../shared/agent-decorative-title-signature'
-import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
 import type { Tab } from '../../../../shared/tab-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { AppState } from '../types'
+import { getTabIdFromPaneKey } from '../terminals/terminal-pty-identities'
 import {
   adoptTerminalTabOwnerMetadataOnlyBuckets,
   getTerminalTabOwners
@@ -46,10 +46,6 @@ function getFallbackTabTitle(tab: TerminalTab): string {
     tab.title ||
     'Terminal 1'
   )
-}
-
-function getTabIdFromPaneKey(paneKey: string): string | null {
-  return parsePaneKey(paneKey)?.tabId ?? parseLegacyNumericPaneKey(paneKey)?.tabId ?? null
 }
 
 function getOwnerStage(

--- a/src/shared/agent-hook-listener/provider-event-routing.ts
+++ b/src/shared/agent-hook-listener/provider-event-routing.ts
@@ -118,13 +118,6 @@ export function hasExplicitUserPrompt(
   if (extractedPrompt.source === 'message') {
     return false
   }
-  if (
-    extractedPrompt.source === 'user_prompt' ||
-    extractedPrompt.source === 'userPrompt' ||
-    extractedPrompt.source === 'user_message'
-  ) {
-    return isNewTurnEvent(source, eventName)
-  }
   return isNewTurnEvent(source, eventName)
 }
 

--- a/src/shared/project-groups.ts
+++ b/src/shared/project-groups.ts
@@ -63,12 +63,7 @@ export function normalizeProjectGroups(value: unknown): ProjectGroup[] {
       id: raw.id,
       name: normalizeProjectGroupName(typeof raw.name === 'string' ? raw.name : ''),
       parentPath: typeof raw.parentPath === 'string' ? raw.parentPath : null,
-      connectionId:
-        typeof raw.connectionId === 'string'
-          ? raw.connectionId
-          : raw.connectionId === null
-            ? null
-            : null,
+      connectionId: typeof raw.connectionId === 'string' ? raw.connectionId : null,
       parentGroupId: typeof raw.parentGroupId === 'string' ? raw.parentGroupId : null,
       createdFrom:
         raw.createdFrom === 'manual' ||


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​118 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​79 |

<!-- /orca-pr-loc -->

## ELI5

Remove branches that did the same thing on both sides, and reuse existing implementations instead of keeping duplicate code.

## What Changed

- Consolidated automation boolean-flag and target resolution.
- Removed unused local and relay branch-cleanup result plumbing without changing Git calls or error handling.
- Reused the canonical pane-key parser.
- Collapsed identical event-routing, normalization, link-interception, activity, quick-command, and tab-selection branches.

Net change: 118 lines removed, 39 added across 11 production files.

## Why

Each edit removes an exact redundancy while preserving evaluation order, return values, side effects, errors, and compatibility behavior. This leaves fewer paths to maintain without changing product behavior.

## Linked Issue

N/A — opportunistic maintenance cleanup; no issue was linked to this work.

## Visual Proof

N/A — there is no UI or interaction behavior change.

## Testing

- [ ] I manually tested these changes locally — not applicable to these non-behavioral control-flow simplifications.
- [x] Automated tests added/updated, or explained why not below — no new assertions were needed; 102 focused existing test executions passed.

Local verification:

- `pnpm tc`
- `pnpm tc:web` after the final renderer/preload pass
- `pnpm run check:code-quality:changed`
- 102 focused Vitest test executions
- pre-commit oxlint, React Doctor lint, and oxfmt
- `git diff --check`

## AI Disclosure

N/A — internal contributor workflow.

## Review

Self-reviewed line by line. Greptile reported 5/5 confidence and safe to merge; CodeRabbit generated no actionable comments.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No protocol, path, keyboard, mobile, remote-wire, Git-version, provider, or SSH execution-boundary behavior changes. Local and relay Git command order and error paths remain unchanged. Main advanced during the scan; a read-only merge-tree audit found no conflicts.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted local gates passed and PR checks are green.