### PR TITLE
fix(paste): exclude xterm helper textareas from text ownership

### DIFF
--- a/src/renderer/src/lib/text-control-paste-ownership.test.ts
+++ b/src/renderer/src/lib/text-control-paste-ownership.test.ts
@@ -54,6 +54,7 @@ describe('text control paste ownership', () => {
     expect(findOwnedPasteEventTextControlTarget(textarea, textarea)).toBe(textarea)
     expect(findOwnedPasteEventTextControlTarget(other, textarea)).toBeNull()
     expect(findOwnedPasteEventTextControlTarget(terminalTextarea, terminalTextarea)).toBeNull()
+    expect(findOwnedTextControlPasteTarget(terminalTextarea)).toBeNull()
   })
 
   it('allows native paste for empty and small payloads', () => {

--- a/src/renderer/src/lib/text-control-paste-ownership.ts
+++ b/src/renderer/src/lib/text-control-paste-ownership.ts
@@ -30,6 +30,11 @@ export function findOwnedTextControlPasteTarget(
   if (!(activeElement instanceof Element)) {
     return null
   }
+  // xterm focuses a hidden helper textarea; it is terminal input, not a native
+  // text-control target for app-menu or large-paste ownership.
+  if (activeElement.closest('.xterm-helper-textarea')) {
+    return null
+  }
   const textControl = activeElement.closest('input, textarea')
   if (!textControl || !isPrimarySelectionTextControl(textControl)) {
     return null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

Exclude xterm.js' hidden `.xterm-helper-textarea` from `findOwnedTextControlPasteTarget`.

The helper textarea receives terminal keystrokes but is not a native text-control target for app-menu or large-paste ownership. This keeps global paste routing from claiming terminal input as an editable form control.

Tests: pnpm test src/renderer/src/lib/text-control-paste-ownership.test.ts src/renderer/src/lib/app-menu-paste.test.ts src/renderer/src/lib/large-text-control-paste.test.ts

## ELI5

The hidden textarea inside xterm is a keyboard transport, not an editable form. Paste ownership now leaves that element alone, so app-level paste continues to reach the terminal instead of being swallowed by an invisible field.

## Performance Measurement

Deterministic ownership fixture: the hidden xterm helper was incorrectly selected as a paste target in the old path (1 incorrect target); the new exclusion selects 0 incorrect targets. The ownership lookup remains one bounded DOM walk, so no standalone latency improvement is claimed.

## User-Facing Trade-offs

None. Native text controls still receive paste ownership, while terminal input is no longer claimed by the hidden helper textarea.