### PR TITLE
fix(agent-status): rekey pane authority on PTY rebind

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -53,6 +53,7 @@ import {
   killAllPty,
   clearProviderPtyState,
   getPtyIdForPaneKey,
+  registerPaneKeyRekeyListener,
   registerPaneKeyTeardownListener,
   getLocalPtyProvider,
   getSshPtyProvider,
@@ -2206,6 +2207,13 @@ async function printServeReady(options: ServeOptions): Promise<void> {
 // Why: on PTY teardown drop the spinner entry explicitly, else the shared timer keeps ticking with sendSyntheticTitle no-oping forever.
 registerPaneKeyTeardownListener((paneKey) => {
   stopSyntheticTitleSpinner(paneKey)
+})
+
+// Why: a surviving PTY can be rebound under a newly-created tab while its hooks keep posting the old physical paneKey; move all hook authority to the new owner at the bind point.
+registerPaneKeyRekeyListener(({ ptyId, previousPaneKey, paneKey }) => {
+  agentHookServer.transferPaneAuthority(previousPaneKey, paneKey, ptyId, Date.now(), {
+    authorityVerified: true
+  })
 })
 
 function sendSyntheticTitle(ptyId: string, data: string, options: { force?: boolean } = {}): void {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -6,7 +6,11 @@ export {
   restorePtyIncarnation,
   getPtyIdsForConnection
 } from './pty/provider/ownership-state'
-export { getPtyIdForPaneKey, registerPaneKeyTeardownListener } from './pty/pane/key-state'
+export {
+  getPtyIdForPaneKey,
+  registerPaneKeyRekeyListener,
+  registerPaneKeyTeardownListener
+} from './pty/pane/key-state'
 export { hasPendingRendererSerializerForPaneKey } from './pty/pane/serializer-state'
 export type {
   BuildPtyHostEnvOptions,

--- a/src/main/ipc/pty/ipc/spawn-commit.ts
+++ b/src/main/ipc/pty/ipc/spawn-commit.ts
@@ -15,7 +15,7 @@ import {
   shouldSkipCodexHomeEnvForWindowsShell,
   codexReattachedHomeRouteField
 } from '../host-env/codex-home'
-import { rememberPaneKeyForPty } from '../pane/key-state'
+import { rememberPaneKeyBindingForPty } from '../pane/key-state'
 import { resolvePaneSpawnReservation } from '../pane/spawn-reservation'
 import { seedTerminalRestoreRecordsFromSpawnResult } from '../pane/agent-session-owners'
 import {
@@ -71,6 +71,16 @@ export async function commitPtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<PtySpawn
       ctx.deps.runtime.seedHeadlessTerminal(ctx.result.id, ctx.result.replay)
     }
   }
+  // Why: the renderer's tab/leaf metadata is the current bind identity even when a surviving process still carries an old ORCA_PANE_KEY; remember it before runtime registration so the rekey notification runs once.
+  const currentPaneKey =
+    ctx.result.isReattach === true
+      ? (ctx.metadataPaneKey ?? ctx.validatedPaneKey)
+      : ctx.validatedPaneKey
+  const rememberedPaneKey = rememberPaneKeyBindingForPty(
+    ctx.result.id,
+    currentPaneKey,
+    ctx.result.isReattach === true ? ctx.sourcePaneKey : undefined
+  )
   if (
     typeof args.worktreeId === 'string' &&
     args.worktreeId.length > 0 &&
@@ -133,11 +143,6 @@ export async function commitPtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<PtySpawn
   if (ctx.isClaudeLaunch && !ctx.stablePaneOwner) {
     markClaudePtySpawned(ctx.result.id)
   }
-  // Why: record the paneKey mapping so clearProviderPtyState can clear the agent-hooks server's per-paneKey caches on exit.
-  // Why: args.env is untrusted IPC JSON (type unenforced); bound the paneKey so malformed/oversized values can't pollute ptyPaneKey or clearPaneState.
-  const rememberedPaneKey = ctx.validatedPaneKey
-    ? rememberPaneKeyForPty(ctx.result.id, ctx.validatedPaneKey)
-    : null
   if (ctx.legacySpawnPaneKey && ctx.migrationUnsupportedPaneKey) {
     agentHookServer.registerPaneKeyAlias(
       ctx.legacySpawnPaneKey.paneKey,

--- a/src/main/ipc/pty/ipc/spawn-env.ts
+++ b/src/main/ipc/pty/ipc/spawn-env.ts
@@ -34,6 +34,9 @@ export async function assemblePtyIpcSpawnEnv(ctx: PtyIpcSpawnState): Promise<voi
     : sshSourceEnv
   const spawnPaneKey = baseEnvWithAuth?.ORCA_PANE_KEY
   const parsedSpawnPaneKey = parseValidPaneKey(spawnPaneKey)
+  ctx.sourcePaneKey = parsedSpawnPaneKey
+    ? makePaneKey(parsedSpawnPaneKey.tabId, parsedSpawnPaneKey.leafId)
+    : null
   const verifiedPaneKey =
     parsedSpawnPaneKey &&
     typeof args.tabId === 'string' &&

--- a/src/main/ipc/pty/ipc/spawn-state.ts
+++ b/src/main/ipc/pty/ipc/spawn-state.ts
@@ -57,6 +57,7 @@ export type PtyIpcSpawnState = {
   requestedAgentTeamsPath: string | undefined
   agentTeamsEnvToDelete: string[] | undefined
   stablePaneKey: string | null
+  sourcePaneKey: string | null
   verifiedLeafId: string | null
   metadataLeafId: string | null
   metadataPaneKey: string | null
@@ -130,6 +131,7 @@ export function createPtyIpcSpawnState(
     requestedAgentTeamsPath: undefined,
     agentTeamsEnvToDelete: undefined,
     stablePaneKey: null,
+    sourcePaneKey: null,
     verifiedLeafId: null,
     metadataLeafId: null,
     metadataPaneKey: null,

--- a/src/main/ipc/pty/pane/key-state.test.ts
+++ b/src/main/ipc/pty/pane/key-state.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  paneKeyPtyId,
+  paneKeyRekeyListeners,
+  ptyPaneKey,
+  rememberPaneKeyForPty,
+  registerPaneKeyRekeyListener
+} from './key-state'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+
+const PTY_ID = 'pty-pane-key-rebind'
+const OLD_PANE_KEY = makePaneKey(
+  '11111111-1111-4111-8111-111111111111',
+  '22222222-2222-4222-8222-222222222222'
+)
+const CURRENT_PANE_KEY = makePaneKey(
+  '33333333-3333-4333-8333-333333333333',
+  '22222222-2222-4222-8222-222222222222'
+)
+
+describe('pane key state', () => {
+  afterEach(() => {
+    ptyPaneKey.delete(PTY_ID)
+    paneKeyPtyId.delete(OLD_PANE_KEY)
+    paneKeyPtyId.delete(CURRENT_PANE_KEY)
+    paneKeyRekeyListeners.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('notifies consumers when a surviving PTY binds to a new pane key', () => {
+    const onRekey = vi.fn()
+    registerPaneKeyRekeyListener(onRekey)
+
+    rememberPaneKeyForPty(PTY_ID, OLD_PANE_KEY)
+    rememberPaneKeyForPty(PTY_ID, CURRENT_PANE_KEY)
+
+    expect(onRekey).toHaveBeenCalledOnce()
+    expect(onRekey).toHaveBeenCalledWith({
+      ptyId: PTY_ID,
+      previousPaneKey: OLD_PANE_KEY,
+      paneKey: CURRENT_PANE_KEY
+    })
+    expect(ptyPaneKey.get(PTY_ID)).toBe(CURRENT_PANE_KEY)
+    expect(paneKeyPtyId.get(CURRENT_PANE_KEY)).toBe(PTY_ID)
+    expect(paneKeyPtyId.has(OLD_PANE_KEY)).toBe(false)
+  })
+
+  it('aliases a stale hook key when the local PTY map was rebuilt', () => {
+    const onRekey = vi.fn()
+    registerPaneKeyRekeyListener(onRekey)
+
+    rememberPaneKeyForPty(PTY_ID, CURRENT_PANE_KEY, { sourcePaneKey: OLD_PANE_KEY })
+
+    expect(onRekey).toHaveBeenCalledWith({
+      ptyId: PTY_ID,
+      previousPaneKey: OLD_PANE_KEY,
+      paneKey: CURRENT_PANE_KEY
+    })
+  })
+})

--- a/src/main/ipc/pty/pane/key-state.ts
+++ b/src/main/ipc/pty/pane/key-state.ts
@@ -1,6 +1,6 @@
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
 
-// Why: track spawn-time paneKey so teardown can clear the agent-hooks server's per-paneKey cache, which otherwise grows unbounded as panes come and go.
+// Why: track the current PTY-bound paneKey so teardown can clear the agent-hooks server's per-paneKey cache, which otherwise grows unbounded as panes come and go.
 export const ptyPaneKey = new Map<string, string>()
 // Why: reverse of ptyPaneKey — callers with a paneKey from outside the PTY lifecycle (e.g. agent-hook status routing) need the ptyId; kept in lock-step via the same sites.
 export const paneKeyPtyId = new Map<string, string>()
@@ -13,9 +13,22 @@ export function getPtyIdForPaneKey(paneKey: string): string | undefined {
 export type PaneKeyTeardownListener = (paneKey: string) => void
 export const paneKeyTeardownListeners = new Set<PaneKeyTeardownListener>()
 
+// Why: a surviving PTY can be rebound to a newly-created tab; hook status keeps posting the old physical key, so consumers must move its authority to the new key.
+export type PaneKeyRekeyListener = (args: {
+  ptyId: string
+  previousPaneKey: string
+  paneKey: string
+}) => void
+export const paneKeyRekeyListeners = new Set<PaneKeyRekeyListener>()
+
 export function registerPaneKeyTeardownListener(listener: PaneKeyTeardownListener): () => void {
   paneKeyTeardownListeners.add(listener)
   return () => paneKeyTeardownListeners.delete(listener)
+}
+
+export function registerPaneKeyRekeyListener(listener: PaneKeyRekeyListener): () => void {
+  paneKeyRekeyListeners.add(listener)
+  return () => paneKeyRekeyListeners.delete(listener)
 }
 
 export function parseValidPaneKey(paneKey: unknown): ReturnType<typeof parsePaneKey> {
@@ -29,7 +42,11 @@ export function isValidPaneKey(paneKey: unknown): paneKey is string {
   return parseValidPaneKey(paneKey) !== null
 }
 
-export function rememberPaneKeyForPty(ptyId: string, paneKey: unknown): string | null {
+export function rememberPaneKeyForPty(
+  ptyId: string,
+  paneKey: unknown,
+  options: { sourcePaneKey?: unknown } = {}
+): string | null {
   const normalizedPaneKey = typeof paneKey === 'string' ? paneKey.trim() : ''
   if (!isValidPaneKey(normalizedPaneKey)) {
     return null
@@ -43,5 +60,29 @@ export function rememberPaneKeyForPty(ptyId: string, paneKey: unknown): string |
   }
   ptyPaneKey.set(ptyId, normalizedPaneKey)
   paneKeyPtyId.set(normalizedPaneKey, ptyId)
+  const sourcePaneKey =
+    typeof options.sourcePaneKey === 'string' ? options.sourcePaneKey.trim() : ''
+  const rekeySources = new Set(
+    [previousPaneKey, isValidPaneKey(sourcePaneKey) ? sourcePaneKey : null].filter(
+      (candidate): candidate is string => Boolean(candidate && candidate !== normalizedPaneKey)
+    )
+  )
+  for (const previous of rekeySources) {
+    for (const listener of paneKeyRekeyListeners) {
+      try {
+        listener({ ptyId, previousPaneKey: previous, paneKey: normalizedPaneKey })
+      } catch (err) {
+        console.error('[pty] paneKey rekey listener threw', err)
+      }
+    }
+  }
   return normalizedPaneKey
+}
+
+export function rememberPaneKeyBindingForPty(
+  ptyId: string,
+  paneKey: string | null | undefined,
+  sourcePaneKey?: unknown
+): string | null {
+  return paneKey ? rememberPaneKeyForPty(ptyId, paneKey, { sourcePaneKey }) : null
 }

--- a/src/main/ipc/pty/runtime/spawn-commit.ts
+++ b/src/main/ipc/pty/runtime/spawn-commit.ts
@@ -10,7 +10,7 @@ import {
 } from '../host-env/codex-home'
 import { markClaudePtySpawned } from '../../../claude-accounts/live-pty-gate'
 import { registerPty } from '../../../memory/pty-registry'
-import { rememberPaneKeyForPty } from '../pane/key-state'
+import * as spawnPaneKeyBinding from './spawn-pane-key-binding'
 import {
   pendingByPaneKey,
   pendingPtyIdBySerializerGeneration,
@@ -64,6 +64,8 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
     if (ctx.result.incarnationId) {
       ptyIncarnationById.set(ctx.result.id, ctx.result.incarnationId)
     }
+    // Why: the adopted surface is the current bind identity even when the surviving process still carries an older hook paneKey.
+    spawnPaneKeyBinding.rememberRuntimeSurfacePaneKey(ctx, owner.surface)
     ctx.deps.runtime?.registerPty(
       ctx.result.id,
       owner.surface.worktreeId,
@@ -113,7 +115,6 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
   ) {
     markNativeWindowsConptyPty(ctx.result.id)
   }
-  const relayResultId = getRelayPtyId(args.connectionId, ctx.result.id)
   const persistSshLease = (): void => {
     if (!ctx.deps.store || !args.connectionId) {
       return
@@ -121,7 +122,7 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
     // Why: SSH leases keep relay ids for remote reconciliation, while session bindings keep app-facing ids for hydration.
     ctx.deps.store.upsertSshRemotePtyLease({
       targetId: args.connectionId,
-      ptyId: relayResultId,
+      ptyId: getRelayPtyId(args.connectionId, ctx.result.id),
       ...(typeof args.worktreeId === 'string' ? { worktreeId: args.worktreeId } : {}),
       ...(typeof args.tabId === 'string' ? { tabId: args.tabId } : {}),
       ...(typeof args.leafId === 'string' && isTerminalLeafId(args.leafId)
@@ -194,6 +195,8 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
   if (args.preAllocatedHandle && !ctx.stablePaneOwner?.handle) {
     ctx.deps.runtime?.registerPreAllocatedHandleForPty(ctx.result.id, args.preAllocatedHandle)
   }
+  // Why: runtime controller metadata is the current bind identity even when a surviving process still carries an old ORCA_PANE_KEY; remember it before runtime registration so the rekey notification runs once.
+  const rememberedPaneKey = spawnPaneKeyBinding.rememberRuntimeSpawnPaneKey(ctx)
   if (args.worktreeId) {
     ctx.deps.runtime?.registerPty(
       ctx.result.id,
@@ -242,14 +245,13 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
     }
   }
   // Why: runtime-owned CLI PTYs bypass the renderer pty:spawn handler; record paneKey here too since hook titles and cache cleanup need this reverse lookup.
-  const paneKey = rememberPaneKeyForPty(ctx.result.id, ctx.env?.ORCA_PANE_KEY)
-  const pendingSerializer = paneKey ? pendingByPaneKey.get(paneKey) : undefined
+  const pendingSerializer = rememberedPaneKey && pendingByPaneKey.get(rememberedPaneKey)
   const inheritRendererReadiness =
     ctx.result.isReattach === true &&
     !pendingSerializer &&
     rendererSerializerReadiness.has(ctx.result.id)
   rendererSerializerReadiness.beginIncarnation(ctx.result.id, inheritRendererReadiness)
-  if (paneKey && pendingSerializer) {
+  if (rememberedPaneKey && pendingSerializer) {
     pendingPtyIdBySerializerGeneration.set(pendingSerializer.gen, ctx.result.id)
   }
   if (!args.connectionId) {
@@ -257,7 +259,7 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
       ptyId: ctx.result.id,
       worktreeId: args.worktreeId ?? null,
       sessionId: ctx.sessionId ?? null,
-      paneKey,
+      paneKey: rememberedPaneKey,
       pid:
         typeof ctx.result.pid === 'number' && Number.isFinite(ctx.result.pid) && ctx.result.pid > 0
           ? ctx.result.pid

--- a/src/main/ipc/pty/runtime/spawn-pane-key-binding.ts
+++ b/src/main/ipc/pty/runtime/spawn-pane-key-binding.ts
@@ -1,0 +1,27 @@
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { rememberPaneKeyBindingForPty } from '../pane/key-state'
+import type { RuntimePtySpawnState } from './spawn-state'
+
+type RuntimePaneKeyContext = Pick<
+  RuntimePtySpawnState,
+  'result' | 'spawnIdentityPaneKey' | 'metadataPaneKey' | 'sourcePaneKey'
+>
+
+export function rememberRuntimeSpawnPaneKey(ctx: RuntimePaneKeyContext): string | null {
+  return rememberPaneKeyBindingForPty(
+    ctx.result.id,
+    ctx.spawnIdentityPaneKey ?? ctx.metadataPaneKey ?? ctx.sourcePaneKey,
+    ctx.result.isReattach === true ? ctx.sourcePaneKey : undefined
+  )
+}
+
+export function rememberRuntimeSurfacePaneKey(
+  ctx: Pick<RuntimePtySpawnState, 'result' | 'sourcePaneKey'>,
+  surface: { tabId: string; leafId: string }
+): void {
+  rememberPaneKeyBindingForPty(
+    ctx.result.id,
+    makePaneKey(surface.tabId, surface.leafId),
+    ctx.sourcePaneKey
+  )
+}

--- a/src/main/ipc/pty/runtime/spawn-preflight.ts
+++ b/src/main/ipc/pty/runtime/spawn-preflight.ts
@@ -2,7 +2,7 @@ import { getAppEnvironment } from '../../../../shared/app-environment'
 import type { PtySpawnResult } from '../../../providers/types'
 import { LocalPtyProvider } from '../../../providers/local-pty-provider'
 import { isValidTerminalTabId } from '../../../../shared/terminal-tab-id'
-import { isTerminalLeafId } from '../../../../shared/stable-pane-id'
+import { isTerminalLeafId, makePaneKey } from '../../../../shared/stable-pane-id'
 import { getAppPtyId, getProvider, getRelayPtyId } from '../provider/registry'
 import { buildPtyHostEnv } from '../host-env/assembly'
 import {
@@ -37,6 +37,7 @@ import { resolvePathEnvKey } from '../../../pty/windows-environment-path'
 import { stampWslOrchestrationCompatibilityHost } from '../../../pty/wsl-orca-env'
 import { ensureCodexStateDbBackfillRecoveryStarted } from '../../../codex/codex-state-db-backfill-recovery'
 import { clearProviderPtyState } from '../provider/state-cleanup'
+import { parseValidPaneKey } from '../pane/key-state'
 import type { RuntimePtySpawnState } from './spawn-state'
 
 export async function prepareRuntimePtySpawn(
@@ -163,6 +164,8 @@ export async function prepareRuntimePtySpawn(
     }
   }
   const sshScopedEnv = stripRemotePaneEnvWhenHooksDisabled(args.connectionId, args.env)
+  const sourcePaneKey = parseValidPaneKey(sshScopedEnv?.ORCA_PANE_KEY)
+  ctx.sourcePaneKey = sourcePaneKey ? makePaneKey(sourcePaneKey.tabId, sourcePaneKey.leafId) : null
   ctx.env = ctx.claudeAuth ? { ...sshScopedEnv, ...ctx.claudeAuth.envPatch } : sshScopedEnv
   ctx.requestedAgentTeamsPath = ctx.env?.ORCA_AGENT_TEAMS_TEAM_ID
     ? ctx.env[resolvePathEnvKey(ctx.env, process.platform)]

--- a/src/main/ipc/pty/runtime/spawn-state.ts
+++ b/src/main/ipc/pty/runtime/spawn-state.ts
@@ -59,6 +59,7 @@ export type RuntimePtySpawnState = {
   hadSessionSizeBeforeAttach: boolean
   sessionSizeBeforeAttach: { cols: number; rows: number } | undefined
   materializedPaneKey: string | null
+  sourcePaneKey: string | null
   metadataLeafId: string | null
   metadataPaneKey: string | null
   spawnIdentityPaneKey: string | null
@@ -165,6 +166,7 @@ export function createRuntimePtySpawnState(
     hadSessionSizeBeforeAttach: false,
     sessionSizeBeforeAttach: undefined,
     materializedPaneKey: null,
+    sourcePaneKey: null,
     metadataLeafId: null,
     metadataPaneKey: null,
     spawnIdentityPaneKey: null,

--- a/src/main/runtime/orca-runtime-provider-reattach-launch-identity.test.ts
+++ b/src/main/runtime/orca-runtime-provider-reattach-launch-identity.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { makePaneKey } from '../../shared/stable-pane-id'
+import { paneKeyPtyId, ptyPaneKey, registerPaneKeyRekeyListener } from '../ipc/pty/pane/key-state'
 import { OrcaRuntimeService } from './orca-runtime'
 
 vi.mock('electron', () => ({
@@ -14,6 +15,17 @@ const LEAF_ID = '22222222-2222-4222-8222-222222222222'
 const PANE_KEY = makePaneKey(TAB_ID, LEAF_ID)
 const INCARNATION_ID = 'provider-reattach-incarnation'
 const WORKTREE_ID = 'repo-1::/tmp/provider-reattach'
+const REKEY_PTY_ID = 'pty-runtime-pane-rekey'
+const REKEY_OLD_TAB_ID = '44444444-4444-4444-8444-444444444444'
+const REKEY_NEW_TAB_ID = '55555555-5555-4555-8555-555555555555'
+const REKEY_OLD_PANE_KEY = makePaneKey(REKEY_OLD_TAB_ID, LEAF_ID)
+const REKEY_NEW_PANE_KEY = makePaneKey(REKEY_NEW_TAB_ID, LEAF_ID)
+
+afterEach(() => {
+  ptyPaneKey.delete(REKEY_PTY_ID)
+  paneKeyPtyId.delete(REKEY_OLD_PANE_KEY)
+  paneKeyPtyId.delete(REKEY_NEW_PANE_KEY)
+})
 
 type RuntimePtyLaunchIdentity = {
   incarnationId: string | null
@@ -96,5 +108,27 @@ describe('provider reattach launch identity', () => {
       launchToken: null,
       launchIncarnationId: null
     })
+  })
+
+  it('rekeys hook authority when graph registration moves a surviving PTY', () => {
+    const onRekey = vi.fn()
+    const unregister = registerPaneKeyRekeyListener(onRekey)
+    const runtime = new OrcaRuntimeService(null)
+
+    runtime.registerPty(REKEY_PTY_ID, WORKTREE_ID, null, {
+      tabId: REKEY_OLD_TAB_ID,
+      leafId: LEAF_ID
+    })
+    runtime.registerPty(REKEY_PTY_ID, WORKTREE_ID, null, {
+      tabId: REKEY_NEW_TAB_ID,
+      leafId: LEAF_ID
+    })
+
+    expect(onRekey).toHaveBeenCalledWith({
+      ptyId: REKEY_PTY_ID,
+      previousPaneKey: REKEY_OLD_PANE_KEY,
+      paneKey: REKEY_NEW_PANE_KEY
+    })
+    unregister()
   })
 })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -170,6 +170,7 @@ import {
 import type { GitAdmissionTier } from '../git/command-runner/git-exec-options'
 import { runWithGitReadCacheInvalidation } from '../git/status'
 import { wakeFolderRepoGitUpgradeWatch } from '../ipc/folder-repo-git-upgrade-wake'
+import { rememberPaneKeyBindingForPty } from '../ipc/pty/pane/key-state'
 import {
   cleanupClaimedCloneTarget,
   claimCloneTarget,
@@ -34872,6 +34873,7 @@ export class OrcaRuntimeService {
         // Why: restored SSH IDs can collide with stale local parser state; connection ownership must win before their first output is parsed.
         this.wslDistroByPtyId.delete(ptyId)
       }
+      rememberPaneKeyBindingForPty(ptyId, state.paneKey)
       // Why: restored/controller-discovered PTYs learn their worktree here without registerPty(), so URL enrichment must bind at this source.
       advertisedUrlWatcher.bindPty(ptyId, worktreeId)
       return pty
@@ -34919,6 +34921,8 @@ export class OrcaRuntimeService {
       pty.tabId = state.tabId
     }
     if (state.paneKey !== undefined) {
+      // Why: graph sync and PTY reattach both converge here; update the reverse map before replacing the record so rekey listeners can transfer hook authority.
+      rememberPaneKeyBindingForPty(ptyId, state.paneKey)
       pty.paneKey = state.paneKey
     }
     if (state.connected !== undefined) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​94 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​118 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​101 |

<!-- /orca-pr-loc -->

## Summary

When a surviving PTY is rebound under a newly-created tab, the PTY bind path now records the new paneKey and notifies the agent-hook server. The server reuses its existing alias machinery to transfer cached status/authority from the old physical key to the current key, and persists the mapping for restart/SSH reattach. A valid stale ORCA_PANE_KEY is retained only as an alias source for successful reattach results; no hook wire field or stream opcode changes.

## Coverage

- Covers local and SSH PTY bind/reattach paths, runtime graph rebinds, hook ingestion, sidebar/status snapshots, and server-side orchestration authority/worker routing through alias resolution.
- Does not rewrite renderer-owned completion-notification or terminal-attention maps that were already keyed by the stale paneKey, and does not replay a historical notification; those consumers converge on the next routed status/snapshot.
- Does not change closed-tab suppression or interrupted decay behavior.

## Verification

- Failing-first: `src/main/ipc/pty/pane/key-state.test.ts` failed before the rekey listener existed; it passes after the fix.
- Passing: targeted PTY/runtime/server suites (41 tests, plus spawn/environment suites 129 tests), `pnpm run typecheck:node`, `pnpm run typecheck:web`, `oxlint`, and `oxfmt --check`.
