### PR TITLE
test(codex): pin Codex read-repair with a real-binary contract check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,6 +31,7 @@ jobs:
       static_analysis: ${{ steps.filter.outputs.static_analysis }}
       typecheck: ${{ steps.filter.outputs.typecheck }}
       git_compatibility: ${{ steps.filter.outputs.git_compatibility }}
+      codex_index_heal_contract: ${{ steps.filter.outputs.codex_index_heal_contract }}
       xterm_patch_sync: ${{ steps.filter.outputs.xterm_patch_sync }}
       shell_contracts: ${{ steps.filter.outputs.shell_contracts }}
       test: ${{ steps.filter.outputs.test }}
@@ -293,6 +294,47 @@ jobs:
             wait "$pid" || status=1
           done
           exit "$status"
+
+  # Why this job: Orca's session index-heal depends on a Codex behavior — a
+  # `thread/read` of an unindexed rollout performs a read-repair that inserts the
+  # `threads` row. Every unit test drives a stub app-server and asserts only that the
+  # call did not error, so if Codex dropped the repair they would all stay green while
+  # the subsystem went inert. This runs the pinned real binary and fails when the
+  # repair stops happening. Pinned because the binary is the thing expected to drift.
+  codex_index_heal_contract:
+    name: Codex index-heal contract
+    needs: [code_paths]
+    if: needs.code_paths.outputs.codex_index_heal_contract == 'true'
+    runs-on: ubuntu-latest
+    env:
+      CODEX_CLI_VERSION: '0.150.1'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/install-node-dependencies
+
+      - name: Install pinned Codex CLI
+        run: |
+          set -euo pipefail
+          npm install --no-audit --no-fund --prefix "$RUNNER_TEMP/codex-cli" \
+            "@openai/codex@$CODEX_CLI_VERSION"
+
+      - name: Verify Codex index-heal contract
+        env:
+          # Why REQUIRED: without a binary the suite skips, and a job that skips
+          # reports success. This turns a failed or missing install into a red test
+          # instead of a green no-op.
+          ORCA_CODEX_CONTRACT_REQUIRED: '1'
+          ORCA_CODEX_CONTRACT_VERSION: ${{ env.CODEX_CLI_VERSION }}
+        run: |
+          set -euo pipefail
+          ORCA_CODEX_CONTRACT_BINARY="$RUNNER_TEMP/codex-cli/node_modules/.bin/codex" \
+            pnpm exec vitest run --config config/vitest.config.ts \
+            src/main/codex/codex-index-heal-binary-contract.test.ts
 
   xterm_patch_sync:
     name: xterm patch sync
@@ -821,6 +863,7 @@ jobs:
       - root_directory_guard
       - typecheck
       - git_compatibility
+      - codex_index_heal_contract
       - xterm_patch_sync
       - shell_contracts
       - test
@@ -851,6 +894,8 @@ jobs:
           TYPECHECK_SHOULD_RUN: ${{ needs.code_paths.outputs.typecheck }}
           GIT_COMPATIBILITY: ${{ needs.git_compatibility.result }}
           GIT_COMPATIBILITY_SHOULD_RUN: ${{ needs.code_paths.outputs.git_compatibility }}
+          CODEX_INDEX_HEAL_CONTRACT: ${{ needs.codex_index_heal_contract.result }}
+          CODEX_INDEX_HEAL_CONTRACT_SHOULD_RUN: ${{ needs.code_paths.outputs.codex_index_heal_contract }}
           XTERM_PATCH_SYNC: ${{ needs.xterm_patch_sync.result }}
           XTERM_PATCH_SYNC_SHOULD_RUN: ${{ needs.code_paths.outputs.xterm_patch_sync }}
           SHELL_CONTRACTS: ${{ needs.shell_contracts.result }}
@@ -896,6 +941,7 @@ jobs:
           check_job static_analysis "$STATIC_ANALYSIS" "$STATIC_ANALYSIS_SHOULD_RUN"
           check_job typecheck "$TYPECHECK" "$TYPECHECK_SHOULD_RUN"
           check_job git_compatibility "$GIT_COMPATIBILITY" "$GIT_COMPATIBILITY_SHOULD_RUN"
+          check_job codex_index_heal_contract "$CODEX_INDEX_HEAL_CONTRACT" "$CODEX_INDEX_HEAL_CONTRACT_SHOULD_RUN"
           check_job xterm_patch_sync "$XTERM_PATCH_SYNC" "$XTERM_PATCH_SYNC_SHOULD_RUN"
           check_job shell_contracts "$SHELL_CONTRACTS" "$SHELL_CONTRACTS_SHOULD_RUN"
           check_job test "$TEST" "$TEST_SHOULD_RUN"

--- a/config/scripts/codex-index-heal-contract-workflow.test.mjs
+++ b/config/scripts/codex-index-heal-contract-workflow.test.mjs
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs'
+import { parse } from 'yaml'
+import { describe, expect, it } from 'vitest'
+
+describe('Codex index-heal contract PR gate', () => {
+  const workflow = parse(readFileSync('.github/workflows/pr.yml', 'utf8'))
+  const job = workflow.jobs.codex_index_heal_contract
+
+  it('installs and verifies against one pinned Codex version', () => {
+    const install = job.steps.find((step) => step.name === 'Install pinned Codex CLI')
+    const verify = job.steps.find((step) => step.name === 'Verify Codex index-heal contract')
+
+    // Why one source: the install and the runtime version assertion drifting apart is
+    // the failure that would leave this job verifying a Codex nobody declared.
+    expect(job.env.CODEX_CLI_VERSION).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(install.run).toContain('"@openai/codex@$CODEX_CLI_VERSION"')
+    expect(verify.env.ORCA_CODEX_CONTRACT_VERSION).toBe('${{ env.CODEX_CLI_VERSION }}')
+
+    // The install prefix and the binary the test is pointed at must be the same tree.
+    expect(install.run).toContain('--prefix "$RUNNER_TEMP/codex-cli"')
+    expect(verify.run).toContain(
+      'ORCA_CODEX_CONTRACT_BINARY="$RUNNER_TEMP/codex-cli/node_modules/.bin/codex"'
+    )
+    expect(verify.run).toContain('src/main/codex/codex-index-heal-binary-contract.test.ts')
+  })
+
+  it('fails rather than skipping when the Codex binary is missing', () => {
+    const verify = job.steps.find((step) => step.name === 'Verify Codex index-heal contract')
+
+    // Why asserted: the contract skips itself without a binary, so a failed install
+    // would otherwise turn this job into a green no-op that verifies nothing.
+    expect(verify.env.ORCA_CODEX_CONTRACT_REQUIRED).toBe('1')
+    expect(job.steps.find((step) => step.name === 'Install pinned Codex CLI').run).toContain(
+      'set -euo pipefail'
+    )
+  })
+})

--- a/config/scripts/pr-code-change-scope.mjs
+++ b/config/scripts/pr-code-change-scope.mjs
@@ -56,6 +56,7 @@ const CODEX_INDEX_HEAL_CONTRACT_PREFIXES = [
   'src/main/codex/codex-session-index-heal',
   'src/main/codex/codex-app-server-session',
   'src/main/codex/codex-state-db',
+  'src/main/sqlite/sync-database',
   'src/main/codex/codex-app-server-capability-signal',
   'src/main/codex/codex-process-exit-deadline',
   'src/main/codex/codex-session-backfill',

--- a/config/scripts/pr-code-change-scope.mjs
+++ b/config/scripts/pr-code-change-scope.mjs
@@ -20,6 +20,7 @@ export const PR_CHECK_JOBS = [
   'static_analysis',
   'typecheck',
   'git_compatibility',
+  'codex_index_heal_contract',
   'xterm_patch_sync',
   'shell_contracts',
   'test',
@@ -46,6 +47,15 @@ const GIT_COMPAT_PREFIXES = [
   'src/main/git/',
   'src/relay/git-',
   'config/scripts/git-binary-compatibility'
+]
+
+// Why narrow: the contract pins Codex's read-repair, so it runs when the heal that
+// depends on it, its app-server transport, or the contract itself changes.
+const CODEX_INDEX_HEAL_CONTRACT_PREFIXES = [
+  'src/main/codex/codex-index-heal-binary-contract',
+  'src/main/codex/codex-session-index-heal',
+  'src/main/codex/codex-app-server-session',
+  'src/main/codex/codex-state-db'
 ]
 
 const XTERM_PREFIXES = [
@@ -256,6 +266,9 @@ function jobDetector(job) {
   switch (job) {
     case 'git_compatibility':
       return (files) => files.some((file) => matchesPrefix(file, GIT_COMPAT_PREFIXES))
+    case 'codex_index_heal_contract':
+      return (files) =>
+        files.some((file) => matchesPrefix(file, CODEX_INDEX_HEAL_CONTRACT_PREFIXES))
     case 'xterm_patch_sync':
       return (files) => files.some((file) => matchesPrefix(file, XTERM_PREFIXES))
     case 'shell_contracts':

--- a/config/scripts/pr-code-change-scope.mjs
+++ b/config/scripts/pr-code-change-scope.mjs
@@ -55,7 +55,15 @@ const CODEX_INDEX_HEAL_CONTRACT_PREFIXES = [
   'src/main/codex/codex-index-heal-binary-contract',
   'src/main/codex/codex-session-index-heal',
   'src/main/codex/codex-app-server-session',
-  'src/main/codex/codex-state-db'
+  'src/main/codex/codex-state-db',
+  'src/main/codex/codex-app-server-capability-signal',
+  'src/main/codex/codex-process-exit-deadline',
+  'src/main/codex/codex-session-backfill',
+  'src/main/codex/codex-session-index-heal-state',
+  'src/main/codex-cli/command',
+  'src/main/win32-utils',
+  'src/shared/node-cli-command-resolution',
+  'src/shared/windows-batch-spawn'
 ]
 
 const XTERM_PREFIXES = [

--- a/config/scripts/pr-code-change-scope.test.mjs
+++ b/config/scripts/pr-code-change-scope.test.mjs
@@ -133,6 +133,23 @@ describe('per-job path classification', () => {
     expectClassification(['src/main/codex/codex-index-heal-binary-contract.test.ts'], {
       codex_index_heal_contract: true
     })
+    // Keep the real-binary gate live when a transport or launch dependency changes.
+    for (const file of [
+      'src/main/codex/codex-app-server-capability-signal.ts',
+      'src/main/codex/codex-process-exit-deadline.ts',
+      'src/main/codex/codex-session-backfill.ts',
+      'src/main/codex/codex-session-index-heal-state.ts',
+      'src/main/codex-cli/command.ts',
+      'src/main/win32-utils.ts',
+      'src/shared/node-cli-command-resolution.ts',
+      'src/shared/windows-batch-spawn.ts'
+    ]) {
+      expectClassification([file], {
+        codex_index_heal_contract: true,
+        package: true,
+        package_windows: true
+      })
+    }
     // A neighbouring Codex module must not drag the real-binary job in.
     expectClassification(['src/main/codex/codex-home-paths.ts'], {
       package: true,

--- a/config/scripts/pr-code-change-scope.test.mjs
+++ b/config/scripts/pr-code-change-scope.test.mjs
@@ -17,6 +17,7 @@ const expensiveJobs = [
   'static_analysis',
   'typecheck',
   'git_compatibility',
+  'codex_index_heal_contract',
   'xterm_patch_sync',
   'shell_contracts',
   'test',
@@ -115,6 +116,27 @@ describe('per-job path classification', () => {
     })
     expectClassification(['src/shared/git-binary-compatibility.test.ts'], {
       git_compatibility: true
+    })
+  })
+
+  it('runs the Codex index-heal contract only when the heal or its transport changes', () => {
+    expectClassification(['src/main/codex/codex-session-index-heal.ts'], {
+      codex_index_heal_contract: true,
+      package: true,
+      package_windows: true
+    })
+    expectClassification(['src/main/codex/codex-app-server-session.ts'], {
+      codex_index_heal_contract: true,
+      package: true,
+      package_windows: true
+    })
+    expectClassification(['src/main/codex/codex-index-heal-binary-contract.test.ts'], {
+      codex_index_heal_contract: true
+    })
+    // A neighbouring Codex module must not drag the real-binary job in.
+    expectClassification(['src/main/codex/codex-home-paths.ts'], {
+      package: true,
+      package_windows: true
     })
   })
 

--- a/config/scripts/pr-code-change-scope.test.mjs
+++ b/config/scripts/pr-code-change-scope.test.mjs
@@ -125,6 +125,11 @@ describe('per-job path classification', () => {
       package: true,
       package_windows: true
     })
+    expectClassification(['src/main/sqlite/sync-database.ts'], {
+      codex_index_heal_contract: true,
+      package: true,
+      package_windows: true
+    })
     expectClassification(['src/main/codex/codex-app-server-session.ts'], {
       codex_index_heal_contract: true,
       package: true,

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -410,6 +410,7 @@ describe('PR workflow parallelism', () => {
       'root_directory_guard',
       'typecheck',
       'git_compatibility',
+      'codex_index_heal_contract',
       'xterm_patch_sync',
       'shell_contracts',
       'test',

--- a/src/main/codex/codex-index-heal-binary-contract.test.ts
+++ b/src/main/codex/codex-index-heal-binary-contract.test.ts
@@ -53,8 +53,8 @@ describeCodexContract('codex binary index-heal contract', () => {
     // Why assert the version: the whole point of a real-binary check is that the
     // binary drifts. A job that quietly ran some other Codex would report a
     // contract this repo never verified.
-    const { stdout } = await execFileAsync(binary!, ['--version'])
-    expect(stdout).toContain(`codex-cli ${expectedVersion}`)
+    const { stdout } = await execFileAsync(binary!, ['--version'], { timeout: SESSION_TIMEOUT_MS })
+    expect(stdout.trim()).toBe(`codex-cli ${expectedVersion}`)
   })
 
   afterEach(() => {

--- a/src/main/codex/codex-index-heal-binary-contract.test.ts
+++ b/src/main/codex/codex-index-heal-binary-contract.test.ts
@@ -1,0 +1,204 @@
+import { execFile } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import SyncDatabase from '../sqlite/sync-database'
+import { runCodexAppServerSession, type CodexAppServerRpc } from './codex-app-server-session'
+import { findNewestCodexStateDbPath } from './codex-state-db'
+
+// Why this file exists: every other index-heal test drives a stub app-server and
+// asserts "healed" as "the `thread/read` call did not error". That pins Orca's half
+// of the contract and nothing about Codex's. The behavior Orca actually depends on
+// lives in the Codex binary — a read of an unindexed rollout performs a read-repair
+// that inserts the `threads` row. If Codex ever dropped that repair, the stub-driven
+// tests would all stay green while the subsystem went silently inert. This is the
+// real-binary backstop, built to the same shape as the Git binary compatibility
+// contract in src/shared/git-binary-compatibility.test.ts.
+//
+// Keep it narrow. It pins the four arms that ablation established Orca relies on,
+// and deliberately asserts nothing else about the app-server, so an unrelated Codex
+// release does not redden it into being disabled.
+
+const execFileAsync = promisify(execFile)
+const binary = process.env.ORCA_CODEX_CONTRACT_BINARY
+const expectedVersion = process.env.ORCA_CODEX_CONTRACT_VERSION
+const describeCodexContract = binary ? describe : describe.skip
+
+// Why this guard: skipping is the right local-dev default, but a CI job whose whole
+// purpose is the real binary must not pass by reporting zero assertions. The job sets
+// ORCA_CODEX_CONTRACT_REQUIRED=1, which turns a missing binary into a red test.
+describe.runIf(process.env.ORCA_CODEX_CONTRACT_REQUIRED === '1' && !binary)(
+  'codex binary index-heal contract prerequisites',
+  () => {
+    it('was given a Codex binary to run against', () => {
+      expect.fail(
+        'ORCA_CODEX_CONTRACT_REQUIRED=1 but ORCA_CODEX_CONTRACT_BINARY is unset, so the contract would have silently skipped'
+      )
+    })
+  }
+)
+
+// Why fixed: `thread/read` never reaches the network, and a whole session is
+// spawn + initialize + one RPC. A generous ceiling still fails fast on a wedged child.
+const SESSION_TIMEOUT_MS = 60_000
+
+type ThreadRow = { id: string; archived: number }
+
+describeCodexContract('codex binary index-heal contract', () => {
+  const disposableHomes: string[] = []
+
+  beforeAll(async () => {
+    // Why assert the version: the whole point of a real-binary check is that the
+    // binary drifts. A job that quietly ran some other Codex would report a
+    // contract this repo never verified.
+    const { stdout } = await execFileAsync(binary!, ['--version'])
+    expect(stdout).toContain(`codex-cli ${expectedVersion}`)
+  })
+
+  afterEach(() => {
+    while (disposableHomes.length > 0) {
+      rmSync(disposableHomes.pop() as string, { recursive: true, force: true })
+    }
+  })
+
+  /**
+   * Builds a disposable CODEX_HOME in the state Orca actually heals from: Codex's
+   * own one-shot sqlite backfill has already run and stamped itself `complete`, so
+   * rollouts that appear afterwards are exactly the ones it will never index on its
+   * own. Never points at the user's real ~/.codex.
+   */
+  async function createBackfilledCodexHome(): Promise<string> {
+    const home = mkdtempSync(join(tmpdir(), 'orca-codex-heal-contract-'))
+    disposableHomes.push(home)
+    mkdirSync(join(home, 'sessions'), { recursive: true })
+    // An app-server session over an empty sessions tree is what stamps the backfill complete.
+    await runAppServerSession(home, async () => undefined)
+    expect(readThreadRows(home)).toEqual([])
+    return home
+  }
+
+  function writeRollout(home: string, threadId: string, stamp: string): void {
+    const dayDir = join(home, 'sessions', '2026', '08', '29')
+    mkdirSync(dayDir, { recursive: true })
+    const meta = {
+      timestamp: '2026-08-29T21:17:33.760Z',
+      ordinal: 0,
+      type: 'session_meta',
+      payload: {
+        session_id: threadId,
+        id: threadId,
+        timestamp: '2026-08-29T21:17:26.840Z',
+        cwd: tmpdir(),
+        originator: 'codex-tui',
+        cli_version: expectedVersion,
+        source: 'cli',
+        thread_source: 'user',
+        model_provider: 'openai'
+      }
+    }
+    const userMessage = {
+      timestamp: '2026-08-29T21:17:40.000Z',
+      ordinal: 1,
+      type: 'event_msg',
+      payload: { type: 'user_message', message: 'index-heal contract fixture' }
+    }
+    writeFileSync(
+      join(dayDir, `rollout-${stamp}-${threadId}.jsonl`),
+      `${JSON.stringify(meta)}\n${JSON.stringify(userMessage)}\n`
+    )
+  }
+
+  // Why reuse runCodexAppServerSession rather than a local JSON-RPC client: it is the
+  // transport the heal itself uses, so a framing or handshake regression that would
+  // break the heal breaks this check too.
+  async function runAppServerSession<T>(
+    home: string,
+    body: (rpc: CodexAppServerRpc) => Promise<T>
+  ): Promise<T> {
+    return runCodexAppServerSession(
+      {
+        command: binary!,
+        args: ['app-server'],
+        cliPath: binary!,
+        env: { CODEX_HOME: home },
+        timeoutMs: SESSION_TIMEOUT_MS
+      },
+      body
+    )
+  }
+
+  function readThreadRows(home: string): ThreadRow[] {
+    const stateDbPath = findNewestCodexStateDbPath(home)
+    if (!stateDbPath) {
+      return []
+    }
+    const db = new SyncDatabase(stateDbPath, { readonly: true, fileMustExist: true })
+    try {
+      return db
+        .prepare('SELECT id, archived FROM threads ORDER BY id')
+        .all() as unknown as ThreadRow[]
+    } finally {
+      db.close()
+    }
+  }
+
+  // Arms 1 and 2 are one test on purpose: the "no read" pass is the negative control
+  // that makes the insert causal rather than incidental. Split across two tests they
+  // would run against two different homes and prove nothing about each other.
+  it('inserts the state row because of the read, not because the server ran', async () => {
+    const home = await createBackfilledCodexHome()
+    const threadId = '01a04f62-715e-7830-9371-50db585caa71'
+    writeRollout(home, threadId, '2026-08-29T14-17-26')
+
+    // Control: a complete app-server session that issues no `thread/read`.
+    await runAppServerSession(home, async () => undefined)
+    expect(readThreadRows(home)).toEqual([])
+
+    await runAppServerSession(home, async (rpc) => {
+      await rpc.request('thread/read', { threadId })
+    })
+
+    expect(readThreadRows(home)).toEqual([{ id: threadId, archived: 0 }])
+  })
+
+  it('leaves an already-indexed thread as a single row', async () => {
+    const home = await createBackfilledCodexHome()
+    const threadId = '01a04f62-715e-7830-9371-50db585caa72'
+    writeRollout(home, threadId, '2026-08-29T15-00-00')
+
+    await runAppServerSession(home, async (rpc) => {
+      await rpc.request('thread/read', { threadId })
+    })
+    expect(readThreadRows(home)).toEqual([{ id: threadId, archived: 0 }])
+
+    await runAppServerSession(home, async (rpc) => {
+      await rpc.request('thread/read', { threadId })
+    })
+
+    expect(readThreadRows(home)).toEqual([{ id: threadId, archived: 0 }])
+  })
+
+  // Why this arm: the heal reads tens of thousands of rollouts. If a read cleared
+  // `archived`, the pass would silently resurrect every thread the user had archived.
+  it('stamps an archived thread archived rather than resurrecting it', async () => {
+    const home = await createBackfilledCodexHome()
+    const threadId = '01a04f62-715e-7830-9371-50db585caa73'
+    writeRollout(home, threadId, '2026-08-29T16-00-00')
+
+    // The archived state is created here, never assumed: a real Codex home may
+    // never have had a thread archived, and this arm would then pass vacuously.
+    await runAppServerSession(home, async (rpc) => {
+      await rpc.request('thread/read', { threadId })
+      await rpc.request('thread/archive', { threadId })
+    })
+    expect(readThreadRows(home)).toEqual([{ id: threadId, archived: 1 }])
+
+    await runAppServerSession(home, async (rpc) => {
+      await rpc.request('thread/read', { threadId })
+    })
+
+    expect(readThreadRows(home)).toEqual([{ id: threadId, archived: 1 }])
+  })
+})

--- a/src/main/codex/codex-index-heal-binary-contract.test.ts
+++ b/src/main/codex/codex-index-heal-binary-contract.test.ts
@@ -43,9 +43,9 @@ describe.runIf(process.env.ORCA_CODEX_CONTRACT_REQUIRED === '1' && !binary)(
 // Why fixed: `thread/read` never reaches the network, and a whole session is
 // spawn + initialize + one RPC. A generous ceiling still fails fast on a wedged child.
 const SESSION_TIMEOUT_MS = 60_000
-// Why: each contract case can use two bounded app-server sessions; keep Vitest's
+// Why: each contract case can use three bounded app-server sessions; keep Vitest's
 // watchdog longer than both child deadlines so cleanup cannot race a test timeout.
-const CONTRACT_TEST_TIMEOUT_MS = SESSION_TIMEOUT_MS * 2 + 10_000
+const CONTRACT_TEST_TIMEOUT_MS = SESSION_TIMEOUT_MS * 3 + 10_000
 
 type ThreadRow = { id: string; archived: number }
 

--- a/src/main/codex/codex-index-heal-binary-contract.test.ts
+++ b/src/main/codex/codex-index-heal-binary-contract.test.ts
@@ -43,10 +43,16 @@ describe.runIf(process.env.ORCA_CODEX_CONTRACT_REQUIRED === '1' && !binary)(
 // Why fixed: `thread/read` never reaches the network, and a whole session is
 // spawn + initialize + one RPC. A generous ceiling still fails fast on a wedged child.
 const SESSION_TIMEOUT_MS = 60_000
+// Why: each contract case can use two bounded app-server sessions; keep Vitest's
+// watchdog longer than both child deadlines so cleanup cannot race a test timeout.
+const CONTRACT_TEST_TIMEOUT_MS = SESSION_TIMEOUT_MS * 2 + 10_000
 
 type ThreadRow = { id: string; archived: number }
 
-describeCodexContract('codex binary index-heal contract', () => {
+describeCodexContract(
+  'codex binary index-heal contract',
+  { timeout: CONTRACT_TEST_TIMEOUT_MS },
+  () => {
   const disposableHomes: string[] = []
 
   beforeAll(async () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​292 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​292 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 |

<!-- /orca-pr-loc -->

## ELI5

Orca copies your old Codex chat sessions into Codex's real home so they show up in Codex's sidebar. Codex only builds its search index **once**, so anything Orca adds afterwards is invisible until someone asks Codex to open it. Orca's "index heal" does exactly that — it opens each session, and Codex quietly files it away properly. That filing step is Codex's behaviour, not Orca's.

Every test we had for this asked Codex to open a session and checked "did that crash?" — using a **fake** Codex. So if the real Codex ever stopped doing the filing, every test would still pass and the feature would quietly do nothing. This PR adds one check that runs the **real** Codex and fails if the filing stops happening.

## User-facing before/after

**No user-visible change today.** This adds no product behaviour and changes no existing code path.

What it would catch: a future Codex release that drops read-repair on `thread/read`. Today that would land silently — index heal would keep reporting tens of thousands of "healed" sessions while indexing none of them, and backfilled sessions would stop appearing in Codex's history. With this check, that release turns the PR job red instead.

## What this is

Index heal is live, not inert: a read of an unindexed rollout is what inserts the `threads` row. But all 55 existing tests (`codex-session-index-heal` 21, `-state` 9, `migration-scheduler` 25) drive a stub app-server and assert "healed" as *the call did not error*. They pin Orca's half of the contract and nothing about Codex's.

## Following the existing precedent

`docs/reference/git-compatibility.md` already establishes that version boundaries are held by a **real-binary compatibility contract in PR CI rather than by mocks**. This matches that mechanism rather than inventing a new shape:

| `git-binary-compatibility.test.ts` | this check |
| --- | --- |
| `ORCA_GIT_COMPAT_BINARY` gates `describe`/`describe.skip` | `ORCA_CODEX_CONTRACT_BINARY`, same pattern |
| `ORCA_GIT_COMPAT_VERSION` asserted against `git --version` in `beforeAll` | `ORCA_CODEX_CONTRACT_VERSION` asserted against `codex --version` |
| `git_compatibility` job, path-filtered via `code_paths` | `codex_index_heal_contract` job, same filter + `verify` aggregation |
| Unit tests kept alongside the matrix | all 55 existing tests kept, untouched |

One deliberate difference: the Git job always supplies a binary, so skipping is not a live risk. Here the job also sets `ORCA_CODEX_CONTRACT_REQUIRED=1`, which turns a missing binary into a **red test** rather than a job that passes by skipping.

The check reuses `runCodexAppServerSession` (the transport index heal itself uses) and `findNewestCodexStateDbPath`, instead of reimplementing JSON-RPC framing or sqlite discovery.

## The four arms, and only these four

Deliberately narrow — a contract that asserts everything the binary does breaks on every unrelated Codex release and gets disabled.

1. A read of an unindexed rollout **inserts** the state row.
2. **No read inserts nothing** — same fixture, same test, so the insert is causal rather than incidental.
3. Re-reading an already-indexed thread inserts nothing.
4. An archived thread is **stamped archived, not resurrected**.

Arms 1 and 2 are one test on purpose: split apart they would run against different homes and prove nothing about each other.

Arm 4 creates the archived state itself via `thread/archive`. It never assumes a home has archived history — a real Codex home may have none, and the arm would then pass vacuously.

## Version scope

Written against **codex-cli 0.150.1**, pinned in the workflow as `CODEX_CLI_VERSION` and asserted at runtime. The binary is the thing expected to drift; when it does, this check is where that shows up. A wrong-version binary fails rather than silently reporting a contract this repo never verified.

## Proof it fails when the repair stops

A check nobody has watched fail is the same false comfort as the tests it backstops. Three ablations, all run:

| Ablation | Result |
| --- | --- |
| Codex replaced by a shim that answers `thread/read` **successfully** but performs no repair | **3/3 red** |
| Version claimed `0.999.0` against the real `0.150.1` binary | **red** (`beforeAll` fails) |
| `ORCA_CODEX_CONTRACT_REQUIRED=1` with no binary | **red** (would otherwise have skipped) |
| Real `codex-cli 0.150.1` | 3 passed |
| No env at all (local dev) | 4 skipped, exit 0 |

The shim is the precise simulation: its `thread/read` returns success, which is exactly what the 55 existing tests assert. Under that same shim the existing tests stay **green** — that is the gap this closes.

## Workflow contract

Mirroring `git-binary-compatibility-workflow.test.mjs`, `config/scripts/codex-index-heal-contract-workflow.test.mjs` pins the job's own wiring — because the realistic drift here is the pinned version flowing to two places:

- `CODEX_CLI_VERSION` is the single source for both the npm install and the runtime version assertion, so they cannot drift apart
- the install prefix and the binary path the test is pointed at are the same tree
- `ORCA_CODEX_CONTRACT_REQUIRED=1` is set

Removing the `REQUIRED` env from `pr.yml` reddens that test, confirming it is live.

## Verification

- Contract vs. real binary: **3 passed**
- Existing heal tests: **55 passed**, unchanged (21 + 9 + 25)
- `config/scripts/pr-code-change-scope.test.mjs`: **25 passed** (added a case; the new job is in the `expensiveJobs` wiring ratchet, so its `needs`/`if`/`outputs` are verified)
- `pnpm tc`: exit 0, 0 `error TS`, incremental state cleared first
- `oxlint` (base, native code-quality, type-aware): clean — each proven live on this file with a deliberate violation first
- `oxfmt` applied
- Full `config/scripts` suite: **1044 passed** (the first push missed `pr-workflow-parallelism.test.mjs`, which pins `verify.needs` exactly; fixed in the second commit)
- CI: **24 checks pass, 0 red, 2 skipping**, attempt 1 on run 2. The `Codex index-heal contract` job ran the real binary on Linux and reported `3 passed | 1 skipped` in 3.9s — the 1 skipped is the prerequisites guard, correctly inert because a binary was supplied.

## Safety

All probing used **disposable** Codex homes (`mkdtempSync`, and a scratch dir under `~/orca-qa/`). The user's real `~/.codex` was treated as read-only: inspected only via `ls` and `sqlite3 file:…?immutable=1`, which creates no `-wal`/`-shm`. Nothing was written, moved, renamed, or deleted there.
