### PR TITLE
perf(renderer): cache structured session tab projection

### DIFF
--- a/src/renderer/src/components/native-chat/StructuredAgentSessionStatusBridge.test.tsx
+++ b/src/renderer/src/components/native-chat/StructuredAgentSessionStatusBridge.test.tsx
@@ -78,7 +78,10 @@ vi.mock('@/runtime/structured-agent-session-client', () => ({
   subscribeStructuredAgentSession: mocks.subscribe
 }))
 
-import { StructuredAgentSessionStatusBridge } from './StructuredAgentSessionStatusBridge'
+import {
+  getStructuredAgentSessionTabs,
+  StructuredAgentSessionStatusBridge
+} from './StructuredAgentSessionStatusBridge'
 import { resetStructuredAgentSessionReadOwnersForTests } from './structured-agent-session-read-owner'
 import { useStructuredAgentSessionRead } from './use-structured-agent-session-read'
 
@@ -161,6 +164,34 @@ describe('StructuredAgentSessionStatusBridge', () => {
   afterEach(() => {
     cleanup()
     resetStructuredAgentSessionReadOwnersForTests()
+  })
+
+  it('reuses the structured-tab projection for an unchanged tab map', () => {
+    const secondStructuredTab = {
+      ...structuredTab,
+      id: 'structured-tab-2',
+      entityId: 'session-2'
+    }
+    const tabsByWorktree: Record<string, Tab[]> = {
+      'wt-1': [structuredTab],
+      'wt-2': [secondStructuredTab]
+    }
+
+    const first = getStructuredAgentSessionTabs(tabsByWorktree)
+    const second = getStructuredAgentSessionTabs(tabsByWorktree)
+
+    expect(second).toBe(first)
+    expect(second).toEqual([structuredTab, secondStructuredTab])
+
+    const nextTabsByWorktree = {
+      ...tabsByWorktree,
+      'wt-3': [{ ...structuredTab, id: 'structured-tab-3', entityId: 'session-3' }]
+    }
+    expect(getStructuredAgentSessionTabs(nextTabsByWorktree)).toEqual([
+      structuredTab,
+      secondStructuredTab,
+      nextTabsByWorktree['wt-3'][0]
+    ])
   })
 
   it('keeps restored inactive tabs transport-neutral', async () => {

--- a/src/renderer/src/components/native-chat/StructuredAgentSessionStatusBridge.tsx
+++ b/src/renderer/src/components/native-chat/StructuredAgentSessionStatusBridge.tsx
@@ -17,6 +17,36 @@ import { useStructuredAgentSessionReadObservation } from './use-structured-agent
 
 type StructuredTab = Tab & { contentType: 'agent-session' }
 
+function isStructuredTab(tab: Tab): tab is StructuredTab {
+  return tab.contentType === 'agent-session' && isAgentSessionHandleProvider(tab.agentSessionAgent)
+}
+
+const structuredTabsByUnifiedTabsSnapshot = new WeakMap<
+  Record<string, Tab[]>,
+  readonly StructuredTab[]
+>()
+
+/** Project structured-session tabs once per immutable tab-map snapshot. */
+export function getStructuredAgentSessionTabs(
+  unifiedTabsByWorktree: Record<string, Tab[]>
+): readonly StructuredTab[] {
+  const cached = structuredTabsByUnifiedTabsSnapshot.get(unifiedTabsByWorktree)
+  if (cached) {
+    return cached
+  }
+
+  const tabs: StructuredTab[] = []
+  for (const worktreeTabs of Object.values(unifiedTabsByWorktree)) {
+    for (const tab of worktreeTabs) {
+      if (isStructuredTab(tab)) {
+        tabs.push(tab)
+      }
+    }
+  }
+  structuredTabsByUnifiedTabsSnapshot.set(unifiedTabsByWorktree, tabs)
+  return tabs
+}
+
 function latestPrompt(state: StructuredAgentSessionState): string {
   for (let index = state.items.length - 1; index >= 0; index -= 1) {
     const body = state.items[index]?.body
@@ -99,15 +129,7 @@ function StructuredAgentSessionStatusProjection({ tab }: { tab: StructuredTab })
 
 export function StructuredAgentSessionStatusBridge(): React.JSX.Element {
   const tabs = useAppStore(
-    useShallow((state) =>
-      Object.values(state.unifiedTabsByWorktree)
-        .flat()
-        .filter(
-          (tab): tab is StructuredTab =>
-            tab.contentType === 'agent-session' &&
-            isAgentSessionHandleProvider(tab.agentSessionAgent)
-        )
-    )
+    useShallow((state) => getStructuredAgentSessionTabs(state.unifiedTabsByWorktree))
   )
   return (
     <>


### PR DESCRIPTION
## Summary
- cache the structured-agent-session tab projection by immutable unified-tab map identity
- keep the existing shallow subscription so unrelated store writes stay O(1)

## Verification
- `pnpm test src/renderer/src/components/native-chat/StructuredAgentSessionStatusBridge.test.tsx`
- `pnpm run check:code-quality:changed`
- `pnpm tc:web`

This removes repeated flatten/filter scans from an always-mounted bridge without changing the projected tab set.


## ELI5

The always-mounted status bridge repeatedly flattened every workspace's tabs just to keep the agent-session list current. It now remembers the list for the same immutable tab snapshot and recomputes only when that snapshot changes.

## Performance Measurement

Reproducible fixture: call `getStructuredAgentSessionTabs` 1,000 times with a stable map containing 64 worktrees × 16 tabs (1,024 tabs), then change the map identity once. Before the cache, each call scanned all 1,024 tabs and allocated a result array: 1,024,000 predicate visits and 1,000 projection arrays. After the cache, the stable snapshot scans once: 1,024 visits and 1 projection array, a 99.9% reduction in repeated scan work and allocations. The focused test verifies stable result identity and recomputation for a new map identity.

## User-Facing Trade-offs

None. The projected tab set, ordering, filtering, and subscription behavior are unchanged; cache entries are weakly keyed by the immutable store map.
