### PR TITLE
fix(cmd-j): preserve browser tab host ownership

### DIFF
--- a/src/renderer/src/lib/browser-page-palette-activation.test.ts
+++ b/src/renderer/src/lib/browser-page-palette-activation.test.ts
@@ -350,3 +350,62 @@ describe('activateBrowserPagePaletteResult group focus', () => {
     expect(useAppStore.getState().activeBrowserTabId).toBeNull()
   })
 })
+
+describe('activateBrowserPagePaletteResult host-colliding browser tabs', () => {
+  it('focuses the selected paired host tab when workspace ids collide', () => {
+    const localHost = makeWorktree({ hostId: 'local', displayName: 'Local' })
+    const remoteHost = makeWorktree({
+      hostId: 'ssh:private-target',
+      runtimeOwnerEnvironmentId: 'paired-host',
+      displayName: 'Remote'
+    })
+    const localTab = makeBrowserTab({ id: 'browser-local-tab', executionHostId: 'local' })
+    const remoteTab = makeBrowserTab({
+      id: 'browser-remote-tab',
+      executionHostId: 'runtime:paired-host',
+      groupId: 'group-remote'
+    })
+    seedStore({
+      worktreesByRepo: { 'repo-1': [localHost, remoteHost] },
+      browserTabsByWorktree: { 'wt-1': [makeWorkspace()] },
+      unifiedTabsByWorktree: { 'wt-1': [localTab, remoteTab] },
+      groupsByWorktree: {
+        'wt-1': [
+          makeGroup({ id: 'group-1', activeTabId: localTab.id }),
+          makeGroup({ id: 'group-remote', activeTabId: remoteTab.id })
+        ]
+      },
+      activeWorktreeId: 'wt-1',
+      activeWorkspaceExecutionHostId: 'local'
+    })
+    mocks.activateAndRevealWorktree.mockImplementation((_id, options) => {
+      useAppStore.setState({ activeWorkspaceExecutionHostId: options?.executionHostId ?? null })
+      return true
+    })
+
+    expect(
+      activateBrowserPagePaletteResult({
+        pageId: 'page-1',
+        workspaceId: 'ws-1',
+        worktreeId: 'wt-1',
+        executionHostId: 'runtime:paired-host'
+      })
+    ).toMatchObject({ status: 'activated' })
+    const state = useAppStore.getState()
+    expect(state.activeWorkspaceExecutionHostId).toBe('runtime:paired-host')
+    expect(state.activeGroupIdByWorktree['wt-1']).toBe('group-remote')
+    expect(state.groupsByWorktree['wt-1'][1].activeTabId).toBe('browser-remote-tab')
+
+    expect(
+      activateBrowserPagePaletteResult({
+        pageId: 'page-1',
+        workspaceId: 'ws-1',
+        worktreeId: 'wt-1',
+        executionHostId: 'local'
+      })
+    ).toMatchObject({ status: 'activated' })
+    expect(useAppStore.getState().activeWorkspaceExecutionHostId).toBe('local')
+    expect(useAppStore.getState().activeGroupIdByWorktree['wt-1']).toBe('group-1')
+    expect(useAppStore.getState().groupsByWorktree['wt-1'][0].activeTabId).toBe('browser-local-tab')
+  })
+})

--- a/src/renderer/src/lib/browser-page-palette-activation.ts
+++ b/src/renderer/src/lib/browser-page-palette-activation.ts
@@ -1,5 +1,8 @@
 import { useAppStore } from '@/store'
-import { activateBrowserWorkspaceTab } from '@/lib/browser-workspace-tab-activation'
+import {
+  activateBrowserWorkspaceTab,
+  resolveBrowserWorkspaceUnifiedTab
+} from '@/lib/browser-workspace-tab-activation'
 import type { ExecutionHostId } from '../../../shared/execution-host'
 import { isBlankBrowserUrl } from './browser-palette-search'
 import { activateAndRevealWorktree } from './worktree-activation'
@@ -29,11 +32,14 @@ export function activateBrowserPagePaletteResult({
   worktreeId
 }: BrowserPagePaletteActivationTarget): BrowserPagePaletteActivationResult {
   const initialState = useAppStore.getState()
-  const page = (initialState.browserPagesByWorkspace[workspaceId] ?? []).find(
-    (candidate) => candidate.id === pageId
-  )
   const workspace = (initialState.browserTabsByWorktree[worktreeId] ?? []).find(
-    (candidate) => candidate.id === workspaceId
+    (candidate) => candidate.id === workspaceId && candidate.worktreeId === worktreeId
+  )
+  const page = (initialState.browserPagesByWorkspace[workspaceId] ?? []).find(
+    (candidate) =>
+      candidate.id === pageId &&
+      candidate.workspaceId === workspaceId &&
+      candidate.worktreeId === worktreeId
   )
   const worktree = initialState.getKnownWorktreeById(worktreeId, executionHostId)
   // Why worktree first: removing a worktree also purges its browser workspaces
@@ -52,6 +58,16 @@ export function activateBrowserPagePaletteResult({
     : 'webview'
 
   const targetHostId = executionHostId ?? worktree.hostId
+  const matchingUnifiedTab = resolveBrowserWorkspaceUnifiedTab({
+    executionHostId: targetHostId,
+    worktreeId: worktree.id,
+    workspaceId: workspace.id
+  })
+  // Validate ownership before activation so a stale browser tab cannot partially
+  // switch the active host and then fail to render a browser surface.
+  if (!matchingUnifiedTab) {
+    return { status: 'failed', reason: 'missing-tab' }
+  }
   const activated = activateAndRevealWorktree(
     worktree.id,
     targetHostId ? { executionHostId: targetHostId } : {}
@@ -64,6 +80,7 @@ export function activateBrowserPagePaletteResult({
   // active behind a tab that never shows the page.
   if (
     !activateBrowserWorkspaceTab({
+      executionHostId: targetHostId,
       worktreeId: worktree.id,
       workspaceId: workspace.id,
       pageId

--- a/src/renderer/src/lib/browser-workspace-tab-activation.ts
+++ b/src/renderer/src/lib/browser-workspace-tab-activation.ts
@@ -1,4 +1,33 @@
 import { useAppStore } from '@/store'
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import type { Tab } from '../../../shared/tab-types'
+import { findAmbiguousWorktreeIds, isUnifiedTabOwnedByWorktree } from './unified-tab-host-ownership'
+
+export function resolveBrowserWorkspaceUnifiedTab(params: {
+  executionHostId?: ExecutionHostId
+  worktreeId: string
+  workspaceId: string
+}): Tab | null {
+  const state = useAppStore.getState()
+  const worktree = params.executionHostId
+    ? state.getKnownWorktreeById(params.worktreeId, params.executionHostId)
+    : undefined
+  if (params.executionHostId && !worktree) {
+    return null
+  }
+  const ambiguousWorktreeIds = params.executionHostId
+    ? findAmbiguousWorktreeIds(state.allWorktrees())
+    : new Set<string>()
+  return (
+    (state.unifiedTabsByWorktree[params.worktreeId] ?? []).find(
+      (candidate) =>
+        candidate.contentType === 'browser' &&
+        candidate.entityId === params.workspaceId &&
+        (!params.executionHostId ||
+          isUnifiedTabOwnedByWorktree(candidate, worktree!, ambiguousWorktreeIds))
+    ) ?? null
+  )
+}
 
 /**
  * Bring a browser workspace forward as the surface the reader is in.
@@ -9,22 +38,25 @@ import { useAppStore } from '@/store'
  * nothing to bring forward.
  */
 export function activateBrowserWorkspaceTab(params: {
+  executionHostId?: ExecutionHostId
   worktreeId: string
   workspaceId: string
   pageId?: string
 }): boolean {
   const state = useAppStore.getState()
-  const unifiedTab = (state.unifiedTabsByWorktree[params.worktreeId] ?? []).find(
-    (candidate) => candidate.contentType === 'browser' && candidate.entityId === params.workspaceId
-  )
+  const unifiedTab = resolveBrowserWorkspaceUnifiedTab(params)
   if (!unifiedTab) {
     return false
   }
-  state.focusGroup(params.worktreeId, unifiedTab.groupId)
-  state.activateTab(unifiedTab.id)
   state.setActiveBrowserTab(params.workspaceId)
   if (params.pageId) {
     state.setActiveBrowserPage(params.workspaceId, params.pageId)
+  }
+  state.focusGroup(params.worktreeId, unifiedTab.groupId)
+  if (params.executionHostId) {
+    state.activateTab(unifiedTab.id, { worktreeId: params.worktreeId })
+  } else {
+    state.activateTab(unifiedTab.id)
   }
   return true
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 |

<!-- /orca-pr-loc -->

## Summary

Fixes STA-5290. Cmd+J browser-page activation now preserves the result's execution-host ownership when paired local and remote runtimes share worktree IDs.

The canonical browser activation boundary now:

- resolves the host-owned unified browser tab using existing execution-host alias rules
- validates the backing workspace/page/tab before switching active host state
- scopes host-qualified tab activation by worktree
- preserves legacy callers that do not provide host metadata

## Root cause

PR #15686 host-qualified palette candidates, but browser activation still resolved unified tabs and browser records by bare IDs. With same-ID local/remote candidates, activation could leave the remote host selected or focus the wrong group.

## Validation

- `pnpm test src/renderer/src/lib/browser-page-palette-activation.test.ts src/renderer/src/lib/browser-palette-page-entries.test.ts src/renderer/src/lib/cmd-j-host-qualified-candidate-ownership.test.ts`
- `pnpm test src/renderer/src/lib/browser-page-palette-activation.test.ts src/renderer/src/lib/file-preview.test.ts`
- `pnpm tc:web`
- `pnpm run check:code-quality:changed`
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/paired-cmd-j-host-qualified-tabs.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1`

The deterministic collision oracle fails when the host-aware resolver is disabled and passes with this change, including remote-to-local repeated activation and visible active-tab assertions.

## Notes

No Linear status/comment changes were made in this PR creation step.
