### PR TITLE
perf(renderer): memoize active worktree editor files

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -163,6 +163,7 @@ import { resumeSleepingAgentSessionsForWorktree } from '@/lib/resume-sleeping-ag
 import { listBoundAgentTabActions, resolveDefaultAgentForNewTab } from '@/lib/agent-tab-shortcuts'
 import { terminalProviderHasAuthoritativeSnapshot } from './terminal/terminal-provider-snapshot-capability'
 import { useTerminalProviderSnapshotCapability } from './terminal/use-terminal-provider-snapshot-capability'
+import { useWorktreeFiles } from './terminal/use-worktree-files'
 import {
   createFloatingWorkspaceBrowserTab,
   createFloatingWorkspaceMarkdownTab,
@@ -460,9 +461,7 @@ function Terminal(): React.JSX.Element | null {
   }, [activeWorktreeId, ensureWorktreeRootGroup])
 
   // Filter editor files to only show those belonging to the active worktree
-  const worktreeFiles = renderedActiveWorktreeId
-    ? openFiles.filter((f) => f.worktreeId === renderedActiveWorktreeId)
-    : []
+  const worktreeFiles = useWorktreeFiles(openFiles, renderedActiveWorktreeId)
   const worktreeBrowserTabs = renderedActiveWorktreeId
     ? (browserTabsByWorktree[renderedActiveWorktreeId] ?? [])
     : []

--- a/src/renderer/src/components/terminal/use-worktree-files.test.tsx
+++ b/src/renderer/src/components/terminal/use-worktree-files.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import { useWorktreeFiles } from './use-worktree-files'
+
+const ACTIVE_WORKTREE_ID = 'wt-active'
+const OTHER_WORKTREE_ID = 'wt-other'
+type WorktreeFilesProps = { openFiles: OpenFile[]; worktreeId: string | null }
+
+function installFilterReadCounter(files: OpenFile[], worktreeIdReads: { value: number }): void {
+  const filter = files.filter.bind(files)
+  Object.defineProperty(files, 'filter', {
+    configurable: true,
+    value: (predicate: (file: OpenFile, index: number, array: OpenFile[]) => unknown): OpenFile[] =>
+      filter((file, index, array) => {
+        worktreeIdReads.value += 1
+        return predicate(file, index, array)
+      })
+  })
+}
+
+function makeCountedOpenFiles(count: number): {
+  files: OpenFile[]
+  worktreeIdReads: { value: number }
+} {
+  const worktreeIdReads = { value: 0 }
+  const files = Array.from({ length: count }, (_, index) => {
+    const worktreeId = index % 2 === 0 ? ACTIVE_WORKTREE_ID : OTHER_WORKTREE_ID
+    return {
+      id: `file-${index}`,
+      filePath: `/repo/${index}.ts`,
+      relativePath: `${index}.ts`,
+      language: 'typescript',
+      isDirty: false,
+      mode: 'edit',
+      worktreeId
+    } as OpenFile
+  })
+  installFilterReadCounter(files, worktreeIdReads)
+  return { files, worktreeIdReads }
+}
+
+afterEach(cleanup)
+
+describe('useWorktreeFiles', () => {
+  it('does not rescan stable open files across 100 unchanged renders', () => {
+    const { files, worktreeIdReads } = makeCountedOpenFiles(10_000)
+    const view = renderHook<OpenFile[], WorktreeFilesProps>(
+      ({ openFiles, worktreeId }: WorktreeFilesProps) => useWorktreeFiles(openFiles, worktreeId),
+      {
+        initialProps: {
+          openFiles: files,
+          worktreeId: ACTIVE_WORKTREE_ID
+        } satisfies WorktreeFilesProps
+      }
+    )
+    const first = view.result.current
+
+    expect(first).toHaveLength(5_000)
+    expect(worktreeIdReads.value).toBe(10_000)
+
+    for (let render = 0; render < 100; render += 1) {
+      view.rerender({ openFiles: files, worktreeId: ACTIVE_WORKTREE_ID })
+    }
+
+    expect(view.result.current).toBe(first)
+    expect(worktreeIdReads.value).toBe(10_000)
+  })
+
+  it('recomputes when the open-file array or rendered worktree changes', () => {
+    const { files, worktreeIdReads } = makeCountedOpenFiles(10)
+    const view = renderHook<OpenFile[], WorktreeFilesProps>(
+      ({ openFiles, worktreeId }: WorktreeFilesProps) => useWorktreeFiles(openFiles, worktreeId),
+      {
+        initialProps: {
+          openFiles: files,
+          worktreeId: ACTIVE_WORKTREE_ID
+        } satisfies WorktreeFilesProps
+      }
+    )
+    const first = view.result.current
+    expect(first).toHaveLength(5)
+    expect(worktreeIdReads.value).toBe(10)
+
+    const replacementFiles = [...files]
+    installFilterReadCounter(replacementFiles, worktreeIdReads)
+    view.rerender({ openFiles: replacementFiles, worktreeId: ACTIVE_WORKTREE_ID })
+    const replacement = view.result.current
+    expect(replacement).not.toBe(first)
+    expect(replacement).toHaveLength(5)
+    expect(worktreeIdReads.value).toBe(20)
+
+    view.rerender({ openFiles: replacementFiles, worktreeId: OTHER_WORKTREE_ID })
+    expect(view.result.current).toHaveLength(5)
+    expect(view.result.current).not.toBe(replacement)
+    expect(worktreeIdReads.value).toBe(30)
+
+    view.rerender({ openFiles: replacementFiles, worktreeId: null })
+    expect(view.result.current).toEqual([])
+    expect(worktreeIdReads.value).toBe(30)
+  })
+})

--- a/src/renderer/src/components/terminal/use-worktree-files.ts
+++ b/src/renderer/src/components/terminal/use-worktree-files.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react'
+import type { OpenFile } from '@/store/slices/editor'
+
+/** Returns the editor files owned by the rendered worktree. */
+export function useWorktreeFiles(
+  openFiles: readonly OpenFile[],
+  renderedActiveWorktreeId: string | null
+): OpenFile[] {
+  return useMemo(
+    () =>
+      renderedActiveWorktreeId
+        ? openFiles.filter((file) => file.worktreeId === renderedActiveWorktreeId)
+        : [],
+    [openFiles, renderedActiveWorktreeId]
+  )
+}


### PR DESCRIPTION
## ELI5

Terminal renders often happen for reasons unrelated to editor tabs. The active worktree file list is unchanged in those renders, so the renderer now remembers the filtered list until either the open-file array or rendered worktree changes.

## Performance Measurement

A deterministic renderHook fixture with 10,000 open files and 100 unchanged rerenders counted the worktree predicate reads:

- Before: 1,010,000 reads (10,000 initial + 100 × 10,000 rerenders).
- After: 10,000 reads (initial projection only; unchanged rerenders reuse the same array).
- Reduction: 1,000,000 reads, or 99.0% fewer predicate reads in this fixture.

The regression test also verifies recomputation when either dependency changes and preserves the null-worktree empty result.

## User-Facing Trade-offs

None. The filtered result and invalidation behavior are unchanged; only redundant renders skip the scan.

## Validation

- Focused Vitest regression: passed (2 tests).
- pnpm tc:web: passed.
- oxlint: passed.
- oxfmt --check: passed.
- Visual proof: N/A — this is a render-time memoization with no intended visual or interaction change.