### PR TITLE
perf: avoid rebuilding shell wrappers during path checks (double agent invocations artifacts)

### DIFF
--- a/src/main/daemon/daemon-shell-ready-wrapper-fileset.ts
+++ b/src/main/daemon/daemon-shell-ready-wrapper-fileset.ts
@@ -10,14 +10,24 @@ import { buildZshStartupHook } from '../zsh-startup-wrapper-builder'
 import { getDaemonBashShellReadyRcfileContent } from './daemon-bash-shell-ready-rcfile'
 import { getDaemonZshWrapperSpec } from './daemon-zsh-shell-ready-wrapper-spec'
 
+/** Paths in the generated tree, kept separate so existence checks do not rebuild wrapper bytes. */
+export function getDaemonShellReadyWrapperPaths(root: string): readonly string[] {
+  const zshDir = join(root, 'zsh')
+  return [
+    join(zshDir, '.zshenv'),
+    join(zshDir, ZSH_WRAPPER_DIR_MARKER_FILE),
+    join(root, 'bash', 'rcfile')
+  ]
+}
+
 // Why only .zshenv: the hook hands ZDOTDIR back on its first lines, so zsh reads
 // .zprofile, .zshrc and .zlogin from the user's own directory. Nothing Orca
 // writes is read after this file.
 export function buildDaemonShellReadyWrapperFiles(root: string): readonly ShellWrapperFile[] {
-  const zshDir = join(root, 'zsh')
+  const [zshEnvPath, zshMarkerPath, bashRcfilePath] = getDaemonShellReadyWrapperPaths(root)
   return [
-    [join(zshDir, '.zshenv'), buildZshStartupHook(getDaemonZshWrapperSpec())],
-    [join(zshDir, ZSH_WRAPPER_DIR_MARKER_FILE), ZSH_WRAPPER_DIR_MARKER_CONTENT],
-    [join(root, 'bash', 'rcfile'), getDaemonBashShellReadyRcfileContent()]
+    [zshEnvPath, buildZshStartupHook(getDaemonZshWrapperSpec())],
+    [zshMarkerPath, ZSH_WRAPPER_DIR_MARKER_CONTENT],
+    [bashRcfilePath, getDaemonBashShellReadyRcfileContent()]
   ]
 }

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -15,7 +15,10 @@ import {
 } from '../shell-startup-features'
 import { resolveShellWrapperRoot } from '../shell-wrapper-content-address'
 import { writeShellWrapperFiles } from '../shell-wrapper-file-writer'
-import { buildDaemonShellReadyWrapperFiles } from './daemon-shell-ready-wrapper-fileset'
+import {
+  buildDaemonShellReadyWrapperFiles,
+  getDaemonShellReadyWrapperPaths
+} from './daemon-shell-ready-wrapper-fileset'
 import { inheritedZdotdirEnv, resolveInheritedZdotdir } from '../zsh-wrapper-dir-ownership'
 import { SHELL_READY_MARKER } from './daemon-shell-ready-marker'
 
@@ -50,8 +53,8 @@ export function getShellReadyWrapperRoot(): string {
   return cachedShellReadyWrapperRoot.root
 }
 
-function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoot()): string[] {
-  return buildDaemonShellReadyWrapperFiles(root).map(([path]) => path)
+function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoot()): readonly string[] {
+  return getDaemonShellReadyWrapperPaths(root)
 }
 
 // Why non-empty and not just present: a partial write leaves a zero-byte

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -391,7 +391,7 @@ export type DaemonSessionInfo = SessionInfo & {
 
 // Stream-socket event shapes live in daemon-stream-events.ts; re-exported so
 // existing importers keep one types entry point.
-export * from './daemon-stream-events'
+export type * from './daemon-stream-events'
 
 // ─── Notify prefix ──────────────────────────────────────────────────
 // Requests with IDs starting with this prefix are fire-and-forget:

--- a/src/main/providers/local-pty-shell-ready-wrapper-fileset.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-fileset.ts
@@ -9,6 +9,12 @@ import { buildZshStartupHook, type ZshStartupHookSpec } from '../zsh-startup-wra
 import { getBashShellReadyRcfileContent } from './local-pty-shell-ready-bash-rcfile'
 import { SHELL_READY_MARKER_ESCAPED } from './local-pty-shell-ready-marker'
 
+/** Paths in the generated tree, kept separate so existence checks do not rebuild wrapper bytes. */
+export function getLocalShellReadyWrapperPaths(root: string): readonly string[] {
+  const zshDir = `${root}/zsh`
+  return [`${zshDir}/.zshenv`, `${zshDir}/${ZSH_WRAPPER_DIR_MARKER_FILE}`, `${root}/bash/rcfile`]
+}
+
 export function getLocalZshWrapperSpec(): ZshStartupHookSpec {
   return {
     headerLabel: 'Orca zsh shell-ready wrapper',
@@ -35,10 +41,10 @@ export function getLocalZshWrapperSpec(): ZshStartupHookSpec {
 // .zprofile, .zshrc and .zlogin from the user's own directory. Nothing Orca
 // writes is read after this file.
 export function buildLocalShellReadyWrapperFiles(root: string): readonly ShellWrapperFile[] {
-  const zshDir = `${root}/zsh`
+  const [zshEnvPath, zshMarkerPath, bashRcfilePath] = getLocalShellReadyWrapperPaths(root)
   return [
-    [`${zshDir}/.zshenv`, buildZshStartupHook(getLocalZshWrapperSpec())],
-    [`${zshDir}/${ZSH_WRAPPER_DIR_MARKER_FILE}`, ZSH_WRAPPER_DIR_MARKER_CONTENT],
-    [`${root}/bash/rcfile`, getBashShellReadyRcfileContent()]
+    [zshEnvPath, buildZshStartupHook(getLocalZshWrapperSpec())],
+    [zshMarkerPath, ZSH_WRAPPER_DIR_MARKER_CONTENT],
+    [bashRcfilePath, getBashShellReadyRcfileContent()]
   ]
 }

--- a/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
@@ -14,11 +14,22 @@ import { getBashShellReadyRcfileContent } from './local-pty-shell-ready-bash-rcf
 import { getZshShellReadyWrapperFile } from './local-pty-shell-ready-wrapper-generation'
 import { makeUserZdotdir } from '../zsh-user-config-dir-fixture'
 // Why resolved rather than hardcoded: the wrapper tree is content-addressed.
-import { getShellReadyWrapperRoot } from './local-pty-shell-ready-wrapper-root'
+import {
+  getRequiredShellReadyWrapperPaths,
+  getShellReadyWrapperRoot
+} from './local-pty-shell-ready-wrapper-root'
+import { buildLocalShellReadyWrapperFiles } from './local-pty-shell-ready-wrapper-fileset'
 
 restoreUserDataPathAfterEach()
 
 describe('ensureShellReadyWrappersAt', () => {
+  it('keeps required wrapper paths aligned with generated files', () => {
+    const root = '/tmp/orca-shell-ready'
+    expect(getRequiredShellReadyWrapperPaths(root)).toEqual(
+      buildLocalShellReadyWrapperFiles(root).map(([path]) => path)
+    )
+  })
+
   // Why: rewriting a byte-identical tree replaces a live file on the terminal
   // spawn path for no gain -- and on Windows that is precisely the collision an
   // indexer or antivirus turns into a failed write. The tree is

--- a/src/main/providers/local-pty-shell-ready-wrapper-root.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-root.ts
@@ -6,7 +6,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { statSync } from 'node:fs'
 import { resolveShellWrapperRoot } from '../shell-wrapper-content-address'
-import { buildLocalShellReadyWrapperFiles } from './local-pty-shell-ready-wrapper-fileset'
+import {
+  buildLocalShellReadyWrapperFiles,
+  getLocalShellReadyWrapperPaths
+} from './local-pty-shell-ready-wrapper-fileset'
 
 export { SHELL_READY_MARKER_ESCAPED } from './local-pty-shell-ready-marker'
 
@@ -45,8 +48,10 @@ export function getShellReadyWrapperRoot(): string {
   return cachedShellReadyWrapperRoot.root
 }
 
-export function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoot()): string[] {
-  return buildLocalShellReadyWrapperFiles(root).map(([path]) => path)
+export function getRequiredShellReadyWrapperPaths(
+  root = getShellReadyWrapperRoot()
+): readonly string[] {
+  return getLocalShellReadyWrapperPaths(root)
 }
 
 /**

--- a/src/main/runtime/rpc/dispatcher.ts
+++ b/src/main/runtime/rpc/dispatcher.ts
@@ -25,7 +25,7 @@ import { mapDispatcherError } from './dispatcher-error-response'
 import { parseRpcRequestParams } from './dispatcher-request-parsing'
 import { routeDispatcherClientHostedBrowserRpc } from './dispatcher-client-browser-routing'
 import { needsLocalCallerFingerprint } from './dispatcher-caller-fingerprint'
-import { createDispatcherStreamingFeatureEmitter } from './dispatcher-streaming-feature-emitter'
+import { RpcStreamingDispatcher } from './rpc-streaming-dispatcher'
 
 export type DispatcherOptions = { runtime: OrcaRuntimeService; methods?: readonly RpcAnyMethod[] }
 
@@ -37,12 +37,20 @@ export class RpcDispatcher {
   private readonly registry: RpcRegistry
   private readonly orchestrationMutations: OrchestrationMutationExecutor
   private readonly legacyOrchestration: OrchestrationLegacyCompatibility
+  private readonly streamingDispatcher: RpcStreamingDispatcher
 
   constructor({ runtime, methods = ALL_RPC_METHODS }: DispatcherOptions) {
     this.runtime = runtime
     this.registry = buildRegistry(methods)
     this.orchestrationMutations = getOrchestrationMutationExecutor(runtime)
     this.legacyOrchestration = new OrchestrationLegacyCompatibility(runtime)
+    this.streamingDispatcher = new RpcStreamingDispatcher({
+      runtime,
+      registry: this.registry,
+      orchestrationMutations: this.orchestrationMutations,
+      legacyOrchestration: this.legacyOrchestration,
+      meta: () => this.meta()
+    })
   }
 
   async dispatch(request: RpcRequest, options?: DispatchCallOptions): Promise<RpcResponse> {
@@ -160,161 +168,12 @@ export class RpcDispatcher {
     }
   }
 
-  // Why: streaming dispatch sends multiple responses through the reply callback
-  // instead of returning a single Promise. This enables terminal.subscribe and
-  // other subscription-style methods that push data over time.
   async dispatchStreaming(
     request: RpcRequest,
     reply: (response: string) => void,
     options?: RpcDispatchStreamingOptions
   ): Promise<void> {
-    const meta = this.meta()
-    const method = this.registry.get(request.method)
-    if (!method) {
-      reply(
-        JSON.stringify(
-          errorResponse(request.id, meta, 'method_not_found', `Unknown method: ${request.method}`)
-        )
-      )
-      return
-    }
-
-    const migrationFence = orchestrationMigrationFence(request, meta)
-    if (migrationFence) {
-      reply(JSON.stringify(migrationFence))
-      return
-    }
-
-    const parsedParams = parseRpcRequestParams(request, method, meta)
-    if (parsedParams.error) {
-      reply(JSON.stringify(parsedParams.error))
-      return
-    }
-
-    if (!isStreamingMethod(method)) {
-      try {
-        const clientHostedBrowser = await routeDispatcherClientHostedBrowserRpc(
-          this.runtime,
-          request.method,
-          parsedParams.value
-        )
-        if (clientHostedBrowser.handled) {
-          recordRuntimeFeatureInteraction(
-            this.runtime,
-            request.method,
-            clientHostedBrowser.result,
-            undefined,
-            request.params
-          )
-          reply(JSON.stringify(successResponse(request.id, meta, clientHostedBrowser.result)))
-          return
-        }
-        const compatibility = await this.legacyOrchestration.tryHandle(
-          request,
-          parsedParams.value,
-          options?.signal
-        )
-        if (compatibility.handled) {
-          reply(JSON.stringify(successResponse(request.id, meta, compatibility.result)))
-          return
-        }
-        const effectiveParams = compatibility.params ?? parsedParams.value
-        const legacyCoordinator = this.legacyOrchestration.createCoordinatorInvocation(
-          request,
-          compatibility.legacyCoordinatorAuthority
-        )
-        const authenticatedCallerFingerprint =
-          options?.authenticatedCallerFingerprint ??
-          (needsLocalCallerFingerprint(request, effectiveParams)
-            ? this.orchestrationMutations.getLocalAuthenticatedCallerFingerprint()
-            : undefined)
-        const invoke = (mutation?: DurableMutationInvocation) => {
-          const legacyCoordinatorRunId = legacyCoordinator?.revalidate()
-          return method.handler(effectiveParams, {
-            runtime: this.runtime,
-            signal: options?.signal,
-            requestId: request.id,
-            connectionId: options?.connectionId,
-            clientId: options?.clientId,
-            pairedDeviceId: options?.pairedDeviceId,
-            clientKind: options?.clientKind,
-            clientCapabilities: options?.clientCapabilities,
-            orchestrationCapability: request.orchestrationCapability,
-            authenticatedCallerFingerprint:
-              mutation?.identity.callerFingerprint ??
-              legacyCoordinator?.mutationCallerFingerprint ??
-              authenticatedCallerFingerprint,
-            recordMutationReceipt: mutation?.recordReceipt,
-            orchestrationMutation: mutation?.identity,
-            pairing: options?.pairing,
-            sendBinary: options?.sendBinary,
-            registerBinaryStreamHandler: options?.registerBinaryStreamHandler,
-            registerBinaryMessageHandler: options?.registerBinaryMessageHandler,
-            legacyCoordinatorRunId,
-            legacyCoordinatorAuthority: legacyCoordinator?.authority,
-            revalidateLegacyCoordinator: legacyCoordinator?.revalidate,
-            orchestrationCompatibilityCallerAuthority:
-              compatibility.orchestrationCompatibilityCallerAuthority,
-            orchestrationCompatibilityEvidence: request.orchestrationCompatibilityEvidence
-          })
-        }
-        const result = await this.orchestrationMutations.run(
-          request,
-          effectiveParams,
-          invoke,
-          legacyCoordinator?.mutationCallerFingerprint ?? authenticatedCallerFingerprint
-        )
-        recordRuntimeFeatureInteraction(
-          this.runtime,
-          request.method,
-          result,
-          undefined,
-          request.params
-        )
-        reply(JSON.stringify(successResponse(request.id, meta, result)))
-      } catch (error) {
-        reply(JSON.stringify(mapDispatcherError(request, meta, error)))
-      }
-      return
-    }
-
-    const { emit, recordedFeatureInteractions } = createDispatcherStreamingFeatureEmitter(
-      this.runtime,
-      request,
-      meta,
-      reply
-    )
-
-    try {
-      const result = await method.handler(
-        parsedParams.value,
-        {
-          runtime: this.runtime,
-          signal: options?.signal,
-          requestId: request.id,
-          connectionId: options?.connectionId,
-          clientId: options?.clientId,
-          pairedDeviceId: options?.pairedDeviceId,
-          clientKind: options?.clientKind,
-          clientCapabilities: options?.clientCapabilities,
-          orchestrationCapability: request.orchestrationCapability,
-          pairing: options?.pairing,
-          sendBinary: options?.sendBinary,
-          registerBinaryStreamHandler: options?.registerBinaryStreamHandler,
-          registerBinaryMessageHandler: options?.registerBinaryMessageHandler
-        },
-        emit
-      )
-      recordRuntimeFeatureInteraction(
-        this.runtime,
-        request.method,
-        result,
-        recordedFeatureInteractions,
-        request.params
-      )
-    } catch (error) {
-      reply(JSON.stringify(mapDispatcherError(request, meta, error)))
-    }
+    return this.streamingDispatcher.dispatch(request, reply, options)
   }
 
   private meta(): RpcEnvelopeMeta {

--- a/src/main/runtime/rpc/rpc-streaming-dispatcher.ts
+++ b/src/main/runtime/rpc/rpc-streaming-dispatcher.ts
@@ -1,0 +1,187 @@
+import { isStreamingMethod, type RpcEnvelopeMeta, type RpcRegistry, type RpcRequest } from './core'
+
+import { errorResponse, successResponse } from './errors'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import type {
+  OrchestrationMutationExecutor,
+  DurableMutationInvocation
+} from './orchestration-mutation-executor'
+import { orchestrationMigrationFence } from './orchestration-contract-fence'
+import { recordRuntimeFeatureInteraction } from './runtime-feature-interaction'
+import type { OrchestrationLegacyCompatibility } from './orchestration-legacy-compatibility'
+import type { RpcDispatchStreamingOptions } from './dispatcher-stream-options'
+import { mapDispatcherError } from './dispatcher-error-response'
+import { parseRpcRequestParams } from './dispatcher-request-parsing'
+import { routeDispatcherClientHostedBrowserRpc } from './dispatcher-client-browser-routing'
+import { needsLocalCallerFingerprint } from './dispatcher-caller-fingerprint'
+import { createDispatcherStreamingFeatureEmitter } from './dispatcher-streaming-feature-emitter'
+
+export type RpcStreamingDispatcherDependencies = {
+  runtime: OrcaRuntimeService
+  registry: RpcRegistry
+  orchestrationMutations: OrchestrationMutationExecutor
+  legacyOrchestration: OrchestrationLegacyCompatibility
+  meta: () => RpcEnvelopeMeta
+}
+
+export class RpcStreamingDispatcher {
+  constructor(private readonly dependencies: RpcStreamingDispatcherDependencies) {}
+
+  // Why: streaming dispatch sends multiple responses through the reply callback instead of a Promise.
+  async dispatch(
+    request: RpcRequest,
+    reply: (response: string) => void,
+    options?: RpcDispatchStreamingOptions
+  ): Promise<void> {
+    const { runtime, registry, orchestrationMutations, legacyOrchestration, meta } =
+      this.dependencies
+    const envelopeMeta = meta()
+    const method = registry.get(request.method)
+    if (!method) {
+      reply(
+        JSON.stringify(
+          errorResponse(
+            request.id,
+            envelopeMeta,
+            'method_not_found',
+            `Unknown method: ${request.method}`
+          )
+        )
+      )
+      return
+    }
+
+    const migrationFence = orchestrationMigrationFence(request, envelopeMeta)
+    if (migrationFence) {
+      reply(JSON.stringify(migrationFence))
+      return
+    }
+
+    const parsedParams = parseRpcRequestParams(request, method, envelopeMeta)
+    if (parsedParams.error) {
+      reply(JSON.stringify(parsedParams.error))
+      return
+    }
+
+    if (!isStreamingMethod(method)) {
+      try {
+        const clientHostedBrowser = await routeDispatcherClientHostedBrowserRpc(
+          runtime,
+          request.method,
+          parsedParams.value
+        )
+        if (clientHostedBrowser.handled) {
+          recordRuntimeFeatureInteraction(
+            runtime,
+            request.method,
+            clientHostedBrowser.result,
+            undefined,
+            request.params
+          )
+          reply(
+            JSON.stringify(successResponse(request.id, envelopeMeta, clientHostedBrowser.result))
+          )
+          return
+        }
+        const compatibility = await legacyOrchestration.tryHandle(
+          request,
+          parsedParams.value,
+          options?.signal
+        )
+        if (compatibility.handled) {
+          reply(JSON.stringify(successResponse(request.id, envelopeMeta, compatibility.result)))
+          return
+        }
+        const effectiveParams = compatibility.params ?? parsedParams.value
+        const legacyCoordinator = legacyOrchestration.createCoordinatorInvocation(
+          request,
+          compatibility.legacyCoordinatorAuthority
+        )
+        const authenticatedCallerFingerprint =
+          options?.authenticatedCallerFingerprint ??
+          (needsLocalCallerFingerprint(request, effectiveParams)
+            ? orchestrationMutations.getLocalAuthenticatedCallerFingerprint()
+            : undefined)
+        const invoke = (mutation?: DurableMutationInvocation) => {
+          const legacyCoordinatorRunId = legacyCoordinator?.revalidate()
+          return method.handler(effectiveParams, {
+            runtime,
+            signal: options?.signal,
+            requestId: request.id,
+            connectionId: options?.connectionId,
+            clientId: options?.clientId,
+            pairedDeviceId: options?.pairedDeviceId,
+            clientKind: options?.clientKind,
+            clientCapabilities: options?.clientCapabilities,
+            orchestrationCapability: request.orchestrationCapability,
+            authenticatedCallerFingerprint:
+              mutation?.identity.callerFingerprint ??
+              legacyCoordinator?.mutationCallerFingerprint ??
+              authenticatedCallerFingerprint,
+            recordMutationReceipt: mutation?.recordReceipt,
+            orchestrationMutation: mutation?.identity,
+            pairing: options?.pairing,
+            sendBinary: options?.sendBinary,
+            registerBinaryStreamHandler: options?.registerBinaryStreamHandler,
+            registerBinaryMessageHandler: options?.registerBinaryMessageHandler,
+            legacyCoordinatorRunId,
+            legacyCoordinatorAuthority: legacyCoordinator?.authority,
+            revalidateLegacyCoordinator: legacyCoordinator?.revalidate,
+            orchestrationCompatibilityCallerAuthority:
+              compatibility.orchestrationCompatibilityCallerAuthority,
+            orchestrationCompatibilityEvidence: request.orchestrationCompatibilityEvidence
+          })
+        }
+        const result = await orchestrationMutations.run(
+          request,
+          effectiveParams,
+          invoke,
+          legacyCoordinator?.mutationCallerFingerprint ?? authenticatedCallerFingerprint
+        )
+        recordRuntimeFeatureInteraction(runtime, request.method, result, undefined, request.params)
+        reply(JSON.stringify(successResponse(request.id, envelopeMeta, result)))
+      } catch (error) {
+        reply(JSON.stringify(mapDispatcherError(request, envelopeMeta, error)))
+      }
+      return
+    }
+
+    const { emit, recordedFeatureInteractions } = createDispatcherStreamingFeatureEmitter(
+      runtime,
+      request,
+      envelopeMeta,
+      reply
+    )
+
+    try {
+      const result = await method.handler(
+        parsedParams.value,
+        {
+          runtime,
+          signal: options?.signal,
+          requestId: request.id,
+          connectionId: options?.connectionId,
+          clientId: options?.clientId,
+          pairedDeviceId: options?.pairedDeviceId,
+          clientKind: options?.clientKind,
+          clientCapabilities: options?.clientCapabilities,
+          orchestrationCapability: request.orchestrationCapability,
+          pairing: options?.pairing,
+          sendBinary: options?.sendBinary,
+          registerBinaryStreamHandler: options?.registerBinaryStreamHandler,
+          registerBinaryMessageHandler: options?.registerBinaryMessageHandler
+        },
+        emit
+      )
+      recordRuntimeFeatureInteraction(
+        runtime,
+        request.method,
+        result,
+        recordedFeatureInteractions,
+        request.params
+      )
+    } catch (error) {
+      reply(JSON.stringify(mapDispatcherError(request, envelopeMeta, error)))
+    }
+  }
+}

--- a/src/main/updater-test-harness.ts
+++ b/src/main/updater-test-harness.ts
@@ -227,6 +227,8 @@ export function createUpdaterMocks(): UpdaterMocks {
 
   /** Shared `beforeEach` body: fresh module registry plus every mock back to its default. */
   const resetUpdaterMocks = () => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
     vi.resetModules()
     autoUpdaterMock.reset()
     nativeUpdaterMock.on.mockReset()
@@ -254,7 +256,6 @@ export function createUpdaterMocks(): UpdaterMocks {
       close: closeLocalBuildFeedMock
     })
     vi.unstubAllGlobals()
-    vi.useRealTimers()
   }
 
   return {

--- a/src/shared/runtime-session-contracts.ts
+++ b/src/shared/runtime-session-contracts.ts
@@ -14,7 +14,7 @@ import type {
   RuntimeMobileSessionTerminalClientTab
 } from './runtime-mobile-session-tab-contracts'
 
-export * from './runtime-mobile-session-tab-contracts'
+export type * from './runtime-mobile-session-tab-contracts'
 
 export type RuntimeGraphStatus = 'ready' | 'reloading' | 'unavailable'
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​239 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​168 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |

<!-- /orca-pr-loc -->

## Summary

- avoid regenerating ~48 KB of shell-wrapper source when warm PTY startup only needs wrapper paths
- keep wrapper generation and non-empty-file validation behavior unchanged
- isolate streaming RPC dispatch from the request dispatcher so the max-lines ratchet remains effective
- make protocol barrels explicitly type-only, avoiding no-op runtime re-export work

## Root cause and performance

Every warm PTY spawn rebuilt all shell wrapper strings and then discarded them after extracting three filenames. This change derives those paths directly. A local benchmark measured path derivation at ~0.20 ms per 1,000 iterations versus ~77.37 ms for rebuilding wrapper bytes (~385x less CPU in this hot path).

The streaming dispatcher is instantiated once per `RpcDispatcher`; request dispatch does not allocate a new dependency object. The type-only barrel changes remove runtime re-export edges and do not change emitted protocol values.

No timers, polling, subprocesses, PTY writes, renderer work, or startup steps were added.

## Validation

- local wrapper generation/path tests
- real bash/zsh/fish node-pty startup-command tests
- RPC streaming and browser-routing tests (14 passed)
- full `pnpm lint`, including max-lines ratchet and type-aware audits
- Node typecheck, snapshots, package checks, and `git diff --check`

## Visual proof

The follow-up is internal performance and organization work; it does not alter rendered UI. The user-visible duplicate-command fix that this preserves was previously verified here:

Before: https://github.com/user-attachments/assets/bb8b24b3-784a-432e-8d45-ac066e77ab19
After: https://github.com/user-attachments/assets/df93f1b3-22c7-441e-8d45-ac066e77ab19
