### PR TITLE
fix(ci): stop hourly/adhoc mac builds from executing native pnpm via node

### DIFF
--- a/config/scripts/build-native-for-platform.mjs
+++ b/config/scripts/build-native-for-platform.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process'
+import { resolvePnpmCliInvocation } from './pnpm-cli-invocation.mjs'
 
 if (process.platform === 'win32') {
   runNodeScript('config/scripts/build-windows-cli-launcher.mjs')
@@ -18,14 +19,8 @@ runPnpmScript('build:notification-status-macos')
 process.exit(0)
 
 function runPnpmScript(scriptName) {
-  const npmExecPath = process.env.npm_execpath
-  const command = npmExecPath
-    ? process.execPath
-    : process.platform === 'win32'
-      ? 'pnpm.cmd'
-      : 'pnpm'
-  const args = npmExecPath ? [npmExecPath, 'run', scriptName] : ['run', scriptName]
-  const result = spawnSync(command, args, { stdio: 'inherit' })
+  const { command, prefixArgs, shell } = resolvePnpmCliInvocation()
+  const result = spawnSync(command, [...prefixArgs, 'run', scriptName], { stdio: 'inherit', shell })
 
   if (result.signal) {
     process.kill(process.pid, result.signal)

--- a/config/scripts/pnpm-cli-invocation.mjs
+++ b/config/scripts/pnpm-cli-invocation.mjs
@@ -1,0 +1,26 @@
+// pnpm 12's npm_execpath is a native binary; feeding it to node broke hourly/adhoc macOS builds.
+
+const JS_CLI_EXTENSION = /\.[cm]?js$/i
+
+export function resolvePnpmCliInvocation({
+  npmExecPath = process.env.npm_execpath,
+  nodeExecPath = process.execPath,
+  platform = process.platform
+} = {}) {
+  if (typeof npmExecPath === 'string' && npmExecPath.length > 0) {
+    if (JS_CLI_EXTENSION.test(npmExecPath)) {
+      return { command: nodeExecPath, prefixArgs: [npmExecPath], shell: false }
+    }
+    return {
+      command: npmExecPath,
+      prefixArgs: [],
+      shell: platform === 'win32' && /\.(cmd|bat)$/i.test(npmExecPath)
+    }
+  }
+
+  return {
+    command: platform === 'win32' ? 'pnpm.cmd' : 'pnpm',
+    prefixArgs: [],
+    shell: platform === 'win32'
+  }
+}

--- a/config/scripts/pnpm-cli-invocation.test.mjs
+++ b/config/scripts/pnpm-cli-invocation.test.mjs
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { resolvePnpmCliInvocation } from './pnpm-cli-invocation.mjs'
+
+const nodeExecPath = '/usr/local/bin/node'
+
+describe('resolvePnpmCliInvocation', () => {
+  it('runs a JS CLI through node so older pnpm.cjs still works', () => {
+    expect(
+      resolvePnpmCliInvocation({
+        npmExecPath: '/Users/runner/setup-pnpm/node_modules/pnpm/bin/pnpm.cjs',
+        nodeExecPath,
+        platform: 'darwin'
+      })
+    ).toEqual({
+      command: nodeExecPath,
+      prefixArgs: ['/Users/runner/setup-pnpm/node_modules/pnpm/bin/pnpm.cjs'],
+      shell: false
+    })
+  })
+
+  it('executes pnpm 12 native binaries directly instead of through node', () => {
+    expect(
+      resolvePnpmCliInvocation({
+        npmExecPath: '/Users/runner/setup-pnpm/pnpm',
+        nodeExecPath,
+        platform: 'darwin'
+      })
+    ).toEqual({
+      command: '/Users/runner/setup-pnpm/pnpm',
+      prefixArgs: [],
+      shell: false
+    })
+  })
+
+  it('does not wrap a Windows native pnpm.exe in node', () => {
+    expect(
+      resolvePnpmCliInvocation({
+        npmExecPath: 'C:\\hostedtoolcache\\pnpm.exe',
+        nodeExecPath: 'C:\\Program Files\\nodejs\\node.exe',
+        platform: 'win32'
+      })
+    ).toEqual({
+      command: 'C:\\hostedtoolcache\\pnpm.exe',
+      prefixArgs: [],
+      shell: false
+    })
+  })
+
+  it('shells out for a Windows .cmd wrapper', () => {
+    expect(
+      resolvePnpmCliInvocation({
+        npmExecPath: 'C:\\Users\\runner\\pnpm.cmd',
+        nodeExecPath: 'C:\\Program Files\\nodejs\\node.exe',
+        platform: 'win32'
+      })
+    ).toEqual({
+      command: 'C:\\Users\\runner\\pnpm.cmd',
+      prefixArgs: [],
+      shell: true
+    })
+  })
+
+  it('treats .js and .mjs CLIs the same as .cjs', () => {
+    for (const npmExecPath of ['/opt/pnpm.js', '/opt/pnpm.mjs']) {
+      expect(resolvePnpmCliInvocation({ npmExecPath, nodeExecPath, platform: 'linux' })).toEqual({
+        command: nodeExecPath,
+        prefixArgs: [npmExecPath],
+        shell: false
+      })
+    }
+  })
+
+  it('falls back to PATH pnpm when npm_execpath is unset', () => {
+    expect(
+      resolvePnpmCliInvocation({ npmExecPath: undefined, nodeExecPath, platform: 'darwin' })
+    ).toEqual({ command: 'pnpm', prefixArgs: [], shell: false })
+    expect(resolvePnpmCliInvocation({ npmExecPath: '', nodeExecPath, platform: 'linux' })).toEqual({
+      command: 'pnpm',
+      prefixArgs: [],
+      shell: false
+    })
+    expect(
+      resolvePnpmCliInvocation({ npmExecPath: undefined, nodeExecPath, platform: 'win32' })
+    ).toEqual({ command: 'pnpm.cmd', prefixArgs: [], shell: true })
+  })
+})
+
+describe('pnpm 12 native-cli callers', () => {
+  it('reinvokes pnpm through the helper rather than `node $npm_execpath`', () => {
+    for (const file of [
+      './build-native-for-platform.mjs',
+      './run-ssh-docker-bulk-open-freeze-e2e.mjs'
+    ]) {
+      const source = readFileSync(new URL(file, import.meta.url), 'utf8')
+      expect(source).toContain("from './pnpm-cli-invocation.mjs'")
+      expect(source).not.toMatch(/process\.execPath,\s*\[\s*(?:pnpmEntry|npmExecPath)/)
+    }
+  })
+})

--- a/config/scripts/run-ssh-docker-bulk-open-freeze-e2e.mjs
+++ b/config/scripts/run-ssh-docker-bulk-open-freeze-e2e.mjs
@@ -1,18 +1,17 @@
 import { spawnSync } from 'node:child_process'
+import { resolvePnpmCliInvocation } from './pnpm-cli-invocation.mjs'
 
 const extraArgs = process.argv.slice(2)
-const pnpmEntry = process.env.npm_execpath
-if (!pnpmEntry) {
-  throw new Error('npm_execpath is required; run this harness through pnpm')
-}
+const { command: pnpm, prefixArgs: pnpmPrefix, shell } = resolvePnpmCliInvocation()
 const env = {
   ...process.env,
   ORCA_E2E_SSH_DOCKER: '1'
 }
 
-const runtime = spawnSync(process.execPath, [pnpmEntry, 'run', 'ensure:electron-runtime'], {
+const runtime = spawnSync(pnpm, [...pnpmPrefix, 'run', 'ensure:electron-runtime'], {
   stdio: 'inherit',
-  env
+  env,
+  shell
 })
 
 if (runtime.status !== 0) {
@@ -20,9 +19,9 @@ if (runtime.status !== 0) {
 }
 
 const result = spawnSync(
-  process.execPath,
+  pnpm,
   [
-    pnpmEntry,
+    ...pnpmPrefix,
     'exec',
     'playwright',
     'test',
@@ -36,7 +35,8 @@ const result = spawnSync(
   ],
   {
     stdio: 'inherit',
-    env
+    env,
+    shell
   }
 )
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |

<!-- /orca-pr-loc -->

## ELI5

Hourly and adhoc macOS builds started failing right after the pnpm 12 upgrade because a build script was still asking Node to run pnpm's new native binary as if it were JavaScript.

## What Changed

- Add `resolvePnpmCliInvocation()` so scripts re-invoke the same pnpm that launched them: JS CLIs (`.js`/`.cjs`/`.mjs`) still go through Node, native pnpm 12 binaries are executed directly, and Windows `.cmd` wrappers still use `shell: true`.
- Use it in `build-native-for-platform.mjs` (the `pnpm build:release` → `build:native` path hourly, adhoc, daily, and release-cut all share).
- Use it in the SSH docker bulk-open freeze e2e harness, which had the same `node $npm_execpath` spawn.

## Why

pnpm 12 ships a native Mach-O/PE binary. `build-native-for-platform.mjs` still did `node $npm_execpath run …`. Node then tried to parse `__PAGEZERO` as JS and died with `SyntaxError: Invalid or unexpected token`.

That matches the failing logs (`/Users/runner/setup-pnpm/pnpm:1`) and the timeline: last green hourly was 21:10 UTC, pnpm 12 landed at 21:13, and every hourly/adhoc macOS run since has failed at **Build app**. Daily and release-cut use the same `pnpm build:release` path and would fail next.

PR CI stayed green because it does not run `build:release` on macOS. Scheduled E2E was already red before the upgrade and its `build e2e app` job still succeeds.

## Linked Issue

N/A — teammate report that hourly + adhoc builds are broken after #17156.

## Visual Proof

N/A — CI spawn path only; no UI or interaction changes.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- Confirmed the live failure: hourly `33289815137` and adhoc `33279599783` both die in `build:native` with Node compiling `/Users/runner/setup-pnpm/pnpm`.
- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/pnpm-cli-invocation.test.mjs` — 7 tests (JS CLI, native macOS/Windows, `.cmd` shell, PATH fallback, caller ratchet)
- `pnpm run check:code-quality:changed` — 0 findings
- After merge, this PR dispatches an adhoc of `main` and waits for it to pass

## Review

- Cross-platform: macOS native binary, Windows `.exe`/`.cmd`, Linux PATH fallback.
- SSH/remote: no execution-host or wire changes.
- Security: still reuses the parent pnpm rather than a random PATH binary when `npm_execpath` is set.
- Performance: invocation helper only; no hot-path change.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)