### PR TITLE
fix(crash): suppress Linux namespace SIGTERM reports

### DIFF
--- a/src/main/crash-reporting/expected-teardown-state.test.ts
+++ b/src/main/crash-reporting/expected-teardown-state.test.ts
@@ -13,6 +13,7 @@ import {
 
 function shouldRecordKilledRenderer(expectedTeardown: 'none' | 'renderer-reload' | 'app-shutdown') {
   return shouldRecordProcessGoneCrash({
+    platform: 'win32',
     source: 'renderer',
     processType: 'renderer',
     reason: 'killed',

--- a/src/main/crash-reporting/gpu-crash-fallback-field-sessions.test.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-field-sessions.test.ts
@@ -66,7 +66,13 @@ const FIELD_GPU_EVENT = {
 describe('1.4.190 win32 GPU-child crash cluster', () => {
   it('does not let process_gone_suppressed gate the fallback candidate check', () => {
     // The GPU death is suppressed as recoverable churn (no user-facing report)...
-    expect(shouldRecordProcessGoneCrash({ ...FIELD_GPU_EVENT, exitCode: -2147483645 })).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        ...FIELD_GPU_EVENT,
+        platform: 'win32',
+        exitCode: -2147483645
+      })
+    ).toBe(false)
     // ...but the fallback path reads the raw child-process-gone event, so the
     // suppression cannot hide a broken driver from recovery.
     expect(

--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, it } from 'vitest'
 import {
-  shouldRecordProcessGoneCrash,
+  shouldRecordProcessGoneCrash as classifyProcessGoneCrash,
   shouldRecoverRendererAfterProcessGone
 } from './process-gone-classification'
+
+type ProcessGoneClassificationInput = Parameters<typeof classifyProcessGoneCrash>[0]
+
+function shouldRecordProcessGoneCrash({
+  platform = 'darwin',
+  ...event
+}: Omit<ProcessGoneClassificationInput, 'platform'> & {
+  platform?: NodeJS.Platform
+}): boolean {
+  return classifyProcessGoneCrash({ platform, ...event })
+}
 
 describe('shouldRecordProcessGoneCrash', () => {
   it('suppresses killed process exits during expected lifecycle teardown', () => {
@@ -258,14 +269,35 @@ describe('shouldRecordProcessGoneCrash', () => {
     ).toBe(true)
   })
 
-  it('still records renderer kills from the recent Linux crash-report cluster', () => {
+  it('suppresses namespace-encoded SIGTERM kills from the recent Linux cluster', () => {
     expect(
       shouldRecordProcessGoneCrash({
+        platform: 'linux',
         source: 'renderer',
         processType: 'renderer',
         reason: 'killed',
         exitCode: 61696,
         expectedTeardown: 'none'
+      })
+    ).toBe(false)
+  })
+
+  it('keeps wait status 61696 reportable outside the exact Linux killed boundary', () => {
+    const processGone = {
+      source: 'renderer' as const,
+      processType: 'renderer',
+      reason: 'killed',
+      exitCode: 61696,
+      expectedTeardown: 'none' as const
+    }
+
+    expect(shouldRecordProcessGoneCrash({ ...processGone, platform: 'darwin' })).toBe(true)
+    expect(shouldRecordProcessGoneCrash({ ...processGone, platform: 'win32' })).toBe(true)
+    expect(
+      shouldRecordProcessGoneCrash({
+        ...processGone,
+        platform: 'linux',
+        reason: 'abnormal-exit'
       })
     ).toBe(true)
   })
@@ -285,6 +317,7 @@ describe('shouldRecordProcessGoneCrash', () => {
   it('records non-SIGTERM killed process exits outside expected lifecycle teardown', () => {
     expect(
       shouldRecordProcessGoneCrash({
+        platform: 'linux',
         source: 'renderer',
         processType: 'renderer',
         reason: 'killed',
@@ -339,6 +372,15 @@ describe('shouldRecordProcessGoneCrash', () => {
 })
 
 describe('shouldRecoverRendererAfterProcessGone', () => {
+  it('recovers unexpected killed renderers', () => {
+    expect(
+      shouldRecoverRendererAfterProcessGone({
+        reason: 'killed',
+        expectedTeardown: 'none'
+      })
+    ).toBe(true)
+  })
+
   it('does not recover expected renderer reload teardown', () => {
     expect(
       shouldRecoverRendererAfterProcessGone({

--- a/src/main/crash-reporting/process-gone-classification.ts
+++ b/src/main/crash-reporting/process-gone-classification.ts
@@ -2,6 +2,8 @@ export type ProcessGoneSource = 'renderer' | 'child'
 export type ExpectedTeardownScope = 'none' | 'renderer-reload' | 'app-shutdown'
 
 const WINDOWS_CONTROL_TERMINATION_EXIT_CODES = new Set([0xc000013a, 0x40010004])
+// Chromium's PID-namespace SIGTERM handler exits 241; waitpid reports 241 << 8.
+const LINUX_NAMESPACE_SIGTERM_WAIT_STATUS = 0xf100
 const RECOVERABLE_CHILD_PROCESS_TYPES = new Set(['gpu'])
 const RECOVERABLE_UTILITY_SERVICE_NAMES = new Set([
   'audio.mojom.AudioService',
@@ -49,6 +51,7 @@ function isRecoverableChromiumChildProcess({
 }
 
 export function shouldRecordProcessGoneCrash({
+  platform,
   source,
   processType,
   serviceName,
@@ -56,6 +59,7 @@ export function shouldRecordProcessGoneCrash({
   exitCode,
   expectedTeardown
 }: {
+  platform: NodeJS.Platform
   source: ProcessGoneSource
   processType?: string
   serviceName?: string
@@ -76,7 +80,11 @@ export function shouldRecordProcessGoneCrash({
   // Why: Electron reports expected Chromium teardown during reload/update as
   // `killed` + SIGTERM or Windows control termination statuses. Treat real
   // crash reasons as reportable, but skip these normal termination shapes.
-  if (exitCode === 15 || isWindowsControlTerminationExitCode(exitCode)) {
+  if (
+    exitCode === 15 ||
+    isWindowsControlTerminationExitCode(exitCode) ||
+    (platform === 'linux' && exitCode === LINUX_NAMESPACE_SIGTERM_WAIT_STATUS)
+  ) {
     return false
   }
   if (expectedTeardown === 'app-shutdown') {

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -117,6 +117,41 @@ describe('recordProcessGoneCrash', () => {
     expect(sink.flushMock).toHaveBeenCalledOnce()
   })
 
+  it('durably suppresses a Linux namespace-encoded renderer SIGTERM', () => {
+    const record = vi.fn()
+
+    withStubbedPlatform('linux', () => {
+      recordProcessGoneCrash(
+        { record } as never,
+        event({ reason: 'killed', exitCode: 61696 }),
+        new ProcessGoneDedupe()
+      )
+    })
+
+    expect(record).not.toHaveBeenCalled()
+    expect(getCrashBreadcrumbSnapshot()).toEqual([
+      expect.objectContaining({
+        name: 'process_gone_suppressed',
+        data: expect.objectContaining({
+          source: 'renderer',
+          reason: 'killed',
+          exitCode: 61696,
+          expectedTeardown: 'none'
+        })
+      })
+    ])
+    expect(sink.records).toEqual([
+      expect.objectContaining({
+        name: 'crash.breadcrumb',
+        attributes: expect.objectContaining({
+          'breadcrumb.name': 'process_gone_suppressed',
+          'breadcrumb.data': expect.objectContaining({ exitCode: 61696 })
+        })
+      })
+    ])
+    expect(sink.flushMock).toHaveBeenCalledOnce()
+  })
+
   it('keeps suppressed renderer evidence scoped to its renderer', () => {
     const dedupe = new ProcessGoneDedupe()
     const suppressed = (webContentsId: number) =>
@@ -475,10 +510,10 @@ describe('recordProcessGoneCrash', () => {
     }
   }
 
-  // Why child kills: the decode gate is source-agnostic and reads
+  // Why child exits: the decode gate is source-agnostic and reads
   // process.platform synchronously at record time, so the platform stub is
   // still in force when it runs.
-  const nonRecoverableChildKill = (
+  const nonRecoverableChildExit = (
     overrides: Partial<ProcessGoneCrashEvent>
   ): ProcessGoneCrashEvent =>
     event({
@@ -494,7 +529,7 @@ describe('recordProcessGoneCrash', () => {
     withStubbedPlatform('linux', () => {
       recordProcessGoneCrash(
         { record } as never,
-        nonRecoverableChildKill({ reason: 'killed', exitCode: 61696 }),
+        nonRecoverableChildExit({ reason: 'abnormal-exit', exitCode: 61696 }),
         new ProcessGoneDedupe()
       )
     })
@@ -518,14 +553,14 @@ describe('recordProcessGoneCrash', () => {
     withStubbedPlatform('win32', () => {
       recordProcessGoneCrash(
         { record } as never,
-        nonRecoverableChildKill({ reason: 'killed', exitCode: 1 }),
+        nonRecoverableChildExit({ reason: 'killed', exitCode: 1 }),
         new ProcessGoneDedupe()
       )
     })
     withStubbedPlatform('linux', () => {
       recordProcessGoneCrash(
         { record } as never,
-        nonRecoverableChildKill({ reason: 'launch-failed', exitCode: 18 }),
+        nonRecoverableChildExit({ reason: 'launch-failed', exitCode: 18 }),
         new ProcessGoneDedupe()
       )
     })

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -80,10 +80,6 @@ const captureProcessMinidump: MinidumpCapture = (crashedAtMs, expectedProcessTyp
 // one here would weaken the other 30s coalescers. Stay uniform with them.
 const SUPPRESSED_PROCESS_GONE_COALESCE_MS = 30_000
 
-function processGoneBreadcrumbData(event: ProcessGoneCrashEvent) {
-  return buildSuppressedProcessGoneBreadcrumbData(event)
-}
-
 function processGoneRendererOrigin(event: ProcessGoneCrashEvent): string | undefined {
   return event.webContentsId === undefined
     ? undefined
@@ -122,7 +118,7 @@ function persistFailureData(event: ProcessGoneCrashEvent, error: unknown) {
       ? error.code
       : undefined
   return {
-    ...processGoneBreadcrumbData(event),
+    ...buildSuppressedProcessGoneBreadcrumbData(event),
     errorName: error instanceof Error ? error.name : typeof error,
     errorMessage: sanitizeCrashReportString(error instanceof Error ? error.message : String(error)),
     ...(errorCode ? { errorCode } : {})
@@ -194,6 +190,7 @@ export function recordProcessGoneCrash(
   scheduleCrashpadDumpPrune()
   if (
     !shouldRecordProcessGoneCrash({
+      platform: process.platform,
       source: event.source,
       processType: event.processType,
       serviceName,
@@ -205,7 +202,7 @@ export function recordProcessGoneCrash(
     // Why: Chromium can crash-loop a recoverable child (network service seen at
     // 1459/min) and each suppressed event costs a span plus a forced disk flush,
     // which both floods the 30-entry ring and evicts the real pre-crash trail.
-    const suppressedData = processGoneBreadcrumbData(event)
+    const suppressedData = buildSuppressedProcessGoneBreadcrumbData(event)
     const origin = processGoneRendererOrigin(event)
     recordCoalescedDurableCrashBreadcrumb({
       name: 'process_gone_suppressed',
@@ -221,7 +218,7 @@ export function recordProcessGoneCrash(
   if (!store) {
     recordDurableCrashBreadcrumb(
       'crash_report_store_unavailable',
-      processGoneBreadcrumbData(event),
+      buildSuppressedProcessGoneBreadcrumbData(event),
       'Crash report store unavailable',
       processGoneRendererOrigin(event)
     )
@@ -305,7 +302,7 @@ export function recordProcessGoneCrash(
     siblingDeaths,
     (reportId, details) => store.attachDetails(reportId, details),
     recorded,
-    processGoneBreadcrumbData(event),
+    buildSuppressedProcessGoneBreadcrumbData(event),
     processGoneRendererOrigin(event)
   )
   void recorded
@@ -322,7 +319,7 @@ export function recordProcessGoneCrash(
         console.error('[crash-reporting] Failed to attach minidump signature:', error)
         recordDurableCrashBreadcrumb(
           'minidump_signature_attach_failed',
-          processGoneBreadcrumbData(event),
+          buildSuppressedProcessGoneBreadcrumbData(event),
           error instanceof Error ? error.message : String(error),
           processGoneRendererOrigin(event)
         )


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​84 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## Description

Two recurring Linux renderer reports had the exact tuple `{ reason: "killed", exitCode: 61696 }`. This PR classifies only that Linux tuple as Chromium's PID-namespace encoding of SIGTERM, matching Orca's existing suppression of raw SIGTERM (`15`). It keeps the raw status in a durable `process_gone_suppressed` breadcrumb and does not change renderer recovery.

Field reports:

- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1788046761474049
- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1788049489135619

Exact boundary:

```ts
platform === 'linux' && reason === 'killed' && exitCode === 0xf100
```

macOS/Windows `61696`, Linux non-`killed` `61696`, and Linux SIGKILL (`9`) remain reportable. Recovery remains separately enabled for unexpected renderer kills.

## Clear, undeniable fix evidence

### 1. Reproduced before changing code

The production classifier was driven with the field tuple before implementation. It returned the wrong result and intentionally exited 1:

```json
{"expected":false,"actual":true,"event":{"platform":"linux","source":"renderer","processType":"renderer","reason":"killed","exitCode":61696,"expectedTeardown":"none"}}
```

Controlled Electron/Linux probes also established the boundaries before the fix:

| Probe | Electron result |
| --- | --- |
| Direct renderer SIGKILL | `{ reason: "killed", exitCode: 9 }` |
| Direct renderer SIGTERM without nested PID namespace | `{ reason: "killed", exitCode: 15 }` |
| Emulated Chromium namespace SIGTERM handler (`exit(241)`) | raw wait status `61696` (`241 << 8`) |

The exact combined live tuple could not be generated in the disposable hosts because Chromium's nested PID namespace could not be activated. Pinned Chromium 150 source closes the mapping: its namespace handler converts SIGTERM to exit 241, waitpid encodes that as `0xf100`, and the zygote remaps it to `PROCESS_WAS_KILLED`, which Electron surfaces as `reason: "killed"`.

Relevant Chromium paths:

- `sandbox/linux/services/namespace_sandbox.h:92-112`
- `sandbox/linux/services/namespace_sandbox.cc:78-90,239-248`
- `content/zygote/zygote_linux.cc:316-353,435-447`

This is not the kernel-OOM/SIGKILL signature: SIGKILL produces raw status `9`.

### 2. Same deterministic probe after the fix

The same production classifier probe now exits 0:

```json
{"expected":false,"actual":false,"event":{"platform":"linux","source":"renderer","processType":"renderer","reason":"killed","exitCode":61696,"expectedTeardown":"none"}}
```

The recorder regression test proves all three required outcomes together:

- `store.record` is never called;
- a durable, flushed `process_gone_suppressed` breadcrumb is written;
- exported breadcrumb data retains raw `exitCode: 61696`.

### 3. Verification

- Crash-reporting suite: **256/256 passed**.
- Final focused post-rebase suite: **60/60 passed**.
- Earlier expanded diagnostics/recovery suite: **132/132 passed**.
- `pnpm tc:node`: passed.
- Changed-code quality (native, type-aware, React Doctor): **0 findings**.
- Formatter, max-lines ratchet, and `git diff --check`: passed.
- Real Electron renderer-crash recovery E2E: **1/1 passed after the fix**. Orca auto-reloaded after forced renderer crashes and terminal input continued reaching the same PTY. The same scenario also passed twice during the pre-fix Linux reproduction.

## ELI5

Linux sometimes reports "Chromium was politely told to stop" as the large number `61696` instead of the familiar SIGTERM number `15`. Orca mistook that translated stop signal for a new crash and asked the user to report it. We now recognize only that exact Linux translation, keep a small diagnostic note, and let the existing reload recovery continue.

## Trade-offs / behavior changes

- Linux `{ killed, 61696 }` events no longer create a user-facing crash report, crash span, report prompt, or minidump attachment.
- A durable breadcrumb keeps the raw event for diagnostics, and Crashpad pruning still runs.
- The external termination and brief renderer reload are not prevented; this PR fixes false crash reporting, not the sender or host memory pressure.
- True SIGKILL/OOM shapes and every event outside the exact Linux boundary remain reportable.

The two field hosts had severe memory pressure and no free swap, so a userspace pressure manager is plausible. The sender and memory owner are not proven; this PR does not claim a renderer leak, Git causation, or crash prevention.

## Adversarial review

**3 fresh-agent loops were run on the evolving diff.**

1. Loop 1 found one test-evidence gap: raw `61696` was asserted in the local breadcrumb ring but not in exported durable telemetry. The assertion was added.
2. Loop 2 was clean.
3. The pre-commit max-lines ratchet required removing an existing pass-through wrapper; loop 3 reviewed that exact final diff and was clean. It also passed 256 crash-reporting tests, Node typecheck, changed-code quality, and patch-integrity checks.

Final result: **clean; zero open findings**.

## Independent `/perf` review

**Clean; zero findings.** The final diff adds one static platform read and one exact branch on a rare process-gone event. It adds no loop, scan, I/O, timer, subprocess, polling, cache, listener, or retained resource. The matched tuple now avoids the expensive report/minidump path and reuses the existing 30-second, 128-key-bounded coalesced breadcrumb path.

Evidence:

- 1,459 suppressed events produce one sink record and one flush in existing stress coverage.
- A warmed 5,000,000-call classifier probe completed in 15.89 ms (~3.18 ns/call).
- Renderer recovery remains separate and unchanged.
