### PR TITLE
perf(shared): classify folder workspace repos in one pass

### DIFF
--- a/src/shared/folder-workspace-execution-host.test.ts
+++ b/src/shared/folder-workspace-execution-host.test.ts
@@ -8,6 +8,7 @@ import type { FolderWorkspace } from './folder-workspace-types'
 import type { ProjectGroup } from './project-group-types'
 import type { Repo } from './repo-types'
 import {
+  findFolderWorkspaceCandidateRepos,
   resolveFolderWorkspaceHost,
   type FolderWorkspaceHostState
 } from './folder-workspace-execution-host'
@@ -171,5 +172,26 @@ describe('folder workspace execution host', () => {
   it('separates a workspace that is gone from one that resolves to local', () => {
     expect(resolveFolderWorkspaceHost(state(), 'fw-missing')).toEqual({ kind: 'missing' })
     expect(resolveFolderWorkspaceHost(state({ repos: [] }), 'fw-1')).toEqual({ kind: 'local' })
+  })
+
+  it('reads each repository membership once while collecting candidates', () => {
+    let membershipReads = 0
+    const repos = Array.from({ length: 32 }, (_, index) => {
+      const candidate = repo({
+        id: ['repo', index].join('-'),
+        path: ['/elsewhere', index].join('/')
+      })
+      Object.defineProperty(candidate, 'projectGroupId', {
+        configurable: true,
+        get: () => {
+          membershipReads += 1
+          return undefined
+        }
+      })
+      return candidate
+    })
+
+    expect(findFolderWorkspaceCandidateRepos(state({ repos }), 'fw-1')).toEqual([])
+    expect(membershipReads).toBe(repos.length)
   })
 })

--- a/src/shared/folder-workspace-execution-host.ts
+++ b/src/shared/folder-workspace-execution-host.ts
@@ -44,14 +44,18 @@ function getFolderScopeCandidateRepos(args: {
   repos: readonly Repo[]
 }): Repo[] {
   const groupIds = getProjectGroupSubtreeIds(args.projectGroups, args.projectGroupId)
-  const groupRepos = args.repos.filter(
-    (repo) => typeof repo.projectGroupId === 'string' && groupIds.has(repo.projectGroupId)
-  )
-  const pathRepos = args.repos.filter(
-    (repo) =>
-      !(typeof repo.projectGroupId === 'string' && groupIds.has(repo.projectGroupId)) &&
-      isPathInsideOrEqual(args.folderPath, repo.path)
-  )
+  // Classify each repo once. The previous pair of filters read every
+  // projectGroupId twice before applying the same path predicate.
+  const groupRepos: Repo[] = []
+  const pathRepos: Repo[] = []
+  for (const repo of args.repos) {
+    const projectGroupId = repo.projectGroupId
+    if (typeof projectGroupId === 'string' && groupIds.has(projectGroupId)) {
+      groupRepos.push(repo)
+    } else if (isPathInsideOrEqual(args.folderPath, repo.path)) {
+      pathRepos.push(repo)
+    }
+  }
   if (args.connectionId) {
     return [
       ...groupRepos,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5

When Orca decides where a folder workspace runs, it checks every repository to see whether it belongs to the project-group scope or sits under the folder path. It used to ask each repository the same membership question twice. One pass now records the answer and keeps the same ordering and host filtering.

## What Changed

- Classify group-scoped and path-scoped repositories in one loop.
- Preserve group-first ordering, path-boundary checks, connection filtering, and mixed-host handling.
- Add a getter-backed regression measurement for repository membership reads.

## Why

Folder workspace host resolution runs shared code used by main and renderer callers. The previous pair of filters repeatedly inspected `projectGroupId` for every repository before applying the same path predicate.

## Performance Measurement

Reproducible fixture: `pnpm test src/shared/folder-workspace-execution-host.test.ts`.

The measurement uses 32 repositories whose `projectGroupId` getter counts reads and performs candidate collection for a workspace whose repos are outside the path and group. The old two-filter implementation performs 64 membership reads (2N); the new single loop performs 32 (N).

- Before: **64** `projectGroupId` reads for 32 repos.
- After: **32** reads for 32 repos.
- Improvement: **50% fewer membership reads** in this candidate-collection pass, while retaining O(N) work and the same output.

## User-Facing Trade-offs

None. Candidate ordering, path containment, local/SSH connection matching, folder-workspace behavior, and ambiguous-host results are unchanged.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

N/A — no UI layout or interaction behavior changed.

## Testing

- [x] `src/shared/folder-workspace-execution-host.test.ts` (8 passed)
- [x] `pnpm tc:node`
- [x] Focused `oxlint --deny-warnings`
- [x] Focused `oxfmt --check`
- [x] `git diff --check`

## Review

Checked folder workspaces, nested project groups, local and SSH repositories, connection-id normalization, path boundaries, and mixed-host ambiguity. No IPC or remote-wire changes.

## Agent skill upstream boundary

- [x] Not applicable.
