### PR TITLE
perf(memory): prune claimed PTY subtrees

### DIFF
--- a/src/main/memory/collector.test.ts
+++ b/src/main/memory/collector.test.ts
@@ -179,6 +179,32 @@ describe('collectSubtree', () => {
 
     expect(collectSubtree(index, 1)).toEqual([1])
   })
+
+  it('does not descend into a subtree already attributed to another PTY', async () => {
+    const { collectSubtree } = await loadCollector()
+    class CountingChildrenMap extends Map<number, number[]> {
+      lookups = 0
+
+      override get(key: number): number[] | undefined {
+        this.lookups += 1
+        return super.get(key)
+      }
+    }
+    const childrenOf = new CountingChildrenMap([
+      [1, [2, 4]],
+      [2, [3]],
+      [3, [5]]
+    ])
+    const byPid = new Map([1, 2, 3, 4, 5].map((pid) => [pid, { pid, ppid: 0, cpu: 0, memory: 0 }]))
+    const index = { byPid, childrenOf, hasPrivateMemory: false }
+
+    // A prior PTY rooted at 2 already claimed 2 and all of its descendants;
+    // the overlapping walk must still include the independent sibling 4.
+    expect(collectSubtree(index, 1, new Set([2]))).toEqual([1, 4])
+    // The excluded branch is not even expanded (2 lookups: roots 1 and 4,
+    // versus 5 without the claimed-subtree fast path).
+    expect(childrenOf.lookups).toBe(2)
+  })
 })
 
 describe('collectMemorySnapshot', () => {
@@ -378,7 +404,7 @@ describe('collectMemorySnapshot', () => {
         worktreeId: 'repo-1::/wt/b',
         sessionId: 's-b',
         paneKey: 'p-b',
-        pid: 100 // also rooted at 100, but every pid is already claimed
+        pid: 101 // a descendant of the first root, already claimed with its subtree
       }
     ])
 

--- a/src/main/memory/collector.ts
+++ b/src/main/memory/collector.ts
@@ -179,7 +179,11 @@ async function enumerateWindows(): Promise<ProcRow[]> {
   return enumerateWindowsProcessResources()
 }
 /** Walk every descendant PID of `root`, inclusive. Exported for tests. */
-export function collectSubtree(index: ProcIndex, root: number): number[] {
+export function collectSubtree(
+  index: ProcIndex,
+  root: number,
+  excludedPids?: ReadonlySet<number>
+): number[] {
   const result: number[] = []
   const seen = new Set<number>()
   const queue = [root]
@@ -188,7 +192,10 @@ export function collectSubtree(index: ProcIndex, root: number): number[] {
     if (pid === undefined) {
       break
     }
-    if (seen.has(pid)) {
+    // Once a PID was attributed to an earlier PTY, its complete subtree was
+    // already traversed. Do not walk those descendants again for overlapping
+    // PTY roots (common when several panes share a supervisor).
+    if (seen.has(pid) || excludedPids?.has(pid)) {
       continue
     }
     seen.add(pid)
@@ -295,7 +302,7 @@ async function runSnapshot(store: MemorySnapshotStore): Promise<MemorySnapshot> 
     let sessionPrivateMemory = 0
 
     if (pty.pid != null) {
-      for (const pid of collectSubtree(processIndex, pty.pid)) {
+      for (const pid of collectSubtree(processIndex, pty.pid, claimed)) {
         if (claimed.has(pid)) {
           continue
         }


### PR DESCRIPTION
## ELI5

The memory dashboard walks each terminal's process family tree. If two terminals point into the same tree, Orca already counted that branch for the first terminal, but it still walked the whole branch again. Now it stops immediately at an already-counted process.

## What Changed

- Let `collectSubtree` receive the snapshot's already-claimed PID set.
- Stop before expanding a PID whose complete subtree was traversed for an earlier PTY.
- Preserve first-registered-PTY attribution and all memory/CPU totals.

## Why

A single fixed host process snapshot can contain overlapping PTY roots (shared supervisors or reparented shells). Rewalking an already-attributed subtree wastes CPU on every memory-dashboard poll without producing new data.

## Performance Measurement

Deterministic overlapping-tree fixture:

- Before: **5** child-map lookups.
- After: **2** child-map lookups.
- Improvement: **60% fewer traversal lookups** in the fixture.

For a previously claimed subtree, later PTY walks now cost O(1) at that root instead of O(subtree size). The snapshot regression also proves a PTY rooted at an already-claimed descendant receives zero duplicate usage.

## User-Facing Trade-offs

None. The process sweep, first-owner attribution, session rows, totals, and history are unchanged; only redundant graph traversal is removed.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

N/A — the dashboard displays the same values.

## Testing

- [x] Focused memory collector suite (31 passed)
- [x] Windows collector suite (14 passed)
- [x] `pnpm tc:node`
- [x] Focused oxlint/format and diff checks

## Review

Self-reviewed against fixed-snapshot traversal, cycles, overlapping roots, missing rows, Windows process enumeration, and first-claim semantics.

## Agent skill upstream boundary

- [x] Not applicable.
