### PR TITLE
fix(orchestration): name the valid send types and the reply path on an invalid --type

### DIFF
--- a/src/cli/specs/orchestration.test.ts
+++ b/src/cli/specs/orchestration.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { formatCommandHelp } from '../help'
+import { ORCHESTRATION_COMMAND_SPECS } from './orchestration'
+
+describe('orchestration command specs', () => {
+  it('lists valid message types and the reply command in send help', () => {
+    const spec = ORCHESTRATION_COMMAND_SPECS.find(
+      (entry) => entry.path.join(' ') === 'orchestration send'
+    )
+    if (!spec) {
+      throw new Error('Missing orchestration send spec')
+    }
+
+    const help = formatCommandHelp(spec)
+
+    expect(help).toContain(
+      'Valid --type values: status, dispatch, worker_done, merge_ready, escalation, handoff, decision_gate, question, heartbeat.'
+    )
+    expect(help).toContain(
+      'To answer a worker question, use `orchestration reply --id <msg_id>` instead of send.'
+    )
+  })
+})

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -68,6 +68,8 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
       'phase'
     ],
     notes: [
+      'Valid --type values: status, dispatch, worker_done, merge_ready, escalation, handoff, decision_gate, question, heartbeat.',
+      'To answer a worker question, use `orchestration reply --id <msg_id>` instead of send.',
       'On Windows PowerShell, quote group addresses such as --to "@all" or --to "@worktree:<id>".',
       "worker_done and heartbeat are exact-Dispatch signals and cannot target groups; omit --to to use the Dispatch's Run mailbox.",
       'worker_done requires --outcome succeeded or --outcome failed.',

--- a/src/main/runtime/rpc/core.ts
+++ b/src/main/runtime/rpc/core.ts
@@ -197,10 +197,24 @@ export class InvalidArgumentError extends Error {
   }
 }
 
-// Why: CLI surfaces one string; take the first issue's message, which each schema authors as the user-facing phrasing.
+// Why: zod ships sideEffects:false, so the bundle drops its en locale and generic invalid_value issues must be reconstructed from "Invalid input".
 export function formatZodError(error: ZodError): string {
   const first = error.issues[0]
-  return first?.message ?? 'invalid_argument'
+  if (!first) {
+    return 'invalid_argument'
+  }
+  let message = first.message
+  if (first.code === 'invalid_value' && first.values.length > 0 && message === 'Invalid input') {
+    message =
+      first.values.length === 1
+        ? `Invalid input: expected ${formatZodValue(first.values[0])}`
+        : `Invalid option: expected one of ${first.values.map(formatZodValue).join('|')}`
+  }
+  return message
+}
+
+function formatZodValue(value: unknown): string {
+  return typeof value === 'string' ? JSON.stringify(value) : String(value)
 }
 
 export { ZodError }

--- a/src/main/runtime/rpc/dispatcher-zod-error-formatting.test.ts
+++ b/src/main/runtime/rpc/dispatcher-zod-error-formatting.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { MESSAGE_TYPES } from '../orchestration/types'
+import { formatZodError } from './core'
+import { ORCHESTRATION_METHODS } from './methods/orchestration'
+
+describe('RPC Zod error formatting', () => {
+  it('enumerates invalid values even when the Zod locale message is generic', () => {
+    const result = z.enum(['first', 'second'], { error: () => 'Invalid input' }).safeParse('typo')
+    if (result.success) {
+      throw new Error('Expected enum parsing to fail')
+    }
+
+    expect(formatZodError(result.error)).toBe('Invalid option: expected one of "first"|"second"')
+  })
+
+  it('uses the Zod single-value phrasing for a literal with a generic locale message', () => {
+    const result = z.literal('only', { error: () => 'Invalid input' }).safeParse('typo')
+    if (result.success) {
+      throw new Error('Expected literal parsing to fail')
+    }
+
+    expect(formatZodError(result.error)).toBe('Invalid input: expected "only"')
+  })
+
+  it('preserves schema-authored invalid value messages', () => {
+    const result = z
+      .enum(['first', 'second'], { error: () => 'Choose a supported mode' })
+      .safeParse('typo')
+    if (result.success) {
+      throw new Error('Expected enum parsing to fail')
+    }
+
+    expect(formatZodError(result.error)).toBe('Choose a supported mode')
+  })
+
+  it('uses the send schema message for valid types and the reply pointer', () => {
+    const sendMethod = ORCHESTRATION_METHODS.find((method) => method.name === 'orchestration.send')
+    const result = sendMethod?.params?.safeParse({ subject: 'hello', type: 'reply' })
+    if (!result || result.success) {
+      throw new Error('Expected orchestration.send type parsing to fail')
+    }
+
+    expect(formatZodError(result.error)).toBe(
+      `Invalid --type: expected one of ${MESSAGE_TYPES.join(', ')}; to answer a worker question, use \`orchestration reply --id <msg_id>\` instead of send.`
+    )
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -125,25 +125,15 @@ function isWorkerReportOutcome(value: unknown): value is 'succeeded' | 'failed' 
   return value === 'succeeded' || value === 'failed'
 }
 
+const INVALID_SEND_TYPE_MESSAGE = `Invalid --type: expected one of ${MESSAGE_TYPES.join(', ')}; to answer a worker question, use \`orchestration reply --id <msg_id>\` instead of send.`
+
 const SendParams = z
   .object({
     to: OptionalString,
     subject: requiredString('Missing --subject'),
     from: OptionalString,
     body: OptionalString,
-    type: z
-      .enum([
-        'status',
-        'dispatch',
-        'worker_done',
-        'merge_ready',
-        'escalation',
-        'handoff',
-        'decision_gate',
-        'question',
-        'heartbeat'
-      ])
-      .optional(),
+    type: z.enum(MESSAGE_TYPES, { error: () => INVALID_SEND_TYPE_MESSAGE }).optional(),
     priority: z.enum(['normal', 'high', 'urgent']).optional(),
     threadId: OptionalString,
     payload: OptionalString,


### PR DESCRIPTION
## ELI5

Sending a message with a made-up `--type` (like `answer`) failed with just "Invalid input" — no list of valid types, no hint that answering a worker's question is what `orchestration reply` is for. Coordinators guessed, got the wall, and fell back to `--type status`, losing the question thread. Now the error names all nine valid types and points at `reply`.

## What Changed

- `SendParams.type` carries a schema-authored error message built from `MESSAGE_TYPES` (no hand-duplicated list): it enumerates the nine valid types and ends with "to answer a worker question, use `orchestration reply --id <msg_id>` instead of send". The enum literal in `SendParams` was also deduplicated to reuse `MESSAGE_TYPES`.
- `formatZodError` gains a generic reconstruction for *uncustomized* enums: when a generic `invalid_value` issue arrives as the bare "Invalid input", it rebuilds zod's native `Invalid option: expected one of ...` from the issue's values. Schema-authored messages still win; the RPC core stays method-agnostic.
- The `send` spec notes now list the valid types and the `reply` pointer, so `--help` answers before the error does.

## Why

Observed in a 12-hour orchestration session (issue #17390): the coordinator answering a lane's question guessed `--type answer`, hit the opaque error, and settled for `--type status` — the worker's question was never resolved as a thread.

Root cause of the opacity, found while writing the failing test: **zod ships `sideEffects: false`, so the app bundle tree-shakes zod's English locale** — plain Node enumerates enum options in dev, but the packaged runtime falls back to the generic "Invalid input" for every uncustomized enum. The `formatZodError` reconstruction fixes that whole class, not just this flag; the schema-authored message fixes this flag's guidance specifically.

## Linked Issue

Fixes #17390

## Visual Proof

N/A — CLI error text; before/after is the test assertion: `invalid_argument: "Invalid input ..."` → `Invalid --type: expected one of status, dispatch, worker_done, merge_ready, escalation, handoff, decision_gate, question, heartbeat; to answer a worker question, use `orchestration reply --id <msg_id>` instead of send.`

## Testing

- [ ] I manually tested these changes locally (verification is by the test suite; the packaged-bundle tree-shaking path itself is exercised through the reconstruction unit tests)
- [x] Automated tests added/updated, or explained why not below

Windows 11, Node 24, pnpm 12 (corepack):

- `vitest run src/main/runtime/rpc/dispatcher-zod-error-formatting.test.ts src/cli/specs/orchestration.test.ts` — 4 passed (schema-authored message wins and carries all nine types + the reply pointer; generic enum reconstruction still fires for other enums; spec notes assertions)
- `pnpm tc:node` and `pnpm tc:cli` — exit 0
- `oxlint` on changed files — 0 findings
- **Full local suite**: `pnpm tc` (node+cli+web) exit 0, and full `pnpm test` — 65,152 passed / 312 failed / 936 skipped; the 312 failures match the clean-`main` baseline list on this machine (the one differing file, a stalled-checkpoint timing test, passes on immediate re-run).

## AI Disclosure

Implemented by a Codex lane under my orchestration (strict TDD, two review rounds), reviewed and re-verified locally by me with Claude Code assistance.

## Review

- **Wire compat**: error-message text only; no schema shape or RPC surface change.
- **Layering**: the reply-pointer lives in the schema (message authored where the field is defined); `formatZodError` stays method-agnostic.
- **Blast radius**: the reconstruction only triggers when a generic enum issue carries the bundled fallback text, so dev-mode messages and schema-authored messages are untouched.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

X: @EnricoPin
