### PR TITLE
perf: index structured TUI process ownership lookups

### DIFF
--- a/src/main/runtime/structured-tui-process-identity.test.ts
+++ b/src/main/runtime/structured-tui-process-identity.test.ts
@@ -1,7 +1,54 @@
 import { describe, expect, it, vi } from 'vitest'
-import { readStructuredTuiProcessIdentity } from './structured-tui-process-identity'
+import {
+  readStructuredTuiProcessIdentity,
+  resolveStructuredTuiChildPid
+} from './structured-tui-process-identity'
 
 describe('structured TUI process identity', () => {
+  it('keeps the first row when a process snapshot contains duplicate PIDs', () => {
+    const child = {
+      pid: 101,
+      ppid: 100,
+      command: 'codex resume first',
+      foreground: true
+    }
+    const duplicate = { ...child, command: 'codex resume duplicate' }
+
+    expect(
+      resolveStructuredTuiChildPid(
+        [{ pid: 100, ppid: 1, command: '/bin/zsh', foreground: false }, child, duplicate],
+        100,
+        'codex'
+      )
+    ).toBe(101)
+  })
+
+  it('indexes process rows once instead of rescanning for every descendant', () => {
+    const rowCount = 64
+    let pidReads = 0
+    const rows = Array.from({ length: rowCount }, (_, index) => {
+      const pid = 100 + index
+      const row = {
+        pid,
+        ppid: index === 0 ? 1 : pid - 1,
+        command: index === 0 ? '/bin/zsh' : `codex resume ${index}`,
+        foreground: index > 0
+      }
+      Object.defineProperty(row, 'pid', {
+        configurable: true,
+        get: () => {
+          pidReads += 1
+          return pid
+        }
+      })
+      return row
+    })
+
+    expect(resolveStructuredTuiChildPid(rows, 100, 'codex')).toBe(101)
+    // The old per-descendant Array#find path performed quadratic PID reads on this chain.
+    expect(pidReads).toBeLessThan(rowCount * 8)
+  })
+
   it('binds the direct Codex child instead of the PTY shell pid', async () => {
     const readStartTime = vi.fn(async () => 1_700_000_000_000)
     await expect(

--- a/src/main/runtime/structured-tui-process-identity.ts
+++ b/src/main/runtime/structured-tui-process-identity.ts
@@ -18,8 +18,13 @@ const STRUCTURED_TUI_PROCESS_POLL_MS = 50
 
 function descendants(rows: ProcessRow[], rootPid: number): (ProcessRow & { depth: number })[] {
   const children = new Map<number, ProcessRow[]>()
+  const rowByPid = new Map<number, ProcessRow>()
   for (const row of rows) {
     children.set(row.ppid, [...(children.get(row.ppid) ?? []), row])
+    // Array#find below was first-match-wins for duplicate PIDs; retain that contract in the index.
+    if (!rowByPid.has(row.pid)) {
+      rowByPid.set(row.pid, row)
+    }
   }
   const found: (ProcessRow & { depth: number })[] = []
   const pending = [{ pid: rootPid, depth: 0 }]
@@ -30,7 +35,7 @@ function descendants(rows: ProcessRow[], rootPid: number): (ProcessRow & { depth
       continue
     }
     seen.add(current.pid)
-    const row = rows.find((candidate) => candidate.pid === current.pid)
+    const row = rowByPid.get(current.pid)
     if (row) {
       found.push({ ...row, depth: current.depth })
     }


### PR DESCRIPTION
## ELI5

When Orca looked for the process that owns a structured terminal, it searched every process row again for each child PID. This change builds a PID lookup table once, so each PID is found directly.

## Performance Measurement

Reproducible fixture: `pnpm test src/main/runtime/structured-tui-process-identity.test.ts --run`

On a deterministic 64-row parent/child chain with PID getter instrumentation, the old path made 2,207 PID reads (including 2,080 linear `Array#find` comparisons); the indexed path made 255, an 88.4% reduction. Lookup work changes from O(N²) to O(N) per snapshot.

## User-Facing Trade-offs

None. Process ownership semantics, duplicate-PID first-match behavior, SSH/Windows paths, and UI are unchanged.

