### PR TITLE
Fix duplicated Codex startup command in new agent tabs

### DIFF
--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
@@ -365,6 +365,37 @@ if [[ -n "$__orca_ready_marker" ]]; then
 fi
 __orca_append_prompt_command '__orca_in_debug_capture=1; __orca_prompt_had_functrace=""; if [[ -o functrace ]]; then __orca_prompt_had_functrace=1; set +T; fi; __orca_outer_debug_trap_spec="$(trap -p DEBUG)"; [[ -z "$__orca_prompt_had_functrace" ]] || set -T; unset __orca_prompt_had_functrace __orca_in_debug_capture'
 __orca_append_prompt_command "__orca_osc133_prompt_done"
+if [[ ${ORCA_POSIX_SHELL_STARTUP_COMMAND+present} == present ]]; then
+  __orca_remove_startup_command_prompt_hook() {
+    local __orca_item
+    local -a __orca_remaining=()
+    if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1) )); then
+      for __orca_item in "${PROMPT_COMMAND[@]+"${PROMPT_COMMAND[@]}"}"; do
+        [[ "$__orca_item" == "__orca_run_startup_command" ]] || __orca_remaining+=("$__orca_item")
+      done
+      PROMPT_COMMAND=("${__orca_remaining[@]+"${__orca_remaining[@]}"}")
+    else
+      for __orca_item in "${__orca_prompt_command_suffix[@]+"${__orca_prompt_command_suffix[@]}"}"; do
+        [[ "$__orca_item" == "__orca_run_startup_command" ]] || __orca_remaining+=("$__orca_item")
+      done
+      __orca_prompt_command_suffix=("${__orca_remaining[@]+"${__orca_remaining[@]}"}")
+    fi
+  }
+  __orca_run_startup_command() {
+    local __orca_command="$ORCA_POSIX_SHELL_STARTUP_COMMAND" __orca_status
+    unset ORCA_POSIX_SHELL_STARTUP_COMMAND
+    __orca_remove_startup_command_prompt_hook
+    unset -f __orca_remove_startup_command_prompt_hook
+    builtin history -s "$__orca_command" 2>/dev/null || true
+    builtin printf '%s
+' "$__orca_command"
+    eval "$__orca_command"
+    __orca_status=$?
+    unset -f __orca_run_startup_command
+    return "$__orca_status"
+  }
+  __orca_append_prompt_command "__orca_run_startup_command"
+fi
 __orca_had_functrace=""
 [[ -o functrace ]] && __orca_had_functrace=1
 set +T

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
@@ -155,7 +155,9 @@ __orca_deferred_init() {
   if [[ -n "${_orca_histfile:-}" ]]; then
     HISTFILE="$_orca_histfile"
   fi
-  if __orca_has_feature ready; then
+  if __orca_has_feature ready || __orca_has_feature startup; then
+    __orca_emit_ready_marker=""
+    __orca_has_feature ready && __orca_emit_ready_marker=1
     # Why: capture the prior zle-line-init so the marker chains to it. On a
     # re-source we are already the bound widget, so keep the function captured
     # the first time instead of clobbering it to empty (which would silently
@@ -170,11 +172,19 @@ __orca_deferred_init() {
       __orca_prev_line_init_fn=""
     fi
     __orca_prompt_mark() {
-      printf "\033]777;orca-shell-ready\007"
+      if [[ "${__orca_emit_ready_marker-1}" == 1 ]]; then
+        printf "\033]777;orca-shell-ready\007"
+      fi
       # Why: call the prior hook as a plain function, not an aliased widget, so
       # $WIDGET stays zle-line-init for add-zle-hook-widget dispatchers.
       if [[ -n "${__orca_prev_line_init_fn:-}" ]]; then
         "${__orca_prev_line_init_fn}" "$@"
+      fi
+      if (( ${+ORCA_POSIX_SHELL_STARTUP_COMMAND} )); then
+        BUFFER="$ORCA_POSIX_SHELL_STARTUP_COMMAND"
+        CURSOR=${#BUFFER}
+        builtin unset ORCA_POSIX_SHELL_STARTUP_COMMAND
+        zle accept-line
       fi
     }
     zle -N zle-line-init __orca_prompt_mark

--- a/src/main/daemon/daemon-zsh-shell-ready-wrapper-spec.ts
+++ b/src/main/daemon/daemon-zsh-shell-ready-wrapper-spec.ts
@@ -7,6 +7,7 @@ export function getDaemonZshWrapperSpec(): ZshStartupHookSpec {
     headerLabel: 'Orca daemon zsh shell-ready wrapper',
     readyMarkerEscaped: SHELL_READY_MARKER,
     osc133CommandMarkers: true,
+    startupCommandDelivery: false,
     overlayRestoreComment:
       "# Why: ~/.zshrc can export the user's default OpenCode config after spawn.",
     restores: {

--- a/src/main/ipc/pty-login-shell-startup-commands.test.ts
+++ b/src/main/ipc/pty-login-shell-startup-commands.test.ts
@@ -10,6 +10,7 @@ import { userInfo } from 'node:os'
 import { resetMacosLoginShellPreflightForTests } from '../providers/macos-tcc-login-shell'
 import { registerPtyHandlers } from './pty'
 import { join } from 'node:path'
+import { POSIX_SHELL_STARTUP_COMMAND_ENV } from '../pty/posix-shell-startup-command'
 // Why resolved rather than hardcoded: the wrapper tree is content-addressed.
 import { getShellReadyWrapperRoot } from '../providers/local-pty-shell-ready-wrapper-root'
 
@@ -239,7 +240,7 @@ describe('registerPtyHandlers', () => {
     }
   )
   posixOnlyIt(
-    'uses the no-marker wrapper and writes quickly for Codex startup commands',
+    'uses the no-marker wrapper for Codex startup commands without a PTY write',
     async () => {
       vi.useFakeTimers()
       const mockProc = createMockProc()
@@ -256,6 +257,7 @@ describe('registerPtyHandlers', () => {
 
         const [, , options] = spawnMock.mock.calls[0]!
         expect(options.env.ORCA_SHELL_FEATURES).not.toContain('ready')
+        expect(options.env[POSIX_SHELL_STARTUP_COMMAND_ENV]).toBe('codex')
 
         await Promise.resolve()
         vi.advanceTimersByTime(49)
@@ -265,7 +267,7 @@ describe('registerPtyHandlers', () => {
         vi.advanceTimersByTime(1)
         await Promise.resolve()
         vi.runAllTimers()
-        expect(mockProc.proc.write).toHaveBeenCalledWith('codex\n')
+        expect(mockProc.proc.write).not.toHaveBeenCalled()
       } finally {
         vi.useRealTimers()
       }
@@ -288,6 +290,7 @@ describe('registerPtyHandlers', () => {
 
       const [, , options] = spawnMock.mock.calls[0]!
       expect(options.env.ORCA_SHELL_FEATURES).toContain('ready')
+      expect(options.env[POSIX_SHELL_STARTUP_COMMAND_ENV]).toBe("codex 'linked issue context'")
       expect(mockProc.proc.write).not.toHaveBeenCalled()
 
       mockProc.emitData('last login: today\r\n')
@@ -303,7 +306,7 @@ describe('registerPtyHandlers', () => {
 
       vi.advanceTimersByTime(150)
       await Promise.resolve()
-      expect(mockProc.proc.write).toHaveBeenCalledWith("codex 'linked issue context'\n")
+      expect(mockProc.proc.write).not.toHaveBeenCalled()
     } finally {
       vi.useRealTimers()
     }
@@ -325,6 +328,9 @@ describe('registerPtyHandlers', () => {
           startupCommandDelivery: 'shell-ready'
         })
 
+        const [, , options] = spawnMock.mock.calls[0]!
+        expect(options.env[POSIX_SHELL_STARTUP_COMMAND_ENV]).toBe("codex 'linked issue context'")
+
         mockProc.emitData('\x1b]777;orca-shell-ready\x07\r\nuser@host % ')
         await Promise.resolve()
         vi.advanceTimersByTime(29)
@@ -333,7 +339,7 @@ describe('registerPtyHandlers', () => {
 
         vi.advanceTimersByTime(1)
         await Promise.resolve()
-        expect(mockProc.proc.write).toHaveBeenCalledWith("codex 'linked issue context'\n")
+        expect(mockProc.proc.write).not.toHaveBeenCalled()
       } finally {
         vi.useRealTimers()
       }
@@ -355,13 +361,14 @@ describe('registerPtyHandlers', () => {
 
       const [, , options] = spawnMock.mock.calls[0]!
       expect(options.env.ORCA_SHELL_FEATURES).toContain('ready')
+      expect(options.env[POSIX_SHELL_STARTUP_COMMAND_ENV]).toBe("codex --prefill 'linked issue context'")
       expect(mockProc.proc.write).not.toHaveBeenCalled()
 
       mockProc.emitData('\x1b]777;orca-shell-ready\x07')
       await Promise.resolve()
       vi.runAllTimers()
       await Promise.resolve()
-      expect(mockProc.proc.write).toHaveBeenCalledWith("codex --prefill 'linked issue context'\n")
+      expect(mockProc.proc.write).not.toHaveBeenCalled()
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/ipc/pty-spawn-env-codex-resume-provenance.test.ts
+++ b/src/main/ipc/pty-spawn-env-codex-resume-provenance.test.ts
@@ -4,6 +4,7 @@ import { spawnMock } from './pty-ipc-mock-registry'
 import { posixOnlyIt, TEST_MANAGED_ROOT } from './pty-ipc-test-constants'
 import { setupPtyIpcSuite } from './pty-ipc-test-harness'
 import { prepareCodexSessionResume } from '../codex/codex-session-resume-preparation'
+import { POSIX_SHELL_STARTUP_COMMAND_ENV } from '../pty/posix-shell-startup-command'
 import { registerPtyHandlers, setLocalPtyProvider, type PrepareCodexSessionResume } from './pty'
 
 vi.mock('electron', () => import('./pty-ipc-mock-registry').then((m) => m.electronModuleMock()))
@@ -168,7 +169,7 @@ describe('registerPtyHandlers', () => {
             await Promise.resolve()
             vi.runAllTimers()
 
-            expect(mockProc.proc.write).toHaveBeenCalledWith('codex\n')
+            expect(mockProc.proc.write).not.toHaveBeenCalled()
             expect(mockProc.proc.write).not.toHaveBeenCalledWith(
               expect.stringContaining(RESUME_SESSION_ID)
             )
@@ -176,6 +177,7 @@ describe('registerPtyHandlers', () => {
             // The pane still runs under the selected account — but with nothing to resume.
             const env = spawnMock.mock.calls.at(-1)![2].env as Record<string, string>
             expect(env.CODEX_HOME).toBe(OTHER_HOME)
+            expect(env[POSIX_SHELL_STARTUP_COMMAND_ENV]).toBe('codex')
             expect(selectedHome).toHaveBeenCalled()
           } finally {
             vi.useRealTimers()
@@ -211,12 +213,13 @@ describe('registerPtyHandlers', () => {
           await Promise.resolve()
           vi.runAllTimers()
 
-          expect(mockProc.proc.write).toHaveBeenCalledWith(
-            `codex 'resume' '${RESUME_SESSION_ID}'\n`
-          )
+          expect(mockProc.proc.write).not.toHaveBeenCalled()
           expect(spawned.agentResumeUnavailable).toBeUndefined()
           const env = spawnMock.mock.calls.at(-1)![2].env as Record<string, string>
           expect(env.CODEX_HOME).toBe(ORIGIN_HOME)
+          expect(env[POSIX_SHELL_STARTUP_COMMAND_ENV]).toBe(
+            `codex 'resume' '${RESUME_SESSION_ID}'`
+          )
           expect(selectedHome).not.toHaveBeenCalled()
         } finally {
           vi.useRealTimers()
@@ -238,7 +241,9 @@ describe('registerPtyHandlers', () => {
           await Promise.resolve()
           vi.runAllTimers()
 
-          expect(mockProc.proc.write).toHaveBeenCalledWith('codex\n')
+          expect(mockProc.proc.write).not.toHaveBeenCalled()
+          const env = spawnMock.mock.calls.at(-1)![2].env as Record<string, string>
+          expect(env[POSIX_SHELL_STARTUP_COMMAND_ENV]).toBe('codex')
           expect(spawned.agentResumeUnavailable).toBe(true)
         } finally {
           vi.useRealTimers()

--- a/src/main/line-editor-ready-output-scanner.test.ts
+++ b/src/main/line-editor-ready-output-scanner.test.ts
@@ -5,11 +5,14 @@ import {
 } from './line-editor-ready-output-scanner'
 
 describe('line editor ready output scanner', () => {
-  it.each(['\x1b[?2004h', '\x1b[?1034h'])('detects %j across chunks', (sequence) => {
-    const state = createLineEditorReadyOutputScanState()
-    expect(scanForLineEditorReadyOutput(state, `prompt${sequence.slice(0, 4)}`)).toBe(false)
-    expect(scanForLineEditorReadyOutput(state, sequence.slice(4))).toBe(true)
-  })
+  it.each(['\x1b[?2004h', '\x1b[?1034h', '\x1b]133;A\x07'])(
+    'detects %j across chunks',
+    (sequence) => {
+      const state = createLineEditorReadyOutputScanState()
+      expect(scanForLineEditorReadyOutput(state, `prompt${sequence.slice(0, 4)}`)).toBe(false)
+      expect(scanForLineEditorReadyOutput(state, sequence.slice(4))).toBe(true)
+    }
+  )
 
   it('ignores ordinary prompt output', () => {
     expect(

--- a/src/main/line-editor-ready-output-scanner.ts
+++ b/src/main/line-editor-ready-output-scanner.ts
@@ -1,4 +1,4 @@
-const LINE_EDITOR_READY_SEQUENCES = ['\x1b[?2004h', '\x1b[?1034h'] as const
+const LINE_EDITOR_READY_SEQUENCES = ['\x1b[?2004h', '\x1b[?1034h', '\x1b]133;A\x07'] as const
 const MAX_SEQUENCE_LENGTH = Math.max(...LINE_EDITOR_READY_SEQUENCES.map((value) => value.length))
 
 export type LineEditorReadyOutputScanState = {

--- a/src/main/providers/local-pty-finalize-environment.ts
+++ b/src/main/providers/local-pty-finalize-environment.ts
@@ -8,6 +8,10 @@ import {
   POWERLEVEL10K_WIZARD_DISABLE_ENV,
   seedPowerlevel10kWizardEnv
 } from '../pty/powerlevel10k-wizard-env'
+import {
+  POSIX_SHELL_STARTUP_COMMAND_ENV,
+  supportsPosixShellStartupCommand
+} from '../pty/posix-shell-startup-command'
 import { resolvePathEnvKey } from '../pty/windows-environment-path'
 import { selectShellStartupFeatures } from '../shell-startup-features'
 import {
@@ -89,19 +93,25 @@ export function finalizeLocalPtySpawnEnvironment(args: {
     // HISTFILE that the system zshrc clobbers, so the decision to wrap has to
     // see whether this spawn actually injected one.
     const isCodexStartupCommand = plan.startupAgentRecognition?.agent === 'codex'
-    // Why: payload-bearing Codex startup can be lost to rc-file noise; plain Codex stays markerless for startup speed.
-    const waitsForShellReady =
-      Boolean(spawn.command) &&
-      (!isCodexStartupCommand ||
-        shouldUseShellReadyStartupDelivery({
-          command: spawn.command as string,
-          startupCommandDelivery: spawn.startupCommandDelivery
-        }))
+    const codexStartupCommand = isCodexStartupCommand ? spawn.command : undefined
+    const codexRequiresShellReady =
+      codexStartupCommand !== undefined &&
+      shouldUseShellReadyStartupDelivery({
+        command: codexStartupCommand,
+        startupCommandDelivery: spawn.startupCommandDelivery
+      })
     // Why delete: ORCA_SHELL_FEATURES is Orca-owned, and only the launch
     // config below may name features for this shell.
     delete env.ORCA_SHELL_FEATURES
-    plan.getFallbackShellReadyConfig = (shell) =>
-      getShellLaunchConfig(
+    delete env[POSIX_SHELL_STARTUP_COMMAND_ENV]
+    plan.getFallbackShellReadyConfig = (shell) => {
+      const wrapperStartupCommand =
+        codexStartupCommand !== undefined && supportsPosixShellStartupCommand(shell)
+          ? codexStartupCommand
+          : undefined
+      const waitsForShellReady =
+        Boolean(spawn.command) && (!isCodexStartupCommand || codexRequiresShellReady)
+      return getShellLaunchConfig(
         shell,
         selectShellStartupFeatures({
           shellPath: shell,
@@ -111,8 +121,10 @@ export function finalizeLocalPtySpawnEnvironment(args: {
           // Why identical: the identity marker exists so the readiness
           // handshake can bind output to the right shell PID.
           emitsStartupIdentity: waitsForShellReady
-        })
+        }),
+        wrapperStartupCommand
       )
+    }
     const shellLaunch = plan.getFallbackShellReadyConfig(plan.shellPath)
     Object.assign(env, shellLaunch.env)
     plan.shellArgs = shellLaunch.args ?? plan.shellArgs

--- a/src/main/providers/local-pty-provider-shell-readiness.test.ts
+++ b/src/main/providers/local-pty-provider-shell-readiness.test.ts
@@ -115,6 +115,7 @@ vi.mock('../shell-prompt-readiness-probe', () => ({
 }))
 
 import { LocalPtyProvider } from './local-pty-provider'
+import { POSIX_SHELL_STARTUP_COMMAND_ENV } from '../pty/posix-shell-startup-command'
 import {
   applyLocalPtyProviderMockDefaults,
   createLocalPtyMockProcess,
@@ -158,6 +159,70 @@ describe('LocalPtyProvider', () => {
   })
 
   describe('spawn', () => {
+    it('delegates markerless Codex startup to the shell wrapper without a PTY write', async () => {
+      process.env.SHELL = '/bin/zsh'
+      const command = "codex '--dangerously-bypass-approvals-and-sandbox'"
+
+      await provider.spawn({ cols: 80, rows: 24, command })
+
+      const spawnEnv = spawnMock.mock.calls.at(-1)?.[2].env
+      expect(spawnEnv[POSIX_SHELL_STARTUP_COMMAND_ENV]).toBe(command)
+      expect(spawnEnv.ORCA_SHELL_FEATURES).toContain('startup')
+      expect(spawnEnv.ORCA_SHELL_FEATURES).not.toContain('ready')
+      expect(mockProc.write).not.toHaveBeenCalled()
+    })
+
+    it('keeps payload-bearing Codex startup in the wrapper readiness path', async () => {
+      process.env.SHELL = '/bin/zsh'
+      const command = "codex '--dangerously-bypass-approvals-and-sandbox' 'review this branch'"
+
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        command,
+        startupCommandDelivery: 'shell-ready'
+      })
+
+      const spawnEnv = spawnMock.mock.calls.at(-1)?.[2].env
+      expect(spawnEnv[POSIX_SHELL_STARTUP_COMMAND_ENV]).toBe(command)
+      expect(spawnEnv.ORCA_SHELL_FEATURES).toContain('startup')
+      expect(spawnEnv.ORCA_SHELL_FEATURES).toContain('ready')
+      expect(mockProc.write).not.toHaveBeenCalled()
+    })
+
+    it('scrubs an inherited wrapper startup command from ordinary panes', async () => {
+      process.env.SHELL = '/bin/zsh'
+
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        env: { [POSIX_SHELL_STARTUP_COMMAND_ENV]: 'poisoned command' }
+      })
+
+      const spawnEnv = spawnMock.mock.calls.at(-1)?.[2].env
+      expect(spawnEnv[POSIX_SHELL_STARTUP_COMMAND_ENV]).toBeUndefined()
+      expect(mockProc.write).not.toHaveBeenCalled()
+    })
+
+    it('retains PTY delivery for unsupported local shells without leaking wrapper state', async () => {
+      vi.useFakeTimers()
+      try {
+        process.env.SHELL = '/bin/sh'
+        const command = "codex '--dangerously-bypass-approvals-and-sandbox'"
+
+        await provider.spawn({ cols: 80, rows: 24, command })
+
+        const spawnEnv = spawnMock.mock.calls.at(-1)?.[2].env
+        expect(spawnEnv[POSIX_SHELL_STARTUP_COMMAND_ENV]).toBeUndefined()
+        expect(mockProc.write).not.toHaveBeenCalled()
+
+        await vi.advanceTimersByTimeAsync(200)
+        expect(mockProc.write).toHaveBeenCalledWith(`${command}\n`)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it('verifies shell identity against the exact spawn PATH', async () => {
       provider.configure({
         buildSpawnEnv: (_id, env) => ({ ...env, PATH: '/post-hook/bin' })

--- a/src/main/providers/local-pty-session-activation.ts
+++ b/src/main/providers/local-pty-session-activation.ts
@@ -1,13 +1,9 @@
 import type * as pty from 'node-pty'
-import {
-  createPtySlaveLineEditorProbe,
-  readPtySlavePath
-} from '../../shared/pty-slave-line-discipline-echo'
 import { isBracketedPasteSafeShell } from '../../shared/startup-command-submission'
 import { PtyStartupIngress, type PtyIngressEmission } from '../../shared/pty-startup-ingress'
 import { resolvePtyOwnerBackend } from '../../shared/pty-owner-backend'
-import { SHELL_STARTUP_FEATURE_ENV } from '../shell-startup-features'
 import { resolveProcessExitCause } from '../../shared/terminal-exit-cause'
+import { POSIX_SHELL_STARTUP_COMMAND_ENV } from '../pty/posix-shell-startup-command'
 import { getAgentForegroundContextPaths } from './agent-foreground-context-paths'
 import { getSpawnedShellName } from './local-pty-launch-helpers'
 import type { LocalPtyLaunchPlan } from './local-pty-launch-plan'
@@ -159,7 +155,14 @@ export function activateLocalPtySession(args: {
   }
   ptyDisposables.set(id, disposables)
 
-  if (spawn.command && !plan.startupCommandDeliveredInShellArgs) {
+  const startupCommandDeliveredByWrapper =
+    spawn.command !== undefined &&
+    plan.shellReadyLaunch?.env[POSIX_SHELL_STARTUP_COMMAND_ENV] === spawn.command
+  if (
+    spawn.command &&
+    !plan.startupCommandDeliveredInShellArgs &&
+    !startupCommandDeliveredByWrapper
+  ) {
     // Why: shells with bracketed paste armed take a multiline startup prompt literally; others use raw submit.
     const spawnedShellName = getSpawnedShellName(plan.shellPath).toLowerCase()
     const bracketedPasteSafe =
@@ -168,14 +171,6 @@ export function activateLocalPtySession(args: {
         shellName: spawnedShellName,
         waitsForShellReady: plan.shellReadyLaunch?.supportsReadyMarker === true
       })
-    const wrappedShellReadyLaunch =
-      plan.shellReadyLaunch?.args &&
-      (plan.shellReadyLaunch.supportsReadyMarker ||
-        plan.shellReadyLaunch.env[SHELL_STARTUP_FEATURE_ENV] !== undefined)
-    const lineEditorProbe =
-      bracketedPasteSafe && wrappedShellReadyLaunch
-        ? createPtySlaveLineEditorProbe(readPtySlavePath(proc))
-        : undefined
     writeStartupCommandWhenShellReady(
       readiness.shellReadyPromise,
       proc,
@@ -184,8 +179,7 @@ export function activateLocalPtySession(args: {
         readiness.setStartupCommandCleanup(cleanup)
       },
       {
-        bracketedPasteSafe,
-        ...(lineEditorProbe ? { lineEditorProbe } : {})
+        bracketedPasteSafe
       }
     )
   }

--- a/src/main/providers/local-pty-session-activation.ts
+++ b/src/main/providers/local-pty-session-activation.ts
@@ -1,7 +1,12 @@
 import type * as pty from 'node-pty'
+import {
+  createPtySlaveLineEditorProbe,
+  readPtySlavePath
+} from '../../shared/pty-slave-line-discipline-echo'
 import { isBracketedPasteSafeShell } from '../../shared/startup-command-submission'
 import { PtyStartupIngress, type PtyIngressEmission } from '../../shared/pty-startup-ingress'
 import { resolvePtyOwnerBackend } from '../../shared/pty-owner-backend'
+import { SHELL_STARTUP_FEATURE_ENV } from '../shell-startup-features'
 import { resolveProcessExitCause } from '../../shared/terminal-exit-cause'
 import { getAgentForegroundContextPaths } from './agent-foreground-context-paths'
 import { getSpawnedShellName } from './local-pty-launch-helpers'
@@ -163,6 +168,14 @@ export function activateLocalPtySession(args: {
         shellName: spawnedShellName,
         waitsForShellReady: plan.shellReadyLaunch?.supportsReadyMarker === true
       })
+    const wrappedShellReadyLaunch =
+      plan.shellReadyLaunch?.args &&
+      (plan.shellReadyLaunch.supportsReadyMarker ||
+        plan.shellReadyLaunch.env[SHELL_STARTUP_FEATURE_ENV] !== undefined)
+    const lineEditorProbe =
+      bracketedPasteSafe && wrappedShellReadyLaunch
+        ? createPtySlaveLineEditorProbe(readPtySlavePath(proc))
+        : undefined
     writeStartupCommandWhenShellReady(
       readiness.shellReadyPromise,
       proc,
@@ -170,7 +183,10 @@ export function activateLocalPtySession(args: {
       (cleanup) => {
         readiness.setStartupCommandCleanup(cleanup)
       },
-      { bracketedPasteSafe }
+      {
+        bracketedPasteSafe,
+        ...(lineEditorProbe ? { lineEditorProbe } : {})
+      }
     )
   }
 

--- a/src/main/providers/local-pty-shell-ready-bash-rcfile.ts
+++ b/src/main/providers/local-pty-shell-ready-bash-rcfile.ts
@@ -7,6 +7,7 @@
 import { BASH_PROMPT_COMMAND_COMPOSITION_BLOCK } from '../bash-prompt-command-composition'
 import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import { getPosixCodexShellLaunchPreflight } from '../pty/codex-shell-launch-preflight'
+import { getBashStartupCommandPromptBlock } from '../pty/posix-shell-startup-command'
 import { BASH_FEATURE_CHANNEL_BLOCK, SHELL_STARTUP_IDENTITY_MARKER_BLOCK } from '../shell-templates'
 import { SHELL_READY_MARKER_ESCAPED } from './local-pty-shell-ready-marker'
 
@@ -122,6 +123,7 @@ if [[ -n "$__orca_ready_marker" ]]; then
 fi
 __orca_append_prompt_command '__orca_in_debug_capture=1; __orca_prompt_had_functrace=""; if [[ -o functrace ]]; then __orca_prompt_had_functrace=1; set +T; fi; __orca_outer_debug_trap_spec="$(trap -p DEBUG)"; [[ -z "$__orca_prompt_had_functrace" ]] || set -T; unset __orca_prompt_had_functrace __orca_in_debug_capture'
 __orca_append_prompt_command "__orca_osc133_prompt_done"
+${getBashStartupCommandPromptBlock()}
 __orca_had_functrace=""
 [[ -o functrace ]] && __orca_had_functrace=1
 set +T

--- a/src/main/providers/local-pty-shell-ready-startup-command.test.ts
+++ b/src/main/providers/local-pty-shell-ready-startup-command.test.ts
@@ -134,6 +134,66 @@ describe('writeStartupCommandWhenShellReady', () => {
     expect(proc._writes).toEqual(['codex\n'])
   })
 
+  it('submits only after the POSIX line editor is active', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    const proc = createMockProc()
+    const lineEditorProbe = vi
+      .fn()
+      .mockResolvedValueOnce('other')
+      .mockResolvedValueOnce('line-editor')
+    const ready = Promise.resolve()
+    writeStartupCommandWhenShellReady(ready, proc, 'codex', () => {}, { lineEditorProbe })
+
+    await ready
+    proc._emitData('\x1b[?2004h')
+    await vi.advanceTimersByTimeAsync(9)
+    expect(proc._writes).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(11)
+    expect(lineEditorProbe).toHaveBeenCalledTimes(2)
+    expect(proc._writes).toEqual(['codex\n'])
+  })
+
+  it('does not replace line-editor readiness with a longer timeout', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    const proc = createMockProc()
+    const cleanup: { run?: () => void } = {}
+    const lineEditorProbe = vi.fn().mockResolvedValue('other')
+    const ready = Promise.resolve()
+    writeStartupCommandWhenShellReady(
+      ready,
+      proc,
+      'codex',
+      (run) => {
+        cleanup.run = run
+      },
+      { lineEditorProbe }
+    )
+
+    await ready
+    proc._emitData('\x1b[?2004h')
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(proc._writes).toEqual([])
+    cleanup.run?.()
+  })
+
+  it('falls back to legacy readiness when the line-editor probe is unavailable', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    const proc = createMockProc()
+    const lineEditorProbe = vi.fn().mockResolvedValue('unavailable')
+    const ready = Promise.resolve()
+    writeStartupCommandWhenShellReady(ready, proc, 'codex', () => {}, { lineEditorProbe })
+
+    await ready
+    proc._emitData('\x1b[?2004h')
+    await vi.advanceTimersByTimeAsync(199)
+    expect(proc._writes).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(proc._writes).toEqual(['codex\n'])
+  })
+
   // Why: multiline startup commands must be bracketed-paste wrapped (ESC[200~ … ESC[201~) so shells insert them literally instead of treating each LF as Enter.
   it('wraps a multiline startup command in bracketed paste when the shell supports it', async () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' })

--- a/src/main/providers/local-pty-shell-ready-startup-command.test.ts
+++ b/src/main/providers/local-pty-shell-ready-startup-command.test.ts
@@ -134,66 +134,6 @@ describe('writeStartupCommandWhenShellReady', () => {
     expect(proc._writes).toEqual(['codex\n'])
   })
 
-  it('submits only after the POSIX line editor is active', async () => {
-    Object.defineProperty(process, 'platform', { value: 'darwin' })
-    const proc = createMockProc()
-    const lineEditorProbe = vi
-      .fn()
-      .mockResolvedValueOnce('other')
-      .mockResolvedValueOnce('line-editor')
-    const ready = Promise.resolve()
-    writeStartupCommandWhenShellReady(ready, proc, 'codex', () => {}, { lineEditorProbe })
-
-    await ready
-    proc._emitData('\x1b[?2004h')
-    await vi.advanceTimersByTimeAsync(9)
-    expect(proc._writes).toEqual([])
-
-    await vi.advanceTimersByTimeAsync(11)
-    expect(lineEditorProbe).toHaveBeenCalledTimes(2)
-    expect(proc._writes).toEqual(['codex\n'])
-  })
-
-  it('does not replace line-editor readiness with a longer timeout', async () => {
-    Object.defineProperty(process, 'platform', { value: 'darwin' })
-    const proc = createMockProc()
-    const cleanup: { run?: () => void } = {}
-    const lineEditorProbe = vi.fn().mockResolvedValue('other')
-    const ready = Promise.resolve()
-    writeStartupCommandWhenShellReady(
-      ready,
-      proc,
-      'codex',
-      (run) => {
-        cleanup.run = run
-      },
-      { lineEditorProbe }
-    )
-
-    await ready
-    proc._emitData('\x1b[?2004h')
-    await vi.advanceTimersByTimeAsync(2000)
-
-    expect(proc._writes).toEqual([])
-    cleanup.run?.()
-  })
-
-  it('falls back to legacy readiness when the line-editor probe is unavailable', async () => {
-    Object.defineProperty(process, 'platform', { value: 'darwin' })
-    const proc = createMockProc()
-    const lineEditorProbe = vi.fn().mockResolvedValue('unavailable')
-    const ready = Promise.resolve()
-    writeStartupCommandWhenShellReady(ready, proc, 'codex', () => {}, { lineEditorProbe })
-
-    await ready
-    proc._emitData('\x1b[?2004h')
-    await vi.advanceTimersByTimeAsync(199)
-    expect(proc._writes).toEqual([])
-
-    await vi.advanceTimersByTimeAsync(1)
-    expect(proc._writes).toEqual(['codex\n'])
-  })
-
   // Why: multiline startup commands must be bracketed-paste wrapped (ESC[200~ … ESC[201~) so shells insert them literally instead of treating each LF as Enter.
   it('wraps a multiline startup command in bracketed paste when the shell supports it', async () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' })

--- a/src/main/providers/local-pty-shell-ready-startup-command.ts
+++ b/src/main/providers/local-pty-shell-ready-startup-command.ts
@@ -2,18 +2,11 @@
  * Writes a startup command into a local PTY once the shell reports readiness.
  */
 import type * as pty from 'node-pty'
-import type { PtySlaveLineEditorProbe } from '../../shared/pty-slave-line-discipline-echo'
 import { buildStartupCommandSubmission } from '../../shared/startup-command-submission'
-import {
-  createLineEditorReadyOutputScanState,
-  scanForLineEditorReadyOutput
-} from '../line-editor-ready-output-scanner'
 
 export const STARTUP_COMMAND_READY_MAX_WAIT_MS = 1500
 const POST_SHELL_READY_STARTUP_COMMAND_DELAY_MS = 30
 const POST_SHELL_READY_STARTUP_COMMAND_FALLBACK_MS = 200
-const LINE_EDITOR_PROBE_INITIAL_RETRY_MS = 10
-const LINE_EDITOR_PROBE_MAX_RETRY_MS = 200
 
 export type ShellReadySignal = {
   postMarkerBytesObserved: boolean
@@ -25,28 +18,14 @@ export function writeStartupCommandWhenShellReady(
   startupCommand: string,
   onExit: (cleanup: () => void) => void,
   // Why: only shells with bracketed-paste active (see isBracketedPasteSafeShell) accept the wrapper; others use the raw path so ESC[200~ isn't echoed.
-  options: {
-    bracketedPasteSafe?: boolean
-    lineEditorProbe?: PtySlaveLineEditorProbe
-  } = {}
+  options: { bracketedPasteSafe?: boolean } = {}
 ): void {
   let sent = false
-  let generation = 0
-  let lineEditorOutputObserved = false
-  let shellReadyResolved = false
-  let shellReadySignal: void | ShellReadySignal
-  let lineEditorProbeAttempt = 0
-  let lineEditorProbeTimer: ReturnType<typeof setTimeout> | null = null
   let postReadyTimer: ReturnType<typeof setTimeout> | null = null
   let postReadyDataDisposable: { dispose: () => void } | null = null
 
   const cleanup = (): void => {
     sent = true
-    generation += 1
-    if (lineEditorProbeTimer !== null) {
-      clearTimeout(lineEditorProbeTimer)
-      lineEditorProbeTimer = null
-    }
     if (postReadyTimer !== null) {
       clearTimeout(postReadyTimer)
       postReadyTimer = null
@@ -60,13 +39,8 @@ export function writeStartupCommandWhenShellReady(
       return
     }
     sent = true
-    generation += 1
     postReadyDataDisposable?.dispose()
     postReadyDataDisposable = null
-    if (lineEditorProbeTimer !== null) {
-      clearTimeout(lineEditorProbeTimer)
-      lineEditorProbeTimer = null
-    }
     if (postReadyTimer !== null) {
       clearTimeout(postReadyTimer)
       postReadyTimer = null
@@ -87,7 +61,11 @@ export function writeStartupCommandWhenShellReady(
     postReadyTimer = setTimeout(flush, POST_SHELL_READY_STARTUP_COMMAND_DELAY_MS)
   }
 
-  const useLegacyReadiness = (signal: void | ShellReadySignal): void => {
+  readyPromise.then((signal) => {
+    if (sent) {
+      return
+    }
+    // Why: marker fires from precmd before the line editor takes the PTY out of ECHO; writing now double-echoes the command, so settle first.
     if (signal?.postMarkerBytesObserved === true) {
       schedulePostReadyFlush()
       return
@@ -106,78 +84,6 @@ export function writeStartupCommandWhenShellReady(
       postReadyTimer = null
       flush()
     }, POST_SHELL_READY_STARTUP_COMMAND_FALLBACK_MS)
-  }
-
-  const waitForLineEditor = (signal: void | ShellReadySignal): void => {
-    const probe = options.lineEditorProbe
-    if (!probe || sent) {
-      return
-    }
-    const probeGeneration = generation
-    void probe()
-      .then((state) => {
-        if (sent || probeGeneration !== generation) {
-          return
-        }
-        if (state === 'line-editor') {
-          flush()
-          return
-        }
-        if (state === 'unavailable') {
-          useLegacyReadiness(signal)
-          return
-        }
-        const retryMs = Math.min(
-          LINE_EDITOR_PROBE_INITIAL_RETRY_MS * 2 ** lineEditorProbeAttempt,
-          LINE_EDITOR_PROBE_MAX_RETRY_MS
-        )
-        lineEditorProbeAttempt += 1
-        lineEditorProbeTimer = setTimeout(() => {
-          lineEditorProbeTimer = null
-          waitForLineEditor(signal)
-        }, retryMs)
-      })
-      .catch(() => {
-        if (sent || probeGeneration !== generation) {
-          return
-        }
-        lineEditorProbeTimer = setTimeout(() => {
-          lineEditorProbeTimer = null
-          waitForLineEditor(signal)
-        }, LINE_EDITOR_PROBE_MAX_RETRY_MS)
-      })
-  }
-
-  if (options.lineEditorProbe) {
-    const lineEditorOutputScanState = createLineEditorReadyOutputScanState()
-    postReadyDataDisposable = proc.onData((data) => {
-      if (!scanForLineEditorReadyOutput(lineEditorOutputScanState, data)) {
-        return
-      }
-      lineEditorOutputObserved = true
-      if (shellReadyResolved) {
-        postReadyDataDisposable?.dispose()
-        postReadyDataDisposable = null
-        waitForLineEditor(shellReadySignal)
-      }
-    })
-  }
-
-  readyPromise.then((signal) => {
-    if (sent) {
-      return
-    }
-    if (options.lineEditorProbe) {
-      shellReadySignal = signal
-      shellReadyResolved = true
-      if (lineEditorOutputObserved) {
-        postReadyDataDisposable?.dispose()
-        postReadyDataDisposable = null
-        waitForLineEditor(signal)
-      }
-    } else {
-      useLegacyReadiness(signal)
-    }
   })
   onExit(cleanup)
 }

--- a/src/main/providers/local-pty-shell-ready-startup-command.ts
+++ b/src/main/providers/local-pty-shell-ready-startup-command.ts
@@ -2,11 +2,18 @@
  * Writes a startup command into a local PTY once the shell reports readiness.
  */
 import type * as pty from 'node-pty'
+import type { PtySlaveLineEditorProbe } from '../../shared/pty-slave-line-discipline-echo'
 import { buildStartupCommandSubmission } from '../../shared/startup-command-submission'
+import {
+  createLineEditorReadyOutputScanState,
+  scanForLineEditorReadyOutput
+} from '../line-editor-ready-output-scanner'
 
 export const STARTUP_COMMAND_READY_MAX_WAIT_MS = 1500
 const POST_SHELL_READY_STARTUP_COMMAND_DELAY_MS = 30
 const POST_SHELL_READY_STARTUP_COMMAND_FALLBACK_MS = 200
+const LINE_EDITOR_PROBE_INITIAL_RETRY_MS = 10
+const LINE_EDITOR_PROBE_MAX_RETRY_MS = 200
 
 export type ShellReadySignal = {
   postMarkerBytesObserved: boolean
@@ -18,14 +25,28 @@ export function writeStartupCommandWhenShellReady(
   startupCommand: string,
   onExit: (cleanup: () => void) => void,
   // Why: only shells with bracketed-paste active (see isBracketedPasteSafeShell) accept the wrapper; others use the raw path so ESC[200~ isn't echoed.
-  options: { bracketedPasteSafe?: boolean } = {}
+  options: {
+    bracketedPasteSafe?: boolean
+    lineEditorProbe?: PtySlaveLineEditorProbe
+  } = {}
 ): void {
   let sent = false
+  let generation = 0
+  let lineEditorOutputObserved = false
+  let shellReadyResolved = false
+  let shellReadySignal: void | ShellReadySignal
+  let lineEditorProbeAttempt = 0
+  let lineEditorProbeTimer: ReturnType<typeof setTimeout> | null = null
   let postReadyTimer: ReturnType<typeof setTimeout> | null = null
   let postReadyDataDisposable: { dispose: () => void } | null = null
 
   const cleanup = (): void => {
     sent = true
+    generation += 1
+    if (lineEditorProbeTimer !== null) {
+      clearTimeout(lineEditorProbeTimer)
+      lineEditorProbeTimer = null
+    }
     if (postReadyTimer !== null) {
       clearTimeout(postReadyTimer)
       postReadyTimer = null
@@ -39,8 +60,13 @@ export function writeStartupCommandWhenShellReady(
       return
     }
     sent = true
+    generation += 1
     postReadyDataDisposable?.dispose()
     postReadyDataDisposable = null
+    if (lineEditorProbeTimer !== null) {
+      clearTimeout(lineEditorProbeTimer)
+      lineEditorProbeTimer = null
+    }
     if (postReadyTimer !== null) {
       clearTimeout(postReadyTimer)
       postReadyTimer = null
@@ -61,11 +87,7 @@ export function writeStartupCommandWhenShellReady(
     postReadyTimer = setTimeout(flush, POST_SHELL_READY_STARTUP_COMMAND_DELAY_MS)
   }
 
-  readyPromise.then((signal) => {
-    if (sent) {
-      return
-    }
-    // Why: marker fires from precmd before the line editor takes the PTY out of ECHO; writing now double-echoes the command, so settle first.
+  const useLegacyReadiness = (signal: void | ShellReadySignal): void => {
     if (signal?.postMarkerBytesObserved === true) {
       schedulePostReadyFlush()
       return
@@ -84,6 +106,78 @@ export function writeStartupCommandWhenShellReady(
       postReadyTimer = null
       flush()
     }, POST_SHELL_READY_STARTUP_COMMAND_FALLBACK_MS)
+  }
+
+  const waitForLineEditor = (signal: void | ShellReadySignal): void => {
+    const probe = options.lineEditorProbe
+    if (!probe || sent) {
+      return
+    }
+    const probeGeneration = generation
+    void probe()
+      .then((state) => {
+        if (sent || probeGeneration !== generation) {
+          return
+        }
+        if (state === 'line-editor') {
+          flush()
+          return
+        }
+        if (state === 'unavailable') {
+          useLegacyReadiness(signal)
+          return
+        }
+        const retryMs = Math.min(
+          LINE_EDITOR_PROBE_INITIAL_RETRY_MS * 2 ** lineEditorProbeAttempt,
+          LINE_EDITOR_PROBE_MAX_RETRY_MS
+        )
+        lineEditorProbeAttempt += 1
+        lineEditorProbeTimer = setTimeout(() => {
+          lineEditorProbeTimer = null
+          waitForLineEditor(signal)
+        }, retryMs)
+      })
+      .catch(() => {
+        if (sent || probeGeneration !== generation) {
+          return
+        }
+        lineEditorProbeTimer = setTimeout(() => {
+          lineEditorProbeTimer = null
+          waitForLineEditor(signal)
+        }, LINE_EDITOR_PROBE_MAX_RETRY_MS)
+      })
+  }
+
+  if (options.lineEditorProbe) {
+    const lineEditorOutputScanState = createLineEditorReadyOutputScanState()
+    postReadyDataDisposable = proc.onData((data) => {
+      if (!scanForLineEditorReadyOutput(lineEditorOutputScanState, data)) {
+        return
+      }
+      lineEditorOutputObserved = true
+      if (shellReadyResolved) {
+        postReadyDataDisposable?.dispose()
+        postReadyDataDisposable = null
+        waitForLineEditor(shellReadySignal)
+      }
+    })
+  }
+
+  readyPromise.then((signal) => {
+    if (sent) {
+      return
+    }
+    if (options.lineEditorProbe) {
+      shellReadySignal = signal
+      shellReadyResolved = true
+      if (lineEditorOutputObserved) {
+        postReadyDataDisposable?.dispose()
+        postReadyDataDisposable = null
+        waitForLineEditor(signal)
+      }
+    } else {
+      useLegacyReadiness(signal)
+    }
   })
   onExit(cleanup)
 }

--- a/src/main/providers/local-pty-shell-ready-wrapper-fileset.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-fileset.ts
@@ -14,6 +14,7 @@ export function getLocalZshWrapperSpec(): ZshStartupHookSpec {
     headerLabel: 'Orca zsh shell-ready wrapper',
     readyMarkerEscaped: SHELL_READY_MARKER_ESCAPED,
     osc133CommandMarkers: true,
+    startupCommandDelivery: true,
     overlayRestoreComment:
       "# Why: ~/.zshrc can export the user's default OpenCode config after spawn.",
     restores: {

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -11,6 +11,7 @@ import {
   isPowerShellExecutableName
 } from '../powershell-osc133-bootstrap'
 import { getFishCodexShellLaunchPreflight } from '../pty/codex-shell-launch-preflight'
+import { POSIX_SHELL_STARTUP_COMMAND_ENV } from '../pty/posix-shell-startup-command'
 import { getFishShellReadyInitCommand } from '../shell-templates'
 import {
   encodeShellStartupFeatures,
@@ -63,12 +64,17 @@ export function getBashWrapperLaunchArgs(): string[] | null {
  */
 export function getShellLaunchConfig(
   shellPath: string,
-  features: readonly ShellStartupFeature[]
+  features: readonly ShellStartupFeature[],
+  startupCommand?: string
 ): ShellReadyLaunchConfig {
   const shellName = pathWin32.basename(basename(shellPath)).toLowerCase()
+  const wrapperFeatures =
+    startupCommand !== undefined && !features.includes('startup')
+      ? [...features, 'startup' as const]
+      : features
 
   if (shellName === 'zsh') {
-    if (features.length === 0) {
+    if (wrapperFeatures.length === 0) {
       return UNWRAPPED
     }
     if (!wrapperTreeUsable()) {
@@ -81,7 +87,10 @@ export function getShellLaunchConfig(
       env: {
         ...inheritedZdotdirEnv(resolveInheritedZdotdir(process.env)),
         ZDOTDIR: `${getShellReadyWrapperRoot()}/zsh`,
-        [SHELL_STARTUP_FEATURE_ENV]: encodeShellStartupFeatures(features)
+        [SHELL_STARTUP_FEATURE_ENV]: encodeShellStartupFeatures(wrapperFeatures),
+        ...(startupCommand !== undefined
+          ? { [POSIX_SHELL_STARTUP_COMMAND_ENV]: startupCommand }
+          : {})
       },
       supportsReadyMarker: features.includes('ready')
     }
@@ -99,7 +108,10 @@ export function getShellLaunchConfig(
     return {
       args,
       env: {
-        [SHELL_STARTUP_FEATURE_ENV]: encodeShellStartupFeatures(features)
+        [SHELL_STARTUP_FEATURE_ENV]: encodeShellStartupFeatures(wrapperFeatures),
+        ...(startupCommand !== undefined
+          ? { [POSIX_SHELL_STARTUP_COMMAND_ENV]: startupCommand }
+          : {})
       },
       supportsReadyMarker: features.includes('ready')
     }
@@ -120,15 +132,20 @@ export function getShellLaunchConfig(
 
   // Why: mirrors daemon/shell-ready.ts; markerless fish stays unwrapped. The
   // selection is baked into the init command, so fish needs no feature env var.
-  if (shellName === 'fish' && features.includes('ready')) {
+  if (shellName === 'fish' && (features.includes('ready') || startupCommand !== undefined)) {
     return {
       args: [
         '-l',
         '-C',
-        `${getFishShellReadyInitCommand(SHELL_READY_MARKER_ESCAPED)}\n${getFishCodexShellLaunchPreflight()}`
+        `${getFishShellReadyInitCommand(
+          SHELL_READY_MARKER_ESCAPED,
+          features.includes('ready'),
+          startupCommand !== undefined
+        )}\n${getFishCodexShellLaunchPreflight()}`
       ],
-      env: {},
-      supportsReadyMarker: true
+      env:
+        startupCommand !== undefined ? { [POSIX_SHELL_STARTUP_COMMAND_ENV]: startupCommand } : {},
+      supportsReadyMarker: features.includes('ready')
     }
   }
 

--- a/src/main/providers/local-pty-shell-startup-command.node-pty.test.ts
+++ b/src/main/providers/local-pty-shell-startup-command.node-pty.test.ts
@@ -1,0 +1,121 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as pty from 'node-pty'
+import { afterEach, describe, expect, it } from 'vitest'
+import { PtyStartupIngress } from '../../shared/pty-startup-ingress'
+import type { TerminalViewRgb } from '../../shared/terminal-view-attributes'
+import { HeadlessEmulator } from '../daemon/headless-emulator'
+import { POSIX_SHELL_STARTUP_COMMAND_ENV } from '../pty/posix-shell-startup-command'
+import { getShellLaunchConfig } from './local-pty-shell-ready'
+import { setTestUserDataPath } from './local-pty-shell-ready-test-harness'
+
+const SHELLS = ['bash', 'zsh', 'fish'].filter(
+  (shell) => process.platform !== 'win32' && spawnSync(shell, ['--version']).status === 0
+)
+const STARTUP_COMMAND = `bash -c 'read -r line; printf "__STARTUP_INPUT__:%s\\n" "$line"'`
+const BLACK: TerminalViewRgb = [0, 0, 0]
+
+function afterCommand(shell: string): string {
+  if (shell === 'fish') {
+    return `if set -q ${POSIX_SHELL_STARTUP_COMMAND_ENV}; echo __AFTER_ENV__:present; else; echo __AFTER_ENV__:missing; end; exit\n`
+  }
+  return `printf '__AFTER_ENV__:%s\\n' "\${${POSIX_SHELL_STARTUP_COMMAND_ENV}-missing}"; exit\n`
+}
+
+describe('local POSIX shell startup-command delivery', () => {
+  let testHome: string | undefined
+
+  afterEach(() => {
+    if (testHome) {
+      rmSync(testHome, { recursive: true, force: true })
+      testHome = undefined
+    }
+  })
+
+  it.each(SHELLS)(
+    '%s runs the command once, forwards stdin, and keeps the shell',
+    async (shell) => {
+      testHome = mkdtempSync(join(tmpdir(), `orca-${shell}-startup-command-`))
+      setTestUserDataPath(testHome)
+      const launch = getShellLaunchConfig(
+        shell,
+        ['overlay', 'markers', 'ready', 'identity'],
+        STARTUP_COMMAND
+      )
+      expect(launch.env[POSIX_SHELL_STARTUP_COMMAND_ENV]).toBe(STARTUP_COMMAND)
+
+      const output = await new Promise<string>((resolve, reject) => {
+        let proc!: pty.IPty
+        const emulator = new HeadlessEmulator({
+          cols: 120,
+          rows: 30,
+          onQueryReply: (reply) => {
+            if (!ingress.answerLiveQueryReply(reply)) {
+              proc.write(reply)
+            }
+          }
+        })
+        emulator.installViewAttributeResponder(() => ({
+          foreground: [255, 255, 255],
+          background: BLACK,
+          cursor: [255, 255, 255],
+          ansi: Array.from({ length: 256 }, () => BLACK),
+          colorSchemeMode: 'dark',
+          cursorStyle: 'block',
+          cursorBlink: false
+        }))
+        proc = pty.spawn(shell, launch.args ?? [], {
+          cols: 120,
+          rows: 30,
+          cwd: testHome,
+          env: {
+            ...process.env,
+            ...launch.env,
+            HOME: testHome,
+            ORCA_ORIG_ZDOTDIR: testHome,
+            ORCA_ZSHENV_SOURCE_DIR: testHome,
+            TERM: 'xterm-256color'
+          }
+        })
+        let transcript = ''
+        let sentInput = false
+        let sentAfter = false
+        const ingress = new PtyStartupIngress({
+          ownerBackend: 'posix-pty',
+          write: (data) => proc.write(data),
+          onEmission: (emission) => {
+            transcript += emission.data
+            void emulator.write(emission.data, { forwardQueryReplies: true })
+            if (!sentInput && transcript.includes(STARTUP_COMMAND)) {
+              sentInput = true
+              proc.write('hello\n')
+            }
+            if (!sentAfter && transcript.includes('__STARTUP_INPUT__:hello')) {
+              sentAfter = true
+              proc.write(afterCommand(shell))
+            }
+          }
+        })
+        const timeout = setTimeout(() => {
+          proc.kill()
+          emulator.dispose()
+          reject(new Error(`${shell} startup command timed out: ${JSON.stringify(transcript)}`))
+        }, 5_000)
+
+        proc.onData((data) => ingress.accept(data))
+        proc.onExit(() => {
+          clearTimeout(timeout)
+          ingress.drainAndClose()
+          emulator.dispose()
+          resolve(transcript)
+        })
+      })
+
+      expect(output.split(STARTUP_COMMAND)).toHaveLength(2)
+      expect(output).toContain('__STARTUP_INPUT__:hello')
+      expect(output).toContain('__AFTER_ENV__:missing')
+    }
+  )
+})

--- a/src/main/pty/posix-shell-startup-command.ts
+++ b/src/main/pty/posix-shell-startup-command.ts
@@ -1,0 +1,41 @@
+import { basename, win32 as pathWin32 } from 'node:path'
+
+export const POSIX_SHELL_STARTUP_COMMAND_ENV = 'ORCA_POSIX_SHELL_STARTUP_COMMAND'
+
+export function supportsPosixShellStartupCommand(shellPath: string): boolean {
+  const shellName = pathWin32.basename(basename(shellPath)).toLowerCase()
+  return shellName === 'bash' || shellName === 'zsh' || shellName === 'fish'
+}
+
+export function getBashStartupCommandPromptBlock(): string {
+  return `if [[ \${${POSIX_SHELL_STARTUP_COMMAND_ENV}+present} == present ]]; then
+  __orca_remove_startup_command_prompt_hook() {
+    local __orca_item
+    local -a __orca_remaining=()
+    if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1) )); then
+      for __orca_item in "\${PROMPT_COMMAND[@]+"\${PROMPT_COMMAND[@]}"}"; do
+        [[ "$__orca_item" == "__orca_run_startup_command" ]] || __orca_remaining+=("$__orca_item")
+      done
+      PROMPT_COMMAND=("\${__orca_remaining[@]+"\${__orca_remaining[@]}"}")
+    else
+      for __orca_item in "\${__orca_prompt_command_suffix[@]+"\${__orca_prompt_command_suffix[@]}"}"; do
+        [[ "$__orca_item" == "__orca_run_startup_command" ]] || __orca_remaining+=("$__orca_item")
+      done
+      __orca_prompt_command_suffix=("\${__orca_remaining[@]+"\${__orca_remaining[@]}"}")
+    fi
+  }
+  __orca_run_startup_command() {
+    local __orca_command="$${POSIX_SHELL_STARTUP_COMMAND_ENV}" __orca_status
+    unset ${POSIX_SHELL_STARTUP_COMMAND_ENV}
+    __orca_remove_startup_command_prompt_hook
+    unset -f __orca_remove_startup_command_prompt_hook
+    builtin history -s "$__orca_command" 2>/dev/null || true
+    builtin printf '%s\n' "$__orca_command"
+    eval "$__orca_command"
+    __orca_status=$?
+    unset -f __orca_run_startup_command
+    return "$__orca_status"
+  }
+  __orca_append_prompt_command "__orca_run_startup_command"
+fi`
+}

--- a/src/main/shell-startup-feature-channel.test.ts
+++ b/src/main/shell-startup-feature-channel.test.ts
@@ -15,6 +15,7 @@ import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:f
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { POSIX_SHELL_STARTUP_COMMAND_ENV } from './pty/posix-shell-startup-command'
 import { selectShellStartupFeatures } from './shell-startup-features'
 import { runZshPty } from './zsh-startup-hook-pty-harness'
 import { ZSH_WRAPPER_DIR_MARKER_FILE } from './shell-templates'
@@ -125,6 +126,16 @@ describePosix('zsh launch config', () => {
     const config = getShellLaunchConfig('/bin/zsh', ['history'])
 
     expect(config.env.ORCA_SHELL_FEATURES).toBe('history')
+  })
+
+  it('wraps a startup-only command without enabling shell readiness', async () => {
+    const { getShellLaunchConfig } = await importFreshLocalPtyShellReady()
+
+    const config = getShellLaunchConfig('/bin/zsh', [], 'codex')
+
+    expect(config.env.ORCA_SHELL_FEATURES).toBe('startup')
+    expect(config.env[POSIX_SHELL_STARTUP_COMMAND_ENV]).toBe('codex')
+    expect(config.supportsReadyMarker).toBe(false)
   })
 
   it('falls back to plain login zsh when the wrapper tree cannot be written', async () => {

--- a/src/main/shell-startup-features.ts
+++ b/src/main/shell-startup-features.ts
@@ -18,7 +18,8 @@ export const SHELL_STARTUP_FEATURES = [
   'history',
   'markers',
   'ready',
-  'identity'
+  'identity',
+  'startup'
 ] as const
 
 export type ShellStartupFeature = (typeof SHELL_STARTUP_FEATURES)[number]

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -1,6 +1,7 @@
 // Why: local PTYs and the daemon/SSH path must use identical ZDOTDIR discovery;
 // small drift here breaks different terminal transports in different ways.
 import { SHELL_STARTUP_FEATURE_ENV } from './shell-startup-features'
+import { POSIX_SHELL_STARTUP_COMMAND_ENV } from './pty/posix-shell-startup-command'
 
 /** Basename of the file every Orca-generated zsh wrapper dir is stamped with. */
 export const ZSH_WRAPPER_DIR_MARKER_FILE = '.orca-shell-wrapper'
@@ -146,7 +147,24 @@ fi`
 // first hook and fails — silently suppressing the marker and stalling every
 // startup command on the pre-ready timeout. Instead, own zle-line-init: emit
 // the marker first, then chain to whatever widget was installed before.
-export function getZshShellReadyMarkerRegistrationBlock(escapedMarker: string): string {
+export function getZshShellReadyMarkerRegistrationBlock(
+  escapedMarker: string,
+  supportsStartupCommand = false
+): string {
+  const markerBlock = supportsStartupCommand
+    ? `  if [[ "\${__orca_emit_ready_marker-1}" == 1 ]]; then
+    printf "${escapedMarker}"
+  fi`
+    : `  printf "${escapedMarker}"`
+  const startupCommandBlock = supportsStartupCommand
+    ? `
+  if (( \${+${POSIX_SHELL_STARTUP_COMMAND_ENV}} )); then
+    BUFFER="\$${POSIX_SHELL_STARTUP_COMMAND_ENV}"
+    CURSOR=\${#BUFFER}
+    builtin unset ${POSIX_SHELL_STARTUP_COMMAND_ENV}
+    zle accept-line
+  fi`
+    : ''
   return `# Why: capture the prior zle-line-init so the marker chains to it. On a
 # re-source we are already the bound widget, so keep the function captured
 # the first time instead of clobbering it to empty (which would silently
@@ -161,14 +179,14 @@ else
   __orca_prev_line_init_fn=""
 fi
 __orca_prompt_mark() {
-  printf "${escapedMarker}"
+${markerBlock}
   # Why: call the prior hook as a plain function, not an aliased widget, so
   # $WIDGET stays zle-line-init for add-zle-hook-widget dispatchers.
   if [[ -n "\${__orca_prev_line_init_fn:-}" ]]; then
     "\${__orca_prev_line_init_fn}" "$@"
-  fi
+  fi${startupCommandBlock}
 }
-zle -N zle-line-init __orca_prompt_mark`
+zle -N zle-line-init __orca_prompt_mark`.replace(/\n\n}\n$/, '\n}\n')
 }
 
 // Why: fish has no ZDOTDIR-style wrapper dir, so the marker rides `--init-command`,
@@ -181,9 +199,22 @@ zle -N zle-line-init __orca_prompt_mark`
 //
 // Why no feature variable: the init command is composed per pane, so the
 // selection is already baked into the text and nothing needs to be exported.
-export function getFishShellReadyInitCommand(escapedMarker: string): string {
+export function getFishShellReadyInitCommand(
+  escapedMarker: string,
+  emitReadyMarker = true,
+  supportsStartupCommand = false
+): string {
+  const readyMarkerBlock = emitReadyMarker ? `  builtin printf "${escapedMarker}"\n` : ''
+  const startupCommandBlock = supportsStartupCommand
+    ? `  if set -q ${POSIX_SHELL_STARTUP_COMMAND_ENV}
+    set -l __orca_command "\$${POSIX_SHELL_STARTUP_COMMAND_ENV}"
+    set -e ${POSIX_SHELL_STARTUP_COMMAND_ENV}
+    builtin printf '%s\\n' "$__orca_command"
+    eval "$__orca_command"
+    return $status
+  end\n`
+    : ''
   return `function __orca_shell_ready_marker --on-event fish_prompt
-  builtin printf "${escapedMarker}"
-  functions -e __orca_shell_ready_marker
-end`
+${readyMarkerBlock}  functions -e __orca_shell_ready_marker
+${startupCommandBlock}end`
 }

--- a/src/main/shell-wrapper-generated-file-snapshot.test.ts
+++ b/src/main/shell-wrapper-generated-file-snapshot.test.ts
@@ -66,12 +66,14 @@ async function expectWrapperFiles(transport: string, root: string): Promise<void
  * markers register through.
  */
 const CONTRACT_GLOBALS = new Set([
+  'BUFFER',
   'CODEX_HOME',
   'HISTFILE',
   'MIMOCODE_HOME',
   'OPENCODE_CONFIG_DIR',
   'PATH',
   'PROMPT_COMMAND',
+  'CURSOR',
   'ZDOTDIR',
   'precmd_functions',
   'preexec_functions'

--- a/src/main/zsh-startup-wrapper-builder.ts
+++ b/src/main/zsh-startup-wrapper-builder.ts
@@ -54,6 +54,8 @@ export type ZshStartupHookSpec = {
   readyMarkerEscaped: string
   /** OSC 133 command-lifecycle hooks (behind the `markers` feature). */
   osc133CommandMarkers: boolean
+  /** Local-only command delivery from the first zle line editor. */
+  startupCommandDelivery: boolean
   /** Comment heading the overlay restores inside the hook. */
   overlayRestoreComment: string
   restores: ZshWrapperRestoreSpec
@@ -147,6 +149,15 @@ function buildDeferredInit(spec: ZshStartupHookSpec): string {
     precmd_functions=(\${precmd_functions:#__orca_deferred_init})
   fi`
     : `  precmd_functions=(\${precmd_functions:#__orca_deferred_init})`
+  const lineInitRegistration = spec.startupCommandDelivery
+    ? `  if __orca_has_feature ready || __orca_has_feature startup; then
+    __orca_emit_ready_marker=""
+    __orca_has_feature ready && __orca_emit_ready_marker=1
+${indentBlock(getZshShellReadyMarkerRegistrationBlock(spec.readyMarkerEscaped, true), '    ')}
+  fi`
+    : featureGuard('ready', [
+        indentBlock(getZshShellReadyMarkerRegistrationBlock(spec.readyMarkerEscaped), '')
+      ])
 
   return `__orca_deferred_init() {
   # Why first: this body runs after the user's own config, so it would otherwise
@@ -165,9 +176,7 @@ ${joinBlocks([
   `  if [[ -n "\${_orca_histfile:-}" ]]; then
     HISTFILE="$_orca_histfile"
   fi`,
-  featureGuard('ready', [
-    indentBlock(getZshShellReadyMarkerRegistrationBlock(spec.readyMarkerEscaped), '')
-  ])
+  lineInitRegistration
 ])}
 ${
   spec.osc133CommandMarkers

--- a/src/relay/pty-shell-overlay-wrappers.ts
+++ b/src/relay/pty-shell-overlay-wrappers.ts
@@ -28,6 +28,7 @@ function getRelayZshWrapperSpec(): ZshStartupHookSpec {
     headerLabel: 'Orca relay zsh overlay wrapper',
     readyMarkerEscaped: SHELL_READY_MARKER_ESCAPED,
     osc133CommandMarkers: false,
+    startupCommandDelivery: false,
     overlayRestoreComment:
       '# Why: remote startup files can re-export user defaults after relay spawn.',
     restores: {

--- a/src/shared/pty-slave-line-discipline-echo.test.ts
+++ b/src/shared/pty-slave-line-discipline-echo.test.ts
@@ -95,8 +95,8 @@ describe('createPtySlaveLineEditorProbe', () => {
     execFileMock.mockImplementationOnce((_c, _a, _o, cb) =>
       cb(Object.assign(new Error('not a tty'), { code: 1 }), '', '')
     )
-    await expect(probe?.()).resolves.toBe('unknown')
-    await expect(probe?.()).resolves.toBe('unknown')
+    await expect(probe?.()).resolves.toBe('unavailable')
+    await expect(probe?.()).resolves.toBe('unavailable')
     expect(execFileMock).toHaveBeenCalledTimes(5)
   })
 })

--- a/src/shared/pty-slave-line-discipline-echo.ts
+++ b/src/shared/pty-slave-line-discipline-echo.ts
@@ -10,7 +10,7 @@ import { execFile, type ExecFileException } from 'node:child_process'
 /** `unknown` means "could not be determined", never "assume quiet". */
 export type PtySlaveLineDisciplineEcho = 'echoing' | 'quiet' | 'unknown'
 
-export type PtySlaveLineEditorState = 'line-editor' | 'other' | 'unknown'
+export type PtySlaveLineEditorState = 'line-editor' | 'other' | 'unknown' | 'unavailable'
 
 export type PtySlaveLineEditorProbe = () => Promise<PtySlaveLineEditorState>
 
@@ -91,7 +91,7 @@ function createSttyProbe<T extends string>(
   ptsName: string | undefined,
   platform: NodeJS.Platform,
   parse: (output: string) => T | 'unknown'
-): (() => Promise<T | 'unknown'>) | undefined {
+): (() => Promise<T | 'unknown' | 'unavailable'>) | undefined {
   if (platform === 'win32' || !ptsName) {
     return undefined
   }
@@ -103,13 +103,17 @@ function createSttyProbe<T extends string>(
   let inFlight: Promise<SttyProbeResult> | null = null
   return async () => {
     if (unavailable) {
-      return 'unknown'
+      return 'unavailable'
     }
     inFlight ??= runStty(ptsName, platform).finally(() => {
       inFlight = null
     })
     const result = await inFlight
     unavailable = result.permanent
-    return result.stdout === null ? 'unknown' : parse(result.stdout)
+    return result.stdout === null
+      ? result.permanent
+        ? 'unavailable'
+        : 'unknown'
+      : parse(result.stdout)
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​274 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​255 |
| Prod | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​168 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​38 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​130 |

<!-- /orca-pr-loc -->

## ELI5

Codex was being sent through the PTY as synthetic keystrokes while zsh/bash/fish were still switching into line-edit mode. The shell could echo that input once, then echo the same command again when the prompt took over. The command now enters through the existing POSIX shell startup wrappers, so the shell owns the handoff and prints it once.

## What changed

- Added a private `startup` shell feature and `ORCA_POSIX_SHELL_STARTUP_COMMAND` transport for recognized local Codex launches.
- zsh places the command in `BUFFER` and calls `zle accept-line` from `zle-line-init`.
- bash runs a one-shot `PROMPT_COMMAND` hook, removes its hook/functions, records history, prints once, and evaluates the command.
- fish runs a one-shot `fish_prompt` event, removes the event, prints once, and evaluates the command.
- Inherited startup-command state is scrubbed before every spawn.
- Unsupported/unwrapped shells keep the existing PTY writer. Windows, WSL, SSH, daemon, relay, and remote wire paths are unchanged.
- Removed the earlier `stty` polling path entirely.

## Root cause

The old path wrote the command into the PTY after the readiness marker. That marker runs before the interactive line editor has necessarily disabled terminal echo, so the kernel/readline transition could expose two visible command lines. Moving delivery into the shell's own line-editor/prompt hooks removes that race instead of adding a delay or polling deadline.

## Visual proof

### Before (duplicate command)

![Before: Codex startup command appears twice](https://github.com/user-attachments/assets/bb8b24b3-784a-4320-868e-73ae2d6bd69f)

### After (one command, live Codex session)

![After: Codex startup command appears once](https://github.com/user-attachments/assets/df93b1b3-22c7-441e-8d45-ac066e77ab19)

## Performance Measurement

There is no added main-process wait, timer, PTY write, `stty` subprocess, or renderer work on the supported direct path. The wrapper consumes an already-exported value at the shell's first prompt; its one-shot hook and environment entry are removed immediately after delivery. This is strictly less work than the previous polling implementation and avoids a fixed settle delay.

## Testing

- Real node-pty integration: bash, zsh, and fish each display the startup command exactly once, forward child stdin, clear the command environment, and remain usable afterward.
- Full `terminal-session.shell-ready-exec-prompt-fallback` gate: **261 tests passed across 16 files**.
- Focused wrapper/provider/snapshot tests: **82 tests passed**.
- Node typecheck: passed.
- Direct Oxlint changed-file scan: 0 warnings, 0 errors.
- `git diff --check`: passed.
- Electron CDP validation: fresh profile, intended worktree identity, real New tab → Codex flow, rendered command exactly once.

The local `pnpm` shim is broken for this checkout (`pnpm@12` resolves to `ENOEXEC`), so the equivalent repository-installed binaries were used for formatting, Vitest, TypeScript, and Oxlint checks; this is an environment issue, not a product failure.

## Merge risk

The change is isolated to local POSIX startup delivery. Snapshot tests verify daemon and relay wrapper output remains unchanged; fallback tests verify unsupported shells retain PTY delivery and inherited state cannot leak across panes. No UI, persistence, IPC, remote protocol, SSH, WSL, Windows, or agent-command construction changes are included.

## Linked issue

N/A — reproduced from a direct report in this worktree.

## User-Facing Trade-offs

None. The supported direct path removes a polling subprocess and fixed wait; unsupported shells and all remote/Windows/WSL paths retain their existing behavior.