### PR TITLE
docs: clarify worktree selection for reused terminals

### DIFF
--- a/src/cli/specs/orchestration-worker-specs.ts
+++ b/src/cli/specs/orchestration-worker-specs.ts
@@ -29,6 +29,7 @@ export const ORCHESTRATION_WORKER_COMMAND_SPECS: CommandSpec[] = [
     ],
     notes: [
       'Current and existing worktrees never rerun setup; a fresh agent terminal is created unless --terminal is explicit.',
+      'When reusing --terminal, pass --worktree for that terminal; current means the coordinator worktree.',
       '--model supports Claude, Codex, and Cursor opaque provider model ids; --effort requires --model. Neither can combine with --terminal.',
       'New worktrees use agent-first creation and default --setup to run. Repository start-immediately runs setup beside the agent; wait-for-setup gates agent readiness and task input.',
       'Creation flags (--name, --repo, --base-branch, --display-name, --comment, --setup) are rejected for current/existing worktrees. Use exact --repo on the selected server; project/host convenience routing remains on worktree create.',


### PR DESCRIPTION
## Summary

Clarifies that `worker-start --terminal` validates the terminal against `--worktree`, and that `current` means the coordinator worktree.

This is the smallest documentation follow-up for the recovery confusion described in #16529. It does not change runtime behavior.

## Validation

- `git diff --check` passed.
- Focused tests were not run: this host does not have `pnpm` installed.