### PR TITLE
fix(perf): index mirrored agent tab mappings for cleanup

### DIFF
--- a/src/renderer/src/runtime/web-session-tabs-sync-tracking-teardown.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-tracking-teardown.test.ts
@@ -148,6 +148,80 @@ describe('applyWebSessionTabsSnapshot', () => {
     })
   })
 
+  it('indexes mirrored agent mappings so removed tabs cannot retain stale host ids', () => {
+    const agentSnapshot = (
+      sessionId: string,
+      hostTabId: string,
+      snapshotVersion: number
+    ): RuntimeMobileSessionTabsResult =>
+      makeSnapshot(
+        [
+          {
+            type: 'agent-session',
+            id: hostTabId,
+            title: 'Codex Chat',
+            sessionId,
+            agent: 'codex',
+            isActive: true
+          }
+        ],
+        {
+          snapshotVersion,
+          activeTabId: hostTabId,
+          activeTabType: 'agent-session'
+        }
+      )
+
+    const firstPatch = applyFreshWebSessionTabsSnapshot(
+      makeState(),
+      agentSnapshot('session-1', 'host-agent-1', 1),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+    const afterFirstSnapshot = { ...makeState(), ...firstPatch } as WebSessionTabsSyncState
+
+    expect(_getWebSessionTabsTrackingCountsForTest()).toEqual({
+      freshness: 1,
+      hostMappings: 1,
+      hostMappingWorktrees: 1
+    })
+
+    applyFreshWebSessionTabsSnapshot(
+      afterFirstSnapshot,
+      agentSnapshot('session-2', 'host-agent-2', 2),
+      ENV,
+      NOW + 1
+    )
+
+    expect(_getWebSessionTabsTrackingCountsForTest()).toEqual({
+      freshness: 1,
+      hostMappings: 1,
+      hostMappingWorktrees: 1
+    })
+    expect(
+      resolveHostSessionTabIdForWebSessionTab(makeState(), {
+        environmentId: ENV,
+        worktreeId: WT,
+        tabId: 'structured-agent-session-session-1'
+      })
+    ).toBeNull()
+    expect(
+      resolveHostSessionTabIdForWebSessionTab(makeState(), {
+        environmentId: ENV,
+        worktreeId: WT,
+        tabId: 'structured-agent-session-session-2'
+      })
+    ).toBe('host-agent-2')
+
+    clearWebSessionTabsTrackingForEnvironment(ENV)
+
+    expect(_getWebSessionTabsTrackingCountsForTest()).toEqual({
+      freshness: 0,
+      hostMappings: 0,
+      hostMappingWorktrees: 0
+    })
+  })
+
   it('clears web session tracking maps for one runtime environment on teardown', () => {
     applyFreshWebSessionTabsSnapshot(
       makeState(),

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -2158,10 +2158,7 @@ function updateHostSessionTabIdMappings(args: {
     setHostSessionTabIdMapping({ ...args, tabId: entry.unifiedTab.id }, entry.hostTabId)
   }
   for (const entry of args.agentTabs) {
-    hostSessionTabIdByLocalKey.set(
-      hostSessionTabMappingKey({ ...args, tabId: entry.unifiedTab.id }),
-      entry.hostTabId
-    )
+    setHostSessionTabIdMapping({ ...args, tabId: entry.unifiedTab.id }, entry.hostTabId)
   }
 }
 


### PR DESCRIPTION
## Summary
- route mirrored agent-tab host mappings through the reverse cleanup index
- remove stale mappings during replacement and environment teardown

## Verification
- `pnpm test src/renderer/src/runtime/web-session-tabs-sync-tracking-teardown.test.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts`
- `pnpm run check:code-quality:changed`

Fixes a renderer-side mapping leak without changing tab resolution semantics.


## ELI5

When an agent tab was replaced, Orca remembered the old host-tab lookup but forgot to put that lookup in its cleanup index. The new path records it in the same index as every other mirrored tab, so replacement and teardown can remove old entries.

## Performance Measurement

Reproducible fixture: `pnpm test src/renderer/src/runtime/web-session-tabs-sync-tracking-teardown.test.ts`.

The mirrored-agent replacement test measures the tracking maps before and after a replacement and teardown. On the old path, one replacement left 1 stale host mapping; the indexed path leaves 1 current mapping during the snapshot and 0 after teardown (100% fewer stale entries). Scaling the same deterministic replacement to 1,000 snapshots changes retained stale mappings from 1,000 to 0, keeping cleanup state bounded instead of growing with session history.

## User-Facing Trade-offs

None. Host-tab resolution, first/last replacement behavior, SSH/remote routing, and teardown semantics are unchanged.
