### PR TITLE
Allow worktree lineage across repo and project boundaries

### DIFF
--- a/src/main/ipc/worktree-create-lineage.test.ts
+++ b/src/main/ipc/worktree-create-lineage.test.ts
@@ -95,7 +95,7 @@ describe('recordWorkspaceLineageForCreatedWorktree', () => {
     vi.restoreAllMocks()
   })
 
-  it('writes both lineage rows for a worktree parent inside the same repo/host/project', () => {
+  it('writes both lineage rows for a worktree parent on the same host', () => {
     const store = createStore({ metaById: { [PARENT_ID]: parentMeta() } })
 
     const result = record(store, { parentWorkspace: worktreeWorkspaceKey(PARENT_ID) })
@@ -126,35 +126,51 @@ describe('recordWorkspaceLineageForCreatedWorktree', () => {
     })
   })
 
-  it('skips both lineage records when the parent belongs to a different repo', () => {
+  it('writes both lineage rows when the parent belongs to another repo on the same host', () => {
     const foreignParentId = 'repo-2::/repos/parent'
     const store = createStore({ metaById: { [foreignParentId]: parentMeta() } })
 
     const result = record(store, { parentWorkspace: worktreeWorkspaceKey(foreignParentId) })
 
+    expect(store.setWorktreeLineage).toHaveBeenCalledWith(
+      CHILD_ID,
+      expect.objectContaining({ parentWorktreeId: foreignParentId })
+    )
+    expect(result.lineage).toMatchObject({ parentWorktreeId: foreignParentId })
+    expect(store.setWorkspaceLineage).toHaveBeenCalled()
+    expect(result.workspaceLineage).toMatchObject({
+      parentWorkspaceKey: worktreeWorkspaceKey(foreignParentId)
+    })
+  })
+
+  it('writes both lineage rows when the parent belongs to another project on the same host', () => {
+    const store = createStore({
+      metaById: { [PARENT_ID]: parentMeta({ projectId: 'project-2' }) }
+    })
+
+    const result = record(store, { parentWorkspace: worktreeWorkspaceKey(PARENT_ID) })
+
+    expect(store.setWorktreeLineage).toHaveBeenCalled()
+    expect(result.lineage).toMatchObject({ parentWorktreeId: PARENT_ID })
+    expect(store.setWorkspaceLineage).toHaveBeenCalled()
+    expect(result.workspaceLineage).toMatchObject({
+      parentWorkspaceKey: worktreeWorkspaceKey(PARENT_ID)
+    })
+  })
+
+  it('skips both lineage records when the parent host conflicts', () => {
+    const store = createStore({
+      metaById: { [PARENT_ID]: parentMeta({ hostId: 'ssh:other-host' }) }
+    })
+
+    const result = record(store, { parentWorkspace: worktreeWorkspaceKey(PARENT_ID) })
+
     expect(store.setWorktreeLineage).not.toHaveBeenCalled()
     expect(result.lineage).toBeNull()
+    // A persisted cross-host row makes filterLineageForHost return null for the entire host.
     expect(store.setWorkspaceLineage).not.toHaveBeenCalled()
     expect(result.workspaceLineage).toBeNull()
   })
-
-  it.each([
-    ['host', parentMeta({ hostId: 'ssh:other-host' })],
-    ['project', parentMeta({ projectId: 'project-2' })]
-  ])(
-    'skips both lineage records when the parent %s conflicts, so no cross-host row is persisted',
-    (_label, meta) => {
-      const store = createStore({ metaById: { [PARENT_ID]: meta } })
-
-      const result = record(store, { parentWorkspace: worktreeWorkspaceKey(PARENT_ID) })
-
-      expect(store.setWorktreeLineage).not.toHaveBeenCalled()
-      expect(result.lineage).toBeNull()
-      // A persisted cross-host row makes filterLineageForHost return null for the entire host.
-      expect(store.setWorkspaceLineage).not.toHaveBeenCalled()
-      expect(result.workspaceLineage).toBeNull()
-    }
-  )
 
   it('skips worktree lineage when the parent has no instance identity', () => {
     const store = createStore({ metaById: { [PARENT_ID]: parentMeta({ instanceId: undefined }) } })

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -295,6 +295,7 @@ function createdWorktreeSharesParentLineageBoundary(
   })
 }
 
+/** Persists the workspace and worktree lineage captured during creation when the parent is valid. */
 export function recordWorkspaceLineageForCreatedWorktree(
   store: Store,
   args: CreateWorktreeArgs,

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -285,17 +285,13 @@ const NO_CREATED_WORKTREE_LINEAGE: CreatedWorktreeLineageRecords = {
   workspaceLineage: null
 }
 
-/** Mirrors the projection's edge rule so we never persist a row the sidebar would silently drop.
- *  WorktreeMeta has no repoId, so the parent's comes from its `<repoId>::<path>` id. */
+/** Mirrors the projection's edge rule so we never persist a row the sidebar would silently drop. */
 function createdWorktreeSharesParentLineageBoundary(
   worktree: Worktree,
-  parentWorktreeId: string,
   parentMeta: WorktreeMeta
 ): boolean {
   return sharesWorktreeLineageBoundary(worktree, {
-    repoId: getRepoIdFromWorktreeId(parentWorktreeId),
-    hostId: parentMeta.hostId,
-    projectId: parentMeta.projectId
+    hostId: parentMeta.hostId
   })
 }
 
@@ -337,16 +333,10 @@ export function recordWorkspaceLineageForCreatedWorktree(
       console.warn(
         `[worktree-create] parent ${parentScope.worktreeId} has no instance identity; skipping lineage`
       )
-    } else if (
-      !createdWorktreeSharesParentLineageBoundary(
-        worktree,
-        parentScope.worktreeId,
-        parentWorktreeMeta
-      )
-    ) {
+    } else if (!createdWorktreeSharesParentLineageBoundary(worktree, parentWorktreeMeta)) {
       parentOutsideLineageBoundary = true
       console.warn(
-        `[worktree-create] parent ${parentScope.worktreeId} is outside ${worktree.id}'s repo/host/project boundary; skipping lineage`
+        `[worktree-create] parent ${parentScope.worktreeId} is outside ${worktree.id}'s host boundary; skipping lineage`
       )
     } else {
       lineage = store.setWorktreeLineage(worktree.id, {

--- a/src/main/runtime/orca-runtime-create-managed-worktree.ts
+++ b/src/main/runtime/orca-runtime-create-managed-worktree.ts
@@ -4,12 +4,13 @@ import type { RuntimeManagedWorktreeCreateArgs } from './runtime-managed-worktre
 import type { CreateWorktreeResult } from '../../shared/worktree/create-types'
 import { isTuiAgentEnabled } from '../../shared/tui-agent-selection'
 import { isFolderRepo } from '../../shared/repo-kind'
-import { getRepoSshConnectionId } from '../../shared/execution-host'
+import { getRepoExecutionHostId, getRepoSshConnectionId } from '../../shared/execution-host'
 import { createRuntimeFolderWorktree } from './runtime-folder-worktree-create'
 import { createRuntimeLocalManagedWorktree } from './runtime-local-worktree-create'
 import { prepareRuntimeLocalWorktreeSetup } from './runtime-local-worktree-setup'
 import { invalidateAuthorizedRootsCache } from '../ipc/filesystem-auth'
 import { startRuntimeLocalWorktreeTerminals } from './runtime-local-worktree-terminal-startup'
+import { getFolderWorkspaceExecutionHostId } from '../../shared/folder-workspace-worktree'
 
 export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWorktreeTerminalProvisioningHost {
   async createManagedWorktree(
@@ -97,6 +98,17 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
     const lineageInput =
       args.lineage || args.comment ? { ...args.lineage, comment: args.comment } : undefined
     const lineageResolution = await this.resolveLineageForWorktreeCreate(lineageInput)
+    // Why: rejecting after either create path returns would strand a child on disk without valid lineage.
+    if (lineageResolution.kind === 'lineage') {
+      const parentHostId =
+        lineageResolution.parent.type === 'worktree'
+          ? lineageResolution.parent.worktree.hostId
+          : getFolderWorkspaceExecutionHostId(lineageResolution.parent.folderWorkspace)
+      this.worktreeLineage.validateParentHost(
+        { hostId: getRepoExecutionHostId(repo) },
+        { hostId: parentHostId }
+      )
+    }
     if (sshConnectionId) {
       // Why normalize the row: the remote-create pipeline reads `repo.connectionId!` at every
       // depth, so hand it the connection the resolved host actually names.

--- a/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
+++ b/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
@@ -11,16 +11,24 @@ import {
   resolveLocalProjectRuntimesForRepos
 } from '../project-runtime-git-options'
 import { getAgentLaunchPlatformForRepo } from './runtime-agent-launch-resolution'
-import { resolveRepoWorktreeRows, resolveScopedWorktreeIdRow } from './repo-worktree-row-resolution'
+import {
+  resolveRepoWorktreeRows,
+  resolveScopedWorktreeIdRow,
+  type RepoWorktreeRow
+} from './repo-worktree-row-resolution'
 import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
 import type { RepoWorktreeRowDeps } from './repo-worktree-row-resolution'
 import { listRuntimeFolderWorkspaces } from './runtime-worktree-filesystem'
-import type { ExecutionHostId } from '../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  getRepoSshConnectionId,
+  LOCAL_EXECUTION_HOST_ID,
+  type ExecutionHostId
+} from '../../shared/execution-host'
 import type { Repo } from '../../shared/repo-types'
 import type { ProjectExecutionRuntimeResolution } from '../../shared/project-execution-runtime'
 import type { RuntimeWorktreeScanResult } from './repo-worktree-resolution-scan'
 import { getSshGitProviderGeneration } from '../providers/ssh-git-dispatch'
-import { getRepoExecutionHostId, getRepoSshConnectionId } from '../../shared/execution-host'
 import type { RuntimeWorktreeScanCache } from './orca-runtime-core'
 import { resolveWorktreeScanCacheTtlMs } from './runtime-worktree-scan-cache'
 
@@ -104,7 +112,14 @@ export class OrcaRuntimeWithListKnownResolvedWorktreesForExplicitTarget extends 
       )
     )
     const lineageById = this.store?.getAllWorktreeLineage?.() ?? {}
-    const worktrees = perRepoWorktrees.flatMap((rows) =>
+    const rowsByHostId = new Map<ExecutionHostId, RepoWorktreeRow[]>()
+    for (const worktree of perRepoWorktrees.flat()) {
+      const hostId = worktree.hostId ?? LOCAL_EXECUTION_HOST_ID
+      const rows = rowsByHostId.get(hostId) ?? []
+      rows.push(worktree)
+      rowsByHostId.set(hostId, rows)
+    }
+    const worktrees = [...rowsByHostId.values()].flatMap((rows) =>
       projectResolvedWorktreeLineage(rows, lineageById)
     )
     return { worktrees, platformByRepoId }

--- a/src/main/runtime/orca-runtime-tests/lineage-and-scan-cache-part-03.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/lineage-and-scan-cache-part-03.spec.ts
@@ -230,6 +230,68 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('projects lineage across repositories on the same host', async () => {
+    const repos = [
+      {
+        id: 'repo-parent',
+        path: '/tmp/repo-parent',
+        displayName: 'parent repo',
+        badgeColor: 'blue' as const,
+        addedAt: 1
+      },
+      {
+        id: 'repo-child',
+        path: '/tmp/repo-child',
+        displayName: 'child repo',
+        badgeColor: 'green' as const,
+        addedAt: 1
+      }
+    ]
+    const parentPath = '/tmp/repo-parent/parent'
+    const childPath = '/tmp/repo-child/child'
+    const parentId = `repo-parent::${parentPath}`
+    const childId = `repo-child::${childPath}`
+    const metaById: Record<string, WorktreeMeta> = {
+      [parentId]: makeWorktreeMeta({ hostId: 'local', instanceId: 'parent-instance' }),
+      [childId]: makeWorktreeMeta({ hostId: 'local', instanceId: 'child-instance' })
+    }
+    const lineageById: Record<string, WorktreeLineage> = {
+      [childId]: {
+        worktreeId: childId,
+        worktreeInstanceId: 'child-instance',
+        parentWorktreeId: parentId,
+        parentWorktreeInstanceId: 'parent-instance',
+        origin: 'manual',
+        capture: { source: 'manual-action', confidence: 'explicit' },
+        createdAt: 1
+      }
+    }
+    const runtimeStore = {
+      ...store,
+      getRepos: () => repos,
+      getRepo: (id: string) => repos.find((repo) => repo.id === id),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (id: string) => metaById[id],
+      getAllWorktreeLineage: () => lineageById
+    }
+    vi.mocked(listWorktrees).mockImplementation(async (repoPath) => [
+      makeWorktreeInfo(repoPath === repos[0].path ? parentPath : childPath)
+    ])
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    const resolved = await (
+      runtime as unknown as { listResolvedWorktrees: () => Promise<Worktree[]> }
+    ).listResolvedWorktrees()
+
+    expect(resolved.find((worktree) => worktree.id === childId)).toMatchObject({
+      parentWorktreeId: parentId,
+      lineage: expect.objectContaining({ parentWorktreeId: parentId })
+    })
+    expect(resolved.find((worktree) => worktree.id === parentId)).toMatchObject({
+      childWorktreeIds: [childId]
+    })
+  })
+
   it('worktree scan cache: rescans immediately after worktree invalidation', async () => {
     vi.mocked(listWorktrees).mockClear()
     const runtime = createRuntime()

--- a/src/main/runtime/orca-runtime-tests/lineage-and-scan-cache.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/lineage-and-scan-cache.spec.ts
@@ -580,25 +580,11 @@ describe('OrcaRuntimeService', () => {
 
   it.each([
     {
-      boundary: 'repository',
-      childRepoId: 'repo-child',
-      parentRepoId: 'repo-parent',
-      childMeta: {},
-      parentMeta: {}
-    },
-    {
       boundary: 'known host',
       childRepoId: TEST_REPO_ID,
       parentRepoId: TEST_REPO_ID,
       childMeta: { hostId: 'runtime:child-host' as const },
       parentMeta: { hostId: 'runtime:parent-host' as const }
-    },
-    {
-      boundary: 'known project',
-      childRepoId: TEST_REPO_ID,
-      parentRepoId: TEST_REPO_ID,
-      childMeta: { projectId: 'project-child' },
-      parentMeta: { projectId: 'project-parent' }
     }
   ])('rejects manual lineage writes across a $boundary boundary', async (scenario) => {
     const repos = [...new Set([scenario.childRepoId, scenario.parentRepoId])].map((id) => ({
@@ -644,12 +630,79 @@ describe('OrcaRuntimeService', () => {
       runtime.updateManagedWorktreeMeta(`id:${childId}`, {
         lineage: { parentWorktree: `id:${parentId}` }
       })
-    ).rejects.toThrow(
-      'Parent worktree must belong to the same repository, execution host, and project.'
-    )
+    ).rejects.toThrow('Parent worktree must belong to the same execution host.')
 
     expect(setWorktreeLineage).not.toHaveBeenCalled()
     expect(setWorkspaceLineage).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      boundary: 'repository',
+      childRepoId: 'repo-child',
+      parentRepoId: 'repo-parent',
+      childMeta: {},
+      parentMeta: {}
+    },
+    {
+      boundary: 'known project',
+      childRepoId: TEST_REPO_ID,
+      parentRepoId: TEST_REPO_ID,
+      childMeta: { projectId: 'project-child' },
+      parentMeta: { projectId: 'project-parent' }
+    }
+  ])('accepts manual lineage writes across a $boundary boundary', async (scenario) => {
+    const repos = [...new Set([scenario.childRepoId, scenario.parentRepoId])].map((id) => ({
+      id,
+      path: join(tmpdir(), id),
+      displayName: id,
+      badgeColor: 'blue' as const,
+      addedAt: 1
+    }))
+    const childRepoPath = repos.find((repo) => repo.id === scenario.childRepoId)!.path
+    const parentRepoPath = repos.find((repo) => repo.id === scenario.parentRepoId)!.path
+    const childPath = join(childRepoPath, 'child')
+    const parentPath = join(parentRepoPath, 'parent')
+    const childId = `${scenario.childRepoId}::${childPath}`
+    const parentId = `${scenario.parentRepoId}::${parentPath}`
+    const metaById: Record<string, WorktreeMeta> = {
+      [childId]: makeWorktreeMeta({ instanceId: 'child-instance', ...scenario.childMeta }),
+      [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance', ...scenario.parentMeta })
+    }
+    const setWorktreeLineage = vi.fn()
+    const setWorkspaceLineage = vi.fn()
+    const runtimeStore = {
+      ...store,
+      getRepos: () => repos,
+      getRepo: (id: string) => repos.find((repo) => repo.id === id),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...metaById[worktreeId], ...meta }
+        return metaById[worktreeId]
+      },
+      getWorktreeLineage: () => undefined,
+      setWorktreeLineage,
+      setWorkspaceLineage
+    }
+    vi.mocked(listWorktrees).mockImplementation(async (repoPath) => [
+      ...(repoPath === childRepoPath ? [makeWorktreeInfo(childPath)] : []),
+      ...(repoPath === parentRepoPath ? [makeWorktreeInfo(parentPath)] : [])
+    ])
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    await runtime.updateManagedWorktreeMeta(`id:${childId}`, {
+      lineage: { parentWorktree: `id:${parentId}` }
+    })
+
+    expect(setWorktreeLineage).toHaveBeenCalledWith(
+      childId,
+      expect.objectContaining({
+        parentWorktreeId: parentId,
+        parentWorktreeInstanceId: 'parent-instance'
+      })
+    )
+    expect(setWorkspaceLineage).toHaveBeenCalled()
   })
 
   it('clears workspace lineage when manually removing a parent', async () => {

--- a/src/main/runtime/orca-runtime-tests/ssh-worktree-lifecycle.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/ssh-worktree-lifecycle.spec.ts
@@ -6,6 +6,7 @@ import {
   ensurePathWithinWorkspaceMock,
   getActiveMultiplexerMock,
   getBranchConflictKind,
+  getSshGitProviderMock,
   gitRunner,
   listWorktrees,
   muxRequestMock,
@@ -23,6 +24,8 @@ import {
   TEST_REPO_PATH,
   createFolderWorkspaceRuntimeStore,
   isOriginMainBaseRefProbe,
+  makeFolderWorkspace,
+  makeWorktreeInfo,
   makeWorktreeMeta,
   store
 } from '../orca-runtime-test-fixtures.spec'
@@ -142,7 +145,108 @@ describe('OrcaRuntimeService', () => {
     expect(listWorktrees).not.toHaveBeenCalled()
   })
 
-  it('records lineage for SSH-backed CLI-created worktrees', async () => {
+  it.each([
+    { direction: 'local to SSH', childConnectionId: null, parentHostId: 'ssh:parent' },
+    { direction: 'SSH to local', childConnectionId: 'child', parentHostId: 'local' },
+    {
+      direction: 'SSH host A to SSH host B',
+      childConnectionId: 'child',
+      parentHostId: 'ssh:parent'
+    }
+  ] as const)('rejects $direction lineage before creating a worktree', async (scenario) => {
+    const repo = {
+      ...store.getRepo(TEST_REPO_ID)!,
+      ...(scenario.childConnectionId ? { connectionId: scenario.childConnectionId } : {})
+    }
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getRepos: () => [repo],
+      getRepo: (id: string) => (id === repo.id ? repo : undefined)
+    } as never)
+    const parentId = 'parent-repo::/parent'
+    const parent = {
+      id: parentId,
+      repoId: 'parent-repo',
+      path: '/parent',
+      hostId: scenario.parentHostId,
+      instanceId: 'parent-instance',
+      head: 'abc',
+      branch: 'parent',
+      isBare: false,
+      isMainWorktree: false,
+      parentWorktreeId: null,
+      childWorktreeIds: [],
+      lineage: null,
+      git: makeWorktreeInfo('/parent')
+    }
+    vi.spyOn(
+      runtime as unknown as {
+        resolveLineageForWorktreeCreate: () => Promise<unknown>
+      },
+      'resolveLineageForWorktreeCreate'
+    ).mockResolvedValue({
+      kind: 'lineage',
+      parent: {
+        type: 'worktree',
+        workspaceKey: `worktree:${parentId}`,
+        worktree: parent,
+        instanceId: parent.instanceId
+      },
+      origin: 'cli',
+      capture: { source: 'explicit-cli-flag', confidence: 'explicit' }
+    })
+
+    await expect(
+      runtime.createManagedWorktree({
+        repoSelector: TEST_REPO_ID,
+        name: 'child',
+        lineage: { parentWorktree: `id:${parentId}` }
+      })
+    ).rejects.toMatchObject({
+      code: 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+      message: 'Parent worktree must belong to the same execution host.'
+    })
+
+    expect(addWorktree).not.toHaveBeenCalled()
+    expect(getSshGitProviderMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { direction: 'local to SSH', childConnectionId: null, parentConnectionId: 'parent' },
+    { direction: 'SSH to local', childConnectionId: 'child', parentConnectionId: null },
+    {
+      direction: 'SSH host A to SSH host B',
+      childConnectionId: 'child',
+      parentConnectionId: 'parent'
+    }
+  ] as const)('rejects $direction folder lineage before creating a worktree', async (scenario) => {
+    const repo = {
+      ...store.getRepo(TEST_REPO_ID)!,
+      ...(scenario.childConnectionId ? { connectionId: scenario.childConnectionId } : {})
+    }
+    const folderWorkspace = makeFolderWorkspace({ connectionId: scenario.parentConnectionId })
+    const runtime = new OrcaRuntimeService({
+      ...createFolderWorkspaceRuntimeStore(folderWorkspace),
+      getRepos: () => [repo],
+      getRepo: (id: string) => (id === repo.id ? repo : undefined)
+    } as never)
+
+    await expect(
+      runtime.createManagedWorktree({
+        repoSelector: TEST_REPO_ID,
+        name: 'child',
+        lineage: { parentWorkspace: TEST_FOLDER_WORKSPACE_KEY }
+      })
+    ).rejects.toMatchObject({
+      code: 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+      message: 'Parent worktree must belong to the same execution host.'
+    })
+
+    expect(addWorktree).not.toHaveBeenCalled()
+    expect(getSshGitProviderMock).not.toHaveBeenCalled()
+  })
+
+  it('records cross-repository lineage for SSH-backed CLI-created worktrees', async () => {
     vi.mocked(listWorktrees).mockClear()
     vi.mocked(addWorktree).mockClear()
     const remoteRepo = {
@@ -159,8 +263,14 @@ describe('OrcaRuntimeService', () => {
         scripts: { setup: '', archive: '' }
       }
     }
+    const parentRepo = {
+      ...remoteRepo,
+      id: 'parent-repo',
+      path: '/remote/parent-repo',
+      displayName: 'parent repo'
+    }
     const parent = {
-      path: '/remote/repo-parent',
+      path: '/remote/parent-repo-parent',
       head: 'abc',
       branch: 'refs/heads/repo-parent',
       isBare: false,
@@ -173,7 +283,7 @@ describe('OrcaRuntimeService', () => {
       isBare: false,
       isMainWorktree: false
     }
-    const parentId = `${TEST_REPO_ID}::${parent.path}`
+    const parentId = `${parentRepo.id}::${parent.path}`
     const childId = `${TEST_REPO_ID}::${created.path}`
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance' })
@@ -181,8 +291,8 @@ describe('OrcaRuntimeService', () => {
     const lineageById: Record<string, WorktreeLineage> = {}
     const remoteStore = {
       ...store,
-      getRepos: () => [remoteRepo],
-      getRepo: (id: string) => (id === TEST_REPO_ID ? remoteRepo : undefined),
+      getRepos: () => [remoteRepo, parentRepo],
+      getRepo: (id: string) => [remoteRepo, parentRepo].find((repo) => repo.id === id),
       getAllWorktreeMeta: () => metaById,
       getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
       setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
@@ -215,7 +325,9 @@ describe('OrcaRuntimeService', () => {
         throw new Error(`unexpected git call: ${args.join(' ')}`)
       }),
       addWorktree: vi.fn().mockResolvedValue(undefined),
-      listWorktrees: vi.fn().mockResolvedValueOnce([parent]).mockResolvedValue([parent, created])
+      listWorktrees: vi.fn(async (repoPath: string) =>
+        repoPath === parentRepo.path ? [parent] : [created]
+      )
     }
     registerSshGitProvider('ssh-1', provider as never)
     getActiveMultiplexerMock.mockReturnValue({ request: muxRequestMock, notify: vi.fn() })

--- a/src/main/runtime/repo-worktree-row-resolution.test.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import type { Repo } from '../../shared/repo-types'
+import type { WorktreeLineage } from '../../shared/worktree/lineage-types'
 import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import type { GitWorktreeInfo, Worktree } from '../../shared/worktree/types'
 import type { Store } from '../persistence'
@@ -38,14 +39,16 @@ function gitWorktree(path: string): GitWorktreeInfo {
 
 function createDeps(repos: Repo[]): RepoWorktreeRowDeps & {
   metaById: Record<string, WorktreeMeta>
+  lineageById: Record<string, WorktreeLineage>
   scanRepo: ReturnType<typeof vi.fn<RepoWorktreeRowDeps['scanRepo']>>
   listFolderWorkspaces: ReturnType<typeof vi.fn<RepoWorktreeRowDeps['listFolderWorkspaces']>>
 } {
   const metaById: Record<string, WorktreeMeta> = {}
+  const lineageById: Record<string, WorktreeLineage> = {}
   const store = {
     getRepos: () => repos,
     getAllWorktreeMeta: () => metaById,
-    getAllWorktreeLineage: () => ({}),
+    getAllWorktreeLineage: () => lineageById,
     getProjects: () => [],
     getSettings: () => ({}),
     setWorktreeMeta: (worktreeId: string, updates: Partial<WorktreeMeta>) => {
@@ -59,7 +62,7 @@ function createDeps(repos: Repo[]): RepoWorktreeRowDeps & {
     worktrees: [gitWorktree(owner.id === 'unrelated' ? '/unrelated/worktree' : '/same/worktree')]
   }))
   const listFolderWorkspaces = vi.fn<RepoWorktreeRowDeps['listFolderWorkspaces']>(() => [])
-  return { store, metaById, scanRepo, listFolderWorkspaces }
+  return { store, metaById, lineageById, scanRepo, listFolderWorkspaces }
 }
 
 describe('host-qualified scoped worktree resolution', () => {
@@ -248,6 +251,27 @@ describe('host-qualified scoped worktree resolution', () => {
     await expect(
       resolveScopedWorktreeIdRow(deps, 'shared::/same/worktree', 'ssh:builder')
     ).resolves.toBeNull()
+    expect(deps.scanRepo).not.toHaveBeenCalled()
+  })
+
+  it('falls back to fleet resolution when the worktree has cross-repo lineage', async () => {
+    const deps = createDeps([
+      repo('repo-child', '/local/child-repo', { executionHostId: 'local' }),
+      repo('repo-parent', '/local/parent-repo', { executionHostId: 'local' })
+    ])
+    const childId = 'repo-child::/same/worktree'
+    const parentId = 'repo-parent::/parent/worktree'
+    deps.lineageById[childId] = {
+      worktreeId: childId,
+      worktreeInstanceId: 'child-instance',
+      parentWorktreeId: parentId,
+      parentWorktreeInstanceId: 'parent-instance',
+      origin: 'manual',
+      capture: { source: 'manual-action', confidence: 'explicit' },
+      createdAt: 1
+    }
+
+    await expect(resolveScopedWorktreeIdRow(deps, childId, 'local')).resolves.toBeNull()
     expect(deps.scanRepo).not.toHaveBeenCalled()
   })
 

--- a/src/main/runtime/repo-worktree-row-resolution.test.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.test.ts
@@ -254,26 +254,58 @@ describe('host-qualified scoped worktree resolution', () => {
     expect(deps.scanRepo).not.toHaveBeenCalled()
   })
 
-  it('falls back to fleet resolution when the worktree has cross-repo lineage', async () => {
-    const deps = createDeps([
-      repo('repo-child', '/local/child-repo', { executionHostId: 'local' }),
-      repo('repo-parent', '/local/parent-repo', { executionHostId: 'local' })
-    ])
-    const childId = 'repo-child::/same/worktree'
-    const parentId = 'repo-parent::/parent/worktree'
-    deps.lineageById[childId] = {
-      worktreeId: childId,
-      worktreeInstanceId: 'child-instance',
-      parentWorktreeId: parentId,
-      parentWorktreeInstanceId: 'parent-instance',
-      origin: 'manual',
-      capture: { source: 'manual-action', confidence: 'explicit' },
-      createdAt: 1
-    }
+  it.each([
+    [
+      'exact child ID',
+      'repo-child::/same/worktree',
+      'repo-parent::/parent/worktree',
+      'repo-child::/same/worktree'
+    ],
+    [
+      'a trailing slash on the child ID',
+      'repo-child::/same/worktree',
+      'repo-parent::/parent/worktree',
+      'repo-child::/same/worktree/'
+    ],
+    [
+      'a doubled separator on the child ID',
+      'repo-child::/same/worktree',
+      'repo-parent::/parent/worktree',
+      'repo-child::/same//worktree'
+    ],
+    [
+      'an NFD child ID',
+      'repo-child::/same/café',
+      'repo-parent::/parent/worktree',
+      `repo-child::${'/same/café'.normalize('NFD')}`
+    ],
+    [
+      'a trailing slash on the parent ID',
+      'repo-child::/same/worktree',
+      'repo-parent::/parent/worktree',
+      'repo-parent::/parent/worktree/'
+    ]
+  ])(
+    'falls back to fleet resolution for cross-repo lineage requested with %s',
+    async (_label, childId, parentId, requestedId) => {
+      const deps = createDeps([
+        repo('repo-child', '/local/child-repo', { executionHostId: 'local' }),
+        repo('repo-parent', '/local/parent-repo', { executionHostId: 'local' })
+      ])
+      deps.lineageById[childId] = {
+        worktreeId: childId,
+        worktreeInstanceId: 'child-instance',
+        parentWorktreeId: parentId,
+        parentWorktreeInstanceId: 'parent-instance',
+        origin: 'manual',
+        capture: { source: 'manual-action', confidence: 'explicit' },
+        createdAt: 1
+      }
 
-    await expect(resolveScopedWorktreeIdRow(deps, childId, 'local')).resolves.toBeNull()
-    expect(deps.scanRepo).not.toHaveBeenCalled()
-  })
+      await expect(resolveScopedWorktreeIdRow(deps, requestedId, 'local')).resolves.toBeNull()
+      expect(deps.scanRepo).not.toHaveBeenCalled()
+    }
+  )
 
   it('reuses fleet owner counts without reloading repos per row', async () => {
     const owners = Array.from({ length: 100 }, (_, index) =>

--- a/src/main/runtime/repo-worktree-row-resolution.test.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.test.ts
@@ -307,6 +307,52 @@ describe('host-qualified scoped worktree resolution', () => {
     }
   )
 
+  it('ignores colliding cross-repo lineage owned by another host', async () => {
+    const childId = 'repo-child::/same/worktree'
+    const parentId = 'repo-parent::/parent/worktree'
+    const deps = createDeps([
+      repo('repo-child', '/local/child-repo', { executionHostId: 'local' }),
+      repo('repo-child', '/remote/child-repo', { executionHostId: 'ssh:builder' }),
+      repo('repo-parent', '/remote/parent-repo', { executionHostId: 'ssh:builder' })
+    ])
+    deps.lineageById[childId] = {
+      worktreeId: childId,
+      worktreeInstanceId: 'remote-child-instance',
+      parentWorktreeId: parentId,
+      parentWorktreeInstanceId: 'remote-parent-instance',
+      origin: 'manual',
+      capture: { source: 'manual-action', confidence: 'explicit' },
+      createdAt: 1
+    }
+    ;(
+      deps.store as Store & {
+        getWorktreeMetaForHost: (
+          worktreeId: string,
+          hostId: ExecutionHostId
+        ) => WorktreeMeta | undefined
+      }
+    ).getWorktreeMetaForHost = (worktreeId, hostId) => {
+      if (hostId !== 'ssh:builder') {
+        return undefined
+      }
+      return worktreeId === childId
+        ? ({ instanceId: 'remote-child-instance', hostId } as unknown as WorktreeMeta)
+        : ({ instanceId: 'remote-parent-instance', hostId } as unknown as WorktreeMeta)
+    }
+
+    await expect(resolveScopedWorktreeIdRow(deps, childId, 'local')).resolves.toMatchObject({
+      id: childId,
+      hostId: 'local'
+    })
+    expect(deps.scanRepo.mock.calls.map(([owner]) => owner)).toEqual([
+      expect.objectContaining({ path: '/local/child-repo' })
+    ])
+
+    deps.scanRepo.mockClear()
+    await expect(resolveScopedWorktreeIdRow(deps, childId, 'ssh:builder')).resolves.toBeNull()
+    expect(deps.scanRepo).not.toHaveBeenCalled()
+  })
+
   it('reuses fleet owner counts without reloading repos per row', async () => {
     const owners = Array.from({ length: 100 }, (_, index) =>
       repo(`repo-${index}`, `/repos/${index}`, { executionHostId: 'local' })

--- a/src/main/runtime/repo-worktree-row-resolution.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.ts
@@ -202,7 +202,20 @@ export async function resolveScopedWorktreeIdRow(
     }
     const child = splitWorktreeId(lineage.worktreeId)
     const parent = splitWorktreeId(lineage.parentWorktreeId)
-    return child?.repoId !== parent?.repoId
+    if (child?.repoId === parent?.repoId) {
+      return false
+    }
+    // Why: lineage IDs are host-unqualified. A colliding edge on another host must not force this
+    // host's otherwise-scoped lookup into a fleet fallback that cannot resolve the target row.
+    if (requiredHostId !== undefined && typeof store.getWorktreeMetaForHost === 'function') {
+      const childMeta = readWorktreeMetaForHost(store, lineage.worktreeId, requiredHostId)
+      const parentMeta = readWorktreeMetaForHost(store, lineage.parentWorktreeId, requiredHostId)
+      return (
+        childMeta?.instanceId === lineage.worktreeInstanceId &&
+        parentMeta?.instanceId === lineage.parentWorktreeInstanceId
+      )
+    }
+    return true
   })
   if (touchesCrossRepoLineage) {
     return null

--- a/src/main/runtime/repo-worktree-row-resolution.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.ts
@@ -175,9 +175,8 @@ export async function resolveRepoWorktreeRows(
 /**
  * Resolve one `<repoId>::<path>` worktree id by scanning only its owning repo.
  *
- * Lineage edges are intra-repo by construction (`sharesResolvedWorktreeLineageBoundary` requires a
- * matching repoId), so projecting over one repo's rows yields the same parent and child ids the
- * fleet scan would. Returns `null` whenever that does not hold, and the caller falls back.
+ * Cross-repo lineage needs every repo on the host, so affected rows return `null` and let the caller
+ * fall back to its fleet scan. Other rows retain the cheap scoped path.
  */
 export async function resolveScopedWorktreeIdRow(
   deps: RepoWorktreeRowDeps,
@@ -187,6 +186,18 @@ export async function resolveScopedWorktreeIdRow(
   const { store } = deps
   const parsed = splitWorktreeIdForFilesystem(worktreeId)
   if (!parsed?.repoId || !parsed.worktreePath) {
+    return null
+  }
+  const lineageById = store.getAllWorktreeLineage?.() ?? {}
+  const touchesCrossRepoLineage = Object.values(lineageById).some((lineage) => {
+    const child = splitWorktreeId(lineage.worktreeId)
+    const parent = splitWorktreeId(lineage.parentWorktreeId)
+    return (
+      child?.repoId !== parent?.repoId &&
+      (lineage.worktreeId === worktreeId || lineage.parentWorktreeId === worktreeId)
+    )
+  })
+  if (touchesCrossRepoLineage) {
     return null
   }
   const owners = store
@@ -208,7 +219,7 @@ export async function resolveScopedWorktreeIdRow(
     store.getAllWorktreeMeta() ?? {},
     resolveLocalProjectRuntimesForRepos(store, [repo])
   )
-  const projected = projectResolvedWorktreeLineage(rows, store.getAllWorktreeLineage?.() ?? {})
+  const projected = projectResolvedWorktreeLineage(rows, lineageById)
   const exact = projected.find((worktree) => worktree.id === worktreeId)
   if (exact) {
     return exact

--- a/src/main/runtime/repo-worktree-row-resolution.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.ts
@@ -188,14 +188,21 @@ export async function resolveScopedWorktreeIdRow(
   if (!parsed?.repoId || !parsed.worktreePath) {
     return null
   }
+  const comparisonKey = worktreeIdComparisonKey(worktreeId)
   const lineageById = store.getAllWorktreeLineage?.() ?? {}
   const touchesCrossRepoLineage = Object.values(lineageById).some((lineage) => {
+    const touchesRequestedWorktree =
+      lineage.worktreeId === worktreeId ||
+      lineage.parentWorktreeId === worktreeId ||
+      (comparisonKey !== null &&
+        (worktreeIdComparisonKey(lineage.worktreeId) === comparisonKey ||
+          worktreeIdComparisonKey(lineage.parentWorktreeId) === comparisonKey))
+    if (!touchesRequestedWorktree) {
+      return false
+    }
     const child = splitWorktreeId(lineage.worktreeId)
     const parent = splitWorktreeId(lineage.parentWorktreeId)
-    return (
-      child?.repoId !== parent?.repoId &&
-      (lineage.worktreeId === worktreeId || lineage.parentWorktreeId === worktreeId)
-    )
+    return child?.repoId !== parent?.repoId
   })
   if (touchesCrossRepoLineage) {
     return null
@@ -226,7 +233,6 @@ export async function resolveScopedWorktreeIdRow(
   }
   // Why (#16243): the scan can spell this id's path differently — the divergence `path:` absorbs.
   // One equivalent row may stand in; two is an ambiguity a scoped lookup must refuse, not guess.
-  const comparisonKey = worktreeIdComparisonKey(worktreeId)
   if (comparisonKey === null) {
     return null
   }

--- a/src/main/runtime/runtime-worktree-lineage-controller.ts
+++ b/src/main/runtime/runtime-worktree-lineage-controller.ts
@@ -5,7 +5,8 @@ import {
   parseWorkspaceKey,
   worktreeWorkspaceKey
 } from '../../shared/workspace-scope'
-import { sharesResolvedWorktreeLineageBoundary } from '../../shared/resolved-worktree-lineage'
+import { sharesWorktreeLineageBoundary } from '../../shared/resolved-worktree-lineage'
+import type { Worktree } from '../../shared/worktree/types'
 import type { OrchestrationDb } from './orchestration/db'
 import type { RuntimeStore } from './runtime-store-contract'
 import type { ResolvedWorktree } from './runtime-worktree-path-identity'
@@ -87,12 +88,7 @@ export class RuntimeWorktreeLineageController {
     if (child.id === parent.id) {
       throw new RuntimeLineageError('LINEAGE_PARENT_CYCLE', 'A worktree cannot parent itself.')
     }
-    if (!sharesResolvedWorktreeLineageBoundary(child, parent)) {
-      throw new RuntimeLineageError(
-        'LINEAGE_PARENT_CONTEXT_CONFLICT',
-        'Parent worktree must belong to the same repository, execution host, and project.'
-      )
-    }
+    this.validateParentHost(child, parent)
     const instanceById = new Map(
       this.deps.getCachedWorktrees()?.map((worktree) => [worktree.id, worktree.instanceId]) ?? [
         [child.id, child.instanceId],
@@ -121,6 +117,16 @@ export class RuntimeWorktreeLineageController {
       }
       cursor = lineage.parentWorktreeId
     }
+  }
+
+  validateParentHost(child: Pick<Worktree, 'hostId'>, parent: Pick<Worktree, 'hostId'>): void {
+    if (sharesWorktreeLineageBoundary(child, parent)) {
+      return
+    }
+    throw new RuntimeLineageError(
+      'LINEAGE_PARENT_CONTEXT_CONFLICT',
+      'Parent worktree must belong to the same execution host.'
+    )
   }
 
   async resolveTaskCandidate(taskId: string): Promise<WorktreeLineageCandidate | null> {

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -58,7 +58,6 @@ export default function NewWorkspaceComposerCard(
     parentWorktreeId,
     onParentWorktreeIdChange,
     selectedRepoExecutionHostId,
-    selectedRepoProjectId,
     activeFolderWorkspaceId,
     onAddProjectOverride,
     onNestedDialogOpenChange
@@ -310,7 +309,6 @@ export default function NewWorkspaceComposerCard(
           parentWorktreeId={parentWorktreeId}
           onParentWorktreeIdChange={onParentWorktreeIdChange}
           selectedRepoExecutionHostId={selectedRepoExecutionHostId}
-          selectedRepoProjectId={selectedRepoProjectId}
           activeFolderWorkspaceId={activeFolderWorkspaceId}
         />
       </div>

--- a/src/renderer/src/components/new-workspace/ComposerParentWorktreePicker.test.tsx
+++ b/src/renderer/src/components/new-workspace/ComposerParentWorktreePicker.test.tsx
@@ -305,7 +305,7 @@ describe('ComposerParentWorktreePicker', () => {
     expect(rows()).toHaveLength(0)
   })
 
-  it('excludes archived worktrees and worktrees from another repo', () => {
+  it('excludes archived worktrees and includes worktrees from another repo on the same host', () => {
     seed(
       [
         makeWorktree({ id: 'alpha', displayName: 'Alpha' }),
@@ -320,10 +320,11 @@ describe('ComposerParentWorktreePicker', () => {
 
     expect(candidateLabels().join(' ')).toContain('Alpha')
     expect(candidateLabels().join(' ')).not.toContain('Archived')
-    expect(candidateLabels().join(' ')).not.toContain('Other repo')
+    expect(candidateLabels().join(' ')).toContain('Other repo')
+    expect(candidateLabels().join(' ')).toContain('repo2')
   })
 
-  it('excludes candidates on another execution host or project', () => {
+  it('excludes candidates on another execution host and includes another project', () => {
     seed([
       makeWorktree({ id: 'same', displayName: 'Same host', hostId: 'local', projectId: 'proj1' }),
       makeWorktree({
@@ -344,7 +345,6 @@ describe('ComposerParentWorktreePicker', () => {
       <ComposerParentWorktreePicker
         repoId={REPO_ID}
         executionHostId="local"
-        projectId="proj1"
         value={null}
         onChange={vi.fn()}
       />
@@ -353,18 +353,16 @@ describe('ComposerParentWorktreePicker', () => {
 
     expect(candidateLabels().join(' ')).toContain('Same host')
     expect(candidateLabels().join(' ')).not.toContain('Other host')
-    expect(candidateLabels().join(' ')).not.toContain('Other project')
+    expect(candidateLabels().join(' ')).toContain('Other project')
   })
 
-  // A worktree with no recorded hostId inherits its repo's host, which is the child's host too.
-  it('keeps candidates whose host or project is unrecorded', () => {
+  it('keeps candidates whose host is inherited from the repo', () => {
     seed([makeWorktree({ id: 'unscoped', displayName: 'Unscoped' })])
 
     render(
       <ComposerParentWorktreePicker
         repoId={REPO_ID}
         executionHostId="local"
-        projectId="proj1"
         value={null}
         onChange={vi.fn()}
       />
@@ -372,6 +370,30 @@ describe('ComposerParentWorktreePicker', () => {
     fireEvent.click(trigger())
 
     expect(candidateLabels().join(' ')).toContain('Unscoped')
+  })
+
+  it('excludes a cross-repo candidate owned by another host', () => {
+    seed(
+      [
+        makeWorktree({ id: 'same', displayName: 'Same host' }),
+        makeWorktree({ id: 'other', displayName: 'Other host', repoId: 'repo2' })
+      ],
+      [REPO_ID, 'repo2']
+    )
+    storeState.repos = [makeRepo(REPO_ID), { ...makeRepo('repo2'), executionHostId: 'ssh:remote' }]
+
+    render(
+      <ComposerParentWorktreePicker
+        repoId={REPO_ID}
+        executionHostId="local"
+        value={null}
+        onChange={vi.fn()}
+      />
+    )
+    fireEvent.click(trigger())
+
+    expect(candidateLabels().join(' ')).toContain('Same host')
+    expect(candidateLabels().join(' ')).not.toContain('Other host')
   })
 
   it('restricts candidates to the active folder workspace subtree', () => {

--- a/src/renderer/src/components/new-workspace/ComposerParentWorktreePicker.test.tsx
+++ b/src/renderer/src/components/new-workspace/ComposerParentWorktreePicker.test.tsx
@@ -396,6 +396,36 @@ describe('ComposerParentWorktreePicker', () => {
     expect(candidateLabels().join(' ')).not.toContain('Other host')
   })
 
+  it('excludes an unstamped candidate with multiple repo owners', () => {
+    seed([
+      makeWorktree({ id: 'ambiguous', displayName: 'Ambiguous owner', repoId: 'repo2' }),
+      makeWorktree({
+        id: 'stamped',
+        displayName: 'Stamped owner',
+        repoId: 'repo2',
+        hostId: 'ssh:remote'
+      })
+    ])
+    storeState.repos = [
+      makeRepo(REPO_ID),
+      makeRepo('repo2'),
+      { ...makeRepo('repo2'), executionHostId: 'ssh:remote' }
+    ]
+
+    render(
+      <ComposerParentWorktreePicker
+        repoId={REPO_ID}
+        executionHostId="ssh:remote"
+        value={null}
+        onChange={vi.fn()}
+      />
+    )
+    fireEvent.click(trigger())
+
+    expect(candidateLabels().join(' ')).not.toContain('Ambiguous owner')
+    expect(candidateLabels().join(' ')).toContain('Stamped owner')
+  })
+
   it('restricts candidates to the active folder workspace subtree', () => {
     const attached = makeWorktree({
       id: 'attached',

--- a/src/renderer/src/components/new-workspace/ComposerParentWorktreePicker.tsx
+++ b/src/renderer/src/components/new-workspace/ComposerParentWorktreePicker.tsx
@@ -16,6 +16,7 @@ import { useAppStore } from '@/store'
 import {
   getIndexedAllWorktrees,
   getIndexedRepoMap,
+  getIndexedRepoOwners,
   getIndexedWorktreeById,
   getIndexedWorktreeMap
 } from '@/store/worktree-repo-index'
@@ -222,10 +223,13 @@ function ParentWorktreeCandidateList({
   const [search, setSearch] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState(0)
   const repoMap = getIndexedRepoMap(repos)
+  const repoOwners = getIndexedRepoOwners(repos)
 
   const candidates = useMemo(() => {
-    const childRepo = repoMap.get(repoId)
-    const childHostId = executionHostId ?? (childRepo ? getRepoExecutionHostId(childRepo) : null)
+    const childRepoOwners = repoOwners.get(repoId) ?? []
+    const childHostId =
+      executionHostId ??
+      (childRepoOwners.length === 1 ? getRepoExecutionHostId(childRepoOwners[0]) : null)
     const worktreeMap = getIndexedWorktreeMap(worktreesByRepo)
     const cyclicLineageIds = getCyclicProjectedWorktreeLineageIds(worktreeLineageById, worktreeMap)
     const folderSubtreeIds = activeFolderWorkspaceId
@@ -238,9 +242,11 @@ function ParentWorktreeCandidateList({
       : null
     return getIndexedAllWorktrees(worktreesByRepo)
       .filter((candidate) => {
-        const candidateRepo = repoMap.get(candidate.repoId)
+        const candidateRepoOwners = repoOwners.get(candidate.repoId) ?? []
+        const candidateRepo = candidateRepoOwners.length === 1 ? candidateRepoOwners[0] : undefined
         return (
           childHostId !== null &&
+          (candidate.hostId !== undefined || candidateRepoOwners.length <= 1) &&
           getWorktreeExecutionHostId(candidate, candidateRepo) === childHostId &&
           !candidate.isArchived &&
           !cyclicLineageIds.has(candidate.id) &&
@@ -252,7 +258,7 @@ function ParentWorktreeCandidateList({
     activeFolderWorkspaceId,
     executionHostId,
     repoId,
-    repoMap,
+    repoOwners,
     workspaceLineageByChildKey,
     worktreeLineageById,
     worktreesByRepo

--- a/src/renderer/src/components/new-workspace/ComposerParentWorktreePicker.tsx
+++ b/src/renderer/src/components/new-workspace/ComposerParentWorktreePicker.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Check, ChevronsUpDown, GitBranch } from 'lucide-react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { Button } from '@/components/ui/button'
+import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
 import { Command, CommandInput, CommandList } from '@/components/ui/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
@@ -14,6 +15,7 @@ import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
 import {
   getIndexedAllWorktrees,
+  getIndexedRepoMap,
   getIndexedWorktreeById,
   getIndexedWorktreeMap
 } from '@/store/worktree-repo-index'
@@ -34,14 +36,14 @@ import {
   getLineageChildWorktree
 } from '@/components/right-sidebar/folder-workspace-attached-worktrees'
 import { COMBOBOX_POPOVER_SURFACE } from './type-ahead-combobox-styles'
-import {
-  sharesWorktreeLineageBoundary,
-  type WorktreeLineageBoundary
-} from '../../../../shared/resolved-worktree-lineage'
 import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
 import type { WorkspaceLineage, WorktreeLineage } from '../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../shared/worktree/types'
-import type { ExecutionHostId } from '../../../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  getWorktreeExecutionHostId,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
 
 /** Single-line row: text-sm leading (20px) over py-2. Set as the row's explicit height. */
 const NO_PARENT_ROW_HEIGHT = 36
@@ -51,7 +53,6 @@ type ComposerParentWorktreePickerProps = {
   repoId: string
   /** Parent must belong to the same execution host that will create the child. */
   executionHostId?: ExecutionHostId | null
-  projectId?: string | null
   value: string | null
   onChange: (id: string | null) => void
   disabled?: boolean
@@ -62,7 +63,6 @@ type ComposerParentWorktreePickerProps = {
 type ParentWorktreeCandidateListProps = {
   repoId: string
   executionHostId?: ExecutionHostId | null
-  projectId?: string | null
   value: string | null
   activeFolderWorkspaceId: string | null
   onSelect: (id: string | null) => void
@@ -78,7 +78,6 @@ type ParentWorktreeCandidateListProps = {
 function ComposerParentWorktreePickerImpl({
   repoId,
   executionHostId,
-  projectId,
   value,
   onChange,
   disabled = false,
@@ -155,7 +154,6 @@ function ComposerParentWorktreePickerImpl({
           <ParentWorktreeCandidateList
             repoId={repoId}
             executionHostId={executionHostId}
-            projectId={projectId}
             value={value}
             activeFolderWorkspaceId={activeFolderWorkspaceId}
             onSelect={handleSelect}
@@ -209,12 +207,12 @@ function getFolderWorkspaceSubtreeIds(
 function ParentWorktreeCandidateList({
   repoId,
   executionHostId,
-  projectId,
   value,
   activeFolderWorkspaceId,
   onSelect
 }: ParentWorktreeCandidateListProps): React.JSX.Element {
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const repos = useAppStore((s) => s.repos)
   const worktreeLineageById = useAppStore((s) => s.worktreeLineageById)
   const workspaceLineageByChildKey = useAppStore((s) => s.workspaceLineageByChildKey)
   const listRef = useRef<HTMLDivElement>(null)
@@ -223,16 +221,11 @@ function ParentWorktreeCandidateList({
   const optionIdPrefix = `${useId()}option`
   const [search, setSearch] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const repoMap = getIndexedRepoMap(repos)
 
   const candidates = useMemo(() => {
-    // Why `?? undefined`: an unresolved host or project is "not known yet", not "no host", and
-    // the boundary check reads undefined on either side as a wildcard. A candidate in this repo
-    // with no recorded hostId inherits that repo's host, so it is on the child's host too.
-    const childBoundary: WorktreeLineageBoundary = {
-      repoId,
-      hostId: executionHostId ?? undefined,
-      projectId: projectId ?? undefined
-    }
+    const childRepo = repoMap.get(repoId)
+    const childHostId = executionHostId ?? (childRepo ? getRepoExecutionHostId(childRepo) : null)
     const worktreeMap = getIndexedWorktreeMap(worktreesByRepo)
     const cyclicLineageIds = getCyclicProjectedWorktreeLineageIds(worktreeLineageById, worktreeMap)
     const folderSubtreeIds = activeFolderWorkspaceId
@@ -244,20 +237,22 @@ function ParentWorktreeCandidateList({
         )
       : null
     return getIndexedAllWorktrees(worktreesByRepo)
-      .filter(
-        (candidate) =>
-          candidate.repoId === repoId &&
+      .filter((candidate) => {
+        const candidateRepo = repoMap.get(candidate.repoId)
+        return (
+          childHostId !== null &&
+          getWorktreeExecutionHostId(candidate, candidateRepo) === childHostId &&
           !candidate.isArchived &&
-          sharesWorktreeLineageBoundary(childBoundary, candidate) &&
           !cyclicLineageIds.has(candidate.id) &&
           (folderSubtreeIds === null || folderSubtreeIds.has(candidate.id))
-      )
+        )
+      })
       .sort(compareWorktreeDisplayName)
   }, [
     activeFolderWorkspaceId,
     executionHostId,
-    projectId,
     repoId,
+    repoMap,
     workspaceLineageByChildKey,
     worktreeLineageById,
     worktreesByRepo
@@ -370,6 +365,8 @@ function ParentWorktreeCandidateList({
               return null
             }
             const isHighlighted = rowIndex === activeIndex
+            const foreignRepo =
+              candidate?.repoId === repoId ? undefined : repoMap.get(candidate?.repoId ?? '')
             return (
               <div
                 key={virtualRow.key}
@@ -396,6 +393,12 @@ function ParentWorktreeCandidateList({
                   <div className="min-w-0 flex-1">
                     <div className="truncate text-[13px] font-medium">{candidate.displayName}</div>
                     <div className="mt-1 flex min-w-0 items-center gap-1.5 text-[11px] leading-none text-muted-foreground">
+                      {foreignRepo ? (
+                        <span className="inline-flex min-w-0 max-w-[8rem] shrink-0 items-center gap-1 rounded border border-border bg-accent px-1.5 py-0.5 text-[10px] font-semibold text-foreground">
+                          <RepoBadgeMark color={foreignRepo.badgeColor} />
+                          <span className="truncate lowercase">{foreignRepo.displayName}</span>
+                        </span>
+                      ) : null}
                       <GitBranch className="size-3 shrink-0" />
                       <span className="truncate">{branchDisplayName(candidate.branch)}</span>
                     </div>

--- a/src/renderer/src/components/new-workspace/NewWorkspaceComposerAdvancedSection.tsx
+++ b/src/renderer/src/components/new-workspace/NewWorkspaceComposerAdvancedSection.tsx
@@ -41,7 +41,6 @@ type NewWorkspaceComposerAdvancedSectionProps = Pick<
   | 'parentWorktreeId'
   | 'onParentWorktreeIdChange'
   | 'selectedRepoExecutionHostId'
-  | 'selectedRepoProjectId'
   | 'activeFolderWorkspaceId'
   | 'note'
   | 'onNoteChange'
@@ -83,7 +82,6 @@ export function NewWorkspaceComposerAdvancedSection({
   parentWorktreeId = null,
   onParentWorktreeIdChange,
   selectedRepoExecutionHostId,
-  selectedRepoProjectId,
   activeFolderWorkspaceId = null,
   note,
   onNoteChange,
@@ -206,7 +204,6 @@ export function NewWorkspaceComposerAdvancedSection({
             <ComposerParentWorktreePicker
               repoId={repoId}
               executionHostId={selectedRepoExecutionHostId}
-              projectId={selectedRepoProjectId}
               value={parentWorktreeId}
               onChange={onParentWorktreeIdChange}
               activeFolderWorkspaceId={activeFolderWorkspaceId}

--- a/src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.test.ts
+++ b/src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.test.ts
@@ -218,7 +218,7 @@ describe('getAttachedWorktreesForFolderWorkspace', () => {
     expect(result.lineageChildrenByParentId.size).toBe(0)
   })
 
-  it('rejects nested descendants across host or project boundaries', () => {
+  it('rejects nested descendants across hosts while keeping cross-repo and project ones', () => {
     const parent = makeWorktree({
       id: 'repo-1::/parent',
       instanceId: 'parent',
@@ -229,6 +229,12 @@ describe('getAttachedWorktreesForFolderWorkspace', () => {
       id: 'repo-1::/host-child',
       instanceId: 'host-child',
       hostId: toSshExecutionHostId('other')
+    })
+    const repoChild = makeWorktree({
+      id: 'repo-2::/repo-child',
+      repoId: 'repo-2',
+      instanceId: 'repo-child',
+      hostId: LOCAL_EXECUTION_HOST_ID
     })
     const projectChild = makeWorktree({
       id: 'repo-1::/project-child',
@@ -243,12 +249,18 @@ describe('getAttachedWorktreesForFolderWorkspace', () => {
       workspaceLineageByChildKey: { [parent.id]: makeWorkspaceLineage(parent) },
       worktreeLineageById: {
         [hostChild.id]: makeWorktreeLineage(hostChild, parent),
+        [repoChild.id]: makeWorktreeLineage(repoChild, parent),
         [projectChild.id]: makeWorktreeLineage(projectChild, parent)
       },
-      worktreesByRepo: { 'repo-1': [parent, hostChild, projectChild] }
+      worktreesByRepo: {
+        'repo-1': [parent, hostChild, projectChild],
+        'repo-2': [repoChild]
+      }
     })
 
-    expect(result.lineageChildrenByParentId.size).toBe(0)
+    expect(result.lineageChildrenByParentId.get(parent.id)?.map((worktree) => worktree.id)).toEqual(
+      [projectChild.id, repoChild.id]
+    )
   })
 
   it('does not attach cyclic legacy descendants', () => {

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
@@ -288,6 +288,8 @@ describe('DeleteWorktreeDialog lineage copy', () => {
       <DeleteWorktreeLineageNotice
         descendants={[child]}
         dirtyChangeCountsByWorktreeId={new Map()}
+        repoMap={new Map()}
+        targetRepoId={child.repoId}
       />
     )
 
@@ -295,6 +297,34 @@ describe('DeleteWorktreeDialog lineage copy', () => {
     expect(markup).toContain('mt-2 min-w-0 max-w-full space-y-1 overflow-hidden')
     expect(markup).toContain('min-w-0 overflow-hidden')
     expect(markup).toContain('truncate text-muted-foreground')
+  })
+
+  it('names the repo of a cross-repo descendant in the lineage notice', async () => {
+    const sameRepoChild = makeWorktree('same-repo-child', '/projects/orca/same-repo-child')
+    const crossRepoChild = {
+      ...makeWorktree('cross-repo-child', '/projects/baseline/cross-repo-child'),
+      repoId: 'repo-baseline'
+    }
+    const foreignRepo: Repo = {
+      id: 'repo-baseline',
+      path: '/projects/baseline',
+      displayName: 'baseline',
+      badgeColor: 'blue',
+      addedAt: 1
+    }
+    const { DeleteWorktreeLineageNotice } = await import('./DeleteWorktreeLineageNotice')
+
+    const markup = renderToStaticMarkup(
+      <DeleteWorktreeLineageNotice
+        descendants={[sameRepoChild, crossRepoChild]}
+        dirtyChangeCountsByWorktreeId={new Map()}
+        repoMap={new Map([[foreignRepo.id, foreignRepo]])}
+        targetRepoId={sameRepoChild.repoId}
+      />
+    )
+
+    expect(markup).toContain('baseline')
+    expect(markup.match(/truncate lowercase/g)).toHaveLength(1)
   })
 
   it('uses non-destructive disk copy for folder workspace deletes', async () => {

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -385,12 +385,12 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
           dirtyChangeCountsByWorktreeId={dirtyChangeCountsByWorktreeId}
         />
 
-        {hasLineageChildren && (
+        {hasLineageChildren && worktree && (
           <DeleteWorktreeLineageNotice
             descendants={lineageDelete.descendants}
             dirtyChangeCountsByWorktreeId={dirtyChangeCountsByWorktreeId}
             repoMap={repoMap}
-            targetRepoId={worktree?.repoId}
+            targetRepoId={worktree.repoId}
           />
         )}
 

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -389,6 +389,8 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
           <DeleteWorktreeLineageNotice
             descendants={lineageDelete.descendants}
             dirtyChangeCountsByWorktreeId={dirtyChangeCountsByWorktreeId}
+            repoMap={repoMap}
+            targetRepoId={worktree?.repoId}
           />
         )}
 

--- a/src/renderer/src/components/sidebar/DeleteWorktreeLineageNotice.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeLineageNotice.tsx
@@ -1,18 +1,24 @@
 import { Workflow } from 'lucide-react'
 import type { JSX } from 'react'
+import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
+import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
 import { DeleteWorktreeDirtyChangeHint } from './DeleteWorktreeDirtyChangeHint'
 import { translate } from '@/i18n/i18n'
 
 type DeleteWorktreeLineageNoticeProps = {
   descendants: readonly Worktree[]
   dirtyChangeCountsByWorktreeId: ReadonlyMap<string, number>
+  repoMap: ReadonlyMap<string, Repo>
+  targetRepoId: string | undefined
 }
 
 export function DeleteWorktreeLineageNotice({
   descendants,
-  dirtyChangeCountsByWorktreeId
+  dirtyChangeCountsByWorktreeId,
+  repoMap,
+  targetRepoId
 }: DeleteWorktreeLineageNoticeProps): JSX.Element | null {
   const childWorkspaceCount = descendants.length
   if (childWorkspaceCount === 0) {
@@ -45,17 +51,31 @@ export function DeleteWorktreeLineageNotice({
           {/* Why: long nowrap paths can otherwise give this grid child an
              intrinsic width wider than the modal. */}
           <div className="mt-2 min-w-0 max-w-full space-y-1 overflow-hidden rounded-sm border border-border/60 bg-background/60 px-2 py-1.5">
-            {descendants.slice(0, 4).map((child) => (
-              <div key={child.id} className="min-w-0 overflow-hidden">
-                <div className="truncate font-medium text-foreground">{child.displayName}</div>
-                <div className="truncate text-muted-foreground">{child.path}</div>
-                <DeleteWorktreeDirtyChangeHint
-                  changeCount={dirtyChangeCountsByWorktreeId.get(
-                    child.hostId ? getWorktreeHostIdentity(child) : child.id
-                  )}
-                />
-              </div>
-            ))}
+            {descendants.slice(0, 4).map((child) => {
+              const foreignRepo =
+                child.repoId === targetRepoId ? undefined : repoMap.get(child.repoId)
+              return (
+                <div key={child.id} className="min-w-0 overflow-hidden">
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <span className="truncate font-medium text-foreground">
+                      {child.displayName}
+                    </span>
+                    {foreignRepo ? (
+                      <span className="inline-flex min-w-0 max-w-[8rem] shrink-0 items-center gap-1 rounded border border-border bg-accent px-1.5 py-0.5 text-[10px] font-semibold text-foreground">
+                        <RepoBadgeMark color={foreignRepo.badgeColor} />
+                        <span className="truncate lowercase">{foreignRepo.displayName}</span>
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="truncate text-muted-foreground">{child.path}</div>
+                  <DeleteWorktreeDirtyChangeHint
+                    changeCount={dirtyChangeCountsByWorktreeId.get(
+                      child.hostId ? getWorktreeHostIdentity(child) : child.id
+                    )}
+                  />
+                </div>
+              )
+            })}
             {descendants.length > 4 ? (
               <div className="text-muted-foreground">
                 +{descendants.length - 4}{' '}

--- a/src/renderer/src/components/sidebar/DeleteWorktreeLineageNotice.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeLineageNotice.tsx
@@ -11,9 +11,10 @@ type DeleteWorktreeLineageNoticeProps = {
   descendants: readonly Worktree[]
   dirtyChangeCountsByWorktreeId: ReadonlyMap<string, number>
   repoMap: ReadonlyMap<string, Repo>
-  targetRepoId: string | undefined
+  targetRepoId: string
 }
 
+/** Summarizes descendants included in a cascade delete and labels foreign repositories. */
 export function DeleteWorktreeLineageNotice({
   descendants,
   dirtyChangeCountsByWorktreeId,

--- a/src/renderer/src/components/sidebar/WorktreeParentPickerPopover.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeParentPickerPopover.tsx
@@ -12,7 +12,7 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import { Command, CommandInput, CommandList } from '@/components/ui/command'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { useAppStore } from '@/store'
-import { useAllWorktrees, useRepoMap, useWorktreeMap } from '@/store/selectors'
+import { useAllWorktrees, useRepoMap, useRepoOwners, useWorktreeMap } from '@/store/selectors'
 import { cn } from '@/lib/utils'
 import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { useWorktreeActivityStatuses } from './use-worktree-activity-statuses'
@@ -139,6 +139,7 @@ export function WorktreeParentPickerPopover({
   const worktrees = useAllWorktrees()
   const worktreeMap = useWorktreeMap()
   const repoMap = useRepoMap()
+  const repoOwners = useRepoOwners()
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const lineageById = useAppStore((s) => s.worktreeLineageById)
   const assignWorktreeParent = useAppStore((s) => s.assignWorktreeParent)
@@ -161,10 +162,10 @@ export function WorktreeParentPickerPopover({
             worktrees,
             lineageById,
             worktreeMap,
-            repoMap
+            repoOwners
           })
         : [],
-    [child, lineageById, repoMap, worktreeMap, worktrees]
+    [child, lineageById, repoOwners, worktreeMap, worktrees]
   )
 
   useLayoutEffect(() => {

--- a/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts
@@ -236,9 +236,8 @@ describe('getFolderWorkspaceCardPrDisplay', () => {
 
   it.each([
     ['repository', { repoId: 'repo-2' }, {}],
-    ['known host', { hostId: 'ssh:remote' as const }, { hostId: 'local' as const }],
     ['known project', { projectId: 'project-b' }, { projectId: 'project-a' }]
-  ])('excludes nested PRs across a %s boundary', (_boundary, childOverrides, parentOverrides) => {
+  ])('includes nested PRs across a %s boundary', (_boundary, childOverrides, parentOverrides) => {
     const parent = makeWorktree({ id: 'parent', instanceId: 'parent', ...parentOverrides })
     const nested = makeWorktree({
       id: 'nested',
@@ -262,6 +261,31 @@ describe('getFolderWorkspaceCardPrDisplay', () => {
       ]),
       hostedReviewCache: null,
       prCache: { [`${nested.repoId}::nested`]: makePrEntry(4, 'success') }
+    })
+
+    expect(display).toMatchObject({ number: 4, status: 'success' })
+  })
+
+  it('excludes nested PRs across a known host boundary', () => {
+    const parent = makeWorktree({ id: 'parent', instanceId: 'parent', hostId: 'local' })
+    const nested = makeWorktree({
+      id: 'nested',
+      instanceId: 'nested',
+      linkedPR: 4,
+      hostId: 'ssh:remote'
+    })
+
+    const display = getFolderWorkspaceCardPrDisplay({
+      folderWorkspaceId: 'folder-1',
+      workspaceLineageByChildKey: { [parent.id]: makeWorkspaceLineage(parent) },
+      worktreeLineageById: { [nested.id]: makeWorktreeLineage(nested, parent) },
+      worktreeMap: new Map([
+        [parent.id, parent],
+        [nested.id, nested]
+      ]),
+      repoMap: new Map([[repo.id, repo]]),
+      hostedReviewCache: null,
+      prCache: { 'repo-1::nested': makePrEntry(4, 'success') }
     })
 
     expect(display).toBeNull()

--- a/src/renderer/src/components/sidebar/use-eligible-worktree-parent-count.ts
+++ b/src/renderer/src/components/sidebar/use-eligible-worktree-parent-count.ts
@@ -1,0 +1,31 @@
+import { useMemo } from 'react'
+import { useRepoOwners } from '@/store/selectors'
+import type { WorktreeLineage } from '../../../../shared/worktree/lineage-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { getEligibleWorktreeParents } from './worktree-parent-candidates'
+
+export function useEligibleWorktreeParentCount(args: {
+  child: Worktree
+  enabled: boolean
+  worktrees: readonly Worktree[]
+  lineageById: Record<string, WorktreeLineage>
+  worktreeMap: Map<string, Worktree>
+  cyclicLineageIds: ReadonlySet<string>
+}): number {
+  const { child, enabled, worktrees, lineageById, worktreeMap, cyclicLineageIds } = args
+  const repoOwners = useRepoOwners()
+  return useMemo(
+    () =>
+      enabled
+        ? getEligibleWorktreeParents({
+            child,
+            worktrees,
+            lineageById,
+            worktreeMap,
+            repoOwners,
+            cyclicLineageIds
+          }).length
+        : 0,
+    [child, cyclicLineageIds, enabled, lineageById, repoOwners, worktreeMap, worktrees]
+  )
+}

--- a/src/renderer/src/components/sidebar/use-worktree-context-menu-model.tsx
+++ b/src/renderer/src/components/sidebar/use-worktree-context-menu-model.tsx
@@ -7,7 +7,7 @@ import {
   getLineageRenderInfo
 } from './worktree-lineage-projection'
 import { getWorkspaceStatus } from './workspace-status'
-import { getEligibleWorktreeParents } from './worktree-parent-candidates'
+import { useEligibleWorktreeParentCount } from './use-eligible-worktree-parent-count'
 import {
   hasSleepableWorkspaceActivity,
   useWorkspaceLineageMenuActions
@@ -210,20 +210,14 @@ export function useWorktreeContextMenuModel({
   const hasAnyContextLineage = activeContextWorktrees.some((item) =>
     hasWorktreeParentLink(item, worktreeLineageById, workspaceLineageByChildKey)
   )
-  const eligibleParentCount = useMemo(
-    () =>
-      menuOpen
-        ? getEligibleWorktreeParents({
-            child: worktree,
-            worktrees: allWorktrees,
-            lineageById: worktreeLineageById,
-            worktreeMap,
-            repoMap,
-            cyclicLineageIds
-          }).length
-        : 0,
-    [allWorktrees, cyclicLineageIds, menuOpen, repoMap, worktree, worktreeLineageById, worktreeMap]
-  )
+  const eligibleParentCount = useEligibleWorktreeParentCount({
+    child: worktree,
+    enabled: menuOpen,
+    worktrees: allWorktrees,
+    lineageById: worktreeLineageById,
+    worktreeMap,
+    cyclicLineageIds
+  })
 
   const setMenuOpenState = useCallback(
     (open: boolean) => {

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -855,7 +855,7 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([parent.id, child.id])
   })
 
-  it('does not include a cross-repo parent when repo filtering leaves the child visible', () => {
+  it('includes a cross-repo parent when repo filtering leaves the child visible', () => {
     const parent = makeWorktree('parent', 'repo1')
     const child = makeWorktree('child', 'repo2')
     const lineage = makeWorktreeLineage(child, parent)
@@ -869,7 +869,7 @@ describe('computeVisibleWorktreeIds', () => {
       })
     )
 
-    expect(result).toEqual([child.id])
+    expect(result).toEqual([parent.id, child.id])
   })
 
   it('does not include a known cross-host parent after host filtering', () => {
@@ -889,7 +889,7 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([child.id])
   })
 
-  it('does not include a known cross-project parent hidden by another filter', () => {
+  it('includes a known cross-project parent hidden by another filter', () => {
     const parent = Object.assign(makeWorktree('parent'), {
       projectId: 'project-b',
       isMainWorktree: true
@@ -906,6 +906,6 @@ describe('computeVisibleWorktreeIds', () => {
       })
     )
 
-    expect(result).toEqual([child.id])
+    expect(result).toEqual([parent.id, child.id])
   })
 })

--- a/src/renderer/src/components/sidebar/workspace-delete-lineage.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-delete-lineage.test.ts
@@ -106,28 +106,40 @@ describe('getWorkspaceDeleteLineage', () => {
     expect(lineage.deleteAllTargets).toEqual([parent])
   })
 
-  it('rejects cross-repo, cross-host, and cross-project descendants', () => {
+  it('rejects cross-host descendants but keeps cross-repo and cross-project ones', () => {
     const parent: Worktree = {
       ...makeWorktree('parent', '/workspaces/parent'),
       hostId: LOCAL_EXECUTION_HOST_ID,
       projectId: 'project-1'
     }
-    const children: Worktree[] = [
-      { ...makeWorktree('repo-child', '/workspaces/repo-child'), repoId: 'repo-2' },
-      {
-        ...makeWorktree('host-child', '/workspaces/host-child'),
-        hostId: toSshExecutionHostId('other')
-      },
-      { ...makeWorktree('project-child', '/workspaces/project-child'), projectId: 'project-2' }
-    ]
+    const repoChild: Worktree = {
+      ...makeWorktree('repo-child', '/workspaces/repo-child'),
+      repoId: 'repo-2'
+    }
+    const hostChild: Worktree = {
+      ...makeWorktree('host-child', '/workspaces/host-child'),
+      hostId: toSshExecutionHostId('other')
+    }
+    const projectChild: Worktree = {
+      ...makeWorktree('project-child', '/workspaces/project-child'),
+      projectId: 'project-2'
+    }
+    const children = [repoChild, hostChild, projectChild]
     const lineageById = Object.fromEntries(
       children.map((child) => [child.id, makeLineage(child, parent)])
     )
 
     const lineage = getWorkspaceDeleteLineage(parent, [parent, ...children], lineageById)
 
-    expect(lineage.descendants).toEqual([])
-    expect(lineage.deleteAllTargets).toEqual([parent])
+    expect(lineage.descendants.map((worktree) => worktree.id)).toEqual([
+      repoChild.id,
+      projectChild.id
+    ])
+    expect(lineage.deleteAllTargets.map((worktree) => worktree.id)).toEqual([
+      repoChild.id,
+      projectChild.id,
+      parent.id
+    ])
   })
 
   it('does not traverse cyclic projected lineage', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-groups-lineage-nesting.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups-lineage-nesting.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { buildRows } from './worktree-list/grouping/build-rows'
 import { getLineageGroupKey, getWorktreeLineageGroupKey } from './worktree-list/grouping/group-keys'
 import { getLineageRenderInfo, getWorktreeLineageAncestors } from './worktree-lineage-projection'
-import { worktree, repoMap } from './worktree-list-groups-test-fixtures'
+import { repo, worktree, repoMap } from './worktree-list-groups-test-fixtures'
+import type { Repo } from '../../../../shared/repo-types'
 import type { WorktreeLineage } from '../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 
@@ -317,17 +318,12 @@ describe('buildRows workspace lineage nesting', () => {
     expect(rows.find((row) => row.type === 'item')).toMatchObject({ depth: 0 })
   })
 
-  it.each([
-    ['repo', { repoId: 'other-repo' }],
-    ['host', { hostId: 'ssh:other-host' as const }],
-    ['project', { projectId: 'github:other/project' }]
-  ])('does not nest resolved lineage across a known %s boundary', (_label, boundary) => {
+  it('does not nest resolved lineage across a known host boundary', () => {
     const boundedParent = {
       ...parent,
       repoId: 'repo-1',
-      hostId: 'local' as const,
-      projectId: 'github:stablyai/orca',
-      ...boundary
+      hostId: 'ssh:other-host' as const,
+      projectId: 'github:stablyai/orca'
     }
     const boundedChild: ResolvedLineageWorktree = {
       ...child,
@@ -354,6 +350,91 @@ describe('buildRows workspace lineage nesting', () => {
     )
 
     expect(rows.filter((row) => row.type === 'item').map((row) => row.depth)).toEqual([0, 0])
+  })
+
+  it.each([
+    ['repository', { repoId: 'repo-2' }],
+    ['project', { projectId: 'github:other/project' }]
+  ])('nests resolved lineage across a %s boundary on the same host', (_label, boundary) => {
+    const boundedParent = {
+      ...parent,
+      repoId: 'repo-1',
+      hostId: 'local' as const,
+      projectId: 'github:stablyai/orca'
+    }
+    const boundedChild: ResolvedLineageWorktree = {
+      ...child,
+      repoId: 'repo-1',
+      hostId: 'local' as const,
+      projectId: 'github:stablyai/orca',
+      lineage,
+      ...boundary
+    }
+    const otherRepo: Repo = { ...repo, id: boundedChild.repoId }
+    const boundedRepoMap = new Map([...repoMap, [otherRepo.id, otherRepo] as const])
+    const rows = buildRows(
+      'none',
+      [boundedChild, boundedParent],
+      boundedRepoMap,
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map<string, Worktree>([
+        [boundedParent.id, boundedParent],
+        [boundedChild.id, boundedChild]
+      ]),
+      true
+    )
+
+    expect(
+      rows.filter((row) => row.type === 'item').map((row) => [row.worktree.id, row.depth])
+    ).toEqual([
+      [boundedParent.id, 0],
+      [boundedChild.id, 1]
+    ])
+  })
+
+  it('nests a cross-repo child under its parent inside a shared status section', () => {
+    const otherRepo: Repo = { ...repo, id: 'repo-2', displayName: 'baseline' }
+    const crossRepoChild: ResolvedLineageWorktree = {
+      ...child,
+      repoId: otherRepo.id,
+      path: '/tmp/baseline/worker',
+      lineage
+    }
+    const rows = buildRows(
+      'workspace-status',
+      [crossRepoChild, parent],
+      new Map([
+        [repo.id, repo],
+        [otherRepo.id, otherRepo]
+      ]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      { [crossRepoChild.id]: lineage },
+      new Map<string, Worktree>([
+        [parent.id, parent],
+        [crossRepoChild.id, crossRepoChild]
+      ]),
+      true
+    )
+
+    const sectionKeys = new Set(
+      rows.filter((row) => row.type === 'item').map((row) => row.sectionKey)
+    )
+    expect(sectionKeys.size).toBe(1)
+    expect(
+      rows.filter((row) => row.type === 'item').map((row) => [row.worktree.id, row.depth])
+    ).toEqual([
+      [parent.id, 0],
+      [crossRepoChild.id, 1]
+    ])
   })
 
   it('keeps the hydrated lineage side-map authoritative when inline metadata disagrees', () => {

--- a/src/renderer/src/components/sidebar/worktree-list/drag/use-lineage-drop-commit.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/drag/use-lineage-drop-commit.ts
@@ -16,12 +16,12 @@ export type WorktreeLineageDropCommit = ReturnType<typeof useWorktreeLineageDrop
 
 // Nesting and un-nesting are the two lineage mutations a sidebar drag can commit.
 export function useWorktreeLineageDropCommit(args: {
-  repoMap: Map<string, Repo>
+  repoOwners: ReadonlyMap<string, readonly Repo[]>
   worktreeMap: Map<string, Worktree>
   worktreeLineageById: Record<string, WorktreeLineage>
   worktreeDragGroups: readonly WorktreeDragGroup[]
 }) {
-  const { repoMap, worktreeMap, worktreeLineageById, worktreeDragGroups } = args
+  const { repoOwners, worktreeMap, worktreeLineageById, worktreeDragGroups } = args
   const assignWorktreeParent = useAppStore((s) => s.assignWorktreeParent)
   const updateWorktreeLineage = useAppStore((s) => s.updateWorktreeLineage)
   const cyclicLineageIds = useMemo(
@@ -51,14 +51,14 @@ export function useWorktreeLineageDropCommit(args: {
             candidateParent,
             lineageById: worktreeLineageById,
             worktreeMap,
-            repoMap,
+            repoOwners,
             cyclicLineageIds
           })
         )
       })
       return canAssignAll ? target : { ...target, lineageParentId: null }
     },
-    [cyclicLineageIds, repoMap, worktreeLineageById, worktreeMap]
+    [cyclicLineageIds, repoOwners, worktreeLineageById, worktreeMap]
   )
 
   const commitWorktreeLineageParentDrop = useCallback(

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/VirtualizedWorktreeViewport.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/VirtualizedWorktreeViewport.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
+import { useRepoOwners } from '@/store/selectors'
 import { translate } from '@/i18n/i18n'
 import { WorktreeListScrollToTopButton } from '../../WorktreeListScrollToTopButton'
 import { renderWorktreeSidebarDropIndicators } from './drop-indicators'
@@ -56,6 +57,7 @@ export const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktr
   // Why: callback-ref only mutates scrollRef; state re-runs the scroll-to-top listener attach.
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null)
   const settings = useAppStore((s) => s.settings)
+  const repoOwners = useRepoOwners()
   const worktreeVisibilityDefaultsByHost = useAppStore((s) => s.worktreeVisibilityDefaultsByHost)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const newCardStyle = settings?.experimentalNewWorktreeCardStyle === true
@@ -97,7 +99,7 @@ export const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktr
 
   const session = useWorktreeDragSession({ rows, scrollRef })
   const lineageDrop = useWorktreeLineageDropCommit({
-    repoMap,
+    repoOwners,
     worktreeMap,
     worktreeLineageById,
     worktreeDragGroups: session.worktreeDragGroups

--- a/src/renderer/src/components/sidebar/worktree-parent-candidates.ts
+++ b/src/renderer/src/components/sidebar/worktree-parent-candidates.ts
@@ -1,4 +1,5 @@
 import { getWorktreeExecutionHostId } from '../../../../shared/execution-host'
+import { sharesResolvedWorktreeLineageBoundary } from '../../../../shared/resolved-worktree-lineage'
 import type { Repo } from '../../../../shared/repo-types'
 import type { WorktreeLineage } from '../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../shared/worktree/types'
@@ -59,12 +60,9 @@ export function isEligibleWorktreeParent({
   childHostId?: string | null
 }): boolean {
   return (
-    candidateParent.repoId === child.repoId &&
+    sharesResolvedWorktreeLineageBoundary(child, candidateParent) &&
     childHostId !== null &&
     getWorktreeOwnerHostId(candidateParent, repoMap) === childHostId &&
-    (child.projectId === undefined ||
-      candidateParent.projectId === undefined ||
-      child.projectId === candidateParent.projectId) &&
     !candidateParent.isArchived &&
     canAssignWorktreeParent({
       child,

--- a/src/renderer/src/components/sidebar/worktree-parent-candidates.ts
+++ b/src/renderer/src/components/sidebar/worktree-parent-candidates.ts
@@ -1,5 +1,4 @@
 import { getWorktreeExecutionHostId } from '../../../../shared/execution-host'
-import { sharesResolvedWorktreeLineageBoundary } from '../../../../shared/resolved-worktree-lineage'
 import type { Repo } from '../../../../shared/repo-types'
 import type { WorktreeLineage } from '../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../shared/worktree/types'
@@ -62,7 +61,6 @@ export function isEligibleWorktreeParent({
   childHostId?: string | null
 }): boolean {
   return (
-    sharesResolvedWorktreeLineageBoundary(child, candidateParent) &&
     childHostId !== null &&
     getWorktreeOwnerHostId(candidateParent, repoMap) === childHostId &&
     !candidateParent.isArchived &&

--- a/src/renderer/src/components/sidebar/worktree-parent-candidates.ts
+++ b/src/renderer/src/components/sidebar/worktree-parent-candidates.ts
@@ -10,16 +10,19 @@ type ParentCandidateArgs = {
   worktrees: readonly Worktree[]
   lineageById: Record<string, WorktreeLineage>
   worktreeMap: Map<string, Worktree>
-  repoMap: Map<string, Pick<Repo, 'connectionId' | 'executionHostId'>>
+  repoOwners: ReadonlyMap<string, readonly Pick<Repo, 'connectionId' | 'executionHostId'>[]>
   cyclicLineageIds?: ReadonlySet<string>
 }
 
 function getWorktreeOwnerHostId(
   worktree: Worktree,
-  repoMap: Map<string, Pick<Repo, 'connectionId' | 'executionHostId'>>
+  repoOwners: ParentCandidateArgs['repoOwners']
 ): string | null {
-  const repo = repoMap.get(worktree.repoId)
-  return repo ? getWorktreeExecutionHostId(worktree, repo) : (worktree.hostId ?? null)
+  if (worktree.hostId !== undefined) {
+    return worktree.hostId
+  }
+  const owners = repoOwners.get(worktree.repoId) ?? []
+  return owners.length === 1 ? getWorktreeExecutionHostId(worktree, owners[0]) : null
 }
 
 /** Lists valid parent targets within the child's effective execution-host boundary. */
@@ -28,10 +31,10 @@ export function getEligibleWorktreeParents({
   worktrees,
   lineageById,
   worktreeMap,
-  repoMap,
+  repoOwners,
   cyclicLineageIds: precomputedCyclicLineageIds
 }: ParentCandidateArgs): Worktree[] {
-  const childHostId = getWorktreeOwnerHostId(child, repoMap)
+  const childHostId = getWorktreeOwnerHostId(child, repoOwners)
   const cyclicLineageIds =
     precomputedCyclicLineageIds ?? getCyclicProjectedWorktreeLineageIds(lineageById, worktreeMap)
   return worktrees.filter((candidate) =>
@@ -40,7 +43,7 @@ export function getEligibleWorktreeParents({
       candidateParent: candidate,
       lineageById,
       worktreeMap,
-      repoMap,
+      repoOwners,
       cyclicLineageIds,
       childHostId
     })
@@ -53,16 +56,16 @@ export function isEligibleWorktreeParent({
   candidateParent,
   lineageById,
   worktreeMap,
-  repoMap,
+  repoOwners,
   cyclicLineageIds,
-  childHostId = getWorktreeOwnerHostId(child, repoMap)
+  childHostId = getWorktreeOwnerHostId(child, repoOwners)
 }: Omit<ParentCandidateArgs, 'worktrees'> & {
   candidateParent: Worktree
   childHostId?: string | null
 }): boolean {
   return (
     childHostId !== null &&
-    getWorktreeOwnerHostId(candidateParent, repoMap) === childHostId &&
+    getWorktreeOwnerHostId(candidateParent, repoOwners) === childHostId &&
     !candidateParent.isArchived &&
     canAssignWorktreeParent({
       child,

--- a/src/renderer/src/components/sidebar/worktree-parent-candidates.ts
+++ b/src/renderer/src/components/sidebar/worktree-parent-candidates.ts
@@ -23,6 +23,7 @@ function getWorktreeOwnerHostId(
   return repo ? getWorktreeExecutionHostId(worktree, repo) : (worktree.hostId ?? null)
 }
 
+/** Lists valid parent targets within the child's effective execution-host boundary. */
 export function getEligibleWorktreeParents({
   child,
   worktrees,
@@ -47,6 +48,7 @@ export function getEligibleWorktreeParents({
   )
 }
 
+/** Whether one candidate can become the child's parent without violating lineage invariants. */
 export function isEligibleWorktreeParent({
   child,
   candidateParent,

--- a/src/renderer/src/components/sidebar/worktree-parent-eligibility.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-parent-eligibility.test.ts
@@ -161,7 +161,7 @@ describe('canAssignWorktreeParent', () => {
     ).toBe(false)
   })
 
-  it('stays repo-agnostic while the picker candidate filter is repo and host scoped', () => {
+  it('offers a cross-repo candidate on the same host to the picker', () => {
     const child = makeWorktree('child', 'repo-a')
     const sameRepo = makeWorktree('same-repo', 'repo-a')
     const otherRepo = makeWorktree('other-repo', 'repo-b')
@@ -186,7 +186,26 @@ describe('canAssignWorktreeParent', () => {
           { id: 'repo-b', connectionId: null, executionHostId: 'local' }
         ])
       }).map((worktree) => worktree.id)
-    ).toEqual([sameRepo.id])
+    ).toEqual([sameRepo.id, otherRepo.id])
+  })
+
+  it('excludes a cross-repo candidate whose repo runs on another host', () => {
+    const child = makeWorktree('child', 'repo-a')
+    const otherRepo = makeWorktree('other-repo', 'repo-b')
+    const worktrees = [child, otherRepo]
+
+    expect(
+      getEligibleWorktreeParents({
+        child,
+        worktrees,
+        lineageById: {},
+        worktreeMap: makeMap(worktrees),
+        repoMap: makeRepoMap([
+          { id: 'repo-a', connectionId: null, executionHostId: 'local' },
+          { id: 'repo-b', connectionId: null, executionHostId: 'ssh:remote' }
+        ])
+      })
+    ).toEqual([])
   })
 
   it('excludes same-repo candidates owned by a different runtime host', () => {
@@ -211,7 +230,7 @@ describe('canAssignWorktreeParent', () => {
     ).toEqual([sameHost.id])
   })
 
-  it('excludes a candidate across a known project boundary for picker and direct drop checks', () => {
+  it('offers a candidate across a known project boundary for picker and direct drop checks', () => {
     const child = { ...makeWorktree('child'), projectId: 'project-a' }
     const sameProject = { ...makeWorktree('same-project'), projectId: 'project-a' }
     const otherProject = { ...makeWorktree('other-project'), projectId: 'project-b' }
@@ -227,11 +246,38 @@ describe('canAssignWorktreeParent', () => {
         worktreeMap,
         repoMap
       }).map((worktree) => worktree.id)
-    ).toEqual([sameProject.id])
+    ).toEqual([sameProject.id, otherProject.id])
     expect(
       isEligibleWorktreeParent({
         child,
         candidateParent: otherProject,
+        lineageById: {},
+        worktreeMap,
+        repoMap
+      })
+    ).toBe(true)
+  })
+
+  it('excludes a candidate across a known host boundary for picker and direct drop checks', () => {
+    const child = { ...makeWorktree('child'), hostId: 'local' as const }
+    const otherHost = { ...makeWorktree('other-host'), hostId: 'ssh:remote' as const }
+    const worktrees = [child, otherHost]
+    const worktreeMap = makeMap(worktrees)
+    const repoMap = makeRepoMap()
+
+    expect(
+      getEligibleWorktreeParents({
+        child,
+        worktrees,
+        lineageById: {},
+        worktreeMap,
+        repoMap
+      })
+    ).toEqual([])
+    expect(
+      isEligibleWorktreeParent({
+        child,
+        candidateParent: otherHost,
         lineageById: {},
         worktreeMap,
         repoMap

--- a/src/renderer/src/components/sidebar/worktree-parent-eligibility.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-parent-eligibility.test.ts
@@ -46,12 +46,16 @@ function makeMap(worktrees: readonly Worktree[]): Map<string, Worktree> {
   return new Map(worktrees.map((worktree) => [worktree.id, worktree]))
 }
 
-function makeRepoMap(
+function makeRepoOwners(
   repos: readonly Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>[] = [
     { id: 'repo', connectionId: null, executionHostId: 'local' }
   ]
-): Map<string, Pick<Repo, 'connectionId' | 'executionHostId'>> {
-  return new Map(repos.map((repo) => [repo.id, repo]))
+): Map<string, Pick<Repo, 'connectionId' | 'executionHostId'>[]> {
+  const owners = new Map<string, Pick<Repo, 'connectionId' | 'executionHostId'>[]>()
+  for (const repo of repos) {
+    owners.set(repo.id, [...(owners.get(repo.id) ?? []), repo])
+  }
+  return owners
 }
 
 describe('canAssignWorktreeParent', () => {
@@ -181,7 +185,7 @@ describe('canAssignWorktreeParent', () => {
         worktrees,
         lineageById: {},
         worktreeMap: makeMap(worktrees),
-        repoMap: makeRepoMap([
+        repoOwners: makeRepoOwners([
           { id: 'repo-a', connectionId: null, executionHostId: 'local' },
           { id: 'repo-b', connectionId: null, executionHostId: 'local' }
         ])
@@ -200,7 +204,7 @@ describe('canAssignWorktreeParent', () => {
         worktrees,
         lineageById: {},
         worktreeMap: makeMap(worktrees),
-        repoMap: makeRepoMap([
+        repoOwners: makeRepoOwners([
           { id: 'repo-a', connectionId: null, executionHostId: 'local' },
           { id: 'repo-b', connectionId: null, executionHostId: 'ssh:remote' }
         ])
@@ -223,11 +227,57 @@ describe('canAssignWorktreeParent', () => {
         worktrees,
         lineageById: {},
         worktreeMap: makeMap(worktrees),
-        repoMap: makeRepoMap([
+        repoOwners: makeRepoOwners([
           { id: 'repo-a', connectionId: null, executionHostId: 'runtime:env-a' }
         ])
       }).map((worktree) => worktree.id)
     ).toEqual([sameHost.id])
+  })
+
+  it('fails closed for unstamped worktrees with duplicate repo owners', () => {
+    const child = makeWorktree('child', 'repo-a')
+    const candidate = makeWorktree('candidate', 'repo-b')
+    const worktrees = [child, candidate]
+    const repoOwners = makeRepoOwners([
+      { id: 'repo-a', connectionId: null, executionHostId: 'local' },
+      { id: 'repo-a', connectionId: null, executionHostId: 'runtime:env-a' },
+      { id: 'repo-b', connectionId: null, executionHostId: 'local' },
+      { id: 'repo-b', connectionId: null, executionHostId: 'runtime:env-b' }
+    ])
+
+    candidate.hostId = 'local'
+    expect(
+      getEligibleWorktreeParents({
+        child,
+        worktrees,
+        lineageById: {},
+        worktreeMap: makeMap(worktrees),
+        repoOwners
+      })
+    ).toEqual([])
+
+    child.hostId = 'local'
+    candidate.hostId = undefined
+    expect(
+      getEligibleWorktreeParents({
+        child,
+        worktrees,
+        lineageById: {},
+        worktreeMap: makeMap(worktrees),
+        repoOwners
+      })
+    ).toEqual([])
+
+    candidate.hostId = 'local'
+    expect(
+      getEligibleWorktreeParents({
+        child,
+        worktrees,
+        lineageById: {},
+        worktreeMap: makeMap(worktrees),
+        repoOwners
+      })
+    ).toEqual([candidate])
   })
 
   it('offers a candidate across a known project boundary for picker and direct drop checks', () => {
@@ -236,7 +286,7 @@ describe('canAssignWorktreeParent', () => {
     const otherProject = { ...makeWorktree('other-project'), projectId: 'project-b' }
     const worktrees = [child, sameProject, otherProject]
     const worktreeMap = makeMap(worktrees)
-    const repoMap = makeRepoMap()
+    const repoOwners = makeRepoOwners()
 
     expect(
       getEligibleWorktreeParents({
@@ -244,7 +294,7 @@ describe('canAssignWorktreeParent', () => {
         worktrees,
         lineageById: {},
         worktreeMap,
-        repoMap
+        repoOwners
       }).map((worktree) => worktree.id)
     ).toEqual([sameProject.id, otherProject.id])
     expect(
@@ -253,7 +303,7 @@ describe('canAssignWorktreeParent', () => {
         candidateParent: otherProject,
         lineageById: {},
         worktreeMap,
-        repoMap
+        repoOwners
       })
     ).toBe(true)
   })
@@ -263,7 +313,7 @@ describe('canAssignWorktreeParent', () => {
     const otherHost = { ...makeWorktree('other-host'), hostId: 'ssh:remote' as const }
     const worktrees = [child, otherHost]
     const worktreeMap = makeMap(worktrees)
-    const repoMap = makeRepoMap()
+    const repoOwners = makeRepoOwners()
 
     expect(
       getEligibleWorktreeParents({
@@ -271,7 +321,7 @@ describe('canAssignWorktreeParent', () => {
         worktrees,
         lineageById: {},
         worktreeMap,
-        repoMap
+        repoOwners
       })
     ).toEqual([])
     expect(
@@ -280,7 +330,7 @@ describe('canAssignWorktreeParent', () => {
         candidateParent: otherHost,
         lineageById: {},
         worktreeMap,
-        repoMap
+        repoOwners
       })
     ).toBe(false)
   })
@@ -297,7 +347,7 @@ describe('canAssignWorktreeParent', () => {
         worktrees: [child, archived, visible],
         lineageById: {},
         worktreeMap: makeMap([child, archived, visible]),
-        repoMap: makeRepoMap()
+        repoOwners: makeRepoOwners()
       }).map((worktree) => worktree.id)
     ).toEqual([visible.id])
   })

--- a/src/renderer/src/hooks/composer-state/composer-store-actions.ts
+++ b/src/renderer/src/hooks/composer-state/composer-store-actions.ts
@@ -51,6 +51,7 @@ export type ComposerStoreActions = {
     compareBaseRef?: string,
     options?: {
       automationProvenanceRequest?: CreateWorktreeArgs['automationProvenanceRequest']
+      executionHostId?: ExecutionHostId
       linkedWorkItem?: WorkspaceLinkedItem | null
       linkedTaskSourceContext?: TaskSourceContext | null
       startupDraft?: string

--- a/src/renderer/src/hooks/composer-state/full-creation-execution.ts
+++ b/src/renderer/src/hooks/composer-state/full-creation-execution.ts
@@ -184,6 +184,7 @@ export function useFullCreationExecution(input: FullCreationExecutionInput) {
         undefined,
         submitCompareBaseRef,
         {
+          ...(selectedRepoExecutionHostId ? { executionHostId: selectedRepoExecutionHostId } : {}),
           linkedWorkItem: toFolderWorkspaceLinkedTask(submitLinkedWorkItem),
           linkedTaskSourceContext: taskSourceContext,
           nameWasGenerated,

--- a/src/renderer/src/hooks/composer-state/quick-creation-execution.ts
+++ b/src/renderer/src/hooks/composer-state/quick-creation-execution.ts
@@ -220,6 +220,7 @@ export function useQuickCreationExecution(input: QuickCreationExecutionInput) {
 
       const request = buildQuickCreationRequest({
         repoId,
+        executionHostId: selectedRepoExecutionHostId,
         ephemeralVmRecipe,
         indeterminateProgress:
           Boolean(activeEphemeralVmRecipeId) ||

--- a/src/renderer/src/hooks/composer-state/quick-creation-request.test.ts
+++ b/src/renderer/src/hooks/composer-state/quick-creation-request.test.ts
@@ -6,6 +6,7 @@ function createInput(
 ): QuickCreationRequestInput {
   return {
     repoId: 'repo-1',
+    executionHostId: null,
     ephemeralVmRecipe: undefined,
     indeterminateProgress: false,
     taskSourceContext: null,
@@ -73,6 +74,7 @@ describe('quick composer creation request', () => {
   it('keeps provider, branch, sparse, runtime, and startup fields in the quick wire payload', () => {
     const request = buildQuickCreationRequest(
       createInput({
+        executionHostId: 'runtime:env-1',
         indeterminateProgress: true,
         nameWasGenerated: true,
         displayName: 'Characterize request',
@@ -98,6 +100,7 @@ describe('quick composer creation request', () => {
     )
 
     expect(request).toMatchObject({
+      executionHostId: 'runtime:env-1',
       worktreeCreateProgressMode: 'indeterminate',
       nameWasGenerated: true,
       displayName: 'Characterize request',

--- a/src/renderer/src/hooks/composer-state/quick-creation-request.ts
+++ b/src/renderer/src/hooks/composer-state/quick-creation-request.ts
@@ -6,10 +6,12 @@ import type { TaskSourceContext } from '../../../../shared/task-source-context'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { GitPushTarget } from '../../../../shared/worktree/types'
 import type { SetupDecision } from '../../../../shared/worktree/create-types'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import { toFolderWorkspaceLinkedTask } from '@/components/sidebar/folder-workspace-composer-helpers'
 
 export type QuickCreationRequestInput = {
   repoId: string
+  executionHostId: ExecutionHostId | null
   ephemeralVmRecipe: WorktreeCreationRequest['ephemeralVmRecipe']
   indeterminateProgress: boolean
   taskSourceContext: TaskSourceContext | null
@@ -56,6 +58,7 @@ export function buildQuickCreationRequest(
 ): WorktreeCreationRequest {
   return {
     repoId: input.repoId,
+    ...(input.executionHostId ? { executionHostId: input.executionHostId } : {}),
     ...(input.ephemeralVmRecipe ? { ephemeralVmRecipe: input.ephemeralVmRecipe } : {}),
     worktreeCreateProgressMode: input.indeterminateProgress ? 'indeterminate' : 'stepped',
     ...(input.taskSourceContext ? { taskSourceContext: input.taskSourceContext } : {}),

--- a/src/renderer/src/lib/ephemeral-vm-worktree-creation.ts
+++ b/src/renderer/src/lib/ephemeral-vm-worktree-creation.ts
@@ -74,6 +74,7 @@ export async function prepareRequestForCreate(
   const preparedRequest: WorktreeCreationRequest = {
     ...request,
     repoId: preparedTarget.setup.repo.id,
+    executionHostId: preparedTarget.setup.setup.hostId,
     ...(preparedTarget.checkoutMode === 'provisioned-root'
       ? { baseBranch: request.baseBranch, compareBaseRef: request.compareBaseRef }
       : getEphemeralVmPortableBaseSelection(request)),

--- a/src/renderer/src/lib/pending-worktree-creation.ts
+++ b/src/renderer/src/lib/pending-worktree-creation.ts
@@ -14,6 +14,7 @@ import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
 import type { AgentStartedTelemetry } from '@/lib/worktree-startup-payload'
 import type { TaskSourceContext, WorkspaceRunContext } from '../../../shared/task-source-context'
 import type { AgentLaunchRoute } from '@/lib/agent-launch-routing'
+import type { ExecutionHostId } from '../../../shared/execution-host'
 
 /** Two-phase status reported by the main process while a worktree is created.
  *  `preparing` covers renderer-side preflight before `createWorktree` starts;
@@ -33,6 +34,8 @@ export type WorktreeCreationProgressMode = 'stepped' | 'indeterminate'
  */
 export type WorktreeCreationRequest = {
   repoId: string
+  /** Host selected with the repo. Retained across background retries and focus changes. */
+  executionHostId?: ExecutionHostId
   /** Source host/account that produced the linked task. Kept separate from the
    *  run context so Retry does not infer provider ownership from the run host. */
   taskSourceContext?: TaskSourceContext | null

--- a/src/renderer/src/lib/worktree-creation-flow-execute.ts
+++ b/src/renderer/src/lib/worktree-creation-flow-execute.ts
@@ -85,6 +85,9 @@ export async function executeWorktreeCreation(
         preparedRequest.linkedGiteaPR,
         preparedRequest.compareBaseRef,
         {
+          ...(preparedRequest.executionHostId
+            ? { executionHostId: preparedRequest.executionHostId }
+            : {}),
           ...(preparedRequest.nameWasGenerated ? { nameWasGenerated: true } : {}),
           ...(preparedRequest.displayNameKind
             ? { displayNameKind: preparedRequest.displayNameKind }

--- a/src/renderer/src/store/selectors.ts
+++ b/src/renderer/src/store/selectors.ts
@@ -14,6 +14,7 @@ import { getProjectHostSetupProjectionFromState } from './project-host-setup-sel
 import {
   getIndexedAllWorktrees as getCachedAllWorktrees,
   getIndexedRepoMap as getCachedRepoMap,
+  getIndexedRepoOwners as getCachedRepoOwners,
   getIndexedWorktreeMap as getCachedWorktreeMap,
   getIndexedWorktreesById as getCachedWorktreesById
 } from './worktree-repo-index'
@@ -227,6 +228,7 @@ export const useRepos = () => useAppStore((s) => s.repos)
 export const useActiveRepo = () =>
   useAppStore(useShallow((s) => selectRepoByIdForActiveWorkspace(s, s.activeRepoId)))
 export const useRepoMap = () => useAppStore((s) => getCachedRepoMap(s.repos))
+export const useRepoOwners = () => useAppStore((s) => getCachedRepoOwners(s.repos))
 
 type ActiveWorkspaceRepoState = Pick<
   AppState,

--- a/src/renderer/src/store/slices/worktrees-create-parent-pick.test.ts
+++ b/src/renderer/src/store/slices/worktrees-create-parent-pick.test.ts
@@ -403,6 +403,53 @@ describe('createWorktree parent pick on a remote runtime', () => {
     expect(toast.warning).not.toHaveBeenCalled()
   })
 
+  it('uses the selected host for duplicate repo ownership and parent validation', async () => {
+    const store = createRemoteStore()
+    const remoteOwner = store.getState().repos[0]!
+    store.setState({
+      repos: [makeRepo(REMOTE_REPO, 'local'), remoteOwner],
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      worktreesByRepo: {
+        [REMOTE_REPO]: [
+          makeWorktree({
+            id: PARENT_ID,
+            repoId: REMOTE_REPO,
+            path: '/remote/parent',
+            displayName: 'parent-wt',
+            instanceId: 'parent-instance',
+            hostId: 'runtime:env-1'
+          })
+        ]
+      }
+    } as Partial<AppState>)
+    mockRuntimeCreate((id) => ({
+      id,
+      ok: true,
+      result: {
+        worktree: makeWorktree({
+          id: `${REMOTE_REPO}::/remote/child`,
+          repoId: REMOTE_REPO,
+          path: '/remote/child'
+        }),
+        lineage: makeLineage({
+          worktreeId: `${REMOTE_REPO}::/remote/child`,
+          parentWorktreeId: PARENT_ID
+        })
+      }
+    }))
+    const createWorktree = store.getState().createWorktree
+    const args: Parameters<typeof createWorktree> = [REMOTE_REPO, 'feature', 'origin/main']
+    args[25] = { parentWorktreeId: PARENT_ID, executionHostId: 'runtime:env-1' }
+
+    await createWorktree(...args)
+
+    expect(createCalls()[0]?.params).toMatchObject({
+      parentWorkspace: worktreeWorkspaceKey(PARENT_ID)
+    })
+    expect(mockApi.worktrees.create).not.toHaveBeenCalled()
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+
   it('retries without the parent and warns when the host no longer has it', async () => {
     mockRuntimeCreate((id) => ({
       id,

--- a/src/renderer/src/store/slices/worktrees-create-parent-pick.test.ts
+++ b/src/renderer/src/store/slices/worktrees-create-parent-pick.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AppState } from '../types'
+import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { toast } from 'sonner'
 import type { RuntimeEnvironmentCallRequest } from '../../runtime/runtime-compatibility-test-fixture'
@@ -29,6 +30,18 @@ vi.mock('@/components/worktree-base-fallback-notice', () => ({
 
 beforeEach(resetWorktreeSliceModuleMemory)
 
+function makeRepo(id: string, executionHostId: Repo['executionHostId']): Repo {
+  return {
+    id,
+    path: `/repos/${id}`,
+    displayName: id,
+    badgeColor: 'blue',
+    addedAt: 1,
+    connectionId: null,
+    executionHostId
+  }
+}
+
 describe('createWorktree composer parent pick', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -37,7 +50,9 @@ describe('createWorktree composer parent pick', () => {
 
   function createParentPickStore(parent?: Worktree) {
     const store = createTestStore()
-    store.setState({ worktreesByRepo: { repo1: parent ? [parent] : [] } } as Partial<AppState>)
+    store.setState({
+      worktreesByRepo: parent ? { [parent.repoId]: [parent] } : { repo1: [] }
+    } as Partial<AppState>)
     return store
   }
 
@@ -69,6 +84,94 @@ describe('createWorktree composer parent pick', () => {
     expect(mockApi.worktrees.create).toHaveBeenCalledWith(
       expect.objectContaining({ parentWorkspace: worktreeWorkspaceKey(parent.id) })
     )
+  })
+
+  it('nests under a parent from another repo on the same host', async () => {
+    const parent = makeWorktree({
+      id: 'repo2::/path/parent',
+      repoId: 'repo2',
+      path: '/path/parent',
+      instanceId: 'parent-instance',
+      hostId: 'local'
+    })
+    const created = makeWorktree({
+      id: 'repo1::/path/child',
+      repoId: 'repo1',
+      path: '/path/child',
+      instanceId: 'child-instance'
+    })
+    const store = createParentPickStore(parent)
+    store.setState({
+      repos: [makeRepo('repo1', 'local'), makeRepo('repo2', 'local')]
+    } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({
+      worktree: created,
+      lineage: makeLineage({
+        worktreeId: created.id,
+        worktreeInstanceId: 'child-instance',
+        parentWorktreeId: parent.id,
+        parentWorktreeInstanceId: 'parent-instance'
+      })
+    })
+
+    await createWithParentPick(store, parent.id)
+
+    expect(mockApi.worktrees.create).toHaveBeenCalledWith(
+      expect.objectContaining({ parentWorkspace: worktreeWorkspaceKey(parent.id) })
+    )
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+
+  it('drops a parent pick from another host', async () => {
+    const parent = makeWorktree({
+      id: 'repo2::/path/parent',
+      repoId: 'repo2',
+      path: '/path/parent',
+      hostId: 'ssh:remote'
+    })
+    const store = createParentPickStore(parent)
+    store.setState({
+      activeWorkspaceKey: folderWorkspaceKey('folder-1'),
+      repos: [makeRepo('repo1', 'local'), makeRepo('repo2', 'ssh:remote')]
+    } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({
+      worktree: makeWorktree({ id: 'repo1::/path/child', repoId: 'repo1', path: '/path/child' })
+    })
+
+    await createWithParentPick(store, parent.id)
+
+    expect(mockApi.worktrees.create).toHaveBeenCalledWith(
+      expect.objectContaining({ parentWorkspace: folderWorkspaceKey('folder-1') })
+    )
+    expect(toast.warning).toHaveBeenCalled()
+  })
+
+  it('drops an unstamped parent pick with multiple repo owners', async () => {
+    const parent = makeWorktree({
+      id: 'repo2::/path/parent',
+      repoId: 'repo2',
+      path: '/path/parent',
+      hostId: undefined
+    })
+    const store = createParentPickStore(parent)
+    store.setState({
+      activeWorkspaceKey: folderWorkspaceKey('folder-1'),
+      repos: [
+        makeRepo('repo1', 'local'),
+        makeRepo('repo2', 'local'),
+        makeRepo('repo2', 'ssh:remote')
+      ]
+    } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({
+      worktree: makeWorktree({ id: 'repo1::/path/child', repoId: 'repo1', path: '/path/child' })
+    })
+
+    await createWithParentPick(store, parent.id)
+
+    expect(mockApi.worktrees.create).toHaveBeenCalledWith(
+      expect.objectContaining({ parentWorkspace: folderWorkspaceKey('folder-1') })
+    )
+    expect(toast.warning).toHaveBeenCalled()
   })
 
   it('drops a stale parent pick and falls back to the active folder workspace', async () => {

--- a/src/renderer/src/store/slices/worktrees-create-parent-pick.test.ts
+++ b/src/renderer/src/store/slices/worktrees-create-parent-pick.test.ts
@@ -450,6 +450,54 @@ describe('createWorktree parent pick on a remote runtime', () => {
     expect(toast.warning).not.toHaveBeenCalled()
   })
 
+  it('uses the accepted host row name when warning about a dropped parent', async () => {
+    const store = createRemoteStore()
+    const remoteOwner = store.getState().repos[0]!
+    const localParent = makeWorktree({
+      id: PARENT_ID,
+      repoId: REMOTE_REPO,
+      path: '/remote/parent',
+      displayName: 'local-parent',
+      instanceId: 'local-parent-instance',
+      hostId: 'local'
+    })
+    const remoteParent = makeWorktree({
+      id: PARENT_ID,
+      repoId: REMOTE_REPO,
+      path: '/remote/parent',
+      displayName: 'remote-parent',
+      instanceId: 'remote-parent-instance',
+      hostId: 'runtime:env-1'
+    })
+    store.setState({
+      repos: [makeRepo(REMOTE_REPO, 'local'), remoteOwner],
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      worktreesByRepo: { [REMOTE_REPO]: [localParent, remoteParent] }
+    } as Partial<AppState>)
+    mockRuntimeCreate((id) => ({
+      id,
+      ok: true,
+      result: {
+        worktree: makeWorktree({
+          id: `${REMOTE_REPO}::/remote/child`,
+          repoId: REMOTE_REPO,
+          path: '/remote/child'
+        }),
+        lineage: null
+      }
+    }))
+    const createWorktree = store.getState().createWorktree
+    const args: Parameters<typeof createWorktree> = [REMOTE_REPO, 'feature', 'origin/main']
+    args[25] = { parentWorktreeId: PARENT_ID, executionHostId: 'runtime:env-1' }
+
+    await createWorktree(...args)
+
+    expect(toast.warning).toHaveBeenCalledWith(
+      'Created without nesting under "remote-parent"',
+      expect.objectContaining({ description: expect.any(String) })
+    )
+  })
+
   it('retries without the parent and warns when the host no longer has it', async () => {
     mockRuntimeCreate((id) => ({
       id,

--- a/src/renderer/src/store/slices/worktrees/create/create-worktree.ts
+++ b/src/renderer/src/store/slices/worktrees/create/create-worktree.ts
@@ -155,7 +155,12 @@ export function createCreateWorktree(
     }
     try {
       // Why outside the retry loop: a branch-name conflict retry must not re-warn about the same dropped pick.
-      const parent = resolveWorktreeCreateParent(get(), repoId, options?.parentWorktreeId)
+      const parent = resolveWorktreeCreateParent(
+        get(),
+        repoId,
+        options?.parentWorktreeId,
+        options?.executionHostId
+      )
       let warnedParentDropped = false
       const warnParentDroppedOnce = (): void => {
         if (warnedParentDropped) {
@@ -169,7 +174,14 @@ export function createCreateWorktree(
       }
       // Why: manual sort is user-authored order; stamp new workspaces at the top rather than relying on sortOrder fallback.
       const manualOrder = get().sortBy === 'manual' ? Date.now() : undefined
-      const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), repoId))
+      const target = getActiveRuntimeTarget(
+        settingsForRepoOwner(
+          get(),
+          repoId,
+          options?.executionHostId,
+          options?.executionHostId !== undefined
+        )
+      )
       if (
         target.kind === 'environment' &&
         (options?.linkedWorkItem?.provider === 'jira' ||

--- a/src/renderer/src/store/slices/worktrees/create/worktree-create-parent-pick.ts
+++ b/src/renderer/src/store/slices/worktrees/create/worktree-create-parent-pick.ts
@@ -49,7 +49,8 @@ export function resolveWorktreeCreateParent(
   })
   const picked = usableRows.length === 1 ? usableRows[0] : undefined
   const usable = picked?.id
-  const pickedDisplayName = pickedRows[0] ? resolveWorktreeDisplayName(pickedRows[0]).trim() : null
+  const displayRow = picked ?? pickedRows[0]
+  const pickedDisplayName = displayRow ? resolveWorktreeDisplayName(displayRow).trim() : null
   if (usable) {
     return {
       parentWorkspace: worktreeWorkspaceKey(usable),

--- a/src/renderer/src/store/slices/worktrees/create/worktree-create-parent-pick.ts
+++ b/src/renderer/src/store/slices/worktrees/create/worktree-create-parent-pick.ts
@@ -3,7 +3,10 @@ import type { WorkspaceKey } from '../../../../../../shared/folder-workspace-typ
 import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
 import { resolveWorktreeDisplayName } from '@/lib/worktree-default-display-name'
-import { getWorktreeExecutionHostId } from '../../../../../../shared/execution-host'
+import {
+  getWorktreeExecutionHostId,
+  type ExecutionHostId
+} from '../../../../../../shared/execution-host'
 import {
   folderWorkspaceKey,
   parseWorkspaceKey,
@@ -27,12 +30,13 @@ export type WorktreeCreateParentPick = {
 export function resolveWorktreeCreateParent(
   state: AppState,
   repoId: string,
-  requestedParentWorktreeId: string | undefined
+  requestedParentWorktreeId: string | undefined,
+  executionHostId?: ExecutionHostId
 ): WorktreeCreateParentPick {
   const pickedRows = requestedParentWorktreeId
     ? getIndexedWorktreesById(state.worktreesByRepo, requestedParentWorktreeId)
     : []
-  const childHostId = repoHostId(state, repoId)
+  const childHostId = repoHostId(state, repoId, executionHostId)
   const repoOwners = getIndexedRepoOwners(state.repos)
   const usableRows = pickedRows.filter((candidate) => {
     const candidateRepoOwners = repoOwners.get(candidate.repoId) ?? []

--- a/src/renderer/src/store/slices/worktrees/create/worktree-create-parent-pick.ts
+++ b/src/renderer/src/store/slices/worktrees/create/worktree-create-parent-pick.ts
@@ -3,12 +3,14 @@ import type { WorkspaceKey } from '../../../../../../shared/folder-workspace-typ
 import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
 import { resolveWorktreeDisplayName } from '@/lib/worktree-default-display-name'
+import { getWorktreeExecutionHostId } from '../../../../../../shared/execution-host'
 import {
   folderWorkspaceKey,
   parseWorkspaceKey,
   worktreeWorkspaceKey
 } from '../../../../../../shared/workspace-scope'
-import { getIndexedWorktreeById } from '@/store/worktree-repo-index'
+import { getIndexedRepoOwners, getIndexedWorktreesById } from '@/store/worktree-repo-index'
+import { repoHostId } from '../listing/worktree-host-ownership'
 
 export type WorktreeCreateParentPick = {
   /** Workspace the create attaches to. Undefined once a stale pick is dropped. */
@@ -27,11 +29,23 @@ export function resolveWorktreeCreateParent(
   repoId: string,
   requestedParentWorktreeId: string | undefined
 ): WorktreeCreateParentPick {
-  const picked = requestedParentWorktreeId
-    ? getIndexedWorktreeById(state.worktreesByRepo, requestedParentWorktreeId)
-    : undefined
-  const usable = picked && !picked.isArchived && picked.repoId === repoId ? picked.id : undefined
-  const pickedDisplayName = picked ? resolveWorktreeDisplayName(picked).trim() : null
+  const pickedRows = requestedParentWorktreeId
+    ? getIndexedWorktreesById(state.worktreesByRepo, requestedParentWorktreeId)
+    : []
+  const childHostId = repoHostId(state, repoId)
+  const repoOwners = getIndexedRepoOwners(state.repos)
+  const usableRows = pickedRows.filter((candidate) => {
+    const candidateRepoOwners = repoOwners.get(candidate.repoId) ?? []
+    const candidateRepo = candidateRepoOwners.length === 1 ? candidateRepoOwners[0] : undefined
+    return (
+      !candidate.isArchived &&
+      (candidate.hostId !== undefined || candidateRepoOwners.length <= 1) &&
+      getWorktreeExecutionHostId(candidate, candidateRepo) === childHostId
+    )
+  })
+  const picked = usableRows.length === 1 ? usableRows[0] : undefined
+  const usable = picked?.id
+  const pickedDisplayName = pickedRows[0] ? resolveWorktreeDisplayName(pickedRows[0]).trim() : null
   if (usable) {
     return {
       parentWorkspace: worktreeWorkspaceKey(usable),

--- a/src/renderer/src/store/slices/worktrees/create/worktree-create-payload.ts
+++ b/src/renderer/src/store/slices/worktrees/create/worktree-create-payload.ts
@@ -7,6 +7,8 @@ import type { WorkspaceLinkedItem } from '../../../../../../shared/worktree/type
 /** Trailing bag for `createWorktree` args that outgrew its positional list. */
 export type CreateWorktreeCallOptions = {
   automationProvenanceRequest?: CreateWorktreeArgs['automationProvenanceRequest']
+  /** Host selected with the repo. Keeps duplicate repo IDs routed to the same owner. */
+  executionHostId?: ExecutionHostId
   linkedWorkItem?: WorkspaceLinkedItem | null
   linkedTaskSourceContext?: TaskSourceContext | null
   /** Lets the owning runtime launch and prefill a task agent without first creating an idle shell. */

--- a/src/renderer/src/store/worktree-repo-index.ts
+++ b/src/renderer/src/store/worktree-repo-index.ts
@@ -16,6 +16,7 @@ type WorktreeSnapshot = {
 // cross-render caching without pinning replaced store snapshots in memory.
 const worktreeSnapshotCache = new WeakMap<AppState['worktreesByRepo'], WorktreeSnapshot>()
 const repoMapCache = new WeakMap<AppState['repos'], Map<string, Repo>>()
+const repoOwnersCache = new WeakMap<AppState['repos'], Map<string, Repo[]>>()
 
 function getWorktreeSnapshot(worktreesByRepo: AppState['worktreesByRepo']): WorktreeSnapshot {
   const cachedSnapshot = worktreeSnapshotCache.get(worktreesByRepo)
@@ -105,4 +106,18 @@ export function getIndexedRepoMap(repos: AppState['repos']): Map<string, Repo> {
   const repoMap = new Map(repos.map((repo) => [repo.id, repo]))
   repoMapCache.set(repos, repoMap)
   return repoMap
+}
+
+/** Every execution-host owner for one repo id, preserving store order. */
+export function getIndexedRepoOwners(repos: AppState['repos']): Map<string, Repo[]> {
+  const cachedOwners = repoOwnersCache.get(repos)
+  if (cachedOwners) {
+    return cachedOwners
+  }
+  const owners = new Map<string, Repo[]>()
+  for (const repo of repos) {
+    owners.set(repo.id, [...(owners.get(repo.id) ?? []), repo])
+  }
+  repoOwnersCache.set(repos, owners)
+  return owners
 }

--- a/src/shared/folder-workspace-worktree.test.ts
+++ b/src/shared/folder-workspace-worktree.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import type { FolderWorkspace } from './folder-workspace-types'
-import { folderWorkspaceToWorktree } from './folder-workspace-worktree'
+import {
+  folderWorkspaceToWorktree,
+  getFolderWorkspaceExecutionHostId
+} from './folder-workspace-worktree'
 
 function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
   return {
@@ -24,6 +27,25 @@ function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWo
 }
 
 describe('folderWorkspaceToWorktree', () => {
+  it.each([
+    {
+      source: 'an explicit host',
+      overrides: { executionHostId: 'runtime:dev' as const },
+      hostId: 'runtime:dev'
+    },
+    {
+      source: 'a durable SSH connection',
+      overrides: { connectionId: 'build box' },
+      hostId: 'ssh:build%20box'
+    },
+    { source: 'neither host field', overrides: {}, hostId: 'local' }
+  ])('derives the projection host from $source', ({ overrides, hostId }) => {
+    const workspace = makeFolderWorkspace(overrides)
+
+    expect(getFolderWorkspaceExecutionHostId(workspace)).toBe(hostId)
+    expect(folderWorkspaceToWorktree(workspace).hostId).toBe(hostId)
+  })
+
   it('projects attached issue tasks without creating linked PR metadata', () => {
     const githubIssue = folderWorkspaceToWorktree(
       makeFolderWorkspace({

--- a/src/shared/folder-workspace-worktree.ts
+++ b/src/shared/folder-workspace-worktree.ts
@@ -1,15 +1,29 @@
 import type { FolderWorkspace } from './folder-workspace-types'
 import type { Worktree } from './worktree/types'
 import { folderWorkspaceKey } from './workspace-scope'
-import { parseExecutionHostId, toSshExecutionHostId } from './execution-host'
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  parseExecutionHostId,
+  toSshExecutionHostId,
+  type ExecutionHostId
+} from './execution-host'
 import { normalizeWorkspaceCreatorProvenance } from './workspace-creator-provenance'
+
+export function getFolderWorkspaceExecutionHostId(
+  folderWorkspace: Pick<FolderWorkspace, 'connectionId' | 'executionHostId'>
+): ExecutionHostId {
+  return (
+    folderWorkspace.executionHostId ??
+    (folderWorkspace.connectionId
+      ? toSshExecutionHostId(folderWorkspace.connectionId)
+      : LOCAL_EXECUTION_HOST_ID)
+  )
+}
 
 export function folderWorkspaceToWorktree(folderWorkspace: FolderWorkspace): Worktree {
   const linkedTask = folderWorkspace.linkedTask
   const creatorProvenance = normalizeWorkspaceCreatorProvenance(folderWorkspace.creatorProvenance)
-  const hostId =
-    folderWorkspace.executionHostId ??
-    (folderWorkspace.connectionId ? toSshExecutionHostId(folderWorkspace.connectionId) : 'local')
+  const hostId = getFolderWorkspaceExecutionHostId(folderWorkspace)
   const parsedHost = parseExecutionHostId(hostId)
   return {
     id: folderWorkspaceKey(folderWorkspace.id),

--- a/src/shared/resolved-worktree-lineage.test.ts
+++ b/src/shared/resolved-worktree-lineage.test.ts
@@ -47,36 +47,25 @@ function lineage(overrides: Partial<WorktreeLineage> = {}): WorktreeLineage {
 
 describe('sharesWorktreeLineageBoundary', () => {
   const boundary = (overrides: Partial<WorktreeLineageBoundary> = {}): WorktreeLineageBoundary => ({
-    repoId: 'repo',
     hostId: 'local',
-    projectId: 'github:stablyai/orca',
     ...overrides
   })
 
-  it('accepts an identical repo, host, and project', () => {
+  it('accepts an identical host', () => {
     expect(sharesWorktreeLineageBoundary(boundary(), boundary())).toBe(true)
-  })
-
-  it('rejects a differing repo even when host and project agree', () => {
-    expect(sharesWorktreeLineageBoundary(boundary(), boundary({ repoId: 'other-repo' }))).toBe(
-      false
-    )
   })
 
   it.each([
     ['child host', boundary({ hostId: undefined }), boundary()],
-    ['parent host', boundary(), boundary({ hostId: undefined })],
-    ['child project', boundary({ projectId: undefined }), boundary()],
-    ['parent project', boundary(), boundary({ projectId: undefined })]
+    ['parent host', boundary(), boundary({ hostId: undefined })]
   ])('treats an undefined %s as compatible', (_label, child, parent) => {
     expect(sharesWorktreeLineageBoundary(child, parent)).toBe(true)
   })
 
-  it.each([
-    ['host', boundary({ hostId: 'ssh:remote' })],
-    ['project', boundary({ projectId: 'github:other/project' })]
-  ])('rejects a defined %s mismatch', (_label, parent) => {
-    expect(sharesWorktreeLineageBoundary(boundary(), parent)).toBe(false)
+  it('rejects a defined host mismatch', () => {
+    expect(sharesWorktreeLineageBoundary(boundary(), boundary({ hostId: 'ssh:remote' }))).toBe(
+      false
+    )
   })
 })
 
@@ -106,11 +95,9 @@ describe('projectResolvedWorktreeLineage', () => {
     ])
   })
 
-  it.each([
-    ['repo', { repoId: 'other-repo' }, {}],
-    ['known host', { hostId: 'local' as const }, { hostId: 'ssh:remote' as const }],
-    ['known project', { projectId: 'github:stablyai/orca' }, { projectId: 'github:other/project' }]
-  ])('rejects a %s boundary mismatch', (_label, childOverrides, parentOverrides) => {
+  it('rejects a known host boundary mismatch', () => {
+    const childOverrides = { hostId: 'local' as const }
+    const parentOverrides = { hostId: 'ssh:remote' as const }
     const boundedChild = worktree('child', 'child-instance', childOverrides)
     const boundedParent = worktree('parent', 'parent-instance', parentOverrides)
 
@@ -124,7 +111,41 @@ describe('projectResolvedWorktreeLineage', () => {
     ])
   })
 
-  it('accepts legacy records when only one side has host or project identity', () => {
+  it.each([
+    [
+      'repository',
+      { repoId: 'other-repo', hostId: 'local' as const },
+      { hostId: 'local' as const }
+    ],
+    [
+      'project',
+      { hostId: 'local' as const, projectId: 'github:stablyai/orca' },
+      { hostId: 'local' as const, projectId: 'github:other/project' }
+    ],
+    [
+      'repository and project',
+      {
+        repoId: 'other-repo',
+        hostId: 'local' as const,
+        projectId: 'github:stablyai/orca'
+      },
+      { hostId: 'local' as const, projectId: 'github:other/project' }
+    ]
+  ])('projects a cross-%s edge on the same host', (_label, childOverrides, parentOverrides) => {
+    const boundedChild = worktree('child', 'child-instance', childOverrides)
+    const boundedParent = worktree('parent', 'parent-instance', parentOverrides)
+
+    const projected = projectResolvedWorktreeLineage([boundedChild, boundedParent], {
+      child: lineage()
+    })
+
+    expect(projected).toMatchObject([
+      { id: 'child', parentWorktreeId: 'parent', lineage: lineage() },
+      { id: 'parent', childWorktreeIds: ['child'] }
+    ])
+  })
+
+  it('accepts legacy records when only one side has host identity', () => {
     const legacyChild = worktree('child', 'child-instance', {
       hostId: 'local',
       projectId: 'github:stablyai/orca'

--- a/src/shared/resolved-worktree-lineage.ts
+++ b/src/shared/resolved-worktree-lineage.ts
@@ -7,21 +7,14 @@ export type WorktreeWithResolvedLineage<T extends Worktree = Worktree> = T & {
   lineage: WorktreeLineage | null
 }
 
-/** The fields a lineage edge is scoped by. Split out so create-time callers — which have a
- *  projected child, not a real Worktree — can check the same rule the projection enforces. */
-export type WorktreeLineageBoundary = Pick<Worktree, 'repoId' | 'hostId' | 'projectId'>
+/** Split out so create-time callers can check the same host boundary as projection. */
+export type WorktreeLineageBoundary = Pick<Worktree, 'hostId'>
 
 export function sharesWorktreeLineageBoundary(
   child: WorktreeLineageBoundary,
   parent: WorktreeLineageBoundary
 ): boolean {
-  return (
-    child.repoId === parent.repoId &&
-    (child.hostId === undefined || parent.hostId === undefined || child.hostId === parent.hostId) &&
-    (child.projectId === undefined ||
-      parent.projectId === undefined ||
-      child.projectId === parent.projectId)
-  )
+  return child.hostId === undefined || parent.hostId === undefined || child.hostId === parent.hostId
 }
 
 export function sharesResolvedWorktreeLineageBoundary(child: Worktree, parent: Worktree): boolean {

--- a/src/shared/resolved-worktree-lineage.ts
+++ b/src/shared/resolved-worktree-lineage.ts
@@ -10,6 +10,7 @@ export type WorktreeWithResolvedLineage<T extends Worktree = Worktree> = T & {
 /** Split out so create-time callers can check the same host boundary as projection. */
 export type WorktreeLineageBoundary = Pick<Worktree, 'hostId'>
 
+/** Whether two lineage endpoints may be related without crossing a known host boundary. */
 export function sharesWorktreeLineageBoundary(
   child: WorktreeLineageBoundary,
   parent: WorktreeLineageBoundary
@@ -17,6 +18,7 @@ export function sharesWorktreeLineageBoundary(
   return child.hostId === undefined || parent.hostId === undefined || child.hostId === parent.hostId
 }
 
+/** Applies the host-only boundary to fully resolved worktrees. */
 export function sharesResolvedWorktreeLineageBoundary(child: Worktree, parent: Worktree): boolean {
   return sharesWorktreeLineageBoundary(child, parent)
 }


### PR DESCRIPTION
## ELI5

Coding agents can create child workspaces in a different repository from their parent. Orca previously discarded or hid those relationships unless both workspaces shared a repository and project. This change lets same-host workspaces remain parented across repositories and projects while still rejecting cross-host relationships.

## What Changed

- Treat execution host identity as the lineage boundary instead of repository and project identity
- Persist and project cross-repository lineage through current creation and runtime resolution paths
- Fall back from repo-scoped resolution when a cross-repo endpoint is requested, including equivalent path spellings
- Offer same-host cross-repo parents in the composer and identify foreign repositories with badges
- Exclude unstamped candidates when duplicate repo IDs have multiple host owners
- Revalidate composer selections at create time, accepting same-host cross-repo parents and dropping ambiguous or cross-host picks
- Keep sidebar nesting, visibility, PR display, and cascade deletion consistent with the new boundary

## Why

Issue #11007 reports that agent-created child worktrees no longer remain grouped beneath their parent. Those agents commonly create children in sibling repositories. Fixing only the sidebar would leave creation-time persistence, repo-scoped runtime projection, composer selection, and deletion traversal inconsistent, so each of those paths must share the same host-only boundary.

This is a current-main port of #12755 by @AmethystLiang. A new PR is necessary because #12755 conflicts with current `main`, which has since gained separate creation-time lineage validation, per-repo runtime resolution, host-qualified identity handling, and a composer parent picker.

## Linked Issue

Fixes #11007

Fixes #12757

Supersedes #12755

## Visual Proof

The UI behavior is carried forward from #12755. These captures show the original implementation that this current-main port preserves:

Cross-repo descendant identified in the delete dialog:

![Delete Workspace dialog showing a foreign-repo child](https://github.com/user-attachments/assets/01f7099d-be67-4d60-96fa-224bdab902b0)

Close-up of the foreign-repository badge:

![Foreign-repository badge in the lineage notice](https://github.com/user-attachments/assets/dc190db5-b532-447f-a105-3ffb22fb024c)

Cross-repository candidate in the parent picker:

![Parent picker offering a candidate from another repository](https://github.com/user-attachments/assets/74e00705-69a7-4bda-b118-2b95cdc1c76d)

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added and updated

Local verification:

- Focused Vitest suite across 13 lineage, runtime, creation, and UI test files: 1,417 passed, 1 skipped
- `pnpm tc`
- `pnpm run check:code-quality:changed`
- `git diff --check`
- Pre-commit Oxlint, React Doctor, and Oxfmt hooks

A broad local `pnpm test` run was stopped after unrelated environment-sensitive shell, PTY, Git, release, and Electron startup tests failed. CI is left to run the complete repository matrix.

## AI Disclosure

OpenAI Codex using a GPT-5 model was used to analyze #12755, port the implementation to current `main`, add tests, and address automated review findings. The resulting code and diffs were reviewed locally before each commit.

## Review

Please focus review on:

- Per-host aggregation in runtime lineage projection
- Fleet fallback for normalized cross-repo lineage endpoints
- Duplicate repo ID ownership in composer selection
- Cross-repo cascade-delete scope and foreign-repo labeling

Original design and visual proof: #12755 by @AmethystLiang.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no upstream skill-installer source or related assets.

## Notes

- Security boundary: known cross-host lineage remains rejected at creation, manual assignment, projection, picker, and deletion traversal layers.
- Cross-platform paths: fallback tests cover trailing separators, doubled separators, and Unicode normalization.
- SSH/runtime: candidates require the same effective execution host; ambiguous unstamped multi-owner candidates fail closed.
- Backwards compatibility: legacy rows with one missing host identity retain existing wildcard compatibility.
- Performance: unaffected scoped lookups retain the single-repository fast path; only worktrees touching cross-repo lineage fall back to fleet resolution.

## Checklist

- [x] This PR is focused on restoring complete cross-repo child-worktree lineage behavior
- [x] I explained what changed and why, including ELI5
- [x] Visual proof from the original implementation is linked above
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered
- [ ] Full `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass locally; focused checks pass and CI will cover the complete matrix

## Performance Measurement

No speed-up is claimed or measured; this is a lineage-correctness change. A scoped lookup performs one O(L) preflight over persisted lineage edges to detect a relevant cross-repository edge. Same-repository requests retain the per-repository scan; the cross-repository fixture returns before any scoped `scanRepo` call (0 calls) and deliberately falls back to the fleet resolver, which scans each host repo once. Picker projection remains one O(C) candidate pass. No wall-clock benchmark was run.

## User-Facing Trade-offs

Same-host child trees from other repositories or projects now appear in sidebar and pickers and are included in lineage/delete traversal, so a delete action can span repositories. Cross-host and ambiguous-owner candidates remain rejected. No other user-facing trade-off is introduced.
