### PR TITLE
fix(memory): hydrate retained PTYs before diagnostics

### DIFF
--- a/src/main/git/worktree-scan-cache-sharing.test.ts
+++ b/src/main/git/worktree-scan-cache-sharing.test.ts
@@ -30,6 +30,7 @@ import {
   _getWorktreeScanCacheSizesForTests,
   _resetWorktreeScanCacheForTests,
   listWorktrees,
+  listWorktreesStrict,
   moveWorktree,
   removeWorktree,
   WORKTREE_LIST_TIMEOUT_MS
@@ -115,6 +116,19 @@ describe('listWorktrees in-flight sharing', () => {
 
       expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
       expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 0, generations: 0 })
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('distinguishes fail-soft empty results from strict scan failures', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const failure = new Error('git spawn timed out')
+      gitExecFileAsyncMock.mockRejectedValue(failure)
+
+      await expect(listWorktrees('/repo')).resolves.toEqual([])
+      await expect(listWorktreesStrict('/repo')).rejects.toBe(failure)
     } finally {
       warnSpy.mockRestore()
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3389,12 +3389,12 @@ void app.whenReady().then(async () => {
   let desktopWindow: BrowserWindow | null = null
   if (process.platform === 'win32' && app.isPackaged && !serveOptions) {
     const desktopStartup = startWindowsDesktopBeforeShellPathReady({
+      bindServices: bindTerminalRuntimeStartupServices,
       openWindow: () => openMainWindow({ revealOnDidFinishLoad: true }),
       shellPathReady,
       startServices: startTerminalRuntimeStartupServices
     })
     desktopWindow = desktopStartup.window
-    bindTerminalRuntimeStartupServices(desktopStartup.services)
   } else {
     await shellPathReady
     bindTerminalRuntimeStartupServices(Promise.resolve(startTerminalRuntimeStartupServices()))
@@ -3410,7 +3410,8 @@ void app.whenReady().then(async () => {
     })
     // Why: headless PTYs must not start on the fallback provider, then get swept when an activated renderer registers desktop lifecycle handlers.
     await localPtyStartupReady
-    registerHeadlessPtyRuntime(
+    await localPtyProviderStartupReady
+    await registerHeadlessPtyRuntime(
       runtime,
       prepareCodexRuntimeHomeForLaunch,
       () => store!.getSettings(),

--- a/src/main/ipc/pty/register-headless-runtime.test.ts
+++ b/src/main/ipc/pty/register-headless-runtime.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { hydrateMock, registerHandlersMock } = vi.hoisted(() => ({
+  hydrateMock: vi.fn(),
+  registerHandlersMock: vi.fn()
+}))
+
+vi.mock('./register-handlers', () => ({
+  registerPtyHandlers: registerHandlersMock
+}))
+
+vi.mock('../../memory/hydrate-local-pty-registry', () => ({
+  hydrateLocalPtyRegistryAtBoot: hydrateMock
+}))
+
+import { registerHeadlessPtyRuntime } from './register-headless-runtime'
+
+describe('registerHeadlessPtyRuntime', () => {
+  it('registers handlers before awaiting registry hydration', async () => {
+    let resolveHydration!: () => void
+    const hydration = new Promise<void>((resolve) => {
+      resolveHydration = resolve
+    })
+    const events: string[] = []
+    registerHandlersMock.mockImplementation(() => events.push('handlers'))
+    hydrateMock.mockImplementation(() => {
+      events.push('hydrate')
+      return hydration
+    })
+    const store = {} as never
+
+    const ready = registerHeadlessPtyRuntime({} as never, undefined, undefined, undefined, store)
+
+    expect(events).toEqual(['handlers', 'hydrate'])
+    expect(registerHandlersMock).toHaveBeenCalledOnce()
+    expect(hydrateMock).toHaveBeenCalledWith(store)
+
+    resolveHydration()
+    await ready
+  })
+})

--- a/src/main/ipc/pty/register-headless-runtime.ts
+++ b/src/main/ipc/pty/register-headless-runtime.ts
@@ -9,6 +9,7 @@ import type {
   PrepareCodexSessionResume
 } from './host-env/types'
 import { registerPtyHandlers } from './register-handlers'
+import { hydrateLocalPtyRegistryAtBoot } from '../../memory/hydrate-local-pty-registry'
 
 export function registerHeadlessPtyRuntime(
   runtime: OrcaRuntimeService,
@@ -21,7 +22,7 @@ export function registerHeadlessPtyRuntime(
     onCodexHomePtySpawned?: (args: CodexHomePtySpawnedLifecycleArgs) => void
     onPtyExit?: (id: string, exitSequence: number) => void
   }
-): void {
+): Promise<void> {
   // Why: headless `orca serve` has no renderer window but still needs the same PTY handlers so remote clients can drive terminals.
   // Why a fake rather than null: `registerPtyHandlers` takes a non-null BrowserWindow. `isDestroyed: () => true`
   // is what makes that safe — every renderer-liveness guard reads it and skips, so no send is ever attempted.
@@ -44,4 +45,5 @@ export function registerHeadlessPtyRuntime(
     store,
     { prepareCodexSessionResume, ...lifecycle }
   )
+  return store ? hydrateLocalPtyRegistryAtBoot(store) : Promise.resolve()
 }

--- a/src/main/memory/hydrate-local-pty-registry.test.ts
+++ b/src/main/memory/hydrate-local-pty-registry.test.ts
@@ -11,7 +11,10 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolveFolderWorkspaceHost } from '../../shared/folder-workspace-execution-host'
+import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { Repo } from '../../shared/repo-types'
+import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import type { SessionInfo } from '../daemon/types'
 import type { DaemonPtyAdapter } from '../daemon/daemon-pty-adapter'
 import type { Store } from '../persistence'
@@ -23,7 +26,6 @@ import type {
 } from './pty-registry'
 
 const LARGE_SESSION_COUNT = 150_000
-
 // Why: the hydrator pulls the daemon provider through this module-level
 // getter. Stubbing it lets us drive the offline / throwing / live paths
 // without spinning up real sockets.
@@ -32,38 +34,65 @@ vi.mock('../daemon/daemon-init', () => ({
   getDaemonProvider: () => getDaemonProviderMock()
 }))
 
-// Why: the hydrator builds its worktreeId → connectionId map through
-// listRepoWorktrees(repo). The git I/O is out of scope for this unit; the mock
-// also lets count tests prove repos without live sessions launch no Git work.
-const listRepoWorktreesMock = vi.fn()
-vi.mock('../repo-worktrees', () => ({
-  listRepoWorktrees: (repo: unknown) => listRepoWorktreesMock(repo)
+const getLocalProjectWorktreeGitOptionsMock = vi.fn()
+vi.mock('../project-runtime-git-options', () => ({
+  getLocalProjectWorktreeGitOptions: (store: unknown, repo: unknown) =>
+    getLocalProjectWorktreeGitOptionsMock(store, repo)
 }))
 
-// Why: hydrateLocalPtyRegistryAtBoot accepts `Pick<Store, 'getRepos'>` and
-// the hydrator only reads `id` + `connectionId` off each Repo, but Repo's
-// required fields (path, displayName, badgeColor, addedAt) still have to be
-// present at the type level. Filling them with placeholder values keeps the
-// test schema-compliant without coupling to anything the hydrator doesn't
-// touch.
+// Why: the hydrator builds its worktreeId → connectionId map through
+// listLocalRepoWorktreesStrict(repo). The git I/O is out of scope for this
+// unit; the mock also lets count tests prove repos without live sessions
+// launch no Git work.
+const listLocalRepoWorktreesStrictMock = vi.fn()
+vi.mock('../repo-worktrees', () => ({
+  listLocalRepoWorktreesStrict: (
+    repo: unknown,
+    options?: { signal?: AbortSignal; wslDistro?: string }
+  ) => listLocalRepoWorktreesStrictMock(repo, options)
+}))
+
+// The runtime option helper accepts Store; mocks keep this fixture scoped to hydration reads.
 function makeStore(
-  repos: { id: string; connectionId?: string | null }[] = []
-): Pick<Store, 'getRepos'> {
+  repos: {
+    id: string
+    connectionId?: string | null
+    executionHostId?: Repo['executionHostId']
+    kind?: Repo['kind']
+    path?: string
+  }[] = [],
+  worktreeMeta: Record<string, WorktreeMeta> = {}
+): Store {
   const built: Repo[] = repos.map((r) => ({
     id: r.id,
-    path: `/tmp/${r.id}`,
+    path: r.path ?? `/tmp/${r.id}`,
     displayName: r.id,
     badgeColor: '#000000',
     addedAt: 0,
-    connectionId: r.connectionId ?? null
+    connectionId: r.connectionId ?? null,
+    executionHostId: r.executionHostId ?? null,
+    kind: r.kind
   }))
-  return { getRepos: () => built }
+  return {
+    getRepos: () => built,
+    getAllWorktreeMeta: () => worktreeMeta,
+    getAllWorktreeMetaForHost: (hostId) =>
+      Object.fromEntries(
+        Object.entries(worktreeMeta).filter(([, meta]) => !meta.hostId || meta.hostId === hostId)
+      )
+  } as Store
 }
 
 function makeProvider(sessions: SessionInfo[]): Pick<DaemonPtyAdapter, 'listSessions'> {
   return {
     listSessions: vi.fn().mockResolvedValue(sessions)
   }
+}
+
+function makeProviderGroup(adapters: Pick<DaemonPtyAdapter, 'listSessions'>[]): {
+  getAllAdapters: () => Pick<DaemonPtyAdapter, 'listSessions'>[]
+} {
+  return { getAllAdapters: () => adapters }
 }
 
 function makeLocalSessions(repoId: string, worktreePath: string, count: number): SessionInfo[] {
@@ -98,6 +127,8 @@ function createDeferred<T>(): {
 // a coherent pair.
 async function loadFresh(): Promise<{
   hydrate: typeof HydrateFn
+  deadlineMs: number
+  gitEnumerationConcurrency: number
   listRegisteredPtys: typeof ListFn
   registerPty: typeof RegisterFn
   unregisterPty: typeof UnregisterFn
@@ -107,6 +138,8 @@ async function loadFresh(): Promise<{
   const registryMod = await import('./pty-registry')
   return {
     hydrate: hydrateMod.hydrateLocalPtyRegistryAtBoot,
+    deadlineMs: hydrateMod.LOCAL_PTY_REGISTRY_BOOT_HYDRATION_DEADLINE_MS,
+    gitEnumerationConcurrency: hydrateMod.LOCAL_PTY_REGISTRY_GIT_ENUMERATION_CONCURRENCY,
     listRegisteredPtys: registryMod.listRegisteredPtys,
     registerPty: registryMod.registerPty,
     unregisterPty: registryMod.unregisterPty
@@ -116,7 +149,8 @@ async function loadFresh(): Promise<{
 describe('hydrateLocalPtyRegistryAtBoot', () => {
   beforeEach(() => {
     getDaemonProviderMock.mockReset()
-    listRepoWorktreesMock.mockReset()
+    getLocalProjectWorktreeGitOptionsMock.mockReset().mockReturnValue({})
+    listLocalRepoWorktreesStrictMock.mockReset()
   })
 
   it('no-op when daemon provider is null at first call (retries on later activation)', async () => {
@@ -126,19 +160,19 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     await hydrate(makeStore([{ id: 'repo-a' }]))
 
     expect(listRegisteredPtys()).toHaveLength(0)
-    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+    expect(listLocalRepoWorktreesStrictMock).not.toHaveBeenCalled()
 
     // Why: the design says the hasHydrated guard must stay false until a
     // provider is obtained, so a later macOS dock re-activation can retry.
     // Provider becomes available; second call should now perform the pass.
     const provider = makeProvider([])
     getDaemonProviderMock.mockReturnValue(provider)
-    listRepoWorktreesMock.mockResolvedValue([])
+    listLocalRepoWorktreesStrictMock.mockResolvedValue([])
 
     await hydrate(makeStore([{ id: 'repo-a' }]))
 
     expect(provider.listSessions).toHaveBeenCalledTimes(1)
-    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+    expect(listLocalRepoWorktreesStrictMock).not.toHaveBeenCalled()
   })
 
   it('catches provider.listSessions rejection and does not throw', async () => {
@@ -147,7 +181,9 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
       listSessions: vi.fn().mockRejectedValue(new Error('socket EPIPE'))
     }
     getDaemonProviderMock.mockReturnValue(provider)
-    listRepoWorktreesMock.mockResolvedValue([{ path: '/local/Triton', isMainWorktree: true }])
+    listLocalRepoWorktreesStrictMock.mockResolvedValue([
+      { path: '/local/Triton', isMainWorktree: true }
+    ])
 
     // Why: the renderer-side step-2 merge fallback covers this case. The
     // hydrator must not surface the failure to the caller — it logs and
@@ -157,7 +193,234 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     warnSpy.mockRestore()
 
     expect(listRegisteredPtys()).toHaveLength(0)
-    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+    expect(listLocalRepoWorktreesStrictMock).not.toHaveBeenCalled()
+  })
+
+  it('coalesces concurrent calls onto one inventory attempt', async () => {
+    const { hydrate } = await loadFresh()
+    const inventory = createDeferred<SessionInfo[]>()
+    const provider = { listSessions: vi.fn(() => inventory.promise) }
+    getDaemonProviderMock.mockReturnValue(provider)
+
+    const first = hydrate(makeStore())
+    const second = hydrate(makeStore())
+
+    expect(first).toBe(second)
+    expect(provider.listSessions).toHaveBeenCalledOnce()
+
+    inventory.resolve([])
+    await first
+  })
+
+  it('retries after worktree enumeration throws', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+    const ptyId = 'repo-a::/local/repo-a@@00000001'
+    const provider = makeProvider([
+      { sessionId: ptyId, pid: 4001, cwd: '/local/repo-a' } as unknown as SessionInfo
+    ])
+    getDaemonProviderMock.mockReturnValue(provider)
+    listLocalRepoWorktreesStrictMock
+      .mockRejectedValueOnce(new Error('git unavailable'))
+      .mockResolvedValue([
+        { path: '/local/repo-a', head: '', branch: '', isBare: false, isMainWorktree: true }
+      ])
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await hydrate(makeStore([{ id: 'repo-a' }]))
+    expect(listRegisteredPtys()).toHaveLength(0)
+    expect(listLocalRepoWorktreesStrictMock).toHaveBeenCalledOnce()
+
+    await hydrate(makeStore([{ id: 'repo-a' }]))
+    warnSpy.mockRestore()
+
+    expect(listRegisteredPtys()).toEqual([expect.objectContaining({ ptyId })])
+    expect(listLocalRepoWorktreesStrictMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('forwards the WSL project runtime and live deadline signal to strict enumeration', async () => {
+    const { hydrate } = await loadFresh()
+    const ptyId = 'repo-a::/mnt/c/repo-a@@00000001'
+    const store = makeStore([{ id: 'repo-a', path: '/mnt/c/repo-a' }])
+    getDaemonProviderMock.mockReturnValue(
+      makeProvider([
+        { sessionId: ptyId, pid: 4001, cwd: '/mnt/c/repo-a' } as unknown as SessionInfo
+      ])
+    )
+    getLocalProjectWorktreeGitOptionsMock.mockReturnValue({ wslDistro: 'Ubuntu' })
+    listLocalRepoWorktreesStrictMock.mockResolvedValue([
+      { path: '/mnt/c/repo-a', head: '', branch: '', isBare: false, isMainWorktree: true }
+    ])
+
+    await hydrate(store)
+
+    const [repo, options] = listLocalRepoWorktreesStrictMock.mock.calls[0] as [
+      Repo,
+      { signal: AbortSignal; wslDistro?: string }
+    ]
+    expect(getLocalProjectWorktreeGitOptionsMock).toHaveBeenCalledWith(store, repo)
+    expect(options.wslDistro).toBe('Ubuntu')
+    expect(options.signal).toBeInstanceOf(AbortSignal)
+    expect(options.signal.aborted).toBe(false)
+  })
+
+  it('resolves by the boot deadline and lets a later call retry stalled enumeration', async () => {
+    vi.useFakeTimers()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const { hydrate, deadlineMs, listRegisteredPtys } = await loadFresh()
+      const ptyId = 'repo-a::/local/repo-a@@00000001'
+      const provider = makeProvider([
+        { sessionId: ptyId, pid: 4001, cwd: '/local/repo-a' } as unknown as SessionInfo
+      ])
+      const signals: AbortSignal[] = []
+      getDaemonProviderMock.mockReturnValue(provider)
+      listLocalRepoWorktreesStrictMock
+        .mockImplementationOnce((_repo: Repo, options?: { signal?: AbortSignal }) => {
+          if (options?.signal) {
+            signals.push(options.signal)
+          }
+          return new Promise(() => {})
+        })
+        .mockImplementation(async (_repo: Repo, options?: { signal?: AbortSignal }) => {
+          if (options?.signal) {
+            signals.push(options.signal)
+          }
+          return [
+            {
+              path: '/local/repo-a',
+              head: '',
+              branch: '',
+              isBare: false,
+              isMainWorktree: true
+            }
+          ]
+        })
+
+      let settled = false
+      const first = hydrate(makeStore([{ id: 'repo-a' }])).then(() => {
+        settled = true
+      })
+      await vi.advanceTimersByTimeAsync(deadlineMs - 1)
+      expect(settled).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(settled).toBe(true)
+      await first
+      expect(signals[0]?.aborted).toBe(true)
+
+      await hydrate(makeStore([{ id: 'repo-a' }]))
+
+      expect(listLocalRepoWorktreesStrictMock).toHaveBeenCalledTimes(2)
+      expect(listRegisteredPtys()).toEqual([expect.objectContaining({ ptyId })])
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      warnSpy.mockRestore()
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
+  })
+
+  it('bounds concurrent Git worktree enumeration', async () => {
+    const { hydrate, gitEnumerationConcurrency } = await loadFresh()
+    const repoCount = 6
+    const gate = createDeferred<void>()
+    let active = 0
+    let maxActive = 0
+    const sessions = Array.from({ length: repoCount }, (_, index) => {
+      const repoId = `repo-${index}`
+      return {
+        sessionId: `${repoId}::/local/${repoId}@@0000000${index}`,
+        pid: 4000 + index,
+        cwd: `/local/${repoId}`
+      } as unknown as SessionInfo
+    })
+    getDaemonProviderMock.mockReturnValue(makeProvider(sessions))
+    listLocalRepoWorktreesStrictMock.mockImplementation(async (repo: Repo) => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await gate.promise
+      active -= 1
+      return [
+        { path: `/local/${repo.id}`, head: '', branch: '', isBare: false, isMainWorktree: true }
+      ]
+    })
+
+    const hydration = hydrate(
+      makeStore(Array.from({ length: repoCount }, (_, index) => ({ id: `repo-${index}` })))
+    )
+    let startedBeforeRelease = 0
+    try {
+      await vi.waitFor(() =>
+        expect(listLocalRepoWorktreesStrictMock).toHaveBeenCalledTimes(gitEnumerationConcurrency)
+      )
+      startedBeforeRelease = listLocalRepoWorktreesStrictMock.mock.calls.length
+    } finally {
+      gate.resolve(undefined)
+      await hydration
+    }
+
+    expect(startedBeforeRelease).toBe(gitEnumerationConcurrency)
+    expect(maxActive).toBe(gitEnumerationConcurrency)
+  })
+
+  it('registers successful adapter rows but retries a failed adapter', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+    const sessionA = {
+      sessionId: 'repo-a::/local/repo-a@@00000001',
+      pid: 4001,
+      cwd: '/local/repo-a'
+    } as unknown as SessionInfo
+    const sessionB = {
+      sessionId: 'repo-b::/local/repo-b@@00000002',
+      pid: 4002,
+      cwd: '/local/repo-b'
+    } as unknown as SessionInfo
+    const adapterA = makeProvider([sessionA])
+    const adapterB = {
+      listSessions: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('legacy unavailable'))
+        .mockRejectedValueOnce(new Error('legacy unavailable'))
+        .mockResolvedValue([sessionB])
+    }
+    getDaemonProviderMock.mockReturnValue(makeProviderGroup([adapterA, adapterB]))
+    listLocalRepoWorktreesStrictMock.mockImplementation(async (repo: Repo) => [
+      { path: `/local/${repo.id}`, head: '', branch: '', isBare: false, isMainWorktree: true }
+    ])
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const store = makeStore([{ id: 'repo-a' }, { id: 'repo-b' }])
+
+    await hydrate(store)
+    expect(listRegisteredPtys().map((pty) => pty.ptyId)).toEqual([sessionA.sessionId])
+
+    await hydrate(store)
+    warnSpy.mockRestore()
+
+    expect(
+      listRegisteredPtys()
+        .map((pty) => pty.ptyId)
+        .sort()
+    ).toEqual([sessionA.sessionId, sessionB.sessionId].sort())
+  })
+
+  it('retries an all-adapter inventory failure and latches only the complete retry', async () => {
+    const { hydrate } = await loadFresh()
+    const firstAdapter = {
+      listSessions: vi.fn().mockRejectedValueOnce(new Error('current down')).mockResolvedValue([])
+    }
+    const secondAdapter = {
+      listSessions: vi.fn().mockRejectedValueOnce(new Error('legacy down')).mockResolvedValue([])
+    }
+    getDaemonProviderMock.mockReturnValue(makeProviderGroup([firstAdapter, secondAdapter]))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await hydrate(makeStore())
+    await hydrate(makeStore())
+    await hydrate(makeStore())
+    warnSpy.mockRestore()
+
+    expect(firstAdapter.listSessions).toHaveBeenCalledTimes(2)
+    expect(secondAdapter.listSessions).toHaveBeenCalledTimes(2)
   })
 
   it('does not clobber a pre-existing registry pid with a null pid from listSessions', async () => {
@@ -183,7 +446,7 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
       { sessionId: ptyId, pid: null, cwd: '/local/Triton' } as unknown as SessionInfo
     ])
     getDaemonProviderMock.mockReturnValue(provider)
-    listRepoWorktreesMock.mockResolvedValue([
+    listLocalRepoWorktreesStrictMock.mockResolvedValue([
       { path: '/local/Triton', head: '', branch: '', isBare: false, isMainWorktree: true }
     ])
 
@@ -193,7 +456,7 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     expect(entry).toBeDefined()
     expect(entry!.pid).toBe(12345)
     expect(entry!.paneKey).toBe('tab-1:1')
-    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+    expect(listLocalRepoWorktreesStrictMock).not.toHaveBeenCalled()
   })
 
   it('does not clobber a pty:spawn registration that arrives during worktree enumeration', async () => {
@@ -207,10 +470,10 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
       createDeferred<
         { path: string; head: string; branch: string; isBare: boolean; isMainWorktree: boolean }[]
       >()
-    listRepoWorktreesMock.mockReturnValue(worktrees.promise)
+    listLocalRepoWorktreesStrictMock.mockReturnValue(worktrees.promise)
 
     const hydration = hydrate(makeStore([{ id: 'repo-a', connectionId: null }]))
-    await vi.waitFor(() => expect(listRepoWorktreesMock).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(listLocalRepoWorktreesStrictMock).toHaveBeenCalledTimes(1))
     registerPty({
       ptyId,
       worktreeId: 'repo-a::/local/Triton',
@@ -244,10 +507,10 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
       createDeferred<
         { path: string; head: string; branch: string; isBare: boolean; isMainWorktree: boolean }[]
       >()
-    listRepoWorktreesMock.mockReturnValue(worktrees.promise)
+    listLocalRepoWorktreesStrictMock.mockReturnValue(worktrees.promise)
 
     const hydration = hydrate(makeStore([{ id: 'repo-a', connectionId: null }]))
-    await vi.waitFor(() => expect(listRepoWorktreesMock).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(listLocalRepoWorktreesStrictMock).toHaveBeenCalledTimes(1))
     unregisterPty(ptyId)
     worktrees.resolve([
       { path: '/local/Triton', head: '', branch: '', isBare: false, isMainWorktree: true }
@@ -266,7 +529,7 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
       { sessionId: ptyId, pid: 999, cwd: '/remote/Stingray' } as unknown as SessionInfo
     ])
     getDaemonProviderMock.mockReturnValue(provider)
-    listRepoWorktreesMock.mockResolvedValue([
+    listLocalRepoWorktreesStrictMock.mockResolvedValue([
       { path: '/remote/Stingray', head: '', branch: '', isBare: false, isMainWorktree: true }
     ])
 
@@ -276,7 +539,24 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     // visible to the local process sampler. Mirrors the spawn-time gate
     // around `registerPty` in `pty.ts`'s `pty:spawn` handler.
     expect(listRegisteredPtys()).toHaveLength(0)
-    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+    expect(listLocalRepoWorktreesStrictMock).not.toHaveBeenCalled()
+  })
+
+  it('skips paired-runtime repos even when connectionId is absent', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+    const provider = makeProvider([
+      {
+        sessionId: 'repo-runtime::/runtime/Stingray@@feedface',
+        pid: 999,
+        cwd: '/runtime/Stingray'
+      } as unknown as SessionInfo
+    ])
+    getDaemonProviderMock.mockReturnValue(provider)
+
+    await hydrate(makeStore([{ id: 'repo-runtime', executionHostId: 'runtime:environment-1' }]))
+
+    expect(listRegisteredPtys()).toHaveLength(0)
+    expect(listLocalRepoWorktreesStrictMock).not.toHaveBeenCalled()
   })
 
   it('registers a local session whose worktree is in the store with the daemon-published pid', async () => {
@@ -287,7 +567,7 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
       { sessionId: ptyId, pid: 4242, cwd: '/local/Triton' } as unknown as SessionInfo
     ])
     getDaemonProviderMock.mockReturnValue(provider)
-    listRepoWorktreesMock.mockResolvedValue([
+    listLocalRepoWorktreesStrictMock.mockResolvedValue([
       { path: '/local/Triton', head: '', branch: '', isBare: false, isMainWorktree: true }
     ])
 
@@ -297,6 +577,221 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     expect(entry).toBeDefined()
     expect(entry!.pid).toBe(4242)
     expect(entry!.worktreeId).toBe('repo-a::/local/Triton')
+  })
+
+  it('matches Windows worktree path spelling while preserving the daemon worktree id', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+    const worktreeId = 'repo-a::C:/Users/Neil/Orca'
+    const ptyId = `${worktreeId}@@cafebabe`
+    getDaemonProviderMock.mockReturnValue(
+      makeProvider([
+        { sessionId: ptyId, pid: 4242, cwd: 'C:/Users/Neil/Orca' } as unknown as SessionInfo
+      ])
+    )
+    listLocalRepoWorktreesStrictMock.mockResolvedValue([
+      {
+        path: 'c:\\users\\neil\\orca',
+        head: '',
+        branch: '',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    await hydrate(makeStore([{ id: 'repo-a', path: 'C:\\Users\\Neil\\Orca' }]))
+
+    expect(listRegisteredPtys()).toEqual([expect.objectContaining({ ptyId, worktreeId })])
+  })
+
+  it('fails closed when live worktrees collide on one normalized key', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+    const ptyId = 'repo-a::C:/Users/Neil/Orca@@cafebabe'
+    getDaemonProviderMock.mockReturnValue(
+      makeProvider([
+        { sessionId: ptyId, pid: 4242, cwd: 'C:/Users/Neil/Orca' } as unknown as SessionInfo
+      ])
+    )
+    listLocalRepoWorktreesStrictMock.mockResolvedValue([
+      {
+        path: 'C:/Users/Neil/Orca',
+        head: '',
+        branch: '',
+        isBare: false,
+        isMainWorktree: true
+      },
+      {
+        path: 'c:\\users\\neil\\orca',
+        head: '',
+        branch: '',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await hydrate(makeStore([{ id: 'repo-a', path: 'C:/Users/Neil/Orca' }]))
+
+    expect(listRegisteredPtys()).toHaveLength(0)
+  })
+
+  it('matches local WSL UNC aliases without treating WSL as a remote host', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+    const worktreeId = 'repo-a::\\\\wsl$\\Ubuntu\\home\\neil\\orca'
+    const ptyId = `${worktreeId}@@cafebabe`
+    getDaemonProviderMock.mockReturnValue(
+      makeProvider([
+        {
+          sessionId: ptyId,
+          pid: 4242,
+          cwd: '\\\\wsl$\\Ubuntu\\home\\neil\\orca'
+        } as unknown as SessionInfo
+      ])
+    )
+    listLocalRepoWorktreesStrictMock.mockResolvedValue([
+      {
+        path: '\\\\wsl.localhost\\ubuntu\\home\\neil\\orca',
+        head: '',
+        branch: '',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    await hydrate(makeStore([{ id: 'repo-a', path: '\\\\wsl$\\Ubuntu\\home\\neil\\orca' }]))
+
+    expect(listRegisteredPtys()).toEqual([expect.objectContaining({ ptyId, worktreeId })])
+  })
+
+  it('preserves an exact repo-backed folder instance id from local-host metadata', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+    const instanceId =
+      'folder-repo::/workspace/folder::workspace:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    const ptyId = `${instanceId}@@cafebabe`
+    getDaemonProviderMock.mockReturnValue(
+      makeProvider([
+        { sessionId: ptyId, pid: 4242, cwd: '/workspace/folder' } as unknown as SessionInfo
+      ])
+    )
+
+    await hydrate(
+      makeStore([{ id: 'folder-repo', kind: 'folder', path: '/workspace/folder' }], {
+        [instanceId]: { hostId: 'local' } as WorktreeMeta
+      })
+    )
+
+    expect(listRegisteredPtys()).toEqual([
+      expect.objectContaining({ ptyId, worktreeId: instanceId })
+    ])
+    expect(listLocalRepoWorktreesStrictMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts legacy unhosted folder-instance metadata for a uniquely local repo', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+    const instanceId =
+      'folder-repo::/workspace/folder::workspace:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    const ptyId = `${instanceId}@@cafebabe`
+    getDaemonProviderMock.mockReturnValue(
+      makeProvider([
+        { sessionId: ptyId, pid: 4242, cwd: '/workspace/folder' } as unknown as SessionInfo
+      ])
+    )
+
+    await hydrate(
+      makeStore([{ id: 'folder-repo', kind: 'folder', path: '/workspace/folder' }], {
+        [instanceId]: {} as WorktreeMeta
+      })
+    )
+
+    expect(listRegisteredPtys()).toEqual([expect.objectContaining({ ptyId })])
+  })
+
+  it('rejects legacy folder-instance metadata when the repo id also has a remote owner', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+    const instanceId =
+      'folder-repo::/workspace/folder::workspace:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    getDaemonProviderMock.mockReturnValue(
+      makeProvider([
+        {
+          sessionId: `${instanceId}@@cafebabe`,
+          pid: 4242,
+          cwd: '/workspace/folder'
+        } as unknown as SessionInfo
+      ])
+    )
+
+    await hydrate(
+      makeStore(
+        [
+          { id: 'folder-repo', kind: 'folder', path: '/workspace/folder' },
+          {
+            id: 'folder-repo',
+            kind: 'folder',
+            path: '/workspace/folder',
+            executionHostId: 'runtime:environment-1'
+          }
+        ],
+        { [instanceId]: {} as WorktreeMeta }
+      )
+    )
+
+    expect(listRegisteredPtys()).toHaveLength(0)
+  })
+
+  it('accepts explicit local folder-instance metadata beside a same-id runtime owner', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+    const instanceId =
+      'folder-repo::/workspace/folder::workspace:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    const ptyId = `${instanceId}@@cafebabe`
+    getDaemonProviderMock.mockReturnValue(
+      makeProvider([
+        { sessionId: ptyId, pid: 4242, cwd: '/workspace/folder' } as unknown as SessionInfo
+      ])
+    )
+
+    await hydrate(
+      makeStore(
+        [
+          { id: 'folder-repo', kind: 'folder', path: '/workspace/folder' },
+          {
+            id: 'folder-repo',
+            kind: 'folder',
+            path: '/workspace/folder',
+            executionHostId: 'runtime:environment-1'
+          }
+        ],
+        { [instanceId]: { hostId: 'local' } as WorktreeMeta }
+      )
+    )
+
+    expect(listRegisteredPtys()).toEqual([expect.objectContaining({ ptyId })])
+  })
+
+  it('keeps true folder workspace PTY ids as an accepted hydration gap', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+    const workspace = {
+      id: 'folder-workspace-1',
+      executionHostId: 'local'
+    } as FolderWorkspace
+    getDaemonProviderMock.mockReturnValue(
+      makeProvider([
+        {
+          sessionId: 'folder:folder-workspace-1@@cafebabe',
+          pid: 4242,
+          cwd: '/workspace/folder'
+        } as unknown as SessionInfo
+      ])
+    )
+
+    expect(
+      resolveFolderWorkspaceHost(
+        { folderWorkspaces: [workspace], projectGroups: [], repos: [] },
+        workspace.id
+      )
+    ).toEqual({ kind: 'local' })
+
+    await hydrate(makeStore())
+
+    expect(listRegisteredPtys()).toHaveLength(0)
+    expect(listLocalRepoWorktreesStrictMock).not.toHaveBeenCalled()
   })
 
   it('does not register a daemon session whose worktree was removed', async () => {
@@ -309,13 +804,13 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
       } as unknown as SessionInfo
     ])
     getDaemonProviderMock.mockReturnValue(provider)
-    listRepoWorktreesMock.mockResolvedValue([
+    listLocalRepoWorktreesStrictMock.mockResolvedValue([
       { path: '/local/current', head: '', branch: '', isBare: false, isMainWorktree: true }
     ])
 
     await hydrate(makeStore([{ id: 'repo-a', connectionId: null }]))
 
-    expect(listRepoWorktreesMock).toHaveBeenCalledTimes(1)
+    expect(listLocalRepoWorktreesStrictMock).toHaveBeenCalledTimes(1)
     expect(listRegisteredPtys()).toHaveLength(0)
   })
 
@@ -334,7 +829,7 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
       )
     )
     getDaemonProviderMock.mockReturnValue(provider)
-    listRepoWorktreesMock.mockImplementation(async (repo: Repo) => [
+    listLocalRepoWorktreesStrictMock.mockImplementation(async (repo: Repo) => [
       {
         path: `/local/${repo.id}`,
         head: '',
@@ -346,8 +841,8 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
 
     await hydrate(makeStore(repos))
 
-    expect(listRepoWorktreesMock).toHaveBeenCalledTimes(activeRepoIds.length)
-    expect(listRepoWorktreesMock.mock.calls.map(([repo]) => (repo as Repo).id)).toEqual(
+    expect(listLocalRepoWorktreesStrictMock).toHaveBeenCalledTimes(activeRepoIds.length)
+    expect(listLocalRepoWorktreesStrictMock.mock.calls.map(([repo]) => (repo as Repo).id)).toEqual(
       activeRepoIds
     )
     expect(listRegisteredPtys()).toHaveLength(activeRepoIds.length)
@@ -374,13 +869,13 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
       .mockResolvedValueOnce([sessionA])
       .mockResolvedValue([sessionA, sessionB])
     getDaemonProviderMock.mockReturnValue({ listSessions })
-    listRepoWorktreesMock.mockImplementation(async (repo: Repo) => [
+    listLocalRepoWorktreesStrictMock.mockImplementation(async (repo: Repo) => [
       { path: `/local/${repo.id}`, head: '', branch: '', isBare: false, isMainWorktree: true }
     ])
 
     await hydrate(makeStore([{ id: 'repo-a' }, { id: 'repo-b' }]))
 
-    expect(listRepoWorktreesMock.mock.calls.map(([repo]) => (repo as Repo).id)).toEqual([
+    expect(listLocalRepoWorktreesStrictMock.mock.calls.map(([repo]) => (repo as Repo).id)).toEqual([
       'repo-a',
       'repo-b'
     ])
@@ -398,7 +893,7 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     const sessions = makeLocalSessions('repo-a', '/local/Triton', LARGE_SESSION_COUNT)
     const provider = makeProvider(sessions)
     getDaemonProviderMock.mockReturnValue(provider)
-    listRepoWorktreesMock.mockResolvedValue([
+    listLocalRepoWorktreesStrictMock.mockResolvedValue([
       { path: '/local/Triton', head: '', branch: '', isBare: false, isMainWorktree: true }
     ])
 

--- a/src/main/memory/hydrate-local-pty-registry.ts
+++ b/src/main/memory/hydrate-local-pty-registry.ts
@@ -1,146 +1,279 @@
-/**
- * Boot-time hydration of `pty-registry` from the live daemon.
- *
- * Why: on warm reattach (fresh Orca process, still-running daemon) the renderer
- * hasn't re-mounted every pane, so `pty:spawn` never fired for those sessions
- * and they surfaced as "REMOTE" despite being local. Fill the gap once at boot,
- * registering only sessions whose repo has no `connectionId` — mirroring the
- * spawn-time gate in `src/main/ipc/pty.ts`.
- */
-
-import { getDaemonProvider } from '../daemon/daemon-init'
-import { DaemonPtyRouter } from '../daemon/daemon-pty-router'
-import { DegradedDaemonPtyProvider } from '../daemon/degraded-daemon-pty-provider'
-import type { DaemonPtyAdapter } from '../daemon/daemon-pty-adapter'
-import type { SessionInfo } from '../daemon/types'
-import { listRegisteredPtys, registerPty } from './pty-registry'
-import { listRepoWorktrees } from '../repo-worktrees'
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
+import { throwIfSignalAborted, waitForPromiseWithSignal } from '../../shared/abort-signal-reason'
+import { mapSettledWithConcurrency } from '../../shared/map-with-concurrency'
 import { parsePtySessionId } from '../../shared/pty-session-id-format'
-import { splitWorktreeId } from '../../shared/worktree/id'
+import { isFolderRepo } from '../../shared/repo-kind'
+import type { Repo } from '../../shared/repo-types'
+import { splitWorktreeId, worktreeIdComparisonKey } from '../../shared/worktree/id'
+import { getDaemonProvider } from '../daemon/daemon-init'
+import type { DaemonPtyAdapter } from '../daemon/daemon-pty-adapter'
+import type { DaemonPtyRouter } from '../daemon/daemon-pty-router'
+import type { DegradedDaemonPtyProvider } from '../daemon/degraded-daemon-pty-provider'
+import type { SessionInfo } from '../daemon/types'
+import { isFolderWorkspaceIdForRepo } from '../ipc/worktrees/folder-workspace-model'
 import type { Store } from '../persistence'
+import { readAllWorktreeMetaForHost } from '../persistence/host-qualified-worktree-meta'
+import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
+import { listLocalRepoWorktreesStrict } from '../repo-worktrees'
+import { listRegisteredPtys, registerPty } from './pty-registry'
 
-// Why: macOS dock reactivation reruns setup; avoid repeating Git I/O and daemon RPC.
+type HydrationStore = Store
+
+type DaemonInventory = {
+  complete: boolean
+  sessions: SessionInfo[]
+}
+
+type LocalRepoCatalog = {
+  byId: Map<string, Repo>
+  ownerCountById: Map<string, number>
+}
+
+// Why: matches existing local Git/read startup budgets while allowing for Defender-heavy repos.
+export const LOCAL_PTY_REGISTRY_BOOT_HYDRATION_DEADLINE_MS = 5_000
+export const LOCAL_PTY_REGISTRY_GIT_ENUMERATION_CONCURRENCY = 4
+
 let hasHydrated = false
+let hydrationInFlight: Promise<void> | null = null
 
-/**
- * Read the live daemon session list and register every local session the
- * registry doesn't already know about.
- *
- * Why: failures here are a coverage degradation (the renderer-side union still
- * covers the gap), not a correctness regression, so they're swallowed.
- */
-export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos'>): Promise<void> {
-  try {
-    if (hasHydrated) {
-      return
-    }
-    const provider = getDaemonProvider()
-    if (!provider) {
-      // Why: leave hasHydrated false so a later activation can retry once the daemon is up.
-      return
-    }
-    // Why: flip only after a provider exists; retrying a failed RPC on the same socket won't help.
-    hasHydrated = true
+export function hydrateLocalPtyRegistryAtBoot(store: HydrationStore): Promise<void> {
+  if (hasHydrated) {
+    return Promise.resolve()
+  }
+  if (hydrationInFlight) {
+    return hydrationInFlight
+  }
 
-    // Why: enumerate Git worktrees only for live-session repos.
-    const reposById = new Map(store.getRepos().map((repo) => [repo.id, repo]))
-    // Why: verify via live git that a referenced worktree still exists, to avoid resurrecting removed ones.
-    const liveLocalWorktreeIds = new Set<string>()
-    const resolvedRepoIds = new Set<string>()
-
-    let sessionInfos = await collectSessionInfos(provider)
-    let alreadyRegistered = new Set(listRegisteredPtys().map((p) => p.ptyId))
-
-    // Why: re-read live sessions each pass to avoid resurrecting exited sessions.
-    for (;;) {
-      const newlyReferencedRepos = new Map<string, ReturnType<(typeof store)['getRepos']>[number]>()
-      for (const info of sessionInfos) {
-        if (alreadyRegistered.has(info.sessionId)) {
-          continue
-        }
-        const { worktreeId } = parsePtySessionId(info.sessionId)
-        const parsedWorktreeId = worktreeId ? splitWorktreeId(worktreeId) : null
-        if (!parsedWorktreeId || resolvedRepoIds.has(parsedWorktreeId.repoId)) {
-          continue
-        }
-        const repo = reposById.get(parsedWorktreeId.repoId)
-        if (!repo || (repo.connectionId ?? null)) {
-          // Why: unknown and SSH repos cannot be proven local, so do not enumerate them.
-          resolvedRepoIds.add(parsedWorktreeId.repoId)
-          continue
-        }
-        newlyReferencedRepos.set(repo.id, repo)
+  const controller = new AbortController()
+  const deadline = setTimeout(() => {
+    controller.abort(new Error('Boot-time pty-registry hydration deadline expired'))
+  }, LOCAL_PTY_REGISTRY_BOOT_HYDRATION_DEADLINE_MS)
+  let attempt!: Promise<void>
+  attempt = waitForPromiseWithSignal(
+    hydrateLocalPtyRegistry(store, controller.signal),
+    controller.signal
+  )
+    .then((complete) => {
+      if (complete) {
+        hasHydrated = true
       }
-      if (newlyReferencedRepos.size === 0) {
-        break
+    })
+    .catch((error) => {
+      console.warn(
+        '[memory] Boot-time pty-registry hydration failed:',
+        error instanceof Error ? error.message : String(error)
+      )
+    })
+    .finally(() => {
+      clearTimeout(deadline)
+      if (hydrationInFlight === attempt) {
+        hydrationInFlight = null
       }
+    })
+  hydrationInFlight = attempt
+  return attempt
+}
 
-      for (const repo of newlyReferencedRepos.values()) {
-        resolvedRepoIds.add(repo.id)
-        const worktrees = await listRepoWorktrees(repo)
-        for (const wt of worktrees) {
-          liveLocalWorktreeIds.add(`${repo.id}::${wt.path}`)
-        }
-      }
+async function hydrateLocalPtyRegistry(
+  store: HydrationStore,
+  signal: AbortSignal
+): Promise<boolean> {
+  throwIfSignalAborted(signal)
+  const provider = getDaemonProvider()
+  if (!provider) {
+    return false
+  }
 
-      sessionInfos = await collectSessionInfos(provider)
-      alreadyRegistered = new Set(listRegisteredPtys().map((p) => p.ptyId))
-    }
-    for (const info of sessionInfos) {
-      // Why: pty:spawn is the authoritative pid writer; don't overwrite its entry with a stale listSessions() pid.
+  const repoCatalog = getLocalRepoCatalog(store.getRepos())
+  const reposById = repoCatalog.byId
+  const verifiedFolderWorktreeIds = getVerifiedFolderWorktreeIds(store, repoCatalog)
+  const liveGitWorktreeIdsByKey = new Map<string, string | null>()
+  const resolvedRepoIds = new Set<string>()
+  let inventory = await collectSessionInfos(provider, signal)
+  let complete = inventory.complete
+  let alreadyRegistered = new Set(listRegisteredPtys().map((pty) => pty.ptyId))
+
+  for (;;) {
+    const referencedRepos = new Map<string, Repo>()
+    for (const info of inventory.sessions) {
       if (alreadyRegistered.has(info.sessionId)) {
         continue
       }
-      const { worktreeId } = parsePtySessionId(info.sessionId)
-      if (!worktreeId) {
+      const parsed = splitWorktreeId(parsePtySessionId(info.sessionId).worktreeId ?? '')
+      if (!parsed || resolvedRepoIds.has(parsed.repoId)) {
         continue
       }
-      // Why: register only proven-local worktrees, matching the spawn-time gate.
-      if (!liveLocalWorktreeIds.has(worktreeId)) {
+      const repo = reposById.get(parsed.repoId)
+      if (!repo || isFolderRepo(repo)) {
+        resolvedRepoIds.add(parsed.repoId)
         continue
       }
-      registerPty({
-        ptyId: info.sessionId,
-        worktreeId,
-        sessionId: info.sessionId,
-        paneKey: null,
-        pid:
-          typeof info.pid === 'number' && Number.isFinite(info.pid) && info.pid > 0
-            ? info.pid
-            : null
-      })
+      referencedRepos.set(repo.id, repo)
     }
-  } catch (err) {
-    console.warn(
-      '[memory] Boot-time pty-registry hydration failed:',
-      err instanceof Error ? err.message : String(err)
+    if (referencedRepos.size === 0) {
+      break
+    }
+    for (const repo of referencedRepos.values()) {
+      resolvedRepoIds.add(repo.id)
+    }
+
+    const worktreeResults = await mapSettledWithConcurrency(
+      [...referencedRepos.values()],
+      LOCAL_PTY_REGISTRY_GIT_ENUMERATION_CONCURRENCY,
+      async (repo) => {
+        throwIfSignalAborted(signal)
+        const worktrees = await waitForPromiseWithSignal(
+          listLocalRepoWorktreesStrict(repo, {
+            ...getLocalProjectWorktreeGitOptions(store, repo),
+            signal
+          }),
+          signal
+        )
+        throwIfSignalAborted(signal)
+        return { repo, worktrees }
+      }
     )
+    throwIfSignalAborted(signal)
+
+    for (const result of worktreeResults) {
+      if (result.status === 'rejected') {
+        complete = false
+        console.warn(
+          '[memory] Worktree enumeration failed during pty-registry hydration:',
+          result.reason instanceof Error ? result.reason.message : String(result.reason)
+        )
+        continue
+      }
+      const { repo, worktrees } = result.value
+      for (const worktree of worktrees) {
+        const worktreeId = `${repo.id}::${worktree.path}`
+        const key = worktreeIdComparisonKey(worktreeId)
+        if (key) {
+          const existing = liveGitWorktreeIdsByKey.get(key)
+          liveGitWorktreeIdsByKey.set(
+            key,
+            existing === undefined || existing === worktreeId ? worktreeId : null
+          )
+        }
+      }
+    }
+
+    inventory = await collectSessionInfos(provider, signal)
+    complete = complete && inventory.complete
+    alreadyRegistered = new Set(listRegisteredPtys().map((pty) => pty.ptyId))
+  }
+
+  throwIfSignalAborted(signal)
+  for (const info of inventory.sessions) {
+    throwIfSignalAborted(signal)
+    if (alreadyRegistered.has(info.sessionId)) {
+      continue
+    }
+    const { worktreeId } = parsePtySessionId(info.sessionId)
+    if (!worktreeId || !isVerifiedLocalWorktree(worktreeId)) {
+      continue
+    }
+    registerPty({
+      ptyId: info.sessionId,
+      worktreeId,
+      sessionId: info.sessionId,
+      paneKey: null,
+      pid:
+        typeof info.pid === 'number' && Number.isFinite(info.pid) && info.pid > 0 ? info.pid : null
+    })
+  }
+  return complete
+
+  function isVerifiedLocalWorktree(worktreeId: string): boolean {
+    if (verifiedFolderWorktreeIds.has(worktreeId)) {
+      return true
+    }
+    const key = worktreeIdComparisonKey(worktreeId)
+    return key !== null && typeof liveGitWorktreeIdsByKey.get(key) === 'string'
   }
 }
 
-async function collectSessionInfos(
-  provider: DaemonPtyRouter | DaemonPtyAdapter | DegradedDaemonPtyProvider
-): Promise<SessionInfo[]> {
-  // Why: fan listSessions across current + legacy adapters so no daemon protocol version is missed.
-  const adapters: readonly DaemonPtyAdapter[] =
-    provider instanceof DaemonPtyRouter || provider instanceof DegradedDaemonPtyProvider
-      ? provider.getAllAdapters()
-      : [provider]
-  const out: SessionInfo[] = []
-  for (const adapter of adapters) {
-    try {
-      const sessions = await adapter.listSessions()
-      // Why: session count can exceed the JS argument limit, so avoid push(...sessions).
-      for (const session of sessions) {
-        out.push(session)
-      }
-    } catch (err) {
-      // Why: one adapter's socket being unreachable is normal; don't abort the others.
-      console.warn(
-        '[memory] listSessions failed for one adapter during hydration:',
-        err instanceof Error ? err.message : String(err)
-      )
+function getLocalRepoCatalog(repos: Repo[]): LocalRepoCatalog {
+  const byId = new Map<string, Repo>()
+  const ownerCountById = new Map<string, number>()
+  const ambiguousIds = new Set<string>()
+  for (const repo of repos) {
+    ownerCountById.set(repo.id, (ownerCountById.get(repo.id) ?? 0) + 1)
+    if (getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID) {
+      continue
+    }
+    if (byId.has(repo.id)) {
+      ambiguousIds.add(repo.id)
+    } else {
+      byId.set(repo.id, repo)
     }
   }
-  return out
+  for (const repoId of ambiguousIds) {
+    byId.delete(repoId)
+  }
+  return { byId, ownerCountById }
+}
+
+function getVerifiedFolderWorktreeIds(
+  store: HydrationStore,
+  repoCatalog: LocalRepoCatalog
+): Set<string> {
+  const verified = new Set<string>()
+  const metadata = readAllWorktreeMetaForHost(store, LOCAL_EXECUTION_HOST_ID)
+  for (const [worktreeId, meta] of Object.entries(metadata)) {
+    const parsed = splitWorktreeId(worktreeId)
+    const repo = parsed ? repoCatalog.byId.get(parsed.repoId) : undefined
+    const hasLocalAuthority =
+      meta.hostId === LOCAL_EXECUTION_HOST_ID ||
+      (meta.hostId === undefined && repoCatalog.ownerCountById.get(parsed?.repoId ?? '') === 1)
+    if (
+      repo &&
+      isFolderRepo(repo) &&
+      hasLocalAuthority &&
+      isFolderWorkspaceIdForRepo(repo, worktreeId)
+    ) {
+      verified.add(worktreeId)
+    }
+  }
+  return verified
+}
+
+async function collectSessionInfos(
+  provider: DaemonPtyRouter | DaemonPtyAdapter | DegradedDaemonPtyProvider,
+  signal: AbortSignal
+): Promise<DaemonInventory> {
+  const adapters =
+    'getAllAdapters' in provider && typeof provider.getAllAdapters === 'function'
+      ? provider.getAllAdapters()
+      : [provider]
+  const results = await Promise.all(
+    adapters.map(async (adapter) => {
+      try {
+        throwIfSignalAborted(signal)
+        const sessions = await waitForPromiseWithSignal<SessionInfo[]>(
+          adapter.listSessions(),
+          signal
+        )
+        throwIfSignalAborted(signal)
+        return { complete: true, sessions }
+      } catch (error) {
+        throwIfSignalAborted(signal)
+        console.warn(
+          '[memory] listSessions failed for one adapter during hydration:',
+          error instanceof Error ? error.message : String(error)
+        )
+        return { complete: false, sessions: [] }
+      }
+    })
+  )
+  const sessions: SessionInfo[] = []
+  for (const result of results) {
+    for (const session of result.sessions) {
+      sessions.push(session)
+    }
+  }
+  return {
+    complete: results.length > 0 && results.every((result) => result.complete),
+    sessions
+  }
 }

--- a/src/main/orcad/orcad-entry.ts
+++ b/src/main/orcad/orcad-entry.ts
@@ -190,7 +190,7 @@ async function startOrcadRuntime(
   // Codex-home and Claude-auth preparation are left unset: both are desktop account
   // flows. A launch that needs one fails with its own message rather than silently
   // spawning an unauthenticated agent.
-  registerHeadlessPtyRuntime(runtime, undefined, () => store.getSettings(), undefined, store)
+  await registerHeadlessPtyRuntime(runtime, undefined, () => store.getSettings(), undefined, store)
 
   // Why: same post-registration reconciliation `--serve` performs. Skipping it leaves
   // restored orchestration rows claiming an authority this host never took over.

--- a/src/main/repo-worktrees.test.ts
+++ b/src/main/repo-worktrees.test.ts
@@ -1,18 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { listWorktreesMock } = vi.hoisted(() => ({
-  listWorktreesMock: vi.fn()
+const { listWorktreesMock, listWorktreesStrictMock } = vi.hoisted(() => ({
+  listWorktreesMock: vi.fn(),
+  listWorktreesStrictMock: vi.fn()
 }))
 
 vi.mock('./git/worktree', () => ({
-  listWorktrees: listWorktreesMock
+  listWorktrees: listWorktreesMock,
+  listWorktreesStrict: listWorktreesStrictMock
 }))
 
-import { createFolderWorktree, isRepoRoot, listRepoWorktrees } from './repo-worktrees'
+import {
+  createFolderWorktree,
+  isRepoRoot,
+  listLocalRepoWorktreesStrict,
+  listRepoWorktrees
+} from './repo-worktrees'
 
 describe('repo-worktrees', () => {
   beforeEach(() => {
     listWorktreesMock.mockReset()
+    listWorktreesStrictMock.mockReset()
   })
 
   it('creates a stable synthetic worktree for folder repos', () => {
@@ -56,6 +64,29 @@ describe('repo-worktrees', () => {
     expect(listWorktreesMock).not.toHaveBeenCalled()
   })
 
+  it('returns the synthetic folder worktree for strict local listing', async () => {
+    const result = await listLocalRepoWorktreesStrict({
+      id: 'repo-1',
+      path: '/workspace/folder',
+      displayName: 'folder',
+      badgeColor: '#000',
+      addedAt: 0,
+      kind: 'folder'
+    })
+
+    expect(result).toEqual([
+      createFolderWorktree({
+        id: 'repo-1',
+        path: '/workspace/folder',
+        displayName: 'folder',
+        badgeColor: '#000',
+        addedAt: 0,
+        kind: 'folder'
+      })
+    ])
+    expect(listWorktreesStrictMock).not.toHaveBeenCalled()
+  })
+
   it('delegates to git worktree listing for git repos', async () => {
     listWorktreesMock.mockResolvedValue([
       { path: '/workspace/repo', head: 'abc', branch: '', isBare: false, isMainWorktree: true }
@@ -76,6 +107,46 @@ describe('repo-worktrees', () => {
 
     expect(listWorktreesMock).toHaveBeenCalledWith('/workspace/repo', { signal })
     expect(result).toHaveLength(1)
+  })
+
+  it('delegates strict local listing with the signal and WSL options', async () => {
+    listWorktreesStrictMock.mockResolvedValue([
+      { path: '/workspace/repo', head: 'abc', branch: '', isBare: false, isMainWorktree: true }
+    ])
+    const signal = new AbortController().signal
+
+    const result = await listLocalRepoWorktreesStrict(
+      {
+        id: 'repo-1',
+        path: '/workspace/repo',
+        displayName: 'repo',
+        badgeColor: '#000',
+        addedAt: 0,
+        kind: 'git'
+      },
+      { signal, wslDistro: 'Ubuntu' }
+    )
+
+    expect(listWorktreesStrictMock).toHaveBeenCalledWith('/workspace/repo', {
+      signal,
+      wslDistro: 'Ubuntu'
+    })
+    expect(result).toHaveLength(1)
+  })
+
+  it('rejects strict listing for remote repos', async () => {
+    await expect(
+      listLocalRepoWorktreesStrict({
+        id: 'repo-1',
+        path: '/workspace/repo',
+        displayName: 'repo',
+        badgeColor: '#000',
+        addedAt: 0,
+        connectionId: 'ssh-1',
+        kind: 'git'
+      })
+    ).rejects.toThrow('remote repository')
+    expect(listWorktreesStrictMock).not.toHaveBeenCalled()
   })
 
   it('treats Windows repo root casing differences as the same local root', () => {

--- a/src/main/repo-worktrees.ts
+++ b/src/main/repo-worktrees.ts
@@ -1,6 +1,6 @@
 import type { Repo } from '../shared/repo-types'
 import type { GitWorktreeInfo } from '../shared/worktree/types'
-import { listWorktrees } from './git/worktree'
+import { listWorktrees, listWorktreesStrict } from './git/worktree'
 import { isFolderRepo } from '../shared/repo-kind'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
 import { areWorktreePathsEqual } from './ipc/worktree-logic'
@@ -50,4 +50,19 @@ export async function listRepoWorktrees(
   return hasLocalRepoWorktreeListOptions(options)
     ? await listWorktrees(repo.path, options)
     : await listWorktrees(repo.path)
+}
+
+export async function listLocalRepoWorktreesStrict(
+  repo: Repo,
+  options?: LocalRepoWorktreeListOptions
+): Promise<GitWorktreeInfo[]> {
+  if (repo.connectionId) {
+    throw new Error('Cannot list worktrees for a remote repository')
+  }
+  if (isFolderRepo(repo)) {
+    return [createFolderWorktree(repo)]
+  }
+  return hasLocalRepoWorktreeListOptions(options)
+    ? await listWorktreesStrict(repo.path, options)
+    : await listWorktreesStrict(repo.path)
 }

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -121,6 +121,7 @@ describe('startup ordering', () => {
     expect(desktopStartup).toContain(
       'openWindow: () => openMainWindow({ revealOnDidFinishLoad: true })'
     )
+    expect(desktopStartup).toContain('bindServices: bindTerminalRuntimeStartupServices')
     expect(desktopStartup).toContain('shellPathReady,')
     expect(desktopStartup).toContain('startServices: startTerminalRuntimeStartupServices')
     expect(barrier).toContain('managedWslCliStartupBarrierReady')

--- a/src/main/startup/headless-pty-hydration-ordering.test.ts
+++ b/src/main/startup/headless-pty-hydration-ordering.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('headless PTY registry hydration ordering', () => {
+  it('uses exactly one deferred-or-immediate desktop hydration path', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/main/window/attach-main-window-services.ts'),
+      'utf8'
+    )
+    const start = source.indexOf('const localPtyProviderStartupReady =')
+    const end = source.indexOf('registerSshHandlers(', start)
+    const hydration = source.slice(start, end)
+
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(end).toBeGreaterThan(start)
+    expect(hydration).toContain('if (localPtyProviderStartupReady)')
+    expect(hydration).toContain('.then(() => hydrateLocalPtyRegistryAtBoot(store))')
+    expect(hydration).toContain('} else {\n    void hydrateLocalPtyRegistryAtBoot(store)')
+    expect(hydration.match(/hydrateLocalPtyRegistryAtBoot\(store\)/g)).toHaveLength(2)
+  })
+
+  it('hydrates Electron serve after provider and handler readiness but before RPC', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const serve = source.indexOf('if (serveOptions) {')
+    const provider = source.indexOf('await localPtyProviderStartupReady', serve)
+    const handlersAndHydration = source.indexOf('await registerHeadlessPtyRuntime(', provider)
+    const rpc = source.indexOf('await runtimeRpc.start()', handlersAndHydration)
+    const readiness = source.indexOf('await printServeReady(serveOptions)', rpc)
+
+    expect(serve).toBeGreaterThanOrEqual(0)
+    expect(provider).toBeGreaterThan(serve)
+    expect(handlersAndHydration).toBeGreaterThan(provider)
+    expect(rpc).toBeGreaterThan(handlersAndHydration)
+    expect(readiness).toBeGreaterThan(rpc)
+  })
+
+  it('hydrates orcad after Store and daemon readiness but before RPC and publication', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/orcad/orcad-entry.ts'), 'utf8')
+    const store = source.indexOf('const store = new Store(')
+    const daemon = source.indexOf('await startOrcadDaemon()', store)
+    const handlersAndHydration = source.indexOf('await registerHeadlessPtyRuntime(', daemon)
+    const rpc = source.indexOf('await rpc.start()', handlersAndHydration)
+    const readiness = source.indexOf('await new ServeReadinessPublisher().publish(', rpc)
+
+    expect(store).toBeGreaterThanOrEqual(0)
+    expect(daemon).toBeGreaterThan(store)
+    expect(handlersAndHydration).toBeGreaterThan(daemon)
+    expect(rpc).toBeGreaterThan(handlersAndHydration)
+    expect(readiness).toBeGreaterThan(rpc)
+  })
+})

--- a/src/main/startup/serve-desktop-activation-wiring.test.ts
+++ b/src/main/startup/serve-desktop-activation-wiring.test.ts
@@ -21,12 +21,19 @@ describe('serve desktop activation wiring', () => {
     )
     const serveIndex = source.indexOf('if (serveOptions) {', appReadyIndex)
     const ptyReadyIndex = source.indexOf('await localPtyStartupReady', serveIndex)
-    const headlessRegistrationIndex = source.indexOf('registerHeadlessPtyRuntime(', serveIndex)
+    const providerReadyIndex = source.indexOf('await localPtyProviderStartupReady', serveIndex)
+    const headlessRegistrationIndex = source.indexOf(
+      'await registerHeadlessPtyRuntime(',
+      serveIndex
+    )
+    const rpcIndex = source.indexOf('await runtimeRpc.start()', serveIndex)
 
     expect(startupIndex).toBeGreaterThanOrEqual(0)
     expect(startupIndex).toBeLessThan(serveIndex)
     expect(ptyReadyIndex).toBeGreaterThan(serveIndex)
-    expect(headlessRegistrationIndex).toBeGreaterThan(ptyReadyIndex)
+    expect(providerReadyIndex).toBeGreaterThan(ptyReadyIndex)
+    expect(headlessRegistrationIndex).toBeGreaterThan(providerReadyIndex)
+    expect(headlessRegistrationIndex).toBeLessThan(rpcIndex)
     expect(source).not.toContain(
       'if (!isServeMode) {\n    startDesktopFirstWindowStartupServices()'
     )

--- a/src/main/startup/windows-desktop-shell-path-startup.test.ts
+++ b/src/main/startup/windows-desktop-shell-path-startup.test.ts
@@ -10,6 +10,29 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
 }
 
 describe('Windows desktop shell PATH startup', () => {
+  it('binds the services promise before opening the window while shell PATH is unresolved', () => {
+    const shellPath = deferred()
+    const events: string[] = []
+    const bindServices = vi.fn(() => events.push('bind'))
+    const openWindow = vi.fn(() => events.push('open'))
+    const options = {
+      bindServices,
+      openWindow,
+      shellPathReady: shellPath.promise,
+      startServices: vi.fn(() => ({
+        firstWindowReady: Promise.resolve(),
+        localPtyReady: Promise.resolve(),
+        localPtyProviderReady: Promise.resolve()
+      }))
+    }
+
+    startWindowsDesktopBeforeShellPathReady(options)
+
+    expect(events).toEqual(['bind', 'open'])
+    expect(bindServices).toHaveBeenCalledOnce()
+    expect(options.startServices).not.toHaveBeenCalled()
+  })
+
   it('opens the first window while shell PATH hydration remains unresolved', async () => {
     const shellPath = deferred()
     const window = { visible: true }
@@ -21,6 +44,7 @@ describe('Windows desktop shell PATH startup', () => {
     }))
 
     const startup = startWindowsDesktopBeforeShellPathReady({
+      bindServices: vi.fn(),
       openWindow,
       shellPathReady: shellPath.promise,
       startServices

--- a/src/main/startup/windows-desktop-shell-path-startup.ts
+++ b/src/main/startup/windows-desktop-shell-path-startup.ts
@@ -5,6 +5,7 @@ export type WindowsDesktopStartupServices = {
 }
 
 type WindowsDesktopShellPathStartupOptions<TWindow> = {
+  bindServices: (services: Promise<WindowsDesktopStartupServices>) => void
   openWindow: () => TWindow
   shellPathReady: Promise<void>
   startServices: () => WindowsDesktopStartupServices
@@ -14,5 +15,6 @@ export function startWindowsDesktopBeforeShellPathReady<TWindow>(
   options: WindowsDesktopShellPathStartupOptions<TWindow>
 ): { window: TWindow; services: Promise<WindowsDesktopStartupServices> } {
   const services = options.shellPathReady.then(options.startServices)
+  options.bindServices(services)
   return { window: options.openWindow(), services }
 }

--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -271,8 +271,8 @@ describe('attachMainWindowServices', () => {
     expect(mainWindow.webContents.reload).toHaveBeenCalledTimes(1)
   })
 
-  it('retries local PTY registry hydration after local startup services are ready', async () => {
-    const localStartup = deferred()
+  it('hydrates once after the local PTY provider barrier resolves', async () => {
+    const providerStartup = deferred()
     const store = createStore()
 
     attachMainWindowServices(
@@ -281,18 +281,17 @@ describe('attachMainWindowServices', () => {
       createRuntime() as never,
       undefined,
       undefined,
-      { awaitLocalPtyStartup: () => localStartup.promise }
+      { awaitLocalPtyProviderStartup: () => providerStartup.promise }
     )
 
-    expect(hydrateLocalPtyRegistryAtBootMock).toHaveBeenCalledTimes(1)
-    expect(hydrateLocalPtyRegistryAtBootMock).toHaveBeenCalledWith(store)
+    expect(hydrateLocalPtyRegistryAtBootMock).not.toHaveBeenCalled()
 
-    localStartup.resolve()
-    await localStartup.promise
+    providerStartup.resolve()
+    await providerStartup.promise
     await Promise.resolve()
 
-    expect(hydrateLocalPtyRegistryAtBootMock).toHaveBeenCalledTimes(2)
-    expect(hydrateLocalPtyRegistryAtBootMock).toHaveBeenLastCalledWith(store)
+    expect(hydrateLocalPtyRegistryAtBootMock).toHaveBeenCalledOnce()
+    expect(hydrateLocalPtyRegistryAtBootMock).toHaveBeenCalledWith(store)
   })
 
   it('passes injected update quit cleanup to the auto-updater', async () => {

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -146,11 +146,9 @@ export function attachMainWindowServices(
   scheduleHistoryGc(async () => {
     return getKnownWorktreeIdsForHistoryGc(store)
   })
-  // Why: daemon PTYs survive renderer restarts, so at boot they're unregistered; hydrate so they aren't mislabeled REMOTE (idempotent, safe to re-run).
-  void hydrateLocalPtyRegistryAtBoot(store)
-  const localPtyStartupReady = options?.awaitLocalPtyStartup?.()
-  if (localPtyStartupReady) {
-    void localPtyStartupReady
+  const localPtyProviderStartupReady = options?.awaitLocalPtyProviderStartup?.()
+  if (localPtyProviderStartupReady) {
+    void localPtyProviderStartupReady
       .then(() => hydrateLocalPtyRegistryAtBoot(store))
       .catch((error) => {
         console.warn(
@@ -158,6 +156,8 @@ export function attachMainWindowServices(
           error instanceof Error ? error.message : String(error)
         )
       })
+  } else {
+    void hydrateLocalPtyRegistryAtBoot(store)
   }
   registerSshHandlers(store, () => mainWindow, runtime)
   registerRemoteWorkspaceHandlers(store, () => mainWindow)


### PR DESCRIPTION
## Description

This PR fixes a Windows startup/resource-accounting defect discovered while investigating four renderer OOM reports with nearly exhausted system commit.

Packaged Windows opened the first window before binding the real terminal startup-services promise. `attachMainWindowServices` therefore captured a resolved placeholder, attempted memory-registry hydration before the daemon/provider existed, and never retried through the real readiness barrier. The result was materially incomplete diagnostics for daemon-retained PTYs.

The change:

- binds the real startup-services promise before the first Windows window opens;
- hydrates desktop terminal ownership after provider readiness without delaying the visible window;
- makes `--serve` and `orcad` await the same bounded path before RPC/readiness publication;
- coalesces concurrent hydration, limits Git inventory to four repo tasks, and applies one five-second overall deadline;
- uses strict Git enumeration so transient failures cannot masquerade as a verified-empty inventory and permanently latch completion;
- forwards the selected WSL distro and live abort signal to strict Git enumeration;
- leaves partial/failed/expired attempts retryable while attempting each repo only once per hydration;
- preserves existing `pty:spawn` PID/pane ownership and keeps SSH, paired-runtime, ambiguous metadata, duplicate ownership, and normalized-path collisions fail-closed.

This is a diagnostics/resource-accounting correctness fix. It does **not** prove which process consumed the historical Windows commit, reduce memory by itself, or claim to prevent the reported OOMs.

## Crash evidence and reproduction

The four grouped Windows reports had only **51, 129, 158, and 379 MB** of commit headroom out of **130,345 MB**, while **17,619–20,031 MB of physical RAM remained free**. One minidump states `VirtualAlloc failed`; the other three share exception `0xe0000008` at `KERNELBASE+0xc187a`. Renderer memory was modest/nonmonotonic. GPU failures correlate, but are not proven causal.

The destructive system-wide OOM was not induced. The concrete accounting defect was reproduced safely on Windows:

- `orca terminal list`: **40 sessions**
- `orca diagnostics memory`: **5 sessions**
- **34 omitted PTY roots / 5,184.7 MB private bytes**
- detached daemon: **720.6 MB private bytes**

## Clear fix evidence

### Deterministic red

- Packaged Windows startup-order test before the fix: **1 failed / 1 passed**.
  - observed: `['open']`
  - required: `['bind', 'open']`
- First adversarial revision test: hydration suite **2 failed / 24 passed** because stalled Git enumeration exceeded the test timeout and no concurrency contract existed.
- Second adversarial pass proved the legacy fail-soft Git path can resolve a timeout as `[]`; the new strict-vs-fail-soft regression test ensures hydration can distinguish enumeration failure from a verified-empty result.
- Third adversarial pass added a regression proving strict WSL enumeration receives both `wslDistro: 'Ubuntu'` and the live hydration `AbortSignal`.

### Final green on `awin`

- Focused startup/hydration suite: **9 files / 101 tests passed** in 6.60s.
- Hydration suite: **27/27 passed**, including deadline cleanup, retry/latching, 150,000-session scaling, max-active Git = 4, strict failure vs empty, WSL routing, and ownership boundaries.
- Electron warm-reattach E2E: **1/1 passed in 29.1s**.
  - Two real Electron launches used one isolated profile.
  - A daemon-backed PTY was seeded, the app was closed/relaunched, and the exact PTY appeared in the second-launch memory snapshot with a positive PID and local ownership.
- `pnpm tc:node`: passed.
- Standard, type-aware, and React Doctor Oxlint scans: zero findings.
- Explicit 16-file format check: passed.
- `git diff --check`: passed.

The E2E uses unpackaged Electron, so it does not execute `app.isPackaged`; the deterministic startup-order test covers the packaged bind-before-open contract.

## ELI5

Orca's memory report was taking attendance before the terminal teacher arrived, then keeping that incomplete list forever. This change waits for the real attendance list—but only for a short, bounded time—so retained terminals and their processes can be counted without making the app wait indefinitely.

## Trade-offs / negative behavior changes

- Headless `--serve` and `orcad` readiness can intentionally wait up to five seconds for hydration. Desktop first-window creation is not delayed.
- Git inventory may run up to four repo tasks concurrently. On Git older than 2.36, the existing compatibility fallback can make a repo scan use a second sequential command, while the four-repo cap remains intact.
- A timeout favors bounded readiness over a guaranteed complete snapshot. Failed/partial attempts remain retryable on a later explicit hydration call; no automatic background retry loop is added.
- Non-cancellable daemon `listSessions` RPCs are raced by the five-second hydration deadline and retain their existing 30-second RPC timeout.
- This improves attribution, not memory consumption; users should not expect it alone to prevent commit exhaustion.

## Adversarial review

**4 fresh sub-agent loops were required until clean.**

1. **Loop 1 — high finding:** sequential Git enumeration could delay headless readiness by roughly `N × 30s`. Fixed with a five-second global deadline, cancellation, and a real four-repo worker cap.
2. **Loop 2 — high finding:** the normal Git path converts failures to fulfilled `[]`, which could latch hydration as complete and suppress retries. Fixed by reusing strict/status-bearing enumeration and covering real fail-soft-vs-strict behavior.
3. **Loop 3 — medium finding:** hydration dropped the selected WSL distro and could run host Git for WSL projects. Fixed by forwarding resolved project runtime options plus the live abort signal, with a regression test.
4. **Loop 4 — CLEAN:** no actionable correctness, security, or maintainability issues. It rechecked startup ordering, timeout/cancellation/concurrency, retry semantics, WSL routing, SSH/paired/folder authority, normalized collisions, and `pty:spawn` preservation.

## Performance review

Separate `$perf` sub-agent result: **PERF CLEAN**.

- Desktop first-window path remains nonblocking.
- Headless readiness has a deliberate maximum five-second hydration budget.
- Git enumeration is genuinely capped at four concurrent repo tasks.
- Each repo is attempted once per hydration; concurrent callers share one in-flight promise.
- Deadline abort reaches native and WSL Git process-tree termination.
- No polling, interval, or steady-state work was introduced.
- Measured subset: 7 files / 82 tests in 6.44s Vitest (7.716s wall); hydration's 27 tests ran in 460ms including the 150,000-session case.

Residual perf gaps: no packaged first-paint wall-clock trace or real WSL process-kill smoke was captured in this review.

## Reliability contract

- **Invariant:** only daemon sessions with verified exact local ownership enter the destructive fallback registry; existing registry rows are never overwritten.
- **Failure source:** missing/late provider, stalled/rejected adapter or Git inventory, Git failure presented as empty, WSL execution-host mismatch, ambiguous normalized ownership, and incomplete folder metadata.
- **Oracle:** daemon inventories plus execution-host metadata and live strict Git worktree inventory; the warm-reattach E2E proves the retained PTY becomes attributable after relaunch.
- **Gate:** provider readiness precedes hydration; headless publication waits for the bounded shared path; desktop schedules hydration without blocking first-window creation.
- **Provider/platform coverage:** native macOS/Linux/Windows and local WSL are eligible. SSH, paired runtimes, and other remote execution hosts remain fail-closed and excluded.
- **Performance budget:** one 5,000ms overall deadline, four concurrent repo scans, one attempt per repo per hydration, and coalesced concurrent callers.
- **Diagnostics:** concise `[memory]` warnings cover adapter, Git enumeration, and deadline failures.
- **Residual gap:** true `folder:<id>@@suffix` folder workspaces remain a tested, fail-closed accepted gap. Exact repo-backed `::workspace:<uuid>` instances are supported only from verified local metadata.

No remote-wire payload, RPC shape, or new Git command/option is introduced; the implementation reuses the existing strict worktree reader and existing Git compatibility behavior.

Final commit: `bea6a59459f000ca6aea500c69e45776ee65e4bd`
