### PR TITLE
fix(diagnostics): count case-only worktree nesting on macOS

### DIFF
--- a/src/renderer/src/lib/typing-latency/diagnostic-summary.test.ts
+++ b/src/renderer/src/lib/typing-latency/diagnostic-summary.test.ts
@@ -59,21 +59,45 @@ describe('summarizeWorktreeNesting', () => {
   })
 
   it('normalizes windows separators, case, and trailing slashes', () => {
-    expect(summarizeWorktreeNesting(worktreesAtPaths('C:\\Repo\\', 'c:/repo/Nested'))).toEqual({
+    expect(
+      summarizeWorktreeNesting(worktreesAtPaths('C:\\Repo\\', 'c:/repo/Nested'), 'win32')
+    ).toEqual({
       maxDepth: 1,
       nestedWorktrees: 1
     })
   })
 
-  it('preserves case-distinct POSIX and SSH worktree paths', () => {
+  it('preserves case-distinct remote POSIX worktree paths', () => {
     expect(
       summarizeWorktreeNesting(
         worktreesAtPaths('/srv/Repo', '/srv/repo/nested').map((worktree) => ({
           ...worktree,
           hostId: 'ssh:openclaw'
-        }))
+        })),
+        'darwin'
       )
     ).toEqual({ maxDepth: 0, nestedWorktrees: 0 })
+  })
+
+  it('folds case-only local POSIX twins on macOS but not on Linux', () => {
+    const worktrees = worktreesAtPaths('/Users/ada/Repo', '/Users/ada/repo/nested')
+    expect(summarizeWorktreeNesting(worktrees, 'darwin')).toEqual({
+      maxDepth: 1,
+      nestedWorktrees: 1
+    })
+    expect(summarizeWorktreeNesting(worktrees, 'linux')).toEqual({
+      maxDepth: 0,
+      nestedWorktrees: 0
+    })
+  })
+
+  it('treats an absent hostId as the local host', () => {
+    expect(
+      summarizeWorktreeNesting(
+        [{ path: '/srv/repo' }, { path: '/srv/repo/nested', hostId: 'local' }],
+        'linux'
+      )
+    ).toEqual({ maxDepth: 1, nestedWorktrees: 1 })
   })
 
   it('does not infer nesting across execution hosts', () => {

--- a/src/renderer/src/lib/typing-latency/diagnostic-summary.ts
+++ b/src/renderer/src/lib/typing-latency/diagnostic-summary.ts
@@ -6,7 +6,12 @@
  * Kept separate from the DOM/store wiring in diagnostic.ts so
  * the arithmetic is unit-testable without an xterm or a live store.
  */
-import { normalizeRuntimePathForComparison } from '../../../../shared/cross-platform-path'
+import {
+  isWindowsAbsolutePathLike,
+  normalizeRuntimePathForComparison
+} from '../../../../shared/cross-platform-path'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+import { getRendererAppPlatform } from '../renderer-app-platform'
 
 export type LatencyPercentiles = {
   count: number
@@ -55,17 +60,39 @@ export type WorktreeNestingCensus = {
 
 type WorktreeLike = { path?: string | null; hostId?: string | null }
 
+/**
+ * Case-only path twins are one directory on a case-insensitive filesystem, so the
+ * census must fold them or the nesting they form goes uncounted. Windows drive/UNC
+ * keys are already folded by `normalizeRuntimePathForComparison`; a POSIX key folds
+ * only for the local host, where the client platform really does report the
+ * filesystem (default macOS APFS is case-insensitive). Remote POSIX paths stay
+ * byte-exact — the execution host owns that fact and we cannot see it from here.
+ */
+function worktreeNestingKey(rawPath: string, foldPosixCase: boolean): string {
+  const normalized = normalizeRuntimePathForComparison(rawPath)
+  return foldPosixCase && !isWindowsAbsolutePathLike(rawPath.normalize('NFC'))
+    ? normalized.toLowerCase()
+    : normalized
+}
+
 export function summarizeWorktreeNesting(
-  worktrees: readonly WorktreeLike[]
+  worktrees: readonly WorktreeLike[],
+  localPlatform: NodeJS.Platform = getRendererAppPlatform()
 ): WorktreeNestingCensus {
-  const pathsByHost = new Map<string | null, Set<string>>()
+  const pathsByHost = new Map<string, Set<string>>()
   for (const worktree of worktrees) {
     if (typeof worktree.path !== 'string' || worktree.path.length === 0) {
       continue
     }
-    const hostId = worktree.hostId ?? null
+    // An absent hostId means the local host, so it must not partition away from 'local'.
+    const hostId = worktree.hostId ?? LOCAL_EXECUTION_HOST_ID
     const paths = pathsByHost.get(hostId) ?? new Set<string>()
-    paths.add(normalizeRuntimePathForComparison(worktree.path))
+    paths.add(
+      worktreeNestingKey(
+        worktree.path,
+        hostId === LOCAL_EXECUTION_HOST_ID && localPlatform === 'darwin'
+      )
+    )
     pathsByHost.set(hostId, paths)
   }
   let maxDepth = 0
@@ -211,6 +238,7 @@ export function summarizeTypingScaleCensus(input: {
   mountedAgentRowCount: number | null
   storeListenerCount: number | null
   focusedPane: FocusedPaneCensus | null
+  localPlatform?: NodeJS.Platform
 }): TypingScaleCensus {
   const state = input.state
   const settings = state?.settings ?? null
@@ -221,7 +249,7 @@ export function summarizeTypingScaleCensus(input: {
     appVersion: input.appVersion,
     repos: state?.worktreesByRepo ? Object.keys(state.worktreesByRepo).length : 0,
     worktrees: worktrees.length,
-    worktreeNesting: summarizeWorktreeNesting(worktrees),
+    worktreeNesting: summarizeWorktreeNesting(worktrees, input.localPlatform),
     tabs: {
       terminal: sumArrayLengths(state?.tabsByWorktree),
       unified: sumArrayLengths(state?.unifiedTabsByWorktree)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 |

<!-- /orca-pr-loc -->

Fixes #17355

## ELI5

Imagine a filing cabinet where the drawer labelled `Repo` and the drawer labelled `repo` are secretly the same drawer. That's how a Mac's disk works by default — capitalization doesn't make a new folder.

Orca has an opt-in DevTools "why is typing slow?" report. Part of it counts how many worktrees are stacked inside each other, because deep stacking is a known cause of slowness. To do that it compares folder paths as text.

The problem: it was comparing capitalization-exactly. So if one worktree was recorded as `/Users/ada/Repo` and another as `/Users/ada/repo/nested`, the counter saw two unrelated folders instead of one nested inside the other — and reported zero nesting when there really was some. The report quietly under-counted the exact thing it exists to measure.

The fix: ignore capitalization **only when we actually know the disk ignores it**. On your own Mac, we know. On a Linux machine you're SSH'd into, capitalization genuinely does matter, so we keep comparing exactly. Guess wrong in that direction and you'd invent nesting that isn't there.

## What changed

`summarizeWorktreeNesting` (`src/renderer/src/lib/typing-latency/diagnostic-summary.ts`) built its comparison key with `normalizeRuntimePathForComparison`, which does NFC + separator folding and lowercases Windows drive/UNC paths, but never case-folds a POSIX path. The local helper it replaced in #17171 case-folded unconditionally.

New `worktreeNestingKey` lowercases the key only for a POSIX path whose host is `local` **and** whose local platform is `darwin`:

- **Windows** drive/UNC keys — unchanged, already folded inside the shared normalizer.
- **Local macOS** POSIX keys — now folded. Default APFS is case-insensitive.
- **Local Linux** POSIX keys — not folded. Case-sensitive.
- **SSH / runtime** POSIX keys — not folded, on any client platform. Per `docs/reference/ssh-execution-boundary.md` the execution host owns its filesystem semantics, and the client can't see them.

`localPlatform` is an injected parameter defaulting to `getRendererAppPlatform()`, so the function stays pure and the tests stay deterministic.

## What I deliberately did NOT change

The issue asked whether `normalizeRuntimePathForComparison` should case-fold on case-insensitive filesystems instead. It should not. `isCaseInsensitiveRuntimeRoot` (`src/shared/cross-platform-path.ts:9-20`) already documents that policy as intentional:

> macOS stays case-sensitive here, matching `normalizeRuntimePathForComparison`: folding a case-sensitive root would merge distinct files, which is worse than missing a case-only duplicate.

That's load-bearing for `isPathInsideOrEqual` and `relativePathInsideRoot`, where merging two distinct files is a real bug rather than an off-by-one in a counter. The established pattern is to fold at the call site that knows its filesystem — which is what the one other such site, `open-tab-entry-dedupe.ts:21`, already does.

The `hostId` partition from #17171 stays, as the issue requested.

## Adjacent fix folded in

The partition key was `worktree.hostId ?? null`, but per `getWorktreeExecutionHostId` an absent `hostId` *means* local. A worktree with no `hostId` and a sibling tagged `'local'` therefore landed in different buckets and never counted as nested — same under-count class as the reported bug. Both now normalize to `LOCAL_EXECUTION_HOST_ID`.

## Verification

- `pnpm test src/renderer/src/lib/typing-latency/ src/shared/cross-platform-path.test.ts src/renderer/src/components/tab-bar/open-tab-entry-dedupe.test.ts` — 82 passed
- `pnpm tc` clean, `oxlint` clean

Tests: renamed the stale `preserves case-distinct POSIX and SSH worktree paths` to `preserves case-distinct remote POSIX worktree paths`, now pinned to an explicit `'darwin'` local platform so it proves remote paths stay byte-exact even on a Mac client. Added `folds case-only local POSIX twins on macOS but not on Linux` and `treats an absent hostId as the local host`.

## Topology check

Confirmed paired-web clients re-tag remote worktrees as `runtime:<envId>` via `withRuntimeWorktreeOwner` (`src/renderer/src/web/preload-api/web-runtime-worktree-catalog.ts:74-85`), and `getRendererAppPlatform()` resolves from the client's own preload/UA. So `hostId === 'local'` really is the client machine on every topology, and the platform used to judge it is that machine's.

## Scope

Renderer-only, one counter in an opt-in DevTools diagnostic. No persisted state, no wire contract, no user-visible worktree behaviour, and the census output shape is unchanged.