### PR TITLE
fix(editor): keep Python triple-quoted f-strings from swallowing the file

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 12.0.0
-        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -59,11 +56,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.0.0':
-    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
-    engines: {node: '>=18.*'}
-    hasBin: true
-
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -94,17 +86,6 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
-
-  '@pnpm/exe@12.0.0':
-    optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0
-      '@pnpm/exe.darwin-x64': 12.0.0
-      '@pnpm/exe.linux-arm64': 12.0.0
-      '@pnpm/exe.linux-arm64-musl': 12.0.0
-      '@pnpm/exe.linux-x64': 12.0.0
-      '@pnpm/exe.linux-x64-musl': 12.0.0
-      '@pnpm/exe.win32-arm64': 12.0.0
-      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.0.0
+        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -56,6 +59,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pnpm/exe@12.0.0':
+    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -86,6 +94,17 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
+
+  '@pnpm/exe@12.0.0':
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
+++ b/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { monaco } from '@/lib/monaco-setup'
+import { patchPythonTripleQuotedFStrings } from '@/lib/monaco-languages/register-python'
 import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 import { resolveDocumentTheme } from '@/lib/document-theme'
 import { useAppStore } from '@/store'
@@ -24,7 +25,13 @@ async function ensureColorizationLanguage(language: string): Promise<void> {
           })
         }
         monaco.languages.setLanguageConfiguration('python', conf)
-        monaco.languages.setMonarchTokensProvider('python', pythonTokens)
+        // Why: this registers an explicit tokens provider, which wins over the
+        // factory installed in monaco-setup. Apply the same triple-quoted
+        // f-string patch so excerpts cannot reinstate the stock grammar's bug.
+        monaco.languages.setMonarchTokensProvider(
+          'python',
+          patchPythonTripleQuotedFStrings(pythonTokens)
+        )
       }
     )
   await pythonLanguageRegistrationPromise

--- a/src/renderer/src/lib/monaco-languages/register-python.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-python.test.ts
@@ -157,6 +157,18 @@ describe('python triple-quoted f-strings', () => {
     expect(interpolated.stateAtLineStart[3]).toBe('root')
   })
 
+  it('keeps a backslash line-continuation inside the f-string a string token', () => {
+    const source = ['x = f"""', 'SELECT 1 \\', 'FROM t', '"""', 'class Runner:'].join('\n')
+    const { stateAtLineStart, tokens } = walk(patchedPython, source)
+
+    // The trailing backslash must not fall through to the default token.
+    const continuation = tokens.filter((entry) => entry.line === 2)
+    expect(continuation.at(-1)?.text).toBe('\\')
+    expect(continuation.at(-1)?.token).toBe('string')
+    expect(stateAtLineStart[2]).toBe(TRIPLE_DOUBLE_QUOTED_F_STRING_STATE)
+    expect(stateAtLineStart[4]).toBe('root')
+  })
+
   it('does not mutate the stock grammar it patches', () => {
     const stockStrings = (stockPythonLanguage.tokenizer as Tokenizer).strings
     expect(stockStrings.some((rule) => isRuleEntry(rule) && rule[0].source === 'f"""')).toBe(false)

--- a/src/renderer/src/lib/monaco-languages/register-python.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-python.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+import type * as Monaco from 'monaco-editor'
+import { language as stockPythonLanguage } from 'monaco-editor/esm/vs/basic-languages/python/python.js'
+import {
+  patchPythonTripleQuotedFStrings,
+  registerPythonLanguage,
+  TRIPLE_DOUBLE_QUOTED_F_STRING_STATE
+} from './register-python'
+
+type MonarchLanguage = Monaco.languages.IMonarchLanguage
+type MonarchRule = [RegExp, unknown, string?] | { include: string }
+type Tokenizer = Record<string, MonarchRule[]>
+
+function isRuleEntry(rule: MonarchRule): rule is [RegExp, unknown, string?] {
+  return Array.isArray(rule)
+}
+
+function resolveAction(rule: [RegExp, unknown, string?]): { token?: string; next?: string } {
+  const [, action, nextShortcut] = rule
+  if (typeof action === 'object' && action !== null) {
+    const structured = action as { token?: string; next?: string }
+    return { token: structured.token, next: structured.next ?? nextShortcut }
+  }
+  return { token: typeof action === 'string' ? action : undefined, next: nextShortcut }
+}
+
+/** Flatten `{ include: '@state' }` so rules are tried in Monarch's real order. */
+function expandRules(tokenizer: Tokenizer, state: string, seen = new Set<string>()): MonarchRule[] {
+  if (seen.has(state)) {
+    return []
+  }
+  seen.add(state)
+  const rules = tokenizer[state] ?? tokenizer[state.split('.')[0]] ?? []
+  return rules.flatMap((rule) =>
+    isRuleEntry(rule) ? [rule] : expandRules(tokenizer, rule.include.replace(/^@/, ''), seen)
+  )
+}
+
+type Walk = { stateAtLineStart: string[]; tokens: { line: number; text: string; token: string }[] }
+
+/**
+ * Walk `source` through the grammar the way Monarch does: longest-prefix rule
+ * order, an explicit state stack, and `@push` / `@pop` / `@popall` transitions.
+ * Only the subset the Python grammar uses is modelled.
+ */
+function walk(language: MonarchLanguage, source: string): Walk {
+  const tokenizer = language.tokenizer as Tokenizer
+  const stack = ['root']
+  const stateAtLineStart: string[] = []
+  const tokens: { line: number; text: string; token: string }[] = []
+
+  source.split('\n').forEach((line, index) => {
+    stateAtLineStart.push(stack.at(-1) ?? 'root')
+    let column = 0
+    let guard = 0
+    while (column < line.length) {
+      if (++guard > 500) {
+        throw new Error(`tokenizer made no progress on line ${index + 1}`)
+      }
+      const rest = line.slice(column)
+      const current = stack.at(-1) ?? 'root'
+      const match = expandRules(tokenizer, current)
+        .map((rule) => {
+          if (!isRuleEntry(rule)) {
+            return null
+          }
+          const anchored = new RegExp(`^(?:${rule[0].source})`, rule[0].flags.replace(/[gy]/g, ''))
+          const found = anchored.exec(rest)
+          return found && found[0].length > 0 ? { rule, text: found[0] } : null
+        })
+        .find((candidate) => candidate !== null)
+
+      if (!match) {
+        column += 1
+        continue
+      }
+
+      const { token, next } = resolveAction(match.rule)
+      tokens.push({ line: index + 1, text: match.text, token: token ?? '' })
+      column += match.text.length
+
+      if (next === '@popall') {
+        stack.splice(1)
+      } else if (next === '@pop') {
+        if (stack.length > 1) {
+          stack.pop()
+        }
+      } else if (next?.startsWith('@')) {
+        stack.push(next.slice(1))
+      }
+    }
+  })
+
+  return { stateAtLineStart, tokens }
+}
+
+// The issue's exact minimal reproduction (STA-5792).
+const FIXTURE = ['x = f"""', 'SELECT 1', '"""', '', 'with open("f.txt") as dag:', '    pass'].join(
+  '\n'
+)
+
+const patchedPython = patchPythonTripleQuotedFStrings(stockPythonLanguage)
+
+describe('python triple-quoted f-strings', () => {
+  it('reproduces the stock grammar defect: code after the f-string is left inside a docstring', () => {
+    const { stateAtLineStart } = walk(stockPythonLanguage, FIXTURE)
+
+    // The body line pops to root, so the closing `"""` reads as an *opening* docstring.
+    expect(stateAtLineStart[2]).toBe('root')
+    expect(stateAtLineStart[4]).toBe('endDblDocString')
+  })
+
+  it('keeps a triple-quoted f-string open and returns to root after it closes', () => {
+    const { stateAtLineStart } = walk(patchedPython, FIXTURE)
+
+    expect(stateAtLineStart[0]).toBe('root')
+    expect(stateAtLineStart[1]).toBe(TRIPLE_DOUBLE_QUOTED_F_STRING_STATE)
+    expect(stateAtLineStart[2]).toBe(TRIPLE_DOUBLE_QUOTED_F_STRING_STATE)
+    // Closing delimiter returns to root instead of opening a docstring.
+    expect(stateAtLineStart[4]).toBe('root')
+  })
+
+  it('tokenizes code after the f-string as keywords rather than one flat string', () => {
+    const { tokens } = walk(patchedPython, FIXTURE)
+    const afterFString = tokens.filter((entry) => entry.line === 5)
+
+    expect(afterFString.length).toBeGreaterThan(1)
+    expect(afterFString.every((entry) => entry.token.startsWith('string'))).toBe(false)
+    expect(afterFString.some((entry) => entry.text === 'with')).toBe(true)
+  })
+
+  it("applies the same fix to f'''", () => {
+    const { stateAtLineStart } = walk(
+      patchedPython,
+      ["x = f'''", 'SELECT 1', "'''", 'class Runner:'].join('\n')
+    )
+
+    expect(stateAtLineStart[1]).toBe('fTripleStringBody')
+    expect(stateAtLineStart[3]).toBe('root')
+  })
+
+  it('leaves single-line and plain triple-quoted strings alone', () => {
+    const singleLine = walk(patchedPython, ['a = f"""SELECT 1"""', 'class Runner:'].join('\n'))
+    expect(singleLine.stateAtLineStart[1]).toBe('root')
+
+    const docstring = walk(
+      patchedPython,
+      ['b = """', 'SELECT 1', '"""', 'class Runner:'].join('\n')
+    )
+    expect(docstring.stateAtLineStart[3]).toBe('root')
+
+    const interpolated = walk(
+      patchedPython,
+      ['c = f"""', 'SELECT {table}', '"""', 'class Runner:'].join('\n')
+    )
+    expect(interpolated.stateAtLineStart[3]).toBe('root')
+  })
+
+  it('does not mutate the stock grammar it patches', () => {
+    const stockStrings = (stockPythonLanguage.tokenizer as Tokenizer).strings
+    expect(stockStrings.some((rule) => isRuleEntry(rule) && rule[0].source === 'f"""')).toBe(false)
+    expect((stockPythonLanguage.tokenizer as Tokenizer)[TRIPLE_DOUBLE_QUOTED_F_STRING_STATE]).toBe(
+      undefined
+    )
+  })
+
+  it('replaces the built-in Python tokenizer factory lazily', async () => {
+    const registerTokensProviderFactory = vi.fn()
+    registerPythonLanguage({
+      languages: { registerTokensProviderFactory }
+    } as unknown as typeof Monaco)
+
+    expect(registerTokensProviderFactory).toHaveBeenCalledTimes(1)
+    expect(registerTokensProviderFactory.mock.calls[0][0]).toBe('python')
+
+    const factory = registerTokensProviderFactory.mock.calls[0][1] as {
+      create: () => Promise<MonarchLanguage>
+    }
+    const created = (await factory.create()).tokenizer as Tokenizer
+    expect(created[TRIPLE_DOUBLE_QUOTED_F_STRING_STATE]).toBeDefined()
+  })
+})

--- a/src/renderer/src/lib/monaco-languages/register-python.ts
+++ b/src/renderer/src/lib/monaco-languages/register-python.ts
@@ -19,7 +19,9 @@ const tripleDoubleQuotedFStringRules: MonarchRule[] = [
   [/\{[^}':!=]+/, 'identifier', '@fStringDetail'],
   [/\\./, 'string'],
   [/[^\\"{}]+/, 'string'],
-  [/["{}]/, 'string']
+  [/["{}]/, 'string'],
+  // Matches the stock string states: a backslash-continuation at end of line.
+  [/\\$/, 'string']
 ]
 
 const tripleSingleQuotedFStringRules: MonarchRule[] = [
@@ -27,7 +29,9 @@ const tripleSingleQuotedFStringRules: MonarchRule[] = [
   [/\{[^}':!=]+/, 'identifier', '@fStringDetail'],
   [/\\./, 'string'],
   [/[^\\'{}]+/, 'string'],
-  [/['{}]/, 'string']
+  [/['{}]/, 'string'],
+  // Matches the stock string states: a backslash-continuation at end of line.
+  [/\\$/, 'string']
 ]
 
 /**

--- a/src/renderer/src/lib/monaco-languages/register-python.ts
+++ b/src/renderer/src/lib/monaco-languages/register-python.ts
@@ -1,0 +1,74 @@
+import type * as Monaco from 'monaco-editor'
+
+type MonacoModule = typeof Monaco
+type MonarchLanguage = Monaco.languages.IMonarchLanguage
+type MonarchRule = Monaco.languages.IMonarchLanguageRule
+type MonarchTokenizer = Record<string, MonarchRule[]>
+
+export const PYTHON_LANGUAGE_ID = 'python'
+export const TRIPLE_DOUBLE_QUOTED_F_STRING_STATE = 'fTripleDblStringBody'
+export const TRIPLE_SINGLE_QUOTED_F_STRING_STATE = 'fTripleStringBody'
+
+// Monaco's `strings` state matches `f"{1,3}` — a quantifier on the quote, not on
+// `f"` — so `f"""` lands in the single-line `fDblStringBody`. That state ends the
+// line with `@popall`, spilling the f-string body into `root`; the closing `"""`
+// is then read as an *opening* docstring and every later line tokenizes as string.
+// These states keep a triple-quoted f-string open until its real terminator.
+const tripleDoubleQuotedFStringRules: MonarchRule[] = [
+  [/"""/, 'string.escape', '@popall'],
+  [/\{[^}':!=]+/, 'identifier', '@fStringDetail'],
+  [/\\./, 'string'],
+  [/[^\\"{}]+/, 'string'],
+  [/["{}]/, 'string']
+]
+
+const tripleSingleQuotedFStringRules: MonarchRule[] = [
+  [/'''/, 'string.escape', '@popall'],
+  [/\{[^}':!=]+/, 'identifier', '@fStringDetail'],
+  [/\\./, 'string'],
+  [/[^\\'{}]+/, 'string'],
+  [/['{}]/, 'string']
+]
+
+/**
+ * Return a copy of Monaco's stock Python grammar that tokenizes triple-quoted
+ * f-strings (`f"""` / `f'''`) as multi-line strings. The stock grammar is left
+ * untouched so a second call cannot compound the patch.
+ */
+export function patchPythonTripleQuotedFStrings(language: MonarchLanguage): MonarchLanguage {
+  const tokenizer = language.tokenizer as MonarchTokenizer
+  const stockStringRules = tokenizer.strings ?? []
+
+  return {
+    ...language,
+    tokenizer: {
+      ...tokenizer,
+      // Ordered before the stock `f'{1,3}` / `f"{1,3}` rules so the triple-quote
+      // forms win; the stock rules still own single- and double-quote f-strings.
+      strings: [
+        [/f"""/, 'string.escape', `@${TRIPLE_DOUBLE_QUOTED_F_STRING_STATE}`],
+        [/f'''/, 'string.escape', `@${TRIPLE_SINGLE_QUOTED_F_STRING_STATE}`],
+        ...stockStringRules
+      ],
+      [TRIPLE_DOUBLE_QUOTED_F_STRING_STATE]: tripleDoubleQuotedFStringRules,
+      [TRIPLE_SINGLE_QUOTED_F_STRING_STATE]: tripleSingleQuotedFStringRules
+    }
+  }
+}
+
+export function loadPatchedPythonMonarchLanguage(): Promise<MonarchLanguage> {
+  return import('monaco-editor/esm/vs/basic-languages/python/python.js').then(({ language }) =>
+    patchPythonTripleQuotedFStrings(language)
+  )
+}
+
+/**
+ * Replace Monaco's built-in Python tokenizer factory with the patched grammar.
+ * Registering a factory (rather than an eager provider) keeps the grammar
+ * lazily loaded, so files that are never Python still pay nothing at startup.
+ */
+export function registerPythonLanguage(monaco: MonacoModule): void {
+  monaco.languages.registerTokensProviderFactory(PYTHON_LANGUAGE_ID, {
+    create: () => loadPatchedPythonMonarchLanguage()
+  })
+}

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -10,6 +10,7 @@ import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 import { registerAstroLanguage } from './monaco-languages/register-astro'
 import { registerJsonlLanguage } from './monaco-languages/register-jsonl'
 import { registerNimLanguage } from './monaco-languages/register-nim'
+import { registerPythonLanguage } from './monaco-languages/register-python'
 import { registerSvelteLanguage } from './monaco-languages/register-svelte'
 import { registerVueLanguage } from './monaco-languages/register-vue'
 import { installMonacoDelayerCancellationGuard } from './monaco-delayer-cancellation-guard'
@@ -79,6 +80,7 @@ registerSvelteLanguage(monaco)
 registerAstroLanguage(monaco)
 registerNimLanguage(monaco)
 registerJsonlLanguage(monaco)
+registerPythonLanguage(monaco)
 installMonacoDelayerCancellationGuard()
 installMonacoDiffEditorDisposalGuard(monaco)
 installMonacoPeekReferencesPreviewOptions()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​195 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​195 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 |

<!-- /orca-pr-loc -->

## Problem

A multi-line f-string opened with `f"""` breaks Python highlighting for **the rest of the file** — every `def`, `class`, `with`, keyword and string below it renders in one flat string color.

```python
x = f"""
SELECT 1
"""

with open("f.txt") as dag:   # ← this and everything below renders as string
    pass
```

## Root cause

Monaco's bundled Python Monarch grammar has no rule for triple-quoted f-strings:

```js
[/f"{1,3}/, "string.escape", "@fDblStringBody"],   // f", f"", f""" all land here
```

`f"{1,3}` is a quantifier on `"`, not on `f"`, so `f"""` enters `fDblStringBody` — a **single-line** state. Two failures follow:

1. `fDblStringBody` ends with `[/[^\\"\{\}]+$/, "string", "@popall"]`, so it pops to `root` at end of line and the body tokenizes as code.
2. The closing `"""` is then read from `root` via `whitespace`'s `[/"""/, "string", "@endDblDocString"]` — the *closing* delimiter opens a docstring, which swallows everything until the next `"""`.

Same class as the Vue multi-line `{{ }}` bug (STA-3085): a Monarch state that is entered but never exited.

## Fix

`register-python.ts` copies the stock grammar and adds dedicated `fTripleDblStringBody` / `fTripleStringBody` states that stay open until the real terminator, ordered ahead of the stock `f"{1,3}` rules. The stock grammar object is not mutated.

It installs via `registerTokensProviderFactory`, which replaces Monaco's own factory — so the Python grammar is still **loaded lazily** and startup cost is unchanged.

`MonacoCodeExcerpt` (notebook excerpts) calls `setMonarchTokensProvider`, which registers *explicit* support that outranks any factory. It previously registered the **stock** grammar, so rendering one notebook excerpt would have silently reinstated the bug app-wide; it now applies the same patch.

## Verification

**Live, on this branch's head, macOS Electron (CDP), real user path** — opened a `.py` file in the editor and read the rendered Monaco token classes:

| line | before | after |
| --- | --- | --- |
| `with open("f.txt") as dag:` | `mtk5` (one flat string span) | `mtk8="with"`, `mtk8="open"`, `mtk8="as"`, `mtk5="\"f.txt\""` |
| `    pass` | `mtk5` | `mtk8="pass"` |
| `class Runner:` | `mtk5` | `mtk8="class"` |
| `    def go(self):` | `mtk5` | `mtk8="def"`, `mtk8="self"` |
| `        return "done"` | `mtk5` | `mtk8="return"`, `mtk5="\"done\""` |

The f-string itself (lines 1–3) still renders as a string in both.

**Tests** — `register-python.test.ts` walks the real exported grammar through a Monarch state-machine simulation (rule order, `@push`/`@pop`/`@popall`):

- a **control** test asserts the stock grammar still exhibits the defect (line 5 starts in `endDblDocString`), so the harness is proven to reproduce the real bug;
- the fix tests assert the f-string state stays open across its body and returns to `root` after the terminator, and that the following line tokenizes as keywords;
- `f'''`, single-line `f"""..."""`, plain `"""` docstrings, and `f"""` with `{interpolation}` are all covered;
- one test asserts the stock grammar is not mutated.

**Ablation (non-vacuity):** removing only the two new `strings` rules turns **3 tests red** (`fStringBody` instead of `fTripleStringBody`, etc.); restoring them returns 7/7 green.

`pnpm tc` clean (0 `error TS`), `oxlint` clean on changed files, `monaco-languages` suite 32/32.

## Scope / compatibility

Renderer-only, no platform-specific code, no IPC or wire change — behaviour is identical on macOS/Windows/Linux, local/SSH/remote runtimes, and folder workspaces. No new startup work: the grammar remains lazily loaded.

Fixes STA-5792.
