### PR TITLE
chore(deps): restore pdfjs-dist release-age exception until it ages out

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,9 @@
 packages: []
 
 minimumReleaseAge: 4320
+# 6.3.289 was published 2026-08-29T12:48Z; it clears the 3-day gate on 2026-09-01T12:48Z.
+minimumReleaseAgeExclude:
+  - pdfjs-dist
 shamefullyHoist: true
 
 supportedArchitectures:


### PR DESCRIPTION
## Problem

`main` cannot install. Every `pnpm install` — local and CI — fails lockfile verification:

```
1 lockfile entries failed verification:
  pdfjs-dist@6.3.289 was published at 2026-08-29T12:48:16.000Z, within
  the minimumReleaseAge cutoff (2026-08-27T09:39:18.447Z)
```

#17372 removed the `minimumReleaseAgeExclude` entry for `pdfjs-dist` two days early. `minimumReleaseAge: 4320` is a 3-day (72h) gate; `pdfjs-dist@6.3.289` was published **2026-08-29T12:48Z**, so it does not clear the gate until **2026-09-01T12:48Z**.

Every job that runs `./.github/actions/install-node-dependencies` fails at ~15-50s: typecheck, all 8 test shards, static analysis, package, native-smoke on all three OSes.

## Fix

Restore the three removed lines, with the age-out date in the comment so the next drop is unambiguous.

## Verification

`pnpm install --frozen-lockfile` on this branch: **Done in 10.3s**. Same command on `main`: fails as above.

Drop the exclusion again any time after 2026-09-01T12:48Z.