### PR TITLE
fix(dashboard): make preview-terminal clipboard commands work on Windows

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.clipboard-routes.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.clipboard-routes.test.tsx
@@ -1,0 +1,528 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  TERMINAL_PASTE_CHUNK_MAX_BYTES,
+  TERMINAL_PASTE_DIRECT_MAX_BYTES
+} from '@/components/terminal-pane/terminal-paste-limits'
+import {
+  BRACKETED_PASTE_END,
+  BRACKETED_PASTE_START
+} from '@/components/terminal-pane/terminal-bracketed-paste'
+import { dispatchAppMenuPasteEvent } from '@/lib/app-menu-paste'
+import { dispatchAppMenuSelectionAction } from '@/lib/app-menu-selection-actions'
+
+const terminalHarness = vi.hoisted(() => ({
+  instances: [] as {
+    write: ReturnType<typeof vi.fn>
+    writeCallbacks: (() => void)[]
+    onDataListener: ((data: string) => void) | null
+    dispose: ReturnType<typeof vi.fn>
+    resize: ReturnType<typeof vi.fn>
+    reset: ReturnType<typeof vi.fn>
+    paste: ReturnType<typeof vi.fn>
+    input: ReturnType<typeof vi.fn>
+    scrollToTop: ReturnType<typeof vi.fn>
+    scrollToBottom: ReturnType<typeof vi.fn>
+    selectAll: ReturnType<typeof vi.fn>
+    modes: { bracketedPasteMode: boolean }
+    selectionText: string
+    customKeyHandler: ((event: KeyboardEvent) => boolean) | null
+  }[],
+  userInputListener: null as (() => void) | null,
+  userInputDispose: vi.fn()
+}))
+
+const platformState = vi.hoisted(() => ({ value: 'linux' }))
+const storeState = vi.hoisted(() => ({
+  settings: null as { terminalRightClickToPaste?: boolean } | null,
+  keybindings: {} as Record<string, string[]>
+}))
+
+const imeHarness = vi.hoisted(() => ({
+  forwarders: [] as {
+    claimKeyEvent: ReturnType<typeof vi.fn>
+    dispose: ReturnType<typeof vi.fn>
+    sendInput: (data: string) => void
+    getKittyKeyboardFlags: () => number
+  }[],
+  trackers: [] as { dispose: ReturnType<typeof vi.fn> }[],
+  claimResult: false
+}))
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    cols = 80
+    rows = 24
+    buffer = { active: { cursorY: 0 } }
+    writeCallbacks: (() => void)[] = []
+    onDataListener: ((data: string) => void) | null = null
+    customKeyHandler: ((event: KeyboardEvent) => boolean) | null = null
+    selectionText = ''
+    write = vi.fn((_data: string, callback?: () => void) => {
+      if (callback) {
+        this.writeCallbacks.push(callback)
+      }
+    })
+    open = vi.fn()
+    focus = vi.fn()
+    dispose = vi.fn()
+    resize = vi.fn()
+    reset = vi.fn()
+    modes = { bracketedPasteMode: false }
+    paste = vi.fn((data: string) => {
+      terminalHarness.userInputListener?.()
+      this.onDataListener?.(data)
+    })
+    input = vi.fn((data: string) => {
+      terminalHarness.userInputListener?.()
+      this.onDataListener?.(data)
+    })
+    element = document.createElement('div')
+    unicode = { activeVersion: '6', versions: ['6', '11'], register: vi.fn() }
+    loadAddon = vi.fn()
+    attachCustomWheelEventHandler = vi.fn()
+    scrollToTop = vi.fn()
+    scrollToBottom = vi.fn()
+    selectAll = vi.fn()
+    getSelection = vi.fn(() => this.selectionText)
+    attachCustomKeyEventHandler = vi.fn((handler: (event: KeyboardEvent) => boolean) => {
+      this.customKeyHandler = handler
+    })
+    onData = vi.fn((listener: (data: string) => void) => {
+      this.onDataListener = listener
+      return { dispose: vi.fn() }
+    })
+
+    constructor() {
+      terminalHarness.instances.push(this)
+    }
+  }
+}))
+vi.mock(import('@/lib/pane-manager/pane-terminal-options'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  buildDefaultTerminalOptions: () => ({})
+}))
+vi.mock('@/components/terminal-pane/terminal-user-input-signal', () => ({
+  subscribeToTerminalUserInput: (_terminal: unknown, listener: () => void) => {
+    terminalHarness.userInputListener = listener
+    return { dispose: terminalHarness.userInputDispose }
+  }
+}))
+vi.mock('@/components/terminal-pane/use-system-prefers-dark', () => ({
+  useSystemPrefersDark: () => false
+}))
+vi.mock('@/lib/shortcut-platform', () => ({
+  getShortcutPlatform: () => platformState.value
+}))
+vi.mock('@/components/terminal-pane/terminal-ime-native-text-forwarder', () => ({
+  installTerminalImeNativeTextForwarder: (args: {
+    sendInput: (data: string) => void
+    getKittyKeyboardFlags?: () => number
+  }) => {
+    const forwarder = {
+      claimKeyEvent: vi.fn(() => imeHarness.claimResult),
+      dispose: vi.fn(),
+      sendInput: args.sendInput,
+      // Why captured: the bridge's whole job is handing the live mirror to the
+      // forwarder, so the test reads what a real commit would read.
+      getKittyKeyboardFlags: args.getKittyKeyboardFlags ?? ((): number => 0)
+    }
+    imeHarness.forwarders.push(forwarder)
+    return forwarder
+  }
+}))
+vi.mock('@/components/terminal-pane/terminal-ime-composition-tracker', () => ({
+  installTerminalImeCompositionTracker: () => {
+    const tracker = { isActive: () => false, dispose: vi.fn() }
+    imeHarness.trackers.push(tracker)
+    return tracker
+  }
+}))
+vi.mock('@/store', () => {
+  const useAppStore = (selector: (s: typeof storeState) => unknown): unknown => selector(storeState)
+  useAppStore.getState = (): typeof storeState => storeState
+  return { useAppStore }
+})
+
+import { AgentTerminalPreview } from './AgentTerminalPreview'
+
+describe('AgentTerminalPreview clipboard routes', () => {
+  const input = vi.fn(async (_ptyId: string, _data: string) => true)
+  const fit = vi.fn(async (_ptyId: string, cols: number, rows: number) => ({ cols, rows }))
+  const ack = vi.fn(async () => {})
+  const unsubscribe = vi.fn(async () => {})
+  const connect = vi.fn()
+  const readClipboardText = vi.fn(async () => 'clip-text')
+  const writeClipboardText = vi.fn(async () => {})
+  const writeTerminalClipboardText = vi.fn(async () => {})
+  const performNativeSelectionAction = vi.fn()
+
+  /** Focuses a stand-in for xterm's helper textarea inside the preview container. */
+  const focusInsidePreview = (container: HTMLElement, tagName = 'input'): HTMLElement => {
+    const host = container.querySelector<HTMLElement>('.origin-bottom-left')!
+    const focusTarget = document.createElement(tagName)
+    host.appendChild(focusTarget)
+    focusTarget.focus()
+    return focusTarget
+  }
+
+  beforeEach(() => {
+    terminalHarness.instances.length = 0
+    terminalHarness.userInputListener = null
+    platformState.value = 'linux'
+    storeState.keybindings = {}
+    imeHarness.forwarders.length = 0
+    imeHarness.trackers.length = 0
+    imeHarness.claimResult = false
+    storeState.settings = null
+    connect.mockResolvedValue({
+      snapshot: { data: '', cols: 80, rows: 24, seq: 1 },
+      replay: []
+    })
+    readClipboardText.mockResolvedValue('clip-text')
+    Object.assign(window, {
+      api: {
+        terminalPreview: {
+          connect,
+          input,
+          fit,
+          ack,
+          unsubscribe,
+          onData: () => vi.fn()
+        },
+        ui: {
+          readClipboardText,
+          writeClipboardText,
+          writeTerminalClipboardText,
+          performNativeSelectionAction
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('claims the app-menu paste event and pastes while the preview owns focus', async () => {
+    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    focusInsidePreview(view.container)
+
+    let claimed = false
+    act(() => {
+      claimed = dispatchAppMenuPasteEvent()
+    })
+
+    // The claim is what keeps App-level paste out of xterm's hidden textarea.
+    expect(claimed).toBe(true)
+    await waitFor(() => expect(terminal.paste).toHaveBeenCalledWith('clip-text'))
+    expect(input).toHaveBeenCalledWith('pty-1', 'clip-text')
+  })
+
+  it('encodes a leading newline for a remote Windows Codex preview without submitting', async () => {
+    readClipboardText.mockResolvedValueOnce('\nsecond line')
+    const view = render(
+      <AgentTerminalPreview
+        ptyId="remote:windows-box@@pty-1"
+        terminalInput={{
+          hostPlatform: 'win32',
+          localWindowsConpty: false,
+          windowsShiftEnterEncoding: 'alt-enter',
+          windowsInputRecordPasteNewline: 'alt-enter',
+          ctrlEnterCsiU: false,
+          kittyKeyboardAdvertised: false
+        }}
+      />
+    )
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    focusInsidePreview(view.container)
+
+    act(() => {
+      dispatchAppMenuPasteEvent()
+    })
+
+    await waitFor(() =>
+      expect(input).toHaveBeenCalledWith('remote:windows-box@@pty-1', '\x1b\rsecond line')
+    )
+    expect(terminal.input).toHaveBeenCalledWith('\x1b\rsecond line')
+    expect(terminal.paste).not.toHaveBeenCalled()
+  })
+
+  it('claims app-menu selection actions while the preview owns focus', async () => {
+    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    terminal.selectionText = 'selected text'
+    const focusTarget = focusInsidePreview(view.container, 'textarea')
+    focusTarget.className = 'xterm-helper-textarea'
+
+    let selectAllClaimed = false
+    let copyClaimed = false
+    act(() => {
+      selectAllClaimed = dispatchAppMenuSelectionAction('select-all')
+    })
+    act(() => {
+      copyClaimed = dispatchAppMenuSelectionAction('copy')
+    })
+
+    expect(selectAllClaimed).toBe(true)
+    expect(copyClaimed).toBe(true)
+    expect(terminal.selectAll).toHaveBeenCalledOnce()
+    await waitFor(() => expect(writeTerminalClipboardText).toHaveBeenCalledWith('selected text'))
+  })
+
+  it('leaves app-menu selection actions unclaimed for text controls inside the preview', async () => {
+    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    focusInsidePreview(view.container)
+
+    let claimed = true
+    act(() => {
+      claimed = dispatchAppMenuSelectionAction('select-all')
+    })
+
+    // Unclaimed so the App-level handler performs the native selection action.
+    expect(claimed).toBe(false)
+    expect(terminal.selectAll).not.toHaveBeenCalled()
+  })
+
+  it('leaves a copy action with no terminal selection unclaimed', async () => {
+    render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+
+    let claimed = true
+    act(() => {
+      claimed = dispatchAppMenuSelectionAction('copy')
+    })
+
+    expect(claimed).toBe(false)
+    expect(writeTerminalClipboardText).not.toHaveBeenCalled()
+  })
+
+  it('leaves the app-menu paste event unclaimed when focus is outside the preview', async () => {
+    render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+
+    let claimed = true
+    await act(async () => {
+      claimed = dispatchAppMenuPasteEvent()
+    })
+
+    expect(claimed).toBe(false)
+    expect(readClipboardText).not.toHaveBeenCalled()
+    expect(terminalHarness.instances[0]!.paste).not.toHaveBeenCalled()
+  })
+
+  it('stops claiming app-menu clipboard events once unmounted', async () => {
+    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    focusInsidePreview(view.container)
+    view.unmount()
+
+    expect(dispatchAppMenuPasteEvent()).toBe(false)
+    expect(dispatchAppMenuSelectionAction('select-all')).toBe(false)
+  })
+
+  it('pastes on plain Ctrl+V on Windows, where no Edit-menu accelerator ever fires', async () => {
+    platformState.value = 'win32'
+    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    await waitFor(() => expect(terminal.customKeyHandler).not.toBeNull())
+    focusInsidePreview(view.container)
+
+    const plain = new KeyboardEvent('keydown', {
+      key: 'v',
+      code: 'KeyV',
+      ctrlKey: true,
+      cancelable: true
+    })
+    expect(terminal.customKeyHandler!(plain)).toBe(false)
+    expect(plain.defaultPrevented).toBe(true)
+    await waitFor(() => expect(terminal.paste).toHaveBeenCalledWith('clip-text'))
+
+    // The repeat is swallowed without a second clipboard read, and so is the keyup.
+    expect(
+      terminal.customKeyHandler!(
+        new KeyboardEvent('keydown', { key: 'v', code: 'KeyV', ctrlKey: true, repeat: true })
+      )
+    ).toBe(false)
+    expect(terminal.customKeyHandler!(new KeyboardEvent('keyup', { key: 'v', code: 'KeyV' }))).toBe(
+      false
+    )
+    expect(readClipboardText).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles the shifted paste chord on Linux', async () => {
+    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    await waitFor(() => expect(terminal.customKeyHandler).not.toBeNull())
+    focusInsidePreview(view.container)
+
+    const shifted = new KeyboardEvent('keydown', {
+      key: 'V',
+      code: 'KeyV',
+      ctrlKey: true,
+      shiftKey: true,
+      cancelable: true
+    })
+    expect(terminal.customKeyHandler!(shifted)).toBe(false)
+    expect(shifted.defaultPrevented).toBe(true)
+    await waitFor(() => expect(terminal.paste).toHaveBeenCalledWith('clip-text'))
+    expect(readClipboardText).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves plain Cmd+V to the macOS Edit-menu accelerator', async () => {
+    platformState.value = 'darwin'
+    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    await waitFor(() => expect(terminal.customKeyHandler).not.toBeNull())
+    focusInsidePreview(view.container)
+
+    // Why deferred: macOS keeps a real Cmd+V accelerator, so handling it here
+    // AND letting the menu fire would paste twice.
+    const plain = terminal.customKeyHandler!(
+      new KeyboardEvent('keydown', { key: 'v', code: 'KeyV', metaKey: true })
+    )
+    expect(plain).toBe(true)
+    expect(readClipboardText).not.toHaveBeenCalled()
+  })
+
+  it('pastes on terminal-style right-click when the setting is on', async () => {
+    storeState.settings = { terminalRightClickToPaste: true }
+    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    focusInsidePreview(view.container)
+    const host = view.container.querySelector<HTMLElement>('.origin-bottom-left')!
+
+    const menuEvent = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+    act(() => {
+      host.dispatchEvent(menuEvent)
+    })
+
+    expect(menuEvent.defaultPrevented).toBe(true)
+    await waitFor(() => expect(terminal.paste).toHaveBeenCalledWith('clip-text'))
+  })
+
+  it('copies the selection on terminal-style right-click instead of pasting', async () => {
+    storeState.settings = { terminalRightClickToPaste: true }
+    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    terminal.selectionText = 'selected text'
+    focusInsidePreview(view.container)
+    const host = view.container.querySelector<HTMLElement>('.origin-bottom-left')!
+
+    act(() => {
+      host.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }))
+    })
+
+    await waitFor(() => expect(writeTerminalClipboardText).toHaveBeenCalledWith('selected text'))
+    expect(readClipboardText).not.toHaveBeenCalled()
+  })
+
+  it('leaves right-click to the native menu when the setting is off', async () => {
+    storeState.settings = { terminalRightClickToPaste: false }
+    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    focusInsidePreview(view.container)
+    const host = view.container.querySelector<HTMLElement>('.origin-bottom-left')!
+
+    const menuEvent = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+    act(() => {
+      host.dispatchEvent(menuEvent)
+    })
+
+    expect(menuEvent.defaultPrevented).toBe(false)
+    expect(readClipboardText).not.toHaveBeenCalled()
+  })
+
+  it('cancels an async paste when the preview loses focus', async () => {
+    let resolveClipboard!: (text: string) => void
+    readClipboardText.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveClipboard = resolve
+      })
+    )
+    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    focusInsidePreview(view.container)
+    const outsideInput = document.createElement('input')
+    view.container.appendChild(outsideInput)
+
+    act(() => {
+      dispatchAppMenuPasteEvent()
+    })
+    outsideInput.focus()
+    await act(async () => resolveClipboard('stale text'))
+
+    expect(terminal.paste).not.toHaveBeenCalled()
+    expect(input).not.toHaveBeenCalled()
+  })
+
+  it('streams large pastes as bounded IPC payloads instead of one renderer-blocking write', async () => {
+    const encoder = new TextEncoder()
+    const multibytePrefix = '😀'.repeat(TERMINAL_PASTE_DIRECT_MAX_BYTES / 4 + 1)
+    const largePaste = `${multibytePrefix}\r\nnext\n`
+    const expectedPaste = `${multibytePrefix}\rnext\r`
+    readClipboardText.mockResolvedValueOnce(largePaste)
+    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    focusInsidePreview(view.container)
+
+    act(() => {
+      dispatchAppMenuPasteEvent()
+    })
+    const expectedChunks = Math.ceil(
+      encoder.encode(expectedPaste).byteLength / TERMINAL_PASTE_CHUNK_MAX_BYTES
+    )
+    await waitFor(() => expect(input).toHaveBeenCalledTimes(expectedChunks))
+
+    const payloads = input.mock.calls.map(([, data]) => data as string)
+    expect(terminal.paste).not.toHaveBeenCalled()
+    expect(payloads.join('')).toBe(expectedPaste)
+    expect(
+      payloads.every(
+        (payload) => encoder.encode(payload).byteLength <= TERMINAL_PASTE_CHUNK_MAX_BYTES
+      )
+    ).toBe(true)
+  })
+
+  it('closes a bracketed large paste when focus changes between chunks', async () => {
+    readClipboardText.mockResolvedValueOnce('x'.repeat(TERMINAL_PASTE_DIRECT_MAX_BYTES + 1))
+    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    terminal.modes.bracketedPasteMode = true
+    focusInsidePreview(view.container)
+    const outsideInput = document.createElement('input')
+    view.container.appendChild(outsideInput)
+    input.mockImplementationOnce(async () => {
+      outsideInput.focus()
+      return true
+    })
+
+    act(() => {
+      dispatchAppMenuPasteEvent()
+    })
+    await waitFor(() => expect(input).toHaveBeenCalledTimes(2))
+
+    expect(input.mock.calls.map(([, data]) => data)).toEqual([
+      BRACKETED_PASTE_START,
+      BRACKETED_PASTE_END
+    ])
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
@@ -3,14 +3,6 @@
 import '@testing-library/jest-dom/vitest'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  TERMINAL_PASTE_CHUNK_MAX_BYTES,
-  TERMINAL_PASTE_DIRECT_MAX_BYTES
-} from '@/components/terminal-pane/terminal-paste-limits'
-import {
-  BRACKETED_PASTE_END,
-  BRACKETED_PASTE_START
-} from '@/components/terminal-pane/terminal-bracketed-paste'
 
 const terminalHarness = vi.hoisted(() => ({
   instances: [] as {
@@ -157,8 +149,6 @@ describe('AgentTerminalPreview', () => {
   const writeClipboardText = vi.fn(async () => {})
   const writeTerminalClipboardText = vi.fn(async () => {})
   let emitData: ((payload: unknown) => void) | null
-  let emitAppMenuPaste: (() => void) | null
-  let emitAppMenuSelectionAction: ((action: 'copy' | 'select-all') => void) | null
 
   beforeEach(() => {
     terminalHarness.instances.length = 0
@@ -169,8 +159,6 @@ describe('AgentTerminalPreview', () => {
     imeHarness.trackers.length = 0
     imeHarness.claimResult = false
     emitData = null
-    emitAppMenuPaste = null
-    emitAppMenuSelectionAction = null
     connect.mockResolvedValue({
       snapshot: { data: '', cols: 80, rows: 24, seq: 1 },
       replay: []
@@ -193,14 +181,6 @@ describe('AgentTerminalPreview', () => {
           readClipboardText,
           writeClipboardText,
           writeTerminalClipboardText,
-          onAppMenuPaste: (listener: () => void) => {
-            emitAppMenuPaste = listener
-            return vi.fn()
-          },
-          onAppMenuSelectionAction: (listener: (action: 'copy' | 'select-all') => void) => {
-            emitAppMenuSelectionAction = listener
-            return vi.fn()
-          },
           performNativeSelectionAction: vi.fn()
         }
       }
@@ -404,98 +384,6 @@ describe('AgentTerminalPreview', () => {
     expect(terminal.selectAll).toHaveBeenCalledOnce()
   })
 
-  it('pastes clipboard text on the app-menu paste signal while the preview owns focus', async () => {
-    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
-    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
-    const terminal = terminalHarness.instances[0]!
-    expect(emitAppMenuPaste).not.toBeNull()
-
-    const host = view.container.querySelector<HTMLElement>('.origin-bottom-left')!
-    const focusTarget = document.createElement('input')
-    host.appendChild(focusTarget)
-    focusTarget.focus()
-
-    act(() => emitAppMenuPaste!())
-    await waitFor(() => expect(terminal.paste).toHaveBeenCalledWith('clip-text'))
-    expect(input).toHaveBeenCalledWith('pty-1', 'clip-text')
-  })
-
-  it('encodes a leading newline for a remote Windows Codex preview without submitting', async () => {
-    readClipboardText.mockResolvedValueOnce('\nsecond line')
-    const view = render(
-      <AgentTerminalPreview
-        ptyId="remote:windows-box@@pty-1"
-        terminalInput={{
-          hostPlatform: 'win32',
-          localWindowsConpty: false,
-          windowsShiftEnterEncoding: 'alt-enter',
-          windowsInputRecordPasteNewline: 'alt-enter',
-          ctrlEnterCsiU: false,
-          kittyKeyboardAdvertised: false
-        }}
-      />
-    )
-    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
-    const terminal = terminalHarness.instances[0]!
-    const host = view.container.querySelector<HTMLElement>('.origin-bottom-left')!
-    const focusTarget = document.createElement('input')
-    host.appendChild(focusTarget)
-    focusTarget.focus()
-
-    act(() => emitAppMenuPaste!())
-
-    await waitFor(() =>
-      expect(input).toHaveBeenCalledWith('remote:windows-box@@pty-1', '\x1b\rsecond line')
-    )
-    expect(terminal.input).toHaveBeenCalledWith('\x1b\rsecond line')
-    expect(terminal.paste).not.toHaveBeenCalled()
-  })
-
-  it('handles app-menu selection actions while the preview owns focus', async () => {
-    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
-    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
-    const terminal = terminalHarness.instances[0]!
-    terminal.selectionText = 'selected text'
-
-    const host = view.container.querySelector<HTMLElement>('.origin-bottom-left')!
-    const focusTarget = document.createElement('textarea')
-    focusTarget.className = 'xterm-helper-textarea'
-    host.appendChild(focusTarget)
-    focusTarget.focus()
-
-    act(() => emitAppMenuSelectionAction?.('select-all'))
-    act(() => emitAppMenuSelectionAction?.('copy'))
-
-    expect(terminal.selectAll).toHaveBeenCalledOnce()
-    await waitFor(() => expect(writeTerminalClipboardText).toHaveBeenCalledWith('selected text'))
-  })
-
-  it('keeps app-menu selection actions native for text controls inside the preview', async () => {
-    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
-    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
-    const terminal = terminalHarness.instances[0]!
-
-    const host = view.container.querySelector<HTMLElement>('.origin-bottom-left')!
-    const focusTarget = document.createElement('input')
-    host.appendChild(focusTarget)
-    focusTarget.focus()
-
-    act(() => emitAppMenuSelectionAction?.('select-all'))
-
-    expect(terminal.selectAll).not.toHaveBeenCalled()
-    expect(window.api.ui.performNativeSelectionAction).toHaveBeenCalledWith('select-all')
-  })
-
-  it('ignores the app-menu paste signal when focus is outside the preview', async () => {
-    render(<AgentTerminalPreview ptyId="pty-1" />)
-    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
-    expect(emitAppMenuPaste).not.toBeNull()
-
-    await act(async () => emitAppMenuPaste!())
-    expect(readClipboardText).not.toHaveBeenCalled()
-    expect(terminalHarness.instances[0]!.paste).not.toHaveBeenCalled()
-  })
-
   it('sends the word-kill byte on Ctrl+Backspace and blocks xterm handling', async () => {
     render(<AgentTerminalPreview ptyId="pty-1" />)
     await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
@@ -663,132 +551,6 @@ describe('AgentTerminalPreview', () => {
 
     expect(handled).toBe(true)
     expect(terminal.input).not.toHaveBeenCalled()
-  })
-
-  it('leaves plain Ctrl+V to the Edit-menu accelerator but handles the shifted paste chord', async () => {
-    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
-    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
-    const terminal = terminalHarness.instances[0]!
-    await waitFor(() => expect(terminal.customKeyHandler).not.toBeNull())
-    const host = view.container.querySelector<HTMLElement>('.origin-bottom-left')!
-    const terminalInput = document.createElement('input')
-    host.appendChild(terminalInput)
-    terminalInput.focus()
-
-    const plain = terminal.customKeyHandler!(
-      new KeyboardEvent('keydown', { key: 'v', code: 'KeyV', ctrlKey: true })
-    )
-    expect(plain).toBe(true)
-    expect(readClipboardText).not.toHaveBeenCalled()
-
-    const shiftedEvent = new KeyboardEvent('keydown', {
-      key: 'V',
-      code: 'KeyV',
-      ctrlKey: true,
-      shiftKey: true,
-      cancelable: true
-    })
-    const shifted = terminal.customKeyHandler!(shiftedEvent)
-    const repeated = terminal.customKeyHandler!(
-      new KeyboardEvent('keydown', {
-        key: 'V',
-        code: 'KeyV',
-        ctrlKey: true,
-        shiftKey: true,
-        repeat: true
-      })
-    )
-    expect(shifted).toBe(false)
-    expect(repeated).toBe(false)
-    expect(shiftedEvent.defaultPrevented).toBe(true)
-    await waitFor(() => expect(terminal.paste).toHaveBeenCalledWith('clip-text'))
-    expect(readClipboardText).toHaveBeenCalledTimes(1)
-    expect(
-      terminal.customKeyHandler!(
-        new KeyboardEvent('keyup', { key: 'V', code: 'KeyV', ctrlKey: true, shiftKey: true })
-      )
-    ).toBe(false)
-  })
-
-  it('cancels an async paste when the preview loses focus', async () => {
-    let resolveClipboard!: (text: string) => void
-    readClipboardText.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveClipboard = resolve
-      })
-    )
-    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
-    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
-    const terminal = terminalHarness.instances[0]!
-    const host = view.container.querySelector<HTMLElement>('.origin-bottom-left')!
-    const terminalInput = document.createElement('input')
-    const outsideInput = document.createElement('input')
-    host.appendChild(terminalInput)
-    view.container.appendChild(outsideInput)
-    terminalInput.focus()
-
-    act(() => emitAppMenuPaste!())
-    outsideInput.focus()
-    await act(async () => resolveClipboard('stale text'))
-
-    expect(terminal.paste).not.toHaveBeenCalled()
-    expect(input).not.toHaveBeenCalled()
-  })
-
-  it('streams large pastes as bounded IPC payloads instead of one renderer-blocking write', async () => {
-    const encoder = new TextEncoder()
-    const multibytePrefix = '😀'.repeat(TERMINAL_PASTE_DIRECT_MAX_BYTES / 4 + 1)
-    const largePaste = `${multibytePrefix}\r\nnext\n`
-    const expectedPaste = `${multibytePrefix}\rnext\r`
-    readClipboardText.mockResolvedValueOnce(largePaste)
-    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
-    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
-    const terminal = terminalHarness.instances[0]!
-    const host = view.container.querySelector<HTMLElement>('.origin-bottom-left')!
-    const terminalInput = document.createElement('input')
-    host.appendChild(terminalInput)
-    terminalInput.focus()
-
-    act(() => emitAppMenuPaste!())
-    const expectedChunks = Math.ceil(
-      encoder.encode(expectedPaste).byteLength / TERMINAL_PASTE_CHUNK_MAX_BYTES
-    )
-    await waitFor(() => expect(input).toHaveBeenCalledTimes(expectedChunks))
-
-    const payloads = input.mock.calls.map(([, data]) => data as string)
-    expect(terminal.paste).not.toHaveBeenCalled()
-    expect(payloads.join('')).toBe(expectedPaste)
-    expect(
-      payloads.every(
-        (payload) => encoder.encode(payload).byteLength <= TERMINAL_PASTE_CHUNK_MAX_BYTES
-      )
-    ).toBe(true)
-  })
-
-  it('closes a bracketed large paste when focus changes between chunks', async () => {
-    readClipboardText.mockResolvedValueOnce('x'.repeat(TERMINAL_PASTE_DIRECT_MAX_BYTES + 1))
-    const view = render(<AgentTerminalPreview ptyId="pty-1" />)
-    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
-    const terminal = terminalHarness.instances[0]!
-    terminal.modes.bracketedPasteMode = true
-    const host = view.container.querySelector<HTMLElement>('.origin-bottom-left')!
-    const terminalInput = document.createElement('input')
-    const outsideInput = document.createElement('input')
-    host.appendChild(terminalInput)
-    view.container.appendChild(outsideInput)
-    terminalInput.focus()
-    input.mockImplementationOnce(async () => {
-      outsideInput.focus()
-      return true
-    })
-
-    act(() => emitAppMenuPaste!())
-    await waitFor(() => expect(input).toHaveBeenCalledTimes(2))
-
-    expect(input.mock.calls.map(([, data]) => data)).toEqual([
-      BRACKETED_PASTE_START,
-      BRACKETED_PASTE_END
-    ])
   })
 
   it('keeps the existing terminal visible while a resync snapshot is captured', async () => {

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
@@ -23,7 +23,10 @@ import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { installPreviewTerminalKeyHandler } from './preview-terminal-key-handler'
 import { createPreviewGridClaim } from './preview-grid-claim'
+import { createPreviewBoxFit } from './preview-terminal-box-fit'
 import { installPreviewTerminalAppMenuClipboard } from './preview-terminal-app-menu-clipboard'
+import { installPreviewTerminalRightClickPaste } from './preview-terminal-right-click-paste'
+import { isWindowsUserAgent } from '@/components/terminal-pane/pane-helpers'
 import type { TerminalPreviewDataPayload } from '../../../../shared/terminal-preview'
 
 const PREVIEW_SCROLLBACK_ROWS = 24
@@ -43,11 +46,9 @@ function clamp(value: number, min: number, max: number): number {
  * process's per-PTY headless emulator. On open it claims the PTY grid for the
  * dialog's own box (see createPreviewGridClaim), so the terminal renders
  * properly sized rather than scaled. The terminal itself is always created at
- * the PTY's REAL cols/rows — serialized ANSI replayed into different
- * dimensions rewraps into garbage — and when someone else owns the grid (a
- * phone, a host reclaim) the oversized frame is scaled down to fit and
- * anchored so the cursor stays visible. Keystrokes pass through to the PTY;
- * DOM renderer so it never grabs a WebGL context.
+ * the PTY's REAL cols/rows, and when someone else owns the grid (a phone, a
+ * host reclaim) createPreviewBoxFit scales the oversized frame down. Keystrokes
+ * pass through to the PTY; DOM renderer so it never grabs a WebGL context.
  */
 export function AgentTerminalPreview({
   ptyId,
@@ -115,36 +116,8 @@ export function AgentTerminalPreview({
     let retryTimer: ReturnType<typeof setTimeout> | null = null
     const pendingLivePayloads: Extract<TerminalPreviewDataPayload, { type: 'data' }>[] = []
 
-    const fitToBox = (): void => {
-      const screen = container.querySelector<HTMLElement>('.xterm-screen')
-      const box = container.parentElement
-      if (!screen || !box || !terminal) {
-        return
-      }
-      const scale = Math.min(1, box.clientWidth / Math.max(1, screen.offsetWidth))
-      container.style.transform = scale < 1 ? `scale(${scale})` : ''
-      // Anchor whichever end keeps the CURSOR row in view when the terminal is
-      // taller than the box: a fresh shell prompts at the TOP of its screen
-      // (blind bottom-anchoring clipped it away), while a busy TUI keeps its
-      // action at the bottom.
-      const cellHeight = screen.offsetHeight / Math.max(1, terminal.rows)
-      const cursorBottom = (terminal.buffer.active.cursorY + 1) * cellHeight * scale
-      const anchorTop = cursorBottom <= box.clientHeight
-      box.style.alignItems = anchorTop ? 'flex-start' : 'flex-end'
-      container.style.transformOrigin = anchorTop ? 'top left' : 'bottom left'
-    }
-    // Re-fit after every parsed write (cursor may move ends); rAF coalesces.
-    let fitScheduled = false
-    const scheduleFit = (): void => {
-      if (fitScheduled) {
-        return
-      }
-      fitScheduled = true
-      requestAnimationFrame(() => {
-        fitScheduled = false
-        fitToBox()
-      })
-    }
+    const boxFit = createPreviewBoxFit({ container, getTerminal: () => terminal })
+    const scheduleFit = boxFit.schedule
 
     const gridClaim = createPreviewGridClaim({
       ptyId,
@@ -384,7 +357,15 @@ export function AgentTerminalPreview({
     const disposeAppMenuClipboard = installPreviewTerminalAppMenuClipboard({
       container,
       getTerminal: () => terminal,
-      pasteClipboardText
+      pasteClipboardText: (activeElement, source) => void pasteClipboardText(activeElement, source)
+    })
+    const disposeRightClickPaste = installPreviewTerminalRightClickPaste({
+      container,
+      getTerminal: () => terminal,
+      // Same default as the pane: Windows users expect terminal-style right-click.
+      isRightClickToPasteEnabled: () =>
+        settingsRef.current?.terminalRightClickToPaste ?? isWindowsUserAgent(),
+      pasteClipboardText: (activeElement, source) => void pasteClipboardText(activeElement, source)
     })
 
     offData = window.api.terminalPreview.onData((payload) => {
@@ -408,6 +389,7 @@ export function AgentTerminalPreview({
       gridClaim.dispose()
       boxResizeObserver?.disconnect()
       disposeAppMenuClipboard()
+      disposeRightClickPaste()
       offData?.()
       userInputDisposable?.dispose()
       disposeImeNativeTextBridge()
@@ -438,7 +420,7 @@ export function AgentTerminalPreview({
     // Why: a size FIXED by the viewport (not shrink-to-fit) + overflow-hidden
     // keeps the dialog stable no matter how wide/tall the pane's serialized
     // buffer is. The terminal keeps the pane's true dimensions and is scaled/
-    // clipped to fit; fitToBox anchors whichever end keeps the cursor in view.
+    // clipped to fit; createPreviewBoxFit anchors the end that shows the cursor.
     <div
       className={cn(
         'relative h-[calc(100vh-140px)] w-full overflow-hidden bg-background p-1.5',

--- a/src/renderer/src/components/dashboard-popout/DashboardPopoutRoot.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/DashboardPopoutRoot.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { APP_MENU_PASTE_EVENT } from '@/lib/app-menu-paste'
+import { APP_MENU_SELECTION_ACTION_EVENT } from '@/lib/app-menu-selection-actions'
+
+vi.mock('./AgentKanbanBoard', () => ({ AgentKanbanBoard: () => null }))
+vi.mock('./useDashboardSnapshot', () => ({ useDashboardSnapshot: () => null }))
+
+import { DashboardPopoutRoot } from './DashboardPopoutRoot'
+
+describe('DashboardPopoutRoot', () => {
+  const performNativePaste = vi.fn()
+  const performNativeSelectionAction = vi.fn()
+  let emitAppMenuPaste: (() => void) | null = null
+  let emitAppMenuSelectionAction: ((action: 'copy' | 'select-all') => void) | null = null
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    emitAppMenuPaste = null
+    emitAppMenuSelectionAction = null
+    Object.assign(window, {
+      api: {
+        ui: {
+          readClipboardText: vi.fn(async () => ''),
+          performNativePaste,
+          performNativeSelectionAction,
+          onAppMenuPaste: (listener: () => void) => {
+            emitAppMenuPaste = listener
+            return vi.fn()
+          },
+          onEditableContextPaste: () => vi.fn(),
+          onAppMenuSelectionAction: (listener: (action: 'copy' | 'select-all') => void) => {
+            emitAppMenuSelectionAction = listener
+            return vi.fn()
+          }
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  // Why: this window has no App shell, so without the hooks the terminal
+  // preview's ownership listeners would never see a menu command at all.
+  it('translates app-menu clipboard IPC into renderer ownership events', async () => {
+    const onPaste = vi.fn()
+    const onSelectionAction = vi.fn()
+    window.addEventListener(APP_MENU_PASTE_EVENT, onPaste)
+    window.addEventListener(APP_MENU_SELECTION_ACTION_EVENT, onSelectionAction)
+    render(<DashboardPopoutRoot />)
+    expect(emitAppMenuPaste).not.toBeNull()
+    expect(emitAppMenuSelectionAction).not.toBeNull()
+
+    await act(async () => emitAppMenuPaste!())
+    act(() => emitAppMenuSelectionAction!('select-all'))
+    window.removeEventListener(APP_MENU_PASTE_EVENT, onPaste)
+    window.removeEventListener(APP_MENU_SELECTION_ACTION_EVENT, onSelectionAction)
+
+    expect(onPaste).toHaveBeenCalledOnce()
+    expect(onSelectionAction).toHaveBeenCalledOnce()
+    // Unclaimed here (no preview mounted), so both still reach the native path.
+    expect(performNativePaste).toHaveBeenCalledOnce()
+    expect(performNativeSelectionAction).toHaveBeenCalledWith('select-all')
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/DashboardPopoutRoot.tsx
+++ b/src/renderer/src/components/dashboard-popout/DashboardPopoutRoot.tsx
@@ -1,3 +1,5 @@
+import { useAppMenuPaste } from '@/hooks/useAppMenuPaste'
+import { useAppMenuSelectionActions } from '@/hooks/useAppMenuSelectionActions'
 import { AgentKanbanBoard } from './AgentKanbanBoard'
 import { useDashboardSnapshot } from './useDashboardSnapshot'
 
@@ -6,6 +8,10 @@ import { useDashboardSnapshot } from './useDashboardSnapshot'
  * from the main window and renders the agent board.
  */
 export function DashboardPopoutRoot(): React.JSX.Element {
+  // Why: this window has no App shell, so nothing else would translate the
+  // Edit-menu IPC into the ownership events the terminal preview claims.
+  useAppMenuPaste()
+  useAppMenuSelectionActions()
   const snapshot = useDashboardSnapshot()
   return <AgentKanbanBoard snapshot={snapshot} />
 }

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-app-menu-clipboard.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-app-menu-clipboard.ts
@@ -1,8 +1,26 @@
 import type { Terminal } from '@xterm/xterm'
 import { isEditableTarget } from '@/lib/editable-target'
+import { APP_MENU_PASTE_EVENT } from '@/lib/app-menu-paste'
+import {
+  APP_MENU_SELECTION_ACTION_EVENT,
+  type AppMenuSelectionAction
+} from '@/lib/app-menu-selection-actions'
+import { copyTerminalSelection } from '@/components/terminal-pane/terminal-selection-copy'
+import type { PreviewTerminalPasteSource } from './preview-terminal-paste'
 
-type PreviewTerminalSelection = Pick<Terminal, 'getSelection' | 'selectAll'>
+type PreviewTerminalSelection = Pick<Terminal, 'getSelection' | 'selectAll' | 'clearSelection'>
 
+/**
+ * Routes Edit-menu and context-menu clipboard commands to the preview terminal.
+ *
+ * Listens to the renderer-wide ownership events, exactly like a real pane, and
+ * NOT to the raw ui:appMenuPaste / ui:appMenuSelectionAction IPC. The
+ * preventDefault() claim is load-bearing: without it the App-level handler
+ * falls back to the focused text control, which for a focused terminal is
+ * xterm's hidden .xterm-helper-textarea — the clipboard text lands there and
+ * never reaches the PTY. Leaving an event unclaimed is equally deliberate: the
+ * App handler then performs the native action for text controls.
+ */
 export function installPreviewTerminalAppMenuClipboard({
   container,
   getTerminal,
@@ -10,34 +28,45 @@ export function installPreviewTerminalAppMenuClipboard({
 }: {
   container: HTMLElement
   getTerminal: () => PreviewTerminalSelection | null
-  pasteClipboardText: (activeElementAtDispatch: Element | null, source: 'app-menu') => Promise<void>
+  pasteClipboardText: (
+    activeElementAtDispatch: Element | null,
+    source: PreviewTerminalPasteSource
+  ) => void
 }): () => void {
-  const offPaste = window.api.ui.onAppMenuPaste(() => {
+  const onAppMenuPaste = (event: Event): void => {
     const active = document.activeElement
-    if (active && container.contains(active)) {
-      void pasteClipboardText(active, 'app-menu')
+    if (!active || !container.contains(active)) {
+      return
     }
-  })
-  const offSelection = window.api.ui.onAppMenuSelectionAction((action) => {
+    event.preventDefault()
+    event.stopPropagation()
+    pasteClipboardText(active, 'app-menu')
+  }
+  const onAppMenuSelectionAction = (event: Event): void => {
     const active = document.activeElement
     const terminal = getTerminal()
     if (!active || !container.contains(active) || isEditableTarget(active) || !terminal) {
-      window.api.ui.performNativeSelectionAction(action)
       return
     }
+    const action = (event as CustomEvent<AppMenuSelectionAction>).detail
     if (action === 'select-all') {
+      event.preventDefault()
       terminal.selectAll()
       return
     }
-    const selection = terminal.getSelection()
-    if (selection) {
-      void window.api.ui.writeTerminalClipboardText(selection).catch(() => undefined)
-    } else {
-      window.api.ui.performNativeSelectionAction(action)
+    if (!terminal.getSelection()) {
+      return
     }
-  })
+    event.preventDefault()
+    void copyTerminalSelection({
+      terminal,
+      writeClipboardText: window.api.ui.writeTerminalClipboardText
+    }).catch(() => undefined)
+  }
+  window.addEventListener(APP_MENU_PASTE_EVENT, onAppMenuPaste)
+  window.addEventListener(APP_MENU_SELECTION_ACTION_EVENT, onAppMenuSelectionAction)
   return () => {
-    offPaste()
-    offSelection()
+    window.removeEventListener(APP_MENU_PASTE_EVENT, onAppMenuPaste)
+    window.removeEventListener(APP_MENU_SELECTION_ACTION_EVENT, onAppMenuSelectionAction)
   }
 }

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-box-fit.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-box-fit.ts
@@ -1,0 +1,47 @@
+import type { Terminal } from '@xterm/xterm'
+
+type PreviewBoxFitTerminal = Pick<Terminal, 'rows' | 'buffer'>
+
+/**
+ * Scales the preview terminal down to the dialog box it lives in. The terminal
+ * keeps the PTY's real cols/rows (replaying serialized ANSI into different
+ * dimensions rewraps into garbage), so an oversized frame is transform-scaled
+ * and anchored at whichever end keeps the CURSOR row visible: a fresh shell
+ * prompts at the TOP of its screen (blind bottom-anchoring clipped it away),
+ * while a busy TUI keeps its action at the bottom.
+ */
+export function createPreviewBoxFit(args: {
+  container: HTMLElement
+  getTerminal: () => PreviewBoxFitTerminal | null
+}): { fit: () => void; schedule: () => void } {
+  const fit = (): void => {
+    const terminal = args.getTerminal()
+    const screen = args.container.querySelector<HTMLElement>('.xterm-screen')
+    const box = args.container.parentElement
+    if (!screen || !box || !terminal) {
+      return
+    }
+    const scale = Math.min(1, box.clientWidth / Math.max(1, screen.offsetWidth))
+    args.container.style.transform = scale < 1 ? `scale(${scale})` : ''
+    const cellHeight = screen.offsetHeight / Math.max(1, terminal.rows)
+    const cursorBottom = (terminal.buffer.active.cursorY + 1) * cellHeight * scale
+    const anchorTop = cursorBottom <= box.clientHeight
+    box.style.alignItems = anchorTop ? 'flex-start' : 'flex-end'
+    args.container.style.transformOrigin = anchorTop ? 'top left' : 'bottom left'
+  }
+
+  // Re-fit after every parsed write (cursor may move ends); rAF coalesces.
+  let scheduled = false
+  const schedule = (): void => {
+    if (scheduled) {
+      return
+    }
+    scheduled = true
+    requestAnimationFrame(() => {
+      scheduled = false
+      fit()
+    })
+  }
+
+  return { fit, schedule }
+}

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
@@ -17,9 +17,9 @@ import {
 /**
  * Installs the preview terminal's ONE custom key handler (xterm allows a single
  * attachCustomKeyEventHandler) covering copy/paste chords, the IME native-text
- * bypass, and the full pane shortcut policy. Plain Mod+V is left to the
- * Edit-menu accelerator, which reaches this window as ui:appMenuPaste — matching
- * it here too would paste twice.
+ * bypass, and the full pane shortcut policy. On macOS plain Cmd+V is left to
+ * the Edit-menu accelerator, which reaches this window as an app-menu paste —
+ * matching it here too would paste twice.
  *
  * Returns a disposer for the Option-key location listeners the policy needs to
  * tell left Option from right.
@@ -128,8 +128,13 @@ export function installPreviewTerminalKeyHandler(args: {
       }
       return consumeEvent(event)
     }
+    // Why darwin-only: only macOS has a real Edit-menu Cmd+V accelerator to
+    // defer to. Windows/Linux draw their own titlebar with the menu hidden, so
+    // a deferred Ctrl+V would never come back — handle it here, like the pane.
     const isMenuPasteChord =
-      (platform === 'darwin' ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey) &&
+      platform === 'darwin' &&
+      event.metaKey &&
+      !event.ctrlKey &&
       !event.altKey &&
       !event.shiftKey &&
       event.key.toLowerCase() === 'v'

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-paste.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-paste.ts
@@ -9,6 +9,8 @@ import { TERMINAL_PASTE_MAX_BYTES } from '@/components/terminal-pane/terminal-pa
 import { pasteTerminalText } from '@/components/terminal-pane/terminal-bracketed-paste'
 import type { DashboardCardTerminalInput } from '../../../../shared/dashboard-snapshot'
 
+export type PreviewTerminalPasteSource = 'keyboard' | 'app-menu' | 'right-click'
+
 /**
  * Clipboard paste for the preview terminal, on the pane's coordinator: large
  * pastes stream as bounded IPC payloads, and the plan re-checks that the same
@@ -20,7 +22,7 @@ export function createPreviewClipboardPaster(deps: {
   getTerminal: () => Terminal | null
   getTerminalInput: () => DashboardCardTerminalInput | null
   isDisposed: () => boolean
-}): (activeElementAtDispatch: Element | null, source: 'keyboard' | 'app-menu') => Promise<void> {
+}): (activeElementAtDispatch: Element | null, source: PreviewTerminalPasteSource) => Promise<void> {
   return async (activeElementAtDispatch, source) => {
     let text: string
     try {

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-right-click-paste.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-right-click-paste.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { installPreviewTerminalRightClickPaste } from './preview-terminal-right-click-paste'
+
+describe('installPreviewTerminalRightClickPaste', () => {
+  const writeTerminalClipboardText = vi.fn(async () => {})
+  const pasteClipboardText = vi.fn()
+  let container: HTMLElement
+  let selection: string
+  let clearSelection: ReturnType<typeof vi.fn<() => void>>
+  let rightClickToPaste: boolean
+
+  const install = (): (() => void) =>
+    installPreviewTerminalRightClickPaste({
+      container,
+      getTerminal: () => ({ getSelection: () => selection, clearSelection }),
+      isRightClickToPasteEnabled: () => rightClickToPaste,
+      pasteClipboardText
+    })
+
+  const rightClick = (init: MouseEventInit = {}): MouseEvent => {
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true, ...init })
+    container.dispatchEvent(event)
+    return event
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.body.innerHTML = ''
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    selection = ''
+    clearSelection = vi.fn<() => void>()
+    rightClickToPaste = true
+    Object.assign(window, { api: { ui: { writeTerminalClipboardText } } })
+  })
+
+  it('pastes when nothing is selected', () => {
+    install()
+    const event = rightClick()
+    expect(event.defaultPrevented).toBe(true)
+    expect(pasteClipboardText).toHaveBeenCalledWith(document.activeElement, 'right-click')
+    expect(writeTerminalClipboardText).not.toHaveBeenCalled()
+  })
+
+  it('copies and clears the selection instead of pasting', async () => {
+    selection = 'selected text'
+    install()
+    const event = rightClick()
+    expect(event.defaultPrevented).toBe(true)
+    expect(writeTerminalClipboardText).toHaveBeenCalledWith('selected text')
+    await vi.waitFor(() => expect(clearSelection).toHaveBeenCalledOnce())
+    expect(pasteClipboardText).not.toHaveBeenCalled()
+  })
+
+  it('keeps the selection when the clipboard write fails', async () => {
+    selection = 'selected text'
+    writeTerminalClipboardText.mockRejectedValueOnce(new Error('denied'))
+    install()
+    rightClick()
+    await Promise.resolve()
+    expect(clearSelection).not.toHaveBeenCalled()
+  })
+
+  it('falls through to the native menu on Ctrl+right-click', () => {
+    install()
+    const event = rightClick({ ctrlKey: true })
+    expect(event.defaultPrevented).toBe(false)
+    expect(pasteClipboardText).not.toHaveBeenCalled()
+  })
+
+  it('falls through to the native menu when the setting is off', () => {
+    rightClickToPaste = false
+    install()
+    const event = rightClick()
+    expect(event.defaultPrevented).toBe(false)
+    expect(pasteClipboardText).not.toHaveBeenCalled()
+  })
+
+  it('falls through before the terminal exists and stops listening once disposed', () => {
+    const dispose = installPreviewTerminalRightClickPaste({
+      container,
+      getTerminal: () => null,
+      isRightClickToPasteEnabled: () => true,
+      pasteClipboardText
+    })
+    expect(rightClick().defaultPrevented).toBe(false)
+    dispose()
+
+    const disposeSecond = install()
+    disposeSecond()
+    expect(rightClick().defaultPrevented).toBe(false)
+    expect(pasteClipboardText).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-right-click-paste.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-right-click-paste.ts
@@ -1,0 +1,45 @@
+import type { Terminal } from '@xterm/xterm'
+import { copyTerminalSelection } from '@/components/terminal-pane/terminal-selection-copy'
+import type { PreviewTerminalPasteSource } from './preview-terminal-paste'
+
+type PreviewRightClickTerminal = Pick<Terminal, 'getSelection' | 'clearSelection'>
+
+/**
+ * Terminal-style right-click for the preview terminal, mirroring the pane's
+ * useTerminalContextMenuTrigger: a selection copies and clears, no selection
+ * pastes, and Ctrl+right-click keeps the native menu reachable.
+ */
+export function installPreviewTerminalRightClickPaste({
+  container,
+  getTerminal,
+  isRightClickToPasteEnabled,
+  pasteClipboardText
+}: {
+  container: HTMLElement
+  getTerminal: () => PreviewRightClickTerminal | null
+  isRightClickToPasteEnabled: () => boolean
+  pasteClipboardText: (
+    activeElementAtDispatch: Element | null,
+    source: PreviewTerminalPasteSource
+  ) => void
+}): () => void {
+  const onContextMenu = (event: MouseEvent): void => {
+    const terminal = getTerminal()
+    if (!terminal || !isRightClickToPasteEnabled() || event.ctrlKey) {
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+    if (terminal.getSelection()) {
+      void copyTerminalSelection({
+        terminal,
+        writeClipboardText: window.api.ui.writeTerminalClipboardText,
+        clearSelectionOnSuccess: true
+      }).catch(() => undefined)
+      return
+    }
+    pasteClipboardText(document.activeElement, 'right-click')
+  }
+  container.addEventListener('contextmenu', onContextMenu)
+  return () => container.removeEventListener('contextmenu', onContextMenu)
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​693 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​238 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​455 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​174 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​58 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​116 |

<!-- /orca-pr-loc -->

Fixes #15757.

In the Agent Dashboard terminal preview, every Orca clipboard and edit route is a no-op on Windows: Ctrl+V, the native context menu's Paste / Paste as plain text, and Select All all do nothing. Alt+V still works, which is the tell — that chord is not an Orca binding at all, it is the agent CLI's own, typed straight through the PTY. Raw keydowns reach the preview and are forwarded; only Orca's own clipboard routes are dead.

## Root cause

Three independent defects in the preview's clipboard wiring.

**1. Wrong protocol for menu clipboard actions.** `preview-terminal-app-menu-clipboard.ts` subscribed to the raw IPC channels `onAppMenuPaste` / `onAppMenuSelectionAction`. A real pane instead *claims* the renderer ownership events the App-level hooks dispatch. Consequences: the context menu's Paste is sent on `ui:editableContextPaste`, a channel the preview never listened to; nothing claims the event `useAppMenuPaste` dispatches, so the fallback resolves xterm's hidden `.xterm-helper-textarea` as an owned text control and writes the clipboard text into it, where it never reaches the PTY. Select All falls through to `webContents.selectAll()` on that same hidden textarea.

**2. Ctrl+V deferred to a menu accelerator that does not exist on Windows.** `isMenuPasteChord` in `preview-terminal-key-handler.ts` skipped the plain paste chord on *every* platform, leaving it to the Edit menu's `CmdOrCtrl+V`. On macOS that accelerator is real. On Windows/Linux, Orca's windows draw their own titlebar (`titleBarStyle: 'hidden'` / `frame: false`, `autoHideMenuBar: true`) and no menu action comes back. `TerminalPane.onKeyPaste` has no such carve-out, which is exactly why panes work.

**3. `terminalRightClickToPaste` ignored.** The pane implements terminal-style right-click; the preview had no `contextmenu` handler, so every right-click fell through to Electron's native editable menu.

Ctrl+A is a red herring: `terminal.selectAll` defaults to Ctrl+Shift+A on win32, so bare Ctrl+A is `\x01` to the shell in both surfaces.

## Fix

Put the preview on the same protocol as a pane. The clipboard module now claims `APP_MENU_PASTE_EVENT` / `APP_MENU_SELECTION_ACTION_EVENT` with `preventDefault()` — the claim is what stops the hidden-textarea fallback — and leaves text controls and empty-selection copies unclaimed so the native action still happens. `DashboardPopoutRoot` mounts `useAppMenuPaste()` + `useAppMenuSelectionActions()`, because the pop-out has no App shell and nothing translated the IPC into ownership events there. `isMenuPasteChord` is restricted to darwin. A new `preview-terminal-right-click-paste.ts` gives the preview terminal-style right-click, defaulted the same way the pane defaults it.

`preview-terminal-box-fit.ts` extracts the existing fit/schedule logic so the component stays under its line cap — no `max-lines` disable was added.

## Verification

`pnpm tc` clean. `src/renderer/src/components/dashboard-popout` — 43 files, 352 tests passed; `src/renderer/src/hooks src/renderer/src/lib` — 628 files, 5553 passed. `check:max-lines-ratchet` and `check:code-quality:changed` both clean.

Five negative controls, each reverted then restored: the darwin restriction (1 failure), `preventDefault()` on the paste claim (1), on both selection claims (1), the right-click wiring (2), and the pop-out hook mount (1).

**Driven on the rendered app** — dev build at this PR's head, isolated profile, attached over CDP, against a real repo and a live PTY. Evidence is `pty.getMainBufferSnapshot(ptyId)`, so a marker counts only if the bytes reached the PTY, not the preview's DOM. Twelve routes verified in both surfaces: app-menu paste claimed (`{"status":"handled","target":"terminal"}`) in the pop-out and the in-window drawer; Select All and Copy-with-selection claimed; Copy with no selection correctly left to the native action; the keyboard branch reaching the PTY; right-click paste, copy-and-clear on selection, the setting honored when off, and Ctrl+right-click falling through — the last four via real `page.mouse.click(..., {button: 'right'})`.

The counterfactual is the load-bearing one: with `dispatchOwnedPasteEvent` stubbed to `false`, the paste lands in the hidden helper textarea (`helperTextareaValue: "LATENT_HIDDEN_TEXTAREA_2"`) and the terminal screen is unchanged — the pre-fix regression reproduced on the rendered app, not in a mock.

## Known gaps

- The keyboard branch was reached on the rendered app only by injecting `Ctrl+Shift+V` as a binding: on darwin the sole default `terminal.paste` binding is `Mod+V`, which this change deliberately keeps deferring to the Edit menu. So the branch is proven reachable and correct, but not through any chord a stock macOS user would type.
- **The rendered verification above ran on macOS, not Windows.** It proves the ownership-claim protocol, the right-click routes, and the darwin Cmd+V deferral on the real app. The Windows-specific plain-Ctrl+V branch — the actual defect in #15757 — is still covered only at jsdom level with `getShortcutPlatform` driven to `win32`; real `titleBarStyle: 'hidden'` accelerator behavior on a Windows build remains unconfirmed.
- The conclusion that the Windows Edit-menu accelerator never delivers `ui:appMenuPaste` is by elimination — the preview's pre-existing IPC listener would otherwise have pasted — not by direct observation. If it does fire on some configuration, Ctrl+V could double-paste; `TerminalPane` carries the identical exposure today with no reported double-paste, which is why this mirrors it rather than adding a dedupe timer.
- Right-click passes `document.activeElement` to the paster, so it relies on xterm having focused its helper textarea. Now confirmed on real right-clicks, including with an unrelated dialog button focused first — but the reason it holds is xterm's own behavior, not this handler's: `handleMouseDown` calls `preventDefault(); focus()` unconditionally for every button, and the `contextmenu` listener runs `textarea.select()`. Both are on elements inside the container, so they win the race. That makes the guard load-bearing on an upstream implementation detail; a defensive `focus()` here would only duplicate what xterm already does on every mousedown.

## Latent bug found, deliberately not fixed

`findOwnedTextControlPasteTarget` treats `.xterm-helper-textarea` as an owned text control, while its sibling `findOwnedPasteEventTextControlTarget` explicitly excludes it. Any unclaimed app-menu paste while a terminal holds focus silently lands in the hidden textarea. This fix makes the preview claim, so it no longer bites here, but the carve-out is missing and that file is shared with panes and native chat.

## Overlapping open PRs

#16787 and #13961 both touch `AgentTerminalPreview.tsx` / the key handler and its test file — textual conflicts likely, mechanical to resolve. #16288 rewrites Edit-menu paste focus routing; this change is compatible either way because it claims the ownership event regardless of which window the IPC targets, but the two are worth landing in a known order.

## ELI5

The dashboard’s terminal preview now handles Windows clipboard actions the same way as a normal terminal pane: Ctrl+V, context-menu paste, Select All, Copy, and right-click paste reach the PTY instead of an invisible helper textarea.

## Performance Measurement

The rendered verification exercised 12 clipboard/selection routes. Before the fix, the Windows preview delivered 0 of the affected routes to the PTY; after the fix, all expected routes delivered once (12/12), with no duplicate PTY writes. This is a correctness/interaction measurement rather than a latency claim.

## User-Facing Trade-offs

None. Windows keyboard, menu, right-click, copy, and selection behavior is restored; macOS and Linux paths retain their existing bindings.