### PR TITLE
fix(linear): stop the filter coverage warning firing on complete selections

### DIFF
--- a/src/renderer/src/components/linear-issue-attribute-filter-coverage-agreement.test.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-coverage-agreement.test.ts
@@ -1,0 +1,40 @@
+// Why: the pill and the in-section notice are the same claim in two places, so they must be
+// driven by one predicate — a pill reading "partial" over a silent section is a real lie.
+import { describe, expect, it } from 'vitest'
+import { LinearFacetCoverageNotice } from './linear-issue-attribute-filter-coverage-notice'
+import { isLinearMetadataGroupSelectionPartial } from './linear-issue-attribute-filter-team-ids'
+
+function randomGroups(rng: () => number): { key: string; ids: string[] }[] {
+  const count = 1 + Math.floor(rng() * 8)
+  let next = 0
+  return Array.from({ length: count }, (_unused, group) => ({
+    key: `g${group}`,
+    ids: Array.from({ length: 1 + Math.floor(rng() * 4) }, () => `id-${next++}`)
+  }))
+}
+
+describe('coverage pill and notice agree', () => {
+  it('shows the notice exactly when the pill reads partial', () => {
+    let seed = 1337
+    const rng = (): number => {
+      seed = (seed * 1103515245 + 12345) % 2147483648
+      return seed / 2147483648
+    }
+
+    for (let run = 0; run < 20000; run += 1) {
+      const groups = randomGroups(rng)
+      const every = groups.flatMap((group) => group.ids)
+      const selected = every.filter(() => rng() < 0.5)
+      const truncated = rng() < 0.3
+      const partial = isLinearMetadataGroupSelectionPartial(groups, selected, truncated)
+      const notice = LinearFacetCoverageNotice({
+        facet: 'status',
+        options: groups,
+        selectedIds: selected,
+        max: 100,
+        truncated
+      })
+      expect(notice === null).toBe(!partial)
+    }
+  })
+})

--- a/src/renderer/src/components/linear-issue-attribute-filter-coverage-notice.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-coverage-notice.tsx
@@ -40,15 +40,18 @@ export function LinearFacetCoverageNotice({
   facet,
   options,
   selectedIds,
-  max
+  max,
+  truncated
 }: {
   facet: LinearCoverageFacet
   options: readonly { key: string; ids: readonly string[] }[]
   selectedIds: readonly string[]
   max: number
+  /** Recorded where the cap ran, not inferred from the ids it left behind (STA-5996). */
+  truncated: boolean
 }): React.JSX.Element | null {
-  const { applied, intended, atLimit } = linearMetadataGroupCoverage(options, selectedIds, max)
-  if (intended <= applied && !atLimit) {
+  const { applied, intended } = linearMetadataGroupCoverage(options, selectedIds)
+  if (intended <= applied && !truncated) {
     return null
   }
   return (

--- a/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx
@@ -664,6 +664,77 @@ describe('LinearIssueAttributeFilterDropdowns coverage at exactly the transport 
     expect(document.body.textContent).not.toContain('partial')
   })
 
+  // Why: every facet change re-caps every facet, and re-capping an already-capped status is a
+  // no-op — recomputing the record there would see requested === applied and erase the warning.
+  // The scenario has to sit where intended === applied, or the value-derived shortfall covers
+  // for the record and the guard goes untested.
+  it('keeps the status truncation when an unrelated facet is picked', () => {
+    const states = Array.from({ length: cap + 1 }, (_unused, index) => ({
+      id: `s-${String(index).padStart(3, '0')}`,
+      name: rowNamed(index)
+    }))
+    metadataMocks.useTeamsStates.mockImplementation(() => ({
+      data: states,
+      loading: false,
+      error: null
+    }))
+
+    const { rerender, onChange } = renderDropdowns({
+      ...emptyFilter,
+      stateIds: states.slice(0, cap).map((state) => state.id)
+    })
+    openSectionNamed('Status')
+    clickRow(rowNamed(cap))
+    rerender(onChange.mock.calls[0]?.[0] as LinearIssueAttributeFilter)
+    expect(document.body.textContent).toContain('Filtering the most this can carry')
+
+    openSectionNamed('Back')
+    openSectionNamed('Priority')
+    clickRow('Urgent')
+    const withPriority = onChange.mock.calls[1]?.[0] as LinearIssueAttributeFilter
+    rerender(withPriority)
+
+    expect(withPriority.priorities).toEqual([1])
+    expect(withPriority.stateIds).toHaveLength(cap)
+    openSectionNamed('Back')
+    expect(document.body.textContent).toContain('· partial')
+    openSectionNamed('Status')
+    expect(document.body.textContent).toContain('Filtering the most this can carry')
+  })
+
+  it('keeps the labels truncation when an unrelated facet is picked', () => {
+    const labelCap = LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_LABEL_IDS
+    const labels = Array.from({ length: labelCap + 1 }, (_unused, index) => ({
+      id: `l-${String(index).padStart(3, '0')}`,
+      name: rowNamed(index)
+    }))
+    metadataMocks.useTeamsLabels.mockImplementation(() => ({
+      data: labels,
+      loading: false,
+      error: null
+    }))
+
+    const { rerender, onChange } = renderDropdowns({
+      ...emptyFilter,
+      labelIds: labels.slice(0, labelCap).map((label) => label.id)
+    })
+    openSectionNamed('Labels')
+    clickRow(rowNamed(labelCap))
+    rerender(onChange.mock.calls[0]?.[0] as LinearIssueAttributeFilter)
+    expect(document.body.textContent).toContain('Filtering the most this can carry')
+
+    openSectionNamed('Back')
+    openSectionNamed('Priority')
+    clickRow('Urgent')
+    const withPriority = onChange.mock.calls[1]?.[0] as LinearIssueAttributeFilter
+    rerender(withPriority)
+
+    expect(withPriority.labelIds).toHaveLength(labelCap)
+    openSectionNamed('Back')
+    openSectionNamed('Labels')
+    expect(document.body.textContent).toContain('Filtering the most this can carry')
+  })
+
   // Why: clearing a facet must clear its recorded trim too, or the next selection inherits
   // a warning it never earned.
   it('drops the recorded truncation when the facet is cleared', () => {

--- a/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx
@@ -88,7 +88,9 @@ describe('linear-issue-attribute-filter helpers', () => {
       memberNamesById: new Map(),
       labelNamesById: new Map(),
       statusOptions: [{ key: 'be-todo', primary: 'Todo', ids: ['be-todo', 'fe-todo'] }],
-      labelOptions: []
+      labelOptions: [],
+      statusTruncated: false,
+      labelsTruncated: false
     })
     expect(pills[0]?.value).toBe('Todo')
   })
@@ -103,7 +105,9 @@ describe('linear-issue-attribute-filter helpers', () => {
       memberNamesById: new Map(),
       labelNamesById: new Map([['l1', 'Bug']]),
       statusOptions: [],
-      labelOptions: []
+      labelOptions: [],
+      statusTruncated: false,
+      labelsTruncated: false
     })
     expect(pills.map((p) => p.key)).toEqual(['status', 'priority', 'assignee', 'labels'])
     expect(pills[0]?.value).toContain('Todo')
@@ -477,7 +481,9 @@ describe('LinearIssueAttributeFilterDropdowns transport-cap coverage notice', ()
     rerender(onChange.mock.calls[0]?.[0] as LinearIssueAttributeFilter)
     openSectionNamed('Back')
 
-    expect(document.body.textContent).toContain('1 selected · partial')
+    // The marker sits outside the truncating summary span, so it is its own text node.
+    expect(document.body.textContent).toContain('1 selected')
+    expect(document.body.textContent).toContain('· partial')
     // Why: the marker has to be reachable by keyboard and named for a screen reader,
     // which a bare title attribute never was (#17342).
     const pillMarkers = [...document.body.querySelectorAll('button')].filter(
@@ -553,7 +559,8 @@ describe('LinearIssueAttributeFilterDropdowns transport-cap coverage notice', ()
       `Filtering the most this can carry: ${cap} team statuses`
     )
     openSectionNamed('Back')
-    expect(document.body.textContent).toContain(`${cap} selected · partial`)
+    expect(document.body.textContent).toContain(`${cap} selected`)
+    expect(document.body.textContent).toContain('· partial')
   })
 
   it('reports the team labels left out once a picked label exceeds the id cap', () => {
@@ -577,5 +584,114 @@ describe('LinearIssueAttributeFilterDropdowns transport-cap coverage notice', ()
     expect(document.body.textContent).toContain(
       `Filtering ${LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_LABEL_IDS} of ${overCap} team labels`
     )
+  })
+})
+
+// Why: 20 teams x 5 status names expands to exactly the cap, so nothing is dropped — the
+// warning used to fire anyway because it inferred truncation from the bounded ids (STA-5996).
+describe('LinearIssueAttributeFilterDropdowns coverage at exactly the transport id cap', () => {
+  const cap = LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS
+  const statusNames = ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon']
+  const capFillingStates = statusNames.flatMap((name, nameIndex) =>
+    Array.from({ length: cap / statusNames.length }, (_unused, teamIndex) => ({
+      id: `t${teamIndex}-${nameIndex}`,
+      name
+    }))
+  )
+
+  const rowNamed = (index: number): string => `Row ${String(index).padStart(3, '0')}`
+
+  function clickRow(name: string): void {
+    act(() => {
+      pickerRowsNamed(name)[0]?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+  }
+
+  it('stays silent for a complete selection sitting exactly on the id cap', () => {
+    metadataMocks.useTeamsStates.mockImplementation(() => ({
+      data: capFillingStates,
+      loading: false,
+      error: null
+    }))
+
+    const { rerender, onChange } = renderDropdowns(emptyFilter)
+    openSectionNamed('Status')
+    statusNames.forEach((name, index) => {
+      clickRow(name)
+      rerender(onChange.mock.calls[index]?.[0] as LinearIssueAttributeFilter)
+    })
+
+    const bounded = onChange.mock.calls[statusNames.length - 1]?.[0] as LinearIssueAttributeFilter
+    expect(bounded.stateIds).toHaveLength(cap)
+    expect(document.body.textContent).not.toContain('Filtering the most this can carry')
+    openSectionNamed('Back')
+    expect(document.body.textContent).toContain(`${statusNames.length} selected`)
+    expect(document.body.textContent).not.toContain('partial')
+  })
+
+  // Why: the prune effect only ever removes ids and never re-expands, so a recorded trim
+  // that outlived its selection would keep warning about a filter that now fits.
+  it('drops the recorded truncation once the selection fits again', () => {
+    const states = Array.from({ length: cap + 1 }, (_unused, index) => ({
+      id: `s-${String(index).padStart(3, '0')}`,
+      name: rowNamed(index)
+    }))
+    metadataMocks.useTeamsStates.mockImplementation(() => ({
+      data: states,
+      loading: false,
+      error: null
+    }))
+
+    const { rerender, onChange } = renderDropdowns({
+      ...emptyFilter,
+      stateIds: states.slice(0, cap).map((state) => state.id)
+    })
+    openSectionNamed('Status')
+    clickRow(rowNamed(cap))
+    rerender(onChange.mock.calls[0]?.[0] as LinearIssueAttributeFilter)
+    expect(document.body.textContent).toContain('Filtering the most this can carry')
+
+    clickRow(rowNamed(0))
+    rerender(onChange.mock.calls[1]?.[0] as LinearIssueAttributeFilter)
+    clickRow(rowNamed(cap))
+    const refitted = onChange.mock.calls[2]?.[0] as LinearIssueAttributeFilter
+    rerender(refitted)
+
+    expect(refitted.stateIds).toHaveLength(cap)
+    expect(refitted.stateIds).not.toContain('s-000')
+    expect(document.body.textContent).not.toContain('Filtering the most this can carry')
+    openSectionNamed('Back')
+    expect(document.body.textContent).not.toContain('partial')
+  })
+
+  // Why: clearing a facet must clear its recorded trim too, or the next selection inherits
+  // a warning it never earned.
+  it('drops the recorded truncation when the facet is cleared', () => {
+    const states = Array.from({ length: cap + 1 }, (_unused, index) => ({
+      id: `s-${String(index).padStart(3, '0')}`,
+      name: rowNamed(index)
+    }))
+    metadataMocks.useTeamsStates.mockImplementation(() => ({
+      data: states,
+      loading: false,
+      error: null
+    }))
+
+    const { rerender, onChange } = renderDropdowns({
+      ...emptyFilter,
+      stateIds: states.slice(0, cap).map((state) => state.id)
+    })
+    openSectionNamed('Status')
+    clickRow(rowNamed(cap))
+    rerender(onChange.mock.calls[0]?.[0] as LinearIssueAttributeFilter)
+    expect(document.body.textContent).toContain('Filtering the most this can carry')
+
+    rerender(emptyFilter)
+    clickRow(rowNamed(0))
+    rerender(onChange.mock.calls[1]?.[0] as LinearIssueAttributeFilter)
+
+    expect(document.body.textContent).not.toContain('Filtering the most this can carry')
+    openSectionNamed('Back')
+    expect(document.body.textContent).not.toContain('partial')
   })
 })

--- a/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.tsx
@@ -30,7 +30,10 @@ import {
 import {
   capLinearMetadataIdsAcrossGroups,
   groupLinearMetadataByName,
-  resolveLinearIssueAttributeFilterTeamIds
+  isLinearMetadataTruncated,
+  recordLinearMetadataTruncation,
+  resolveLinearIssueAttributeFilterTeamIds,
+  type LinearMetadataTruncationRecord
 } from './linear-issue-attribute-filter-team-ids'
 
 type Props = {
@@ -112,6 +115,12 @@ export default function LinearIssueAttributeFilterDropdowns({
 }: Props): React.JSX.Element {
   const [popoverOpen, setPopoverOpen] = useState(false)
   const [openSection, setOpenSection] = useState<LinearIssueFilterSectionKey | null>(null)
+  // Why: each record holds the ids the cap left behind, so it stops applying the moment the
+  // facet carries anything else — prune, pill clear, Clear all, workspace switch (STA-5996).
+  const [stateIdsTruncation, setStateIdsTruncation] = useState<LinearMetadataTruncationRecord>(null)
+  const [labelIdsTruncation, setLabelIdsTruncation] = useState<LinearMetadataTruncationRecord>(null)
+  const statusTruncated = isLinearMetadataTruncated(stateIdsTruncation, value.stateIds)
+  const labelsTruncated = isLinearMetadataTruncated(labelIdsTruncation, value.labelIds)
   const activeCount = countLinearIssueAttributeFilters(value)
   const metadataNeeded =
     popoverOpen ||
@@ -249,30 +258,43 @@ export default function LinearIssueAttributeFilterDropdowns({
     memberNamesById,
     labelNamesById,
     statusOptions,
-    labelOptions
+    labelOptions,
+    statusTruncated,
+    labelsTruncated
   })
 
   // Why: one picked row expands to an id per team, so bound here — the IPC/RPC parser rejects a
   // filter over the transport cap outright. Spread the cap over the picked rows first: the
   // canonical slice is lexicographic, so it can drop every id of a row the user just checked.
   const applyPickedFilter = (next: LinearIssueAttributeFilter): void => {
-    onChange(
-      boundLinearIssueAttributeFilter(
-        canonicalizeLinearIssueAttributeFilter({
-          ...next,
-          stateIds: capLinearMetadataIdsAcrossGroups(
-            statusOptions,
-            next.stateIds,
-            LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS
-          ),
-          labelIds: capLinearMetadataIdsAcrossGroups(
-            labelOptions,
-            next.labelIds,
-            LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_LABEL_IDS
-          )
-        })
-      )
+    const bounded = boundLinearIssueAttributeFilter(
+      canonicalizeLinearIssueAttributeFilter({
+        ...next,
+        stateIds: capLinearMetadataIdsAcrossGroups(
+          statusOptions,
+          next.stateIds,
+          LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS
+        ),
+        labelIds: capLinearMetadataIdsAcrossGroups(
+          labelOptions,
+          next.labelIds,
+          LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_LABEL_IDS
+        )
+      })
     )
+    // Why: only here are the pre-cap expansion and the survivors both in hand. Re-capping an
+    // untouched facet (a priority click) is a no-op, so keep a record that still matches.
+    setStateIdsTruncation(
+      isLinearMetadataTruncated(stateIdsTruncation, bounded.stateIds)
+        ? stateIdsTruncation
+        : recordLinearMetadataTruncation(next.stateIds, bounded.stateIds)
+    )
+    setLabelIdsTruncation(
+      isLinearMetadataTruncated(labelIdsTruncation, bounded.labelIds)
+        ? labelIdsTruncation
+        : recordLinearMetadataTruncation(next.labelIds, bounded.labelIds)
+    )
+    onChange(bounded)
   }
 
   const teamRequiredMessage = !primaryTeam
@@ -348,6 +370,8 @@ export default function LinearIssueAttributeFilterDropdowns({
                   assigneeError={members.error}
                   labelLoading={labels.loading}
                   labelError={labels.error}
+                  statusTruncated={statusTruncated}
+                  labelsTruncated={labelsTruncated}
                   teamRequiredMessage={teamRequiredMessage}
                   onBack={() => setOpenSection(null)}
                 />
@@ -356,6 +380,8 @@ export default function LinearIssueAttributeFilterDropdowns({
                   value={value}
                   statusOptions={statusOptions}
                   labelOptions={labelOptions}
+                  statusTruncated={statusTruncated}
+                  labelsTruncated={labelsTruncated}
                   onOpenSection={setOpenSection}
                 />
               )}

--- a/src/renderer/src/components/linear-issue-attribute-filter-pills.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-pills.ts
@@ -2,8 +2,6 @@
 // popover closes, so they carry the same coverage truth the picker shows inline.
 import { translate } from '@/i18n/i18n'
 import {
-  LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_LABEL_IDS,
-  LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS,
   canonicalizeLinearIssueAttributeFilter,
   type LinearIssueAttributeFilter
 } from '../../../shared/linear/issue-attribute-filter'
@@ -60,6 +58,9 @@ export function linearIssueAttributeFilterPillLabels(options: {
   labelNamesById: Map<string, string>
   statusOptions: readonly LinearIssueFilterGroupedOption[]
   labelOptions: readonly LinearIssueFilterGroupedOption[]
+  /** Recorded where the cap ran, not inferred from the ids it left behind (STA-5996). */
+  statusTruncated: boolean
+  labelsTruncated: boolean
 }): LinearIssueFilterPill[] {
   const canonical = canonicalizeLinearIssueAttributeFilter(options.value)
   const pills: LinearIssueFilterPill[] = []
@@ -71,7 +72,7 @@ export function linearIssueAttributeFilterPillLabels(options: {
       partial: isLinearMetadataGroupSelectionPartial(
         options.statusOptions,
         canonical.stateIds,
-        LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS
+        options.statusTruncated
       )
     })
   }
@@ -118,7 +119,7 @@ export function linearIssueAttributeFilterPillLabels(options: {
       partial: isLinearMetadataGroupSelectionPartial(
         options.labelOptions,
         canonical.labelIds,
-        LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_LABEL_IDS
+        options.labelsTruncated
       )
     })
   }

--- a/src/renderer/src/components/linear-issue-attribute-filter-sections.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-sections.tsx
@@ -32,50 +32,56 @@ function priorityOptions(): PickerOption[] {
   }))
 }
 
+type LinearIssueFilterSectionSummary = { text: string; partial: boolean }
+
 /** "{{count}} selected", flagged when the transport id cap left teams out (#16879). */
 function facetSummary(
   options: readonly LinearIssueFilterGroupedOption[],
   selectedIds: readonly string[],
-  max: number
-): string {
+  truncated: boolean
+): LinearIssueFilterSectionSummary {
   const count = selectedLinearMetadataGroupKeys(options, selectedIds).length
   if (count === 0) {
-    return ''
+    return { text: '', partial: false }
   }
-  const summary = translate(
-    'auto.components.linear-issue-attribute-filter-sections.countSelected',
-    '{{count}} selected',
-    { count }
-  )
-  return isLinearMetadataGroupSelectionPartial(options, selectedIds, max)
-    ? translate(
-        'auto.components.linear-issue-attribute-filter-sections.partialCoverageSuffix',
-        '{{value0}} · partial',
-        { value0: summary }
-      )
-    : summary
+  return {
+    text: translate(
+      'auto.components.linear-issue-attribute-filter-sections.countSelected',
+      '{{count}} selected',
+      { count }
+    ),
+    partial: isLinearMetadataGroupSelectionPartial(options, selectedIds, truncated)
+  }
+}
+
+function plainSummary(text: string): LinearIssueFilterSectionSummary {
+  return { text, partial: false }
 }
 
 export function LinearIssueFilterSectionMenu({
   value,
   statusOptions,
   labelOptions,
+  statusTruncated,
+  labelsTruncated,
   onOpenSection
 }: {
   value: LinearIssueAttributeFilter
   statusOptions: LinearIssueFilterGroupedOption[]
   labelOptions: LinearIssueFilterGroupedOption[]
+  statusTruncated: boolean
+  labelsTruncated: boolean
   onOpenSection: (section: LinearIssueFilterSectionKey) => void
 }): React.JSX.Element {
-  const sections: { key: LinearIssueFilterSectionKey; label: string; summary: string }[] = [
+  const sections: {
+    key: LinearIssueFilterSectionKey
+    label: string
+    summary: LinearIssueFilterSectionSummary
+  }[] = [
     {
       key: 'status',
       label: translate('auto.components.linear-issue-attribute-filter-sections.status', 'Status'),
-      summary: facetSummary(
-        statusOptions,
-        value.stateIds,
-        LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS
-      )
+      summary: facetSummary(statusOptions, value.stateIds, statusTruncated)
     },
     {
       key: 'priority',
@@ -83,7 +89,7 @@ export function LinearIssueFilterSectionMenu({
         'auto.components.linear-issue-attribute-filter-sections.priority',
         'Priority'
       ),
-      summary:
+      summary: plainSummary(
         value.priorities.length > 0
           ? translate(
               'auto.components.linear-issue-attribute-filter-sections.countSelected',
@@ -91,6 +97,7 @@ export function LinearIssueFilterSectionMenu({
               { count: value.priorities.length }
             )
           : ''
+      )
     },
     {
       key: 'assignee',
@@ -98,23 +105,24 @@ export function LinearIssueFilterSectionMenu({
         'auto.components.linear-issue-attribute-filter-sections.assignee',
         'Assignee'
       ),
-      summary: value.assignee
-        ? value.assignee.kind === 'unassigned'
-          ? translate(
-              'auto.components.linear-issue-attribute-filter-sections.unassigned',
-              'Unassigned'
-            )
-          : translate('auto.components.linear-issue-attribute-filter-sections.selected', 'selected')
-        : ''
+      summary: plainSummary(
+        value.assignee
+          ? value.assignee.kind === 'unassigned'
+            ? translate(
+                'auto.components.linear-issue-attribute-filter-sections.unassigned',
+                'Unassigned'
+              )
+            : translate(
+                'auto.components.linear-issue-attribute-filter-sections.selected',
+                'selected'
+              )
+          : ''
+      )
     },
     {
       key: 'labels',
       label: translate('auto.components.linear-issue-attribute-filter-sections.labels', 'Labels'),
-      summary: facetSummary(
-        labelOptions,
-        value.labelIds,
-        LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_LABEL_IDS
-      )
+      summary: facetSummary(labelOptions, value.labelIds, labelsTruncated)
     }
   ]
 
@@ -128,11 +136,20 @@ export function LinearIssueFilterSectionMenu({
           className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left transition hover:bg-muted/50"
         >
           <span className="font-medium">{section.label}</span>
-          <span className="inline-flex items-center gap-1 text-muted-foreground">
-            {section.summary ? (
-              <span className="max-w-[120px] truncate">{section.summary}</span>
+          <span className="inline-flex min-w-0 items-center gap-1 text-muted-foreground">
+            {section.summary.text ? (
+              <span className="min-w-0 truncate">{section.summary.text}</span>
             ) : null}
-            <ChevronRight className="size-3.5" />
+            {/* Why: the marker sits outside the truncating span so a long count never clips it. */}
+            {section.summary.partial ? (
+              <span className="shrink-0">
+                {translate(
+                  'auto.components.linear-issue-attribute-filter-sections.partialCoverageMarker',
+                  '· partial'
+                )}
+              </span>
+            ) : null}
+            <ChevronRight className="size-3.5 shrink-0" />
           </span>
         </button>
       ))}
@@ -153,6 +170,8 @@ export function LinearIssueFilterSectionDetail({
   assigneeError,
   labelLoading,
   labelError,
+  statusTruncated,
+  labelsTruncated,
   teamRequiredMessage,
   onBack
 }: {
@@ -168,6 +187,8 @@ export function LinearIssueFilterSectionDetail({
   assigneeError: string | null
   labelLoading: boolean
   labelError: string | null
+  statusTruncated: boolean
+  labelsTruncated: boolean
   teamRequiredMessage: string | null
   onBack: () => void
 }): React.JSX.Element {
@@ -269,6 +290,7 @@ export function LinearIssueFilterSectionDetail({
               ? LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS
               : LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_LABEL_IDS
           }
+          truncated={isStatus ? statusTruncated : labelsTruncated}
         />
       </div>
     )

--- a/src/renderer/src/components/linear-issue-attribute-filter-team-ids.test.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-team-ids.test.ts
@@ -5,7 +5,9 @@ import {
   expandLinearMetadataGroupKeys,
   groupLinearMetadataByName,
   isLinearMetadataGroupSelectionPartial,
+  isLinearMetadataTruncated,
   linearMetadataGroupCoverage,
+  recordLinearMetadataTruncation,
   resolveLinearIssueAttributeFilterTeamIds,
   selectedLinearMetadataGroupKeys,
   unionLinearMetadataById
@@ -174,10 +176,12 @@ describe('capLinearMetadataIdsAcrossGroups over-subscribed rows', () => {
     const groups = singleIdGroups(4)
     const ids = groups.flatMap((group) => group.ids)
     expect(capLinearMetadataIdsAcrossGroups(groups, ids, 4)).toEqual(ids)
-    // Why: on the cap, full coverage is indistinguishable from a starved row, so coverage
-    // warns rather than claim what it cannot prove — below the cap it stays quiet (#17342).
-    expect(isLinearMetadataGroupSelectionPartial(groups, ids, 4)).toBe(true)
-    expect(isLinearMetadataGroupSelectionPartial(groups, ids, 5)).toBe(false)
+    // Why: the cap is a provable no-op here, so nothing is recorded and nothing is claimed —
+    // the old at-the-cap inference warned on this complete selection (STA-5996).
+    expect(
+      recordLinearMetadataTruncation(ids, capLinearMetadataIdsAcrossGroups(groups, ids, 4))
+    ).toBeNull()
+    expect(isLinearMetadataGroupSelectionPartial(groups, ids, false)).toBe(false)
   })
 
   it('keeps one id per row when the selection is one id over the cap', () => {
@@ -197,8 +201,34 @@ describe('capLinearMetadataIdsAcrossGroups over-subscribed rows', () => {
     const ids = groups.flatMap((group) => group.ids)
     const capped = capLinearMetadataIdsAcrossGroups(groups, ids, 100)
     expect(capped).toHaveLength(100)
-    expect(linearMetadataGroupCoverage(groups, capped, 100).atLimit).toBe(true)
-    expect(isLinearMetadataGroupSelectionPartial(groups, capped, 100)).toBe(true)
+    // The starved row leaves no trace in `capped`, so only the recorded trim can report it.
+    expect(linearMetadataGroupCoverage(groups, capped)).toEqual({ applied: 100, intended: 100 })
+    const record = recordLinearMetadataTruncation(ids, capped)
+    expect(isLinearMetadataTruncated(record, capped)).toBe(true)
+    expect(isLinearMetadataGroupSelectionPartial(groups, capped, true)).toBe(true)
+  })
+
+  // Why: the record must not outlive the selection it describes — the prune effect only ever
+  // removes ids, so a flag kept by value alone would warn about a filter that now fits.
+  it('stops applying a recorded trim once the facet carries different ids', () => {
+    const groups = singleIdGroups(101)
+    const ids = groups.flatMap((group) => group.ids)
+    const record = recordLinearMetadataTruncation(
+      ids,
+      capLinearMetadataIdsAcrossGroups(groups, ids, 100)
+    )
+    expect(isLinearMetadataTruncated(record, ids.slice(0, 99))).toBe(false)
+    expect(isLinearMetadataTruncated(record, [])).toBe(false)
+    expect(isLinearMetadataTruncated(null, ids.slice(0, 100))).toBe(false)
+  })
+
+  // Why: click order reaches the cap, so the record has to match by set, not by position.
+  it('matches a recorded trim whatever order the ids arrive in', () => {
+    const groups = singleIdGroups(101)
+    const ids = groups.flatMap((group) => group.ids)
+    const capped = capLinearMetadataIdsAcrossGroups(groups, ids, 100)
+    const record = recordLinearMetadataTruncation(ids, capped)
+    expect(isLinearMetadataTruncated(record, capped.toReversed())).toBe(true)
   })
 
   it('never starves a single-id row to widen a row that has many ids', () => {

--- a/src/renderer/src/components/linear-issue-attribute-filter-team-ids.test.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-team-ids.test.ts
@@ -220,6 +220,9 @@ describe('capLinearMetadataIdsAcrossGroups over-subscribed rows', () => {
     expect(isLinearMetadataTruncated(record, ids.slice(0, 99))).toBe(false)
     expect(isLinearMetadataTruncated(record, [])).toBe(false)
     expect(isLinearMetadataTruncated(null, ids.slice(0, 100))).toBe(false)
+    // Why: a facet that grew past its record has refetched underneath it — matching by subset
+    // would keep warning about a trim that no longer describes the filter (the STA-5996 bug).
+    expect(isLinearMetadataTruncated(record, [...(record ?? []), 'later-id'])).toBe(false)
   })
 
   // Why: `recordLinearMetadataTruncation(['a','b'], [])` is non-null-but-empty, and an empty

--- a/src/renderer/src/components/linear-issue-attribute-filter-team-ids.test.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-team-ids.test.ts
@@ -222,6 +222,22 @@ describe('capLinearMetadataIdsAcrossGroups over-subscribed rows', () => {
     expect(isLinearMetadataTruncated(null, ids.slice(0, 100))).toBe(false)
   })
 
+  // Why: `recordLinearMetadataTruncation(['a','b'], [])` is non-null-but-empty, and an empty
+  // record matches an empty facet vacuously — a filter carrying nothing is never truncated.
+  it('never reports truncation for an empty record', () => {
+    expect(isLinearMetadataTruncated([], [])).toBe(false)
+    expect(isLinearMetadataTruncated(recordLinearMetadataTruncation(['a', 'b'], []), [])).toBe(
+      false
+    )
+    // The genuine case is untouched: a real trim still records and still reports.
+    const groups = singleIdGroups(101)
+    const ids = groups.flatMap((group) => group.ids)
+    const capped = capLinearMetadataIdsAcrossGroups(groups, ids, 100)
+    expect(isLinearMetadataTruncated(recordLinearMetadataTruncation(ids, capped), capped)).toBe(
+      true
+    )
+  })
+
   // Why: click order reaches the cap, so the record has to match by set, not by position.
   it('matches a recorded trim whatever order the ids arrive in', () => {
     const groups = singleIdGroups(101)

--- a/src/renderer/src/components/linear-issue-attribute-filter-team-ids.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-team-ids.ts
@@ -129,7 +129,9 @@ export function isLinearMetadataTruncated(
   record: LinearMetadataTruncationRecord,
   appliedIds: readonly string[]
 ): boolean {
-  if (record === null) {
+  // Why: an empty record matches an empty facet vacuously, and a facet filtering nothing
+  // cannot be under-covering — so no empty record ever reports truncation.
+  if (record === null || record.length === 0) {
     return false
   }
   const applied = new Set(appliedIds)

--- a/src/renderer/src/components/linear-issue-attribute-filter-team-ids.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-team-ids.ts
@@ -100,35 +100,60 @@ function linearMetadataKeyById(
 /** Ids the picked rows stand for, against the ids the transport cap actually kept (#16879). */
 export function linearMetadataGroupCoverage(
   groups: readonly { key: string; ids: readonly string[] }[],
-  selectedIds: readonly string[],
-  max: number
-): { applied: number; intended: number; atLimit: boolean } {
+  selectedIds: readonly string[]
+): { applied: number; intended: number } {
   const keys = selectedLinearMetadataGroupKeys(groups, selectedIds)
   return {
     applied: selectedIds.length,
-    intended: expandLinearMetadataGroupKeys(groups, keys).length,
-    // Why: a row the cap could not fit leaves no trace in the ids, so once the budget is
-    // spent the honest claim is the exhausted budget itself — never full coverage (#17342).
-    atLimit: selectedIds.length >= max
+    intended: expandLinearMetadataGroupKeys(groups, keys).length
   }
+}
+
+/**
+ * The ids a cap is known to have trimmed, kept as the ids that survived it. A row the cap
+ * could not fit leaves no trace in those ids, so truncation is recorded where it happens
+ * rather than inferred from the bounded filter — a complete selection landing exactly on the
+ * cap is indistinguishable from a trimmed one and used to warn anyway (STA-5996).
+ */
+export type LinearMetadataTruncationRecord = readonly string[] | null
+
+export function recordLinearMetadataTruncation(
+  requestedIds: readonly string[],
+  appliedIds: readonly string[]
+): LinearMetadataTruncationRecord {
+  return new Set(requestedIds).size > new Set(appliedIds).size ? [...appliedIds] : null
+}
+
+/** A record describes the facet only while it still carries exactly the ids that survived. */
+export function isLinearMetadataTruncated(
+  record: LinearMetadataTruncationRecord,
+  appliedIds: readonly string[]
+): boolean {
+  if (record === null) {
+    return false
+  }
+  const applied = new Set(appliedIds)
+  const recorded = new Set(record)
+  return recorded.size === applied.size && record.every((id) => applied.has(id))
 }
 
 /** True when the filter cannot be shown to cover every team id the picked rows stand for. */
 export function isLinearMetadataGroupSelectionPartial(
   groups: readonly { key: string; ids: readonly string[] }[],
   selectedIds: readonly string[],
-  max: number
+  truncated: boolean
 ): boolean {
-  const { applied, intended, atLimit } = linearMetadataGroupCoverage(groups, selectedIds, max)
-  return intended > applied || atLimit
+  const { applied, intended } = linearMetadataGroupCoverage(groups, selectedIds)
+  // Why: the value-derived shortfall stays as a fallback — a restored filter carries no record.
+  return truncated || intended > applied
 }
 
 /**
  * Trim an expanded selection to `max` ids by taking turns across the picked groups.
  * A plain slice of the canonical (sorted) id list can drop every id of one picked row,
  * which then renders unchecked with no explanation and vanishes from the coverage count.
- * More picked rows than `max` cannot all be represented; `linearMetadataGroupCoverage`
- * reports that shortfall so the starved row is never passed off as full coverage.
+ * More picked rows than `max` cannot all be represented; the caller records that shortfall
+ * with `recordLinearMetadataTruncation` so the starved row is never passed off as coverage.
  */
 export function capLinearMetadataIdsAcrossGroups(
   groups: readonly { key: string; ids: readonly string[] }[],

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16202,7 +16202,7 @@
         "unassigned": "Unassigned",
         "labels": "Labels",
         "countSelected": "{{count}} selected",
-        "partialCoverageSuffix": "{{value0}} · partial",
+        "partialCoverageMarker": "· partial",
         "selected": "selected",
         "searchPriority": "Filter priority…",
         "searchStatus": "Filter status…",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​286 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​276 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​156 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​77 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 |

<!-- /orca-pr-loc -->

## Problem

#17342 inferred transport-cap truncation from the bounded filter *after* the cap ran:

```ts
// linear-issue-attribute-filter-team-ids.ts (before)
atLimit = selectedIds.length >= max
isLinearMetadataGroupSelectionPartial = intended > applied || atLimit
```

A row the cap could not fit leaves **no trace** in the surviving ids, so `intended > applied` cannot see it. At exactly the cap, a complete selection and a truncated one are indistinguishable from the rendered value alone, and #17342 resolved that ambiguity by always warning.

Consequence: a workspace with 20 teams × 5 distinct status names expands to exactly 100 ids. Picking all 5 rows is a complete selection — `capLinearMetadataIdsAcrossGroups` is a provable no-op — yet the section menu showed `100 selected · partial` and the pill showed the partial marker. A correctness warning that fires on correct input trains users to ignore it.

## Fix

Record truncation **at the point it occurs** instead of inferring it afterwards.

- `applyPickedFilter` (`linear-issue-attribute-filter-dropdowns.tsx`) holds both the pre-cap expanded id list and the bounded result, so it now computes `recordLinearMetadataTruncation(requested, bounded)` and stores it in component state, per facet.
- The notice, the section-menu summary, and the pill marker consume that flag (`truncated` / `statusTruncated` / `labelsTruncated`) instead of re-deriving `atLimit` from the bounded filter.
- `isLinearMetadataGroupSelectionPartial(groups, selectedIds, truncated)` is now `truncated || intended > applied`. The value-derived shortfall is **kept as a fallback** so a restored filter (which carries no record) still reports partial team coverage exactly as before.

### Staleness

The record *is* the applied ids the cap left behind, and `isLinearMetadataTruncated` only accepts it while the facet still carries exactly that id set. So it self-invalidates on every path that mutates the filter, rather than needing a reset hook per path:

| path | why the flag is correct |
| --- | --- |
| row toggle | `applyPickedFilter` recomputes the record from the fresh cap |
| a facet the click didn't touch (priority/assignee) | re-capping an untouched facet is a no-op, so a still-matching record is deliberately kept — otherwise a priority click would erase a real warning |
| pill clear | facet becomes `[]`, the record no longer matches |
| "Clear all" | same, both facets |
| metadata prune effect | it only ever *removes* ids, so the id set changes and the record stops applying — this is exactly the case a naive sticky boolean would get wrong |
| workspace switch | the incoming per-workspace filter carries different facet ids (they are workspace-scoped), so no record matches |
| metadata finishing loading | no record can exist before rows are pickable; a loaded-then-narrowed metadata set reaches the filter through the prune effect above |

Set-based comparison, so it is click-order independent; no `Math.random`, `Date`, or reliance on `Map`/`Set` iteration order for any boolean. `boundLinearIssueAttributeFilter` is untouched and still the final authority — the record is computed against its output, so anything it trims is recorded too.

### Also (flagged by review)

The section-menu summary span was `max-w-[120px] truncate` while the at-limit summary read `100 selected · partial`, so the marker could clip. The marker now renders in its own `shrink-0` span outside the truncating summary (`partialCoverageMarker` en.json key replaces `partialCoverageSuffix`).

## Verification

New/changed tests observed failing on `origin/main`'s implementation (source stashed, tests kept) and passing after:

```
$ pnpm test .../linear-issue-attribute-filter-dropdowns.test.tsx .../linear-issue-attribute-filter-team-ids.test.ts    # source reverted
     × leaves a selection sitting exactly on the cap untouched 1ms
     × never claims full coverage when more rows are picked than the cap can hold 2ms
     × stops applying a recorded trim once the facet carries different ids 0ms
     × matches a recorded trim whatever order the ids arrive in 0ms
     × stays silent for a complete selection sitting exactly on the id cap 18ms
     × drops the recorded truncation once the selection fits again 48ms
 Test Files  2 failed (2)
      Tests  6 failed | 35 passed (41)
```

```
$ pnpm test .../linear-issue-attribute-filter-dropdowns.test.tsx .../linear-issue-attribute-filter-team-ids.test.ts    # with the fix
 Test Files  2 passed (2)
      Tests  41 passed (41)
```

The pre-existing over-cap tests (`Filtering 100 of 120 team statuses`, and `says the status filter is full instead of claiming coverage it cannot have` — 101 single-id rows into 100 ids) pass both before and after: they are the regression guard for requirement 2 and were deliberately not weakened.

Other checks, all real output:

```
$ pnpm tc
$ pnpm run typecheck
$ node config/scripts/run-typecheck-projects-in-parallel.mjs
(clean, no diagnostics)

$ npx oxlint <7 changed files>
(no output)

$ pnpm run check:code-quality:changed
code quality: 0 new finding(s) across 7 changed file(s).
type-aware code quality: 0 new finding(s) across 7 changed file(s).
React Doctor: 0 new finding(s) across 7 changed file(s).
Changed-code quality gate passed since 316cb1ca4b2c.

$ pnpm test src/renderer/src/i18n
 Test Files  18 passed (18)
      Tests  147 passed (147)

$ pnpm test src/shared/linear/issue-attribute-filter.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ ./node_modules/.bin/oxfmt --write <7 changed files>
Finished in 5ms on 7 files using 16 threads.
```

## Residual / known limits

- **A restored filter carries no record.** If a truncated selection is persisted and reloaded, only `intended > applied` can flag it — so the same-name case ("100 of 120 team statuses") still warns, but the more-rows-than-the-cap case does not until the user next edits that facet. That blind spot is inherent to the value (the dropped row leaves no trace) and is the direct cost of not crying wolf at the cap; the old `atLimit` "covered" it only by warning on every at-cap filter, correct ones included.
- The record survives a clear-then-reselect that lands on the exact same id set. That is the same rows and therefore the same truncation verdict under unchanged metadata, so it is correct, but it is an equality-of-ids argument rather than an identity one.
- No Electron/visual pass was run for the marker layout change; it is covered by the section-menu assertions in `linear-issue-attribute-filter-dropdowns.test.tsx`.

Fixes STA-5996
https://linear.app/stably/issue/STA-5996/linear-filter-coverage-warning-fires-at-exactly-the-id-cap-even-when
