### PR TITLE
test(vitest): adapt happy-dom OffscreenCanvas canvas mocks

### DIFF
--- a/config/scripts/happy-dom-offscreen-canvas.test.ts
+++ b/config/scripts/happy-dom-offscreen-canvas.test.ts
@@ -1,0 +1,67 @@
+/** @vitest-environment happy-dom */
+import { Terminal } from '@xterm/xterm'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { installHappyDomOffscreenCanvasCompatibility } from './happy-dom-offscreen-canvas'
+
+type TestOffscreenCanvas = new (
+  width: number,
+  height: number
+) => {
+  getContext: (contextType: string, contextAttributes?: unknown) => unknown
+}
+
+const openTerminals: Terminal[] = []
+
+describe('happy-dom OffscreenCanvas compatibility', () => {
+  afterEach(() => {
+    while (openTerminals.length > 0) {
+      openTerminals.pop()?.dispose()
+    }
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('delegates adapter-less 2D contexts to the existing HTML canvas double', () => {
+    const offscreenCanvas = (globalThis as { OffscreenCanvas?: TestOffscreenCanvas })
+      .OffscreenCanvas
+    if (!offscreenCanvas) {
+      expect(installHappyDomOffscreenCanvasCompatibility()).toBe(false)
+      return
+    }
+
+    const context = { measureText: () => ({ width: 10 }) }
+    const getContext = vi
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockReturnValue(context as unknown as CanvasRenderingContext2D)
+
+    expect(installHappyDomOffscreenCanvasCompatibility()).toBe(true)
+    expect(new offscreenCanvas(1, 1).getContext('2d')).toBe(context)
+    expect(getContext).toHaveBeenCalled()
+  })
+
+  it('does not turn unsupported non-2D contexts into test doubles', () => {
+    const offscreenCanvas = (globalThis as { OffscreenCanvas?: TestOffscreenCanvas })
+      .OffscreenCanvas
+    if (!offscreenCanvas) {
+      return
+    }
+
+    const getContext = vi.spyOn(HTMLCanvasElement.prototype, 'getContext')
+    expect(new offscreenCanvas(1, 1).getContext('webgl')).toBeNull()
+    expect(getContext).not.toHaveBeenCalled()
+  })
+
+  it('keeps xterm DOM rendering open with the existing HTML canvas double', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+    const host = document.createElement('div')
+    document.body.append(host)
+    const terminal = new Terminal()
+    openTerminals.push(terminal)
+
+    terminal.open(host)
+
+    expect(terminal.element).not.toBeNull()
+  })
+})

--- a/config/scripts/happy-dom-offscreen-canvas.ts
+++ b/config/scripts/happy-dom-offscreen-canvas.ts
@@ -1,0 +1,59 @@
+// Why: happy-dom exposes OffscreenCanvas without a default canvas adapter. xterm prefers that API
+// and then cannot open in tests that already provide the HTML canvas text-metric stand-in.
+
+const OFFSCREEN_CANVAS_COMPATIBILITY_INSTALLED = Symbol.for(
+  'orca.happyDomOffscreenCanvasCompatibility'
+)
+
+type PatchableCanvas = {
+  getContext?: (contextType: string, contextAttributes?: unknown) => unknown
+} & Record<symbol, unknown>
+
+type CanvasConstructor = {
+  prototype: PatchableCanvas
+  new (width: number, height: number): PatchableCanvas
+}
+
+type HappyDomGlobals = {
+  OffscreenCanvas?: CanvasConstructor
+  HTMLCanvasElement?: { prototype: PatchableCanvas }
+  document?: Pick<Document, 'createElement'>
+}
+
+/** Make happy-dom's adapter-less OffscreenCanvas honor the existing HTML canvas test double. */
+export function installHappyDomOffscreenCanvasCompatibility(): boolean {
+  const globals = globalThis as unknown as HappyDomGlobals
+  const offscreenCanvas = globals.OffscreenCanvas
+  const htmlCanvas = globals.HTMLCanvasElement
+  const document = globals.document
+  if (!offscreenCanvas || !htmlCanvas || !document) {
+    return false
+  }
+
+  const prototype = offscreenCanvas.prototype
+  if (prototype[OFFSCREEN_CANVAS_COMPATIBILITY_INSTALLED] === true) {
+    return true
+  }
+  const originalGetContext = prototype.getContext
+  if (!originalGetContext || !htmlCanvas.prototype.getContext) {
+    return false
+  }
+
+  prototype.getContext = function patchedGetContext(
+    this: PatchableCanvas,
+    contextType: string,
+    contextAttributes?: unknown
+  ): unknown {
+    const context = originalGetContext.call(this, contextType, contextAttributes)
+    if (contextType !== '2d' || context) {
+      return context
+    }
+
+    const canvas = document.createElement('canvas') as PatchableCanvas
+    return htmlCanvas.prototype.getContext!.call(canvas, contextType, contextAttributes)
+  }
+  prototype[OFFSCREEN_CANVAS_COMPATIBILITY_INSTALLED] = true
+  return true
+}
+
+installHappyDomOffscreenCanvasCompatibility()

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     execArgv: ['--no-experimental-webstorage', '--expose-gc'],
     // Why: happy-dom drops MutationObserver callbacks on GC; keep them alive like a browser does.
     setupFiles: [
+      resolve('config/scripts/happy-dom-offscreen-canvas.ts'),
       resolve('config/scripts/happy-dom-mutation-observer-retention.ts'),
       resolve('config/scripts/vitest-host-ports-setup.ts')
     ],


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 |

<!-- /orca-pr-loc -->

## Root cause

`happy-dom@20.11.8` now exposes `OffscreenCanvas`, but without a configured canvas adapter its `getContext("2d")` returns `null`. xterm intentionally prefers that API and throws while creating its `WidthCache`, so otherwise-unrelated unit shards fail before reaching their assertions. The same failure reproduces on the dependency upgrade PR #17330.

## Fix

Install one idempotent Vitest compatibility setup: when an OffscreenCanvas 2D context is adapter-less, delegate to the existing `HTMLCanvasElement.prototype.getContext` test double. Real adapters and non-2D contexts are returned unchanged. Production/browser code is untouched.

## Regression proof

- Added compatibility tests for adapter-less 2D delegation and non-2D isolation.
- Added an xterm `Terminal.open()` regression proving the current happy-dom setup can construct the DOM renderer.
- Verified on happy-dom 20.9.0 and an isolated origin/main environment with happy-dom 20.11.8 + Vitest 4.1.11.

## Local verification

- Vitest compatibility + xterm regression: 3/3 passed on 20.11.8 (and 20.9.0).
- Existing xterm placeholder-mask focused suite: 13/13 passed.
- `oxlint --deny-warnings`, `oxfmt --check`, and `git diff --check`: passed.

## Readiness / elegance

- Test-only, no IPC/RPC, wire, SSH, mobile, persistence, packaging, or production rendering changes.
- The shim addresses the dependency contract mismatch at the Vitest environment boundary; it does not suppress xterm errors or alter xterm production code.
- It preserves available canvas implementations, is bounded and idempotent, and reuses the existing HTML canvas doubles.
- Native/Electron verification is not applicable to this test-environment-only change.

Closes the post-#17330 test baseline regression affecting #17169, #17170, and #17172.