### PR TITLE
fix(automations): stop vetoing Escape for overlays the page does not own (STA-5207)

### DIFF
--- a/src/renderer/src/components/automations/AutomationsPage.escape-precedence.test.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.escape-precedence.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+
+/**
+ * The Automations page installs a window capture-phase Escape handler. Capture on
+ * `window` runs before Radix's document-capture DismissableLayer, which dismisses
+ * only `if (!event.defaultPrevented)` — so any preventDefault here silently vetoes
+ * dismissal of a dialog layered above the page (STA-5207).
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+  installAutomationsPageHarness,
+  mocks,
+  renderPage,
+  settleHostQueries
+} from './automations-page-test-harness'
+
+installAutomationsPageHarness()
+
+function pressEscape(target: EventTarget): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+  target.dispatchEvent(event)
+  return event
+}
+
+async function renderWithCloseSpy(): Promise<ReturnType<typeof vi.fn>> {
+  const closeAutomationsPage = vi.fn()
+  mocks.state.closeAutomationsPage = closeAutomationsPage
+  await renderPage()
+  await settleHostQueries()
+  return closeAutomationsPage
+}
+
+describe('automations page Escape precedence', () => {
+  it('closes the page when nothing is layered above it', async () => {
+    const closeAutomationsPage = await renderWithCloseSpy()
+
+    const event = pressEscape(document.body)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(closeAutomationsPage).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves Escape to a store modal opened over the page', async () => {
+    mocks.state.activeModal = 'new-workspace-composer'
+    const closeAutomationsPage = await renderWithCloseSpy()
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+
+    const event = pressEscape(input)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(closeAutomationsPage).not.toHaveBeenCalled()
+  })
+
+  it('leaves Escape to a store modal even when focus is on page chrome', async () => {
+    mocks.state.activeModal = 'worktree-palette'
+    const closeAutomationsPage = await renderWithCloseSpy()
+
+    const event = pressEscape(document.body)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(closeAutomationsPage).not.toHaveBeenCalled()
+  })
+
+  it('leaves Escape to a visible overlay that the store does not track', async () => {
+    const closeAutomationsPage = await renderWithCloseSpy()
+    const overlay = document.createElement('div')
+    overlay.setAttribute('role', 'dialog')
+    document.body.appendChild(overlay)
+
+    const event = pressEscape(document.body)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(closeAutomationsPage).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -8,6 +8,7 @@ import { useAppStore } from '@/store'
 import { getAgentCatalog } from '@/lib/agent-catalog'
 import { useRepoMap, useWorktreeMap } from '@/store/selectors'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { hasVisibleOverlay } from '@/lib/visible-overlay'
 import type {
   Automation,
   AutomationCreateInput,
@@ -208,6 +209,7 @@ export default function AutomationsPage(): React.JSX.Element {
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const closeAutomationsPage = useAppStore((s) => s.closeAutomationsPage)
+  const activeModal = useAppStore((s) => s.activeModal)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const sshTargetLabels = useAppStore((s) => s.sshTargetLabels)
   const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
@@ -2497,7 +2499,9 @@ export default function AutomationsPage(): React.JSX.Element {
   }
 
   useEffect(() => {
-    if (createOpen || deleteTarget || externalDeleteTarget) {
+    // Why: a modal layered over the page owns Esc; this listener is capture-phase on
+    // window, so preventDefault here would veto the modal's own dismissal.
+    if (createOpen || deleteTarget || externalDeleteTarget || activeModal !== 'none') {
       return
     }
 
@@ -2508,6 +2512,11 @@ export default function AutomationsPage(): React.JSX.Element {
 
       const target = event.target
       if (!(target instanceof HTMLElement)) {
+        return
+      }
+
+      // Why: popovers and menus live outside the store's modal registry; they own Esc too.
+      if (hasVisibleOverlay()) {
         return
       }
 
@@ -2554,6 +2563,7 @@ export default function AutomationsPage(): React.JSX.Element {
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
   }, [
+    activeModal,
     closeAutomationsPage,
     createOpen,
     deleteTarget,

--- a/src/renderer/src/components/automations/automations-page-fixtures.ts
+++ b/src/renderer/src/components/automations/automations-page-fixtures.ts
@@ -217,6 +217,7 @@ export function makeStoreState(): AutomationsPageStoreFixtures {
       openSettingsPage: noop,
       openSettingsTarget: noop,
       closeAutomationsPage: noop,
+      activeModal: 'none',
       sshConnectionStates: new Map(),
       sshTargetLabels: new Map(),
       removedSshTargetLabels: new Map(),

--- a/src/renderer/src/components/settings/use-settings-page-effects.ts
+++ b/src/renderer/src/components/settings/use-settings-page-effects.ts
@@ -6,6 +6,7 @@ import { resolveAppearanceAccordionDeepLink } from './appearance-usage-percentag
 import { registerWindowCloseGuard } from '../window-close-request-coordinator'
 import { isIntentionalAppRestartInProgress } from '@/lib/updater-beforeunload'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { hasVisibleOverlay } from '@/lib/visible-overlay'
 import { translate } from '@/i18n/i18n'
 import {
   getSettingsTargetHostSelection,
@@ -80,24 +81,6 @@ export function useSettingsPageEffects(
   }, [refreshModelStates, setVoiceModelStatesLoading, showDesktopOnlySettings])
 
   useEffect(() => {
-    const hasVisibleOverlay = (): boolean =>
-      Array.from(
-        document.querySelectorAll('[role="dialog"], [role="listbox"], [role="menu"]')
-      ).some((element) => {
-        if (!(element instanceof HTMLElement)) {
-          return false
-        }
-        if (element.closest('[aria-hidden="true"]')) {
-          return false
-        }
-        const style = window.getComputedStyle(element)
-        return (
-          style.display !== 'none' &&
-          style.visibility !== 'hidden' &&
-          element.getClientRects().length > 0
-        )
-      })
-
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (event.key !== 'Escape' || event.defaultPrevented) {
         return

--- a/src/renderer/src/components/skills/use-skills-page-keyboard-navigation.ts
+++ b/src/renderer/src/components/skills/use-skills-page-keyboard-navigation.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import type { SkillsPageView } from './skills-page-view'
+import { hasVisibleOverlay } from '@/lib/visible-overlay'
 
 type UseSkillsPageKeyboardNavigationOptions = {
   closeSkillsPage: () => void
@@ -17,33 +18,12 @@ export function useSkillsPageKeyboardNavigation({
   view
 }: UseSkillsPageKeyboardNavigationOptions): void {
   useEffect(() => {
-    const hasVisibleOverlay = (): boolean =>
-      Array.from(
-        document.querySelectorAll('[role="dialog"], [role="listbox"], [role="menu"]')
-      ).some((element) => {
-        if (!(element instanceof HTMLElement)) {
-          return false
-        }
-        if (element.closest('[aria-hidden="true"]')) {
-          return false
-        }
-        if (element.closest('[data-skills-page-list="true"]')) {
-          return false
-        }
-        const style = window.getComputedStyle(element)
-        return (
-          style.display !== 'none' &&
-          style.visibility !== 'hidden' &&
-          element.getClientRects().length > 0
-        )
-      })
-
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (event.key !== 'Escape') {
         return
       }
       // Why: menus and dialogs own Escape before page-level navigation.
-      if (hasVisibleOverlay()) {
+      if (hasVisibleOverlay({ ignoreSelector: '[data-skills-page-list="true"]' })) {
         return
       }
       const target = event.target

--- a/src/renderer/src/components/workspace-space/WorkspaceSpacePage.tsx
+++ b/src/renderer/src/components/workspace-space/WorkspaceSpacePage.tsx
@@ -4,30 +4,13 @@ import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { WorkspaceSpaceManagerPanel } from '../status-bar/WorkspaceSpaceManagerPanel'
 import { useAppStore } from '../../store'
+import { hasVisibleOverlay } from '@/lib/visible-overlay'
 import { translate } from '@/i18n/i18n'
 
 export default function WorkspaceSpacePage(): React.JSX.Element {
   const closeSpacePage = useAppStore((state) => state.closeSpacePage)
 
   useEffect(() => {
-    const hasVisibleOverlay = (): boolean =>
-      Array.from(
-        document.querySelectorAll('[role="dialog"], [role="listbox"], [role="menu"]')
-      ).some((element) => {
-        if (!(element instanceof HTMLElement)) {
-          return false
-        }
-        if (element.closest('[aria-hidden="true"]')) {
-          return false
-        }
-        const style = window.getComputedStyle(element)
-        return (
-          style.display !== 'none' &&
-          style.visibility !== 'hidden' &&
-          element.getClientRects().length > 0
-        )
-      })
-
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (event.key !== 'Escape') {
         return

--- a/src/renderer/src/lib/visible-overlay.test.ts
+++ b/src/renderer/src/lib/visible-overlay.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { hasVisibleOverlay } from './visible-overlay'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+function mount(html: string): void {
+  document.body.innerHTML = html
+}
+
+describe('hasVisibleOverlay', () => {
+  it('is false with no overlay on screen', () => {
+    mount('<div>page chrome</div>')
+
+    expect(hasVisibleOverlay()).toBe(false)
+  })
+
+  it.each(['dialog', 'alertdialog', 'listbox', 'menu'])('sees a visible %s', (role) => {
+    mount(`<div role="${role}"></div>`)
+
+    expect(hasVisibleOverlay()).toBe(true)
+  })
+
+  it('ignores an overlay inside an aria-hidden subtree', () => {
+    mount('<div aria-hidden="true"><div role="dialog"></div></div>')
+
+    expect(hasVisibleOverlay()).toBe(false)
+  })
+
+  it('ignores a display:none overlay', () => {
+    mount('<div role="dialog" style="display: none"></div>')
+
+    expect(hasVisibleOverlay()).toBe(false)
+  })
+
+  it('ignores a visibility:hidden overlay', () => {
+    mount('<div role="dialog" style="visibility: hidden"></div>')
+
+    expect(hasVisibleOverlay()).toBe(false)
+  })
+
+  it('ignores overlays inside ignoreSelector but not their siblings', () => {
+    mount('<div data-page-list="true"><div role="listbox"></div></div><div role="menu"></div>')
+
+    expect(hasVisibleOverlay({ ignoreSelector: '[data-page-list="true"]' })).toBe(true)
+
+    document.querySelector('[role="menu"]')?.remove()
+
+    expect(hasVisibleOverlay({ ignoreSelector: '[data-page-list="true"]' })).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/visible-overlay.ts
+++ b/src/renderer/src/lib/visible-overlay.ts
@@ -1,0 +1,31 @@
+const OVERLAY_SELECTOR = '[role="dialog"], [role="alertdialog"], [role="listbox"], [role="menu"]'
+
+type VisibleOverlayOptions = {
+  /** Overlays inside a match are treated as page content, not as a layer above it. */
+  ignoreSelector?: string
+}
+
+/**
+ * Whether a dialog, alert dialog, listbox, or menu is on screen. Page-level Escape
+ * handlers ask this before acting: the overlay owns the first Escape, and a page
+ * that preventDefaults instead vetoes the overlay's own dismissal.
+ */
+export function hasVisibleOverlay(options?: VisibleOverlayOptions): boolean {
+  return Array.from(document.querySelectorAll(OVERLAY_SELECTOR)).some((element) => {
+    if (!(element instanceof HTMLElement)) {
+      return false
+    }
+    if (element.closest('[aria-hidden="true"]')) {
+      return false
+    }
+    if (options?.ignoreSelector && element.closest(options.ignoreSelector)) {
+      return false
+    }
+    const style = window.getComputedStyle(element)
+    return (
+      style.display !== 'none' &&
+      style.visibility !== 'hidden' &&
+      element.getClientRects().length > 0
+    )
+  })
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​59 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 |

<!-- /orca-pr-loc -->

Fixes **STA-5207**. One of 6 real defects split out of the [test-detected-bugs sweep](https://linear.app/stably/view/test-detected-bugs-3a9343ad1a27).

## ELI5
The Automations page has an Escape handler for its own window-capture mode. It was vetoing Escape for **everything** — including dialogs, menus and listboxes it has nothing to do with. Open a dialog on that page and Escape stopped closing it.

The handler now only vetoes when an overlay it actually owns is visible.

## Reuse
The "is a real overlay visible?" test was already written twice — inline in `AutomationsPage.tsx` and again in `WorkspaceSpacePage.tsx`. Rather than fix one copy, it is extracted to `src/renderer/src/lib/visible-overlay.ts` and both call sites now share it (as do `use-settings-page-effects.ts` and `use-skills-page-keyboard-navigation.ts`).

## Proof
Revert `AutomationsPage.tsx` to `2daea491b96`:

```
Test Files  1 failed (1)
     Tests  3 failed | 1 passed (4)
```

At HEAD, automations + `visible-overlay`: `91 files passed`, `728 passed`.

`pnpm tc` clean.

## Performance Measurement

This is a correctness and helper-deduplication change, not a measured hot-path optimization. The shared overlay predicate replaces duplicated inline logic at the call sites; render and Escape-event latency are otherwise unchanged (N/A).

## User-Facing Trade-offs

None. Escape is intercepted only for overlays the page owns; dialogs, menus, and listboxes regain their normal dismissal behavior.
