### PR TITLE
feat(native-chat): preview pending image attachments

### DIFF
--- a/src/renderer/src/components/editor/local-image-cache-pinning.ts
+++ b/src/renderer/src/components/editor/local-image-cache-pinning.ts
@@ -1,0 +1,40 @@
+const pinnedKeys = new Map<string, number>()
+
+export function pinLocalImageCacheKey(key: string): void {
+  pinnedKeys.set(key, (pinnedKeys.get(key) ?? 0) + 1)
+}
+
+export function unpinLocalImageCacheKey(key: string): void {
+  const count = pinnedKeys.get(key)
+  if (!count || count <= 1) {
+    pinnedKeys.delete(key)
+    return
+  }
+  pinnedKeys.set(key, count - 1)
+}
+
+export function isLocalImageCacheKeyPinned(key: string): boolean {
+  return pinnedKeys.has(key)
+}
+
+export function clearLocalImageCachePins(): void {
+  pinnedKeys.clear()
+}
+
+export function prunePinnedLocalImageCache(
+  cache: Map<string, string>,
+  maxSize: number,
+  revoke: (url: string) => void
+): void {
+  while (cache.size > maxSize) {
+    const oldest = Array.from(cache.keys()).find((key) => !isLocalImageCacheKeyPinned(key))
+    if (oldest === undefined) {
+      return
+    }
+    const url = cache.get(oldest)
+    cache.delete(oldest)
+    if (url) {
+      revoke(url)
+    }
+  }
+}

--- a/src/renderer/src/components/editor/useLocalImageSrc.test.ts
+++ b/src/renderer/src/components/editor/useLocalImageSrc.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { act, createElement } from 'react'
+import { act, createElement, Fragment } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
@@ -59,15 +59,19 @@ function HookProbe({
   return null
 }
 
-function HookList({ count }: { count: number }): null {
-  return Array.from({ length: count }, (_value, index) =>
-    createElement(HookProbe, {
-      key: index,
-      filePath: `/repo/image-${index}.png`,
-      onRender: () => {},
-      src: `/repo/image-${index}.png`
-    })
-  ) as unknown as null
+function HookList({ count }: { count: number }): React.JSX.Element {
+  return createElement(
+    Fragment,
+    null,
+    Array.from({ length: count }, (_value, index) =>
+      createElement(HookProbe, {
+        key: index,
+        filePath: `/repo/image-${index}.png`,
+        onRender: () => {},
+        src: `/repo/image-${index}.png`
+      })
+    )
+  )
 }
 
 beforeEach(() => {

--- a/src/renderer/src/components/editor/useLocalImageSrc.test.ts
+++ b/src/renderer/src/components/editor/useLocalImageSrc.test.ts
@@ -59,6 +59,17 @@ function HookProbe({
   return null
 }
 
+function HookList({ count }: { count: number }): null {
+  return Array.from({ length: count }, (_value, index) =>
+    createElement(HookProbe, {
+      key: index,
+      filePath: `/repo/image-${index}.png`,
+      onRender: () => {},
+      src: `/repo/image-${index}.png`
+    })
+  ) as unknown as null
+}
+
 beforeEach(() => {
   resetLocalImageSrcStateForTests()
   vi.spyOn(URL, 'createObjectURL').mockReset()
@@ -111,6 +122,24 @@ describe('loadLocalImageSrc', () => {
       'blob:local-image'
     ])
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not revoke blob URLs still used by mounted previews during eviction', async () => {
+    const readFile = vi.fn().mockResolvedValue(binaryPreview())
+    let nextUrl = 0
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(() => `blob:image-${++nextUrl}`)
+    setReadFile(readFile)
+
+    const container = document.createElement('div')
+    const root: Root = createRoot(container)
+    await act(async () => {
+      root.render(createElement(HookList, { count: 101 }))
+      await flushPromises()
+    })
+
+    expect(readFile).toHaveBeenCalledTimes(101)
+    expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('blob:image-1')
+    root.unmount()
   })
 
   it('clears failed in-flight reads so a later retry can succeed', async () => {

--- a/src/renderer/src/components/editor/useLocalImageSrc.ts
+++ b/src/renderer/src/components/editor/useLocalImageSrc.ts
@@ -2,6 +2,12 @@ import { useEffect, useState } from 'react'
 import { resolveImageAbsolutePath } from './markdown-preview-links'
 import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
 import { readRuntimeFilePreview } from '@/runtime/runtime-file-client'
+import {
+  clearLocalImageCachePins,
+  pinLocalImageCacheKey,
+  prunePinnedLocalImageCache,
+  unpinLocalImageCacheKey
+} from './local-image-cache-pinning'
 
 // Why: the renderer is served from http://localhost in dev mode, so file://
 // URLs in <img> tags are blocked by cross-origin restrictions. Loading images
@@ -43,17 +49,9 @@ function cacheBlobUrl(key: string, url: string): void {
     }
   }
   blobUrlCache.set(key, url)
-  if (blobUrlCache.size > BLOB_URL_CACHE_MAX_SIZE) {
-    const oldest = blobUrlCache.keys().next().value
-    if (oldest !== undefined) {
-      const oldUrl = blobUrlCache.get(oldest)
-      blobUrlCache.delete(oldest)
-      if (oldUrl) {
-        URL.revokeObjectURL(oldUrl)
-      }
-    }
-  }
+  prunePinnedLocalImageCache(blobUrlCache, BLOB_URL_CACHE_MAX_SIZE, URL.revokeObjectURL)
 }
+
 const cacheListeners = new Set<() => void>()
 let cacheGeneration = 0
 const pendingBlobUrlRevocations = new Set<string>()
@@ -169,6 +167,22 @@ export function useLocalImageSrc(
   runtimeContext?: Omit<RuntimeFileOperationArgs, 'connectionId'> & { connectionId?: string | null }
 ): string | undefined {
   const [generation, setGeneration] = useState(cacheGeneration)
+
+  useEffect(() => {
+    if (!rawSrc || isExternalUrl(rawSrc)) {
+      return
+    }
+    const absolutePath = resolveImageAbsolutePath(rawSrc, filePath)
+    if (!absolutePath) {
+      return
+    }
+    const cacheKey = getLocalImageCacheKey(absolutePath, connectionId, runtimeContext)
+    pinLocalImageCacheKey(cacheKey)
+    return () => {
+      unpinLocalImageCacheKey(cacheKey)
+      prunePinnedLocalImageCache(blobUrlCache, BLOB_URL_CACHE_MAX_SIZE, URL.revokeObjectURL)
+    }
+  }, [rawSrc, filePath, connectionId, runtimeContext])
 
   useEffect(() => {
     return onImageCacheInvalidated(() => setGeneration(cacheGeneration))
@@ -323,6 +337,7 @@ export function resetLocalImageSrcStateForTests(): void {
     URL.revokeObjectURL(url)
   }
   blobUrlCache.clear()
+  clearLocalImageCachePins()
   inFlightBlobUrlLoads.clear()
   cacheGeneration = 0
   pendingBlobUrlRevocations.clear()

--- a/src/renderer/src/components/editor/useLocalImageSrc.ts
+++ b/src/renderer/src/components/editor/useLocalImageSrc.ts
@@ -120,6 +120,7 @@ function disposeImageCacheModuleState(): void {
     URL.revokeObjectURL(url)
   }
   blobUrlCache.clear()
+  clearLocalImageCachePins()
   inFlightBlobUrlLoads.clear()
   cacheListeners.clear()
 }

--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -56,6 +56,7 @@ export type NativeChatComposerFieldProps = {
 export type NativeChatComposerImageAttachment = {
   id: string
   path: string
+  connectionId?: string
 }
 
 /**

--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -1,12 +1,9 @@
 import type { ClipboardEventHandler, KeyboardEventHandler, RefObject } from 'react'
 import { useLayoutEffect, useRef } from 'react'
-import { Image as ImageIcon, ImageOff, X } from 'lucide-react'
-import { translate } from '@/i18n/i18n'
+import { ImageOff } from 'lucide-react'
 import type { useImeEnterGestureOwnership } from '@/lib/ime-composition-keyboard-event'
 import { cn } from '@/lib/utils'
 import { NATIVE_FILE_DROP_TARGET } from '../../../../shared/native-file-drop'
-import { basename } from '@/lib/path'
-import { isNativeChatPastedImagePath } from './native-chat-image-paste'
 import type { ComposerAutocomplete, NativeChatPickerItem } from './native-chat-composer-state'
 import { NativeChatMentionHint, NativeChatPickerMenu } from './NativeChatAutocompleteMenus'
 import { NativeChatComposerActions } from './NativeChatComposerActions'
@@ -16,6 +13,7 @@ import type {
   SessionOptionsSurface
 } from '../../../../shared/native-chat-session-options'
 import type { NativeChatOptionPickerRequest } from './native-chat-composer-types'
+import { NativeChatImageAttachmentPreview } from './NativeChatImageAttachmentPreview'
 
 export type NativeChatComposerFieldProps = {
   textareaRef: RefObject<HTMLTextAreaElement | null>
@@ -184,34 +182,13 @@ export function NativeChatComposerField({
             )}
           >
             {imageAttachments.length > 0 ? (
-              <div className="mb-2 flex flex-wrap gap-1.5 px-1">
+              <div className="mb-2 flex flex-wrap gap-2 px-1 pt-1.5">
                 {imageAttachments.map((attachment) => (
-                  <div
+                  <NativeChatImageAttachmentPreview
                     key={attachment.id}
-                    className="flex max-w-full items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs text-muted-foreground"
-                    title={attachment.path}
-                  >
-                    <ImageIcon className="size-3.5 shrink-0" />
-                    <span className="max-w-56 truncate">
-                      {isNativeChatPastedImagePath(attachment.path)
-                        ? translate(
-                            'components.native-chat.composer.pastedImageLabel',
-                            'Pasted image'
-                          )
-                        : basename(attachment.path)}
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => onRemoveImageAttachment(attachment.id)}
-                      aria-label={translate(
-                        'components.native-chat.composer.removeAttachment',
-                        'Remove attachment'
-                      )}
-                      className="flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    >
-                      <X className="size-3" />
-                    </button>
-                  </div>
+                    attachment={attachment}
+                    onRemove={onRemoveImageAttachment}
+                  />
                 ))}
               </div>
             ) : null}

--- a/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react'
+import { Image as ImageIcon, X } from 'lucide-react'
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
+import { translate } from '@/i18n/i18n'
+import { basename } from '@/lib/path'
+import { useLocalImageSrc } from '@/components/editor/useLocalImageSrc'
+import { isNativeChatPastedImagePath } from './native-chat-image-paste'
+import type { NativeChatComposerImageAttachment } from './NativeChatComposerField'
+
+type Props = {
+  attachment: NativeChatComposerImageAttachment
+  onRemove: (id: string) => void
+}
+
+/** Thumbnail for a pending image, with an in-app full-size preview on click. */
+export function NativeChatImageAttachmentPreview({
+  attachment,
+  onRemove
+}: Props): React.JSX.Element {
+  const [isOpen, setIsOpen] = useState(false)
+  const previewSrc = useLocalImageSrc(attachment.path, attachment.path)
+  const filename = isNativeChatPastedImagePath(attachment.path)
+    ? translate('components.native-chat.composer.pastedImageLabel', 'Pasted image')
+    : basename(attachment.path)
+
+  return (
+    <>
+      <div className="relative size-14 shrink-0">
+        <button
+          type="button"
+          aria-label={`${translate('components.native-chat.composer.viewAttachment', 'View image')}: ${filename}`}
+          title={filename}
+          onClick={() => setIsOpen(true)}
+          className="flex size-full items-center justify-center overflow-hidden rounded-md border border-border bg-background transition-colors hover:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {previewSrc ? (
+            <img src={previewSrc} alt={filename} className="size-full object-cover" />
+          ) : (
+            <ImageIcon className="size-5 text-muted-foreground" />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => onRemove(attachment.id)}
+          aria-label={translate(
+            'components.native-chat.composer.removeAttachment',
+            'Remove attachment'
+          )}
+          className="absolute -right-1.5 -top-1.5 flex size-4 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <X className="size-3" />
+        </button>
+      </div>
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent className="flex max-h-[90vh] max-w-[90vw] flex-col gap-3 border-border bg-background p-3 sm:max-w-4xl">
+          <DialogTitle className="truncate text-sm">{filename}</DialogTitle>
+          <DialogDescription className="sr-only">
+            {translate('components.native-chat.composer.imagePreview', 'Full-size image preview')}
+          </DialogDescription>
+          <div className="scrollbar-sleek flex min-h-0 items-center justify-center overflow-auto rounded-md bg-muted/20 p-2">
+            {previewSrc ? (
+              <img
+                src={previewSrc}
+                alt={filename}
+                className="max-h-[75vh] max-w-full object-contain"
+              />
+            ) : (
+              <div className="flex items-center gap-2 py-12 text-sm text-muted-foreground">
+                <ImageIcon className="size-4" />
+                {translate(
+                  'components.native-chat.composer.imagePreviewUnavailable',
+                  'Preview unavailable'
+                )}
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Image as ImageIcon, X } from 'lucide-react'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { translate } from '@/i18n/i18n'
@@ -18,14 +18,41 @@ export function NativeChatImageAttachmentPreview({
   onRemove
 }: Props): React.JSX.Element {
   const [isOpen, setIsOpen] = useState(false)
-  const previewSrc = useLocalImageSrc(attachment.path, attachment.path, attachment.connectionId)
+  const [isNearViewport, setIsNearViewport] = useState(false)
+  const thumbnailRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const element = thumbnailRef.current
+    if (!element) {
+      return
+    }
+    if (typeof IntersectionObserver === 'undefined') {
+      setIsNearViewport(true)
+      return
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setIsNearViewport(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: '128px' }
+    )
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+  const previewSrc = useLocalImageSrc(
+    isNearViewport || isOpen ? attachment.path : undefined,
+    attachment.path,
+    attachment.connectionId
+  )
   const filename = isNativeChatPastedImagePath(attachment.path)
     ? translate('components.native-chat.composer.pastedImageLabel', 'Pasted image')
     : basename(attachment.path)
 
   return (
     <>
-      <div className="relative size-14 shrink-0">
+      <div ref={thumbnailRef} className="relative size-14 shrink-0">
         <button
           type="button"
           aria-label={`${translate('components.native-chat.composer.viewAttachment', 'View image')}: ${filename}`}

--- a/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.tsx
@@ -18,7 +18,7 @@ export function NativeChatImageAttachmentPreview({
   onRemove
 }: Props): React.JSX.Element {
   const [isOpen, setIsOpen] = useState(false)
-  const previewSrc = useLocalImageSrc(attachment.path, attachment.path)
+  const previewSrc = useLocalImageSrc(attachment.path, attachment.path, attachment.connectionId)
   const filename = isNativeChatPastedImagePath(attachment.path)
     ? translate('components.native-chat.composer.pastedImageLabel', 'Pasted image')
     : basename(attachment.path)

--- a/src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx
+++ b/src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx
@@ -6,7 +6,7 @@
  *  has no layout engine, so real pixel growth is covered by app validation. */
 
 import { createRef } from 'react'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/i18n/i18n', () => ({
@@ -22,12 +22,24 @@ vi.mock('./NativeChatAutocompleteMenus', () => ({
   NativeChatPickerMenu: () => null
 }))
 
+vi.mock('@/components/editor/useLocalImageSrc', () => ({
+  useLocalImageSrc: () => 'blob:attachment-preview'
+}))
+
 import { NativeChatComposerField } from './NativeChatComposerField'
 import { useImeEnterGestureOwnership } from '@/lib/ime-composition-keyboard-event'
 
 afterEach(() => cleanup())
 
-function TestField({ draft }: { draft: string }): React.JSX.Element {
+const EMPTY_IMAGE_ATTACHMENTS: { id: string; path: string }[] = []
+
+function TestField({
+  draft,
+  imageAttachments = EMPTY_IMAGE_ATTACHMENTS
+}: {
+  draft: string
+  imageAttachments?: { id: string; path: string }[]
+}): React.JSX.Element {
   const imeEnterGesture = useImeEnterGestureOwnership()
   return (
     <NativeChatComposerField
@@ -39,7 +51,7 @@ function TestField({ draft }: { draft: string }): React.JSX.Element {
       autocomplete={{ mode: 'none' }}
       activeSuggestion={0}
       notice={null}
-      imageAttachments={[]}
+      imageAttachments={imageAttachments}
       sendButtonDisabled={false}
       isWorking={false}
       attachDisabled={false}
@@ -100,5 +112,16 @@ describe('native chat composer autogrow', () => {
     // A JS measure pass writes style.height and only re-measures on the next
     // value change, so a re-wrap from a window/pane resize would strand it.
     expect(renderField('a\n'.repeat(6)).style.height).toBe('')
+  })
+})
+
+describe('native chat composer image attachments', () => {
+  it('renders a thumbnail and opens a full-size preview when clicked', () => {
+    render(<TestField draft="" imageAttachments={[{ id: 'image-1', path: '/tmp/example.png' }]} />)
+
+    expect(screen.getByRole('img', { name: 'example.png' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'View image: example.png' }))
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(screen.getByRole('dialog').textContent).toContain('example.png')
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx
+++ b/src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx
@@ -23,13 +23,16 @@ vi.mock('./NativeChatAutocompleteMenus', () => ({
 }))
 
 vi.mock('@/components/editor/useLocalImageSrc', () => ({
-  useLocalImageSrc: () => 'blob:attachment-preview'
+  useLocalImageSrc: (src?: string) => (src ? 'blob:attachment-preview' : undefined)
 }))
 
 import { NativeChatComposerField } from './NativeChatComposerField'
 import { useImeEnterGestureOwnership } from '@/lib/ime-composition-keyboard-event'
 
-afterEach(() => cleanup())
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
 
 const EMPTY_IMAGE_ATTACHMENTS: { id: string; path: string }[] = []
 
@@ -116,10 +119,11 @@ describe('native chat composer autogrow', () => {
 })
 
 describe('native chat composer image attachments', () => {
-  it('renders a thumbnail and opens a full-size preview when clicked', () => {
+  it('renders a thumbnail and opens a full-size preview when clicked', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined)
     render(<TestField draft="" imageAttachments={[{ id: 'image-1', path: '/tmp/example.png' }]} />)
 
-    expect(screen.getByRole('img', { name: 'example.png' })).toBeTruthy()
+    expect(await screen.findByRole('img', { name: 'example.png' })).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'View image: example.png' }))
     expect(screen.getByRole('dialog')).toBeTruthy()
     expect(screen.getByRole('dialog').textContent).toContain('example.png')

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
@@ -36,7 +36,7 @@ export function useNativeChatComposerAttachments({
   setNotice
 }: UseNativeChatComposerAttachmentsArgs): {
   imageAttachments: NativeChatComposerImageAttachment[]
-  attachResolvedPaths: (paths: string[]) => void
+  attachResolvedPaths: (paths: string[], connectionId?: string | null) => void
   clearImageAttachments: () => void
   flushPendingAttachments: () => void
   removeImageAttachment: (id: string) => void
@@ -45,7 +45,7 @@ export function useNativeChatComposerAttachments({
     () => readNativeChatAttachmentCache(attachmentScopeKey)
   )
   const imageAttachmentCounter = useRef(0)
-  const pendingResolvedPathsRef = useRef<string[]>([])
+  const pendingResolvedPathsRef = useRef<{ path: string; connectionId?: string | null }[]>([])
   const pendingPathLimitRejectedRef = useRef(false)
   const disabledRef = useRef(disabled)
 
@@ -73,15 +73,19 @@ export function useNativeChatComposerAttachments({
   )
 
   const appendImageAttachments = useCallback(
-    (paths: string[]) => {
+    (paths: { path: string; connectionId?: string | null }[]) => {
       if (paths.length === 0) {
         return
       }
       updateImageAttachments((prev) => [
         ...prev,
-        ...paths.map((path) => {
+        ...paths.map(({ path, connectionId }) => {
           imageAttachmentCounter.current += 1
-          return { id: `${Date.now()}-${imageAttachmentCounter.current}`, path }
+          return {
+            id: `${Date.now()}-${imageAttachmentCounter.current}`,
+            path,
+            connectionId: connectionId ?? undefined
+          }
         })
       ])
     },
@@ -111,7 +115,11 @@ export function useNativeChatComposerAttachments({
   // already-uploaded remote paths for SSH worktrees (the composer uploads
   // before calling this — see native-chat-attachment-upload.ts).
   const applyResolvedPaths = useCallback(
-    (paths: string[], focus: boolean, preserveNotice = false) => {
+    (
+      resolvedPaths: { path: string; connectionId?: string | null }[],
+      focus: boolean,
+      preserveNotice = false
+    ) => {
       const target = resolveTarget()
       if (
         (!target && !allowWithoutTarget) ||
@@ -125,17 +133,19 @@ export function useNativeChatComposerAttachments({
         )
         return
       }
-      const imagePaths = paths.filter(isNativeChatImageAttachmentPath)
-      const filePaths = paths.filter((path) => !isNativeChatImageAttachmentPath(path))
+      const imagePaths = resolvedPaths.filter(({ path }) => isNativeChatImageAttachmentPath(path))
+      const filePaths = resolvedPaths
+        .filter(({ path }) => !isNativeChatImageAttachmentPath(path))
+        .map(({ path }) => path)
       // Images are NOT sent to the TUI here — they ride along on submit (see
       // NativeChatComposer.send) so the GUI chips and the TUI input never
       // diverge and removing a chip needs no TUI un-paste.
-      appendImageAttachments(imagePaths)
+      appendImageAttachments(imagePaths.map(({ path, connectionId }) => ({ path, connectionId })))
       insertFileReferences(filePaths)
       if (!preserveNotice) {
         setNotice(null)
       }
-      if (focus && paths.length > 0) {
+      if (focus && resolvedPaths.length > 0) {
         requestAnimationFrame(() => textareaRef.current?.focus())
       }
     },
@@ -150,7 +160,7 @@ export function useNativeChatComposerAttachments({
   )
 
   const attachResolvedPaths = useCallback(
-    (paths: string[]) => {
+    (paths: string[], connectionId?: string | null) => {
       if (paths.length === 0 || disabledRef.current) {
         return
       }
@@ -166,10 +176,13 @@ export function useNativeChatComposerAttachments({
           )
           return
         }
-        pendingResolvedPathsRef.current.push(...paths)
+        pendingResolvedPathsRef.current.push(...paths.map((path) => ({ path, connectionId })))
         return
       }
-      applyResolvedPaths(paths, true)
+      applyResolvedPaths(
+        paths.map((path) => ({ path, connectionId })),
+        true
+      )
     },
     [applyResolvedPaths, isComposing, setNotice]
   )

--- a/src/renderer/src/components/native-chat/use-native-chat-external-attachments.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-external-attachments.test.tsx
@@ -132,7 +132,7 @@ describe('useNativeChatExternalAttachments', () => {
       expectedSshTargetId: 'conn-1',
       expectedSshConnectionGeneration: 4
     })
-    expect(attachResolvedPaths).toHaveBeenCalledWith(['/remote/wt/.orca/drops/a.txt'])
+    expect(attachResolvedPaths).toHaveBeenCalledWith(['/remote/wt/.orca/drops/a.txt'], 'conn-1')
   })
 
   it('delivers concurrent SSH resolutions in order without deduplicating paths', async () => {
@@ -164,8 +164,8 @@ describe('useNativeChatExternalAttachments', () => {
     })
 
     expect(attachResolvedPaths.mock.calls).toEqual([
-      [['/remote/wt/.orca/drops/b.txt', '/remote/wt/.orca/drops/b.txt']],
-      [['/remote/wt/.orca/drops/a.txt']]
+      [['/remote/wt/.orca/drops/b.txt', '/remote/wt/.orca/drops/b.txt'], 'conn-1'],
+      [['/remote/wt/.orca/drops/a.txt'], 'conn-1']
     ])
   })
 

--- a/src/renderer/src/components/native-chat/use-native-chat-external-attachments.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-external-attachments.ts
@@ -15,7 +15,7 @@ export type UseNativeChatExternalAttachmentsArgs = {
   /** Live composer-disabled state; read at await-resume via a ref so a flip
    *  mid-upload doesn't attach into a guarded composer. */
   disabled: boolean
-  attachResolvedPaths: (paths: string[]) => void
+  attachResolvedPaths: (paths: string[], connectionId?: string | null) => void
   setNotice: (notice: string | null) => void
 }
 
@@ -70,7 +70,7 @@ export function useNativeChatExternalAttachments({
         if (!remotePaths || remotePaths.length === 0 || disabledRef.current) {
           return
         }
-        attachResolvedPaths(remotePaths)
+        attachResolvedPaths(remotePaths, owner.connectionId)
       })()
     },
     [attachResolvedPaths, resolveAttachmentOwner, setNotice]

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16573,7 +16573,10 @@
           "on": "On",
           "off": "Off"
         },
-        "pendingAttachmentLimit": "Too many attachments are waiting. Finish composing before attaching more."
+        "pendingAttachmentLimit": "Too many attachments are waiting. Finish composing before attaching more.",
+        "viewAttachment": "View image",
+        "imagePreview": "Full-size image preview",
+        "imagePreviewUnavailable": "Preview unavailable"
       },
       "tool": {
         "running": "Running…",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​214 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​56 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​158 |

<!-- /orca-pr-loc -->

## Summary

- Replace pending native-chat image pills with thumbnail previews.
- Open a full-size in-app preview dialog when a thumbnail is clicked.
- Keep removal as a separate accessible control and share the behavior across regular and structured native chat.
- Add focused rendering/interaction coverage and localization copy.

## Verification

- `pnpm test src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx`
- `pnpm tc:web`
- Changed-file `oxlint` and React doctor checks
- Localization catalog validation
- Electron CDP attach/render check (no active native-chat session was available for attachment end-to-end interaction)