### PR TITLE
test(orca-profiles): probe every transferable field through the session merge

### DIFF
--- a/src/main/orca-profiles/profile-project-session-field-disposition.ts
+++ b/src/main/orca-profiles/profile-project-session-field-disposition.ts
@@ -35,9 +35,9 @@ type SessionFieldDisposition = {
  * is now a compile error to skip, and the two owner-keyed lists below are what those paths
  * actually iterate -- so a field marked `prunedByOwnerKey` is pruned by construction.
  *
- * Not covered: `mergeWorkspaceSessions`, the apply side of a transfer, is still a hand-written
- * field list. It is safe for this field only because `extractSessionForTransfer` never emits it --
- * classify a new field as transferable and that merge has to be edited by hand.
+ * `mergeWorkspaceSessions`, the apply side of a transfer, is a hand-written field list too, so
+ * `SESSION_FIELDS_TRANSFERRED` below drives a probe per transferable field: classify a new field as
+ * transferable and that merge fails a test until it carries the field through.
  */
 export const WORKSPACE_SESSION_FIELD_DISPOSITION = {
   // Residue: it can name the repo being removed, and no main-side path clears it. Harmless only
@@ -151,3 +151,16 @@ export const SESSION_FIELDS_PRUNED_BY_OWNER_KEY = SESSION_FIELDS.filter(
 export const SESSION_FIELDS_COPIED_BY_OWNER_KEY = SESSION_FIELDS.filter(
   (field) => WORKSPACE_SESSION_FIELD_DISPOSITION[field].onTransfer === 'copiedByOwnerKey'
 )
+
+/** Fields a transfer can carry, so the apply-side merge has to account for each one. */
+export type TransferredSessionField = {
+  [
+    K in keyof typeof WORKSPACE_SESSION_FIELD_DISPOSITION
+  ]: (typeof WORKSPACE_SESSION_FIELD_DISPOSITION)[K]['onTransfer'] extends 'notTransferred'
+    ? never
+    : K
+}[keyof typeof WORKSPACE_SESSION_FIELD_DISPOSITION]
+
+export const SESSION_FIELDS_TRANSFERRED = SESSION_FIELDS.filter(
+  (field) => WORKSPACE_SESSION_FIELD_DISPOSITION[field].onTransfer !== 'notTransferred'
+) as TransferredSessionField[]

--- a/src/main/orca-profiles/profile-project-session-merge-field-coverage.test.ts
+++ b/src/main/orca-profiles/profile-project-session-merge-field-coverage.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultWorkspaceSession } from '../../shared/constants'
+import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
+import {
+  SESSION_FIELDS_TRANSFERRED,
+  type TransferredSessionField
+} from './profile-project-session-field-disposition'
+import { mergeWorkspaceSessions } from './profile-project-session-state'
+
+/**
+ * Why: `mergeWorkspaceSessions` is the apply side of a project transfer and is a hand-written
+ * field list. A field classified as transferable but missing from that list is dropped silently --
+ * `...base` still supplies a value, so the merged session looks well-formed and the loss only
+ * shows up as the user's tabs, layouts, or browser workspaces missing after the transfer.
+ * Every transferable field is probed here so the omission fails a test instead.
+ */
+
+const PROBE_KEY = 'orca-merge-probe-owner'
+const PROBE_TEXT = 'orca-merge-probe-value'
+const PROBE_NUMBER = 41
+
+type MergeProbeKind = 'record' | 'numericRecord' | 'array' | 'scalar'
+
+// Adding a transferable session field is a compile error until it is probed here.
+const MERGE_PROBE_KIND = {
+  activeWorkspaceKey: 'scalar',
+  activeWorktreeId: 'scalar',
+  activeWorktreeIdsOnShutdown: 'array',
+  tabsByWorktree: 'record',
+  terminalLayoutsByTabId: 'record',
+  openFilesByWorktree: 'record',
+  activeFileIdByWorktree: 'record',
+  browserTabsByWorktree: 'record',
+  browserPagesByWorkspace: 'record',
+  activeBrowserTabIdByWorktree: 'record',
+  activeTabTypeByWorktree: 'record',
+  activeTabIdByWorktree: 'record',
+  unifiedTabs: 'record',
+  tabGroups: 'record',
+  tabGroupLayouts: 'record',
+  activeGroupIdByWorktree: 'record',
+  lastVisitedAtByWorktreeId: 'numericRecord',
+  defaultTerminalTabsAppliedByWorktreeId: 'record',
+  terminalPtyIncarnationsByPaneKey: 'record',
+  terminalTopologyRevisionByRepoId: 'numericRecord',
+  terminalSurfaceTombstonesByPaneKey: 'record'
+} as const satisfies Record<TransferredSessionField, MergeProbeKind>
+
+function probeValue(kind: MergeProbeKind): unknown {
+  switch (kind) {
+    case 'record':
+      return { [PROBE_KEY]: PROBE_TEXT }
+    case 'numericRecord':
+      return { [PROBE_KEY]: PROBE_NUMBER }
+    case 'array':
+      return [PROBE_TEXT]
+    case 'scalar':
+      return PROBE_TEXT
+  }
+}
+
+function readProbe(merged: WorkspaceSessionState, field: TransferredSessionField): unknown {
+  const value = (merged as Record<string, unknown>)[field]
+  const kind = MERGE_PROBE_KIND[field]
+  if (kind === 'array') {
+    return Array.isArray(value) ? value.find((entry) => entry === PROBE_TEXT) : undefined
+  }
+  if (kind === 'scalar') {
+    return value
+  }
+  return (value as Record<string, unknown> | undefined)?.[PROBE_KEY]
+}
+
+function expectedProbe(field: TransferredSessionField): unknown {
+  return MERGE_PROBE_KIND[field] === 'numericRecord' ? PROBE_NUMBER : PROBE_TEXT
+}
+
+describe('mergeWorkspaceSessions transferable field coverage', () => {
+  it('probes every field the transfer census says can arrive', () => {
+    expect(Object.keys(MERGE_PROBE_KIND).sort()).toEqual([...SESSION_FIELDS_TRANSFERRED].sort())
+  })
+
+  it.each(SESSION_FIELDS_TRANSFERRED)('carries incoming %s into the merged session', (field) => {
+    const incoming = {
+      ...getDefaultWorkspaceSession(),
+      [field]: probeValue(MERGE_PROBE_KIND[field])
+    } as WorkspaceSessionState
+
+    const merged = mergeWorkspaceSessions(getDefaultWorkspaceSession(), incoming)
+
+    expect(readProbe(merged, field)).toEqual(expectedProbe(field))
+  })
+
+  it('keeps the base value for a field the transfer census never emits', () => {
+    const base = { ...getDefaultWorkspaceSession(), activeRepoId: 'base-repo' }
+    const incoming = { ...getDefaultWorkspaceSession(), activeRepoId: 'incoming-repo' }
+
+    expect(mergeWorkspaceSessions(base, incoming).activeRepoId).toBe('base-repo')
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 |

<!-- /orca-pr-loc -->

## ELI5

Moving a project between profiles packs up your session — tabs, terminal layouts, open files, browser workspaces — and unpacks it on the other side. The unpacking step is a hand-written list of fields to carry over. If someone adds a new field to the session and forgets that list, the unpack silently keeps the empty default instead, and nothing complains. This generates the checklist from the packing side so the two can't drift apart.

## User-facing before / after

**Before** — a field the transfer census marks transferable but `mergeWorkspaceSessions` forgets is dropped during a project transfer. `...base` still supplies a value, so the merged session looks well-formed and there is no error; the user just finds tabs, terminal layouts, or browser workspaces missing after moving the project.

**After** — the same omission is a compile error *and* a failing test before it can ship. No change to runtime behaviour: this adds a derived list and a test.

## Proof (re-derived here, not carried over)

Ablating **each** of the 21 transferable fields individually — making the merge fall back to `base` for that one field — against all 20 `src/main/orca-profiles` test files on `main`:

| arm | result |
|---|---|
| each field ablated, `main` coverage only | **18 of 21 redden nothing** (only `browserTabsByWorktree`, `terminalPtyIncarnationsByPaneKey`, `terminalTopologyRevisionByRepoId` are caught today) |
| each field ablated, with this test | **21 of 21 redden** — 18 with a single failure, and the three `main` already catches with two |

**What that 0 means.** Not unreachable and not vacuous: a *total* merge no-op reddens 2 of 132, so the function is reached and asserted on. The per-field zeros mean genuinely **unprotected**. This is the trap where a surface looks watched because deleting all of it reddens something, while deleting the one field that matters reddens nothing.

**Positive control on the census itself** — flipping `activeRepoId` to `copiedByOwnerKey` without probing it fails the census equality test *and* fails `tc` with `TS2741: Property 'activeRepoId' is missing ... but required in type 'Record<TransferredSessionField, MergeProbeKind>'`.

Note: the original sweep reported *19 of 22*; re-deriving gives **18 of 21** (21 transferable fields, not 22 — `activeTabId` is `notTransferred`). Same three protected fields either way.

Cold `pnpm tc` (caches cleared) exit 0; `src/main/orca-profiles` 21 files / 155 tests green.

