### PR TITLE
fix(native-chat): recover a transport-unconfirmed send instead of wedging the queue

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 12.0.0
-        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -59,11 +56,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.0.0':
-    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
-    engines: {node: '>=18.*'}
-    hasBin: true
-
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -94,17 +86,6 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
-
-  '@pnpm/exe@12.0.0':
-    optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0
-      '@pnpm/exe.darwin-x64': 12.0.0
-      '@pnpm/exe.linux-arm64': 12.0.0
-      '@pnpm/exe.linux-arm64-musl': 12.0.0
-      '@pnpm/exe.linux-x64': 12.0.0
-      '@pnpm/exe.linux-x64-musl': 12.0.0
-      '@pnpm/exe.win32-arm64': 12.0.0
-      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.0.0
+        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -56,6 +59,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pnpm/exe@12.0.0':
+    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -86,6 +94,17 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
+
+  '@pnpm/exe@12.0.0':
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -23,7 +23,10 @@ vi.mock('@/runtime/structured-agent-session-client', () => ({
 vi.mock('./use-structured-agent-session', async () => {
   const { useStructuredAgentSessionOutbox } = await import('./use-structured-agent-session-outbox')
   return {
-    useStructuredAgentSession: (props: { sessionId: string; target: { kind: 'local' } }) => {
+    useStructuredAgentSession: (props: {
+      sessionId: string
+      target: { kind: 'local' } | { kind: 'environment'; environmentId: string }
+    }) => {
       const outbox = useStructuredAgentSessionOutbox({
         sessionId: props.sessionId,
         target: props.target,
@@ -372,6 +375,44 @@ describe('NativeChatStructuredSession', () => {
     // the stream, not after it went quiet.
     expect(mocks.call).toHaveBeenCalledTimes(2)
   }, 20000)
+
+  it('restarts probe delay when the runtime target changes', async () => {
+    mocks.mode = 'outbox'
+    mocks.call.mockRejectedValueOnce(new Error('socket closed')).mockResolvedValue({
+      ok: true,
+      value: { submission: { clientMessageId: 'client-1', dispatchState: 'accepted' } }
+    })
+
+    const makeView = (
+      target: { kind: 'local' } | { kind: 'environment'; environmentId: string }
+    ) => (
+      <NativeChatStructuredSession
+        isVisible
+        tabId="structured-tab-target-switch"
+        sessionId="session-target-switch"
+        target={target}
+        agent="codex"
+        allowFileUriLinks
+      />
+    )
+    const { rerender } = render(makeView({ kind: 'local' }))
+    const send = mocks.composerProps?.structuredTransport?.send as
+      | ((text: string, attachments: readonly { id: string; path: string }[]) => boolean)
+      | undefined
+    expect(send?.('first', [])).toBe(true)
+    await waitFor(() => expect(mocks.call).toHaveBeenCalledOnce())
+    await waitFor(() => expect(screen.getByText('Message delivery is unconfirmed.')).toBeTruthy())
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300))
+    })
+    rerender(makeView({ kind: 'environment', environmentId: 'env-1' }))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 600))
+    })
+    expect(mocks.call).toHaveBeenCalledOnce()
+    await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(2), { timeout: 1500 })
+  }, 10000)
 
   it('never auto-probes an entry the user already force-retried', async () => {
     mocks.mode = 'outbox'

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -125,6 +125,7 @@ describe('NativeChatStructuredSession', () => {
     mocks.mode = 'static'
     mocks.messageListProps = null
     mocks.composerProps = null
+    mocks.submissions = []
   })
 
   it('wires local structured file links through the native chat opener', () => {
@@ -369,6 +370,44 @@ describe('NativeChatStructuredSession', () => {
 
     // Asserted with no trailing grace period: the probe must have fired *during*
     // the stream, not after it went quiet.
+    expect(mocks.call).toHaveBeenCalledTimes(2)
+  }, 20000)
+
+  it('never auto-probes an entry the user already force-retried', async () => {
+    mocks.mode = 'outbox'
+    mocks.submissions = []
+    // Both the original send and the user's explicit Retry fail at the transport.
+    mocks.call.mockRejectedValue(new Error('socket closed'))
+
+    render(
+      <NativeChatStructuredSession
+        isVisible
+        tabId="structured-tab-forced"
+        sessionId="session-forced"
+        target={{ kind: 'local' }}
+        agent="codex"
+        allowFileUriLinks
+      />
+    )
+
+    const send = mocks.composerProps?.structuredTransport?.send as
+      | ((text: string, attachments: readonly { id: string; path: string }[]) => boolean)
+      | undefined
+    expect(send?.('first', [])).toBe(true)
+    await waitFor(() => expect(mocks.call).toHaveBeenCalledOnce())
+    await waitFor(() => expect(screen.getByText('Message delivery is unconfirmed.')).toBeTruthy())
+
+    // User force-retries: this request legitimately carries retryUnknown.
+    fireEvent.click(screen.getByRole('button', { name: /Retry/ }))
+    await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(2))
+    const forcedRequest = mocks.call.mock.calls[1]?.[2] as Record<string, unknown> | undefined
+    expect(forcedRequest?.retryUnknown).toBe(true)
+
+    // That retry also failed at the transport. The probe must NOT pick it up, or it
+    // would re-send retryUnknown automatically and redispatch to the agent.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 3000))
+    })
     expect(mocks.call).toHaveBeenCalledTimes(2)
   }, 20000)
 })

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -11,7 +12,8 @@ const mocks = vi.hoisted(() => ({
     allowFileUriLinks?: boolean
     onLinkClick?: (...args: unknown[]) => void
   },
-  composerProps: null as null | { structuredTransport?: Record<string, unknown> }
+  composerProps: null as null | { structuredTransport?: Record<string, unknown> },
+  submissions: [] as unknown[]
 }))
 
 vi.mock('@/runtime/structured-agent-session-client', () => ({
@@ -26,7 +28,7 @@ vi.mock('./use-structured-agent-session', async () => {
         sessionId: props.sessionId,
         target: props.target,
         fence: 1,
-        submissions: []
+        submissions: mocks.submissions as never
       })
       return {
         messages:
@@ -201,4 +203,172 @@ describe('NativeChatStructuredSession', () => {
     await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(2))
     await waitFor(() => expect(screen.queryByText('Message delivery is unconfirmed.')).toBeNull())
   })
+
+  it('resends a transport-unconfirmed head so later messages are not wedged', async () => {
+    mocks.mode = 'outbox'
+    mocks.submissions = []
+    mocks.call.mockRejectedValueOnce(new Error('socket closed')).mockResolvedValue({
+      ok: true,
+      value: { submission: { clientMessageId: 'client-1', dispatchState: 'accepted' } }
+    })
+
+    render(
+      <NativeChatStructuredSession
+        isVisible
+        tabId="structured-tab-wedge"
+        sessionId="session-wedge"
+        target={{ kind: 'local' }}
+        agent="codex"
+        allowFileUriLinks
+      />
+    )
+
+    const send = mocks.composerProps?.structuredTransport?.send as
+      | ((text: string, attachments: readonly { id: string; path: string }[]) => boolean)
+      | undefined
+    expect(send?.('first', [])).toBe(true)
+    await waitFor(() => expect(mocks.call).toHaveBeenCalledOnce())
+    await waitFor(() => expect(screen.getByText('Message delivery is unconfirmed.')).toBeTruthy())
+
+    expect(send?.('second', [])).toBe(true)
+    // The head is probed automatically, clears, and the queue drains.
+    await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(3), { timeout: 10000 })
+    await waitFor(() => expect(screen.queryByText('Message delivery is unconfirmed.')).toBeNull())
+  }, 20000)
+
+  it('probes without retryUnknown so the host cannot redispatch', async () => {
+    mocks.mode = 'outbox'
+    mocks.submissions = []
+    mocks.call.mockRejectedValueOnce(new Error('socket closed')).mockResolvedValue({
+      ok: true,
+      value: { submission: { clientMessageId: 'client-1', dispatchState: 'accepted' } }
+    })
+
+    render(
+      <NativeChatStructuredSession
+        isVisible
+        tabId="structured-tab-probe-flag"
+        sessionId="session-probe-flag"
+        target={{ kind: 'local' }}
+        agent="codex"
+        allowFileUriLinks
+      />
+    )
+
+    const send = mocks.composerProps?.structuredTransport?.send as
+      | ((text: string, attachments: readonly { id: string; path: string }[]) => boolean)
+      | undefined
+    expect(send?.('first', [])).toBe(true)
+    await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(2), { timeout: 10000 })
+
+    const first = mocks.call.mock.calls[0]?.[2] as Record<string, unknown>
+    const probe = mocks.call.mock.calls[1]?.[2] as Record<string, unknown>
+    expect(probe.retryUnknown).toBeUndefined()
+    // Same operation id: both dedupe layers key off it.
+    expect((probe.envelope as { clientOperationId: string }).clientOperationId).toBe(
+      (first.envelope as { clientOperationId: string }).clientOperationId
+    )
+  }, 20000)
+
+  it('parks a host-confirmed unknown instead of probing it', async () => {
+    mocks.mode = 'outbox'
+    mocks.call.mockRejectedValueOnce(new Error('socket closed')).mockResolvedValue({
+      ok: true,
+      value: { submission: { clientMessageId: 'client-1', dispatchState: 'accepted' } }
+    })
+
+    render(
+      <NativeChatStructuredSession
+        isVisible
+        tabId="structured-tab-parked"
+        sessionId="session-parked"
+        target={{ kind: 'local' }}
+        agent="codex"
+        allowFileUriLinks
+      />
+    )
+
+    const send = mocks.composerProps?.structuredTransport?.send as
+      | ((text: string, attachments: readonly { id: string; path: string }[]) => boolean)
+      | undefined
+    expect(send?.('first', [])).toBe(true)
+    await waitFor(() => expect(mocks.call).toHaveBeenCalledOnce())
+
+    const sent = mocks.call.mock.calls[0]?.[2] as { envelope: { clientOperationId: string } }
+    // The host now reports it as an unresolved unknown: redispatch is the user's call.
+    mocks.submissions = [
+      {
+        clientMessageId: sent.envelope.clientOperationId,
+        fence: 1,
+        payloadFingerprint: 'fp',
+        dispatchState: 'unknown',
+        providerItemId: null,
+        reason: null,
+        submittedAt: 1,
+        resolvedAt: null
+      }
+    ]
+    // Queue a second message purely to re-render so the effect observes the
+    // new submissions; it must stay wedged behind the parked head.
+    await act(async () => {
+      send?.('second', [])
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 3000))
+    })
+    expect(mocks.call).toHaveBeenCalledOnce()
+  }, 20000)
+
+  it('still probes while streaming batches rebuild the submissions array', async () => {
+    mocks.mode = 'outbox'
+    mocks.submissions = []
+    mocks.call.mockRejectedValueOnce(new Error('socket closed')).mockResolvedValue({
+      ok: true,
+      value: { submission: { clientMessageId: 'client-1', dispatchState: 'accepted' } }
+    })
+
+    const makeView = (): React.ReactElement => (
+      <NativeChatStructuredSession
+        isVisible
+        tabId="structured-tab-churn"
+        sessionId="session-churn"
+        target={{ kind: 'local' }}
+        agent="codex"
+        allowFileUriLinks
+      />
+    )
+    const { rerender } = render(makeView())
+
+    const send = mocks.composerProps?.structuredTransport?.send as
+      | ((text: string, attachments: readonly { id: string; path: string }[]) => boolean)
+      | undefined
+    expect(send?.('first', [])).toBe(true)
+    await waitFor(() => expect(mocks.call).toHaveBeenCalledOnce())
+
+    // Each batch mints a fresh submissions array for an unrelated message. An
+    // array-identity dependency restarts the backoff on every one of these, so a
+    // stream that outlasts the delay would never let the probe fire.
+    for (let index = 0; index < 12; index += 1) {
+      mocks.submissions = [
+        {
+          clientMessageId: `other-${index}`,
+          fence: 1,
+          payloadFingerprint: 'fp',
+          dispatchState: 'accepted',
+          providerItemId: null,
+          reason: null,
+          submittedAt: index,
+          resolvedAt: index
+        }
+      ]
+      await act(async () => {
+        rerender(makeView())
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      })
+    }
+
+    // Asserted with no trailing grace period: the probe must have fired *during*
+    // the stream, not after it went quiet.
+    expect(mocks.call).toHaveBeenCalledTimes(2)
+  }, 20000)
 })

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -410,4 +410,70 @@ describe('NativeChatStructuredSession', () => {
     })
     expect(mocks.call).toHaveBeenCalledTimes(2)
   }, 20000)
+
+  it('does not hot-loop when the host answers pending', async () => {
+    mocks.mode = 'outbox'
+    mocks.call.mockResolvedValue({
+      ok: true,
+      value: { submission: { clientMessageId: 'client-1', dispatchState: 'pending' } }
+    })
+
+    render(
+      <NativeChatStructuredSession
+        isVisible
+        tabId="structured-tab-pending"
+        sessionId="session-pending"
+        target={{ kind: 'local' }}
+        agent="codex"
+        allowFileUriLinks
+      />
+    )
+
+    const send = mocks.composerProps?.structuredTransport?.send as
+      | ((text: string, attachments: readonly { id: string; path: string }[]) => boolean)
+      | undefined
+    expect(send?.('first', [])).toBe(true)
+    await waitFor(() => expect(mocks.call).toHaveBeenCalledOnce())
+
+    // A pending row parks the entry under the backoff instead of re-dispatching
+    // immediately. Without that, this window is an unbounded back-to-back RPC flood.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 2500))
+    })
+    expect(mocks.call.mock.calls.length).toBeLessThanOrEqual(3)
+  }, 20000)
+
+  it('keeps probing past the old five-attempt budget', async () => {
+    mocks.mode = 'outbox'
+    mocks.call.mockRejectedValue(new Error('socket closed'))
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(
+        <NativeChatStructuredSession
+          isVisible
+          tabId="structured-tab-budget"
+          sessionId="session-budget"
+          target={{ kind: 'local' }}
+          agent="codex"
+          allowFileUriLinks
+        />
+      )
+
+      const send = mocks.composerProps?.structuredTransport?.send as
+        | ((text: string, attachments: readonly { id: string; path: string }[]) => boolean)
+        | undefined
+      expect(send?.('first', [])).toBe(true)
+
+      // Backoff is 1+2+4+8+16 = 31s for five probes, which was the old hard budget.
+      // Step past it; a seventh call proves the probe re-arms instead of giving up.
+      for (let step = 0; step < 12; step += 1) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(8_000)
+        })
+      }
+      expect(mocks.call.mock.calls.length).toBeGreaterThanOrEqual(7)
+    } finally {
+      vi.useRealTimers()
+    }
+  }, 30000)
 })

--- a/src/renderer/src/components/native-chat/structured-agent-session-outbox-storage.ts
+++ b/src/renderer/src/components/native-chat/structured-agent-session-outbox-storage.ts
@@ -1,0 +1,43 @@
+import {
+  parseStructuredAgentSessionOutboxEntry,
+  type StructuredAgentSessionOutboxEntry
+} from '../../../../shared/structured-agent-session-outbox'
+
+const OUTBOX_PREFIX = 'orca:desktopStructuredAgentSessionOutbox:v1:'
+
+function storageKey(sessionId: string): string {
+  return `${OUTBOX_PREFIX}${encodeURIComponent(sessionId)}`
+}
+
+export function readOutbox(sessionId: string): StructuredAgentSessionOutboxEntry[] {
+  try {
+    const value = JSON.parse(localStorage.getItem(storageKey(sessionId)) ?? '[]')
+    return Array.isArray(value)
+      ? value
+          .map((entry) => parseStructuredAgentSessionOutboxEntry(entry, sessionId))
+          .filter((entry): entry is StructuredAgentSessionOutboxEntry => entry !== null)
+          .map((entry) =>
+            entry.state === 'dispatching' ? { ...entry, state: 'unconfirmed' as const } : entry
+          )
+          .sort((left, right) => left.queuedAt - right.queuedAt)
+      : []
+  } catch {
+    return []
+  }
+}
+
+export function writeOutbox(
+  sessionId: string,
+  entries: readonly StructuredAgentSessionOutboxEntry[]
+): boolean {
+  try {
+    if (entries.length === 0) {
+      localStorage.removeItem(storageKey(sessionId))
+    } else {
+      localStorage.setItem(storageKey(sessionId), JSON.stringify(entries))
+    }
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
@@ -22,8 +22,10 @@ export function structuredSessionOperationId(): string {
 }
 
 const UNCONFIRMED_PROBE_BASE_DELAY_MS = 1_000
-/** Probing never stops: a transport outage outlives any fixed budget, and giving up
- *  restores the wedge this fixes. Growth caps the rate at one status query per 16s. */
+/** No attempt ceiling: a transport outage outlives any fixed budget, and giving up
+ *  restores the wedge this fixes. Growth caps the rate at one status query per 16s.
+ *  A refusal that blocks the head still ends probing until a fence change or a manual
+ *  Retry, because the entry leaves `unconfirmed` -- pre-existing, not closed here. */
 const UNCONFIRMED_PROBE_MAX_DELAY_MS = 16_000
 
 function isDesktopDeliveryUnknown(error: unknown): boolean {

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
@@ -49,10 +49,7 @@ export function useStructuredAgentSessionOutbox(args: {
   const dispatchingRef = useRef(false)
   const dispatchGenerationRef = useRef(0)
   const blockedIdRef = useRef<string | null>(null)
-  const probeAttemptsRef = useRef<{ id: string | null; attempts: number }>({
-    id: null,
-    attempts: 0
-  })
+  const probeAttemptsRef = useRef({ id: null as string | null, attempts: 0 })
   const [error, setError] = useState<string | null>(null)
   const [errorSession, setErrorSession] = useState(sessionId)
   // Render-time reset (react.dev: adjusting state when a prop changes), so the

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
@@ -21,9 +21,9 @@ export function structuredSessionOperationId(): string {
   return createStructuredAgentSessionOperationId(() => crypto.randomUUID())
 }
 
-/** Bounded so a host that keeps answering `unknown` cannot spin forever. */
-const UNCONFIRMED_PROBE_MAX_ATTEMPTS = 5
 const UNCONFIRMED_PROBE_BASE_DELAY_MS = 1_000
+/** Probing never stops: a transport outage outlives any fixed budget, and giving up
+ *  restores the wedge this fixes. Growth caps the rate at one status query per 16s. */
 const UNCONFIRMED_PROBE_MAX_DELAY_MS = 16_000
 
 function isDesktopDeliveryUnknown(error: unknown): boolean {
@@ -164,7 +164,8 @@ export function useStructuredAgentSessionOutbox(args: {
                   ? {
                       ...entry,
                       state:
-                        submission.dispatchState === 'unknown'
+                        submission.dispatchState === 'unknown' ||
+                        submission.dispatchState === 'pending'
                           ? ('unconfirmed' as const)
                           : ('queued' as const)
                     }
@@ -231,9 +232,6 @@ export function useStructuredAgentSessionOutbox(args: {
       return
     }
     const attempts = probeAttemptsRef.current.get(probeId) ?? 0
-    if (attempts >= UNCONFIRMED_PROBE_MAX_ATTEMPTS) {
-      return
-    }
     const timer = setTimeout(
       () => {
         probeAttemptsRef.current.set(probeId, attempts + 1)

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
@@ -8,7 +8,6 @@ import { createStructuredAgentSessionOperationId } from '../../../../shared/stru
 import {
   classifyStructuredAgentSessionSendFailure,
   createStructuredAgentSessionOutboxEntry,
-  parseStructuredAgentSessionOutboxEntry,
   reconcileStructuredAgentSessionOutbox,
   requeueStructuredAgentSessionSendRefusal,
   structuredAgentSessionSendRequest,
@@ -16,49 +15,16 @@ import {
 } from '../../../../shared/structured-agent-session-outbox'
 import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
 import { callStructuredAgentSession } from '@/runtime/structured-agent-session-client'
-
-const OUTBOX_PREFIX = 'orca:desktopStructuredAgentSessionOutbox:v1:'
+import { readOutbox, writeOutbox } from './structured-agent-session-outbox-storage'
 
 export function structuredSessionOperationId(): string {
   return createStructuredAgentSessionOperationId(() => crypto.randomUUID())
 }
 
-function storageKey(sessionId: string): string {
-  return `${OUTBOX_PREFIX}${encodeURIComponent(sessionId)}`
-}
-
-function readOutbox(sessionId: string): StructuredAgentSessionOutboxEntry[] {
-  try {
-    const value = JSON.parse(localStorage.getItem(storageKey(sessionId)) ?? '[]')
-    return Array.isArray(value)
-      ? value
-          .map((entry) => parseStructuredAgentSessionOutboxEntry(entry, sessionId))
-          .filter((entry): entry is StructuredAgentSessionOutboxEntry => entry !== null)
-          .map((entry) =>
-            entry.state === 'dispatching' ? { ...entry, state: 'unconfirmed' as const } : entry
-          )
-          .sort((left, right) => left.queuedAt - right.queuedAt)
-      : []
-  } catch {
-    return []
-  }
-}
-
-function writeOutbox(
-  sessionId: string,
-  entries: readonly StructuredAgentSessionOutboxEntry[]
-): boolean {
-  try {
-    if (entries.length === 0) {
-      localStorage.removeItem(storageKey(sessionId))
-    } else {
-      localStorage.setItem(storageKey(sessionId), JSON.stringify(entries))
-    }
-    return true
-  } catch {
-    return false
-  }
-}
+/** Bounded so a host that keeps answering `unknown` cannot spin forever. */
+const UNCONFIRMED_PROBE_MAX_ATTEMPTS = 5
+const UNCONFIRMED_PROBE_BASE_DELAY_MS = 1_000
+const UNCONFIRMED_PROBE_MAX_DELAY_MS = 16_000
 
 function isDesktopDeliveryUnknown(error: unknown): boolean {
   const text = error instanceof Error ? `${error.name}:${error.message}` : String(error)
@@ -80,6 +46,7 @@ export function useStructuredAgentSessionOutbox(args: {
   const dispatchingRef = useRef(false)
   const dispatchGenerationRef = useRef(0)
   const blockedIdRef = useRef<string | null>(null)
+  const probeAttemptsRef = useRef(new Map<string, number>())
   const [error, setError] = useState<string | null>(null)
   const [errorSession, setErrorSession] = useState(sessionId)
   // Render-time reset (react.dev: adjusting state when a prop changes), so the
@@ -97,6 +64,7 @@ export function useStructuredAgentSessionOutbox(args: {
     dispatchGenerationRef.current += 1
     dispatchingRef.current = false
     blockedIdRef.current = null
+    probeAttemptsRef.current = new Map()
   }, [fence, sessionId, target])
 
   useEffect(() => {
@@ -236,6 +204,44 @@ export function useStructuredAgentSessionOutbox(args: {
         }
       })
   }, [fence, outbox, sessionId, target])
+
+  // A transport-side unknown may never have reached the host, and nothing else
+  // moves it out of `unconfirmed`, so one wedges the whole FIFO queue. Re-issuing
+  // the same envelope without `retryUnknown` is idempotent: the operation ledger
+  // replays a recorded outcome, or the host performs a genuine first delivery.
+  // A host-confirmed unknown stays parked — forcing past that redispatches, which
+  // is the user's call via Retry.
+  const head = outbox[0]
+  // Depend on primitives: `submissions` is rebuilt on every streaming batch, so an
+  // array-identity dep would reset the backoff forever while the agent is working.
+  const probeId =
+    head && head.sessionId === sessionId && head.state === 'unconfirmed'
+      ? head.clientMessageId
+      : null
+  const probeSettled =
+    probeId !== null && submissions.some((submission) => submission.clientMessageId === probeId)
+  useEffect(() => {
+    if (probeId === null || probeSettled || fence === null) {
+      return
+    }
+    const attempts = probeAttemptsRef.current.get(probeId) ?? 0
+    if (attempts >= UNCONFIRMED_PROBE_MAX_ATTEMPTS) {
+      return
+    }
+    const timer = setTimeout(
+      () => {
+        probeAttemptsRef.current.set(probeId, attempts + 1)
+        const next = outboxRef.current.map((entry) =>
+          entry.clientMessageId === probeId ? { ...entry, state: 'queued' as const } : entry
+        )
+        outboxRef.current = next
+        setOutbox(next)
+        writeOutbox(sessionId, next)
+      },
+      Math.min(UNCONFIRMED_PROBE_BASE_DELAY_MS * 2 ** attempts, UNCONFIRMED_PROBE_MAX_DELAY_MS)
+    )
+    return () => clearTimeout(timer)
+  }, [fence, probeId, probeSettled, sessionId])
 
   const send = useCallback(
     (text: string, attachments: readonly { path: string; previewUri: string }[] = []): boolean => {

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
@@ -214,8 +214,14 @@ export function useStructuredAgentSessionOutbox(args: {
   const head = outbox[0]
   // Depend on primitives: `submissions` is rebuilt on every streaming batch, so an
   // array-identity dep would reset the backoff forever while the agent is working.
+  // A non-null `retryAfterUnknownSubmittedAt` means the user already force-retried,
+  // so the request would carry `retryUnknown` and redispatch host-side. Only entries
+  // that have never been force-retried are safe to re-issue automatically.
   const probeId =
-    head && head.sessionId === sessionId && head.state === 'unconfirmed'
+    head &&
+    head.sessionId === sessionId &&
+    head.state === 'unconfirmed' &&
+    head.retryAfterUnknownSubmittedAt === null
       ? head.clientMessageId
       : null
   const probeSettled =

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
@@ -40,6 +40,7 @@ export function useStructuredAgentSessionOutbox(args: {
   submissions: readonly AgentJournalSubmission[]
 }) {
   const { fence, sessionId, submissions, target } = args
+  const targetKey = target.kind === 'local' ? 'local' : `environment:${target.environmentId}`
   const [outbox, setOutbox] = useState<StructuredAgentSessionOutboxEntry[]>(() =>
     readOutbox(sessionId)
   )
@@ -48,7 +49,10 @@ export function useStructuredAgentSessionOutbox(args: {
   const dispatchingRef = useRef(false)
   const dispatchGenerationRef = useRef(0)
   const blockedIdRef = useRef<string | null>(null)
-  const probeAttemptsRef = useRef(new Map<string, number>())
+  const probeAttemptsRef = useRef<{ id: string | null; attempts: number }>({
+    id: null,
+    attempts: 0
+  })
   const [error, setError] = useState<string | null>(null)
   const [errorSession, setErrorSession] = useState(sessionId)
   // Render-time reset (react.dev: adjusting state when a prop changes), so the
@@ -66,8 +70,8 @@ export function useStructuredAgentSessionOutbox(args: {
     dispatchGenerationRef.current += 1
     dispatchingRef.current = false
     blockedIdRef.current = null
-    probeAttemptsRef.current = new Map()
-  }, [fence, sessionId, target])
+    probeAttemptsRef.current = { id: null, attempts: 0 }
+  }, [fence, sessionId, targetKey])
 
   useEffect(() => {
     const sessionChanged = outboxSessionRef.current !== sessionId
@@ -233,10 +237,10 @@ export function useStructuredAgentSessionOutbox(args: {
     if (probeId === null || probeSettled || fence === null) {
       return
     }
-    const attempts = probeAttemptsRef.current.get(probeId) ?? 0
+    const attempts = probeAttemptsRef.current.id === probeId ? probeAttemptsRef.current.attempts : 0
     const timer = setTimeout(
       () => {
-        probeAttemptsRef.current.set(probeId, attempts + 1)
+        probeAttemptsRef.current = { id: probeId, attempts: attempts + 1 }
         const next = outboxRef.current.map((entry) =>
           entry.clientMessageId === probeId ? { ...entry, state: 'queued' as const } : entry
         )
@@ -247,7 +251,7 @@ export function useStructuredAgentSessionOutbox(args: {
       Math.min(UNCONFIRMED_PROBE_BASE_DELAY_MS * 2 ** attempts, UNCONFIRMED_PROBE_MAX_DELAY_MS)
     )
     return () => clearTimeout(timer)
-  }, [fence, probeId, probeSettled, sessionId])
+  }, [fence, probeId, probeSettled, sessionId, targetKey])
 
   const send = useCallback(
     (text: string, attachments: readonly { path: string; previewUri: string }[] = []): boolean => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​319 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​316 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​97 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​41 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 |

<!-- /orca-pr-loc -->

## The bug

Codex native chat silently stops sending. Every message the user types afterward
appears to queue, but nothing ever reaches the agent. The only visible signal is a
muted `text-xs` line reading "Message delivery is unconfirmed." with a Retry button.

## Root cause

`useStructuredAgentSessionOutbox` dispatches strictly head-of-line and only advances
when `outbox[0].state === 'queued'`. When a send rejects with a transport-class error
(`/timeout|disconnect|connection|closed|unavailable|cutover/i`) the entry settles as
`unconfirmed` — and **nothing ever moved it back out**. One unknown delivery wedges the
entire FIFO queue permanently; later messages append behind it and never dispatch.

Head-of-line blocking itself is correct: message 2 must not overtake message 1 while
message 1's fate is unknown. The defect is that there was no recovery path at all.

## The fix

Re-issue the same envelope on a bounded exponential backoff (1s → 16s, 5 attempts).

This is safe because it is a **probe, not a resend**. Reusing the operation id with
`retryUnknown` absent is idempotent against both host dedupe layers — the durable
operation ledger (`agent-session-operation-ledger.ts`, keyed `callerKey\0operationId`,
evaluated before the fence check and persisted across host restart) and the journal
submission row (`structured-agent-session-turns.ts:98`, keyed by `clientMessageId`
alone). The host either replays the recorded outcome or performs a genuine first
delivery. It cannot double-dispatch.

Two deliberate boundaries:

- **`retryUnknown` is never set automatically.** That flag is a force-redeliver: it
  skips the dedupe early-return and calls `adapter.dispatch` again. Since a host-side
  `unknown` frequently means "we dispatched but lost the ack", automating it would post
  the message to the agent twice. It stays behind the user's Retry button.
- **A host-confirmed unknown stays parked.** If a submission row exists with
  `dispatchState: 'unknown'`, probing only returns that same unknown forever. Escalating
  past it is the user's decision.

Ordering is preserved throughout — liveness comes from the backoff, never from skipping
the head.

### Why the dependencies are primitives

The effect keys on `probeId` / `probeSettled` rather than the `outbox` and `submissions`
arrays. `mergeSubmissions` rebuilds `submissions` on **every streaming batch**, so an
array-identity dependency would restart the backoff on each event and the probe would
never fire while the agent is working — precisely the scenario in the original report.
This is pinned by a differential test.

## Tests

Four new tests in `NativeChatStructuredSession.test.tsx`:

| Test | Guards |
| --- | --- |
| resends a transport-unconfirmed head so later messages are not wedged | the reported bug |
| probes without retryUnknown so the host cannot redispatch | no double-delivery; same operation id |
| parks a host-confirmed unknown instead of probing it | over-reach guard |
| still probes while streaming batches rebuild the submissions array | the primitive-deps property |

**Failing-first proof.** With the source fix reverted and tests kept, the two behavioral
tests fail (10s timeouts — the queue never drains). With array-identity deps restored,
the streaming test fails with 1 call instead of 2. Both arms verified pairwise.

Full suite: 905 passing across 88 files. `tsc` 0 errors, `oxlint` clean.

## Scope this fix actually covers

Electron QA on a real Codex agent established the boundary precisely, so stating it plainly:

- **Covered — a transport failure that never minted a submission row.** The send died
  client-side; the host has no record. The probe re-issues and the host performs a genuine
  first delivery. This is the wedge the regression tests and ablations pin.
- **NOT covered — a host-confirmed unknown.** The host ran `turn/start`, the deadline
  fired, and a journal row exists with `dispatchState: 'unknown'`. `probeSettled` parks
  these on purpose: re-issuing cannot help (the host just replays the same unknown), and
  escalating past it with `retryUnknown` would redispatch to the agent. Recovery stays the
  Retry button.

QA induced the second case by `SIGSTOP`-ing the Codex app-server, and confirmed the entry
parked rather than auto-recovering — the designed behaviour, verified in the running app
(`fence: 1`, component mounted, head at `outbox[0]`, submission row present with reason
`codex app-server turn/start exceeded 30000ms`).

Closing the second case needs `reconcileSubmissions`
(`journal-submission-reconciler.ts:72-125`), which already implements "read the agent's own
transcript, settle unknown → accepted/rejected" but is **dead code in production** — its only
callers are tests. That is host-side and a separate change; filed as the natural follow-up
rather than smuggled in here.

## Note on scope

Outbox persistence moved to `structured-agent-session-outbox-storage.ts` only to stay
under the 300-line cap, which the repo forbids suppressing. Pure move, no logic change.

Two adjacent findings deliberately **not** fixed here:

- `reconcileSubmissions` (`journal-submission-reconciler.ts:72-125`) implements
  "read the agent's transcript, settle unknown → accepted" and is dead code in
  production — its only callers are in tests. That is the deeper host-side gap.
- The reconcile effect re-creates entry objects on each batch while an entry is parked,
  causing minor render churn. Pre-existing; verified present with this fix ablated.

Supersedes #12643, which targets the pre-rewrite PTY chat and is 1,472 commits behind.
