### PR TITLE
fix(relay): propagate worktree listing failures

### DIFF
--- a/src/relay/git-handler-worktree-inspection.test.ts
+++ b/src/relay/git-handler-worktree-inspection.test.ts
@@ -49,13 +49,13 @@ describe('GitHandler', () => {
         .spyOn(handler as unknown as GitSpyTarget, 'git')
         .mockRejectedValue(new Error('aborted'))
 
-      const result = await dispatcher.callRequest(
-        'git.listWorktrees',
-        { repoPath: tmpDir },
-        { isStale: () => false, signal: controller.signal }
-      )
-
-      expect(result).toEqual([])
+      await expect(
+        dispatcher.callRequest(
+          'git.listWorktrees',
+          { repoPath: tmpDir },
+          { isStale: () => false, signal: controller.signal }
+        )
+      ).rejects.toThrow('aborted')
       expect(gitSpy).toHaveBeenCalledWith(['worktree', 'list', '--porcelain', '-z'], tmpDir, {
         signal: controller.signal
       })

--- a/src/relay/git-handler-worktree-operations.ts
+++ b/src/relay/git-handler-worktree-operations.ts
@@ -119,37 +119,35 @@ export class GitHandlerWorktreeOperations extends GitHandlerOperationContext {
 
   async listWorktrees(params: Record<string, unknown>, context?: RequestContext) {
     const repoPath = params.repoPath as string
-    return this.gitCapabilities
-      .runWithFallback(
-        'worktree-list-z',
-        async () => {
-          const { stdout } = await this.git(['worktree', 'list', '--porcelain', '-z'], repoPath, {
+    return this.gitCapabilities.runWithFallback(
+      'worktree-list-z',
+      async () => {
+        const { stdout } = await this.git(['worktree', 'list', '--porcelain', '-z'], repoPath, {
+          signal: context?.signal
+        })
+        return this.normalizeMainWorktreePath(
+          repoPath,
+          parseWorktreeList(stdout, { nulDelimited: true })
+        )
+      },
+      async () => {
+        // Why: Git <2.36 lacks worktree-list `-z`, so fall back to the newline-block parser (loses newline-in-path safety).
+        try {
+          const { stdout } = await this.git(['worktree', 'list', '--porcelain'], repoPath, {
             signal: context?.signal
           })
-          return this.normalizeMainWorktreePath(
+          const normalized = await this.normalizeMainWorktreePath(
             repoPath,
-            parseWorktreeList(stdout, { nulDelimited: true })
+            parseWorktreeList(stdout)
           )
-        },
-        async () => {
-          // Why: Git <2.36 lacks worktree-list `-z`, so fall back to the newline-block parser (loses newline-in-path safety).
-          try {
-            const { stdout } = await this.git(['worktree', 'list', '--porcelain'], repoPath, {
-              signal: context?.signal
-            })
-            const normalized = await this.normalizeMainWorktreePath(
-              repoPath,
-              parseWorktreeList(stdout)
-            )
-            // Why: Git <2.31 emits no `prunable` annotation, so probe each linked worktree's existence instead of trusting stale registrations (issue #8389).
-            return annotatePrunableWorktreesByExistence(normalized)
-          } catch {
-            return []
-          }
-        },
-        isUnsupportedWorktreeListZError
-      )
-      .catch(() => [])
+          // Why: Git <2.31 emits no `prunable` annotation, so probe each linked worktree's existence instead of trusting stale registrations (issue #8389).
+          return annotatePrunableWorktreesByExistence(normalized)
+        } catch {
+          return []
+        }
+      },
+      isUnsupportedWorktreeListZError
+    )
   }
 
   async addWorktree(params: Record<string, unknown>) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |

<!-- /orca-pr-loc -->

Stop converting unexpected relay worktree-list failures into an empty list.

The strict -z capability fallback remains intact, but transport, cancellation, and other unexpected failures now reach the SSH client so create reconciliation can report the real failure instead of treating the worktree as missing.

Tests: pnpm test src/relay/git-handler-worktree-inspection.test.ts src/relay/git-handler-worktree-git-capabilities.test.ts

## ELI5

If a remote worktree listing fails, an empty list does not mean “there are no worktrees.” The relay now passes unexpected failures through so the client can show the real problem and retry safely.

## Performance Measurement

Deterministic failure fixture: an unexpected listing failure was converted to an empty result (1 masked failure) before; it now reaches the caller (0 masked failures). The `-z` unsupported-capability fallback and subprocess count are unchanged, so no latency improvement is claimed.

## User-Facing Trade-offs

None. Users see an actionable listing error instead of a misleading empty workspace; valid listings and the Git capability fallback are unchanged.