### PR TITLE
test(persistence): give the 130k-leaf pane alias scale test headroom

### DIFF
--- a/src/main/persistence-pane-identity-migration.test.ts
+++ b/src/main/persistence-pane-identity-migration.test.ts
@@ -507,6 +507,7 @@ describe('Store', () => {
     )
   })
 
+  // ~9s locally; the 30s default timeout leaves too little headroom on a loaded CI shard.
   it('loads legacy pane aliases from very large persisted split layouts', async () => {
     const leafCount = 130_000
     writeDataFile({
@@ -561,7 +562,7 @@ describe('Store', () => {
         (entry) => entry.ptyId === 'large-pty' && entry.legacyPaneKey === `tab1:${leafCount}`
       )
     ).toBe(true)
-  })
+  }, 120_000)
 
   it('converts unambiguous dev migration rows into persisted aliases', async () => {
     const stablePaneKey = makePaneKey('tab1', TEST_LEAF_1)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Problem

`persistence-pane-identity-migration.test.ts > loads legacy pane aliases from very large persisted split layouts` intermittently fails the `test / tests node 24 1/8` shard — and with it the `verify` aggregate gate — with:

```
Error: Test timed out in 30000ms.
```

It flaked #17187, whose diff is confined to `src/renderer/src/components/terminal-pane/` and shares no import path with this file.

## Cause

The test builds a 130,000-leaf balanced split layout and asserts the alias migration produces `leafCount + 1` entries. It runs ~9-15s locally against the 30s default in `config/vitest.config.ts:37` — roughly 2-3x margin. The shard it runs on already takes ~257s wall-clock, so under load it crosses 30s. Nothing about the test is nondeterministic; it is purely a timing margin problem.

## Fix

Give this one test an explicit `120_000` timeout, matching the existing convention for known-slow tests (`local-worktree-filesystem-wsl-banner.wsl.test.ts`, `persistence-async-write-syscalls.test.ts`). The default stays 30s for every other test.

Deliberately not reducing `leafCount` — the scale is the point of the test, and it guards the alias migration path that recent worktree/pane perf work touches.

## Verification

`pnpm test src/main/persistence-pane-identity-migration.test.ts` — 7 passed, 16.36s total. `oxlint` clean.