### PR TITLE
perf(main): summarize workspace space rows in one pass

### DIFF
--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -14,6 +14,7 @@ import {
 } from './workspace-space-scan-control'
 import {
   scanWorkspaceSpaceRepo,
+  summarizeWorkspaceSpaceRows,
   type WorkspaceSpaceAnalyzeOptions,
   type WorkspaceSpaceScanLimiters
 } from './workspace-space-repo-scan'
@@ -152,15 +153,20 @@ export async function analyzeWorkspaceSpace(
     .flatMap((result) => result.worktrees)
     .sort((a, b) => b.sizeBytes - a.sizeBytes || a.displayName.localeCompare(b.displayName))
   throwIfWorkspaceSpaceScanAborted(options.signal)
+  const summary = summarizeWorkspaceSpaceRows(worktrees)
+  let unavailableRepoCount = 0
+  for (const repo of repos) {
+    if (repo.error !== null) {
+      unavailableRepoCount += 1
+    }
+  }
   return {
     scannedAt,
-    totalSizeBytes: worktrees.reduce((sum, row) => sum + row.sizeBytes, 0),
-    reclaimableBytes: worktrees.reduce((sum, row) => sum + row.reclaimableBytes, 0),
+    totalSizeBytes: summary.totalSizeBytes,
+    reclaimableBytes: summary.reclaimableBytes,
     worktreeCount: worktrees.length,
-    scannedWorktreeCount: worktrees.filter((row) => row.status === 'ok').length,
-    unavailableWorktreeCount:
-      worktrees.filter((row) => row.status !== 'ok').length +
-      repos.filter((repo) => repo.error !== null).length,
+    scannedWorktreeCount: summary.scannedWorktreeCount,
+    unavailableWorktreeCount: summary.unavailableWorktreeCount + unavailableRepoCount,
     repos,
     worktrees
   }

--- a/src/main/workspace-space-repo-scan.test.ts
+++ b/src/main/workspace-space-repo-scan.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import type { WorkspaceSpaceWorktree } from '../shared/workspace-space-types'
+import { summarizeWorkspaceSpaceRows } from './workspace-space-repo-scan'
+
+describe('summarizeWorkspaceSpaceRows', () => {
+  it('reads each summary field once per row', () => {
+    const reads = { status: 0, sizeBytes: 0, reclaimableBytes: 0 }
+    const makeRow = (status: WorkspaceSpaceWorktree['status']) =>
+      new Proxy({ status, sizeBytes: 10, reclaimableBytes: 4 } as WorkspaceSpaceWorktree, {
+        get(target, property, receiver) {
+          if (
+            property === 'status' ||
+            property === 'sizeBytes' ||
+            property === 'reclaimableBytes'
+          ) {
+            reads[property] += 1
+          }
+          return Reflect.get(target, property, receiver)
+        }
+      })
+
+    expect(summarizeWorkspaceSpaceRows([makeRow('ok'), makeRow('unavailable')])).toEqual({
+      scannedWorktreeCount: 1,
+      unavailableWorktreeCount: 1,
+      totalSizeBytes: 20,
+      reclaimableBytes: 8
+    })
+    expect(reads).toEqual({ status: 2, sizeBytes: 2, reclaimableBytes: 2 })
+  })
+})

--- a/src/main/workspace-space-repo-scan.ts
+++ b/src/main/workspace-space-repo-scan.ts
@@ -52,6 +52,33 @@ export type WorkspaceSpaceRepoScanResult = {
   worktrees: WorkspaceSpaceWorktree[]
 }
 
+export function summarizeWorkspaceSpaceRows(
+  rows: readonly WorkspaceSpaceWorktree[]
+): Pick<
+  WorkspaceSpaceRepoSummary,
+  'scannedWorktreeCount' | 'unavailableWorktreeCount' | 'totalSizeBytes' | 'reclaimableBytes'
+> {
+  let scannedWorktreeCount = 0
+  let unavailableWorktreeCount = 0
+  let totalSizeBytes = 0
+  let reclaimableBytes = 0
+  for (const row of rows) {
+    if (row.status === 'ok') {
+      scannedWorktreeCount += 1
+    } else {
+      unavailableWorktreeCount += 1
+    }
+    totalSizeBytes += row.sizeBytes
+    reclaimableBytes += row.reclaimableBytes
+  }
+  return {
+    scannedWorktreeCount,
+    unavailableWorktreeCount,
+    totalSizeBytes,
+    reclaimableBytes
+  }
+}
+
 async function listWorktreesForSpaceScan(
   store: Store,
   repo: Repo,
@@ -230,6 +257,7 @@ export async function scanWorkspaceSpaceRepo(args: {
     },
     options.onProgress
   )
+  const summary = summarizeWorkspaceSpaceRows(rows)
   return {
     worktrees: rows,
     summary: {
@@ -239,10 +267,7 @@ export async function scanWorkspaceSpaceRepo(args: {
       path: repo.path,
       isRemote: Boolean(repo.connectionId),
       worktreeCount: rows.length,
-      scannedWorktreeCount: rows.filter((row) => row.status === 'ok').length,
-      unavailableWorktreeCount: rows.filter((row) => row.status !== 'ok').length,
-      totalSizeBytes: rows.reduce((sum, row) => sum + row.sizeBytes, 0),
-      reclaimableBytes: rows.reduce((sum, row) => sum + row.reclaimableBytes, 0),
+      ...summary,
       error: null
     }
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 |

<!-- /orca-pr-loc -->

## ELI5
Workspace Space counted the same worktree list four separate times to total bytes and statuses. We now walk it once and keep the same answers, so large scans spend less CPU on bookkeeping.

## Performance Measurement
Deterministic 1,000-worktree projection (10 repos): the old per-repo + global summaries performed 8,010 array callback visits (four row traversals in each summary plus repo-error checks); the one-pass helper performs 2,010 visits (two row traversals plus repo-error checks), a 74.9% reduction. Summary-field reads fall from 8,010 to 6,010 (24.9% fewer: status is read once instead of twice per summary). The focused getter-count test verifies one read of each field per row.

Validation:
- `pnpm test src/main/workspace-space-repo-scan.test.ts src/main/workspace-space-analysis.test.ts` (12 passed)
- `pnpm tc:node`
- `pnpm exec oxlint src/main/workspace-space-analysis.ts src/main/workspace-space-repo-scan.ts src/main/workspace-space-repo-scan.test.ts`
- `pnpm exec oxfmt --check src/main/workspace-space-analysis.ts src/main/workspace-space-repo-scan.ts src/main/workspace-space-repo-scan.test.ts`

## User-Facing Trade-offs
None. Ordering, status classification, byte totals, cancellation, and SSH/local behavior are unchanged.