### PR TITLE
perf(renderer): avoid remote PTY selector allocations

### DIFF
--- a/src/renderer/src/lib/tab-agent-remote-pty-selector.ts
+++ b/src/renderer/src/lib/tab-agent-remote-pty-selector.ts
@@ -1,0 +1,23 @@
+import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
+
+/** Checks both PTY projections without allocating a dedupe set on each store notification. */
+export function hasRemoteRuntimePtyForTab(
+  tabPtyIds: readonly string[] | undefined,
+  leafPtyIdsById: Readonly<Record<string, string>> | undefined
+): boolean {
+  if (tabPtyIds?.some((ptyId) => parseRemoteRuntimePtyId(ptyId) !== null)) {
+    return true
+  }
+  if (!leafPtyIdsById) {
+    return false
+  }
+  for (const leafId in leafPtyIdsById) {
+    if (
+      Object.hasOwn(leafPtyIdsById, leafId) &&
+      parseRemoteRuntimePtyId(leafPtyIdsById[leafId]!) !== null
+    ) {
+      return true
+    }
+  }
+  return false
+}

--- a/src/renderer/src/lib/use-tab-agent-remote-pty-selector.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-remote-pty-selector.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { hasRemoteRuntimePtyForTab } from './tab-agent-remote-pty-selector'
+
+const REMOTE_PTY = 'remote:environment-1@@terminal-1'
+
+describe('hasRemoteRuntimePtyForTab', () => {
+  it('short-circuits on a tab-level remote PTY', () => {
+    let leafReads = 0
+    const leafPtyIdsById = new Proxy(
+      { leaf: REMOTE_PTY },
+      {
+        ownKeys: () => {
+          leafReads += 1
+          return ['leaf']
+        }
+      }
+    )
+
+    expect(hasRemoteRuntimePtyForTab([REMOTE_PTY], leafPtyIdsById)).toBe(true)
+    expect(leafReads).toBe(0)
+  })
+
+  it('finds a remote PTY that is present only in the layout projection', () => {
+    expect(
+      hasRemoteRuntimePtyForTab(['local-pty'], { first: 'local-pty', second: REMOTE_PTY })
+    ).toBe(true)
+  })
+
+  it('ignores inherited layout properties like Object.values did', () => {
+    const inherited = { inherited: REMOTE_PTY }
+    const leafPtyIdsById = Object.create(inherited) as Record<string, string>
+    leafPtyIdsById.local = 'local-pty'
+
+    expect(hasRemoteRuntimePtyForTab(['local-pty'], leafPtyIdsById)).toBe(false)
+  })
+
+  it('avoids transient Set and Object.values allocations across repeated checks', () => {
+    const originalSet = globalThis.Set
+    const valuesSpy = vi.spyOn(Object, 'values').mockImplementation(() => {
+      throw new Error('unexpected Object.values allocation')
+    })
+    vi.stubGlobal(
+      'Set',
+      class UnexpectedSet {
+        constructor() {
+          throw new Error('unexpected Set allocation')
+        }
+      }
+    )
+
+    try {
+      for (let check = 0; check < 1_000; check += 1) {
+        expect(hasRemoteRuntimePtyForTab(['local-pty'], { first: 'local-pty-2' })).toBe(false)
+      }
+    } finally {
+      valuesSpy.mockRestore()
+      vi.stubGlobal('Set', originalSet)
+    }
+  })
+})

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
 import { isShellProcess } from '../../../shared/agent-detection'
 import { worktreeUsesRemoteConnection } from '@/store/terminals/terminal-workspace-routing'
-import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
+import { hasRemoteRuntimePtyForTab } from './tab-agent-remote-pty-selector'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
 import {
   resolveFocusedCompletedTabAgent,
@@ -254,14 +254,12 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     }
     return (s.ptyIdsByTabId[tab.id] ?? []).length <= 1
   })
-  const hasRemoteRuntimePty = useAppStore((s) => {
-    const layout = s.terminalLayoutsByTabId[tab.id]
-    const ptyIds = new Set(s.ptyIdsByTabId[tab.id] ?? [])
-    for (const ptyId of Object.values(layout?.ptyIdsByLeafId ?? {})) {
-      ptyIds.add(ptyId)
-    }
-    return [...ptyIds].some((ptyId) => parseRemoteRuntimePtyId(ptyId) !== null)
-  })
+  const hasRemoteRuntimePty = useAppStore((s) =>
+    hasRemoteRuntimePtyForTab(
+      s.ptyIdsByTabId[tab.id],
+      s.terminalLayoutsByTabId[tab.id]?.ptyIdsByLeafId
+    )
+  )
   const isRemoteWorktree = useAppStore((s) => worktreeUsesRemoteConnection(s, tab.worktreeId))
   const isRemoteLike = isRemoteWorktree || hasRemoteRuntimePty
 


### PR DESCRIPTION
## ELI5

Every tab checks whether any of its terminal IDs belongs to a remote runtime. That check was building and copying temporary collections on every store notification. It now scans the two existing collections directly and stops as soon as it finds a match.

## What Changed

- Replace transient `Set`, `Object.values`, and spread-array construction with an allocation-free selector helper.
- Check tab-level PTYs first for an early exit.
- Preserve own-property behavior for layout maps and the same remote-ID parser.

## Why

`useTabAgent` runs for visible tab icons and its Zustand selector is evaluated on store writes. Background terminal/status churn should not allocate three temporary collections per tab just to answer a boolean question.

## Performance Measurement

Deterministic 1,000-check fixture:

- Before: **1,000 Sets + 1,000 `Object.values` arrays + 1,000 spread arrays** = **3,000 transient collections**.
- After: **0 transient collections** from the selector.
- Improvement: **100% removal** of those measured allocations.

The test fails if the helper constructs a `Set` or calls `Object.values`, and also proves tab-level remote IDs skip layout enumeration entirely.

## User-Facing Trade-offs

None. The boolean result, remote-ID parsing, inherited-property behavior, tab icon identity, and local/remote routing remain unchanged.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

N/A — tab icons and behavior are unchanged.

## Testing

- [x] Focused selector and tab-agent suites (48 passed)
- [x] `pnpm tc:web`
- [x] Focused oxlint, React Doctor, and format checks

## Review

Self-reviewed for duplicate PTYs, tab-only/layout-only IDs, own properties, early exit, remote-runtime IDs, and ordinary SSH worktrees.

## Agent skill upstream boundary

- [x] Not applicable.
