### PR TITLE
perf: overlap independent worktree create preflight

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -1549,14 +1549,16 @@ export async function createRemoteWorktree(
   await registerRequiredSshWorktreeCreateRoots(repo.connectionId!, [repo.path])
 
   // Why: explicit branches and non-username prefix modes never consume this; skipping the remote probe preserves the exact branch name.
-  const username =
-    !args.branchNameOverride && settings.branchPrefix === 'git-username'
-      ? await getSshGitUsername(provider, repo.path)
-      : ''
-
   const branchConflictSubject = args.branchNameOverride ? 'branch name' : 'worktree name'
   // Why: don't fall back to hardcoded 'origin/main'; it may not exist (master/develop) and yields an opaque git error, so fail clearly and let the UI prompt.
-  const basePlan = await getOrStartRemoteWorktreeCreateBasePlan(provider, repo, args.baseBranch)
+  // Username and base-plan probes are independent read-only work; overlap them so
+  // SSH latency is paid once before the conflict loop.
+  const [username, basePlan] = await Promise.all([
+    !args.branchNameOverride && settings.branchPrefix === 'git-username'
+      ? getSshGitUsername(provider, repo.path)
+      : Promise.resolve(''),
+    getOrStartRemoteWorktreeCreateBasePlan(provider, repo, args.baseBranch)
+  ])
   if (!basePlan) {
     throw new Error(
       'Could not resolve a default base ref for this repo. Pick a base branch explicitly and try again.'
@@ -1567,12 +1569,10 @@ export async function createRemoteWorktree(
   let baseFallback: WorktreeCreateBaseFallback | undefined
 
   if (remoteTrackingBase) {
-    const hasRemoteTrackingBaseRef = await hasCommitRefSsh(
-      provider,
-      repo.path,
-      remoteTrackingBase.ref
-    )
-    const hasNamedLocalBaseRef = await hasRemoteWorktreeBaseRef(provider, repo.path, baseBranch)
+    const [hasRemoteTrackingBaseRef, hasNamedLocalBaseRef] = await Promise.all([
+      hasCommitRefSsh(provider, repo.path, remoteTrackingBase.ref),
+      hasRemoteWorktreeBaseRef(provider, repo.path, baseBranch)
+    ])
     const hasFallbackLocalBaseRef =
       !hasNamedLocalBaseRef &&
       (await hasRemoteWorktreeBaseRef(provider, repo.path, remoteTrackingBase.branch))
@@ -2016,42 +2016,45 @@ export async function createLocalWorktree(
     ? sanitizeWorktreeDisplayName(args.displayName)
     : undefined
   // Why: explicit branches and non-username prefix modes never consume this; skipping the probe preserves the exact generated branch name.
-  const username =
+  // Username and base resolution are independent read-only probes. Starting
+  // both before awaiting removes one serial git/config round trip from create.
+  const [username, resolvedBaseBranch] = await Promise.all([
     !args.branchNameOverride && settings.branchPrefix === 'git-username'
-      ? await resolveLocalGitUsername(repo.path)
-      : ''
-
-  let baseBranch = await resolveWorktreeCreateBase({
-    requestedBaseBranch: args.baseBranch,
-    repoWorktreeBaseRef: repo.worktreeBaseRef,
-    resolveDefaultBaseRef: () => resolveDefaultBaseRefWithLocalGit(localGitExecOptions),
-    isBaseUsable: async (baseBranchCandidate) => {
-      if (runtime) {
-        const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(
-          repo.path,
-          baseBranchCandidate,
-          ...localWorktreeGitOptionArgs
-        )
-        if (remoteTrackingBase) {
-          if (
-            await runtime.hasRemoteTrackingRef(
-              repo.path,
-              remoteTrackingBase,
-              ...localWorktreeGitOptionArgs
-            )
-          ) {
-            return true
-          }
-          return hasLocalWorktreeBaseRefWithOptions(
+      ? resolveLocalGitUsername(repo.path)
+      : Promise.resolve(''),
+    resolveWorktreeCreateBase({
+      requestedBaseBranch: args.baseBranch,
+      repoWorktreeBaseRef: repo.worktreeBaseRef,
+      resolveDefaultBaseRef: () => resolveDefaultBaseRefWithLocalGit(localGitExecOptions),
+      isBaseUsable: async (baseBranchCandidate) => {
+        if (runtime) {
+          const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(
             repo.path,
             baseBranchCandidate,
-            localGitExecOptions
+            ...localWorktreeGitOptionArgs
           )
+          if (remoteTrackingBase) {
+            if (
+              await runtime.hasRemoteTrackingRef(
+                repo.path,
+                remoteTrackingBase,
+                ...localWorktreeGitOptionArgs
+              )
+            ) {
+              return true
+            }
+            return hasLocalWorktreeBaseRefWithOptions(
+              repo.path,
+              baseBranchCandidate,
+              localGitExecOptions
+            )
+          }
         }
+        return hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranchCandidate, localGitExecOptions)
       }
-      return hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranchCandidate, localGitExecOptions)
-    }
-  })
+    })
+  ])
+  let baseBranch = resolvedBaseBranch
   if (!baseBranch) {
     // Why: no default base resolved; fail clearly rather than pass a hardcoded non-existent ref to git worktree add (opaque error) so the UI can prompt.
     throw new Error(
@@ -2075,16 +2078,14 @@ export async function createLocalWorktree(
       ...localWorktreeGitOptionArgs
     )
     if (remoteTrackingBase) {
-      const hasRemoteTrackingBaseRef = await runtime.hasRemoteTrackingRef(
-        repo.path,
-        remoteTrackingBase,
-        ...localWorktreeGitOptionArgs
-      )
-      const hasNamedLocalBaseRef = await hasLocalWorktreeBaseRefWithOptions(
-        repo.path,
-        baseBranch,
-        localGitExecOptions
-      )
+      const [hasRemoteTrackingBaseRef, hasNamedLocalBaseRef] = await Promise.all([
+        runtime.hasRemoteTrackingRef(
+          repo.path,
+          remoteTrackingBase,
+          ...localWorktreeGitOptionArgs
+        ),
+        hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranch, localGitExecOptions)
+      ])
       const hasFallbackLocalBaseRef =
         !hasNamedLocalBaseRef &&
         (await hasLocalWorktreeBaseRefWithOptions(
@@ -2591,9 +2592,14 @@ export async function createLocalWorktree(
 
   // Why: project-level `orca.yaml` shared directories add to (never replace) the per-user
   // setting, so a repo's shared dirs reach every teammate (issue #10451).
-  const sharedDirectories = await timing.time('resolve_shared_directories', () =>
-    resolveWorktreeSharedDirectories(repo.path, localWorktreeGitOptions)
-  )
+  const [sharedDirectories, includePaths] = await Promise.all([
+    timing.time('resolve_shared_directories', () =>
+      resolveWorktreeSharedDirectories(repo.path, localWorktreeGitOptions)
+    ),
+    timing.time('resolve_worktreeinclude', () =>
+      resolveWorktreeIncludePaths(repo.path, localWorktreeGitOptions)
+    )
+  ])
   if (sharedDirectories.length > 0) {
     await timing.time('create_shared_directories', async () => {
       await createWorktreeSharedPaths(repo.path, created.path, sharedDirectories)
@@ -2602,9 +2608,6 @@ export async function createLocalWorktree(
 
   // Why: project-level `.worktreeinclude` travels with the repo (issue #7549); copy semantics
   // (never symlink) so each worktree owns its files. Paths already linked above are skipped.
-  const includePaths = await timing.time('resolve_worktreeinclude', () =>
-    resolveWorktreeIncludePaths(repo.path, localWorktreeGitOptions)
-  )
   let includeCopyWarning: string | undefined
   if (includePaths.length > 0) {
     await timing.time('copy_worktreeinclude', async () => {

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -2018,42 +2018,42 @@ export async function createLocalWorktree(
   // Why: explicit branches and non-username prefix modes never consume this; skipping the probe preserves the exact generated branch name.
   // Username and base resolution are independent read-only probes. Starting
   // both before awaiting removes one serial git/config round trip from create.
-  const [username, resolvedBaseBranch] = await Promise.all([
+  const usernamePromise =
     !args.branchNameOverride && settings.branchPrefix === 'git-username'
       ? resolveLocalGitUsername(repo.path)
-      : Promise.resolve(''),
-    resolveWorktreeCreateBase({
-      requestedBaseBranch: args.baseBranch,
-      repoWorktreeBaseRef: repo.worktreeBaseRef,
-      resolveDefaultBaseRef: () => resolveDefaultBaseRefWithLocalGit(localGitExecOptions),
-      isBaseUsable: async (baseBranchCandidate) => {
-        if (runtime) {
-          const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(
+      : Promise.resolve('')
+  const baseBranchPromise = resolveWorktreeCreateBase({
+    requestedBaseBranch: args.baseBranch,
+    repoWorktreeBaseRef: repo.worktreeBaseRef,
+    resolveDefaultBaseRef: () => resolveDefaultBaseRefWithLocalGit(localGitExecOptions),
+    isBaseUsable: async (baseBranchCandidate) => {
+      if (runtime) {
+        const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(
+          repo.path,
+          baseBranchCandidate,
+          ...localWorktreeGitOptionArgs
+        )
+        if (remoteTrackingBase) {
+          if (
+            await runtime.hasRemoteTrackingRef(
+              repo.path,
+              remoteTrackingBase,
+              ...localWorktreeGitOptionArgs
+            )
+          ) {
+            return true
+          }
+          return hasLocalWorktreeBaseRefWithOptions(
             repo.path,
             baseBranchCandidate,
-            ...localWorktreeGitOptionArgs
+            localGitExecOptions
           )
-          if (remoteTrackingBase) {
-            if (
-              await runtime.hasRemoteTrackingRef(
-                repo.path,
-                remoteTrackingBase,
-                ...localWorktreeGitOptionArgs
-              )
-            ) {
-              return true
-            }
-            return hasLocalWorktreeBaseRefWithOptions(
-              repo.path,
-              baseBranchCandidate,
-              localGitExecOptions
-            )
-          }
         }
-        return hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranchCandidate, localGitExecOptions)
       }
-    })
-  ])
+      return hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranchCandidate, localGitExecOptions)
+    }
+  })
+  const [username, resolvedBaseBranch] = await Promise.all([usernamePromise, baseBranchPromise])
   let baseBranch = resolvedBaseBranch
   if (!baseBranch) {
     // Why: no default base resolved; fail clearly rather than pass a hardcoded non-existent ref to git worktree add (opaque error) so the UI can prompt.
@@ -2079,11 +2079,7 @@ export async function createLocalWorktree(
     )
     if (remoteTrackingBase) {
       const [hasRemoteTrackingBaseRef, hasNamedLocalBaseRef] = await Promise.all([
-        runtime.hasRemoteTrackingRef(
-          repo.path,
-          remoteTrackingBase,
-          ...localWorktreeGitOptionArgs
-        ),
+        runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase, ...localWorktreeGitOptionArgs),
         hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranch, localGitExecOptions)
       ])
       const hasFallbackLocalBaseRef =

--- a/src/main/ipc/worktrees-local-create-flow.test.ts
+++ b/src/main/ipc/worktrees-local-create-flow.test.ts
@@ -113,22 +113,26 @@ describe('registerWorktreeHandlers', () => {
     const events: string[] = []
     let resolveUsername!: (value: string) => void
     let resolveBase!: (value: string | null) => void
-    const usernamePromise = new Promise<string>((resolve) => {
-      events.push('username-start')
-      resolveUsername = resolve
-    })
-    const basePromise = new Promise<string | null>((resolve) => {
-      events.push('base-start')
-      resolveBase = resolve
-    })
     store.getSettings.mockReturnValue({
       branchPrefix: 'git-username',
       nestWorkspaces: false,
       refreshLocalBaseRefOnWorktreeCreate: false,
       workspaceDir: '/workspace'
     })
-    resolveLocalGitUsernameMock.mockReturnValue(usernamePromise)
-    resolveDefaultBaseRefWithLocalGitMock.mockReturnValue(basePromise)
+    resolveLocalGitUsernameMock.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          events.push('username-start')
+          resolveUsername = resolve
+        })
+    )
+    resolveDefaultBaseRefWithLocalGitMock.mockImplementation(
+      () =>
+        new Promise<string | null>((resolve) => {
+          events.push('base-start')
+          resolveBase = resolve
+        })
+    )
     listWorktreesMock.mockResolvedValue([
       {
         path: '/workspace/concurrent-probe',

--- a/src/main/ipc/worktrees-local-create-flow.test.ts
+++ b/src/main/ipc/worktrees-local-create-flow.test.ts
@@ -7,6 +7,7 @@ import {
   addWorktreeMock,
   resolveLocalGitUsernameMock,
   getBaseRefDefaultMock,
+  resolveDefaultBaseRefWithLocalGitMock,
   getBranchConflictKindMock,
   getEffectiveHooksMock,
   createSetupRunnerScriptMock,
@@ -106,6 +107,50 @@ describe('registerWorktreeHandlers', () => {
 
   beforeEach(() => {
     runtimeStub = setupWorktreeHandlers()
+  })
+
+  it('starts username and base-ref probes concurrently', async () => {
+    const events: string[] = []
+    let resolveUsername!: (value: string) => void
+    let resolveBase!: (value: string | null) => void
+    const usernamePromise = new Promise<string>((resolve) => {
+      events.push('username-start')
+      resolveUsername = resolve
+    })
+    const basePromise = new Promise<string | null>((resolve) => {
+      events.push('base-start')
+      resolveBase = resolve
+    })
+    store.getSettings.mockReturnValue({
+      branchPrefix: 'git-username',
+      nestWorkspaces: false,
+      refreshLocalBaseRefOnWorktreeCreate: false,
+      workspaceDir: '/workspace'
+    })
+    resolveLocalGitUsernameMock.mockReturnValue(usernamePromise)
+    resolveDefaultBaseRefWithLocalGitMock.mockReturnValue(basePromise)
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/concurrent-probe',
+        head: 'created-sha',
+        branch: 'jdoe/concurrent-probe',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const creation = handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'concurrent-probe'
+    })
+    await Promise.resolve()
+
+    expect(events).toEqual(['username-start', 'base-start'])
+    resolveUsername('jdoe')
+    resolveBase('origin/main')
+    await expect(creation).resolves.toMatchObject({
+      worktree: expect.objectContaining({ branch: 'jdoe/concurrent-probe' })
+    })
   })
 
   it('prefetches the local default create base through the runtime refresh cache', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -26793,38 +26793,32 @@ export class OrcaRuntimeService {
     let effectiveSanitizedName = sanitizedName
     // Username and base resolution are independent read-only probes. Starting
     // both before awaiting removes one serial git/config round trip from create.
-    const [username, baseBranch] = await Promise.all([
+    const usernamePromise =
       !args.branchNameOverride && settings.branchPrefix === 'git-username'
         ? resolveLocalGitUsername(repo.path)
-        : Promise.resolve(''),
-      resolveWorktreeCreateBase({
-        requestedBaseBranch: args.baseBranch,
-        repoWorktreeBaseRef: repo.worktreeBaseRef,
-        resolveDefaultBaseRef: () =>
-          hasLocalWorktreeGitOptions
-            ? resolveDefaultBaseRefWithLocalGit(localGitExecOptions)
-            : getBaseRefDefault(repo.path),
-        isBaseUsable: async (baseBranchCandidate) => {
-          const remoteTrackingBase = await this.resolveRemoteTrackingBase(
-            repo.path,
-            baseBranchCandidate,
-            ...localWorktreeGitOptionArgs
-          )
-          if (remoteTrackingBase) {
-            if (
-              await this.hasRemoteTrackingRef(
-                repo.path,
-                remoteTrackingBase,
-                ...localWorktreeGitOptionArgs
-              )
-            ) {
-              return true
-            }
-            return hasLocalWorktreeBaseRef(
+        : Promise.resolve('')
+    const baseBranchPromise = resolveWorktreeCreateBase({
+      requestedBaseBranch: args.baseBranch,
+      repoWorktreeBaseRef: repo.worktreeBaseRef,
+      resolveDefaultBaseRef: () =>
+        hasLocalWorktreeGitOptions
+          ? resolveDefaultBaseRefWithLocalGit(localGitExecOptions)
+          : getBaseRefDefault(repo.path),
+      isBaseUsable: async (baseBranchCandidate) => {
+        const remoteTrackingBase = await this.resolveRemoteTrackingBase(
+          repo.path,
+          baseBranchCandidate,
+          ...localWorktreeGitOptionArgs
+        )
+        if (remoteTrackingBase) {
+          if (
+            await this.hasRemoteTrackingRef(
               repo.path,
-              baseBranchCandidate,
-              hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {}
+              remoteTrackingBase,
+              ...localWorktreeGitOptionArgs
             )
+          ) {
+            return true
           }
           return hasLocalWorktreeBaseRef(
             repo.path,
@@ -26832,8 +26826,14 @@ export class OrcaRuntimeService {
             hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {}
           )
         }
-      })
-    ])
+        return hasLocalWorktreeBaseRef(
+          repo.path,
+          baseBranchCandidate,
+          hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {}
+        )
+      }
+    })
+    const [username, baseBranch] = await Promise.all([usernamePromise, baseBranchPromise])
     if (!baseBranch) {
       // Why: a null default means no suitable ref exists; fail clearly instead
       // of handing Git a fabricated origin/main ref.

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -26791,35 +26791,40 @@ export class OrcaRuntimeService {
     const requestedDisplayName = args.displayName?.trim() || undefined
     const sanitizedName = sanitizeWorktreeName(args.name)
     let effectiveSanitizedName = sanitizedName
-    // Why: explicit branches and non-username prefix modes never consume this
-    // value; skipping the probes preserves the exact generated branch name.
-    const username =
+    // Username and base resolution are independent read-only probes. Starting
+    // both before awaiting removes one serial git/config round trip from create.
+    const [username, baseBranch] = await Promise.all([
       !args.branchNameOverride && settings.branchPrefix === 'git-username'
-        ? await resolveLocalGitUsername(repo.path)
-        : ''
-
-    const baseBranch = await resolveWorktreeCreateBase({
-      requestedBaseBranch: args.baseBranch,
-      repoWorktreeBaseRef: repo.worktreeBaseRef,
-      resolveDefaultBaseRef: () =>
-        hasLocalWorktreeGitOptions
-          ? resolveDefaultBaseRefWithLocalGit(localGitExecOptions)
-          : getBaseRefDefault(repo.path),
-      isBaseUsable: async (baseBranchCandidate) => {
-        const remoteTrackingBase = await this.resolveRemoteTrackingBase(
-          repo.path,
-          baseBranchCandidate,
-          ...localWorktreeGitOptionArgs
-        )
-        if (remoteTrackingBase) {
-          if (
-            await this.hasRemoteTrackingRef(
+        ? resolveLocalGitUsername(repo.path)
+        : Promise.resolve(''),
+      resolveWorktreeCreateBase({
+        requestedBaseBranch: args.baseBranch,
+        repoWorktreeBaseRef: repo.worktreeBaseRef,
+        resolveDefaultBaseRef: () =>
+          hasLocalWorktreeGitOptions
+            ? resolveDefaultBaseRefWithLocalGit(localGitExecOptions)
+            : getBaseRefDefault(repo.path),
+        isBaseUsable: async (baseBranchCandidate) => {
+          const remoteTrackingBase = await this.resolveRemoteTrackingBase(
+            repo.path,
+            baseBranchCandidate,
+            ...localWorktreeGitOptionArgs
+          )
+          if (remoteTrackingBase) {
+            if (
+              await this.hasRemoteTrackingRef(
+                repo.path,
+                remoteTrackingBase,
+                ...localWorktreeGitOptionArgs
+              )
+            ) {
+              return true
+            }
+            return hasLocalWorktreeBaseRef(
               repo.path,
-              remoteTrackingBase,
-              ...localWorktreeGitOptionArgs
+              baseBranchCandidate,
+              hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {}
             )
-          ) {
-            return true
           }
           return hasLocalWorktreeBaseRef(
             repo.path,
@@ -26827,13 +26832,8 @@ export class OrcaRuntimeService {
             hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {}
           )
         }
-        return hasLocalWorktreeBaseRef(
-          repo.path,
-          baseBranchCandidate,
-          hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {}
-        )
-      }
-    })
+      })
+    ])
     if (!baseBranch) {
       // Why: a null default means no suitable ref exists; fail clearly instead
       // of handing Git a fabricated origin/main ref.
@@ -26990,18 +26990,15 @@ export class OrcaRuntimeService {
       ...localWorktreeGitOptionArgs
     )
     if (remoteTrackingBase) {
-      const hadRemoteTrackingBaseRef = await this.hasRemoteTrackingRef(
-        repo.path,
-        remoteTrackingBase,
-        ...localWorktreeGitOptionArgs
-      )
-      const hasLocalBaseRef =
-        hadRemoteTrackingBaseRef ||
-        (await hasLocalWorktreeBaseRef(
+      const [hadRemoteTrackingBaseRef, hasNamedLocalBaseRef] = await Promise.all([
+        this.hasRemoteTrackingRef(repo.path, remoteTrackingBase, ...localWorktreeGitOptionArgs),
+        hasLocalWorktreeBaseRef(
           repo.path,
           baseBranch,
           hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {}
-        ))
+        )
+      ])
+      const hasLocalBaseRef = hadRemoteTrackingBaseRef || hasNamedLocalBaseRef
       if (!hadRemoteTrackingBaseRef && hasLocalBaseRef) {
         remoteTrackingBase = null
       } else {
@@ -27300,22 +27297,18 @@ export class OrcaRuntimeService {
       await createWorktreeLinkedPaths(repo.path, created.path, symlinkPaths)
     }
 
-    // Why: project-level `orca.yaml` shared directories add to (never replace) the
-    // per-user setting, so a repo's shared dirs reach every teammate (issue #10451).
-    const sharedDirectories = await resolveWorktreeSharedDirectories(
-      repo.path,
-      localWorktreeGitOptions
-    )
+    // Why: these discoveries are read-only; overlap them, but keep the
+    // shared-path mutation ahead of include copies below.
+    const [sharedDirectories, worktreeIncludePaths] = await Promise.all([
+      resolveWorktreeSharedDirectories(repo.path, localWorktreeGitOptions),
+      resolveWorktreeIncludePaths(repo.path, localWorktreeGitOptions)
+    ])
     if (sharedDirectories.length > 0) {
       await createWorktreeSharedPaths(repo.path, created.path, sharedDirectories)
     }
 
     // Why: project-level `.worktreeinclude` travels with the repo (issue #7549); copy semantics
     // (never symlink) so each worktree owns its files. Paths already linked above are skipped.
-    const worktreeIncludePaths = await resolveWorktreeIncludePaths(
-      repo.path,
-      localWorktreeGitOptions
-    )
     let includeCopyWarning: string | undefined
     if (worktreeIncludePaths.length > 0) {
       const skippedIncludePaths = await createWorktreeCopiedPaths(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​59 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 |

<!-- /orca-pr-loc -->

## Summary

- Resolve the branch-prefix username and worktree base plan concurrently for local, runtime, and SSH worktree creation.
- Overlap independent remote-tracking/local-base presence probes while preserving fallback and mutation ordering.
- Resolve `orca.yaml` shared directories and `.worktreeinclude` entries concurrently after the worktree exists; shared-path mutations still finish before include copies.

This is a small, read-only preflight optimization extracted from the broader early-terminal work in #13704. It does not change IPC/RPC payloads, checkout semantics, cleanup, or terminal startup.

## Correctness / risk

- No new Git commands; only independent existing probes overlap.
- Branch conflict/suffix loops and all mutations remain ordered.
- SSH/WSL options are passed unchanged and remote execution remains host-owned.
- Folder workspaces continue to bypass Git worktree creation.

## Evidence

- Added a deterministic test proving username and base probes start before either completes.
- Focused worktree-create suites: 33 passed.
- Runtime worktree tests and typecheck passed before commit; changed-code quality was previously green on the same diff. The current checkout's pnpm wrapper is blocked by the repository's minimum-release-age check for an unrelated `pdfjs-dist@6.3.289` lockfile entry.

## Follow-up context

- #17290 contains speculative checkout preparation and separate Windows long-path hardening.
- #13704 remains draft; its PTY/early-terminal/relay changes should not be bundled with this optimization.
