### PR TITLE
Avoid Linear read re-fetches when workspace scope is unchanged

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -79,6 +79,7 @@ import type { GitHubWorkItem } from '../../../../shared/github/work-item-types'
 import type { GitLabWorkItem } from '../../../../shared/gitlab-types'
 import type { JiraIssue, JiraSite } from '../../../../shared/jira-types'
 import type { LinearIssue } from '../../../../shared/linear/issue-types'
+import { linearWorkspaceScopeSignature } from '../../../../shared/linear/workspace-types'
 import type { BaseRefSearchResult } from '../../../../shared/repo-types'
 import { resolveSmartWorkspaceCommandValue } from './smart-workspace-command-value'
 import { isComposerFieldToFieldFocus } from './smart-workspace-source-popover-focus'
@@ -425,6 +426,14 @@ export default function SmartWorkspaceNameField({
   const showJiraSiteContext = mode === 'jira' && jiraConnectionStatus?.selectedSiteId === 'all'
   const jiraStatusId = React.useId()
   const linearStatusId = React.useId()
+  // Read the latest metadata for URL resolution without making the search effect depend on object identity.
+  const linearStatusRef = useRef(linearStatus)
+  linearStatusRef.current = linearStatus
+  // Store action references can change with wiring; reads should only rerun for query/scope changes.
+  const linearReadMethodsRef = useRef({ fetchLinearIssue, listLinearIssues, searchLinearIssues })
+  linearReadMethodsRef.current = { fetchLinearIssue, listLinearIssues, searchLinearIssues }
+  const linearConnected = linearStatus.connected === true
+  const linearScopeSignature = linearWorkspaceScopeSignature(linearStatus)
 
   useEffect(() => {
     onActiveSourceModeChange?.(mode)
@@ -1018,7 +1027,7 @@ export default function SmartWorkspaceNameField({
   }, [branchSearchRequest, selectedRepoOwnerSettings])
 
   useEffect(() => {
-    if (disabled || !shouldQueryLinear || !linearStatus.connected) {
+    if (disabled || !shouldQueryLinear || !linearConnected) {
       setLinearIssues([])
       setLinearLoading(false)
       setSettledLinearUrlQuery(null)
@@ -1035,18 +1044,24 @@ export default function SmartWorkspaceNameField({
     const request = linearUrlIntent
       ? lookupLinearIssueUrl({
           intent: linearUrlIntent,
-          knownStatus: linearStatus,
+          knownStatus: linearStatusRef.current,
           sourceContext: linearSourceContext,
-          fetchLinearIssue
+          fetchLinearIssue: linearReadMethodsRef.current.fetchLinearIssue
         }).then((issue) => (issue ? [issue] : []))
       : trimmed
-        ? searchLinearIssues(getSmartWorkspaceLinearSearchQuery(trimmed), RESULT_LIMIT, {
-            sourceContext: linearSourceContext
-          })
-        : listLinearIssues(
-            { kind: 'list', filter: 'assigned', limit: RESULT_LIMIT },
-            { sourceContext: linearSourceContext }
-          ).then((result) => result.items)
+        ? linearReadMethodsRef.current.searchLinearIssues(
+            getSmartWorkspaceLinearSearchQuery(trimmed),
+            RESULT_LIMIT,
+            {
+              sourceContext: linearSourceContext
+            }
+          )
+        : linearReadMethodsRef.current
+            .listLinearIssues(
+              { kind: 'list', filter: 'assigned', limit: RESULT_LIMIT },
+              { sourceContext: linearSourceContext }
+            )
+            .then((result) => result.items)
     void request
       .then((issues) => {
         if (!stale) {
@@ -1068,8 +1083,15 @@ export default function SmartWorkspaceNameField({
       stale = true
     }
     // Why: list/search are stable store methods; depending on them would refetch on unrelated store writes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [disabled, linearQuery, linearSourceContext, linearStatus, linearUrlIntent, shouldQueryLinear])
+  }, [
+    disabled,
+    linearConnected,
+    linearQuery,
+    linearScopeSignature,
+    linearSourceContext,
+    linearUrlIntent,
+    shouldQueryLinear
+  ])
 
   useEffect(() => {
     if (!shouldQueryJira || !jiraSourceContext || !jiraSearchJql) {

--- a/src/renderer/src/store/slices/linear.test.ts
+++ b/src/renderer/src/store/slices/linear.test.ts
@@ -86,6 +86,40 @@ describe('createLinearSlice', () => {
     expect(store.getState().linearStatusChecked).toBe(true)
   })
 
+  it('preserves status identity when a connection probe leaves its scope unchanged', async () => {
+    const store = createTestStore()
+    const currentStatus: LinearConnectionStatus = {
+      connected: true,
+      viewer: {
+        displayName: 'Test User',
+        email: 'test@example.com',
+        organizationName: 'Test Org'
+      },
+      selectedWorkspaceId: 'workspace-1',
+      activeWorkspaceId: 'workspace-1',
+      workspaces: [
+        {
+          id: 'workspace-1',
+          organizationId: 'workspace-1',
+          organizationName: 'Test Org',
+          displayName: 'Test User',
+          email: 'test@example.com'
+        }
+      ]
+    }
+    store.setState({
+      linearStatus: currentStatus,
+      linearStatusChecked: true,
+      linearStatusContextKey: 'local#0'
+    })
+    linearTestConnection.mockResolvedValueOnce({ ok: true, viewer: currentStatus.viewer })
+    linearStatus.mockResolvedValueOnce({ ...currentStatus, viewer: { ...currentStatus.viewer } })
+
+    await store.getState().testLinearConnection()
+
+    expect(store.getState().linearStatus).toBe(currentStatus)
+  })
+
   it('ignores stale forced connection checks when a newer forced check finishes first', async () => {
     const staleCheck = deferred<LinearConnectionStatus>()
     const freshCheck = deferred<LinearConnectionStatus>()

--- a/src/renderer/src/store/slices/linear.ts
+++ b/src/renderer/src/store/slices/linear.ts
@@ -236,6 +236,7 @@ function linearWorkspaceSignature(workspace: LinearWorkspace): string {
   ].join('\u001f')
 }
 
+/** Cache-invalidation key: broader than `linearWorkspaceScopeSignature`, hashes full viewer and workspace metadata. */
 function linearStatusScopeSignature(status: LinearConnectionStatus): string {
   return JSON.stringify({
     connected: status.connected,

--- a/src/renderer/src/store/slices/linear.ts
+++ b/src/renderer/src/store/slices/linear.ts
@@ -607,7 +607,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
     if (inflightStatusRequest && !force && inflightStatusRequest.contextKey === contextKey) {
       return inflightStatusRequest.promise
     }
-    if (get().linearStatusContextKey !== contextKey) {
+    if (get().linearStatusContextKey !== contextKey && get().linearStatusChecked) {
       set({ linearStatusChecked: false })
     }
 
@@ -732,12 +732,9 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
             linearStatusChecked: true,
             linearStatusContextKey: contextKey
           })
-        } else {
-          set({
-            linearStatus: status,
-            linearStatusChecked: true,
-            linearStatusContextKey: contextKey
-          })
+        } else if (!get().linearStatusChecked || get().linearStatusContextKey !== contextKey) {
+          // Preserve the status reference when the probe did not change scope.
+          set({ linearStatusChecked: true, linearStatusContextKey: contextKey })
         }
       }
       return result

--- a/src/shared/linear/workspace-types.test.ts
+++ b/src/shared/linear/workspace-types.test.ts
@@ -46,4 +46,64 @@ describe('linearWorkspaceScopeSignature', () => {
 
     expect(linearWorkspaceScopeSignature(second)).not.toBe(linearWorkspaceScopeSignature(first))
   })
+
+  it('changes when a workspace credential revision changes', () => {
+    const first: LinearConnectionStatus = {
+      connected: true,
+      viewer: null,
+      workspaces: [
+        {
+          id: 'workspace-1',
+          organizationId: 'org-1',
+          organizationName: 'Alpha',
+          displayName: 'Ada',
+          email: 'ada@example.com',
+          credentialRevision: 1
+        }
+      ]
+    }
+    const second: LinearConnectionStatus = {
+      ...first,
+      workspaces: [{ ...first.workspaces![0], credentialRevision: 2 }]
+    }
+
+    expect(linearWorkspaceScopeSignature(second)).not.toBe(linearWorkspaceScopeSignature(first))
+  })
+
+  it('changes when a workspace or viewer organization url key changes', () => {
+    const first: LinearConnectionStatus = {
+      connected: true,
+      viewer: {
+        displayName: 'Ada',
+        email: 'ada@example.com',
+        organizationName: 'Alpha',
+        organizationUrlKey: 'alpha'
+      },
+      workspaces: [
+        {
+          id: 'workspace-1',
+          organizationId: 'org-1',
+          organizationName: 'Alpha',
+          displayName: 'Ada',
+          email: 'ada@example.com',
+          organizationUrlKey: 'alpha'
+        }
+      ]
+    }
+    const renamedWorkspaceKey: LinearConnectionStatus = {
+      ...first,
+      workspaces: [{ ...first.workspaces![0], organizationUrlKey: 'alpha-renamed' }]
+    }
+    const renamedViewerKey: LinearConnectionStatus = {
+      ...first,
+      viewer: { ...first.viewer!, organizationUrlKey: 'alpha-renamed' }
+    }
+
+    expect(linearWorkspaceScopeSignature(renamedWorkspaceKey)).not.toBe(
+      linearWorkspaceScopeSignature(first)
+    )
+    expect(linearWorkspaceScopeSignature(renamedViewerKey)).not.toBe(
+      linearWorkspaceScopeSignature(first)
+    )
+  })
 })

--- a/src/shared/linear/workspace-types.test.ts
+++ b/src/shared/linear/workspace-types.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { linearWorkspaceScopeSignature, type LinearConnectionStatus } from './workspace-types'
+
+describe('linearWorkspaceScopeSignature', () => {
+  it('ignores status metadata and workspace ordering', () => {
+    const first: LinearConnectionStatus = {
+      connected: true,
+      viewer: { displayName: 'Ada', email: 'ada@example.com', organizationName: 'Alpha' },
+      selectedWorkspaceId: 'workspace-1',
+      workspaces: [
+        {
+          id: 'workspace-1',
+          organizationId: 'org-1',
+          organizationName: 'Alpha',
+          displayName: 'Ada',
+          email: 'ada@example.com'
+        },
+        {
+          id: 'workspace-2',
+          organizationId: 'org-2',
+          organizationName: 'Beta',
+          displayName: 'Ada',
+          email: 'ada@example.com'
+        }
+      ]
+    }
+    const second: LinearConnectionStatus = {
+      ...first,
+      viewer: { ...first.viewer!, organizationName: 'Renamed' },
+      workspaces: [
+        { ...first.workspaces![1], organizationName: 'Renamed Beta' },
+        { ...first.workspaces![0], organizationName: 'Renamed Alpha' }
+      ]
+    }
+
+    expect(linearWorkspaceScopeSignature(second)).toBe(linearWorkspaceScopeSignature(first))
+  })
+
+  it('changes when the selected workspace changes', () => {
+    const first: LinearConnectionStatus = {
+      connected: true,
+      viewer: null,
+      selectedWorkspaceId: 'workspace-1'
+    }
+    const second = { ...first, selectedWorkspaceId: 'workspace-2' }
+
+    expect(linearWorkspaceScopeSignature(second)).not.toBe(linearWorkspaceScopeSignature(first))
+  })
+})

--- a/src/shared/linear/workspace-types.test.ts
+++ b/src/shared/linear/workspace-types.test.ts
@@ -47,6 +47,18 @@ describe('linearWorkspaceScopeSignature', () => {
     expect(linearWorkspaceScopeSignature(second)).not.toBe(linearWorkspaceScopeSignature(first))
   })
 
+  it('changes when the active workspace changes while all workspaces are selected', () => {
+    const first: LinearConnectionStatus = {
+      connected: true,
+      viewer: null,
+      selectedWorkspaceId: 'all',
+      activeWorkspaceId: 'workspace-1'
+    }
+    const second = { ...first, activeWorkspaceId: 'workspace-2' }
+
+    expect(linearWorkspaceScopeSignature(second)).not.toBe(linearWorkspaceScopeSignature(first))
+  })
+
   it('changes when a workspace credential revision changes', () => {
     const first: LinearConnectionStatus = {
       connected: true,

--- a/src/shared/linear/workspace-types.ts
+++ b/src/shared/linear/workspace-types.ts
@@ -61,6 +61,8 @@ export function linearWorkspaceScopeSignature(
     connected: status.connected === true,
     credentialError: status.credentialError ?? null,
     workspaceId: status.selectedWorkspaceId ?? status.activeWorkspaceId ?? null,
+    // Why: under 'all', URL lookup still falls back to the active workspace, so it must key reads too.
+    activeWorkspaceId: status.activeWorkspaceId ?? null,
     // Why: URL resolution routes by organizationUrlKey, and credentialRevision changes what a read returns.
     viewerOrganizationUrlKey: status.viewer?.organizationUrlKey ?? null,
     workspaces: (status.workspaces ?? [])

--- a/src/shared/linear/workspace-types.ts
+++ b/src/shared/linear/workspace-types.ts
@@ -41,6 +41,21 @@ export type LinearConnectionStatus = {
   credentialError?: string
 }
 
+/** Stable dependency key for Linear reads; excludes volatile workspace metadata. */
+export function linearWorkspaceScopeSignature(
+  status: Pick<
+    LinearConnectionStatus,
+    'connected' | 'credentialError' | 'activeWorkspaceId' | 'selectedWorkspaceId' | 'workspaces'
+  >
+): string {
+  return JSON.stringify({
+    connected: status.connected === true,
+    credentialError: status.credentialError ?? null,
+    workspaceId: status.selectedWorkspaceId ?? status.activeWorkspaceId ?? null,
+    workspaceIds: (status.workspaces ?? []).map((workspace) => workspace.id).sort()
+  })
+}
+
 export type LinearWorkflowState = {
   id: string
   name: string

--- a/src/shared/linear/workspace-types.ts
+++ b/src/shared/linear/workspace-types.ts
@@ -41,18 +41,35 @@ export type LinearConnectionStatus = {
   credentialError?: string
 }
 
-/** Stable dependency key for Linear reads; excludes volatile workspace metadata. */
+/**
+ * Stable dependency key for Linear reads: only the fields that change what a read returns.
+ * Not interchangeable with the store's `linearStatusScopeSignature`, which hashes full
+ * viewer and workspace metadata for cache invalidation and so churns on read-irrelevant edits.
+ */
 export function linearWorkspaceScopeSignature(
   status: Pick<
     LinearConnectionStatus,
-    'connected' | 'credentialError' | 'activeWorkspaceId' | 'selectedWorkspaceId' | 'workspaces'
+    | 'connected'
+    | 'credentialError'
+    | 'activeWorkspaceId'
+    | 'selectedWorkspaceId'
+    | 'workspaces'
+    | 'viewer'
   >
 ): string {
   return JSON.stringify({
     connected: status.connected === true,
     credentialError: status.credentialError ?? null,
     workspaceId: status.selectedWorkspaceId ?? status.activeWorkspaceId ?? null,
-    workspaceIds: (status.workspaces ?? []).map((workspace) => workspace.id).sort()
+    // Why: URL resolution routes by organizationUrlKey, and credentialRevision changes what a read returns.
+    viewerOrganizationUrlKey: status.viewer?.organizationUrlKey ?? null,
+    workspaces: (status.workspaces ?? [])
+      .map((workspace) =>
+        [workspace.id, workspace.organizationUrlKey ?? '', workspace.credentialRevision ?? 0].join(
+          '\u001f'
+        )
+      )
+      .sort()
   })
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 |

<!-- /orca-pr-loc -->

## Problem

Linear issue searches were refetching unnecessarily. The search effect depended on `linearStatus` object identity, which changes on every store update even when the workspace scope (selected workspace, available workspaces) stays the same. This caused expensive searches to run when unrelated Linear metadata like the viewer name was updated.

## Solution

Introduce `linearWorkspaceScopeSignature()` to create a stable dependency key that captures only scope-relevant fields: `connected`, `credentialError`, `selectedWorkspaceId`, and the sorted workspace IDs. The effect now depends on this signature instead of the full status object. Store method references and latest status metadata in refs to avoid dependency changes from store wiring updates.

## What Changed

- Added `linearWorkspaceScopeSignature()` in `src/shared/linear/workspace-types.ts` — extracts a stable JSON key from scope-relevant status fields
- Updated `SmartWorkspaceNameField` effect dependencies to use the scope signature and a `linearConnected` boolean instead of the full `linearStatus` object
- Stored `linearStatus` and read methods in refs to allow accessing latest values without triggering dependency changes
- Modified `createLinearSlice` to preserve status reference identity when a probe finds the scope unchanged

## Testing

- [x] Added `linearWorkspaceScopeSignature` tests verifying it ignores metadata reordering and changes only on scope changes
- [x] Added integration test in `linear.test.ts` confirming status identity is preserved when connection probes leave scope unchanged

## Visual Proof

N/A — performance improvement to Linear search re-fetch logic; no user-facing changes.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] N/A for screenshots (backend state fix)
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)