### PR TITLE
fix(updater): accept GitHub release asset redirects on Windows

### DIFF
--- a/src/main/updater-net-request.fixture.ts
+++ b/src/main/updater-net-request.fixture.ts
@@ -1,0 +1,38 @@
+import { EventEmitter } from 'node:events'
+import { vi, type Mock } from 'vitest'
+
+type NetFetchResponse = {
+  ok?: boolean
+  status?: number
+}
+
+export function installNetRequestFetchAdapter(netRequestMock: Mock, netFetchMock: Mock): void {
+  netRequestMock.mockImplementation(
+    (options: { method?: string; redirect?: string; url: string }) => {
+      const request = new EventEmitter() as EventEmitter & {
+        abort: Mock
+        end: Mock
+      }
+      request.abort = vi.fn()
+      request.end = vi.fn(() => {
+        Promise.resolve(
+          netFetchMock(options.url, { method: options.method, redirect: options.redirect })
+        ).then(
+          (response: NetFetchResponse) => {
+            const status = response.status ?? (response.ok ? 200 : 503)
+            if (options.redirect === 'manual' && status >= 300 && status < 400) {
+              request.emit('redirect', status, options.method ?? 'GET', 'https://redirect.test', {})
+              // Why: Electron cancels an unfollowed manual redirect and then emits 'error'.
+              request.emit('error', new Error('Redirect was cancelled'))
+            } else {
+              request.emit('response', { statusCode: status })
+            }
+          },
+          (error) => request.emit('error', error)
+        )
+        return request
+      })
+      return request
+    }
+  )
+}

--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -110,6 +110,7 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.useRealTimers()
     setPlatformForTest(ORIGINAL_PLATFORM)
   })
 
@@ -148,6 +149,113 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
       state: 'ready'
     })
     expect(assetRequestInits).toEqual([expect.objectContaining({ redirect: 'manual' })])
+  })
+
+  it.each([301, 307, 308])('accepts a GitHub %s asset redirect as ready', async (status) => {
+    setPlatformForTest('win32')
+    netFetchMock.mockImplementation(
+      (url: string, init?: { method?: string }) => {
+        if (url === 'https://github.com/stablyai/orca/releases.atom') {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            text: () => Promise.resolve(buildAtomFeed(['v1.4.190']))
+          })
+        }
+        if (isPlatformManifestRequest(url)) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            text: () => Promise.resolve(buildWindowsManifest('1.4.190'))
+          })
+        }
+        if (init?.method === 'HEAD') {
+          return Promise.resolve({ ok: false, status, text: () => Promise.resolve('') })
+        }
+        return Promise.resolve({ ok: false, status: 503, text: () => Promise.resolve('') })
+      }
+    )
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.189', 1)).resolves.toEqual({
+      tags: ['v1.4.190'],
+      state: 'ready'
+    })
+  })
+
+  it('reports a GitHub asset request error as unavailable', async () => {
+    setPlatformForTest('win32')
+    netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === 'https://github.com/stablyai/orca/releases.atom') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(buildAtomFeed(['v1.4.190']))
+        })
+      }
+      if (isPlatformManifestRequest(url)) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(buildWindowsManifest('1.4.190'))
+        })
+      }
+      if (init?.method === 'HEAD') {
+        return Promise.reject(new Error('network down'))
+      }
+      return Promise.resolve({ ok: false, status: 503, text: () => Promise.resolve('') })
+    })
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.189', 1)).resolves.toEqual({
+      tags: [],
+      state: 'unavailable',
+      unavailableReason: 'manifest'
+    })
+  })
+
+  it('aborts a GitHub asset request that exceeds the timeout', async () => {
+    vi.useFakeTimers()
+    setPlatformForTest('win32')
+    let resolveAsset: (() => void) | undefined
+    const pendingAsset = new Promise<{ ok: boolean; status: number }>((resolve) => {
+      resolveAsset = () => resolve({ ok: false, status: 503 })
+    })
+    netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === 'https://github.com/stablyai/orca/releases.atom') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(buildAtomFeed(['v1.4.190']))
+        })
+      }
+      if (isPlatformManifestRequest(url)) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(buildWindowsManifest('1.4.190'))
+        })
+      }
+      if (init?.method === 'HEAD') {
+        return pendingAsset
+      }
+      return Promise.resolve({ ok: false, status: 503, text: () => Promise.resolve('') })
+    })
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+    const readiness = fetchNewerReleaseTagsWithReadiness('1.4.189', 1)
+    await vi.advanceTimersByTimeAsync(5000)
+
+    await expect(readiness).resolves.toEqual({
+      tags: [],
+      state: 'unavailable',
+      unavailableReason: 'manifest'
+    })
+    const request = netRequestMock.mock.results[0]?.value as { abort: ReturnType<typeof vi.fn> }
+    expect(request.abort).toHaveBeenCalledOnce()
+    resolveAsset?.()
   })
 
   it('reports not-ready with a verified last-good tag when the newest assets are unavailable', async () => {

--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installNetRequestFetchAdapter } from './updater-net-request.fixture'
 import { publishingIncident } from './updater-prerelease-feed-reproduction.fixture'
 
-const { netFetchMock } = vi.hoisted(() => ({
-  netFetchMock: vi.fn()
+const ORIGINAL_PLATFORM = process.platform
+
+const { netFetchMock, netRequestMock } = vi.hoisted(() => ({
+  netFetchMock: vi.fn(),
+  netRequestMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
-  net: { fetch: netFetchMock }
+  net: { fetch: netFetchMock, request: netRequestMock }
 }))
 
 function buildAtomFeed(tags: string[]): string {
@@ -31,6 +35,20 @@ function buildManifest(tag: string): string {
 
 function isPlatformManifestRequest(url: string): boolean {
   return /\/latest(?:-[a-z]+)?\.yml$/.test(url)
+}
+
+function setPlatformForTest(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform })
+}
+
+function buildWindowsManifest(version: string): string {
+  return [
+    `version: ${version}`,
+    'files:',
+    '  - url: orca-windows-setup.exe',
+    '    sha512: test',
+    'path: orca-windows-setup.exe'
+  ].join('\n')
 }
 
 function respondWithAtom(
@@ -86,10 +104,50 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
   beforeEach(() => {
     vi.resetModules()
     netFetchMock.mockReset()
+    netRequestMock.mockReset()
+    installNetRequestFetchAdapter(netRequestMock, netFetchMock)
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    setPlatformForTest(ORIGINAL_PLATFORM)
+  })
+
+  it("offers a Windows release from GitHub's asset redirect without probing Azure", async () => {
+    setPlatformForTest('win32')
+    const assetRequestInits: { method?: string; redirect?: string }[] = []
+
+    netFetchMock.mockImplementation(
+      (url: string, init?: { method?: string; redirect?: string }) => {
+        if (url === 'https://github.com/stablyai/orca/releases.atom') {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            text: () => Promise.resolve(buildAtomFeed(['v1.4.190']))
+          })
+        }
+        if (isPlatformManifestRequest(url)) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            text: () => Promise.resolve(buildWindowsManifest('1.4.190'))
+          })
+        }
+        if (init?.method === 'HEAD') {
+          assetRequestInits.push(init)
+          return Promise.resolve({ ok: false, status: 302, text: () => Promise.resolve('') })
+        }
+        return Promise.resolve({ ok: false, status: 503, text: () => Promise.resolve('') })
+      }
+    )
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.189', 1)).resolves.toEqual({
+      tags: ['v1.4.190'],
+      state: 'ready'
+    })
+    expect(assetRequestInits).toEqual([expect.objectContaining({ redirect: 'manual' })])
   })
 
   it('reports not-ready with a verified last-good tag when the newest assets are unavailable', async () => {

--- a/src/main/updater-prerelease-feed.test.ts
+++ b/src/main/updater-prerelease-feed.test.ts
@@ -1,13 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installNetRequestFetchAdapter } from './updater-net-request.fixture'
 
 const ORIGINAL_PLATFORM = process.platform
 
-const { netFetchMock } = vi.hoisted(() => ({
-  netFetchMock: vi.fn()
+const { netFetchMock, netRequestMock } = vi.hoisted(() => ({
+  netFetchMock: vi.fn(),
+  netRequestMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
-  net: { fetch: netFetchMock }
+  net: { fetch: netFetchMock, request: netRequestMock }
 }))
 
 function buildAtomFeed(tags: string[]): string {
@@ -89,6 +91,8 @@ describe('fetchNewerReleaseTag', () => {
   beforeEach(() => {
     vi.resetModules()
     netFetchMock.mockReset()
+    netRequestMock.mockReset()
+    installNetRequestFetchAdapter(netRequestMock, netFetchMock)
   })
 
   afterEach(() => {

--- a/src/main/updater-prerelease-feed.test.ts
+++ b/src/main/updater-prerelease-feed.test.ts
@@ -162,6 +162,7 @@ describe('fetchNewerReleaseTag', () => {
       expect(assetUrls).toEqual([
         'https://github.com/stablyai/orca/releases/download/v1.4.1/Orca-1.4.1-arm64-mac.zip'
       ])
+      expect(netRequestMock).toHaveBeenCalledTimes(platform === 'win32' ? 1 : 0)
     }
   )
 

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -149,8 +149,11 @@ function getGitHubReleaseAssetReadiness(assetUrl: string): Promise<ReleaseReadin
 }
 
 async function getReleaseAssetReadiness(tag: string, assetName: string): Promise<ReleaseReadiness> {
-  const isGitHubReleaseAsset = !/^https?:\/\//i.test(assetName)
-  const assetUrl = isGitHubReleaseAsset
+  const isRelativeAsset = !/^https?:\/\//i.test(assetName)
+  const isGitHubReleaseAsset =
+    process.platform === 'win32' &&
+    (isRelativeAsset || /^https:\/\/github\.com\/stablyai\/orca\/releases\/download\//i.test(assetName))
+  const assetUrl = isRelativeAsset
     ? getReleaseAssetUrl(tag, assetName.split('/').findLast(Boolean) ?? assetName)
     : assetName
   if (isGitHubReleaseAsset) {

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -105,16 +105,63 @@ function getManifestAssetNames(manifestText: string): string[] {
 
 type ReleaseReadiness = 'ready' | 'not-ready' | 'unavailable'
 
-async function isReleaseAssetAvailable(tag: string, assetName: string): Promise<ReleaseReadiness> {
+function getGitHubReleaseAssetReadiness(assetUrl: string): Promise<ReleaseReadiness> {
+  return new Promise((resolve) => {
+    const request = net.request({ method: 'HEAD', url: assetUrl, redirect: 'manual' })
+    let settled = false
+    const settle = (readiness: ReleaseReadiness): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      resolve(readiness)
+    }
+    const timeout = setTimeout(() => {
+      request.abort()
+      settle('unavailable')
+    }, FETCH_TIMEOUT_MS)
+
+    request.on('redirect', (statusCode) => {
+      // Why: GitHub's 302 proves the asset exists without probing its signed storage URL.
+      settle(statusCode === 302 ? 'ready' : 'unavailable')
+    })
+    request.on('response', (response) => {
+      settle(
+        response.statusCode === 404
+          ? 'not-ready'
+          : response.statusCode >= 200 && response.statusCode < 300
+            ? 'ready'
+            : 'unavailable'
+      )
+    })
+    request.on('error', () => settle('unavailable'))
+    try {
+      request.end()
+    } catch {
+      settle('unavailable')
+    }
+  })
+}
+
+async function getReleaseAssetReadiness(tag: string, assetName: string): Promise<ReleaseReadiness> {
+  const isGitHubReleaseAsset = !/^https?:\/\//i.test(assetName)
+  const assetUrl = isGitHubReleaseAsset
+    ? getReleaseAssetUrl(tag, assetName.split('/').findLast(Boolean) ?? assetName)
+    : assetName
+  if (isGitHubReleaseAsset) {
+    return getGitHubReleaseAssetReadiness(assetUrl)
+  }
+
   try {
-    const assetUrl = assetName.startsWith('http')
-      ? assetName
-      : getReleaseAssetUrl(tag, assetName.split('/').findLast(Boolean) ?? assetName)
     const res = await net.fetch(assetUrl, {
       method: 'HEAD',
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
     })
-    return res.status === 404 ? 'not-ready' : res.ok ? 'ready' : 'unavailable'
+    if (res.status === 404) {
+      return 'not-ready'
+    }
+    return res.ok ? 'ready' : 'unavailable'
   } catch {
     return 'unavailable'
   }
@@ -144,7 +191,7 @@ async function getPlatformManifestReadiness(tag: string): Promise<ReleaseReadine
       return 'not-ready'
     }
     const assetResults = await Promise.all(
-      assetNames.map((assetName) => isReleaseAssetAvailable(tag, assetName))
+      assetNames.map((assetName) => getReleaseAssetReadiness(tag, assetName))
     )
     return assetResults.includes('not-ready')
       ? 'not-ready'

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -118,13 +118,17 @@ function getGitHubReleaseAssetReadiness(assetUrl: string): Promise<ReleaseReadin
       resolve(readiness)
     }
     const timeout = setTimeout(() => {
-      request.abort()
+      try {
+        request.abort()
+      } catch {
+        // The request may already have been cancelled by Electron.
+      }
       settle('unavailable')
     }, FETCH_TIMEOUT_MS)
 
     request.on('redirect', (statusCode) => {
       // Why: GitHub's 302 proves the asset exists without probing its signed storage URL.
-      settle(statusCode === 302 ? 'ready' : 'unavailable')
+      settle(statusCode >= 300 && statusCode < 400 ? 'ready' : 'unavailable')
     })
     request.on('response', (response) => {
       settle(

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { installNetRequestFetchAdapter } from './updater-net-request.fixture'
 import { publishingIncident } from './updater-prerelease-feed-reproduction.fixture'
 
-const { netFetchMock } = vi.hoisted(() => ({ netFetchMock: vi.fn() }))
+const { netFetchMock, netRequestMock } = vi.hoisted(() => ({
+  netFetchMock: vi.fn(),
+  netRequestMock: vi.fn()
+}))
 
 const { appMock, browserWindowMock, nativeUpdaterMock, autoUpdaterMock, isMock, killAllPtyMock } =
   vi.hoisted(() => {
@@ -75,7 +79,7 @@ vi.mock('electron', () => ({
   BrowserWindow: browserWindowMock,
   autoUpdater: nativeUpdaterMock,
   powerMonitor: { on: vi.fn() },
-  net: { fetch: netFetchMock }
+  net: { fetch: netFetchMock, request: netRequestMock }
 }))
 
 vi.mock('electron-updater', () => ({
@@ -173,6 +177,8 @@ describe('updater check failure handling', () => {
       status: 200,
       text: () => Promise.resolve('<feed></feed>')
     })
+    netRequestMock.mockReset()
+    installNetRequestFetchAdapter(netRequestMock, netFetchMock)
   })
 
   it('surfaces GitHub release-transition failures with calmer copy and no short retry', async () => {


### PR DESCRIPTION
## ELI5

On Windows, GitHub release assets are often served through a signed-storage redirect. The
updater was treating that redirect as an unavailable asset, so a published release could be
reported as a generic network failure. The readiness check now recognizes the redirect as proof
that the asset is available.

## What Changed

- Add a redirect-aware `electron.net.request` probe for GitHub release assets.
- Treat GitHub's 302 asset redirect as `ready` without following the signed storage URL.
- Preserve the existing status handling for direct/non-GitHub URLs (`404` = `not-ready`, other
  failures = `unavailable`).
- Add a small request fixture and regression coverage for the Windows release shape.

## Why

I reproduced #17163 on `awin` with Orca 1.4.190: the Windows asset endpoint returned a 302 signed
redirect while the release was published. The old readiness path classified that response as
unavailable and surfaced “Couldn't reach the update server”; the manual GitHub download worked at
the same time. This is an updater readiness classification issue, not a network reachability
failure.

## Linked Issue

Fixes #17163

## Visual Proof

N/A — this changes updater network/readiness classification and adds no layout or visual surface.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Reproduction-first regression: the new test fails against the old implementation when the asset
probe returns the 302 redirect, then passes with the redirect-aware request. The focused updater
suite passes (48 tests), the full updater suite passes (259 tests), and `pnpm tc:node` passes.

The implementation keeps direct URL probes on the existing fetch path and does not change SSH,
WSL, or non-Windows update behavior. Platform state is restored after tests.

## Review

The probe settles exactly once and aborts on timeout/error. It does not follow or parse the signed
storage URL; a redirect is only used as an availability signal. Existing `404`/non-2xx semantics
remain unchanged for direct URLs.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

No new dependency, IPC field, or persisted setting is introduced. The change is compatible with
older release feeds and with native Windows, macOS, Linux, and remote update checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and compatibility impact considered (or N/A)
- [x] `pnpm typecheck`/focused tests pass; CI will run the full build and lint gates
