### PR TITLE
perf(mobile): compare terminal themes without serialization

### DIFF
--- a/mobile/src/session/mobile-terminal-records.test.ts
+++ b/mobile/src/session/mobile-terminal-records.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   getTerminalRecordsFromSessionTabs,
   hasConnectedTerminalAbsentFromSessionTabs,
   mergeTerminalListWithKnownRecords,
   mergeTerminalRecordsByCurrentOrder,
   mobileSessionTabsEqual,
+  mobileTerminalThemesEqual,
   type MobileTerminalSessionTab,
   type TerminalRecord
 } from './mobile-terminal-records'
@@ -26,6 +27,35 @@ const darkTheme = {
 }
 
 describe('mobile terminal records', () => {
+  it('compares terminal themes without serializing them', () => {
+    const equivalentTheme = {
+      mode: 'dark' as const,
+      theme: { foreground: '#eeeeee', background: '#111111' }
+    }
+    const stringify = vi.spyOn(JSON, 'stringify').mockImplementation(() => {
+      throw new Error('unexpected theme serialization')
+    })
+
+    try {
+      for (let comparison = 0; comparison < 1_000; comparison += 1) {
+        expect(mobileTerminalThemesEqual(darkTheme, equivalentTheme)).toBe(true)
+        expect(mobileTerminalThemesEqual(darkTheme, lightTheme)).toBe(false)
+      }
+    } finally {
+      stringify.mockRestore()
+    }
+  })
+
+  it('detects additional theme fields from a newer host', () => {
+    const withNewField = {
+      ...darkTheme,
+      theme: { ...darkTheme.theme, futureAccent: '#ff00ff' }
+    }
+
+    expect(mobileTerminalThemesEqual(darkTheme, withNewField)).toBe(false)
+    expect(mobileTerminalThemesEqual(withNewField, { ...withNewField })).toBe(true)
+  })
+
   it('keeps the known theme when a session-tab snapshot omits it', () => {
     const known: TerminalRecord[] = [
       { handle: 'pty-1', title: 'Old title', terminalTheme: darkTheme, isActive: false }

--- a/mobile/src/session/mobile-terminal-records.ts
+++ b/mobile/src/session/mobile-terminal-records.ts
@@ -63,6 +63,34 @@ type MobileSessionTabLike =
       isActive?: boolean
     }
 
+export function mobileTerminalThemesEqual(
+  left: MobileTerminalTheme | null | undefined,
+  right: MobileTerminalTheme | null | undefined
+): boolean {
+  if (left === right) {
+    return true
+  }
+  if (!left || !right || left.mode !== right.mode) {
+    return false
+  }
+  const leftColors = left.theme as Readonly<Record<string, unknown>>
+  const rightColors = right.theme as Readonly<Record<string, unknown>>
+  for (const color in leftColors) {
+    if (
+      Object.hasOwn(leftColors, color) &&
+      (!Object.hasOwn(rightColors, color) || leftColors[color] !== rightColors[color])
+    ) {
+      return false
+    }
+  }
+  for (const color in rightColors) {
+    if (Object.hasOwn(rightColors, color) && !Object.hasOwn(leftColors, color)) {
+      return false
+    }
+  }
+  return true
+}
+
 export function mobileSessionTabsEqual(
   a: readonly MobileSessionTabLike[],
   b: readonly MobileSessionTabLike[]
@@ -96,7 +124,7 @@ function mobileSessionTabEqual(
         a.launchDraft === b.launchDraft &&
         a.launchDraftCreatedAt === b.launchDraftCreatedAt &&
         JSON.stringify(a.agentStatus ?? null) === JSON.stringify(b.agentStatus ?? null) &&
-        JSON.stringify(a.terminalTheme ?? null) === JSON.stringify(b.terminalTheme ?? null)
+        mobileTerminalThemesEqual(a.terminalTheme, b.terminalTheme)
       )
     case 'markdown':
       return (
@@ -234,8 +262,7 @@ export function terminalRecordsEqual(
       (terminal, index) =>
         terminal.handle === b[index]?.handle &&
         terminal.title === b[index]?.title &&
-        JSON.stringify(terminal.terminalTheme ?? null) ===
-          JSON.stringify(b[index]?.terminalTheme ?? null) &&
+        mobileTerminalThemesEqual(terminal.terminalTheme, b[index]?.terminalTheme) &&
         terminal.isActive === b[index]?.isActive
     )
   )


### PR DESCRIPTION
## ELI5

Mobile repeatedly asks whether terminal themes changed. It used to turn both themes into JSON strings just to compare them. Themes are shallow color maps, so this compares their fields directly without creating strings.

## What Changed

- Add an allocation-free equality check for terminal mode and color fields.
- Use it for session-tab and terminal-list reconciliation.
- Compare all own enumerable color fields so a field added by a newer host still triggers an update.

## Why

Terminal/session snapshots reconcile repeatedly. Serializing both theme objects on every unchanged comparison creates avoidable strings and scans the same data twice.

## Performance Measurement

Deterministic repeated-comparison fixture:

- Before: **2 `JSON.stringify` calls per theme comparison**.
- After: **0 `JSON.stringify` calls**.
- Improvement: **100% removal** of measured theme serialization (4,000 serializations avoided across the test's 2,000 equality calls).

The regression test makes `JSON.stringify` throw and completes all comparisons, while separate coverage proves changed modes/colors and newer-host fields still compare correctly.

## User-Facing Trade-offs

None. Equal themes remain equal; any known or future own color-field change still refreshes the terminal. No transport or persisted shape changes.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

N/A — terminal colors and update behavior are unchanged.

## Testing

- [x] `pnpm test src/session/mobile-terminal-records.test.ts` (14 passed)
- [x] `pnpm typecheck` in `mobile/`
- [x] Focused mobile oxlint and format checks

## Review

Self-reviewed for undefined themes, mode changes, field insertion order, additional fields from newer hosts, and remote wire compatibility.

## Agent skill upstream boundary

- [x] Not applicable.
