### PR TITLE
perf(worktree): prepare checkouts while the composer is open

### DIFF
--- a/src/main/git/worktree-add.ts
+++ b/src/main/git/worktree-add.ts
@@ -19,7 +19,46 @@ import type {
 import { gitExecOptions, resolveWorktreeAddTimeoutMs } from './worktree-operation-options'
 import { bumpWorktreeScanGeneration } from './worktree-scan-cache'
 
-async function persistWorktreeCreationBase(
+export type WorktreeAddBaseContext = AddWorktreeResult & {
+  effectiveBase: string
+}
+
+export async function resolveWorktreeAddBaseContext(
+  repoPath: string,
+  baseBranch: string,
+  refreshLocalBaseRef: boolean,
+  options: AddWorktreeOptions
+): Promise<WorktreeAddBaseContext> {
+  const effectiveBase = await resolveWorktreeAddBaseRef(baseBranch, (qualifiedRef) =>
+    hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
+  )
+  const localBaseRefRefresh = refreshLocalBaseRef
+    ? await refreshLocalBaseRefForWorktreeCreate(
+        repoPath,
+        baseBranch,
+        effectiveBase,
+        options.remoteTrackingBase,
+        options
+      )
+    : undefined
+  const localBaseRefUpdateSuggestion =
+    !refreshLocalBaseRef && options.suggestLocalBaseRefUpdate
+      ? await getLocalBaseRefUpdateSuggestionForWorktreeCreate(
+          repoPath,
+          baseBranch,
+          effectiveBase,
+          options.remoteTrackingBase,
+          options
+        )
+      : undefined
+  return {
+    effectiveBase,
+    ...(localBaseRefRefresh ? { localBaseRefRefresh } : {}),
+    ...(localBaseRefUpdateSuggestion ? { localBaseRefUpdateSuggestion } : {})
+  }
+}
+
+export async function persistWorktreeCreationBase(
   worktreePath: string,
   branch: string,
   effectiveBase: string,
@@ -43,6 +82,33 @@ async function persistWorktreeCreationBase(
         unsetError
       )
     }
+  }
+}
+
+export async function configurePushAutoSetupRemote(
+  worktreePath: string,
+  options: GitWorktreeExecOptions
+): Promise<void> {
+  try {
+    let alreadySet = false
+    try {
+      await gitExecFileAsync(['config', '--get', 'push.autoSetupRemote'], {
+        ...gitExecOptions(worktreePath, options)
+      })
+      alreadySet = true
+    } catch (readError) {
+      const code = (readError as { code?: unknown })?.code
+      if (code !== 1) {
+        throw readError
+      }
+    }
+    if (!alreadySet) {
+      await gitExecFileAsync(['config', '--local', 'push.autoSetupRemote', 'true'], {
+        ...gitExecOptions(worktreePath, options)
+      })
+    }
+  } catch (error) {
+    console.warn(`addWorktree: failed to set push.autoSetupRemote for ${worktreePath}`, error)
   }
 }
 
@@ -120,27 +186,15 @@ async function performAddWorktree(
     // Why: --no-track avoids inheriting the base's upstream so `git status` won't misreport "behind by N" pre-publish; first push sets it (see push.autoSetupRemote below).
     args.push('--no-track', '-b', branch, worktreePath)
     if (baseBranch) {
-      effectiveBase = await resolveWorktreeAddBaseRef(baseBranch, (qualifiedRef) =>
-        hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
+      const baseContext = await resolveWorktreeAddBaseContext(
+        repoPath,
+        baseBranch,
+        refreshLocalBaseRef,
+        options
       )
-      // Why: resolve the creation base first to distinguish remote-tracking refs from slash-containing local branches (mutation gated behind the explicit setting).
-      if (refreshLocalBaseRef) {
-        localBaseRefRefresh = await refreshLocalBaseRefForWorktreeCreate(
-          repoPath,
-          baseBranch,
-          effectiveBase,
-          options.remoteTrackingBase,
-          options
-        )
-      } else if (options.suggestLocalBaseRefUpdate) {
-        localBaseRefUpdateSuggestion = await getLocalBaseRefUpdateSuggestionForWorktreeCreate(
-          repoPath,
-          baseBranch,
-          effectiveBase,
-          options.remoteTrackingBase,
-          options
-        )
-      }
+      effectiveBase = baseContext.effectiveBase
+      localBaseRefRefresh = baseContext.localBaseRefRefresh
+      localBaseRefUpdateSuggestion = baseContext.localBaseRefUpdateSuggestion
       args.push(effectiveBase)
     }
   }
@@ -163,29 +217,7 @@ async function performAddWorktree(
   // `git push` create+set origin/<branch> (git >=2.37; older clients ignore it). `--local` on a
   // linked worktree writes the shared common-dir config (whole repo) — intentional and idempotent,
   // so it's warn-only and not rolled back on failure.
-  try {
-    // Why: `--get` (not `--local --get`) so a value at any scope counts as "user already chose" and isn't overwritten.
-    let alreadySet = false
-    try {
-      await gitExecFileAsync(['config', '--get', 'push.autoSetupRemote'], {
-        ...gitExecOptions(worktreePath, options)
-      })
-      alreadySet = true
-    } catch (readError) {
-      // Why: `git config --get` exits 1 only when unset at every scope; any other code is a real read failure — rethrow rather than overwrite the user's value.
-      const code = (readError as { code?: unknown })?.code
-      if (code !== 1) {
-        throw readError
-      }
-    }
-    if (!alreadySet) {
-      await gitExecFileAsync(['config', '--local', 'push.autoSetupRemote', 'true'], {
-        ...gitExecOptions(worktreePath, options)
-      })
-    }
-  } catch (error) {
-    console.warn(`addWorktree: failed to set push.autoSetupRemote for ${worktreePath}`, error)
-  }
+  await configurePushAutoSetupRemote(worktreePath, options)
   return {
     ...(localBaseRefRefresh ? { localBaseRefRefresh } : {}),
     ...(localBaseRefUpdateSuggestion ? { localBaseRefUpdateSuggestion } : {})

--- a/src/main/git/worktree-add.ts
+++ b/src/main/git/worktree-add.ts
@@ -90,6 +90,7 @@ export async function configurePushAutoSetupRemote(
   options: GitWorktreeExecOptions
 ): Promise<void> {
   try {
+    // Why: `--get` (not `--local --get`) treats a value at any scope as an explicit user choice.
     let alreadySet = false
     try {
       await gitExecFileAsync(['config', '--get', 'push.autoSetupRemote'], {
@@ -97,6 +98,7 @@ export async function configurePushAutoSetupRemote(
       })
       alreadySet = true
     } catch (readError) {
+      // Why: exit 1 means unset; other codes are real read failures and must not overwrite config.
       const code = (readError as { code?: unknown })?.code
       if (code !== 1) {
         throw readError

--- a/src/main/git/worktree-create-preparation-real-git.test.ts
+++ b/src/main/git/worktree-create-preparation-real-git.test.ts
@@ -14,6 +14,7 @@ import {
   finalizePreparedWorktree,
   prepareWorktreeCreateCheckout
 } from './worktree-create-preparation'
+import { areWorktreePathsEqual } from './worktree-path-comparison'
 
 const tempRoots: string[] = []
 
@@ -98,13 +99,17 @@ describe('prepared worktree creation with real Git', () => {
 
     expect(git(finalPath, ['rev-parse', 'HEAD'])).toBe(latestHead)
     expect(git(finalPath, ['branch', '--show-current'])).toBe('feature/prepared')
-    expect(await readFile(join(finalPath, 'version.txt'), 'utf8')).toBe('two\n')
+    expect((await readFile(join(finalPath, 'version.txt'), 'utf8')).replaceAll('\r\n', '\n')).toBe(
+      'two\n'
+    )
     expect(git(finalPath, ['config', '--get', 'branch.feature/prepared.base'])).toBe(
       'refs/heads/main'
     )
     expect(git(finalPath, ['config', '--get', 'push.autoSetupRemote'])).toBe('true')
-    expect((await listWorktrees(repoPath)).map((worktree) => worktree.path)).toContain(
-      await realpath(finalPath)
-    )
+    const listedWorktrees = await listWorktrees(repoPath)
+    const resolvedFinalPath = await realpath(finalPath)
+    expect(
+      listedWorktrees.some((worktree) => areWorktreePathsEqual(worktree.path, resolvedFinalPath))
+    ).toBe(true)
   })
 })

--- a/src/main/git/worktree-create-preparation-real-git.test.ts
+++ b/src/main/git/worktree-create-preparation-real-git.test.ts
@@ -95,7 +95,14 @@ describe('prepared worktree creation with real Git', () => {
     git(repoPath, ['commit', '--quiet', '-m', 'advance base'])
     const latestHead = git(repoPath, ['rev-parse', 'HEAD'])
 
-    await finalizePreparedWorktree(repoPath, preparedPath, finalPath, 'feature/prepared', 'main')
+    await finalizePreparedWorktree(
+      repoPath,
+      preparedPath,
+      finalPath,
+      'feature/prepared',
+      'main',
+      createWorktreePreparationLockReason('real-git-test')
+    )
 
     expect(git(finalPath, ['rev-parse', 'HEAD'])).toBe(latestHead)
     expect(git(finalPath, ['branch', '--show-current'])).toBe('feature/prepared')
@@ -111,5 +118,9 @@ describe('prepared worktree creation with real Git', () => {
     expect(
       listedWorktrees.some((worktree) => areWorktreePathsEqual(worktree.path, resolvedFinalPath))
     ).toBe(true)
+    expect(
+      listedWorktrees.find((worktree) => areWorktreePathsEqual(worktree.path, resolvedFinalPath))
+        ?.locked
+    ).not.toBe(true)
   })
 })

--- a/src/main/git/worktree-create-preparation-real-git.test.ts
+++ b/src/main/git/worktree-create-preparation-real-git.test.ts
@@ -101,7 +101,7 @@ describe('prepared worktree creation with real Git', () => {
       finalPath,
       'feature/prepared',
       'main',
-      createWorktreePreparationLockReason('real-git-test')
+      false
     )
 
     expect(git(finalPath, ['rev-parse', 'HEAD'])).toBe(latestHead)

--- a/src/main/git/worktree-create-preparation-real-git.test.ts
+++ b/src/main/git/worktree-create-preparation-real-git.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../shared/worktree/create-preparation'
 import { listWorktrees } from './worktree'
 import {
+  discardPreparedWorktree,
   finalizePreparedWorktree,
   prepareWorktreeCreateCheckout
 } from './worktree-create-preparation'
@@ -43,6 +44,28 @@ afterEach(async () => {
 })
 
 describe('prepared worktree creation with real Git', () => {
+  it('cleans up when the create signal is canceled', async () => {
+    const { repoPath, root } = await createRepo()
+    const preparationRoot = join(root, WORKTREE_CREATE_PREPARATION_DIRECTORY)
+    const preparedPath = join(preparationRoot, `${process.pid}-canceled`)
+    await mkdir(preparationRoot, { recursive: true })
+
+    await prepareWorktreeCreateCheckout(
+      repoPath,
+      preparedPath,
+      'main',
+      createWorktreePreparationLockReason('canceled-test')
+    )
+
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      discardPreparedWorktree(repoPath, preparedPath, { signal: controller.signal })
+    ).resolves.toBeUndefined()
+
+    expect(await listWorktrees(repoPath, { includeCreatePreparations: true })).toHaveLength(1)
+  })
+
   it('hides the preparation, retargets an advanced base, and attaches the final branch', async () => {
     const { repoPath, root } = await createRepo()
     const preparationRoot = join(root, WORKTREE_CREATE_PREPARATION_DIRECTORY)

--- a/src/main/git/worktree-create-preparation-real-git.test.ts
+++ b/src/main/git/worktree-create-preparation-real-git.test.ts
@@ -87,7 +87,8 @@ describe('prepared worktree creation with real Git', () => {
     expect(visibleBeforeSubmit).toHaveLength(1)
     expect(allBeforeSubmit).toHaveLength(2)
     expect(allBeforeSubmit.find(isWorktreeCreatePreparation)).toMatchObject({
-      locked: true
+      locked: true,
+      lockReason: expect.stringContaining('orca-create-preparation:v1:')
     })
 
     await writeFile(join(repoPath, 'version.txt'), 'two\n')

--- a/src/main/git/worktree-create-preparation-real-git.test.ts
+++ b/src/main/git/worktree-create-preparation-real-git.test.ts
@@ -1,0 +1,86 @@
+import { execFileSync } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  createWorktreePreparationLockReason,
+  isWorktreeCreatePreparation,
+  WORKTREE_CREATE_PREPARATION_DIRECTORY
+} from '../../shared/worktree/create-preparation'
+import { listWorktrees } from './worktree'
+import {
+  finalizePreparedWorktree,
+  prepareWorktreeCreateCheckout
+} from './worktree-create-preparation'
+
+const tempRoots: string[] = []
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe']
+  }).trim()
+}
+
+async function createRepo(): Promise<{ repoPath: string; root: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-prepared-worktree-'))
+  tempRoots.push(root)
+  const repoPath = join(root, 'repo')
+  execFileSync('git', ['init', '--quiet', repoPath])
+  git(repoPath, ['symbolic-ref', 'HEAD', 'refs/heads/main'])
+  git(repoPath, ['config', 'user.email', 'test@example.com'])
+  git(repoPath, ['config', 'user.name', 'Test User'])
+  await writeFile(join(repoPath, 'version.txt'), 'one\n')
+  git(repoPath, ['add', 'version.txt'])
+  git(repoPath, ['commit', '--quiet', '-m', 'initial'])
+  return { repoPath, root }
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('prepared worktree creation with real Git', () => {
+  it('hides the preparation, retargets an advanced base, and attaches the final branch', async () => {
+    const { repoPath, root } = await createRepo()
+    const preparationRoot = join(root, WORKTREE_CREATE_PREPARATION_DIRECTORY)
+    const preparedPath = join(preparationRoot, `${process.pid}-test`)
+    const finalPath = join(root, 'final-worktree')
+    await mkdir(preparationRoot, { recursive: true })
+
+    await prepareWorktreeCreateCheckout(
+      repoPath,
+      preparedPath,
+      'main',
+      createWorktreePreparationLockReason('real-git-test')
+    )
+
+    const visibleBeforeSubmit = await listWorktrees(repoPath)
+    const allBeforeSubmit = await listWorktrees(repoPath, { includeCreatePreparations: true })
+    expect(visibleBeforeSubmit).toHaveLength(1)
+    expect(allBeforeSubmit).toHaveLength(2)
+    expect(allBeforeSubmit.find(isWorktreeCreatePreparation)).toMatchObject({
+      locked: true
+    })
+
+    await writeFile(join(repoPath, 'version.txt'), 'two\n')
+    git(repoPath, ['add', 'version.txt'])
+    git(repoPath, ['commit', '--quiet', '-m', 'advance base'])
+    const latestHead = git(repoPath, ['rev-parse', 'HEAD'])
+
+    await finalizePreparedWorktree(repoPath, preparedPath, finalPath, 'feature/prepared', 'main')
+
+    expect(git(finalPath, ['rev-parse', 'HEAD'])).toBe(latestHead)
+    expect(git(finalPath, ['branch', '--show-current'])).toBe('feature/prepared')
+    expect(await readFile(join(finalPath, 'version.txt'), 'utf8')).toBe('two\n')
+    expect(git(finalPath, ['config', '--get', 'branch.feature/prepared.base'])).toBe(
+      'refs/heads/main'
+    )
+    expect(git(finalPath, ['config', '--get', 'push.autoSetupRemote'])).toBe('true')
+    expect((await listWorktrees(repoPath)).map((worktree) => worktree.path)).toContain(
+      await realpath(finalPath)
+    )
+  })
+})

--- a/src/main/git/worktree-create-preparation-real-git.test.ts
+++ b/src/main/git/worktree-create-preparation-real-git.test.ts
@@ -33,6 +33,7 @@ async function createRepo(): Promise<{ repoPath: string; root: string }> {
   git(repoPath, ['symbolic-ref', 'HEAD', 'refs/heads/main'])
   git(repoPath, ['config', 'user.email', 'test@example.com'])
   git(repoPath, ['config', 'user.name', 'Test User'])
+  git(repoPath, ['config', 'core.autocrlf', 'false'])
   await writeFile(join(repoPath, 'version.txt'), 'one\n')
   git(repoPath, ['add', 'version.txt'])
   git(repoPath, ['commit', '--quiet', '-m', 'initial'])

--- a/src/main/git/worktree-create-preparation.ts
+++ b/src/main/git/worktree-create-preparation.ts
@@ -6,7 +6,8 @@ import {
   notifyPreparedWorktreeMutation,
   persistWorktreeCreationBase,
   resolveWorktreeAddBaseContext,
-  resolveWorktreeAddTimeoutMs
+  resolveWorktreeAddTimeoutMs,
+  WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS
 } from './worktree'
 import { hasWorktreeBaseCommitRef } from './worktree-base-ref-probe'
 import { gitExecFileAsync } from './runner'
@@ -29,14 +30,21 @@ async function performDiscardPreparedWorktree(
   worktreePath: string,
   options: GitWorktreeExecOptions
 ): Promise<void> {
+  const cleanupGitOptions = {
+    ...gitExecOptions(repoPath, options),
+    timeout: options.timeout ?? WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS
+  }
   try {
-    await gitExecFileAsync(['worktree', 'unlock', worktreePath], gitExecOptions(repoPath, options))
+    await gitExecFileAsync(
+      [...windowsLongPathGitArgs(repoPath), 'worktree', 'unlock', worktreePath],
+      cleanupGitOptions
+    )
   } catch {
     // It may be unlocked already or only partially registered.
   }
   await gitExecFileAsync(
-    ['worktree', 'remove', '--force', worktreePath],
-    gitExecOptions(repoPath, options)
+    [...windowsLongPathGitArgs(repoPath), 'worktree', 'remove', '--force', worktreePath],
+    cleanupGitOptions
   )
 }
 
@@ -71,8 +79,15 @@ export async function prepareWorktreeCreateCheckout(
           { ...gitExecOptions(worktreePath, options), timeout: resolveWorktreeAddTimeoutMs() }
         )
         await gitExecFileAsync(
-          ['worktree', 'lock', '--reason', lockReason, worktreePath],
-          gitExecOptions(repoPath, options)
+          [
+            ...windowsLongPathGitArgs(repoPath),
+            'worktree',
+            'lock',
+            '--reason',
+            lockReason,
+            worktreePath
+          ],
+          { ...gitExecOptions(repoPath, options), timeout: resolveWorktreeAddTimeoutMs() }
         )
       } catch (error) {
         await performDiscardPreparedWorktree(repoPath, worktreePath, options).catch(() => {})
@@ -134,39 +149,43 @@ export async function finalizePreparedWorktree(
   refreshLocalBaseRef = false,
   options: AddWorktreeOptions = {}
 ): Promise<AddWorktreeResult> {
+  const finalizeGitOptions: AddWorktreeOptions = {
+    ...options,
+    timeout: options.timeout ?? resolveWorktreeAddTimeoutMs()
+  }
   try {
     return await runWithGitReadCacheInvalidation(async () => {
       const baseContext = await resolveWorktreeAddBaseContext(
         repoPath,
         baseBranch,
         refreshLocalBaseRef,
-        options
+        finalizeGitOptions
       )
       const { stdout: targetHeadOutput } = await gitExecFileAsync(
         ['rev-parse', '--verify', `${baseContext.effectiveBase}^{commit}`],
-        gitExecOptions(repoPath, options)
+        gitExecOptions(repoPath, finalizeGitOptions)
       )
       const targetHead = targetHeadOutput.trim()
       const { stdout: preparedHeadOutput } = await gitExecFileAsync(
         ['rev-parse', '--verify', 'HEAD'],
-        gitExecOptions(preparedPath, options)
+        gitExecOptions(preparedPath, finalizeGitOptions)
       )
       if (preparedHeadOutput.trim() !== targetHead) {
         await gitExecFileAsync(
           [...windowsLongPathGitArgs(preparedPath), 'reset', '--hard', targetHead],
-          { ...gitExecOptions(preparedPath, options), timeout: resolveWorktreeAddTimeoutMs() }
+          gitExecOptions(preparedPath, finalizeGitOptions)
         )
       }
 
       let moved = false
       try {
         await gitExecFileAsync(
-          ['worktree', 'unlock', preparedPath],
-          gitExecOptions(repoPath, options)
+          [...windowsLongPathGitArgs(repoPath), 'worktree', 'unlock', preparedPath],
+          gitExecOptions(repoPath, finalizeGitOptions)
         )
         await gitExecFileAsync(
-          ['worktree', 'move', preparedPath, worktreePath],
-          gitExecOptions(repoPath, options)
+          [...windowsLongPathGitArgs(repoPath), 'worktree', 'move', preparedPath, worktreePath],
+          gitExecOptions(repoPath, finalizeGitOptions)
         )
         moved = true
         await gitExecFileAsync(
@@ -178,7 +197,7 @@ export async function finalizePreparedWorktree(
             branch,
             targetHead
           ],
-          gitExecOptions(worktreePath, options)
+          gitExecOptions(worktreePath, finalizeGitOptions)
         )
       } catch (error) {
         await removeFailedFinalization(
@@ -186,13 +205,18 @@ export async function finalizePreparedWorktree(
           moved ? worktreePath : preparedPath,
           branch,
           moved,
-          options
+          finalizeGitOptions
         )
         throw error
       }
 
-      await persistWorktreeCreationBase(worktreePath, branch, baseContext.effectiveBase, options)
-      await configurePushAutoSetupRemote(worktreePath, options)
+      await persistWorktreeCreationBase(
+        worktreePath,
+        branch,
+        baseContext.effectiveBase,
+        finalizeGitOptions
+      )
+      await configurePushAutoSetupRemote(worktreePath, finalizeGitOptions)
       return {
         ...(baseContext.localBaseRefRefresh
           ? { localBaseRefRefresh: baseContext.localBaseRefRefresh }

--- a/src/main/git/worktree-create-preparation.ts
+++ b/src/main/git/worktree-create-preparation.ts
@@ -25,13 +25,21 @@ function gitExecOptions(
   }
 }
 
+function gitCleanupOptions(
+  cwd: string,
+  options: GitWorktreeExecOptions
+): { cwd: string; wslDistro?: string; timeout?: number } {
+  // Why: cancellation must not strand a partially moved worktree; cleanup is bounded separately.
+  return gitExecOptions(cwd, { ...options, signal: undefined })
+}
+
 async function performDiscardPreparedWorktree(
   repoPath: string,
   worktreePath: string,
   options: GitWorktreeExecOptions
 ): Promise<void> {
   const cleanupGitOptions = {
-    ...gitExecOptions(repoPath, options),
+    ...gitCleanupOptions(repoPath, options),
     timeout: options.timeout ?? WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS
   }
   try {
@@ -125,7 +133,7 @@ async function removeFailedFinalization(
     try {
       const { stdout } = await gitExecFileAsync(
         ['symbolic-ref', '--short', 'HEAD'],
-        gitExecOptions(cleanupPath, options)
+        gitCleanupOptions(cleanupPath, options)
       )
       branchAttached = stdout.trim() === branch
     } catch {
@@ -134,9 +142,10 @@ async function removeFailedFinalization(
   }
   await performDiscardPreparedWorktree(repoPath, cleanupPath, options).catch(() => {})
   if (branchAttached) {
-    await gitExecFileAsync(['branch', '-D', '--', branch], gitExecOptions(repoPath, options)).catch(
-      () => {}
-    )
+    await gitExecFileAsync(
+      ['branch', '-D', '--', branch],
+      gitCleanupOptions(repoPath, options)
+    ).catch(() => {})
   }
 }
 

--- a/src/main/git/worktree-create-preparation.ts
+++ b/src/main/git/worktree-create-preparation.ts
@@ -1,0 +1,208 @@
+import { windowsLongPathGitArgs } from '../../shared/windows-long-path-git-args'
+import { resolveWorktreeAddBaseRef } from '../../shared/worktree/base-ref'
+import type { AddWorktreeOptions, AddWorktreeResult, GitWorktreeExecOptions } from './worktree'
+import {
+  configurePushAutoSetupRemote,
+  notifyPreparedWorktreeMutation,
+  persistWorktreeCreationBase,
+  resolveWorktreeAddBaseContext,
+  resolveWorktreeAddTimeoutMs
+} from './worktree'
+import { hasWorktreeBaseCommitRef } from './worktree-base-ref-probe'
+import { gitExecFileAsync } from './runner'
+import { runWithGitReadCacheInvalidation } from './status'
+
+function gitExecOptions(
+  cwd: string,
+  options: GitWorktreeExecOptions
+): { cwd: string; wslDistro?: string; signal?: AbortSignal; timeout?: number } {
+  return {
+    cwd,
+    ...(options.wslDistro ? { wslDistro: options.wslDistro } : {}),
+    ...(options.signal ? { signal: options.signal } : {}),
+    ...(options.timeout ? { timeout: options.timeout } : {})
+  }
+}
+
+async function performDiscardPreparedWorktree(
+  repoPath: string,
+  worktreePath: string,
+  options: GitWorktreeExecOptions
+): Promise<void> {
+  try {
+    await gitExecFileAsync(['worktree', 'unlock', worktreePath], gitExecOptions(repoPath, options))
+  } catch {
+    // It may be unlocked already or only partially registered.
+  }
+  await gitExecFileAsync(
+    ['worktree', 'remove', '--force', worktreePath],
+    gitExecOptions(repoPath, options)
+  )
+}
+
+export async function prepareWorktreeCreateCheckout(
+  repoPath: string,
+  worktreePath: string,
+  baseBranch: string,
+  lockReason: string,
+  options: GitWorktreeExecOptions = {}
+): Promise<void> {
+  try {
+    await runWithGitReadCacheInvalidation(async () => {
+      const effectiveBase = await resolveWorktreeAddBaseRef(baseBranch, (qualifiedRef) =>
+        hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
+      )
+      try {
+        await gitExecFileAsync(
+          [
+            ...windowsLongPathGitArgs(repoPath),
+            'worktree',
+            'add',
+            '--detach',
+            '--no-checkout',
+            worktreePath,
+            effectiveBase
+          ],
+          { ...gitExecOptions(repoPath, options), timeout: resolveWorktreeAddTimeoutMs() }
+        )
+        // Why: reset materializes files without running user post-checkout hooks before submit.
+        await gitExecFileAsync(
+          [...windowsLongPathGitArgs(worktreePath), 'reset', '--hard', effectiveBase],
+          { ...gitExecOptions(worktreePath, options), timeout: resolveWorktreeAddTimeoutMs() }
+        )
+        await gitExecFileAsync(
+          ['worktree', 'lock', '--reason', lockReason, worktreePath],
+          gitExecOptions(repoPath, options)
+        )
+      } catch (error) {
+        await performDiscardPreparedWorktree(repoPath, worktreePath, options).catch(() => {})
+        throw error
+      }
+    })
+  } finally {
+    notifyPreparedWorktreeMutation(repoPath)
+  }
+}
+
+export async function discardPreparedWorktree(
+  repoPath: string,
+  worktreePath: string,
+  options: GitWorktreeExecOptions = {}
+): Promise<void> {
+  try {
+    await runWithGitReadCacheInvalidation(() =>
+      performDiscardPreparedWorktree(repoPath, worktreePath, options)
+    )
+  } finally {
+    notifyPreparedWorktreeMutation(repoPath)
+  }
+}
+
+async function removeFailedFinalization(
+  repoPath: string,
+  cleanupPath: string,
+  branch: string,
+  moved: boolean,
+  options: GitWorktreeExecOptions
+): Promise<void> {
+  let branchAttached = false
+  if (moved) {
+    try {
+      const { stdout } = await gitExecFileAsync(
+        ['symbolic-ref', '--short', 'HEAD'],
+        gitExecOptions(cleanupPath, options)
+      )
+      branchAttached = stdout.trim() === branch
+    } catch {
+      // Detached or no longer readable.
+    }
+  }
+  await performDiscardPreparedWorktree(repoPath, cleanupPath, options).catch(() => {})
+  if (branchAttached) {
+    await gitExecFileAsync(['branch', '-D', '--', branch], gitExecOptions(repoPath, options)).catch(
+      () => {}
+    )
+  }
+}
+
+export async function finalizePreparedWorktree(
+  repoPath: string,
+  preparedPath: string,
+  worktreePath: string,
+  branch: string,
+  baseBranch: string,
+  refreshLocalBaseRef = false,
+  options: AddWorktreeOptions = {}
+): Promise<AddWorktreeResult> {
+  try {
+    return await runWithGitReadCacheInvalidation(async () => {
+      const baseContext = await resolveWorktreeAddBaseContext(
+        repoPath,
+        baseBranch,
+        refreshLocalBaseRef,
+        options
+      )
+      const { stdout: targetHeadOutput } = await gitExecFileAsync(
+        ['rev-parse', '--verify', `${baseContext.effectiveBase}^{commit}`],
+        gitExecOptions(repoPath, options)
+      )
+      const targetHead = targetHeadOutput.trim()
+      const { stdout: preparedHeadOutput } = await gitExecFileAsync(
+        ['rev-parse', '--verify', 'HEAD'],
+        gitExecOptions(preparedPath, options)
+      )
+      if (preparedHeadOutput.trim() !== targetHead) {
+        await gitExecFileAsync(
+          [...windowsLongPathGitArgs(preparedPath), 'reset', '--hard', targetHead],
+          { ...gitExecOptions(preparedPath, options), timeout: resolveWorktreeAddTimeoutMs() }
+        )
+      }
+
+      let moved = false
+      try {
+        await gitExecFileAsync(
+          ['worktree', 'unlock', preparedPath],
+          gitExecOptions(repoPath, options)
+        )
+        await gitExecFileAsync(
+          ['worktree', 'move', preparedPath, worktreePath],
+          gitExecOptions(repoPath, options)
+        )
+        moved = true
+        await gitExecFileAsync(
+          [
+            ...windowsLongPathGitArgs(worktreePath),
+            'checkout',
+            '--no-track',
+            '-b',
+            branch,
+            targetHead
+          ],
+          gitExecOptions(worktreePath, options)
+        )
+      } catch (error) {
+        await removeFailedFinalization(
+          repoPath,
+          moved ? worktreePath : preparedPath,
+          branch,
+          moved,
+          options
+        )
+        throw error
+      }
+
+      await persistWorktreeCreationBase(worktreePath, branch, baseContext.effectiveBase, options)
+      await configurePushAutoSetupRemote(worktreePath, options)
+      return {
+        ...(baseContext.localBaseRefRefresh
+          ? { localBaseRefRefresh: baseContext.localBaseRefRefresh }
+          : {}),
+        ...(baseContext.localBaseRefUpdateSuggestion
+          ? { localBaseRefUpdateSuggestion: baseContext.localBaseRefUpdateSuggestion }
+          : {})
+      }
+    })
+  } finally {
+    notifyPreparedWorktreeMutation(repoPath)
+  }
+}

--- a/src/main/git/worktree-create-preparation.ts
+++ b/src/main/git/worktree-create-preparation.ts
@@ -126,11 +126,15 @@ export async function unlockPreparedWorktree(
   worktreePath: string,
   options: GitWorktreeExecOptions = {}
 ): Promise<void> {
+  const cleanupGitOptions = {
+    ...gitCleanupOptions(repoPath, options),
+    timeout: options.timeout ?? WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS
+  }
   try {
     await runWithGitReadCacheInvalidation(() =>
       gitExecFileAsync(
         [...windowsLongPathGitArgs(repoPath), 'worktree', 'unlock', worktreePath],
-        gitCleanupOptions(repoPath, options)
+        cleanupGitOptions
       )
     )
   } finally {

--- a/src/main/git/worktree-create-preparation.ts
+++ b/src/main/git/worktree-create-preparation.ts
@@ -121,6 +121,23 @@ export async function discardPreparedWorktree(
   }
 }
 
+export async function unlockPreparedWorktree(
+  repoPath: string,
+  worktreePath: string,
+  options: GitWorktreeExecOptions = {}
+): Promise<void> {
+  try {
+    await runWithGitReadCacheInvalidation(() =>
+      gitExecFileAsync(
+        [...windowsLongPathGitArgs(repoPath), 'worktree', 'unlock', worktreePath],
+        gitCleanupOptions(repoPath, options)
+      )
+    )
+  } finally {
+    notifyPreparedWorktreeMutation(repoPath)
+  }
+}
+
 async function removeFailedFinalization(
   repoPath: string,
   cleanupPath: string,
@@ -155,6 +172,7 @@ export async function finalizePreparedWorktree(
   worktreePath: string,
   branch: string,
   baseBranch: string,
+  lockReason: string,
   refreshLocalBaseRef = false,
   options: AddWorktreeOptions = {}
 ): Promise<AddWorktreeResult> {
@@ -197,6 +215,18 @@ export async function finalizePreparedWorktree(
           gitExecOptions(repoPath, finalizeGitOptions)
         )
         moved = true
+        // Why: keep a moved checkout hidden and recoverable if the host crashes before submit completes.
+        await gitExecFileAsync(
+          [
+            ...windowsLongPathGitArgs(repoPath),
+            'worktree',
+            'lock',
+            '--reason',
+            lockReason,
+            worktreePath
+          ],
+          gitExecOptions(repoPath, finalizeGitOptions)
+        )
         await gitExecFileAsync(
           [
             ...windowsLongPathGitArgs(worktreePath),
@@ -208,6 +238,17 @@ export async function finalizePreparedWorktree(
           ],
           gitExecOptions(worktreePath, finalizeGitOptions)
         )
+        await persistWorktreeCreationBase(
+          worktreePath,
+          branch,
+          baseContext.effectiveBase,
+          finalizeGitOptions
+        )
+        await configurePushAutoSetupRemote(worktreePath, finalizeGitOptions)
+        await gitExecFileAsync(
+          [...windowsLongPathGitArgs(repoPath), 'worktree', 'unlock', worktreePath],
+          gitExecOptions(repoPath, finalizeGitOptions)
+        )
       } catch (error) {
         await removeFailedFinalization(
           repoPath,
@@ -218,14 +259,6 @@ export async function finalizePreparedWorktree(
         )
         throw error
       }
-
-      await persistWorktreeCreationBase(
-        worktreePath,
-        branch,
-        baseContext.effectiveBase,
-        finalizeGitOptions
-      )
-      await configurePushAutoSetupRemote(worktreePath, finalizeGitOptions)
       return {
         ...(baseContext.localBaseRefRefresh
           ? { localBaseRefRefresh: baseContext.localBaseRefRefresh }

--- a/src/main/git/worktree-create-preparation.ts
+++ b/src/main/git/worktree-create-preparation.ts
@@ -176,7 +176,6 @@ export async function finalizePreparedWorktree(
   worktreePath: string,
   branch: string,
   baseBranch: string,
-  lockReason: string,
   refreshLocalBaseRef = false,
   options: AddWorktreeOptions = {}
 ): Promise<AddWorktreeResult> {
@@ -211,26 +210,19 @@ export async function finalizePreparedWorktree(
       let moved = false
       try {
         await gitExecFileAsync(
-          [...windowsLongPathGitArgs(repoPath), 'worktree', 'unlock', preparedPath],
-          gitExecOptions(repoPath, finalizeGitOptions)
-        )
-        await gitExecFileAsync(
-          [...windowsLongPathGitArgs(repoPath), 'worktree', 'move', preparedPath, worktreePath],
-          gitExecOptions(repoPath, finalizeGitOptions)
-        )
-        moved = true
-        // Why: keep a moved checkout hidden and recoverable if the host crashes before submit completes.
-        await gitExecFileAsync(
           [
             ...windowsLongPathGitArgs(repoPath),
             'worktree',
-            'lock',
-            '--reason',
-            lockReason,
+            'move',
+            '-f',
+            '-f',
+            preparedPath,
             worktreePath
           ],
           gitExecOptions(repoPath, finalizeGitOptions)
         )
+        moved = true
+        // Why: `-f -f` moves the locked preparation while preserving its lock reason (Git >=2.25).
         await gitExecFileAsync(
           [
             ...windowsLongPathGitArgs(worktreePath),

--- a/src/main/git/worktree-listing.ts
+++ b/src/main/git/worktree-listing.ts
@@ -1,4 +1,5 @@
 import { stat } from 'node:fs/promises'
+import { isWorktreeCreatePreparation } from '../../shared/worktree/create-preparation'
 import type { GitWorktreeInfo } from '../../shared/worktree/types'
 import { readTranslatedWorktreeGraph, readWorktreeList } from './worktree-list-reader'
 import type { GitWorktreeExecOptions } from './worktree-operation-options'
@@ -13,7 +14,10 @@ export async function listWorktreeGraph(
   options: GitWorktreeExecOptions = {}
 ): Promise<GitWorktreeInfo[]> {
   try {
-    return await readTranslatedWorktreeGraph(repoPath, options)
+    const worktrees = await readTranslatedWorktreeGraph(repoPath, options)
+    return options.includeCreatePreparations
+      ? worktrees
+      : worktrees.filter((worktree) => !isWorktreeCreatePreparation(worktree))
   } catch (err) {
     if (getErrorCode(err) === 'ENOENT') {
       try {
@@ -39,7 +43,10 @@ export async function listWorktreesUnshared(
 ): Promise<GitWorktreeInfo[]> {
   try {
     const worktrees = await readTranslatedWorktreeGraph(repoPath, options)
-    return annotateSparseCheckoutStatus(worktrees)
+    const visibleWorktrees = options.includeCreatePreparations
+      ? worktrees
+      : worktrees.filter((worktree) => !isWorktreeCreatePreparation(worktree))
+    return annotateSparseCheckoutStatus(visibleWorktrees)
   } catch (err) {
     if (getErrorCode(err) === 'ENOENT') {
       try {
@@ -68,7 +75,10 @@ export async function listWorktreesStrict(
     const translatedPath = translateWorktreePath(worktree.path, repoPath, options)
     return translatedPath === worktree.path ? worktree : { ...worktree, path: translatedPath }
   })
-  return annotateSparseCheckoutStatus(worktrees)
+  const visibleWorktrees = options.includeCreatePreparations
+    ? worktrees
+    : worktrees.filter((worktree) => !isWorktreeCreatePreparation(worktree))
+  return annotateSparseCheckoutStatus(visibleWorktrees)
 }
 
 async function annotateSparseCheckoutStatus(

--- a/src/main/git/worktree-operation-options.ts
+++ b/src/main/git/worktree-operation-options.ts
@@ -18,6 +18,7 @@ export type GitWorktreeExecOptions = {
   wslDistro?: string
   signal?: AbortSignal
   timeout?: number
+  includeCreatePreparations?: boolean
 }
 
 export type WorktreeRemovalPreflightOptions = GitWorktreeExecOptions & {

--- a/src/main/git/worktree-scan-cache.ts
+++ b/src/main/git/worktree-scan-cache.ts
@@ -94,7 +94,7 @@ export function listWorktrees(
 }
 
 /**
- * `listWorktreeGraph` through the same in-flight map, so callers that must see a Git failure
+ * `listWorktreesStrict` through the same in-flight map, so callers that must see a Git failure
  * (worktree-create verification) still coalesce with a concurrent refresh (#16520).
  */
 export function listWorktreesSharedStrict(

--- a/src/main/git/worktree-scan-cache.ts
+++ b/src/main/git/worktree-scan-cache.ts
@@ -66,7 +66,7 @@ function shareWorktreeScan(
   const timeout = options.timeout ?? WORKTREE_LIST_TIMEOUT_MS
   // Why: callers with different deadlines cannot safely share which timeout wins the scan.
   // Why `run.name`: a strict joiner must never receive a softened `[]` from a lenient scan.
-  const key = `${repoPath}\0${options.wslDistro ?? ''}\0${timeout}\0${generation}\0${run.name}`
+  const key = `${repoPath}\0${options.wslDistro ?? ''}\0${timeout}\0${options.includeCreatePreparations === true}\0${generation}\0${run.name}`
   const inFlight = inFlightWorktreeScans.get(key)
   if (inFlight) {
     return inFlight
@@ -94,7 +94,7 @@ export function listWorktrees(
 }
 
 /**
- * `listWorktreesStrict` through the same in-flight map, so callers that must see a Git failure
+ * `listWorktreeGraph` through the same in-flight map, so callers that must see a Git failure
  * (worktree-create verification) still coalesce with a concurrent refresh (#16520).
  */
 export function listWorktreesSharedStrict(

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1,4 +1,9 @@
 export { addWorktree } from './worktree-add'
+export {
+  configurePushAutoSetupRemote,
+  persistWorktreeCreationBase,
+  resolveWorktreeAddBaseContext
+} from './worktree-add'
 export { forceDeleteLocalBranch } from './worktree-branch-removal'
 export { parseWorktreeList } from './worktree-list-parser'
 export { listWorktreeGraph, listWorktreesStrict } from './worktree-listing'
@@ -25,5 +30,6 @@ export {
   listWorktrees,
   listWorktreesSharedStrict
 } from './worktree-scan-cache'
+export { bumpWorktreeScanGeneration as notifyPreparedWorktreeMutation } from './worktree-scan-cache'
 export { addSparseWorktree } from './worktree-sparse-add'
 export { parseCoreSparseCheckoutFlag } from './worktree-sparse-state'

--- a/src/main/host-tree-removal.ts
+++ b/src/main/host-tree-removal.ts
@@ -6,15 +6,25 @@ import type { RmOptions } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { win32 } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
+import { isWindowsAbsolutePathLike } from '../shared/cross-platform-path'
 
 const WINDOWS_REMOVE_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000]
 const WINDOWS_RM_MAX_RETRIES = 8
 const WINDOWS_RM_RETRY_DELAY_MS = 150
 
+/** Convert a native host filesystem path to the Win32 long-path namespace. */
+export function toHostFilesystemPath(targetPath: string): string {
+  // POSIX paths are used by WSL callers even while the Electron process runs
+  // on Windows; do not reinterpret those as drive-relative Win32 paths.
+  return process.platform === 'win32' && isWindowsAbsolutePathLike(targetPath)
+    ? win32.toNamespacedPath(targetPath)
+    : targetPath
+}
+
 export function toHostRemovalPath(targetPath: string): string {
   // Why: Git for Windows can fail long recursive deletes even after Orca has
   // proven the worktree target; Node's host deletion should use Win32 long paths.
-  return process.platform === 'win32' ? win32.toNamespacedPath(targetPath) : targetPath
+  return toHostFilesystemPath(targetPath)
 }
 
 function getHostRemovalOptions(): RmOptions {

--- a/src/main/host-tree-removal.ts
+++ b/src/main/host-tree-removal.ts
@@ -7,6 +7,7 @@ import { rm } from 'node:fs/promises'
 import { win32 } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { isWindowsAbsolutePathLike } from '../shared/cross-platform-path'
+import { isWslUncPath } from '../shared/wsl-paths'
 
 const WINDOWS_REMOVE_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000]
 const WINDOWS_RM_MAX_RETRIES = 8
@@ -16,7 +17,9 @@ const WINDOWS_RM_RETRY_DELAY_MS = 150
 export function toHostFilesystemPath(targetPath: string): string {
   // POSIX paths are used by WSL callers even while the Electron process runs
   // on Windows; do not reinterpret those as drive-relative Win32 paths.
-  return process.platform === 'win32' && isWindowsAbsolutePathLike(targetPath)
+  return process.platform === 'win32' &&
+    isWindowsAbsolutePathLike(targetPath) &&
+    !isWslUncPath(targetPath)
     ? win32.toNamespacedPath(targetPath)
     : targetPath
 }

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -29,6 +29,7 @@ import type {
 import { getPRForBranch } from '../github/client'
 import { listWorktrees, addWorktree, addSparseWorktree } from '../git/worktree'
 import type { AddWorktreeOptions, AddWorktreeResult } from '../git/worktree'
+import { consumePreparedWorktreeCreate } from '../worktree-create-preparation'
 import {
   getBranchConflictKind,
   resolveDefaultBaseRefViaExec,
@@ -2379,10 +2380,27 @@ export async function createLocalWorktree(
     ...remoteTrackingBaseOption,
     ...(suggestLocalBaseRefUpdate ? { suggestLocalBaseRefUpdate } : {})
   }
+  const preparedWorktreeOptions = suggestLocalBaseRefUpdate
+    ? addProjectGitOptions({ ...remoteTrackingBaseOption, suggestLocalBaseRefUpdate })
+    : addProjectGitOptions(remoteTrackingBaseOption)
   let addResult: AddWorktreeResult
   try {
     addResult =
       (await timing.time('git_worktree_add', async () => {
+        if (sparseDirectories.length === 0 && !checkoutExistingBranch) {
+          const preparedResult = await consumePreparedWorktreeCreate({
+            repoPath: repo.path,
+            workspaceRoot,
+            worktreePath,
+            branch: branchName,
+            baseBranch,
+            refreshLocalBaseRef: settings.refreshLocalBaseRefOnWorktreeCreate,
+            ...(preparedWorktreeOptions ? { options: preparedWorktreeOptions } : {})
+          })
+          if (preparedResult) {
+            return preparedResult
+          }
+        }
         if (sparseDirectories.length > 0) {
           if (checkoutExistingBranch) {
             return addSparseWorktree(

--- a/src/main/ipc/worktrees/create/register-worktree-prefetch-handler.ts
+++ b/src/main/ipc/worktrees/create/register-worktree-prefetch-handler.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron'
 import { prefetchWorktreeCreateBase } from '../../../worktree-create-base-prefetch'
+import { prepareWorktreeCreateForRepo } from '../../../worktree-create-preparation'
 import type { WorktreeIpcContext } from '../worktree-ipc-context'
 
 export function registerWorktreePrefetchHandler(context: WorktreeIpcContext): void {
@@ -13,7 +14,14 @@ export function registerWorktreePrefetchHandler(context: WorktreeIpcContext): vo
         return
       }
       try {
-        await prefetchWorktreeCreateBase({ repo, baseBranch: args.baseBranch, runtime })
+        const baseBranch = await prefetchWorktreeCreateBase({
+          repo,
+          baseBranch: args.baseBranch,
+          runtime
+        })
+        if (baseBranch) {
+          await prepareWorktreeCreateForRepo(store, repo, baseBranch)
+        }
       } catch {
         // Why: optimistic warm-up; the real create path awaits the same refresh and reports failures there.
       }

--- a/src/main/local-worktree-filesystem.test.ts
+++ b/src/main/local-worktree-filesystem.test.ts
@@ -118,6 +118,13 @@ describe('local worktree filesystem runtime access', () => {
     })
   })
 
+  it('leaves WSL UNC paths unchanged on a Windows host', async () => {
+    await withPlatform('win32', async () => {
+      const wslPath = String.raw`\\wsl.localhost\Ubuntu\home\me\worktrees`
+      expect(toHostFilesystemPath(wslPath)).toBe(wslPath)
+    })
+  })
+
   it('retries transient host removal failures on Windows', async () => {
     vi.useFakeTimers()
     await withPlatform('win32', async () => {

--- a/src/main/local-worktree-filesystem.test.ts
+++ b/src/main/local-worktree-filesystem.test.ts
@@ -22,6 +22,7 @@ vi.mock('node:fs/promises', () => ({
 import {
   getLocalWorktreePathAccess,
   removeLocalWorktreePath,
+  toHostFilesystemPath,
   toHostRemovalPath
 } from './local-worktree-filesystem'
 
@@ -100,6 +101,20 @@ describe('local worktree filesystem runtime access', () => {
           retryDelay: expect.any(Number)
         })
       )
+    })
+  })
+
+  it('uses the same Win32 namespace for host directory creation on Windows', async () => {
+    await withPlatform('win32', async () => {
+      const longPath = `C:\\repo\\${'nested\\'.repeat(40)}feature`
+
+      expect(toHostFilesystemPath(longPath)).toBe(`\\\\?\\${longPath}`)
+    })
+  })
+
+  it('leaves POSIX WSL paths unchanged on a Windows host', async () => {
+    await withPlatform('win32', async () => {
+      expect(toHostFilesystemPath('/home/me/worktrees')).toBe('/home/me/worktrees')
     })
   })
 

--- a/src/main/local-worktree-filesystem.ts
+++ b/src/main/local-worktree-filesystem.ts
@@ -5,7 +5,7 @@ import { removeHostTree } from './host-tree-removal'
 import { toLinuxPath } from './wsl'
 import type { ReadPath, StatPath } from './worktree-orphan-gitdir-proof'
 
-export { toHostRemovalPath } from './host-tree-removal'
+export { toHostFilesystemPath, toHostRemovalPath } from './host-tree-removal'
 
 export type LocalWorktreeFilesystemOptions = {
   wslDistro?: string

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1257,6 +1257,10 @@ import {
   resolveWorktreeRemovalRepoOwner
 } from '../worktree-removal-repo-owner'
 import { prefetchWorktreeCreateBase } from '../worktree-create-base-prefetch'
+import {
+  consumePreparedWorktreeCreate,
+  prepareWorktreeCreateForRepo
+} from '../worktree-create-preparation'
 import { prepareLocalWorktreeRootForRepo } from '../worktree-root-preparation'
 import { getWorktreeWatcherRemoval } from '../ipc/worktree-watcher-removal'
 import { acquireWatcherRemovalGate } from '../ipc/watcher-removal-gate'
@@ -26494,11 +26498,14 @@ export class OrcaRuntimeService {
     }
 
     const repo = await this.resolveRepoSelector(args.repoSelector)
-    await prefetchWorktreeCreateBase({
+    const baseBranch = await prefetchWorktreeCreateBase({
       repo,
       baseBranch: args.baseBranch,
       runtime: this
     })
+    if (baseBranch) {
+      await prepareWorktreeCreateForRepo(this.requireStore(), repo, baseBranch)
+    }
   }
 
   async createManagedWorktree(args: {
@@ -27082,9 +27089,27 @@ export class OrcaRuntimeService {
       ...(suggestLocalBaseRefUpdate ? { suggestLocalBaseRefUpdate } : {})
     }
     const defaultAddWorktreeOption = addProjectGitOptions()
+    const preparedWorktreeOptions = suggestLocalBaseRefUpdate
+      ? addProjectGitOptions({ ...remoteTrackingBaseOption, suggestLocalBaseRefUpdate })
+      : remoteTrackingBaseOption
+        ? addProjectGitOptions(remoteTrackingBaseOption)
+        : defaultAddWorktreeOption
     let addResult: AddWorktreeResult
     try {
+      const preparedResult =
+        sparseDirectories.length === 0 && !checkoutExistingBranch
+          ? await consumePreparedWorktreeCreate({
+              repoPath: repo.path,
+              workspaceRoot,
+              worktreePath,
+              branch: branchName,
+              baseBranch,
+              refreshLocalBaseRef: settings.refreshLocalBaseRefOnWorktreeCreate,
+              ...(preparedWorktreeOptions ? { options: preparedWorktreeOptions } : {})
+            })
+          : null
       addResult =
+        preparedResult ??
         (await (sparseDirectories.length > 0
           ? checkoutExistingBranch
             ? addSparseWorktree(
@@ -27180,7 +27205,8 @@ export class OrcaRuntimeService {
                       branchName,
                       baseBranch,
                       settings.refreshLocalBaseRefOnWorktreeCreate
-                    ))) ?? {}
+                    ))) ??
+        {}
     } catch (error) {
       if (shouldRetireGeneratedName && failedWorktreeCreationNeedsRetirement(error)) {
         await retireGeneratedWorktreeName(this.store, repo, settings, effectiveSanitizedName)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -26504,7 +26504,11 @@ export class OrcaRuntimeService {
       runtime: this
     })
     if (baseBranch) {
-      await prepareWorktreeCreateForRepo(this.requireStore(), repo, baseBranch)
+      try {
+        await prepareWorktreeCreateForRepo(this.requireStore(), repo, baseBranch)
+      } catch {
+        // Why: speculative preparation is an optimistic warm-up; the real create path reports failures.
+      }
     }
   }
 

--- a/src/main/worktree-create-base-prefetch.ts
+++ b/src/main/worktree-create-base-prefetch.ts
@@ -44,7 +44,7 @@ async function prefetchLocalWorktreeCreateBase(
   repo: Repo,
   baseBranch: string | undefined,
   runtime: WorktreeCreateBasePrefetchRuntime
-): Promise<void> {
+): Promise<string | undefined> {
   const resolvedBaseBranch = await resolveWorktreeCreateBase({
     requestedBaseBranch: baseBranch,
     repoWorktreeBaseRef: repo.worktreeBaseRef,
@@ -64,13 +64,13 @@ async function prefetchLocalWorktreeCreateBase(
     }
   })
   if (!resolvedBaseBranch) {
-    return
+    return undefined
   }
   if (
     isFullGitObjectId(resolvedBaseBranch) &&
     (await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch))
   ) {
-    return
+    return resolvedBaseBranch
   }
   const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(repo.path, resolvedBaseBranch)
   if (remoteTrackingBase) {
@@ -79,34 +79,35 @@ async function prefetchLocalWorktreeCreateBase(
       !(await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch))
     ) {
       await runtime.getOrStartRemoteTrackingBaseRefresh(repo.path, remoteTrackingBase)
-      return
+      return resolvedBaseBranch
     }
   }
   if (await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch)) {
     // Why: hosted-review start points and local branch bases are already local; a broad remote fetch cannot make them fresher.
-    return
+    return resolvedBaseBranch
   }
 
   // Why: keep optimistic prefetch on the same best-effort fallback path as
   // create so the real create can reuse the runtime's remote fetch cache.
   await runtime.fetchRemoteWithCache(repo.path, 'origin')
+  return resolvedBaseBranch
 }
 
 export async function prefetchWorktreeCreateBase(args: {
   repo: Repo
   baseBranch?: string
   runtime: WorktreeCreateBasePrefetchRuntime
-}): Promise<void> {
+}): Promise<string | undefined> {
   if (isFolderRepo(args.repo)) {
-    return
+    return undefined
   }
   if (args.repo.connectionId) {
     const provider = getSshGitProvider(args.repo.connectionId)
     if (!provider) {
-      return
+      return undefined
     }
     await prefetchRemoteWorktreeCreateBase(provider, args.repo, { baseBranch: args.baseBranch })
-    return
+    return undefined
   }
-  await prefetchLocalWorktreeCreateBase(args.repo, args.baseBranch, args.runtime)
+  return prefetchLocalWorktreeCreateBase(args.repo, args.baseBranch, args.runtime)
 }

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   prepareCheckout: vi.fn(),
   finalize: vi.fn(),
   discard: vi.fn(),
+  unlock: vi.fn(),
   getWorktreeOptions: vi.fn()
 }))
 
@@ -16,7 +17,8 @@ vi.mock('./git/worktree', () => ({ listWorktreeGraph: mocks.listWorktreeGraph })
 vi.mock('./git/worktree-create-preparation', () => ({
   prepareWorktreeCreateCheckout: mocks.prepareCheckout,
   finalizePreparedWorktree: mocks.finalize,
-  discardPreparedWorktree: mocks.discard
+  discardPreparedWorktree: mocks.discard,
+  unlockPreparedWorktree: mocks.unlock
 }))
 vi.mock('./project-runtime-git-options', () => ({
   getLocalProjectWorktreeGitOptions: mocks.getWorktreeOptions
@@ -41,6 +43,7 @@ beforeEach(() => {
   mocks.prepareCheckout.mockReset().mockResolvedValue(undefined)
   mocks.finalize.mockReset().mockResolvedValue({})
   mocks.discard.mockReset().mockResolvedValue(undefined)
+  mocks.unlock.mockReset().mockResolvedValue(undefined)
   mocks.getWorktreeOptions.mockReset().mockReturnValue({})
 })
 
@@ -100,6 +103,7 @@ describe('worktree create preparation registry', () => {
       '/workspace/final',
       'feature/test',
       'origin/main',
+      expect.stringMatching(/^orca-create-preparation:v1:/),
       undefined,
       options
     )
@@ -111,6 +115,24 @@ describe('worktree create preparation registry', () => {
     await prepareWorktreeCreateForRepo(store, repo, 'origin/release')
 
     expect(mocks.listWorktreeGraph).toHaveBeenCalledTimes(2)
+  })
+
+  it('unlocks a stale branch-attached final path instead of deleting user work', async () => {
+    mocks.listWorktreeGraph.mockResolvedValueOnce([
+      {
+        path: '/workspace/final',
+        branch: 'refs/heads/feature/test',
+        lockReason: 'orca-create-preparation:v1:999999999:stale',
+        head: 'deadbeef',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+
+    expect(mocks.unlock).toHaveBeenCalledWith(repo.path, '/workspace/final', {})
+    expect(mocks.discard).not.toHaveBeenCalledWith(repo.path, '/workspace/final', {})
   })
 
   it('cleans up and returns null so normal add can run when finalization fails', async () => {

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -152,6 +152,24 @@ describe('worktree create preparation registry', () => {
     expect(mocks.discard).not.toHaveBeenCalledWith(repo.path, '/workspace/final', {})
   })
 
+  it('does not classify a user branch worktree under the preparation directory as stale', async () => {
+    mocks.listWorktreeGraph.mockResolvedValueOnce([
+      {
+        path: '/workspace/.orca-preparing/999999999-user-worktree',
+        branch: 'refs/heads/user-worktree',
+        lockReason: undefined,
+        head: 'deadbeef',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+
+    expect(mocks.unlock).not.toHaveBeenCalled()
+    expect(mocks.discard).not.toHaveBeenCalled()
+  })
+
   it('cleans up and returns null so normal add can run when finalization fails', async () => {
     await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
     mocks.finalize.mockRejectedValueOnce(new Error('submodules prevent worktree move'))

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from './persistence'
+import type { Repo } from '../shared/repo-types'
+
+const mocks = vi.hoisted(() => ({
+  mkdir: vi.fn(),
+  listWorktreesStrict: vi.fn(),
+  prepareCheckout: vi.fn(),
+  finalize: vi.fn(),
+  discard: vi.fn(),
+  getWorktreeOptions: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({ mkdir: mocks.mkdir }))
+vi.mock('./git/worktree', () => ({ listWorktreesStrict: mocks.listWorktreesStrict }))
+vi.mock('./git/worktree-create-preparation', () => ({
+  prepareWorktreeCreateCheckout: mocks.prepareCheckout,
+  finalizePreparedWorktree: mocks.finalize,
+  discardPreparedWorktree: mocks.discard
+}))
+vi.mock('./project-runtime-git-options', () => ({
+  getLocalProjectWorktreeGitOptions: mocks.getWorktreeOptions
+}))
+vi.mock('./ipc/worktree-logic', () => ({
+  computeWorkspaceRoot: () => '/workspace',
+  getWorktreePathSettings: () => ({ workspaceDir: '/workspace', nestWorkspaces: false })
+}))
+
+import {
+  _resetWorktreeCreatePreparationsForTests,
+  consumePreparedWorktreeCreate,
+  prepareWorktreeCreateForRepo
+} from './worktree-create-preparation'
+
+const repo = { id: 'repo-1', path: '/repo' } as Repo
+const store = { getSettings: () => ({}) } as unknown as Store
+
+beforeEach(() => {
+  mocks.mkdir.mockReset().mockResolvedValue(undefined)
+  mocks.listWorktreesStrict.mockReset().mockResolvedValue([])
+  mocks.prepareCheckout.mockReset().mockResolvedValue(undefined)
+  mocks.finalize.mockReset().mockResolvedValue({})
+  mocks.discard.mockReset().mockResolvedValue(undefined)
+  mocks.getWorktreeOptions.mockReset().mockReturnValue({})
+})
+
+afterEach(async () => {
+  await _resetWorktreeCreatePreparationsForTests()
+})
+
+describe('worktree create preparation registry', () => {
+  it('deduplicates preparation for the same repo, base, runtime, and workspace root', async () => {
+    await Promise.all([
+      prepareWorktreeCreateForRepo(store, repo, 'origin/main'),
+      prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    ])
+
+    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not claim a preparation after the selected base changes', async () => {
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+
+    await expect(
+      consumePreparedWorktreeCreate({
+        repoPath: repo.path,
+        workspaceRoot: '/workspace',
+        worktreePath: '/workspace/final',
+        branch: 'feature/test',
+        baseBranch: 'origin/release'
+      })
+    ).resolves.toBeNull()
+    expect(mocks.finalize).not.toHaveBeenCalled()
+  })
+
+  it('routes preparation and finalization through the selected WSL runtime', async () => {
+    const options = { wslDistro: 'Ubuntu' }
+    mocks.getWorktreeOptions.mockReturnValue(options)
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+
+    await consumePreparedWorktreeCreate({
+      repoPath: repo.path,
+      workspaceRoot: '/workspace',
+      worktreePath: '/workspace/final',
+      branch: 'feature/test',
+      baseBranch: 'origin/main',
+      options
+    })
+
+    expect(mocks.prepareCheckout).toHaveBeenCalledWith(
+      repo.path,
+      expect.any(String),
+      'origin/main',
+      expect.any(String),
+      options
+    )
+    expect(mocks.finalize).toHaveBeenCalledWith(
+      repo.path,
+      expect.any(String),
+      '/workspace/final',
+      'feature/test',
+      'origin/main',
+      undefined,
+      options
+    )
+  })
+
+  it('retries stale cleanup after a transient listing failure', async () => {
+    mocks.listWorktreesStrict.mockRejectedValueOnce(new Error('temporary listing failure'))
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/release')
+
+    expect(mocks.listWorktreesStrict).toHaveBeenCalledTimes(2)
+  })
+
+  it('cleans up and returns null so normal add can run when finalization fails', async () => {
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    mocks.finalize.mockRejectedValueOnce(new Error('submodules prevent worktree move'))
+
+    await expect(
+      consumePreparedWorktreeCreate({
+        repoPath: repo.path,
+        workspaceRoot: '/workspace',
+        worktreePath: '/workspace/final',
+        branch: 'feature/test',
+        baseBranch: 'origin/main'
+      })
+    ).resolves.toBeNull()
+    expect(mocks.mkdir).toHaveBeenCalledWith('/workspace', { recursive: true })
+    expect(mocks.discard).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -103,7 +103,6 @@ describe('worktree create preparation registry', () => {
       '/workspace/final',
       'feature/test',
       'origin/main',
-      expect.stringMatching(/^orca-create-preparation:v1:/),
       undefined,
       options
     )

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -4,7 +4,7 @@ import type { Repo } from '../shared/repo-types'
 
 const mocks = vi.hoisted(() => ({
   mkdir: vi.fn(),
-  listWorktreesStrict: vi.fn(),
+  listWorktreeGraph: vi.fn(),
   prepareCheckout: vi.fn(),
   finalize: vi.fn(),
   discard: vi.fn(),
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('node:fs/promises', () => ({ mkdir: mocks.mkdir }))
-vi.mock('./git/worktree', () => ({ listWorktreesStrict: mocks.listWorktreesStrict }))
+vi.mock('./git/worktree', () => ({ listWorktreeGraph: mocks.listWorktreeGraph }))
 vi.mock('./git/worktree-create-preparation', () => ({
   prepareWorktreeCreateCheckout: mocks.prepareCheckout,
   finalizePreparedWorktree: mocks.finalize,
@@ -37,7 +37,7 @@ const store = { getSettings: () => ({}) } as unknown as Store
 
 beforeEach(() => {
   mocks.mkdir.mockReset().mockResolvedValue(undefined)
-  mocks.listWorktreesStrict.mockReset().mockResolvedValue([])
+  mocks.listWorktreeGraph.mockReset().mockResolvedValue([])
   mocks.prepareCheckout.mockReset().mockResolvedValue(undefined)
   mocks.finalize.mockReset().mockResolvedValue({})
   mocks.discard.mockReset().mockResolvedValue(undefined)
@@ -106,11 +106,11 @@ describe('worktree create preparation registry', () => {
   })
 
   it('retries stale cleanup after a transient listing failure', async () => {
-    mocks.listWorktreesStrict.mockRejectedValueOnce(new Error('temporary listing failure'))
+    mocks.listWorktreeGraph.mockRejectedValueOnce(new Error('temporary listing failure'))
     await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
     await prepareWorktreeCreateForRepo(store, repo, 'origin/release')
 
-    expect(mocks.listWorktreesStrict).toHaveBeenCalledTimes(2)
+    expect(mocks.listWorktreeGraph).toHaveBeenCalledTimes(2)
   })
 
   it('cleans up and returns null so normal add can run when finalization fails', async () => {

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -24,7 +24,10 @@ vi.mock('./project-runtime-git-options', () => ({
   getLocalProjectWorktreeGitOptions: mocks.getWorktreeOptions
 }))
 vi.mock('./ipc/worktree-logic', () => ({
-  computeWorkspaceRoot: () => (process.platform === 'win32' ? 'C:\\workspace' : '/workspace'),
+  computeWorkspaceRoot: (repoPath: string) =>
+    process.platform === 'win32' && /^[A-Za-z]:[\\/]/.test(repoPath)
+      ? 'C:\\workspace'
+      : '/workspace',
   getWorktreePathSettings: () => ({
     workspaceDir: process.platform === 'win32' ? 'C:\\workspace' : '/workspace',
     nestWorkspaces: false

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Store } from './persistence'
 import type { Repo } from '../shared/repo-types'
+import { WORKTREE_CREATE_PREPARATION_DIRECTORY } from '../shared/worktree/create-preparation'
 
 const mocks = vi.hoisted(() => ({
   mkdir: vi.fn(),
@@ -171,6 +172,27 @@ describe('worktree create preparation registry', () => {
 
     expect(mocks.unlock).not.toHaveBeenCalled()
     expect(mocks.discard).not.toHaveBeenCalled()
+  })
+
+  it('does not discard a detached worktree with caller-controlled preparation metadata', async () => {
+    mocks.listWorktreeGraph.mockResolvedValueOnce([
+      {
+        path: `/workspace/${WORKTREE_CREATE_PREPARATION_DIRECTORY}/999-checkout`,
+        branch: undefined,
+        lockReason: 'orca-create-preparation:v1:999999999:spoofed',
+        head: 'deadbeef',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+
+    expect(mocks.discard).not.toHaveBeenCalledWith(
+      repo.path,
+      `/workspace/${WORKTREE_CREATE_PREPARATION_DIRECTORY}/999-checkout`,
+      {}
+    )
   })
 
   it('cleans up and returns null so normal add can run when finalization fails', async () => {

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -24,8 +24,11 @@ vi.mock('./project-runtime-git-options', () => ({
   getLocalProjectWorktreeGitOptions: mocks.getWorktreeOptions
 }))
 vi.mock('./ipc/worktree-logic', () => ({
-  computeWorkspaceRoot: () => '/workspace',
-  getWorktreePathSettings: () => ({ workspaceDir: '/workspace', nestWorkspaces: false })
+  computeWorkspaceRoot: () => (process.platform === 'win32' ? 'C:\\workspace' : '/workspace'),
+  getWorktreePathSettings: () => ({
+    workspaceDir: process.platform === 'win32' ? 'C:\\workspace' : '/workspace',
+    nestWorkspaces: false
+  })
 }))
 
 import {
@@ -52,6 +55,21 @@ afterEach(async () => {
 })
 
 describe('worktree create preparation registry', () => {
+  it('namespaces native Windows preparation directories for long paths', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      await prepareWorktreeCreateForRepo(store, { ...repo, path: 'C:\\repo' }, 'origin/main')
+
+      expect(mocks.mkdir).toHaveBeenCalledWith(
+        expect.stringMatching(/^\\\\\?\\C:\\workspace\\\.orca-preparing/),
+        { recursive: true }
+      )
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
   it('deduplicates preparation for the same repo, base, runtime, and workspace root', async () => {
     await Promise.all([
       prepareWorktreeCreateForRepo(store, repo, 'origin/main'),

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -22,6 +22,7 @@ import {
 } from './git/worktree-create-preparation'
 import { getLocalProjectWorktreeGitOptions } from './project-runtime-git-options'
 import { computeWorkspaceRoot, getWorktreePathSettings } from './ipc/worktree-logic'
+import { toHostFilesystemPath } from './host-tree-removal'
 
 export const WORKTREE_CREATE_PREPARATION_TTL_MS = 5 * 60_000
 export const WORKTREE_CREATE_PREPARATION_LIMIT = 3
@@ -195,7 +196,9 @@ export function prepareWorktreeCreateForRepo(
     ready: (async () => {
       await cleanupStalePreparations(repo.path, options)
       await mkdir(
-        pathOps(workspaceRoot).join(workspaceRoot, WORKTREE_CREATE_PREPARATION_DIRECTORY),
+        toHostFilesystemPath(
+          pathOps(workspaceRoot).join(workspaceRoot, WORKTREE_CREATE_PREPARATION_DIRECTORY)
+        ),
         { recursive: true }
       )
       await prepareWorktreeCreateCheckout(repo.path, preparedPath, baseBranch, lockReason, options)
@@ -246,7 +249,9 @@ export async function consumePreparedWorktreeCreate(
     return null
   }
   try {
-    await mkdir(pathOps(args.worktreePath).dirname(args.worktreePath), { recursive: true })
+    await mkdir(toHostFilesystemPath(pathOps(args.worktreePath).dirname(args.worktreePath)), {
+      recursive: true
+    })
     return await finalizePreparedWorktree(
       args.repoPath,
       entry.preparedPath,

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -17,6 +17,7 @@ import { listWorktreeGraph } from './git/worktree'
 import {
   discardPreparedWorktree,
   finalizePreparedWorktree,
+  unlockPreparedWorktree,
   prepareWorktreeCreateCheckout
 } from './git/worktree-create-preparation'
 import { getLocalProjectWorktreeGitOptions } from './project-runtime-git-options'
@@ -31,6 +32,7 @@ type PreparationEntry = {
   repoPath: string
   workspaceRoot: string
   preparedPath: string
+  lockReason: string
   options: AddWorktreeOptions
   createdAt: number
   ready: Promise<void>
@@ -131,7 +133,13 @@ async function cleanupStalePreparations(
         if (!ownerPid || isProcessAlive(ownerPid)) {
           continue
         }
-        await discardPreparedWorktree(repoPath, worktree.path, options).catch(() => {})
+        // Preserve a branch-attached final path after a crash; only detached or
+        // still-hidden preparations are safe to discard automatically.
+        await (
+          worktree.branch && parseWorktreePreparationPathOwnerPid(worktree.path) === null
+            ? unlockPreparedWorktree(repoPath, worktree.path, options)
+            : discardPreparedWorktree(repoPath, worktree.path, options)
+        ).catch(() => {})
       }
     }
     const workerCount = Math.min(STALE_PREPARATION_CLEANUP_CONCURRENCY, staleWorktrees.length)
@@ -168,6 +176,7 @@ export function prepareWorktreeCreateForRepo(
 
   enforcePreparationLimit()
   const preparationId = `${process.pid}-${randomUUID()}`
+  const lockReason = createWorktreePreparationLockReason(preparationId)
   const preparedPath = pathOps(workspaceRoot).join(
     workspaceRoot,
     WORKTREE_CREATE_PREPARATION_DIRECTORY,
@@ -181,6 +190,7 @@ export function prepareWorktreeCreateForRepo(
     repoPath: repo.path,
     workspaceRoot,
     preparedPath,
+    lockReason,
     options,
     createdAt: Date.now(),
     expiration,
@@ -190,13 +200,7 @@ export function prepareWorktreeCreateForRepo(
         pathOps(workspaceRoot).join(workspaceRoot, WORKTREE_CREATE_PREPARATION_DIRECTORY),
         { recursive: true }
       )
-      await prepareWorktreeCreateCheckout(
-        repo.path,
-        preparedPath,
-        baseBranch,
-        createWorktreePreparationLockReason(preparationId),
-        options
-      )
+      await prepareWorktreeCreateCheckout(repo.path, preparedPath, baseBranch, lockReason, options)
     })()
   } satisfies PreparationEntry)
   preparations.set(key, entry)
@@ -251,6 +255,7 @@ export async function consumePreparedWorktreeCreate(
       args.worktreePath,
       args.branch,
       args.baseBranch,
+      entry.lockReason,
       args.refreshLocalBaseRef,
       options
     )

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -1,0 +1,263 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir } from 'node:fs/promises'
+import { posix, win32 } from 'node:path'
+import type { Store } from './persistence'
+import type { Repo } from '../shared/repo-types'
+import { isFolderRepo } from '../shared/repo-kind'
+import { isWindowsAbsolutePathLike } from '../shared/cross-platform-path'
+import {
+  WORKTREE_CREATE_PREPARATION_DIRECTORY,
+  createWorktreePreparationLockReason,
+  isWorktreeCreatePreparation,
+  parseWorktreePreparationOwnerPid,
+  parseWorktreePreparationPathOwnerPid
+} from '../shared/worktree/create-preparation'
+import type { AddWorktreeOptions, AddWorktreeResult } from './git/worktree'
+import { listWorktreesStrict } from './git/worktree'
+import {
+  discardPreparedWorktree,
+  finalizePreparedWorktree,
+  prepareWorktreeCreateCheckout
+} from './git/worktree-create-preparation'
+import { getLocalProjectWorktreeGitOptions } from './project-runtime-git-options'
+import { computeWorkspaceRoot, getWorktreePathSettings } from './ipc/worktree-logic'
+
+export const WORKTREE_CREATE_PREPARATION_TTL_MS = 5 * 60_000
+export const WORKTREE_CREATE_PREPARATION_LIMIT = 3
+
+type PreparationEntry = {
+  key: string
+  repoPath: string
+  workspaceRoot: string
+  preparedPath: string
+  options: AddWorktreeOptions
+  createdAt: number
+  ready: Promise<void>
+  expiration: NodeJS.Timeout
+}
+
+type ConsumePreparedWorktreeArgs = {
+  repoPath: string
+  workspaceRoot: string
+  worktreePath: string
+  branch: string
+  baseBranch: string
+  refreshLocalBaseRef?: boolean
+  options?: AddWorktreeOptions
+}
+
+const preparations = new Map<string, PreparationEntry>()
+const staleCleanupStarted = new Set<string>()
+
+function pathOps(path: string): Pick<typeof posix, 'dirname' | 'join' | 'normalize'> {
+  return isWindowsAbsolutePathLike(path) ? win32 : posix
+}
+
+function pathKey(path: string): string {
+  const normalized = pathOps(path).normalize(path)
+  return isWindowsAbsolutePathLike(path) ? normalized.toLowerCase() : normalized
+}
+
+function preparationKey(
+  repoPath: string,
+  workspaceRoot: string,
+  baseBranch: string,
+  options: AddWorktreeOptions
+): string {
+  return `${pathKey(repoPath)}\0${pathKey(workspaceRoot)}\0${baseBranch}\0${options.wslDistro ?? ''}`
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+async function discardEntry(entry: PreparationEntry): Promise<void> {
+  await entry.ready.catch(() => {})
+  await discardPreparedWorktree(entry.repoPath, entry.preparedPath, entry.options).catch(() => {})
+}
+
+function expireEntry(entry: PreparationEntry): void {
+  if (preparations.get(entry.key) !== entry) {
+    return
+  }
+  preparations.delete(entry.key)
+  void discardEntry(entry)
+}
+
+function enforcePreparationLimit(): void {
+  while (preparations.size >= WORKTREE_CREATE_PREPARATION_LIMIT) {
+    const oldest = [...preparations.values()].sort(
+      (left, right) => left.createdAt - right.createdAt
+    )[0]
+    if (!oldest) {
+      return
+    }
+    preparations.delete(oldest.key)
+    clearTimeout(oldest.expiration)
+    void discardEntry(oldest)
+  }
+}
+
+async function cleanupStalePreparations(
+  repoPath: string,
+  options: AddWorktreeOptions
+): Promise<void> {
+  const cleanupKey = `${pathKey(repoPath)}\0${options.wslDistro ?? ''}`
+  if (staleCleanupStarted.has(cleanupKey)) {
+    return
+  }
+  staleCleanupStarted.add(cleanupKey)
+  try {
+    const worktrees = await listWorktreesStrict(repoPath, {
+      ...options,
+      includeCreatePreparations: true
+    })
+    await Promise.all(
+      worktrees.filter(isWorktreeCreatePreparation).map(async (worktree) => {
+        const ownerPid =
+          parseWorktreePreparationOwnerPid(worktree.lockReason) ??
+          parseWorktreePreparationPathOwnerPid(worktree.path)
+        if (!ownerPid || isProcessAlive(ownerPid)) {
+          return
+        }
+        await discardPreparedWorktree(repoPath, worktree.path, options).catch(() => {})
+      })
+    )
+  } catch {
+    staleCleanupStarted.delete(cleanupKey)
+  }
+}
+
+export function prepareWorktreeCreateForRepo(
+  store: Store,
+  repo: Repo,
+  baseBranch: string
+): Promise<void> {
+  if (repo.connectionId || isFolderRepo(repo)) {
+    return Promise.resolve()
+  }
+  const options = getLocalProjectWorktreeGitOptions(store, repo)
+  const workspaceRoot = computeWorkspaceRoot(
+    repo.path,
+    getWorktreePathSettings(repo, store.getSettings())
+  )
+  const key = preparationKey(repo.path, workspaceRoot, baseBranch, options)
+  const existing = preparations.get(key)
+  if (existing) {
+    return existing.ready
+  }
+
+  enforcePreparationLimit()
+  const preparationId = `${process.pid}-${randomUUID()}`
+  const preparedPath = pathOps(workspaceRoot).join(
+    workspaceRoot,
+    WORKTREE_CREATE_PREPARATION_DIRECTORY,
+    preparationId
+  )
+  const entry = {} as PreparationEntry
+  const expiration = setTimeout(() => expireEntry(entry), WORKTREE_CREATE_PREPARATION_TTL_MS)
+  expiration.unref()
+  Object.assign(entry, {
+    key,
+    repoPath: repo.path,
+    workspaceRoot,
+    preparedPath,
+    options,
+    createdAt: Date.now(),
+    expiration,
+    ready: (async () => {
+      await cleanupStalePreparations(repo.path, options)
+      await mkdir(
+        pathOps(workspaceRoot).join(workspaceRoot, WORKTREE_CREATE_PREPARATION_DIRECTORY),
+        { recursive: true }
+      )
+      await prepareWorktreeCreateCheckout(
+        repo.path,
+        preparedPath,
+        baseBranch,
+        createWorktreePreparationLockReason(preparationId),
+        options
+      )
+    })()
+  } satisfies PreparationEntry)
+  preparations.set(key, entry)
+  void entry.ready.catch(() => {
+    if (preparations.get(key) === entry) {
+      preparations.delete(key)
+      clearTimeout(entry.expiration)
+    }
+  })
+  return entry.ready
+}
+
+async function claimPreparedWorktree(
+  repoPath: string,
+  workspaceRoot: string,
+  baseBranch: string,
+  options: AddWorktreeOptions
+): Promise<PreparationEntry | null> {
+  const key = preparationKey(repoPath, workspaceRoot, baseBranch, options)
+  const entry = preparations.get(key)
+  if (!entry) {
+    return null
+  }
+  preparations.delete(key)
+  clearTimeout(entry.expiration)
+  try {
+    await entry.ready
+    return entry
+  } catch {
+    return null
+  }
+}
+
+export async function consumePreparedWorktreeCreate(
+  args: ConsumePreparedWorktreeArgs
+): Promise<AddWorktreeResult | null> {
+  const options = args.options ?? {}
+  const entry = await claimPreparedWorktree(
+    args.repoPath,
+    args.workspaceRoot,
+    args.baseBranch,
+    options
+  )
+  if (!entry) {
+    return null
+  }
+  try {
+    await mkdir(pathOps(args.worktreePath).dirname(args.worktreePath), { recursive: true })
+    return await finalizePreparedWorktree(
+      args.repoPath,
+      entry.preparedPath,
+      args.worktreePath,
+      args.branch,
+      args.baseBranch,
+      args.refreshLocalBaseRef,
+      options
+    )
+  } catch (error) {
+    await discardPreparedWorktree(args.repoPath, entry.preparedPath, options).catch(() => {})
+    console.warn(
+      '[worktree-create] prepared checkout could not be finalized; using normal add',
+      error
+    )
+    return null
+  }
+}
+
+export async function _resetWorktreeCreatePreparationsForTests(): Promise<void> {
+  const entries = [...preparations.values()]
+  preparations.clear()
+  staleCleanupStarted.clear()
+  await Promise.all(
+    entries.map(async (entry) => {
+      clearTimeout(entry.expiration)
+      await discardEntry(entry)
+    })
+  )
+}

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -127,19 +127,18 @@ async function cleanupStalePreparations(
       while (nextIndex < staleWorktrees.length) {
         const worktree = staleWorktrees[nextIndex]
         nextIndex += 1
-        const ownerPid =
-          parseWorktreePreparationOwnerPid(worktree.lockReason) ??
-          parseWorktreePreparationPathOwnerPid(worktree.path)
-        if (!ownerPid || isProcessAlive(ownerPid)) {
+        const lockOwnerPid = parseWorktreePreparationOwnerPid(worktree.lockReason)
+        const pathOwnerPid = parseWorktreePreparationPathOwnerPid(worktree.path)
+        if (!lockOwnerPid || isProcessAlive(lockOwnerPid)) {
           continue
         }
         // Preserve a branch-attached final path after a crash; only detached or
         // still-hidden preparations are safe to discard automatically.
-        await (
-          worktree.branch && parseWorktreePreparationPathOwnerPid(worktree.path) === null
-            ? unlockPreparedWorktree(repoPath, worktree.path, options)
-            : discardPreparedWorktree(repoPath, worktree.path, options)
-        ).catch(() => {})
+        if (worktree.branch && pathOwnerPid === null) {
+          await unlockPreparedWorktree(repoPath, worktree.path, options).catch(() => {})
+        } else if (pathOwnerPid === lockOwnerPid) {
+          await discardPreparedWorktree(repoPath, worktree.path, options).catch(() => {})
+        }
       }
     }
     const workerCount = Math.min(STALE_PREPARATION_CLEANUP_CONCURRENCY, staleWorktrees.length)

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -32,7 +32,6 @@ type PreparationEntry = {
   repoPath: string
   workspaceRoot: string
   preparedPath: string
-  lockReason: string
   options: AddWorktreeOptions
   createdAt: number
   ready: Promise<void>
@@ -190,7 +189,6 @@ export function prepareWorktreeCreateForRepo(
     repoPath: repo.path,
     workspaceRoot,
     preparedPath,
-    lockReason,
     options,
     createdAt: Date.now(),
     expiration,
@@ -255,7 +253,6 @@ export async function consumePreparedWorktreeCreate(
       args.worktreePath,
       args.branch,
       args.baseBranch,
-      entry.lockReason,
       args.refreshLocalBaseRef,
       options
     )

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -13,7 +13,7 @@ import {
   parseWorktreePreparationPathOwnerPid
 } from '../shared/worktree/create-preparation'
 import type { AddWorktreeOptions, AddWorktreeResult } from './git/worktree'
-import { listWorktreesStrict } from './git/worktree'
+import { listWorktreeGraph } from './git/worktree'
 import {
   discardPreparedWorktree,
   finalizePreparedWorktree,
@@ -47,7 +47,7 @@ type ConsumePreparedWorktreeArgs = {
 }
 
 const preparations = new Map<string, PreparationEntry>()
-const staleCleanupStarted = new Set<string>()
+const staleCleanupInFlight = new Map<string, Promise<void>>()
 
 function pathOps(path: string): Pick<typeof posix, 'dirname' | 'join' | 'normalize'> {
   return isWindowsAbsolutePathLike(path) ? win32 : posix
@@ -108,12 +108,13 @@ async function cleanupStalePreparations(
   options: AddWorktreeOptions
 ): Promise<void> {
   const cleanupKey = `${pathKey(repoPath)}\0${options.wslDistro ?? ''}`
-  if (staleCleanupStarted.has(cleanupKey)) {
+  const existing = staleCleanupInFlight.get(cleanupKey)
+  if (existing) {
+    await existing.catch(() => {})
     return
   }
-  staleCleanupStarted.add(cleanupKey)
-  try {
-    const worktrees = await listWorktreesStrict(repoPath, {
+  const cleanup = (async () => {
+    const worktrees = await listWorktreeGraph(repoPath, {
       ...options,
       includeCreatePreparations: true
     })
@@ -128,8 +129,14 @@ async function cleanupStalePreparations(
         await discardPreparedWorktree(repoPath, worktree.path, options).catch(() => {})
       })
     )
-  } catch {
-    staleCleanupStarted.delete(cleanupKey)
+  })()
+  staleCleanupInFlight.set(cleanupKey, cleanup)
+  try {
+    await cleanup.catch(() => {})
+  } finally {
+    if (staleCleanupInFlight.get(cleanupKey) === cleanup) {
+      staleCleanupInFlight.delete(cleanupKey)
+    }
   }
 }
 
@@ -253,7 +260,7 @@ export async function consumePreparedWorktreeCreate(
 export async function _resetWorktreeCreatePreparationsForTests(): Promise<void> {
   const entries = [...preparations.values()]
   preparations.clear()
-  staleCleanupStarted.clear()
+  staleCleanupInFlight.clear()
   await Promise.all(
     entries.map(async (entry) => {
       clearTimeout(entry.expiration)

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -24,6 +24,7 @@ import { computeWorkspaceRoot, getWorktreePathSettings } from './ipc/worktree-lo
 
 export const WORKTREE_CREATE_PREPARATION_TTL_MS = 5 * 60_000
 export const WORKTREE_CREATE_PREPARATION_LIMIT = 3
+const STALE_PREPARATION_CLEANUP_CONCURRENCY = 4
 
 type PreparationEntry = {
   key: string
@@ -118,17 +119,23 @@ async function cleanupStalePreparations(
       ...options,
       includeCreatePreparations: true
     })
-    await Promise.all(
-      worktrees.filter(isWorktreeCreatePreparation).map(async (worktree) => {
+    const staleWorktrees = worktrees.filter(isWorktreeCreatePreparation)
+    let nextIndex = 0
+    async function discardNextStalePreparation(): Promise<void> {
+      while (nextIndex < staleWorktrees.length) {
+        const worktree = staleWorktrees[nextIndex]
+        nextIndex += 1
         const ownerPid =
           parseWorktreePreparationOwnerPid(worktree.lockReason) ??
           parseWorktreePreparationPathOwnerPid(worktree.path)
         if (!ownerPid || isProcessAlive(ownerPid)) {
-          return
+          continue
         }
         await discardPreparedWorktree(repoPath, worktree.path, options).catch(() => {})
-      })
-    )
+      }
+    }
+    const workerCount = Math.min(STALE_PREPARATION_CLEANUP_CONCURRENCY, staleWorktrees.length)
+    await Promise.all(Array.from({ length: workerCount }, () => discardNextStalePreparation()))
   })()
   staleCleanupInFlight.set(cleanupKey, cleanup)
   try {

--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -151,6 +151,35 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
     await rm(join(repoPath, 'deferred-trash'), { recursive: true, force: true })
   })
 
+  it('supports prepared worktree creation and finalization', async () => {
+    await runGit(['worktree', 'add', '--detach', '--no-checkout', 'compat-prepared', 'HEAD'])
+    await runGit(['-C', 'compat-prepared', 'reset', '--hard', 'HEAD'])
+    await runGit([
+      'worktree',
+      'lock',
+      '--reason',
+      'orca-create-preparation:v1:compat',
+      'compat-prepared'
+    ])
+    await runGit(['worktree', 'unlock', 'compat-prepared'])
+    await runGit(['worktree', 'move', 'compat-prepared', 'compat-final'])
+    await runGit([
+      '-C',
+      'compat-final',
+      'checkout',
+      '--no-track',
+      '-b',
+      'compat-prepared-final',
+      'HEAD'
+    ])
+
+    await expect(runGit(['-C', 'compat-final', 'branch', '--show-current'])).resolves.toMatchObject(
+      { stdout: 'compat-prepared-final\n' }
+    )
+    await runGit(['worktree', 'remove', '--force', 'compat-final'])
+    await runGit(['branch', '-D', 'compat-prepared-final'])
+  })
+
   it('recognizes ref and merge-tree compatibility boundaries', async () => {
     const fetchHeadPath = join(repoPath, '.git', 'FETCH_HEAD')
     await writeFile(fetchHeadPath, 'sentinel\n')

--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -161,8 +161,8 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
       'orca-create-preparation:v1:compat',
       'compat-prepared'
     ])
-    await runGit(['worktree', 'unlock', 'compat-prepared'])
-    await runGit(['worktree', 'move', 'compat-prepared', 'compat-final'])
+    // Why: `-f -f` moves a locked preparation while preserving its lock reason (Git >=2.25).
+    await runGit(['worktree', 'move', '-f', '-f', 'compat-prepared', 'compat-final'])
     await runGit([
       '-C',
       'compat-final',
@@ -176,6 +176,7 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
     await expect(runGit(['-C', 'compat-final', 'branch', '--show-current'])).resolves.toMatchObject(
       { stdout: 'compat-prepared-final\n' }
     )
+    await runGit(['worktree', 'unlock', 'compat-final'])
     await runGit(['worktree', 'remove', '--force', 'compat-final'])
     await runGit(['branch', '-D', 'compat-prepared-final'])
   })

--- a/src/shared/worktree/create-preparation.test.ts
+++ b/src/shared/worktree/create-preparation.test.ts
@@ -26,14 +26,14 @@ describe('worktree create preparation classification', () => {
     ).toBe(false)
   })
 
-  it('classifies an unlocked detached preparation by its hidden path', () => {
+  it('does not classify an unlocked detached path without durable ownership', () => {
     expect(
       isWorktreeCreatePreparation({
         path: `/workspace/${WORKTREE_CREATE_PREPARATION_DIRECTORY}/123-checkout`,
         branch: undefined,
         lockReason: undefined
       })
-    ).toBe(true)
+    ).toBe(false)
   })
 
   it('does not classify an arbitrary detached user path by directory name alone', () => {

--- a/src/shared/worktree/create-preparation.test.ts
+++ b/src/shared/worktree/create-preparation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createWorktreePreparationLockReason,
+  isWorktreeCreatePreparation,
+  WORKTREE_CREATE_PREPARATION_DIRECTORY
+} from './create-preparation'
+
+describe('worktree create preparation classification', () => {
+  it('recognizes an explicitly locked preparation regardless of branch state', () => {
+    expect(
+      isWorktreeCreatePreparation({
+        path: `/workspace/${WORKTREE_CREATE_PREPARATION_DIRECTORY}/123-checkout`,
+        branch: 'refs/heads/feature',
+        lockReason: createWorktreePreparationLockReason('test')
+      })
+    ).toBe(true)
+  })
+
+  it('does not classify a branch-attached user worktree by path alone', () => {
+    expect(
+      isWorktreeCreatePreparation({
+        path: `/workspace/${WORKTREE_CREATE_PREPARATION_DIRECTORY}/123-user-worktree`,
+        branch: 'refs/heads/feature',
+        lockReason: undefined
+      })
+    ).toBe(false)
+  })
+
+  it('classifies an unlocked detached preparation by its hidden path', () => {
+    expect(
+      isWorktreeCreatePreparation({
+        path: `/workspace/${WORKTREE_CREATE_PREPARATION_DIRECTORY}/123-checkout`,
+        branch: undefined,
+        lockReason: undefined
+      })
+    ).toBe(true)
+  })
+})

--- a/src/shared/worktree/create-preparation.test.ts
+++ b/src/shared/worktree/create-preparation.test.ts
@@ -35,4 +35,14 @@ describe('worktree create preparation classification', () => {
       })
     ).toBe(true)
   })
+
+  it('does not classify an arbitrary detached user path by directory name alone', () => {
+    expect(
+      isWorktreeCreatePreparation({
+        path: `/workspace/${WORKTREE_CREATE_PREPARATION_DIRECTORY}/user-worktree`,
+        branch: undefined,
+        lockReason: undefined
+      })
+    ).toBe(false)
+  })
 })

--- a/src/shared/worktree/create-preparation.test.ts
+++ b/src/shared/worktree/create-preparation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   createWorktreePreparationLockReason,
   isWorktreeCreatePreparation,
+  parseWorktreePreparationPathOwnerPid,
   WORKTREE_CREATE_PREPARATION_DIRECTORY
 } from './create-preparation'
 
@@ -34,6 +35,14 @@ describe('worktree create preparation classification', () => {
         lockReason: undefined
       })
     ).toBe(false)
+  })
+
+  it('does not parse an arbitrary preparation path with a numeric prefix', () => {
+    expect(
+      parseWorktreePreparationPathOwnerPid(
+        `/workspace/${WORKTREE_CREATE_PREPARATION_DIRECTORY}/123-checkout`
+      )
+    ).toBeNull()
   })
 
   it('does not classify an arbitrary detached user path by directory name alone', () => {

--- a/src/shared/worktree/create-preparation.ts
+++ b/src/shared/worktree/create-preparation.ts
@@ -36,6 +36,8 @@ export function isWorktreeCreatePreparation(worktree: {
   if (worktree.branch) {
     return false
   }
-  const pathParts = worktree.path.split(/[\\/]+/)
-  return pathParts.includes(WORKTREE_CREATE_PREPARATION_DIRECTORY)
+  // Unlocked leftovers are only recoverable when the generated `<pid>-...`
+  // segment is present; an arbitrary user directory named `.orca-preparing`
+  // is not enough evidence to hide or remove a worktree.
+  return parseWorktreePreparationPathOwnerPid(worktree.path) !== null
 }

--- a/src/shared/worktree/create-preparation.ts
+++ b/src/shared/worktree/create-preparation.ts
@@ -26,9 +26,15 @@ export function parseWorktreePreparationPathOwnerPid(path: string): number | nul
 export function isWorktreeCreatePreparation(worktree: {
   path: string
   lockReason?: string
+  branch?: string
 }): boolean {
   if (worktree.lockReason?.startsWith(WORKTREE_CREATE_PREPARATION_LOCK_PREFIX)) {
     return true
+  }
+  // A real branch worktree under a user-chosen `.orca-preparing` directory
+  // must stay visible and must never be eligible for destructive stale cleanup.
+  if (worktree.branch) {
+    return false
   }
   const pathParts = worktree.path.split(/[\\/]+/)
   return pathParts.includes(WORKTREE_CREATE_PREPARATION_DIRECTORY)

--- a/src/shared/worktree/create-preparation.ts
+++ b/src/shared/worktree/create-preparation.ts
@@ -28,16 +28,9 @@ export function isWorktreeCreatePreparation(worktree: {
   lockReason?: string
   branch?: string
 }): boolean {
-  if (worktree.lockReason?.startsWith(WORKTREE_CREATE_PREPARATION_LOCK_PREFIX)) {
-    return true
-  }
-  // A real branch worktree under a user-chosen `.orca-preparing` directory
-  // must stay visible and must never be eligible for destructive stale cleanup.
-  if (worktree.branch) {
-    return false
-  }
-  // Unlocked leftovers are only recoverable when the generated `<pid>-...`
-  // segment is present; an arbitrary user directory named `.orca-preparing`
-  // is not enough evidence to hide or remove a worktree.
-  return parseWorktreePreparationPathOwnerPid(worktree.path) !== null
+  // The Git lock reason is the durable ownership proof. A path can be chosen
+  // by a user (including for an uncommitted detached worktree), so path shape
+  // alone must never hide or force-remove it. A crash before locking may leave
+  // an unlocked detached entry for manual cleanup, but cannot delete user data.
+  return worktree.lockReason?.startsWith(WORKTREE_CREATE_PREPARATION_LOCK_PREFIX) ?? false
 }

--- a/src/shared/worktree/create-preparation.ts
+++ b/src/shared/worktree/create-preparation.ts
@@ -1,0 +1,35 @@
+export const WORKTREE_CREATE_PREPARATION_DIRECTORY = '.orca-preparing'
+export const WORKTREE_CREATE_PREPARATION_LOCK_PREFIX = 'orca-create-preparation:v1:'
+
+export function createWorktreePreparationLockReason(sessionId: string): string {
+  return `${WORKTREE_CREATE_PREPARATION_LOCK_PREFIX}${process.pid}:${sessionId}`
+}
+
+export function parseWorktreePreparationOwnerPid(lockReason?: string): number | null {
+  if (!lockReason?.startsWith(WORKTREE_CREATE_PREPARATION_LOCK_PREFIX)) {
+    return null
+  }
+  const pid = Number(lockReason.slice(WORKTREE_CREATE_PREPARATION_LOCK_PREFIX.length).split(':')[0])
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null
+}
+
+export function parseWorktreePreparationPathOwnerPid(path: string): number | null {
+  const pathParts = path.split(/[\\/]+/)
+  const preparationIndex = pathParts.lastIndexOf(WORKTREE_CREATE_PREPARATION_DIRECTORY)
+  if (preparationIndex === -1) {
+    return null
+  }
+  const pid = Number(pathParts[preparationIndex + 1]?.split('-')[0])
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null
+}
+
+export function isWorktreeCreatePreparation(worktree: {
+  path: string
+  lockReason?: string
+}): boolean {
+  if (worktree.lockReason?.startsWith(WORKTREE_CREATE_PREPARATION_LOCK_PREFIX)) {
+    return true
+  }
+  const pathParts = worktree.path.split(/[\\/]+/)
+  return pathParts.includes(WORKTREE_CREATE_PREPARATION_DIRECTORY)
+}

--- a/src/shared/worktree/create-preparation.ts
+++ b/src/shared/worktree/create-preparation.ts
@@ -1,5 +1,7 @@
 export const WORKTREE_CREATE_PREPARATION_DIRECTORY = '.orca-preparing'
 export const WORKTREE_CREATE_PREPARATION_LOCK_PREFIX = 'orca-create-preparation:v1:'
+const WORKTREE_CREATE_PREPARATION_ID_PATTERN =
+  /^(\d+)-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export function createWorktreePreparationLockReason(sessionId: string): string {
   return `${WORKTREE_CREATE_PREPARATION_LOCK_PREFIX}${process.pid}:${sessionId}`
@@ -19,7 +21,11 @@ export function parseWorktreePreparationPathOwnerPid(path: string): number | nul
   if (preparationIndex === -1) {
     return null
   }
-  const pid = Number(pathParts[preparationIndex + 1]?.split('-')[0])
+  const preparationId = pathParts[preparationIndex + 1]
+  if (!preparationId || !WORKTREE_CREATE_PREPARATION_ID_PATTERN.test(preparationId)) {
+    return null
+  }
+  const pid = Number(preparationId.split('-')[0])
   return Number.isSafeInteger(pid) && pid > 0 ? pid : null
 }
 
@@ -32,5 +38,5 @@ export function isWorktreeCreatePreparation(worktree: {
   // by a user (including for an uncommitted detached worktree), so path shape
   // alone must never hide or force-remove it. A crash before locking may leave
   // an unlocked detached entry for manual cleanup, but cannot delete user data.
-  return worktree.lockReason?.startsWith(WORKTREE_CREATE_PREPARATION_LOCK_PREFIX) ?? false
+  return parseWorktreePreparationOwnerPid(worktree.lockReason) !== null
 }

--- a/tests/tools/benchmarks/worktree-create-speculation-bench.mjs
+++ b/tests/tools/benchmarks/worktree-create-speculation-bench.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { performance } from 'node:perf_hooks'
+
+function parseArgs(argv) {
+  const options = { repo: process.cwd(), base: 'HEAD', iterations: 5 }
+  const firstFlag = argv.findIndex((value, index) => index > 0 && value.startsWith('--'))
+  for (let index = firstFlag === -1 ? argv.length : firstFlag; index < argv.length; index += 1) {
+    const flag = argv[index]
+    const value = argv[index + 1]
+    if (flag === '--repo' && value) {
+      options.repo = path.resolve(value)
+    } else if (flag === '--base' && value) {
+      options.base = value
+    } else if (flag === '--iterations' && value && Number.isInteger(Number(value))) {
+      options.iterations = Number(value)
+    } else {
+      throw new Error(`Unknown or incomplete argument: ${flag}`)
+    }
+    index += 1
+  }
+  if (options.iterations < 1) {
+    throw new Error('--iterations must be positive')
+  }
+  return options
+}
+
+function git(repo, args) {
+  const result = spawnSync('git', ['-C', repo, ...args], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    windowsHide: true
+  })
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed\n${result.stderr || result.stdout}`)
+  }
+  return result.stdout.trim()
+}
+
+function time(operation) {
+  const startedAt = performance.now()
+  operation()
+  return performance.now() - startedAt
+}
+
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right)
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle]
+}
+
+function summarize(samples) {
+  return {
+    medianMs: Number(median(samples).toFixed(1)),
+    minMs: Number(Math.min(...samples).toFixed(1)),
+    maxMs: Number(Math.max(...samples).toFixed(1)),
+    samplesMs: samples.map((sample) => Number(sample.toFixed(1)))
+  }
+}
+
+function removeWorktree(repo, worktreePath, branch, locked = false) {
+  if (locked) {
+    git(repo, ['worktree', 'unlock', worktreePath])
+  }
+  git(repo, ['worktree', 'remove', '--force', worktreePath])
+  if (branch) {
+    git(repo, ['branch', '-D', branch])
+  }
+}
+
+function benchmark(options) {
+  const repo = git(options.repo, ['rev-parse', '--show-toplevel'])
+  const base = git(repo, ['rev-parse', '--verify', `${options.base}^{commit}`])
+  const retargetBase = git(repo, ['rev-parse', '--verify', `${base}~20^{commit}`])
+  const scratchRoot = mkdtempSync(path.join(path.dirname(repo), '.orca-create-bench-'))
+  const samples = { baseline: [], prepare: [], submit: [], retarget: [], cancel: [] }
+  const prefix = `orca-create-bench-${process.pid}-${Date.now()}`
+
+  try {
+    for (let index = 0; index < options.iterations; index += 1) {
+      const baselinePath = path.join(scratchRoot, `baseline-${index}`)
+      const baselineBranch = `${prefix}-baseline-${index}`
+      samples.baseline.push(
+        time(() =>
+          git(repo, ['worktree', 'add', '--no-track', '-b', baselineBranch, baselinePath, base])
+        )
+      )
+      removeWorktree(repo, baselinePath, baselineBranch)
+
+      const preparedPath = path.join(scratchRoot, `prepared-${index}`)
+      const finalPath = path.join(scratchRoot, `final-${index}`)
+      const finalBranch = `${prefix}-final-${index}`
+      samples.prepare.push(
+        time(() => {
+          git(repo, ['worktree', 'add', '--detach', '--no-checkout', preparedPath, base])
+          git(preparedPath, ['reset', '--hard', base])
+          git(repo, [
+            'worktree',
+            'lock',
+            '--reason',
+            `orca-create-preparation:v1:${process.pid}:${index}`,
+            preparedPath
+          ])
+        })
+      )
+      samples.submit.push(
+        time(() => {
+          const targetHead = git(repo, ['rev-parse', '--verify', `${base}^{commit}`])
+          git(preparedPath, ['rev-parse', '--verify', 'HEAD'])
+          git(repo, ['worktree', 'unlock', preparedPath])
+          git(repo, ['worktree', 'move', preparedPath, finalPath])
+          git(finalPath, ['checkout', '--no-track', '-b', finalBranch, targetHead])
+        })
+      )
+      removeWorktree(repo, finalPath, finalBranch)
+
+      const retargetPath = path.join(scratchRoot, `retarget-${index}`)
+      git(repo, ['worktree', 'add', '--detach', '--no-checkout', retargetPath, base])
+      git(retargetPath, ['reset', '--hard', base])
+      git(repo, ['worktree', 'lock', '--reason', 'orca-create-preparation:v1:bench', retargetPath])
+      samples.retarget.push(time(() => git(retargetPath, ['reset', '--hard', retargetBase])))
+      removeWorktree(repo, retargetPath, undefined, true)
+
+      const cancelledPath = path.join(scratchRoot, `cancel-${index}`)
+      git(repo, ['worktree', 'add', '--detach', '--no-checkout', cancelledPath, base])
+      git(cancelledPath, ['reset', '--hard', base])
+      git(repo, ['worktree', 'lock', '--reason', 'orca-create-preparation:v1:bench', cancelledPath])
+      samples.cancel.push(time(() => removeWorktree(repo, cancelledPath, undefined, true)))
+    }
+  } finally {
+    rmSync(scratchRoot, { force: true, recursive: true })
+    git(repo, ['worktree', 'prune'])
+  }
+
+  return {
+    platform: `${process.platform}-${process.arch}`,
+    os: os.release(),
+    gitVersion: git(repo, ['--version']),
+    repo,
+    trackedFiles: Number(git(repo, ['ls-files']).split('\n').filter(Boolean).length),
+    iterations: options.iterations,
+    base,
+    retargetBase,
+    baselineSubmit: summarize(samples.baseline),
+    speculativePrepare: summarize(samples.prepare),
+    speculativeSubmit: summarize(samples.submit),
+    changeBaseAfterPrepare: summarize(samples.retarget),
+    cancelPrepared: summarize(samples.cancel)
+  }
+}
+
+console.log(JSON.stringify(benchmark(parseArgs(process.argv)), null, 2))

--- a/tests/tools/benchmarks/worktree-create-speculation-bench.mjs
+++ b/tests/tools/benchmarks/worktree-create-speculation-bench.mjs
@@ -110,9 +110,9 @@ function benchmark(options) {
         time(() => {
           const targetHead = git(repo, ['rev-parse', '--verify', `${base}^{commit}`])
           git(preparedPath, ['rev-parse', '--verify', 'HEAD'])
-          git(repo, ['worktree', 'unlock', preparedPath])
-          git(repo, ['worktree', 'move', preparedPath, finalPath])
+          git(repo, ['worktree', 'move', '-f', '-f', preparedPath, finalPath])
           git(finalPath, ['checkout', '--no-track', '-b', finalBranch, targetHead])
+          git(repo, ['worktree', 'unlock', finalPath])
         })
       )
       removeWorktree(repo, finalPath, finalBranch)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​605 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​605 |
| Prod | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​779 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​63 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​716 |

<!-- /orca-pr-loc -->

## Summary

- prepare a hidden detached checkout after the existing composer base prefetch, moving the expensive materialization off the submit path
- claim only an exact repository, base, runtime, and workspace-root match; retarget the checkout if the selected base advanced, then move it and attach the final branch
- hide and lock preparations, expire them after five minutes, cap them at three, and clean up preparations left by dead Orca processes
- fall back to ordinary worktree creation for sparse checkouts, existing branches, changed inputs, unsupported moves such as submodule worktrees, or any preparation/finalization failure
- add a reproducible cross-platform benchmark and real-Git lifecycle coverage

This explores the speculative-creation idea raised as a follow-up to #13704.

## Measured impact

Five-iteration medians using the production-equivalent sequence (`--no-checkout`, materialize, lock, target-head probes, unlock, move, and branch attach):

| Host | Tracked files | Ordinary submit | Prepared submit | Reduction |
| --- | ---: | ---: | ---: | ---: |
| Local macOS, Git 2.44 | 20,019 | 6908.8 ms | 413.1 ms | 94% |
| `openclaw`, Linux, Git 2.43 | 20,012 | 1026.0 ms | 327.5 ms | 68% |
| `awin`, Windows, Git 2.55 | 16,622 | 8315.3 ms | 747.7 ms | 91% |

Preparation medians were 6695.1 ms on macOS, 1011.6 ms on Linux, and 8172.7 ms on Windows. Retargeting an already-prepared checkout to another commit took 263.5 ms, 646.4 ms, and 631.6 ms respectively.

The rendered Electron flow completed in 7.0 seconds in the benchmark repository because that checkout currently discovers roughly 430 worktrees and post-create reconciliation dominates. This change measurably removes the Git materialization cost from submit; pathological listing/reconciliation remains separate work.

Run the benchmark with:

```sh
node tests/tools/benchmarks/worktree-create-speculation-bench.mjs --repo /path/to/repo --iterations 5
```

## Compatibility and safety

- `git worktree add --no-checkout` plus `reset --hard` materializes files without firing post-checkout hooks before submit; final branch attachment fires the normal checkout hook from the final path
- native, WSL, and paired-runtime work remain owned by their existing execution host and routing
- direct SSH remains fetch-prefetch-only; this does not add a relay mutation RPC
- there is no remote wire change, and mixed client/server versions retain ordinary creation as the fallback
- folder workspaces are unaffected
- the exact prepare/move/finalize command sequence is covered by the Git 2.25 compatibility contract
- creation-base metadata, local-base refresh suggestions, and `push.autoSetupRemote` behavior are preserved

## Verification

- `pnpm tc`
- focused worktree, WSL-routing, SSH-prefetch, listing-cache, real-Git, and compatibility tests: 53 passed, 11 environment-gated tests skipped locally
- `pnpm run check:code-quality:changed`: zero findings
- `git diff --check`
- Electron/CDP validation: preparation remained absent from the sidebar/store, nested workspace movement used the prepared fast path, and the final branch rendered normally
