### PR TITLE
perf(relay): stop ACK boundary scans at first pending boundary

### DIFF
--- a/config/scripts/pty-source-ack-boundary-benchmark.mjs
+++ b/config/scripts/pty-source-ack-boundary-benchmark.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Benchmarks relay PTY sent-boundary cleanup across a cumulative ACK drain, using the shipped
+// PtySourceSentBoundaries rather than a stub so V8's real Set/array costs are included.
+import { performance } from 'node:perf_hooks'
+import { createJiti } from 'jiti'
+
+const BOUNDARY_COUNTS = [1_024, 4_096, 16_384, 65_536]
+// Set rehash timing swings run to run, so every row reports a median instead of a single sample.
+const REPETITIONS = 3
+const jiti = createJiti(import.meta.url)
+const { PtySourceSentBoundaries } = await jiti.import(
+  '../../src/relay/pty-source-sent-boundaries.ts'
+)
+
+// Pre-change cleanup: rescan every retained boundary on every ACK.
+function fullScanDrain(count) {
+  const boundaries = new Set()
+  for (let boundary = 0; boundary <= count; boundary += 1) {
+    boundaries.add(boundary)
+  }
+  const started = performance.now()
+  for (let creditedEndSu = 1; creditedEndSu <= count; creditedEndSu += 1) {
+    for (const boundary of boundaries) {
+      if (boundary < creditedEndSu) {
+        boundaries.delete(boundary)
+      }
+    }
+  }
+  return performance.now() - started
+}
+
+// Early-break cleanup: stops at the first live boundary, but still rebuilds a Set iterator per ACK.
+function earlyBreakDrain(count) {
+  const boundaries = new Set()
+  for (let boundary = 0; boundary <= count; boundary += 1) {
+    boundaries.add(boundary)
+  }
+  const started = performance.now()
+  for (let creditedEndSu = 1; creditedEndSu <= count; creditedEndSu += 1) {
+    for (const boundary of boundaries) {
+      if (boundary >= creditedEndSu) {
+        break
+      }
+      boundaries.delete(boundary)
+    }
+  }
+  return performance.now() - started
+}
+
+// Shipped cleanup: a monotone cursor over ascending boundaries, so no boundary is ever revisited.
+function cursorDrain(count) {
+  const boundaries = new PtySourceSentBoundaries(0)
+  for (let boundary = 1; boundary <= count; boundary += 1) {
+    boundaries.add(boundary)
+  }
+  const started = performance.now()
+  for (let creditedEndSu = 1; creditedEndSu <= count; creditedEndSu += 1) {
+    boundaries.dropBelow(creditedEndSu)
+  }
+  return performance.now() - started
+}
+
+function medianMs(drain, count) {
+  const samples = Array.from({ length: REPETITIONS }, () => drain(count)).sort((a, b) => a - b)
+  return samples[(samples.length - 1) >> 1]
+}
+
+function report(count) {
+  const fullScanMs = medianMs(fullScanDrain, count)
+  const earlyBreakMs = medianMs(earlyBreakDrain, count)
+  const cursorMs = medianMs(cursorDrain, count)
+  console.log(
+    `${String(count).padStart(6)} boundaries  ` +
+      `full-scan ${fullScanMs.toFixed(2)}ms  ` +
+      `early-break ${earlyBreakMs.toFixed(2)}ms  ` +
+      `cursor ${cursorMs.toFixed(3)}ms  ` +
+      `(cursor is ${(fullScanMs / cursorMs).toFixed(0)}x faster than full-scan, ` +
+      `${(earlyBreakMs / cursorMs).toFixed(0)}x faster than early-break)`
+  )
+}
+
+// Warm the three drains up first so the smallest row is not dominated by JIT tiering.
+fullScanDrain(256)
+earlyBreakDrain(256)
+cursorDrain(256)
+
+for (const count of BOUNDARY_COUNTS) {
+  report(count)
+}

--- a/src/relay/pty-source-credit-ledger.test.ts
+++ b/src/relay/pty-source-credit-ledger.test.ts
@@ -6,8 +6,9 @@ import {
 } from '../shared/pty-source-credit-contract'
 import { RelayPtySourceCreditLedger } from './pty-source-credit-ledger'
 import { CLOSED_DELIVERY_TOMBSTONE_LIMIT, type DeliveryRecord } from './pty-source-credit-record'
+import type { PtySourceSentBoundaries } from './pty-source-sent-boundaries'
 
-type BoundaryRecord = { sentBoundaries: Set<number> }
+type BoundaryRecord = { sentBoundaries: PtySourceSentBoundaries }
 
 function getBoundaryRecord(
   ledger: RelayPtySourceCreditLedger,
@@ -19,43 +20,6 @@ function getBoundaryRecord(
     throw new Error('test delivery record missing')
   }
   return record
-}
-
-type CountingBoundarySet = Set<number> & { readonly visits: number }
-
-function createCountingBoundarySet(boundaries: readonly number[]): CountingBoundarySet {
-  const pending = new Set(boundaries)
-  let visits = 0
-  return {
-    get visits() {
-      return visits
-    },
-    has: (boundary: number) => pending.has(boundary),
-    delete: (boundary: number) => pending.delete(boundary),
-    *[Symbol.iterator](): IterableIterator<number> {
-      for (const boundary of pending) {
-        visits += 1
-        yield boundary
-      }
-    }
-  } as unknown as CountingBoundarySet
-}
-
-function countLegacyBoundaryVisits(
-  boundaries: readonly number[],
-  credits: readonly number[]
-): number {
-  const pending = new Set(boundaries)
-  let visits = 0
-  for (const creditedEndSu of credits) {
-    for (const boundary of pending) {
-      visits += 1
-      if (boundary < creditedEndSu) {
-        pending.delete(boundary)
-      }
-    }
-  }
-  return visits
 }
 
 function identity(
@@ -290,7 +254,7 @@ describe('RelayPtySourceCreditLedger', () => {
     expect(ledger.reserveNextSend(owner, 2)!.span.data).toBe('ef')
   })
 
-  it('stops ACK boundary cleanup at the first uncredited boundary', () => {
+  it('reclaims every credited boundary across a long sequential ACK drain', () => {
     const boundaryCount = 1_024
     const spanCount = boundaryCount - 1
     const ledger = new RelayPtySourceCreditLedger({
@@ -307,14 +271,11 @@ describe('RelayPtySourceCreditLedger', () => {
     }
 
     const record = getBoundaryRecord(ledger, owner)
-    const insertionOrder = [...record.sentBoundaries]
-    expect(insertionOrder).toEqual(Array.from({ length: boundaryCount }, (_, index) => index))
-    const countedBoundaries = createCountingBoundarySet(insertionOrder)
-    record.sentBoundaries = countedBoundaries
-    const credits = Array.from({ length: spanCount }, (_, index) => index + 1)
-    const legacyVisits = countLegacyBoundaryVisits(insertionOrder, credits)
+    expect([...record.sentBoundaries]).toEqual(
+      Array.from({ length: boundaryCount }, (_, index) => index)
+    )
 
-    for (const creditedEndSu of credits) {
+    for (let creditedEndSu = 1; creditedEndSu <= spanCount; creditedEndSu += 1) {
       expect(
         ledger.acknowledge(owner, {
           id: owner.id,
@@ -324,12 +285,13 @@ describe('RelayPtySourceCreditLedger', () => {
           creditedEndSu
         })
       ).toBe('advanced')
+      // Every boundary below the credit must be gone, so the oldest live one is the credit itself.
+      const [oldestLive] = record.sentBoundaries
+      expect(oldestLive).toBe(creditedEndSu)
     }
 
-    expect(legacyVisits).toBe(524_799)
-    expect(countedBoundaries.visits).toBe(2_046)
-    expect(ledger.retentionSnapshot()).toEqual({ sourceSu: 0, dataBytes: 0, spans: 0 })
     expect([...record.sentBoundaries]).toEqual([spanCount])
+    expect(ledger.retentionSnapshot()).toEqual({ sourceSu: 0, dataBytes: 0, spans: 0 })
   })
 
   it('deletes every boundary skipped by a jump-ahead cumulative ACK', () => {

--- a/src/relay/pty-source-credit-ledger.test.ts
+++ b/src/relay/pty-source-credit-ledger.test.ts
@@ -1,20 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import {
   ptySourceDeliveryKey,
-  type PtySourceDeliveryIdentity,
-  type PtySourceSpan
+  type PtySourceDeliveryIdentity
 } from '../shared/pty-source-credit-contract'
 import { RelayPtySourceCreditLedger } from './pty-source-credit-ledger'
 import { CLOSED_DELIVERY_TOMBSTONE_LIMIT, type DeliveryRecord } from './pty-source-credit-record'
-import type { PtySourceSentBoundaries } from './pty-source-sent-boundaries'
 
-type BoundaryRecord = { sentBoundaries: PtySourceSentBoundaries }
-
-function getBoundaryRecord(
+function getDeliveryRecord(
   ledger: RelayPtySourceCreditLedger,
   owner: PtySourceDeliveryIdentity
-): BoundaryRecord {
-  const internals = ledger as unknown as { deliveries: Map<string, BoundaryRecord> }
+): DeliveryRecord {
+  const internals = ledger as unknown as { deliveries: Map<string, DeliveryRecord> }
   const record = internals.deliveries.get(ptySourceDeliveryKey(owner))
   if (!record) {
     throw new Error('test delivery record missing')
@@ -70,23 +66,6 @@ function drainOne(
   return reservation
 }
 
-type CursorRecord = {
-  spans: PtySourceSpan[]
-  sendSpanIndex: number
-}
-
-function getCursorRecord(
-  ledger: RelayPtySourceCreditLedger,
-  owner: PtySourceDeliveryIdentity
-): CursorRecord {
-  const internals = ledger as unknown as { deliveries: Map<string, CursorRecord> }
-  const record = internals.deliveries.get(ptySourceDeliveryKey(owner))
-  if (!record) {
-    throw new Error('test delivery record missing')
-  }
-  return record
-}
-
 // Why: retention totals are maintained incrementally, so recomputing from the live records is
 // the only independent check that no mutation path skipped a counter update.
 function expectRetentionMatchesRecords(ledger: RelayPtySourceCreditLedger): void {
@@ -117,7 +96,7 @@ describe('RelayPtySourceCreditLedger', () => {
       append(ledger, owner, 'x', `span-${index}`)
     }
 
-    const record = getCursorRecord(ledger, owner)
+    const record = getDeliveryRecord(ledger, owner)
     let indexedReads = 0
     const spans = record.spans
     record.spans = new Proxy(spans, {
@@ -151,7 +130,7 @@ describe('RelayPtySourceCreditLedger', () => {
     const owner = identity('token-gap')
     ledger.open(owner, 8)
     append(ledger, owner, 'ab', 'span-gap')
-    const record = getCursorRecord(ledger, owner)
+    const record = getDeliveryRecord(ledger, owner)
     record.spans = [
       Object.freeze({
         ...record.spans[0],
@@ -180,7 +159,7 @@ describe('RelayPtySourceCreditLedger', () => {
 
     const first = ledger.reserveNextSend(oldOwner, 2)!
     ledger.commitSend(first)
-    expect(getCursorRecord(ledger, oldOwner).sendSpanIndex).toBe(0)
+    expect(getDeliveryRecord(ledger, oldOwner).sendSpanIndex).toBe(0)
     ledger.acknowledge(oldOwner, {
       id: oldOwner.id,
       clientGeneration: oldOwner.clientGeneration,
@@ -188,7 +167,7 @@ describe('RelayPtySourceCreditLedger', () => {
       deliveryToken: oldOwner.deliveryToken,
       creditedEndSu: 2
     })
-    expect(getCursorRecord(ledger, oldOwner).sendSpanIndex).toBe(0)
+    expect(getDeliveryRecord(ledger, oldOwner).sendSpanIndex).toBe(0)
 
     const attempted = ledger.reserveNextSend(oldOwner, 1)!
     expect(attempted.span.data).toBe('c')
@@ -200,7 +179,7 @@ describe('RelayPtySourceCreditLedger', () => {
     ledger.commitSend(ledger.reserveNextSend(oldOwner, 2)!)
     const rotation = ledger.rotate(oldOwner, replacement, 2, 16)
     expect(rotation.recovery.map((span) => span.data).join('')).toBe('cdef')
-    expect(getCursorRecord(ledger, replacement).sendSpanIndex).toBe(0)
+    expect(getDeliveryRecord(ledger, replacement).sendSpanIndex).toBe(0)
     // Rotation is the only path that removes and re-adds a record in one call.
     expectRetentionMatchesRecords(ledger)
     ledger.commitSend(ledger.reserveNextSend(replacement, 16)!)
@@ -237,7 +216,7 @@ describe('RelayPtySourceCreditLedger', () => {
     append(ledger, owner, 'ef', 'span-c')
     ledger.commitSend(ledger.reserveNextSend(owner, 2)!)
     ledger.commitSend(ledger.reserveNextSend(owner, 2)!)
-    expect(getCursorRecord(ledger, owner).sendSpanIndex).toBe(1)
+    expect(getDeliveryRecord(ledger, owner).sendSpanIndex).toBe(1)
 
     ledger.acknowledge(owner, {
       id: owner.id,
@@ -248,7 +227,7 @@ describe('RelayPtySourceCreditLedger', () => {
     })
 
     // Reclaim dropped both spans the cursor had passed, so it must rebase onto the new head.
-    const record = getCursorRecord(ledger, owner)
+    const record = getDeliveryRecord(ledger, owner)
     expect(record.spans.map((span) => span.data)).toEqual(['ef'])
     expect(record.sendSpanIndex).toBe(0)
     expect(ledger.reserveNextSend(owner, 2)!.span.data).toBe('ef')
@@ -270,7 +249,7 @@ describe('RelayPtySourceCreditLedger', () => {
       ledger.commitSend(reservation!)
     }
 
-    const record = getBoundaryRecord(ledger, owner)
+    const record = getDeliveryRecord(ledger, owner)
     expect([...record.sentBoundaries]).toEqual(
       Array.from({ length: boundaryCount }, (_, index) => index)
     )
@@ -304,7 +283,7 @@ describe('RelayPtySourceCreditLedger', () => {
     for (let index = 0; index < 8; index += 1) {
       ledger.commitSend(ledger.reserveNextSend(owner, 1)!)
     }
-    const record = getBoundaryRecord(ledger, owner)
+    const record = getDeliveryRecord(ledger, owner)
     expect([...record.sentBoundaries]).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8])
 
     expect(
@@ -333,7 +312,7 @@ describe('RelayPtySourceCreditLedger', () => {
         const reservation = drainOne(ledger, owner, 1 + ((seed * 13 + turn * 7) % 19))
         const snapshot = ledger.snapshot(owner)
         expect(snapshot.sentEndSu - snapshot.creditedEndSu).toBeLessThanOrEqual(windowSu)
-        const record = getCursorRecord(ledger, owner)
+        const record = getDeliveryRecord(ledger, owner)
         const containingIndex = record.spans.findIndex(
           (span) =>
             span.sourceStartSu <= snapshot.sentEndSu && span.sourceEndSu > snapshot.sentEndSu
@@ -470,7 +449,7 @@ describe('RelayPtySourceCreditLedger', () => {
 
     ledger.commitSend(pending)
     expect(ledger.snapshot(owner)).toMatchObject({ sentEndSu: 4, creditedEndSu: 4 })
-    expect([...getBoundaryRecord(ledger, owner).sentBoundaries]).toEqual([4])
+    expect([...getDeliveryRecord(ledger, owner).sentBoundaries]).toEqual([4])
     expect(ledger.retentionSnapshot()).toEqual({ sourceSu: 0, dataBytes: 0, spans: 0 })
   })
 

--- a/src/relay/pty-source-credit-ledger.test.ts
+++ b/src/relay/pty-source-credit-ledger.test.ts
@@ -7,6 +7,57 @@ import {
 import { RelayPtySourceCreditLedger } from './pty-source-credit-ledger'
 import { CLOSED_DELIVERY_TOMBSTONE_LIMIT, type DeliveryRecord } from './pty-source-credit-record'
 
+type BoundaryRecord = { sentBoundaries: Set<number> }
+
+function getBoundaryRecord(
+  ledger: RelayPtySourceCreditLedger,
+  owner: PtySourceDeliveryIdentity
+): BoundaryRecord {
+  const internals = ledger as unknown as { deliveries: Map<string, BoundaryRecord> }
+  const record = internals.deliveries.get(ptySourceDeliveryKey(owner))
+  if (!record) {
+    throw new Error('test delivery record missing')
+  }
+  return record
+}
+
+type CountingBoundarySet = Set<number> & { readonly visits: number }
+
+function createCountingBoundarySet(boundaries: readonly number[]): CountingBoundarySet {
+  const pending = new Set(boundaries)
+  let visits = 0
+  return {
+    get visits() {
+      return visits
+    },
+    has: (boundary: number) => pending.has(boundary),
+    delete: (boundary: number) => pending.delete(boundary),
+    *[Symbol.iterator](): IterableIterator<number> {
+      for (const boundary of pending) {
+        visits += 1
+        yield boundary
+      }
+    }
+  } as unknown as CountingBoundarySet
+}
+
+function countLegacyBoundaryVisits(
+  boundaries: readonly number[],
+  credits: readonly number[]
+): number {
+  const pending = new Set(boundaries)
+  let visits = 0
+  for (const creditedEndSu of credits) {
+    for (const boundary of pending) {
+      visits += 1
+      if (boundary < creditedEndSu) {
+        pending.delete(boundary)
+      }
+    }
+  }
+  return visits
+}
+
 function identity(
   deliveryToken = 'token-1',
   overrides: Partial<PtySourceDeliveryIdentity> = {}
@@ -237,6 +288,52 @@ describe('RelayPtySourceCreditLedger', () => {
     expect(record.spans.map((span) => span.data)).toEqual(['ef'])
     expect(record.sendSpanIndex).toBe(0)
     expect(ledger.reserveNextSend(owner, 2)!.span.data).toBe('ef')
+  })
+
+  it('stops ACK boundary cleanup at the first uncredited boundary', () => {
+    const boundaryCount = 1_024
+    const spanCount = boundaryCount - 1
+    const ledger = new RelayPtySourceCreditLedger({
+      maxRetainedSpans: boundaryCount,
+      maxAggregateRetainedSpans: boundaryCount
+    })
+    const owner = identity()
+    ledger.open(owner, boundaryCount)
+    for (let index = 0; index < spanCount; index += 1) {
+      append(ledger, owner, 'x', `span-${index}`)
+      const reservation = ledger.reserveNextSend(owner, 1)
+      expect(reservation).not.toBeNull()
+      ledger.commitSend(reservation!)
+    }
+
+    const record = getBoundaryRecord(ledger, owner)
+    const insertionOrder = [...record.sentBoundaries]
+    expect(insertionOrder).toEqual(Array.from({ length: boundaryCount }, (_, index) => index))
+    const countedBoundaries = createCountingBoundarySet(insertionOrder)
+    record.sentBoundaries = countedBoundaries
+    const credits = Array.from({ length: spanCount }, (_, index) => index + 1)
+    const legacyVisits = countLegacyBoundaryVisits(insertionOrder, credits)
+
+    for (const creditedEndSu of credits) {
+      expect(
+        ledger.acknowledge(owner, {
+          id: owner.id,
+          clientGeneration: owner.clientGeneration,
+          ownerGeneration: owner.ownerGeneration,
+          deliveryToken: owner.deliveryToken,
+          creditedEndSu
+        })
+      ).toBe('advanced')
+    }
+
+    expect(legacyVisits).toBe(524_799)
+    expect(countedBoundaries.visits).toBe(2_046)
+    expect(legacyVisits - countedBoundaries.visits).toBe(522_753)
+    console.log(
+      `[bench] ${boundaryCount} sent boundaries: ACK iterator visits ${legacyVisits} -> ${countedBoundaries.visits} ` +
+        `(-${(((legacyVisits - countedBoundaries.visits) / legacyVisits) * 100).toFixed(2)}%)`
+    )
+    expect(ledger.retentionSnapshot()).toEqual({ sourceSu: 0, dataBytes: 0, spans: 0 })
   })
 
   it('never exceeds a token source window across generated send/ACK sequences', () => {

--- a/src/relay/pty-source-credit-ledger.test.ts
+++ b/src/relay/pty-source-credit-ledger.test.ts
@@ -288,6 +288,8 @@ describe('RelayPtySourceCreditLedger', () => {
       // Every boundary below the credit must be gone, so the oldest live one is the credit itself.
       const [oldestLive] = record.sentBoundaries
       expect(oldestLive).toBe(creditedEndSu)
+      // Boundary cleanup and span reclamation must stay in step on every ACK, not just the last.
+      expect(ledger.retentionSnapshot().spans).toBe(spanCount - creditedEndSu)
     }
 
     expect([...record.sentBoundaries]).toEqual([spanCount])

--- a/src/relay/pty-source-credit-ledger.test.ts
+++ b/src/relay/pty-source-credit-ledger.test.ts
@@ -328,12 +328,31 @@ describe('RelayPtySourceCreditLedger', () => {
 
     expect(legacyVisits).toBe(524_799)
     expect(countedBoundaries.visits).toBe(2_046)
-    expect(legacyVisits - countedBoundaries.visits).toBe(522_753)
-    console.log(
-      `[bench] ${boundaryCount} sent boundaries: ACK iterator visits ${legacyVisits} -> ${countedBoundaries.visits} ` +
-        `(-${(((legacyVisits - countedBoundaries.visits) / legacyVisits) * 100).toFixed(2)}%)`
-    )
     expect(ledger.retentionSnapshot()).toEqual({ sourceSu: 0, dataBytes: 0, spans: 0 })
+    expect([...record.sentBoundaries]).toEqual([spanCount])
+  })
+
+  it('deletes every boundary skipped by a jump-ahead cumulative ACK', () => {
+    const ledger = new RelayPtySourceCreditLedger()
+    const owner = identity()
+    ledger.open(owner, 16)
+    append(ledger, owner, 'abcdefgh')
+    for (let index = 0; index < 8; index += 1) {
+      ledger.commitSend(ledger.reserveNextSend(owner, 1)!)
+    }
+    const record = getBoundaryRecord(ledger, owner)
+    expect([...record.sentBoundaries]).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8])
+
+    expect(
+      ledger.acknowledge(owner, {
+        id: owner.id,
+        clientGeneration: owner.clientGeneration,
+        ownerGeneration: owner.ownerGeneration,
+        deliveryToken: owner.deliveryToken,
+        creditedEndSu: 8
+      })
+    ).toBe('advanced')
+    expect([...record.sentBoundaries]).toEqual([8])
   })
 
   it('never exceeds a token source window across generated send/ACK sequences', () => {
@@ -487,6 +506,7 @@ describe('RelayPtySourceCreditLedger', () => {
 
     ledger.commitSend(pending)
     expect(ledger.snapshot(owner)).toMatchObject({ sentEndSu: 4, creditedEndSu: 4 })
+    expect([...getBoundaryRecord(ledger, owner).sentBoundaries]).toEqual([4])
     expect(ledger.retentionSnapshot()).toEqual({ sourceSu: 0, dataBytes: 0, spans: 0 })
   })
 

--- a/src/relay/pty-source-credit-record.ts
+++ b/src/relay/pty-source-credit-record.ts
@@ -17,6 +17,7 @@ import {
   assertPtySourceSpan
 } from '../shared/pty-source-credit-validation'
 import { chargedPtyRetainedStringBytes } from '../shared/pty-retained-string-memory'
+import { PtySourceSentBoundaries } from './pty-source-sent-boundaries'
 
 export const DEFAULT_RETAINED_SOURCE_SU = 512 * 1024
 export const DEFAULT_AGGREGATE_RETAINED_SOURCE_SU = 48 * 1024 * 1024
@@ -44,7 +45,7 @@ export type DeliveryRecord = {
   spans: PtySourceSpan[]
   /** First retained span that may contain the next unsent source unit. */
   sendSpanIndex: number
-  sentBoundaries: Set<number>
+  sentBoundaries: PtySourceSentBoundaries
   pendingSend: PtySourceSendReservation | null
   reservedAckEndSu: number | null
   attemptedEndSu: number | null
@@ -71,7 +72,7 @@ export function createDeliveryRecord(
     retainedDataBytes: 0,
     spans: [],
     sendSpanIndex: 0,
-    sentBoundaries: new Set([checkpointSourceEndSu]),
+    sentBoundaries: new PtySourceSentBoundaries(checkpointSourceEndSu),
     pendingSend: null,
     reservedAckEndSu: null,
     attemptedEndSu: null,

--- a/src/relay/pty-source-credit-settlement.ts
+++ b/src/relay/pty-source-credit-settlement.ts
@@ -101,6 +101,10 @@ export function commitPtySourceSend(
   if (record.pendingSend !== reservation) {
     throw new Error('PTY source send reservation is stale')
   }
+  // advanceCredit breaks on the first uncredited boundary, so sentBoundaries inserts must ascend.
+  if (reservation.span.sourceEndSu <= record.sentEndSu) {
+    throw new Error('PTY source send reservation regresses the sent boundary')
+  }
   record.pendingSend = null
   record.sentEndSu = reservation.span.sourceEndSu
   record.sentBoundaries.add(record.sentEndSu)

--- a/src/relay/pty-source-credit-settlement.ts
+++ b/src/relay/pty-source-credit-settlement.ts
@@ -31,9 +31,11 @@ function reclaimCreditedSpans(record: DeliveryRecord): void {
 function advanceCredit(record: DeliveryRecord, creditedEndSu: number): void {
   record.creditedEndSu = creditedEndSu
   for (const boundary of record.sentBoundaries) {
-    if (boundary < creditedEndSu) {
-      record.sentBoundaries.delete(boundary)
+    // Boundaries are inserted in increasing sentEndSu order, so later values cannot be eligible.
+    if (boundary >= creditedEndSu) {
+      break
     }
+    record.sentBoundaries.delete(boundary)
   }
   reclaimCreditedSpans(record)
 }

--- a/src/relay/pty-source-credit-settlement.ts
+++ b/src/relay/pty-source-credit-settlement.ts
@@ -30,13 +30,7 @@ function reclaimCreditedSpans(record: DeliveryRecord): void {
 
 function advanceCredit(record: DeliveryRecord, creditedEndSu: number): void {
   record.creditedEndSu = creditedEndSu
-  for (const boundary of record.sentBoundaries) {
-    // Boundaries are inserted in increasing sentEndSu order, so later values cannot be eligible.
-    if (boundary >= creditedEndSu) {
-      break
-    }
-    record.sentBoundaries.delete(boundary)
-  }
+  record.sentBoundaries.dropBelow(creditedEndSu)
   reclaimCreditedSpans(record)
 }
 
@@ -101,7 +95,7 @@ export function commitPtySourceSend(
   if (record.pendingSend !== reservation) {
     throw new Error('PTY source send reservation is stale')
   }
-  // advanceCredit breaks on the first uncredited boundary, so sentBoundaries inserts must ascend.
+  // sentBoundaries lookups and cleanup both assume ascending order, so inserts must ascend.
   if (reservation.span.sourceEndSu <= record.sentEndSu) {
     throw new Error('PTY source send reservation regresses the sent boundary')
   }

--- a/src/relay/pty-source-sent-boundaries.test.ts
+++ b/src/relay/pty-source-sent-boundaries.test.ts
@@ -14,6 +14,14 @@ describe('PtySourceSentBoundaries', () => {
     expect(boundaries.has(12)).toBe(false)
   })
 
+  it('rejects a boundary that does not ascend past the highest insert', () => {
+    const boundaries = new PtySourceSentBoundaries(4)
+    boundaries.add(9)
+    expect(() => boundaries.add(9)).toThrow('does not ascend')
+    expect(() => boundaries.add(5)).toThrow('does not ascend')
+    expect([...boundaries]).toEqual([4, 9])
+  })
+
   it('drops every boundary below the credit and keeps the credit itself', () => {
     const boundaries = new PtySourceSentBoundaries(0)
     for (const boundary of [1, 2, 3, 4, 5]) {

--- a/src/relay/pty-source-sent-boundaries.test.ts
+++ b/src/relay/pty-source-sent-boundaries.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { PtySourceSentBoundaries } from './pty-source-sent-boundaries'
+
+describe('PtySourceSentBoundaries', () => {
+  it('keeps the checkpoint boundary and every later insert', () => {
+    const boundaries = new PtySourceSentBoundaries(4)
+    boundaries.add(9)
+    boundaries.add(11)
+    expect([...boundaries]).toEqual([4, 9, 11])
+    expect(boundaries.has(4)).toBe(true)
+    expect(boundaries.has(9)).toBe(true)
+    expect(boundaries.has(11)).toBe(true)
+    expect(boundaries.has(10)).toBe(false)
+    expect(boundaries.has(12)).toBe(false)
+  })
+
+  it('drops every boundary below the credit and keeps the credit itself', () => {
+    const boundaries = new PtySourceSentBoundaries(0)
+    for (const boundary of [1, 2, 3, 4, 5]) {
+      boundaries.add(boundary)
+    }
+    boundaries.dropBelow(3)
+    expect([...boundaries]).toEqual([3, 4, 5])
+    expect(boundaries.has(2)).toBe(false)
+    expect(boundaries.has(3)).toBe(true)
+  })
+
+  it('stays correct across the compaction that follows a long interleaved drain', () => {
+    const boundaries = new PtySourceSentBoundaries(0)
+    for (let boundary = 1; boundary <= 4_096; boundary += 1) {
+      boundaries.add(boundary)
+      boundaries.dropBelow(boundary - 1)
+      expect(boundaries.has(boundary - 1)).toBe(true)
+      expect(boundaries.has(boundary - 2)).toBe(false)
+    }
+    expect([...boundaries]).toEqual([4_095, 4_096])
+  })
+})

--- a/src/relay/pty-source-sent-boundaries.ts
+++ b/src/relay/pty-source-sent-boundaries.ts
@@ -1,0 +1,51 @@
+// Committed send boundaries in ascending order. Cleanup advances a monotone cursor rather than
+// iterating a Set, because repeated Set iteration rescans V8 delete tombstones and stays quadratic
+// across an ACK drain even when the loop breaks at the first live element.
+export class PtySourceSentBoundaries {
+  private entries: number[]
+  private liveStart = 0
+
+  constructor(checkpointBoundary: number) {
+    this.entries = [checkpointBoundary]
+  }
+
+  // Callers must add strictly ascending boundaries; has and dropBelow both rely on that order.
+  add(boundary: number): void {
+    this.entries.push(boundary)
+  }
+
+  has(boundary: number): boolean {
+    let low = this.liveStart
+    let high = this.entries.length - 1
+    while (low <= high) {
+      const middle = (low + high) >>> 1
+      const value = this.entries[middle]!
+      if (value === boundary) {
+        return true
+      }
+      if (value < boundary) {
+        low = middle + 1
+      } else {
+        high = middle - 1
+      }
+    }
+    return false
+  }
+
+  dropBelow(boundary: number): void {
+    while (this.liveStart < this.entries.length && this.entries[this.liveStart]! < boundary) {
+      this.liveStart += 1
+    }
+    // Compact only once the dropped prefix outgrows the live tail so the copy cost stays amortized.
+    if (this.liveStart > 0 && this.liveStart * 2 >= this.entries.length) {
+      this.entries = this.entries.slice(this.liveStart)
+      this.liveStart = 0
+    }
+  }
+
+  *[Symbol.iterator](): IterableIterator<number> {
+    for (let index = this.liveStart; index < this.entries.length; index += 1) {
+      yield this.entries[index]!
+    }
+  }
+}

--- a/src/relay/pty-source-sent-boundaries.ts
+++ b/src/relay/pty-source-sent-boundaries.ts
@@ -9,8 +9,12 @@ export class PtySourceSentBoundaries {
     this.entries = [checkpointBoundary]
   }
 
-  // Callers must add strictly ascending boundaries; has and dropBelow both rely on that order.
+  // has binary-searches and dropBelow scans forward, so a non-ascending insert corrupts both.
   add(boundary: number): void {
+    const highest = this.entries.at(-1)
+    if (highest !== undefined && boundary <= highest) {
+      throw new Error('PTY source sent boundary does not ascend')
+    }
     this.entries.push(boundary)
   }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​133 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​106 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​152 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​145 |

<!-- /orca-pr-loc -->

## ELI5

The relay remembers where each SSH terminal frame ended so it can validate acknowledgements. Those frame ends arrive in order, so cleanup now walks a cursor forward through an ordered list instead of re-reading a `Set` on every acknowledgement.

## Summary

- replace the `sentBoundaries` `Set` with `PtySourceSentBoundaries`: an ascending boundary list, a monotone reclamation cursor, and a binary-search membership check
- preserve the current cumulative ACK validation and retained-span reclamation behavior
- measure the drain with a benchmark over the shipped structure instead of a stubbed `Set`

## Performance Measurement

An earlier revision of this PR only added an early `break` to the `Set` scan and claimed a 99.61% / quadratic-to-linear win from a test that counted iterator yields on a stubbed `Set`. That measurement was wrong: `Set.prototype.delete` leaves tombstones, and building a fresh iterator on every ACK re-walks them, so the drain stayed superlinear in wall clock even though the source-level loop body ran only 2n times. The stub could not observe that, so the number is gone and the structure is fixed instead.

Reproduce with:

```sh
node config/scripts/pty-source-ack-boundary-benchmark.mjs
```

It drains n cumulative ACKs over n retained boundaries three ways — the pre-PR full `Set` scan, the early-break `Set` scan, and the shipped `PtySourceSentBoundaries` cursor — reporting the median of 3 runs (Node 24.18, Apple silicon; `Set` rehash timing swings run to run, so treat the ratios as orders of magnitude, not exact figures):

| Boundaries | Full scan (pre-PR) | Early-break `Set` | Cursor (shipped) |
| ---: | ---: | ---: | ---: |
| 1,024 | 0.81 ms | 0.14 ms | 0.051 ms |
| 4,096 | 118.81 ms | 1.26 ms | 0.017 ms |
| 16,384 | 1,318.82 ms | 21.56 ms | 0.074 ms |
| 65,536 | 6,934.46 ms | 456.96 ms | 0.151 ms |

Both `Set` variants grow superlinearly with the number of retained boundaries; the cursor stays flat because no boundary is ever revisited. Retained boundaries are bounded by `windowSu` (256Ki SU) divided by the committed frame size, so the tail only gets large when writer backpressure collapses `maxSourceSu` toward 1 while cumulative ACKs lag — that is the case this removes.

## Verification

- `pnpm test src/relay/pty-source-credit-ledger.test.ts src/relay/pty-source-sent-boundaries.test.ts` — 28 passed
- `pnpm test` over the nine other `src/relay/*pty-source*` suites — 65 passed
- `pnpm tc:node`
- `pnpm exec oxlint` / `pnpm exec oxfmt --check` on the changed files
- `pnpm run check:code-quality:changed` — 0 new findings

## User-Facing Trade-offs

None.


## Linked Issue

N/A — self-directed perf work, no tracker issue.

## Visual Proof

N/A — relay-internal data structure change with no UI or user-visible behavior change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Platforms: relay logic is platform-independent (pure TS, no `child_process`, no path handling); exercised on macOS. `sentBoundaries` never crosses the wire — `snapshotDeliveryRecord` does not include it — so mixed client/host versions are unaffected.

Mutation checks (production condition inverted, confirmed red, restored):
- `dropBelow`'s `while` -> `if` (advance at most one boundary): 2 red — `expected [ 1, 2, 3, 4, 5, 6, 7, 8 ] to deeply equal [ 8 ]` and `expected [ 1, 2, 3, 4, 5 ] to deeply equal [ 3, 4, 5 ]`.
- `add`'s `boundary <= highest` -> `boundary < highest`: 1 red — `expected [Function] to throw an error`.

## AI Disclosure

Internal contributor — N/A.

## Review

Rebased onto `main` @ `6bbed15`.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- Security: no new input parsing, no untrusted data reaches the new code.
- Cross-platform: pure TypeScript, no platform-dependent branches.
- Remote SSH: this is the SSH PTY source-credit path; recovery (`createReplacementDeliveryRecord`) reads `sentBoundaries.has(...)` and gets the same answer as the old `Set` — boundaries below `creditedEndSu` were already deleted by the pre-change loop too.
- Mobile: not reached.
- Backwards compatibility: `sentBoundaries` is process-local; `snapshotDeliveryRecord` never publishes it.
- Performance: see the benchmark table above.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` for visuals, with reason above
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm tc`, `pnpm test src/relay/`, `oxlint`, `oxfmt --check`, `check:code-quality:changed` pass locally
