### PR TITLE
test(ci): level one Codex teardown budget to its siblings, trim two stale raises

### DIFF
--- a/config/scripts/check-runtime-electron-ratchet.test.mjs
+++ b/config/scripts/check-runtime-electron-ratchet.test.mjs
@@ -43,7 +43,7 @@ describe('the checked-in baseline', () => {
     const current = await collectElectronImporters()
     const baseline = readBaseline(readFileSync('config/runtime-electron-baseline.txt', 'utf8'))
     expect(diffAgainstBaseline(current, baseline)).toEqual({ added: [], removed: [] })
-  }, 120_000)
+  }, 60_000)
 
   // Why an exact-empty assertion now: the reachable set reached zero, so "may only
   // shrink" has no room left and any entry at all is a regression. This is strictly

--- a/src/main/codex/codex-app-server-teardown.integration.test.ts
+++ b/src/main/codex/codex-app-server-teardown.integration.test.ts
@@ -88,6 +88,8 @@ async function cleanupServer(server: RunningServer): Promise<void> {
 }
 
 describe.runIf(process.platform !== 'win32')('Codex app-server process teardown', () => {
+  // Why 60s, matching the sibling cases: all four drive the same 40 consecutive
+  // launches, and this one was the only case left on the 30s default.
   it('reaps the forced-close descendant in 40 consecutive launches', async () => {
     const running: RunningServer[] = []
     try {
@@ -105,7 +107,7 @@ describe.runIf(process.platform !== 'win32')('Codex app-server process teardown'
         await cleanupServer(server)
       }
     }
-  }, 30_000)
+  }, 60_000)
 
   it.each(['normal', 'signal'] as const)(
     'reaps provider descendants before relaying a %s root exit in 40 consecutive launches',

--- a/src/renderer/src/components/terminal-pane/issue-4631-terminal-hover-link-provider.repro.test.ts
+++ b/src/renderer/src/components/terminal-pane/issue-4631-terminal-hover-link-provider.repro.test.ts
@@ -132,5 +132,5 @@ describe('issue 4631 terminal hover link-provider repro', () => {
     })
 
     expect(buildElapsedMs + extractElapsedMs + elapsedMs).toBeLessThan(100)
-  }, 120_000)
+  })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Problem

Three separate defects in how per-test timeout budgets are assigned, all found by measuring rather than reading:

1. **Uneven protection across equal-cost siblings.** `codex-app-server-teardown.integration.test.ts` has four cases that each drive the *same* 40 consecutive app-server launches. Three carry a 60s budget; the forced-close case was left on the 30s default. Measured under contention all four cost 5.8–6.5s, so the one case with no headroom was the one most likely to flake first on a slower runner.
2. **A budget that outgrew its test.** The runtime-electron ratchet walks the real module graph in ~0.7s against a 120s budget.
3. **A budget that can never fire.** The issue-4631 hover-link repro asserts `buildElapsedMs + extractElapsedMs + elapsedMs < 100`. A 120s test budget sits three orders of magnitude above an assertion that already bounds the work at 100ms, so the assertion always wins first.

## Solution

- `codex-app-server-teardown.integration.test.ts`: forced-close case `30_000` → `60_000`, matching its three siblings.
- `check-runtime-electron-ratchet.test.mjs`: `120_000` → `60_000` (still ~80x the measured cost; the module graph grows with the repo, so the raise stays explicit rather than being dropped).
- `issue-4631-terminal-hover-link-provider.repro.test.ts`: raise removed; inherits the 30s default at ~124x measured cost.

## How this was measured

Every budget was measured **before** being changed, solo and under contention — full vitest worker parallelism plus 24 CPU hogs on 18 cores:

| Test | Budget before | Solo | Contended | Budget after |
| :--- | ---: | ---: | ---: | ---: |
| codex teardown — forced-close | 30,000ms | — | 6,046ms | 60,000ms |
| codex teardown — normal / signal / stdin-race (unchanged siblings) | 60,000ms | — | 6,484–6,512ms | 60,000ms |
| runtime-electron ratchet baseline | 120,000ms | 947ms | 740ms | 60,000ms |
| issue-4631 hover-link repro | 120,000ms | 113ms | 242ms | 30,000ms (default) |

No budget was lowered on a test that was not measured under contention first.

## Budgets deliberately left alone

Measuring also cleared several budgets that *look* stale but are not. These were candidates and are being explicitly kept:

- **All six 120s/300s raises in `resolve-7za-path.test.mjs`.** They read as 0–2ms on a developer machine, but every one of those tests reaches `getPath7za()`, which **downloads the electron-builder toolset on a cold cache**. The fast local reading is a warm-cache artifact, not evidence of an unused budget. Lowering these would have re-reddened cold CI runners.
- **`skill-freshness-inventory.test.ts` (90s).** Writes `MAXIMUM_PLUGIN_SCAN_ENTRIES + 1` = 16,385 real files; the fixture size is the production bound and is exactly what makes the test detect #10918. It is storage-bound, not masking, and shrinking the fixture would destroy the coverage. Left untouched.
- **`relay-native-dependency-coverage.test.ts` (60s)** runs a real esbuild bundle, and **`plugin-worker-supervision`** (45s) has 500/2000/5000ms backoff inherent to the assertion.

## ELI5

Some tests are allowed to run longer than others before CI calls them stuck. Four tests here do exactly the same amount of work, but one of them had been given half the allowance of the other three — so it was the one most likely to be killed early on a busy machine, even though nothing was wrong with it. We gave it the same allowance as its siblings. Two other tests had allowances of two minutes for work that takes well under a second, so we brought those down to something honest. We timed every test on a loaded machine before changing any number, and we left alone the ones that only *look* slow-for-no-reason but are really waiting on a download or on writing 16,000 files.

## User-facing before/after

**No user-visible change.** This is CI-timing hygiene only — no product code, no UI, no behavior change. What it prevents:

- **Before**: the forced-close Codex teardown case could be killed at 30s on a loaded runner while three identical tests beside it were allowed 60s — a flake that looks like a product bug and costs a re-run.
- **After**: it fails only when the teardown logic is actually broken, and two budgets no longer overstate how long their tests may take, so a genuine hang surfaces in a minute rather than two.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

All three touched files pass, solo and under contention (11/11). Gates run individually in the foreground: `pnpm tc` cold (tsbuildinfo cleared) exit 0 with zero `error TS`; `oxlint` exit 0, proven live with a planted `no-debugger` violation; `oxfmt --check` clean on 3 files.

## Visual Proof

N/A — test-only timing change, no UI.

## Cross-platform / SSH / mobile

The Codex teardown suite is already `describe.runIf(process.platform !== 'win32')`; the other two are platform-neutral. No mobile, SSH, or wire surface touched.
