### PR TITLE
perf(renderer): narrow app root settings subscriptions

### DIFF
--- a/src/renderer/src/app-shell/AppRootSurfaces.tsx
+++ b/src/renderer/src/app-shell/AppRootSurfaces.tsx
@@ -16,6 +16,11 @@ import { shouldRenderPetOverlay } from '../components/pet/pet-overlay-visibility
 import { useAppStore } from '../store'
 import type { UpdateStatus } from '../../../shared/update-status-types'
 import { useLazyModalMounts } from './use-lazy-modal-mounts'
+import {
+  selectAppRootSurfacePetEnabled,
+  selectAppRootSurfaceTelemetryOptedIn,
+  selectAppRootSurfaceVoiceEnabled
+} from './app-root-surface-settings'
 import type { FloatingWorkspacePanelState } from './use-floating-workspace-panel'
 import type { OnboardingGate } from './use-onboarding-and-feature-tips'
 
@@ -122,11 +127,14 @@ export function AppRootSurfaces(props: {
   const { mountedLazyModalIds, shouldMountAddRepoDialog } = useLazyModalMounts()
   const activeView = useAppStore((s) => s.activeView)
   const activeModal = useAppStore((s) => s.activeModal)
-  const settings = useAppStore((s) => s.settings)
+  // Keep this always-mounted surface subscribed only to the settings fields it reads. A
+  // settings object replacement for an unrelated preference should not rerender every overlay.
+  const voiceEnabled = useAppStore(selectAppRootSurfaceVoiceEnabled)
+  const petEnabled = useAppStore(selectAppRootSurfacePetEnabled)
+  const telemetryOptedIn = useAppStore(selectAppRootSurfaceTelemetryOptedIn)
   const statusBarVisible = useAppStore((s) => s.statusBarVisible)
   const persistedUIReady = useAppStore((s) => s.persistedUIReady)
   const petVisible = useAppStore((s) => s.petVisible)
-  const petEnabled = useAppStore((s) => s.settings?.experimentalPet === true)
   const dictationState = useAppStore((s) => s.dictationState)
   const updateStatus = useAppStore((s) => s.updateStatus)
   const activeContextualTourId = useAppStore((s) => s.activeContextualTourId)
@@ -134,8 +142,7 @@ export function AppRootSurfaces(props: {
 
   const shouldMountSetupGuideTelemetryObserver = persistedUIReady
   const shouldMountUpdateCard = shouldMountUpdateCardForStatus(updateStatus)
-  const shouldMountDictationController =
-    settings?.voice?.enabled === true || dictationState !== 'idle'
+  const shouldMountDictationController = voiceEnabled || dictationState !== 'idle'
   const renderPetOverlay = shouldRenderPetOverlay({ persistedUIReady, petEnabled, petVisible })
 
   return (
@@ -281,10 +288,7 @@ export function AppRootSurfaces(props: {
       </OverlayBoundary>
       <StarNagAgentValueMomentObserver />
       {/* Why: mount at App root to render once per session; internal cohort gate limits it to pre-telemetry users — see telemetry-plan.md §First-launch experience. */}
-      <OverlayBoundary
-        boundaryId="overlay.telemetry-first-launch"
-        resetKey={settings?.telemetry?.optedIn ?? 'unknown'}
-      >
+      <OverlayBoundary boundaryId="overlay.telemetry-first-launch" resetKey={telemetryOptedIn}>
         <TelemetryFirstLaunchSurface />
       </OverlayBoundary>
       <OverlayBoundary boundaryId="overlay.zoom" resetKey={activeView}>

--- a/src/renderer/src/app-shell/app-root-surface-settings.test.tsx
+++ b/src/renderer/src/app-shell/app-root-surface-settings.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { useStore } from 'zustand'
+import { createStore } from 'zustand/vanilla'
+import { describe, expect, it } from 'vitest'
+import { getDefaultSettings } from '../../../shared/constants'
+import {
+  selectAppRootSurfacePetEnabled,
+  selectAppRootSurfaceTelemetryOptedIn,
+  selectAppRootSurfaceVoiceEnabled
+} from './app-root-surface-settings'
+
+type SurfaceState = Parameters<typeof selectAppRootSurfaceVoiceEnabled>[0]
+
+describe('app root surface settings selectors', () => {
+  it('does not rerender for an unrelated settings replacement', () => {
+    const store = createStore<SurfaceState>(() => ({ settings: getDefaultSettings('/tmp') }))
+    let renderCount = 0
+    const view = renderHook(() => {
+      renderCount += 1
+      return {
+        voiceEnabled: useStore(store, selectAppRootSurfaceVoiceEnabled),
+        petEnabled: useStore(store, selectAppRootSurfacePetEnabled),
+        telemetryOptedIn: useStore(store, selectAppRootSurfaceTelemetryOptedIn)
+      }
+    })
+
+    expect(renderCount).toBe(1)
+    act(() => {
+      const settings = store.getState().settings!
+      store.setState({ settings: { ...settings, editorAutoSave: !settings.editorAutoSave } })
+    })
+
+    expect(renderCount).toBe(1)
+    expect(view.result.current.voiceEnabled).toBe(false)
+    expect(view.result.current.petEnabled).toBe(false)
+    expect(view.result.current.telemetryOptedIn).toBe('unknown')
+    view.unmount()
+  })
+
+  it('still rerenders when a setting used by a surface changes', () => {
+    const store = createStore<SurfaceState>(() => ({ settings: getDefaultSettings('/tmp') }))
+    let renderCount = 0
+    const view = renderHook(() => {
+      renderCount += 1
+      return useStore(store, selectAppRootSurfaceVoiceEnabled)
+    })
+
+    act(() => {
+      const settings = store.getState().settings!
+      store.setState({ settings: { ...settings, voice: { ...settings.voice!, enabled: true } } })
+    })
+
+    expect(renderCount).toBe(2)
+    view.unmount()
+  })
+})

--- a/src/renderer/src/app-shell/app-root-surface-settings.ts
+++ b/src/renderer/src/app-shell/app-root-surface-settings.ts
@@ -1,0 +1,17 @@
+import type { AppState } from '../store/types'
+
+type AppRootSurfaceSettingsState = Pick<AppState, 'settings'>
+
+export function selectAppRootSurfaceVoiceEnabled(state: AppRootSurfaceSettingsState): boolean {
+  return state.settings?.voice?.enabled === true
+}
+
+export function selectAppRootSurfacePetEnabled(state: AppRootSurfaceSettingsState): boolean {
+  return state.settings?.experimentalPet === true
+}
+
+export function selectAppRootSurfaceTelemetryOptedIn(
+  state: AppRootSurfaceSettingsState
+): boolean | 'unknown' {
+  return state.settings?.telemetry?.optedIn ?? 'unknown'
+}

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -306,7 +306,8 @@ describe('renderer startup runtime routing', () => {
 
     expect(source).toContain("import('../components/dictation/DictationController').then")
     expect(source).not.toContain("from '../components/dictation/DictationController'")
-    expect(source).toContain("settings?.voice?.enabled === true || dictationState !== 'idle'")
+    expect(source).toContain('useAppStore(selectAppRootSurfaceVoiceEnabled)')
+    expect(source).toContain("voiceEnabled || dictationState !== 'idle'")
     expect(source).toContain('shouldMountDictationController ?')
   })
 


### PR DESCRIPTION
## ELI5

The always-mounted root overlay host was watching the entire settings object even though it only cares about three switches. Changing an unrelated preference made the whole root surface render again. It now watches only the three values it actually uses.

## What Changed

- Project voice-enabled, pet-enabled, and telemetry-opt-in values with scalar selectors.
- Keep relevant preference changes live while ignoring unrelated settings-object replacements.
- Add a render-count regression around the real Zustand subscription behavior.

## Why

`AppRootSurfaces` stays mounted for the whole app session and hosts every root modal/overlay. Broad settings subscription churn makes unrelated preference writes revisit that full React subtree.

## Performance Measurement

Deterministic render-count test for one unrelated settings replacement:

- Before: **2 renders** (initial + unrelated update).
- After: **1 render** (initial only).
- Improvement: **50% fewer renders** for the measured interaction, and **zero additional root renders per unrelated settings write**.

A relevant voice setting change still produces the expected second render.

## User-Facing Trade-offs

None. Voice, pet, and telemetry changes still update their surfaces immediately; unrelated settings no longer wake this root component.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

N/A — rendered appearance and interaction behavior are intentionally unchanged.

## Testing

- [x] Focused startup-routing and selector suites (27 passed)
- [x] `pnpm tc`
- [x] Focused oxlint, React Doctor, and format checks

## Review

Self-reviewed for selector completeness, hydration defaults, modal ordering, and relevant-setting reactivity.

## Agent skill upstream boundary

- [x] Not applicable.
