### PR TITLE
fix(daemon): sweep hand-typed agent descendants on teardown

### DIFF
--- a/src/main/daemon/agent-teardown-evidence.ts
+++ b/src/main/daemon/agent-teardown-evidence.ts
@@ -1,0 +1,12 @@
+import { recognizeAgentProcess } from '../../shared/agent-process-recognition'
+import type { TuiAgent } from '../../shared/tui-agent'
+
+/** Teardown must sweep descendants: agent-launched, or a recognized agent live in the
+ * foreground — a hand-typed `claude` (bare, or under a wrapper the foreground tracker
+ * resolved) leaks the same detached MCP children as a launched one. */
+export function hasAgentTeardownEvidence(
+  launchAgent: TuiAgent | null | undefined,
+  subprocess: { getForegroundProcess(): string | null }
+): boolean {
+  return Boolean(launchAgent) || recognizeAgentProcess(subprocess.getForegroundProcess()) !== null
+}

--- a/src/main/daemon/session-termination-controller.ts
+++ b/src/main/daemon/session-termination-controller.ts
@@ -1,5 +1,6 @@
 import { killWithDescendantSweep } from '../pty-descendant-termination'
 import { PhysicalExitTracker } from '../../shared/physical-exit-tracker'
+import { hasAgentTeardownEvidence } from './agent-teardown-evidence'
 import type { SubprocessHandle } from './session-subprocess-handle'
 import type { TuiAgent } from '../../shared/tui-agent'
 
@@ -55,7 +56,7 @@ export class SessionTerminationController {
     if (!this.beginTermination()) {
       return
     }
-    if (!this.deps.launchAgent) {
+    if (!hasAgentTeardownEvidence(this.deps.launchAgent, this.deps.subprocess)) {
       this.signalTerminationRoot()
     } else {
       // Why: agent tool children live in detached process groups a dying shell's SIGHUP never reaches, so sweep them.

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -712,6 +712,27 @@ describe('Session', () => {
       expect(killWithDescendantSweepMock).not.toHaveBeenCalled()
     })
 
+    it('shell-foreground kill stays on the plain path', () => {
+      createSession()
+      subprocess.foregroundProcess = 'zsh'
+      session.kill()
+      expect(subprocess.killed).toBe(true)
+      expect(killWithDescendantSweepMock).not.toHaveBeenCalled()
+    })
+
+    it('recognized agent foreground kill routes through the descendant sweep without launchAgent', () => {
+      // Why: a hand-typed `claude` leaks its detached MCP children if teardown trusts launchAgent alone.
+      createSession()
+      subprocess.foregroundProcess = 'claude'
+      session.kill()
+      expect(killWithDescendantSweepMock).toHaveBeenCalledWith(
+        subprocess.pid,
+        expect.any(Function),
+        expect.objectContaining({ ownsRoot: expect.any(Function) })
+      )
+      expect(subprocess.killed).toBe(false)
+    })
+
     it('agent kill routes through the descendant sweep with the subprocess as root', () => {
       createSession({ launchAgent: 'claude' })
       session.kill()

--- a/src/main/daemon/terminal-session-teardown.test.ts
+++ b/src/main/daemon/terminal-session-teardown.test.ts
@@ -10,6 +10,7 @@ vi.mock('../pty-descendant-termination', () => ({
 function createPlainShellSession(overrides: Partial<Session> = {}): Session {
   return {
     launchAgent: undefined,
+    getForegroundProcess: () => null,
     pid: 4242,
     isAlive: true,
     forceKillAndWaitForExit: vi.fn(async () => {}),
@@ -119,6 +120,31 @@ describe('TerminalSessionTeardown plain-shell teardown', () => {
     expect(session.forceKillAndWaitForExit).not.toHaveBeenCalled()
     expect(session.kill).toHaveBeenCalled()
   })
+
+  it.each([
+    ['graceful', false],
+    ['immediate', true]
+  ])(
+    'hand-typed agent foreground routes %s kill through the agent sweep despite no launchAgent',
+    async (_case, immediate) => {
+      // Why: a `claude` the user typed into a plain shell has launchAgent unset, but its
+      // detached MCP children still outlive a root-only kill (the reported leak).
+      setPlatform('linux')
+      const session = createPlainShellSession({
+        getForegroundProcess: () => 'claude'
+      } as Partial<Session>)
+      const teardown = new TerminalSessionTeardown(new Map([['s1', session]]))
+
+      await teardown.killSession('s1', session, immediate)
+
+      expect(killWithDescendantSweepMock).toHaveBeenCalledWith(
+        4242,
+        expect.any(Function),
+        expect.objectContaining({ ownsRoot: expect.any(Function) })
+      )
+      expect(session.kill).not.toHaveBeenCalled()
+    }
+  )
 })
 
 describe('pty job ownership reaches the daemon teardown path', () => {

--- a/src/main/daemon/terminal-session-teardown.ts
+++ b/src/main/daemon/terminal-session-teardown.ts
@@ -1,4 +1,5 @@
 import { killWithDescendantSweep } from '../pty-descendant-termination'
+import { hasAgentTeardownEvidence } from './agent-teardown-evidence'
 import type { Session } from './session'
 
 type AgentTeardownOperation = {
@@ -34,7 +35,9 @@ export class TerminalSessionTeardown {
   }
 
   killSession(sessionId: string, session: Session, immediate: boolean): void | Promise<void> {
-    if (session.launchAgent) {
+    // Evidence, not launchAgent: a hand-typed `claude` in a plain shell needs the same
+    // descendant sweep or its detached MCP children survive the tab close.
+    if (hasAgentTeardownEvidence(session.launchAgent, session)) {
       return this.killAgentSession(sessionId, session, immediate)
     }
     if (immediate) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |

<!-- /orca-pr-loc -->

## Summary

- classify teardown as agent-owned when a recognized agent is live in the foreground, even when the session was not launched by Orca
- route graceful and immediate teardown through the existing descendant sweep while preserving plain-shell behavior
- add regressions for hand-typed agent and shell foreground paths

## Testing

- `pnpm test src/main/daemon` (1700 passed, 3 skipped; 2 files skipped)
- cold `pnpm tc:node`
- `pnpm run check:code-quality:changed`
- safe zsh reproduction confirmed `jobs -p` empty while the recorded `sleep` child survived and was reparented to PID 1; the PID was terminated afterward
- ablation restored the old launch-only gates and the three new regressions failed; production files were byte-verified restored

## Linear

[STA-5947](https://linear.app/stably/issue/STA-5947/bug-agent-tool-descendants-escape-orca-ownership-after-a-completed)

No Electron/UI evidence applies; this is a daemon process-teardown change.