### PR TITLE
fix(settings): let Escape close settings from the search field

### DIFF
--- a/src/cli/specs/orchestration-worker-specs.ts
+++ b/src/cli/specs/orchestration-worker-specs.ts
@@ -29,6 +29,7 @@ export const ORCHESTRATION_WORKER_COMMAND_SPECS: CommandSpec[] = [
     ],
     notes: [
       'Current and existing worktrees never rerun setup; a fresh agent terminal is created unless --terminal is explicit.',
+      'When reusing --terminal, pass --worktree for that terminal; current means the coordinator worktree.',
       '--model supports Claude, Codex, and Cursor opaque provider model ids; --effort requires --model. Neither can combine with --terminal.',
       'New worktrees use agent-first creation and default --setup to run. Repository start-immediately runs setup beside the agent; wait-for-setup gates agent readiness and task input.',
       'Creation flags (--name, --repo, --base-branch, --display-name, --comment, --setup) are rejected for current/existing worktrees. Use exact --repo on the selected server; project/host convenience routing remains on worktree create.',

--- a/src/renderer/src/components/settings/use-settings-page-effects.ts
+++ b/src/renderer/src/components/settings/use-settings-page-effects.ts
@@ -16,7 +16,6 @@ import type { SettingsStoreModel } from './use-settings-store-model'
 import type { SettingsInteractionController } from './use-settings-interaction-controller'
 import {
   getSettingsSectionId,
-  isEditableTarget,
   SHORTCUTS_ESCAPE_CONFIRM_TOAST_ID,
   SHORTCUTS_ESCAPE_CONFIRM_WINDOW_MS
 } from './settings-navigation-foundations'
@@ -89,8 +88,8 @@ export function useSettingsPageEffects(
       if (hasVisibleOverlay()) {
         return
       }
-      // Why: Escape in an editable control means "cancel this edit", not "close Settings" — defer to the field's own handler.
-      if (isEditableTarget(event.target)) {
+      // Why: IME composition owns Escape; ordinary controls should still close Settings.
+      if (event.isComposing) {
         return
       }
       if (activeSectionId === 'shortcuts') {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | 0 |

<!-- /orca-pr-loc -->

## Summary
- allow Settings-level Escape handling when focus is on ordinary controls, including the autofocused search field
- keep Escape reserved for IME composition and visible overlays
- clarify `orchestration worker --terminal` worktree selection in CLI help

## Why
Settings previously ignored the first Escape because the search field is autofocused and the page handler rejected every editable target. The handler now defers only while IME composition is active; controls that handle Escape themselves still win via `defaultPrevented`.

## Validation
- `pnpm tc:node`
- `pnpm tc:web`
- oxlint/pre-commit checks passed

## Contributor credit
Original orchestration help-text clarification proposed by @Mar-IA-no in #17420.

Co-authored-by: Mar-IA-no <marianofm@gmail.com>