### PR TITLE
fix(ssh): match the exact worktree created

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -90,7 +90,7 @@ import {
   shouldSetDisplayName,
   mergeWorktree
 } from './worktree-logic'
-import { resolveCreatedWorktree } from './created-worktree-reconciliation'
+import { findCreatedWorktree, resolveCreatedWorktree } from './created-worktree-reconciliation'
 import type { BranchPrefixSettings } from '../../shared/branch-prefix'
 import { getRepoIdFromWorktreeId } from '../../shared/worktree/id'
 import { parseWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
@@ -1840,9 +1840,9 @@ export async function createRemoteWorktree(
   const gitWorktrees = await timing.time('list_created_worktree', async () =>
     provider.listWorktrees(repo.path)
   )
-  const created = gitWorktrees.find(
-    (gw) => gw.branch?.endsWith(branchName) || gw.path.endsWith(effectiveSanitizedName)
-  )
+  // Match the exact requested path first, then the exact branch ref. Suffix matching can
+  // select an older `prefix/<branchName>` worktree when the newly created row is present.
+  const created = findCreatedWorktree(gitWorktrees, remotePath, branchName)
   if (!created) {
     throw new Error('Worktree created but not found in listing')
   }

--- a/src/main/ipc/worktrees-ssh-setup-launch.test.ts
+++ b/src/main/ipc/worktrees-ssh-setup-launch.test.ts
@@ -127,6 +127,13 @@ describe('registerWorktreeHandlers', () => {
       addWorktree: vi.fn().mockResolvedValue(undefined),
       listWorktrees: vi.fn().mockResolvedValue([
         {
+          path: '/remote/old-improve-dashboard',
+          head: 'old123',
+          branch: 'refs/heads/archive/improve-dashboard',
+          isBare: false,
+          isMainWorktree: false
+        },
+        {
           path: '/remote/repo-improve-dashboard',
           head: 'abc123',
           branch: 'refs/heads/improve-dashboard',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | 0 |

<!-- /orca-pr-loc -->

SSH worktree creation now reconciles the requested path and branch using the shared exact-match helper. This prevents a pre-existing prefixed branch/path from being selected by suffix matching when the newly created worktree is present.

Includes a regression fixture covering the branch suffix collision.

Tests: pnpm test src/main/ipc/worktrees-ssh-setup-launch.test.ts src/main/ipc/created-worktree-reconciliation.test.ts

## ELI5

When SSH creates a worktree, a suffix-based lookup could pick an older branch/path that merely looked similar. Reconciliation now requires the requested path and branch to match exactly.

## Performance Measurement

Deterministic collision fixture: two candidates share a branch/path suffix. The old resolver selected the wrong candidate (1 incorrect selection); the exact-match helper selects 0 incorrect candidates and the newly created worktree. No additional Git probes are introduced.

## User-Facing Trade-offs

None. Exact reconciliation preserves the requested worktree, while the existing creation and cleanup ordering remains unchanged.