### PR TITLE
test(e2e): match the paired-client reveal assertion to showInactive()

### DIFF
--- a/tests/e2e/helpers/paired-client-window-reveal.unit.test.ts
+++ b/tests/e2e/helpers/paired-client-window-reveal.unit.test.ts
@@ -32,13 +32,13 @@ describe('assertPairedClientWindowRevealed', () => {
     ).toThrow(/no BrowserWindow/)
   })
 
-  it('rejects a window that stays hidden after show()', () => {
+  it('rejects a window that stays hidden after showInactive()', () => {
     expect(() =>
       assertPairedClientWindowRevealed({
         isVisible: false,
         wasVisible: false,
         windowCount: 2
       })
-    ).toThrow(/stayed hidden after show\(\)/)
+    ).toThrow(/stayed hidden after showInactive\(\)/)
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | 0 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

#17347 switched the paired-client reveal path to `window.showInactive()` and updated the thrown message accordingly, but `paired-client-window-reveal.unit.test.ts` still asserts `show()`.

The suite is red on `main`, so it fails unrelated PRs:

```
AssertionError: expected [Function] to throw error matching /stayed hidden after show\(\)/
                but got 'Paired client window stayed hidden after showInactive() (windows: 2)'
```

Verified by checking the file out from pristine `origin/main` and running it — fails there too, so it is not introduced by any open branch.

One-line assertion fix plus the test title, which described the same wrong call. 4/4 pass.