### PR TITLE
fix(windows): stage node-addon-api headers before process-tree rebuild

### DIFF
--- a/config/scripts/build-windows-process-tree-relay-addon.mjs
+++ b/config/scripts/build-windows-process-tree-relay-addon.mjs
@@ -29,11 +29,11 @@ import {
   readSync,
   writeFileSync
 } from 'node:fs'
-import { createRequire } from 'node:module'
-import { dirname, join, resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 import { RELAY_WINDOWS_PROCESS_TREE_FILENAME } from '../../src/shared/relay-artifacts.ts'
 import {
   nodeGypRebuildInvocation,
+  stageWindowsProcessTreeNodeAddonApiHeaders,
   WINDOWS_PROCESS_TREE_PACKAGE_DIR as PACKAGE_DIR
 } from './windows-process-tree-gyp-rebuild.mjs'
 
@@ -96,10 +96,6 @@ function assertPatchApplied() {
 function applyWindowsProcessTreeBuildFixes() {
   const bindingPath = join(PACKAGE_DIR, 'binding.gyp')
   const processPath = join(PACKAGE_DIR, 'src', 'process.cc')
-  const nodeAddonApiDir = dirname(
-    createRequire(join(PACKAGE_DIR, 'package.json')).resolve('node-addon-api/package.json')
-  )
-  const stagedHeaderDir = join(PACKAGE_DIR, 'deps', 'node-addon-api')
   let bindingGyp = readFileSync(bindingPath, 'utf8')
   let processCc = readFileSync(processPath, 'utf8')
   const originalBinding = bindingGyp
@@ -134,10 +130,7 @@ function applyWindowsProcessTreeBuildFixes() {
   if (processCc !== originalProcess) {
     writeFileSync(processPath, processCc)
   }
-  mkdirSync(stagedHeaderDir, { recursive: true })
-  for (const header of ['napi.h', 'napi-inl.h', 'napi-inl.deprecated.h']) {
-    copyFileSync(join(nodeAddonApiDir, header), join(stagedHeaderDir, header))
-  }
+  stageWindowsProcessTreeNodeAddonApiHeaders(PACKAGE_DIR)
   if (bindingGyp !== originalBinding || processCc !== originalProcess) {
     console.warn('[windows-process-tree] Repaired un-applied pnpm patch hunks before build.')
   }

--- a/config/scripts/rebuild-native-deps.mjs
+++ b/config/scripts/rebuild-native-deps.mjs
@@ -20,6 +20,7 @@
 
 import { rebuild } from '@electron/rebuild'
 import { execFileSync, spawnSync } from 'node:child_process'
+import { stageWindowsProcessTreeNodeAddonApiHeaders } from './windows-process-tree-gyp-rebuild.mjs'
 import {
   copyFileSync,
   existsSync,
@@ -130,6 +131,14 @@ if (!ignoreModules.includes('cpu-features')) {
       process.exit(1)
     }
   }
+}
+
+if (
+  rebuildPlatform === 'win32' &&
+  modulesToRebuild.includes('@vscode/windows-process-tree') &&
+  existsSync(join(projectDir, 'node_modules', '@vscode', 'windows-process-tree', 'package.json'))
+) {
+  stageWindowsProcessTreeNodeAddonApiHeaders()
 }
 
 try {

--- a/config/scripts/rebuild-native-deps.test.mjs
+++ b/config/scripts/rebuild-native-deps.test.mjs
@@ -21,6 +21,9 @@ const sourceInstallScriptPath = fileURLToPath(
 const sourceNodePtyJobOwnershipPath = fileURLToPath(
   new URL('./node-pty-job-ownership.cjs', import.meta.url)
 )
+const sourceWindowsProcessTreeGypRebuildPath = fileURLToPath(
+  new URL('./windows-process-tree-gyp-rebuild.mjs', import.meta.url)
+)
 
 describe('rebuild-native-deps Electron install fallback', () => {
   it('continues non-strict postinstall when Electron retry download fails', () => {
@@ -158,6 +161,41 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
       }
     }
   )
+
+  it('stages windows-process-tree node-addon-api headers before a Windows rebuild', () => {
+    const projectDir = mkTempProject()
+
+    try {
+      writeFakeUsableElectronPackage(projectDir, { platform: 'win32' })
+      writeFakeElectronRebuild(projectDir)
+      writeFakeNodePtyConptyPayload(projectDir, 'x64')
+      writeFakeWindowsProcessTreeWithNodeAddonApi(projectDir)
+
+      const result = runRebuildScript(
+        projectDir,
+        { npm_config_platform: 'win32', npm_config_arch: 'x64' },
+        ['--platform=win32', '--arch=x64', '--force']
+      )
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(
+        readFileSync(
+          join(
+            projectDir,
+            'node_modules',
+            '@vscode',
+            'windows-process-tree',
+            'deps',
+            'node-addon-api',
+            'napi.h'
+          ),
+          'utf8'
+        )
+      ).toBe('// napi.h\n')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
 
   it('restores the ConPTY runtime payload after a Windows Electron rebuild', () => {
     const projectDir = mkTempProject()
@@ -343,6 +381,10 @@ function mkTempProject() {
   copyFileSync(
     sourceNodePtyJobOwnershipPath,
     join(projectDir, 'config', 'scripts', 'node-pty-job-ownership.cjs')
+  )
+  copyFileSync(
+    sourceWindowsProcessTreeGypRebuildPath,
+    join(projectDir, 'config', 'scripts', 'windows-process-tree-gyp-rebuild.mjs')
   )
   return projectDir
 }
@@ -576,6 +618,18 @@ function writeFakeWindowsProcessTree(projectDir) {
   const processTreeDir = join(projectDir, 'node_modules', '@vscode', 'windows-process-tree')
   mkdirSync(processTreeDir, { recursive: true })
   writeFileSync(join(processTreeDir, 'index.js'), 'module.exports = {}\n')
+}
+
+function writeFakeWindowsProcessTreeWithNodeAddonApi(projectDir) {
+  const processTreeDir = join(projectDir, 'node_modules', '@vscode', 'windows-process-tree')
+  const nodeAddonApiDir = join(processTreeDir, 'node_modules', 'node-addon-api')
+  mkdirSync(nodeAddonApiDir, { recursive: true })
+  writeFileSync(join(processTreeDir, 'package.json'), '{"dependencies":{"node-addon-api":"*"}}\n')
+  writeFileSync(join(processTreeDir, 'index.js'), 'module.exports = {}\n')
+  writeFileSync(join(nodeAddonApiDir, 'package.json'), '{"name":"node-addon-api"}\n')
+  writeFileSync(join(nodeAddonApiDir, 'napi.h'), '// napi.h\n')
+  writeFileSync(join(nodeAddonApiDir, 'napi-inl.h'), '// napi-inl.h\n')
+  writeFileSync(join(nodeAddonApiDir, 'napi-inl.deprecated.h'), '// napi-inl.deprecated.h\n')
 }
 
 function writeNodePtyPatchFile(projectDir) {

--- a/config/scripts/windows-process-tree-gyp-path.test.mjs
+++ b/config/scripts/windows-process-tree-gyp-path.test.mjs
@@ -20,15 +20,22 @@ describe('windows-process-tree node-addon-api gyp path', () => {
       join(projectDir, 'config/scripts/build-windows-process-tree-relay-addon.mjs'),
       'utf8'
     )
-    expect(buildScript).toContain(
-      "for (const header of ['napi.h', 'napi-inl.h', 'napi-inl.deprecated.h'])"
-    )
-    expect(buildScript).toContain("import { createRequire } from 'node:module'")
-    expect(buildScript).toContain("import { dirname, join, resolve } from 'node:path'")
-    expect(buildScript).toContain(
-      "createRequire(join(PACKAGE_DIR, 'package.json')).resolve('node-addon-api/package.json')"
-    )
+    expect(buildScript).toContain('stageWindowsProcessTreeNodeAddonApiHeaders(PACKAGE_DIR)')
     expect(buildScript).toContain('Repaired un-applied pnpm patch hunks before build.')
+    const rebuildHelper = readFileSync(
+      join(projectDir, 'config/scripts/windows-process-tree-gyp-rebuild.mjs'),
+      'utf8'
+    )
+    expect(rebuildHelper).toContain("createRequire(join(packageDir, 'package.json'))")
+    expect(rebuildHelper).toContain("resolve('node-addon-api/package.json')")
+    expect(rebuildHelper).toContain("'napi.h'")
+    expect(rebuildHelper).toContain("'napi-inl.h'")
+    expect(rebuildHelper).toContain("'napi-inl.deprecated.h'")
+    const rebuildScript = readFileSync(
+      join(projectDir, 'config/scripts/rebuild-native-deps.mjs'),
+      'utf8'
+    )
+    expect(rebuildScript).toContain('stageWindowsProcessTreeNodeAddonApiHeaders()')
   })
 
   it('resolves node_addon_api.gyp to a real file from the package directory', () => {

--- a/config/scripts/windows-process-tree-gyp-rebuild.mjs
+++ b/config/scripts/windows-process-tree-gyp-rebuild.mjs
@@ -9,8 +9,9 @@
  * hop escapes the store and configure fails with "node_addon_api.gyp not
  * found" (run 32999886072).
  */
-import { realpathSync } from 'node:fs'
-import { join, resolve } from 'node:path'
+import { copyFileSync, mkdirSync, realpathSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, resolve } from 'node:path'
 
 const ROOT = resolve(import.meta.dirname, '..', '..')
 
@@ -21,6 +22,12 @@ export const WINDOWS_PROCESS_TREE_PACKAGE_DIR = join(
   'windows-process-tree'
 )
 
+export const WINDOWS_PROCESS_TREE_NODE_ADDON_API_HEADERS = [
+  'napi.h',
+  'napi-inl.h',
+  'napi-inl.deprecated.h'
+]
+
 export function nodeGypRebuildInvocation(arch, packageDir = WINDOWS_PROCESS_TREE_PACKAGE_DIR) {
   return {
     args: [
@@ -30,4 +37,19 @@ export function nodeGypRebuildInvocation(arch, packageDir = WINDOWS_PROCESS_TREE
     ],
     cwd: realpathSync(packageDir)
   }
+}
+
+// Patched binding.gyp includes deps/node-addon-api; the tarball does not ship those headers.
+export function stageWindowsProcessTreeNodeAddonApiHeaders(
+  packageDir = WINDOWS_PROCESS_TREE_PACKAGE_DIR
+) {
+  const nodeAddonApiDir = dirname(
+    createRequire(join(packageDir, 'package.json')).resolve('node-addon-api/package.json')
+  )
+  const stagedHeaderDir = join(packageDir, 'deps', 'node-addon-api')
+  mkdirSync(stagedHeaderDir, { recursive: true })
+  for (const header of WINDOWS_PROCESS_TREE_NODE_ADDON_API_HEADERS) {
+    copyFileSync(join(nodeAddonApiDir, header), join(stagedHeaderDir, header))
+  }
+  return stagedHeaderDir
 }

--- a/config/scripts/windows-process-tree-gyp-rebuild.test.mjs
+++ b/config/scripts/windows-process-tree-gyp-rebuild.test.mjs
@@ -1,9 +1,20 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, realpathSync } from 'node:fs'
-import { resolve } from 'node:path'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   nodeGypRebuildInvocation,
+  stageWindowsProcessTreeNodeAddonApiHeaders,
+  WINDOWS_PROCESS_TREE_NODE_ADDON_API_HEADERS,
   WINDOWS_PROCESS_TREE_PACKAGE_DIR
 } from './windows-process-tree-gyp-rebuild.mjs'
 
@@ -25,5 +36,26 @@ describe('windows-process-tree node-gyp rebuild', () => {
     const { args } = nodeGypRebuildInvocation('arm64')
     expect(args).toContain('rebuild')
     expect(args).toContain('--arch=arm64')
+  })
+
+  it('copies node-addon-api headers into the patched include dir', () => {
+    const packageDir = mkdtempSync(join(tmpdir(), 'orca-windows-process-tree-headers-'))
+    try {
+      const nodeAddonApiDir = join(packageDir, 'node_modules', 'node-addon-api')
+      mkdirSync(nodeAddonApiDir, { recursive: true })
+      writeFileSync(join(packageDir, 'package.json'), '{"dependencies":{"node-addon-api":"*"}}\n')
+      writeFileSync(join(nodeAddonApiDir, 'package.json'), '{"name":"node-addon-api"}\n')
+      for (const header of WINDOWS_PROCESS_TREE_NODE_ADDON_API_HEADERS) {
+        writeFileSync(join(nodeAddonApiDir, header), `// ${header}\n`)
+      }
+
+      const stagedDir = stageWindowsProcessTreeNodeAddonApiHeaders(packageDir)
+      expect(stagedDir).toBe(join(packageDir, 'deps', 'node-addon-api'))
+      for (const header of WINDOWS_PROCESS_TREE_NODE_ADDON_API_HEADERS) {
+        expect(readFileSync(join(stagedDir, header), 'utf8')).toBe(`// ${header}\n`)
+      }
+    } finally {
+      rmSync(packageDir, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |

<!-- /orca-pr-loc -->

## ELI5

Windows hourly/adhoc installs were dying because a native module was compiled before its C++ headers were copied into place.

## What Changed

- Stage `node-addon-api` headers into `@vscode/windows-process-tree`'s patched `deps/node-addon-api` include dir from `rebuild-native-deps.mjs` (postinstall / Electron rebuild), not only from the later relay-addon script.
- Share that copy with `build-windows-process-tree-relay-addon.mjs`.

## Why

The patched `binding.gyp` includes `deps/node-addon-api` instead of a pnpm-sensitive gyp `require()`. Those headers are not in the tarball. The relay-addon script copies them, but `pnpm install` on Windows runs `rebuild-native-deps.mjs` first. After the pnpm 12 upgrade, patched node-pty artifacts are missing on a frozen Windows install, so postinstall electron-rebuilds `windows-process-tree` and MSVC fails with `C1083: Cannot open include file: 'napi.h'`.

That is what failed the Windows leg of adhoc [33291346261](https://github.com/stablyai/orca/actions/runs/33291346261) after #17331 unblocked macOS.

PR Windows packaging stayed green because it installs with `--ignore-scripts` and does not run this postinstall path.

## Linked Issue

N/A — follow-up to #17331 / pnpm 12 (#17156).

## Visual Proof

N/A — native rebuild / CI install path only.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/windows-process-tree-gyp-rebuild.test.mjs config/scripts/windows-process-tree-gyp-path.test.mjs config/scripts/rebuild-native-deps.test.mjs` — 14 passed, 3 skipped
- `pnpm run check:code-quality:changed` — 0 findings
- After merge, Windows adhoc will be rebuilt into already-published `v1.4.193-adhoc.20260830035642`

## Review

- Windows-only compile path; macOS/Linux skip `windows-process-tree` in this rebuild list.
- SSH/remote: this is the addon the Windows relay uses instead of the PowerShell scan.
- No UI change.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)