### PR TITLE
[negative control] unrelated edit must not run the real-IME lane

### DIFF
--- a/src/main/git/branch-rename.ts
+++ b/src/main/git/branch-rename.ts
@@ -1,3 +1,4 @@
+// Negative-control edit: unrelated to any IME surface.
 import { isNoUpstreamError, stripCredentialsFromMessage } from '../../shared/git-remote-error'
 import {
   resolveEffectiveGitUpstream,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

Throwaway, will be closed. Base is the gate PR's branch, so the merge-base diff is one unrelated file under src/main/git/. Evidence that the path filter does not summon a three-and-a-half-minute ibus session for a Git edit.