### PR TITLE
test(shared): pin the crash-report secret and UNC path redactions

### DIFF
--- a/src/shared/crash-report-redaction.test.ts
+++ b/src/shared/crash-report-redaction.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeCrashReportString } from './crash-report-redaction'
+
+/**
+ * Why: a crash report leaves the machine. Each pattern below is the only thing standing between
+ * a real secret or a real filesystem path and the report body, and neutering either of these two
+ * used to leave the whole suite green.
+ */
+
+const API_KEY = 'sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789'
+const UNC_WITH_SPACE = 'open "\\\\fileserver\\Private Share\\brennan\\creds.txt" failed'
+
+describe('sanitizeCrashReportString', () => {
+  it('redacts a bare sk- API key that no assignment keyword introduces', () => {
+    const sanitized = sanitizeCrashReportString(`Request failed for API key ${API_KEY} (401)`)
+
+    expect(sanitized).not.toContain(API_KEY)
+    expect(sanitized).not.toContain('sk-ant-api03')
+    expect(sanitized).toContain('[redacted-secret]')
+  })
+
+  it('redacts a quoted UNC path whose segments contain spaces', () => {
+    const sanitized = sanitizeCrashReportString(UNC_WITH_SPACE)
+
+    expect(sanitized).not.toContain('Private Share')
+    expect(sanitized).not.toContain('creds.txt')
+    expect(sanitized).toContain('[redacted-path]')
+  })
+
+  // Positive control: prose that resembles neither must survive, so the assertions above
+  // cannot pass by redacting everything.
+  it('leaves text carrying no secret and no path untouched', () => {
+    const prose = 'Renderer crashed while restoring 3 tabs after a sk- prefixed heading'
+
+    expect(sanitizeCrashReportString(prose)).toBe(prose)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

When Orca crashes it can send a report so we can fix the crash. Before sending, it scrubs secrets and file paths out of the text. The scrubbing works. What was missing was anything *checking* that it keeps working — so if someone tidied up one of the scrub rules, reports would quietly start carrying an API key or a network file path and every test would still pass. This adds the missing check.

## User-facing before / after

**Neither of the two patterns this pins is leaking today.** `sanitizeCrashReportString` redacts bare `sk-…` API keys and quoted UNC paths correctly on `main`; I verified both patterns are present and working before writing this.

That wording is deliberately scoped, and the scope matters. Unquoted paths whose segments contain a space are only *partially* redacted on `main` right now, with no ablation at all — `C:\Users\Some One\AppData\...` sanitizes to `[redacted-path] One\AppData\...`, and `/Users/jane doe/Documents/Work Projects/...` to `[redacted-path] doe/Documents/Work Projects/...`. On Windows a username with a space leaks the whole remaining path. That is a real, live defect on a body that leaves the machine; it is being handled separately, and **this PR does not fix it**.

**Before** — deleting either pattern leaves the entire suite green, so a future edit could silently start a leak into a report body **that leaves the machine**.

**After** — deleting either pattern fails a test.

This is test-only. No runtime behaviour changes.

## Proof (re-derived here)

Population: all 37 crash-related test files on `main` (391 tests).

| ablation | `main` coverage only | with this test |
|---|---|---|
| remove the bare `sk-` secret pattern | **0 of 391 redden** | 1 red |
| remove the quoted-UNC path pattern | **0 of 391 redden** | 1 red |
| no-op the **whole** sanitizer | 23 of 391 redden (7 files) | — |

**What those zeros mean.** The whole-function control reddens 23 tests, so the module is reached and the population does assert on redaction. The per-pattern zeros therefore mean genuinely **unprotected** — not unreachable, not clamped, not vacuous.

**The UNC leak is partial, which is worse than it sounds.** With the quoted pattern removed, the unquoted fallback still matches `\\fileserver\Private` and stops at the space, producing:

```
open "[redacted-path] Share\brennan\creds.txt" failed
```

The report *looks* redacted while still carrying the filename. Asserting only on the presence of `[redacted-path]` would pass here; the test asserts the tail segment is gone, which is what catches it.

**Positive control** — prose carrying neither a secret nor a path must survive byte-identical, so these pins cannot pass by redacting everything.

The fixture key is synthetic, matching the pattern shape only — no real secret.

Cold `pnpm tc` (caches cleared) exit 0; 38 files / 394 tests green.

