### PR TITLE
fix(native-chat): preserve structured chat across rollback

### DIFF
--- a/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-reverse.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-reverse.ts
@@ -130,7 +130,7 @@ export async function handoffStructuredSessionToNative(
     throw error
   }
   context.releaseOwner(sessionId)
-  deps.transport?.revealNativeSession?.({
+  await deps.transport?.revealNativeSession?.({
     workspaceId: record.location.workspaceId,
     sessionId,
     agent: record.provider,

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-types.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-types.ts
@@ -49,7 +49,7 @@ export type StructuredAgentSessionHandoffTransport = {
     sessionId: string
     agent?: 'claude' | 'codex'
     adoptedTerminal?: true
-  }): void
+  }): Promise<void> | void
   waitForTuiExit(owner: StructuredTuiOwner): Promise<{ transcriptPath?: string }>
   waitForTuiIdleOrExit(
     owner: StructuredTuiOwner,

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -184,6 +184,14 @@ export class StructuredAgentSessionHost {
     return listStructuredAgentSessionTabs(this.sessions)
   }
 
+  listPersistedVisibleSessionIds(): string[] {
+    return this.deps.store.listVisibleSessionIds()
+  }
+
+  setSessionTabVisibility(sessionId: string, visible: boolean): Promise<void> {
+    return this.deps.store.setSessionTabVisibility(sessionId, visible)
+  }
+
   reconcileRestartLeases = async (): Promise<void> => {
     const refusal = await this.reconcileLeases('startup')
     if (refusal) {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -184,8 +184,8 @@ export class StructuredAgentSessionHost {
     return listStructuredAgentSessionTabs(this.sessions)
   }
 
-  listPersistedVisibleSessionIds(): string[] {
-    return this.deps.store.listVisibleSessionIds()
+  getPersistedVisibleSessionTabIndex(): { present: boolean; sessionIds: string[] } {
+    return this.deps.store.getVisibleSessionTabIndex()
   }
 
   setSessionTabVisibility(sessionId: string, visible: boolean): Promise<void> {

--- a/src/main/runtime/agent-session-record-store-file.ts
+++ b/src/main/runtime/agent-session-record-store-file.ts
@@ -26,6 +26,8 @@ import {
   renameDurable,
   writeTempFileDurable
 } from '../durable-file-write'
+import { parseVisibleSessionIds } from './agent-session-visible-tab-index'
+import { serializeAgentSessionStoreState } from './agent-session-store-serialization'
 
 export const AGENT_SESSION_STORE_SCHEMA_VERSION = 2 as const
 
@@ -41,6 +43,8 @@ export type AgentSessionStoreState = {
   retiredClaimKeys: RetiredAgentSessionClaimKey[]
   /** Rows this build cannot validate, kept with a durable refusal reason. */
   unreadableRecords: Map<string, { reason: string; raw: unknown }>
+  /** Structured sessions that currently have a visible chat tab. */
+  visibleSessionIds: Set<string>
 }
 
 export type LoadedAgentSessionStore = {
@@ -58,9 +62,7 @@ export function agentSessionStorePath(directory: string): string {
   return join(directory, AGENT_SESSION_STORE_FILE_NAME)
 }
 
-function backupPath(filePath: string): string {
-  return `${filePath}.bak`
-}
+const backupPath = (filePath: string): string => `${filePath}.bak`
 
 function emptyState(hostId: string): AgentSessionStoreState {
   return {
@@ -69,7 +71,8 @@ function emptyState(hostId: string): AgentSessionStoreState {
     records: new Map(),
     operations: new Map(),
     retiredClaimKeys: [],
-    unreadableRecords: new Map()
+    unreadableRecords: new Map(),
+    visibleSessionIds: new Set()
   }
 }
 
@@ -77,7 +80,7 @@ export function agentSessionStoreRevision(state: AgentSessionStoreState): string
   return createHash('sha256')
     .update(String(state.schemaVersion))
     .update('\0')
-    .update(serializeState(state))
+    .update(serializeAgentSessionStoreState(state))
     .digest('hex')
 }
 
@@ -101,6 +104,7 @@ function parseState(
     operations?: unknown
     retiredClaimKeys?: unknown
     unusableRecords?: unknown
+    visibleSessionIds?: unknown
   }
   if (
     !Number.isSafeInteger(file.schemaVersion) ||
@@ -208,6 +212,17 @@ function parseState(
       state.retiredClaimKeys.push({ keyId: key.keyId, retiredAt: key.retiredAt as number })
     }
   }
+  const visibleSessionIds = parseVisibleSessionIds(
+    file.visibleSessionIds,
+    schemaVersion,
+    AGENT_SESSION_STORE_SCHEMA_VERSION
+  )
+  if (!visibleSessionIds.valid) {
+    return null
+  }
+  for (const sessionId of visibleSessionIds.ids) {
+    state.visibleSessionIds.add(sessionId)
+  }
   return { state, needsRewrite }
 }
 
@@ -295,21 +310,6 @@ export async function loadAgentSessionStore(
   }
 }
 
-function serializeState(state: AgentSessionStoreState): string {
-  const records: Record<string, unknown> = Object.create(null)
-  for (const [sessionId, record] of state.records) {
-    records[sessionId] = record
-  }
-  return JSON.stringify({
-    schemaVersion: AGENT_SESSION_STORE_SCHEMA_VERSION,
-    hostId: state.hostId,
-    records,
-    operations: Object.fromEntries(state.operations),
-    retiredClaimKeys: state.retiredClaimKeys,
-    unusableRecords: Object.fromEntries(state.unreadableRecords)
-  })
-}
-
 /**
  * Commit the whole state. The live path is never absent: the new content is made durable in a temp
  * file first, a validated primary is COPIED to the backup, and only then does the rename publish it.
@@ -329,7 +329,7 @@ export async function saveAgentSessionStore(
   await chmod(directory, 0o700)
   const tmpPath = durableWriteTempPath(filePath)
   try {
-    await writeTempFileDurable(tmpPath, serializeState(state), 0o600)
+    await writeTempFileDurable(tmpPath, serializeAgentSessionStoreState(state), 0o600)
     // Only a primary parsed under the transaction lock may replace the backup. During recovery the
     // primary is corrupt or absent, so the known-good backup must survive until publication.
     if (options.primaryStatus === 'validated') {

--- a/src/main/runtime/agent-session-record-store-file.ts
+++ b/src/main/runtime/agent-session-record-store-file.ts
@@ -45,6 +45,8 @@ export type AgentSessionStoreState = {
   unreadableRecords: Map<string, { reason: string; raw: unknown }>
   /** Structured sessions that currently have a visible chat tab. */
   visibleSessionIds: Set<string>
+  /** True once this store has committed the visibility index field. */
+  visibleSessionIdsIndexPresent: boolean
 }
 
 export type LoadedAgentSessionStore = {
@@ -72,7 +74,8 @@ function emptyState(hostId: string): AgentSessionStoreState {
     operations: new Map(),
     retiredClaimKeys: [],
     unreadableRecords: new Map(),
-    visibleSessionIds: new Set()
+    visibleSessionIds: new Set(),
+    visibleSessionIdsIndexPresent: false
   }
 }
 
@@ -220,9 +223,8 @@ function parseState(
   if (!visibleSessionIds.valid) {
     return null
   }
-  for (const sessionId of visibleSessionIds.ids) {
-    state.visibleSessionIds.add(sessionId)
-  }
+  state.visibleSessionIdsIndexPresent = visibleSessionIds.present
+  visibleSessionIds.ids.forEach((sessionId) => state.visibleSessionIds.add(sessionId))
   return { state, needsRewrite }
 }
 

--- a/src/main/runtime/agent-session-record-store.ts
+++ b/src/main/runtime/agent-session-record-store.ts
@@ -118,6 +118,11 @@ export class AgentSessionRecordStore {
   listVisibleSessionIds = (): string[] =>
     [...this.state.visibleSessionIds].filter((sessionId) => this.state.records.has(sessionId))
 
+  getVisibleSessionTabIndex = (): { present: boolean; sessionIds: string[] } => ({
+    present: this.state.visibleSessionIdsIndexPresent,
+    sessionIds: this.listVisibleSessionIds()
+  })
+
   /** Persist the user-visible tab reference separately from the rollback-sensitive profile tabs. */
   setSessionTabVisibility(sessionId: string, visible: boolean): Promise<void> {
     return this.transact(() => {
@@ -129,6 +134,7 @@ export class AgentSessionRecordStore {
       } else {
         this.state.visibleSessionIds.delete(sessionId)
       }
+      this.state.visibleSessionIdsIndexPresent = true
     })
   }
 

--- a/src/main/runtime/agent-session-record-store.ts
+++ b/src/main/runtime/agent-session-record-store.ts
@@ -115,6 +115,23 @@ export class AgentSessionRecordStore {
 
   listRecords = (): AgentSessionRecord[] => [...this.state.records.values()]
 
+  listVisibleSessionIds = (): string[] =>
+    [...this.state.visibleSessionIds].filter((sessionId) => this.state.records.has(sessionId))
+
+  /** Persist the user-visible tab reference separately from the rollback-sensitive profile tabs. */
+  setSessionTabVisibility(sessionId: string, visible: boolean): Promise<void> {
+    return this.transact(() => {
+      if (visible) {
+        if (!this.state.records.has(sessionId)) {
+          throw new Error('agent_session_identity_required')
+        }
+        this.state.visibleSessionIds.add(sessionId)
+      } else {
+        this.state.visibleSessionIds.delete(sessionId)
+      }
+    })
+  }
+
   listByScope(location: AgentSessionExecutionLocation): AgentSessionRecord[] {
     const scope = agentSessionScopeKey(location)
     return this.listRecords().filter((record) => agentSessionScopeKey(record.location) === scope)

--- a/src/main/runtime/agent-session-recovery-publish-fault.test.ts
+++ b/src/main/runtime/agent-session-recovery-publish-fault.test.ts
@@ -48,7 +48,8 @@ function state(generation: number): AgentSessionStoreState {
     operations: new Map(),
     retiredClaimKeys: [{ keyId: `generation-${generation}`, retiredAt: generation }],
     unreadableRecords: new Map(),
-    visibleSessionIds: new Set()
+    visibleSessionIds: new Set(),
+    visibleSessionIdsIndexPresent: false
   }
 }
 

--- a/src/main/runtime/agent-session-recovery-publish-fault.test.ts
+++ b/src/main/runtime/agent-session-recovery-publish-fault.test.ts
@@ -47,7 +47,8 @@ function state(generation: number): AgentSessionStoreState {
     records: new Map(),
     operations: new Map(),
     retiredClaimKeys: [{ keyId: `generation-${generation}`, retiredAt: generation }],
-    unreadableRecords: new Map()
+    unreadableRecords: new Map(),
+    visibleSessionIds: new Set()
   }
 }
 

--- a/src/main/runtime/agent-session-store-serialization.ts
+++ b/src/main/runtime/agent-session-store-serialization.ts
@@ -5,13 +5,16 @@ export function serializeAgentSessionStoreState(state: AgentSessionStoreState): 
   for (const [sessionId, record] of state.records) {
     records[sessionId] = record
   }
-  return JSON.stringify({
+  const serialized: Record<string, unknown> = {
     schemaVersion: state.schemaVersion,
     hostId: state.hostId,
     records,
     operations: Object.fromEntries(state.operations),
     retiredClaimKeys: state.retiredClaimKeys,
-    unusableRecords: Object.fromEntries(state.unreadableRecords),
-    visibleSessionIds: [...state.visibleSessionIds]
-  })
+    unusableRecords: Object.fromEntries(state.unreadableRecords)
+  }
+  if (state.visibleSessionIdsIndexPresent) {
+    serialized.visibleSessionIds = [...state.visibleSessionIds]
+  }
+  return JSON.stringify(serialized)
 }

--- a/src/main/runtime/agent-session-store-serialization.ts
+++ b/src/main/runtime/agent-session-store-serialization.ts
@@ -1,0 +1,17 @@
+import type { AgentSessionStoreState } from './agent-session-record-store-file'
+
+export function serializeAgentSessionStoreState(state: AgentSessionStoreState): string {
+  const records: Record<string, unknown> = Object.create(null)
+  for (const [sessionId, record] of state.records) {
+    records[sessionId] = record
+  }
+  return JSON.stringify({
+    schemaVersion: state.schemaVersion,
+    hostId: state.hostId,
+    records,
+    operations: Object.fromEntries(state.operations),
+    retiredClaimKeys: state.retiredClaimKeys,
+    unusableRecords: Object.fromEntries(state.unreadableRecords),
+    visibleSessionIds: [...state.visibleSessionIds]
+  })
+}

--- a/src/main/runtime/agent-session-store-transaction-queue.ts
+++ b/src/main/runtime/agent-session-store-transaction-queue.ts
@@ -38,12 +38,14 @@ function agentSessionStoreStateChanged(
   operations: ReadonlyMap<string, AgentSessionOperationRow>,
   retiredClaimKeys: AgentSessionStoreState['retiredClaimKeys'],
   unreadableRecords: AgentSessionStoreState['unreadableRecords'],
-  visibleSessionIds: AgentSessionStoreState['visibleSessionIds']
+  visibleSessionIds: AgentSessionStoreState['visibleSessionIds'],
+  visibleSessionIdsIndexPresent: AgentSessionStoreState['visibleSessionIdsIndexPresent']
 ): boolean {
   return (
     !mapEntriesMatch(state.records, records) ||
     !mapEntriesMatch(state.operations, operations) ||
     !mapEntriesMatch(state.unreadableRecords, unreadableRecords) ||
+    state.visibleSessionIdsIndexPresent !== visibleSessionIdsIndexPresent ||
     state.visibleSessionIds.size !== visibleSessionIds.size ||
     [...state.visibleSessionIds].some((id) => !visibleSessionIds.has(id)) ||
     state.retiredClaimKeys.length !== retiredClaimKeys.length ||
@@ -98,6 +100,7 @@ export class AgentSessionStoreTransactionQueue {
         const retiredClaimKeys = [...this.state.retiredClaimKeys]
         const unreadableRecords = new Map(this.state.unreadableRecords)
         const visibleSessionIds = new Set(this.state.visibleSessionIds)
+        const visibleSessionIdsIndexPresent = this.state.visibleSessionIdsIndexPresent
         try {
           // The lost commit may have granted a higher fence than the backup records show. Rather
           // than refuse forever, raise every recovered fence clear of anything that commit could
@@ -116,7 +119,8 @@ export class AgentSessionStoreTransactionQueue {
               operations,
               retiredClaimKeys,
               unreadableRecords,
-              visibleSessionIds
+              visibleSessionIds,
+              visibleSessionIdsIndexPresent
             )
           ) {
             return result
@@ -136,6 +140,7 @@ export class AgentSessionStoreTransactionQueue {
           this.state.retiredClaimKeys = retiredClaimKeys
           this.state.unreadableRecords = unreadableRecords
           this.state.visibleSessionIds = visibleSessionIds
+          this.state.visibleSessionIdsIndexPresent = visibleSessionIdsIndexPresent
           throw error
         }
       })

--- a/src/main/runtime/agent-session-store-transaction-queue.ts
+++ b/src/main/runtime/agent-session-store-transaction-queue.ts
@@ -37,12 +37,15 @@ function agentSessionStoreStateChanged(
   records: ReadonlyMap<string, AgentSessionRecord>,
   operations: ReadonlyMap<string, AgentSessionOperationRow>,
   retiredClaimKeys: AgentSessionStoreState['retiredClaimKeys'],
-  unreadableRecords: AgentSessionStoreState['unreadableRecords']
+  unreadableRecords: AgentSessionStoreState['unreadableRecords'],
+  visibleSessionIds: AgentSessionStoreState['visibleSessionIds']
 ): boolean {
   return (
     !mapEntriesMatch(state.records, records) ||
     !mapEntriesMatch(state.operations, operations) ||
     !mapEntriesMatch(state.unreadableRecords, unreadableRecords) ||
+    state.visibleSessionIds.size !== visibleSessionIds.size ||
+    [...state.visibleSessionIds].some((id) => !visibleSessionIds.has(id)) ||
     state.retiredClaimKeys.length !== retiredClaimKeys.length ||
     state.retiredClaimKeys.some((entry, index) => entry !== retiredClaimKeys[index])
   )
@@ -94,6 +97,7 @@ export class AgentSessionStoreTransactionQueue {
         const operations = new Map(this.state.operations)
         const retiredClaimKeys = [...this.state.retiredClaimKeys]
         const unreadableRecords = new Map(this.state.unreadableRecords)
+        const visibleSessionIds = new Set(this.state.visibleSessionIds)
         try {
           // The lost commit may have granted a higher fence than the backup records show. Rather
           // than refuse forever, raise every recovered fence clear of anything that commit could
@@ -111,7 +115,8 @@ export class AgentSessionStoreTransactionQueue {
               records,
               operations,
               retiredClaimKeys,
-              unreadableRecords
+              unreadableRecords,
+              visibleSessionIds
             )
           ) {
             return result
@@ -130,6 +135,7 @@ export class AgentSessionStoreTransactionQueue {
           this.state.operations = operations
           this.state.retiredClaimKeys = retiredClaimKeys
           this.state.unreadableRecords = unreadableRecords
+          this.state.visibleSessionIds = visibleSessionIds
           throw error
         }
       })

--- a/src/main/runtime/agent-session-visible-tab-index.ts
+++ b/src/main/runtime/agent-session-visible-tab-index.ts
@@ -1,0 +1,21 @@
+export function parseVisibleSessionIds(
+  raw: unknown,
+  schemaVersion: number,
+  currentSchemaVersion: number
+): { ids: string[]; valid: boolean } {
+  if (raw === undefined) {
+    return { ids: [], valid: true }
+  }
+  if (!Array.isArray(raw)) {
+    return { ids: [], valid: schemaVersion !== currentSchemaVersion }
+  }
+  const ids: string[] = []
+  for (const value of raw) {
+    if (typeof value === 'string' && value.length > 0) {
+      ids.push(value)
+    } else if (schemaVersion === currentSchemaVersion) {
+      return { ids: [], valid: false }
+    }
+  }
+  return { ids, valid: true }
+}

--- a/src/main/runtime/agent-session-visible-tab-index.ts
+++ b/src/main/runtime/agent-session-visible-tab-index.ts
@@ -2,20 +2,20 @@ export function parseVisibleSessionIds(
   raw: unknown,
   schemaVersion: number,
   currentSchemaVersion: number
-): { ids: string[]; valid: boolean } {
+): { ids: string[]; present: boolean; valid: boolean } {
   if (raw === undefined) {
-    return { ids: [], valid: true }
+    return { ids: [], present: false, valid: true }
   }
   if (!Array.isArray(raw)) {
-    return { ids: [], valid: schemaVersion !== currentSchemaVersion }
+    return { ids: [], present: false, valid: schemaVersion !== currentSchemaVersion }
   }
   const ids: string[] = []
   for (const value of raw) {
     if (typeof value === 'string' && value.length > 0) {
       ids.push(value)
     } else if (schemaVersion === currentSchemaVersion) {
-      return { ids: [], valid: false }
+      return { ids: [], present: true, valid: false }
     }
   }
-  return { ids, valid: true }
+  return { ids, present: true, valid: true }
 }

--- a/src/main/runtime/orca-runtime-structured-session-restore.test.ts
+++ b/src/main/runtime/orca-runtime-structured-session-restore.test.ts
@@ -107,6 +107,44 @@ describe('structured session cold restoration', () => {
     )
   })
 
+  it('prefers the durable visible-session index after a legacy profile drops agent tabs', async () => {
+    const runtime = new OrcaRuntimeService()
+    const restoreReadableSessions = vi.fn(async () => undefined)
+    const internal = runtime as unknown as {
+      store: { getWorkspaceSession: () => unknown }
+      hasPersistedStructuredAgentSessionStore(): boolean
+      getKnownWorkspaceSessionWorktreeIds(): Set<string>
+      hydrateHeadlessMobileSessionTabsFromWorkspaceSession(): Set<string>
+      refreshMobileSessionPtyRecords(): Promise<Set<string> | null>
+      ensureStructuredAgentSessionHost(): Promise<void>
+    }
+    internal.store = {
+      getWorkspaceSession: () => ({
+        activeRepoId: null,
+        activeWorktreeId: 'workspace-1',
+        activeTabId: null,
+        tabsByWorktree: {},
+        terminalLayoutsByTabId: {},
+        unifiedTabs: { 'workspace-1': [] }
+      })
+    }
+    internal.hasPersistedStructuredAgentSessionStore = () => true
+    internal.getKnownWorkspaceSessionWorktreeIds = () => new Set()
+    internal.hydrateHeadlessMobileSessionTabsFromWorkspaceSession = () => new Set()
+    internal.refreshMobileSessionPtyRecords = async () => new Set()
+    internal.ensureStructuredAgentSessionHost = async () => undefined
+    setStructuredAgentSessionHost({
+      reconcileRestartLeases: async () => undefined,
+      listPersistedVisibleSessionIds: () => ['session-survives-rollback'],
+      restoreReadableSessions,
+      listSessionTabs: () => []
+    } as never)
+
+    await runtime.restoreStructuredAgentSessionTabs()
+
+    expect(restoreReadableSessions).toHaveBeenCalledWith(['session-survives-rollback'])
+  })
+
   it('normalizes a restored tab id and removes it when closed', async () => {
     const runtime = new OrcaRuntimeService()
     const closeSessionTab = vi.fn(async () => undefined)

--- a/src/main/runtime/orca-runtime-structured-session-restore.test.ts
+++ b/src/main/runtime/orca-runtime-structured-session-restore.test.ts
@@ -135,7 +135,10 @@ describe('structured session cold restoration', () => {
     internal.ensureStructuredAgentSessionHost = async () => undefined
     setStructuredAgentSessionHost({
       reconcileRestartLeases: async () => undefined,
-      listPersistedVisibleSessionIds: () => ['session-survives-rollback'],
+      getPersistedVisibleSessionTabIndex: () => ({
+        present: true,
+        sessionIds: ['session-survives-rollback']
+      }),
       restoreReadableSessions,
       listSessionTabs: () => []
     } as never)
@@ -143,6 +146,60 @@ describe('structured session cold restoration', () => {
     await runtime.restoreStructuredAgentSessionTabs()
 
     expect(restoreReadableSessions).toHaveBeenCalledWith(['session-survives-rollback'])
+  })
+
+  it('treats an empty durable visible-session index as authoritative', async () => {
+    const runtime = new OrcaRuntimeService()
+    const restoreReadableSessions = vi.fn(async () => undefined)
+    const internal = runtime as unknown as {
+      store: { getWorkspaceSession: () => unknown }
+      hasPersistedStructuredAgentSessionStore(): boolean
+      getKnownWorkspaceSessionWorktreeIds(): Set<string>
+      hydrateHeadlessMobileSessionTabsFromWorkspaceSession(): Set<string>
+      refreshMobileSessionPtyRecords(): Promise<Set<string> | null>
+      ensureStructuredAgentSessionHost(): Promise<void>
+    }
+    internal.store = {
+      getWorkspaceSession: () => ({
+        activeRepoId: null,
+        activeWorktreeId: 'workspace-1',
+        activeTabId: 'agent-session:closed-session',
+        tabsByWorktree: {},
+        terminalLayoutsByTabId: {},
+        activeTabIdByWorktree: { 'workspace-1': 'agent-session:closed-session' },
+        unifiedTabs: {
+          'workspace-1': [
+            {
+              id: 'agent-session:closed-session',
+              entityId: 'closed-session',
+              groupId: 'group-1',
+              worktreeId: 'workspace-1',
+              contentType: 'agent-session',
+              label: 'Codex Chat',
+              customLabel: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        }
+      })
+    }
+    internal.hasPersistedStructuredAgentSessionStore = () => true
+    internal.getKnownWorkspaceSessionWorktreeIds = () => new Set()
+    internal.hydrateHeadlessMobileSessionTabsFromWorkspaceSession = () => new Set()
+    internal.refreshMobileSessionPtyRecords = async () => new Set()
+    internal.ensureStructuredAgentSessionHost = async () => undefined
+    setStructuredAgentSessionHost({
+      reconcileRestartLeases: async () => undefined,
+      getPersistedVisibleSessionTabIndex: () => ({ present: true, sessionIds: [] }),
+      restoreReadableSessions,
+      listSessionTabs: () => []
+    } as never)
+
+    await runtime.restoreStructuredAgentSessionTabs()
+
+    expect(restoreReadableSessions).toHaveBeenCalledWith([])
   })
 
   it('normalizes a restored tab id and removes it when closed', async () => {
@@ -263,7 +320,7 @@ describe('structured session cold restoration', () => {
         throw new Error('session_tab_not_found')
       })
     } as never)
-    runtime.publishStructuredAgentSessionTab({
+    await runtime.publishStructuredAgentSessionTab({
       workspaceId: 'workspace-1',
       sessionId: 'session-1',
       agent: 'codex',

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10132,7 +10132,7 @@ export class OrcaRuntimeService {
           }
         }
       }
-      this.closeStructuredAgentSessionTab(worktreeId, snapshot, tab)
+      await this.closeStructuredAgentSessionTab(worktreeId, snapshot, tab)
     } else {
       if (!this.notifier?.closeSessionTab) {
         throw new Error('runtime_unavailable')
@@ -10238,11 +10238,15 @@ export class OrcaRuntimeService {
     return true
   }
 
-  private closeStructuredAgentSessionTab(
+  private async closeStructuredAgentSessionTab(
     worktreeId: string,
     snapshot: RuntimeMobileSessionTabsSnapshot,
     tab: RuntimeMobileSessionAgentTab
-  ): void {
+  ): Promise<void> {
+    const host = getStructuredAgentSessionHost()
+    if (typeof host?.setSessionTabVisibility === 'function') {
+      await host.setSessionTabVisibility(tab.sessionId, false)
+    }
     const nextTabs = snapshot.tabs.filter((candidate) => candidate.id !== tab.id)
     const active = nextTabs.find((candidate) => candidate.isActive) ?? nextTabs[0] ?? null
     const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
@@ -11754,11 +11758,11 @@ export class OrcaRuntimeService {
       stopRecoveredOwner: (record) => this.stopStructuredSessionProcess(record),
       tuiStatus: (owner) => this.structuredTuiStatus(owner),
       closeTuiOwner: (owner) => this.closeStructuredTuiOwner(owner),
-      revealNativeSession: ({ workspaceId, sessionId, agent = 'codex', adoptedTerminal }) => {
+      revealNativeSession: async ({ workspaceId, sessionId, agent = 'codex', adoptedTerminal }) => {
         if (adoptedTerminal || agent !== 'codex') {
           return
         }
-        this.publishStructuredAgentSessionTab({
+        await this.publishStructuredAgentSessionTab({
           workspaceId,
           sessionId,
           agent,
@@ -12317,10 +12321,15 @@ export class OrcaRuntimeService {
   private async restoreStructuredAgentSessionTabsOnce(): Promise<void> {
     await this.prepareStructuredAgentSessionStartupRestoration()
     const host = getStructuredAgentSessionHost()
+    const persistedVisibleIds =
+      typeof host?.listPersistedVisibleSessionIds === 'function'
+        ? host.listPersistedVisibleSessionIds()
+        : []
+    const profileIds = collectSavedStructuredAgentSessionIds(
+      this.store?.getWorkspaceSession?.(LOCAL_EXECUTION_HOST_ID) ?? null
+    )
     await host?.restoreReadableSessions(
-      collectSavedStructuredAgentSessionIds(
-        this.store?.getWorkspaceSession?.(LOCAL_EXECUTION_HOST_ID) ?? null
-      )
+      persistedVisibleIds.length > 0 ? persistedVisibleIds : profileIds
     )
     for (const worktreeId of this.getKnownWorkspaceSessionWorktreeIds()) {
       this.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(worktreeId, {
@@ -12337,7 +12346,7 @@ export class OrcaRuntimeService {
       while (sessionId.startsWith('agent-session:')) {
         sessionId = sessionId.slice('agent-session:'.length)
       }
-      this.publishStructuredAgentSessionTab({
+      await this.publishStructuredAgentSessionTab({
         ...session,
         agent: 'codex',
         sessionId,
@@ -12347,13 +12356,17 @@ export class OrcaRuntimeService {
     }
   }
 
-  publishStructuredAgentSessionTab(input: {
+  async publishStructuredAgentSessionTab(input: {
     workspaceId: string
     sessionId: string
     agent: 'codex'
     activate: boolean
     notify?: boolean
-  }): void {
+  }): Promise<void> {
+    const host = getStructuredAgentSessionHost()
+    if (typeof host?.setSessionTabVisibility === 'function') {
+      await host.setSessionTabVisibility(input.sessionId, true)
+    }
     const existing = this.mobileSessionTabsByWorktree.get(input.workspaceId)
     const id = `agent-session:${input.sessionId}`
     if (existing?.tabs.some((tab) => tab.id === id)) {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12321,15 +12321,15 @@ export class OrcaRuntimeService {
   private async restoreStructuredAgentSessionTabsOnce(): Promise<void> {
     await this.prepareStructuredAgentSessionStartupRestoration()
     const host = getStructuredAgentSessionHost()
-    const persistedVisibleIds =
-      typeof host?.listPersistedVisibleSessionIds === 'function'
-        ? host.listPersistedVisibleSessionIds()
-        : []
+    const persistedVisibleIndex =
+      typeof host?.getPersistedVisibleSessionTabIndex === 'function'
+        ? host.getPersistedVisibleSessionTabIndex()
+        : { present: false, sessionIds: [] }
     const profileIds = collectSavedStructuredAgentSessionIds(
       this.store?.getWorkspaceSession?.(LOCAL_EXECUTION_HOST_ID) ?? null
     )
     await host?.restoreReadableSessions(
-      persistedVisibleIds.length > 0 ? persistedVisibleIds : profileIds
+      persistedVisibleIndex.present ? persistedVisibleIndex.sessionIds : profileIds
     )
     for (const worktreeId of this.getKnownWorkspaceSessionWorktreeIds()) {
       this.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(worktreeId, {

--- a/src/main/runtime/rpc/methods/structured-agent-session.test.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.test.ts
@@ -95,6 +95,8 @@ function hostStub(): StructuredAgentSessionHost {
     })),
     send: vi.fn(async () => ({ ok: true, replayed: false })),
     cancel: vi.fn(async () => ({ ok: true, replayed: false })),
+    close: vi.fn(async () => undefined),
+    setSessionTabVisibility: vi.fn(async () => undefined),
     respondToPrompt: vi.fn(async () => ({ ok: true, replayed: false })),
     setOption: vi.fn(async () => ({ ok: true, replayed: false })),
     handoffStatus: vi.fn(async () => ({ owner: 'native' })),
@@ -178,6 +180,14 @@ afterEach(() => {
 })
 
 describe('capability gating', () => {
+  it('clears durable tab visibility when closing through the agent-session RPC', async () => {
+    const response = await call('agentSession.close', { sessionId: SESSION }, STRUCTURED_CLIENT)
+
+    expect(response).toMatchObject({ ok: true, result: { ok: true } })
+    expect(hostCalls.close).toHaveBeenCalledWith(SESSION)
+    expect(hostCalls.setSessionTabVisibility).toHaveBeenCalledWith(SESSION, false)
+  })
+
   it('advertises the capability without bumping the protocol version', () => {
     expect(RUNTIME_CAPABILITIES).toContain(STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY)
     expect(RUNTIME_CAPABILITIES).toContain(STRUCTURED_AGENT_SESSION_HOLD_RUNTIME_CAPABILITY)

--- a/src/main/runtime/rpc/methods/structured-agent-session.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.ts
@@ -91,7 +91,7 @@ export const STRUCTURED_AGENT_SESSION_METHODS: RpcAnyMethod[] = [
           envelope: { ...params.envelope, payloadFingerprint: hostFingerprint }
         })
         if (result.ok && resolved.agent === 'codex') {
-          ctx.runtime.publishStructuredAgentSessionTab({
+          await ctx.runtime.publishStructuredAgentSessionTab({
             workspaceId: resolved.location.workspaceId,
             sessionId: result.value.sessionId,
             agent: 'codex',

--- a/src/main/runtime/rpc/methods/structured-agent-session.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.ts
@@ -128,7 +128,12 @@ export const STRUCTURED_AGENT_SESSION_METHODS: RpcAnyMethod[] = [
     name: 'agentSession.close',
     params: OptionsParams,
     handler: async (params, ctx) => {
-      await requireHost(ctx).close(params.sessionId)
+      const host = requireHost(ctx)
+      await host.close(params.sessionId)
+      // Terminal-disposal closes use this RPC without the session-tabs retirement RPC.
+      if (typeof host.setSessionTabVisibility === 'function') {
+        await host.setSessionTabVisibility(params.sessionId, false)
+      }
       return { ok: true as const }
     }
   }),

--- a/src/main/runtime/structured-agent-session-rollback-compatibility.test.ts
+++ b/src/main/runtime/structured-agent-session-rollback-compatibility.test.ts
@@ -100,7 +100,9 @@ describe('structured session rollback compatibility', () => {
     await writeFile(join(journalDir, 'journal.log'), 'durable-journal-fixture\n')
 
     const target = await AgentSessionRecordStore.open({ directory: storeDir, hostId: 'local' })
+    expect(target.getVisibleSessionTabIndex()).toEqual({ present: false, sessionIds: [] })
     await target.setSessionTabVisibility(SESSION, true)
+    expect(target.getVisibleSessionTabIndex()).toEqual({ present: true, sessionIds: [SESSION] })
 
     const targetProfile = profileWithStructuredTab()
     const targetParsed = safeParseWorkspaceSession(targetProfile)
@@ -136,6 +138,7 @@ describe('structured session rollback compatibility', () => {
 
     await reloaded.setSessionTabVisibility(SESSION, false)
     const afterClose = await AgentSessionRecordStore.open({ directory: storeDir, hostId: 'local' })
+    expect(afterClose.getVisibleSessionTabIndex()).toEqual({ present: true, sessionIds: [] })
     expect(afterClose.listVisibleSessionIds()).toEqual([])
     expect(afterClose.getRecord(SESSION)?.providerHandleChain).toHaveLength(1)
   })

--- a/src/main/runtime/structured-agent-session-rollback-compatibility.test.ts
+++ b/src/main/runtime/structured-agent-session-rollback-compatibility.test.ts
@@ -1,0 +1,142 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { agentSessionRecordFixture } from '../../shared/agent-session-record.test-fixture'
+import { safeParseWorkspaceSession } from '../../shared/workspace-session-schema'
+import { journalDirectoryFor } from '../native-chat/agent-session-journal/journal-paths'
+import { AgentSessionRecordStore } from './agent-session-record-store'
+import { AGENT_SESSION_STORE_FILE_NAME } from './agent-session-record-store-file'
+import { collectSavedStructuredAgentSessionIds } from './saved-structured-agent-session-restoration'
+
+const WORKSPACE = 'workspace-1'
+const SESSION = 'session-alpha-1'
+
+function structuredTab() {
+  return {
+    id: `agent-session:${SESSION}`,
+    entityId: SESSION,
+    groupId: 'group-1',
+    worktreeId: WORKSPACE,
+    contentType: 'agent-session' as const,
+    label: 'Codex Chat',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function profileWithStructuredTab(): Record<string, unknown> {
+  return {
+    activeRepoId: null,
+    activeWorktreeId: WORKSPACE,
+    activeTabId: structuredTab().id,
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    activeTabIdByWorktree: { [WORKSPACE]: structuredTab().id },
+    unifiedTabs: { [WORKSPACE]: [structuredTab()] }
+  }
+}
+
+/** The pinned base rejects the new discriminator and salvages the remaining profile. */
+function pinnedBaseRoundTrip(raw: Record<string, unknown>): Record<string, unknown> {
+  const unifiedTabs = raw.unifiedTabs as Record<string, unknown[]> | undefined
+  return {
+    ...raw,
+    ...(unifiedTabs
+      ? {
+          unifiedTabs: Object.fromEntries(
+            Object.entries(unifiedTabs).map(([worktreeId, tabs]) => [
+              worktreeId,
+              tabs.filter((tab) => {
+                const contentType = (tab as { contentType?: unknown }).contentType
+                return (
+                  contentType === 'terminal' ||
+                  contentType === 'editor' ||
+                  contentType === 'diff' ||
+                  contentType === 'conflict-review' ||
+                  contentType === 'check-details' ||
+                  contentType === 'browser' ||
+                  contentType === 'simulator'
+                )
+              })
+            ])
+          )
+        }
+      : {})
+  }
+}
+
+let root: string
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('structured session rollback compatibility', () => {
+  it('keeps the visible session reference through target → base → target', async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-structured-rollback-'))
+    const storeDir = join(root, 'agent-store')
+    await mkdir(storeDir, { recursive: true })
+    const record = agentSessionRecordFixture({
+      ...agentSessionRecordFixture().lease,
+      sessionId: SESSION,
+      runtimeKind: 'native'
+    })
+    await writeFile(
+      join(storeDir, AGENT_SESSION_STORE_FILE_NAME),
+      JSON.stringify({
+        schemaVersion: 2,
+        hostId: 'local',
+        records: { [SESSION]: record },
+        operations: {},
+        retiredClaimKeys: [],
+        unusableRecords: {}
+      })
+    )
+    const journalDir = journalDirectoryFor(root, { workspaceId: WORKSPACE, sessionId: SESSION })
+    await mkdir(journalDir, { recursive: true })
+    await writeFile(join(journalDir, 'journal.log'), 'durable-journal-fixture\n')
+
+    const target = await AgentSessionRecordStore.open({ directory: storeDir, hostId: 'local' })
+    await target.setSessionTabVisibility(SESSION, true)
+
+    const targetProfile = profileWithStructuredTab()
+    const targetParsed = safeParseWorkspaceSession(targetProfile)
+    expect(targetParsed?.success).toBe(true)
+    expect(
+      collectSavedStructuredAgentSessionIds(targetParsed?.success ? targetParsed.data : null)
+    ).toEqual([SESSION])
+
+    const baseProfile = pinnedBaseRoundTrip(targetProfile)
+    const baseParsed = safeParseWorkspaceSession(baseProfile)
+    expect(baseParsed?.success).toBe(true)
+    expect(
+      collectSavedStructuredAgentSessionIds(baseParsed?.success ? baseParsed.data : null)
+    ).toEqual([])
+
+    await writeFile(join(root, 'profile.json'), JSON.stringify(baseProfile))
+    const targetReloadedProfile = safeParseWorkspaceSession(JSON.parse(JSON.stringify(baseProfile)))
+    expect(targetReloadedProfile?.success).toBe(true)
+    expect(
+      collectSavedStructuredAgentSessionIds(
+        targetReloadedProfile?.success ? targetReloadedProfile.data : null
+      )
+    ).toEqual([])
+    const reloaded = await AgentSessionRecordStore.open({ directory: storeDir, hostId: 'local' })
+    expect(reloaded.listVisibleSessionIds()).toEqual([SESSION])
+    expect(reloaded.getRecord(SESSION)?.providerHandleChain).toHaveLength(1)
+    await expect(readFile(join(journalDir, 'journal.log'), 'utf8')).resolves.toBe(
+      'durable-journal-fixture\n'
+    )
+    expect(
+      JSON.parse(await readFile(join(storeDir, AGENT_SESSION_STORE_FILE_NAME), 'utf8'))
+    ).toMatchObject({ visibleSessionIds: [SESSION] })
+
+    await reloaded.setSessionTabVisibility(SESSION, false)
+    const afterClose = await AgentSessionRecordStore.open({ directory: storeDir, hostId: 'local' })
+    expect(afterClose.listVisibleSessionIds()).toEqual([])
+    expect(afterClose.getRecord(SESSION)?.providerHandleChain).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​254 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​252 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​141 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​38 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​103 |

<!-- /orca-pr-loc -->

## Summary

- Preserve visible structured Codex chat session identities in the durable agent-session store.
- Restore from that identity index when an older profile parser drops `contentType: agent-session` tabs.
- Remove the visibility reference on chat close while retaining the durable record and journal.
- Await handoff reveal persistence so a failed compatibility write is observable.

## Root cause

The workspace profile tab list was treated as the sole restoration identity for structured sessions. The pinned base release rejects the newer `agent-session` discriminator and salvages those entries away; after the base release rewrites the profile, re-upgrade can no longer discover the surviving records/journals.

This is a persistence ownership/lifecycle issue, not a reason to revert the structured-chat feature. The visible-tab reference now lives with the structured-session store, which older builds do not rewrite. Closed historical journals remain lazy and are not resurrected on startup.

## Regression coverage

- Automated target → pinned-base → target profile fixture.
- Verifies target parsing, legacy discriminator salvage, durable record/journal survival, and target re-upgrade recovery identity.
- Verifies deliberate close removes only the visible reference.
- Verifies runtime startup prefers the durable visible-session index after profile tab loss.

## Validation

- `pnpm tc`
- Focused Vitest suites (61 tests)
- Changed-code quality gate
- Oxlint
- Oxfmt

## ELI5

An older Orca build can erase structured-chat tabs it does not understand when it rewrites the profile. The visible chat IDs now live in the durable agent-session store, which the older build leaves alone, and that list is used when the app returns. Closing removes only the visible-tab pointer; the record and journal stay available, and open/close waits for the durable write.

## Performance Measurement

This is a persistence-compatibility fix, not a throughput optimization, so no speedup is claimed. In the deterministic target-to-pinned-base-to-target fixture, profile-only restoration returns 0 session IDs after the base round-trip, while the durable index restores 1 ID and preserves the journal; closing leaves the durable record and an empty visible index. No timing claim is made.

## User-Facing Trade-offs

There is no visible data-loss trade-off. Each visibility change now waits for one small durable whole-store transaction, which can add a little open/close latency; closed chats remain in history but are not resurrected. Stores without the new field retain the legacy profile fallback.
