### PR TITLE
fix(agents): launch Droid at High autonomy in yolo mode

### DIFF
--- a/src/shared/tui-agent-launch-defaults.test.ts
+++ b/src/shared/tui-agent-launch-defaults.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { getTuiAgentDefaultArgs, resolveTuiAgentLaunchArgs } from './tui-agent-launch-defaults'
+
+describe('tui agent launch defaults', () => {
+  it('launches Droid at High autonomy by default', () => {
+    // Why: interactive `droid` ignores unknown options, so a wrong flag would fail silently; pin the exact args.
+    expect(getTuiAgentDefaultArgs('droid')).toBe('--auto high')
+  })
+
+  it('falls back to the Droid autonomy default when a profile has no Droid entry', () => {
+    expect(resolveTuiAgentLaunchArgs('droid', { claude: '--dangerously-skip-permissions' })).toBe(
+      '--auto high'
+    )
+  })
+
+  it('honors an explicit empty Droid entry as a manual launch', () => {
+    expect(resolveTuiAgentLaunchArgs('droid', { droid: '' })).toBe('')
+  })
+})

--- a/src/shared/tui-agent-permissions.test.ts
+++ b/src/shared/tui-agent-permissions.test.ts
@@ -76,6 +76,48 @@ describe('tui agent permissions', () => {
     ).toBe('mixed')
   })
 
+  it('resolves one Droid yolo launch as yolo', () => {
+    expect(
+      resolveTuiAgentPermissionMode({
+        agent: 'droid',
+        agentArgs: YOLO_TUI_AGENT_ARGS.droid,
+        agentEnv: {}
+      })
+    ).toBe('yolo')
+  })
+
+  it('resolves one empty Droid launch as manual', () => {
+    expect(resolveTuiAgentPermissionMode({ agent: 'droid', agentArgs: '', agentEnv: {} })).toBe(
+      'manual'
+    )
+  })
+
+  it('resolves a lower Droid autonomy level as mixed', () => {
+    expect(
+      resolveTuiAgentPermissionMode({ agent: 'droid', agentArgs: '--auto medium', agentEnv: {} })
+    ).toBe('mixed')
+  })
+
+  it('clears the Droid autonomy flag when applying manual mode', () => {
+    const result = applyAgentPermissionMode({
+      mode: 'manual',
+      agentDefaultArgs: YOLO_TUI_AGENT_ARGS,
+      agentDefaultEnv: YOLO_TUI_AGENT_ENV
+    })
+
+    expect(result.agentDefaultArgs.droid).toBe('')
+  })
+
+  it('restores the Droid autonomy flag when applying yolo mode to an untouched profile', () => {
+    const result = applyAgentPermissionMode({
+      mode: 'yolo',
+      agentDefaultArgs: { droid: '' },
+      agentDefaultEnv: {}
+    })
+
+    expect(result.agentDefaultArgs.droid).toBe('--auto high')
+  })
+
   it('resolves env-driven yolo launches', () => {
     expect(
       resolveTuiAgentPermissionMode({

--- a/src/shared/tui-agent-permissions.ts
+++ b/src/shared/tui-agent-permissions.ts
@@ -19,6 +19,9 @@ export const YOLO_TUI_AGENT_ARGS: Partial<Record<TuiAgent, string>> = {
   'command-code': '--yolo',
   continue: '--allow "*"',
   cursor: '--yolo',
+  // Why: interactive `droid` exposes autonomy as `--auto <low|medium|high>`; `--skip-permissions-unsafe`
+  // is a `droid exec`-only flag that Factory scopes to isolated sandboxes, so High autonomy is the yolo analogue.
+  droid: '--auto high',
   kimi: '--yolo',
   'mistral-vibe': '--agent auto-approve',
   'qwen-code': '--approval-mode yolo',


### PR DESCRIPTION
## ELI5

Orca has a "Yolo" switch that tells every coding agent "don't stop and ask me before each edit or command". Droid was the one agent the switch forgot about, so Droid kept asking. This teaches Orca the Droid spelling of that switch: `--auto high`.

## What Changed

- `src/shared/tui-agent-permissions.ts`: add `droid: '--auto high'` to `YOLO_TUI_AGENT_ARGS`. Because `DEFAULT_TUI_AGENT_ARGS` and `PERMISSION_AGENT_IDS` derive from this map, Droid now gets the flag on launch and the Yolo/Manual toggle in Settings → Agents covers it.
- `src/shared/tui-agent-permissions.test.ts`: Droid yolo / manual / mixed resolution, and `applyAgentPermissionMode` clearing and restoring the Droid flag.
- `src/shared/tui-agent-launch-defaults.test.ts` (new): pins the exact default args (`--auto high`), the fallback for a profile without a `droid` key, and an explicit empty entry meaning manual. Interactive `droid` ignores unknown options, so a wrong flag would fail silently — hence the pin.

## Why

Droid is in `TUI_AGENT_CONFIG` but was missing from `YOLO_TUI_AGENT_ARGS`, so Orca launched a bare `droid` that fell back to Factory's default autonomy (Off) and prompted for every edit and command.

`--auto <level>` is the autonomy flag on the interactive `droid` command (`droid --help`; https://docs.factory.ai/autonomy-and-safety/auto-run). `high` runs everything without asking except Droid's built-in blocklist, which is the interactive counterpart of the other Yolo entries. `--skip-permissions-unsafe` is `droid exec`-only, cannot be combined with `--auto`, and Factory scopes it to disposable containers, so it is not the right default for a desktop launch. Tier overview: https://github.com/github/awesome-copilot/blob/main/agents/droid.agent.md

## Linked Issue

Fixes #17502

## Visual Proof

N/A — no new UI. The only visible change is that the Droid row in Settings → Agents now lists `--auto high` as its default args, rendered by the existing per-agent row like every other agent. Launch behavior: before `droid '<prompt>'`, after `droid --auto high '<prompt>'` (pinned by the new tests).

## Testing

- `vitest run` on `src/shared`, `src/main/persistence`, `src/renderer/src/components/{settings,onboarding}` and the agent-startup suites: 2114 passed, 1 skipped (macOS).
- `pnpm typecheck`: pass. `oxlint` + `oxfmt --check` on the changed files: clean.
- `droid --auto high --version` on droid 0.208.1 accepts the flag; `--skip-permissions-unsafe` is absent from the interactive `--help`.
- Not yet done: an end-to-end run inside a packaged Orca build. Linux / Windows / SSH not exercised — the change is a pure arg-table entry and goes through the same launch path as the other agents.

- [ ] I manually tested these changes locally (CLI flag verified; no full Orca app run yet)
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Fable 5), reviewed and directed by a human.

## Review

Self-review: cross-platform — string-only arg entry, no path or shell handling; SSH/remote — same `resolveTuiAgentLaunchArgs` path used for local and remote launches; agents — only Droid is touched, other entries unchanged; performance — none; security — raises Droid autonomy to High only under the Yolo profile, which is already the documented meaning of that setting; Droid's blocklist/denylist checks remain active. Note for maintainers: a profile that was migrated before this change has no `droid` key, so it falls back to the new default; Manual-mode users would need to re-apply Manual once (same as when any agent is added to the map). Happy to send a backfill follow-up if you want that handled in `migrateAgentYoloDefaults`.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No impact on Security beyond the Yolo semantics above, Cross-platform, Remote SSH, Mobile (mobile consumes the same shared map via `resolveTuiAgentLaunchArgs`), backwards compatibility, or performance.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (typecheck + targeted vitest + oxlint/oxfmt on changed files pass locally; full lint/test/build left to CI)
