### PR TITLE
fix(shared): redact crash-report paths that wear a URL

### DIFF
--- a/src/shared/crash-report-redaction.test.ts
+++ b/src/shared/crash-report-redaction.test.ts
@@ -173,11 +173,16 @@ const LEAKED_PATH_FORMS: readonly (readonly [string, string, readonly string[]])
     'connect JDBC:MySQL://db.internal:3306/appdb failed',
     ['db.internal', '3306', 'appdb']
   ],
-  // The ':' before a scheme is not always another scheme. Refusing to start after one would leave
-  // this path whole.
+  // What precedes a scheme is not always another scheme. Refusing to start after punctuation would
+  // leave these paths whole.
   [
     'file URL behind a colon that is no scheme',
     'at line 12:file:///Users/alice/Documents/secret.js here',
+    ['alice', 'Documents', 'secret.js']
+  ],
+  [
+    'file URL behind a version that is no scheme',
+    'orca 1.2.3-file:///Users/alice/Documents/secret.js here',
     ['alice', 'Documents', 'secret.js']
   ],
   // Roots the bare patterns cannot start from: a tilde home, and a drive spelled with forward slashes.

--- a/src/shared/crash-report-redaction.test.ts
+++ b/src/shared/crash-report-redaction.test.ts
@@ -100,6 +100,30 @@ const LEAKED_PATH_FORMS: readonly (readonly [string, string, readonly string[]])
     'read /Users/brennan/My Documents/My Notes.txt failed',
     ['brennan', 'My Documents', 'My Notes', 'Notes.txt']
   ],
+  // A dot is not only a filename's. It sits inside folder names too -- a version, a date -- and
+  // reading one as the path's end shipped every segment after it.
+  [
+    'unquoted POSIX, a dot inside a spaced folder name',
+    'read /Users/brennan/Release 1.0 Notes/creds.txt failed',
+    ['brennan', 'Release 1.0 Notes', 'creds.txt']
+  ],
+  [
+    'unquoted drive letter, a dot inside a spaced folder name',
+    'load C:\\Users\\brennan\\Orca v1.2 beta\\creds.txt failed',
+    ['brennan', 'Orca v1.2 beta', 'creds.txt']
+  ],
+  // An extension is as long as its format made it. The eight-character bound that used to end the
+  // path here is shorter than the ones macOS, iOS and Java hand out every day.
+  [
+    'unquoted POSIX, an extension longer than eight characters',
+    'read /Users/brennan/My App.entitlements failed',
+    ['brennan', 'My App', 'App.entitlements']
+  ],
+  [
+    'unquoted drive letter, an extension longer than eight characters',
+    'load C:\\Users\\brennan\\Work Files\\App.xcodeproj failed',
+    ['brennan', 'Work Files', 'App.xcodeproj']
+  ],
   // A directory chain ending in no filename at all: the run that continues it carries separators
   // and nothing else, so a chain has to count as path evidence on its own.
   [

--- a/src/shared/crash-report-redaction.test.ts
+++ b/src/shared/crash-report-redaction.test.ts
@@ -391,7 +391,7 @@ describe('sanitizeCrashReportString path redaction is all-or-nothing', () => {
   // fails on a return to quadratic rather than on a slow machine.
   it.each([
     ['a line of many paths', '/opt/orca/logs/frame.js '.repeat(4_260)],
-    ['a few runs carrying many separators', `/opt/o/a ${`${'x/'.repeat(3_000)} `.repeat(8)}`]
+    ['a few runs carrying many separators', `/opt/o/a ${`${'x/'.repeat(6_000)} `.repeat(8)}`]
   ])('sanitises a very long single line in bounded time (%s)', (_name, line) => {
     expect(line.length).toBeGreaterThan(45_000)
 
@@ -400,4 +400,106 @@ describe('sanitizeCrashReportString path redaction is all-or-nothing', () => {
 
     expect(performance.now() - startedAt).toBeLessThan(250)
   })
+})
+
+/**
+ * Why: every rule holding a path's spaces to that path is one character class or one bound, and any
+ * of them that no row watches can be deleted or tightened with the suite still green -- which is how
+ * a bound whose tight side drops long paths, and a guard holding an undecided question open, both
+ * went unpinned. Each row is the measured output of ablating exactly one element.
+ */
+describe('sanitizeCrashReportString pins each element of the space-crossing rule', () => {
+  it.each([
+    // A quote ends an unquoted path, so a quoted path beside one keeps its closing delimiter.
+    [
+      'a quote ends the unquoted path',
+      'read /Users/brennan/a.txt "quoted /Users/alice/c.txt" tail',
+      'read [redacted-path] "quoted [redacted-path]" tail'
+    ],
+    // The window is two runs wide. Tightened, a four-word folder name ships from its second word.
+    [
+      'a folder name of four words',
+      'read /Users/brennan/A B C D/creds.txt failed',
+      'read [redacted-path] failed'
+    ],
+    // The scheme stack is matched with the path, three deep, or a driver is left naming the host.
+    [
+      'a path behind three stacked schemes',
+      'connect a:jdbc:postgresql://db.internal:5432/orca failed',
+      'connect [redacted-path] failed'
+    ],
+    // A name has to end its token. Without that, a dotted suffix on a word in the prose reads as a
+    // filename and the sentence carrying it is redacted along with the path.
+    [
+      'prose carrying a separator and a dotted suffix',
+      'read /etc/hosts see docs/api.md#anchor for detail',
+      'read [redacted-path] see docs/api.md#anchor for detail'
+    ]
+  ])('%s', (_name, input, expected) => {
+    expect(sanitizeCrashReportString(input)).toBe(expected)
+  })
+
+  // The run bound is the longest segment a filesystem hands back: 255 on APFS, NTFS and ext4. Both
+  // sides are pinned -- tightening it drops a legal path, widening it returns the quadratic.
+  it('crosses a space into a segment as long as a filesystem allows', () => {
+    const segment = 'n'.repeat(255)
+
+    expect(
+      sanitizeCrashReportString(`read /Users/brennan/Team ${segment}/creds.txt failed`, 4_000)
+    ).toBe('read [redacted-path] failed')
+  })
+
+  it('gives up on a segment longer than a filesystem allows', () => {
+    const segment = 'n'.repeat(300)
+
+    expect(
+      sanitizeCrashReportString(`read /Users/brennan/Team ${segment}/creds.txt failed`, 4_000)
+    ).toBe(`read [redacted-path] ${segment}/creds.txt failed`)
+  })
+
+  // Parked, awaiting a decision: sentence punctuation inside a folder name. The path stops there and
+  // the segments after it ship. Crossing it collapses two stack frames into one, so the guard stays
+  // until that is settled -- pinned so that deleting a character class cannot settle it by accident.
+  it.each([
+    [
+      'a comma',
+      'read /Users/brennan/Notes, Drafts/creds.txt failed',
+      'read [redacted-path] Drafts/creds.txt failed'
+    ],
+    [
+      'a semicolon',
+      'read /Users/brennan/A; B/creds.txt failed',
+      'read [redacted-path] B/creds.txt failed'
+    ],
+    [
+      'an exclamation mark',
+      'read /Users/brennan/Wow! Notes/creds.txt failed',
+      'read [redacted-path] Notes/creds.txt failed'
+    ]
+  ])(
+    'stops a path where a folder name carries sentence punctuation (%s)',
+    (_name, input, expected) => {
+      expect(sanitizeCrashReportString(input)).toBe(expected)
+    }
+  )
+
+  // The other side of the same trade-off as the row above: a filename with anything after its
+  // extension is not a name to this rule, and relaxing that is what eats the prose. Known limit.
+  it.each([
+    [
+      'a suffix after the extension',
+      'read /Users/brennan/My Notes.txt-bak failed',
+      'read [redacted-path] Notes.txt-bak failed'
+    ],
+    [
+      'an editor backup marker',
+      'read /Users/brennan/My Notes.txt~ failed',
+      'read [redacted-path] Notes.txt~ failed'
+    ]
+  ])(
+    'stops a path at a filename carrying a suffix after its extension (%s)',
+    (_name, input, expected) => {
+      expect(sanitizeCrashReportString(input)).toBe(expected)
+    }
+  )
 })

--- a/src/shared/crash-report-redaction.test.ts
+++ b/src/shared/crash-report-redaction.test.ts
@@ -387,8 +387,8 @@ describe('sanitizeCrashReportString path redaction is all-or-nothing', () => {
 
   // A crash report carries minified frames, serialised state and base64 blobs, all on one line. The
   // crossing looks ahead over a bounded window for that reason: scanning to the end of the line at
-  // every space made a 100KB line cost over a second. The budget is ~250x the measured cost, so it
-  // fails on a return to quadratic rather than on a slow machine.
+  // every space made a 100KB line cost over a second. The budget is ~150x the measured cost (1.3ms
+  // against 250ms), so it fails on a return to quadratic rather than on a slow machine.
   it.each([
     ['a line of many paths', '/opt/orca/logs/frame.js '.repeat(4_260)],
     ['a few runs carrying many separators', `/opt/o/a ${`${'x/'.repeat(6_000)} `.repeat(8)}`]
@@ -458,8 +458,9 @@ describe('sanitizeCrashReportString pins each element of the space-crossing rule
   })
 
   // Parked, awaiting a decision: sentence punctuation inside a folder name. The path stops there and
-  // the segments after it ship. Crossing it collapses two stack frames into one, so the guard stays
-  // until that is settled -- pinned so that deleting a character class cannot settle it by accident.
+  // the segments after it ship. Crossing it eats the prose that follows a path instead -- 'failed:
+  // /Users/alice/a.js; retry with lib/x/y.js' loses its second half -- so the guard stays until that
+  // is settled, pinned so that deleting a character class cannot settle it by accident.
   it.each([
     [
       'a comma',
@@ -483,8 +484,14 @@ describe('sanitizeCrashReportString pins each element of the space-crossing rule
     }
   )
 
-  // The other side of the same trade-off as the row above: a filename with anything after its
-  // extension is not a name to this rule, and relaxing that is what eats the prose. Known limit.
+  // KNOWN LEAK, accepted and awaiting the same decision. A spaced final segment whose extension is
+  // followed by something that is not itself an extension ('.txt-bak', '.txt~') is not a name to
+  // this rule, so the path ends before it and the filename ships beside the marker. These rows are
+  // the leak, not the fix: they hold the measured output so it cannot change unnoticed.
+  // It is the trailing lookahead on the name that leaks here, and the same lookahead is the only
+  // thing keeping 'see docs/api.md#anchor for detail' out of the redaction -- one element, two
+  // directions, which is why this waits on replacing the pattern with per-token classification
+  // rather than on a wider character class. Ablating that lookahead reddens all three rows at once.
   it.each([
     [
       'a suffix after the extension',
@@ -497,9 +504,18 @@ describe('sanitizeCrashReportString pins each element of the space-crossing rule
       'read [redacted-path] Notes.txt~ failed'
     ]
   ])(
-    'stops a path at a filename carrying a suffix after its extension (%s)',
+    'leaks a filename carrying a non-extension suffix (known limit) (%s)',
     (_name, input, expected) => {
       expect(sanitizeCrashReportString(input)).toBe(expected)
     }
   )
+
+  // The leak's boundary: a further dot is itself an extension, so a double-extension filename is a
+  // name and goes whole. Without this the limit above reads wider than it is.
+  it.each([
+    ['a double extension', 'read /Users/brennan/My Notes.tar.gz failed'],
+    ['a dotted backup suffix', 'read /Users/brennan/My Notes.txt.bak failed']
+  ])('redacts a spaced filename carrying a second extension whole (%s)', (_name, input) => {
+    expect(sanitizeCrashReportString(input)).toBe('read [redacted-path] failed')
+  })
 })

--- a/src/shared/crash-report-redaction.test.ts
+++ b/src/shared/crash-report-redaction.test.ts
@@ -27,21 +27,27 @@ describe('sanitizeCrashReportString', () => {
     expect(sanitized).toContain('[redacted-path]')
   })
 
-  // Positive control: prose that resembles neither must survive, so the assertions above
-  // cannot pass by redacting everything.
-  it('leaves text carrying no secret and no path untouched', () => {
-    const prose = 'Renderer crashed while restoring 3 tabs after a sk- prefixed heading'
-
+  // Positive control: text that resembles neither must survive, so the assertions above cannot pass
+  // by redacting everything. The later rows are the near-misses -- a tilde that roots no path, and a
+  // URL whose path names a server rather than this disk.
+  it.each([
+    'Renderer crashed while restoring 3 tabs after a sk- prefixed heading',
+    'throughput was ~5s/op after the retry',
+    'cache~v2/entries/cold was empty',
+    'POST https://api.example.com/v1/messages returned 500',
+    'require node:fs and npm:left-pad'
+  ])('leaves text carrying no secret and no path untouched: %s', (prose) => {
     expect(sanitizeCrashReportString(prose)).toBe(prose)
   })
 })
 
 /**
- * Why: the unquoted patterns used to stop at the first space, emitting [redacted-path] with the
- * rest of the path still beside it -- a report that looks scrubbed but still carries a share name,
- * a directory chain and a filename. Each form below is pinned to go whole.
+ * Why: a path reaches a report in more shapes than the bare patterns can see. The unquoted patterns
+ * used to stop at the first space, emitting [redacted-path] with the rest of the path still beside
+ * it; the URL and tilde forms below were missed outright, so a username left the machine untouched.
+ * Each form is pinned to go whole -- marker emitted and content removed in one operation.
  */
-const PARTIAL_LEAK_FORMS: readonly (readonly [string, string, readonly string[]])[] = [
+const LEAKED_PATH_FORMS: readonly (readonly [string, string, readonly string[]])[] = [
   [
     'unquoted UNC, one space',
     'open \\\\fileserver\\Private Share\\brennan\\creds.txt failed',
@@ -110,11 +116,76 @@ const PARTIAL_LEAK_FORMS: readonly (readonly [string, string, readonly string[]]
     'drive-letter path inside a stack frame',
     '    at load (C:\\Users\\brennan\\My Documents\\app.js:12:9)',
     ['brennan', 'My Documents', 'app.js']
+  ],
+  // URL-shaped roots. A renderer stack is file:// throughout, so this is the form a crash report is
+  // most likely to carry -- and the one that used to survive redaction entirely.
+  [
+    'file URL',
+    'load file:///Users/alice/Documents/app.js failed',
+    ['alice', 'Documents', 'app.js']
+  ],
+  [
+    'file URL inside a stack frame',
+    '    at load (file:///Users/alice/My Documents/app.js:12:9)',
+    ['alice', 'My Documents', 'app.js']
+  ],
+  [
+    'quoted file URL',
+    'load "file:///Users/alice/My Documents/app.js" failed',
+    ['alice', 'My Documents', 'app.js']
+  ],
+  [
+    'file URL rooted at a drive',
+    'load file:///C:/Users/alice/Documents/app.js failed',
+    ['Users', 'alice', 'Documents']
+  ],
+  [
+    'file URL naming a host',
+    'load file://fileserver/Private Share/alice/creds.txt failed',
+    ['fileserver', 'Private Share', 'alice', 'creds.txt']
+  ],
+  ['file URL without an authority', 'load file:/Users/alice/app.js failed', ['alice', 'app.js']],
+  [
+    'file URL with an uppercase scheme',
+    'load FILE:///Users/alice/Documents/app.js failed',
+    ['alice', 'Documents', 'app.js']
+  ],
+  [
+    'editor deep link',
+    'open vscode://file/Users/alice/Documents/app.ts:3 failed',
+    ['alice', 'Documents', 'app.ts']
+  ],
+  ['app scheme URL', 'load app:///Users/alice/dist/index.js failed', ['alice', 'dist']],
+  [
+    'share URL',
+    'mount smb://fileserver/Private Share/alice/creds.txt failed',
+    ['fileserver', 'Private Share', 'alice', 'creds.txt']
+  ],
+  // Roots the bare patterns cannot start from: a tilde home, and a drive spelled with forward slashes.
+  [
+    'tilde home',
+    'read ~/Documents/My Notes/creds.txt failed',
+    ['Documents', 'My Notes', 'creds.txt']
+  ],
+  [
+    'tilde home of a named user',
+    'read ~alice/Documents/creds.txt failed',
+    ['alice', 'Documents', 'creds.txt']
+  ],
+  [
+    'drive letter with forward slashes',
+    'open C:/Users/alice/My Documents/creds.txt failed',
+    ['Users', 'alice', 'My Documents', 'creds.txt']
+  ],
+  [
+    'quoted drive letter with forward slashes',
+    'open "C:/Users/alice/My Documents/creds.txt" failed',
+    ['Users', 'alice', 'My Documents', 'creds.txt']
   ]
 ]
 
 describe('sanitizeCrashReportString path redaction is all-or-nothing', () => {
-  it.each(PARTIAL_LEAK_FORMS)('redacts %s whole', (_name, input, fragments) => {
+  it.each(LEAKED_PATH_FORMS)('redacts %s whole', (_name, input, fragments) => {
     const sanitized = sanitizeCrashReportString(input)
 
     expect(sanitized).toContain('[redacted-path]')
@@ -124,9 +195,12 @@ describe('sanitizeCrashReportString path redaction is all-or-nothing', () => {
     // The defect shape: a marker sitting next to surviving path content. A separator after the
     // marker catches a path cut mid-chain. It cannot see a cut inside the last segment -- what
     // survives there is a bare filename, 'My Notes.txt' cut to 'Notes.txt' -- so a name carrying an
-    // extension beside the marker is forbidden too.
+    // extension beside the marker is forbidden too. Leading covers a root left standing where the
+    // marker begins -- 'file:///C:[redacted-path]', 'C:[redacted-path]', '~[redacted-path]',
+    // 'jdbc:[redacted-path]' -- which still names where the file lived.
     expect(sanitized).not.toMatch(/\[redacted-path\][^\n]*[\\/]/)
     expect(sanitized).not.toMatch(/\[redacted-path\] ?\S*\.[A-Za-z0-9]/)
+    expect(sanitized).not.toMatch(/[\\/:~][^\s]*\[redacted-path\]/)
   })
 
   // Control for the space-crossing rule specifically: it must not swallow the prose that follows a
@@ -183,6 +257,38 @@ describe('sanitizeCrashReportString path redaction is all-or-nothing', () => {
       'path-shaped words after a filename',
       'read /Users/brennan/Documents/creds.txt then check b/c/d.txt now',
       'then check b/c/d.txt now'
+    ],
+    // The URL rule must not reach a remote resource: a web-transport path names a server's route,
+    // not this machine's disk, and redacting it would cost the report its failing endpoint.
+    [
+      'remote https URL carrying a path',
+      'read /etc/hosts then POST https://api.example.com/v1/messages',
+      'then POST https://api.example.com/v1/messages'
+    ],
+    [
+      'websocket URL carrying a path',
+      'read /etc/hosts then ws://127.0.0.1:9229/devtools/page/ABC',
+      'then ws://127.0.0.1:9229/devtools/page/ABC'
+    ],
+    [
+      'dev server URL carrying a path',
+      'read /etc/hosts then GET http://localhost:5173/src/main.tsx',
+      'then GET http://localhost:5173/src/main.tsx'
+    ],
+    [
+      'scheme that names no path',
+      'read /etc/hosts then require node:fs and npm:left-pad',
+      'then require node:fs and npm:left-pad'
+    ],
+    [
+      'git remote over ssh',
+      'read /etc/hosts then push git@github.com:orgname/reponame.git',
+      'then push git@github.com:orgname/reponame.git'
+    ],
+    [
+      'remote URL whose scheme is uppercased',
+      'read /etc/hosts then POST HTTPS://api.example.com/v1/messages',
+      'then POST HTTPS://api.example.com/v1/messages'
     ]
   ])('keeps the prose after a redacted path (%s)', (_name, input, survives) => {
     expect(sanitizeCrashReportString(input)).toBe(`read [redacted-path] ${survives}`)

--- a/src/shared/crash-report-redaction.test.ts
+++ b/src/shared/crash-report-redaction.test.ts
@@ -161,6 +161,25 @@ const LEAKED_PATH_FORMS: readonly (readonly [string, string, readonly string[]])
     'mount smb://fileserver/Private Share/alice/creds.txt failed',
     ['fileserver', 'Private Share', 'alice', 'creds.txt']
   ],
+  // A scheme stacked on another: matching from the inner one left the driver beside the marker,
+  // 'jdbc:[redacted-path]', which the invariant below reads as a root still standing.
+  [
+    'database URL behind a driver scheme',
+    'connect jdbc:postgresql://db.internal:5432/orca failed',
+    ['db.internal', '5432', 'orca']
+  ],
+  [
+    'database URL behind a driver scheme, uppercased',
+    'connect JDBC:MySQL://db.internal:3306/appdb failed',
+    ['db.internal', '3306', 'appdb']
+  ],
+  // The ':' before a scheme is not always another scheme. Refusing to start after one would leave
+  // this path whole.
+  [
+    'file URL behind a colon that is no scheme',
+    'at line 12:file:///Users/alice/Documents/secret.js here',
+    ['alice', 'Documents', 'secret.js']
+  ],
   // Roots the bare patterns cannot start from: a tilde home, and a drive spelled with forward slashes.
   [
     'tilde home',
@@ -197,10 +216,13 @@ describe('sanitizeCrashReportString path redaction is all-or-nothing', () => {
     // survives there is a bare filename, 'My Notes.txt' cut to 'Notes.txt' -- so a name carrying an
     // extension beside the marker is forbidden too. Leading covers a root left standing where the
     // marker begins -- 'file:///C:[redacted-path]', 'C:[redacted-path]', '~[redacted-path]',
-    // 'jdbc:[redacted-path]' -- which still names where the file lived.
+    // 'jdbc:[redacted-path]' -- which still names where the file lived. A root is a separator, a
+    // tilde or a scheme; a bare ':' is not one, or a frame's 'line 12:' would read as a root.
     expect(sanitized).not.toMatch(/\[redacted-path\][^\n]*[\\/]/)
     expect(sanitized).not.toMatch(/\[redacted-path\] ?\S*\.[A-Za-z0-9]/)
-    expect(sanitized).not.toMatch(/[\\/:~][^\s]*\[redacted-path\]/)
+    expect(sanitized).not.toMatch(
+      /[\\/~][^\s]*\[redacted-path\]|[A-Za-z][A-Za-z0-9+.-]*:\[redacted-path\]/
+    )
   })
 
   // Control for the space-crossing rule specifically: it must not swallow the prose that follows a

--- a/src/shared/crash-report-redaction.ts
+++ b/src/shared/crash-report-redaction.ts
@@ -30,6 +30,9 @@ const PATH_STOP = '\\s"\'`<>)'
 // segment; without it a single long run carrying many separators costs as much on its own.
 const MAX_CROSSED_RUNS = 2
 const MAX_RUN_LENGTH = 255
+// An extension is as long as its format made it -- '.entitlements', '.mobileprovision' -- so a
+// length bound here ends a path at the last name it still recognised. The run bound caps the reach.
+const EXTENSION = '\\.[A-Za-z0-9]+'
 
 // What may follow a space and still be the same path. No run in the window starts with the separator
 // (so a second path on the same line stays a second path) and none carries ':' (so two stack frames
@@ -40,12 +43,12 @@ const MAX_RUN_LENGTH = 255
 //     read/write failed' reaches neither and is left alone.
 //   'My Notes.txt' -- a spaced last segment is only a name, so every run before it has to carry a
 //     separator. 'then push git@github.com' does not, which stops a host from reading as a file.
-const pathContinuation = (separator: string): string => {
+const pathContinuation = (separator: string, crossableRuns: number): string => {
   const body = `[^${PATH_STOP}:]{0,${MAX_RUN_LENGTH}}`
   const run = `[^${PATH_STOP}:${separator}]${body}`
   const chainRun = `${run}${separator}${body}`
-  const name = `\\.[A-Za-z0-9]{1,8}(?![^${PATH_STOP}:])`
-  const crossed = (crossable: string): string => `(?:${crossable}[ \\t]){0,${MAX_CROSSED_RUNS}}`
+  const name = `${EXTENSION}(?![^${PATH_STOP}:])`
+  const crossed = (crossable: string): string => `(?:${crossable}[ \\t]){0,${crossableRuns}}`
   return (
     `(?:${crossed(run)}(?:${chainRun}${name}|${chainRun}${separator}${body})` +
     `|${crossed(chainRun)}${run}${name})`
@@ -56,8 +59,13 @@ const pathContinuation = (separator: string): string => {
 // continues it, which keeps emitting the marker and removing the path a single operation rather
 // than two. A run ending in a name ends the path -- a filename is the last thing in one -- and
 // sentence punctuation ends it too, so the prose after a path survives.
+// A name only ends a path where the path does not visibly resume. A dot sits inside folder names
+// too -- 'Release 1.0 Notes/spec.md' -- and there it is no filename, so after a name the crossing
+// still reaches the very next run. It reaches no further: a path has no filler words between its
+// segments, which is what 'creds.txt then check b/c/d.txt' has and what leaves that prose alone.
 const unquotedPathTail = (separator: string): string =>
-  `(?:[^${PATH_STOP}]|(?<![.,;:!?])(?<!\\.[A-Za-z0-9]{1,8})[ \\t](?=${pathContinuation(separator)}))*`
+  `(?:[^${PATH_STOP}]|(?<![.,;:!?])(?:(?<!${EXTENSION})[ \\t](?=${pathContinuation(separator, MAX_CROSSED_RUNS)})` +
+  `|[ \\t](?=${pathContinuation(separator, 0)})))*`
 const POSIX_TAIL = unquotedPathTail('/')
 const WINDOWS_TAIL = unquotedPathTail('\\\\')
 

--- a/src/shared/crash-report-redaction.ts
+++ b/src/shared/crash-report-redaction.ts
@@ -67,7 +67,14 @@ const WINDOWS_TAIL = unquotedPathTail('\\\\')
 // rejects. Matching from the scheme removes it with the path, so no root is left beside the marker,
 // and the scheme is proof enough of a path that no plain first segment is needed. The web transports
 // are excluded: their path names a remote resource, not this machine's disk.
-const LOCAL_URL_ROOT = '(?<![A-Za-z0-9+.-])(?!(?:https?|wss?):)[A-Za-z][A-Za-z0-9+.-]*:/'
+// A scheme can also be stacked on another, as a database URL stacks one on its driver. The stack is
+// matched with the path, because starting inside it left `jdbc:` standing beside the marker. The
+// lookbehind still admits a ':' before the scheme, so a path behind one that is no scheme at all --
+// 'at line 12:file:///...' -- is not left whole.
+const MAX_STACKED_SCHEMES = 3
+const LOCAL_URL_ROOT =
+  `(?<![A-Za-z0-9+.-])(?:[A-Za-z][A-Za-z0-9+.-]*:){0,${MAX_STACKED_SCHEMES}}?` +
+  '(?!(?:https?|wss?):)[A-Za-z][A-Za-z0-9+.-]*:/'
 
 const PATH_PATTERNS = [
   /(["'`])\/[A-Za-z0-9._-]+\/(?:(?!\1)[^<>\n\r])+\1/g,

--- a/src/shared/crash-report-redaction.ts
+++ b/src/shared/crash-report-redaction.ts
@@ -69,11 +69,12 @@ const WINDOWS_TAIL = unquotedPathTail('\\\\')
 // are excluded: their path names a remote resource, not this machine's disk.
 // A scheme can also be stacked on another, as a database URL stacks one on its driver. The stack is
 // matched with the path, because starting inside it left `jdbc:` standing beside the marker. The
-// lookbehind still admits a ':' before the scheme, so a path behind one that is no scheme at all --
-// 'at line 12:file:///...' -- is not left whole.
+// lookbehind still admits what is no scheme at all before it -- 'at line 12:file:///...',
+// '1.2.3-file:///...' -- so a path behind punctuation is not left whole. It keeps rejecting a word
+// character, which is what stops the tail of an excluded scheme ('ttps:/') from matching on its own.
 const MAX_STACKED_SCHEMES = 3
 const LOCAL_URL_ROOT =
-  `(?<![A-Za-z0-9+.-])(?:[A-Za-z][A-Za-z0-9+.-]*:){0,${MAX_STACKED_SCHEMES}}?` +
+  `(?<![A-Za-z0-9])(?:[A-Za-z][A-Za-z0-9+.-]*:){0,${MAX_STACKED_SCHEMES}}?` +
   '(?!(?:https?|wss?):)[A-Za-z][A-Za-z0-9+.-]*:/'
 
 const PATH_PATTERNS = [

--- a/src/shared/crash-report-redaction.ts
+++ b/src/shared/crash-report-redaction.ts
@@ -61,10 +61,20 @@ const unquotedPathTail = (separator: string): string =>
 const POSIX_TAIL = unquotedPathTail('/')
 const WINDOWS_TAIL = unquotedPathTail('\\\\')
 
+// A local path also reaches a report wearing a URL: renderer stacks are `file://` throughout, and a
+// deep link (`vscode://file/...`), a share URL, or a drive spelled `C:/...` carries one too. The bare
+// patterns cannot see any of them -- the root `/` sits behind a scheme, which their lookbehind
+// rejects. Matching from the scheme removes it with the path, so no root is left beside the marker,
+// and the scheme is proof enough of a path that no plain first segment is needed. The web transports
+// are excluded: their path names a remote resource, not this machine's disk.
+const LOCAL_URL_ROOT = '(?<![A-Za-z0-9+.-])(?!(?:https?|wss?):)[A-Za-z][A-Za-z0-9+.-]*:/'
+
 const PATH_PATTERNS = [
   /(["'`])\/[A-Za-z0-9._-]+\/(?:(?!\1)[^<>\n\r])+\1/g,
   /(["'`])[A-Za-z]:\\(?:(?!\1)[^<>\n\r])+\1/gi,
   /(["'`])\\\\[^\\\s"'`<>\n\r)]+\\(?:(?!\1)[^<>\n\r])+\1/gi,
+  new RegExp(`${LOCAL_URL_ROOT}${POSIX_TAIL}`, 'gi'),
+  new RegExp(`(?<![A-Za-z0-9./~])~[A-Za-z0-9._-]*/[A-Za-z0-9._-]+/${POSIX_TAIL}`, 'g'),
   new RegExp(`(?<![A-Za-z0-9./])/[A-Za-z0-9._-]+/${POSIX_TAIL}`, 'g'),
   new RegExp(`(?<![A-Za-z0-9])[A-Za-z]:\\\\${WINDOWS_TAIL}`, 'gi'),
   new RegExp(`\\\\\\\\[^\\\\${PATH_STOP}]+\\\\${WINDOWS_TAIL}`, 'gi'),


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​289 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​275 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |

<!-- /orca-pr-loc -->

Stacked on #17312 (which sits on #17310). Six commits are new here.

## ELI5

A crash report is a note your app mails home when it breaks. Before it's mailed, we cross out
anything private — like the folder path that has your name in it.

We were only crossing out paths written the plain way (`/Users/alice/notes.txt`). But the same
path can be written as a web-style address — `file:///Users/alice/notes.txt` — and written that
way, **we didn't cross out any of it**. The whole thing, name included, went out in the mail.

That spelling isn't exotic: when the app's UI crashes, the error's stack trace uses that exact
form for every line. So this was the most likely way for a path to be in a report, and the one
way we weren't looking at.

## Severity

This is a **total** miss, not a partial one: the path was not shortened or marked, it was left
completely untouched, in a report that **leaves the machine**. It applies on macOS, Linux and
Windows.

It is separate from the partial-redaction defect #17312 fixes, and pre-dates both PRs.

## User-facing before / after

A crash while loading a renderer module, as it would appear in the submitted report:

**Before**
```
at loadModule (file:///Users/alice/Projects/client-acme/src/index.js:412:17)
```
`alice`, the employer, and the client name all ship.

**After**
```
at loadModule ([redacted-path])
```

A Windows report, where the drive root used to survive on the marker's left:

| | Before | After |
|---|---|---|
| `file:///C:/Users/alice/AppData/...` | `file:///C:[redacted-path]` | `[redacted-path]` |
| `C:/Users/alice/Documents/creds.txt` | `C:[redacted-path]` | `[redacted-path]` |
| `~alice/Documents/creds.txt` | *(untouched — username shipped)* | `[redacted-path]` |
| `vscode://file/Users/alice/app.ts` | *(untouched)* | `[redacted-path]` |
| `smb://fileserver/Private Share/alice/...` | *(untouched)* | `[redacted-path]` |

Diagnostics that must survive are unchanged — a failing endpoint still reads
`POST https://api.example.com/v1/messages`, and a devtools socket still reads
`ws://127.0.0.1:9229/devtools/page/ABC`.

## What changed

One pattern, plus one for tilde homes. A path's root is recognised only when nothing
word-like or slash-like precedes it — which is exactly what a URL scheme puts there. Matching
**from the scheme** removes it together with the path, so the marker is emitted and the content
removed in one operation (#17312's invariant) and no root is left beside the marker.

Web transports (`http`, `https`, `ws`, `wss`) are excluded: their path names a server's route,
not this disk. Redacting those would cost every report its failing endpoint.

## The census

I enumerated one axis: **the lead-in — what precedes a path's root, and what delimits it** —
across 60+ synthetic forms run through the real sanitiser. It found three families:

| Family | Verdict |
|---|---|
| **URL-scheme lead-in** (`file:`, `vscode:`, `app:`, `smb:`, `sftp:`, `ssh:`, `webpack:`, `chrome-extension:`, `blob:file:`) | **total miss** — fixed |
| **Tilde lead-in** (`~alice/...` total miss; `~/...` left `~` beside the marker) | fixed |
| **Forward-slash drive root** (`C:/...`, `file:///C:/...`) | root survived beside the marker — fixed |

Three findings are deliberately **not** fixed here, with reproductions below.

### Not fixed 1 — a stop character inside a path segment (pre-existing partial leak)

An apostrophe, paren, bracket or quote inside a segment truncates the redaction and leaves the
rest of the path — **including a username** — beside the marker:

```
C:\Users\O'Brien\creds.txt   ->  [redacted-path]'Brien\creds.txt
/Users/alice/Copy (2)/x.txt  ->  [redacted-path] (2)/x.txt
```

I implemented the obvious fix — generalize #17312's "cross only to reach a run that continues
the path" rule from spaces to these characters — and **measured it destroying diagnostics**: two
stack frames on one line collapsed into a single redaction.

```
at f (/Users/alice/a.js:1:2) at g (/Users/bob/b.js:3:4)
  with the relaxation:  at f ([redacted-path])          <- 'at g (' destroyed, 2 markers -> 1
  as shipped:           at f ([redacted-path]) at g ([redacted-path])
```

The crossing rule that bounds a safe fix for spaces does not bound one here, so this needs its
own decision rather than riding along on a URL fix. Same reasoning applied to the secret
patterns in #17312.

### Not fixed 2 — a space in the **first** path segment

`read /Private Share/alice/creds.txt` is a total miss, and is a miss on the parent commit too —
the root-segment class can't span a space. This is a distinct axis (the root token, not the
lead-in). The UNC and URL spellings of the same path are both covered, so the exposure is a bare
POSIX path whose top-level directory has a space.

### Not fixed 3 — a local path inside an `http(s)` URL

`http://localhost:5173/@fs/Users/alice/proj/x.js` (a Vite dev-server URL) is untouched. A path
inside a web-transport URL cannot be told from a remote route without heuristics, and redacting
it would break the exclusion above. Query parameters are already covered
(`?path=/Users/alice/x` redacts today).

### What this census cannot see

It probes `sanitizeCrashReportString` on single strings. It does not cover: fields that reach a
report **without** passing through the sanitiser (native minidump payloads, Electron's own
crashReporter fields); detail **keys** as opposed to values; non-path identifiers (hostnames,
emails, git remotes); or a path split across two fields. It also enumerates the lead-in axis
only — findings 1 and 2 above are the two other axes it brushed against.

## Two more roots, found while pinning this one

Both reproduced against the real sanitiser first, both in this same root, both leaving a path or its scheme in a report that reads as scrubbed.

**A scheme stacked on another.** A database URL stacks one on its driver, and the root matched the inner one:

| | before | after |
|---|---|---|
| `connect jdbc:postgresql://db.internal:5432/orca failed` | `connect jdbc:[redacted-path] failed` | `connect [redacted-path] failed` |

That is exactly the shape this PR's own invariant forbids — a root left standing where the marker begins — and the invariant did not see it because no fixture carried a stacked scheme. The stack is matched with the path now; leftmost-first already prefers the outermost, so nothing else moved.

**Punctuation before a scheme.** The lookbehind rejected `+`, `.` and `-` there, so a path introduced by anything ending in one survived **whole** — on `main` and on both parents:

| | before | after |
|---|---|---|
| `orca 1.2.3-file:///Users/alice/Documents/secret.js` | *(untouched — username and path shipped)* | `[redacted-path]` |

Only a word character has to be rejected there. That half is what stops the tail of an excluded scheme (`ttps:/` inside `https://`) from matching on its own, and it stays: ablating it reddens the six web-transport controls. Adding punctuation back reddens the new pin and nothing else.

Both directions are now pinned, including the case that argues against the obvious fix: refusing to start after any `:` would leave `at line 12:file:///Users/alice/...` whole, so the lookbehind deliberately admits one.

**The invariant now names what a root is** — a separator, a tilde, or a scheme — rather than any `:` at all. As written it read a stack frame's `line 12:` as a root; a line number beside the marker names nothing about where a file lived.

## Proof

- **77 pins pass on the fix; 23 go red against the parent commit and 44 against `main`.** Every new form is load-bearing, none passes vacuously.
- **Per-element ablation, one entry at a time** (a pattern list is where whole-set ablation hides a dead entry), tree asserted clean between each. Reds: URL pattern **16**, tilde pattern **2**, web-transport exclusion **6**, scheme lookbehind **6**, scheme stack **2**, the lookbehind admitting punctuation **1**, tilde lookbehind **1**, tilde second-segment rule **1**, case-insensitive flag **1**.
- The web-transport and scheme-lookbehind counts were re-measured across four ablation shapes each — deleting the guard, and weakening it three ways. **Six is the maximum any shape produces**, at both the 38-pin and 60-pin suite sizes; the earlier figures stand.
- **Three elements I first wrote were dead** — an explicit forward-slash drive pattern, a quoted variant, and the URL authority group all reddened **0**, because the URL rule already subsumed them. Removed, not kept.
- The strengthened invariant (no root on the marker's **left**) was added because 4 pins passed against the parent commit without it — clamped, not protected.
- Cold typecheck (tsbuildinfo cleared) on all three projects -- node, cli, web: exit 0, zero `error TS`, proven live with a planted type error first (exit 1, TS2322).
- `oxlint` proven live with a planted `no-debugger` (exit 1), then clean on the changed files; `oxfmt` applied.
- 424 tests across 32 crash-reporting test files pass.
- The three findings left unfixed above were re-run byte-for-byte against this branch: **all three are unchanged**, including the two-frames-on-one-line contract that bounds the first of them. Nothing here quietly decides any of them.

All fixtures are synthetic (`alice`, `bob`, `brennan`, `fileserver`, `O'Brien`, `db.internal`) — no real path, no real secret, and no path that exists on the machine these were written on.

---

## Round 6 — two more leak shapes closed, every element pinned, one leak documented

Two shapes still shipped path content beside the marker, both ordinary. Measured against three
revisions: `main` (`f572ba34bc`), and `9e0ce53448`, this PR's state before these commits.

| input | on `main` | before | after |
|---|---|---|---|
| `read /Users/alice/Release 1.0 Notes/spec.md failed` | `read [redacted-path] 1.0 Notes/spec.md failed` | `read [redacted-path] Notes/spec.md failed` | `read [redacted-path] failed` |
| `load C:\Users\Alice Smith\Release 1.0 Notes\spec.md` | `load [redacted-path] Smith\Release 1.0 Notes\spec.md` | `load [redacted-path] Notes\spec.md` | `load [redacted-path]` |
| `sign /Users/alice/Work Files/App.entitlements failed` | *(same as before)* | `sign [redacted-path] Files/App.entitlements failed` | `sign [redacted-path] failed` |
| `build /Users/alice/Work Files/App.xcodeproj failed` | *(same as before)* | `build [redacted-path] Files/App.xcodeproj failed` | `build [redacted-path] failed` |

Only the last two shipped byte-identical to `main`. The first two leaked on `main` as well, but
not identically — `main` kept one more segment — so this closes a shape that was wrong on `main`
and still wrong, differently, on the parent.

**A dot is not only a filename's.** The guard that stops the crossing after a filename read `1.0`
and `v1.2` inside a folder name as the end of the path. It is still needed — `creds.txt then check
b/c/d.txt` must keep its prose — so it is narrowed, not removed: after a name the crossing may
reach the very next run and no further, because a path has no filler words between its segments.

**An extension is as long as its format made it.** The bound was eight characters, and
`.xcodeproj` (9), `.storyboard` (10) and `.entitlements` (12) are all past it, so a spaced final
segment carrying one was not a name to this rule and the filename shipped. The run bound already
caps the lookahead's reach, so the length bound only ever ended a path early. Restoring the old
`{1,8}` reddens two rows.

### Every element is now pinned

Each element mutated one at a time, tree asserted clean between, the file's hash asserted changed
on every mutation. Two baselines are shown because the "unpinned" claim depends on which suite you
ask: the parent commit's, and this PR's own suite immediately before this round's pins.

| element | red at the parent | red before this round | red now |
|---|---|---|---|
| quotes in the stop set | 0 | 2 | 3 |
| the sentence-punctuation guard | 0 | 0 | 3 |
| the name's trailing lookahead | 0 | 0 | 3 |
| the crossed-run window, tightened | 0 | 0 | 1 |
| the run bound, tightened | 0 | 0 | 1 |
| the run bound, widened | 1 | 1 | 2 |
| the scheme stack, tightened | 0 | 0 | 1 |

Five of the seven mutations reddened nothing at all before this round and are newly pinned. The
other two were **not** unpinned, and an earlier draft of this section said they were: quotes was
already caught by two rows added earlier in this PR (it reddened 0 only against the parent's
suite, which is where the "measured inert" reading came from), and the widened run bound was
already caught by the timing row. Both are now pinned directly as well.

**Timing.** The budget is 250 ms. The shipped cost is 1.3 ms median on the longer of the two
inputs (headroom 148–191× across both). Widening the run bound to 100 000 returns the quadratic:
1321 / 1426 / 1400 ms over three runs, 5.3–5.7× past the budget. The earlier observation of 252 ms
against a 250 ms budget was that row **failing** under load on a narrower input, not clearing it —
the input is wider now so the margin is decided by the code. That bound is also pinned
behaviourally, with no timing dependence: widening it reddens *gives up on a segment longer than a
filesystem allows* alongside the timing row, which is the second red in its row above.

### Known limits

**Punctuation inside a folder name** stays parked, and is now held open by three rows rather than
by an unwatched character class. Removing its guard redacts *more*, not less — the cost is the
prose after a path: `failed: /Users/alice/a.js; retry with lib/x/y.js` loses its second half. (An
earlier comment attributed a collapsed pair of stack frames to this guard; measured, that belongs
to the stop-character relaxation under "Not fixed 1" above, not to this one.)

**A filename carrying a non-extension suffix still leaks, and is documented as such.** This is a
real, unfixed leak on `main` and here:

```
read /Users/alice/My Notes.txt-bak failed  ->  read [redacted-path] Notes.txt-bak failed
```

The filename ships beside the marker. The same holds for `.txt~`, `.js-v2` and `.md-draft`. It is
pinned by two rows marked `KNOWN LEAK` in the suite, so it cannot change unnoticed, plus two rows
fixing its boundary — a *second extension* is still a name, so `My Notes.tar.gz` goes whole (those
two rows go red against `main`, so they are pinning a real difference).

It is not fixed here because it is not separable: the trailing lookahead on the name is what leaks
here **and** is the only thing keeping `see docs/api.md#anchor for detail` out of the redaction.
Ablating that one lookahead reddens all three rows at once. One element, two directions — which is
why this waits on the open decision to replace the pattern with per-token classification, rather
than on a wider character class.

Both parked decisions are verified **byte-identical to `main` and to the parent on 14 inputs**,
with a positive control on the same harness (a control input yields three distinct outputs across
the three modules, so the comparison is not vacuous).
