### PR TITLE
feat(browser): edit a page annotation's comment and intent inline in the tray

### DIFF
--- a/src/renderer/src/components/browser-pane/annotate/browser-guest-annotate-overlays.tsx
+++ b/src/renderer/src/components/browser-pane/annotate/browser-guest-annotate-overlays.tsx
@@ -72,7 +72,8 @@ export function BrowserGuestAnnotateOverlays({
     handleCopyBrowserAnnotations,
     browserAnnotationsCopied,
     handleClearBrowserAnnotations,
-    handleDeleteBrowserAnnotation
+    handleDeleteBrowserAnnotation,
+    handleUpdateBrowserAnnotation
   } = annotationSend
 
   return (
@@ -112,6 +113,7 @@ export function BrowserGuestAnnotateOverlays({
           browserAnnotationsCopied={browserAnnotationsCopied}
           handleClearBrowserAnnotations={handleClearBrowserAnnotations}
           handleDeleteBrowserAnnotation={handleDeleteBrowserAnnotation}
+          handleUpdateBrowserAnnotation={handleUpdateBrowserAnnotation}
         />
       ) : null}
       {/* Right-click context dropdown, positioned at the grabbed element's center. */}

--- a/src/renderer/src/components/browser-pane/annotate/browser-page-annotation-tray.test.tsx
+++ b/src/renderer/src/components/browser-pane/annotate/browser-page-annotation-tray.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import type { BrowserPageAnnotation } from '../../../../../shared/browser-grab-types'
+import { BrowserPageAnnotationTray } from './browser-page-annotation-tray'
+
+afterEach(() => {
+  cleanup()
+})
+
+function makeAnnotation(): BrowserPageAnnotation {
+  return {
+    id: 'annotation-1',
+    browserPageId: 'page-1',
+    comment: 'Fix this button',
+    intent: 'change',
+    priority: 'important',
+    createdAt: '2026-05-15T00:00:00.000Z',
+    payload: {
+      page: {
+        sanitizedUrl: 'https://example.com',
+        title: 'Example',
+        viewportWidth: 1280,
+        viewportHeight: 720,
+        scrollX: 0,
+        scrollY: 0,
+        devicePixelRatio: 1,
+        capturedAt: '2026-05-15T00:00:00.000Z'
+      },
+      target: {
+        tagName: 'button',
+        selector: 'button',
+        textSnippet: 'Submit',
+        htmlSnippet: '<button>Submit</button>',
+        attributes: {},
+        accessibility: {
+          role: 'button',
+          accessibleName: 'Submit',
+          ariaLabel: null,
+          ariaLabelledBy: null
+        },
+        rectViewport: { x: 0, y: 0, width: 100, height: 40 },
+        rectPage: { x: 0, y: 0, width: 100, height: 40 },
+        computedStyles: {
+          display: 'inline-flex',
+          position: 'static',
+          width: '100px',
+          height: '40px',
+          margin: '0px',
+          padding: '0px',
+          color: 'rgb(0, 0, 0)',
+          backgroundColor: 'rgba(0, 0, 0, 0)',
+          border: '0px none',
+          borderRadius: '0px',
+          fontFamily: 'Geist',
+          fontSize: '14px',
+          fontWeight: '400',
+          lineHeight: '20px',
+          textAlign: 'center',
+          zIndex: 'auto'
+        }
+      },
+      nearbyText: [],
+      ancestorPath: [],
+      screenshot: null
+    }
+  }
+}
+
+function renderTray(): {
+  handleDeleteBrowserAnnotation: ReturnType<typeof vi.fn>
+  handleUpdateBrowserAnnotation: ReturnType<typeof vi.fn>
+} {
+  const handleDeleteBrowserAnnotation = vi.fn()
+  const handleUpdateBrowserAnnotation = vi.fn()
+
+  render(
+    <TooltipProvider>
+      <BrowserPageAnnotationTray
+        browserAnnotations={[makeAnnotation()]}
+        annotationTraySendOpen={false}
+        handleAnnotationTraySendOpenChange={vi.fn()}
+        worktreeId="wt-1"
+        activeGroupId={undefined}
+        browserAnnotationsPrompt="prompt"
+        handleBrowserAnnotationsSentToAgent={vi.fn()}
+        handleCopyBrowserAnnotations={vi.fn()}
+        browserAnnotationsCopied={false}
+        handleClearBrowserAnnotations={vi.fn()}
+        handleDeleteBrowserAnnotation={handleDeleteBrowserAnnotation}
+        handleUpdateBrowserAnnotation={handleUpdateBrowserAnnotation}
+      />
+    </TooltipProvider>
+  )
+
+  return { handleDeleteBrowserAnnotation, handleUpdateBrowserAnnotation }
+}
+
+describe('BrowserPageAnnotationTray edit mode', () => {
+  it('seeds the textarea with the current comment when entering edit mode', () => {
+    renderTray()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit annotation 1' }))
+
+    expect(screen.getByRole('textbox', { name: 'Annotation comment' })).toHaveValue(
+      'Fix this button'
+    )
+  })
+
+  it('saves the trimmed comment and the chosen intent', () => {
+    const { handleUpdateBrowserAnnotation } = renderTray()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit annotation 1' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Annotation comment' }), {
+      target: { value: '  Updated comment  ' }
+    })
+    fireEvent.click(screen.getByRole('radio', { name: 'Question' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(handleUpdateBrowserAnnotation).toHaveBeenCalledWith(
+      'annotation-1',
+      'Updated comment',
+      'question'
+    )
+  })
+
+  it('restores the read view on cancel without saving', () => {
+    const { handleUpdateBrowserAnnotation } = renderTray()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit annotation 1' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Annotation comment' }), {
+      target: { value: 'Changed but cancelled' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(handleUpdateBrowserAnnotation).not.toHaveBeenCalled()
+    expect(screen.getByText('Fix this button')).toBeInTheDocument()
+    expect(screen.queryByRole('textbox', { name: 'Annotation comment' })).not.toBeInTheDocument()
+  })
+
+  it('restores the read view when Escape fires from the intent toggle group', () => {
+    const { handleUpdateBrowserAnnotation } = renderTray()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit annotation 1' }))
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Question' }), {
+      key: 'Escape',
+      bubbles: true
+    })
+
+    expect(handleUpdateBrowserAnnotation).not.toHaveBeenCalled()
+    expect(screen.getByText('Fix this button')).toBeInTheDocument()
+    expect(screen.queryByRole('textbox', { name: 'Annotation comment' })).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/browser-pane/annotate/browser-page-annotation-tray.tsx
+++ b/src/renderer/src/components/browser-pane/annotate/browser-page-annotation-tray.tsx
@@ -1,4 +1,5 @@
-import { CircleCheck, Copy, MessageSquarePlus, Send, Trash2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { CircleCheck, Copy, MessageSquarePlus, Pencil, Send, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -6,8 +7,15 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
 import { translate } from '@/i18n/i18n'
-import type { BrowserPageAnnotation } from '../../../../../shared/browser-grab-types'
+import {
+  GRAB_BUDGET,
+  type BrowserAnnotationIntent,
+  type BrowserPageAnnotation
+} from '../../../../../shared/browser-grab-types'
+import { BROWSER_ANNOTATION_INTENT_OPTIONS } from '../describe-page/browser-annotation-geometry'
 import { BrowserAnnotationSendMenuContent } from './BrowserAnnotationSendMenuContent'
 import { preventAgentSendTargetOutsideDismiss } from './prevent-agent-send-target-outside-dismiss'
 
@@ -22,7 +30,8 @@ export function BrowserPageAnnotationTray({
   handleCopyBrowserAnnotations,
   browserAnnotationsCopied,
   handleClearBrowserAnnotations,
-  handleDeleteBrowserAnnotation
+  handleDeleteBrowserAnnotation,
+  handleUpdateBrowserAnnotation
 }: {
   browserAnnotations: BrowserPageAnnotation[]
   annotationTraySendOpen: boolean
@@ -35,7 +44,45 @@ export function BrowserPageAnnotationTray({
   browserAnnotationsCopied: boolean
   handleClearBrowserAnnotations: () => void
   handleDeleteBrowserAnnotation: (annotationId: string) => void
+  handleUpdateBrowserAnnotation: (
+    annotationId: string,
+    comment: string,
+    intent: BrowserAnnotationIntent
+  ) => void
 }): React.JSX.Element {
+  const [editingAnnotationId, setEditingAnnotationId] = useState<string | null>(null)
+  const [editComment, setEditComment] = useState('')
+  const [editIntent, setEditIntent] = useState<BrowserAnnotationIntent>('change')
+
+  // Why: a delete or clear while a row is mid-edit must not leave edit state pointing at nothing.
+  useEffect(() => {
+    if (
+      editingAnnotationId &&
+      !browserAnnotations.some((annotation) => annotation.id === editingAnnotationId)
+    ) {
+      setEditingAnnotationId(null)
+    }
+  }, [browserAnnotations, editingAnnotationId])
+
+  const handleStartEdit = (annotation: BrowserPageAnnotation): void => {
+    setEditingAnnotationId(annotation.id)
+    setEditComment(annotation.comment)
+    setEditIntent(annotation.intent)
+  }
+
+  const handleCancelEdit = (): void => {
+    setEditingAnnotationId(null)
+  }
+
+  const handleSaveEdit = (): void => {
+    const trimmed = editComment.trim()
+    if (!trimmed || !editingAnnotationId) {
+      return
+    }
+    handleUpdateBrowserAnnotation(editingAnnotationId, trimmed, editIntent)
+    setEditingAnnotationId(null)
+  }
+
   return (
     <div className="absolute right-3 bottom-3 z-30 flex max-h-[45%] w-[min(20rem,calc(100%-1.5rem))] flex-col overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)]">
       <div className="flex items-center gap-2 border-b border-border px-3 py-2">
@@ -124,40 +171,141 @@ export function BrowserPageAnnotationTray({
         </Tooltip>
       </div>
       <div className="scrollbar-sleek min-h-0 flex-1 overflow-auto p-1.5">
-        {browserAnnotations.map((annotation, index) => (
-          <div
-            key={annotation.id}
-            className="group flex gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent focus-within:bg-accent"
-          >
-            <div className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-foreground">
-              {index + 1}
-            </div>
-            <div className="min-w-0 flex-1">
-              <div className="truncate font-medium text-foreground">
-                {annotation.payload.target.accessibility.accessibleName ||
-                  annotation.payload.target.textSnippet ||
-                  annotation.payload.target.tagName}
-              </div>
-              <div className="mt-0.5 line-clamp-2 text-muted-foreground">{annotation.comment}</div>
-              <div className="mt-1 text-[11px] text-muted-foreground">
-                <span>{annotation.intent}</span>
-              </div>
-            </div>
-            <Button
-              size="icon-xs"
-              variant="ghost"
-              className="can-hover:opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 group-focus-within:opacity-100"
-              onClick={() => handleDeleteBrowserAnnotation(annotation.id)}
-              aria-label={translate(
-                'auto.components.browser.pane.BrowserPane.f2d0c22d67',
-                'Delete annotation {{value0}}',
-                { value0: index + 1 }
-              )}
+        {browserAnnotations.map((annotation, index) => {
+          const isEditing = annotation.id === editingAnnotationId
+          return (
+            <div
+              key={annotation.id}
+              className="group flex gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent focus-within:bg-accent"
             >
-              <Trash2 className="size-3" />
-            </Button>
-          </div>
-        ))}
+              <div className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-foreground">
+                {index + 1}
+              </div>
+              {isEditing ? (
+                <div
+                  className="min-w-0 flex-1"
+                  data-slot="annotation-edit"
+                  onKeyDown={(event) => {
+                    // Why: bail-out selector in useGrabMode lets this reach any focused child, not just the textarea.
+                    if (event.key === 'Escape') {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      handleCancelEdit()
+                    }
+                  }}
+                >
+                  <textarea
+                    value={editComment}
+                    onChange={(event) => setEditComment(event.target.value)}
+                    maxLength={GRAB_BUDGET.annotationCommentMaxLength}
+                    className="h-16 w-full resize-none rounded-md border border-input bg-background px-2 py-1.5 text-xs outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring"
+                    autoFocus
+                    aria-label={translate(
+                      'auto.components.browser.pane.BrowserPane.d2a7092e6e',
+                      'Annotation comment'
+                    )}
+                    onKeyDown={(event) => {
+                      if (isScreenSubmitShortcut(event)) {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        handleSaveEdit()
+                      }
+                    }}
+                  />
+                  <ToggleGroup
+                    type="single"
+                    size="sm"
+                    variant="outline"
+                    value={editIntent}
+                    onValueChange={(value) => {
+                      if (value) {
+                        setEditIntent(value as BrowserAnnotationIntent)
+                      }
+                    }}
+                    className="mt-1.5 h-7 w-full [&_[data-slot=toggle-group-item]]:h-7 [&_[data-slot=toggle-group-item]]:flex-1 [&_[data-slot=toggle-group-item]]:px-1.5"
+                    aria-label={translate(
+                      'auto.components.browser.pane.annotate.browser.page.annotation.tray.449d2c2629',
+                      'Annotation intent'
+                    )}
+                  >
+                    {BROWSER_ANNOTATION_INTENT_OPTIONS.map((option) => {
+                      const Icon = option.icon
+                      return (
+                        <ToggleGroupItem
+                          key={option.value}
+                          value={option.value}
+                          aria-label={option.label}
+                          className="gap-1 text-[11px] data-[state=on]:border-foreground/20 data-[state=on]:bg-foreground/10 data-[state=on]:text-foreground data-[state=on]:shadow-xs data-[state=on]:hover:bg-foreground/15 data-[state=on]:hover:text-foreground"
+                        >
+                          <Icon className="size-3" />
+                          <span>{option.label}</span>
+                        </ToggleGroupItem>
+                      )
+                    })}
+                  </ToggleGroup>
+                  <div className="mt-1.5 flex justify-end gap-1.5">
+                    <Button size="xs" variant="ghost" onClick={handleCancelEdit}>
+                      {translate(
+                        'auto.components.browser.pane.annotate.browser.page.annotation.tray.024467ceac',
+                        'Cancel'
+                      )}
+                    </Button>
+                    <Button size="xs" disabled={!editComment.trim()} onClick={handleSaveEdit}>
+                      {translate(
+                        'auto.components.browser.pane.annotate.browser.page.annotation.tray.c16f932cb3',
+                        'Save'
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate font-medium text-foreground">
+                      {annotation.payload.target.accessibility.accessibleName ||
+                        annotation.payload.target.textSnippet ||
+                        annotation.payload.target.tagName}
+                    </div>
+                    <div className="mt-0.5 line-clamp-2 text-muted-foreground">
+                      {annotation.comment}
+                    </div>
+                    <div className="mt-1 text-[11px] text-muted-foreground">
+                      <span>{annotation.intent}</span>
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 items-start gap-0.5">
+                    <Button
+                      size="icon-xs"
+                      variant="ghost"
+                      className="can-hover:opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 group-focus-within:opacity-100"
+                      onClick={() => handleStartEdit(annotation)}
+                      aria-label={translate(
+                        'auto.components.browser.pane.annotate.browser.page.annotation.tray.09a7c1df70',
+                        'Edit annotation {{value0}}',
+                        { value0: index + 1 }
+                      )}
+                    >
+                      <Pencil className="size-3" />
+                    </Button>
+                    <Button
+                      size="icon-xs"
+                      variant="ghost"
+                      className="can-hover:opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 group-focus-within:opacity-100"
+                      onClick={() => handleDeleteBrowserAnnotation(annotation.id)}
+                      aria-label={translate(
+                        'auto.components.browser.pane.BrowserPane.f2d0c22d67',
+                        'Delete annotation {{value0}}',
+                        { value0: index + 1 }
+                      )}
+                    >
+                      <Trash2 className="size-3" />
+                    </Button>
+                  </div>
+                </>
+              )}
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/src/renderer/src/components/browser-pane/annotate/use-browser-page-annotation-send.ts
+++ b/src/renderer/src/components/browser-pane/annotate/use-browser-page-annotation-send.ts
@@ -10,7 +10,10 @@ import {
 } from 'react'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
-import type { BrowserPageAnnotation } from '../../../../../shared/browser-grab-types'
+import type {
+  BrowserAnnotationIntent,
+  BrowserPageAnnotation
+} from '../../../../../shared/browser-grab-types'
 import { formatBrowserAnnotationsAsMarkdown } from './browser-annotation-output'
 import { EMPTY_BROWSER_ANNOTATIONS } from '../describe-page/browser-annotation-geometry'
 
@@ -33,6 +36,11 @@ export function useBrowserPageAnnotationSend({
   handleCopyBrowserAnnotations: () => void
   handleClearBrowserAnnotations: () => void
   handleDeleteBrowserAnnotation: (annotationId: string) => void
+  handleUpdateBrowserAnnotation: (
+    annotationId: string,
+    comment: string,
+    intent: BrowserAnnotationIntent
+  ) => void
   handleBrowserAnnotationsSentToAgent: () => void
   activeGroupId: string | undefined
 } {
@@ -56,6 +64,7 @@ export function useBrowserPageAnnotationSend({
   const annotationBannerSendOpen = activeAgentSendTargetModeId === annotationBannerSendModeId
   const annotationTraySendOpen = activeAgentSendTargetModeId === annotationTraySendModeId
   const deleteBrowserPageAnnotation = useAppStore((s) => s.deleteBrowserPageAnnotation)
+  const updateBrowserPageAnnotation = useAppStore((s) => s.updateBrowserPageAnnotation)
   const clearBrowserPageAnnotations = useAppStore((s) => s.clearBrowserPageAnnotations)
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
 
@@ -174,6 +183,14 @@ export function useBrowserPageAnnotationSend({
     ]
   )
 
+  const handleUpdateBrowserAnnotation = useCallback(
+    (annotationId: string, comment: string, intent: BrowserAnnotationIntent): void => {
+      updateBrowserPageAnnotation(browserTabId, annotationId, { comment, intent })
+      recordFeatureInteraction('browser-annotations')
+    },
+    [browserTabId, recordFeatureInteraction, updateBrowserPageAnnotation]
+  )
+
   return {
     browserAnnotations,
     browserAnnotationsPrompt,
@@ -187,6 +204,7 @@ export function useBrowserPageAnnotationSend({
     handleCopyBrowserAnnotations,
     handleClearBrowserAnnotations,
     handleDeleteBrowserAnnotation,
+    handleUpdateBrowserAnnotation,
     handleBrowserAnnotationsSentToAgent,
     activeGroupId
   }

--- a/src/renderer/src/components/browser-pane/annotate/useGrabMode.test.ts
+++ b/src/renderer/src/components/browser-pane/annotate/useGrabMode.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 function createReactHookHarness() {
@@ -47,6 +49,7 @@ describe('useGrabMode', () => {
     vi.doUnmock('@/hooks/useMountedRef')
     vi.resetModules()
     vi.unstubAllGlobals()
+    document.body.innerHTML = ''
   })
 
   it('uses the latest browser page when toggled before the page-change effect runs', async () => {
@@ -271,5 +274,106 @@ describe('useGrabMode', () => {
       expect(grab.state).toBe('awaiting')
       expect(grab.payload).toBeNull()
     })
+  })
+
+  it('keeps grab mode active when Escape comes from inside an annotation-edit row', async () => {
+    const harness = createReactHookHarness()
+    const addEventListener = vi.fn()
+    const setGrabMode = vi.fn(async () => ({ ok: true }))
+    vi.doMock('react', () => harness.react)
+    vi.doMock('@/hooks/useMountedRef', () => ({
+      useMountedRef: () => ({ current: true })
+    }))
+    vi.stubGlobal('window', {
+      addEventListener,
+      removeEventListener: vi.fn(),
+      api: {
+        browser: {
+          setGrabMode,
+          awaitGrabSelection: vi.fn(() => new Promise(() => {})),
+          cancelGrab: vi.fn()
+        }
+      }
+    })
+    const { useGrabMode } = await import('./useGrabMode')
+    const render = () => {
+      harness.beginRender()
+      // oxlint-disable-next-line react-hooks/rules-of-hooks -- test harness mocks React's hook dispatcher directly.
+      return useGrabMode('page-1')
+    }
+
+    const grab = render()
+    grab.toggle()
+    expect(render().state).toBe('armed')
+    harness.effects[1]?.effect()
+    const handleKeyDown = addEventListener.mock.calls[0]?.[1] as (event: KeyboardEvent) => void
+
+    // Why: a button in the edit row isn't itself editable, so only the
+    // annotation-edit closest() clause (not isEditableKeyboardTarget) exempts it.
+    const editRow = document.createElement('div')
+    editRow.setAttribute('data-slot', 'annotation-edit')
+    const cancelButton = document.createElement('button')
+    editRow.appendChild(cancelButton)
+    document.body.appendChild(editRow)
+
+    const preventDefault = vi.fn()
+    handleKeyDown({
+      key: 'Escape',
+      target: cancelButton,
+      preventDefault,
+      stopPropagation: vi.fn()
+    } as unknown as KeyboardEvent)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(setGrabMode).toHaveBeenCalledTimes(1)
+    expect(render().state).toBe('armed')
+  })
+
+  it('cancels grab mode when Escape comes from outside any exempt container', async () => {
+    const harness = createReactHookHarness()
+    const addEventListener = vi.fn()
+    const setGrabMode = vi.fn(async () => ({ ok: true }))
+    vi.doMock('react', () => harness.react)
+    vi.doMock('@/hooks/useMountedRef', () => ({
+      useMountedRef: () => ({ current: true })
+    }))
+    vi.stubGlobal('window', {
+      addEventListener,
+      removeEventListener: vi.fn(),
+      api: {
+        browser: {
+          setGrabMode,
+          awaitGrabSelection: vi.fn(() => new Promise(() => {})),
+          cancelGrab: vi.fn()
+        }
+      }
+    })
+    const { useGrabMode } = await import('./useGrabMode')
+    const render = () => {
+      harness.beginRender()
+      // oxlint-disable-next-line react-hooks/rules-of-hooks -- test harness mocks React's hook dispatcher directly.
+      return useGrabMode('page-1')
+    }
+
+    const grab = render()
+    grab.toggle()
+    expect(render().state).toBe('armed')
+    harness.effects[1]?.effect()
+    const handleKeyDown = addEventListener.mock.calls[0]?.[1] as (event: KeyboardEvent) => void
+
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+
+    const preventDefault = vi.fn()
+    handleKeyDown({
+      key: 'Escape',
+      target: outside,
+      preventDefault,
+      stopPropagation: vi.fn()
+    } as unknown as KeyboardEvent)
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(setGrabMode).toHaveBeenLastCalledWith({ browserPageId: 'page-1', enabled: false })
+    expect(render().state).toBe('idle')
   })
 })

--- a/src/renderer/src/components/browser-pane/annotate/useGrabMode.ts
+++ b/src/renderer/src/components/browser-pane/annotate/useGrabMode.ts
@@ -255,7 +255,9 @@ export function useGrabMode(browserPageId: string): GrabModeHook {
             : null
         if (
           isEditableKeyboardTarget(e.target) ||
-          element?.closest('[data-slot="select-trigger"], [data-slot="select-content"]')
+          element?.closest(
+            '[data-slot="select-trigger"], [data-slot="select-content"], [data-slot="annotation-edit"]'
+          )
         ) {
           return
         }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15257,6 +15257,18 @@
                   }
                 }
               }
+            },
+            "browser": {
+              "page": {
+                "annotation": {
+                  "tray": {
+                    "09a7c1df70": "Edit annotation {{value0}}",
+                    "c16f932cb3": "Save",
+                    "024467ceac": "Cancel",
+                    "449d2c2629": "Annotation intent"
+                  }
+                }
+              }
             }
           },
           "navigate": {

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -467,6 +467,61 @@ describe('createBrowserSlice annotations', () => {
     expect(stored?.comment).toHaveLength(GRAB_BUDGET.annotationCommentMaxLength)
     expect(stored?.payload.screenshot).toBeNull()
   })
+
+  it('updates an existing annotation comment and intent', () => {
+    const store = createTestStore()
+    const tab = store.getState().createBrowserTab('wt-1', 'https://example.com')
+    const pageId = tab.activePageId
+    if (!pageId) {
+      throw new Error('Expected a new browser page')
+    }
+    store.getState().addBrowserPageAnnotation(makeAnnotation(pageId))
+
+    store
+      .getState()
+      .updateBrowserPageAnnotation(pageId, 'annotation-1', { comment: 'Updated', intent: 'change' })
+
+    const stored = store.getState().browserAnnotationsByPageId[pageId]?.[0]
+    expect(stored?.comment).toBe('Updated')
+    expect(stored?.intent).toBe('change')
+  })
+
+  it('sanitizes an oversized comment when updating an annotation', () => {
+    const store = createTestStore()
+    const tab = store.getState().createBrowserTab('wt-1', 'https://example.com')
+    const pageId = tab.activePageId
+    if (!pageId) {
+      throw new Error('Expected a new browser page')
+    }
+    store.getState().addBrowserPageAnnotation(makeAnnotation(pageId))
+    const oversizedComment = 'a'.repeat(GRAB_BUDGET.annotationCommentMaxLength + 10)
+
+    store.getState().updateBrowserPageAnnotation(pageId, 'annotation-1', {
+      comment: oversizedComment,
+      intent: 'fix'
+    })
+
+    const stored = store.getState().browserAnnotationsByPageId[pageId]?.[0]
+    expect(stored?.comment).toHaveLength(GRAB_BUDGET.annotationCommentMaxLength)
+  })
+
+  it('is a no-op when updating an annotation id that does not exist', () => {
+    const store = createTestStore()
+    const tab = store.getState().createBrowserTab('wt-1', 'https://example.com')
+    const pageId = tab.activePageId
+    if (!pageId) {
+      throw new Error('Expected a new browser page')
+    }
+    store.getState().addBrowserPageAnnotation(makeAnnotation(pageId))
+    const stateBefore = store.getState()
+
+    store.getState().updateBrowserPageAnnotation(pageId, 'missing-annotation', {
+      comment: 'Updated',
+      intent: 'change'
+    })
+
+    expect(store.getState()).toBe(stateBefore)
+  })
 })
 
 describe('createBrowserSlice floating tabs', () => {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -15,7 +15,11 @@ import type {
   BrowserWorkspace
 } from '../../../../shared/browser-workspace-types'
 import type { WorkspaceSessionState } from '../../../../shared/workspace-session-state-types'
-import { GRAB_BUDGET, type BrowserPageAnnotation } from '../../../../shared/browser-grab-types'
+import {
+  GRAB_BUDGET,
+  type BrowserAnnotationIntent,
+  type BrowserPageAnnotation
+} from '../../../../shared/browser-grab-types'
 import {
   clearClientHostedBrowserCloseIntents,
   isDurableClientHostedBrowserHandle,
@@ -315,6 +319,11 @@ export type BrowserSlice = {
     viewportPresetId: BrowserViewportPresetId | null
   ) => void
   addBrowserPageAnnotation: (annotation: BrowserPageAnnotation) => void
+  updateBrowserPageAnnotation: (
+    pageId: string,
+    annotationId: string,
+    patch: { comment: string; intent: BrowserAnnotationIntent }
+  ) => void
   deleteBrowserPageAnnotation: (pageId: string, annotationId: string) => void
   clearBrowserPageAnnotations: (pageId: string) => void
   hydrateBrowserSession: (
@@ -1842,6 +1851,24 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
         browserAnnotationsByPageId: {
           ...s.browserAnnotationsByPageId,
           [annotation.browserPageId]: next
+        }
+      }
+    }),
+
+  updateBrowserPageAnnotation: (pageId, annotationId, patch) =>
+    set((s) => {
+      const existing = s.browserAnnotationsByPageId[pageId] ?? []
+      const target = existing.find((annotation) => annotation.id === annotationId)
+      if (!target) {
+        return s
+      }
+      const updated = sanitizeBrowserPageAnnotation({ ...target, ...patch })
+      return {
+        browserAnnotationsByPageId: {
+          ...s.browserAnnotationsByPageId,
+          [pageId]: existing.map((annotation) =>
+            annotation.id === annotationId ? updated : annotation
+          )
         }
       }
     }),


### PR DESCRIPTION
## ELI5

When you annotate an element in the embedded browser and make a typo, the only way to fix it today is to delete the annotation and re-pick the element on the page. This PR adds a small pencil button to each annotation row in the tray: click it, fix the text or intent right there, save. The element you picked stays picked.

## What Changed

- New store action `updateBrowserPageAnnotation(pageId, annotationId, patch)` next to the existing add/delete/clear actions. It no-ops (same state reference) when the id is missing and runs the merged annotation through the existing `sanitizeBrowserPageAnnotation`, so edits obey the same comment length budget as adds.
- Each tray row gets a hover-revealed edit button beside the delete button. It swaps the row to an inline editor: a textarea seeded with the current comment, the intent toggle seeded with the current intent, and Save/Cancel. The screen submit shortcut saves, Escape cancels, Save is disabled while the trimmed comment is empty, and only one row edits at a time. If the annotation is deleted or the list cleared mid-edit, the edit state drops safely.
- The annotate mode's window-level capture keydown listener gains an exemption for the edit container (marked `data-slot="annotation-edit"`), so Escape cancels only the row edit instead of tearing down the whole annotate session. A capture listener fires before descendant React handlers, so this cannot be solved with `stopPropagation` from inside the row.
- Handler is threaded through the existing overlay props, so both surfaces that render the tray (browser pane and HTML doc preview) get the feature with no surface-specific code.
- Four new machine-minted localization keys for the new strings (minted via the repo's extraction script, catalog checks pass).

Deliberately untouched: annotation element targets, cross-navigation persistence, and `browser-annotation-output.ts` (the send/copy builder reads comment and intent live off the array, so edited text flows through with no change).

## Why

Annotations queue up feedback for an agent; a typo or a wrong intent choice currently costs the whole annotation, including the picked element. Inline editing preserves the target and keeps the review flow moving. Editing lives in the tray row rather than re-opening the anchored composer because the compose popover's anchor geometry is only guaranteed while an add is pending; the inline row edit avoids that entire class of stale-anchor problems.

## Linked Issue

Fixes #17501

## Visual Proof

Before and after screenshots attached (before: hover reveals only delete; after: hover reveals edit + delete; after: the row in inline edit mode).
<img width="1920" height="1020" alt="annotation-edit-before" src="https://github.com/user-attachments/assets/581e98bf-14db-402c-ad41-da8192cb6e25" />

<img width="1920" height="1020" alt="annotation-edit-after-hover" src="https://github.com/user-attachments/assets/efb8f25f-0d4b-4137-88e8-3ae20905265a" />

<img width="1920" height="1020" alt="annotation-edit-after-editing" src="https://github.com/user-attachments/assets/6a367706-a737-405b-a0f2-f48fa2e034f9" />


## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Manually verified on Windows in the dev app: pencil appears on hover, editing seeds current values, save updates the row and the copied feedback, cancel and Escape leave the annotation unchanged, Escape does not exit annotate mode.

Automated: 3 new store tests (update merges and sanitizes like add; nonexistent id is a strict no-op) and a new component test for the tray (seeded editor, save passes trimmed comment and chosen intent, cancel restores the read view, Escape regression). Full targeted suite: 83 tests across 12 files pass. Typecheck passes for node, web, and cli projects; oxlint clean on changed files; max-lines ratchet clean; localization catalog, extraction, and coverage checks pass.

## AI Disclosure

Built with Claude Code (Claude Fable 5). The implementation, tests, and an adversarial review pass were AI-generated under human direction and manual verification; the feature was manually tested in the running app by the author.

## Review

AI code-review summary (adversarial pass over the diff):
- Cross-platform: renderer-only change; no platform APIs, shortcuts use the existing `isScreenSubmitShortcut` helper which already handles the Mac/Windows modifier split.
- SSH/remote and agent compatibility: no wire, RPC, or host-side changes; the send/copy prompt content is produced by the untouched output builder.
- Performance: state updates are targeted array maps behind an id lookup; no new subscriptions or effects in hot paths.
- UI: shadcn primitives and existing tray patterns reused; a11y labels on the new controls (edit button and textarea both labeled); two review findings (Escape swallowed by a window-level capture listener, unlabeled textarea) were found and fixed before this PR.
- Security: no new inputs cross a trust boundary; edited comments pass through the same sanitizer and length budget as added ones.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No security, SSH, mobile, or backwards-compatibility surface is touched; the change is confined to the renderer's annotate components and one store slice. The one subtle interaction (annotate mode's global Escape handling) is covered by a dedicated regression test.

## Author

X: [@Sahir__S](https://x.com/Sahir__S)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
