### PR TITLE
refactor(preflight): rename execLocalPreflightCommand to execLocalPreflightCommandOrThrow

### DIFF
--- a/src/main/ipc/preflight-command-exec.ts
+++ b/src/main/ipc/preflight-command-exec.ts
@@ -41,7 +41,11 @@ async function withPreflightTimeout<T>(command: string, commandPromise: Promise<
   }
 }
 
-export async function execLocalPreflightCommand(
+/** Rejects on non-zero exit, spawn failure, or timeout — it never reports
+ *  "absent" as a value. A caller that collapses that rejection into `false`
+ *  makes "not installed" and "could not run it" the same answer; see
+ *  docs/reference/wsl-probe-failure-semantics.md before doing so. */
+export async function execLocalPreflightCommandOrThrow(
   command: string,
   args: string[]
 ): Promise<PreflightCommandResult> {
@@ -79,7 +83,7 @@ export async function isCommandAvailable(
   try {
     await (wslTarget
       ? execCommandInWslOrThrow(wslTarget, `${shellQuote(command)} --version`)
-      : execLocalPreflightCommand(command, ['--version']))
+      : execLocalPreflightCommandOrThrow(command, ['--version']))
     return true
   } catch {
     return false

--- a/src/main/ipc/preflight-windows-path-refresh.repro.test.ts
+++ b/src/main/ipc/preflight-windows-path-refresh.repro.test.ts
@@ -8,7 +8,7 @@ import {
   mergePersistedWindowsPathAsync
 } from '../pty/windows-environment-path'
 import { __setWindowsPathRegistryLoaderForTests } from '../pty/windows-path-registry-reader'
-import { execLocalPreflightCommand } from './preflight-command-exec'
+import { execLocalPreflightCommandOrThrow } from './preflight-command-exec'
 
 describe.runIf(process.platform === 'win32')('Windows preflight Path refresh reproduction', () => {
   const originalPath = process.env.Path ?? process.env.PATH ?? ''
@@ -42,7 +42,7 @@ describe.runIf(process.platform === 'win32')('Windows preflight Path refresh rep
     }))
     __resetPersistedWindowsPathCacheForTests()
 
-    await expect(execLocalPreflightCommand(command, ['/?'])).rejects.toMatchObject({
+    await expect(execLocalPreflightCommandOrThrow(command, ['/?'])).rejects.toMatchObject({
       code: 'ENOENT'
     })
 
@@ -50,7 +50,7 @@ describe.runIf(process.platform === 'win32')('Windows preflight Path refresh rep
     const refreshOptions = { forceRefresh: true }
     await mergePersistedWindowsPathAsync(process.env, refreshOptions)
 
-    await expect(execLocalPreflightCommand(command, ['/?'])).resolves.toMatchObject({
+    await expect(execLocalPreflightCommandOrThrow(command, ['/?'])).resolves.toMatchObject({
       stdout: expect.any(String)
     })
     expect(getRegistryKey).toHaveBeenCalledTimes(4)

--- a/src/main/preflight/agent-detection.ts
+++ b/src/main/preflight/agent-detection.ts
@@ -30,7 +30,7 @@ export type { PreflightRuntimeContext }
 import { hydrateShellPathForAgentDetection } from '../ipc/agent-detection-shell-path'
 import {
   execCommandInWslOrThrow,
-  execLocalPreflightCommand,
+  execLocalPreflightCommandOrThrow,
   isCommandAvailable,
   isCommandOnPath,
   shellQuote
@@ -255,7 +255,7 @@ async function isGhAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolea
   try {
     await (wslTarget
       ? execCommandInWslOrThrow(wslTarget, `${shellQuote('gh')} auth status`)
-      : execLocalPreflightCommand('gh', ['auth', 'status']))
+      : execLocalPreflightCommandOrThrow('gh', ['auth', 'status']))
     // Why: for plain-text `gh auth status`, exit 0 means gh did not detect any
     // authentication issues for the checked hosts/accounts.
     return true
@@ -276,7 +276,7 @@ async function isGlabAuthenticated(wslTarget?: WslPreflightTarget): Promise<bool
   try {
     await (wslTarget
       ? execCommandInWslOrThrow(wslTarget, `${shellQuote('glab')} auth status`)
-      : execLocalPreflightCommand('glab', ['auth', 'status']))
+      : execLocalPreflightCommandOrThrow('glab', ['auth', 'status']))
     return true
   } catch (error) {
     const stdout = (error as { stdout?: string }).stdout ?? ''


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | 0 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

Follow-up to #17375, which renamed its WSL sibling.

`execLocalPreflightCommand` has the **identical** throwing contract as `execCommandInWslOrThrow` and is called from the same `try { … } catch { return false }` blocks in `isCommandAvailable` and `isCommandOnPath`. After #17375 the pair read inconsistently — one announced that it throws, the other didn't, while both collapse to a silent `false`.

That silent `false` is the bug class documented in `docs/reference/wsl-probe-failure-semantics.md` and guarded by the ratchet in #17352: a probe that **cannot run** the command reports the same value as one that ran it and found nothing.

## Change

Pure mechanical rename across 3 files (1 definition, 4 usages incl. one test import). No behaviour, signature, or error-handling change.

Also adds a doc comment stating the contract plainly — it rejects rather than reporting "absent", so a caller collapsing that rejection into `false` makes "not installed" and "could not run it" the same answer.

## Verification

- `pnpm run typecheck` (full, not just `tc:node`) — clean
- `pnpm test src/main/ipc/preflight src/main/wsl/wsl-probe-failure-semantics.test.ts` — 83 passed / 1 skipped
- `oxlint` on all 3 changed files — clean