### PR TITLE
perf(renderer): index folder workspace host ownership

### DIFF
--- a/src/renderer/src/store/folder-workspaces/folder-workspace-catalog.test.ts
+++ b/src/renderer/src/store/folder-workspaces/folder-workspace-catalog.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import {
+  getFolderWorkspaceCatalogReplacementIdentities,
+  getFolderWorkspaceHostId,
+  mergeFetchedFolderWorkspaceCatalog
+} from './folder-workspace-catalog'
+
+function makeProjectGroup(overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id: 'group-1',
+    name: 'Platform',
+    parentPath: '/workspace/platform',
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'folder-1',
+    projectGroupId: 'group-1',
+    name: 'Platform folder',
+    folderPath: '/workspace/platform',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+describe('folder workspace host resolution', () => {
+  it.each([
+    [
+      'uses a normalized explicit host stamp',
+      makeFolderWorkspace({ executionHostId: ' runtime:env-1 ' as never }),
+      [],
+      'runtime:env-1'
+    ],
+    [
+      'uses a workspace SSH connection',
+      makeFolderWorkspace({ connectionId: 'ssh-1' }),
+      [],
+      'ssh:ssh-1'
+    ],
+    [
+      'uses the single owning project-group host',
+      makeFolderWorkspace(),
+      [makeProjectGroup({ executionHostId: 'runtime:env-1' })],
+      'runtime:env-1'
+    ],
+    [
+      'keeps duplicate project-group copies on one host',
+      makeFolderWorkspace(),
+      [
+        makeProjectGroup({ executionHostId: 'runtime:env-1' }),
+        makeProjectGroup({ executionHostId: 'runtime:env-1' })
+      ],
+      'runtime:env-1'
+    ],
+    [
+      'falls back local for ambiguous project-group owners',
+      makeFolderWorkspace(),
+      [
+        makeProjectGroup({ executionHostId: 'runtime:env-1' }),
+        makeProjectGroup({ executionHostId: 'runtime:env-2' })
+      ],
+      'local'
+    ]
+  ])('%s', (_description, workspace, projectGroups, expectedHostId) => {
+    expect(getFolderWorkspaceHostId(workspace, projectGroups)).toBe(expectedHostId)
+  })
+
+  it('indexes project-group hosts once while merging repeated workspace rows', () => {
+    let hostReads = 0
+    const projectGroup = makeProjectGroup()
+    Object.defineProperty(projectGroup, 'executionHostId', {
+      configurable: true,
+      get: () => {
+        hostReads += 1
+        return 'runtime:env-1'
+      }
+    })
+    const previous = Array.from({ length: 8 }, (_, index) =>
+      makeFolderWorkspace({ id: `folder-${index}` })
+    )
+    const fetched = previous.map((workspace) => ({ ...workspace, name: 'Updated' }))
+
+    const merged = mergeFetchedFolderWorkspaceCatalog(
+      { folderWorkspaces: fetched, hostId: 'runtime:env-1' },
+      previous,
+      [projectGroup]
+    )
+
+    expect(merged.folderWorkspaces).toEqual(fetched)
+    expect(hostReads).toBe(1)
+  })
+
+  it('reuses one host index for replacement identities', () => {
+    let hostReads = 0
+    const projectGroup = makeProjectGroup()
+    Object.defineProperty(projectGroup, 'executionHostId', {
+      configurable: true,
+      get: () => {
+        hostReads += 1
+        return 'runtime:env-1'
+      }
+    })
+    const rows = Array.from({ length: 8 }, (_, index) =>
+      makeFolderWorkspace({ id: `folder-${index}` })
+    )
+
+    const identities = getFolderWorkspaceCatalogReplacementIdentities(
+      { folderWorkspaces: rows, hostId: 'runtime:env-1' },
+      rows,
+      [projectGroup]
+    )
+
+    expect(identities).toHaveProperty('size', rows.length)
+    expect(hostReads).toBe(1)
+  })
+})

--- a/src/renderer/src/store/folder-workspaces/folder-workspace-catalog.ts
+++ b/src/renderer/src/store/folder-workspaces/folder-workspace-catalog.ts
@@ -28,6 +28,51 @@ export type FetchedFolderWorkspaceCatalog = {
   hostId: ExecutionHostId
 }
 
+type FolderWorkspaceHostIndex = ReadonlyMap<string, ExecutionHostId | null>
+
+function createFolderWorkspaceHostIndex(
+  projectGroups: readonly ProjectGroup[]
+): FolderWorkspaceHostIndex {
+  const hostByGroupId = new Map<string, ExecutionHostId | null>()
+  for (const group of projectGroups) {
+    const hostId = getProjectGroupHostId(group)
+    if (!hostByGroupId.has(group.id)) {
+      hostByGroupId.set(group.id, hostId)
+      continue
+    }
+    const existingHostId = hostByGroupId.get(group.id)
+    if (existingHostId !== null && existingHostId !== hostId) {
+      // Multiple copies of a group on different hosts are intentionally local/ambiguous.
+      hostByGroupId.set(group.id, null)
+    }
+  }
+  return hostByGroupId
+}
+
+function getFolderWorkspaceHostIdFromIndex(
+  workspace: FolderWorkspace,
+  hostByGroupId: FolderWorkspaceHostIndex
+): ExecutionHostId {
+  return hostByGroupId.get(workspace.projectGroupId) ?? LOCAL_EXECUTION_HOST_ID
+}
+
+function createFolderWorkspaceHostResolver(
+  projectGroups: readonly ProjectGroup[]
+): (workspace: FolderWorkspace) => ExecutionHostId {
+  let hostByGroupId: FolderWorkspaceHostIndex | undefined
+  return (workspace) => {
+    const explicitHostId = parseExecutionHostId(workspace.executionHostId)?.id
+    if (explicitHostId) {
+      return explicitHostId
+    }
+    if (workspace.connectionId) {
+      return toSshExecutionHostId(workspace.connectionId)
+    }
+    hostByGroupId ??= createFolderWorkspaceHostIndex(projectGroups)
+    return getFolderWorkspaceHostIdFromIndex(workspace, hostByGroupId)
+  }
+}
+
 export function getFolderWorkspaceHostId(
   workspace: FolderWorkspace,
   projectGroups: readonly ProjectGroup[]
@@ -39,21 +84,26 @@ export function getFolderWorkspaceHostId(
   if (workspace.connectionId) {
     return toSshExecutionHostId(workspace.connectionId)
   }
-  const matchingHosts = new Set(
-    projectGroups
-      .filter((group) => group.id === workspace.projectGroupId)
-      .map(getProjectGroupHostId)
-  )
-  return matchingHosts.size === 1
-    ? ([...matchingHosts][0] as ExecutionHostId)
-    : LOCAL_EXECUTION_HOST_ID
+  let matchingHostId: ExecutionHostId | undefined
+  for (const group of projectGroups) {
+    if (group.id !== workspace.projectGroupId) {
+      continue
+    }
+    const hostId = getProjectGroupHostId(group)
+    if (matchingHostId === undefined) {
+      matchingHostId = hostId
+    } else if (matchingHostId !== hostId) {
+      return LOCAL_EXECUTION_HOST_ID
+    }
+  }
+  return matchingHostId ?? LOCAL_EXECUTION_HOST_ID
 }
 
 function getFolderWorkspaceHostIdentity(
   workspace: FolderWorkspace,
-  projectGroups: readonly ProjectGroup[]
+  resolveHostId: (workspace: FolderWorkspace) => ExecutionHostId
 ): string {
-  return JSON.stringify([getFolderWorkspaceHostId(workspace, projectGroups), workspace.id])
+  return JSON.stringify([resolveHostId(workspace), workspace.id])
 }
 
 export function getFolderWorkspaceUpdateIdentity(
@@ -74,21 +124,22 @@ function mergeFetchedFolderWorkspacesForHost({
   projectGroups: readonly ProjectGroup[]
   hostId: string
 }): readonly FolderWorkspace[] {
+  const resolveHostId = createFolderWorkspaceHostResolver(projectGroups)
   const fetchedIdentities = new Set(
-    fetched.map((workspace) => getFolderWorkspaceHostIdentity(workspace, projectGroups))
+    fetched.map((workspace) => getFolderWorkspaceHostIdentity(workspace, resolveHostId))
   )
   const preserved = previous.filter((workspace) => {
-    const existingHostId = getFolderWorkspaceHostId(workspace, projectGroups)
+    const existingHostId = resolveHostId(workspace)
     return (
       !catalogOwnsHost(hostId, existingHostId) ||
-      fetchedIdentities.has(getFolderWorkspaceHostIdentity(workspace, projectGroups))
+      fetchedIdentities.has(getFolderWorkspaceHostIdentity(workspace, resolveHostId))
     )
   })
   return unchangedMergeSource(
     previous,
     preserved,
     mergeByIdentity(preserved, fetched, (workspace) =>
-      getFolderWorkspaceHostIdentity(workspace, projectGroups)
+      getFolderWorkspaceHostIdentity(workspace, resolveHostId)
     )
   )
 }
@@ -98,16 +149,14 @@ export function getFolderWorkspaceCatalogReplacementIdentities(
   currentFolderWorkspaces: readonly FolderWorkspace[],
   projectGroups: readonly ProjectGroup[]
 ): Set<string> {
+  const resolveHostId = createFolderWorkspaceHostResolver(projectGroups)
   const replacedIdentities = new Set(
     catalog.folderWorkspaces.map((workspace) =>
-      getFolderWorkspaceUpdateIdentity(
-        getFolderWorkspaceHostId(workspace, projectGroups),
-        workspace.id
-      )
+      getFolderWorkspaceUpdateIdentity(resolveHostId(workspace), workspace.id)
     )
   )
   for (const workspace of currentFolderWorkspaces) {
-    const hostId = getFolderWorkspaceHostId(workspace, projectGroups)
+    const hostId = resolveHostId(workspace)
     if (catalogOwnsHost(catalog.hostId, hostId)) {
       replacedIdentities.add(getFolderWorkspaceUpdateIdentity(hostId, workspace.id))
     }
@@ -164,10 +213,20 @@ export async function fetchFolderWorkspaceCatalogForTarget(
             { timeoutMs: 15_000, reuseRecentCompatibilityFailure: true }
           )
         ).folderWorkspaces
-  return {
-    folderWorkspaces: fetchedFolderWorkspaces.map((workspace) =>
+  let ownedFolderWorkspaces: FolderWorkspace[]
+  if (target.kind === 'local') {
+    const resolveHostId = createFolderWorkspaceHostResolver(projectGroups)
+    ownedFolderWorkspaces = fetchedFolderWorkspaces.map((workspace) => ({
+      ...workspace,
+      executionHostId: resolveHostId(workspace)
+    }))
+  } else {
+    ownedFolderWorkspaces = fetchedFolderWorkspaces.map((workspace) =>
       folderWorkspaceWithFetchedOwner(workspace, target, projectGroups)
-    ),
+    )
+  }
+  return {
+    folderWorkspaces: ownedFolderWorkspaces,
     hostId: getRuntimeTargetHostId(target)
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​135 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​135 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 |

<!-- /orca-pr-loc -->

## ELI5

When Orca syncs folder workspaces, it repeatedly asks which project-group host owns each row. It used to scan all project-group copies and allocate a temporary set for every row. A small host index answers those repeated questions once per catalog operation.

## What Changed

- Build a lazy project-group ID → unique host index for each merge/replacement operation.
- Keep explicit workspace host pins and direct SSH connections on their existing fast paths.
- Preserve duplicate-host ambiguity fallback to local and all catalog ownership semantics.
- Add deterministic getter-count coverage for merge and replacement identity paths.

## Why

Folder-workspace catalog merges and replacement-identity calculations resolve ownership repeatedly for the same project-group collection. This is a renderer store hot path during host refreshes, where repeated rows magnify the scan and temporary `Set` allocations.

## Performance Measurement

Reproducible fixture: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/folder-workspaces/folder-workspace-catalog.test.ts`.

The fixture uses eight rows and a getter-backed project-group host field. It measures the same host-resolution work through merge and replacement-identity operations.

- Merge path: **32 → 1** host-field reads (96.9% fewer).
- Replacement identities: **16 → 1** host-field reads (93.8% fewer).
- The index is lazy, so rows with explicit host stamps or workspace SSH connections do not scan project groups.

## User-Facing Trade-offs

None. Host ownership, duplicate-host fallback, local/SSH routing, catalog replacement behavior, ordering, and workspace data are unchanged.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

N/A — no UI layout or interaction behavior changed.

## Testing

- [x] Focused folder-workspace catalog suite (7 passed)
- [x] Related all-host and mutation suites (20 passed)
- [x] `pnpm tc:web`
- [x] Focused `oxlint --deny-warnings`
- [x] Focused `oxfmt --check`
- [x] `git diff --check`

## Review

Checked explicit execution-host pins, direct SSH connections, duplicate and conflicting project-group owners, local and runtime catalog fetches, folder-workspace ordering, and owner-routed mutations. No IPC or remote-wire changes.

## Agent skill upstream boundary

- [x] Not applicable.
