### PR TITLE
feat: open absolute paths from Quick Open

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1105,9 +1105,53 @@ html.native-shell .app-layout {
   text-align: left;
 }
 
+.editor-header-path--breadcrumbs {
+  display: flex;
+  align-items: baseline;
+  cursor: default;
+}
+
 .editor-header-path:hover,
 .editor-header-path:focus-visible {
   color: var(--foreground);
+}
+
+.editor-header-path--breadcrumbs:hover,
+.editor-header-path--breadcrumbs:focus-visible {
+  color: var(--muted-foreground);
+}
+
+.editor-header-path-segment {
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 0 1px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  line-height: inherit;
+}
+
+.editor-header-path-segment:hover,
+.editor-header-path-segment:focus-visible {
+  color: var(--foreground);
+}
+
+.editor-header-path-segment-current {
+  color: var(--foreground);
+}
+
+.editor-header-path-separator,
+.editor-header-path-preview-suffix {
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+}
+
+.editor-header-path-separator {
+  padding: 0 2px;
+  opacity: 0.55;
+  user-select: none;
 }
 
 .editor-header-path--static {
@@ -1124,28 +1168,6 @@ html.native-shell .app-layout {
   align-items: center;
   gap: 8px;
   min-width: 0;
-}
-
-.editor-header-copy-toast {
-  opacity: 0;
-  transform: translateY(2px);
-  transition:
-    opacity 120ms ease,
-    transform 120ms ease;
-  pointer-events: none;
-  flex-shrink: 0;
-  padding: 2px 6px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--accent) 72%, transparent);
-  color: var(--foreground);
-  font-size: 11px;
-  line-height: 1.2;
-  white-space: nowrap;
-}
-
-.editor-header-copy-toast.is-visible {
-  opacity: 1;
-  transform: translateY(0);
 }
 
 /* ── Content ─────────────────────────────────────────── */

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -22,6 +22,7 @@ import {
   QuickOpenInstallRgGuidance
 } from '@/components/quick-open-install-rg-guidance'
 import {
+  createTabEntryAllowAbsolutePathsSelector,
   getTabEntryAllowAbsolutePaths,
   getTabEntryFileOperationContext
 } from '@/components/tab-bar/tab-create-entry-local-path'
@@ -29,6 +30,7 @@ import {
   isTabEntryAbsolutePathLike,
   validateNewTabEntryAbsolutePath
 } from '@/components/tab-bar/tab-create-entry-path-validation'
+import { TAB_ENTRY_ABSOLUTE_PATH_REMOTE_BLOCKED_MESSAGE } from '@/components/tab-bar/tab-create-entry-classifier'
 import { openAbsoluteTabEntryFile } from '@/components/tab-bar/tab-create-entry-absolute-file'
 import { statRuntimePath } from '@/runtime/runtime-file-client'
 
@@ -85,11 +87,14 @@ function QuickOpenContent({ visible }: { visible: boolean }): React.JSX.Element 
       return null
     }
   }, [localPlatform, query])
-  const absolutePathAllowed = useAppStore((state) =>
-    absolutePath && activeWorktreeId
-      ? getTabEntryAllowAbsolutePaths(state, activeWorktreeId)
-      : false
+  const absolutePathAllowedSelector = useMemo(
+    () =>
+      createTabEntryAllowAbsolutePathsSelector(activeWorktreeId ?? '', {
+        skip: !absolutePath
+      }),
+    [absolutePath, activeWorktreeId]
   )
+  const absolutePathAllowed = useAppStore(absolutePathAllowedSelector)
   const { files, loading, loadError, truncated } = useRuntimeFileListForWorktree({
     enabled: visible,
     worktreeId: activeWorktreeId,
@@ -154,7 +159,6 @@ function QuickOpenContent({ visible }: { visible: boolean }): React.JSX.Element 
     try {
       const state = useAppStore.getState()
       const runtimeContext = getTabEntryFileOperationContext(state, activeWorktreeId, worktreePath)
-      skipReturnFocus()
       await openAbsoluteTabEntryFile({
         context: runtimeContext,
         groupId: activeGroupId,
@@ -173,6 +177,7 @@ function QuickOpenContent({ visible }: { visible: boolean }): React.JSX.Element 
         worktreeId: activeWorktreeId,
         worktreePath
       })
+      skipReturnFocus()
       closeModal()
     } catch (error) {
       setAbsolutePathError(error instanceof Error ? error.message : String(error))
@@ -227,6 +232,10 @@ function QuickOpenContent({ visible }: { visible: boolean }): React.JSX.Element 
         {absolutePathError ? (
           <div className="py-6 px-4 text-center text-sm text-muted-foreground whitespace-pre-wrap">
             {absolutePathError}
+          </div>
+        ) : isTabEntryAbsolutePathLike(query.trim()) && !absolutePathAllowed ? (
+          <div className="py-6 px-4 text-center text-sm text-muted-foreground whitespace-pre-wrap">
+            {TAB_ENTRY_ABSOLUTE_PATH_REMOTE_BLOCKED_MESSAGE}
           </div>
         ) : absolutePathOption ? (
           <CommandItem

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -4,6 +4,7 @@ import { useActiveWorktree } from '@/store/selectors'
 import { detectLanguage } from '@/lib/language-detect'
 import { joinPath } from '@/lib/path'
 import { getFileTypeIcon } from '@/lib/file-type-icons'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import {
   CommandDialog,
   CommandInput,
@@ -20,6 +21,16 @@ import {
   parseQuickOpenInstallRgGuidance,
   QuickOpenInstallRgGuidance
 } from '@/components/quick-open-install-rg-guidance'
+import {
+  getTabEntryAllowAbsolutePaths,
+  getTabEntryFileOperationContext
+} from '@/components/tab-bar/tab-create-entry-local-path'
+import {
+  isTabEntryAbsolutePathLike,
+  validateNewTabEntryAbsolutePath
+} from '@/components/tab-bar/tab-create-entry-path-validation'
+import { openAbsoluteTabEntryFile } from '@/components/tab-bar/tab-create-entry-absolute-file'
+import { statRuntimePath } from '@/runtime/runtime-file-client'
 
 const QUICK_OPEN_CLOSE_LINGER_MS = 300
 
@@ -54,17 +65,39 @@ function QuickOpenContent({ visible }: { visible: boolean }): React.JSX.Element 
   const closeModal = useAppStore((s) => s.closeModal)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const openFile = useAppStore((s) => s.openFile)
+  const activeGroupId = useAppStore((s) =>
+    activeWorktreeId ? s.activeGroupIdByWorktree[activeWorktreeId] : undefined
+  )
   const activeWorktree = useActiveWorktree()
 
   const [query, setQuery] = useState('')
   const deferredQuery = useDeferredValue(query)
+  const worktreePath = activeWorktree?.path ?? null
+  const localPlatform = getRendererAppPlatform() === 'win32' ? 'windows' : 'posix'
+  const absolutePath = useMemo(() => {
+    const trimmed = query.trim()
+    if (!isTabEntryAbsolutePathLike(trimmed)) {
+      return null
+    }
+    try {
+      return validateNewTabEntryAbsolutePath(trimmed, localPlatform)
+    } catch {
+      return null
+    }
+  }, [localPlatform, query])
+  const absolutePathAllowed = useAppStore((state) =>
+    absolutePath && activeWorktreeId
+      ? getTabEntryAllowAbsolutePaths(state, activeWorktreeId)
+      : false
+  )
   const { files, loading, loadError, truncated } = useRuntimeFileListForWorktree({
     enabled: visible,
     worktreeId: activeWorktreeId,
-    query: deferredQuery
+    query: absolutePath && absolutePathAllowed ? undefined : deferredQuery
   })
-
-  const worktreePath = activeWorktree?.path ?? null
+  const absolutePathOption = absolutePath && absolutePathAllowed ? absolutePath : null
+  const [absolutePathError, setAbsolutePathError] = useState<string | null>(null)
+  useEffect(() => setAbsolutePathError(null), [absolutePath])
 
   // Why: Radix's onCloseAutoFocus restore is suppressed below, so dismissing
   // the dialog (Esc / click-away) would otherwise leave the active panel
@@ -108,6 +141,54 @@ function QuickOpenContent({ visible }: { visible: boolean }): React.JSX.Element 
     [activeWorktreeId, worktreePath, openFile, closeModal, skipReturnFocus]
   )
 
+  const handleOpenAbsolutePath = useCallback(async () => {
+    if (
+      !absolutePath ||
+      !absolutePathAllowed ||
+      !activeWorktreeId ||
+      !worktreePath ||
+      !activeGroupId
+    ) {
+      return
+    }
+    try {
+      const state = useAppStore.getState()
+      const runtimeContext = getTabEntryFileOperationContext(state, activeWorktreeId, worktreePath)
+      skipReturnFocus()
+      await openAbsoluteTabEntryFile({
+        context: runtimeContext,
+        groupId: activeGroupId,
+        operations: {
+          assertAbsolutePathAllowed: () => {
+            if (!getTabEntryAllowAbsolutePaths(useAppStore.getState(), activeWorktreeId)) {
+              throw new Error('Absolute paths require a local workspace.')
+            }
+          },
+          authorizeExternalPath: window.api.fs.authorizeExternalPath,
+          openFile,
+          statRuntimePath
+        },
+        filePath: absolutePath,
+        localPlatform,
+        worktreeId: activeWorktreeId,
+        worktreePath
+      })
+      closeModal()
+    } catch (error) {
+      setAbsolutePathError(error instanceof Error ? error.message : String(error))
+    }
+  }, [
+    absolutePath,
+    absolutePathAllowed,
+    activeGroupId,
+    activeWorktreeId,
+    closeModal,
+    localPlatform,
+    openFile,
+    skipReturnFocus,
+    worktreePath
+  ])
+
   const handleOpenChange = useCallback(
     (open: boolean) => {
       if (!open) {
@@ -143,7 +224,25 @@ function QuickOpenContent({ visible }: { visible: boolean }): React.JSX.Element 
         className="!h-9 !py-2"
       />
       <CommandList className="p-2">
-        {loading ? (
+        {absolutePathError ? (
+          <div className="py-6 px-4 text-center text-sm text-muted-foreground whitespace-pre-wrap">
+            {absolutePathError}
+          </div>
+        ) : absolutePathOption ? (
+          <CommandItem
+            value={absolutePathOption}
+            onSelect={() => void handleOpenAbsolutePath()}
+            className="min-w-0 !p-0"
+          >
+            <div className="flex w-full min-w-0 items-center gap-2 px-3 py-1">
+              {(() => {
+                const FileIcon = getFileTypeIcon(absolutePathOption)
+                return <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
+              })()}
+              <span className="min-w-0 truncate text-foreground">{absolutePathOption}</span>
+            </div>
+          </CommandItem>
+        ) : loading ? (
           <div className="py-6 text-center text-sm text-muted-foreground">
             {translate('auto.components.QuickOpen.722a21e1a8', 'Loading files...')}
           </div>

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -233,7 +233,7 @@ function QuickOpenContent({ visible }: { visible: boolean }): React.JSX.Element 
           <div className="py-6 px-4 text-center text-sm text-muted-foreground whitespace-pre-wrap">
             {absolutePathError}
           </div>
-        ) : isTabEntryAbsolutePathLike(query.trim()) && !absolutePathAllowed ? (
+        ) : absolutePath && !absolutePathAllowed ? (
           <div className="py-6 px-4 text-center text-sm text-muted-foreground whitespace-pre-wrap">
             {TAB_ENTRY_ABSOLUTE_PATH_REMOTE_BLOCKED_MESSAGE}
           </div>

--- a/src/renderer/src/components/editor/EditorHeaderPathBreadcrumbs.tsx
+++ b/src/renderer/src/components/editor/EditorHeaderPathBreadcrumbs.tsx
@@ -1,0 +1,179 @@
+import { Fragment, useEffect, useState } from 'react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { translate } from '@/i18n/i18n'
+import { joinPath } from '@/lib/path'
+import { useAppStore } from '@/store'
+import { useWorktreeById } from '@/store/selectors'
+import type { OpenFile } from '@/store/slices/editor'
+import type { DirEntry } from '../../../../shared/filesystem-entry-types'
+import { CLOSE_ALL_CONTEXT_MENUS_EVENT } from '../tab-bar/SortableTab'
+import { EditorHeaderPathDirectoryMenu } from './EditorHeaderPathDirectoryMenu'
+import {
+  joinEditorHeaderPathEntry,
+  listEditorHeaderDirectory,
+  openEditorHeaderPathFile,
+  type EditorHeaderDirectoryListing
+} from './editor-header-path-directory'
+import {
+  getEditorHeaderPathPreviewSuffix,
+  getEditorHeaderPathSegments,
+  resolveEditorHeaderDirectoryAbsolutePath,
+  type EditorHeaderPathSegment
+} from './editor-header-path-segments'
+
+type EditorHeaderPathBreadcrumbsProps = {
+  activeFile: OpenFile
+  pathTitle: string
+}
+
+type ListingState = {
+  segmentId: string
+  directoryAbsolutePath: string
+  directoryRelativePath: string
+}
+
+export function EditorHeaderPathBreadcrumbs({
+  activeFile,
+  pathTitle
+}: EditorHeaderPathBreadcrumbsProps): React.JSX.Element {
+  const worktree = useWorktreeById(activeFile.worktreeId)
+  const worktreePath = worktree?.path ?? null
+  const openFile = useAppStore((state) => state.openFile)
+  const openMarkdownPreview = useAppStore((state) => state.openMarkdownPreview)
+  const activeGroupId = useAppStore((state) => state.activeGroupIdByWorktree[activeFile.worktreeId])
+  const { worktreeId, runtimeEnvironmentId, externalSshTargetId, operationProvenance } = activeFile
+  const segments = getEditorHeaderPathSegments(activeFile) ?? []
+  const previewSuffix = getEditorHeaderPathPreviewSuffix(activeFile)
+  const [listing, setListing] = useState<ListingState | null>(null)
+  const [loadState, setLoadState] = useState<EditorHeaderDirectoryListing | { status: 'loading' }>({
+    status: 'loading'
+  })
+
+  useEffect(() => {
+    const closeListing = (): void => setListing(null)
+    window.addEventListener(CLOSE_ALL_CONTEXT_MENUS_EVENT, closeListing)
+    return () => window.removeEventListener(CLOSE_ALL_CONTEXT_MENUS_EVENT, closeListing)
+  }, [])
+
+  useEffect(() => {
+    if (!listing) {
+      return
+    }
+    let cancelled = false
+    setLoadState({ status: 'loading' })
+    void listEditorHeaderDirectory(
+      { worktreeId, runtimeEnvironmentId, externalSshTargetId, operationProvenance },
+      worktreePath,
+      listing.directoryAbsolutePath
+    ).then((result) => {
+      if (!cancelled) {
+        setLoadState(result)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [
+    externalSshTargetId,
+    listing,
+    operationProvenance,
+    runtimeEnvironmentId,
+    worktreeId,
+    worktreePath
+  ])
+
+  const openListing = (segment: EditorHeaderPathSegment): void => {
+    setLoadState({ status: 'loading' })
+    setListing({
+      segmentId: segment.id,
+      directoryRelativePath: segment.relativeDirectoryPath,
+      directoryAbsolutePath: resolveEditorHeaderDirectoryAbsolutePath(
+        activeFile,
+        worktreePath,
+        segment.relativeDirectoryPath
+      )
+    })
+  }
+
+  const handleSelectEntry = (entry: DirEntry): void => {
+    if (!listing) {
+      return
+    }
+    if (entry.isDirectory) {
+      setLoadState({ status: 'loading' })
+      setListing({
+        ...listing,
+        directoryRelativePath: listing.directoryRelativePath
+          ? `${listing.directoryRelativePath}/${entry.name}`
+          : entry.name,
+        directoryAbsolutePath: joinPath(listing.directoryAbsolutePath, entry.name)
+      })
+      return
+    }
+    openEditorHeaderPathFile({
+      currentFile: activeFile,
+      ...joinEditorHeaderPathEntry(
+        listing.directoryAbsolutePath,
+        listing.directoryRelativePath,
+        entry.name
+      ),
+      targetGroupId: activeGroupId ?? undefined,
+      openFile,
+      openMarkdownPreview
+    })
+    setListing(null)
+  }
+
+  return (
+    <div className="editor-header-path editor-header-path--breadcrumbs" title={pathTitle}>
+      {segments.map((segment, index) => (
+        <Fragment key={segment.id}>
+          {index > 0 ? <span className="editor-header-path-separator">/</span> : null}
+          <Popover
+            open={listing?.segmentId === segment.id}
+            onOpenChange={(open) => {
+              if (open) {
+                openListing(segment)
+                return
+              }
+              if (!open && listing?.segmentId === segment.id) {
+                setListing(null)
+              }
+            }}
+            modal={false}
+          >
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                data-editor-header-path-segment={segment.id}
+                className={`editor-header-path-segment${
+                  segment.isFile ? ' editor-header-path-segment-current' : ''
+                }`}
+                aria-label={translate(
+                  'auto.components.editor.EditorPanelHeaderPath.5d0a8b17c3',
+                  'Browse {{value0}}',
+                  { value0: segment.label }
+                )}
+              >
+                {segment.label}
+              </button>
+            </PopoverTrigger>
+            {listing?.segmentId === segment.id ? (
+              <PopoverContent align="start" side="bottom" sideOffset={4} className="w-auto p-0">
+                <EditorHeaderPathDirectoryMenu
+                  loadState={loadState}
+                  directoryAbsolutePath={listing.directoryAbsolutePath}
+                  currentFilePath={activeFile.filePath}
+                  onSelectEntry={handleSelectEntry}
+                />
+              </PopoverContent>
+            ) : null}
+          </Popover>
+        </Fragment>
+      ))}
+      {previewSuffix ? (
+        <span className="editor-header-path-preview-suffix">{previewSuffix}</span>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/editor/EditorHeaderPathBreadcrumbs.tsx
+++ b/src/renderer/src/components/editor/EditorHeaderPathBreadcrumbs.tsx
@@ -1,6 +1,8 @@
 import { Fragment, useEffect, useState } from 'react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { translate } from '@/i18n/i18n'
+import { getEditorFileOperationContext } from '@/lib/editor-file-operation-owner'
+import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import { joinPath } from '@/lib/path'
 import { useAppStore } from '@/store'
 import { useWorktreeById } from '@/store/selectors'
@@ -30,6 +32,10 @@ type ListingState = {
   segmentId: string
   directoryAbsolutePath: string
   directoryRelativePath: string
+  ownerFile: Pick<
+    OpenFile,
+    'worktreeId' | 'runtimeEnvironmentId' | 'externalSshTargetId' | 'operationProvenance'
+  >
 }
 
 export function EditorHeaderPathBreadcrumbs({
@@ -41,7 +47,6 @@ export function EditorHeaderPathBreadcrumbs({
   const openFile = useAppStore((state) => state.openFile)
   const openMarkdownPreview = useAppStore((state) => state.openMarkdownPreview)
   const activeGroupId = useAppStore((state) => state.activeGroupIdByWorktree[activeFile.worktreeId])
-  const { worktreeId, runtimeEnvironmentId, externalSshTargetId, operationProvenance } = activeFile
   const segments = getEditorHeaderPathSegments(activeFile) ?? []
   const previewSuffix = getEditorHeaderPathPreviewSuffix(activeFile)
   const [listing, setListing] = useState<ListingState | null>(null)
@@ -62,7 +67,7 @@ export function EditorHeaderPathBreadcrumbs({
     let cancelled = false
     setLoadState({ status: 'loading' })
     void listEditorHeaderDirectory(
-      { worktreeId, runtimeEnvironmentId, externalSshTargetId, operationProvenance },
+      listing.ownerFile,
       worktreePath,
       listing.directoryAbsolutePath
     ).then((result) => {
@@ -73,20 +78,19 @@ export function EditorHeaderPathBreadcrumbs({
     return () => {
       cancelled = true
     }
-  }, [
-    externalSshTargetId,
-    listing,
-    operationProvenance,
-    runtimeEnvironmentId,
-    worktreeId,
-    worktreePath
-  ])
+  }, [listing, worktreePath])
 
   const openListing = (segment: EditorHeaderPathSegment): void => {
     setLoadState({ status: 'loading' })
     setListing({
       segmentId: segment.id,
       directoryRelativePath: segment.relativeDirectoryPath,
+      ownerFile: {
+        worktreeId: activeFile.worktreeId,
+        runtimeEnvironmentId: activeFile.runtimeEnvironmentId,
+        externalSshTargetId: activeFile.externalSshTargetId,
+        operationProvenance: activeFile.operationProvenance
+      },
       directoryAbsolutePath: resolveEditorHeaderDirectoryAbsolutePath(
         activeFile,
         worktreePath,
@@ -110,8 +114,23 @@ export function EditorHeaderPathBreadcrumbs({
       })
       return
     }
+    try {
+      getEditorFileOperationContext(useAppStore.getState(), listing.ownerFile, worktreePath)
+    } catch (error) {
+      setLoadState({
+        status: 'error',
+        message: extractIpcErrorMessage(
+          error,
+          translate(
+            'auto.components.editor.EditorPanelHeaderPath.7e2c1a9b04',
+            'Could not list this folder.'
+          )
+        )
+      })
+      return
+    }
     openEditorHeaderPathFile({
-      currentFile: activeFile,
+      currentFile: { ...listing.ownerFile, mode: activeFile.mode },
       ...joinEditorHeaderPathEntry(
         listing.directoryAbsolutePath,
         listing.directoryRelativePath,

--- a/src/renderer/src/components/editor/EditorHeaderPathDirectoryMenu.tsx
+++ b/src/renderer/src/components/editor/EditorHeaderPathDirectoryMenu.tsx
@@ -1,0 +1,79 @@
+import { File, Folder, Loader2 } from 'lucide-react'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import type { DirEntry } from '../../../../shared/filesystem-entry-types'
+import type { EditorHeaderDirectoryListing } from './editor-header-path-directory'
+import { isEditorHeaderPathCurrentEntry } from './editor-header-path-segments'
+
+type EditorHeaderPathDirectoryMenuProps = {
+  loadState: EditorHeaderDirectoryListing | { status: 'loading' }
+  directoryAbsolutePath: string
+  currentFilePath: string
+  onSelectEntry: (entry: DirEntry) => void
+}
+
+export function EditorHeaderPathDirectoryMenu({
+  loadState,
+  directoryAbsolutePath,
+  currentFilePath,
+  onSelectEntry
+}: EditorHeaderPathDirectoryMenuProps): React.JSX.Element {
+  if (loadState.status === 'loading') {
+    return (
+      <div className="flex items-center gap-2 px-2 py-2 text-xs text-muted-foreground">
+        <Loader2 className="size-3.5 animate-spin" />
+        {translate('auto.components.editor.EditorPanelHeaderPath.3c8f0d21a6', 'Loading…')}
+      </div>
+    )
+  }
+
+  if (loadState.status === 'error') {
+    return (
+      <div className="max-w-[18rem] px-2 py-2 text-xs text-destructive" role="alert">
+        {loadState.message}
+      </div>
+    )
+  }
+
+  if (loadState.entries.length === 0) {
+    return (
+      <div className="px-2 py-2 text-xs text-muted-foreground">
+        {translate(
+          'auto.components.editor.EditorPanelHeaderPath.9b14e6c2d0',
+          'This folder is empty.'
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="popover-scroll-content scrollbar-sleek max-h-72 min-w-[12rem] overflow-y-auto p-1">
+      {loadState.entries.map((entry) => {
+        const isCurrent =
+          !entry.isDirectory &&
+          isEditorHeaderPathCurrentEntry(directoryAbsolutePath, entry.name, currentFilePath)
+        return (
+          <button
+            key={`${entry.isDirectory ? 'dir' : 'file'}:${entry.name}`}
+            type="button"
+            data-current={isCurrent ? 'true' : undefined}
+            data-editor-header-path-entry={entry.name}
+            data-editor-header-path-entry-kind={entry.isDirectory ? 'directory' : 'file'}
+            className={cn(
+              'flex w-full items-center gap-2 rounded-[7px] px-2 py-1 text-left text-[12px] leading-5 font-medium text-foreground hover:bg-accent',
+              isCurrent && 'bg-accent'
+            )}
+            onClick={() => onSelectEntry(entry)}
+          >
+            {entry.isDirectory ? (
+              <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+            ) : (
+              <File className="size-3.5 shrink-0 text-muted-foreground" />
+            )}
+            <span className="truncate">{entry.name}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -3,7 +3,6 @@ import { useAppStore } from '@/store'
 import { getConnectionId } from '@/lib/connection-context'
 import { detectLanguage } from '@/lib/language-detect'
 import { canShowWorkspaceFileBrowserAction, openFilePreviewToSide } from '@/lib/file-preview'
-import { getEditorHeaderCopyState } from './editor-header'
 import { isLocalPathOpenBlocked, showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 import { exportActiveMarkdownToPdf } from './export-active-markdown'
@@ -82,30 +81,6 @@ function EditorPanelInner({
   const editorDrafts = useAppStore(editorDraftSelector)
   const settings = useAppStore((s) => s.settings)
   const panelRef = useRef<HTMLDivElement>(null)
-  const [copiedPathToast, setCopiedPathToast] = useState<{ fileId: string; token: number } | null>(
-    null
-  )
-  const copiedPathToastResetTimerRef = useRef<number | null>(null)
-  // Why: clipboard IPC can resolve after the editor panel unmounts; skip path
-  // toast feedback instead of starting a reset timer on a stale panel.
-  const pathCopyMountedRef = useRef(false)
-  const clearCopiedPathToastResetTimer = useCallback((): void => {
-    if (copiedPathToastResetTimerRef.current === null) {
-      return
-    }
-    window.clearTimeout(copiedPathToastResetTimerRef.current)
-    copiedPathToastResetTimerRef.current = null
-  }, [])
-  const setPanelRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      panelRef.current = node
-      pathCopyMountedRef.current = node !== null
-      if (!node) {
-        clearCopiedPathToastResetTimer()
-      }
-    },
-    [clearCopiedPathToastResetTimer]
-  )
   const [sideBySide, setSideBySide] = useState(settings?.diffDefaultView === 'side-by-side')
   const [prevDiffView, setPrevDiffView] = useState(settings?.diffDefaultView)
 
@@ -175,35 +150,6 @@ function EditorPanelInner({
     handleSave,
     enabled: isCmdSaveOwner
   })
-
-  const handleCopyPath = useCallback(async (): Promise<void> => {
-    if (!activeFile) {
-      return
-    }
-    const copyState = getEditorHeaderCopyState(activeFile)
-    if (!copyState.copyText) {
-      return
-    }
-    try {
-      await window.api.ui.writeClipboardText(copyState.copyText)
-      if (!pathCopyMountedRef.current) {
-        return
-      }
-      clearCopiedPathToastResetTimer()
-      const nextToast = { fileId: activeFile.id, token: Date.now() }
-      setCopiedPathToast(nextToast)
-      copiedPathToastResetTimerRef.current = window.setTimeout(() => {
-        copiedPathToastResetTimerRef.current = null
-        setCopiedPathToast((current) => (current?.token === nextToast.token ? null : current))
-      }, 1500)
-    } catch {
-      if (!pathCopyMountedRef.current) {
-        return
-      }
-      clearCopiedPathToastResetTimer()
-      setCopiedPathToast(null)
-    }
-  }, [activeFile, clearCopiedPathToastResetTimer])
 
   if (!activeFile) {
     return null
@@ -336,11 +282,10 @@ function EditorPanelInner({
     // Why: each split pane needs an isolated bridge between its diff editor and header controls.
     <DiffNavigationProvider>
       <EditorPanelShell
-        panelRef={setPanelRef}
+        panelRef={panelRef}
         activeFile={activeFile}
         activeViewStateId={activeViewStateId}
         model={model}
-        copiedPathVisible={copiedPathToast?.fileId === activeFile.id}
         showMarkdownTableOfContents={isMarkdownTableOfContentsVisible}
         canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
         markdownFrontmatterVisible={isMarkdownFrontmatterVisible}
@@ -353,7 +298,6 @@ function EditorPanelInner({
         renameDialogFile={renameDialogFile}
         renameError={renameError}
         disableRenameBrowse={disableRenameBrowse}
-        onCopyPath={() => void handleCopyPath()}
         onOpenDiffTargetFile={handleOpenDiffTargetFile}
         onOpenPreviewToSide={handleOpenPreviewToSide}
         onOpenMarkdownPreview={handleOpenMarkdownPreview}

--- a/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
@@ -66,7 +66,6 @@ const activeFile: OpenFile = {
 
 const baseProps = {
   activeFile,
-  copiedPathVisible: false,
   isSingleDiff: false,
   isDiffSurface: true,
   isMarkdown: false,
@@ -86,7 +85,6 @@ const baseProps = {
   markdownFrontmatterVisible: false,
   sideBySide: false,
   openFileState: { canOpen: false },
-  onCopyPath: vi.fn(),
   onOpenDiffTargetFile: vi.fn(),
   onOpenPreviewToSide: vi.fn(),
   onOpenMarkdownPreview: vi.fn(),

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -23,7 +23,6 @@ import { markdownArtifactSourceKey } from './markdown-artifact-upload'
 
 type EditorPanelHeaderProps = {
   activeFile: OpenFile
-  copiedPathVisible: boolean
   isSingleDiff: boolean
   isDiffSurface: boolean
   isMarkdown: boolean
@@ -43,7 +42,6 @@ type EditorPanelHeaderProps = {
   markdownFrontmatterVisible: boolean
   sideBySide: boolean
   openFileState: EditorHeaderOpenFileState
-  onCopyPath: () => void
   onOpenDiffTargetFile: (preferredMarkdownViewMode?: 'rich') => void
   onOpenPreviewToSide: () => void
   onOpenMarkdownPreview: () => void
@@ -58,7 +56,6 @@ type EditorPanelHeaderProps = {
 
 export function EditorPanelHeader({
   activeFile,
-  copiedPathVisible,
   isSingleDiff,
   isDiffSurface,
   isMarkdown,
@@ -78,7 +75,6 @@ export function EditorPanelHeader({
   markdownFrontmatterVisible,
   sideBySide,
   openFileState,
-  onCopyPath,
   onOpenDiffTargetFile,
   onOpenPreviewToSide,
   onOpenMarkdownPreview,
@@ -111,9 +107,7 @@ export function EditorPanelHeader({
     <div className="editor-header">
       <EditorPanelHeaderPath
         activeFile={activeFile}
-        copiedPathVisible={copiedPathVisible}
         canShowMarkdownPreview={canShowMarkdownPreview}
-        onCopyPath={onCopyPath}
         onOpenMarkdownPreview={onOpenMarkdownPreview}
         onOpenContainingFolder={onOpenContainingFolder}
       />

--- a/src/renderer/src/components/editor/EditorPanelHeaderPath.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeaderPath.test.tsx
@@ -1,0 +1,402 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import { EditorPanelHeaderPath } from './EditorPanelHeaderPath'
+
+const readRuntimeDirectory = vi.hoisted(() => vi.fn())
+const openFile = vi.hoisted(() => vi.fn())
+const openMarkdownPreview = vi.hoisted(() => vi.fn())
+const getEditorFileOperationContext = vi.hoisted(() => vi.fn())
+const activateTab = vi.hoisted(() => vi.fn())
+const writeClipboardText = vi.hoisted(() => vi.fn(async () => undefined))
+
+vi.mock('@/runtime/runtime-file-client', () => ({
+  readRuntimeDirectory: (...args: unknown[]) => readRuntimeDirectory(...args)
+}))
+vi.mock('@/lib/editor-file-operation-owner', () => ({
+  getEditorFileOperationContext: (...args: unknown[]) => getEditorFileOperationContext(...args)
+}))
+vi.mock('@/store', () => {
+  const getState = () => ({
+    openFile,
+    openMarkdownPreview,
+    openFiles: [],
+    unifiedTabsByWorktree: {},
+    activeGroupIdByWorktree: { 'wt-1': 'group-1' },
+    activateTab
+  })
+  const useAppStore = (selector: (state: ReturnType<typeof getState>) => unknown) =>
+    selector(getState())
+  useAppStore.getState = getState
+  return { useAppStore }
+})
+vi.mock('@/store/selectors', () => ({
+  useWorktreeById: () => ({ path: '/repo' })
+}))
+vi.mock('./editor-header-file-rename', () => ({
+  useEditorHeaderFileRename: (file: OpenFile) => ({
+    canRename: file.mode === 'edit',
+    currentFileName: file.relativePath.split(/[\\/]/).pop() ?? file.relativePath,
+    isRenaming: false,
+    renameInputRef: () => {},
+    openRenameInput: vi.fn(),
+    commitRename: vi.fn(),
+    cancelRename: vi.fn()
+  })
+}))
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useShortcutLabel: () => '⌘⇧V'
+}))
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, options?: Record<string, unknown>) =>
+    fallback.replace(/\{\{(\w+)\}\}/g, (_match, name: string) =>
+      options?.[name] === undefined ? `{{${name}}}` : String(options[name])
+    ),
+  i18n: { language: 'en' }
+}))
+vi.mock('../tab-bar/SortableTab', () => ({
+  CLOSE_ALL_CONTEXT_MENUS_EVENT: 'close-all-context-menus'
+}))
+vi.mock('@/components/ui/popover', async () => {
+  const { cloneElement, createContext, isValidElement, useContext, useMemo } = await import('react')
+  const PopoverContext = createContext<{
+    open: boolean
+    onOpenChange?: (open: boolean) => void
+  }>({ open: false })
+
+  return {
+    Popover: ({
+      children,
+      open = false,
+      onOpenChange
+    }: {
+      children: React.ReactNode
+      open?: boolean
+      onOpenChange?: (open: boolean) => void
+    }) => {
+      const contextValue = useMemo(() => ({ open, onOpenChange }), [onOpenChange, open])
+      return <PopoverContext.Provider value={contextValue}>{children}</PopoverContext.Provider>
+    },
+    PopoverContent: ({ children }: { children: React.ReactNode }) => (
+      <div data-editor-header-path-menu>{children}</div>
+    ),
+    PopoverTrigger: ({ children }: { children: React.ReactNode }) => {
+      const { open, onOpenChange } = useContext(PopoverContext)
+      if (!isValidElement<{ onClick?: (event: unknown) => void }>(children)) {
+        return children
+      }
+      return cloneElement(children, {
+        onClick: (event: unknown) => {
+          children.props.onClick?.(event)
+          onOpenChange?.(!open)
+        }
+      })
+    }
+  }
+})
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <>{children}</> : null,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onSelect
+  }: {
+    children: React.ReactNode
+    onSelect?: () => void
+  }) => <button onClick={onSelect}>{children}</button>,
+  DropdownMenuSeparator: () => null,
+  DropdownMenuShortcut: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+function makeOpenFile(overrides: Partial<OpenFile> = {}): OpenFile {
+  return {
+    id: '/repo/src/lib/path.ts',
+    filePath: '/repo/src/lib/path.ts',
+    relativePath: 'src/lib/path.ts',
+    worktreeId: 'wt-1',
+    language: 'typescript',
+    isDirty: false,
+    mode: 'edit',
+    ...overrides
+  }
+}
+
+function renderPath(file: OpenFile): void {
+  render(
+    <EditorPanelHeaderPath
+      activeFile={file}
+      canShowMarkdownPreview={false}
+      onOpenMarkdownPreview={vi.fn()}
+      onOpenContainingFolder={vi.fn()}
+    />
+  )
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: { ui: { writeClipboardText } }
+  })
+  getEditorFileOperationContext.mockReturnValue({
+    settings: {},
+    worktreeId: 'wt-1',
+    worktreePath: '/repo',
+    expectedExecutionHostId: 'local'
+  })
+  readRuntimeDirectory.mockImplementation(async (_context: unknown, dirPath: string) => {
+    if (dirPath === '/repo/src') {
+      return [
+        { name: 'lib', isDirectory: true, isSymlink: false },
+        { name: 'main.ts', isDirectory: false, isSymlink: false }
+      ]
+    }
+    if (dirPath === '/repo/src/lib') {
+      return [
+        { name: 'other.ts', isDirectory: false, isSymlink: false },
+        { name: 'path.ts', isDirectory: false, isSymlink: false }
+      ]
+    }
+    if (dirPath === '/repo/docs') {
+      return [
+        { name: 'README.md', isDirectory: false, isSymlink: false },
+        { name: 'guide.md', isDirectory: false, isSymlink: false }
+      ]
+    }
+    throw new Error(`unexpected dir ${dirPath}`)
+  })
+})
+
+describe('EditorPanelHeaderPath', () => {
+  it('keeps the filename inside .editor-header-path for real file tabs', () => {
+    renderPath(makeOpenFile())
+    const path = document.querySelector('.editor-header-path')
+    expect(path?.textContent).toContain('path.ts')
+    expect(path?.querySelectorAll('[data-editor-header-path-segment]')).toHaveLength(3)
+  })
+
+  it('keeps virtual tabs as a single static label', () => {
+    renderPath(
+      makeOpenFile({
+        id: '/repo/src/lib/path.ts::unstaged',
+        mode: 'diff',
+        diffSource: 'unstaged'
+      })
+    )
+    const path = document.querySelector('.editor-header-path')
+    expect(path?.textContent).toContain('path.ts')
+    expect(path?.textContent).toContain('(diff)')
+    expect(path?.querySelectorAll('[data-editor-header-path-segment]')).toHaveLength(0)
+    expect(path?.className).toContain('editor-header-path--static')
+  })
+
+  it('keeps absolute relative paths as a single static label', () => {
+    renderPath(
+      makeOpenFile({
+        filePath: '/outside/path.ts',
+        relativePath: '/outside/path.ts'
+      })
+    )
+    const path = document.querySelector('.editor-header-path')
+    expect(path?.querySelectorAll('[data-editor-header-path-segment]')).toHaveLength(0)
+    expect(path?.className).toContain('editor-header-path--static')
+  })
+
+  it('leaves the preview suffix beside the filename instead of making it a segment', () => {
+    renderPath(
+      makeOpenFile({
+        id: 'markdown-preview::/repo/docs/README.md',
+        filePath: '/repo/docs/README.md',
+        relativePath: 'docs/README.md',
+        language: 'markdown',
+        mode: 'markdown-preview'
+      })
+    )
+    const path = document.querySelector('.editor-header-path')
+    expect(path?.textContent).toContain('README.md')
+    expect(path?.textContent).toContain('(preview)')
+    expect(
+      [...path!.querySelectorAll('[data-editor-header-path-segment]')].map(
+        (node) => node.textContent
+      )
+    ).toEqual(['docs', 'README.md'])
+  })
+
+  it('lists the current directory from the filename and the clicked parent from an ancestor', async () => {
+    render(
+      <EditorPanelHeaderPath
+        activeFile={makeOpenFile()}
+        canShowMarkdownPreview={false}
+        onOpenMarkdownPreview={vi.fn()}
+        onOpenContainingFolder={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Browse path.ts' }))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'other.ts' })).toBeTruthy()
+    })
+    expect(readRuntimeDirectory).toHaveBeenCalledWith(expect.anything(), '/repo/src/lib')
+    expect(screen.getByRole('button', { name: 'path.ts' }).getAttribute('data-current')).toBe(
+      'true'
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Browse src' }))
+    expect(screen.queryByRole('button', { name: 'other.ts' })).toBeNull()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'main.ts' })).toBeTruthy()
+    })
+    expect(readRuntimeDirectory).toHaveBeenCalledWith(expect.anything(), '/repo/src')
+    expect(
+      screen.getByRole('button', { name: 'lib' }).getAttribute('data-editor-header-path-entry-kind')
+    ).toBe('directory')
+
+    fireEvent.click(screen.getByRole('button', { name: 'lib' }))
+    expect(screen.queryByRole('button', { name: 'main.ts' })).toBeNull()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'path.ts' })).toBeTruthy()
+    })
+    expect(readRuntimeDirectory).toHaveBeenLastCalledWith(expect.anything(), '/repo/src/lib')
+  })
+
+  it('opens a sibling file with openFile and keeps preview for markdown targets', async () => {
+    renderPath(makeOpenFile())
+    fireEvent.click(screen.getByRole('button', { name: 'Browse path.ts' }))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'other.ts' })).toBeTruthy()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'other.ts' }))
+    expect(openFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '/repo/src/lib/other.ts',
+        relativePath: 'src/lib/other.ts',
+        mode: 'edit'
+      }),
+      { targetGroupId: 'group-1' }
+    )
+    expect(openMarkdownPreview).not.toHaveBeenCalled()
+
+    cleanup()
+    renderPath(
+      makeOpenFile({
+        id: 'markdown-preview::/repo/docs/README.md',
+        filePath: '/repo/docs/README.md',
+        relativePath: 'docs/README.md',
+        language: 'markdown',
+        mode: 'markdown-preview'
+      })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Browse README.md' }))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'guide.md' })).toBeTruthy()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'guide.md' }))
+    expect(openMarkdownPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '/repo/docs/guide.md',
+        relativePath: 'docs/guide.md',
+        language: 'markdown'
+      }),
+      { targetGroupId: 'group-1' }
+    )
+  })
+
+  it('shows a listing error inside the popover', async () => {
+    readRuntimeDirectory.mockRejectedValueOnce(new Error('EACCES: permission denied'))
+    renderPath(makeOpenFile())
+    fireEvent.click(screen.getByRole('button', { name: 'Browse path.ts' }))
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toContain('EACCES')
+    })
+  })
+
+  it('keeps an open listing mounted when unrelated file state changes', async () => {
+    const file = makeOpenFile()
+    const { rerender } = render(
+      <EditorPanelHeaderPath
+        activeFile={file}
+        canShowMarkdownPreview={false}
+        onOpenMarkdownPreview={vi.fn()}
+        onOpenContainingFolder={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Browse path.ts' }))
+    const entry = await screen.findByRole('button', { name: 'other.ts' })
+
+    rerender(
+      <EditorPanelHeaderPath
+        activeFile={{ ...file, isDirty: true }}
+        canShowMarkdownPreview={false}
+        onOpenMarkdownPreview={vi.fn()}
+        onOpenContainingFolder={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'other.ts' })).toBe(entry)
+    expect(readRuntimeDirectory).toHaveBeenCalledOnce()
+  })
+
+  it('keeps path context-menu actions reachable', () => {
+    const file = makeOpenFile()
+    const onOpenContainingFolder = vi.fn()
+    render(
+      <EditorPanelHeaderPath
+        activeFile={file}
+        canShowMarkdownPreview={false}
+        onOpenMarkdownPreview={vi.fn()}
+        onOpenContainingFolder={onOpenContainingFolder}
+      />
+    )
+    fireEvent.contextMenu(document.querySelector('.editor-header-path-row')!)
+    fireEvent.click(screen.getByText('Copy Path'))
+    fireEvent.click(screen.getByText('Copy Relative Path'))
+    fireEvent.click(screen.getByText(/Reveal in|Open Containing Folder/))
+    expect(writeClipboardText).toHaveBeenNthCalledWith(1, file.filePath)
+    expect(writeClipboardText).toHaveBeenNthCalledWith(2, file.relativePath)
+    expect(onOpenContainingFolder).toHaveBeenCalledOnce()
+  })
+
+  it('remounts breadcrumbs when the active file changes', async () => {
+    let resolveOldListing!: (entries: unknown[]) => void
+    readRuntimeDirectory.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveOldListing = resolve))
+    )
+    const firstFile = makeOpenFile()
+    const secondFile = makeOpenFile({
+      id: '/repo/docs/README.md',
+      filePath: '/repo/docs/README.md',
+      relativePath: 'docs/README.md',
+      language: 'markdown'
+    })
+    const { rerender } = render(
+      <EditorPanelHeaderPath
+        activeFile={firstFile}
+        canShowMarkdownPreview={false}
+        onOpenMarkdownPreview={vi.fn()}
+        onOpenContainingFolder={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Browse path.ts' }))
+
+    rerender(
+      <EditorPanelHeaderPath
+        activeFile={secondFile}
+        canShowMarkdownPreview={false}
+        onOpenMarkdownPreview={vi.fn()}
+        onOpenContainingFolder={vi.fn()}
+      />
+    )
+    resolveOldListing([{ name: 'stale.ts', isDirectory: false, isSymlink: false }])
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'stale.ts' })).toBeNull())
+    expect(screen.getByRole('button', { name: 'Browse README.md' })).toBeTruthy()
+  })
+})

--- a/src/renderer/src/components/editor/EditorPanelHeaderPath.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeaderPath.test.tsx
@@ -319,7 +319,9 @@ describe('EditorPanelHeaderPath', () => {
   })
 
   it('keeps an open listing mounted when unrelated file state changes', async () => {
-    const file = makeOpenFile()
+    const file = makeOpenFile({
+      operationProvenance: { marker: 'same-owner' } as never
+    })
     const { rerender } = render(
       <EditorPanelHeaderPath
         activeFile={file}
@@ -333,7 +335,11 @@ describe('EditorPanelHeaderPath', () => {
 
     rerender(
       <EditorPanelHeaderPath
-        activeFile={{ ...file, isDirty: true }}
+        activeFile={{
+          ...file,
+          isDirty: true,
+          operationProvenance: { ...file.operationProvenance } as never
+        }}
         canShowMarkdownPreview={false}
         onOpenMarkdownPreview={vi.fn()}
         onOpenContainingFolder={vi.fn()}
@@ -342,6 +348,48 @@ describe('EditorPanelHeaderPath', () => {
 
     expect(screen.getByRole('button', { name: 'other.ts' })).toBe(entry)
     expect(readRuntimeDirectory).toHaveBeenCalledOnce()
+  })
+
+  it('refuses to open a stale listing after the file owner changes', async () => {
+    const file = makeOpenFile({
+      externalSshTargetId: 'ssh-1',
+      operationProvenance: { marker: 'ssh-1' } as never
+    })
+    const { rerender } = render(
+      <EditorPanelHeaderPath
+        activeFile={file}
+        canShowMarkdownPreview={false}
+        onOpenMarkdownPreview={vi.fn()}
+        onOpenContainingFolder={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Browse path.ts' }))
+    const entry = await screen.findByRole('button', { name: 'other.ts' })
+
+    rerender(
+      <EditorPanelHeaderPath
+        activeFile={{
+          ...file,
+          externalSshTargetId: 'ssh-2',
+          operationProvenance: { marker: 'ssh-2' } as never
+        }}
+        canShowMarkdownPreview={false}
+        onOpenMarkdownPreview={vi.fn()}
+        onOpenContainingFolder={vi.fn()}
+      />
+    )
+    getEditorFileOperationContext.mockImplementation(() => {
+      throw new Error('File owner changed')
+    })
+    fireEvent.click(entry)
+
+    expect(openFile).not.toHaveBeenCalled()
+    expect(screen.getByRole('alert').textContent).toContain('File owner changed')
+    expect(getEditorFileOperationContext).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ externalSshTargetId: 'ssh-1' }),
+      '/repo'
+    )
   })
 
   it('keeps path context-menu actions reachable', () => {

--- a/src/renderer/src/components/editor/EditorPanelHeaderPath.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeaderPath.tsx
@@ -13,8 +13,10 @@ import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
 import type { OpenFile } from '@/store/slices/editor'
 import { CLOSE_ALL_CONTEXT_MENUS_EVENT } from '../tab-bar/SortableTab'
+import { EditorHeaderPathBreadcrumbs } from './EditorHeaderPathBreadcrumbs'
 import { useEditorHeaderFileRename } from './editor-header-file-rename'
 import { getEditorHeaderCopyState } from './editor-header'
+import { canNavigateEditorHeaderPath } from './editor-header-path-segments'
 
 const isMac = navigator.userAgent.includes('Mac')
 const isLinux = navigator.userAgent.includes('Linux')
@@ -28,18 +30,14 @@ const revealLabel = isMac
 
 type EditorPanelHeaderPathProps = {
   activeFile: OpenFile
-  copiedPathVisible: boolean
   canShowMarkdownPreview: boolean
-  onCopyPath: () => void
   onOpenMarkdownPreview: () => void
   onOpenContainingFolder: () => void
 }
 
 export function EditorPanelHeaderPath({
   activeFile,
-  copiedPathVisible,
   canShowMarkdownPreview,
-  onCopyPath,
   onOpenMarkdownPreview,
   onOpenContainingFolder
 }: EditorPanelHeaderPathProps): React.JSX.Element {
@@ -47,7 +45,7 @@ export function EditorPanelHeaderPath({
   const [pathMenuPoint, setPathMenuPoint] = useState({ x: 0, y: 0 })
   const skipMenuFocusRestoreRef = useRef(false)
   const headerCopyState = getEditorHeaderCopyState(activeFile)
-  const canCopyHeaderPath = headerCopyState.copyText !== null
+  const canNavigatePath = canNavigateEditorHeaderPath(activeFile)
   const isVirtualEditorTab = activeFile.mode === 'check-details'
   const markdownPreviewShortcutLabel = useShortcutLabel('editor.markdownPreview')
   const {
@@ -108,23 +106,22 @@ export function EditorPanelHeaderPath({
             }}
             onBlur={commitRename}
           />
+        ) : canNavigatePath ? (
+          <EditorHeaderPathBreadcrumbs
+            key={activeFile.id}
+            activeFile={activeFile}
+            pathTitle={headerCopyState.pathTitle}
+          />
         ) : (
           <button
             type="button"
-            className={`editor-header-path${canCopyHeaderPath ? '' : ' editor-header-path--static'}`}
-            onClick={canCopyHeaderPath ? onCopyPath : undefined}
-            disabled={!canCopyHeaderPath}
+            className="editor-header-path editor-header-path--static"
+            disabled
             title={headerCopyState.pathTitle}
           >
             {headerCopyState.pathLabel}
           </button>
         )}
-        <span
-          className={`editor-header-copy-toast${copiedPathVisible ? ' is-visible' : ''}`}
-          aria-live="polite"
-        >
-          {headerCopyState.copyToastLabel}
-        </span>
       </div>
       <DropdownMenu open={pathMenuOpen} onOpenChange={setPathMenuOpen} modal={false}>
         <DropdownMenuTrigger asChild>

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -20,7 +20,6 @@ type EditorPanelShellProps = {
   activeFile: OpenFile
   activeViewStateId: string | null | undefined
   model: EditorPanelRenderModel
-  copiedPathVisible: boolean
   showMarkdownTableOfContents: boolean
   canShowMarkdownFrontmatterToggle: boolean
   markdownFrontmatterVisible: boolean
@@ -33,7 +32,6 @@ type EditorPanelShellProps = {
   renameDialogFile: OpenFile | null
   renameError: string | null
   disableRenameBrowse: boolean
-  onCopyPath: () => void
   onOpenDiffTargetFile: (preferredMarkdownViewMode?: 'rich') => void
   onOpenPreviewToSide: () => void
   onOpenMarkdownPreview: () => void
@@ -61,7 +59,6 @@ export function EditorPanelShell({
   activeFile,
   activeViewStateId,
   model,
-  copiedPathVisible,
   showMarkdownTableOfContents,
   canShowMarkdownFrontmatterToggle,
   markdownFrontmatterVisible,
@@ -74,7 +71,6 @@ export function EditorPanelShell({
   renameDialogFile,
   renameError,
   disableRenameBrowse,
-  onCopyPath,
   onOpenDiffTargetFile,
   onOpenPreviewToSide,
   onOpenMarkdownPreview,
@@ -101,7 +97,6 @@ export function EditorPanelShell({
       {shouldShowEditorPanelHeader(activeFile, model.isCombinedDiff) && (
         <EditorPanelHeader
           activeFile={activeFile}
-          copiedPathVisible={copiedPathVisible}
           isSingleDiff={model.isSingleDiff}
           isDiffSurface={model.isDiffSurface}
           isMarkdown={model.isMarkdown}
@@ -121,7 +116,6 @@ export function EditorPanelShell({
           markdownFrontmatterVisible={markdownFrontmatterVisible}
           sideBySide={sideBySide}
           openFileState={model.openFileState}
-          onCopyPath={onCopyPath}
           onOpenDiffTargetFile={onOpenDiffTargetFile}
           onOpenPreviewToSide={onOpenPreviewToSide}
           onOpenMarkdownPreview={onOpenMarkdownPreview}

--- a/src/renderer/src/components/editor/editor-header-path-directory.test.ts
+++ b/src/renderer/src/components/editor/editor-header-path-directory.test.ts
@@ -110,6 +110,16 @@ describe('listEditorHeaderDirectory', () => {
 })
 
 describe('openEditorHeaderPathFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getState.mockReturnValue({
+      settings: {},
+      openFiles: [],
+      unifiedTabsByWorktree: {},
+      activateTab
+    })
+  })
+
   it('opens an ordinary file in the current group', () => {
     const openFile = vi.fn()
     const openMarkdownPreview = vi.fn()

--- a/src/renderer/src/components/editor/editor-header-path-directory.test.ts
+++ b/src/renderer/src/components/editor/editor-header-path-directory.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+
+const readRuntimeDirectory = vi.hoisted(() => vi.fn())
+const getEditorFileOperationContext = vi.hoisted(() => vi.fn())
+const getState = vi.hoisted(() => vi.fn())
+
+vi.mock('@/runtime/runtime-file-client', () => ({
+  readRuntimeDirectory: (...args: unknown[]) => readRuntimeDirectory(...args)
+}))
+vi.mock('@/lib/editor-file-operation-owner', () => ({
+  getEditorFileOperationContext: (...args: unknown[]) => getEditorFileOperationContext(...args)
+}))
+vi.mock('@/store', () => ({
+  useAppStore: { getState: () => getState() }
+}))
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+import {
+  joinEditorHeaderPathEntry,
+  listEditorHeaderDirectory,
+  openEditorHeaderPathFile
+} from './editor-header-path-directory'
+
+const file: Pick<
+  OpenFile,
+  'mode' | 'worktreeId' | 'runtimeEnvironmentId' | 'externalSshTargetId' | 'operationProvenance'
+> = {
+  mode: 'edit',
+  worktreeId: 'wt-1'
+}
+
+const activateTab = vi.fn()
+
+describe('listEditorHeaderDirectory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getState.mockReturnValue({
+      settings: {},
+      openFiles: [],
+      unifiedTabsByWorktree: {},
+      activateTab
+    })
+    getEditorFileOperationContext.mockReturnValue({
+      settings: {},
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      expectedExecutionHostId: 'local'
+    })
+  })
+
+  it('filters hidden tree entries and sorts folders first', async () => {
+    readRuntimeDirectory.mockResolvedValueOnce([
+      { name: 'z.ts', isDirectory: false, isSymlink: false },
+      { name: '.git', isDirectory: true, isSymlink: false },
+      { name: 'node_modules', isDirectory: true, isSymlink: false },
+      { name: '10 - dir', isDirectory: true, isSymlink: false },
+      { name: '9 - a.ts', isDirectory: false, isSymlink: false }
+    ])
+
+    await expect(listEditorHeaderDirectory(file, '/repo', '/repo/src')).resolves.toEqual({
+      status: 'ok',
+      entries: [
+        { name: '10 - dir', isDirectory: true, isSymlink: false },
+        { name: '9 - a.ts', isDirectory: false, isSymlink: false },
+        { name: 'z.ts', isDirectory: false, isSymlink: false }
+      ]
+    })
+    expect(readRuntimeDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: 'wt-1', worktreePath: '/repo' }),
+      '/repo/src'
+    )
+  })
+
+  it('returns a visible listing error instead of throwing', async () => {
+    readRuntimeDirectory.mockRejectedValueOnce(new Error('EACCES'))
+    await expect(listEditorHeaderDirectory(file, '/repo', '/repo/src')).resolves.toEqual({
+      status: 'error',
+      message: 'EACCES'
+    })
+  })
+
+  it('passes the open file owner into the existing readDir route', async () => {
+    const sshFile = {
+      ...file,
+      runtimeEnvironmentId: 'env-1',
+      externalSshTargetId: 'ssh-1'
+    }
+    readRuntimeDirectory.mockResolvedValueOnce([])
+    await listEditorHeaderDirectory(sshFile, '/remote/repo', '/remote/repo/src')
+    expect(getEditorFileOperationContext).toHaveBeenCalledWith(
+      expect.anything(),
+      sshFile,
+      '/remote/repo'
+    )
+    expect(readRuntimeDirectory).toHaveBeenCalledWith(expect.anything(), '/remote/repo/src')
+  })
+
+  it('surfaces owner-resolution failures in the listing', async () => {
+    getEditorFileOperationContext.mockImplementationOnce(() => {
+      throw new Error("Couldn't verify which host owns this file.")
+    })
+    await expect(listEditorHeaderDirectory(file, '/repo', '/repo/src')).resolves.toEqual({
+      status: 'error',
+      message: "Couldn't verify which host owns this file."
+    })
+  })
+})
+
+describe('openEditorHeaderPathFile', () => {
+  it('opens an ordinary file in the current group', () => {
+    const openFile = vi.fn()
+    const openMarkdownPreview = vi.fn()
+    const target = joinEditorHeaderPathEntry('/repo/src/lib', 'src/lib', 'other.ts')
+
+    openEditorHeaderPathFile({
+      currentFile: file,
+      ...target,
+      targetGroupId: 'group-1',
+      openFile,
+      openMarkdownPreview
+    })
+
+    expect(openMarkdownPreview).not.toHaveBeenCalled()
+    expect(openFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '/repo/src/lib/other.ts',
+        relativePath: 'src/lib/other.ts',
+        worktreeId: 'wt-1',
+        language: 'typescript',
+        mode: 'edit'
+      }),
+      { targetGroupId: 'group-1' }
+    )
+  })
+
+  it('keeps markdown preview when the current tab is a preview of markdown', () => {
+    const openFile = vi.fn()
+    const openMarkdownPreview = vi.fn()
+    const target = joinEditorHeaderPathEntry('/repo/docs', 'docs', 'guide.md')
+
+    openEditorHeaderPathFile({
+      currentFile: { ...file, mode: 'markdown-preview' },
+      ...target,
+      targetGroupId: 'group-1',
+      openFile,
+      openMarkdownPreview
+    })
+
+    expect(openFile).not.toHaveBeenCalled()
+    expect(openMarkdownPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '/repo/docs/guide.md',
+        relativePath: 'docs/guide.md',
+        language: 'markdown',
+        worktreeId: 'wt-1'
+      }),
+      { targetGroupId: 'group-1' }
+    )
+  })
+
+  it.each([
+    ['edit' as const, '/repo/src/lib/other.ts', 'other.ts'],
+    ['markdown-preview' as const, '/repo/docs/guide.md', 'guide.md']
+  ])('activates an existing %s tab in another split group', (mode, filePath, name) => {
+    const existingId = mode === 'edit' ? filePath : `markdown-preview::${filePath}`
+    getState.mockReturnValue({
+      settings: {},
+      openFiles: [
+        {
+          id: existingId,
+          filePath,
+          relativePath: name,
+          worktreeId: 'wt-1',
+          language: mode === 'edit' ? 'typescript' : 'markdown',
+          isDirty: false,
+          mode
+        }
+      ],
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'unified-existing',
+            entityId: existingId,
+            groupId: 'group-2',
+            contentType: 'editor'
+          }
+        ]
+      },
+      activateTab
+    })
+    const openFile = vi.fn()
+    const openMarkdownPreview = vi.fn()
+
+    openEditorHeaderPathFile({
+      currentFile: { ...file, mode },
+      filePath,
+      relativePath: name,
+      targetGroupId: 'group-1',
+      openFile,
+      openMarkdownPreview
+    })
+
+    expect(activateTab).toHaveBeenCalledWith('unified-existing')
+    const opener = mode === 'edit' ? openFile : openMarkdownPreview
+    expect(opener).toHaveBeenCalledWith(expect.anything(), { targetGroupId: 'group-2' })
+  })
+})

--- a/src/renderer/src/components/editor/editor-header-path-directory.ts
+++ b/src/renderer/src/components/editor/editor-header-path-directory.ts
@@ -1,0 +1,131 @@
+import { detectLanguage } from '@/lib/language-detect'
+import { extractIpcErrorMessage } from '@/lib/ipc-error'
+import { getEditorFileOperationContext } from '@/lib/editor-file-operation-owner'
+import { joinPath, normalizeRelativePath } from '@/lib/path'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import type { OpenFile } from '@/store/slices/editor'
+import { isSameEditorOwner } from '@/store/slices/editor/file-ids/editor-file-ids'
+import { readRuntimeDirectory } from '@/runtime/runtime-file-client'
+import { sortDirEntries } from '../../../../shared/file-name-sort'
+import type { DirEntry } from '../../../../shared/filesystem-entry-types'
+import { shouldIncludeFileExplorerEntry } from '../right-sidebar/file-explorer-entries'
+import { getEditorHeaderPathOpenKind } from './editor-header-path-segments'
+
+export type EditorHeaderDirectoryListing =
+  | { status: 'ok'; entries: DirEntry[] }
+  | { status: 'error'; message: string }
+
+type EditorHeaderPathOwnerFile = Pick<
+  OpenFile,
+  'worktreeId' | 'runtimeEnvironmentId' | 'externalSshTargetId' | 'operationProvenance'
+>
+
+export async function listEditorHeaderDirectory(
+  file: EditorHeaderPathOwnerFile,
+  worktreePath: string | null,
+  directoryAbsolutePath: string
+): Promise<EditorHeaderDirectoryListing> {
+  try {
+    const context = getEditorFileOperationContext(useAppStore.getState(), file, worktreePath)
+    const entries = await readRuntimeDirectory(context, directoryAbsolutePath)
+    return {
+      status: 'ok',
+      entries: sortDirEntries(entries.filter(shouldIncludeFileExplorerEntry))
+    }
+  } catch (error) {
+    return {
+      status: 'error',
+      message: extractIpcErrorMessage(
+        error,
+        translate(
+          'auto.components.editor.EditorPanelHeaderPath.7e2c1a9b04',
+          'Could not list this folder.'
+        )
+      )
+    }
+  }
+}
+
+export function joinEditorHeaderPathEntry(
+  directoryAbsolutePath: string,
+  directoryRelativePath: string,
+  entryName: string
+): { filePath: string; relativePath: string } {
+  return {
+    filePath: joinPath(directoryAbsolutePath, entryName),
+    relativePath: normalizeRelativePath(
+      directoryRelativePath ? `${directoryRelativePath}/${entryName}` : entryName
+    )
+  }
+}
+
+export function openEditorHeaderPathFile(args: {
+  currentFile: Pick<
+    OpenFile,
+    'mode' | 'worktreeId' | 'runtimeEnvironmentId' | 'externalSshTargetId' | 'operationProvenance'
+  >
+  filePath: string
+  relativePath: string
+  targetGroupId?: string
+  openFile: (file: Omit<OpenFile, 'id' | 'isDirty'>, options?: { targetGroupId?: string }) => string
+  openMarkdownPreview: (
+    file: Pick<
+      OpenFile,
+      | 'filePath'
+      | 'relativePath'
+      | 'worktreeId'
+      | 'language'
+      | 'runtimeEnvironmentId'
+      | 'externalSshTargetId'
+    >,
+    options?: { targetGroupId?: string }
+  ) => void
+}): void {
+  const language = detectLanguage(args.relativePath)
+  const kind = getEditorHeaderPathOpenKind(args.currentFile.mode, language)
+  const state = useAppStore.getState()
+  const existingFile = state.openFiles.find(
+    (file) =>
+      file.filePath === args.filePath &&
+      file.mode === kind &&
+      isSameEditorOwner(file, args.currentFile.worktreeId, args.currentFile.runtimeEnvironmentId)
+  )
+  const existingTab = existingFile
+    ? (state.unifiedTabsByWorktree[args.currentFile.worktreeId] ?? []).find(
+        (tab) => tab.entityId === existingFile.id && tab.contentType === 'editor'
+      )
+    : undefined
+  if (existingTab) {
+    state.activateTab(existingTab.id)
+  }
+  const targetGroupId = existingTab?.groupId ?? args.targetGroupId
+  if (kind === 'markdown-preview') {
+    args.openMarkdownPreview(
+      {
+        filePath: args.filePath,
+        relativePath: args.relativePath,
+        worktreeId: args.currentFile.worktreeId,
+        language,
+        runtimeEnvironmentId: args.currentFile.runtimeEnvironmentId,
+        externalSshTargetId: args.currentFile.externalSshTargetId
+      },
+      targetGroupId === undefined ? undefined : { targetGroupId }
+    )
+    return
+  }
+
+  args.openFile(
+    {
+      filePath: args.filePath,
+      relativePath: args.relativePath,
+      worktreeId: args.currentFile.worktreeId,
+      language,
+      mode: 'edit',
+      runtimeEnvironmentId: args.currentFile.runtimeEnvironmentId,
+      externalSshTargetId: args.currentFile.externalSshTargetId,
+      operationProvenance: args.currentFile.operationProvenance
+    },
+    targetGroupId === undefined ? undefined : { targetGroupId }
+  )
+}

--- a/src/renderer/src/components/editor/editor-header-path-segments.test.ts
+++ b/src/renderer/src/components/editor/editor-header-path-segments.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import {
+  canNavigateEditorHeaderPath,
+  getEditorHeaderPathOpenKind,
+  getEditorHeaderPathPreviewSuffix,
+  getEditorHeaderPathSegments,
+  isEditorHeaderPathCurrentEntry,
+  resolveEditorHeaderDirectoryAbsolutePath
+} from './editor-header-path-segments'
+
+function makeOpenFile(overrides: Partial<OpenFile> = {}): OpenFile {
+  return {
+    id: '/repo/src/lib/path.ts',
+    filePath: '/repo/src/lib/path.ts',
+    relativePath: 'src/lib/path.ts',
+    worktreeId: 'wt-1',
+    language: 'typescript',
+    isDirty: false,
+    mode: 'edit',
+    ...overrides
+  }
+}
+
+describe('canNavigateEditorHeaderPath', () => {
+  it('allows real file tabs and rejects virtual tabs', () => {
+    expect(canNavigateEditorHeaderPath(makeOpenFile({ mode: 'edit' }))).toBe(true)
+    expect(canNavigateEditorHeaderPath(makeOpenFile({ mode: 'markdown-preview' }))).toBe(true)
+    expect(canNavigateEditorHeaderPath(makeOpenFile({ mode: 'diff' }))).toBe(false)
+    expect(canNavigateEditorHeaderPath(makeOpenFile({ mode: 'conflict-review' }))).toBe(false)
+    expect(canNavigateEditorHeaderPath(makeOpenFile({ mode: 'check-details' }))).toBe(false)
+  })
+
+  it('keeps absolute relative paths static across runtime path flavors', () => {
+    expect(canNavigateEditorHeaderPath(makeOpenFile({ relativePath: '/outside/file.ts' }))).toBe(
+      false
+    )
+    expect(
+      canNavigateEditorHeaderPath(makeOpenFile({ relativePath: 'C:\\outside\\file.ts' }))
+    ).toBe(false)
+    expect(
+      canNavigateEditorHeaderPath(makeOpenFile({ relativePath: '\\\\server\\share\\file.ts' }))
+    ).toBe(false)
+  })
+})
+
+describe('getEditorHeaderPathSegments', () => {
+  it('splits posix worktree-relative paths and lists the file parent for the filename', () => {
+    const segments = getEditorHeaderPathSegments(makeOpenFile())
+    expect(segments).toEqual([
+      { id: 'src', label: 'src', relativeDirectoryPath: 'src', isFile: false },
+      { id: 'src/lib', label: 'lib', relativeDirectoryPath: 'src/lib', isFile: false },
+      { id: 'src/lib/path.ts', label: 'path.ts', relativeDirectoryPath: 'src/lib', isFile: true }
+    ])
+  })
+
+  it('splits Windows worktree-relative paths', () => {
+    const segments = getEditorHeaderPathSegments(
+      makeOpenFile({
+        filePath: 'C:\\repo\\src\\lib\\path.ts',
+        relativePath: 'src\\lib\\path.ts'
+      })
+    )
+    expect(segments?.map((segment) => segment.label)).toEqual(['src', 'lib', 'path.ts'])
+    expect(segments?.[2]).toMatchObject({
+      label: 'path.ts',
+      relativeDirectoryPath: 'src/lib',
+      isFile: true
+    })
+  })
+
+  it('keeps a root file as a single segment that lists the worktree root', () => {
+    expect(
+      getEditorHeaderPathSegments(
+        makeOpenFile({ relativePath: 'README.md', filePath: '/repo/README.md' })
+      )
+    ).toEqual([{ id: 'README.md', label: 'README.md', relativeDirectoryPath: '', isFile: true }])
+  })
+
+  it('does not turn the preview suffix into a path segment', () => {
+    const file = makeOpenFile({
+      id: 'markdown-preview::/repo/docs/README.md',
+      filePath: '/repo/docs/README.md',
+      relativePath: 'docs/README.md',
+      language: 'markdown',
+      mode: 'markdown-preview'
+    })
+    const segments = getEditorHeaderPathSegments(file)
+    expect(segments?.map((segment) => segment.label)).toEqual(['docs', 'README.md'])
+    expect(getEditorHeaderPathPreviewSuffix(file)).toBe(' (preview)')
+    expect(segments?.some((segment) => segment.label.includes('preview'))).toBe(false)
+  })
+
+  it('returns no segments for virtual tabs', () => {
+    expect(getEditorHeaderPathSegments(makeOpenFile({ mode: 'diff' }))).toBeNull()
+    expect(getEditorHeaderPathSegments(makeOpenFile({ mode: 'conflict-review' }))).toBeNull()
+    expect(getEditorHeaderPathSegments(makeOpenFile({ mode: 'check-details' }))).toBeNull()
+  })
+})
+
+describe('resolveEditorHeaderDirectoryAbsolutePath', () => {
+  it('joins posix and Windows worktree roots', () => {
+    const file = makeOpenFile()
+    expect(resolveEditorHeaderDirectoryAbsolutePath(file, '/repo', 'src/lib')).toBe('/repo/src/lib')
+    expect(resolveEditorHeaderDirectoryAbsolutePath(file, '/repo', '')).toBe('/repo')
+    expect(
+      resolveEditorHeaderDirectoryAbsolutePath(
+        makeOpenFile({
+          filePath: 'C:\\repo\\src\\lib\\path.ts',
+          relativePath: 'src\\lib\\path.ts'
+        }),
+        'C:\\repo',
+        'src/lib'
+      )
+    ).toBe('C:\\repo\\src\\lib')
+  })
+
+  it('uses a folder workspace root the same way as a git worktree root', () => {
+    expect(
+      resolveEditorHeaderDirectoryAbsolutePath(
+        makeOpenFile({
+          worktreeId: 'folder::notes',
+          filePath: '/Users/me/notes/docs/todo.md',
+          relativePath: 'docs/todo.md'
+        }),
+        '/Users/me/notes',
+        'docs'
+      )
+    ).toBe('/Users/me/notes/docs')
+  })
+})
+
+describe('isEditorHeaderPathCurrentEntry', () => {
+  it('matches the current file across Windows path flavors', () => {
+    expect(
+      isEditorHeaderPathCurrentEntry('/repo/src/lib', 'path.ts', '/repo/src/lib/path.ts')
+    ).toBe(true)
+    expect(
+      isEditorHeaderPathCurrentEntry('C:\\repo\\src\\lib', 'path.ts', 'C:\\repo\\src\\lib\\path.ts')
+    ).toBe(true)
+    expect(
+      isEditorHeaderPathCurrentEntry('/repo/src/lib', 'other.ts', '/repo/src/lib/path.ts')
+    ).toBe(false)
+  })
+})
+
+describe('getEditorHeaderPathOpenKind', () => {
+  it('keeps markdown preview only when the current tab is already a preview of markdown', () => {
+    expect(getEditorHeaderPathOpenKind('markdown-preview', 'markdown')).toBe('markdown-preview')
+    expect(getEditorHeaderPathOpenKind('markdown-preview', 'typescript')).toBe('edit')
+    expect(getEditorHeaderPathOpenKind('edit', 'markdown')).toBe('edit')
+  })
+})

--- a/src/renderer/src/components/editor/editor-header-path-segments.ts
+++ b/src/renderer/src/components/editor/editor-header-path-segments.ts
@@ -1,0 +1,76 @@
+import { joinPath } from '@/lib/path'
+import {
+  isRuntimePathAbsolute,
+  normalizeRuntimePathForComparison
+} from '../../../../shared/cross-platform-path'
+import type { OpenFile } from '@/store/slices/editor'
+import { getUntitledFileRoot } from './untitled-file-rename-path'
+
+export type EditorHeaderPathSegment = {
+  id: string
+  label: string
+  relativeDirectoryPath: string
+  isFile: boolean
+}
+
+const PREVIEW_SUFFIX = ' (preview)'
+
+export function canNavigateEditorHeaderPath(
+  file: Pick<OpenFile, 'mode' | 'relativePath'>
+): boolean {
+  return (
+    (file.mode === 'edit' || file.mode === 'markdown-preview') &&
+    !isRuntimePathAbsolute(file.relativePath)
+  )
+}
+
+export function getEditorHeaderPathPreviewSuffix(file: Pick<OpenFile, 'mode'>): string | null {
+  return file.mode === 'markdown-preview' ? PREVIEW_SUFFIX : null
+}
+
+export function getEditorHeaderPathSegments(
+  file: Pick<OpenFile, 'mode' | 'relativePath'>
+): EditorHeaderPathSegment[] | null {
+  if (!canNavigateEditorHeaderPath(file)) {
+    return null
+  }
+
+  const parts = file.relativePath.split(/[\\/]+/).filter(Boolean)
+  return parts.map((label, index) => {
+    const isFile = index === parts.length - 1
+    const directoryParts = isFile ? parts.slice(0, -1) : parts.slice(0, index + 1)
+    return {
+      id: parts.slice(0, index + 1).join('/'),
+      label,
+      relativeDirectoryPath: directoryParts.join('/'),
+      isFile
+    }
+  })
+}
+
+export function resolveEditorHeaderDirectoryAbsolutePath(
+  file: Pick<OpenFile, 'filePath' | 'relativePath'>,
+  worktreePath: string | null | undefined,
+  relativeDirectoryPath: string
+): string {
+  const root = worktreePath?.trim() || getUntitledFileRoot(file, worktreePath)
+  return relativeDirectoryPath ? joinPath(root, relativeDirectoryPath) : root
+}
+
+export function isEditorHeaderPathCurrentEntry(
+  listingDirectoryAbsolutePath: string,
+  entryName: string,
+  currentFilePath: string
+): boolean {
+  return (
+    normalizeRuntimePathForComparison(joinPath(listingDirectoryAbsolutePath, entryName)) ===
+    normalizeRuntimePathForComparison(currentFilePath)
+  )
+}
+
+export function getEditorHeaderPathOpenKind(
+  currentMode: OpenFile['mode'],
+  language: string
+): 'edit' | 'markdown-preview' {
+  return currentMode === 'markdown-preview' && language === 'markdown' ? 'markdown-preview' : 'edit'
+}

--- a/src/renderer/src/components/editor/editor-header.test.ts
+++ b/src/renderer/src/components/editor/editor-header.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { getEditorHeaderCopyState, getEditorHeaderOpenFileState } from './editor-header'
+import { canNavigateEditorHeaderPath } from './editor-header-path-segments'
 import type { OpenFile } from '@/store/slices/editor'
 
 function makeOpenFile(overrides: Partial<OpenFile> = {}): OpenFile {
@@ -18,8 +19,6 @@ function makeOpenFile(overrides: Partial<OpenFile> = {}): OpenFile {
 describe('getEditorHeaderCopyState', () => {
   it('shows the absolute file path for normal file tabs', () => {
     expect(getEditorHeaderCopyState(makeOpenFile())).toEqual({
-      copyText: '/repo/file.ts',
-      copyToastLabel: 'File path copied',
       pathLabel: '/repo/file.ts',
       pathTitle: '/repo/file.ts'
     })
@@ -35,8 +34,6 @@ describe('getEditorHeaderCopyState', () => {
         })
       )
     ).toEqual({
-      copyText: '/repo/file.ts',
-      copyToastLabel: 'File path copied',
       pathLabel: '/repo/file.ts (diff)',
       pathTitle: '/repo/file.ts (diff)'
     })
@@ -52,8 +49,6 @@ describe('getEditorHeaderCopyState', () => {
         })
       )
     ).toEqual({
-      copyText: '/repo/file.ts',
-      copyToastLabel: 'File path copied',
       pathLabel: '/repo/file.ts (staged diff)',
       pathTitle: '/repo/file.ts (staged diff)'
     })
@@ -83,8 +78,6 @@ describe('getEditorHeaderCopyState', () => {
         })
       )
     ).toEqual({
-      copyText: null,
-      copyToastLabel: 'Check details copied',
       pathLabel: 'verify',
       pathTitle: 'verify'
     })
@@ -102,11 +95,19 @@ describe('getEditorHeaderCopyState', () => {
         })
       )
     ).toEqual({
-      copyText: '/repo/worktree',
-      copyToastLabel: 'Worktree path copied',
       pathLabel: 'All Changes',
       pathTitle: '/repo/worktree'
     })
+  })
+})
+
+describe('canNavigateEditorHeaderPath', () => {
+  it('is only true for real file tabs', () => {
+    expect(canNavigateEditorHeaderPath(makeOpenFile({ mode: 'edit' }))).toBe(true)
+    expect(canNavigateEditorHeaderPath(makeOpenFile({ mode: 'markdown-preview' }))).toBe(true)
+    expect(canNavigateEditorHeaderPath(makeOpenFile({ mode: 'diff' }))).toBe(false)
+    expect(canNavigateEditorHeaderPath(makeOpenFile({ mode: 'conflict-review' }))).toBe(false)
+    expect(canNavigateEditorHeaderPath(makeOpenFile({ mode: 'check-details' }))).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/editor/editor-header.ts
+++ b/src/renderer/src/components/editor/editor-header.ts
@@ -4,8 +4,6 @@ import type { GitStatusEntry } from '../../../../shared/git-status-types'
 import { getEditorDisplayLabel } from './editor-labels'
 
 export type EditorHeaderCopyState = {
-  copyText: string | null
-  copyToastLabel: string
   pathLabel: string
   pathTitle: string
 }
@@ -22,8 +20,6 @@ export function shouldShowEditorPanelHeader(file: OpenFile, isCombinedDiff: bool
 export function getEditorHeaderCopyState(file: OpenFile): EditorHeaderCopyState {
   if (file.mode === 'conflict-review') {
     return {
-      copyText: file.filePath,
-      copyToastLabel: 'Worktree path copied',
       pathLabel: 'Conflict Review',
       pathTitle: file.filePath
     }
@@ -32,8 +28,6 @@ export function getEditorHeaderCopyState(file: OpenFile): EditorHeaderCopyState 
   if (file.mode === 'check-details') {
     const label = file.checkRunDetails?.check.name ?? 'Check details'
     return {
-      copyText: null,
-      copyToastLabel: 'Check details copied',
       pathLabel: label,
       pathTitle: label
     }
@@ -48,8 +42,6 @@ export function getEditorHeaderCopyState(file: OpenFile): EditorHeaderCopyState 
 
   if (isCombinedDiff) {
     return {
-      copyText: file.filePath,
-      copyToastLabel: 'Worktree path copied',
       pathLabel: file.relativePath,
       pathTitle: file.filePath
     }
@@ -58,8 +50,6 @@ export function getEditorHeaderCopyState(file: OpenFile): EditorHeaderCopyState 
   const displayLabel = getEditorDisplayLabel(file, 'fullPath')
 
   return {
-    copyText: file.filePath,
-    copyToastLabel: 'File path copied',
     pathLabel: displayLabel,
     pathTitle: displayLabel
   }

--- a/src/renderer/src/components/tab-bar/tab-create-entry-classifier.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-create-entry-classifier.test.ts
@@ -587,4 +587,13 @@ describe('tab create entry path validation', () => {
       expect(() => validateNewTabEntryAbsolutePath(path), path).toThrow()
     }
   })
+
+  it('rejects absolute-looking paths with trailing separators or controls', () => {
+    expect(() => validateNewTabEntryAbsolutePath('/tmp/notes.md/', 'posix')).toThrow(
+      'directory path'
+    )
+    expect(() => validateNewTabEntryAbsolutePath('/tmp/notes\u0000.md', 'posix')).toThrow(
+      'control characters'
+    )
+  })
 })

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14617,6 +14617,12 @@
           "2076ecfc9c": "Previous change",
           "631dab0df3": "Next change"
         },
+        "EditorPanelHeaderPath": {
+          "3c8f0d21a6": "Loading…",
+          "5d0a8b17c3": "Browse {{value0}}",
+          "7e2c1a9b04": "Could not list this folder.",
+          "9b14e6c2d0": "This folder is empty."
+        },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "Export as PDF",
           "561251019a": "More actions",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -12879,6 +12879,12 @@
           "2076ecfc9c": "Cambio anterior",
           "631dab0df3": "Cambio siguiente"
         },
+        "EditorPanelHeaderPath": {
+          "3c8f0d21a6": "Cargando…",
+          "5d0a8b17c3": "Explorar {{value0}}",
+          "7e2c1a9b04": "No se pudo listar esta carpeta.",
+          "9b14e6c2d0": "Esta carpeta está vacía."
+        },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "Exportar como PDF",
           "561251019a": "Más acciones",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -12879,6 +12879,12 @@
           "2076ecfc9c": "前の変更",
           "631dab0df3": "次の変更"
         },
+        "EditorPanelHeaderPath": {
+          "3c8f0d21a6": "読み込み中…",
+          "5d0a8b17c3": "{{value0}} を参照",
+          "7e2c1a9b04": "このフォルダーを一覧できませんでした。",
+          "9b14e6c2d0": "このフォルダーは空です。"
+        },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "PDFとしてエクスポート",
           "561251019a": "その他の操作",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -12946,6 +12946,12 @@
           "2076ecfc9c": "이전 변경",
           "631dab0df3": "다음 변경"
         },
+        "EditorPanelHeaderPath": {
+          "3c8f0d21a6": "로드 중…",
+          "5d0a8b17c3": "{{value0}} 찾아보기",
+          "7e2c1a9b04": "이 폴더를 나열할 수 없습니다.",
+          "9b14e6c2d0": "이 폴더는 비어 있습니다."
+        },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "PDF로 내보내기",
           "561251019a": "추가 작업",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -12935,6 +12935,13 @@
           "2076ecfc9c": "上一个更改",
           "631dab0df3": "下一个更改"
         },
+        "EditorPanelHeaderPath": {
+          "3c8f0d21a6": "正在加载…",
+          "5d0a8b17c3": "浏览 {{value0}}",
+          "7e2c1a9b04": "无法列出此文件夹。",
+          "9b14e6c2d0": "此文件夹为空。"
+        },
+
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "导出为 PDF",
           "561251019a": "更多操作",

--- a/tests/e2e/golden-file-open-edit-save.spec.ts
+++ b/tests/e2e/golden-file-open-edit-save.spec.ts
@@ -41,11 +41,16 @@ test('@golden opens, edits, saves, and reopens a tracked file', async ({
   await expect(editorHeaderPath).toContainText(README_PATH, {
     timeout: 20_000
   })
+  const editor = orcaPage.locator('.rich-markdown-editor')
+  await expect(editor).toBeVisible({ timeout: 25_000 })
+  await expect(editor).toContainText('Orca E2E Test Repo')
+
   await editorHeaderPath.locator('.editor-header-path-segment-current').click()
   const packageEntry = orcaPage.locator('[data-editor-header-path-entry="package.json"]')
   await expect(packageEntry).toBeVisible()
   await packageEntry.click()
   await expect(orcaPage.locator('.editor-header-path').first()).toContainText('package.json')
+  await expect(orcaPage.locator('.monaco-editor').first()).toBeVisible({ timeout: 25_000 })
 
   await editorHeaderPath.locator('.editor-header-path-segment-current').click()
   const readmeEntry = orcaPage.locator(`[data-editor-header-path-entry="${README_PATH}"]`)
@@ -53,9 +58,6 @@ test('@golden opens, edits, saves, and reopens a tracked file', async ({
   await readmeEntry.click()
   await expect(orcaPage.locator('.editor-header-path').first()).toContainText(README_PATH)
 
-  const editor = orcaPage.locator('.rich-markdown-editor')
-  await expect(editor).toBeVisible({ timeout: 25_000 })
-  await expect(editor).toContainText('Orca E2E Test Repo')
   await editor.click()
   await orcaPage.keyboard.press('ControlOrMeta+End')
   await orcaPage.keyboard.press('Enter')

--- a/tests/e2e/golden-file-open-edit-save.spec.ts
+++ b/tests/e2e/golden-file-open-edit-save.spec.ts
@@ -37,9 +37,22 @@ test('@golden opens, edits, saves, and reopens a tracked file', async ({
   await expect(readmeRow).toBeVisible({ timeout: 10_000 })
   await readmeRow.click()
 
-  await expect(orcaPage.locator('.editor-header-path').first()).toContainText(README_PATH, {
+  const editorHeaderPath = orcaPage.locator('.editor-header-path').first()
+  await expect(editorHeaderPath).toContainText(README_PATH, {
     timeout: 20_000
   })
+  await editorHeaderPath.locator('.editor-header-path-segment-current').click()
+  const packageEntry = orcaPage.locator('[data-editor-header-path-entry="package.json"]')
+  await expect(packageEntry).toBeVisible()
+  await packageEntry.click()
+  await expect(orcaPage.locator('.editor-header-path').first()).toContainText('package.json')
+
+  await editorHeaderPath.locator('.editor-header-path-segment-current').click()
+  const readmeEntry = orcaPage.locator(`[data-editor-header-path-entry="${README_PATH}"]`)
+  await expect(readmeEntry).toBeVisible()
+  await readmeEntry.click()
+  await expect(orcaPage.locator('.editor-header-path').first()).toContainText(README_PATH)
+
   const editor = orcaPage.locator('.rich-markdown-editor')
   await expect(editor).toBeVisible({ timeout: 25_000 })
   await expect(editor).toContainText('Orca E2E Test Repo')
@@ -51,7 +64,7 @@ test('@golden opens, edits, saves, and reopens a tracked file', async ({
 
   await expect.poll(() => readFileSync(readmePath, 'utf8'), { timeout: 10_000 }).toContain(sentinel)
   const readmeTab = orcaPage.locator('[data-tab-id]').filter({ hasText: README_PATH }).last()
-  await readmeTab.getByRole('button', { name: 'Close tab' }).click()
+  await readmeTab.locator('[data-tab-close-button="true"]').click()
   await expect(
     orcaPage.locator('.editor-header-path').filter({ hasText: README_PATH })
   ).toHaveCount(0)


### PR DESCRIPTION
## Summary

This PR contains two related editor navigation improvements:

- Quick Open accepts valid local absolute file paths and opens them through the existing authorization and runtime stat checks.
- The editor path header exposes browsable path segments for opening sibling files. The old single-click copy behavior was removed; copying remains available from the path context menu.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/QuickOpen.mount-gating.test.tsx src/renderer/src/components/tab-bar/tab-create-entry-action.test.ts`
- `pnpm exec oxlint src/renderer/src/components/QuickOpen.tsx --deny-warnings`
- `git diff --check`
- Electron Quick Open E2E built and rendered the dialog; the existing assertion expected English labels while the test environment rendered Chinese labels.
- `pnpm exec tsc --noEmit -p config/tsconfig.web.json` remains blocked by existing TS6307 project-file-list errors outside this change.

## Review follow-up

- Absolute-path failures now preserve modal return focus.
- Absolute-path permission checks use the existing memoized selector.
- Remote workspaces now show the existing local-workspace requirement instead of No matching files.

Fixes #17356