### PR TITLE
perf(git): classify status line-stat inputs once

### DIFF
--- a/src/main/git/source-control/status-line-stats.ts
+++ b/src/main/git/source-control/status-line-stats.ts
@@ -1,4 +1,5 @@
 import type { GitStatusEntry } from '../../../shared/git-status-types'
+import { collectGitStatusLineStatInputs } from '../../../shared/git-status-line-stat-inputs'
 import {
   applyLineStats,
   collectUntrackedAdditions,
@@ -50,11 +51,7 @@ export async function attachLineStats(
   if (entries.length === 0) {
     return true
   }
-  const hasStaged = entries.some((entry) => entry.area === 'staged')
-  const hasUnstaged = entries.some((entry) => entry.area === 'unstaged')
-  const untrackedPaths = entries
-    .filter((entry) => entry.area === 'untracked')
-    .map((entry) => entry.path)
+  const { hasStaged, hasUnstaged, untrackedPaths } = collectGitStatusLineStatInputs(entries)
   const emptyStats = new Map<string, GitLineStats>()
   const [stagedStats, unstagedStats, untrackedStats] = await Promise.all([
     hasStaged ? runNumstat(worktreePath, true, options) : Promise.resolve(emptyStats),
@@ -62,11 +59,12 @@ export async function attachLineStats(
     collectUntrackedAdditions(worktreePath, untrackedPaths, options.signal)
   ])
   for (const entry of entries) {
+    const area = entry.area
     applyLineStats(
       entry,
-      entry.area === 'staged'
+      area === 'staged'
         ? (stagedStats ?? emptyStats).get(entry.path)
-        : entry.area === 'unstaged'
+        : area === 'unstaged'
           ? (unstagedStats ?? emptyStats).get(entry.path)
           : untrackedStats.get(entry.path)
     )

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -11,6 +11,7 @@ import type { RelayGitStreamExec } from './git-stdout-stream'
 import type { GitUpstreamStatus } from '../shared/git-status-types'
 import { StatusPorcelainParser } from '../shared/git-status-porcelain-parser'
 import { splitRemoteBranchName } from '../shared/git-effective-upstream'
+import { collectGitStatusLineStatInputs } from '../shared/git-status-line-stat-inputs'
 import { readOrProbeNoEffectiveUpstreamStatus } from './git-status-upstream-negative-cache'
 import {
   applyLineStats,
@@ -274,11 +275,7 @@ async function attachLineStats(
   if (entries.length === 0) {
     return true
   }
-  const hasStaged = entries.some((entry) => entry.area === 'staged')
-  const hasUnstaged = entries.some((entry) => entry.area === 'unstaged')
-  const untrackedPaths = entries
-    .filter((entry) => entry.area === 'untracked')
-    .map((entry) => entry.path as string)
+  const { hasStaged, hasUnstaged, untrackedPaths } = collectGitStatusLineStatInputs(entries)
   const emptyStats = new Map<string, GitLineStats>()
   const [stagedStats, unstagedStats, untrackedStats] = await Promise.all([
     hasStaged ? runNumstat(git, worktreePath, true, signal) : Promise.resolve(emptyStats),
@@ -287,11 +284,12 @@ async function attachLineStats(
   ])
   for (const entry of entries) {
     const filePath = entry.path as string
+    const area = entry.area
     applyLineStats(
       entry as { added?: number; removed?: number },
-      entry.area === 'staged'
+      area === 'staged'
         ? (stagedStats ?? emptyStats).get(filePath)
-        : entry.area === 'unstaged'
+        : area === 'unstaged'
           ? (unstagedStats ?? emptyStats).get(filePath)
           : untrackedStats.get(filePath)
     )

--- a/src/shared/git-status-line-stat-inputs.test.ts
+++ b/src/shared/git-status-line-stat-inputs.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { collectGitStatusLineStatInputs } from './git-status-line-stat-inputs'
+
+describe('collectGitStatusLineStatInputs', () => {
+  it('classifies mixed status entries without changing path order', () => {
+    expect(
+      collectGitStatusLineStatInputs([
+        { area: 'staged', path: 'staged.ts' },
+        { area: 'untracked', path: 'first.txt' },
+        { area: 'unstaged', path: 'unstaged.ts' },
+        { area: 'untracked', path: 'second.txt' },
+        { area: 'ignored', path: 'ignored.log' }
+      ])
+    ).toEqual({
+      hasStaged: true,
+      hasUnstaged: true,
+      untrackedPaths: ['first.txt', 'second.txt']
+    })
+  })
+
+  it('reads each of 1,000 untracked entries once', () => {
+    let areaReads = 0
+    let pathReads = 0
+    const entries = Array.from({ length: 1_000 }, (_, index) => {
+      const entry: { area: unknown; path: unknown } = { area: undefined, path: undefined }
+      Object.defineProperties(entry, {
+        area: {
+          enumerable: true,
+          get: () => {
+            areaReads += 1
+            return 'untracked'
+          }
+        },
+        path: {
+          enumerable: true,
+          get: () => {
+            pathReads += 1
+            return `file-${index}.txt`
+          }
+        }
+      })
+      return entry
+    })
+
+    const result = collectGitStatusLineStatInputs(entries)
+
+    expect(areaReads).toBe(1_000)
+    expect(pathReads).toBe(1_000)
+    expect(result).toEqual({
+      hasStaged: false,
+      hasUnstaged: false,
+      untrackedPaths: Array.from({ length: 1_000 }, (_, index) => `file-${index}.txt`)
+    })
+  })
+})

--- a/src/shared/git-status-line-stat-inputs.ts
+++ b/src/shared/git-status-line-stat-inputs.ts
@@ -1,0 +1,31 @@
+type GitStatusLineStatEntry = {
+  area?: unknown
+  path?: unknown
+}
+
+export type GitStatusLineStatInputs = {
+  hasStaged: boolean
+  hasUnstaged: boolean
+  untrackedPaths: string[]
+}
+
+export function collectGitStatusLineStatInputs(
+  entries: readonly GitStatusLineStatEntry[]
+): GitStatusLineStatInputs {
+  let hasStaged = false
+  let hasUnstaged = false
+  const untrackedPaths: string[] = []
+
+  for (const entry of entries) {
+    const area = entry.area
+    if (area === 'staged') {
+      hasStaged = true
+    } else if (area === 'unstaged') {
+      hasUnstaged = true
+    } else if (area === 'untracked') {
+      untrackedPaths.push(entry.path as string)
+    }
+  }
+
+  return { hasStaged, hasUnstaged, untrackedPaths }
+}


### PR DESCRIPTION
## ELI5

Before counting changed-file line stats, Orca asked the same list three separate questions: “is anything staged?”, “is anything unstaged?”, and “which files are untracked?” Each question walked the complete list again. This records all three answers during one walk.

## What Changed

- Add a shared one-pass status-entry classifier.
- Use it in native and relay line-stat attachment paths.
- Read each entry’s staging area once while preserving untracked path order.
- Add a 1,000-entry getter-count regression fixture.

## Why

Git status refreshes can contain thousands of entries. The previous `some` + `some` + `filter` + `map` sequence repeatedly traversed the same rows and allocated intermediate arrays before the independent line-stat probes began.

## Performance Measurement

Reproducible fixture: run `pnpm test src/shared/git-status-line-stat-inputs.test.ts`. The 1,000-entry fixture instruments property reads; existing native and relay status suites cover integration behavior.

- Before: **up to 4 list passes** and **3,000 `area` reads** for 1,000 untracked entries, plus a filter/map temporary array.
- After: **1 list pass**, **1,000 `area` reads**, **1,000 path reads**, and **no filter/map temporary array**.
- Improvement: **75% fewer worst-case entry classification reads/passes** and **100% removal** of the measured intermediate filter/map allocation.

The classifier preserves staged/unstaged detection, untracked path ordering, and the existing three line-stat probes.

## User-Facing Trade-offs

None. Native and relay status results, line counts, path order, cancellation, and Git subprocess concurrency are unchanged. The optimization only prepares the same inputs more efficiently.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

N/A — status content and interactions are unchanged.

## Testing

- [x] `pnpm test src/shared/git-status-line-stat-inputs.test.ts` (2 passed)
- [x] `pnpm test src/relay/git-handler-status-ops.test.ts` (12 passed)
- [x] `pnpm test src/main/git/status.test.ts` (26 passed)
- [x] `pnpm tc:node`
- [x] Focused oxfmt check
- [x] Focused oxlint check
- [x] `git diff --check`
- [x] Commit hooks: oxlint, React Doctor, and oxfmt

## Review

Self-reviewed for staged, unstaged, untracked, ignored, empty, and mixed entries; preserved untracked order and area-specific stats. Considered native, WSL, SSH, folder workspaces, Git 2.25 compatibility, cancellation, and remote-wire behavior. No Git command or wire shape changes.

## Agent skill upstream boundary

- [x] Not applicable.
