### PR TITLE
fix(orchestration): explain invalid send message types

### DIFF
--- a/src/cli/specs/orchestration.test.ts
+++ b/src/cli/specs/orchestration.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { ORCHESTRATION_COMMAND_SPECS } from './orchestration'
+
+describe('orchestration send command spec', () => {
+  it('documents valid message types and the question reply path', () => {
+    const sendSpec = ORCHESTRATION_COMMAND_SPECS.find(
+      (spec) => spec.path.join(' ') === 'orchestration send'
+    )
+
+    expect(sendSpec?.notes).toEqual(
+      expect.arrayContaining([
+        'Valid --type values: status, dispatch, worker_done, merge_ready, escalation, handoff, decision_gate, question, heartbeat.',
+        'To answer a worker question, use orchestration reply --id <msg_id> --body <text> with the same Orca CLI executable.'
+      ])
+    )
+  })
+})

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -68,6 +68,8 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
       'phase'
     ],
     notes: [
+      'Valid --type values: status, dispatch, worker_done, merge_ready, escalation, handoff, decision_gate, question, heartbeat.',
+      'To answer a worker question, use orchestration reply --id <msg_id> --body <text> with the same Orca CLI executable.',
       'On Windows PowerShell, quote group addresses such as --to "@all" or --to "@worktree:<id>".',
       "worker_done and heartbeat are exact-Dispatch signals and cannot target groups; omit --to to use the Dispatch's Run mailbox.",
       'worker_done requires --outcome succeeded or --outcome failed.',

--- a/src/main/runtime/rpc/methods/orchestration-send-invalid-type.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-send-invalid-type.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { RpcRequest } from '../core'
+import { ORCHESTRATION_METHODS } from './orchestration'
+import { RpcDispatcher } from '../dispatcher'
+import { createOrchestrationRpcHarness } from './orchestration-rpc-test-harness'
+import { ORCHESTRATION_CONTRACT_VERSION } from '../../../../shared/protocol-version'
+
+describe('orchestration.send invalid message type', () => {
+  const h = createOrchestrationRpcHarness()
+
+  afterEach(() => {
+    h.cleanup()
+  })
+
+  it('explains valid message types and the question reply path', async () => {
+    const { runtime, ctx } = h.setup()
+    const dispatcher = new RpcDispatcher({ runtime, methods: ORCHESTRATION_METHODS })
+    const request: RpcRequest = {
+      id: 'req_1',
+      authToken: 'token',
+      method: 'orchestration.send',
+      params: { to: 'b', subject: 'hi', type: 'answer' },
+      orchestrationContractVersion: ORCHESTRATION_CONTRACT_VERSION
+    }
+
+    const response = await dispatcher.dispatch(request, ctx)
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: {
+        code: 'invalid_argument',
+        message:
+          'Invalid --type. Expected one of: status, dispatch, worker_done, merge_ready, escalation, handoff, decision_gate, question, heartbeat. To answer a worker question, use the same Orca CLI executable with orchestration reply --id <msg_id> --body <text>.'
+      }
+    })
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -74,6 +74,11 @@ async function routeAllMailboxPages(
 
 type DispatchMutationMessageType = 'worker_done' | 'heartbeat' | 'escalation' | 'decision_gate'
 
+const SEND_MESSAGE_TYPE_ERROR = [
+  `Invalid --type. Expected one of: ${MESSAGE_TYPES.join(', ')}.`,
+  'To answer a worker question, use the same Orca CLI executable with orchestration reply --id <msg_id> --body <text>.'
+].join(' ')
+
 function isDispatchMutationMessageType(
   type: string | undefined
 ): type is DispatchMutationMessageType {
@@ -130,17 +135,9 @@ const SendParams = z
     from: OptionalString,
     body: OptionalString,
     type: z
-      .enum([
-        'status',
-        'dispatch',
-        'worker_done',
-        'merge_ready',
-        'escalation',
-        'handoff',
-        'decision_gate',
-        'question',
-        'heartbeat'
-      ])
+      .enum(MESSAGE_TYPES, {
+        error: SEND_MESSAGE_TYPE_ERROR
+      })
       .optional(),
     priority: z.enum(['normal', 'high', 'urgent']).optional(),
     threadId: OptionalString,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 |

<!-- /orca-pr-loc -->

## Summary\n\n- Make invalid orchestration send --type errors list supported message types.\n- Direct users answering worker questions to orchestration reply --id <msg_id> --body <text>.\n- Document the guidance in send --help.\n\n## Validation\n\n- origin/main baseline repro still returns bare Invalid input.\n- Reverted schema oracle fails the regression; candidate passes.\n- Focused RPC, CLI-spec, and SSH tests: 66 passed.\n- tc:cli, changed-code quality, formatting, bundled-guide verification, and CLI build pass.\n- tc:node attempted after rebasing onto current main but exhausted local Node heap during the repository-wide check.\n\nNo valid orchestration semantics or wire fields changed.