### PR TITLE
fix(pty): let any unverifiable probe poison the combined liveness verdict

### DIFF
--- a/src/main/daemon/daemon-pty-adapter-protocol-compatibility.test.ts
+++ b/src/main/daemon/daemon-pty-adapter-protocol-compatibility.test.ts
@@ -605,7 +605,14 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       await expect(legacy.inspectProcess('sess-a')).resolves.toEqual({
         foregroundProcess: null,
         hasChildProcesses: true,
-        unavailable: true
+        unavailable: true,
+        processEvidence: {
+          foreground: {
+            verdict: 'unverifiable',
+            reason: 'daemon lacks process inspection support'
+          },
+          children: { verdict: 'unverifiable', reason: 'daemon lacks process inspection support' }
+        }
       })
       await expect(legacy.getForegroundProcess('sess-a')).resolves.toBeNull()
       await expect(legacy.hasChildProcesses('sess-a')).resolves.toBe(true)
@@ -623,7 +630,11 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
       expect(await legacy.inspectProcess('sess-a')).toEqual({
         foregroundProcess: 'codex',
-        hasChildProcesses: true
+        hasChildProcesses: true,
+        processEvidence: {
+          foreground: { verdict: 'live', processName: 'codex' },
+          children: { verdict: 'live' }
+        }
       })
       expect(request).toHaveBeenCalledWith('getForegroundProcess', { sessionId: 'sess-a' })
       expect(request).not.toHaveBeenCalledWith('inspectProcess', expect.anything())
@@ -639,7 +650,11 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
       expect(await legacy.inspectProcess('sess-a')).toEqual({
         foregroundProcess: 'bash',
-        hasChildProcesses: false
+        hasChildProcesses: false,
+        processEvidence: {
+          foreground: { verdict: 'exited', processName: 'bash' },
+          children: { verdict: 'exited' }
+        }
       })
 
       legacy.dispose()
@@ -653,7 +668,11 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
       expect(await legacy.inspectProcess('sess-a')).toEqual({
         foregroundProcess: null,
-        hasChildProcesses: false
+        hasChildProcesses: false,
+        processEvidence: {
+          foreground: { verdict: 'exited', processName: null },
+          children: { verdict: 'exited' }
+        }
       })
 
       legacy.dispose()

--- a/src/main/daemon/daemon-pty-process-inspection.ts
+++ b/src/main/daemon/daemon-pty-process-inspection.ts
@@ -8,6 +8,10 @@ import {
   type SessionInfo
 } from './types'
 import type { PtyProcessInspection } from '../providers/pty-process-inspection'
+import {
+  buildPtyProcessInspectionWireResult,
+  type PtyForegroundProcessEvidence
+} from '../../shared/pty-process-inspection-evidence'
 
 export abstract class DaemonPtyProcessInspection extends DaemonPtyBufferSnapshots {
   // Why: daemon-backed PTYs can host long-lived agents while detached; cleanup prompts must not treat them as idle shells.
@@ -24,7 +28,18 @@ export abstract class DaemonPtyProcessInspection extends DaemonPtyBufferSnapshot
 
   async inspectProcess(id: string): Promise<PtyProcessInspection> {
     if (this.protocolVersion < GET_FOREGROUND_PROCESS_PROTOCOL_VERSION) {
-      return { foregroundProcess: null, hasChildProcesses: true, unavailable: true }
+      return {
+        foregroundProcess: null,
+        hasChildProcesses: true,
+        unavailable: true,
+        processEvidence: {
+          foreground: {
+            verdict: 'unverifiable',
+            reason: 'daemon lacks process inspection support'
+          },
+          children: { verdict: 'unverifiable', reason: 'daemon lacks process inspection support' }
+        }
+      }
     }
     if (this.protocolVersion < COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION) {
       // Why: pre-v27 daemons survive an in-place app update; compose the inspection client-side from the
@@ -34,15 +49,15 @@ export abstract class DaemonPtyProcessInspection extends DaemonPtyBufferSnapshot
       const { foregroundProcess } = await this.client.request<{
         foregroundProcess: string | null
       }>('getForegroundProcess', { sessionId: id })
-      return {
-        foregroundProcess,
-        hasChildProcesses: this.hasChildProcessesFromForeground(foregroundProcess)
-      }
+      const foreground = classifyDaemonForegroundProcess(foregroundProcess)
+      return buildPtyProcessInspectionWireResult(
+        foreground,
+        this.hasChildProcessesFromForeground(foregroundProcess)
+          ? { verdict: 'live' }
+          : { verdict: 'exited' }
+      )
     }
-    return this.client.request<{
-      foregroundProcess: string | null
-      hasChildProcesses: boolean
-    }>('inspectProcess', { sessionId: id })
+    return this.client.request<PtyProcessInspection>('inspectProcess', { sessionId: id })
   }
 
   async getForegroundProcess(id: string): Promise<string | null> {
@@ -185,4 +200,12 @@ export abstract class DaemonPtyProcessInspection extends DaemonPtyBufferSnapshot
       }
     })
   }
+}
+
+function classifyDaemonForegroundProcess(
+  foregroundProcess: string | null
+): PtyForegroundProcessEvidence {
+  return foregroundProcess !== null && !isShellProcess(foregroundProcess)
+    ? { verdict: 'live', processName: foregroundProcess }
+    : { verdict: 'exited', processName: foregroundProcess }
 }

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -226,7 +226,11 @@ it('preserves unavailable inspection from the owning legacy daemon', async () =>
   await expect(router.inspectProcess('legacy-session')).resolves.toEqual({
     foregroundProcess: null,
     hasChildProcesses: true,
-    unavailable: true
+    unavailable: true,
+    processEvidence: {
+      foreground: { verdict: 'unverifiable', reason: 'peer omitted process inspection evidence' },
+      children: { verdict: 'unverifiable', reason: 'peer omitted process inspection evidence' }
+    }
   })
 })
 

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -9,6 +9,7 @@ import type {
   PtySpawnResult
 } from '../providers/types'
 import type { PtyProcessInspection } from '../providers/pty-process-inspection'
+import { ensurePtyProcessInspectionEvidence } from '../../shared/pty-process-inspection-evidence'
 import { shouldHandoffDaemonHistory } from './daemon-history-handoff'
 import type { DaemonPtyRouterDataEvent, DaemonPtyRouterExitEvent } from './daemon-pty-router-events'
 import { DaemonSessionOwnerResolver } from './daemon-session-owner-resolution'
@@ -178,7 +179,9 @@ export class DaemonPtyRouter implements IPtyProvider {
   }
 
   async inspectProcess(id: string): Promise<PtyProcessInspection> {
-    return this.adapterForInspection(id).inspectProcess(id)
+    return ensurePtyProcessInspectionEvidence(
+      await this.adapterForInspection(id).inspectProcess(id)
+    )
   }
 
   async confirmForegroundProcess(id: string): Promise<string | null> {

--- a/src/main/daemon/degraded-daemon-pty-process-inspection.ts
+++ b/src/main/daemon/degraded-daemon-pty-process-inspection.ts
@@ -1,0 +1,19 @@
+import {
+  inspectPtyProviderProcess,
+  type PtyProcessInspection
+} from '../providers/pty-process-inspection'
+import type { IPtyProvider } from '../providers/types'
+import { ensurePtyProcessInspectionEvidence } from '../../shared/pty-process-inspection-evidence'
+
+export async function inspectDegradedDaemonPtyProcess(
+  id: string,
+  hasPty: (id: string) => boolean,
+  resolveProvider: (id: string) => IPtyProvider
+): Promise<PtyProcessInspection> {
+  if (!hasPty(id)) {
+    throw new Error('terminal_gone')
+  }
+  return ensurePtyProcessInspectionEvidence(
+    await inspectPtyProviderProcess(resolveProvider(id), id)
+  )
+}

--- a/src/main/daemon/degraded-daemon-pty-provider.test.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.test.ts
@@ -288,7 +288,11 @@ it('preserves unavailable inspection from an owning daemon', async () => {
   await expect(provider.inspectProcess('daemon-session')).resolves.toEqual({
     foregroundProcess: null,
     hasChildProcesses: true,
-    unavailable: true
+    unavailable: true,
+    processEvidence: {
+      foreground: { verdict: 'unverifiable', reason: 'peer omitted process inspection evidence' },
+      children: { verdict: 'unverifiable', reason: 'peer omitted process inspection evidence' }
+    }
   })
 })
 

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -1,7 +1,6 @@
 import type { DaemonPtyAdapter } from './daemon-pty-adapter'
 import { combineUnsubscribes } from './combine-unsubscribes'
 import { shutdownDegradedFallbackSessions } from './degraded-daemon-fallback-shutdown'
-import { inspectPtyProviderProcess } from '../providers/pty-process-inspection'
 import type {
   IPtyProvider,
   PtyBackgroundStreamEvent,
@@ -19,6 +18,7 @@ import {
 } from './degraded-daemon-session-routing'
 import { DegradedDaemonFreshSpawnRouter } from './degraded-daemon-fresh-spawn-routing'
 import { DegradedDaemonOwnerRecovery } from './degraded-daemon-owner-recovery'
+import { inspectDegradedDaemonPtyProcess } from './degraded-daemon-pty-process-inspection'
 
 export class DegradedDaemonPtyProvider implements IPtyProvider {
   readonly isDegraded = true
@@ -187,9 +187,11 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     return this.providerFor(id).getForegroundProcess(id)
   }
   inspectProcess(id: string) {
-    return this.hasPty(id)
-      ? inspectPtyProviderProcess(this.providerFor(id), id)
-      : Promise.reject(new Error('terminal_gone'))
+    return inspectDegradedDaemonPtyProcess(
+      id,
+      (ptyId) => this.hasPty(ptyId),
+      (ptyId) => this.providerFor(ptyId)
+    )
   }
   async confirmForegroundProcess(id: string): Promise<string | null> {
     return this.providerFor(id).confirmForegroundProcess?.(id) ?? null

--- a/src/main/daemon/terminal-host-process-inspection.test.ts
+++ b/src/main/daemon/terminal-host-process-inspection.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import { TerminalHost } from './terminal-host'
+
+describe('TerminalHost process inspection', () => {
+  it('publishes process evidence with daemon inspection results', async () => {
+    let onExit: ((code: number) => void) | undefined
+    const emitExit = (): void => onExit?.(0)
+    const subprocess = {
+      pid: 99999,
+      getForegroundProcess: vi.fn(() => 'codex'),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(emitExit),
+      terminateOwnedTree: vi.fn(() => 'unavailable'),
+      forceKill: vi.fn(emitExit),
+      signal: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn((callback: (code: number) => void) => {
+        onExit = callback
+      }),
+      dispose: vi.fn()
+    }
+    const host = new TerminalHost({ spawnSubprocess: vi.fn(() => subprocess) as never })
+
+    await host.createOrAttach({
+      sessionId: 'session-1',
+      cols: 80,
+      rows: 24,
+      streamClient: { onData: vi.fn(), onExit: vi.fn() }
+    })
+
+    expect(host.inspectProcess('session-1')).toEqual({
+      foregroundProcess: 'codex',
+      hasChildProcesses: true,
+      processEvidence: {
+        foreground: { verdict: 'live', processName: 'codex' },
+        children: { verdict: 'live' }
+      }
+    })
+    await host.dispose()
+  })
+})

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -21,6 +21,10 @@ import { listLiveTerminalHostSessions } from './terminal-host-session-listing'
 import { createOrAttachTerminalSession } from './terminal-host-session-create'
 import { isShellProcess } from '../../shared/agent-detection'
 import { TerminalAttachCanceledError } from './daemon-errors'
+import {
+  buildPtyProcessInspectionWireResult,
+  type PtyProcessInspectionWireResult
+} from '../../shared/pty-process-inspection-evidence'
 
 export type { CreateOrAttachOptions, CreateOrAttachResult } from './terminal-host-create-contract'
 
@@ -214,15 +218,15 @@ export class TerminalHost {
     return session.getForegroundProcess()
   }
 
-  inspectProcess(sessionId: string): {
-    foregroundProcess: string | null
-    hasChildProcesses: boolean
-  } {
+  inspectProcess(sessionId: string): PtyProcessInspectionWireResult {
     const foregroundProcess = this.getAliveSession(sessionId).getForegroundProcess()
-    return {
-      foregroundProcess,
-      hasChildProcesses: foregroundProcess !== null && !isShellProcess(foregroundProcess)
-    }
+    const foreground =
+      foregroundProcess !== null && !isShellProcess(foregroundProcess)
+        ? { verdict: 'live' as const, processName: foregroundProcess }
+        : { verdict: 'exited' as const, processName: foregroundProcess }
+    const children =
+      foreground.verdict === 'live' ? { verdict: 'live' as const } : { verdict: 'exited' as const }
+    return buildPtyProcessInspectionWireResult(foreground, children)
   }
 
   async confirmForegroundProcess(sessionId: string): Promise<string | null> {

--- a/src/main/ipc/pty-session-liveness-and-ownership.test.ts
+++ b/src/main/ipc/pty-session-liveness-and-ownership.test.ts
@@ -101,7 +101,11 @@ describe('registerPtyHandlers', () => {
       await expect(handlers.get('pty:inspectProcess')!(null, { id })).resolves.toEqual({
         foregroundProcess: null,
         hasChildProcesses: false,
-        unavailable: true
+        unavailable: true,
+        processEvidence: {
+          foreground: { verdict: 'unverifiable', reason: 'pty route unavailable' },
+          children: { verdict: 'unverifiable', reason: 'pty route unavailable' }
+        }
       })
       expect(inspectProcess).not.toHaveBeenCalled()
     }
@@ -514,7 +518,11 @@ describe('registerPtyHandlers', () => {
     await expect(handlers.get('pty:inspectProcess')!(null, { id: 'gone-pty' })).resolves.toEqual({
       foregroundProcess: null,
       hasChildProcesses: false,
-      unavailable: true
+      unavailable: true,
+      processEvidence: {
+        foreground: { verdict: 'unverifiable', reason: 'pty no longer exists' },
+        children: { verdict: 'unverifiable', reason: 'pty no longer exists' }
+      }
     })
   })
 })

--- a/src/main/ipc/pty-startup-swap-window-presence.test.ts
+++ b/src/main/ipc/pty-startup-swap-window-presence.test.ts
@@ -263,6 +263,14 @@ describe('registerPtyHandlers daemon-swap-window presence', () => {
     // flight there is no window in which its word could be fabricated.
     await expect(
       handlers.get('pty:inspectProcess')!(null, { id: 'never-spawned-pty' })
-    ).resolves.toEqual({ foregroundProcess: null, hasChildProcesses: false, unavailable: true })
+    ).resolves.toEqual({
+      foregroundProcess: null,
+      hasChildProcesses: false,
+      unavailable: true,
+      processEvidence: {
+        foreground: { verdict: 'unverifiable', reason: 'pty no longer exists' },
+        children: { verdict: 'unverifiable', reason: 'pty no longer exists' }
+      }
+    })
   })
 })

--- a/src/main/ipc/pty/ipc/inspect.ts
+++ b/src/main/ipc/pty/ipc/inspect.ts
@@ -170,14 +170,30 @@ export function installPtyInspectIpcHandlers(deps: {
   ipcMain.handle('pty:inspectProcess', async (_event, args: { id: string }) => {
     // Why: same routing hazard as pty:hasPty — an unroutable id must read as unavailable, not as a local-provider answer or a raised IPC error.
     if (typeof args?.id !== 'string' || !args.id || args.id.startsWith('remote:')) {
-      return { foregroundProcess: null, hasChildProcesses: false, unavailable: true as const }
+      return {
+        foregroundProcess: null,
+        hasChildProcesses: false,
+        unavailable: true as const,
+        processEvidence: {
+          foreground: { verdict: 'unverifiable', reason: 'pty route unavailable' },
+          children: { verdict: 'unverifiable', reason: 'pty route unavailable' }
+        }
+      }
     }
     // Why: the pre-swap LocalPtyProvider does not own restored daemon ids, so
     // nothing it reports about one is an observation; the post-swap owner must
     // answer completion-sensitive inspection.
     await awaitSwapWindow(args.id)
     if (!hasPtyProviderForInspection(args.id)) {
-      return { foregroundProcess: null, hasChildProcesses: false, unavailable: true as const }
+      return {
+        foregroundProcess: null,
+        hasChildProcesses: false,
+        unavailable: true as const,
+        processEvidence: {
+          foreground: { verdict: 'unverifiable', reason: 'pty route unavailable' },
+          children: { verdict: 'unverifiable', reason: 'pty route unavailable' }
+        }
+      }
     }
     return inspectPtyProviderProcessForRenderer(getProviderForPty(args.id), args.id)
   })

--- a/src/main/providers/local-pty-foreground-inspection.ts
+++ b/src/main/providers/local-pty-foreground-inspection.ts
@@ -10,6 +10,10 @@ import {
   ptyProcesses,
   ptyShellName
 } from './local-pty-provider-state'
+import {
+  classifyLocalForegroundEvidence,
+  type LocalForegroundObservation
+} from './local-pty-process-evidence'
 import { resolveStableForegroundProcess } from './stable-foreground-process'
 import {
   canRevalidateCachedAgentWithoutScan,
@@ -35,11 +39,19 @@ export async function hasLocalPtyChildProcesses(id: string): Promise<boolean> {
   }
 }
 
+/** Legacy callers receive only the observed/stable process name. */
 export async function getLocalPtyForegroundProcess(id: string): Promise<string | null> {
+  return (await observeLocalPtyForegroundProcess(id)).processName
+}
+
+/** Foreground process plus whether the execution host actually answered. */
+export async function observeLocalPtyForegroundProcess(
+  id: string
+): Promise<LocalForegroundObservation> {
   const proc = ptyProcesses.get(id)
   if (!proc) {
     ptyLastRecognizedForeground.delete(id)
-    return null
+    return { processName: null, evidence: { verdict: 'exited', processName: null } }
   }
   const fallbackProcess = resolveForegroundFallbackProcess(
     proc.process || null,
@@ -60,7 +72,10 @@ export async function getLocalPtyForegroundProcess(id: string): Promise<string |
     try {
       const paneProcessIds = readWindowsPtyJobProcessIds(proc)
       if (ptyProcesses.get(id) !== proc) {
-        return null
+        return {
+          processName: null,
+          evidence: { verdict: 'unverifiable', reason: 'pty replaced during inspection' }
+        }
       }
       const verdict = judgeCachedAgentJobEvidence({
         jobProcessIds: paneProcessIds,
@@ -70,7 +85,10 @@ export async function getLocalPtyForegroundProcess(id: string): Promise<string |
         identityAgeMs: Date.now() - (cachedEntry?.at ?? 0)
       })
       if (verdict === 'confirmed' || verdict === 'unproven') {
-        return cachedAgent
+        return {
+          processName: cachedAgent,
+          evidence: classifyLocalForegroundEvidence(cachedAgent, true)
+        }
       }
       if (verdict === 'exited') {
         // The shell stands alone in a complete, inescapable job list: no
@@ -102,7 +120,10 @@ export async function getLocalPtyForegroundProcess(id: string): Promise<string |
     )
     // Why: the scan can outlive PTY teardown/id reuse; stale results must not resurrect cache for a foreign id.
     if (ptyProcesses.get(id) !== proc) {
-      return null
+      return {
+        processName: null,
+        evidence: { verdict: 'unverifiable', reason: 'pty replaced during inspection' }
+      }
     }
     // Why: a degraded scan reporting shell-as-foreground fires a false "agent done"; keep last recognized agent instead.
     const lastRecognizedAgent = ptyLastRecognizedForeground.get(id)?.name ?? null
@@ -141,13 +162,32 @@ export async function getLocalPtyForegroundProcess(id: string): Promise<string |
     } else if (!stable.lastRecognizedAgent) {
       ptyLastRecognizedForeground.delete(id)
     }
-    return stable.processName
+    if (!stableResolution.available) {
+      return {
+        processName: stable.processName,
+        evidence: {
+          verdict: 'unverifiable',
+          reason: paneMembershipUnavailable
+            ? 'pane membership read unavailable'
+            : 'process table scan degraded'
+        }
+      }
+    }
+    return {
+      processName: stable.processName,
+      evidence: classifyLocalForegroundEvidence(stable.processName, true)
+    }
   } catch {
     if (ptyProcesses.get(id) !== proc) {
-      return null
+      return {
+        processName: null,
+        evidence: { verdict: 'unverifiable', reason: 'pty replaced during inspection' }
+      }
     }
-    // Why: an inspection error is a degraded read; fall back to last recognized agent (null reads as an exit).
-    return ptyLastRecognizedForeground.get(id)?.name ?? null
+    return {
+      processName: ptyLastRecognizedForeground.get(id)?.name ?? null,
+      evidence: { verdict: 'unverifiable', reason: 'foreground inspection threw' }
+    }
   }
 }
 

--- a/src/main/providers/local-pty-process-evidence.ts
+++ b/src/main/providers/local-pty-process-evidence.ts
@@ -1,0 +1,72 @@
+import type {
+  PtyChildProcessesEvidence,
+  PtyForegroundProcessEvidence
+} from '../../shared/pty-process-inspection-evidence'
+import { isShellProcess } from '../../shared/shell-process-detection'
+
+/** A local foreground read plus the evidence behind it. */
+export type LocalForegroundObservation = {
+  processName: string | null
+  evidence: PtyForegroundProcessEvidence
+}
+
+export function classifyLocalForegroundEvidence(
+  processName: string | null,
+  available: boolean
+): PtyForegroundProcessEvidence {
+  if (!available) {
+    return { verdict: 'unverifiable', reason: 'process table scan degraded' }
+  }
+  if (!processName || isShellProcess(processName)) {
+    return { verdict: 'exited', processName }
+  }
+  return { verdict: 'live', processName }
+}
+
+type LocalPtyTitleRead = { ok: true; title: string | null } | { ok: false }
+
+/** A native title read that throws is a failed probe, not an idle shell. */
+export function readLocalPtyTitle(proc: { process: string } | undefined): LocalPtyTitleRead {
+  if (!proc) {
+    return { ok: false }
+  }
+  try {
+    return { ok: true, title: proc.process || null }
+  } catch {
+    return { ok: false }
+  }
+}
+
+/** Keep legacy booleans while retaining the three-valued child-process verdict. */
+export function classifyLocalPtyChildProcesses(input: {
+  procPresent: boolean
+  titleRead: LocalPtyTitleRead
+  shell: string | undefined
+  foreground: PtyForegroundProcessEvidence
+}): { hasChildProcesses: boolean; evidence: PtyChildProcessesEvidence } {
+  if (!input.procPresent) {
+    return { hasChildProcesses: false, evidence: { verdict: 'exited' } }
+  }
+  if (!input.titleRead.ok) {
+    return {
+      hasChildProcesses: false,
+      evidence: { verdict: 'unverifiable', reason: 'pty title read failed' }
+    }
+  }
+  if (!input.shell || input.titleRead.title !== input.shell) {
+    return { hasChildProcesses: true, evidence: { verdict: 'live' } }
+  }
+  if (input.foreground.verdict === 'unverifiable') {
+    return {
+      hasChildProcesses: false,
+      evidence: {
+        verdict: 'unverifiable',
+        reason: 'pty title matches the shell while the foreground scan is degraded'
+      }
+    }
+  }
+  if (input.foreground.verdict === 'live') {
+    return { hasChildProcesses: false, evidence: { verdict: 'live' } }
+  }
+  return { hasChildProcesses: false, evidence: { verdict: 'exited' } }
+}

--- a/src/main/providers/local-pty-provider-foreground-process.test.ts
+++ b/src/main/providers/local-pty-provider-foreground-process.test.ts
@@ -229,6 +229,31 @@ describe('LocalPtyProvider', () => {
       await expect(foreground).resolves.toBeNull()
     })
 
+    it('publishes mixed evidence when exit lands during an inspection', async () => {
+      let resolveScan!: (resolution: { available: boolean; processName: string | null }) => void
+      resolveAgentForegroundProcessMock.mockReturnValue(
+        new Promise((resolve) => {
+          resolveScan = resolve
+        })
+      )
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+
+      const inspection = provider.inspectProcess(id)
+      // The node-pty exit callback clears the provider maps while the
+      // foreground process-table read is still in flight.
+      exitCb?.({ exitCode: 0 })
+      resolveScan({ available: true, processName: null })
+
+      await expect(inspection).resolves.toMatchObject({
+        foregroundProcess: null,
+        hasChildProcesses: false,
+        processEvidence: {
+          foreground: { verdict: 'unverifiable' },
+          children: { verdict: 'exited' }
+        }
+      })
+    })
+
     it('confirms a still-active agent from job membership without a whole-table scan', async () => {
       Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
       mockProc.process = 'powershell.exe'

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -4,14 +4,18 @@ import {
   confirmLocalPtyForegroundProcess,
   confirmLocalPtyShellForeground,
   getLocalPtyForegroundProcess,
-  hasLocalPtyChildProcesses
+  hasLocalPtyChildProcesses,
+  observeLocalPtyForegroundProcess
 } from './local-pty-foreground-inspection'
+import { classifyLocalPtyChildProcesses, readLocalPtyTitle } from './local-pty-process-evidence'
+import type { PtyProcessInspection } from './pty-process-inspection'
 import type { LocalPtyProviderOptions } from './local-pty-provider-types'
 import {
   advanceLoadGeneration,
   clearPtyState,
   pendingLocalPtySpawns,
   ptyProcesses,
+  ptyShellName,
   resetLoadGeneration,
   type DataCallback,
   type ExitCallback
@@ -127,6 +131,22 @@ export class LocalPtyProvider implements IPtyProvider {
 
   confirmShellForeground(id: string): Promise<boolean> {
     return confirmLocalPtyShellForeground(id)
+  }
+
+  async inspectProcess(id: string): Promise<PtyProcessInspection> {
+    const foreground = await observeLocalPtyForegroundProcess(id)
+    const proc = ptyProcesses.get(id)
+    const children = classifyLocalPtyChildProcesses({
+      procPresent: proc !== undefined,
+      titleRead: readLocalPtyTitle(proc),
+      shell: ptyShellName.get(id),
+      foreground: foreground.evidence
+    })
+    return {
+      foregroundProcess: foreground.processName,
+      hasChildProcesses: children.hasChildProcesses,
+      processEvidence: { foreground: foreground.evidence, children: children.evidence }
+    }
   }
 
   async serialize(_ids: string[]): Promise<string> {

--- a/src/main/providers/pty-process-inspection-mixed-evidence-race.test.ts
+++ b/src/main/providers/pty-process-inspection-mixed-evidence-race.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { IPtyProvider } from './types'
+import { inspectPtyProviderProcess } from './pty-process-inspection'
+
+describe('PTY inspection when the process exits between probes', () => {
+  it('does not turn an exit during the foreground read into a safe idle result', async () => {
+    let exited = false
+    const onExit = vi.fn(() => {
+      exited = true
+    })
+    const provider = {
+      hasPty: vi.fn(() => !exited),
+      getForegroundProcess: vi.fn(async () => {
+        // This is the interleaving: node-pty reports the process exit while the
+        // foreground probe is in flight, before the child probe starts.
+        onExit()
+        return null
+      }),
+      hasChildProcesses: vi.fn(async () => !exited)
+    } as unknown as IPtyProvider
+
+    const inspection = await inspectPtyProviderProcess(provider, 'pty-race')
+
+    expect(onExit).toHaveBeenCalledOnce()
+    expect(provider.getForegroundProcess).toHaveBeenCalledOnce()
+    expect(provider.hasChildProcesses).toHaveBeenCalledOnce()
+    // A process that vanished mid-read leaves the foreground half unknown while
+    // the later child read sees it gone. The combined result must retain both.
+    expect(inspection).toMatchObject({
+      processEvidence: {
+        foreground: { verdict: 'unverifiable' },
+        children: { verdict: 'exited' }
+      }
+    })
+  })
+})

--- a/src/main/providers/pty-process-inspection.test.ts
+++ b/src/main/providers/pty-process-inspection.test.ts
@@ -71,7 +71,11 @@ describe('PTY provider process inspection', () => {
 
     await expect(inspectPtyProviderProcess(provider, 'pty-1')).resolves.toEqual({
       foregroundProcess: 'codex',
-      hasChildProcesses: true
+      hasChildProcesses: true,
+      processEvidence: {
+        foreground: { verdict: 'live', processName: 'codex' },
+        children: { verdict: 'live' }
+      }
     })
   })
 })

--- a/src/main/providers/pty-process-inspection.test.ts
+++ b/src/main/providers/pty-process-inspection.test.ts
@@ -36,7 +36,11 @@ describe('PTY provider process inspection', () => {
     await expect(inspectPtyProviderProcessForRenderer(provider, 'pty-missing')).resolves.toEqual({
       foregroundProcess: null,
       hasChildProcesses: false,
-      unavailable: true
+      unavailable: true,
+      processEvidence: {
+        foreground: { verdict: 'unverifiable', reason: 'pty no longer exists' },
+        children: { verdict: 'unverifiable', reason: 'pty no longer exists' }
+      }
     })
   })
 

--- a/src/main/providers/pty-process-inspection.ts
+++ b/src/main/providers/pty-process-inspection.ts
@@ -1,9 +1,15 @@
 import type { IPtyProvider } from './types'
+import {
+  buildPtyProcessInspectionWireResult,
+  type PtyProcessInspectionEvidence
+} from '../../shared/pty-process-inspection-evidence'
+import { isShellProcess } from '../../shared/shell-process-detection'
 
 export type PtyProcessInspection = {
   foregroundProcess: string | null
   hasChildProcesses: boolean
   unavailable?: true
+  processEvidence?: PtyProcessInspectionEvidence
 }
 
 type CompletionSensitivePtyProvider = IPtyProvider & {
@@ -22,8 +28,19 @@ export async function inspectPtyProviderProcess(
     return inspectProcess.call(provider, ptyId)
   }
   const foregroundProcess = await provider.getForegroundProcess(ptyId)
+  // A local exit can land after the initial hasPty check but before the
+  // foreground probe resolves. Keep that half explicitly unverifiable rather
+  // than letting its null collapse look like an observed idle shell.
+  const foregroundStillPresent = provider.hasPty?.(ptyId) !== false
   const hasChildProcesses = await provider.hasChildProcesses(ptyId)
-  return { foregroundProcess, hasChildProcesses }
+  return buildPtyProcessInspectionWireResult(
+    foregroundStillPresent
+      ? foregroundProcess && !isShellProcess(foregroundProcess)
+        ? { verdict: 'live', processName: foregroundProcess }
+        : { verdict: 'exited', processName: foregroundProcess }
+      : { verdict: 'unverifiable', reason: 'pty exited during foreground inspection' },
+    hasChildProcesses ? { verdict: 'live' } : { verdict: 'exited' }
+  )
 }
 
 export async function inspectPtyProviderProcessForRenderer(

--- a/src/main/providers/pty-process-inspection.ts
+++ b/src/main/providers/pty-process-inspection.ts
@@ -51,7 +51,15 @@ export async function inspectPtyProviderProcessForRenderer(
     return await inspectPtyProviderProcess(provider, ptyId)
   } catch (error) {
     if (error instanceof Error && error.message === 'terminal_gone') {
-      return { foregroundProcess: null, hasChildProcesses: false, unavailable: true }
+      return {
+        foregroundProcess: null,
+        hasChildProcesses: false,
+        unavailable: true,
+        processEvidence: {
+          foreground: { verdict: 'unverifiable', reason: 'pty no longer exists' },
+          children: { verdict: 'unverifiable', reason: 'pty no longer exists' }
+        }
+      }
     }
     throw error
   }

--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -241,7 +241,11 @@ describe('SshPtyProvider', () => {
     const inspection = {
       foregroundProcess: null,
       hasChildProcesses: true,
-      unavailable: true as const
+      unavailable: true as const,
+      processEvidence: {
+        foreground: { verdict: 'unverifiable' as const, reason: 'relay unavailable' },
+        children: { verdict: 'unverifiable' as const, reason: 'relay unavailable' }
+      }
     }
     mux.request.mockResolvedValue(inspection)
 

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -23,6 +23,7 @@ import { SshPtySpawnExitRaceTracker } from './ssh-pty-spawn-exit-race'
 import { SshAgentSessionCapabilities } from './ssh-agent-session-capabilities'
 import type { PtyProcessInspection } from './pty-process-inspection'
 import { writeToSshPty, writeToSshPtyWithSettlement } from './ssh-pty-write'
+import { ensurePtyProcessInspectionEvidence } from '../../shared/pty-process-inspection-evidence'
 
 // Why: sequential relay teardown calls share one absolute budget; convert to the mux-relative timeout only at dispatch.
 function relayTimeoutOptions(deadlineMs: number | undefined): { timeoutMs: number } | undefined {
@@ -261,9 +262,10 @@ export class SshPtyProvider implements IPtyProvider {
   }
 
   async inspectProcess(id: string): Promise<PtyProcessInspection> {
-    return (await this.mux.request('pty.inspectProcess', {
+    const result = (await this.mux.request('pty.inspectProcess', {
       id: this.toRelayPtyId(id)
     })) as PtyProcessInspection
+    return ensurePtyProcessInspectionEvidence(result)
   }
 
   async serialize(ids: string[]): Promise<string> {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -13334,7 +13334,11 @@ describe('OrcaRuntimeService', () => {
     const inspection = {
       foregroundProcess: null,
       hasChildProcesses: true,
-      unavailable: true as const
+      unavailable: true as const,
+      processEvidence: {
+        foreground: { verdict: 'unverifiable' as const, reason: 'daemon unavailable' },
+        children: { verdict: 'unverifiable' as const, reason: 'daemon unavailable' }
+      }
     }
     const inspectProcess = vi.fn(async () => inspection)
     const getForegroundProcess = vi.fn(async () => null)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -630,6 +630,7 @@ import {
   type TerminalQuickCommandMutation
 } from '../../shared/terminal-quick-commands'
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
+import type { PtyProcessInspectionEvidence } from '../../shared/pty-process-inspection-evidence'
 import {
   buildAgentDraftLaunchPlan,
   buildAgentResumeStartupPlan,
@@ -2114,9 +2115,12 @@ type RuntimePtyController = {
   markReversibleStops?(ptyIds: readonly string[]): () => void
   getCwd?(ptyId: string): Promise<string | null>
   getForegroundProcess(ptyId: string): Promise<string | null>
-  inspectProcess?(
-    ptyId: string
-  ): Promise<{ foregroundProcess: string | null; hasChildProcesses: boolean; unavailable?: true }>
+  inspectProcess?(ptyId: string): Promise<{
+    foregroundProcess: string | null
+    hasChildProcesses: boolean
+    unavailable?: true
+    processEvidence?: PtyProcessInspectionEvidence
+  }>
   confirmForegroundProcess?(ptyId: string): Promise<string | null>
   confirmShellForeground?(ptyId: string): Promise<boolean>
   hasChildProcesses?(ptyId: string): Promise<boolean>
@@ -23791,9 +23795,12 @@ export class OrcaRuntimeService {
     return { removed: true }
   }
 
-  async inspectTerminalProcess(
-    terminalSelector: string
-  ): Promise<{ foregroundProcess: string | null; hasChildProcesses: boolean; unavailable?: true }> {
+  async inspectTerminalProcess(terminalSelector: string): Promise<{
+    foregroundProcess: string | null
+    hasChildProcesses: boolean
+    unavailable?: true
+    processEvidence?: PtyProcessInspectionEvidence
+  }> {
     const leaf = this.resolveLiveLeafForHandle(terminalSelector)
     if (!leaf?.ptyId || !this.ptyController) {
       throw new Error('terminal_gone')

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -630,7 +630,11 @@ import {
   type TerminalQuickCommandMutation
 } from '../../shared/terminal-quick-commands'
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
-import type { PtyProcessInspectionEvidence } from '../../shared/pty-process-inspection-evidence'
+import {
+  buildPtyProcessInspectionWireResult,
+  ensurePtyProcessInspectionEvidence,
+  type PtyProcessInspectionEvidence
+} from '../../shared/pty-process-inspection-evidence'
 import {
   buildAgentDraftLaunchPlan,
   buildAgentResumeStartupPlan,
@@ -23806,11 +23810,16 @@ export class OrcaRuntimeService {
       throw new Error('terminal_gone')
     }
     if (this.ptyController.inspectProcess) {
-      return this.ptyController.inspectProcess(leaf.ptyId)
+      return ensurePtyProcessInspectionEvidence(await this.ptyController.inspectProcess(leaf.ptyId))
     }
     const foregroundProcess = await this.ptyController.getForegroundProcess(leaf.ptyId)
     const hasChildProcesses = (await this.ptyController.hasChildProcesses?.(leaf.ptyId)) ?? false
-    return { foregroundProcess, hasChildProcesses }
+    return buildPtyProcessInspectionWireResult(
+      foregroundProcess !== null && !isShellProcess(foregroundProcess)
+        ? { verdict: 'live', processName: foregroundProcess }
+        : { verdict: 'exited', processName: foregroundProcess },
+      hasChildProcesses ? { verdict: 'live' } : { verdict: 'exited' }
+    )
   }
 
   reorderRepos(orderedIds: string[]): { status: 'applied' | 'rejected' } {

--- a/src/preload/api/pty-api.ts
+++ b/src/preload/api/pty-api.ts
@@ -5,6 +5,7 @@ import type {
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import type { ProjectExecutionRuntimeResolution } from '../../shared/project-execution-runtime'
 import type { PtyListedSession } from '../../shared/pty-listed-session'
+import type { PtyProcessInspectionEvidence } from '../../shared/pty-process-inspection-evidence'
 import type { PtyMainDeliveryDiagnostics } from '../../shared/pty-delivery-diagnostics'
 import type { PtyModelRestoreNeededEvent } from '../../shared/pty-model-restore-marker'
 import type {
@@ -113,6 +114,7 @@ export type PtyApi = {
     foregroundProcess: string | null
     hasChildProcesses: boolean
     unavailable?: true
+    processEvidence?: PtyProcessInspectionEvidence
   }>
   confirmForegroundProcess: (id: string) => Promise<string | null>
   getCwd: (id: string) => Promise<string>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,6 +20,7 @@ import {
 } from '../shared/doc-preview-scheme'
 import type { DocPreviewGrantRequest } from './api/doc-preview-api'
 import type { AppIdentity } from '../shared/app-identity'
+import type { PtyProcessInspectionEvidence } from '../shared/pty-process-inspection-evidence'
 import type { MacCapturedDigitRowChord } from '../shared/macos-symbolic-hotkeys'
 import type { ComputerAwakeStatus } from '../shared/computer-awake-mode'
 import type {
@@ -1251,6 +1252,7 @@ const api = {
       foregroundProcess: string | null
       hasChildProcesses: boolean
       unavailable?: true
+      processEvidence?: PtyProcessInspectionEvidence
     }> => ipcRenderer.invoke('pty:inspectProcess', { id }),
     confirmForegroundProcess: (id: string): Promise<string | null> =>
       ipcRenderer.invoke('pty:confirmForegroundProcess', { id }),

--- a/src/relay/pty-handler-spawn-admission.test.ts
+++ b/src/relay/pty-handler-spawn-admission.test.ts
@@ -91,6 +91,21 @@ describe('PtyHandler', () => {
     )
   })
 
+  it('publishes evidence alongside relay process inspection scalars', async () => {
+    await spawnPty({ cols: 80, rows: 24 })
+    vi.spyOn(ptyShellUtils, 'getForegroundProcessName').mockResolvedValue('codex')
+    vi.mocked(ptyShellUtils.processHasChildren).mockResolvedValue(true)
+
+    await expect(dispatcher.callRequest('pty.inspectProcess', { id: 'pty-1' })).resolves.toEqual({
+      foregroundProcess: 'codex',
+      hasChildProcesses: true,
+      processEvidence: {
+        foreground: { verdict: 'live', processName: 'codex' },
+        children: { verdict: 'live' }
+      }
+    })
+  })
+
   it('spawns a PTY and returns an id', async () => {
     const result = await spawnPty({ cols: 80, rows: 24 })
     expect(result).toEqual({ id: 'pty-1', incarnationId: expect.any(String) })

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -48,6 +48,8 @@ import {
 } from '../shared/git-credential-prompt-env'
 import { isTuiAgent } from '../shared/tui-agent-config'
 import type { TuiAgent } from '../shared/tui-agent'
+import { isShellProcess } from '../shared/shell-process-detection'
+import { buildPtyProcessInspectionWireResult } from '../shared/pty-process-inspection-evidence'
 import { forceKillPosixPtyProcessGroups } from '../main/pty/posix-pty-process-groups'
 import { stripInheritedBuildModeEnv } from '../main/pty/build-mode-env'
 import { stripLegacyTerminalShimEnv } from '../main/pty/legacy-terminal-shim-dir'
@@ -2215,10 +2217,7 @@ export class PtyHandler {
     return await getForegroundProcessName(managed.pty.pid, managed.pty.process || null)
   }
 
-  private async inspectProcess(params: Record<string, unknown>): Promise<{
-    foregroundProcess: string | null
-    hasChildProcesses: boolean
-  }> {
+  private async inspectProcess(params: Record<string, unknown>) {
     const id = params.id as string
     const managed = this.ptys.get(id)
     if (!managed || managed.disposed) {
@@ -2228,10 +2227,14 @@ export class PtyHandler {
       managed.pty.pid,
       managed.pty.process || null
     )
-    return {
-      foregroundProcess,
-      hasChildProcesses: await processHasChildren(managed.pty.pid)
-    }
+    const foreground =
+      foregroundProcess !== null && !isShellProcess(foregroundProcess)
+        ? { verdict: 'live' as const, processName: foregroundProcess }
+        : { verdict: 'exited' as const, processName: foregroundProcess }
+    const children = (await processHasChildren(managed.pty.pid))
+      ? { verdict: 'live' as const }
+      : { verdict: 'exited' as const }
+    return buildPtyProcessInspectionWireResult(foreground, children)
   }
 
   private async listProcesses(): Promise<PtyProcessSummary[]> {

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -149,7 +149,11 @@ import {
   useActivityTerminalPortals,
   type ActivityTerminalPortalTarget
 } from './activity/activity-terminal-portal'
-import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
+import {
+  inspectRuntimeTerminalProcess,
+  isRemoteRuntimePtyId
+} from '@/runtime/runtime-terminal-inspection'
+import { resolveTerminalProcessCloseVerdict } from './terminal/terminal-process-close-decision'
 import {
   activateWebRuntimeSessionTab,
   createWebRuntimeSessionBrowserTab,
@@ -560,15 +564,21 @@ function Terminal(): React.JSX.Element | null {
           }
         )
         if (localPtyIds.length > 0) {
-          void Promise.all(localPtyIds.map((id) => window.api.pty.hasChildProcesses(id))).then(
-            (results) => {
-              if (results.some(Boolean)) {
-                setWindowCloseDialogOpen(true)
-              } else {
-                confirmNativeWindowClose()
-              }
+          // Keep this local-only filter deliberate: SSH terminals detach and persist through the relay.
+          void Promise.allSettled(
+            localPtyIds.map((id) => inspectRuntimeTerminalProcess(state.settings, id))
+          ).then((results) => {
+            const hasBusyPty = results.some(
+              (result) =>
+                result.status === 'fulfilled' &&
+                resolveTerminalProcessCloseVerdict(result.value) !== 'exited'
+            )
+            if (hasBusyPty) {
+              setWindowCloseDialogOpen(true)
+            } else {
+              confirmNativeWindowClose()
             }
-          )
+          })
           return
         }
       }

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -57,6 +57,7 @@ import { useEffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/use-effective-
 import { useTerminalFontZoom } from './useTerminalFontZoom'
 import CloseTerminalDialog, { type CloseTerminalDialogCopyKind } from './CloseTerminalDialog'
 import { resolveLeafCloseCopyKind } from '../terminal/terminal-close-copy-kind'
+import { resolveTerminalProcessCloseVerdict } from '../terminal/terminal-process-close-decision'
 import { RUNNING_CLOSE_PROBE_TIMEOUT_MS } from '../terminal/running-terminal-close-guard'
 import CodexRestartChip from '../CodexRestartChip'
 import { MobileDriverOverlay } from './MobileDriverOverlay'
@@ -1249,10 +1250,8 @@ function TerminalPane(
         .then((process) => {
           clearTimeout(probeTimeout)
           decide(() => {
-            if (
-              !process.hasChildProcesses ||
-              settings?.skipCloseTerminalWithRunningProcessConfirm
-            ) {
+            const verdict = resolveTerminalProcessCloseVerdict(process)
+            if (verdict === 'exited' || settings?.skipCloseTerminalWithRunningProcessConfirm) {
               executeClosePane(paneId)
             } else {
               confirmClose()

--- a/src/renderer/src/components/terminal/running-terminal-close-guard.test.ts
+++ b/src/renderer/src/components/terminal/running-terminal-close-guard.test.ts
@@ -140,7 +140,11 @@ describe('guardRunningTerminalClose', () => {
   it('closes an idle terminal without a prompt', async () => {
     inspectRuntimeTerminalProcessMock.mockResolvedValue({
       foregroundProcess: 'zsh',
-      hasChildProcesses: false
+      hasChildProcesses: false,
+      processEvidence: {
+        foreground: { verdict: 'exited', processName: 'zsh' },
+        children: { verdict: 'exited' }
+      }
     })
     const onClose = vi.fn()
 
@@ -159,6 +163,20 @@ describe('guardRunningTerminalClose', () => {
         foreground: { verdict: 'unverifiable', reason: 'exit raced the foreground read' },
         children: { verdict: 'exited' }
       }
+    })
+    const onClose = vi.fn()
+
+    guard(onClose)
+    await settleProbe()
+
+    expect(onClose).not.toHaveBeenCalled()
+    expect(visibleRequest()).toMatchObject({ terminalTabId: 'tab-1' })
+  })
+
+  it('prompts when a remote result omits processEvidence instead of treating it as idle', async () => {
+    inspectRuntimeTerminalProcessMock.mockResolvedValue({
+      foregroundProcess: 'zsh',
+      hasChildProcesses: false
     })
     const onClose = vi.fn()
 
@@ -257,7 +275,17 @@ describe('guardRunningTerminalClose', () => {
     })
     inspectRuntimeTerminalProcessMock.mockImplementation(async (_settings, ptyId: string) => ({
       foregroundProcess: ptyId === 'pty-a' ? 'npm' : 'zsh',
-      hasChildProcesses: ptyId === 'pty-a'
+      hasChildProcesses: ptyId === 'pty-a',
+      processEvidence:
+        ptyId === 'pty-a'
+          ? {
+              foreground: { verdict: 'live', processName: 'npm' },
+              children: { verdict: 'live' }
+            }
+          : {
+              foreground: { verdict: 'exited', processName: 'zsh' },
+              children: { verdict: 'exited' }
+            }
     }))
 
     guard()

--- a/src/renderer/src/components/terminal/running-terminal-close-guard.test.ts
+++ b/src/renderer/src/components/terminal/running-terminal-close-guard.test.ts
@@ -151,6 +151,24 @@ describe('guardRunningTerminalClose', () => {
     expect(visibleRequest()).toBeNull()
   })
 
+  it('prompts when foreground evidence is unverifiable even if children report exited', async () => {
+    inspectRuntimeTerminalProcessMock.mockResolvedValue({
+      foregroundProcess: null,
+      hasChildProcesses: false,
+      processEvidence: {
+        foreground: { verdict: 'unverifiable', reason: 'exit raced the foreground read' },
+        children: { verdict: 'exited' }
+      }
+    })
+    const onClose = vi.fn()
+
+    guard(onClose)
+    await settleProbe()
+
+    expect(onClose).not.toHaveBeenCalled()
+    expect(visibleRequest()).toMatchObject({ terminalTabId: 'tab-1' })
+  })
+
   it('defers a busy terminal behind a confirmation that carries the tab label', async () => {
     const onClose = vi.fn()
 
@@ -192,7 +210,7 @@ describe('guardRunningTerminalClose', () => {
     expect(visibleRequest()).toBeNull()
   })
 
-  it('fails open when a remote handle reports the inspection as unavailable', async () => {
+  it('prompts when a remote handle reports the inspection as unavailable', async () => {
     inspectRuntimeTerminalProcessMock.mockResolvedValue({
       foregroundProcess: null,
       hasChildProcesses: true,
@@ -203,8 +221,8 @@ describe('guardRunningTerminalClose', () => {
     guard(onClose)
     await settleProbe()
 
-    expect(onClose).toHaveBeenCalledTimes(1)
-    expect(visibleRequest()).toBeNull()
+    expect(onClose).not.toHaveBeenCalled()
+    expect(visibleRequest()).toMatchObject({ terminalTabId: 'tab-1' })
   })
 
   it('prompts once for a split tab where only the second pane is busy', async () => {

--- a/src/renderer/src/components/terminal/running-terminal-close-guard.ts
+++ b/src/renderer/src/components/terminal/running-terminal-close-guard.ts
@@ -1,13 +1,10 @@
 import { useAppStore } from '@/store'
 import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-inspection'
-import {
-  combinePtyProcessInspectionVerdict,
-  readPtyProcessInspectionEvidence
-} from '../../../../shared/pty-process-inspection-evidence'
 import { useRunningTerminalCloseConfirmStore } from '@/store/running-terminal-close-confirm'
 import type { TerminalTabCloseReason } from '@/store/slices/terminal-tab-retirement'
 import type { AppState } from '@/store/types'
 import { resolveBusyPtyCloseCopyKind } from './terminal-close-copy-kind'
+import { resolveTerminalProcessCloseVerdict } from './terminal-process-close-decision'
 
 export type RunningTerminalCloseGuardOptions = {
   force?: boolean
@@ -138,9 +135,7 @@ export function guardRunningTerminalClose(params: {
         const result = results[index]
         return (
           result?.status === 'fulfilled' &&
-          (result.value.unavailable === true ||
-            combinePtyProcessInspectionVerdict(readPtyProcessInspectionEvidence(result.value)) !==
-              'exited')
+          resolveTerminalProcessCloseVerdict(result.value) !== 'exited'
         )
       })
       if (busyPtyIds.length === 0) {

--- a/src/renderer/src/components/terminal/running-terminal-close-guard.ts
+++ b/src/renderer/src/components/terminal/running-terminal-close-guard.ts
@@ -1,5 +1,9 @@
 import { useAppStore } from '@/store'
 import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-inspection'
+import {
+  combinePtyProcessInspectionVerdict,
+  readPtyProcessInspectionEvidence
+} from '../../../../shared/pty-process-inspection-evidence'
 import { useRunningTerminalCloseConfirmStore } from '@/store/running-terminal-close-confirm'
 import type { TerminalTabCloseReason } from '@/store/slices/terminal-tab-retirement'
 import type { AppState } from '@/store/types'
@@ -134,8 +138,9 @@ export function guardRunningTerminalClose(params: {
         const result = results[index]
         return (
           result?.status === 'fulfilled' &&
-          result.value.hasChildProcesses &&
-          result.value.unavailable !== true
+          (result.value.unavailable === true ||
+            combinePtyProcessInspectionVerdict(readPtyProcessInspectionEvidence(result.value)) !==
+              'exited')
         )
       })
       if (busyPtyIds.length === 0) {

--- a/src/renderer/src/components/terminal/terminal-close-confirm-keyboard-vs-mouse.test.ts
+++ b/src/renderer/src/components/terminal/terminal-close-confirm-keyboard-vs-mouse.test.ts
@@ -96,9 +96,20 @@ describe('#10142 close confirmation policy is the same for keyboard and mouse', 
   it('keyboard Cmd+W path probes for running child processes before closing', () => {
     const source = readFileSync(join(__dirname, '../terminal-pane/TerminalPane.tsx'), 'utf8')
     const handler = source.slice(source.indexOf('const handleRequestClosePane'))
-    expect(handler.slice(0, handler.indexOf('useImperativeHandle'))).toContain(
-      'inspectRuntimeTerminalProcess'
-    )
+    const body = handler.slice(0, handler.indexOf('useImperativeHandle'))
+    expect(body).toContain('inspectRuntimeTerminalProcess')
+    expect(body).toContain('resolveTerminalProcessCloseVerdict')
+    expect(body).not.toContain('process.hasChildProcesses')
+  })
+
+  it('native window close uses the composite verdict for every local PTY', () => {
+    const source = readFileSync(join(__dirname, '../Terminal.tsx'), 'utf8')
+    const handler = source.slice(source.indexOf('const proceedToNativeWindowClose'))
+    const body = handler.slice(0, handler.indexOf('const waitForFileClosed'))
+
+    expect(body).toContain('inspectRuntimeTerminalProcess')
+    expect(body).toContain('resolveTerminalProcessCloseVerdict')
+    expect(body).not.toContain('results.some(Boolean)')
   })
 
   // Control: the harness does observe a guard when one exists — pinning blocks the same mouse close.

--- a/src/renderer/src/components/terminal/terminal-process-close-decision.test.ts
+++ b/src/renderer/src/components/terminal/terminal-process-close-decision.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTerminalProcessCloseVerdict } from './terminal-process-close-decision'
+
+describe('terminal close process verdict', () => {
+  it('keeps a native-window close prompt for a mixed foreground-race result', () => {
+    expect(
+      resolveTerminalProcessCloseVerdict({
+        foregroundProcess: null,
+        hasChildProcesses: false,
+        processEvidence: {
+          foreground: { verdict: 'unverifiable', reason: 'foreground read raced exit' },
+          children: { verdict: 'exited' }
+        }
+      })
+    ).toBe('unverifiable')
+  })
+
+  it('keeps a split-pane close prompt for an unavailable result', () => {
+    expect(
+      resolveTerminalProcessCloseVerdict({
+        foregroundProcess: null,
+        hasChildProcesses: false,
+        unavailable: true
+      })
+    ).toBe('unverifiable')
+  })
+
+  it('treats a remote result without processEvidence as unverifiable', () => {
+    expect(
+      resolveTerminalProcessCloseVerdict({
+        foregroundProcess: 'zsh',
+        hasChildProcesses: false
+      })
+    ).toBe('unverifiable')
+  })
+})

--- a/src/renderer/src/components/terminal/terminal-process-close-decision.ts
+++ b/src/renderer/src/components/terminal/terminal-process-close-decision.ts
@@ -1,0 +1,16 @@
+import {
+  combinePtyProcessInspectionVerdict,
+  readPtyProcessInspectionEvidence,
+  type PtyProcessVerdict
+} from '../../../../shared/pty-process-inspection-evidence'
+import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-process-inspection'
+
+/** Resolve the composite PTY answer used by every destructive terminal close path. */
+export function resolveTerminalProcessCloseVerdict(
+  result: RuntimeTerminalProcessInspection
+): PtyProcessVerdict {
+  if (result.unavailable === true) {
+    return 'unverifiable'
+  }
+  return combinePtyProcessInspectionVerdict(readPtyProcessInspectionEvidence(result))
+}

--- a/src/renderer/src/runtime/runtime-terminal-inspection.test.ts
+++ b/src/renderer/src/runtime/runtime-terminal-inspection.test.ts
@@ -176,7 +176,15 @@ describe('runtime terminal owner routing', () => {
           { activeRuntimeEnvironmentId: 'env-2' },
           'remote:env-1@@terminal-stale'
         )
-      ).resolves.toEqual({ foregroundProcess: null, hasChildProcesses: false, unavailable: true })
+      ).resolves.toEqual({
+        foregroundProcess: null,
+        hasChildProcesses: false,
+        unavailable: true,
+        processEvidence: {
+          foreground: { verdict: 'unverifiable', reason: 'remote terminal route unavailable' },
+          children: { verdict: 'unverifiable', reason: 'remote terminal route unavailable' }
+        }
+      })
     }
   )
 

--- a/src/renderer/src/runtime/runtime-terminal-inspection.ts
+++ b/src/renderer/src/runtime/runtime-terminal-inspection.ts
@@ -3,20 +3,21 @@ import type { RuntimeTerminalSend } from '../../../shared/runtime-types'
 import { makePaneKey, type PaneKey } from '../../../shared/stable-pane-id'
 import { isTerminalInputTooLargeWithDeferredMeasurement } from '../../../shared/terminal-input'
 import { useAppStore } from '../store'
-import { RuntimeRpcCallError, callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
+import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
 import {
   getRemoteRuntimePtyEnvironmentId,
   getRemoteRuntimeTerminalHandle
 } from './runtime-terminal-stream'
+import {
+  inspectRuntimeTerminalProcess,
+  isTerminalGoneError,
+  isRemoteRuntimePtyId,
+  type RuntimeTerminalProcessInspection
+} from './runtime-terminal-process-inspection'
 
-export type RuntimeTerminalProcessInspection = {
-  foregroundProcess: string | null
-  hasChildProcesses: boolean
-  // Why: callers must not treat a stale remote handle as authoritative idle evidence.
-  unavailable?: true
-}
+export { inspectRuntimeTerminalProcess, isRemoteRuntimePtyId }
+export type { RuntimeTerminalProcessInspection }
 
-const REMOTE_PTY_ID_PREFIX = 'remote:'
 const DESKTOP_RUNTIME_CLIENT = { id: 'orca-desktop', type: 'desktop' } as const
 type TerminalLayoutsByTabId = ReturnType<typeof useAppStore.getState>['terminalLayoutsByTabId']
 type TerminalPaneOwner = {
@@ -73,30 +74,6 @@ function isRuntimePtyInputTooLarge(data: string): boolean | Promise<boolean> {
   return isTerminalInputTooLargeWithDeferredMeasurement(data)
 }
 
-export function isRemoteRuntimePtyId(ptyId: string): boolean {
-  return ptyId.startsWith(REMOTE_PTY_ID_PREFIX)
-}
-
-function isTerminalGoneError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
-  const code =
-    error instanceof RuntimeRpcCallError
-      ? error.code
-      : error && typeof error === 'object' && 'code' in error
-        ? String((error as { code?: unknown }).code)
-        : ''
-  return (
-    code === 'no_connected_pty' ||
-    code === 'terminal_handle_stale' ||
-    code === 'terminal_exited' ||
-    code === 'terminal_gone' ||
-    message.includes('terminal_handle_stale') ||
-    message.includes('terminal_exited') ||
-    message.includes('terminal_gone') ||
-    message.includes('no_connected_pty')
-  )
-}
-
 export function recordRuntimeTerminalInputForPtyId(ptyId: string, timestamp = Date.now()): void {
   const state = useAppStore.getState()
   const paneKey = resolvePaneKeyForPtyId(state.terminalLayoutsByTabId, ptyId)
@@ -110,35 +87,6 @@ export function recordRuntimeTerminalInputForPtyId(ptyId: string, timestamp = Da
   } catch {
     // Ignore malformed legacy layout data; the planner will stay
     // conservative when a live PTY cannot be matched to an eligible pane.
-  }
-}
-
-export async function inspectRuntimeTerminalProcess(
-  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
-  ptyId: string
-): Promise<RuntimeTerminalProcessInspection> {
-  const ownerEnvironmentId = getRemoteRuntimePtyEnvironmentId(ptyId)
-  const target = ownerEnvironmentId
-    ? ({ kind: 'environment', environmentId: ownerEnvironmentId } as const)
-    : getActiveRuntimeTarget(settings)
-  const terminal = getRemoteRuntimeTerminalHandle(ptyId)
-  if (target.kind !== 'environment' || !terminal) {
-    return window.api.pty.inspectProcess(ptyId)
-  }
-
-  try {
-    const result = await callRuntimeRpc<{ process: RuntimeTerminalProcessInspection }>(
-      target,
-      'terminal.inspectProcess',
-      { terminal },
-      { timeoutMs: 15_000 }
-    )
-    return result.process
-  } catch (error) {
-    if (isTerminalGoneError(error)) {
-      return { foregroundProcess: null, hasChildProcesses: false, unavailable: true }
-    }
-    throw error
   }
 }
 

--- a/src/renderer/src/runtime/runtime-terminal-process-inspection.ts
+++ b/src/renderer/src/runtime/runtime-terminal-process-inspection.ts
@@ -43,7 +43,15 @@ export async function inspectRuntimeTerminalProcess(
     return result.process
   } catch (error) {
     if (isTerminalGoneError(error)) {
-      return { foregroundProcess: null, hasChildProcesses: false, unavailable: true }
+      return {
+        foregroundProcess: null,
+        hasChildProcesses: false,
+        unavailable: true,
+        processEvidence: {
+          foreground: { verdict: 'unverifiable', reason: 'remote terminal route unavailable' },
+          children: { verdict: 'unverifiable', reason: 'remote terminal route unavailable' }
+        }
+      }
     }
     throw error
   }

--- a/src/renderer/src/runtime/runtime-terminal-process-inspection.ts
+++ b/src/renderer/src/runtime/runtime-terminal-process-inspection.ts
@@ -1,0 +1,70 @@
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import type { PtyProcessInspectionEvidence } from '../../../shared/pty-process-inspection-evidence'
+import { RuntimeRpcCallError, callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
+import {
+  getRemoteRuntimePtyEnvironmentId,
+  getRemoteRuntimeTerminalHandle
+} from './runtime-terminal-stream'
+
+const REMOTE_PTY_ID_PREFIX = 'remote:'
+
+export function isRemoteRuntimePtyId(ptyId: string): boolean {
+  return ptyId.startsWith(REMOTE_PTY_ID_PREFIX)
+}
+
+export type RuntimeTerminalProcessInspection = {
+  foregroundProcess: string | null
+  hasChildProcesses: boolean
+  // Why: callers must not treat a stale remote handle as authoritative idle evidence.
+  unavailable?: true
+  processEvidence?: PtyProcessInspectionEvidence
+}
+
+export async function inspectRuntimeTerminalProcess(
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
+  ptyId: string
+): Promise<RuntimeTerminalProcessInspection> {
+  const ownerEnvironmentId = getRemoteRuntimePtyEnvironmentId(ptyId)
+  const target = ownerEnvironmentId
+    ? ({ kind: 'environment', environmentId: ownerEnvironmentId } as const)
+    : getActiveRuntimeTarget(settings)
+  const terminal = getRemoteRuntimeTerminalHandle(ptyId)
+  if (target.kind !== 'environment' || !terminal) {
+    return window.api.pty.inspectProcess(ptyId)
+  }
+
+  try {
+    const result = await callRuntimeRpc<{ process: RuntimeTerminalProcessInspection }>(
+      target,
+      'terminal.inspectProcess',
+      { terminal },
+      { timeoutMs: 15_000 }
+    )
+    return result.process
+  } catch (error) {
+    if (isTerminalGoneError(error)) {
+      return { foregroundProcess: null, hasChildProcesses: false, unavailable: true }
+    }
+    throw error
+  }
+}
+
+export function isTerminalGoneError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  const code =
+    error instanceof RuntimeRpcCallError
+      ? error.code
+      : error && typeof error === 'object' && 'code' in error
+        ? String((error as { code?: unknown }).code)
+        : ''
+  return (
+    code === 'no_connected_pty' ||
+    code === 'terminal_handle_stale' ||
+    code === 'terminal_exited' ||
+    code === 'terminal_gone' ||
+    message.includes('terminal_handle_stale') ||
+    message.includes('terminal_exited') ||
+    message.includes('terminal_gone') ||
+    message.includes('no_connected_pty')
+  )
+}

--- a/src/renderer/src/store/slices/workspace-cleanup-candidate-enrichment.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-candidate-enrichment.ts
@@ -241,7 +241,7 @@ async function enrichWorkspaceCleanupCandidate(
   const terminalProbe = await probeTerminalLiveness(state, tabs)
   if (terminalProbe === 'running') {
     blockers.push('running-terminal')
-  } else if (terminalProbe === 'unknown') {
+  } else if (terminalProbe === 'unverifiable') {
     blockers.push('terminal-liveness-unknown')
   }
 

--- a/src/renderer/src/store/slices/workspace-cleanup-local-evidence-mixed-evidence.test.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-local-evidence-mixed-evidence.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AppState } from '../types'
+import { probeTerminalLiveness } from './workspace-cleanup-local-evidence'
+
+describe('workspace cleanup mixed PTY evidence', () => {
+  it('preserves an unverifiable foreground half when children report exited', async () => {
+    const inspectProcess = vi.fn().mockResolvedValue({
+      foregroundProcess: null,
+      hasChildProcesses: false,
+      processEvidence: {
+        foreground: { verdict: 'unverifiable', reason: 'exit raced the foreground read' },
+        children: { verdict: 'exited' }
+      }
+    })
+    ;(globalThis as { window?: unknown }).window = {
+      api: {
+        pty: {
+          inspectProcess,
+          hasChildProcesses: vi.fn(),
+          getForegroundProcess: vi.fn()
+        }
+      }
+    }
+    const state = {
+      settings: { activeRuntimeEnvironmentId: null },
+      tabsByWorktree: {},
+      ptyIdsByTabId: { 'tab-1': ['pty-race'] },
+      runtimePaneTitlesByTabId: {},
+      terminalLayoutsByTabId: {}
+    } as unknown as AppState
+
+    await expect(probeTerminalLiveness(state, [{ id: 'tab-1', title: 'shell' }])).resolves.toBe(
+      'unverifiable'
+    )
+    expect(inspectProcess).toHaveBeenCalledWith('pty-race')
+  })
+})

--- a/src/renderer/src/store/slices/workspace-cleanup-local-evidence.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-local-evidence.ts
@@ -6,19 +6,14 @@ import {
 import { classifyTitleActivity, isExplicitAgentStatusFresh } from '@/lib/pane-agent-evidence'
 import type { WorkspaceCleanupCandidate } from '../../../../shared/workspace-cleanup'
 import { getWorktreeVisitTimestamp } from '@/lib/worktree-visit-recency'
+import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-process-inspection'
+import {
+  combinePtyProcessInspectionVerdict,
+  readPtyProcessInspectionEvidence
+} from '../../../../shared/pty-process-inspection-evidence'
 
 const RECENT_VISIBLE_CONTEXT_MS = 24 * 60 * 60 * 1000
 const VIEWED_FROM_CLEANUP_MS = 2 * 60 * 60 * 1000
-const SHELL_PROCESS_NAMES = new Set([
-  'bash',
-  'cmd',
-  'fish',
-  'nu',
-  'powershell',
-  'pwsh',
-  'sh',
-  'zsh'
-])
 const AGENT_PROCESS_NAMES = new Set([
   'aider',
   'amp',
@@ -158,7 +153,7 @@ export function hasWorkingTitleAgent(
 export async function probeTerminalLiveness(
   state: AppState,
   tabs: { id: string; title: string }[]
-): Promise<'idle' | 'running' | 'unknown'> {
+): Promise<'idle' | 'running' | 'unverifiable'> {
   const ptyChecks = tabs.flatMap((tab) =>
     (state.ptyIdsByTabId[tab.id] ?? []).map((ptyId) => ({ tab, ptyId }))
   )
@@ -169,12 +164,22 @@ export async function probeTerminalLiveness(
   let unknown = false
   for (const { tab, ptyId } of ptyChecks) {
     try {
-      const [hasChildProcesses, foregroundProcess] = await Promise.all([
-        window.api.pty.hasChildProcesses(ptyId),
-        window.api.pty.getForegroundProcess(ptyId)
-      ])
-      const processName = normalizeProcessName(foregroundProcess)
-      if (!hasChildProcesses && (!processName || SHELL_PROCESS_NAMES.has(processName))) {
+      const inspection = await inspectTerminalProcessForCleanup(state.settings, ptyId)
+      if (inspection.unavailable === true) {
+        unknown = true
+        continue
+      }
+      const evidence = readPtyProcessInspectionEvidence(inspection)
+      const verdict = combinePtyProcessInspectionVerdict(evidence)
+      if (verdict === 'unverifiable') {
+        unknown = true
+        continue
+      }
+      const processName =
+        evidence.foreground.verdict === 'unverifiable'
+          ? null
+          : normalizeProcessName(evidence.foreground.processName)
+      if (verdict === 'exited') {
         continue
       }
       if (
@@ -190,7 +195,23 @@ export async function probeTerminalLiveness(
     }
   }
 
-  return unknown ? 'unknown' : 'idle'
+  return unknown ? 'unverifiable' : 'idle'
+}
+
+async function inspectTerminalProcessForCleanup(
+  settings: AppState['settings'],
+  ptyId: string
+): Promise<Awaited<ReturnType<typeof inspectRuntimeTerminalProcess>>> {
+  // Test/web preloads may expose only the legacy pair; retain that route while
+  // desktop and runtime hosts use the atomic evidence-bearing inspection.
+  if (typeof window.api.pty.inspectProcess === 'function') {
+    return inspectRuntimeTerminalProcess(settings, ptyId)
+  }
+  const [hasChildProcesses, foregroundProcess] = await Promise.all([
+    window.api.pty.hasChildProcesses(ptyId),
+    window.api.pty.getForegroundProcess(ptyId)
+  ])
+  return { foregroundProcess, hasChildProcesses }
 }
 
 function hasIdleAgentTitleForPty(

--- a/src/shared/pty-process-inspection-evidence.test.ts
+++ b/src/shared/pty-process-inspection-evidence.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { combinePtyProcessInspectionVerdict } from './pty-process-inspection-evidence'
+
+describe('PTY inspection evidence combination', () => {
+  it('lets any unverifiable component poison the combined verdict', () => {
+    expect(
+      combinePtyProcessInspectionVerdict({
+        foreground: { verdict: 'unverifiable', reason: 'exit raced the foreground read' },
+        children: { verdict: 'exited' }
+      })
+    ).toBe('unverifiable')
+  })
+
+  it.each([
+    [
+      'both exited',
+      {
+        foreground: { verdict: 'exited' as const, processName: null },
+        children: { verdict: 'exited' as const }
+      },
+      'exited'
+    ],
+    [
+      'foreground live',
+      {
+        foreground: { verdict: 'live' as const, processName: 'codex' },
+        children: { verdict: 'exited' as const }
+      },
+      'live'
+    ],
+    [
+      'child live',
+      {
+        foreground: { verdict: 'exited' as const, processName: null },
+        children: { verdict: 'live' as const }
+      },
+      'live'
+    ]
+  ])('combines %s', (_label, evidence, expected) => {
+    expect(combinePtyProcessInspectionVerdict(evidence)).toBe(expected)
+  })
+})

--- a/src/shared/pty-process-inspection-evidence.test.ts
+++ b/src/shared/pty-process-inspection-evidence.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from 'vitest'
-import { combinePtyProcessInspectionVerdict } from './pty-process-inspection-evidence'
+import {
+  combinePtyProcessInspectionVerdict,
+  readPtyProcessInspectionEvidence
+} from './pty-process-inspection-evidence'
 
 describe('PTY inspection evidence combination', () => {
+  it('treats an omitted wire evidence field as unverifiable', () => {
+    expect(
+      combinePtyProcessInspectionVerdict(
+        readPtyProcessInspectionEvidence({ foregroundProcess: 'zsh', hasChildProcesses: false })
+      )
+    ).toBe('unverifiable')
+  })
+
   it('lets any unverifiable component poison the combined verdict', () => {
     expect(
       combinePtyProcessInspectionVerdict({

--- a/src/shared/pty-process-inspection-evidence.ts
+++ b/src/shared/pty-process-inspection-evidence.ts
@@ -1,0 +1,134 @@
+/**
+ * Evidence returned by the two independent PTY liveness probes.
+ *
+ * `unverifiable` means the execution host could not answer; it is never an
+ * alias for process death. The optional wire field preserves this distinction
+ * while old clients continue to read the legacy scalar fields.
+ */
+export type PtyForegroundProcessEvidence =
+  | { verdict: 'live'; processName: string }
+  | { verdict: 'exited'; processName: string | null }
+  | { verdict: 'unverifiable'; reason: string }
+
+export type PtyChildProcessesEvidence =
+  | { verdict: 'live' }
+  | { verdict: 'exited' }
+  | { verdict: 'unverifiable'; reason: string }
+
+export type PtyProcessInspectionEvidence = {
+  foreground: PtyForegroundProcessEvidence
+  children: PtyChildProcessesEvidence
+}
+
+export type PtyProcessVerdict = 'live' | 'unverifiable' | 'exited'
+
+/** Any unknown component poisons the whole answer; a partial answer is not an answer. */
+export function combinePtyProcessInspectionVerdict(
+  evidence: PtyProcessInspectionEvidence
+): PtyProcessVerdict {
+  if (
+    evidence.foreground.verdict === 'unverifiable' ||
+    evidence.children.verdict === 'unverifiable'
+  ) {
+    return 'unverifiable'
+  }
+  if (evidence.foreground.verdict === 'live' || evidence.children.verdict === 'live') {
+    return 'live'
+  }
+  return 'exited'
+}
+
+export type PtyProcessInspectionWireResult = {
+  foregroundProcess: string | null
+  hasChildProcesses: boolean
+  processEvidence: PtyProcessInspectionEvidence
+}
+
+/** Compose legacy fields without allowing an unverifiable probe to claim idle. */
+export function buildPtyProcessInspectionWireResult(
+  foreground: PtyForegroundProcessEvidence,
+  children: PtyChildProcessesEvidence
+): PtyProcessInspectionWireResult {
+  return {
+    foregroundProcess:
+      foreground.verdict === 'live' || foreground.verdict === 'exited'
+        ? foreground.processName
+        : null,
+    hasChildProcesses: children.verdict === 'live',
+    processEvidence: { foreground, children }
+  }
+}
+
+/**
+ * Normalize evidence from a mixed-version peer. Malformed or absent evidence
+ * never upgrades an unknown probe to an observed exit.
+ */
+export function readPtyProcessInspectionEvidence(result: {
+  foregroundProcess: string | null
+  hasChildProcesses: boolean
+  processEvidence?: PtyProcessInspectionEvidence
+}): PtyProcessInspectionEvidence {
+  const evidence = result.processEvidence
+  if (evidence === undefined) {
+    // Legacy peers only publish these two fields. Preserve compatibility for
+    // ordinary readers; absence-action callers apply their stricter fence.
+    return {
+      foreground: classifyLegacyForegroundProcess(result.foregroundProcess),
+      children: result.hasChildProcesses ? { verdict: 'live' } : { verdict: 'exited' }
+    }
+  }
+  return {
+    foreground: normalizeForegroundEvidence(evidence.foreground),
+    children: normalizeChildrenEvidence(evidence.children)
+  }
+}
+
+function normalizeReason(reason: unknown): string {
+  return typeof reason === 'string' ? reason : 'unspecified'
+}
+
+function normalizeForegroundEvidence(
+  evidence: PtyForegroundProcessEvidence | undefined
+): PtyForegroundProcessEvidence {
+  if (evidence?.verdict === 'live') {
+    if (typeof evidence.processName === 'string' && evidence.processName.length > 0) {
+      return { verdict: 'live', processName: evidence.processName }
+    }
+  }
+  if (evidence?.verdict === 'exited') {
+    const processName = evidence.processName ?? null
+    if (processName === null || typeof processName === 'string') {
+      return { verdict: 'exited', processName }
+    }
+  }
+  if (evidence?.verdict === 'unverifiable') {
+    return { verdict: 'unverifiable', reason: normalizeReason(evidence.reason) }
+  }
+  return { verdict: 'unverifiable', reason: 'malformed foreground inspection evidence' }
+}
+
+function classifyLegacyForegroundProcess(processName: string | null): PtyForegroundProcessEvidence {
+  if (!processName) {
+    return { verdict: 'exited', processName: null }
+  }
+  const basename = processName
+    .trim()
+    .replace(/^.*[\\/]/, '')
+    .replace(/\.exe$/i, '')
+  const shells = new Set(['bash', 'cmd', 'fish', 'nu', 'powershell', 'pwsh', 'sh', 'zsh'])
+  return shells.has(basename.toLowerCase())
+    ? { verdict: 'exited', processName }
+    : { verdict: 'live', processName }
+}
+
+function normalizeChildrenEvidence(
+  evidence: PtyChildProcessesEvidence | undefined
+): PtyChildProcessesEvidence {
+  if (evidence?.verdict === 'live' || evidence?.verdict === 'exited') {
+    return { verdict: evidence.verdict }
+  }
+  if (evidence?.verdict === 'unverifiable') {
+    return { verdict: 'unverifiable', reason: normalizeReason(evidence.reason) }
+  }
+  return { verdict: 'unverifiable', reason: 'malformed child-process inspection evidence' }
+}

--- a/src/shared/pty-process-inspection-evidence.ts
+++ b/src/shared/pty-process-inspection-evidence.ts
@@ -32,6 +32,7 @@ export function combinePtyProcessInspectionVerdict(
   ) {
     return 'unverifiable'
   }
+  // A live sample wins conservatively: prompting is safer than closing if it ended between probes.
   if (evidence.foreground.verdict === 'live' || evidence.children.verdict === 'live') {
     return 'live'
   }
@@ -70,17 +71,30 @@ export function readPtyProcessInspectionEvidence(result: {
 }): PtyProcessInspectionEvidence {
   const evidence = result.processEvidence
   if (evidence === undefined) {
-    // Legacy peers only publish these two fields. Preserve compatibility for
-    // ordinary readers; absence-action callers apply their stricter fence.
+    // Legacy peers omit this field; an updated client cannot call that absence idle.
     return {
-      foreground: classifyLegacyForegroundProcess(result.foregroundProcess),
-      children: result.hasChildProcesses ? { verdict: 'live' } : { verdict: 'exited' }
+      foreground: { verdict: 'unverifiable', reason: 'peer omitted process inspection evidence' },
+      children: { verdict: 'unverifiable', reason: 'peer omitted process inspection evidence' }
     }
   }
   return {
     foreground: normalizeForegroundEvidence(evidence.foreground),
     children: normalizeChildrenEvidence(evidence.children)
   }
+}
+
+/** Add an explicit unknown verdict when a mixed-version peer omitted the optional field. */
+export function ensurePtyProcessInspectionEvidence<
+  T extends {
+    foregroundProcess: string | null
+    hasChildProcesses: boolean
+    processEvidence?: PtyProcessInspectionEvidence
+  }
+>(result: T): T & { processEvidence: PtyProcessInspectionEvidence } {
+  if (result.processEvidence !== undefined) {
+    return result as T & { processEvidence: PtyProcessInspectionEvidence }
+  }
+  return { ...result, processEvidence: readPtyProcessInspectionEvidence(result) }
 }
 
 function normalizeReason(reason: unknown): string {
@@ -105,20 +119,6 @@ function normalizeForegroundEvidence(
     return { verdict: 'unverifiable', reason: normalizeReason(evidence.reason) }
   }
   return { verdict: 'unverifiable', reason: 'malformed foreground inspection evidence' }
-}
-
-function classifyLegacyForegroundProcess(processName: string | null): PtyForegroundProcessEvidence {
-  if (!processName) {
-    return { verdict: 'exited', processName: null }
-  }
-  const basename = processName
-    .trim()
-    .replace(/^.*[\\/]/, '')
-    .replace(/\.exe$/i, '')
-  const shells = new Set(['bash', 'cmd', 'fish', 'nu', 'powershell', 'pwsh', 'sh', 'zsh'])
-  return shells.has(basename.toLowerCase())
-    ? { verdict: 'exited', processName }
-    : { verdict: 'live', processName }
 }
 
 function normalizeChildrenEvidence(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 15 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$​225 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$​19 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$​206 |
| Prod | 16 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$​193 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$​76 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$​117 |

<!-- /orca-pr-loc -->

## Completed scope

When a process exits during inspection, the independent foreground and child-process probes can disagree: foreground may be `unverifiable` while children report `exited`. The composite rule now makes any `unverifiable` component poison the whole answer, so destructive close flows never turn “we could not tell” into “nothing is running.”

Both destructive consumers use that composite verdict:

- Native-window close checks the combined verdict for each local PTY. The local-only filter is intentional because SSH terminals detach and persist through the relay; closing the local window must not prompt or kill those remote sessions.
- Split-pane close uses the same combined verdict instead of reading `hasChildProcesses` directly.

The optional `processEvidence` wire field is now published and normalized across the full surface: daemon/terminal-host inspection, daemon routing and degraded providers, SSH and relay providers, runtime fallback, and unavailable IPC/remote paths. Mixed-version peers that omit the optional field are treated as `unverifiable` by updated clients, while the legacy `hasChildProcesses` scalar remains `false` for an unverifiable probe for old-client compatibility. No stream opcode changed, so capability negotiation is not required.

The combination retains conservative `live`-wins behavior when probes are sampled at different times: prompting is safer than closing if a process ended between samples, and the code documents that temporal choice.

## Verification

- Focused suites: 16 test files, 1,507 passed, 1 skipped.
- Dedicated pinning covers native-window close, split-pane close, and absent remote evidence; each path is asserted at its publication/consumer boundary.
- Cold typecheck: `pnpm tc` passed with zero errors.
- Changed-code quality gate: zero new findings across 42 files; formatting checked on 29 files.
- Electron validation confirmed the running-terminal close dialog in the target worktree.

## Known limitation, deliberately not fixed here

The repeated degraded-provider replacement limitation remains unchanged; it is a separately routed product decision.

## ELI5

A process can exit between the foreground and child checks. The old pair could look like “nothing is running” even when one check was unknowable, allowing a destructive close without a prompt. Each check now reports `live`, `unverifiable`, or `exited`; uncertainty blocks an automatic close and a live sample wins conservatively. Evidence travels through local, SSH, and relay paths, and missing evidence from an old peer is also unknown.

## Performance Measurement

This is a liveness-correctness fix, not a performance optimization, so no wall-clock speedup is claimed. Where supported, one `inspectProcess` response carries both evidence halves per PTY (legacy providers retain the two-call fallback), and verdict combination is O(1). The mixed-race fixture performs one foreground and one child probe and records `unverifiable + exited` rather than idle.

## User-Facing Trade-offs

When a host is unavailable, an old peer omits evidence, or a probe races an exit, users may see a confirmation prompt instead of an automatic close. That conservative behavior avoids closing an uncertain session. The field is optional, no stream opcode changed, and remote sessions remain excluded from local-window close.
