### PR TITLE
fix(jira): negotiate user-field support with remote hosts

### DIFF
--- a/src/renderer/src/runtime/runtime-jira-client.test.ts
+++ b/src/renderer/src/runtime/runtime-jira-client.test.ts
@@ -2,21 +2,29 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  jiraCreateIssue,
   jiraGetIssue,
   jiraIssueComments,
   jiraListAssignableUsers,
   jiraLookupIssueSummary,
   jiraReadStatus,
-  jiraSearchIssues
+  jiraSearchIssues,
+  jiraSearchUsers
 } from './runtime-jira-client'
 import { clearRuntimeCompatibilityCacheForTests } from './runtime-rpc-client'
 import { createCompatibleRuntimeStatusResponse } from './runtime-compatibility-test-fixture'
+import {
+  JIRA_USER_FIELDS_RUNTIME_CAPABILITY,
+  JIRA_USER_FIELDS_UPDATE_REQUIRED_MESSAGE
+} from '../../../shared/protocol-version'
 
 type RuntimeSubscribeArgs = Parameters<typeof window.api.runtimeEnvironments.subscribe>[0]
 type RuntimeSubscribeCallbacks = Parameters<typeof window.api.runtimeEnvironments.subscribe>[1]
 
 const jiraSearchIssuesLocal = vi.fn()
 const jiraListAssignableUsersLocal = vi.fn()
+const jiraSearchUsersLocal = vi.fn()
+const jiraCreateIssueLocal = vi.fn()
 const jiraReadStatusLocal = vi.fn()
 const jiraLookupIssueSummaryLocal = vi.fn()
 const jiraCancelIssueSummaryLocal = vi.fn()
@@ -27,6 +35,8 @@ beforeEach(() => {
   clearRuntimeCompatibilityCacheForTests()
   jiraSearchIssuesLocal.mockReset()
   jiraListAssignableUsersLocal.mockReset()
+  jiraSearchUsersLocal.mockReset()
+  jiraCreateIssueLocal.mockReset()
   jiraReadStatusLocal.mockReset()
   jiraLookupIssueSummaryLocal.mockReset()
   jiraCancelIssueSummaryLocal.mockReset()
@@ -39,7 +49,9 @@ beforeEach(() => {
         lookupIssueSummary: jiraLookupIssueSummaryLocal,
         cancelIssueSummary: jiraCancelIssueSummaryLocal,
         searchIssues: jiraSearchIssuesLocal,
-        listAssignableUsers: jiraListAssignableUsersLocal
+        listAssignableUsers: jiraListAssignableUsersLocal,
+        searchUsers: jiraSearchUsersLocal,
+        createIssue: jiraCreateIssueLocal
       },
       runtimeEnvironments: {
         call: runtimeCall,
@@ -54,6 +66,17 @@ afterEach(() => {
 })
 
 describe('runtime Jira client search bounds', () => {
+  function createRuntimeStatusWithoutJiraUserFieldsCapability() {
+    const status = createCompatibleRuntimeStatusResponse()
+    if (!status.ok) {
+      throw new Error('Expected a successful compatibility fixture.')
+    }
+    status.result.capabilities = status.result.capabilities?.filter(
+      (capability) => capability !== JIRA_USER_FIELDS_RUNTIME_CAPABILITY
+    )
+    return status
+  }
+
   it('routes isolated status and summary reads through local and paired-runtime owners', async () => {
     const localContext = {
       kind: 'task-source' as const,
@@ -168,6 +191,145 @@ describe('runtime Jira client search bounds', () => {
 
     expect(jiraListAssignableUsersLocal).not.toHaveBeenCalled()
     expect(runtimeCall).not.toHaveBeenCalled()
+  })
+
+  it('routes local Jira user search through IPC', async () => {
+    jiraSearchUsersLocal.mockResolvedValue([{ accountId: 'account-1', displayName: 'Ada' }])
+
+    await expect(jiraSearchUsers(null, 'Ada', 'site-1')).resolves.toEqual([
+      { accountId: 'account-1', displayName: 'Ada' }
+    ])
+
+    expect(jiraSearchUsersLocal).toHaveBeenCalledWith({ query: 'Ada', siteId: 'site-1' })
+    expect(runtimeCall).not.toHaveBeenCalled()
+  })
+
+  it('routes remote Jira user search only when the host advertises the capability', async () => {
+    runtimeCall.mockImplementation(async (args: { method: string }) => {
+      if (args.method === 'status.get') {
+        return createCompatibleRuntimeStatusResponse()
+      }
+      return {
+        id: 'rpc-1',
+        ok: true,
+        result: [{ accountId: 'account-1', displayName: 'Ada' }],
+        _meta: { runtimeId: 'remote-runtime' }
+      }
+    })
+
+    await expect(
+      jiraSearchUsers({ activeRuntimeEnvironmentId: 'env-1' }, 'Ada', 'site-1')
+    ).resolves.toEqual([{ accountId: 'account-1', displayName: 'Ada' }])
+    expect(runtimeCall).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ method: 'status.get', selector: 'env-1' })
+    )
+    expect(runtimeCall).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: 'jira.searchUsers',
+        params: { query: 'Ada', siteId: 'site-1' },
+        selector: 'env-1'
+      })
+    )
+  })
+
+  it('degrades remote Jira user search when the host lacks the capability', async () => {
+    runtimeCall.mockResolvedValue(createRuntimeStatusWithoutJiraUserFieldsCapability())
+
+    await expect(jiraSearchUsers({ activeRuntimeEnvironmentId: 'env-1' }, 'Ada')).resolves.toEqual(
+      []
+    )
+    expect(runtimeCall).toHaveBeenCalledTimes(1)
+    expect(runtimeCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'jira.searchUsers' })
+    )
+  })
+
+  it('blocks remote Jira user-field creation when the host lacks the capability', async () => {
+    runtimeCall.mockResolvedValue(createRuntimeStatusWithoutJiraUserFieldsCapability())
+
+    await expect(
+      jiraCreateIssue(
+        { activeRuntimeEnvironmentId: 'env-1' },
+        {
+          projectId: 'project-1',
+          issueTypeId: 'type-1',
+          title: 'Issue',
+          userFieldKeys: ['reporter']
+        }
+      )
+    ).rejects.toThrow(JIRA_USER_FIELDS_UPDATE_REQUIRED_MESSAGE)
+    expect(runtimeCall).toHaveBeenCalledTimes(1)
+    expect(runtimeCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'jira.createIssue' })
+    )
+  })
+
+  it('keeps ordinary remote Jira creation compatible with hosts without the user-field capability', async () => {
+    runtimeCall.mockImplementation(async (args: { method: string }) => {
+      if (args.method === 'status.get') {
+        return createRuntimeStatusWithoutJiraUserFieldsCapability()
+      }
+      return {
+        id: 'rpc-1',
+        ok: true,
+        result: { ok: true, id: 'issue-1', key: 'ORCA-1', url: 'https://jira.example/ORCA-1' },
+        _meta: { runtimeId: 'remote-runtime' }
+      }
+    })
+
+    await expect(
+      jiraCreateIssue(
+        { activeRuntimeEnvironmentId: 'env-1' },
+        { projectId: 'project-1', issueTypeId: 'type-1', title: 'Issue' }
+      )
+    ).resolves.toMatchObject({ ok: true, key: 'ORCA-1' })
+    expect(runtimeCall).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'jira.createIssue', selector: 'env-1' })
+    )
+  })
+
+  it('routes remote Jira user-field creation after capability validation', async () => {
+    runtimeCall.mockImplementation(async (args: { method: string }) => {
+      if (args.method === 'status.get') {
+        return createCompatibleRuntimeStatusResponse()
+      }
+      return {
+        id: 'rpc-1',
+        ok: true,
+        result: { ok: true, id: 'issue-1', key: 'ORCA-1', url: 'https://jira.example/ORCA-1' },
+        _meta: { runtimeId: 'remote-runtime' }
+      }
+    })
+
+    await expect(
+      jiraCreateIssue(
+        { activeRuntimeEnvironmentId: 'env-1' },
+        {
+          projectId: 'project-1',
+          issueTypeId: 'type-1',
+          title: 'Issue',
+          customFields: { reporter: 'account-1' },
+          userFieldKeys: ['reporter']
+        }
+      )
+    ).resolves.toMatchObject({ ok: true, key: 'ORCA-1' })
+
+    expect(runtimeCall).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: 'jira.createIssue',
+        params: {
+          projectId: 'project-1',
+          issueTypeId: 'type-1',
+          title: 'Issue',
+          customFields: { reporter: 'account-1' },
+          userFieldKeys: ['reporter']
+        },
+        selector: 'env-1'
+      })
+    )
   })
 
   it('streams image-bearing issue and comment payloads from remote runtimes', async () => {

--- a/src/renderer/src/runtime/runtime-jira-client.ts
+++ b/src/renderer/src/runtime/runtime-jira-client.ts
@@ -3,8 +3,6 @@ import type {
   JiraComment,
   JiraConnectionStatus,
   JiraCreateField,
-  JiraCreateIssueArgs,
-  JiraCreateIssueResult,
   JiraIssue,
   JiraIssueFilter,
   JiraIssueType,
@@ -15,7 +13,6 @@ import type {
   JiraProjectStatusOrder,
   JiraSiteSelection,
   JiraTransition,
-  JiraUser,
   JiraViewer
 } from '../../../shared/jira-types'
 import { searchLocalJiraIssues } from './local-jira-search-cancellation'
@@ -25,6 +22,11 @@ import { readRuntimeJiraPayload } from './runtime-jira-payload-stream'
 import { getJiraRuntimeTarget, type RuntimeJiraSettings } from './runtime-jira-target'
 
 export { jiraLookupIssueSummary, jiraReadStatus } from './runtime-jira-summary-client'
+export {
+  jiraCreateIssue,
+  jiraListAssignableUsers,
+  jiraSearchUsers
+} from './runtime-jira-user-fields-client'
 export type { RuntimeJiraSettings } from './runtime-jira-target'
 
 export type JiraConnectResult = { ok: true; viewer: JiraViewer } | { ok: false; error: string }
@@ -155,16 +157,6 @@ export async function jiraGetIssue(
     : window.api.jira.getIssue(args)
 }
 
-export async function jiraCreateIssue(
-  settings: RuntimeJiraSettings,
-  args: JiraCreateIssueArgs
-): Promise<JiraCreateIssueResult> {
-  const target = getJiraRuntimeTarget(settings)
-  return target.kind === 'environment'
-    ? callRuntimeRpc<JiraCreateIssueResult>(target, 'jira.createIssue', args, { timeoutMs: 30_000 })
-    : window.api.jira.createIssue(args)
-}
-
 export async function jiraUpdateIssue(
   settings: RuntimeJiraSettings,
   key: string,
@@ -265,38 +257,6 @@ export async function jiraListPriorities(
 }
 
 /** Lists users assignable to an existing issue, via the active runtime. */
-export async function jiraListAssignableUsers(
-  settings: RuntimeJiraSettings,
-  key: string,
-  query?: string,
-  siteId?: string | null
-): Promise<JiraUser[]> {
-  if (!isRuntimeProviderSearchQueryWithinLimit(query)) {
-    return []
-  }
-  const target = getJiraRuntimeTarget(settings)
-  const args = { key, query, siteId: siteId ?? undefined }
-  return target.kind === 'environment'
-    ? callRuntimeRpc<JiraUser[]>(target, 'jira.listAssignableUsers', args, { timeoutMs: 30_000 })
-    : window.api.jira.listAssignableUsers(args)
-}
-
-/** Searches Jira users through the active runtime (remote RPC or local IPC). */
-export async function jiraSearchUsers(
-  settings: RuntimeJiraSettings,
-  query?: string,
-  siteId?: string | null
-): Promise<JiraUser[]> {
-  if (!isRuntimeProviderSearchQueryWithinLimit(query)) {
-    return []
-  }
-  const target = getJiraRuntimeTarget(settings)
-  const args = { query, siteId: siteId ?? undefined }
-  return target.kind === 'environment'
-    ? callRuntimeRpc<JiraUser[]>(target, 'jira.searchUsers', args, { timeoutMs: 30_000 })
-    : window.api.jira.searchUsers(args)
-}
-
 export async function jiraListTransitions(
   settings: RuntimeJiraSettings,
   key: string,

--- a/src/renderer/src/runtime/runtime-jira-user-fields-client.ts
+++ b/src/renderer/src/runtime/runtime-jira-user-fields-client.ts
@@ -1,0 +1,75 @@
+import type {
+  JiraCreateIssueArgs,
+  JiraCreateIssueResult,
+  JiraUser
+} from '../../../shared/jira-types'
+import {
+  JIRA_USER_FIELDS_RUNTIME_CAPABILITY,
+  JIRA_USER_FIELDS_UPDATE_REQUIRED_MESSAGE
+} from '../../../shared/protocol-version'
+import {
+  assertRuntimeEnvironmentCapability,
+  callRuntimeRpc,
+  runtimeEnvironmentSupportsCapability
+} from './runtime-rpc-client'
+import { isRuntimeProviderSearchQueryWithinLimit } from './runtime-provider-search-bounds'
+import { getJiraRuntimeTarget, type RuntimeJiraSettings } from './runtime-jira-target'
+
+export async function jiraCreateIssue(
+  settings: RuntimeJiraSettings,
+  args: JiraCreateIssueArgs
+): Promise<JiraCreateIssueResult> {
+  const target = getJiraRuntimeTarget(settings)
+  if (target.kind === 'environment' && (args.userFieldKeys?.length ?? 0) > 0) {
+    await assertRuntimeEnvironmentCapability(
+      target.environmentId,
+      JIRA_USER_FIELDS_RUNTIME_CAPABILITY,
+      JIRA_USER_FIELDS_UPDATE_REQUIRED_MESSAGE,
+      30_000
+    )
+  }
+  return target.kind === 'environment'
+    ? callRuntimeRpc<JiraCreateIssueResult>(target, 'jira.createIssue', args, { timeoutMs: 30_000 })
+    : window.api.jira.createIssue(args)
+}
+
+export async function jiraListAssignableUsers(
+  settings: RuntimeJiraSettings,
+  key: string,
+  query?: string,
+  siteId?: string | null
+): Promise<JiraUser[]> {
+  if (!isRuntimeProviderSearchQueryWithinLimit(query)) {
+    return []
+  }
+  const target = getJiraRuntimeTarget(settings)
+  const args = { key, query, siteId: siteId ?? undefined }
+  return target.kind === 'environment'
+    ? callRuntimeRpc<JiraUser[]>(target, 'jira.listAssignableUsers', args, { timeoutMs: 30_000 })
+    : window.api.jira.listAssignableUsers(args)
+}
+
+export async function jiraSearchUsers(
+  settings: RuntimeJiraSettings,
+  query?: string,
+  siteId?: string | null
+): Promise<JiraUser[]> {
+  if (!isRuntimeProviderSearchQueryWithinLimit(query)) {
+    return []
+  }
+  const target = getJiraRuntimeTarget(settings)
+  if (
+    target.kind === 'environment' &&
+    !(await runtimeEnvironmentSupportsCapability(
+      target.environmentId,
+      JIRA_USER_FIELDS_RUNTIME_CAPABILITY,
+      30_000
+    ))
+  ) {
+    return []
+  }
+  const args = { query, siteId: siteId ?? undefined }
+  return target.kind === 'environment'
+    ? callRuntimeRpc<JiraUser[]>(target, 'jira.searchUsers', args, { timeoutMs: 30_000 })
+    : window.api.jira.searchUsers(args)
+}

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -60,6 +60,9 @@ export const FOLDER_WORKSPACE_PATH_STATUS_RUNTIME_CAPABILITY =
   'folder-workspace.path-status.v1' as const
 export const LINEAR_ISSUE_ATTRIBUTE_FILTER_RUNTIME_CAPABILITY =
   'linear.issue-attribute-filter.v1' as const
+export const JIRA_USER_FIELDS_RUNTIME_CAPABILITY = 'jira.user-fields.v1' as const
+export const JIRA_USER_FIELDS_UPDATE_REQUIRED_MESSAGE =
+  'Creating Jira issues with user fields requires a newer Orca server. Update the server and try again.'
 // Why: signals the host exposes the Agent Session History scanner over RPC
 // (aiVault.listSessions). Registered unconditionally for every build, so it is a
 // STATIC capability advertised by getStatus() automatically — NOT a runtime
@@ -207,6 +210,7 @@ export const RUNTIME_CAPABILITIES = [
   WORKTREE_GITHUB_PR_SUPPRESSION_RUNTIME_CAPABILITY,
   FOLDER_WORKSPACE_PATH_STATUS_RUNTIME_CAPABILITY,
   LINEAR_ISSUE_ATTRIBUTE_FILTER_RUNTIME_CAPABILITY,
+  JIRA_USER_FIELDS_RUNTIME_CAPABILITY,
   AI_VAULT_RUNTIME_CAPABILITY,
   AI_VAULT_SESSION_TITLES_RUNTIME_CAPABILITY,
   TERMINAL_QUERY_REPLY_INPUT_RUNTIME_CAPABILITY,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​164 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​162 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​84 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​45 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 |

<!-- /orca-pr-loc -->

Follow-up to #17456 (merged as df48337d720d9950e6cdf9fc2332d4cb38544e09).

The merged Jira user-field flow adds a new `jira.searchUsers` RPC and sends `userFieldKeys` to the host. Older paired Orca hosts do not expose that RPC or shape those fields, so this follow-up makes the mixed-version behavior explicit:

- Advertise `jira.user-fields.v1` in runtime capabilities.
- Do not call `jira.searchUsers` when the remote host does not advertise the capability; the picker degrades to no results.
- Refuse remote issue creation with user fields on an older host with a clear update-required message, while preserving ordinary issue creation compatibility.
- Keep the runtime client under the repository max-lines limit by extracting user-field calls into a focused module.
- Add local/remote capability routing and fallback tests.

Validation: full `pnpm test` (7,177 files passed, 66,924 tests passed), `pnpm tc:web`, `pnpm tc:node`, changed-code quality gate, and focused runtime tests all pass.