### PR TITLE
fix(terminal): fail closed on ambiguous PTY ownership

### DIFF
--- a/src/renderer/src/hooks/ipc-events/terminal-presentation-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/terminal-presentation-ipc-bridge.ts
@@ -68,6 +68,10 @@ export function registerTerminalPresentationIpcBridge(unsubs: (() => void)[]): v
                 tabId !== undefined ? { preferTabId: tabId } : {}
               )
             : { kind: 'none' as const }
+          if (ownership.kind === 'ambiguous') {
+            // Why: creating a new tab would compound the already-ambiguous PTY binding.
+            throw new Error('Terminal creation is unavailable because the PTY owner is ambiguous')
+          }
           const existingTab =
             ownership.kind === 'owned'
               ? worktreeTabs.find((candidate) => candidate.id === ownership.tabId)

--- a/src/renderer/src/hooks/terminal-presentation-ipc-bridge-ownership.test.ts
+++ b/src/renderer/src/hooks/terminal-presentation-ipc-bridge-ownership.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { setupTerminalCreateSurfacing } from './ipc-events-terminal-create-test-harness'
+
+describe('terminal presentation PTY ownership', () => {
+  it('fails closed when persisted PTY ownership is ambiguous', async () => {
+    const scenario = await setupTerminalCreateSurfacing(() => false)
+    const { storeState, createTerminalListenerRef, createTab, replyTerminalCreate } = scenario
+    const createTerminalListener = createTerminalListenerRef.current
+    if (!createTerminalListener) {
+      throw new Error('Expected create-terminal listener to be registered')
+    }
+    storeState.tabsByWorktree = {
+      'wt-2': [
+        { id: 'tab-primary', ptyId: 'pty-duplicate' },
+        { id: 'tab-stale', ptyId: null }
+      ]
+    }
+    storeState.terminalLayoutsByTabId = {
+      'tab-stale': {
+        ptyIdsByLeafId: { 'leaf-stale': 'pty-duplicate' }
+      }
+    }
+
+    createTerminalListener({
+      requestId: 'req-ambiguous-pty',
+      worktreeId: 'wt-2',
+      ptyId: 'pty-duplicate'
+    })
+
+    expect(createTab).not.toHaveBeenCalled()
+    expect(replyTerminalCreate).toHaveBeenCalledWith({
+      requestId: 'req-ambiguous-pty',
+      error: 'Terminal creation is unavailable because the PTY owner is ambiguous'
+    })
+  })
+})


### PR DESCRIPTION
## ELI5

If Orca's saved renderer state says the same PTY belongs to multiple tabs, Orca now refuses to create another tab for it and returns an explicit error. That stops a corrupted ownership state from getting worse.

## What Changed

- fail closed when terminal presentation receives the existing resolver's `ambiguous` result
- prevent the fallback from calling `createTab(..., { initialPtyId })` for that PTY
- add a focused regression test for one direct tab binding plus one conflicting persisted split-layout binding

## Why

`resolveTerminalTabPtyOwnership` already models conflicting bindings as `ambiguous`, but the terminal-presentation bridge handled only `owned`. `ambiguous` therefore fell through the same path as `none` and minted a third binding.

The fix consumes the existing discriminated result and uses the bridge's existing error-reply path. It does not change xterm, add another ownership classifier, or alter a wire contract.

## Linked Issue

Refs #17171 — discovered during that PR's readiness investigation; there is no standalone issue for this narrowly scoped root cause.

## Visual Proof

N/A — this changes a fail-closed renderer-state decision and request error reply, with no visual or interaction surface.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Fresh local macOS evidence:

- focused presentation/resolver suite: 3 files, 18 tests passed
- registered `terminal-session.layout-pty-ownership` unit gate: 5 files, 40 tests passed
- `pnpm tc:web`: passed
- native and type-aware `oxlint` on both touched files with warnings denied: passed
- `oxfmt --check` on both touched files: passed
- reliability-gate manifest, max-lines ratchet, runtime-Electron ratchet, and `git diff --check`: passed

Physical Windows, Linux, and SSH corrupted-state journeys were not run for this PR. The decision is provider-neutral renderer state; CI covers Windows packaging and the broader test matrix.

## AI Disclosure

## Review

Readiness and elegance review found zero proven P0/P1/P2 issues. The four-line product change reuses the authoritative resolver and the standard bridge error path. It introduces no xterm logic, polling, retry, timer, listener, session inventory, subprocess, retained state, dependency, generated artifact, schema, path, shell, or platform branch.

Automated review: Greptile 5/5 with no actionable defects; CodeRabbit reported minimal merge risk and no actionable code comments.

Reliability contract:

- **Invariant:** `terminal-session.layout-pty-ownership` — a presentation request must never add another tab owner when PTY ownership is ambiguous.
- **Failure source:** an unhandled `ambiguous` result fell through to fresh-tab creation.
- **Oracle:** seed conflicting persisted owners, request the PTY, and require zero `createTab` calls plus an explicit failure reply.
- **Provider/platform coverage:** the shared renderer decision applies to local, daemon, SSH, WSL, remote-runtime, and mobile-triggered presentation without a local-only assumption.
- **Performance budget:** one constant-time branch; no new work loop or resource ownership.
- **Diagnostics:** request callers receive `Terminal creation is unavailable because the PTY owner is ambiguous`.
- **Residual gap:** no physical Windows/Linux/SSH journey seeds this corrupted persisted shape; coverage is deterministic at the provider-neutral renderer boundary.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security/supply chain: no new input authority, network sink, dependency, secret, shell, or executable path.
- Cross-platform/SSH/mobile: no path, process, liveness, transport, payload, persistence-schema, or mobile protocol change.
- Backward compatibility: the request shape and reply shape are unchanged; only an already-ambiguous state now rejects instead of creating another owner.
- Performance/resources: constant-time guard; no allocation retained beyond the existing callback.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
