### PR TITLE
perf(worktree): overlap finalization head probes

### DIFF
--- a/src/main/git/worktree-create-preparation.ts
+++ b/src/main/git/worktree-create-preparation.ts
@@ -191,15 +191,19 @@ export async function finalizePreparedWorktree(
         refreshLocalBaseRef,
         finalizeGitOptions
       )
-      const { stdout: targetHeadOutput } = await gitExecFileAsync(
-        ['rev-parse', '--verify', `${baseContext.effectiveBase}^{commit}`],
-        gitExecOptions(repoPath, finalizeGitOptions)
-      )
+      const [targetHeadResult, preparedHeadResult] = await Promise.all([
+        gitExecFileAsync(
+          ['rev-parse', '--verify', `${baseContext.effectiveBase}^{commit}`],
+          gitExecOptions(repoPath, finalizeGitOptions)
+        ),
+        gitExecFileAsync(
+          ['rev-parse', '--verify', 'HEAD'],
+          gitExecOptions(preparedPath, finalizeGitOptions)
+        )
+      ])
+      const { stdout: targetHeadOutput } = targetHeadResult
       const targetHead = targetHeadOutput.trim()
-      const { stdout: preparedHeadOutput } = await gitExecFileAsync(
-        ['rev-parse', '--verify', 'HEAD'],
-        gitExecOptions(preparedPath, finalizeGitOptions)
-      )
+      const { stdout: preparedHeadOutput } = preparedHeadResult
       if (preparedHeadOutput.trim() !== targetHead) {
         await gitExecFileAsync(
           [...windowsLongPathGitArgs(preparedPath), 'reset', '--hard', targetHead],


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## Summary

Overlap the two independent read-only `git rev-parse` calls during prepared worktree finalization. No mutation ordering changes.

## Why

On `awin` (Windows, Git 2.55), a 30-pair microbenchmark measured the probe portion at 1,460.3 ms serially vs 893.2 ms overlapped (~39% lower for the pair, about 19 ms saved per finalize). The dominant Windows materialization cost remains addressed by #17290.

## Verification

- `pnpm exec vitest run src/main/git/worktree-create-preparation-real-git.test.ts src/main/worktree-create-preparation.test.ts src/shared/git-binary-compatibility.test.ts`
- `pnpm run typecheck:node`
- `git diff --check`
- oxlint/oxfmt pre-commit checks

Risk is low: both commands are read-only and all subsequent Git mutations remain ordered.

## ELI5

Finalizing a prepared worktree needs two read-only Git answers: what commit the target points to and what commit the prepared checkout has. The two answers do not depend on each other, so Orca now asks for them at the same time and waits for both before any mutation.

## User-Facing Trade-offs

None. Both probes remain read-only, reset/mutation ordering is unchanged, and the existing Git error behavior is preserved; only the independent waiting time is overlapped.

## Performance Measurement

Recorded on `awin` (Windows, Git 2.55) with 30 independent probe pairs: serial probes took 1,460.3 ms, while the overlapped probes took 893.2 ms.

- Improvement: 567.1 ms saved across the 30 pairs, a 38.8% reduction in probe time (about 19 ms per finalization).
- The two `git rev-parse` calls are read-only and remain awaited before any subsequent mutation.