### PR TITLE
fix(tests): match showInactive() in paired-client-window-reveal spec

### DIFF
--- a/tests/e2e/helpers/paired-client-window-reveal.unit.test.ts
+++ b/tests/e2e/helpers/paired-client-window-reveal.unit.test.ts
@@ -32,13 +32,13 @@ describe('assertPairedClientWindowRevealed', () => {
     ).toThrow(/no BrowserWindow/)
   })
 
-  it('rejects a window that stays hidden after show()', () => {
+  it('rejects a window that stays hidden after showInactive()', () => {
     expect(() =>
       assertPairedClientWindowRevealed({
         isVisible: false,
         wasVisible: false,
         windowCount: 2
       })
-    ).toThrow(/stayed hidden after show\(\)/)
+    ).toThrow(/stayed hidden after showInactive\(\)/)
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | 0 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Problem

`tests/e2e/helpers/paired-client-window-reveal.unit.test.ts` fails deterministically on `main` and on every PR branched from it:

```
AssertionError: expected [Function] to throw error matching /stayed hidden after show\(\)/
but got 'Paired client window stayed hidden af…'
```

## Root cause

#17347 ("keep automated Electron launches out of the foreground", `5ea9daba97f`) changed the helper from `window.show()` to `window.showInactive()` and updated the thrown message to match — but the unit test's regex and title still expect `show()`.

On current `main`:
- `paired-client-window-reveal.ts:24` throws `...stayed hidden after showInactive() (windows: N)`
- `paired-client-window-reveal.unit.test.ts:42` asserts `/stayed hidden after show\(\)/`

The implementation is correct; only the spec is stale.

## Why this wasn't obvious

The CI summary shows the message truncated (`'...stayed hidden af…'`), which hides the actual mismatch. That truncation is only chai's `truncateThreshold` shortening the *display* — regex matching runs against the full message. The real value is visible only in the raw job log via `gh api .../actions/jobs/<id>/logs`.

It also passes on any worktree based on a commit predating #17347, which is how it initially read as a flake.

## Scope

Confirmed across 7 shard-2 runs on unrelated branches — 100% reproducible, same mismatch every time.

Note this does **not** explain the other currently-failing shards (e.g. `terminal-ime-substituted-text-commit.test.ts` on #17332). That is a separate, unrelated problem still outstanding.

## Change

Test title and regex updated to `showInactive()`. No implementation change.

Before (reproduced locally on current `main`): 1 failed | 3 passed
After: 4 passed