### PR TITLE
chore(deps): remove pdfjs-dist release exception

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,9 +5,6 @@
 packages: []
 
 minimumReleaseAge: 4320
-# 6.3.289 is younger than the 3-day age gate; drop this once it ages.
-minimumReleaseAgeExclude:
-  - pdfjs-dist
 shamefullyHoist: true
 
 supportedArchitectures:


### PR DESCRIPTION
Remove the temporary minimumReleaseAgeExclude entry for pdfjs-dist now that the dependency no longer needs an install-age bypass.

Note: pdfjs-dist@6.3.289 is currently younger than the repository's 3-day minimum release age, so the supply-chain install check may remain blocked until it ages.