### PR TITLE
feat(source-control): Adds worktree selection to the git view

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.branch-line-total.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.branch-line-total.test.tsx
@@ -65,6 +65,10 @@ vi.mock('@/store/selectors', () => ({
   useActiveWorktree: () => mocks.activeWorktree,
   useRepoById: (repoId: string | null) =>
     repoId === mocks.activeRepo.id ? mocks.activeRepo : null,
+  useWorktreeById: (worktreeId: string | null) =>
+    worktreeId === mocks.activeWorktree.id ? mocks.activeWorktree : null,
+  useWorktreesForRepo: (repoId: string | null) =>
+    repoId === mocks.activeRepo.id ? [mocks.activeWorktree] : [],
   useWorktreeMap: () => new Map([[mocks.activeWorktree.id, mocks.activeWorktree]])
 }))
 

--- a/src/renderer/src/components/right-sidebar/SourceControl.open-file-highlight.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.open-file-highlight.test.tsx
@@ -58,6 +58,10 @@ vi.mock('@/store/selectors', () => ({
   useActiveWorktree: () => mocks.activeWorktree,
   useRepoById: (repoId: string | null) =>
     repoId === mocks.activeRepo.id ? mocks.activeRepo : null,
+  useWorktreeById: (worktreeId: string | null) =>
+    worktreeId === mocks.activeWorktree.id ? mocks.activeWorktree : null,
+  useWorktreesForRepo: (repoId: string | null) =>
+    repoId === mocks.activeRepo.id ? [mocks.activeWorktree] : [],
   useWorktreeMap: () => new Map([[mocks.activeWorktree.id, mocks.activeWorktree]])
 }))
 

--- a/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
@@ -75,6 +75,10 @@ vi.mock('@/store/selectors', () => ({
   useActiveWorktree: () => mocks.activeWorktree,
   useRepoById: (repoId: string | null) =>
     repoId === mocks.activeRepo.id ? mocks.activeRepo : null,
+  useWorktreeById: (worktreeId: string | null) =>
+    worktreeId === mocks.activeWorktree.id ? mocks.activeWorktree : null,
+  useWorktreesForRepo: (repoId: string | null) =>
+    repoId === mocks.activeRepo.id ? [mocks.activeWorktree] : [],
   useWorktreeMap: () => new Map([[mocks.activeWorktree.id, mocks.activeWorktree]])
 }))
 

--- a/src/renderer/src/components/right-sidebar/SourceControl.virtual-file-list.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.virtual-file-list.test.tsx
@@ -63,6 +63,10 @@ vi.mock('@/store/selectors', () => ({
   useActiveWorktree: () => mocks.activeWorktree,
   useRepoById: (repoId: string | null) =>
     repoId === mocks.activeRepo.id ? mocks.activeRepo : null,
+  useWorktreeById: (worktreeId: string | null) =>
+    worktreeId === mocks.activeWorktree.id ? mocks.activeWorktree : null,
+  useWorktreesForRepo: (repoId: string | null) =>
+    repoId === mocks.activeRepo.id ? [mocks.activeWorktree] : [],
   useWorktreeMap: () => new Map([[mocks.activeWorktree.id, mocks.activeWorktree]])
 }))
 

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-action-context.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-action-context.ts
@@ -16,6 +16,7 @@ export type DropdownActionContext = {
   conflictOperation: GitConflictOperation
   isPullRequestOperationActive: boolean
   canPushLinkedReviewWithoutUpstream: boolean
+  isSubjectLinkedWorktree: boolean
   rebaseBaseRef: string | null | undefined
   hasDirtyLocalChanges: boolean
   upstreamLoading: boolean
@@ -54,7 +55,8 @@ export function deriveDropdownActionContext(inputs: DropdownActionInputs): Dropd
     hasCurrentBranch = true,
     canPushLinkedReviewWithoutUpstream = false,
     rebaseBaseRef,
-    isPullRequestOperationActive = false
+    isPullRequestOperationActive = false,
+    isSubjectLinkedWorktree = false
   } = inputs
 
   const hasStaged = stagedCount > 0
@@ -116,6 +118,7 @@ export function deriveDropdownActionContext(inputs: DropdownActionInputs): Dropd
     conflictOperation,
     isPullRequestOperationActive,
     canPushLinkedReviewWithoutUpstream,
+    isSubjectLinkedWorktree,
     rebaseBaseRef,
     hasDirtyLocalChanges,
     upstreamLoading,

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-commit-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-commit-items.ts
@@ -22,6 +22,7 @@ export function buildCommitDropdownItems(ctx: DropdownActionContext): CommitDrop
     publishBlockedByMergedPR,
     publishBlockedByPRLoading,
     publishBlockedByDetachedHead,
+    ahead,
     behind,
     shouldForcePushWithLease,
     commitDisabledReason,
@@ -52,12 +53,14 @@ export function buildCommitDropdownItems(ctx: DropdownActionContext): CommitDrop
             ? 'Linked review branch target is unavailable'
             : !hasUpstream && !(hasOpenHostedReview && canPushLinkedReviewWithoutUpstream)
               ? 'Publish the branch first to push commits'
-              : (commitDisabledReason ??
-                (shouldForcePushWithLease
-                  ? 'Commit staged changes and force push with lease'
-                  : behind > 0
-                    ? 'Commit staged changes and try to push'
-                    : 'Commit staged changes and push'))
+              : isSubjectLinkedWorktree && behind > 0 && ahead > 0 && !shouldForcePushWithLease
+                ? 'Diverged from remote. Push is not available on a linked worktree — reconcile on the main checkout.'
+                : (commitDisabledReason ??
+                  (shouldForcePushWithLease
+                    ? 'Commit staged changes and force push with lease'
+                    : behind > 0
+                      ? 'Commit staged changes and try to push'
+                      : 'Commit staged changes and push'))
   const commitPush: DropdownItem = {
     kind: 'commit_push',
     label: shouldForcePushWithLease ? 'Commit & Force Push' : 'Commit & Push',
@@ -70,6 +73,7 @@ export function buildCommitDropdownItems(ctx: DropdownActionContext): CommitDrop
       publishBlockedByDetachedHead ||
       publishBlockedByPRLoading ||
       publishBlockedByMergedPR ||
+      (isSubjectLinkedWorktree && behind > 0 && ahead > 0 && !shouldForcePushWithLease) ||
       commitDisabledReason !== null
   }
 

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-commit-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-commit-items.ts
@@ -25,7 +25,8 @@ export function buildCommitDropdownItems(ctx: DropdownActionContext): CommitDrop
     behind,
     shouldForcePushWithLease,
     commitDisabledReason,
-    canCommit
+    canCommit,
+    isSubjectLinkedWorktree
   } = ctx
 
   const commit: DropdownItem = {
@@ -85,6 +86,10 @@ export function buildCommitDropdownItems(ctx: DropdownActionContext): CommitDrop
     if (publishBlockedByDetachedHead) {
       return 'Check out a branch before syncing commits'
     }
+    if (isSubjectLinkedWorktree) {
+      // Why: Commit & Sync pulls after the commit, which is disallowed on a linked worktree.
+      return 'Sync is not available on a linked worktree'
+    }
     if (!hasUpstream) {
       // Why: direct the user to Publish Branch (the primary action) rather than naming a nonexistent compound action.
       return 'Publish the branch first to sync commits'
@@ -110,6 +115,7 @@ export function buildCommitDropdownItems(ctx: DropdownActionContext): CommitDrop
       !hasUpstream ||
       publishBlockedByDetachedHead ||
       shouldForcePushWithLease ||
+      isSubjectLinkedWorktree ||
       commitDisabledReason !== null
   }
 

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -162,6 +162,30 @@ describe('resolveDropdownItems', () => {
     expect(byKind.commit_sync.disabled).toBe(false)
   })
 
+  it('disables push on a diverged linked worktree without patch-equivalence', () => {
+    const items = resolveDropdownItems(
+      inputs({
+        stagedCount: 1,
+        hasMessage: true,
+        upstreamStatus: { hasUpstream: true, ahead: 2, behind: 3 },
+        isSubjectLinkedWorktree: true
+      })
+    )
+    const byKind = Object.fromEntries(
+      items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+
+    expect(byKind.push.disabled).toBe(true)
+    expect(byKind.push.title).toBe(
+      'Diverged from remote. Push is not available on a linked worktree — reconcile on the main checkout.'
+    )
+    expect(byKind.commit_push.disabled).toBe(true)
+    expect(byKind.commit_push.title).toBe(
+      'Diverged from remote. Push is not available on a linked worktree — reconcile on the main checkout.'
+    )
+    expect(byKind.force_push.disabled).toBe(false)
+  })
+
   it('offers force-push-with-lease when remote-only commits are patch-equivalent', () => {
     const items = resolveDropdownItems(
       inputs({
@@ -664,7 +688,9 @@ describe('resolveDropdownItems', () => {
   it('disables pull, fast-forward, and sync on a linked worktree while keeping push enabled', () => {
     const items = resolveDropdownItems(
       inputs({
-        upstreamStatus: { hasUpstream: true, ahead: 2, behind: 3 },
+        // Why: ahead-only (behind 0) so push is a fast-forward and stays available; a diverged
+        // linked worktree (ahead>0 && behind>0) is covered by the dedicated gating test above.
+        upstreamStatus: { hasUpstream: true, ahead: 2, behind: 0 },
         isSubjectLinkedWorktree: true
       })
     )

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -660,6 +660,44 @@ describe('resolveDropdownItems', () => {
       'Try a fast-forward pull; git may reject local commits'
     )
   })
+
+  it('disables pull, fast-forward, and sync on a linked worktree while keeping push enabled', () => {
+    const items = resolveDropdownItems(
+      inputs({
+        upstreamStatus: { hasUpstream: true, ahead: 2, behind: 3 },
+        isSubjectLinkedWorktree: true
+      })
+    )
+    const byKind = Object.fromEntries(
+      items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+    expect(byKind.pull.disabled).toBe(true)
+    expect(byKind.pull.title).toBe('Pull is not available on a linked worktree')
+    expect(byKind.fast_forward.disabled).toBe(true)
+    expect(byKind.fast_forward.title).toBe('Fast-forward is not available on a linked worktree')
+    expect(byKind.sync.disabled).toBe(true)
+    expect(byKind.sync.title).toBe('Sync is not available on a linked worktree')
+    // Why: push stays available on a worktree so the branch can be published.
+    expect(byKind.push.disabled).toBe(false)
+    expect(byKind.force_push.disabled).toBe(false)
+    expect(byKind.fetch.disabled).toBe(false)
+  })
+
+  it('keeps Publish Branch available on a linked worktree with no upstream', () => {
+    const items = resolveDropdownItems(
+      inputs({
+        upstreamStatus: { hasUpstream: false, ahead: 0, behind: 0 },
+        isSubjectLinkedWorktree: true
+      })
+    )
+    const byKind = Object.fromEntries(
+      items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+    expect(byKind.publish.disabled).toBe(false)
+    expect(byKind.publish.title).toBe('Publish this branch to origin')
+    expect(byKind.push.disabled).toBe(false)
+    expect(byKind.fetch.disabled).toBe(false)
+  })
 })
 
 // Why: PR #8196 — drive the real push-target resolution the component uses so

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-remote-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-remote-items.ts
@@ -66,13 +66,19 @@ export function buildRemoteDropdownItems(ctx: DropdownActionContext): RemoteDrop
               ? 'Push this branch and set an upstream if needed'
               : shouldForcePushWithLease
                 ? 'Try a regular push; git may require force push'
-                : behind > 0 && ahead > 0
-                  ? 'Push local commits; git may require syncing first'
-                  : ahead === 0
-                    ? `Nothing to push${upstreamStatus?.upstreamName ? ` to ${upstreamStatus.upstreamName}` : ''}`
-                    : describePushCount(ahead),
-    // Why: Push stays available without an upstream (git resolves --set-upstream) and under force-with-lease; only detached HEAD and unknown review targets block.
-    disabled: globalBusy || publishBlockedByDetachedHead || pushBlockedByOpenHostedReviewTarget
+                : isSubjectLinkedWorktree && behind > 0 && ahead > 0
+                  ? 'Diverged from remote. Push is not available on a linked worktree — reconcile on the main checkout.'
+                  : behind > 0 && ahead > 0
+                    ? 'Push local commits; git may require syncing first'
+                    : ahead === 0
+                      ? `Nothing to push${upstreamStatus?.upstreamName ? ` to ${upstreamStatus.upstreamName}` : ''}`
+                      : describePushCount(ahead),
+    // Why: Push stays available without an upstream (git resolves --set-upstream) and under force-with-lease; only detached HEAD, unknown review targets, and a diverged linked worktree (a plain push would be rejected as non-fast-forward) block.
+    disabled:
+      globalBusy ||
+      publishBlockedByDetachedHead ||
+      pushBlockedByOpenHostedReviewTarget ||
+      (isSubjectLinkedWorktree && behind > 0 && ahead > 0 && !shouldForcePushWithLease)
   }
 
   const forcePush: DropdownItem = {

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-remote-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-remote-items.ts
@@ -47,7 +47,8 @@ export function buildRemoteDropdownItems(ctx: DropdownActionContext): RemoteDrop
     behind,
     shouldForcePushWithLease,
     pushLabelCount,
-    forcePushTitle
+    forcePushTitle,
+    isSubjectLinkedWorktree
   } = ctx
 
   const push: DropdownItem = {
@@ -105,14 +106,21 @@ export function buildRemoteDropdownItems(ctx: DropdownActionContext): RemoteDrop
           ? 'PR is already merged'
           : publishBlockedByDetachedHead
             ? 'Check out a branch before pulling commits'
-            : !hasUpstream
-              ? 'Publish the branch first to pull commits'
-              : shouldForcePushWithLease
-                ? 'Nothing new to pull — remote only has older copies of local commits'
-                : behind === 0
-                  ? 'Nothing to pull'
-                  : describePullCount(behind),
-    disabled: globalBusy || upstreamLoading || !hasUpstream || publishBlockedByDetachedHead
+            : isSubjectLinkedWorktree
+              ? 'Pull is not available on a linked worktree'
+              : !hasUpstream
+                ? 'Publish the branch first to pull commits'
+                : shouldForcePushWithLease
+                  ? 'Nothing new to pull — remote only has older copies of local commits'
+                  : behind === 0
+                    ? 'Nothing to pull'
+                    : describePullCount(behind),
+    disabled:
+      globalBusy ||
+      upstreamLoading ||
+      !hasUpstream ||
+      publishBlockedByDetachedHead ||
+      isSubjectLinkedWorktree
   }
 
   const fastForward: DropdownItem = {
@@ -126,16 +134,23 @@ export function buildRemoteDropdownItems(ctx: DropdownActionContext): RemoteDrop
           ? 'PR is already merged'
           : publishBlockedByDetachedHead
             ? 'Check out a branch before fast-forwarding'
-            : !hasUpstream
-              ? 'Publish the branch first to fast-forward'
-              : shouldForcePushWithLease
-                ? 'Nothing new to fast-forward — remote only has older copies of local commits'
-                : behind === 0
-                  ? 'Nothing to fast-forward'
-                  : ahead > 0
-                    ? 'Try a fast-forward pull; git may reject local commits'
-                    : describeFastForwardCount(behind),
-    disabled: globalBusy || upstreamLoading || !hasUpstream || publishBlockedByDetachedHead
+            : isSubjectLinkedWorktree
+              ? 'Fast-forward is not available on a linked worktree'
+              : !hasUpstream
+                ? 'Publish the branch first to fast-forward'
+                : shouldForcePushWithLease
+                  ? 'Nothing new to fast-forward — remote only has older copies of local commits'
+                  : behind === 0
+                    ? 'Nothing to fast-forward'
+                    : ahead > 0
+                      ? 'Try a fast-forward pull; git may reject local commits'
+                      : describeFastForwardCount(behind),
+    disabled:
+      globalBusy ||
+      upstreamLoading ||
+      !hasUpstream ||
+      publishBlockedByDetachedHead ||
+      isSubjectLinkedWorktree
   }
 
   const sync: DropdownItem = {
@@ -149,19 +164,22 @@ export function buildRemoteDropdownItems(ctx: DropdownActionContext): RemoteDrop
           ? 'PR is already merged'
           : publishBlockedByDetachedHead
             ? 'Check out a branch before syncing commits'
-            : !hasUpstream
-              ? 'Publish the branch first to sync commits'
-              : shouldForcePushWithLease
-                ? 'Use Force Push — remote only has older copies of local commits'
-                : ahead === 0 && behind === 0
-                  ? 'Branch is up to date'
-                  : describeSyncCounts(ahead, behind),
+            : isSubjectLinkedWorktree
+              ? 'Sync is not available on a linked worktree'
+              : !hasUpstream
+                ? 'Publish the branch first to sync commits'
+                : shouldForcePushWithLease
+                  ? 'Use Force Push — remote only has older copies of local commits'
+                  : ahead === 0 && behind === 0
+                    ? 'Branch is up to date'
+                    : describeSyncCounts(ahead, behind),
     disabled:
       globalBusy ||
       upstreamLoading ||
       !hasUpstream ||
       publishBlockedByDetachedHead ||
-      shouldForcePushWithLease
+      shouldForcePushWithLease ||
+      isSubjectLinkedWorktree
   }
 
   const rebaseBaseLabel = rebaseBaseRef ? formatRebaseBaseRef(rebaseBaseRef) : null

--- a/src/renderer/src/components/right-sidebar/source-control-header-toolbar-identity.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-header-toolbar-identity.test.tsx
@@ -51,6 +51,10 @@ function renderToolbar(options?: {
       filterExpanded={false}
       onFilterQueryChange={vi.fn()}
       onFilterExpandedChange={vi.fn()}
+      worktreeList={[]}
+      selectedWorktreeId={null}
+      appActiveWorktreeId={null}
+      onSelectWorktree={vi.fn()}
       visibleCreatePrHeaderAction={
         options?.visibleCreatePrHeaderAction === undefined
           ? CREATE_PR_ACTION

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action-types.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action-types.ts
@@ -62,4 +62,7 @@ export type PrimaryActionInputs = {
   // Why: eligibility is fetched asynchronously; keep the header anchor visible
   // while the request is in flight instead of flashing it in after ~1s.
   isHostedReviewCreationLoading?: boolean
+  // True when the Source Control subject is a git linked worktree (not the main checkout).
+  // Push/publish stays available; pull/sync are not offered on a worktree.
+  isSubjectLinkedWorktree?: boolean
 }

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
@@ -247,6 +247,11 @@ function resolvePrimaryActionTitle(
         'auto.components.right.sidebar.source.control.primary.action.8f9a0b1c2d',
         'Nothing to commit. Branch is up to date.'
       )
+    case 'pull_unavailable_on_worktree':
+      return translate(
+        'auto.components.right.sidebar.source.control.primary.action.pull_unavailable_on_worktree',
+        'Pull is not available on a linked worktree.'
+      )
     case 'checking_review_creation':
       return translate(
         'auto.components.right.sidebar.source.control.primary.action.h3i4j5k607',

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
@@ -252,6 +252,11 @@ function resolvePrimaryActionTitle(
         'auto.components.right.sidebar.source.control.primary.action.pull_unavailable_on_worktree',
         'Pull is not available on a linked worktree.'
       )
+    case 'push_unavailable_on_worktree':
+      return translate(
+        'auto.components.right.sidebar.source.control.primary.action.push_unavailable_on_worktree',
+        'Diverged from remote. Push is not available on a linked worktree — reconcile on the main checkout.'
+      )
     case 'checking_review_creation':
       return translate(
         'auto.components.right.sidebar.source.control.primary.action.h3i4j5k607',

--- a/src/renderer/src/components/right-sidebar/source-control/listing/use-worktree-context.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/use-worktree-context.ts
@@ -5,7 +5,13 @@ import { getRepoOwnerRoutedSettings } from '@/lib/repo-runtime-owner'
 import { resolveSourceControlLaunchPlatform } from '@/lib/source-control-launch-platform'
 import { getWorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
 import { useAppStore } from '@/store'
-import { useActiveWorktree, useRepoById, useWorktreeMap } from '@/store/selectors'
+import {
+  useActiveWorktree,
+  useRepoById,
+  useWorktreeById,
+  useWorktreeMap,
+  useWorktreesForRepo
+} from '@/store/selectors'
 import { getGitHubPRCacheKey } from '@/store/slices/github-cache-key'
 import { getHostedReviewCacheKey } from '@/store/slices/hosted-review-cache-identity'
 import type { GitBranchChangeEntry } from '../../../../../../shared/git-diff-compare-types'
@@ -17,13 +23,23 @@ const EMPTY_GIT_STATUS_ENTRIES: GitStatusEntry[] = []
 const EMPTY_BRANCH_CHANGE_ENTRIES: GitBranchChangeEntry[] = []
 
 /**
- * Resolves the active worktree/repo and every store-backed value the Source Control panel reads
- * about it: git status, branch compare, conflict + upstream state, hosted-review cache entries and
- * the repo-owner-routed settings that every git call must be pinned to.
+ * Resolves the worktree/repo the Source Control panel is showing and every store-backed value it
+ * reads about it: git status, branch compare, conflict + upstream state, hosted-review cache
+ * entries and the repo-owner-routed settings that every git call must be pinned to.
+ *
+ * The subject is normally the app-active worktree; the panel can also pin it to another worktree
+ * of the same repo (the worktree picker) so its status/commits are inspected without switching the
+ * active workspace. A subject that disappears from the catalog falls back to the app-active
+ * worktree.
  */
-export function useSourceControlWorktreeContext() {
-  const activeWorktree = useActiveWorktree()
-  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+export function useSourceControlWorktreeContext(subjectWorktreeId?: string | null) {
+  const appActiveWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const appActiveWorktree = useActiveWorktree()
+  // Why: the subject can be any same-repo worktree; the app-active fallback keeps the panel alive
+  // when the picked worktree is removed or pruned.
+  const activeWorktree =
+    useWorktreeById(subjectWorktreeId ?? appActiveWorktreeId) ?? appActiveWorktree
+  const activeWorktreeId = activeWorktree?.id ?? appActiveWorktreeId
   const activeWorktreeInstanceId = activeWorktree?.instanceId
   const activeGroupId = useAppStore((s) =>
     activeWorktreeId ? s.activeGroupIdByWorktree[activeWorktreeId] : undefined
@@ -35,6 +51,7 @@ export function useSourceControlWorktreeContext() {
   const activeRepoPath = activeRepo?.path ?? null
   const activeRepoConnectionId = activeRepo?.connectionId ?? null
   const activeRepoExecutionHostId = activeRepo?.executionHostId ?? null
+  const worktreeList = useWorktreesForRepo(activeRepoId)
   const gitIdentityDisplay = activeWorktree ? getWorktreeGitIdentityDisplay(activeWorktree) : null
   const branchName = gitIdentityDisplay?.kind === 'branch' ? gitIdentityDisplay.branchName : ''
   const entries = useAppStore((s) =>
@@ -157,6 +174,7 @@ export function useSourceControlWorktreeContext() {
     activeWorktree,
     activeWorktreeId,
     activeWorktreeInstanceId,
+    appActiveWorktreeId,
     branchEntries,
     branchLineTotal,
     branchName,
@@ -177,6 +195,7 @@ export function useSourceControlWorktreeContext() {
     repositoryHuge,
     rightSidebarTab,
     settings,
+    worktreeList,
     worktreeMap,
     worktreePath
   }

--- a/src/renderer/src/components/right-sidebar/source-control/listing/use-worktree-context.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/use-worktree-context.ts
@@ -17,10 +17,12 @@ import { getHostedReviewCacheKey } from '@/store/slices/hosted-review-cache-iden
 import type { GitBranchChangeEntry } from '../../../../../../shared/git-diff-compare-types'
 import type { GitStatusEntry } from '../../../../../../shared/git-status-types'
 import { isFolderRepo } from '../../../../../../shared/repo-kind'
+import type { DetectedWorktree } from '../../../../../../shared/worktree/types'
 import { selectReviewCacheData, selectReviewCacheEntry } from '../../review-cache-entry-selection'
 
 const EMPTY_GIT_STATUS_ENTRIES: GitStatusEntry[] = []
 const EMPTY_BRANCH_CHANGE_ENTRIES: GitBranchChangeEntry[] = []
+const EMPTY_DETECTED_WORKTREES: DetectedWorktree[] = []
 
 /**
  * Resolves the worktree/repo the Source Control panel is showing and every store-backed value it
@@ -51,7 +53,26 @@ export function useSourceControlWorktreeContext(subjectWorktreeId?: string | nul
   const activeRepoPath = activeRepo?.path ?? null
   const activeRepoConnectionId = activeRepo?.connectionId ?? null
   const activeRepoExecutionHostId = activeRepo?.executionHostId ?? null
-  const worktreeList = useWorktreesForRepo(activeRepoId)
+  // Why: the picker lists every git worktree of the repo, including detected siblings that the
+  // sidebar visibility policy hides — status/commits can still be inspected for them.
+  const knownWorktrees = useWorktreesForRepo(activeRepoId)
+  const detectedWorktrees = useAppStore((s) =>
+    activeRepoId
+      ? (s.detectedWorktreesByRepo?.[activeRepoId]?.worktrees ?? EMPTY_DETECTED_WORKTREES)
+      : EMPTY_DETECTED_WORKTREES
+  )
+  const worktreeList = useMemo(() => {
+    if (detectedWorktrees.length === 0) {
+      return knownWorktrees
+    }
+    const byId = new Map(knownWorktrees.map((worktree) => [worktree.id, worktree]))
+    for (const worktree of detectedWorktrees) {
+      if (!byId.has(worktree.id)) {
+        byId.set(worktree.id, worktree)
+      }
+    }
+    return [...byId.values()]
+  }, [detectedWorktrees, knownWorktrees])
   const gitIdentityDisplay = activeWorktree ? getWorktreeGitIdentityDisplay(activeWorktree) : null
   const branchName = gitIdentityDisplay?.kind === 'branch' ? gitIdentityDisplay.branchName : ''
   const entries = useAppStore((s) =>

--- a/src/renderer/src/components/right-sidebar/source-control/panel/header-toolbar.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/header-toolbar.tsx
@@ -4,6 +4,7 @@ import type { GitBranchCompareSummary } from '../../../../../../shared/git-diff-
 import type { GitBranchLineTotal } from '../../../../../../shared/git-status-types'
 import type { SourceControlViewMode } from '../../../../../../shared/ui-chrome-types'
 import type { HostedReviewInfo } from '../../../../../../shared/hosted-review'
+import type { Worktree } from '../../../../../../shared/worktree/types'
 import type { PrimaryAction } from '../../source-control-primary-action'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -11,6 +12,7 @@ import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import type { WorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
 import { HostedReviewHeaderLink, HostedReviewIcon } from '../review/hosted-review-header-chrome'
+import { SourceControlWorktreePicker } from './worktree-picker'
 import { SourceControlBranchContextRow } from './branch-context-row'
 import { shouldShowSourceControlBranchContextChrome } from './branch-context-stats'
 import { SourceControlHeaderOverflowMenu } from './header-overflow-menu'
@@ -20,6 +22,10 @@ type SourceControlHeaderToolbarProps = {
   filterExpanded: boolean
   onFilterQueryChange: (value: string) => void
   onFilterExpandedChange: (expanded: boolean) => void
+  worktreeList: readonly Worktree[]
+  selectedWorktreeId: string | null
+  appActiveWorktreeId: string | null
+  onSelectWorktree: (worktreeId: string) => void
   visibleCreatePrHeaderAction: PrimaryAction | null
   hostedReview: HostedReviewInfo | null
   isCreatePrIntentInFlight: boolean
@@ -148,6 +154,10 @@ export function SourceControlHeaderToolbar({
   filterExpanded,
   onFilterQueryChange,
   onFilterExpandedChange,
+  worktreeList,
+  selectedWorktreeId,
+  appActiveWorktreeId,
+  onSelectWorktree,
   visibleCreatePrHeaderAction,
   hostedReview,
   isCreatePrIntentInFlight,
@@ -219,6 +229,14 @@ export function SourceControlHeaderToolbar({
       >
         {showCollapsedToolbar ? (
           <>
+            {worktreeList.length > 1 ? (
+              <SourceControlWorktreePicker
+                worktrees={worktreeList}
+                selectedWorktreeId={selectedWorktreeId ?? appActiveWorktreeId ?? ''}
+                currentWorktreeId={appActiveWorktreeId ?? ''}
+                onSelect={onSelectWorktree}
+              />
+            ) : null}
             {hostedReview ? (
               <HostedReviewToolbarLink
                 review={hostedReview}

--- a/src/renderer/src/components/right-sidebar/source-control/panel/panel-ready.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/panel-ready.tsx
@@ -3,6 +3,10 @@ import { SourceControlHeaderToolbar } from './header-toolbar'
 import { SourceControlNotesShelf } from '../notes/notes-shelf'
 import { SourceControlPanelContent } from './panel-content'
 import { SourceControlPanelDialogs } from './panel-dialogs'
+import {
+  shouldShowSourceControlNonActiveWorktreeNotice,
+  SourceControlNonActiveWorktreeNotice
+} from './worktree-picker'
 import type { SourceControlPanelReadyProps } from './panel-props'
 
 /** The panel chrome: toolbar, notes shelf, the scrolling file surface, bulk bar and dialog layer. */
@@ -10,7 +14,9 @@ export function SourceControlPanelReady(props: SourceControlPanelReadyProps) {
   const { model, worktreePath } = props
   const {
     activeGroupId,
+    activeWorktree,
     activeWorktreeId,
+    appActiveWorktreeId,
     branchLineTotal,
     branchSummary,
     bulkStagePaths,
@@ -49,10 +55,12 @@ export function SourceControlPanelReady(props: SourceControlPanelReadyProps) {
     setFilterQuery,
     setPendingDiffCommentsClear,
     setSourceControlRoot,
+    setViewWorktreeId,
     settings,
     sourceControlViewMode,
     suppressedGitHubPRState,
-    visibleCreatePrHeaderAction
+    visibleCreatePrHeaderAction,
+    worktreeList
   } = model
 
   return (
@@ -67,6 +75,10 @@ export function SourceControlPanelReady(props: SourceControlPanelReadyProps) {
           filterExpanded={filterExpanded}
           onFilterQueryChange={setFilterQuery}
           onFilterExpandedChange={setFilterExpanded}
+          worktreeList={worktreeList}
+          selectedWorktreeId={activeWorktreeId}
+          appActiveWorktreeId={appActiveWorktreeId}
+          onSelectWorktree={setViewWorktreeId}
           visibleCreatePrHeaderAction={visibleCreatePrHeaderAction}
           hostedReview={hostedReview}
           isCreatePrIntentInFlight={isCreatePrIntentInFlight}
@@ -91,6 +103,14 @@ export function SourceControlPanelReady(props: SourceControlPanelReadyProps) {
           headDisplay={gitIdentityDisplay}
           manualReviewUrl={manualReviewUrl}
         />
+
+        {/* Why: a viewed non-active worktree means every action below targets another worktree; keep that visible at all times. */}
+        {shouldShowSourceControlNonActiveWorktreeNotice(
+          activeWorktreeId ?? '',
+          appActiveWorktreeId ?? ''
+        ) && (
+          <SourceControlNonActiveWorktreeNotice displayName={activeWorktree?.displayName ?? ''} />
+        )}
 
         {/* Why: hidden when count is 0 — notes are created from the diff view, so an empty Notes shelf here is pure chrome. */}
         {activeWorktreeId && worktreePath && diffCommentCount > 0 && (

--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-model.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-model.ts
@@ -104,7 +104,8 @@ export function useSourceControlPanelModel() {
     hostedReviewReviewLabel: hostedReviewCreateCopy.reviewLabel,
     hasSuppressedGitHubPRState: suppressedGitHubPRState !== null,
     conflictOperation,
-    effectiveBaseRef
+    effectiveBaseRef,
+    isSubjectLinkedWorktree: activeWorktree ? !activeWorktree.isMainWorktree : false
   })
   const handleRelinkSuppressedGitHubPR = useCallback(() => {
     if (!activeWorktree || !activeWorktreeId || suppressedGitHubPRState?.status !== 'matched') {

--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-state.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-state.ts
@@ -1,18 +1,23 @@
+import { useAppStore } from '@/store'
 import { useSourceControlDiffCommentNotes } from '../notes/use-diff-comment-notes'
 import { useSourceControlStoreActions } from '../listing/use-store-actions'
 import { useSourceControlWorktreeContext } from '../listing/use-worktree-context'
 import { useSourceControlBranchLineTotalGate } from '../sync/use-branch-line-total-gate'
 import { useSourceControlStatusRefresh } from '../sync/use-status-refresh'
 import { useSourceControlPanelViewState } from './use-panel-view-state'
+import { useSourceControlViewWorktreeSelection } from './use-source-control-view-worktree-selection'
 import { useSourceControlWorktreeOperationState } from './use-worktree-operation-state'
 
 /**
- * The panel's ground floor: what worktree/repo is active, the store actions it drives, and the
- * state it owns itself. Everything else in the panel is derived from this.
+ * The panel's ground floor: what worktree/repo is being shown (the picker subject, defaulting to
+ * the app-active worktree), the store actions it drives, and the state it owns itself. Everything
+ * else in the panel is derived from this.
  */
 export function useSourceControlPanelState() {
-  const context = useSourceControlWorktreeContext()
+  const settings = useAppStore((s) => s.settings)
   const storeActions = useSourceControlStoreActions()
+  const selection = useSourceControlViewWorktreeSelection()
+  const context = useSourceControlWorktreeContext(selection.subjectWorktreeId)
   const {
     activeConnectionId,
     activeRepoSettings,
@@ -24,20 +29,20 @@ export function useSourceControlPanelState() {
     isBranchVisible,
     isFolder,
     repositoryHuge,
-    settings,
     worktreeMap,
     worktreePath
   } = context
+  // Why: view state is keyed to the shown worktree so picking another one starts with a fresh view.
+  const viewState = useSourceControlPanelViewState({
+    activeWorktreeId,
+    settings,
+    updateSettings: storeActions.updateSettings
+  })
 
   const notes = useSourceControlDiffCommentNotes({
     activeWorktreeId,
     clearDiffComments: storeActions.clearDiffComments,
     clearDiffCommentsForFile: storeActions.clearDiffCommentsForFile
-  })
-  const viewState = useSourceControlPanelViewState({
-    activeWorktreeId,
-    settings,
-    updateSettings: storeActions.updateSettings
   })
   const operationState = useSourceControlWorktreeOperationState({
     activeWorktreeId,
@@ -68,7 +73,8 @@ export function useSourceControlPanelState() {
     ...notes,
     ...viewState,
     ...operationState,
-    ...statusRefresh
+    ...statusRefresh,
+    setViewWorktreeId: selection.setViewWorktreeId
   }
 }
 

--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-view-state.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-view-state.ts
@@ -14,7 +14,7 @@ function createDefaultCollapsedSections(): Set<string> {
 /**
  * Local presentation state for the Source Control panel: filter, collapsed sections/directories,
  * list-vs-tree mode and the base-ref dialog, plus the per-worktree reset that keeps a worktree
- * switch from inheriting the previous worktree's view.
+ * switch (app-active or picker-pinned) from inheriting the previous worktree's view.
  */
 export function useSourceControlPanelViewState({
   activeWorktreeId,

--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-source-control-view-worktree-selection.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-source-control-view-worktree-selection.test.tsx
@@ -3,33 +3,37 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+type MockWorktree = { id: string; repoId: string }
+
+function worktree(id: string, repoId: string): MockWorktree {
+  return { id, repoId }
+}
+
 const state = vi.hoisted(() => ({
   activeWorktreeId: 'wt-a' as string | null,
-  worktreeMap: new Map<string, { id: string; repoId: string }>([
-    ['wt-a', { id: 'wt-a', repoId: 'repo-1' }],
-    ['wt-b', { id: 'wt-b', repoId: 'repo-1' }],
-    ['wt-c', { id: 'wt-c', repoId: 'repo-2' }]
-  ])
+  worktreesByRepo: {
+    'repo-1': [worktree('wt-a', 'repo-1'), worktree('wt-b', 'repo-1')],
+    'repo-2': [worktree('wt-c', 'repo-2')]
+  } as Record<string, MockWorktree[]>,
+  detectedWorktreesByRepo: {} as Record<string, { worktrees: MockWorktree[] }>
 }))
 
 vi.mock('@/store', () => ({
   useAppStore: (selector: (s: typeof state) => unknown) => selector(state)
 }))
 
-vi.mock('@/store/selectors', () => ({
-  useWorktreeMap: () => state.worktreeMap
-}))
+vi.mock('@/store/selectors', () => ({}))
 
 const { useSourceControlViewWorktreeSelection } =
   await import('./use-source-control-view-worktree-selection')
 
-function Harness(): React.JSX.Element {
+function Harness({ pinId = 'wt-b' }: { pinId?: string }): React.JSX.Element {
   const { subjectWorktreeId, setViewWorktreeId } = useSourceControlViewWorktreeSelection()
   return (
     <div>
       <span data-testid="subject">{subjectWorktreeId ?? 'null'}</span>
-      <button type="button" onClick={() => setViewWorktreeId('wt-b')}>
-        pick-b
+      <button type="button" onClick={() => setViewWorktreeId(pinId)}>
+        pick
       </button>
     </div>
   )
@@ -45,36 +49,52 @@ describe('useSourceControlViewWorktreeSelection', () => {
 
   it('pins the subject to the picked worktree', () => {
     render(<Harness />)
-    fireEvent.click(screen.getByText('pick-b'))
+    fireEvent.click(screen.getByText('pick'))
     expect(screen.getByTestId('subject').textContent).toBe('wt-b')
   })
 
   it('keeps the pin when the app-active worktree switches within the same repo', () => {
     render(<Harness />)
-    fireEvent.click(screen.getByText('pick-b'))
+    fireEvent.click(screen.getByText('pick'))
     state.activeWorktreeId = 'wt-a2'
-    state.worktreeMap.set('wt-a2', { id: 'wt-a2', repoId: 'repo-1' })
+    // Why: real store updates replace the record identity; the memo keys on it.
+    state.worktreesByRepo = {
+      ...state.worktreesByRepo,
+      'repo-1': [...state.worktreesByRepo['repo-1'], worktree('wt-a2', 'repo-1')]
+    }
     // Why: the mocked store is a plain object; bump React with a sibling update
     // so the subscription re-reads the new active id.
-    fireEvent.click(screen.getByText('pick-b'))
+    fireEvent.click(screen.getByText('pick'))
     expect(screen.getByTestId('subject').textContent).toBe('wt-b')
   })
 
   it('follows the app-active worktree when the active repo changes', () => {
     render(<Harness />)
-    fireEvent.click(screen.getByText('pick-b'))
+    fireEvent.click(screen.getByText('pick'))
     state.activeWorktreeId = 'wt-c'
-    fireEvent.click(screen.getByText('pick-b'))
+    fireEvent.click(screen.getByText('pick'))
     expect(screen.getByTestId('subject').textContent).toBe('wt-c')
   })
 
   it('falls back to the app-active worktree when the pinned one disappears', () => {
     render(<Harness />)
-    fireEvent.click(screen.getByText('pick-b'))
+    fireEvent.click(screen.getByText('pick'))
     expect(screen.getByTestId('subject').textContent).toBe('wt-b')
-    state.worktreeMap.delete('wt-b')
+    state.worktreesByRepo = {
+      ...state.worktreesByRepo,
+      'repo-1': state.worktreesByRepo['repo-1'].filter((entry) => entry.id !== 'wt-b')
+    }
     state.activeWorktreeId = 'wt-a'
-    fireEvent.click(screen.getByText('pick-b'))
+    fireEvent.click(screen.getByText('pick'))
     expect(screen.getByTestId('subject').textContent).toBe('wt-a')
+  })
+
+  it('accepts a pinned worktree that only exists in the detected catalog', () => {
+    state.detectedWorktreesByRepo['repo-1'] = {
+      worktrees: [worktree('wt-external', 'repo-1')]
+    }
+    render(<Harness pinId="wt-external" />)
+    fireEvent.click(screen.getByText('pick'))
+    expect(screen.getByTestId('subject').textContent).toBe('wt-external')
   })
 })

--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-source-control-view-worktree-selection.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-source-control-view-worktree-selection.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  activeWorktreeId: 'wt-a' as string | null,
+  worktreeMap: new Map<string, { id: string; repoId: string }>([
+    ['wt-a', { id: 'wt-a', repoId: 'repo-1' }],
+    ['wt-b', { id: 'wt-b', repoId: 'repo-1' }],
+    ['wt-c', { id: 'wt-c', repoId: 'repo-2' }]
+  ])
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (s: typeof state) => unknown) => selector(state)
+}))
+
+vi.mock('@/store/selectors', () => ({
+  useWorktreeMap: () => state.worktreeMap
+}))
+
+const { useSourceControlViewWorktreeSelection } =
+  await import('./use-source-control-view-worktree-selection')
+
+function Harness(): React.JSX.Element {
+  const { subjectWorktreeId, setViewWorktreeId } = useSourceControlViewWorktreeSelection()
+  return (
+    <div>
+      <span data-testid="subject">{subjectWorktreeId ?? 'null'}</span>
+      <button type="button" onClick={() => setViewWorktreeId('wt-b')}>
+        pick-b
+      </button>
+    </div>
+  )
+}
+
+afterEach(cleanup)
+
+describe('useSourceControlViewWorktreeSelection', () => {
+  it('defaults to the app-active worktree', () => {
+    render(<Harness />)
+    expect(screen.getByTestId('subject').textContent).toBe('wt-a')
+  })
+
+  it('pins the subject to the picked worktree', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByText('pick-b'))
+    expect(screen.getByTestId('subject').textContent).toBe('wt-b')
+  })
+
+  it('keeps the pin when the app-active worktree switches within the same repo', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByText('pick-b'))
+    state.activeWorktreeId = 'wt-a2'
+    state.worktreeMap.set('wt-a2', { id: 'wt-a2', repoId: 'repo-1' })
+    // Why: the mocked store is a plain object; bump React with a sibling update
+    // so the subscription re-reads the new active id.
+    fireEvent.click(screen.getByText('pick-b'))
+    expect(screen.getByTestId('subject').textContent).toBe('wt-b')
+  })
+
+  it('follows the app-active worktree when the active repo changes', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByText('pick-b'))
+    state.activeWorktreeId = 'wt-c'
+    fireEvent.click(screen.getByText('pick-b'))
+    expect(screen.getByTestId('subject').textContent).toBe('wt-c')
+  })
+
+  it('falls back to the app-active worktree when the pinned one disappears', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByText('pick-b'))
+    expect(screen.getByTestId('subject').textContent).toBe('wt-b')
+    state.worktreeMap.delete('wt-b')
+    state.activeWorktreeId = 'wt-a'
+    fireEvent.click(screen.getByText('pick-b'))
+    expect(screen.getByTestId('subject').textContent).toBe('wt-a')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-source-control-view-worktree-selection.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-source-control-view-worktree-selection.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useReducer } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 type MockWorktree = { id: string; repoId: string }
@@ -29,11 +30,17 @@ const { useSourceControlViewWorktreeSelection } =
 
 function Harness({ pinId = 'wt-b' }: { pinId?: string }): React.JSX.Element {
   const { subjectWorktreeId, setViewWorktreeId } = useSourceControlViewWorktreeSelection()
+  // Why: the mocked store is a plain object (no subscription), so a non-pinning re-render is the
+  // only way to make the hook re-read the mutated state.
+  const [, bump] = useReducer((x: number) => x + 1, 0)
   return (
     <div>
       <span data-testid="subject">{subjectWorktreeId ?? 'null'}</span>
       <button type="button" onClick={() => setViewWorktreeId(pinId)}>
         pick
+      </button>
+      <button type="button" onClick={() => bump()}>
+        bump
       </button>
     </div>
   )
@@ -51,6 +58,20 @@ describe('useSourceControlViewWorktreeSelection', () => {
     render(<Harness />)
     fireEvent.click(screen.getByText('pick'))
     expect(screen.getByTestId('subject').textContent).toBe('wt-b')
+  })
+
+  it('follows the app-active worktree when it switches within the same repo without a pin', () => {
+    render(<Harness />)
+    expect(screen.getByTestId('subject').textContent).toBe('wt-a')
+    state.activeWorktreeId = 'wt-a2'
+    // Why: real store updates replace the record identity; the memo keys on it.
+    state.worktreesByRepo = {
+      ...state.worktreesByRepo,
+      'repo-1': [...state.worktreesByRepo['repo-1'], worktree('wt-a2', 'repo-1')]
+    }
+    // Why: the mocked store is a plain object; bump (not pick) so no pin is set while React re-reads the new active id.
+    fireEvent.click(screen.getByText('bump'))
+    expect(screen.getByTestId('subject').textContent).toBe('wt-a2')
   })
 
   it('keeps the pin when the app-active worktree switches within the same repo', () => {

--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-source-control-view-worktree-selection.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-source-control-view-worktree-selection.ts
@@ -3,11 +3,12 @@ import { useAppStore } from '@/store'
 import type { Worktree } from '../../../../../../shared/worktree/types'
 
 /**
- * Owns which worktree the Source Control panel is showing. Defaults to the app-active worktree; the
- * user can pin another worktree of the same repo through the picker. The pin survives app-active
- * switches within the same repo (so a reviewed worktree stays in view while the user works
- * elsewhere), resets when the active repo changes, and falls back to the app-active worktree when
- * the pinned one disappears from the catalog.
+ * Owns which worktree the Source Control panel is showing. With no pin the panel follows the
+ * app-active worktree on every switch (including same-repo switches, since the right sidebar
+ * stays mounted); the user can pin another worktree of the same repo through the picker. The pin
+ * survives app-active switches within the same repo (so a reviewed worktree stays in view while
+ * the user works elsewhere), resets when the active repo changes, and falls back to the app-active
+ * worktree when the pinned one disappears from the catalog.
  *
  * The known-worktree catalog spans both registered workspaces and detected git worktrees, so a pin
  * can target a worktree Orca has only detected (e.g. externally created siblings hidden from the
@@ -37,13 +38,16 @@ export function useSourceControlViewWorktreeSelection(): {
     return map
   }, [detectedWorktreesByRepo, worktreesByRepo])
   const appActiveRepoId = knownWorktreeById.get(appActiveWorktreeId ?? '')?.repoId ?? null
-  const [viewWorktreeId, setViewWorktreeId] = useState<string | null>(appActiveWorktreeId)
+  // Why: null means "not pinned" — the subject falls back to the app-active worktree below, so a
+  // same-repo app-active switch is followed without an explicit pick. Only a picker selection
+  // assigns a real pin.
+  const [viewWorktreeId, setViewWorktreeId] = useState<string | null>(null)
   // Why: reset during render instead of key-remounting on switch (which caused a Windows IPC storm).
   // Keyed to the repo so a same-repo app-active switch keeps the user's explicit pin.
   const [selectionRepoId, setSelectionRepoId] = useState(appActiveRepoId)
   if (selectionRepoId !== appActiveRepoId) {
     setSelectionRepoId(appActiveRepoId)
-    setViewWorktreeId(appActiveWorktreeId)
+    setViewWorktreeId(null)
   }
   const subjectWorktreeId =
     viewWorktreeId && knownWorktreeById.has(viewWorktreeId) ? viewWorktreeId : appActiveWorktreeId

--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-source-control-view-worktree-selection.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-source-control-view-worktree-selection.ts
@@ -1,6 +1,6 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useAppStore } from '@/store'
-import { useWorktreeMap } from '@/store/selectors'
+import type { Worktree } from '../../../../../../shared/worktree/types'
 
 /**
  * Owns which worktree the Source Control panel is showing. Defaults to the app-active worktree; the
@@ -8,14 +8,35 @@ import { useWorktreeMap } from '@/store/selectors'
  * switches within the same repo (so a reviewed worktree stays in view while the user works
  * elsewhere), resets when the active repo changes, and falls back to the app-active worktree when
  * the pinned one disappears from the catalog.
+ *
+ * The known-worktree catalog spans both registered workspaces and detected git worktrees, so a pin
+ * can target a worktree Orca has only detected (e.g. externally created siblings hidden from the
+ * sidebar by the visibility policy).
  */
 export function useSourceControlViewWorktreeSelection(): {
   subjectWorktreeId: string | null
   setViewWorktreeId: (worktreeId: string) => void
 } {
   const appActiveWorktreeId = useAppStore((s) => s.activeWorktreeId)
-  const worktreeMap = useWorktreeMap()
-  const appActiveRepoId = worktreeMap.get(appActiveWorktreeId ?? '')?.repoId ?? null
+  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const detectedWorktreesByRepo = useAppStore((s) => s.detectedWorktreesByRepo)
+  const knownWorktreeById = useMemo(() => {
+    const map = new Map<string, Worktree>()
+    for (const list of Object.values(worktreesByRepo ?? {})) {
+      for (const worktree of list) {
+        map.set(worktree.id, worktree)
+      }
+    }
+    for (const result of Object.values(detectedWorktreesByRepo ?? {})) {
+      for (const worktree of result.worktrees) {
+        if (!map.has(worktree.id)) {
+          map.set(worktree.id, worktree)
+        }
+      }
+    }
+    return map
+  }, [detectedWorktreesByRepo, worktreesByRepo])
+  const appActiveRepoId = knownWorktreeById.get(appActiveWorktreeId ?? '')?.repoId ?? null
   const [viewWorktreeId, setViewWorktreeId] = useState<string | null>(appActiveWorktreeId)
   // Why: reset during render instead of key-remounting on switch (which caused a Windows IPC storm).
   // Keyed to the repo so a same-repo app-active switch keeps the user's explicit pin.
@@ -25,6 +46,6 @@ export function useSourceControlViewWorktreeSelection(): {
     setViewWorktreeId(appActiveWorktreeId)
   }
   const subjectWorktreeId =
-    viewWorktreeId && worktreeMap.has(viewWorktreeId) ? viewWorktreeId : appActiveWorktreeId
+    viewWorktreeId && knownWorktreeById.has(viewWorktreeId) ? viewWorktreeId : appActiveWorktreeId
   return { subjectWorktreeId, setViewWorktreeId }
 }

--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-source-control-view-worktree-selection.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-source-control-view-worktree-selection.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import { useAppStore } from '@/store'
+import { useWorktreeMap } from '@/store/selectors'
+
+/**
+ * Owns which worktree the Source Control panel is showing. Defaults to the app-active worktree; the
+ * user can pin another worktree of the same repo through the picker. The pin survives app-active
+ * switches within the same repo (so a reviewed worktree stays in view while the user works
+ * elsewhere), resets when the active repo changes, and falls back to the app-active worktree when
+ * the pinned one disappears from the catalog.
+ */
+export function useSourceControlViewWorktreeSelection(): {
+  subjectWorktreeId: string | null
+  setViewWorktreeId: (worktreeId: string) => void
+} {
+  const appActiveWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const worktreeMap = useWorktreeMap()
+  const appActiveRepoId = worktreeMap.get(appActiveWorktreeId ?? '')?.repoId ?? null
+  const [viewWorktreeId, setViewWorktreeId] = useState<string | null>(appActiveWorktreeId)
+  // Why: reset during render instead of key-remounting on switch (which caused a Windows IPC storm).
+  // Keyed to the repo so a same-repo app-active switch keeps the user's explicit pin.
+  const [selectionRepoId, setSelectionRepoId] = useState(appActiveRepoId)
+  if (selectionRepoId !== appActiveRepoId) {
+    setSelectionRepoId(appActiveRepoId)
+    setViewWorktreeId(appActiveWorktreeId)
+  }
+  const subjectWorktreeId =
+    viewWorktreeId && worktreeMap.has(viewWorktreeId) ? viewWorktreeId : appActiveWorktreeId
+  return { subjectWorktreeId, setViewWorktreeId }
+}

--- a/src/renderer/src/components/right-sidebar/source-control/panel/worktree-picker-filter.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/worktree-picker-filter.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../../../../shared/worktree/types'
+import {
+  filterSourceControlWorktrees,
+  getSourceControlWorktreeSearchText
+} from './worktree-picker-filter'
+
+function makeWorktree(overrides: Partial<Worktree>): Worktree {
+  return {
+    id: 'repo::/path',
+    repoId: 'repo',
+    displayName: 'feature/alpha',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    path: '/path',
+    head: '0123456789abcdef',
+    branch: 'feature/alpha',
+    isBare: false,
+    isMainWorktree: false,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+const WORKTREES: readonly Worktree[] = [
+  makeWorktree({
+    id: 'repo::/main',
+    displayName: 'orca',
+    path: '/main',
+    branch: 'main',
+    isMainWorktree: true
+  }),
+  makeWorktree({
+    id: 'repo::/worktrees/alpha',
+    displayName: 'alpha',
+    path: '/worktrees/alpha',
+    branch: 'feature/alpha',
+    comment: 'API refactor'
+  }),
+  makeWorktree({
+    id: 'repo::/worktrees/beta',
+    displayName: 'beta',
+    path: '/worktrees/beta',
+    branch: 'hotfix/login',
+    comment: ''
+  })
+]
+
+describe('getSourceControlWorktreeSearchText', () => {
+  it('includes name, path, comment and branch', () => {
+    const text = getSourceControlWorktreeSearchText(WORKTREES[1])
+    expect(text).toContain('alpha')
+    expect(text).toContain('/worktrees/alpha')
+    expect(text).toContain('api refactor')
+    expect(text).toContain('feature/alpha')
+  })
+})
+
+describe('filterSourceControlWorktrees', () => {
+  it('returns the full list for an empty query', () => {
+    expect(filterSourceControlWorktrees(WORKTREES, '')).toBe(WORKTREES)
+    expect(filterSourceControlWorktrees(WORKTREES, '   ')).toBe(WORKTREES)
+  })
+
+  it('matches the branch name', () => {
+    expect(filterSourceControlWorktrees(WORKTREES, 'hotfix').map((w) => w.displayName)).toEqual([
+      'beta'
+    ])
+  })
+
+  it('matches the display name case-insensitively', () => {
+    expect(filterSourceControlWorktrees(WORKTREES, 'ALPHA').map((w) => w.displayName)).toEqual([
+      'alpha'
+    ])
+  })
+
+  it('matches the comment', () => {
+    expect(filterSourceControlWorktrees(WORKTREES, 'refactor').map((w) => w.displayName)).toEqual([
+      'alpha'
+    ])
+  })
+
+  it('returns no rows when nothing matches', () => {
+    expect(filterSourceControlWorktrees(WORKTREES, 'zzz')).toEqual([])
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control/panel/worktree-picker-filter.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/worktree-picker-filter.ts
@@ -1,0 +1,31 @@
+import type { Worktree } from '../../../../../../shared/worktree/types'
+import { getWorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
+
+/** Every searchable token for a worktree row: name, path, comment and current branch. */
+export function getSourceControlWorktreeSearchText(worktree: Worktree): string {
+  const identity = getWorktreeGitIdentityDisplay(worktree)
+  const headLabel =
+    identity?.kind === 'branch'
+      ? identity.branchName
+      : identity?.kind === 'detached'
+        ? identity.sourceControlLabel
+        : ''
+  return [worktree.displayName, worktree.path, worktree.comment, headLabel]
+    .filter((part) => part.length > 0)
+    .join('\n')
+    .toLowerCase()
+}
+
+/** Case-insensitive substring filter over name/path/comment/branch for the picker. */
+export function filterSourceControlWorktrees(
+  worktrees: readonly Worktree[],
+  rawQuery: string
+): readonly Worktree[] {
+  const query = rawQuery.trim().toLowerCase()
+  if (!query) {
+    return worktrees
+  }
+  return worktrees.filter((worktree) =>
+    getSourceControlWorktreeSearchText(worktree).includes(query)
+  )
+}

--- a/src/renderer/src/components/right-sidebar/source-control/panel/worktree-picker.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/worktree-picker.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment happy-dom
+
+import type React from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Worktree } from '../../../../../../shared/worktree/types'
+
+const popoverMock = vi.hoisted(() => ({
+  open: false,
+  onOpenChange: undefined as ((open: boolean) => void) | undefined
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+// Radix `asChild` renders the child itself and owns its click; mirror that so
+// the trigger button is clickable and content mounts only while open.
+vi.mock('@/components/ui/popover', async () => {
+  const { cloneElement } = await import('react')
+  return {
+    Popover: ({
+      children,
+      open,
+      onOpenChange
+    }: {
+      children: React.ReactNode
+      open?: boolean
+      onOpenChange?: (open: boolean) => void
+    }) => {
+      popoverMock.open = open ?? false
+      popoverMock.onOpenChange = onOpenChange
+      return <div>{children}</div>
+    },
+    PopoverTrigger: ({ children }: { children: React.ReactElement }) =>
+      cloneElement(children as React.ReactElement<{ onClick?: () => void }>, {
+        onClick: () => popoverMock.onOpenChange?.(!popoverMock.open)
+      }),
+    PopoverContent: ({ children }: { children: React.ReactNode }) =>
+      popoverMock.open ? <div>{children}</div> : null
+  }
+})
+
+vi.mock('@/components/ui/command', () => ({
+  Command: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandInput: ({
+    value,
+    placeholder,
+    onValueChange
+  }: {
+    value?: string
+    placeholder?: string
+    onValueChange?: (value: string) => void
+  }) => (
+    <input
+      data-slot="command-input"
+      value={value}
+      placeholder={placeholder}
+      onChange={(event) => onValueChange?.(event.target.value)}
+    />
+  ),
+  CommandList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandItem: ({
+    children,
+    onSelect,
+    'data-testid': dataTestId
+  }: {
+    children: React.ReactNode
+    onSelect?: (value: string) => void
+    'data-testid'?: string
+  }) => (
+    <button
+      type="button"
+      data-testid={dataTestId}
+      onClick={() => onSelect?.('repo::/worktrees/beta')}
+    >
+      {children}
+    </button>
+  )
+}))
+
+const { SourceControlWorktreePicker, shouldShowSourceControlNonActiveWorktreeNotice } =
+  await import('./worktree-picker')
+
+function makeWorktree(overrides: Partial<Worktree>): Worktree {
+  return {
+    id: 'repo::/worktrees/alpha',
+    repoId: 'repo',
+    displayName: 'alpha',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    path: '/worktrees/alpha',
+    head: '0123456789abcdef',
+    branch: 'refs/heads/feature/alpha',
+    isBare: false,
+    isMainWorktree: false,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+const WORKTREES: readonly Worktree[] = [
+  makeWorktree({
+    id: 'repo::/main',
+    displayName: 'orca',
+    path: '/main',
+    branch: 'refs/heads/main',
+    isMainWorktree: true
+  }),
+  makeWorktree({ id: 'repo::/worktrees/alpha', displayName: 'alpha' }),
+  makeWorktree({
+    id: 'repo::/worktrees/beta',
+    displayName: 'beta',
+    path: '/worktrees/beta',
+    branch: 'refs/heads/hotfix/login'
+  })
+]
+
+afterEach(() => {
+  cleanup()
+  popoverMock.open = false
+})
+
+describe('SourceControlWorktreePicker', () => {
+  it('shows the selected worktree on the trigger', () => {
+    render(
+      <SourceControlWorktreePicker
+        worktrees={WORKTREES}
+        selectedWorktreeId="repo::/worktrees/alpha"
+        currentWorktreeId="repo::/main"
+        onSelect={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('source-control-worktree-picker')).toBeTruthy()
+    expect(screen.getByText('alpha')).toBeTruthy()
+  })
+
+  it('selects another worktree from the list', () => {
+    const onSelect = vi.fn()
+    render(
+      <SourceControlWorktreePicker
+        worktrees={WORKTREES}
+        selectedWorktreeId="repo::/worktrees/alpha"
+        currentWorktreeId="repo::/main"
+        onSelect={onSelect}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('source-control-worktree-picker'))
+    fireEvent.click(
+      screen.getByTestId('source-control-worktree-picker-option-repo::/worktrees/beta')
+    )
+
+    expect(onSelect).toHaveBeenCalledWith('repo::/worktrees/beta')
+  })
+
+  it('filters the list as the user types', () => {
+    render(
+      <SourceControlWorktreePicker
+        worktrees={WORKTREES}
+        selectedWorktreeId="repo::/main"
+        currentWorktreeId="repo::/main"
+        onSelect={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('source-control-worktree-picker'))
+    const input = screen.getByPlaceholderText('Search worktrees…')
+    fireEvent.change(input, { target: { value: 'hotfix' } })
+
+    expect(screen.getByText('beta')).toBeTruthy()
+    expect(
+      screen.queryByTestId('source-control-worktree-picker-option-repo::/worktrees/alpha')
+    ).toBeNull()
+    expect(screen.queryByTestId('source-control-worktree-picker-option-repo::/main')).toBeNull()
+  })
+
+  it('marks the app-active worktree as current', () => {
+    render(
+      <SourceControlWorktreePicker
+        worktrees={WORKTREES}
+        selectedWorktreeId="repo::/main"
+        currentWorktreeId="repo::/main"
+        onSelect={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('source-control-worktree-picker'))
+    expect(screen.getByText('Current')).toBeTruthy()
+  })
+})
+
+describe('shouldShowSourceControlNonActiveWorktreeNotice', () => {
+  it('shows only when the viewed worktree differs from the app-active one', () => {
+    expect(shouldShowSourceControlNonActiveWorktreeNotice('a', 'a')).toBe(false)
+    expect(shouldShowSourceControlNonActiveWorktreeNotice('b', 'a')).toBe(true)
+    expect(shouldShowSourceControlNonActiveWorktreeNotice('', 'a')).toBe(true)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control/panel/worktree-picker.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/worktree-picker.tsx
@@ -1,0 +1,224 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import { Check, ChevronsUpDown, Eye, Workflow } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { Worktree } from '../../../../../../shared/worktree/types'
+import { getWorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
+import { filterSourceControlWorktrees } from './worktree-picker-filter'
+
+type SourceControlWorktreePickerProps = {
+  /** Every worktree of the active repo, including the main checkout. */
+  worktrees: readonly Worktree[]
+  /** The worktree the panel is currently showing. */
+  selectedWorktreeId: string
+  /** The app-active worktree; rendered as the "current" row in the list. */
+  currentWorktreeId: string
+  onSelect: (worktreeId: string) => void
+}
+
+function resolvePickerTriggerLabel(worktrees: readonly Worktree[], worktreeId: string): string {
+  return worktrees.find((worktree) => worktree.id === worktreeId)?.displayName ?? ''
+}
+
+export function SourceControlWorktreePicker({
+  worktrees,
+  selectedWorktreeId,
+  currentWorktreeId,
+  onSelect
+}: SourceControlWorktreePickerProps): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+
+  const selectedWorktree = useMemo(
+    () => worktrees.find((worktree) => worktree.id === selectedWorktreeId) ?? null,
+    [selectedWorktreeId, worktrees]
+  )
+  const viewingNonActive = selectedWorktreeId !== currentWorktreeId
+  // Why: keep the repo's main checkout pinned at the top; the rest alphabetical so the list is stable.
+  const orderedWorktrees = useMemo(
+    () =>
+      [...worktrees].sort(
+        (left, right) =>
+          Number(right.isMainWorktree) - Number(left.isMainWorktree) ||
+          left.displayName.localeCompare(right.displayName)
+      ),
+    [worktrees]
+  )
+  const filteredWorktrees = useMemo(
+    () => filterSourceControlWorktrees(orderedWorktrees, query),
+    [orderedWorktrees, query]
+  )
+  const triggerLabel = resolvePickerTriggerLabel(worktrees, selectedWorktreeId)
+  const triggerTitle = translate(
+    'auto.components.right.sidebar.SourceControl.worktreePickerTriggerTitle',
+    'Worktree: {{value0}}',
+    { value0: triggerLabel || selectedWorktree?.path || '' }
+  )
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (!nextOpen) {
+      setQuery('')
+    }
+  }, [])
+
+  const handleSelect = useCallback(
+    (worktreeId: string) => {
+      if (worktreeId !== selectedWorktreeId) {
+        onSelect(worktreeId)
+      }
+      setOpen(false)
+    },
+    [onSelect, selectedWorktreeId]
+  )
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="xs"
+          role="combobox"
+          aria-expanded={open}
+          aria-label={triggerTitle}
+          title={triggerTitle}
+          data-testid="source-control-worktree-picker"
+          className="h-6 min-w-0 max-w-[160px] shrink-0 px-2 text-[11px] font-normal"
+        >
+          {viewingNonActive ? (
+            <Eye
+              className="size-3 shrink-0 text-amber-600 dark:text-amber-400"
+              aria-hidden="true"
+            />
+          ) : (
+            <Workflow className="size-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+          )}
+          <span className="min-w-0 flex-1 truncate">{triggerLabel || selectedWorktree?.path}</span>
+          <ChevronsUpDown className="size-3 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[min(320px,calc(100vw-1rem))] min-w-[var(--radix-popover-trigger-width)] p-0"
+      >
+        <Command shouldFilter={false}>
+          <CommandInput
+            autoFocus
+            placeholder={translate(
+              'auto.components.right.sidebar.SourceControl.worktreePickerSearchPlaceholder',
+              'Search worktrees…'
+            )}
+            value={query}
+            onValueChange={setQuery}
+            className="text-xs"
+          />
+          <CommandList>
+            <CommandEmpty>
+              {translate(
+                'auto.components.right.sidebar.SourceControl.worktreePickerEmpty',
+                'No worktrees match your search.'
+              )}
+            </CommandEmpty>
+            {filteredWorktrees.map((worktree) => {
+              const isSelected = worktree.id === selectedWorktreeId
+              const isCurrent = worktree.id === currentWorktreeId
+              const identity = getWorktreeGitIdentityDisplay(worktree)
+              const headLabel =
+                identity?.kind === 'branch'
+                  ? identity.branchName
+                  : identity?.kind === 'detached'
+                    ? identity.sourceControlLabel
+                    : null
+              return (
+                <CommandItem
+                  key={worktree.id}
+                  value={worktree.id}
+                  onSelect={() => handleSelect(worktree.id)}
+                  className="items-center gap-2 px-3 py-1.5 text-xs"
+                  data-testid={`source-control-worktree-picker-option-${worktree.id}`}
+                >
+                  <Check
+                    className={cn(
+                      'size-3 shrink-0 text-muted-foreground',
+                      isSelected ? 'opacity-70' : 'opacity-0'
+                    )}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <span className="flex min-w-0 items-center gap-1.5">
+                      <span className="truncate text-xs">{worktree.displayName}</span>
+                      {worktree.isMainWorktree ? (
+                        <span className="shrink-0 rounded-sm bg-muted px-1 py-px text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
+                          {translate(
+                            'auto.components.right.sidebar.SourceControl.worktreePickerMainBadge',
+                            'Main'
+                          )}
+                        </span>
+                      ) : null}
+                      {isCurrent ? (
+                        <span className="shrink-0 text-[10px] text-muted-foreground">
+                          {translate(
+                            'auto.components.right.sidebar.SourceControl.worktreePickerCurrentBadge',
+                            'Current'
+                          )}
+                        </span>
+                      ) : null}
+                    </span>
+                    <p className="mt-0.5 truncate text-[10px] text-muted-foreground">
+                      {headLabel ? <span className="font-mono">{headLabel} · </span> : null}
+                      <span className="font-mono">{worktree.path}</span>
+                    </p>
+                  </div>
+                </CommandItem>
+              )
+            })}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export function shouldShowSourceControlNonActiveWorktreeNotice(
+  selectedWorktreeId: string,
+  currentWorktreeId: string
+): boolean {
+  return selectedWorktreeId !== currentWorktreeId
+}
+
+export function SourceControlNonActiveWorktreeNotice({
+  displayName,
+  className
+}: {
+  displayName: string
+  className?: string
+}): React.JSX.Element {
+  return (
+    <div
+      role="status"
+      data-testid="source-control-non-active-worktree-notice"
+      className={cn(
+        'flex items-center gap-1.5 border-b border-border bg-muted/40 px-3 py-1 text-[10.5px] text-muted-foreground',
+        className
+      )}
+    >
+      <Eye className="size-3 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+      <span className="min-w-0 truncate">
+        {translate(
+          'auto.components.right.sidebar.SourceControl.worktreePickerNonActiveNotice',
+          'Viewing {{value0}} — changes and commits shown for this worktree',
+          { value0: displayName }
+        )}
+      </span>
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/source-control/review/use-action-model.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/review/use-action-model.ts
@@ -37,7 +37,8 @@ export function useSourceControlActionModel({
   hostedReviewReviewLabel,
   hasSuppressedGitHubPRState,
   conflictOperation,
-  effectiveBaseRef
+  effectiveBaseRef,
+  isSubjectLinkedWorktree
 }: {
   grouped: SourceControlEntryGroups
   commitMessage: string
@@ -53,6 +54,7 @@ export function useSourceControlActionModel({
   branchSummary: GitBranchCompareSummary | null
   branchName: string
   canUseHostedReviewPushTarget: boolean
+  isSubjectLinkedWorktree: boolean
   isCreatePrIntentInFlight: boolean
   remoteStatus: HeaderInput['upstreamStatus']
   hostedReviewState: HeaderInput['prState']
@@ -104,7 +106,8 @@ export function useSourceControlActionModel({
           branchSummary?.status === 'ready' ? (branchSummary.commitsAhead ?? 0) : undefined,
         hasCurrentBranch: Boolean(branchName),
         canPushLinkedReviewWithoutUpstream: canUseHostedReviewPushTarget,
-        isPrIntentInFlight: isCreatePrIntentInFlight
+        isPrIntentInFlight: isCreatePrIntentInFlight,
+        isSubjectLinkedWorktree
       }),
     [
       commitMessage,
@@ -121,6 +124,7 @@ export function useSourceControlActionModel({
       hostedReviewStateForActions,
       canUseHostedReviewPushTarget,
       isCreatePrIntentInFlight,
+      isSubjectLinkedWorktree,
       branchSummary?.commitsAhead,
       branchSummary?.status,
       branchName,
@@ -225,7 +229,8 @@ export function useSourceControlActionModel({
           branchSummary?.status === 'ready' ? (branchSummary.commitsAhead ?? 0) : undefined,
         hasCurrentBranch: Boolean(branchName),
         canPushLinkedReviewWithoutUpstream: canUseHostedReviewPushTarget,
-        rebaseBaseRef: effectiveBaseRef
+        rebaseBaseRef: effectiveBaseRef,
+        isSubjectLinkedWorktree
       }),
     [
       commitMessage,
@@ -245,6 +250,7 @@ export function useSourceControlActionModel({
       hostedReviewStateForActions,
       prGenerating,
       canUseHostedReviewPushTarget,
+      isSubjectLinkedWorktree,
       branchSummary?.commitsAhead,
       branchSummary?.status,
       branchName,

--- a/src/renderer/src/components/right-sidebar/source-control/review/use-action-model.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/review/use-action-model.ts
@@ -38,7 +38,7 @@ export function useSourceControlActionModel({
   hasSuppressedGitHubPRState,
   conflictOperation,
   effectiveBaseRef,
-  isSubjectLinkedWorktree
+  isSubjectLinkedWorktree = false
 }: {
   grouped: SourceControlEntryGroups
   commitMessage: string
@@ -54,7 +54,7 @@ export function useSourceControlActionModel({
   branchSummary: GitBranchCompareSummary | null
   branchName: string
   canUseHostedReviewPushTarget: boolean
-  isSubjectLinkedWorktree: boolean
+  isSubjectLinkedWorktree?: boolean
   isCreatePrIntentInFlight: boolean
   remoteStatus: HeaderInput['upstreamStatus']
   hostedReviewState: HeaderInput['prState']

--- a/src/renderer/src/components/right-sidebar/source-control/sync/use-status-refresh.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/sync/use-status-refresh.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ORCA_TERMINAL_COMMAND_FINISHED_EVENT,
+  type TerminalCommandFinishedEventDetail
+} from '@/hooks/terminal-command-finished-event'
+import {
+  ORCA_WORKTREE_FILE_CHANGE_EVENT,
+  type WorktreeFileChangeEventDetail
+} from '@/hooks/worktree-file-change-event'
+import { useSourceControlStatusRefresh } from './use-status-refresh'
+
+// Why: the module under test shells out to the real git status refresher; a spy lets the test
+// assert which signals actually prod a refresh without touching the filesystem.
+const refreshGitStatusForWorktree = vi.fn()
+
+vi.mock('../../git-status-refresh', () => ({
+  refreshGitStatusForWorktree: (...args: unknown[]) => refreshGitStatusForWorktree(...args)
+}))
+
+vi.mock('../../git-status-file-watch-refresh', () => ({
+  shouldRefreshGitStatusForFileChange: () => true
+}))
+
+vi.mock('@/lib/connection-context', () => ({
+  getConnectionId: () => null
+}))
+
+vi.mock('@/lib/window-visibility-interval', () => ({
+  isWindowVisible: () => true
+}))
+
+vi.mock('@/lib/worktree-runtime-owner', () => ({
+  getRuntimeEnvironmentIdForWorktree: () => 'env-viewed'
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (key: string) => key
+}))
+
+vi.mock('sonner', () => ({
+  toast: { warning: vi.fn() }
+}))
+
+const state = vi.hoisted(() => ({
+  setGitStatus: vi.fn(),
+  updateWorktreeGitIdentity: vi.fn(),
+  setUpstreamStatus: vi.fn(),
+  fetchUpstreamStatus: vi.fn(),
+  activeWorktreeId: 'wt-active'
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (s: typeof state) => unknown) => selector(state)
+}))
+
+function Harness(): React.JSX.Element {
+  useSourceControlStatusRefresh({
+    activeRepoSettings: null,
+    activeWorktreeId: 'wt-viewed',
+    worktreePath: '/repo/viewed',
+    isFolder: false,
+    repositoryHuge: null,
+    activeConnectionId: null,
+    worktreeMap: new Map()
+  })
+  return <div />
+}
+
+describe('useSourceControlStatusRefresh viewed-worktree lane', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    refreshGitStatusForWorktree.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('refreshes once immediately when the picker lands on a non-active worktree', () => {
+    render(<Harness />)
+    // Why: the gate requires the subject to differ from the app-active id; with a 60s interval
+    // and no signal yet, exactly one refresh (the selection seed) must have fired.
+    expect(refreshGitStatusForWorktree).toHaveBeenCalledTimes(1)
+  })
+
+  it('recurringly polls the viewed non-active worktree while visible', () => {
+    render(<Harness />)
+    expect(refreshGitStatusForWorktree).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(60_000)
+    expect(refreshGitStatusForWorktree).toHaveBeenCalledTimes(2)
+  })
+
+  it('debounces a terminal-command-finished signal for the viewed worktree', () => {
+    render(<Harness />)
+    expect(refreshGitStatusForWorktree).toHaveBeenCalledTimes(1)
+    const detail: TerminalCommandFinishedEventDetail = {
+      worktreeId: 'wt-viewed',
+      exitCode: 0
+    }
+    window.dispatchEvent(
+      new CustomEvent(ORCA_TERMINAL_COMMAND_FINISHED_EVENT, { detail })
+    )
+    // Why: only a debounce timer is pending; it must not fire before the floor.
+    expect(refreshGitStatusForWorktree).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(125)
+    expect(refreshGitStatusForWorktree).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores terminal-command-finished signals for other worktrees', () => {
+    render(<Harness />)
+    expect(refreshGitStatusForWorktree).toHaveBeenCalledTimes(1)
+    window.dispatchEvent(
+      new CustomEvent(ORCA_TERMINAL_COMMAND_FINISHED_EVENT, {
+        detail: { worktreeId: 'wt-other', exitCode: null } satisfies TerminalCommandFinishedEventDetail
+      })
+    )
+    vi.advanceTimersByTime(125)
+    expect(refreshGitStatusForWorktree).toHaveBeenCalledTimes(1)
+  })
+
+  it('debounces a matching worktree file-change signal', () => {
+    render(<Harness />)
+    expect(refreshGitStatusForWorktree).toHaveBeenCalledTimes(1)
+    window.dispatchEvent(
+      new CustomEvent(ORCA_WORKTREE_FILE_CHANGE_EVENT, {
+        detail: {
+          runtimeEnvironmentId: 'env-viewed',
+          payload: { worktreePath: '/repo/viewed', events: [] }
+        } satisfies WorktreeFileChangeEventDetail
+      })
+    )
+    vi.advanceTimersByTime(125)
+    expect(refreshGitStatusForWorktree).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores file-change signals from another runtime environment', () => {
+    render(<Harness />)
+    expect(refreshGitStatusForWorktree).toHaveBeenCalledTimes(1)
+    window.dispatchEvent(
+      new CustomEvent(ORCA_WORKTREE_FILE_CHANGE_EVENT, {
+        detail: {
+          runtimeEnvironmentId: 'env-other',
+          payload: { worktreePath: '/repo/viewed', events: [] }
+        } satisfies WorktreeFileChangeEventDetail
+      })
+    )
+    vi.advanceTimersByTime(125)
+    expect(refreshGitStatusForWorktree).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control/sync/use-status-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/sync/use-status-refresh.ts
@@ -6,12 +6,29 @@ import {
   hasDismissedHugeRepoWarning,
   markHugeRepoWarningDismissed
 } from '@/lib/source-control-huge-repo-warning-dismissals'
+import { isWindowVisible } from '@/lib/window-visibility-interval'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { translate } from '@/i18n/i18n'
 import type { RuntimeGitContext } from '@/runtime/runtime-git-client'
 import { useAppStore } from '@/store'
 import type { GitPushTarget } from '../../../../../../shared/worktree/types'
 import type { PullRequestGenerationContext } from '@/store/slices/pull-request-generation'
+import {
+  ORCA_TERMINAL_COMMAND_FINISHED_EVENT,
+  type TerminalCommandFinishedEventDetail
+} from '@/hooks/terminal-command-finished-event'
+import {
+  ORCA_WORKTREE_FILE_CHANGE_EVENT,
+  type WorktreeFileChangeEventDetail
+} from '@/hooks/worktree-file-change-event'
+import { shouldRefreshGitStatusForFileChange } from '../../git-status-file-watch-refresh'
 import { refreshGitStatusForWorktree } from '../../git-status-refresh'
+
+// Why: the global status poller only refreshes the app-active worktree, so a viewed non-active
+// worktree needs its own cadence to keep panel state current while it stays pinned.
+const VIEWED_WORKTREE_POLL_INTERVAL_MS = 60_000
+// Why: file watchers deliver atomic writes as bursts; coalesce them like the app-active lane does.
+const VIEWED_WORKTREE_SIGNAL_DEBOUNCE_MS = 125
 
 export type SourceControlStatusRefresh = {
   refreshActiveGitStatus: (signal?: AbortSignal) => Promise<void>
@@ -47,6 +64,9 @@ export function useSourceControlStatusRefresh({
   const setUpstreamStatus = useAppStore((s) => s.setUpstreamStatus)
   const fetchUpstreamStatus = useAppStore((s) => s.fetchUpstreamStatus)
   const appActiveWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const viewedWorktreeRuntimeEnvironmentId = useAppStore((s) =>
+    getRuntimeEnvironmentIdForWorktree(s, activeWorktreeId)
+  )
   const refreshActiveGitStatus = useCallback(
     async (signal?: AbortSignal): Promise<void> => {
       if (!activeWorktreeId || !worktreePath || isFolder) {
@@ -90,7 +110,7 @@ export function useSourceControlStatusRefresh({
   }, [refreshActiveGitStatus])
 
   // Why: the global status poller only refreshes the app-active worktree; a viewed non-active
-  // worktree gets one refresh when the picker lands on it so its changes appear immediately.
+  // worktree keeps its own cadence so its panel state stays current while it is pinned.
   useEffect(() => {
     if (
       !activeWorktreeId ||
@@ -101,7 +121,76 @@ export function useSourceControlStatusRefresh({
       return
     }
     void refreshActiveGitStatus()
-  }, [activeWorktreeId, appActiveWorktreeId, isFolder, refreshActiveGitStatus, worktreePath])
+
+    let intervalId: number | null = null
+    let refreshTimer: ReturnType<typeof setTimeout> | null = null
+
+    const scheduleRefresh = (): void => {
+      if (!isWindowVisible()) {
+        return
+      }
+      if (refreshTimer) {
+        clearTimeout(refreshTimer)
+      }
+      // Why: file watchers deliver atomic writes as bursts; coalesce them like the app-active lane does.
+      refreshTimer = setTimeout(() => {
+        refreshTimer = null
+        if (!isWindowVisible()) {
+          return
+        }
+        void refreshActiveGitStatus()
+      }, VIEWED_WORKTREE_SIGNAL_DEBOUNCE_MS)
+    }
+
+    intervalId = window.setInterval(() => {
+      if (isWindowVisible()) {
+        void refreshActiveGitStatus()
+      }
+    }, VIEWED_WORKTREE_POLL_INTERVAL_MS)
+
+    const handleCommandFinished = (event: Event): void => {
+      const detail = (event as CustomEvent<TerminalCommandFinishedEventDetail>).detail
+      if (detail?.worktreeId !== activeWorktreeId) {
+        return
+      }
+      scheduleRefresh()
+    }
+    window.addEventListener(ORCA_TERMINAL_COMMAND_FINISHED_EVENT, handleCommandFinished)
+
+    const handleWorktreeFileChange = (event: Event): void => {
+      const detail = (event as CustomEvent<WorktreeFileChangeEventDetail>).detail
+      if (!detail) {
+        return
+      }
+      if (
+        (detail.runtimeEnvironmentId ?? null) !== (viewedWorktreeRuntimeEnvironmentId ?? null)
+      ) {
+        return
+      }
+      if (shouldRefreshGitStatusForFileChange(detail.payload, worktreePath)) {
+        scheduleRefresh()
+      }
+    }
+    window.addEventListener(ORCA_WORKTREE_FILE_CHANGE_EVENT, handleWorktreeFileChange)
+
+    return () => {
+      if (intervalId) {
+        window.clearInterval(intervalId)
+      }
+      if (refreshTimer) {
+        clearTimeout(refreshTimer)
+      }
+      window.removeEventListener(ORCA_TERMINAL_COMMAND_FINISHED_EVENT, handleCommandFinished)
+      window.removeEventListener(ORCA_WORKTREE_FILE_CHANGE_EVENT, handleWorktreeFileChange)
+    }
+  }, [
+    activeWorktreeId,
+    appActiveWorktreeId,
+    isFolder,
+    refreshActiveGitStatus,
+    viewedWorktreeRuntimeEnvironmentId,
+    worktreePath
+  ])
 
   // Why: when status is truncated, offer once per worktree to .gitignore the flooding folder; local-only since the SSH huge-folder write path isn't wired.
   useEffect(() => {

--- a/src/renderer/src/components/right-sidebar/source-control/sync/use-status-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/sync/use-status-refresh.ts
@@ -46,6 +46,7 @@ export function useSourceControlStatusRefresh({
   const updateWorktreeGitIdentity = useAppStore((s) => s.updateWorktreeGitIdentity)
   const setUpstreamStatus = useAppStore((s) => s.setUpstreamStatus)
   const fetchUpstreamStatus = useAppStore((s) => s.fetchUpstreamStatus)
+  const appActiveWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const refreshActiveGitStatus = useCallback(
     async (signal?: AbortSignal): Promise<void> => {
       if (!activeWorktreeId || !worktreePath || isFolder) {
@@ -87,6 +88,20 @@ export function useSourceControlStatusRefresh({
       console.warn('[SourceControl] post-mutation git status refresh failed', error)
     }
   }, [refreshActiveGitStatus])
+
+  // Why: the global status poller only refreshes the app-active worktree; a viewed non-active
+  // worktree gets one refresh when the picker lands on it so its changes appear immediately.
+  useEffect(() => {
+    if (
+      !activeWorktreeId ||
+      !worktreePath ||
+      isFolder ||
+      activeWorktreeId === appActiveWorktreeId
+    ) {
+      return
+    }
+    void refreshActiveGitStatus()
+  }, [activeWorktreeId, appActiveWorktreeId, isFolder, refreshActiveGitStatus, worktreePath])
 
   // Why: when status is truncated, offer once per worktree to .gitignore the flooding folder; local-only since the SSH huge-folder write path isn't wired.
   useEffect(() => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12552,7 +12552,8 @@
                   "f0c6e2a581": "This branch is not ready for a {{value0}} yet.",
                   "8f9a0b1c2d": "Nothing to commit. Branch is up to date.",
                   "h3i4j5k607": "Checking whether this branch can create a {{value0}}…",
-                  "pull_unavailable_on_worktree": "Pull is not available on a linked worktree."
+                  "pull_unavailable_on_worktree": "Pull is not available on a linked worktree.",
+                  "push_unavailable_on_worktree": "Diverged from remote. Push is not available on a linked worktree — reconcile on the main checkout."
                 }
               },
               "branch": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12036,7 +12036,13 @@
             "a4e93c21d7": "Current branch: {{value0}}",
             "c7d4e2f801": "Change base ref: {{value0}}",
             "f3a1b8c204": "upstream",
-            "createPrIntentGenerateDetailsFailed": "Could not generate review details. Retry Create PR."
+            "createPrIntentGenerateDetailsFailed": "Could not generate review details. Retry Create PR.",
+            "worktreePickerTriggerTitle": "Worktree: {{value0}}",
+            "worktreePickerSearchPlaceholder": "Search worktrees…",
+            "worktreePickerEmpty": "No worktrees match your search.",
+            "worktreePickerMainBadge": "Main",
+            "worktreePickerCurrentBadge": "Current",
+            "worktreePickerNonActiveNotice": "Viewing {{value0}} — changes and commits shown for this worktree"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "Could not start the selected agent.",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12551,7 +12551,8 @@
                   "e9b5d1f470": "Check out a branch before creating a {{value0}}.",
                   "f0c6e2a581": "This branch is not ready for a {{value0}} yet.",
                   "8f9a0b1c2d": "Nothing to commit. Branch is up to date.",
-                  "h3i4j5k607": "Checking whether this branch can create a {{value0}}…"
+                  "h3i4j5k607": "Checking whether this branch can create a {{value0}}…",
+                  "pull_unavailable_on_worktree": "Pull is not available on a linked worktree."
                 }
               },
               "branch": {

--- a/src/shared/source-control-primary-action-decision-types.ts
+++ b/src/shared/source-control-primary-action-decision-types.ts
@@ -48,6 +48,7 @@ export type SourceControlPrimaryActionTitleIntent =
   | 'nothing_to_commit_up_to_date'
   | 'checking_review_creation'
   | 'pull_unavailable_on_worktree'
+  | 'push_unavailable_on_worktree'
 
 export type SourceControlPrimaryActionDecision = {
   kind: SourceControlPrimaryActionKind

--- a/src/shared/source-control-primary-action-decision-types.ts
+++ b/src/shared/source-control-primary-action-decision-types.ts
@@ -47,6 +47,7 @@ export type SourceControlPrimaryActionTitleIntent =
   | 'create_review'
   | 'nothing_to_commit_up_to_date'
   | 'checking_review_creation'
+  | 'pull_unavailable_on_worktree'
 
 export type SourceControlPrimaryActionDecision = {
   kind: SourceControlPrimaryActionKind
@@ -94,4 +95,7 @@ export type SourceControlPrimaryActionDecisionInputs = {
   canPushLinkedReviewWithoutUpstream?: boolean
   isPrIntentInFlight?: boolean
   isHostedReviewCreationLoading?: boolean
+  /** True when the Source Control subject is a git linked worktree (not the main checkout).
+   *  Pushing stays available, but pull/sync merge into the local branch and are not offered. */
+  isSubjectLinkedWorktree?: boolean
 }

--- a/src/shared/source-control-primary-action-decision.test.ts
+++ b/src/shared/source-control-primary-action-decision.test.ts
@@ -194,7 +194,7 @@ describe('source-control primary action decision', () => {
     })
   })
 
-  it('returns push instead of sync on a linked worktree when diverged', () => {
+  it('returns a disabled push on a linked worktree when diverged without patch-equivalence', () => {
     const result = resolveSourceControlCommitAreaPrimaryActionDecision(
       inputs({
         upstreamStatus: { hasUpstream: true, ahead: 2, behind: 3 },
@@ -203,8 +203,28 @@ describe('source-control primary action decision', () => {
     )
     expect(result).toMatchObject({
       kind: 'push',
-      titleIntent: 'push_count',
+      titleIntent: 'push_unavailable_on_worktree',
       count: 2,
+      disabled: true
+    })
+  })
+
+  it('offers force-push-with-lease on a linked worktree when diverged and patch-equivalent', () => {
+    const result = resolveSourceControlCommitAreaPrimaryActionDecision(
+      inputs({
+        upstreamStatus: {
+          hasUpstream: true,
+          ahead: 2,
+          behind: 3,
+          behindCommitsArePatchEquivalent: true
+        },
+        isSubjectLinkedWorktree: true
+      })
+    )
+    expect(result).toMatchObject({
+      kind: 'push',
+      labelIntent: 'force_push',
+      titleIntent: 'force_push_with_lease',
       disabled: false
     })
   })

--- a/src/shared/source-control-primary-action-decision.test.ts
+++ b/src/shared/source-control-primary-action-decision.test.ts
@@ -165,6 +165,60 @@ describe('source-control primary action decision', () => {
     expect(resolveSourceControlCommitAreaPrimaryActionDecision(input).kind).toBe('commit')
   })
 
+  it('returns disabled pull-blocked action on a linked worktree when behind only', () => {
+    const result = resolveSourceControlCommitAreaPrimaryActionDecision(
+      inputs({
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 3 },
+        isSubjectLinkedWorktree: true
+      })
+    )
+    expect(result).toMatchObject({
+      kind: 'commit',
+      titleIntent: 'pull_unavailable_on_worktree',
+      disabled: true
+    })
+  })
+
+  it('keeps push available on a linked worktree with no upstream', () => {
+    const result = resolveSourceControlCommitAreaPrimaryActionDecision(
+      inputs({
+        upstreamStatus: { hasUpstream: false, ahead: 0, behind: 0 },
+        hasCurrentBranch: true,
+        isSubjectLinkedWorktree: true
+      })
+    )
+    expect(result).toMatchObject({
+      kind: 'publish',
+      titleIntent: 'publish_branch',
+      disabled: false
+    })
+  })
+
+  it('returns push instead of sync on a linked worktree when diverged', () => {
+    const result = resolveSourceControlCommitAreaPrimaryActionDecision(
+      inputs({
+        upstreamStatus: { hasUpstream: true, ahead: 2, behind: 3 },
+        isSubjectLinkedWorktree: true
+      })
+    )
+    expect(result).toMatchObject({
+      kind: 'push',
+      titleIntent: 'push_count',
+      count: 2,
+      disabled: false
+    })
+  })
+
+  it('keeps pull for the main checkout when behind', () => {
+    const result = resolveSourceControlCommitAreaPrimaryActionDecision(
+      inputs({
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 3 },
+        isSubjectLinkedWorktree: false
+      })
+    )
+    expect(result).toMatchObject({ kind: 'pull', titleIntent: 'pull_count', disabled: false })
+  })
+
   it('returns disabled create review while hosted-review creation eligibility is loading', () => {
     const input = inputs({
       upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 },

--- a/src/shared/source-control-primary-action-decision.ts
+++ b/src/shared/source-control-primary-action-decision.ts
@@ -36,7 +36,8 @@ export function resolveSourceControlPrimaryActionDecision(
     hasCurrentBranch = true,
     canPushLinkedReviewWithoutUpstream = false,
     isPrIntentInFlight = false,
-    isHostedReviewCreationLoading = false
+    isHostedReviewCreationLoading = false,
+    isSubjectLinkedWorktree = false
   } = inputs
 
   if (isPrIntentInFlight) {
@@ -162,6 +163,16 @@ export function resolveSourceControlPrimaryActionDecision(
         requiresForceWithLease: true
       }
     }
+    if (isSubjectLinkedWorktree) {
+      // Why: Sync would merge remote into the local branch (a pull), which is disallowed on a worktree.
+      return {
+        kind: 'push',
+        labelIntent: 'push',
+        titleIntent: 'push_count',
+        disabled: false,
+        count: upstreamStatus.ahead
+      }
+    }
     return {
       kind: 'sync',
       labelIntent: 'sync',
@@ -173,6 +184,14 @@ export function resolveSourceControlPrimaryActionDecision(
   }
 
   if (upstreamStatus.behind > 0) {
+    if (isSubjectLinkedWorktree) {
+      return {
+        kind: 'commit',
+        labelIntent: 'commit',
+        titleIntent: 'pull_unavailable_on_worktree',
+        disabled: true
+      }
+    }
     return {
       kind: 'pull',
       labelIntent: 'pull',

--- a/src/shared/source-control-primary-action-decision.ts
+++ b/src/shared/source-control-primary-action-decision.ts
@@ -164,12 +164,14 @@ export function resolveSourceControlPrimaryActionDecision(
       }
     }
     if (isSubjectLinkedWorktree) {
-      // Why: Sync would merge remote into the local branch (a pull), which is disallowed on a worktree.
+      // Why: a diverged branch cannot fast-forward with a plain push (git rejects
+      // non-fast-forward), and force-push would rewrite remote history the worktree
+      // hasn't reconciled. Reconcile on the main checkout instead.
       return {
         kind: 'push',
         labelIntent: 'push',
-        titleIntent: 'push_count',
-        disabled: false,
+        titleIntent: 'push_unavailable_on_worktree',
+        disabled: true,
         count: upstreamStatus.ahead
       }
     }


### PR DESCRIPTION
## Summary

Adds worktree selection to the Source Control view:

- **Worktree picker in the source-control header**: pick any detected git worktree to inspect its status and commits without switching the active workspace. The panel pins to the chosen worktree and falls back to the app-active one.
- **Picker lists all detected worktrees** — not just the ones visible in the sidebar.
- **Push/pull gating by worktree kind**: push/publish works on a linked worktree (publishes the branch to origin), while pull, fast-forward, sync and commit-sync are disabled on a linked worktree with explanatory tooltips; the main checkout keeps pull working.

## Why

A multi-worktree workflow needs a way to look at another worktree's state from the active one, and the pull/sync actions must not be offered on a linked worktree where they would be unsafe or misleading.

## Changes

- Adds `worktree-picker` (picker UI, filter, tests) and `use-source-control-view-worktree-selection` (pin/fallback logic, tests) under the source-control panel.
- Threads `subjectWorktreeId` through the panel state; the picker's selection drives which worktree's status is shown.
- Threads `isSubjectLinkedWorktree` through the primary-action decision and dropdown resolvers; pull/sync/fast-forward/commit-sync are disabled on a linked worktree, push/force-push/fetch/publish remain available.
- Includes detected worktrees in the picker list (not just sidebar-visible ones).
- Adds the missing localization keys (including the linked-worktree pull gate) so `verify:localization-catalog` passes.

## Verification

- `typecheck:web` passes.
- Source-control test suites pass (44 files, 422 tests) plus the SourceControl top-level suites and the new feature tests.
- `verify:localization-catalog` passes.
- oxlint clean on all changed files.
