### PR TITLE
perf(worktrees): bound fleet resolution concurrency

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -66,6 +66,7 @@ import {
   appendNormalizedToTailBuffer,
   buildPreview,
   OrcaRuntimeService,
+  RESOLVED_WORKTREE_REPO_CONCURRENCY,
   resolveWorktreeScanCacheTtlMs,
   type RuntimeTerminalAgentStatusEvent
 } from './orca-runtime'
@@ -43122,6 +43123,56 @@ describe('OrcaRuntimeService', () => {
       repos.map((repo) => `${repo.path}/main`)
     )
     expect(listWorktrees).toHaveBeenCalledTimes(15)
+  })
+
+  it('bounds concurrent fleet worktree resolution across repositories', async () => {
+    const repoCount = RESOLVED_WORKTREE_REPO_CONCURRENCY + 4
+    const baseRepo = store.getRepos()[0]
+    const repos = Array.from({ length: repoCount }, (_, index) => ({
+      ...baseRepo,
+      id: `fleet-repo-${index + 1}`,
+      path: `/tmp/fleet-repo-${index + 1}`,
+      displayName: `fleet-repo-${index + 1}`
+    }))
+    let activeScans = 0
+    let maxActiveScans = 0
+    let startedScanCount = 0
+    const releaseScans = deferred<void>()
+    vi.mocked(scanLocalRepoWorktreesForResolutionMock).mockReset()
+    vi.mocked(scanLocalRepoWorktreesForResolutionMock).mockImplementation(
+      async (repoPath: string) => {
+        activeScans += 1
+        maxActiveScans = Math.max(maxActiveScans, activeScans)
+        startedScanCount += 1
+        await releaseScans.promise
+        activeScans -= 1
+        return { ok: true, worktrees: [makeWorktreeInfo(`${repoPath}/main`)] }
+      }
+    )
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getRepos: () => repos,
+      getRepo: (id: string) => repos.find((repo) => repo.id === id),
+      getAllWorktreeMeta: () => ({}),
+      getWorktreeMeta: () => undefined
+    } as never)
+    const listing = runtime.listManagedWorktrees()
+
+    try {
+      await vi.waitFor(() => expect(startedScanCount).toBe(RESOLVED_WORKTREE_REPO_CONCURRENCY), {
+        timeout: 1000
+      })
+      expect(activeScans).toBe(RESOLVED_WORKTREE_REPO_CONCURRENCY)
+      expect(startedScanCount).toBe(RESOLVED_WORKTREE_REPO_CONCURRENCY)
+    } finally {
+      releaseScans.resolve()
+    }
+
+    const result = await listing
+    expect(maxActiveScans).toBe(RESOLVED_WORKTREE_REPO_CONCURRENCY)
+    expect(result.worktrees.map((worktree) => worktree.path)).toEqual(
+      repos.map((repo) => `${repo.path}/main`)
+    )
   })
 
   it('worktree scan cache: shares one in-flight repo scan across concurrent consumers', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -985,6 +985,7 @@ import {
 import { getRepoOwnedWorktreeMeta } from '../worktree-metadata-ownership'
 import { readWorktreeMetaForHost } from '../persistence/host-qualified-worktree-meta'
 import { withTimeout } from '../../shared/promise-timeout-fallback'
+import { mapWithConcurrency } from '../../shared/map-with-concurrency'
 import {
   getLocalWorktreePathAccess,
   removeLocalWorktreePath,
@@ -34487,17 +34488,17 @@ export class OrcaRuntimeService {
       ])
     )
     const deps = this.repoWorktreeRowDeps()
-    const perRepoWorktrees = await Promise.all(
-      repos.map(
-        async (repo) =>
-          await resolveRepoWorktreeRows(
-            deps,
-            repo,
-            metaById,
-            projectRuntimeByRepoId,
-            repoOwnerCounts.get(repo.id) ?? 1
-          )
-      )
+    const perRepoWorktrees = await mapWithConcurrency(
+      repos,
+      RESOLVED_WORKTREE_REPO_CONCURRENCY,
+      async (repo) =>
+        await resolveRepoWorktreeRows(
+          deps,
+          repo,
+          metaById,
+          projectRuntimeByRepoId,
+          repoOwnerCounts.get(repo.id) ?? 1
+        )
     )
     const lineageById = this.store?.getAllWorktreeLineage?.() ?? {}
     const worktrees = perRepoWorktrees.flatMap((rows) =>
@@ -41391,6 +41392,9 @@ const DEFAULT_WORKTREE_LIST_LIMIT = 200
 const DEFAULT_WORKTREE_PS_LIMIT = 200
 const DISCONNECTED_PTY_RECORD_MAX = 128
 const RESOLVED_WORKTREE_CACHE_TTL_MS = 1000
+// Why: a resolved fleet snapshot can touch every local, WSL, and SSH repo; keep
+// Git/provider subprocesses bounded so a large workspace does not starve the UI.
+export const RESOLVED_WORKTREE_REPO_CONCURRENCY = 8
 const WORKTREE_SCAN_CACHE_TTL_MS = 30_000
 // Why: agent-scratch repos don't need 30s freshness — the steady-state scan
 // fan-out was measured at ~128 git execs/min on real installs, mostly against


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## Summary
- cap concurrent repo worktree resolution at eight scans
- preserve deterministic repo ordering while preventing fleet snapshots from flooding Git/provider subprocesses
- add a regression test for the concurrency bound

## Why
Large Orca workspaces resolve every repository during fleet snapshots. Starting every repo at once can starve the app and agent terminals under load.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts src/shared/map-with-concurrency.test.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-throughput.bench.test.ts`
- pre-commit oxlint/oxfmt hooks

## ELI5

A fleet refresh may need to inspect many repositories at once. Starting every scan simultaneously can swamp the machine, so the refresh now runs at most eight repository scans at a time and still returns rows in the original repository order.

## Performance Measurement

Reproducible deterministic fixture: resolve 12 repositories (the concurrency limit of 8 plus 4), hold each scan open, and record the maximum number of active scans.

- Before (`Promise.all`): 12 concurrent scans.
- After (`mapWithConcurrency(..., 8)`): 8 concurrent scans.
- Improvement: peak scan/subprocess concurrency falls by 4 (33.3%) for this fixture and remains capped at 8 for larger fleets; ordering and total rows are unchanged.

Run the focused concurrency regression with `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts`.

## User-Facing Trade-offs

None in behavior: repository ordering, worktree results, and refresh semantics are unchanged. Very large fleets are intentionally paced in batches of eight, trading unbounded burst pressure for a bounded, more responsive refresh.