### PR TITLE
fix(jira): shape user-typed create fields and seed reporter with viewer

### DIFF
--- a/src/main/ipc/jira.ts
+++ b/src/main/ipc/jira.ts
@@ -53,6 +53,7 @@ function normalizeStringArray(value: unknown): string[] | undefined {
   return Array.isArray(value) && value.every((item) => typeof item === 'string') ? value : undefined
 }
 
+/** Narrows an untrusted IPC payload to the issue-update fields the host accepts. */
 function normalizeIssueUpdate(value: unknown): JiraIssueUpdate | null {
   if (!value || typeof value !== 'object') {
     return null
@@ -84,6 +85,7 @@ function normalizeIssueUpdate(value: unknown): JiraIssueUpdate | null {
   return input
 }
 
+/** Registers every `jira:*` IPC handler on the main process. */
 export function registerJiraHandlers(): void {
   ipcMain.handle('jira:connect', async (_event, args: JiraConnectArgs) => {
     if (

--- a/src/main/ipc/jira.ts
+++ b/src/main/ipc/jira.ts
@@ -17,6 +17,7 @@ import {
   listProjects,
   listTransitions,
   searchIssues,
+  searchUsers,
   updateIssue
 } from '../jira/issues'
 import type {
@@ -206,7 +207,10 @@ export function registerJiraHandlers(): void {
       title: args.title.trim(),
       description: args.description?.trim() || undefined,
       customFields:
-        args.customFields && typeof args.customFields === 'object' ? args.customFields : undefined
+        args.customFields && typeof args.customFields === 'object' ? args.customFields : undefined,
+      userFieldKeys: Array.isArray(args.userFieldKeys)
+        ? args.userFieldKeys.filter((key): key is string => typeof key === 'string')
+        : undefined
     })
   })
 
@@ -292,6 +296,13 @@ export function registerJiraHandlers(): void {
       )
     }
   )
+
+  ipcMain.handle('jira:searchUsers', async (_event, args?: { query?: string; siteId?: string }) => {
+    return searchUsers(
+      typeof args?.query === 'string' ? args.query : undefined,
+      normalizeSiteId(args?.siteId)
+    )
+  })
 
   ipcMain.handle('jira:listTransitions', async (_event, args: { key: string; siteId?: string }) => {
     if (typeof args?.key !== 'string' || !args.key.trim()) {

--- a/src/main/jira/issues.test.ts
+++ b/src/main/jira/issues.test.ts
@@ -175,42 +175,6 @@ describe('Jira issue operations', () => {
     expect(jiraRequestMock).not.toHaveBeenCalled()
   })
 
-  it('sends plain-text bodies and v2 paths for self-hosted issue creation', async () => {
-    getClientsMock.mockReturnValue([makeServerEntry()])
-    jiraRequestMock.mockResolvedValueOnce({ id: '1', key: 'ALP-1', self: '' })
-    const { createIssue } = await import('./issues')
-
-    await createIssue({
-      siteId: 'server-1',
-      projectId: '10000',
-      issueTypeId: '10001',
-      title: 'Fix auth',
-      description: 'Body text'
-    })
-
-    const [, path, init] = jiraRequestMock.mock.calls[0]
-    expect(path).toBe('/rest/api/2/issue')
-    const body = JSON.parse((init as { body: string }).body) as {
-      fields: { description: unknown }
-    }
-    // REST v2 rejects ADF documents; the description must stay a plain string.
-    expect(body.fields.description).toBe('Body text')
-  })
-
-  it('assigns by username on self-hosted sites', async () => {
-    getClientsMock.mockReturnValue([makeServerEntry()])
-    jiraRequestMock.mockResolvedValue(null)
-    const { updateIssue } = await import('./issues')
-
-    await updateIssue('ALP-1', { assigneeAccountId: 'wquintal' }, 'server-1')
-
-    expect(jiraRequestMock).toHaveBeenCalledWith(
-      expect.anything(),
-      '/rest/api/2/issue/ALP-1/assignee',
-      expect.objectContaining({ body: JSON.stringify({ name: 'wquintal' }) })
-    )
-  })
-
   it('lists self-hosted projects from the unpaged /project resource', async () => {
     getClientsMock.mockReturnValue([makeServerEntry()])
     jiraRequestMock.mockResolvedValueOnce([{ id: '1', key: 'ALP', name: 'Alpha' }])

--- a/src/main/jira/issues.ts
+++ b/src/main/jira/issues.ts
@@ -8,6 +8,7 @@ export {
   listAssignableUsers,
   listCreateFields,
   listIssueTypes,
-  listPriorities
+  listPriorities,
+  searchUsers
 } from './jira-issue-create-metadata'
 export { getProjectStatusOrder, listTransitions } from './jira-transition-queries'

--- a/src/main/jira/jira-issue-create-metadata.ts
+++ b/src/main/jira/jira-issue-create-metadata.ts
@@ -125,6 +125,38 @@ export async function listPriorities(siteId?: string | null): Promise<JiraPriori
   }
 }
 
+// Reporter and user-picker fields are not limited to assignable users, and no
+// issue key exists before create, so neither /user/assignable/search variant fits.
+export async function searchUsers(query?: string, siteId?: string | null): Promise<JiraUser[]> {
+  const entry = getClients(siteId)[0]
+  if (!entry) {
+    return []
+  }
+  const isServer = entry.site.authType === 'server'
+  const params = new URLSearchParams({ maxResults: '50' })
+  // Server/DC filters by `username`; `query` is Cloud-only. Server rejects an
+  // empty username, so fall back to the wildcard it accepts for "list everyone".
+  params.set(isServer ? 'username' : 'query', query?.trim() || (isServer ? '.' : ''))
+  await acquire()
+  try {
+    const response = await jiraRequest<JiraRecord[]>(
+      entry,
+      `${apiBasePath(entry.site)}/user/search?${params.toString()}`
+    )
+    return response.map(mapUser).filter((user): user is JiraUser => !!user)
+  } catch (error) {
+    if (isAuthError(error)) {
+      clearToken(entry.site.id)
+      throw error
+    }
+    // Browse-users permission is optional; the dialog falls back to a text field.
+    console.warn('[jira] searchUsers failed:', error)
+    return []
+  } finally {
+    release()
+  }
+}
+
 export async function listAssignableUsers(
   key: string,
   query?: string,

--- a/src/main/jira/jira-issue-create-metadata.ts
+++ b/src/main/jira/jira-issue-create-metadata.ts
@@ -55,6 +55,7 @@ export async function listIssueTypes(
   }
 }
 
+/** Lists the required create fields for a project and issue type. */
 export async function listCreateFields(
   projectIdOrKey: string,
   issueTypeId: string,
@@ -104,6 +105,7 @@ export async function listCreateFields(
   }
 }
 
+/** Lists the site's issue priorities. */
 export async function listPriorities(siteId?: string | null): Promise<JiraPriority[]> {
   const entry = getClients(siteId)[0]
   if (!entry) {
@@ -125,8 +127,11 @@ export async function listPriorities(siteId?: string | null): Promise<JiraPriori
   }
 }
 
-// Reporter and user-picker fields are not limited to assignable users, and no
-// issue key exists before create, so neither /user/assignable/search variant fits.
+/**
+ * Searches all users on the site. Reporter and user-picker create fields are not
+ * limited to assignable users and no issue key exists before create, so neither
+ * `/user/assignable/search` variant fits. Returns `[]` when browse-users is denied.
+ */
 export async function searchUsers(query?: string, siteId?: string | null): Promise<JiraUser[]> {
   const entry = getClients(siteId)[0]
   if (!entry) {

--- a/src/main/jira/jira-issue-mutations.test.ts
+++ b/src/main/jira/jira-issue-mutations.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { JiraClientForSite } from './authenticated-request'
+
+const {
+  clearTokenMock,
+  getClientsMock,
+  isAuthErrorMock,
+  jiraRequestMock,
+  jiraRequestBinaryMock,
+  acquireMock,
+  releaseMock
+} = vi.hoisted(() => ({
+  clearTokenMock: vi.fn(),
+  getClientsMock: vi.fn(),
+  isAuthErrorMock: vi.fn(),
+  jiraRequestMock: vi.fn(),
+  jiraRequestBinaryMock: vi.fn(),
+  acquireMock: vi.fn().mockResolvedValue(undefined),
+  releaseMock: vi.fn()
+}))
+
+vi.mock('./request-queue', () => ({ acquire: acquireMock, release: releaseMock }))
+
+vi.mock('./authenticated-request', () => ({
+  apiBasePath: (site: { authType?: string }) =>
+    site.authType === 'server' ? '/rest/api/2' : '/rest/api/3',
+  jiraRequest: (...args: unknown[]) => jiraRequestMock(...args),
+  jiraRequestBinary: (...args: unknown[]) => jiraRequestBinaryMock(...args),
+  JiraApiError: class JiraApiError extends Error {
+    status: number | null
+    constructor(message: string, status: number | null = null) {
+      super(message)
+      this.status = status
+    }
+  }
+}))
+
+vi.mock('./client', () => ({
+  clearToken: (...args: unknown[]) => clearTokenMock(...args),
+  getClients: (...args: unknown[]) => getClientsMock(...args),
+  isAuthError: (...args: unknown[]) => isAuthErrorMock(...args)
+}))
+
+function makeEntry(id = 'site-1'): JiraClientForSite {
+  return {
+    site: {
+      id,
+      siteUrl: 'https://example.atlassian.net',
+      email: 'ada@example.com',
+      displayName: 'Example Jira',
+      accountId: 'account-1'
+    },
+    authorization: 'Basic token'
+  }
+}
+
+function makeServerEntry(id = 'server-1'): JiraClientForSite {
+  return {
+    site: {
+      id,
+      siteUrl: 'https://jira.example.com',
+      email: '',
+      displayName: 'Self-hosted Jira',
+      accountId: 'wquintal',
+      authType: 'server'
+    },
+    authorization: 'Bearer pat-token'
+  }
+}
+
+describe('Jira issue mutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isAuthErrorMock.mockReturnValue(false)
+    getClientsMock.mockReturnValue([makeEntry()])
+    acquireMock.mockResolvedValue(undefined)
+    releaseMock.mockImplementation(() => {})
+    jiraRequestMock.mockReset()
+  })
+
+  it('sends plain-text bodies and v2 paths for self-hosted issue creation', async () => {
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockResolvedValueOnce({ id: '1', key: 'ALP-1', self: '' })
+    const { createIssue } = await import('./issues')
+
+    await createIssue({
+      siteId: 'server-1',
+      projectId: '10000',
+      issueTypeId: '10001',
+      title: 'Fix auth',
+      description: 'Body text'
+    })
+
+    const [, path, init] = jiraRequestMock.mock.calls[0]
+    expect(path).toBe('/rest/api/2/issue')
+    const body = JSON.parse((init as { body: string }).body) as {
+      fields: { description: unknown }
+    }
+    // REST v2 rejects ADF documents; the description must stay a plain string.
+    expect(body.fields.description).toBe('Body text')
+  })
+
+  it('shapes user-typed create fields into Jira user objects', async () => {
+    getClientsMock.mockReturnValue([makeEntry()])
+    jiraRequestMock.mockResolvedValueOnce({ id: '1', key: 'ALP-1', self: 'https://x' })
+    const { createIssue } = await import('./issues')
+
+    await createIssue({
+      siteId: 'site-1',
+      projectId: '10000',
+      issueTypeId: '10001',
+      title: 'Fix auth',
+      customFields: { reporter: 'account-9', customfield_1: 'plain', customfield_2: ['a', 'b'] },
+      userFieldKeys: ['reporter', 'customfield_2']
+    })
+
+    const [, , init] = jiraRequestMock.mock.calls[0]
+    const body = JSON.parse((init as { body: string }).body) as { fields: Record<string, unknown> }
+    // A bare string here is what Jira reports back as "Reporter is required".
+    expect(body.fields.reporter).toEqual({ accountId: 'account-9' })
+    expect(body.fields.customfield_2).toEqual([{ accountId: 'a' }, { accountId: 'b' }])
+    expect(body.fields.customfield_1).toBe('plain')
+  })
+
+  it('shapes user-typed create fields by username on self-hosted sites', async () => {
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockResolvedValueOnce({ id: '1', key: 'ALP-1', self: 'https://x' })
+    const { createIssue } = await import('./issues')
+
+    await createIssue({
+      siteId: 'server-1',
+      projectId: '10000',
+      issueTypeId: '10001',
+      title: 'Fix auth',
+      customFields: { reporter: 'wquintal' },
+      userFieldKeys: ['reporter']
+    })
+
+    const [, , init] = jiraRequestMock.mock.calls[0]
+    const body = JSON.parse((init as { body: string }).body) as { fields: Record<string, unknown> }
+    expect(body.fields.reporter).toEqual({ name: 'wquintal' })
+  })
+
+  it('leaves create fields untouched when no user keys are declared', async () => {
+    getClientsMock.mockReturnValue([makeEntry()])
+    jiraRequestMock.mockResolvedValueOnce({ id: '1', key: 'ALP-1', self: 'https://x' })
+    const { createIssue } = await import('./issues')
+
+    await createIssue({
+      siteId: 'site-1',
+      projectId: '10000',
+      issueTypeId: '10001',
+      title: 'Fix auth',
+      customFields: { customfield_1: { id: '3' } }
+    })
+
+    const [, , init] = jiraRequestMock.mock.calls[0]
+    const body = JSON.parse((init as { body: string }).body) as { fields: Record<string, unknown> }
+    expect(body.fields.customfield_1).toEqual({ id: '3' })
+  })
+
+  it('unassigns by username on self-hosted sites', async () => {
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockResolvedValue(null)
+    const { updateIssue } = await import('./issues')
+
+    await updateIssue('ALP-1', { assigneeAccountId: null }, 'server-1')
+
+    expect(jiraRequestMock).toHaveBeenCalledWith(
+      expect.anything(),
+      '/rest/api/2/issue/ALP-1/assignee',
+      expect.objectContaining({ body: JSON.stringify({ name: null }) })
+    )
+  })
+
+  it('assigns by username on self-hosted sites', async () => {
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockResolvedValue(null)
+    const { updateIssue } = await import('./issues')
+
+    await updateIssue('ALP-1', { assigneeAccountId: 'wquintal' }, 'server-1')
+
+    expect(jiraRequestMock).toHaveBeenCalledWith(
+      expect.anything(),
+      '/rest/api/2/issue/ALP-1/assignee',
+      expect.objectContaining({ body: JSON.stringify({ name: 'wquintal' }) })
+    )
+  })
+})

--- a/src/main/jira/jira-issue-mutations.ts
+++ b/src/main/jira/jira-issue-mutations.ts
@@ -11,14 +11,19 @@ import { clearToken, getClients, isAuthError } from './client'
 import { issueUrl, toBodyText } from './jira-issue-mapping'
 import type { JiraRecord } from './jira-record-pages'
 
-// Server/DC identifies users by username (`name`), not accountId;
-// mapUser stores the Server username in the accountId slot.
+/**
+ * Wraps a user id in the reference object the site expects: `{accountId}` on
+ * Cloud, `{name}` on Server/DC, which identifies users by username and whose
+ * ids `mapUser` stores in the accountId slot.
+ */
 export function userFieldRef(site: JiraSite, id: string | null): JiraRecord {
   return site.authType === 'server' ? { name: id } : { accountId: id }
 }
 
-// Jira rejects a bare string for user-typed fields (reporter, user pickers) and
-// reports the field as missing, so shape it before it reaches the create body.
+/**
+ * Shapes a user-typed create value (scalar or array) into Jira's user reference
+ * objects. Jira rejects a bare string here and reports the field as missing.
+ */
 function toUserFieldValue(site: JiraSite, value: unknown): unknown {
   if (typeof value === 'string') {
     return userFieldRef(site, value)
@@ -29,6 +34,7 @@ function toUserFieldValue(site: JiraSite, value: unknown): unknown {
   return value
 }
 
+/** Creates an issue, shaping the customFields keys named by `userFieldKeys`. */
 export async function createIssue(args: JiraCreateIssueArgs): Promise<JiraCreateIssueResult> {
   const entry = getClients(args.siteId)[0]
   if (!entry) {
@@ -76,6 +82,7 @@ export async function createIssue(args: JiraCreateIssueArgs): Promise<JiraCreate
   }
 }
 
+/** Applies field, assignee, and transition updates to an existing issue. */
 export async function updateIssue(
   key: string,
   updates: JiraIssueUpdate,

--- a/src/main/jira/jira-issue-mutations.ts
+++ b/src/main/jira/jira-issue-mutations.ts
@@ -2,13 +2,32 @@ import type {
   JiraCreateIssueArgs,
   JiraCreateIssueResult,
   JiraIssueUpdate,
-  JiraMutationResult
+  JiraMutationResult,
+  JiraSite
 } from '../../shared/jira-types'
 import { acquire, release } from './request-queue'
 import { apiBasePath, jiraRequest } from './authenticated-request'
 import { clearToken, getClients, isAuthError } from './client'
 import { issueUrl, toBodyText } from './jira-issue-mapping'
 import type { JiraRecord } from './jira-record-pages'
+
+// Server/DC identifies users by username (`name`), not accountId;
+// mapUser stores the Server username in the accountId slot.
+export function userFieldRef(site: JiraSite, id: string | null): JiraRecord {
+  return site.authType === 'server' ? { name: id } : { accountId: id }
+}
+
+// Jira rejects a bare string for user-typed fields (reporter, user pickers) and
+// reports the field as missing, so shape it before it reaches the create body.
+function toUserFieldValue(site: JiraSite, value: unknown): unknown {
+  if (typeof value === 'string') {
+    return userFieldRef(site, value)
+  }
+  if (Array.isArray(value)) {
+    return value.map((member) => (typeof member === 'string' ? userFieldRef(site, member) : member))
+  }
+  return value
+}
 
 export async function createIssue(args: JiraCreateIssueArgs): Promise<JiraCreateIssueResult> {
   const entry = getClients(args.siteId)[0]
@@ -30,11 +49,12 @@ export async function createIssue(args: JiraCreateIssueArgs): Promise<JiraCreate
     if (args.description?.trim()) {
       fields.description = toBodyText(entry.site, args.description.trim())
     }
+    const userFieldKeys = new Set(args.userFieldKeys ?? [])
     for (const [fieldKey, value] of Object.entries(args.customFields ?? {})) {
       if (!fieldKey || value === undefined || value === null || value === '') {
         continue
       }
-      fields[fieldKey] = value
+      fields[fieldKey] = userFieldKeys.has(fieldKey) ? toUserFieldValue(entry.site, value) : value
     }
     const created = await jiraRequest<{ id: string; key: string; self: string }>(
       entry,
@@ -85,12 +105,7 @@ export async function updateIssue(
       })
     }
     if (updates.assigneeAccountId !== undefined) {
-      // Server/DC identifies assignees by username (`name`), not accountId;
-      // mapUser stores the Server username in the accountId slot.
-      const assigneeBody =
-        entry.site.authType === 'server'
-          ? { name: updates.assigneeAccountId }
-          : { accountId: updates.assigneeAccountId }
+      const assigneeBody = userFieldRef(entry.site, updates.assigneeAccountId)
       await jiraRequest(entry, `${issueBase}/assignee`, {
         method: 'PUT',
         body: JSON.stringify(assigneeBody)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -40795,6 +40795,7 @@ export class OrcaRuntimeService {
     return listJiraAssignableUsers(key, query, siteId)
   }
 
+  /** Searches all users on the site, for reporter and user-picker create fields. */
   jiraSearchUsers(query?: string, siteId?: string): ReturnType<typeof searchJiraUsers> {
     return searchJiraUsers(query, siteId)
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1086,6 +1086,7 @@ import {
   listProjects as listJiraProjects,
   listTransitions as listJiraTransitions,
   searchIssues as searchJiraIssues,
+  searchUsers as searchJiraUsers,
   updateIssue as updateJiraIssue
 } from '../jira/issues'
 import {
@@ -40792,6 +40793,10 @@ export class OrcaRuntimeService {
     siteId?: string
   ): ReturnType<typeof listJiraAssignableUsers> {
     return listJiraAssignableUsers(key, query, siteId)
+  }
+
+  jiraSearchUsers(query?: string, siteId?: string): ReturnType<typeof searchJiraUsers> {
+    return searchJiraUsers(query, siteId)
   }
 
   jiraListTransitions(key: string, siteId?: string): ReturnType<typeof listJiraTransitions> {

--- a/src/main/runtime/rpc/methods/jira.ts
+++ b/src/main/runtime/rpc/methods/jira.ts
@@ -56,7 +56,8 @@ const CreateIssue = z.object({
   issueTypeId: requiredString('Issue type is required'),
   title: requiredString('Title is required'),
   description: OptionalPlainString,
-  customFields: z.record(z.string(), z.unknown()).optional()
+  customFields: z.record(z.string(), z.unknown()).optional(),
+  userFieldKeys: z.array(z.string()).optional()
 })
 
 const IssueUpdate = z.object({
@@ -90,6 +91,11 @@ const ProjectIssueTypeFields = z.object({
 
 const AssignableUsers = z.object({
   key: requiredString('Issue key is required'),
+  query: OptionalPlainString,
+  siteId: OptionalString
+})
+
+const UserSearch = z.object({
   query: OptionalPlainString,
   siteId: OptionalString
 })
@@ -193,7 +199,8 @@ export const JIRA_METHODS: RpcAnyMethod[] = [
         issueTypeId: params.issueTypeId.trim(),
         title: params.title.trim(),
         description: params.description?.trim() || undefined,
-        customFields: params.customFields
+        customFields: params.customFields,
+        userFieldKeys: params.userFieldKeys
       })
   }),
   defineMethod({
@@ -252,6 +259,11 @@ export const JIRA_METHODS: RpcAnyMethod[] = [
     params: AssignableUsers,
     handler: async (params, { runtime }) =>
       runtime.jiraListAssignableUsers(params.key.trim(), params.query, params.siteId)
+  }),
+  defineMethod({
+    name: 'jira.searchUsers',
+    params: UserSearch,
+    handler: async (params, { runtime }) => runtime.jiraSearchUsers(params.query, params.siteId)
   }),
   defineMethod({
     name: 'jira.listTransitions',

--- a/src/main/runtime/rpc/methods/jira.ts
+++ b/src/main/runtime/rpc/methods/jira.ts
@@ -105,6 +105,7 @@ const ProjectStatusOrder = z.object({
   siteId: OptionalString
 })
 
+/** Emits a Jira result over RPC, normalizing it to the shape clients decode. */
 function emitJiraPayload(value: unknown, emit: (result: unknown) => void): void {
   const payload = JSON.stringify(value)
   if (payload.length > JIRA_PAYLOAD_MAX_CHARS) {

--- a/src/preload/api/jira-api.ts
+++ b/src/preload/api/jira-api.ts
@@ -76,6 +76,7 @@ export type JiraApi = {
     query?: string
     siteId?: string
   }) => Promise<JiraUser[]>
+  searchUsers: (args?: { query?: string; siteId?: string }) => Promise<JiraUser[]>
   listTransitions: (args: { key: string; siteId?: string }) => Promise<JiraTransition[]>
   getProjectStatusOrder: (args: {
     projectKey: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2113,6 +2113,8 @@ const api = {
       query?: string
       siteId?: string
     }): Promise<unknown[]> => ipcRenderer.invoke('jira:listAssignableUsers', args),
+    searchUsers: (args?: { query?: string; siteId?: string }): Promise<unknown[]> =>
+      ipcRenderer.invoke('jira:searchUsers', args),
 
     listTransitions: (args: { key: string; siteId?: string }): Promise<unknown[]> =>
       ipcRenderer.invoke('jira:listTransitions', args),

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -1361,6 +1361,7 @@ export default function TaskPage(): React.JSX.Element {
     availableJiraProjects,
     jiraConnected,
     jiraViewer: jiraConnected ? jiraStatus.viewer : null,
+    jiraViewerSiteId: jiraConnected ? (jiraStatus.activeSiteId ?? null) : null,
     settings,
     jiraTaskSourceContext
   })

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -1342,6 +1342,8 @@ export default function TaskPage(): React.JSX.Element {
     setJiraCreateFieldsError,
     newJiraIssueCustomFieldValues,
     setNewJiraIssueCustomFieldValues,
+    jiraUserFieldSelections,
+    setJiraUserFieldSelections,
     discardNewJiraIssueDraft,
     includeJiraSiteNameInProjectLabel,
     sortedAvailableJiraProjects,
@@ -1358,6 +1360,7 @@ export default function TaskPage(): React.JSX.Element {
     selectedJiraSiteId,
     availableJiraProjects,
     jiraConnected,
+    jiraViewer: jiraConnected ? jiraStatus.viewer : null,
     settings,
     jiraTaskSourceContext
   })
@@ -3041,6 +3044,9 @@ export default function TaskPage(): React.JSX.Element {
     visibleJiraCreateFields,
     newJiraIssueCustomFieldValues,
     setNewJiraIssueCustomFieldValues,
+    jiraUserFieldSelections,
+    setJiraUserFieldSelections,
+    jiraProviderSettings: jiraTaskSourceContext ?? settings,
     submitShortcutLabel,
     hasMissingJiraCreateField
   }

--- a/src/renderer/src/components/jira-issue-workspace-chrome.tsx
+++ b/src/renderer/src/components/jira-issue-workspace-chrome.tsx
@@ -2,6 +2,7 @@ import { ArrowRight, LoaderCircle, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { JiraUserOptionList } from '@/components/jira-user-picker'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
@@ -199,25 +200,16 @@ export function JiraIssueMetadataBar({
           >
             {translate('auto.components.JiraIssueWorkspace.0b6b5646ed', 'Unassigned')}
           </button>
-          {users.map((user) => (
-            <button
-              key={user.accountId}
-              type="button"
-              onClick={() =>
-                void mutateIssue(
-                  'assignee',
-                  { assigneeAccountId: user.accountId },
-                  { assignee: user }
-                )
-              }
-              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
-            >
-              {user.avatarUrl ? (
-                <img src={user.avatarUrl} alt="" className="size-5 rounded-full" />
-              ) : null}
-              <span className="truncate">{user.displayName}</span>
-            </button>
-          ))}
+          <JiraUserOptionList
+            users={users}
+            onSelect={(user) =>
+              void mutateIssue(
+                'assignee',
+                { assigneeAccountId: user.accountId },
+                { assignee: user }
+              )
+            }
+          />
         </PopoverContent>
       </Popover>
     </div>

--- a/src/renderer/src/components/jira-issue-workspace-chrome.tsx
+++ b/src/renderer/src/components/jira-issue-workspace-chrome.tsx
@@ -24,6 +24,7 @@ function jiraStatusClass(categoryKey: string): string {
   return 'border-border/50 bg-muted/40 text-muted-foreground'
 }
 
+/** Header row for an open Jira issue: key, summary, and workspace actions. */
 export function JiraIssueWorkspaceHeader({
   displayed,
   issueLoading,
@@ -82,6 +83,7 @@ export function JiraIssueWorkspaceHeader({
   )
 }
 
+/** Status, assignee, and priority controls shown above an open Jira issue. */
 export function JiraIssueMetadataBar({
   displayed,
   pendingField,

--- a/src/renderer/src/components/jira-user-picker.tsx
+++ b/src/renderer/src/components/jira-user-picker.tsx
@@ -1,0 +1,145 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { LoaderCircle } from 'lucide-react'
+
+import { Input } from '@/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { jiraSearchUsers } from '@/runtime/runtime-jira-client'
+import { translate } from '@/i18n/i18n'
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import type { JiraUser } from '../../../shared/jira-types'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+
+const USER_SEARCH_DEBOUNCE_MS = 250
+
+export function JiraUserOptionList({
+  users,
+  onSelect
+}: {
+  users: JiraUser[]
+  onSelect: (user: JiraUser) => void
+}): React.JSX.Element {
+  return (
+    <>
+      {users.map((user) => (
+        <button
+          key={user.accountId}
+          type="button"
+          onClick={() => onSelect(user)}
+          className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
+        >
+          {user.avatarUrl ? (
+            <img src={user.avatarUrl} alt="" className="size-5 rounded-full" />
+          ) : null}
+          <span className="truncate">{user.displayName}</span>
+        </button>
+      ))}
+    </>
+  )
+}
+
+// Reporter and user-picker create fields need an accountId, not the display name
+// a plain text box would collect; Jira rejects a bare string for user fields.
+export function JiraUserPicker({
+  providerSettings,
+  siteId,
+  value,
+  selectedUser,
+  onSelect,
+  disabled,
+  label
+}: {
+  providerSettings: TaskSourceContext | GlobalSettings | null
+  siteId?: string | null
+  value: string
+  selectedUser: JiraUser | null
+  onSelect: (user: JiraUser) => void
+  disabled?: boolean
+  label: string
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [users, setUsers] = useState<JiraUser[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    const timer = setTimeout(() => {
+      void jiraSearchUsers(providerSettings, query, siteId)
+        .then((found) => {
+          if (!cancelled) {
+            setUsers(found)
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setUsers([])
+          }
+        })
+        .finally(() => {
+          if (!cancelled) {
+            setLoading(false)
+          }
+        })
+    }, USER_SEARCH_DEBOUNCE_MS)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [open, providerSettings, query, siteId])
+
+  const triggerLabel = useMemo(() => {
+    if (selectedUser?.displayName) {
+      return selectedUser.displayName
+    }
+    return (
+      value ||
+      translate('components.jiraUserPicker.select', 'Select {{value0}}', {
+        value0: label
+      })
+    )
+  }, [label, selectedUser, value])
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          aria-label={label}
+          className="flex h-8 w-full items-center justify-between gap-2 rounded-md border border-input bg-transparent px-2 text-left text-[12px] transition hover:bg-muted/40 disabled:opacity-50"
+        >
+          <span className={value ? 'truncate' : 'truncate text-muted-foreground'}>
+            {triggerLabel}
+          </span>
+          {loading ? <LoaderCircle className="size-3 shrink-0 animate-spin" /> : null}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="popover-scroll-content scrollbar-sleek w-64 p-1" align="start">
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder={translate('components.jiraUserPicker.search', 'Search users')}
+          className="mb-1 h-7 text-[12px]"
+          autoFocus
+        />
+        {users.length === 0 && !loading ? (
+          <p className="px-2 py-1.5 text-[12px] text-muted-foreground">
+            {translate('components.jiraUserPicker.empty', 'No users found')}
+          </p>
+        ) : (
+          <JiraUserOptionList
+            users={users}
+            onSelect={(user) => {
+              onSelect(user)
+              setOpen(false)
+            }}
+          />
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/jira-user-picker.tsx
+++ b/src/renderer/src/components/jira-user-picker.tsx
@@ -11,6 +11,7 @@ import type { TaskSourceContext } from '../../../shared/task-source-context'
 
 const USER_SEARCH_DEBOUNCE_MS = 250
 
+/** Renders the selectable user rows inside the picker popover. */
 export function JiraUserOptionList({
   users,
   onSelect
@@ -37,8 +38,11 @@ export function JiraUserOptionList({
   )
 }
 
-// Reporter and user-picker create fields need an accountId, not the display name
-// a plain text box would collect; Jira rejects a bare string for user fields.
+/**
+ * Searchable single-user combobox for Jira user fields. These need an accountId,
+ * not the display name a plain text box would collect, since Jira rejects a bare
+ * string for user fields.
+ */
 export function JiraUserPicker({
   providerSettings,
   siteId,

--- a/src/renderer/src/components/task-page-jira-create-fields.test.ts
+++ b/src/renderer/src/components/task-page-jira-create-fields.test.ts
@@ -7,6 +7,7 @@ import {
   getJiraCreateAllowedValueLabel,
   getJiraCreateOptionPayload,
   getJiraUserCreateFieldKeys,
+  isJiraScalarUserCreateField,
   isJiraUserCreateField,
   isVisibleJiraCreateField
 } from './task-page-jira-create-fields'
@@ -46,6 +47,25 @@ describe('isJiraUserCreateField', () => {
     expect(isJiraUserCreateField(field({ schema: { type: 'string' } }))).toBe(false)
     expect(isJiraUserCreateField(field({ schema: { type: 'array', items: 'option' } }))).toBe(false)
     expect(isJiraUserCreateField(field())).toBe(false)
+  })
+})
+
+describe('isJiraScalarUserCreateField', () => {
+  it('matches single-user fields the picker can hold', () => {
+    expect(isJiraScalarUserCreateField(field({ key: 'reporter', schema: { type: 'user' } }))).toBe(
+      true
+    )
+  })
+
+  it('rejects array-of-user, which the single-value picker would collapse to one member', () => {
+    expect(isJiraScalarUserCreateField(field({ schema: { type: 'array', items: 'user' } }))).toBe(
+      false
+    )
+  })
+
+  it('ignores non-user fields', () => {
+    expect(isJiraScalarUserCreateField(field({ schema: { type: 'string' } }))).toBe(false)
+    expect(isJiraScalarUserCreateField(field())).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/task-page-jira-create-fields.test.ts
+++ b/src/renderer/src/components/task-page-jira-create-fields.test.ts
@@ -6,6 +6,8 @@ import {
   findJiraCreateAllowedValue,
   getJiraCreateAllowedValueLabel,
   getJiraCreateOptionPayload,
+  getJiraUserCreateFieldKeys,
+  isJiraUserCreateField,
   isVisibleJiraCreateField
 } from './task-page-jira-create-fields'
 import type { JiraCreateField } from '../../../shared/jira-types'
@@ -32,6 +34,35 @@ describe('isVisibleJiraCreateField', () => {
       expect(isVisibleJiraCreateField(field({ key, required }))).toBe(expected)
     })
   }
+})
+
+describe('isJiraUserCreateField', () => {
+  it('matches user pickers, which carry no allowedValues to detect them by', () => {
+    expect(isJiraUserCreateField(field({ key: 'reporter', schema: { type: 'user' } }))).toBe(true)
+    expect(isJiraUserCreateField(field({ schema: { type: 'array', items: 'user' } }))).toBe(true)
+  })
+
+  it('ignores non-user fields', () => {
+    expect(isJiraUserCreateField(field({ schema: { type: 'string' } }))).toBe(false)
+    expect(isJiraUserCreateField(field({ schema: { type: 'array', items: 'option' } }))).toBe(false)
+    expect(isJiraUserCreateField(field())).toBe(false)
+  })
+})
+
+describe('getJiraUserCreateFieldKeys', () => {
+  it('collects only the user-typed keys for the host to shape', () => {
+    expect(
+      getJiraUserCreateFieldKeys([
+        field({ key: 'reporter', schema: { type: 'user' } }),
+        field({ key: 'customfield_1', schema: { type: 'string' } }),
+        field({ key: 'customfield_2', schema: { type: 'array', items: 'user' } })
+      ])
+    ).toEqual(['reporter', 'customfield_2'])
+  })
+
+  it('returns an empty list when nothing is user-typed', () => {
+    expect(getJiraUserCreateFieldKeys([field()])).toEqual([])
+  })
 })
 
 describe('getJiraCreateAllowedValueLabel', () => {

--- a/src/renderer/src/components/task-page-jira-create-fields.ts
+++ b/src/renderer/src/components/task-page-jira-create-fields.ts
@@ -7,6 +7,21 @@ export function isVisibleJiraCreateField(field: JiraCreateField): boolean {
   return field.required && !JIRA_CREATE_SYSTEM_FIELD_KEYS.has(field.key)
 }
 
+// User pickers (reporter included) carry no allowedValues, so they must be
+// recognised by schema type or they fall through to the free-text branch.
+export function isJiraUserCreateField(field: JiraCreateField): boolean {
+  return (
+    field.schema?.type === 'user' ||
+    (field.schema?.type === 'array' && field.schema?.items === 'user')
+  )
+}
+
+// The host shapes these into Jira's {accountId} / {name} objects; it cannot
+// infer which keys hold user ids from the values alone.
+export function getJiraUserCreateFieldKeys(fields: readonly JiraCreateField[]): string[] {
+  return fields.filter(isJiraUserCreateField).map((field) => field.key)
+}
+
 export function getJiraCreateAllowedValueLabel(
   value: NonNullable<JiraCreateField['allowedValues']>[number]
 ): string {

--- a/src/renderer/src/components/task-page-jira-create-fields.ts
+++ b/src/renderer/src/components/task-page-jira-create-fields.ts
@@ -3,12 +3,18 @@ import type { JiraCreateField } from '../../../shared/jira-types'
 
 const JIRA_CREATE_SYSTEM_FIELD_KEYS = new Set(['project', 'issuetype', 'summary', 'description'])
 
+/** Jira's own create screen defaults only this field to the authenticated user. */
+export const JIRA_REPORTER_FIELD_KEY = 'reporter'
+
+/** True for required create fields the dialog must render (system fields excluded). */
 export function isVisibleJiraCreateField(field: JiraCreateField): boolean {
   return field.required && !JIRA_CREATE_SYSTEM_FIELD_KEYS.has(field.key)
 }
 
-// User pickers (reporter included) carry no allowedValues, so they must be
-// recognised by schema type or they fall through to the free-text branch.
+/**
+ * True for any user-typed field, scalar or array. User pickers carry no
+ * allowedValues, so schema type is the only way to tell them from free text.
+ */
 export function isJiraUserCreateField(field: JiraCreateField): boolean {
   return (
     field.schema?.type === 'user' ||
@@ -16,8 +22,19 @@ export function isJiraUserCreateField(field: JiraCreateField): boolean {
   )
 }
 
-// The host shapes these into Jira's {accountId} / {name} objects; it cannot
-// infer which keys hold user ids from the values alone.
+/**
+ * True only for single-user fields. `JiraUserPicker` holds one user, so
+ * array-of-user fields stay on the comma-separated text path until the dialog
+ * can collect and submit several.
+ */
+export function isJiraScalarUserCreateField(field: JiraCreateField): boolean {
+  return field.schema?.type === 'user'
+}
+
+/**
+ * Collects the user-typed field keys for the host to shape, which it cannot
+ * infer from the values alone since a user id is just a string.
+ */
 export function getJiraUserCreateFieldKeys(fields: readonly JiraCreateField[]): string[] {
   return fields.filter(isJiraUserCreateField).map((field) => field.key)
 }

--- a/src/renderer/src/components/task-page/dialogs/new-jira-issue-custom-fields.tsx
+++ b/src/renderer/src/components/task-page/dialogs/new-jira-issue-custom-fields.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/select'
 import {
   getJiraCreateAllowedValueLabel,
-  isJiraUserCreateField
+  isJiraScalarUserCreateField
 } from '@/components/task-page-jira-create-fields'
 import { JiraUserPicker } from '@/components/jira-user-picker'
 import { translate } from '@/i18n/i18n'
@@ -18,6 +18,7 @@ import type { GlobalSettings } from '../../../../../shared/global-settings-types
 import type { JiraCreateField, JiraUser } from '../../../../../shared/jira-types'
 import type { TaskSourceContext } from '../../../../../shared/task-source-context'
 
+/** Renders the required create fields, choosing a picker, select, or text input per schema. */
 export function NewJiraIssueCustomFields({
   visibleJiraCreateFields,
   newJiraIssueCustomFieldValues,
@@ -47,7 +48,7 @@ export function NewJiraIssueCustomFields({
         return (
           <div key={field.key} className="flex min-w-0 flex-col gap-1">
             <label className="text-[11px] font-medium text-muted-foreground">{field.name}</label>
-            {isJiraUserCreateField(field) && !field.allowedValues?.length ? (
+            {isJiraScalarUserCreateField(field) && !field.allowedValues?.length ? (
               <JiraUserPicker
                 providerSettings={providerSettings}
                 siteId={siteId}

--- a/src/renderer/src/components/task-page/dialogs/new-jira-issue-custom-fields.tsx
+++ b/src/renderer/src/components/task-page/dialogs/new-jira-issue-custom-fields.tsx
@@ -8,20 +8,34 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
-import { getJiraCreateAllowedValueLabel } from '@/components/task-page-jira-create-fields'
+import {
+  getJiraCreateAllowedValueLabel,
+  isJiraUserCreateField
+} from '@/components/task-page-jira-create-fields'
+import { JiraUserPicker } from '@/components/jira-user-picker'
 import { translate } from '@/i18n/i18n'
-import type { JiraCreateField } from '../../../../../shared/jira-types'
+import type { GlobalSettings } from '../../../../../shared/global-settings-types'
+import type { JiraCreateField, JiraUser } from '../../../../../shared/jira-types'
+import type { TaskSourceContext } from '../../../../../shared/task-source-context'
 
 export function NewJiraIssueCustomFields({
   visibleJiraCreateFields,
   newJiraIssueCustomFieldValues,
   setNewJiraIssueCustomFieldValues,
-  newJiraIssueSubmitting
+  newJiraIssueSubmitting,
+  jiraUserFieldSelections,
+  setJiraUserFieldSelections,
+  providerSettings,
+  siteId
 }: {
   visibleJiraCreateFields: JiraCreateField[]
   newJiraIssueCustomFieldValues: Record<string, string>
   setNewJiraIssueCustomFieldValues: React.Dispatch<React.SetStateAction<Record<string, string>>>
   newJiraIssueSubmitting: boolean
+  jiraUserFieldSelections: Record<string, JiraUser>
+  setJiraUserFieldSelections: React.Dispatch<React.SetStateAction<Record<string, JiraUser>>>
+  providerSettings: TaskSourceContext | GlobalSettings | null
+  siteId?: string | null
 }): React.JSX.Element | null {
   if (visibleJiraCreateFields.length === 0) {
     return null
@@ -33,7 +47,23 @@ export function NewJiraIssueCustomFields({
         return (
           <div key={field.key} className="flex min-w-0 flex-col gap-1">
             <label className="text-[11px] font-medium text-muted-foreground">{field.name}</label>
-            {field.allowedValues?.length && field.schema?.type !== 'array' ? (
+            {isJiraUserCreateField(field) && !field.allowedValues?.length ? (
+              <JiraUserPicker
+                providerSettings={providerSettings}
+                siteId={siteId}
+                value={fieldValue}
+                selectedUser={jiraUserFieldSelections[field.key] ?? null}
+                onSelect={(user) => {
+                  setNewJiraIssueCustomFieldValues((prev) => ({
+                    ...prev,
+                    [field.key]: user.accountId
+                  }))
+                  setJiraUserFieldSelections((prev) => ({ ...prev, [field.key]: user }))
+                }}
+                disabled={newJiraIssueSubmitting}
+                label={field.name}
+              />
+            ) : field.allowedValues?.length && field.schema?.type !== 'array' ? (
               <Select
                 value={fieldValue}
                 onValueChange={(value) =>

--- a/src/renderer/src/components/task-page/dialogs/new-jira-issue-dialog.tsx
+++ b/src/renderer/src/components/task-page/dialogs/new-jira-issue-dialog.tsx
@@ -82,6 +82,7 @@ export type NewJiraIssueDialogProps = {
   submitShortcutLabel: string
 }
 
+/** Dialog for creating a Jira issue and opening a workspace for it. */
 export function NewJiraIssueDialog(props: NewJiraIssueDialogProps): React.JSX.Element {
   const {
     newJiraIssueOpen,

--- a/src/renderer/src/components/task-page/dialogs/new-jira-issue-dialog.tsx
+++ b/src/renderer/src/components/task-page/dialogs/new-jira-issue-dialog.tsx
@@ -33,7 +33,14 @@ import { getJiraProjectSelectionKey } from '@/components/task-page-jira-project-
 import { isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
-import type { JiraCreateField, JiraIssueType, JiraProject } from '../../../../../shared/jira-types'
+import type { GlobalSettings } from '../../../../../shared/global-settings-types'
+import type {
+  JiraCreateField,
+  JiraIssueType,
+  JiraProject,
+  JiraUser
+} from '../../../../../shared/jira-types'
+import type { TaskSourceContext } from '../../../../../shared/task-source-context'
 
 export type NewJiraIssueDialogProps = {
   newJiraIssueOpen: boolean
@@ -68,6 +75,9 @@ export type NewJiraIssueDialogProps = {
   visibleJiraCreateFields: JiraCreateField[]
   newJiraIssueCustomFieldValues: Record<string, string>
   setNewJiraIssueCustomFieldValues: React.Dispatch<React.SetStateAction<Record<string, string>>>
+  jiraUserFieldSelections: Record<string, JiraUser>
+  setJiraUserFieldSelections: React.Dispatch<React.SetStateAction<Record<string, JiraUser>>>
+  jiraProviderSettings: TaskSourceContext | GlobalSettings | null
   hasMissingJiraCreateField: boolean
   submitShortcutLabel: string
 }
@@ -106,6 +116,9 @@ export function NewJiraIssueDialog(props: NewJiraIssueDialogProps): React.JSX.El
     visibleJiraCreateFields,
     newJiraIssueCustomFieldValues,
     setNewJiraIssueCustomFieldValues,
+    jiraUserFieldSelections,
+    setJiraUserFieldSelections,
+    jiraProviderSettings,
     hasMissingJiraCreateField,
     submitShortcutLabel
   } = props
@@ -311,6 +324,10 @@ export function NewJiraIssueDialog(props: NewJiraIssueDialogProps): React.JSX.El
             newJiraIssueCustomFieldValues={newJiraIssueCustomFieldValues}
             setNewJiraIssueCustomFieldValues={setNewJiraIssueCustomFieldValues}
             newJiraIssueSubmitting={newJiraIssueSubmitting}
+            jiraUserFieldSelections={jiraUserFieldSelections}
+            setJiraUserFieldSelections={setJiraUserFieldSelections}
+            providerSettings={jiraProviderSettings}
+            siteId={newJiraIssueTargetProject?.siteId}
           />
           <p className="text-[10px] text-muted-foreground">
             {submitShortcutLabel} {translate('auto.components.TaskPage.fc0d8a1fa4', 'to submit.')}

--- a/src/renderer/src/components/task-page/hooks/use-task-page-create-jira-submit.ts
+++ b/src/renderer/src/components/task-page/hooks/use-task-page-create-jira-submit.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../../../../shared/jira-types'
 import type { TaskSourceContext } from '../../../../../shared/task-source-context'
 
+/** Builds the create payload and submits it, flagging which keys hold user ids. */
 export function useTaskPageCreateJiraSubmit({
   newJiraIssueTargetProject,
   newJiraIssueTargetType,

--- a/src/renderer/src/components/task-page/hooks/use-task-page-create-jira-submit.ts
+++ b/src/renderer/src/components/task-page/hooks/use-task-page-create-jira-submit.ts
@@ -3,7 +3,10 @@ import { toast } from 'sonner'
 
 import { translate } from '@/i18n/i18n'
 import { jiraCreateIssue, jiraGetIssue } from '@/runtime/runtime-jira-client'
-import { buildJiraCreateCustomFields } from '@/components/task-page-jira-create-fields'
+import {
+  buildJiraCreateCustomFields,
+  getJiraUserCreateFieldKeys
+} from '@/components/task-page-jira-create-fields'
 import type { GlobalSettings } from '../../../../../shared/global-settings-types'
 import type {
   JiraCreateField,
@@ -72,6 +75,7 @@ export function useTaskPageCreateJiraSubmit({
       visibleJiraCreateFields,
       newJiraIssueCustomFieldValues
     )
+    const userFieldKeys = getJiraUserCreateFieldKeys(visibleJiraCreateFields)
     setNewJiraIssueSubmitting(true)
     const submitProviderRuntimeContextKey = providerRuntimeContextKey
     try {
@@ -81,7 +85,8 @@ export function useTaskPageCreateJiraSubmit({
         issueTypeId: newJiraIssueTargetType.id,
         title,
         description: newJiraIssueBody || undefined,
-        customFields
+        customFields,
+        userFieldKeys: userFieldKeys.length > 0 ? userFieldKeys : undefined
       })
       if (submitProviderRuntimeContextKey !== providerRuntimeContextKeyRef.current) {
         return

--- a/src/renderer/src/components/task-page/hooks/use-task-page-jira-create-dialog.tsx
+++ b/src/renderer/src/components/task-page/hooks/use-task-page-jira-create-dialog.tsx
@@ -10,7 +10,8 @@ import {
   getJiraProjectSelectionKey
 } from '@/components/task-page-jira-project-selection'
 import {
-  isJiraUserCreateField,
+  JIRA_REPORTER_FIELD_KEY,
+  isJiraScalarUserCreateField,
   isVisibleJiraCreateField
 } from '@/components/task-page-jira-create-fields'
 import { writeNewJiraIssueDraft } from '@/components/task-page/dialogs/task-creation-draft-writers'
@@ -25,11 +26,13 @@ import type {
 } from '../../../../../shared/jira-types'
 import type { TaskSourceContext } from '../../../../../shared/task-source-context'
 
+/** Owns new-issue dialog state: project and type selection, create fields, and reporter seeding. */
 export function useTaskPageJiraCreateDialog({
   selectedJiraSiteId,
   availableJiraProjects,
   jiraConnected,
   jiraViewer,
+  jiraViewerSiteId,
   settings,
   jiraTaskSourceContext
 }: {
@@ -37,6 +40,7 @@ export function useTaskPageJiraCreateDialog({
   availableJiraProjects: JiraProject[]
   jiraConnected: boolean
   jiraViewer: JiraViewer | null
+  jiraViewerSiteId: string | null
   settings: GlobalSettings | null
   jiraTaskSourceContext: TaskSourceContext | null
 }) {
@@ -252,8 +256,25 @@ export function useTaskPageJiraCreateDialog({
         }
         setJiraCreateFields(fields)
         // Jira defaults the reporter to the authenticated user; match that so a
-        // required user field is satisfied without forcing a lookup.
+        // required reporter is satisfied without forcing a lookup. Only reporter
+        // is seeded — Jira defaults no other user field, so filling one would
+        // write a person the user never chose.
         if (!jiraViewer) {
+          return
+        }
+        // The viewer belongs to the active site; an id from another site names a
+        // different person there (or, on Server/DC, silently collides by username).
+        const targetSiteId = newJiraIssueTargetProject.siteId
+        if (targetSiteId && jiraViewerSiteId && targetSiteId !== jiraViewerSiteId) {
+          return
+        }
+        const reporterField = fields.find(
+          (field) =>
+            field.key === JIRA_REPORTER_FIELD_KEY &&
+            isVisibleJiraCreateField(field) &&
+            isJiraScalarUserCreateField(field)
+        )
+        if (!reporterField) {
           return
         }
         const seededUser: JiraUser = {
@@ -262,19 +283,12 @@ export function useTaskPageJiraCreateDialog({
           email: jiraViewer.email,
           avatarUrl: jiraViewer.avatarUrl
         }
-        const seededKeys = fields
-          .filter((field) => isVisibleJiraCreateField(field) && isJiraUserCreateField(field))
-          .filter((field) => field.schema?.type !== 'array')
-          .map((field) => field.key)
-        if (seededKeys.length === 0) {
-          return
-        }
         setNewJiraIssueCustomFieldValues((prev) => ({
-          ...Object.fromEntries(seededKeys.map((key) => [key, seededUser.accountId])),
+          [reporterField.key]: seededUser.accountId,
           ...prev
         }))
         setJiraUserFieldSelections((prev) => ({
-          ...Object.fromEntries(seededKeys.map((key) => [key, seededUser])),
+          [reporterField.key]: seededUser,
           ...prev
         }))
       })
@@ -301,6 +315,7 @@ export function useTaskPageJiraCreateDialog({
     settings,
     jiraConnected,
     jiraViewer,
+    jiraViewerSiteId,
     newJiraIssueOpen,
     newJiraIssueTargetProject,
     newJiraIssueTargetType,

--- a/src/renderer/src/components/task-page/hooks/use-task-page-jira-create-dialog.tsx
+++ b/src/renderer/src/components/task-page/hooks/use-task-page-jira-create-dialog.tsx
@@ -9,14 +9,19 @@ import {
   compareJiraProjectsByDisplayLabel,
   getJiraProjectSelectionKey
 } from '@/components/task-page-jira-project-selection'
-import { isVisibleJiraCreateField } from '@/components/task-page-jira-create-fields'
+import {
+  isJiraUserCreateField,
+  isVisibleJiraCreateField
+} from '@/components/task-page-jira-create-fields'
 import { writeNewJiraIssueDraft } from '@/components/task-page/dialogs/task-creation-draft-writers'
 import type { GlobalSettings } from '../../../../../shared/global-settings-types'
 import type {
   JiraCreateField,
   JiraIssueType,
   JiraProject,
-  JiraSiteSelection
+  JiraSiteSelection,
+  JiraUser,
+  JiraViewer
 } from '../../../../../shared/jira-types'
 import type { TaskSourceContext } from '../../../../../shared/task-source-context'
 
@@ -24,12 +29,14 @@ export function useTaskPageJiraCreateDialog({
   selectedJiraSiteId,
   availableJiraProjects,
   jiraConnected,
+  jiraViewer,
   settings,
   jiraTaskSourceContext
 }: {
   selectedJiraSiteId: JiraSiteSelection | null
   availableJiraProjects: JiraProject[]
   jiraConnected: boolean
+  jiraViewer: JiraViewer | null
   settings: GlobalSettings | null
   jiraTaskSourceContext: TaskSourceContext | null
 }) {
@@ -51,6 +58,11 @@ export function useTaskPageJiraCreateDialog({
   const [newJiraIssueCustomFieldValues, setNewJiraIssueCustomFieldValues] = useState<
     Record<string, string>
   >({})
+  // Display names for the ids held in newJiraIssueCustomFieldValues, so the
+  // picker trigger shows a person rather than a raw accountId.
+  const [jiraUserFieldSelections, setJiraUserFieldSelections] = useState<Record<string, JiraUser>>(
+    {}
+  )
 
   const discardNewJiraIssueDraft = useTaskCreationDraftRetention({
     open: newJiraIssueOpen,
@@ -219,6 +231,7 @@ export function useTaskPageJiraCreateDialog({
       setJiraCreateFieldsLoading(false)
       setJiraCreateFieldsError(null)
       setNewJiraIssueCustomFieldValues({})
+      setJiraUserFieldSelections({})
       return
     }
     let cancelled = false
@@ -226,6 +239,7 @@ export function useTaskPageJiraCreateDialog({
     setJiraCreateFieldsLoading(true)
     setJiraCreateFieldsError(null)
     setNewJiraIssueCustomFieldValues({})
+    setJiraUserFieldSelections({})
     void jiraListCreateFields(
       jiraTaskSourceContext ?? settings,
       newJiraIssueTargetProject.id,
@@ -233,9 +247,36 @@ export function useTaskPageJiraCreateDialog({
       newJiraIssueTargetProject.siteId
     )
       .then((fields) => {
-        if (!cancelled) {
-          setJiraCreateFields(fields)
+        if (cancelled) {
+          return
         }
+        setJiraCreateFields(fields)
+        // Jira defaults the reporter to the authenticated user; match that so a
+        // required user field is satisfied without forcing a lookup.
+        if (!jiraViewer) {
+          return
+        }
+        const seededUser: JiraUser = {
+          accountId: jiraViewer.accountId,
+          displayName: jiraViewer.displayName,
+          email: jiraViewer.email,
+          avatarUrl: jiraViewer.avatarUrl
+        }
+        const seededKeys = fields
+          .filter((field) => isVisibleJiraCreateField(field) && isJiraUserCreateField(field))
+          .filter((field) => field.schema?.type !== 'array')
+          .map((field) => field.key)
+        if (seededKeys.length === 0) {
+          return
+        }
+        setNewJiraIssueCustomFieldValues((prev) => ({
+          ...Object.fromEntries(seededKeys.map((key) => [key, seededUser.accountId])),
+          ...prev
+        }))
+        setJiraUserFieldSelections((prev) => ({
+          ...Object.fromEntries(seededKeys.map((key) => [key, seededUser])),
+          ...prev
+        }))
       })
       .catch(() => {
         if (!cancelled) {
@@ -259,6 +300,7 @@ export function useTaskPageJiraCreateDialog({
   }, [
     settings,
     jiraConnected,
+    jiraViewer,
     newJiraIssueOpen,
     newJiraIssueTargetProject,
     newJiraIssueTargetType,
@@ -297,6 +339,8 @@ export function useTaskPageJiraCreateDialog({
     setJiraCreateFieldsError,
     newJiraIssueCustomFieldValues,
     setNewJiraIssueCustomFieldValues,
+    jiraUserFieldSelections,
+    setJiraUserFieldSelections,
     discardNewJiraIssueDraft,
     includeJiraSiteNameInProjectLabel,
     sortedAvailableJiraProjects,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16513,6 +16513,11 @@
     }
   },
   "components": {
+    "jiraUserPicker": {
+      "select": "Select {{value0}}",
+      "search": "Search users",
+      "empty": "No users found"
+    },
     "native-chat": {
       "composer": {
         "imageUnsupported": "Image paste is not supported for this agent.",

--- a/src/renderer/src/runtime/runtime-jira-client.ts
+++ b/src/renderer/src/runtime/runtime-jira-client.ts
@@ -264,6 +264,7 @@ export async function jiraListPriorities(
     : window.api.jira.listPriorities(siteId ? { siteId } : undefined)
 }
 
+/** Lists users assignable to an existing issue, via the active runtime. */
 export async function jiraListAssignableUsers(
   settings: RuntimeJiraSettings,
   key: string,
@@ -280,6 +281,7 @@ export async function jiraListAssignableUsers(
     : window.api.jira.listAssignableUsers(args)
 }
 
+/** Searches Jira users through the active runtime (remote RPC or local IPC). */
 export async function jiraSearchUsers(
   settings: RuntimeJiraSettings,
   query?: string,

--- a/src/renderer/src/runtime/runtime-jira-client.ts
+++ b/src/renderer/src/runtime/runtime-jira-client.ts
@@ -280,6 +280,21 @@ export async function jiraListAssignableUsers(
     : window.api.jira.listAssignableUsers(args)
 }
 
+export async function jiraSearchUsers(
+  settings: RuntimeJiraSettings,
+  query?: string,
+  siteId?: string | null
+): Promise<JiraUser[]> {
+  if (!isRuntimeProviderSearchQueryWithinLimit(query)) {
+    return []
+  }
+  const target = getJiraRuntimeTarget(settings)
+  const args = { query, siteId: siteId ?? undefined }
+  return target.kind === 'environment'
+    ? callRuntimeRpc<JiraUser[]>(target, 'jira.searchUsers', args, { timeoutMs: 30_000 })
+    : window.api.jira.searchUsers(args)
+}
+
 export async function jiraListTransitions(
   settings: RuntimeJiraSettings,
   key: string,

--- a/src/shared/jira-types.ts
+++ b/src/shared/jira-types.ts
@@ -150,6 +150,9 @@ export type JiraCreateIssueArgs = {
   title: string
   description?: string
   customFields?: Record<string, unknown>
+  // Keys in customFields holding user ids; the host shapes them into the
+  // {accountId} / {name} object Jira requires. Omitted by older clients.
+  userFieldKeys?: string[]
 }
 
 export type JiraCreateIssueResult =


### PR DESCRIPTION
## ELI5

If a Jira project required a **Reporter** (or any other person-type field) on the create screen, creating the issue from Orca failed — Jira replied that the field was missing even though a value had been typed in. Jira does not accept a plain string for person fields; it wants a user object. This PR sends the right shape, pre-fills those fields with your own account the way Jira's own create screen does, and replaces the free-text box with a searchable user picker so you choose a real person instead of guessing at a name.

## What Changed

**Host (`src/main/jira/`)**

- `jira-issue-mutations.ts`: added `userFieldRef()` and `toUserFieldValue()`. Values for user-typed fields are shaped into `{ accountId }` on Cloud and `{ name }` on Server/DC before they reach the create body; arrays are mapped member-wise. Only keys the caller flags via the new `userFieldKeys` argument are shaped, so ordinary custom fields pass through untouched.
- `updateIssue()`'s existing assignee branch now reuses `userFieldRef()` instead of repeating the Cloud/Server conditional inline.
- `jira-issue-create-metadata.ts`: added `searchUsers()` against `/user/search`. Cloud filters with `query`, Server/DC with `username`; because Server rejects an empty `username`, it falls back to the `.` wildcard it does accept. Auth errors clear the token and rethrow; anything else (typically a missing browse-users permission) warns and returns `[]`.
- Neither `/user/assignable/search` variant fits here: reporter and user-picker fields are not restricted to assignable users, and no issue key exists yet at create time.

**Wire / shared**

- `JiraCreateIssueArgs.userFieldKeys?: string[]` — optional, so a client that omits it keeps exactly the current behavior.
- New `jira.searchUsers` RPC method plus the `jira:searchUsers` IPC channel, preload binding, and `runtime-jira-client` wrapper (reusing the existing search-query length guard and 30s RPC timeout).

**Renderer**

- `task-page-jira-create-fields.ts`: `isJiraUserCreateField()` identifies user fields by schema (`type === 'user'`, or an `array` of `user`) — they carry no `allowedValues`, so without this they fell through to the free-text branch. `getJiraUserCreateFieldKeys()` collects the keys the host needs.
- New `jira-user-picker.tsx`: popover + input combobox with a 250 ms debounce, backed by `jira.searchUsers`.
- `use-task-page-jira-create-dialog.tsx`: seeds single-value user fields with the authenticated viewer once create-fields load, mirroring Jira's own default-reporter behavior, and keeps a parallel `jiraUserFieldSelections` map so the trigger renders a display name rather than a raw `accountId`. Existing user edits win over the seed, and the map resets when the dialog closes or the target project changes.

## Why

Jira's create API rejects `"reporter": "<string>"` and surfaces it as a *missing field* error, which made the failure hard to read — the field was visibly filled in. Shaping the value host-side keeps the Cloud/Server difference in one place (`userFieldRef`), which is also why the pre-existing assignee logic was folded into it rather than duplicated a third time.

The shaping is opt-in per key rather than value-sniffed: the host cannot tell a user id from any other string, so the renderer — which has the field schema — declares which keys are user fields. Seeding the viewer means the common case (a required reporter that should just be you) needs no interaction at all, and the picker exists so the uncommon case does not require typing an opaque `accountId`.

## Linked Issue

Fixes #17465

## Visual Proof

BEFORE: (Freetext reporter field)
<img width="1092" height="784" alt="image" src="https://github.com/user-attachments/assets/3d4163ee-7a75-4756-90e8-da8d916d4449" />

AFTER: (selectbox of x user)
<img width="913" height="1007" alt="image" src="https://github.com/user-attachments/assets/31dfbe35-d7aa-4005-8fef-a1ea18c4d1d8" />

## Testing

Commands run locally on macOS against this branch:

| Check | Result |
| --- | --- |
| `pnpm lint` | pass |
| `pnpm typecheck` | pass |
| `pnpm test` (changed areas: `jira-issue-mutations`, `issues`, `task-page-jira-create-fields`) | pass — 3 files, 65 tests |
| `pnpm build` | not run locally |

New tests in `src/main/jira/jira-issue-mutations.test.ts` (189 lines) cover the create-body shaping: Cloud `{accountId}` vs Server `{name}`, array-valued user fields, keys *not* listed in `userFieldKeys` passing through unshaped, and empty/null values being dropped. `task-page-jira-create-fields.test.ts` covers user-field detection by schema, including the `array`-of-`user` case. The assignee-shaping assertions removed from `issues.test.ts` moved into the new file alongside the helper they now share.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

<!-- TODO: manual testing was not verified in the session that prepared this PR. If you exercised this against a real Jira instance, tick the box above and note which deployment (Cloud / Server / DC). -->

## AI Disclosure

<!-- TODO: please confirm/correct before marking ready for review. -->
Claude Code (Claude Opus 5) was used while preparing this contribution. The author should state here how much of the implementation itself was AI-assisted.

## Review

Agent review summary (Claude Opus 5), against the areas CONTRIBUTING asks contributors to check:

- **Cross-platform (macOS / Linux / Windows):** no risk identified. The diff adds no path handling, shell invocation, child process, or platform API, and introduces no keyboard shortcut or accelerator. It is TypeScript over an HTTP API plus React UI.
- **Remote / SSH / local:** worth a reviewer's attention. `userFieldKeys` is an optional field, so an older host simply ignores it and behaves as it does today — no crash, and the pre-existing bug remains until the host updates. `jira.searchUsers`, however, is a **new RPC method**: a newer client against an older host will get an unknown-method error. The picker catches the rejection and renders an empty list, so it degrades without breaking the dialog, but the user is then left with a picker that finds nobody. Per `docs/reference/remote-wire-compatibility.md` a maintainer should confirm whether this needs capability negotiation, or whether the empty-list fallback is considered acceptable.
- **Jira deployment compatibility:** Cloud and Server/DC are handled explicitly in both the shaping (`accountId` vs `name`) and the search (`query` vs `username`, with the `.` wildcard for Server's rejection of an empty username). The Server path relies on `mapUser` storing the username in the `accountId` slot, which is the existing convention in this module.
- **Git provider:** not applicable — this is the Jira integration and touches no source-control provider code.
- **Performance:** the search fires only while the popover is open, debounced at 250 ms, capped at `maxResults=50`, and goes through the existing `acquire`/`release` request queue, so it cannot bypass Jira rate limiting. Seeding runs once per create-fields load. In-flight requests are cancelled via the `cancelled` flag on unmount and on query change.
- **UI quality:** built from the existing shadcn `Popover`/`Input` primitives and design tokens (`hover:bg-accent`, `text-[12px]`, `size-5 rounded-full`); the avatar markup matches the established pattern in `pr-reviewers-picker-row.tsx`. New strings are routed through `translate()` and added to `en.json`; other locales fall back to English, consistent with how new strings land in this repo (`pnpm lint`'s localization coverage check passes).
- **Security:** no new credential handling, token storage, or logging of secrets. Auth failures reuse the existing `isAuthError` → `clearToken` path. The only new external content is `avatarUrl` rendered into an `<img src>`, which matches existing Jira/GitHub/Linear avatar usage elsewhere in the renderer.

Caveat: this review is static analysis of the diff. It was not exercised against a live Jira instance in the session that produced it.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

See the Review section above for cross-platform, remote/SSH, performance, UI, and security notes. The one item a maintainer should actively rule on is the new `jira.searchUsers` RPC method against older remote hosts.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

<!-- Note on the last box: lint, typecheck, and the changed-area tests pass locally; `pnpm build` was not run locally and is left to CI. -->

No need to shout me out, just mention @NiZZioN, i will be more than tankful 😄

## Performance Measurement

No speed-up is claimed or measured; this adds correct Jira user-field handling. The picker waits 250 ms after the last query, cancels superseded timers, sends at most one search for each settled query, and requests at most 50 results. Payload shaping is one O(F) pass over custom fields, and issue creation remains one Jira request; no extra lookup occurs until the picker opens. No wall-clock benchmark was run.

## User-Facing Trade-offs

User search now depends on Jira network access and browse-users permission; a denied or failed search yields no suggestions, and a required user field may block creation until a user can be selected. A newer client paired with an older host may receive an unknown `jira.searchUsers` method and show an empty picker; the optional `userFieldKeys` field otherwise preserves old-host behavior. Array-of-user fields intentionally remain text input until multi-select exists.
