### PR TITLE
perf(shared): index git history merge parents lazily

### DIFF
--- a/src/shared/git-history-graph.test.ts
+++ b/src/shared/git-history-graph.test.ts
@@ -29,6 +29,19 @@ function item(
   }
 }
 
+function trackedItem(id: string, parentIds: string[], reads: { count: number }): GitHistoryItem {
+  const result = item(id, parentIds)
+  Object.defineProperty(result, 'id', {
+    configurable: true,
+    enumerable: true,
+    get: () => {
+      reads.count += 1
+      return id
+    }
+  })
+  return result
+}
+
 function branch(name: string, revision: string): GitHistoryItemRef {
   return {
     id: `refs/heads/${name}`,
@@ -78,6 +91,60 @@ describe('git history graph model', () => {
       { id: 'B', color: GIT_HISTORY_LANE_COLORS[0] }
     ])
     expect(getGitHistoryMergeParentLaneIndex(viewModels[0]!, 'B')).toBe(1)
+  })
+
+  it('keeps the first matching parent when history contains duplicate ids', () => {
+    const headRef = branch('head', 'merge')
+    const firstParentRef = branch('first', 'duplicate')
+    const laterParentRef = remote('later', 'duplicate')
+    const colorMap = buildDefaultGitHistoryColorMap({
+      currentRef: headRef,
+      remoteRef: firstParentRef,
+      baseRef: laterParentRef
+    })
+    const viewModels = buildGitHistoryViewModels(
+      [
+        item('merge', ['base', 'duplicate'], [headRef]),
+        item('base', []),
+        item('duplicate', [], [firstParentRef]),
+        item('duplicate', [], [laterParentRef])
+      ],
+      colorMap,
+      headRef
+    )
+
+    expect(viewModels[0]!.outputSwimlanes[1]!.color).toBe(GIT_HISTORY_REMOTE_REF_COLOR)
+  })
+
+  it('avoids building a parent index for linear history', () => {
+    const count = 64
+    const reads = { count: 0 }
+    const historyItems = Array.from({ length: count }, (_, index) =>
+      trackedItem(`commit-${index}`, index + 1 < count ? [`commit-${index + 1}`] : [], reads)
+    )
+
+    buildGitHistoryViewModels(historyItems)
+
+    // A linear graph reads each item while projecting; an eager index would add one read per row.
+    expect(reads.count).toBeLessThanOrEqual(count * 5)
+  })
+
+  it('indexes merge parents once instead of rescanning a large history', () => {
+    const mergeCount = 64
+    const targetId = `target-${mergeCount}`
+    const reads = { count: 0 }
+    const historyItems: GitHistoryItem[] = []
+    for (let index = 0; index < mergeCount; index += 1) {
+      historyItems.push(trackedItem(`merge-${index}`, [`missing-${index}`, targetId], reads))
+      // Reset swimlanes between merges so this measures parent lookup, not lane growth.
+      historyItems.push(trackedItem(`leaf-${index}`, [], reads))
+    }
+    historyItems.push(trackedItem(targetId, [], reads))
+
+    buildGitHistoryViewModels(historyItems)
+
+    // Repeated Array#find scans grow with rows; one index build stays within a linear read budget.
+    expect(reads.count).toBeLessThan(historyItems.length * 8)
   })
 
   it('inserts incoming and outgoing boundary rows at the merge base', () => {

--- a/src/shared/git-history-graph.ts
+++ b/src/shared/git-history-graph.ts
@@ -103,6 +103,7 @@ export function buildGitHistoryViewModels(
 ): GitHistoryItemViewModel[] {
   let colorIndex = -1
   const viewModels: GitHistoryItemViewModel[] = []
+  let historyItemsById: Map<string, GitHistoryItem> | undefined
 
   for (const historyItem of historyItems) {
     const kind = historyItem.id === currentRef?.revision ? 'HEAD' : 'node'
@@ -131,7 +132,18 @@ export function buildGitHistoryViewModels(
       if (index === 0) {
         colorIdentifier = getLabelColorIdentifier(historyItem, colorMap)
       } else {
-        const parent = historyItems.find((item) => item.id === historyItem.parentIds[index])
+        // Side-parent colors need a lookup; defer indexing so linear histories pay no map cost.
+        if (!historyItemsById) {
+          historyItemsById = new Map()
+          for (const candidate of historyItems) {
+            // Array#find returns the first duplicate, so retain first-wins ordering here.
+            const candidateId = candidate.id
+            if (!historyItemsById.has(candidateId)) {
+              historyItemsById.set(candidateId, candidate)
+            }
+          }
+        }
+        const parent = historyItemsById.get(historyItem.parentIds[index]!)
         colorIdentifier = parent ? getLabelColorIdentifier(parent, colorMap) : undefined
       }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

A merge commit can have a second parent. The history graph used to search the entire commit list every time it needed that parent’s label color. A lookup table now finds parents directly, and it is built only when a second-parent lookup is actually needed.

## What Changed

- Lazily build a first-match commit-ID map for secondary merge-parent color lookups.
- Preserve the first-match behavior of the old `Array.find` path for duplicate IDs.
- Keep linear histories allocation-free on this path.
- Add duplicate, linear, and merge-heavy lookup-count coverage.

## Why

`buildGitHistoryViewModels` runs while rendering source-control history. Repeated full-array searches made merge-heavy histories quadratic in the number of loaded commits, especially as history paging exposes deeper ranges.

## Performance Measurement

Reproducible fixture: `pnpm test src/shared/git-history-graph.test.ts src/shared/git-history.test.ts`.

The tests use getter-backed commit IDs to count lookup work and exercise linear, merge-heavy, and duplicate-ID histories.

- Linear 64-row history: **0 index builds** and **316 ID reads** in both versions; no merge-parent map is allocated.
- Merge-heavy fixture (64 merges, 129 rows): **8,899 -> 643** getter-backed commit-ID reads (**92.8% fewer**); one lazy **O(N)** index replaces repeated **O(N)** scans for each secondary parent.
- Duplicate IDs: the map keeps the first occurrence, matching `Array.find` exactly.
- Improvement: secondary-parent lookup changes from O(commits) per parent to O(1) after one index build, flattening the merge-heavy growth curve without adding work to linear histories.

## User-Facing Trade-offs

None. Graph lane colors, duplicate-ID behavior, ordering, boundary rows, and linear-history output are unchanged.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

N/A — no UI layout or interaction behavior changed.

## Testing

- [x] Git history graph and history suites (19 passed)
- [x] `pnpm tc:node`
- [x] Focused `oxlint --deny-warnings`
- [x] Focused `oxfmt --check`
- [x] `git diff --check`
- [x] Commit hooks passed

## Review

Checked merge-parent lane coloring, first-match duplicate semantics, linear-history fast path, paging/boundary rows, and Git-provider-independent rendering. No IPC or remote-wire changes.

## Agent skill upstream boundary

- [x] Not applicable.

