### PR TITLE
fix(scripts): stop pnpm-cli-invocation test leaking npm_execpath into the fallback case

### DIFF
--- a/config/scripts/pnpm-cli-invocation.test.mjs
+++ b/config/scripts/pnpm-cli-invocation.test.mjs
@@ -1,10 +1,15 @@
 import { readFileSync } from 'node:fs'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { resolvePnpmCliInvocation } from './pnpm-cli-invocation.mjs'
 
 const nodeExecPath = '/usr/local/bin/node'
 
 describe('resolvePnpmCliInvocation', () => {
+  // Why: config/vitest.config.ts does not set unstubEnvs, so stubs would leak into later cases.
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   it('runs a JS CLI through node so older pnpm.cjs still works', () => {
     expect(
       resolvePnpmCliInvocation({
@@ -71,18 +76,53 @@ describe('resolvePnpmCliInvocation', () => {
     }
   })
 
-  it('falls back to PATH pnpm when npm_execpath is unset', () => {
-    expect(
-      resolvePnpmCliInvocation({ npmExecPath: undefined, nodeExecPath, platform: 'darwin' })
-    ).toEqual({ command: 'pnpm', prefixArgs: [], shell: false })
+  // Why: `npmExecPath: undefined` would hit the destructuring default and read the ambient
+  // npm_execpath, so an explicit empty string is the only env-independent way to force this branch.
+  it('falls back to PATH pnpm when npm_execpath is empty', () => {
+    expect(resolvePnpmCliInvocation({ npmExecPath: '', nodeExecPath, platform: 'darwin' })).toEqual(
+      { command: 'pnpm', prefixArgs: [], shell: false }
+    )
     expect(resolvePnpmCliInvocation({ npmExecPath: '', nodeExecPath, platform: 'linux' })).toEqual({
       command: 'pnpm',
       prefixArgs: [],
       shell: false
     })
-    expect(
-      resolvePnpmCliInvocation({ npmExecPath: undefined, nodeExecPath, platform: 'win32' })
-    ).toEqual({ command: 'pnpm.cmd', prefixArgs: [], shell: true })
+    expect(resolvePnpmCliInvocation({ npmExecPath: '', nodeExecPath, platform: 'win32' })).toEqual({
+      command: 'pnpm.cmd',
+      prefixArgs: [],
+      shell: true
+    })
+  })
+
+  // Both callers invoke the helper with no options, so the env default is the only path they take.
+  it('reads npm_execpath from the environment when the option is omitted', () => {
+    vi.stubEnv('npm_execpath', '/opt/pnpm/bin/pnpm.cjs')
+    expect(resolvePnpmCliInvocation({ nodeExecPath, platform: 'darwin' })).toEqual({
+      command: nodeExecPath,
+      prefixArgs: ['/opt/pnpm/bin/pnpm.cjs'],
+      shell: false
+    })
+
+    vi.stubEnv('npm_execpath', '/opt/pnpm/bin/pnpm')
+    expect(resolvePnpmCliInvocation({ nodeExecPath, platform: 'darwin' })).toEqual({
+      command: '/opt/pnpm/bin/pnpm',
+      prefixArgs: [],
+      shell: false
+    })
+  })
+
+  it('falls back to PATH pnpm when npm_execpath is absent from the environment', () => {
+    vi.stubEnv('npm_execpath', undefined)
+    expect(resolvePnpmCliInvocation({ nodeExecPath, platform: 'darwin' })).toEqual({
+      command: 'pnpm',
+      prefixArgs: [],
+      shell: false
+    })
+    expect(resolvePnpmCliInvocation({ nodeExecPath, platform: 'win32' })).toEqual({
+      command: 'pnpm.cmd',
+      prefixArgs: [],
+      shell: true
+    })
   })
 })
 

--- a/config/scripts/pnpm-cli-invocation.test.mjs
+++ b/config/scripts/pnpm-cli-invocation.test.mjs
@@ -52,18 +52,30 @@ describe('resolvePnpmCliInvocation', () => {
     })
   })
 
-  it('shells out for a Windows .cmd wrapper', () => {
-    expect(
-      resolvePnpmCliInvocation({
-        npmExecPath: 'C:\\Users\\runner\\pnpm.cmd',
-        nodeExecPath: 'C:\\Program Files\\nodejs\\node.exe',
-        platform: 'win32'
-      })
-    ).toEqual({
-      command: 'C:\\Users\\runner\\pnpm.cmd',
-      prefixArgs: [],
-      shell: true
-    })
+  it('shells out for every Windows batch wrapper extension and casing', () => {
+    for (const npmExecPath of [
+      'C:\\Users\\runner\\pnpm.cmd',
+      'C:\\Users\\runner\\pnpm.bat',
+      'C:\\tools\\PNPM.CMD',
+      'C:\\tools\\PNPM.BAT'
+    ]) {
+      expect(
+        resolvePnpmCliInvocation({
+          npmExecPath,
+          nodeExecPath: 'C:\\Program Files\\nodejs\\node.exe',
+          platform: 'win32'
+        })
+      ).toEqual({ command: npmExecPath, prefixArgs: [], shell: true })
+    }
+  })
+
+  // Why: only cmd.exe needs the shell hop; a .cmd-named path elsewhere must still exec directly.
+  it('does not shell out for a .cmd path on a non-Windows platform', () => {
+    for (const platform of ['darwin', 'linux']) {
+      expect(
+        resolvePnpmCliInvocation({ npmExecPath: '/opt/pnpm.cmd', nodeExecPath, platform })
+      ).toEqual({ command: '/opt/pnpm.cmd', prefixArgs: [], shell: false })
+    }
   })
 
   it('treats .js and .mjs CLIs the same as .cjs', () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Problem

`config/scripts/pnpm-cli-invocation.test.mjs` asserted the "npm_execpath is unset" fallback by passing `npmExecPath: undefined`. `resolvePnpmCliInvocation` (`config/scripts/pnpm-cli-invocation.mjs:5-9`) declares that option with a destructuring default (`npmExecPath = process.env.npm_execpath`), and a destructuring default fires on an explicit `undefined` — so the test never reached the fallback branch and instead read the ambient `npm_execpath`. Under `pnpm test` (a `pnpm run` script, which exports `npm_execpath`) the assertion received the pnpm 12 native binary path instead of `'pnpm'`. This is not pnpm-12-specific: any launcher exporting `npm_execpath` breaks it (under npm it comes back as node + `npm-cli.js`). CI is currently green only because `.github/workflows/unit-tests.yml` runs the suite via `pnpm exec vitest`, and pnpm's `exec` does not export `npm_execpath` — so this is a local-dev red test today and a landmine if the CI step ever moves to `pnpm run test`.

## Fix

Test-only; `pnpm-cli-invocation.mjs` is correct and unchanged (both production callers — `build-native-for-platform.mjs` and `run-ssh-docker-bulk-open-freeze-e2e.mjs` — call it with no options and depend on the env default).

- Force the fallback branch with an explicit `''`, the only env-independent value that gets past the destructuring default. This covers all three platform cases, including the win32 `undefined` site that had the identical defect and was only masked because the darwin assertion threw first.
- Add coverage for the env default itself, which previously had none despite being the only path both real callers exercise: `vi.stubEnv('npm_execpath', ...)` for the JS-CLI and native-binary forms, plus a stubbed-absent case asserting the PATH `pnpm` / `pnpm.cmd` fallback.
- `afterEach(() => vi.unstubAllEnvs())`, since `config/vitest.config.ts` does not enable `unstubEnvs` and stubs would otherwise leak into the caller-ratchet describe below.

## Verification

Before the change, with the file reverted, under `pnpm test`:

```
 FAIL  config/scripts/pnpm-cli-invocation.test.mjs > resolvePnpmCliInvocation > falls back to PATH pnpm when npm_execpath is unset
AssertionError: expected { …(3) } to deeply equal { command: 'pnpm', …(2) }
-   "command": "pnpm",
+   "command": "/Users/nwparker/pnpm/.tools/pnpm/12.0.0/bin/pnpm",
 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```

After, in all three invocation shapes:

- `pnpm test config/scripts/pnpm-cli-invocation.test.mjs` (npm_execpath set to the pnpm 12 native binary) -> `Test Files 1 passed (1) / Tests 9 passed (9)`
- `./node_modules/.bin/vitest run --config config/vitest.config.ts config/scripts/pnpm-cli-invocation.test.mjs` (npm_execpath absent) -> `Tests 9 passed (9)`
- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/pnpm-cli-invocation.test.mjs` (the CI shape) -> `Tests 9 passed (9)`

`oxlint config/scripts/pnpm-cli-invocation.test.mjs` -> clean (exit 0); `oxfmt` applied. `pnpm tc` skipped: the change is a single `.mjs` test file with no TypeScript touched.

Fixes STA-5982
https://linear.app/stably/issue/STA-5982/continuous-scan-pnpm-cli-invocationtestmjs-fails-under-pnpm-test-due