### PR TITLE
perf(browser): group client-hosted row publication

### DIFF
--- a/src/main/runtime/client-hosted-browser-row-publication.test.ts
+++ b/src/main/runtime/client-hosted-browser-row-publication.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { ClientHostedBrowserRowsEvent } from '../../shared/client-hosted-browser-rows'
 import { ClientHostedBrowserRowPublisher } from './client-hosted-browser-row-publication'
 import { RuntimeBrowserPageRegistry } from './runtime-browser-page-registry'
@@ -29,17 +29,19 @@ function publishPage(
 function createPublisher(): {
   publisher: ClientHostedBrowserRowPublisher
   registry: RuntimeBrowserPageRegistry
+  listClientPages: ReturnType<typeof vi.fn>
   events: ClientHostedBrowserRowsEvent[]
   livePlacements: Set<string>
   detach(): void
   attach(): void
 } {
   const registry = new RuntimeBrowserPageRegistry()
+  const listClientPages = vi.fn((worktreeId?: string) => registry.listPages(worktreeId))
   const events: ClientHostedBrowserRowsEvent[] = []
   const livePlacements = new Set<string>()
   let attached = true
   const publisher = new ClientHostedBrowserRowPublisher({
-    listClientPages: (worktreeId) => registry.listPages(worktreeId),
+    listClientPages,
     hasLivePlacement: (browserPageId) => livePlacements.has(browserPageId),
     resolveDeviceName: () => 'Studio',
     getEmitter: () =>
@@ -52,6 +54,7 @@ function createPublisher(): {
   return {
     publisher,
     registry,
+    listClientPages,
     events,
     livePlacements,
     detach: () => {
@@ -156,6 +159,32 @@ describe('ClientHostedBrowserRowPublisher', () => {
     publisher.publishAll()
 
     expect(events.map((event) => event.worktreeId).sort()).toEqual(['wt-1', 'wt-2'])
+  })
+
+  // Why: the bare announcement used to scan the registry once per workspace after its initial
+  // inventory (65 calls for 64 workspaces); grouping that inventory keeps the refresh to one scan.
+  it('scans the registry once when publishing all workspaces', () => {
+    const { publisher, registry, events, livePlacements, listClientPages } = createPublisher()
+    const worktreeIds = Array.from({ length: 64 }, (_, index) => `wt-${index}`)
+    for (const [index, worktreeId] of worktreeIds.entries()) {
+      const browserPageId = `page-${index}`
+      publishPage(registry, browserPageId, worktreeId)
+      livePlacements.add(browserPageId)
+    }
+
+    publisher.publishAll()
+
+    expect(listClientPages).toHaveBeenCalledTimes(1)
+    expect(listClientPages).toHaveBeenCalledWith()
+    expect(events.map((event) => event.worktreeId)).toEqual(worktreeIds)
+    expect(events).toHaveLength(worktreeIds.length)
+    for (const [index, event] of events.entries()) {
+      expect(event.rows).toHaveLength(1)
+      expect(event.rows[0]).toMatchObject({
+        browserPageId: `page-${index}`,
+        worktreeId: worktreeIds[index]
+      })
+    }
   })
 
   // Why: a bare republish must still be able to retract rows the renderer is still showing.

--- a/src/main/runtime/client-hosted-browser-row-publication.ts
+++ b/src/main/runtime/client-hosted-browser-row-publication.ts
@@ -27,7 +27,15 @@ export class ClientHostedBrowserRowPublisher {
     if (!emit) {
       return
     }
-    const rows = this.buildRows(this.host.listClientPages(worktreeId))
+    this.publishPages(worktreeId, this.host.listClientPages(worktreeId), emit)
+  }
+
+  private publishPages(
+    worktreeId: string,
+    pages: readonly RuntimeBrowserClientPage[],
+    emit: (event: ClientHostedBrowserRowsEvent) => void
+  ): void {
+    const rows = this.buildRows(pages)
     // Why: the announcement this rides on also fires on terminal and editor churn, so most calls
     // concern a workspace that has never had a client page. Only speak up when something changed.
     if (rows.length === 0 && !this.publishedWorktreeIds.has(worktreeId)) {
@@ -42,11 +50,20 @@ export class ClientHostedBrowserRowPublisher {
   }
 
   publishAll(): void {
-    for (const worktreeId of new Set([
-      ...this.publishedWorktreeIds,
-      ...this.host.listClientPages().map((page) => page.workspaceId)
-    ])) {
-      this.publish(worktreeId)
+    const pagesByWorktreeId = new Map<string, RuntimeBrowserClientPage[]>()
+    for (const page of this.host.listClientPages()) {
+      const pages = pagesByWorktreeId.get(page.workspaceId)
+      if (pages) {
+        pages.push(page)
+      } else {
+        pagesByWorktreeId.set(page.workspaceId, [page])
+      }
+    }
+    for (const worktreeId of new Set([...this.publishedWorktreeIds, ...pagesByWorktreeId.keys()])) {
+      const emit = this.host.getEmitter()
+      if (emit) {
+        this.publishPages(worktreeId, pagesByWorktreeId.get(worktreeId) ?? [], emit)
+      }
     }
   }
 


### PR DESCRIPTION
## ELI5

A bare browser-row refresh used to scan the full page registry once for every workspace. It now scans once, groups pages in memory, and publishes each workspace from its bucket.

## Performance Measurement

Before: one unscoped `listClientPages()` call plus one scoped call per workspace (65 calls for 64 workspaces).

After: one unscoped call, followed by in-memory grouping.

Improvement: **98.5% fewer registry scans** in the 64-workspace fixture (65 → 1). The deterministic regression creates 64 workspaces, asserts exactly one registry call, preserves workspace order, and verifies each event owns its matching page row. The row projection intentionally ignores `active`, so the active-row contract is unchanged.

Verification:
- `pnpm test src/main/runtime/client-hosted-browser-row-publication.test.ts`
- `pnpm test src/main/runtime/client-hosted-browser-row-publication.test.ts src/main/runtime/client-hosted-browser-row-push.integration.test.ts`
- `pnpm tc:node`
- `pnpm exec oxlint src/main/runtime/client-hosted-browser-row-publication.ts src/main/runtime/client-hosted-browser-row-publication.test.ts`
- `pnpm exec oxfmt --check src/main/runtime/client-hosted-browser-row-publication.ts src/main/runtime/client-hosted-browser-row-publication.test.ts`

## User-Facing Trade-offs

None.

