### PR TITLE
fix(browser): refuse DevTools for offscreen guests

### DIFF
--- a/src/main/browser/browser-manager-guest-lifecycle.test.ts
+++ b/src/main/browser/browser-manager-guest-lifecycle.test.ts
@@ -174,6 +174,52 @@ describe('browserManager', () => {
     }
   )
 
+  it('refuses devtools for an offscreen guest instead of opening it on the host display', async () => {
+    const guest = {
+      id: 138,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'window'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    webContentsFromIdMock.mockReturnValue(guest)
+    expect(
+      browserManager.registerOffscreenGuest({
+        browserPageId: 'offscreen-devtools',
+        webContentsId: guest.id
+      })
+    ).toBe(true)
+
+    await expect(browserManager.openDevTools('offscreen-devtools')).resolves.toBe(false)
+    expect(guestOpenDevToolsMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps devtools available for a desktop webview guest', async () => {
+    const guest = {
+      id: 139,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    webContentsFromIdMock.mockReturnValue(guest)
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'desktop-devtools',
+      webContentsId: guest.id,
+      rendererWebContentsId
+    })
+
+    await expect(browserManager.openDevTools('desktop-devtools')).resolves.toBe(true)
+    expect(guestOpenDevToolsMock).toHaveBeenCalledWith({ mode: 'detach' })
+  })
+
   // Why the exit door needs the same check: a document page withdraws by revoking its grant, so its
   // id here is misaddressed — and unregistering opens by evicting whatever grab that id names.
   it('refuses unregisterGuest for a page the document registry holds', () => {

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -1876,6 +1876,11 @@ export class BrowserManager {
       this.unregisterGuest(browserTabId)
       return false
     }
+    // Offscreen guests have no visible window on this desktop; detaching DevTools would open it
+    // on the host display with no route back to the remote client.
+    if (this.offscreenGuestIds.has(webContentsId)) {
+      return false
+    }
     guest.openDevTools({ mode: 'detach' })
     return true
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

Related to #17406

## Summary
- refuse detached DevTools for hidden offscreen browser guests
- preserve DevTools for desktop webview and client-hosted browser guests
- add lifecycle coverage for both ownership paths

## Why
Offscreen/headless pages are backed by hidden main-process BrowserWindows and only the page WebContents is streamed to remote clients. Detaching DevTools otherwise opens an unreachable window on the host display. The guard is at BrowserManager, the shared guest ownership boundary; current streamed remote UI already omits Inspect.

## Validation
- deterministic paired headed/headless browser fixture: 2/2
- browser-manager tests: 147/147
- focused lifecycle tests: 19/19
- browser/IPC/UI suite: 120/120
- Node typecheck, changed-code quality, oxlint, formatting, and diff checks passed
- reverted guard oracle reproduces the detached-host behavior and fails the regression test

No remote wire changes or client-rendered DevTools transport are included.