### PR TITLE
refactor(preflight): rename execCommandInWsl to execCommandInWslOrThrow

### DIFF
--- a/docs/reference/wsl-probe-failure-semantics.md
+++ b/docs/reference/wsl-probe-failure-semantics.md
@@ -12,7 +12,7 @@ answer.
 
 ```ts
 try {
-  await execCommandInWsl(target, `${shellQuote(command)} --version`)
+  await execCommandInWslOrThrow(target, `${shellQuote(command)} --version`)
   return true
 } catch {
   return false // "not installed" and "could not ask" are now the same value

--- a/src/main/ipc/preflight-command-exec.ts
+++ b/src/main/ipc/preflight-command-exec.ts
@@ -58,7 +58,10 @@ export async function execLocalPreflightCommand(
   return withPreflightTimeout(command, commandPromise)
 }
 
-export async function execCommandInWsl(
+// Throws on any failure — a distro that is booting/unreachable throws the
+// same way a command that genuinely doesn't exist does. Callers must not
+// collapse both into "absent"; see docs/reference/wsl-probe-failure-semantics.md.
+export async function execCommandInWslOrThrow(
   target: WslPreflightTarget,
   command: string
 ): Promise<PreflightCommandResult> {
@@ -75,7 +78,7 @@ export async function isCommandAvailable(
 ): Promise<boolean> {
   try {
     await (wslTarget
-      ? execCommandInWsl(wslTarget, `${shellQuote(command)} --version`)
+      ? execCommandInWslOrThrow(wslTarget, `${shellQuote(command)} --version`)
       : execLocalPreflightCommand(command, ['--version']))
     return true
   } catch {
@@ -97,7 +100,7 @@ export async function isCommandOnPath(
   }
   try {
     // Why: preflight must validate the executable on PATH, not a shell alias or function.
-    const { stdout } = await execCommandInWsl(
+    const { stdout } = await execCommandInWslOrThrow(
       wslTarget,
       [
         // Same skip as agent detection: without it this branch answers "yes"

--- a/src/main/preflight/agent-detection.ts
+++ b/src/main/preflight/agent-detection.ts
@@ -29,7 +29,7 @@ import {
 export type { PreflightRuntimeContext }
 import { hydrateShellPathForAgentDetection } from '../ipc/agent-detection-shell-path'
 import {
-  execCommandInWsl,
+  execCommandInWslOrThrow,
   execLocalPreflightCommand,
   isCommandAvailable,
   isCommandOnPath,
@@ -254,7 +254,7 @@ export async function detectRemoteAgents(args: { connectionId: string }): Promis
 async function isGhAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {
   try {
     await (wslTarget
-      ? execCommandInWsl(wslTarget, `${shellQuote('gh')} auth status`)
+      ? execCommandInWslOrThrow(wslTarget, `${shellQuote('gh')} auth status`)
       : execLocalPreflightCommand('gh', ['auth', 'status']))
     // Why: for plain-text `gh auth status`, exit 0 means gh did not detect any
     // authentication issues for the checked hosts/accounts.
@@ -275,7 +275,7 @@ async function isGhAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolea
 async function isGlabAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {
   try {
     await (wslTarget
-      ? execCommandInWsl(wslTarget, `${shellQuote('glab')} auth status`)
+      ? execCommandInWslOrThrow(wslTarget, `${shellQuote('glab')} auth status`)
       : execLocalPreflightCommand('glab', ['auth', 'status']))
     return true
   } catch (error) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## Why

Orca has a recurring WSL bug class: a probe that **cannot reach** its distro returns the same value as one that asked and got "no". It has shipped three times — the preflight CLI cache (#17350), the `glab auth status` VM wakeups (#8941), and `listRunningWslDistrosAsync` failing closed (#17072).

`execCommandInWsl` throws on failure, and its callers wrap it like this:

```ts
try {
  await execCommandInWsl(target, `${shellQuote(command)} --version`)
  return true
} catch {
  return false // "not installed" and "could not ask" are now the same value
}
```

Naming it `...OrThrow` puts the throwing contract in front of whoever writes that `catch`, so the swallow is visible at the call site rather than something you have to go read the callee to discover. It pairs with the ratchet and reference doc added in #17352.

## Change

Pure mechanical rename — no behaviour, signature, or error-handling changes.

- `src/main/ipc/preflight-command-exec.ts` — export renamed, both internal call sites updated, doc comment now states the throwing contract and that callers must distinguish "absent" from "unreachable".
- `src/main/preflight/agent-detection.ts` — import + 2 call sites (`gh auth status`, `glab auth status`).
- `docs/reference/wsl-probe-failure-semantics.md` — the canonical example now shows the name a reader will actually grep for.

5 call sites total. No test changes needed — mocks target the module, not this symbol.

## Follow-up, deliberately not here

`execLocalPreflightCommand` (same file) has the **identical** throwing contract and sits in the same `try { … } catch { return false }` blocks. After this rename the pair reads inconsistently — one says `OrThrow`, the other doesn't, while both collapse to a silent `false`. Worth its own small PR; kept out to keep this diff mechanical.

## Verification

- `pnpm run typecheck` (full, not just `tc:node`) — clean
- `pnpm test src/main/ipc/preflight src/main/wsl/wsl-probe-failure-semantics.test.ts` — 83 passed / 1 skipped
- `oxlint` on both changed source files — clean