### PR TITLE
fix(orchestration): submit staged mail pointer while working

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -12519,7 +12519,7 @@
             "large persisted mismatches route in 50-row pages with coalesced per-mailbox wakes",
             "Run pointers pin the existing mixed-version-compatible --run identity",
             "direct and Dispatch mail remain durable without unpinned synthetic terminal turns",
-            "a delayed pointer submit cannot press Enter after the agent becomes working",
+            "a staged pointer submits once when Codex or Claude becomes working and still withholds Enter for permission",
             "an explicit check releases its staged pointer reservation without redrive",
             "accepted pointer text is durably deduplicated before delayed Enter and provider Enter refusal",
             "a known PTY exit releases staged rows for the replacement process",

--- a/src/main/runtime/orchestration-mailbox-notification-consistency.test.ts
+++ b/src/main/runtime/orchestration-mailbox-notification-consistency.test.ts
@@ -471,25 +471,54 @@ describe('orchestration notification mailbox consistency', () => {
     db.close()
   })
 
-  it('does not submit or duplicate a pointer after the agent becomes working', async () => {
-    vi.useFakeTimers()
-    const db = createDatabase('orca-mailbox-working-before-enter-')
-    const harness = createRuntime(db)
-    const run = createBoundRun(db, 'Working-before-Enter Run')
-    const message = insertDirectRunMessage(db, run.id, 'Actionable status')
+  it.each([
+    ['Codex', '\x1b]0;Codex working\x07', '\x1b]0;Codex done\x07'],
+    ['Claude', '\x1b]0;\u280b Claude working\x07', '\x1b]0;\u2733 Claude Code\x07']
+  ])(
+    'submits a staged pointer after %s becomes working without duplicating it',
+    async (_provider, workingTitle, idleTitle) => {
+      vi.useFakeTimers()
+      const db = createDatabase('orca-mailbox-working-before-enter-')
+      const harness = createRuntime(db)
+      const run = createBoundRun(db, 'Working-before-Enter Run')
+      const message = insertDirectRunMessage(db, run.id, 'Actionable status')
 
-    await driveToLiveIdle(harness.runtime)
-    expect(pointerCount(harness.write)).toBe(1)
-    harness.runtime.onPtyData(PTY_ID, '\x1b]0;Codex working\x07', 3)
-    await vi.advanceTimersByTimeAsync(500)
+      await driveToLiveIdle(harness.runtime)
+      expect(pointerCount(harness.write)).toBe(1)
+      harness.runtime.onPtyData(PTY_ID, workingTitle, 3)
+      await vi.advanceTimersByTimeAsync(500)
 
-    expect(harness.write.mock.calls.filter(([, payload]) => payload === '\r')).toHaveLength(0)
-    expect(db.getMessageById(message.id)?.delivered_at).toEqual(expect.any(String))
-    harness.runtime.onPtyData(PTY_ID, '\x1b]0;Codex done\x07', 4)
-    await Promise.resolve()
-    expect(pointerCount(harness.write)).toBe(1)
-    db.close()
-  })
+      expect(harness.write.mock.calls.filter(([, payload]) => payload === '\r')).toHaveLength(1)
+      expect(db.getMessageById(message.id)?.delivered_at).toEqual(expect.any(String))
+      harness.runtime.onPtyData(PTY_ID, idleTitle, 4)
+      await Promise.resolve()
+      expect(pointerCount(harness.write)).toBe(1)
+      db.close()
+    }
+  )
+
+  it.each([
+    ['Codex', '\x1b]0;Codex permission\x07'],
+    ['Claude', '\x1b]0;Claude waiting for permission\x07']
+  ])(
+    'does not submit a staged pointer after %s enters a permission state',
+    async (_provider, permissionTitle) => {
+      vi.useFakeTimers()
+      const db = createDatabase('orca-mailbox-permission-before-enter-')
+      const harness = createRuntime(db)
+      const run = createBoundRun(db, 'Permission-before-Enter Run')
+      const message = insertDirectRunMessage(db, run.id, 'Actionable status')
+
+      await driveToLiveIdle(harness.runtime)
+      expect(pointerCount(harness.write)).toBe(1)
+      harness.runtime.onPtyData(PTY_ID, permissionTitle, 3)
+      await vi.advanceTimersByTimeAsync(500)
+
+      expect(harness.write.mock.calls.filter(([, payload]) => payload === '\r')).toHaveLength(0)
+      expect(db.getMessageById(message.id)?.delivered_at).toEqual(expect.any(String))
+      db.close()
+    }
+  )
 
   it('releases staged pointer state when an explicit check owns the batch', async () => {
     vi.useFakeTimers()

--- a/src/main/runtime/orchestration/mailbox-pointer-submit.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-submit.ts
@@ -54,8 +54,9 @@ export function submitOrchestrationMailboxPointer<TWaiter extends OrchestrationM
       } else if (deps.mailboxOwner.resolve(currentLeaf) !== input.mailboxHandle) {
         clearAndRedrive = true
       } else if (
-        currentLeaf.lastAgentStatus === 'idle' &&
-        currentLeaf.lastAgentStatusObservedLive
+        currentLeaf.lastAgentStatusObservedLive &&
+        // Once staged, working is queue-safe; idle-only strands Orca-owned text in the composer.
+        (currentLeaf.lastAgentStatus === 'idle' || currentLeaf.lastAgentStatus === 'working')
       ) {
         if (
           shouldReleaseOrchestrationPointer(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

Orca can paste an orchestration notification while an agent is idle, then see the agent become busy before the delayed Enter. Orca previously canceled only the Enter, leaving its own notification stranded in the composer. This completes the submission Orca already started.

## What Changed

- Allow a staged mailbox pointer to submit when the same live Codex or Claude leaf transitions from `idle` to `working` during the 500 ms settlement window.
- Preserve the existing PTY, mailbox-owner, delivery-flight, session, and permission fences.
- Add Codex- and Claude-shaped regression cases for working transitions and permission-state negatives.
- Update the matching reliability contract.

## Why

Mailbox pointer delivery writes text directly to the PTY and submits it after a delay; it does not use `terminal send --enter`. The previous idle-only submit guard marked the mail delivered but withheld Enter when status changed to working, with no redrive. Cold park/unpark can amplify the timing window because the main-owned PTY and retained status outlive the renderer pane.

This is a narrow atomicity fix, not a new notification policy: delivery still begins only from the existing eligible state, and permission states still withhold Enter.

## Linked Issue

Fixes #16986

## Visual Proof

N/A — no rendered UI component changed. The defect and fix are at the main-runtime PTY write boundary and are covered by deterministic transition tests. The existing issue contains the visible before-state; real Claude/Codex internal composer acceptance remains an explicit validation gap.

## Testing

- `pnpm test src/main/runtime/orchestration-mailbox-notification-consistency.test.ts` — 23/23 passed
- Full mailbox/daemon/SSH transport reliability gate — 226/226 passed
- `pnpm tc:node` — passed
- `pnpm run check:code-quality:changed` — zero findings
- `git diff --check` — passed
- Electron real-PTY idle-mail delivery regression — 1/1 passed on macOS; fixture records stdin rather than provider-internal composer state

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

The broader prompt-transaction ownership work and human-draft collision policy are intentionally out of scope. Routing durable mailbox delivery through the generic prompt transaction would require replay/duplication semantics beyond this fix.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No path, shortcut, renderer, IPC, stream opcode, or remote-wire changes. The execution host continues to own PTY writes, so SSH and folder-workspace boundaries are unchanged. The predicate is provider-agnostic; tests cover Codex and Claude status shapes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Focused test, changed-file lint, and node typecheck pass; CI will cover full lint and build

## Performance Measurement

This is an atomicity fix, not a speed optimization, so no speedup claim is made. The existing 500-ms settlement timer remains; the guard adds at most one status-string comparison and no timer, database, RPC, or scan. In the fixed fixture, the working transition changes the result from 0 Enter writes (stranded staged text) to exactly 1 Enter write while the pointer count remains 1; Codex and Claude permission fixtures remain at 0 Enter writes.

## User-Facing Trade-offs

None beyond the intended behavior: an Orca-owned staged notification now submits if its same live pane becomes `working` during settlement. PTY and mailbox ownership, duplicate suppression, and permission-state withholding remain intact; no user-authored draft policy changes.
