### PR TITLE
perf(mobile): summarize diff review counts in one pass

### DIFF
--- a/mobile/src/session/mobile-diff-review-queue.test.ts
+++ b/mobile/src/session/mobile-diff-review-queue.test.ts
@@ -5,7 +5,9 @@ import type { MobileGitStatusEntry } from '../source-control/mobile-git-status'
 import {
   buildMobileDiffReviewQueue,
   createMobileDiffReviewFileKey,
-  filterMobileDiffReviewQueue
+  filterMobileDiffReviewQueue,
+  summarizeMobileDiffReviewQueue,
+  type MobileDiffReviewQueueItem
 } from './mobile-diff-review-queue'
 
 const emptyReviewState: MobileDiffReviewState = { version: 1, files: {} }
@@ -116,5 +118,62 @@ describe('mobile diff review queue', () => {
     expect(filterMobileDiffReviewQueue(queue, 'notes').map((item) => item.filePath)).toEqual([
       'b.ts'
     ])
+  })
+
+  it('summarizes review counts in one pass without rereading item fields', () => {
+    const entryCount = 1_000
+    const reads = { isReviewed: 0, scope: 0, canStage: 0 }
+    let expectedReviewedCount = 0
+    let expectedReviewedUnstagedItems = 0
+    let expectedReviewedUnstagedCount = 0
+    const queue = Array.from({ length: entryCount }, (_, index) => {
+      const isReviewed = index % 2 === 0
+      const scope = index % 3 === 0 ? 'unstaged' : 'staged'
+      const canStage = index % 5 === 0
+      if (isReviewed) {
+        expectedReviewedCount += 1
+        if (scope === 'unstaged') {
+          expectedReviewedUnstagedItems += 1
+          if (canStage) {
+            expectedReviewedUnstagedCount += 1
+          }
+        }
+      }
+      const item = {} as MobileDiffReviewQueueItem
+      Object.defineProperties(item, {
+        isReviewed: {
+          enumerable: true,
+          get: () => {
+            reads.isReviewed += 1
+            return isReviewed
+          }
+        },
+        scope: {
+          enumerable: true,
+          get: () => {
+            reads.scope += 1
+            return scope
+          }
+        },
+        canStage: {
+          enumerable: true,
+          get: () => {
+            reads.canStage += 1
+            return canStage
+          }
+        }
+      })
+      return item
+    })
+
+    expect(summarizeMobileDiffReviewQueue(queue)).toEqual({
+      reviewedCount: expectedReviewedCount,
+      reviewedUnstagedCount: expectedReviewedUnstagedCount
+    })
+    expect(reads).toEqual({
+      isReviewed: entryCount,
+      scope: expectedReviewedCount,
+      canStage: expectedReviewedUnstagedItems
+    })
   })
 })

--- a/mobile/src/session/mobile-diff-review-queue.ts
+++ b/mobile/src/session/mobile-diff-review-queue.ts
@@ -272,3 +272,25 @@ export function filterMobileDiffReviewQueue(
       return [...queue]
   }
 }
+
+export type MobileDiffReviewQueueSummary = {
+  reviewedCount: number
+  reviewedUnstagedCount: number
+}
+
+export function summarizeMobileDiffReviewQueue(
+  queue: readonly MobileDiffReviewQueueItem[]
+): MobileDiffReviewQueueSummary {
+  let reviewedCount = 0
+  let reviewedUnstagedCount = 0
+  for (const item of queue) {
+    if (!item.isReviewed) {
+      continue
+    }
+    reviewedCount += 1
+    if (item.scope === 'unstaged' && item.canStage) {
+      reviewedUnstagedCount += 1
+    }
+  }
+  return { reviewedCount, reviewedUnstagedCount }
+}

--- a/mobile/src/session/use-mobile-diff-review-controller.ts
+++ b/mobile/src/session/use-mobile-diff-review-controller.ts
@@ -9,6 +9,7 @@ import {
   buildMobileDiffReviewQueue,
   filterMobileDiffReviewQueue,
   mobileDiffReviewCommentMatchesItem,
+  summarizeMobileDiffReviewQueue,
   type MobileDiffReviewQueueFilter,
   type MobileDiffReviewQueueItem
 } from './mobile-diff-review-queue'
@@ -133,12 +134,12 @@ export function useMobileDiffReviewController(input: ControllerInput) {
 
   const filteredQueue = useMemo(() => filterMobileDiffReviewQueue(queue, filter), [filter, queue])
   const currentItem = filteredQueue[currentIndex] ?? null
-  const reviewedCount = queue.filter((item) => item.isReviewed).length
+  const { reviewedCount, reviewedUnstagedCount } = useMemo(
+    () => summarizeMobileDiffReviewQueue(queue),
+    [queue]
+  )
   const unsentComments =
     screenState.kind === 'ready' ? getUnsentMobileDiffComments(screenState.comments) : []
-  const reviewedUnstagedCount = queue.filter(
-    (item) => item.scope === 'unstaged' && item.isReviewed && item.canStage
-  ).length
 
   useEffect(() => {
     seededInitialTargetRef.current = false


### PR DESCRIPTION
## ELI5

The mobile diff-review screen needs two counters from the same review queue. It used to reread the whole queue twice and build two throwaway lists just to count them. This counts both values together in one pass, then reuses the answer while the queue is unchanged.

## What Changed

- Add a single-pass `summarizeMobileDiffReviewQueue` projection.
- Memoize the summary by the immutable queue identity in the review controller.
- Remove two render-time `filter` arrays.
- Add a deterministic 1,000-item getter-count test.

## Why

The review controller rerenders for state beyond queue contents, including composer and action state. The previous inline filters rescanned every item and allocated two arrays on each render, even when the queue itself had not changed.

## Performance Measurement

Reproducible fixture: from `mobile/`, run `pnpm test src/session/mobile-diff-review-queue.test.ts`. The 1,000-item fixture instruments every field read while preserving the production predicate shape.

- Before: **2 queue traversals**, **1,334 `isReviewed` reads**, **1,000 `scope` reads**, **167 `canStage` reads**, and **2 temporary filter arrays**.
- After: **1 queue traversal**, **1,000 `isReviewed` reads**, **500 `scope` reads**, **167 `canStage` reads**, and **0 temporary filter arrays**.
- Improvement: **50% fewer queue traversals**, **25.0% fewer `isReviewed` reads**, **50% fewer `scope` reads**, and **100% removal** of measured filter-array allocations.

The `useMemo` skips even that single pass on unrelated rerenders where the queue identity is unchanged.

## User-Facing Trade-offs

None. Reviewed and reviewed-unstaged counts use the same predicates, and the queue is rebuilt rather than mutated for every count-relevant update.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

N/A — diff-review counts and interaction behavior are unchanged.

## Testing

- [x] `pnpm test src/session/mobile-diff-review-queue.test.ts` from `mobile/` (5 passed)
- [x] `pnpm typecheck` from `mobile/`
- [x] Focused oxfmt check
- [x] Focused oxlint check
- [x] Commit hooks: oxlint, React Doctor, and oxfmt
- [x] `git diff --check`

## Review

Self-reviewed for queue immutability, staged/unstaged scope, review state, staging eligibility, empty queues, cross-platform behavior, SSH/folder workspaces, and remote-wire compatibility. No platform, execution-boundary, or wire changes.

## Agent skill upstream boundary

- [x] Not applicable.
