### PR TITLE
fix(shared): redact unquoted crash-report paths whole

### DIFF
--- a/src/shared/crash-report-redaction.test.ts
+++ b/src/shared/crash-report-redaction.test.ts
@@ -72,6 +72,35 @@ const PARTIAL_LEAK_FORMS: readonly (readonly [string, string, readonly string[]]
     'open %APPDATA%\\Orca App Data\\creds.txt failed',
     ['Orca App Data', 'creds.txt']
   ],
+  // A space inside the *last* segment: what survived here carried no separator, which is why the
+  // invariant below had to grow a second shape to see it.
+  [
+    'unquoted POSIX, space in the filename',
+    'read /Users/brennan/Documents/My Notes.txt failed',
+    ['brennan', 'Documents', 'My Notes', 'Notes.txt']
+  ],
+  [
+    'unquoted drive letter, space in the filename',
+    'load C:\\Users\\brennan\\Documents\\My Notes.txt failed',
+    ['brennan', 'Documents', 'My Notes', 'Notes.txt']
+  ],
+  [
+    'unquoted UNC, space in the filename',
+    'open \\\\fileserver\\share\\My Notes.txt failed',
+    ['fileserver', 'share', 'My Notes', 'Notes.txt']
+  ],
+  [
+    'unquoted POSIX, spaces in both a folder and the filename',
+    'read /Users/brennan/My Documents/My Notes.txt failed',
+    ['brennan', 'My Documents', 'My Notes', 'Notes.txt']
+  ],
+  // A directory chain ending in no filename at all: the run that continues it carries separators
+  // and nothing else, so a chain has to count as path evidence on its own.
+  [
+    'spaced directory chain, no filename',
+    'watcher failed on \\\\nas01\\Team Share\\orca\\workspace and fell back to polling',
+    ['nas01', 'Team Share', 'orca', 'workspace']
+  ],
   [
     'POSIX path inside a stack frame',
     '    at load (/Users/brennan/My Documents/app.js:12:9)',
@@ -92,8 +121,12 @@ describe('sanitizeCrashReportString path redaction is all-or-nothing', () => {
     for (const fragment of fragments) {
       expect(sanitized).not.toContain(fragment)
     }
-    // The defect shape: a marker sitting next to surviving path content.
+    // The defect shape: a marker sitting next to surviving path content. A separator after the
+    // marker catches a path cut mid-chain. It cannot see a cut inside the last segment -- what
+    // survives there is a bare filename, 'My Notes.txt' cut to 'Notes.txt' -- so a name carrying an
+    // extension beside the marker is forbidden too.
     expect(sanitized).not.toMatch(/\[redacted-path\][^\n]*[\\/]/)
+    expect(sanitized).not.toMatch(/\[redacted-path\] ?\S*\.[A-Za-z0-9]/)
   })
 
   // Control for the space-crossing rule specifically: it must not swallow the prose that follows a
@@ -113,8 +146,101 @@ describe('sanitizeCrashReportString path redaction is all-or-nothing', () => {
       'following URL',
       'read /etc/hosts then see https://example.com for help',
       'then see https://example.com for help'
+    ],
+    // A separator in the prose is not a path continuing: 'and/or' and 'read/write' carry one and
+    // are words. The crossing reads them as prose because neither ends in a name.
+    [
+      'slash in the words that follow',
+      'read /Users/brennan/Documents/creds.txt but read/write failed',
+      'but read/write failed'
+    ],
+    [
+      'slash in the words that follow, no sentence break',
+      'read /etc/hosts then it failed and/or retried',
+      'then it failed and/or retried'
+    ],
+    // A hostname is spelled like a filename. It is only reachable across plain words, and a name
+    // alone continues a path only when every run before it carries a separator.
+    [
+      'host that reads like a filename',
+      'read /etc/hosts then reach api.example.com for the status',
+      'then reach api.example.com for the status'
+    ],
+    // A separator alone is not enough, one run away or several: a run has to reach a name or a
+    // second separator, and the window it is looked for in is two runs wide.
+    [
+      'slash in the very next words',
+      'read /etc/hosts or read/write failed',
+      'or read/write failed'
+    ],
+    [
+      'path-shaped words further along the sentence',
+      'read /etc/hosts before the retry loop reached src/net/socket.js',
+      'before the retry loop reached src/net/socket.js'
+    ],
+    // A name ends a path, so nothing after a filename is read as more of it.
+    [
+      'path-shaped words after a filename',
+      'read /Users/brennan/Documents/creds.txt then check b/c/d.txt now',
+      'then check b/c/d.txt now'
     ]
   ])('keeps the prose after a redacted path (%s)', (_name, input, survives) => {
     expect(sanitizeCrashReportString(input)).toBe(`read [redacted-path] ${survives}`)
+  })
+
+  // Three things hold a path's spaces to one path. Each is a single character or bound in one
+  // pattern, each ablates to a silent collapse, and none of the rows above sees it go.
+  it.each([
+    [
+      'both ending in a filename',
+      'moved /Users/alice/My Docs/a.txt to /Users/bob/My Docs/b.txt and retried',
+      'moved [redacted-path] to [redacted-path] and retried'
+    ],
+    [
+      'the first ending in a folder',
+      'copied /Users/alice/My Docs/logs/app to /Users/bob/My Docs/b.txt now',
+      'copied [redacted-path] to [redacted-path] now'
+    ]
+  ])('keeps two paths on one line two paths (%s)', (_name, input, expected) => {
+    expect(sanitizeCrashReportString(input)).toBe(expected)
+  })
+
+  it('keeps two stack frames on one line two frames', () => {
+    const sanitized = sanitizeCrashReportString(
+      'at load (/Users/alice/My Docs/a.js:12:9) at emit (/Users/bob/My Docs/b.js:1:1)'
+    )
+
+    expect(sanitized).toBe('at load ([redacted-path]) at emit ([redacted-path])')
+  })
+
+  it.each([
+    [
+      'the next line holding its own path',
+      'read /Users/alice/My Docs/a.txt\nand then /Users/bob/My Docs/b.txt failed',
+      'read [redacted-path]\nand then [redacted-path] failed'
+    ],
+    [
+      'the next line opening with path-shaped text',
+      'read /Users/alice/Documents\nBackups/My Notes.txt failed',
+      'read [redacted-path]\nBackups/My Notes.txt failed'
+    ]
+  ])('stops a path at the end of its line (%s)', (_name, input, expected) => {
+    expect(sanitizeCrashReportString(input)).toBe(expected)
+  })
+
+  // A crash report carries minified frames, serialised state and base64 blobs, all on one line. The
+  // crossing looks ahead over a bounded window for that reason: scanning to the end of the line at
+  // every space made a 100KB line cost over a second. The budget is ~250x the measured cost, so it
+  // fails on a return to quadratic rather than on a slow machine.
+  it.each([
+    ['a line of many paths', '/opt/orca/logs/frame.js '.repeat(4_260)],
+    ['a few runs carrying many separators', `/opt/o/a ${`${'x/'.repeat(3_000)} `.repeat(8)}`]
+  ])('sanitises a very long single line in bounded time (%s)', (_name, line) => {
+    expect(line.length).toBeGreaterThan(45_000)
+
+    const startedAt = performance.now()
+    sanitizeCrashReportString(line, 4_000)
+
+    expect(performance.now() - startedAt).toBeLessThan(250)
   })
 })

--- a/src/shared/crash-report-redaction.test.ts
+++ b/src/shared/crash-report-redaction.test.ts
@@ -35,3 +35,86 @@ describe('sanitizeCrashReportString', () => {
     expect(sanitizeCrashReportString(prose)).toBe(prose)
   })
 })
+
+/**
+ * Why: the unquoted patterns used to stop at the first space, emitting [redacted-path] with the
+ * rest of the path still beside it -- a report that looks scrubbed but still carries a share name,
+ * a directory chain and a filename. Each form below is pinned to go whole.
+ */
+const PARTIAL_LEAK_FORMS: readonly (readonly [string, string, readonly string[]])[] = [
+  [
+    'unquoted UNC, one space',
+    'open \\\\fileserver\\Private Share\\brennan\\creds.txt failed',
+    ['Private Share', 'brennan', 'creds.txt']
+  ],
+  [
+    'unquoted UNC, two spaces',
+    'open \\\\fileserver\\Very Private Share\\creds.txt failed',
+    ['Very Private Share', 'creds.txt']
+  ],
+  [
+    'unquoted drive letter',
+    'load C:\\Users\\brennan\\My Documents\\creds.txt failed',
+    ['Users', 'brennan', 'My Documents', 'creds.txt']
+  ],
+  [
+    'unquoted POSIX',
+    'read /Users/brennan/My Documents/creds.txt failed',
+    ['brennan', 'My Documents', 'creds.txt']
+  ],
+  [
+    'unquoted POSIX, backslash-escaped space',
+    'read /Users/brennan/My\\ Documents/creds.txt failed',
+    ['brennan', 'Documents', 'creds.txt']
+  ],
+  [
+    'environment-variable root',
+    'open %APPDATA%\\Orca App Data\\creds.txt failed',
+    ['Orca App Data', 'creds.txt']
+  ],
+  [
+    'POSIX path inside a stack frame',
+    '    at load (/Users/brennan/My Documents/app.js:12:9)',
+    ['brennan', 'My Documents', 'app.js']
+  ],
+  [
+    'drive-letter path inside a stack frame',
+    '    at load (C:\\Users\\brennan\\My Documents\\app.js:12:9)',
+    ['brennan', 'My Documents', 'app.js']
+  ]
+]
+
+describe('sanitizeCrashReportString path redaction is all-or-nothing', () => {
+  it.each(PARTIAL_LEAK_FORMS)('redacts %s whole', (_name, input, fragments) => {
+    const sanitized = sanitizeCrashReportString(input)
+
+    expect(sanitized).toContain('[redacted-path]')
+    for (const fragment of fragments) {
+      expect(sanitized).not.toContain(fragment)
+    }
+    // The defect shape: a marker sitting next to surviving path content.
+    expect(sanitized).not.toMatch(/\[redacted-path\][^\n]*[\\/]/)
+  })
+
+  // Control for the space-crossing rule specifically: it must not swallow the prose that follows a
+  // path, or these pins could pass by redacting the rest of every line.
+  it.each([
+    [
+      'plain prose',
+      'read /Users/brennan/Documents/creds.txt but the disk was full',
+      'but the disk was full'
+    ],
+    [
+      'sentence break',
+      'read /etc/hosts. Then it failed and/or retried',
+      'Then it failed and/or retried'
+    ],
+    [
+      'following URL',
+      'read /etc/hosts then see https://example.com for help',
+      'then see https://example.com for help'
+    ]
+  ])('keeps the prose after a redacted path (%s)', (_name, input, survives) => {
+    expect(sanitizeCrashReportString(input)).toBe(`read [redacted-path] ${survives}`)
+  })
+})

--- a/src/shared/crash-report-redaction.ts
+++ b/src/shared/crash-report-redaction.ts
@@ -23,15 +23,26 @@ const CREDENTIAL_URL_PATTERN = /\b[A-Za-z0-9._%+-]+:[A-Za-z0-9._%+-]+@(?=[^/\s]+
 const SECRET_ASSIGNMENT_PATTERN =
   /\b(token|access[_-]?token|refresh[_-]?token|api[_-]?key|client[_-]?secret|secret|password|account[_-]?key)\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^&\s,;]+)/gi
 
-// Quoted paths retain spaces; unquoted paths stop at whitespace to preserve prose.
+// Characters that end an unquoted path token.
+const PATH_STOP = '\\s"\'`<>)'
+
+// Quoted paths keep their spaces. An unquoted path crosses a space only to reach a run that
+// continues it -- one carrying a separator but not starting one, so a second path stays separate --
+// which keeps emitting the marker and removing the path a single operation rather than two.
+// Sentence punctuation and ':' (URL schemes, line:col) end the crossing, so prose after a path survives.
+const unquotedPathTail = (separator: string): string =>
+  `(?:[^${PATH_STOP}]|(?<![.,;:!?])[ \\t](?=(?:[^${PATH_STOP}:]*[ \\t])*?[^${PATH_STOP}:${separator}][^${PATH_STOP}:]*${separator}))*`
+const POSIX_TAIL = unquotedPathTail('/')
+const WINDOWS_TAIL = unquotedPathTail('\\\\')
+
 const PATH_PATTERNS = [
   /(["'`])\/[A-Za-z0-9._-]+\/(?:(?!\1)[^<>\n\r])+\1/g,
   /(["'`])[A-Za-z]:\\(?:(?!\1)[^<>\n\r])+\1/gi,
   /(["'`])\\\\[^\\\s"'`<>\n\r)]+\\(?:(?!\1)[^<>\n\r])+\1/gi,
-  /(?<![A-Za-z0-9./])\/[A-Za-z0-9._-]+\/(?:\\ |[^\s"'`<>)]*)/g,
-  /(?<![A-Za-z0-9])[A-Za-z]:\\(?:\\ |[^\s"'`<>\n\r)]*)/gi,
-  /\\\\[^\\\s"'`<>\n\r)]+\\(?:\\ |[^\s"'`<>\n\r)]*)/gi,
-  /%(?:USERPROFILE|APPDATA|LOCALAPPDATA|HOMEDRIVE|HOMEPATH)%[^\s"'`<>)]*/gi
+  new RegExp(`(?<![A-Za-z0-9./])/[A-Za-z0-9._-]+/${POSIX_TAIL}`, 'g'),
+  new RegExp(`(?<![A-Za-z0-9])[A-Za-z]:\\\\${WINDOWS_TAIL}`, 'gi'),
+  new RegExp(`\\\\\\\\[^\\\\${PATH_STOP}]+\\\\${WINDOWS_TAIL}`, 'gi'),
+  new RegExp(`%(?:USERPROFILE|APPDATA|LOCALAPPDATA|HOMEDRIVE|HOMEPATH)%${WINDOWS_TAIL}`, 'gi')
 ]
 
 export function sanitizeCrashReportString(

--- a/src/shared/crash-report-redaction.ts
+++ b/src/shared/crash-report-redaction.ts
@@ -25,13 +25,39 @@ const SECRET_ASSIGNMENT_PATTERN =
 
 // Characters that end an unquoted path token.
 const PATH_STOP = '\\s"\'`<>)'
+// A crossing looks ahead over a bounded window. Unbounded, it re-read the rest of the line at every
+// space, so one long line cost a second to sanitise. The run bound is a filesystem's longest
+// segment; without it a single long run carrying many separators costs as much on its own.
+const MAX_CROSSED_RUNS = 2
+const MAX_RUN_LENGTH = 255
+
+// What may follow a space and still be the same path. No run in the window starts with the separator
+// (so a second path on the same line stays a second path) and none carries ':' (so two stack frames
+// do not collapse into one). Beyond that the window must reach a run that is path evidence by
+// itself, because nothing else separates a path's spaced segments from the prose that follows one:
+//   'Very Private Share\\creds.txt' -- a run carrying a separator and a name, or a separator twice
+//     ('Team Share\\orca\\workspace'), is a segment chain, so plain runs may precede it. 'but
+//     read/write failed' reaches neither and is left alone.
+//   'My Notes.txt' -- a spaced last segment is only a name, so every run before it has to carry a
+//     separator. 'then push git@github.com' does not, which stops a host from reading as a file.
+const pathContinuation = (separator: string): string => {
+  const body = `[^${PATH_STOP}:]{0,${MAX_RUN_LENGTH}}`
+  const run = `[^${PATH_STOP}:${separator}]${body}`
+  const chainRun = `${run}${separator}${body}`
+  const name = `\\.[A-Za-z0-9]{1,8}(?![^${PATH_STOP}:])`
+  const crossed = (crossable: string): string => `(?:${crossable}[ \\t]){0,${MAX_CROSSED_RUNS}}`
+  return (
+    `(?:${crossed(run)}(?:${chainRun}${name}|${chainRun}${separator}${body})` +
+    `|${crossed(chainRun)}${run}${name})`
+  )
+}
 
 // Quoted paths keep their spaces. An unquoted path crosses a space only to reach a run that
-// continues it -- one carrying a separator but not starting one, so a second path stays separate --
-// which keeps emitting the marker and removing the path a single operation rather than two.
-// Sentence punctuation and ':' (URL schemes, line:col) end the crossing, so prose after a path survives.
+// continues it, which keeps emitting the marker and removing the path a single operation rather
+// than two. A run ending in a name ends the path -- a filename is the last thing in one -- and
+// sentence punctuation ends it too, so the prose after a path survives.
 const unquotedPathTail = (separator: string): string =>
-  `(?:[^${PATH_STOP}]|(?<![.,;:!?])[ \\t](?=(?:[^${PATH_STOP}:]*[ \\t])*?[^${PATH_STOP}:${separator}][^${PATH_STOP}:]*${separator}))*`
+  `(?:[^${PATH_STOP}]|(?<![.,;:!?])(?<!\\.[A-Za-z0-9]{1,8})[ \\t](?=${pathContinuation(separator)}))*`
 const POSIX_TAIL = unquotedPathTail('/')
 const WINDOWS_TAIL = unquotedPathTail('\\\\')
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​209 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​209 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |

<!-- /orca-pr-loc -->

Stacked on #17310 — that PR pins the patterns, this one fixes a defect the pinning exposed. Review #17310 first; this PR's diff is only the fix plus its own pins.

## ELI5

Before a crash report is sent, Orca scrubs file paths out of it and writes `[redacted-path]` where each one was. The scrubber knew how to find where a path *starts*, but it stopped at the first space — and lots of real folders have spaces in their names ("My Documents", "Private Share").

So it would cut the path in half: replace the first half with `[redacted-path]` and leave the second half sitting right next to it. The report **looked** scrubbed — it had the redaction marker and everything — while still spelling out a share name, folder names, and a filename.

That's worse than missing the path entirely. A path with no marker looks like a leak and someone might notice. A path *with* a marker in front of it looks like the system already handled it, so nobody looks twice.

## User-facing before / after

Crash reports leave the machine. Severity here is a **partial** path leak in a report that reads as scrubbed — not a total one, and not a credential leak. The quoted form was already correct; only unquoted paths were affected.

A crash report containing `open \\fileserver\Private Share\brennan\creds.txt failed`:

| | what got sent |
|---|---|
| **Before** | `open [redacted-path] Share\brennan\creds.txt failed` |
| **After** | `open [redacted-path] failed` |

The share name, the username and the filename all travelled, behind a marker saying they had been removed.

## The defect was not UNC-specific

I reproduced against the real `sanitizeCrashReportString` before changing anything. Every **unquoted** form leaked its tail from the first space onward — the shape is "stop at whitespace", not anything about UNC:

| form | before |
|---|---|
| unquoted UNC | `open [redacted-path] Share\brennan\creds.txt failed` |
| drive letter | `load [redacted-path] Documents\creds.txt failed` |
| POSIX | `read [redacted-path] Documents/creds.txt failed` |
| `%APPDATA%` root | `open [redacted-path] Data\creds.txt failed` |
| POSIX in a stack frame | `at load ([redacted-path] Documents/app.js:12:9)` |

All four unquoted patterns carried a `(?:\\ |…)` branch that looks like it handles backslash-escaped spaces. It is **dead**: the alternation is tried at the position right after the path root, where the next character is a segment name, never `\ `. The pre-fix output for `/Users/brennan/My\ Documents/creds.txt` proves it — it leaked identically. Whole-set ablation would never have surfaced that; only ablating the single element does.

## What I enumerated, and what the census cannot see

**Axis: path-root syntax × quoted/unquoted × contains-a-space.** That is the axis the pattern list itself is organised on — 7 patterns, 3 quoted and 4 unquoted — so it is the axis on which an entry can go dead.

Verified as **not** covered by these patterns, before or after this PR — all pre-existing *total* misses (no marker at all, so not the deceptive shape fixed here), and all left alone rather than silently widened:

- `file:///Users/alice/creds.txt` — **survives whole**; the lookbehind blocks a `/` preceded by `/`. Carries a full home path, so this is the one I would fix next.
- `/Ünïcode/alice/creds.txt` — survives; the first-segment class is `[A-Za-z0-9._-]+`.
- `src/main/creds.txt`, `./config/creds.txt` — bare relative paths, survive.
- `/etc` — single-segment root, survives (two separators required).

What the census **cannot** see: only strings routed through `sanitizeCrashReportString`. Detail keys ending in `path` are replaced wholesale upstream and never reach these patterns. And I enumerated the pattern set *as written* — I have no corpus of real crash reports, so the relative frequency of each form in the field is unmeasured.

## The fix

Emitting the marker and removing the path become one operation. An unquoted path crosses a space only to reach a run that is **path evidence by itself**:

- a run carrying a separator **and** a name — `Share\creds.txt` — or a separator twice — `Team Share\orca\workspace`. Plain runs may precede one, which is how a folder with two spaces is crossed.
- a run carrying **only** a name — `My Notes.txt`, a last segment with a space in it — but then every run before it has to carry a separator, so `then push git@github.com` cannot pull a hostname in.

No run in the window starts with the separator, so a second path on the same line stays a second path; none carries `:`, so two stack frames do not collapse into one; and a run ending in a name **ends** the path, because a filename is the last thing in one. Sentence punctuation ends it too.

Enforced invariant, asserted on every fixture: **nothing of a path survives next to a marker** — no separator, and no name carrying an extension.

## Two counterexamples this commit fixes

Both reproduced against the real sanitiser before anything changed.

**1. Prose carrying a slash after a path was swallowed.** Introduced by the first commit here, and it contradicts that commit's own control — that control survives on a full stop, and the same sentence without one does not:

| | before this commit | after |
|---|---|---|
| `read /etc/hosts then it failed and/or retried` | `read [redacted-path] retried` | `read [redacted-path] then it failed and/or retried` |
| `read …/creds.txt but read/write failed` | `read [redacted-path] failed` | `read [redacted-path] but read/write failed` |

A crash report exists to carry that text. `and/or` is not a path continuing.

**2. A path whose last segment holds a space still leaked the filename** — on `main`, on the parent commit and on this one alike:

| | before | after |
|---|---|---|
| `read /Users/brennan/Documents/My Notes.txt failed` | `read [redacted-path] Notes.txt failed` | `read [redacted-path] failed` |

The invariant could not see it: what survives there carries no separator, so a rule about separators reads it as prose. That is a check blind to the case it exists for, so it now forbids a **name** beside the marker as well.

The two pull in opposite directions — one says match less, the other match more — so they are fixed by one rule rather than two, and the rule is what the section above describes.

## The cost of the crossing

The crossing looked ahead by scanning the rest of the line at every space, which turned a linear cost quadratic. A crash report is exactly where a very long line arrives: minified frames, serialised state, base64 blobs.

One line of space-separated paths, best of three, measured under load:

| line | parent commit | this commit | `main` |
|---|---|---|---|
| 12KB | 11.7ms | 0.1ms | 0.1ms |
| 25KB | 70.3ms | 0.2ms | 0.2ms |
| 50KB | 289.0ms | 0.4ms | 0.3ms |
| 100KB | 1,346ms | 0.8ms | 0.7ms |

Four times the cost per doubling before, twice after. The window is now bounded two ways: at most two runs are skipped, and a run is at most a filesystem's longest segment. Both bounds are load-bearing — unbounding the run length alone puts a line of separator-heavy runs back at 334ms — and both are pinned by a timing test with a ~250x margin, so it fails on a return to quadratic rather than on a slow machine.

## Proof

32 pins pass on the fix. Against the parent commit, **8 of the new ones go red**, including the timing pin at 1,189ms.

Per-element ablation, one entry at a time, tree asserted clean between each:

| ablation | red | what it pins |
|---|---|---|
| `)` dropped from the stop set | 1 | two stack frames on one line stay two |
| crossing widened to any whitespace | 1 | a path stops at the end of its line |
| a window run may start with the separator | 1 | two paths on one line stay two |
| `:` dropped from the window runs | 1 | frames again — and the URL control |
| any separator-carrying run may terminate | 1 | `or read/write failed` stays prose |
| the two-separator chain terminator dropped | 2 | a directory chain ending in no filename |
| the name-ends-a-path guard dropped | 1 | `…/creds.txt then check b/c/d.txt` stays prose |
| skipped-run bound 2 → 64 | 1 | path-shaped words further along a sentence |
| run-length bound 255 → 8192 | 1 | the timing pin, on separator-heavy runs |
| plain runs may precede a bare name | 1 | a host spelled like a file |

**Three elements of the parent commit's mechanism reddened 0 and were not inert** — instrumented rather than counted, by diffing the sanitiser's output with each one removed:

- `)` in the stop set: without it, two frames on one line collapse into a single marker and everything after the first is destroyed.
- the crossing being space-and-tab only: without it, a path reaches across a line break into the next line.
- a continuation never starting with the separator: inert under the parent's unbounded scan, which crossed to the same place anyway — and load-bearing under a bounded window, so it is pinned here.

A fourth candidate, quotes in the stop set, changed no output on any probe: measured inert, left unpinned.

**Controls.** #17310's positive control still holds. Nine cases now assert the prose after a path survives byte-identical — plain prose, a sentence break, a following URL, a slash one run away and several, a filename-shaped host, and path-shaped words after a filename — so these pins cannot pass by eating the rest of every line.

Fixtures are synthetic (`fileserver`, `brennan`, `alice`, `creds.txt`) and contain nothing from a real machine.

## Secret patterns: same shape?

Asked and checked. **Yes, one can** — `SECRET_ASSIGNMENT_PATTERN`'s unquoted-value branch `[^&\s,;]+` terminates at whitespace, exactly like the unquoted path tails did:

```
password=hunter2 correcthorse battery  ->  password=[redacted] correcthorse battery
```

I have **not** changed it here, deliberately. A path can be extended safely because a separator and a filename are real evidence that the text continues; an unquoted secret value has no such evidence, so extending it across whitespace would swallow arbitrary prose. Fixing it needs a decision about that trade-off rather than a quiet regex widening in a path PR. Flagging for a follow-up. Its behaviour is unchanged by this commit.

The other secret patterns match whole or not at all. Two produce cosmetic residue that is not secret material (`=` base64 padding after a `Bearer` token; characters outside a token's own alphabet), and the private-key block matches to its `-----END-----` or to end-of-string.

## Known limits

- A folder name carrying sentence punctuation still ends the crossing: `/Users/alice/Notes, Drafts/creds.txt` keeps `Drafts/creds.txt`. Unchanged by this commit, and deliberately: the general fix collapses stack frames, which is filed as its own decision on #17317.
- A path whose last segment has a space **and** no extension — `…/My Documents/My Notes` — is still cut at that space. A bare extensionless token is lexically identical to prose; the name rule is what resolves the common case, and there is nothing left to resolve this one with.
- Prose is absorbed in two narrow shapes, both in the safe direction and both pinned as such: a path-shaped token (`docs/readme.md`) within two runs after a path, and a filename-shaped token directly after one.

## Verification

- `pnpm tc` run **cold** (tsbuildinfo cleared): exit 0, zero `error TS`, proven live with a planted type error first.
- `oxlint`: exit 0 on both files, proven live with a planted violation. `oxfmt` applied.
- 327 tests green across 28 crash-reporting suites.
- Differential against `main` over 25 crash-report-shaped lines: 6 differ, every one a path redacted whole where `main` cut it, and no line of prose lost that `main` kept.
