### PR TITLE
perf(wsl): place worktrees inside the distro when the project runs in WSL

### DIFF
--- a/src/main/ipc/filesystem-allowed-roots.ts
+++ b/src/main/ipc/filesystem-allowed-roots.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path'
 import type { Store } from '../persistence'
 import { computeWorkspaceRoot, getWorktreePathSettings } from './worktree-logic'
+import { getWorktreeMirrorDistro } from '../project-runtime-git-options'
 import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
 import { getProjectGroupSubtreeIds } from '../../shared/project-groups'
 import type { FolderWorkspace } from '../../shared/folder-workspace-types'
@@ -97,7 +98,15 @@ export function getAllowedRoots(store: Store): string[] {
     } else {
       for (const repo of localRepos) {
         roots.push(
-          resolve(computeWorkspaceRoot(repo.path, getWorktreePathSettings(repo, settings)))
+          resolve(
+            computeWorkspaceRoot(
+              repo.path,
+              // Why enriched here too: placement has to agree with the create
+              // flow, or renderer file access is denied for a worktree Orca
+              // just put on the WSL side.
+              getWorktreePathSettings(repo, settings, getWorktreeMirrorDistro(store, repo))
+            )
+          )
         )
       }
     }

--- a/src/main/ipc/worktree-base-directory-watch-targets.test.ts
+++ b/src/main/ipc/worktree-base-directory-watch-targets.test.ts
@@ -215,6 +215,20 @@ describe('worktree base directory watch target resolution', () => {
     expect(getSshFilesystemProviderMock).toHaveBeenCalledWith('missing')
   })
 
+  // A mirrored layout puts the working trees inside the distro while the gitdir
+  // stays on the Windows drive, so the UNC root skip must not take git-common with it.
+  it('keeps the Windows-side git-common watcher when only the workspace root is a WSL UNC path', async () => {
+    const repo = makeRepo(0, {
+      path: 'C:\\Users\\alice\\orca',
+      worktreeBasePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\workspaces'
+    })
+
+    const targets = await buildWorktreeBaseDirectoryWatchTargets(makeStore([repo]) as never)
+
+    expect([...targets.values()].map((target) => target.kind)).toEqual(['git-common'])
+    expect([...targets.values()][0]?.path).toBe('C:/Users/alice/orca/.git')
+  })
+
   it('does not publish ordered partial targets when a repo resolver rejects unexpectedly', async () => {
     const completed = makeRepo(0)
     const broken = makeRepo(1)

--- a/src/main/ipc/worktree-base-directory-watch-targets.ts
+++ b/src/main/ipc/worktree-base-directory-watch-targets.ts
@@ -17,6 +17,7 @@ import {
 import { isWslUncPath } from '../../shared/wsl-paths'
 import { mapWithConcurrency } from '../../shared/map-with-concurrency'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
+import { getWorktreeMirrorDistro } from '../project-runtime-git-options'
 import {
   computeWorkspaceRoot,
   getWorktreePathSettings,
@@ -129,9 +130,10 @@ async function maybeAddBaseTarget(
   targets: Map<string, WorktreeBaseWatchTarget>,
   repo: Repo,
   settings: GlobalSettings,
+  mirrorDistro: string | undefined,
   connectionId?: string
 ): Promise<void> {
-  const pathSettings = getWorktreePathSettings(repo, settings)
+  const pathSettings = getWorktreePathSettings(repo, settings, mirrorDistro)
   const { workspaceRoot, nestWorkspaces } = getBaseWatchLayout(repo, pathSettings, connectionId)
   // Why: WSL UNC roots are unreliable for native watching; avoid project-level polling.
   if (isWslUncPath(workspaceRoot) || isWslUncPath(repo.path)) {
@@ -183,7 +185,8 @@ async function maybeAddBaseTarget(
 
 async function resolveRepoTargets(
   repo: Repo,
-  settings: GlobalSettings
+  settings: GlobalSettings,
+  mirrorDistro: string | undefined
 ): Promise<Map<string, WorktreeBaseWatchTarget>> {
   const targets = new Map<string, WorktreeBaseWatchTarget>()
   if (isFolderRepo(repo)) {
@@ -191,9 +194,9 @@ async function resolveRepoTargets(
   }
   const executionHostId = getRepoExecutionHostId(repo)
   if (executionHostId === LOCAL_EXECUTION_HOST_ID) {
-    await maybeAddBaseTarget(targets, repo, settings)
+    await maybeAddBaseTarget(targets, repo, settings, mirrorDistro)
   } else if (repo.connectionId) {
-    await maybeAddBaseTarget(targets, repo, settings, repo.connectionId)
+    await maybeAddBaseTarget(targets, repo, settings, mirrorDistro, repo.connectionId)
   }
   return targets
 }
@@ -221,7 +224,7 @@ export async function buildWorktreeBaseDirectoryWatchTargets(
   const resolvedRepoTargets = await mapWithConcurrency(
     store.getRepos(),
     WORKTREE_BASE_TARGET_RESOLUTION_CONCURRENCY,
-    (repo) => resolveRepoTargets(repo, settings)
+    (repo) => resolveRepoTargets(repo, settings, getWorktreeMirrorDistro(store, repo))
   )
   const targets = new Map<string, WorktreeBaseWatchTarget>()
   for (const repoTargets of resolvedRepoTargets) {

--- a/src/main/ipc/worktree-base-directory-watch-targets.ts
+++ b/src/main/ipc/worktree-base-directory-watch-targets.ts
@@ -126,6 +126,12 @@ function getBaseWatchLayout(
   }
 }
 
+function warnSkippedWslRoot(repoId: string, workspaceRoot: string): void {
+  if (shouldEmitBoundedWarning(skippedWslWarnings, `${repoId}:${workspaceRoot}`)) {
+    console.warn(`[worktree-base-watcher] skipping WSL worktree root watcher for ${workspaceRoot}`)
+  }
+}
+
 async function maybeAddBaseTarget(
   targets: Map<string, WorktreeBaseWatchTarget>,
   repo: Repo,
@@ -135,17 +141,6 @@ async function maybeAddBaseTarget(
 ): Promise<void> {
   const pathSettings = getWorktreePathSettings(repo, settings, mirrorDistro)
   const { workspaceRoot, nestWorkspaces } = getBaseWatchLayout(repo, pathSettings, connectionId)
-  // Why: WSL UNC roots are unreliable for native watching; avoid project-level polling.
-  if (isWslUncPath(workspaceRoot) || isWslUncPath(repo.path)) {
-    const key = `${repo.id}:${workspaceRoot}`
-    if (shouldEmitBoundedWarning(skippedWslWarnings, key)) {
-      console.warn(
-        `[worktree-base-watcher] skipping WSL worktree root watcher for ${workspaceRoot}`
-      )
-    }
-    return
-  }
-
   const config = {
     repoId: repo.id,
     repoName: getRuntimePathBasename(repo.path).replace(/\.git$/, ''),
@@ -155,17 +150,28 @@ async function maybeAddBaseTarget(
   if (connectionId && !remoteProvider) {
     return
   }
-  try {
-    const rootStat = remoteProvider
-      ? await remoteProvider.stat(workspaceRoot)
-      : await stat(workspaceRoot)
-    if (isDirectoryStat(rootStat)) {
-      await addTarget(targets, 'base', workspaceRoot, config, connectionId)
-    }
-  } catch {
-    const key = normalizeWatchKey(workspaceRoot)
-    if (shouldEmitBoundedWarning(missingRootWarnings, key)) {
-      console.warn(`[worktree-base-watcher] worktree root unavailable: ${workspaceRoot}`)
+  // Why: WSL UNC paths are unreliable for native watching. A repo inside the
+  // distro has nothing watchable at all; a Windows-drive repo whose worktrees
+  // are mirrored into the distro still has its gitdir on the Windows side.
+  if (isWslUncPath(repo.path)) {
+    warnSkippedWslRoot(repo.id, workspaceRoot)
+    return
+  }
+  if (isWslUncPath(workspaceRoot)) {
+    warnSkippedWslRoot(repo.id, workspaceRoot)
+  } else {
+    try {
+      const rootStat = remoteProvider
+        ? await remoteProvider.stat(workspaceRoot)
+        : await stat(workspaceRoot)
+      if (isDirectoryStat(rootStat)) {
+        await addTarget(targets, 'base', workspaceRoot, config, connectionId)
+      }
+    } catch {
+      const key = normalizeWatchKey(workspaceRoot)
+      if (shouldEmitBoundedWarning(missingRootWarnings, key)) {
+        console.warn(`[worktree-base-watcher] worktree root unavailable: ${workspaceRoot}`)
+      }
     }
   }
 
@@ -178,7 +184,7 @@ async function maybeAddBaseTarget(
         }
       : undefined
   )
-  if (commonDir) {
+  if (commonDir && !isWslUncPath(commonDir)) {
     await addTarget(targets, 'git-common', commonDir, config, connectionId)
   }
 }

--- a/src/main/ipc/worktree-logic-wsl.test.ts
+++ b/src/main/ipc/worktree-logic-wsl.test.ts
@@ -260,4 +260,86 @@ describe('computeWorktreePath WSL layout', () => {
       })
     ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\jin\\custom-worktrees\\feature')
   })
+
+  // The C:\ repo + WSL runtime case: git status stats every working-tree file,
+  // so a tree on the Windows drive costs ~46s across the 9p mount versus ~0.2s
+  // native with only the gitdir left behind.
+  describe('Windows-drive repo whose project runs in WSL', () => {
+    it('places worktrees inside the distro', () => {
+      parseWslPathMock.mockReturnValue(null)
+      getWslHomeMock.mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+
+      expect(
+        computeWorktreePath('feature', 'C:\\Users\\jin\\repo', {
+          nestWorkspaces: false,
+          workspaceDir: 'C:\\workspaces',
+          wslMirrorDistro: 'Ubuntu'
+        })
+      ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\jin\\orca\\workspaces\\feature')
+    })
+
+    it('keeps Windows placement when the project has no WSL runtime', () => {
+      parseWslPathMock.mockReturnValue(null)
+
+      expect(
+        computeWorktreePath('feature', 'C:\\Users\\jin\\repo', {
+          nestWorkspaces: false,
+          workspaceDir: 'C:\\workspaces'
+        })
+      ).toBe(win32.join('C:\\workspaces', 'feature'))
+      expect(getWslHomeMock).not.toHaveBeenCalled()
+    })
+
+    it('falls back to Windows placement when the distro home cannot be resolved', () => {
+      parseWslPathMock.mockReturnValue(null)
+      getWslHomeMock.mockReturnValue(null)
+
+      expect(
+        computeWorktreePath('feature', 'C:\\Users\\jin\\repo', {
+          nestWorkspaces: false,
+          workspaceDir: 'C:\\workspaces',
+          wslMirrorDistro: 'Ubuntu'
+        })
+      ).toBe(win32.join('C:\\workspaces', 'feature'))
+    })
+
+    it('respects an explicit repo-relative workspace dir', () => {
+      parseWslPathMock.mockReturnValue(null)
+
+      expect(
+        computeWorktreePath('feature', 'C:\\Users\\jin\\repo', {
+          nestWorkspaces: false,
+          workspaceDir: 'worktrees',
+          wslMirrorDistro: 'Ubuntu'
+        })
+      ).toBe(win32.join('C:\\Users\\jin\\repo', 'worktrees', 'feature'))
+      expect(getWslHomeMock).not.toHaveBeenCalled()
+    })
+
+    it('ignores a stray mirror distro on a POSIX repo path', () => {
+      parseWslPathMock.mockReturnValue(null)
+
+      expect(
+        computeWorktreePath('feature', '/Users/jin/repo', {
+          nestWorkspaces: false,
+          workspaceDir: '/Users/jin/workspaces',
+          wslMirrorDistro: 'Ubuntu'
+        })
+      ).toBe('/Users/jin/workspaces/feature')
+      expect(getWslHomeMock).not.toHaveBeenCalled()
+    })
+
+    it('mirrors on the async path too', async () => {
+      parseWslPathMock.mockReturnValue(null)
+      getWslHomeAsyncMock.mockResolvedValue('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+
+      await expect(
+        computeWorktreePathAsync('feature', 'C:\\Users\\jin\\repo', {
+          nestWorkspaces: false,
+          workspaceDir: 'C:\\workspaces',
+          wslMirrorDistro: 'Ubuntu'
+        })
+      ).resolves.toBe('\\\\wsl.localhost\\Ubuntu\\home\\jin\\orca\\workspaces\\feature')
+    })
+  })
 })

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -7,7 +7,12 @@ import { splitWorktreeId } from '../../shared/worktree/id'
 import { replaceKnownEmojiWithShortcodes } from '../../shared/emoji-shortcode-catalog'
 import { getWslHome, getWslHomeAsync, parseWslPath } from '../wsl'
 
-type WorktreePathSettings = Pick<GlobalSettings, 'nestWorkspaces' | 'workspaceDir'>
+type WorktreePathSettings = Pick<GlobalSettings, 'nestWorkspaces' | 'workspaceDir'> & {
+  /** Distro to mirror the workspace root into when the repo itself sits on a
+   *  Windows drive but this project's git runs in WSL. Omitted = today's
+   *  placement, so any caller that cannot resolve the runtime is unaffected. */
+  wslMirrorDistro?: string
+}
 type WorktreeBasePathRepo = Pick<Repo, 'path' | 'worktreeBasePath'>
 
 export {
@@ -132,11 +137,11 @@ export async function computeWorktreePathAsync(
 
 async function computeWorkspaceRootAsync(
   repoPath: string,
-  settings: { workspaceDir: string }
+  settings: { workspaceDir: string; wslMirrorDistro?: string }
 ): Promise<string> {
-  const wsl = parseWslPath(repoPath)
-  if (wsl && shouldMirrorWorkspaceDirInsideWsl(repoPath, settings.workspaceDir)) {
-    const wslHome = await getWslHomeAsync(wsl.distro)
+  const distro = resolveMirrorDistro(repoPath, settings)
+  if (distro && shouldMirrorWorkspaceDirInsideWsl(repoPath, settings.workspaceDir)) {
+    const wslHome = await getWslHomeAsync(distro)
     if (wslHome) {
       return win32.join(wslHome, 'orca', 'workspaces')
     }
@@ -144,10 +149,13 @@ async function computeWorkspaceRootAsync(
   return resolveWorkspaceDirForRepo(repoPath, settings.workspaceDir)
 }
 
-export function computeWorkspaceRoot(repoPath: string, settings: { workspaceDir: string }): string {
-  const wsl = parseWslPath(repoPath)
-  if (wsl && shouldMirrorWorkspaceDirInsideWsl(repoPath, settings.workspaceDir)) {
-    const wslHome = getWslHome(wsl.distro)
+export function computeWorkspaceRoot(
+  repoPath: string,
+  settings: { workspaceDir: string; wslMirrorDistro?: string }
+): string {
+  const distro = resolveMirrorDistro(repoPath, settings)
+  if (distro && shouldMirrorWorkspaceDirInsideWsl(repoPath, settings.workspaceDir)) {
+    const wslHome = getWslHome(distro)
     if (wslHome) {
       // Why: WSL UNC paths are still Windows paths from Node's perspective.
       // Mirror absolute local desktop workspace roots inside the distro so
@@ -180,11 +188,16 @@ export function computeRemoteWorktreePath(
 
 export function getWorktreePathSettings(
   repo: WorktreeBasePathRepo,
-  settings: WorktreePathSettings
+  settings: WorktreePathSettings,
+  wslMirrorDistro?: string
 ): WorktreePathSettings {
   return {
     nestWorkspaces: settings.nestWorkspaces,
-    workspaceDir: getEffectiveWorktreeBasePath(repo, settings)
+    workspaceDir: getEffectiveWorktreeBasePath(repo, settings),
+    // Why pass it through rather than resolve here: placement has to agree
+    // across create, allowed-roots and watch-targets, so the distro is
+    // resolved once by the caller that owns the store and threaded down.
+    ...(wslMirrorDistro ? { wslMirrorDistro } : {})
   }
 }
 
@@ -236,6 +249,26 @@ function getEffectiveWorktreeBasePath(
 function getRepoWorktreeBasePath(repo: Pick<Repo, 'worktreeBasePath'>): string | undefined {
   const trimmed = repo.worktreeBasePath?.trim()
   return trimmed || undefined
+}
+
+/**
+ * Which distro's filesystem this repo's worktrees belong on, if any.
+ *
+ * A repo already inside WSL names its own distro. A repo on a Windows drive
+ * names none — but if this project's git runs in WSL, its worktrees still
+ * belong on the Linux side: `git status` stats every working-tree file, and
+ * doing that across the 9p mount costs ~46s on a real repo versus ~0.2s with
+ * the tree native and only the gitdir left on the Windows drive.
+ */
+function resolveMirrorDistro(
+  repoPath: string,
+  settings: { wslMirrorDistro?: string }
+): string | undefined {
+  const wsl = parseWslPath(repoPath)
+  if (wsl) {
+    return wsl.distro
+  }
+  return isWindowsAbsolutePathLike(repoPath) ? settings.wslMirrorDistro : undefined
 }
 
 function shouldMirrorWorkspaceDirInsideWsl(repoPath: string, workspaceDir: string): boolean {

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -257,8 +257,8 @@ function getRepoWorktreeBasePath(repo: Pick<Repo, 'worktreeBasePath'>): string |
  * A repo already inside WSL names its own distro. A repo on a Windows drive
  * names none — but if this project's git runs in WSL, its worktrees still
  * belong on the Linux side: `git status` stats every working-tree file, and
- * doing that across the 9p mount costs ~46s on a real repo versus ~0.2s with
- * the tree native and only the gitdir left on the Windows drive.
+ * doing that across the 9p mount is ~20x slower than the same clean tree on
+ * ext4 (`git worktree add` ~26x), with only the gitdir left on the Windows drive.
  */
 function resolveMirrorDistro(
   repoPath: string,

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -133,7 +133,8 @@ import {
 } from '../agent-trust-presets'
 import {
   getLocalProjectGitExecOptions,
-  getLocalProjectWorktreeGitOptions
+  getLocalProjectWorktreeGitOptions,
+  getWorktreeMirrorDistro
 } from '../project-runtime-git-options'
 import {
   getBranchNameOverrideCandidate,
@@ -1996,7 +1997,11 @@ export async function createLocalWorktree(
 ): Promise<CreateWorktreeResult> {
   const timing = createWorktreeCreateTimingRecorder()
   const settings = store.getSettings()
-  const worktreePathSettings = getWorktreePathSettings(repo, settings)
+  const worktreePathSettings = getWorktreePathSettings(
+    repo,
+    settings,
+    getWorktreeMirrorDistro(store, repo)
+  )
   const localGitExecOptions = getLocalProjectGitExecOptions(store, repo)
   const localWorktreeGitOptions = getLocalProjectWorktreeGitOptions(store, repo)
   const hasLocalWorktreeGitOptions = Object.keys(localWorktreeGitOptions).length > 0

--- a/src/main/local-project-runtime-resolution.ts
+++ b/src/main/local-project-runtime-resolution.ts
@@ -1,4 +1,5 @@
 import type { Store } from './persistence'
+import type { GlobalSettings } from '../shared/global-settings-types'
 import type { Project } from '../shared/project-types'
 import type { Repo } from '../shared/repo-types'
 import {
@@ -14,18 +15,42 @@ import {
 import { getRepoIdFromWorktreeId } from '../shared/worktree/id'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../shared/execution-host'
 
-function canResolveProjectRuntimeForRepo(store: Store): boolean {
+/**
+ * The slice of the store runtime resolution actually reads. Structural rather
+ * than the full `Store` so narrowed stores -- the Orca runtime's `RuntimeStore`,
+ * worktree root preparation -- resolve the same runtime the create path does
+ * instead of silently falling back to host placement.
+ *
+ * Members stay optional because those stores declare them optional; the
+ * `typeof` guards below are what actually decide whether resolution can run.
+ */
+export type ProjectRuntimeResolutionStore = {
+  getProjects?: Store['getProjects']
+  getRepo?: Store['getRepo']
+  getSettings?: () => Partial<Pick<GlobalSettings, 'localWindowsRuntimeDefault'>>
+}
+
+type ResolvableStore = ProjectRuntimeResolutionStore & {
+  getProjects: NonNullable<ProjectRuntimeResolutionStore['getProjects']>
+  getSettings: NonNullable<ProjectRuntimeResolutionStore['getSettings']>
+}
+
+function canResolveProjectRuntimeForRepo(
+  store: ProjectRuntimeResolutionStore
+): store is ResolvableStore {
   return typeof store.getProjects === 'function' && typeof store.getSettings === 'function'
 }
 
-function canResolveProjectRuntimeForWorktreeId(store: Store): boolean {
+function canResolveProjectRuntimeForWorktreeId(
+  store: ProjectRuntimeResolutionStore
+): store is ResolvableStore & { getRepo: NonNullable<ProjectRuntimeResolutionStore['getRepo']> } {
   return canResolveProjectRuntimeForRepo(store) && typeof store.getRepo === 'function'
 }
 
 function resolveLocalProjectRuntime(
-  store: Store,
+  store: ResolvableStore,
   project: Project,
-  settings: ReturnType<Store['getSettings']> = store.getSettings()
+  settings: ReturnType<ResolvableStore['getSettings']> = store.getSettings()
 ): ProjectExecutionRuntimeResolution {
   const wslAvailable = hasCachedWslAvailability()
     ? (getCachedWslAvailability() ?? undefined)
@@ -42,7 +67,7 @@ function resolveLocalProjectRuntime(
 }
 
 export function resolveLocalProjectRuntimeForRepo(
-  store: Store,
+  store: ProjectRuntimeResolutionStore,
   repo: Repo
 ): ProjectExecutionRuntimeResolution | undefined {
   if (
@@ -59,7 +84,7 @@ export function resolveLocalProjectRuntimeForRepo(
 }
 
 export function resolveLocalProjectRuntimesForRepos(
-  store: Store,
+  store: ProjectRuntimeResolutionStore,
   repos: readonly Repo[]
 ): ReadonlyMap<string, ProjectExecutionRuntimeResolution> {
   const runtimeByRepoId = new Map<string, ProjectExecutionRuntimeResolution>()
@@ -93,7 +118,7 @@ export function resolveLocalProjectRuntimesForRepos(
 }
 
 export function resolveLocalProjectRuntimeForWorktreeId(
-  store: Store | undefined,
+  store: ProjectRuntimeResolutionStore | undefined,
   worktreeId: string | undefined
 ): ProjectExecutionRuntimeResolution | undefined {
   if (!store || !worktreeId) {

--- a/src/main/project-runtime-git-options.test.ts
+++ b/src/main/project-runtime-git-options.test.ts
@@ -4,6 +4,7 @@ import type { Project } from '../shared/project-types'
 import type { Repo } from '../shared/repo-types'
 import {
   getLocalProjectGitExecOptions,
+  getWorktreeMirrorDistro,
   resolveLocalProjectRuntimeForRepo
 } from './project-runtime-git-options'
 import { _resetWslCachesForTests, _setWslCachesForTests } from './wsl'
@@ -133,6 +134,46 @@ describe('project runtime git options', () => {
     )
 
     expect(runtime).toBeUndefined()
+  })
+
+  describe('getWorktreeMirrorDistro', () => {
+    it('names the distro a resolved WSL project runs in', () => {
+      _setWslCachesForTests({ available: true, distros: ['Ubuntu'] })
+      const project = makeProject({
+        localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+      })
+
+      expect(
+        withPlatform('win32', () => getWorktreeMirrorDistro(makeStore(project), makeRepo()))
+      ).toBe('Ubuntu')
+    })
+
+    it('names no distro for a host-runtime project', () => {
+      const project = makeProject({ localWindowsRuntimePreference: { kind: 'windows-host' } })
+
+      expect(
+        withPlatform('win32', () => getWorktreeMirrorDistro(makeStore(project), makeRepo()))
+      ).toBeUndefined()
+    })
+
+    // Placement must not throw where git execution does: a project awaiting
+    // repair still gets a worktree, on the Windows side as it always has.
+    it('names no distro instead of throwing when the runtime needs repair', () => {
+      _setWslCachesForTests({ available: true, distros: ['Debian'] })
+      const project = makeProject({
+        localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+      })
+
+      expect(
+        withPlatform('win32', () => getWorktreeMirrorDistro(makeStore(project), makeRepo()))
+      ).toBeUndefined()
+    })
+
+    it('names no distro when the store cannot resolve projects', () => {
+      _setWslCachesForTests({ available: true, distros: ['Ubuntu'] })
+
+      expect(withPlatform('win32', () => getWorktreeMirrorDistro({}, makeRepo()))).toBeUndefined()
+    })
   })
 
   it('does not apply local Windows runtime routing to runtime-owned repos', () => {

--- a/src/main/project-runtime-git-options.ts
+++ b/src/main/project-runtime-git-options.ts
@@ -1,6 +1,9 @@
 import type { Store } from './persistence'
 import type { Repo } from '../shared/repo-types'
-import { resolveLocalProjectRuntimeForRepo } from './local-project-runtime-resolution'
+import {
+  resolveLocalProjectRuntimeForRepo,
+  type ProjectRuntimeResolutionStore
+} from './local-project-runtime-resolution'
 import type { ProjectExecutionRuntimeResolution } from '../shared/project-execution-runtime'
 
 export {
@@ -63,4 +66,22 @@ export function getLocalProjectWorktreeGitOptionsForRuntime(
   // every project once per repo on a polling path.
   const { wslDistro } = getLocalProjectGitExecOptionsForRuntime(repo, projectRuntime)
   return wslDistro ? { wslDistro } : {}
+}
+
+/**
+ * Distro whose filesystem this repo's worktrees belong on, or undefined.
+ *
+ * Deliberately non-throwing where `getLocalProjectGitExecOptions` throws: a
+ * runtime that needs repair must not block creating a worktree, it just falls
+ * back to the Windows-side placement that has always been used.
+ */
+export function getWorktreeMirrorDistro(
+  store: ProjectRuntimeResolutionStore,
+  repo: Repo
+): string | undefined {
+  const projectRuntime = resolveLocalProjectRuntimeForRepo(store, repo)
+  if (!projectRuntime || projectRuntime.status !== 'resolved') {
+    return undefined
+  }
+  return projectRuntime.runtime.kind === 'wsl' ? projectRuntime.runtime.distro : undefined
 }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -957,6 +957,7 @@ import { createStackedHostedReview as createStackedHostedReviewFromRepo } from '
 import {
   getLocalProjectGitExecOptions,
   getLocalProjectWorktreeGitOptions,
+  getWorktreeMirrorDistro,
   getLocalProjectWorktreeGitOptionsForRuntime,
   resolveLocalProjectRuntimeForRepo,
   resolveLocalProjectRuntimesForRepos
@@ -1460,6 +1461,9 @@ type RuntimeStore = {
   getSettings(): {
     workspaceDir: string
     nestWorkspaces: boolean
+    // Read by worktree placement: decides whether this project's worktrees
+    // mirror into a WSL distro instead of the Windows drive.
+    localWindowsRuntimeDefault?: GlobalSettings['localWindowsRuntimeDefault']
     refreshLocalBaseRefOnWorktreeCreate: boolean
     localBaseRefSuggestionDismissed?: boolean
     branchPrefix: string
@@ -26773,7 +26777,11 @@ export class OrcaRuntimeService {
       }
     }
     const settings = createSettings
-    const worktreePathSettings = getWorktreePathSettings(repo, settings)
+    const worktreePathSettings = getWorktreePathSettings(
+      repo,
+      settings,
+      getWorktreeMirrorDistro(this.requireStore(), repo)
+    )
     const localGitExecOptions = getLocalProjectGitExecOptions(this.requireStore(), repo)
     const localWorktreeGitOptions = getLocalProjectWorktreeGitOptions(this.requireStore(), repo)
     const hasLocalWorktreeGitOptions = hasLocalGitOptions(localWorktreeGitOptions)

--- a/src/main/worktree-name-retirement.ts
+++ b/src/main/worktree-name-retirement.ts
@@ -30,23 +30,40 @@ import {
 import { discoverRetiredWorktreeNames } from './worktree-retirement-discovery'
 import { runRetirementBackfillScan } from './worktree-retirement-backfill-scan'
 import { hasCachedWslHome, parseWslPath } from './wsl'
+import { getWorktreeMirrorDistro } from './project-runtime-git-options'
+import type { ProjectRuntimeResolutionStore } from './local-project-runtime-resolution'
 
 const RETIREMENT_PROBE_NAME = 'orca-retirement-probe'
 
-type RetirementReadStore = {
+type RetirementRuntimeStore = {
+  getProjects?: ProjectRuntimeResolutionStore['getProjects']
+  getSettings?: ProjectRuntimeResolutionStore['getSettings']
+}
+type RetirementReadStore = RetirementRuntimeStore & {
   getRetiredWorktreeNameRegistry(repoId: string): RetiredNameRegistry
   getRetiredWorktreeNameRegistryForNamespace?(namespaceKey: string): RetiredNameRegistry
   getSshTarget?: SshTargetLookup
 }
-type RetirementBackfillStore = {
+type RetirementBackfillStore = RetirementRuntimeStore & {
   mergeRetiredWorktreeNames(repoId: string, names: Iterable<string>): boolean
 }
-type RetirementWriteStore = {
+type RetirementWriteStore = RetirementRuntimeStore & {
   addRetiredWorktreeName(repoId: string, name: string): void
   mergeRetiredWorktreeNamesForNamespace?(namespaceKey: string, names: Iterable<string>): boolean
   getSshTarget?: SshTargetLookup
 }
-type RetirementPathSettings = Pick<GlobalSettings, 'nestWorkspaces' | 'workspaceDir'>
+type RetirementPathSettings = Pick<GlobalSettings, 'nestWorkspaces' | 'workspaceDir'> & {
+  wslMirrorDistro?: string
+}
+
+function withMirrorDistro(
+  store: RetirementRuntimeStore,
+  repo: Repo,
+  settings: RetirementPathSettings
+): RetirementPathSettings {
+  const distro = getWorktreeMirrorDistro(store, repo)
+  return distro ? { ...settings, wslMirrorDistro: distro } : settings
+}
 
 /** Only canonical generator output is persisted. Collision retries advance canonical tiers, so a
  *  repeat-suffixed path can never be generated again and needs no permanent registry entry. */
@@ -109,7 +126,8 @@ async function getRetirementCollisionKey(
     repo.path,
     repo.worktreeBasePath ?? '',
     settings.workspaceDir,
-    settings.nestWorkspaces ? 'nested' : 'flat'
+    settings.nestWorkspaces ? 'nested' : 'flat',
+    settings.wslMirrorDistro ?? ''
   ].join('\u0000')
   const cached = collisionKeyCache.get(cacheKey)
   if (cached !== undefined) {
@@ -172,15 +190,16 @@ export async function getRetiredNameRegistryForRepo(
     return EMPTY_RETIRED_NAME_REGISTRY
   }
   const lookup = sshTargetLookup(store)
+  const pathSettings = withMirrorDistro(store, repo, settings)
   let collisionKey: string | null = null
   try {
-    collisionKey = await ensureRetiredWorktreeNamesBackfilled(store, repo, settings)
+    collisionKey = await ensureRetiredWorktreeNamesBackfilled(store, repo, pathSettings)
   } catch (error) {
     console.warn(`[worktrees] retirement backfill failed for repo ${repo.id}:`, error)
   }
   let registry = store.getRetiredWorktreeNameRegistry(repo.id)
   if (store.getRetiredWorktreeNameRegistryForNamespace) {
-    collisionKey ??= await getRetirementCollisionKey(repo, settings, lookup)
+    collisionKey ??= await getRetirementCollisionKey(repo, pathSettings, lookup)
     registry = mergeRetiredNameRegistries(
       registry,
       readNamespaceRegistry(store, repo, collisionKey, lookup)
@@ -194,8 +213,14 @@ export async function getRetiredNameRegistryForRepo(
     if (isEmptyRetiredNameRegistry(candidateRegistry)) {
       continue
     }
-    collisionKey ??= await getRetirementCollisionKey(repo, settings, lookup)
-    if ((await getRetirementCollisionKey(candidate, settings, lookup)) !== collisionKey) {
+    collisionKey ??= await getRetirementCollisionKey(repo, pathSettings, lookup)
+    if (
+      (await getRetirementCollisionKey(
+        candidate,
+        withMirrorDistro(store, candidate, settings),
+        lookup
+      )) !== collisionKey
+    ) {
       continue
     }
     registry = mergeRetiredNameRegistries(registry, candidateRegistry)
@@ -226,7 +251,11 @@ export async function retireGeneratedWorktreeName(
     return
   }
   try {
-    const namespaceKey = await getRetirementCollisionKey(repo, settings, sshTargetLookup(store))
+    const namespaceKey = await getRetirementCollisionKey(
+      repo,
+      withMirrorDistro(store, repo, settings),
+      sshTargetLookup(store)
+    )
     store.mergeRetiredWorktreeNamesForNamespace(namespaceKey, [name])
   } catch (error) {
     console.warn(`[worktrees] failed to persist retirement namespace for ${repo.id}:`, error)
@@ -260,7 +289,7 @@ export async function ensureRetiredWorktreeNamesBackfilled(
   const probePath = await computeWorktreePathAsync(
     RETIREMENT_PROBE_NAME,
     repo.path,
-    getWorktreePathSettings(repo, settings)
+    getWorktreePathSettings(repo, settings, settings.wslMirrorDistro)
   )
   const scanKey = `${getRepoExecutionHostId(repo)}:${worktreePathComparisonKey(probePath)}`
   const names = await runRetirementBackfillScan(store, scanKey, () =>

--- a/src/main/worktree-root-preparation.ts
+++ b/src/main/worktree-root-preparation.ts
@@ -4,15 +4,22 @@ import type { Repo } from '../shared/repo-types'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../shared/execution-host'
 import { isFolderRepo } from '../shared/repo-kind'
 import { computeWorkspaceRoot, getWorktreePathSettings } from './ipc/worktree-logic'
+import { getWorktreeMirrorDistro } from './project-runtime-git-options'
+import type { ProjectRuntimeResolutionStore } from './local-project-runtime-resolution'
 
-type WorktreeRootPreparationSettings = Pick<GlobalSettings, 'workspaceDir' | 'nestWorkspaces'>
+// `localWindowsRuntimeDefault` is listed because the mirror distro is resolved
+// from it plus the project catalog: a store that omits it prepares a different
+// root than the create path uses.
+type WorktreeRootPreparationSettings = Pick<GlobalSettings, 'workspaceDir' | 'nestWorkspaces'> &
+  Partial<Pick<GlobalSettings, 'localWindowsRuntimeDefault'>>
 type WorktreeRootPreparationStore = {
   getSettings: () => WorktreeRootPreparationSettings
   getRepos: () => Repo[]
+  getProjects?: ProjectRuntimeResolutionStore['getProjects']
 }
 
 export async function prepareLocalWorktreeRootForRepo(
-  store: Pick<WorktreeRootPreparationStore, 'getSettings'>,
+  store: Pick<WorktreeRootPreparationStore, 'getSettings' | 'getProjects'>,
   repo: Repo
 ): Promise<void> {
   if (getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID || isFolderRepo(repo)) {
@@ -20,7 +27,10 @@ export async function prepareLocalWorktreeRootForRepo(
   }
 
   try {
-    const root = computeWorkspaceRoot(repo.path, getWorktreePathSettings(repo, store.getSettings()))
+    const root = computeWorkspaceRoot(
+      repo.path,
+      getWorktreePathSettings(repo, store.getSettings(), getWorktreeMirrorDistro(store, repo))
+    )
     // Why: mkdir touches the current root to preflight macOS TCC, while
     // access remains scoped by recomputed settings instead of a permanent grant.
     await mkdir(root, { recursive: true })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​137 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​137 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​214 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​65 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​149 |

<!-- /orca-pr-loc -->

## Problem

A repo on `C:\` whose project execution runtime is WSL got its worktrees created **on the Windows drive**. Git then runs inside the distro but walks the working tree across the 9p/drvfs boundary, so every status/add/create pays that crossing.

Orca already mirrors worktrees into the distro — but only when the *repo path itself* is a WSL UNC path. The common case (repo cloned to `C:\Users\...`, project runtime switched to WSL) was never covered.

## Measured

On a real Windows box (awin, Ubuntu-24.04, `stablyai/orca` @ `a25d8f1fdc`, 16,622 files). Alternating runs against **two clean worktrees of the same commit**, so this is apples-to-apples:

| operation | on `/mnt/c` | in the distro | speedup |
| --- | --- | --- | --- |
| `git worktree add` | 42.8s | 1.62s | ~26x |
| `git status` warm, clean | 1.53–1.70s | 0.076–0.116s | ~20x |
| `git status` warm, 200 files dirty | 1.53–1.90s | 0.073–0.117s | ~20x |
| `git add -A` | 1.49s | 0.048s | ~31x |

## Approach

Widen the existing mirror gate from *"the repo path is a WSL UNC path"* to *"…or this project's resolved runtime is WSL"*.

The distro is threaded through as an **optional** `wslMirrorDistro` on `WorktreePathSettings`. Any caller that doesn't or can't resolve it keeps today's placement byte-for-byte — that's the blast-radius control.

Enriched at the five call sites that must agree on the root:

- worktree create (runtime + IPC)
- `getAllowedRoots`
- worktree base-directory watch targets
- worktree root preparation

Disagreement between those means renderer file access denied for a worktree Orca just created, or a base directory nobody watches — so they're changed together, deliberately.

## Design notes

**Non-throwing where git exec throws.** `getWorktreeMirrorDistro` returns `undefined` for a `repair-required` runtime rather than throwing like `getLocalProjectGitExecOptions` does. A project awaiting repair should still get a worktree — on the Windows side, exactly as before.

**Structural store slice.** Runtime resolution now takes `ProjectRuntimeResolutionStore` (`getProjects` / `getRepo` / `getSettings`) instead of the full `Store`. Without this the narrowed stores — `RuntimeStore` and worktree root preparation — would have silently resolved to `undefined` and prepared a *different* root than create uses. That's the sharp edge here and it's typed shut rather than commented around.

## Risk: what if the runtime flips back to windows-host?

Worktrees already placed in the distro live at `\\wsl.localhost\<distro>\...` with a Linux-dialect `.git` (`gitdir: /mnt/c/...`) that host `git.exe` cannot parse.

This is already handled: the git runner routes **by cwd**, not by the runtime flag — `wsl-command-resolution.ts:77` does `parseWslPath(cwd)` before consulting `wslDistroOverride`. A UNC cwd reaches WSL git regardless of what the project runtime currently says. Verified the artifact dialect on awin: `gitdir: /mnt/c/Users/neil/orca/orca/.git/worktrees/orca-mirror-probe`.

## Tests

- `worktree-logic-wsl.test.ts`: 6 new cases — mirrors on sync and async paths; keeps Windows placement with no WSL runtime; falls back when distro `$HOME` is unresolvable; respects a repo-relative workspace dir; ignores a stray distro on a POSIX repo path.
- `project-runtime-git-options.test.ts`: 4 new cases for `getWorktreeMirrorDistro` — resolved WSL, host runtime, repair-required (returns `undefined`, does not throw), and an unresolvable store.

Full `typecheck` clean; `oxlint src/` clean; worktree/repos/runtime/settings suites pass (2,218 tests).

## Not covered

Existing worktrees are not migrated — this only affects placement of newly created ones.