### PR TITLE
Raise rich Markdown size limit to 600 KB

### DIFF
--- a/src/renderer/src/components/editor/markdown-rich-size-limit.test.ts
+++ b/src/renderer/src/components/editor/markdown-rich-size-limit.test.ts
@@ -3,6 +3,10 @@ import { RICH_MARKDOWN_MAX_SIZE_BYTES } from '../../../../shared/constants'
 import { exceedsMarkdownRichModeSizeLimit } from './markdown-rich-size-limit'
 
 describe('exceedsMarkdownRichModeSizeLimit', () => {
+  it('uses a 600 KB default rich-mode ceiling', () => {
+    expect(RICH_MARKDOWN_MAX_SIZE_BYTES).toBe(600 * 1024)
+  })
+
   it('allows markdown at the rich-mode byte limit', () => {
     expect(exceedsMarkdownRichModeSizeLimit('a'.repeat(RICH_MARKDOWN_MAX_SIZE_BYTES))).toBe(false)
   })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -83,16 +83,13 @@ export const getDefaultTerminalRightClickToPaste = (
   platform = typeof process !== 'undefined' ? process.platform : ''
 ): boolean => platform === 'win32'
 
-/** Why: ProseMirror renders the whole document — no virtualization — so opening
- *  one blocks the main thread for as long as it takes to build the DOM. Measured
- *  in a packaged build (M-series) on a doc with a code block every ~570 bytes,
- *  blocking mount / median keystroke: 300 KB 1.7 s / 59 ms · 600 KB 4.2 s / 201 ms
- *  · 900 KB 8.8 s / 431 ms. The same 300 KB as pure prose is 0.8 s / 16 ms, so
- *  node-view count drives the cost far more than byte size — but bytes are the
- *  only thing cheap enough to test before parsing. The blocking mount is what
- *  pins this ceiling; past it, fall back to source mode (Monaco) with a per-file
- *  "Open anyway" escape hatch. Real headroom needs #7056. */
-export const RICH_MARKDOWN_MAX_SIZE_BYTES = 300 * 1024
+/** Why: ProseMirror renders the whole document without virtualization. After the
+ *  parser/highlighter work in #17134/#17147/#17158, M-series Electron measurements
+ *  on distinct code blocks every ~600 bytes put visible mount / longest task at
+ *  300 KB 0.70 / 0.66 s · 450 KB 1.09 / 1.02 s · 600 KB 1.49 / 1.41 s, with
+ *  600 KB typing at 38 ms median / 39 ms p95. Bytes remain the only cheap
+ *  pre-parse guard; larger files use source mode with an "Open anyway" escape hatch. */
+export const RICH_MARKDOWN_MAX_SIZE_BYTES = 600 * 1024
 
 export const DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS = 1000
 export const MIN_EDITOR_AUTO_SAVE_DELAY_MS = 250


### PR DESCRIPTION
## ELI5

Markdown files up to 600 KB now open directly in the rich editor. Larger files still fall back to the source editor and keep the existing per-file “Open anyway” escape hatch.

## What Changed

- Raised `RICH_MARKDOWN_MAX_SIZE_BYTES` from 300 KB to 600 KB.
- Added a regression assertion for the 600 KB product ceiling.
- Updated the performance rationale beside the constant with current Electron measurements.

## Why

The parser and code-block rendering improvements in #17134, #17147, and #17158 materially reduced the cost of large Markdown documents. On an M-series Mac, a 600 KB stress document with 1,024 distinct code blocks now mounts visibly in 1.49 s with a 1.41 s longest task; typing measured 38 ms median / 39 ms p95. That is within the previous accepted 300 KB mount budget (~1.7 s), so doubling the conservative byte ceiling is now supported by measured headroom.

## Linked Issue

Refs #7056

## Visual Proof

The editor UI is unchanged; these screenshots show the rendered behavior on either side of the new threshold.

**613,677 bytes — opens directly in rich mode**

![613,677-byte Markdown file open in rich mode](https://github.com/user-attachments/assets/5a1fefc4-3da8-44a3-9423-c701a99db524)

**614,401 bytes — source fallback with the 600 KB warning and “Open anyway”**

![614,401-byte Markdown file showing the source fallback](https://github.com/user-attachments/assets/9afb3179-8c4b-4d22-8a05-172e2576ba94)

Clicking “Open anyway” was also exercised and rendered the complete rich document (1,024 code blocks).

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated on macOS in the actual Electron renderer:

- 613,677 bytes opens directly in rich mode.
- 614,401 bytes shows source fallback, the 600 KB message, and “Open anyway.”
- “Open anyway” renders the complete rich document.
- 600 KB stress-document typing: 38 ms median / 39 ms p95 across 20 edits.
- `corepack pnpm test src/renderer/src/components/editor/markdown-rich-size-limit.test.ts src/renderer/src/store/slices/editor-rich-markdown-size-override.test.ts`
- `corepack pnpm tc:web`
- `corepack pnpm run check:code-quality:changed`
- `corepack pnpm exec oxfmt --check src/shared/constants.ts src/renderer/src/components/editor/markdown-rich-size-limit.test.ts`
- `git diff --check`

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

This changes only a shared byte constant and its regression coverage. It adds no platform-, filesystem-, provider-, SSH-, folder-workspace-, or wire-specific behavior. The existing source fallback remains in place above 600 KB.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after behavioral screenshots attached for the new threshold
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (N/A beyond the shared constant)
- [x] Focused tests, web typecheck, formatting, and changed-code quality pass locally; CI will cover the full matrix
