### PR TITLE
Invoke build scripts directly instead of via npm_execpath

### DIFF
--- a/config/scripts/build-native-for-platform.mjs
+++ b/config/scripts/build-native-for-platform.mjs
@@ -12,28 +12,10 @@ if (process.platform !== 'darwin') {
   process.exit(0)
 }
 
-runPnpmScript('build:computer-macos')
-runPnpmScript('build:keyboard-layout-macos')
-runPnpmScript('build:notification-status-macos')
+runNodeScript('config/scripts/build-computer-macos.mjs')
+runNodeScript('config/scripts/build-keyboard-layout-macos.mjs')
+runNodeScript('config/scripts/build-notification-status-macos.mjs')
 process.exit(0)
-
-function runPnpmScript(scriptName) {
-  const npmExecPath = process.env.npm_execpath
-  const command = npmExecPath
-    ? process.execPath
-    : process.platform === 'win32'
-      ? 'pnpm.cmd'
-      : 'pnpm'
-  const args = npmExecPath ? [npmExecPath, 'run', scriptName] : ['run', scriptName]
-  const result = spawnSync(command, args, { stdio: 'inherit' })
-
-  if (result.signal) {
-    process.kill(process.pid, result.signal)
-  }
-  if (result.status !== 0 || result.error) {
-    process.exit(result.status ?? 1)
-  }
-}
 
 function runNodeScript(scriptPath) {
   const result = spawnSync(process.execPath, [scriptPath], { stdio: 'inherit' })

--- a/config/scripts/run-ssh-docker-bulk-open-freeze-e2e.mjs
+++ b/config/scripts/run-ssh-docker-bulk-open-freeze-e2e.mjs
@@ -1,28 +1,26 @@
 import { spawnSync } from 'node:child_process'
 
 const extraArgs = process.argv.slice(2)
-const pnpmEntry = process.env.npm_execpath
-if (!pnpmEntry) {
-  throw new Error('npm_execpath is required; run this harness through pnpm')
-}
+const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const env = {
   ...process.env,
   ORCA_E2E_SSH_DOCKER: '1'
 }
-
-const runtime = spawnSync(process.execPath, [pnpmEntry, 'run', 'ensure:electron-runtime'], {
+const spawnOptions = {
   stdio: 'inherit',
-  env
-})
+  env,
+  shell: process.platform === 'win32'
+}
+
+const runtime = spawnSync(pnpm, ['run', 'ensure:electron-runtime'], spawnOptions)
 
 if (runtime.status !== 0) {
   process.exit(runtime.status ?? 1)
 }
 
 const result = spawnSync(
-  process.execPath,
+  pnpm,
   [
-    pnpmEntry,
     'exec',
     'playwright',
     'test',
@@ -34,10 +32,7 @@ const result = spawnSync(
     '--workers=1',
     ...extraArgs
   ],
-  {
-    stdio: 'inherit',
-    env
-  }
+  spawnOptions
 )
 
 process.exit(result.status ?? 1)

--- a/config/scripts/run-ssh-docker-bulk-open-freeze-e2e.test.mjs
+++ b/config/scripts/run-ssh-docker-bulk-open-freeze-e2e.test.mjs
@@ -1,0 +1,52 @@
+import { spawnSync } from 'node:child_process'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const scriptPath = fileURLToPath(
+  new URL('./run-ssh-docker-bulk-open-freeze-e2e.mjs', import.meta.url)
+)
+
+describe('SSH Docker bulk-open freeze runner', () => {
+  it('invokes pnpm from PATH when npm_execpath is a native executable', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'orca-bulk-open-pnpm-'))
+    const logPath = path.join(tempDir, 'pnpm.log')
+    const shimPath = path.join(tempDir, process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm')
+    const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'PATH'
+
+    try {
+      writePnpmShim(shimPath)
+      const result = spawnSync(process.execPath, [scriptPath], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          [pathKey]: `${tempDir}${path.delimiter}${process.env[pathKey] ?? ''}`,
+          npm_execpath: process.execPath,
+          ORCA_TEST_PNPM_LOG: logPath
+        }
+      })
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(readFileSync(logPath, 'utf8').replaceAll('\r\n', '\n')).toBe(
+        [
+          'run ensure:electron-runtime',
+          'exec playwright test tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1',
+          ''
+        ].join('\n')
+      )
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})
+
+function writePnpmShim(shimPath) {
+  if (process.platform === 'win32') {
+    writeFileSync(shimPath, '@echo off\r\necho %*>>"%ORCA_TEST_PNPM_LOG%"\r\n', 'utf8')
+    return
+  }
+  writeFileSync(shimPath, '#!/bin/sh\nprintf \'%s\\n\' "$*" >>"$ORCA_TEST_PNPM_LOG"\n', 'utf8')
+  chmodSync(shimPath, 0o755)
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 |

<!-- /orca-pr-loc -->

## Problem

Build scripts relied on the `npm_execpath` environment variable set by npm/pnpm, creating brittle coupling to npm's internal implementation and requiring scripts to always be run through pnpm.

## Solution

Invoke Node.js scripts and pnpm directly from PATH:
- `build-native-for-platform.mjs`: Call Node scripts directly instead of via pnpm wrapper
- `run-ssh-docker-bulk-open-freeze-e2e.mjs`: Find pnpm from PATH with platform-aware detection (`pnpm.cmd` on Windows, `pnpm` on Unix)
- Added test to verify correct pnpm invocation and argument passing

## ELI5

Build scripts no longer depend on npm internals—they call pnpm directly from the system and invoke Node scripts directly, making the build process more robust and portable.

## What Changed

- Removed `runPnpmScript()` function from `build-native-for-platform.mjs` and replaced pnpm invocations with direct Node script calls
- Changed `run-ssh-docker-bulk-open-freeze-e2e.mjs` to invoke pnpm from PATH instead of requiring `npm_execpath` environment variable
- Added test file `run-ssh-docker-bulk-open-freeze-e2e.test.mjs` to verify correct pnpm invocation behavior

## Why

Eliminating the `npm_execpath` dependency makes scripts more portable and less fragile. They can now be invoked directly with the Node runtime without requiring npm/pnpm as a wrapper.

## Linked Issue

Fixes #

## Visual Proof

N/A – No UI or behavior changes.

## Testing

- [x] Automated test added for SSH docker bulk-open freeze runner
- [x] Test verifies pnpm is correctly invoked from PATH
- [x] Cross-platform handling for Windows (`pnpm.cmd`) and Unix-like systems

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md`

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)