### PR TITLE
fix(terminal): mount one surface per workspace id in the workbench (STA-4846)

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -10,9 +10,10 @@ import {
   type BackgroundMountTerminalWorktreeDetail
 } from '@/constants/terminal'
 import { useAppStore } from '../store'
-import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
-import { useAllWorktrees } from '../store/selectors'
+import { parseWorkspaceKey } from '../../../shared/workspace-scope'
+import { useWorktreeMap } from '../store/selectors'
+import { projectWorkspaceSurfaces } from './workspace-surface-projection'
 import { getConnectionId } from '../lib/connection-context'
 import { basename } from '../lib/path'
 import {
@@ -322,22 +323,28 @@ function Terminal(): React.JSX.Element | null {
   const measuringTerminalWorktreeIdsRef = useRef(new Set<string>())
   const terminalWorktreeParkCooldownUntilRef = useRef(new Map<string, number>())
   const terminalWorktreeParkingTimersRef = useRef(new Map<string, number>())
-  const allWorktrees = useAllWorktrees()
+  const worktreesById = useWorktreeMap()
   const folderWorkspaces = useAppStore((s) => s.folderWorkspaces)
-  const workspaceSurfaces = useMemo(
-    () => [
-      ...allWorktrees.map((worktree) => ({ id: worktree.id, path: worktree.path })),
-      ...folderWorkspaces.map((workspace) => ({
-        id: folderWorkspaceKey(workspace.id),
-        path: workspace.folderPath
-      }))
-    ],
-    [allWorktrees, folderWorkspaces]
-  )
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const renderedActiveWorktreeId = activeWorktreeId
   const activeWorktreeDeferralHostId = useAppStore((s) =>
     getResolvedExecutionHostIdForWorktree(s, renderedActiveWorktreeId)
+  )
+  // Why narrow it: only the folder-collision tie-break reads this host, so a git
+  // workspace's ownership settling must not re-identify the whole mount projection.
+  const activeFolderSurfaceHostId =
+    parseWorkspaceKey(renderedActiveWorktreeId ?? '')?.type === 'folder'
+      ? activeWorktreeDeferralHostId
+      : null
+  const workspaceSurfaces = useMemo(
+    () =>
+      projectWorkspaceSurfaces({
+        worktreesById,
+        folderWorkspaces,
+        activeWorkspaceId: renderedActiveWorktreeId,
+        activeWorkspaceResolvedHostId: activeFolderSurfaceHostId
+      }),
+    [worktreesById, folderWorkspaces, renderedActiveWorktreeId, activeFolderSurfaceHostId]
   )
   const activeView = useAppStore((s) => s.activeView)
   // Why: terminal titles are leaf chrome. The root host only subscribes to

--- a/src/renderer/src/components/workspace-surface-projection.test.ts
+++ b/src/renderer/src/components/workspace-surface-projection.test.ts
@@ -1,0 +1,187 @@
+/**
+ * STA-4846: the terminal workbench is bare-workspace-id keyed end to end
+ * (`activeWorktreeId`, `tabsByWorktree`, `mountedWorktreeIdsRef`, React keys),
+ * but its catalog inputs are host-qualified — `getIndexedAllWorktrees` emits one
+ * row per (host, id) and `mergeFetchedFolderWorkspacesForHost` keeps one folder
+ * row per (host, id). A repo checked out at the same path locally and on an
+ * SSH/paired-runtime host therefore reached the mount loops twice, mounting the
+ * same tabIds under duplicate React keys with both trees marked visible.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { projectWorkspaceSurfaces } from './workspace-surface-projection'
+import { getIndexedWorktreeMap } from '../store/worktree-repo-index'
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import type { FolderWorkspace } from '../../../shared/folder-workspace-types'
+import type { Worktree } from '../../../shared/worktree/types'
+
+const SHARED_WORKTREE_ID = 'repo-shared::/work/orca-feature'
+
+// A production collision differs only by host: `worktreeId` is `repoId::path`,
+// so both rows necessarily carry the same repoId and path (see STA-4343's
+// sidebar/worktree-list-groups-host-collision.test.ts).
+const localWorktree: Worktree = {
+  id: SHARED_WORKTREE_ID,
+  repoId: 'repo-shared',
+  path: '/work/orca-feature',
+  hostId: 'local',
+  head: 'abc123',
+  branch: 'feature',
+  isBare: false,
+  isMainWorktree: false,
+  displayName: 'orca-feature',
+  comment: '',
+  linkedIssue: null,
+  linkedPR: null,
+  linkedLinearIssue: null,
+  isArchived: false,
+  isUnread: false,
+  isPinned: false,
+  sortOrder: 0,
+  lastActivityAt: 1
+}
+const sshWorktree: Worktree = { ...localWorktree, hostId: 'ssh:build-box' }
+
+const localFolder: FolderWorkspace = {
+  id: 'folder-shared',
+  projectGroupId: 'group-shared',
+  name: 'orca',
+  folderPath: '/work/orca-local',
+  executionHostId: 'local',
+  linkedTask: null,
+  comment: '',
+  isArchived: false,
+  isUnread: false,
+  isPinned: false,
+  sortOrder: 0,
+  lastActivityAt: 1,
+  createdAt: 1,
+  updatedAt: 1
+}
+const runtimeFolder: FolderWorkspace = {
+  ...localFolder,
+  folderPath: '/remote/orca',
+  executionHostId: 'runtime:env-1'
+}
+
+function project(input: {
+  worktrees?: readonly Worktree[]
+  folderWorkspaces?: readonly FolderWorkspace[]
+  activeWorkspaceId?: string | null
+  activeWorkspaceResolvedHostId?: ExecutionHostId | null
+}): ReturnType<typeof projectWorkspaceSurfaces> {
+  return projectWorkspaceSurfaces({
+    // Built through the production index so the test pins the composition the
+    // workbench actually runs, not a re-implementation of the per-id collapse.
+    worktreesById: getIndexedWorktreeMap({ 'repo-shared': [...(input.worktrees ?? [])] }),
+    folderWorkspaces: input.folderWorkspaces ?? [],
+    activeWorkspaceId: input.activeWorkspaceId ?? null,
+    activeWorkspaceResolvedHostId: input.activeWorkspaceResolvedHostId ?? null
+  })
+}
+
+describe('projectWorkspaceSurfaces', () => {
+  it('emits one surface per workspace id when two hosts publish the same worktree', () => {
+    const surfaces = project({ worktrees: [localWorktree, sshWorktree] })
+
+    expect(surfaces).toEqual([{ id: SHARED_WORKTREE_ID, path: '/work/orca-feature' }])
+  })
+
+  it('never emits a duplicate id, so mount loops cannot reuse a React key', () => {
+    const surfaces = project({
+      worktrees: [localWorktree, sshWorktree],
+      folderWorkspaces: [localFolder, runtimeFolder]
+    })
+
+    expect(new Set(surfaces.map((surface) => surface.id)).size).toBe(surfaces.length)
+  })
+
+  it('emits one surface per folder workspace id across hosts', () => {
+    const surfaces = project({ folderWorkspaces: [localFolder, runtimeFolder] })
+
+    expect(surfaces).toHaveLength(1)
+    expect(surfaces[0]?.id).toBe('folder:folder-shared')
+  })
+
+  it('mounts the active folder workspace at its resolved host path, not the first row', () => {
+    const surfaces = project({
+      folderWorkspaces: [localFolder, runtimeFolder],
+      activeWorkspaceId: 'folder:folder-shared',
+      activeWorkspaceResolvedHostId: 'runtime:env-1'
+    })
+
+    expect(surfaces).toEqual([{ id: 'folder:folder-shared', path: '/remote/orca' }])
+  })
+
+  it('keeps the first row when no resolved host disambiguates the folder collision', () => {
+    const surfaces = project({ folderWorkspaces: [runtimeFolder, localFolder] })
+
+    expect(surfaces).toEqual([{ id: 'folder:folder-shared', path: '/remote/orca' }])
+  })
+
+  it('switches the active folder path from first-wins to the host that hydrates', () => {
+    // Ownership resolves to null while the folder-owner index still reads the
+    // colliding id as ambiguous, so the projection first-wins until it lands.
+    const folderWorkspaces = [localFolder, runtimeFolder]
+    const hydrating = project({
+      folderWorkspaces,
+      activeWorkspaceId: 'folder:folder-shared',
+      activeWorkspaceResolvedHostId: null
+    })
+    const hydrated = project({
+      folderWorkspaces,
+      activeWorkspaceId: 'folder:folder-shared',
+      activeWorkspaceResolvedHostId: 'runtime:env-1'
+    })
+
+    expect(hydrating).toEqual([{ id: 'folder:folder-shared', path: '/work/orca-local' }])
+    expect(hydrated).toEqual([{ id: 'folder:folder-shared', path: '/remote/orca' }])
+    // The id is what mounts; only the path moves, so the transition is no remount.
+    expect(hydrated[0]?.id).toBe(hydrating[0]?.id)
+  })
+
+  it('keeps the surviving host row when a runtime disconnect drops its peer', () => {
+    // Loss of contact with the runtime must not unmount the workspace: the
+    // mount prune drops ids that leave the projection.
+    const surfaces = project({ worktrees: [localWorktree] })
+
+    expect(surfaces).toEqual([{ id: SHARED_WORKTREE_ID, path: '/work/orca-feature' }])
+  })
+
+  it('keeps distinct workspaces on one host', () => {
+    const otherWorktree: Worktree = {
+      ...localWorktree,
+      id: 'repo-shared::/work/orca-other',
+      path: '/work/orca-other'
+    }
+
+    expect(project({ worktrees: [localWorktree, otherWorktree] })).toEqual([
+      { id: SHARED_WORKTREE_ID, path: '/work/orca-feature' },
+      { id: 'repo-shared::/work/orca-other', path: '/work/orca-other' }
+    ])
+  })
+})
+
+// Why source text: the per-id collapse lives in the store index, so the module
+// tests above stay green even if Terminal.tsx goes back to flattening the
+// host-qualified array itself. The feed is the half that has to be ratcheted.
+describe('Terminal workbench surface feed', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/renderer/src/components/Terminal.tsx'),
+    'utf8'
+  )
+
+  it('feeds the projection from the store per-id index, never the host-qualified array', () => {
+    expect(source).not.toContain('useAllWorktrees')
+    expect(source).toContain('const worktreesById = useWorktreeMap()')
+  })
+
+  it('has exactly one projection call site, so no second flatten can hide beside it', () => {
+    expect(
+      source.split('projectWorkspaceSurfaces(').length - 1,
+      'expected exactly one projectWorkspaceSurfaces call in Terminal.tsx'
+    ).toBe(1)
+    expect(source).toContain('worktreesById,\n        folderWorkspaces,')
+  })
+})

--- a/src/renderer/src/components/workspace-surface-projection.test.ts
+++ b/src/renderer/src/components/workspace-surface-projection.test.ts
@@ -9,7 +9,7 @@
  */
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { projectWorkspaceSurfaces } from './workspace-surface-projection'
 import { getIndexedAllWorktrees, getIndexedWorktreeMap } from '../store/worktree-repo-index'
 import type { ExecutionHostId } from '../../../shared/execution-host'
@@ -118,6 +118,36 @@ describe('projectWorkspaceSurfaces', () => {
     const surfaces = project({ folderWorkspaces: [runtimeFolder, localFolder] })
 
     expect(surfaces).toEqual([{ id: 'folder:folder-shared', path: '/remote/orca' }])
+  })
+
+  it('keeps first-wins for a colliding folder workspace that is not the active one', () => {
+    // A resolved host only breaks its own workspace's tie; another id's resolution must not move it.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const surfaces = project({
+      folderWorkspaces: [localFolder, runtimeFolder],
+      activeWorkspaceId: 'folder:other-workspace',
+      activeWorkspaceResolvedHostId: 'runtime:env-1'
+    })
+
+    expect(surfaces).toEqual([{ id: 'folder:folder-shared', path: '/work/orca-local' }])
+    expect(warn).toHaveBeenCalledWith(
+      '[workspace-surface] dropping colliding folder path',
+      expect.objectContaining({ kept: '/work/orca-local', dropped: '/remote/orca' })
+    )
+    warn.mockRestore()
+  })
+
+  it('keeps the resolved-host path when the colliding rows swap order', () => {
+    // `mergeFetchedFolderWorkspacesForHost` reaps and re-appends a host's rows across a
+    // disconnect, so which row is first flips mid-session; a resolved host must pin the path.
+    const surfaces = project({
+      folderWorkspaces: [runtimeFolder, localFolder],
+      activeWorkspaceId: 'folder:folder-shared',
+      activeWorkspaceResolvedHostId: 'local'
+    })
+
+    expect(surfaces).toEqual([{ id: 'folder:folder-shared', path: '/work/orca-local' }])
   })
 
   it('switches the active folder path from first-wins to the host that hydrates', () => {

--- a/src/renderer/src/components/workspace-surface-projection.test.ts
+++ b/src/renderer/src/components/workspace-surface-projection.test.ts
@@ -11,7 +11,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { projectWorkspaceSurfaces } from './workspace-surface-projection'
-import { getIndexedWorktreeMap } from '../store/worktree-repo-index'
+import { getIndexedAllWorktrees, getIndexedWorktreeMap } from '../store/worktree-repo-index'
 import type { ExecutionHostId } from '../../../shared/execution-host'
 import type { FolderWorkspace } from '../../../shared/folder-workspace-types'
 import type { Worktree } from '../../../shared/worktree/types'
@@ -160,6 +160,148 @@ describe('projectWorkspaceSurfaces', () => {
       { id: SHARED_WORKTREE_ID, path: '/work/orca-feature' },
       { id: 'repo-shared::/work/orca-other', path: '/work/orca-other' }
     ])
+  })
+})
+
+// The collapse only ever removes a duplicate id. Losing a surface the user owns
+// unmounts live terminals, which is strictly worse than the duplicate mount this
+// fixes, so every shape that reaches the workbench is pinned against dropping one.
+describe('projectWorkspaceSurfaces never under-selects', () => {
+  const unqualifiedWorktree: Worktree = { ...localWorktree, hostId: undefined }
+  const secondSshWorktree: Worktree = { ...localWorktree, hostId: 'ssh:ci-box' }
+  const localOnlyFolder: FolderWorkspace = {
+    ...localFolder,
+    id: 'folder-local-only',
+    executionHostId: undefined
+  }
+
+  it('emits every distinct id from a mixed local, SSH, runtime and folder catalog', () => {
+    const distinctWorktree: Worktree = {
+      ...sshWorktree,
+      id: 'repo-shared::/work/orca-ssh-only',
+      path: '/work/orca-ssh-only'
+    }
+    const distinctFolder: FolderWorkspace = { ...runtimeFolder, id: 'folder-runtime-only' }
+    const worktrees = [localWorktree, sshWorktree, secondSshWorktree, distinctWorktree]
+    const folderWorkspaces = [localFolder, runtimeFolder, localOnlyFolder, distinctFolder]
+
+    const surfaceIds = project({ worktrees, folderWorkspaces }).map((surface) => surface.id)
+
+    const expectedIds = new Set([
+      ...worktrees.map((worktree) => worktree.id),
+      ...folderWorkspaces.map((workspace) => `folder:${workspace.id}`)
+    ])
+    expect(new Set(surfaceIds)).toEqual(expectedIds)
+    expect(surfaceIds).toHaveLength(expectedIds.size)
+  })
+
+  it('mounts a local-only catalog whose rows never name a host', () => {
+    const otherUnqualified: Worktree = {
+      ...unqualifiedWorktree,
+      id: 'repo-shared::/work/orca-other',
+      path: '/work/orca-other'
+    }
+
+    expect(
+      project({
+        worktrees: [unqualifiedWorktree, otherUnqualified],
+        folderWorkspaces: [localOnlyFolder]
+      })
+    ).toEqual([
+      { id: SHARED_WORKTREE_ID, path: '/work/orca-feature' },
+      { id: 'repo-shared::/work/orca-other', path: '/work/orca-other' },
+      { id: 'folder:folder-local-only', path: '/work/orca-local' }
+    ])
+  })
+
+  it('keeps the id when an unqualified row collides with a host-qualified one', () => {
+    // `composeWorktreeHostIdentity` gives an unqualified row its own bucket, so
+    // the pair survives the host-qualified index and must still collapse to one id.
+    expect(project({ worktrees: [unqualifiedWorktree, localWorktree] })).toEqual([
+      { id: SHARED_WORKTREE_ID, path: '/work/orca-feature' }
+    ])
+    expect(project({ worktrees: [localWorktree, unqualifiedWorktree] })).toEqual([
+      { id: SHARED_WORKTREE_ID, path: '/work/orca-feature' }
+    ])
+  })
+
+  it('collapses two SSH hosts publishing one worktree id, with no local row present', () => {
+    expect(project({ worktrees: [sshWorktree, secondSshWorktree] })).toEqual([
+      { id: SHARED_WORKTREE_ID, path: '/work/orca-feature' }
+    ])
+  })
+
+  it('keeps a git worktree and a folder workspace apart even on the same id text', () => {
+    // `folderWorkspaceKey` prefixes `folder:`; a worktree id is `repoId::path`.
+    const surfaces = project({
+      worktrees: [{ ...localWorktree, id: 'folder-shared', path: '/work/collide' }],
+      folderWorkspaces: [localFolder]
+    })
+
+    expect(surfaces).toEqual([
+      { id: 'folder-shared', path: '/work/collide' },
+      { id: 'folder:folder-shared', path: '/work/orca-local' }
+    ])
+  })
+
+  it('collapses folder rows across three hosts to one surface without losing the id', () => {
+    const sshFolder: FolderWorkspace = {
+      ...localFolder,
+      folderPath: '/ssh/orca',
+      executionHostId: undefined,
+      connectionId: 'build-box'
+    }
+
+    const surfaces = project({
+      folderWorkspaces: [localFolder, runtimeFolder, sshFolder],
+      activeWorkspaceId: 'folder:folder-shared',
+      activeWorkspaceResolvedHostId: 'ssh:build-box'
+    })
+
+    expect(surfaces).toEqual([{ id: 'folder:folder-shared', path: '/ssh/orca' }])
+  })
+
+  it('does not let a folder row that names no host win the local tie-break', () => {
+    // `getCatalogOwnerHostId` defaults an unstamped row to `local`; honouring that
+    // would mount the unstamped row's path over the row that really is local.
+    const unstampedPeer: FolderWorkspace = {
+      ...localFolder,
+      folderPath: '/unknown/orca',
+      executionHostId: undefined,
+      connectionId: undefined
+    }
+
+    expect(
+      project({
+        folderWorkspaces: [localFolder, unstampedPeer],
+        activeWorkspaceId: 'folder:folder-shared',
+        activeWorkspaceResolvedHostId: 'local'
+      })
+    ).toEqual([{ id: 'folder:folder-shared', path: '/work/orca-local' }])
+  })
+
+  it('emits nothing extra and nothing missing for an empty catalog', () => {
+    expect(project({})).toEqual([])
+  })
+})
+
+// The feed swapped `useAllWorktrees` for `useWorktreeMap`. Both read the same
+// WeakMap-cached snapshot of `worktreesByRepo`, so the zustand `Object.is` compare
+// still re-renders on exactly the writes that replace the slice — no dropped update.
+describe('worktree surface feed subscription identity', () => {
+  const worktreesByRepo = { 'repo-shared': [localWorktree, sshWorktree] }
+
+  it('returns a stable map for an unchanged slice and a fresh one after a replace', () => {
+    expect(getIndexedWorktreeMap(worktreesByRepo)).toBe(getIndexedWorktreeMap(worktreesByRepo))
+    expect(getIndexedWorktreeMap({ ...worktreesByRepo })).not.toBe(
+      getIndexedWorktreeMap(worktreesByRepo)
+    )
+  })
+
+  it('exposes the same id set the host-qualified array does', () => {
+    expect(new Set(getIndexedWorktreeMap(worktreesByRepo).keys())).toEqual(
+      new Set(getIndexedAllWorktrees(worktreesByRepo).map((worktree) => worktree.id))
+    )
   })
 })
 

--- a/src/renderer/src/components/workspace-surface-projection.ts
+++ b/src/renderer/src/components/workspace-surface-projection.ts
@@ -1,0 +1,66 @@
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import type { FolderWorkspace } from '../../../shared/folder-workspace-types'
+import type { Worktree } from '../../../shared/worktree/types'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { getCatalogOwnerHostId } from '../lib/worktree-runtime-owner-index'
+
+export type WorkspaceSurface = { id: string; path: string }
+
+type FolderWorkspaceSurfaceRow = Pick<
+  FolderWorkspace,
+  'id' | 'folderPath' | 'connectionId' | 'executionHostId'
+>
+
+/**
+ * The terminal workbench's mount set: exactly one surface per workspace id.
+ *
+ * Why collapse here and nowhere else: the workbench is bare-id keyed end to end
+ * (`activeWorktreeId`, `tabsByWorktree`, `mountedWorktreeIdsRef`, React keys),
+ * so it can only represent one surface per id — but both catalogs it reads are
+ * host-qualified on purpose (STA-4343), keeping a row per (host, id). Emitting
+ * both mounts one workspace's tabs twice under a duplicate React key. Listing
+ * surfaces such as the sidebar must keep showing every host.
+ *
+ * `worktreesById` is the store's first-wins per-id index, and that collapse is
+ * lossless: `worktreeId` is `repoId::path`, so colliding rows agree on the path.
+ */
+export function projectWorkspaceSurfaces({
+  worktreesById,
+  folderWorkspaces,
+  activeWorkspaceId,
+  activeWorkspaceResolvedHostId
+}: {
+  worktreesById: ReadonlyMap<string, Pick<Worktree, 'path'>>
+  folderWorkspaces: readonly FolderWorkspaceSurfaceRow[]
+  activeWorkspaceId: string | null
+  /** Resolved (not user-selected) host of the active workspace; the folder tie-break. */
+  activeWorkspaceResolvedHostId: ExecutionHostId | null
+}): WorkspaceSurface[] {
+  const surfaces: WorkspaceSurface[] = []
+  for (const [worktreeId, worktree] of worktreesById) {
+    surfaces.push({ id: worktreeId, path: worktree.path })
+  }
+  const folderSurfaceIndexById = new Map<string, number>()
+  for (const workspace of folderWorkspaces) {
+    const id = folderWorkspaceKey(workspace.id)
+    const surface = { id, path: workspace.folderPath }
+    const existingIndex = folderSurfaceIndexById.get(id)
+    if (existingIndex === undefined) {
+      folderSurfaceIndexById.set(id, surfaces.length)
+      surfaces.push(surface)
+      continue
+    }
+    // Why: a folder-workspace id is opaque, not path-derived, so colliding hosts
+    // disagree on the path; only the active workspace's resolved host breaks the tie.
+    // Deriving that host from the row alone is sufficient because every stored row is
+    // stamped with an explicit `executionHostId` by `folderWorkspaceWithFetchedOwner`.
+    if (
+      activeWorkspaceResolvedHostId &&
+      id === activeWorkspaceId &&
+      getCatalogOwnerHostId(workspace) === activeWorkspaceResolvedHostId
+    ) {
+      surfaces[existingIndex] = surface
+    }
+  }
+  return surfaces
+}

--- a/src/renderer/src/components/workspace-surface-projection.ts
+++ b/src/renderer/src/components/workspace-surface-projection.ts
@@ -1,4 +1,4 @@
-import type { ExecutionHostId } from '../../../shared/execution-host'
+import { parseExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
 import type { FolderWorkspace } from '../../../shared/folder-workspace-types'
 import type { Worktree } from '../../../shared/worktree/types'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
@@ -10,6 +10,23 @@ type FolderWorkspaceSurfaceRow = Pick<
   FolderWorkspace,
   'id' | 'folderPath' | 'connectionId' | 'executionHostId'
 >
+
+/**
+ * The row's own host, or null when the row names none.
+ *
+ * `getCatalogOwnerHostId` defaults an unstamped row to `local`, which is the
+ * right answer for an owner lookup but the wrong one for a tie-break: it would
+ * let a row that never named a host win the `local` tie and mount another
+ * host's path. Only a row that names its own host may claim the collision.
+ */
+function getStampedFolderWorkspaceHostId(
+  workspace: FolderWorkspaceSurfaceRow
+): ExecutionHostId | null {
+  const namesOwnHost = Boolean(
+    parseExecutionHostId(workspace.executionHostId) ?? workspace.connectionId?.trim()
+  )
+  return namesOwnHost ? getCatalogOwnerHostId(workspace) : null
+}
 
 /**
  * The terminal workbench's mount set: exactly one surface per workspace id.
@@ -53,11 +70,12 @@ export function projectWorkspaceSurfaces({
     // Why: a folder-workspace id is opaque, not path-derived, so colliding hosts
     // disagree on the path; only the active workspace's resolved host breaks the tie.
     // Deriving that host from the row alone is sufficient because every stored row is
-    // stamped with an explicit `executionHostId` by `folderWorkspaceWithFetchedOwner`.
+    // stamped with an explicit `executionHostId` by `folderWorkspaceWithFetchedOwner`;
+    // an unstamped row keeps first-wins rather than guessing.
     if (
       activeWorkspaceResolvedHostId &&
       id === activeWorkspaceId &&
-      getCatalogOwnerHostId(workspace) === activeWorkspaceResolvedHostId
+      getStampedFolderWorkspaceHostId(workspace) === activeWorkspaceResolvedHostId
     ) {
       surfaces[existingIndex] = surface
     }

--- a/src/renderer/src/components/workspace-surface-projection.ts
+++ b/src/renderer/src/components/workspace-surface-projection.ts
@@ -78,6 +78,15 @@ export function projectWorkspaceSurfaces({
       getStampedFolderWorkspaceHostId(workspace) === activeWorkspaceResolvedHostId
     ) {
       surfaces[existingIndex] = surface
+    } else if (surfaces[existingIndex].path !== surface.path) {
+      // The dropped row's path is the PTY cwd for a tab with no startupCwd, so make the
+      // unresolvable drop observable rather than silently spawning in the other host's directory.
+      console.warn('[workspace-surface] dropping colliding folder path', {
+        id,
+        kept: surfaces[existingIndex].path,
+        dropped: surface.path,
+        droppedHost: getCatalogOwnerHostId(workspace)
+      })
     }
   }
   return surfaces

--- a/tests/e2e/helpers/electron-main-evaluate-retry.ts
+++ b/tests/e2e/helpers/electron-main-evaluate-retry.ts
@@ -1,0 +1,38 @@
+const MAIN_EVALUATE_ATTEMPTS = 5
+const MAIN_EVALUATE_RETRY_MS = 200
+
+/**
+ * Playwright raises this message for any main-process CDP failure that is neither
+ * a JS error nor a closed session, so it does not mean anything navigated — it is
+ * also what a handle the main process has not finished publishing looks like.
+ */
+function isTransientMainEvaluateError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('Execution context was destroyed')
+}
+
+function waitBeforeRetry(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, MAIN_EVALUATE_RETRY_MS))
+}
+
+/**
+ * Run a main-process `ElectronApplication.evaluate` that must not flake.
+ *
+ * Why: `ElectronApplication.evaluate` is unreliable on Electron 27+
+ * (microsoft/playwright#33737) and can reject spuriously while the app is still
+ * coming up — most often on the first call after `electron.launch()` resolves,
+ * which is before the app is `ready`. Wrap only calls that are safe to repeat;
+ * a closed app or a failed assertion still propagates on the first attempt.
+ */
+export async function retryTransientMainEvaluate<T>(run: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; attempt < MAIN_EVALUATE_ATTEMPTS; attempt += 1) {
+    try {
+      return await run()
+    } catch (error) {
+      if (!isTransientMainEvaluateError(error)) {
+        throw error
+      }
+      await waitBeforeRetry()
+    }
+  }
+  return run()
+}

--- a/tests/e2e/helpers/electron-main-evaluate-retry.unit.test.ts
+++ b/tests/e2e/helpers/electron-main-evaluate-retry.unit.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { retryTransientMainEvaluate } from './electron-main-evaluate-retry'
+
+const transient = (): Error =>
+  new Error('Execution context was destroyed, most likely because of a navigation.')
+
+describe('retryTransientMainEvaluate', () => {
+  it('returns the first successful read without retrying', async () => {
+    let calls = 0
+    await expect(
+      retryTransientMainEvaluate(async () => {
+        calls += 1
+        return '/isolated/home'
+      })
+    ).resolves.toBe('/isolated/home')
+    expect(calls).toBe(1)
+  })
+
+  it('rides out the startup window that made the paired-client launch flaky', async () => {
+    let calls = 0
+    await expect(
+      retryTransientMainEvaluate(async () => {
+        calls += 1
+        if (calls < 3) {
+          throw transient()
+        }
+        return '/isolated/home'
+      })
+    ).resolves.toBe('/isolated/home')
+    expect(calls).toBe(3)
+  })
+
+  it('rethrows a real failure immediately instead of masking it behind retries', async () => {
+    let calls = 0
+    await expect(
+      retryTransientMainEvaluate(async () => {
+        calls += 1
+        throw new Error('Electron E2E HOME escaped the disposable profile boundary')
+      })
+    ).rejects.toThrow(/escaped the disposable profile/)
+    expect(calls).toBe(1)
+  })
+
+  it('gives up rather than looping forever when the app never becomes evaluable', async () => {
+    let calls = 0
+    await expect(
+      retryTransientMainEvaluate(async () => {
+        calls += 1
+        throw transient()
+      })
+    ).rejects.toThrow(/Execution context was destroyed/)
+    expect(calls).toBe(5)
+  })
+})

--- a/tests/e2e/helpers/host-session-tabs.ts
+++ b/tests/e2e/helpers/host-session-tabs.ts
@@ -16,22 +16,37 @@ export async function readHostTabs(
   return response.result
 }
 
+type HostBrowserPageRow = { browserPageId: string; url: string }
+
 /**
- * The browser pages the host itself still holds for a worktree.
+ * The host's own browser page registry for a workspace, addressed by worktree selector.
  *
  * Why not readHostTabs: a headless paired host does not project browser pages into
- * session.tabs.list — that snapshot carries only terminals — so asking it whether a page survived
- * a close answers "no" whether or not the close ever reached the host. browser.tabList reads the
- * host's own page registry, which is the thing a close has to empty.
+ * session.tabs.list — that snapshot carries only terminals, and it additionally hides client-placed
+ * pages from any peer that does not advertise `BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY`, which the
+ * CLI socket deliberately does not. `browser.tabList` has neither limitation, so it is the only
+ * oracle that answers "does the host still hold this page" for both placements.
  */
+async function readHostBrowserPages(
+  hostClient: RuntimeClient,
+  worktreeSelector: string,
+  timeoutMs?: number
+): Promise<HostBrowserPageRow[]> {
+  const response = await hostClient.call<{ tabs: HostBrowserPageRow[] }>(
+    'browser.tabList',
+    { worktree: worktreeSelector },
+    { timeoutMs }
+  )
+  return response.result.tabs
+}
+
+/** The page ids the host still holds for a repo-backed worktree. */
 export async function readHostBrowserPageIds(
   hostClient: RuntimeClient,
   repoPath: string
 ): Promise<string[]> {
-  const response = await hostClient.call<{ tabs: { browserPageId: string }[] }>('browser.tabList', {
-    worktree: `path:${repoPath}`
-  })
-  return response.result.tabs.map((tab) => tab.browserPageId).sort()
+  const tabs = await readHostBrowserPages(hostClient, `path:${repoPath}`)
+  return tabs.map((tab) => tab.browserPageId).sort()
 }
 
 /**
@@ -46,9 +61,21 @@ export async function readHostBrowserPageUrl(
   repoPath: string,
   browserPageId: string
 ): Promise<string | null> {
-  const response = await hostClient.call<{ tabs: { browserPageId: string; url: string }[] }>(
-    'browser.tabList',
-    { worktree: `path:${repoPath}` }
-  )
-  return response.result.tabs.find((tab) => tab.browserPageId === browserPageId)?.url ?? null
+  const tabs = await readHostBrowserPages(hostClient, `path:${repoPath}`)
+  return tabs.find((tab) => tab.browserPageId === browserPageId)?.url ?? null
+}
+
+/**
+ * Every browser page URL the host holds, for callers that address the workspace by selector
+ * (`id:`/`path:`) rather than repo path — a folder workspace has no repo path.
+ *
+ * Why the explicit ceiling: a paired host's client is constructed with a 5s default, which the
+ * first tabList can outrun while the host brings its browser session up.
+ */
+export async function readHostBrowserPageUrls(
+  hostClient: RuntimeClient,
+  worktreeSelector: string
+): Promise<string[]> {
+  const tabs = await readHostBrowserPages(hostClient, worktreeSelector, 15_000)
+  return tabs.map((tab) => tab.url)
 }

--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -27,6 +27,7 @@ import path from 'node:path'
 import { TEST_REPO_PATH_FILE } from '../global-setup'
 import { cleanupE2EDaemons, closeElectronAppForE2E } from './electron-process-shutdown'
 import { getOrcaElectronLaunchArgs } from './electron-launch-args'
+import { retryTransientMainEvaluate } from './electron-main-evaluate-retry'
 import { getE2ECompletedOnboardingProfile } from './e2e-completed-onboarding-profile'
 import {
   assertElectronResolvedIsolatedHome,
@@ -256,7 +257,9 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
     })
     forwardElectronProcessLogs(app, testInfo)
     try {
-      const resolvedHome = await app.evaluate(({ app }) => app.getPath('home'))
+      const resolvedHome = await retryTransientMainEvaluate(() =>
+        app.evaluate(({ app }) => app.getPath('home'))
+      )
       assertElectronResolvedIsolatedHome(resolvedHome, homeIsolation)
     } catch (error) {
       await closeElectronAppForE2E(app)

--- a/tests/e2e/helpers/orca-restart.ts
+++ b/tests/e2e/helpers/orca-restart.ts
@@ -22,6 +22,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { getE2ECompletedOnboardingProfile } from './e2e-completed-onboarding-profile'
 import { getOrcaElectronLaunchArgs } from './electron-launch-args'
+import { retryTransientMainEvaluate } from './electron-main-evaluate-retry'
 import { cleanupE2EDaemons, closeElectronAppForE2E } from './electron-process-shutdown'
 import {
   assertElectronResolvedIsolatedHome,
@@ -188,7 +189,9 @@ export function createRestartSession(
       app.process().stderr?.on('data', (chunk: Buffer) => onStderr(chunk.toString()))
     }
     try {
-      const resolvedHome = await app.evaluate(({ app }) => app.getPath('home'))
+      const resolvedHome = await retryTransientMainEvaluate(() =>
+        app.evaluate(({ app }) => app.getPath('home'))
+      )
       assertElectronResolvedIsolatedHome(resolvedHome, homeIsolation)
     } catch (error) {
       await closeElectronAppForE2E(app)

--- a/tests/e2e/helpers/paired-electron-client.ts
+++ b/tests/e2e/helpers/paired-electron-client.ts
@@ -16,6 +16,7 @@ import {
   assertElectronResolvedIsolatedHome,
   createElectronHomeIsolation
 } from './electron-home-isolation'
+import { retryTransientMainEvaluate } from './electron-main-evaluate-retry'
 import { forwardElectronProcessLogs } from './orca-app'
 import {
   replaceRuntimePairingInPlace,
@@ -178,12 +179,16 @@ export async function launchPairedElectronClient(
     }
   })
 
+  // Why before the home assert: forwarding starts here, so a client that fails during startup
+  // otherwise reaches CI as a bare Playwright error with none of its own output attached.
+  forwardElectronProcessLogs(app, testInfo)
   try {
     assertElectronResolvedIsolatedHome(
-      await app.evaluate(({ app: electronApp }) => electronApp.getPath('home')),
+      await retryTransientMainEvaluate(() =>
+        app.evaluate(({ app: electronApp }) => electronApp.getPath('home'))
+      ),
       homeIsolation
     )
-    forwardElectronProcessLogs(app, testInfo)
     const page = await app.firstWindow({ timeout: 120_000 })
     await page.waitForLoadState('domcontentloaded')
     await page.waitForFunction(() => Boolean(window.__store), null, { timeout: 30_000 })

--- a/tests/e2e/helpers/terminal-pty-write-spy.ts
+++ b/tests/e2e/helpers/terminal-pty-write-spy.ts
@@ -1,62 +1,48 @@
 import type { ElectronApplication } from '@stablyai/playwright-test'
 
+import { retryTransientMainEvaluate } from './electron-main-evaluate-retry'
+
 export type PtyWriteLogEntry = { id: string; data: string }
 
-const PTY_WRITE_SPY_INSTALL_ATTEMPTS = 3
-const PTY_WRITE_SPY_INSTALL_RETRY_MS = 150
-
 export async function installTerminalPtyWriteSpy(app: ElectronApplication): Promise<void> {
-  for (let attempt = 1; attempt <= PTY_WRITE_SPY_INSTALL_ATTEMPTS; attempt += 1) {
-    try {
-      await app.evaluate(({ ipcMain }) => {
-        const global = globalThis as unknown as {
-          __terminalPtyWriteLog?: PtyWriteLogEntry[]
-          __terminalPtyWriteSpyInstalled?: boolean
-          __terminalPtyWriteAcceptedSpyInstalled?: boolean
-          __terminalPtyWriteDelayMs?: number
-        }
-        if (global.__terminalPtyWriteSpyInstalled) {
-          return
-        }
-        global.__terminalPtyWriteLog = []
-        global.__terminalPtyWriteSpyInstalled = true
-        ipcMain.prependListener('pty:write', (_event: unknown, args: PtyWriteLogEntry) => {
-          global.__terminalPtyWriteLog!.push({ id: args.id, data: args.data })
-        })
-
-        // Playwright cannot observe ipcRenderer.invoke payloads, so this e2e spy wraps main's handler.
-        const invokeHandlers = (
-          ipcMain as unknown as {
-            _invokeHandlers?: Map<string, (event: unknown, args: PtyWriteLogEntry) => unknown>
-          }
-        )._invokeHandlers
-        const writeAcceptedHandler = invokeHandlers?.get('pty:writeAccepted')
-        if (!writeAcceptedHandler || global.__terminalPtyWriteAcceptedSpyInstalled) {
-          return
-        }
-        global.__terminalPtyWriteAcceptedSpyInstalled = true
-        invokeHandlers?.set('pty:writeAccepted', async (event, args) => {
-          global.__terminalPtyWriteLog!.push({ id: args.id, data: args.data })
-          const delayMs = Math.max(0, global.__terminalPtyWriteDelayMs ?? 0)
-          if (delayMs > 0) {
-            await new Promise((resolve) => setTimeout(resolve, delayMs))
-          }
-          return writeAcceptedHandler(event, args)
-        })
-      })
-      return
-    } catch (error) {
-      if (
-        attempt === PTY_WRITE_SPY_INSTALL_ATTEMPTS ||
-        !isTransientPtyWriteSpyInstallError(error)
-      ) {
-        throw error
+  await retryTransientMainEvaluate(() =>
+    app.evaluate(({ ipcMain }) => {
+      const global = globalThis as unknown as {
+        __terminalPtyWriteLog?: PtyWriteLogEntry[]
+        __terminalPtyWriteSpyInstalled?: boolean
+        __terminalPtyWriteAcceptedSpyInstalled?: boolean
+        __terminalPtyWriteDelayMs?: number
       }
-      // Why: Electron can recreate the evaluated main-world context during
-      // startup; retry keeps setup deterministic without hiding real failures.
-      await waitForPtyWriteSpyInstallRetry()
-    }
-  }
+      if (global.__terminalPtyWriteSpyInstalled) {
+        return
+      }
+      global.__terminalPtyWriteLog = []
+      global.__terminalPtyWriteSpyInstalled = true
+      ipcMain.prependListener('pty:write', (_event: unknown, args: PtyWriteLogEntry) => {
+        global.__terminalPtyWriteLog!.push({ id: args.id, data: args.data })
+      })
+
+      // Playwright cannot observe ipcRenderer.invoke payloads, so this e2e spy wraps main's handler.
+      const invokeHandlers = (
+        ipcMain as unknown as {
+          _invokeHandlers?: Map<string, (event: unknown, args: PtyWriteLogEntry) => unknown>
+        }
+      )._invokeHandlers
+      const writeAcceptedHandler = invokeHandlers?.get('pty:writeAccepted')
+      if (!writeAcceptedHandler || global.__terminalPtyWriteAcceptedSpyInstalled) {
+        return
+      }
+      global.__terminalPtyWriteAcceptedSpyInstalled = true
+      invokeHandlers?.set('pty:writeAccepted', async (event, args) => {
+        global.__terminalPtyWriteLog!.push({ id: args.id, data: args.data })
+        const delayMs = Math.max(0, global.__terminalPtyWriteDelayMs ?? 0)
+        if (delayMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delayMs))
+        }
+        return writeAcceptedHandler(event, args)
+      })
+    })
+  )
 }
 
 export async function clearTerminalPtyWriteLog(app: ElectronApplication): Promise<void> {
@@ -92,12 +78,4 @@ export async function setTerminalPtyWriteDelay(
     const global = globalThis as unknown as { __terminalPtyWriteDelayMs?: number }
     global.__terminalPtyWriteDelayMs = Math.max(0, nextDelayMs)
   }, delayMs)
-}
-
-function isTransientPtyWriteSpyInstallError(error: unknown): boolean {
-  return error instanceof Error && error.message.includes('Execution context was destroyed')
-}
-
-function waitForPtyWriteSpyInstallRetry(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, PTY_WRITE_SPY_INSTALL_RETRY_MS))
 }

--- a/tests/e2e/paired-cmd-j-host-qualified-tabs.spec.ts
+++ b/tests/e2e/paired-cmd-j-host-qualified-tabs.spec.ts
@@ -5,7 +5,11 @@ import {
   launchPairedElectronClient,
   type PairedElectronClient
 } from './helpers/paired-electron-client'
-import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  waitForActiveWorktree,
+  waitForSessionReady,
+  waitForStartupWorktreeRefresh
+} from './helpers/store'
 
 test('routes same-id browser and simulator Cmd-J rows to their owning paired host', async ({
   orcaPage
@@ -66,6 +70,9 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
         { timeout: 60_000, message: 'paired client never mirrored the host browser tab' }
       )
       .toBe(remoteHostId)
+    // Why: hydration's deferred all-host scan rewrites worktreesByRepo; seeding ahead of it is silently reaped.
+    await waitForStartupWorktreeRefresh(page)
+    // Why: empties the mirror's reachable-target set, so the session.tabs subscription tears down before seeding.
     await page.evaluate(() => {
       window.__store!.setState({
         runtimeEnvironments: [],
@@ -112,6 +119,24 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
           !remoteGroup
         ) {
           throw new Error('Paired client did not retain the mirrored host browser topology')
+        }
+        // Why: the fixture nests the client's own layout under its local pane, so the remote group
+        // has to already be rendered there — otherwise the remote rows silently stop being visible.
+        const renderedGroupIds = new Set<string>()
+        const pendingLayoutNodes = [state.layoutByWorktree[sharedWorktreeId]]
+        while (pendingLayoutNodes.length > 0) {
+          const node = pendingLayoutNodes.pop()
+          if (!node) {
+            continue
+          }
+          if (node.type === 'leaf') {
+            renderedGroupIds.add(node.groupId)
+            continue
+          }
+          pendingLayoutNodes.push(node.first, node.second)
+        }
+        if (renderedGroupIds.size > 0 && !renderedGroupIds.has(remoteGroup.id)) {
+          throw new Error('Paired client layout does not render the mirrored host browser group')
         }
         const local = {
           ...seed,
@@ -162,9 +187,17 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
           sortOrder: 0,
           createdAt: 1
         })
+        // Why: a session.tabs frame rebuilds the host's live tabs from the snapshot either way;
+        // keeping their ids in the groups' tabOrder is what makes placement treat them as already
+        // known, so the frame re-lands them where they are instead of adopting them into a group.
+        const retainedMirroredTabs = (state.unifiedTabsByWorktree[sharedWorktreeId] ?? []).map(
+          (candidate) =>
+            candidate.id === remoteUnifiedTab.id
+              ? { ...candidate, executionHostId: remoteHostId }
+              : candidate
+        )
         const tabs = [
           tab('browser-tab-local', 'browser-local', 'group-local', 'local', 'browser', 'Local'),
-          { ...remoteUnifiedTab, executionHostId: remoteHostId },
           tab(
             'simulator-local',
             'simulator-local',
@@ -180,15 +213,16 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
             remoteHostId,
             'simulator',
             'Remote emulator proof'
-          )
+          ),
+          ...retainedMirroredTabs
         ]
         store.setState({
-          repos: [{ ...seedRepo, connectionId: null, executionHostId: 'local' }, seedRepo],
-          worktreesByRepo: { [seed.repoId]: [local, remote] },
+          worktreesByRepo: { ...state.worktreesByRepo, [seed.repoId]: [local, remote] },
           activeRepoId: seed.repoId,
           activeWorktreeId: sharedWorktreeId,
           activeWorkspaceExecutionHostId: 'local',
           browserTabsByWorktree: {
+            ...state.browserTabsByWorktree,
             [sharedWorktreeId]: [localBrowser, seededRemoteBrowser]
           },
           browserPagesByWorkspace: {
@@ -212,8 +246,9 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
               }
             ]
           },
-          unifiedTabsByWorktree: { [sharedWorktreeId]: tabs },
+          unifiedTabsByWorktree: { ...state.unifiedTabsByWorktree, [sharedWorktreeId]: tabs },
           groupsByWorktree: {
+            ...state.groupsByWorktree,
             [sharedWorktreeId]: [
               {
                 id: 'group-local',
@@ -221,28 +256,45 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
                 activeTabId: 'browser-tab-local',
                 tabOrder: ['browser-tab-local', 'simulator-local']
               },
-              {
-                ...remoteGroup,
-                worktreeId: sharedWorktreeId,
-                activeTabId: remoteUnifiedTab.id,
-                tabOrder: [remoteUnifiedTab.id, 'simulator-remote']
-              }
+              ...(state.groupsByWorktree[sharedWorktreeId] ?? []).map((group) =>
+                group.id === remoteGroup.id
+                  ? {
+                      ...group,
+                      activeTabId: remoteUnifiedTab.id,
+                      tabOrder: [...group.tabOrder, 'simulator-remote']
+                    }
+                  : group
+              )
             ]
           },
-          activeGroupIdByWorktree: { [sharedWorktreeId]: 'group-local' },
+          activeGroupIdByWorktree: {
+            ...state.activeGroupIdByWorktree,
+            [sharedWorktreeId]: 'group-local'
+          },
           layoutByWorktree: {
+            ...state.layoutByWorktree,
             [sharedWorktreeId]: {
               type: 'split',
               direction: 'horizontal',
               first: { type: 'leaf', groupId: 'group-local' },
-              second: { type: 'leaf', groupId: remoteGroup.id },
+              // Why: wrap the client's own layout so a host-side split keeps rendering its panes.
+              second: state.layoutByWorktree[sharedWorktreeId] ?? {
+                type: 'leaf',
+                groupId: remoteGroup.id
+              },
               ratio: 0.5
             }
           },
           activeBrowserTabId: 'browser-local',
-          activeBrowserTabIdByWorktree: { [sharedWorktreeId]: 'browser-local' },
+          activeBrowserTabIdByWorktree: {
+            ...state.activeBrowserTabIdByWorktree,
+            [sharedWorktreeId]: 'browser-local'
+          },
           activeTabType: 'browser',
-          activeTabTypeByWorktree: { [sharedWorktreeId]: 'browser' }
+          activeTabTypeByWorktree: {
+            ...state.activeTabTypeByWorktree,
+            [sharedWorktreeId]: 'browser'
+          }
         })
         return {
           remoteGroupId: remoteGroup.id,
@@ -282,20 +334,38 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
       browserCount: 2,
       owners: [
         ['browser-tab-local', 'local', seeded.sharedWorktreeId],
-        [seeded.remoteTabId, remoteHostId, seeded.sharedWorktreeId],
         ['simulator-local', 'local', seeded.sharedWorktreeId],
-        ['simulator-remote', remoteHostId, seeded.sharedWorktreeId]
+        ['simulator-remote', remoteHostId, seeded.sharedWorktreeId],
+        [seeded.remoteTabId, remoteHostId, seeded.sharedWorktreeId]
       ],
       workspaceOwners: [
         ['browser-local', seeded.sharedWorktreeId],
         [seeded.remoteWorkspaceId, seeded.sharedWorktreeId]
       ]
     })
+    // Why: a live catalog refresh that reaps one same-id row re-hosts the surviving palette
+    // entry, so assert the collision still exists at click time instead of blaming the palette.
+    const expectSameIdCollisionIntact = async (step: string): Promise<void> => {
+      expect(
+        await page.evaluate(
+          (worktreeId) =>
+            window
+              .__store!.getState()
+              .allWorktrees()
+              .filter((worktree) => worktree.id === worktreeId)
+              .map((worktree) => worktree.hostId)
+              .sort(),
+          seeded.sharedWorktreeId
+        ),
+        `same-id host rows before ${step}`
+      ).toEqual(['local', remoteHostId].sort())
+    }
     await page.evaluate(() => window.__store!.getState().openModal('worktree-palette'))
     let palette = page.getByRole('dialog', { name: 'Jump to...' })
     let input = palette.getByPlaceholder(
       'Search chats, terminals, worktrees, settings, and actions...'
     )
+    await expectSameIdCollisionIntact('remote browser page palette open')
     const remoteBrowserAfterOpen = await page.evaluate(
       ({ tabId, worktreeId }) => {
         const state = window.__store!.getState()
@@ -304,10 +374,6 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
         )
         return {
           browserCount: state.browserTabsByWorktree[worktreeId]?.length ?? 0,
-          hosts: state
-            .allWorktrees()
-            .filter((worktree) => worktree.id === worktreeId)
-            .map((worktree) => worktree.hostId),
           owner: tab?.executionHostId ?? null
         }
       },
@@ -317,7 +383,6 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
       }
     )
     expect(remoteBrowserAfterOpen.browserCount).toBe(2)
-    expect(remoteBrowserAfterOpen.hosts).toEqual(['local', remoteHostId])
     expect(remoteBrowserAfterOpen.owner).toBe(remoteHostId)
     await input.fill('New Tab')
     await expect(
@@ -328,6 +393,7 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
       body: await page.screenshot(),
       contentType: 'image/png'
     })
+    await expectSameIdCollisionIntact('remote browser page click')
     await palette.locator(`[cmdk-item][data-value="browser-page:${seeded.remotePageId}"]`).click()
     await expect
       .poll(() =>
@@ -357,6 +423,7 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
     await expect(palette.locator('[cmdk-item][data-value="browser-page:page-local"]')).toHaveCount(
       1
     )
+    await expectSameIdCollisionIntact('local browser page click')
     await palette.locator('[cmdk-item][data-value="browser-page:page-local"]').click()
     await expect
       .poll(() =>
@@ -384,6 +451,7 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
       body: await page.screenshot(),
       contentType: 'image/png'
     })
+    await expectSameIdCollisionIntact('remote simulator click')
     await palette.locator('[cmdk-item][data-value="simulator-tab:simulator-remote"]').click()
     await expect
       .poll(() =>
@@ -415,6 +483,7 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
       '[cmdk-item][data-value="simulator-tab:simulator-local"]'
     )
     await expect(localSimulatorRow).toHaveCount(1)
+    await expectSameIdCollisionIntact('local simulator click')
     await localSimulatorRow.click()
     await expect
       .poll(() =>

--- a/tests/e2e/paired-cmd-j-host-qualified-tabs.spec.ts
+++ b/tests/e2e/paired-cmd-j-host-qualified-tabs.spec.ts
@@ -397,16 +397,29 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
     await palette.locator(`[cmdk-item][data-value="browser-page:${seeded.remotePageId}"]`).click()
     await expect
       .poll(() =>
-        page.evaluate(() => {
+        page.evaluate((worktreeId) => {
           const state = window.__store!.getState()
+          const activeGroupId = state.activeGroupIdByWorktree[worktreeId]
           return [
             state.activeWorkspaceExecutionHostId,
             state.activeBrowserTabId,
-            state.activeTabType
+            state.activeTabType,
+            activeGroupId,
+            (state.groupsByWorktree[worktreeId] ?? []).find((group) => group.id === activeGroupId)
+              ?.activeTabId
           ]
-        })
+        }, seeded.sharedWorktreeId)
       )
-      .toEqual([remoteHostId, seeded.remoteWorkspaceId, 'browser'])
+      // Why the group's own activeTabId: `data-active` on a browser tab is the strip's active
+      // tab, not `activeBrowserTabId`, so the simulator rows below already wait on it — asserting
+      // the DOM off the global browser state alone races the group activation.
+      .toEqual([
+        remoteHostId,
+        seeded.remoteWorkspaceId,
+        'browser',
+        seeded.remoteGroupId,
+        seeded.remoteTabId
+      ])
     await expect(palette).not.toBeVisible()
     await expect(
       page.locator(`[data-tab-id="${seeded.remoteWorkspaceId}"][data-active="true"]`).first()
@@ -427,16 +440,20 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
     await palette.locator('[cmdk-item][data-value="browser-page:page-local"]').click()
     await expect
       .poll(() =>
-        page.evaluate(() => {
+        page.evaluate((worktreeId) => {
           const state = window.__store!.getState()
+          const activeGroupId = state.activeGroupIdByWorktree[worktreeId]
           return [
             state.activeWorkspaceExecutionHostId,
             state.activeBrowserTabId,
-            state.activeTabType
+            state.activeTabType,
+            activeGroupId,
+            (state.groupsByWorktree[worktreeId] ?? []).find((group) => group.id === activeGroupId)
+              ?.activeTabId
           ]
-        })
+        }, seeded.sharedWorktreeId)
       )
-      .toEqual(['local', 'browser-local', 'browser'])
+      .toEqual(['local', 'browser-local', 'browser', 'group-local', 'browser-tab-local'])
     await expect(
       page.locator('[data-tab-id="browser-local"][data-active="true"]').first()
     ).toBeVisible()

--- a/tests/e2e/pr11346-selected-runtime-add.spec.ts
+++ b/tests/e2e/pr11346-selected-runtime-add.spec.ts
@@ -7,6 +7,7 @@ import type { ProjectGroup } from '../../src/shared/project-group-types'
 import type { Repo } from '../../src/shared/repo-types'
 import { expect, test } from './helpers/orca-app'
 import { revealPairedClientWindow } from './helpers/paired-client-window-reveal'
+import { forwardRendererConsole } from './helpers/renderer-console-forwarding'
 import {
   createRuntimeDesktopPairingOffer,
   launchPairedElectronClient
@@ -21,11 +22,6 @@ import {
 } from './pr11346-selected-runtime-identity-oracle'
 
 async function selectRuntimeHost(page: Page, runtimeName: string): Promise<Locator> {
-  const crashDialog = page.getByRole('dialog', { name: /recoverable UI error/i })
-  if (await crashDialog.isVisible()) {
-    // Why: same-ID collision fixtures intentionally exceed terminal-workbench invariants.
-    await crashDialog.getByRole('button', { name: /Don't Send/i }).click()
-  }
   await page
     .getByRole('button', { name: /Add Project/i })
     .first()
@@ -100,6 +96,9 @@ async function runSelectedRuntimeAddJourney(
 
   const offer = await createRuntimeDesktopPairingOffer(orcaPage)
   const client = await launchPairedElectronClient(offer, testInfo, runtimeName)
+  // Why: the client renders the workbench under test, and a contained render
+  // crash only names its component stack on the renderer console.
+  forwardRendererConsole(client.page, testInfo)
   const serverUserDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'))
   const clientUserDataDir = await client.app.evaluate(({ app }) => app.getPath('userData'))
   const serverRuntime = new RuntimeClient(serverUserDataDir)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​664 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​112 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​552 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 |

<!-- /orca-pr-loc -->

Fixes **STA-4846**. One of 6 real defects split out of the [test-detected-bugs sweep](https://linear.app/stably/view/test-detected-bugs-3a9343ad1a27).

## ELI5
The workspace catalog is deliberately keyed by *(which machine, which workspace)* — the same workspace id can legitimately appear once for your laptop and once for an SSH host. That's by design (STA-4343).

The terminal workbench, though, is keyed by workspace id **alone** — `activeWorktreeId`, `tabsByWorktree`, `mountedWorktreeIdsRef`, React keys, all bare-id. Hand it both rows and it mounts the same workspace's tabs twice under one React key.

## It's worse than a duplicate-key warning
Visibility is `workspace.id === renderedActiveWorktreeId`, and `activeWorktreeId` is a bare `string | null`. So a collision on the **active** workspace marks *both* duplicate surfaces visible — two `absolute inset-0` non-hidden trees mounting the same tabIds at once, not one live plus one hidden. Each mounts a full `TerminalPaneOverlayLayer` → `TerminalOverlaySlot` → `TerminalPane` for the same tabId, contending over tabId-keyed global registries (`terminal-input-quarantine`, `terminal-parked-watcher-registry`, `terminal-pane-recovery`).

The folder branch collides identically: `getFolderWorkspaceHostIdentity` is `JSON.stringify([hostId, workspace.id])` and `mergeFetchedFolderWorkspacesForHost` is *engineered* to keep both hosts' rows, so `folderWorkspaceKey(workspace.id)` collides too.

## The fix
One explicit projection (`projectWorkspaceSurfaces`) that collapses to exactly one surface per id **at the workbench boundary, and only there**. Sidebar and other listing surfaces still show every host — that is intended behavior, not a bug.

The collapse is lossless for git worktrees: `worktreeId` is `repoId::path`, so colliding rows agree on the path. Folder workspaces have opaque, non-path-derived ids, so they get an explicit host tie-break instead.

## Why this cannot drop a surface the user owns
This runs on every workspace switch for every user, so under-selection — losing a terminal — would be strictly worse than the duplicate it fixes. It cannot happen, and the argument is mechanical rather than empirical:

1. **The id set is unchanged.** `getIndexedAllWorktrees` and `getIndexedWorktreeMap` are built from the *same* `byHostAndId` loop in `src/renderer/src/store/worktree-repo-index.ts:46-61`; the map holds every distinct id the array does, only without repeats. The old feed's id set and the new feed's id set are literally the same set — pinned by a test.
2. **The id round-trip is exact.** The map key comes from `getWorktreeIdFromHostIdentity`, and `src/shared/worktree/host-qualified-identity.ts:34-39,66-68` splits on the first `|`, which an execution host id cannot contain. An **unqualified** row (`hostId: undefined`) composes to `|<id>` and round-trips identically, so it keeps its id rather than being swallowed.
3. **Nothing downstream is host-aware, so a second row never carried its own state.** Every read keyed off a surface is bare-id: `tabsByWorktree[workspace.id]` (`Terminal.tsx:2674`), `browserTabsByWorktree[workspace.id]` (`Terminal.tsx:2739`), `mountedWorktreeIdsRef`, `layoutByWorktree`, `activeGroupIdByWorktree`. Two rows with one id rendered *the same tabs twice*, not two hosts' tabs. Collapsing removes a duplicate, never a workspace.
4. **Only `path` differs between colliding rows, and for git it doesn't.** `src/shared/worktree/types.ts:62` defines `id` as `` `${repoId}::${path}` ``, so a git collision necessarily agrees on the path.
5. **The unmount prune is safe.** `Terminal.tsx:1422` prunes `mountedWorktreeIdsRef` against the surface **id set**; that set is unchanged (1), so no mounted workspace is evicted.
6. **Folder and git ids are disjoint.** `folderWorkspaceKey` prefixes `folder:` (`src/shared/workspace-scope.ts:3-9`), so a folder workspace can never collapse into a worktree.

Covered by 20 unit tests, including: local-only catalogs where no row names a host; unqualified vs `local` on one id; **two SSH hosts** on one id with no local row; three-host folder collapse; folder workspaces alongside git worktrees; and a whole-catalog assertion that the emitted id set equals the distinct input id set exactly.

### Tie-break hardening
The folder tie-break now requires the row to *name* its own host. `getCatalogOwnerHostId` defaults an unstamped row to `local` — right for an owner lookup, wrong for a tie-break, where it would let a row that never named a host win the `local` tie and mount another host's path. An unstamped row now keeps first-wins instead of guessing. Mutation-checked: reverting that one predicate turns the new test red.

### `useAllWorktrees` → `useWorktreeMap`
Behavior-preserving. Both selectors are `useAppStore((s) => …(s.worktreesByRepo))` over the *same* `WeakMap`-cached snapshot, so zustand's `Object.is` compare fires on exactly the same writes — the ones that replace `worktreesByRepo`. No update can be dropped; a test pins both the reference stability and the id-set equality. The `useMemo` gains `renderedActiveWorktreeId` and `activeFolderSurfaceHostId` as deps, but every effect consuming `workspaceSurfaces` already depended on `renderedActiveWorktreeId`, so no effect runs more often than before.

## Honest caveat
The ticket's original symptom — a React error boundary on `terminal-workbench` — remains **UNDETERMINED**. No React stack was ever captured (the ticket concedes this in its own "Diagnostics gap"), and 5 runs at HEAD completed the journey with the collision state asserted live.

What investigation *did* settle is the duplicate-mount defect above: it is production-real, not fixture-dependent, and sits on exactly the reported render path. **It is fixed here on its own merits — this PR does not claim to be a proven fix for the reported crash.** The one adjacent datapoint is that `pr11346-selected-runtime-add.spec.ts` no longer needs its conditional "recoverable UI error" dialog dismissal; that is suggestive for *this fixture*, not proof for the filed report.

## Proof

The behavioural guarantee is carried by the unit suite, not by a suite-wide count — reverting
`Terminal.tsx` to `2daea491b96` fails exactly the two source-text ratchet assertions in
`workspace-surface-projection.test.ts` (`useAllWorktrees` still present, no
`projectWorkspaceSurfaces` call site) and nothing else, because the rest of the suite never
constructs a same-id-two-host catalog. The real coverage is the 20 cases in that file, including
the under-selection set above.

```
$ pnpm test src/renderer/src/components/workspace-surface-projection.test.ts
 Test Files  1 passed (1)
      Tests  20 passed (20)
```

`pnpm tc` clean. `oxlint` clean. `pnpm run check:code-quality:changed`: `0 new finding(s) across 6 changed file(s)` for code quality, type-aware code quality, and React Doctor.

Both changed e2e specs green at CI's worker count:

```
$ pnpm exec playwright test --config tests/playwright.config.ts --project=electron-headless \
    tests/e2e/paired-cmd-j-host-qualified-tabs.spec.ts tests/e2e/pr11346-selected-runtime-add.spec.ts
  ✓ paired-cmd-j-host-qualified-tabs.spec.ts:14:5 › routes same-id browser and simulator Cmd-J rows to their owning paired host (29.9s)
  ✓ pr11346-selected-runtime-add.spec.ts:760:5 › keeps every selected-runtime Add Project path in hidden-window desktop parity (47.8s)
  2 passed (3.4m)
```

The CI failure this branch previously showed (`Cannot find module './helpers/renderer-console-forwarding'`) was a missing helper that has since landed on `main` via #17434; the rebase onto `main` resolves it with no code change here.

## Performance Measurement

Deterministic same-ID/different-host fixture: the old workbench mounted 2 terminal surfaces for one bare workspace id; the explicit projection mounts 1. That removes 1 duplicate `TerminalPane` tree (50% fewer mounted terminal surfaces) while preserving both host rows in the sidebar.

## User-Facing Trade-offs

None. Each host's workspace remains visible in listings; only the workbench's duplicate mount is collapsed to one surface per workspace id. The projection provably emits every distinct workspace id it is given (see "Why this cannot drop a surface the user owns"), so no user loses a terminal on any workspace switch.
