### PR TITLE
fix(settings): always render agent environment field

### DIFF
--- a/src/renderer/src/components/settings/AgentCatalogRow.test.tsx
+++ b/src/renderer/src/components/settings/AgentCatalogRow.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AgentCatalogRowProps } from './AgentCatalogRow'
+import { AgentCatalogRow } from './AgentCatalogRow'
+
+function getRowProps(): AgentCatalogRowProps {
+  return {
+    agentId: 'claude',
+    label: 'Claude',
+    homepageUrl: 'https://code.claude.com/docs',
+    defaultCmd: 'claude',
+    defaultArgs: '',
+    defaultEnv: {},
+    isDetected: true,
+    isEnabled: true,
+    isDefault: false,
+    cmdOverride: undefined,
+    argsOverride: '',
+    envOverride: {},
+    onSetDefault: vi.fn(),
+    onSetEnabled: vi.fn(),
+    onSaveOverride: vi.fn(),
+    onSaveArgs: vi.fn(),
+    onSaveEnv: vi.fn()
+  }
+}
+
+describe('AgentCatalogRow', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the Environment input after expanding an agent with no env configured', () => {
+    render(<AgentCatalogRow {...getRowProps()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand command override' }))
+
+    expect(screen.getByText('Environment')).toBeTruthy()
+    expect(screen.getByPlaceholderText('No default environment')).toBeTruthy()
+  })
+})

--- a/src/renderer/src/components/settings/AgentCatalogRow.tsx
+++ b/src/renderer/src/components/settings/AgentCatalogRow.tsx
@@ -216,16 +216,14 @@ export function AgentCatalogRow({
               onSaveArgs={onSaveArgs}
             />
           </div>
-          {(defaultEnvSummary || envSummary) && (
-            <div className="mt-2">
-              <AgentDefaultEnvInput
-                key={`${agentId}:${envSummary}`}
-                defaultEnv={defaultEnv}
-                envOverride={envOverride}
-                onSaveEnv={onSaveEnv}
-              />
-            </div>
-          )}
+          <div className="mt-2">
+            <AgentDefaultEnvInput
+              key={`${agentId}:${envSummary}`}
+              defaultEnv={defaultEnv}
+              envOverride={envOverride}
+              onSaveEnv={onSaveEnv}
+            />
+          </div>
           {sessionSourceHome && (
             <div className="mt-2">
               <AgentSessionSourceHomeInput


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |

<!-- /orca-pr-loc -->

## Summary

Fixes STA-5915 by rendering the per-agent Environment input whenever a detected agent's launch overrides are expanded, including when both default and override environment maps are empty.

## Validation

- Added a failing-first regression test that expands a Claude row with empty environment maps and checks the Environment input.
- Proved ablation: restoring the value-presence gate reddens the test; fixed source was restored byte-for-byte.
- Settings suite: 167 files / 1094 tests passed.
- pnpm tc passed.
- Targeted oxlint and oxfmt passed.
- Electron/CDP validation was attempted with an isolated profile and alternate renderer port; unique launches became unresponsive before a screenshot could be captured, so visible UI evidence remains blocked.