### PR TITLE
Revert waiting for setup before agent startup

### DIFF
--- a/orca.yaml
+++ b/orca.yaml
@@ -1,4 +1,3 @@
-setupAgentStartupPolicy: wait-for-setup
 scripts:
   setup: |
     node config/scripts/run-internal-dev-setup.mjs


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | 0 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 |

<!-- /orca-pr-loc -->

Reverts the setupAgentStartupPolicy wait-for-setup setting from #17124 so agent startup is not delayed by setup.