### PR TITLE
fix(worktree): gate agent activation on the live surface census, not renderer state (STA-5701)

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -598,7 +598,8 @@ import {
   getRepoIdFromWorktreeId,
   splitWorktreeId,
   splitWorktreeIdForFilesystem,
-  worktreeIdComparisonKey
+  worktreeIdComparisonKey,
+  worktreeIdsEqual
 } from '../../shared/worktree/id'
 import { getProjectIdForProviderIdentity } from '../../shared/project-host-setup-projection'
 import {
@@ -4767,7 +4768,7 @@ export class OrcaRuntimeService {
         const record = state.next.sleepingAgentSessionsByPaneKey?.[blocked.paneKey]
         if (
           !record ||
-          !runtimeWorktreeIdsEqual(record.worktreeId, blocked.worktreeId) ||
+          !worktreeIdsEqual(record.worktreeId, blocked.worktreeId) ||
           record.automaticResumeBlockedBy === 'legacy-orchestration-worker'
         ) {
           continue
@@ -4861,7 +4862,7 @@ export class OrcaRuntimeService {
       pty.incarnationId !== expected.incarnationId ||
       pty.tabId !== expected.tabId ||
       pty.paneKey !== makePaneKey(expected.tabId, expected.leafId) ||
-      !runtimeWorktreeIdsEqual(pty.worktreeId, expected.worktreeId) ||
+      !worktreeIdsEqual(pty.worktreeId, expected.worktreeId) ||
       this.handleByPtyId.get(expected.ptyId) !== expected.terminalHandle
     ) {
       return false
@@ -4870,11 +4871,11 @@ export class OrcaRuntimeService {
     const leaf = this.leaves.get(this.getLeafKey(expected.tabId, expected.leafId))
     const ptyLeaves = this.getLeavesForPty(expected.ptyId)
     return (
-      Boolean(tab && runtimeWorktreeIdsEqual(tab.worktreeId, expected.worktreeId)) &&
+      Boolean(tab && worktreeIdsEqual(tab.worktreeId, expected.worktreeId)) &&
       Boolean(
         leaf &&
         leaf.ptyId === expected.ptyId &&
-        runtimeWorktreeIdsEqual(leaf.worktreeId, expected.worktreeId)
+        worktreeIdsEqual(leaf.worktreeId, expected.worktreeId)
       ) &&
       ptyLeaves.length === 1 &&
       ptyLeaves[0]?.tabId === expected.tabId &&
@@ -4941,7 +4942,7 @@ export class OrcaRuntimeService {
               })
             : session
         const record = next.sleepingAgentSessionsByPaneKey?.[candidate.paneKey]
-        if (record && runtimeWorktreeIdsEqual(record.worktreeId, candidate.worktreeId)) {
+        if (record && worktreeIdsEqual(record.worktreeId, candidate.worktreeId)) {
           const sleepingAgentSessionsByPaneKey = { ...next.sleepingAgentSessionsByPaneKey }
           delete sleepingAgentSessionsByPaneKey[candidate.paneKey]
           next = { ...next, sleepingAgentSessionsByPaneKey }
@@ -5019,7 +5020,7 @@ export class OrcaRuntimeService {
     const pty = this.ptysById.get(candidate.ptyId)
     if (
       leaf?.ptyId === candidate.ptyId &&
-      runtimeWorktreeIdsEqual(leaf.worktreeId, candidate.worktreeId)
+      worktreeIdsEqual(leaf.worktreeId, candidate.worktreeId)
     ) {
       this.leaves.delete(leafKey)
       const surfaceHandle = this.handleByLeafKey.get(leafKey)
@@ -5308,7 +5309,7 @@ export class OrcaRuntimeService {
               const identity = reveal?.identity
               if (
                 !identity ||
-                !runtimeWorktreeIdsEqual(identity.worktreeId, candidate.worktreeId) ||
+                !worktreeIdsEqual(identity.worktreeId, candidate.worktreeId) ||
                 identity.tabId !== candidate.tabId ||
                 identity.leafId !== candidate.leafId ||
                 identity.ptyId !== candidate.ptyId
@@ -6851,7 +6852,7 @@ export class OrcaRuntimeService {
     resolution: NativeChatLaunchDraftResolutionTombstone
   ): void {
     for (const [worktreeId, snapshot] of this.mobileSessionTabsByWorktree) {
-      if (!runtimeWorktreeIdsEqual(worktreeId, resolution.worktreeId)) {
+      if (!worktreeIdsEqual(worktreeId, resolution.worktreeId)) {
         continue
       }
       const next = this.applyNativeChatLaunchDraftResolutionFence(snapshot)
@@ -6878,7 +6879,7 @@ export class OrcaRuntimeService {
       const resolution = this.nativeChatLaunchDraftResolutionByTabId.get(tab.parentTabId)
       if (
         !resolution ||
-        !runtimeWorktreeIdsEqual(snapshot.worktree, resolution.worktreeId) ||
+        !worktreeIdsEqual(snapshot.worktree, resolution.worktreeId) ||
         tab.launchDraft !== resolution.text ||
         tab.launchDraftCreatedAt !== resolution.createdAt
       ) {
@@ -6897,7 +6898,7 @@ export class OrcaRuntimeService {
     snapshot: RuntimeMobileSessionTabsSnapshot
   ): void {
     for (const [tabId, resolution] of this.nativeChatLaunchDraftResolutionByTabId) {
-      if (!runtimeWorktreeIdsEqual(snapshot.worktree, resolution.worktreeId)) {
+      if (!worktreeIdsEqual(snapshot.worktree, resolution.worktreeId)) {
         continue
       }
       const surfaces = snapshot.tabs.filter(
@@ -9760,9 +9761,7 @@ export class OrcaRuntimeService {
     // Why: 'live'/'quit' captures describe a pane that was still running, so a reconnect
     // must still mint its replacement PTY (#11542). Only a worktree-owned capture records
     // a deliberate takedown the user did not ask to undo.
-    return (
-      record?.origin === 'worktree-sleep' && runtimeWorktreeIdsEqual(record.worktreeId, worktreeId)
-    )
+    return record?.origin === 'worktree-sleep' && worktreeIdsEqual(record.worktreeId, worktreeId)
   }
 
   private shouldMaterializeHeadlessMobileSessionTab(
@@ -11602,10 +11601,7 @@ export class OrcaRuntimeService {
             `id:${record.location.workspaceId}`
           )
           const baseNamespace = this.getAgentSessionExecutionNamespace(workspace, provider)
-          if (
-            !baseNamespace ||
-            !runtimeWorktreeIdsEqual(workspace.id, record.location.workspaceId)
-          ) {
+          if (!baseNamespace || !worktreeIdsEqual(workspace.id, record.location.workspaceId)) {
             throw new Error('agent_session_identity_required')
           }
           const claim = this.agentSessionClaimSigner.createClaim({
@@ -11654,7 +11650,7 @@ export class OrcaRuntimeService {
                   },
                   persisted
                 },
-                runtimeWorktreeIdsEqual
+                worktreeIdsEqual
               )
               return { pty, owner, persisted, evaluation }
             })
@@ -19556,7 +19552,7 @@ export class OrcaRuntimeService {
         throw new Error('terminal_orphan_stale')
       }
       if (
-        !runtimeWorktreeIdsEqual(pty.worktreeId, workspace.id) ||
+        !worktreeIdsEqual(pty.worktreeId, workspace.id) ||
         !terminalOrphanExecutionOwnersEqual(
           { connectionId: worktreeConnectionId, wslDistro: worktreeWslDistro },
           {
@@ -19575,7 +19571,7 @@ export class OrcaRuntimeService {
       if (
         visualOwners.some(
           (owner) =>
-            !runtimeWorktreeIdsEqual(owner.worktreeId, workspace.id) ||
+            !worktreeIdsEqual(owner.worktreeId, workspace.id) ||
             owner.tabId !== claim.tabId ||
             owner.leafId !== claim.leafId
         )
@@ -19624,7 +19620,7 @@ export class OrcaRuntimeService {
       const binding = persistedBinding(claim.ptyId)
       return (
         binding !== null &&
-        runtimeWorktreeIdsEqual(binding.worktreeId, workspace.id) &&
+        worktreeIdsEqual(binding.worktreeId, workspace.id) &&
         binding.paneKey === paneKey &&
         session.terminalPtyIncarnationsByPaneKey?.[paneKey] === claim.incarnationId
       )
@@ -19717,7 +19713,7 @@ export class OrcaRuntimeService {
       const existingBinding = persistedBinding(claim.ptyId)
       if (
         existingBinding &&
-        (!runtimeWorktreeIdsEqual(existingBinding.worktreeId, workspace.id) ||
+        (!worktreeIdsEqual(existingBinding.worktreeId, workspace.id) ||
           existingBinding.paneKey !== paneKey)
       ) {
         throw new Error('terminal_orphan_competing_owner')
@@ -19730,15 +19726,14 @@ export class OrcaRuntimeService {
       const graphOwner = this.leaves.get(this.getLeafKey(claim.tabId, claim.leafId))
       if (
         graphOwner &&
-        (graphOwner.ptyId !== claim.ptyId ||
-          !runtimeWorktreeIdsEqual(graphOwner.worktreeId, workspace.id))
+        (graphOwner.ptyId !== claim.ptyId || !worktreeIdsEqual(graphOwner.worktreeId, workspace.id))
       ) {
         throw new Error('terminal_orphan_surface_occupied')
       }
       if (
         Object.entries(session.tabsByWorktree).some(
           ([ownerWorktreeId, tabs]) =>
-            !runtimeWorktreeIdsEqual(ownerWorktreeId, workspace.id) &&
+            !worktreeIdsEqual(ownerWorktreeId, workspace.id) &&
             tabs.some((tab) => tab.id === claim.tabId)
         )
       ) {
@@ -22376,7 +22371,7 @@ export class OrcaRuntimeService {
       if (
         freshPtyLiveness !== null &&
         freshPtyOwner?.connected &&
-        !runtimeWorktreeIdsEqual(freshPtyOwner.worktreeId, leaf.worktreeId)
+        !worktreeIdsEqual(freshPtyOwner.worktreeId, leaf.worktreeId)
       ) {
         // Why: provider/persisted ownership is fresher than a renderer leaf left behind by graph migration or another client.
         continue
@@ -31658,7 +31653,7 @@ export class OrcaRuntimeService {
       if (
         !pty?.connected ||
         !pty.tabId ||
-        (worktreeId !== null && !runtimeWorktreeIdsEqual(pty.worktreeId, worktreeId))
+        (worktreeId !== null && !worktreeIdsEqual(pty.worktreeId, worktreeId))
       ) {
         continue
       }
@@ -32559,7 +32554,7 @@ export class OrcaRuntimeService {
     const sessionWorktreeId = session ? resolveTerminalSessionWorktreeId(session, worktreeId) : null
     const persistedTab = sessionWorktreeId
       ? session?.tabsByWorktree[sessionWorktreeId]?.find(
-          (tab) => tab.id === tabId && runtimeWorktreeIdsEqual(tab.worktreeId, worktreeId)
+          (tab) => tab.id === tabId && worktreeIdsEqual(tab.worktreeId, worktreeId)
         )
       : undefined
     const persistedLayout = session?.terminalLayoutsByTabId?.[tabId]
@@ -32583,8 +32578,8 @@ export class OrcaRuntimeService {
     const rendererMounted = Boolean(
       rendererTab &&
       rendererLeaf &&
-      runtimeWorktreeIdsEqual(rendererTab.worktreeId, worktreeId) &&
-      runtimeWorktreeIdsEqual(rendererLeaf.worktreeId, worktreeId) &&
+      worktreeIdsEqual(rendererTab.worktreeId, worktreeId) &&
+      worktreeIdsEqual(rendererLeaf.worktreeId, worktreeId) &&
       rendererLeaf.ptyId === ptyId
     )
     if (persisted && persistedLayout) {
@@ -32599,7 +32594,7 @@ export class OrcaRuntimeService {
     // Why: renderer adoption can precede graph sync; this path still requires reveal success before commit.
     const projected = [...this.mobileSessionTabsByWorktree.entries()].some(
       ([candidateWorktreeId, snapshot]) =>
-        runtimeWorktreeIdsEqual(candidateWorktreeId, worktreeId) &&
+        worktreeIdsEqual(candidateWorktreeId, worktreeId) &&
         snapshot.tabs.some(
           (tab) =>
             tab.type === 'terminal' &&
@@ -32733,7 +32728,7 @@ export class OrcaRuntimeService {
     // Preserve folder-instance suffixes while normalizing cross-platform path spelling.
     const ownsWorktree = options.resolvedWorktreeId
       ? (candidate: string | undefined): boolean =>
-          candidate ? runtimeWorktreeIdsEqual(candidate, worktree.id) : false
+          candidate ? worktreeIdsEqual(candidate, worktree.id) : false
       : (candidate: string | undefined): boolean => candidate === worktree.id
     const ownsHost = (ptyId: string, connectionId?: string | null): boolean => {
       if (options.resolvedRuntimeEnvironmentId !== undefined) {
@@ -33252,7 +33247,7 @@ export class OrcaRuntimeService {
     const ptyIds = new Set<string>()
     for (const leaf of this.leaves.values()) {
       if (
-        runtimeWorktreeIdsEqual(leaf.worktreeId, worktreeId) &&
+        worktreeIdsEqual(leaf.worktreeId, worktreeId) &&
         leaf.connected &&
         leaf.ptyId &&
         (!freshPtyIds || freshPtyIds.has(leaf.ptyId))
@@ -33262,7 +33257,7 @@ export class OrcaRuntimeService {
     }
     for (const pty of this.ptysById.values()) {
       if (
-        runtimeWorktreeIdsEqual(pty.worktreeId, worktreeId) &&
+        worktreeIdsEqual(pty.worktreeId, worktreeId) &&
         pty.connected &&
         (!freshPtyIds || freshPtyIds.has(pty.ptyId))
       ) {
@@ -35138,7 +35133,7 @@ export class OrcaRuntimeService {
         !providerWorktree &&
         Boolean(persistedWorktree) &&
         Boolean(inferredWorktreeId) &&
-        runtimeWorktreeIdsEqual(session.worktreeId as string, inferredWorktreeId as string)
+        worktreeIdsEqual(session.worktreeId as string, inferredWorktreeId as string)
       // Why: an unresolved explicit provider owner remains authoritative unless the session id proves it was frozen before a persisted rename migration.
       const worktreeId = providerWorktree
         ? providerWorktree.id
@@ -35154,25 +35149,19 @@ export class OrcaRuntimeService {
         session.incarnationId &&
         persistedSurface.incarnationId === session.incarnationId &&
         Boolean(worktreeId) &&
-        runtimeWorktreeIdsEqual(persistedSurface.worktreeId, worktreeId as string)
+        worktreeIdsEqual(persistedSurface.worktreeId, worktreeId as string)
       this.adoptControllerTerminalHandle(
         session.id,
         controllerIdentity?.handle ?? session.terminalHandle,
         controllerIdentity?.incarnationId ?? session.incarnationId,
         { exactRestoredSurface: Boolean(restoresExactSurface && controllerIdentity) }
       )
-      if (
-        !targetWorktreeId ||
-        (worktreeId && runtimeWorktreeIdsEqual(worktreeId, targetWorktreeId))
-      ) {
+      if (!targetWorktreeId || (worktreeId && worktreeIdsEqual(worktreeId, targetWorktreeId))) {
         selectedLivePtyIds.add(session.id)
       }
-      if (
-        targetWorktreeId &&
-        (!worktreeId || !runtimeWorktreeIdsEqual(worktreeId, targetWorktreeId))
-      ) {
+      if (targetWorktreeId && (!worktreeId || !worktreeIdsEqual(worktreeId, targetWorktreeId))) {
         const receipt = this.restoredOrchestrationAuthorityByPtyId.get(session.id)
-        if (receipt && runtimeWorktreeIdsEqual(receipt.worktreeId, targetWorktreeId)) {
+        if (receipt && worktreeIdsEqual(receipt.worktreeId, targetWorktreeId)) {
           this.restoredOrchestrationAuthorityByPtyId.delete(session.id)
         }
         continue
@@ -35226,7 +35215,7 @@ export class OrcaRuntimeService {
           allLivePtyIds.add(pty.ptyId)
           if (
             !targetWorktreeId ||
-            (pty.worktreeId && runtimeWorktreeIdsEqual(pty.worktreeId, targetWorktreeId))
+            (pty.worktreeId && worktreeIdsEqual(pty.worktreeId, targetWorktreeId))
           ) {
             selectedLivePtyIds.add(pty.ptyId)
           }
@@ -37087,7 +37076,7 @@ export class OrcaRuntimeService {
       legacyActiveRun &&
       handleWorktreeId &&
       legacyCoordinatorWorktreeId &&
-      runtimeWorktreeIdsEqual(legacyCoordinatorWorktreeId, handleWorktreeId)
+      worktreeIdsEqual(legacyCoordinatorWorktreeId, handleWorktreeId)
         ? legacyActiveRun
         : undefined
     const coordinatorHandle = runCoordinatorHandle ?? scopedLegacyActiveRun?.coordinator_handle
@@ -43184,18 +43173,6 @@ function runtimePathsEqual(left: string, right: string): boolean {
   return normalizeRuntimePathForComparison(left) === normalizeRuntimePathForComparison(right)
 }
 
-/**
- * Why: runtime identity is per *workspace*, not per checkout dir. Folder projects back
- * several independent workspaces with one directory, separated only by the
- * `::workspace:<uuid>` suffix that filesystem callers must strip; stripping it here
- * instead lets one session steal a sibling's PTYs. Normalize only path spelling, so
- * Windows/WSL/SSH ids still match themselves across hosts.
- */
-function runtimeWorktreeIdsEqual(left: string, right: string): boolean {
-  const leftKey = worktreeIdComparisonKey(left)
-  return leftKey === null ? left === right : leftKey === worktreeIdComparisonKey(right)
-}
-
 function runtimeWorktreeIdentityKey(worktreeId: string): string {
   // Same suffix rule: this keys PTY refresh, sleep, and mutation-queue state per session.
   const parsed = splitWorktreeId(worktreeId)
@@ -43252,7 +43229,7 @@ function resolveTerminalSessionWorktreeId(
     ...Object.keys(session.activeGroupIdByWorktree ?? {})
   ])
   const matches = [...keyedWorktreeIds].filter((worktreeId) =>
-    runtimeWorktreeIdsEqual(worktreeId, targetWorktreeId)
+    worktreeIdsEqual(worktreeId, targetWorktreeId)
   )
   return matches.length > 1 ? null : (matches[0] ?? targetWorktreeId)
 }

--- a/src/main/runtime/terminal-list-execution-host-scope.test.ts
+++ b/src/main/runtime/terminal-list-execution-host-scope.test.ts
@@ -366,6 +366,35 @@ describe('listTerminals scope declaration', () => {
     expect(result.hostScope?.omittedHostIds).toEqual(['local', 'ssh:box-1'])
   })
 
+  // The renderer's surface census can read an empty scope on a plain local machine, not
+  // only on a degraded host: a superseded inventory answers for no host at all.
+  it('reports an empty scope when a concurrent inventory refresh supersedes this one', async () => {
+    const runtime = makeRuntime([])
+    const releases: (() => void)[] = []
+    runtime.setPtyController({
+      spawn: vi.fn(async () => ({ id: 'never' })),
+      write: () => true,
+      kill: () => true,
+      listProcesses: vi.fn(async () => []),
+      listProcessesWithHostScope: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            releases.push(() => resolve({ processes: [], hostIds: ['local'] }))
+          })
+      )
+    } as never)
+
+    const superseded = runtime.listTerminals(`id:${LOCAL_WORKTREE_ID}`)
+    await vi.waitFor(() => expect(releases).toHaveLength(1))
+    const current = runtime.listTerminals(`id:${LOCAL_WORKTREE_ID}`)
+    await vi.waitFor(() => expect(releases).toHaveLength(2))
+    releases[1]!()
+    releases[0]!()
+
+    expect((await superseded).hostScope?.hostIds).toEqual([])
+    expect((await current).hostScope?.hostIds).toEqual(['local'])
+  })
+
   it('reports the hosts a worktree-scoped listing skipped, so an empty result is not absolute', async () => {
     const runtime = makeRuntime([
       { worktreeId: SSH_WORKTREE_ID, leafId: SSH_LEAF_ID, ptyId: 'ssh:box-1@@pty-7' }

--- a/src/renderer/src/lib/worktree-agent-activation-gate.test.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-gate.test.ts
@@ -3,14 +3,17 @@ import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-r
 import { structuredAgentSessionTabId } from '../../../shared/structured-agent-session-projection'
 import type { PtyListedSession } from '../../../shared/pty-listed-session'
 import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
-import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
+import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
 import type { TerminalSlice } from '@/store/slices/terminals'
 import { runWorktreeAgentActivationGate } from './worktree-agent-activation-gate'
+import type { LiveTerminalSurfaceOwnerIndex } from './worktree-live-terminal-surface-owners'
 
 const WORKTREE_ID = 'repo::/worktree'
 const STALE_STRUCTURED_SESSION_ID = 'structured-session-stale'
 const LIVE_LEAF_ID = '11111111-1111-4111-8111-111111111111'
 const DEAD_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+const SIBLING_LEAF_ID = '33333333-3333-4333-8333-333333333333'
 
 function listed(id: string): PtyListedSession {
   return { id, cwd: '/worktree', title: 'Codex', agentOwnership: 'present' }
@@ -70,16 +73,48 @@ function runtimeSnapshot(
   }
 }
 
+/** The gate's own fixtures index panes by leaf, so keep that map materialized. */
+type SeededLayout = TerminalLayoutSnapshot & { ptyIdsByLeafId: Record<string, string> }
+
 function testDeps(args: {
   sessions?: PtyListedSession[]
   sleeping?: SleepingAgentSessionRecord[]
   structured?: boolean
   resumeCount?: number
+  /** Host census of PTY→surface ownership; null models a host that could not answer. */
+  surfaceOwners?: LiveTerminalSurfaceOwnerIndex | null
 }) {
   const resume = vi.fn(() => args.resumeCount ?? 1)
   const sleeping = args.sleeping ?? []
   const ptyIdsByTabId: Record<string, string[]> = {}
   const tabsByWorktree: Record<string, TerminalTab[]> = { [WORKTREE_ID]: [] }
+  const terminalLayoutsByTabId: Record<string, SeededLayout> = Object.fromEntries(
+    sleeping.map((record) => {
+      const leafId = record.paneKey.slice(record.paneKey.indexOf(':') + 1)
+      return [
+        record.tabId!,
+        {
+          root: { type: 'leaf' as const, leafId },
+          activeLeafId: leafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      ]
+    })
+  )
+  const setTabLayout: TerminalSlice['setTabLayout'] = vi.fn((tabId, layout) => {
+    if (!layout) {
+      delete terminalLayoutsByTabId[tabId]
+      return
+    }
+    terminalLayoutsByTabId[tabId] = { ...layout, ptyIdsByLeafId: { ...layout.ptyIdsByLeafId } }
+  })
+  const replaceTerminalLayoutPanePtyId = vi.fn((tabId: string, leafId: string, ptyId: string) => {
+    const layout = terminalLayoutsByTabId[tabId]
+    if (layout) {
+      layout.ptyIdsByLeafId[leafId] = ptyId
+    }
+  })
   let createdCount = 0
   const createTab: TerminalSlice['createTab'] = vi.fn((worktreeId, _group, _shell, options) => {
     createdCount += 1
@@ -97,6 +132,9 @@ function testDeps(args: {
     tabsByWorktree[worktreeId] ??= []
     tabsByWorktree[worktreeId].push(tab)
     ptyIdsByTabId[tab.id] = tab.ptyId ? [tab.ptyId] : []
+    if (options?.initialLeafId) {
+      setTabLayout(id, singlePaneLayoutSnapshot(options.initialLeafId, options.initialPtyId))
+    }
     return tab
   })
   const updateTabPtyId = vi.fn((tabId: string, ptyId: string) => {
@@ -105,26 +143,14 @@ function testDeps(args: {
   const store = {
     createTab,
     ptyIdsByTabId,
+    setTabLayout,
     tabsByWorktree,
     sleepingAgentSessionsByPaneKey: Object.fromEntries(
       sleeping.map((record) => [record.paneKey, record])
     ),
     updateTabPtyId,
-    replaceTerminalLayoutPanePtyId: vi.fn(),
-    terminalLayoutsByTabId: Object.fromEntries(
-      sleeping.map((record) => {
-        const leafId = record.paneKey.slice(record.paneKey.indexOf(':') + 1)
-        return [
-          record.tabId!,
-          {
-            root: { type: 'leaf' as const, leafId },
-            activeLeafId: leafId,
-            expandedLeafId: null,
-            ptyIdsByLeafId: {}
-          }
-        ]
-      })
-    ),
+    replaceTerminalLayoutPanePtyId,
+    terminalLayoutsByTabId,
     unifiedTabsByWorktree: {
       [WORKTREE_ID]: args.structured
         ? [
@@ -150,8 +176,36 @@ function testDeps(args: {
     deps: {
       getState: () => store,
       listSessions: vi.fn(async () => args.sessions ?? []),
+      listSurfaceOwners: vi.fn(async () =>
+        args.surfaceOwners === undefined ? new Map() : args.surfaceOwners
+      ),
       resume
     }
+  }
+}
+
+function seedExistingSurface(
+  store: ReturnType<ReturnType<typeof testDeps>['deps']['getState']>,
+  args: { tabId: string; leafId: string; boundPtyId?: string }
+): void {
+  store.tabsByWorktree[WORKTREE_ID] = [
+    ...(store.tabsByWorktree[WORKTREE_ID] ?? []),
+    {
+      id: args.tabId,
+      ptyId: null,
+      worktreeId: WORKTREE_ID,
+      title: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 1
+    }
+  ]
+  store.terminalLayoutsByTabId[args.tabId] = {
+    root: { type: 'leaf' as const, leafId: args.leafId },
+    activeLeafId: args.leafId,
+    expandedLeafId: null,
+    ptyIdsByLeafId: args.boundPtyId ? { [args.leafId]: args.boundPtyId } : {}
   }
 }
 
@@ -449,6 +503,183 @@ describe('worktree agent activation gate', () => {
 
     expect(resume).toHaveBeenCalledWith(WORKTREE_ID, {
       skipClaimKeys: new Set([`${WORKTREE_ID}\0codex\0session_id\0live-session`])
+    })
+  })
+  it('does not mint a second surface for a PTY bound only in the persisted layout', async () => {
+    const livePtyId = `${WORKTREE_ID}@@live-agent`
+    const { deps, createTab } = testDeps({ sessions: [listed(livePtyId)] })
+    seedExistingSurface(deps.getState(), {
+      tabId: 'tab-live',
+      leafId: LIVE_LEAF_ID,
+      boundPtyId: livePtyId
+    })
+
+    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
+
+    expect(createTab).not.toHaveBeenCalled()
+    expect(deps.listSurfaceOwners).not.toHaveBeenCalled()
+  })
+
+  it('does not mint a second surface for a PTY recorded only on the tab row', async () => {
+    const livePtyId = `${WORKTREE_ID}@@live-agent`
+    const { deps, createTab } = testDeps({ sessions: [listed(livePtyId)] })
+    const store = deps.getState()
+    seedExistingSurface(store, { tabId: 'tab-live', leafId: LIVE_LEAF_ID })
+    store.tabsByWorktree[WORKTREE_ID]![0]!.ptyId = livePtyId
+
+    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
+
+    expect(createTab).not.toHaveBeenCalled()
+  })
+
+  it('restores the host-owned surface when the renderer projection lost every binding', async () => {
+    const livePtyId = `${WORKTREE_ID}@@live-agent`
+    const { deps, createTab } = testDeps({
+      sessions: [listed(livePtyId)],
+      surfaceOwners: new Map([
+        [
+          livePtyId,
+          {
+            paneKey: `tab-live:${LIVE_LEAF_ID}`,
+            ptyId: livePtyId,
+            tabId: 'tab-live'
+          }
+        ]
+      ])
+    })
+    const store = deps.getState()
+    seedExistingSurface(store, { tabId: 'tab-live', leafId: LIVE_LEAF_ID })
+
+    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
+
+    expect(createTab).not.toHaveBeenCalled()
+    expect(store.updateTabPtyId).toHaveBeenCalledWith('tab-live', livePtyId)
+    expect(store.replaceTerminalLayoutPanePtyId).toHaveBeenCalledWith(
+      'tab-live',
+      LIVE_LEAF_ID,
+      livePtyId
+    )
+  })
+
+  it('materializes the host tab id for a surface this renderer never mounted', async () => {
+    const livePtyId = `${WORKTREE_ID}@@live-agent`
+    const hostTabId = '3359f7c8-9bd8-4931-8104-52b6bdbd108d'
+    const { deps, createTab } = testDeps({
+      sessions: [listed(livePtyId)],
+      surfaceOwners: new Map([
+        [
+          livePtyId,
+          {
+            paneKey: `${hostTabId}:${LIVE_LEAF_ID}`,
+            ptyId: livePtyId,
+            tabId: hostTabId
+          }
+        ]
+      ])
+    })
+
+    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
+
+    expect(createTab).toHaveBeenCalledOnce()
+    expect(createTab).toHaveBeenCalledWith(WORKTREE_ID, undefined, undefined, {
+      id: hostTabId,
+      initialLeafId: LIVE_LEAF_ID,
+      initialPtyId: livePtyId,
+      activate: false,
+      recordInteraction: false
+    })
+  })
+
+  it('declines to mint when the host cannot say who owns a live PTY', async () => {
+    const livePtyId = `${WORKTREE_ID}@@live-agent`
+    const { deps, createTab } = testDeps({
+      sessions: [listed(livePtyId)],
+      surfaceOwners: null
+    })
+
+    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
+
+    expect(createTab).not.toHaveBeenCalled()
+  })
+
+  it('declines to mint when two host surfaces claim one live PTY', async () => {
+    const livePtyId = `${WORKTREE_ID}@@live-agent`
+    const { deps, createTab } = testDeps({
+      sessions: [listed(livePtyId)],
+      surfaceOwners: new Map([[livePtyId, null]])
+    })
+
+    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
+
+    expect(createTab).not.toHaveBeenCalled()
+  })
+
+  it('re-reads local ownership after the census before minting', async () => {
+    const livePtyId = `${WORKTREE_ID}@@live-agent`
+    const { deps, createTab } = testDeps({
+      sessions: [listed(livePtyId)],
+      surfaceOwners: new Map()
+    })
+    const store = deps.getState()
+    seedExistingSurface(store, { tabId: 'tab-live', leafId: LIVE_LEAF_ID })
+    // The pane mounts while the census is in flight, binding the PTY behind the sweep.
+    deps.listSurfaceOwners.mockImplementation(async () => {
+      store.ptyIdsByTabId['tab-live'] = [livePtyId]
+      return new Map()
+    })
+
+    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
+
+    expect(createTab).not.toHaveBeenCalled()
+  })
+
+  it('gives every host pane of an unmounted tab its own leaf', async () => {
+    const firstPtyId = `${WORKTREE_ID}@@live-agent`
+    const secondPtyId = `${WORKTREE_ID}@@live-sibling`
+    const hostTabId = '3359f7c8-9bd8-4931-8104-52b6bdbd108d'
+    const { deps, createTab } = testDeps({
+      sessions: [listed(firstPtyId), listed(secondPtyId)],
+      surfaceOwners: new Map([
+        [
+          firstPtyId,
+          { paneKey: `${hostTabId}:${LIVE_LEAF_ID}`, ptyId: firstPtyId, tabId: hostTabId }
+        ],
+        [
+          secondPtyId,
+          { paneKey: `${hostTabId}:${SIBLING_LEAF_ID}`, ptyId: secondPtyId, tabId: hostTabId }
+        ]
+      ])
+    })
+    const store = deps.getState()
+
+    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
+
+    expect(createTab).toHaveBeenCalledOnce()
+    expect(store.terminalLayoutsByTabId[hostTabId]?.root).toEqual({
+      type: 'split',
+      direction: 'horizontal',
+      first: { type: 'leaf', leafId: LIVE_LEAF_ID },
+      second: { type: 'leaf', leafId: SIBLING_LEAF_ID }
+    })
+    expect(store.terminalLayoutsByTabId[hostTabId]?.ptyIdsByLeafId).toEqual({
+      [LIVE_LEAF_ID]: firstPtyId,
+      [SIBLING_LEAF_ID]: secondPtyId
+    })
+  })
+
+  it('still adopts a live PTY the host reports as owned by no surface', async () => {
+    const livePtyId = `${WORKTREE_ID}@@orphan-agent`
+    const { deps, createTab } = testDeps({
+      sessions: [listed(livePtyId)],
+      surfaceOwners: new Map()
+    })
+
+    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
+
+    expect(createTab).toHaveBeenCalledWith(WORKTREE_ID, undefined, undefined, {
+      initialPtyId: livePtyId,
+      activate: false,
+      recordInteraction: false
     })
   })
 })

--- a/src/renderer/src/lib/worktree-agent-activation-gate.test.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-gate.test.ts
@@ -590,28 +590,66 @@ describe('worktree agent activation gate', () => {
     })
   })
 
-  it('declines to mint when the host cannot say who owns a live PTY', async () => {
+  // Failing closed must not also fail silent: an unreadable census leaves the workspace with
+  // no surface, so the gate has to hand the caller its seed instead of claiming 'adopted'.
+  it('declines to mint but still asks for a seed when the host cannot answer', async () => {
     const livePtyId = `${WORKTREE_ID}@@live-agent`
     const { deps, createTab } = testDeps({
       sessions: [listed(livePtyId)],
-      surfaceOwners: null
+      surfaceOwners: null,
+      resumeCount: 0
     })
 
-    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
+    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('empty')
 
     expect(createTab).not.toHaveBeenCalled()
   })
 
-  it('declines to mint when two host surfaces claim one live PTY', async () => {
+  it('declines to mint but still asks for a seed when two host surfaces claim one live PTY', async () => {
     const livePtyId = `${WORKTREE_ID}@@live-agent`
     const { deps, createTab } = testDeps({
       sessions: [listed(livePtyId)],
-      surfaceOwners: new Map([[livePtyId, null]])
+      surfaceOwners: new Map([[livePtyId, null]]),
+      resumeCount: 0
     })
+
+    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('empty')
+
+    expect(createTab).not.toHaveBeenCalled()
+  })
+
+  it('reports adopted only for the PTYs that actually landed on a surface', async () => {
+    const adoptedPtyId = `${WORKTREE_ID}@@orphan-agent`
+    const unverifiablePtyId = `${WORKTREE_ID}@@ambiguous-agent`
+    const { deps } = testDeps({
+      sessions: [listed(adoptedPtyId), listed(unverifiablePtyId)],
+      surfaceOwners: new Map([[unverifiablePtyId, null]]),
+      resumeCount: 0
+    })
+
+    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
+  })
+
+  it('adopts a host surface hydrated under a differently spelled workspace id', async () => {
+    const livePtyId = `${WORKTREE_ID}@@live-agent`
+    const { deps, createTab } = testDeps({
+      sessions: [listed(livePtyId)],
+      surfaceOwners: new Map([
+        [livePtyId, { paneKey: `tab-live:${LIVE_LEAF_ID}`, ptyId: livePtyId, tabId: 'tab-live' }]
+      ])
+    })
+    const store = deps.getState()
+    seedExistingSurface(store, { tabId: 'tab-live', leafId: LIVE_LEAF_ID })
+    // Packaged hydration can key the same workspace by an equivalent path spelling.
+    store.tabsByWorktree[`${WORKTREE_ID}/`] = store.tabsByWorktree[WORKTREE_ID]!
+    store.tabsByWorktree[WORKTREE_ID] = []
 
     await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
 
     expect(createTab).not.toHaveBeenCalled()
+    expect(store.terminalLayoutsByTabId['tab-live']?.ptyIdsByLeafId).toEqual({
+      [LIVE_LEAF_ID]: livePtyId
+    })
   })
 
   it('re-reads local ownership after the census before minting', async () => {

--- a/src/renderer/src/lib/worktree-agent-activation-gate.test.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-gate.test.ts
@@ -618,6 +618,29 @@ describe('worktree agent activation gate', () => {
     expect(createTab).not.toHaveBeenCalled()
   })
 
+  it('reports a decline when the host names a leaf the persisted layout does not have', async () => {
+    const livePtyId = `${WORKTREE_ID}@@live-agent`
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { deps, createTab } = testDeps({
+      sessions: [listed(livePtyId)],
+      surfaceOwners: new Map([
+        [livePtyId, { paneKey: `tab-live:${SIBLING_LEAF_ID}`, ptyId: livePtyId, tabId: 'tab-live' }]
+      ]),
+      resumeCount: 0
+    })
+    seedExistingSurface(deps.getState(), { tabId: 'tab-live', leafId: LIVE_LEAF_ID })
+
+    // The seam re-checks its own guard, so an existing tab is not re-seeded by 'empty'.
+    await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('empty')
+
+    expect(createTab).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(
+      '[worktree-activation] live PTYs left without a surface',
+      expect.objectContaining({ worktreeId: WORKTREE_ID, declinedPtyIds: [livePtyId] })
+    )
+    warn.mockRestore()
+  })
+
   it('reports adopted only for the PTYs that actually landed on a surface', async () => {
     const adoptedPtyId = `${WORKTREE_ID}@@orphan-agent`
     const unverifiablePtyId = `${WORKTREE_ID}@@ambiguous-agent`

--- a/src/renderer/src/lib/worktree-agent-activation-gate.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-gate.ts
@@ -8,29 +8,31 @@ import {
   type ResumeSleepingAgentSessionsOptions
 } from './resume-sleeping-agent-session'
 import { getProviderSessionClaimKey } from './sleeping-agent-pane-ownership'
-import { bindLivePtyToExactSurface } from './worktree-agent-live-surface-adoption'
+import {
+  adoptLiveWorkspacePtySurfaces,
+  bindLivePtyToExactSurface,
+  type LiveSurfaceAdoptionStore
+} from './worktree-agent-live-surface-adoption'
+import type { LiveTerminalSurfaceOwnerIndex } from './worktree-live-terminal-surface-owners'
+import { readWorktreeLiveTerminalSurfaceOwners } from './worktree-live-terminal-surface-owners'
 import { isStructuredAgentSyntheticSleepingRecord } from './structured-agent-synthetic-sleeping-record'
 import {
   readWorktreeStructuredActivationInventory,
   type StructuredActivationInventory
 } from './worktree-agent-structured-inventory'
 
-type ActivationStore = Pick<
-  ReturnType<typeof useAppStore.getState>,
-  | 'createTab'
-  | 'ptyIdsByTabId'
-  | 'sleepingAgentSessionsByPaneKey'
-  | 'tabsByWorktree'
-  | 'terminalLayoutsByTabId'
-  | 'unifiedTabsByWorktree'
-  | 'updateTabPtyId'
-  | 'replaceTerminalLayoutPanePtyId'
->
+type ActivationStore = LiveSurfaceAdoptionStore &
+  Pick<
+    ReturnType<typeof useAppStore.getState>,
+    'sleepingAgentSessionsByPaneKey' | 'unifiedTabsByWorktree'
+  >
 
 type ActivationGateDeps = {
   getState: () => ActivationStore
   awaitReady?: () => Promise<boolean>
   listSessions: () => Promise<PtyListedSession[]>
+  /** Host-recorded PTY→surface ownership; null when the host could not answer. */
+  listSurfaceOwners: (worktreeId: string) => Promise<LiveTerminalSurfaceOwnerIndex | null>
   hasStructuredSession?: (worktreeId: string) => Promise<boolean | StructuredActivationInventory>
   resume: (worktreeId: string, options?: ResumeSleepingAgentSessionsOptions) => number
 }
@@ -85,10 +87,6 @@ function hasStructuredSession(store: ActivationStore, worktreeId: string): boole
   return (store.unifiedTabsByWorktree[worktreeId] ?? []).some(
     (tab) => tab.contentType === 'agent-session'
   )
-}
-
-function ptyIsAlreadyBound(store: ActivationStore, ptyId: string): boolean {
-  return Object.values(store.ptyIdsByTabId).some((ids) => ids.includes(ptyId))
 }
 
 function sessionBelongsToWorkspace(sessionId: string, worktreeId: string): boolean {
@@ -212,17 +210,12 @@ export async function runWorktreeAgentActivationGate(
     }
   }
   if (liveWorkspaceSessions.length > 0) {
-    for (const session of liveWorkspaceSessions) {
-      const store = deps.getState()
-      if (ptyIsAlreadyBound(store, session.id)) {
-        continue
-      }
-      store.createTab(worktreeId, undefined, undefined, {
-        initialPtyId: session.id,
-        activate: false,
-        recordInteraction: false
-      })
-    }
+    await adoptLiveWorkspacePtySurfaces(
+      deps.getState,
+      worktreeId,
+      [...liveWorkspacePtyIds],
+      deps.listSurfaceOwners
+    )
     if (!workspaceHasSleepingAgentSessions(deps.getState(), worktreeId)) {
       return 'adopted'
     }
@@ -260,6 +253,7 @@ export function gateWorktreeAgentActivation(
     awaitReady: waitForWorkspaceSessionReady,
     listSessions: () =>
       typeof window === 'undefined' ? Promise.resolve([]) : window.api.pty.listSessions(),
+    listSurfaceOwners: readWorktreeLiveTerminalSurfaceOwners,
     hasStructuredSession: readWorktreeStructuredActivationInventory,
     resume: resumeSleepingAgentSessionsForWorktree
   }).finally(() => {

--- a/src/renderer/src/lib/worktree-agent-activation-gate.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-gate.ts
@@ -209,14 +209,18 @@ export async function runWorktreeAgentActivationGate(
       return 'blocked'
     }
   }
+  let liveSurfaceAdopted = false
   if (liveWorkspaceSessions.length > 0) {
-    await adoptLiveWorkspacePtySurfaces(
+    // Why: an unreadable census adopts nothing and mints nothing, so reporting 'adopted'
+    // would suppress the caller's seed and leave the workspace with no surface at all —
+    // fail-closed must still leave the user a usable pane (STA-5701).
+    liveSurfaceAdopted = await adoptLiveWorkspacePtySurfaces(
       deps.getState,
       worktreeId,
       [...liveWorkspacePtyIds],
       deps.listSurfaceOwners
     )
-    if (!workspaceHasSleepingAgentSessions(deps.getState(), worktreeId)) {
+    if (liveSurfaceAdopted && !workspaceHasSleepingAgentSessions(deps.getState(), worktreeId)) {
       return 'adopted'
     }
   }
@@ -232,9 +236,11 @@ export async function runWorktreeAgentActivationGate(
       structuredInventory
     )
   })
+  // 'empty' is the caller's directive — "this gate produced no surface, seed one" — not a
+  // claim the host had nothing; the callers re-check their own seeding guards first.
   return launched > 0
     ? 'resumed'
-    : liveWorkspaceSessions.length > 0
+    : liveSurfaceAdopted
       ? 'adopted'
       : structured
         ? 'structured'

--- a/src/renderer/src/lib/worktree-agent-activation-gate.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-gate.ts
@@ -214,12 +214,20 @@ export async function runWorktreeAgentActivationGate(
     // Why: an unreadable census adopts nothing and mints nothing, so reporting 'adopted'
     // would suppress the caller's seed and leave the workspace with no surface at all —
     // fail-closed must still leave the user a usable pane (STA-5701).
-    liveSurfaceAdopted = await adoptLiveWorkspacePtySurfaces(
+    const adoption = await adoptLiveWorkspacePtySurfaces(
       deps.getState,
       worktreeId,
       [...liveWorkspacePtyIds],
       deps.listSurfaceOwners
     )
+    liveSurfaceAdopted = adoption.surfaced
+    // A live agent the user can no longer see has to be diagnosable from the console.
+    if (adoption.declinedPtyIds.length > 0) {
+      console.warn('[worktree-activation] live PTYs left without a surface', {
+        worktreeId,
+        declinedPtyIds: adoption.declinedPtyIds
+      })
+    }
     if (liveSurfaceAdopted && !workspaceHasSleepingAgentSessions(deps.getState(), worktreeId)) {
       return 'adopted'
     }

--- a/src/renderer/src/lib/worktree-agent-activation-seam.test.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-seam.test.ts
@@ -2,7 +2,10 @@ import path from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AppState } from '@/store'
 import { useAppStore } from '@/store'
-import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import type {
+  RuntimeMobileSessionTabsResult,
+  RuntimeTerminalSummary
+} from '../../../shared/runtime-types'
 import { activateAndRevealWorktree } from './worktree-activation'
 import { waitForWorktreeAgentActivationGateForTests } from './worktree-agent-activation-gate'
 import { makeCreatedAgentWorktree as makeWorktree } from './worktree-activation-created-agent-test-state'
@@ -76,6 +79,27 @@ function structuredSnapshot(worktreeId: string): RuntimeMobileSessionTabsResult 
   }
 }
 
+function orphanTerminalRow(
+  worktree: ReturnType<typeof makeWorktree>,
+  ptyId: string
+): RuntimeTerminalSummary {
+  return {
+    handle: 'orphan-1',
+    ptyId,
+    orphaned: true,
+    worktreeId: worktree.id,
+    worktreePath: worktree.path,
+    branch: worktree.branch ?? 'main',
+    tabId: `pty:${ptyId}`,
+    leafId: `pty:${ptyId}`,
+    title: 'Codex',
+    connected: true,
+    writable: true,
+    lastOutputAt: null,
+    preview: ''
+  }
+}
+
 function stubInventory(args?: { structured?: boolean; livePtyId?: string }): {
   runtimeCall: ReturnType<typeof vi.fn>
   listSessions: ReturnType<typeof vi.fn>
@@ -90,6 +114,17 @@ function stubInventory(args?: { structured?: boolean; livePtyId?: string }): {
     }
     if (method === 'agentSession.handoffStatus') {
       return { ok: true, result: { owner: 'native' } }
+    }
+    if (method === 'terminal.list') {
+      // The host knows this PTY but binds it to no surface, so adoption may mint one.
+      return {
+        ok: true,
+        result: {
+          terminals: args?.livePtyId ? [orphanTerminalRow(worktree, args.livePtyId)] : [],
+          truncated: false,
+          hostScope: { hostIds: ['local'], omittedHostIds: [] }
+        }
+      }
     }
     throw new Error(`Unexpected runtime method: ${method}`)
   })

--- a/src/renderer/src/lib/worktree-agent-activation-seam.test.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-seam.test.ts
@@ -100,7 +100,12 @@ function orphanTerminalRow(
   }
 }
 
-function stubInventory(args?: { structured?: boolean; livePtyId?: string }): {
+function stubInventory(args?: {
+  structured?: boolean
+  livePtyId?: string
+  /** Host that could not produce a complete census for the workspace it was asked about. */
+  unverifiableCensus?: boolean
+}): {
   runtimeCall: ReturnType<typeof vi.fn>
   listSessions: ReturnType<typeof vi.fn>
 } {
@@ -120,9 +125,15 @@ function stubInventory(args?: { structured?: boolean; livePtyId?: string }): {
       return {
         ok: true,
         result: {
-          terminals: args?.livePtyId ? [orphanTerminalRow(worktree, args.livePtyId)] : [],
+          terminals: args?.unverifiableCensus
+            ? []
+            : args?.livePtyId
+              ? [orphanTerminalRow(worktree, args.livePtyId)]
+              : [],
           truncated: false,
-          hostScope: { hostIds: ['local'], omittedHostIds: [] }
+          hostScope: args?.unverifiableCensus
+            ? { hostIds: [], omittedHostIds: ['local', 'runtime:env-9'] }
+            : { hostIds: ['local'], omittedHostIds: [] }
         }
       }
     }
@@ -217,6 +228,24 @@ describe('worktree agent activation seam', () => {
 
     const tabs = useAppStore.getState().tabsByWorktree[worktree.id] ?? []
     expect(tabs).toHaveLength(1)
+    expect(tabs[0]?.ptyId).toBeNull()
+  })
+
+  // A paired-runtime owner is always omitted from its own scoped census, and an SSH relay that
+  // never answered omits everything. Declining to mint is right; leaving the workspace with no
+  // surface at all is not — the user asked for a pane and must get one.
+  it('still seeds a usable pane when the census cannot prove who owns a live PTY', async () => {
+    const worktree = makeWorktree()
+    const livePtyId = `${worktree.id}@@live-codex`
+    useAppStore.setState(baseState())
+    stubInventory({ livePtyId, unverifiableCensus: true })
+
+    expect(activateAndRevealWorktree(worktree.id)).toEqual({ primaryTabId: null })
+    await waitForWorktreeAgentActivationGateForTests(worktree.id)
+
+    const tabs = useAppStore.getState().tabsByWorktree[worktree.id] ?? []
+    expect(tabs).toHaveLength(1)
+    // A fresh shell, never a second surface forked onto the live agent's PTY.
     expect(tabs[0]?.ptyId).toBeNull()
   })
 

--- a/src/renderer/src/lib/worktree-agent-live-surface-adoption.ts
+++ b/src/renderer/src/lib/worktree-agent-live-surface-adoption.ts
@@ -1,10 +1,16 @@
 import { parsePaneKey } from '../../../shared/stable-pane-id'
 import type { useAppStore } from '@/store'
+import { resolveTerminalTabPtyOwnership } from './terminal-tab-for-pty-id'
+import type {
+  LiveTerminalSurfaceOwner,
+  LiveTerminalSurfaceOwnerIndex
+} from './worktree-live-terminal-surface-owners'
 
-type LiveSurfaceAdoptionStore = Pick<
+export type LiveSurfaceAdoptionStore = Pick<
   ReturnType<typeof useAppStore.getState>,
   | 'createTab'
   | 'ptyIdsByTabId'
+  | 'setTabLayout'
   | 'tabsByWorktree'
   | 'terminalLayoutsByTabId'
   | 'updateTabPtyId'
@@ -62,4 +68,96 @@ export function bindLivePtyToExactSurface(
     recordInteraction: false
   })
   return created.id === terminal.tabId
+}
+
+function tabExists(store: LiveSurfaceAdoptionStore, tabId: string): boolean {
+  return Object.values(store.tabsByWorktree).some((tabs) => tabs.some((tab) => tab.id === tabId))
+}
+
+/** Bind one host-owned PTY to the surface the host names for it. */
+function adoptHostOwnedSurface(
+  getState: () => LiveSurfaceAdoptionStore,
+  worktreeId: string,
+  owner: LiveTerminalSurfaceOwner,
+  materializedTabIds: Set<string>
+): void {
+  const store = getState()
+  const known = tabExists(store, owner.tabId)
+  if (bindLivePtyToExactSurface(store, worktreeId, owner)) {
+    if (!known) {
+      materializedTabIds.add(owner.tabId)
+    }
+    return
+  }
+  const pane = parsePaneKey(owner.paneKey)
+  // Why: a tab this sweep materialized carries only the one host leaf it was
+  // minted with, so the host's later panes need a leaf rather than no surface.
+  if (!pane || !materializedTabIds.has(owner.tabId)) {
+    return
+  }
+  const current = getState()
+  const layout = current.terminalLayoutsByTabId[owner.tabId]
+  if (!layout?.root) {
+    return
+  }
+  current.setTabLayout(owner.tabId, {
+    ...layout,
+    root: {
+      type: 'split',
+      direction: 'horizontal',
+      first: layout.root,
+      second: { type: 'leaf', leafId: pane.leafId }
+    },
+    ptyIdsByLeafId: { ...layout.ptyIdsByLeafId, [pane.leafId]: owner.ptyId }
+  })
+  current.updateTabPtyId(owner.tabId, owner.ptyId)
+}
+
+/**
+ * Give every live workspace PTY the surface that already owns it, minting one
+ * only for a PTY proven to have none.
+ */
+export async function adoptLiveWorkspacePtySurfaces(
+  getState: () => LiveSurfaceAdoptionStore,
+  worktreeId: string,
+  livePtyIds: readonly string[],
+  listSurfaceOwners: (worktreeId: string) => Promise<LiveTerminalSurfaceOwnerIndex | null>
+): Promise<void> {
+  // Why: ptyIdsByTabId holds only panes this renderer mounted, so a tab bound
+  // solely in tab.ptyId or the persisted layout used to read as unbound.
+  const unbound = livePtyIds.filter(
+    (ptyId) => resolveTerminalTabPtyOwnership(getState(), worktreeId, ptyId).kind === 'none'
+  )
+  if (unbound.length === 0) {
+    return
+  }
+  let surfaceOwners: LiveTerminalSurfaceOwnerIndex | null
+  try {
+    surfaceOwners = await listSurfaceOwners(worktreeId)
+  } catch {
+    surfaceOwners = null
+  }
+  const materializedTabIds = new Set<string>()
+  for (const ptyId of unbound) {
+    // Why: a pane can mount while the census is in flight, so the pre-RPC
+    // verdict is stale by the time it would authorize a mint.
+    if (resolveTerminalTabPtyOwnership(getState(), worktreeId, ptyId).kind !== 'none') {
+      continue
+    }
+    const owner = surfaceOwners?.get(ptyId)
+    if (owner) {
+      adoptHostOwnedSurface(getState, worktreeId, owner, materializedTabIds)
+      continue
+    }
+    // Why: only the execution host can prove a live PTY is unowned, and minting
+    // on anything weaker forks a running agent onto a second empty surface.
+    if (!surfaceOwners || surfaceOwners.has(ptyId)) {
+      continue
+    }
+    getState().createTab(worktreeId, undefined, undefined, {
+      initialPtyId: ptyId,
+      activate: false,
+      recordInteraction: false
+    })
+  }
 }

--- a/src/renderer/src/lib/worktree-agent-live-surface-adoption.ts
+++ b/src/renderer/src/lib/worktree-agent-live-surface-adoption.ts
@@ -1,4 +1,5 @@
 import { parsePaneKey } from '../../../shared/stable-pane-id'
+import { worktreeIdsEqual } from '../../../shared/worktree/id'
 import type { useAppStore } from '@/store'
 import { resolveTerminalTabPtyOwnership } from './terminal-tab-for-pty-id'
 import type {
@@ -51,7 +52,7 @@ export function bindLivePtyToExactSurface(
   if (existing) {
     const layout = store.terminalLayoutsByTabId[terminal.tabId]
     if (
-      existing.ownerWorktreeId !== worktreeId ||
+      !worktreeIdsEqual(existing.ownerWorktreeId, worktreeId) ||
       !layoutContainsLeaf(layout?.root ?? null, pane.leafId)
     ) {
       return false
@@ -74,31 +75,31 @@ function tabExists(store: LiveSurfaceAdoptionStore, tabId: string): boolean {
   return Object.values(store.tabsByWorktree).some((tabs) => tabs.some((tab) => tab.id === tabId))
 }
 
-/** Bind one host-owned PTY to the surface the host names for it. */
+/** Bind one host-owned PTY to the surface the host names for it; false when none could be named. */
 function adoptHostOwnedSurface(
   getState: () => LiveSurfaceAdoptionStore,
   worktreeId: string,
   owner: LiveTerminalSurfaceOwner,
   materializedTabIds: Set<string>
-): void {
+): boolean {
   const store = getState()
   const known = tabExists(store, owner.tabId)
   if (bindLivePtyToExactSurface(store, worktreeId, owner)) {
     if (!known) {
       materializedTabIds.add(owner.tabId)
     }
-    return
+    return true
   }
   const pane = parsePaneKey(owner.paneKey)
   // Why: a tab this sweep materialized carries only the one host leaf it was
   // minted with, so the host's later panes need a leaf rather than no surface.
   if (!pane || !materializedTabIds.has(owner.tabId)) {
-    return
+    return false
   }
   const current = getState()
   const layout = current.terminalLayoutsByTabId[owner.tabId]
   if (!layout?.root) {
-    return
+    return false
   }
   current.setTabLayout(owner.tabId, {
     ...layout,
@@ -111,25 +112,31 @@ function adoptHostOwnedSurface(
     ptyIdsByLeafId: { ...layout.ptyIdsByLeafId, [pane.leafId]: owner.ptyId }
   })
   current.updateTabPtyId(owner.tabId, owner.ptyId)
+  return true
 }
 
 /**
  * Give every live workspace PTY the surface that already owns it, minting one
  * only for a PTY proven to have none.
+ *
+ * Returns whether any live PTY ends the sweep holding a surface. False means the
+ * workspace has live agents but nothing the user can look at — the caller owes them
+ * a seeded pane, because failing closed must not also fail silent.
  */
 export async function adoptLiveWorkspacePtySurfaces(
   getState: () => LiveSurfaceAdoptionStore,
   worktreeId: string,
   livePtyIds: readonly string[],
   listSurfaceOwners: (worktreeId: string) => Promise<LiveTerminalSurfaceOwnerIndex | null>
-): Promise<void> {
+): Promise<boolean> {
   // Why: ptyIdsByTabId holds only panes this renderer mounted, so a tab bound
   // solely in tab.ptyId or the persisted layout used to read as unbound.
   const unbound = livePtyIds.filter(
     (ptyId) => resolveTerminalTabPtyOwnership(getState(), worktreeId, ptyId).kind === 'none'
   )
+  let surfaced = unbound.length < livePtyIds.length
   if (unbound.length === 0) {
-    return
+    return surfaced
   }
   let surfaceOwners: LiveTerminalSurfaceOwnerIndex | null
   try {
@@ -142,11 +149,12 @@ export async function adoptLiveWorkspacePtySurfaces(
     // Why: a pane can mount while the census is in flight, so the pre-RPC
     // verdict is stale by the time it would authorize a mint.
     if (resolveTerminalTabPtyOwnership(getState(), worktreeId, ptyId).kind !== 'none') {
+      surfaced = true
       continue
     }
     const owner = surfaceOwners?.get(ptyId)
     if (owner) {
-      adoptHostOwnedSurface(getState, worktreeId, owner, materializedTabIds)
+      surfaced = adoptHostOwnedSurface(getState, worktreeId, owner, materializedTabIds) || surfaced
       continue
     }
     // Why: only the execution host can prove a live PTY is unowned, and minting
@@ -159,5 +167,7 @@ export async function adoptLiveWorkspacePtySurfaces(
       activate: false,
       recordInteraction: false
     })
+    surfaced = true
   }
+  return surfaced
 }

--- a/src/renderer/src/lib/worktree-agent-live-surface-adoption.ts
+++ b/src/renderer/src/lib/worktree-agent-live-surface-adoption.ts
@@ -119,24 +119,26 @@ function adoptHostOwnedSurface(
  * Give every live workspace PTY the surface that already owns it, minting one
  * only for a PTY proven to have none.
  *
- * Returns whether any live PTY ends the sweep holding a surface. False means the
- * workspace has live agents but nothing the user can look at — the caller owes them
- * a seeded pane, because failing closed must not also fail silent.
+ * `surfaced` is whether any live PTY ends the sweep holding a surface. False means the
+ * workspace has live agents but nothing the user can look at — the caller owes them a
+ * seeded pane, because failing closed must not also fail silent. `declinedPtyIds` names
+ * the live PTYs the sweep left without one, so a decline is diagnosable and not mute.
  */
 export async function adoptLiveWorkspacePtySurfaces(
   getState: () => LiveSurfaceAdoptionStore,
   worktreeId: string,
   livePtyIds: readonly string[],
   listSurfaceOwners: (worktreeId: string) => Promise<LiveTerminalSurfaceOwnerIndex | null>
-): Promise<boolean> {
+): Promise<{ surfaced: boolean; declinedPtyIds: string[] }> {
   // Why: ptyIdsByTabId holds only panes this renderer mounted, so a tab bound
   // solely in tab.ptyId or the persisted layout used to read as unbound.
   const unbound = livePtyIds.filter(
     (ptyId) => resolveTerminalTabPtyOwnership(getState(), worktreeId, ptyId).kind === 'none'
   )
   let surfaced = unbound.length < livePtyIds.length
+  const declinedPtyIds: string[] = []
   if (unbound.length === 0) {
-    return surfaced
+    return { surfaced, declinedPtyIds }
   }
   let surfaceOwners: LiveTerminalSurfaceOwnerIndex | null
   try {
@@ -154,12 +156,17 @@ export async function adoptLiveWorkspacePtySurfaces(
     }
     const owner = surfaceOwners?.get(ptyId)
     if (owner) {
-      surfaced = adoptHostOwnedSurface(getState, worktreeId, owner, materializedTabIds) || surfaced
+      if (adoptHostOwnedSurface(getState, worktreeId, owner, materializedTabIds)) {
+        surfaced = true
+      } else {
+        declinedPtyIds.push(ptyId)
+      }
       continue
     }
     // Why: only the execution host can prove a live PTY is unowned, and minting
     // on anything weaker forks a running agent onto a second empty surface.
     if (!surfaceOwners || surfaceOwners.has(ptyId)) {
+      declinedPtyIds.push(ptyId)
       continue
     }
     getState().createTab(worktreeId, undefined, undefined, {
@@ -169,5 +176,5 @@ export async function adoptLiveWorkspacePtySurfaces(
     })
     surfaced = true
   }
-  return surfaced
+  return { surfaced, declinedPtyIds }
 }

--- a/src/renderer/src/lib/worktree-live-terminal-surface-owners.test.ts
+++ b/src/renderer/src/lib/worktree-live-terminal-surface-owners.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeTerminalSummary } from '../../../shared/runtime-types'
+import {
+  indexLiveTerminalSurfaceOwners,
+  readWorktreeLiveTerminalSurfaceOwners
+} from './worktree-live-terminal-surface-owners'
+
+const WORKTREE_ID = 'repo::/worktree'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const OTHER_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+
+function summary(overrides: Partial<RuntimeTerminalSummary>): RuntimeTerminalSummary {
+  return {
+    handle: 'term-1',
+    ptyId: `${WORKTREE_ID}@@live-agent`,
+    worktreeId: WORKTREE_ID,
+    worktreePath: '/worktree',
+    branch: 'main',
+    tabId: 'tab-live',
+    leafId: LEAF_ID,
+    title: 'Codex',
+    connected: true,
+    writable: true,
+    lastOutputAt: 1,
+    preview: '',
+    ...overrides
+  }
+}
+
+function stubTerminalList(result: unknown): void {
+  vi.stubGlobal('window', {
+    api: { runtime: { call: vi.fn(async () => ({ ok: true, result })) } }
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('live terminal surface owners', () => {
+  it('records the exact pane the host binds a live PTY to', () => {
+    const owners = indexLiveTerminalSurfaceOwners([summary({})], WORKTREE_ID)
+
+    expect(owners.get(`${WORKTREE_ID}@@live-agent`)).toEqual({
+      paneKey: `tab-live:${LEAF_ID}`,
+      ptyId: `${WORKTREE_ID}@@live-agent`,
+      tabId: 'tab-live'
+    })
+  })
+
+  it('leaves an orphaned PTY absent so it stays eligible for a recovery tab', () => {
+    const ptyId = `${WORKTREE_ID}@@orphan`
+    const owners = indexLiveTerminalSurfaceOwners(
+      [
+        summary({
+          ptyId,
+          orphaned: true,
+          tabId: `pty:${ptyId}`,
+          leafId: `pty:${ptyId}`
+        })
+      ],
+      WORKTREE_ID
+    )
+
+    expect(owners.has(ptyId)).toBe(false)
+  })
+
+  it('ignores rows belonging to another workspace', () => {
+    const owners = indexLiveTerminalSurfaceOwners(
+      [summary({ worktreeId: 'repo::/other' })],
+      WORKTREE_ID
+    )
+
+    expect(owners.size).toBe(0)
+  })
+
+  it('reports a PTY claimed by two panes as unverifiable rather than unowned', () => {
+    const ptyId = `${WORKTREE_ID}@@live-agent`
+    const owners = indexLiveTerminalSurfaceOwners(
+      [summary({}), summary({ handle: 'term-2', leafId: OTHER_LEAF_ID })],
+      WORKTREE_ID
+    )
+
+    expect(owners.has(ptyId)).toBe(true)
+    expect(owners.get(ptyId)).toBeNull()
+  })
+
+  it('reports an unaddressable surface as unverifiable rather than unowned', () => {
+    const ptyId = `${WORKTREE_ID}@@live-agent`
+    const owners = indexLiveTerminalSurfaceOwners([summary({ leafId: 'legacy-0' })], WORKTREE_ID)
+
+    expect(owners.has(ptyId)).toBe(true)
+    expect(owners.get(ptyId)).toBeNull()
+  })
+
+  it('refuses a census whose own execution host never answered', async () => {
+    stubTerminalList({
+      terminals: [],
+      truncated: false,
+      hostScope: { hostIds: [], omittedHostIds: ['local', 'ssh:box'] }
+    })
+
+    await expect(readWorktreeLiveTerminalSurfaceOwners(WORKTREE_ID)).resolves.toBeNull()
+  })
+
+  it('indexes a scoped census that omits the hosts of other workspaces', async () => {
+    stubTerminalList({
+      terminals: [summary({})],
+      truncated: false,
+      hostScope: { hostIds: ['local'], omittedHostIds: ['ssh:box-1'] }
+    })
+
+    const owners = await readWorktreeLiveTerminalSurfaceOwners(WORKTREE_ID)
+
+    expect(owners?.get(`${WORKTREE_ID}@@live-agent`)?.tabId).toBe('tab-live')
+  })
+
+  it('refuses a census from a host that cannot name the scope it answered for', async () => {
+    stubTerminalList({ terminals: [summary({})], truncated: false })
+
+    await expect(readWorktreeLiveTerminalSurfaceOwners(WORKTREE_ID)).resolves.toBeNull()
+  })
+
+  it('refuses a truncated census', async () => {
+    stubTerminalList({
+      terminals: [summary({})],
+      truncated: true,
+      hostScope: { hostIds: ['local'], omittedHostIds: [] }
+    })
+
+    await expect(readWorktreeLiveTerminalSurfaceOwners(WORKTREE_ID)).resolves.toBeNull()
+  })
+
+  it('indexes a complete census', async () => {
+    stubTerminalList({
+      terminals: [summary({})],
+      truncated: false,
+      hostScope: { hostIds: ['local'], omittedHostIds: [] }
+    })
+
+    const owners = await readWorktreeLiveTerminalSurfaceOwners(WORKTREE_ID)
+
+    expect(owners?.get(`${WORKTREE_ID}@@live-agent`)?.tabId).toBe('tab-live')
+  })
+
+  it('refuses a census the host could not answer', async () => {
+    vi.stubGlobal('window', {
+      api: { runtime: { call: vi.fn(async () => ({ ok: false, error: { message: 'nope' } })) } }
+    })
+
+    await expect(readWorktreeLiveTerminalSurfaceOwners(WORKTREE_ID)).resolves.toBeNull()
+  })
+})

--- a/src/renderer/src/lib/worktree-live-terminal-surface-owners.test.ts
+++ b/src/renderer/src/lib/worktree-live-terminal-surface-owners.test.ts
@@ -74,6 +74,16 @@ describe('live terminal surface owners', () => {
     expect(owners.size).toBe(0)
   })
 
+  // Dropping the host's row over path spelling would read as `unowned` and mint a duplicate.
+  it('indexes a row the host spelled with an equivalent workspace path', () => {
+    const owners = indexLiveTerminalSurfaceOwners(
+      [summary({ worktreeId: `${WORKTREE_ID}/` })],
+      WORKTREE_ID
+    )
+
+    expect(owners.get(`${WORKTREE_ID}@@live-agent`)?.tabId).toBe('tab-live')
+  })
+
   it('reports a PTY claimed by two panes as unverifiable rather than unowned', () => {
     const ptyId = `${WORKTREE_ID}@@live-agent`
     const owners = indexLiveTerminalSurfaceOwners(

--- a/src/renderer/src/lib/worktree-live-terminal-surface-owners.ts
+++ b/src/renderer/src/lib/worktree-live-terminal-surface-owners.ts
@@ -1,0 +1,114 @@
+import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
+import type {
+  RuntimeTerminalListHostScope,
+  RuntimeTerminalListResult,
+  RuntimeTerminalSummary
+} from '../../../shared/runtime-types'
+import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
+
+/** The exact surface the execution host records as owning a live PTY. */
+export type LiveTerminalSurfaceOwner = {
+  paneKey: string
+  ptyId: string
+  tabId: string
+}
+
+/**
+ * ptyId → owning surface, as the execution host records it. The renderer's own
+ * binding maps are a projection that hydration, a second window, or a
+ * client-created tab can leave empty, so they cannot answer "is this PTY
+ * unowned?" — only the host can.
+ *
+ * Three verdicts, never two: an entry is the owner, a `null` entry is
+ * `unverifiable` (the host named a surface this renderer cannot address, or
+ * named two), and a whole-index `null` is `unverifiable` for every PTY. Absence
+ * from a readable index is the only proof of `unowned`.
+ */
+export type LiveTerminalSurfaceOwnerIndex = ReadonlyMap<string, LiveTerminalSurfaceOwner | null>
+
+const OWNER_LISTING_LIMIT = 200
+
+/** A host that predates `hostScope` cannot say what it answered for, so it cannot be read. */
+function isScopedTerminalListResult(
+  value: unknown
+): value is RuntimeTerminalListResult & { hostScope: RuntimeTerminalListHostScope } {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    !Array.isArray((value as { terminals?: unknown }).terminals)
+  ) {
+    return false
+  }
+  const hostScope = (value as { hostScope?: unknown }).hostScope
+  return (
+    Boolean(hostScope) &&
+    typeof hostScope === 'object' &&
+    Array.isArray((hostScope as { hostIds?: unknown }).hostIds) &&
+    Array.isArray((hostScope as { omittedHostIds?: unknown }).omittedHostIds)
+  )
+}
+
+function toSurfaceOwner(terminal: RuntimeTerminalSummary): LiveTerminalSurfaceOwner | null {
+  if (!terminal.ptyId || !terminal.tabId || terminal.tabId.includes(':')) {
+    return null
+  }
+  return isTerminalLeafId(terminal.leafId)
+    ? {
+        paneKey: makePaneKey(terminal.tabId, terminal.leafId),
+        ptyId: terminal.ptyId,
+        tabId: terminal.tabId
+      }
+    : null
+}
+
+export function indexLiveTerminalSurfaceOwners(
+  terminals: readonly RuntimeTerminalSummary[],
+  worktreeId: string
+): Map<string, LiveTerminalSurfaceOwner | null> {
+  const owners = new Map<string, LiveTerminalSurfaceOwner | null>()
+  for (const terminal of terminals) {
+    // `orphaned` is the host's own word for "live PTY, no surface owns it".
+    if (terminal.worktreeId !== worktreeId || !terminal.ptyId || terminal.orphaned === true) {
+      continue
+    }
+    const owner = toSurfaceOwner(terminal)
+    const recorded = owners.get(terminal.ptyId)
+    // Two surfaces claiming one PTY is the duplicate this index must not endorse.
+    owners.set(
+      terminal.ptyId,
+      owners.has(terminal.ptyId) && recorded?.paneKey !== owner?.paneKey ? null : owner
+    )
+  }
+  return owners
+}
+
+/**
+ * Reads the local execution host's census. Null when it could not produce a
+ * complete one for the workspace.
+ */
+export async function readWorktreeLiveTerminalSurfaceOwners(
+  worktreeId: string
+): Promise<LiveTerminalSurfaceOwnerIndex | null> {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  const response = await window.api.runtime.call({
+    method: 'terminal.list',
+    params: {
+      worktree: toRuntimeWorktreeSelector(worktreeId),
+      limit: OWNER_LISTING_LIMIT,
+      includeVisualLayouts: false
+    }
+  })
+  if (!response.ok || !isScopedTerminalListResult(response.result)) {
+    return null
+  }
+  const { hostScope, terminals, truncated } = response.result
+  // A worktree-scoped listing names every host but the target's as omitted by
+  // design, so completeness here is "the workspace's own host answered" —
+  // `hostIds` holds exactly that host when it did. A truncated list never proves
+  // any PTY unowned.
+  return truncated === true || hostScope.hostIds.length === 0
+    ? null
+    : indexLiveTerminalSurfaceOwners(terminals, worktreeId)
+}

--- a/src/renderer/src/lib/worktree-live-terminal-surface-owners.ts
+++ b/src/renderer/src/lib/worktree-live-terminal-surface-owners.ts
@@ -4,6 +4,7 @@ import type {
   RuntimeTerminalListResult,
   RuntimeTerminalSummary
 } from '../../../shared/runtime-types'
+import { worktreeIdsEqual } from '../../../shared/worktree/id'
 import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 
 /** The exact surface the execution host records as owning a live PTY. */
@@ -68,7 +69,13 @@ export function indexLiveTerminalSurfaceOwners(
   const owners = new Map<string, LiveTerminalSurfaceOwner | null>()
   for (const terminal of terminals) {
     // `orphaned` is the host's own word for "live PTY, no surface owns it".
-    if (terminal.worktreeId !== worktreeId || !terminal.ptyId || terminal.orphaned === true) {
+    // Path spelling can differ between the host's row and the renderer's id; dropping a row
+    // over that would read as `unowned` and mint the duplicate this index exists to prevent.
+    if (
+      !worktreeIdsEqual(terminal.worktreeId, worktreeId) ||
+      !terminal.ptyId ||
+      terminal.orphaned === true
+    ) {
       continue
     }
     const owner = toSurfaceOwner(terminal)

--- a/src/renderer/src/lib/worktree-reactivation-tab-forkbomb.test.ts
+++ b/src/renderer/src/lib/worktree-reactivation-tab-forkbomb.test.ts
@@ -94,7 +94,34 @@ describe('STA-1111 worktree reopen does not fork-bomb tabs', () => {
     vi.stubGlobal('window', {
       api: {
         runtime: {
-          call: vi.fn(async () => ({ ok: true, result: { snapshots: [] } }))
+          call: vi.fn(async ({ method }: { method: string }) =>
+            method === 'terminal.list'
+              ? {
+                  ok: true,
+                  result: {
+                    // The host still binds the restored PTY to its original pane.
+                    terminals: [
+                      {
+                        handle: 'restored-1',
+                        ptyId: livePtyId,
+                        worktreeId: worktree.id,
+                        worktreePath: worktree.path,
+                        branch: 'main',
+                        tabId: 'packaged-restart-pane',
+                        leafId,
+                        title: 'Codex',
+                        connected: true,
+                        writable: true,
+                        lastOutputAt: null,
+                        preview: ''
+                      }
+                    ],
+                    truncated: false,
+                    hostScope: { hostIds: ['local'], omittedHostIds: [] }
+                  }
+                }
+              : { ok: true, result: { snapshots: [] } }
+          )
         },
         pty: {
           listSessions: vi.fn(async () => [
@@ -122,6 +149,8 @@ describe('STA-1111 worktree reopen does not fork-bomb tabs', () => {
     const restored = useAppStore.getState()
     expect(restored.tabsByWorktree[worktree.id]).toHaveLength(1)
     expect(restored.tabsByWorktree[worktree.id]?.[0]?.ptyId).toBe(livePtyId)
+    // The host's pane, not a freshly minted duplicate surface.
+    expect(restored.tabsByWorktree[worktree.id]?.[0]?.id).toBe('packaged-restart-pane')
     expect(restored.automaticAgentResumeClaimsByTabId).toEqual({})
     expect(restored.sleepingAgentSessionsByPaneKey[paneKey]).toBeDefined()
   })

--- a/src/shared/worktree/id.ts
+++ b/src/shared/worktree/id.ts
@@ -43,6 +43,18 @@ export function worktreeIdComparisonKey(worktreeId: string): string | null {
   )}`
 }
 
+/**
+ * Why: workspace identity is per *workspace*, not per checkout dir. Folder projects back several
+ * independent workspaces with one directory, separated only by the `::workspace:<uuid>` suffix that
+ * filesystem callers must strip; stripping it here instead lets one session steal a sibling's PTYs.
+ * Normalize only path spelling, so Windows/WSL/SSH ids still match themselves across hosts, and
+ * fall back to exact equality for a malformed id.
+ */
+export function worktreeIdsEqual(left: string, right: string): boolean {
+  const leftKey = worktreeIdComparisonKey(left)
+  return leftKey === null ? left === right : leftKey === worktreeIdComparisonKey(right)
+}
+
 export function splitWorktreeId(worktreeId: string): ParsedWorktreeId | null {
   const separatorIdx = worktreeId.indexOf(WORKTREE_ID_SEPARATOR)
   if (separatorIdx === -1) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​544 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​525 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​310 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​92 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​218 |

<!-- /orca-pr-loc -->

Fixes **STA-5701**. One of 6 real defects split out of the [test-detected-bugs sweep](https://linear.app/stably/view/test-detected-bugs-3a9343ad1a27).

## ELI5
Before opening an agent pane, the app asks "is one already open?" — but it only looked at what the **renderer** currently knows. On an SSH host, or right after a reconnect, the renderer doesn't know everything. So it answered "nothing here" and minted a second pane for a PTY that already had one.

The check now consults the real census of live terminal surfaces instead of renderer-local state.

## The part that matters for SSH
An empty census and an unreachable host are not the same answer. `readWorktreeLiveTerminalSurfaceOwners` returns `null` — **unverifiable** — on any of:

- `!response.ok`
- malformed or absent `hostScope`
- `truncated === true`
- `hostScope.hostIds.length === 0`

and the mint guard is `if (!surfaceOwners || surfaceOwners.has(ptyId)) continue`. A surface is minted only when a readable, untruncated, host-scoped index **positively omits** the PTY. Absence of contact is never evidence of absence of a pane.

An early draft of this module treated a missing `hostScope` as a complete census — the exact SSH fail-open the change exists to remove — and was caught in review.

## Failing closed must not also fail silent
Declining to mint is the safe direction, but it has its own user-visible failure: **the pane the user asked for never appears at all.** That was reachable, and is now fixed.

`gateWorktreeAgentActivation` is not advisory. Both call sites suppress their own terminal seeding while the gate runs (`primaryTabId = null`) and re-seed **only** on `outcome === 'empty'` — `worktree-activation.ts:148,258` and `Terminal.tsx:1546`. The gate used to report `'adopted'` whenever `liveWorkspaceSessions.length > 0`, whether or not the sweep bound anything. So on an unverifiable census the sweep adopted nothing, minted nothing, claimed `'adopted'`, and the caller stood down: **zero tabs, blank workspace.**

`hostScope.hostIds` is empty — legitimately, by design — in three shipping cases, each verified in `terminal-list-execution-host-scope.test.ts`:

| Case | Test |
| --- | --- |
| Paired-runtime workspace (runtime hosts are never claimed as covered) | `does not claim local coverage for a paired-runtime folder workspace` |
| SSH host whose relay never answered | `keeps a disconnected folder-workspace SSH host omitted` |
| Local process inventory threw | `marks every known host omitted when process inventory is unverifiable` |

`adoptLiveWorkspacePtySurfaces` now returns whether **any** live PTY ends the sweep holding a surface — counting panes already bound, panes bound to the host's named surface, and panes minted. The gate reports `'adopted'` only then; otherwise it falls through and hands the caller `'empty'`, which is the caller's directive ("this gate produced no surface, seed one"), not a claim the host had nothing. The seeded surface is a **fresh shell with its own PTY** — never a second surface forked onto the live agent's PTY — so the duplicate this PR exists to prevent stays prevented. Both callers re-check their own guards (`shouldAutoCreateInitialTerminal`, host authority, "user closed the last terminal"), so an intentionally-emptied workspace still stays empty.

## Holes checked and closed
- **Census `null` (unverifiable)** — real, and the worst one: blank workspace. Closed above.
- **Census entry `null`** (host named an unaddressable surface, or two surfaces claimed one PTY) — same blank-workspace path. Closed by the same change.
- **`adoptHostOwnedSurface` binds nothing** (existing tab whose layout lacks the host's leaf, or a competing binding under another tab) — it now reports `false` rather than returning silently, so the seed still fires.
- **Host row spelled with an equivalent workspace path** — was **fail-open**: `indexLiveTerminalSurfaceOwners` dropped the row on `!==`, the PTY read as unowned, and the duplicate got minted. Now folded through `worktreeIdsEqual`. `bindLivePtyToExactSurface` had the mirror-image bug (a tab hydrated under a differently-spelled key was unbindable, so no pane); same fix. The `::workspace:<uuid>` suffix is preserved, so folder-workspace siblings still cannot steal each other's PTYs.
- **Surface registered but dead/exited** — not reachable: the census is only consulted for ptyIds `pty.listSessions()` already reported live, and `orphaned === true` rows are deliberately left absent so they stay eligible for a recovery tab.
- **Surface owned by a different host than the activation targets** — not reachable: a worktree-scoped listing sets `candidates = [scopedHostId]`, so a non-empty `hostIds` provably contains the workspace's own host and nothing else.
- **Stale census after a disconnect** — not reachable: the census is read fresh per activation, and local ownership is re-read after the RPC returns, before anything is minted.

## Proof
Revert `worktree-agent-activation-gate.ts` + `worktree-agent-live-surface-adoption.ts` to the pre-fix state:

```
Test Files  1 failed (1)
     Tests  8 failed | 18 passed (26)
```

Revert only the fail-silent guard (report `'adopted'` unconditionally again) and the seam test shows the blank workspace directly:

```
FAIL  worktree-agent-activation-seam.test.ts > still seeds a usable pane when the census cannot prove who owns a live PTY
AssertionError: expected [] to have a length of 1 but got +0
```

At HEAD:

```
$ pnpm test src/renderer/src/lib/worktree-agent-activation-gate.test.ts \
    src/renderer/src/lib/worktree-live-terminal-surface-owners.test.ts \
    src/renderer/src/lib/worktree-agent-activation-seam.test.ts \
    src/renderer/src/lib/worktree-reactivation-tab-forkbomb.test.ts
 Test Files  4 passed (4)
      Tests  47 passed (47)

$ pnpm test src/main/runtime/orca-runtime.test.ts
 Test Files  1 passed (1)
      Tests  1216 passed | 1 skipped (1217)

$ pnpm test src/renderer/src/lib/worktree src/main/runtime/terminal-list-execution-host-scope.test.ts src/renderer/src/lib/terminal-tab-for-pty-id
 Test Files  49 passed (49)
      Tests  507 passed (507)

$ pnpm tc          # clean
$ oxlint           # exit 0, no findings in changed files
$ pnpm run check:code-quality:changed
code quality: 0 new finding(s) across 9 changed file(s).
type-aware code quality: 0 new finding(s) across 9 changed file(s).
React Doctor: 0 new finding(s) across 9 changed file(s).
```

## Also here
`worktreeIdsEqual` is lifted from a private runtime helper into `src/shared/worktree/id.ts` — a byte-identical move (exact `repoId`, path spelling folded via `normalizeRuntimePathForComparison`, `::workspace:<uuid>` suffix preserved, exact fallback for a malformed id). Windows/WSL/SSH ids still match themselves across hosts, and no folder-workspace sibling can steal another's PTYs. It now has renderer callers too (the two spelling fixes above).

> The same additive helper also appears in the STA-4577 PR, which needs it independently. The additions are identical, so the two merge cleanly in either order — verified by merging all split branches together and diffing against the original combined tree (empty).

## Performance Measurement

Deterministic host-collision fixture: stale renderer state could mint 2 surfaces for one live PTY; the host-scoped census gates that to 1 (50% fewer duplicate terminal surfaces). The census is read once per activation decision and remains bounded by the existing response contract.

## User-Facing Trade-offs

None. Activation is safer on local, SSH, and paired-remote hosts. An unreachable, truncated, or ambiguous census still refuses to mint a duplicate onto a live agent's PTY — and now also refuses to leave the user staring at an empty workspace: the caller seeds an ordinary shell, exactly as it would for a workspace with no agent at all.

## Reverting

A plain `git revert` of this PR also removes `worktreeIdsEqual` from `src/shared/worktree/id.ts`, which breaks whichever STA-4577 PR (#17430 / #17445) has landed by then — they import it. To revert:

```
git revert -n <sha> && git checkout HEAD -- src/shared/worktree/id.ts
```

The rest of the revert is clean: 5 production files, no schema, no wire change, no persisted-state change.

## Merge order

Merge this before #17445, or rebase #17445 onto it — both add `worktreeIdsEqual` at the same anchor in `src/shared/worktree/id.ts` with different JSDoc, so `git merge-tree` reports a content conflict. Resolution when rebasing #17445: drop its `id.ts` hunk and keep this one's. #17430 merges cleanly in either order (byte-identical `id.ts` hunk, non-overlapping `orca-runtime.ts` hunks).
