### PR TITLE
fix(runtime): avoid premature heartbeat sweep during WebSocket handshake

### DIFF
--- a/src/main/runtime/rpc/remote-runtime-server-heartbeat-missed-probe-tolerance.test.ts
+++ b/src/main/runtime/rpc/remote-runtime-server-heartbeat-missed-probe-tolerance.test.ts
@@ -19,7 +19,12 @@ describe('RemoteRuntimeServerHeartbeat missed-probe tolerance', () => {
     const socket = makeSocket()
     const heartbeat = new RemoteRuntimeServerHeartbeat(INTERVAL_MS, () => now)
     heartbeat.noteAlive(socket)
-    heartbeat.start(() => [socket]) // probe #1
+    heartbeat.start(() => [socket])
+
+    // Probe #1 goes out on first tick
+    now += INTERVAL_MS
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS)
+    expect(socket.ping).toHaveBeenCalledTimes(1)
     heartbeat.noteAlive(socket) // pongs probe #1
 
     // A transient blackhole: probe #2 goes out and its pong is stuck in the network.

--- a/src/main/runtime/rpc/remote-runtime-server-heartbeat.test.ts
+++ b/src/main/runtime/rpc/remote-runtime-server-heartbeat.test.ts
@@ -7,6 +7,22 @@ afterEach(() => {
 })
 
 describe('RemoteRuntimeServerHeartbeat', () => {
+  it('does not probe newly connected sockets synchronously on start()', async () => {
+    vi.useFakeTimers()
+    const socket = { ping: vi.fn(), terminate: vi.fn() } as unknown as WebSocket
+    const heartbeat = new RemoteRuntimeServerHeartbeat(100)
+    heartbeat.noteAlive(socket)
+    heartbeat.start(() => [socket])
+
+    // start() must not sweep synchronously during connection handshake
+    expect(socket.ping).not.toHaveBeenCalled()
+
+    // Periodic sweep begins on the first interval tick
+    await vi.advanceTimersByTimeAsync(100)
+    expect(socket.ping).toHaveBeenCalledTimes(1)
+    heartbeat.stop()
+  })
+
   it('still reaps a persistently silent client while another remains alive', async () => {
     vi.useFakeTimers()
     let now = 1_000
@@ -16,25 +32,30 @@ describe('RemoteRuntimeServerHeartbeat', () => {
     const heartbeat = new RemoteRuntimeServerHeartbeat(100, () => now, 128, 2)
     heartbeat.noteAlive(responsiveSocket)
     heartbeat.noteAlive(deadSocket)
-    // start() probes immediately: both are pinged now (probe #1) and cleared to await a pong.
     heartbeat.start(() => [responsiveSocket, deadSocket])
-    // Only the responsive socket pongs the immediate probe.
+    expect(responsiveSocket.ping).not.toHaveBeenCalled()
+    expect(deadSocket.ping).not.toHaveBeenCalled()
+
+    // Tick #1: probe #1 goes out to both
+    now += 100
+    await vi.advanceTimersByTimeAsync(100)
+    expect(responsiveSocket.ping).toHaveBeenCalledTimes(1)
+    expect(deadSocket.ping).toHaveBeenCalledTimes(1)
     heartbeat.noteAlive(responsiveSocket)
 
-    // Miss #1: not yet evidence, so the silent socket is re-probed rather than reaped.
+    // Tick #2: probe #2 goes out. Silent socket has missed 1 probe (not reaped yet)
     now += 100
     await vi.advanceTimersByTimeAsync(100)
     heartbeat.noteAlive(responsiveSocket)
     expect(deadSocket.ping).toHaveBeenCalledTimes(2)
     expect(deadSocket.terminate).not.toHaveBeenCalled()
 
-    // Miss #2 reaches the limit: consecutive silence is evidence.
+    // Tick #3: Miss #2 reaches the limit: consecutive silence is evidence, dead socket reaped
     now += 100
     await vi.advanceTimersByTimeAsync(100)
 
     expect(responsiveSocket.ping).toHaveBeenCalledTimes(3)
     expect(responsiveSocket.terminate).not.toHaveBeenCalled()
-    expect(deadSocket.ping).toHaveBeenCalledTimes(2)
     expect(deadSocket.terminate).toHaveBeenCalledTimes(1)
     heartbeat.stop()
   })
@@ -46,13 +67,16 @@ describe('RemoteRuntimeServerHeartbeat', () => {
     // Limit of 1 isolates the resume grant: without it the very next sweep would reap.
     const heartbeat = new RemoteRuntimeServerHeartbeat(100, () => now, 128, 1)
     heartbeat.noteAlive(socket)
-    // start() probes immediately (ping #1); the socket pongs it.
     heartbeat.start(() => [socket])
+
+    now += 100
+    await vi.advanceTimersByTimeAsync(100) // ping #1, socket pongs
     heartbeat.noteAlive(socket)
 
     now += 100
     await vi.advanceTimersByTimeAsync(100) // ping #2, socket pongs
     heartbeat.noteAlive(socket)
+
     now += 3_600_000
     await vi.advanceTimersByTimeAsync(100) // resumed-from-pause: re-grants a probe (ping #3), no reap
 

--- a/src/main/runtime/rpc/remote-runtime-server-heartbeat.ts
+++ b/src/main/runtime/rpc/remote-runtime-server-heartbeat.ts
@@ -33,11 +33,6 @@ export class RemoteRuntimeServerHeartbeat {
     this.lastTickAt = this.now()
     this.timer = setInterval(() => this.sweep(getClients()), this.intervalMs)
     this.timer.unref?.()
-    // Why: the interval's first tick is a full intervalMs (~15s) out, so arming on the first accepted
-    // connection would leave that socket unprobed for the whole window. Sweep once now so the first
-    // liveness ping goes out immediately; seeded-alive sockets are pinged (not reaped) and have until
-    // the next tick to pong. WS pong is answered at the protocol level, so a live socket always survives.
-    this.sweep(getClients())
   }
 
   stop(): void {

--- a/src/main/runtime/rpc/ws-transport.test.ts
+++ b/src/main/runtime/rpc/ws-transport.test.ts
@@ -107,8 +107,7 @@ describe('WebSocketTransport', () => {
     await waitForHeartbeatLifecycle(transport, 1, true)
     const firstServerSocket = Array.from(lifecycle.wss.clients)[0]
     expect(firstServerSocket).toBeDefined()
-    // Note: arming probes immediately, so `alive` membership is racy here (the client's protocol-level
-    // pong re-adds the socket right after the arm sweep clears it). Assert the arm/disarm lifecycle only.
+    // Note: periodic probes run on timer interval ticks; assert the arm/disarm lifecycle here.
     const firstTimer = lifecycle.heartbeat.timer
 
     const secondClient = await connectWs(transport)


### PR DESCRIPTION
## ELI5

When a phone or remote client connects to Orca, the server immediately
ran an initial heartbeat sweep on the newly connected WebSocket. In my
reproduction, this caused the connection to close with code 1006 before
the application handshake could complete.

This change lets the connection finish its initial handshake before the
first heartbeat sweep, while keeping the normal periodic heartbeat checks
and dead-socket cleanup unchanged.

## What Changed

`RemoteRuntimeServerHeartbeat.start()` no longer performs a synchronous
`this.sweep()` when heartbeat monitoring starts.

The existing periodic `setInterval()` sweep remains unchanged.

A regression test was added to verify that a newly connected socket is
not synchronously probed during `start()`, while periodic probing and
dead-socket cleanup continue to work.

## Why

The synchronous initial heartbeat sweep was the trigger for the premature
WebSocket 1006 termination observed in my reproduction.

Removing that immediate sweep allows the WebSocket/application handshake
to proceed before the first heartbeat probe, without disabling heartbeat
monitoring.

## Linked Issue

Fixes #12140 

## Visual Proof

`N/A`
Why: this is a runtime/WebSocket lifecycle fix with no user-facing UI
or visual changes.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

### Manual testing

- Linux ARM64 / PRoot
- Orca Android v0.0.46 over LAN
- Loopback WebSocket connection
- LAN WebSocket connection
- E2EE handshake and encrypted RPC session

### Automated testing

- `remote-runtime-server-heartbeat.test.ts`
  - verifies `start()` does not synchronously probe newly connected sockets
  - verifies periodic heartbeat sweeps still occur
- `remote-runtime-server-heartbeat-missed-probe-tolerance.test.ts`
  - updated timing expectations so the first probe occurs on the first
    interval tick

Targeted linting with `oxlint` passed with 0 errors and 0 warnings on the
modified files.

The physical Android client successfully connected to the patched server
without any modification to the Android APK.

The full monorepo `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build`
checks could not all be completed in the ARM64/PRoot environment because
dependency installation required network-fetched platform binaries that
timed out. GitHub Actions CI can provide the full-repository validation.

### Automated testing

- `remote-runtime-server-heartbeat.test.ts`
- Missed-probe tolerance timing regression

The Android client successfully connected to the patched server without
any modification to the Android APK.

## AI Disclosure

AI assistance was used during investigation, debugging, implementation,
testing, and preparation of this contribution.

- Google Antigravity / Gemini: repository investigation, local debugging,
  implementation, test execution, and environment verification.
- OpenAI ChatGPT: research, issue analysis, technical review, and review
  of the contribution materials.

The reported behavior and fix were reproduced and verified in my local
environment, including testing with a physical Android client.

## Review

Reviewed for:

- Security and E2EE/authentication preservation
- Cross-platform behavior
- Local/LAN/remote compatibility
- Heartbeat behavior and dead-socket reaping
- Backwards compatibility
- Performance impact
- Regression risk

The change removes only the synchronous startup heartbeat sweep. Normal
periodic heartbeat processing remains unchanged.

## Agent skill upstream boundary

- [x] Not applicable

## Notes

- No cryptographic or authentication changes.
- No UI changes.
- Mobile behavior verified with Android 0.0.46.
- No platform-specific code introduced.
- No SSH-specific behavior changed.
- No filesystem/path handling changed.
- Normal 15-second heartbeat maintenance remains active.
- The fix is limited to connection startup behavior.
- Cross-platform impact reviewed: the change uses platform-neutral
  Node.js timer behavior and does not introduce OS-specific code.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

### Contributor Info
- **GitHub**: `@rehanahmed00`
- **X**: `@Rehan_Ahmed_0_0`
