### PR TITLE
fix(worktrees): bound scan generation map

### DIFF
--- a/src/main/local-worktree-scan-generation.test.ts
+++ b/src/main/local-worktree-scan-generation.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  getLocalWorktreeScanGeneration,
+  getLocalWorktreeScanGenerationCountForTests,
+  isLocalWorktreeScanGenerationCurrent,
+  MAX_LOCAL_WORKTREE_SCAN_GENERATIONS,
+  resetLocalWorktreeScanGenerationsForTests
+} from './local-worktree-scan-generation'
+
+describe('local worktree scan generations', () => {
+  beforeEach(() => {
+    resetLocalWorktreeScanGenerationsForTests()
+  })
+
+  it('retains every entry while the derived eviction count is below zero', () => {
+    const ids = ['repo-a', 'repo-b', 'repo-c']
+    const generations = ids.map((id) => getLocalWorktreeScanGeneration(id))
+
+    expect(getLocalWorktreeScanGenerationCountForTests()).toBe(ids.length)
+    expect(ids.map((id) => getLocalWorktreeScanGeneration(id))).toEqual(generations)
+  })
+
+  it('bounds unique repository churn and evicts the least recently used id', () => {
+    const generations = new Map<string, number>()
+    for (let index = 0; index < MAX_LOCAL_WORKTREE_SCAN_GENERATIONS; index += 1) {
+      const id = `repo-${index}`
+      generations.set(id, getLocalWorktreeScanGeneration(id))
+    }
+
+    // Refresh repo-0 so repo-1, not the hot entry, is the next eviction candidate.
+    expect(getLocalWorktreeScanGeneration('repo-0')).toBe(generations.get('repo-0'))
+    getLocalWorktreeScanGeneration('repo-overflow')
+
+    expect(getLocalWorktreeScanGenerationCountForTests()).toBe(MAX_LOCAL_WORKTREE_SCAN_GENERATIONS)
+    expect(getLocalWorktreeScanGeneration('repo-0')).toBe(generations.get('repo-0'))
+    expect(getLocalWorktreeScanGeneration('repo-1')).not.toBe(generations.get('repo-1'))
+  })
+
+  it('rejects an old generation after its repository id is evicted', () => {
+    const staleGeneration = getLocalWorktreeScanGeneration('stale-repo')
+    for (let index = 0; index < MAX_LOCAL_WORKTREE_SCAN_GENERATIONS; index += 1) {
+      getLocalWorktreeScanGeneration(`repo-${index}`)
+    }
+
+    expect(isLocalWorktreeScanGenerationCurrent('stale-repo', staleGeneration)).toBe(false)
+    expect(getLocalWorktreeScanGenerationCountForTests()).toBe(MAX_LOCAL_WORKTREE_SCAN_GENERATIONS)
+  })
+})

--- a/src/main/local-worktree-scan-generation.ts
+++ b/src/main/local-worktree-scan-generation.ts
@@ -1,18 +1,35 @@
 const generationByRepoId = new Map<string, number>()
 let generationSequence = 0
 
+// Why: repository IDs are process-lifetime inputs, so bound churn from removed and re-added repos.
+export const MAX_LOCAL_WORKTREE_SCAN_GENERATIONS = 512
+
+function rememberGeneration(repoId: string, generation: number): void {
+  // Map insertion order is the recency order; refresh existing IDs before trimming the oldest.
+  generationByRepoId.delete(repoId)
+  generationByRepoId.set(repoId, generation)
+  while (generationByRepoId.size > MAX_LOCAL_WORKTREE_SCAN_GENERATIONS) {
+    const oldest = generationByRepoId.keys().next()
+    if (oldest.done) {
+      break
+    }
+    generationByRepoId.delete(oldest.value)
+  }
+}
+
 export function getLocalWorktreeScanGeneration(repoId: string): number {
   const existing = generationByRepoId.get(repoId)
   if (existing !== undefined) {
+    rememberGeneration(repoId, existing)
     return existing
   }
   const generation = ++generationSequence
-  generationByRepoId.set(repoId, generation)
+  rememberGeneration(repoId, generation)
   return generation
 }
 
 export function bumpLocalWorktreeScanGeneration(repoId: string): void {
-  generationByRepoId.set(repoId, ++generationSequence)
+  rememberGeneration(repoId, ++generationSequence)
 }
 
 export function isLocalWorktreeScanGenerationCurrent(repoId: string, generation: number): boolean {
@@ -22,4 +39,8 @@ export function isLocalWorktreeScanGenerationCurrent(repoId: string, generation:
 export function resetLocalWorktreeScanGenerationsForTests(): void {
   generationSequence += 1
   generationByRepoId.clear()
+}
+
+export function getLocalWorktreeScanGenerationCountForTests(): number {
+  return generationByRepoId.size
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |

<!-- /orca-pr-loc -->

## Summary
- Bound process-global local worktree scan generations to a 512-entry LRU keyed by repository ID.
- Refresh recency on generation reads and bumps; evicted IDs receive a new generation, preserving stale-scan rejection.
- Add regression coverage for under-cap retention, LRU eviction, and stale generations after eviction.

## Verification
- Reproduced growth axis: unique repository IDs touched over process lifetime (not refresh count).
- Targeted Vitest: 133 tests passed.
- Changed-code quality and cold typecheck passed.
- Ablation removing trim produced 2 red tests; fixed bytes restored and verified.

Fixes STA-5959