### PR TITLE
feat(ssh): batch process evidence in PTY inventory

### DIFF
--- a/src/main/providers/agent-foreground-process-batch.test.ts
+++ b/src/main/providers/agent-foreground-process-batch.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseStrictProcessTableRows,
+  ProcessTableCaptureError
+} from '../../shared/process-table-snapshot'
+import {
+  resolveAgentForegroundProcessesBatch,
+  resolveAgentForegroundProcessesFromIndex
+} from './agent-foreground-process'
+import {
+  buildProcessTableIndex,
+  type ProcessTableIndexStats
+} from '../../shared/process-table-snapshot'
+
+describe('strict process-table evidence parser', () => {
+  it('extracts pgid/tpgid while retaining command spacing', () => {
+    expect(
+      parseStrictProcessTableRows(
+        ' PID PPID PGID TPGID STAT COMMAND\r\n 100 1 100 101 Ss /bin/zsh -l\r\n 101 100 101 101 S+ node /opt/codex --flag  value\r\n'
+      )
+    ).toEqual([
+      { pid: 100, ppid: 1, pgid: 100, tpgid: 101, stat: 'Ss', command: '/bin/zsh -l' },
+      {
+        pid: 101,
+        ppid: 100,
+        pgid: 101,
+        tpgid: 101,
+        stat: 'S+',
+        command: 'node /opt/codex --flag  value'
+      }
+    ])
+  })
+
+  it.each(['101 100 101 S+ node /opt/codex', '101 100 -2 101 S+ node /opt/codex'])(
+    'rejects malformed/truncated captures (%s)',
+    (capture) => {
+      expect(() => parseStrictProcessTableRows(capture)).toThrow(ProcessTableCaptureError)
+    }
+  )
+
+  it('accepts no-controlling-tty sentinels for later unverifiable classification', () => {
+    expect(parseStrictProcessTableRows('100 1 100 0 Ss /bin/zsh')).toEqual([
+      { pid: 100, ppid: 1, pgid: 100, tpgid: 0, stat: 'Ss', command: '/bin/zsh' }
+    ])
+    expect(parseStrictProcessTableRows('100 1 100 -1 Ss /bin/zsh')).toEqual([
+      { pid: 100, ppid: 1, pgid: 100, tpgid: -1, stat: 'Ss', command: '/bin/zsh' }
+    ])
+  })
+})
+
+describe('batched foreground process correlation', () => {
+  it('uses tpgid/pgid association instead of stat alone', () => {
+    const rows = parseStrictProcessTableRows(
+      [
+        '100 1 100 101 Ss /bin/zsh',
+        '101 100 100 101 S+ node /opt/not-an-agent',
+        '102 100 101 101 S  node /opt/codex'
+      ].join('\n')
+    )
+    expect(
+      resolveAgentForegroundProcessesFromIndex(buildProcessTableIndex(rows), [
+        { rootPid: 100, fallbackProcess: 'zsh' }
+      ])
+    ).toEqual([{ available: true, processName: 'codex' }])
+  })
+
+  it('returns unverifiable for a missing root or no controlling tty', () => {
+    const rows = parseStrictProcessTableRows('100 1 100 0 Ss /bin/zsh')
+    expect(
+      resolveAgentForegroundProcessesFromIndex(buildProcessTableIndex(rows), [
+        { rootPid: 100, fallbackProcess: 'zsh' },
+        { rootPid: 999, fallbackProcess: 'zsh' }
+      ])
+    ).toEqual([
+      { available: false, processName: 'zsh', reason: 'no_controlling_tty' },
+      { available: false, processName: 'zsh', reason: 'root_missing' }
+    ])
+  })
+
+  it.each([1, 50, 200])('captures and indexes one host table for %s panes', async (paneCount) => {
+    const rows = Array.from({ length: paneCount }, (_, index) => {
+      const rootPid = 10_000 + index * 2
+      return [
+        {
+          pid: rootPid,
+          ppid: 1,
+          pgid: rootPid,
+          tpgid: rootPid + 1,
+          stat: 'Ss',
+          command: '/bin/zsh'
+        },
+        {
+          pid: rootPid + 1,
+          ppid: rootPid,
+          pgid: rootPid + 1,
+          tpgid: rootPid + 1,
+          stat: 'S',
+          command: 'node /opt/codex'
+        }
+      ]
+    }).flat()
+    const stats: ProcessTableIndexStats = {
+      captures: 0,
+      indexBuilds: 0,
+      rowVisits: 0,
+      indexLookups: 0
+    }
+    const results = await resolveAgentForegroundProcessesBatch(
+      rows
+        .map((row) => (row.pid % 2 === 0 ? { rootPid: row.pid, fallbackProcess: 'zsh' } : null))
+        .filter(
+          (request): request is { rootPid: number; fallbackProcess: string } => request !== null
+        ),
+      { readRows: async () => rows, stats }
+    )
+    expect(results).toHaveLength(paneCount)
+    expect(results.every((result) => result.processName === 'codex')).toBe(true)
+    expect(stats).toMatchObject({ captures: 1, indexBuilds: 1, rowVisits: paneCount * 2 })
+    expect(stats.indexLookups).toBeLessThanOrEqual(paneCount * 4)
+  })
+})

--- a/src/main/providers/agent-foreground-process-batch.ts
+++ b/src/main/providers/agent-foreground-process-batch.ts
@@ -1,0 +1,151 @@
+import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
+import { resolveOuterWrapperForegroundProcess } from '../../shared/foreground-wrapper-agent'
+import type { ForegroundProcessEvidence } from '../../shared/foreground-process-evidence'
+import {
+  buildProcessTableIndex,
+  getStrictProcessTableSnapshot,
+  type ProcessTableIndex,
+  type ProcessTableIndexStats,
+  type ProcessTableRow
+} from '../../shared/process-table-snapshot'
+
+export type BatchedForegroundProcessRequest = {
+  rootPid: number
+  fallbackProcess?: string | null
+}
+
+export type BatchedForegroundProcessResult = {
+  available: boolean
+  processName: string | null
+  reason?: string
+}
+
+export type BatchedForegroundProcessOptions = {
+  rows?: readonly ProcessTableRow[]
+  readRows?: () => Promise<readonly ProcessTableRow[]>
+  stats?: ProcessTableIndexStats
+}
+
+export async function resolveAgentForegroundProcessesBatch(
+  requests: readonly BatchedForegroundProcessRequest[],
+  options: BatchedForegroundProcessOptions = {}
+): Promise<BatchedForegroundProcessResult[]> {
+  let rows = options.rows
+  if (!rows) {
+    if (options.stats) {
+      options.stats.captures = (options.stats.captures ?? 0) + 1
+    }
+    rows = await (options.readRows?.() ?? getStrictProcessTableSnapshot())
+  }
+  const index = buildProcessTableIndex(rows, options.stats)
+  return resolveAgentForegroundProcessesFromIndex(index, requests)
+}
+
+export function resolveAgentForegroundProcessesFromIndex(
+  index: ProcessTableIndex,
+  requests: readonly BatchedForegroundProcessRequest[]
+): BatchedForegroundProcessResult[] {
+  const uniqueRoots = new Set<number>()
+  for (const request of requests) {
+    uniqueRoots.add(request.rootPid)
+  }
+  const rootsByPid = new Set(uniqueRoots)
+  const depthByPid = new Map<number, number>()
+  const rowsByOwner = new Map<number, (ProcessTableRow & { depth: number })[]>()
+  const queue: { row: ProcessTableRow; owner: number; depth: number }[] = []
+  for (const rootPid of uniqueRoots) {
+    const root = lookupIndex(index, (value) => value.byPid.get(rootPid))
+    if (root) {
+      depthByPid.set(root.pid, 0)
+      queue.push({ row: root, owner: root.pid, depth: 0 })
+    }
+  }
+  for (let cursor = 0; cursor < queue.length; cursor += 1) {
+    const current = queue[cursor]
+    const owned = rowsByOwner.get(current.owner) ?? []
+    if (current.depth > 0) {
+      owned.push({ ...current.row, depth: current.depth })
+    }
+    rowsByOwner.set(current.owner, owned)
+    const children = lookupIndex(index, (value) => value.childrenByPpid.get(current.row.pid) ?? [])
+    for (const child of children) {
+      const childOwner = rootsByPid.has(child.pid) ? child.pid : current.owner
+      const childDepth = rootsByPid.has(child.pid) ? 0 : current.depth + 1
+      const priorDepth = depthByPid.get(child.pid)
+      if (priorDepth !== undefined && priorDepth <= childDepth) {
+        continue
+      }
+      depthByPid.set(child.pid, childDepth)
+      queue.push({ row: child, owner: childOwner, depth: childDepth })
+    }
+  }
+
+  return requests.map((request) => {
+    const root = lookupIndex(index, (value) => value.byPid.get(request.rootPid))
+    if (!root) {
+      return {
+        available: false,
+        processName: request.fallbackProcess ?? null,
+        reason: 'root_missing'
+      }
+    }
+    if (root.pgid === undefined || root.tpgid === undefined) {
+      return {
+        available: false,
+        processName: request.fallbackProcess ?? null,
+        reason: 'correlation_unavailable'
+      }
+    }
+    if (root.tpgid === 0 || root.tpgid === -1) {
+      return {
+        available: false,
+        processName: request.fallbackProcess ?? null,
+        reason: 'no_controlling_tty'
+      }
+    }
+    const candidates = (rowsByOwner.get(root.pid) ?? []).filter((row) => row.pgid === root.tpgid)
+    let bestCandidate: (ProcessTableRow & { depth: number }) | null = null
+    let bestName: ReturnType<typeof recognizeAgentProcessFromCommandLine> = null
+    for (const candidate of candidates) {
+      const recognized = recognizeAgentProcessFromCommandLine(candidate.command)
+      if (
+        recognized &&
+        (bestCandidate === null || candidateScore(candidate) > candidateScore(bestCandidate))
+      ) {
+        bestCandidate = candidate
+        bestName = recognized
+      }
+    }
+    if (bestCandidate && bestName) {
+      return {
+        available: true,
+        processName: resolveOuterWrapperForegroundProcess(bestName, bestCandidate, candidates)
+      }
+    }
+    return { available: true, processName: null }
+  })
+}
+
+function lookupIndex<T>(index: ProcessTableIndex, lookup: (value: ProcessTableIndex) => T): T {
+  if (index.stats) {
+    index.stats.indexLookups += 1
+  }
+  return lookup(index)
+}
+
+function candidateScore(row: ProcessTableRow & { depth: number }): number {
+  return (row.stat.includes('+') ? 10_000 : 0) + row.depth
+}
+
+export function toForegroundProcessEvidence(
+  result: BatchedForegroundProcessResult,
+  metadata: { authorityGeneration: string; observationEpoch: number; capturedAgeMs: number }
+): ForegroundProcessEvidence {
+  return result.available
+    ? { ...metadata, verdict: 'live', processName: result.processName }
+    : {
+        ...metadata,
+        verdict: 'unverifiable',
+        reason: result.reason ?? 'correlation_unavailable'
+      }
+}

--- a/src/main/providers/agent-foreground-process-batch.ts
+++ b/src/main/providers/agent-foreground-process-batch.ts
@@ -1,4 +1,9 @@
-import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
+import {
+  isAgentForegroundWrapperProcess,
+  isExpectedAgentProcess,
+  recognizeAgentProcessFromCommandLine
+} from '../../shared/agent-process-recognition'
+import { getFirstCommandToken } from '../../shared/command-token-scanner'
 import { resolveOuterWrapperForegroundProcess } from '../../shared/foreground-wrapper-agent'
 import type { ForegroundProcessEvidence } from '../../shared/foreground-process-evidence'
 import {
@@ -103,7 +108,19 @@ export function resolveAgentForegroundProcessesFromIndex(
         reason: 'no_controlling_tty'
       }
     }
-    const candidates = (rowsByOwner.get(root.pid) ?? []).filter((row) => row.pgid === root.tpgid)
+    const allCandidates = rowsByOwner.get(root.pid) ?? []
+    const foregroundCandidates = allCandidates.filter((row) => row.pgid === root.tpgid)
+    const fallbackProcess = request.fallbackProcess
+    const wrapperFallback =
+      typeof fallbackProcess === 'string' && isAgentForegroundWrapperProcess(fallbackProcess)
+    const candidates = wrapperFallback
+      ? foregroundCandidates.filter((candidate) =>
+          isExpectedAgentProcess(getFirstCommandToken(candidate.command), fallbackProcess)
+        )
+      : foregroundCandidates
+    if (wrapperFallback && candidates.length !== 1) {
+      return { available: true, processName: null }
+    }
     let bestCandidate: (ProcessTableRow & { depth: number }) | null = null
     let bestName: ReturnType<typeof recognizeAgentProcessFromCommandLine> = null
     for (const candidate of candidates) {
@@ -119,7 +136,7 @@ export function resolveAgentForegroundProcessesFromIndex(
     if (bestCandidate && bestName) {
       return {
         available: true,
-        processName: resolveOuterWrapperForegroundProcess(bestName, bestCandidate, candidates)
+        processName: resolveOuterWrapperForegroundProcess(bestName, bestCandidate, allCandidates)
       }
     }
     return { available: true, processName: null }

--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -13,6 +13,14 @@ import {
 import { isShellProcess } from '../../shared/shell-process-detection'
 
 export type { AgentForegroundResolutionOptions } from './windows-agent-foreground-process'
+export {
+  resolveAgentForegroundProcessesBatch,
+  resolveAgentForegroundProcessesFromIndex,
+  toForegroundProcessEvidence,
+  type BatchedForegroundProcessOptions,
+  type BatchedForegroundProcessRequest,
+  type BatchedForegroundProcessResult
+} from './agent-foreground-process-batch'
 
 export type AgentForegroundProcessResolution = {
   available: boolean

--- a/src/main/providers/pty-process-info.ts
+++ b/src/main/providers/pty-process-info.ts
@@ -1,5 +1,6 @@
 import type { AgentSessionOwnerBinding } from '../../shared/agent-session-host-authority'
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
+import type { ForegroundProcessEvidence } from '../../shared/foreground-process-evidence'
 
 export type PtyProcessInfo = {
   id: string
@@ -14,5 +15,7 @@ export type PtyProcessInfo = {
   terminalHandle?: string
   /** Exact WSL owner reported by the PTY provider; null means native Windows. */
   wslDistro?: string | null
+  /** Optional host-side process evidence attached to an inventory seed. */
+  foregroundProcessEvidence?: ForegroundProcessEvidence
   agentSessionOwners?: AgentSessionOwnerBinding[]
 }

--- a/src/main/providers/pty-process-list-admission.test.ts
+++ b/src/main/providers/pty-process-list-admission.test.ts
@@ -9,6 +9,37 @@ import {
 } from './pty-process-list-admission'
 
 describe('PtyProcessListAdmission', () => {
+  const evidence = {
+    verdict: 'live' as const,
+    processName: 'codex',
+    authorityGeneration: 'relay-generation',
+    observationEpoch: 4,
+    capturedAgeMs: 12
+  }
+
+  it('preserves and clones optional foreground evidence', () => {
+    const admission = new PtyProcessListAdmission()
+    const admitted = admission.admit({
+      id: 'pty-1',
+      cwd: '/repo',
+      title: 'shell',
+      foregroundProcessEvidence: evidence
+    })
+    expect(admitted.foregroundProcessEvidence).toEqual(evidence)
+    expect(admitted.foregroundProcessEvidence).not.toBe(evidence)
+  })
+
+  it('rejects malformed foreground evidence instead of stripping it', () => {
+    expect(() =>
+      new PtyProcessListAdmission().admit({
+        id: 'pty-1',
+        cwd: '/repo',
+        title: 'shell',
+        foregroundProcessEvidence: { ...evidence, verdict: 'wat' }
+      } as never)
+    ).toThrow('invalid_pty_process_list')
+  })
+
   it('strips unknown provider payloads from admitted process metadata', () => {
     const admission = new PtyProcessListAdmission()
 

--- a/src/main/providers/pty-process-list-admission.ts
+++ b/src/main/providers/pty-process-list-admission.ts
@@ -2,6 +2,10 @@ import { isAgentSessionOwnerBinding } from '../../shared/agent-session-host-auth
 import { MAX_CLAIMED_AGENT_PTY_OWNER_ENTRIES } from '../../shared/claimed-agent-pty-owner'
 import { cloneAgentSessionOwnerBinding } from '../../shared/claimed-agent-pty-owner-snapshot'
 import { isPtyIncarnationId } from '../../shared/pty-incarnation'
+import {
+  cloneForegroundProcessEvidence,
+  isForegroundProcessEvidence
+} from '../../shared/foreground-process-evidence'
 import type { PtyProcessInfo } from './types'
 
 export const MAX_AGGREGATED_PTY_PROCESS_LIST_ENTRIES = 4096
@@ -53,6 +57,12 @@ export class PtyProcessListAdmission {
     const terminalHandleBytes = retainedOptionalStringBytes(value.terminalHandle)
     const wslDistroBytes =
       value.wslDistro === null ? 0 : retainedOptionalStringBytes(value.wslDistro)
+    const evidenceBytes =
+      value.foregroundProcessEvidence === undefined
+        ? 0
+        : isForegroundProcessEvidence(value.foregroundProcessEvidence)
+          ? Buffer.byteLength(JSON.stringify(value.foregroundProcessEvidence), 'utf8')
+          : null
     if (
       idBytes === null ||
       cwdBytes === null ||
@@ -60,6 +70,7 @@ export class PtyProcessListAdmission {
       worktreeIdBytes === null ||
       terminalHandleBytes === null ||
       wslDistroBytes === null ||
+      evidenceBytes === null ||
       (value.rootProcessId !== undefined &&
         (!Number.isSafeInteger(value.rootProcessId) || value.rootProcessId <= 0)) ||
       (value.incarnationId !== undefined && !isPtyIncarnationId(value.incarnationId)) ||
@@ -93,6 +104,7 @@ export class PtyProcessListAdmission {
       worktreeIdBytes +
       terminalHandleBytes +
       wslDistroBytes +
+      evidenceBytes +
       ownerBytes
     if (
       nextEntries > MAX_AGGREGATED_PTY_PROCESS_LIST_ENTRIES ||
@@ -114,6 +126,13 @@ export class PtyProcessListAdmission {
       ...(value.worktreeId !== undefined ? { worktreeId: value.worktreeId } : {}),
       ...(value.terminalHandle !== undefined ? { terminalHandle: value.terminalHandle } : {}),
       ...(value.wslDistro !== undefined ? { wslDistro: value.wslDistro } : {}),
+      ...(value.foregroundProcessEvidence !== undefined
+        ? {
+            foregroundProcessEvidence: cloneForegroundProcessEvidence(
+              value.foregroundProcessEvidence
+            )
+          }
+        : {}),
       ...(normalizedOwners !== undefined ? { agentSessionOwners: normalizedOwners } : {})
     }
   }

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -13,6 +13,7 @@ import {
   resolveProcessCwd,
   processHasChildren,
   getForegroundProcessName,
+  getForegroundProcessNameFromProcessTable,
   isProcessAlive,
   listShellProfiles
 } from './pty-shell-utils'
@@ -63,6 +64,16 @@ import {
 } from '../shared/pty-startup-ingress'
 import { resolvePtyOwnerBackend, type PtyOwnerBackend } from '../shared/pty-owner-backend'
 import { RecentPtyOutputBuffer } from '../main/runtime/recent-pty-output-buffer'
+import {
+  resolveAgentForegroundProcessesBatch,
+  toForegroundProcessEvidence,
+  type BatchedForegroundProcessResult
+} from '../main/providers/agent-foreground-process'
+import {
+  getStrictProcessTableSnapshot,
+  type ProcessTableRow
+} from '../shared/process-table-snapshot'
+import type { ForegroundProcessEvidence } from '../shared/foreground-process-evidence'
 import { expandWindowsPathEnvironmentVariables } from '../shared/windows-environment-expansion'
 import {
   agentSessionOwnerBindingsEqual,
@@ -361,6 +372,7 @@ type PtyProcessSummary = {
   title: string
   worktreeId?: string
   terminalHandle?: string
+  foregroundProcessEvidence?: ForegroundProcessEvidence
   agentSessionOwners?: AgentSessionOwnerBinding[]
 }
 
@@ -436,6 +448,7 @@ export type RelayPtyWorktreeRemovalCoordinator = {
 export class PtyHandler {
   private ptys = new Map<string, ManagedPty>()
   private readonly ptyIdMintEpoch: string
+  private foregroundEvidenceEpoch = 0
   private nextId = 1
   private dispatcher: RelayDispatcher
   private graceTimeMs: number
@@ -2247,13 +2260,55 @@ export class PtyHandler {
     // listing is what publishes `agentSessionOwners`, i.e. "there is a live agent session here you
     // can adopt". A shell can exit without node-pty's onExit, and an unverified entry advertised
     // that session forever. Snapshot the map because reaping mutates it.
-    for (const [id, managed] of Array.from(this.ptys)) {
+    const managedEntries = Array.from(this.ptys)
+    // R1 seed evidence is additive and POSIX-only. Windows authorities retain
+    // the existing title/liveness path until the measured relay adapter lands.
+    let evidenceRows: readonly ProcessTableRow[] | null = null
+    let evidenceResults: BatchedForegroundProcessResult[] = []
+    const evidenceEpoch = ++this.foregroundEvidenceEpoch
+    if (process.platform !== 'win32' && managedEntries.length > 0) {
+      try {
+        evidenceRows = await getStrictProcessTableSnapshot()
+        evidenceResults = await resolveAgentForegroundProcessesBatch(
+          managedEntries.map(([, managed]) => ({
+            rootPid: managed.pty.pid,
+            fallbackProcess: managed.pty.process || null
+          })),
+          { rows: evidenceRows }
+        )
+      } catch {
+        // An unreadable capture is represented as unverifiable evidence below;
+        // existing inventory fields remain available for old clients.
+      }
+    }
+    for (const [entryIndex, [id, managed]] of managedEntries.entries()) {
       if (managed.disposed || (managed.pty.pid && !isProcessAlive(managed.pty.pid))) {
         this.reapExitedPty(managed)
         continue
       }
       const title =
-        (await getForegroundProcessName(managed.pty.pid, managed.pty.process || null)) || 'shell'
+        (evidenceRows
+          ? getForegroundProcessNameFromProcessTable(
+              [...evidenceRows],
+              managed.pty.pid,
+              managed.pty.process || null
+            )
+          : await getForegroundProcessName(managed.pty.pid, managed.pty.process || null)) || 'shell'
+      const foregroundProcessEvidence =
+        process.platform !== 'win32'
+          ? toForegroundProcessEvidence(
+              evidenceResults[entryIndex] ?? {
+                available: false,
+                processName: managed.pty.process || null,
+                reason: 'table_unreadable'
+              },
+              {
+                authorityGeneration: this.ptyIdMintEpoch,
+                observationEpoch: evidenceEpoch,
+                capturedAgeMs: 0
+              }
+            )
+          : undefined
       results.push({
         id,
         incarnationId: managed.incarnationId,
@@ -2261,6 +2316,7 @@ export class PtyHandler {
         title,
         ...(managed.worktreeId ? { worktreeId: managed.worktreeId } : {}),
         ...(managed.terminalHandle ? { terminalHandle: managed.terminalHandle } : {}),
+        ...(foregroundProcessEvidence ? { foregroundProcessEvidence } : {}),
         ...(this.agentSessionOwners.listForPty(id).length
           ? { agentSessionOwners: this.agentSessionOwners.listForPty(id) }
           : {})

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -13,7 +13,6 @@ import {
   resolveProcessCwd,
   processHasChildren,
   getForegroundProcessName,
-  getForegroundProcessNameFromProcessTable,
   isProcessAlive,
   listShellProfiles
 } from './pty-shell-utils'
@@ -2286,13 +2285,10 @@ export class PtyHandler {
         this.reapExitedPty(managed)
         continue
       }
+      // Reuse batched correlation; per-PTY tree scans recreate O(PTY × rows) work.
       const title =
         (evidenceRows
-          ? getForegroundProcessNameFromProcessTable(
-              [...evidenceRows],
-              managed.pty.pid,
-              managed.pty.process || null
-            )
+          ? (evidenceResults[entryIndex]?.processName ?? managed.pty.process ?? null)
           : await getForegroundProcessName(managed.pty.pid, managed.pty.process || null)) || 'shell'
       const foregroundProcessEvidence =
         process.platform !== 'win32'

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -220,15 +220,11 @@ function candidateScore(row: ProcessTableRow & { depth: number }): number {
   return (row.stat.includes('+') ? 10_000 : 0) + row.depth
 }
 
-function processCommandToken(command: string): string {
-  return getFirstCommandToken(command)
-}
-
 function candidateMatchesFallbackWrapper(
   candidate: ProcessTableRow,
   fallbackProcess: string
 ): boolean {
-  return isExpectedAgentProcess(processCommandToken(candidate.command), fallbackProcess)
+  return isExpectedAgentProcess(getFirstCommandToken(candidate.command), fallbackProcess)
 }
 
 async function getRecognizedForegroundDescendant(
@@ -237,43 +233,52 @@ async function getRecognizedForegroundDescendant(
 ): Promise<string | null> {
   try {
     const rows = await getProcessTableSnapshot()
-    const root = rows.find((row) => row.pid === pid)
-    const candidates = collectDescendants(rows, pid).sort(
-      (a, b) => candidateScore(b) - candidateScore(a)
-    )
-    // Why: SSH relays do not have the daemon's async wrapper cache. Inspect the
-    // remote process tree so node/python agent entrypoints become real agents.
-    const foregroundIsKnown =
-      root?.stat.includes('+') === true ||
-      candidates.some((candidate) => candidate.stat.includes('+'))
-    const foregroundCandidates = foregroundIsKnown
-      ? candidates.filter((candidate) => candidate.stat.includes('+'))
-      : candidates
-    const inspectionCandidates =
-      fallbackProcess && isAgentForegroundWrapperProcess(fallbackProcess)
-        ? foregroundCandidates.filter((candidate) =>
-            candidateMatchesFallbackWrapper(candidate, fallbackProcess)
-          )
-        : foregroundCandidates
-    if (
-      fallbackProcess &&
-      isAgentForegroundWrapperProcess(fallbackProcess) &&
-      inspectionCandidates.length !== 1
-    ) {
-      return null
-    }
-    for (const candidate of inspectionCandidates) {
-      const recognized = recognizeAgentProcessFromCommandLine(candidate.command)
-      if (recognized) {
-        // Why: return the outer wrapper (omp) rather than the deeper wrapped child
-        // (pi) of a shell→omp→pi tree — see resolveOuterWrapperForegroundProcess.
-        return resolveOuterWrapperForegroundProcess(recognized, candidate, candidates)
-      }
-    }
+    return getForegroundProcessNameFromProcessTable(rows, pid, fallbackProcess)
   } catch {
     // Fall through to node-pty's process name or the root command name.
   }
   return null
+}
+
+export function getForegroundProcessNameFromProcessTable(
+  rows: ProcessTableRow[],
+  pid: number,
+  fallbackProcess?: string | null
+): string | null {
+  const root = rows.find((row) => row.pid === pid)
+  const candidates = collectDescendants(rows, pid).sort(
+    (a, b) => candidateScore(b) - candidateScore(a)
+  )
+  // Why: SSH relays do not have the daemon's async wrapper cache. Inspect the
+  // remote process tree so node/python agent entrypoints become real agents.
+  const foregroundIsKnown =
+    root?.stat.includes('+') === true ||
+    candidates.some((candidate) => candidate.stat.includes('+'))
+  const foregroundCandidates = foregroundIsKnown
+    ? candidates.filter((candidate) => candidate.stat.includes('+'))
+    : candidates
+  const inspectionCandidates =
+    fallbackProcess && isAgentForegroundWrapperProcess(fallbackProcess)
+      ? foregroundCandidates.filter((candidate) =>
+          candidateMatchesFallbackWrapper(candidate, fallbackProcess)
+        )
+      : foregroundCandidates
+  if (
+    fallbackProcess &&
+    isAgentForegroundWrapperProcess(fallbackProcess) &&
+    inspectionCandidates.length !== 1
+  ) {
+    return null
+  }
+  for (const candidate of inspectionCandidates) {
+    const recognized = recognizeAgentProcessFromCommandLine(candidate.command)
+    if (recognized) {
+      // Why: return the outer wrapper (omp) rather than the deeper wrapped child
+      // (pi) of a shell→omp→pi tree — see resolveOuterWrapperForegroundProcess.
+      return resolveOuterWrapperForegroundProcess(recognized, candidate, candidates)
+    }
+  }
+  return fallbackProcess ?? null
 }
 
 /**
@@ -332,9 +337,6 @@ export async function getForegroundProcessName(
   }
 }
 
-/**
- * List available shell profiles from /etc/shells (or known fallbacks).
- */
 export function listShellProfiles(): { name: string; path: string }[] {
   const profiles: { name: string; path: string }[] = []
   const seen = new Set<string>()

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -40,9 +40,14 @@ export type AgentCompletionCoordinatorOptions = {
   shouldSuppressConfirmedProcessExitCompletion?: (exited: RecognizedAgentProcess) => boolean
   isLive: () => boolean
   shouldPollProcessCadence?: () => boolean
+  // Why: direct SSH/remote authorities publish foreground evidence with their
+  // inventory, so a pane without agent evidence can stay push-driven instead
+  // of scheduling redundant host process-table reads while idle.
+  shouldPollNoEvidenceProcessCadence?: () => boolean
   // Why: on hosts where one inspection forks a whole-process-table scan (local
   // Windows PowerShell/CIM), panes without agent evidence relax to a slow
-  // cadence; cheap hosts (POSIX `ps`, SSH/remote-owned scans) keep full cadence.
+  // cadence; remote authorities can disable no-evidence polling entirely and
+  // re-arm from output/title activity instead.
   isProcessInspectionCostly?: () => boolean
   shouldSuppressHookCompletion?: (payload: AgentCompletionStatusSnapshot) => boolean
 }

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -53,7 +53,7 @@ export function createAgentCompletionCoordinator(
     pollTrackingStarted: false,
     pollTimer: null as ReturnType<typeof setTimeout> | null,
     pollTimerTier: null as 'active' | 'idle' | 'hidden' | 'no-evidence' | null,
-    lastPaneActivityAt: 0,
+    lastPaneActivityAt: null,
     hasAgentRunEvidence: false,
     pendingProcessExitAgent: null as RecognizedAgentProcess | null,
     lastForegroundAgent: null as RecognizedAgentProcess | null,

--- a/src/renderer/src/components/terminal-pane/agent-completion-no-evidence-cadence.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-no-evidence-cadence.test.ts
@@ -92,6 +92,38 @@ describe('agent completion no-evidence inspection cadence', () => {
     expect(inspectProcess).toHaveBeenCalledTimes(30)
   })
 
+  it('costs zero idle inspections when the host publishes foreground evidence', async () => {
+    const inspectProcess = vi.fn(async () => processResult(null, false))
+    const { coordinator } = createCoordinator(inspectProcess, {
+      shouldPollNoEvidenceProcessCadence: () => false
+    })
+
+    coordinator.startProcessTracking()
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(inspectProcess).not.toHaveBeenCalled()
+  })
+
+  it('starts a bounded hot cadence after output on an evidence-publishing host', async () => {
+    const inspectProcess = vi.fn(async () => processResult(null, false))
+    const { coordinator } = createCoordinator(inspectProcess, {
+      shouldPollNoEvidenceProcessCadence: () => false
+    })
+
+    coordinator.startProcessTracking()
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(inspectProcess).not.toHaveBeenCalled()
+
+    coordinator.observeOutputActivity()
+    await vi.advanceTimersByTimeAsync(12_000)
+
+    // Output arms 2s polls only for the 10s activity window; silence then
+    // disarms the host reads again instead of falling back to a slow timer.
+    expect(inspectProcess).toHaveBeenCalledTimes(4)
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(inspectProcess).toHaveBeenCalledTimes(4)
+  })
+
   it('escalates to the hot cadence when PTY output appears mid-interval', async () => {
     const inspectProcess = vi.fn(async () => processResult(null, false))
     const { coordinator } = createCoordinator(inspectProcess)

--- a/src/renderer/src/components/terminal-pane/agent-completion-no-evidence-cadence.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-no-evidence-cadence.test.ts
@@ -124,6 +124,20 @@ describe('agent completion no-evidence inspection cadence', () => {
     expect(inspectProcess).toHaveBeenCalledTimes(4)
   })
 
+  it('does not re-arm no-evidence scans for output from hidden panes', async () => {
+    const inspectProcess = vi.fn(async () => processResult(null, false))
+    const { coordinator } = createCoordinator(inspectProcess, {
+      shouldPollProcessCadence: () => false,
+      shouldPollNoEvidenceProcessCadence: () => false
+    })
+
+    coordinator.startProcessTracking()
+    coordinator.observeOutputActivity()
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(inspectProcess).not.toHaveBeenCalled()
+  })
+
   it('escalates to the hot cadence when PTY output appears mid-interval', async () => {
     const inspectProcess = vi.fn(async () => processResult(null, false))
     const { coordinator } = createCoordinator(inspectProcess)

--- a/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
@@ -200,7 +200,10 @@ export function createAgentCompletionProcessMonitor({
     return (
       state.hasAgentRunEvidence ||
       state.lastForegroundAgent !== null ||
-      options.shouldPollProcessCadence?.() !== false
+      (options.shouldPollProcessCadence?.() !== false &&
+        options.shouldPollNoEvidenceProcessCadence?.() !== false) ||
+      (state.lastPaneActivityAt !== null &&
+        Date.now() - state.lastPaneActivityAt < NO_EVIDENCE_ACTIVITY_HOT_WINDOW_MS)
     )
   }
 
@@ -216,7 +219,7 @@ export function createAgentCompletionProcessMonitor({
     }
     if (
       options.isProcessInspectionCostly?.() === true &&
-      (state.lastPaneActivityAt === 0 ||
+      (state.lastPaneActivityAt === null ||
         Date.now() - state.lastPaneActivityAt >= NO_EVIDENCE_ACTIVITY_HOT_WINDOW_MS)
     ) {
       return 'no-evidence'

--- a/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
@@ -202,7 +202,8 @@ export function createAgentCompletionProcessMonitor({
       state.lastForegroundAgent !== null ||
       (options.shouldPollProcessCadence?.() !== false &&
         options.shouldPollNoEvidenceProcessCadence?.() !== false) ||
-      (state.lastPaneActivityAt !== null &&
+      (options.shouldPollProcessCadence?.() !== false &&
+        state.lastPaneActivityAt !== null &&
         Date.now() - state.lastPaneActivityAt < NO_EVIDENCE_ACTIVITY_HOT_WINDOW_MS)
     )
   }

--- a/src/renderer/src/components/terminal-pane/agent-completion-process-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-process-types.ts
@@ -21,7 +21,7 @@ export type ProcessMonitorState = {
   pollTrackingStarted: boolean
   pollTimer: ReturnType<typeof setTimeout> | null
   pollTimerTier: PollCadenceTier | null
-  lastPaneActivityAt: number
+  lastPaneActivityAt: number | null
   hasAgentRunEvidence: boolean
   pendingProcessExitAgent: RecognizedAgentProcess | null
   lastForegroundAgent: RecognizedAgentProcess | null

--- a/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
@@ -229,12 +229,11 @@ export function installTerminalKeydownFit(session: ConnectPanePtySession): void 
       }),
     shouldPollProcessCadence: () =>
       isAgentTaskCompleteTrackingEnabled() && session.deps.isVisibleRef.current,
-    shouldPollNoEvidenceProcessCadence: () =>
-      !isRemoteExecutionHostPtyId(session.transport.getPtyId()),
     isProcessInspectionCostly: () => {
       // Why: local Windows inspection forks a powershell.exe whole-process-table
-      // CIM scan per poll (~10-40x heavier than POSIX `ps`). Remote authorities
-      // use the zero-idle cadence gate above instead.
+      // CIM scan per poll (~10-40x heavier than POSIX `ps`). Keep the no-evidence
+      // cadence enabled until inventory evidence is consumed by this renderer;
+      // mixed-version relays may omit the optional field.
       if (!navigator.userAgent.includes('Windows')) {
         return false
       }

--- a/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
@@ -229,11 +229,12 @@ export function installTerminalKeydownFit(session: ConnectPanePtySession): void 
       }),
     shouldPollProcessCadence: () =>
       isAgentTaskCompleteTrackingEnabled() && session.deps.isVisibleRef.current,
+    shouldPollNoEvidenceProcessCadence: () =>
+      !isRemoteExecutionHostPtyId(session.transport.getPtyId()),
     isProcessInspectionCostly: () => {
       // Why: local Windows inspection forks a powershell.exe whole-process-table
-      // CIM scan per poll (~10-40x heavier than POSIX `ps`); SSH/remote PTYs run
-      // their scans on the remote host, so only local Windows panes relax the
-      // no-evidence cadence.
+      // CIM scan per poll (~10-40x heavier than POSIX `ps`). Remote authorities
+      // use the zero-idle cadence gate above instead.
       if (!navigator.userAgent.includes('Windows')) {
         return false
       }

--- a/src/shared/__fixtures__/linux-process-table-kernel-rows.txt
+++ b/src/shared/__fixtures__/linux-process-table-kernel-rows.txt
@@ -1,0 +1,9 @@
+ PID PPID PGID TPGID STAT COMMAND
+   1    0    1     0 Ss   /sbin/init
+   2    0    0    -1 S    [kthreadd]
+   3    2    0    -1 I    [pool_workqueue_release]
+   4    2    0    -1 I    [kworker/R-rcu_g]
+   5    2    0    -1 I    [kworker/R-sync_wq]
+   6    2    0    -1 I    [kworker/R-slub_]
+ 100    1  100   100 Ss+  /bin/bash -l
+ 101  100  101   101 S+   node /opt/codex

--- a/src/shared/foreground-process-evidence.ts
+++ b/src/shared/foreground-process-evidence.ts
@@ -1,0 +1,44 @@
+/** Metadata attached to a host process-table observation. */
+export type ForegroundEvidenceObservation = {
+  authorityGeneration: string
+  observationEpoch: number
+  /** Age at serialization; receivers rebase this onto their monotonic clock. */
+  capturedAgeMs: number
+}
+
+export type ForegroundProcessEvidence =
+  | ({ verdict: 'live'; processName: string | null } & ForegroundEvidenceObservation)
+  | ({ verdict: 'unverifiable'; reason: string } & ForegroundEvidenceObservation)
+
+export function isForegroundProcessEvidence(value: unknown): value is ForegroundProcessEvidence {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+  const input = value as Record<string, unknown>
+  if (
+    typeof input.authorityGeneration !== 'string' ||
+    input.authorityGeneration.length === 0 ||
+    input.authorityGeneration.length > 256 ||
+    typeof input.observationEpoch !== 'number' ||
+    !Number.isSafeInteger(input.observationEpoch) ||
+    input.observationEpoch < 0 ||
+    typeof input.capturedAgeMs !== 'number' ||
+    !Number.isSafeInteger(input.capturedAgeMs) ||
+    input.capturedAgeMs < 0 ||
+    input.capturedAgeMs > 86_400_000
+  ) {
+    return false
+  }
+  if (input.verdict === 'live') {
+    return input.processName === null || typeof input.processName === 'string'
+  }
+  return (
+    input.verdict === 'unverifiable' && typeof input.reason === 'string' && input.reason.length > 0
+  )
+}
+
+export function cloneForegroundProcessEvidence(
+  evidence: ForegroundProcessEvidence
+): ForegroundProcessEvidence {
+  return { ...evidence }
+}

--- a/src/shared/process-table-snapshot.test.ts
+++ b/src/shared/process-table-snapshot.test.ts
@@ -1,5 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { createProcessTableSnapshotReader, parseProcessTableRows } from './process-table-snapshot'
+import {
+  createProcessTableSnapshotReader,
+  parseProcessTableRows,
+  parseStrictProcessTableRows,
+  ProcessTableCaptureError
+} from './process-table-snapshot'
 
 function deferred<T>(): {
   promise: Promise<T>
@@ -213,5 +220,50 @@ describe('parseProcessTableRows', () => {
   it('tolerates CRLF and skips header/blank/non-matching lines', () => {
     const rows = parseProcessTableRows('  PID PPID STAT COMMAND\r\n42 1 Ss /sbin/launchd\r\n\r\n')
     expect(rows).toEqual([{ pid: 42, ppid: 1, stat: 'Ss', command: '/sbin/launchd' }])
+  })
+})
+
+describe('parseStrictProcessTableRows', () => {
+  it('accepts Linux kernel roots and bracketed comm values', () => {
+    const capture = readFileSync(
+      join(__dirname, '__fixtures__', 'linux-process-table-kernel-rows.txt'),
+      'utf8'
+    )
+    expect(parseStrictProcessTableRows(capture)).toEqual([
+      { pid: 1, ppid: 0, pgid: 1, tpgid: 0, stat: 'Ss', command: '/sbin/init' },
+      { pid: 2, ppid: 0, pgid: 0, tpgid: -1, stat: 'S', command: '[kthreadd]' },
+      {
+        pid: 3,
+        ppid: 2,
+        pgid: 0,
+        tpgid: -1,
+        stat: 'I',
+        command: '[pool_workqueue_release]'
+      },
+      { pid: 4, ppid: 2, pgid: 0, tpgid: -1, stat: 'I', command: '[kworker/R-rcu_g]' },
+      { pid: 5, ppid: 2, pgid: 0, tpgid: -1, stat: 'I', command: '[kworker/R-sync_wq]' },
+      { pid: 6, ppid: 2, pgid: 0, tpgid: -1, stat: 'I', command: '[kworker/R-slub_]' },
+      { pid: 100, ppid: 1, pgid: 100, tpgid: 100, stat: 'Ss+', command: '/bin/bash -l' },
+      { pid: 101, ppid: 100, pgid: 101, tpgid: 101, stat: 'S+', command: 'node /opt/codex' }
+    ])
+  })
+
+  it('still rejects truncated captures as unreadable', () => {
+    expect(() => parseStrictProcessTableRows('100 1 100 100 Ss+')).toThrow(ProcessTableCaptureError)
+  })
+
+  it.each([
+    '0 0 0 0 S [invalid-pid]',
+    '100 1 -1 100 S [invalid-pgid]',
+    '100 1 100 -2 S [invalid-tpgid]'
+  ])('rejects domain-invalid numeric values (%s)', (capture) => {
+    expect(() => parseStrictProcessTableRows(capture)).toThrow(ProcessTableCaptureError)
+  })
+
+  it('rejects an empty or header-only capture as unreadable', () => {
+    expect(() => parseStrictProcessTableRows('')).toThrow(ProcessTableCaptureError)
+    expect(() => parseStrictProcessTableRows('PID PPID PGID TPGID STAT COMMAND')).toThrow(
+      ProcessTableCaptureError
+    )
   })
 })

--- a/src/shared/process-table-snapshot.ts
+++ b/src/shared/process-table-snapshot.ts
@@ -7,7 +7,8 @@ const execFile = promisify(execFileCb)
 // a 750ms/2000ms per-pane cadence. On a shared SSH relay every tracked agent
 // terminal drives it, so concurrent panes used to each fork their own `ps`,
 // pinning idle CPU (issue #6288). Memoizing collapses overlapping scans to one.
-const PS_ARGS = ['-axo', 'pid=,ppid=,stat=,command='] as const
+/** Columns used by the evidence reader. Keep command last so its spaces survive parsing. */
+export const PS_ARGS = ['-axo', 'pid=,ppid=,pgid=,tpgid=,stat=,command='] as const
 const PS_TIMEOUT_MS = 3000
 
 // Why: 500ms is below the active cadence poll's minimum inter-poll gap (~675ms
@@ -24,30 +25,150 @@ const DEFAULT_SNAPSHOT_TTL_MS = 500
 export type ProcessTableRow = {
   pid: number
   ppid: number
+  /** Process group id. Optional only on rows produced by the legacy parser input shape. */
+  pgid?: number
+  /** Terminal foreground process group id (`0`/`-1` means no controlling tty). */
+  tpgid?: number
   stat: string
   command: string
 }
 
 /**
- * Parse `ps -axo pid=,ppid=,stat=,command=` output into rows. Tolerates CRLF so
- * a snapshot parsed on any host stays correct; `command` (last field) keeps its
+ * Parse legacy or evidence-shaped `ps` output into rows. Tolerates CRLF so a
+ * snapshot parsed on any host stays correct; `command` (last field) keeps its
  * internal spaces because the regex is anchored and greedy on the tail.
  */
 export function parseProcessTableRows(stdout: string): ProcessTableRow[] {
   const rows: ProcessTableRow[] = []
   for (const line of stdout.split(/\r?\n/)) {
-    const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/)
+    const trimmed = line.trim()
+    const match = trimmed.match(/^(\d+)\s+(\d+)\s+(?:(-?\d+)\s+(-?\d+)\s+)?(\S+)\s+(.+)$/)
     if (!match) {
       continue
     }
     rows.push({
       pid: Number(match[1]),
       ppid: Number(match[2]),
-      stat: match[3],
-      command: match[4]
-    })
+      ...(match[3] !== undefined ? { pgid: Number(match[3]), tpgid: Number(match[4]) } : {}),
+      stat: match[5] ?? match[3],
+      command: match[6] ?? match[4]
+    } as ProcessTableRow)
   }
   return rows
+}
+
+export class ProcessTableCaptureError extends Error {
+  readonly code = 'process_table_unreadable'
+
+  constructor(readonly reason: string) {
+    super(`process table unreadable: ${reason}`)
+    this.name = 'ProcessTableCaptureError'
+  }
+}
+
+/**
+ * Parse a process-table capture for identity evidence. Unlike the historical
+ * parser above, every non-framing line must be valid: silently dropping one row
+ * could turn a truncated table into a false empty/no-agent result.
+ */
+export function parseStrictProcessTableRows(stdout: string): ProcessTableRow[] {
+  const rows: ProcessTableRow[] = []
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line) {
+      continue
+    }
+    if (/^PID\s+PPID\s+PGID\s+TPGID\s+STAT\s+COMMAND$/i.test(line)) {
+      continue
+    }
+    const match = line.match(/^(\d+)\s+(\d+)\s+(-?\d+)\s+(-?\d+)\s+(\S+)\s+(.+)$/)
+    if (!match) {
+      throw new ProcessTableCaptureError('malformed_row')
+    }
+    const pid = Number(match[1])
+    const ppid = Number(match[2])
+    const pgid = Number(match[3])
+    const tpgid = Number(match[4])
+    if (
+      !Number.isSafeInteger(pid) ||
+      pid <= 0 ||
+      !Number.isSafeInteger(ppid) ||
+      ppid < 0 ||
+      !Number.isSafeInteger(pgid) ||
+      pgid <= 0 ||
+      !Number.isSafeInteger(tpgid) ||
+      (tpgid < 0 && tpgid !== -1) ||
+      match[6].length === 0
+    ) {
+      throw new ProcessTableCaptureError('invalid_numeric_field')
+    }
+    rows.push({ pid, ppid, pgid, tpgid, stat: match[5], command: match[6] })
+  }
+  return rows
+}
+
+/** Alias retained for callers that prefer the adjective at the end. */
+export const parseProcessTableRowsStrict = parseStrictProcessTableRows
+
+export type ProcessTableIndexStats = {
+  captures?: number
+  indexBuilds: number
+  rowVisits: number
+  indexLookups: number
+}
+
+export type ProcessTableIndex = {
+  rows: readonly ProcessTableRow[]
+  byPid: ReadonlyMap<number, ProcessTableRow>
+  childrenByPpid: ReadonlyMap<number, readonly ProcessTableRow[]>
+  byPgid: ReadonlyMap<number, readonly ProcessTableRow[]>
+  byTpgid: ReadonlyMap<number, readonly ProcessTableRow[]>
+  stats?: ProcessTableIndexStats
+}
+
+/** Build all correlation indexes in one linear pass over a capture. */
+export function buildProcessTableIndex(
+  rows: readonly ProcessTableRow[],
+  stats?: ProcessTableIndexStats
+): ProcessTableIndex {
+  if (stats) {
+    stats.indexBuilds += 1
+  }
+  const byPid = new Map<number, ProcessTableRow>()
+  const childrenByPpid = new Map<number, ProcessTableRow[]>()
+  const byPgid = new Map<number, ProcessTableRow[]>()
+  const byTpgid = new Map<number, ProcessTableRow[]>()
+  for (const row of rows) {
+    if (stats) {
+      stats.rowVisits += 1
+    }
+    byPid.set(row.pid, row)
+    const children = childrenByPpid.get(row.ppid) ?? []
+    children.push(row)
+    childrenByPpid.set(row.ppid, children)
+    if (row.pgid !== undefined) {
+      const group = byPgid.get(row.pgid) ?? []
+      group.push(row)
+      byPgid.set(row.pgid, group)
+    }
+    if (row.tpgid !== undefined) {
+      const foreground = byTpgid.get(row.tpgid) ?? []
+      foreground.push(row)
+      byTpgid.set(row.tpgid, foreground)
+    }
+  }
+  return { rows, byPid, childrenByPpid, byPgid, byTpgid, stats }
+}
+
+export function lookupProcessTableIndex<T>(
+  index: ProcessTableIndex,
+  lookup: (index: ProcessTableIndex) => T,
+  stats = index.stats
+): T {
+  if (stats) {
+    stats.indexLookups += 1
+  }
+  return lookup(index)
 }
 
 type Snapshot<T> = { value: T; capturedAtMs: number }
@@ -179,6 +300,17 @@ const defaultReader = createProcessTableSnapshotReader<ProcessTableRow[]>({
   now: () => Date.now()
 })
 
+const strictReader = createProcessTableSnapshotReader<ProcessTableRow[]>({
+  runPs: async () => {
+    const { stdout } = await execFile('ps', [...PS_ARGS], {
+      encoding: 'utf-8',
+      timeout: PS_TIMEOUT_MS
+    })
+    return parseStrictProcessTableRows(stdout)
+  },
+  now: () => Date.now()
+})
+
 /**
  * Run (or reuse a recent) `ps -axo pid=,ppid=,stat=,command=` scan and return
  * its parsed rows. Per-process singleton: the relay and local main processes
@@ -193,10 +325,20 @@ export function getFreshProcessTableSnapshot(): Promise<ProcessTableRow[]> {
   return defaultReader.getFreshSnapshot()
 }
 
+/** Run (or reuse) the strict evidence capture. */
+export function getStrictProcessTableSnapshot(): Promise<ProcessTableRow[]> {
+  return strictReader.getSnapshot()
+}
+
+export function getFreshStrictProcessTableSnapshot(): Promise<ProcessTableRow[]> {
+  return strictReader.getFreshSnapshot()
+}
+
 /**
  * Test-only: clear the shared snapshot cache so suites that mock `ps` between
  * cases don't have one case's snapshot served to the next within the TTL.
  */
 export function resetProcessTableSnapshotForTests(): void {
   defaultReader.reset()
+  strictReader.reset()
 }

--- a/src/shared/process-table-snapshot.ts
+++ b/src/shared/process-table-snapshot.ts
@@ -70,6 +70,13 @@ export class ProcessTableCaptureError extends Error {
  * Parse a process-table capture for identity evidence. Unlike the historical
  * parser above, every non-framing line must be valid: silently dropping one row
  * could turn a truncated table into a false empty/no-agent result.
+ *
+ * Linux kernel roots legitimately report `ppid=0`, `pgid=0`, and
+ * `tpgid=-1`; user-space processes can also report `tpgid=0`/`-1` when no
+ * controlling TTY is attached. The parser therefore rejects only values
+ * outside the process-table domain (`pid <= 0`, `ppid < 0`, `pgid < 0`, or
+ * `tpgid < -1`), while retaining strict row framing and non-empty fields;
+ * an empty/header-only capture is unreadable as well.
  */
 export function parseStrictProcessTableRows(stdout: string): ProcessTableRow[] {
   const rows: ProcessTableRow[] = []
@@ -95,7 +102,7 @@ export function parseStrictProcessTableRows(stdout: string): ProcessTableRow[] {
       !Number.isSafeInteger(ppid) ||
       ppid < 0 ||
       !Number.isSafeInteger(pgid) ||
-      pgid <= 0 ||
+      pgid < 0 ||
       !Number.isSafeInteger(tpgid) ||
       (tpgid < 0 && tpgid !== -1) ||
       match[6].length === 0
@@ -103,6 +110,9 @@ export function parseStrictProcessTableRows(stdout: string): ProcessTableRow[] {
       throw new ProcessTableCaptureError('invalid_numeric_field')
     }
     rows.push({ pid, ppid, pgid, tpgid, stat: match[5], command: match[6] })
+  }
+  if (rows.length === 0) {
+    throw new ProcessTableCaptureError('empty_capture')
   }
   return rows
 }

--- a/src/shared/process-table-snapshot.ts
+++ b/src/shared/process-table-snapshot.ts
@@ -322,7 +322,7 @@ const strictReader = createProcessTableSnapshotReader<ProcessTableRow[]>({
 })
 
 /**
- * Run (or reuse a recent) `ps -axo pid=,ppid=,stat=,command=` scan and return
+ * Run (or reuse a recent) `ps -axo` process-table scan and return
  * its parsed rows. Per-process singleton: the relay and local main processes
  * each dedupe their own scans and share a single parse per TTL window.
  */


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​260 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​259 |
| Prod | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​516 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​59 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​457 |

<!-- /orca-pr-loc -->

## Summary

- Extend POSIX process-table captures with `pgid`/`tpgid` and add a strict parser that treats malformed or incomplete captures as unreadable.
- Build one host-wide process index and correlate all managed PTYs in linear time, using terminal foreground-group association for agent evidence.
- Add optional, validated foreground evidence to the existing `pty.listProcesses` inventory frame while preserving legacy fields and renderer gates.

## Tests

- [x] Focused Vitest suites (25 tests): strict parser, sentinel and failure taxonomy, batched correlation, 1/50/200-pane counters, and evidence admission.
- [x] Existing process-table, foreground-process, relay inventory, SSH mapping, and admission suites (82 tests) pass.
- [x] `tsc --noEmit -p config/tsconfig.node.json` passes.
- [x] Oxlint passes on all changed files.
- [x] `git diff --check` passes.
- [x] Red proof: temporarily added the naive per-pane full-table scan; the 1/50/200-pane scan-volume gate failed (row visits grew from 2/100/400 to 3/2600/40400), then restored the indexed implementation and the gate passed.
- [ ] Live SSH relay/electron validation remains for the coordinator's integration pass; this change is additive and does not open renderer gates.
