### PR TITLE
fix(native-chat): replay a draft clear dropped mid-composition

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -1,5 +1,5 @@
 import type { ClipboardEventHandler, KeyboardEventHandler, RefObject } from 'react'
-import { useLayoutEffect } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import { Image as ImageIcon, ImageOff, X } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
 import type { useImeEnterGestureOwnership } from '@/lib/ime-composition-keyboard-event'
@@ -60,6 +60,27 @@ export type NativeChatComposerImageAttachment = {
   path: string
 }
 
+/**
+ * Applies a draft clear that was dropped mid-composition: everything the field held when the
+ * IME started is what the clear was meant to erase, so only the composed segment survives.
+ * Diffed from both ends because an IME edits at the caret, which need not be the end.
+ */
+function imeComposedSegment(base: string, settled: string): string {
+  const limit = Math.min(base.length, settled.length)
+  let prefix = 0
+  while (prefix < limit && base[prefix] === settled[prefix]) {
+    prefix += 1
+  }
+  let suffix = 0
+  while (
+    suffix < limit - prefix &&
+    base[base.length - 1 - suffix] === settled[settled.length - 1 - suffix]
+  ) {
+    suffix += 1
+  }
+  return settled.slice(prefix, settled.length - suffix)
+}
+
 export function NativeChatComposerField({
   textareaRef,
   draft,
@@ -97,17 +118,37 @@ export function NativeChatComposerField({
   sessionOptionsSnapshot,
   sessionOptionsPickerRequest
 }: NativeChatComposerFieldProps): React.JSX.Element {
+  // Value the IME started from, and whether a programmatic clear was dropped on top of it.
+  const compositionBaseRef = useRef('')
+  const droppedDraftClearRef = useRef(false)
+
   // Browser owns the provisional value; React synchronizes drafts only between IME sessions.
   useLayoutEffect(() => {
     const textarea = textareaRef.current
-    if (!textarea || imeEnterGesture.isComposing()) {
+    if (!textarea) {
       return
     }
+    if (imeEnterGesture.isComposing()) {
+      // Why: a clear (an async structured send confirming) would otherwise be lost outright and
+      // the sent text would ride along into the next message. Only clears are carved out of
+      // browser ownership; every other programmatic draft still loses to the live composition.
+      droppedDraftClearRef.current ||= draft === '' && textarea.value !== ''
+      return
+    }
+    droppedDraftClearRef.current = false
     if (textarea.value === draft) {
       return
     }
     textarea.value = draft
   }, [draft, imeEnterGesture, textareaRef])
+
+  const settleImeValue = (element: HTMLTextAreaElement): void => {
+    if (droppedDraftClearRef.current) {
+      droppedDraftClearRef.current = false
+      element.value = imeComposedSegment(compositionBaseRef.current, element.value)
+    }
+    onImeSettled(element)
+  }
 
   return (
     <div className="shrink-0 bg-background">
@@ -190,17 +231,18 @@ export function NativeChatComposerField({
                 const compositionWasActive = imeEnterGesture.isComposing()
                 imeEnterGesture.reset()
                 if (compositionWasActive) {
-                  onImeSettled(event.currentTarget)
+                  settleImeValue(event.currentTarget)
                 }
               }}
-              onCompositionStart={() => {
+              onCompositionStart={(event) => {
+                compositionBaseRef.current = event.currentTarget.value
                 imeEnterGesture.setComposing(true)
               }}
               onCompositionEnd={(event) => {
                 const compositionWasActive = imeEnterGesture.isComposing()
                 imeEnterGesture.setComposing(false)
                 if (compositionWasActive) {
-                  onImeSettled(event.currentTarget)
+                  settleImeValue(event.currentTarget)
                 }
               }}
               onPaste={onPaste}

--- a/src/renderer/src/components/native-chat/native-chat-composer-composition.test.tsx
+++ b/src/renderer/src/components/native-chat/native-chat-composer-composition.test.tsx
@@ -237,6 +237,47 @@ describe('native chat composer composition ownership', () => {
     expect(onImeSettled).toHaveBeenCalledWith(input)
   })
 
+  it('replays a draft clear dropped mid-composition when the field settles on blur', () => {
+    let settledValue: string | null = null
+    const props = fieldProps({
+      draft: '안녕',
+      onImeSettled: (element) => {
+        settledValue = element.value
+      }
+    })
+    const view = render(<TestField {...props} />)
+    const input = textarea()
+    fireEvent.compositionStart(input)
+    input.value = '안녕하'
+    view.rerender(<TestField {...props} draft="안녕하" />)
+
+    // The accepted structured send lands while the next composition is still open.
+    view.rerender(<TestField {...props} draft="" />)
+    expect(input.value).toBe('안녕하')
+
+    fireEvent.blur(input)
+    expect(settledValue).toBe('하')
+    expect(input.value).toBe('하')
+  })
+
+  it('forgets a dropped clear that the browser already settled', () => {
+    const onImeSettled = vi.fn()
+    const props = fieldProps({ draft: '안녕', onImeSettled })
+    const view = render(<TestField {...props} />)
+    const input = textarea()
+    fireEvent.compositionStart(input)
+    input.value = '안녕하'
+    view.rerender(<TestField {...props} draft="" />)
+    fireEvent.blur(input)
+
+    // A second composition must not inherit the first one's clear.
+    fireEvent.compositionStart(input)
+    input.value = '하늘'
+    fireEvent.blur(input)
+
+    expect(input.value).toBe('하늘')
+  })
+
   it('keeps the browser value through a same-draft streaming rerender', () => {
     const onImeSettled = vi.fn()
     const props = fieldProps({ onImeSettled })

--- a/src/renderer/src/components/native-chat/native-chat-structured-send-composition-clear.test.tsx
+++ b/src/renderer/src/components/native-chat/native-chat-structured-send-composition-clear.test.tsx
@@ -1,0 +1,238 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as nativeChatAgentProfiles from '../../../../shared/native-chat-agent-profiles'
+import type { NativeChatStructuredComposerTransport } from './native-chat-composer-types'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+vi.mock('./NativeChatComposerActions', () => ({
+  NativeChatComposerActions: () => <div data-testid="composer-actions" />
+}))
+vi.mock('./NativeChatAutocompleteMenus', () => ({
+  NativeChatMentionHint: () => null,
+  NativeChatPickerMenu: () => null
+}))
+vi.mock('../../store', () => {
+  const state = {
+    dictationState: 'idle',
+    settings: { voice: { enabled: false }, nativeChatSessionOptions: {} },
+    updateSettings: vi.fn(),
+    clearNativeChatLaunchDraft: vi.fn(),
+    markNativeChatLaunchDraftAdopted: vi.fn()
+  }
+  const useAppStore = (selector: (value: typeof state) => unknown): unknown => selector(state)
+  useAppStore.getState = () => state
+  return { useAppStore }
+})
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  isRemoteRuntimePtyId: () => false,
+  sendRuntimePtyInput: vi.fn()
+}))
+vi.mock('@/lib/agent-paste-draft', () => ({
+  getSettingsForAgentTabRuntimeOwner: () => ({})
+}))
+vi.mock('./native-chat-runtime-send', () => ({
+  sendNativeChatMessage: vi.fn(),
+  sendNativeChatTypedCommand: vi.fn(),
+  sendNativeChatMessageVerified: vi.fn(),
+  typeNativeChatCommand: vi.fn(),
+  submitNativeChatPrompt: vi.fn()
+}))
+vi.mock('./native-chat-runtime-image-send', () => ({
+  sendNativeChatMessageWithImageAttachments: vi.fn()
+}))
+vi.mock('./claude-model-switch-confirmation', () => ({
+  createClaudeModelSwitchConfirmationObserver: vi.fn()
+}))
+vi.mock('../../../../shared/native-chat-agent-profiles', async (importOriginal) => ({
+  ...(await importOriginal<typeof nativeChatAgentProfiles>()),
+  getVerifiedNativeChatCommands: () => []
+}))
+vi.mock('@/lib/native-chat-telemetry', () => ({
+  emitNativeChatMessageSent: vi.fn(),
+  emitNativeChatPickerItemAccepted: vi.fn(),
+  emitNativeChatPickerOpened: vi.fn(),
+  emitNativeChatSendClassified: vi.fn()
+}))
+vi.mock('./use-native-chat-skills', () => ({
+  useNativeChatSkills: () => ({ status: 'ready', skills: [], error: null, retry: () => {} })
+}))
+vi.mock('../dictation/dictation-control-events', () => ({
+  dispatchDictationControl: vi.fn()
+}))
+
+import { NativeChatComposer } from './NativeChatComposer'
+
+type Dispatched = { handled: boolean; accepted: boolean; error: string | null }
+
+function deferred(): { promise: Promise<Dispatched>; resolve: (value: Dispatched) => void } {
+  let resolve!: (value: Dispatched) => void
+  const promise = new Promise<Dispatched>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
+}
+
+const PASS_THROUGH: Dispatched = { handled: false, accepted: false, error: null }
+
+function transport(
+  overrides: Partial<NativeChatStructuredComposerTransport> = {}
+): NativeChatStructuredComposerTransport {
+  return {
+    send: vi.fn(() => true),
+    dispatchCommand: vi.fn(async () => PASS_THROUGH),
+    optionsSurface: {
+      getSnapshot: () => [],
+      setOption: vi.fn(),
+      invokeAction: vi.fn(),
+      subscribe: () => () => {}
+    },
+    optionSnapshot: [],
+    onError: vi.fn(),
+    runtime: 'remote',
+    ...overrides
+  }
+}
+
+function textarea(): HTMLTextAreaElement {
+  return screen.getByRole('textbox') as HTMLTextAreaElement
+}
+
+function pressEnter(input: HTMLTextAreaElement): void {
+  fireEvent.keyDown(input, { key: 'Enter', keyCode: 13, isComposing: false })
+}
+
+let paneCounter = 0
+
+function renderComposer(structuredTransport: NativeChatStructuredComposerTransport): void {
+  paneCounter += 1
+  render(
+    <NativeChatComposer
+      terminalTabId={`tab-${paneCounter}`}
+      paneKey={`tab-${paneCounter}:structured`}
+      targetPtyId={null}
+      agent="codex"
+      structuredTransport={structuredTransport}
+    />
+  )
+}
+
+describe('structured send racing the next IME composition', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        git: { discoverCommitMessageModels: vi.fn().mockResolvedValue({ success: false }) },
+        pty: { getMainBufferSnapshot: vi.fn().mockResolvedValue(null) },
+        ui: { onFileDrop: () => vi.fn() }
+      }
+    })
+  })
+
+  afterEach(() => cleanup())
+
+  // The regression: the RPC's clear lands while the NEXT composition is live, so the DOM sync
+  // drops it and settlement used to adopt the sent text back into the composer (#17359).
+  it('does not resurrect the sent message when the clear lands mid-composition', async () => {
+    const dispatch = deferred()
+    const structured = transport({ dispatchCommand: vi.fn(() => dispatch.promise) })
+    renderComposer(structured)
+    const input = textarea()
+
+    fireEvent.change(input, { target: { value: '안녕' } })
+    pressEnter(input)
+    expect(structured.dispatchCommand).toHaveBeenCalledWith('안녕')
+
+    fireEvent.compositionStart(input)
+    fireEvent.change(input, { target: { value: '안녕하' } })
+
+    await act(async () => {
+      dispatch.resolve(PASS_THROUGH)
+      await dispatch.promise
+    })
+    fireEvent.compositionEnd(input, { data: '하' })
+
+    expect(input.value).toBe('하')
+
+    await act(async () => pressEnter(input))
+    expect(structured.send).toHaveBeenLastCalledWith('하', [])
+  })
+
+  it('keeps the composed text when a mid-composition clear lands away from the caret', async () => {
+    const dispatch = deferred()
+    const structured = transport({ dispatchCommand: vi.fn(() => dispatch.promise) })
+    renderComposer(structured)
+    const input = textarea()
+
+    fireEvent.change(input, { target: { value: 'abcd' } })
+    pressEnter(input)
+
+    fireEvent.compositionStart(input)
+    fireEvent.change(input, { target: { value: 'ab가cd' } })
+
+    await act(async () => {
+      dispatch.resolve(PASS_THROUGH)
+      await dispatch.promise
+    })
+    fireEvent.compositionEnd(input, { data: '가' })
+
+    expect(input.value).toBe('가')
+  })
+
+  // Clearing optimistically before the RPC would lose the draft here, which is why the clear
+  // stays on the acceptance path and is instead replayed at settlement.
+  it('keeps the draft when the send is rejected', async () => {
+    const structured = transport({ send: vi.fn(() => false) })
+    renderComposer(structured)
+    const input = textarea()
+
+    fireEvent.change(input, { target: { value: '안녕' } })
+    await act(async () => pressEnter(input))
+
+    expect(structured.send).toHaveBeenCalledWith('안녕', [])
+    expect(input.value).toBe('안녕')
+  })
+
+  it('keeps the draft when a rejected send races the next composition', async () => {
+    const dispatch = deferred()
+    const structured = transport({
+      dispatchCommand: vi.fn(() => dispatch.promise),
+      send: vi.fn(() => false)
+    })
+    renderComposer(structured)
+    const input = textarea()
+
+    fireEvent.change(input, { target: { value: '안녕' } })
+    pressEnter(input)
+
+    fireEvent.compositionStart(input)
+    fireEvent.change(input, { target: { value: '안녕하' } })
+
+    await act(async () => {
+      dispatch.resolve(PASS_THROUGH)
+      await dispatch.promise
+    })
+    fireEvent.compositionEnd(input, { data: '하' })
+
+    expect(input.value).toBe('안녕하')
+  })
+
+  // A rejected command still reports its error, and the composer keeps the text to retry.
+  it('keeps the draft when a handled command is rejected', async () => {
+    const structured = transport({
+      dispatchCommand: vi.fn(async () => ({ handled: true, accepted: false, error: 'nope' }))
+    })
+    renderComposer(structured)
+    const input = textarea()
+
+    fireEvent.change(input, { target: { value: '/model' } })
+    await act(async () => pressEnter(input))
+
+    expect(structured.onError).toHaveBeenCalledWith('nope')
+    expect(structured.send).not.toHaveBeenCalled()
+    expect(input.value).toBe('/model')
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.test.tsx
@@ -208,6 +208,11 @@ describe('useNativeChatComposerAttachments', () => {
     })
 
     expect(probe.draft()).toBe('각 @/remote/b.txt @/remote/b.txt @/remote/a.txt ')
+    // The focus this flush must not steal would be scheduled a frame out, so without advancing
+    // one the assertions below hold even when the flush does steal focus.
+    await act(async () => {
+      await new Promise((resolve) => requestAnimationFrame(resolve))
+    })
     expect(focus).not.toHaveBeenCalled()
     expect(document.activeElement).not.toBe(textarea)
     act(() => probe.root.unmount())


### PR DESCRIPTION
Fixes #17359

## The bug

A structured send clears the draft **asynchronously**, inside
`dispatchNativeChatStructuredComposerText(...).then(...)`, and only on acceptance
(`NativeChatComposer.tsx:255`). If the user opens the **next** IME composition before the RPC
resolves:

1. `setDraft('')` lands while a composition is active.
2. `NativeChatComposerField`'s layout effect skips the DOM write — the browser owns the value
   while composing (#17169).
3. `onImeSettled` then adopts `element.value` as authoritative, and the already-sent text is
   still in it.

Observed `dom = "안녕하"` for `sent = ["안녕"]`: the composer keeps the message it just sent, and
it rides along on the next one. The window is one RPC round trip and is widest on remote/SSH
structured sessions. The PTY path clears synchronously and is unaffected.

## The fix

The issue lists two options; this takes the second.

Clearing optimistically before awaiting was rejected: the structured path guards on
`if (!accepted) return`, so an early clear would trade draft-resurrection for **draft loss on a
rejected send**.

Instead the field records that a programmatic clear was dropped mid-composition and applies it
at settlement:

- `compositionBaseRef` — the value the field held when the IME started (captured in the existing
  `onCompositionStart`); that is exactly what the clear was meant to erase.
- `droppedDraftClearRef` — set in the existing DOM-sync effect when a `draft === ''` render is
  skipped because a composition is live.
- At settlement (both `compositionend` and the `blur` fallback), the field keeps only the
  composed segment — diffed from both ends, since an IME edits at the caret, which need not be
  the end.

This is the same "defer while composing, flush at settlement" shape the attachment queue already
uses. The "browser always wins at settlement" model from #17169 is preserved: **only** clears are
carved out. Any other programmatic draft still loses to the live composition, and the clear stays
on the acceptance path, so a rejected send keeps its draft.

## Tests

New `native-chat-structured-send-composition-clear.test.tsx` drives the **real** `NativeChatComposer`
(real field, real draft hook, real settle contract) against a structured transport whose
`dispatchCommand` resolves under test control:

- the exact reported sequence — send, next composition opens before the RPC resolves, settle —
  ends at `하`, and the follow-up send dispatches `하`, not `안녕하`
- the same race with the composition away from the caret
- **rejected send keeps the draft** (both plain and racing the next composition)
- a handled-but-rejected command reports its error and keeps the draft to retry

Plus two field-level cases in `native-chat-composer-composition.test.tsx` for the blur settle path
and for not leaking a dropped clear into the following composition.

Mutation-checked: reverting `NativeChatComposerField.tsx` fails 3 of the new tests with exactly
the reported `안녕하` symptom; dropping only the flag reset fails the leak test.

## Also fixed (issue's "Related" section)

`use-native-chat-composer-attachments.test.tsx` asserted the deferred flush never steals focus,
but that focus call is inside `requestAnimationFrame` and the test never advanced a frame — so
the assertions were vacuous. Verified by mutating the flush to `applyResolvedPaths(paths, true, ...)`:
all 50 tests still passed before, and the mutant now fails.

## Verification

- `pnpm tc` — clean
- `pnpm test src/renderer/src/components/native-chat` — 89 files, 908 tests pass
- `npx oxlint` on the changed files — clean; `pnpm run check:code-quality:changed` — 0 new findings