### PR TITLE
chore: enable React correctness lints

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -40,7 +40,7 @@
     "react/no-string-refs": "error",
     "react/no-unescaped-entities": "error",
     "react/require-render-return": "error",
-    "react/error-boundaries": "off",
+    "react/error-boundaries": "error",
     "react/globals": "off",
     "react/immutability": "off",
     "react/incompatible-library": "off",
@@ -48,10 +48,10 @@
     "react/purity": "off",
     "react/refs": "off",
     "react/set-state-in-effect": "off",
-    "react/set-state-in-render": "off",
+    "react/set-state-in-render": "error",
     "react/static-components": "off",
-    "react/use-memo": "off",
-    "react/void-use-memo": "off",
+    "react/use-memo": "error",
+    "react/void-use-memo": "error",
     "react/jsx-curly-brace-presence": [
       "error",
       { "props": "never", "children": "never", "propElementValues": "always" }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -41,7 +41,7 @@
     "react/no-unescaped-entities": "error",
     "react/require-render-return": "error",
     "react/error-boundaries": "error",
-    "react/globals": "off",
+    "react/globals": "error",
     "react/immutability": "off",
     "react/incompatible-library": "off",
     "react/preserve-manual-memoization": "off",
@@ -74,6 +74,7 @@
     "typescript/consistent-type-definitions": ["error", "type"],
     "typescript/consistent-type-imports": "error",
     "typescript/no-explicit-any": ["error", { "ignoreRestArgs": true }],
+    "typescript/no-confusing-non-null-assertion": "error",
     "typescript/no-import-type-side-effects": "error",
     "typescript/no-unnecessary-boolean-literal-compare": "error",
     "typescript/no-unnecessary-template-expression": "error",
@@ -143,6 +144,7 @@
     {
       "files": ["**/*.test.*", "**/*.spec.*", "**/*-benchmark.*"],
       "rules": {
+        "react/globals": "off",
         "quadratic-buffer-concat/no-loop-carried-concat": "off",
         "renderer-scrollbar-style/require-styled-vertical-scrollbar": "off"
       }

--- a/mobile/src/hooks/use-mobile-dictation-source.test.ts
+++ b/mobile/src/hooks/use-mobile-dictation-source.test.ts
@@ -95,7 +95,7 @@ describe('useMobileDictation source invariants', () => {
       /import \{[^}]*createMobileDictationKeepAwakeOwner[^}]*\} from '\.\/mobile-dictation-keep-awake'/
     )
     expect(source).toContain(
-      'const keepAwakeOwner = useMemo(createMobileDictationKeepAwakeOwner, [])'
+      'const keepAwakeOwner = useMemo(() => createMobileDictationKeepAwakeOwner(), [])'
     )
     expect(keepAwakeSource).toContain('activateKeepAwakeAsync')
     expect(keepAwakeSource).toContain('deactivateKeepAwake')

--- a/mobile/src/hooks/use-mobile-dictation.ts
+++ b/mobile/src/hooks/use-mobile-dictation.ts
@@ -26,7 +26,7 @@ export type { UseMobileDictationResult } from './mobile-dictation-session-state'
 
 export function useMobileDictation(options: UseMobileDictationOptions): UseMobileDictationResult {
   const { client, enabled, onTranscript, onError } = options
-  const keepAwakeOwner = useMemo(createMobileDictationKeepAwakeOwner, [])
+  const keepAwakeOwner = useMemo(() => createMobileDictationKeepAwakeOwner(), [])
   const [status, setStatus] = useState<DictationStatus>('idle')
   const [error, setError] = useState<string | null>(null)
   const activeIdRef = useRef<string | null>(null)

--- a/src/renderer/src/components/mobile/paired-mobile-devices.ts
+++ b/src/renderer/src/components/mobile/paired-mobile-devices.ts
@@ -16,6 +16,10 @@ type PairedMobileDevicesSnapshot = {
   error: boolean
 }
 
+type RefreshPairedMobileDevicesOptions = {
+  force?: boolean
+}
+
 const EMPTY_SNAPSHOT: PairedMobileDevicesSnapshot = {
   devices: [],
   loaded: false,
@@ -80,9 +84,7 @@ export function replacePairedMobileDevices(devices: readonly PairedMobileDevice[
 
 export function refreshPairedMobileDevices({
   force = false
-}: {
-  force?: boolean
-} = {}): Promise<readonly PairedMobileDevice[]> {
+}: RefreshPairedMobileDevicesOptions = {}): Promise<readonly PairedMobileDevice[]> {
   if (activeRequest && !force) {
     return activeRequest.promise
   }
@@ -173,7 +175,10 @@ export function usePairedMobileDevices({
   refresh: typeof refreshPairedMobileDevices
 } {
   const currentSnapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
-  const refresh = useCallback(refreshPairedMobileDevices, [])
+  const refresh = useCallback(
+    (options?: RefreshPairedMobileDevicesOptions) => refreshPairedMobileDevices(options),
+    []
+  )
 
   useEffect(() => {
     if (!enabled || !refreshOnMount || currentSnapshot.loaded || currentSnapshot.loading) {


### PR DESCRIPTION
## Summary

- enable react/error-boundaries, react/set-state-in-render, react/use-memo, and react/void-use-memo
- make the two existing memo callbacks explicit without changing their signatures or lifecycle
- update the mobile dictation source invariant for the lint-compliant callback form

## Validation

- corepack pnpm lint
- corepack pnpm tc
- corepack pnpm run check:code-quality:changed
- corepack pnpm exec oxfmt --check .
- corepack pnpm test src/renderer/src/components/mobile/paired-mobile-devices.test.ts
- cd mobile && pnpm lint && pnpm typecheck && pnpm format:check
- cd mobile && pnpm test src/hooks/use-mobile-dictation-source.test.ts