### PR TITLE
fix(hosted-review): floor stale revalidation retries

### DIFF
--- a/src/renderer/src/store/slices/hosted-review-cache.test.ts
+++ b/src/renderer/src/store/slices/hosted-review-cache.test.ts
@@ -194,6 +194,37 @@ describe('hosted review cache revalidation', () => {
     expect(mockApi.hostedReview.forBranch).toHaveBeenCalledTimes(3)
   })
 
+  it('keeps failed stale-while-revalidate calls behind a minimum interval floor', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    mockApi.hostedReview.forBranch
+      .mockResolvedValueOnce(review)
+      .mockRejectedValue(new Error('provider outage'))
+    const store = makeStore()
+    const options = { linkedGitHubPR: 42, staleWhileRevalidate: true }
+
+    await store.getState().fetchHostedReviewForBranch('/repo', 'feature/outage', {
+      linkedGitHubPR: 42
+    })
+    vi.setSystemTime(60_001)
+    await store.getState().fetchHostedReviewForBranch('/repo', 'feature/outage', options)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mockApi.hostedReview.forBranch).toHaveBeenCalledTimes(2)
+
+    // A failed lookup leaves the entry stale, so each caller queues another retry.
+    await store.getState().fetchHostedReviewForBranch('/repo', 'feature/outage', options)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockApi.hostedReview.forBranch).toHaveBeenCalledTimes(2)
+
+    // The next retry is admitted only after the explicit floor elapses.
+    await vi.advanceTimersByTimeAsync(2_999)
+    expect(mockApi.hostedReview.forBranch).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(mockApi.hostedReview.forBranch).toHaveBeenCalledTimes(3)
+  })
+
   it('lets a force refresh supersede queued stale-while-revalidate work', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(0)

--- a/src/renderer/src/store/slices/hosted-review-request-state.ts
+++ b/src/renderer/src/store/slices/hosted-review-request-state.ts
@@ -2,6 +2,9 @@ import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import { slowTaskRequiredIdleMs } from '@/components/right-sidebar/coalesced-poll-runner'
 
 const HOSTED_REVIEW_REVALIDATION_IDLE_MULTIPLIER = 5
+// Why: provider outages can resolve immediately while leaving the cache stale;
+// keep repeated visible callers off the API even when no duration backoff applies.
+const HOSTED_REVIEW_REVALIDATION_MIN_INTERVAL_MS = 3000
 const HOSTED_REVIEW_REVALIDATION_MAX_INTERVAL_MS = 5 * 60_000
 
 export const inflightHostedReviewRequests = new Map<
@@ -32,7 +35,7 @@ function requiredHostedReviewRevalidationIdleMs(lane: HostedReviewRevalidationLa
   return slowTaskRequiredIdleMs(
     lane.lastRunDurationMs,
     HOSTED_REVIEW_REVALIDATION_IDLE_MULTIPLIER,
-    0,
+    HOSTED_REVIEW_REVALIDATION_MIN_INTERVAL_MS,
     HOSTED_REVIEW_REVALIDATION_MAX_INTERVAL_MS
   )
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5
When a hosted-review provider is down, retries could happen immediately because the retry delay was zero for fast failures. This adds a three-second floor between stale-while-revalidate attempts while preserving the existing duration-based backoff.

## What Changed
- Added a 3,000 ms minimum idle interval to the hosted-review revalidation lane.
- Added regression coverage for repeated provider failures and stale cache callers.

## Why
Failures do not update `fetchedAt`, so visible callers can keep requesting stale data. A nonzero floor prevents an outage from turning those callers into an immediate API retry loop.

## Linked Issue
Fixes https://linear.app/stably/issue/STA-5881/hosted-review-revalidation-lane-needs-a-floor

## Visual Proof
N/A — this is renderer request scheduling and cache pacing; no user-visible UI or interaction changed.

## Testing
- `npx vitest run --config config/vitest.config.ts src/renderer/src/store/slices/hosted-review-cache.test.ts`
- Focused hosted-review suites: 5 files / 45 tests passed.
- Cold typechecks with isolated build-info files: node, CLI, and web passed.
- `node config/scripts/check-changed-code-quality.mjs` passed (0 new findings).
- Failing-first ablation: replacing the floor argument with `0` reproduced the regression (3 calls before 3 seconds); implementation restored byte-for-byte.

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (N/A; scheduling-only change)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (focused local gates pass; full CI will cover)
