### PR TITLE
fix(native-chat): serialize structured session resumes

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -6870,6 +6870,7 @@
         "workspace activation",
         "sleep and hibernate restore",
         "provider session dedupe",
+        "structured session surface holds",
         "sidebar and mobile identity",
         "runtime-owned background PTY mount and remount"
       ],
@@ -6877,7 +6878,7 @@
       "providers": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["local", "daemon", "remote-runtime"],
-      "coverageNotes": "Renderer ownership/dedupe contracts cover provider-session claims. Local and daemon attach-only contracts prove an existing stable-pane owner is adopted without provider creation, while remote-runtime transport contracts preserve adopted ownership through cancellation. The Electron oracle covers a local macOS runtime and daemon with real agent, Setup, and unrelated-canary processes; SSH, WSL, paired-server, Linux, and Windows remain contract-only or unrun.",
+      "coverageNotes": "Renderer ownership/dedupe contracts cover provider-session claims. Local and daemon attach-only contracts prove an existing stable-pane owner is adopted without provider creation, while remote-runtime transport contracts preserve adopted ownership through cancellation. Structured host contracts race desktop and paired surface holds through one deferred provider acquisition, shared failure, retry, release, disposal, subscription abort, and a stop-versus-reopen overlap. The Electron oracle covers a local macOS runtime and daemon with real agent, Setup, and unrelated-canary processes; SSH, WSL, paired-server, Linux, and Windows remain contract-only or unrun.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/6800",
         "https://github.com/stablyai/orca/pull/5240",
@@ -6886,16 +6887,22 @@
         "https://github.com/stablyai/orca/pull/11789",
         "https://github.com/stablyai/orca/pull/11819"
       ],
-      "invariant": "Workspace activation, launch, restore, sleep, hibernate, dedupe, clearing, mount, remount, and reconnect code must not replay or resume a provider session id already owned, queued, pending, live, or durably bound to a host PTY in that workspace. A renderer with missing projection state must adopt the exact runtime-owned PTY for the original tab and leaf rather than create a replacement.",
-      "oracle": "Renderer-state tests assert provider-session ownership across preserved and queued panes. Main/provider contracts assert atomic attach-only adoption, stable host/worktree/tab/leaf identity, no fresh spawn on adoption, and safe paired-runtime cancellation. The Electron oracle creates inactive runtime-owned Codex and Setup PTYs plus an unrelated canary, seeds an exact resumable provider session, removes only the target renderer projections, and activates the workspace. It requires byte-stable handle, PTY, incarnation, tab, leaf, process PID, renderer graph, persisted binding, runtime id, graph epoch, and daemon PID across first mount and reload; PID-specific DOM keyboard I/O must remain live with one launch, zero resume argv, zero signals, zero interruption text, and no canary mutation.",
+      "invariant": "Workspace activation, launch, restore, sleep, hibernate, dedupe, clearing, mount, remount, and reconnect code must not replay or resume a provider session id already owned, queued, pending, live, or durably bound to a host PTY in that workspace. Concurrent structured surface holds for one session share one in-flight resume; every caller observes the same failure, a later retry remains possible, release or disposal during acquisition cannot publish a stale child, and a hold arriving during eviction remains cancellable before it reacquires after teardown. Failed eviction is retried once before later demand reacquires. A subscription opens only while its retain hold is still current after any overlapping close, and cancelled restoration cannot reinsert a closed session. A renderer with missing projection state must adopt the exact runtime-owned PTY for the original tab and leaf rather than create a replacement.",
+      "oracle": "Renderer-state tests assert provider-session ownership across preserved and queued panes. Main/provider contracts assert atomic attach-only adoption, stable host/worktree/tab/leaf identity, no fresh spawn on adoption, and safe paired-runtime cancellation. Deferred structured-host tests race desktop and paired holders, require one resume and one provider acquisition, replay the same error to both callers, retry after settlement, release a child published by a failed resume after every holder leaves, invalidate pending work on disposal, reject disposal during eviction wait, preserve eviction failure until explicit retry, release only after the last holder leaves, and reopen a surface only after overlapping teardown settles. RPC tests abort a subscription while eviction is deferred, race close after retain settlement, and require zero stale subscriber opens; a surviving stream restores only readable state after teardown. Runtime integration defers an admitted provider connection across shutdown and requires the adapter to supersede and close it before teardown completes. The Electron oracle creates inactive runtime-owned Codex and Setup PTYs plus an unrelated canary, seeds an exact resumable provider session, removes only the target renderer projections, and activates the workspace. It requires byte-stable handle, PTY, incarnation, tab, leaf, process PID, renderer graph, persisted binding, runtime id, graph epoch, and daemon PID across first mount and reload; PID-specific DOM keyboard I/O must remain live with one launch, zero resume argv, zero signals, zero interruption text, and no canary mutation.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/native-chat/agent-session-wire/structured-agent-session-holds.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-restart-restore.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-surface-lifetime.test.ts src/main/runtime/rpc/methods/structured-agent-session-hold.test.ts src/main/runtime/structured-agent-session-runtime.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts tests/e2e/completed-worker-retirement-resume.unit.test.ts --reporter=verbose",
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts src/main/providers/local-pty-provider-spawn-session.test.ts src/main/daemon/terminal-host.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/ipc/pty-pane-materialization-race.test.ts src/main/ipc/pty-persisted-incarnation-repair.test.ts src/main/ipc/pty-pane-reservation-settlement.test.ts src/main/runtime/orca-runtime.test.ts src/renderer/src/lib/pane-manager/pane-fit.test.ts src/renderer/src/components/terminal-pane/pty-connection-deferred-reattach-live-output.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-host-session-launch.test.ts",
         "pnpm exec electron-vite build --mode e2e && SKIP_BUILD=1 pnpm exec playwright test tests/e2e/live-background-terminal-mount-authority.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1"
       ],
       "testFiles": [
         "src/renderer/src/lib/resume-sleeping-agent-session.test.ts",
+        "src/main/native-chat/agent-session-wire/structured-agent-session-holds.test.ts",
+        "src/main/native-chat/agent-session-wire/structured-agent-session-restart-restore.test.ts",
+        "src/main/native-chat/agent-session-wire/structured-agent-session-surface-lifetime.test.ts",
+        "src/main/runtime/rpc/methods/structured-agent-session-hold.test.ts",
+        "src/main/runtime/structured-agent-session-runtime.test.ts",
         "tests/e2e/completed-worker-retirement-resume.unit.test.ts",
         "src/main/providers/local-pty-provider-spawn-session.test.ts",
         "src/main/daemon/terminal-host.test.ts",
@@ -6910,6 +6917,43 @@
         "tests/e2e/live-background-terminal-mount-authority.spec.ts"
       ],
       "assertionRefs": [
+        {
+          "file": "src/main/native-chat/agent-session-wire/structured-agent-session-holds.test.ts",
+          "assertions": [
+            "concurrent same-session holds share one deferred resume and its exact failure before a fresh retry",
+            "forget invalidates the pending generation without letting its failure remove a replacement holder",
+            "release during resume preserves remaining holders, evicts a child published before failed settlement after every holder leaves, and disposal invalidates a pre-attach resume",
+            "a replacement hold waits for an in-flight eviction, remains cancellable while pending, and resumes only after teardown",
+            "disposal rejects an eviction-waiting hold, and later demand retries even a valueless eviction rejection before reacquiring"
+          ]
+        },
+        {
+          "file": "src/main/native-chat/agent-session-wire/structured-agent-session-restart-restore.test.ts",
+          "assertions": [
+            "holder cancellation while the journal opens cannot publish a stale readable session"
+          ]
+        },
+        {
+          "file": "src/main/native-chat/agent-session-wire/structured-agent-session-surface-lifetime.test.ts",
+          "assertions": [
+            "desktop and paired surfaces converge through one provider acquisition and one live lease",
+            "a paired surface arriving while release eviction stops the child reopens only after teardown"
+          ]
+        },
+        {
+          "file": "src/main/runtime/rpc/methods/structured-agent-session-hold.test.ts",
+          "assertions": [
+            "a transport aborted during deferred eviction opens no subscriber and retains no holder",
+            "close beginning after retain settlement invalidates the holder before a subscriber can open or readable restoration can reinsert it",
+            "a surviving subscription waits for eviction and restores only readable state before opening"
+          ]
+        },
+        {
+          "file": "src/main/runtime/structured-agent-session-runtime.test.ts",
+          "assertions": [
+            "shutdown supersedes and closes a provider connection whose resume attach was already admitted"
+          ]
+        },
         {
           "file": "tests/e2e/completed-worker-retirement-resume.unit.test.ts",
           "assertions": [
@@ -8189,9 +8233,7 @@
       "assertionRefs": [
         {
           "file": "tests/e2e/persisted-session-production-upgrade.spec.ts",
-          "assertions": [
-            "upgrades a legacy daemon session and keeps it stable after relaunch"
-          ]
+          "assertions": ["upgrades a legacy daemon session and keeps it stable after relaunch"]
         }
       ],
       "evidenceRuns": [

--- a/src/main/codex/codex-structured-session-close.ts
+++ b/src/main/codex/codex-structured-session-close.ts
@@ -41,7 +41,10 @@ export async function closeCodexPublishedSession(
   if (exited !== true) {
     return false
   }
-  sessions.delete(sessionId)
+  // A timed-out/stale close may finish after a replacement was published; never delete it.
+  if (sessions.get(sessionId) === session) {
+    sessions.delete(sessionId)
+  }
   if (!session.ended) {
     session.ended = true
     const event: CodexStructuredSessionEvent = {

--- a/src/main/codex/codex-structured-session-shutdown.test.ts
+++ b/src/main/codex/codex-structured-session-shutdown.test.ts
@@ -8,6 +8,7 @@ import {
   CodexStructuredSessionAdapter,
   type CodexStructuredLaunch
 } from './codex-structured-session-adapter'
+import { closeCodexPublishedSession } from './codex-structured-session-close'
 
 const SESSION_ID = 'session-1'
 const THREAD_ID = 'thread-1'
@@ -30,6 +31,30 @@ function identity(): AgentSessionJournalIdentity {
 }
 
 describe('CodexStructuredSessionAdapter shutdown', () => {
+  it('does not let a stale close delete a replacement session', async () => {
+    const closeGate = Promise.withResolvers<boolean>()
+    const oldSession = {
+      connection: { close: () => closeGate.promise },
+      prompts: { clear: () => {} },
+      ended: true,
+      translator: null
+    }
+    const replacement = {
+      connection: { close: async () => true },
+      prompts: { clear: () => {} },
+      ended: false,
+      translator: null
+    }
+    const sessions = new Map([['session-1', oldSession]])
+
+    const closing = closeCodexPublishedSession(sessions as never, 'session-1')
+    sessions.set('session-1', replacement)
+    closeGate.resolve(true)
+
+    await expect(closing).resolves.toBe(true)
+    expect(sessions.get('session-1')).toBe(replacement)
+  })
+
   it('refuses acquisitions that enter after closeAll starts', async () => {
     const connections: CodexAppServerConnection[] = []
     const openConnection = (async () => {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-holders.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-holders.ts
@@ -1,49 +1,63 @@
-// Who WANTS this session alive, as a set of ids rather than a count.
-//
-// A refcount is the obvious shape and the wrong one. Every path that decrements it — a chat tab
-// closing, a transport dying, a client retrying a release it already sent — can fire twice or not
-// at all, and an integer cannot tell those apart: a duplicate release evicts a session somebody is
-// still looking at, and a lost one leaks the child forever. A set answers both idempotently,
-// because it records WHICH surface holds the session, not how many do.
+export type StructuredAgentSessionHolderRegistration = {
+  token: symbol
+  active: boolean
+}
 
 export class StructuredAgentSessionHolders {
-  private readonly bySession = new Map<string, Set<string>>()
+  private readonly registrations = new Map<string, StructuredAgentSessionHolderRegistration>()
 
-  /** True when the session gained its FIRST holder — the edge that ends a pending release. */
-  add(sessionId: string, holderId: string): boolean {
-    const holders = this.bySession.get(sessionId)
-    if (!holders) {
-      this.bySession.set(sessionId, new Set([holderId]))
-      return true
+  get size(): number {
+    return this.registrations.size
+  }
+
+  add(
+    holderId: string,
+    active: boolean
+  ): { alreadyHeld: boolean; registration: StructuredAgentSessionHolderRegistration } {
+    const existing = this.registrations.get(holderId)
+    if (existing) {
+      return { alreadyHeld: true, registration: existing }
     }
-    holders.add(holderId)
+    const registration = { token: Symbol(holderId), active }
+    this.registrations.set(holderId, registration)
+    return { alreadyHeld: false, registration }
+  }
+
+  isCurrent(holderId: string, registration: StructuredAgentSessionHolderRegistration): boolean {
+    return this.registrations.get(holderId)?.token === registration.token
+  }
+
+  remove(holderId: string): boolean {
+    const holder = this.registrations.get(holderId)
+    if (!holder) {
+      return false
+    }
+    this.registrations.delete(holderId)
+    return holder.active && !this.hasActive()
+  }
+
+  hasActive(): boolean {
+    for (const holder of this.registrations.values()) {
+      if (holder.active) {
+        return true
+      }
+    }
     return false
   }
 
-  /** True when the session lost its LAST holder — the edge that starts one. */
-  remove(sessionId: string, holderId: string): boolean {
-    const holders = this.bySession.get(sessionId)
-    if (!holders?.delete(holderId) || holders.size > 0) {
-      return false
+  forget(preservePending: boolean): void {
+    for (const [holderId, holder] of this.registrations) {
+      if (holder.active || !preservePending) {
+        this.registrations.delete(holderId)
+      }
     }
-    this.bySession.delete(sessionId)
-    return true
   }
 
-  isHeld(sessionId: string): boolean {
-    return (this.bySession.get(sessionId)?.size ?? 0) > 0
+  get(holderId: string): StructuredAgentSessionHolderRegistration | undefined {
+    return this.registrations.get(holderId)
   }
 
-  has(sessionId: string, holderId: string): boolean {
-    return this.bySession.get(sessionId)?.has(holderId) ?? false
-  }
-
-  holderIds(sessionId: string): string[] {
-    return [...(this.bySession.get(sessionId) ?? [])]
-  }
-
-  /** Drops every holder of one session without evaluating the edge, for a session that is gone. */
-  forget(sessionId: string): void {
-    this.bySession.delete(sessionId)
+  clear(): void {
+    this.registrations.clear()
   }
 }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-holds.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-holds.test.ts
@@ -2,7 +2,6 @@
 // deadline that keeps teardown from hanging.
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { StructuredAgentSessionHolders } from './structured-agent-session-holders'
 import { StructuredAgentSessionReleaseClock } from './structured-agent-session-release-clock'
 import { StructuredAgentSessionHolds } from './structured-agent-session-holds'
 import {
@@ -37,40 +36,6 @@ afterEach(() => {
   for (const created of clocks.splice(0)) {
     created.dispose()
   }
-})
-
-describe('the holder set', () => {
-  it('reports the first and last holder, and nothing in between', () => {
-    const holders = new StructuredAgentSessionHolders()
-
-    expect(holders.add('session-1', 'a')).toBe(true)
-    expect(holders.add('session-1', 'b')).toBe(false)
-    expect(holders.remove('session-1', 'a')).toBe(false)
-    expect(holders.remove('session-1', 'b')).toBe(true)
-    expect(holders.isHeld('session-1')).toBe(false)
-  })
-
-  // The reason this is a set and not a count: every release path can fire twice or not at all.
-  it('absorbs a duplicate hold and a duplicate release', () => {
-    const holders = new StructuredAgentSessionHolders()
-
-    holders.add('session-1', 'a')
-    holders.add('session-1', 'a')
-    expect(holders.remove('session-1', 'a')).toBe(true)
-    expect(holders.remove('session-1', 'a')).toBe(false)
-    expect(holders.holderIds('session-1')).toEqual([])
-  })
-
-  it('keeps one session holders out of another session holders', () => {
-    const holders = new StructuredAgentSessionHolders()
-
-    holders.add('session-1', 'a')
-    holders.add('session-2', 'a')
-    holders.remove('session-1', 'a')
-
-    expect(holders.isHeld('session-1')).toBe(false)
-    expect(holders.isHeld('session-2')).toBe(true)
-  })
 })
 
 describe('the release clock', () => {
@@ -176,6 +141,656 @@ describe('holds', () => {
     )
     expect(holds.isHeld('session-1')).toBe(false)
     holds.dispose()
+  })
+
+  it('shares the synthesized ownership failure when resume publishes no child', async () => {
+    const resumeGate = Promise.withResolvers<void>()
+    const holds = new StructuredAgentSessionHolds({
+      resume: async () => resumeGate.promise,
+      hasProviderChild: () => false,
+      isTurnActive: () => false,
+      evict: async () => {},
+      graceMs: 1
+    })
+
+    const desktop = holds.hold('session-1', 'desktop-chat')
+    const paired = holds.hold('session-1', 'paired-chat')
+    resumeGate.resolve()
+    const failed = await Promise.allSettled([desktop, paired])
+
+    expect(failed[0]).toMatchObject({
+      status: 'rejected',
+      reason: expect.objectContaining({ message: 'agent_session_ownership_unknown' })
+    })
+    expect(failed[1]).toMatchObject({ status: 'rejected' })
+    if (failed[0]?.status !== 'rejected' || failed[1]?.status !== 'rejected') {
+      throw new Error('both holds must reject')
+    }
+    expect(failed[1].reason).toBe(failed[0].reason)
+    expect(holds.isHeld('session-1')).toBe(false)
+    holds.dispose()
+  })
+
+  it('single-flights concurrent resume requests until the provider child is published', async () => {
+    const entered = Promise.withResolvers<void>()
+    const resumeGate = Promise.withResolvers<void>()
+    let child = false
+    const resume = vi.fn(async () => {
+      entered.resolve()
+      await resumeGate.promise
+      child = true
+    })
+    const holds = new StructuredAgentSessionHolds({
+      resume,
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict: async () => {},
+      graceMs: 1
+    })
+
+    const desktop = holds.hold('session-1', 'desktop-chat')
+    await entered.promise
+    const paired = holds.hold('session-1', 'paired-chat')
+    await Promise.resolve()
+
+    expect(resume).toHaveBeenCalledOnce()
+    resumeGate.resolve()
+    await expect(Promise.all([desktop, paired])).resolves.toEqual([undefined, undefined])
+    expect(holds.isHeld('session-1')).toBe(true)
+    holds.dispose()
+  })
+
+  it('shares a resume failure and permits a fresh retry after it settles', async () => {
+    const failure = new Error('resume failed')
+    const resumeGate = Promise.withResolvers<void>()
+    let child = false
+    const resume = vi.fn<() => Promise<void>>(async () => {
+      await resumeGate.promise
+      throw failure
+    })
+    const holds = new StructuredAgentSessionHolds({
+      resume,
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict: async () => {},
+      graceMs: 1
+    })
+
+    const desktop = holds.hold('session-1', 'desktop-chat')
+    const paired = holds.hold('session-1', 'paired-chat')
+    await Promise.resolve()
+    expect(resume).toHaveBeenCalledOnce()
+
+    resumeGate.resolve()
+    const failed = await Promise.allSettled([desktop, paired])
+    expect(failed).toEqual([
+      { status: 'rejected', reason: failure },
+      { status: 'rejected', reason: failure }
+    ])
+    expect(holds.isHeld('session-1')).toBe(false)
+
+    resume.mockImplementation(async () => {
+      child = true
+    })
+    await expect(holds.hold('session-1', 'retry-chat')).resolves.toBeUndefined()
+    expect(resume).toHaveBeenCalledTimes(2)
+    holds.dispose()
+  })
+
+  it('shares a failure after the pending resume temporarily publishes a child', async () => {
+    const failure = new Error('settlement failed')
+    const published = Promise.withResolvers<void>()
+    const settlementGate = Promise.withResolvers<void>()
+    let child = false
+    const resume = vi.fn(async () => {
+      child = true
+      published.resolve()
+      await settlementGate.promise
+      throw failure
+    })
+    const holds = new StructuredAgentSessionHolds({
+      resume,
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict: async () => {
+        child = false
+      },
+      graceMs: 1
+    })
+
+    const desktop = holds.hold('session-1', 'desktop-chat')
+    await published.promise
+    const paired = holds.hold('session-1', 'paired-chat')
+    await Promise.resolve()
+    expect(resume).toHaveBeenCalledOnce()
+
+    settlementGate.resolve()
+    expect(await Promise.allSettled([desktop, paired])).toEqual([
+      { status: 'rejected', reason: failure },
+      { status: 'rejected', reason: failure }
+    ])
+    expect(holds.isHeld('session-1')).toBe(false)
+    holds.dispose()
+  })
+
+  it('releases a child published after every holder left even when resume fails', async () => {
+    const failure = new Error('settlement failed after publication')
+    const resumeEntered = Promise.withResolvers<void>()
+    const resumeGate = Promise.withResolvers<void>()
+    let child = false
+    const evict = vi.fn(async () => {
+      child = false
+    })
+    const holds = new StructuredAgentSessionHolds({
+      resume: async () => {
+        resumeEntered.resolve()
+        await resumeGate.promise
+        child = true
+        throw failure
+      },
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict,
+      graceMs: 1
+    })
+
+    const pending = holds.hold('session-1', 'desktop-chat')
+    await resumeEntered.promise
+    holds.release('session-1', 'desktop-chat')
+    resumeGate.resolve()
+
+    await expect(pending).rejects.toBe(failure)
+    await vi.waitFor(() => expect(evict).toHaveBeenCalledOnce())
+    expect(child).toBe(false)
+    holds.dispose()
+  })
+
+  it('does not block another session behind a pending resume', async () => {
+    const firstEntered = Promise.withResolvers<void>()
+    const firstGate = Promise.withResolvers<void>()
+    const children = new Set<string>()
+    const resume = vi.fn(async (sessionId: string) => {
+      if (sessionId === 'session-1') {
+        firstEntered.resolve()
+        await firstGate.promise
+      }
+      children.add(sessionId)
+    })
+    const holds = new StructuredAgentSessionHolds({
+      resume,
+      hasProviderChild: (sessionId) => children.has(sessionId),
+      isTurnActive: () => false,
+      evict: async () => {},
+      graceMs: 1
+    })
+
+    const first = holds.hold('session-1', 'desktop-chat')
+    await firstEntered.promise
+    await expect(holds.hold('session-2', 'paired-chat')).resolves.toBeUndefined()
+    expect(resume).toHaveBeenCalledWith('session-2', expect.any(Function))
+
+    firstGate.resolve()
+    await expect(first).resolves.toBeUndefined()
+    holds.dispose()
+  })
+
+  it('releases a cancelled holder without cancelling another holder shared resume', async () => {
+    const entered = Promise.withResolvers<void>()
+    const resumeGate = Promise.withResolvers<void>()
+    let child = false
+    const evict = vi.fn(async () => {
+      child = false
+    })
+    const holds = new StructuredAgentSessionHolds({
+      resume: async () => {
+        entered.resolve()
+        await resumeGate.promise
+        child = true
+      },
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict,
+      graceMs: 1
+    })
+
+    const desktop = holds.hold('session-1', 'desktop-chat')
+    await entered.promise
+    const paired = holds.hold('session-1', 'paired-chat')
+    holds.release('session-1', 'desktop-chat')
+    resumeGate.resolve()
+
+    await expect(Promise.all([desktop, paired])).resolves.toEqual([undefined, undefined])
+    expect(holds.isHeld('session-1')).toBe(true)
+    expect(evict).not.toHaveBeenCalled()
+
+    holds.release('session-1', 'paired-chat')
+    await vi.waitFor(() => expect(evict).toHaveBeenCalledOnce())
+    holds.dispose()
+  })
+
+  it('arms release when every holder leaves during a shared resume', async () => {
+    const entered = Promise.withResolvers<void>()
+    const resumeGate = Promise.withResolvers<void>()
+    let child = false
+    const evict = vi.fn(async () => {
+      child = false
+    })
+    const holds = new StructuredAgentSessionHolds({
+      resume: async () => {
+        entered.resolve()
+        await resumeGate.promise
+        child = true
+      },
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict,
+      graceMs: 1
+    })
+
+    const desktop = holds.hold('session-1', 'desktop-chat')
+    await entered.promise
+    const paired = holds.hold('session-1', 'paired-chat')
+    holds.release('session-1', 'desktop-chat')
+    holds.release('session-1', 'paired-chat')
+    resumeGate.resolve()
+
+    await expect(Promise.all([desktop, paired])).resolves.toEqual([undefined, undefined])
+    expect(holds.isHeld('session-1')).toBe(false)
+    await vi.waitFor(() => expect(evict).toHaveBeenCalledOnce())
+    holds.dispose()
+  })
+
+  it('waits for an in-flight eviction before registering a replacement hold', async () => {
+    const evictionEntered = Promise.withResolvers<void>()
+    const evictionGate = Promise.withResolvers<void>()
+    let child = true
+    const resume = vi.fn(async () => {
+      child = true
+    })
+    let holds: StructuredAgentSessionHolds
+    holds = new StructuredAgentSessionHolds({
+      resume,
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict: async () => {
+        evictionEntered.resolve()
+        await evictionGate.promise
+        child = false
+        holds.forget('session-1')
+      },
+      graceMs: 1
+    })
+
+    await holds.hold('session-1', 'desktop-chat', { resume: false })
+    holds.release('session-1', 'desktop-chat')
+    await evictionEntered.promise
+    const replacement = holds.hold('session-1', 'paired-chat')
+    await Promise.resolve()
+
+    expect(holds.isHeld('session-1')).toBe(false)
+    expect(resume).not.toHaveBeenCalled()
+    evictionGate.resolve()
+    await expect(replacement).resolves.toBeUndefined()
+    expect(resume).toHaveBeenCalledOnce()
+    expect(holds.isHeld('session-1')).toBe(true)
+    holds.dispose()
+  })
+
+  it('does not retain a hold released while eviction is still running', async () => {
+    const evictionEntered = Promise.withResolvers<void>()
+    const evictionGate = Promise.withResolvers<void>()
+    let child = true
+    const resume = vi.fn(async () => {
+      child = true
+    })
+    let holds: StructuredAgentSessionHolds
+    holds = new StructuredAgentSessionHolds({
+      resume,
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict: async () => {
+        evictionEntered.resolve()
+        await evictionGate.promise
+        child = false
+        holds.forget('session-1')
+      },
+      graceMs: 1
+    })
+
+    const eviction = holds.evict('session-1')
+    await evictionEntered.promise
+    const retaining = holds.hold('session-1', 'subscription:paired', { resume: false })
+    holds.release('session-1', 'subscription:paired')
+    evictionGate.resolve()
+
+    await eviction
+    await expect(retaining).resolves.toBeUndefined()
+    expect(holds.isHeld('session-1')).toBe(false)
+    expect(resume).not.toHaveBeenCalled()
+    holds.dispose()
+  })
+
+  it('rejects a hold still waiting for eviction when the host is disposed', async () => {
+    const evictionEntered = Promise.withResolvers<void>()
+    const evictionGate = Promise.withResolvers<void>()
+    const resume = vi.fn(async () => {})
+    const holds = new StructuredAgentSessionHolds({
+      resume,
+      hasProviderChild: () => false,
+      isTurnActive: () => false,
+      evict: async () => {
+        evictionEntered.resolve()
+        await evictionGate.promise
+      },
+      graceMs: 1
+    })
+
+    const eviction = holds.evict('session-1')
+    await evictionEntered.promise
+    const pending = holds.hold('session-1', 'paired-chat')
+    holds.dispose()
+    evictionGate.resolve()
+
+    await eviction
+    await expect(pending).rejects.toThrow('agent_session_ownership_unknown')
+    expect(resume).not.toHaveBeenCalled()
+    expect(holds.isHeld('session-1')).toBe(false)
+  })
+
+  it('retries failed teardown before admitting a later hold', async () => {
+    const failure = new Error('teardown failed after stopping the child')
+    const evictionEntered = Promise.withResolvers<void>()
+    const evictionGate = Promise.withResolvers<void>()
+    let child = true
+    const resume = vi.fn(async () => {
+      child = true
+    })
+    let attempts = 0
+    let holds: StructuredAgentSessionHolds
+    holds = new StructuredAgentSessionHolds({
+      resume,
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict: async () => {
+        attempts += 1
+        if (attempts === 1) {
+          evictionEntered.resolve()
+          await evictionGate.promise
+          throw failure
+        }
+        child = false
+        holds.forget('session-1')
+      },
+      graceMs: 1
+    })
+
+    const eviction = holds.evict('session-1')
+    await evictionEntered.promise
+    const waiting = holds.hold('session-1', 'paired-chat')
+    evictionGate.resolve()
+
+    await expect(eviction).rejects.toBe(failure)
+    await expect(waiting).rejects.toBe(failure)
+    await expect(holds.hold('session-1', 'desktop-chat')).resolves.toBeUndefined()
+    expect(attempts).toBe(2)
+    expect(resume).toHaveBeenCalledOnce()
+    expect(holds.isHeld('session-1')).toBe(true)
+    holds.dispose()
+  })
+
+  it('retries an eviction that rejected without an error value', async () => {
+    const evictionEntered = Promise.withResolvers<void>()
+    const evictionGate = Promise.withResolvers<void>()
+    const retryFailure = new Error('retry failed')
+    const resume = vi.fn(async () => {})
+    let attempts = 0
+    const holds = new StructuredAgentSessionHolds({
+      resume,
+      hasProviderChild: () => true,
+      isTurnActive: () => false,
+      evict: async () => {
+        attempts += 1
+        if (attempts === 1) {
+          evictionEntered.resolve()
+          await evictionGate.promise
+          throw undefined
+        }
+        throw retryFailure
+      },
+      graceMs: 1
+    })
+
+    const eviction = holds.evict('session-1')
+    await evictionEntered.promise
+    const waiting = holds.hold('session-1', 'paired-chat')
+    evictionGate.resolve()
+
+    const [evictionResult, waitingResult] = await Promise.allSettled([eviction, waiting])
+    expect(evictionResult).toEqual({ status: 'rejected', reason: undefined })
+    expect(waitingResult).toEqual({ status: 'rejected', reason: undefined })
+    await expect(holds.hold('session-1', 'desktop-chat')).rejects.toBe(retryFailure)
+    expect(attempts).toBe(2)
+    expect(resume).not.toHaveBeenCalled()
+    holds.dispose()
+  })
+
+  it('waits for an eviction chained before its hold continuation', async () => {
+    const firstEntered = Promise.withResolvers<void>()
+    const firstGate = Promise.withResolvers<void>()
+    const secondEntered = Promise.withResolvers<void>()
+    const secondGate = Promise.withResolvers<void>()
+    let evictionCount = 0
+    let child = true
+    const resume = vi.fn(async () => {
+      child = true
+    })
+    let holds: StructuredAgentSessionHolds
+    holds = new StructuredAgentSessionHolds({
+      resume,
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict: async () => {
+        evictionCount += 1
+        const entered = evictionCount === 1 ? firstEntered : secondEntered
+        const gate = evictionCount === 1 ? firstGate : secondGate
+        entered.resolve()
+        await gate.promise
+        child = false
+        holds.forget('session-1')
+      },
+      graceMs: 1
+    })
+
+    const first = holds.evict('session-1')
+    await firstEntered.promise
+    const chained = first.then(() => holds.evict('session-1'))
+    const replacement = holds.hold('session-1', 'paired-chat')
+    firstGate.resolve()
+    await secondEntered.promise
+    await Promise.resolve()
+
+    expect(holds.isHeld('session-1')).toBe(false)
+    expect(resume).not.toHaveBeenCalled()
+    secondGate.resolve()
+    await chained
+    await expect(replacement).resolves.toBeUndefined()
+    expect(resume).toHaveBeenCalledOnce()
+    expect(holds.isHeld('session-1')).toBe(true)
+    holds.dispose()
+  })
+
+  it('invalidates a pending resume before eviction starts', async () => {
+    const resumeEntered = Promise.withResolvers<void>()
+    const resumeGate = Promise.withResolvers<void>()
+    let resumeWasCurrent = true
+    const evict = vi.fn(async () => {})
+    const holds = new StructuredAgentSessionHolds({
+      resume: async (_sessionId, isCurrent) => {
+        resumeEntered.resolve()
+        await resumeGate.promise
+        resumeWasCurrent = isCurrent()
+        if (!resumeWasCurrent) {
+          throw new Error('agent_session_ownership_unknown')
+        }
+      },
+      hasProviderChild: () => false,
+      isTurnActive: () => false,
+      evict,
+      graceMs: 1
+    })
+
+    const pending = holds.hold('session-1', 'desktop-chat')
+    await resumeEntered.promise
+    await holds.evict('session-1')
+    resumeGate.resolve()
+
+    await expect(pending).rejects.toThrow('agent_session_ownership_unknown')
+    expect(resumeWasCurrent).toBe(false)
+    expect(evict).toHaveBeenCalledOnce()
+    expect(holds.isHeld('session-1')).toBe(false)
+    holds.dispose()
+  })
+
+  it('does not let a forgotten resume settle a replacement of the same holder', async () => {
+    const firstEntered = Promise.withResolvers<void>()
+    const firstGate = Promise.withResolvers<void>()
+    const firstFailure = new Error('forgotten resume failed')
+    let child = false
+    const resume = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(async () => {
+        firstEntered.resolve()
+        await firstGate.promise
+        throw firstFailure
+      })
+      .mockImplementationOnce(async () => {
+        child = true
+      })
+    const holds = new StructuredAgentSessionHolds({
+      resume,
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict: async () => {},
+      graceMs: 1
+    })
+
+    const forgotten = holds.hold('session-1', 'desktop-chat')
+    await firstEntered.promise
+    holds.forget('session-1')
+    await expect(holds.hold('session-1', 'desktop-chat')).resolves.toBeUndefined()
+
+    firstGate.resolve()
+    await expect(forgotten).rejects.toBe(firstFailure)
+    expect(resume).toHaveBeenCalledTimes(2)
+    expect(holds.isHeld('session-1')).toBe(true)
+    holds.dispose()
+  })
+
+  it('does not report a forgotten hold as live after its resume succeeds', async () => {
+    const entered = Promise.withResolvers<void>()
+    const resumeGate = Promise.withResolvers<void>()
+    let child = false
+    const evict = vi.fn(async () => {
+      child = false
+    })
+    const holds = new StructuredAgentSessionHolds({
+      resume: async () => {
+        entered.resolve()
+        await resumeGate.promise
+        child = true
+      },
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict,
+      graceMs: 1
+    })
+
+    const forgotten = holds.hold('session-1', 'desktop-chat')
+    await entered.promise
+    holds.forget('session-1')
+    resumeGate.resolve()
+
+    await expect(forgotten).rejects.toThrow('agent_session_ownership_unknown')
+    expect(holds.isHeld('session-1')).toBe(false)
+    await vi.waitFor(() => expect(evict).toHaveBeenCalledOnce())
+    holds.dispose()
+  })
+
+  it('releases a forgotten child when its replacement resume fails', async () => {
+    const firstGate = Promise.withResolvers<void>()
+    const secondGate = Promise.withResolvers<void>()
+    const replacementFailure = new Error('replacement resume failed')
+    let child = false
+    const evict = vi.fn(async () => {
+      child = false
+    })
+    const resume = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(async () => {
+        await firstGate.promise
+        child = true
+      })
+      .mockImplementationOnce(async () => {
+        await secondGate.promise
+        throw replacementFailure
+      })
+    const holds = new StructuredAgentSessionHolds({
+      resume,
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict,
+      graceMs: 1
+    })
+
+    const forgotten = holds.hold('session-1', 'desktop-chat')
+    await Promise.resolve()
+    holds.forget('session-1')
+    const replacement = holds.hold('session-1', 'paired-chat')
+    await Promise.resolve()
+
+    firstGate.resolve()
+    await expect(forgotten).rejects.toThrow('agent_session_ownership_unknown')
+    secondGate.resolve()
+    await expect(replacement).rejects.toBe(replacementFailure)
+    expect(holds.isHeld('session-1')).toBe(false)
+    await vi.waitFor(() => expect(evict).toHaveBeenCalledOnce())
+    holds.dispose()
+  })
+
+  it('invalidates a pending resume when the host is disposed', async () => {
+    const entered = Promise.withResolvers<void>()
+    const resumeGate = Promise.withResolvers<void>()
+    let resumeWasCurrent = true
+    let child = false
+    const evict = vi.fn(async () => {})
+    const holds = new StructuredAgentSessionHolds({
+      resume: async (_sessionId, isCurrent) => {
+        entered.resolve()
+        await resumeGate.promise
+        resumeWasCurrent = isCurrent()
+        if (!resumeWasCurrent) {
+          throw new Error('agent_session_ownership_unknown')
+        }
+        child = true
+      },
+      hasProviderChild: () => child,
+      isTurnActive: () => false,
+      evict,
+      graceMs: 1
+    })
+
+    const pending = holds.hold('session-1', 'desktop-chat')
+    await entered.promise
+    holds.dispose()
+    resumeGate.resolve()
+    await expect(pending).rejects.toThrow('agent_session_ownership_unknown')
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(resumeWasCurrent).toBe(false)
+    expect(child).toBe(false)
+    expect(holds.isHeld('session-1')).toBe(false)
+    expect(holds.isReleasePending('session-1')).toBe(false)
+    expect(evict).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-holds.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-holds.ts
@@ -14,11 +14,14 @@ import {
   StructuredAgentSessionReleaseClock,
   type StructuredAgentSessionReleaseClockDeps
 } from './structured-agent-session-release-clock'
-import { StructuredAgentSessionHolders } from './structured-agent-session-holders'
+import {
+  StructuredAgentSessionHolders,
+  type StructuredAgentSessionHolderRegistration
+} from './structured-agent-session-holders'
 
 export type StructuredAgentSessionHoldsDeps = {
   /** Acquires a provider child for a session that has none. A no-op when one is already live. */
-  resume: (sessionId: string) => Promise<void>
+  resume: (sessionId: string, isCurrent: () => boolean) => Promise<void>
   /** Whether evicting this session would actually free anything. */
   hasProviderChild: (sessionId: string) => boolean
   isTurnActive: (sessionId: string) => boolean
@@ -33,15 +36,32 @@ export type StructuredAgentSessionHoldOptions = {
   resume?: boolean
 }
 
+type StructuredAgentSessionResume = {
+  promise: Promise<void>
+  state: { forgotten: boolean; failure?: Error }
+}
+
+type StructuredAgentSessionLifecycle = {
+  holders: StructuredAgentSessionHolders
+  resume?: StructuredAgentSessionResume
+  eviction?: Promise<void>
+  evictionFailure?: { error: unknown }
+}
+
+export type StructuredAgentSessionHolderLease = {
+  isCurrent: () => boolean
+}
+
 export class StructuredAgentSessionHolds {
-  private readonly holders = new StructuredAgentSessionHolders()
+  private readonly sessions = new Map<string, StructuredAgentSessionLifecycle>()
   private readonly clock: StructuredAgentSessionReleaseClock
+  private disposed = false
 
   constructor(private readonly deps: StructuredAgentSessionHoldsDeps) {
     const clockDeps: StructuredAgentSessionReleaseClockDeps = {
       isTurnActive: deps.isTurnActive,
-      isHeld: (sessionId) => this.holders.isHeld(sessionId),
-      evict: (sessionId) => this.deps.evict(sessionId),
+      isHeld: (sessionId) => this.isHeld(sessionId),
+      evict: (sessionId) => this.evict(sessionId),
       ...(deps.onError ? { onError: deps.onError } : {}),
       ...(deps.graceMs === undefined ? {} : { graceMs: deps.graceMs })
     }
@@ -53,51 +73,255 @@ export class StructuredAgentSessionHolds {
     holderId: string,
     options: StructuredAgentSessionHoldOptions = {}
   ): Promise<void> {
-    const alreadyHeld = this.holders.has(sessionId, holderId)
-    this.holders.add(sessionId, holderId)
+    if (this.disposed) {
+      throw new Error('agent_session_ownership_unknown')
+    }
+    const lifecycle = this.lifecycleFor(sessionId)
+    const { alreadyHeld, registration } = this.addHolder(
+      lifecycle,
+      holderId,
+      lifecycle.eviction === undefined && lifecycle.evictionFailure === undefined
+    )
     // Unconditional, not only on the first-holder edge: a second surface arriving during the grace
     // window must cancel the pending release too.
     this.clock.cancel(sessionId)
-    if (options.resume === false || this.deps.hasProviderChild(sessionId)) {
-      return
-    }
     try {
-      await this.deps.resume(sessionId)
-      if (!this.deps.hasProviderChild(sessionId)) {
+      if (lifecycle.evictionFailure !== undefined && lifecycle.eviction === undefined) {
+        await this.evict(sessionId)
+      }
+      while (lifecycle.eviction) {
+        await lifecycle.eviction
+      }
+      if (this.disposed) {
         throw new Error('agent_session_ownership_unknown')
       }
+      if (!this.isCurrentHolder(sessionId, lifecycle, holderId, registration)) {
+        return
+      }
+      registration.active = true
+      const pendingResume = lifecycle.resume
+      if (
+        options.resume === false ||
+        (this.deps.hasProviderChild(sessionId) && pendingResume === undefined)
+      ) {
+        return
+      }
+      const resume = pendingResume ?? this.resumeSession(sessionId, lifecycle)
+      await resume.promise
+      if (resume.state.forgotten || !this.deps.hasProviderChild(sessionId)) {
+        resume.state.failure ??= new Error('agent_session_ownership_unknown')
+        throw resume.state.failure
+      }
     } catch (error) {
-      if (!alreadyHeld) {
-        this.holders.remove(sessionId, holderId)
+      if (!alreadyHeld && this.isCurrentHolder(sessionId, lifecycle, holderId, registration)) {
+        const lostLastHolder = this.removeHolder(lifecycle, holderId)
+        if (lostLastHolder && this.deps.hasProviderChild(sessionId)) {
+          this.clock.arm(sessionId)
+        }
       }
       throw error
+    } finally {
+      this.prune(sessionId, lifecycle)
     }
   }
 
   release(sessionId: string, holderId: string): void {
-    if (!this.holders.remove(sessionId, holderId)) {
+    const lifecycle = this.sessions.get(sessionId)
+    if (!lifecycle) {
       return
     }
-    if (this.deps.hasProviderChild(sessionId)) {
+    const lostLastHolder = this.removeHolder(lifecycle, holderId)
+    if (lostLastHolder && this.deps.hasProviderChild(sessionId)) {
       this.clock.arm(sessionId)
     }
+    this.prune(sessionId, lifecycle)
   }
 
   /** Drops the holders of a session that is gone, whoever evicted it. */
   forget(sessionId: string): void {
     this.clock.cancel(sessionId)
-    this.holders.forget(sessionId)
+    const lifecycle = this.sessions.get(sessionId)
+    if (!lifecycle) {
+      return
+    }
+    lifecycle.holders.forget(lifecycle.eviction !== undefined)
+    if (lifecycle.resume) {
+      lifecycle.resume.state.forgotten = true
+      lifecycle.resume = undefined
+    }
+    this.prune(sessionId, lifecycle)
   }
 
   isHeld(sessionId: string): boolean {
-    return this.holders.isHeld(sessionId)
+    const lifecycle = this.sessions.get(sessionId)
+    return lifecycle ? this.hasActiveHolder(lifecycle) : false
+  }
+
+  holderLease(sessionId: string, holderId: string): StructuredAgentSessionHolderLease | null {
+    const lifecycle = this.sessions.get(sessionId)
+    const registration = lifecycle?.holders.get(holderId)
+    if (!lifecycle || !registration?.active || lifecycle.eviction) {
+      return null
+    }
+    return {
+      isCurrent: () =>
+        !this.disposed &&
+        this.sessions.get(sessionId) === lifecycle &&
+        lifecycle.eviction === undefined &&
+        lifecycle.holders.isCurrent(holderId, registration)
+    }
   }
 
   isReleasePending(sessionId: string): boolean {
     return this.clock.isArmed(sessionId)
   }
 
+  evict(sessionId: string): Promise<void> {
+    if (this.disposed) {
+      return Promise.resolve()
+    }
+    const lifecycle = this.lifecycleFor(sessionId)
+    if (lifecycle.eviction) {
+      return lifecycle.eviction
+    }
+    lifecycle.evictionFailure = undefined
+    if (lifecycle.resume) {
+      lifecycle.resume.state.forgotten = true
+      lifecycle.resume = undefined
+    }
+    const attempt = Promise.resolve().then(() => this.deps.evict(sessionId))
+    lifecycle.eviction = attempt
+    void attempt.then(
+      () => this.clearEviction(sessionId, lifecycle, attempt),
+      (error) => {
+        lifecycle.evictionFailure = { error }
+        this.clearEviction(sessionId, lifecycle, attempt)
+      }
+    )
+    return attempt
+  }
+
   dispose(): void {
+    if (this.disposed) {
+      return
+    }
+    this.disposed = true
     this.clock.dispose()
+    for (const lifecycle of this.sessions.values()) {
+      if (lifecycle.resume) {
+        lifecycle.resume.state.forgotten = true
+      }
+      lifecycle.holders.clear()
+    }
+    this.sessions.clear()
+  }
+
+  private lifecycleFor(sessionId: string): StructuredAgentSessionLifecycle {
+    const existing = this.sessions.get(sessionId)
+    if (existing) {
+      return existing
+    }
+    const created: StructuredAgentSessionLifecycle = {
+      holders: new StructuredAgentSessionHolders()
+    }
+    this.sessions.set(sessionId, created)
+    return created
+  }
+
+  private resumeSession(
+    sessionId: string,
+    lifecycle: StructuredAgentSessionLifecycle
+  ): StructuredAgentSessionResume {
+    if (lifecycle.resume) {
+      return lifecycle.resume
+    }
+    const state: StructuredAgentSessionResume['state'] = { forgotten: false }
+    const attempt: StructuredAgentSessionResume = {
+      promise: Promise.resolve().then(async () => {
+        let hasProviderChild = false
+        try {
+          await this.deps.resume(sessionId, () => !state.forgotten)
+        } finally {
+          hasProviderChild = this.deps.hasProviderChild(sessionId)
+          if (!this.hasActiveHolder(lifecycle) && hasProviderChild) {
+            this.clock.arm(sessionId)
+          }
+        }
+        if (state.forgotten || !hasProviderChild) {
+          state.failure ??= new Error('agent_session_ownership_unknown')
+          throw state.failure
+        }
+      }),
+      state
+    }
+    lifecycle.resume = attempt
+    void attempt.promise.then(
+      () => this.clearResume(sessionId, lifecycle, attempt),
+      () => this.clearResume(sessionId, lifecycle, attempt)
+    )
+    return attempt
+  }
+
+  private clearResume(
+    sessionId: string,
+    lifecycle: StructuredAgentSessionLifecycle,
+    attempt: StructuredAgentSessionResume
+  ): void {
+    if (lifecycle.resume === attempt) {
+      lifecycle.resume = undefined
+    }
+    this.prune(sessionId, lifecycle)
+  }
+
+  private clearEviction(
+    sessionId: string,
+    lifecycle: StructuredAgentSessionLifecycle,
+    attempt: Promise<void>
+  ): void {
+    if (lifecycle.eviction === attempt) {
+      lifecycle.eviction = undefined
+    }
+    this.prune(sessionId, lifecycle)
+  }
+
+  private addHolder(
+    lifecycle: StructuredAgentSessionLifecycle,
+    holderId: string,
+    active: boolean
+  ): { alreadyHeld: boolean; registration: StructuredAgentSessionHolderRegistration } {
+    return lifecycle.holders.add(holderId, active)
+  }
+
+  private isCurrentHolder(
+    sessionId: string,
+    lifecycle: StructuredAgentSessionLifecycle,
+    holderId: string,
+    registration: StructuredAgentSessionHolderRegistration
+  ): boolean {
+    return (
+      this.sessions.get(sessionId) === lifecycle &&
+      lifecycle.holders.isCurrent(holderId, registration)
+    )
+  }
+
+  /** Removes one holder and reports whether the session lost its last holder. */
+  private removeHolder(lifecycle: StructuredAgentSessionLifecycle, holderId: string): boolean {
+    return lifecycle.holders.remove(holderId)
+  }
+
+  private hasActiveHolder(lifecycle: StructuredAgentSessionLifecycle): boolean {
+    return lifecycle.holders.hasActive()
+  }
+
+  private prune(sessionId: string, lifecycle: StructuredAgentSessionLifecycle): void {
+    if (
+      this.sessions.get(sessionId) === lifecycle &&
+      lifecycle.holders.size === 0 &&
+      lifecycle.resume === undefined &&
+      lifecycle.eviction === undefined &&
+      lifecycle.evictionFailure === undefined
+    ) {
+      this.sessions.delete(sessionId)
+    }
   }
 }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host-lifetime.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host-lifetime.ts
@@ -67,7 +67,7 @@ export async function evictHeldStructuredAgentSession(
 export function createStructuredAgentSessionHolds(
   context: StructuredAgentSessionLifetimeContext,
   input: {
-    resume: (sessionId: string) => Promise<void>
+    resume: (sessionId: string, isCurrent: () => boolean) => Promise<void>
     evict: (sessionId: string) => Promise<void>
   }
 ): StructuredAgentSessionHolds {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -94,8 +94,8 @@ export class StructuredAgentSessionHost {
       now: this.now
     })
     this.holds = createStructuredAgentSessionHolds(this.lifetimeContext(), {
-      resume: (sessionId) => this.resumeForHold(sessionId),
-      evict: (sessionId) => this.close(sessionId)
+      resume: (sessionId, isCurrent) => this.resumeForHold(sessionId, isCurrent),
+      evict: (sessionId) => this.closeSession(sessionId)
     })
     this.readableRestorer = new StructuredAgentSessionReadableRestorer({
       store: deps.store,
@@ -128,12 +128,18 @@ export class StructuredAgentSessionHost {
 
   isHeld = (sessionId: string): boolean => this.holds.isHeld(sessionId)
 
-  private async resumeForHold(sessionId: string): Promise<void> {
+  private async resumeForHold(sessionId: string, isCurrent: () => boolean): Promise<void> {
     const unreconciled = await this.reconcileLeases(sessionId)
     if (unreconciled) {
       throw new Error(unreconciled.code)
     }
+    if (!isCurrent()) {
+      throw new Error('agent_session_ownership_unknown')
+    }
     await this.runtimeState.resolveRecovery(sessionId)
+    if (!isCurrent()) {
+      throw new Error('agent_session_ownership_unknown')
+    }
     await resumeHeldStructuredAgentSession({
       sessionId,
       deps: this.deps,
@@ -168,9 +174,14 @@ export class StructuredAgentSessionHost {
   /** Releases a session's resources without ending the conversation: the record and journal stay
    *  on disk, so the same session can be attached again. */
   close(sessionId: string): Promise<void> {
+    return this.holds.evict(sessionId)
+  }
+
+  private closeSession(sessionId: string): Promise<void> {
     return this.serialize(sessionId, async () => {
       await this.handoffs.closeRetainedTuiOwner(sessionId)
       await evictHeldStructuredAgentSession(this.lifetimeContext(), sessionId)
+      this.subscribers.closeSession(sessionId)
       // Whoever asked for the close, the surfaces that were holding this session are looking at a
       // session that no longer exists. A failed eviction throws above and keeps them.
       this.holds.forget(sessionId)
@@ -201,6 +212,15 @@ export class StructuredAgentSessionHost {
 
   restoreReadableSessions = (sessionIds?: readonly string[]): Promise<void> =>
     this.restartRestore.run(() => this.readableRestorer.restore(sessionIds))
+
+  ensureReadableSession = async (
+    sessionId: string,
+    isCurrent?: (sessionId: string) => boolean
+  ): Promise<void> => {
+    if (!this.sessions.has(sessionId)) {
+      await this.readableRestorer.restoreMissing([sessionId], isCurrent)
+    }
+  }
 
   private serialize = <T>(sessionId: string, task: () => Promise<T>): Promise<T> =>
     this.tasks.serialize(sessionId, task)
@@ -292,6 +312,20 @@ export class StructuredAgentSessionHost {
       journal: session.journal,
       fence,
       handoff: this.handoffs.status(input.sessionId)
+    })
+  }
+
+  async subscribeHeld(input: AgentSessionSubscribeInput, holderId: string): Promise<() => void> {
+    const holderLease = this.holds.holderLease(input.sessionId, holderId)
+    if (!holderLease) {
+      throw new Error('agent_session_ownership_unknown')
+    }
+    await this.ensureReadableSession(input.sessionId, () => holderLease.isCurrent())
+    return this.serialize(input.sessionId, async () => {
+      if (!holderLease.isCurrent()) {
+        throw new Error('agent_session_ownership_unknown')
+      }
+      return this.subscribe(input)
     })
   }
 

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-readable-restorer.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-readable-restorer.ts
@@ -29,7 +29,14 @@ export class StructuredAgentSessionReadableRestorer {
     return this.restorePromise
   }
 
-  private async restoreReadableSessions(sessionIds?: readonly string[]): Promise<void> {
+  restoreMissing(sessionIds: readonly string[], isCurrent?: (sessionId: string) => boolean) {
+    return this.restoreReadableSessions(sessionIds, isCurrent)
+  }
+
+  private async restoreReadableSessions(
+    sessionIds?: readonly string[],
+    isCurrent?: (sessionId: string) => boolean
+  ): Promise<void> {
     const targetOrder = sessionIds
       ? new Map(sessionIds.map((sessionId, index) => [sessionId, index]))
       : null
@@ -46,7 +53,8 @@ export class StructuredAgentSessionReadableRestorer {
     }
     await restoreStructuredAgentSessionsOnRestart({
       ...this.input,
-      records
+      records,
+      ...(isCurrent ? { isCurrent } : {})
     })
   }
 }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-release-clock.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-release-clock.ts
@@ -25,12 +25,16 @@ export type StructuredAgentSessionReleaseClockDeps = {
 export class StructuredAgentSessionReleaseClock {
   private readonly timers = new Map<string, ReturnType<typeof setTimeout>>()
   private readonly graceMs: number
+  private disposed = false
 
   constructor(private readonly deps: StructuredAgentSessionReleaseClockDeps) {
     this.graceMs = deps.graceMs ?? STRUCTURED_AGENT_SESSION_RELEASE_GRACE_MS
   }
 
   arm(sessionId: string): void {
+    if (this.disposed) {
+      return
+    }
     this.cancel(sessionId)
     const timer = setTimeout(() => {
       this.timers.delete(sessionId)
@@ -54,6 +58,7 @@ export class StructuredAgentSessionReleaseClock {
   }
 
   dispose(): void {
+    this.disposed = true
     for (const timer of this.timers.values()) {
       clearTimeout(timer)
     }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-restart-restore.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-restart-restore.test.ts
@@ -56,4 +56,35 @@ describe('restart journal restoration', () => {
     expect(restoreRead).toHaveBeenCalledTimes(records.length)
     expect(peak).toBe(4)
   })
+
+  it('does not publish a readable session cancelled while its journal opens', async () => {
+    const restoreEntered = Promise.withResolvers<void>()
+    const restoreGate = Promise.withResolvers<void>()
+    let current = true
+    const onReadable = vi.fn()
+    restoreRead.mockImplementationOnce(async () => {
+      restoreEntered.resolve()
+      await restoreGate.promise
+      return { journal: {}, params: {}, fence: 1, hasProviderChild: false }
+    })
+
+    const restoration = restoreStructuredAgentSessionsOnRestart({
+      store: {} as never,
+      journalRoot: '/tmp/journals',
+      records: [{ sessionId: 'session-1' } as AgentSessionRecord],
+      reconcile: async () => null,
+      resolveRecovery: async () => undefined,
+      serialize: async (_sessionId, task) => task(),
+      hasSession: () => false,
+      onReadable,
+      restoreHandoff: async () => undefined,
+      isCurrent: () => current
+    })
+    await restoreEntered.promise
+    current = false
+    restoreGate.resolve()
+
+    await restoration
+    expect(onReadable).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-restart-restore.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-restart-restore.ts
@@ -32,6 +32,7 @@ export async function restoreStructuredAgentSessionsOnRestart(input: {
   hasSession: (sessionId: string) => boolean
   onReadable: (sessionId: string, restored: RestoredStructuredAgentSessionRead) => void
   restoreHandoff: (sessionId: string) => Promise<void>
+  isCurrent?: (sessionId: string) => boolean
 }): Promise<void> {
   await mapWithConcurrency(input.records, JOURNAL_RESTORE_CONCURRENCY, async ({ sessionId }) => {
     const unreconciled = await input.reconcile(sessionId)
@@ -40,6 +41,9 @@ export async function restoreStructuredAgentSessionsOnRestart(input: {
       await input.resolveRecovery(sessionId)
     }
     await input.serialize(sessionId, async () => {
+      if (input.isCurrent && !input.isCurrent(sessionId)) {
+        return
+      }
       if (input.hasSession(sessionId)) {
         // A surface that took a hold mid-restore already attached this one.
         await input.restoreHandoff(sessionId)
@@ -50,7 +54,7 @@ export async function restoreStructuredAgentSessionsOnRestart(input: {
         input.journalRoot,
         sessionId
       )
-      if (!restored) {
+      if (!restored || (input.isCurrent && !input.isCurrent(sessionId))) {
         return
       }
       input.onReadable(sessionId, restored)

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-subscribers.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-subscribers.ts
@@ -91,6 +91,12 @@ export class AgentSessionSubscribers {
     }
   }
 
+  closeSession(sessionId: string): void {
+    for (const subscriber of this.subscribers(sessionId)) {
+      this.close(sessionId, subscriber.id)
+    }
+  }
+
   /** Fan out whatever each subscriber has not yet seen. */
   publish(sessionId: string, journal: AgentSessionJournal): void {
     for (const subscriber of this.subscribers(sessionId)) {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-surface-lifetime.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-surface-lifetime.test.ts
@@ -169,6 +169,32 @@ describe('a chat that closes', () => {
     expect(closeSession).not.toHaveBeenCalled()
     expect(host.hasSession(SESSION)).toBe(true)
   })
+
+  it('reopens a surface that arrives while the released child is stopping', async () => {
+    await attach()
+    await host.hold(SESSION, SURFACE)
+    acquire.mockClear()
+    const closeEntered = Promise.withResolvers<void>()
+    const closeGate = Promise.withResolvers<void>()
+    closeSession.mockImplementationOnce(async () => {
+      closeEntered.resolve()
+      await closeGate.promise
+      return true
+    })
+
+    host.release(SESSION, SURFACE)
+    await closeEntered.promise
+    const replacement = host.hold(SESSION, 'paired-phone:1')
+    await Promise.resolve()
+
+    expect(host.isHeld(SESSION)).toBe(false)
+    expect(acquire).not.toHaveBeenCalled()
+    closeGate.resolve()
+    await expect(replacement).resolves.toBeUndefined()
+    expect(acquire).toHaveBeenCalledOnce()
+    expect(host.isHeld(SESSION)).toBe(true)
+    expect(host.hasSession(SESSION)).toBe(true)
+  })
 })
 
 describe('a session with a turn in flight', () => {
@@ -220,6 +246,31 @@ describe('startup', () => {
       runtimeKind: 'native',
       ownerProcess: { pid: 4242 }
     })
+  })
+
+  it('gives concurrent surfaces one shared provider resume', async () => {
+    await attach()
+    await reboot()
+    await host.restoreReadableSessions()
+    const entered = Promise.withResolvers<void>()
+    const acquireGate = Promise.withResolvers<void>()
+    const runAcquire = acquire.getMockImplementation()!
+    acquire.mockImplementation(async (input) => {
+      entered.resolve()
+      await acquireGate.promise
+      return runAcquire(input)
+    })
+
+    const desktop = host.hold(SESSION, SURFACE)
+    await entered.promise
+    const paired = host.hold(SESSION, 'paired-phone:1')
+    await Promise.resolve()
+
+    expect(acquire).toHaveBeenCalledOnce()
+    acquireGate.resolve()
+    await expect(Promise.all([desktop, paired])).resolves.toEqual([undefined, undefined])
+    expect(acquire).toHaveBeenCalledOnce()
+    expect(store.getRecord(SESSION)?.lease.claimStatus).toBe('live')
   })
 })
 

--- a/src/main/runtime/rpc/methods/structured-agent-session-hold.test.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session-hold.test.ts
@@ -213,6 +213,124 @@ describe('a client that disappears without cleanup', () => {
     expect(closeSession).toHaveBeenCalledWith(SESSION)
   })
 
+  it('does not open a subscription aborted while session eviction is running', async () => {
+    const closeEntered = Promise.withResolvers<void>()
+    const closeGate = Promise.withResolvers<void>()
+    closeSession.mockImplementationOnce(async () => {
+      closeEntered.resolve()
+      await closeGate.promise
+      return true
+    })
+    const closing = host.close(SESSION)
+    await closeEntered.promise
+    const subscribe = vi.spyOn(host, 'subscribe')
+    const transport = new AbortController()
+    const dispatching = dispatcher.dispatchStreaming(
+      {
+        id: 'aborted-during-eviction',
+        authToken: 'token',
+        method: 'agentSession.subscribe',
+        params: { sessionId: SESSION }
+      },
+      () => {},
+      {
+        signal: transport.signal,
+        clientId: 'paired-client',
+        clientKind: 'runtime',
+        clientCapabilities: CLIENT.clientCapabilities,
+        connectionId: CONNECTION
+      }
+    )
+    await Promise.resolve()
+    transport.abort()
+    closeGate.resolve()
+
+    await closing
+    await dispatching
+    expect(subscribe).not.toHaveBeenCalled()
+    expect(host.isHeld(SESSION)).toBe(false)
+  })
+
+  it('does not open a subscription when close starts after its retain settles', async () => {
+    const closeEntered = Promise.withResolvers<void>()
+    const closeGate = Promise.withResolvers<void>()
+    closeSession.mockImplementationOnce(async () => {
+      closeEntered.resolve()
+      await closeGate.promise
+      return true
+    })
+    const readableEntered = Promise.withResolvers<void>()
+    const readableGate = Promise.withResolvers<void>()
+    const ensureReadable = host.ensureReadableSession
+    vi.spyOn(host, 'ensureReadableSession').mockImplementationOnce(async (sessionId, isCurrent) => {
+      readableEntered.resolve()
+      await readableGate.promise
+      await ensureReadable(sessionId, isCurrent)
+    })
+    const subscribe = vi.spyOn(host, 'subscribe')
+    const replies: RpcResponse[] = []
+    const dispatching = dispatcher.dispatchStreaming(
+      {
+        id: 'close-after-retain',
+        authToken: 'token',
+        method: 'agentSession.subscribe',
+        params: { sessionId: SESSION }
+      },
+      (raw) => replies.push(JSON.parse(raw) as RpcResponse),
+      CLIENT
+    )
+    await readableEntered.promise
+
+    const closing = host.close(SESSION)
+    await closeEntered.promise
+    readableGate.resolve()
+    closeGate.resolve()
+
+    await closing
+    await dispatching
+    expect(subscribe).not.toHaveBeenCalled()
+    expect(host.isHeld(SESSION)).toBe(false)
+    expect(host.hasSession(SESSION)).toBe(false)
+    expect(replies).toHaveLength(1)
+    expect(replies[0]).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining('agent_session_ownership_unknown') }
+    })
+  })
+
+  it('opens a readable subscription only after overlapping eviction settles', async () => {
+    const closeEntered = Promise.withResolvers<void>()
+    const closeGate = Promise.withResolvers<void>()
+    closeSession.mockImplementationOnce(async () => {
+      closeEntered.resolve()
+      await closeGate.promise
+      return true
+    })
+    const closing = host.close(SESSION)
+    await closeEntered.promise
+    const subscribe = vi.spyOn(host, 'subscribe')
+    const dispatching = dispatcher.dispatchStreaming(
+      {
+        id: 'retained-after-eviction',
+        authToken: 'token',
+        method: 'agentSession.subscribe',
+        params: { sessionId: SESSION }
+      },
+      () => {},
+      CLIENT
+    )
+    await Promise.resolve()
+    expect(subscribe).not.toHaveBeenCalled()
+    closeGate.resolve()
+
+    await closing
+    await dispatching
+    expect(subscribe).toHaveBeenCalledOnce()
+    expect(host.isHeld(SESSION)).toBe(true)
+    expect(host.hasSession(SESSION)).toBe(true)
+    expect(store.getRecord(SESSION)?.lease.claimStatus).toBe('released')
+  })
+
   it('does not let a stream alone resume a released session', async () => {
     await host.close(SESSION)
     expect(host.hasSession(SESSION)).toBe(false)

--- a/src/main/runtime/rpc/methods/structured-agent-session.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.ts
@@ -210,24 +210,31 @@ export const STRUCTURED_AGENT_SESSION_METHODS: RpcAnyMethod[] = [
       if (closed) {
         return
       }
-      // The host emits the opening snapshot (or the missed batch) synchronously
-      // inside open(), so nothing between here and there can interleave.
-      dispose = host.subscribe({
-        id: subscriptionId,
-        sessionId: params.sessionId,
-        emit,
-        ...(params.cursor ? { cursor: params.cursor } : {})
-      })
-      if (closed) {
-        dispose()
-      } else {
-        // Fire-and-forget, but never unhandled: a resume that refuses leaves the stream holding a
-        // readable session, which is exactly what the client sees anyway.
-        void host
-          .hold(params.sessionId, streamHolder, { resume: false })
-          .catch((error: unknown) =>
-            console.warn('[agent-session] stream hold failed', params.sessionId, error)
-          )
+      try {
+        await host.hold(params.sessionId, streamHolder, { resume: false })
+        if (closed) {
+          return
+        }
+        // The host emits the opening snapshot (or the missed batch) synchronously
+        // inside open(), so nothing between here and there can interleave.
+        dispose = await host.subscribeHeld(
+          {
+            id: subscriptionId,
+            sessionId: params.sessionId,
+            emit,
+            ...(params.cursor ? { cursor: params.cursor } : {})
+          },
+          streamHolder
+        )
+        if (closed) {
+          dispose()
+        }
+      } catch (error) {
+        const transportClosed = closed
+        releaseTransportSubscription()
+        if (!transportClosed) {
+          throw error
+        }
       }
     }
   }),

--- a/src/main/runtime/structured-agent-session-runtime.test.ts
+++ b/src/main/runtime/structured-agent-session-runtime.test.ts
@@ -2,6 +2,12 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  HOST_TEST_NOW,
+  HOST_TEST_SESSION,
+  HOST_TEST_THREAD,
+  hostTestAttachParams
+} from '../native-chat/agent-session-wire/structured-agent-session-host-test-data'
 import type {
   AgentSessionClaimStatus,
   AgentSessionProcessIdentity,
@@ -261,5 +267,76 @@ describe('structured agent-session runtime install', () => {
         failure
       )
     )
+  })
+
+  it('closes a child whose resume attach was already admitted when shutdown began', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(HOST_TEST_NOW)
+    stateDirectory = await mkdtemp(join(tmpdir(), 'orca-structured-runtime-'))
+    const secondOpenEntered = Promise.withResolvers<void>()
+    const secondOpenGate = Promise.withResolvers<void>()
+    const connections: { closed: boolean }[] = []
+    let openCount = 0
+    const host = await ensureStructuredAgentSessionHost({
+      stateDirectory,
+      hostId: HOST_ID,
+      claimKeyId: 'key-1',
+      resolveWorkspacePath: async () => stateDirectory!,
+      resolveEnvironment: async () => ({}),
+      resolveCodexCommand: () => '/usr/local/bin/codex',
+      readProcessStartTime: async () => 1_700_000_000_000,
+      openCodexConnection: async (_launch, handlers = {}) => {
+        openCount += 1
+        if (openCount === 2) {
+          secondOpenEntered.resolve()
+          await secondOpenGate.promise
+        }
+        const connection = {
+          pid: 4242,
+          closed: false,
+          request: async (method: string) =>
+            method === 'thread/start' || method === 'thread/resume'
+              ? { thread: { id: HOST_TEST_THREAD } }
+              : method === 'model/list'
+                ? {
+                    data: [
+                      {
+                        model: 'gpt-test',
+                        displayName: 'GPT Test',
+                        hidden: false,
+                        supportedReasoningEfforts: [],
+                        isDefault: true
+                      }
+                    ],
+                    nextCursor: null
+                  }
+                : {},
+          notify: () => {},
+          respond: () => {},
+          respondWithError: () => {},
+          close: async () => {
+            connection.closed = true
+            return true
+          },
+          ...handlers
+        }
+        connections.push(connection)
+        return connection as never
+      }
+    })
+    await expect(
+      host.attach({ callerKey: 'runtime-shutdown-test' }, hostTestAttachParams(null))
+    ).resolves.toMatchObject({ ok: true })
+    await host.close(HOST_TEST_SESSION)
+
+    const holding = host.hold(HOST_TEST_SESSION, 'desktop-chat:shutdown-race')
+    await secondOpenEntered.promise
+    const stopping = stopStructuredAgentSessionRuntime()
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    secondOpenGate.resolve()
+
+    await expect(holding).rejects.toThrow()
+    await stopping
+    expect(connections).toHaveLength(2)
+    expect(connections[1]?.closed).toBe(true)
   })
 })

--- a/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
@@ -95,7 +95,7 @@ const STRUCTURED_CALLS: {
   },
   // A subscription that opens with nothing to say answers with no reply at all,
   // so reaching the host is the only signal that the gate opened.
-  { method: 'agentSession.subscribe', hostMethod: 'subscribe' },
+  { method: 'agentSession.subscribe', hostMethod: 'subscribeHeld' },
   // Teardown runs through the runtime's subscription registry rather than the
   // host, so its reply is the only signal that the gate opened.
   { method: 'agentSession.unsubscribe', hostMethod: null, result: { unsubscribed: true } }
@@ -297,6 +297,7 @@ function structuredHostStub(): Record<string, ReturnType<typeof vi.fn>> {
     readOptions: vi.fn(async () => ({ models: [], current: { model: 'gpt-live' } })),
     history: vi.fn(() => ({ ok: true, page: { items: [] } })),
     subscribe: vi.fn(() => () => undefined),
+    subscribeHeld: vi.fn(async () => () => undefined),
     unsubscribe: vi.fn()
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​954 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​36 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​918 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​429 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​82 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​347 |

<!-- /orca-pr-loc -->

## Summary

- single-flight structured provider resume at the per-host, per-session lifecycle boundary
- keep holder registration, in-flight resume, eviction, failure, cancellation, and disposal state in one lifecycle record
- fence readable restoration with generation-scoped leases so close/replacement cannot republish stale state
- make provider close completion identity-safe so a timed-out stale close cannot delete a replacement session
- add deterministic concurrency and cleanup coverage for resume, eviction, restoration, shutdown, retry, and stale-close races

## Reproduction evidence

The deferred-promise oracle is red on exact origin/main b8d5b0486e: two concurrent holds enter provider resume twice before the first activation publishes its child. The real host/store oracle also rejects one concurrent surface with agent_session_ownership_unknown.

On this branch both oracles are green. With the single-flight guard deliberately disabled, both turn red again, proving the tests exercise the repaired behavior rather than merely passing.

A fresh deferred-close oracle also reproduced the review-found edge case: a close that times out can finish after a replacement is published. The amended close boundary now deletes only the exact session object it closed, leaving the replacement intact.

## Semantics

- concurrent callers share the same promise and error identity
- settled resume failures clear for a fresh retry
- eviction overlaps are ordered; failed eviction remains explicit and is retried before later demand
- undefined rejection values remain distinguishable from no cached failure
- disposal and holder replacement invalidate stale work without deadlock or stale publication
- retain-only subscriptions do not initiate resume but can retain an already-authorized child
- late close completion cannot remove a newer session with the same ID

No RPC, schema, opcode, payload, process, path, dependency, or platform-specific behavior changes.

## Validation

- focused lifecycle + adapter regression: 6 files, 95 tests
- full structured host package: 35 files, 228 tests
- mixed-version structured wire fixture: 11 tests
- full pnpm tc
- changed-code quality: 0 findings
- reliability manifest: 99 gates
- Electron production build
- git diff --check

Three Electron E2E attempts (candidate twice, exact main once) stopped at the same pre-feature fixture setup: live-background-terminal-mount-authority.spec.ts:604 observed an empty fake-Codex spawn ledger. The failure occurs before mount-authority assertions and before changed structured-session code, so it is recorded as a current-main/environment blocker rather than a candidate regression.

Three independent lifecycle/compatibility/exact-hash reviews were reconciled. One valid timeout/retry stale-close finding was reproduced and fixed at the provider session-map ownership boundary; the remaining reviews found no blocker. Linux/Windows/WSL/SSH behavior is contract-covered rather than runtime-executed; the implementation is host-local TypeScript and the mixed-version wire fixture remains green.
