### PR TITLE
fix(git): preserve remote listing failures in branch conflict checks

### DIFF
--- a/src/main/git/repo-branch-conflict.test.ts
+++ b/src/main/git/repo-branch-conflict.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { getBranchConflictKindViaExec } from './repo-branch-conflict'
+
+// Enumerate the host-owned conflict policy's remote-list outcome axis: a successful empty list
+// is a negative answer, while a failed list must remain distinguishable from that answer.
+describe('getBranchConflictKindViaExec remote listing outcomes', () => {
+  it('keeps an empty successful remote list distinct from a failed list', async () => {
+    const emptyListExec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'rev-parse') {
+        throw new Error('missing local ref')
+      }
+      if (args[0] === 'remote') {
+        return { stdout: '' }
+      }
+      if (args[0] === 'for-each-ref') {
+        return { stdout: '' }
+      }
+      throw new Error(`unexpected git ${args.join(' ')}`)
+    })
+
+    await expect(
+      getBranchConflictKindViaExec(emptyListExec, 'feature/empty', 'origin/main')
+    ).resolves.toBeNull()
+
+    const listingFailure = new Error('git remote failed')
+    const failedListExec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'rev-parse') {
+        throw new Error('missing local ref')
+      }
+      if (args[0] === 'remote') {
+        throw listingFailure
+      }
+      if (args[0] === 'for-each-ref') {
+        return { stdout: 'refs/remotes/origin/feature/empty\n' }
+      }
+      throw new Error(`unexpected git ${args.join(' ')}`)
+    })
+
+    await expect(
+      getBranchConflictKindViaExec(failedListExec, 'feature/empty', 'origin/main')
+    ).rejects.toBe(listingFailure)
+  })
+
+  it('does not turn a failed remote-ref listing into a no-conflict answer', async () => {
+    const refListingFailure = new Error('git for-each-ref failed')
+    const exec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'rev-parse') {
+        throw new Error('missing local ref')
+      }
+      if (args[0] === 'remote') {
+        return { stdout: 'origin\n' }
+      }
+      if (args[0] === 'for-each-ref') {
+        throw refListingFailure
+      }
+      throw new Error(`unexpected git ${args.join(' ')}`)
+    })
+
+    await expect(getBranchConflictKindViaExec(exec, 'feature/empty', 'origin/main')).rejects.toBe(
+      refListingFailure
+    )
+  })
+})

--- a/src/main/git/repo-branch-conflict.ts
+++ b/src/main/git/repo-branch-conflict.ts
@@ -14,16 +14,12 @@ async function hasGitRefAsync(exec: GitExec, ref: string): Promise<boolean> {
 }
 
 async function listRemoteNamesViaExec(exec: GitExec): Promise<string[]> {
-  try {
-    const { stdout } = await exec(['remote'])
-    return stdout
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .sort((a, b) => b.length - a.length)
-  } catch {
-    return []
-  }
+  const { stdout } = await exec(['remote'])
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length)
 }
 
 /** Run branch-conflict policy through the host that owns Git execution. */
@@ -36,21 +32,20 @@ export async function getBranchConflictKindViaExec(
     return 'local'
   }
 
-  try {
-    const remoteNames = await listRemoteNamesViaExec(exec)
-    const { stdout } = await exec(['for-each-ref', '--format=%(refname)', 'refs/remotes'])
-    const hasRemoteConflict = stdout.split(/\r?\n/).some((ref) => {
-      const trimmed = ref.trim()
-      if (isAllowedRemoteBaseRef(trimmed, allowedBaseRef)) {
-        return false
-      }
-      return resolveConfiguredRemoteBranchName(trimmed, remoteNames) === branchName
-    })
+  // A successful empty list proves that no remotes are configured. A failed list is not that
+  // answer, so keep it outside the fail-soft ref scan and let the execution error propagate.
+  const remoteNames = await listRemoteNamesViaExec(exec)
 
-    return hasRemoteConflict ? 'remote' : null
-  } catch {
-    return null
-  }
+  const { stdout } = await exec(['for-each-ref', '--format=%(refname)', 'refs/remotes'])
+  const hasRemoteConflict = stdout.split(/\r?\n/).some((ref) => {
+    const trimmed = ref.trim()
+    if (isAllowedRemoteBaseRef(trimmed, allowedBaseRef)) {
+      return false
+    }
+    return resolveConfiguredRemoteBranchName(trimmed, remoteNames) === branchName
+  })
+
+  return hasRemoteConflict ? 'remote' : null
 }
 
 export function getBranchConflictKind(

--- a/src/main/ipc/worktree-remote-ssh-branch-conflict.test.ts
+++ b/src/main/ipc/worktree-remote-ssh-branch-conflict.test.ts
@@ -72,4 +72,26 @@ describe('getSshBranchConflictKind remote ownership', () => {
       getSshBranchConflictKind(provider, '/srv/repo', 'my-task', 'origin/main')
     ).resolves.toBe('remote')
   })
+
+  it('propagates a failed remote listing instead of treating it as no remotes', async () => {
+    const listingFailure = new Error('ssh: remote listing unavailable')
+    const provider: ConflictProvider = {
+      exec: vi.fn(async (args: string[]) => {
+        if (args[0] === 'rev-parse') {
+          throw new Error('missing local ref')
+        }
+        if (args[0] === 'remote') {
+          throw listingFailure
+        }
+        if (args[0] === 'for-each-ref') {
+          return { stdout: 'refs/remotes/origin/my-task\n', stderr: '' }
+        }
+        throw new Error(`unexpected git ${args.join(' ')}`)
+      })
+    }
+
+    await expect(
+      getSshBranchConflictKind(provider, '/srv/repo', 'my-task', 'origin/main')
+    ).rejects.toBe(listingFailure)
+  })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 |

<!-- /orca-pr-loc -->

## Summary

- Propagate `git remote` and `for-each-ref` failures instead of treating them as no branch conflict.
- Cover successful empty listings and failed local/SSH listings with regression tests.

Fixes STA-5962

## Verification

- Reproduced the original failure: a failed `git remote` resolved as `null` alongside a successful empty listing.
- Focused Vitest: 58 tests passed.
- `pnpm tc:node` passed.
- Ablation: restoring the swallowed-error path reddened both failure tests; fixed bytes were restored and rechecked.