### PR TITLE
fix(workspace-cleanup): preserve concurrent browse writes

### DIFF
--- a/src/main/ipc/ui.ts
+++ b/src/main/ipc/ui.ts
@@ -1,9 +1,6 @@
 import { BrowserWindow, ipcMain, webContents, type WebContents } from 'electron'
 import type { Store } from '../persistence'
-import type {
-  PersistedUIState,
-  PersistedUIStateUpdate
-} from '../../shared/persisted-ui-state-types'
+import type { PersistedUIStateUpdate } from '../../shared/persisted-ui-state-types'
 import { isFeatureInteractionId } from '../../shared/feature-interactions'
 
 let trustedUIRendererWebContentsId: number | null = null

--- a/src/main/ipc/ui.ts
+++ b/src/main/ipc/ui.ts
@@ -1,6 +1,9 @@
 import { BrowserWindow, ipcMain, webContents, type WebContents } from 'electron'
 import type { Store } from '../persistence'
-import type { PersistedUIState } from '../../shared/persisted-ui-state-types'
+import type {
+  PersistedUIState,
+  PersistedUIStateUpdate
+} from '../../shared/persisted-ui-state-types'
 import { isFeatureInteractionId } from '../../shared/feature-interactions'
 
 let trustedUIRendererWebContentsId: number | null = null
@@ -63,7 +66,7 @@ export function registerUIHandlers(
     return store.getUI()
   })
 
-  ipcMain.handle('ui:set', (_event, args: Partial<PersistedUIState>) => {
+  ipcMain.handle('ui:set', (_event, args: PersistedUIStateUpdate) => {
     store.updateUI(args)
   })
 

--- a/src/main/persistence/applying-settings/ui-interaction-merge.ts
+++ b/src/main/persistence/applying-settings/ui-interaction-merge.ts
@@ -1,6 +1,9 @@
 import type { WorkspaceKey } from '../../../shared/folder-workspace-types'
 import type { PersistedState } from '../../../shared/persisted-state-types'
-import type { PersistedUIStateUpdate } from '../../../shared/persisted-ui-state-types'
+import type {
+  PersistedUIState,
+  PersistedUIStateUpdate
+} from '../../../shared/persisted-ui-state-types'
 import type { WorkspaceLineage } from '../../../shared/worktree/lineage-types'
 import { normalizeFeatureInteractions } from '../../../shared/feature-interactions'
 import { normalizeContextualTourIds } from '../../../shared/contextual-tours'
@@ -43,8 +46,14 @@ export function mergeContextualTourSeenIds(
 }
 
 export function stripMainOwnedTelemetryMarkerFromUI(
+  value: PersistedUIState | undefined
+): Partial<PersistedUIState>
+export function stripMainOwnedTelemetryMarkerFromUI(
   value: PersistedUIStateUpdate | undefined
-): PersistedUIStateUpdate {
+): PersistedUIStateUpdate
+export function stripMainOwnedTelemetryMarkerFromUI(
+  value: PersistedUIState | PersistedUIStateUpdate | undefined
+): Partial<PersistedUIState> | PersistedUIStateUpdate {
   if (!value || typeof value !== 'object') {
     return {}
   }

--- a/src/main/persistence/applying-settings/ui-interaction-merge.ts
+++ b/src/main/persistence/applying-settings/ui-interaction-merge.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceKey } from '../../../shared/folder-workspace-types'
 import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { PersistedUIStateUpdate } from '../../../shared/persisted-ui-state-types'
 import type { WorkspaceLineage } from '../../../shared/worktree/lineage-types'
 import { normalizeFeatureInteractions } from '../../../shared/feature-interactions'
 import { normalizeContextualTourIds } from '../../../shared/contextual-tours'
@@ -42,16 +43,15 @@ export function mergeContextualTourSeenIds(
 }
 
 export function stripMainOwnedTelemetryMarkerFromUI(
-  value: Partial<PersistedState['ui']> | undefined
-): Partial<PersistedState['ui']> {
+  value: PersistedUIStateUpdate | undefined
+): PersistedUIStateUpdate {
   if (!value || typeof value !== 'object') {
     return {}
   }
-  const { featureInteractionTelemetryBuckets: _reserved, ...ui } = value as Partial<
-    PersistedState['ui']
-  > & {
-    featureInteractionTelemetryBuckets?: unknown
-  }
+  const { featureInteractionTelemetryBuckets: _reserved, ...ui } =
+    value as PersistedUIStateUpdate & {
+      featureInteractionTelemetryBuckets?: unknown
+    }
   void _reserved
   return ui
 }

--- a/src/main/persistence/applying-settings/ui-state-update.ts
+++ b/src/main/persistence/applying-settings/ui-state-update.ts
@@ -1,4 +1,5 @@
 import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { PersistedUIStateUpdate } from '../../../shared/persisted-ui-state-types'
 import {
   getDefaultUIState,
   normalizeAgentActivityDisplayMode,
@@ -55,7 +56,7 @@ export type UIUpdateOperations = {
 
 export function updatePersistedUI(
   operations: UIUpdateOperations,
-  updates: Partial<PersistedState['ui']>
+  updates: PersistedUIStateUpdate
 ): void {
   if ('browserKagiSessionLink' in updates && !updates.browserKagiSessionLink) {
     operations.removeRetainedBlob(PROTECTED_SECRET_SLOT.browserKagiSessionLink)

--- a/src/main/persistence/loading-store/profile-preferences.ts
+++ b/src/main/persistence/loading-store/profile-preferences.ts
@@ -1,6 +1,7 @@
 import type { GlobalSettings } from '../../../shared/global-settings-types'
 import type { OnboardingChecklistState } from '../../../shared/onboarding-state-types'
 import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { PersistedUIStateUpdate } from '../../../shared/persisted-ui-state-types'
 import { getDefaultOnboardingState } from '../../../shared/constants'
 import type { FeatureInteractionId } from '../../../shared/feature-interactions'
 import {
@@ -81,7 +82,7 @@ export class ProfilePreferences {
     )
   }
 
-  updateUI(updates: Partial<PersistedState['ui']>): void {
+  updateUI(updates: PersistedUIStateUpdate): void {
     updatePersistedUI(getUIUpdateOperations(this), updates)
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -374,7 +374,10 @@ import type {
   ClaudeRateLimitAccountsState,
   CodexRateLimitAccountsState
 } from '../../shared/managed-account-types'
-import type { PersistedUIState } from '../../shared/persisted-ui-state-types'
+import type {
+  PersistedUIState,
+  PersistedUIStateUpdate
+} from '../../shared/persisted-ui-state-types'
 import type { MemorySnapshot, StatsSummary } from '../../shared/process-stats-types'
 import type {
   NestedRepoScanResult,
@@ -4192,7 +4195,7 @@ export class OrcaRuntimeService {
     return this.store.getUI()
   }
 
-  updateUIState(updates: Partial<PersistedUIState>): PersistedUIState {
+  updateUIState(updates: PersistedUIStateUpdate): PersistedUIState {
     if (!this.store?.getUI || !this.store.updateUI) {
       throw new Error('runtime_unavailable')
     }

--- a/src/main/runtime/rpc/methods/workspace-cleanup-ui-schema.test.ts
+++ b/src/main/runtime/rpc/methods/workspace-cleanup-ui-schema.test.ts
@@ -16,7 +16,7 @@ describe('workspaceCleanup client-ui schema', () => {
     const parsed = WorkspaceCleanup.parse({ dismissals: { 'wt-1': DISMISSAL }, browse })
 
     expect(parsed.browse).toEqual(browse)
-    expect(parsed.dismissals['wt-1']).toEqual(DISMISSAL)
+    expect(parsed.dismissals?.['wt-1']).toEqual(DISMISSAL)
   })
 
   it('still accepts a dismissals-only payload from a client that predates browse', () => {
@@ -33,7 +33,7 @@ describe('workspaceCleanup client-ui schema', () => {
     const qualified = { ...DISMISSAL, executionHostId: 'ssh:ssh-1' }
     const parsed = WorkspaceCleanup.parse({ dismissals: { 'ssh:ssh-1\0wt-1': qualified } })
 
-    expect(parsed.dismissals['ssh:ssh-1\0wt-1']).toEqual(qualified)
+    expect(parsed.dismissals?.['ssh:ssh-1\0wt-1']).toEqual(qualified)
   })
 
   // The wire contract: a NEWER client's filter groups must never fail an older

--- a/src/main/runtime/rpc/methods/workspace-cleanup-ui-schema.test.ts
+++ b/src/main/runtime/rpc/methods/workspace-cleanup-ui-schema.test.ts
@@ -23,6 +23,12 @@ describe('workspaceCleanup client-ui schema', () => {
     expect(WorkspaceCleanup.parse({ dismissals: {} })).toEqual({ dismissals: {} })
   })
 
+  it('accepts a browse-only update so its writer does not replace dismissals', () => {
+    const browse = createDefaultWorkspaceCleanupBrowseState()
+
+    expect(WorkspaceCleanup.parse({ browse })).toEqual({ browse })
+  })
+
   it('preserves the optional host qualifier on a dismissal', () => {
     const qualified = { ...DISMISSAL, executionHostId: 'ssh:ssh-1' }
     const parsed = WorkspaceCleanup.parse({ dismissals: { 'ssh:ssh-1\0wt-1': qualified } })

--- a/src/main/runtime/rpc/methods/workspace-cleanup-ui-schema.ts
+++ b/src/main/runtime/rpc/methods/workspace-cleanup-ui-schema.ts
@@ -25,6 +25,6 @@ const WorkspaceCleanupBrowse = z
   .transform((value) => normalizeWorkspaceCleanupBrowseState(value))
 
 export const WorkspaceCleanup = z.object({
-  dismissals: z.record(z.string(), WorkspaceCleanupDismissal),
+  dismissals: z.record(z.string(), WorkspaceCleanupDismissal).optional(),
   browse: WorkspaceCleanupBrowse.optional()
 })

--- a/src/preload/api/ui-command-event-api.ts
+++ b/src/preload/api/ui-command-event-api.ts
@@ -1,4 +1,7 @@
-import type { PersistedUIState } from '../../shared/persisted-ui-state-types'
+import type {
+  PersistedUIState,
+  PersistedUIStateUpdate
+} from '../../shared/persisted-ui-state-types'
 import type { TuiAgent } from '../../shared/tui-agent'
 import type {
   WorktreeDefaultTabsLaunch,
@@ -36,11 +39,11 @@ export type CloseActiveTabPayload = { sourceId: string }
 
 export type UiCommandEventApi = {
   get: () => Promise<PersistedUIState>
-  set: (args: Partial<PersistedUIState>) => Promise<void>
+  set: (args: PersistedUIStateUpdate) => Promise<void>
   /** Like set, but REJECTS when the update did not reach the host (the web preload's set
    *  swallows transport failures for offline use). The diff writer needs the distinction:
    *  folding an unacked patch into its baseline would silently stop retrying it (STA-5781). */
-  setWithAck?: (args: Partial<PersistedUIState>) => Promise<void>
+  setWithAck?: (args: PersistedUIStateUpdate) => Promise<void>
   recordFeatureInteraction: (id: FeatureInteractionId) => Promise<PersistedUIState>
   onStateChanged: (callback: (ui: PersistedUIState) => void) => () => void
   onOpenSettings: (callback: () => void) => () => void

--- a/src/renderer/src/store/slices/workspace-cleanup-browse.test.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-browse.test.ts
@@ -10,11 +10,21 @@ import {
   createDefaultWorkspaceCleanupBrowseState,
   normalizeWorkspaceCleanupBrowseState
 } from '../../../../shared/workspace-cleanup-browse-state'
+import type { WorkspaceCleanupUIState } from '../../../../shared/workspace-cleanup'
+import { mergeWorkspaceCleanupUIState } from '../../../../shared/workspace-cleanup-ui-state'
+import type { PersistedUIStateUpdate } from '../../../../shared/persisted-ui-state-types'
 
 const DISMISSAL = {
   worktreeId: 'wt-1',
   dismissedAt: 1700000000000,
   fingerprint: 'fp-1',
+  classifierVersion: 2
+}
+
+const CONCURRENT_DISMISSAL = {
+  worktreeId: 'wt-2',
+  dismissedAt: 1700000001000,
+  fingerprint: 'fp-2',
   classifierVersion: 2
 }
 
@@ -46,7 +56,7 @@ describe('workspace cleanup browse slice', () => {
     )
   })
 
-  it('persists the debounced state alongside the dismissals it would otherwise erase', async () => {
+  it('persists only the debounced state it owns', async () => {
     const uiSet = vi.fn().mockResolvedValue(undefined)
     const store = createStore(uiSet)
 
@@ -61,7 +71,28 @@ describe('workspace cleanup browse slice', () => {
 
     expect(uiSet).toHaveBeenCalledTimes(1)
     expect(uiSet).toHaveBeenCalledWith({
-      workspaceCleanup: { dismissals: { 'wt-1': DISMISSAL }, browse: next }
+      workspaceCleanup: { browse: next }
+    })
+  })
+
+  it('does not revert a dismissal written while the browse update is debounced', async () => {
+    let persisted: WorkspaceCleanupUIState = { dismissals: { 'wt-1': DISMISSAL } }
+    const uiSet = vi.fn(async (updates: PersistedUIStateUpdate): Promise<void> => {
+      persisted = mergeWorkspaceCleanupUIState(persisted, updates.workspaceCleanup) ?? persisted
+    })
+    const store = createStore(uiSet)
+    const nextBrowse = createDefaultWorkspaceCleanupBrowseState()
+    nextBrowse.filters.query = 'stale'
+
+    store.getState().updateWorkspaceCleanupBrowseState(nextBrowse)
+    persisted = mergeWorkspaceCleanupUIState(persisted, {
+      dismissals: { ...persisted.dismissals, 'wt-2': CONCURRENT_DISMISSAL }
+    }) as WorkspaceCleanupUIState
+    await vi.advanceTimersByTimeAsync(WORKSPACE_CLEANUP_BROWSE_PERSIST_DEBOUNCE_MS)
+
+    expect(persisted).toEqual({
+      dismissals: { 'wt-1': DISMISSAL, 'wt-2': CONCURRENT_DISMISSAL },
+      browse: nextBrowse
     })
   })
 

--- a/src/renderer/src/store/slices/workspace-cleanup-browse.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-browse.ts
@@ -38,12 +38,9 @@ export const createWorkspaceCleanupBrowseSlice: StateCreator<
     }
     persistTimer = setTimeout(() => {
       persistTimer = null
-      // Why dismissals ride along: the legacy wire schema requires the field,
-      // while `browse` stays optional for older clients.
       window.api.ui
         .set({
           workspaceCleanup: {
-            dismissals: get().workspaceCleanupDismissals,
             browse: get().workspaceCleanupBrowse
           }
         })

--- a/src/renderer/src/web/preload-api/web-preference-normalization.ts
+++ b/src/renderer/src/web/preload-api/web-preference-normalization.ts
@@ -13,7 +13,10 @@ import type {
 } from '../../../../shared/feature-interactions'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { PairedUiState, PairingLocalUiField } from '../../../../shared/pairing-local-ui-fields'
-import type { PersistedUIState } from '../../../../shared/persisted-ui-state-types'
+import type {
+  PersistedUIState,
+  PersistedUIStateUpdate
+} from '../../../../shared/persisted-ui-state-types'
 import { normalizeStatusBarUsageMode } from '../../../../shared/status-bar-usage-mode'
 import { normalizeTerminalCustomThemes } from '../../../../shared/terminal-custom-themes'
 import {
@@ -27,10 +30,10 @@ import { mergeWorkspaceCleanupUIState } from '../../../../shared/workspace-clean
 
 export function mergeWebUIState(
   base: PersistedUIState,
-  updates: Partial<PersistedUIState>
+  updates: PersistedUIStateUpdate
 ): PersistedUIState {
   const { featureInteractionTelemetryBuckets: _reserved, ...safeUpdates } =
-    updates as Partial<PersistedUIState> & {
+    updates as PersistedUIStateUpdate & {
       featureInteractionTelemetryBuckets?: unknown
     }
   void _reserved

--- a/src/shared/persisted-ui-state-types.ts
+++ b/src/shared/persisted-ui-state-types.ts
@@ -205,3 +205,7 @@ export type PersistedUIState = {
   /** Whether this profile may receive automatic contextual tours; missing = renderer hasn't classified the profile yet. */
   contextualToursAutoEligible?: boolean
 }
+
+export type PersistedUIStateUpdate = Omit<Partial<PersistedUIState>, 'workspaceCleanup'> & {
+  workspaceCleanup?: Partial<WorkspaceCleanupUIState>
+}

--- a/src/shared/workspace-cleanup-ui-state.test.ts
+++ b/src/shared/workspace-cleanup-ui-state.test.ts
@@ -34,6 +34,37 @@ describe('workspace cleanup UI state', () => {
     })
   })
 
+  it('keeps dismissals when the browse writer publishes a browse-only patch', () => {
+    const browse = createDefaultWorkspaceCleanupBrowseState()
+    browse.filters.query = 'fresh'
+
+    expect(
+      mergeWorkspaceCleanupUIState(
+        {
+          dismissals: {
+            'wt-1': {
+              worktreeId: 'wt-1',
+              dismissedAt: 1700000000000,
+              fingerprint: 'fp-1',
+              classifierVersion: 2
+            }
+          }
+        },
+        { browse }
+      )
+    ).toEqual({
+      dismissals: {
+        'wt-1': {
+          worktreeId: 'wt-1',
+          dismissedAt: 1700000000000,
+          fingerprint: 'fp-1',
+          classifierVersion: 2
+        }
+      },
+      browse
+    })
+  })
+
   it('accepts browse state published by a compatible peer', () => {
     const current = createDefaultWorkspaceCleanupBrowseState()
     current.filters.query = 'local'

--- a/src/shared/workspace-cleanup-ui-state.ts
+++ b/src/shared/workspace-cleanup-ui-state.ts
@@ -3,12 +3,13 @@ import type { WorkspaceCleanupUIState } from './workspace-cleanup'
 /** Keep browse state when an older client or host publishes dismissals only. */
 export function mergeWorkspaceCleanupUIState(
   current: WorkspaceCleanupUIState | undefined,
-  incoming: WorkspaceCleanupUIState | undefined
+  incoming: Partial<WorkspaceCleanupUIState> | undefined
 ): WorkspaceCleanupUIState | undefined {
   if (!incoming) {
     return current
   }
   return {
+    dismissals: current?.dismissals ?? {},
     ...current,
     ...incoming
   }


### PR DESCRIPTION
Fixes [STA-5865](https://linear.app/stablyai/issue/STA-5865)

The debounced workspace-cleanup browse writer now sends only the `browse` patch it owns. The UI update type and schema accept partial `workspaceCleanup` updates, and main/web merges retain sibling dismissals while applying browse changes.

Verification:

- `corepack pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/client-ui.test.ts src/main/runtime/rpc/methods/workspace-cleanup-ui-schema.test.ts src/main/persistence-ui-state.test.ts src/renderer/src/web/web-preload-api-ui.test.ts src/renderer/src/store/slices/workspace-cleanup-browse.test.ts src/shared/workspace-cleanup-ui-state.test.ts` (6 files, 117 tests)
- `corepack pnpm run typecheck:node` (pass)
- `corepack pnpm run typecheck:cli` (pass)
- `corepack pnpm run typecheck:web` (pass)
- Oxlint on all 14 changed files (pass; 14 files confirmed with `--debug=files`)
- Ablation of the browse writer's patch isolation makes the concurrent-dismissal test fail, then restoring the exact file bytes returns the test to green.

Electron visible validation was attempted with the worktree dev runner, but this Linux host has no X server (`Missing X server or $DISPLAY`), so the rendered UI remains unverified; unit/integration coverage exercises the real persistence seam.