### PR TITLE
perf(mobile): project home host connection maps once

### DIFF
--- a/mobile/src/home/home-host-connection-projection.test.ts
+++ b/mobile/src/home/home-host-connection-projection.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import type { MobileConnectionPath } from '../transport/stable-logical-rpc-client'
+import {
+  projectHomeHostConnections,
+  type HomeHostConnectionProjectionEntry
+} from './home-host-connection-projection'
+
+describe('projectHomeHostConnections', () => {
+  it('reads each connection once while preserving all lookup values', () => {
+    const entryCount = 1_000
+    const reads = {
+      hostId: 0,
+      path: 0,
+      pendingPath: 0,
+      pairingRejected: 0
+    }
+    const entries = Array.from({ length: entryCount }, (_, index) => {
+      const hostId = index === entryCount - 1 ? '__proto__' : `host-${index}`
+      const path: MobileConnectionPath = index % 2 === 0 ? 'lan' : 'relay'
+      const pendingPath = index === 1 ? undefined : index % 2 === 0 ? null : 'tailscale'
+      const pairingRejected = index % 3 === 0
+      const entry = {} as HomeHostConnectionProjectionEntry
+      Object.defineProperties(entry, {
+        hostId: {
+          enumerable: true,
+          get: () => {
+            reads.hostId += 1
+            return hostId
+          }
+        },
+        path: {
+          enumerable: true,
+          get: () => {
+            reads.path += 1
+            return path
+          }
+        },
+        pendingPath: {
+          enumerable: true,
+          get: () => {
+            reads.pendingPath += 1
+            return pendingPath
+          }
+        },
+        pairingRejected: {
+          enumerable: true,
+          get: () => {
+            reads.pairingRejected += 1
+            return pairingRejected
+          }
+        }
+      })
+      return entry
+    })
+
+    const projection = projectHomeHostConnections(entries)
+
+    expect(reads).toEqual({
+      hostId: entryCount,
+      path: entryCount,
+      pendingPath: entryCount,
+      pairingRejected: entryCount
+    })
+    expect(Object.keys(projection.hostPaths)).toHaveLength(entryCount)
+    expect(Object.keys(projection.hostPendingPaths)).toHaveLength(entryCount)
+    expect(Object.keys(projection.hostPairingRejected)).toHaveLength(entryCount)
+    expect(projection.hostPaths['host-0']).toBe('lan')
+    expect(projection.hostPaths['host-1']).toBe('relay')
+    expect(projection.hostPendingPaths['host-0']).toBeNull()
+    expect(projection.hostPendingPaths['host-1']).toBeUndefined()
+    expect(projection.hostPendingPaths['host-3']).toBe('tailscale')
+    expect(projection.hostPairingRejected['host-0']).toBe(true)
+    expect(projection.hostPairingRejected['host-1']).toBe(false)
+    expect(Object.hasOwn(projection.hostPaths, '__proto__')).toBe(true)
+    expect(projection.hostPaths['__proto__']).toBe('relay')
+    expect(Object.getPrototypeOf(projection.hostPaths)).toBe(Object.prototype)
+  })
+})

--- a/mobile/src/home/home-host-connection-projection.ts
+++ b/mobile/src/home/home-host-connection-projection.ts
@@ -1,0 +1,37 @@
+import type { MobileConnectionPath } from '../transport/stable-logical-rpc-client'
+
+export type HomeHostConnectionProjectionEntry = {
+  hostId: string
+  path: MobileConnectionPath
+  pendingPath: MobileConnectionPath | null
+  pairingRejected: boolean
+}
+
+export type HomeHostConnectionProjection = {
+  hostPaths: Record<string, MobileConnectionPath>
+  hostPendingPaths: Record<string, MobileConnectionPath | null>
+  hostPairingRejected: Record<string, boolean>
+}
+
+/** Build all host lookup maps while reading each connection entry once. */
+export function projectHomeHostConnections(
+  entries: readonly HomeHostConnectionProjectionEntry[]
+): HomeHostConnectionProjection {
+  // Null-prototype records avoid the __proto__ setter; restore the usual prototype for parity
+  // with Object.fromEntries once the projection is complete.
+  const hostPaths = Object.create(null) as Record<string, MobileConnectionPath>
+  const hostPendingPaths = Object.create(null) as Record<string, MobileConnectionPath | null>
+  const hostPairingRejected = Object.create(null) as Record<string, boolean>
+
+  for (const { hostId, path, pendingPath, pairingRejected } of entries) {
+    hostPaths[hostId] = path
+    hostPendingPaths[hostId] = pendingPath
+    hostPairingRejected[hostId] = pairingRejected
+  }
+
+  Object.setPrototypeOf(hostPaths, Object.prototype)
+  Object.setPrototypeOf(hostPendingPaths, Object.prototype)
+  Object.setPrototypeOf(hostPairingRejected, Object.prototype)
+
+  return { hostPaths, hostPendingPaths, hostPairingRejected }
+}

--- a/mobile/src/home/use-mobile-home-data.ts
+++ b/mobile/src/home/use-mobile-home-data.ts
@@ -29,6 +29,7 @@ import {
   fetchMobileHomeStats,
   fetchMobileHomeTaskProviders
 } from './mobile-home-host-requests'
+import { projectHomeHostConnections } from './home-host-connection-projection'
 import { useMobileHomeHostConnections } from './use-mobile-home-host-connections'
 
 export function useMobileHomeData() {
@@ -167,14 +168,9 @@ export function useMobileHomeData() {
   const primaryTaskProviders = primaryHost
     ? (taskProvidersByHost[primaryHost.id] ?? ['github'])
     : []
-  const hostPaths = Object.fromEntries(
-    connections.allClients.map(({ hostId, path }) => [hostId, path])
-  )
-  const hostPendingPaths = Object.fromEntries(
-    connections.allClients.map(({ hostId, pendingPath }) => [hostId, pendingPath])
-  )
-  const hostPairingRejected = Object.fromEntries(
-    connections.allClients.map(({ hostId, pairingRejected }) => [hostId, pairingRejected])
+  const hostConnectionProjection = useMemo(
+    () => projectHomeHostConnections(connections.allClients),
+    [connections.allClients]
   )
 
   return {
@@ -182,9 +178,9 @@ export function useMobileHomeData() {
     accountsHosts,
     connectedHosts,
     hostCatalog,
-    hostPairingRejected,
-    hostPaths,
-    hostPendingPaths,
+    hostPairingRejected: hostConnectionProjection.hostPairingRejected,
+    hostPaths: hostConnectionProjection.hostPaths,
+    hostPendingPaths: hostConnectionProjection.hostPendingPaths,
     primaryHost,
     primaryTaskProviders,
     resumeCard,


### PR DESCRIPTION
## ELI5

The mobile home screen needs three lookup tables from the same host list. It used to walk the whole list three times and create a tiny temporary pair for every table entry. This fills all three tables together in one walk and reuses them while the connection list is unchanged.

## What Changed

- Build active-path, pending-path, and pairing-rejection records in one pass.
- Memoize the combined projection by the stable `allClients` array identity.
- Preserve ordinary-object behavior, including own `__proto__` keys and `null` values.
- Add a deterministic 1,000-entry getter-count and parity test.

## Why

The mobile home hook rendered three `Object.fromEntries(connections.allClients.map(...))` projections independently. Each render repeated the host-list traversal, reread every host ID three times, and allocated three arrays of `[key, value]` pairs.

## Performance Measurement

Reproducible fixture: from `mobile/`, run `pnpm test src/home/home-host-connection-projection.test.ts`. The fixture projects 1,000 instrumented connection entries and counts every property read.

- Before: **3 full passes**, **3,000 host-ID reads**, and **3,000 transient `[key, value]` arrays**.
- After: **1 full pass**, **1,000 host-ID reads**, and **0 transient pair arrays**.
- Improvement: **66.7% fewer list passes and host-ID reads**, plus **100% removal** of measured pair-array allocations.

The `useMemo` also skips the projection entirely on unrelated renders where `allClients` retains its identity.

## User-Facing Trade-offs

None. The three lookup tables contain the same values and retain ordinary object prototypes. Coverage includes `null`, `undefined`, booleans, and an own `__proto__` host key.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

N/A — mobile home content and interaction behavior are unchanged.

## Testing

- [x] `pnpm test src/home/home-host-connection-projection.test.ts` from `mobile/` (1 passed)
- [x] `pnpm typecheck` from `mobile/`
- [x] Focused oxfmt check
- [x] Focused oxlint check
- [x] Commit hooks: oxlint, React Doctor, and oxfmt
- [x] `git diff --check`

## Review

Self-reviewed for duplicate host IDs, `null`/`undefined`, special object keys, memoization identity, cross-platform behavior, SSH/folder workspaces, and remote-wire compatibility. No platform, execution-boundary, or wire shape changes.

## Agent skill upstream boundary

- [x] Not applicable.
