### PR TITLE
chore(deps): pin the pdfjs-dist release-age exception to 6.3.289

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages: []
 minimumReleaseAge: 4320
 # 6.3.289 was published 2026-08-29T12:48Z; it clears the 3-day gate on 2026-09-01T12:48Z.
 minimumReleaseAgeExclude:
-  - pdfjs-dist
+  - pdfjs-dist@6.3.289
 shamefullyHoist: true
 
 supportedArchitectures:


### PR DESCRIPTION
One-line follow-up to #17385.

#17385 restored the exclusion as a bare package name to get CI installing again. A bare name exempts **every** version of `pdfjs-dist` from `minimumReleaseAge` — forever, including a version published minutes ago. That is a standing supply-chain hole, not a temporary waiver.

pnpm's `minimumReleaseAgeExclude` accepts `name@exact-version`, so scope it to the one version that needs it.

```diff
 minimumReleaseAgeExclude:
-  - pdfjs-dist
+  - pdfjs-dist@6.3.289
```

## Verification (pnpm 12.0.0)

| Config | Result |
|---|---|
| `pdfjs-dist@6.3.289` | `pnpm install --frozen-lockfile` → **Done in 10.5s** |
| `pdfjs-dist@6.3.288` (deliberately wrong) | **`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`** |

The negative case is the point: it proves the version is actually matched rather than the whole entry being parsed loosely and the name alone doing the work.

Still drop the exclusion entirely after **2026-09-01T12:48Z**.