### PR TITLE
fix(mobile): keep the terminal surface theme-colored until the engine can paint

### DIFF
--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -9,6 +9,7 @@ import {
 } from './terminal-webview-engine-error-state'
 import { TERMINAL_WEBVIEW_FRAME_STYLES } from './terminal-webview-frame-styles'
 import { useTerminalWebReadyWatchdog } from './terminal-webview-ready-watchdog'
+import { useTerminalWebViewPingProbe } from './terminal-webview-ping-probe'
 import { XTERM_WEBVIEW_SOURCE } from './terminal-webview-html'
 import type { TerminalWebViewCommand } from './terminal-webview-messages'
 import { createTerminalWebViewPendingMessages } from './terminal-webview-pending-messages'
@@ -64,9 +65,14 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
   const readyResolveRef = useRef<(() => void) | null>(null)
   const { clearEngineError, engineError, reportEngineError, reportNativeEngineError } =
     useTerminalWebViewEngineErrorState(onEngineError)
+  const webReadyProbeRef = useRef<(() => void) | null>(null)
+  const runWebReadyProbe = useCallback(() => {
+    webReadyProbeRef.current?.()
+  }, [])
   const { armWebReadyWatchdog, clearWebReadyWatchdog } = useTerminalWebReadyWatchdog(
     isWebReadyRef,
-    reportEngineError
+    reportEngineError,
+    runWebReadyProbe
   )
 
   const sendToWebView = useCallback((msg: TerminalWebViewCommand) => {
@@ -79,6 +85,12 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
   const flushPendingMessages = useCallback(() => {
     pendingMessages.flush(sendToWebView)
   }, [pendingMessages, sendToWebView])
+
+  const sendProbePing = useCallback(() => {
+    pendingPingIdRef.current = sendToWebView({ type: 'ping' })
+  }, [sendToWebView])
+  const { attemptPingRecovery, cancelPingProbe, markRecoveryPing, takeProbeNotifyParent } =
+    useTerminalWebViewPingProbe(isWebReadyRef, sendProbePing)
 
   const postMessage = useCallback(
     (msg: TerminalWebViewCommand) => {
@@ -108,6 +120,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     (notifyParent: boolean) => {
       pendingPingIdRef.current = null
       isWebReadyRef.current = true
+      cancelPingProbe()
       clearWebReadyWatchdog()
       clearEngineError()
       if (notifyParent) {
@@ -119,6 +132,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
       flushPendingMessages()
     },
     [
+      cancelPingProbe,
       clearEngineError,
       clearWebReadyWatchdog,
       flushPendingMessages,
@@ -145,7 +159,9 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         typeof msg.pingId === 'number' &&
         msg.pingId === pendingPingIdRef.current
       ) {
-        confirmWebReady(false)
+        // Why: a watchdog/reload probe must notify the parent so it resubscribes and
+        // re-inits (the repaint); the foreground-recovery ping runs its own resubscribe.
+        confirmWebReady(takeProbeNotifyParent())
       } else if (msg.type === 'ready') {
         // Why: the WebView's init() rAF chain has run — term is open,
         // renderService is populated, first paint has happened. Resolve
@@ -198,9 +214,21 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
       onTerminalTap,
       onFileTap,
       onOpenUrl,
-      onTextScaleChange
+      onTextScaleChange,
+      takeProbeNotifyParent
     ]
   )
+
+  useEffect(() => {
+    webReadyProbeRef.current = () => {
+      attemptPingRecovery(true, () =>
+        reportEngineError(
+          'Terminal did not initialize - no ready signal from the terminal view',
+          true
+        )
+      )
+    }
+  }, [attemptPingRecovery, reportEngineError])
 
   const handleLoadStart = useCallback(() => {
     isWebReadyRef.current = false
@@ -215,8 +243,10 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
 
   const handleReload = useCallback(() => {
     clearEngineError()
-    webViewRef.current?.reload()
-  }, [clearEngineError])
+    // Why: in the wedged live-document state, reload reproduces the same error while a
+    // ping recovers instantly (the app-switch cure); reload stays as the last resort.
+    attemptPingRecovery(true, () => webViewRef.current?.reload())
+  }, [attemptPingRecovery, clearEngineError])
 
   const handleContentProcessDidTerminate = useCallback(() => {
     // Why: WKWebView content-process loss is recoverable; stale commands belong
@@ -253,6 +283,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         // Why: a blanked store shows white until repaint; hiding is invisible because the
         // container shares the terminal background.
         setSurfaceReady(false)
+        markRecoveryPing()
         armWebReadyWatchdog()
         pendingPingIdRef.current = sendToWebView({ type: 'ping' })
       },
@@ -373,7 +404,15 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         })
       }
     }),
-    [armWebReadyWatchdog, postMessage, sendToWebView, terminalTheme, textScale, writeCoalescer]
+    [
+      armWebReadyWatchdog,
+      markRecoveryPing,
+      postMessage,
+      sendToWebView,
+      terminalTheme,
+      textScale,
+      writeCoalescer
+    ]
   )
 
   return (

--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, forwardRef, useImperativeHandle, useEffect, useMemo } from 'react'
+import { useRef, useCallback, forwardRef, useImperativeHandle, useEffect, useMemo, useState } from 'react'
 import { Platform, View } from 'react-native'
 import { WebView, type WebViewMessageEvent } from 'react-native-webview'
 import type { TerminalOscLinkRange } from '../../../src/shared/terminal-osc-link-ranges'
@@ -44,6 +44,10 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
 ) {
   const webViewRef = useRef<WebView>(null)
   const isWebReadyRef = useRef(false)
+  // Why: the engine's inline script blocks the document's first paint, and iOS can resume
+  // with a blanked backing store — both show the native white surface. Track readiness as
+  // state so the WebView stays hidden behind the themed container until it can paint (#17304).
+  const [surfaceReady, setSurfaceReady] = useState(false)
   const pendingMessages = useMemo(() => createTerminalWebViewPendingMessages(), [])
   const messageIdRef = useRef(0)
   const pendingPingIdRef = useRef<number | null>(null)
@@ -103,6 +107,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     (notifyParent: boolean) => {
       pendingPingIdRef.current = null
       isWebReadyRef.current = true
+      setSurfaceReady(true)
       clearWebReadyWatchdog()
       clearEngineError()
       if (notifyParent) {
@@ -195,6 +200,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
 
   const handleLoadStart = useCallback(() => {
     isWebReadyRef.current = false
+    setSurfaceReady(false)
     pendingPingIdRef.current = null
     armWebReadyWatchdog()
     // Why: messages queued for a previous WebView generation are stale after a reload;
@@ -240,6 +246,9 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         // Why: direct ping is the only command allowed through while readiness is
         // invalid; init/write commands queue until this exact document answers.
         isWebReadyRef.current = false
+        // Why: a blanked store shows white until repaint; hiding is invisible because the
+        // container shares the terminal background.
+        setSurfaceReady(false)
         armWebReadyWatchdog()
         pendingPingIdRef.current = sendToWebView({ type: 'ping' })
       },
@@ -368,7 +377,10 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
       <WebView
         ref={webViewRef}
         source={XTERM_WEBVIEW_SOURCE}
-        style={TERMINAL_WEBVIEW_FRAME_STYLES.webview}
+        style={[
+          TERMINAL_WEBVIEW_FRAME_STYLES.webview,
+          !surfaceReady && TERMINAL_WEBVIEW_FRAME_STYLES.webviewHidden
+        ]}
         originWhitelist={['*']}
         javaScriptEnabled
         scrollEnabled={false}

--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -45,8 +45,9 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
   const webViewRef = useRef<WebView>(null)
   const isWebReadyRef = useRef(false)
   // Why: the engine's inline script blocks the document's first paint, and iOS can resume
-  // with a blanked backing store — both show the native white surface. Track readiness as
-  // state so the WebView stays hidden behind the themed container until it can paint (#17304).
+  // with a blanked backing store — both show the native white surface. Track paint readiness
+  // as state so the WebView stays hidden behind the themed container until the 'ready'
+  // notification, which follows the post-init rAF chain and thus a committed paint (#17304).
   const [surfaceReady, setSurfaceReady] = useState(false)
   const pendingMessages = useMemo(() => createTerminalWebViewPendingMessages(), [])
   const messageIdRef = useRef(0)
@@ -107,7 +108,6 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     (notifyParent: boolean) => {
       pendingPingIdRef.current = null
       isWebReadyRef.current = true
-      setSurfaceReady(true)
       clearWebReadyWatchdog()
       clearEngineError()
       if (notifyParent) {
@@ -151,6 +151,10 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         // renderService is populated, first paint has happened. Resolve
         // any pending awaitReady() so a queued measure can now safely
         // read cell dims.
+        // Why: web-ready/pong prove script liveness, not a committed repaint — revealing
+        // there can still show the native white surface. 'ready' follows the rAF chain
+        // after first paint, so this is the earliest honest moment to show the surface.
+        setSurfaceReady(true)
         const resolve = readyResolveRef.current
         readyResolveRef.current = null
         readyPromiseRef.current = null

--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, forwardRef, useImperativeHandle, useEffect, useMemo, useState } from 'react'
+import { useRef, useCallback, forwardRef, useImperativeHandle, useEffect, useMemo } from 'react'
 import { Platform, View } from 'react-native'
 import { WebView, type WebViewMessageEvent } from 'react-native-webview'
 import type { TerminalOscLinkRange } from '../../../src/shared/terminal-osc-link-ranges'
@@ -7,6 +7,7 @@ import {
   TerminalWebViewEngineErrorOverlay,
   useTerminalWebViewEngineErrorState
 } from './terminal-webview-engine-error-state'
+import { useTerminalWebViewDocumentLifecycle } from './terminal-webview-document-lifecycle'
 import { TERMINAL_WEBVIEW_FRAME_STYLES } from './terminal-webview-frame-styles'
 import { useTerminalWebReadyWatchdog } from './terminal-webview-ready-watchdog'
 import { useTerminalWebViewPingProbe } from './terminal-webview-ping-probe'
@@ -45,11 +46,6 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
 ) {
   const webViewRef = useRef<WebView>(null)
   const isWebReadyRef = useRef(false)
-  // Why: the engine's inline script blocks the document's first paint, and iOS can resume
-  // with a blanked backing store — both show the native white surface. Track paint readiness
-  // as state so the WebView stays hidden behind the themed container until the 'ready'
-  // notification, which follows the post-init rAF chain and thus a committed paint (#17304).
-  const [surfaceReady, setSurfaceReady] = useState(false)
   const pendingMessages = useMemo(() => createTerminalWebViewPendingMessages(), [])
   const messageIdRef = useRef(0)
   const pendingPingIdRef = useRef<number | null>(null)
@@ -116,6 +112,24 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     }
   }, [writeCoalescer])
 
+  const {
+    handleContentProcessDidTerminate,
+    handleReload,
+    hideSurface,
+    invalidateDocument,
+    markSurfacePainted,
+    surfaceReady
+  } = useTerminalWebViewDocumentLifecycle({
+    armWebReadyWatchdog,
+    attemptPingRecovery,
+    clearEngineError,
+    isWebReadyRef,
+    pendingMessages,
+    pendingPingIdRef,
+    webViewRef,
+    writeCoalescer
+  })
+
   const confirmWebReady = useCallback(
     (notifyParent: boolean) => {
       pendingPingIdRef.current = null
@@ -163,18 +177,17 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         // re-inits (the repaint); the foreground-recovery ping runs its own resubscribe.
         confirmWebReady(takeProbeNotifyParent())
       } else if (msg.type === 'ready') {
-        // Why: the WebView's init() rAF chain has run — term is open,
-        // renderService is populated, first paint has happened. Resolve
-        // any pending awaitReady() so a queued measure can now safely
-        // read cell dims.
-        // Why: web-ready/pong prove script liveness, not a committed repaint — revealing
-        // there can still show the native white surface. 'ready' follows the rAF chain
-        // after first paint, so this is the earliest honest moment to show the surface.
-        setSurfaceReady(true)
-        const resolve = readyResolveRef.current
-        readyResolveRef.current = null
-        readyPromiseRef.current = null
-        resolve?.()
+        // Why: resize() notifies 'ready' too, synchronously. Only init's runs after the rAF
+        // chain and the drained replay, so only it proves the repaint — a resize flushed
+        // during foreground recovery would reveal the still-blank surface and answer the
+        // awaitReady() a measure is holding for the init that has not landed yet.
+        if (msg.source === 'init') {
+          markSurfacePainted()
+          const resolve = readyResolveRef.current
+          readyResolveRef.current = null
+          readyPromiseRef.current = null
+          resolve?.()
+        }
       } else if (msg.type === 'measure-result') {
         const resolve = measureResolveRef.current
         measureResolveRef.current = null
@@ -202,6 +215,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     },
     [
       confirmWebReady,
+      markSurfacePainted,
       reportEngineError,
       onSelectionMode,
       onSelectionCopy,
@@ -230,36 +244,6 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     }
   }, [attemptPingRecovery, reportEngineError])
 
-  const handleLoadStart = useCallback(() => {
-    isWebReadyRef.current = false
-    setSurfaceReady(false)
-    pendingPingIdRef.current = null
-    armWebReadyWatchdog()
-    // Why: messages queued for a previous WebView generation are stale after a reload;
-    // dropping them avoids replaying terminal chunks before the next init snapshot.
-    pendingMessages.clear()
-    writeCoalescer.clear()
-  }, [armWebReadyWatchdog, pendingMessages, writeCoalescer])
-
-  const handleReload = useCallback(() => {
-    clearEngineError()
-    // Why: in the wedged live-document state, reload reproduces the same error while a
-    // ping recovers instantly (the app-switch cure); reload stays as the last resort.
-    attemptPingRecovery(true, () => webViewRef.current?.reload())
-  }, [attemptPingRecovery, clearEngineError])
-
-  const handleContentProcessDidTerminate = useCallback(() => {
-    // Why: WKWebView content-process loss is recoverable; stale commands belong
-    // to the dead document and the replacement must prove readiness before replay.
-    isWebReadyRef.current = false
-    pendingPingIdRef.current = null
-    pendingMessages.clear()
-    writeCoalescer.clear()
-    clearEngineError()
-    armWebReadyWatchdog()
-    webViewRef.current?.reload()
-  }, [armWebReadyWatchdog, clearEngineError, pendingMessages, writeCoalescer])
-
   useEffect(() => {
     postMessage({ type: 'set-theme', terminalTheme })
   }, [postMessage, terminalThemeKey, terminalTheme])
@@ -282,7 +266,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         isWebReadyRef.current = false
         // Why: a blanked store shows white until repaint; hiding is invisible because the
         // container shares the terminal background.
-        setSurfaceReady(false)
+        hideSurface()
         markRecoveryPing()
         armWebReadyWatchdog()
         pendingPingIdRef.current = sendToWebView({ type: 'ping' })
@@ -406,6 +390,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     }),
     [
       armWebReadyWatchdog,
+      hideSurface,
       markRecoveryPing,
       postMessage,
       sendToWebView,
@@ -434,7 +419,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         // Why: Android WebView defaults textZoom to the system font scale, inflating
         // xterm's DOM glyphs past its canvas-measured cell grid (#4579). iOS ignores it.
         textZoom={100}
-        onLoadStart={handleLoadStart}
+        onLoadStart={invalidateDocument}
         onMessage={handleMessage}
         onError={(event) => reportNativeEngineError('Terminal WebView load failed', event)}
         onHttpError={(event) => reportNativeEngineError('Terminal WebView HTTP error', event)}

--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -9,7 +9,10 @@ import {
 } from './terminal-webview-engine-error-state'
 import { useTerminalWebViewDocumentLifecycle } from './terminal-webview-document-lifecycle'
 import { TERMINAL_WEBVIEW_FRAME_STYLES } from './terminal-webview-frame-styles'
-import { useTerminalWebReadyWatchdog } from './terminal-webview-ready-watchdog'
+import {
+  TERMINAL_WEB_READY_UNMET,
+  useTerminalWebReadyWatchdog
+} from './terminal-webview-ready-watchdog'
 import { useTerminalWebViewPingProbe } from './terminal-webview-ping-probe'
 import { XTERM_WEBVIEW_SOURCE } from './terminal-webview-html'
 import type { TerminalWebViewCommand } from './terminal-webview-messages'
@@ -62,9 +65,8 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
   const { clearEngineError, engineError, reportEngineError, reportNativeEngineError } =
     useTerminalWebViewEngineErrorState(onEngineError)
   const webReadyProbeRef = useRef<(() => void) | null>(null)
-  const runWebReadyProbe = useCallback(() => {
-    webReadyProbeRef.current?.()
-  }, [])
+  // Why: late-bound, because the probe needs attemptPingRecovery, which is built below.
+  const runWebReadyProbe = useCallback(() => webReadyProbeRef.current?.(), [])
   const { armWebReadyWatchdog, clearWebReadyWatchdog } = useTerminalWebReadyWatchdog(
     isWebReadyRef,
     reportEngineError,
@@ -113,6 +115,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
   }, [writeCoalescer])
 
   const {
+    armPaintReadyWatchdog,
     handleContentProcessDidTerminate,
     handleReload,
     hideSurface,
@@ -126,6 +129,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     isWebReadyRef,
     pendingMessages,
     pendingPingIdRef,
+    reportEngineError,
     webViewRef,
     writeCoalescer
   })
@@ -235,12 +239,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
 
   useEffect(() => {
     webReadyProbeRef.current = () => {
-      attemptPingRecovery(true, () =>
-        reportEngineError(
-          'Terminal did not initialize - no ready signal from the terminal view',
-          true
-        )
-      )
+      attemptPingRecovery(true, () => reportEngineError(TERMINAL_WEB_READY_UNMET, true))
     }
   }, [attemptPingRecovery, reportEngineError])
 
@@ -297,6 +296,11 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         readyPromiseRef.current = new Promise<void>((resolve) => {
           readyResolveRef.current = resolve
         })
+        // Why: only init's 'ready' opens the surface gate, and nothing else watches for
+        // it — a lost one leaves a hidden terminal with no ping and no overlay, curable
+        // only by an app switch. This is the arming edge because a pane the session
+        // never subscribed to never inits, and must not be judged for not painting.
+        armPaintReadyWatchdog()
         // Why: pending chunks are pre-snapshot data; the init snapshot supersedes
         // them, and writing them after init would corrupt the fresh buffer.
         writeCoalescer.clear()
@@ -389,6 +393,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
       }
     }),
     [
+      armPaintReadyWatchdog,
       armWebReadyWatchdog,
       hideSurface,
       markRecoveryPing,

--- a/mobile/src/terminal/terminal-webview-document-lifecycle.ts
+++ b/mobile/src/terminal/terminal-webview-document-lifecycle.ts
@@ -1,0 +1,76 @@
+import { useCallback, useState, type RefObject } from 'react'
+import type { WebView } from 'react-native-webview'
+
+type TerminalWebViewDocumentLifecycleOptions = {
+  armWebReadyWatchdog: () => void
+  attemptPingRecovery: (notifyParent: boolean, onGiveUp: () => void) => void
+  clearEngineError: () => void
+  isWebReadyRef: RefObject<boolean>
+  pendingMessages: { clear: () => void }
+  pendingPingIdRef: RefObject<number | null>
+  webViewRef: RefObject<WebView | null>
+  writeCoalescer: { clear: () => void }
+}
+
+// Why: the document a WebView is showing can be replaced (reload), die (content-process
+// loss), or come back blanked from an iOS suspend. Each of those invalidates readiness,
+// the queued commands, and the painted surface at once, so they live together here —
+// a path that resets only some of it is how a blank surface reaches the user (#17304).
+export function useTerminalWebViewDocumentLifecycle({
+  armWebReadyWatchdog,
+  attemptPingRecovery,
+  clearEngineError,
+  isWebReadyRef,
+  pendingMessages,
+  pendingPingIdRef,
+  webViewRef,
+  writeCoalescer
+}: TerminalWebViewDocumentLifecycleOptions) {
+  // Why: the engine's inline script blocks the document's first paint, and iOS can resume
+  // with a blanked backing store — both show the native white surface. Track paint readiness
+  // as state so the WebView stays hidden behind the themed container until init's 'ready',
+  // which follows the post-init rAF chain and thus a committed paint.
+  const [surfaceReady, setSurfaceReady] = useState(false)
+  const markSurfacePainted = useCallback(() => setSurfaceReady(true), [])
+  const hideSurface = useCallback(() => setSurfaceReady(false), [])
+
+  const invalidateDocument = useCallback(() => {
+    isWebReadyRef.current = false
+    setSurfaceReady(false)
+    pendingPingIdRef.current = null
+    armWebReadyWatchdog()
+    // Why: messages queued for a previous WebView generation are stale after a reload;
+    // dropping them avoids replaying terminal chunks before the next init snapshot.
+    pendingMessages.clear()
+    writeCoalescer.clear()
+  }, [armWebReadyWatchdog, isWebReadyRef, pendingMessages, pendingPingIdRef, writeCoalescer])
+
+  const reloadDocument = useCallback(() => {
+    // Why: reload discards the backing store before onLoadStart can invalidate.
+    invalidateDocument()
+    webViewRef.current?.reload()
+  }, [invalidateDocument, webViewRef])
+
+  const handleReload = useCallback(() => {
+    clearEngineError()
+    // Why: in the wedged live-document state, reload reproduces the same error while a
+    // ping recovers instantly (the app-switch cure); reload stays as the last resort.
+    attemptPingRecovery(true, reloadDocument)
+  }, [attemptPingRecovery, clearEngineError, reloadDocument])
+
+  const handleContentProcessDidTerminate = useCallback(() => {
+    // Why: WKWebView content-process loss is recoverable; stale commands belong
+    // to the dead document and the replacement must prove readiness before replay.
+    clearEngineError()
+    reloadDocument()
+  }, [clearEngineError, reloadDocument])
+
+  return {
+    handleContentProcessDidTerminate,
+    handleReload,
+    hideSurface,
+    invalidateDocument,
+    markSurfacePainted,
+    surfaceReady
+  }
+}

--- a/mobile/src/terminal/terminal-webview-document-lifecycle.ts
+++ b/mobile/src/terminal/terminal-webview-document-lifecycle.ts
@@ -1,13 +1,22 @@
-import { useCallback, useState, type RefObject } from 'react'
+import { useCallback, useRef, useState, type RefObject } from 'react'
 import type { WebView } from 'react-native-webview'
+import {
+  TERMINAL_PAINT_READY_UNMET,
+  useTerminalPaintReadyWatchdog
+} from './terminal-webview-ready-watchdog'
 
 type TerminalWebViewDocumentLifecycleOptions = {
   armWebReadyWatchdog: () => void
-  attemptPingRecovery: (notifyParent: boolean, onGiveUp: () => void) => void
+  attemptPingRecovery: (
+    notifyParent: boolean,
+    onGiveUp: () => void,
+    isRecoveredRef?: RefObject<boolean>
+  ) => void
   clearEngineError: () => void
   isWebReadyRef: RefObject<boolean>
   pendingMessages: { clear: () => void }
   pendingPingIdRef: RefObject<number | null>
+  reportEngineError: (message: string, fatal: boolean) => void
   webViewRef: RefObject<WebView | null>
   writeCoalescer: { clear: () => void }
 }
@@ -23,6 +32,7 @@ export function useTerminalWebViewDocumentLifecycle({
   isWebReadyRef,
   pendingMessages,
   pendingPingIdRef,
+  reportEngineError,
   webViewRef,
   writeCoalescer
 }: TerminalWebViewDocumentLifecycleOptions) {
@@ -31,19 +41,55 @@ export function useTerminalWebViewDocumentLifecycle({
   // as state so the WebView stays hidden behind the themed container until init's 'ready',
   // which follows the post-init rAF chain and thus a committed paint.
   const [surfaceReady, setSurfaceReady] = useState(false)
-  const markSurfacePainted = useCallback(() => setSurfaceReady(true), [])
-  const hideSurface = useCallback(() => setSurfaceReady(false), [])
+  // Why: the watchdog fires from a timer, where React state is a stale closure.
+  const surfacePaintedRef = useRef(false)
+
+  const probeBeforePaintError = useCallback(() => {
+    // Why: notifyParent, because the cure is a resubscribe whose re-init repaints — the
+    // pong alone cannot reveal a surface that only init's 'ready' opens.
+    attemptPingRecovery(
+      true,
+      () => reportEngineError(TERMINAL_PAINT_READY_UNMET, true),
+      surfacePaintedRef
+    )
+  }, [attemptPingRecovery, reportEngineError])
+  const { armPaintReadyWatchdog, clearPaintReadyWatchdog } = useTerminalPaintReadyWatchdog(
+    surfacePaintedRef,
+    reportEngineError,
+    probeBeforePaintError
+  )
+
+  const markSurfacePainted = useCallback(() => {
+    surfacePaintedRef.current = true
+    setSurfaceReady(true)
+    clearPaintReadyWatchdog()
+  }, [clearPaintReadyWatchdog])
+  const hideSurface = useCallback(() => {
+    surfacePaintedRef.current = false
+    setSurfaceReady(false)
+  }, [])
 
   const invalidateDocument = useCallback(() => {
     isWebReadyRef.current = false
+    surfacePaintedRef.current = false
     setSurfaceReady(false)
     pendingPingIdRef.current = null
     armWebReadyWatchdog()
+    // Why: no init is outstanding against a document that is going away; the next one
+    // arms a fresh paint watchdog.
+    clearPaintReadyWatchdog()
     // Why: messages queued for a previous WebView generation are stale after a reload;
     // dropping them avoids replaying terminal chunks before the next init snapshot.
     pendingMessages.clear()
     writeCoalescer.clear()
-  }, [armWebReadyWatchdog, isWebReadyRef, pendingMessages, pendingPingIdRef, writeCoalescer])
+  }, [
+    armWebReadyWatchdog,
+    clearPaintReadyWatchdog,
+    isWebReadyRef,
+    pendingMessages,
+    pendingPingIdRef,
+    writeCoalescer
+  ])
 
   const reloadDocument = useCallback(() => {
     // Why: reload discards the backing store before onLoadStart can invalidate.
@@ -66,6 +112,7 @@ export function useTerminalWebViewDocumentLifecycle({
   }, [clearEngineError, reloadDocument])
 
   return {
+    armPaintReadyWatchdog,
     handleContentProcessDidTerminate,
     handleReload,
     hideSurface,

--- a/mobile/src/terminal/terminal-webview-engine-error.test.ts
+++ b/mobile/src/terminal/terminal-webview-engine-error.test.ts
@@ -151,6 +151,12 @@ describe('TerminalWebView engine errors', () => {
       act(() => {
         vi.advanceTimersByTime(15000)
       })
+      // Why: the watchdog now probes a possibly-live document first; the error only
+      // lands after the ping grace window expires unanswered.
+      expect(onEngineError).not.toHaveBeenCalled()
+      act(() => {
+        vi.advanceTimersByTime(2500)
+      })
 
       expect(onEngineError).toHaveBeenCalledWith(
         'Terminal did not initialize - no ready signal from the terminal view'

--- a/mobile/src/terminal/terminal-webview-engine.test.ts
+++ b/mobile/src/terminal/terminal-webview-engine.test.ts
@@ -234,6 +234,19 @@ describe('terminal WebView bundled engine', () => {
     expect(harness.term.refresh).toHaveBeenCalledTimes(1)
   })
 
+  it('labels the init and resize readiness notifications distinctly', () => {
+    // Why: init() and resize() both notify 'ready', but only init's runs after the rAF
+    // chain and the drained replay. Native gates the surface reveal on the label, so an
+    // unlabeled notify would reveal a blank surface when a resize answers first (#17304).
+    expect(terminalHtmlSource).toContain(
+      "notify({ type: 'ready', cols: cols, rows: rows, source: 'init' })"
+    )
+    expect(terminalHtmlSource).toContain(
+      "notify({ type: 'ready', cols: cols, rows: rows, source: 'resize' })"
+    )
+    expect(terminalHtmlSource).not.toContain("notify({ type: 'ready', cols: cols, rows: rows })")
+  })
+
   it('answers native readiness probes from the live document', () => {
     expect(terminalHtmlSource).toContain("if (msg.type === 'ping')")
     expect(terminalHtmlSource).toContain("notify({ type: 'pong', pingId: msg.id })")

--- a/mobile/src/terminal/terminal-webview-frame-styles.ts
+++ b/mobile/src/terminal/terminal-webview-frame-styles.ts
@@ -9,5 +9,10 @@ export const TERMINAL_WEBVIEW_FRAME_STYLES = StyleSheet.create({
   webview: {
     flex: 1,
     backgroundColor: colors.terminalBg
+  },
+  // Why: the surface stays themed (container bg) while the document cannot paint yet;
+  // opacity keeps layout and the WKWebView alive, unlike unmounting (#17304).
+  webviewHidden: {
+    opacity: 0
   }
 })

--- a/mobile/src/terminal/terminal-webview-html/terminal-init-and-write.ts
+++ b/mobile/src/terminal/terminal-webview-html/terminal-init-and-write.ts
@@ -103,7 +103,9 @@ export const TERMINAL_HTML_INIT_AND_WRITE = `${TERMINAL_WEBGL_RECOVERY_JS}
         initialOscLinkRowOffset = 0;
         initialOscLinkEvictionReady = true;
         applyFitScale('init-replay');
-        notify({ type: 'ready', cols: cols, rows: rows });
+        // Why: only this 'ready' follows the rAF chain and the drained replay, so only it
+        // proves a committed repaint; native gates the surface reveal on source (#17304).
+        notify({ type: 'ready', cols: cols, rows: rows, source: 'init' });
       });
     });
   }
@@ -132,7 +134,7 @@ export const TERMINAL_HTML_INIT_AND_WRITE = `${TERMINAL_WEBGL_RECOVERY_JS}
     term.resize(cols || term.cols, rows || term.rows);
     emitKeyboardAvoidanceMetrics();
     applyFitScale('resize-msg');
-    notify({ type: 'ready', cols: cols, rows: rows });
+    notify({ type: 'ready', cols: cols, rows: rows, source: 'resize' });
   }
 
   // reflow(): see terminal-webview-reflow-injected.ts (extracted for max-lines).

--- a/mobile/src/terminal/terminal-webview-payload-hash.test.ts
+++ b/mobile/src/terminal/terminal-webview-payload-hash.test.ts
@@ -6,8 +6,8 @@ import { XTERM_HTML } from './terminal-webview-html'
 // uncovered region ships silently. A diff here means the emitted WebView source changed —
 // update these values only when that change is deliberate, and only after checking the
 // document still runs. Refactors that merely move slice boundaries must leave them alone.
-const EXPECTED_SHA256 = '42cc000faddc3b58b8fd4855f848c7878f0cd6166c613f66d733645e8e1b9608'
-const EXPECTED_LENGTH = 729776
+const EXPECTED_SHA256 = '9df6417b890339a8ae4b8e54e5bd2e76d9d0508920643106f20fa860dc73b34f'
+const EXPECTED_LENGTH = 729992
 
 describe('terminal WebView payload', () => {
   it('composes the expected document', () => {

--- a/mobile/src/terminal/terminal-webview-ping-probe.ts
+++ b/mobile/src/terminal/terminal-webview-ping-probe.ts
@@ -1,0 +1,58 @@
+import { useCallback, useRef, type RefObject } from 'react'
+
+// Why: long enough for a suspended document to wake and answer, short enough that a
+// genuinely dead engine still reaches the error overlay promptly.
+export const WEB_READY_PROBE_GRACE_MS = 2500
+
+// Why: iOS can hand back a live document whose ready signal was lost in a transition —
+// an app switch cures that instantly through ping/pong, while reloading reproduces the
+// wedge. Ping the document first and fall back only when the grace window expires.
+export function useTerminalWebViewPingProbe(
+  isWebReadyRef: RefObject<boolean>,
+  sendPing: () => void
+) {
+  const probeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const probeGiveUpRef = useRef<(() => void) | null>(null)
+  const probeNotifyParentRef = useRef(false)
+
+  const cancelPingProbe = useCallback(() => {
+    if (probeTimerRef.current) {
+      clearTimeout(probeTimerRef.current)
+      probeTimerRef.current = null
+    }
+    probeGiveUpRef.current = null
+  }, [])
+
+  const attemptPingRecovery = useCallback(
+    (notifyParent: boolean, onGiveUp: () => void) => {
+      cancelPingProbe()
+      probeNotifyParentRef.current = notifyParent
+      probeGiveUpRef.current = onGiveUp
+      sendPing()
+      probeTimerRef.current = setTimeout(() => {
+        probeTimerRef.current = null
+        const giveUp = probeGiveUpRef.current
+        probeGiveUpRef.current = null
+        if (!isWebReadyRef.current) {
+          giveUp?.()
+        }
+      }, WEB_READY_PROBE_GRACE_MS)
+    },
+    [cancelPingProbe, isWebReadyRef, sendPing]
+  )
+
+  // Why: foreground recovery resubscribes on its own, so its ping must not
+  // double-notify the parent, and it supersedes any in-flight probe.
+  const markRecoveryPing = useCallback(() => {
+    cancelPingProbe()
+    probeNotifyParentRef.current = false
+  }, [cancelPingProbe])
+
+  const takeProbeNotifyParent = useCallback(() => {
+    const notifyParent = probeNotifyParentRef.current
+    probeNotifyParentRef.current = false
+    return notifyParent
+  }, [])
+
+  return { attemptPingRecovery, cancelPingProbe, markRecoveryPing, takeProbeNotifyParent }
+}

--- a/mobile/src/terminal/terminal-webview-ping-probe.ts
+++ b/mobile/src/terminal/terminal-webview-ping-probe.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, type RefObject } from 'react'
+import { useCallback, useEffect, useRef, type RefObject } from 'react'
 
 // Why: long enough for a suspended document to wake and answer, short enough that a
 // genuinely dead engine still reaches the error overlay promptly.
@@ -47,6 +47,10 @@ export function useTerminalWebViewPingProbe(
     cancelPingProbe()
     probeNotifyParentRef.current = false
   }, [cancelPingProbe])
+
+  // Why: an armed probe outlives the pane by up to the grace window, and its give-up
+  // reports an engine error or reloads a WebView the unmounted owner no longer has.
+  useEffect(() => cancelPingProbe, [cancelPingProbe])
 
   const takeProbeNotifyParent = useCallback(() => {
     const notifyParent = probeNotifyParentRef.current

--- a/mobile/src/terminal/terminal-webview-ping-probe.ts
+++ b/mobile/src/terminal/terminal-webview-ping-probe.ts
@@ -23,17 +23,21 @@ export function useTerminalWebViewPingProbe(
     probeGiveUpRef.current = null
   }, [])
 
+  // Why: `isRecoveredRef` names the signal that proves this probe's cure. The paint probe
+  // runs on a document that is already web-ready, so judging it by liveness would silence
+  // its give-up forever; it watches the painted surface instead.
   const attemptPingRecovery = useCallback(
-    (notifyParent: boolean, onGiveUp: () => void) => {
+    (notifyParent: boolean, onGiveUp: () => void, isRecoveredRef?: RefObject<boolean>) => {
       cancelPingProbe()
       probeNotifyParentRef.current = notifyParent
       probeGiveUpRef.current = onGiveUp
+      const recoveredRef = isRecoveredRef ?? isWebReadyRef
       sendPing()
       probeTimerRef.current = setTimeout(() => {
         probeTimerRef.current = null
         const giveUp = probeGiveUpRef.current
         probeGiveUpRef.current = null
-        if (!isWebReadyRef.current) {
+        if (!recoveredRef.current) {
           giveUp?.()
         }
       }, WEB_READY_PROBE_GRACE_MS)

--- a/mobile/src/terminal/terminal-webview-ready-watchdog.ts
+++ b/mobile/src/terminal/terminal-webview-ready-watchdog.ts
@@ -8,9 +8,11 @@ const WEB_READY_WATCHDOG_MS = 15000
 
 export function useTerminalWebReadyWatchdog(
   isWebReadyRef: RefObject<boolean>,
-  reportEngineError: (message: string, fatal: boolean) => void
+  reportEngineError: (message: string, fatal: boolean) => void,
+  probeBeforeError?: () => void
 ) {
   const watchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const probedRef = useRef(false)
 
   const clearWebReadyWatchdog = useCallback(() => {
     if (watchdogRef.current) {
@@ -21,6 +23,7 @@ export function useTerminalWebReadyWatchdog(
 
   const armWebReadyWatchdog = useCallback(() => {
     clearWebReadyWatchdog()
+    probedRef.current = false
     const fire = () => {
       watchdogRef.current = null
       if (isWebReadyRef.current) {
@@ -31,13 +34,21 @@ export function useTerminalWebReadyWatchdog(
         watchdogRef.current = setTimeout(fire, WEB_READY_WATCHDOG_MS)
         return
       }
+      if (probeBeforeError && !probedRef.current) {
+        // Why: iOS can hand back a live document whose ready signal was lost in a
+        // transition — an app switch cures it instantly via ping/pong, so try that
+        // cure once before surfacing a reload prompt that cannot help.
+        probedRef.current = true
+        probeBeforeError()
+        return
+      }
       reportEngineError(
         'Terminal did not initialize - no ready signal from the terminal view',
         true
       )
     }
     watchdogRef.current = setTimeout(fire, WEB_READY_WATCHDOG_MS)
-  }, [clearWebReadyWatchdog, isWebReadyRef, reportEngineError])
+  }, [clearWebReadyWatchdog, isWebReadyRef, probeBeforeError, reportEngineError])
 
   useEffect(() => {
     armWebReadyWatchdog()

--- a/mobile/src/terminal/terminal-webview-ready-watchdog.ts
+++ b/mobile/src/terminal/terminal-webview-ready-watchdog.ts
@@ -6,27 +6,40 @@ import { AppState } from 'react-native'
 // fires — without a native watchdog that failure is a silent blank pane.
 const WEB_READY_WATCHDOG_MS = 15000
 
-export function useTerminalWebReadyWatchdog(
-  isWebReadyRef: RefObject<boolean>,
-  reportEngineError: (message: string, fatal: boolean) => void,
+export const TERMINAL_WEB_READY_UNMET =
+  'Terminal did not initialize - no ready signal from the terminal view'
+export const TERMINAL_PAINT_READY_UNMET =
+  'Terminal did not paint - no init ready from the terminal view'
+
+type TerminalReadinessWatchdogOptions = {
+  isSatisfiedRef: RefObject<boolean>
   probeBeforeError?: () => void
-) {
+  reportEngineError: (message: string, fatal: boolean) => void
+  unmetMessage: string
+}
+
+function useTerminalReadinessWatchdog({
+  isSatisfiedRef,
+  probeBeforeError,
+  reportEngineError,
+  unmetMessage
+}: TerminalReadinessWatchdogOptions) {
   const watchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const probedRef = useRef(false)
 
-  const clearWebReadyWatchdog = useCallback(() => {
+  const clearWatchdog = useCallback(() => {
     if (watchdogRef.current) {
       clearTimeout(watchdogRef.current)
       watchdogRef.current = null
     }
   }, [])
 
-  const armWebReadyWatchdog = useCallback(() => {
-    clearWebReadyWatchdog()
+  const armWatchdog = useCallback(() => {
+    clearWatchdog()
     probedRef.current = false
     const fire = () => {
       watchdogRef.current = null
-      if (isWebReadyRef.current) {
+      if (isSatisfiedRef.current) {
         return
       }
       if (AppState.currentState !== 'active') {
@@ -35,25 +48,58 @@ export function useTerminalWebReadyWatchdog(
         return
       }
       if (probeBeforeError && !probedRef.current) {
-        // Why: iOS can hand back a live document whose ready signal was lost in a
+        // Why: iOS can hand back a live document whose signal was lost in a
         // transition — an app switch cures it instantly via ping/pong, so try that
         // cure once before surfacing a reload prompt that cannot help.
         probedRef.current = true
         probeBeforeError()
         return
       }
-      reportEngineError(
-        'Terminal did not initialize - no ready signal from the terminal view',
-        true
-      )
+      reportEngineError(unmetMessage, true)
     }
     watchdogRef.current = setTimeout(fire, WEB_READY_WATCHDOG_MS)
-  }, [clearWebReadyWatchdog, isWebReadyRef, probeBeforeError, reportEngineError])
+  }, [clearWatchdog, isSatisfiedRef, probeBeforeError, reportEngineError, unmetMessage])
 
+  useEffect(() => clearWatchdog, [clearWatchdog])
+
+  return { armWatchdog, clearWatchdog }
+}
+
+export function useTerminalWebReadyWatchdog(
+  isWebReadyRef: RefObject<boolean>,
+  reportEngineError: (message: string, fatal: boolean) => void,
+  probeBeforeError?: () => void
+) {
+  const { armWatchdog, clearWatchdog } = useTerminalReadinessWatchdog({
+    isSatisfiedRef: isWebReadyRef,
+    probeBeforeError,
+    reportEngineError,
+    unmetMessage: TERMINAL_WEB_READY_UNMET
+  })
+
+  // Why: the first document has no other arming edge — later ones arm from onLoadStart.
   useEffect(() => {
-    armWebReadyWatchdog()
-    return clearWebReadyWatchdog
-  }, [armWebReadyWatchdog, clearWebReadyWatchdog])
+    armWatchdog()
+  }, [armWatchdog])
 
-  return { armWebReadyWatchdog, clearWebReadyWatchdog }
+  return { armWebReadyWatchdog: armWatchdog, clearWebReadyWatchdog: clearWatchdog }
+}
+
+// Why: web-ready proves the script runs, not that the terminal painted. If init's 'ready'
+// is lost, the surface gate never opens and nothing else notices — no ping, no overlay,
+// a terminal that stays hidden until an app switch. Armed by init() rather than by
+// readiness, because a pane the session never subscribed to legitimately never inits.
+export function useTerminalPaintReadyWatchdog(
+  isSurfacePaintedRef: RefObject<boolean>,
+  reportEngineError: (message: string, fatal: boolean) => void,
+  probeBeforeError?: () => void
+) {
+  const { armWatchdog, clearWatchdog } = useTerminalReadinessWatchdog({
+    isSatisfiedRef: isSurfacePaintedRef,
+    probeBeforeError,
+    reportEngineError,
+    unmetMessage: TERMINAL_PAINT_READY_UNMET
+  })
+
+  return { armPaintReadyWatchdog: armWatchdog, clearPaintReadyWatchdog: clearWatchdog }
 }

--- a/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
+++ b/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
@@ -6,6 +6,7 @@ import { readTerminalWebViewHtmlSource } from './terminal-webview-html-source.te
 // TerminalWebView.tsx. Concatenate both so assertions resolve regardless of file.
 const source =
   readFileSync(new URL('./TerminalWebView.tsx', import.meta.url), 'utf8') +
+  readFileSync(new URL('./terminal-webview-document-lifecycle.ts', import.meta.url), 'utf8') +
   readFileSync(new URL('./terminal-webview-pending-messages.ts', import.meta.url), 'utf8') +
   readFileSync(new URL('./terminal-webview-url-tap.ts', import.meta.url), 'utf8') +
   readFileSync(new URL('./terminal-webview-tap-dispatch-injected.ts', import.meta.url), 'utf8') +

--- a/mobile/src/terminal/terminal-webview-surface-ready.test.tsx
+++ b/mobile/src/terminal/terminal-webview-surface-ready.test.tsx
@@ -67,17 +67,22 @@ describe('TerminalWebView surface readiness gate', () => {
     return { renderer, ref }
   }
 
-  it('hides the surface until the document reports web-ready', () => {
+  it('hides the surface through web-ready and reveals only on the painted ready', () => {
     const { renderer } = render()
     expect(webViewIsHidden(renderer)).toBe(true)
 
+    // Why: web-ready proves script liveness, not a committed repaint — still hidden.
     deliverMessage(renderer, { type: 'web-ready' })
+    expect(webViewIsHidden(renderer)).toBe(true)
+
+    deliverMessage(renderer, { type: 'ready' })
     expect(webViewIsHidden(renderer)).toBe(false)
   })
 
-  it('hides again on load start and reveals on the recovery pong', () => {
+  it('hides again on load start and stays hidden through the recovery pong until ready', () => {
     const { renderer, ref } = render()
     deliverMessage(renderer, { type: 'web-ready' })
+    deliverMessage(renderer, { type: 'ready' })
     expect(webViewIsHidden(renderer)).toBe(false)
 
     act(() => {
@@ -91,9 +96,12 @@ describe('TerminalWebView surface readiness gate', () => {
     })
     expect(webViewIsHidden(renderer)).toBe(true)
 
-    // Why: the recovery ping is message id 2 here (set-theme after web-ready is id 1).
     const pingId = JSON.parse(mocks.postMessage.mock.calls.at(-1)?.[0] as string).id as number
     deliverMessage(renderer, { type: 'pong', pingId })
+    // Why: the pong restores messaging, but only the re-init 'ready' proves a repaint.
+    expect(webViewIsHidden(renderer)).toBe(true)
+
+    deliverMessage(renderer, { type: 'ready' })
     expect(webViewIsHidden(renderer)).toBe(false)
   })
 
@@ -102,6 +110,7 @@ describe('TerminalWebView surface readiness gate', () => {
     try {
       const { renderer, ref } = render()
       deliverMessage(renderer, { type: 'web-ready' })
+      deliverMessage(renderer, { type: 'ready' })
       act(() => {
         ref.current?.prepareForForegroundRecovery()
       })

--- a/mobile/src/terminal/terminal-webview-surface-ready.test.tsx
+++ b/mobile/src/terminal/terminal-webview-surface-ready.test.tsx
@@ -5,10 +5,12 @@ import type { TerminalWebViewHandle } from './terminal-webview-contract'
 
 const mocks = vi.hoisted(() => ({
   postMessage: vi.fn(),
+  reload: vi.fn(),
   platformOS: { value: 'ios' }
 }))
 
 vi.mock('react-native', () => ({
+  AppState: { currentState: 'active', addEventListener: () => ({ remove: () => {} }) },
   Platform: {
     get OS() {
       return mocks.platformOS.value
@@ -25,7 +27,7 @@ vi.mock('lucide-react-native', () => ({ RefreshCw: 'RefreshCw' }))
 vi.mock('react-native-webview', () => ({
   WebView: forwardRef(function MockWebView(props: Record<string, unknown>, ref) {
     if (ref && typeof ref === 'object') {
-      ;(ref as { current: unknown }).current = { postMessage: mocks.postMessage }
+      ;(ref as { current: unknown }).current = { postMessage: mocks.postMessage, reload: mocks.reload }
     }
     return createElement('WebView', props)
   })
@@ -36,6 +38,7 @@ vi.mock('./terminal-webview-html', () => ({ XTERM_WEBVIEW_SOURCE: { html: '<html
 
 import { TerminalWebView } from './TerminalWebView'
 import { TERMINAL_WEBVIEW_FRAME_STYLES } from './terminal-webview-frame-styles'
+import { TerminalWebViewEngineErrorOverlay } from './terminal-webview-engine-error-state'
 
 function findWebView(renderer: ReactTestRenderer) {
   return renderer.root.findByType('WebView' as never)
@@ -103,6 +106,102 @@ describe('TerminalWebView surface readiness gate', () => {
 
     deliverMessage(renderer, { type: 'ready' })
     expect(webViewIsHidden(renderer)).toBe(false)
+  })
+
+  function lastPostedPingId(): number {
+    const pings = mocks.postMessage.mock.calls
+      .map((c) => JSON.parse(c[0] as string) as { type: string; id: number })
+      .filter((m) => m.type === 'ping')
+    expect(pings.length).toBeGreaterThan(0)
+    return pings.at(-1)!.id
+  }
+
+  it('watchdog pings the live document before surfacing the engine error', () => {
+    vi.useFakeTimers()
+    const onWebReady = vi.fn()
+    const onEngineError = vi.fn()
+    const ref = { current: null as TerminalWebViewHandle | null }
+    let renderer!: ReactTestRenderer
+    act(() => {
+      renderer = create(createElement(TerminalWebView, { ref, onWebReady, onEngineError } as never))
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(15000)
+    })
+    // Why: the probe replaces the immediate error — a ping goes out instead.
+    expect(onEngineError).not.toHaveBeenCalled()
+    const pingId = lastPostedPingId()
+
+    deliverMessage(renderer, { type: 'pong', pingId })
+    // Why: the probe's pong must notify the parent so it resubscribes and re-inits.
+    expect(onWebReady).toHaveBeenCalledTimes(1)
+    act(() => {
+      vi.advanceTimersByTime(60000)
+    })
+    expect(onEngineError).not.toHaveBeenCalled()
+  })
+
+  it('watchdog still errors when the probe goes unanswered', () => {
+    vi.useFakeTimers()
+    const onEngineError = vi.fn()
+    act(() => {
+      create(createElement(TerminalWebView, { onEngineError } as never))
+    })
+    act(() => {
+      vi.advanceTimersByTime(15000)
+    })
+    expect(onEngineError).not.toHaveBeenCalled()
+    act(() => {
+      vi.advanceTimersByTime(2500)
+    })
+    expect(onEngineError).toHaveBeenCalled()
+  })
+
+  it('reload button pings first and only reloads when the probe expires', () => {
+    vi.useFakeTimers()
+    const onEngineError = vi.fn()
+    let renderer!: ReactTestRenderer
+    act(() => {
+      renderer = create(createElement(TerminalWebView, { onEngineError } as never))
+    })
+    act(() => {
+      vi.advanceTimersByTime(15000 + 2500)
+    })
+    expect(onEngineError).toHaveBeenCalled()
+
+    const overlay = renderer.root.findByType(TerminalWebViewEngineErrorOverlay)
+    act(() => {
+      overlay.props.onReload()
+    })
+    expect(mocks.reload).not.toHaveBeenCalled()
+    const pingId = lastPostedPingId()
+
+    deliverMessage(renderer, { type: 'pong', pingId })
+    act(() => {
+      vi.advanceTimersByTime(60000)
+    })
+    // Why: the live document answered — reload never fires.
+    expect(mocks.reload).not.toHaveBeenCalled()
+  })
+
+  it('reload button falls back to a real reload when the document stays silent', () => {
+    vi.useFakeTimers()
+    let renderer!: ReactTestRenderer
+    act(() => {
+      renderer = create(createElement(TerminalWebView, {} as never))
+    })
+    act(() => {
+      vi.advanceTimersByTime(15000 + 2500)
+    })
+    const overlay = renderer.root.findByType(TerminalWebViewEngineErrorOverlay)
+    act(() => {
+      overlay.props.onReload()
+    })
+    act(() => {
+      vi.advanceTimersByTime(2500)
+    })
+    expect(mocks.reload).toHaveBeenCalledTimes(1)
   })
 
   it('keeps the surface visible on non-iOS foreground recovery', () => {

--- a/mobile/src/terminal/terminal-webview-surface-ready.test.tsx
+++ b/mobile/src/terminal/terminal-webview-surface-ready.test.tsx
@@ -1,0 +1,113 @@
+import { createElement, forwardRef } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalWebViewHandle } from './terminal-webview-contract'
+
+const mocks = vi.hoisted(() => ({
+  postMessage: vi.fn(),
+  platformOS: { value: 'ios' }
+}))
+
+vi.mock('react-native', () => ({
+  Platform: {
+    get OS() {
+      return mocks.platformOS.value
+    }
+  },
+  View: 'View',
+  StyleSheet: { create: <T,>(styles: T) => styles, absoluteFillObject: {} },
+  Text: 'Text',
+  Pressable: 'Pressable'
+}))
+
+vi.mock('lucide-react-native', () => ({ RefreshCw: 'RefreshCw' }))
+
+vi.mock('react-native-webview', () => ({
+  WebView: forwardRef(function MockWebView(props: Record<string, unknown>, ref) {
+    if (ref && typeof ref === 'object') {
+      ;(ref as { current: unknown }).current = { postMessage: mocks.postMessage }
+    }
+    return createElement('WebView', props)
+  })
+}))
+
+// Why: the real source inlines the generated xterm bundle, which is not built in unit tests.
+vi.mock('./terminal-webview-html', () => ({ XTERM_WEBVIEW_SOURCE: { html: '<html></html>' } }))
+
+import { TerminalWebView } from './TerminalWebView'
+import { TERMINAL_WEBVIEW_FRAME_STYLES } from './terminal-webview-frame-styles'
+
+function findWebView(renderer: ReactTestRenderer) {
+  return renderer.root.findByType('WebView' as never)
+}
+
+function webViewIsHidden(renderer: ReactTestRenderer): boolean {
+  const style = findWebView(renderer).props.style as unknown[]
+  return Array.isArray(style) && style.includes(TERMINAL_WEBVIEW_FRAME_STYLES.webviewHidden)
+}
+
+function deliverMessage(renderer: ReactTestRenderer, payload: Record<string, unknown>): void {
+  act(() => {
+    findWebView(renderer).props.onMessage({ nativeEvent: { data: JSON.stringify(payload) } })
+  })
+}
+
+describe('TerminalWebView surface readiness gate', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  function render(): { renderer: ReactTestRenderer; ref: { current: TerminalWebViewHandle | null } } {
+    const ref = { current: null as TerminalWebViewHandle | null }
+    let renderer!: ReactTestRenderer
+    act(() => {
+      renderer = create(createElement(TerminalWebView, { ref } as never))
+    })
+    return { renderer, ref }
+  }
+
+  it('hides the surface until the document reports web-ready', () => {
+    const { renderer } = render()
+    expect(webViewIsHidden(renderer)).toBe(true)
+
+    deliverMessage(renderer, { type: 'web-ready' })
+    expect(webViewIsHidden(renderer)).toBe(false)
+  })
+
+  it('hides again on load start and reveals on the recovery pong', () => {
+    const { renderer, ref } = render()
+    deliverMessage(renderer, { type: 'web-ready' })
+    expect(webViewIsHidden(renderer)).toBe(false)
+
+    act(() => {
+      findWebView(renderer).props.onLoadStart()
+    })
+    expect(webViewIsHidden(renderer)).toBe(true)
+
+    deliverMessage(renderer, { type: 'web-ready' })
+    act(() => {
+      ref.current?.prepareForForegroundRecovery()
+    })
+    expect(webViewIsHidden(renderer)).toBe(true)
+
+    // Why: the recovery ping is message id 2 here (set-theme after web-ready is id 1).
+    const pingId = JSON.parse(mocks.postMessage.mock.calls.at(-1)?.[0] as string).id as number
+    deliverMessage(renderer, { type: 'pong', pingId })
+    expect(webViewIsHidden(renderer)).toBe(false)
+  })
+
+  it('keeps the surface visible on non-iOS foreground recovery', () => {
+    mocks.platformOS.value = 'android'
+    try {
+      const { renderer, ref } = render()
+      deliverMessage(renderer, { type: 'web-ready' })
+      act(() => {
+        ref.current?.prepareForForegroundRecovery()
+      })
+      expect(webViewIsHidden(renderer)).toBe(false)
+    } finally {
+      mocks.platformOS.value = 'ios'
+    }
+  })
+})

--- a/mobile/src/terminal/terminal-webview-surface-ready.test.tsx
+++ b/mobile/src/terminal/terminal-webview-surface-ready.test.tsx
@@ -134,6 +134,88 @@ describe('TerminalWebView surface readiness gate', () => {
     expect(webViewIsHidden(renderer)).toBe(false)
   })
 
+  it('pings for a lost init ready and reveals on the re-init that follows', () => {
+    // Why: web-ready clears the readiness watchdog, so before this nothing watched for a
+    // lost init 'ready' — the surface stayed hidden with no ping and no overlay.
+    vi.useFakeTimers()
+    const onWebReady = vi.fn()
+    const onEngineError = vi.fn()
+    const ref = { current: null as TerminalWebViewHandle | null }
+    let renderer!: ReactTestRenderer
+    act(() => {
+      renderer = create(createElement(TerminalWebView, { ref, onWebReady, onEngineError } as never))
+    })
+    deliverMessage(renderer, { type: 'web-ready' })
+    expect(onWebReady).toHaveBeenCalledTimes(1)
+    act(() => {
+      ref.current?.init(80, 24)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(15000)
+    })
+    const pingId = lastPostedPingId()
+    expect(onEngineError).not.toHaveBeenCalled()
+
+    // Why: the probe pong must notify the parent — only its resubscribe re-inits, and only
+    // an init 'ready' opens the gate. The pong itself proves nothing about paint.
+    deliverMessage(renderer, { type: 'pong', pingId })
+    expect(onWebReady).toHaveBeenCalledTimes(2)
+    act(() => {
+      vi.advanceTimersByTime(60000)
+    })
+    deliverMessage(renderer, { type: 'ready', source: 'init' })
+    expect(webViewIsHidden(renderer)).toBe(false)
+    expect(onEngineError).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the engine error when the lost-paint probe goes unanswered', () => {
+    vi.useFakeTimers()
+    const onEngineError = vi.fn()
+    const ref = { current: null as TerminalWebViewHandle | null }
+    act(() => {
+      create(createElement(TerminalWebView, { ref, onEngineError } as never))
+    })
+    act(() => {
+      ref.current?.init(80, 24)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(15000)
+    })
+    expect(onEngineError).not.toHaveBeenCalled()
+    act(() => {
+      vi.advanceTimersByTime(2500)
+    })
+    // Why: the document is web-ready, so only the painted surface can clear this probe.
+    expect(onEngineError).toHaveBeenCalledWith(
+      'Terminal did not paint - no init ready from the terminal view'
+    )
+  })
+
+  it('does not judge paint once the init ready has arrived', () => {
+    vi.useFakeTimers()
+    const onEngineError = vi.fn()
+    const ref = { current: null as TerminalWebViewHandle | null }
+    let renderer!: ReactTestRenderer
+    act(() => {
+      renderer = create(createElement(TerminalWebView, { ref, onEngineError } as never))
+    })
+    deliverMessage(renderer, { type: 'web-ready' })
+    act(() => {
+      ref.current?.init(80, 24)
+    })
+    deliverMessage(renderer, { type: 'ready', source: 'init' })
+
+    mocks.postMessage.mockClear()
+    act(() => {
+      vi.advanceTimersByTime(60000)
+    })
+    expect(onEngineError).not.toHaveBeenCalled()
+    expect(postedTypes()).not.toContain('ping')
+    expect(webViewIsHidden(renderer)).toBe(false)
+  })
+
   it('hides the surface when the content process terminates', () => {
     const { renderer } = render()
     deliverMessage(renderer, { type: 'web-ready' })
@@ -147,6 +229,12 @@ describe('TerminalWebView surface readiness gate', () => {
     expect(webViewIsHidden(renderer)).toBe(true)
     expect(mocks.reload).toHaveBeenCalledTimes(1)
   })
+
+  function postedTypes(): string[] {
+    return mocks.postMessage.mock.calls.map(
+      (c) => (JSON.parse(c[0] as string) as { type: string }).type
+    )
+  }
 
   function lastPostedPingId(): number {
     const pings = mocks.postMessage.mock.calls

--- a/mobile/src/terminal/terminal-webview-surface-ready.test.tsx
+++ b/mobile/src/terminal/terminal-webview-surface-ready.test.tsx
@@ -27,7 +27,10 @@ vi.mock('lucide-react-native', () => ({ RefreshCw: 'RefreshCw' }))
 vi.mock('react-native-webview', () => ({
   WebView: forwardRef(function MockWebView(props: Record<string, unknown>, ref) {
     if (ref && typeof ref === 'object') {
-      ;(ref as { current: unknown }).current = { postMessage: mocks.postMessage, reload: mocks.reload }
+      ;(ref as { current: unknown }).current = {
+        postMessage: mocks.postMessage,
+        reload: mocks.reload
+      }
     }
     return createElement('WebView', props)
   })
@@ -61,7 +64,10 @@ describe('TerminalWebView surface readiness gate', () => {
     vi.useRealTimers()
   })
 
-  function render(): { renderer: ReactTestRenderer; ref: { current: TerminalWebViewHandle | null } } {
+  function render(): {
+    renderer: ReactTestRenderer
+    ref: { current: TerminalWebViewHandle | null }
+  } {
     const ref = { current: null as TerminalWebViewHandle | null }
     let renderer!: ReactTestRenderer
     act(() => {
@@ -78,14 +84,14 @@ describe('TerminalWebView surface readiness gate', () => {
     deliverMessage(renderer, { type: 'web-ready' })
     expect(webViewIsHidden(renderer)).toBe(true)
 
-    deliverMessage(renderer, { type: 'ready' })
+    deliverMessage(renderer, { type: 'ready', source: 'init' })
     expect(webViewIsHidden(renderer)).toBe(false)
   })
 
   it('hides again on load start and stays hidden through the recovery pong until ready', () => {
     const { renderer, ref } = render()
     deliverMessage(renderer, { type: 'web-ready' })
-    deliverMessage(renderer, { type: 'ready' })
+    deliverMessage(renderer, { type: 'ready', source: 'init' })
     expect(webViewIsHidden(renderer)).toBe(false)
 
     act(() => {
@@ -104,8 +110,42 @@ describe('TerminalWebView surface readiness gate', () => {
     // Why: the pong restores messaging, but only the re-init 'ready' proves a repaint.
     expect(webViewIsHidden(renderer)).toBe(true)
 
-    deliverMessage(renderer, { type: 'ready' })
+    deliverMessage(renderer, { type: 'ready', source: 'init' })
     expect(webViewIsHidden(renderer)).toBe(false)
+  })
+
+  it('stays hidden when a resize answers before the recovery re-init', () => {
+    const { renderer, ref } = render()
+    deliverMessage(renderer, { type: 'web-ready' })
+    deliverMessage(renderer, { type: 'ready', source: 'init' })
+
+    act(() => {
+      ref.current?.prepareForForegroundRecovery()
+    })
+    const pingId = JSON.parse(mocks.postMessage.mock.calls.at(-1)?.[0] as string).id as number
+    deliverMessage(renderer, { type: 'pong', pingId })
+
+    // Why: resize() notifies 'ready' synchronously, so a queued resize flushed by the pong
+    // answers before the re-init repaint — accepting it would reveal the blank surface.
+    deliverMessage(renderer, { type: 'ready', source: 'resize' })
+    expect(webViewIsHidden(renderer)).toBe(true)
+
+    deliverMessage(renderer, { type: 'ready', source: 'init' })
+    expect(webViewIsHidden(renderer)).toBe(false)
+  })
+
+  it('hides the surface when the content process terminates', () => {
+    const { renderer } = render()
+    deliverMessage(renderer, { type: 'web-ready' })
+    deliverMessage(renderer, { type: 'ready', source: 'init' })
+    expect(webViewIsHidden(renderer)).toBe(false)
+
+    act(() => {
+      findWebView(renderer).props.onContentProcessDidTerminate({ nativeEvent: {} })
+    })
+    // Why: the dead process leaves an invalid backing store on screen until onLoadStart.
+    expect(webViewIsHidden(renderer)).toBe(true)
+    expect(mocks.reload).toHaveBeenCalledTimes(1)
   })
 
   function lastPostedPingId(): number {
@@ -156,6 +196,54 @@ describe('TerminalWebView surface readiness gate', () => {
       vi.advanceTimersByTime(2500)
     })
     expect(onEngineError).toHaveBeenCalled()
+  })
+
+  it('hides a surface the fallback reload is about to discard', () => {
+    // Why: an init 'ready' can land while readiness is still invalid (recovery ping
+    // unanswered), leaving the surface visible when the probe later gives up. reload()
+    // blanks the backing store before onLoadStart can hide it.
+    vi.useFakeTimers()
+    let renderer!: ReactTestRenderer
+    act(() => {
+      renderer = create(createElement(TerminalWebView, {} as never))
+    })
+    deliverMessage(renderer, { type: 'ready', source: 'init' })
+    expect(webViewIsHidden(renderer)).toBe(false)
+
+    act(() => {
+      vi.advanceTimersByTime(15000 + 2500)
+    })
+    const overlay = renderer.root.findByType(TerminalWebViewEngineErrorOverlay)
+    act(() => {
+      overlay.props.onReload()
+    })
+    act(() => {
+      vi.advanceTimersByTime(2500)
+    })
+    expect(mocks.reload).toHaveBeenCalledTimes(1)
+    expect(webViewIsHidden(renderer)).toBe(true)
+  })
+
+  it('cancels an armed ping probe when the pane unmounts', () => {
+    vi.useFakeTimers()
+    const onEngineError = vi.fn()
+    let renderer!: ReactTestRenderer
+    act(() => {
+      renderer = create(createElement(TerminalWebView, { onEngineError } as never))
+    })
+    act(() => {
+      vi.advanceTimersByTime(15000)
+    })
+    expect(lastPostedPingId()).toBeGreaterThan(0)
+
+    act(() => {
+      renderer.unmount()
+    })
+    act(() => {
+      vi.advanceTimersByTime(2500)
+    })
+    // Why: the give-up would report an engine error for a pane that no longer exists.
+    expect(onEngineError).not.toHaveBeenCalled()
   })
 
   it('reload button pings first and only reloads when the probe expires', () => {
@@ -209,7 +297,7 @@ describe('TerminalWebView surface readiness gate', () => {
     try {
       const { renderer, ref } = render()
       deliverMessage(renderer, { type: 'web-ready' })
-      deliverMessage(renderer, { type: 'ready' })
+      deliverMessage(renderer, { type: 'ready', source: 'init' })
       act(() => {
         ref.current?.prepareForForegroundRecovery()
       })

--- a/mobile/src/terminal/terminal-write-coalescer-boundaries.test.ts
+++ b/mobile/src/terminal/terminal-write-coalescer-boundaries.test.ts
@@ -8,6 +8,10 @@ import {
 } from './terminal-write-coalescer'
 
 const webViewSource = readFileSync(new URL('./TerminalWebView.tsx', import.meta.url), 'utf8')
+const lifecycleSource = readFileSync(
+  new URL('./terminal-webview-document-lifecycle.ts', import.meta.url),
+  'utf8'
+)
 
 // Simulates TerminalWebView's postMessage: ready → deliver, not ready → queue.
 // There is no React render harness in the node environment, so the boundary
@@ -145,13 +149,20 @@ describe('terminal write coalescer boundaries', () => {
     }
   })
 
-  it('clears the coalescer in both document-lifecycle hooks alongside pendingMessages', () => {
-    for (const hook of ['const handleLoadStart', 'const handleContentProcessDidTerminate']) {
-      const start = webViewSource.indexOf(hook)
-      expect(start).toBeGreaterThanOrEqual(0)
-      const body = webViewSource.slice(start, webViewSource.indexOf('}, [', start))
-      expect(body).toContain('pendingMessages.clear()')
-      expect(body).toContain('writeCoalescer.clear()')
+  it('clears the coalescer alongside pendingMessages on every document invalidation', () => {
+    const start = lifecycleSource.indexOf('const invalidateDocument')
+    expect(start).toBeGreaterThanOrEqual(0)
+    const body = lifecycleSource.slice(start, lifecycleSource.indexOf('}, [', start))
+    expect(body).toContain('pendingMessages.clear()')
+    expect(body).toContain('writeCoalescer.clear()')
+    // Why: both document-replacement paths must reach it — load start directly, and
+    // content-process death through the reload helper.
+    expect(webViewSource).toContain('onLoadStart={invalidateDocument}')
+    for (const hook of ['const reloadDocument', 'const handleContentProcessDidTerminate']) {
+      const hookStart = lifecycleSource.indexOf(hook)
+      expect(hookStart).toBeGreaterThanOrEqual(0)
+      const hookBody = lifecycleSource.slice(hookStart, lifecycleSource.indexOf('}, [', hookStart))
+      expect(hookBody).toMatch(/invalidateDocument\(\)|reloadDocument\(\)/)
     }
   })
 


### PR DESCRIPTION
## ELI5

On a dark theme, opening the phone app onto a terminal shows a big white rectangle until the terminal engine finishes booting (and sometimes again after returning from background). Everything around it is dark; the white is the WebView's native surface showing through before the page can paint. This keeps the terminal area theme-colored the whole time instead.

## What Changed

Two halves, both anchored on the component's existing readiness machinery:

**1. The surface stays theme-colored until it can paint.**
- `terminal-webview-html/terminal-init-and-write.ts`: the engine notified `ready` from both `init()` and `resize()`. Only init's runs after the rAF chain and the drained replay (a committed repaint); resize's is synchronous. Both now carry a `source` so the native side can tell them apart — review feedback, since a resize flushed during foreground recovery answered first and revealed a blank surface.
- `TerminalWebView.tsx`: reveal the WebView (and resolve the pending `awaitReady()`) only on the init `ready`, and render it with `opacity: 0` until then, over the container that already carries the terminal background color. Earlier review feedback had already moved this off `web-ready`/`pong`, which only prove script liveness.
- New `terminal-webview-document-lifecycle.ts`: owns `surfaceReady` and every path that invalidates the document — `onLoadStart`, content-process death, and the fallback reload — since each leaves a backing store that is no longer painted content, and the two reload paths discard it before `onLoadStart` can hide it. `prepareForForegroundRecovery()` hides through the same state.
- `terminal-webview-frame-styles.ts`: the `webviewHidden` style (opacity keeps layout and the WKWebView alive, unlike unmounting).
- `terminal-webview-ready-watchdog.ts`: the watchdog is now generalized over the ref it observes and the message it reports, and a second one watches paint readiness. The existing watchdog only observes `web-ready`/`pong` and is cleared once the document proves it is alive — so a lost init `ready` left the terminal hidden with no ping and no overlay, curable only by an app switch (the issue's "loads forever until you leave and come back", silent instead of white). On expiry the paint watchdog pings; the pong notifies the parent, whose resubscribe re-inits, and that init `ready` opens the gate. An unanswered ping surfaces the engine error instead. It is armed by `init()` rather than by readiness, because a pane the session never subscribed to legitimately never inits and must not be judged for not painting.

**2. A live-but-silent document is cured with a ping before erroring or reloading** (from the live iPhone repro on the issue: waiting ends in the engine error; reload reproduces it; an app switch fixes it instantly — proof the document was alive with a lost ready latch).
- `terminal-webview-ready-watchdog.ts`: on expiry the watchdog now probes once and only surfaces the fatal error if the grace window passes unanswered.
- New `terminal-webview-ping-probe.ts` hook: sends the ping, arms the grace timer, and remembers whether the answering `pong` should notify the parent (a probe pong must, so the parent resubscribes and re-inits — the repaint; the foreground-recovery ping must not, since recovery resubscribes itself) It also cancels the armed probe on unmount so the give-up cannot report an engine error for a pane that is gone.
- The error overlay's Reload button pings first; a real `reload()` is the last resort.
- Tests: `terminal-webview-surface-ready.test.tsx` grows probe coverage (watchdog pings before erroring; unanswered probe still errors; Reload recovers via pong without reloading; silent document still reloads), and the existing watchdog contract test in `terminal-webview-engine-error.test.ts` is updated for the ping grace window.

## Why

The terminal document embeds the whole bundled xterm engine as a synchronous inline `<script>` (`terminal-webview-html.ts`), which blocks the document's first paint. The dark CSS is all there (`html, body { background: #1a1b26 }`, dark RN container/webview styles, dark route background) but never gets to render until the engine finishes evaluating — and until first paint, the opaque WKWebView surface shows its native default: white. iOS can also resume the app with a blanked WKWebView backing store, which stays white until the (already-wired) foreground recovery repaints it; users see white unless they switch tabs and back.

Gating visibility on the readiness signal the component already maintains closes every white window — cold boot, reload, and blanked-store resume — without touching the engine's boot order. Since the container and the terminal share the same background color, the hidden interval reads as flat theme, not a flash.

## Linked Issue

Fixes #17304

## Visual Proof

N/A — I cannot capture the before/after from this machine (the affected client is the iOS app; reported and reproduced on an iPhone against a Windows v1.4.192 host). The before is a solid white terminal area on a dark-themed app during engine boot; the after is the same interval rendered in the terminal background color. Happy to have the reporter capture a screen recording on a build carrying this patch.

## Testing

- [ ] I manually tested these changes locally (no iOS build environment on this machine — verification is by unit test; the live iPhone retest will follow on the next build)
- [x] Automated tests added/updated, or explained why not below

On Windows (repo checkout, Node 24 / pnpm 12), rebased on `main`:

- `pnpm test` (mobile) — 4199 passed, 14 failed; the same 14 fail on a clean checkout of `main` (verified by stash/run/pop). They are source-text invariant tests that break on a CRLF working tree, not on this change.
- `terminal-webview-surface-ready.test.tsx` — 11/11 (visibility gate, resize-vs-init `ready`, content-process death, fallback reload, probe paths, unmount cleanup). Each new assertion was checked red by reverting the fix before re-applying it.
- `pnpm typecheck` (mobile) — exit 0
- `pnpm lint` (mobile) — 0 findings. The document-lifecycle hook moved into its own module because adding `useState` widened the React import past the formatter's line width, and the wrapped import pushed `TerminalWebView.tsx` over its `max-lines` budget.
- `oxfmt --check` on the changed files — clean (this also fixes two formatting failures the earlier pushes introduced)
- `ORCA_CODE_QUALITY_BASE=upstream/main pnpm run check:code-quality:changed` — 0 new findings across 12 changed files

## AI Disclosure

Investigated and implemented with AI assistance (Claude Code); diagnosis, fix, and tests reviewed and verified locally by me.

## Review

- **Cross-platform**: `prepareForForegroundRecovery` keeps its iOS-only guard; Android/desktop behavior changes only in that the boot interval is dark instead of white.
- **SSH/remote & wire compat**: no RPC or client↔host wire change. The `ready` notification gained a `source` field, but it crosses only the RN↔WebView bridge inside one app bundle, where both ends ship together.
- **Performance**: one state flip per readiness transition; no extra renders in steady state.
- **UI**: the engine-error overlay is unaffected (it renders above the hidden WebView with its own background).
- **Risk**: a lost init `ready` would otherwise leave the surface hidden forever, and the pre-existing watchdog did *not* cover it — it stops observing once `web-ready` arrives. That gap is what the paint watchdog closes: ping first, then the engine-error overlay, so the failure is either cured or visible. The engine also drops readys from superseded generations itself.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

A deeper follow-up could defer the inline engine evaluation so the dark body paints first (shrinking the window instead of masking it); left out deliberately to avoid touching boot ordering.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

X: @EnricoPin



