### PR TITLE
perf(packaging): ship one native runtime per target

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -90,6 +90,8 @@ const bundledPluginResources = {
 // runtime dependency closure to Resources/node_modules so bare require() calls
 // do not fall through to a developer checkout's node_modules.
 const commonExtraResources = [relayExtraResource, bundledPluginResources, skillFreshnessResources]
+// Why: native speech addons must be real files outside app.asar; copy only the
+// package matching the artifact target instead of every optional variant.
 const macSpeechNativeResource = {
   from: 'node_modules/sherpa-onnx-darwin-${arch}',
   to: 'node_modules/sherpa-onnx-darwin-${arch}'
@@ -162,6 +164,10 @@ module.exports = {
     // Why: bundled plugins ship via extraResources to resources/plugins/launch;
     // packing the source tree into app.asar would duplicate those exact bytes.
     '!resources/plugins/launch/**',
+    // Why: speech packages are copied selectively through the platform
+    // extraResources entry below; keeping them in app.asar would ship every
+    // native variant (and duplicate the selected one).
+    '!node_modules/sherpa-onnx*{,/**/*}',
     // Why: the Windows CLI shim ships via extraResources to resources/bin/orca.cmd
     // (beside the native resources/bin/orca.exe). Packing the source tree into
     // app.asar too lets asarUnpack:['resources/**'] extract a second copy at
@@ -185,9 +191,6 @@ module.exports = {
   // before the GUI process starts, so those deps need the same treatment.
   // Why: out/package.json pins compiled output to CommonJS so parent
   // package.json files with type=module cannot change the packaged CLI loader.
-  // Why: sherpa-onnx native bindings (platform-specific subpackages) must be
-  // unpacked because they ship .node addons + .dylib/.so files that cannot be
-  // dlopen()'d from inside the asar archive.
   // Why: the OpenCode SQLite worker entry is also spawned by the scanner
   // service, which runs under ELECTRON_RUN_AS_NODE and so cannot see into
   // app.asar. Left packed, that spawn fails closed and every OpenCode session
@@ -221,8 +224,7 @@ module.exports = {
     'node_modules/ws/**',
     'node_modules/tweetnacl/**',
     'node_modules/zod/**',
-    'node_modules/yaml/**',
-    'node_modules/sherpa-onnx*/**'
+    'node_modules/yaml/**'
   ],
   afterPack: async (context) => {
     // Why: a Linux runner-image glibc bump silently shipped a node-pty pty.node
@@ -424,12 +426,6 @@ module.exports = {
       {
         from: 'node_modules/agent-browser/bin/agent-browser-darwin-${arch}',
         to: 'agent-browser-darwin-${arch}'
-      },
-      // Why: serve-sim resolves its helper binary and camera assets relative
-      // to dist/serve-sim.js, so the whole package must be a real resource dir.
-      {
-        from: 'node_modules/serve-sim',
-        to: 'serve-sim'
       },
       {
         from: 'native/computer-use-macos/.build/release/Orca Computer Use.app',

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -156,6 +156,16 @@ describe('electron-builder config', () => {
     )
   })
 
+  it('ships one macOS serve-sim package through the runtime closure', () => {
+    const serveSimResources = electronBuilderConfig.mac.extraResources.filter((resource) =>
+      [join('node_modules', 'serve-sim'), 'serve-sim'].includes(resource.to)
+    )
+
+    expect(serveSimResources).toEqual([
+      expect.objectContaining({ to: join('node_modules', 'serve-sim') })
+    ])
+  })
+
   // Why: the Windows CLI shim is delivered only via extraResources to
   // resources/bin/orca.cmd (beside the native resources/bin/orca.exe). If the
   // source tree is also packed into app.asar it gets extracted by

--- a/config/scripts/electron-builder-speech-config.test.mjs
+++ b/config/scripts/electron-builder-speech-config.test.mjs
@@ -1,0 +1,41 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const electronBuilderConfig = require('../electron-builder.config.cjs')
+const { FileMatcher } = require('app-builder-lib/out/fileMatcher')
+
+describe('electron-builder speech resources', () => {
+  it('excludes bundled variants and keeps one target resource per platform', () => {
+    expect(electronBuilderConfig.files).toContain('!node_modules/sherpa-onnx*{,/**/*}')
+    expect(electronBuilderConfig.asarUnpack).not.toContain('node_modules/sherpa-onnx*/**')
+
+    for (const [platform, packagePath] of [
+      ['mac', 'node_modules/sherpa-onnx-darwin-${arch}'],
+      ['linux', 'node_modules/sherpa-onnx-linux-${arch}'],
+      ['win', 'node_modules/sherpa-onnx-win-x64']
+    ]) {
+      const speechResources = electronBuilderConfig[platform].extraResources.filter(
+        (resource) =>
+          typeof resource.to === 'string' && resource.to.startsWith('node_modules/sherpa-onnx')
+      )
+      expect(speechResources).toEqual([{ from: packagePath, to: packagePath }])
+    }
+
+    const matcher = new FileMatcher('/app', '/dest', (value) => value, electronBuilderConfig.files)
+    matcher.prependPattern('**/*')
+    const isPacked = matcher.createFilter()
+    const stat = { isDirectory: () => false }
+    for (const packageName of [
+      'sherpa-onnx',
+      'sherpa-onnx-darwin-arm64',
+      'sherpa-onnx-darwin-x64',
+      'sherpa-onnx-linux-arm64',
+      'sherpa-onnx-linux-x64',
+      'sherpa-onnx-win-x64'
+    ]) {
+      expect(isPacked(`/app/node_modules/${packageName}/index.js`, stat)).toBe(false)
+    }
+    expect(isPacked('/app/node_modules/ws/index.js', stat)).toBe(true)
+  })
+})

--- a/src/main/emulator/serve-sim-execution.test.ts
+++ b/src/main/emulator/serve-sim-execution.test.ts
@@ -1,0 +1,125 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronMocks = vi.hoisted(() => ({
+  getAppPath: vi.fn(),
+  getPath: vi.fn(),
+  getVersion: vi.fn()
+}))
+const materializerMocks = vi.hoisted(() => ({
+  materializeServeSimRuntime: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getAppPath: electronMocks.getAppPath,
+    getPath: electronMocks.getPath,
+    getVersion: electronMocks.getVersion
+  }
+}))
+vi.mock('./serve-sim-runtime-materializer', () => materializerMocks)
+
+import { resolveServeSimExecutable } from './serve-sim-execution'
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+const originalResourcesPath = Object.getOwnPropertyDescriptor(process, 'resourcesPath')
+const cleanupPaths: string[] = []
+
+function setProcessProperty(name: 'platform' | 'resourcesPath', value: string): void {
+  Object.defineProperty(process, name, { configurable: true, value })
+}
+
+function restoreProcessProperty(
+  name: 'platform' | 'resourcesPath',
+  descriptor?: PropertyDescriptor
+) {
+  if (descriptor) {
+    Object.defineProperty(process, name, descriptor)
+  } else {
+    Reflect.deleteProperty(process, name)
+  }
+}
+
+async function createServeSimPackage(packageDir: string): Promise<string> {
+  const entry = join(packageDir, 'dist', 'serve-sim.js')
+  await mkdir(join(packageDir, 'dist'), { recursive: true })
+  await writeFile(entry, 'console.log("serve-sim")')
+  return entry
+}
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), 'orca-serve-sim-execution-'))
+  cleanupPaths.push(root)
+  setProcessProperty('platform', 'linux')
+  setProcessProperty('resourcesPath', join(root, 'resources'))
+  electronMocks.getAppPath.mockReset().mockReturnValue(join(root, 'app'))
+  electronMocks.getPath.mockReset().mockReturnValue(join(root, 'user-data'))
+  electronMocks.getVersion.mockReset().mockReturnValue('test-version')
+  materializerMocks.materializeServeSimRuntime.mockReset()
+})
+
+afterEach(async () => {
+  restoreProcessProperty('platform', originalPlatform)
+  restoreProcessProperty('resourcesPath', originalResourcesPath)
+  await Promise.all(
+    cleanupPaths.splice(0).map((path) => rm(path, { recursive: true, force: true }))
+  )
+})
+
+describe('resolveServeSimExecutable', () => {
+  it('preserves the legacy Resources/serve-sim path as the first packaged choice', async () => {
+    const resourcesPath = process.resourcesPath
+    const legacyEntry = await createServeSimPackage(join(resourcesPath, 'serve-sim'))
+    await createServeSimPackage(join(resourcesPath, 'node_modules', 'serve-sim'))
+
+    expect(resolveServeSimExecutable()).toEqual({
+      command: process.execPath,
+      baseArgs: [legacyEntry],
+      usesElectronAsNode: true
+    })
+    expect(electronMocks.getAppPath).not.toHaveBeenCalled()
+  })
+
+  it('uses the deduplicated Resources/node_modules/serve-sim package', async () => {
+    const packagedEntry = await createServeSimPackage(
+      join(process.resourcesPath, 'node_modules', 'serve-sim')
+    )
+
+    expect(resolveServeSimExecutable()).toEqual({
+      command: process.execPath,
+      baseArgs: [packagedEntry],
+      usesElectronAsNode: true
+    })
+    expect(electronMocks.getAppPath).not.toHaveBeenCalled()
+  })
+
+  it('materializes either packaged resource location on macOS', async () => {
+    setProcessProperty('platform', 'darwin')
+    const packagedPackageDir = join(process.resourcesPath, 'node_modules', 'serve-sim')
+    await createServeSimPackage(packagedPackageDir)
+    const materializedPackageDir = join(process.resourcesPath, 'materialized-serve-sim')
+    materializerMocks.materializeServeSimRuntime.mockReturnValue(materializedPackageDir)
+
+    expect(resolveServeSimExecutable()).toEqual({
+      command: process.execPath,
+      baseArgs: [join(materializedPackageDir, 'dist', 'serve-sim.js')],
+      usesElectronAsNode: true
+    })
+    expect(materializerMocks.materializeServeSimRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({ bundledPackageDir: packagedPackageDir })
+    )
+  })
+
+  it('preserves the app node_modules development fallback', async () => {
+    const appPackageDir = join(electronMocks.getAppPath(), 'node_modules', 'serve-sim')
+    const appEntry = await createServeSimPackage(appPackageDir)
+
+    expect(resolveServeSimExecutable()).toEqual({
+      command: process.execPath,
+      baseArgs: [appEntry],
+      usesElectronAsNode: true
+    })
+  })
+})

--- a/src/main/emulator/serve-sim-execution.ts
+++ b/src/main/emulator/serve-sim-execution.ts
@@ -10,7 +10,7 @@ import {
 } from 'node:fs'
 import { app } from 'electron'
 import { platform, tmpdir } from 'node:os'
-import { delimiter, dirname, join } from 'node:path'
+import { delimiter, join } from 'node:path'
 import { EmulatorError } from './emulator-errors'
 import { materializeServeSimRuntime } from './serve-sim-runtime-materializer'
 
@@ -95,15 +95,22 @@ export function resolveServeSimExecutable(): ServeSimExecutable {
     (process.platform === 'darwin'
       ? join(app.getPath('exe'), '..', '..', 'Resources')
       : join(app.getPath('exe'), '..', 'resources'))
-  const bundled = join(bundledResourcesPath, 'serve-sim', 'dist', 'serve-sim.js')
-  if (existsSync(bundled)) {
+  // macOS releases used to copy serve-sim to Resources/serve-sim explicitly.
+  // The runtime closure now owns a single copy under Resources/node_modules;
+  // keep the root path first so already-installed bundles continue to work.
+  for (const bundledPackageDir of [
+    join(bundledResourcesPath, 'serve-sim'),
+    join(bundledResourcesPath, 'node_modules', 'serve-sim')
+  ]) {
+    const bundledEntry = join(bundledPackageDir, 'dist', 'serve-sim.js')
+    if (!existsSync(bundledEntry)) {
+      continue
+    }
     if (process.platform === 'darwin') {
       // Why: the bundled camera dylib is signed but has no Gatekeeper ticket
       // (iOS-simulator arch), so injecting it from the quarantined app bundle
       // can trip syspolicyd; run serve-sim from an unquarantined copy instead.
-      const materializedDir = resolveMaterializedServeSimPackageDir(
-        join(bundledResourcesPath, 'serve-sim')
-      )
+      const materializedDir = resolveMaterializedServeSimPackageDir(bundledPackageDir)
       if (materializedDir) {
         return {
           command: process.execPath,
@@ -112,18 +119,13 @@ export function resolveServeSimExecutable(): ServeSimExecutable {
         }
       }
     }
-    return { command: process.execPath, baseArgs: [bundled], usesElectronAsNode: true }
+    return { command: process.execPath, baseArgs: [bundledEntry], usesElectronAsNode: true }
   }
 
-  const nodeModulesEntry = join(
-    app.getAppPath(),
-    'node_modules',
-    'serve-sim',
-    'dist',
-    'serve-sim.js'
-  )
+  const nodeModulesPackageDir = join(app.getAppPath(), 'node_modules', 'serve-sim')
+  const nodeModulesEntry = join(nodeModulesPackageDir, 'dist', 'serve-sim.js')
   if (existsSync(nodeModulesEntry)) {
-    const helperBin = join(dirname(nodeModulesEntry), '..', 'bin', 'serve-sim-bin')
+    const helperBin = join(nodeModulesPackageDir, 'bin', 'serve-sim-bin')
     if (existsSync(helperBin) && process.platform !== 'win32') {
       try {
         accessSync(helperBin, constants.X_OK)


### PR DESCRIPTION
## What this changes

- Exclude all Sherpa optional packages from `app.asar` and copy only the native package required by each target.
- Stop copying a second macOS `serve-sim` directory at `Resources/serve-sim`; use the runtime-closure copy at `Resources/node_modules/serve-sim`.
- Keep the legacy `Resources/serve-sim` lookup first so already-installed bundles continue to launch.

### ELI5

The installer used to carry extra copies/variants of native helpers. This PR puts each platform’s speech engine in one known place and keeps one simulator helper instead of two. Existing installs still work because the old location is still recognized.

## Measurement (macOS arm64, unpacked `dist/mac-arm64/Orca.app`)

- Total app after the complete size pass: ~495 MB (baseline ~531 MB).
- Duplicate `serve-sim` copy removed: approximately 4.2 MB.
- Packaged `Resources/node_modules` contains exactly one `serve-sim` directory and exactly one `sherpa-onnx-darwin-arm64` package.
- `app.asar` and `app.asar.unpacked` contain no Sherpa entries.
- The macOS baseline already contained only the target Sherpa package; the target-selection rule is a defensive guarantee for Linux/Windows artifacts rather than a claimed extra macOS saving.

## Crash-report/debugability

This PR does not change JavaScript minification, source maps, crash IPC payloads, or breadcrumb collection. The serve-sim resolver keeps the existing executable/error paths and adds coverage for both resource locations.

## Readiness checklist

Reviewed against all eight sections:

- SSH/remote/network: no SSH, relay, RPC, or remote execution code changed.
- Crash/retry/growth: resolver performs a bounded two-location existence check; no new retry loop, timer, listener, or retained state.
- Security/supply chain: no new network sink, secret, installer hook, or dependency change; resources come from existing pinned packages.
- Performance/resources: removes one ~4.2 MB copy; resolver does at most two filesystem probes before the existing materialization path.
- Functional correctness: legacy path is preferred, new path is supported, and packaged Electron/CDP smoke passed.
- Backward compatibility/data loss: no persisted state, schema, IPC, or mobile surface changed.
- Cross-platform/remoting: uses `path.join`; target resources cover macOS, Linux, and Windows x64; native load checks passed for the packaged macOS target.
- Code organization: packaging and resolver logic remain in their existing domain modules.

**Verdict: PASS.** No proven P0/P1/P2 findings. Residual validation gap: Linux and Windows release artifacts should run their normal CI native-load checks.

## Validation

- Focused packaging tests: 42/42 passed.
- Related packaging/CLI tests: 35/35 passed.
- `pnpm run tc:node` and changed-file lint/format checks passed.
- `pnpm run build:unpack` passed on macOS arm64.
- Post-pack resource, signing/native checks, plain-Node native load, and Electron/CDP smoke checks passed.
