### PR TITLE
fix(agent): detect Qwen Code Node launcher on Windows

### DIFF
--- a/src/shared/agent-node-entrypoint-identities.ts
+++ b/src/shared/agent-node-entrypoint-identities.ts
@@ -14,6 +14,13 @@ export const EXACT_NODE_ENTRYPOINT_IDENTITIES: readonly {
     agent: 'cursor',
     processName: 'cursor-agent'
   },
+  // Why: Qwen's Windows and npm launchers both run a generic cli-entry.js under Node.
+  {
+    pattern:
+      /(?:^|\/)(?:node_modules\/@qwen-code\/qwen-code\/(?:scripts\/)?cli-entry\.js|appdata\/local\/qwen-code\/qwen-code\/lib\/cli-entry\.js)$/,
+    agent: 'qwen-code',
+    processName: 'qwen'
+  },
   // Why: Pi's npm shim launches a generic cli.js; only the exact package path is authoritative.
   {
     pattern:

--- a/src/shared/agent-node-entrypoint-identities.ts
+++ b/src/shared/agent-node-entrypoint-identities.ts
@@ -14,10 +14,15 @@ export const EXACT_NODE_ENTRYPOINT_IDENTITIES: readonly {
     agent: 'cursor',
     processName: 'cursor-agent'
   },
-  // Why: Qwen's Windows and npm launchers both run a generic cli-entry.js under Node.
+  // Why: Qwen's npm shim runs a generic cli-entry.js under Node.
   {
-    pattern:
-      /(?:^|\/)(?:node_modules\/@qwen-code\/qwen-code\/(?:scripts\/)?cli-entry\.js|appdata\/local\/qwen-code\/qwen-code\/lib\/cli-entry\.js)$/,
+    pattern: /(?:^|\/)node_modules\/@qwen-code\/qwen-code\/(?:scripts\/)?cli-entry\.js$/,
+    agent: 'qwen-code',
+    processName: 'qwen'
+  },
+  // Why: the standalone launcher lives under the standard per-user LocalAppData root.
+  {
+    pattern: /^[a-z]:\/users\/[^/]+\/appdata\/local\/qwen-code\/qwen-code\/lib\/cli-entry\.js$/,
     agent: 'qwen-code',
     processName: 'qwen'
   },

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -212,6 +212,11 @@ describe('agent process recognition', () => {
         String.raw`node.exe C:\tools\unrelated\qwen-code\qwen-code\lib\cli-entry.js`
       )
     ).toBeNull()
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        String.raw`node.exe C:\tools\unrelated\AppData\Local\qwen-code\qwen-code\lib\cli-entry.js`
+      )
+    ).toBeNull()
   })
 
   it('recognizes agent CLIs launched through interpreter wrappers', () => {

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -191,6 +191,29 @@ describe('agent process recognition', () => {
     expect(isRecognizedAgentType('qwen')).toBe(true)
   })
 
+  it('recognizes Qwen Code launched through Node on Windows', () => {
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        String.raw`"C:\Users\dev\AppData\Local\qwen-code\qwen-code\node\node.exe" "C:\Users\dev\AppData\Local\qwen-code\qwen-code\lib\cli-entry.js" --approval-mode yolo`
+      )
+    ).toEqual({ agent: 'qwen-code', processName: 'qwen' })
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        String.raw`node.exe C:\Users\dev\AppData\Roaming\npm\node_modules\@qwen-code\qwen-code\cli-entry.js`
+      )
+    ).toEqual({ agent: 'qwen-code', processName: 'qwen' })
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        String.raw`node.exe C:\Users\dev\AppData\Roaming\npm\node_modules\@qwen-code\qwen-code\scripts\cli-entry.js`
+      )
+    ).toEqual({ agent: 'qwen-code', processName: 'qwen' })
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        String.raw`node.exe C:\tools\unrelated\qwen-code\qwen-code\lib\cli-entry.js`
+      )
+    ).toBeNull()
+  })
+
   it('recognizes agent CLIs launched through interpreter wrappers', () => {
     expect(
       recognizeAgentProcessFromCommandLine('node /Users/dev/.nvm/versions/node/bin/codex')


### PR DESCRIPTION
## ELI5

Qwen Code runs as `node.exe` on Windows, so Orca could not identify the agent by process name. This change recognizes Qwen Code from its exact official entry-script paths while continuing to reject unrelated Node scripts.

## What Changed

- Added exact Node entrypoint identities for Qwen Code's Windows standalone and npm layouts.
- Added regression coverage for both layouts and for an unrelated generic `cli-entry.js` path.

## Why

The Windows launcher delegates to Node, which means process-name detection can only see `node.exe`. Matching the anchored Qwen install paths fixes detection without broadly classifying generic Node applications as Qwen Code.

## Linked Issue

Fixes #17326

## Visual Proof

N/A - this changes backend process recognition and has no visual UI change.

## Testing

- [ ] I manually tested these changes locally with the full Qwen Code application
- [x] Automated tests added/updated

Commands run:

```text
vitest run src/shared/agent-process-recognition.test.ts src/main/providers/agent-foreground-process.test.ts
# 2 files passed, 74 tests passed

oxfmt --check src/shared/agent-node-entrypoint-identities.ts src/shared/agent-process-recognition.test.ts
oxlint src/shared/agent-node-entrypoint-identities.ts src/shared/agent-process-recognition.test.ts
tsc --noEmit -p config/tsconfig.node.json --composite false
```

Windows command-line shapes are covered by unit tests. A live Qwen Code installation was not used. Linux/macOS behavior is unchanged.

## AI Disclosure

OpenAI Codex (GPT-5) was used for repository analysis, implementation, test execution, self-review, and PR drafting.

## Author

GitHub: @libaojiang  
X (Twitter): N/A

## Review

- Cross-platform: paths are normalized before matching; the added expressions accept Windows separators after normalization and do not change Linux/macOS process-name recognition.
- Remote/SSH/local: no filesystem assumptions or local-only calls were added; recognition still operates on the command line reported by the execution host.
- Agent compatibility: only anchored Qwen Code entrypoint paths were added; the negative test keeps unrelated `cli-entry.js` processes unrecognized.
- Performance: two constant regular-expression checks were added to the existing small identity table.
- UI: no visual or interaction surface changed.
- Security: strict package/install path matching avoids treating arbitrary Node scripts as a supported agent.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No release metadata, dependencies, or unrelated files were changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (targeted lint, typecheck, and tests pass; full build was not run)