### PR TITLE
fix(agents): preserve manual mode for newly added defaults

### DIFF
--- a/src/main/persistence/applying-settings/terminal-settings-migrations.test.ts
+++ b/src/main/persistence/applying-settings/terminal-settings-migrations.test.ts
@@ -9,7 +9,7 @@ describe('migrateAgentYoloDefaults', () => {
       agentDefaultEnv: {}
     } as never)
 
-    expect(migrated.agentDefaultArgs.droid).toBe('')
-    expect(migrated.agentDefaultEnv.goose).toEqual({})
+    expect(migrated.agentDefaultArgs?.droid).toBe('')
+    expect(migrated.agentDefaultEnv?.goose).toEqual({})
   })
 })

--- a/src/main/persistence/applying-settings/terminal-settings-migrations.test.ts
+++ b/src/main/persistence/applying-settings/terminal-settings-migrations.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { migrateAgentYoloDefaults } from './terminal-settings-migrations'
+
+describe('migrateAgentYoloDefaults', () => {
+  it('keeps newly added agent defaults manual for already migrated profiles', () => {
+    const migrated = migrateAgentYoloDefaults({
+      agentYoloDefaultsMigrated: true,
+      agentDefaultArgs: { claude: '--dangerously-skip-permissions' },
+      agentDefaultEnv: {}
+    } as never)
+
+    expect(migrated.agentDefaultArgs.droid).toBe('')
+    expect(migrated.agentDefaultEnv.goose).toEqual({})
+  })
+})

--- a/src/main/persistence/applying-settings/terminal-settings-migrations.ts
+++ b/src/main/persistence/applying-settings/terminal-settings-migrations.ts
@@ -124,6 +124,18 @@ export function migrateAgentYoloDefaults(
   const existingArgs = normalizeTuiAgentArgsRecord(settings?.agentDefaultArgs)
   const existingEnv = normalizeTuiAgentEnvRecord(settings?.agentDefaultEnv)
   if (settings?.agentYoloDefaultsMigrated === true) {
+    // Keep newly added agents manual for profiles migrated by an older build.
+    // Missing keys otherwise fall through to the current (possibly yolo) defaults.
+    for (const agent of Object.keys(DEFAULT_TUI_AGENT_ARGS)) {
+      if (!(agent in existingArgs)) {
+        existingArgs[agent as keyof typeof DEFAULT_TUI_AGENT_ARGS] = ''
+      }
+    }
+    for (const agent of Object.keys(DEFAULT_TUI_AGENT_ENV)) {
+      if (!(agent in existingEnv)) {
+        existingEnv[agent as keyof typeof DEFAULT_TUI_AGENT_ENV] = {}
+      }
+    }
     return {
       agentDefaultArgs: existingArgs,
       agentDefaultEnv: existingEnv,

--- a/src/shared/tui-agent-permissions.ts
+++ b/src/shared/tui-agent-permissions.ts
@@ -28,7 +28,8 @@ export const YOLO_TUI_AGENT_ARGS: Partial<Record<TuiAgent, string>> = {
   grok: '--permission-mode bypassPermissions',
   devin: '--permission-mode bypass',
   ante: '--yolo',
-  trae: '--yolo'
+  trae: '--yolo',
+  droid: '--auto high'
 }
 
 export const YOLO_TUI_AGENT_ENV: Partial<Record<TuiAgent, Record<string, string>>> = {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 |

<!-- /orca-pr-loc -->

## Summary
- add Droid’s `--auto high` argument to Yolo agent defaults
- backfill missing defaults as manual for profiles already marked migrated
- add regression coverage for the migration path

## Why
Without the backfill, an existing profile with `agentYoloDefaultsMigrated: true` and no Droid entry could launch Droid with the new high-autonomy flag while the UI still represented it as manual.

## Validation
- `pnpm tc:node`
- `pnpm tc:web`
- `pnpm test src/main/persistence/applying-settings/terminal-settings-migrations.test.ts`
- oxlint/pre-commit checks passed

## Contributor credit
Original Droid Yolo mapping proposed by @SudoAI-DEV in #17505.

Co-authored-by: SudoAI-DEV <220139811+SudoAI-DEV@users.noreply.github.com>