### PR TITLE
perf(terminal): assemble queued output chunks linearly

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-queue-chunks.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-queue-chunks.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import type { QueueEntry } from './pane-terminal-output-queue-registry'
+import { enqueueChunk, takeQueuedChunk } from './pane-terminal-output-queue-chunks'
+
+function createEntry(): QueueEntry {
+  return {
+    terminal: {} as QueueEntry['terminal'],
+    chunks: [],
+    chunkIndex: 0,
+    queuedChars: 0,
+    backgroundBacklogDropped: false,
+    highPriority: false,
+    foregroundHold: false,
+    foregroundHoldSafetyDelayMs: 0,
+    foregroundCoalesce: false,
+    foregroundCoalesceDelayMs: 0,
+    foregroundHoldSafetyTimer: null,
+    foregroundCoalesceTimer: null,
+    foregroundReleaseDeadlineAt: null,
+    foregroundReleaseDeadlineFixed: false
+  }
+}
+
+describe('pane terminal output queue chunks', () => {
+  it('assembles many queued chunks in order and preserves a partial residual', () => {
+    const entry = createEntry()
+    const chunks = Array.from({ length: 128 }, (_, index) => `${index}:`)
+    for (const chunk of chunks) {
+      enqueueChunk(entry, chunk, { foreground: false })
+    }
+
+    const allData = chunks.join('')
+    const first = takeQueuedChunk(entry, allData.length - 2)
+    expect(first?.data).toBe(allData.slice(0, -2))
+    expect(entry.queuedChars).toBe(2)
+
+    const second = takeQueuedChunk(entry, 2)
+    expect(second?.data).toBe(allData.slice(-2))
+    expect(entry.queuedChars).toBe(0)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-queue-chunks.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-queue-chunks.ts
@@ -13,6 +13,9 @@ const ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY = (): boolean => true
 export function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
   let remaining = limit
   let data = ''
+  // Join source chunks once; repeated `data += chunk` can flatten tiny-chunk floods.
+  let dataParts: string[] | null = null
+  let dataLength = 0
   let foreground: boolean | null = null
   let forceForegroundRefresh = false
   let followupForegroundRefresh = false
@@ -56,7 +59,15 @@ export function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite |
       additionalBeforeWriteCallbacks.push(chunk.beforeWrite)
     }
     if (chunk.data.length <= remaining) {
-      data += chunk.data
+      if (dataParts) {
+        dataParts.push(chunk.data)
+      } else if (dataLength === 0) {
+        data = chunk.data
+      } else {
+        dataParts = [data, chunk.data]
+        data = ''
+      }
+      dataLength += chunk.data.length
       remaining -= chunk.data.length
       entry.queuedChars -= chunk.data.length
       // Clear drained slots before the 64-chunk compaction can release them.
@@ -79,7 +90,16 @@ export function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite |
       continue
     }
 
-    data += chunk.data.slice(0, remaining)
+    const prefix = chunk.data.slice(0, remaining)
+    if (dataParts) {
+      dataParts.push(prefix)
+    } else if (dataLength === 0) {
+      data = prefix
+    } else {
+      dataParts = [data, prefix]
+      data = ''
+    }
+    dataLength += prefix.length
     const residual = chunk.data.slice(remaining)
     // Geometric flattening bounds retained parents while keeping total copy work linear.
     const flatten = residual.length * 2 <= chunk.retainedChars
@@ -97,9 +117,10 @@ export function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite |
     entry.queuedChars = 0
   }
   recordQueueDebugPressure()
-  return data
+  const assembledData = dataParts ? dataParts.join('') : data
+  return assembledData
     ? {
-        data,
+        data: assembledData,
         foreground: foreground === true,
         forceForegroundRefresh,
         followupForegroundRefresh,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |

<!-- /orca-pr-loc -->

## Summary
- avoid repeated string concatenation when draining many terminal-output chunks
- join chunk parts once while preserving foreground boundaries, callbacks, ACK credits, and partial residuals
- add a regression test for ordered multi-chunk assembly

## Why
Under heavy agent output, repeated concatenation in the renderer queue can repeatedly copy accumulated strings. Building parts and joining once keeps drain assembly linear and reduces renderer CPU pressure.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-queue-chunks.test.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-queue-retention.test.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts`
- pre-commit oxlint/oxfmt hooks

## ELI5

When terminal output arrives in many tiny pieces, the queue used to grow one output string a piece at a time. It now keeps the pieces in a list and joins them once, while preserving partial chunks and all callbacks.

## Performance Measurement

Reproducible deterministic fixture from the queue regression: enqueue 128 ordered chunks, then drain the complete output except for a two-character residual.

- Before: 128 `data += ...` string-assembly operations.
- After: 1 final `join('')` (the first chunk is reused directly and later chunks are collected).
- Improvement: 127 fewer assembly operations, a 99.2% reduction for this 128-chunk drain; output order and residual handling are unchanged.

Run the focused queue coverage with `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-queue-chunks.test.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-queue-retention.test.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts`.

## User-Facing Trade-offs

None. Terminal output ordering, foreground boundaries, callbacks, ACK credits, residual chunks, and queue compaction remain unchanged; only redundant intermediate string assembly is removed.