### PR TITLE
Add observability for closed-tab hook suppression

### DIFF
--- a/src/main/agent-hooks/server-closed-tab-suppression.test.ts
+++ b/src/main/agent-hooks/server-closed-tab-suppression.test.ts
@@ -225,6 +225,7 @@ describe('AgentHookServer listener replay', () => {
       await expect(postHook('late local')).resolves.toMatchObject({ status: 204 })
 
       expect(server.getStatusSnapshot()).toEqual([])
+      expect(debug).toHaveBeenCalledTimes(1)
       expect(debug).toHaveBeenCalledWith('[agent-hooks] agent-status-suppressed', {
         reason: 'closed-tab',
         paneKey: PANE,
@@ -255,6 +256,7 @@ describe('AgentHookServer listener replay', () => {
         'conn-1'
       )
 
+      expect(debug).toHaveBeenCalledTimes(1)
       expect(debug).toHaveBeenCalledWith('[agent-hooks] agent-status-suppressed', {
         reason: 'closed-tab',
         paneKey: PANE,

--- a/src/main/agent-hooks/server-closed-tab-suppression.test.ts
+++ b/src/main/agent-hooks/server-closed-tab-suppression.test.ts
@@ -202,6 +202,7 @@ describe('AgentHookServer listener replay', () => {
 
   it('suppresses local HTTP hook writes for a recently closed tab', async () => {
     const server = new AgentHookServer()
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {})
     await server.start({ env: 'production' })
     try {
       const env = server.buildPtyEnv()
@@ -224,8 +225,95 @@ describe('AgentHookServer listener replay', () => {
       await expect(postHook('late local')).resolves.toMatchObject({ status: 204 })
 
       expect(server.getStatusSnapshot()).toEqual([])
+      expect(debug).toHaveBeenCalledWith('[agent-hooks] agent-status-suppressed', {
+        reason: 'closed-tab',
+        paneKey: PANE,
+        tabId: 'tab-1',
+        source: 'claude'
+      })
     } finally {
       server.stop()
+      debug.mockRestore()
+    }
+  })
+
+  it('logs remote hook suppression for a recently closed tab', () => {
+    const server = new AgentHookServer()
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    try {
+      server.dropStatusEntriesByTabPrefix('tab-1')
+
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          source: 'claude',
+          hookEventName: 'Stop',
+          payload: { state: 'done', prompt: 'late remote', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+
+      expect(debug).toHaveBeenCalledWith('[agent-hooks] agent-status-suppressed', {
+        reason: 'closed-tab',
+        paneKey: PANE,
+        tabId: 'tab-1',
+        source: 'claude'
+      })
+    } finally {
+      debug.mockRestore()
+    }
+  })
+
+  it('logs terminal status suppression for a recently closed tab', () => {
+    const server = new AgentHookServer()
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    try {
+      server.dropStatusEntriesByTabPrefix('tab-1')
+
+      server.ingestTerminalStatus({
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        payload: { state: 'done', prompt: 'late terminal', agentType: 'codex' }
+      })
+
+      expect(debug).toHaveBeenCalledTimes(1)
+      expect(debug).toHaveBeenCalledWith('[agent-hooks] agent-status-suppressed', {
+        reason: 'closed-tab',
+        paneKey: PANE,
+        tabId: 'tab-1'
+      })
+    } finally {
+      debug.mockRestore()
+    }
+  })
+
+  it('does not log closed-tab suppression for a pane-only fence', () => {
+    const server = new AgentHookServer()
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    try {
+      server.retirePaneAuthority(PANE)
+
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          source: 'claude',
+          hookEventName: 'Stop',
+          payload: { state: 'done', prompt: 'retired pane', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+
+      expect(debug).not.toHaveBeenCalledWith(
+        '[agent-hooks] agent-status-suppressed',
+        expect.anything()
+      )
+    } finally {
+      debug.mockRestore()
     }
   })
 

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1165,6 +1165,23 @@ export class AgentHookServer {
     }
   }
 
+  private logClosedTabStatusSuppression(
+    paneKey: string,
+    source: AgentHookSource | undefined
+  ): void {
+    const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
+    const tabId = parsePaneKey(ownerPaneKey)?.tabId
+    if (!tabId || !this.closedAgentStatusTabIds.has(tabId)) {
+      return
+    }
+    console.debug('[agent-hooks] agent-status-suppressed', {
+      reason: 'closed-tab',
+      paneKey: ownerPaneKey,
+      tabId,
+      ...(source ? { source } : {})
+    })
+  }
+
   private getAgentStatusDisposition(
     paneKey: string,
     event?: {
@@ -1183,6 +1200,7 @@ export class AgentHookServer {
       this.closedAgentStatusPaneKeys.has(ownerPaneKey)
     const tabId = parsePaneKey(ownerPaneKey)?.tabId
     if (tabId && this.closedAgentStatusTabIds.has(tabId)) {
+      this.logClosedTabStatusSuppression(ownerPaneKey, event?.source)
       return 'suppress'
     }
     if (!paneRetired) {


### PR DESCRIPTION
## Summary
- log a single structured debug event when agent status is suppressed because its tab was closed
- cover local HTTP, remote relay, and terminal/keep-awake ingress paths without changing suppression behavior
- assert the closed-tab event is emitted exactly once and remains absent for pane-only retirement

Linear: STA-5963

## Verification
- pnpm test src/main/agent-hooks/server-closed-tab-suppression.test.ts
- pnpm test src/main/agent-hooks
- pnpm tc
- pnpm run check:code-quality:changed
- ablation: removing the log helper produced 3 targeted test failures; restored byte-identical sources

Generated tsbuildinfo backup remains untracked and is intentionally untouched.