### PR TITLE
perf(filesystem): avoid per-entry directory promises

### DIFF
--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -485,15 +485,9 @@ async function isBinaryFilePrefix(filePath: string): Promise<boolean> {
   }
 }
 
-async function isDirectoryEntry(
-  dirPath: string,
-  entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean },
-  _resolveEntryPath: (entryPath: string) => Promise<string>
-): Promise<boolean> {
+function isDirectoryEntry(entry: { isDirectory(): boolean; isSymbolicLink(): boolean }): boolean {
   // Why: following a symlink in readDir can touch macOS TCC-protected containers; treat links as file-like until explicitly opened.
-  void _resolveEntryPath
   if (entry.isSymbolicLink()) {
-    void dirPath
     return false
   }
   if (entry.isDirectory()) {
@@ -552,15 +546,11 @@ export function registerFilesystemHandlers(
         const dirPath = await resolveAuthorizedPath(args.dirPath, store)
         throwSite = 'readdir'
         const entries = await readdir(dirPath, { withFileTypes: true })
-        const mapped = await Promise.all(
-          entries.map(async (entry) => ({
-            name: entry.name,
-            isDirectory: await isDirectoryEntry(dirPath, entry, (entryPath) =>
-              resolveAuthorizedPath(entryPath, store)
-            ),
-            isSymlink: entry.isSymbolicLink()
-          }))
-        )
+        const mapped = entries.map((entry) => ({
+          name: entry.name,
+          isDirectory: isDirectoryEntry(entry),
+          isSymlink: entry.isSymbolicLink()
+        }))
         return sortDirEntries(mapped)
       } catch (error: unknown) {
         recordCrashBreadcrumb(

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -1511,16 +1511,11 @@ export class RuntimeFileCommands {
 
     const dirPath = await resolveAuthorizedPath(target.path, this.host.requireStore())
     const entries = await readdir(dirPath, { withFileTypes: true })
-    const mapped = await Promise.all(
-      entries.map(async (entry) => {
-        const entryPath = join(dirPath, entry.name)
-        return {
-          name: entry.name,
-          isDirectory: await isRuntimeDirectoryEntry(entry, entryPath),
-          isSymlink: entry.isSymbolicLink()
-        }
-      })
-    )
+    const mapped = entries.map((entry) => ({
+      name: entry.name,
+      isDirectory: isRuntimeDirectoryEntry(entry),
+      isSymlink: entry.isSymbolicLink()
+    }))
     return sortDirEntries(mapped)
   }
 
@@ -2573,13 +2568,12 @@ function basenameFromRelativePath(relativePath: string): string {
   return normalized.slice(normalized.lastIndexOf('/') + 1)
 }
 
-async function isRuntimeDirectoryEntry(
-  entry: { isDirectory(): boolean; isSymbolicLink(): boolean },
-  _entryPath: string
-): Promise<boolean> {
+function isRuntimeDirectoryEntry(entry: {
+  isDirectory(): boolean
+  isSymbolicLink(): boolean
+}): boolean {
   // Why: listings are passive UI reads; don't stat symlink targets here (explicit open/expand resolves them).
   if (entry.isSymbolicLink()) {
-    void _entryPath
     return false
   }
   if (entry.isDirectory()) {

--- a/src/relay/fs-path-metadata-requests.test.ts
+++ b/src/relay/fs-path-metadata-requests.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { readdirMock, statMock } = vi.hoisted(() => ({
+  readdirMock: vi.fn(),
+  statMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>
+  return { ...original, readdir: readdirMock, stat: statMock }
+})
+
+import { readRelayDir } from './fs-path-metadata-requests'
+
+function dirEntry(args: { name: string; directory?: boolean; symlink?: boolean }) {
+  return {
+    name: args.name,
+    isDirectory: () => args.directory ?? false,
+    isSymbolicLink: () => args.symlink ?? false
+  }
+}
+
+describe('readRelayDir', () => {
+  beforeEach(() => {
+    readdirMock.mockReset()
+    statMock.mockReset()
+  })
+
+  it('creates asynchronous classification work only for symlinks in a large listing', async () => {
+    readdirMock.mockResolvedValue([
+      ...Array.from({ length: 1_000 }, (_, index) => dirEntry({ name: `file-${index}.txt` })),
+      dirEntry({ name: 'directory', directory: true }),
+      dirEntry({ name: 'directory-link', symlink: true }),
+      dirEntry({ name: 'file-link', symlink: true })
+    ])
+    statMock
+      .mockResolvedValueOnce({ isDirectory: () => true })
+      .mockResolvedValueOnce({ isDirectory: () => false })
+
+    const originalAll = Promise.all.bind(Promise)
+    let promiseBearingEntries = -1
+    const allSpy = vi.spyOn(Promise, 'all').mockImplementation(((values: Iterable<unknown>) => {
+      const entries = Array.from(values)
+      promiseBearingEntries = entries.filter((entry) => entry instanceof Promise).length
+      return originalAll(entries)
+    }) as typeof Promise.all)
+
+    try {
+      const result = await readRelayDir({ dirPath: '/repo' })
+
+      expect(result.slice(0, 2)).toEqual([
+        { name: 'directory', isDirectory: true, isSymlink: false },
+        { name: 'directory-link', isDirectory: true, isSymlink: true }
+      ])
+      expect(result.find((entry) => entry.name === 'file-link')).toEqual({
+        name: 'file-link',
+        isDirectory: false,
+        isSymlink: true
+      })
+    } finally {
+      allSpy.mockRestore()
+    }
+
+    expect(statMock).toHaveBeenCalledTimes(2)
+    expect(promiseBearingEntries).toBe(2)
+  })
+})

--- a/src/relay/fs-path-metadata-requests.ts
+++ b/src/relay/fs-path-metadata-requests.ts
@@ -3,16 +3,10 @@ import { join } from 'node:path'
 import { sortDirEntries } from '../shared/file-name-sort'
 import { expandTilde } from './context'
 
-async function isDirectoryEntry(
+async function resolveSymlinkDirectoryEntry(
   dirPath: string,
   entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean }
 ): Promise<boolean> {
-  if (entry.isDirectory()) {
-    return true
-  }
-  if (!entry.isSymbolicLink()) {
-    return false
-  }
   try {
     // Why: the file explorer needs target type for symlinked directories so a
     // workspace link to an external folder expands instead of opening as a file.
@@ -43,13 +37,26 @@ function fileStatFromLstat(stats: Awaited<ReturnType<typeof lstat>>) {
 export async function readRelayDir(params: Record<string, unknown>) {
   const dirPath = expandTilde(params.dirPath as string)
   const entries = await readdir(dirPath, { withFileTypes: true })
-  const mapped = await Promise.all(
-    entries.map(async (entry) => ({
+  const mapped: { name: string; isDirectory: boolean; isSymlink: boolean }[] = []
+  const symlinkProbes: Promise<void>[] = []
+  for (const entry of entries) {
+    const mappedEntry = {
       name: entry.name,
-      isDirectory: await isDirectoryEntry(dirPath, entry),
+      isDirectory: entry.isDirectory(),
       isSymlink: entry.isSymbolicLink()
-    }))
-  )
+    }
+    mapped.push(mappedEntry)
+    if (!mappedEntry.isDirectory && mappedEntry.isSymlink) {
+      symlinkProbes.push(
+        resolveSymlinkDirectoryEntry(dirPath, entry).then((isDirectory) => {
+          mappedEntry.isDirectory = isDirectory
+        })
+      )
+    }
+  }
+  if (symlinkProbes.length > 0) {
+    await Promise.all(symlinkProbes)
+  }
   return sortDirEntries(mapped)
 }
 


### PR DESCRIPTION
## ELI5

Orca was wrapping every file in a directory listing in a tiny promise, even when deciding file-vs-folder was already available synchronously. This removes those empty promise wrappers and keeps asynchronous work only for relay symlinks that genuinely need a target lookup.

## What Changed

- Map local Electron `fs:readDir` entries synchronously.
- Map runtime file-explorer entries synchronously.
- In the relay, classify normal files/directories synchronously and await only symlink target stats.
- Preserve sorting and the different local-vs-relay symlink policies.

## Why

Large folders feed one async callback and one promise into `Promise.all` per entry despite ordinary `Dirent` classification requiring no I/O. This adds allocation and microtask overhead on file-explorer refresh paths.

## Performance Measurement

Deterministic relay fixture: 1,003 entries (1,000 files, one directory, two symlinks).

- Before: **1,003 promise-bearing classification entries**.
- After: **2 promise-bearing entries**, exactly matching the two symlinks that require `stat`.
- Improvement: **99.8% fewer per-entry promises** in the measured listing.

For local and runtime listings with no symlinks, per-entry promises drop from **N to 0 (100%)**.

## User-Facing Trade-offs

None. Names, sort order, local authorization, local non-following symlink behavior, relay symlink-directory expansion, and per-link failure behavior are unchanged. SSH provider routing and wire shapes are untouched.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

N/A — file explorer contents and behavior are unchanged.

## Testing

- [x] Focused filesystem/runtime/relay suites (145 passed, 1 skipped)
- [x] Folder-workspace, SSH, and UNC routing coverage (3 passed)
- [x] `pnpm tc:node`
- [x] Focused oxlint/format and diff checks

## Review

Self-reviewed for macOS TCC-safe local symlink handling, relay symlink targets, Windows/UNC path construction, SSH ownership, folder workspaces, and mixed-version wire compatibility.

## Agent skill upstream boundary

- [x] Not applicable.
