### PR TITLE
perf(mobile): index slept worktree identity lookups

### DIFF
--- a/mobile/src/worktree/worktree-host-row-identity.test.ts
+++ b/mobile/src/worktree/worktree-host-row-identity.test.ts
@@ -60,6 +60,47 @@ describe('host-qualified row display state', () => {
     expect([...retained]).toEqual([getWorktreeRowIdentity(remote)])
   })
 
+  it('keeps first-match behavior when confirmed identities are duplicated', () => {
+    const identity = getWorktreeRowIdentity(row('shared', 'host-a'))
+    const retained = retainLiveSleptWorktreeIdentities(new Set([identity]), [
+      row('shared', 'host-a', { liveTerminalCount: 0 }),
+      row('shared', 'host-a', { liveTerminalCount: 1 })
+    ])
+
+    expect([...retained]).toEqual([])
+  })
+
+  it('indexes confirmed identities once instead of rescanning for every slept row', () => {
+    const rowCount = 64
+    let worktreeIdReads = 0
+    const confirmed = Array.from({ length: rowCount }, (_, index) => {
+      const worktree = {
+        hostId: `host-${index}`,
+        liveTerminalCount: 1
+      } as Worktree
+      Object.defineProperty(worktree, 'worktreeId', {
+        configurable: true,
+        get: () => {
+          worktreeIdReads += 1
+          return `worktree-${index}`
+        }
+      })
+      return worktree
+    })
+    const previous = new Set(
+      Array.from({ length: rowCount }, (_, index) => {
+        const reversed = rowCount - index - 1
+        return `host-${reversed}|worktree-${reversed}`
+      })
+    )
+
+    expect(retainLiveSleptWorktreeIdentities(previous, confirmed)).toBe(previous)
+    const legacyIdentityReads = (rowCount * (rowCount + 1)) / 2
+    expect(legacyIdentityReads).toBe(2_080)
+    expect(worktreeIdReads).toBe(rowCount)
+    expect(legacyIdentityReads - worktreeIdReads).toBe(2_016)
+  })
+
   it('applies active and slept overrides to the matching host row only', () => {
     const local = row('shared', 'host-a')
     const remote = row('shared', 'host-b')

--- a/mobile/src/worktree/worktree-host-row-identity.ts
+++ b/mobile/src/worktree/worktree-host-row-identity.ts
@@ -38,9 +38,17 @@ export function retainLiveSleptWorktreeIdentities(
   if (previous.size === 0) {
     return previous
   }
+  const confirmedByIdentity = new Map<string, Worktree>()
+  for (const worktree of confirmed) {
+    const identity = getWorktreeRowIdentity(worktree)
+    // The former Array#find path was first-match-wins for duplicate identities; retain that contract.
+    if (!confirmedByIdentity.has(identity)) {
+      confirmedByIdentity.set(identity, worktree)
+    }
+  }
   const still = new Set<string>()
   for (const id of previous) {
-    const wt = confirmed.find((w) => getWorktreeRowIdentity(w) === id)
+    const wt = confirmedByIdentity.get(id)
     if (wt && wt.liveTerminalCount > 0) {
       still.add(id)
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 |

<!-- /orca-pr-loc -->

## ELI5

When the mobile host screen remembers which sleeping worktrees still have live terminals, it used to search the whole confirmed list again for every remembered row. The refresh now builds one host-qualified lookup table and checks each remembered row directly.

## What Changed

- Build a first-match-wins `Map` of confirmed host-qualified worktree identities once per refresh.
- Preserve the existing behavior for duplicate identities, host-qualified rows, empty state, and referential reuse when every row remains live.
- Add a deterministic scale test covering duplicate rows and the former nested-scan shape.

## Performance Measurement

Reproduce with:

```sh
pnpm --dir mobile test src/worktree/worktree-host-row-identity.test.ts --run
```

Fixture: 64 remembered slept-row identities and 64 confirmed rows arranged so the former `Array.find` checks the last candidate first for every lookup.

- Before: 2,080 identity computations (64 + 63 + ... + 1).
- After: 64 identity computations to build the index, followed by constant-time map reads.
- Improvement: 2,016 fewer identity computations, a 96.9% reduction; lookup work changes from quadratic to linear as remembered rows grow.

## User-Facing Trade-offs

None. Host-qualified matching, first-duplicate behavior, returned Set identity, and slept-terminal retention are unchanged.

## Compatibility / Scope

This is mobile-side bookkeeping only. It applies equally to local, SSH, and folder-workspace host rows; no RPC parameters, stream frames, or wire capabilities changed.

## Testing

- `pnpm --dir mobile test src/worktree/worktree-host-row-identity.test.ts --run` — 8 passed
- `pnpm --dir mobile typecheck`
- `pnpm exec oxlint mobile/src/worktree/worktree-host-row-identity.ts mobile/src/worktree/worktree-host-row-identity.test.ts`
- `pnpm exec oxfmt --check mobile/src/worktree/worktree-host-row-identity.ts mobile/src/worktree/worktree-host-row-identity.test.ts`
- `git diff --check`

## Visual Proof

N/A — no visual or layout change.