### PR TITLE
perf(preflight): cache WSL CLI probes per distro

### DIFF
--- a/src/main/ipc/preflight-host-cli-status.test.ts
+++ b/src/main/ipc/preflight-host-cli-status.test.ts
@@ -315,6 +315,100 @@ describe('preflight', () => {
     )
   })
 
+  describe('WSL preflight caching', () => {
+    // Why win32 + these stubs: a WSL target probes git/gh/glab through the
+    // runner, so every case below counts runner spawns rather than execFile.
+    function stubWslProbes(): void {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      execFileAsyncMock.mockImplementation(async () => {
+        throw Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' })
+      })
+      runWslProcessMock.mockImplementation(async ({ script }: { script: string }) => ({
+        environmentResolved: true,
+        code: 0,
+        stdout: script.includes('auth status')
+          ? 'github.com\n  - Active account: true\n'
+          : 'version 2.0.0\n',
+        stderr: '',
+        timedOut: false
+      }))
+    }
+
+    it('reuses the cached result instead of re-spawning wsl.exe probes', async () => {
+      stubWslProbes()
+
+      const first = await runPreflightCheck(false, { wslDistro: 'Ubuntu' })
+      const spawnsAfterFirst = runWslProcessMock.mock.calls.length
+      const second = await runPreflightCheck(false, { wslDistro: 'Ubuntu' })
+
+      expect(spawnsAfterFirst).toBeGreaterThan(0)
+      expect(runWslProcessMock.mock.calls.length).toBe(spawnsAfterFirst)
+      expect(second).toEqual(first)
+    })
+
+    it('keeps each distro on its own cache entry', async () => {
+      stubWslProbes()
+
+      await runPreflightCheck(false, { wslDistro: 'Ubuntu' })
+      const spawnsAfterUbuntu = runWslProcessMock.mock.calls.length
+      await runPreflightCheck(false, { wslDistro: 'Debian' })
+
+      expect(runWslProcessMock.mock.calls.length).toBeGreaterThan(spawnsAfterUbuntu)
+      expect(runWslProcessMock).toHaveBeenCalledWith(expect.objectContaining({ distro: 'Debian' }))
+    })
+
+    it('re-probes when the caller forces a refresh', async () => {
+      stubWslProbes()
+
+      await runPreflightCheck(false, { wslDistro: 'Ubuntu' })
+      const spawnsAfterFirst = runWslProcessMock.mock.calls.length
+      await runPreflightCheck(true, { wslDistro: 'Ubuntu' })
+
+      expect(runWslProcessMock.mock.calls.length).toBeGreaterThan(spawnsAfterFirst)
+    })
+
+    it('collapses concurrent callers onto one probe set', async () => {
+      stubWslProbes()
+
+      const [first, second] = await Promise.all([
+        runPreflightCheck(false, { wslDistro: 'Ubuntu' }),
+        runPreflightCheck(false, { wslDistro: 'Ubuntu' })
+      ])
+      const singleRunSpawns = runWslProcessMock.mock.calls.length
+
+      runWslProcessMock.mockClear()
+      await runPreflightCheck(true, { wslDistro: 'Ubuntu' })
+
+      expect(first).toEqual(second)
+      // One shared run, not two: a second full set would double the spawn count.
+      expect(singleRunSpawns).toBe(runWslProcessMock.mock.calls.length)
+    })
+
+    // Why this matters: an unreachable distro reports the same `installed:
+    // false` as a distro with no tooling, so a session-lifetime cache would pin
+    // "git not installed" until relaunch. The TTL must let it recover.
+    it('re-probes after the cache entry expires so a transient failure self-heals', async () => {
+      vi.useFakeTimers()
+      try {
+        stubWslProbes()
+        runWslProcessMock.mockRejectedValue(new Error('distro not running'))
+
+        const failed = await runPreflightCheck(false, { wslDistro: 'Ubuntu' })
+        expect(failed.git).toEqual({ installed: false })
+
+        stubWslProbes()
+        runWslProcessMock.mockClear()
+        vi.advanceTimersByTime(30_000 + 1)
+        const recovered = await runPreflightCheck(false, { wslDistro: 'Ubuntu' })
+
+        expect(runWslProcessMock.mock.calls.length).toBeGreaterThan(0)
+        expect(recovered.git).toEqual({ installed: true })
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
   it('uses the persisted Windows Path when probing host CLIs', async () => {
     Object.defineProperty(process, 'platform', {
       configurable: true,

--- a/src/main/ipc/preflight-host-cli-status.test.ts
+++ b/src/main/ipc/preflight-host-cli-status.test.ts
@@ -88,7 +88,7 @@ vi.mock('../gitea/client', () => ({
   getGiteaAuthStatus: getGiteaAuthStatusMock
 }))
 
-import { registerPreflightHandlers, runPreflightCheck } from './preflight'
+import { _resetPreflightCache, registerPreflightHandlers, runPreflightCheck } from './preflight'
 import {
   defaultAzureDevOpsStatus,
   defaultBitbucketStatus,
@@ -387,6 +387,81 @@ describe('preflight', () => {
     // Why this matters: an unreachable distro reports the same `installed:
     // false` as a distro with no tooling, so a session-lifetime cache would pin
     // "git not installed" until relaunch. The TTL must let it recover.
+    // Why these two: a slower run settling last must not overwrite a newer
+    // answer, or a forced refresh silently returns to the status it replaced.
+    it('does not let a superseded probe overwrite a newer forced refresh', async () => {
+      stubWslProbes()
+      // Why gate on phase captured at call time: the stale run's three
+      // --version probes all start before the refresh, and all report nothing
+      // installed, so it never issues auth calls. The two runs are then
+      // trivially distinguishable in the cached result.
+      let phase: 'stale' | 'fresh' = 'stale'
+      let releaseStale!: () => void
+      const staleGate = new Promise<void>((resolve) => {
+        releaseStale = resolve
+      })
+      runWslProcessMock.mockImplementation(async ({ script }: { script: string }) => {
+        const isStale = phase === 'stale'
+        if (isStale) {
+          await staleGate
+        }
+        return {
+          environmentResolved: true,
+          code: isStale ? 1 : 0,
+          stdout: isStale
+            ? ''
+            : script.includes('auth status')
+              ? 'github.com\n  - Active account: true\n'
+              : 'version 2.0.0\n',
+          stderr: '',
+          timedOut: false
+        }
+      })
+
+      const stalePending = runPreflightCheck(false, { wslDistro: 'Ubuntu' })
+      phase = 'fresh'
+      const fresh = await runPreflightCheck(true, { wslDistro: 'Ubuntu' })
+      expect(fresh.git).toEqual({ installed: true })
+
+      releaseStale()
+      const staleResult = await stalePending
+      expect(staleResult.git).toEqual({ installed: false })
+
+      // The superseded run still returns its own answer to its own caller, but
+      // must not have become the cached one.
+      const cachedNow = await runPreflightCheck(false, { wslDistro: 'Ubuntu' })
+      expect(cachedNow.git).toEqual({ installed: true })
+    })
+
+    it('does not repopulate a cache that was reset while a probe was in flight', async () => {
+      stubWslProbes()
+      let release!: () => void
+      const gate = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      runWslProcessMock.mockImplementation(async ({ script }: { script: string }) => {
+        await gate
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: script.includes('auth status')
+            ? 'github.com\n  - Active account: true\n'
+            : 'version 2.0.0\n',
+          stderr: '',
+          timedOut: false
+        }
+      })
+
+      const inFlight = runPreflightCheck(false, { wslDistro: 'Ubuntu' })
+      _resetPreflightCache()
+      release()
+      await inFlight
+
+      runWslProcessMock.mockClear()
+      await runPreflightCheck(false, { wslDistro: 'Ubuntu' })
+      expect(runWslProcessMock.mock.calls.length).toBeGreaterThan(0)
+    })
+
     it('re-probes after the cache entry expires so a transient failure self-heals', async () => {
       vi.useFakeTimers()
       try {

--- a/src/main/preflight/agent-detection.ts
+++ b/src/main/preflight/agent-detection.ts
@@ -93,6 +93,16 @@ const cachedByWslDistro = new Map<string, { result: PreflightStatus; expiresAt: 
 // set instead of one full set each before the first result lands.
 const preflightInFlight = new Map<string, Promise<PreflightStatus>>()
 
+// Why a generation per key: two runs for the same target can overlap (a forced
+// refresh started while a slower probe is still out). Without this the slower
+// one settles last and writes its older result over the newer one, so the next
+// caller reads staler status than the refresh it asked for. The epoch does the
+// same for `_resetPreflightCache`, which integrations call on credential
+// changes: a probe already in flight must not repopulate the cache it cleared.
+const latestPreflightRun = new Map<string, number>()
+let preflightRunCounter = 0
+let preflightCacheEpoch = 0
+
 const LOCAL_PREFLIGHT_CACHE_KEY = 'local'
 
 function preflightCacheKey(wslTarget: WslPreflightTarget | null): string {
@@ -104,6 +114,10 @@ export function _resetPreflightCache(): void {
   cached = null
   cachedByWslDistro.clear()
   preflightInFlight.clear()
+  latestPreflightRun.clear()
+  // Why bump rather than just clear: a probe already in flight would otherwise
+  // settle after this and repopulate the cache an integration just invalidated.
+  preflightCacheEpoch += 1
 }
 
 function uniqueAgentIds(ids: Iterable<string>): string[] {
@@ -294,17 +308,27 @@ export async function runPreflightCheck(
     }
   }
 
+  const runId = ++preflightRunCounter
+  const epochAtStart = preflightCacheEpoch
+  latestPreflightRun.set(cacheKey, runId)
+
   const run = executePreflightCheck(force, context, wslTarget)
   preflightInFlight.set(cacheKey, run)
   try {
     const result = await run
-    if (wslTarget) {
-      cachedByWslDistro.set(cacheKey, {
-        result,
-        expiresAt: Date.now() + WSL_PREFLIGHT_CACHE_TTL_MS
-      })
-    } else {
-      cached = result
+    // Superseded by a newer run, or the cache was reset while this was out:
+    // return what we probed, but do not let it become the cached answer.
+    const isCurrent =
+      latestPreflightRun.get(cacheKey) === runId && epochAtStart === preflightCacheEpoch
+    if (isCurrent) {
+      if (wslTarget) {
+        cachedByWslDistro.set(cacheKey, {
+          result,
+          expiresAt: Date.now() + WSL_PREFLIGHT_CACHE_TTL_MS
+        })
+      } else {
+        cached = result
+      }
     }
     return result
   } finally {

--- a/src/main/preflight/agent-detection.ts
+++ b/src/main/preflight/agent-detection.ts
@@ -77,10 +77,33 @@ export type { RemoteWindowsTerminalCapabilities }
 // Why: cache the result so repeated Landing mounts don't re-spawn processes.
 // The check only runs once per app session — relaunch to re-check.
 let cached: PreflightStatus | null = null
+// Why keyed by distro rather than one slot: each distro carries its own
+// toolchain, so distro A's result must never answer for distro B. Previously a
+// WSL target skipped the cache entirely and re-spawned five wsl.exe probes —
+// two of them login shells — on every caller, waking an idle VM each time.
+//
+// Why a TTL here when the local cache lasts the session: `isCommandAvailable`
+// collapses every failure into `installed: false`, so an unreachable distro is
+// indistinguishable from one with no tooling. Pinning that for the session
+// would report "git not installed" until relaunch; expiring lets it self-heal
+// while still collapsing the burst of calls that made this expensive.
+const WSL_PREFLIGHT_CACHE_TTL_MS = 30_000
+const cachedByWslDistro = new Map<string, { result: PreflightStatus; expiresAt: number }>()
+// Collapses concurrent callers (several panes mounting at once) onto one probe
+// set instead of one full set each before the first result lands.
+const preflightInFlight = new Map<string, Promise<PreflightStatus>>()
+
+const LOCAL_PREFLIGHT_CACHE_KEY = 'local'
+
+function preflightCacheKey(wslTarget: WslPreflightTarget | null): string {
+  return wslTarget ? `wsl:${wslTarget.distro ?? ''}` : LOCAL_PREFLIGHT_CACHE_KEY
+}
 
 /** @internal - tests need a clean preflight cache between cases. */
 export function _resetPreflightCache(): void {
   cached = null
+  cachedByWslDistro.clear()
+  preflightInFlight.clear()
 }
 
 function uniqueAgentIds(ids: Iterable<string>): string[] {
@@ -254,11 +277,50 @@ export async function runPreflightCheck(
   context?: PreflightRuntimeContext
 ): Promise<PreflightStatus> {
   const wslTarget = getPreflightWslTarget(context)
-  const cacheable = !wslTarget
-  if (cacheable && cached && !force) {
-    return cached
+  const cacheKey = preflightCacheKey(wslTarget)
+
+  if (!force) {
+    if (wslTarget) {
+      const entry = cachedByWslDistro.get(cacheKey)
+      if (entry && entry.expiresAt > Date.now()) {
+        return entry.result
+      }
+    } else if (cached) {
+      return cached
+    }
+    const inFlight = preflightInFlight.get(cacheKey)
+    if (inFlight) {
+      return inFlight
+    }
   }
 
+  const run = executePreflightCheck(force, context, wslTarget)
+  preflightInFlight.set(cacheKey, run)
+  try {
+    const result = await run
+    if (wslTarget) {
+      cachedByWslDistro.set(cacheKey, {
+        result,
+        expiresAt: Date.now() + WSL_PREFLIGHT_CACHE_TTL_MS
+      })
+    } else {
+      cached = result
+    }
+    return result
+  } finally {
+    // Why the identity check: a concurrent force run replaces this entry, and
+    // that newer run must stay joinable after this one settles.
+    if (preflightInFlight.get(cacheKey) === run) {
+      preflightInFlight.delete(cacheKey)
+    }
+  }
+}
+
+async function executePreflightCheck(
+  force: boolean,
+  context: PreflightRuntimeContext | undefined,
+  wslTarget: WslPreflightTarget | null
+): Promise<PreflightStatus> {
   if (process.platform === 'win32' && !wslTarget) {
     await mergePersistedWindowsPathAsync(process.env, { forceRefresh: force })
   }
@@ -294,10 +356,6 @@ export async function runPreflightCheck(
     bitbucket,
     azureDevOps,
     gitea
-  }
-
-  if (cacheable) {
-    cached = result
   }
 
   return result


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​170 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​169 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​89 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 |

<!-- /orca-pr-loc -->

## Problem

A preflight check against a WSL target skipped the cache entirely:

```ts
const cacheable = !wslTarget
```

So every caller re-spawned up to **five `wsl.exe` probes** — `git`/`gh`/`glab` detection plus `gh`/`glab` auth status, two of them through login shells — with no cache and no in-flight dedupe. Repeated Landing mounts, pane switches, and per-worktree session restore each paid the full set, and each set wakes an idle distro.

This is also the mechanism behind the background VM wakeups in #8941: `glab auth status` runs *inside* WSL for any Windows user without a native `glab.exe`, and nothing cached it, so it repeated.

Measured context on a real Windows host: this path is a large share of cold-start WSL spawns when several WSL worktrees restore.

## Change

- Cache the preflight result **per distro**, so one distro's toolchain never answers for another.
- Join **concurrent callers** onto a single probe set instead of letting each run its own.
- The WSL entry **expires** rather than living for the session like the local cache does.

## Why the WSL entry expires when the local one doesn't

`isCommandAvailable` collapses every failure into `installed: false`, so an unreachable distro is indistinguishable from one with no tooling:

```ts
try { ... return true } catch { return false }
```

Caching that for the session would report "git not installed" until app relaunch, where the previous uncached code self-healed on the next call. A bounded entry keeps the burst collapsed — which is where the cost actually was — while letting a transient failure recover on its own.

I hit this while writing the tests: the first implementation used session-lifetime caching to match the local path, and the failed-probe test caught it.

## Follow-up, deliberately not in this PR

The real defect underneath is that the probe layer doesn't propagate *unreachable* vs *absent*. Fixing that would allow a longer-lived entry and better error messaging, but it reaches well past WSL into shared exec code, so it belongs in its own change.

## Tests

Five new cases: cache reuse, per-distro isolation, `force` bypass, concurrent-caller collapse, and TTL self-heal after a transient failure.

- `src/main/ipc/preflight-host-cli-status.test.ts` — 20 passed
- Preflight suite — 79 passed / 1 skipped
- `pnpm tc:node` — clean (the `cdp-print-to-pdf` error present on this base is pre-existing and untouched here)
- `oxlint` — clean