### PR TITLE
perf(shared): project automation list in one pass

### DIFF
--- a/src/shared/automation-list-scope.test.ts
+++ b/src/shared/automation-list-scope.test.ts
@@ -200,6 +200,49 @@ describe('projectAutomationList', () => {
     expect(result.items[0]?.usageSummary?.knownRuns).toBe(2)
     expect(result.items[1]?.usageSummary).toBeNull()
   })
+
+  it('projects and scopes in one collection traversal', () => {
+    const collectionMethodReads: string[] = []
+    const repoLookups: string[] = []
+    const targetLookups: string[] = []
+    const source = new Proxy(records, {
+      get(target, property, receiver) {
+        if (property === 'map' || property === 'filter') {
+          collectionMethodReads.push(String(property))
+        }
+        return Reflect.get(target, property, receiver)
+      }
+    })
+    const usageIds: string[] = []
+    const result = projectAutomationList(
+      source,
+      {
+        ...context(),
+        repoConnectionId: (repoId) => {
+          repoLookups.push(repoId)
+          return repoId === 'repo-1' ? null : repoId === 'repo-ssh' ? 'ssh-1' : undefined
+        },
+        sshTargetGeneration: (targetId) => {
+          targetLookups.push(targetId)
+          return targetId === 'ssh-1' ? 7 : undefined
+        },
+        usageSummary: (id) => {
+          usageIds.push(id)
+          return null
+        }
+      },
+      { kind: 'self' }
+    )
+
+    expect(collectionMethodReads).toEqual([])
+    expect(result.automations.map((entry) => entry.id)).toEqual(['local-1'])
+    expect(result.items.map((item) => item.automationId)).toEqual(['local-1'])
+    expect(result.items[0]?.selector).toEqual({ kind: 'self' })
+    expect(result.orphanCount).toBe(1)
+    expect(repoLookups).toEqual(['repo-1'])
+    expect(targetLookups).toEqual(['ssh-1', 'ssh-gone'])
+    expect(usageIds).toEqual(['local-1'])
+  })
 })
 
 describe('automationChangePublications', () => {

--- a/src/shared/automation-list-scope.ts
+++ b/src/shared/automation-list-scope.ts
@@ -238,21 +238,32 @@ export function projectAutomationList(
   context: AutomationProjectionContext,
   scope?: AutomationListScopeSelector
 ): AutomationListResult {
-  const projected = automations.map((automation) => ({
-    automation,
-    selector: projectAutomationSelector(automation, context)
-  }))
-  const orphanCount = projected.filter((entry) => entry.selector.kind === 'orphan').length
-  const scoped = scope
-    ? projected.filter((entry) => automationSelectorMatchesScope(entry.selector, scope))
-    : projected
+  const scopedAutomations: Automation[] = []
+  const items: AutomationListItem[] = []
+  let orphanCount = 0
+  for (const automation of automations) {
+    const selector = projectAutomationSelector(automation, context)
+    if (selector.kind === 'orphan') {
+      orphanCount += 1
+    }
+    if (scope && !automationSelectorMatchesScope(selector, scope)) {
+      continue
+    }
+    scopedAutomations.push(automation)
+    items.push({
+      automationId: automation.id,
+      selector
+    })
+  }
+  // Keep usage lookups after projection, matching the previous staged pipeline's ordering.
+  if (context.usageSummary) {
+    for (const item of items) {
+      item.usageSummary = context.usageSummary(item.automationId)
+    }
+  }
   return {
-    automations: scoped.map((entry) => entry.automation),
-    items: scoped.map((entry) => ({
-      automationId: entry.automation.id,
-      selector: entry.selector,
-      ...(context.usageSummary ? { usageSummary: context.usageSummary(entry.automation.id) } : {})
-    })),
+    automations: scopedAutomations,
+    items,
     orphanCount
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## ELI5

The automations screen first figured out what every automation means, then walked the same results several more times to count orphans, filter the selected host, and build rows. One loop now does those jobs together, so the answer is produced without temporary copies and repeated passes.

## What Changed

- Project each automation and count orphan records in one traversal.
- Apply optional host scoping while the selector is already known.
- Build the returned automation and item arrays directly.
- Preserve selector-before-usage callback ordering and add traversal/ordering coverage.

## Why

`projectAutomationList` is used by the automation list projection path. Its previous `map` + orphan `filter` + scope `filter` + two final `map` calls allocated an intermediate record for every automation and traversed the projected list repeatedly.

## Performance Measurement

Reproducible fixture: `pnpm test src/shared/automation-list-scope.test.ts`.

The regression fixture wraps the source list in a Proxy and performs a scoped projection with usage summaries. It asserts that the implementation does not access `map` or `filter` helpers, preserves the scoped order and orphan count, and invokes usage summaries only for returned rows.

- Before: **5 collection passes** (`map`, orphan `filter`, scope `filter`, and two final output `map` calls) plus an intermediate projected array.
- After: **1** direct loop and only the output arrays.
- Improvement: **80% fewer collection passes** and no per-automation intermediate projection objects in the measured path; selector and usage callback counts remain unchanged.

## User-Facing Trade-offs

None. Automation ordering, scope matching, orphan counts, usage-summary values, and callback ordering are unchanged.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

N/A — no UI layout or interaction behavior changed.

## Testing

- [x] `src/shared/automation-list-scope.test.ts` (22 passed)
- [x] `pnpm tc:node`
- [x] Focused `oxlint --deny-warnings`
- [x] Focused `oxfmt --check`
- [x] `git diff --check`
- [x] Commit hooks passed

## Review

Checked local, SSH, orphan, and scoped automation projections, usage-summary callbacks, ordering, and remote authority semantics. No IPC or wire-shape changes.

## Agent skill upstream boundary

- [x] Not applicable.