### PR TITLE
perf(renderer): cache active terminal chrome projection

### DIFF
--- a/src/renderer/src/store/active-terminal-chrome-selector.test.ts
+++ b/src/renderer/src/store/active-terminal-chrome-selector.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import {
+  resetActiveTerminalChromeStateSelectorCacheForTest,
+  selectActiveTerminalChromeState
+} from './active-terminal-chrome-selector'
+
+function terminalTab(id: string, worktreeId = 'wt-1'): TerminalTab {
+  return {
+    id,
+    ptyId: null,
+    worktreeId,
+    title: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+describe('selectActiveTerminalChromeState', () => {
+  beforeEach(() => {
+    resetActiveTerminalChromeStateSelectorCacheForTest()
+  })
+
+  it('reuses the projection for stable inputs across selector fanout', () => {
+    const tabs = [terminalTab('tab-1')]
+    const state = {
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'tab-1',
+      tabsByWorktree: { 'wt-1': tabs },
+      canExpandPaneByTabId: { 'tab-1': true },
+      expandedPaneByTabId: { 'tab-1': false }
+    } satisfies Parameters<typeof selectActiveTerminalChromeState>[0]
+
+    const first = selectActiveTerminalChromeState(state)
+    let distinctResults = 0
+    let previous = first
+    const iterations = 100_000
+    for (let index = 0; index < iterations; index += 1) {
+      const selected = selectActiveTerminalChromeState(state)
+      if (selected !== previous) {
+        distinctResults += 1
+      }
+      previous = selected
+    }
+
+    expect(distinctResults).toBe(0)
+    expect(previous).toBe(first)
+  })
+
+  it('reuses equivalent replacement inputs and invalidates visible scalar changes', () => {
+    const tabs = [terminalTab('tab-1')]
+    const state = {
+      activeWorktreeId: 'wt-1',
+      activeTabId: null,
+      tabsByWorktree: { 'wt-1': tabs },
+      canExpandPaneByTabId: { 'tab-1': false },
+      expandedPaneByTabId: { 'tab-1': false }
+    } satisfies Parameters<typeof selectActiveTerminalChromeState>[0]
+
+    const first = selectActiveTerminalChromeState(state)
+    const equivalentReplacement = selectActiveTerminalChromeState({
+      ...state,
+      tabsByWorktree: { 'wt-1': tabs.map((tab) => ({ ...tab, title: 'new title' })) },
+      canExpandPaneByTabId: { 'tab-1': false },
+      expandedPaneByTabId: { 'tab-1': false }
+    })
+    expect(equivalentReplacement).toBe(first)
+
+    const afterActiveTabId = selectActiveTerminalChromeState({
+      ...state,
+      activeTabId: 'tab-1'
+    })
+    expect(afterActiveTabId).not.toBe(first)
+
+    const afterActiveWorktreeId = selectActiveTerminalChromeState({
+      ...state,
+      activeWorktreeId: 'wt-2',
+      tabsByWorktree: { 'wt-2': tabs }
+    })
+    expect(afterActiveWorktreeId).not.toBe(afterActiveTabId)
+
+    const afterEffectiveActiveTabId = selectActiveTerminalChromeState({
+      ...state,
+      tabsByWorktree: { 'wt-1': [terminalTab('tab-2')] }
+    })
+    expect(afterEffectiveActiveTabId).not.toBe(afterActiveWorktreeId)
+    expect(afterEffectiveActiveTabId.effectiveActiveTabId).toBe('tab-2')
+
+    const afterCanExpand = selectActiveTerminalChromeState({
+      ...state,
+      canExpandPaneByTabId: { 'tab-1': true }
+    })
+    expect(afterCanExpand).not.toBe(afterEffectiveActiveTabId)
+    expect(afterCanExpand.activeTabCanExpand).toBe(true)
+
+    const afterExpanded = selectActiveTerminalChromeState({
+      ...state,
+      canExpandPaneByTabId: { 'tab-1': true },
+      expandedPaneByTabId: { 'tab-1': true }
+    })
+    expect(afterExpanded).not.toBe(afterCanExpand)
+    expect(afterExpanded.effectiveActiveTabExpanded).toBe(true)
+
+    const afterTabCount = selectActiveTerminalChromeState({
+      ...state,
+      tabsByWorktree: {
+        'wt-1': [...tabs, terminalTab('tab-2')]
+      }
+    })
+    expect(afterTabCount).not.toBe(afterExpanded)
+    expect(afterTabCount.tabCount).toBe(2)
+  })
+})

--- a/src/renderer/src/store/active-terminal-chrome-selector.ts
+++ b/src/renderer/src/store/active-terminal-chrome-selector.ts
@@ -20,6 +20,9 @@ export type ActiveTerminalChromeState = {
 
 const EMPTY_TABS: NonNullable<AppState['tabsByWorktree'][string]> = []
 
+// Why: every Zustand write reruns this app-shell selector, including title-only tab updates.
+let activeTerminalChromeCache: ActiveTerminalChromeState | null = null
+
 export function selectActiveTerminalChromeState(
   state: ActiveTerminalChromeSelectorState
 ): ActiveTerminalChromeState {
@@ -27,16 +30,37 @@ export function selectActiveTerminalChromeState(
     ? (state.tabsByWorktree[state.activeWorktreeId] ?? EMPTY_TABS)
     : EMPTY_TABS
   const effectiveActiveTabId = state.activeTabId ?? tabs[0]?.id ?? null
-  return {
+  const activeTabCanExpand = effectiveActiveTabId
+    ? (state.canExpandPaneByTabId[effectiveActiveTabId] ?? false)
+    : false
+  const effectiveActiveTabExpanded = effectiveActiveTabId
+    ? (state.expandedPaneByTabId[effectiveActiveTabId] ?? false)
+    : false
+  const cached = activeTerminalChromeCache
+  if (
+    cached &&
+    cached.activeWorktreeId === state.activeWorktreeId &&
+    cached.activeTabId === state.activeTabId &&
+    cached.tabCount === tabs.length &&
+    cached.effectiveActiveTabId === effectiveActiveTabId &&
+    cached.activeTabCanExpand === activeTabCanExpand &&
+    cached.effectiveActiveTabExpanded === effectiveActiveTabExpanded
+  ) {
+    return cached
+  }
+
+  const selected: ActiveTerminalChromeState = {
     activeWorktreeId: state.activeWorktreeId,
     activeTabId: state.activeTabId,
     tabCount: tabs.length,
     effectiveActiveTabId,
-    activeTabCanExpand: effectiveActiveTabId
-      ? (state.canExpandPaneByTabId[effectiveActiveTabId] ?? false)
-      : false,
-    effectiveActiveTabExpanded: effectiveActiveTabId
-      ? (state.expandedPaneByTabId[effectiveActiveTabId] ?? false)
-      : false
+    activeTabCanExpand,
+    effectiveActiveTabExpanded
   }
+  activeTerminalChromeCache = selected
+  return selected
+}
+
+export function resetActiveTerminalChromeStateSelectorCacheForTest(): void {
+  activeTerminalChromeCache = null
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

## ELI5

The app shell asks the active-terminal chrome selector for the same six values on every store update. The selector used to build a new answer object every time, even when the visible tab and layout values had not changed. It now reuses the previous answer whenever those six scalar values are unchanged.

## What Changed

- Cache the active-terminal chrome projection by its six scalar output values.
- Reuse the cached object across unrelated writes and title-only tab replacements.
- Invalidate automatically when active IDs, tab count, effective tab ID, or either expand flag changes.
- Add deterministic 100,000-read identity and invalidation coverage.

## Why

`selectActiveTerminalChromeState` is passed through `useShallow` by the always-mounted app shell. Zustand reruns it for every store write, so repeated object allocation was unnecessary work on terminal/status update paths. The projection contains only scalar values, making value-keyed reuse behavior-neutral even when surrounding records are replaced.

## Performance Measurement

Reproducible fixture: `pnpm test src/renderer/src/store/active-terminal-chrome-selector.test.ts`; it runs 100,000 calls against a stable one-tab state and counts result identity changes.

- Before: **100,000 / 100,000** calls returned a newly allocated result object.
- After: **0 / 100,000** calls changed result identity.
- Improvement: **100% fewer projection allocations** in the repeated-read case (100,000 → 0).

## User-Facing Trade-offs

None. The selector fields and fallback behavior are unchanged; only equivalent scalar projections share an object identity.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

N/A — no UI layout or interaction behavior changed.

## Testing

- [x] Active-terminal selector + related selector suites (22 passed)
- [x] `pnpm tc:web`
- [x] Focused `oxlint`
- [x] Focused `oxfmt --check`
- [x] `git diff --check`

## Review

Checked active-worktree/tab fallback selection, tab-count and effective-tab derivation, expand-state flags, title-only replacement arrays, and unrelated store-write behavior. No IPC, SSH, folder-workspace, or remote-wire changes.

## Agent skill upstream boundary

- [x] Not applicable.

