### PR TITLE
Fix opening HTTPS URLs from headless runtimes

### DIFF
--- a/src/cli/browser-handler-groups.ts
+++ b/src/cli/browser-handler-groups.ts
@@ -53,7 +53,16 @@ export const BROWSER_HANDLER_GROUPS: readonly HandlerGroup[] = [
   },
   {
     name: 'browser-tab',
-    keys: ['tab list', 'tab show', 'tab current', 'tab switch', 'tab create', 'tab close', 'exec'],
+    keys: [
+      'open-url',
+      'tab list',
+      'tab show',
+      'tab current',
+      'tab switch',
+      'tab create',
+      'tab close',
+      'exec'
+    ],
     load: async () => (await import('./handlers/browser-tab.js')).BROWSER_TAB_HANDLERS
   },
   {

--- a/src/cli/browser.test.ts
+++ b/src/cli/browser.test.ts
@@ -183,6 +183,27 @@ describe('orca cli browser page targeting', () => {
     )
   })
 
+  it('opens browser-launch URLs on the client hosting the current worktree', async () => {
+    queueFixtures(
+      callMock,
+      worktreeListFixture([buildWorktree('/tmp/repo/feature', 'feature/foo')]),
+      okFixture('req_open_url', { browserPageId: 'page-local' })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['open-url', '--url', 'https://example.com/login', '--json'], '/tmp/repo/feature')
+
+    expect(callMock).toHaveBeenNthCalledWith(
+      2,
+      'browser.openUrl',
+      {
+        url: 'https://example.com/login',
+        worktree: 'id:repo::/tmp/repo/feature'
+      },
+      { timeoutMs: 60_000 }
+    )
+  })
+
   it('passes tab profile updates through by page id', async () => {
     queueFixtures(
       callMock,

--- a/src/cli/handlers/browser-tab.ts
+++ b/src/cli/handlers/browser-tab.ts
@@ -15,6 +15,16 @@ import { RuntimeClientError } from '../runtime-client'
 import { getBrowserCommandTarget, getBrowserWorktreeSelector } from '../selectors'
 
 export const BROWSER_TAB_HANDLERS: Record<string, CommandHandler> = {
+  'open-url': async ({ flags, client, cwd, json }) => {
+    const url = getRequiredStringFlag(flags, 'url')
+    const worktree = await getBrowserWorktreeSelector(flags, cwd, client)
+    const result = await client.call<{ browserPageId: string }>(
+      'browser.openUrl',
+      { url, worktree },
+      { timeoutMs: 60_000 }
+    )
+    printResult(result, json, (v) => `Opened URL in tab ${v.browserPageId}`)
+  },
   'tab list': async ({ flags, client, cwd, json }) => {
     const worktree = await getBrowserWorktreeSelector(flags, cwd, client)
     const result = await client.call<BrowserTabListResult>('browser.tabList', { worktree })

--- a/src/cli/specs/browser-basic.ts
+++ b/src/cli/specs/browser-basic.ts
@@ -3,6 +3,12 @@ import { GLOBAL_FLAGS } from '../args'
 
 export const BROWSER_BASIC_COMMAND_SPECS: CommandSpec[] = [
   {
+    path: ['open-url'],
+    summary: 'Open a URL on the paired client that hosts this terminal',
+    usage: 'orca open-url --url <url> [--worktree <selector>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'url', 'worktree']
+  },
+  {
     path: ['snapshot'],
     summary: 'Capture an accessibility snapshot of the active browser tab',
     usage: 'orca snapshot [--worktree <selector>] [--json]',

--- a/src/main/ipc/pty-spawn-env-terminal-basics.test.ts
+++ b/src/main/ipc/pty-spawn-env-terminal-basics.test.ts
@@ -58,6 +58,75 @@ describe('registerPtyHandlers', () => {
   const { handlers, mainWindow, spawnAndGetEnv, withBundledCli } = setupPtyIpcSuite()
 
   describe('spawn environment', () => {
+    it('routes headless browser launches through the owning Orca workspace', () => {
+      const inheritedBrowser = process.env.BROWSER
+      delete process.env.BROWSER
+      try {
+        const env = buildPtyHostEnv(
+          'pty-headless',
+          {},
+          {
+            isPackaged: true,
+            userDataPath: '/tmp/orca-user-data',
+            selectedCodexHomePath: null,
+            agentStatusHooksEnabled: false,
+            routeBrowserOpensToClient: true
+          }
+        )
+
+        expect(env.BROWSER).toBe('orca open-url --url %s')
+      } finally {
+        if (inheritedBrowser === undefined) {
+          delete process.env.BROWSER
+        } else {
+          process.env.BROWSER = inheritedBrowser
+        }
+      }
+    })
+
+    it('preserves an explicit browser command on headless runtimes', () => {
+      const env = buildPtyHostEnv(
+        'pty-custom-browser',
+        { BROWSER: 'custom-browser %s' },
+        {
+          isPackaged: true,
+          userDataPath: '/tmp/orca-user-data',
+          selectedCodexHomePath: null,
+          agentStatusHooksEnabled: false,
+          routeBrowserOpensToClient: true
+        }
+      )
+
+      expect(env.BROWSER).toBe('custom-browser %s')
+    })
+
+    it('uses the registered WSL CLI name for headless browser launches', () => {
+      const inheritedBrowser = process.env.BROWSER
+      delete process.env.BROWSER
+      try {
+        const env = buildPtyHostEnv(
+          'pty-headless-wsl',
+          {},
+          {
+            isPackaged: true,
+            userDataPath: '/tmp/orca-user-data',
+            selectedCodexHomePath: null,
+            isWsl: true,
+            agentStatusHooksEnabled: false,
+            routeBrowserOpensToClient: true
+          }
+        )
+
+        expect(env.BROWSER).toBe('orca-ide open-url --url %s')
+      } finally {
+        if (inheritedBrowser === undefined) {
+          delete process.env.BROWSER
+        } else {
+          process.env.BROWSER = inheritedBrowser
+        }
+      }
+    })
+
     it('passes the PTY-resolved Codex home to the WSL relay lane', () => {
       const runtimeHome =
         '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.local\\share\\orca\\codex-runtime-home\\home'

--- a/src/main/ipc/pty/host-env/assembly.ts
+++ b/src/main/ipc/pty/host-env/assembly.ts
@@ -264,6 +264,15 @@ export function buildPtyHostEnv(
       : bundledCliBin
   }
 
+  if (
+    opts.routeBrowserOpensToClient === true &&
+    baseEnv.BROWSER === undefined &&
+    process.env.BROWSER === undefined
+  ) {
+    const cliCommand = opts.isWsl ? (opts.isPackaged ? 'orca-ide' : 'orca-dev') : 'orca'
+    baseEnv.BROWSER = `${cliCommand} open-url --url %s`
+  }
+
   // Why: must run after the prepends above — they re-read PATH from the unscrubbed
   // process.env when baseEnv carries none, which is the daemon path's normal shape.
   stripLegacyTerminalShimEnv(baseEnv, process.platform)

--- a/src/main/ipc/pty/host-env/types.ts
+++ b/src/main/ipc/pty/host-env/types.ts
@@ -29,6 +29,8 @@ export type BuildPtyHostEnvOptions = {
   agentStatusHooksEnabled: boolean
   codexStatusHooksEnabled?: boolean
   networkProxySettings?: NetworkProxySettings
+  /** Headless paired runtimes hand browser launches to the client-hosted Orca browser. */
+  routeBrowserOpensToClient?: boolean
   /** Keep indexed Git config off the sparse daemon wire; the daemon appends guard entries after merging its inherited env. */
   deferGitConfigGuardToDaemon?: boolean
 }

--- a/src/main/ipc/pty/ipc/spawn-env-codex.ts
+++ b/src/main/ipc/pty/ipc/spawn-env-codex.ts
@@ -142,6 +142,7 @@ export async function assemblePtyIpcSpawnCodexEnv(ctx: PtyIpcSpawnState): Promis
         agentStatusHooksEnabled: isAgentStatusHooksEnabled(ptySettings),
         codexStatusHooksEnabled: isCodexStatusHooksEnabled(ptySettings),
         networkProxySettings: ptySettings,
+        routeBrowserOpensToClient: ctx.deps.runtime?.shouldRelayTerminalBrowserOpens(),
         deferGitConfigGuardToDaemon:
           ctx.provider.supportsGitCredentialGuardHost?.(ctx.effectiveSessionId) === true
       })

--- a/src/main/ipc/pty/ipc/spawn-env-codex.ts
+++ b/src/main/ipc/pty/ipc/spawn-env-codex.ts
@@ -142,7 +142,7 @@ export async function assemblePtyIpcSpawnCodexEnv(ctx: PtyIpcSpawnState): Promis
         agentStatusHooksEnabled: isAgentStatusHooksEnabled(ptySettings),
         codexStatusHooksEnabled: isCodexStatusHooksEnabled(ptySettings),
         networkProxySettings: ptySettings,
-        routeBrowserOpensToClient: ctx.deps.runtime?.shouldRelayTerminalBrowserOpens(),
+        routeBrowserOpensToClient: ctx.deps.runtime?.shouldRelayTerminalBrowserOpens?.(),
         deferGitConfigGuardToDaemon:
           ctx.provider.supportsGitCredentialGuardHost?.(ctx.effectiveSessionId) === true
       })

--- a/src/main/ipc/pty/provider/local-configure.ts
+++ b/src/main/ipc/pty/provider/local-configure.ts
@@ -73,7 +73,7 @@ export function configureLocalPtyProvider(args: {
         agentStatusHooksEnabled: isAgentStatusHooksEnabled(ptySettings),
         codexStatusHooksEnabled: isCodexStatusHooksEnabled(ptySettings),
         networkProxySettings: ptySettings,
-        routeBrowserOpensToClient: runtime?.shouldRelayTerminalBrowserOpens()
+        routeBrowserOpensToClient: runtime?.shouldRelayTerminalBrowserOpens?.()
       })
       // Why: agents need their terminal handle at process start to self-identify in orchestration messages without an extra RPC.
       const requestedHandle = baseEnv.ORCA_TERMINAL_HANDLE

--- a/src/main/ipc/pty/provider/local-configure.ts
+++ b/src/main/ipc/pty/provider/local-configure.ts
@@ -72,7 +72,8 @@ export function configureLocalPtyProvider(args: {
         wslDistro: ctx?.wslDistro ?? null,
         agentStatusHooksEnabled: isAgentStatusHooksEnabled(ptySettings),
         codexStatusHooksEnabled: isCodexStatusHooksEnabled(ptySettings),
-        networkProxySettings: ptySettings
+        networkProxySettings: ptySettings,
+        routeBrowserOpensToClient: runtime?.shouldRelayTerminalBrowserOpens()
       })
       // Why: agents need their terminal handle at process start to self-identify in orchestration messages without an extra RPC.
       const requestedHandle = baseEnv.ORCA_TERMINAL_HANDLE

--- a/src/main/ipc/pty/runtime/spawn-preflight.ts
+++ b/src/main/ipc/pty/runtime/spawn-preflight.ts
@@ -258,6 +258,7 @@ export async function prepareRuntimePtySpawn(
         agentStatusHooksEnabled: isAgentStatusHooksEnabled(ptySettings),
         codexStatusHooksEnabled: isCodexStatusHooksEnabled(ptySettings),
         networkProxySettings: ptySettings,
+        routeBrowserOpensToClient: ctx.deps.runtime?.shouldRelayTerminalBrowserOpens(),
         deferGitConfigGuardToDaemon:
           ctx.provider.supportsGitCredentialGuardHost?.(ctx.sessionId) === true
       })

--- a/src/main/ipc/pty/runtime/spawn-preflight.ts
+++ b/src/main/ipc/pty/runtime/spawn-preflight.ts
@@ -258,7 +258,7 @@ export async function prepareRuntimePtySpawn(
         agentStatusHooksEnabled: isAgentStatusHooksEnabled(ptySettings),
         codexStatusHooksEnabled: isCodexStatusHooksEnabled(ptySettings),
         networkProxySettings: ptySettings,
-        routeBrowserOpensToClient: ctx.deps.runtime?.shouldRelayTerminalBrowserOpens(),
+        routeBrowserOpensToClient: ctx.deps.runtime?.shouldRelayTerminalBrowserOpens?.(),
         deferGitConfigGuardToDaemon:
           ctx.provider.supportsGitCredentialGuardHost?.(ctx.sessionId) === true
       })

--- a/src/main/orcad/electron-sidecar-method-routing.test.ts
+++ b/src/main/orcad/electron-sidecar-method-routing.test.ts
@@ -52,6 +52,10 @@ async function runtimeCommandFor(
 }
 
 describe('electronSidecarRuntimeMethodName', () => {
+  it('maps client URL opens to the browser.openUrl RPC', () => {
+    expect(electronSidecarRuntimeMethodName('browserOpenUrlOnClient')).toBe('browser.openUrl')
+  })
+
   it('round-trips every registered browser RPC method', async () => {
     const mismatches: string[] = []
     const unmapped: string[] = []

--- a/src/main/orcad/electron-sidecar-method-routing.ts
+++ b/src/main/orcad/electron-sidecar-method-routing.ts
@@ -10,6 +10,9 @@ export const TARGETLESS_BROWSER_METHODS: Record<string, true> = {
 }
 
 export function electronSidecarRuntimeMethodName(browserMethod: string): string {
+  if (browserMethod === 'browserOpenUrlOnClient') {
+    return 'browser.openUrl'
+  }
   const suffix = browserMethod.slice('browser'.length)
   if (suffix === 'ProceedCertificate') {
     return 'browser.certificate.proceed'

--- a/src/main/runtime/browser-host-capability-selection.test.ts
+++ b/src/main/runtime/browser-host-capability-selection.test.ts
@@ -19,6 +19,16 @@ describe('browser host capability selection', () => {
     expect(() => leases.select(undefined, ['mirror.v1'])).toThrow('browser_host_unavailable')
   })
 
+  it('skips a webview-only host when client automation is required', () => {
+    const leases = registry()
+    attach(leases, 'webview-only', ['webview'])
+    attach(leases, 'automation', ['webview', 'automation-v1'])
+
+    expect(leases.select(undefined, ['webview', 'automation-v1'])).toMatchObject({
+      browserHostClientId: 'host-automation'
+    })
+  })
+
   it('keeps multiple qualified hosts ambiguous without arbitrary routing', () => {
     const leases = registry()
     attach(leases, 'a', ['webview', 'commands.v1'])

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -54,6 +54,7 @@ import type {
   BrowserSessionUserAgentMode
 } from '../../shared/browser-workspace-types'
 import type { BrowserNetworkExecutionHost } from '../../shared/browser-client-host-protocol'
+import { BROWSER_CLIENT_AUTOMATION_HOST_CAPABILITY } from '../../shared/browser-client-automation-protocol'
 import type { BrowserPageCreationPlacement } from '../../shared/browser-client-host-placement'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import { browserNetworkExecutionHostKey } from '../browser/browser-network-execution-route'
@@ -1738,7 +1739,10 @@ export class RuntimeBrowserCommands {
     }
     const lease = this.host
       .getBrowserHostLeaseRegistry()
-      .select(undefined, [BROWSER_HOST_WEBVIEW_CAPABILITY])
+      .select(undefined, [
+        BROWSER_HOST_WEBVIEW_CAPABILITY,
+        BROWSER_CLIENT_AUTOMATION_HOST_CAPABILITY
+      ])
     return this.browserTabCreate(
       {
         url: params.url,

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -96,6 +96,7 @@ import {
 } from './browser-tab-create-publication'
 import type { RuntimeNavigationTarget } from '../../shared/runtime-navigation'
 import type { BrowserHostLeaseRegistry } from './browser-host-lease-registry'
+import { BROWSER_HOST_WEBVIEW_CAPABILITY } from './browser-host-capability-selection'
 import {
   closeRuntimeBrowserClientPage,
   createRuntimeBrowserClientPage,
@@ -1725,6 +1726,29 @@ export class RuntimeBrowserCommands {
     }
 
     return { browserPageId }
+  }
+
+  async browserOpenUrlOnClient(params: {
+    url: string
+    worktree: string
+  }): Promise<{ browserPageId: string }> {
+    const protocol = new URL(params.url).protocol
+    if (protocol !== 'http:' && protocol !== 'https:') {
+      throw new BrowserError('invalid_argument', 'Only http(s) URLs can be opened on the client.')
+    }
+    const lease = this.host
+      .getBrowserHostLeaseRegistry()
+      .select(undefined, [BROWSER_HOST_WEBVIEW_CAPABILITY])
+    return this.browserTabCreate(
+      {
+        url: params.url,
+        worktree: params.worktree,
+        activate: true,
+        navigation: 'caller',
+        placement: { kind: 'client', browserHostClientId: lease.browserHostClientId }
+      },
+      { pairedDeviceId: lease.pairedDeviceId, clientKind: 'runtime' }
+    )
   }
 
   async browserTabSetProfile(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3127,6 +3127,21 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('relays terminal browser launches only while headless owns the graph', () => {
+    const runtime = createRuntime()
+    electronMocks.BrowserWindow.fromId.mockImplementation((windowId: number) =>
+      windowId === TEST_WINDOW_ID ? ({ isDestroyed: () => false } as never) : null
+    )
+
+    expect(runtime.shouldRelayTerminalBrowserOpens()).toBe(false)
+
+    runtime.syncWindowGraph(HEADLESS_RUNTIME_WINDOW_ID, { tabs: [], leaves: [] })
+    expect(runtime.shouldRelayTerminalBrowserOpens()).toBe(true)
+
+    runtime.attachWindow(TEST_WINDOW_ID)
+    expect(runtime.shouldRelayTerminalBrowserOpens()).toBe(false)
+  })
+
   it('marks live headless PTYs for renderer reattach before desktop promotion', () => {
     const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal({

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -6620,6 +6620,10 @@ export class OrcaRuntimeService {
     }
   }
 
+  shouldRelayTerminalBrowserOpens(): boolean {
+    return this.authoritativeWindowId === HEADLESS_RUNTIME_WINDOW_ID
+  }
+
   // Why: scans the transcript-owning host's disk (correct by construction over
   // RPC — a remote/SSH host scans its own disk). Delegates to the one shared
   // cache so the desktop panel and the mobile screen never double-scan.
@@ -41227,6 +41231,9 @@ export class OrcaRuntimeService {
 
   browserTabCreate: RuntimeBrowserCommands['browserTabCreate'] =
     this.browserCommands.browserTabCreate.bind(this.browserCommands)
+
+  browserOpenUrlOnClient: RuntimeBrowserCommands['browserOpenUrlOnClient'] =
+    this.browserCommands.browserOpenUrlOnClient.bind(this.browserCommands)
 
   browserTabSetProfile: RuntimeBrowserCommands['browserTabSetProfile'] =
     this.browserCommands.browserTabSetProfile.bind(this.browserCommands)

--- a/src/main/runtime/rpc/methods/browser-core.ts
+++ b/src/main/runtime/rpc/methods/browser-core.ts
@@ -31,7 +31,7 @@ import {
   Upload,
   Wait
 } from './browser-schemas'
-import { BrowserTabCreateParams } from './browser-tab-create-schema'
+import { BrowserOpenUrlParams, BrowserTabCreateParams } from './browser-tab-create-schema'
 import { BROWSER_TEXT_METHODS } from './browser-text-rpc-methods'
 
 const CertificateProceed = BrowserTarget.extend({
@@ -117,6 +117,11 @@ export const BROWSER_CORE_METHODS: RpcMethod[] = [
       pairedDeviceId
         ? runtime.browserTabCreate(params, { pairedDeviceId, clientKind })
         : runtime.browserTabCreate(params, { clientKind })
+  }),
+  defineMethod({
+    name: 'browser.openUrl',
+    params: BrowserOpenUrlParams,
+    handler: async (params, { runtime }) => runtime.browserOpenUrlOnClient(params)
   }),
   defineMethod({
     name: 'browser.tabSetProfile',

--- a/src/main/runtime/rpc/methods/browser-tab-create-schema.ts
+++ b/src/main/runtime/rpc/methods/browser-tab-create-schema.ts
@@ -16,3 +16,8 @@ export const BrowserTabCreateParams = z.object({
   targetGroupId: OptionalString,
   placement: BrowserPageCreationPlacement.optional()
 })
+
+export const BrowserOpenUrlParams = z.object({
+  url: z.url(),
+  worktree: z.string().min(1)
+})

--- a/src/main/runtime/rpc/methods/browser.test.ts
+++ b/src/main/runtime/rpc/methods/browser.test.ts
@@ -48,6 +48,26 @@ describe('browser RPC methods', () => {
     })
   })
 
+  it('routes host browser-open requests through the dedicated client opener', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      browserOpenUrlOnClient: vi.fn().mockResolvedValue({ browserPageId: 'page-local' })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: BROWSER_CORE_METHODS })
+
+    await dispatcher.dispatch(
+      makeRequest('browser.openUrl', {
+        url: 'https://example.com/login',
+        worktree: 'id:wt-1'
+      })
+    )
+
+    expect(runtime.browserOpenUrlOnClient).toHaveBeenCalledWith({
+      url: 'https://example.com/login',
+      worktree: 'id:wt-1'
+    })
+  })
+
   it('validates profile user-agent modes', () => {
     expect(
       ProfileCreate.safeParse({ label: 'Google', scope: 'isolated', userAgentMode: 'native' })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​139 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​139 |
| Prod | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 |

<!-- /orca-pr-loc -->

## ELI5

When a command running on a paired/headless Orca host opens a login URL, Orca now opens it in the browser on the viewing client. Loopback OAuth callbacks continue through the existing browser network tunnel to the execution host.

## What Changed

- Added `orca open-url --url <url>` and a `browser.openUrl` runtime method.
- Injected that command as `$BROWSER` only for terminals whose graph is owned by a headless runtime.
- Reused the active browser-host lease and existing client-hosted browser page creation path.
- Accepted only HTTP(S) URLs, required an unambiguous compatible browser host, and preserved user-defined `$BROWSER` values.
- Added CLI, PTY environment, runtime ownership, and RPC coverage.

## Why

Headless and paired runtimes cannot launch OAuth HTTPS URLs on the viewing machine with a normal host-local browser command. Reusing Orca's client-hosted browser and network tunnel opens the flow where the user can interact with it while keeping loopback callbacks connected to the remote execution host.

## Linked Issue

Fixes #16274

## Visual Proof

N/A — this changes terminal URL routing and introduces no new UI.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Passed locally:

- `pnpm test src/main/ipc/pty-spawn-env-terminal-basics.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/browser.test.ts src/cli/browser.test.ts` (1,290 passed, 1 skipped)
- `pnpm tc:node`
- `pnpm run check:code-quality:changed` (0 new findings)
- `git diff --check`

## AI Disclosure

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Desktop-owned terminal environments remain unchanged.
- Existing `$BROWSER` values are preserved.
- The implementation uses the existing client browser lease and browser network tunnel, avoiding a new stream opcode and preserving mixed-version wire behavior.
- The execution host owns URL validation and client-host selection; unsupported or ambiguous targets fail safely.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Performance Measurement

This is an opt-in routing and correctness feature, not a latency optimization, so no speedup is claimed. PTY setup adds only the existing ownership predicate and a guarded `$BROWSER` assignment; desktop and local PTYs and inherited `BROWSER` values take the unchanged path. A headless URL open adds one `browser.openUrl` RPC and reuses the existing client tab-create flow; selector resolution remains the existing worktree path, with no polling or recurring work introduced.

## User-Facing Trade-offs

Headless paired terminals need an unambiguous client browser host with the required capability; absent or ambiguous hosts fail explicitly instead of opening remotely. Only HTTP and HTTPS URLs are accepted. User-provided `$BROWSER`, desktop and local behavior, WSL command names, and existing browser-tab behavior remain unchanged.
