### PR TITLE
perf(agent-status): coalesce deferred freshness scans

### DIFF
--- a/src/renderer/src/store/slices/agent-status-freshness-scheduler.test.ts
+++ b/src/renderer/src/store/slices/agent-status-freshness-scheduler.test.ts
@@ -26,6 +26,10 @@ function setup(entries: AgentStatusEntry[]) {
   return { bumpEpochs, scheduler }
 }
 
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => queueMicrotask(resolve))
+}
+
 describe('freshness scheduler completion deadlines', () => {
   afterEach(() => {
     vi.useRealTimers()
@@ -134,6 +138,47 @@ describe('freshness scheduler completion deadlines', () => {
     vi.advanceTimersByTime(AGENT_STATUS_STALE_AFTER_MS + 1)
     expect(bumpEpochs).toHaveBeenCalledTimes(1)
 
+    scheduler.dispose()
+  })
+
+  it('coalesces pending deferred scans while preserving each queue slot', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const entries = [doneEntry()]
+    const getEntries = vi.fn(() => entries)
+    const bumpEpochs = vi.fn()
+    const scheduler = createFreshnessScheduler({ getEntries, bumpEpochs })
+    const queueMicrotaskSpy = vi.spyOn(globalThis, 'queueMicrotask')
+
+    scheduler.scheduleDeferred()
+    scheduler.scheduleDeferred()
+    expect(queueMicrotaskSpy).toHaveBeenCalledTimes(2)
+    expect(getEntries).not.toHaveBeenCalled()
+
+    await flushMicrotasks()
+
+    expect(getEntries).toHaveBeenCalledTimes(1)
+    scheduler.dispose()
+  })
+
+  it('keeps a deferred request queued while a scan is running', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    let scheduler!: ReturnType<typeof createFreshnessScheduler>
+    let firstRead = true
+    const getEntries = vi.fn(() => {
+      if (firstRead) {
+        firstRead = false
+        scheduler.scheduleDeferred()
+      }
+      return []
+    })
+    scheduler = createFreshnessScheduler({ getEntries, bumpEpochs: vi.fn() })
+
+    scheduler.scheduleDeferred()
+    await flushMicrotasks()
+
+    expect(getEntries).toHaveBeenCalledTimes(2)
     scheduler.dispose()
   })
 })

--- a/src/renderer/src/store/slices/agent-status-freshness-scheduler.ts
+++ b/src/renderer/src/store/slices/agent-status-freshness-scheduler.ts
@@ -10,6 +10,12 @@ export type FreshnessSchedulerDeps = {
 export type FreshnessScheduler = {
   schedule: () => void
   /**
+   * Defer a freshness scan until the microtask queue drains. Multiple pending
+   * requests still retain their queue slots for ordering, but only the newest
+   * request performs the scan.
+   */
+  scheduleDeferred: () => void
+  /**
    * Cancel any pending freshness timer. Intended for tests that create a
    * fresh store per case — production callers do not need this because the
    * zustand store is a module-level singleton that lives until process exit.
@@ -23,12 +29,23 @@ export function createFreshnessScheduler(deps: FreshnessSchedulerDeps): Freshnes
   // into the test process.
   let timer: ReturnType<typeof setTimeout> | null = null
   let lastCheckedAt: number | null = null
+  let deferredScheduleGeneration = 0
 
   const clear = (): void => {
     if (timer !== null) {
       clearTimeout(timer)
       timer = null
     }
+  }
+
+  const scheduleDeferred = (): void => {
+    const generation = ++deferredScheduleGeneration
+    queueMicrotask(() => {
+      if (generation !== deferredScheduleGeneration) {
+        return
+      }
+      schedule()
+    })
   }
 
   const schedule = (): void => {
@@ -91,5 +108,11 @@ export function createFreshnessScheduler(deps: FreshnessSchedulerDeps): Freshnes
     }, delayMs)
   }
 
-  return { schedule, dispose: clear }
+  const dispose = (): void => {
+    clear()
+    // Invalidate callbacks already queued by scheduleDeferred.
+    deferredScheduleGeneration += 1
+  }
+
+  return { schedule, scheduleDeferred, dispose }
 }

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1545,7 +1545,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         storeGet().setGeneratedTabTitlesFromAgentPrompts(generatedTabTitleUpdates)
       }
       if (freshnessRequested) {
-        queueMicrotask(() => freshness.schedule())
+        freshness.scheduleDeferred()
       }
       for (const effect of effects) {
         effect()
@@ -1577,7 +1577,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       batchedAgentStatusFreshnessRequested ||= acceptedInBatch
       return
     }
-    queueMicrotask(() => freshness.schedule())
+    freshness.scheduleDeferred()
   }
 
   const clearSleepingAgentSessionsByPaneKey = (paneKeys: readonly string[]): void => {
@@ -1695,7 +1695,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         }
       })
       if (hadLive) {
-        queueMicrotask(() => freshness.schedule())
+        freshness.scheduleDeferred()
       }
       if (typeof window !== 'undefined') {
         window.api?.agentStatus?.retirePaneAuthority?.(ownerPaneKey)
@@ -2720,7 +2720,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           sortEpoch: s.sortEpoch + 1
         }
       })
-      queueMicrotask(() => freshness.schedule())
+      freshness.scheduleDeferred()
     },
 
     removeAgentStatusByTabPrefix: (tabIdPrefix) => {
@@ -2770,7 +2770,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           sortEpoch: s.sortEpoch + 1
         }
       })
-      queueMicrotask(() => freshness.schedule())
+      freshness.scheduleDeferred()
     },
 
     clearTransientAgentStatuses: (connectionId, clearedAt) => {
@@ -2820,7 +2820,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         }
       })
       if (removed) {
-        queueMicrotask(() => freshness.schedule())
+        freshness.scheduleDeferred()
       }
     },
 
@@ -2902,7 +2902,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       })
       // Why: freshness.schedule only matters when the live map changed, so gate on the live presence observed inside set() — no-op/retained-only drops skip it.
       if (liveExisted) {
-        queueMicrotask(() => freshness.schedule())
+        freshness.scheduleDeferred()
       }
       // Why: propagate the dismissal to the main-process hook cache so the on-disk cache doesn't re-hydrate this row on next launch. Fire-and-forget.
       // Why: the typeof window guard keeps the slice usable from the node test env, where window is undefined.
@@ -2925,7 +2925,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         return dropped.patch
       })
       if (hadLive) {
-        queueMicrotask(() => freshness.schedule())
+        freshness.scheduleDeferred()
       }
       if (typeof window !== 'undefined') {
         window.api?.agentStatus?.dropByTabPrefix?.(tabIdPrefix)
@@ -3032,7 +3032,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         }
       })
       if (hadLive) {
-        queueMicrotask(() => freshness.schedule())
+        freshness.scheduleDeferred()
       }
     },
 
@@ -3180,7 +3180,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         }
       })
       if (hadLive) {
-        queueMicrotask(() => freshness.schedule())
+        freshness.scheduleDeferred()
       }
     },
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

## Summary
- retain each deferred queueMicrotask for existing ordering and reentrant behavior
- skip superseded freshness callbacks so a burst of status writes performs one O(entries) scan
- invalidate queued callbacks during scheduler disposal

## Validation
- pnpm test src/renderer/src/store/slices/agent-status-freshness-scheduler.test.ts src/renderer/src/store/slices/agent-status-batch.test.ts src/renderer/src/store/slices/agent-status.test.ts
- pnpm tc:web
- pnpm run check:code-quality:changed
- pnpm exec oxfmt --check (changed files)

## ELI5

When many agent-status updates arrive together, each update used to line up a full check of every status row. Orca still keeps every request in its original microtask queue slot, but superseded requests now step aside so the newest request performs one scan using the complete current state.

## Performance Measurement

Reproducible deterministic fixture: queue 64 deferred freshness requests synchronously against 64 agent-status entries, then drain the microtask queue once. Instrument `getEntries` in `agent-status-freshness-scheduler.test.ts`; each call represents one full O(entries) scan.

- Before (`queueMicrotask(() => freshness.schedule())`): 64 scans / 4,096 entry visits.
- After (`freshness.scheduleDeferred()`): 1 scan / 64 entry visits.
- Improvement: 63 fewer scans and 4,032 fewer entry visits, a 98.44% reduction in scan work.

The pending-burst work changes from O(B × E) to O(B + E): all B microtask queue slots remain for ordering, while only the latest request scans E entries. Run the focused coverage with `pnpm test src/renderer/src/store/slices/agent-status-freshness-scheduler.test.ts --run`.

## User-Facing Trade-offs

None. Freshness deadlines, status ordering, reentrant scheduling, and rendered agent state are unchanged; only redundant scans from the same pending burst are skipped.