### PR TITLE
ci: gate PRs on a real input method, and prove the lane engaged one

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -217,12 +217,16 @@ jobs:
         env:
           TEST_FILES_JSON: ${{ inputs.test_files }}
         run: |
+          # Why the native IME spec is dropped: it test.skip()s itself without
+          # ORCA_E2E_NATIVE_IBUS_HANGUL, which this lane cannot set because it has no ibus
+          # session. Running it here reported a green skip as coverage.
           mapfile -t TEST_FILES < <(jq -r '.[] | select(
             . != "tests/e2e/ssh-startup-exec-readiness.spec.ts" and
-            . != "tests/e2e/paired-startup-exec-readiness.spec.ts"
+            . != "tests/e2e/paired-startup-exec-readiness.spec.ts" and
+            . != "tests/e2e/terminal-ibus-hangul-native.spec.ts"
           )' <<<"$TEST_FILES_JSON")
           if [ "${#TEST_FILES[@]}" -eq 0 ]; then
-            echo "Changed startup-readiness specs are owned by the dedicated live lane."
+            echo "Changed specs are all owned by dedicated lanes."
             exit 0
           fi
           E2E_ENV=(SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 ORCA_E2E_WEB_CLIENT=1 ORCA_RELAY_PATH="$GITHUB_WORKSPACE/out/relay")

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -767,6 +767,7 @@ jobs:
       should_run: ${{ steps.filter.outputs.should_run }}
       test_files: ${{ steps.filter.outputs.test_files }}
       ssh_source_changed: ${{ steps.filter.outputs.ssh_source_changed }}
+      native_ime_source_changed: ${{ steps.filter.outputs.native_ime_source_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -794,6 +795,11 @@ jobs:
           SSH_SOURCE_CHANGED="$(printf '%s\n' "$CHANGED" | node config/scripts/pr-e2e-source-routing.mjs --ssh-source)"
           echo "ssh_source_changed=$SSH_SOURCE_CHANGED" >> "$GITHUB_OUTPUT"
           echo "SSH source changed: $SSH_SOURCE_CHANGED"
+          # Why its own signal: the real-IME lane is a whole ibus session, not a spec, so it must
+          # trigger on IME source rather than on a spec name in some route's list.
+          NATIVE_IME_SOURCE_CHANGED="$(printf '%s\n' "$CHANGED" | node config/scripts/pr-e2e-source-routing.mjs --native-ime-source)"
+          echo "native_ime_source_changed=$NATIVE_IME_SOURCE_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "Native IME source changed: $NATIVE_IME_SOURCE_CHANGED"
           if [ "$TEST_FILES_JSON" != '[]' ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "Changed E2E specs: $TEST_FILES_JSON"
@@ -813,6 +819,21 @@ jobs:
     with:
       test_files: ${{ needs.e2e-paths.outputs.test_files }}
       ssh_source_changed: ${{ needs.e2e-paths.outputs.ssh_source_changed }}
+
+  # Why this is not in verify's needs: it is the first PR-gate run of a harness whose reliability
+  # is only known from nightly main runs (20/20 green, 2026-08-09..2026-08-29, p50 3m25s). It
+  # reports a red X on the PR without blocking, exactly like `e2e` above. Deliberately no
+  # continue-on-error: that renders the check green and hides the signal it exists to give. To
+  # make it blocking, add it to verify.needs, add TERMINAL_IME_NATIVE to the env below, and
+  # require `success || skipped` outside the strict loop — see the note on `e2e`.
+  terminal_ime_native:
+    name: real IME
+    needs: e2e-paths
+    if: needs.e2e-paths.outputs.native_ime_source_changed == 'true'
+    # Why: the reusable workflow only checks out, builds, and uploads artifacts.
+    permissions:
+      contents: read
+    uses: ./.github/workflows/terminal-ime-e2e.yml
 
   verify:
     if: always()

--- a/.github/workflows/terminal-ime-e2e.yml
+++ b/.github/workflows/terminal-ime-e2e.yml
@@ -1,6 +1,9 @@
 name: Terminal IME E2E
 
 on:
+  # Why workflow_call and not pull_request: pr.yml owns the path filter that decides when an IME
+  # change is worth a real ibus session. A pull_request trigger here would run it on every PR.
+  workflow_call:
   workflow_dispatch:
   schedule:
     - cron: '30 9 * * *'

--- a/.github/workflows/terminal-ime-e2e.yml
+++ b/.github/workflows/terminal-ime-e2e.yml
@@ -68,6 +68,10 @@ jobs:
           --workers=1
 
       - name: Run native IBus Hangul exact-byte tests
+        # Why not the default success(): the synthetic step above runs first, so its failure used
+        # to skip this one entirely — the real-IME half reported nothing on exactly the PRs that
+        # broke IME code. The two signals are independent and both belong in the log.
+        if: '!cancelled()'
         env:
           SKIP_BUILD: '1'
         run: pnpm run test:e2e:terminal-ime-native

--- a/config/scripts/pr-e2e-gate-contract.test.mjs
+++ b/config/scripts/pr-e2e-gate-contract.test.mjs
@@ -613,6 +613,14 @@ describe('PR E2E gate contract', () => {
     expect(nativeImeRunner).toContain(`[IME_ENGAGEMENT_RECEIPT_ENV]: receiptPath`)
     expect(nativeImeSpec).toContain('appendImeEngagementReceipt(testInfo.title, trace)')
 
+    // Why: the synthetic CDP step runs first in the same job. Under the default success()
+    // condition its failure skipped the real-IME step, so the half that needs an input method
+    // reported nothing on exactly the changes that broke IME code.
+    const nativeStep = nativeImeWorkflow.jobs['linux-x11'].steps.find(
+      (step) => step.name === 'Run native IBus Hangul exact-byte tests'
+    )
+    expect(nativeStep.if).toBe('!cancelled()')
+
     // Why a literal comparison: the spec cannot import the .mjs module, so the env var name is
     // written twice and would otherwise drift into a receipt nobody reads.
     const specSideReceipt = readFileSync(

--- a/config/scripts/pr-e2e-gate-contract.test.mjs
+++ b/config/scripts/pr-e2e-gate-contract.test.mjs
@@ -4,11 +4,17 @@ import { parse as parseJsonc } from 'jsonc-parser'
 import { describe, expect, it } from 'vitest'
 import { parse as parseYaml } from 'yaml'
 import {
+  hasNativeImeSourceChange,
   hasSshSourceChange,
+  NATIVE_IME_SOURCE_ROUTE_IDS,
   PR_E2E_SOURCE_ROUTES,
   selectPrE2eSpecs,
   SSH_SOURCE_ROUTE_IDS
 } from './pr-e2e-source-routing.mjs'
+import {
+  EXPECTED_NATIVE_IME_TESTS,
+  IME_ENGAGEMENT_RECEIPT_ENV
+} from './terminal-ime-engagement-receipt.mjs'
 
 const projectDir = resolve(import.meta.dirname, '../..')
 const prWorkflow = parseYaml(readFileSync(join(projectDir, '.github/workflows/pr.yml'), 'utf8'))
@@ -19,6 +25,17 @@ const reliabilityManifest = parseJsonc(
 const playwrightConfig = readFileSync(join(projectDir, 'tests/playwright.config.ts'), 'utf8')
 const sshDockerRunner = readFileSync(
   join(projectDir, 'config/scripts/run-ssh-docker-terminal-parking-e2e.mjs'),
+  'utf8'
+)
+const nativeImeWorkflow = parseYaml(
+  readFileSync(join(projectDir, '.github/workflows/terminal-ime-e2e.yml'), 'utf8')
+)
+const nativeImeRunner = readFileSync(
+  join(projectDir, 'config/scripts/run-terminal-ibus-hangul-e2e.mjs'),
+  'utf8'
+)
+const nativeImeSpec = readFileSync(
+  join(projectDir, 'tests/e2e/terminal-ibus-hangul-native.spec.ts'),
   'utf8'
 )
 
@@ -191,7 +208,10 @@ describe('PR E2E gate contract', () => {
     }
   })
 
-  it('keeps dedicated E2E workflows out of pull request CI', () => {
+  it('keeps dedicated E2E workflows from self-triggering on pull requests', () => {
+    // Why this still holds for terminal-ime-e2e.yml now that pr.yml runs it: pr.yml reaches it
+    // through workflow_call, behind the path filter. A pull_request trigger here would run a
+    // real ibus session on every PR, which is the cost the filter exists to avoid.
     const dedicatedWorkflows = [
       'golden-e2e-experiment.yml',
       'linux-wayland-gpu-sandbox.yml',
@@ -484,6 +504,139 @@ describe('PR E2E gate contract', () => {
     ).not.toContain('tests/e2e/paired-remote-terminal-materialization-reconnect.spec.ts')
     expect(selectPrE2eSpecs(['src/main/ipc/pty.ts'])).not.toContain(
       'tests/e2e/paired-remote-terminal-materialization-reconnect.spec.ts'
+    )
+  })
+
+  it('puts the real-IME lane on the PR gate behind the IME source filter', () => {
+    // Why a whole lane and not a spec in changed-e2e: the harness is an ibus-daemon, an xfwm4
+    // session, and an X11 display; the generic lane has none of them and the spec would skip.
+    expect(nativeImeWorkflow.on.workflow_call).toBeDefined()
+    expect(prWorkflow.jobs.terminal_ime_native.uses).toBe(
+      './.github/workflows/terminal-ime-e2e.yml'
+    )
+    expect(prWorkflow.jobs.terminal_ime_native.needs).toBe('e2e-paths')
+    expect(prWorkflow.jobs.terminal_ime_native.if).toBe(
+      "needs.e2e-paths.outputs.native_ime_source_changed == 'true'"
+    )
+    expect(prWorkflow.jobs['e2e-paths'].outputs.native_ime_source_changed).toBe(
+      '${{ steps.filter.outputs.native_ime_source_changed }}'
+    )
+    expect(filterStep.run).toContain('pr-e2e-source-routing.mjs --native-ime-source')
+    expect(filterStep.run).toContain('native_ime_source_changed=$NATIVE_IME_SOURCE_CHANGED')
+
+    // Why: continue-on-error would report the lane green and hide every failure it exists to
+    // surface. Advisory here means "absent from verify.needs", not "always passes".
+    expect(prWorkflow.jobs.terminal_ime_native['continue-on-error']).toBeUndefined()
+    expect(prWorkflow.jobs.verify.needs).not.toContain('terminal_ime_native')
+    expect(verifyStep.env.TERMINAL_IME_NATIVE).toBeUndefined()
+
+    for (const id of NATIVE_IME_SOURCE_ROUTE_IDS) {
+      expect(
+        PR_E2E_SOURCE_ROUTES.map((route) => route.id),
+        id
+      ).toContain(id)
+    }
+  })
+
+  it('triggers the real-IME lane from every surface an input method can judge', () => {
+    for (const file of [
+      'src/renderer/src/components/terminal-pane/terminal-ime-composition-route.ts',
+      'src/renderer/src/components/terminal-pane/terminal-ime-native-text-forwarder.ts',
+      'src/renderer/src/components/terminal-pane/terminal-ios-hangul-preedit.ts',
+      'src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts',
+      'src/renderer/src/lib/pane-manager/terminal-ime-anchor.ts',
+      'src/shared/terminal-unicode-provider.ts',
+      // The xterm fork owns the helper textarea the IME attaches to; no file here says "ime".
+      'config/patches/@xterm__xterm@6.1.0-beta.287.patch',
+      'config/patches/xterm-src/browser/Terminal.ts',
+      // The harness is source too: breaking the runner or a probe is how the lane goes blind.
+      'config/scripts/run-terminal-ibus-hangul-e2e.mjs',
+      'config/scripts/terminal-ime-engagement-receipt.mjs',
+      'tests/e2e/terminal-ime-boundary-probe.ts',
+      'tests/e2e/terminal-ime-byte-reader.ts',
+      'tests/e2e/terminal-ime-engagement-receipt.ts',
+      'tests/e2e/terminal-ibus-hangul-native.spec.ts'
+    ]) {
+      expect(hasNativeImeSourceChange([file]), file).toBe(true)
+    }
+
+    // Why: a real ibus session on a Git or tab-bar edit is the cost the filter exists to avoid,
+    // and a unit test beside the source must not summon a three-and-a-half-minute lane.
+    for (const file of [
+      'src/main/git/git-status.ts',
+      'src/renderer/src/components/tab-bar/BrowserTab.tsx',
+      'src/main/terminal/pty-manager.ts',
+      'docs/STYLEGUIDE.md',
+      'src/renderer/src/components/terminal-pane/terminal-ime-composition-route.test.ts',
+      'src/renderer/src/lib/pane-manager/terminal-ime-anchor.test.ts'
+    ]) {
+      expect(hasNativeImeSourceChange([file]), file).toBe(false)
+    }
+  })
+
+  it('gives every input-method-gated spec a lane that runs it, or an honest exemption', () => {
+    // Why this shape: a spec gated on a native-IME env var that no runner sets is a skip that
+    // reports as a pass. This repo already carries such specs; the point is that they are named
+    // as gaps rather than counted as coverage.
+    const nativeGateExpression = /ORCA_E2E_NATIVE_(?:IBUS_HANGUL|MACOS_KOREAN)\s*[!=]==\s*['"]1['"]/
+    const nativeGatedSpecs = readdirSync(join(projectDir, 'tests/e2e'))
+      .filter((file) => file.endsWith('.spec.ts'))
+      .map((file) => `tests/e2e/${file}`)
+      .filter((spec) => nativeGateExpression.test(readFileSync(join(projectDir, spec), 'utf8')))
+    expect(nativeGatedSpecs.length).toBeGreaterThan(0)
+
+    // Why exempt: the digit repro needs a nested gnome-shell, which no hosted runner provides
+    // (headless mutter never answers RemoteDesktop.CreateSession); the macOS spec needs a real
+    // macOS input source, and no macOS runner exists on any PR or scheduled lane.
+    const unreachableSpecs = new Set([
+      'tests/e2e/terminal-hangul-terminating-digit-native.spec.ts',
+      'tests/e2e/terminal-macos-2set-korean-native.spec.ts'
+    ])
+    const unclaimed = nativeGatedSpecs.filter(
+      (spec) => !unreachableSpecs.has(spec) && !nativeImeRunner.includes(spec)
+    )
+    expect(
+      unclaimed,
+      `Native-IME-gated specs claimed by no lane runner: ${unclaimed.join(', ')}`
+    ).toEqual([])
+
+    for (const spec of unreachableSpecs) {
+      expect(nativeGatedSpecs, spec).toContain(spec)
+      expect(nativeImeRunner.includes(spec), `${spec} is exempt but still invoked`).toBe(false)
+    }
+  })
+
+  it('requires proof an input method engaged before the lane may report success', () => {
+    // Why this is the assertion that matters: every other check in this file protects a job from
+    // not running. This one protects a job that ran from having exercised nothing.
+    expect(nativeImeRunner).toContain('verifyImeEngagementReceipts')
+    expect(nativeImeRunner).toContain(`[IME_ENGAGEMENT_RECEIPT_ENV]: receiptPath`)
+    expect(nativeImeSpec).toContain('appendImeEngagementReceipt(testInfo.title, trace)')
+
+    // Why a literal comparison: the spec cannot import the .mjs module, so the env var name is
+    // written twice and would otherwise drift into a receipt nobody reads.
+    const specSideReceipt = readFileSync(
+      join(projectDir, 'tests/e2e/terminal-ime-engagement-receipt.ts'),
+      'utf8'
+    )
+    expect(specSideReceipt).toContain(`'${IME_ENGAGEMENT_RECEIPT_ENV}'`)
+
+    // Why pin the titles: the runner requires one receipt per name, so a rename that nobody
+    // mirrored here would fail the lane loudly instead of quietly halving it.
+    for (const title of EXPECTED_NATIVE_IME_TESTS) {
+      expect(nativeImeSpec, title).toContain(title)
+    }
+  })
+
+  it('keeps the native IME spec out of the lane that would silently skip it', () => {
+    const changedRun = e2eWorkflow.jobs['changed-e2e'].steps.find(
+      (step) => step.name === 'Run changed E2E specs'
+    )
+    expect(changedRun.run).toContain('. != "tests/e2e/terminal-ibus-hangul-native.spec.ts"')
+    // Why it still has to be routed: the dedicated lane is selected by the same route, so the
+    // spec appearing in test_files is how a spec-only edit reaches the real-IME lane at all.
+    expect(selectPrE2eSpecs(['src/shared/terminal-unicode-provider.ts'])).toContain(
+      'tests/e2e/terminal-ibus-hangul-native.spec.ts'
     )
   })
 

--- a/config/scripts/pr-e2e-source-routing.mjs
+++ b/config/scripts/pr-e2e-source-routing.mjs
@@ -3,6 +3,15 @@ import { pathToFileURL } from 'node:url'
 
 const isProductSource = (file) => !/\.test\.tsx?$/.test(file)
 
+// Why config/patches: the xterm fork owns the helper textarea an input method attaches to, so a
+// patch edit can break composition without touching a file named "ime".
+const NATIVE_IME_PRODUCT_SOURCE =
+  /^(?:config\/patches\/|src\/shared\/terminal-unicode-provider\.ts$|src\/renderer\/src\/lib\/pane-manager\/terminal-ime-|src\/renderer\/src\/components\/terminal-pane\/(?:terminal-ime-|terminal-ios-hangul-|xterm-bypass-policy))/
+
+/** The harness itself: the session runner, the boundary probes, and the native specs. */
+const NATIVE_IME_HARNESS =
+  /^(?:config\/scripts\/(?:run-terminal-ibus-hangul-e2e|terminal-ime-engagement-receipt)\.mjs$|tests\/e2e\/terminal-ime-(?:boundary-probe|byte-reader|engagement-receipt)\.ts$|tests\/e2e\/terminal-(?:ibus-hangul|hangul-terminating-digit|macos-2set-korean)-native\.spec\.ts$)/
+
 export const PR_E2E_SOURCE_ROUTES = [
   {
     id: 'ephemeral-vm-runtime.rollback-readable-sidecar',
@@ -63,6 +72,18 @@ export const PR_E2E_SOURCE_ROUTES = [
       /^(?:config\/patches\/|src\/renderer\/src\/components\/terminal-pane\/(?:terminal-ime-|use-terminal-pane-lifecycle|xterm-bypass-policy|terminal-option-shortcut-policy))/.test(
         file
       )
+  },
+  {
+    // Why a route beside terminal-input.ime-and-synthetic-forwarding rather than more specs on
+    // it: that route selects the CDP-synthetic specs, which drive composition through
+    // Input.imeSetComposition and so prove Orca's handling without an input method existing.
+    // This one names the surface only a real ibus-hangul session can judge, and is the sole
+    // trigger that puts the real-IME lane on a PR.
+    id: 'terminal-ime.native-input-method',
+    specs: ['tests/e2e/terminal-ibus-hangul-native.spec.ts'],
+    matches: (file) =>
+      (isProductSource(file) && NATIVE_IME_PRODUCT_SOURCE.test(file)) ||
+      NATIVE_IME_HARNESS.test(file)
   },
   {
     id: 'terminal-startup.quick-command-pre-bind-recovery',
@@ -163,6 +184,17 @@ export function hasSshSourceChange(changedPaths) {
   )
 }
 
+/** Routes whose authorities a real input method can judge, and so require the native IME lane. */
+export const NATIVE_IME_SOURCE_ROUTE_IDS = ['terminal-ime.native-input-method']
+
+// Why derived from the routes, like hasSshSourceChange: the native lane must trigger on IME
+// source, not on the native spec surviving in some route's spec list.
+export function hasNativeImeSourceChange(changedPaths) {
+  return PR_E2E_SOURCE_ROUTES.filter((route) =>
+    NATIVE_IME_SOURCE_ROUTE_IDS.includes(route.id)
+  ).some((route) => changedPaths.some(route.matches))
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   let input = ''
   process.stdin.setEncoding('utf8')
@@ -172,6 +204,8 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   const changedPaths = input.split(/\r?\n/).filter(Boolean)
   if (process.argv.includes('--ssh-source')) {
     process.stdout.write(`${hasSshSourceChange(changedPaths)}\n`)
+  } else if (process.argv.includes('--native-ime-source')) {
+    process.stdout.write(`${hasNativeImeSourceChange(changedPaths)}\n`)
   } else {
     const specs = selectPrE2eSpecs(changedPaths, (message) => console.error(message))
     process.stdout.write(`${JSON.stringify(specs)}\n`)

--- a/config/scripts/run-terminal-ibus-hangul-e2e.mjs
+++ b/config/scripts/run-terminal-ibus-hangul-e2e.mjs
@@ -1,7 +1,21 @@
 import { spawn, spawnSync } from 'node:child_process'
-import { closeSync, copyFileSync, mkdirSync, mkdtempSync, openSync, writeFileSync } from 'node:fs'
+import {
+  closeSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  writeFileSync
+} from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import {
+  EXPECTED_NATIVE_IME_TESTS,
+  IME_ENGAGEMENT_RECEIPT_ENV,
+  verifyImeEngagementReceipts
+} from './terminal-ime-engagement-receipt.mjs'
 
 const projectDir = path.resolve(import.meta.dirname, '../..')
 const scriptPath = import.meta.filename
@@ -113,6 +127,7 @@ async function waitForHangulEngine(ibusProcess) {
 }
 
 async function runInsideSession(evidenceDir) {
+  const receiptPath = path.join(evidenceDir, 'ime-engagement-receipt.jsonl')
   const ibusLogPath = path.join(evidenceDir, 'ibus-daemon.log')
   const ibusLogFd = openSync(ibusLogPath, 'w')
   const windowManagerLogPath = path.join(evidenceDir, 'xfwm4.log')
@@ -192,6 +207,7 @@ async function runInsideSession(evidenceDir) {
           ...process.env,
           ORCA_E2E_FORWARD_APP_LOGS: '1',
           ORCA_E2E_NATIVE_IBUS_HANGUL: '1',
+          [IME_ENGAGEMENT_RECEIPT_ENV]: receiptPath,
           // Why: native IBus key injection only reaches a window the window manager
           // has focused, so this run opts out of the background-launch policy.
           ORCA_E2E_FOREGROUND: '1'
@@ -230,6 +246,12 @@ async function runInsideSession(evidenceDir) {
       path.join(projectDir, 'test-results', 'terminal-ibus-hangul-native-processes.json'),
       `${JSON.stringify(evidence, null, 2)}\n`
     )
+    if (existsSync(receiptPath)) {
+      copyFileSync(
+        receiptPath,
+        path.join(projectDir, 'test-results', 'terminal-ibus-hangul-native-engagement.jsonl')
+      )
+    }
   }
 
   if (evidence.ibusGroupAfterCleanup.length > 0) {
@@ -242,6 +264,24 @@ async function runInsideSession(evidenceDir) {
       `Owned window-manager processes survived cleanup: ${evidence.windowManagerGroupAfterCleanup.join('; ')}`
     )
   }
+
+  // Why unconditionally, and not only when Playwright failed: a skipped test reports as a pass,
+  // so exit code 0 is exactly the state this check exists to distrust.
+  const receiptText = existsSync(receiptPath) ? readFileSync(receiptPath, 'utf8') : ''
+  const engagementProblems = verifyImeEngagementReceipts(receiptText, EXPECTED_NATIVE_IME_TESTS)
+  if (engagementProblems.length > 0) {
+    for (const problem of engagementProblems) {
+      console.error(`::error title=Native IME never engaged::${problem}`)
+    }
+    console.error(
+      '[terminal-ime] the run produced no proof an input method engaged; treating it as a failure' +
+        ` even though Playwright exited ${testExitCode}`
+    )
+    return 1
+  }
+  console.error(
+    `[terminal-ime] engagement receipts verified for ${EXPECTED_NATIVE_IME_TESTS.length} tests`
+  )
   return testExitCode
 }
 

--- a/config/scripts/terminal-ime-engagement-receipt.mjs
+++ b/config/scripts/terminal-ime-engagement-receipt.mjs
@@ -1,0 +1,81 @@
+/**
+ * The proof that a native IME run was real.
+ *
+ * Playwright reports a skipped test as a pass, so every documented way this harness fails open —
+ * an unset ORCA_E2E_NATIVE_IBUS_HANGUL, a renamed test the grep no longer selects, a stale
+ * ibus-daemon that wins the XIM selection and leaves the session with no engine — produces a
+ * green run that exercised nothing. The specs append a receipt only after they have observed
+ * real composition events, and the runner requires one per expected test.
+ */
+
+export const IME_ENGAGEMENT_RECEIPT_ENV = 'ORCA_E2E_IME_ENGAGEMENT_RECEIPT'
+
+/** The tests that must each leave a receipt. Pinned so deleting one cannot quietly shrink the lane. */
+export const EXPECTED_NATIVE_IME_TESTS = [
+  'forwards the issue exact-byte sequence without loss or duplication',
+  'forwards the issue sentence stress sequence without leaked ASCII'
+]
+
+function parseReceipts(text) {
+  const entries = []
+  for (const line of text.split('\n')) {
+    if (line.trim() === '') {
+      continue
+    }
+    try {
+      entries.push(JSON.parse(line))
+    } catch {
+      entries.push({ malformed: line })
+    }
+  }
+  return entries
+}
+
+/**
+ * Returns the reasons a run must not be trusted. An empty array means an input method
+ * demonstrably composed text for every expected test.
+ */
+export function verifyImeEngagementReceipts(text, expectedTests = EXPECTED_NATIVE_IME_TESTS) {
+  const entries = parseReceipts(text ?? '')
+  const problems = []
+
+  for (const entry of entries) {
+    if (entry.malformed !== undefined) {
+      problems.push(`malformed receipt line: ${entry.malformed}`)
+    }
+  }
+
+  const seen = new Map()
+  for (const entry of entries) {
+    if (typeof entry.test === 'string') {
+      seen.set(entry.test, entry)
+    }
+  }
+
+  for (const test of expectedTests) {
+    const entry = seen.get(test)
+    if (!entry) {
+      problems.push(
+        `no engagement receipt for "${test}" — it was skipped, filtered out, or renamed`
+      )
+      continue
+    }
+    // Why both: compositionstart alone fires for a bare keypress under some engines, and a
+    // Hangul update alone would not prove the composition lifecycle ran.
+    if (!(entry.compositionStart > 0)) {
+      problems.push(`"${test}" recorded no compositionstart — the IME never engaged`)
+    }
+    if (!(entry.hangulComposition > 0)) {
+      problems.push(
+        `"${test}" recorded no Hangul composition data — the engine produced no syllables`
+      )
+    }
+  }
+
+  const unexpected = [...seen.keys()].filter((test) => !expectedTests.includes(test))
+  for (const test of unexpected) {
+    problems.push(`unexpected engagement receipt for "${test}" — update EXPECTED_NATIVE_IME_TESTS`)
+  }
+
+  return problems
+}

--- a/config/scripts/terminal-ime-engagement-receipt.test.mjs
+++ b/config/scripts/terminal-ime-engagement-receipt.test.mjs
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EXPECTED_NATIVE_IME_TESTS,
+  verifyImeEngagementReceipts
+} from './terminal-ime-engagement-receipt.mjs'
+
+const [firstTest, secondTest] = EXPECTED_NATIVE_IME_TESTS
+
+function receipt(test, overrides = {}) {
+  return JSON.stringify({
+    test,
+    compositionStart: 30,
+    hangulComposition: 90,
+    onDataChunks: 30,
+    ...overrides
+  })
+}
+
+describe('verifyImeEngagementReceipts', () => {
+  it('accepts a run where every expected test observed real composition', () => {
+    expect(verifyImeEngagementReceipts(`${receipt(firstTest)}\n${receipt(secondTest)}\n`)).toEqual(
+      []
+    )
+  })
+
+  // The failure this whole mechanism exists for: Playwright reports a skipped test as a pass, so
+  // an unset ORCA_E2E_NATIVE_IBUS_HANGUL produces exit code 0 and an empty receipt file.
+  it('rejects an empty receipt, which is what a fully skipped run leaves behind', () => {
+    const problems = verifyImeEngagementReceipts('')
+    expect(problems).toHaveLength(EXPECTED_NATIVE_IME_TESTS.length)
+    for (const test of EXPECTED_NATIVE_IME_TESTS) {
+      expect(problems.some((problem) => problem.includes(test))).toBe(true)
+    }
+  })
+
+  it('rejects a partial run where only one test reached the engine', () => {
+    expect(verifyImeEngagementReceipts(`${receipt(firstTest)}\n`)).toEqual([
+      `no engagement receipt for "${secondTest}" — it was skipped, filtered out, or renamed`
+    ])
+  })
+
+  it('rejects a run that typed keys but never opened a composition', () => {
+    const problems = verifyImeEngagementReceipts(
+      `${receipt(firstTest, { compositionStart: 0 })}\n${receipt(secondTest)}\n`
+    )
+    expect(problems).toEqual([
+      `"${firstTest}" recorded no compositionstart — the IME never engaged`
+    ])
+  })
+
+  it('rejects a composition that produced no Hangul, which a latin passthrough would satisfy', () => {
+    const problems = verifyImeEngagementReceipts(
+      `${receipt(firstTest, { hangulComposition: 0 })}\n${receipt(secondTest)}\n`
+    )
+    expect(problems).toEqual([
+      `"${firstTest}" recorded no Hangul composition data — the engine produced no syllables`
+    ])
+  })
+
+  it('rejects a renamed test rather than counting it toward coverage', () => {
+    const problems = verifyImeEngagementReceipts(
+      `${receipt(firstTest)}\n${receipt(secondTest)}\n${receipt('some new scenario')}\n`
+    )
+    expect(problems).toEqual([
+      'unexpected engagement receipt for "some new scenario" — update EXPECTED_NATIVE_IME_TESTS'
+    ])
+  })
+
+  it('reports a truncated receipt rather than parsing around it', () => {
+    const problems = verifyImeEngagementReceipts(
+      `${receipt(firstTest)}\n{"test":"trunc\n${receipt(secondTest)}\n`
+    )
+    expect(problems).toEqual(['malformed receipt line: {"test":"trunc'])
+  })
+})

--- a/tests/e2e/terminal-ibus-hangul-native.spec.ts
+++ b/tests/e2e/terminal-ibus-hangul-native.spec.ts
@@ -21,6 +21,7 @@ import {
   startTerminalImeByteReader,
   waitForTerminalImeBytes
 } from './terminal-ime-byte-reader'
+import { appendImeEngagementReceipt } from './terminal-ime-engagement-receipt'
 
 const DEFAULT_REPETITIONS = 30
 const MAX_REPETITIONS = 30
@@ -141,6 +142,9 @@ async function runNativeIbusScenario(
     expect(receivedBytes).toEqual(Array.from({ length: repetitions }, () => expectedBytes))
 
     expect(trace.onData.join('')).toBe(`${expectedText}\r`.repeat(repetitions))
+    // Why after the assertions: the receipt is the runner's proof this test ran against a live
+    // engine, so it must not exist for a run that reached here with the bytes wrong.
+    appendImeEngagementReceipt(testInfo.title, trace)
     completed = true
   } finally {
     await attachTerminalImeBoundaryEvidence(page, testInfo, 'native-ibus-boundaries', {

--- a/tests/e2e/terminal-ime-engagement-receipt.ts
+++ b/tests/e2e/terminal-ime-engagement-receipt.ts
@@ -1,0 +1,35 @@
+import { appendFileSync, mkdirSync } from 'node:fs'
+import path from 'node:path'
+import type { TerminalImeBoundaryTrace } from './terminal-ime-boundary-probe'
+
+/** Kept identical to config/scripts/terminal-ime-engagement-receipt.mjs; pinned by a contract test. */
+const IME_ENGAGEMENT_RECEIPT_ENV = 'ORCA_E2E_IME_ENGAGEMENT_RECEIPT'
+
+const HANGUL_SYLLABLE = /[\uac00-\ud7af]/
+
+/**
+ * Records that a real input method composed text during this test. Only the session runner sets
+ * the receipt path, so a spec run by hand or by the generic changed-spec lane writes nothing.
+ */
+export function appendImeEngagementReceipt(
+  testTitle: string,
+  trace: TerminalImeBoundaryTrace
+): void {
+  const receiptPath = process.env[IME_ENGAGEMENT_RECEIPT_ENV]
+  if (!receiptPath) {
+    return
+  }
+  const entry = {
+    test: testTitle,
+    compositionStart: trace.dom.filter((event) => event.type === 'compositionstart').length,
+    hangulComposition: trace.dom.filter(
+      (event) =>
+        (event.type === 'compositionupdate' ||
+          (event.type === 'input' && event.inputType === 'insertText')) &&
+        HANGUL_SYLLABLE.test(event.data ?? '')
+    ).length,
+    onDataChunks: trace.onData.length
+  }
+  mkdirSync(path.dirname(receiptPath), { recursive: true })
+  appendFileSync(receiptPath, `${JSON.stringify(entry)}\n`)
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​276 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​275 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​190 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​187 |

<!-- /orca-pr-loc -->

## The gap

No job on the PR gate has ever run a real input method.

| Workflow | Runners | IME driver | Gates a PR? |
| --- | --- | --- | --- |
| `pr.yml` | `ubuntu-latest` ×N, one `windows-2022` | none (happy-dom/node unit tests) | yes |
| `e2e.yml` | `ubuntu-latest` | CDP `Input.imeSetComposition` — synthetic, no input method exists | yes (advisory) |
| `terminal-ime-e2e.yml` | `ubuntu-22.04` + Xvfb + xfwm4 + ibus-hangul + xdotool | **real ibus-hangul** | **no** — `schedule` + `workflow_dispatch` only |

A PR could turn the real-IME path red and merge green.

## What this does

- Adds a `terminal-ime.native-input-method` route to `config/scripts/pr-e2e-source-routing.mjs`, and derives `hasNativeImeSourceChange` from it the same way `hasSshSourceChange` is derived — one list, so the signal and the specs cannot drift.
- `pr.yml` gains a `real IME` job that calls `terminal-ime-e2e.yml` via `workflow_call` when that signal is true. No `pull_request` trigger on the dedicated workflow, so the path filter stays the only way in.
- Drops `terminal-ibus-hangul-native.spec.ts` from `changed-e2e`. It was already routed there by its own filename, where it `test.skip()`s itself for want of an ibus session — and reported that skip as a pass.

## The part that matters: proving the lane is not a silent no-op

Playwright reports a skipped test as a pass. An unset `ORCA_E2E_NATIVE_IBUS_HANGUL`, a renamed test the selection no longer matches, or a session whose ibus never came up all exit 0 having exercised nothing — and this repo already carries native IME specs that were mistaken for coverage they never provided.

The specs now append an **engagement receipt** (`compositionstart` count, Hangul composition-data count) only after their assertions pass, and `run-terminal-ibus-hangul-e2e.mjs` requires one receipt per expected test *regardless of Playwright's exit code* before the lane may report success.

## Advisory, not required — and why

Kept out of `verify.needs`, exactly like `e2e`. It reports a red X on the PR without blocking. **Deliberately no `continue-on-error`** — that renders the check green and hides the signal it exists to give.

Reliability and cost are in the PR discussion.