### PR TITLE
fix(ssh): release the remote-workspace notification handler on teardown

### DIFF
--- a/src/main/ssh/ssh-relay-session-subscription-release.test.ts
+++ b/src/main/ssh/ssh-relay-session-subscription-release.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SshRelaySession } from './ssh-relay-session'
+import type { SshConnection } from './ssh-connection'
+import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
+
+/**
+ * Why: teardownProviders drops every subscription the session took out on the mux. No-oping the
+ * whole function fails plenty of tests, but no-oping any single release used to fail none — so a
+ * subscription left behind here would survive review, and reconnect would re-register on top of
+ * it. Each release is asserted individually.
+ */
+
+// Why a fresh spy per subscription: one shared cleanup spy cannot tell "this subscription was
+// released" from "some other subscription was released", which makes the assertion vacuous.
+const { notificationCleanups, notificationByMethodCleanups, registeredPtyProvider } = vi.hoisted(
+  () => ({
+    notificationCleanups: [] as ReturnType<typeof vi.fn>[],
+    notificationByMethodCleanups: [] as ReturnType<typeof vi.fn>[],
+    registeredPtyProvider: { dispose: vi.fn(), attachForReconnect: vi.fn() }
+  })
+)
+
+function trackCleanup(into: ReturnType<typeof vi.fn>[]): ReturnType<typeof vi.fn> {
+  const cleanup = vi.fn()
+  into.push(cleanup)
+  return cleanup
+}
+
+vi.mock('./ssh-relay-deploy', () => ({ deployAndLaunchRelay: vi.fn() }))
+vi.mock('./ssh-pty-consumer-session', () => ({
+  openSshPtyConsumerSession: vi.fn()
+}))
+vi.mock('../ipc/ssh-pty-output-intake-registry', () => ({
+  acceptSshPtyOutputData: vi.fn().mockResolvedValue(undefined),
+  acceptSshPtyOutputExit: vi.fn().mockResolvedValue(undefined),
+  allocateSshPtyProviderGeneration: vi.fn(() => 41),
+  beginSshPtyOutputGenerationMigration: vi.fn(() => ({
+    byPty: new Map(),
+    completion: Promise.resolve()
+  })),
+  closeSshPtyOutputGeneration: vi.fn(),
+  getSshPtyAcceptedSourceCheckpoints: vi.fn(() => []),
+  applySshPtySourceCancellationProof: vi.fn(() => true),
+  applySshPtySourceRecoveryCancellationProof: vi.fn(() => true),
+  installSshPtySourceAckPublisher: vi.fn(() => () => {}),
+  installSshPtySourceCancellationPublisher: vi.fn(() => () => {})
+}))
+vi.mock('./ssh-relay-deploy-helpers', () => ({ execCommand: vi.fn().mockResolvedValue('') }))
+vi.mock('./ssh-channel-multiplexer', () => ({
+  SshChannelMultiplexer: class MockSshChannelMultiplexer {
+    private disposed = false
+    notify = vi.fn()
+    notifyWithSettlement = vi.fn()
+    request = vi.fn().mockResolvedValue([])
+    onNotification = vi.fn(() => trackCleanup(notificationCleanups))
+    onNotificationByMethod = vi.fn(() => trackCleanup(notificationByMethodCleanups))
+    onRequest = vi.fn().mockReturnValue(() => {})
+    onDispose = vi.fn(() => () => {})
+    dispose = vi.fn(() => {
+      this.disposed = true
+    })
+    isDisposed = vi.fn(() => this.disposed)
+  }
+}))
+vi.mock('../providers/ssh-pty-provider', () => ({
+  isSshPtyNotFoundError: () => false,
+  isSshPtyIdentityMismatchError: () => false,
+  SshPtyProvider: class MockSshPtyProvider {
+    onData = vi.fn().mockReturnValue(() => {})
+    onReplay = vi.fn().mockReturnValue(() => {})
+    onExit = vi.fn().mockReturnValue(() => {})
+    attach = vi.fn().mockResolvedValue(undefined)
+    attachForReconnect = vi.fn().mockResolvedValue({})
+    setPtyDeliveryPauseAdapter = vi.fn()
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-filesystem-provider', () => ({
+  SshFilesystemProvider: class MockSshFilesystemProvider {
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-git-provider', () => ({ SshGitProvider: class MockSshGitProvider {} }))
+vi.mock('../ipc/pty', () => ({
+  registerSshPtyProvider: vi.fn(),
+  unregisterSshPtyProvider: vi.fn(),
+  getSshPtyProvider: vi.fn().mockReturnValue(registeredPtyProvider),
+  getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  clearPtyOwnershipForConnection: vi.fn(),
+  clearProviderPtyState: vi.fn(),
+  deletePtyOwnership: vi.fn(),
+  setPtyOwnership: vi.fn(),
+  restorePtyIncarnation: vi.fn(),
+  isCurrentPtyExit: vi.fn(() => true)
+}))
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  registerSshFilesystemProvider: vi.fn(),
+  unregisterSshFilesystemProvider: vi.fn(),
+  getSshFilesystemProvider: vi.fn().mockReturnValue({ dispose: vi.fn() })
+}))
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  registerSshGitProvider: vi.fn(),
+  unregisterSshGitProvider: vi.fn()
+}))
+
+const { openSshPtyConsumerSession } = await import('./ssh-pty-consumer-session')
+
+// Covers the subscriptions this fixture actually takes out. Still unpinned here: the ack and
+// cancellation publishers (installed only on a flow-control-negotiated consumer session) and the
+// agent-hook notification handler (remote agent hooks are off in this environment).
+const SUBSCRIPTION_RELEASES = [
+  ['mux notification handler', notificationCleanups],
+  ['pty recovery notification handler', notificationByMethodCleanups]
+] as const
+
+async function establishedSession(): Promise<SshRelaySession> {
+  const { mockStore, mockPortForward, getMainWindow } = createMockDeps()
+  const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+  await session.establish({} as SshConnection)
+  return session
+}
+
+describe('SshRelaySession subscription release on teardown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    notificationCleanups.length = 0
+    notificationByMethodCleanups.length = 0
+    vi.mocked(openSshPtyConsumerSession).mockImplementation(
+      async (_mux: unknown, options: { clientInstanceId: string }) => ({
+        state: {
+          mode: 'legacy-fallback',
+          clientInstanceId: options.clientInstanceId,
+          serverBuildId: 'test-relay-build'
+        },
+        resumed: false
+      })
+    )
+    mockDeploySuccess()
+  })
+
+  it.each(SUBSCRIPTION_RELEASES)('releases every %s on disposal', async (_label, cleanups) => {
+    const session = await establishedSession()
+    const held = cleanups.filter((cleanup) => cleanup.mock.calls.length === 0)
+    expect(held.length).toBeGreaterThan(0)
+
+    await session.disposeAndPersist()
+
+    for (const cleanup of held) {
+      expect(cleanup).toHaveBeenCalled()
+    }
+  })
+
+  // Positive control: an established session that is never disposed must still hold at least one
+  // subscription of each kind, so the assertions above cannot pass on a session that took none out.
+  it('still holds subscriptions of every kind while established', async () => {
+    await establishedSession()
+
+    for (const [, cleanups] of SUBSCRIPTION_RELEASES) {
+      expect(cleanups.filter((cleanup) => cleanup.mock.calls.length === 0).length).toBeGreaterThan(
+        0
+      )
+    }
+  })
+})

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -309,6 +309,7 @@ export class SshRelaySession {
   private muxDisposeCleanup: (() => void) | null = null
   // Why: hold the notification-handler disposer so teardownProviders can release it on reconnect/shutdown (symmetric with muxDisposeCleanup).
   private muxNotificationCleanup: (() => void) | null = null
+  private remoteWorkspaceNotificationCleanup: (() => void) | null = null
   // Why: onStateChange never fires when the relay channel closes but SSH stays up; this callback lets ssh.ts drive relay-level reconnect.
   private _onRelayLost: ((targetId: string) => void) | null = null
   // Why: a version mismatch or a blocked owner admission is terminal, so it needs a separate callback
@@ -1475,8 +1476,11 @@ export class SshRelaySession {
     return isAgentStatusHooksEnabled(store.getSettings?.())
   }
 
+  // Why: capture the disposer for the same reason the agent-hook handler below does -- teardown
+  // has to release it, and re-wiring must not stack a second handler on a live mux.
   private wireUpRemoteWorkspaceEvents(mux: SshChannelMultiplexer): void {
-    mux.onNotification((method, params) => {
+    this.remoteWorkspaceNotificationCleanup?.()
+    this.remoteWorkspaceNotificationCleanup = mux.onNotification((method, params) => {
       notifyRemoteWorkspaceHandlers(this.targetId, method, params)
     })
   }
@@ -1587,6 +1591,8 @@ export class SshRelaySession {
     this.releaseRelayLossWatcher()
     this.muxNotificationCleanup?.()
     this.muxNotificationCleanup = null
+    this.remoteWorkspaceNotificationCleanup?.()
+    this.remoteWorkspaceNotificationCleanup = null
     for (const cleanup of this.ptyRecoveryNotificationCleanups) {
       cleanup()
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​164 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​164 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## ELI5

When an SSH connection tears down, the relay session should hand back every "tell me when something happens" subscription it took out. It took out two and handed back one. In practice nothing goes wrong today, because the layer underneath throws away all its subscriptions when it shuts down. This adds the missing hand-back so the two halves match, and pins each hand-back individually so a future change can't quietly drop one.

## User-facing before / after — stated carefully

**I could not reproduce a live leak, and this PR does not claim one.**

`wireUpRemoteWorkspaceEvents` took out a `mux.onNotification` subscription and discarded the disposer, so `teardownProviders` released one of the two notification handlers the session registers. That asymmetry is real. Its consequence is currently contained:

- `SshChannelMultiplexer.dispose()` unconditionally clears `notificationHandlers` (with a comment saying disposed muxes must not retain session closures through subscribers), and
- every abandoned mux ends up disposed — stated carefully, because the obvious wording is not true. One failure path, the `'PTY reattach'` guard in `reconnect()`, is a bare `return` that calls neither `teardownProviders` nor `mux.dispose()`, unlike the two guards immediately above it. It is still safe, but for a different reason: every event that can invalidate that attempt disposes `this.mux` first. The only two `this.mux =` assignments are each on a freshly created mux and each preceded by disposal of its predecessor (`establish()` throws unless the state is `idle`; `reconnect()`'s preamble runs `teardownProviders` before creating a successor), and `isDisposed()` can only read true after `runDisposal` has already run `teardownProviders`. So the mux is always disposed by the time that `return` is reached.

So: **no user-visible symptom before or after.** What changes is that the session now releases its own subscription instead of relying on the multiplexer to sweep up, symmetric with the agent-hook handler beside it, and re-wiring can no longer stack a second handler on a live mux. Treat this as the missing half of an existing symmetry plus a pin — not a bug fix.

## Proof (re-derived here)

Population: all 129 `src/main/ssh` test files on `main` (1,780 tests).

| ablation | `main` coverage only | with this test |
|---|---|---|
| revert the disposer fix entirely | — (that *is* `main`) | 1 red |
| remove the pty-recovery release (a different single statement) | **0 of 1,766 redden** | 1 red |
| no-op the **whole** `teardownProviders` | 30 of 1,780 redden (7 files) | — |

**What that 0 means.** The whole-function control reddens 30 tests, so teardown is heavily exercised. The single-statement zero means genuinely **unprotected** — teardown looked watched because deleting all of it reddens plenty, while deleting the one release that mattered reddened nothing.

**Coverage honesty.** This pins the remote-workspace notification handler and the pty-recovery notification handlers. It does **not** pin the agent-hook handler (remote agent hooks are flagged off in the fixture) or the ack/cancellation publishers (installed only on a flow-control-negotiated consumer session). That limit is stated in the test file rather than left implied.

A per-subscription spy is used rather than one shared cleanup spy, so "this subscription was released" cannot be confused with "some other subscription was released". A positive control asserts an established, never-disposed session still holds at least one subscription of each kind, so the release assertions cannot pass on a session that took none out.

Cold `pnpm tc` (caches cleared) exit 0; `src/main/ssh` 129 files / 1,781 tests green.

