### PR TITLE
fix(remote): re-activate the pending host surface on paired PTY attach (STA-5291)

### DIFF
--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-pending-host-surface-attach.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-pending-host-surface-attach.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createRemoteRuntimeTransportMocks,
+  type MultiplexSubscriptionCallbacks
+} from './remote-runtime-pty-transport-test-harness'
+import type { PtyTransportRecoveryState } from './pty-transport-types'
+
+let subscriptionCallbacks: MultiplexSubscriptionCallbacks = null
+let resolvedPaneHandle = 'terminal-1'
+
+const { runtimeCall, resetRemoteRuntimeTransport, subscribedTerminalHandles } =
+  createRemoteRuntimeTransportMocks({
+    getCallbacks: () => subscriptionCallbacks,
+    setCallbacks: (callbacks) => {
+      subscriptionCallbacks = callbacks
+    },
+    getResolvedPaneHandle: () => resolvedPaneHandle,
+    setResolvedPaneHandle: (handle) => {
+      resolvedPaneHandle = handle
+    }
+  })
+
+const HOST_SURFACE_ATTACH_WINDOW_MS = 15_000
+
+function hostSessionSnapshot(status: 'pending-handle' | 'ready' | 'absent'): unknown {
+  return {
+    worktree: 'id:wt-1',
+    publicationEpoch: 'epoch-1',
+    snapshotVersion: 1,
+    activeGroupId: 'group-1',
+    activeTabId: 'host-tab-1::leaf-1',
+    activeTabType: 'terminal',
+    tabs:
+      status === 'absent'
+        ? []
+        : [
+            {
+              type: 'terminal',
+              id: 'host-tab-1::leaf-1',
+              parentTabId: 'host-tab-1',
+              leafId: 'leaf-1',
+              title: 'Terminal 1',
+              isActive: true,
+              status,
+              terminal: status === 'ready' ? 'terminal-1' : null
+            }
+          ]
+  }
+}
+
+function respondWithPendingHostSurface(args: { method: string }): Promise<unknown> {
+  if (args.method === 'session.tabs.activate' || args.method === 'session.tabs.list') {
+    return Promise.resolve({ ok: true, result: hostSessionSnapshot('pending-handle') })
+  }
+  return Promise.resolve({ ok: true, result: { terminal: { handle: 'duplicate-terminal' } } })
+}
+
+function countCalls(method: string): number {
+  return runtimeCall.mock.calls.filter((call) => call[0].method === method).length
+}
+
+function hostSurfaceRequestBudgets(): number[] {
+  return runtimeCall.mock.calls
+    .filter(
+      (call) => call[0].method === 'session.tabs.list' || call[0].method === 'session.tabs.activate'
+    )
+    .map((call) => call[0].timeoutMs as number)
+}
+
+describe('initial host-mirror attach against a surface published as pending-handle', () => {
+  beforeEach(() => {
+    resetRemoteRuntimeTransport()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps re-activating a surface the host never materializes', async () => {
+    runtimeCall.mockImplementation(respondWithPendingHostSurface)
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'web-terminal-host-tab-1',
+      leafId: 'leaf-1'
+    })
+
+    const connect = transport.connect({ url: '', callbacks: {} })
+    await vi.advanceTimersByTimeAsync(HOST_SURFACE_ATTACH_WINDOW_MS)
+    await expect(connect).resolves.toBeUndefined()
+
+    expect(countCalls('session.tabs.activate')).toBeGreaterThan(1)
+  })
+
+  it('ends the bounded wait in a revivable recovery epoch, never stranded in connecting', async () => {
+    runtimeCall.mockImplementation(respondWithPendingHostSurface)
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const { REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS } =
+      await import('./remote-runtime-pty-recovery-state')
+    const recoveryStates: PtyTransportRecoveryState[] = []
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'web-terminal-host-tab-1',
+      leafId: 'leaf-1'
+    })
+
+    const connect = transport.connect({
+      url: '',
+      callbacks: {
+        onRecoveryStateChange: (state) => {
+          recoveryStates.push(state)
+        }
+      }
+    })
+    await vi.advanceTimersByTimeAsync(HOST_SURFACE_ATTACH_WINDOW_MS)
+    await expect(connect).resolves.toBeUndefined()
+
+    expect(transport.getRecoveryState?.().phase).toBe('recovering')
+    expect(recoveryStates.at(-1)?.phase).toBe('recovering')
+
+    await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
+
+    expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+    expect(transport.retryRecovery?.()).toBe(true)
+  })
+
+  it('leaves a reattached pane recoverable when the relaunched host never materializes it', async () => {
+    runtimeCall.mockImplementation(respondWithPendingHostSurface)
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const { REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS } =
+      await import('./remote-runtime-pty-recovery-state')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'web-terminal-host-tab-1',
+      leafId: 'leaf-1'
+    })
+
+    transport.attach({
+      existingPtyId: 'remote:env-1@@stale-client-handle',
+      cols: 100,
+      rows: 30,
+      callbacks: {}
+    })
+    await vi.advanceTimersByTimeAsync(
+      HOST_SURFACE_ATTACH_WINDOW_MS + REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS
+    )
+
+    expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+    expect(transport.retryRecovery?.()).toBe(true)
+  })
+
+  it('revives a given-up pane when network online or system resume fires', async () => {
+    let hostMaterialized = false
+    runtimeCall.mockImplementation((args: { method: string }) => {
+      if (args.method === 'session.tabs.activate' || args.method === 'session.tabs.list') {
+        return Promise.resolve({
+          ok: true,
+          result: hostSessionSnapshot(hostMaterialized ? 'ready' : 'pending-handle')
+        })
+      }
+      return Promise.resolve({ ok: true, result: { terminal: { handle: 'duplicate-terminal' } } })
+    })
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const { REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS, retryAllRemoteRuntimePtyRecoveriesNow } =
+      await import('./remote-runtime-pty-recovery-state')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'web-terminal-host-tab-1',
+      leafId: 'leaf-1'
+    })
+
+    const connect = transport.connect({ url: '', callbacks: {} })
+    await vi.advanceTimersByTimeAsync(
+      HOST_SURFACE_ATTACH_WINDOW_MS + REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS
+    )
+    await expect(connect).resolves.toBeUndefined()
+    expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+
+    hostMaterialized = true
+    expect(retryAllRemoteRuntimePtyRecoveriesNow()).toBe(1)
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(subscribedTerminalHandles()).toContain('terminal-1')
+    expect(transport.getPtyId?.()).toBe('remote:env-1@@terminal-1')
+  })
+
+  it('concludes absence from list inventory only, never from an activation snapshot', async () => {
+    runtimeCall.mockImplementation((args: { method: string }) => {
+      if (args.method === 'session.tabs.activate') {
+        return Promise.resolve({ ok: true, result: hostSessionSnapshot('absent') })
+      }
+      if (args.method === 'session.tabs.list') {
+        return Promise.resolve({ ok: true, result: hostSessionSnapshot('pending-handle') })
+      }
+      return Promise.resolve({ ok: true, result: { terminal: { handle: 'duplicate-terminal' } } })
+    })
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onError = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'web-terminal-host-tab-1',
+      leafId: 'leaf-1'
+    })
+
+    const connect = transport.connect({ url: '', callbacks: { onError } })
+    await vi.advanceTimersByTimeAsync(HOST_SURFACE_ATTACH_WINDOW_MS)
+    await expect(connect).resolves.toBeUndefined()
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(countCalls('session.tabs.activate')).toBeGreaterThan(1)
+    expect(transport.getRecoveryState?.().phase).toBe('recovering')
+  })
+
+  it('stops re-activating once an activation outcome is unobservable', async () => {
+    let activations = 0
+    runtimeCall.mockImplementation((args: { method: string }) => {
+      if (args.method === 'session.tabs.activate') {
+        activations += 1
+        return Promise.resolve(
+          activations > 1
+            ? {
+                ok: false,
+                error: {
+                  code: 'remote_runtime_unavailable',
+                  message: 'Remote Orca runtime connection closed'
+                }
+              }
+            : { ok: true, result: hostSessionSnapshot('pending-handle') }
+        )
+      }
+      if (args.method === 'session.tabs.list') {
+        return Promise.resolve({ ok: true, result: hostSessionSnapshot('pending-handle') })
+      }
+      return Promise.resolve({ ok: true, result: { terminal: { handle: 'duplicate-terminal' } } })
+    })
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'web-terminal-host-tab-1',
+      leafId: 'leaf-1'
+    })
+
+    const connect = transport.connect({ url: '', callbacks: {} })
+    await vi.advanceTimersByTimeAsync(HOST_SURFACE_ATTACH_WINDOW_MS)
+    await expect(connect).resolves.toBeUndefined()
+
+    // Why: the failed activation may still have minted a host PTY, so replaying it would duplicate the shell.
+    expect(activations).toBe(2)
+    expect(countCalls('session.tabs.list')).toBeGreaterThan(2)
+  })
+
+  it('bounds every in-loop request by the remaining attach budget', async () => {
+    runtimeCall.mockImplementation(respondWithPendingHostSurface)
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'web-terminal-host-tab-1',
+      leafId: 'leaf-1'
+    })
+
+    const connect = transport.connect({ url: '', callbacks: {} })
+    await vi.advanceTimersByTimeAsync(HOST_SURFACE_ATTACH_WINDOW_MS)
+    await expect(connect).resolves.toBeUndefined()
+
+    const budgets = hostSurfaceRequestBudgets().slice(1)
+    expect(budgets.length).toBeGreaterThan(1)
+    expect(Math.max(...budgets)).toBeLessThan(HOST_SURFACE_ATTACH_WINDOW_MS)
+    expect(budgets.at(-1)).toBeLessThan(2_000)
+  })
+
+  it('attaches once a re-activation materializes the relaunched host surface', async () => {
+    let activations = 0
+    runtimeCall.mockImplementation((args: { method: string }) => {
+      if (args.method === 'session.tabs.activate') {
+        activations += 1
+        return Promise.resolve({
+          ok: true,
+          result: hostSessionSnapshot(activations > 1 ? 'ready' : 'pending-handle')
+        })
+      }
+      if (args.method === 'session.tabs.list') {
+        return Promise.resolve({
+          ok: true,
+          result: hostSessionSnapshot('pending-handle')
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        result: { terminal: { handle: 'duplicate-terminal' } }
+      })
+    })
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'web-terminal-host-tab-1',
+      leafId: 'leaf-1'
+    })
+
+    const connect = transport.connect({ url: '', callbacks: {} })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    await expect(connect).resolves.toMatchObject({
+      id: 'remote:env-1@@terminal-1'
+    })
+    expect(countCalls('terminal.create')).toBe(0)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -86,7 +86,7 @@ const REMOTE_TERMINAL_INPUT_FLUSH_MS = 8
 const REMOTE_TERMINAL_VIEWPORT_FLUSH_MS = 33
 const REMOTE_RUNTIME_MAX_PENDING_QUERY_REPLIES = 64
 const HOST_SESSION_ATTACH_POLL_MS = 150
-const HOST_SESSION_REPLACEMENT_POLL_MAX_MS = 1_000
+const HOST_SESSION_POLL_MAX_MS = 1_000
 const HOST_SESSION_ATTACH_TIMEOUT_MS = 15_000
 const HOST_SESSION_INVENTORY_MAX_WINDOWS_PER_RECOVERY = 2
 const HOST_SESSION_SAME_HANDLE_END_REUSE_LIMIT = 2
@@ -604,34 +604,68 @@ export function createRemoteRuntimePtyTransport(
     }
 
     const startedAt = Date.now()
+    let pollMs = HOST_SESSION_ATTACH_POLL_MS
+    let nextRequest: 'activate' | 'list' = 'list'
+    let activationOutcomeUnknown = false
     while (isCurrent()) {
       const remainingMs = HOST_SESSION_ATTACH_TIMEOUT_MS - (Date.now() - startedAt)
       if (remainingMs <= 0) {
         return undefined
       }
       // Why: host mirrors can publish before their PTY handle is ready, but a stuck pending surface must not poll forever.
-      await new Promise((resolve) =>
-        setTimeout(resolve, Math.min(HOST_SESSION_ATTACH_POLL_MS, remainingMs))
-      )
-      const listed = await listRemoteRuntimeSessionTabsDeduped({
-        environmentId: currentRuntimeEnvironmentId,
-        worktreeId,
-        load: () =>
-          callRuntime<RuntimeMobileSessionTabsResult>('session.tabs.list', {
-            worktree
-          })
-      })
-      const handle = findReadyHostSessionHandle(listed, hostTabId)
+      await new Promise((resolve) => setTimeout(resolve, Math.min(pollMs, remainingMs)))
+      pollMs = Math.min(pollMs * 2, HOST_SESSION_POLL_MAX_MS)
+      // Why: an RPC left on its own 15s default would stretch this bounded wait to ~30s before the pane reports any terminal state.
+      const requestRemainingMs = HOST_SESSION_ATTACH_TIMEOUT_MS - (Date.now() - startedAt)
+      if (requestRemainingMs <= 0) {
+        return undefined
+      }
+      const request = nextRequest
+      let snapshot: RuntimeMobileSessionTabsResult
+      try {
+        snapshot =
+          request === 'list'
+            ? await listRemoteRuntimeSessionTabsDeduped({
+                environmentId: currentRuntimeEnvironmentId,
+                worktreeId,
+                load: () =>
+                  callRuntime<RuntimeMobileSessionTabsResult>(
+                    'session.tabs.list',
+                    {
+                      worktree
+                    },
+                    requestRemainingMs
+                  )
+              })
+            : await activateHostSessionSurface(hostTabId, worktree, 'user', requestRemainingMs)
+      } catch (error) {
+        if (request === 'list') {
+          throw error
+        }
+        // Why: no re-activation failure is absence proof, whether the surface is missing or the host predates the method — but
+        // activation materializes host-side, so an outcome the client never saw must not be replayed into a duplicate PTY.
+        activationOutcomeUnknown = true
+        nextRequest = 'list'
+        continue
+      }
+      const handle = findReadyHostSessionHandle(snapshot, hostTabId)
       if (handle) {
         return handle
       }
-      if (!hasHostSessionTerminalSurface(listed, hostTabId)) {
+      if (request === 'activate') {
+        // Why: an activation response can race host publication, so inventory — not this snapshot — decides what exists.
+        nextRequest = 'list'
+        continue
+      }
+      if (!hasHostSessionTerminalSurface(snapshot, hostTabId)) {
         const siblingStillExists =
-          getHostSessionTerminalSurfaces(listed, hostTabId, {
+          getHostSessionTerminalSurfaces(snapshot, hostTabId, {
             matchRequestedLeaf: false
           }).length > 0
         return siblingStillExists ? false : null
       }
+      // Why: a host relaunch republishes the surface unmaterialized, and only activation can mint its PTY — list-only polling waits forever.
+      nextRequest = activationOutcomeUnknown ? 'list' : 'activate'
     }
     return undefined
   }
@@ -798,9 +832,25 @@ export function createRemoteRuntimePtyTransport(
       }
       // Why: a stale response can precede its replacement; bounded backoff avoids retrying the stale handle in a hot loop.
       await new Promise((resolve) => setTimeout(resolve, Math.min(pollMs, remainingMs)))
-      pollMs = Math.min(pollMs * 2, HOST_SESSION_REPLACEMENT_POLL_MAX_MS)
+      pollMs = Math.min(pollMs * 2, HOST_SESSION_POLL_MAX_MS)
     }
     return { handle: undefined, inventoryFailed: false }
+  }
+
+  // Why: the reconnect button and a parked external trigger revive a pane the same way — replay whichever entry point opened it.
+  function replayLastTransportEntryPoint(): boolean {
+    if (destroyed || terminalEnded || connected) {
+      return false
+    }
+    if (lastAttachOptions) {
+      transport.attach(lastAttachOptions)
+      return true
+    }
+    if (lastConnectOptions) {
+      void transport.connect(lastConnectOptions)
+      return true
+    }
+    return false
   }
 
   async function attachHostSessionMirror(
@@ -818,17 +868,26 @@ export function createRemoteRuntimePtyTransport(
       (expectedLifecycleEpoch === undefined || expectedLifecycleEpoch === lifecycleEpoch)
     const hostTabId = toHostSessionTabId(tabId)
     const hostHandle = await waitForHostSessionHandleWithRecovery(hostTabId, isCurrent)
-    if (hostHandle === undefined || !isCurrent()) {
+    if (!isCurrent()) {
       return undefined
     }
-    if (hostHandle === null) {
-      surfaceErrorMessage('Remote terminal was closed.')
-      return undefined
-    }
-    if (!hostHandle || !isCurrent()) {
-      if (isCurrent()) {
-        surfaceErrorMessage('Remote terminal was closed.')
+    if (hostHandle === undefined) {
+      connecting = false
+      // Why: no handle and no removal evidence is unknown liveness, so own an epoch and keep an unarmed retry parked for the
+      // banner and online/resume to fire — a silent 'connecting' renders no banner and retryRecovery() refuses to run.
+      if (recovery.currentPhase !== 'disconnected') {
+        const recoveryEpoch = recovery.isActive ? recovery.currentEpoch : recovery.begin()
+        recovery.parkRetryForExternalTrigger(recoveryEpoch, () => {
+          replayLastTransportEntryPoint()
+        })
       }
+      emitRecoveryState()
+      return undefined
+    }
+    if (!hostHandle) {
+      connecting = false
+      emitRecoveryState()
+      surfaceErrorMessage('Remote terminal was closed.')
       return undefined
     }
 
@@ -2493,12 +2552,7 @@ export function createRemoteRuntimePtyTransport(
         recovery.currentPhase === 'disconnected'
       ) {
         recovery.cancel()
-        if (lastAttachOptions) {
-          transport.attach(lastAttachOptions)
-          return true
-        }
-        if (lastConnectOptions) {
-          void transport.connect(lastConnectOptions)
+        if (replayLastTransportEntryPoint()) {
           return true
         }
       }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​308 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​308 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​83 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 |

<!-- /orca-pr-loc -->

Fixes **STA-5291**. One of 6 real defects split out of the [test-detected-bugs sweep](https://linear.app/stably/view/test-detected-bugs-3a9343ad1a27).

## ELI5
When attaching to a terminal on a remote machine, the app opens a slot and polls it, waiting for the host to fill it in. It was polling a slot it had opened but never **re-activated** — so the slot could never fill. Blank pane, no error, forever.

The pending host surface is now re-activated on attach.

## Verdict vocabulary
The old code surfaced `"Remote terminal was closed."` whenever the bounded wait simply ran out — asserting death from loss of contact. The new code splits the verdict three ways:

| Result | Meaning | Behavior |
|---|---|---|
| `undefined` | **unverifiable** | park a revivable retry, no error text |
| `false` | host still publishes a sibling surface for the tab | — |
| `null` | host inventory positively **omits** it | `"Remote terminal was closed."` |

Only the latter two reach the error. Absence is concluded from a `session.tabs.list` inventory only, never from a `session.tabs.activate` response snapshot.

## Not replaying an unobserved activation
A failed re-activation sets `activationOutcomeUnknown = true` and permanently downgrades the ladder to list-only — an unobserved activation may already have minted a host PTY, and replaying it would fork a second shell. Pinned by `stops re-activating once an activation outcome is unobservable` (`expect(activations).toBe(2)`).

Per-request budgets (`HOST_SESSION_ATTACH_TIMEOUT_MS - elapsed`, bail if `<= 0`) plus exponential poll backoff capped at `HOST_SESSION_POLL_MAX_MS = 1_000`, so a slow or half-open link can neither spin the loop nor exceed the attach window.

## Proof
Revert `remote-runtime-pty-transport.ts` to `2daea491b96`:

```
Test Files  1 failed (1)
     Tests  8 failed (8)
```

At HEAD: `17 files passed`, `136 passed`.

`pnpm tc` clean.

## Performance Measurement

Deterministic attach regression: a failed activation is attempted twice at most (the original attempt plus the bounded recovery path), then the ladder becomes list-only; an unbounded replay loop is reduced to 0 replays. The attach budget and poll backoff remain the existing bounds.

## User-Facing Trade-offs

None. Unverifiable hosts remain revivable rather than being labeled dead, while positively missing remote surfaces still report closure.
