### PR TITLE
perf(terminal): index accepted input pane ownership

### DIFF
--- a/src/renderer/src/runtime/runtime-terminal-inspection.test.ts
+++ b/src/renderer/src/runtime/runtime-terminal-inspection.test.ts
@@ -209,6 +209,53 @@ describe('runtime terminal owner routing', () => {
     })
   })
 
+  it('attributes a delayed runtime acknowledgement to the current layout owner', async () => {
+    const pendingSend = Promise.withResolvers<{
+      ok: true
+      result: { send: { handle: string; accepted: true; bytesWritten: number } }
+      _meta: { runtimeId: string }
+    }>()
+    runtimeCall.mockReturnValue(pendingSend.promise)
+    useAppStore.setState({
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'remote:env-1@@terminal-1' }
+        }
+      }
+    })
+    recordRuntimeTerminalInputForPtyId('remote:env-1@@terminal-1', 123)
+    useAppStore.setState({ lastTerminalInputAtByPaneKey: {} })
+
+    expect(
+      sendRuntimePtyInput({ activeRuntimeEnvironmentId: 'env-2' }, 'remote:env-1@@terminal-1', 'x')
+    ).toBe(true)
+    const nextLeafId = '22222222-2222-4222-8222-222222222222'
+    useAppStore.setState({
+      terminalLayoutsByTabId: {
+        'tab-2': {
+          root: { type: 'leaf', leafId: nextLeafId },
+          activeLeafId: nextLeafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [nextLeafId]: 'remote:env-1@@terminal-1' }
+        }
+      }
+    })
+    pendingSend.resolve({
+      ok: true,
+      result: { send: { handle: 'terminal-1', accepted: true, bytesWritten: 1 } },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+
+    await vi.waitFor(() => {
+      expect(useAppStore.getState().lastTerminalInputAtByPaneKey).toEqual({
+        [`tab-2:${nextLeafId}`]: expect.any(Number)
+      })
+    })
+  })
+
   it('does not record declined fire-and-forget runtime input', async () => {
     runtimeCall.mockResolvedValue({
       ok: true,
@@ -477,6 +524,163 @@ describe('runtime terminal owner routing', () => {
     recordRuntimeTerminalInputForPtyId('local-pty', 123)
 
     expect(useAppStore.getState().lastTerminalInputAtByPaneKey[PANE_KEY]).toBe(123)
+  })
+
+  it('indexes a stable layout identity once across repeated terminal input', () => {
+    const layoutCount = 500
+    let layoutEnumerations = 0
+    let leafEnumerations = 0
+    const layouts = Object.fromEntries(
+      Array.from({ length: layoutCount }, (_, index) => {
+        const leafId = `00000000-0000-4000-8000-${index.toString(16).padStart(12, '0')}`
+        const ptyIdsByLeafId = new Proxy(
+          { [leafId]: `pty-${index}` },
+          {
+            ownKeys: (target) => {
+              leafEnumerations += 1
+              return Reflect.ownKeys(target)
+            }
+          }
+        )
+        return [
+          `tab-${index}`,
+          {
+            root: { type: 'leaf' as const, leafId },
+            activeLeafId: leafId,
+            expandedLeafId: null,
+            ptyIdsByLeafId
+          }
+        ]
+      })
+    )
+    const observedLayouts = new Proxy(layouts, {
+      ownKeys: (target) => {
+        layoutEnumerations += 1
+        return Reflect.ownKeys(target)
+      }
+    })
+    useAppStore.setState({ terminalLayoutsByTabId: observedLayouts })
+
+    recordRuntimeTerminalInputForPtyId('pty-0', 10_000)
+    expect({ layoutEnumerations, leafEnumerations }).toEqual({
+      layoutEnumerations: 1,
+      leafEnumerations: 1
+    })
+    layoutEnumerations = 0
+    leafEnumerations = 0
+
+    for (let timestamp = 1; timestamp <= 100; timestamp += 1) {
+      recordRuntimeTerminalInputForPtyId(`pty-${layoutCount - 1}`, timestamp * 10_000)
+    }
+
+    expect({ layoutEnumerations, leafEnumerations }).toEqual({
+      layoutEnumerations: 1,
+      leafEnumerations: layoutCount
+    })
+    expect(
+      useAppStore.getState().lastTerminalInputAtByPaneKey[
+        `tab-${layoutCount - 1}:00000000-0000-4000-8000-${(layoutCount - 1)
+          .toString(16)
+          .padStart(12, '0')}`
+      ]
+    ).toBe(1_000_000)
+  })
+
+  it('reindexes a PTY when the immutable layout identity changes', () => {
+    const nextLeafId = '22222222-2222-4222-8222-222222222222'
+    useAppStore.setState({
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'rebound-pty' }
+        }
+      }
+    })
+    recordRuntimeTerminalInputForPtyId('rebound-pty', 123)
+
+    useAppStore.setState({
+      terminalLayoutsByTabId: {
+        'tab-2': {
+          root: { type: 'leaf', leafId: nextLeafId },
+          activeLeafId: nextLeafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [nextLeafId]: 'rebound-pty' }
+        }
+      }
+    })
+    recordRuntimeTerminalInputForPtyId('rebound-pty', 1_000)
+
+    expect(useAppStore.getState().lastTerminalInputAtByPaneKey).toEqual({
+      [PANE_KEY]: 123,
+      [`tab-2:${nextLeafId}`]: 1_000
+    })
+  })
+
+  it('reindexes stale owners without caching misses within the same layout identity', () => {
+    const nextLeafId = '22222222-2222-4222-8222-222222222222'
+    useAppStore.setState({
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'rebound-pty' }
+        }
+      }
+    })
+    const layouts = useAppStore.getState().terminalLayoutsByTabId
+    recordRuntimeTerminalInputForPtyId('rebound-pty', 123)
+    recordRuntimeTerminalInputForPtyId('late-pty', 456)
+
+    const firstLayout = layouts['tab-1']
+    expect(firstLayout).toBeDefined()
+    if (!firstLayout) {
+      return
+    }
+    firstLayout.ptyIdsByLeafId = Object.create({ [LEAF_ID]: 'rebound-pty' })
+    Object.setPrototypeOf(layouts, { 'tab-1': firstLayout })
+    delete layouts['tab-1']
+    layouts['tab-2'] = {
+      root: { type: 'leaf', leafId: nextLeafId },
+      activeLeafId: nextLeafId,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [nextLeafId]: 'rebound-pty', [LEAF_ID]: 'late-pty' }
+    }
+    recordRuntimeTerminalInputForPtyId('rebound-pty', 1_000)
+    recordRuntimeTerminalInputForPtyId('late-pty', 2_000)
+
+    expect(useAppStore.getState().terminalLayoutsByTabId).toBe(layouts)
+    expect(useAppStore.getState().lastTerminalInputAtByPaneKey).toEqual({
+      [PANE_KEY]: 123,
+      [`tab-2:${nextLeafId}`]: 1_000,
+      [`tab-2:${LEAF_ID}`]: 2_000
+    })
+  })
+
+  it('preserves a malformed first match instead of routing a duplicate PTY', () => {
+    const nextLeafId = '22222222-2222-4222-8222-222222222222'
+    useAppStore.setState({
+      terminalLayoutsByTabId: {
+        'legacy:tab': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'duplicate-pty' }
+        },
+        'tab-2': {
+          root: { type: 'leaf', leafId: nextLeafId },
+          activeLeafId: nextLeafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [nextLeafId]: 'duplicate-pty' }
+        }
+      }
+    })
+
+    recordRuntimeTerminalInputForPtyId('duplicate-pty', 123)
+
+    expect(useAppStore.getState().lastTerminalInputAtByPaneKey).toEqual({})
   })
 
   it('reports success after fallback fire-and-forget writes when local acceptance cannot be verified', async () => {

--- a/src/renderer/src/runtime/runtime-terminal-inspection.ts
+++ b/src/renderer/src/runtime/runtime-terminal-inspection.ts
@@ -1,6 +1,6 @@
 import type { GlobalSettings } from '../../../shared/global-settings-types'
 import type { RuntimeTerminalSend } from '../../../shared/runtime-types'
-import { makePaneKey } from '../../../shared/stable-pane-id'
+import { makePaneKey, type PaneKey } from '../../../shared/stable-pane-id'
 import { isTerminalInputTooLargeWithDeferredMeasurement } from '../../../shared/terminal-input'
 import { useAppStore } from '../store'
 import { RuntimeRpcCallError, callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
@@ -18,6 +18,56 @@ export type RuntimeTerminalProcessInspection = {
 
 const REMOTE_PTY_ID_PREFIX = 'remote:'
 const DESKTOP_RUNTIME_CLIENT = { id: 'orca-desktop', type: 'desktop' } as const
+type TerminalLayoutsByTabId = ReturnType<typeof useAppStore.getState>['terminalLayoutsByTabId']
+type TerminalPaneOwner = {
+  tabId: string
+  leafId: string
+  paneKey: PaneKey
+}
+
+const paneOwnersByPtyIdByLayoutIdentity = new WeakMap<
+  TerminalLayoutsByTabId,
+  Map<string, TerminalPaneOwner>
+>()
+
+function resolvePaneKeyForPtyId(layouts: TerminalLayoutsByTabId, ptyId: string): PaneKey | null {
+  let paneOwnersByPtyId = paneOwnersByPtyIdByLayoutIdentity.get(layouts)
+  if (!paneOwnersByPtyId) {
+    paneOwnersByPtyId = new Map<string, TerminalPaneOwner>()
+    paneOwnersByPtyIdByLayoutIdentity.set(layouts, paneOwnersByPtyId)
+  }
+  const cachedOwner = paneOwnersByPtyId.get(ptyId)
+  if (cachedOwner) {
+    const layout = Object.prototype.propertyIsEnumerable.call(layouts, cachedOwner.tabId)
+      ? layouts[cachedOwner.tabId]
+      : undefined
+    const ptyIdsByLeafId = layout?.ptyIdsByLeafId
+    if (
+      ptyIdsByLeafId &&
+      Object.prototype.propertyIsEnumerable.call(ptyIdsByLeafId, cachedOwner.leafId) &&
+      ptyIdsByLeafId[cachedOwner.leafId] === ptyId
+    ) {
+      return cachedOwner.paneKey
+    }
+    paneOwnersByPtyId.delete(ptyId)
+  }
+  for (const [tabId, layout] of Object.entries(layouts)) {
+    for (const [leafId, leafPtyId] of Object.entries(layout?.ptyIdsByLeafId ?? {})) {
+      if (leafPtyId !== ptyId) {
+        continue
+      }
+      try {
+        const paneKey = makePaneKey(tabId, leafId)
+        paneOwnersByPtyId.set(ptyId, { tabId, leafId, paneKey })
+        return paneKey
+      } catch {
+        // Preserve first-match behavior for malformed legacy layout rows.
+        return null
+      }
+    }
+  }
+  return null
+}
 
 function isRuntimePtyInputTooLarge(data: string): boolean | Promise<boolean> {
   return isTerminalInputTooLargeWithDeferredMeasurement(data)
@@ -49,21 +99,17 @@ function isTerminalGoneError(error: unknown): boolean {
 
 export function recordRuntimeTerminalInputForPtyId(ptyId: string, timestamp = Date.now()): void {
   const state = useAppStore.getState()
-  for (const [tabId, layout] of Object.entries(state.terminalLayoutsByTabId)) {
-    for (const [leafId, leafPtyId] of Object.entries(layout?.ptyIdsByLeafId ?? {})) {
-      if (leafPtyId !== ptyId) {
-        continue
-      }
-      try {
-        // Why: paired/runtime sends can bypass xterm.onData, so hibernation
-        // needs the same user-input marker from the PTY-id route.
-        state.recordTerminalInput(makePaneKey(tabId, leafId), timestamp)
-      } catch {
-        // Ignore malformed legacy layout data; the planner will stay
-        // conservative when a live PTY cannot be matched to an eligible pane.
-      }
-      return
-    }
+  const paneKey = resolvePaneKeyForPtyId(state.terminalLayoutsByTabId, ptyId)
+  if (!paneKey) {
+    return
+  }
+  try {
+    // Why: paired/runtime sends can bypass xterm.onData, so hibernation
+    // needs the same user-input marker from the PTY-id route.
+    state.recordTerminalInput(paneKey, timestamp)
+  } catch {
+    // Ignore malformed legacy layout data; the planner will stay
+    // conservative when a live PTY cannot be matched to an eligible pane.
   }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​204 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​204 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 |

<!-- /orca-pr-loc -->

## ELI5

Every accepted keystroke or paste chunk marks its terminal pane as recently used so hibernation does not park an active terminal. That marker rediscovered the same pane by walking every saved terminal layout on every input.

This keeps a weak, layout-identity-scoped PTY-to-pane lookup. A repeated input validates the cached tab/leaf owner in constant time; a replaced layout gets a fresh lookup naturally, an in-place rebind evicts and rescans, and misses are not cached.

## Measurement proof

Deterministic work-count oracle: 500 one-leaf layouts, target PTY in the last layout, 100 accepted input markers.

| Work | Before | After |
| --- | ---: | ---: |
| Outer layout enumerations | 100 | 1 |
| Leaf-map enumerations | 50,000 | 500 |
| Final activity marker | 1,000,000 | 1,000,000 |

That is 100x less enumeration work for the repeated-input scenario. The production large-draft path can validate and send an allowed 16 MiB paste in more than 1,000 chunks, so this removes accumulated-layout work from a real input path rather than a synthetic background task.

## Behavior / reliability sign-off

Invariant: accepted input is still recorded against the current pane owning that PTY (`terminal-input.activity-ownership`), including when a remote acknowledgement arrives after ownership moves.

- No input cap, batching, delay, dropped input, routing change, IPC/RPC change, persistence change, or wire-format change.
- Send acceptance remains authoritative; rejected input still records nothing.
- Layout replacement, same-object rebind, uncached misses, inherited properties, malformed first matches, and delayed remote acknowledgements have deterministic coverage.
- Cache lifetime follows the layout object through a `WeakMap`; only successful PTY owners are retained.
- The existing `terminal-session.layout-pty-ownership` unit gate passed. The lookup is provider/platform-neutral renderer code: local/daemon behavior is visibly exercised; remote-runtime ownership timing is unit-covered; SSH, WSL, Linux, and Windows behavior is unaffected because provider routing and wire data are untouched.

Residual gap: production layout writers replace the outer layout record and normalize duplicate ownership. An arbitrary external mutation that inserts an earlier duplicate while retaining the cached owner cannot be observed in constant time; that shape is outside the store mutation contract. Owner removal/rebind within the same identity still evicts safely.

## Visible proof

The intended `Orca: nwparker/perf-terminal-input-pane-index` dev instance created a real terminal through the UI. With 500 historical layouts seeded, the real `sendRuntimePtyInputVerified` path accepted 25/25 characters, recorded the correct pane activity marker, and visibly printed `ORCA_INPUT_CACHE_OK`.

![terminal-input-cache-ok-2.png](https://github.com/user-attachments/assets/184c5698-9538-4f77-a1cd-90ef2316c068)

The isolated Electron profile fell back to a local PTY after its daemon socket failed to start. Rendered SSH/remote-runtime behavior remains a stated manual gap; deterministic routing and delayed-acknowledgement tests cover those shared semantics.

## Validation

- `pnpm test` across 13 terminal-input and layout-ownership files: 156 passed
- Focused runtime inspection: 30 passed
- `pnpm tc:web`
- `pnpm run check:code-quality:changed`: 0 findings
- Electron/CDP: intended worktree identity, real terminal UI, 25/25 accepted characters, visible shell output, correct backing activity marker

## Merge risk

Low. This is renderer-only, adds no timers/listeners/processes/network calls, and retains no layout after that layout object becomes unreachable. A cold PTY lookup still performs the existing ordered scan; only verified repeat ownership skips it.
