### PR TITLE
fix(session): deduplicate editor records during restore

### DIFF
--- a/src/renderer/src/store/slices/editor-session-duplicate-restore.test.ts
+++ b/src/renderer/src/store/slices/editor-session-duplicate-restore.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+import type { WorkspaceSessionState } from '../../../../shared/workspace-session-state-types'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+import { buildWorkspaceSessionPayload } from '../../lib/workspace-session'
+import { createStoreSessionMockApi } from './store-session-test-harness'
+import { createTestStore, makeWorktree } from './store-test-helpers'
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return { ...actual, detectAgentStatusFromTitle: vi.fn().mockReturnValue(null) }
+})
+
+createStoreSessionMockApi()
+
+const WORKTREE_ID = 'repo-1::/workspace'
+const FILE_PATH = '/workspace/.scratch/preview.png'
+const SSH_FOLDER_ID = 'ssh-folder'
+const SSH_FOLDER_KEY = folderWorkspaceKey(SSH_FOLDER_ID)
+const SSH_FILE_PATH = '/srv/workspace/.scratch/preview.png'
+
+function prepareStore() {
+  const store = createTestStore()
+  store.setState({
+    repos: [
+      { id: 'repo-1', path: '/workspace', displayName: 'Repo', badgeColor: '#000', addedAt: 0 }
+    ],
+    worktreesByRepo: {
+      'repo-1': [makeWorktree({ id: WORKTREE_ID, repoId: 'repo-1', path: '/workspace' })]
+    },
+    activeWorktreeId: WORKTREE_ID
+  })
+  return store
+}
+
+function prepareSshFolderStore() {
+  const store = createTestStore()
+  store.setState({
+    folderWorkspaces: [
+      {
+        id: SSH_FOLDER_ID,
+        projectGroupId: 'ssh-project',
+        name: 'SSH folder',
+        folderPath: '/srv/workspace',
+        connectionId: 'ssh-target',
+        linkedTask: null,
+        comment: '',
+        isArchived: false,
+        isUnread: false,
+        isPinned: false,
+        sortOrder: 0,
+        lastActivityAt: 0,
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ],
+    activeWorktreeId: SSH_FOLDER_KEY
+  })
+  return store
+}
+
+function corruptSession(worktreeId = WORKTREE_ID, filePath = FILE_PATH): WorkspaceSessionState {
+  const persistedFile = {
+    filePath,
+    relativePath: '.scratch/preview.png',
+    worktreeId,
+    language: 'image'
+  }
+  const editorTab = (id: string, sortOrder: number) => ({
+    id,
+    entityId: filePath,
+    groupId: 'group-restored',
+    worktreeId,
+    contentType: 'editor' as const,
+    label: 'preview.png',
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: 1_788_002_466_152
+  })
+  return {
+    activeRepoId: 'repo-1',
+    activeWorktreeId: worktreeId,
+    activeTabId: null,
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    openFilesByWorktree: {
+      [worktreeId]: [persistedFile, { ...persistedFile }, { ...persistedFile }]
+    },
+    activeFileIdByWorktree: { [worktreeId]: `editor:stale-pane:${filePath}` },
+    activeTabTypeByWorktree: { [worktreeId]: 'editor' },
+    unifiedTabs: {
+      [worktreeId]: [editorTab('editor-restored-a', 0), editorTab('editor-restored-b', 1)]
+    },
+    tabGroups: {
+      [worktreeId]: [
+        {
+          id: 'group-restored',
+          worktreeId,
+          activeTabId: `editor:third-pane:${filePath}`,
+          tabOrder: [`editor:third-pane:${filePath}`]
+        }
+      ]
+    },
+    activeGroupIdByWorktree: { [worktreeId]: 'group-restored' }
+  }
+}
+
+function closeAndRestart(
+  prepare: typeof prepareStore,
+  session: WorkspaceSessionState,
+  workspaceId: string
+) {
+  const store = prepare()
+  store.getState().hydrateTabsSession(session)
+  store.getState().hydrateEditorSession(session)
+
+  expect.soft(store.getState().openFiles).toHaveLength(1)
+  expect.soft(store.getState().unifiedTabsByWorktree[workspaceId]).toHaveLength(1)
+
+  const activeFileId = store.getState().activeFileIdByWorktree[workspaceId]
+  expect(activeFileId).toBeTruthy()
+  store.getState().closeFile(activeFileId!)
+
+  const persistedAfterClose = buildWorkspaceSessionPayload(store.getState())
+  const restartedStore = prepare()
+  restartedStore.getState().hydrateTabsSession(persistedAfterClose)
+  restartedStore.getState().hydrateEditorSession(persistedAfterClose)
+  return restartedStore.getState()
+}
+
+describe('corrupt editor session restore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not preserve duplicate records that resurrect a closed editor', () => {
+    const restarted = closeAndRestart(prepareStore, corruptSession(), WORKTREE_ID)
+    expect(restarted.openFiles).toEqual([])
+    expect(restarted.unifiedTabsByWorktree[WORKTREE_ID] ?? []).toEqual([])
+  })
+
+  it('cleans the same corruption for an SSH-hosted folder workspace', () => {
+    const restarted = closeAndRestart(
+      prepareSshFolderStore,
+      corruptSession(SSH_FOLDER_KEY, SSH_FILE_PATH),
+      SSH_FOLDER_KEY
+    )
+    expect(restarted.openFiles).toEqual([])
+    expect(restarted.unifiedTabsByWorktree[SSH_FOLDER_KEY] ?? []).toEqual([])
+  })
+
+  it('rewrites group references from a duplicate editor row to the survivor', () => {
+    const store = prepareStore()
+    const session = corruptSession()
+    session.tabGroups![WORKTREE_ID]![0] = {
+      ...session.tabGroups![WORKTREE_ID]![0],
+      activeTabId: 'editor-restored-b',
+      tabOrder: ['editor-restored-b'],
+      recentTabIds: ['editor-restored-b']
+    }
+
+    store.getState().hydrateTabsSession(session)
+
+    expect(store.getState().unifiedTabsByWorktree[WORKTREE_ID].map((tab) => tab.id)).toEqual([
+      'editor-restored-a'
+    ])
+    expect(store.getState().groupsByWorktree[WORKTREE_ID][0]).toEqual(
+      expect.objectContaining({
+        activeTabId: 'editor-restored-a',
+        tabOrder: ['editor-restored-a'],
+        recentTabIds: ['editor-restored-a']
+      })
+    )
+  })
+
+  it('preserves shared editor entities in separate split groups', () => {
+    const store = prepareStore()
+    const session = corruptSession()
+    const [left, right] = session.unifiedTabs![WORKTREE_ID]!
+    session.unifiedTabs![WORKTREE_ID] = [
+      { ...left, id: 'editor-left', groupId: 'group-left' },
+      { ...right, id: 'editor-right', groupId: 'group-right' }
+    ]
+    session.tabGroups![WORKTREE_ID] = [
+      {
+        id: 'group-left',
+        worktreeId: WORKTREE_ID,
+        activeTabId: 'editor-left',
+        tabOrder: ['editor-left']
+      },
+      {
+        id: 'group-right',
+        worktreeId: WORKTREE_ID,
+        activeTabId: 'editor-right',
+        tabOrder: ['editor-right']
+      }
+    ]
+
+    store.getState().hydrateTabsSession(session)
+    store.getState().hydrateEditorSession(session)
+
+    expect(store.getState().openFiles).toHaveLength(1)
+    expect(store.getState().unifiedTabsByWorktree[WORKTREE_ID].map((tab) => tab.id)).toEqual([
+      'editor-left',
+      'editor-right'
+    ])
+  })
+})

--- a/src/renderer/src/store/slices/editor-session-duplicate-restore.test.ts
+++ b/src/renderer/src/store/slices/editor-session-duplicate-restore.test.ts
@@ -299,4 +299,60 @@ describe('corrupt editor session restore', () => {
       expect.objectContaining({ id: 'group-b', tabOrder: ['group-b-only'], activeTabId: null })
     ])
   })
+
+  it('keeps a stale cross-group reference away from a surviving declared owner', () => {
+    const store = prepareStore()
+    const session = corruptSession()
+    session.unifiedTabs![WORKTREE_ID] = [
+      {
+        ...session.unifiedTabs![WORKTREE_ID]![0],
+        id: 'shared-id',
+        entityId: '/workspace/.scratch/shared.png',
+        groupId: 'group-a',
+        label: 'shared.png',
+        sortOrder: 0
+      },
+      {
+        ...session.unifiedTabs![WORKTREE_ID]![0],
+        id: 'group-a-only',
+        entityId: '/workspace/.scratch/group-a-only.png',
+        groupId: 'group-a',
+        label: 'group-a-only.png',
+        sortOrder: 1
+      },
+      {
+        ...session.unifiedTabs![WORKTREE_ID]![1],
+        id: 'group-b-only',
+        entityId: '/workspace/.scratch/group-b-only.png',
+        groupId: 'group-b',
+        label: 'group-b-only.png',
+        sortOrder: 2
+      }
+    ]
+    session.tabGroups![WORKTREE_ID] = [
+      {
+        id: 'group-b',
+        worktreeId: WORKTREE_ID,
+        activeTabId: 'shared-id',
+        tabOrder: ['shared-id', 'group-b-only']
+      },
+      {
+        id: 'group-a',
+        worktreeId: WORKTREE_ID,
+        activeTabId: 'group-a-only',
+        tabOrder: ['group-a-only']
+      }
+    ]
+
+    store.getState().hydrateTabsSession(session)
+
+    expect(store.getState().groupsByWorktree[WORKTREE_ID]).toEqual([
+      expect.objectContaining({ id: 'group-b', tabOrder: ['group-b-only'], activeTabId: null }),
+      expect.objectContaining({
+        id: 'group-a',
+        tabOrder: ['group-a-only', 'shared-id'],
+        activeTabId: 'group-a-only'
+      })
+    ])
+  })
 })

--- a/src/renderer/src/store/slices/editor-session-duplicate-restore.test.ts
+++ b/src/renderer/src/store/slices/editor-session-duplicate-restore.test.ts
@@ -247,4 +247,56 @@ describe('corrupt editor session restore', () => {
       'editor-right'
     ])
   })
+
+  it('does not let a globally duplicated id hydrate into another group', () => {
+    const store = prepareStore()
+    const session = corruptSession()
+    session.unifiedTabs![WORKTREE_ID] = [
+      {
+        ...session.unifiedTabs![WORKTREE_ID]![0],
+        id: 'shared-id',
+        entityId: '/workspace/.scratch/group-a.png',
+        groupId: 'group-a',
+        label: 'group-a.png',
+        sortOrder: 0
+      },
+      {
+        ...session.unifiedTabs![WORKTREE_ID]![1],
+        id: 'shared-id',
+        entityId: '/workspace/.scratch/group-b.png',
+        groupId: 'group-b',
+        label: 'group-b.png',
+        sortOrder: 1
+      },
+      {
+        ...session.unifiedTabs![WORKTREE_ID]![1],
+        id: 'group-b-only',
+        entityId: '/workspace/.scratch/group-b-only.png',
+        groupId: 'group-b',
+        label: 'group-b-only.png',
+        sortOrder: 2
+      }
+    ]
+    session.tabGroups![WORKTREE_ID] = [
+      {
+        id: 'group-a',
+        worktreeId: WORKTREE_ID,
+        activeTabId: 'shared-id',
+        tabOrder: ['shared-id']
+      },
+      {
+        id: 'group-b',
+        worktreeId: WORKTREE_ID,
+        activeTabId: 'shared-id',
+        tabOrder: ['shared-id', 'group-b-only']
+      }
+    ]
+
+    store.getState().hydrateTabsSession(session)
+
+    expect(store.getState().groupsByWorktree[WORKTREE_ID]).toEqual([
+      expect.objectContaining({ id: 'group-a', tabOrder: ['shared-id'] }),
+      expect.objectContaining({ id: 'group-b', tabOrder: ['group-b-only'], activeTabId: null })
+    ])
+  })
 })

--- a/src/renderer/src/store/slices/editor-session-duplicate-restore.test.ts
+++ b/src/renderer/src/store/slices/editor-session-duplicate-restore.test.ts
@@ -175,6 +175,46 @@ describe('corrupt editor session restore', () => {
     )
   })
 
+  it('does not redirect a stale alias reference into another group', () => {
+    const store = prepareStore()
+    const session = corruptSession()
+    const [left, right] = session.unifiedTabs![WORKTREE_ID]!
+    session.unifiedTabs![WORKTREE_ID] = [
+      { ...left, id: 'editor-group-a-left', groupId: 'group-a' },
+      { ...right, id: 'editor-group-a-duplicate', groupId: 'group-a' },
+      {
+        ...right,
+        id: 'editor-group-b',
+        entityId: '/workspace/.scratch/other.png',
+        groupId: 'group-b',
+        label: 'other.png',
+        sortOrder: 2
+      }
+    ]
+    session.tabGroups![WORKTREE_ID] = [
+      {
+        id: 'group-a',
+        worktreeId: WORKTREE_ID,
+        activeTabId: 'editor-group-a-duplicate',
+        tabOrder: ['editor-group-a-left', 'editor-group-a-duplicate']
+      },
+      {
+        id: 'group-b',
+        worktreeId: WORKTREE_ID,
+        activeTabId: 'editor-group-b',
+        // This stale reference must not be rewritten with group-a's alias.
+        tabOrder: ['editor-group-a-duplicate', 'editor-group-b']
+      }
+    ]
+
+    store.getState().hydrateTabsSession(session)
+
+    expect(store.getState().groupsByWorktree[WORKTREE_ID]).toEqual([
+      expect.objectContaining({ id: 'group-a', tabOrder: ['editor-group-a-left'] }),
+      expect.objectContaining({ id: 'group-b', tabOrder: ['editor-group-b'] })
+    ])
+  })
+
   it('preserves shared editor entities in separate split groups', () => {
     const store = prepareStore()
     const session = corruptSession()

--- a/src/renderer/src/store/slices/editor/actions/hydrate-editor-session.ts
+++ b/src/renderer/src/store/slices/editor/actions/hydrate-editor-session.ts
@@ -7,7 +7,7 @@ import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import type { WorkspaceVisibleTabType } from '../../../../../../shared/tab-types'
 import type { OpenFile } from '../types/open-file'
 import { buildValidWorktreeIdsForSessionHydration } from '../../degraded-repo-worktree-validity'
-import { buildOwnedEditorFileId } from '../file-ids/editor-file-ids'
+import { buildOwnedEditorFileId, isSameEditorOwner } from '../file-ids/editor-file-ids'
 import {
   addEditorFileIdMigration,
   migrateEditorFileId,
@@ -49,6 +49,16 @@ export function createHydrateEditorSession(
             continue
           }
           for (const pf of files) {
+            // Split tabs share one OpenFile; repeated records for the same owner are corruption.
+            if (
+              legacyHydratedOpenFiles.some(
+                (file) =>
+                  file.filePath === pf.filePath &&
+                  isSameEditorOwner(file, worktreeId, pf.runtimeEnvironmentId)
+              )
+            ) {
+              continue
+            }
             const legacyId = resolveLegacyHydratedEditorFileId(
               legacyHydratedOpenFiles,
               pf,

--- a/src/renderer/src/store/slices/tab-group-reference-repair.ts
+++ b/src/renderer/src/store/slices/tab-group-reference-repair.ts
@@ -30,6 +30,30 @@ export function layoutSpanningGroups(
     )
 }
 
+/** Prevent one retained tab row from hydrating into multiple groups. */
+export function resolveTabGroupOwners(
+  tabs: readonly Tab[],
+  groups: readonly TabGroup[],
+  tabIdAliasesByGroup?: Map<string, Map<string, string>>
+): Map<string, string> {
+  const tabGroupIdById = new Map(tabs.map((tab) => [tab.id, tab.groupId]))
+  const tabOwners = new Map<string, string>()
+  for (const group of groups) {
+    const tabIdAliases = tabIdAliasesByGroup?.get(group.id)
+    for (const persistedTabId of group.tabOrder) {
+      const tabId = tabIdAliases?.get(persistedTabId) ?? persistedTabId
+      const persistedOwner = tabGroupIdById.get(tabId)
+      if (persistedOwner === undefined) {
+        continue
+      }
+      if (!tabOwners.has(tabId) || group.id === persistedOwner) {
+        tabOwners.set(tabId, group.id)
+      }
+    }
+  }
+  return tabOwners
+}
+
 /** Re-home tabs stranded by a dropped group so hydration cannot render a blank workspace. */
 export function adoptGrouplessTabs(
   tabsByWorktree: Record<string, Tab[]>,

--- a/src/renderer/src/store/slices/tab-group-reference-repair.ts
+++ b/src/renderer/src/store/slices/tab-group-reference-repair.ts
@@ -36,22 +36,47 @@ export function resolveTabGroupOwners(
   groups: readonly TabGroup[],
   tabIdAliasesByGroup?: Map<string, Map<string, string>>
 ): Map<string, string> {
+  const persistedGroupIds = new Set(groups.map((group) => group.id))
   const tabGroupIdById = new Map(tabs.map((tab) => [tab.id, tab.groupId]))
-  const tabOwners = new Map<string, string>()
+  const tabOwners = new Map(
+    tabs.filter((tab) => persistedGroupIds.has(tab.groupId)).map((tab) => [tab.id, tab.groupId])
+  )
   for (const group of groups) {
     const tabIdAliases = tabIdAliasesByGroup?.get(group.id)
     for (const persistedTabId of group.tabOrder) {
       const tabId = tabIdAliases?.get(persistedTabId) ?? persistedTabId
-      const persistedOwner = tabGroupIdById.get(tabId)
-      if (persistedOwner === undefined) {
+      if (!tabGroupIdById.has(tabId)) {
         continue
       }
-      if (!tabOwners.has(tabId) || group.id === persistedOwner) {
+      if (!tabOwners.has(tabId)) {
         tabOwners.set(tabId, group.id)
       }
     }
   }
   return tabOwners
+}
+
+/** Restore declared-owner rows omitted from a persisted tab order. */
+export function appendOwnedTabIdsToGroups(
+  groups: readonly TabGroup[],
+  tabOwners: ReadonlyMap<string, string>
+): TabGroup[] {
+  const tabIdsByGroup = new Map<string, string[]>()
+  for (const [tabId, groupId] of tabOwners) {
+    const tabIds = tabIdsByGroup.get(groupId) ?? []
+    tabIds.push(tabId)
+    tabIdsByGroup.set(groupId, tabIds)
+  }
+  return groups.map((group) => {
+    const ownedTabIds = tabIdsByGroup.get(group.id)
+    if (!ownedTabIds) {
+      return group
+    }
+    const missingTabIds = ownedTabIds.filter((tabId) => !group.tabOrder.includes(tabId))
+    return missingTabIds.length > 0
+      ? { ...group, tabOrder: [...group.tabOrder, ...missingTabIds] }
+      : group
+  })
 }
 
 /** Re-home tabs stranded by a dropped group so hydration cannot render a blank workspace. */

--- a/src/renderer/src/store/slices/tab-group-state.ts
+++ b/src/renderer/src/store/slices/tab-group-state.ts
@@ -201,6 +201,30 @@ export function dedupeTabsById<T extends { id: string }>(tabs: T[]): T[] {
   })
 }
 
+export function dedupeEditorTabsWithinGroups(tabs: Tab[]): {
+  tabs: Tab[]
+  tabIdAliases: Map<string, string>
+} {
+  const tabIdAliases = new Map<string, string>()
+  const editorTabIdByGroupAndEntity = new Map<string, Map<string, string>>()
+  const dedupedTabs = dedupeTabsById(tabs).filter((tab) => {
+    if (tab.contentType !== 'editor') {
+      return true
+    }
+    const editorTabIdByEntity =
+      editorTabIdByGroupAndEntity.get(tab.groupId) ?? new Map<string, string>()
+    editorTabIdByGroupAndEntity.set(tab.groupId, editorTabIdByEntity)
+    const existingTabId = editorTabIdByEntity.get(tab.entityId)
+    if (existingTabId !== undefined) {
+      tabIdAliases.set(tab.id, existingTabId)
+      return false
+    }
+    editorTabIdByEntity.set(tab.entityId, tab.id)
+    return true
+  })
+  return { tabs: dedupedTabs, tabIdAliases }
+}
+
 export function dedupeTabOrder(tabIds: string[]): string[] {
   const seen = new Set<string>()
   const deduped: string[] = []

--- a/src/renderer/src/store/slices/tab-group-state.ts
+++ b/src/renderer/src/store/slices/tab-group-state.ts
@@ -203,9 +203,9 @@ export function dedupeTabsById<T extends { id: string }>(tabs: T[]): T[] {
 
 export function dedupeEditorTabsWithinGroups(tabs: Tab[]): {
   tabs: Tab[]
-  tabIdAliases: Map<string, string>
+  tabIdAliasesByGroup: Map<string, Map<string, string>>
 } {
-  const tabIdAliases = new Map<string, string>()
+  const tabIdAliasesByGroup = new Map<string, Map<string, string>>()
   const editorTabIdByGroupAndEntity = new Map<string, Map<string, string>>()
   const dedupedTabs = dedupeTabsById(tabs).filter((tab) => {
     if (tab.contentType !== 'editor') {
@@ -216,13 +216,15 @@ export function dedupeEditorTabsWithinGroups(tabs: Tab[]): {
     editorTabIdByGroupAndEntity.set(tab.groupId, editorTabIdByEntity)
     const existingTabId = editorTabIdByEntity.get(tab.entityId)
     if (existingTabId !== undefined) {
+      const tabIdAliases = tabIdAliasesByGroup.get(tab.groupId) ?? new Map<string, string>()
+      tabIdAliasesByGroup.set(tab.groupId, tabIdAliases)
       tabIdAliases.set(tab.id, existingTabId)
       return false
     }
     editorTabIdByEntity.set(tab.entityId, tab.id)
     return true
   })
-  return { tabs: dedupedTabs, tabIdAliases }
+  return { tabs: dedupedTabs, tabIdAliasesByGroup }
 }
 
 export function dedupeTabOrder(tabIds: string[]): string[] {

--- a/src/renderer/src/store/slices/tabs-hydration.test.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.test.ts
@@ -414,9 +414,9 @@ describe('buildHydratedTabState – legacy format', () => {
     // Why: editor owner migration re-stamped a tab id a sibling record already
     // held. Two rows under one id repeat a React key and strand a ghost row.
     const duplicateId = 'editor:wt%3A%3Alungfish:env-a:FINAL-REPORT.md'
-    const editorTab = (id: string, sortOrder: number) => ({
+    const editorTab = (id: string, entityId: string, sortOrder: number) => ({
       id,
-      entityId: 'editor:wt%3A%3Alungfish:env-b:FINAL-REPORT.md',
+      entityId,
       groupId: 'g1',
       worktreeId: 'w1',
       contentType: 'editor' as const,
@@ -429,7 +429,11 @@ describe('buildHydratedTabState – legacy format', () => {
     const session: WorkspaceSessionState = {
       ...makeBaseSession(),
       unifiedTabs: {
-        w1: [editorTab('t-unique', 0), editorTab(duplicateId, 1), editorTab(duplicateId, 2)]
+        w1: [
+          editorTab('t-unique', 'editor:wt%3A%3Alungfish:env-c:FINAL-REPORT.md', 0),
+          editorTab(duplicateId, 'editor:wt%3A%3Alungfish:env-b:FINAL-REPORT.md', 1),
+          editorTab(duplicateId, 'editor:wt%3A%3Alungfish:env-b:FINAL-REPORT.md', 2)
+        ]
       },
       tabGroups: {
         w1: [

--- a/src/renderer/src/store/slices/tabs-hydration.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.ts
@@ -4,8 +4,8 @@ import { isValidTerminalTabId } from '../../../../shared/terminal-tab-id'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { adoptGrouplessTabs, layoutSpanningGroups } from './tab-group-reference-repair'
 import {
+  dedupeEditorTabsWithinGroups,
   dedupeTabOrder,
-  dedupeTabsById,
   getPersistedEditFileIdsByWorktree,
   isTransientEditorContentType,
   sanitizeRecentTabIds,
@@ -66,6 +66,7 @@ function hydrateUnifiedFormat(
   const groupsByWorktree: Record<string, TabGroup[]> = {}
   const activeGroupIdByWorktree: Record<string, string> = {}
   const layoutByWorktree: Record<string, TabGroupLayoutNode> = {}
+  const tabIdAliasesByWorktree: Record<string, Map<string, string>> = {}
   const persistedEditFileIdsByWorktree = getPersistedEditFileIdsByWorktree(session)
 
   for (const [worktreeId, tabs] of Object.entries(session.unifiedTabs!)) {
@@ -137,7 +138,9 @@ function hydrateUnifiedFormat(
       })
       .sort((a, b) => a.sortOrder - b.sortOrder || a.createdAt - b.createdAt)
     // Why after the sort: the surviving record is the one the strip renders first.
-    tabsByWorktree[worktreeId] = dedupeTabsById(hydratedTabs)
+    const deduped = dedupeEditorTabsWithinGroups(hydratedTabs)
+    tabsByWorktree[worktreeId] = deduped.tabs
+    tabIdAliasesByWorktree[worktreeId] = deduped.tabIdAliases
   }
 
   for (const [worktreeId, groups] of Object.entries(session.tabGroups!)) {
@@ -149,17 +152,23 @@ function hydrateUnifiedFormat(
     }
 
     const validTabIds = new Set((tabsByWorktree[worktreeId] ?? []).map((t) => t.id))
+    const tabIdAliases = tabIdAliasesByWorktree[worktreeId]
+    const canonicalTabId = (tabId: string): string => tabIdAliases?.get(tabId) ?? tabId
     const validatedGroups = groups.map((g) => {
       // Why: persisted tabOrder can contain duplicates from older buggy
       // writes. Deduping during hydration restores the store invariant before
       // later group operations branch on tab counts or neighbors.
-      const tabOrder = dedupeTabOrder(g.tabOrder.filter((tid) => validTabIds.has(tid)))
-      const activeTabId = g.activeTabId && validTabIds.has(g.activeTabId) ? g.activeTabId : null
+      const tabOrder = dedupeTabOrder(
+        g.tabOrder.map(canonicalTabId).filter((tid) => validTabIds.has(tid))
+      )
+      const canonicalActiveTabId = g.activeTabId ? canonicalTabId(g.activeTabId) : null
+      const activeTabId =
+        canonicalActiveTabId && validTabIds.has(canonicalActiveTabId) ? canonicalActiveTabId : null
       // Why: persisted MRU may reference tabs that no longer exist. Sanitize
       // against the live tabOrder, then ensure the current active tab sits at
       // the tail so the first close after restore jumps back to the previous
       // tab rather than falling through to neighbor selection.
-      const sanitizedRecent = sanitizeRecentTabIds(g.recentTabIds, tabOrder)
+      const sanitizedRecent = sanitizeRecentTabIds(g.recentTabIds?.map(canonicalTabId), tabOrder)
       const recentTabIds =
         activeTabId && sanitizedRecent.at(-1) !== activeTabId
           ? [...sanitizedRecent.filter((id) => id !== activeTabId), activeTabId]

--- a/src/renderer/src/store/slices/tabs-hydration.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.ts
@@ -4,6 +4,7 @@ import { isValidTerminalTabId } from '../../../../shared/terminal-tab-id'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import {
   adoptGrouplessTabs,
+  appendOwnedTabIdsToGroups,
   layoutSpanningGroups,
   resolveTabGroupOwners
 } from './tab-group-reference-repair'
@@ -156,26 +157,20 @@ function hydrateUnifiedFormat(
     }
 
     const hydratedTabsForWorktree = tabsByWorktree[worktreeId] ?? []
-    const validTabIds = new Set(hydratedTabsForWorktree.map((tab) => tab.id))
     const tabIdAliasesByGroup = tabIdAliasesByWorktree[worktreeId]
     const tabOwners = resolveTabGroupOwners(hydratedTabsForWorktree, groups, tabIdAliasesByGroup)
-
-    const validatedGroups = groups.map((g) => {
+    const validatedGroups = appendOwnedTabIdsToGroups(groups, tabOwners).map((g) => {
       const tabIdAliases = tabIdAliasesByGroup?.get(g.id)
       const canonicalTabId = (tabId: string): string => tabIdAliases?.get(tabId) ?? tabId
       // Why: persisted tabOrder can contain duplicates from older buggy
       // writes. Deduping during hydration restores the store invariant before
       // later group operations branch on tab counts or neighbors.
       const tabOrder = dedupeTabOrder(
-        g.tabOrder
-          .map(canonicalTabId)
-          .filter((tid) => validTabIds.has(tid) && tabOwners.get(tid) === g.id)
+        g.tabOrder.map(canonicalTabId).filter((tid) => tabOwners.get(tid) === g.id)
       )
       const canonicalActiveTabId = g.activeTabId ? canonicalTabId(g.activeTabId) : null
       const activeTabId =
-        canonicalActiveTabId &&
-        validTabIds.has(canonicalActiveTabId) &&
-        tabOwners.get(canonicalActiveTabId) === g.id
+        canonicalActiveTabId && tabOwners.get(canonicalActiveTabId) === g.id
           ? canonicalActiveTabId
           : null
       // Why: persisted MRU may reference tabs that no longer exist. Sanitize

--- a/src/renderer/src/store/slices/tabs-hydration.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.ts
@@ -2,7 +2,11 @@ import type { Tab, TabGroup, TabGroupLayoutNode } from '../../../../shared/tab-t
 import type { WorkspaceSessionState } from '../../../../shared/workspace-session-state-types'
 import { isValidTerminalTabId } from '../../../../shared/terminal-tab-id'
 import { createBrowserUuid } from '@/lib/browser-uuid'
-import { adoptGrouplessTabs, layoutSpanningGroups } from './tab-group-reference-repair'
+import {
+  adoptGrouplessTabs,
+  layoutSpanningGroups,
+  resolveTabGroupOwners
+} from './tab-group-reference-repair'
 import {
   dedupeEditorTabsWithinGroups,
   dedupeTabOrder,
@@ -151,8 +155,11 @@ function hydrateUnifiedFormat(
       continue
     }
 
-    const validTabIds = new Set((tabsByWorktree[worktreeId] ?? []).map((t) => t.id))
+    const hydratedTabsForWorktree = tabsByWorktree[worktreeId] ?? []
+    const validTabIds = new Set(hydratedTabsForWorktree.map((tab) => tab.id))
     const tabIdAliasesByGroup = tabIdAliasesByWorktree[worktreeId]
+    const tabOwners = resolveTabGroupOwners(hydratedTabsForWorktree, groups, tabIdAliasesByGroup)
+
     const validatedGroups = groups.map((g) => {
       const tabIdAliases = tabIdAliasesByGroup?.get(g.id)
       const canonicalTabId = (tabId: string): string => tabIdAliases?.get(tabId) ?? tabId
@@ -160,11 +167,17 @@ function hydrateUnifiedFormat(
       // writes. Deduping during hydration restores the store invariant before
       // later group operations branch on tab counts or neighbors.
       const tabOrder = dedupeTabOrder(
-        g.tabOrder.map(canonicalTabId).filter((tid) => validTabIds.has(tid))
+        g.tabOrder
+          .map(canonicalTabId)
+          .filter((tid) => validTabIds.has(tid) && tabOwners.get(tid) === g.id)
       )
       const canonicalActiveTabId = g.activeTabId ? canonicalTabId(g.activeTabId) : null
       const activeTabId =
-        canonicalActiveTabId && validTabIds.has(canonicalActiveTabId) ? canonicalActiveTabId : null
+        canonicalActiveTabId &&
+        validTabIds.has(canonicalActiveTabId) &&
+        tabOwners.get(canonicalActiveTabId) === g.id
+          ? canonicalActiveTabId
+          : null
       // Why: persisted MRU may reference tabs that no longer exist. Sanitize
       // against the live tabOrder, then ensure the current active tab sits at
       // the tail so the first close after restore jumps back to the previous

--- a/src/renderer/src/store/slices/tabs-hydration.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.ts
@@ -66,7 +66,7 @@ function hydrateUnifiedFormat(
   const groupsByWorktree: Record<string, TabGroup[]> = {}
   const activeGroupIdByWorktree: Record<string, string> = {}
   const layoutByWorktree: Record<string, TabGroupLayoutNode> = {}
-  const tabIdAliasesByWorktree: Record<string, Map<string, string>> = {}
+  const tabIdAliasesByWorktree: Record<string, Map<string, Map<string, string>>> = {}
   const persistedEditFileIdsByWorktree = getPersistedEditFileIdsByWorktree(session)
 
   for (const [worktreeId, tabs] of Object.entries(session.unifiedTabs!)) {
@@ -140,7 +140,7 @@ function hydrateUnifiedFormat(
     // Why after the sort: the surviving record is the one the strip renders first.
     const deduped = dedupeEditorTabsWithinGroups(hydratedTabs)
     tabsByWorktree[worktreeId] = deduped.tabs
-    tabIdAliasesByWorktree[worktreeId] = deduped.tabIdAliases
+    tabIdAliasesByWorktree[worktreeId] = deduped.tabIdAliasesByGroup
   }
 
   for (const [worktreeId, groups] of Object.entries(session.tabGroups!)) {
@@ -152,9 +152,10 @@ function hydrateUnifiedFormat(
     }
 
     const validTabIds = new Set((tabsByWorktree[worktreeId] ?? []).map((t) => t.id))
-    const tabIdAliases = tabIdAliasesByWorktree[worktreeId]
-    const canonicalTabId = (tabId: string): string => tabIdAliases?.get(tabId) ?? tabId
+    const tabIdAliasesByGroup = tabIdAliasesByWorktree[worktreeId]
     const validatedGroups = groups.map((g) => {
+      const tabIdAliases = tabIdAliasesByGroup?.get(g.id)
+      const canonicalTabId = (tabId: string): string => tabIdAliases?.get(tabId) ?? tabId
       // Why: persisted tabOrder can contain duplicates from older buggy
       // writes. Deduping during hydration restores the store invariant before
       // later group operations branch on tab counts or neighbors.


### PR DESCRIPTION
## ELI5

Session restore could keep several records for the same editor file. Closing the visible tab
removed only one record, so the stale ones recreated the tab on the next restart. Restore now
keeps one record for each editor owner/file and repairs every tab reference to that survivor.

## What Changed

- Dedupe same-owner `OpenFile` records while hydrating an editor session.
- Dedupe repeated editor tabs for the same entity within a tab group while preserving the first
  (stable) row.
- Rewrite `tabOrder`, active-tab, and MRU references through the survivor alias before validating
  the hydrated groups.
- Keep the same editor entity in separate split groups; only duplicate rows in one group are
  collapsed.
- Add regression coverage for corrupted persisted sessions, close/restart behavior, and an
  SSH-hosted folder workspace.

## Why

I reproduced #17185 from the reported persisted state: duplicate `openFilesByWorktree` entries,
duplicate `unifiedTabs` rows, and group/active references to stale editor IDs caused a closed PNG
tab to resurrect after restart. The old hydration path only removed duplicate tab IDs, not the
same-file/same-owner records that minted the ghost tab.

## Linked Issue

Fixes #17185

## Visual Proof

N/A — this is persisted-session hydration and reference repair; there is no new visual surface.

## Testing

- [x] I manually reproduced the persisted duplicate-record state before changing the code
- [x] Automated tests added/updated

The focused restore/hydration run passes (157 tests across the issue-focused files), including the
new close/restart regression and SSH/folder-workspace case. `pnpm tc` and the changed-code quality
gate pass. The tests assert that a closed editor stays closed after a second hydration and that
split groups sharing an entity remain intact.

## Review

The repair is bounded to hydration: it does not rewrite persisted data in place, and it aliases
only IDs that were actually removed. Existing terminal/browser tabs and separate split groups are
left unchanged. Folder workspaces and SSH-scoped session keys use the same ownership check.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

No RPC, wire field, dependency, or platform-specific process behavior changes. The logic runs on
local, folder, SSH, and mixed-version session payloads using the existing optional fields.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and compatibility impact considered (or N/A)
- [x] `pnpm typecheck`/focused tests pass; CI will run the full build and lint gates
