### PR TITLE
fix(linux): preserve AppImage CLI arguments without user namespaces

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -683,6 +683,9 @@ jobs:
       - name: Verify headless serve signal shutdown
         run: node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage
 
+      - name: Verify AppImage CLI sandbox boundary
+        run: node config/scripts/run-appimage-cli-sandbox-docker.mjs --appimage dist/orca-linux.AppImage
+
       - name: Smoke packaged CLI
         run: node config/scripts/smoke-packaged-cli.mjs --app-dir=dist/linux-unpacked
 

--- a/config/docker/appimage-cli-sandbox/Dockerfile
+++ b/config/docker/appimage-cli-sandbox/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    libasound2t64 \
+    libatk-bridge2.0-0 \
+    libatspi2.0-0 \
+    libcups2t64 \
+    libdrm2 \
+    libgbm1 \
+    libgtk-3-0t64 \
+    libnss3 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    p7zip-full \
+    util-linux \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash orca
+
+COPY run-contract.sh /usr/local/bin/run-contract
+RUN chmod 755 /usr/local/bin/run-contract
+
+ENTRYPOINT ["/usr/local/bin/run-contract"]

--- a/config/docker/appimage-cli-sandbox/run-contract.sh
+++ b/config/docker/appimage-cli-sandbox/run-contract.sh
@@ -75,13 +75,21 @@ chmod 755 "$gui_root/AppRun" "$gui_root/unshare" "$gui_root/orca-ide"
 
 for mode in unset empty; do
   if [[ "$mode" == unset ]]; then
-    gui_capture=$(runuser -u orca -- env -u ELECTRON_RUN_AS_NODE APPDIR="$gui_root" \
+    if ! gui_capture=$(runuser -u orca -- env -u ELECTRON_RUN_AS_NODE APPDIR="$gui_root" \
       "$gui_root/AppRun" alpha '' 'two words' 'dollar$sign' 'snowman-☃' --flag=value omega | \
-      base64 -w0)
+      base64 -w0); then
+      printf 'FAIL gui-capture mode=%s actual=command-failed\n' "$mode" >&2
+      failures=$((failures + 1))
+      continue
+    fi
   else
-    gui_capture=$(runuser -u orca -- env ELECTRON_RUN_AS_NODE= APPDIR="$gui_root" \
+    if ! gui_capture=$(runuser -u orca -- env ELECTRON_RUN_AS_NODE= APPDIR="$gui_root" \
       "$gui_root/AppRun" alpha '' 'two words' 'dollar$sign' 'snowman-☃' --flag=value omega | \
-      base64 -w0)
+      base64 -w0); then
+      printf 'FAIL gui-capture mode=%s actual=command-failed\n' "$mode" >&2
+      failures=$((failures + 1))
+      continue
+    fi
   fi
   gui_expected=$(printf '%s\0' --no-sandbox alpha '' 'two words' 'dollar$sign' 'snowman-☃' \
     --flag=value omega | base64 -w0)
@@ -94,7 +102,10 @@ for mode in unset empty; do
   fi
 done
 
-probe_count=$(wc -l </tmp/orca-appimage-unshare.log)
+probe_count=0
+if [[ -f /tmp/orca-appimage-unshare.log ]]; then
+  probe_count=$(wc -l </tmp/orca-appimage-unshare.log)
+fi
 if [[ "$probe_count" -ne 2 ]]; then
   printf 'FAIL unshare-probe expected=2 actual=%s\n' "$probe_count" >&2
   failures=$((failures + 1))

--- a/config/docker/appimage-cli-sandbox/run-contract.sh
+++ b/config/docker/appimage-cli-sandbox/run-contract.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Dollar signs are intentionally literal argv fixtures.
+# shellcheck disable=SC2016
+set -euo pipefail
+
+app_root=/artifacts/root
+app_run="$app_root/AppRun"
+expected_args='["alpha","","two words","dollar$sign","snowman-☃","--flag=value","omega"]'
+expected_sandbox_arg='["alpha","--no-sandbox","omega"]'
+cli_bootstrap='(async()=>{const path=require("path");const cli=path.join(process.env.APPDIR,"resources","app.asar.unpacked","out","cli","index.js");await Promise.resolve(require(cli).main(process.argv.slice(1)))})().catch(error=>{console.error(error&&error.stack?error.stack:String(error));process.exit(1)})'
+
+install -d -o orca -g orca /tmp/orca-appimage-gui
+cat >"$app_root/unshare" <<'EOF'
+#!/usr/bin/env bash
+printf 'unshare-called\n' >>/tmp/orca-appimage-unshare.log
+exit 1
+EOF
+chmod 755 "$app_root/unshare"
+rm -f /tmp/orca-appimage-unshare.log
+
+failures=0
+for value in 0 1 1-ish; do
+  capture=$(runuser -u orca -- env ELECTRON_RUN_AS_NODE="$value" APPDIR="$app_root" \
+    "$app_run" -e 'process.stdout.write(JSON.stringify(process.argv.slice(1)))' -- \
+    alpha '' 'two words' 'dollar$sign' 'snowman-☃' --flag=value omega 2>&1) || {
+    printf 'FAIL node-capture value=%s output=%s\n' "$value" "$capture" >&2
+    failures=$((failures + 1))
+    continue
+  }
+  if [[ "$capture" != "$expected_args" ]]; then
+    printf 'FAIL node-capture value=%s expected=%s actual=%s\n' \
+      "$value" "$expected_args" "$capture" >&2
+    failures=$((failures + 1))
+  else
+    printf 'PASS node-capture value=%s argv=%s\n' "$value" "$capture"
+  fi
+
+  sandbox_arg_capture=$(runuser -u orca -- env ELECTRON_RUN_AS_NODE="$value" APPDIR="$app_root" \
+    "$app_run" -e 'process.stdout.write(JSON.stringify(process.argv.slice(1)))' -- \
+    alpha --no-sandbox omega 2>&1) || {
+    printf 'FAIL node-user-sandbox-arg value=%s output=%s\n' "$value" "$sandbox_arg_capture" >&2
+    failures=$((failures + 1))
+    continue
+  }
+  if [[ "$sandbox_arg_capture" != "$expected_sandbox_arg" ]]; then
+    printf 'FAIL node-user-sandbox-arg value=%s expected=%s actual=%s\n' \
+      "$value" "$expected_sandbox_arg" "$sandbox_arg_capture" >&2
+    failures=$((failures + 1))
+  else
+    printf 'PASS node-user-sandbox-arg value=%s argv=%s\n' "$value" "$sandbox_arg_capture"
+  fi
+
+  cli_output=$(runuser -u orca -- env ELECTRON_RUN_AS_NODE="$value" APPDIR="$app_root" \
+    "$app_run" -e "$cli_bootstrap" -- --help 2>&1) || {
+    printf 'FAIL cli-parser value=%s output=%s\n' "$value" "$cli_output" >&2
+    failures=$((failures + 1))
+    continue
+  }
+  if [[ "$cli_output" != *'Usage: orca <command> [options]'* ]]; then
+    printf 'FAIL cli-parser value=%s output=%s\n' "$value" "$cli_output" >&2
+    failures=$((failures + 1))
+  else
+    printf 'PASS cli-parser value=%s\n' "$value"
+  fi
+done
+
+gui_root=/tmp/orca-appimage-gui
+cp "$app_run" "$gui_root/AppRun"
+cp "$app_root/unshare" "$gui_root/unshare"
+cat >"$gui_root/orca-ide" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\0' "$@"
+EOF
+chmod 755 "$gui_root/AppRun" "$gui_root/unshare" "$gui_root/orca-ide"
+
+for mode in unset empty; do
+  if [[ "$mode" == unset ]]; then
+    gui_capture=$(runuser -u orca -- env -u ELECTRON_RUN_AS_NODE APPDIR="$gui_root" \
+      "$gui_root/AppRun" alpha '' 'two words' 'dollar$sign' 'snowman-☃' --flag=value omega | \
+      base64 -w0)
+  else
+    gui_capture=$(runuser -u orca -- env ELECTRON_RUN_AS_NODE= APPDIR="$gui_root" \
+      "$gui_root/AppRun" alpha '' 'two words' 'dollar$sign' 'snowman-☃' --flag=value omega | \
+      base64 -w0)
+  fi
+  gui_expected=$(printf '%s\0' --no-sandbox alpha '' 'two words' 'dollar$sign' 'snowman-☃' \
+    --flag=value omega | base64 -w0)
+  if [[ "$gui_capture" != "$gui_expected" ]]; then
+    printf 'FAIL gui-capture mode=%s expected-base64=%s actual-base64=%s\n' \
+      "$mode" "$gui_expected" "$gui_capture" >&2
+    failures=$((failures + 1))
+  else
+    printf 'PASS gui-capture mode=%s argv-base64=%s\n' "$mode" "$gui_capture"
+  fi
+done
+
+probe_count=$(wc -l </tmp/orca-appimage-unshare.log)
+if [[ "$probe_count" -ne 2 ]]; then
+  printf 'FAIL unshare-probe expected=2 actual=%s\n' "$probe_count" >&2
+  failures=$((failures + 1))
+else
+  printf 'PASS unshare-probe count=%s\n' "$probe_count"
+fi
+
+if [[ "$failures" -ne 0 ]]; then
+  printf 'AppImage CLI sandbox contract failed: %s signal(s)\n' "$failures" >&2
+  exit 1
+fi
+
+printf 'AppImage CLI sandbox contract passed.\n'

--- a/config/patches/app-builder-lib@26.15.3.patch
+++ b/config/patches/app-builder-lib@26.15.3.patch
@@ -1,0 +1,13 @@
+diff --git a/out/targets/appimage/appImageUtil.js b/out/targets/appimage/appImageUtil.js
+index b685375f1194e3a71da14b3105e7ed11e4d57f45..8dbecb809c1bd720e1e90ced55097462909d6b6c 100644
+--- a/out/targets/appimage/appImageUtil.js
++++ b/out/targets/appimage/appImageUtil.js
+@@ -219,7 +219,7 @@ NO_SANDBOX=()
+ #   - On minimal systems (e.g. Alpine or stripped-down containers) 'unshare' may not exist.
+ #     In that case the shell will return exit code 127 ("command not found"), which will cause
+ #     us to add '--no-sandbox'. This is an intentional fail-safe: we prefer the app to start
+ #     without sandboxing rather than crash on startup.
+-if [ $HAVE_NO_SANDBOX -eq 0 ] && ! unshare -Ur true 2>/dev/null ; then
++if [ -z "\${ELECTRON_RUN_AS_NODE-}" ] && [ $HAVE_NO_SANDBOX -eq 0 ] && ! unshare -Ur true 2>/dev/null ; then
+   NO_SANDBOX=(--no-sandbox)
+ fi

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -8194,9 +8194,7 @@
       "assertionRefs": [
         {
           "file": "tests/e2e/persisted-session-production-upgrade.spec.ts",
-          "assertions": [
-            "upgrades a legacy daemon session and keeps it stable after relaunch"
-          ]
+          "assertions": ["upgrades a legacy daemon session and keeps it stable after relaunch"]
         }
       ],
       "evidenceRuns": [
@@ -16515,6 +16513,105 @@
         "The harness exercises foreground headless Linux shutdown and does not replace desktop, updater, SSH, or detached PTY lifecycle coverage."
       ],
       "demotionRule": "Keep experimental or demote if either signal traps, returns nonzero, retains its listener/Xvfb/run-owned process identity, touches the unrelated canary, or the focused gate flakes without an identified product or harness defect."
+    },
+    {
+      "id": "runtime.appimage-cli-sandbox-argument-boundary",
+      "title": "AppImage sandbox fallback preserves Electron Node CLI arguments",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "runtime-platform",
+      "layer": "linux-appimage-launcher",
+      "surfaces": [
+        "packaged Linux AppImage GUI startup",
+        "registered AppImage orca-ide CLI",
+        "direct ELECTRON_RUN_AS_NODE AppImage execution"
+      ],
+      "platforms": ["linux"],
+      "providers": ["local-daemon"],
+      "coveredPlatforms": ["linux"],
+      "coveredProviders": ["local-daemon"],
+      "coverageNotes": "An Ubuntu 24.04 amd64 container extracts a real x64 AppImage, forces the generated AppRun unshare probe to fail, and executes its packaged Electron and Orca CLI as an unprivileged user. The PR package lane repeats the same contract against the newly generated x64 AppImage; arm64 packaging and direct outer-AppImage runtime execution remain uncollected.",
+      "motivatingLinks": [
+        "https://linear.app/stably/issue/STA-5597",
+        "https://github.com/stablyai/orca/issues/16650"
+      ],
+      "invariant": "When unshare -Ur fails, generated AppRun prepends exactly one --no-sandbox only for Electron GUI semantics (ELECTRON_RUN_AS_NODE unset or empty). Every non-empty Node-mode value skips the probe and fallback, preserves byte-exact user argv, and reaches Orca CLI parsing.",
+      "oracle": "Extract the packaged AppImage into a disposable Docker volume, shadow unshare with a deterministic failing executable, then use the actual packaged Electron to capture Node argv for ELECTRON_RUN_AS_NODE values 0, 1, and 1-ish, including empty, spaced, dollar, UTF-8, option-shaped, and explicit user --no-sandbox arguments. Independently require the actual packaged Orca CLI main function to render help. Trace NUL-delimited GUI argv for unset and empty values, require --no-sandbox first, and require exactly two unshare probes. Expected-red mode additionally requires all three exact Node bad-option rejections while both GUI cases remain green.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts config/scripts/appimage-cli-sandbox-contract.test.mjs --reporter=dot",
+        "shellcheck config/docker/appimage-cli-sandbox/run-contract.sh",
+        "node config/scripts/run-appimage-cli-sandbox-docker.mjs --appimage dist/orca-linux.AppImage --platform linux/amd64"
+      ],
+      "testFiles": [
+        "config/scripts/appimage-cli-sandbox-contract.test.mjs",
+        "config/scripts/run-appimage-cli-sandbox-docker.mjs",
+        "config/docker/appimage-cli-sandbox/run-contract.sh"
+      ],
+      "assertionRefs": [
+        {
+          "file": "config/scripts/appimage-cli-sandbox-contract.test.mjs",
+          "assertions": [
+            "the generated AppRun gates fallback on unset or empty ELECTRON_RUN_AS_NODE",
+            "the exact-version app-builder-lib patch remains pinned in the manifest and lockfile",
+            "PR CI builds an x64 AppImage before invoking the packaged contract"
+          ]
+        },
+        {
+          "file": "config/scripts/run-appimage-cli-sandbox-docker.mjs",
+          "assertions": [
+            "the exact AppImage SHA-256, AppRun override, and Docker platform are published",
+            "expected-red runs require the original Node bad-option signal for every non-empty value",
+            "expected-red runs still require both GUI fallback cases to pass"
+          ]
+        },
+        {
+          "file": "config/docker/appimage-cli-sandbox/run-contract.sh",
+          "assertions": [
+            "actual packaged Electron preserves byte-exact Node argv and explicit user --no-sandbox",
+            "actual packaged Orca main reaches argument parsing for every non-empty value",
+            "GUI unset and empty prepend fallback and are the only modes that probe unshare"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-29",
+          "runner": "local",
+          "platform": "linux",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts config/scripts/appimage-cli-sandbox-contract.test.mjs --reporter=dot",
+          "result": "passed",
+          "durationSeconds": 1,
+          "summary": "The generated-script, dependency-patch, lockfile, and PR workflow assertions passed. The separately recorded four-way Docker oracle used the actual v1.4.188 packaged Electron and CLI with generated AppRun variants."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 120,
+        "scope": "one pinned Ubuntu 24.04 image build, AppImage extraction, nine packaged Node/CLI executions, and two GUI argv traces"
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "The deterministic failing executable and exact argv comparisons are new; native CI history has not started."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "The identical oracle against v1.4.188 AppImage 2e70cb5e199 with packaged AppRun f48e4f9b653, latest-main generated AppRun f48e4f9b653, and candidate with the guard reverted all reject Node values 0, 1, and 1-ish before JavaScript with bad option: --no-sandbox while GUI fallback passes. Candidate generated AppRun d0bb9032926 preserves all Node argv, reaches Orca parsing, keeps GUI fallback first, and reduces probes from five to exactly two."
+      },
+      "performanceBudget": {
+        "required": false,
+        "evidence": "Node-mode AppRun replaces a failing external unshare probe with one shell environment check; GUI startup retains the existing probe. The product change adds no process, polling, IPC, listener, filesystem scan, renderer work, wire field, or retained state."
+      },
+      "promotionCriteria": [
+        "Collect 100 consecutive native amd64 CI passes or 14 days of soak history.",
+        "Collect one direct outer-AppImage run on a native Linux host without user namespaces.",
+        "Collect the same packaged contract for the arm64 AppImage release artifact.",
+        "Keep exact Node argv, real CLI parser, GUI fallback order, and probe-count assertions green."
+      ],
+      "knownGaps": [
+        "Local Docker on arm64 macOS uses amd64 emulation and cannot execute the outer AppImage runtime, so the harness extracts it with 7z before running the actual AppRun and packaged Electron.",
+        "The PR package lane builds x64 only; the architecture-neutral generated script has not yet been exercised from a packaged arm64 AppImage.",
+        "The pnpm patch is version-specific and must be refreshed or retired when app-builder-lib changes."
+      ],
+      "demotionRule": "Demote if any non-empty Node value triggers the namespace probe or receives an injected fallback flag, GUI fallback stops reaching Electron, byte-exact argv or CLI parsing regresses, or the packaged gate flakes without an identified product or harness defect."
     },
     {
       "id": "ssh-managed-hooks.node18-runtime-compatibility",

--- a/config/scripts/appimage-cli-sandbox-contract.test.mjs
+++ b/config/scripts/appimage-cli-sandbox-contract.test.mjs
@@ -1,0 +1,48 @@
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+
+import { parse, parseAllDocuments } from 'yaml'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const { generateAppRunScript } = require('app-builder-lib/out/targets/appimage/appImageUtil')
+const lockfile = parseAllDocuments(readFileSync('pnpm-lock.yaml', 'utf8'))
+  .map((document) => document.toJS())
+  .find((document) => document.patchedDependencies)
+const workspace = parse(readFileSync('pnpm-workspace.yaml', 'utf8'))
+const workflow = parse(readFileSync('.github/workflows/pr.yml', 'utf8'))
+
+const appRun = generateAppRunScript({
+  DesktopFileName: 'orca-ide.desktop',
+  ExecutableName: 'orca-ide',
+  ProductName: 'Orca',
+  ProductFilename: 'Orca',
+  ResourceName: 'appimagekit-orca-ide'
+})
+
+describe('AppImage CLI sandbox boundary', () => {
+  it('limits generated sandbox fallback to Electron GUI mode', () => {
+    expect(appRun).toContain(
+      'if [ -z "${ELECTRON_RUN_AS_NODE-}" ] && [ $HAVE_NO_SANDBOX -eq 0 ] && ! unshare -Ur true 2>/dev/null ; then'
+    )
+    expect(appRun).toContain('exec "$BIN" "${NO_SANDBOX[@]}" "${args[@]}"')
+  })
+
+  it('pins the AppRun generator patch in the manifest and lockfile', () => {
+    const patchPath = 'config/patches/app-builder-lib@26.15.3.patch'
+    expect(workspace.patchedDependencies['app-builder-lib@26.15.3']).toBe(patchPath)
+    expect(lockfile.patchedDependencies['app-builder-lib@26.15.3']).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('runs the packaged oracle after building the x64 AppImage', () => {
+    const steps = workflow.jobs.package.steps
+    const packageStep = steps.find((step) => step.name === 'Package unpacked app')
+    const oracleStep = steps.find((step) => step.name === 'Verify AppImage CLI sandbox boundary')
+
+    expect(packageStep.run).toContain('--linux AppImage --x64 --publish never')
+    expect(oracleStep.run).toBe(
+      'node config/scripts/run-appimage-cli-sandbox-docker.mjs --appimage dist/orca-linux.AppImage'
+    )
+    expect(steps.indexOf(oracleStep)).toBeGreaterThan(steps.indexOf(packageStep))
+  })
+})

--- a/config/scripts/pr-code-change-scope.mjs
+++ b/config/scripts/pr-code-change-scope.mjs
@@ -180,6 +180,9 @@ const SHARED_PACKAGE_PREFIXES = [
 
 const LINUX_PACKAGE_PREFIXES = [
   ...SHARED_PACKAGE_PREFIXES,
+  'config/docker/appimage-cli-sandbox/',
+  'config/patches/app-builder-lib@',
+  'config/scripts/run-appimage-cli-sandbox',
   'native/computer-use-linux/',
   'resources/linux/',
   'config/scripts/run-headless-serve'

--- a/config/scripts/pr-code-change-scope.test.mjs
+++ b/config/scripts/pr-code-change-scope.test.mjs
@@ -181,6 +181,17 @@ describe('per-job path classification', () => {
     expectClassification(['native/computer-use-macos/Package.swift'], {})
   })
 
+  it('runs Linux packaging when AppImage CLI sandbox inputs change', () => {
+    for (const file of [
+      'config/docker/appimage-cli-sandbox/Dockerfile',
+      'config/docker/appimage-cli-sandbox/run-contract.sh',
+      'config/patches/app-builder-lib@26.15.3.patch',
+      'config/scripts/run-appimage-cli-sandbox-docker.mjs'
+    ]) {
+      expectClassification([file], { package: true })
+    }
+  })
+
   it('runs shell contracts when live-shell inputs change', () => {
     expectClassification(['src/main/daemon/shell-ready.ts'], {
       shell_contracts: true,

--- a/config/scripts/run-appimage-cli-sandbox-docker.mjs
+++ b/config/scripts/run-appimage-cli-sandbox-docker.mjs
@@ -100,8 +100,10 @@ function valueAfter(flag) {
 
 function assertExpectedNodeSandboxFailure(output) {
   for (const value of ['0', '1', '1-ish']) {
-    const signal = `FAIL node-capture value=${value} output=/artifacts/root/orca-ide: bad option: --no-sandbox`
-    if (!output.includes(signal)) {
+    const failureLine = output
+      .split(/\r?\n/)
+      .find((line) => line.includes(`FAIL node-capture value=${value}`))
+    if (!failureLine || !failureLine.includes('bad option: --no-sandbox')) {
       fail(`Expected Node sandbox rejection was absent for ELECTRON_RUN_AS_NODE=${value}`)
     }
   }
@@ -110,6 +112,7 @@ function assertExpectedNodeSandboxFailure(output) {
       fail(`GUI fallback did not pass for ELECTRON_RUN_AS_NODE ${mode}`)
     }
   }
+  // Three failed Node launches plus two GUI launches should produce five probes.
   if (!output.includes('FAIL unshare-probe expected=2 actual=5')) {
     fail('Expected five affected AppRun sandbox probes were not observed')
   }

--- a/config/scripts/run-appimage-cli-sandbox-docker.mjs
+++ b/config/scripts/run-appimage-cli-sandbox-docker.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const args = process.argv.slice(2)
+const appImageArg = valueAfter('--appimage')
+const appRunArg = valueAfter('--app-run')
+const platform = valueAfter('--platform') ?? 'linux/amd64'
+const expectFailure = args.includes('--expect-failure')
+if (!appImageArg) {
+  fail(
+    'Usage: run-appimage-cli-sandbox-docker.mjs --appimage <path> [--app-run <path>] [--platform <linux platform>] [--expect-failure]'
+  )
+}
+
+const appImage = resolve(appImageArg)
+const appRun = appRunArg ? resolve(appRunArg) : null
+if (!existsSync(appImage)) {
+  fail(`AppImage not found: ${appImage}`)
+}
+if (appRun && !existsSync(appRun)) {
+  fail(`AppRun not found: ${appRun}`)
+}
+
+const suffix = `${process.pid}-${Date.now()}`
+const image = `orca-appimage-cli-sandbox:${suffix}`
+const volume = `orca-appimage-cli-sandbox-${suffix}`
+const dockerDirectory = resolve('config', 'docker', 'appimage-cli-sandbox')
+const sha256 = createHash('sha256').update(readFileSync(appImage)).digest('hex')
+
+try {
+  docker(['build', '--platform', platform, '-t', image, dockerDirectory])
+  docker(['volume', 'create', volume])
+  const extractArgs = [
+    'run',
+    '--rm',
+    '--platform',
+    platform,
+    '--entrypoint',
+    'bash',
+    '-v',
+    `${appImage}:/input/orca.AppImage:ro`,
+    '-v',
+    `${volume}:/artifacts`,
+    image,
+    '-lc',
+    '7z x /input/orca.AppImage -o/artifacts/root -y >/dev/null && chmod -R a+rX /artifacts/root'
+  ]
+  docker(extractArgs)
+  if (appRun) {
+    docker([
+      'run',
+      '--rm',
+      '--platform',
+      platform,
+      '--entrypoint',
+      'bash',
+      '-v',
+      `${appRun}:/input/AppRun:ro`,
+      '-v',
+      `${volume}:/artifacts`,
+      image,
+      '-lc',
+      'cp /input/AppRun /artifacts/root/AppRun && chmod 755 /artifacts/root/AppRun'
+    ])
+  }
+
+  console.log(
+    JSON.stringify({ type: 'appimage_cli_sandbox_input', appImage, sha256, appRun, platform })
+  )
+  const result = docker(
+    ['run', '--rm', '--platform', platform, '-v', `${volume}:/artifacts`, image],
+    { allowFailure: true }
+  )
+  process.stdout.write(result.stdout)
+  process.stderr.write(result.stderr)
+  const failed = result.status !== 0
+  if (expectFailure && failed) {
+    assertExpectedNodeSandboxFailure(`${result.stdout}\n${result.stderr}`)
+  }
+  if (failed !== expectFailure) {
+    fail(
+      expectFailure
+        ? 'AppImage CLI sandbox oracle unexpectedly passed'
+        : `AppImage CLI sandbox oracle failed with status ${result.status}`
+    )
+  }
+  console.log(expectFailure ? 'Observed expected contract failure.' : 'Contract validation passed.')
+} finally {
+  docker(['volume', 'rm', volume], { allowFailure: true })
+  docker(['image', 'rm', image], { allowFailure: true })
+}
+
+function valueAfter(flag) {
+  const index = args.indexOf(flag)
+  return index === -1 ? null : (args[index + 1] ?? null)
+}
+
+function assertExpectedNodeSandboxFailure(output) {
+  for (const value of ['0', '1', '1-ish']) {
+    const signal = `FAIL node-capture value=${value} output=/artifacts/root/orca-ide: bad option: --no-sandbox`
+    if (!output.includes(signal)) {
+      fail(`Expected Node sandbox rejection was absent for ELECTRON_RUN_AS_NODE=${value}`)
+    }
+  }
+  for (const mode of ['unset', 'empty']) {
+    if (!output.includes(`PASS gui-capture mode=${mode}`)) {
+      fail(`GUI fallback did not pass for ELECTRON_RUN_AS_NODE ${mode}`)
+    }
+  }
+  if (!output.includes('FAIL unshare-probe expected=2 actual=5')) {
+    fail('Expected five affected AppRun sandbox probes were not observed')
+  }
+}
+
+function docker(dockerArgs, options = {}) {
+  const result = spawnSync('docker', dockerArgs, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    maxBuffer: 20 * 1024 * 1024
+  })
+  if (result.error) {
+    throw result.error
+  }
+  if (result.status !== 0 && !options.allowFailure) {
+    process.stdout.write(result.stdout)
+    process.stderr.write(result.stderr)
+    fail(`docker ${dockerArgs[0]} failed with status ${result.status}`)
+  }
+  return result
+}
+
+function fail(message) {
+  console.error(message)
+  process.exitCode = 1
+  throw new Error(message)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,7 @@ patchedDependencies:
   '@xterm/addon-serialize@0.15.0-beta.300': 851eac3d75e6d8c013b9f4c053e61d824b23965cb19ecc28e335e05059f3a294
   '@xterm/addon-webgl@0.20.0-beta.299': 94687e89a0115e6e6aa102837f986debdc029c091527ee5eb4a4e17ceaf9473e
   '@xterm/xterm@6.1.0-beta.303': 98756bcedc402bcdb7c6ab7b015d2e59cd18e97b03a2c06a27e95bb3ba429d9d
+  app-builder-lib@26.15.3: 7525db76e37e44b9d125de3b721ae21b0daaac4f043f9f6e7b46a8084c27a376
   lint-staged@16.4.0: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
   node-pty@1.1.0: 572a46f539dd9da26e259702da974e1e693329e299625c97eb7c28e4e642500e
 
@@ -9818,7 +9819,7 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0):
+  app-builder-lib@26.15.3(patch_hash=7525db76e37e44b9d125de3b721ae21b0daaac4f043f9f6e7b46a8084c27a376)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0):
     dependencies:
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
@@ -10477,7 +10478,7 @@ snapshots:
 
   dmg-builder@26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
+      app-builder-lib: 26.15.3(patch_hash=7525db76e37e44b9d125de3b721ae21b0daaac4f043f9f6e7b46a8084c27a376)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
       builder-util: 26.15.3(supports-color@7.2.0)
       fs-extra: 10.1.0
       js-yaml: 4.3.1
@@ -10526,7 +10527,7 @@ snapshots:
 
   electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
+      app-builder-lib: 26.15.3(patch_hash=7525db76e37e44b9d125de3b721ae21b0daaac4f043f9f6e7b46a8084c27a376)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
       builder-util: 26.15.3(supports-color@7.2.0)
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
@@ -10535,7 +10536,7 @@ snapshots:
 
   electron-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
+      app-builder-lib: 26.15.3(patch_hash=7525db76e37e44b9d125de3b721ae21b0daaac4f043f9f6e7b46a8084c27a376)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
       builder-util: 26.15.3(supports-color@7.2.0)
       builder-util-runtime: 9.7.0(supports-color@7.2.0)
       chalk: 4.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,6 +41,7 @@ overrides:
   monaco-editor>dompurify: 3.4.13
 
 patchedDependencies:
+  app-builder-lib@26.15.3: config/patches/app-builder-lib@26.15.3.patch
   node-pty@1.1.0: config/patches/node-pty@1.1.0.patch
   '@xterm/addon-ligatures@0.11.0-beta.300': config/patches/@xterm__addon-ligatures@0.11.0-beta.300.patch
   '@xterm/addon-webgl@0.20.0-beta.299': config/patches/@xterm__addon-webgl@0.20.0-beta.299.patch


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​419 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​412 |

<!-- /orca-pr-loc -->

## ELI5

On Linux hosts where user namespaces are unavailable, AppImage startup adds Chromium's `--no-sandbox` fallback. Orca's CLI runs Electron as Node, where that Chromium flag is fatal, so every `orca-ide` command failed before Orca could parse it. This keeps the fallback for the desktop GUI but never injects it into Node-mode CLI arguments.

## What Changed

- Patch app-builder-lib's generated AppRun at the owning boundary: probe/inject `--no-sandbox` only when `ELECTRON_RUN_AS_NODE` is unset or empty.
- Add a pinned Ubuntu 24.04 Docker contract using an actual packaged AppImage's AppRun, Electron binary, and Orca CLI with deterministic `unshare -Ur` failure.
- Verify byte-exact Node argv for `ELECTRON_RUN_AS_NODE=0`, `1`, and `1-ish`; actual Orca help parsing; GUI fallback ordering for unset/empty values; and exact namespace-probe counts.
- Run the packaged oracle in Linux package CI, route future oracle/patch changes into that job, and register the invariant and promotion gaps in the reliability inventory.

## Why

app-builder-lib computes the fallback and prepends it before Electron receives argv, so this is the narrowest correct boundary. Orca-side filtering is too late, extraction/caching is much broader, downgrading loses the required GUI fallback, and vendoring a complete AppRun would take ownership of unrelated upstream launcher behavior.

The exact-version pnpm patch is the local shipping mechanism. The same one-line guard should be upstreamed to electron-builder, then removed here once a released app-builder-lib includes it.

## Linked Issue

- Linear: https://linear.app/stably/issue/STA-5597

Fixes #16650

## Visual Proof

N/A — Linux AppImage packaging/argv boundary only; no rendered UI changes.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Four-way identical Docker oracle with forced `unshare` failure:

| Variant | Node modes (`0`, `1`, `1-ish`) | GUI unset/empty |
| --- | --- | --- |
| v1.4.188 baseline | exact `bad option: --no-sandbox` failure | fallback passes |
| latest-main generated AppRun | same exact failure | fallback passes |
| candidate | byte-exact argv and Orca parser pass | fallback passes |
| candidate with guard reverted | original exact failure restored | fallback passes |

Post-rebase candidate AppRun SHA-256: `d0bb9032926e325bd8c07ed84ef23da9e195666686b67ee217363caa14ca1409`.

Passed:

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm tc`
- packaged Docker oracle against the post-rebase generated AppRun
- 31 focused contract/routing/workflow tests
- changed-code quality, reliability inventory, max-lines, Electron-runtime ratchet
- ShellCheck, Node syntax, formatting, and `git diff --check`

## Review

- Independent architecture, product/security, and regression reviews completed clean.
- A separate implementation-choice challenge compared supported builder hooks, custom/vendored AppRun, CLI filtering, extraction/cache, downgrade, and postinstall rewrite approaches. It found this exact-version one-line generator patch to be the best narrow shipping implementation; upstream electron-builder remains the permanent owner.
- macOS, Windows, deb/rpm unpacked runtime, SSH, folder-workspace, paired-runtime, and wire behavior do not execute the changed AppImage branch.
- Packaged arm64 and direct outer-AppImage native-host runs are recorded promotion gaps; the generated shell condition itself is architecture-neutral.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no agent skill-installer material.

## Notes

- GUI sandbox fallback behavior is unchanged.
- Node mode skips an irrelevant failing namespace probe and preserves user argv.
- The app-builder-lib patch must be refreshed, removed, or replaced by the upstream fix during a dependency upgrade.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (focused local gates and packaged oracle pass; full CI covers the rebased tree)
