### PR TITLE
feat(linux): configurable window controls position

### DIFF
--- a/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
+++ b/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
@@ -69,6 +69,7 @@ export function createSettings(overrides: TestSettingsOverrides = {}): GlobalSet
     sourceControlGroupOrder: 'changes-first',
     sourceControlCompareAgainstUpstream: false,
     showTitlebarAppName: true,
+    windowControlsPosition: 'right',
     showTasksButton: true,
     floatingTerminalEnabled: false,
     floatingTerminalCwd: '~',

--- a/src/main/codex-accounts/service-test-harness.ts
+++ b/src/main/codex-accounts/service-test-harness.ts
@@ -90,6 +90,7 @@ export function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalS
     sourceControlGroupOrder: 'changes-first',
     sourceControlCompareAgainstUpstream: false,
     showTitlebarAppName: true,
+    windowControlsPosition: 'right',
     showTasksButton: true,
     floatingTerminalEnabled: false,
     floatingTerminalCwd: '~',

--- a/src/main/persistence/applying-settings/settings-update.ts
+++ b/src/main/persistence/applying-settings/settings-update.ts
@@ -15,6 +15,7 @@ import { normalizeTerminalShortcutPolicy } from '../../../shared/keybindings'
 import { normalizeSourceControlGroupOrder } from '../../../shared/source-control-group-order'
 import { normalizeAppIconId } from '../../../shared/app-icon'
 import { normalizeUiLanguage } from '../../../shared/ui-language'
+import { normalizeWindowControlsPosition } from '../../../shared/window-controls-position'
 import { normalizeWorktreeVisibilityDefaults } from '../../../shared/external-worktree-visibility'
 import { normalizePRBotAuthorOverrides } from '../../../shared/pr-bot-author-overrides'
 import type { PersistedState } from '../../../shared/persisted-state-types'
@@ -67,6 +68,11 @@ export function updateSettings(
   }
   if ('showMenuBarIcon' in updates) {
     sanitizedUpdates.showMenuBarIcon = updates.showMenuBarIcon === true
+  }
+  if ('windowControlsPosition' in updates) {
+    sanitizedUpdates.windowControlsPosition = normalizeWindowControlsPosition(
+      updates.windowControlsPosition
+    )
   }
   // Why: the artifact publish capability must be an exact boolean on disk; no truthy value grants it.
   if ('artifactSharingEnabled' in updates) {

--- a/src/main/persistence/loading-store/normalize-loaded-global-settings.ts
+++ b/src/main/persistence/loading-store/normalize-loaded-global-settings.ts
@@ -7,6 +7,7 @@ import { normalizeAppIconId } from '../../../shared/app-icon'
 import { normalizeTerminalCustomThemes } from '../../../shared/terminal-custom-themes'
 import { projectSourceControlAiToLegacyCommitMessageAi } from '../../../shared/source-control-ai'
 import { normalizeUiLanguage } from '../../../shared/ui-language'
+import { normalizeWindowControlsPosition } from '../../../shared/window-controls-position'
 import { stripRetiredGlobalSettings } from '../applying-settings/terminal-settings-migrations'
 import { readLegacySidekickFlag } from '../applying-settings/onboarding-normalization'
 import type { PersistedState } from '../../../shared/persisted-state-types'
@@ -109,6 +110,9 @@ export function normalizeLoadedGlobalSettings(
     minimizeToTrayOnClose: parsed.settings?.minimizeToTrayOnClose === true,
     // Why: missing means default-on; round-trips unchanged on non-mac since darwin consumers gate the effect.
     showMenuBarIcon: parsed.settings?.showMenuBarIcon !== false,
+    windowControlsPosition: normalizeWindowControlsPosition(
+      parsed.settings?.windowControlsPosition
+    ),
     uiLanguage: normalizeUiLanguage(parsed.settings?.uiLanguage),
     defaultTaskSource: taskProviderSettings.defaultTaskSource,
     visibleTaskProviders: taskProviderSettings.visibleTaskProviders,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -18,7 +18,9 @@ import {
   MAC_TRAFFIC_LIGHTS_WIDTH,
   WINDOW_CONTROLS_HEIGHT,
   WINDOW_CONTROLS_WIDTH,
-  hasCustomTitleBar
+  hasCustomTitleBar,
+  resolveCustomWindowControlsSide,
+  windowControlsSideInsets
 } from './app-shell/app-window-chrome'
 import { useAppChromeLayout } from './app-shell/use-app-chrome-layout'
 import { useAppSessionPersistence } from './app-shell/use-app-session-persistence'
@@ -31,12 +33,16 @@ import { useOnboardingAndFeatureTips } from './app-shell/use-onboarding-and-feat
 import { usePersistedUIWriter } from './app-shell/use-persisted-ui-writer'
 import { useRuntimeGraphSync } from './app-shell/use-runtime-graph-sync'
 import { useWindowVisibilityEffects } from './app-shell/use-window-visibility-effects'
+import { useAppStore } from './store'
 
 function App(): React.JSX.Element {
   const layout = useAppChromeLayout()
   const floatingWorkspace = useFloatingWorkspacePanel()
   const onboardingGate = useOnboardingAndFeatureTips()
   const clearUnreadDockBadge = useUnreadDockBadge()
+  const windowControlsPreference = useAppStore((s) => s.settings?.windowControlsPosition)
+  const windowControlsSide = resolveCustomWindowControlsSide(windowControlsPreference)
+  const windowControlsInsets = windowControlsSideInsets(windowControlsSide)
 
   // Why enabled && open: the overlay only renders while the feature is on, and its panel is
   // aria-hidden while closed — so that pair is what "on screen" means for the floating workspace.
@@ -58,8 +64,12 @@ function App(): React.JSX.Element {
     const root = document.documentElement.style
     root.setProperty('--window-controls-width', WINDOW_CONTROLS_WIDTH)
     root.setProperty('--window-controls-height', WINDOW_CONTROLS_HEIGHT)
+    root.setProperty('--window-controls-left', windowControlsInsets.left)
+    root.setProperty('--window-controls-right', windowControlsInsets.right)
+    root.setProperty('--window-controls-right-edge-height', windowControlsInsets.rightEdgeHeight)
     root.setProperty('--mac-traffic-lights-width', MAC_TRAFFIC_LIGHTS_WIDTH)
-  }, [])
+    document.documentElement.dataset.windowControlsSide = windowControlsSide
+  }, [windowControlsInsets, windowControlsSide])
 
   const { cancelReturnFocusFrame } = floatingWorkspace
   const setAppRootNode = useCallback(
@@ -82,8 +92,11 @@ function App(): React.JSX.Element {
           '--collapsed-sidebar-header-width': `${layout.collapsedSidebarHeaderWidth}px`,
           // Shared so surfaces can avoid the Windows/Linux window-controls overlay without hardcoding 138px everywhere.
           '--window-controls-width': WINDOW_CONTROLS_WIDTH,
-          // Side-position activity bar uses this to push icons below the Windows/Linux window-controls overlay.
+          '--window-controls-left': windowControlsInsets.left,
+          '--window-controls-right': windowControlsInsets.right,
+          // Side-position activity bar uses this to push icons below the right-edge window-controls overlay.
           '--window-controls-height': WINDOW_CONTROLS_HEIGHT,
+          '--window-controls-right-edge-height': windowControlsInsets.rightEdgeHeight,
           // Full-bleed surfaces use this to keep the macOS traffic lights uncovered.
           '--mac-traffic-lights-width': MAC_TRAFFIC_LIGHTS_WIDTH
         } as React.CSSProperties
@@ -109,7 +122,7 @@ function App(): React.JSX.Element {
       <PinnedTabCloseDialog />
       <RunningTerminalCloseDialog />
       {/* Why: Electron's drag-region hit-test is DOM-order-based (ignores z-index); render last so WindowControls stay clickable. */}
-      {hasCustomTitleBar && <WindowControls />}
+      {hasCustomTitleBar && <WindowControls side={windowControlsSide} />}
     </div>
   )
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -61,15 +61,15 @@ function App(): React.JSX.Element {
   // (sheets, dialogs) mount outside it and would otherwise fall back to 0px and
   // render their controls under the Windows/Linux window-controls overlay.
   useEffect(() => {
+    const insets = windowControlsSideInsets(windowControlsSide)
     const root = document.documentElement.style
     root.setProperty('--window-controls-width', WINDOW_CONTROLS_WIDTH)
     root.setProperty('--window-controls-height', WINDOW_CONTROLS_HEIGHT)
-    root.setProperty('--window-controls-left', windowControlsInsets.left)
-    root.setProperty('--window-controls-right', windowControlsInsets.right)
-    root.setProperty('--window-controls-right-edge-height', windowControlsInsets.rightEdgeHeight)
+    root.setProperty('--window-controls-left', insets.left)
+    root.setProperty('--window-controls-right', insets.right)
+    root.setProperty('--window-controls-right-edge-height', insets.rightEdgeHeight)
     root.setProperty('--mac-traffic-lights-width', MAC_TRAFFIC_LIGHTS_WIDTH)
-    document.documentElement.dataset.windowControlsSide = windowControlsSide
-  }, [windowControlsInsets, windowControlsSide])
+  }, [windowControlsSide])
 
   const { cancelReturnFocusFrame } = floatingWorkspace
   const setAppRootNode = useCallback(

--- a/src/renderer/src/app-shell/AppWorkspaceShell.tsx
+++ b/src/renderer/src/app-shell/AppWorkspaceShell.tsx
@@ -168,8 +168,8 @@ export function AppWorkspaceShell(props: {
                     className="absolute top-0 z-10 flex items-center h-[36px]"
                     style={
                       {
-                        // Why: --window-controls-width keeps the toggle clear of the fixed window-controls overlay (138px on custom chrome, 0px otherwise); no internal spacer — one would cover the pane-actions Ellipsis button with an unclickable div.
-                        right: 'var(--window-controls-width)',
+                        // Why: --window-controls-right keeps the toggle clear of the fixed right-edge window-controls overlay (138px on custom chrome, 0px when controls are left or absent); no internal spacer — one would cover the pane-actions Ellipsis button with an unclickable div.
+                        right: 'var(--window-controls-right, var(--window-controls-width))',
                         WebkitAppRegion: 'no-drag'
                       } as React.CSSProperties
                     }

--- a/src/renderer/src/app-shell/TitlebarLeftControls.tsx
+++ b/src/renderer/src/app-shell/TitlebarLeftControls.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/store/slices/worktree-nav-history'
 import { useShortcutLabel } from '../hooks/useShortcutLabel'
 import { useAppStore } from '../store'
-import { hasCustomTitleBar, isMac } from './app-window-chrome'
+import { hasCustomTitleBar, isMac, resolveCustomWindowControlsSide } from './app-window-chrome'
 import type { AppChromeLayout } from './use-app-chrome-layout'
 
 /**
@@ -26,6 +26,9 @@ import type { AppChromeLayout } from './use-app-chrome-layout'
 export function TitlebarLeftControls({ layout }: { layout: AppChromeLayout }): React.JSX.Element {
   const toggleSidebar = useAppStore((s) => s.toggleSidebar)
   const updateSettings = useAppStore((s) => s.updateSettings)
+  const windowControlsSide = resolveCustomWindowControlsSide(
+    useAppStore((s) => s.settings?.windowControlsPosition)
+  )
   const canGoBackWorktree = useAppStore(canGoBackWorktreeHistory)
   const canGoForwardWorktree = useAppStore(canGoForwardWorktreeHistory)
   const leftSidebarShortcutLabel = useShortcutLabel('sidebar.left.toggle')
@@ -47,6 +50,10 @@ export function TitlebarLeftControls({ layout }: { layout: AppChromeLayout }): R
         ) : hasCustomTitleBar ? (
           /* Why: Windows/Linux remove the native title bar, so render the logo plus a ··· button that pops the application menu (as Alt does). */
           <>
+            {/* Why: when Linux puts min/max/close on the left, reserve the overlay width before the logo/menu cluster. */}
+            {windowControlsSide === 'left' ? (
+              <div className="window-controls-titlebar-spacer-left" />
+            ) : null}
             <img src={logo} alt="" aria-hidden className="titlebar-logo" />
             <Tooltip>
               <TooltipTrigger asChild>

--- a/src/renderer/src/app-shell/TitlebarMainStrip.tsx
+++ b/src/renderer/src/app-shell/TitlebarMainStrip.tsx
@@ -5,7 +5,7 @@ import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
 import { ActivityTitlebarControls } from '../components/activity/ActivityTitlebarControls'
 import { useShortcutLabel } from '../hooks/useShortcutLabel'
 import { useAppStore } from '../store'
-import { hasCustomTitleBar } from './app-window-chrome'
+import { hasCustomTitleBar, resolveCustomWindowControlsSide } from './app-window-chrome'
 import type { AppChromeLayout } from './use-app-chrome-layout'
 
 export function RightSidebarToggle(): React.JSX.Element {
@@ -33,6 +33,9 @@ export function RightSidebarToggle(): React.JSX.Element {
 
 /** The titlebar's center/right strip: the tab-strip portal slot and the trailing chrome buttons. */
 export function TitlebarMainStrip({ layout }: { layout: AppChromeLayout }): React.JSX.Element {
+  const windowControlsSide = resolveCustomWindowControlsSide(
+    useAppStore((s) => s.settings?.windowControlsPosition)
+  )
   const handleToggleExpand = (): void => {
     if (!layout.effectiveActiveTabId) {
       return
@@ -73,8 +76,10 @@ export function TitlebarMainStrip({ layout }: { layout: AppChromeLayout }): Reac
       )}
       {/* Why: the open right sidebar's header renders its own close button, so hide this duplicate. */}
       {layout.showRightSidebarControls && !layout.rightSidebarOpen ? <RightSidebarToggle /> : null}
-      {/* Why: reserve space so the Windows/Linux window-controls overlay doesn't obscure content. */}
-      {hasCustomTitleBar && <div className="window-controls-titlebar-spacer" />}
+      {/* Why: reserve space so the right-edge window-controls overlay doesn't obscure content. */}
+      {hasCustomTitleBar && windowControlsSide === 'right' ? (
+        <div className="window-controls-titlebar-spacer" />
+      ) : null}
     </>
   )
 }

--- a/src/renderer/src/app-shell/WindowControls.tsx
+++ b/src/renderer/src/app-shell/WindowControls.tsx
@@ -76,7 +76,6 @@ export function WindowControls({ side }: WindowControlsProps): React.JSX.Element
   return (
     <div
       className={side === 'left' ? 'window-controls window-controls-side-left' : 'window-controls'}
-      data-side={side}
     >
       {/* Why: left side follows GNOME/macOS order (close, minimize, maximize); right keeps Windows order. */}
       {side === 'left' ? (

--- a/src/renderer/src/app-shell/WindowControls.tsx
+++ b/src/renderer/src/app-shell/WindowControls.tsx
@@ -1,8 +1,13 @@
 import { useEffect, useState } from 'react'
 import { translate } from '@/i18n/i18n'
+import type { WindowControlsPosition } from '../../../shared/window-controls-position'
+
+type WindowControlsProps = {
+  side: WindowControlsPosition
+}
 
 // Why: Windows and Linux both remove the native title bar, so we render our own min/max/close buttons (Fluent/Win11-style SVGs).
-export function WindowControls(): React.JSX.Element {
+export function WindowControls({ side }: WindowControlsProps): React.JSX.Element {
   const [maximized, setMaximized] = useState(false)
   useEffect(() => {
     // Why: maximize-changed only fires on transitions; seed from main on mount so a startup-maximized window shows the right icon.
@@ -18,48 +23,75 @@ export function WindowControls(): React.JSX.Element {
       unsubscribe()
     }
   }, [])
+
+  const minimizeButton = (
+    <button
+      className="window-controls-btn"
+      aria-label={translate('auto.App.bbb7f90669', 'Minimize')}
+      onClick={() => window.api.ui.minimize()}
+    >
+      <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden>
+        <path d="M0 5h10v1H0z" fill="currentColor" />
+      </svg>
+    </button>
+  )
+
+  const maximizeButton = (
+    <button
+      className="window-controls-btn"
+      aria-label={
+        maximized
+          ? translate('auto.App.66f0a552e5', 'Restore')
+          : translate('auto.App.c9d6f98459', 'Maximize')
+      }
+      onClick={() => window.api.ui.maximize()}
+    >
+      {maximized ? (
+        // Restore icon (two overlapping squares)
+        <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden>
+          <path d="M2 0v2H0v8h8V8h2V0H2zm6 9H1V3h7v6zM9 7H8V2H3V1h6v6z" fill="currentColor" />
+        </svg>
+      ) : (
+        // Maximize icon (single square outline)
+        <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden>
+          <path d="M0 0v10h10V0H0zm9 9H1V1h8v8z" fill="currentColor" />
+        </svg>
+      )}
+    </button>
+  )
+
+  const closeButton = (
+    <button
+      className="window-controls-btn window-controls-close"
+      aria-label={translate('auto.App.e960d18540', 'Close')}
+      // Why: route close through main so the 'close' event fires the terminal-running confirmation guard; window.close() is unreliable in sandboxed renderers.
+      onClick={() => window.api.ui.requestClose()}
+    >
+      <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden>
+        <path d="M1 0L0 1l4 4-4 4 1 1 4-4 4 4 1-1-4-4 4-4-1-1-4 4-4-4z" fill="currentColor" />
+      </svg>
+    </button>
+  )
+
   return (
-    <div className="window-controls">
-      <button
-        className="window-controls-btn"
-        aria-label={translate('auto.App.bbb7f90669', 'Minimize')}
-        onClick={() => window.api.ui.minimize()}
-      >
-        <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden>
-          <path d="M0 5h10v1H0z" fill="currentColor" />
-        </svg>
-      </button>
-      <button
-        className="window-controls-btn"
-        aria-label={
-          maximized
-            ? translate('auto.App.66f0a552e5', 'Restore')
-            : translate('auto.App.c9d6f98459', 'Maximize')
-        }
-        onClick={() => window.api.ui.maximize()}
-      >
-        {maximized ? (
-          // Restore icon (two overlapping squares)
-          <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden>
-            <path d="M2 0v2H0v8h8V8h2V0H2zm6 9H1V3h7v6zM9 7H8V2H3V1h6v6z" fill="currentColor" />
-          </svg>
-        ) : (
-          // Maximize icon (single square outline)
-          <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden>
-            <path d="M0 0v10h10V0H0zm9 9H1V1h8v8z" fill="currentColor" />
-          </svg>
-        )}
-      </button>
-      <button
-        className="window-controls-btn window-controls-close"
-        aria-label={translate('auto.App.e960d18540', 'Close')}
-        // Why: route close through main so the 'close' event fires the terminal-running confirmation guard; window.close() is unreliable in sandboxed renderers.
-        onClick={() => window.api.ui.requestClose()}
-      >
-        <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden>
-          <path d="M1 0L0 1l4 4-4 4 1 1 4-4 4 4 1-1-4-4 4-4-1-1-4 4-4-4z" fill="currentColor" />
-        </svg>
-      </button>
+    <div
+      className={side === 'left' ? 'window-controls window-controls-side-left' : 'window-controls'}
+      data-side={side}
+    >
+      {/* Why: left side follows GNOME/macOS order (close, minimize, maximize); right keeps Windows order. */}
+      {side === 'left' ? (
+        <>
+          {closeButton}
+          {minimizeButton}
+          {maximizeButton}
+        </>
+      ) : (
+        <>
+          {minimizeButton}
+          {maximizeButton}
+          {closeButton}
+        </>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/app-shell/app-window-chrome.test.ts
+++ b/src/renderer/src/app-shell/app-window-chrome.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   hasCustomTitleBar,
   resolveCustomWindowControlsSide,
+  shortcutPlatform,
   windowControlsSideInsets
 } from './app-window-chrome'
 
@@ -33,7 +34,7 @@ describe('resolveCustomWindowControlsSide', () => {
       expect(resolved).toBe('right')
       return
     }
-    // Why: Windows custom chrome keeps the right convention even if a preference is stored.
-    expect(resolved).toBe(process.platform === 'linux' ? 'left' : 'right')
+    // Why: match shortcutPlatform (navigator.userAgent), not process.platform — Vitest's UA is not the host OS.
+    expect(resolved).toBe(shortcutPlatform === 'linux' ? 'left' : 'right')
   })
 })

--- a/src/renderer/src/app-shell/app-window-chrome.test.ts
+++ b/src/renderer/src/app-shell/app-window-chrome.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  hasCustomTitleBar,
+  resolveCustomWindowControlsSide,
+  windowControlsSideInsets
+} from './app-window-chrome'
+
+describe('windowControlsSideInsets', () => {
+  it('places the cluster on the requested side when custom chrome is active', () => {
+    if (!hasCustomTitleBar) {
+      expect(windowControlsSideInsets('left')).toEqual({
+        left: '0px',
+        right: '0px',
+        rightEdgeHeight: '0px'
+      })
+      return
+    }
+    const right = windowControlsSideInsets('right')
+    const left = windowControlsSideInsets('left')
+    expect(right.right).not.toBe('0px')
+    expect(right.left).toBe('0px')
+    expect(right.rightEdgeHeight).not.toBe('0px')
+    expect(left.left).toBe(right.right)
+    expect(left.right).toBe('0px')
+    expect(left.rightEdgeHeight).toBe('0px')
+  })
+})
+
+describe('resolveCustomWindowControlsSide', () => {
+  it('only honors left when custom Linux chrome is active', () => {
+    const resolved = resolveCustomWindowControlsSide('left')
+    if (!hasCustomTitleBar) {
+      expect(resolved).toBe('right')
+      return
+    }
+    // Why: Windows custom chrome keeps the right convention even if a preference is stored.
+    expect(resolved).toBe(process.platform === 'linux' ? 'left' : 'right')
+  })
+})

--- a/src/renderer/src/app-shell/app-window-chrome.ts
+++ b/src/renderer/src/app-shell/app-window-chrome.ts
@@ -2,6 +2,8 @@ import {
   isPairedWebClientWindow,
   shouldRenderDesktopWindowChrome
 } from '@/lib/desktop-window-chrome'
+import type { WindowControlsPosition } from '../../../shared/window-controls-position'
+import { resolveWindowControlsSide } from '../../../shared/window-controls-position'
 
 export const isMac = navigator.userAgent.includes('Mac')
 const isWindows = !isMac && navigator.userAgent.includes('Windows')
@@ -20,3 +22,28 @@ export const WINDOW_CONTROLS_HEIGHT = hasCustomTitleBar ? '36px' : '0px'
 // Why: macOS paints traffic lights on the window's top-left edge. Windows and Linux paint their
 // controls on the right, so only macOS needs a surface to keep the left edge uncovered.
 export const MAC_TRAFFIC_LIGHTS_WIDTH = isMac ? '80px' : '0px'
+
+export function resolveCustomWindowControlsSide(
+  preference: WindowControlsPosition | undefined
+): WindowControlsPosition {
+  if (!hasCustomTitleBar) {
+    return 'right'
+  }
+  return resolveWindowControlsSide({
+    platform: shortcutPlatform,
+    preference
+  })
+}
+
+export function windowControlsSideInsets(side: WindowControlsPosition): {
+  left: string
+  right: string
+  rightEdgeHeight: string
+} {
+  if (!hasCustomTitleBar) {
+    return { left: '0px', right: '0px', rightEdgeHeight: '0px' }
+  }
+  return side === 'left'
+    ? { left: WINDOW_CONTROLS_WIDTH, right: '0px', rightEdgeHeight: '0px' }
+    : { left: '0px', right: WINDOW_CONTROLS_WIDTH, rightEdgeHeight: WINDOW_CONTROLS_HEIGHT }
+}

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -858,17 +858,25 @@ html.native-shell .app-layout {
 }
 
 /* Why: desktop custom title bar buttons replace hidden native OS chrome.
-   Anchored to the top-right corner of the viewport so they overlay any layout
-   mode (full titlebar, workspace split, etc.) and stay accessible at all times. */
+   Anchored to the top corner of the viewport so they overlay any layout
+   mode (full titlebar, workspace split, etc.) and stay accessible at all times.
+   Default is the right edge (Windows/Linux convention); `.window-controls-side-left`
+   flips to the left for the Linux preference. */
 .window-controls {
   position: fixed;
   top: 0;
   right: 0;
+  left: auto;
   z-index: 9999;
   display: flex;
   flex-direction: row;
   height: 36px;
   -webkit-app-region: no-drag;
+}
+
+.window-controls-side-left {
+  left: 0;
+  right: auto;
 }
 
 .window-controls-btn {
@@ -898,10 +906,15 @@ html.native-shell .app-layout {
 
 /* Why: flex spacer that reserves the width occupied by the three window-control
    buttons (3 × 46px) so that the preceding titlebar content is not obscured by
-   the fixed-position overlay when custom desktop chrome is active. */
+   the fixed-position overlay when custom desktop chrome is active on that edge. */
 .window-controls-titlebar-spacer {
   flex-shrink: 0;
-  width: var(--window-controls-width, 0px);
+  width: var(--window-controls-right, var(--window-controls-width, 0px));
+}
+
+.window-controls-titlebar-spacer-left {
+  flex-shrink: 0;
+  width: var(--window-controls-left, 0px);
 }
 
 .right-sidebar-header-drag {
@@ -919,6 +932,7 @@ html.native-shell .app-layout {
 :root[data-regular-terminal-input-focused] .titlebar,
 :root[data-regular-terminal-input-focused] .titlebar-left,
 :root[data-regular-terminal-input-focused] .window-controls-titlebar-spacer,
+:root[data-regular-terminal-input-focused] .window-controls-titlebar-spacer-left,
 :root[data-regular-terminal-input-focused] .right-sidebar-header-drag,
 :root[data-regular-terminal-input-focused] [data-terminal-focus-release-surface='true'] {
   -webkit-app-region: no-drag;
@@ -929,29 +943,34 @@ html.native-shell .app-layout {
 }
 
 /* Why: the right sidebar header extends to the window's right edge. When custom
-   desktop chrome is active, the fixed-position window-controls overlay sits on
-   top of that edge, so we add matching padding-right so the header's close
+   desktop chrome is active on the right, the fixed-position window-controls overlay
+   sits on top of that edge, so we add matching padding-right so the header's close
    button (pr-1) isn't hidden behind the overlay. */
 .right-sidebar-header-inset {
-  padding-right: var(--window-controls-width, 0px);
+  padding-right: var(--window-controls-right, var(--window-controls-width, 0px));
 }
 
 /* Why: in side-bar activity-bar mode the icon strip sits flush against the
    right window edge. The fixed-position window-controls overlay (height 36px,
-   width 138px) covers the top-right corner when custom desktop chrome is
-   active, so the topmost sidebar icons are unreachable without this offset. */
+   width 138px) covers the top-right corner when custom chrome is on the right,
+   so the topmost sidebar icons are unreachable without this offset. Left-side
+   controls leave the right edge clear, so the var is 0px then. */
 .side-activity-bar-windows-inset {
-  padding-top: var(--window-controls-height, 0px);
+  padding-top: var(--window-controls-right-edge-height, var(--window-controls-height, 0px));
 }
 
 /* Why: in side activity-bar mode the panel header does NOT extend to the window
    edge — the 40px icon strip sits to its right. But the window-controls overlay
-   is 138px wide when custom desktop chrome is active, so it still overlaps the
-   panel by (138 - 40) = 98px. Apply exactly that remainder as padding-right so
-   the close button clears the minimize button. max(0px, ...) keeps this a no-op
-   when the var is 0px and the subtraction would otherwise go negative. */
+   is 138px wide when custom desktop chrome is active on the right, so it still
+   overlaps the panel by (138 - 40) = 98px. Apply exactly that remainder as
+   padding-right so the close button clears the minimize button. max(0px, ...)
+   keeps this a no-op when the var is 0px and the subtraction would otherwise go
+   negative. */
 .right-sidebar-header-side-inset {
-  padding-right: max(0px, calc(var(--window-controls-width, 0px) - 40px));
+  padding-right: max(
+    0px,
+    calc(var(--window-controls-right, var(--window-controls-width, 0px)) - 40px)
+  );
 }
 
 .sidebar-toggle {

--- a/src/renderer/src/components/artifacts/ArtifactDetailHeader.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactDetailHeader.tsx
@@ -27,7 +27,7 @@ export function ArtifactDetailHeader({
   return (
     // Why: the drawer is right-anchored under the fixed Windows/Linux window-controls
     // overlay, which paints above it — inset the actions so they stay clickable.
-    <div className="flex flex-wrap items-start justify-between gap-3 border-b border-border/50 px-4 py-3 pr-[max(1rem,var(--window-controls-width,0px))]">
+    <div className="flex flex-wrap items-start justify-between gap-3 border-b border-border/50 px-4 py-3 pl-[max(1rem,var(--window-controls-left,0px))] pr-[max(1rem,var(--window-controls-right,var(--window-controls-width,0px)))]">
       {/* Why: a floor rather than min-w-0 — otherwise the title truncates to nothing before the actions wrap. */}
       <div className="min-w-40 flex-1 space-y-0.5">
         {title}

--- a/src/renderer/src/components/artifacts/ArtifactsPage.test.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactsPage.test.tsx
@@ -156,7 +156,9 @@ describe('ArtifactsPage', () => {
     expect(
       screen
         .getByRole('button', { name: 'Close' })
-        .closest('.pr-\\[max\\(1rem\\,var\\(--window-controls-width\\,0px\\)\\)\\]')
+        .closest(
+          '.pr-\\[max\\(1rem\\,var\\(--window-controls-right\\,var\\(--window-controls-width\\,0px\\)\\)\\)\\]'
+        )
     ).not.toBeNull()
     const copyButton = screen.getByRole('button', { name: 'Copy link' })
     expect(copyButton).toHaveAttribute('data-variant', 'default')

--- a/src/renderer/src/components/artifacts/ArtifactsPage.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactsPage.tsx
@@ -174,7 +174,9 @@ export default function ArtifactsPage(): React.JSX.Element {
         // Why: no stacked center titlebar on this page; keep the title clear of Windows/Linux window controls.
         style={
           {
-            paddingRight: 'max(0.75rem, var(--window-controls-width, 0px))'
+            paddingRight:
+              'max(0.75rem, var(--window-controls-right, var(--window-controls-width, 0px)))',
+            paddingLeft: 'max(0.75rem, var(--window-controls-left, 0px))'
           } as React.CSSProperties
         }
       >

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -2569,7 +2569,9 @@ export default function AutomationsPage(): React.JSX.Element {
         className="flex shrink-0 items-center px-3 pb-3 md:px-5"
         style={
           {
-            paddingRight: 'max(0.75rem, var(--window-controls-width, 0px))'
+            paddingRight:
+              'max(0.75rem, var(--window-controls-right, var(--window-controls-width, 0px)))',
+            paddingLeft: 'max(0.75rem, var(--window-controls-left, 0px))'
           } as React.CSSProperties
         }
       >

--- a/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
@@ -22,6 +22,7 @@ import {
   getThemeEntries,
   getTitlebarEntries,
   getTypographyEntries,
+  getWindowControlsPositionEntries,
   getZoomEntries
 } from './appearance-search'
 import {
@@ -41,6 +42,7 @@ type AppearanceInterfaceSectionProps = {
   fontSuggestions: string[]
   isDesktopMac: boolean
   isDesktopWindows: boolean
+  isDesktopLinux: boolean
   onRequestFontSuggestions?: () => void
   forceVisiblePrimary?: boolean
 }
@@ -52,6 +54,7 @@ export function AppearanceInterfaceSection({
   fontSuggestions,
   isDesktopMac,
   isDesktopWindows,
+  isDesktopLinux,
   onRequestFontSuggestions,
   forceVisiblePrimary = false
 }: AppearanceInterfaceSectionProps): React.JSX.Element {
@@ -66,10 +69,12 @@ export function AppearanceInterfaceSection({
   const themeEntry = getThemeEntries()[0]
   const themeLabel = translate('auto.components.settings.AppearancePane.932ff1fbff', 'Theme')
   const titlebarEntry = getTitlebarEntries()[0]
+  const windowControlsPositionEntry = getWindowControlsPositionEntries()[0]
   const typographyEntry = getTypographyEntries()[0]
   const zoomEntry = getZoomEntries()[0]
   const advancedEntries = [
     ...getTitlebarEntries(),
+    ...(isDesktopLinux ? getWindowControlsPositionEntries() : []),
     ...getSystemTrayEntries({ showSystemTray: isDesktopWindows }),
     ...getMenuBarIconEntries({ showMenuBarIcon: isDesktopMac })
   ]
@@ -217,6 +222,65 @@ export function AppearanceInterfaceSection({
                 }
               />
             </SearchableSetting>
+
+            {isDesktopLinux ? (
+              <SearchableSetting
+                title={translate(
+                  'settings.appearance.windowControlsPosition.title',
+                  'Window Controls Position'
+                )}
+                description={windowControlsPositionEntry?.description}
+                keywords={
+                  windowControlsPositionEntry?.keywords ?? [
+                    'titlebar',
+                    'window',
+                    'controls',
+                    'linux',
+                    'left',
+                    'right'
+                  ]
+                }
+              >
+                <SettingsRow
+                  label={translate(
+                    'settings.appearance.windowControlsPosition.title',
+                    'Window Controls Position'
+                  )}
+                  description={translate(
+                    'settings.appearance.windowControlsPosition.description',
+                    'Place minimize, maximize, and close on the left or right on Linux.'
+                  )}
+                  control={
+                    <SettingsSegmentedControl
+                      ariaLabel={translate(
+                        'settings.appearance.windowControlsPosition.title',
+                        'Window Controls Position'
+                      )}
+                      value={settings.windowControlsPosition === 'left' ? 'left' : 'right'}
+                      onChange={(option) => {
+                        updateSettings({ windowControlsPosition: option })
+                      }}
+                      options={[
+                        {
+                          value: 'left',
+                          label: translate(
+                            'settings.appearance.windowControlsPosition.left',
+                            'Left'
+                          )
+                        },
+                        {
+                          value: 'right',
+                          label: translate(
+                            'settings.appearance.windowControlsPosition.right',
+                            'Right'
+                          )
+                        }
+                      ]}
+                    />
+                  }
+                />
+              </SearchableSetting>
+            ) : null}
 
             {isDesktopWindows ? (
               <SearchableSetting

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -23,6 +23,7 @@ import {
   getThemeEntries,
   getTitlebarEntries,
   getTypographyEntries,
+  getWindowControlsPositionEntries,
   getZoomEntries
 } from './appearance-search'
 import { getTerminalAppearanceSearchEntries } from './terminal-search'
@@ -84,6 +85,7 @@ export function AppearancePane({
   // browser web client has no local tray to control.
   const isDesktopWindows = getRendererAppPlatform() === 'win32' && !isWebClient
   const isDesktopMac = getRendererAppPlatform() === 'darwin' && !isWebClient
+  const isDesktopLinux = getRendererAppPlatform() === 'linux' && !isWebClient
 
   // Why: Terminal / Window settings were too easy to miss when only Interface
   // started open; keep sections independently collapsible but expanded by default.
@@ -142,6 +144,7 @@ export function AppearancePane({
     ...getTypographyEntries(),
     ...(SHOW_UI_LANGUAGE_SETTING ? getLanguageEntries() : []),
     ...getTitlebarEntries(),
+    ...(isDesktopLinux ? getWindowControlsPositionEntries() : []),
     ...getSystemTrayEntries({ showSystemTray: isDesktopWindows }),
     ...getMenuBarIconEntries({ showMenuBarIcon: isDesktopMac })
   ]
@@ -224,6 +227,7 @@ export function AppearancePane({
             onRequestFontSuggestions={onRequestFontSuggestions}
             isDesktopMac={isDesktopMac}
             isDesktopWindows={isDesktopWindows}
+            isDesktopLinux={isDesktopLinux}
             forceVisiblePrimary={interfaceLabelMatches}
           />
         </AppearanceSection>

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -162,6 +162,51 @@ export const getTitlebarEntries = createLocalizedCatalog((): SettingsSearchEntry
   }
 ])
 
+export const getWindowControlsPositionEntries = createLocalizedCatalog(
+  (): SettingsSearchEntry[] => [
+    {
+      title: translate(
+        'settings.appearance.windowControlsPosition.title',
+        'Window Controls Position'
+      ),
+      description: translate(
+        'settings.appearance.windowControlsPosition.description',
+        'Place minimize, maximize, and close on the left or right on Linux.'
+      ),
+      keywords: [
+        ...translateSearchKeyword(
+          'settings.appearance.windowControlsPosition.keyword.titlebar',
+          'titlebar'
+        ),
+        ...translateSearchKeyword(
+          'settings.appearance.windowControlsPosition.keyword.window',
+          'window'
+        ),
+        ...translateSearchKeyword(
+          'settings.appearance.windowControlsPosition.keyword.controls',
+          'controls'
+        ),
+        ...translateSearchKeyword(
+          'settings.appearance.windowControlsPosition.keyword.linux',
+          'linux'
+        ),
+        ...translateSearchKeyword(
+          'settings.appearance.windowControlsPosition.keyword.left',
+          'left'
+        ),
+        ...translateSearchKeyword(
+          'settings.appearance.windowControlsPosition.keyword.right',
+          'right'
+        ),
+        ...translateSearchKeyword(
+          'settings.appearance.windowControlsPosition.keyword.close',
+          'close'
+        )
+      ]
+    }
+  ]
+)
+
 export const getStatusBarEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   getUsagePercentageDisplayEntry(),
   ...getStatusBarToggles().map(({ title, description, keywords }) => ({
@@ -224,6 +269,7 @@ type AppearancePaneSearchOptions = {
   showWarpImport?: boolean
   showSystemTray?: boolean
   showMenuBarIcon?: boolean
+  showWindowControlsPosition?: boolean
 }
 
 function buildAppearancePaneSearchEntries(
@@ -238,6 +284,7 @@ function buildAppearancePaneSearchEntries(
     ...getTerminalAppearanceSearchEntries(options),
     ...getLayoutEntries(),
     ...getTitlebarEntries(),
+    ...(options.showWindowControlsPosition ? getWindowControlsPositionEntries() : []),
     ...getStatusBarEntries(),
     ...getSidebarEntries(),
     ...getAppIconEntries(),
@@ -252,6 +299,7 @@ export function getAppearancePaneSearchEntries(
   return buildAppearancePaneSearchEntries({
     showWarpImport: options.showWarpImport ?? true,
     showSystemTray: options.showSystemTray,
-    showMenuBarIcon: options.showMenuBarIcon
+    showMenuBarIcon: options.showMenuBarIcon,
+    showWindowControlsPosition: options.showWindowControlsPosition
   })
 }

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -184,6 +184,15 @@ describe('getTerminalPaneSearchEntries', () => {
     expect(matchesSettingsSearch('status item', macEntries)).toBe(true)
   })
 
+  it('includes the Linux window-controls position entry only when that control is shown', () => {
+    const linuxEntries = getAppearancePaneSearchEntries({ showWindowControlsPosition: true })
+    const otherEntries = getAppearancePaneSearchEntries({ showWindowControlsPosition: false })
+
+    expect(linuxEntries.some((entry) => entry.title === 'Window Controls Position')).toBe(true)
+    expect(otherEntries.some((entry) => entry.title === 'Window Controls Position')).toBe(false)
+    expect(matchesSettingsSearch('linux', linuxEntries)).toBe(true)
+  })
+
   it('keeps sidebar shortcut restore settings in the Appearance search index', () => {
     const automationsEntry = getSidebarEntries().find(
       (entry) => entry.title === 'Show Automations Button'

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -324,7 +324,8 @@ export default function TabGroupPanel({
               className="shrink-0"
               style={
                 {
-                  width: 'calc(40px + var(--window-controls-width, 0px))',
+                  width:
+                    'calc(40px + var(--window-controls-right, var(--window-controls-width, 0px)))',
                   WebkitAppRegion: 'no-drag'
                 } as React.CSSProperties
               }

--- a/src/renderer/src/hooks/settings-navigation-build-options.ts
+++ b/src/renderer/src/hooks/settings-navigation-build-options.ts
@@ -3,6 +3,7 @@ import type { Repo } from '../../../shared/repo-types'
 export type SettingsNavigationBuildOptions = {
   isMac: boolean
   isWindows: boolean
+  isLinux: boolean
   isLocalWindowsHost: boolean
   isWindowsTerminalHost: boolean
   isWebClient: boolean

--- a/src/renderer/src/hooks/settings-navigation-interface-sections.ts
+++ b/src/renderer/src/hooks/settings-navigation-interface-sections.ts
@@ -11,6 +11,7 @@ import type { SettingsNavigationBuildOptions } from './settings-navigation-build
 export function buildInterfaceSettingsSections({
   isMac,
   isWindows,
+  isLinux,
   isWebClient,
   managedBrowserCreationEnabled,
   mobileEmulatorCreationEnabled
@@ -29,7 +30,7 @@ export function buildInterfaceSettingsSections({
         showWarpImport: showDesktopOnlySettings,
         showSystemTray: showDesktopOnlySettings && isWindows,
         showMenuBarIcon: showDesktopOnlySettings && isMac,
-        showWindowControlsPosition: showDesktopOnlySettings && !isMac && !isWindows
+        showWindowControlsPosition: showDesktopOnlySettings && isLinux
       }),
       group: 'interface'
     },

--- a/src/renderer/src/hooks/settings-navigation-interface-sections.ts
+++ b/src/renderer/src/hooks/settings-navigation-interface-sections.ts
@@ -28,7 +28,8 @@ export function buildInterfaceSettingsSections({
       searchEntries: getAppearancePaneSearchEntries({
         showWarpImport: showDesktopOnlySettings,
         showSystemTray: showDesktopOnlySettings && isWindows,
-        showMenuBarIcon: showDesktopOnlySettings && isMac
+        showMenuBarIcon: showDesktopOnlySettings && isMac,
+        showWindowControlsPosition: showDesktopOnlySettings && !isMac && !isWindows
       }),
       group: 'interface'
     },

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -9,7 +9,11 @@ import {
   getWebRuntimeEnvironmentsSearchEntry
 } from '@/components/settings/runtime-environments-search'
 import { getTerminalPaneSearchEntries } from '@/components/settings/terminal-search'
-import { isMacUserAgent, isWindowsUserAgent } from '@/components/terminal-pane/pane-helpers'
+import {
+  isLinuxUserAgent,
+  isMacUserAgent,
+  isWindowsUserAgent
+} from '@/components/terminal-pane/pane-helpers'
 import { useLinearProviderConnected } from '@/hooks/useLinearProviderConnected'
 import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
 import type { SettingsNavSection } from '@/lib/settings-navigation-types'
@@ -36,6 +40,7 @@ export { isWebClientLocation } from '@/lib/web-client-location'
 export function buildSettingsNavigationMetadata({
   isMac,
   isWindows,
+  isLinux = !isMac && !isWindows,
   isLocalWindowsHost = isWindows,
   isWindowsTerminalHost = isWindows,
   isWebClient,
@@ -47,6 +52,7 @@ export function buildSettingsNavigationMetadata({
 }: {
   isMac: boolean
   isWindows: boolean
+  isLinux?: boolean
   isLocalWindowsHost?: boolean
   isWindowsTerminalHost?: boolean
   isWebClient: boolean
@@ -73,6 +79,7 @@ export function buildSettingsNavigationMetadata({
   const options: SettingsNavigationBuildOptions = {
     isMac,
     isWindows,
+    isLinux,
     isLocalWindowsHost,
     isWindowsTerminalHost,
     isWebClient,
@@ -115,6 +122,7 @@ export function useSettingsNavigationMetadata(): SettingsNavSection[] {
   )
   const isMac = isMacUserAgent()
   const isWindows = isWindowsUserAgent()
+  const isLinux = isLinuxUserAgent()
   const isWebClient = isWebClientLocation()
   const isLinearConnected = useLinearProviderConnected()
   const windowsTerminalCapabilityOwnerKey = useWindowsTerminalCapabilityOwnerKey(
@@ -152,6 +160,7 @@ export function useSettingsNavigationMetadata(): SettingsNavSection[] {
       buildSettingsNavigationMetadata({
         isMac,
         isWindows,
+        isLinux,
         isLocalWindowsHost,
         isWindowsTerminalHost,
         isWebClient,
@@ -165,6 +174,7 @@ export function useSettingsNavigationMetadata(): SettingsNavSection[] {
     [
       isMac,
       isWindows,
+      isLinux,
       isLocalWindowsHost,
       isWindowsTerminalHost,
       isWebClient,

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -134,6 +134,7 @@ export function buildDefaultSettings(args: {
     sourceControlGroupOrder: DEFAULT_SOURCE_CONTROL_GROUP_ORDER,
     sourceControlCompareAgainstUpstream: false,
     showTitlebarAppName: true,
+    windowControlsPosition: 'right',
     showTasksButton: true,
     showAutomationsButton: true,
     artifactsEnabled: true,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -36,6 +36,7 @@ import type {
   TaskViewPresetId
 } from './ui-chrome-types'
 import type { SetupScriptLaunchMode } from './worktree/launch-types'
+import type { WindowControlsPosition } from './window-controls-position'
 import type {
   CustomWorktreeVisibilitySource,
   ExternalWorktreeVisibility,
@@ -222,6 +223,11 @@ export type GlobalSettings = {
   sourceControlCompareAgainstUpstream: boolean
   /** Whether to show the Orca app name in the titlebar. */
   showTitlebarAppName: boolean
+  /**
+   * Where custom min/max/close buttons sit on Linux. Windows stays right; macOS
+   * keeps native traffic lights. Default right preserves the historical layout.
+   */
+  windowControlsPosition: WindowControlsPosition
   /** Hides the Tasks sidebar button (also removes it from keyboard navigation). */
   showTasksButton: boolean
   /** Only toggles the sidebar shortcut; Automations stay reachable from Settings/View menu. */

--- a/src/shared/window-controls-position.test.ts
+++ b/src/shared/window-controls-position.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_WINDOW_CONTROLS_POSITION,
+  normalizeWindowControlsPosition,
+  resolveWindowControlsSide
+} from './window-controls-position'
+
+describe('normalizeWindowControlsPosition', () => {
+  it('keeps left and right', () => {
+    expect(normalizeWindowControlsPosition('left')).toBe('left')
+    expect(normalizeWindowControlsPosition('right')).toBe('right')
+  })
+
+  it('falls back to the default for unknown values', () => {
+    expect(normalizeWindowControlsPosition(undefined)).toBe(DEFAULT_WINDOW_CONTROLS_POSITION)
+    expect(normalizeWindowControlsPosition('system')).toBe(DEFAULT_WINDOW_CONTROLS_POSITION)
+    expect(normalizeWindowControlsPosition(1)).toBe(DEFAULT_WINDOW_CONTROLS_POSITION)
+  })
+})
+
+describe('resolveWindowControlsSide', () => {
+  it('honors left only on Linux', () => {
+    expect(resolveWindowControlsSide({ platform: 'linux', preference: 'left' })).toBe('left')
+    expect(resolveWindowControlsSide({ platform: 'linux', preference: 'right' })).toBe('right')
+  })
+
+  it('keeps Windows and macOS on the right convention', () => {
+    expect(resolveWindowControlsSide({ platform: 'win32', preference: 'left' })).toBe('right')
+    expect(resolveWindowControlsSide({ platform: 'darwin', preference: 'left' })).toBe('right')
+  })
+})

--- a/src/shared/window-controls-position.ts
+++ b/src/shared/window-controls-position.ts
@@ -1,0 +1,20 @@
+export const WINDOW_CONTROLS_POSITIONS = ['left', 'right'] as const
+
+export type WindowControlsPosition = (typeof WINDOW_CONTROLS_POSITIONS)[number]
+
+export const DEFAULT_WINDOW_CONTROLS_POSITION: WindowControlsPosition = 'right'
+
+export function normalizeWindowControlsPosition(value: unknown): WindowControlsPosition {
+  return value === 'left' || value === 'right' ? value : DEFAULT_WINDOW_CONTROLS_POSITION
+}
+
+/** Linux custom chrome can flip sides; Windows stays right; macOS uses native traffic lights. */
+export function resolveWindowControlsSide(input: {
+  platform: NodeJS.Platform
+  preference: WindowControlsPosition | undefined
+}): WindowControlsPosition {
+  if (input.platform !== 'linux') {
+    return 'right'
+  }
+  return normalizeWindowControlsPosition(input.preference)
+}


### PR DESCRIPTION
## ELI5

On Linux, you can move the window minimize/maximize/close buttons to the left (like macOS) or keep them on the right. Default stays on the right.

## What Changed

- New setting `windowControlsPosition` (`left` | `right`, default `right`)
- Linux-only Appearance control + search entry (explicit Linux gate)
- Custom window-controls overlay, button order, and layout insets follow the chosen side
- Windows stays right; macOS keeps native traffic lights

## Why

Linux desktop conventions differ, and many users prefer macOS-style left controls. A preference keeps the current default while making left placement available without changing other platforms.

## Linked Issue

Fixes #17060

## Visual Proof

N/A for committed assets — verified locally on Linux with Settings → Appearance → Window Controls Position switching Left/Right and confirming titlebar/sidebar insets clear the cluster. Happy to attach screenshots in a follow-up comment if maintainers want them on the PR.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Platforms tested: **Linux** (Pop!_OS) via `pnpm dev`. Windows/macOS behavior is gated to remain unchanged (unit coverage for resolve/normalize + search gating).

Automated: `window-controls-position`, `app-window-chrome`, Appearance search, settings-navigation metadata tests.

## AI Disclosure

Assisted by Cursor (Composer) for implementation and review-feedback fixes.

## Review

Addressed bot review feedback:
- Test asserts against `shortcutPlatform` (UA), not `process.platform`
- Appearance search gated with explicit `isLinux` / `isLinuxUserAgent()`
- Document CSS vars effect depends on side only (no fresh-insets identity churn)
- Removed unused `data-side` / `dataset.windowControlsSide`

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Cross-platform: Linux-only UI and left resolution. SSH/remote/web client unaffected (no custom desktop chrome). Backwards compatible default (`right`).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)