### PR TITLE
test(cross-version-wire): compare published fields per frame

### DIFF
--- a/docs/reference/remote-wire-compatibility.md
+++ b/docs/reference/remote-wire-compatibility.md
@@ -91,9 +91,11 @@ pnpm exec vitest run --config config/vitest.config.ts tests/e2e/cross-version-wi
 
 It fails when a frame is refused by the receiving build's decoder (Rule 2), when the
 observed frame sequence changes (Rule 3), or when published snapshot content or
-negotiated capabilities differ from the contract. Adding an optional field keeps it
-green (Rule 1); making a client depend on that field turns the new-client/old-host
-pairing red.
+negotiated capabilities differ from the contract. Repeated frame shapes are compared
+by corresponding journey occurrence (initial, reveal, reconnect), so a field removed
+from one occurrence cannot hide behind a sibling that still publishes it. Adding an
+optional field keeps the suite green (Rule 1); making a client depend on that field
+turns the new-client/old-host pairing red.
 
 ### Never write down what the old side has
 
@@ -109,8 +111,11 @@ Derive the expectation from the baseline that was actually checked out:
 
 - for a published frame, pair each build against a client of its own version and
   compare the skewed pairing against that same-version reference, so the expectation
-  is whatever that build publishes today (`publishedFieldNames` in
-  `tests/e2e/cross-version-wire/published-field-shape.ts`);
+  is whatever that build publishes today. Compare repeated frames by corresponding
+  occurrence with `comparePublishedFieldOccurrences` in
+  `tests/e2e/cross-version-wire/published-field-shape.ts`; never union keys across
+  initial, reveal, and reconnect frames, because a sibling can mask one occurrence's
+  removed field;
 - for a negotiated surface, read the old build's advertised capabilities and
   registered method names from its checkout, and assert they agree with each other
   rather than asserting the old build lacks them;

--- a/tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
@@ -9,7 +9,7 @@
 // same-version reference pairing of the build that publishes the frame.
 
 import { afterEach, beforeAll, describe, expect, it } from 'vitest'
-import { comparePublishedFields, publishedFieldNames } from './published-field-shape'
+import { comparePublishedFieldOccurrences, publishedFieldNames } from './published-field-shape'
 import { resolveBaselineReleaseRef, selectLatestStableReleaseTag } from './release-checkout'
 import {
   CrossVersionJourneyStall,
@@ -51,6 +51,7 @@ const EXPECTED_JOURNEY_FRAMES = [
   'C>H Input',
   'C>H Unsubscribe'
 ]
+const SNAPSHOT_START_OCCURRENCES = ['initial', 'reveal', 'reconnect'] as const
 
 let baselineRef: string
 let current: TerminalWireBuild
@@ -81,6 +82,23 @@ function expectJourneyActuallyRan(record: JourneyRecord): void {
   expect(record.subscribedEvents).toHaveLength(2)
   expect(record.snapshotStarts).toHaveLength(3)
   expect(record.missingRuntimeMethods).toEqual([])
+}
+
+function expectSnapshotStartFieldsRemainPublished(args: {
+  older: readonly Record<string, unknown>[]
+  newer: readonly Record<string, unknown>[]
+  olderLabel: string
+  newerLabel: string
+}): void {
+  const skewByOccurrence = comparePublishedFieldOccurrences(args)
+  for (const [index, skew] of skewByOccurrence.entries()) {
+    const occurrence = SNAPSHOT_START_OCCURRENCES[index] ?? `occurrence ${index + 1}`
+    expect(
+      skew.removed,
+      `${args.newerLabel} stopped publishing ${occurrence} SnapshotStart fields ` +
+        `${args.olderLabel} publishes (it added: ${skew.added.join(', ') || 'nothing'})`
+    ).toEqual([])
+  }
 }
 
 function expectWireCompatible(record: JourneyRecord): void {
@@ -151,7 +169,9 @@ describe('cross-version remote terminal wire', () => {
     expectWireCompatible(baselineReference)
     // Anti-vacuous: a reference read from a pairing that published nothing would
     // make every comparison against it trivially true.
-    expect(publishedFieldNames(baselineReference.snapshotStarts).length).toBeGreaterThan(4)
+    for (const start of baselineReference.snapshotStarts) {
+      expect(publishedFieldNames(start).length).toBeGreaterThan(4)
+    }
   })
 
   it(
@@ -185,18 +205,35 @@ describe('cross-version remote terminal wire', () => {
   )
 
   it('adds SnapshotStart fields rather than dropping ones the old host still publishes', () => {
-    const skew = comparePublishedFields({
-      older: publishedFieldNames(baselineReference.snapshotStarts),
-      newer: publishedFieldNames(currentReference.snapshotStarts)
-    })
     // Rule 1 is additive-only. A field the old host still publishes is one an old
     // client may still read, so dropping it breaks that client with no opcode
     // change for the decoder check to catch.
-    expect(
-      skew.removed,
-      `current code stopped publishing SnapshotStart fields ${baselineRef} still publishes ` +
-        `(it added: ${skew.added.join(', ') || 'nothing'})`
-    ).toEqual([])
+    expectSnapshotStartFieldsRemainPublished({
+      older: baselineReference.snapshotStarts,
+      newer: currentReference.snapshotStarts,
+      olderLabel: baselineRef,
+      newerLabel: 'current code'
+    })
+  })
+
+  it('detects a field removed from only the reveal SnapshotStart occurrence', () => {
+    const mutated = currentReference.snapshotStarts.map((start) => ({ ...start }))
+    const revealIndex = SNAPSHOT_START_OCCURRENCES.indexOf('reveal')
+    const reveal = mutated[revealIndex]
+    if (!reveal) {
+      throw new Error('The terminal journey did not publish a reveal SnapshotStart')
+    }
+    expect(reveal).toHaveProperty('seq')
+    delete reveal.seq
+
+    expect(() =>
+      expectSnapshotStartFieldsRemainPublished({
+        older: currentReference.snapshotStarts,
+        newer: mutated,
+        olderLabel: 'current reference',
+        newerLabel: 'current mutation'
+      })
+    ).toThrow(/reveal SnapshotStart fields.*seq/)
   })
 
   it(

--- a/tests/e2e/cross-version-wire/published-field-shape.ts
+++ b/tests/e2e/cross-version-wire/published-field-shape.ts
@@ -16,9 +16,9 @@ export type PublishedFieldSkew = {
   removed: string[]
 }
 
-/** Sorted union of the keys across one published frame sequence. */
-export function publishedFieldNames(payloads: Record<string, unknown>[]): string[] {
-  return [...new Set(payloads.flatMap((payload) => Object.keys(payload)))].sort()
+/** Sorted keys from one published frame occurrence. */
+export function publishedFieldNames(payload: Record<string, unknown>): string[] {
+  return Object.keys(payload).sort()
 }
 
 /**
@@ -35,4 +35,27 @@ export function comparePublishedFields(args: {
     added: [...newer].filter((name) => !older.has(name)).sort(),
     removed: [...older].filter((name) => !newer.has(name)).sort()
   }
+}
+
+/** Compare corresponding occurrences without letting sibling frames hide a removal. */
+export function comparePublishedFieldOccurrences(args: {
+  older: readonly Record<string, unknown>[]
+  newer: readonly Record<string, unknown>[]
+}): PublishedFieldSkew[] {
+  if (args.older.length !== args.newer.length) {
+    throw new Error(
+      `Published frame occurrence count differs: older ${args.older.length}, newer ${args.newer.length}`
+    )
+  }
+
+  return args.older.map((older, index) => {
+    const newer = args.newer[index]
+    if (!newer) {
+      throw new Error(`Missing newer published frame occurrence ${index + 1}`)
+    }
+    return comparePublishedFields({
+      older: publishedFieldNames(older),
+      newer: publishedFieldNames(newer)
+    })
+  })
 }

--- a/tests/e2e/cross-version-wire/published-field-shape.unit.test.ts
+++ b/tests/e2e/cross-version-wire/published-field-shape.unit.test.ts
@@ -1,19 +1,51 @@
 import { describe, expect, it } from 'vitest'
-import { comparePublishedFields, publishedFieldNames } from './published-field-shape'
+import {
+  comparePublishedFieldOccurrences,
+  comparePublishedFields,
+  publishedFieldNames
+} from './published-field-shape'
 
 describe('published field shape', () => {
-  it('unions the keys across a frame sequence, so a field only one frame carries counts', () => {
-    expect(
-      publishedFieldNames([
-        { kind: 'scrollback', seq: 0 },
-        { kind: 'scrollback', seq: 27, requestId: 1 },
-        { kind: 'scrollback', seq: 27 }
-      ])
-    ).toEqual(['kind', 'requestId', 'seq'])
+  it('sorts the keys from one published frame occurrence', () => {
+    expect(publishedFieldNames({ seq: 27, kind: 'scrollback', requestId: 1 })).toEqual([
+      'kind',
+      'requestId',
+      'seq'
+    ])
   })
 
-  it('reads an empty sequence as no fields, which is what the anti-vacuous check tests', () => {
-    expect(publishedFieldNames([])).toEqual([])
+  it('detects a field removed from only one corresponding occurrence', () => {
+    expect(
+      comparePublishedFieldOccurrences({
+        older: [
+          { kind: 'scrollback', seq: 0 },
+          { kind: 'scrollback', seq: 27, requestId: 1 },
+          { kind: 'scrollback', seq: 27 }
+        ],
+        newer: [
+          { kind: 'scrollback', seq: 0 },
+          { kind: 'scrollback', requestId: 1 },
+          { kind: 'scrollback', seq: 27 }
+        ]
+      })
+    ).toEqual([
+      { added: [], removed: [] },
+      { added: [], removed: ['seq'] },
+      { added: [], removed: [] }
+    ])
+  })
+
+  it('rejects unequal occurrence counts instead of truncating the comparison', () => {
+    expect(() =>
+      comparePublishedFieldOccurrences({
+        older: [{ kind: 'scrollback' }, { kind: 'scrollback' }],
+        newer: [{ kind: 'scrollback' }]
+      })
+    ).toThrow(/occurrence count differs: older 2, newer 1/)
+  })
+
+  it('reads an empty payload as no fields, which is what the anti-vacuous check tests', () => {
+    expect(publishedFieldNames({})).toEqual([])
   })
 
   it('reports an added field as added and nothing as removed', () => {


### PR DESCRIPTION
## ELI5

The cross-version test checked which fields Orca publishes by combining all three snapshot-start frames into one set. That let one healthy frame hide a field missing from another. The test now compares initial to initial, reveal to reveal, and reconnect to reconnect.

## Root cause

`publishedFieldNames()` unioned keys across every `SnapshotStart` occurrence. If the reveal frame stopped publishing `seq`, the initial and reconnect frames still contributed `seq` to the union, so the additive-only compatibility oracle stayed green.

This was an oracle defect, not a wire defect. The correction belongs in the cross-version test helper and adds no production behavior.

## What changed

- Read sorted field names from one published frame rather than a sequence-wide union.
- Compare corresponding initial, reveal, and reconnect occurrences.
- Reject unequal occurrence counts before comparison, avoiding silent zip truncation.
- Keep occurrence labels in the terminal-domain assertion so failures name the exact journey step.
- Add a real-suite mutation that clones the current reference, proves reveal currently has `seq`, removes only that field, and verifies the oracle fails with `reveal` and `seq` in the diagnostic.
- Document why repeated frames must never be unioned.

Follow-up to #17178.

## Red / green proof

Before the helper change, the reveal-only mutation failed its proving test:

```text
AssertionError: expected [] to deeply equal [ 'seq' ]
```

The aggregate oracle saw no removal because sibling frames still published `seq`.

After the change, the same shape is detected at the reveal occurrence. The committed regression runs through the exact `expectSnapshotStartFieldsRemainPublished → comparePublishedFieldOccurrences` path used by the real baseline/current gate.

## Exact-head verification

Published head: `5abd60553f397343869922a1babb1bdb425ef5ed`

- Focused helper + real terminal suite: 2 files / 17 tests passed.
- `pnpm tc`: passed.
- `pnpm run check:code-quality:changed`: zero code, type-aware, and React Doctor findings across 3 changed code files.
- `pnpm run check:reliability-gates`: 99 gates valid.
- `pnpm exec oxfmt --check` on all four changed files: passed.
- `git diff --check`: passed.

## Readiness and code elegance

Independent audits found zero proven P0/P1/P2 findings; counsel was unnecessary because there were no candidates.

- Exactly four files change: three test/helper files and the existing remote-wire reference.
- No production, protocol, RPC/IPC, SSH, relay, mobile, persistence, dependency, packaging, provider, platform, or workspace behavior changes.
- The mutation reuses the already-loaded current reference; it adds no journey, checkout, process, network request, polling, or runtime cost beyond in-memory object cloning.
- No release field list is hard-coded. Literal `seq` exists only as a mutation of the current build's observed contract.
- Equal-count enforcement, direct helper coverage, real-oracle mutation coverage, and occurrence-specific diagnostics remain cohesive; no parallel comparator was added.
- The regression is in `cross-version-terminal-wire.unit.test.ts`, which the dedicated cross-version CI job actually executes.

Native-host and Electron verification are N/A because this PR changes only test-oracle and documentation code.

## Visual proof

N/A — no rendered Orca UI surface changes.

## AI disclosure

AI-assisted implementation, mutation construction, and review were used. All claims above are tied to the exact committed diff and test output.

## Checklist

- [x] Root oracle defect fixed rather than baseline symptoms allowlisted
- [x] No production or wire behavior changed
- [x] Red/green mutation proof recorded
- [x] Exact real CI oracle carries the regression
- [x] Typecheck, focused tests, reliability manifest, formatting, whitespace, and changed-code quality pass
- [x] Readiness and code-elegance reviews have zero findings
- [x] Fresh GitHub CI run `33282334469` on `5abd60553f3` completed cleanly (18 successful, 9 skipped, 0 failed or pending).
