### PR TITLE
test(wsl): guard probes that report failure as a negative answer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ docs/**
 !docs/reference/windows-setup-shell.md
 !docs/reference/worktree-scan-fingerprint.md
 !docs/reference/wsl-command-execution.md
+!docs/reference/wsl-probe-failure-semantics.md
 !docs/reference/xterm-patch-regeneration.md
 
 # Stably CLI (only docs/ are tracked)

--- a/docs/reference/wsl-probe-failure-semantics.md
+++ b/docs/reference/wsl-probe-failure-semantics.md
@@ -1,0 +1,86 @@
+# WSL probe failure semantics
+
+A WSL probe answers a question about a distro: is `git` installed, what is
+`$HOME`, which distros are running. Every one of those probes can fail for a
+reason that has nothing to do with the answer — the distro is booting, `wsl.exe`
+is slow under load, the VM was just shut down.
+
+The recurring bug in this subsystem is reporting that failure as a negative
+answer.
+
+## The shape
+
+```ts
+try {
+  await execCommandInWsl(target, `${shellQuote(command)} --version`)
+  return true
+} catch {
+  return false // "not installed" and "could not ask" are now the same value
+}
+```
+
+Nothing downstream can tell those two apart, because by this point they aren't
+two things.
+
+## Why it keeps shipping
+
+Swallowing on its own is survivable. An uncached caller asks again a moment
+later and the answer corrects itself, so the bug stays invisible in review and
+in manual testing.
+
+It becomes user-visible when the swallowed value is **cached** or used to
+**gate discovery**. Then a distro that was busy for one second reports no git,
+or no agent sessions, until the app is relaunched. The failure is sticky,
+silent, and indistinguishable from the real thing.
+
+Three instances so far:
+
+| Where | What the user saw | Status |
+| --- | --- | --- |
+| Preflight CLI probes | Caching the result would have pinned "git not installed" until relaunch | Bounded entry ([#17350](https://github.com/stablyai/orca/pull/17350)) |
+| `glab auth status` fallback into WSL | Idle VM woken repeatedly for users who never touch GitLab | Open ([#8941](https://github.com/stablyai/orca/issues/8941)) |
+| `listRunningWslDistrosAsync` | Fails closed to `[]` with no last-known-good, polled every 2s — a persistently broken `wsl.exe` makes every WSL session vanish app-wide | Open (PR #17072 review) |
+
+## What to do instead
+
+Pick the cheapest option that fits the call site.
+
+1. **Don't pin it.** If the probe is cheap and uncached, swallowing is fine —
+   the next call self-heals. This is what most of `src/` legitimately does.
+2. **Bound the entry.** If you cache, give it a TTL so a transient failure
+   expires instead of lasting the session. Cheap, no signature change, and what
+   [#17350](https://github.com/stablyai/orca/pull/17350) does.
+3. **Keep last-known-good.** If the probe gates discovery, fall back to the
+   previous successful answer on failure rather than to empty. `listWslDistrosAsync`
+   in `src/main/wsl.ts` already does this — `listRunningWslDistrosAsync`, added
+   beside it, does not.
+4. **Propagate the third state.** The durable fix: return
+   `present | absent | unreachable` instead of a boolean, so a caller cannot
+   accidentally treat "could not ask" as "no". This reaches past WSL into shared
+   exec code and hasn't been done.
+
+Whichever you pick, say in a comment which one and why — that sentence is what
+the guard below is really asking for.
+
+## The guard
+
+`src/main/wsl/wsl-probe-failure-semantics.test.ts` scans the WSL and preflight
+probe modules for `catch { return false | [] | null }` and holds the current set
+in an allowlist that only shrinks.
+
+Its limits are worth being explicit about, because they decide how much it is
+worth trusting:
+
+- **It cannot see the dangerous part.** Whether a swallowed value is later
+  cached or gates discovery is dataflow, not syntax. Every allowlisted entry is
+  currently safe; the guard does not verify that and cannot.
+- **It is scoped, not global.** The same shape appears ~850 times across `src/`
+  and is usually correct, because for most callers a failure genuinely does mean
+  absent. Enforcing it repo-wide would be noise. It only matters where the
+  answer describes a WSL distro.
+- **It catches a shape, not a mistake.** Code can conflate failure and absence
+  without ever writing `catch { return false }`.
+
+So it does not prevent the bug. What it does is stop a new swallow site
+appearing in these modules without someone stating why the value is safe to
+pin — which is the review conversation that was missing all three times.

--- a/src/main/wsl/__fixtures__/wsl-probe-failure-swallow-allowlist.txt
+++ b/src/main/wsl/__fixtures__/wsl-probe-failure-swallow-allowlist.txt
@@ -1,0 +1,25 @@
+# WSL/preflight probes that turn a failure into the same value a legitimate
+# negative answer produces -- `catch { return false | [] | null }`.
+#
+# Enforced by ../wsl-probe-failure-semantics.test.ts. See
+# docs/reference/wsl-probe-failure-semantics.md for what to do instead.
+#
+# Swallowing on its own is survivable: the caller re-probes and the answer
+# self-heals. It turns into a user-visible bug when the swallowed value is then
+# CACHED or GATES DISCOVERY, because "the distro was busy for one second"
+# becomes "you have no git" or "you have no sessions" until relaunch. Every
+# entry below is currently safe only because nothing downstream pins it.
+#
+# The list only shrinks. A new entry is not forbidden, but it has to be added
+# deliberately with a note saying why the swallowed value cannot be pinned --
+# which is the review conversation this guard exists to force.
+#
+# Known real instances of the pinned form, for context:
+#   - preflight per-distro caching (#17350) -- fixed by bounding the entry.
+#   - `glab auth status` waking an idle VM (#8941) -- open.
+#   - `listRunningWslDistrosAsync` failing closed with no last-known-good,
+#     polled every 2s (PR #17072 review) -- open.
+main/ipc/preflight-command-exec.ts
+main/ipc/preflight-test-harness.ts
+main/ipc/preflight-wsl-agent-detection.ts
+main/wsl.ts

--- a/src/main/wsl/wsl-probe-failure-semantics.test.ts
+++ b/src/main/wsl/wsl-probe-failure-semantics.test.ts
@@ -37,9 +37,13 @@ const SWALLOW_ALLOWLIST: readonly string[] = readFileSync(
  */
 const SCANNED_ROOTS = ['main/wsl', 'main/preflight', 'main/ipc/preflight']
 
-/** `catch { return <indistinguishable-from-a-real-negative> }`. */
+/** `catch { return <indistinguishable-from-a-real-negative> }`.
+ *
+ *  Comments are tolerated on BOTH sides of the return: the doc asks authors to
+ *  write down why a swallow is safe, and the natural place for that sentence is
+ *  trailing the `return` — which must not be a way to slip past the guard. */
 const SWALLOW_PATTERN =
-  /catch\s*(?:\([^)]*\))?\s*\{\s*(?:\/\/[^\n]*\n\s*)*return\s+(?:false|\[\]|null|undefined|new Set\(\)|new Map\(\))\s*;?\s*\}/
+  /catch\s*(?:\([^)]*\))?\s*\{\s*(?:\/\/[^\n]*\n\s*|\/\*[\s\S]*?\*\/\s*)*return\s+(?:false|\[\]|null|undefined|new Set\(\)|new Map\(\))\s*;?\s*(?:\/\/[^\n]*\n?\s*|\/\*[\s\S]*?\*\/\s*)*\}/
 
 const SRC_ROOT = resolve(__dirname, '..', '..')
 

--- a/src/main/wsl/wsl-probe-failure-semantics.test.ts
+++ b/src/main/wsl/wsl-probe-failure-semantics.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Guard the one WSL failure mode that keeps coming back in different clothes:
+ * a probe that reports "not there" when it actually means "could not ask".
+ *
+ * `catch { return false }` is not itself the bug -- an uncached caller just
+ * asks again and the answer corrects itself. The bug is what happens when that
+ * value is cached or used to gate discovery: a distro that was busy for one
+ * second reports no git, or no agent sessions, for the rest of the session.
+ * It has shipped that way at least three times (see the allowlist header).
+ *
+ * A repo-wide rule is not workable -- the shape appears ~850 times in `src/`
+ * and is usually correct, because for most callers a failure genuinely does
+ * mean absent. It is only dangerous where the answer describes a WSL distro,
+ * which is why the scan is scoped to the probe modules that own those answers.
+ *
+ * This guard cannot see the dangerous part. Whether a swallowed value gets
+ * pinned is dataflow, not syntax. What it can do is stop a new swallow site
+ * from appearing in these modules without someone saying out loud why it is
+ * safe to pin -- which is the review that was missing all three times.
+ */
+const SWALLOW_ALLOWLIST: readonly string[] = readFileSync(
+  join(__dirname, '__fixtures__', 'wsl-probe-failure-swallow-allowlist.txt'),
+  'utf8'
+)
+  .split('\n')
+  .map((line) => line.trim())
+  .filter((line) => line.length > 0 && !line.startsWith('#'))
+
+/**
+ * The probe modules that answer questions *about a WSL distro*. Scoped
+ * deliberately: outside these, a swallowed failure is somebody else's
+ * judgement call and usually a correct one.
+ */
+const SCANNED_ROOTS = ['main/wsl', 'main/preflight', 'main/ipc/preflight']
+
+/** `catch { return <indistinguishable-from-a-real-negative> }`. */
+const SWALLOW_PATTERN =
+  /catch\s*(?:\([^)]*\))?\s*\{\s*(?:\/\/[^\n]*\n\s*)*return\s+(?:false|\[\]|null|undefined|new Set\(\)|new Map\(\))\s*;?\s*\}/
+
+const SRC_ROOT = resolve(__dirname, '..', '..')
+
+/** Prefix match on purpose: the probes live both in a directory (`main/wsl/`)
+ *  and as siblings named for it (`main/wsl.ts`, `main/ipc/preflight-*.ts`). */
+function isScanned(relativePath: string): boolean {
+  return SCANNED_ROOTS.some((root) => relativePath.startsWith(root))
+}
+
+/** Tests may swallow freely -- they are not shipped and several exist to drive
+ *  the failure path on purpose. */
+function isTestFile(path: string): boolean {
+  return /\.(test|spec)\.tsx?$/.test(path)
+}
+
+function collectTypeScriptFiles(directory: string, found: string[]): void {
+  for (const entry of readdirSync(directory)) {
+    if (entry === '__fixtures__' || entry === 'node_modules') {
+      continue
+    }
+    const absolute = join(directory, entry)
+    if (statSync(absolute).isDirectory()) {
+      collectTypeScriptFiles(absolute, found)
+      continue
+    }
+    if (absolute.endsWith('.ts') && !isTestFile(absolute)) {
+      found.push(absolute)
+    }
+  }
+}
+
+function findSwallowingFiles(): string[] {
+  const candidates: string[] = []
+  collectTypeScriptFiles(SRC_ROOT, candidates)
+  return candidates
+    .map((absolute) => relative(SRC_ROOT, absolute).split('\\').join('/'))
+    .filter(isScanned)
+    .filter((relativePath) =>
+      SWALLOW_PATTERN.test(readFileSync(join(SRC_ROOT, relativePath), 'utf8'))
+    )
+    .sort()
+}
+
+describe('WSL probe failure semantics', () => {
+  it('records every probe module that reports a failure as a negative answer', () => {
+    expect(findSwallowingFiles()).toEqual([...SWALLOW_ALLOWLIST].sort())
+  })
+
+  it('keeps the allowlist honest', () => {
+    const swallowing = new Set(findSwallowingFiles())
+    const stale = SWALLOW_ALLOWLIST.filter((entry) => !swallowing.has(entry))
+    // Why fail on a stale entry rather than ignore it: an entry that no longer
+    // matches means the file was fixed, and leaving it listed would let the
+    // next swallow site slip back in under an allowance nobody re-reviewed.
+    expect(stale).toEqual([])
+  })
+})

--- a/src/main/wsl/wsl-probe-failure-semantics.test.ts
+++ b/src/main/wsl/wsl-probe-failure-semantics.test.ts
@@ -83,9 +83,23 @@ function findSwallowingFiles(): string[] {
     .sort()
 }
 
+const ALLOWLIST_PATH = 'src/main/wsl/__fixtures__/wsl-probe-failure-swallow-allowlist.txt'
+const GUIDANCE = `See docs/reference/wsl-probe-failure-semantics.md`
+
 describe('WSL probe failure semantics', () => {
   it('records every probe module that reports a failure as a negative answer', () => {
-    expect(findSwallowingFiles()).toEqual([...SWALLOW_ALLOWLIST].sort())
+    const allowed = new Set(SWALLOW_ALLOWLIST)
+    const unlisted = findSwallowingFiles().filter((file) => !allowed.has(file))
+    expect(
+      unlisted,
+      unlisted.length === 0
+        ? ''
+        : `New WSL probe module(s) turn a failure into a negative answer:\n` +
+            `${unlisted.map((file) => `  - ${file}`).join('\n')}\n\n` +
+            `That is only safe while nothing caches the value or uses it to gate\n` +
+            `discovery. If it is safe, add the file to ${ALLOWLIST_PATH}\n` +
+            `with a note saying why. If it is not, ${GUIDANCE} for the options.`
+    ).toEqual([])
   })
 
   it('keeps the allowlist honest', () => {
@@ -94,6 +108,14 @@ describe('WSL probe failure semantics', () => {
     // Why fail on a stale entry rather than ignore it: an entry that no longer
     // matches means the file was fixed, and leaving it listed would let the
     // next swallow site slip back in under an allowance nobody re-reviewed.
-    expect(stale).toEqual([])
+    expect(
+      stale,
+      stale.length === 0
+        ? ''
+        : `These entries no longer match — the files were fixed. Nothing is\n` +
+            `wrong with your change; the ratchet just needs to shrink.\n` +
+            `Delete from ${ALLOWLIST_PATH}:\n` +
+            `${stale.map((entry) => `  - ${entry}`).join('\n')}`
+    ).toEqual([])
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​150 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​150 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 |

<!-- /orca-pr-loc -->

## The bug this is about

A WSL probe that cannot reach its distro returns the same value as one that asked and got "no":

```ts
try {
  await execCommandInWsl(target, `${shellQuote(command)} --version`)
  return true
} catch {
  return false // "not installed" and "could not ask" are now the same value
}
```

Swallowing on its own is survivable — an uncached caller asks again and the answer self-heals, which is why this passes review and manual testing. It becomes user-visible when the value is **cached** or **gates discovery**: a distro busy for one second then reports no git, or no agent sessions, until relaunch. Sticky, silent, indistinguishable from the real thing.

It has shipped three times:

| Where | Effect | Status |
| --- | --- | --- |
| Preflight CLI probes | Caching would pin "git not installed" until relaunch | Bounded in #17350 |
| `glab auth status` WSL fallback | Idle VM woken repeatedly for users who never touch GitLab | Open (#8941) |
| `listRunningWslDistrosAsync` | Fails closed to `[]` with no last-known-good, polled every 2s — a persistently broken `wsl.exe` makes every WSL session vanish app-wide | Open (PR #17072 review) |

## What this adds

- `src/main/wsl/wsl-probe-failure-semantics.test.ts` — scans the WSL and preflight probe modules for the shape, allowlist only shrinks.
- `docs/reference/wsl-probe-failure-semantics.md` — the four options for handling it (don't pin / bound the entry / keep last-known-good / propagate a third state) and which existing code does which.

Verified the guard actually fails: adding a new swallow site to a scanned module turns it red, removing it turns it green.

## What it does NOT do — please read before trusting it

- **It cannot see the dangerous part.** Whether a swallowed value is later cached or gates discovery is dataflow, not syntax. Every allowlisted entry is safe *today*; this guard does not verify that and cannot.
- **It is scoped, not global.** The shape appears ~850 times across `src/` in 556 files and is usually correct — for most callers a failure genuinely does mean absent. Repo-wide enforcement would be pure noise. It only matters where the answer describes a WSL distro, which is why the scan covers `main/wsl*`, `main/preflight/`, `main/ipc/preflight*` and nothing else.
- **It catches a shape, not a mistake.** Code can conflate failure and absence without ever writing `catch { return false }`.

So this does not prevent the bug. It stops a new swallow site appearing in these modules without someone stating why the value is safe to pin — the review conversation that was missing all three times. The durable fix is propagating `present | absent | unreachable` out of the probe layer; that reaches well past WSL into shared exec code and isn't attempted here.

## Tests

`src/main/wsl/wsl-probe-failure-semantics.test.ts` — 2 passed. Seeded at 4 files / 7 occurrences.