### PR TITLE
fix(native-chat): keep agent responses selectable

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { NativeChatLiveSession } from './use-native-chat-live-session'
+import { NativeChatMessageList } from './NativeChatMessageList'
+
+afterEach(cleanup)
+
+const session: NativeChatLiveSession = {
+  messages: [
+    {
+      id: 'assistant-1',
+      role: 'assistant',
+      blocks: [{ type: 'text', text: 'Selectable agent response.' }],
+      timestamp: 1,
+      source: 'transcript'
+    }
+  ],
+  status: 'ready',
+  sessionId: 'session-1',
+  agent: 'codex',
+  hasMore: false,
+  loadingEarlier: false,
+  loadEarlier: vi.fn(),
+  readPhase: 'ready'
+}
+
+describe('NativeChatMessageList assistant messages', () => {
+  it('keeps prose selectable and places non-selectable controls after it', () => {
+    render(
+      <NativeChatMessageList
+        session={session}
+        isWorking={false}
+        expandSignal={false}
+        fontScale={1}
+      />
+    )
+
+    const prose = screen.getByText('Selectable agent response.')
+    const row = prose.closest('.group')
+    const copyButton = screen.getByRole('button', { name: 'Copy message' })
+    const controls = copyButton.parentElement
+
+    expect(row).toHaveClass('select-text')
+    expect(controls).toHaveClass('select-none', 'pointer-events-none', 'mt-1')
+    expect(controls).not.toHaveClass('absolute')
+    expect(prose.compareDocumentPosition(controls!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -68,9 +68,7 @@ function ImageAttachmentRefs({ blocks }: { blocks: NativeChatBlock[] }): React.J
   )
 }
 
-/** Inline controls for an agent message (mobile AgentControls parity): copy the
- *  message's prose, and scroll so this message's top aligns to the viewport top.
- *  Reveals on hover / keyboard focus like the prior copy affordance. */
+/** Footer controls for an agent message: copy its prose or align it to the viewport top. */
 function AgentControls({
   markdown,
   onScrollToTop,
@@ -243,19 +241,12 @@ function MessageRow({
     <div
       ref={rowRef}
       className={cn(
-        'group relative max-w-full text-sm leading-relaxed text-foreground',
+        'group relative max-w-full select-text text-sm leading-relaxed text-foreground',
         // Reasoning is the agent thinking aloud — quieter, italic, like an aside.
         isReasoning && 'border-l-2 border-border/60 pl-3 italic text-muted-foreground',
         isSystem && 'text-xs text-muted-foreground'
       )}
     >
-      {showControls ? (
-        <AgentControls
-          markdown={markdown}
-          onScrollToTop={scrollToTop}
-          className="absolute -top-8 right-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
-        />
-      ) : null}
       <ImageAttachmentRefs blocks={prose} />
       {markdown ? (
         <CommentMarkdown
@@ -267,6 +258,13 @@ function MessageRow({
         />
       ) : null}
       {tools.length > 0 ? <NativeChatToolRun blocks={tools} expandSignal={expandSignal} /> : null}
+      {showControls ? (
+        <AgentControls
+          markdown={markdown}
+          onScrollToTop={scrollToTop}
+          className="pointer-events-none mt-1 -mb-5 w-fit select-none opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
+        />
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |

<!-- /orca-pr-loc -->

## Summary

- Keep assistant prose selectable during mouse drag.
- Move copy and scroll controls into a footer below the response.
- Prevent hidden controls from intercepting pointer selection.
- Add a regression test for selectable prose and control placement.

## Verification

- `pnpm run check:code-quality:changed`
- `pnpm tc:web`
- `pnpm test src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx src/renderer/src/components/native-chat/NativeChatMessageList.provider-frame.test.tsx`
- Electron E2E: seeded a Claude native-chat transcript, dragged across the rendered assistant response, verified `window.getSelection()` contained the full response, clicked Copy message, and verified the clipboard matched exactly.

## Visual proof

![02-hydrated.png](https://github.com/user-attachments/assets/01f97bc7-cf12-4349-a96d-93f8696f6231)

## ELI5

The copy and scroll buttons used to float on top of the assistant's words, so an invisible button could steal a mouse drag and stop text selection. The buttons now sit in a footer after the response and ignore pointer events while hidden; hover and keyboard access remain available.

## Performance Measurement

This is a UI correctness fix, not a performance optimization, so no speedup is claimed. The regression fixture renders one assistant row with one two-button controls footer; message parsing and control-render counts remain one per assistant message before and after. No new IPC or network work is added.

## User-Facing Trade-offs

The controls move below the response and add only the intentional footer spacing; they remain hover- and keyboard-accessible. Transcript, copy, and selection data are unchanged.
