### PR TITLE
feat(browser): add mobile viewport toggle shortcut

### DIFF
--- a/src/main/browser/browser-guest-shortcut-dispatch.ts
+++ b/src/main/browser/browser-guest-shortcut-dispatch.ts
@@ -138,12 +138,7 @@ export function forwardGuestShortcutInput(
     // Why: the address bar lives in renderer chrome, not the guest page; forward so the active BrowserPane can focus its input.
     renderer.send('ui:focusBrowserAddressBar')
   } else if (
-    keybindingMatchesAction(
-      'browser.toggleMobileDesktopViewport',
-      input,
-      process.platform,
-      keybindings
-    )
+    keybindingMatchesAction('browser.toggleMobileViewport', input, process.platform, keybindings)
   ) {
     renderer.send('ui:toggleBrowserViewport', browserTabId)
   } else if (keybindingMatchesAction('browser.hardReload', input, process.platform, keybindings)) {

--- a/src/main/browser/browser-guest-shortcut-dispatch.ts
+++ b/src/main/browser/browser-guest-shortcut-dispatch.ts
@@ -137,6 +137,15 @@ export function forwardGuestShortcutInput(
   ) {
     // Why: the address bar lives in renderer chrome, not the guest page; forward so the active BrowserPane can focus its input.
     renderer.send('ui:focusBrowserAddressBar')
+  } else if (
+    keybindingMatchesAction(
+      'browser.toggleMobileDesktopViewport',
+      input,
+      process.platform,
+      keybindings
+    )
+  ) {
+    renderer.send('ui:toggleBrowserViewport', browserTabId)
   } else if (keybindingMatchesAction('browser.hardReload', input, process.platform, keybindings)) {
     // Why: forward hard reload so reloadIgnoringCache() runs on the renderer's parked-webview ref that owns the guest surface.
     renderer.send('ui:hardReloadBrowserPage')

--- a/src/main/browser/browser-manager-guest-shortcuts.test.ts
+++ b/src/main/browser/browser-manager-guest-shortcuts.test.ts
@@ -336,7 +336,8 @@ describe('browserManager', () => {
     browserManager.setSettingsResolver(() => ({
       keybindings: {
         'tab.newBrowser': ['Mod+Alt+B'],
-        'worktree.quickOpen': ['Mod+Shift+O']
+        'worktree.quickOpen': ['Mod+Shift+O'],
+        'browser.toggleMobileDesktopViewport': ['Mod+Alt+V']
       }
     }))
 
@@ -411,8 +412,23 @@ describe('browserManager', () => {
     )
     expect(customQuickOpenPreventDefault).toHaveBeenCalledTimes(1)
 
+    const viewportPreventDefault = vi.fn()
+    beforeInputHandler?.(
+      { preventDefault: viewportPreventDefault },
+      {
+        type: 'keyDown',
+        code: 'KeyV',
+        key: 'v',
+        ...primary,
+        alt: true,
+        shift: false
+      }
+    )
+    expect(viewportPreventDefault).toHaveBeenCalledTimes(1)
+
     expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:newBrowserTab')
     expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:openQuickOpen')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:toggleBrowserViewport', 'browser-1')
   })
 
   it('forwards browser guest Ctrl+Tab keydown and Ctrl release', () => {

--- a/src/main/browser/browser-manager-guest-shortcuts.test.ts
+++ b/src/main/browser/browser-manager-guest-shortcuts.test.ts
@@ -337,7 +337,7 @@ describe('browserManager', () => {
       keybindings: {
         'tab.newBrowser': ['Mod+Alt+B'],
         'worktree.quickOpen': ['Mod+Shift+O'],
-        'browser.toggleMobileDesktopViewport': ['Mod+Alt+V']
+        'browser.toggleMobileViewport': ['Mod+Alt+V']
       }
     }))
 

--- a/src/preload/api/ui-command-event-api.ts
+++ b/src/preload/api/ui-command-event-api.ts
@@ -104,6 +104,7 @@ export type UiCommandEventApi = {
   onFocusBrowserAddressBar: (callback: () => void) => () => void
   onFindInBrowserPage: (source: BrowserFindSource, callback: () => void) => () => void
   onReloadBrowserPage: (callback: () => void) => () => void
+  onToggleBrowserViewport: (callback: (browserPageId: string) => void) => () => void
   onBrowserHistoryNavigate: (callback: (direction: 'back' | 'forward') => void) => () => void
   onZoomBrowserPage: (callback: (direction: 'in' | 'out' | 'reset') => void) => () => void
   onHardReloadBrowserPage: (callback: () => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4035,6 +4035,12 @@ const api = {
       ipcRenderer.on('ui:reloadBrowserPage', listener)
       return () => ipcRenderer.removeListener('ui:reloadBrowserPage', listener)
     },
+    onToggleBrowserViewport: (callback: (browserPageId: string) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, browserPageId: string): void =>
+        callback(browserPageId)
+      ipcRenderer.on('ui:toggleBrowserViewport', listener)
+      return () => ipcRenderer.removeListener('ui:toggleBrowserViewport', listener)
+    },
     onBrowserHistoryNavigate: (callback: (direction: 'back' | 'forward') => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, direction: 'back' | 'forward'): void =>
         callback(direction)

--- a/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.chrome-parity.test.tsx
+++ b/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.chrome-parity.test.tsx
@@ -80,6 +80,7 @@ beforeEach(() => {
         findRequests.subscribe(callback),
       onBrowserHistoryNavigate: historyNavigate.subscribe,
       onReloadBrowserPage: (callback: () => void) => reloadRequests.subscribe(callback),
+      onToggleBrowserViewport: () => () => {},
       onHardReloadBrowserPage: (callback: () => void) => hardReloadRequests.subscribe(callback),
       onZoomBrowserPage: zoomRequests.subscribe,
       writeClipboardText

--- a/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.tsx
+++ b/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.tsx
@@ -30,6 +30,7 @@ import { useWebviewGuestFocus } from './assemble-chrome/browser-page-guest-focus
 import { RemoteRuntimeEgressIndicator } from './assemble-chrome/browser-egress-indicator'
 import { getBrowserPageZoomIndicatorState } from './host-guest/browser-page-zoom'
 import { useBrowserPageWebviewShortcuts } from './host-guest/use-browser-page-webview-shortcuts'
+import { useBrowserPageViewportShortcut } from './host-guest/use-browser-page-viewport-shortcut'
 import { useClientHostedGuestActivationFocus } from './host-guest/use-client-hosted-guest-activation-focus'
 import { useBrowserPageZoomFeedback } from './host-guest/use-browser-page-zoom-feedback'
 import { BrowserLoadFailureOverlay } from './navigate/browser-load-failure-overlay'
@@ -151,6 +152,7 @@ export function ClientHostedBrowserPagePane({
     chromeShortcutScope,
     setFindOpen
   })
+  useBrowserPageViewportShortcut({ browserPage: browserTab, workspaceId, chromeShortcutScope })
   useBrowserPageWebviewShortcuts({
     browserTabId: browserTab.id,
     isActive,

--- a/src/renderer/src/components/browser-pane/assemble-chrome/BrowserToolbarMenu.tsx
+++ b/src/renderer/src/components/browser-pane/assemble-chrome/BrowserToolbarMenu.tsx
@@ -5,10 +5,7 @@ import { useAppStore } from '@/store'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { shouldShowBrowserImportHint } from './browser-import-hint-visibility'
 import type { BrowserViewportPresetId } from '../../../../../shared/browser-workspace-types'
-import {
-  browserViewportPresetToOverride,
-  getBrowserViewportPreset
-} from '../../../../../shared/browser-viewport-presets'
+import { applyBrowserPageViewportPreset } from '../host-guest/browser-viewport-preset-actions'
 import { BrowserToolbarMenuDropdown } from './browser-toolbar-menu-dropdown'
 import { BrowserToolbarProfileDialogs } from './browser-toolbar-profile-dialogs'
 import { translate } from '@/i18n/i18n'
@@ -38,7 +35,6 @@ export function BrowserToolbarMenu({
   const importCookiesToProfile = useAppStore((s) => s.importCookiesToProfile)
   const fetchDetectedBrowsers = useAppStore((s) => s.fetchDetectedBrowsers)
   const browserSessionImportState = useAppStore((s) => s.browserSessionImportState)
-  const setBrowserPageViewportPreset = useAppStore((s) => s.setBrowserPageViewportPreset)
   const browserCookieTourStepActive = useAppStore(
     (s) => s.activeContextualTourId === 'browser' && s.activeContextualTourStepIndex === 2
   )
@@ -53,10 +49,7 @@ export function BrowserToolbarMenu({
   const shouldForceMenuOpen = browserCookieTourStepActive && isActive && !importHintVisible
 
   const applyViewportPreset = (nextId: BrowserViewportPresetId | null): void => {
-    setBrowserPageViewportPreset(browserPageId, nextId)
-    const preset = getBrowserViewportPreset(nextId)
-    const override = preset ? browserViewportPresetToOverride(preset) : null
-    void window.api.browser.setViewportOverride({ browserPageId, override })
+    applyBrowserPageViewportPreset(browserPageId, nextId)
   }
 
   const [newProfileDialogOpen, setNewProfileDialogOpen] = useState(false)

--- a/src/renderer/src/components/browser-pane/assemble-chrome/browser-page-pane.tsx
+++ b/src/renderer/src/components/browser-pane/assemble-chrome/browser-page-pane.tsx
@@ -29,6 +29,7 @@ import { useWebviewGuestFocus } from './browser-page-guest-focus'
 import { useBrowserPageFindShortcuts } from './use-browser-page-find-shortcuts'
 import { useBrowserPageGrabAnnotations } from '../annotate/use-browser-page-grab-annotations'
 import { useBrowserPageKeyboardShortcuts } from '../host-guest/use-browser-page-keyboard-shortcuts'
+import { useBrowserPageViewportShortcut } from '../host-guest/use-browser-page-viewport-shortcut'
 import { useBrowserPageMarkupCapture } from '../annotate/use-browser-page-markup-capture'
 import { useBrowserPageNavigationDownloads } from '../navigate/use-browser-page-navigation-downloads'
 import { useBrowserPageReloadActions } from '../navigate/use-browser-page-reload-actions'
@@ -241,6 +242,7 @@ export function BrowserPagePane({
     chromeShortcutScope,
     setFindOpen
   })
+  useBrowserPageViewportShortcut({ browserPage: browserTab, workspaceId, chromeShortcutScope })
   useBrowserPageKeyboardShortcuts({
     browserTabId: browserTab.id,
     isActive,

--- a/src/renderer/src/components/browser-pane/client-hosted-browser-pane-test-rig.ts
+++ b/src/renderer/src/components/browser-pane/client-hosted-browser-pane-test-rig.ts
@@ -61,6 +61,7 @@ export function installClientHostedPaneApi(overrides?: {
         onFindInBrowserPage: inert,
         onBrowserHistoryNavigate: inert,
         onReloadBrowserPage: inert,
+        onToggleBrowserViewport: inert,
         onHardReloadBrowserPage: inert,
         onZoomBrowserPage: inert,
         getZoomLevel: () => 0,

--- a/src/renderer/src/components/browser-pane/host-guest/browser-viewport-preset-actions.test.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-viewport-preset-actions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import type { BrowserPage } from '../../../../../shared/browser-workspace-types'
+import { resolveBrowserViewportToggleTarget } from './browser-viewport-preset-actions'
+
+type Selection = Pick<
+  BrowserPage,
+  'viewportPresetId' | 'lastMobileViewportPresetId' | 'lastDesktopViewportPresetId'
+>
+
+function selection(overrides: Partial<Selection> = {}): Selection {
+  return {
+    viewportPresetId: null,
+    lastMobileViewportPresetId: null,
+    lastDesktopViewportPresetId: null,
+    ...overrides
+  }
+}
+
+describe('resolveBrowserViewportToggleTarget', () => {
+  it('uses Mobile M from the responsive viewport and Desktop from a mobile viewport', () => {
+    expect(resolveBrowserViewportToggleTarget(selection())).toBe('mobile-m')
+    expect(resolveBrowserViewportToggleTarget(selection({ viewportPresetId: 'mobile-m' }))).toBe(
+      'desktop'
+    )
+  })
+
+  it('switches in both directions using the most recently selected presets', () => {
+    expect(
+      resolveBrowserViewportToggleTarget(
+        selection({
+          viewportPresetId: 'mobile-l',
+          lastMobileViewportPresetId: 'mobile-l',
+          lastDesktopViewportPresetId: 'laptop-l'
+        })
+      )
+    ).toBe('laptop-l')
+    expect(
+      resolveBrowserViewportToggleTarget(
+        selection({
+          viewportPresetId: 'laptop-l',
+          lastMobileViewportPresetId: 'mobile-l',
+          lastDesktopViewportPresetId: 'laptop-l'
+        })
+      )
+    ).toBe('mobile-l')
+  })
+
+  it('ignores a remembered preset from the wrong viewport mode', () => {
+    expect(
+      resolveBrowserViewportToggleTarget(
+        selection({ viewportPresetId: 'desktop', lastMobileViewportPresetId: 'laptop' })
+      )
+    ).toBe('mobile-m')
+  })
+})

--- a/src/renderer/src/components/browser-pane/host-guest/browser-viewport-preset-actions.test.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-viewport-preset-actions.test.ts
@@ -4,33 +4,35 @@ import { resolveBrowserViewportToggleTarget } from './browser-viewport-preset-ac
 
 type Selection = Pick<
   BrowserPage,
-  'viewportPresetId' | 'lastMobileViewportPresetId' | 'lastDesktopViewportPresetId'
+  'viewportPresetId' | 'lastMobileViewportPresetId' | 'lastNonMobileViewportPresetId'
 >
 
 function selection(overrides: Partial<Selection> = {}): Selection {
   return {
     viewportPresetId: null,
     lastMobileViewportPresetId: null,
-    lastDesktopViewportPresetId: null,
+    lastNonMobileViewportPresetId: undefined,
     ...overrides
   }
 }
 
 describe('resolveBrowserViewportToggleTarget', () => {
-  it('uses Mobile M from the responsive viewport and Desktop from a mobile viewport', () => {
+  it('uses Mobile M from the responsive viewport and returns to the responsive viewport', () => {
     expect(resolveBrowserViewportToggleTarget(selection())).toBe('mobile-m')
-    expect(resolveBrowserViewportToggleTarget(selection({ viewportPresetId: 'mobile-m' }))).toBe(
-      'desktop'
-    )
+    expect(
+      resolveBrowserViewportToggleTarget(
+        selection({ viewportPresetId: 'mobile-m', lastNonMobileViewportPresetId: null })
+      )
+    ).toBeNull()
   })
 
-  it('switches in both directions using the most recently selected presets', () => {
+  it('switches in both directions using the most recently selected states', () => {
     expect(
       resolveBrowserViewportToggleTarget(
         selection({
           viewportPresetId: 'mobile-l',
           lastMobileViewportPresetId: 'mobile-l',
-          lastDesktopViewportPresetId: 'laptop-l'
+          lastNonMobileViewportPresetId: 'laptop-l'
         })
       )
     ).toBe('laptop-l')
@@ -39,7 +41,7 @@ describe('resolveBrowserViewportToggleTarget', () => {
         selection({
           viewportPresetId: 'laptop-l',
           lastMobileViewportPresetId: 'mobile-l',
-          lastDesktopViewportPresetId: 'laptop-l'
+          lastNonMobileViewportPresetId: 'laptop-l'
         })
       )
     ).toBe('mobile-l')
@@ -51,5 +53,10 @@ describe('resolveBrowserViewportToggleTarget', () => {
         selection({ viewportPresetId: 'desktop', lastMobileViewportPresetId: 'laptop' })
       )
     ).toBe('mobile-m')
+    expect(
+      resolveBrowserViewportToggleTarget(
+        selection({ viewportPresetId: 'mobile-m', lastNonMobileViewportPresetId: 'mobile-l' })
+      )
+    ).toBeNull()
   })
 })

--- a/src/renderer/src/components/browser-pane/host-guest/browser-viewport-preset-actions.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-viewport-preset-actions.ts
@@ -1,0 +1,50 @@
+import type {
+  BrowserPage,
+  BrowserViewportPresetId
+} from '../../../../../shared/browser-workspace-types'
+import {
+  browserViewportPresetToOverride,
+  getBrowserViewportPreset
+} from '../../../../../shared/browser-viewport-presets'
+import { useAppStore } from '@/store'
+
+export const DEFAULT_MOBILE_VIEWPORT_PRESET_ID: BrowserViewportPresetId = 'mobile-m'
+export const DEFAULT_DESKTOP_VIEWPORT_PRESET_ID: BrowserViewportPresetId = 'desktop'
+
+type BrowserViewportSelection = Pick<
+  BrowserPage,
+  'viewportPresetId' | 'lastMobileViewportPresetId' | 'lastDesktopViewportPresetId'
+>
+
+function rememberedPreset(
+  id: BrowserViewportPresetId | null | undefined,
+  mobile: boolean
+): BrowserViewportPresetId | null {
+  const preset = getBrowserViewportPreset(id)
+  return preset?.mobile === mobile ? preset.id : null
+}
+
+export function resolveBrowserViewportToggleTarget(
+  page: BrowserViewportSelection
+): BrowserViewportPresetId {
+  const current = getBrowserViewportPreset(page.viewportPresetId)
+  if (current?.mobile) {
+    return (
+      rememberedPreset(page.lastDesktopViewportPresetId, false) ??
+      DEFAULT_DESKTOP_VIEWPORT_PRESET_ID
+    )
+  }
+  return (
+    rememberedPreset(page.lastMobileViewportPresetId, true) ?? DEFAULT_MOBILE_VIEWPORT_PRESET_ID
+  )
+}
+
+export function applyBrowserPageViewportPreset(
+  browserPageId: string,
+  presetId: BrowserViewportPresetId | null
+): void {
+  useAppStore.getState().setBrowserPageViewportPreset(browserPageId, presetId)
+  const preset = getBrowserViewportPreset(presetId)
+  const override = preset ? browserViewportPresetToOverride(preset) : null
+  void window.api.browser.setViewportOverride({ browserPageId, override })
+}

--- a/src/renderer/src/components/browser-pane/host-guest/browser-viewport-preset-actions.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-viewport-preset-actions.ts
@@ -9,11 +9,10 @@ import {
 import { useAppStore } from '@/store'
 
 export const DEFAULT_MOBILE_VIEWPORT_PRESET_ID: BrowserViewportPresetId = 'mobile-m'
-export const DEFAULT_DESKTOP_VIEWPORT_PRESET_ID: BrowserViewportPresetId = 'desktop'
 
 type BrowserViewportSelection = Pick<
   BrowserPage,
-  'viewportPresetId' | 'lastMobileViewportPresetId' | 'lastDesktopViewportPresetId'
+  'viewportPresetId' | 'lastMobileViewportPresetId' | 'lastNonMobileViewportPresetId'
 >
 
 function rememberedPreset(
@@ -26,13 +25,13 @@ function rememberedPreset(
 
 export function resolveBrowserViewportToggleTarget(
   page: BrowserViewportSelection
-): BrowserViewportPresetId {
+): BrowserViewportPresetId | null {
   const current = getBrowserViewportPreset(page.viewportPresetId)
   if (current?.mobile) {
-    return (
-      rememberedPreset(page.lastDesktopViewportPresetId, false) ??
-      DEFAULT_DESKTOP_VIEWPORT_PRESET_ID
-    )
+    if (page.lastNonMobileViewportPresetId === null) {
+      return null
+    }
+    return rememberedPreset(page.lastNonMobileViewportPresetId, false)
   }
   return (
     rememberedPreset(page.lastMobileViewportPresetId, true) ?? DEFAULT_MOBILE_VIEWPORT_PRESET_ID

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-shortcut.test.tsx
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-shortcut.test.tsx
@@ -41,7 +41,7 @@ function Harness({ scope = 'focused' }: { scope?: BrowserChromeShortcutScope }):
   return <input data-browser-overlay-tab-id={page.workspaceId} data-testid="browser-input" />
 }
 
-function pressViewportChord(target: HTMLElement = window.document.body): void {
+function pressViewportChord(target: HTMLElement = window.document.body, repeat = false): void {
   act(() => {
     target.dispatchEvent(
       new KeyboardEvent('keydown', {
@@ -49,6 +49,7 @@ function pressViewportChord(target: HTMLElement = window.document.body): void {
         code: 'KeyV',
         metaKey: true,
         altKey: true,
+        repeat,
         bubbles: true,
         cancelable: true
       })
@@ -90,6 +91,14 @@ describe('useBrowserPageViewportShortcut', () => {
     pressViewportChord()
 
     expect(applyPreset).toHaveBeenCalledWith('page-1', 'mobile-l')
+  })
+
+  it('ignores auto-repeated browser chrome shortcuts', () => {
+    render(<Harness />)
+
+    pressViewportChord(window.document.body, true)
+
+    expect(applyPreset).not.toHaveBeenCalled()
   })
 
   it('does not claim the chord from a terminal or editor target in another split', () => {

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-shortcut.test.tsx
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-shortcut.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import type { BrowserPage } from '../../../../../shared/browser-workspace-types'
+import type { BrowserChromeShortcutScope } from '../describe-page/browser-page-types'
+import type * as BrowserViewportPresetActions from './browser-viewport-preset-actions'
+import { useBrowserPageViewportShortcut } from './use-browser-page-viewport-shortcut'
+
+const applyPreset = vi.hoisted(() => vi.fn())
+vi.mock('./browser-viewport-preset-actions', async (importOriginal) => ({
+  ...(await importOriginal<typeof BrowserViewportPresetActions>()),
+  applyBrowserPageViewportPreset: applyPreset
+}))
+
+const page: BrowserPage = {
+  id: 'page-1',
+  workspaceId: 'workspace-1',
+  worktreeId: 'worktree-1',
+  url: 'https://example.com',
+  title: 'Example',
+  loading: false,
+  faviconUrl: null,
+  canGoBack: false,
+  canGoForward: false,
+  loadError: null,
+  createdAt: 1,
+  viewportPresetId: 'desktop',
+  lastMobileViewportPresetId: 'mobile-l',
+  lastDesktopViewportPresetId: 'desktop'
+}
+
+let guestToggle: ((browserPageId: string) => void) | null = null
+
+function Harness({ scope = 'focused' }: { scope?: BrowserChromeShortcutScope }): React.JSX.Element {
+  useBrowserPageViewportShortcut({
+    browserPage: page,
+    workspaceId: page.workspaceId,
+    chromeShortcutScope: scope
+  })
+  return <input data-browser-overlay-tab-id={page.workspaceId} data-testid="browser-input" />
+}
+
+function pressViewportChord(target: HTMLElement = window.document.body): void {
+  act(() => {
+    target.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'v',
+        code: 'KeyV',
+        metaKey: true,
+        altKey: true,
+        bubbles: true,
+        cancelable: true
+      })
+    )
+  })
+}
+
+describe('useBrowserPageViewportShortcut', () => {
+  beforeEach(() => {
+    applyPreset.mockReset()
+    guestToggle = null
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
+    })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        ui: {
+          onToggleBrowserViewport: (callback: (browserPageId: string) => void) => {
+            guestToggle = callback
+            return () => {
+              guestToggle = null
+            }
+          }
+        }
+      }
+    })
+    useAppStore.setState({
+      keybindings: { 'browser.toggleMobileDesktopViewport': ['Mod+Alt+V'] }
+    })
+  })
+
+  afterEach(() => cleanup())
+
+  it('applies the remembered mobile preset from browser chrome', () => {
+    render(<Harness />)
+
+    pressViewportChord()
+
+    expect(applyPreset).toHaveBeenCalledWith('page-1', 'mobile-l')
+  })
+
+  it('does not claim the chord from a terminal or editor target in another split', () => {
+    render(<Harness scope="owned-target" />)
+    const terminalInput = document.createElement('textarea')
+    document.body.append(terminalInput)
+
+    pressViewportChord(terminalInput)
+    expect(applyPreset).not.toHaveBeenCalled()
+
+    pressViewportChord(document.querySelector('[data-testid="browser-input"]')!)
+    expect(applyPreset).toHaveBeenCalledWith('page-1', 'mobile-l')
+  })
+
+  it('handles a focused guest event only for its own browser page', () => {
+    render(<Harness />)
+
+    act(() => guestToggle?.('other-page'))
+    expect(applyPreset).not.toHaveBeenCalled()
+
+    act(() => guestToggle?.('page-1'))
+    expect(applyPreset).toHaveBeenCalledWith('page-1', 'mobile-l')
+  })
+})

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-shortcut.test.tsx
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-shortcut.test.tsx
@@ -27,7 +27,7 @@ const page: BrowserPage = {
   createdAt: 1,
   viewportPresetId: 'desktop',
   lastMobileViewportPresetId: 'mobile-l',
-  lastDesktopViewportPresetId: 'desktop'
+  lastNonMobileViewportPresetId: 'desktop'
 }
 
 let guestToggle: ((browserPageId: string) => void) | null = null
@@ -78,7 +78,7 @@ describe('useBrowserPageViewportShortcut', () => {
       }
     })
     useAppStore.setState({
-      keybindings: { 'browser.toggleMobileDesktopViewport': ['Mod+Alt+V'] }
+      keybindings: { 'browser.toggleMobileViewport': ['Mod+Alt+V'] }
     })
   })
 

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-shortcut.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-shortcut.ts
@@ -1,0 +1,64 @@
+import { useEffect } from 'react'
+import { getShortcutPlatform } from '@/hooks/useShortcutLabel'
+import { useAppStore } from '@/store'
+import type { BrowserPage } from '../../../../../shared/browser-workspace-types'
+import { keybindingMatchesAction } from '../../../../../shared/keybindings'
+import { browserOverlayOwnsShortcutTarget } from '../describe-page/browser-overlay-shortcut-target'
+import type { BrowserChromeShortcutScope } from '../describe-page/browser-page-types'
+import {
+  applyBrowserPageViewportPreset,
+  resolveBrowserViewportToggleTarget
+} from './browser-viewport-preset-actions'
+
+export function useBrowserPageViewportShortcut({
+  browserPage,
+  workspaceId,
+  chromeShortcutScope
+}: {
+  browserPage: BrowserPage
+  workspaceId: string
+  chromeShortcutScope: BrowserChromeShortcutScope
+}): void {
+  const keybindings = useAppStore((state) => state.keybindings)
+
+  useEffect(() => {
+    if (chromeShortcutScope === 'inactive') {
+      return
+    }
+    const shortcutPlatform = getShortcutPlatform()
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (
+        !keybindingMatchesAction(
+          'browser.toggleMobileDesktopViewport',
+          event,
+          shortcutPlatform,
+          keybindings
+        ) ||
+        (chromeShortcutScope === 'owned-target' &&
+          !browserOverlayOwnsShortcutTarget(event.target, workspaceId))
+      ) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      applyBrowserPageViewportPreset(
+        browserPage.id,
+        resolveBrowserViewportToggleTarget(browserPage)
+      )
+    }
+    window.addEventListener('keydown', handleKeyDown, true)
+    return () => window.removeEventListener('keydown', handleKeyDown, true)
+  }, [browserPage, chromeShortcutScope, keybindings, workspaceId])
+
+  useEffect(() => {
+    return window.api.ui.onToggleBrowserViewport((browserPageId) => {
+      if (browserPageId !== browserPage.id) {
+        return
+      }
+      applyBrowserPageViewportPreset(
+        browserPage.id,
+        resolveBrowserViewportToggleTarget(browserPage)
+      )
+    })
+  }, [browserPage])
+}

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-shortcut.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-shortcut.ts
@@ -29,7 +29,7 @@ export function useBrowserPageViewportShortcut({
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (
         !keybindingMatchesAction(
-          'browser.toggleMobileDesktopViewport',
+          'browser.toggleMobileViewport',
           event,
           shortcutPlatform,
           keybindings

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-shortcut.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-shortcut.ts
@@ -28,6 +28,7 @@ export function useBrowserPageViewportShortcut({
     const shortcutPlatform = getShortcutPlatform()
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (
+        event.repeat ||
         !keybindingMatchesAction(
           'browser.toggleMobileViewport',
           event,

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1905,7 +1905,7 @@ function buildMirroredBrowserTabs(
       browserRuntimeEnvironmentId: environmentId,
       viewportPresetId: existing?.page.viewportPresetId ?? null,
       lastMobileViewportPresetId: existing?.page.lastMobileViewportPresetId,
-      lastDesktopViewportPresetId: existing?.page.lastDesktopViewportPresetId
+      lastNonMobileViewportPresetId: existing?.page.lastNonMobileViewportPresetId
     }
     // Why: reuse hinges on browserPageEqual comparing workspaceId — the removed-workspace
     // page-list cleanup gates on page.workspaceId matching this entry's workspace.id.
@@ -2500,7 +2500,7 @@ function browserPageEqual(a: BrowserPage, b: BrowserPage): boolean {
     a.browserRuntimeEnvironmentId === b.browserRuntimeEnvironmentId &&
     a.viewportPresetId === b.viewportPresetId &&
     a.lastMobileViewportPresetId === b.lastMobileViewportPresetId &&
-    a.lastDesktopViewportPresetId === b.lastDesktopViewportPresetId
+    a.lastNonMobileViewportPresetId === b.lastNonMobileViewportPresetId
   )
 }
 

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1903,7 +1903,9 @@ function buildMirroredBrowserTabs(
         (tab.placement?.kind === 'client' ? existing?.page.loadError : tab.loadError) ?? null,
       createdAt,
       browserRuntimeEnvironmentId: environmentId,
-      viewportPresetId: existing?.page.viewportPresetId ?? null
+      viewportPresetId: existing?.page.viewportPresetId ?? null,
+      lastMobileViewportPresetId: existing?.page.lastMobileViewportPresetId,
+      lastDesktopViewportPresetId: existing?.page.lastDesktopViewportPresetId
     }
     // Why: reuse hinges on browserPageEqual comparing workspaceId — the removed-workspace
     // page-list cleanup gates on page.workspaceId matching this entry's workspace.id.
@@ -2496,7 +2498,9 @@ function browserPageEqual(a: BrowserPage, b: BrowserPage): boolean {
     a.loadError?.validatedUrl === b.loadError?.validatedUrl &&
     a.createdAt === b.createdAt &&
     a.browserRuntimeEnvironmentId === b.browserRuntimeEnvironmentId &&
-    a.viewportPresetId === b.viewportPresetId
+    a.viewportPresetId === b.viewportPresetId &&
+    a.lastMobileViewportPresetId === b.lastMobileViewportPresetId &&
+    a.lastDesktopViewportPresetId === b.lastDesktopViewportPresetId
   )
 }
 

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -105,6 +105,21 @@ function makeAnnotation(pageId: string, id = 'annotation-1'): BrowserPageAnnotat
 }
 
 describe('createBrowserSlice annotations', () => {
+  it('keeps the latest mobile and desktop viewport presets synchronized with menu changes', () => {
+    const store = createTestStore()
+    const tab = store.getState().createBrowserTab('wt-1', 'https://example.com')
+    const pageId = tab.activePageId!
+
+    store.getState().setBrowserPageViewportPreset(pageId, 'mobile-l')
+    store.getState().setBrowserPageViewportPreset(pageId, 'laptop-l')
+
+    expect(store.getState().browserPagesByWorkspace[tab.id]?.[0]).toMatchObject({
+      viewportPresetId: 'laptop-l',
+      lastMobileViewportPresetId: 'mobile-l',
+      lastDesktopViewportPresetId: 'laptop-l'
+    })
+  })
+
   it('announces the store-selected browser page before its guest is destroyed', () => {
     const store = createTestStore()
     const previous = store.getState().createBrowserTab('wt-1', 'https://previous.example.com')

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -105,18 +105,23 @@ function makeAnnotation(pageId: string, id = 'annotation-1'): BrowserPageAnnotat
 }
 
 describe('createBrowserSlice annotations', () => {
-  it('keeps the latest mobile and desktop viewport presets synchronized with menu changes', () => {
+  it('keeps the latest mobile preset and non-mobile state synchronized with menu changes', () => {
     const store = createTestStore()
     const tab = store.getState().createBrowserTab('wt-1', 'https://example.com')
     const pageId = tab.activePageId!
 
     store.getState().setBrowserPageViewportPreset(pageId, 'mobile-l')
-    store.getState().setBrowserPageViewportPreset(pageId, 'laptop-l')
+    expect(store.getState().browserPagesByWorkspace[tab.id]?.[0]).toMatchObject({
+      viewportPresetId: 'mobile-l',
+      lastMobileViewportPresetId: 'mobile-l',
+      lastNonMobileViewportPresetId: null
+    })
 
+    store.getState().setBrowserPageViewportPreset(pageId, 'laptop-l')
     expect(store.getState().browserPagesByWorkspace[tab.id]?.[0]).toMatchObject({
       viewportPresetId: 'laptop-l',
       lastMobileViewportPresetId: 'mobile-l',
-      lastDesktopViewportPresetId: 'laptop-l'
+      lastNonMobileViewportPresetId: 'laptop-l'
     })
   })
 

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -76,6 +76,7 @@ import type {
 } from '../../../../shared/runtime-types'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { translate } from '@/i18n/i18n'
+import { getBrowserViewportPreset } from '../../../../shared/browser-viewport-presets'
 import {
   getSettingsFocusedExecutionHostId,
   LOCAL_EXECUTION_HOST_ID,
@@ -1821,8 +1822,22 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       if (!workspace) {
         return s
       }
+      const currentPreset = getBrowserViewportPreset(page.viewportPresetId)
+      const nextPreset = getBrowserViewportPreset(viewportPresetId)
+      const rememberedPresets = {
+        ...(currentPreset?.mobile
+          ? { lastMobileViewportPresetId: currentPreset.id }
+          : currentPreset
+            ? { lastDesktopViewportPresetId: currentPreset.id }
+            : {}),
+        ...(nextPreset?.mobile
+          ? { lastMobileViewportPresetId: nextPreset.id }
+          : nextPreset
+            ? { lastDesktopViewportPresetId: nextPreset.id }
+            : {})
+      }
       const nextPages = (s.browserPagesByWorkspace[workspace.id] ?? []).map((entry) =>
-        entry.id === pageId ? { ...entry, viewportPresetId } : entry
+        entry.id === pageId ? { ...entry, ...rememberedPresets, viewportPresetId } : entry
       )
       return {
         browserPagesByWorkspace: {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -1827,14 +1827,10 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       const rememberedPresets = {
         ...(currentPreset?.mobile
           ? { lastMobileViewportPresetId: currentPreset.id }
-          : currentPreset
-            ? { lastDesktopViewportPresetId: currentPreset.id }
-            : {}),
+          : { lastNonMobileViewportPresetId: currentPreset?.id ?? null }),
         ...(nextPreset?.mobile
           ? { lastMobileViewportPresetId: nextPreset.id }
-          : nextPreset
-            ? { lastDesktopViewportPresetId: nextPreset.id }
-            : {})
+          : { lastNonMobileViewportPresetId: nextPreset?.id ?? null })
       }
       const nextPages = (s.browserPagesByWorkspace[workspace.id] ?? []).map((entry) =>
         entry.id === pageId ? { ...entry, ...rememberedPresets, viewportPresetId } : entry

--- a/src/renderer/src/web/preload-api/web-ui-api.ts
+++ b/src/renderer/src/web/preload-api/web-ui-api.ts
@@ -190,6 +190,7 @@ export function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     onFocusBrowserAddressBar: () => noopUnsubscribe,
     onFindInBrowserPage: () => noopUnsubscribe,
     onReloadBrowserPage: () => noopUnsubscribe,
+    onToggleBrowserViewport: () => noopUnsubscribe,
     onBrowserHistoryNavigate: () => noopUnsubscribe,
     onZoomBrowserPage: () => noopUnsubscribe,
     onHardReloadBrowserPage: () => noopUnsubscribe,

--- a/src/shared/browser-workspace-types.ts
+++ b/src/shared/browser-workspace-types.ts
@@ -102,9 +102,9 @@ export type BrowserPage = {
   remoteBrowserPageClientHosted?: boolean
   /** Active CDP viewport emulation preset. null = default (fill pane, no CDP override) */
   viewportPresetId?: BrowserViewportPresetId | null
-  /** Most recent presets in each mode, retained so the keyboard toggle can return to them. */
+  /** Most recent mobile preset and non-mobile state retained for viewport toggling. */
   lastMobileViewportPresetId?: BrowserViewportPresetId | null
-  lastDesktopViewportPresetId?: BrowserViewportPresetId | null
+  lastNonMobileViewportPresetId?: BrowserViewportPresetId | null
   /** Set on a page that shows a workspace document; absent on every page that shows a URL. */
   docLocation?: BrowserPageDocLocation | null
   /** Set on a page the address bar converted from the other kind; absent everywhere else. */

--- a/src/shared/browser-workspace-types.ts
+++ b/src/shared/browser-workspace-types.ts
@@ -102,6 +102,9 @@ export type BrowserPage = {
   remoteBrowserPageClientHosted?: boolean
   /** Active CDP viewport emulation preset. null = default (fill pane, no CDP override) */
   viewportPresetId?: BrowserViewportPresetId | null
+  /** Most recent presets in each mode, retained so the keyboard toggle can return to them. */
+  lastMobileViewportPresetId?: BrowserViewportPresetId | null
+  lastDesktopViewportPresetId?: BrowserViewportPresetId | null
   /** Set on a page that shows a workspace document; absent on every page that shows a URL. */
   docLocation?: BrowserPageDocLocation | null
   /** Set on a page the address bar converted from the other kind; absent everywhere else. */

--- a/src/shared/keybindings-unassigned-actions.test.ts
+++ b/src/shared/keybindings-unassigned-actions.test.ts
@@ -8,6 +8,25 @@ import {
 import type { KeybindingActionId, KeybindingPlatform } from './keybindings'
 
 describe('keybindings', () => {
+  it('keeps browser viewport toggling unassigned on every platform', () => {
+    const platforms: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
+    for (const platform of platforms) {
+      expect(
+        getEffectiveKeybindingsForAction('browser.toggleMobileDesktopViewport', platform)
+      ).toEqual([])
+    }
+
+    const definition = getKeybindingDefinition('browser.toggleMobileDesktopViewport')
+    expect(definition).toMatchObject({
+      title: 'Toggle Mobile/Desktop Viewport',
+      group: 'Browser',
+      scope: 'browser'
+    })
+    expect(definition?.searchKeywords).toEqual(
+      expect.arrayContaining(['viewport', 'mobile', 'desktop', 'responsive', 'toggle'])
+    )
+  })
+
   it('keeps equalize pane sizes unassigned until users customize it', () => {
     expect(getEffectiveKeybindingsForAction('terminal.equalizePaneSizes', 'darwin')).toEqual([])
     expect(

--- a/src/shared/keybindings-unassigned-actions.test.ts
+++ b/src/shared/keybindings-unassigned-actions.test.ts
@@ -11,14 +11,12 @@ describe('keybindings', () => {
   it('keeps browser viewport toggling unassigned on every platform', () => {
     const platforms: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
     for (const platform of platforms) {
-      expect(
-        getEffectiveKeybindingsForAction('browser.toggleMobileDesktopViewport', platform)
-      ).toEqual([])
+      expect(getEffectiveKeybindingsForAction('browser.toggleMobileViewport', platform)).toEqual([])
     }
 
-    const definition = getKeybindingDefinition('browser.toggleMobileDesktopViewport')
+    const definition = getKeybindingDefinition('browser.toggleMobileViewport')
     expect(definition).toMatchObject({
-      title: 'Toggle Mobile/Desktop Viewport',
+      title: 'Toggle Mobile Viewport',
       group: 'Browser',
       scope: 'browser'
     })

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -84,7 +84,7 @@ export type KeybindingActionId =
   | 'browser.reload'
   | 'browser.hardReload'
   | 'browser.focusAddressBar'
-  | 'browser.toggleMobileDesktopViewport'
+  | 'browser.toggleMobileViewport'
   | 'browser.grabElement'
   | 'editor.find'
   | 'editor.replace'
@@ -798,8 +798,8 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     defaultBindings: platformBindings(['Mod+L'])
   },
   {
-    id: 'browser.toggleMobileDesktopViewport',
-    title: 'Toggle Mobile/Desktop Viewport',
+    id: 'browser.toggleMobileViewport',
+    title: 'Toggle Mobile Viewport',
     group: 'Browser',
     scope: 'browser',
     searchKeywords: [

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -84,6 +84,7 @@ export type KeybindingActionId =
   | 'browser.reload'
   | 'browser.hardReload'
   | 'browser.focusAddressBar'
+  | 'browser.toggleMobileDesktopViewport'
   | 'browser.grabElement'
   | 'editor.find'
   | 'editor.replace'
@@ -795,6 +796,22 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'browser',
     searchKeywords: ['shortcut', 'browser', 'address', 'url', 'location'],
     defaultBindings: platformBindings(['Mod+L'])
+  },
+  {
+    id: 'browser.toggleMobileDesktopViewport',
+    title: 'Toggle Mobile/Desktop Viewport',
+    group: 'Browser',
+    scope: 'browser',
+    searchKeywords: [
+      'shortcut',
+      'browser',
+      'viewport',
+      'mobile',
+      'desktop',
+      'responsive',
+      'toggle'
+    ],
+    defaultBindings: platformBindings([])
   },
   {
     id: 'browser.grabElement',

--- a/src/shared/workspace-session-browser-schema.ts
+++ b/src/shared/workspace-session-browser-schema.ts
@@ -101,6 +101,8 @@ export const browserPageSchema = z.object({
   // added still validate; without this, zod would strip the field during
   // restore and reset the user's chosen preset on every app restart.
   viewportPresetId: browserViewportPresetIdSchema.nullable().optional(),
+  lastMobileViewportPresetId: browserViewportPresetIdSchema.nullable().optional(),
+  lastDesktopViewportPresetId: browserViewportPresetIdSchema.nullable().optional(),
   // Why listed here and not just typed: z.object strips what it does not name, so an unlisted
   // docLocation restores a workspace document as a blank New Tab — the page keeps its blank url
   // and loses the only field that said which document it was.

--- a/src/shared/workspace-session-browser-schema.ts
+++ b/src/shared/workspace-session-browser-schema.ts
@@ -102,7 +102,7 @@ export const browserPageSchema = z.object({
   // restore and reset the user's chosen preset on every app restart.
   viewportPresetId: browserViewportPresetIdSchema.nullable().optional(),
   lastMobileViewportPresetId: browserViewportPresetIdSchema.nullable().optional(),
-  lastDesktopViewportPresetId: browserViewportPresetIdSchema.nullable().optional(),
+  lastNonMobileViewportPresetId: browserViewportPresetIdSchema.nullable().optional(),
   // Why listed here and not just typed: z.object strips what it does not name, so an unlisted
   // docLocation restores a workspace document as a blank New Tab — the page keeps its blank url
   // and loses the only field that said which document it was.


### PR DESCRIPTION
## ELI5

Adds a remappable browser shortcut that temporarily switches the current page to a mobile viewport. Triggering it again returns to the viewport used before switching.

## What Changed

- Added an unassigned **Toggle Mobile Viewport** action under Browser shortcuts.
- Toggles between the current non-mobile viewport and the last selected mobile preset.
- Returns to the normal responsive pane size when that was the starting state.
- Returns to an explicit Laptop/Desktop preset when that was the starting state.
- Uses Mobile M as the initial mobile preset and remembers later mobile selections.
- Handles shortcuts while either browser chrome or the browser guest is focused.
- Supports client-hosted browser pages.
- Persists the remembered viewport state across session restoration.

## Why

Responsive testing currently requires opening the viewport menu and selecting presets with the mouse, or running `orca viewport` from a terminal.

A remappable toggle keeps the workflow in the browser pane while preserving the user’s previous viewport rather than always forcing the Desktop preset.

## Linked Issue

Fixes #17404

## Visual Proof

https://github.com/user-attachments/assets/34da5c8a-1b30-4098-953c-df6667b6be2a

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Verified with:

- Targeted Vitest suites covering viewport selection, browser guest dispatch, client-hosted browser behavior, state synchronization, and keybinding registration
- `pnpm tc`
- `pnpm run check:code-quality:changed`
- `git diff --check`

## AI Disclosure

GPT 5.6 Sol was used for implementation.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

The action is unbound by default, so it does not claim an additional platform shortcut.

The viewport state fields are optional, preserving compatibility with sessions and remote clients that do not yet provide them.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after video attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and shortcut impact considered
- [x] Full `pnpm lint`, `pnpm test`, and `pnpm build` pass; targeted checks and typecheck pass
