### PR TITLE
Speed up CI dependency and computer E2E setup

### DIFF
--- a/.github/actions/install-node-dependencies/action.yml
+++ b/.github/actions/install-node-dependencies/action.yml
@@ -1,5 +1,5 @@
 name: Install Node dependencies
-description: Installs the Node toolchain and repository dependencies for CI jobs.
+description: Installs the Node toolchain and repository dependencies for CI jobs, with optional Electron archive caching.
 
 inputs:
   native-runtime:
@@ -14,6 +14,10 @@ inputs:
     description: Save restored native modules at job end. Set false when a later step overwrites the same path with a different ABI.
     required: false
     default: 'true'
+  cache-electron-package:
+    description: Cache the Electron package archive and export ELECTRON_CACHE for following steps.
+    required: false
+    default: 'false'
 
 outputs:
   node-version:
@@ -22,6 +26,9 @@ outputs:
   native-cache-scope:
     description: Operating-system image scope used by the native module cache.
     value: ${{ steps.native-cache-scope.outputs.scope }}
+  native-cache-hit:
+    description: Whether the compiled native module cache was restored.
+    value: ${{ steps.native-cache-restore.outputs.cache-hit || steps.native-cache-restore-only.outputs.cache-hit }}
 
 runs:
   using: composite
@@ -90,6 +97,32 @@ runs:
           git -C "$GITHUB_WORKSPACE" diff --exit-code -- package.json pnpm-lock.yaml pnpm-workspace.yaml
         fi
 
+    - name: Resolve Electron package cache
+      id: electron-package-cache
+      if: inputs.native-runtime == 'electron' || inputs.cache-electron-package == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "$RUNNER_OS" in
+          Linux) cache_root="$HOME/.cache/electron" ;;
+          macOS) cache_root="$HOME/Library/Caches/electron" ;;
+          Windows) cache_root="${LOCALAPPDATA:-$HOME/AppData/Local}/electron/Cache" ;;
+          *)
+            echo "::error::Unsupported runner OS for Electron cache: $RUNNER_OS"
+            exit 2
+            ;;
+        esac
+        printf 'cache-root=%s\n' "$cache_root" >> "$GITHUB_OUTPUT"
+        printf 'ELECTRON_CACHE=%s\n' "$cache_root" >> "$GITHUB_ENV"
+        printf 'version=%s\n' "$(node -p "require('./node_modules/electron/package.json').version")" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Electron package archive
+      if: inputs.native-runtime == 'electron' || inputs.cache-electron-package == 'true'
+      uses: actions/cache@v5
+      with:
+        path: ${{ steps.electron-package-cache.outputs.cache-root }}
+        key: electron-package-${{ runner.os }}-${{ runner.arch }}-${{ steps.electron-package-cache.outputs.version }}
+
     # Why cached: `--ignore-scripts` leaves node-pty without build/Release, so
     # ensure-native-runtime node-gyp-compiles it in every job that asks for a runtime.
     # The artifacts are ABI-bound, so the key carries the target runtime, the resolved
@@ -112,6 +145,7 @@ runs:
         echo "scope=$scope" >> "$GITHUB_OUTPUT"
 
     - name: Restore compiled native modules
+      id: native-cache-restore
       if: inputs.native-runtime != 'none' && inputs.persist-native-cache != 'false'
       uses: actions/cache@v5
       with:
@@ -119,9 +153,10 @@ runs:
           node_modules/.pnpm/node-pty@*/node_modules/node-pty/build
           node_modules/.pnpm/windows-native-registry@*/node_modules/windows-native-registry/build
           node_modules/.pnpm/@vscode+windows-process-tree@*/node_modules/@vscode/windows-process-tree/build
-        key: native-modules-${{ runner.os }}-${{ steps.native-cache-scope.outputs.scope }}-${{ runner.arch }}-${{ inputs.native-runtime }}-node${{ steps.default-node.outputs.node-version }}${{ steps.requested-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml', '.github/actions/install-node-dependencies/action.yml', 'config/scripts/ensure-native-runtime.mjs', 'config/scripts/rebuild-native-deps.mjs', 'config/patches/node-pty@1.1.0.patch', 'config/patches/@vscode__windows-process-tree@0.8.0.patch') }}
+        key: native-modules-${{ runner.os }}-${{ steps.native-cache-scope.outputs.scope }}-${{ runner.arch }}-${{ inputs.native-runtime }}-node${{ steps.requested-node.outputs.node-version || steps.default-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml', '.github/actions/install-node-dependencies/action.yml', 'config/scripts/ensure-native-runtime.mjs', 'config/scripts/rebuild-native-deps.mjs', 'config/patches/node-pty@1.1.0.patch', 'config/patches/@vscode__windows-process-tree@0.8.0.patch') }}
 
     - name: Restore compiled native modules without saving
+      id: native-cache-restore-only
       if: inputs.native-runtime != 'none' && inputs.persist-native-cache == 'false'
       uses: actions/cache/restore@v5
       with:
@@ -129,7 +164,7 @@ runs:
           node_modules/.pnpm/node-pty@*/node_modules/node-pty/build
           node_modules/.pnpm/windows-native-registry@*/node_modules/windows-native-registry/build
           node_modules/.pnpm/@vscode+windows-process-tree@*/node_modules/@vscode/windows-process-tree/build
-        key: native-modules-${{ runner.os }}-${{ steps.native-cache-scope.outputs.scope }}-${{ runner.arch }}-${{ inputs.native-runtime }}-node${{ steps.default-node.outputs.node-version }}${{ steps.requested-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml', '.github/actions/install-node-dependencies/action.yml', 'config/scripts/ensure-native-runtime.mjs', 'config/scripts/rebuild-native-deps.mjs', 'config/patches/node-pty@1.1.0.patch', 'config/patches/@vscode__windows-process-tree@0.8.0.patch') }}
+        key: native-modules-${{ runner.os }}-${{ steps.native-cache-scope.outputs.scope }}-${{ runner.arch }}-${{ inputs.native-runtime }}-node${{ steps.requested-node.outputs.node-version || steps.default-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml', '.github/actions/install-node-dependencies/action.yml', 'config/scripts/ensure-native-runtime.mjs', 'config/scripts/rebuild-native-deps.mjs', 'config/patches/node-pty@1.1.0.patch', 'config/patches/@vscode__windows-process-tree@0.8.0.patch') }}
 
     - name: Prepare native runtime
       if: inputs.native-runtime != 'none'

--- a/.github/workflows/computer-e2e.yml
+++ b/.github/workflows/computer-e2e.yml
@@ -55,6 +55,10 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+concurrency:
+  group: computer-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   native-smoke:
     if: github.event_name == 'pull_request'
@@ -70,7 +74,7 @@ jobs:
         with:
           persist-credentials: false
       - if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y python3 python3-gi gir1.2-atspi-2.0 at-spi2-core gedit xvfb xclip xdotool
+        run: sudo apt-get update && sudo apt-get install -y python3 python3-gi gir1.2-atspi-2.0 at-spi2-core
       - uses: ./.github/actions/install-node-dependencies
         with:
           native-runtime: node
@@ -118,7 +122,7 @@ jobs:
           src/shared/remote-runtime-client.test.ts
       - run: pnpm verify:computer-native
       - run: pnpm build:cli
-      - run: pnpm build:electron-vite
+      - run: pnpm run build:electron-vite:parallel
       # Why: boot the BUILT daemon-entry under plain Node the way production
       # forks it. v1.4.129-rc.1 shipped a daemon that exited at module load
       # (leaked electron require) while every other check passed; this fails
@@ -174,7 +178,7 @@ jobs:
           native-runtime: electron
       - run: pnpm verify:computer-native
       - run: pnpm build:cli
-      - run: pnpm build:electron-vite
+      - run: pnpm run build:electron-vite:parallel
       - run: xvfb-run --auto-servernum dbus-run-session -- pnpm test:e2e:computer --reporter=verbose tests/e2e/computer-linux.e2e.ts
 
   windows:
@@ -191,5 +195,5 @@ jobs:
           native-runtime: electron
       - run: pnpm verify:computer-native
       - run: pnpm build:cli
-      - run: pnpm build:electron-vite
+      - run: pnpm run build:electron-vite:parallel
       - run: pnpm test:e2e:computer --reporter=verbose tests/e2e/computer-windows.e2e.ts tests/e2e/computer-windows-store.e2e.ts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -215,16 +215,16 @@ jobs:
       - uses: ./.github/actions/install-node-dependencies
 
       # Why: every project is `composite`, so tsc already writes a .tsbuildinfo that lets
-      # the next run skip unchanged files. CI threw it away each time. The key is per-SHA
-      # so each run saves its own; restore-keys inherit the newest prior graph to diff against.
+      # the next run skip unchanged files. Share one cache entry across commits while the
+      # PR base stays stable; actions/cache keeps the first successful graph and the
+      # compiler still invalidates stale files from its content hashes.
       - name: Cache TypeScript incremental state
         uses: actions/cache@v5
         with:
           path: config/*.tsbuildinfo
-          key: tsbuildinfo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'config/tsconfig*.json') }}-${{ github.sha }}
+          key: tsbuildinfo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'config/tsconfig*.json') }}-${{ github.event.pull_request.base.sha }}
           restore-keys: |
             tsbuildinfo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'config/tsconfig*.json') }}-
-            tsbuildinfo-${{ runner.os }}-
 
       - run: pnpm run typecheck
 
@@ -630,9 +630,7 @@ jobs:
       - name: Cache electron-builder downloads
         uses: actions/cache@v5
         with:
-          path: |
-            ~/.cache/electron
-            ~/.cache/electron-builder
+          path: ~/.cache/electron-builder
           key: electron-builder-linux-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             electron-builder-linux-
@@ -723,6 +721,7 @@ jobs:
           persist-native-cache: 'false'
 
       - name: Save compiled Node native modules
+        if: steps.deps.outputs.native-cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           native-runtime: node
           node-version: ${{ matrix.node }}
+          cache-electron-package: 'true'
 
       - name: Install Electron package binary for tests
         run: node config/scripts/install-electron-package-binary.mjs

--- a/config/scripts/computer-e2e-workflow.test.mjs
+++ b/config/scripts/computer-e2e-workflow.test.mjs
@@ -6,6 +6,17 @@ import { parse } from 'yaml'
 const projectDir = resolve(import.meta.dirname, '../..')
 
 describe('computer-use e2e workflow', () => {
+  it('cancels superseded pull request runs without cancelling scheduled runs', () => {
+    const workflow = parse(
+      readFileSync(join(projectDir, '.github/workflows/computer-e2e.yml'), 'utf8')
+    )
+
+    expect(workflow.concurrency).toEqual({
+      group: 'computer-e2e-${{ github.event.pull_request.number || github.ref }}',
+      'cancel-in-progress': "${{ github.event_name == 'pull_request' }}"
+    })
+  })
+
   it('runs computer-use e2e files serially because they share desktop focus', () => {
     const config = readFileSync(join(projectDir, 'tests/e2e/vitest.config.ts'), 'utf8')
 
@@ -121,6 +132,29 @@ describe('computer-use e2e workflow', () => {
     }
   })
 
+  it('keeps Linux native imports available without installing the GUI-only stack in PR smoke', () => {
+    const workflow = parse(
+      readFileSync(join(projectDir, '.github/workflows/computer-e2e.yml'), 'utf8')
+    )
+    const nativeSmokeInstall = workflow.jobs['native-smoke'].steps.find(
+      (step) => step.if === "runner.os == 'Linux'"
+    )
+    const scheduledLinuxInstall = workflow.jobs.linux.steps.find((step) =>
+      step.run?.includes('apt-get install')
+    )
+
+    expect(nativeSmokeInstall.run).toContain('python3')
+    expect(nativeSmokeInstall.run).toContain('python3-gi')
+    expect(nativeSmokeInstall.run).toContain('gir1.2-atspi-2.0')
+    expect(nativeSmokeInstall.run).toContain('at-spi2-core')
+    expect(nativeSmokeInstall.run).not.toContain('gedit')
+    expect(nativeSmokeInstall.run).not.toContain('xvfb')
+    expect(nativeSmokeInstall.run).not.toContain('xdotool')
+    expect(scheduledLinuxInstall.run).toContain('gedit')
+    expect(scheduledLinuxInstall.run).toContain('xvfb')
+    expect(scheduledLinuxInstall.run).toContain('xdotool')
+  })
+
   it('builds and tests the macOS helper on every trigger without hosted TCC e2e', () => {
     const workflow = parse(
       readFileSync(join(projectDir, '.github/workflows/computer-e2e.yml'), 'utf8')
@@ -210,7 +244,7 @@ describe('computer-use e2e workflow', () => {
     )
     const steps = workflow.jobs['native-smoke'].steps
     const runs = steps.map((step) => step.run).filter((run) => typeof run === 'string')
-    const buildIndex = runs.indexOf('pnpm build:electron-vite')
+    const buildIndex = runs.indexOf('pnpm run build:electron-vite:parallel')
     const daemonSmokeIndex = runs.indexOf('node config/scripts/daemon-boot-smoke.mjs')
 
     expect(daemonSmokeIndex, 'native-smoke must boot the built daemon').toBeGreaterThanOrEqual(0)
@@ -226,7 +260,9 @@ describe('computer-use e2e workflow', () => {
       readFileSync(join(projectDir, '.github/workflows/computer-e2e.yml'), 'utf8')
     )
     const steps = workflow.jobs['native-smoke'].steps
-    const buildIndex = steps.findIndex((step) => step.run === 'pnpm build:electron-vite')
+    const buildIndex = steps.findIndex(
+      (step) => step.run === 'pnpm run build:electron-vite:parallel'
+    )
     const reproIndex = steps.findIndex(
       (step) => step.run === 'node config/scripts/windows-daemon-workspace-close-repro.mjs'
     )
@@ -275,7 +311,7 @@ describe('computer-use e2e workflow', () => {
       const runs = workflow.jobs[jobName].steps
         .map((step) => step.run)
         .filter((run) => typeof run === 'string')
-      const buildIndex = runs.indexOf('pnpm build:electron-vite')
+      const buildIndex = runs.indexOf('pnpm run build:electron-vite:parallel')
       const e2eIndexes = runs
         .map((run, index) => (run.includes('test:e2e:computer') ? index : -1))
         .filter((index) => index >= 0)

--- a/config/scripts/install-electron-package-binary.mjs
+++ b/config/scripts/install-electron-package-binary.mjs
@@ -125,7 +125,9 @@ function repairElectronPathFile() {
 async function installElectronPackageBinary() {
   const electronDistDir = resolve(electronPackageDir, 'dist')
   const tempDir = mkdtempSync(resolve(tmpdir(), 'orca-electron-'))
-  const cacheRoot = join(tempDir, 'cache')
+  const persistentCacheRoot =
+    process.env.ORCA_ELECTRON_PACKAGE_CACHE_ROOT || process.env.ELECTRON_CACHE || null
+  const cacheRoot = persistentCacheRoot ?? join(tempDir, 'cache')
   const extractDir = join(tempDir, 'extract')
 
   try {
@@ -135,11 +137,13 @@ async function installElectronPackageBinary() {
       platform: targetPlatform,
       arch: targetArch,
       cacheRoot,
-      force: true,
+      force: !persistentCacheRoot,
       tempDirectory: tempDir,
       ...(shouldUseRemoteChecksums() ? {} : { checksums: electronRequire('./checksums.json') })
     }
-    const zipPath = await downloadElectronArtifactWithRetry(downloadOptions)
+    const zipPath = await downloadElectronArtifactWithRetry(downloadOptions, {
+      cacheRootIsPersistent: Boolean(persistentCacheRoot)
+    })
 
     // Why: CI has observed partial extracts directly under node_modules/electron
     // that leave only dist/locales. Verify in temp before replacing package dist.
@@ -159,7 +163,7 @@ async function installElectronPackageBinary() {
   }
 }
 
-async function downloadElectronArtifactWithRetry(downloadOptions) {
+async function downloadElectronArtifactWithRetry(downloadOptions, { cacheRootIsPersistent }) {
   const retryDelays = getDownloadRetryDelays()
 
   for (let attempt = 0; ; attempt += 1) {
@@ -175,7 +179,9 @@ async function downloadElectronArtifactWithRetry(downloadOptions) {
         `[electron-package] Transient Electron download failure (${formatDownloadError(error)}); ` +
           `retrying in ${retryDelay}ms (${attempt + 2}/${retryDelays.length + 1}).`
       )
-      rmSync(downloadOptions.cacheRoot, { recursive: true, force: true })
+      if (!cacheRootIsPersistent) {
+        rmSync(downloadOptions.cacheRoot, { recursive: true, force: true })
+      }
       await new Promise((resolveDelay) => setTimeout(resolveDelay, retryDelay))
     }
   }

--- a/config/scripts/install-electron-package-binary.test.mjs
+++ b/config/scripts/install-electron-package-binary.test.mjs
@@ -38,6 +38,7 @@ describe('install-electron-package-binary', () => {
       expect(readFileSync(join(projectDir, 'electron-get.log'), 'utf8')).toMatch(
         /cacheRoot=.*orca-electron-.*cache/
       )
+      expect(readFileSync(join(projectDir, 'electron-get.log'), 'utf8')).toContain('force=true')
       expect(readFileSync(join(projectDir, 'node_modules', 'electron', 'path.txt'), 'utf8')).toBe(
         'electron'
       )
@@ -74,6 +75,29 @@ describe('install-electron-package-binary', () => {
       )
       expect(result.stdout).toContain('Repaired Electron path.txt -> electron')
       expect(existsSync(join(projectDir, 'electron-get.log'))).toBe(false)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('reuses a configured persistent cache without forcing a fresh download', () => {
+    const projectDir = mkTempProject()
+    const cacheRoot = join(projectDir, 'electron-cache')
+
+    try {
+      writeFakeElectronPackage(projectDir)
+      writeFakeElectronGet(projectDir)
+      writeFakeExtractor(projectDir, { createExecutable: true })
+
+      const result = runInstallScript(projectDir, {
+        ORCA_ELECTRON_PACKAGE_CACHE_ROOT: cacheRoot
+      })
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(readFileSync(join(projectDir, 'electron-get.log'), 'utf8')).toContain(
+        `cacheRoot=${cacheRoot} platform=linux arch=x64 force=false`
+      )
+      expect(existsSync(cacheRoot)).toBe(true)
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }
@@ -200,6 +224,33 @@ describe('install-electron-package-binary', () => {
         readFileSync(join(projectDir, 'electron-get.log'), 'utf8').trim().split('\n')
       ).toHaveLength(2)
       expect(result.stderr).toContain('Transient Electron download failure (ECONNRESET)')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps a persistent cache root while retrying transient failures', () => {
+    const projectDir = mkTempProject()
+    const cacheRoot = join(projectDir, 'electron-cache')
+
+    try {
+      writeFakeElectronPackage(projectDir)
+      writeFakeElectronGet(projectDir, {
+        downloadFailures: 1,
+        downloadErrorCode: 'ECONNRESET'
+      })
+      writeFakeExtractor(projectDir, { createExecutable: true })
+      mkdirSync(cacheRoot, { recursive: true })
+      writeFileSync(join(cacheRoot, 'preserved.marker'), 'keep me')
+
+      const result = runInstallScript(projectDir, {
+        ORCA_ELECTRON_PACKAGE_CACHE_ROOT: cacheRoot,
+        ORCA_ELECTRON_PACKAGE_RETRY_DELAYS_MS: '0,0'
+      })
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(existsSync(join(cacheRoot, 'preserved.marker'))).toBe(true)
+      expect(readFileSync(join(projectDir, 'electron-get.log'), 'utf8').trim().split('\n')).toHaveLength(2)
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }
@@ -385,6 +436,8 @@ function runInstallScript(projectDir, extraEnv = {}) {
     encoding: 'utf8',
     env: {
       ...process.env,
+      ELECTRON_CACHE: undefined,
+      ORCA_ELECTRON_PACKAGE_CACHE_ROOT: undefined,
       npm_config_platform: 'linux',
       npm_config_arch: 'x64',
       ORCA_ELECTRON_PACKAGE_EXTRACTOR: join(projectDir, 'fake-extractor.cjs'),
@@ -450,7 +503,7 @@ exports.downloadArtifact = async function downloadArtifact(details) {
   downloadAttempt += 1
   appendFileSync(
     'electron-get.log',
-    'cacheRoot=' + details.cacheRoot + ' platform=' + details.platform + ' arch=' + details.arch + '\\n'
+    'cacheRoot=' + details.cacheRoot + ' platform=' + details.platform + ' arch=' + details.arch + ' force=' + details.force + '\\n'
   )
   if (${JSON.stringify(downloadNeverSettles)}) {
     return new Promise(() => {})

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -72,6 +72,7 @@ describe('PR workflow parallelism', () => {
     )
     expect(sharedTest.strategy.matrix.shard_total).toEqual([8])
     expect(installStep.with['node-version']).toBe('${{ matrix.node }}')
+    expect(installStep.with['cache-electron-package']).toBe('true')
     expect(testStep.run).toContain('--shard=${{ matrix.shard }}/${{ matrix.shard_total }}')
     for (const testFile of nativeShellContractFiles) {
       expect(testStep.run).toContain(`--exclude=${testFile}`)
@@ -283,6 +284,11 @@ describe('PR workflow parallelism', () => {
     expect(installFor('package').with['native-runtime']).toBe('electron')
     expect(installFor('package_windows').with['native-runtime']).toBe('node')
     expect(installFor('package_windows').with['persist-native-cache']).toBe('false')
+    expect(
+      workflow.jobs.package_windows.steps.find(
+        (step) => step.name === 'Save compiled Node native modules'
+      ).if
+    ).toBe("steps.deps.outputs.native-cache-hit != 'true'")
 
     expect(dependencyAction.inputs['persist-native-cache'].default).toBe('true')
     expect(
@@ -351,7 +357,9 @@ describe('PR workflow parallelism', () => {
       expect(cacheStep.with.key).toContain('${{ inputs.native-runtime }}')
       expect(cacheStep.with.key).toContain('${{ runner.os }}')
       expect(cacheStep.with.key).toContain('${{ runner.arch }}')
-      expect(cacheStep.with.key).toContain('steps.requested-node.outputs.node-version')
+      expect(cacheStep.with.key).toContain(
+        'steps.requested-node.outputs.node-version || steps.default-node.outputs.node-version'
+      )
       expect(cacheStep.with.key).toContain('steps.native-cache-scope.outputs.scope')
       expect(cacheStep.with.key).toContain('config/patches/node-pty@1.1.0.patch')
       expect(cacheStep.with.key).toContain(
@@ -365,12 +373,31 @@ describe('PR workflow parallelism', () => {
       expect(cacheStep.with.path).toContain('@vscode+windows-process-tree@')
       expect(cacheStep.with['restore-keys']).toBeUndefined()
     }
+    expect(steps[cacheIndex].id).toBe('native-cache-restore')
+    expect(restoreOnly.id).toBe('native-cache-restore-only')
     const cacheScope = steps.find((step) => step.name === 'Resolve native cache scope')
     expect(cacheScope.if).toBe("inputs.native-runtime != 'none'")
     expect(cacheScope.run).toContain('/etc/os-release')
     expect(dependencyAction.outputs['native-cache-scope'].value).toBe(
       '${{ steps.native-cache-scope.outputs.scope }}'
     )
+    expect(dependencyAction.outputs['native-cache-hit'].value).toContain(
+      'steps.native-cache-restore.outputs.cache-hit'
+    )
+    expect(dependencyAction.outputs['native-cache-hit'].value).toContain(
+      'steps.native-cache-restore-only.outputs.cache-hit'
+    )
+    const electronCache = steps.find((step) => step.name === 'Cache Electron package archive')
+    const electronCacheResolution = steps.find(
+      (step) => step.name === 'Resolve Electron package cache'
+    )
+    expect(electronCacheResolution.if).toBe(
+      "inputs.native-runtime == 'electron' || inputs.cache-electron-package == 'true'"
+    )
+    expect(electronCache.if).toBe(electronCacheResolution.if)
+    expect(electronCache.uses).toBe('actions/cache@v5')
+    expect(electronCache.with.key).toContain('steps.electron-package-cache.outputs.version')
+    expect(dependencyAction.inputs['cache-electron-package'].default).toBe('false')
   })
 
   it('reuses TypeScript incremental state across typecheck runs', () => {
@@ -381,13 +408,15 @@ describe('PR workflow parallelism', () => {
     expect(cacheIndex).toBeGreaterThanOrEqual(0)
     expect(cacheIndex).toBeLessThan(checkIndex)
     expect(steps[cacheIndex].with.path).toBe('config/*.tsbuildinfo')
-    // Why restore-keys matter here: an exact-key miss is the normal case (the key is
-    // per-SHA), so without them the cache would never once be read.
+    // Why restore-keys matter here: the base SHA key is shared by every commit in a PR,
+    // but actions/cache keeps the first successful graph until the base or config changes.
     expect(steps[cacheIndex].with['restore-keys']).toBeTruthy()
     // The buildinfo is only reusable while the compiler options that produced it hold.
     expect(steps[cacheIndex].with.key).toContain(
       "hashFiles('pnpm-lock.yaml', 'config/tsconfig*.json')"
     )
+    expect(steps[cacheIndex].with.key).toContain('github.event.pull_request.base.sha')
+    expect(steps[cacheIndex].with['restore-keys']).not.toContain('tsbuildinfo-${{ runner.os }}-\n')
   })
 
   it('checks out full history without historical blobs', () => {


### PR DESCRIPTION
## Summary

- Cache Electron package archives across CI jobs and platforms instead of downloading the archive into a disposable cache on every job.
- Expose native cache-hit state so Windows packaging skips an unnecessary cache save, and make native cache keys use the same resolved Node version expression everywhere.
- Reuse the TypeScript incremental cache across commits sharing a PR base and remove the broad incompatible fallback.
- Cancel superseded computer-E2E PR runs, trim GUI-only Linux smoke dependencies while retaining AT-SPI imports, and use the parallel Electron-Vite build.

The investigation found the PR merge path around 6.5 minutes and the full advisory fan-out around 21.5 minutes. Electron setup was repeated across roughly a dozen jobs; computer-E2E had no PR concurrency cancellation; and computer-E2E builds used the serial Electron-Vite target runner.

## Validation

- `node --check` passed for all modified `.mjs` files.
- `git diff --check` passed.
- `install-electron-package-binary.test.mjs`: 16 passed via Vitest.
- `computer-e2e-workflow.test.mjs`: 17 passed via Vitest.
- Changed PR workflow contract tests: 4 targeted tests passed. The full PR contract file has one pre-existing Windows path-separator failure in this Windows checkout.
- Full `pnpm` validation was unavailable because the local pnpm executable is missing and dependencies are not installed.

Generated with read-only CI reviews from multiple sub-agents; their findings were incorporated, including retaining the AT-SPI packages required by `verify:computer-native`.